### PR TITLE
convert some tests and propagate database.DB

### DIFF
--- a/cmd/frontend/backend/user_emails.go
+++ b/cmd/frontend/backend/user_emails.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/router"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/txemail"
 	"github.com/sourcegraph/sourcegraph/internal/txemail/txtypes"
@@ -134,7 +133,7 @@ func (userEmails) Add(ctx context.Context, db database.DB, userID int32, email s
 		// Send email verification email.
 		if err := SendUserEmailVerificationEmail(ctx, usr.Username, email, *code); err != nil {
 			return errors.Wrap(err, "SendUserEmailVerificationEmail")
-		} else if err = db.Users().SetLastVerification(ctx, userID, email, *code); err != nil {
+		} else if err = db.UserEmails().SetLastVerification(ctx, userID, email, *code); err != nil {
 			return errors.Wrap(err, "SetLastVerificationSentAt")
 		}
 	}
@@ -194,13 +193,13 @@ Please verify your email address on Sourcegraph ({{.Host}}) by clicking this lin
 
 // SendUserEmailOnFieldUpdate sends the user an email that important account information has changed.
 // The change is the information we want to provide the user about the change
-func (userEmails) SendUserEmailOnFieldUpdate(ctx context.Context, db dbutil.DB, id int32, change string) error {
-	email, _, err := database.UserEmails(db).GetPrimaryEmail(ctx, id)
+func (userEmails) SendUserEmailOnFieldUpdate(ctx context.Context, db database.DB, id int32, change string) error {
+	email, _, err := db.UserEmails().GetPrimaryEmail(ctx, id)
 	if err != nil {
 		log15.Warn("Failed to get user email", "error", err)
 		return err
 	}
-	usr, err := database.Users(db).GetByID(ctx, id)
+	usr, err := db.Users().GetByID(ctx, id)
 	if err != nil {
 		log15.Warn("Failed to get user from database", "error", err)
 		return err

--- a/cmd/frontend/backend/user_emails_test.go
+++ b/cmd/frontend/backend/user_emails_test.go
@@ -6,10 +6,12 @@ import (
 	"testing"
 	"time"
 
+	mockrequire "github.com/derision-test/go-mockgen/testutil/require"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
 	"github.com/sourcegraph/sourcegraph/internal/txemail"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -104,17 +106,15 @@ func TestCheckEmailAbuse(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			db := dbtesting.GetDB(t)
-			database.Mocks.Users.CheckAndDecrementInviteQuota = func(context.Context, int32) (bool, error) {
-				return test.hasQuote, nil
-			}
-			database.Mocks.UserEmails.ListByUser = func(context.Context, database.UserEmailsListOptions) ([]*database.UserEmail, error) {
-				return test.mockEmails, nil
-			}
-			defer func() {
-				database.Mocks.Users.CheckAndDecrementInviteQuota = nil
-				database.Mocks.UserEmails.ListByUser = nil
-			}()
+			users := dbmock.NewMockUserStore()
+			users.CheckAndDecrementInviteQuotaFunc.SetDefaultReturn(test.hasQuote, nil)
+
+			userEmails := dbmock.NewMockUserEmailsStore()
+			userEmails.ListByUserFunc.SetDefaultReturn(test.mockEmails, nil)
+
+			db := dbmock.NewMockDB()
+			db.UsersFunc.SetDefaultReturn(users)
+			db.UserEmailsFunc.SetDefaultReturn(userEmails)
 
 			abused, reason, err := checkEmailAbuse(ctx, db, 1)
 			if test.expErr != err {
@@ -161,23 +161,22 @@ func TestSendUserEmailVerificationEmail(t *testing.T) {
 }
 
 func TestSendUserEmailOnFieldUpdate(t *testing.T) {
-	db := dbtesting.GetDB(t)
 	var sent *txemail.Message
 	txemail.MockSend = func(ctx context.Context, message txemail.Message) error {
 		sent = &message
 		return nil
 	}
-	database.Mocks.UserEmails.GetPrimaryEmail = func(ctx context.Context, id int32) (emailCanonicalCase string, verified bool, err error) {
-		return "a@example.com", true, nil
-	}
-	database.Mocks.Users.GetByID = func(ctx context.Context, id int32) (*types.User, error) {
-		return &types.User{Username: "Foo"}, nil
-	}
-	defer func() {
-		txemail.MockSend = nil
-		database.Mocks.UserEmails.GetPrimaryEmail = nil
-		database.Mocks.Users.GetByID = nil
-	}()
+	defer func() { txemail.MockSend = nil }()
+
+	userEmails := dbmock.NewMockUserEmailsStore()
+	userEmails.GetPrimaryEmailFunc.SetDefaultReturn("a@example.com", true, nil)
+
+	users := dbmock.NewMockUserStore()
+	users.GetByIDFunc.SetDefaultReturn(&types.User{Username: "Foo"}, nil)
+
+	db := dbmock.NewMockDB()
+	db.UserEmailsFunc.SetDefaultReturn(userEmails)
+	db.UsersFunc.SetDefaultReturn(users)
 
 	if err := UserEmails.SendUserEmailOnFieldUpdate(context.Background(), db, 123, "updated password"); err != nil {
 		t.Fatal(err)
@@ -203,4 +202,7 @@ func TestSendUserEmailOnFieldUpdate(t *testing.T) {
 	}); !reflect.DeepEqual(*sent, want) {
 		t.Errorf("got %+v, want %+v", *sent, want)
 	}
+
+	mockrequire.Called(t, userEmails.GetPrimaryEmailFunc)
+	mockrequire.Called(t, users.GetByIDFunc)
 }

--- a/cmd/frontend/graphqlbackend/access_tokens.go
+++ b/cmd/frontend/graphqlbackend/access_tokens.go
@@ -119,7 +119,7 @@ func (r *schemaResolver) DeleteAccessToken(ctx context.Context, args *deleteAcce
 		if err != nil {
 			return nil, err
 		}
-		token, err := database.AccessTokens(r.db).GetByID(ctx, accessTokenID)
+		token, err := r.db.AccessTokens().GetByID(ctx, accessTokenID)
 		if err != nil {
 			return nil, err
 		}
@@ -128,12 +128,12 @@ func (r *schemaResolver) DeleteAccessToken(ctx context.Context, args *deleteAcce
 		if err := backend.CheckSiteAdminOrSameUser(ctx, r.db, token.SubjectUserID); err != nil {
 			return nil, err
 		}
-		if err := database.AccessTokens(r.db).DeleteByID(ctx, token.ID); err != nil {
+		if err := r.db.AccessTokens().DeleteByID(ctx, token.ID); err != nil {
 			return nil, err
 		}
 
 	case args.ByToken != nil:
-		token, err := database.AccessTokens(r.db).GetByToken(ctx, *args.ByToken)
+		token, err := r.db.AccessTokens().GetByToken(ctx, *args.ByToken)
 		if err != nil {
 			return nil, err
 		}
@@ -141,7 +141,7 @@ func (r *schemaResolver) DeleteAccessToken(ctx context.Context, args *deleteAcce
 
 		// 🚨 SECURITY: This is easier than the ByID case because anyone holding the access token's
 		// secret value is assumed to be allowed to delete it.
-		if err := database.AccessTokens(r.db).DeleteByToken(ctx, *args.ByToken); err != nil {
+		if err := r.db.AccessTokens().DeleteByToken(ctx, *args.ByToken); err != nil {
 			return nil, err
 		}
 

--- a/cmd/frontend/graphqlbackend/access_tokens.go
+++ b/cmd/frontend/graphqlbackend/access_tokens.go
@@ -80,7 +80,7 @@ func (r *schemaResolver) CreateAccessToken(ctx context.Context, args *createAcce
 		return nil, errors.Errorf("all access tokens must have scope %q", authz.ScopeUserAll)
 	}
 
-	id, token, err := database.AccessTokens(r.db).Create(ctx, userID, args.Scopes, args.Note, actor.FromContext(ctx).UID)
+	id, token, err := r.db.AccessTokens().Create(ctx, userID, args.Scopes, args.Note, actor.FromContext(ctx).UID)
 
 	if conf.CanSendEmail() {
 		if err := backend.UserEmails.SendUserEmailOnFieldUpdate(ctx, r.db, userID, "created an access token"); err != nil {

--- a/cmd/frontend/graphqlbackend/access_tokens_test.go
+++ b/cmd/frontend/graphqlbackend/access_tokens_test.go
@@ -16,16 +16,16 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 // 🚨 SECURITY: This tests that users can't create tokens for users they aren't allowed to do so for.
 func TestMutation_CreateAccessToken(t *testing.T) {
-	db := database.NewDB(nil)
-
-	mockAccessTokensCreate := func(t *testing.T, wantCreatorUserID int32, wantScopes []string) {
-		database.Mocks.AccessTokens.Create = func(subjectUserID int32, scopes []string, note string, creatorUserID int32) (int64, string, error) {
+	newMockAccessTokens := func(t *testing.T, wantCreatorUserID int32, wantScopes []string) database.AccessTokenStore {
+		accessTokens := dbmock.NewMockAccessTokenStore()
+		accessTokens.CreateFunc.SetDefaultHook(func(_ context.Context, subjectUserID int32, scopes []string, note string, creatorUserID int32) (int64, string, error) {
 			if want := int32(1); subjectUserID != want {
 				t.Errorf("got %v, want %v", subjectUserID, want)
 			}
@@ -39,17 +39,21 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 				t.Errorf("got %v, want %v", creatorUserID, wantCreatorUserID)
 			}
 			return 1, "t", nil
-		}
+		})
+		return accessTokens
 	}
 
 	const uid1GQLID = "VXNlcjox"
 
 	t.Run("authenticated as user", func(t *testing.T) {
-		resetMocks()
-		mockAccessTokensCreate(t, 1, []string{authz.ScopeUserAll})
-		database.Mocks.Users.GetByCurrentAuthUser = func(ctx context.Context) (*types.User, error) {
-			return &types.User{ID: 1, SiteAdmin: false}, nil
-		}
+		accessTokens := newMockAccessTokens(t, 1, []string{authz.ScopeUserAll})
+		users := dbmock.NewMockUserStore()
+		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 1, SiteAdmin: false}, nil)
+
+		db := dbmock.NewMockDB()
+		db.AccessTokensFunc.SetDefaultReturn(accessTokens)
+		db.UsersFunc.SetDefaultReturn(users)
+
 		RunTests(t, []*Test{
 			{
 				Context: actor.WithActor(context.Background(), &actor.Actor{UID: 1}),
@@ -75,10 +79,8 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 	})
 
 	t.Run("authenticated as user, using invalid scopes", func(t *testing.T) {
-		resetMocks()
-
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		result, err := (&schemaResolver{db: database.NewDB(db)}).CreateAccessToken(ctx, &createAccessTokenInput{User: uid1GQLID /* no scopes */, Note: "n"})
+		result, err := (&schemaResolver{db: dbmock.NewMockDB()}).CreateAccessToken(ctx, &createAccessTokenInput{User: uid1GQLID /* no scopes */, Note: "n"})
 		if err == nil {
 			t.Error("err == nil")
 		}
@@ -88,13 +90,14 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 	})
 
 	t.Run("authenticated as user, using site-admin-only scopes", func(t *testing.T) {
-		resetMocks()
-		database.Mocks.Users.GetByCurrentAuthUser = func(ctx context.Context) (*types.User, error) {
-			return &types.User{ID: 1, SiteAdmin: false}, nil
-		}
+		users := dbmock.NewMockUserStore()
+		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 1, SiteAdmin: false}, nil)
+
+		db := dbmock.NewMockDB()
+		db.UsersFunc.SetDefaultReturn(users)
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		result, err := (&schemaResolver{db: database.NewDB(db)}).CreateAccessToken(ctx, &createAccessTokenInput{
+		result, err := (&schemaResolver{db: db}).CreateAccessToken(ctx, &createAccessTokenInput{
 			User:   uid1GQLID,
 			Scopes: []string{authz.ScopeUserAll, authz.ScopeSiteAdminSudo},
 			Note:   "n",
@@ -109,11 +112,13 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 
 	t.Run("authenticated as site admin, using site-admin-only scopes", func(t *testing.T) {
 		resetMocks()
-		mockAccessTokensCreate(t, 1, []string{authz.ScopeSiteAdminSudo, authz.ScopeUserAll})
-		database.Mocks.Users.GetByCurrentAuthUser = func(ctx context.Context) (*types.User, error) {
-			return &types.User{ID: 1, SiteAdmin: true}, nil
-		}
-		defer func() { database.Mocks.Users.GetByCurrentAuthUser = nil }()
+		accessTokens := newMockAccessTokens(t, 1, []string{authz.ScopeSiteAdminSudo, authz.ScopeUserAll})
+		users := dbmock.NewMockUserStore()
+		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 1, SiteAdmin: true}, nil)
+
+		db := dbmock.NewMockDB()
+		db.AccessTokensFunc.SetDefaultReturn(accessTokens)
+		db.UsersFunc.SetDefaultReturn(users)
 
 		RunTests(t, []*Test{
 			{
@@ -140,13 +145,15 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 	})
 
 	t.Run("authenticated as different user who is a site-admin. Default config", func(t *testing.T) {
-		resetMocks()
 		const differentSiteAdminUID = 234
-		mockAccessTokensCreate(t, differentSiteAdminUID, []string{authz.ScopeUserAll})
-		database.Mocks.Users.GetByCurrentAuthUser = func(ctx context.Context) (*types.User, error) {
-			return &types.User{ID: differentSiteAdminUID, SiteAdmin: true}, nil
-		}
-		defer func() { database.Mocks.Users.GetByCurrentAuthUser = nil }()
+
+		accessTokens := newMockAccessTokens(t, differentSiteAdminUID, []string{authz.ScopeUserAll})
+		users := dbmock.NewMockUserStore()
+		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: differentSiteAdminUID, SiteAdmin: true}, nil)
+
+		db := dbmock.NewMockDB()
+		db.AccessTokensFunc.SetDefaultReturn(accessTokens)
+		db.UsersFunc.SetDefaultReturn(users)
 
 		RunTests(t, []*Test{
 			{
@@ -173,13 +180,15 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 	})
 
 	t.Run("authenticated as different user who is a site-admin. Admin allowed", func(t *testing.T) {
-		resetMocks()
 		const differentSiteAdminUID = 234
-		mockAccessTokensCreate(t, differentSiteAdminUID, []string{authz.ScopeUserAll})
-		database.Mocks.Users.GetByCurrentAuthUser = func(ctx context.Context) (*types.User, error) {
-			return &types.User{ID: differentSiteAdminUID, SiteAdmin: true}, nil
-		}
-		defer func() { database.Mocks.Users.GetByCurrentAuthUser = nil }()
+
+		accessTokens := newMockAccessTokens(t, differentSiteAdminUID, []string{authz.ScopeUserAll})
+		users := dbmock.NewMockUserStore()
+		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: differentSiteAdminUID, SiteAdmin: true}, nil)
+
+		db := dbmock.NewMockDB()
+		db.AccessTokensFunc.SetDefaultReturn(accessTokens)
+		db.UsersFunc.SetDefaultReturn(users)
 
 		conf.Get().AuthAccessTokens = &schema.AuthAccessTokens{Allow: string(conf.AccessTokensAdmin)}
 		defer func() { conf.Get().AuthAccessTokens = nil }()
@@ -209,16 +218,15 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 	})
 
 	t.Run("unauthenticated", func(t *testing.T) {
-		resetMocks()
-		database.Mocks.Users.GetByCurrentAuthUser = func(ctx context.Context) (*types.User, error) { return nil, database.ErrNoCurrentUser }
-		defer func() { database.Mocks.Users.GetByCurrentAuthUser = nil }()
-		database.Mocks.Users.GetByID = func(_ context.Context, userID int32) (*types.User, error) {
-			return &types.User{Username: "username"}, nil
-		}
-		defer func() { database.Mocks.Users.GetByID = nil }()
+		users := dbmock.NewMockUserStore()
+		users.GetByCurrentAuthUserFunc.SetDefaultReturn(nil, database.ErrNoCurrentUser)
+		users.GetByIDFunc.SetDefaultReturn(&types.User{Username: "username"}, nil)
+
+		db := dbmock.NewMockDB()
+		db.UsersFunc.SetDefaultReturn(users)
 
 		ctx := actor.WithActor(context.Background(), nil)
-		result, err := (&schemaResolver{db: database.NewDB(db)}).CreateAccessToken(ctx, &createAccessTokenInput{User: uid1GQLID, Note: "n"})
+		result, err := (&schemaResolver{db: db}).CreateAccessToken(ctx, &createAccessTokenInput{User: uid1GQLID, Note: "n"})
 		if err == nil {
 			t.Error("Expected error, but there was none")
 		}
@@ -228,17 +236,16 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 	})
 
 	t.Run("authenticated as different non-site-admin user", func(t *testing.T) {
-		resetMocks()
 		const differentNonSiteAdminUID = 456
-		database.Mocks.Users.GetByCurrentAuthUser = func(ctx context.Context) (*types.User, error) { return &types.User{ID: differentNonSiteAdminUID}, nil }
-		defer func() { database.Mocks.Users.GetByCurrentAuthUser = nil }()
-		database.Mocks.Users.GetByID = func(_ context.Context, userID int32) (*types.User, error) {
-			return &types.User{Username: "username"}, nil
-		}
-		defer func() { database.Mocks.Users.GetByID = nil }()
+		users := dbmock.NewMockUserStore()
+		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: differentNonSiteAdminUID}, nil)
+		users.GetByIDFunc.SetDefaultReturn(&types.User{Username: "username"}, nil)
+
+		db := dbmock.NewMockDB()
+		db.UsersFunc.SetDefaultReturn(users)
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: differentNonSiteAdminUID})
-		result, err := (&schemaResolver{db: database.NewDB(db)}).CreateAccessToken(ctx, &createAccessTokenInput{User: uid1GQLID, Note: "n"})
+		result, err := (&schemaResolver{db: db}).CreateAccessToken(ctx, &createAccessTokenInput{User: uid1GQLID, Note: "n"})
 		if err == nil {
 			t.Error("Expected error, but there was none")
 		}
@@ -248,10 +255,11 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 	})
 
 	t.Run("disable sudo token for dotcom", func(t *testing.T) {
-		database.Mocks.Users.GetByCurrentAuthUser = func(ctx context.Context) (*types.User, error) {
-			return &types.User{ID: 1, SiteAdmin: true}, nil
-		}
-		defer func() { database.Mocks.Users.GetByCurrentAuthUser = nil }()
+		users := dbmock.NewMockUserStore()
+		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 1, SiteAdmin: true}, nil)
+
+		db := dbmock.NewMockDB()
+		db.UsersFunc.SetDefaultReturn(users)
 
 		conf.Get().AuthAccessTokens = &schema.AuthAccessTokens{Allow: string(conf.AccessTokensAdmin)}
 		defer func() { conf.Get().AuthAccessTokens = nil }()
@@ -260,7 +268,7 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 		defer envvar.MockSourcegraphDotComMode(false)
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		_, err := (&schemaResolver{db: database.NewDB(db)}).CreateAccessToken(ctx, &createAccessTokenInput{
+		_, err := (&schemaResolver{db: db}).CreateAccessToken(ctx, &createAccessTokenInput{
 			User:   uid1GQLID,
 			Scopes: []string{authz.ScopeUserAll, authz.ScopeSiteAdminSudo},
 		})

--- a/cmd/frontend/graphqlbackend/user_emails.go
+++ b/cmd/frontend/graphqlbackend/user_emails.go
@@ -108,12 +108,12 @@ func (r *schemaResolver) RemoveUserEmail(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	if err := database.UserEmails(r.db).Remove(ctx, userID, args.Email); err != nil {
+	if err := r.db.UserEmails().Remove(ctx, userID, args.Email); err != nil {
 		return nil, err
 	}
 
 	// 🚨 SECURITY: If an email is removed, invalidate any existing password reset tokens that may have been sent to that email.
-	if err := database.Users(r.db).DeletePasswordResetCode(ctx, userID); err != nil {
+	if err := r.db.Users().DeletePasswordResetCode(ctx, userID); err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/internal/auth/userpasswd/reset_password.go
+++ b/cmd/frontend/internal/auth/userpasswd/reset_password.go
@@ -163,7 +163,7 @@ To set the password for {{.Username}} on Sourcegraph, follow this link:
 })
 
 // HandleResetPasswordCode resets the password if the correct code is provided.
-func HandleResetPasswordCode(db dbutil.DB) func(w http.ResponseWriter, r *http.Request) {
+func HandleResetPasswordCode(db database.DB) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if handleEnabledCheck(w) {
 			return
@@ -188,7 +188,7 @@ func HandleResetPasswordCode(db dbutil.DB) func(w http.ResponseWriter, r *http.R
 			return
 		}
 
-		success, err := database.Users(db).SetPassword(ctx, params.UserID, params.Code, params.Password)
+		success, err := db.Users().SetPassword(ctx, params.UserID, params.Code, params.Password)
 		if err != nil {
 			httpLogAndError(w, "Unexpected error", http.StatusInternalServerError, "err", err)
 			return


### PR DESCRIPTION
This converts a bunch of tests to use the new mock stores and
propagates database.DB through the codebase a bit more. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
