### PR TITLE
[Hack time] Add google search result searchbox for sourcegraph.com

### DIFF
--- a/cmd/frontend/internal/app/ui/app.html
+++ b/cmd/frontend/internal/app/ui/app.html
@@ -3,25 +3,6 @@
 
 <head>
 
-	{{ if .Context.SourcegraphDotComMode }}
-	<!-- Google Search Result SearchBox -->
-	<script type="application/ld+json">
-		{
-			"@context": "https://schema.org",
-			"@type": "WebSite",
-			"url": "https://sourcegraph.com",
-			"potentialAction": {
-				"@type": "SearchAction",
-				"target": {
-					"@type": "EntryPoint",
-					"urlTemplate": "https://sourcegraph.com/search?q={search_term_string}&utm_source=google-search-result&utm_campaign=google-search-result-searchbox"
-				},
-				"query-input": "required name=search_term_string"
-			}
-		}
-	</script>
-	<!-- End Google Search Result SearchBox -->
-	{{ end }}
 	{{.Injected.HeadTop}}
 	<meta charset="utf-8">
 	<meta http-equiv="x-ua-compatible" content="ie=edge">
@@ -73,6 +54,26 @@
 	<!-- Google Tag Manager (noscript) -->
 	<noscript><iframe ignore-csp src="https://www.googletagmanager.com/ns.html?id=GTM-TB4NLS7" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 	<!-- End Google Tag Manager (noscript) -->
+
+	<!-- Google Search Result SearchBox -->
+	<!-- See https://developers.google.com/search/docs/advanced/structured-data/sitelinks-searchbox -->
+	<script type="application/ld+json">
+		{
+			"@context": "https://schema.org",
+			"@type": "WebSite",
+			"url": "https://sourcegraph.com",
+			"potentialAction": {
+				"@type": "SearchAction",
+				"target": {
+					"@type": "EntryPoint",
+					"urlTemplate": "https://sourcegraph.com/search?q={search_term_string}&utm_source=google-search-result&utm_campaign=google-search-result-searchbox"
+				},
+				"query-input": "required name=search_term_string"
+			}
+		}
+	</script>
+	<!-- End Google Search Result SearchBox -->
+
 	{{ end }}
 	{{.Injected.BodyTop}}
 	<div id="root"></div>

--- a/cmd/frontend/internal/app/ui/app.html
+++ b/cmd/frontend/internal/app/ui/app.html
@@ -57,7 +57,7 @@
 
 	<!-- Google Search Result SearchBox -->
 	<!-- See https://developers.google.com/search/docs/advanced/structured-data/sitelinks-searchbox -->
-	<script type="application/ld+json">
+	<script ignore-csp type="application/ld+json">
 		{
 			"@context": "https://schema.org",
 			"@type": "WebSite",

--- a/cmd/frontend/internal/app/ui/app.html
+++ b/cmd/frontend/internal/app/ui/app.html
@@ -2,6 +2,26 @@
 <html lang="en" class="base">
 
 <head>
+
+	{{ if .Context.SourcegraphDotComMode }}
+	<!-- Google Search Result SearchBox -->
+	<script type="application/ld+json">
+		{
+			"@context": "https://schema.org",
+			"@type": "WebSite",
+			"url": "https://sourcegraph.com",
+			"potentialAction": {
+				"@type": "SearchAction",
+				"target": {
+					"@type": "EntryPoint",
+					"urlTemplate": "https://sourcegraph.com/search?q={search_term_string}&utm_source=google-search-result&utm_campaign=google-search-result-searchbox"
+				},
+				"query-input": "required name=search_term_string"
+			}
+		}
+	</script>
+	<!-- End Google Search Result SearchBox -->
+	{{ end }}
 	{{.Injected.HeadTop}}
 	<meta charset="utf-8">
 	<meta http-equiv="x-ua-compatible" content="ie=edge">


### PR DESCRIPTION
See [structured data docs](https://developers.google.com/search/docs/advanced/structured-data/sitelinks-searchbox) for more details.

### Description
This PR adds support for the search box in google search results. 

<details>
<summary> Example for IMDB </summary>

![image](https://user-images.githubusercontent.com/6717049/140539549-b0cfbef0-7530-4f07-97df-92d6215713d3.png)

</details>
