### PR TITLE
remove most uses of ensureStore

### DIFF
--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -115,6 +115,8 @@ func (s *repoStore) Transact(ctx context.Context) (RepoStore, error) {
 // ensureStore instantiates a basestore.Store if necessary, using the dbconn.Global handle.
 // This function ensures access to dbconn happens after the rest of the code or tests have
 // initialized it.
+// This can't be removed yet because GlobalRepos still uses the zero value of `repoStore`,
+// depending on it being initialized by `ensureStore`
 func (s *repoStore) ensureStore() {
 	s.once.Do(func() {
 		if s.Store == nil {


### PR DESCRIPTION
This removes most uses of `ensureStore` methods on our stores. These
were necessary when we had global stores to make sure that we
initialized the stores _after_ `dbconn.Global` was initialized. Now that
the store types are private and there are no global stores for these types, 
they must be created through their constructor, which requires a valid
`dbutil.DB`, making `ensureStore` a no-op. 

The only store that we could not safely remove `ensureStore` from is
`repoStore` because GlobalRepos still exists and depends on this
behavior.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
