### PR TITLE
Update bext e2e tests

### DIFF
--- a/client/browser/src/end-to-end/github.test.ts
+++ b/client/browser/src/end-to-end/github.test.ts
@@ -44,7 +44,7 @@ describe('Sourcegraph browser extension on github.com', function () {
         // Not using '.js-file-line' because it breaks the reliance on :nth-child() in testSingleFilePage()
         lineSelector: '.js-file-line-container tr',
         goToDefinitionURL:
-            'https://github.com/sourcegraph/jsonrpc2/blob/4fb7cd90793ee6ab445f466b900e6bffb9b63d78/call_opt.go#L5:6',
+            'https://github.com/sourcegraph/jsonrpc2/blob/4fb7cd90793ee6ab445f466b900e6bffb9b63d78/call_opt.go#L9:6',
     })
 
     const tokens = {

--- a/client/browser/src/end-to-end/gitlab.test.ts
+++ b/client/browser/src/end-to-end/gitlab.test.ts
@@ -55,7 +55,7 @@ describe('Sourcegraph browser extension on Gitlab Server', () => {
         getDriver: () => driver,
         url: url.href,
         // Other than GitHub, the URL must not include the column in the hash.
-        goToDefinitionURL: new URL('#L5', url.href).href,
+        goToDefinitionURL: new URL('#L9:6', url.href).href,
         repoName: `${REPO_PATH_PREFIX}/sourcegraph/jsonrpc2`,
         sourcegraphBaseUrl,
         lineSelector: '.line',


### PR DESCRIPTION
Fixes bext failing e2e tests due to https://github.com/sourcegraph/sourcegraph/pull/26892.

> I could not run bext e2e tests locally, chrome is weirdly blocking bext with `Error: net::ERR_BLOCKED_BY_CLIENT at chrome-extension://bmfbcejdknlknpncfpeloejonjoledha/options.html`. But I belive, this should fix failing tests.