### PR TITLE
sg ci logs: fix ci branch, improve error handling

### DIFF
--- a/dev/sg/internal/loki/loki_test.go
+++ b/dev/sg/internal/loki/loki_test.go
@@ -18,6 +18,20 @@ func TestNewStreamFromJobLogs(t *testing.T) {
 		wantErr bool
 	}{
 		{
+			name: "parse empty content",
+			args: args{
+				log: ``,
+			},
+			want: [][2]string{},
+		},
+		{
+			name: "parse invalid line",
+			args: args{
+				log: `~~~ Preparing working directory`,
+			},
+			wantErr: true,
+		},
+		{
 			name: "parse line",
 			args: args{
 				log: `_bk;t=1633575941106~~~ Preparing working directory`,
@@ -67,6 +81,10 @@ remote: Counting objects:   8% (2/25)_bk;t=1633575947202`,
 				t.Errorf("NewStreamFromJobLogs() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
+			if tt.wantErr {
+				return
+			}
+
 			if diff := cmp.Diff(tt.want, got.Values); diff != "" {
 				t.Fatalf("(-want +got):\n%s", diff)
 			}

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -602,7 +602,7 @@ commands:
       mkdir -p "$(dirname ${GRAFANA_LOG_FILE})"
 
       docker inspect $CONTAINER >/dev/null 2>&1 && docker rm -f $CONTAINER
-      ./docker-images/grafana/build.sh
+      IMAGE=sourcegraph/grafana:dev ./docker-images/grafana/build.sh
     env:
       GRAFANA_DISK: $HOME/.sourcegraph-dev/data/grafana
       # Log file location: since we log outside of the Docker container, we should
@@ -687,6 +687,7 @@ commands:
 
   loki:
     cmd: |
+      echo "Loki: serving on http://localhost:3100"
       echo "Loki: note that logs are piped to ${LOKI_LOG_FILE}"
       docker run --rm --name=loki \
         -p 3100:3100 -v $LOKI_DISK:/loki \

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -602,7 +602,7 @@ commands:
       mkdir -p "$(dirname ${GRAFANA_LOG_FILE})"
 
       docker inspect $CONTAINER >/dev/null 2>&1 && docker rm -f $CONTAINER
-      IMAGE=sourcegraph/grafana:dev ./docker-images/grafana/build.sh
+      ./docker-images/grafana/build.sh
     env:
       GRAFANA_DISK: $HOME/.sourcegraph-dev/data/grafana
       # Log file location: since we log outside of the Docker container, we should


### PR DESCRIPTION
- fix `getCIBranch` always failing in CI (https://buildkite.com/sourcegraph/sourcegraph/builds/115202#4d7735c5-9892-46c5-a8b1-2c514abe5cfb/65-66)
- better message for missing bk timestamps
- continue pushing logs on error
- set additional branch label from `BUILDKITE_BRANCH` only