### PR TITLE
dev/ci: split logs uploads by 'wait' block

### DIFF
--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -710,14 +710,15 @@ func publishExecutorDockerMirror(version string) operations.Operation {
 	}
 }
 
-func uploadBuildLogs() operations.Operation {
+// uploadBuildLogs publishes logs from failed jobs to Grafana Cloud. It runs as soon as
+// all previous steps up until a "wait" has run.
+func uploadBuildLogs(key string) operations.Operation {
 	return func(pipeline *bk.Pipeline) {
-		stepOpts := []bk.StepOpt{
+		pipeline.AddEnsureStep(fmt.Sprintf(":file_cabinet: Uploading build logs (%s)", key),
 			// Allow the upload to fail without failing the build.
+			bk.Key(fmt.Sprintf("upload-logs:%s", key)),
 			bk.SoftFail(1),
 			bk.AllowDependencyFailure(),
-			bk.Cmd("./enterprise/dev/upload-build-logs.sh"),
-		}
-		pipeline.AddEnsureStep(":file_cabinet: Uploading build logs", stepOpts...)
+			bk.Cmd("./enterprise/dev/upload-build-logs.sh"))
 	}
 }


### PR DESCRIPTION
"wait" blocks prevent subsequent steps from running, meaning we seem to be missing some logs uploads on main.

Requires https://github.com/sourcegraph/sourcegraph/pull/27145 to gracefully handle errors
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
