### PR TITLE
monitoring: allow worker duration prometheus buckets to be configurable

### DIFF
--- a/enterprise/cmd/executor/main.go
+++ b/enterprise/cmd/executor/main.go
@@ -88,9 +88,14 @@ func makeWorkerMetrics(queueName string) workerutil.WorkerMetrics {
 		Registerer: prometheus.DefaultRegisterer,
 	}
 
-	return workerutil.NewMetrics(observationContext, "executor_processor", map[string]string{
-		"queue": queueName,
-	})
+	return workerutil.NewMetrics(observationContext, "executor_processor",
+		// derived from historic data, ideally we will use spare high-res histograms once they're a reality
+		// 										 30s 1m	 2.5m 5m   7.5m 10m  15m  20m	30m	  45m	1hr
+		workerutil.WithDurationBuckets([]float64{30, 60, 150, 300, 450, 600, 900, 1200, 1800, 2700, 3600}),
+		workerutil.WithLabels(map[string]string{
+			"queue": queueName,
+		}),
+	)
 }
 
 func mustRegisterVMCountMetric(observationContext *observation.Context, prefix string) {

--- a/enterprise/cmd/precise-code-intel-worker/main.go
+++ b/enterprise/cmd/precise-code-intel-worker/main.go
@@ -185,7 +185,7 @@ func mustRegisterQueueMetric(observationContext *observation.Context, workerStor
 }
 
 func makeWorkerMetrics(observationContext *observation.Context) workerutil.WorkerMetrics {
-	return workerutil.NewMetrics(observationContext, "codeintel_upload_processor", nil)
+	return workerutil.NewMetrics(observationContext, "codeintel_upload_processor")
 }
 
 func initializeUploadStore(ctx context.Context, uploadStore uploadstore.Store) error {

--- a/enterprise/cmd/worker/internal/codeintel/indexing_job.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing_job.go
@@ -68,8 +68,8 @@ func (j *indexingJob) Routines(ctx context.Context) ([]goroutine.BackgroundRouti
 	enqueuerDBStoreShim := &enqueuer.DBStoreShim{Store: dbStore}
 	policyMatcher := policies.NewMatcher(gitserverClient, policies.IndexingExtractor, false, true)
 	indexEnqueuer := enqueuer.NewIndexEnqueuer(enqueuerDBStoreShim, gitserverClient, repoupdater.DefaultClient, indexingConfigInst.AutoIndexEnqueuerConfig, observationContext)
-	syncMetrics := workerutil.NewMetrics(observationContext, "codeintel_dependency_index_processor", nil)
-	queueingMetrics := workerutil.NewMetrics(observationContext, "codeintel_dependency_index_queueing", nil)
+	syncMetrics := workerutil.NewMetrics(observationContext, "codeintel_dependency_index_processor")
+	queueingMetrics := workerutil.NewMetrics(observationContext, "codeintel_dependency_index_queueing")
 
 	prometheus.DefaultRegisterer.MustRegister(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "src_codeintel_dependency_index_total",

--- a/enterprise/internal/batches/background/metrics.go
+++ b/enterprise/internal/batches/background/metrics.go
@@ -24,12 +24,12 @@ type batchChangesMetrics struct {
 
 func newMetrics(observationContext *observation.Context) batchChangesMetrics {
 	return batchChangesMetrics{
-		reconcilerWorkerMetrics:            workerutil.NewMetrics(observationContext, "batch_changes_reconciler", nil),
-		bulkProcessorWorkerMetrics:         workerutil.NewMetrics(observationContext, "batch_changes_bulk_processor", nil),
+		reconcilerWorkerMetrics:            workerutil.NewMetrics(observationContext, "batch_changes_reconciler"),
+		bulkProcessorWorkerMetrics:         workerutil.NewMetrics(observationContext, "batch_changes_bulk_processor"),
 		reconcilerWorkerResetterMetrics:    makeResetterMetrics(observationContext, "batch_changes_reconciler"),
 		bulkProcessorWorkerResetterMetrics: makeResetterMetrics(observationContext, "batch_changes_bulk_processor"),
 
-		batchSpecResolutionWorkerMetrics:         workerutil.NewMetrics(observationContext, "batch_changes_batch_spec_resolution_worker", nil),
+		batchSpecResolutionWorkerMetrics:         workerutil.NewMetrics(observationContext, "batch_changes_batch_spec_resolution_worker"),
 		batchSpecResolutionWorkerResetterMetrics: makeResetterMetrics(observationContext, "batch_changes_batch_spec_resolution_worker_resetter"),
 
 		batchSpecWorkspaceExecutionWorkerResetterMetrics: makeResetterMetrics(observationContext, "batch_spec_workspace_execution_worker_resetter"),

--- a/enterprise/internal/codemonitors/background/metrics.go
+++ b/enterprise/internal/codemonitors/background/metrics.go
@@ -43,7 +43,7 @@ func newMetricsForTriggerQueries() codeMonitorsMetrics {
 	observationContext.Registerer.MustRegister(errors)
 
 	return codeMonitorsMetrics{
-		workerMetrics: workerutil.NewMetrics(observationContext, "code_monitors_trigger_queries", nil),
+		workerMetrics: workerutil.NewMetrics(observationContext, "code_monitors_trigger_queries"),
 		resets:        resets,
 		resetFailures: resetFailures,
 		errors:        errors,
@@ -76,7 +76,7 @@ func newActionMetrics() codeMonitorsMetrics {
 	observationContext.Registerer.MustRegister(errors)
 
 	return codeMonitorsMetrics{
-		workerMetrics: workerutil.NewMetrics(observationContext, "code_monitors_actions", nil),
+		workerMetrics: workerutil.NewMetrics(observationContext, "code_monitors_actions"),
 		resets:        resets,
 		resetFailures: resetFailures,
 		errors:        errors,

--- a/enterprise/internal/insights/background/background.go
+++ b/enterprise/internal/insights/background/background.go
@@ -85,7 +85,7 @@ func GetBackgroundJobs(ctx context.Context, mainAppDB *sql.DB, insightsDB *sql.D
 // Individual insights workers may then _also_ want to register their own metrics, if desired, in
 // their NewWorker functions.
 func newWorkerMetrics(observationContext *observation.Context, workerName string) (workerutil.WorkerMetrics, dbworker.ResetterMetrics) {
-	workerMetrics := workerutil.NewMetrics(observationContext, workerName+"_processor", nil)
+	workerMetrics := workerutil.NewMetrics(observationContext, workerName+"_processor")
 	resetterMetrics := dbworker.NewMetrics(observationContext, workerName)
 	return workerMetrics, *resetterMetrics
 }

--- a/internal/repos/sync_worker.go
+++ b/internal/repos/sync_worker.go
@@ -107,7 +107,7 @@ func newWorkerMetrics(r prometheus.Registerer) workerutil.WorkerMetrics {
 		}
 	}
 
-	return workerutil.NewMetrics(observationContext, "repo_updater_external_service_syncer", nil)
+	return workerutil.NewMetrics(observationContext, "repo_updater_external_service_syncer")
 }
 
 func newResetterMetrics(r prometheus.Registerer) dbworker.ResetterMetrics {

--- a/internal/workerutil/observability.go
+++ b/internal/workerutil/observability.go
@@ -24,6 +24,21 @@ type operations struct {
 	handle *observation.Operation
 }
 
+type metricOptions struct {
+	labels          map[string]string
+	durationBuckets []float64
+}
+
+type MetricOption func(o *metricOptions)
+
+func WithLabels(labels map[string]string) MetricOption {
+	return func(o *metricOptions) { o.labels = labels }
+}
+
+func WithDurationBuckets(buckets []float64) MetricOption {
+	return func(o *metricOptions) { o.durationBuckets = buckets }
+}
+
 // NewMetrics creates and registers the following metrics for a generic worker instance.
 //
 //   - {prefix}_duration_seconds_bucket: handler operation latency histogram
@@ -32,10 +47,18 @@ type operations struct {
 //   - {prefix}_handlers: the number of active handler routines
 //
 // The given labels are emitted on each metric.
-func NewMetrics(observationContext *observation.Context, prefix string, labels map[string]string) WorkerMetrics {
-	keys := make([]string, 0, len(labels))
-	values := make([]string, 0, len(labels))
-	for key, value := range labels {
+func NewMetrics(observationContext *observation.Context, prefix string, opts ...MetricOption) WorkerMetrics {
+	options := &metricOptions{
+		durationBuckets: prometheus.DefBuckets,
+	}
+
+	for _, fn := range opts {
+		fn(options)
+	}
+
+	keys := make([]string, 0, len(options.labels))
+	values := make([]string, 0, len(options.labels))
+	for key, value := range options.labels {
 		keys = append(keys, key)
 		values = append(values, value)
 	}
@@ -56,17 +79,18 @@ func NewMetrics(observationContext *observation.Context, prefix string, labels m
 	)
 
 	return WorkerMetrics{
-		operations: newOperations(observationContext, prefix, keys, values),
+		operations: newOperations(observationContext, prefix, keys, values, options.durationBuckets),
 		numJobs:    newLenientConcurrencyGauge(numJobs, time.Second*5),
 	}
 }
 
-func newOperations(observationContext *observation.Context, prefix string, keys, values []string) *operations {
+func newOperations(observationContext *observation.Context, prefix string, keys, values []string, durationBuckets []float64) *operations {
 	metrics := metrics.NewOperationMetrics(
 		observationContext.Registerer,
 		prefix,
 		metrics.WithLabels(append(keys, "op")...),
 		metrics.WithCountHelp("Total number of method invocations."),
+		metrics.WithDurationBuckets(durationBuckets),
 	)
 
 	op := func(name string) *observation.Operation {

--- a/internal/workerutil/worker_test.go
+++ b/internal/workerutil/worker_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"sync"
-
 	"testing"
 	"time"
 
@@ -34,7 +33,7 @@ func TestWorkerHandlerSuccess(t *testing.T) {
 		WorkerHostname: "test",
 		NumHandlers:    1,
 		Interval:       time.Second,
-		Metrics:        NewMetrics(&observation.TestContext, "", nil),
+		Metrics:        NewMetrics(&observation.TestContext, ""),
 	}
 
 	store.DequeueFunc.PushReturn(TestRecord{ID: 42}, true, nil)
@@ -70,7 +69,7 @@ func TestWorkerHandlerFailure(t *testing.T) {
 		WorkerHostname: "test",
 		NumHandlers:    1,
 		Interval:       time.Second,
-		Metrics:        NewMetrics(&observation.TestContext, "", nil),
+		Metrics:        NewMetrics(&observation.TestContext, ""),
 	}
 
 	store.DequeueFunc.PushReturn(TestRecord{ID: 42}, true, nil)
@@ -114,7 +113,7 @@ func TestWorkerHandlerNonRetryableFailure(t *testing.T) {
 		WorkerHostname: "test",
 		NumHandlers:    1,
 		Interval:       time.Second,
-		Metrics:        NewMetrics(&observation.TestContext, "", nil),
+		Metrics:        NewMetrics(&observation.TestContext, ""),
 	}
 
 	store.DequeueFunc.PushReturn(TestRecord{ID: 42}, true, nil)
@@ -161,7 +160,7 @@ func TestWorkerConcurrent(t *testing.T) {
 				WorkerHostname: "test",
 				NumHandlers:    numHandlers,
 				Interval:       time.Second,
-				Metrics:        NewMetrics(&observation.TestContext, "", nil),
+				Metrics:        NewMetrics(&observation.TestContext, ""),
 			}
 
 			for i := 0; i < NumTestRecords; i++ {
@@ -250,7 +249,7 @@ func TestWorkerBlockingPreDequeueHook(t *testing.T) {
 		WorkerHostname: "test",
 		NumHandlers:    1,
 		Interval:       time.Second,
-		Metrics:        NewMetrics(&observation.TestContext, "", nil),
+		Metrics:        NewMetrics(&observation.TestContext, ""),
 	}
 
 	store.DequeueFunc.PushReturn(TestRecord{ID: 42}, true, nil)
@@ -280,7 +279,7 @@ func TestWorkerConditionalPreDequeueHook(t *testing.T) {
 		WorkerHostname: "test",
 		NumHandlers:    1,
 		Interval:       time.Second,
-		Metrics:        NewMetrics(&observation.TestContext, "", nil),
+		Metrics:        NewMetrics(&observation.TestContext, ""),
 	}
 
 	store.DequeueFunc.PushReturn(TestRecord{ID: 42}, true, nil)
@@ -356,7 +355,7 @@ func TestWorkerDequeueHeartbeat(t *testing.T) {
 		NumHandlers:       1,
 		HeartbeatInterval: heartbeatInterval,
 		Interval:          time.Second,
-		Metrics:           NewMetrics(&observation.TestContext, "", nil),
+		Metrics:           NewMetrics(&observation.TestContext, ""),
 	}
 
 	dequeued := make(chan struct{})
@@ -403,7 +402,7 @@ func TestWorkerNumTotalJobs(t *testing.T) {
 		NumHandlers:    1,
 		NumTotalJobs:   5,
 		Interval:       time.Second,
-		Metrics:        NewMetrics(&observation.TestContext, "", nil),
+		Metrics:        NewMetrics(&observation.TestContext, ""),
 	}
 
 	store.DequeueFunc.SetDefaultReturn(TestRecord{ID: 42}, true, nil)
@@ -431,7 +430,7 @@ func TestWorkerMaxActiveTime(t *testing.T) {
 		NumTotalJobs:   50,
 		MaxActiveTime:  time.Second * 5,
 		Interval:       time.Second,
-		Metrics:        NewMetrics(&observation.TestContext, "", nil),
+		Metrics:        NewMetrics(&observation.TestContext, ""),
 	}
 
 	called := make(chan struct{})
@@ -504,7 +503,7 @@ func TestWorkerCancel(t *testing.T) {
 		NumHandlers:       1,
 		HeartbeatInterval: time.Second,
 		Interval:          time.Second,
-		Metrics:           NewMetrics(&observation.TestContext, "", nil),
+		Metrics:           NewMetrics(&observation.TestContext, ""),
 	}
 
 	dequeued := make(chan struct{})


### PR DESCRIPTION
Executors are the first user of the configurable API, with buckets of 30s, 1m, 2.5m, 5m, 7.5m, 10m, 15m, 20m, 30m, 45m, 1hr as opposed to the upper limit bucket of 10s into which basically everything was placed, so we got nothing of value there (see screenshot below). 

But no more :sunglasses: 

![image](https://user-images.githubusercontent.com/18282288/140586518-aa8d1cf2-ce4b-4af2-981e-57aeb619da2c.png)
