### PR TITLE
batches: prefill SSBC editor with hello world example

### DIFF
--- a/client/web/src/enterprise/batches/create/NewCreateBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/NewCreateBatchChangePage.tsx
@@ -52,6 +52,7 @@ import {
     replaceBatchSpecInput,
 } from './backend'
 import { MonacoBatchSpecEditor } from './editor/MonacoBatchSpecEditor'
+import helloWorldSample from './examples/hello-world.batch.yaml'
 import styles from './NewCreateBatchChangePage.module.scss'
 import { excludeRepo } from './yaml-util'
 
@@ -138,7 +139,7 @@ export const NewCreateBatchChangePage: React.FunctionComponent<CreateBatchChange
 
     const [isLoading, setIsLoading] = useState<boolean | Error>(false)
     const [previewID, setPreviewID] = useState<Scalars['ID']>()
-    const [code, setCode] = useState<string>('name: ')
+    const [code, setCode] = useState<string>(helloWorldSample)
 
     const submitBatchSpec = useCallback<React.MouseEventHandler>(async () => {
         if (!previewID) {

--- a/client/web/src/enterprise/batches/create/OldCreateBatchChangeContent.tsx
+++ b/client/web/src/enterprise/batches/create/OldCreateBatchChangeContent.tsx
@@ -7,8 +7,8 @@ import { Container } from '@sourcegraph/wildcard'
 import { SidebarGroup, SidebarGroupHeader } from '../../../components/Sidebar'
 
 import combySample from './examples/comby.batch.yaml'
-import helloWorldSample from './examples/empty.batch.yaml'
 import goImportsSample from './examples/go-imports.batch.yaml'
+import helloWorldSample from './examples/hello-world.batch.yaml'
 import minimalSample from './examples/minimal.batch.yaml'
 
 // SampleTabHeader is superseded by ExampleTabs and can be removed when SSBC is rolled out

--- a/client/web/src/enterprise/batches/create/examples/hello-world.batch.yaml
+++ b/client/web/src/enterprise/batches/create/examples/hello-world.batch.yaml
@@ -3,7 +3,7 @@ description: Add Hello World to READMEs
 
 # Find all repositories that contain a README.md file.
 on:
-  - repositoriesMatchingQuery: file:README.md
+  - repositoriesMatchingQuery: file:README.md count:100
 
 # In each repository, run this command. Each repository's resulting diff is captured.
 steps:
@@ -17,4 +17,3 @@ changesetTemplate:
   branch: hello-world # Push the commit to this branch.
   commit:
     message: Append Hello World to all README.md files
-  published: false


### PR DESCRIPTION
Just sets the "Hello World" example spec as the initial SSBC editor content! Looks a bit more welcoming. 🙂