### PR TITLE
Don't display the context CTA banner for org members

### DIFF
--- a/client/web/src/search/input/SearchContextDropdown.tsx
+++ b/client/web/src/search/input/SearchContextDropdown.tsx
@@ -80,6 +80,8 @@ export const SearchContextDropdown: React.FunctionComponent<SearchContextDropdow
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isOpen])
 
+    const isUserAnOrgMember = authenticatedUser?.organizations.nodes.length !== 0
+
     return (
         <Dropdown
             isOpen={isOpen}
@@ -111,7 +113,7 @@ export const SearchContextDropdown: React.FunctionComponent<SearchContextDropdow
                 </code>
             </DropdownToggle>
             <DropdownMenu positionFixed={true} className={styles.menu}>
-                {isSourcegraphDotCom && !hasUserAddedRepositories && !hasUsedNonGlobalContext ? (
+                {isSourcegraphDotCom && !isUserAnOrgMember && !hasUserAddedRepositories && !hasUsedNonGlobalContext ? (
                     <SearchContextCtaPrompt
                         telemetryService={telemetryService}
                         authenticatedUser={authenticatedUser}


### PR DESCRIPTION
### Description

Don't display the context CTA banner if a user is an org member.
[Link](https://sourcegraph.atlassian.net/browse/CLOUD-114) to the issue in Jira.

### Tests

The fix was tested locally with two users and a demo organization. 