### PR TITLE
web: refactor spacing in navbar component

### DIFF
--- a/client/wildcard/src/components/NavBar/NavBar.module.scss
+++ b/client/wildcard/src/components/NavBar/NavBar.module.scss
@@ -53,6 +53,7 @@
     height: 100%;
     margin: 0;
     padding: 0;
+    gap: 1rem;
     @media (--sm-breakpoint-down) {
         border-radius: var(--border-radius);
         border: 1px solid var(--border-color-2);

--- a/client/wildcard/src/components/NavBar/NavItem.module.scss
+++ b/client/wildcard/src/components/NavBar/NavItem.module.scss
@@ -3,7 +3,6 @@
 .item {
     display: flex;
     align-items: stretch;
-    margin: 0 0.5rem;
     &:first-child {
         margin-left: 0;
     }


### PR DESCRIPTION
## Context
Make the scss code cleaner by removing the `margin-right` spacing in each NavBar item and only letting the parent node handle the spacing via `gap` property

## Results
Unnoticeable differences compared to using the `margin-right` property

![sourcegraph-navbar](https://user-images.githubusercontent.com/47023801/140662686-4bb44303-31d7-46ac-9680-4e3068f87010.png)

Closes #25243
