### PR TITLE
Webhook log backend tweaks

### DIFF
--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -186,5 +186,5 @@ func (r *externalServiceResolver) GrantedScopes(ctx context.Context) (*[]string,
 }
 
 func (r *externalServiceResolver) WebhookLogs(ctx context.Context, args *webhookLogsArgs) (*webhookLogConnectionResolver, error) {
-	return newWebhookLogConnectionResolver(ctx, r.db, args, r.externalService.ID)
+	return newWebhookLogConnectionResolver(ctx, r.db, args, webhookLogsExternalServiceID{r.externalService.ID})
 }

--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -186,5 +186,5 @@ func (r *externalServiceResolver) GrantedScopes(ctx context.Context) (*[]string,
 }
 
 func (r *externalServiceResolver) WebhookLogs(ctx context.Context, args *webhookLogsArgs) (*webhookLogConnectionResolver, error) {
-	return newWebhookLogConnectionResolver(ctx, r.db, args, webhookLogsExternalServiceID{r.externalService.ID})
+	return newWebhookLogConnectionResolver(ctx, r.db, args, webhookLogsExternalServiceID(r.externalService.ID))
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1406,7 +1406,9 @@ type Query {
     temporarySettings: TemporarySettings!
 
     """
-    Returns recently received webhooks that did not match an external service.
+    Returns recently received webhooks across all external services, optionally
+    limiting the returned values to only those that didn't match any external
+    service.
 
     Only site admins can access this field.
     """
@@ -1425,6 +1427,11 @@ type Query {
         Only include webhook logs that resulted in errors.
         """
         onlyErrors: Boolean
+
+        """
+        Only include webhook logs that were not matched to an external service.
+        """
+        onlyUnmatched: Boolean
 
         """
         Only include webhook logs on or after this time.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6407,18 +6407,63 @@ type WebhookLog implements Node {
     """
     The received webhook request.
     """
-    request: WebhookLogMessage!
+    request: WebhookLogRequest!
 
     """
     The response sent by the webhook handler.
     """
-    response: WebhookLogMessage!
+    response: WebhookLogResponse!
 }
 
 """
 A HTTP message (request or response) within a webhook log.
 """
-type WebhookLogMessage {
+interface WebhookLogMessage {
+    """
+    The headers in the HTTP message.
+    """
+    headers: [WebhookLogHeader!]!
+
+    """
+    The body content of the HTTP message.
+    """
+    body: String!
+}
+
+"""
+A HTTP request within a webhook log.
+"""
+type WebhookLogRequest implements WebhookLogMessage {
+    """
+    The headers in the HTTP message.
+    """
+    headers: [WebhookLogHeader!]!
+
+    """
+    The body content of the HTTP message.
+    """
+    body: String!
+
+    """
+    The method used in the HTTP request.
+    """
+    method: String!
+
+    """
+    The requested URL.
+    """
+    url: String!
+
+    """
+    The HTTP version in use.
+    """
+    version: String!
+}
+
+"""
+A HTTP response within a webhook log.
+"""
+type WebhookLogResponse implements WebhookLogMessage {
     """
     The headers in the HTTP message.
     """

--- a/cmd/frontend/graphqlbackend/webhook_logs.go
+++ b/cmd/frontend/graphqlbackend/webhook_logs.go
@@ -22,7 +22,7 @@ import (
 // access to webhook logs: the webhookLogs method on the top level query, and on
 // the ExternalService type.
 type webhookLogsArgs struct {
-	First      *int
+	graphqlutil.ConnectionArgs
 	After      *string
 	OnlyErrors *bool
 	Since      *time.Time
@@ -62,7 +62,7 @@ func (args *webhookLogsArgs) toListOpts(externalServiceID webhookLogsExternalSer
 	}
 
 	if args.First != nil {
-		opts.Limit = *args.First
+		opts.Limit = int(*args.First)
 	} else {
 		opts.Limit = 50
 	}

--- a/cmd/frontend/graphqlbackend/webhook_logs.go
+++ b/cmd/frontend/graphqlbackend/webhook_logs.go
@@ -222,7 +222,7 @@ func (r *webhookLogResolver) ReceivedAt() DateTime {
 
 func (r *webhookLogResolver) ExternalService(ctx context.Context) (*externalServiceResolver, error) {
 	if r.log.ExternalServiceID == nil {
-		return nil, errors.New("no external service attached to webhook log")
+		return nil, nil
 	}
 
 	return externalServiceByID(ctx, r.db, marshalExternalServiceID(*r.log.ExternalServiceID))

--- a/cmd/frontend/graphqlbackend/webhook_logs.go
+++ b/cmd/frontend/graphqlbackend/webhook_logs.go
@@ -232,8 +232,8 @@ func (r *webhookLogResolver) StatusCode() int32 {
 	return int32(r.log.StatusCode)
 }
 
-func (r *webhookLogResolver) Request() *webhookLogMessageResolver {
-	return &webhookLogMessageResolver{message: &r.log.Request}
+func (r *webhookLogResolver) Request() *webhookLogRequestResolver {
+	return &webhookLogRequestResolver{webhookLogMessageResolver{message: &r.log.Request}}
 }
 
 func (r *webhookLogResolver) Response() *webhookLogMessageResolver {
@@ -258,6 +258,22 @@ func (r *webhookLogMessageResolver) Headers() []*webhookLogHeaderResolver {
 
 func (r *webhookLogMessageResolver) Body() string {
 	return string(r.message.Body)
+}
+
+type webhookLogRequestResolver struct {
+	webhookLogMessageResolver
+}
+
+func (r *webhookLogRequestResolver) Method() string {
+	return r.message.Method
+}
+
+func (r *webhookLogRequestResolver) URL() string {
+	return r.message.URL
+}
+
+func (r *webhookLogRequestResolver) Version() string {
+	return r.message.Version
 }
 
 type webhookLogHeaderResolver struct {

--- a/cmd/frontend/graphqlbackend/webhook_logs.go
+++ b/cmd/frontend/graphqlbackend/webhook_logs.go
@@ -32,13 +32,11 @@ type webhookLogsArgs struct {
 // webhookLogsExternalServiceID is used to represent an external service ID,
 // which may be a constant defined below to represent all or unmatched external
 // services.
-type webhookLogsExternalServiceID struct {
-	id int64
-}
+type webhookLogsExternalServiceID int64
 
 var (
-	webhookLogsAllExternalServices      = webhookLogsExternalServiceID{-1}
-	webhookLogsUnmatchedExternalService = webhookLogsExternalServiceID{0}
+	webhookLogsAllExternalServices      webhookLogsExternalServiceID = -1
+	webhookLogsUnmatchedExternalService webhookLogsExternalServiceID = 0
 )
 
 func (id webhookLogsExternalServiceID) toListOpt() *int64 {
@@ -48,7 +46,8 @@ func (id webhookLogsExternalServiceID) toListOpt() *int64 {
 	case webhookLogsUnmatchedExternalService:
 		fallthrough
 	default:
-		return &id.id
+		i := int64(id)
+		return &i
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/webhook_logs_test.go
+++ b/cmd/frontend/graphqlbackend/webhook_logs_test.go
@@ -49,7 +49,7 @@ func TestWebhookLogsArgs(t *testing.T) {
 				},
 			},
 			"all arguments": {
-				id: webhookLogsExternalServiceID{1},
+				id: webhookLogsExternalServiceID(1),
 				input: webhookLogsArgs{
 					ConnectionArgs: graphqlutil.ConnectionArgs{
 						First: int32Ptr(25),
@@ -159,7 +159,7 @@ func TestWebhookLogConnectionResolver(t *testing.T) {
 					First: int32Ptr(20),
 				},
 			},
-			externalServiceID: webhookLogsExternalServiceID{1},
+			externalServiceID: webhookLogsExternalServiceID(1),
 			store:             store,
 		}
 
@@ -192,7 +192,7 @@ func TestWebhookLogConnectionResolver(t *testing.T) {
 					First: int32Ptr(20),
 				},
 			},
-			externalServiceID: webhookLogsExternalServiceID{1},
+			externalServiceID: webhookLogsExternalServiceID(1),
 			store:             store,
 		}
 
@@ -228,7 +228,7 @@ func TestWebhookLogConnectionResolver(t *testing.T) {
 					First: int32Ptr(20),
 				},
 			},
-			externalServiceID: webhookLogsExternalServiceID{1},
+			externalServiceID: webhookLogsExternalServiceID(1),
 			store:             store,
 		}
 
@@ -246,7 +246,7 @@ func TestWebhookLogConnectionResolver_TotalCount(t *testing.T) {
 			args: &webhookLogsArgs{
 				OnlyErrors: boolPtr(true),
 			},
-			externalServiceID: webhookLogsExternalServiceID{1},
+			externalServiceID: webhookLogsExternalServiceID(1),
 			store:             store,
 		}
 
@@ -276,7 +276,7 @@ func TestWebhookLogConnectionResolver_TotalCount(t *testing.T) {
 			args: &webhookLogsArgs{
 				OnlyErrors: boolPtr(true),
 			},
-			externalServiceID: webhookLogsExternalServiceID{1},
+			externalServiceID: webhookLogsExternalServiceID(1),
 			store:             store,
 		}
 

--- a/cmd/frontend/graphqlbackend/webhook_logs_test.go
+++ b/cmd/frontend/graphqlbackend/webhook_logs_test.go
@@ -25,20 +25,19 @@ func TestWebhookLogsArgs(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		for name, tc := range map[string]struct {
-			id    int64
+			id    webhookLogsExternalServiceID
 			input webhookLogsArgs
 			want  database.WebhookLogListOpts
 		}{
 			"no arguments": {
-				id:    0,
+				id:    webhookLogsAllExternalServices,
 				input: webhookLogsArgs{},
 				want: database.WebhookLogListOpts{
-					Limit:             50,
-					ExternalServiceID: int64Ptr(0),
+					Limit: 50,
 				},
 			},
 			"OnlyErrors false": {
-				id: 0,
+				id: webhookLogsUnmatchedExternalService,
 				input: webhookLogsArgs{
 					OnlyErrors: boolPtr(false),
 				},
@@ -49,7 +48,7 @@ func TestWebhookLogsArgs(t *testing.T) {
 				},
 			},
 			"all arguments": {
-				id: 1,
+				id: webhookLogsExternalServiceID{1},
 				input: webhookLogsArgs{
 					First:      intPtr(25),
 					After:      stringPtr("40"),
@@ -83,7 +82,7 @@ func TestWebhookLogsArgs(t *testing.T) {
 			"foo",
 		} {
 			t.Run(input, func(t *testing.T) {
-				_, err := (&webhookLogsArgs{After: &input}).toListOpts(0)
+				_, err := (&webhookLogsArgs{After: &input}).toListOpts(webhookLogsUnmatchedExternalService)
 				assert.NotNil(t, err)
 			})
 		}
@@ -100,7 +99,7 @@ func TestNewWebhookLogConnectionResolver(t *testing.T) {
 		db := dbmock.NewMockDB()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		_, err := newWebhookLogConnectionResolver(context.Background(), db, nil, 0)
+		_, err := newWebhookLogConnectionResolver(context.Background(), db, nil, webhookLogsUnmatchedExternalService)
 		assert.ErrorIs(t, err, backend.ErrNotAuthenticated)
 	})
 
@@ -111,7 +110,7 @@ func TestNewWebhookLogConnectionResolver(t *testing.T) {
 		db := dbmock.NewMockDB()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		_, err := newWebhookLogConnectionResolver(context.Background(), db, nil, 0)
+		_, err := newWebhookLogConnectionResolver(context.Background(), db, nil, webhookLogsUnmatchedExternalService)
 		assert.ErrorIs(t, err, backend.ErrMustBeSiteAdmin)
 	})
 
@@ -122,7 +121,7 @@ func TestNewWebhookLogConnectionResolver(t *testing.T) {
 		db := dbmock.NewMockDB()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		_, err := newWebhookLogConnectionResolver(context.Background(), db, nil, 0)
+		_, err := newWebhookLogConnectionResolver(context.Background(), db, nil, webhookLogsUnmatchedExternalService)
 		assert.Nil(t, err)
 	})
 }
@@ -155,7 +154,7 @@ func TestWebhookLogConnectionResolver(t *testing.T) {
 			args: &webhookLogsArgs{
 				First: intPtr(20),
 			},
-			externalServiceID: 1,
+			externalServiceID: webhookLogsExternalServiceID{1},
 			store:             store,
 		}
 
@@ -186,7 +185,7 @@ func TestWebhookLogConnectionResolver(t *testing.T) {
 			args: &webhookLogsArgs{
 				First: intPtr(20),
 			},
-			externalServiceID: 1,
+			externalServiceID: webhookLogsExternalServiceID{1},
 			store:             store,
 		}
 
@@ -220,7 +219,7 @@ func TestWebhookLogConnectionResolver(t *testing.T) {
 			args: &webhookLogsArgs{
 				First: intPtr(20),
 			},
-			externalServiceID: 1,
+			externalServiceID: webhookLogsExternalServiceID{1},
 			store:             store,
 		}
 
@@ -238,7 +237,7 @@ func TestWebhookLogConnectionResolver_TotalCount(t *testing.T) {
 			args: &webhookLogsArgs{
 				OnlyErrors: boolPtr(true),
 			},
-			externalServiceID: 1,
+			externalServiceID: webhookLogsExternalServiceID{1},
 			store:             store,
 		}
 
@@ -268,7 +267,7 @@ func TestWebhookLogConnectionResolver_TotalCount(t *testing.T) {
 			args: &webhookLogsArgs{
 				OnlyErrors: boolPtr(true),
 			},
-			externalServiceID: 1,
+			externalServiceID: webhookLogsExternalServiceID{1},
 			store:             store,
 		}
 

--- a/cmd/frontend/graphqlbackend/webhook_logs_test.go
+++ b/cmd/frontend/graphqlbackend/webhook_logs_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
@@ -50,7 +51,9 @@ func TestWebhookLogsArgs(t *testing.T) {
 			"all arguments": {
 				id: webhookLogsExternalServiceID{1},
 				input: webhookLogsArgs{
-					First:      intPtr(25),
+					ConnectionArgs: graphqlutil.ConnectionArgs{
+						First: int32Ptr(25),
+					},
 					After:      stringPtr("40"),
 					OnlyErrors: boolPtr(true),
 					Since:      timePtr(now),
@@ -152,7 +155,9 @@ func TestWebhookLogConnectionResolver(t *testing.T) {
 
 		r := &webhookLogConnectionResolver{
 			args: &webhookLogsArgs{
-				First: intPtr(20),
+				ConnectionArgs: graphqlutil.ConnectionArgs{
+					First: int32Ptr(20),
+				},
 			},
 			externalServiceID: webhookLogsExternalServiceID{1},
 			store:             store,
@@ -183,7 +188,9 @@ func TestWebhookLogConnectionResolver(t *testing.T) {
 
 		r := &webhookLogConnectionResolver{
 			args: &webhookLogsArgs{
-				First: intPtr(20),
+				ConnectionArgs: graphqlutil.ConnectionArgs{
+					First: int32Ptr(20),
+				},
 			},
 			externalServiceID: webhookLogsExternalServiceID{1},
 			store:             store,
@@ -217,7 +224,9 @@ func TestWebhookLogConnectionResolver(t *testing.T) {
 
 		r := &webhookLogConnectionResolver{
 			args: &webhookLogsArgs{
-				First: intPtr(20),
+				ConnectionArgs: graphqlutil.ConnectionArgs{
+					First: int32Ptr(20),
+				},
 			},
 			externalServiceID: webhookLogsExternalServiceID{1},
 			store:             store,
@@ -277,7 +286,7 @@ func TestWebhookLogConnectionResolver_TotalCount(t *testing.T) {
 }
 
 func boolPtr(v bool) *bool           { return &v }
-func intPtr(v int) *int              { return &v }
+func int32Ptr(v int32) *int32        { return &v }
 func int64Ptr(v int64) *int64        { return &v }
 func stringPtr(v string) *string     { return &v }
 func timePtr(v time.Time) *time.Time { return &v }

--- a/cmd/frontend/webhooks/middleware.go
+++ b/cmd/frontend/webhooks/middleware.go
@@ -60,6 +60,7 @@ func (mw *LogMiddleware) Logger(next http.Handler) http.Handler {
 		// most importantly, the status code.
 		writer := &responseWriter{
 			ResponseWriter: w,
+			statusCode:     200,
 		}
 
 		// The external service ID is looked up within the webhook handler, but
@@ -110,11 +111,7 @@ type responseWriter struct {
 var _ http.ResponseWriter = &responseWriter{}
 
 func (rw *responseWriter) Write(data []byte) (int, error) {
-	if rw.statusCode == 0 {
-		rw.statusCode = http.StatusOK
-	}
 	rw.buf.Write(data)
-
 	return rw.ResponseWriter.Write(data)
 }
 

--- a/cmd/frontend/webhooks/middleware.go
+++ b/cmd/frontend/webhooks/middleware.go
@@ -78,13 +78,22 @@ func (mw *LogMiddleware) Logger(next http.Handler) http.Handler {
 		// Delegate to the next handler.
 		next.ServeHTTP(writer, r.WithContext(ctx))
 
+		// See if we have the requested URL.
+		url := ""
+		if u := r.URL; u != nil {
+			url = u.String()
+		}
+
 		// Write the payload.
 		if err := mw.store.Create(r.Context(), &types.WebhookLog{
 			ExternalServiceID: externalServiceID,
 			StatusCode:        writer.statusCode,
 			Request: types.WebhookLogMessage{
-				Header: r.Header,
-				Body:   buf.Bytes(),
+				Header:  r.Header,
+				Body:    buf.Bytes(),
+				Method:  r.Method,
+				URL:     url,
+				Version: r.Proto,
 			},
 			Response: types.WebhookLogMessage{
 				Header: writer.Header(),

--- a/cmd/frontend/webhooks/middleware_test.go
+++ b/cmd/frontend/webhooks/middleware_test.go
@@ -77,6 +77,8 @@ func TestLogMiddleware(t *testing.T) {
 		store.CreateFunc.SetDefaultHook(func(c context.Context, log *types.WebhookLog) error {
 			assert.Equal(t, es, *log.ExternalServiceID)
 			assert.Equal(t, http.StatusCreated, log.StatusCode)
+			assert.Equal(t, "GET", log.Request.Method)
+			assert.Equal(t, "HTTP/1.1", log.Request.Version)
 			assert.Equal(t, "bar", log.Response.Header.Get("foo"))
 			assert.Equal(t, content, log.Response.Body)
 

--- a/internal/types/webhook_logs.go
+++ b/internal/types/webhook_logs.go
@@ -15,6 +15,9 @@ type WebhookLog struct {
 }
 
 type WebhookLogMessage struct {
-	Header http.Header
-	Body   []byte
+	Header  http.Header
+	Body    []byte
+	Method  string `json:",omitempty"`
+	URL     string `json:",omitempty"`
+	Version string `json:",omitempty"`
 }


### PR DESCRIPTION
Here are a few odds and ends that became more obvious needs as I worked on #27179:

* The design Rob and I came up with needs the ability to retrieve _all_ webhook logs, as well as unmatched logs, so that ability has been added to the top level query resolver `webhookLogs()` method. (This was already supported in the store anyway.)
* The middleware would fail to write the correct status code if the handler didn't explicitly set one and didn't send any response bytes. It now defaults to `200`.
* I hadn't added tracking for the request URL, which might be useful, so I added that. I also added the method and version, which means we can render the request like it really looked on the wire. (Spoiler: highlight.js has some really nifty formatting for this.)
* Fixed a bug with requesting the `externalService` on webhook logs that don't have an external service.
* Changed the pagination to use `graphqlutil.ConnectionArgs` because our GraphQL library couldn't unmarshal a JSON number into an `int`. Cool. I feel really good about it.

Rather than splitting these up, I've put them in this PR for easier reviewing, but if anyone wants them in separate PRs I am happy to oblige.