### PR TITLE
Fix browser extension failing e2e tests

### DIFF
--- a/client/browser/src/end-to-end/github.test.ts
+++ b/client/browser/src/end-to-end/github.test.ts
@@ -44,7 +44,7 @@ describe('Sourcegraph browser extension on github.com', function () {
         // Not using '.js-file-line' because it breaks the reliance on :nth-child() in testSingleFilePage()
         lineSelector: '.js-file-line-container tr',
         goToDefinitionURL:
-            'https://github.com/sourcegraph/jsonrpc2/blob/4fb7cd90793ee6ab445f466b900e6bffb9b63d78/call_opt.go#L9:6',
+            'https://github.com/sourcegraph/jsonrpc2/blob/4fb7cd90793ee6ab445f466b900e6bffb9b63d78/call_opt.go#L5:6',
     })
 
     const tokens = {

--- a/client/browser/src/end-to-end/gitlab.test.ts
+++ b/client/browser/src/end-to-end/gitlab.test.ts
@@ -55,7 +55,7 @@ describe('Sourcegraph browser extension on Gitlab Server', () => {
         getDriver: () => driver,
         url: url.href,
         // Other than GitHub, the URL must not include the column in the hash.
-        goToDefinitionURL: new URL('#L9:6', url.href).href,
+        goToDefinitionURL: new URL('#L5', url.href).href,
         repoName: `${REPO_PATH_PREFIX}/sourcegraph/jsonrpc2`,
         sourcegraphBaseUrl,
         lineSelector: '.line',

--- a/client/browser/src/end-to-end/shared.ts
+++ b/client/browser/src/end-to-end/shared.ts
@@ -85,7 +85,7 @@ export function testSingleFilePage({
             const line = await getDriver().page.waitForSelector(`${lineSelector}:nth-child(${lineNumber})`, {
                 timeout: 10000,
             })
-            const [token] = await line.$x('//span[text()="CallOption"]')
+            const [token] = await line.$x('.//span[text()="CallOption"]')
             await token.hover()
             await getDriver().page.waitForSelector('.test-tooltip-go-to-definition')
             await retry(async () => {


### PR DESCRIPTION
Currently browser extension e2e are failin in [bext/release branch](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=bext%2Frelease).

This PR:
- Reverts https://github.com/sourcegraph/sourcegraph/pull/27144, because it didn't fix
- Fixes failing e2e tests

### How to test

1. `yarn run download-puppeteer-browser`
1. `EXTENSION_PERMISSIONS_ALL_URLS=true yarn --cwd client/browser build`
1. `SOURCEGRAPH_BASE_URL=https://sourcegraph.com PERCY_BROWSER_EXECUTABLE=node_modules/puppeteer/.local-chromium/linux-901812/chrome-linux/chrome yarn -s mocha ./src/end-to-end/(gitlab|github).test.ts`
