### PR TITLE
search: Minor improvements to no results page

### DIFF
--- a/client/web/src/search/results/NoResultsPage.module.scss
+++ b/client/web/src/search/results/NoResultsPage.module.scss
@@ -2,6 +2,7 @@
 
 .root {
     align-self: stretch;
+    margin-top: 3rem;
 
     > .panels {
         display: flex;
@@ -42,6 +43,10 @@
 
     h4:first-of-type {
         margin-top: initial;
+    }
+
+    p {
+        margin: 1rem 0;
     }
 }
 

--- a/client/web/src/search/results/NoResultsPage.tsx
+++ b/client/web/src/search/results/NoResultsPage.tsx
@@ -263,51 +263,45 @@ export const NoResultsPage: React.FunctionComponent<NoResultsPageProps> = ({
                                 Try searching in regexp mode to match terms independently, similar to an AND search, but
                                 term ordering is maintained.
                             </p>
-                            <p>
-                                <SearchInputExample
-                                    showSearchContext={searchContextsEnabled && showSearchContext}
-                                    query="repo:sourcegraph const Authentication"
-                                    patternType={SearchPatternType.regexp}
-                                    runnable={isSourcegraphDotCom}
-                                    onRun={() =>
-                                        telemetryService.log('NoResultsSearchLiteral', { search: 'regexp search' })
-                                    }
-                                />
-                            </p>
+                            <SearchInputExample
+                                showSearchContext={searchContextsEnabled && showSearchContext}
+                                query="repo:sourcegraph const Authentication"
+                                patternType={SearchPatternType.regexp}
+                                runnable={isSourcegraphDotCom}
+                                onRun={() =>
+                                    telemetryService.log('NoResultsSearchLiteral', { search: 'regexp search' })
+                                }
+                            />
                         </Container>
                     )}
                     {!hiddenSectionIDs?.includes(SectionID.COMMON_PROBLEMS) && (
                         <Container sectionID={SectionID.COMMON_PROBLEMS} title="Common Problems" onClose={onClose}>
                             <h4>Finding a specific repository</h4>
                             <p>Repositories are specified by their org/repository-name convention:</p>
-                            <p>
-                                <SearchInputExample
-                                    showSearchContext={searchContextsEnabled && showSearchContext}
-                                    query="repo:sourcegraph/about lang:go publish"
-                                    runnable={isSourcegraphDotCom}
-                                    onRun={() =>
-                                        telemetryService.log('NoResultsCommonProblems', {
-                                            search: 'zfind specific repo',
-                                        })
-                                    }
-                                />
-                            </p>
+                            <SearchInputExample
+                                showSearchContext={searchContextsEnabled && showSearchContext}
+                                query="repo:sourcegraph/about lang:go publish"
+                                runnable={isSourcegraphDotCom}
+                                onRun={() =>
+                                    telemetryService.log('NoResultsCommonProblems', {
+                                        search: 'zfind specific repo',
+                                    })
+                                }
+                            />
                             <p>
                                 To search within all of an org’s repositories, specify only the org name and a trailing
                                 slash:
                             </p>
-                            <p>
-                                <SearchInputExample
-                                    showSearchContext={searchContextsEnabled && showSearchContext}
-                                    query="repo:sourcegraph/ lang:go publish"
-                                    runnable={isSourcegraphDotCom}
-                                    onRun={() =>
-                                        telemetryService.log('NoResultsCommonProblems', {
-                                            search: 'find specific repo',
-                                        })
-                                    }
-                                />
-                            </p>
+                            <SearchInputExample
+                                showSearchContext={searchContextsEnabled && showSearchContext}
+                                query="repo:sourcegraph/ lang:go publish"
+                                runnable={isSourcegraphDotCom}
+                                onRun={() =>
+                                    telemetryService.log('NoResultsCommonProblems', {
+                                        search: 'find specific repo',
+                                    })
+                                }
+                            />
                             <p>
                                 <small>
                                     <Link
@@ -321,30 +315,24 @@ export const NoResultsPage: React.FunctionComponent<NoResultsPageProps> = ({
 
                             <h4>AND, OR, NOT</h4>
                             <p>Conditionals and grouping are possible within queries:</p>
-                            <p>
-                                <SearchInputExample
-                                    showSearchContext={searchContextsEnabled && showSearchContext}
-                                    query="repo:sourcegraph/ (lang:typescript OR lang:go) auth"
-                                    runnable={isSourcegraphDotCom}
-                                    onRun={() => telemetryService.log('NoResultsCommonProblems', { search: 'and or' })}
-                                />
-                            </p>
+                            <SearchInputExample
+                                showSearchContext={searchContextsEnabled && showSearchContext}
+                                query="repo:sourcegraph/ (lang:typescript OR lang:go) auth"
+                                runnable={isSourcegraphDotCom}
+                                onRun={() => telemetryService.log('NoResultsCommonProblems', { search: 'and or' })}
+                            />
 
                             <h4>Escaping</h4>
                             <p>
                                 Because our default mode is literal, escaping requires a dedicated filter. Use the
                                 content filter to include spaces and filter keywords in searches.
                             </p>
-                            <p>
-                                <SearchInputExample
-                                    showSearchContext={searchContextsEnabled && showSearchContext}
-                                    query={'content:"class Vector"'}
-                                    runnable={isSourcegraphDotCom}
-                                    onRun={() =>
-                                        telemetryService.log('NoResultsCommonProblems', { search: 'escaping' })
-                                    }
-                                />
-                            </p>
+                            <SearchInputExample
+                                showSearchContext={searchContextsEnabled && showSearchContext}
+                                query={'content:"class Vector"'}
+                                runnable={isSourcegraphDotCom}
+                                onRun={() => telemetryService.log('NoResultsCommonProblems', { search: 'escaping' })}
+                            />
                         </Container>
                     )}
 

--- a/client/web/src/search/results/StreamingSearchResults.module.scss
+++ b/client/web/src/search/results/StreamingSearchResults.module.scss
@@ -63,4 +63,9 @@
             font-size: 0.875rem;
         }
     }
+
+    &__content-centered {
+        max-width: 65rem;
+        margin: auto;
+    }
 }

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -274,7 +274,9 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
                 )}
 
                 {results?.alert && (
-                    <SearchAlert alert={results.alert} caseSensitive={caseSensitive} patternType={patternType} />
+                    <div className={classNames(styles.streamingSearchResultsContentCentered, 'mt-4')}>
+                        <SearchAlert alert={results.alert} caseSensitive={caseSensitive} patternType={patternType} />
+                    </div>
                 )}
 
                 {showSignUpCta && (

--- a/client/web/src/search/results/StreamingSearchResultsFooter.module.scss
+++ b/client/web/src/search/results/StreamingSearchResultsFooter.module.scss
@@ -1,4 +1,0 @@
-.footer {
-    max-width: 65rem;
-    margin: auto;
-}

--- a/client/web/src/search/results/StreamingSearchResultsFooter.tsx
+++ b/client/web/src/search/results/StreamingSearchResultsFooter.tsx
@@ -7,13 +7,13 @@ import { AggregateStreamingSearchResults } from '@sourcegraph/shared/src/search/
 import { ErrorAlert } from '../../components/alerts'
 
 import { StreamingProgressCount } from './progress/StreamingProgressCount'
-import styles from './StreamingSearchResultsFooter.module.scss'
+import styles from './StreamingSearchResults.module.scss'
 
 export const StreamingSearchResultFooter: React.FunctionComponent<{
     results?: AggregateStreamingSearchResults
     children?: React.ReactChild | React.ReactChild[]
 }> = ({ results, children }) => (
-    <div className={classNames(styles.footer, 'd-flex flex-column align-items-center')}>
+    <div className={classNames(styles.streamingSearchResultsContentCentered, 'd-flex flex-column align-items-center')}>
         {(!results || results?.state === 'loading') && (
             <div className="text-center my-4" data-testid="loading-container">
                 <LoadingSpinner className="icon-inline" />


### PR DESCRIPTION
Addressing comments [here](https://www.figma.com/file/E8fcpTxwiqVf1fLxNR6jQJ/No-results%3A-Improving-search-messages?node-id=295%3A9086):

- Add max width to other alert render location.
- Adjust margins between alerts and no results information.
- Remove `<p>` warpper around search examples to avoid invalid DOM nesting
  warning (and adjust margins accordingly).