### PR TITLE
[CLOUD-124] Add more test cases for different authentication states

### DIFF
--- a/cmd/frontend/graphqlbackend/settings_mutation_test.go
+++ b/cmd/frontend/graphqlbackend/settings_mutation_test.go
@@ -116,22 +116,59 @@ func TestSettingsMutation(t *testing.T) {
 	db := dbmock.NewMockDB()
 	t.Run("only allowed by authenticated user on Sourcegraph.com", func(t *testing.T) {
 		users := dbmock.NewMockUserStore()
-		users.GetByIDFunc.SetDefaultReturn(&types.User{ID: 1}, nil)
 		db.UsersFunc.SetDefaultReturn(users)
 
 		orig := envvar.SourcegraphDotComMode()
 		envvar.MockSourcegraphDotComMode(true)
 		defer envvar.MockSourcegraphDotComMode(orig) // reset
 
-		_, err := newSchemaResolver(db).SettingsMutation(context.Background(),
-			&settingsMutationArgs{
-				Input: &settingsMutationGroupInput{
-					Subject: MarshalUserID(1),
+		tests := []struct {
+			name  string
+			ctx   context.Context
+			setup func()
+		}{
+			{
+				name: "unauthenticated",
+				ctx:  context.Background(),
+				setup: func() {
+					users.GetByIDFunc.SetDefaultReturn(&types.User{ID: 1}, nil)
 				},
 			},
-		)
-		got := fmt.Sprintf("%v", err)
-		want := "must be authenticated as user with id 1"
-		assert.Equal(t, want, got)
+			{
+				name: "another user",
+				ctx:  actor.WithActor(context.Background(), &actor.Actor{UID: 2}),
+				setup: func() {
+					users.GetByIDFunc.SetDefaultHook(func(ctx context.Context, id int32) (*types.User, error) {
+						return &types.User{ID: id}, nil
+					})
+				},
+			},
+			{
+				name: "site admin",
+				ctx:  actor.WithActor(context.Background(), &actor.Actor{UID: 2}),
+				setup: func() {
+					users.GetByIDFunc.SetDefaultHook(func(ctx context.Context, id int32) (*types.User, error) {
+						return &types.User{ID: id, SiteAdmin: true}, nil
+					})
+				},
+			},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				test.setup()
+
+				_, err := newSchemaResolver(db).SettingsMutation(
+					test.ctx,
+					&settingsMutationArgs{
+						Input: &settingsMutationGroupInput{
+							Subject: MarshalUserID(1),
+						},
+					},
+				)
+				got := fmt.Sprintf("%v", err)
+				want := "must be authenticated as user with id 1"
+				assert.Equal(t, want, got)
+			})
+		}
 	})
 }


### PR DESCRIPTION
This is a followup of #27188 and #27063 to add more test cases to cover different authentication states.

---

Part of CLOUD-124