### PR TITLE
migrations/frontend: Drop unused column repo_permissions.user_ids

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1771,7 +1771,6 @@ Indexes:
 ---------------+--------------------------+-----------+----------+-----------------
  repo_id       | integer                  |           | not null | 
  permission    | text                     |           | not null | 
- user_ids      | bytea                    |           | not null | '\x'::bytea
  updated_at    | timestamp with time zone |           | not null | 
  synced_at     | timestamp with time zone |           |          | 
  user_ids_ints | integer[]                |           | not null | '{}'::integer[]

--- a/migrations/frontend/1528395931_drop_unused_column_user_ids_from_repo_permissions_table.down.sql
+++ b/migrations/frontend/1528395931_drop_unused_column_user_ids_from_repo_permissions_table.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE IF EXISTS repo_permissions ADD COLUMN user_ids bytea NOT NULL default '\x';
+
+COMMIT;

--- a/migrations/frontend/1528395931_drop_unused_column_user_ids_from_repo_permissions_table.up.sql
+++ b/migrations/frontend/1528395931_drop_unused_column_user_ids_from_repo_permissions_table.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE IF EXISTS repo_permissions DROP COLUMN IF EXISTS user_ids;
+
+COMMIT;


### PR DESCRIPTION

![drop_user_ids_from_repo_permissions_table](https://user-images.githubusercontent.com/2682729/140746707-47058eb5-9cf8-49b2-a559-ed2f9a3349ad.gif)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
