### PR TITLE
graphqlbackend: Perform sub-repo filtering on tree and content fetches

### DIFF
--- a/cmd/frontend/graphqlbackend/authz.go
+++ b/cmd/frontend/graphqlbackend/authz.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 type AuthzResolver interface {
@@ -59,20 +60,17 @@ type PermissionsInfoResolver interface {
 	UpdatedAt() DateTime
 }
 
-// TODO: Remove usage of nolint
-
 var (
 	// subRepoPermsInstance should be initialized and used only via SubRepoPerms().
-	//nolint:unused
 	subRepoPermsInstance authz.SubRepoPermissionChecker
-	//nolint:unused
-	subRepoPermsOnce sync.Once
+	subRepoPermsOnce     sync.Once
 )
 
 // subRepoPermsClient returns a global instance of the SubRepoPermissionsChecker for use in
 // graphqlbackend only.
-//nolint:unused
-func subRepoPermsClient(db database.DB) authz.SubRepoPermissionChecker {
+//
+// Exposed as a variable so that it can be changed in tests
+var subRepoPermsClient = func(db dbutil.DB) authz.SubRepoPermissionChecker {
 	subRepoPermsOnce.Do(func() {
 		subRepoPermsInstance = authz.NewSubRepoPermsClient(database.SubRepoPerms(db))
 	})

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -2,6 +2,7 @@ package graphqlbackend
 
 import (
 	"context"
+	"io/fs"
 	"net/url"
 	"os"
 	"sync"
@@ -9,12 +10,15 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/externallink"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
@@ -201,8 +205,11 @@ func (r *GitCommitResolver) Tree(ctx context.Context, args *struct {
 	defer span.Finish()
 	span.SetTag("path", args.Path)
 
-	stat, err := git.Stat(ctx, r.gitRepo, api.CommitID(r.oid), args.Path)
+	stat, err := gitStat(ctx, r.db, r.gitRepo, api.CommitID(r.oid), args.Path)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	if !stat.Mode().IsDir() {
@@ -219,7 +226,7 @@ func (r *GitCommitResolver) Tree(ctx context.Context, args *struct {
 func (r *GitCommitResolver) Blob(ctx context.Context, args *struct {
 	Path string
 }) (*GitTreeEntryResolver, error) {
-	stat, err := git.Stat(ctx, r.gitRepo, api.CommitID(r.oid), args.Path)
+	stat, err := gitStat(ctx, r.db, r.gitRepo, api.CommitID(r.oid), args.Path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -353,4 +360,20 @@ func (r *GitCommitResolver) canonicalRepoRevURL() *url.URL {
 	url := *r.repoResolver.RepoMatch.URL()
 	url.Path += "@" + string(r.oid)
 	return &url
+}
+
+func gitStat(ctx context.Context, db dbutil.DB, repo api.RepoName, commit api.CommitID, path string) (fs.FileInfo, error) {
+	perms, err := authz.CurrentUserPermissions(ctx, subRepoPermsClient(db), authz.RepoContent{
+		Repo: repo,
+		Path: path,
+	})
+	if err != nil {
+		log15.Error("checking sub-repo permissions in gitStat", "error", err)
+		return nil, errors.New("checking sub-repo permissions")
+	}
+	// No access
+	if !perms.Include(authz.Read) {
+		return nil, os.ErrNotExist
+	}
+	return git.Stat(ctx, repo, commit, path)
 }

--- a/cmd/frontend/graphqlbackend/git_tree.go
+++ b/cmd/frontend/graphqlbackend/git_tree.go
@@ -143,6 +143,9 @@ func gitReadDir(ctx context.Context, db dbutil.DB, repo api.RepoName, commit api
 	}
 
 	client := subRepoPermsClient(db)
+	if !client.Enabled() {
+		return entries, nil
+	}
 
 	// Filter in place
 	n := 0

--- a/cmd/frontend/graphqlbackend/git_tree.go
+++ b/cmd/frontend/graphqlbackend/git_tree.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+
 	"github.com/cockroachdb/errors"
 	"github.com/inconshreveable/log15"
 
@@ -149,9 +151,10 @@ func gitReadDir(ctx context.Context, db dbutil.DB, repo api.RepoName, commit api
 
 	// Filter in place
 	n := 0
+	a := actor.FromContext(ctx)
 	for _, entry := range entries {
 		// Check whether to filter out this entry due to sub-repo permissions
-		perms, err := authz.CurrentUserPermissions(ctx, client, authz.RepoContent{
+		perms, err := authz.ActorPermissions(ctx, client, a, authz.RepoContent{
 			Repo: repo,
 			Path: entry.Name(),
 		})

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cloneurls"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/highlight"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
@@ -75,6 +76,20 @@ func (r *GitTreeEntryResolver) Content(ctx context.Context) (string, error) {
 	r.contentOnce.Do(func() {
 		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
+
+		perms, err := authz.CurrentUserPermissions(ctx, subRepoPermsClient(r.db), authz.RepoContent{
+			Repo: r.commit.repoResolver.RepoName(),
+			Path: r.Path(),
+		})
+		if err != nil {
+			log15.Error("checking sub-repo permissions", "error", err)
+			r.content, r.contentErr = nil, errors.New("checking sub-repo permissions")
+		}
+		// No access
+		if !perms.Include(authz.Read) {
+			r.content, r.contentErr = nil, nil
+			return
+		}
 
 		r.content, r.contentErr = git.ReadFile(
 			ctx,
@@ -212,8 +227,9 @@ func (r *GitTreeEntryResolver) IsSingleChild(ctx context.Context, args *gitTreeE
 	if r.isSingleChild != nil {
 		return *r.isSingleChild, nil
 	}
-	entries, err := git.ReadDir(
+	entries, err := gitReadDir(
 		ctx,
+		r.db,
 		r.commit.repoResolver.RepoName(),
 		api.CommitID(r.commit.OID()),
 		path.Dir(r.Path()),

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -229,7 +229,7 @@ func (r *GitTreeEntryResolver) IsSingleChild(ctx context.Context, args *gitTreeE
 	}
 	entries, err := gitReadDir(
 		ctx,
-		r.db,
+		subRepoPermsClient(r.db),
 		r.commit.repoResolver.RepoName(),
 		api.CommitID(r.commit.OID()),
 		path.Dir(r.Path()),

--- a/cmd/frontend/graphqlbackend/git_tree_entry_test.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry_test.go
@@ -6,8 +6,11 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
@@ -65,4 +68,62 @@ func TestGitTreeEntry_Content(t *testing.T) {
 	if have, want := newByteSize, int32(len([]byte(wantContent))); have != want {
 		t.Fatalf("wrong file size, want=%d have=%d", want, have)
 	}
+}
+
+func TestGitTreeEntry_Content_Sub_Repo_Filtering(t *testing.T) {
+	wantPath := "foobar.md"
+	wantContent := ""
+
+	ctx := setupSubRepoDeny(context.Background(), t, []string{"foobar.md"})
+
+	git.Mocks.ReadFile = func(commit api.CommitID, name string) ([]byte, error) {
+		if name != wantPath {
+			t.Fatalf("wrong name in ReadFile call. want=%q, have=%q", wantPath, name)
+		}
+		return []byte("something"), nil
+	}
+	t.Cleanup(func() { git.Mocks.ReadFile = nil })
+
+	db := dbmock.NewMockDB()
+	gitTree := &GitTreeEntryResolver{
+		db: db,
+		commit: &GitCommitResolver{
+			repoResolver: NewRepositoryResolver(db, &types.Repo{Name: "my/repo"}),
+		},
+		stat: CreateFileInfo(wantPath, false),
+	}
+
+	newFileContent, err := gitTree.Content(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(newFileContent, wantContent); diff != "" {
+		t.Fatalf("wrong newFileContent: %s", diff)
+	}
+}
+
+func setupSubRepoDeny(ctx context.Context, t *testing.T, denyPaths []string) context.Context {
+	oldFn := subRepoPermsClient
+	t.Cleanup(func() { subRepoPermsClient = oldFn })
+
+	subRepoPermsClient = func(db dbutil.DB) authz.SubRepoPermissionChecker {
+		m := authz.NewMockSubRepoPermissionChecker()
+		m.PermissionsFunc.SetDefaultHook(func(ctx context.Context, i int32, content authz.RepoContent) (authz.Perms, error) {
+			for _, p := range denyPaths {
+				if p == content.Path {
+					return authz.None, nil
+				}
+			}
+			return authz.Read, nil
+		})
+		m.EnabledFunc.SetDefaultHook(func() bool {
+			return true
+		})
+		return m
+	}
+
+	return actor.WithActor(ctx, &actor.Actor{
+		UID: 1,
+	})
 }

--- a/cmd/frontend/graphqlbackend/git_tree_test.go
+++ b/cmd/frontend/graphqlbackend/git_tree_test.go
@@ -17,48 +17,7 @@ import (
 
 func TestGitTree(t *testing.T) {
 	db := database.NewDB(nil)
-	resetMocks()
-	database.Mocks.ExternalServices.List = func(opt database.ExternalServicesListOptions) ([]*types.ExternalService, error) {
-		return nil, nil
-	}
-	database.Mocks.Repos.MockGetByName(t, "github.com/gorilla/mux", 2)
-	backend.Mocks.Repos.ResolveRev = func(ctx context.Context, repo *types.Repo, rev string) (api.CommitID, error) {
-		if repo.ID != 2 || rev != exampleCommitSHA1 {
-			t.Error("wrong arguments to Repos.ResolveRev")
-		}
-		return exampleCommitSHA1, nil
-	}
-	backend.Mocks.Repos.MockGetCommit_Return_NoCheck(t, &gitapi.Commit{ID: exampleCommitSHA1})
-
-	git.Mocks.Stat = func(commit api.CommitID, path string) (fs.FileInfo, error) {
-		if string(commit) != exampleCommitSHA1 {
-			t.Errorf("got commit %q, want %q", commit, exampleCommitSHA1)
-		}
-		if want := "foo bar"; path != want {
-			t.Errorf("got path %q, want %q", path, want)
-		}
-		return &util.FileInfo{Name_: path, Mode_: os.ModeDir}, nil
-	}
-	git.Mocks.ReadDir = func(commit api.CommitID, name string, recurse bool) ([]fs.FileInfo, error) {
-		if string(commit) != exampleCommitSHA1 {
-			t.Errorf("got commit %q, want %q", commit, exampleCommitSHA1)
-		}
-		if want := "foo bar"; name != want {
-			t.Errorf("got name %q, want %q", name, want)
-		}
-		if recurse {
-			t.Error("got recurse == false, want true")
-		}
-		return []fs.FileInfo{
-			&util.FileInfo{Name_: name + "/testDirectory", Mode_: os.ModeDir},
-			&util.FileInfo{Name_: name + "/Geoffrey's random queries.32r242442bf", Mode_: os.ModeDir},
-			&util.FileInfo{Name_: name + "/testFile", Mode_: 0},
-			&util.FileInfo{Name_: name + "/% token.4288249258.sql", Mode_: 0},
-		}, nil
-	}
-	defer git.ResetMocks()
-
-	RunTests(t, []*Test{
+	tests := []*Test{
 		{
 			Schema: mustParseGraphQLSchema(t, db),
 			Query: `
@@ -116,5 +75,112 @@ func TestGitTree(t *testing.T) {
 }
 			`,
 		},
-	})
+	}
+	testGitTree(t, tests)
+}
+
+func TestGitTree_SubRepo_Deny(t *testing.T) {
+	ctx := setupSubRepoDeny(context.Background(), t, []string{"foo bar/testFile"})
+	db := database.NewDB(nil)
+	tests := []*Test{
+		{
+			Context: ctx,
+			Schema:  mustParseGraphQLSchema(t, db),
+			Query: `
+				{
+					repository(name: "github.com/gorilla/mux") {
+						commit(rev: "` + exampleCommitSHA1 + `") {
+							tree(path: "foo bar") {
+								directories {
+									name
+									path
+									url
+								}
+								files {
+									name
+									path
+									url
+								}
+							}
+						}
+					}
+				}
+			`,
+			ExpectedResult: `
+{
+  "repository": {
+    "commit": {
+      "tree": {
+        "directories": [
+          {
+            "name": "Geoffrey's random queries.32r242442bf",
+            "path": "foo bar/Geoffrey's random queries.32r242442bf",
+            "url": "/github.com/gorilla/mux@1234567890123456789012345678901234567890/-/tree/foo%20bar/Geoffrey%27s%20random%20queries.32r242442bf"
+          },
+          {
+            "name": "testDirectory",
+            "path": "foo bar/testDirectory",
+            "url": "/github.com/gorilla/mux@1234567890123456789012345678901234567890/-/tree/foo%20bar/testDirectory"
+          }
+        ],
+        "files": [
+          {
+            "name": "% token.4288249258.sql",
+            "path": "foo bar/% token.4288249258.sql",
+            "url": "/github.com/gorilla/mux@1234567890123456789012345678901234567890/-/blob/foo%20bar/%25%20token.4288249258.sql"
+          }
+        ]
+      }
+    }
+  }
+}
+			`,
+		},
+	}
+	testGitTree(t, tests)
+}
+
+func testGitTree(t *testing.T, tests []*Test) {
+	resetMocks()
+	database.Mocks.ExternalServices.List = func(opt database.ExternalServicesListOptions) ([]*types.ExternalService, error) {
+		return nil, nil
+	}
+	database.Mocks.Repos.MockGetByName(t, "github.com/gorilla/mux", 2)
+	backend.Mocks.Repos.ResolveRev = func(ctx context.Context, repo *types.Repo, rev string) (api.CommitID, error) {
+		if repo.ID != 2 || rev != exampleCommitSHA1 {
+			t.Error("wrong arguments to Repos.ResolveRev")
+		}
+		return exampleCommitSHA1, nil
+	}
+	backend.Mocks.Repos.MockGetCommit_Return_NoCheck(t, &gitapi.Commit{ID: exampleCommitSHA1})
+
+	git.Mocks.Stat = func(commit api.CommitID, path string) (fs.FileInfo, error) {
+		if string(commit) != exampleCommitSHA1 {
+			t.Errorf("got commit %q, want %q", commit, exampleCommitSHA1)
+		}
+		if want := "foo bar"; path != want {
+			t.Errorf("got path %q, want %q", path, want)
+		}
+		return &util.FileInfo{Name_: path, Mode_: os.ModeDir}, nil
+	}
+	git.Mocks.ReadDir = func(commit api.CommitID, name string, recurse bool) ([]fs.FileInfo, error) {
+		if string(commit) != exampleCommitSHA1 {
+			t.Errorf("got commit %q, want %q", commit, exampleCommitSHA1)
+		}
+		if want := "foo bar"; name != want {
+			t.Errorf("got name %q, want %q", name, want)
+		}
+		if recurse {
+			t.Error("got recurse == false, want true")
+		}
+		return []fs.FileInfo{
+			&util.FileInfo{Name_: name + "/testDirectory", Mode_: os.ModeDir},
+			&util.FileInfo{Name_: name + "/Geoffrey's random queries.32r242442bf", Mode_: os.ModeDir},
+			&util.FileInfo{Name_: name + "/testFile", Mode_: 0},
+			&util.FileInfo{Name_: name + "/% token.4288249258.sql", Mode_: 0},
+		}, nil
+	}
+	defer git.ResetMocks()
+
+	RunTests(t, tests)
 }

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -129,7 +129,7 @@ func (r *schemaResolver) Search(ctx context.Context, args *SearchArgs) (SearchIm
 	return NewSearchImplementer(ctx, r.db, args)
 }
 
-// detectSearchType returns the search type to perfrom ("regexp", or
+// detectSearchType returns the search type to perform ("regexp", or
 // "literal"). The search type derives from three sources: the version and
 // patternType parameters passed to the search endpoint (literal search is the
 // default in V2), and the `patternType:` filter in the input query string which

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations.go
@@ -244,7 +244,7 @@ func (r *CachedLocationResolver) resolvePath(ctx context.Context, commitResolver
 }
 
 // resolveLocations creates a slide of LocationResolvers for the given list of adjusted locations. The
-// resulting list may be smaller than the the input list as any locations with a commit not known by
+// resulting list may be smaller than the input list as any locations with a commit not known by
 // gitserver will be skipped.
 func resolveLocations(ctx context.Context, locationResolver *CachedLocationResolver, locations []resolvers.AdjustedLocation) ([]gql.LocationResolver, error) {
 	resolvedLocations := make([]gql.LocationResolver, 0, len(locations))

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
@@ -27,7 +27,7 @@ const (
 
 var errAutoIndexingNotEnabled = errors.New("precise code intelligence auto indexing is not enabled")
 
-// Resolver is the main interface to code intel-related operations exposted to the GraphQL API. This
+// Resolver is the main interface to code intel-related operations exposed to the GraphQL API. This
 // resolver concerns itself with GraphQL/API-specific behaviors (auth, validation, marshaling, etc.).
 // All code intel-specific behavior is delegated to the underlying resolver instance, which is defined
 // in the parent package.

--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -74,12 +74,18 @@ func (s *subRepoPermsClient) Permissions(ctx context.Context, userID int32, cont
 		return Read, nil
 	}
 
+	if s.permissionsGetter == nil {
+		return None, errors.New("PermissionsGetter is nil")
+	}
+
 	if userID == 0 {
 		return None, &ErrUnauthenticated{}
 	}
 
-	if s.permissionsGetter == nil {
-		return None, errors.New("PermissionsGetter is nil")
+	// An empty path is equivalent to repo permissions so we can assume it has
+	// already been checked at that level.
+	if content.Path == "" {
+		return Read, nil
 	}
 
 	if supported, err := s.permissionsGetter.RepoSupported(ctx, content.Repo); err != nil {

--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -177,5 +177,9 @@ func ActorPermissions(ctx context.Context, s SubRepoPermissionChecker, a *actor.
 		return None, &ErrUnauthenticated{}
 	}
 
-	return s.Permissions(ctx, a.UID, content)
+	perms, err := s.Permissions(ctx, a.UID, content)
+	if err != nil {
+		return None, errors.Wrapf(err, "getting actor permissions for actor", a.UID)
+	}
+	return perms, nil
 }


### PR DESCRIPTION
This change adds sub-repo filtering when fetching file content and browsing git repo
trees.

Closes https://github.com/sourcegraph/sourcegraph/issues/27138