### PR TITLE
[cloud][CLOUD-73] Disallow site-admin access to organizations on Cloud

### DIFF
--- a/client/web/src/site-admin/SiteAdminOrgsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminOrgsPage.tsx
@@ -127,20 +127,26 @@ export const SiteAdminOrgsPage: React.FunctionComponent<Props> = ({ telemetrySer
                 <Link to="/help/admin/organizations">Sourcegraph documentation</Link> for information about configuring
                 organizations.
             </p>
-            <FilteredConnection<OrganizationFields, Omit<OrgNodeProps, 'node'>>
-                className="list-group list-group-flush mt-3"
-                noun="organization"
-                pluralNoun="organizations"
-                queryConnection={fetchAllOrganizations}
-                nodeComponent={OrgNode}
-                nodeComponentProps={{
-                    onDidUpdate: onDidUpdateOrg,
-                    history,
-                }}
-                updates={orgUpdates}
-                history={history}
-                location={location}
-            />
+            {window.context.sourcegraphDotComMode ? (
+                <div className="alert alert-info">
+                    Only organization members can view & modify organization settings.
+                </div>
+            ) : (
+                <FilteredConnection<OrganizationFields, Omit<OrgNodeProps, 'node'>>
+                    className="list-group list-group-flush mt-3"
+                    noun="organization"
+                    pluralNoun="organizations"
+                    queryConnection={fetchAllOrganizations}
+                    nodeComponent={OrgNode}
+                    nodeComponentProps={{
+                        onDidUpdate: onDidUpdateOrg,
+                        history,
+                    }}
+                    updates={orgUpdates}
+                    history={history}
+                    location={location}
+                />
+            )}
         </div>
     )
 }

--- a/cmd/frontend/backend/orgs.go
+++ b/cmd/frontend/backend/orgs.go
@@ -3,12 +3,9 @@ package backend
 import (
 	"context"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
-
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
-
 	"github.com/cockroachdb/errors"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
@@ -16,23 +13,17 @@ import (
 
 var ErrNotAuthenticated = errors.New("not authenticated")
 
-// CheckOrgAccessOrSiteAdminCloud returns an error if:
-// (1) if we are on cloud instance and the user is not a member of the organization
-// (2) if we are on prem instance and
+// CheckOrgAccessOrSiteAdmin returns an error if:
+// (1) if we are on Cloud instance and the user is not a member of the organization
+// (2) if we are NOT on Cloud and
 //    (a) the user is not a member of the organization
 //    (b) the user is not a site admin
-func CheckOrgAccessOrSiteAdminCloud(ctx context.Context, db dbutil.DB, orgID int32) error {
-	allowAdmin := !envvar.SourcegraphDotComMode()
-	return checkOrgAccess(ctx, database.NewDB(db), orgID, allowAdmin)
-}
-
-// CheckOrgAccessOrSiteAdmin returns an error if the user is NEITHER (1) a site
-// admin NOR (2) a member of the organization with the specified ID.
 //
-// It is used when an action on an org can be performed by site admins and the
-// organization's members, but nobody else.
+// It is used when an action on an org can only be performed by the
+// organization's members, (or site-admins - not on Cloud).
 func CheckOrgAccessOrSiteAdmin(ctx context.Context, db database.DB, orgID int32) error {
-	return checkOrgAccess(ctx, db, orgID, true)
+	allowAdmin := !envvar.SourcegraphDotComMode()
+	return checkOrgAccess(ctx, db, orgID, allowAdmin)
 }
 
 // CheckOrgAccess returns an error if the user is not a member of the

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -29,7 +29,7 @@ func (r *schemaResolver) Organization(ctx context.Context, args struct{ Name str
 	if envvar.SourcegraphDotComMode() {
 		err := backend.CheckOrgAccess(ctx, r.db, org.ID)
 		if err != nil {
-			return nil, err
+			return nil, errors.Newf("org not found: %s", args.Name)
 		}
 	}
 	return &OrgResolver{db: r.db, org: org}, nil
@@ -60,7 +60,7 @@ func OrgByIDInt32(ctx context.Context, db database.DB, orgID int32) (*OrgResolve
 	if envvar.SourcegraphDotComMode() {
 		err := backend.CheckOrgAccess(ctx, db, org.ID)
 		if err != nil {
-			return nil, err
+			return nil, errors.Newf("org not found: %d", orgID)
 		}
 	}
 	return &OrgResolver{db, org}, nil

--- a/cmd/frontend/graphqlbackend/org_test.go
+++ b/cmd/frontend/graphqlbackend/org_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"testing"
 
+	gqlerrors "github.com/graph-gophers/graphql-go/errors"
 	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
@@ -16,28 +18,101 @@ import (
 func TestOrganization(t *testing.T) {
 	db := database.NewDB(nil)
 	resetMocks()
+	envvar.MockSourcegraphDotComMode(false)
 	database.Mocks.Orgs.GetByName = func(context.Context, string) (*types.Org, error) {
 		return &types.Org{ID: 1, Name: "acme"}, nil
 	}
 
-	RunTests(t, []*Test{
-		{
-			Schema: mustParseGraphQLSchema(t, db),
-			Query: `
+	t.Cleanup(func() {
+		resetMocks()
+		envvar.MockSourcegraphDotComMode(false)
+	})
+
+	t.Run("Default behavior", func(t *testing.T) {
+		RunTests(t, []*Test{
+			{
+				Schema: mustParseGraphQLSchema(t, db),
+				Query: `
 				{
 					organization(name: "acme") {
 						name
 					}
 				}
 			`,
-			ExpectedResult: `
+				ExpectedResult: `
 				{
 					"organization": {
 						"name": "acme"
 					}
 				}
 			`,
-		},
+			},
+		})
+	})
+
+	t.Run("Fails on Cloud if user is not org member", func(t *testing.T) {
+		envvar.MockSourcegraphDotComMode(true)
+		RunTests(t, []*Test{
+			{
+				Schema: mustParseGraphQLSchema(t, db),
+				Query: `
+				{
+					organization(name: "acme") {
+						name
+					}
+				}
+			`,
+				ExpectedResult: `
+				{
+					"organization": null
+				}
+				`,
+				ExpectedErrors: []*gqlerrors.QueryError{
+					{
+						Message: "org not found: acme",
+						Path:    []interface{}{string("organization")},
+					},
+				},
+			},
+		})
+	})
+
+	t.Run("Succeeds on Cloud if user is org member", func(t *testing.T) {
+		envvar.MockSourcegraphDotComMode(true)
+		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
+
+		database.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
+			return &types.User{
+				ID:        1,
+				SiteAdmin: false,
+			}, nil
+		}
+		database.Mocks.OrgMembers.GetByOrgIDAndUserID = func(context.Context, int32, int32) (*types.OrgMembership, error) {
+			return &types.OrgMembership{
+				OrgID:  1,
+				UserID: 1,
+			}, nil
+		}
+		RunTests(t, []*Test{
+			{
+				Schema:  mustParseGraphQLSchema(t, db),
+				Context: ctx,
+				Query: `
+				{
+					organization(name: "acme") {
+						name
+					}
+				}
+			`,
+				ExpectedResult: `
+				{
+					"organization": {
+						"name": "acme"
+					}
+				}
+				`,
+			},
+		})
 	})
 }
 

--- a/cmd/frontend/graphqlbackend/orgs.go
+++ b/cmd/frontend/graphqlbackend/orgs.go
@@ -55,6 +55,7 @@ func (r *orgConnectionResolver) Nodes(ctx context.Context) ([]*OrgResolver, erro
 }
 
 func (r *orgConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
+	// 🚨 SECURITY: Not allowed on Cloud.
 	if envvar.SourcegraphDotComMode() {
 		return 0, errors.New("counting organizations is not allowed")
 	}

--- a/cmd/frontend/graphqlbackend/orgs.go
+++ b/cmd/frontend/graphqlbackend/orgs.go
@@ -3,7 +3,10 @@ package graphqlbackend
 import (
 	"context"
 
+	"github.com/cockroachdb/errors"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 )
@@ -26,6 +29,11 @@ type orgConnectionResolver struct {
 }
 
 func (r *orgConnectionResolver) Nodes(ctx context.Context) ([]*OrgResolver, error) {
+	// 🚨 SECURITY: Not allowed on Cloud.
+	if envvar.SourcegraphDotComMode() {
+		return nil, errors.New("listing organizations is not allowed")
+	}
+
 	// 🚨 SECURITY: Only site admins can list organisations.
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err

--- a/cmd/frontend/graphqlbackend/orgs.go
+++ b/cmd/frontend/graphqlbackend/orgs.go
@@ -55,6 +55,9 @@ func (r *orgConnectionResolver) Nodes(ctx context.Context) ([]*OrgResolver, erro
 }
 
 func (r *orgConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
+	if envvar.SourcegraphDotComMode() {
+		return 0, errors.New("counting organizations is not allowed")
+	}
 	// 🚨 SECURITY: Only site admins can count organisations.
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return 0, err


### PR DESCRIPTION
# Description
Disallow site-admin to access organizations on Cloud. Only members of the organization will have read-write access to organization settings, to view the organization fields (including name) and to view it's members.

# Related items
https://sourcegraph.atlassian.net/browse/CLOUD-73

# Screenshots

<img width="836" alt="Screenshot 2021-11-09 at 21 55 32" src="https://user-images.githubusercontent.com/9974711/141003213-2a76c8b2-feb6-4334-b782-15ca7bef40d5.png">

<img width="1141" alt="Screenshot 2021-11-08 at 16 09 29" src="https://user-images.githubusercontent.com/9974711/140770435-8505fb53-1f44-4489-bc10-62341cbb1da5.png">


# Testing locally

## New behavior on Cloud

1. Run sg locally in dotcom mode: `EXTSVC_CONFIG_ALLOW_EDITS=true sg start dotcom`
2. Login as a site-admin
3. Create an organization
4. Logout and log in as a different site-admin (not a member of the organization)
5. Go to https://sourcegraph.test:3443/site-admin/organizations and verify that you cannot see the list of organizations
6. Try to access organization settings by going to https://sourcegraph.test:3443/organizations/PUT_ORG_NAME_HERE/settings and verify that you are shown an error

## Old behavior applied when not on cloud

1. Run sg locally in enterprise mode: `EXTSVC_CONFIG_ALLOW_EDITS=true sg start enterprise`
2. Login as a site-admin
3. Go to https://sourcegraph.test:3443/site-admin/organizations and verify that you can see the list of all orgs defined on the instance
4. Try to access any organization settings that the site-admin is not a member off - this should work
5. Try to modify any organization settings that the site-admin is not a member off - this should work
6. Try to add a member to the organization directly, without creating an invite - this should work