### PR TITLE
Extract and persist batch spec execution cache entries

### DIFF
--- a/enterprise/internal/batches/background/batch_spec_workspace_execution_worker.go
+++ b/enterprise/internal/batches/background/batch_spec_workspace_execution_worker.go
@@ -165,11 +165,35 @@ func (s *batchSpecWorkspaceExecutionWorkerStore) MarkComplete(ctx context.Contex
 		return false, err
 	}
 
-	job, changesetSpecIDs, err := loadAndExtractChangesetSpecIDs(ctx, tx, int64(id))
+	job, err := tx.GetBatchSpecWorkspaceExecutionJob(ctx, store.GetBatchSpecWorkspaceExecutionJobOpts{ID: int64(id)})
+	if err != nil {
+		return false, errors.Wrap(err, "loading batch spec workspace execution job")
+	}
+
+	events, err := logEventsFromLogEntries(job.ExecutionLogs)
+	if err != nil {
+		return false, err
+	}
+
+	changesetSpecIDs, err := extractChangesetSpecIDs(ctx, tx, events)
 	if err != nil {
 		// Rollback transaction but ignore rollback errors
 		tx.Done(err)
-		return s.Store.MarkFailed(ctx, id, fmt.Sprintf("failed to extract changeset IDs ID: %s", err), options)
+		return s.Store.MarkFailed(ctx, id, fmt.Sprintf("failed to extract changeset IDs: %s", err), options)
+	}
+
+	cacheEntries, err := extractCacheEntries(ctx, events)
+	if err != nil {
+		// Rollback transaction but ignore rollback errors
+		tx.Done(err)
+		return s.Store.MarkFailed(ctx, id, fmt.Sprintf("failed to extract cache entries: %s", err), options)
+	}
+
+	for _, entry := range cacheEntries {
+		if err := tx.CreateBatchSpecExecutionCacheEntry(ctx, entry); err != nil {
+			tx.Done(err)
+			return s.Store.MarkFailed(ctx, id, fmt.Sprintf("failed to save cache entry: %s", err), options)
+		}
 	}
 
 	err = deleteAccessToken(ctx, tx, job.AccessTokenID)
@@ -237,30 +261,54 @@ func setChangesetSpecIDs(ctx context.Context, tx *store.Store, batchSpecWorkspac
 	return tx.Exec(ctx, sqlf.Sprintf(setChangesetSpecIDsOnBatchSpecWorkspaceQueryFmtstr, marshaledIDs, batchSpecWorkspaceID))
 }
 
-func loadAndExtractChangesetSpecIDs(ctx context.Context, s *store.Store, id int64) (*btypes.BatchSpecWorkspaceExecutionJob, []int64, error) {
-	job, err := s.GetBatchSpecWorkspaceExecutionJob(ctx, store.GetBatchSpecWorkspaceExecutionJobOpts{ID: id})
-	if err != nil {
-		return job, []int64{}, err
+func extractCacheEntries(ctx context.Context, events []*batcheslib.LogEvent) ([]*btypes.BatchSpecExecutionCacheEntry, error) {
+	var entries []*btypes.BatchSpecExecutionCacheEntry
+
+	for _, e := range events {
+		switch m := e.Metadata.(type) {
+		case *batcheslib.CacheResultMetadata:
+			// TODO: This is stupid, because we unmarshal and then marshal again.
+			value, err := json.Marshal(&m.Value)
+			if err != nil {
+				return nil, err
+			}
+
+			entries = append(entries, &btypes.BatchSpecExecutionCacheEntry{
+				Key:   m.Key,
+				Value: string(value),
+			})
+		case *batcheslib.CacheAfterStepResultMetadata:
+			// TODO: This is stupid, because we unmarshal and then marshal again.
+			value, err := json.Marshal(&m.Value)
+			if err != nil {
+				return nil, err
+			}
+
+			entries = append(entries, &btypes.BatchSpecExecutionCacheEntry{
+				Key:   m.Key,
+				Value: string(value),
+			})
+		}
 	}
 
-	if len(job.ExecutionLogs) < 1 {
-		return job, []int64{}, errors.Newf("job %d has no execution logs", job.ID)
-	}
+	return entries, nil
+}
 
-	randIDs, err := extractChangesetSpecRandIDs(job.ExecutionLogs)
+func extractChangesetSpecIDs(ctx context.Context, s *store.Store, events []*batcheslib.LogEvent) ([]int64, error) {
+	randIDs, err := extractChangesetSpecRandIDs(events)
 	if err != nil {
-		return job, []int64{}, err
+		return []int64{}, err
 	}
 
 	// No ids, take a short path here. Otherwise, we would retrieve _ALL_ changeset
 	// specs from ListChangesetSpecs below.
 	if len(randIDs) == 0 {
-		return job, []int64{}, nil
+		return []int64{}, nil
 	}
 
 	specs, _, err := s.ListChangesetSpecs(ctx, store.ListChangesetSpecsOpts{RandIDs: randIDs})
 	if err != nil {
-		return job, []int64{}, err
+		return []int64{}, err
 	}
 
 	var ids []int64
@@ -268,12 +316,17 @@ func loadAndExtractChangesetSpecIDs(ctx context.Context, s *store.Store, id int6
 		ids = append(ids, spec.ID)
 	}
 
-	return job, ids, nil
+	return ids, nil
 }
 
 var ErrNoChangesetSpecIDs = errors.New("no changeset ids found in execution logs")
+var ErrNoSrcCLILogEntry = errors.New("no src-cli log entry found in execution logs")
 
-func extractChangesetSpecRandIDs(logs []workerutil.ExecutionLogEntry) ([]string, error) {
+func logEventsFromLogEntries(logs []workerutil.ExecutionLogEntry) ([]*batcheslib.LogEvent, error) {
+	if len(logs) < 1 {
+		return nil, errors.Newf("job has no execution logs")
+	}
+
 	var (
 		entry workerutil.ExecutionLogEntry
 		found bool
@@ -287,15 +340,18 @@ func extractChangesetSpecRandIDs(logs []workerutil.ExecutionLogEntry) ([]string,
 		}
 	}
 	if !found {
-		return nil, ErrNoChangesetSpecIDs
+		return nil, ErrNoSrcCLILogEntry
 	}
 
-	logLines := btypes.ParseJSONLogsFromOutput(entry.Out)
-	for _, l := range logLines {
-		if l.Status != batcheslib.LogEventStatusSuccess {
+	return btypes.ParseJSONLogsFromOutput(entry.Out), nil
+}
+
+func extractChangesetSpecRandIDs(events []*batcheslib.LogEvent) ([]string, error) {
+	for _, e := range events {
+		if e.Status != batcheslib.LogEventStatusSuccess {
 			continue
 		}
-		if m, ok := l.Metadata.(*batcheslib.UploadingChangesetSpecsMetadata); ok {
+		if m, ok := e.Metadata.(*batcheslib.UploadingChangesetSpecsMetadata); ok {
 			rawIDs := m.IDs
 			if len(rawIDs) == 0 {
 				// No changesets were the result of this execution. That's fine!

--- a/enterprise/internal/batches/background/batch_spec_workspace_execution_worker_test.go
+++ b/enterprise/internal/batches/background/batch_spec_workspace_execution_worker_test.go
@@ -2,6 +2,7 @@ package background
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -20,6 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
+	"github.com/sourcegraph/sourcegraph/lib/batches/execution"
 )
 
 func TestBatchSpecWorkspaceExecutionWorkerStore_MarkComplete(t *testing.T) {
@@ -63,13 +65,32 @@ func TestBatchSpecWorkspaceExecutionWorkerStore_MarkComplete(t *testing.T) {
 		changesetSpecGraphQLIDs = append(changesetSpecGraphQLIDs, fmt.Sprintf("%q", relay.MarshalID("doesnotmatter", spec.RandID)))
 	}
 
-	// Add a log entry that contains the changeset spec IDs
+	// See the `output` var below
+	cacheEntryKeys := []string{
+		"Nsw12JxoLSHN4ta6D3G7FQ",
+		"JkC7Q0OOCZZ3Acv79QfwSA-step-0",
+		"0ydsSXJ77syIPdwNrsGlzQ-step-1",
+		"utgLpuQ3njDtLe3eztArAQ-step-2",
+		"RoG8xSgpganc5BJ0_D3XGA-step-3",
+		"Nsw12JxoLSHN4ta6D3G7FQ-step-4",
+	}
+
+	// Log entries with cache entries and a log entry that contains the changeset spec IDs
 	jsonArray := `[` + strings.Join(changesetSpecGraphQLIDs, ",") + `]`
+	output := `
+stdout: {"operation":"CACHE_RESULT","timestamp":"2021-11-04T12:43:19.551Z","status":"SUCCESS","metadata":{"key":"Nsw12JxoLSHN4ta6D3G7FQ","value":{"diff":"diff --git README.md README.md\nindex 1914491..d6782d3 100644\n--- README.md\n+++ README.md\n@@ -3,4 +3,7 @@ This repository is used to test opening and closing pull request with Automation\n \n (c) Copyright Sourcegraph 2013-2020.\n (c) Copyright Sourcegraph 2013-2020.\n-(c) Copyright Sourcegraph 2013-2020.\n\\ No newline at end of file\n+(c) Copyright Sourcegraph 2013-2020.this is step 2\n+this is step 3\n+this is step 4\n+previous_step.modified_files=[README.md]\ndiff --git README.txt README.txt\nnew file mode 100644\nindex 0000000..888e1ec\n--- /dev/null\n+++ README.txt\n@@ -0,0 +1 @@\n+this is step 1\ndiff --git my-output.txt my-output.txt\nnew file mode 100644\nindex 0000000..257ae8e\n--- /dev/null\n+++ my-output.txt\n@@ -0,0 +1 @@\n+this is step 5\n","changedFiles":{"modified":["README.md"],"added":["README.txt","my-output.txt"],"deleted":null,"renamed":null},"outputs":{"myOutput":"my-output.txt"},"Path":""}}}
+stdout: {"operation":"CACHE_AFTER_STEP_RESULT","timestamp":"2021-11-04T12:43:19.551Z","status":"SUCCESS","metadata":{"key":"JkC7Q0OOCZZ3Acv79QfwSA-step-0","value":{"stepIndex":0,"diff":"ZGlmZiAtLWdpdCBSRUFETUUudHh0IFJFQURNRS50eHQKbmV3IGZpbGUgbW9kZSAxMDA2NDQKaW5kZXggMDAwMDAwMC4uODg4ZTFlYwotLS0gL2Rldi9udWxsCisrKyBSRUFETUUudHh0CkBAIC0wLDAgKzEgQEAKK3RoaXMgaXMgc3RlcCAxCg==","outputs":{},"previousStepResult":{"Files":null,"Stdout":null,"Stderr":null}}}}
+stdout: {"operation":"CACHE_AFTER_STEP_RESULT","timestamp":"2021-11-04T12:43:19.551Z","status":"SUCCESS","metadata":{"key":"0ydsSXJ77syIPdwNrsGlzQ-step-1","value":{"stepIndex":1,"diff":"ZGlmZiAtLWdpdCBSRUFETUUubWQgUkVBRE1FLm1kCmluZGV4IDE5MTQ0OTEuLjVjMmI3MmQgMTAwNjQ0Ci0tLSBSRUFETUUubWQKKysrIFJFQURNRS5tZApAQCAtMyw0ICszLDQgQEAgVGhpcyByZXBvc2l0b3J5IGlzIHVzZWQgdG8gdGVzdCBvcGVuaW5nIGFuZCBjbG9zaW5nIHB1bGwgcmVxdWVzdCB3aXRoIEF1dG9tYXRpb24KIAogKGMpIENvcHlyaWdodCBTb3VyY2VncmFwaCAyMDEzLTIwMjAuCiAoYykgQ29weXJpZ2h0IFNvdXJjZWdyYXBoIDIwMTMtMjAyMC4KLShjKSBDb3B5cmlnaHQgU291cmNlZ3JhcGggMjAxMy0yMDIwLgpcIE5vIG5ld2xpbmUgYXQgZW5kIG9mIGZpbGUKKyhjKSBDb3B5cmlnaHQgU291cmNlZ3JhcGggMjAxMy0yMDIwLnRoaXMgaXMgc3RlcCAyCmRpZmYgLS1naXQgUkVBRE1FLnR4dCBSRUFETUUudHh0Cm5ldyBmaWxlIG1vZGUgMTAwNjQ0CmluZGV4IDAwMDAwMDAuLjg4OGUxZWMKLS0tIC9kZXYvbnVsbAorKysgUkVBRE1FLnR4dApAQCAtMCwwICsxIEBACit0aGlzIGlzIHN0ZXAgMQo=","outputs":{},"previousStepResult":{"Files":{"modified":null,"added":["README.txt"],"deleted":null,"renamed":null},"Stdout":{},"Stderr":{}}}}}
+stdout: {"operation":"CACHE_AFTER_STEP_RESULT","timestamp":"2021-11-04T12:43:19.551Z","status":"SUCCESS","metadata":{"key":"utgLpuQ3njDtLe3eztArAQ-step-2","value":{"stepIndex":2,"diff":"ZGlmZiAtLWdpdCBSRUFETUUubWQgUkVBRE1FLm1kCmluZGV4IDE5MTQ0OTEuLmNkMmNjYmYgMTAwNjQ0Ci0tLSBSRUFETUUubWQKKysrIFJFQURNRS5tZApAQCAtMyw0ICszLDUgQEAgVGhpcyByZXBvc2l0b3J5IGlzIHVzZWQgdG8gdGVzdCBvcGVuaW5nIGFuZCBjbG9zaW5nIHB1bGwgcmVxdWVzdCB3aXRoIEF1dG9tYXRpb24KIAogKGMpIENvcHlyaWdodCBTb3VyY2VncmFwaCAyMDEzLTIwMjAuCiAoYykgQ29weXJpZ2h0IFNvdXJjZWdyYXBoIDIwMTMtMjAyMC4KLShjKSBDb3B5cmlnaHQgU291cmNlZ3JhcGggMjAxMy0yMDIwLgpcIE5vIG5ld2xpbmUgYXQgZW5kIG9mIGZpbGUKKyhjKSBDb3B5cmlnaHQgU291cmNlZ3JhcGggMjAxMy0yMDIwLnRoaXMgaXMgc3RlcCAyCit0aGlzIGlzIHN0ZXAgMwpkaWZmIC0tZ2l0IFJFQURNRS50eHQgUkVBRE1FLnR4dApuZXcgZmlsZSBtb2RlIDEwMDY0NAppbmRleCAwMDAwMDAwLi44ODhlMWVjCi0tLSAvZGV2L251bGwKKysrIFJFQURNRS50eHQKQEAgLTAsMCArMSBAQAordGhpcyBpcyBzdGVwIDEK","outputs":{"myOutput":"my-output.txt"},"previousStepResult":{"Files":{"modified":["README.md"],"added":["README.txt"],"deleted":null,"renamed":null},"Stdout":{},"Stderr":{}}}}}
+stdout: {"operation":"CACHE_AFTER_STEP_RESULT","timestamp":"2021-11-04T12:43:19.551Z","status":"SUCCESS","metadata":{"key":"RoG8xSgpganc5BJ0_D3XGA-step-3","value":{"stepIndex":3,"diff":"ZGlmZiAtLWdpdCBSRUFETUUubWQgUkVBRE1FLm1kCmluZGV4IDE5MTQ0OTEuLmQ2NzgyZDMgMTAwNjQ0Ci0tLSBSRUFETUUubWQKKysrIFJFQURNRS5tZApAQCAtMyw0ICszLDcgQEAgVGhpcyByZXBvc2l0b3J5IGlzIHVzZWQgdG8gdGVzdCBvcGVuaW5nIGFuZCBjbG9zaW5nIHB1bGwgcmVxdWVzdCB3aXRoIEF1dG9tYXRpb24KIAogKGMpIENvcHlyaWdodCBTb3VyY2VncmFwaCAyMDEzLTIwMjAuCiAoYykgQ29weXJpZ2h0IFNvdXJjZWdyYXBoIDIwMTMtMjAyMC4KLShjKSBDb3B5cmlnaHQgU291cmNlZ3JhcGggMjAxMy0yMDIwLgpcIE5vIG5ld2xpbmUgYXQgZW5kIG9mIGZpbGUKKyhjKSBDb3B5cmlnaHQgU291cmNlZ3JhcGggMjAxMy0yMDIwLnRoaXMgaXMgc3RlcCAyCit0aGlzIGlzIHN0ZXAgMwordGhpcyBpcyBzdGVwIDQKK3ByZXZpb3VzX3N0ZXAubW9kaWZpZWRfZmlsZXM9W1JFQURNRS5tZF0KZGlmZiAtLWdpdCBSRUFETUUudHh0IFJFQURNRS50eHQKbmV3IGZpbGUgbW9kZSAxMDA2NDQKaW5kZXggMDAwMDAwMC4uODg4ZTFlYwotLS0gL2Rldi9udWxsCisrKyBSRUFETUUudHh0CkBAIC0wLDAgKzEgQEAKK3RoaXMgaXMgc3RlcCAxCg==","outputs":{"myOutput":"my-output.txt"},"previousStepResult":{"Files":{"modified":["README.md"],"added":["README.txt"],"deleted":null,"renamed":null},"Stdout":{},"Stderr":{}}}}}
+stdout: {"operation":"CACHE_AFTER_STEP_RESULT","timestamp":"2021-11-04T12:43:19.551Z","status":"SUCCESS","metadata":{"key":"Nsw12JxoLSHN4ta6D3G7FQ-step-4","value":{"stepIndex":4,"diff":"ZGlmZiAtLWdpdCBSRUFETUUubWQgUkVBRE1FLm1kCmluZGV4IDE5MTQ0OTEuLmQ2NzgyZDMgMTAwNjQ0Ci0tLSBSRUFETUUubWQKKysrIFJFQURNRS5tZApAQCAtMyw0ICszLDcgQEAgVGhpcyByZXBvc2l0b3J5IGlzIHVzZWQgdG8gdGVzdCBvcGVuaW5nIGFuZCBjbG9zaW5nIHB1bGwgcmVxdWVzdCB3aXRoIEF1dG9tYXRpb24KIAogKGMpIENvcHlyaWdodCBTb3VyY2VncmFwaCAyMDEzLTIwMjAuCiAoYykgQ29weXJpZ2h0IFNvdXJjZWdyYXBoIDIwMTMtMjAyMC4KLShjKSBDb3B5cmlnaHQgU291cmNlZ3JhcGggMjAxMy0yMDIwLgpcIE5vIG5ld2xpbmUgYXQgZW5kIG9mIGZpbGUKKyhjKSBDb3B5cmlnaHQgU291cmNlZ3JhcGggMjAxMy0yMDIwLnRoaXMgaXMgc3RlcCAyCit0aGlzIGlzIHN0ZXAgMwordGhpcyBpcyBzdGVwIDQKK3ByZXZpb3VzX3N0ZXAubW9kaWZpZWRfZmlsZXM9W1JFQURNRS5tZF0KZGlmZiAtLWdpdCBSRUFETUUudHh0IFJFQURNRS50eHQKbmV3IGZpbGUgbW9kZSAxMDA2NDQKaW5kZXggMDAwMDAwMC4uODg4ZTFlYwotLS0gL2Rldi9udWxsCisrKyBSRUFETUUudHh0CkBAIC0wLDAgKzEgQEAKK3RoaXMgaXMgc3RlcCAxCmRpZmYgLS1naXQgbXktb3V0cHV0LnR4dCBteS1vdXRwdXQudHh0Cm5ldyBmaWxlIG1vZGUgMTAwNjQ0CmluZGV4IDAwMDAwMDAuLjI1N2FlOGUKLS0tIC9kZXYvbnVsbAorKysgbXktb3V0cHV0LnR4dApAQCAtMCwwICsxIEBACit0aGlzIGlzIHN0ZXAgNQo=","outputs":{"myOutput":"my-output.txt"},"previousStepResult":{"Files":{"modified":["README.md"],"added":["README.txt"],"deleted":null,"renamed":null},"Stdout":{},"Stderr":{}}}}}
+stdout: {"operation":"UPLOADING_CHANGESET_SPECS","timestamp":"2021-09-09T13:20:32.95Z","status":"SUCCESS","metadata":{"ids":` + jsonArray + `}} `
+
 	entry := workerutil.ExecutionLogEntry{
 		Key:        "step.src.0",
 		Command:    []string{"src", "batch", "preview", "-f", "spec.yml", "-text-only"},
 		StartTime:  time.Now().Add(-5 * time.Second),
-		Out:        `stdout: {"operation":"UPLOADING_CHANGESET_SPECS","timestamp":"2021-09-09T13:20:32.95Z","status":"SUCCESS","metadata":{"ids":` + jsonArray + `}} `,
+		Out:        output,
 		DurationMs: intptr(200),
 	}
 
@@ -142,6 +163,21 @@ func TestBatchSpecWorkspaceExecutionWorkerStore_MarkComplete(t *testing.T) {
 			}
 		}
 
+		for _, wantKey := range cacheEntryKeys {
+			entry, err := s.GetBatchSpecExecutionCacheEntry(ctx, store.GetBatchSpecExecutionCacheEntryOpts{Key: wantKey})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var cachedExecutionResult *execution.Result
+			if err := json.Unmarshal([]byte(entry.Value), &cachedExecutionResult); err != nil {
+				t.Fatal(err)
+			}
+			if cachedExecutionResult.Diff == "" {
+				t.Fatalf("wrong diff extracted")
+			}
+		}
+
 		_, err = database.AccessTokens(db).GetByID(ctx, tokenID)
 		if err != database.ErrAccessTokenNotFound {
 			t.Fatalf("access token was not deleted")
@@ -183,117 +219,39 @@ func TestBatchSpecWorkspaceExecutionWorkerStore_MarkComplete(t *testing.T) {
 func TestExtractChangesetSpecIDs(t *testing.T) {
 	tests := []struct {
 		name        string
-		entries     []workerutil.ExecutionLogEntry
+		events      []*batcheslib.LogEvent
 		wantRandIDs []string
 		wantErr     error
 	}{
 		{
 			name: "success",
-			entries: []workerutil.ExecutionLogEntry{
-				{Key: "setup.firecracker.start"},
-				// Reduced log output because we don't care about _all_ lines
+			events: []*batcheslib.LogEvent{
 				{
-					Key: "step.src.0",
-					Out: `
-stdout: {"operation":"EXECUTING_TASKS","timestamp":"2021-09-09T13:20:32.942Z","status":"SUCCESS"}
-stdout: {"operation":"UPLOADING_CHANGESET_SPECS","timestamp":"2021-09-09T13:20:32.942Z","status":"STARTED","metadata":{"total":1}}
-stdout: {"operation":"UPLOADING_CHANGESET_SPECS","timestamp":"2021-09-09T13:20:32.95Z","status":"PROGRESS","metadata":{"done":1,"total":1}}
-stdout: {"operation":"UPLOADING_CHANGESET_SPECS","timestamp":"2021-09-09T13:20:32.95Z","status":"SUCCESS","metadata":{"ids":["Q2hhbmdlc2V0U3BlYzoiNkxIYWN5dkI3WDYi"]}}
-
-`,
-				},
-			},
-			// Run `echo "QmF0Y2hTcGVjOiJBZFBMTDU5SXJmWCI=" | base64 -d` to get this
-			wantRandIDs: []string{"6LHacyvB7X6"},
-		},
-		{
-
-			name:    "no step.src.0 log entry",
-			entries: []workerutil.ExecutionLogEntry{},
-			wantErr: ErrNoChangesetSpecIDs,
-		},
-
-		{
-
-			name: "no upload step in the output",
-			entries: []workerutil.ExecutionLogEntry{
-				{
-					Key: "step.src.0",
-					Out: `stdout: {"operation":"PARSING_BATCH_SPEC","timestamp":"2021-07-06T09:38:51.481Z","status":"STARTED"}
-stdout: {"operation":"PARSING_BATCH_SPEC","timestamp":"2021-07-06T09:38:51.481Z","status":"SUCCESS"}
-`,
-				},
-			},
-			wantErr: ErrNoChangesetSpecIDs,
-		},
-		{
-			name: "empty array the output",
-			entries: []workerutil.ExecutionLogEntry{
-				{
-					Key: "step.src.0",
-					Out: `
-stdout: {"operation":"EXECUTING_TASKS","timestamp":"2021-09-09T13:20:32.942Z","status":"SUCCESS"}
-stdout: {"operation":"UPLOADING_CHANGESET_SPECS","timestamp":"2021-09-09T13:20:32.942Z","status":"STARTED","metadata":{"total":1}}
-stdout: {"operation":"UPLOADING_CHANGESET_SPECS","timestamp":"2021-09-09T13:20:32.95Z","status":"PROGRESS","metadata":{"done":1,"total":1}}
-stdout: {"operation":"UPLOADING_CHANGESET_SPECS","timestamp":"2021-09-09T13:20:32.95Z","status":"SUCCESS","metadata":{"ids":[]}}
-
-`,
-				},
-			},
-			wantRandIDs: []string{},
-		},
-
-		{
-			name: "additional text in log output",
-			entries: []workerutil.ExecutionLogEntry{
-				{
-					Key: "step.src.0",
-					Out: `stdout: {"operation":"EXECUTING_TASKS","timestamp":"2021-09-09T13:20:32.941Z","status":"STARTED","metadata":{"tasks":[]}}
-stdout: {"operation":"EXECUTING_TASKS","timestamp":"2021-09-09T13:20:32.942Z","status":"SUCCESS"}
-stderr: HORSE
-stdout: {"operation":"UPLOADING_CHANGESET_SPECS","timestamp":"2021-09-09T13:20:32.942Z","status":"STARTED","metadata":{"total":1}}
-stderr: HORSE
-stdout: {"operation":"UPLOADING_CHANGESET_SPECS","timestamp":"2021-09-09T13:20:32.95Z","status":"PROGRESS","metadata":{"done":1,"total":1}}
-stderr: HORSE
-stdout: {"operation":"UPLOADING_CHANGESET_SPECS","timestamp":"2021-09-09T13:20:32.95Z","status":"SUCCESS","metadata":{"ids":["Q2hhbmdlc2V0U3BlYzoiNkxIYWN5dkI3WDYi"]}}
-`,
+					Status: batcheslib.LogEventStatusSuccess,
+					Metadata: &batcheslib.UploadingChangesetSpecsMetadata{
+						IDs: []string{"Q2hhbmdlc2V0U3BlYzoiNkxIYWN5dkI3WDYi"},
+					},
 				},
 			},
 			wantRandIDs: []string{"6LHacyvB7X6"},
 		},
-
 		{
-			name: "invalid json",
-			entries: []workerutil.ExecutionLogEntry{
+			name: "wrong status",
+			events: []*batcheslib.LogEvent{
 				{
-					Key: "step.src.0",
-					Out: `stdout: {"operation":"PARSING_BATCH_SPEC","timestamp":"2021-07-06T09:38:51.481Z","status":"STARTED"}
-stdout: {HOOOORSE}
-stdout: {HORSE}
-stdout: {HORSE}
-`,
+					Status: batcheslib.LogEventStatusFailure,
+					Metadata: &batcheslib.UploadingChangesetSpecsMetadata{
+						IDs: []string{},
+					},
 				},
 			},
 			wantErr: ErrNoChangesetSpecIDs,
-		},
-
-		{
-			name: "non-json output inbetween valid json",
-			entries: []workerutil.ExecutionLogEntry{
-				{
-					Key: "step.src.0",
-					Out: `stdout: {"operation":"PARSING_BATCH_SPEC","timestamp":"2021-07-12T12:25:33.965Z","status":"STARTED"}
-stdout: No changeset specs created
-stdout: {"operation":"UPLOADING_CHANGESET_SPECS","timestamp":"2021-09-09T13:20:32.95Z","status":"SUCCESS","metadata":{"ids":["Q2hhbmdlc2V0U3BlYzoiNkxIYWN5dkI3WDYi"]}}`,
-				},
-			},
-			wantRandIDs: []string{"6LHacyvB7X6"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			have, err := extractChangesetSpecRandIDs(tt.entries)
+			have, err := extractChangesetSpecRandIDs(tt.events)
 			if tt.wantErr != nil {
 				if err != tt.wantErr {
 					t.Fatalf("wrong error. want=%s, got=%s", tt.wantErr, err)


### PR DESCRIPTION
This is part of #26929.

When a `BatchSpecWorkspaceExecutionJob` completes we extract the cache entries in the log messages and persist them to the database.

What's still a bit bad is the marshaling/unmarshaling. But I'm not sure (yet) what the best thing to do here is.