### PR TITLE
remove a bunch of database.NewDB()

### DIFF
--- a/cmd/frontend/graphqlbackend/access_token.go
+++ b/cmd/frontend/graphqlbackend/access_token.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 // accessTokenResolver resolves an access token.
@@ -21,7 +20,7 @@ import (
 // other services likely allow user accounts to do more than what access tokens
 // alone can via the API.
 type accessTokenResolver struct {
-	db          dbutil.DB
+	db          database.DB
 	accessToken database.AccessToken
 }
 
@@ -30,7 +29,7 @@ func accessTokenByID(ctx context.Context, db database.DB, id graphql.ID) (*acces
 	if err != nil {
 		return nil, err
 	}
-	accessToken, err := database.AccessTokens(db).GetByID(ctx, accessTokenID)
+	accessToken, err := db.AccessTokens().GetByID(ctx, accessTokenID)
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +50,7 @@ func unmarshalAccessTokenID(id graphql.ID) (accessTokenID int64, err error) {
 func (r *accessTokenResolver) ID() graphql.ID { return marshalAccessTokenID(r.accessToken.ID) }
 
 func (r *accessTokenResolver) Subject(ctx context.Context) (*UserResolver, error) {
-	return UserByIDInt32(ctx, database.NewDB(r.db), r.accessToken.SubjectUserID)
+	return UserByIDInt32(ctx, r.db, r.accessToken.SubjectUserID)
 }
 
 func (r *accessTokenResolver) Scopes() []string { return r.accessToken.Scopes }
@@ -59,7 +58,7 @@ func (r *accessTokenResolver) Scopes() []string { return r.accessToken.Scopes }
 func (r *accessTokenResolver) Note() string { return r.accessToken.Note }
 
 func (r *accessTokenResolver) Creator(ctx context.Context) (*UserResolver, error) {
-	return UserByIDInt32(ctx, database.NewDB(r.db), r.accessToken.CreatorUserID)
+	return UserByIDInt32(ctx, r.db, r.accessToken.CreatorUserID)
 }
 
 func (r *accessTokenResolver) CreatedAt() DateTime { return DateTime{Time: r.accessToken.CreatedAt} }

--- a/cmd/frontend/graphqlbackend/access_tokens.go
+++ b/cmd/frontend/graphqlbackend/access_tokens.go
@@ -160,7 +160,7 @@ func (r *siteResolver) AccessTokens(ctx context.Context, args *struct {
 }) (*accessTokenConnectionResolver, error) {
 	// 🚨 SECURITY: Only site admins can list all access tokens. This is safe as the
 	// token values themselves are not stored in our database.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, database.NewDB(r.db)); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/graphqlbackend/access_tokens.go
+++ b/cmd/frontend/graphqlbackend/access_tokens.go
@@ -16,7 +16,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 type createAccessTokenInput struct {
@@ -194,7 +193,7 @@ type accessTokenConnectionResolver struct {
 	once         sync.Once
 	accessTokens []*database.AccessToken
 	err          error
-	db           dbutil.DB
+	db           database.DB
 }
 
 func (r *accessTokenConnectionResolver) compute(ctx context.Context) ([]*database.AccessToken, error) {
@@ -206,7 +205,7 @@ func (r *accessTokenConnectionResolver) compute(ctx context.Context) ([]*databas
 			opt2.Limit++ // so we can detect if there is a next page
 		}
 
-		r.accessTokens, r.err = database.AccessTokens(r.db).List(ctx, opt2)
+		r.accessTokens, r.err = r.db.AccessTokens().List(ctx, opt2)
 	})
 	return r.accessTokens, r.err
 }
@@ -228,7 +227,7 @@ func (r *accessTokenConnectionResolver) Nodes(ctx context.Context) ([]*accessTok
 }
 
 func (r *accessTokenConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
-	count, err := database.AccessTokens(r.db).Count(ctx, r.opt)
+	count, err := r.db.AccessTokens().Count(ctx, r.opt)
 	return int32(count), err
 }
 

--- a/cmd/frontend/graphqlbackend/affiliated_repositories_connection.go
+++ b/cmd/frontend/graphqlbackend/affiliated_repositories_connection.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
@@ -157,7 +156,7 @@ func (a *affiliatedRepositoriesConnection) Nodes(ctx context.Context) ([]*codeHo
 type codeHostRepositoryResolver struct {
 	repo     *types.CodeHostRepository
 	codeHost *types.ExternalService
-	db       dbutil.DB
+	db       database.DB
 }
 
 func (r *codeHostRepositoryResolver) Name() string {
@@ -170,7 +169,7 @@ func (r *codeHostRepositoryResolver) Private() bool {
 
 func (r *codeHostRepositoryResolver) CodeHost(ctx context.Context) *externalServiceResolver {
 	return &externalServiceResolver{
-		db:              database.NewDB(r.db),
+		db:              r.db,
 		externalService: r.codeHost,
 	}
 }

--- a/cmd/frontend/graphqlbackend/compute_test.go
+++ b/cmd/frontend/graphqlbackend/compute_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hexops/autogold"
 	"github.com/sourcegraph/sourcegraph/internal/compute"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
@@ -26,7 +26,7 @@ func TestToResultResolverList(t *testing.T) {
 			context.Background(),
 			computeQuery.Command,
 			matches,
-			new(dbtesting.MockDB),
+			dbmock.NewMockDB(),
 		)
 		var results []string
 		for _, r := range resolvers {

--- a/cmd/frontend/graphqlbackend/default_settings.go
+++ b/cmd/frontend/graphqlbackend/default_settings.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 var builtinExtensions = map[string]bool{
@@ -52,7 +51,7 @@ var builtinExtensions = map[string]bool{
 	"sourcegraph/vhdl":       true,
 }
 
-func defaultSettings(db dbutil.DB) map[string]interface{} {
+func defaultSettings(db database.DB) map[string]interface{} {
 	extensionIDs := []string{}
 	for id := range builtinExtensions {
 		extensionIDs = append(extensionIDs, id)
@@ -72,7 +71,7 @@ func defaultSettings(db dbutil.DB) map[string]interface{} {
 const singletonDefaultSettingsGQLID = "DefaultSettings"
 
 type defaultSettingsResolver struct {
-	db    dbutil.DB
+	db    database.DB
 	gqlID string
 }
 
@@ -88,7 +87,7 @@ func (r *defaultSettingsResolver) LatestSettings(ctx context.Context) (*settings
 		return nil, err
 	}
 	settings := &api.Settings{Subject: api.SettingsSubject{Default: true}, Contents: string(contents)}
-	return &settingsResolver{database.NewDB(r.db), &settingsSubject{defaultSettings: r}, settings, nil}, nil
+	return &settingsResolver{r.db, &settingsSubject{defaultSettings: r}, settings, nil}, nil
 }
 
 func (r *defaultSettingsResolver) SettingsURL() *string { return nil }

--- a/cmd/frontend/graphqlbackend/event_log.go
+++ b/cmd/frontend/graphqlbackend/event_log.go
@@ -4,19 +4,18 @@ import (
 	"context"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 type userEventLogResolver struct {
-	db    dbutil.DB
+	db    database.DB
 	event *types.Event
 }
 
 func (s *userEventLogResolver) User(ctx context.Context) (*UserResolver, error) {
 	if s.event.UserID != nil {
-		user, err := UserByIDInt32(ctx, database.NewDB(s.db), *s.event.UserID)
+		user, err := UserByIDInt32(ctx, s.db, *s.event.UserID)
 		if err != nil && errcode.IsNotFound(err) {
 			// Don't throw an error if a user has been deleted.
 			return nil, nil

--- a/cmd/frontend/graphqlbackend/event_logs.go
+++ b/cmd/frontend/graphqlbackend/event_logs.go
@@ -6,7 +6,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 func (r *UserResolver) EventLogs(ctx context.Context, args *struct {
@@ -25,12 +24,12 @@ func (r *UserResolver) EventLogs(ctx context.Context, args *struct {
 }
 
 type userEventLogsConnectionResolver struct {
-	db  dbutil.DB
+	db  database.DB
 	opt database.EventLogsListOptions
 }
 
 func (r *userEventLogsConnectionResolver) Nodes(ctx context.Context) ([]*userEventLogResolver, error) {
-	events, err := database.EventLogs(r.db).ListAll(ctx, r.opt)
+	events, err := r.db.EventLogs().ListAll(ctx, r.opt)
 	if err != nil {
 		return nil, err
 	}
@@ -48,9 +47,9 @@ func (r *userEventLogsConnectionResolver) TotalCount(ctx context.Context) (int32
 	var err error
 
 	if r.opt.EventName != nil {
-		count, err = database.EventLogs(r.db).CountByUserIDAndEventName(ctx, r.opt.UserID, *r.opt.EventName)
+		count, err = r.db.EventLogs().CountByUserIDAndEventName(ctx, r.opt.UserID, *r.opt.EventName)
 	} else {
-		count, err = database.EventLogs(r.db).CountByUserID(ctx, r.opt.UserID)
+		count, err = r.db.EventLogs().CountByUserID(ctx, r.opt.UserID)
 	}
 
 	return int32(count), err
@@ -61,9 +60,9 @@ func (r *userEventLogsConnectionResolver) PageInfo(ctx context.Context) (*graphq
 	var err error
 
 	if r.opt.EventName != nil {
-		count, err = database.EventLogs(r.db).CountByUserIDAndEventName(ctx, r.opt.UserID, *r.opt.EventName)
+		count, err = r.db.EventLogs().CountByUserIDAndEventName(ctx, r.opt.UserID, *r.opt.EventName)
 	} else {
-		count, err = database.EventLogs(r.db).CountByUserID(ctx, r.opt.UserID)
+		count, err = r.db.EventLogs().CountByUserID(ctx, r.opt.UserID)
 	}
 
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/external_account.go
+++ b/cmd/frontend/graphqlbackend/external_account.go
@@ -44,7 +44,7 @@ func unmarshalExternalAccountID(id graphql.ID) (externalAccountID int32, err err
 
 func (r *externalAccountResolver) ID() graphql.ID { return marshalExternalAccountID(r.account.ID) }
 func (r *externalAccountResolver) User(ctx context.Context) (*UserResolver, error) {
-	return UserByIDInt32(ctx, database.NewDB(r.db), r.account.UserID)
+	return UserByIDInt32(ctx, r.db, r.account.UserID)
 }
 func (r *externalAccountResolver) ServiceType() string { return r.account.ServiceType }
 func (r *externalAccountResolver) ServiceID() string   { return r.account.ServiceID }
@@ -68,7 +68,7 @@ func (r *externalAccountResolver) AccountData(ctx context.Context) (*JSONValue, 
 	// GitLab, but only site admins can view account data for all other types.
 	var err error
 	if r.account.ServiceType == extsvc.TypeGitHub || r.account.ServiceType == extsvc.TypeGitLab {
-		err = backend.CheckSiteAdminOrSameUser(ctx, database.NewDB(r.db), actor.FromContext(ctx).UID)
+		err = backend.CheckSiteAdminOrSameUser(ctx, r.db, actor.FromContext(ctx).UID)
 	} else {
 		err = backend.CheckUserIsSiteAdmin(ctx, r.db, actor.FromContext(ctx).UID)
 	}

--- a/cmd/frontend/graphqlbackend/external_account.go
+++ b/cmd/frontend/graphqlbackend/external_account.go
@@ -9,12 +9,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )
 
 type externalAccountResolver struct {
-	db      dbutil.DB
+	db      database.DB
 	account extsvc.Account
 }
 
@@ -23,7 +22,7 @@ func externalAccountByID(ctx context.Context, db database.DB, id graphql.ID) (*e
 	if err != nil {
 		return nil, err
 	}
-	account, err := database.ExternalAccounts(db).Get(ctx, externalAccountID)
+	account, err := db.UserExternalAccounts().Get(ctx, externalAccountID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/external_accounts.go
+++ b/cmd/frontend/graphqlbackend/external_accounts.go
@@ -9,7 +9,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )
 
@@ -66,7 +65,7 @@ func (r *UserResolver) ExternalAccounts(ctx context.Context, args *struct {
 // 🚨 SECURITY: When instantiating an externalAccountConnectionResolver value, the caller MUST check
 // permissions.
 type externalAccountConnectionResolver struct {
-	db  dbutil.DB
+	db  database.DB
 	opt database.ExternalAccountsListOptions
 
 	// cache results because they are used by multiple fields
@@ -84,7 +83,7 @@ func (r *externalAccountConnectionResolver) compute(ctx context.Context) ([]*ext
 			opt2.Limit++ // so we can detect if there is a next page
 		}
 
-		r.externalAccounts, r.err = database.ExternalAccounts(r.db).List(ctx, opt2)
+		r.externalAccounts, r.err = r.db.UserExternalAccounts().List(ctx, opt2)
 	})
 	return r.externalAccounts, r.err
 }
@@ -103,7 +102,7 @@ func (r *externalAccountConnectionResolver) Nodes(ctx context.Context) ([]*exter
 }
 
 func (r *externalAccountConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
-	count, err := database.ExternalAccounts(r.db).Count(ctx, r.opt)
+	count, err := r.db.UserExternalAccounts().Count(ctx, r.opt)
 	return int32(count), err
 }
 

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -145,12 +145,12 @@ func (r *schemaResolver) UpdateExternalService(ctx context.Context, args *update
 		DisplayName: args.Input.DisplayName,
 		Config:      args.Input.Config,
 	}
-	if err := database.ExternalServices(r.db).Update(ctx, ps, id, update); err != nil {
+	if err := r.db.ExternalServices().Update(ctx, ps, id, update); err != nil {
 		return nil, err
 	}
 
 	// Fetch from database again to get all fields with updated values.
-	es, err = database.ExternalServices(r.db).GetByID(ctx, id)
+	es, err = r.db.ExternalServices().GetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -297,12 +297,12 @@ type externalServiceConnectionResolver struct {
 	once             sync.Once
 	externalServices []*types.ExternalService
 	err              error
-	db               dbutil.DB
+	db               database.DB
 }
 
 func (r *externalServiceConnectionResolver) compute(ctx context.Context) ([]*types.ExternalService, error) {
 	r.once.Do(func() {
-		r.externalServices, r.err = database.ExternalServices(r.db).List(ctx, r.opt)
+		r.externalServices, r.err = r.db.ExternalServices().List(ctx, r.opt)
 	})
 	return r.externalServices, r.err
 }
@@ -314,7 +314,7 @@ func (r *externalServiceConnectionResolver) Nodes(ctx context.Context) ([]*exter
 	}
 	resolvers := make([]*externalServiceResolver, 0, len(externalServices))
 	for _, externalService := range externalServices {
-		resolvers = append(resolvers, &externalServiceResolver{db: database.NewDB(r.db), externalService: externalService})
+		resolvers = append(resolvers, &externalServiceResolver{db: r.db, externalService: externalService})
 	}
 	return resolvers, nil
 }
@@ -323,7 +323,7 @@ func (r *externalServiceConnectionResolver) TotalCount(ctx context.Context) (int
 	// Reset pagination cursor to get correct total count
 	opt := r.opt
 	opt.AfterID = 0
-	count, err := database.ExternalServices(r.db).Count(ctx, opt)
+	count, err := r.db.ExternalServices().Count(ctx, opt)
 	return int32(count), err
 }
 
@@ -346,7 +346,7 @@ func (r *externalServiceConnectionResolver) PageInfo(ctx context.Context) (*grap
 	// In case the number of results happens to be the same as the limit,
 	// we need another query to get accurate total count with same cursor
 	// to determine if there are more results than the limit we set.
-	count, err := database.ExternalServices(r.db).Count(ctx, r.opt)
+	count, err := r.db.ExternalServices().Count(ctx, r.opt)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -19,7 +19,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -361,7 +360,7 @@ func (r *externalServiceConnectionResolver) PageInfo(ctx context.Context) (*grap
 type computedExternalServiceConnectionResolver struct {
 	args             graphqlutil.ConnectionArgs
 	externalServices []*types.ExternalService
-	db               dbutil.DB
+	db               database.DB
 }
 
 func (r *computedExternalServiceConnectionResolver) Nodes(ctx context.Context) []*externalServiceResolver {
@@ -371,7 +370,7 @@ func (r *computedExternalServiceConnectionResolver) Nodes(ctx context.Context) [
 	}
 	resolvers := make([]*externalServiceResolver, 0, len(svcs))
 	for _, svc := range svcs {
-		resolvers = append(resolvers, &externalServiceResolver{db: database.NewDB(r.db), externalService: svc})
+		resolvers = append(resolvers, &externalServiceResolver{db: r.db, externalService: svc})
 	}
 	return resolvers
 }

--- a/cmd/frontend/graphqlbackend/file_match.go
+++ b/cmd/frontend/graphqlbackend/file_match.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
-
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
@@ -39,7 +39,7 @@ func (fm *FileMatchResolver) File() *GitTreeEntryResolver {
 
 func (fm *FileMatchResolver) Commit() *GitCommitResolver {
 	return &GitCommitResolver{
-		db:           fm.db,
+		db:           database.NewDB(fm.db),
 		repoResolver: fm.RepoResolver,
 		oid:          GitObjectID(fm.CommitID),
 		inputRev:     fm.InputRev,

--- a/cmd/frontend/graphqlbackend/file_match.go
+++ b/cmd/frontend/graphqlbackend/file_match.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
@@ -14,7 +13,7 @@ type FileMatchResolver struct {
 	result.FileMatch
 
 	RepoResolver *RepositoryResolver
-	db           dbutil.DB
+	db           database.DB
 }
 
 // Equal provides custom comparison which is used by go-cmp
@@ -39,7 +38,7 @@ func (fm *FileMatchResolver) File() *GitTreeEntryResolver {
 
 func (fm *FileMatchResolver) Commit() *GitCommitResolver {
 	return &GitCommitResolver{
-		db:           database.NewDB(fm.db),
+		db:           fm.db,
 		repoResolver: fm.RepoResolver,
 		oid:          GitObjectID(fm.CommitID),
 		inputRev:     fm.InputRev,

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
@@ -34,7 +33,7 @@ func (r *schemaResolver) gitCommitByID(ctx context.Context, id graphql.ID) (*Git
 }
 
 type GitCommitResolver struct {
-	db           dbutil.DB
+	db           database.DB
 	repoResolver *RepositoryResolver
 
 	// inputRev is the Git revspec that the user originally requested that resolved to this Git commit. It is used
@@ -58,7 +57,7 @@ type GitCommitResolver struct {
 
 // When set to nil, commit will be loaded lazily as needed by the resolver. Pass in a commit when you have batch loaded
 // a bunch of them and already have them at hand.
-func toGitCommitResolver(repo *RepositoryResolver, db dbutil.DB, id api.CommitID, commit *gitapi.Commit) *GitCommitResolver {
+func toGitCommitResolver(repo *RepositoryResolver, db database.DB, id api.CommitID, commit *gitapi.Commit) *GitCommitResolver {
 	return &GitCommitResolver{
 		db:              db,
 		repoResolver:    repo,
@@ -191,7 +190,7 @@ func (r *GitCommitResolver) ExternalURLs(ctx context.Context) ([]*externallink.R
 		return nil, err
 	}
 
-	return externallink.Commit(ctx, database.NewDB(r.db), repo, api.CommitID(r.oid))
+	return externallink.Commit(ctx, r.db, repo, api.CommitID(r.oid))
 }
 
 func (r *GitCommitResolver) Tree(ctx context.Context, args *struct {

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
@@ -19,7 +19,7 @@ import (
 
 func TestGitCommitResolver(t *testing.T) {
 	ctx := context.Background()
-	db := new(dbtesting.MockDB)
+	db := dbmock.NewMockDB()
 
 	commit := &gitapi.Commit{
 		ID:      "c1",
@@ -94,7 +94,7 @@ func TestGitCommitResolver(t *testing.T) {
 			},
 		}} {
 			t.Run(tc.name, func(t *testing.T) {
-				repo := NewRepositoryResolver(database.NewDB(db), &types.Repo{Name: "bob-repo"})
+				repo := NewRepositoryResolver(db, &types.Repo{Name: "bob-repo"})
 				// We pass no commit here to test that it gets lazy loaded via
 				// the git.GetCommit mock above.
 				r := toGitCommitResolver(repo, db, "c1", nil)

--- a/cmd/frontend/graphqlbackend/git_commits.go
+++ b/cmd/frontend/graphqlbackend/git_commits.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
@@ -78,7 +79,7 @@ func (r *gitCommitConnectionResolver) Nodes(ctx context.Context) ([]*GitCommitRe
 
 	resolvers := make([]*GitCommitResolver, len(commits))
 	for i, commit := range commits {
-		resolvers[i] = toGitCommitResolver(r.repo, r.db, commit.ID, commit)
+		resolvers[i] = toGitCommitResolver(r.repo, database.NewDB(r.db), commit.ID, commit)
 	}
 
 	return resolvers, nil

--- a/cmd/frontend/graphqlbackend/git_commits.go
+++ b/cmd/frontend/graphqlbackend/git_commits.go
@@ -6,13 +6,12 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
 type gitCommitConnectionResolver struct {
-	db            dbutil.DB
+	db            database.DB
 	revisionRange string
 
 	first  *int32
@@ -79,7 +78,7 @@ func (r *gitCommitConnectionResolver) Nodes(ctx context.Context) ([]*GitCommitRe
 
 	resolvers := make([]*GitCommitResolver, len(commits))
 	for i, commit := range commits {
-		resolvers[i] = toGitCommitResolver(r.repo, database.NewDB(r.db), commit.ID, commit)
+		resolvers[i] = toGitCommitResolver(r.repo, r.db, commit.ID, commit)
 	}
 
 	return resolvers, nil

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -52,7 +52,7 @@ type GitTreeEntryResolver struct {
 }
 
 func NewGitTreeEntryResolver(commit *GitCommitResolver, db database.DB, stat fs.FileInfo) *GitTreeEntryResolver {
-	return &GitTreeEntryResolver{db: database.NewDB(db), commit: commit, stat: stat}
+	return &GitTreeEntryResolver{db: db, commit: commit, stat: stat}
 }
 
 func (r *GitTreeEntryResolver) Path() string { return r.stat.Name() }

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -22,7 +22,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/highlight"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
@@ -52,7 +51,7 @@ type GitTreeEntryResolver struct {
 	isSingleChild *bool // whether this is the single entry in its parent. Only set by the (&GitTreeEntryResolver) entries.
 }
 
-func NewGitTreeEntryResolver(commit *GitCommitResolver, db dbutil.DB, stat fs.FileInfo) *GitTreeEntryResolver {
+func NewGitTreeEntryResolver(commit *GitCommitResolver, db database.DB, stat fs.FileInfo) *GitTreeEntryResolver {
 	return &GitTreeEntryResolver{db: database.NewDB(db), commit: commit, stat: stat}
 }
 

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -549,7 +549,7 @@ func (r *schemaResolver) repositoryByID(ctx context.Context, id graphql.ID) (*Re
 	if err != nil {
 		return nil, err
 	}
-	return NewRepositoryResolver(database.NewDB(r.db), repo), nil
+	return NewRepositoryResolver(r.db, repo), nil
 }
 
 type RedirectResolver struct {

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -607,7 +607,7 @@ func (r *schemaResolver) RepositoryRedirect(ctx context.Context, args *struct {
 		}
 		return nil, err
 	}
-	return &repositoryRedirect{repo: NewRepositoryResolver(database.NewDB(r.db), repo)}, nil
+	return &repositoryRedirect{repo: NewRepositoryResolver(r.db, repo)}, nil
 }
 
 func (r *schemaResolver) PhabricatorRepo(ctx context.Context, args *struct {

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
@@ -74,7 +74,7 @@ func TestRepository(t *testing.T) {
 }
 
 func TestResolverTo(t *testing.T) {
-	db := new(dbtesting.MockDB)
+	db := dbmock.NewMockDB()
 	// This test exists purely to remove some non determinism in our tests
 	// run. The To* resolvers are stored in a map in our graphql
 	// implementation => the order we call them is non deterministic =>
@@ -84,7 +84,7 @@ func TestResolverTo(t *testing.T) {
 		&GitTreeEntryResolver{db: db},
 		&NamespaceResolver{},
 		&NodeResolver{},
-		&RepositoryResolver{db: database.NewDB(db)},
+		&RepositoryResolver{db: db},
 		&CommitSearchResultResolver{},
 		&gitRevSpec{},
 		&repositorySuggestionResolver{},

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -49,7 +49,7 @@ func BenchmarkPrometheusFieldName(b *testing.B) {
 }
 
 func TestRepository(t *testing.T) {
-	db := database.NewDB(nil)
+	db := dbmock.NewMockDB()
 	resetMocks()
 	database.Mocks.Repos.MockGetByName(t, "github.com/gorilla/mux", 2)
 	RunTests(t, []*Test{
@@ -233,7 +233,7 @@ func TestAffiliatedRepositories(t *testing.T) {
 	RunTests(t, []*Test{
 		{
 			Context: ctx,
-			Schema:  mustParseGraphQLSchema(t, database.NewDB(nil)),
+			Schema:  mustParseGraphQLSchema(t, dbmock.NewMockDB()),
 			Query: `
 			{
 				affiliatedRepositories(
@@ -282,7 +282,7 @@ func TestAffiliatedRepositories(t *testing.T) {
 	RunTests(t, []*Test{
 		{
 			Context: ctx,
-			Schema:  mustParseGraphQLSchema(t, database.NewDB(nil)),
+			Schema:  mustParseGraphQLSchema(t, dbmock.NewMockDB()),
 			Query: `
 			{
 				affiliatedRepositories(
@@ -335,7 +335,7 @@ func TestAffiliatedRepositories(t *testing.T) {
 	RunTests(t, []*Test{
 		{
 			Context: ctx,
-			Schema:  mustParseGraphQLSchema(t, database.NewDB(nil)),
+			Schema:  mustParseGraphQLSchema(t, dbmock.NewMockDB()),
 			Query: `
 			{
 				affiliatedRepositories(
@@ -391,7 +391,7 @@ func TestAffiliatedRepositories(t *testing.T) {
 	RunTests(t, []*Test{
 		{
 			Context: ctx,
-			Schema:  mustParseGraphQLSchema(t, database.NewDB(nil)),
+			Schema:  mustParseGraphQLSchema(t, dbmock.NewMockDB()),
 			Query: `
 			{
 				affiliatedRepositories(

--- a/cmd/frontend/graphqlbackend/hunk.go
+++ b/cmd/frontend/graphqlbackend/hunk.go
@@ -4,12 +4,11 @@ import (
 	"context"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
 type hunkResolver struct {
-	db   dbutil.DB
+	db   database.DB
 	repo *RepositoryResolver
 	hunk *git.Hunk
 }
@@ -50,7 +49,7 @@ func (r *hunkResolver) Message() string {
 }
 
 func (r *hunkResolver) Commit(ctx context.Context) (*GitCommitResolver, error) {
-	return toGitCommitResolver(r.repo, database.NewDB(r.db), r.hunk.CommitID, nil), nil
+	return toGitCommitResolver(r.repo, r.db, r.hunk.CommitID, nil), nil
 }
 
 func (r *hunkResolver) Filename() string {

--- a/cmd/frontend/graphqlbackend/hunk.go
+++ b/cmd/frontend/graphqlbackend/hunk.go
@@ -3,6 +3,7 @@ package graphqlbackend
 import (
 	"context"
 
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
@@ -49,7 +50,7 @@ func (r *hunkResolver) Message() string {
 }
 
 func (r *hunkResolver) Commit(ctx context.Context) (*GitCommitResolver, error) {
-	return toGitCommitResolver(r.repo, r.db, r.hunk.CommitID, nil), nil
+	return toGitCommitResolver(r.repo, database.NewDB(r.db), r.hunk.CommitID, nil), nil
 }
 
 func (r *hunkResolver) Filename() string {

--- a/cmd/frontend/graphqlbackend/org_invitation.go
+++ b/cmd/frontend/graphqlbackend/org_invitation.go
@@ -7,16 +7,15 @@ import (
 	"github.com/graph-gophers/graphql-go/relay"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 // organizationInvitationResolver implements the GraphQL type OrganizationInvitation.
 type organizationInvitationResolver struct {
-	db dbutil.DB
+	db database.DB
 	v  *database.OrgInvitation
 }
 
-func orgInvitationByID(ctx context.Context, db dbutil.DB, id graphql.ID) (*organizationInvitationResolver, error) {
+func orgInvitationByID(ctx context.Context, db database.DB, id graphql.ID) (*organizationInvitationResolver, error) {
 	orgInvitationID, err := unmarshalOrgInvitationID(id)
 	if err != nil {
 		return nil, err
@@ -24,7 +23,7 @@ func orgInvitationByID(ctx context.Context, db dbutil.DB, id graphql.ID) (*organ
 	return orgInvitationByIDInt64(ctx, db, orgInvitationID)
 }
 
-func orgInvitationByIDInt64(ctx context.Context, db dbutil.DB, id int64) (*organizationInvitationResolver, error) {
+func orgInvitationByIDInt64(ctx context.Context, db database.DB, id int64) (*organizationInvitationResolver, error) {
 	orgInvitation, err := database.OrgInvitations(db).GetByID(ctx, id)
 	if err != nil {
 		return nil, err
@@ -44,15 +43,15 @@ func unmarshalOrgInvitationID(id graphql.ID) (orgInvitationID int64, err error) 
 }
 
 func (r *organizationInvitationResolver) Organization(ctx context.Context) (*OrgResolver, error) {
-	return OrgByIDInt32(ctx, database.NewDB(r.db), r.v.OrgID)
+	return OrgByIDInt32(ctx, r.db, r.v.OrgID)
 }
 
 func (r *organizationInvitationResolver) Sender(ctx context.Context) (*UserResolver, error) {
-	return UserByIDInt32(ctx, database.NewDB(r.db), r.v.SenderUserID)
+	return UserByIDInt32(ctx, r.db, r.v.SenderUserID)
 }
 
 func (r *organizationInvitationResolver) Recipient(ctx context.Context) (*UserResolver, error) {
-	return UserByIDInt32(ctx, database.NewDB(r.db), r.v.RecipientUserID)
+	return UserByIDInt32(ctx, r.db, r.v.RecipientUserID)
 }
 func (r *organizationInvitationResolver) CreatedAt() DateTime { return DateTime{Time: r.v.CreatedAt} }
 func (r *organizationInvitationResolver) NotifiedAt() *DateTime {

--- a/cmd/frontend/graphqlbackend/orgs.go
+++ b/cmd/frontend/graphqlbackend/orgs.go
@@ -6,7 +6,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 func (r *schemaResolver) Organizations(args *struct {
@@ -22,13 +21,13 @@ func (r *schemaResolver) Organizations(args *struct {
 }
 
 type orgConnectionResolver struct {
-	db  dbutil.DB
+	db  database.DB
 	opt database.OrgsListOptions
 }
 
 func (r *orgConnectionResolver) Nodes(ctx context.Context) ([]*OrgResolver, error) {
 	// 🚨 SECURITY: Only site admins can list organisations.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, database.NewDB(r.db)); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 
@@ -40,7 +39,7 @@ func (r *orgConnectionResolver) Nodes(ctx context.Context) ([]*OrgResolver, erro
 	var l []*OrgResolver
 	for _, org := range orgs {
 		l = append(l, &OrgResolver{
-			db:  database.NewDB(r.db),
+			db:  r.db,
 			org: org,
 		})
 	}
@@ -49,7 +48,7 @@ func (r *orgConnectionResolver) Nodes(ctx context.Context) ([]*OrgResolver, erro
 
 func (r *orgConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
 	// 🚨 SECURITY: Only site admins can count organisations.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, database.NewDB(r.db)); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return 0, err
 	}
 

--- a/cmd/frontend/graphqlbackend/person.go
+++ b/cmd/frontend/graphqlbackend/person.go
@@ -6,13 +6,12 @@ import (
 	"sync"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 type PersonResolver struct {
-	db    dbutil.DB
+	db    database.DB
 	name  string
 	email string
 
@@ -25,7 +24,7 @@ type PersonResolver struct {
 	err  error
 }
 
-func NewPersonResolver(db dbutil.DB, name, email string, includeUserInfo bool) *PersonResolver {
+func NewPersonResolver(db database.DB, name, email string, includeUserInfo bool) *PersonResolver {
 	return &PersonResolver{
 		db:              db,
 		name:            name,
@@ -99,5 +98,5 @@ func (r *PersonResolver) User(ctx context.Context) (*UserResolver, error) {
 	if user == nil || err != nil {
 		return nil, err
 	}
-	return NewUserResolver(database.NewDB(r.db), user), nil
+	return NewUserResolver(r.db, user), nil
 }

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/externallink"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/phabricator"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -505,7 +504,7 @@ func (r *schemaResolver) ResolvePhabricatorDiff(ctx context.Context, args *struc
 	return getCommit()
 }
 
-func makePhabClientForOrigin(ctx context.Context, db dbutil.DB, origin string) (*phabricator.Client, error) {
+func makePhabClientForOrigin(ctx context.Context, db database.DB, origin string) (*phabricator.Client, error) {
 	opt := database.ExternalServicesListOptions{
 		Kinds: []string{extsvc.KindPhabricator},
 		LimitOffset: &database.LimitOffset{
@@ -513,7 +512,7 @@ func makePhabClientForOrigin(ctx context.Context, db dbutil.DB, origin string) (
 		},
 	}
 	for {
-		svcs, err := database.ExternalServices(db).List(ctx, opt)
+		svcs, err := db.ExternalServices().List(ctx, opt)
 		if err != nil {
 			return nil, errors.Wrap(err, "list")
 		}

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -184,7 +184,7 @@ func (r *RepositoryComparisonResolver) FileDiffs(ctx context.Context, args *File
 // RepositoryComparisonResolver to produce the new file in a FileDiffResolver.
 func repositoryComparisonNewFile(db dbutil.DB, r *FileDiffResolver) FileResolver {
 	return &GitTreeEntryResolver{
-		db:     db,
+		db:     database.NewDB(db),
 		commit: r.Head,
 		stat:   CreateFileInfo(r.FileDiff.NewName, false),
 	}
@@ -413,7 +413,7 @@ func (r *FileDiffResolver) OldFile() FileResolver {
 		return nil
 	}
 	return &GitTreeEntryResolver{
-		db:     r.db,
+		db:     database.NewDB(r.db),
 		commit: r.Base,
 		stat:   CreateFileInfo(r.FileDiff.OrigName, false),
 	}

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/highlight"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
@@ -89,7 +90,7 @@ func NewRepositoryComparison(ctx context.Context, db dbutil.DB, r *RepositoryRes
 			return nil, err
 		}
 
-		return toGitCommitResolver(r, db, commitID, nil), nil
+		return toGitCommitResolver(r, database.NewDB(db), commitID, nil), nil
 	}
 
 	head, err := getCommit(ctx, r.RepoName(), headRevspec)

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -162,7 +162,7 @@ func (r *RepositoryComparisonResolver) Commits(
 	args *graphqlutil.ConnectionArgs,
 ) *gitCommitConnectionResolver {
 	return &gitCommitConnectionResolver{
-		db:            r.db,
+		db:            database.NewDB(r.db),
 		revisionRange: r.baseRevspec + ".." + r.headRevspec,
 		first:         args.First,
 		repo:          r.repo,

--- a/cmd/frontend/graphqlbackend/repository_contributor.go
+++ b/cmd/frontend/graphqlbackend/repository_contributor.go
@@ -2,11 +2,10 @@ package graphqlbackend
 
 import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 type repositoryContributorResolver struct {
-	db    dbutil.DB
+	db    database.DB
 	name  string
 	email string
 	count int32
@@ -31,7 +30,7 @@ func (r *repositoryContributorResolver) Commits(args *struct {
 		revisionRange = *r.args.RevisionRange
 	}
 	return &gitCommitConnectionResolver{
-		db:            database.NewDB(r.db),
+		db:            r.db,
 		revisionRange: revisionRange,
 		path:          r.args.Path,
 		author:        &r.email, // TODO(sqs): support when contributor resolves to user, and user has multiple emails

--- a/cmd/frontend/graphqlbackend/repository_contributor.go
+++ b/cmd/frontend/graphqlbackend/repository_contributor.go
@@ -1,6 +1,9 @@
 package graphqlbackend
 
-import "github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+import (
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+)
 
 type repositoryContributorResolver struct {
 	db    dbutil.DB
@@ -28,7 +31,7 @@ func (r *repositoryContributorResolver) Commits(args *struct {
 		revisionRange = *r.args.RevisionRange
 	}
 	return &gitCommitConnectionResolver{
-		db:            r.db,
+		db:            database.NewDB(r.db),
 		revisionRange: revisionRange,
 		path:          r.args.Path,
 		author:        &r.email, // TODO(sqs): support when contributor resolves to user, and user has multiple emails

--- a/cmd/frontend/graphqlbackend/repository_contributors.go
+++ b/cmd/frontend/graphqlbackend/repository_contributors.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
@@ -70,7 +71,7 @@ func (r *repositoryContributorConnectionResolver) Nodes(ctx context.Context) ([]
 	resolvers := make([]*repositoryContributorResolver, len(results))
 	for i, contributor := range results {
 		resolvers[i] = &repositoryContributorResolver{
-			db:    r.db,
+			db:    database.NewDB(r.db),
 			name:  contributor.Name,
 			email: contributor.Email,
 			count: contributor.Count,

--- a/cmd/frontend/graphqlbackend/repository_contributors.go
+++ b/cmd/frontend/graphqlbackend/repository_contributors.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
@@ -29,7 +28,7 @@ func (r *RepositoryResolver) Contributors(args *struct {
 }
 
 type repositoryContributorConnectionResolver struct {
-	db    dbutil.DB
+	db    database.DB
 	args  repositoryContributorsArgs
 	first *int32
 
@@ -71,7 +70,7 @@ func (r *repositoryContributorConnectionResolver) Nodes(ctx context.Context) ([]
 	resolvers := make([]*repositoryContributorResolver, len(results))
 	for i, contributor := range results {
 		resolvers[i] = &repositoryContributorResolver{
-			db:    database.NewDB(r.db),
+			db:    r.db,
 			name:  contributor.Name,
 			email: contributor.Email,
 			count: contributor.Count,

--- a/cmd/frontend/graphqlbackend/settings_cascade.go
+++ b/cmd/frontend/graphqlbackend/settings_cascade.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -23,7 +22,7 @@ import (
 // - Organization settings
 // - Current user settings
 type settingsCascade struct {
-	db dbutil.DB
+	db database.DB
 	// At most 1 of these fields is set.
 	unauthenticatedActor bool
 	subject              *settingsSubject
@@ -36,7 +35,7 @@ func (r *settingsCascade) Subjects(ctx context.Context) ([]*settingsSubject, err
 		return mockSettingsCascadeSubjects()
 	}
 
-	subjects := []*settingsSubject{{defaultSettings: &defaultSettingsResolver{db: r.db, gqlID: singletonDefaultSettingsGQLID}}, {site: &siteResolver{db: database.NewDB(r.db), gqlID: singletonSiteGQLID}}}
+	subjects := []*settingsSubject{{defaultSettings: &defaultSettingsResolver{db: r.db, gqlID: singletonDefaultSettingsGQLID}}, {site: &siteResolver{db: r.db, gqlID: singletonSiteGQLID}}}
 
 	if r.unauthenticatedActor {
 		return subjects, nil
@@ -50,7 +49,7 @@ func (r *settingsCascade) Subjects(ctx context.Context) ([]*settingsSubject, err
 		subjects = append(subjects, r.subject)
 
 	case r.subject.user != nil:
-		orgs, err := database.Orgs(r.db).GetByUserID(ctx, r.subject.user.user.ID)
+		orgs, err := r.db.Orgs().GetByUserID(ctx, r.subject.user.user.ID)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/settings_cascade.go
+++ b/cmd/frontend/graphqlbackend/settings_cascade.go
@@ -59,7 +59,7 @@ func (r *settingsCascade) Subjects(ctx context.Context) ([]*settingsSubject, err
 		})
 		// Apply the user's orgs' settings.
 		for _, org := range orgs {
-			subjects = append(subjects, &settingsSubject{org: &OrgResolver{db: database.NewDB(r.db), org: org}})
+			subjects = append(subjects, &settingsSubject{org: &OrgResolver{db: r.db, org: org}})
 		}
 		// Apply the user's own settings last (it has highest priority).
 		subjects = append(subjects, r.subject)

--- a/cmd/frontend/graphqlbackend/settings_cascade_test.go
+++ b/cmd/frontend/graphqlbackend/settings_cascade_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -180,9 +180,8 @@ func TestMergeSettings(t *testing.T) {
 }
 
 func TestSubjects(t *testing.T) {
-	db := new(dbtesting.MockDB)
 	t.Run("Default settings are included", func(t *testing.T) {
-		cascade := &settingsCascade{db: db, unauthenticatedActor: true}
+		cascade := &settingsCascade{db: dbmock.NewMockDB(), unauthenticatedActor: true}
 		subjects, err := cascade.Subjects(context.Background())
 		if err != nil {
 			t.Fatal(err)

--- a/cmd/frontend/graphqlbackend/signature.go
+++ b/cmd/frontend/graphqlbackend/signature.go
@@ -3,7 +3,7 @@ package graphqlbackend
 import (
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
 )
 
@@ -20,7 +20,7 @@ func (r signatureResolver) Date() string {
 	return r.date.Format(time.RFC3339)
 }
 
-func toSignatureResolver(db dbutil.DB, sig *gitapi.Signature, includeUserInfo bool) *signatureResolver {
+func toSignatureResolver(db database.DB, sig *gitapi.Signature, includeUserInfo bool) *signatureResolver {
 	if sig == nil {
 		return nil
 	}

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -7,7 +7,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/symbol"
 )
@@ -92,7 +91,7 @@ func (r *symbolConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.P
 }
 
 type symbolResolver struct {
-	db     dbutil.DB
+	db     database.DB
 	commit *GitCommitResolver
 	*result.SymbolMatch
 }

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/symbol"
@@ -50,7 +51,7 @@ func (r *GitCommitResolver) Symbols(ctx context.Context, args *symbolsArgs) (*sy
 	}, nil
 }
 
-func symbolResultsToResolvers(db dbutil.DB, commit *GitCommitResolver, symbols []*result.SymbolMatch) []symbolResolver {
+func symbolResultsToResolvers(db database.DB, commit *GitCommitResolver, symbols []*result.SymbolMatch) []symbolResolver {
 	symbolResolvers := make([]symbolResolver, 0, len(symbols))
 	for _, symbol := range symbols {
 		symbolResolvers = append(symbolResolvers, toSymbolResolver(db, commit, symbol))
@@ -58,7 +59,7 @@ func symbolResultsToResolvers(db dbutil.DB, commit *GitCommitResolver, symbols [
 	return symbolResolvers
 }
 
-func toSymbolResolver(db dbutil.DB, commit *GitCommitResolver, sr *result.SymbolMatch) symbolResolver {
+func toSymbolResolver(db database.DB, commit *GitCommitResolver, sr *result.SymbolMatch) symbolResolver {
 	return symbolResolver{
 		db:          db,
 		commit:      commit,

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -500,7 +500,7 @@ func (r *UserResolver) PublicRepositories(ctx context.Context) ([]*RepositoryRes
 				ID:   repo.RepoID,
 				Name: api.RepoName(repo.RepoURI),
 			},
-			db: database.NewDB(r.db),
+			db: r.db,
 			innerRepo: &types.Repo{
 				ID: repo.RepoID,
 			},

--- a/cmd/frontend/internal/app/editor.go
+++ b/cmd/frontend/internal/app/editor.go
@@ -17,7 +17,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cloneurls"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 func editorRev(ctx context.Context, repoName api.RepoName, rev string, beExplicit bool) (string, error) {

--- a/cmd/frontend/internal/app/editor.go
+++ b/cmd/frontend/internal/app/editor.go
@@ -55,7 +55,7 @@ func editorRev(ctx context.Context, repoName api.RepoName, rev string, beExplici
 
 // editorRequest represents the parameters to a Sourcegraph "open file", "search", etc. editor request.
 type editorRequest struct {
-	db dbutil.DB
+	db database.DB
 
 	// Fields that are required in all requests.
 	editor  string // editor name, e.g. "Atom", "Sublime", etc.
@@ -123,7 +123,7 @@ func (r *editorRequest) searchRedirect(ctx context.Context) (string, error) {
 	var repoFilter string
 	if s.remoteURL != "" {
 		// Search in this repository.
-		repoName, err := cloneurls.ReposourceCloneURLToRepoName(ctx, database.NewDB(r.db), s.remoteURL)
+		repoName, err := cloneurls.ReposourceCloneURLToRepoName(ctx, r.db, s.remoteURL)
 		if err != nil {
 			return "", err
 		}
@@ -175,7 +175,7 @@ func (r *editorRequest) searchRedirect(ctx context.Context) (string, error) {
 func (r *editorRequest) openFileRedirect(ctx context.Context) (string, error) {
 	of := r.openFileRequest
 	// Determine the repo name and branch.
-	repoName, err := cloneurls.ReposourceCloneURLToRepoName(ctx, database.NewDB(r.db), of.remoteURL)
+	repoName, err := cloneurls.ReposourceCloneURLToRepoName(ctx, r.db, of.remoteURL)
 	if err != nil {
 		return "", err
 	}
@@ -217,7 +217,7 @@ func (r *editorRequest) redirectURL(ctx context.Context) (string, error) {
 }
 
 // parseEditorRequest parses an editor request from the search query values.
-func parseEditorRequest(db dbutil.DB, q url.Values) (*editorRequest, error) {
+func parseEditorRequest(db database.DB, q url.Values) (*editorRequest, error) {
 	v := &editorRequest{
 		db:                db,
 		editor:            q.Get("editor"),
@@ -271,7 +271,7 @@ func parseEditorRequest(db dbutil.DB, q url.Values) (*editorRequest, error) {
 	return v, nil
 }
 
-func serveEditor(db dbutil.DB) func(w http.ResponseWriter, r *http.Request) error {
+func serveEditor(db database.DB) func(w http.ResponseWriter, r *http.Request) error {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		editorRequest, err := parseEditorRequest(db, r.URL.Query())
 		if err != nil {

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -285,7 +285,7 @@ func initRouter(db database.DB, router *mux.Router, codeIntelResolver graphqlbac
 	}, nil, index)))
 
 	// streaming search
-	router.Get(routeSearchStream).Handler(search.StreamHandler(database.NewDB(db)))
+	router.Get(routeSearchStream).Handler(search.StreamHandler(db))
 
 	// search badge
 	router.Get(routeSearchBadge).Handler(searchBadgeHandler())

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -153,7 +153,7 @@ func NewInternalHandler(m *mux.Router, db database.DB, schema *graphql.Schema, n
 	m.Get(apirouter.GraphQL).Handler(trace.Route(handler(serveGraphQL(schema, rateLimitWatcher, true))))
 	m.Get(apirouter.Configuration).Handler(trace.Route(handler(serveConfiguration)))
 	m.Path("/ping").Methods("GET").Name("ping").HandlerFunc(handlePing)
-	m.Get(apirouter.StreamingSearch).Handler(trace.Route(frontendsearch.StreamHandler(database.NewDB(db))))
+	m.Get(apirouter.StreamingSearch).Handler(trace.Route(frontendsearch.StreamHandler(db)))
 
 	m.Get(apirouter.LSIFUpload).Handler(trace.Route(newCodeIntelUploadHandler(true)))
 

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -281,7 +281,7 @@ LOOP:
 func (h *streamHandler) startSearch(ctx context.Context, a *args) (events <-chan streaming.SearchEvent, inputs run.SearchInputs, results func() (*graphqlbackend.SearchResultsResolver, error)) {
 	eventsC := make(chan streaming.SearchEvent)
 
-	search, err := h.newSearchResolver(ctx, database.NewDB(h.db), &graphqlbackend.SearchArgs{
+	search, err := h.newSearchResolver(ctx, h.db, &graphqlbackend.SearchArgs{
 		Query:       a.Query,
 		Version:     a.Version,
 		PatternType: strPtr(a.PatternType),

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
@@ -246,7 +246,7 @@ func (r *changesetResolver) Author() (*graphqlbackend.PersonResolver, error) {
 	}
 
 	return graphqlbackend.NewPersonResolver(
-		r.store.DB(),
+		r.store.DatabaseDB(),
 		name,
 		email,
 		// Try to find the corresponding Sourcegraph user.

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec.go
@@ -203,7 +203,7 @@ type gitCommitDescriptionResolver struct {
 
 func (r *gitCommitDescriptionResolver) Author() *graphqlbackend.PersonResolver {
 	return graphqlbackend.NewPersonResolver(
-		r.store.DB(),
+		r.store.DatabaseDB(),
 		r.authorName,
 		r.authorEmail,
 		// Try to find the corresponding Sourcegraph user.

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations.go
@@ -29,7 +29,7 @@ import (
 type CachedLocationResolver struct {
 	sync.RWMutex
 	children map[api.RepoID]*cachedRepositoryResolver
-	db       dbutil.DB
+	db       database.DB
 }
 
 type cachedRepositoryResolver struct {
@@ -47,7 +47,7 @@ type cachedCommitResolver struct {
 // NewCachedLocationResolver creates a location resolver with an empty cache.
 func NewCachedLocationResolver(db dbutil.DB) *CachedLocationResolver {
 	return &CachedLocationResolver{
-		db:       db,
+		db:       database.NewDB(db),
 		children: map[api.RepoID]*cachedRepositoryResolver{},
 	}
 }
@@ -214,7 +214,7 @@ func (r *CachedLocationResolver) resolveRepository(ctx context.Context, id api.R
 		return nil, err
 	}
 
-	return gql.NewRepositoryResolver(database.NewDB(r.db), repo), nil
+	return gql.NewRepositoryResolver(r.db, repo), nil
 }
 
 // Commit resolves the git commit with the given repository resolver and commit hash. This method may


### PR DESCRIPTION
This PR is me looking for uses of `database.NewDB()` and removes
them by propagating down a `database.DB` from a parent context. 
We can do this because, almost everywhere, there is a `database.DB`
_somewhere_ in the calling path because we've removed most globals.

The changes are very mechanical. There are many commits just so 
I could keep things incremental.
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
