### PR TITLE
insights: delete insight mutation

### DIFF
--- a/cmd/frontend/graphqlbackend/insights.go
+++ b/cmd/frontend/graphqlbackend/insights.go
@@ -29,6 +29,8 @@ type InsightsResolver interface {
 	CreateLineChartSearchInsight(ctx context.Context, args *CreateLineChartSearchInsightArgs) (InsightViewPayloadResolver, error)
 	UpdateLineChartSearchInsight(ctx context.Context, args *UpdateLineChartSearchInsightArgs) (InsightViewPayloadResolver, error)
 
+	DeleteInsightView(ctx context.Context, args *DeleteInsightViewArgs) (*EmptyResponse, error)
+
 	// Admin Management
 	UpdateInsightSeries(ctx context.Context, args *UpdateInsightSeriesArgs) (InsightSeriesMetadataPayloadResolver, error)
 	InsightSeriesQueryStatus(ctx context.Context) ([]InsightSeriesQueryStatusResolver, error)
@@ -322,4 +324,8 @@ type InsightViewQueryArgs struct {
 	After   *string
 	Id      *graphql.ID
 	Filters *InsightViewFiltersInput
+}
+
+type DeleteInsightViewArgs struct {
+	Id graphql.ID
 }

--- a/cmd/frontend/graphqlbackend/insights.graphql
+++ b/cmd/frontend/graphqlbackend/insights.graphql
@@ -709,6 +709,8 @@ extend type Mutation {
     Update a line chart backed by search insights.
     """
     updateLineChartSearchInsight(id: ID!, input: UpdateLineChartSearchInsightInput!): InsightViewPayload!
+
+    deleteInsightView(id: ID!): EmptyResponse!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/insights.graphql
+++ b/cmd/frontend/graphqlbackend/insights.graphql
@@ -710,6 +710,9 @@ extend type Mutation {
     """
     updateLineChartSearchInsight(id: ID!, input: UpdateLineChartSearchInsightInput!): InsightViewPayload!
 
+    """
+    Delete an insight view given the graphql ID.
+    """
     deleteInsightView(id: ID!): EmptyResponse!
 }
 

--- a/enterprise/internal/insights/resolvers/disabled_resolver.go
+++ b/enterprise/internal/insights/resolvers/disabled_resolver.go
@@ -63,3 +63,7 @@ func (r *disabledResolver) UpdateLineChartSearchInsight(ctx context.Context, arg
 func (r *disabledResolver) InsightViews(ctx context.Context, args *graphqlbackend.InsightViewQueryArgs) (graphqlbackend.InsightViewConnectionResolver, error) {
 	return nil, errors.New(r.reason)
 }
+
+func (r *disabledResolver) DeleteInsightView(ctx context.Context, args *graphqlbackend.DeleteInsightViewArgs) (*graphqlbackend.EmptyResponse, error) {
+	return nil, errors.New(r.reason)
+}

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -573,3 +573,24 @@ func getExistingSeriesRepositories(seriesId string, existingSeries []types.Insig
 	}
 	return nil
 }
+
+func (r *Resolver) DeleteInsightView(ctx context.Context, args *graphqlbackend.DeleteInsightViewArgs) (*graphqlbackend.EmptyResponse, error) {
+	var viewId string
+	err := relay.UnmarshalSpec(args.Id, &viewId)
+	if err != nil {
+		return nil, errors.Wrap(err, "error unmarshalling the insight view id")
+	}
+
+	validator := InsightPermissionsValidator{baseInsightResolver: r.baseInsightResolver}
+	err = validator.validateUserAccessForView(ctx, viewId)
+	if err != nil {
+		return nil, err
+	}
+
+	err = r.insightStore.DeleteViewByUniqueID(ctx, viewId)
+	if err != nil {
+		return nil, errors.Wrap(err, "DeleteView")
+	}
+
+	return &graphqlbackend.EmptyResponse{}, nil
+}

--- a/enterprise/internal/insights/resolvers/validator.go
+++ b/enterprise/internal/insights/resolvers/validator.go
@@ -1,0 +1,54 @@
+package resolvers
+
+import (
+	"context"
+	"sync"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
+
+	"github.com/cockroachdb/errors"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+)
+
+type InsightPermissionsValidator struct {
+	baseInsightResolver
+
+	once    sync.Once
+	userIds []int
+	orgIds  []int
+	err     error
+}
+
+func (v *InsightPermissionsValidator) loadUserContext(ctx context.Context) error {
+	v.once.Do(func() {
+		userIds, orgIds, err := getUserPermissions(ctx, database.Orgs(v.postgresDB))
+		if err != nil {
+			v.err = errors.Wrap(err, "unable to load user permissions context")
+			return
+		}
+		v.userIds = userIds
+		v.orgIds = orgIds
+	})
+
+	return v.err
+}
+
+func (v *InsightPermissionsValidator) validateUserAccessForView(ctx context.Context, insightId string) error {
+	err := v.loadUserContext(ctx)
+	if err != nil {
+		return err
+	}
+	results, err := v.insightStore.GetAll(ctx, store.InsightQueryArgs{UniqueID: insightId, UserID: v.userIds, OrgID: v.orgIds})
+	if err != nil {
+		return errors.Wrap(err, "GetAll")
+	}
+	// 🚨 SECURITY: if the user context doesn't get any response here that means they cannot see the insight.
+	// The important assumption is that the store is returning only insights visible to the user, as well as the assumption
+	// that there is no split between viewers / editors. We will return a generic not found error to prevent leaking
+	// insight existence.
+	if len(results) == 0 {
+		return errors.New("insight not found")
+	}
+
+	return nil
+}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/27208

Adds a mutation to delete insight views. Includes a small refactor to add some reusability / cached calls for checking insight view permissions.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
