### PR TITLE
Revert "codeintel: downgrade lsif-go to 1.6.7 to avoid OOMing"

### DIFF
--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -6,7 +6,7 @@ jobs:
     # Skip running on forks
     if: github.repository == 'sourcegraph/sourcegraph'
     runs-on: ubuntu-latest
-    container: sourcegraph/lsif-go:v1.6.7 # v1.7.0 OOMs, see https://github.com/sourcegraph/sourcegraph/pull/27213
+    container: sourcegraph/lsif-go
     strategy:
       matrix:
         root:


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#27213 now that lsif-go skips loading dependencies by default https://github.com/sourcegraph/lsif-go/pull/212 and its memory usage should be back down to what it was in v1.6.7.