### PR TITLE
batches: only show "Create" if user can create in namespace

### DIFF
--- a/client/web/src/enterprise/batches/global/GlobalBatchChangesArea.tsx
+++ b/client/web/src/enterprise/batches/global/GlobalBatchChangesArea.tsx
@@ -85,7 +85,9 @@ export const AuthenticatedBatchChangesArea = withAuthenticatedUser<Authenticated
     <div className="w-100">
         <Switch>
             <Route
-                render={props => <BatchChangeListPage headingElement="h1" {...outerProps} {...props} />}
+                render={props => (
+                    <BatchChangeListPage headingElement="h1" canCreate={true} {...outerProps} {...props} />
+                )}
                 path={match.url}
                 exact={true}
             />

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.story.tsx
@@ -36,6 +36,7 @@ add('List of batch changes', () => (
             <BatchChangeListPage
                 {...props}
                 headingElement="h1"
+                canCreate={true}
                 queryBatchChanges={queryBatchChanges}
                 areBatchChangesLicensed={batchChangesLicensed}
             />
@@ -49,6 +50,7 @@ add('Licensing not enforced', () => (
             <BatchChangeListPage
                 {...props}
                 headingElement="h1"
+                canCreate={true}
                 queryBatchChanges={queryBatchChanges}
                 areBatchChangesLicensed={batchChangesNotLicensed}
             />
@@ -78,6 +80,7 @@ add('No batch changes', () => {
                 <BatchChangeListPage
                     {...props}
                     headingElement="h1"
+                    canCreate={true}
                     queryBatchChanges={queryBatchChanges}
                     areBatchChangesLicensed={batchChangesLicensed}
                 />
@@ -86,33 +89,45 @@ add('No batch changes', () => {
     )
 })
 
-add('All batch changes tab empty', () => {
-    const queryBatchChanges = useCallback(
-        () =>
-            of({
-                batchChanges: {
-                    totalCount: 0,
-                    nodes: [],
-                    pageInfo: {
-                        endCursor: null,
-                        hasNextPage: false,
-                    },
-                },
-                totalCount: 0,
-            }),
-        []
-    )
-    return (
-        <WebStory>
-            {props => (
-                <BatchChangeListPage
-                    {...props}
-                    headingElement="h1"
-                    queryBatchChanges={queryBatchChanges}
-                    areBatchChangesLicensed={batchChangesLicensed}
-                    openTab="batchChanges"
-                />
-            )}
-        </WebStory>
-    )
-})
+const QUERY_NO_BATCH_CHANGES = () =>
+    of({
+        batchChanges: {
+            totalCount: 0,
+            nodes: [],
+            pageInfo: {
+                endCursor: null,
+                hasNextPage: false,
+            },
+        },
+        totalCount: 0,
+    })
+
+add('All batch changes tab empty', () => (
+    <WebStory>
+        {props => (
+            <BatchChangeListPage
+                {...props}
+                headingElement="h1"
+                canCreate={true}
+                queryBatchChanges={QUERY_NO_BATCH_CHANGES}
+                areBatchChangesLicensed={batchChangesLicensed}
+                openTab="batchChanges"
+            />
+        )}
+    </WebStory>
+))
+
+add('All batch changes tab empty, cannot create', () => (
+    <WebStory>
+        {props => (
+            <BatchChangeListPage
+                {...props}
+                headingElement="h1"
+                canCreate={false}
+                queryBatchChanges={QUERY_NO_BATCH_CHANGES}
+                areBatchChangesLicensed={batchChangesLicensed}
+                openTab="batchChanges"
+            />
+        )}
+    </WebStory>
+))


### PR DESCRIPTION
Small enhancement to the namespace batch changes list page so that the "Create" button is hidden from the header (and empty list view) if either:
- it's a user namespace, and you are not that user
- it's an organization namespace, and you do not belong to that organization
