### PR TITLE
insights: return pie chart insights with their own presentation options

### DIFF
--- a/cmd/frontend/graphqlbackend/insights.go
+++ b/cmd/frontend/graphqlbackend/insights.go
@@ -153,6 +153,7 @@ type InsightViewResolver interface {
 	DefaultFilters(ctx context.Context) (InsightViewFiltersResolver, error)
 	AppliedFilters(ctx context.Context) (InsightViewFiltersResolver, error)
 	DataSeries(ctx context.Context) ([]InsightSeriesResolver, error)
+	PresentationType(ctx context.Context) (string, error)
 	Presentation(ctx context.Context) (InsightPresentation, error)
 	DataSeriesDefinitions(ctx context.Context) ([]InsightDataSeriesDefinition, error)
 }
@@ -164,6 +165,11 @@ type InsightDataSeriesDefinition interface {
 type LineChartInsightViewPresentation interface {
 	Title(ctx context.Context) (string, error)
 	SeriesPresentation(ctx context.Context) ([]LineChartDataSeriesPresentationResolver, error)
+}
+
+type PieChartInsightViewPresentation interface {
+	Title(ctx context.Context) (string, error)
+	OtherThreshold(ctx context.Context) (float64, error)
 }
 
 type LineChartDataSeriesPresentationResolver interface {
@@ -181,6 +187,7 @@ type SearchInsightDataSeriesDefinitionResolver interface {
 
 type InsightPresentation interface {
 	ToLineChartInsightViewPresentation() (LineChartInsightViewPresentation, bool)
+	ToPieChartInsightViewPresentation() (PieChartInsightViewPresentation, bool)
 }
 
 type InsightTimeScope interface {

--- a/cmd/frontend/graphqlbackend/insights.graphql
+++ b/cmd/frontend/graphqlbackend/insights.graphql
@@ -744,11 +744,6 @@ type InsightView implements Node {
     dataSeries: [InsightsSeries!]!
 
     """
-    Presentation type for the insight. (e.g. line, pie, etc.)
-    """
-    presentationType: PresentationType!
-
-    """
     Presentation options for the insight.
     """
     presentation: InsightPresentation!
@@ -768,14 +763,6 @@ union InsightDataSeriesDefinition = SearchInsightDataSeriesDefinition
 Defines presentation options for the insight.
 """
 union InsightPresentation = LineChartInsightViewPresentation | PieChartInsightViewPresentation
-
-"""
-Presentation types.
-"""
-enum PresentationType {
-    LINE
-    PIE
-}
 
 """
 Defines a scope of time for which the insight data is generated.

--- a/cmd/frontend/graphqlbackend/insights.graphql
+++ b/cmd/frontend/graphqlbackend/insights.graphql
@@ -662,6 +662,7 @@ input PieChartSearchInsightInput {
     The query string.
     """
     query: String!
+
     """
     The scope of repositories.
     """
@@ -681,6 +682,7 @@ input PieChartOptionsInput {
     The title for the pie chart.
     """
     title: String
+
     """
     The threshold for which groups fall into the "other category". Only categories with a percentage greater than
     this value will be separately rendered.
@@ -703,12 +705,13 @@ extend type Mutation {
     Create a line chart backed by search insights.
     """
     createLineChartSearchInsight(input: LineChartSearchInsightInput!): InsightViewPayload!
-    #    createPieChartSearchInsight(input: PieChartSearchInsightInput!): CreateInsightResult!
+    #createPieChartSearchInsight(input: PieChartSearchInsightInput!): InsightViewPayload!
 
     """
     Update a line chart backed by search insights.
     """
     updateLineChartSearchInsight(id: ID!, input: UpdateLineChartSearchInsightInput!): InsightViewPayload!
+    #updatePieChartSearchInsight(input: UpdatePieChartSearchInsightInput!): InsightViewPayload!
 }
 
 """
@@ -736,6 +739,11 @@ type InsightView implements Node {
     dataSeries: [InsightsSeries!]!
 
     """
+    Presentation type for the insight. (e.g. line, pie, etc.)
+    """
+    presentationType: PresentationType!
+
+    """
     Presentation options for the insight.
     """
     presentation: InsightPresentation!
@@ -754,8 +762,15 @@ union InsightDataSeriesDefinition = SearchInsightDataSeriesDefinition
 """
 Defines presentation options for the insight.
 """
-union InsightPresentation = LineChartInsightViewPresentation
-#    | PieChartInsightViewPresentation
+union InsightPresentation = LineChartInsightViewPresentation | PieChartInsightViewPresentation
+
+"""
+Presentation types.
+"""
+enum PresentationType {
+    LINE
+    PIE
+}
 
 """
 Defines a scope of time for which the insight data is generated.

--- a/enterprise/internal/insights/discovery/discovery.go
+++ b/enterprise/internal/insights/discovery/discovery.go
@@ -389,9 +389,10 @@ func migrateSeries(ctx context.Context, insightStore *store.InsightStore, from i
 	}
 
 	view := types.InsightView{
-		Title:       from.Title,
-		Description: from.Description,
-		UniqueID:    from.ID,
+		Title:            from.Title,
+		Description:      from.Description,
+		UniqueID:         from.ID,
+		PresentationType: string(types.Line),
 	}
 
 	if from.Filters != nil {
@@ -434,9 +435,10 @@ func migrateLangStatSeries(ctx context.Context, insightStore *store.InsightStore
 	log15.Info("insights migration: attempting to migrate insight", "unique_id", from.ID)
 
 	view := types.InsightView{
-		Title:          from.Title,
-		UniqueID:       from.ID,
-		OtherThreshold: from.OtherThreshold,
+		Title:            from.Title,
+		UniqueID:         from.ID,
+		OtherThreshold:   &from.OtherThreshold,
+		PresentationType: string(types.Pie),
 	}
 	series := types.InsightSeries{
 		SeriesID:           ksuid.New().String(),

--- a/enterprise/internal/insights/discovery/discovery.go
+++ b/enterprise/internal/insights/discovery/discovery.go
@@ -392,7 +392,7 @@ func migrateSeries(ctx context.Context, insightStore *store.InsightStore, from i
 		Title:            from.Title,
 		Description:      from.Description,
 		UniqueID:         from.ID,
-		PresentationType: string(types.Line),
+		PresentationType: types.Line,
 	}
 
 	if from.Filters != nil {
@@ -438,7 +438,7 @@ func migrateLangStatSeries(ctx context.Context, insightStore *store.InsightStore
 		Title:            from.Title,
 		UniqueID:         from.ID,
 		OtherThreshold:   &from.OtherThreshold,
-		PresentationType: string(types.Pie),
+		PresentationType: types.Pie,
 	}
 	series := types.InsightSeries{
 		SeriesID:           ksuid.New().String(),

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -99,10 +99,18 @@ func (i *insightViewResolver) DataSeries(ctx context.Context) ([]graphqlbackend.
 	return resolvers, nil
 }
 
-func (i *insightViewResolver) Presentation(ctx context.Context) (graphqlbackend.InsightPresentation, error) {
-	lineChartPresentation := &lineChartInsightViewPresentation{view: i.view}
+func (i *insightViewResolver) PresentationType(ctx context.Context) (string, error) {
+	return i.view.PresentationType, nil
+}
 
-	return &insightPresentationUnionResolver{resolver: lineChartPresentation}, nil
+func (i *insightViewResolver) Presentation(ctx context.Context) (graphqlbackend.InsightPresentation, error) {
+	if i.view.PresentationType == "PIE" {
+		pieChartPresentation := &pieChartInsightViewPresentation{view: i.view}
+		return &insightPresentationUnionResolver{resolver: pieChartPresentation}, nil
+	} else {
+		lineChartPresentation := &lineChartInsightViewPresentation{view: i.view}
+		return &insightPresentationUnionResolver{resolver: lineChartPresentation}, nil
+	}
 }
 
 func (i *insightViewResolver) DataSeriesDefinitions(ctx context.Context) ([]graphqlbackend.InsightDataSeriesDefinition, error) {
@@ -328,6 +336,22 @@ func (r *Resolver) UpdateLineChartSearchInsight(ctx context.Context, args *graph
 	return &insightPayloadResolver{baseInsightResolver: r.baseInsightResolver, viewId: insightViewId}, nil
 }
 
+type pieChartInsightViewPresentation struct {
+	view *types.Insight
+}
+
+func (p *pieChartInsightViewPresentation) Title(ctx context.Context) (string, error) {
+	return p.view.Title, nil
+}
+
+func (p *pieChartInsightViewPresentation) OtherThreshold(ctx context.Context) (float64, error) {
+	if p.view.OtherThreshold == nil {
+		log15.Warn("Returning a pie chart with no threshold set. This should never happen!", "id", p.view.UniqueID)
+		return 0, nil
+	}
+	return *p.view.OtherThreshold, nil
+}
+
 type insightPayloadResolver struct {
 	viewId string
 	baseInsightResolver
@@ -370,6 +394,12 @@ type insightPresentationUnionResolver struct {
 // ToLineChartInsightViewPresentation is used by the GraphQL library to resolve type fragments for unions
 func (r *insightPresentationUnionResolver) ToLineChartInsightViewPresentation() (graphqlbackend.LineChartInsightViewPresentation, bool) {
 	res, ok := r.resolver.(*lineChartInsightViewPresentation)
+	return res, ok
+}
+
+// ToPieChartInsightViewPresentation is used by the GraphQL library to resolve type fragments for unions
+func (r *insightPresentationUnionResolver) ToPieChartInsightViewPresentation() (graphqlbackend.PieChartInsightViewPresentation, bool) {
+	res, ok := r.resolver.(*pieChartInsightViewPresentation)
 	return res, ok
 }
 

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -100,11 +100,11 @@ func (i *insightViewResolver) DataSeries(ctx context.Context) ([]graphqlbackend.
 }
 
 func (i *insightViewResolver) PresentationType(ctx context.Context) (string, error) {
-	return i.view.PresentationType, nil
+	return string(i.view.PresentationType), nil
 }
 
 func (i *insightViewResolver) Presentation(ctx context.Context) (graphqlbackend.InsightPresentation, error) {
-	if i.view.PresentationType == "PIE" {
+	if i.view.PresentationType == types.Pie {
 		pieChartPresentation := &pieChartInsightViewPresentation{view: i.view}
 		return &insightPresentationUnionResolver{resolver: pieChartPresentation}, nil
 	} else {

--- a/enterprise/internal/insights/store/dashboard_store_test.go
+++ b/enterprise/internal/insights/store/dashboard_store_test.go
@@ -297,9 +297,10 @@ func TestAssociateViewsById(t *testing.T) {
 	t.Run("create and add view to dashboard", func(t *testing.T) {
 		insightStore := NewInsightStore(timescale)
 		view, err := insightStore.CreateView(ctx, types.InsightView{
-			Title:       "great view",
-			Description: "my view",
-			UniqueID:    "view1234567",
+			Title:            "great view",
+			Description:      "my view",
+			UniqueID:         "view1234567",
+			PresentationType: string(types.Line),
 		}, []InsightViewGrant{GlobalGrant()})
 		if err != nil {
 			t.Fatal(err)
@@ -348,9 +349,10 @@ func TestRemoveViewsFromDashboard(t *testing.T) {
 	insightStore := NewInsightStore(timescale)
 
 	view, err := insightStore.CreateView(ctx, types.InsightView{
-		Title:       "view1",
-		Description: "view1",
-		UniqueID:    "view1",
+		Title:            "view1",
+		Description:      "view1",
+		UniqueID:         "view1",
+		PresentationType: string(types.Line),
 	}, []InsightViewGrant{GlobalGrant()})
 	if err != nil {
 		t.Fatal(err)

--- a/enterprise/internal/insights/store/dashboard_store_test.go
+++ b/enterprise/internal/insights/store/dashboard_store_test.go
@@ -300,7 +300,7 @@ func TestAssociateViewsById(t *testing.T) {
 			Title:            "great view",
 			Description:      "my view",
 			UniqueID:         "view1234567",
-			PresentationType: string(types.Line),
+			PresentationType: types.Line,
 		}, []InsightViewGrant{GlobalGrant()})
 		if err != nil {
 			t.Fatal(err)
@@ -352,7 +352,7 @@ func TestRemoveViewsFromDashboard(t *testing.T) {
 		Title:            "view1",
 		Description:      "view1",
 		UniqueID:         "view1",
-		PresentationType: string(types.Line),
+		PresentationType: types.Line,
 	}, []InsightViewGrant{GlobalGrant()})
 	if err != nil {
 		t.Fatal(err)

--- a/enterprise/internal/insights/store/insight_store_test.go
+++ b/enterprise/internal/insights/store/insight_store_test.go
@@ -83,6 +83,7 @@ func TestGet(t *testing.T) {
 				SampleIntervalUnit:  sampleIntervalUnit,
 				Label:               "label1",
 				LineColor:           "color1",
+				PresentationType:    string(types.Line),
 			},
 			{
 				ViewID:              1,
@@ -101,6 +102,7 @@ func TestGet(t *testing.T) {
 				SampleIntervalUnit:  sampleIntervalUnit,
 				Label:               "label2",
 				LineColor:           "color2",
+				PresentationType:    string(types.Line),
 			},
 			{
 				ViewID:              2,
@@ -119,6 +121,7 @@ func TestGet(t *testing.T) {
 				SampleIntervalUnit:  sampleIntervalUnit,
 				Label:               "second-label-2",
 				LineColor:           "second-color-2",
+				PresentationType:    string(types.Line),
 			},
 		}
 
@@ -153,6 +156,7 @@ func TestGet(t *testing.T) {
 				SampleIntervalUnit:  sampleIntervalUnit,
 				Label:               "label1",
 				LineColor:           "color1",
+				PresentationType:    string(types.Line),
 			},
 			{
 				ViewID:              1,
@@ -171,6 +175,7 @@ func TestGet(t *testing.T) {
 				SampleIntervalUnit:  sampleIntervalUnit,
 				Label:               "label2",
 				LineColor:           "color2",
+				PresentationType:    string(types.Line),
 			},
 		}
 
@@ -204,6 +209,7 @@ func TestGet(t *testing.T) {
 				SampleIntervalUnit:  sampleIntervalUnit,
 				Label:               "label1",
 				LineColor:           "color1",
+				PresentationType:    string(types.Line),
 			},
 			{
 				ViewID:              1,
@@ -222,6 +228,7 @@ func TestGet(t *testing.T) {
 				SampleIntervalUnit:  sampleIntervalUnit,
 				Label:               "label2",
 				LineColor:           "color2",
+				PresentationType:    string(types.Line),
 			},
 		}
 
@@ -297,9 +304,10 @@ func TestCreateView(t *testing.T) {
 	t.Run("test create view", func(t *testing.T) {
 
 		view := types.InsightView{
-			Title:       "my view",
-			Description: "my view description",
-			UniqueID:    "1234567",
+			Title:            "my view",
+			Description:      "my view description",
+			UniqueID:         "1234567",
+			PresentationType: string(types.Line),
 		}
 
 		got, err := store.CreateView(ctx, view, []InsightViewGrant{GlobalGrant()})
@@ -308,10 +316,11 @@ func TestCreateView(t *testing.T) {
 		}
 
 		want := types.InsightView{
-			ID:          1,
-			Title:       "my view",
-			Description: "my view description",
-			UniqueID:    "1234567",
+			ID:               1,
+			Title:            "my view",
+			Description:      "my view description",
+			UniqueID:         "1234567",
+			PresentationType: string(types.Line),
 		}
 
 		if diff := cmp.Diff(want, got); diff != "" {
@@ -336,6 +345,7 @@ func TestCreateGetView_WithGrants(t *testing.T) {
 		Title:       "user 1 view only",
 		Description: "user 1 should see this only",
 		UniqueID:    uniqueID,
+		PresentationType: string(types.Line),
 	}, []InsightViewGrant{UserGrant(1), OrgGrant(5)})
 	if err != nil {
 		t.Fatal(err)
@@ -460,17 +470,20 @@ func TestUpdateView(t *testing.T) {
 
 	t.Run("test update view", func(t *testing.T) {
 		view := types.InsightView{
-			Title:       "my view",
-			Description: "my view description",
-			UniqueID:    "1234567",
+			Title:            "my view",
+			Description:      "my view description",
+			UniqueID:         "1234567",
+			PresentationType: string(types.Line),
 		}
 		got, err := store.CreateView(ctx, view, []InsightViewGrant{GlobalGrant()})
 		if err != nil {
 			t.Fatal(err)
 		}
 		autogold.Want("AfterCreateView", types.InsightView{
-			ID: 1, Title: "my view", Description: "my view description",
-			UniqueID: "1234567",
+			ID: 1, Title: "my view",
+			Description:      "my view description",
+			UniqueID:         "1234567",
+			PresentationType: string(types.Line),
 		}).Equal(t, got)
 
 		include, exclude := "include repos", "exclude repos"
@@ -511,6 +524,7 @@ func TestUpdateViewSeries(t *testing.T) {
 			Title:       "my view",
 			Description: "my view description",
 			UniqueID:    "1234567",
+			PresentationType: string(types.Line),
 		}, []InsightViewGrant{GlobalGrant()})
 		if err != nil {
 			t.Fatal(err)
@@ -569,6 +583,7 @@ func TestDeleteView(t *testing.T) {
 		Title:       "user 1 view only",
 		Description: "user 1 should see this only",
 		UniqueID:    uniqueID,
+		PresentationType: string(types.Line),
 	}, []InsightViewGrant{GlobalGrant()})
 	if err != nil {
 		t.Fatal(err)
@@ -646,9 +661,10 @@ func TestAttachSeriesView(t *testing.T) {
 			t.Fatal(err)
 		}
 		view := types.InsightView{
-			Title:       "my view",
-			Description: "my view description",
-			UniqueID:    "1234567",
+			Title:            "my view",
+			Description:      "my view description",
+			UniqueID:         "1234567",
+			PresentationType: string(types.Line),
 		}
 		view, err = store.CreateView(ctx, view, []InsightViewGrant{GlobalGrant()})
 		if err != nil {
@@ -685,6 +701,7 @@ func TestAttachSeriesView(t *testing.T) {
 			SampleIntervalUnit:  sampleIntervalUnit,
 			Label:               "my label",
 			LineColor:           "my stroke",
+			PresentationType:    string(types.Line),
 		}}
 
 		if diff := cmp.Diff(want, got); diff != "" {
@@ -721,9 +738,10 @@ func TestRemoveSeriesFromView(t *testing.T) {
 			t.Fatal(err)
 		}
 		view := types.InsightView{
-			Title:       "my view",
-			Description: "my view description",
-			UniqueID:    "1234567",
+			Title:            "my view",
+			Description:      "my view description",
+			UniqueID:         "1234567",
+			PresentationType: string(types.Line),
 		}
 		view, err = store.CreateView(ctx, view, []InsightViewGrant{GlobalGrant()})
 		if err != nil {
@@ -760,6 +778,7 @@ func TestRemoveSeriesFromView(t *testing.T) {
 			SampleIntervalUnit:  sampleIntervalUnit,
 			Label:               "my label",
 			LineColor:           "my stroke",
+			PresentationType:    string(types.Line),
 		}}
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Errorf("unexpected result after attaching series to view (want/got): %s", diff)

--- a/enterprise/internal/insights/store/insight_store_test.go
+++ b/enterprise/internal/insights/store/insight_store_test.go
@@ -83,7 +83,7 @@ func TestGet(t *testing.T) {
 				SampleIntervalUnit:  sampleIntervalUnit,
 				Label:               "label1",
 				LineColor:           "color1",
-				PresentationType:    string(types.Line),
+				PresentationType:    types.Line,
 			},
 			{
 				ViewID:              1,
@@ -102,7 +102,7 @@ func TestGet(t *testing.T) {
 				SampleIntervalUnit:  sampleIntervalUnit,
 				Label:               "label2",
 				LineColor:           "color2",
-				PresentationType:    string(types.Line),
+				PresentationType:    types.Line,
 			},
 			{
 				ViewID:              2,
@@ -121,7 +121,7 @@ func TestGet(t *testing.T) {
 				SampleIntervalUnit:  sampleIntervalUnit,
 				Label:               "second-label-2",
 				LineColor:           "second-color-2",
-				PresentationType:    string(types.Line),
+				PresentationType:    types.Line,
 			},
 		}
 
@@ -156,7 +156,7 @@ func TestGet(t *testing.T) {
 				SampleIntervalUnit:  sampleIntervalUnit,
 				Label:               "label1",
 				LineColor:           "color1",
-				PresentationType:    string(types.Line),
+				PresentationType:    types.Line,
 			},
 			{
 				ViewID:              1,
@@ -175,7 +175,7 @@ func TestGet(t *testing.T) {
 				SampleIntervalUnit:  sampleIntervalUnit,
 				Label:               "label2",
 				LineColor:           "color2",
-				PresentationType:    string(types.Line),
+				PresentationType:    types.Line,
 			},
 		}
 
@@ -209,7 +209,7 @@ func TestGet(t *testing.T) {
 				SampleIntervalUnit:  sampleIntervalUnit,
 				Label:               "label1",
 				LineColor:           "color1",
-				PresentationType:    string(types.Line),
+				PresentationType:    types.Line,
 			},
 			{
 				ViewID:              1,
@@ -228,7 +228,7 @@ func TestGet(t *testing.T) {
 				SampleIntervalUnit:  sampleIntervalUnit,
 				Label:               "label2",
 				LineColor:           "color2",
-				PresentationType:    string(types.Line),
+				PresentationType:    types.Line,
 			},
 		}
 
@@ -307,7 +307,7 @@ func TestCreateView(t *testing.T) {
 			Title:            "my view",
 			Description:      "my view description",
 			UniqueID:         "1234567",
-			PresentationType: string(types.Line),
+			PresentationType: types.Line,
 		}
 
 		got, err := store.CreateView(ctx, view, []InsightViewGrant{GlobalGrant()})
@@ -320,7 +320,7 @@ func TestCreateView(t *testing.T) {
 			Title:            "my view",
 			Description:      "my view description",
 			UniqueID:         "1234567",
-			PresentationType: string(types.Line),
+			PresentationType: types.Line,
 		}
 
 		if diff := cmp.Diff(want, got); diff != "" {
@@ -345,7 +345,7 @@ func TestCreateGetView_WithGrants(t *testing.T) {
 		Title:            "user 1 view only",
 		Description:      "user 1 should see this only",
 		UniqueID:         uniqueID,
-		PresentationType: string(types.Line),
+		PresentationType: types.Line,
 	}, []InsightViewGrant{UserGrant(1), OrgGrant(5)})
 	if err != nil {
 		t.Fatal(err)
@@ -419,7 +419,7 @@ func TestCreateGetView_WithGrants(t *testing.T) {
 			Title:            "global only",
 			Description:      "global only",
 			UniqueID:         uniqueID,
-			PresentationType: string(types.Line),
+			PresentationType: types.Line,
 		}, []InsightViewGrant{GlobalGrant()})
 		if err != nil {
 			t.Fatal(err)
@@ -474,7 +474,7 @@ func TestUpdateView(t *testing.T) {
 			Title:            "my view",
 			Description:      "my view description",
 			UniqueID:         "1234567",
-			PresentationType: string(types.Line),
+			PresentationType: types.Line,
 		}
 		got, err := store.CreateView(ctx, view, []InsightViewGrant{GlobalGrant()})
 		if err != nil {
@@ -484,7 +484,7 @@ func TestUpdateView(t *testing.T) {
 			ID: 1, Title: "my view",
 			Description:      "my view description",
 			UniqueID:         "1234567",
-			PresentationType: string(types.Line),
+			PresentationType: types.Line,
 		}).Equal(t, got)
 
 		include, exclude := "include repos", "exclude repos"
@@ -525,7 +525,7 @@ func TestUpdateViewSeries(t *testing.T) {
 			Title:            "my view",
 			Description:      "my view description",
 			UniqueID:         "1234567",
-			PresentationType: string(types.Line),
+			PresentationType: types.Line,
 		}, []InsightViewGrant{GlobalGrant()})
 		if err != nil {
 			t.Fatal(err)
@@ -584,7 +584,7 @@ func TestDeleteView(t *testing.T) {
 		Title:            "user 1 view only",
 		Description:      "user 1 should see this only",
 		UniqueID:         uniqueID,
-		PresentationType: string(types.Line),
+		PresentationType: types.Line,
 	}, []InsightViewGrant{GlobalGrant()})
 	if err != nil {
 		t.Fatal(err)
@@ -665,7 +665,7 @@ func TestAttachSeriesView(t *testing.T) {
 			Title:            "my view",
 			Description:      "my view description",
 			UniqueID:         "1234567",
-			PresentationType: string(types.Line),
+			PresentationType: types.Line,
 		}
 		view, err = store.CreateView(ctx, view, []InsightViewGrant{GlobalGrant()})
 		if err != nil {
@@ -702,7 +702,7 @@ func TestAttachSeriesView(t *testing.T) {
 			SampleIntervalUnit:  sampleIntervalUnit,
 			Label:               "my label",
 			LineColor:           "my stroke",
-			PresentationType:    string(types.Line),
+			PresentationType:    types.Line,
 		}}
 
 		if diff := cmp.Diff(want, got); diff != "" {
@@ -742,7 +742,7 @@ func TestRemoveSeriesFromView(t *testing.T) {
 			Title:            "my view",
 			Description:      "my view description",
 			UniqueID:         "1234567",
-			PresentationType: string(types.Line),
+			PresentationType: types.Line,
 		}
 		view, err = store.CreateView(ctx, view, []InsightViewGrant{GlobalGrant()})
 		if err != nil {
@@ -779,7 +779,7 @@ func TestRemoveSeriesFromView(t *testing.T) {
 			SampleIntervalUnit:  sampleIntervalUnit,
 			Label:               "my label",
 			LineColor:           "my stroke",
-			PresentationType:    string(types.Line),
+			PresentationType:    types.Line,
 		}}
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Errorf("unexpected result after attaching series to view (want/got): %s", diff)

--- a/enterprise/internal/insights/store/insight_store_test.go
+++ b/enterprise/internal/insights/store/insight_store_test.go
@@ -342,9 +342,9 @@ func TestCreateGetView_WithGrants(t *testing.T) {
 
 	uniqueID := "user1viewonly"
 	view, err := store.CreateView(ctx, types.InsightView{
-		Title:       "user 1 view only",
-		Description: "user 1 should see this only",
-		UniqueID:    uniqueID,
+		Title:            "user 1 view only",
+		Description:      "user 1 should see this only",
+		UniqueID:         uniqueID,
 		PresentationType: string(types.Line),
 	}, []InsightViewGrant{UserGrant(1), OrgGrant(5)})
 	if err != nil {
@@ -416,9 +416,10 @@ func TestCreateGetView_WithGrants(t *testing.T) {
 	t.Run("no users or orgs provided should only return global", func(t *testing.T) {
 		uniqueID := "globalonly"
 		view, err := store.CreateView(ctx, types.InsightView{
-			Title:       "global only",
-			Description: "global only",
-			UniqueID:    uniqueID,
+			Title:            "global only",
+			Description:      "global only",
+			UniqueID:         uniqueID,
+			PresentationType: string(types.Line),
 		}, []InsightViewGrant{GlobalGrant()})
 		if err != nil {
 			t.Fatal(err)
@@ -521,9 +522,9 @@ func TestUpdateViewSeries(t *testing.T) {
 
 	t.Run("test update view series", func(t *testing.T) {
 		view, err := store.CreateView(ctx, types.InsightView{
-			Title:       "my view",
-			Description: "my view description",
-			UniqueID:    "1234567",
+			Title:            "my view",
+			Description:      "my view description",
+			UniqueID:         "1234567",
 			PresentationType: string(types.Line),
 		}, []InsightViewGrant{GlobalGrant()})
 		if err != nil {
@@ -580,9 +581,9 @@ func TestDeleteView(t *testing.T) {
 
 	uniqueID := "user1viewonly"
 	view, err := store.CreateView(ctx, types.InsightView{
-		Title:       "user 1 view only",
-		Description: "user 1 should see this only",
-		UniqueID:    uniqueID,
+		Title:            "user 1 view only",
+		Description:      "user 1 should see this only",
+		UniqueID:         uniqueID,
 		PresentationType: string(types.Line),
 	}, []InsightViewGrant{GlobalGrant()})
 	if err != nil {

--- a/enterprise/internal/insights/store/testdata/TestCreateGetView_WithGrants/no_users_or_orgs_provided_should_only_return_global.golden
+++ b/enterprise/internal/insights/store/testdata/TestCreateGetView_WithGrants/no_users_or_orgs_provided_should_only_return_global.golden
@@ -14,4 +14,5 @@
 	Label:              "label2",
 	LineColor:          "red",
 	SampleIntervalUnit: "MONTH",
+	PresentationType:   "LINE",
 }}

--- a/enterprise/internal/insights/store/testdata/TestCreateGetView_WithGrants/no_users_or_orgs_provided_should_only_return_global.golden
+++ b/enterprise/internal/insights/store/testdata/TestCreateGetView_WithGrants/no_users_or_orgs_provided_should_only_return_global.golden
@@ -14,5 +14,5 @@
 	Label:              "label2",
 	LineColor:          "red",
 	SampleIntervalUnit: "MONTH",
-	PresentationType:   "LINE",
+	PresentationType:   types.PresentationType("LINE"),
 }}

--- a/enterprise/internal/insights/store/testdata/TestCreateGetView_WithGrants/org_5_can_see_the_view.golden
+++ b/enterprise/internal/insights/store/testdata/TestCreateGetView_WithGrants/org_5_can_see_the_view.golden
@@ -14,5 +14,5 @@
 	Label:              "label1",
 	LineColor:          "blue",
 	SampleIntervalUnit: "MONTH",
-	PresentationType:   "LINE",
+	PresentationType:   types.PresentationType("LINE"),
 }}

--- a/enterprise/internal/insights/store/testdata/TestCreateGetView_WithGrants/org_5_can_see_the_view.golden
+++ b/enterprise/internal/insights/store/testdata/TestCreateGetView_WithGrants/org_5_can_see_the_view.golden
@@ -14,4 +14,5 @@
 	Label:              "label1",
 	LineColor:          "blue",
 	SampleIntervalUnit: "MONTH",
+	PresentationType:   "LINE",
 }}

--- a/enterprise/internal/insights/store/testdata/TestCreateGetView_WithGrants/user_1_can_see_this_view.golden
+++ b/enterprise/internal/insights/store/testdata/TestCreateGetView_WithGrants/user_1_can_see_this_view.golden
@@ -14,5 +14,5 @@
 	Label:              "label1",
 	LineColor:          "blue",
 	SampleIntervalUnit: "MONTH",
-	PresentationType:   "LINE",
+	PresentationType:   types.PresentationType("LINE"),
 }}

--- a/enterprise/internal/insights/store/testdata/TestCreateGetView_WithGrants/user_1_can_see_this_view.golden
+++ b/enterprise/internal/insights/store/testdata/TestCreateGetView_WithGrants/user_1_can_see_this_view.golden
@@ -14,4 +14,5 @@
 	Label:              "label1",
 	LineColor:          "blue",
 	SampleIntervalUnit: "MONTH",
+	PresentationType:   "LINE",
 }}

--- a/enterprise/internal/insights/types/types.go
+++ b/enterprise/internal/insights/types/types.go
@@ -26,15 +26,19 @@ type InsightViewSeries struct {
 	SampleIntervalValue           int
 	DefaultFilterIncludeRepoRegex *string
 	DefaultFilterExcludeRepoRegex *string
+	OtherThreshold                *float64
+	PresentationType              string
 }
 
 type Insight struct {
-	ViewID      int
-	UniqueID    string
-	Title       string
-	Description string
-	Series      []InsightViewSeries
-	Filters     InsightViewFilters
+	ViewID           int
+	UniqueID         string
+	Title            string
+	Description      string
+	Series           []InsightViewSeries
+	Filters          InsightViewFilters
+	OtherThreshold   *float64
+	PresentationType string
 }
 
 type InsightViewFilters struct {
@@ -50,12 +54,13 @@ type InsightViewSeriesMetadata struct {
 
 // InsightView is a single insight view that may or may not have any associated series.
 type InsightView struct {
-	ID             int
-	Title          string
-	Description    string
-	UniqueID       string
-	Filters        InsightViewFilters
-	OtherThreshold float32
+	ID               int
+	Title            string
+	Description      string
+	UniqueID         string
+	Filters          InsightViewFilters
+	OtherThreshold   *float64
+	PresentationType string
 }
 
 // InsightSeries is a single data series for a Code Insight. This contains some metadata about the data series, as well
@@ -121,3 +126,10 @@ type InsightSeriesStatus struct {
 	Failed     int
 	Completed  int
 }
+
+type PresentationType string
+
+const (
+	Line PresentationType = "LINE"
+	Pie  PresentationType = "PIE"
+)

--- a/enterprise/internal/insights/types/types.go
+++ b/enterprise/internal/insights/types/types.go
@@ -27,7 +27,7 @@ type InsightViewSeries struct {
 	DefaultFilterIncludeRepoRegex *string
 	DefaultFilterExcludeRepoRegex *string
 	OtherThreshold                *float64
-	PresentationType              string
+	PresentationType              PresentationType
 }
 
 type Insight struct {
@@ -38,7 +38,7 @@ type Insight struct {
 	Series           []InsightViewSeries
 	Filters          InsightViewFilters
 	OtherThreshold   *float64
-	PresentationType string
+	PresentationType PresentationType
 }
 
 type InsightViewFilters struct {
@@ -60,7 +60,7 @@ type InsightView struct {
 	UniqueID         string
 	Filters          InsightViewFilters
 	OtherThreshold   *float64
-	PresentationType string
+	PresentationType PresentationType
 }
 
 // InsightSeries is a single data series for a Code Insight. This contains some metadata about the data series, as well

--- a/internal/insights/insights.go
+++ b/internal/insights/insights.go
@@ -276,7 +276,7 @@ type LangStatsInsight struct {
 	ID             string
 	Title          string
 	Repository     string
-	OtherThreshold float32
+	OtherThreshold float64
 	OrgID          *int32
 	UserID         *int32
 }

--- a/internal/usagestats/code_insights_test.go
+++ b/internal/usagestats/code_insights_test.go
@@ -278,7 +278,7 @@ func TestGetLangStatsInsights(t *testing.T) {
 			ID:             "codeStatsInsights.insight.global.lang1",
 			Title:          "my insight",
 			Repository:     "github.com/sourcegraph/sourcegraph",
-			OtherThreshold: float32(0),
+			OtherThreshold: float64(0),
 			OrgID:          &orgId,
 		},
 	}

--- a/migrations/codeinsights/1000000020_presentation_type.down.sql
+++ b/migrations/codeinsights/1000000020_presentation_type.down.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+ALTER TABLE insight_view
+    ALTER COLUMN other_threshold TYPE FLOAT4,
+    DROP COLUMN IF EXISTS presentation_type;
+
+DROP TYPE presentation_type_enum;
+
+COMMIT;

--- a/migrations/codeinsights/1000000020_presentation_type.up.sql
+++ b/migrations/codeinsights/1000000020_presentation_type.up.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+CREATE TYPE presentation_type_enum AS ENUM ('LINE', 'PIE');
+ALTER TABLE insight_view
+    ADD COLUMN IF NOT EXISTS presentation_type presentation_type_enum NOT NULL DEFAULT 'LINE',
+    ALTER COLUMN other_threshold type FLOAT8; -- Changing this because the GraphQL float type is a float64.
+
+COMMENT ON COLUMN insight_view.presentation_type IS 'The basic presentation type for the insight view. (e.g Line, Pie, etc.)';
+
+COMMIT;


### PR DESCRIPTION
PR 1/2 for https://github.com/sourcegraph/sourcegraph/issues/26675

## Description

This PR returns pie charts (langstats) insights as a part of the GraphQL response for the `InsightView` type. Specifically, it returns them with their own `presentation`, distinct from the `LineChartInsightViewPresentation`. I'll follow up with another PR to do the create/update mutations.

- Added a `presentation_type` field to `insight_view`. Not sure if this is the best name, but it seemed to align with what we're calling it in the API. Other options might be `chart_type` or just `type`. Any thoughts here?
- I added this `PresentationType` field to the `InsightView` response so that the frontend will be able to easily distinguish between these types without having to rely on inferring it from what's in the `presentation` object.
- I also added an enum for the `PresentationType` which I figure we can add to as more types become available.

## Testing Steps

If you've got langstats insights in your db, you should just be able to observe them through querying the API for insights and verifying that the `presentationType` is `PIE` and that the right fields are returned in `presentation`.