### PR TITLE
security: enable handling CORS policies differently for API and non-API routes

### DIFF
--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -80,9 +80,9 @@ func newExternalHTTPHandler(db database.DB, schema *graphql.Schema, gitHubWebhoo
 	}
 	// Mount handlers and assets.
 	sm := http.NewServeMux()
-	sm.Handle("/.api/", apiHandler)
-	sm.Handle("/.executors/", executorProxyHandler)
-	sm.Handle("/", appHandler)
+	sm.Handle("/.api/", secureHeadersMiddleware(apiHandler, crossOriginPolicyAPI))
+	sm.Handle("/.executors/", secureHeadersMiddleware(executorProxyHandler, crossOriginPolicyNever))
+	sm.Handle("/", secureHeadersMiddleware(appHandler, crossOriginPolicyNever))
 	assetsutil.Mount(sm)
 
 	var h http.Handler = sm
@@ -96,7 +96,6 @@ func newExternalHTTPHandler(db database.DB, schema *graphql.Schema, gitHubWebhoo
 	h = middleware.Trace(h)
 	h = gcontext.ClearHandler(h)
 	h = healthCheckMiddleware(h)
-	h = secureHeadersMiddleware(h)
 	h = middleware.BlackHole(h)
 	h = middleware.SourcegraphComGoGetHandler(h)
 	h = internalauth.ForbidAllRequestsMiddleware(h)
@@ -159,11 +158,38 @@ func withInternalActor(h http.Handler) http.Handler {
 // for more information on this technique.
 const corsAllowHeader = "X-Requested-With"
 
+// crossOriginPolicy describes the cross-origin policy the middleware should be enforcing.
+type crossOriginPolicy string
+
+const (
+	// crossOriginPolicyAPI describes that the middleware should handle cross origin requests as a
+	// public API. That is, cross-origin requests are allowed from any domain but
+	// cookie/session-based authentication is only allowed if the origin is in the configured
+	/// allow-list of origins. Otherwise, only access token authentication is permitted.
+	//
+	// This is to be used for all /.api routes, such as our GraphQL and search streaming APIs as we
+	// want third-party websites (such as e.g. github1s.com, or internal tools for on-prem
+	// customers) to be able to leverage our API. Their users will need to provide an access token,
+	// or the website would need to be added to Sourcegraph's CORS allow list in order to be granted
+	// cookie/session-based authentication (which is dangerous to expose to untrusted domains.)
+	crossOriginPolicyAPI crossOriginPolicy = "API"
+
+	// crossOriginPolicyNever describes that the middleware should handle cross origin requests by
+	// never allowing them. This makes sense for e.g. routes such as e.g. sign out pages, where
+	// cookie based authentication is needed and requests should never come from a domain other than
+	// the Sourcegraph instance itself.
+	//
+	// Important: This only applies to cross-origin requests issued by clients that respect CORS,
+	// such as browsers. So for example Code Intelligence /.executors, despite being "an API",
+	// should use this policy unless they intend to get cross-origin requests _from browsers_.
+	crossOriginPolicyNever crossOriginPolicy = "never"
+)
+
 // secureHeadersMiddleware adds and checks for HTTP security-related headers.
 //
 // 🚨 SECURITY: This handler is served to all clients, even on private servers to clients who have
 // not authenticated. It must not reveal any sensitive information.
-func secureHeadersMiddleware(next http.Handler) http.Handler {
+func secureHeadersMiddleware(next http.Handler, policy crossOriginPolicy) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// headers for security
 		w.Header().Set("X-Content-Type-Options", "nosniff")


### PR DESCRIPTION
This change has no effect, the behavior is identical before and after. Instead, the actual change in behavior will come in a subsequent PR. All this does is make `scureHeadersMiddleware` aware of what type of route it is protecting-what cross origin request policy it should be enforcing.

This is needed to improve security in various ways:

1. To make our handling of cross-origin requests on non-API endpoints such as sign out routes more strict, [as described here](https://github.com/sourcegraph/sourcegraph/blob/7b99b4c3f47bf52db5216b274f8746885835a8f3/doc/dev/security/csrf_security_model.md#deprecate-corsorigin-add-apicorsorigin).
2. To make behavior of things such as this more strict: https://github.com/sourcegraph/security-issues/issues/176

Note that there is one _small_ behavior change, the secure middleware headers will now run _after_ the following middlewares:

```
        h = middleware.Trace(h)
        h = gcontext.ClearHandler(h)
        h = healthCheckMiddleware(h)
```

It is 100% OK to do this because:

1. It doesn't matter when request tracing occurs.
2. It doesn't matter when health check request handling occurs.
3. `gcontext.ClearHandler` executes once the request has finished (deferred execution),
   so it's behavior does not actually change.

Helps sourcegraph/security-issues#176

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
