### PR TITLE
tracing: dont log nothing at the start of a trace

### DIFF
--- a/internal/observation/observation.go
+++ b/internal/observation/observation.go
@@ -219,7 +219,9 @@ func (op *Operation) trace(ctx context.Context, args Args) (*trace.Trace, contex
 	}
 
 	tr, ctx := op.context.Tracer.New(ctx, op.kebabName, "")
-	tr.LogFields(mergeLogFields(op.logFields, args.LogFields)...)
+	if mergedFields := mergeLogFields(op.logFields, args.LogFields); len(mergedFields) > 0 {
+		tr.LogFields(mergedFields...)
+	}
 	return tr, ctx
 }
 


### PR DESCRIPTION
Turn this:
![image](https://user-images.githubusercontent.com/18282288/140824828-f2f8c293-1a31-4c2a-a746-33ffbea725b2.png)

into this:
![image](https://user-images.githubusercontent.com/18282288/140824856-b68dd1e5-70ad-45ca-b15a-7d650a2db70c.png)
