### PR TITLE
batches: resize SSBC editor to remaining screen height

### DIFF
--- a/client/web/src/enterprise/batches/create/NewCreateBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/NewCreateBatchChangePage.tsx
@@ -257,7 +257,7 @@ export const NewCreateBatchChangePage: React.FunctionComponent<CreateBatchChange
     )
 
     return (
-        <div className="d-flex flex-column p-4 w-100">
+        <div className="d-flex flex-column p-4 w-100 h-100">
             <div className="d-flex flex-0 justify-content-between">
                 <div className="flex-1">
                     <PageHeader
@@ -295,8 +295,7 @@ export const NewCreateBatchChangePage: React.FunctionComponent<CreateBatchChange
             </div>
             <div className="d-flex flex-1">
                 <div className={styles.editorContainer}>
-                    {/* TODO: Calculate height from remaining window height */}
-                    <MonacoBatchSpecEditor isLightTheme={isLightTheme} value={code} onChange={setCode} height={800} />
+                    <MonacoBatchSpecEditor isLightTheme={isLightTheme} value={code} onChange={setCode} />
                 </div>
                 <Container className={styles.workspacesPreviewContainer}>
                     {codeUpdateError && <ErrorAlert error={codeUpdateError} />}

--- a/client/web/src/enterprise/batches/create/editor/MonacoBatchSpecEditor.tsx
+++ b/client/web/src/enterprise/batches/create/editor/MonacoBatchSpecEditor.tsx
@@ -25,7 +25,6 @@ export interface Props extends ThemeProps {
     value: string | undefined
     onChange?: (newValue: string) => void
     readOnly?: boolean | undefined
-    height?: number
 }
 
 interface State {}
@@ -78,7 +77,7 @@ export class MonacoBatchSpecEditor extends React.PureComponent<Props, State> {
             <MonacoEditor
                 className={classNames(styles.editor, this.props.className)}
                 language="yaml"
-                height={this.props.height || 400}
+                height="100%"
                 isLightTheme={this.props.isLightTheme}
                 value={this.props.value}
                 editorWillMount={this.editorWillMount}


### PR DESCRIPTION
Soooooooo let's just ignore the fact that I first implemented this completely by hand with DOM element sizes and window resize listeners because I thought the underlying editor component **only** accepted a height in pixels. 😅 Turns out _we_ just only accepted a height in pixels and I'm bad at assumptions.

This just adapts our implementation of the editor component to accept strings so that we can set the SSBC editor height to a percentage like `'100%'`. The behavior for numbers and `'auto'` is retained.

![image](https://user-images.githubusercontent.com/8942601/140830090-61646fbf-4765-48dd-83f9-049d6209d136.png)
