### PR TITLE
security: make CORS enforcement of non-API routes even more strict

### DIFF
--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -80,9 +80,9 @@ func newExternalHTTPHandler(db database.DB, schema *graphql.Schema, gitHubWebhoo
 	}
 	// Mount handlers and assets.
 	sm := http.NewServeMux()
-	sm.Handle("/.api/", apiHandler)
-	sm.Handle("/.executors/", executorProxyHandler)
-	sm.Handle("/", appHandler)
+	sm.Handle("/.api/", secureHeadersMiddleware(apiHandler, crossOriginPolicyAPI))
+	sm.Handle("/.executors/", secureHeadersMiddleware(executorProxyHandler, crossOriginPolicyNever))
+	sm.Handle("/", secureHeadersMiddleware(appHandler, crossOriginPolicyNever))
 	assetsutil.Mount(sm)
 
 	var h http.Handler = sm
@@ -96,7 +96,6 @@ func newExternalHTTPHandler(db database.DB, schema *graphql.Schema, gitHubWebhoo
 	h = middleware.Trace(h)
 	h = gcontext.ClearHandler(h)
 	h = healthCheckMiddleware(h)
-	h = secureHeadersMiddleware(h)
 	h = middleware.BlackHole(h)
 	h = middleware.SourcegraphComGoGetHandler(h)
 	h = internalauth.ForbidAllRequestsMiddleware(h)
@@ -159,11 +158,38 @@ func withInternalActor(h http.Handler) http.Handler {
 // for more information on this technique.
 const corsAllowHeader = "X-Requested-With"
 
+// crossOriginPolicy describes the cross-origin policy the middleware should be enforcing.
+type crossOriginPolicy string
+
+const (
+	// crossOriginPolicyAPI describes that the middleware should handle cross origin requests as a
+	// public API. That is, cross-origin requests are allowed from any domain but
+	// cookie/session-based authentication is only allowed if the origin is in the configured
+	/// allow-list of origins. Otherwise, only access token authentication is permitted.
+	//
+	// This is to be used for all /.api routes, such as our GraphQL and search streaming APIs as we
+	// want third-party websites (such as e.g. github1s.com, or internal tools for on-prem
+	// customers) to be able to leverage our API. Their users will need to provide an access token,
+	// or the website would need to be added to Sourcegraph's CORS allow list in order to be granted
+	// cookie/session-based authentication (which is dangerous to expose to untrusted domains.)
+	crossOriginPolicyAPI crossOriginPolicy = "API"
+
+	// crossOriginPolicyNever describes that the middleware should handle cross origin requests by
+	// never allowing them. This makes sense for e.g. routes such as e.g. sign out pages, where
+	// cookie based authentication is needed and requests should never come from a domain other than
+	// the Sourcegraph instance itself.
+	//
+	// Important: This only applies to cross-origin requests issued by clients that respect CORS,
+	// such as browsers. So for example Code Intelligence /.executors, despite being "an API",
+	// should use this policy unless they intend to get cross-origin requests _from browsers_.
+	crossOriginPolicyNever crossOriginPolicy = "never"
+)
+
 // secureHeadersMiddleware adds and checks for HTTP security-related headers.
 //
 // 🚨 SECURITY: This handler is served to all clients, even on private servers to clients who have
 // not authenticated. It must not reveal any sensitive information.
-func secureHeadersMiddleware(next http.Handler) http.Handler {
+func secureHeadersMiddleware(next http.Handler, policy crossOriginPolicy) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// headers for security
 		w.Header().Set("X-Content-Type-Options", "nosniff")


### PR DESCRIPTION
This PR is stacked on top of #27240.

There are three commits:

* The first has no behavior change, it just moves code around to make te next commit even more clean and make the logic more legible.
* The second:
    * Forbids cross-origin requests for all non-API routes, even if they are from an allowed origin in the site config `corsOrigin` setting. 
    * Effectively makes `corsOrigin` only configure cross-origin access of our _API routes_. i.e. because a cross-origin request for verify email, sign out, etc. never makes any sense, we should be more strict.
    * Fixes sourcegraph/security-issues#176
* The third updates our CSRF threat model document to reflect the improvements.