### PR TITLE
sg: use docker volumes by default in redis-postgres, fix args

### DIFF
--- a/dev/redis-postgres.yml
+++ b/dev/redis-postgres.yml
@@ -17,14 +17,14 @@ services:
     ports:
       - 5432:5432
     environment:
-      - POSTGRES_PASSWORD=${PGUSER:-sourcegraph}
-      - POSTGRES_USER=${PGPASSWORD:-sourcegraph}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-sourcegraph}
+      - POSTGRES_USER=${POSTGRES_USER:-sourcegraph}
       - POSTGRES_DB=${PGDATABASE:-sourcegraph}
       - "POSTGRES_INITDB_ARGS= --encoding=UTF8 "
     volumes:
       # Match PGDATA in Dockerfile
       # https://sourcegraph.com/search?q=context:%40sourcegraph/all+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:%5Edocker-images/postgres.*/Dockerfile+PGDATA
-      - ${PGDATA_DIR:-postgres_data}:/data/pgdata-12
+      - ${PGDATA_DIR:-postgres_12_data}:/data/pgdata-12
 volumes:
   redis_data:
-  postgres_data:
+  postgres_12_data:

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -543,8 +543,6 @@ commands:
     cmd: docker-compose -f dev/redis-postgres.yml up $COMPOSE_ARGS
     env:
       COMPOSE_ARGS: --force-recreate
-      PGDATA_DIR: ""
-      REDIS_DATA_DIR: ""
 
   jaeger:
     cmd: |

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -543,8 +543,7 @@ commands:
     cmd: docker-compose -f dev/redis-postgres.yml up $COMPOSE_ARGS
     env:
       COMPOSE_ARGS: --force-recreate
-      # Set the following to a path on disk to persist data (or unset to not persist data)
-      PGDATA_DIR: $HOME/.sourcegraph-dev/data/postgresql
+      PGDATA_DIR: ""
       REDIS_DATA_DIR: ""
 
   jaeger:


### PR DESCRIPTION
- Switch to using docker volumes by default for persisting postgres data. This seems to work just fine, and mounting disks seems [prone to issues](https://sourcegraph.slack.com/archives/C07KZF47K/p1636153062263100).
  - Gave pg volume a version-specific name, since I ran into an issue here with an existing volume of the same name.
- The postgres arguments for user/password were flipped 🤔 Switched them around