### PR TITLE
search: rename TextSearch -> RepoSubsetTextSearch job

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -672,7 +672,7 @@ func (r *searchResolver) toSearchInputs(q query.Q) (*search.TextParameters, []ru
 					UseFullDeadline: args.UseFullDeadline,
 				}
 
-				jobs = append(jobs, &unindexed.TextSearch{
+				jobs = append(jobs, &unindexed.RepoSubsetTextSearch{
 					ZoektArgs:         zoektArgs,
 					SearcherArgs:      searcherArgs,
 					FileMatchLimit:    args.PatternInfo.FileMatchLimit,
@@ -1729,7 +1729,7 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 			return waitGroup(args.ResultTypes.Without(result.TypeSymbol) == 0)
 		case "Repo":
 			return waitGroup(true)
-		case "Text":
+		case "RepoSubsetText":
 			return waitGroup(true)
 		case "Structural":
 			return waitGroup(true)

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -303,7 +303,7 @@ func callSearcherOverRepos(
 	return g.Wait()
 }
 
-type TextSearch struct {
+type RepoSubsetTextSearch struct {
 	ZoektArgs         *search.ZoektParameters
 	SearcherArgs      *search.SearcherParameters
 	FileMatchLimit    int32
@@ -313,7 +313,7 @@ type TextSearch struct {
 	OnMissingRepoRevs zoektutil.OnMissingRepoRevs
 }
 
-func (t *TextSearch) Run(ctx context.Context, stream streaming.Sender, repos searchrepos.Pager) error {
+func (t *RepoSubsetTextSearch) Run(ctx context.Context, stream streaming.Sender, repos searchrepos.Pager) error {
 	ctx, stream, cleanup := streaming.WithLimit(ctx, stream, int(t.FileMatchLimit))
 	defer cleanup()
 
@@ -334,6 +334,6 @@ func (t *TextSearch) Run(ctx context.Context, stream streaming.Sender, repos sea
 	})
 }
 
-func (*TextSearch) Name() string {
-	return "Text"
+func (*RepoSubsetTextSearch) Name() string {
+	return "RepoSubsetText"
 }


### PR DESCRIPTION
Prep for discriminating `RepoSubset` and `Global` repo text searches so I can create separate jobs for these.

`RepoSubsetTextSearch` is a bit long winded but I couldn't come up with something better right now, and it could be shortened later after the jobs are clearly delineated.