### PR TITLE
search: config fingerprint to reduce work done by zoekt polling

### DIFF
--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -3,6 +3,7 @@ package httpapi
 import (
 	"log"
 	"net/http"
+	"os"
 	"reflect"
 	"strconv"
 	"time"
@@ -124,6 +125,8 @@ func NewInternalHandler(m *mux.Router, db database.DB, schema *graphql.Schema, n
 		RepoStore:           database.Repos(db),
 		SearchContextsStore: database.SearchContexts(db),
 		Indexers:            search.Indexers(),
+
+		MinLastChangedEnabled: os.Getenv("SRC_SEARCH_CORE_MIN_LAST_CHANGED") != "",
 	}
 	m.Get(apirouter.SearchConfiguration).Handler(trace.Route(handler(indexer.serveConfiguration)))
 	m.Get(apirouter.ReposIndex).Handler(trace.Route(handler(indexer.serveList)))

--- a/go.mod
+++ b/go.mod
@@ -98,6 +98,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.9
 	github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2
 	github.com/microcosm-cc/bluemonday v1.0.16
+	github.com/mitchellh/hashstructure v1.1.0
 	github.com/montanaflynn/stats v0.6.6
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
 	github.com/neelance/parallel v0.0.0-20160708114440-4de9ce63d14c

--- a/go.sum
+++ b/go.sum
@@ -1454,6 +1454,8 @@ github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUb
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
+github.com/mitchellh/hashstructure v1.1.0 h1:P6P1hdjqAAknpY/M1CGipelZgp+4y9ja9kmUZPXP+H0=
+github.com/mitchellh/hashstructure v1.1.0/go.mod h1:xUDAozZz0Wmdiufv0uyhnHkUTN6/6d8ulp4AwfLKrmA=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v0.0.0-20170523030023-d0303fe80992/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/internal/search/backend/config.go
+++ b/internal/search/backend/config.go
@@ -1,0 +1,146 @@
+package backend
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/mitchellh/hashstructure"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+const configFingerprintHeader = "X-Sourcegraph-Config-Fingerprint"
+
+// ParseAndSetConfigFingerprint will set the current config fingerprint in
+// w. If r specifies a config fingerprint, we return the minimum time for a
+// repository to have changed.
+//
+// A config fingerprint represents a point in time that indexed search
+// configuration was generated. It is an opaque identifier sent to clients to
+// allow efficient calculation of what has changed since the last
+// request. zoekt-sourcegraph-indexserver reads and sets these headers to
+// reduce the amount of work required when it polls.
+func ParseAndSetConfigFingerprint(w http.ResponseWriter, r *http.Request, siteConfig *schema.SiteConfiguration) (minLastChanged time.Time, err error) {
+	// Before we load anything generate a config fingerprint representing the
+	// point in time just before loading. This is sent to the client via a
+	// header for use in the next call.
+	fingerprint, err := newConfigFingerprint(siteConfig)
+	if err != nil {
+		return time.Time{}, err
+	}
+	w.Header().Set(configFingerprintHeader, fingerprint.Marshal())
+
+	// If the user specified a fingerprint to diff against, we can use it to
+	// reduce the amount of work we do. minLastChanged being zero means we
+	// check every repository.
+	old, err := parseConfigFingerprint(r.Header.Get(configFingerprintHeader))
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	// Different site config may affect any repository, so we need to load
+	// them all in.
+	if !old.SameConfig(fingerprint) {
+		return time.Time{}, nil
+	}
+
+	// We can just load what has changed since the last config fingerprint.
+	return old.Since(), nil
+}
+
+// configFingerprint represents a point in time that indexed search
+// configuration was generated. It is an opaque identifier sent to clients to
+// allow efficient calculation of what has changed since the last request.
+type configFingerprint struct {
+	ts   time.Time
+	hash uint64
+}
+
+// newConfigFingerprint returns a ConfigFingerprint for the current time and sc.
+func newConfigFingerprint(sc *schema.SiteConfiguration) (*configFingerprint, error) {
+	hash, err := hashstructure.Hash(sc, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &configFingerprint{
+		ts:   time.Now(),
+		hash: hash,
+	}, nil
+}
+
+// parseConfigFingerprint unmarshals s and returns ConfigFingerprint. This is
+// the inverse of Marshal.
+func parseConfigFingerprint(s string) (_ *configFingerprint, err error) {
+	parts := strings.Fields(s)
+
+	// We support no cursor.
+	if len(parts) == 0 {
+		return &configFingerprint{}, nil
+	}
+
+	if len(parts) < 2 || parts[0] != "search-config-fingerprint" {
+		return nil, errors.Errorf("malformed search-config-fingerprint: %q", s)
+	}
+	if parts[1] != "1" {
+		// Unknown version, treat as if not specified
+		return &configFingerprint{}, nil
+	}
+
+	// Use consistent error wrapping from this point since we know it is a
+	// version 1 search-config-fingerprint.
+	defer func() {
+		if err != nil {
+			err = errors.Wrapf(err, "malformed search-config-fingerprint 1: %q", s)
+		}
+	}()
+
+	if len(parts) != 4 {
+		return nil, errors.New("expected 4 fields")
+	}
+
+	ts, err := time.Parse(time.RFC3339, parts[2])
+	if err != nil {
+		return nil, errors.Wrapf(err, "malformed search-config-fingerprint 1: %q", s)
+	}
+
+	hash, err := strconv.ParseUint(parts[3], 16, 64)
+	if err != nil {
+		return nil, errors.Wrapf(err, "malformed search-config-fingerprint 1: %q", s)
+	}
+
+	return &configFingerprint{
+		ts:   ts,
+		hash: hash,
+	}, nil
+}
+
+// Marshal returns an opaque string for c to send to clients.
+func (c *configFingerprint) Marshal() string {
+	ts := c.ts.UTC().Truncate(time.Second)
+	return fmt.Sprintf("search-config-fingerprint 1 %s %x", ts.Format(time.RFC3339), c.hash)
+}
+
+// Since returns the time to return changes since. Note: It does not return
+// the exact time the fingerprint was generated, but instead some time in the
+// past to allow for time skew and races.
+func (c *configFingerprint) Since() time.Time {
+	if c.ts.IsZero() {
+		return c.ts
+	}
+	// 90s is the same value recommended by the TOTP spec.
+	return c.ts.Add(-90 * time.Second)
+}
+
+// SameConfig returns true if c2 was generated with the same site
+// configuration.
+func (c *configFingerprint) SameConfig(c2 *configFingerprint) bool {
+	// ts being zero indicates a missing cursor or non-fatal unmarshalling of
+	// the cursor.
+	if c.ts.IsZero() || c2.ts.IsZero() {
+		return false
+	}
+	return c.hash == c2.hash
+}

--- a/internal/search/backend/config_test.go
+++ b/internal/search/backend/config_test.go
@@ -1,0 +1,159 @@
+package backend
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func TestParseAndSetConfigFingerprint(t *testing.T) {
+	mk := func(sc *schema.SiteConfiguration) *configFingerprint {
+		t.Helper()
+		fingerprint, err := newConfigFingerprint(sc)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return fingerprint
+	}
+
+	parseAndSet := func(fingerprint string, sc *schema.SiteConfiguration) time.Time {
+		t.Helper()
+		r := httptest.NewRequest("GET", "/", nil)
+		r.Header.Set("X-Sourcegraph-Config-Fingerprint", fingerprint)
+		w := httptest.NewRecorder()
+		minLastChanged, err := ParseAndSetConfigFingerprint(w, r, sc)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := parseConfigFingerprint(w.Result().Header.Get("X-Sourcegraph-Config-Fingerprint"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := mk(sc)
+		if !got.SameConfig(want) {
+			t.Fatal("expected same config in response fingerprint")
+		}
+
+		return minLastChanged
+	}
+
+	sc1 := &schema.SiteConfiguration{
+		ExperimentalFeatures: &schema.ExperimentalFeatures{
+			SearchIndexBranches: map[string][]string{
+				"foo": {"dev"},
+			},
+		},
+	}
+	sc2 := &schema.SiteConfiguration{
+		ExperimentalFeatures: &schema.ExperimentalFeatures{
+			SearchIndexBranches: map[string][]string{
+				"foo": {"dev", "qa"},
+			},
+		},
+	}
+
+	if got := parseAndSet("", sc1); !got.IsZero() {
+		t.Fatal("expect no min last changed for missing fingerprint")
+	}
+
+	if got := parseAndSet(mk(sc1).Marshal(), sc2); !got.IsZero() {
+		t.Fatal("expect no min last changed for different site config")
+	}
+
+	if got := parseAndSet(mk(sc1).Marshal(), sc1); got.IsZero() {
+		t.Fatal("expect min last changed for same site config")
+	}
+}
+
+func TestConfigFingerprint(t *testing.T) {
+	sc1 := &schema.SiteConfiguration{
+		ExperimentalFeatures: &schema.ExperimentalFeatures{
+			SearchIndexBranches: map[string][]string{
+				"foo": {"dev"},
+			},
+		},
+	}
+	sc2 := &schema.SiteConfiguration{
+		ExperimentalFeatures: &schema.ExperimentalFeatures{
+			SearchIndexBranches: map[string][]string{
+				"foo": {"dev", "qa"},
+			},
+		},
+	}
+
+	var seq time.Duration
+	mk := func(sc *schema.SiteConfiguration) *configFingerprint {
+		t.Helper()
+		cf, err := newConfigFingerprint(sc)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Each consecutive call we adjust the time significantly to ensure
+		// when comparing config we don't take into account time.
+		cf.ts = cf.ts.Add(seq * time.Hour)
+		seq++
+
+		testMarshal(t, cf)
+		return cf
+	}
+
+	cfA := mk(sc1)
+	cfB := mk(sc1)
+	cfC := mk(sc2)
+
+	if !cfA.SameConfig(cfB) {
+		t.Fatal("expected same config for A and B")
+	}
+	if cfA.SameConfig(cfC) {
+		t.Fatal("expected different config for A and C")
+	}
+}
+
+func TestConfigFingerprint_Marshal(t *testing.T) {
+	// Use a fixed time for this test case
+	now, err := time.Parse(time.RFC3339, "2006-01-02T15:04:05Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cf := configFingerprint{
+		ts:   now,
+		hash: 123,
+	}
+
+	got := cf.Marshal()
+	want := "search-config-fingerprint 1 2006-01-02T15:04:05Z 7b"
+	if got != want {
+		t.Errorf("unexpected marshal value:\ngot:  %s\nwant: %s", got, want)
+	}
+
+	testMarshal(t, &cf)
+}
+
+func testMarshal(t *testing.T, cf *configFingerprint) {
+	t.Helper()
+
+	v := cf.Marshal()
+	t.Log(v)
+
+	got, err := parseConfigFingerprint(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !cf.SameConfig(got) {
+		t.Error("expected same config")
+	}
+
+	since := got.Since()
+	if since.After(cf.ts) {
+		t.Error("since should not be after ts")
+	}
+	if since.Before(cf.ts.Add(-time.Hour)) {
+		t.Error("since should not be before ts - hour")
+	}
+}


### PR DESCRIPTION
configFingerprint is an opaque structure used by Sourcegraph to minimize the amount of work done when zoekt polls for repository options. It is a timestamp and a hash of the configuration. Using these two bits of information, we can heuristically calculate what has changed since the fingerprint.

We version the fingerprint format since we expect changes in the future as the requirements of inputs to IndexOptions changes. Additionally we hide parsing this behind a temporary environment variable `SRC_SEARCH_CORE_MIN_LAST_CHANGED`.

Note: this supercedes a previous PR "introduce ConfigFingerprint"  https://github.com/sourcegraph/sourcegraph/pull/27133. Instead it only exports a single function which takes in an http request/response and the site config. This hides business logic from the httpapi handler implementation.
