### PR TITLE
ci: replace upload step with a pre-exit hook

### DIFF
--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# About $SOFT_FAIL_EXIT_CODES (example value: "1 2 3 4"):
+# It's a quick hack to circumvent the problem describe in
+# https://github.com/sourcegraph/sourcegraph/issues/27264.
+
+set -e # Not -u because $SOFT_FAIL_EXIT_CODES may not be bound
+
+if [[ "$BUILDKITE_PIPELINE_NAME" != "sourcegraph" ]]; then
+    exit 0
+fi
+
+if [ "$BUILDKITE_BRANCH" == "main" ]; then
+    if [ "$BUILDKITE_COMMAND_EXIT_STATUS" -eq 0 ]; then
+        # If the job exit code is either 0 or a soft failt exit code defined by that step, do nothing.
+        exit 0
+    fi
+
+    # Turn the string of exit codes "1 2 3 4" into an array of strings
+    IFS=' ' read -ra codes <<<"$SOFT_FAIL_EXIT_CODES"
+    for code in "${codes[@]}"; do
+        if [ "$code" == "$BUILDKITE_COMMAND_EXIT_STATUS" ]; then
+            # If the Buildkite exit code is a soft fail, do nothing either.
+            exit 0
+        fi
+    done
+
+    # Non-zero exit code and not a soft fail: upload the logs.
+    ./enterprise/dev/upload-build-logs.sh
+fi

--- a/dev/sg/sg_ci.go
+++ b/dev/sg/sg_ci.go
@@ -31,12 +31,13 @@ const (
 var (
 	ciFlagSet = flag.NewFlagSet("sg ci", flag.ExitOnError)
 
-	ciLogsFlagSet      = flag.NewFlagSet("sg ci logs", flag.ExitOnError)
-	ciLogsBranchFlag   = ciLogsFlagSet.String("branch", "", "Branch name of build to find logs for (defaults to current branch)")
-	ciLogsJobStateFlag = ciLogsFlagSet.String("state", "failed", "Job states to export logs for.")
-	ciLogsJobQueryFlag = ciLogsFlagSet.String("job", "", "ID or name of the job to export logs for.")
-	ciLogsBuildFlag    = ciLogsFlagSet.String("build", "", "Override branch detection with a specific build number")
-	ciLogsOutFlag      = ciLogsFlagSet.String("out", ciLogsOutStdout,
+	ciLogsFlagSet               = flag.NewFlagSet("sg ci logs", flag.ExitOnError)
+	ciLogsBranchFlag            = ciLogsFlagSet.String("branch", "", "Branch name of build to find logs for (defaults to current branch)")
+	ciLogsJobStateFlag          = ciLogsFlagSet.String("state", "failed", "Job states to export logs for.")
+	ciLogsJobOverwriteStateFlag = ciLogsFlagSet.String("overwrite-state", "", "State to overwrite the job state metadata")
+	ciLogsJobQueryFlag          = ciLogsFlagSet.String("job", "", "ID or name of the job to export logs for.")
+	ciLogsBuildFlag             = ciLogsFlagSet.String("build", "", "Override branch detection with a specific build number")
+	ciLogsOutFlag               = ciLogsFlagSet.String("out", ciLogsOutStdout,
 		fmt.Sprintf("Output format, either 'stdout' or a URL pointing to a Loki instance, such as %q", loki.DefaultLokiURL))
 
 	ciStatusFlagSet    = flag.NewFlagSet("sg ci status", flag.ExitOnError)
@@ -319,6 +320,10 @@ From there, you can start exploring logs with the Grafana explore panel.
 						job := log.JobMeta.Job
 						if log.JobMeta.Label != nil {
 							job = fmt.Sprintf("%q (%s)", *log.JobMeta.Label, log.JobMeta.Job)
+						}
+						if *ciLogsJobOverwriteStateFlag != "" {
+							failed := *ciLogsJobOverwriteStateFlag
+							log.JobMeta.State = &failed
 						}
 
 						pending.Updatef("Processing build %d job %s (%d/%d)...",

--- a/enterprise/dev/ci/internal/buildkite/buildkite.go
+++ b/enterprise/dev/ci/internal/buildkite/buildkite.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"io"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -252,13 +253,20 @@ type softFailExitStatus struct {
 
 // SoftFail indicates the specified exit codes should trigger a soft fail.
 // https://buildkite.com/docs/pipelines/command-step#command-step-attributes
+// This function also adds a specific env var named SOFT_FAIL_EXIT_CODES, enabling
+// to get exit codes from the scripts until https://github.com/sourcegraph/sourcegraph/issues/27264
+// is fixed.
 func SoftFail(exitCodes ...int) StepOpt {
 	return func(step *Step) {
+		var codes []string
 		for _, code := range exitCodes {
+			codes = append(codes, strconv.Itoa(code))
 			step.SoftFail = append(step.SoftFail, softFailExitStatus{
 				ExitStatus: code,
 			})
 		}
+		// https://github.com/sourcegraph/sourcegraph/issues/27264
+		step.Env["SOFT_FAIL_EXIT_CODES"] = strings.Join(codes, " ")
 	}
 }
 

--- a/enterprise/dev/ci/internal/buildkite/buildkite_test.go
+++ b/enterprise/dev/ci/internal/buildkite/buildkite_test.go
@@ -9,6 +9,21 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/buildkite"
 )
 
+func TestStepSoftFail(t *testing.T) {
+	pipeline := buildkite.Pipeline{}
+	stepOpt := buildkite.SoftFail(1, 2, 3, 4)
+	pipeline.AddStep("foo", stepOpt)
+	step, ok := pipeline.Steps[0].(*buildkite.Step)
+	if !ok {
+		t.Fatal("Pipeline step is not a buildkite.Step")
+	}
+	want := "1 2 3 4"
+	got := step.Env["SOFT_FAIL_EXIT_CODES"]
+	if got != want {
+		t.Fatalf("want %q, got %q", want, got)
+	}
+}
+
 func TestOutputSanitization(t *testing.T) {
 	t.Run("JSON", func(t *testing.T) {
 		tests := []struct {

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -709,16 +709,3 @@ func publishExecutorDockerMirror(version string) operations.Operation {
 		pipeline.AddStep(":packer: :white_check_mark: docker registry mirror image", stepOpts...)
 	}
 }
-
-// uploadBuildLogs publishes logs from failed jobs to Grafana Cloud. It runs as soon as
-// all previous steps up until a "wait" has run.
-func uploadBuildLogs(key string) operations.Operation {
-	return func(pipeline *bk.Pipeline) {
-		pipeline.AddEnsureStep(fmt.Sprintf(":file_cabinet: Uploading build logs (%s)", key),
-			// Allow the upload to fail without failing the build.
-			bk.Key(fmt.Sprintf("upload-logs:%s", key)),
-			bk.SoftFail(1),
-			bk.AllowDependencyFailure(),
-			bk.Cmd("./enterprise/dev/upload-build-logs.sh"))
-	}
-}

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -218,10 +218,10 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			serverQA(c.candidateImageTag()),
 			testUpgrade(c.candidateImageTag(), minimumUpgradeableVersion))
 
-		// Upload logs up to this point
-		if c.RunType.Is(MainBranch) {
-			ops.Append(uploadBuildLogs("builds-and-tests"))
-		}
+		// // Upload logs up to this point
+		// if c.RunType.Is(MainBranch) {
+		// 	ops.Append(uploadBuildLogs("builds-and-tests"))
+		// }
 
 		// All operations before this point are required
 		ops.Append(wait)
@@ -238,17 +238,17 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			}
 		}
 
-		// Upload logs up to this point
-		if c.RunType.Is(MainBranch) {
-			ops.Append(uploadBuildLogs("publish"))
-		}
+		// // Upload logs up to this point
+		// if c.RunType.Is(MainBranch) {
+		// 	ops.Append(uploadBuildLogs("publish"))
+		// }
 
 		// Propagate changes elsewhere
 		if c.RunType.Is(MainBranch) {
 			ops.Append(
 				wait, // wait for all steps to pass
-				triggerUpdaterPipeline,
-				uploadBuildLogs("updater"))
+				triggerUpdaterPipeline)
+			// uploadBuildLogs("updater"))
 		}
 	}
 

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -218,11 +218,6 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			serverQA(c.candidateImageTag()),
 			testUpgrade(c.candidateImageTag(), minimumUpgradeableVersion))
 
-		// // Upload logs up to this point
-		// if c.RunType.Is(MainBranch) {
-		// 	ops.Append(uploadBuildLogs("builds-and-tests"))
-		// }
-
 		// All operations before this point are required
 		ops.Append(wait)
 
@@ -238,17 +233,11 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			}
 		}
 
-		// // Upload logs up to this point
-		// if c.RunType.Is(MainBranch) {
-		// 	ops.Append(uploadBuildLogs("publish"))
-		// }
-
 		// Propagate changes elsewhere
 		if c.RunType.Is(MainBranch) {
 			ops.Append(
 				wait, // wait for all steps to pass
 				triggerUpdaterPipeline)
-			// uploadBuildLogs("updater"))
 		}
 	}
 

--- a/enterprise/dev/upload-build-logs.sh
+++ b/enterprise/dev/upload-build-logs.sh
@@ -7,8 +7,9 @@ Usage: upload-build-logs.sh
 Upload a buildkite build result in Loki.
 
 Requires:
-- \$BUILDKITE_COMMIT
-- \$LOKI_URL
+- \$BUILDKITE_BUILD_NUMBER
+- \$BUILDKITE_JOB_ID
+- \$BUILD_LOGS_LOKI_URL
 EOF
 }
 
@@ -29,5 +30,8 @@ echo "--- :go: Building sg"
   popd
 )
 
-echo "--- :arrow_up: Uploading logs (if build failed)"
-./ci_sg ci logs --out="$BUILD_LOGS_LOKI_URL" --state="failed" --build="$BUILDKITE_BUILD_NUMBER"
+echo "--- :file_cabinet: Uploading logs"
+# Because we are running this script in the buildkite post-exit hook, the state of the job is still "running".
+# Passing --state="" just overrides the default. It's not set to any specific state because this script caller
+# is responsible of making sure the job has failed.
+./ci_sg ci logs --out="$BUILD_LOGS_LOKI_URL" --state="" --overwrite-state="failed" --build="$BUILDKITE_BUILD_NUMBER" --job="$BUILDKITE_JOB_ID"


### PR DESCRIPTION
The previous approach proved to be unreliable in certain cases,
especially when wait steps are getting involved.

This change now triggers a post-exit hook on every step that will
upload if a hard failure is detected.

I have not documented the `--overwrite-state` in SG's doc because that's not a flag meant to be used by our users.
