### PR TITLE
Add browser extension sg cli support

### DIFF
--- a/client/browser/README.md
+++ b/client/browser/README.md
@@ -127,10 +127,13 @@ Click reload for Sourcegraph at `about:debugging`
 
 ## Testing
 
-- Unit tests: `yarn test`
-- E2E tests: `yarn test-e2e`
+- Unit tests: `sg test bext`
+- Integration tests: `sg test bext-integration`
+- E2E tests: 
+  - `EXTENSION_PERMISSIONS_ALL_URLS=true yarn --cwd client/browser build`
+  - `sg test bext-e2e`
 
-### e2e tests
+### E2E tests
 
 The test suite in `end-to-end/github.test.ts` runs on the release branch `bext/release` in both Chrome and Firefox against a Sourcegraph Docker instance.
 

--- a/client/browser/README.md
+++ b/client/browser/README.md
@@ -129,7 +129,7 @@ Click reload for Sourcegraph at `about:debugging`
 
 - Unit tests: `sg test bext`
 - Integration tests: `sg test bext-integration`
-- E2E tests: 
+- E2E tests:
   - `EXTENSION_PERMISSIONS_ALL_URLS=true yarn --cwd client/browser build`
   - `sg test bext-e2e`
 

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -711,6 +711,10 @@ commands:
   debug-env:
     cmd: env
 
+  bext:
+    cmd: yarn --cwd client/browser dev
+    install: yarn
+
 checks:
   docker:
     cmd: docker version
@@ -975,6 +979,18 @@ tests:
   web-integration:
     cmd: yarn test-integration
     install: ENTERPRISE=1 yarn build-web
+
+  bext:
+    cmd: yarn --cwd client/browser test
+
+  bext-integration:
+    cmd: yarn --cwd client/browser test-integration
+
+  bext-e2e:
+    cmd: yarn run download-puppeteer-browser && yarn --cwd client/browser mocha ./src/end-to-end/github.test.ts ./src/end-to-end/gitlab.test.ts
+    env:
+      SOURCEGRAPH_BASE_URL: https://sourcegraph.com
+      PERCY_BROWSER_EXECUTABLE: node_modules/puppeteer/.local-chromium/linux-901812/chrome-linux/chrome
 
   frontend:
     cmd: yarn run jest --testPathIgnorePatterns end-to-end regression integration storybook


### PR DESCRIPTION

This PR:
- Add `sg test bext|bext-integration|bext-e2e` to run corresponding tests
- Add `sg run bext` to start bext in dev mode