### PR TITLE
conf: rename `AccessTokAllow` to `AccessTokenAllow`

### DIFF
--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -74,7 +74,7 @@ type JSContext struct {
 
 	BillingPublishableKey string `json:"billingPublishableKey,omitempty"`
 
-	AccessTokensAllow conf.AccessTokAllow `json:"accessTokensAllow"`
+	AccessTokensAllow conf.AccessTokenAllow `json:"accessTokensAllow"`
 
 	AllowSignup bool `json:"allowSignup"`
 

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -85,29 +85,25 @@ func PhabricatorConfigs(ctx context.Context) ([]*schema.PhabricatorConnection, e
 	return config, nil
 }
 
-type AccessTokAllow string
+type AccessTokenAllow string
 
 const (
-	AccessTokensNone  AccessTokAllow = "none"
-	AccessTokensAll   AccessTokAllow = "all-users-create"
-	AccessTokensAdmin AccessTokAllow = "site-admin-create"
+	AccessTokensNone  AccessTokenAllow = "none"
+	AccessTokensAll   AccessTokenAllow = "all-users-create"
+	AccessTokensAdmin AccessTokenAllow = "site-admin-create"
 )
 
-// AccessTokensAllow returns whether access tokens are enabled, disabled, or restricted to creation by admin users.
-func AccessTokensAllow() AccessTokAllow {
+// AccessTokensAllow returns whether access tokens are enabled, disabled, or
+// restricted creation to only site admins.
+func AccessTokensAllow() AccessTokenAllow {
 	cfg := Get().AuthAccessTokens
-	if cfg == nil {
+	if cfg == nil || cfg.Allow == "" {
 		return AccessTokensAll
 	}
-	switch cfg.Allow {
-	case "":
-		return AccessTokensAll
-	case string(AccessTokensAll):
-		return AccessTokensAll
-	case string(AccessTokensNone):
-		return AccessTokensNone
-	case string(AccessTokensAdmin):
-		return AccessTokensAdmin
+	v := AccessTokenAllow(cfg.Allow)
+	switch v {
+	case AccessTokensAll, AccessTokensAdmin:
+		return v
 	default:
 		return AccessTokensNone
 	}


### PR DESCRIPTION
I do not see a clear gain personally for saving two letters (`en`), also simplified the `conf.AccessTokensAllow()` a little bit.