### PR TITLE
Update m1_mac_local_dev.md - bump Jaeger, remove trailing '

### DIFF
--- a/doc/dev/how-to/m1_mac_local_dev.md
+++ b/doc/dev/how-to/m1_mac_local_dev.md
@@ -15,6 +15,6 @@
    ```
    and updating your shell (e.g. `source ~/.zshenv`). (Based on https://linguinecode.com/post/how-to-fix-m1-mac-puppeteer-chromium-arm64-bug)
 2. Run `softwareupdate --install-rosetta`.
-3. Get the Mac version of Jaeger https://www.jaegertracing.io/download/, extract it, then `cp ~/Downloads/jaeger-1.28.0-darwin-amd64/jaeger-all-in-one ~/sourcegraph/.bin/jaeger-all-in-one-1.18.1-darwin-arm64`.
+3. Get the Mac version of Jaeger https://www.jaegertracing.io/download/, extract it, then `cp ~/Downloads/jaeger-1.28.0-darwin-amd64/jaeger-all-in-one ~/sourcegraph/.bin/jaeger-all-in-one-1.18.1-darwin-arm64` (adjust ~/sourcegraph to point to you local clone of github.com/sourcegraph/sourcegraph).
 
 Did you bump into another issue and solve it locally? Consider updating this list! 🙇

--- a/doc/dev/how-to/m1_mac_local_dev.md
+++ b/doc/dev/how-to/m1_mac_local_dev.md
@@ -10,11 +10,11 @@
    ```
    If you hit an error above, try allowing the app under System Preferences > Security & Privacy > General Tab > Allow Anyways. If it was successful, exit Chromium and point Puppeteer to Chromium by adding the following to your shell configuration (e.g. `~/.zshenv`)
    ```
-   export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true'
+   export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
    export PUPPETEER_EXECUTABLE_PATH=`which chromium`
    ```
    and updating your shell (e.g. `source ~/.zshenv`). (Based on https://linguinecode.com/post/how-to-fix-m1-mac-puppeteer-chromium-arm64-bug)
 2. Run `softwareupdate --install-rosetta`.
-3. Get the Mac version of Jaeger https://www.jaegertracing.io/download/, extract it, then `cp ~/Downloads/jaeger-1.27.0-darwin-amd64/jaeger-all-in-one ~/sourcegraph/.bin/jaeger-all-in-one-1.18.1-darwin-arm64`.
+3. Get the Mac version of Jaeger https://www.jaegertracing.io/download/, extract it, then `cp ~/Downloads/jaeger-1.28.0-darwin-amd64/jaeger-all-in-one ~/sourcegraph/.bin/jaeger-all-in-one-1.18.1-darwin-arm64`.
 
 Did you bump into another issue and solve it locally? Consider updating this list! 🙇

--- a/doc/dev/how-to/m1_mac_local_dev.md
+++ b/doc/dev/how-to/m1_mac_local_dev.md
@@ -1,20 +1,35 @@
 # Workarounds for M1 Mac local development
 
-1. If you hit a Puppeteer error stating "The chromium binary is not available for arm64", you need to install Chromium for Puppeteer via Homebrew.
+## Puppeteer
+If you hit a Puppeteer error stating "The chromium binary is not available for arm64", you need to install Chromium for Puppeteer via Homebrew.
    ```
    brew install --no-quarantine chromium
    ```
+
    Check that Chromium opens correctly:
    ```
    open -a /Applications/Chromium.app
    ```
+
    If you hit an error above, try allowing the app under System Preferences > Security & Privacy > General Tab > Allow Anyways. If it was successful, exit Chromium and point Puppeteer to Chromium by adding the following to your shell configuration (e.g. `~/.zshenv`)
    ```
    export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
    export PUPPETEER_EXECUTABLE_PATH=`which chromium`
    ```
-   and updating your shell (e.g. `source ~/.zshenv`). (Based on https://linguinecode.com/post/how-to-fix-m1-mac-puppeteer-chromium-arm64-bug)
-2. Run `softwareupdate --install-rosetta`.
-3. Get the Mac version of Jaeger https://www.jaegertracing.io/download/, extract it, then `cp ~/Downloads/jaeger-1.28.0-darwin-amd64/jaeger-all-in-one ~/sourcegraph/.bin/jaeger-all-in-one-1.18.1-darwin-arm64` (adjust ~/sourcegraph to point to you local clone of github.com/sourcegraph/sourcegraph).
+   and updating your shell (e.g. `source ~/.zshenv`). 
+
+(Based on https://linguinecode.com/post/how-to-fix-m1-mac-puppeteer-chromium-arm64-bug)
+
+## Rosetta
+Run `softwareupdate --install-rosetta`.
+
+## Jaeger
+Get the Mac version of Jaeger https://www.jaegertracing.io/download/, extract it, then 
+
+```
+cp ~/Downloads/jaeger-1.28.0-darwin-amd64/jaeger-all-in-one ~/sourcegraph/.bin/jaeger-all-in-one-1.18.1-darwin-arm64
+``` 
+
+(adjust `~/sourcegraph` to point to you local clone of `github.com/sourcegraph/sourcegraph`).
 
 Did you bump into another issue and solve it locally? Consider updating this list! 🙇


### PR DESCRIPTION
1. Remove trailing ' from command
2. Better formatting (see below)
3. Bump Jaeger version

Before:
<img width="986" alt="Screenshot 2021-11-15 at 11 25 14" src="https://user-images.githubusercontent.com/1022220/141765497-dba5e043-5db7-4dad-8d21-2e0e438464c9.png">
After:
<img width="857" alt="Screenshot 2021-11-15 at 11 25 49" src="https://user-images.githubusercontent.com/1022220/141765562-0e7ec0fc-1041-4df9-ba4a-25822eefe508.png">

