### PR TITLE
convert external services tests to use new db mocks

### DIFF
--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -125,7 +125,7 @@ func (r *schemaResolver) UpdateExternalService(ctx context.Context, args *update
 		return nil, err
 	}
 
-	es, err := database.ExternalServices(r.db).GetByID(ctx, id)
+	es, err := r.db.ExternalServices().GetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -218,7 +218,7 @@ func (r *schemaResolver) DeleteExternalService(ctx context.Context, args *delete
 		return nil, err
 	}
 
-	es, err := database.ExternalServices(r.db).GetByID(ctx, id)
+	es, err := r.db.ExternalServices().GetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +228,7 @@ func (r *schemaResolver) DeleteExternalService(ctx context.Context, args *delete
 		return nil, err
 	}
 
-	if err := database.ExternalServices(r.db).Delete(ctx, id); err != nil {
+	if err := r.db.ExternalServices().Delete(ctx, id); err != nil {
 		return nil, err
 	}
 	now := time.Now()


### PR DESCRIPTION
This PR converts the tests in `external_services_test.go` to use the new
database mocks.

I'm working towards creating a critical mass of example tests using the new database
mocks so the codebase moves in that direction independently of my intervention.
I'll keep making incremental progress towards deprecating the global mocks, but
I expect the PRs to slow down a bit from here, both because `database.DB` is spread
through the codebase enough that I can use the new mocks for new tests, and because
I expect to have less slack time moving forward. 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
