### PR TITLE
security: remove duplicated code in CORS handling

### DIFF
--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -246,14 +246,9 @@ func handleCORSRequest(w http.ResponseWriter, r *http.Request, policy crossOrigi
 	// 	"Origin: *" -> "Access-Control-Allow-Origin: *"
 	// 	"Origin: https://foobar.com" -> "Access-Control-Allow-Origin: https://foobar.com"
 	//
-	headerOrigin := r.Header.Get("Origin")
-	isExtensionRequest := headerOrigin == devExtension || headerOrigin == prodExtension
-	corsOrigin := conf.Get().CorsOrigin
-
 	w.Header().Set("Access-Control-Allow-Credentials", "true")
-
-	if isExtensionRequest || isAllowedOrigin(headerOrigin, strings.Fields(corsOrigin)) {
-		w.Header().Set("Access-Control-Allow-Origin", headerOrigin)
+	if isTrustedOrigin(r) {
+		w.Header().Set("Access-Control-Allow-Origin", r.Header.Get("Origin"))
 	}
 
 	if r.Method == "OPTIONS" {

--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -248,20 +248,19 @@ func handleCORSRequest(w http.ResponseWriter, r *http.Request, policy crossOrigi
 	//
 	headerOrigin := r.Header.Get("Origin")
 	isExtensionRequest := headerOrigin == devExtension || headerOrigin == prodExtension
+	corsOrigin := conf.Get().CorsOrigin
 
-	if corsOrigin := conf.Get().CorsOrigin; corsOrigin != "" || isExtensionRequest {
-		w.Header().Set("Access-Control-Allow-Credentials", "true")
+	w.Header().Set("Access-Control-Allow-Credentials", "true")
 
-		if isExtensionRequest || isAllowedOrigin(headerOrigin, strings.Fields(corsOrigin)) {
-			w.Header().Set("Access-Control-Allow-Origin", headerOrigin)
-		}
+	if isExtensionRequest || isAllowedOrigin(headerOrigin, strings.Fields(corsOrigin)) {
+		w.Header().Set("Access-Control-Allow-Origin", headerOrigin)
+	}
 
-		if r.Method == "OPTIONS" {
-			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-			w.Header().Set("Access-Control-Allow-Headers", corsAllowHeader+", X-Sourcegraph-Client, Content-Type, Authorization, X-Sourcegraph-Should-Trace")
-			w.WriteHeader(http.StatusOK)
-			return true // we handled the request
-		}
+	if r.Method == "OPTIONS" {
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", corsAllowHeader+", X-Sourcegraph-Client, Content-Type, Authorization, X-Sourcegraph-Should-Trace")
+		w.WriteHeader(http.StatusOK)
+		return true // we handled the request
 	}
 	return false
 }


### PR DESCRIPTION
Stacked on top of #27295

`isTrustedOrigin` is a defined function which checks whether or not
a request comes from a trusted origin or not, but prior to this change
we had the same exact logic duplicated in our CORS handling method in
order to determine if we should send `Access-Control-Allow-Origin` back
to the client with the origin the request came from.

Much clearer to reuse the same code, and reduces the surface area that
bugs could arise in.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
