### PR TITLE
security: improve clarity of CORS docstrings

### DIFF
--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -246,14 +246,9 @@ func handleCORSRequest(w http.ResponseWriter, r *http.Request, policy crossOrigi
 	// 	"Origin: *" -> "Access-Control-Allow-Origin: *"
 	// 	"Origin: https://foobar.com" -> "Access-Control-Allow-Origin: https://foobar.com"
 	//
-	headerOrigin := r.Header.Get("Origin")
-	isExtensionRequest := headerOrigin == devExtension || headerOrigin == prodExtension
-	corsOrigin := conf.Get().CorsOrigin
-
 	w.Header().Set("Access-Control-Allow-Credentials", "true")
-
-	if isExtensionRequest || isAllowedOrigin(headerOrigin, strings.Fields(corsOrigin)) {
-		w.Header().Set("Access-Control-Allow-Origin", headerOrigin)
+	if isTrustedOrigin(r) {
+		w.Header().Set("Access-Control-Allow-Origin", r.Header.Get("Origin"))
 	}
 
 	if r.Method == "OPTIONS" {

--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -235,19 +235,23 @@ func handleCORSRequest(w http.ResponseWriter, r *http.Request, policy crossOrigi
 		return false
 	}
 
-	// If the headerOrigin is the development or production Chrome Extension explicitly set the Allow-Control-Allow-Origin
-	// to the incoming header URL. Otherwise use the configured CORS origin.
-	//
-	// Note: API users also rely on this codepath handling wildcards
-	// properly. For example, if Sourcegraph is behind a corporate VPN an
-	// admin may choose to set the CORS origin to "*" and would expect
-	// Sourcegraph to respond appropriately to any Origin request header:
-	//
-	// 	"Origin: *" -> "Access-Control-Allow-Origin: *"
-	// 	"Origin: https://foobar.com" -> "Access-Control-Allow-Origin: https://foobar.com"
-	//
 	w.Header().Set("Access-Control-Allow-Credentials", "true")
+
 	if isTrustedOrigin(r) {
+		// The request came from a trusted origin, either from the browser extension's fixed origin
+		// identifier or from an origin present in the site configuration `corsOrigin` allow list.
+		//
+		// This means we should allow the exact origin to make the request, the browser will grant
+		// their request the ability to authenticate via a session cookie.
+		//
+		// Note: API users also rely on this codepath handling wildcards properly. For example, if
+		// Sourcegraph is behind a corporate VPN an admin may choose to set the CORS origin to "*"
+		// (via a proxy, not what a browser would ever send) and would expect Sourcegraph to respond
+		// appropriately to any Origin request header:
+		//
+		// 	"Origin: *" -> "Access-Control-Allow-Origin: *"
+		// 	"Origin: https://foobar.com" -> "Access-Control-Allow-Origin: https://foobar.com"
+		//
 		w.Header().Set("Access-Control-Allow-Origin", r.Header.Get("Origin"))
 	}
 

--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -248,20 +248,19 @@ func handleCORSRequest(w http.ResponseWriter, r *http.Request, policy crossOrigi
 	//
 	headerOrigin := r.Header.Get("Origin")
 	isExtensionRequest := headerOrigin == devExtension || headerOrigin == prodExtension
+	corsOrigin := conf.Get().CorsOrigin
 
-	if corsOrigin := conf.Get().CorsOrigin; corsOrigin != "" || isExtensionRequest {
-		w.Header().Set("Access-Control-Allow-Credentials", "true")
+	w.Header().Set("Access-Control-Allow-Credentials", "true")
 
-		if isExtensionRequest || isAllowedOrigin(headerOrigin, strings.Fields(corsOrigin)) {
-			w.Header().Set("Access-Control-Allow-Origin", headerOrigin)
-		}
+	if isExtensionRequest || isAllowedOrigin(headerOrigin, strings.Fields(corsOrigin)) {
+		w.Header().Set("Access-Control-Allow-Origin", headerOrigin)
+	}
 
-		if r.Method == "OPTIONS" {
-			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-			w.Header().Set("Access-Control-Allow-Headers", corsAllowHeader+", X-Sourcegraph-Client, Content-Type, Authorization, X-Sourcegraph-Should-Trace")
-			w.WriteHeader(http.StatusOK)
-			return true // we handled the request
-		}
+	if r.Method == "OPTIONS" {
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", corsAllowHeader+", X-Sourcegraph-Client, Content-Type, Authorization, X-Sourcegraph-Should-Trace")
+		w.WriteHeader(http.StatusOK)
+		return true // we handled the request
 	}
 	return false
 }


### PR DESCRIPTION
Stacked on top of #27297

In particular, the wildcard handling comment here was incomplete and
did not clarify how a request with `Origin: *` would actually end up
at Sourcegraph (after all, browsers would send a URL not `*`.) We've
had regressions here in the past, e.g. one I fixed almost 3 years ago
in 92c706d85813a7e03a7ddfe55ab7f218ed4ca38a

So generally improve the clarity of these docstrings and explain what
is going on.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>