### PR TITLE
insights: fix panic caused by missing base resolver (and nil store)

### DIFF
--- a/enterprise/internal/insights/resolvers/dashboard_resolvers.go
+++ b/enterprise/internal/insights/resolvers/dashboard_resolvers.go
@@ -422,5 +422,5 @@ type insightsDashboardPayloadResolver struct {
 
 func (i *insightsDashboardPayloadResolver) Dashboard(ctx context.Context) (graphqlbackend.InsightsDashboardResolver, error) {
 	id := newRealDashboardID(int64(i.dashboard.ID))
-	return &insightsDashboardResolver{dashboard: i.dashboard, id: &id}, nil
+	return &insightsDashboardResolver{dashboard: i.dashboard, id: &id, baseInsightResolver: i.baseInsightResolver}, nil
 }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/27245

There was a resolver (`insightsDashboardResolver`) that didn't drill down the `baseInsightResolver`, and therefore had a nil `insightStore`.

Here is a query that should capture all of these, to verify we have them all now.
https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:insights/resolvers/.*+count:all+Resolver%7B...%7D%2C+nil&patternType=structural

