### PR TITLE
Add a note to sg docs about attaching a debugger

### DIFF
--- a/doc/dev/background-information/sg/index.md
+++ b/doc/dev/background-information/sg/index.md
@@ -270,6 +270,9 @@ specific to your work.
 
 You can run `sg run debug-env` to see the environment variables passed `sg`'s child processes.
 
+## Debugger
+To attach the [Delve](https://github.com/go-delve/delve) debugger, pass the environment variable `DELVE=true` into `sg`. [Read more here](https://docs.sourcegraph.com/dev/how-to/debug_live_code#debug-go-code)
+
 ### Examples
 
 #### Changing database configuration


### PR DESCRIPTION
Cross linking the notes about attaching a local debugger to `sg`.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
