### PR TITLE
search: fix help dropdown button submitting search instead

### DIFF
--- a/client/web/src/search/input/SearchHelpDropdownButton.tsx
+++ b/client/web/src/search/input/SearchHelpDropdownButton.tsx
@@ -21,9 +21,9 @@ export const SearchHelpDropdownButton: React.FunctionComponent = () => {
     return (
         <ButtonDropdown isOpen={isOpen} toggle={toggleIsOpen} className="search-help-dropdown-button d-flex">
             <DropdownToggle
-                tag="button"
                 caret={false}
-                className="px-2 btn btn-link d-flex align-items-center cursor-pointer"
+                color="link"
+                className="px-2 d-flex align-items-center cursor-pointer"
                 aria-label="Quick help for search"
             >
                 <HelpCircleOutlineIcon


### PR DESCRIPTION
`<button>` without `type="button"` strikes again. 

ReactStrap will use a button with `type="button"` by default, we just have to give it the `link` color to match the old style :) 

Fixes #27310