### PR TITLE
codeintel: Pin lsif-go to 1.7.2 prior to upgrade

### DIFF
--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -6,7 +6,7 @@ jobs:
     # Skip running on forks
     if: github.repository == 'sourcegraph/sourcegraph'
     runs-on: ubuntu-latest
-    container: sourcegraph/lsif-go
+    container: sourcegraph/lsif-go:v1.7.2 # Pinned in preparation for upgrade
     strategy:
       matrix:
         root:


### PR DESCRIPTION
Pinning this now will help avoid errors in PRs once https://github.com/sourcegraph/lsif-go/pull/216 is merged and needs another command line argument `--dep-batch-size=100` in order to succeed.