### PR TITLE
connect uses of database.DB

### DIFF
--- a/cmd/frontend/graphqlbackend/execution_log_entry.go
+++ b/cmd/frontend/graphqlbackend/execution_log_entry.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
 
@@ -18,7 +17,7 @@ type ExecutionLogEntryResolver interface {
 	DurationMilliseconds() *int32
 }
 
-func NewExecutionLogEntryResolver(db dbutil.DB, entry workerutil.ExecutionLogEntry) *executionLogEntryResolver {
+func NewExecutionLogEntryResolver(db database.DB, entry workerutil.ExecutionLogEntry) *executionLogEntryResolver {
 	return &executionLogEntryResolver{
 		db:    db,
 		entry: entry,
@@ -26,7 +25,7 @@ func NewExecutionLogEntryResolver(db dbutil.DB, entry workerutil.ExecutionLogEnt
 }
 
 type executionLogEntryResolver struct {
-	db    dbutil.DB
+	db    database.DB
 	entry workerutil.ExecutionLogEntry
 }
 
@@ -57,7 +56,7 @@ func (r *executionLogEntryResolver) DurationMilliseconds() *int32 {
 
 func (r *executionLogEntryResolver) Out(ctx context.Context) (string, error) {
 	// 🚨 SECURITY: Only site admins can view executor log contents.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, database.NewDB(r.db)); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		if err != backend.ErrMustBeSiteAdmin {
 			return "", err
 		}

--- a/cmd/frontend/graphqlbackend/org_members.go
+++ b/cmd/frontend/graphqlbackend/org_members.go
@@ -6,7 +6,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -40,16 +39,16 @@ func (r *organizationMembershipConnectionResolver) PageInfo() *graphqlutil.PageI
 }
 
 type organizationMembershipResolver struct {
-	db         dbutil.DB
+	db         database.DB
 	membership *types.OrgMembership
 }
 
 func (r *organizationMembershipResolver) Organization(ctx context.Context) (*OrgResolver, error) {
-	return OrgByIDInt32(ctx, database.NewDB(r.db), r.membership.OrgID)
+	return OrgByIDInt32(ctx, r.db, r.membership.OrgID)
 }
 
 func (r *organizationMembershipResolver) User(ctx context.Context) (*UserResolver, error) {
-	return UserByIDInt32(ctx, database.NewDB(r.db), r.membership.UserID)
+	return UserByIDInt32(ctx, r.db, r.membership.UserID)
 }
 
 func (r *organizationMembershipResolver) CreatedAt() DateTime {

--- a/cmd/frontend/graphqlbackend/preview_repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/preview_repository_comparison.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sourcegraph/go-diff/diff"
 
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
@@ -54,7 +55,7 @@ func (r *previewRepositoryComparisonResolver) BaseRepository() *RepositoryResolv
 }
 
 func (r *previewRepositoryComparisonResolver) FileDiffs(ctx context.Context, args *FileDiffsConnectionArgs) (FileDiffConnection, error) {
-	return NewFileDiffConnectionResolver(r.db, r.commit, r.commit, args, fileDiffConnectionCompute(r.patch), previewNewFile), nil
+	return NewFileDiffConnectionResolver(database.NewDB(r.db), r.commit, r.commit, args, fileDiffConnectionCompute(r.patch), previewNewFile), nil
 }
 
 func fileDiffConnectionCompute(patch string) func(ctx context.Context, args *FileDiffsConnectionArgs) ([]*diff.FileDiff, int32, bool, error) {
@@ -113,7 +114,7 @@ func fileDiffConnectionCompute(patch string) func(ctx context.Context, args *Fil
 	}
 }
 
-func previewNewFile(db dbutil.DB, r *FileDiffResolver) FileResolver {
+func previewNewFile(db database.DB, r *FileDiffResolver) FileResolver {
 	fileStat := CreateFileInfo(r.FileDiff.NewName, false)
 	return NewVirtualFileResolver(fileStat, fileDiffVirtualFileContent(r))
 }

--- a/cmd/frontend/graphqlbackend/preview_repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/preview_repository_comparison.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sourcegraph/go-diff/diff"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 type PreviewRepositoryComparisonResolver interface {
@@ -18,7 +17,7 @@ type PreviewRepositoryComparisonResolver interface {
 }
 
 // NewPreviewRepositoryComparisonResolver is a convenience function to get a preview diff from a repo, given a base rev and the git patch.
-func NewPreviewRepositoryComparisonResolver(ctx context.Context, db dbutil.DB, repo *RepositoryResolver, baseRev, patch string) (*previewRepositoryComparisonResolver, error) {
+func NewPreviewRepositoryComparisonResolver(ctx context.Context, db database.DB, repo *RepositoryResolver, baseRev, patch string) (*previewRepositoryComparisonResolver, error) {
 	args := &RepositoryCommitArgs{Rev: baseRev}
 	commit, err := repo.Commit(ctx, args)
 	if err != nil {
@@ -33,7 +32,7 @@ func NewPreviewRepositoryComparisonResolver(ctx context.Context, db dbutil.DB, r
 }
 
 type previewRepositoryComparisonResolver struct {
-	db     dbutil.DB
+	db     database.DB
 	repo   *RepositoryResolver
 	commit *GitCommitResolver
 	patch  string
@@ -55,7 +54,7 @@ func (r *previewRepositoryComparisonResolver) BaseRepository() *RepositoryResolv
 }
 
 func (r *previewRepositoryComparisonResolver) FileDiffs(ctx context.Context, args *FileDiffsConnectionArgs) (FileDiffConnection, error) {
-	return NewFileDiffConnectionResolver(database.NewDB(r.db), r.commit, r.commit, args, fileDiffConnectionCompute(r.patch), previewNewFile), nil
+	return NewFileDiffConnectionResolver(r.db, r.commit, r.commit, args, fileDiffConnectionCompute(r.patch), previewNewFile), nil
 }
 
 func fileDiffConnectionCompute(patch string) func(ctx context.Context, args *FileDiffsConnectionArgs) ([]*diff.FileDiff, int32, bool, error) {

--- a/cmd/frontend/graphqlbackend/preview_repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/preview_repository_comparison_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
@@ -19,7 +18,7 @@ import (
 
 func TestPreviewRepositoryComparisonResolver(t *testing.T) {
 	ctx := context.Background()
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(nil)
 
 	const testDiffFiles = 3
 	const testOldFile = `First
@@ -99,7 +98,7 @@ index 9bd8209..d2acfa9 100644
 
 	repo := &types.Repo{ID: api.RepoID(1), Name: "github.com/sourcegraph/sourcegraph", CreatedAt: time.Now()}
 
-	previewComparisonResolver, err := NewPreviewRepositoryComparisonResolver(ctx, db, NewRepositoryResolver(database.NewDB(db), repo), string(wantHeadRevision), testDiff)
+	previewComparisonResolver, err := NewPreviewRepositoryComparisonResolver(ctx, db, NewRepositoryResolver(db, repo), string(wantHeadRevision), testDiff)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -419,7 +419,7 @@ func (r *schemaResolver) ResolvePhabricatorDiff(ctx context.Context, args *struc
 		if err != nil {
 			return nil, err
 		}
-		r := NewRepositoryResolver(database.NewDB(r.db), repo)
+		r := NewRepositoryResolver(r.db, repo)
 		return r.Commit(ctx, &RepositoryCommitArgs{Rev: targetRef})
 	}
 

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -319,7 +319,7 @@ func (r *fileDiffConnectionResolver) Nodes(ctx context.Context) ([]FileDiff, err
 	resolvers := make([]FileDiff, len(fileDiffs))
 	for i, fileDiff := range fileDiffs {
 		resolvers[i] = &FileDiffResolver{
-			db:       r.db,
+			db:       database.NewDB(r.db),
 			newFile:  r.newFile,
 			FileDiff: fileDiff,
 			Base:     r.base,
@@ -384,7 +384,7 @@ type FileDiffResolver struct {
 	Base     *GitCommitResolver
 	Head     *GitCommitResolver
 
-	db      dbutil.DB
+	db      database.DB
 	newFile NewFileFunc
 }
 
@@ -413,7 +413,7 @@ func (r *FileDiffResolver) OldFile() FileResolver {
 		return nil
 	}
 	return &GitTreeEntryResolver{
-		db:     database.NewDB(r.db),
+		db:     r.db,
 		commit: r.Base,
 		stat:   CreateFileInfo(r.FileDiff.OrigName, false),
 	}

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -61,7 +61,7 @@ type FileDiff interface {
 	InternalID() string
 }
 
-func NewRepositoryComparison(ctx context.Context, db dbutil.DB, r *RepositoryResolver, args *RepositoryComparisonInput) (*RepositoryComparisonResolver, error) {
+func NewRepositoryComparison(ctx context.Context, db database.DB, r *RepositoryResolver, args *RepositoryComparisonInput) (*RepositoryComparisonResolver, error) {
 	var baseRevspec, headRevspec string
 	if args.Base == nil {
 		baseRevspec = "HEAD"
@@ -90,7 +90,7 @@ func NewRepositoryComparison(ctx context.Context, db dbutil.DB, r *RepositoryRes
 			return nil, err
 		}
 
-		return toGitCommitResolver(r, database.NewDB(db), commitID, nil), nil
+		return toGitCommitResolver(r, db, commitID, nil), nil
 	}
 
 	head, err := getCommit(ctx, r.RepoName(), headRevspec)
@@ -128,7 +128,7 @@ func (r *RepositoryResolver) Comparison(ctx context.Context, args *RepositoryCom
 }
 
 type RepositoryComparisonResolver struct {
-	db                       dbutil.DB
+	db                       database.DB
 	baseRevspec, headRevspec string
 	base, head               *GitCommitResolver
 	repo                     *RepositoryResolver
@@ -162,7 +162,7 @@ func (r *RepositoryComparisonResolver) Commits(
 	args *graphqlutil.ConnectionArgs,
 ) *gitCommitConnectionResolver {
 	return &gitCommitConnectionResolver{
-		db:            database.NewDB(r.db),
+		db:            r.db,
 		revisionRange: r.baseRevspec + ".." + r.headRevspec,
 		first:         args.First,
 		repo:          r.repo,

--- a/cmd/frontend/graphqlbackend/repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/highlight"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git/gitapi"
@@ -26,7 +25,7 @@ import (
 
 func TestRepositoryComparison(t *testing.T) {
 	ctx := context.Background()
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(nil)
 
 	wantBaseRevision := "24f7ca7c1190835519e261d7eefa09df55ceea4f"
 	wantMergeBaseRevision := "a7985dde7f92ad3490ec513be78fa2b365c7534c"
@@ -63,7 +62,7 @@ func TestRepositoryComparison(t *testing.T) {
 	t.Cleanup(func() { git.Mocks.MergeBase = nil })
 
 	input := &RepositoryComparisonInput{Base: &wantBaseRevision, Head: &wantHeadRevision}
-	repoResolver := NewRepositoryResolver(database.NewDB(db), repo)
+	repoResolver := NewRepositoryResolver(db, repo)
 
 	comp, err := NewRepositoryComparison(ctx, db, repoResolver, input)
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
@@ -27,7 +26,7 @@ func (r *RepositoryResolver) MirrorInfo() *repositoryMirrorInfoResolver {
 
 type repositoryMirrorInfoResolver struct {
 	repository *RepositoryResolver
-	db         dbutil.DB
+	db         database.DB
 
 	// memoize the repo-updater RepoUpdateSchedulerInfo call
 	repoUpdateSchedulerInfoOnce   sync.Once
@@ -66,7 +65,7 @@ var nonSCPURLRegex = lazyregexp.New(`^(git\+)?(https?|ssh|rsync|file|git|perforc
 func (r *repositoryMirrorInfoResolver) RemoteURL(ctx context.Context) (string, error) {
 	// 🚨 SECURITY: The remote URL might contain secret credentials in the URL userinfo, so
 	// only allow site admins to see it.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, database.NewDB(r.db)); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return "", err
 	}
 

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
@@ -235,7 +234,7 @@ const (
 var mockDecodedViewerFinalSettings *schema.Settings
 
 // decodedViewerFinalSettings returns the final (merged) settings for the viewer
-func decodedViewerFinalSettings(ctx context.Context, db dbutil.DB) (_ *schema.Settings, err error) {
+func decodedViewerFinalSettings(ctx context.Context, db database.DB) (_ *schema.Settings, err error) {
 	tr, ctx := trace.New(ctx, "decodedViewerFinalSettings", "")
 	defer func() {
 		tr.SetError(err)
@@ -245,7 +244,7 @@ func decodedViewerFinalSettings(ctx context.Context, db dbutil.DB) (_ *schema.Se
 		return mockDecodedViewerFinalSettings, nil
 	}
 
-	cascade, err := (&schemaResolver{db: database.NewDB(db)}).ViewerSettings(ctx)
+	cascade, err := (&schemaResolver{db: db}).ViewerSettings(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -20,7 +20,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/comby"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/commit"
@@ -443,7 +442,7 @@ func (a searchAlert) wrapResults() *SearchResults {
 	return &SearchResults{Alert: &a}
 }
 
-func (a searchAlert) wrapSearchImplementer(db dbutil.DB) *alertSearchImplementer {
+func (a searchAlert) wrapSearchImplementer(db database.DB) *alertSearchImplementer {
 	return &alertSearchImplementer{
 		db:    db,
 		alert: a,
@@ -453,12 +452,12 @@ func (a searchAlert) wrapSearchImplementer(db dbutil.DB) *alertSearchImplementer
 // alertSearchImplementer is a light wrapper type around an alert that implements
 // SearchImplementer. This helps avoid needing to have a db on the searchAlert type
 type alertSearchImplementer struct {
-	db    dbutil.DB
+	db    database.DB
 	alert searchAlert
 }
 
 func (a alertSearchImplementer) Results(context.Context) (*SearchResultsResolver, error) {
-	return &SearchResultsResolver{db: database.NewDB(a.db), SearchResults: a.alert.wrapResults()}, nil
+	return &SearchResultsResolver{db: a.db, SearchResults: a.alert.wrapResults()}, nil
 }
 
 func (alertSearchImplementer) Suggestions(context.Context, *searchSuggestionsArgs) ([]SearchSuggestionResolver, error) {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -144,7 +144,7 @@ func matchesToResolvers(db database.DB, matches []result.Match) []SearchResultRe
 		if existing, ok := repoResolvers[repoKey{repoName, rev}]; ok {
 			return existing
 		}
-		resolver := NewRepositoryResolver(database.NewDB(db), repoName.ToRepo())
+		resolver := NewRepositoryResolver(db, repoName.ToRepo())
 		resolver.RepoMatch.Rev = rev
 		repoResolvers[repoKey{repoName, rev}] = resolver
 		return resolver

--- a/cmd/frontend/graphqlbackend/settings_cascade.go
+++ b/cmd/frontend/graphqlbackend/settings_cascade.go
@@ -230,5 +230,5 @@ func (r schemaResolver) ViewerSettings(ctx context.Context) (*settingsCascade, e
 
 // Deprecated: in the GraphQL API
 func (r *schemaResolver) ViewerConfiguration(ctx context.Context) (*settingsCascade, error) {
-	return schemaResolver{db: database.NewDB(r.db)}.ViewerSettings(ctx)
+	return schemaResolver{db: r.db}.ViewerSettings(ctx)
 }

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -89,7 +89,7 @@ func (r *siteResolver) LatestSettings(ctx context.Context) (*settingsResolver, e
 	if settings == nil {
 		return nil, nil
 	}
-	return &settingsResolver{database.NewDB(r.db), &settingsSubject{site: r}, settings, nil}, nil
+	return &settingsResolver{r.db, &settingsSubject{site: r}, settings, nil}, nil
 }
 
 func (r *siteResolver) SettingsCascade() *settingsCascade {
@@ -123,13 +123,13 @@ func (r *siteResolver) AllowSiteSettingsEdits() bool {
 }
 
 type siteConfigurationResolver struct {
-	db dbutil.DB
+	db database.DB
 }
 
 func (r *siteConfigurationResolver) ID(ctx context.Context) (int32, error) {
 	// 🚨 SECURITY: The site configuration contains secret tokens and credentials,
 	// so only admins may view it.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, database.NewDB(r.db)); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return 0, err
 	}
 	return 0, nil // TODO(slimsag): future: return the real ID here to prevent races
@@ -138,7 +138,7 @@ func (r *siteConfigurationResolver) ID(ctx context.Context) (int32, error) {
 func (r *siteConfigurationResolver) EffectiveContents(ctx context.Context) (JSONCString, error) {
 	// 🚨 SECURITY: The site configuration contains secret tokens and credentials,
 	// so only admins may view it.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, database.NewDB(r.db)); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return "", err
 	}
 	siteConfig := globals.ConfigurationServerFrontendOnly.Raw().Site

--- a/cmd/frontend/graphqlbackend/site_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/site_usage_stats.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/usagestatsdeprecated"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -15,7 +14,7 @@ func (r *siteResolver) UsageStatistics(ctx context.Context, args *struct {
 	Weeks  *int32
 	Months *int32
 }) (*siteUsageStatisticsResolver, error) {
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, database.NewDB(r.db)); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/graphqlbackend/status_messages.go
+++ b/cmd/frontend/graphqlbackend/status_messages.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
 )
 
@@ -37,7 +36,7 @@ func (r *schemaResolver) StatusMessages(ctx context.Context) ([]*statusMessageRe
 
 type statusMessageResolver struct {
 	message repos.StatusMessage
-	db      dbutil.DB
+	db      database.DB
 }
 
 func (r *statusMessageResolver) ToCloningProgress() (*statusMessageResolver, bool) {
@@ -83,5 +82,5 @@ func (r *statusMessageResolver) ExternalService(ctx context.Context) (*externalS
 		return nil, err
 	}
 
-	return &externalServiceResolver{db: database.NewDB(r.db), externalService: externalService}, nil
+	return &externalServiceResolver{db: r.db, externalService: externalService}, nil
 }

--- a/cmd/frontend/graphqlbackend/survey_response.go
+++ b/cmd/frontend/graphqlbackend/survey_response.go
@@ -13,14 +13,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/siteid"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 type surveyResponseResolver struct {
-	db             dbutil.DB
+	db             database.DB
 	surveyResponse *types.SurveyResponse
 }
 
@@ -31,7 +30,7 @@ func marshalSurveyResponseID(id int32) graphql.ID { return relay.MarshalID("Surv
 
 func (s *surveyResponseResolver) User(ctx context.Context) (*UserResolver, error) {
 	if s.surveyResponse.UserID != nil {
-		user, err := UserByIDInt32(ctx, database.NewDB(s.db), *s.surveyResponse.UserID)
+		user, err := UserByIDInt32(ctx, s.db, *s.surveyResponse.UserID)
 		if err != nil && errcode.IsNotFound(err) {
 			// This can happen if the user has been deleted, see issue #4888 and #6454
 			return nil, nil

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -450,15 +450,15 @@ func (r *UserResolver) BatchChangesCodeHosts(ctx context.Context, args *ListBatc
 	return EnterpriseResolvers.batchChangesResolver.BatchChangesCodeHosts(ctx, args)
 }
 
-func viewerCanChangeUsername(ctx context.Context, db dbutil.DB, userID int32) bool {
-	if err := backend.CheckSiteAdminOrSameUser(ctx, database.NewDB(db), userID); err != nil {
+func viewerCanChangeUsername(ctx context.Context, db database.DB, userID int32) bool {
+	if err := backend.CheckSiteAdminOrSameUser(ctx, db, userID); err != nil {
 		return false
 	}
 	if conf.Get().AuthEnableUsernameChanges {
 		return true
 	}
 	// 🚨 SECURITY: Only site admins are allowed to change a user's username when auth.enableUsernameChanges == false.
-	return backend.CheckCurrentUserIsSiteAdmin(ctx, database.NewDB(db)) == nil
+	return backend.CheckCurrentUserIsSiteAdmin(ctx, db) == nil
 }
 
 // Users may be trying to change their own username, or someone else's.

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -243,7 +243,7 @@ func (r *schemaResolver) UpdateUser(ctx context.Context, args *updateUserArgs) (
 
 // CurrentUser returns the authenticated user if any. If there is no authenticated user, it returns
 // (nil, nil). If some other error occurs, then the error is returned.
-func CurrentUser(ctx context.Context, db dbutil.DB) (*UserResolver, error) {
+func CurrentUser(ctx context.Context, db database.DB) (*UserResolver, error) {
 	user, err := database.Users(db).GetByCurrentAuthUser(ctx)
 	if err != nil {
 		if errcode.IsNotFound(err) || err == database.ErrNoCurrentUser {
@@ -251,7 +251,7 @@ func CurrentUser(ctx context.Context, db dbutil.DB) (*UserResolver, error) {
 		}
 		return nil, err
 	}
-	return NewUserResolver(database.NewDB(db), user), nil
+	return NewUserResolver(db, user), nil
 }
 
 func (r *UserResolver) Organizations(ctx context.Context) (*orgConnectionStaticResolver, error) {

--- a/cmd/frontend/graphqlbackend/user_emails.go
+++ b/cmd/frontend/graphqlbackend/user_emails.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 var timeNow = time.Now
@@ -42,7 +41,7 @@ func (r *UserResolver) Emails(ctx context.Context) ([]*userEmailResolver, error)
 }
 
 type userEmailResolver struct {
-	db        dbutil.DB
+	db        database.DB
 	userEmail database.UserEmail
 	user      *UserResolver
 }
@@ -64,7 +63,7 @@ func (r *userEmailResolver) VerificationPending() bool {
 func (r *userEmailResolver) User() *UserResolver { return r.user }
 
 func (r *userEmailResolver) ViewerCanManuallyVerify(ctx context.Context) (bool, error) {
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, database.NewDB(r.db)); err == backend.ErrNotAuthenticated || err == backend.ErrMustBeSiteAdmin {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err == backend.ErrNotAuthenticated || err == backend.ErrMustBeSiteAdmin {
 		return false, nil
 	} else if err != nil {
 		return false, err

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -9,7 +9,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/usagestats"
 )
@@ -142,14 +141,14 @@ func (r *userConnectionResolver) useCache() bool {
 // staticUserConnectionResolver implements the GraphQL type UserConnection based on an underlying
 // list of users that is computed statically.
 type staticUserConnectionResolver struct {
-	db    dbutil.DB
+	db    database.DB
 	users []*types.User
 }
 
 func (r *staticUserConnectionResolver) Nodes() []*UserResolver {
 	resolvers := make([]*UserResolver, len(r.users))
 	for i, user := range r.users {
-		resolvers[i] = NewUserResolver(database.NewDB(r.db), user)
+		resolvers[i] = NewUserResolver(r.db, user)
 	}
 	return resolvers
 }

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -40,7 +40,7 @@ type UserConnectionResolver interface {
 var _ UserConnectionResolver = &userConnectionResolver{}
 
 type userConnectionResolver struct {
-	db           dbutil.DB
+	db           database.DB
 	opt          database.UsersListOptions
 	activePeriod *string
 
@@ -86,7 +86,7 @@ func (r *userConnectionResolver) compute(ctx context.Context) ([]*types.User, in
 
 func (r *userConnectionResolver) Nodes(ctx context.Context) ([]*UserResolver, error) {
 	// 🚨 SECURITY: Only site admins can list users.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, database.NewDB(r.db)); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 
@@ -104,7 +104,7 @@ func (r *userConnectionResolver) Nodes(ctx context.Context) ([]*UserResolver, er
 	var l []*UserResolver
 	for _, user := range users {
 		l = append(l, &UserResolver{
-			db:   database.NewDB(r.db),
+			db:   r.db,
 			user: user,
 		})
 	}
@@ -113,7 +113,7 @@ func (r *userConnectionResolver) Nodes(ctx context.Context) ([]*UserResolver, er
 
 func (r *userConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
 	// 🚨 SECURITY: Only site admins can count users.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, database.NewDB(r.db)); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return 0, err
 	}
 

--- a/cmd/frontend/graphqlbackend/users_create.go
+++ b/cmd/frontend/graphqlbackend/users_create.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -55,11 +54,11 @@ func (r *schemaResolver) CreateUser(ctx context.Context, args *struct {
 //
 // 🚨 SECURITY: Only site admins should be able to instantiate this value.
 type createUserResult struct {
-	db   dbutil.DB
+	db   database.DB
 	user *types.User
 }
 
-func (r *createUserResult) User() *UserResolver { return NewUserResolver(database.NewDB(r.db), r.user) }
+func (r *createUserResult) User() *UserResolver { return NewUserResolver(r.db, r.user) }
 
 func (r *createUserResult) ResetPasswordURL(ctx context.Context) (*string, error) {
 	if !userpasswd.ResetPasswordEnabled() {

--- a/cmd/frontend/internal/app/debug.go
+++ b/cmd/frontend/internal/app/debug.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/debugproxies"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/search"
@@ -32,7 +31,7 @@ func init() {
 	conf.ContributeWarning(newPrometheusValidator(srcprometheus.NewClient(srcprometheus.PrometheusURL)))
 }
 
-func addNoK8sClientHandler(r *mux.Router, db dbutil.DB) {
+func addNoK8sClientHandler(r *mux.Router, db database.DB) {
 	noHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, `Cluster information not available`)
 		fmt.Fprintf(w, `<br><br><a href="headers">headers</a><br>`)
@@ -81,14 +80,14 @@ var PreMountGrafanaHook func() error
 // This error is returned if the current license does not support monitoring.
 const errMonitoringNotLicensed = `The feature "monitoring" is not activated in your Sourcegraph license. Upgrade your Sourcegraph subscription to use this feature.`
 
-func addNoGrafanaHandler(r *mux.Router, db dbutil.DB) {
+func addNoGrafanaHandler(r *mux.Router, db database.DB) {
 	noGrafana := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, `Grafana endpoint proxying: Please set env var GRAFANA_SERVER_URL`)
 	})
 	r.Handle("/grafana", adminOnly(noGrafana, db))
 }
 
-func addGrafanaNotLicensedHandler(r *mux.Router, db dbutil.DB) {
+func addGrafanaNotLicensedHandler(r *mux.Router, db database.DB) {
 	notLicensed := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, errMonitoringNotLicensed, http.StatusUnauthorized)
 	})
@@ -96,7 +95,7 @@ func addGrafanaNotLicensedHandler(r *mux.Router, db dbutil.DB) {
 }
 
 // addReverseProxyForService registers a reverse proxy for the specified service.
-func addGrafana(r *mux.Router, db dbutil.DB) {
+func addGrafana(r *mux.Router, db database.DB) {
 	if PreMountGrafanaHook != nil {
 		if err := PreMountGrafanaHook(); err != nil {
 			addGrafanaNotLicensedHandler(r, db)
@@ -128,14 +127,14 @@ func addGrafana(r *mux.Router, db dbutil.DB) {
 	}
 }
 
-func addNoJaegerHandler(r *mux.Router, db dbutil.DB) {
+func addNoJaegerHandler(r *mux.Router, db database.DB) {
 	noJaeger := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, `Jaeger endpoint proxying: Please set env var JAEGER_SERVER_URL`)
 	})
 	r.Handle("/jaeger", adminOnly(noJaeger, db))
 }
 
-func addJaeger(r *mux.Router, db dbutil.DB) {
+func addJaeger(r *mux.Router, db database.DB) {
 	if len(jaegerURLFromEnv) > 0 {
 		fmt.Println("Jaeger URL from env ", jaegerURLFromEnv)
 		jaegerURL, err := url.Parse(jaegerURLFromEnv)
@@ -159,7 +158,7 @@ func addJaeger(r *mux.Router, db dbutil.DB) {
 	}
 }
 
-func addZoekt(r *mux.Router, db dbutil.DB) {
+func addZoekt(r *mux.Router, db database.DB) {
 	z := search.Indexed()
 	if z == nil {
 		return
@@ -179,9 +178,9 @@ func addZoekt(r *mux.Router, db dbutil.DB) {
 }
 
 // adminOnly is a HTTP middleware which only allows requests by admins.
-func adminOnly(next http.Handler, db dbutil.DB) http.Handler {
+func adminOnly(next http.Handler, db database.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := backend.CheckCurrentUserIsSiteAdmin(r.Context(), database.NewDB(db)); err != nil {
+		if err := backend.CheckCurrentUserIsSiteAdmin(r.Context(), db); err != nil {
 			http.Error(w, err.Error(), http.StatusUnauthorized)
 			return
 		}

--- a/cmd/frontend/internal/app/debug_test.go
+++ b/cmd/frontend/internal/app/debug_test.go
@@ -124,7 +124,7 @@ func TestGrafanaLicensing(t *testing.T) {
 
 		router := mux.NewRouter()
 		// nil db as calls are mocked above
-		addGrafana(router, nil)
+		addGrafana(router, database.NewDB(nil))
 		rec := httptest.NewRecorder()
 		router.ServeHTTP(rec, httptest.NewRequest("GET", "/grafana", nil))
 
@@ -144,7 +144,7 @@ func TestGrafanaLicensing(t *testing.T) {
 
 		router := mux.NewRouter()
 		// nil db as calls are mocked above
-		addGrafana(router, nil)
+		addGrafana(router, database.NewDB(nil))
 		rec := httptest.NewRecorder()
 		router.ServeHTTP(rec, httptest.NewRequest("GET", "/grafana", nil))
 

--- a/cmd/frontend/internal/httpapi/api_test.go
+++ b/cmd/frontend/internal/httpapi/api_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi/router"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
 	"github.com/sourcegraph/sourcegraph/internal/txemail"
 )
@@ -18,11 +18,10 @@ func init() {
 
 func newTest() *httptestutil.Client {
 	enterpriseServices := enterprise.DefaultServices()
-	db := new(dbtesting.MockDB)
 	rateLimitStore, _ := memstore.New(1024)
 	rateLimiter := graphqlbackend.NewRateLimiteWatcher(rateLimitStore)
 
-	return httptestutil.NewTest(NewHandler(db,
+	return httptestutil.NewTest(NewHandler(dbmock.NewMockDB(),
 		router.New(mux.NewRouter()),
 		nil,
 		enterpriseServices.GitHubWebhook,

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -25,7 +25,6 @@ import (
 	registry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/api"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/webhooks"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -39,7 +39,7 @@ import (
 //
 // 🚨 SECURITY: The caller MUST wrap the returned handler in middleware that checks authentication
 // and sets the actor in the request context.
-func NewHandler(db dbutil.DB, m *mux.Router, schema *graphql.Schema, githubWebhook webhooks.Registerer, gitlabWebhook, bitbucketServerWebhook http.Handler, newCodeIntelUploadHandler enterprise.NewCodeIntelUploadHandler, rateLimiter graphqlbackend.LimitWatcher) http.Handler {
+func NewHandler(db database.DB, m *mux.Router, schema *graphql.Schema, githubWebhook webhooks.Registerer, gitlabWebhook, bitbucketServerWebhook http.Handler, newCodeIntelUploadHandler enterprise.NewCodeIntelUploadHandler, rateLimiter graphqlbackend.LimitWatcher) http.Handler {
 	if m == nil {
 		m = apirouter.New(nil)
 	}
@@ -81,7 +81,7 @@ func NewHandler(db dbutil.DB, m *mux.Router, schema *graphql.Schema, githubWebho
 
 	m.Get(apirouter.GraphQL).Handler(trace.Route(handler(serveGraphQL(schema, rateLimiter, false))))
 
-	m.Get(apirouter.SearchStream).Handler(trace.Route(frontendsearch.StreamHandler(database.NewDB(db))))
+	m.Get(apirouter.SearchStream).Handler(trace.Route(frontendsearch.StreamHandler(db)))
 
 	// Return the minimum src-cli version that's compatible with this instance
 	m.Get(apirouter.SrcCliVersion).Handler(trace.Route(handler(srcCliVersionServe)))

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/provider.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/oauth"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
@@ -62,7 +63,7 @@ func parseProvider(p *schema.GitHubAuthProvider, db dbutil.DB, sourceCfg schema.
 				&oauth2Cfg,
 				oauth.SessionIssuer(db, &sessionIssuerHelper{
 					CodeHost:    codeHost,
-					db:          db,
+					db:          database.NewDB(db),
 					clientID:    p.ClientID,
 					allowSignup: p.AllowSignup,
 					allowOrgs:   p.AllowOrgs,

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/session.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/session.go
@@ -20,7 +20,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/oauth"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	esauth "github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	githubsvc "github.com/sourcegraph/sourcegraph/internal/extsvc/github"
@@ -30,7 +29,7 @@ import (
 
 type sessionIssuerHelper struct {
 	*extsvc.CodeHost
-	db          dbutil.DB
+	db          database.DB
 	clientID    string
 	allowSignup bool
 	allowOrgs   []string
@@ -98,7 +97,7 @@ func (s *sessionIssuerHelper) GetOrCreateUser(ctx context.Context, token *oauth2
 	}
 
 	for i, attempt := range attempts {
-		userID, safeErrMsg, err := auth.GetAndSaveUser(ctx, database.NewDB(s.db), auth.GetAndSaveUserOp{
+		userID, safeErrMsg, err := auth.GetAndSaveUser(ctx, s.db, auth.GetAndSaveUserOp{
 			UserProps: database.NewUser{
 				Username:        login,
 				Email:           attempt.email,

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/session_test.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/session_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	githubsvc "github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -313,7 +312,7 @@ func TestSessionIssuerHelper_CreateCodeHostConnectionHandlesExistingService(t *t
 func createCodeHostConnectionHelper(t *testing.T, serviceExists bool) {
 	t.Helper()
 
-	db := dbtest.NewDB(t)
+	db := database.NewDB(nil)
 
 	ctx := context.Background()
 	s := &sessionIssuerHelper{db: db}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace.go
@@ -305,7 +305,7 @@ func (r *batchSpecWorkspaceStagesResolver) Setup() []graphqlbackend.ExecutionLog
 
 func (r *batchSpecWorkspaceStagesResolver) SrcExec() graphqlbackend.ExecutionLogEntryResolver {
 	if entry, ok := findExecutionLogEntry(r.execution, "step.src.0"); ok {
-		return graphqlbackend.NewExecutionLogEntryResolver(r.store.DB(), entry)
+		return graphqlbackend.NewExecutionLogEntryResolver(r.store.DatabaseDB(), entry)
 	}
 
 	return nil
@@ -321,7 +321,7 @@ func (r *batchSpecWorkspaceStagesResolver) executionLogEntryResolversWithPrefix(
 		if !strings.HasPrefix(entry.Key, prefix) {
 			continue
 		}
-		r := graphqlbackend.NewExecutionLogEntryResolver(r.store.DB(), entry)
+		r := graphqlbackend.NewExecutionLogEntryResolver(r.store.DatabaseDB(), entry)
 		resolvers = append(resolvers, r)
 	}
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step.go
@@ -122,7 +122,7 @@ func (r *batchSpecWorkspaceStepResolver) DiffStat(ctx context.Context) (*graphql
 
 func (r *batchSpecWorkspaceStepResolver) Diff(ctx context.Context) (graphqlbackend.PreviewRepositoryComparisonResolver, error) {
 	if r.stepInfo.Diff != nil {
-		return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DB(), r.repo, r.baseRev, *r.stepInfo.Diff)
+		return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), r.repo, r.baseRev, *r.stepInfo.Diff)
 	}
 	return nil, nil
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
@@ -483,7 +483,7 @@ func (r *changesetResolver) Diff(ctx context.Context) (graphqlbackend.Repository
 
 		return graphqlbackend.NewPreviewRepositoryComparisonResolver(
 			ctx,
-			r.store.DB(),
+			r.store.DatabaseDB(),
 			r.repoResolver,
 			desc.BaseRev,
 			diff,

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
@@ -518,7 +518,7 @@ func (r *changesetResolver) Diff(ctx context.Context) (graphqlbackend.Repository
 		}
 	}
 
-	return graphqlbackend.NewRepositoryComparison(ctx, r.store.DB(), r.repoResolver, &graphqlbackend.RepositoryComparisonInput{
+	return graphqlbackend.NewRepositoryComparison(ctx, r.store.DatabaseDB(), r.repoResolver, &graphqlbackend.RepositoryComparisonInput{
 		Base:         &base,
 		Head:         &head,
 		FetchMissing: true,

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec.go
@@ -174,7 +174,7 @@ func (r *changesetDescriptionResolver) Diff(ctx context.Context) (graphqlbackend
 	if err != nil {
 		return nil, err
 	}
-	return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DB(), r.repoResolver, r.desc.BaseRev, diff)
+	return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), r.repoResolver, r.desc.BaseRev, diff)
 }
 
 func (r *changesetDescriptionResolver) Commits() []graphqlbackend.GitCommitDescriptionResolver {

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index_steps.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index_steps.go
@@ -6,6 +6,7 @@ import (
 
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
@@ -51,7 +52,7 @@ func (r *indexStepsResolver) Index() gql.IndexStepResolver {
 
 func (r *indexStepsResolver) Upload() gql.ExecutionLogEntryResolver {
 	if entry, ok := r.findExecutionLogEntry("step.src.0"); ok {
-		return gql.NewExecutionLogEntryResolver(dbconn.Global, entry)
+		return gql.NewExecutionLogEntryResolver(database.NewDB(dbconn.Global), entry)
 	}
 
 	return nil
@@ -77,7 +78,7 @@ func (r *indexStepsResolver) executionLogEntryResolversWithPrefix(prefix string)
 		if !strings.HasPrefix(entry.Key, prefix) {
 			continue
 		}
-		r := gql.NewExecutionLogEntryResolver(dbconn.Global, entry)
+		r := gql.NewExecutionLogEntryResolver(database.NewDB(dbconn.Global), entry)
 		resolvers = append(resolvers, r)
 	}
 

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index_steps_index.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index_steps_index.go
@@ -3,6 +3,7 @@ package graphql
 import (
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
@@ -19,7 +20,7 @@ func (r *indexStepResolver) Outfile() *string      { return strPtr(r.index.Outfi
 
 func (r *indexStepResolver) LogEntry() gql.ExecutionLogEntryResolver {
 	if r.entry != nil {
-		return gql.NewExecutionLogEntryResolver(dbconn.Global, *r.entry)
+		return gql.NewExecutionLogEntryResolver(database.NewDB(dbconn.Global), *r.entry)
 	}
 
 	return nil

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index_steps_preindex.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index_steps_preindex.go
@@ -3,6 +3,7 @@ package graphql
 import (
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
@@ -20,7 +21,7 @@ func (r *preIndexStepResolver) Commands() []string { return r.step.Commands }
 
 func (r *preIndexStepResolver) LogEntry() gql.ExecutionLogEntryResolver {
 	if r.entry != nil {
-		return gql.NewExecutionLogEntryResolver(dbconn.Global, *r.entry)
+		return gql.NewExecutionLogEntryResolver(database.NewDB(dbconn.Global), *r.entry)
 	}
 
 	return nil

--- a/enterprise/cmd/frontend/internal/registry/publisher_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/publisher_graphql.go
@@ -27,7 +27,7 @@ func extensionRegistryViewerPublishers(ctx context.Context, db dbutil.DB) ([]gra
 	}
 
 	var publishers []graphqlbackend.RegistryPublisher
-	user, err := graphqlbackend.CurrentUser(ctx, db)
+	user, err := graphqlbackend.CurrentUser(ctx, database.NewDB(db))
 	if err != nil || user == nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is another PR that reduces our dependency on `database.NewDB()`
by passing the `database.DB` type through rather than converting to 
`dbutil.DB` and back. The process here is just: 
1) look for a use of `database.NewDB()`
2) convert the `dbutil.DB` it's wrapping into a `database.DB`
3) update call sites
4) repeat

All these uses of `database.NewDB()` were intended to be temporary
until more of the codebase was converted to use `database.DB` instead
of `dbutil.DB`. It allowed me to make these changes incrementally, 
but now we're getting to the point where we can connect all the disconnected
`database.DB` instances into one large chain. 

The changes here are extremely mechanical, so I apologize for the continued
stream of boring PRs 😄 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
