### PR TITLE
graphqlbackend: specify `NoNamespace` to exclude inaccessible external services

### DIFF
--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -282,7 +282,7 @@ func (r *schemaResolver) ExternalServices(ctx context.Context, args *ExternalSer
 
 	opt := database.ExternalServicesListOptions{
 		// 🚨 SECURITY: When both `namespaceUserID` and `namespaceOrgID` are not
-		// specified we need to explicitly specifying `NoNamespace`, otherwise site
+		// specified we need to explicitly specify `NoNamespace`, otherwise site
 		// admins will be able to list all user code host connections that are not
 		// accessible when trying to access them individually.
 		NoNamespace:     namespaceUserID == 0 && namespaceOrgID == 0,

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -281,6 +281,11 @@ func (r *schemaResolver) ExternalServices(ctx context.Context, args *ExternalSer
 	}
 
 	opt := database.ExternalServicesListOptions{
+		// 🚨 SECURITY: When both `namespaceUserID` and `namespaceOrgID` are not
+		// specified we need to explicitly specifying `NoNamespace`, otherwise site
+		// admins will be able to list all user code host connections that are not
+		// accessible when trying to access them individually.
+		NoNamespace:     namespaceUserID == 0 && namespaceOrgID == 0,
 		NamespaceUserID: namespaceUserID,
 		NamespaceOrgID:  namespaceOrgID,
 		AfterID:         afterID,


### PR DESCRIPTION
Based on our product design, site admins are not able to access user code host connections, this design is correctly enforced when site admins try to access them individually. However, this can be currently bypassed using `externalServices` endpoint.

![CleanShot 2021-11-10 at 14 01 05@2x](https://user-images.githubusercontent.com/2946214/141058622-5375348f-8be1-4381-821e-91afc2bffcd2.png)

This PR fixes that.

Another nice side-effect is that in the site admin area, we now only see the site-level code host connections.

<img width="930" alt="CleanShot 2021-11-10 at 14 02 14@2x" src="https://user-images.githubusercontent.com/2946214/141058687-e7aeef1c-02d6-46a5-915f-cd56c89b0769.png">


