### PR TITLE
gomod: update zoekt

### DIFF
--- a/dev/zoekt/update
+++ b/dev/zoekt/update
@@ -18,7 +18,7 @@ module="$(go get "${fork}@${version}" 2>&1 | grep -E -o ${fork}'@v0.0.0-[0-9a-z-
 newsha="$(echo "$module" | grep -o '[a-f0-9]*$')"
 
 echo "https://github.com/sourcegraph/zoekt/compare/$oldsha...$newsha"
-echo "git log --pretty=format:'- https://github.com/sourcegraph/zoekt/commit/%h %s' $oldsha...$newsha"
+echo "git log --pretty=format:'- https://github.com/sourcegraph/zoekt/commit/%h %s' $oldsha...$newsha | sed 's/ (#[0-9]*)//g'"
 echo "git log --pretty=format:'- %h %s' $oldsha...$newsha"
 
 go mod edit "-replace=${upstream}=${module}"

--- a/go.mod
+++ b/go.mod
@@ -333,7 +333,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20211021094329-fe32d3466c1f
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20211110070858-ae47cfcc20df
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20210809100802-88b656a8713e

--- a/go.sum
+++ b/go.sum
@@ -1827,8 +1827,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20211021094329-fe32d3466c1f h1:YzxLYTchnuPya9UysSotiupo5yqrbwWjyDIS5euFBlw=
-github.com/sourcegraph/zoekt v0.0.0-20211021094329-fe32d3466c1f/go.mod h1:aLcDL//nbHjkOFRadYDb9yNiFc3yOq+3ZSFKSGESiME=
+github.com/sourcegraph/zoekt v0.0.0-20211110070858-ae47cfcc20df h1:8nuGSASl6EaHl1XFJBhitTL6xqqX/DACtvMj31XQSMc=
+github.com/sourcegraph/zoekt v0.0.0-20211110070858-ae47cfcc20df/go.mod h1:x1Zva3SbvSL4wCQnQ93LGTpQrXjKp8r8vyd09l/xCBE=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/internal/search/backend/cached_test.go
+++ b/internal/search/backend/cached_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/zoekt"
 	zoektquery "github.com/google/zoekt/query"
 )
@@ -52,8 +53,9 @@ func TestCachedSearcher(t *testing.T) {
 	have, _ = s.List(ctx, &zoektquery.Const{Value: true}, nil)
 	want = &zoekt.RepoList{Repos: ms.FakeSearcher.Repos}
 
-	if !cmp.Equal(have, want) {
-		t.Fatalf("list mismatch: %s", cmp.Diff(have, want))
+	diffOpts := cmpopts.IgnoreUnexported(zoekt.Repository{})
+	if d := cmp.Diff(want, have, diffOpts); d != "" {
+		t.Fatalf("list mismatch: %s", d)
 	}
 
 	if have, want := atomic.LoadInt64(&ms.ListCalls), int64(1); have != want {
@@ -68,7 +70,7 @@ func TestCachedSearcher(t *testing.T) {
 		have, _ = s.List(ctx, &zoektquery.Const{Value: true}, nil)
 		want = &zoekt.RepoList{Repos: ms.FakeSearcher.Repos}
 
-		if !cmp.Equal(have, want) {
+		if !cmp.Equal(have, want, diffOpts) {
 			time.Sleep(10 * time.Millisecond)
 			continue
 		}


### PR DESCRIPTION
Quite a few changes since our last bump:

- https://github.com/sourcegraph/zoekt/commit/ae47cfc indexserver: ensure indexed for unchanged repositories
- https://github.com/sourcegraph/zoekt/commit/905148e indexserver: set and read Config Fingerprint
- https://github.com/sourcegraph/zoekt/commit/8cc3582 indexserver: Sourcegraph interface is just List
- https://github.com/sourcegraph/zoekt/commit/d89a313 indexserver: move CloneURL into IndexOptions
- https://github.com/sourcegraph/zoekt/commit/bfeddd7 indexserver: delete meta file after merging
- https://github.com/sourcegraph/zoekt/commit/cd787b0 update README to reflect we are the defacto source
- https://github.com/sourcegraph/zoekt/commit/f8682c1 shards: stream results per repo for compound shards
- https://github.com/sourcegraph/zoekt/commit/ba7cd37 indexserver: merge in order of priority
- https://github.com/sourcegraph/zoekt/commit/004c956 shards: send max pending priority while searching
- https://github.com/sourcegraph/zoekt/commit/df63d76 indexserver: don't delete shards if merge didn't run
- https://github.com/sourcegraph/zoekt/commit/4c69cfb indexserver: automate merging
- https://github.com/sourcegraph/zoekt/commit/9d85eab indexserver: update merge policy
- https://github.com/sourcegraph/zoekt/commit/0e81eb3 shards: set SearchResult.Progress.Priority
- https://github.com/sourcegraph/zoekt/commit/c79ecf9 shards: only `observeMetrics` when `r.err == nil`
- https://github.com/sourcegraph/zoekt/commit/f493172 shards: buffer search channel
