### PR TITLE
Remove noop -clear-cache flag in 'src batch exec' jobs

### DIFF
--- a/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform.go
@@ -130,14 +130,9 @@ func transformRecord(ctx context.Context, s batchesStore, job *btypes.BatchSpecW
 		VirtualMachineFiles: map[string]string{"input.json": string(marshaledInput)},
 		CliSteps: []apiclient.CliStep{
 			{
-				Commands: []string{
-					"batch",
-					"exec",
-					"-f", "input.json",
-					"-clear-cache",
-				},
-				Dir: ".",
-				Env: cliEnv,
+				Commands: []string{"batch", "exec", "-f", "input.json"},
+				Dir:      ".",
+				Env:      cliEnv,
 			},
 		},
 		RedactedValues: map[string]string{

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform_test.go
@@ -97,12 +97,8 @@ func TestTransformRecord(t *testing.T) {
 		VirtualMachineFiles: map[string]string{"input.json": string(marshaledInput)},
 		CliSteps: []apiclient.CliStep{
 			{
-				Commands: []string{
-					"batch", "exec",
-					"-f", "input.json",
-					"-clear-cache",
-				},
-				Dir: ".",
+				Commands: []string{"batch", "exec", "-f", "input.json"},
+				Dir:      ".",
 				Env: []string{
 					"SRC_ENDPOINT=https://sourcegraph:hunter2@test.io",
 					"SRC_ACCESS_TOKEN=" + accessToken,


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/26929

After https://github.com/sourcegraph/src-cli/pull/653 the `-clear-cache`
flag for `src batch exec` will be a noop so we can remove it here.
