### PR TITLE
perforce: Add separate NetworkThreadFetch config option

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -250,15 +250,16 @@ func main() {
 func configureFusionClient(conn schema.PerforceConnection) server.FusionConfig {
 	// Set up default settings first
 	fc := server.FusionConfig{
-		Enabled:         conn.UseFusionClient,
-		Client:          conn.P4Client,
-		LookAhead:       2000,
-		NetworkThreads:  12,
-		PrintBatch:      10,
-		Refresh:         100,
-		Retries:         10,
-		MaxChanges:      -1,
-		IncludeBinaries: false,
+		Enabled:             conn.UseFusionClient,
+		Client:              conn.P4Client,
+		LookAhead:           2000,
+		NetworkThreads:      12,
+		NetworkThreadsFetch: 12,
+		PrintBatch:          10,
+		Refresh:             100,
+		Retries:             10,
+		MaxChanges:          -1,
+		IncludeBinaries:     false,
 	}
 
 	if conn.FusionClient == nil {
@@ -268,6 +269,7 @@ func configureFusionClient(conn schema.PerforceConnection) server.FusionConfig {
 	fc.Enabled = conn.FusionClient.Enabled || conn.UseFusionClient
 	fc.LookAhead = conn.FusionClient.LookAhead
 	fc.NetworkThreads = conn.FusionClient.NetworkThreads
+	fc.NetworkThreadsFetch = conn.FusionClient.NetworkThreadsFetch
 	fc.PrintBatch = conn.FusionClient.PrintBatch
 	fc.Refresh = conn.FusionClient.Refresh
 	fc.Retries = conn.FusionClient.Retries

--- a/cmd/gitserver/server/vcs_syncer.go
+++ b/cmd/gitserver/server/vcs_syncer.go
@@ -135,6 +135,9 @@ type FusionConfig struct {
 	// NetworkThreads: The number of threads in the threadpool for running network
 	// calls. Defaults to the number of logical CPUs.
 	NetworkThreads int
+	// NetworkThreadsFetch: The same as network threads but specifically used when
+	// fetching rather than cloning.
+	NetworkThreadsFetch int
 	// PrintBatch:  The p4 print batch size
 	PrintBatch int
 	// Refresh: How many times a connection should be reused before it is refreshed
@@ -342,7 +345,7 @@ func (s *PerforceDepotSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, dir
 			"--client", s.FusionConfig.Client,
 			"--user", username,
 			"--src", root+".git",
-			"--networkThreads", strconv.Itoa(s.FusionConfig.NetworkThreads),
+			"--networkThreads", strconv.Itoa(s.FusionConfig.NetworkThreadsFetch),
 			"--printBatch", strconv.Itoa(s.FusionConfig.PrintBatch),
 			"--port", host,
 			"--lookAhead", strconv.Itoa(s.FusionConfig.LookAhead),

--- a/schema/perforce.schema.json
+++ b/schema/perforce.schema.json
@@ -104,6 +104,12 @@
           "default": 12,
           "minimum": 1
         },
+        "networkThreadsFetch": {
+          "description": "The number of threads in the threadpool for running network calls when performing fetches. Defaults to the number of logical CPUs.",
+          "type": "integer",
+          "default": 12,
+          "minimum": 1
+        },
         "printBatch": {
           "description": "The p4 print batch size",
           "type": "integer",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -630,6 +630,8 @@ type FusionClient struct {
 	MaxChanges int `json:"maxChanges,omitempty"`
 	// NetworkThreads description: The number of threads in the threadpool for running network calls. Defaults to the number of logical CPUs.
 	NetworkThreads int `json:"networkThreads,omitempty"`
+	// NetworkThreadsFetch description: The number of threads in the threadpool for running network calls when performing fetches. Defaults to the number of logical CPUs.
+	NetworkThreadsFetch int `json:"networkThreadsFetch,omitempty"`
 	// PrintBatch description: The p4 print batch size
 	PrintBatch int `json:"printBatch,omitempty"`
 	// Refresh description: How many times a connection should be reused before it is refreshed


### PR DESCRIPTION
This allows specifiying a different number of threads for fetches as
opposed to clones.
