### PR TITLE
doc/repo: incremental sync can be effectively a complete sync

### DIFF
--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -287,6 +287,7 @@ The two types of sync, [user-centric and repository-centric](#background-permiss
 - **Complete sync** means a user has completed user-centric permissions sync (or a repository has completed a repository-centric sync), which indicates the most accurate permissions from the code host has been presisted to Sourcegraph for the user (or vice versa for repositories).
 - **Incremental sync** means a user has *not* yet completed a recent user-centric permissions sync, but has been recently granted some permissions from a repository-centric sync (or vice versa for repositories).
   - For example, if a user has *not* had a user-centric permissions sync, but has been granted permissions from one or more repository-centric syncs, the user will have only completed an incremental sync. In this state, a user might not have access to all repositories they should have access to, but will incrementally receive more access as repository-centric syncs complete.
+  - It is possible to be in an incremental sync state where a user or repository has effectively completed a complete sync, and all access rules are aligned with what is in the code host - for example, if a user completed a complete sync and a single repository is added, the user will be granted access to that repository through incremental sync, so the user will have full access to everything the user should have access to despite being in an incremental sync state.
 
 The state of permissions is [repeatedly and continuously updated in the background](#permissions-sync-scheduling).
 


### PR DESCRIPTION
See diff. Response to https://sourcegraph.slack.com/archives/C02HNFNN5HU/p1636399635057000