### PR TITLE
Correct Redis alert

### DIFF
--- a/monitoring/definitions/redis.go
+++ b/monitoring/definitions/redis.go
@@ -31,7 +31,7 @@ func Redis() *monitoring.Container {
 							Query:         `redis_up{app="redis-store"}`,
 							DataMustExist: true,
 							Panel:         monitoring.Panel().LegendFormat("{{app}}"),
-							Critical:      monitoring.Alert().LessOrEqual(1, nil).For(10 * time.Second),
+							Critical:      monitoring.Alert().Less(1, nil).For(10 * time.Second),
 							PossibleSolutions: `
 								- Ensure redis-store is running
 							`,
@@ -52,7 +52,7 @@ func Redis() *monitoring.Container {
 							Query:         `redis_up{app="redis-cache"}`,
 							Panel:         monitoring.Panel().LegendFormat("{{app}}"),
 							DataMustExist: true,
-							Critical:      monitoring.Alert().LessOrEqual(1, nil).For(10 * time.Second),
+							Critical:      monitoring.Alert().Less(1, nil).For(10 * time.Second),
 							PossibleSolutions: `
 								- Ensure redis-cache is running
 							`,


### PR DESCRIPTION
Redis alert should fire only when Redis up value is less than 1. Not less than or equal



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
