### PR TITLE
Code Insights: Separate gql queries in order to fix problem with fetching all insigh…

### DIFF
--- a/client/web/src/enterprise/insights/core/backend/api/get-backend-insight.ts
+++ b/client/web/src/enterprise/insights/core/backend/api/get-backend-insight.ts
@@ -4,7 +4,7 @@ import { map, switchMap } from 'rxjs/operators'
 import { SearchBackendBasedInsight } from '../../types/insight/search-insight'
 import { fetchBackendInsights } from '../requests/fetch-backend-insights'
 import { BackendInsightData } from '../types'
-import { createViewContent } from '../utils/create-view-content'
+import { createLineChartContent } from '../utils/create-line-chart-content'
 
 export class InsightStillProcessingError extends Error {
     constructor(message: string = 'Your insight is being processed') {
@@ -29,7 +29,7 @@ export function getBackendInsight(insight: SearchBackendBasedInsight): Observabl
             view: {
                 title: insight.title ?? backendInsight.title,
                 subtitle: '',
-                content: [createViewContent(backendInsight, series)],
+                content: [createLineChartContent(backendInsight, series)],
                 isFetchingHistoricalData: backendInsight.series.some(
                     ({ status: { pendingJobs, backfillQueuedAt } }) => pendingJobs > 0 || backfillQueuedAt === null
                 ),

--- a/client/web/src/enterprise/insights/core/backend/api/get-backend-insights.ts
+++ b/client/web/src/enterprise/insights/core/backend/api/get-backend-insights.ts
@@ -5,7 +5,7 @@ import { asError } from '@sourcegraph/shared/src/util/errors'
 
 import { fetchBackendInsights } from '../requests/fetch-backend-insights'
 import { ViewInsightProviderResult, ViewInsightProviderSourceType } from '../types'
-import { createViewContent } from '../utils/create-view-content'
+import { createLineChartContent } from '../utils/create-line-chart-content'
 
 /**
  * Returns list of backend insights via gql API request.
@@ -47,7 +47,7 @@ function getRawBackendInsights(insightIds: string[]): Observable<ViewInsightProv
                     id: insight.id,
                     view: {
                         title: insight.title,
-                        content: [createViewContent(insight)],
+                        content: [createLineChartContent(insight)],
                     },
                     source: ViewInsightProviderSourceType.Backend,
                 })

--- a/client/web/src/enterprise/insights/core/backend/code-insights-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-backend.ts
@@ -46,7 +46,9 @@ export interface CodeInsightsBackend {
 
     /**
      * Return all accessible for a user insights that are filtered by ids param.
-     * If ids is nullable value then returns all insights.
+     * If ids is nullable value then returns all insights. Insights in this case
+     * present only insight configurations and meta data without actual data about
+     * data series or pie chart data.
      *
      * @param ids - list of insight ids
      */
@@ -60,6 +62,12 @@ export interface CodeInsightsBackend {
      */
     getReachableInsights: (subjectId: string) => Observable<ReachableInsight[]>
 
+    /**
+     * Return insight (meta and presentation data) by insight id.
+     * Note that insight model doesn't contain any data series points.
+     *
+     * @param id
+     */
     getInsightById: (id: string) => Observable<Insight | null>
 
     findInsightByName: (input: FindInsightByNameInput) => Observable<Insight | null>

--- a/client/web/src/enterprise/insights/core/backend/gql/GetInsightView.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql/GetInsightView.ts
@@ -1,0 +1,29 @@
+import { gql } from '@apollo/client'
+
+/**
+ * GQL query for fetching insight data model with data series points and chart
+ * information.
+ */
+export const GET_INSIGHT_VIEW_GQL = gql`
+    query GetInsightView($id: ID) {
+        insightViews(id: $id) {
+            nodes {
+                id
+                dataSeries {
+                    seriesId
+                    label
+                    points {
+                        dateTime
+                        value
+                    }
+                    status {
+                        backfillQueuedAt
+                        completedJobs
+                        pendingJobs
+                        failedJobs
+                    }
+                }
+            }
+        }
+    }
+`

--- a/client/web/src/enterprise/insights/core/backend/gql/GetInsights.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql/GetInsights.ts
@@ -1,0 +1,42 @@
+import { gql } from '@apollo/client'
+
+/**
+ * GQL query for getting all insight views that are accessible for a user.
+ * Note that this query doesn't contains any chart data series points.
+ * Insight model in this case contains only meta and presentation chart data.
+ */
+export const GET_INSIGHTS_GQL = gql`
+    query GetInsights($id: ID) {
+        insightViews(id: $id) {
+            nodes {
+                id
+                presentation {
+                    __typename
+                    ... on LineChartInsightViewPresentation {
+                        title
+                        seriesPresentation {
+                            seriesId
+                            label
+                            color
+                        }
+                    }
+                }
+                dataSeriesDefinitions {
+                    ... on SearchInsightDataSeriesDefinition {
+                        seriesId
+                        query
+                        repositoryScope {
+                            repositories
+                        }
+                        timeScope {
+                            ... on InsightIntervalTimeScope {
+                                unit
+                                value
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+`

--- a/client/web/src/enterprise/insights/core/backend/gql/GetInsightsDashboards.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql/GetInsightsDashboards.ts
@@ -1,0 +1,22 @@
+import { gql } from '@apollo/client'
+
+export const GET_INSIGHTS_DASHBOARDS_GQL = gql`
+    query InsightsDashboards($id: ID) {
+        insightsDashboards(id: $id) {
+            nodes {
+                id
+                title
+                views {
+                    nodes {
+                        id
+                    }
+                }
+                grants {
+                    users
+                    organizations
+                    global
+                }
+            }
+        }
+    }
+`

--- a/client/web/src/enterprise/insights/core/backend/utils/get-dashboard-grants.ts
+++ b/client/web/src/enterprise/insights/core/backend/utils/get-dashboard-grants.ts
@@ -1,0 +1,28 @@
+import { InsightsPermissionGrantsInput } from '../../../../../graphql-operations'
+import { DashboardCreateInput } from '../code-insights-backend-types'
+
+/**
+ * Helper function to parse a grants object from a given type and visibility.
+ * TODO: Remove this function when settings api is deprecated
+ *
+ * @param input {object} - A DashboardCreateInput object
+ * @param input.type {('personal'|'organization'|'global')} - The type of the dashboard
+ * @param input.visibility {string} - Usually the user or organization id
+ * @param input.userIds {string[]} - The user ids to grant permissions to
+ * @returns - A properly formatted grants object
+ */
+export const createDashboardGrants = (input: DashboardCreateInput): InsightsPermissionGrantsInput => {
+    const grants: InsightsPermissionGrantsInput = {}
+    const { type, userIds, visibility } = input
+    if (type === 'personal') {
+        grants.users = userIds || []
+    }
+    if (type === 'organization') {
+        grants.organizations = [visibility]
+    }
+    if (type === 'global') {
+        grants.global = true
+    }
+
+    return grants
+}

--- a/client/web/src/enterprise/insights/core/backend/utils/insight-transformers.ts
+++ b/client/web/src/enterprise/insights/core/backend/utils/insight-transformers.ts
@@ -3,10 +3,10 @@ import { uniq } from 'lodash'
 
 import { isDefined } from '@sourcegraph/shared/src/util/types'
 
-import { GetInsightsResult, InsightViewsFields, TimeIntervalStepUnit } from '../../../../../graphql-operations'
+import { GetInsightsResult, TimeIntervalStepUnit, TimeIntervalStepInput } from '../../../../../graphql-operations'
 import { Insight, InsightType, SearchBasedInsight } from '../../types'
 
-function getDurationFromStep(step: InsightViewsFields['dataSeriesDefinitions'][number]['timeScope']): Duration {
+function getDurationFromStep(step: TimeIntervalStepInput): Duration {
     switch (step.unit) {
         case TimeIntervalStepUnit.HOUR:
             return { hours: step.value }
@@ -70,10 +70,10 @@ export const getInsightView = (insight: GetInsightsResult['insightViews']['nodes
     switch (insight.presentation.__typename) {
         case 'LineChartInsightViewPresentation': {
             const isBackendInsight = insight.dataSeriesDefinitions.every(
-                series => series.repositoryScope.repositories.length > 0
+                series => series.repositoryScope.repositories.length === 0
             )
 
-            const series = insight.dataSeries.map(series => ({
+            const series = insight.presentation.seriesPresentation.map(series => ({
                 name: series.label,
                 query:
                     insight.dataSeriesDefinitions.find(definition => definition.seriesId === series.seriesId)?.query ||

--- a/client/web/src/enterprise/insights/core/backend/utils/parse-dashboard-type.ts
+++ b/client/web/src/enterprise/insights/core/backend/utils/parse-dashboard-type.ts
@@ -1,0 +1,25 @@
+import { InsightsDashboardType } from '../../types'
+
+/**
+ * Helper function to parse the dashboard type from the grants object.
+ * TODO: Remove this function when settings api is deprecated
+ *
+ * @param grants {object} - A grants object from an insight dashboard
+ * @param grants.global {boolean}
+ * @param grants.users {string[]}
+ * @param grants.organizations {string[]}
+ * @returns - The type of the dashboard
+ */
+export const parseDashboardType = (grants?: {
+    global?: boolean
+    users?: string[]
+    organizations?: string[]
+}): InsightsDashboardType.Personal | InsightsDashboardType.Organization | InsightsDashboardType.Global => {
+    if (grants?.global) {
+        return InsightsDashboardType.Global
+    }
+    if (grants?.organizations?.length) {
+        return InsightsDashboardType.Organization
+    }
+    return InsightsDashboardType.Personal
+}

--- a/client/web/src/enterprise/insights/core/types/dashboard/virtual-dashboard.ts
+++ b/client/web/src/enterprise/insights/core/types/dashboard/virtual-dashboard.ts
@@ -7,5 +7,5 @@ import { InsightsDashboardType } from './core'
 export interface VirtualInsightsDashboard {
     type: InsightsDashboardType.All
     id: string
-    insightIds: string[]
+    insightIds?: string[]
 }

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/add-insight-modal/AddInsightModal.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/add-insight-modal/AddInsightModal.tsx
@@ -11,7 +11,7 @@ import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 
 import { FORM_ERROR, SubmissionErrors } from '../../../../../components/form/hooks/useForm'
 import { CodeInsightsBackendContext } from '../../../../../core/backend/code-insights-backend-context'
-import { parseType } from '../../../../../core/backend/code-insights-gql-backend'
+import { parseDashboardType } from '../../../../../core/backend/utils/parse-dashboard-type'
 import { SettingsBasedInsightDashboard } from '../../../../../core/types'
 
 import styles from './AddInsightModal.module.scss'
@@ -47,7 +47,7 @@ export const AddInsightModal: React.FunctionComponent<AddInsightModalProps> = pr
     const handleSubmit = async (values: AddInsightFormValues): Promise<void | SubmissionErrors> => {
         try {
             const { insightIds } = values
-            const type = dashboard.grants && parseType(dashboard.grants)
+            const type = dashboard.grants && parseDashboardType(dashboard.grants)
 
             await updateDashboard({
                 previousDashboard: dashboard,

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
@@ -21,6 +21,7 @@ import { DashboardInsights } from './components/dashboard-inisghts/DashboardInsi
 import styles from './DashboardsContent.module.scss'
 import { useCopyURLHandler } from './hooks/use-copy-url-handler'
 import { useDashboardSelectHandler } from './hooks/use-dashboard-select-handler'
+import { findDashboardByUrlId } from './utils/find-dashboard-by-url-id'
 import { isDashboardConfigurable } from './utils/is-dashboard-configurable'
 
 export interface DashboardsContentProps extends TelemetryProps {
@@ -37,13 +38,10 @@ export const DashboardsContent: React.FunctionComponent<DashboardsContentProps> 
     const { dashboardID, telemetryService } = props
 
     const history = useHistory()
-    const { getDashboards, getInsightSubjects, getDashboardById } = useContext(CodeInsightsBackendContext)
+    const { getDashboards, getInsightSubjects } = useContext(CodeInsightsBackendContext)
 
     const subjects = useObservable(useMemo(() => getInsightSubjects(), [getInsightSubjects]))
     const dashboards = useObservable(useMemo(() => getDashboards(), [getDashboards]))
-    const currentDashboard = useObservable(
-        useMemo(() => getDashboardById(dashboardID), [getDashboardById, dashboardID])
-    )
 
     // State to open/close add/remove insights modal UI
     const [isAddInsightOpen, setAddInsightsState] = useState<boolean>(false)
@@ -54,6 +52,12 @@ export const DashboardsContent: React.FunctionComponent<DashboardsContentProps> 
     const menuReference = useRef<HTMLButtonElement | null>(null)
 
     const user = useObservable(authenticatedUser)
+
+    if (dashboards === undefined) {
+        return <LoadingSpinner />
+    }
+
+    const currentDashboard = findDashboardByUrlId(dashboards, dashboardID)
 
     const handleSelect = (action: DashboardMenuAction): void => {
         switch (action) {
@@ -92,10 +96,6 @@ export const DashboardsContent: React.FunctionComponent<DashboardsContentProps> 
 
     const handleAddInsightRequest = (): void => {
         setAddInsightsState(true)
-    }
-
-    if (dashboards === undefined) {
-        return <LoadingSpinner />
     }
 
     return (

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
@@ -13,8 +13,6 @@ import { EmptyInsightDashboard } from '../empty-insight-dashboard/EmptyInsightDa
 
 import { DashboardInsightsContext } from './DashboardInsightsContext'
 
-const DEFAULT_INSIGHT_IDS: string[] = []
-
 interface DashboardInsightsProps extends TelemetryProps {
     dashboard: InsightDashboard
     subjects?: SupportedInsightSubject[]
@@ -26,9 +24,7 @@ export const DashboardInsights: React.FunctionComponent<DashboardInsightsProps> 
 
     const { getInsights } = useContext(CodeInsightsBackendContext)
 
-    const dashboardInsightIds = dashboard.insightIds ?? DEFAULT_INSIGHT_IDS
-    const insightIds = useDistinctValue(dashboardInsightIds)
-
+    const insightIds = useDistinctValue(dashboard.insightIds)
     const insights = useObservable(useMemo(() => getInsights(insightIds), [getInsights, insightIds]))
 
     if (insights === undefined) {

--- a/client/web/src/enterprise/insights/pages/insights/creation/InsightCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/InsightCreationPage.tsx
@@ -6,7 +6,7 @@ import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryServi
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 
 import { CodeInsightsBackendContext } from '../../../core/backend/code-insights-backend-context'
-import { parseType } from '../../../core/backend/code-insights-gql-backend'
+import { parseDashboardType } from '../../../core/backend/utils/parse-dashboard-type'
 import { InsightDashboard, isVirtualDashboard, Insight } from '../../../core/types'
 import { isUserSubject } from '../../../core/types/subjects'
 import { useQueryParameters } from '../../../hooks/use-query-parameters'
@@ -26,7 +26,7 @@ const getVisibilityFromDashboard = (dashboard: InsightDashboard | null): string 
 
     // If no owner, this is using the graphql api
     if (!dashboard.owner) {
-        return parseType(dashboard.grants)
+        return parseDashboardType(dashboard.grants)
     }
 
     return dashboard.owner.id


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/27335

**Note:** This PR is a kind of work in progress. We merge our effort with @unclejustin on that to finish this PR as soon as possible in order to unlock dog-food testing and further tickets for setting migration.

## Background

At the moment on main, we re-use gql query for fetching insights list with insight configurations and metadata and for fetching one insight (insights one by one actually) with data series points. Fetching all insights with all data series points is a very expensive operation for our BE and this is why it fails with timeout each time.

## Solution 

For each gql request we should check can we really reuse something from other requests. This PR separates `insightById` gql request and `getInsights` request gql queries. 

## Known issues
- [ ] If you reload the dashboard page with an already picked personal dashboard you will see a 404 screen


