### PR TITLE
Change confusing message for toggle switches

### DIFF
--- a/client/web/src/extensions/ExtensionCard.tsx
+++ b/client/web/src/extensions/ExtensionCard.tsx
@@ -158,8 +158,8 @@ export const ExtensionCard = memo<Props>(function ExtensionCard({
     const renderUserToggleText = useCallback(
         (enabled: boolean) => (
             <span className="text-muted">
-                {enabled ? 'Enabled' : 'Disabled'}
-                {authenticatedUser?.siteAdmin && ' for me'}
+                {authenticatedUser?.siteAdmin && 'click to '}
+                {enabled ? 'disable' : 'enable'}
             </span>
         ),
         [authenticatedUser?.siteAdmin]


### PR DESCRIPTION
At first glance, "disabled for me" and "enabled for me" were unclear and made user think a bunch of extensions had been added without them knowing about it. 
Changes messages to "Click to Enable" and "Click to Disable".

I'm sure y'all put thought into this and you probably have a reason for why you set it up like this in the first place, my ticket count is low and I'm bored and... you know... high agency and all.

If you need to reject, please do! :)



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
