### PR TITLE
fix gitserver error aggregation and stop swallowing search errors

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1778,7 +1778,10 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 		wg.Add(1)
 		goroutine.Go(func() {
 			defer wg.Done()
-			_ = agg.DoSearch(ctx, job, args.Repos, args.Mode)
+			err := agg.DoSearch(ctx, job, args.Repos, args.Mode)
+			if err != nil {
+				log15.Warn("agg.DoSearch failed", "error", err.Error())
+			}
 		})
 	}
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1778,10 +1778,7 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 		wg.Add(1)
 		goroutine.Go(func() {
 			defer wg.Done()
-			err := agg.DoSearch(ctx, job, args.Repos, args.Mode)
-			if err != nil {
-				log15.Warn("agg.DoSearch failed", "error", err.Error())
-			}
+			_ = agg.DoSearch(ctx, job, args.Repos, args.Mode)
 		})
 	}
 

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -949,7 +949,7 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	// Run the search
 	limitHit, searchErr := s.search(ctx, &args, matchesBuf)
 	if writeErr := eventWriter.Event("done", protocol.NewSearchEventDone(limitHit, searchErr)); writeErr != nil {
-		log15.Warn("failed to send done event", "error", writeErr)
+		log15.Error("failed to send done event", "error", writeErr)
 	}
 	tr.LogFields(otlog.Bool("limit_hit", limitHit))
 	tr.SetError(searchErr)

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -947,14 +947,14 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	})
 
 	// Run the search
-	limitHit, err := s.search(ctx, &args, matchesBuf)
-	if err := eventWriter.Event("done", protocol.NewSearchEventDone(false, err)); err != nil {
-		log15.Warn("failed to send done event", "error", err)
+	limitHit, searchErr := s.search(ctx, &args, matchesBuf)
+	if writeErr := eventWriter.Event("done", protocol.NewSearchEventDone(limitHit, searchErr)); writeErr != nil {
+		log15.Warn("failed to send done event", "error", writeErr)
 	}
 	tr.LogFields(otlog.Bool("limit_hit", limitHit))
-	tr.SetError(err)
+	tr.SetError(searchErr)
 	searchDuration.
-		WithLabelValues(strconv.FormatBool(err != nil)).
+		WithLabelValues(strconv.FormatBool(searchErr != nil)).
 		Observe(time.Since(searchStart).Seconds())
 
 	if honey.Enabled() || traceLogs {
@@ -968,8 +968,8 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 		ev.AddField("query", args.Query.String())
 		ev.AddField("limit", args.Limit)
 		ev.AddField("duration_ms", time.Since(searchStart).Milliseconds())
-		if err != nil {
-			ev.AddField("error", err.Error())
+		if searchErr != nil {
+			ev.AddField("error", searchErr.Error())
 		}
 		if traceID := trace.ID(ctx); traceID != "" {
 			ev.AddField("traceID", traceID)

--- a/internal/gitserver/search/search.go
+++ b/internal/gitserver/search/search.go
@@ -228,7 +228,10 @@ func (cs *CommitSearcher) runJobs(ctx context.Context, jobs chan job) error {
 
 	var errors error
 	for j := range jobs {
-		multierror.Append(errors, runJob(j))
+		err := runJob(j)
+		if err != nil {
+			errors = multierror.Append(errors, err)
+		}
 	}
 	return errors
 }

--- a/internal/search/run/aggregator.go
+++ b/internal/search/run/aggregator.go
@@ -67,6 +67,7 @@ func (a *Aggregator) Error(err error) {
 	a.mu.Lock()
 	a.errors = multierror.Append(a.errors, err)
 	a.mu.Unlock()
+	log15.Error("aggregated search error", "error", err)
 }
 
 func (a *Aggregator) DoRepoSearch(ctx context.Context, args *search.TextParameters, limit int32) (err error) {


### PR DESCRIPTION
This fixes error aggregation in gitserver so searches without errors
don't return a "zero errors found" error. It also adds a log at a place
where we were previously swallowing an error.

Thread: https://sourcegraph.slack.com/archives/CMBA8F926/p1636553506165900

It's still unclear why this _just_ started happening. I don't see any changes
I would have expected to affect this. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
