### PR TITLE
[cloud][CLOUD-127] Disable site-admin access to reset password link on Cloud

### DIFF
--- a/client/web/src/site-admin/SiteAdminAllUsersPage.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage.tsx
@@ -192,6 +192,12 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
                         <CopyableText text={this.state.resetPasswordURL} size={40} />
                     </div>
                 )}
+                {this.state.resetPasswordURL === null && (
+                    <div className="alert alert-success mt-2">
+                        Password was reset. The reset link was sent to the primary email of the user:{' '}
+                        <strong>{this.props.node.emails.find(item => item.isPrimary)?.email}</strong>
+                    </div>
+                )}
             </li>
         )
     }

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -73,6 +73,13 @@ export function fetchAllUsers(args: { first?: number; query?: string }): Observa
                         id
                         username
                         displayName
+                        emails {
+                            email
+                            verified
+                            verificationPending
+                            viewerCanManuallyVerify
+                            isPrimary
+                        }
                         createdAt
                         siteAdmin
                         organizations {

--- a/cmd/frontend/graphqlbackend/users_randomize_password.go
+++ b/cmd/frontend/graphqlbackend/users_randomize_password.go
@@ -50,10 +50,10 @@ func (r *schemaResolver) RandomizeUserPassword(ctx context.Context, args *struct
 	User graphql.ID
 }) (*randomizeUserPasswordResult, error) {
 	if !userpasswd.ResetPasswordEnabled() {
-		return nil, errors.New("Resetting passwords is not enabled")
+		return nil, errors.New("resetting passwords is not enabled")
 	}
 	if envvar.SourcegraphDotComMode() && !conf.CanSendEmail() {
-		return nil, errors.New("Unable to reset password because email sending is not configured")
+		return nil, errors.New("unable to reset password because email sending is not configured")
 	}
 	// 🚨 SECURITY: Only site admins can randomize user passwords.
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
@@ -62,7 +62,7 @@ func (r *schemaResolver) RandomizeUserPassword(ctx context.Context, args *struct
 
 	userID, err := UnmarshalUserID(args.User)
 	if err != nil {
-		return nil, errors.New("Cannot parse user ID")
+		return nil, errors.Wrap(err, "cannot parse user ID")
 	}
 
 	if err := database.Users(r.db).RandomizePasswordAndClearPasswordResetRateLimit(ctx, userID); err != nil {

--- a/cmd/frontend/graphqlbackend/users_randomize_password.go
+++ b/cmd/frontend/graphqlbackend/users_randomize_password.go
@@ -2,40 +2,56 @@ package graphqlbackend
 
 import (
 	"context"
+	"net/url"
 
+	"github.com/cockroachdb/errors"
 	"github.com/graph-gophers/graphql-go"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/userpasswd"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 type randomizeUserPasswordResult struct {
-	db     dbutil.DB
-	userID int32
+	resetURL *url.URL
 }
 
-func (r *randomizeUserPasswordResult) ResetPasswordURL(ctx context.Context) (*string, error) {
-	if !userpasswd.ResetPasswordEnabled() {
-		return nil, nil
+func (r *randomizeUserPasswordResult) ResetPasswordURL() *string {
+	urlStr := globals.ExternalURL().ResolveReference(r.resetURL).String()
+	return &urlStr
+}
+
+func sendEmail(ctx context.Context, db dbutil.DB, userID int32, resetURL *url.URL) error {
+	user, err := database.Users(db).GetByID(ctx, userID)
+	if err != nil {
+		return err
 	}
 
-	// This method modifies the DB, which is somewhat counterintuitive for a "value" type from an
-	// implementation POV. Its behavior is justified because it is convenient and intuitive from the
-	// POV of the API consumer.
-	resetURL, err := backend.MakePasswordResetURL(ctx, r.db, r.userID)
+	email, _, err := database.UserEmails(db).GetPrimaryEmail(ctx, userID)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	urlStr := globals.ExternalURL().ResolveReference(resetURL).String()
-	return &urlStr, nil
+
+	if err = userpasswd.SendResetPasswordURLEmail(ctx, email, user.Username, resetURL); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (r *schemaResolver) RandomizeUserPassword(ctx context.Context, args *struct {
 	User graphql.ID
 }) (*randomizeUserPasswordResult, error) {
+	if !userpasswd.ResetPasswordEnabled() {
+		return nil, errors.New("Resetting passwords is not enabled")
+	}
+	if envvar.SourcegraphDotComMode() && !conf.CanSendEmail() {
+		return nil, errors.New("Unable to reset password because email sending is not configured")
+	}
 	// 🚨 SECURITY: Only site admins can randomize user passwords.
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
@@ -43,12 +59,29 @@ func (r *schemaResolver) RandomizeUserPassword(ctx context.Context, args *struct
 
 	userID, err := UnmarshalUserID(args.User)
 	if err != nil {
-		return nil, err
+		return nil, errors.New("Cannot parse user ID")
 	}
 
 	if err := database.Users(r.db).RandomizePasswordAndClearPasswordResetRateLimit(ctx, userID); err != nil {
 		return nil, err
 	}
 
-	return &randomizeUserPasswordResult{db: r.db, userID: userID}, nil
+	// This method modifies the DB, which is somewhat counterintuitive for a "value" type from an
+	// implementation POV. Its behavior is justified because it is convenient and intuitive from the
+	// POV of the API consumer.
+	resetURL, err := backend.MakePasswordResetURL(ctx, r.db, userID)
+	if err != nil {
+		return nil, err
+	}
+	// Send email to the user instead of returning the reset URL on Cloud
+	if envvar.SourcegraphDotComMode() {
+		if err := sendEmail(ctx, r.db, userID, resetURL); err != nil {
+			return nil, err
+		}
+
+		// 🚨 SECURITY: Do not return reset URL on Cloud
+		resetURL = nil
+	}
+
+	return &randomizeUserPasswordResult{resetURL: resetURL}, nil
 }

--- a/cmd/frontend/graphqlbackend/users_randomize_password.go
+++ b/cmd/frontend/graphqlbackend/users_randomize_password.go
@@ -21,6 +21,9 @@ type randomizeUserPasswordResult struct {
 }
 
 func (r *randomizeUserPasswordResult) ResetPasswordURL() *string {
+	if r.resetURL == nil {
+		return nil
+	}
 	urlStr := globals.ExternalURL().ResolveReference(r.resetURL).String()
 	return &urlStr
 }

--- a/cmd/frontend/graphqlbackend/users_randomize_password_test.go
+++ b/cmd/frontend/graphqlbackend/users_randomize_password_test.go
@@ -4,15 +4,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/internal/txemail"
-
-	"github.com/sourcegraph/sourcegraph/internal/types"
-
-	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/schema"
-
 	"github.com/graph-gophers/graphql-go/errors"
 
+	"github.com/sourcegraph/sourcegraph/internal/txemail"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/schema"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 )

--- a/cmd/frontend/graphqlbackend/users_randomize_password_test.go
+++ b/cmd/frontend/graphqlbackend/users_randomize_password_test.go
@@ -39,7 +39,7 @@ func TestRandomizeUserPassword(t *testing.T) {
 				ExpectedResult: "null",
 				ExpectedErrors: []*errors.QueryError{
 					{
-						Message: "Resetting passwords is not enabled",
+						Message: "resetting passwords is not enabled",
 						Path:    []interface{}{string("randomizeUserPassword")},
 					},
 				},
@@ -70,7 +70,7 @@ func TestRandomizeUserPassword(t *testing.T) {
 				ExpectedResult: "null",
 				ExpectedErrors: []*errors.QueryError{
 					{
-						Message: "Unable to reset password because email sending is not configured",
+						Message: "unable to reset password because email sending is not configured",
 						Path:    []interface{}{string("randomizeUserPassword")},
 					},
 				},
@@ -132,7 +132,7 @@ func TestRandomizeUserPassword(t *testing.T) {
 				ExpectedResult: "null",
 				ExpectedErrors: []*errors.QueryError{
 					{
-						Message: "Cannot parse user ID",
+						Message: "cannot parse user ID: illegal base64 data at input byte 4",
 						Path:    []interface{}{string("randomizeUserPassword")},
 					},
 				},

--- a/cmd/frontend/graphqlbackend/users_randomize_password_test.go
+++ b/cmd/frontend/graphqlbackend/users_randomize_password_test.go
@@ -1,0 +1,179 @@
+package graphqlbackend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/types"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/schema"
+
+	"github.com/graph-gophers/graphql-go/errors"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+)
+
+func TestRandomizeUserPassword(t *testing.T) {
+	resetMocks()
+
+	defer func() {
+		resetMocks()
+	}()
+
+	db := database.NewDB(nil)
+	userID := int32(42)
+	userIDBase64 := MarshalUserID(userID)
+
+	t.Run("Errors when resetting passwords is not enabled", func(t *testing.T) {
+		RunTests(t, []*Test{
+			{
+				Schema: mustParseGraphQLSchema(t, db),
+				Query: `
+					mutation {
+						randomizeUserPassword(user: $user) {
+							resetPasswordURL
+						}
+					}
+				`,
+				ExpectedResult: "null",
+				ExpectedErrors: []*errors.QueryError{
+					{
+						Message: "Resetting passwords is not enabled",
+						Path:    []interface{}{string("randomizeUserPassword")},
+					},
+				},
+				Variables: map[string]interface{}{"user": userIDBase64},
+			},
+		})
+	})
+
+	t.Run("Errors on Cloud when sending emails is not enabled", func(t *testing.T) {
+		conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{AuthProviders: []schema.AuthProviders{{Builtin: &schema.BuiltinAuthProvider{}}}}})
+		envvar.MockSourcegraphDotComMode(true)
+
+		defer func() {
+			conf.Mock(nil)
+			envvar.MockSourcegraphDotComMode(false)
+		}()
+
+		RunTests(t, []*Test{
+			{
+				Schema: mustParseGraphQLSchema(t, db),
+				Query: `
+					mutation {
+						randomizeUserPassword(user: "$user") {
+							resetPasswordURL
+						}
+					}
+				`,
+				ExpectedResult: "null",
+				ExpectedErrors: []*errors.QueryError{
+					{
+						Message: "Unable to reset password because email sending is not configured",
+						Path:    []interface{}{string("randomizeUserPassword")},
+					},
+				},
+				Variables: map[string]interface{}{"user": userIDBase64},
+			},
+		})
+	})
+
+	// tests below depend on AuthProviders and EmailSmtp being configured properly
+	conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{AuthProviders: []schema.AuthProviders{{Builtin: &schema.BuiltinAuthProvider{}}}, EmailSmtp: &schema.SMTPServerConfig{}}})
+
+	t.Run("Returns error if user is not site-admin", func(t *testing.T) {
+		db := database.NewDB(nil)
+		database.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
+			return &types.User{SiteAdmin: false}, nil
+		}
+		defer resetMocks()
+
+		RunTests(t, []*Test{
+			{
+				Schema: mustParseGraphQLSchema(t, db),
+				Query: `
+					mutation {
+						randomizeUserPassword(user: "$user") {
+							resetPasswordURL
+						}
+					}
+				`,
+				ExpectedResult: "null",
+				ExpectedErrors: []*errors.QueryError{
+					{
+						Message: "must be site admin",
+						Path:    []interface{}{string("randomizeUserPassword")},
+					},
+				},
+				Variables: map[string]interface{}{"user": userIDBase64},
+			},
+		})
+	})
+
+	t.Run("Returns error when cannot parse user ID", func(t *testing.T) {
+		db := database.NewDB(nil)
+		database.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
+			return &types.User{SiteAdmin: true}, nil
+		}
+
+		defer resetMocks()
+
+		RunTests(t, []*Test{
+			{
+				Schema: mustParseGraphQLSchema(t, db),
+				Query: `
+					mutation {
+						randomizeUserPassword(user: "$user") {
+							resetPasswordURL
+						}
+					}
+				`,
+				ExpectedResult: "null",
+				ExpectedErrors: []*errors.QueryError{
+					{
+						Message: "Cannot parse user ID",
+						Path:    []interface{}{string("randomizeUserPassword")},
+					},
+				},
+				Variables: map[string]interface{}{"user": "alice"},
+			},
+		})
+	})
+
+	t.Run("Returns resetPasswordUrl if user is site-admin", func(t *testing.T) {
+		db := database.NewDB(nil)
+		database.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
+			return &types.User{SiteAdmin: true}, nil
+		}
+
+		defer resetMocks()
+
+		RunTests(t, []*Test{
+			{
+				Schema: mustParseGraphQLSchema(t, db),
+				Query: `
+					mutation {
+						randomizeUserPassword(user: "$user") {
+							resetPasswordURL
+						}
+					}
+				`,
+				ExpectedResult: "null",
+				ExpectedErrors: []*errors.QueryError{
+					{
+						Message: "must be site admin",
+						Path:    []interface{}{string("randomizeUserPassword")},
+					},
+				},
+				Variables: map[string]interface{}{"user": userIDBase64},
+			},
+		})
+	})
+
+	//t.Run("Does not return resetUrl when in Cloud", func(t *testing.T) {
+	//	envvar.MockSourcegraphDotComMode(true)
+	//
+	//})
+}

--- a/cmd/frontend/graphqlbackend/users_randomize_password_test.go
+++ b/cmd/frontend/graphqlbackend/users_randomize_password_test.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/graph-gophers/graphql-go/errors"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/txemail"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/schema"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 func TestRandomizeUserPassword(t *testing.T) {

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -1097,6 +1097,10 @@ WHERE id=%s
 // A randomized password is used (instead of an empty password) to avoid bugs where an empty password
 // is considered to be no password. The random password is expected to be irretrievable.
 func (u *userStore) RandomizePasswordAndClearPasswordResetRateLimit(ctx context.Context, id int32) error {
+	if Mocks.Users.RandomizePasswordAndClearPasswordResetRateLimit != nil {
+		return Mocks.Users.RandomizePasswordAndClearPasswordResetRateLimit(ctx, id)
+	}
+
 	passwd, err := hashPassword(randstring.NewLen(36))
 	if err != nil {
 		return err

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -950,6 +950,9 @@ var (
 )
 
 func (u *userStore) RenewPasswordResetCode(ctx context.Context, id int32) (string, error) {
+	if Mocks.Users.RenewPasswordResetCode != nil {
+		return Mocks.Users.RenewPasswordResetCode(ctx, id)
+	}
 	if _, err := u.GetByID(ctx, id); err != nil {
 		return "", err
 	}

--- a/internal/database/users_mock.go
+++ b/internal/database/users_mock.go
@@ -8,22 +8,23 @@ import (
 )
 
 type MockUsers struct {
-	Create                       func(ctx context.Context, info NewUser) (newUser *types.User, err error)
-	Update                       func(userID int32, update UserUpdate) error
-	Delete                       func(ctx context.Context, id int32) error
-	HardDelete                   func(ctx context.Context, id int32) error
-	SetIsSiteAdmin               func(id int32, isSiteAdmin bool) error
-	CheckAndDecrementInviteQuota func(ctx context.Context, userID int32) (bool, error)
-	GetByID                      func(ctx context.Context, id int32) (*types.User, error)
-	GetByUsername                func(ctx context.Context, username string) (*types.User, error)
-	GetByUsernames               func(ctx context.Context, usernames ...string) ([]*types.User, error)
-	GetByCurrentAuthUser         func(ctx context.Context) (*types.User, error)
-	GetByVerifiedEmail           func(ctx context.Context, email string) (*types.User, error)
-	Count                        func(ctx context.Context, opt *UsersListOptions) (int, error)
-	List                         func(ctx context.Context, opt *UsersListOptions) ([]*types.User, error)
-	InvalidateSessionsByID       func(ctx context.Context, id int32) error
-	HasTag                       func(ctx context.Context, userID int32, tag string) (bool, error)
-	Tags                         func(ctx context.Context, userID int32) (map[string]bool, error)
+	Create                                          func(ctx context.Context, info NewUser) (newUser *types.User, err error)
+	Update                                          func(userID int32, update UserUpdate) error
+	Delete                                          func(ctx context.Context, id int32) error
+	HardDelete                                      func(ctx context.Context, id int32) error
+	SetIsSiteAdmin                                  func(id int32, isSiteAdmin bool) error
+	CheckAndDecrementInviteQuota                    func(ctx context.Context, userID int32) (bool, error)
+	GetByID                                         func(ctx context.Context, id int32) (*types.User, error)
+	GetByUsername                                   func(ctx context.Context, username string) (*types.User, error)
+	GetByUsernames                                  func(ctx context.Context, usernames ...string) ([]*types.User, error)
+	GetByCurrentAuthUser                            func(ctx context.Context) (*types.User, error)
+	GetByVerifiedEmail                              func(ctx context.Context, email string) (*types.User, error)
+	Count                                           func(ctx context.Context, opt *UsersListOptions) (int, error)
+	List                                            func(ctx context.Context, opt *UsersListOptions) ([]*types.User, error)
+	InvalidateSessionsByID                          func(ctx context.Context, id int32) error
+	HasTag                                          func(ctx context.Context, userID int32, tag string) (bool, error)
+	Tags                                            func(ctx context.Context, userID int32) (map[string]bool, error)
+	RandomizePasswordAndClearPasswordResetRateLimit func(ctx context.Context, userID int32) error
 }
 
 func (s *MockUsers) MockGetByID_Return(t *testing.T, returns *types.User, returnsErr error) (called *bool) {

--- a/internal/database/users_mock.go
+++ b/internal/database/users_mock.go
@@ -25,6 +25,7 @@ type MockUsers struct {
 	HasTag                                          func(ctx context.Context, userID int32, tag string) (bool, error)
 	Tags                                            func(ctx context.Context, userID int32) (map[string]bool, error)
 	RandomizePasswordAndClearPasswordResetRateLimit func(ctx context.Context, userID int32) error
+	RenewPasswordResetCode                          func(ctx context.Context, id int32) (string, error)
 }
 
 func (s *MockUsers) MockGetByID_Return(t *testing.T, returns *types.User, returnsErr error) (called *bool) {


### PR DESCRIPTION
# Description
Disable site-admin access to reset password link on Cloud. Exposing the password reset link could lead to hostile user account takeover by a bad acting site-admin. This would have bad impact on the security reputation of sourcegraph.com

# Screenshots

## Old behaviour

This is the current behaviour. We will continue behaving like this if not on cloud 
<img width="1144" alt="Screenshot 2021-11-11 at 16 06 37" src="https://user-images.githubusercontent.com/9974711/141331124-48e2d919-8082-4ad8-9a38-93155a498dd3.png">

## New behavior

Only applicable to Cloud
<img width="1116" alt="Screenshot 2021-11-11 at 17 11 17" src="https://user-images.githubusercontent.com/9974711/141331267-1b032ad4-3588-4ddf-8bdc-ef28a168fafd.png">

# Testing locally

To test this change locally, do the following:

## Old behavior

1. Run `sg start enterprise`
2. Make sure you have at least 2 users, one of which is site-admin
3. Login as a site-admin and go to https://sourcegraph.test:3443/site-admin/users
4. Click on `Reset password` button of the other user
5. You should see the reset password link in the success message (old behavior mentioned above)

## New behavior

1. Run `sg start cloud`
2. Make sure you have at least 2 users, one of which is site-admin
3. Login as a site-admin and go to https://sourcegraph.test:3443/site-admin/users
4. Click on `Reset password` button of the other user
5. You should **NOT** see the reset password link in the success message (new behavior mentioned above)
