### PR TITLE
codeintel: Bump lsif-go in CI

### DIFF
--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -6,7 +6,7 @@ jobs:
     # Skip running on forks
     if: github.repository == 'sourcegraph/sourcegraph'
     runs-on: ubuntu-latest
-    container: sourcegraph/lsif-go:v1.7.2 # Pinned in preparation for upgrade
+    container: sourcegraph/lsif-go
     strategy:
       matrix:
         root:
@@ -20,7 +20,8 @@ jobs:
       # Run lsif-go
       - name: Run lsif-go
         working-directory: ${{ matrix.root }}
-        run: lsif-go --no-animation
+        # --dep-batch-size=100 avoids loading all deps into memory and getting OOM killed
+        run: lsif-go --no-animation --dep-batch-size=100
 
       # Upload lsif-go data to Cloud, Dogfood, and Demo instances
       - name: Upload lsif-go dump to Cloud

--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -6,7 +6,7 @@ jobs:
     # Skip running on forks
     if: github.repository == 'sourcegraph/sourcegraph'
     runs-on: ubuntu-latest
-    container: sourcegraph/lsif-go
+    container: sourcegraph/lsif-go:v1.7.3
     strategy:
       matrix:
         root:

--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -6,7 +6,7 @@ jobs:
     # Skip running on forks
     if: github.repository == 'sourcegraph/sourcegraph'
     runs-on: ubuntu-latest
-    container: sourcegraph/lsif-go:v1.7.2
+    container: sourcegraph/lsif-go
     strategy:
       matrix:
         root:

--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -6,7 +6,7 @@ jobs:
     # Skip running on forks
     if: github.repository == 'sourcegraph/sourcegraph'
     runs-on: ubuntu-latest
-    container: sourcegraph/lsif-go:v1.7.3
+    container: sourcegraph/lsif-go:v1.7.2
     strategy:
       matrix:
         root:


### PR DESCRIPTION
GitHub Actions runners only have 7GB of memory, and lsif-go uses more than that when all deps are loaded into memory at once. This bumps lsif-go and adds `--dep-batch-size=100` to help keep memory usage under 7GB.

See https://github.com/sourcegraph/sourcegraph/issues/27211