### PR TITLE
web: fix theme flashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -384,6 +384,7 @@
     "lodash": "^4.17.20",
     "marked": "^4.0.0",
     "mdi-react": "^8.1.0",
+    "memoize-one": "^6.0.0",
     "minimatch": "^3.0.4",
     "monaco-editor": "^0.24.0",
     "monaco-yaml": "^3.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16464,6 +16464,11 @@ memoize-one@^5.0.0:
   resolved "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.4.tgz#005928aced5c43d890a4dfab18ca908b0ec92cbc"
   integrity sha512-P0z5IeAH6qHHGkJIXWw0xC2HNEgkx/9uWWBQw64FJj3/ol14VYdfVGWWr0fXfjhhv3TKVIqUq65os6O4GUNksA==
 
+memoize-one@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz#b2591b871ed82948aee4727dc6abceeeac8c1045"
+  integrity sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==
+
 memoizee@^0.4.14:
   version "0.4.14"
   resolved "https://registry.npmjs.org/memoizee/-/memoizee-0.4.14.tgz#07a00f204699f9a95c2d9e77218271c7cd610d57"


### PR DESCRIPTION
## Context

Because the global theme class was added in the `useEffect` after the initial DOM tree render, it caused the [CSS transition](https://github.com/sourcegraph/sourcegraph/issues/26435#issuecomment-963422763) on some elements. 

## Changes

- Global theme class is now added via a synchronous function that's memoized to prevent redundant DOM updates.
- A [small dependency](https://bundlephobia.com/package/memoize-one@6.0.0) (400b) was added to use a proper memoization function. See [here](https://dev.to/nioufe/you-should-not-use-lodash-for-memoization-3441) why the lodash equivalent is not enough here. A proper memorization function would be useful in other places.

Closes https://github.com/sourcegraph/sourcegraph/issues/26435