### PR TITLE
Change team from distrib to delivery

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
 
 
 <!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
-<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
+<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->


### PR DESCRIPTION
The delivery team will cherry-pick PRs to release branches



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
