### PR TITLE
productsubscription: ignore deleted users when listing

### DIFF
--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql_test.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql_test.go
@@ -1,0 +1,24 @@
+package productsubscription
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
+)
+
+func TestProductSubscription_Account(t *testing.T) {
+	t.Run("user not found should be ignored", func(t *testing.T) {
+		users := dbmock.NewMockUserStore()
+		users.GetByIDFunc.SetDefaultReturn(nil, &errcode.Mock{IsNotFound: true})
+
+		db := dbmock.NewMockDB()
+		db.UsersFunc.SetDefaultReturn(users)
+
+		_, err := (&productSubscription{v: &dbSubscription{UserID: 1}, db: db}).Account(context.Background())
+		assert.Nil(t, err)
+	})
+}


### PR DESCRIPTION
The "Product subscriptions" page consistently complaints about a user not found error, which is caused by a user associated with the product subscription has been deleted. IMO we should ignore deleted users in listing product subscriptions because removing the user does not invalid the associated product subscription automatically, it just so happens that one was linked to the other.

<img width="939" alt="CleanShot 2021-11-11 at 11 47 21@2x" src="https://user-images.githubusercontent.com/2946214/141233773-c19230f9-a99f-4d25-a4f8-8b5e50ec536f.png">

