### PR TITLE
web: hide "Settings" button on dotcom from site admins

### DIFF
--- a/client/web/src/site-admin/SiteAdminAllUsersPage.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage.tsx
@@ -113,9 +113,15 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
                         <span className="text-muted">{this.props.node.displayName}</span>
                     </div>
                     <div>
-                        <Link className="btn btn-sm btn-secondary" to={`${userURL(this.props.node.username)}/settings`}>
-                            <SettingsIcon className="icon-inline" /> Settings
-                        </Link>{' '}
+                        {!window.context.sourcegraphDotComMode && (
+                                <Link
+                                    className="btn btn-sm btn-secondary"
+                                    to={`${userURL(this.props.node.username)}/settings`}
+                                >
+                                    <SettingsIcon className="icon-inline" /> Settings
+                                </Link>
+                            ) &&
+                            ' '}
                         {this.props.node.id !== this.props.authenticatedUser.id && (
                             <button
                                 type="button"

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -335,7 +335,7 @@ func (r *schemaResolver) UpdatePassword(ctx context.Context, args *struct {
 	OldPassword string
 	NewPassword string
 }) (*EmptyResponse, error) {
-	// 🚨 SECURITY: A user can only change their own password.
+	// 🚨 SECURITY: Only the authenticated user can change their password.
 	user, err := database.Users(r.db).GetByCurrentAuthUser(ctx)
 	if err != nil {
 		return nil, err
@@ -359,7 +359,7 @@ func (r *schemaResolver) UpdatePassword(ctx context.Context, args *struct {
 func (r *schemaResolver) CreatePassword(ctx context.Context, args *struct {
 	NewPassword string
 }) (*EmptyResponse, error) {
-	// 🚨 SECURITY: A user can only create their own password.
+	// 🚨 SECURITY: Only the authenticated user can create their password.
 	user, err := database.Users(r.db).GetByCurrentAuthUser(ctx)
 	if err != nil {
 		return nil, err
@@ -367,6 +367,7 @@ func (r *schemaResolver) CreatePassword(ctx context.Context, args *struct {
 	if user == nil {
 		return nil, errors.New("no authenticated user")
 	}
+
 	if err := database.Users(r.db).CreatePassword(ctx, user.ID, args.NewPassword); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR removes the "Settings" button on **Site admin > Users** page on Sourcegraph.com.


---

Part of CLOUD-124