### PR TITLE
Don't allow forwarding env vars in server-side batch changes

### DIFF
--- a/enterprise/internal/batches/background/batch_spec_workspace_creator.go
+++ b/enterprise/internal/batches/background/batch_spec_workspace_creator.go
@@ -54,9 +54,12 @@ func (r *batchSpecWorkspaceCreator) process(
 	}
 
 	evaluatableSpec, err := batcheslib.ParseBatchSpec([]byte(spec.RawSpec), batcheslib.ParseBatchSpecOptions{
-		AllowArrayEnvironments: true,
-		AllowTransformChanges:  true,
-		AllowConditionalExec:   true,
+		AllowTransformChanges: true,
+		AllowConditionalExec:  true,
+		// We don't allow forwarding of environment variables in server-side
+		// batch changes, since we'd then leak the executor/Firecracker
+		// internal environment.
+		AllowArrayEnvironments: false,
 	})
 	if err != nil {
 		return err

--- a/enterprise/internal/batches/background/batch_spec_workspace_creator_test.go
+++ b/enterprise/internal/batches/background/batch_spec_workspace_creator_test.go
@@ -226,7 +226,6 @@ func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 	}
 
 	resolver := &dummyWorkspaceResolver{workspaces: []*service.RepoWorkspace{workspace}}
-
 	creator := &batchSpecWorkspaceCreator{store: s}
 	if err := creator.process(context.Background(), s, resolver.DummyBuilder, job); err != nil {
 		t.Fatalf("proces failed: %s", err)

--- a/schema/batch_spec.schema.json
+++ b/schema/batch_spec.schema.json
@@ -148,7 +148,7 @@
                     },
                     {
                       "type": "object",
-                      "description": "An environment variable to set in the step environment: the value will be passed through from the environment src is running within.",
+                      "description": "An environment variable to set in the step environment: the key is used as the environment variable name and the value as the value.",
                       "additionalProperties": {
                         "type": "string"
                       },


### PR DESCRIPTION
This is part of #26929 since building the cache key relies on env vars
and we want to avoid the env-var forwarding to go into SSBC.

It also fixes a duplicate comment in the batch spec schema, copying in
the description from our official docs.

