### PR TITLE
search: enable efficient indexer polling by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to Sourcegraph are documented in this file.
 - GNU's `wget` has been added to all `sourcegraph/*` Docker images that use `sourcegraph/alpine` as its base [#26823](https://github.com/sourcegraph/sourcegraph/pull/26823)
 - Added the "no results page", a help page shown if a search doesn't return any results [#26154](https://github.com/sourcegraph/sourcegraph/pull/26154)
 - Added monitoring page for Redis databases [#26967](https://github.com/sourcegraph/sourcegraph/issues/26967)
+- The search indexer only polls repositories that have been marked as changed. This reduces a large source of load in installations with a large number of repositories. If you notice index staleness, you can try disabling by setting the environment variable `SRC_SEARCH_INDEXER_EFFICIENT_POLLING_DISABLED` on `sourcegraph-frontend`. [#27058](https://github.com/sourcegraph/sourcegraph/issues/27058)
 
 ### Changed
 

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -125,7 +125,7 @@ func NewInternalHandler(m *mux.Router, db database.DB, schema *graphql.Schema, n
 		SearchContextsStore: database.SearchContexts(db),
 		Indexers:            search.Indexers(),
 
-		MinLastChangedEnabled: os.Getenv("SRC_SEARCH_CORE_MIN_LAST_CHANGED") != "",
+		MinLastChangedDisabled: os.Getenv("SRC_SEARCH_INDEXER_EFFICIENT_POLLING_DISABLED") != "",
 	}
 	m.Get(apirouter.SearchConfiguration).Handler(trace.Route(handler(indexer.serveConfiguration)))
 	m.Get(apirouter.ReposIndex).Handler(trace.Route(handler(indexer.serveList)))

--- a/cmd/frontend/internal/httpapi/search.go
+++ b/cmd/frontend/internal/httpapi/search.go
@@ -74,9 +74,9 @@ type searchIndexerServer struct {
 		Enabled() bool
 	}
 
-	// MinLastChangedEnabled is a feature flag for enabling more efficient
-	// polling by zoekt.
-	MinLastChangedEnabled bool
+	// MinLastChangedDisabled is a feature flag for disabling more efficient
+	// polling by zoekt. This can be removed after v3.34 is cut (Dec 2021).
+	MinLastChangedDisabled bool
 }
 
 // serveConfiguration is _only_ used by the zoekt index server. Zoekt does
@@ -112,7 +112,7 @@ func (h *searchIndexerServer) serveConfiguration(w http.ResponseWriter, r *http.
 	}
 
 	var minLastChanged time.Time
-	if h.MinLastChangedEnabled {
+	if !h.MinLastChangedDisabled {
 		var err error
 		minLastChanged, err = searchbackend.ParseAndSetConfigFingerprint(w, r, &siteConfig)
 		if err != nil {


### PR DESCRIPTION
We also add a changelog entry as well as instructions on how to disable.

Closes https://github.com/sourcegraph/sourcegraph/issues/27058