### PR TITLE
graphqlbackend: allow site admins to list user emails on dotcom

### DIFF
--- a/cmd/frontend/graphqlbackend/user_emails.go
+++ b/cmd/frontend/graphqlbackend/user_emails.go
@@ -18,17 +18,10 @@ import (
 var timeNow = time.Now
 
 func (r *UserResolver) Emails(ctx context.Context) ([]*userEmailResolver, error) {
-	// 🚨 SECURITY: Only the authenticated user can view their email on
-	// Sourcegraph.com.
-	if envvar.SourcegraphDotComMode() {
-		if err := backend.CheckSameUser(ctx, r.user.ID); err != nil {
-			return nil, err
-		}
-	} else {
-		// 🚨 SECURITY: Only the self user and site admins can fetch a user's emails.
-		if err := backend.CheckSiteAdminOrSameUser(ctx, r.db, r.user.ID); err != nil {
-			return nil, err
-		}
+	// 🚨 SECURITY: Only the authenticated user and site admins can list user's
+	// emails.
+	if err := backend.CheckSiteAdminOrSameUser(ctx, r.db, r.user.ID); err != nil {
+		return nil, err
 	}
 
 	userEmails, err := database.UserEmails(r.db).ListByUser(ctx, database.UserEmailsListOptions{

--- a/cmd/frontend/graphqlbackend/user_emails_test.go
+++ b/cmd/frontend/graphqlbackend/user_emails_test.go
@@ -19,60 +19,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-func TestUser_Emails(t *testing.T) {
-	db := dbmock.NewMockDB()
-	t.Run("only allowed by authenticated user on Sourcegraph.com", func(t *testing.T) {
-		users := dbmock.NewMockUserStore()
-		db.UsersFunc.SetDefaultReturn(users)
-
-		orig := envvar.SourcegraphDotComMode()
-		envvar.MockSourcegraphDotComMode(true)
-		defer envvar.MockSourcegraphDotComMode(orig) // reset
-
-		tests := []struct {
-			name  string
-			ctx   context.Context
-			setup func()
-		}{
-			{
-				name: "unauthenticated",
-				ctx:  context.Background(),
-				setup: func() {
-					users.GetByIDFunc.SetDefaultReturn(&types.User{ID: 1}, nil)
-				},
-			},
-			{
-				name: "another user",
-				ctx:  actor.WithActor(context.Background(), &actor.Actor{UID: 2}),
-				setup: func() {
-					users.GetByIDFunc.SetDefaultHook(func(ctx context.Context, id int32) (*types.User, error) {
-						return &types.User{ID: id}, nil
-					})
-				},
-			},
-			{
-				name: "site admin",
-				ctx:  actor.WithActor(context.Background(), &actor.Actor{UID: 2}),
-				setup: func() {
-					users.GetByIDFunc.SetDefaultHook(func(ctx context.Context, id int32) (*types.User, error) {
-						return &types.User{ID: id, SiteAdmin: true}, nil
-					})
-				},
-			},
-		}
-		for _, test := range tests {
-			t.Run(test.name, func(t *testing.T) {
-				test.setup()
-
-				_, err := NewUserResolver(db, &types.User{ID: 1}).Emails(test.ctx)
-				got := fmt.Sprintf("%v", err)
-				want := "must be authenticated as user with id 1"
-				assert.Equal(t, want, got)
-			})
-		}
-	})
-}
-
 func TestUserEmail_ViewerCanManuallyVerify(t *testing.T) {
 	db := dbmock.NewMockDB()
 	t.Run("only allowed by authenticated user on Sourcegraph.com", func(t *testing.T) {


### PR DESCRIPTION
This is restricted as part of CLOUD-124, but given this is causing trouble for **Site admin > Product subscriptions** page, and listing emails won't cause account takeover (unlike add emails) by compromised site admins, I think it makes sense to revert this part of the change.