### PR TITLE
Code Insights: Implement delete insights mutation handler in gql api class

### DIFF
--- a/client/web/src/enterprise/insights/InsightsRouter.tsx
+++ b/client/web/src/enterprise/insights/InsightsRouter.tsx
@@ -51,15 +51,14 @@ export const InsightsRouter = withAuthenticatedUser<InsightsRouterProps>(props =
     const match = useRouteMatch()
     const apolloClient = useApolloClient()
 
+    const gqlApi = useMemo(() => new CodeInsightsGqlBackend(apolloClient), [apolloClient])
     const api = useMemo(() => {
         // Disabled by default condition
         const isNewGqlApiEnabled =
             !isErrorLike(settingsCascade.final) && settingsCascade.final?.experimentalFeatures?.codeInsightsGqlApi
 
-        return isNewGqlApiEnabled
-            ? new CodeInsightsGqlBackend(apolloClient)
-            : new CodeInsightsSettingsCascadeBackend(settingsCascade, platformContext)
-    }, [platformContext, settingsCascade, apolloClient])
+        return isNewGqlApiEnabled ? gqlApi : new CodeInsightsSettingsCascadeBackend(settingsCascade, platformContext)
+    }, [platformContext, settingsCascade, gqlApi])
 
     return (
         <CodeInsightsBackendContext.Provider value={api}>

--- a/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.tsx
@@ -16,6 +16,8 @@ interface SmartInsightsViewGridProps extends TelemetryProps {
     insights: Insight[]
 }
 
+const INSIGHT_PAGE_CONTEXT = {}
+
 /**
  * Renders grid of smart (stateful) insight card. These cards can independently extract and update
  * the insights settings (settings cascade subjects).
@@ -33,7 +35,7 @@ export const SmartInsightsViewGrid: React.FunctionComponent<SmartInsightsViewGri
                     // Set execution insight context explicitly since this grid component is used
                     // only for the dashboard (insights) page
                     where="insightsPage"
-                    context={{}}
+                    context={INSIGHT_PAGE_CONTEXT}
                 />
             ))}
         </ViewGrid>

--- a/client/web/src/enterprise/insights/core/backend/code-insights-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-backend.ts
@@ -52,7 +52,7 @@ export interface CodeInsightsBackend {
      *
      * @param ids - list of insight ids
      */
-    getInsights: (ids?: string[]) => Observable<Insight[]>
+    getInsights: (dashboardId: string) => Observable<Insight[]>
 
     /**
      * Returns all reachable subject's insights from subject with subjectId.
@@ -76,7 +76,7 @@ export interface CodeInsightsBackend {
 
     updateInsight: (event: InsightUpdateInput) => Observable<void[]>
 
-    deleteInsight: (insightId: string) => Observable<void[]>
+    deleteInsight: (insightId: string) => Observable<unknown>
 
     /**
      * Returns all available for users subjects (sharing levels, historically it was introduced

--- a/client/web/src/enterprise/insights/core/backend/code-insights-gql-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-gql-backend.ts
@@ -1,4 +1,4 @@
-import { ApolloClient, gql } from '@apollo/client'
+import { ApolloCache, ApolloClient, gql } from '@apollo/client'
 import { from, Observable, of, throwError } from 'rxjs'
 import { map, mapTo, switchMap } from 'rxjs/operators'
 import { LineChartContent, PieChartContent } from 'sourcegraph'
@@ -11,6 +11,7 @@ import {
     CreateInsightResult,
     CreateInsightsDashboardInput,
     DeleteDashboardResult,
+    GetDashboardInsightsResult,
     GetInsightsResult,
     GetInsightViewResult,
     InsightsDashboardsResult,
@@ -48,6 +49,7 @@ import {
     InsightUpdateInput,
     ReachableInsight,
 } from './code-insights-backend-types'
+import { GET_DASHBOARD_INSIGHTS_GQL } from './gql/GetDashboardInsights'
 import { GET_INSIGHTS_GQL } from './gql/GetInsights'
 import { GET_INSIGHTS_DASHBOARDS_GQL } from './gql/GetInsightsDashboards'
 import { GET_INSIGHT_VIEW_GQL } from './gql/GetInsightView'
@@ -56,26 +58,29 @@ import { createDashboardGrants } from './utils/get-dashboard-grants'
 import { getInsightView, getStepInterval } from './utils/insight-transformers'
 import { parseDashboardType } from './utils/parse-dashboard-type'
 
-const errorMockMethod = (methodName: string) => () => throwError(new Error(`Implement ${methodName} method first`))
-
 export class CodeInsightsGqlBackend implements CodeInsightsBackend {
     constructor(private apolloClient: ApolloClient<object>) {}
 
     // Insights
-    public getInsights = (ids?: string[]): Observable<Insight[]> =>
-        fromObservableQuery(
-            this.apolloClient.watchQuery<GetInsightsResult>({ query: GET_INSIGHTS_GQL })
-        ).pipe(
-            map(({ data }) => {
-                const insightViews = data.insightViews.nodes.map(getInsightView)
+    public getInsights = (dashboardId: string): Observable<Insight[]> => {
+        // Handle virtual dashboard that doesn't exist in BE gql API and cause of that
+        // we need to use here insightViews query to fetch all available insights
+        if (dashboardId === 'all') {
+            return fromObservableQuery(
+                this.apolloClient.watchQuery<GetInsightsResult>({
+                    query: GET_INSIGHTS_GQL,
+                })
+            ).pipe(map(({ data }) => data.insightViews.nodes.map(getInsightView)))
+        }
 
-                if (ids) {
-                    return insightViews.filter(insight => ids.includes(insight.id))
-                }
-
-                return insightViews
+        // Get all insights from the user-created dashboard
+        return fromObservableQuery(
+            this.apolloClient.watchQuery<GetDashboardInsightsResult>({
+                query: GET_DASHBOARD_INSIGHTS_GQL,
+                variables: { id: dashboardId },
             })
-        )
+        ).pipe(map(({ data }) => data.insightsDashboards.nodes[0].views?.nodes.map(getInsightView) ?? []))
+    }
 
     public getInsightById = (id: string): Observable<Insight | null> =>
         fromObservableQuery(
@@ -96,10 +101,10 @@ export class CodeInsightsGqlBackend implements CodeInsightsBackend {
         )
 
     public findInsightByName = (input: FindInsightByNameInput): Observable<Insight | null> =>
-        this.getInsights().pipe(map(insights => insights.find(insight => insight.title === input.name) || null))
+        this.getInsights('all').pipe(map(insights => insights.find(insight => insight.title === input.name) || null))
 
     public getReachableInsights = (): Observable<ReachableInsight[]> =>
-        this.getInsights().pipe(
+        this.getInsights('all').pipe(
             map(insights =>
                 insights.map(insight => ({
                     ...insight,
@@ -115,10 +120,12 @@ export class CodeInsightsGqlBackend implements CodeInsightsBackend {
     // the `Insight` type than we use elsewhere. This is a temporary solution to make the code
     // fit with both of those shapes.
     public getBackendInsightData = (insight: SearchBackendBasedInsight): Observable<BackendInsightData> =>
-        from(
-            this.apolloClient.query<GetInsightViewResult>({
+        fromObservableQuery(
+            this.apolloClient.watchQuery<GetInsightViewResult>({
                 query: GET_INSIGHT_VIEW_GQL,
                 variables: { id: insight.id },
+                // In order to avoid unnecessary requests and enable caching for BE insights
+                fetchPolicy: 'cache-first',
             })
         ).pipe(
             // Note: this insight is guaranteed to exist since this function
@@ -206,7 +213,25 @@ export class CodeInsightsGqlBackend implements CodeInsightsBackend {
         return of()
     }
 
-    public deleteInsight = errorMockMethod('deleteInsight')
+    public deleteInsight = (insightId: string): Observable<unknown> =>
+        from(
+            this.apolloClient.mutate({
+                mutation: gql`
+                    mutation DeleteInsightView($id: ID!) {
+                        deleteInsightView(id: $id) {
+                            alwaysNil
+                        }
+                    }
+                `,
+                variables: { id: insightId },
+                update(cache: ApolloCache<DeleteDashboardResult>, result) {
+                    const deletedInsightReference = cache.identify({ __typename: 'InsightView', id: insightId })
+
+                    // Remove deleted insights from the apollo cache
+                    cache.evict({ id: deletedInsightReference })
+                },
+            })
+        )
 
     // Dashboards
     public getDashboards = (): Observable<InsightDashboard[]> =>

--- a/client/web/src/enterprise/insights/core/backend/code-insights-gql-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-gql-backend.ts
@@ -70,7 +70,7 @@ export class CodeInsightsGqlBackend implements CodeInsightsBackend {
                 this.apolloClient.watchQuery<GetInsightsResult>({
                     query: GET_INSIGHTS_GQL,
                 })
-            ).pipe(map(({ data }) => data.insightViews.nodes.map(getInsightView)))
+            ).pipe(map(({ data }) => data.insightViews.nodes.map(getInsightView).filter(Boolean) as Insight[]))
         }
 
         // Get all insights from the user-created dashboard
@@ -79,7 +79,13 @@ export class CodeInsightsGqlBackend implements CodeInsightsBackend {
                 query: GET_DASHBOARD_INSIGHTS_GQL,
                 variables: { id: dashboardId },
             })
-        ).pipe(map(({ data }) => data.insightsDashboards.nodes[0].views?.nodes.map(getInsightView) ?? []))
+        ).pipe(
+            map(
+                ({ data }) =>
+                    (data.insightsDashboards.nodes[0].views?.nodes.map(getInsightView).filter(Boolean) as Insight[]) ??
+                    []
+            )
+        )
     }
 
     public getInsightById = (id: string): Observable<Insight | null> =>
@@ -96,7 +102,7 @@ export class CodeInsightsGqlBackend implements CodeInsightsBackend {
                     return null
                 }
 
-                return getInsightView(insightData)
+                return getInsightView(insightData) || null
             })
         )
 

--- a/client/web/src/enterprise/insights/core/backend/code-insights-setting-cascade-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-setting-cascade-backend.ts
@@ -51,19 +51,26 @@ export class CodeInsightsSettingsCascadeBackend implements CodeInsightsBackend {
     ) {}
 
     // Insights
-    public getInsights = (ids?: string[]): Observable<Insight[]> => {
-        if (ids) {
-            // Return filtered by ids list of insights
-            return of(ids.map(id => findInsightById(this.settingCascade, id)).filter(isDefined))
-        }
+    public getInsights = (dashboardId?: string): Observable<Insight[]> =>
+        this.getDashboardById(dashboardId).pipe(
+            switchMap(dashboard => {
+                if (dashboard) {
+                    const ids = dashboard.insightIds
 
-        // Return all insights
-        const { final } = this.settingCascade
-        const normalizedFinalSettings = !final || isErrorLike(final) ? {} : final
-        const insightIds = getInsightIdsFromSettings(normalizedFinalSettings)
+                    if (ids) {
+                        // Return filtered by ids list of insights
+                        return of(ids.map(id => findInsightById(this.settingCascade, id)).filter(isDefined))
+                    }
+                }
 
-        return of(insightIds.map(id => findInsightById(this.settingCascade, id)).filter(isDefined))
-    }
+                // Return all insights
+                const { final } = this.settingCascade
+                const normalizedFinalSettings = !final || isErrorLike(final) ? {} : final
+                const insightIds = getInsightIdsFromSettings(normalizedFinalSettings)
+
+                return of(insightIds.map(id => findInsightById(this.settingCascade, id)).filter(isDefined))
+            })
+        )
 
     public getInsightById = (id: string): Observable<Insight | null> => of(findInsightById(this.settingCascade, id))
 

--- a/client/web/src/enterprise/insights/core/backend/gql/GetDashboardInsights.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql/GetDashboardInsights.ts
@@ -1,0 +1,41 @@
+import { gql } from '@apollo/client'
+
+export const GET_DASHBOARD_INSIGHTS_GQL = gql`
+    query GetDashboardInsights($id: ID) {
+        insightsDashboards(id: $id) {
+            nodes {
+                views {
+                    nodes {
+                        id
+                        presentation {
+                            __typename
+                            ... on LineChartInsightViewPresentation {
+                                title
+                                seriesPresentation {
+                                    seriesId
+                                    label
+                                    color
+                                }
+                            }
+                        }
+                        dataSeriesDefinitions {
+                            ... on SearchInsightDataSeriesDefinition {
+                                seriesId
+                                query
+                                repositoryScope {
+                                    repositories
+                                }
+                                timeScope {
+                                    ... on InsightIntervalTimeScope {
+                                        unit
+                                        value
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+`

--- a/client/web/src/enterprise/insights/core/backend/utils/insight-transformers.ts
+++ b/client/web/src/enterprise/insights/core/backend/utils/insight-transformers.ts
@@ -65,7 +65,7 @@ export function getStepInterval(insight: SearchBasedInsight): [TimeIntervalStepU
  *
  * @param insight - gql insight model
  */
-export const getInsightView = (insight: GetInsightsResult['insightViews']['nodes'][0]): Insight => {
+export const getInsightView = (insight: GetInsightsResult['insightViews']['nodes'][0]): Insight | undefined => {
     // TODO [VK] Support lang stats insight
     switch (insight.presentation.__typename) {
         case 'LineChartInsightViewPresentation': {

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
@@ -8,7 +8,6 @@ import { SmartInsightsViewGrid } from '../../../../../../../components/insights-
 import { CodeInsightsBackendContext } from '../../../../../../../core/backend/code-insights-backend-context'
 import { InsightDashboard } from '../../../../../../../core/types'
 import { SupportedInsightSubject } from '../../../../../../../core/types/subjects'
-import { useDistinctValue } from '../../../../../../../hooks/use-distinct-value'
 import { EmptyInsightDashboard } from '../empty-insight-dashboard/EmptyInsightDashboard'
 
 import { DashboardInsightsContext } from './DashboardInsightsContext'
@@ -24,8 +23,7 @@ export const DashboardInsights: React.FunctionComponent<DashboardInsightsProps> 
 
     const { getInsights } = useContext(CodeInsightsBackendContext)
 
-    const insightIds = useDistinctValue(dashboard.insightIds)
-    const insights = useObservable(useMemo(() => getInsights(insightIds), [getInsights, insightIds]))
+    const insights = useObservable(useMemo(() => getInsights(dashboard.id), [getInsights, dashboard.id]))
 
     if (insights === undefined) {
         return <LoadingSpinner />

--- a/client/web/src/enterprise/insights/sections/ExtensionViewsDirectorySection.tsx
+++ b/client/web/src/enterprise/insights/sections/ExtensionViewsDirectorySection.tsx
@@ -88,7 +88,7 @@ const ExtensionViewsDirectorySectionContent: React.FunctionComponent<ExtensionVi
     )
 
     // Read code insights views from the settings cascade
-    const insights = useObservable(useMemo(() => getInsights(), [getInsights])) ?? EMPTY_INSIGHT_LIST
+    const insights = useObservable(useMemo(() => getInsights('all'), [getInsights])) ?? EMPTY_INSIGHT_LIST
 
     // Pull extension views with Extension API
     const extensionViews =

--- a/client/web/src/enterprise/insights/sections/ExtensionViewsHomepageSection.tsx
+++ b/client/web/src/enterprise/insights/sections/ExtensionViewsHomepageSection.tsx
@@ -58,7 +58,7 @@ const ExtensionViewsHomepageSectionContent: React.FunctionComponent<ExtensionVie
     const { getInsights } = useContext(CodeInsightsBackendContext)
 
     // Read insights from the setting cascade
-    const insights = useObservable(useMemo(() => getInsights(), [getInsights])) ?? EMPTY_INSIGHT_LIST
+    const insights = useObservable(useMemo(() => getInsights('all'), [getInsights])) ?? EMPTY_INSIGHT_LIST
 
     // Pull extension views by Extension API.
     const extensionViews =


### PR DESCRIPTION
Closes part of https://github.com/sourcegraph/sourcegraph/issues/27415 (known issue #3 - _After search insight creation the dashboard page fails with runtime error about the premature observable cancelation_)

Closes https://github.com/sourcegraph/sourcegraph/issues/27217

### Background

In this PR we implement a delete insight mutation handler in our GQL API class. We had to slightly change the interface of `getInsights` method in order to avoid problems with re-fetching and Apolo cache. 

**For reviewers:** please test deleting of insight with new API and with old setting-based API to avoid regressions around insights fetching on the dashboard page since we've changed some methods of setting-based API as well to implement the latest common API interface.