### PR TITLE
database: Add SubRepoPermsStore.AllSupportedRepos

### DIFF
--- a/internal/database/sub_repo_perms_store_test.go
+++ b/internal/database/sub_repo_perms_store_test.go
@@ -225,6 +225,29 @@ func TestSubRepoPermsRepoSupported(t *testing.T) {
 	}
 }
 
+func TestSubRepoPermsAllSupportedRepos(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
+	db := dbtest.NewDB(t)
+
+	ctx := context.Background()
+	s := SubRepoPerms(db)
+	prepareSubRepoTestData(ctx, t, db)
+
+	have, err := s.AllSupportedRepos(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []api.RepoName{"perforce1"}
+
+	if diff := cmp.Diff(want, have); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
 func prepareSubRepoTestData(ctx context.Context, t *testing.T, db dbutil.DB) {
 	t.Helper()
 


### PR DESCRIPTION
It's very likely that we will always have a relatively small number of
repos that support sub-repo permissions so a way to get them all will be
useful.

Initially we plan to use this to cache the entire list for easy
checking.
