### PR TITLE
conf: enable dependency injection of site-config accessing to reduce use of global accessors

### DIFF
--- a/cmd/frontend/graphqlbackend/site_alerts.go
+++ b/cmd/frontend/graphqlbackend/site_alerts.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/updatecheck"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	srcprometheus "github.com/sourcegraph/sourcegraph/internal/src-prometheus"
 	"github.com/sourcegraph/sourcegraph/internal/version"
@@ -85,10 +86,10 @@ func (r *siteResolver) Alerts(ctx context.Context) ([]*Alert, error) {
 var disableSecurity, _ = strconv.ParseBool(env.Get("DISABLE_SECURITY", "false", "disables security upgrade notices"))
 
 func init() {
-	conf.ContributeWarning(func(c conf.Unified) (problems conf.Problems) {
-		if c.ExternalURL == "" {
+	conf.ContributeWarning(func(c conftypes.SiteConfigQuerier) (problems conf.Problems) {
+		if c.SiteConfig().ExternalURL == "" {
 			problems = append(problems, conf.NewSiteProblem("`externalURL` is required to be set for many features of Sourcegraph to work correctly."))
-		} else if conf.DeployType() != conf.DeployDev && strings.HasPrefix(c.ExternalURL, "http://") {
+		} else if conf.DeployType() != conf.DeployDev && strings.HasPrefix(c.SiteConfig().ExternalURL, "http://") {
 			problems = append(problems, conf.NewSiteProblem("Your connection is not private. We recommend [configuring Sourcegraph to use HTTPS/SSL](https://docs.sourcegraph.com/admin/nginx)"))
 		}
 

--- a/cmd/frontend/internal/app/debug.go
+++ b/cmd/frontend/internal/app/debug.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/debugproxies"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -24,8 +25,10 @@ import (
 	srcprometheus "github.com/sourcegraph/sourcegraph/internal/src-prometheus"
 )
 
-var grafanaURLFromEnv = env.Get("GRAFANA_SERVER_URL", "", "URL at which Grafana can be reached")
-var jaegerURLFromEnv = env.Get("JAEGER_SERVER_URL", "", "URL at which Jaeger UI can be reached")
+var (
+	grafanaURLFromEnv = env.Get("GRAFANA_SERVER_URL", "", "URL at which Grafana can be reached")
+	jaegerURLFromEnv  = env.Get("JAEGER_SERVER_URL", "", "URL at which Jaeger UI can be reached")
+)
 
 func init() {
 	conf.ContributeWarning(newPrometheusValidator(srcprometheus.NewClient(srcprometheus.PrometheusURL)))
@@ -195,7 +198,7 @@ func adminOnly(next http.Handler, db database.DB) http.Handler {
 // It also accepts the error from creating `srcprometheus.Client` as an parameter, to validate
 // Prometheus configuration.
 func newPrometheusValidator(prom srcprometheus.Client, promErr error) conf.Validator {
-	return func(c conf.Unified) conf.Problems {
+	return func(c conftypes.SiteConfigQuerier) conf.Problems {
 		// surface new prometheus client error if it was unexpected
 		prometheusUnavailable := errors.Is(promErr, srcprometheus.ErrPrometheusUnavailable)
 		if promErr != nil && !prometheusUnavailable {
@@ -203,7 +206,7 @@ func newPrometheusValidator(prom srcprometheus.Client, promErr error) conf.Valid
 		}
 
 		// no need to validate prometheus config if no `observability.*` settings are configured
-		observabilityNotConfigured := len(c.ObservabilityAlerts) == 0 && len(c.ObservabilitySilenceAlerts) == 0
+		observabilityNotConfigured := len(c.SiteConfig().ObservabilityAlerts) == 0 && len(c.SiteConfig().ObservabilitySilenceAlerts) == 0
 		if observabilityNotConfigured {
 			// no observability configuration, no checks to make
 			return nil

--- a/cmd/frontend/internal/auth/config.go
+++ b/cmd/frontend/internal/auth/config.go
@@ -1,18 +1,21 @@
 package auth
 
-import "github.com/sourcegraph/sourcegraph/internal/conf"
+import (
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+)
 
 func init() {
 	conf.ContributeValidator(validateConfig)
 }
 
-func validateConfig(c conf.Unified) (problems conf.Problems) {
-	if len(c.AuthProviders) == 0 {
+func validateConfig(c conftypes.SiteConfigQuerier) (problems conf.Problems) {
+	if len(c.SiteConfig().AuthProviders) == 0 {
 		problems = append(problems, conf.NewSiteProblem("no auth providers set (all access will be forbidden)"))
 	}
 
 	// Validate that `auth.enableUsernameChanges` is not set if SSO is configured
-	if conf.HasExternalAuthProvider(c) && c.AuthEnableUsernameChanges {
+	if conf.HasExternalAuthProvider(c) && c.SiteConfig().AuthEnableUsernameChanges {
 		problems = append(problems, conf.NewSiteProblem("`auth.enableUsernameChanges` must not be true if external auth providers are set in `auth.providers`"))
 	}
 

--- a/cmd/frontend/internal/auth/userpasswd/config.go
+++ b/cmd/frontend/internal/auth/userpasswd/config.go
@@ -6,6 +6,7 @@ import (
 	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -48,9 +49,9 @@ func init() {
 	conf.ContributeValidator(validateConfig)
 }
 
-func validateConfig(c conf.Unified) (problems conf.Problems) {
+func validateConfig(c conftypes.SiteConfigQuerier) (problems conf.Problems) {
 	var builtinAuthProviders int
-	for _, p := range c.AuthProviders {
+	for _, p := range c.SiteConfig().AuthProviders {
 		if p.Builtin != nil {
 			builtinAuthProviders++
 		}

--- a/cmd/frontend/internal/session/session.go
+++ b/cmd/frontend/internal/session/session.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -26,8 +27,10 @@ import (
 	"github.com/gorilla/sessions"
 )
 
-var sessionStore sessions.Store
-var sessionCookieKey = env.Get("SRC_SESSION_COOKIE_KEY", "", "secret key used for securing the session cookies")
+var (
+	sessionStore     sessions.Store
+	sessionCookieKey = env.Get("SRC_SESSION_COOKIE_KEY", "", "secret key used for securing the session cookies")
+)
 
 // defaultExpiryPeriod is the default session expiry period (if none is specified explicitly): 90 days.
 const defaultExpiryPeriod = 90 * 24 * time.Hour
@@ -36,12 +39,12 @@ const defaultExpiryPeriod = 90 * 24 * time.Hour
 const cookieName = "sgs"
 
 func init() {
-	conf.ContributeValidator(func(c conf.Unified) (problems conf.Problems) {
-		if c.AuthSessionExpiry == "" {
+	conf.ContributeValidator(func(c conftypes.SiteConfigQuerier) (problems conf.Problems) {
+		if c.SiteConfig().AuthSessionExpiry == "" {
 			return nil
 		}
 
-		d, err := time.ParseDuration(c.AuthSessionExpiry)
+		d, err := time.ParseDuration(c.SiteConfig().AuthSessionExpiry)
 		if err != nil {
 			return conf.NewSiteProblems("auth.sessionExpiry does not conform to the Go time.Duration format (https://golang.org/pkg/time/#ParseDuration). The default of 90 days will be used.")
 		}

--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -4,6 +4,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/shared"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 )
@@ -16,7 +17,7 @@ func main() {
 	// See https://github.com/sourcegraph/sourcegraph/issues/3847 for details.
 	authz.SetProviders(true, []authz.Provider{})
 
-	shared.Main(func(db database.DB, outOfBandMigrationRunner *oobmigration.Runner) enterprise.Services {
+	shared.Main(func(db database.DB, c conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner) enterprise.Services {
 		return enterprise.DefaultServices()
 	})
 }

--- a/cmd/frontend/shared/frontend.go
+++ b/cmd/frontend/shared/frontend.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cli"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
@@ -19,7 +20,7 @@ import (
 // It is exposed as function in a package so that it can be called by other
 // main package implementations such as Sourcegraph Enterprise, which import
 // proprietary/private code.
-func Main(enterpriseSetupHook func(db database.DB, outOfBandMigrationRunner *oobmigration.Runner) enterprise.Services) {
+func Main(enterpriseSetupHook func(db database.DB, conf conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner) enterprise.Services) {
 	env.Lock()
 	err := cli.Main(enterpriseSetupHook)
 	if err != nil {

--- a/cmd/github-proxy/github-proxy.go
+++ b/cmd/github-proxy/github-proxy.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
@@ -65,8 +66,8 @@ func main() {
 	env.Lock()
 	env.HandleHelpFlag()
 	logging.Init()
-	tracer.Init()
-	sentry.Init()
+	tracer.Init(conf.DefaultClient())
+	sentry.Init(conf.DefaultClient())
 	trace.Init()
 
 	// Ready immediately

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -65,8 +65,8 @@ func main() {
 
 	conf.Init()
 	logging.Init()
-	tracer.Init()
-	sentry.Init()
+	tracer.Init(conf.DefaultClient())
+	sentry.Init(conf.DefaultClient())
 	trace.Init()
 
 	if reposDir == "" {
@@ -292,7 +292,6 @@ func getPercent(p int) (int, error) {
 // getStores initializes a connection to the database and returns RepoStore and
 // ExternalServiceStore.
 func getDB() (dbutil.DB, error) {
-
 	//
 	// START FLAILING
 
@@ -305,9 +304,9 @@ func getDB() (dbutil.DB, error) {
 	// END FLAILING
 	//
 
-	dsn := conf.Get().ServiceConnections.PostgresDSN
+	dsn := conf.Get().ServiceConnections().PostgresDSN
 	conf.Watch(func() {
-		newDSN := conf.Get().ServiceConnections.PostgresDSN
+		newDSN := conf.Get().ServiceConnections().PostgresDSN
 		if dsn != newDSN {
 			// The DSN was changed (e.g. by someone modifying the env vars on
 			// the frontend). We need to respect the new DSN. Easiest way to do

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -63,8 +63,10 @@ const tempDirName = ".tmp"
 // logs to stderr
 var traceLogs bool
 
-var lastCheckAt = make(map[api.RepoName]time.Time)
-var lastCheckMutex sync.Mutex
+var (
+	lastCheckAt    = make(map[api.RepoName]time.Time)
+	lastCheckMutex sync.Mutex
+)
 
 // debounce() provides some filtering to prevent spammy requests for the same
 // repository. If the last fetch of the repository was within the given
@@ -398,7 +400,7 @@ func (s *Server) Janitor(interval time.Duration) {
 func (s *Server) SyncRepoState(interval time.Duration, batchSize, perSecond int) {
 	var previousAddrs string
 	for {
-		addrs := conf.Get().ServiceConnections.GitServers
+		addrs := conf.Get().ServiceConnections().GitServers
 		// We turn addrs into a string here for easy comparison and storage of previous
 		// addresses since we'd need to take a copy of the slice anyway.
 		currentAddrs := strings.Join(addrs, ",")
@@ -987,7 +989,6 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 // search handles the core logic of the search. It is passed a matchesBuf so it doesn't need to
 // concern itself with event types, and all instrumentation is handled in the calling function.
 func (s *Server) search(ctx context.Context, args *protocol.SearchRequest, matchesBuf *streamhttp.JSONArrayBuf) (limitHit bool, err error) {
-
 	args.Repo = protocol.NormalizeRepo(args.Repo)
 	if args.Limit == 0 {
 		args.Limit = math.MaxInt32

--- a/cmd/query-runner/main.go
+++ b/cmd/query-runner/main.go
@@ -40,8 +40,8 @@ func main() {
 
 	conf.Init()
 	logging.Init()
-	tracer.Init()
-	sentry.Init()
+	tracer.Init(conf.DefaultClient())
+	sentry.Init(conf.DefaultClient())
 	trace.Init()
 
 	go func() {

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -68,8 +68,8 @@ func Main(enterpriseInit EnterpriseInit) {
 
 	conf.Init()
 	logging.Init()
-	tracer.Init()
-	sentry.Init()
+	tracer.Init(conf.DefaultClient())
+	sentry.Init(conf.DefaultClient())
 	trace.Init()
 
 	// Signals health of startup
@@ -108,9 +108,9 @@ func Main(enterpriseInit EnterpriseInit) {
 
 	clock := func() time.Time { return time.Now().UTC() }
 
-	dsn := conf.Get().ServiceConnections.PostgresDSN
+	dsn := conf.Get().ServiceConnections().PostgresDSN
 	conf.Watch(func() {
-		newDSN := conf.Get().ServiceConnections.PostgresDSN
+		newDSN := conf.Get().ServiceConnections().PostgresDSN
 		if dsn != newDSN {
 			// The DSN was changed (e.g. by someone modifying the env vars on
 			// the frontend). We need to respect the new DSN. Easiest way to do

--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -30,8 +30,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 )
 
-var cacheDir = env.Get("CACHE_DIR", "/tmp", "directory to store cached archives.")
-var cacheSizeMB = env.Get("SEARCHER_CACHE_SIZE_MB", "100000", "maximum size of the on disk cache in megabytes")
+var (
+	cacheDir    = env.Get("CACHE_DIR", "/tmp", "directory to store cached archives.")
+	cacheSizeMB = env.Get("SEARCHER_CACHE_SIZE_MB", "100000", "maximum size of the on disk cache in megabytes")
+)
 
 const port = "3181"
 
@@ -41,8 +43,8 @@ func main() {
 	log.SetFlags(0)
 	conf.Init()
 	logging.Init()
-	tracer.Init()
-	sentry.Init()
+	tracer.Init(conf.DefaultClient())
+	sentry.Init(conf.DefaultClient())
 	trace.Init()
 
 	// Ready immediately

--- a/cmd/symbols/main.go
+++ b/cmd/symbols/main.go
@@ -56,8 +56,8 @@ func main() {
 	log.SetFlags(0)
 	conf.Init()
 	logging.Init()
-	tracer.Init()
-	sentry.Init()
+	tracer.Init(conf.DefaultClient())
+	sentry.Init(conf.DefaultClient())
 	trace.Init()
 
 	// Ready immediately

--- a/cmd/worker/shared/main.go
+++ b/cmd/worker/shared/main.go
@@ -51,8 +51,8 @@ func Start(additionalJobs map[string]job.Job) {
 	env.HandleHelpFlag()
 	conf.Init()
 	logging.Init()
-	tracer.Init()
-	sentry.Init()
+	tracer.Init(conf.DefaultClient())
+	sentry.Init(conf.DefaultClient())
 	trace.Init()
 	if err := keyring.Init(context.Background()); err != nil {
 		log.Fatalf("Failed to intialise keyring: %v", err)

--- a/cmd/worker/workerdb/service_connections.go
+++ b/cmd/worker/workerdb/service_connections.go
@@ -14,9 +14,9 @@ import (
 //
 // This method should only be called for critical values like database connection config.
 func WatchServiceConnectionValue(f func(serviceConnections conftypes.ServiceConnections) string) string {
-	value := f(conf.Get().ServiceConnections)
+	value := f(conf.Get().ServiceConnections())
 	conf.Watch(func() {
-		if newValue := f(conf.Get().ServiceConnections); value != newValue {
+		if newValue := f(conf.Get().ServiceConnections()); value != newValue {
 			log.Fatalf("Detected settings change change, restarting to take effect: %s", newValue)
 		}
 	})

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/config.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/config.go
@@ -5,14 +5,15 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func Init(db dbutil.DB) {
 	const pkgName = "githuboauth"
-	conf.ContributeValidator(func(cfg conf.Unified) conf.Problems {
-		_, problems := parseConfig(&cfg, db)
+	conf.ContributeValidator(func(cfg conftypes.SiteConfigQuerier) conf.Problems {
+		_, problems := parseConfig(cfg, db)
 		return problems
 	})
 	go func() {
@@ -36,8 +37,8 @@ type Provider struct {
 	providers.Provider
 }
 
-func parseConfig(cfg *conf.Unified, db dbutil.DB) (ps []Provider, problems conf.Problems) {
-	for _, pr := range cfg.AuthProviders {
+func parseConfig(cfg conftypes.SiteConfigQuerier, db dbutil.DB) (ps []Provider, problems conf.Problems) {
+	for _, pr := range cfg.SiteConfig().AuthProviders {
 		if pr.Github == nil {
 			continue
 		}

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/config.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -12,8 +13,8 @@ import (
 const PkgName = "gitlaboauth"
 
 func Init(db dbutil.DB) {
-	conf.ContributeValidator(func(cfg conf.Unified) conf.Problems {
-		_, problems := parseConfig(&cfg, db)
+	conf.ContributeValidator(func(cfg conftypes.SiteConfigQuerier) conf.Problems {
+		_, problems := parseConfig(cfg, db)
 		return problems
 	})
 	go func() {
@@ -32,18 +33,18 @@ func Init(db dbutil.DB) {
 	}()
 }
 
-func parseConfig(cfg *conf.Unified, db dbutil.DB) (ps map[schema.GitLabAuthProvider]providers.Provider, problems conf.Problems) {
+func parseConfig(cfg conftypes.SiteConfigQuerier, db dbutil.DB) (ps map[schema.GitLabAuthProvider]providers.Provider, problems conf.Problems) {
 	ps = make(map[schema.GitLabAuthProvider]providers.Provider)
-	for _, pr := range cfg.AuthProviders {
+	for _, pr := range cfg.SiteConfig().AuthProviders {
 		if pr.Gitlab == nil {
 			continue
 		}
 
-		if cfg.ExternalURL == "" {
+		if cfg.SiteConfig().ExternalURL == "" {
 			problems = append(problems, conf.NewSiteProblem("`externalURL` was empty and it is needed to determine the OAuth callback URL."))
 			continue
 		}
-		externalURL, err := url.Parse(cfg.ExternalURL)
+		externalURL, err := url.Parse(cfg.SiteConfig().ExternalURL)
 		if err != nil {
 			problems = append(problems, conf.NewSiteProblem("Could not parse `externalURL`, which is needed to determine the OAuth callback URL."))
 			continue

--- a/enterprise/cmd/frontend/internal/auth/httpheader/config.go
+++ b/enterprise/cmd/frontend/internal/auth/httpheader/config.go
@@ -2,6 +2,7 @@ package httpheader
 
 import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -24,9 +25,9 @@ func init() {
 	conf.ContributeValidator(validateConfig)
 }
 
-func validateConfig(c conf.Unified) (problems conf.Problems) {
+func validateConfig(c conftypes.SiteConfigQuerier) (problems conf.Problems) {
 	var httpHeaderAuthProviders int
-	for _, p := range c.AuthProviders {
+	for _, p := range c.SiteConfig().AuthProviders {
 		if p.HttpHeader != nil {
 			httpHeaderAuthProviders++
 		}

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/config.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/config.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -52,17 +53,17 @@ func init() {
 	conf.ContributeValidator(validateConfig)
 }
 
-func validateConfig(c conf.Unified) (problems conf.Problems) {
+func validateConfig(c conftypes.SiteConfigQuerier) (problems conf.Problems) {
 	var loggedNeedsExternalURL bool
-	for _, p := range c.AuthProviders {
-		if p.Openidconnect != nil && c.ExternalURL == "" && !loggedNeedsExternalURL {
+	for _, p := range c.SiteConfig().AuthProviders {
+		if p.Openidconnect != nil && c.SiteConfig().ExternalURL == "" && !loggedNeedsExternalURL {
 			problems = append(problems, conf.NewSiteProblem("openidconnect auth provider requires `externalURL` to be set to the external URL of your site (example: https://sourcegraph.example.com)"))
 			loggedNeedsExternalURL = true
 		}
 	}
 
 	seen := map[schema.OpenIDConnectAuthProvider]int{}
-	for i, p := range c.AuthProviders {
+	for i, p := range c.SiteConfig().AuthProviders {
 		if p.Openidconnect != nil {
 			if j, ok := seen[*p.Openidconnect]; ok {
 				problems = append(problems, conf.NewSiteProblem(fmt.Sprintf("OpenID Connect auth provider at index %d is duplicate of index %d, ignoring", i, j)))

--- a/enterprise/cmd/frontend/internal/auth/saml/config.go
+++ b/enterprise/cmd/frontend/internal/auth/saml/config.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -67,17 +68,17 @@ func init() {
 	conf.ContributeValidator(validateConfig)
 }
 
-func validateConfig(c conf.Unified) (problems conf.Problems) {
+func validateConfig(c conftypes.SiteConfigQuerier) (problems conf.Problems) {
 	var loggedNeedsExternalURL bool
-	for _, p := range c.AuthProviders {
-		if p.Saml != nil && c.ExternalURL == "" && !loggedNeedsExternalURL {
+	for _, p := range c.SiteConfig().AuthProviders {
+		if p.Saml != nil && c.SiteConfig().ExternalURL == "" && !loggedNeedsExternalURL {
 			problems = append(problems, conf.NewSiteProblem("saml auth provider requires `externalURL` to be set to the external URL of your site (example: https://sourcegraph.example.com)"))
 			loggedNeedsExternalURL = true
 		}
 	}
 
 	seen := map[schema.SAMLAuthProvider]int{}
-	for i, p := range c.AuthProviders {
+	for i, p := range c.SiteConfig().AuthProviders {
 		if p.Saml != nil {
 			if j, ok := seen[*p.Saml]; ok {
 				problems = append(problems, conf.NewSiteProblem(fmt.Sprintf("SAML auth provider at index %d is duplicate of index %d, ignoring", i, j)))

--- a/enterprise/cmd/frontend/internal/authz/init.go
+++ b/enterprise/cmd/frontend/internal/authz/init.go
@@ -15,13 +15,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/hooks"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/authz/resolvers"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/licensing/enforcement"
-	eauthz "github.com/sourcegraph/sourcegraph/enterprise/internal/authz"
 	eiauthz "github.com/sourcegraph/sourcegraph/enterprise/internal/authz"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
@@ -33,7 +33,7 @@ import (
 
 var clock = timeutil.Now
 
-func Init(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
+func Init(ctx context.Context, db dbutil.DB, _ conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
 	database.ExternalServices = edb.NewExternalServicesStore
 	database.Authz = func(db dbutil.DB) database.AuthzStore {
 		return edb.NewAuthzStore(db, clock)
@@ -44,10 +44,11 @@ func Init(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigrat
 
 	extsvcStore := database.ExternalServices(db)
 
+	// TODO(nsc): use c
 	// Report any authz provider problems in external configs.
-	conf.ContributeWarning(func(cfg conf.Unified) (problems conf.Problems) {
+	conf.ContributeWarning(func(cfg conftypes.SiteConfigQuerier) (problems conf.Problems) {
 		_, _, seriousProblems, warnings :=
-			eauthz.ProvidersFromConfig(context.Background(), &cfg, extsvcStore)
+			eiauthz.ProvidersFromConfig(context.Background(), cfg, extsvcStore)
 		problems = append(problems, conf.NewExternalServiceProblems(seriousProblems...)...)
 		problems = append(problems, conf.NewExternalServiceProblems(warnings...)...)
 		return problems
@@ -65,7 +66,7 @@ func Init(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigrat
 		}
 
 		// We can ignore problems returned here because they would have been surfaced in other places.
-		_, providers, _, _ := eauthz.ProvidersFromConfig(context.Background(), conf.Get(), extsvcStore)
+		_, providers, _, _ := eiauthz.ProvidersFromConfig(context.Background(), conf.Get(), extsvcStore)
 		if len(providers) == 0 {
 			return nil
 		}

--- a/enterprise/cmd/frontend/internal/batches/init.go
+++ b/enterprise/cmd/frontend/internal/batches/init.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types/scheduler/window"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -19,10 +20,10 @@ import (
 // Init initializes the given enterpriseServices to include the required
 // resolvers for Batch Changes and sets up webhook handlers for changeset
 // events.
-func Init(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
+func Init(ctx context.Context, db dbutil.DB, _ conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
 	// Validate site configuration.
-	conf.ContributeValidator(func(c conf.Unified) (problems conf.Problems) {
-		if _, err := window.NewConfiguration(c.BatchChangesRolloutWindows); err != nil {
+	conf.ContributeValidator(func(c conftypes.SiteConfigQuerier) (problems conf.Problems) {
+		if _, err := window.NewConfiguration(c.SiteConfig().BatchChangesRolloutWindows); err != nil {
 			problems = append(problems, conf.NewSiteProblem(err.Error()))
 		}
 

--- a/enterprise/cmd/frontend/internal/codeintel/upload_handler.go
+++ b/enterprise/cmd/frontend/internal/codeintel/upload_handler.go
@@ -5,14 +5,15 @@ import (
 	"net/http"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/httpapi"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 // NewCodeIntelUploadHandler creates a new code intel LSIF upload HTTP handler. This is used
 // by both the enterprise frontend codeintel init code to install handlers in the frontend API
 // as well as the the enterprise frontend executor init code to install handlers in the proxy.
-func NewCodeIntelUploadHandler(ctx context.Context, db dbutil.DB, internal bool) (http.Handler, error) {
-	if err := initServices(ctx, db); err != nil {
+func NewCodeIntelUploadHandler(ctx context.Context, conf conftypes.SiteConfigQuerier, db dbutil.DB, internal bool) (http.Handler, error) {
+	if err := initServices(ctx, conf, db); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/cmd/frontend/internal/codemonitors/init.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/init.go
@@ -5,12 +5,13 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codemonitors/resolvers"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 )
 
-func Init(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
+func Init(ctx context.Context, db dbutil.DB, _ conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
 	enterpriseServices.CodeMonitorsResolver = resolvers.NewResolver(db)
 	return nil
 }

--- a/enterprise/cmd/frontend/internal/dotcom/init.go
+++ b/enterprise/cmd/frontend/internal/dotcom/init.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/dotcom/billing"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/dotcom/productsubscription"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/dotcom/stripeutil"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
@@ -39,7 +40,7 @@ func (d dotcomRootResolver) NodeResolvers() map[string]graphqlbackend.NodeByIDFu
 
 var _ graphqlbackend.DotcomRootResolver = dotcomRootResolver{}
 
-func Init(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
+func Init(ctx context.Context, db dbutil.DB, _ conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
 	stripeEnabled := stripeutil.ValidateAndPublishConfig()
 	// Only enabled on Sourcegraph.com or when Stripe is configured correctly.
 	if envvar.SourcegraphDotComMode() || stripeEnabled {

--- a/enterprise/cmd/frontend/internal/executorqueue/init.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/init.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 
@@ -17,9 +17,9 @@ import (
 )
 
 // Init initializes the executor endpoints required for use with the executor service.
-func Init(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
+func Init(ctx context.Context, db dbutil.DB, conf conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
 	accessToken := func() string {
-		if accessToken := conf.Get().ExecutorsAccessToken; accessToken != "" {
+		if accessToken := conf.SiteConfig().ExecutorsAccessToken; accessToken != "" {
 			return accessToken
 		}
 		// Fallback to old environment variable, for a smooth rollout.
@@ -34,7 +34,7 @@ func Init(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigrat
 		"batches":   batches.QueueOptions(db, accessToken, observationContext),
 	}
 
-	handler, err := codeintel.NewCodeIntelUploadHandler(ctx, db, true)
+	handler, err := codeintel.NewCodeIntelUploadHandler(ctx, conf, db, true)
 	if err != nil {
 		return err
 	}

--- a/enterprise/cmd/frontend/internal/licensing/init/init.go
+++ b/enterprise/cmd/frontend/internal/licensing/init/init.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/licensing/resolvers"
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/registry"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
@@ -24,7 +24,7 @@ import (
 
 // TODO(efritz) - de-globalize assignments in this function
 // TODO(efritz) - refactor licensing packages - this is a huge mess!
-func Init(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
+func Init(ctx context.Context, db dbutil.DB, conf conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
 	// Enforce the license's max user count by preventing the creation of new users when the max is
 	// reached.
 	database.BeforeCreateUser = enforcement.NewBeforeCreateUserHook()
@@ -66,7 +66,7 @@ func Init(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigrat
 			return nil
 		}
 
-		if conf.Get().Branding == nil {
+		if conf.SiteConfig().Branding == nil {
 			return nil
 		}
 

--- a/enterprise/cmd/frontend/internal/searchcontexts/init.go
+++ b/enterprise/cmd/frontend/internal/searchcontexts/init.go
@@ -5,13 +5,14 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/searchcontexts/resolvers"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 )
 
-func Init(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
+func Init(ctx context.Context, db dbutil.DB, _ conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
 	enterpriseServices.SearchContextsResolver = resolvers.NewResolver(database.NewDB(db))
 	return nil
 }

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -29,6 +29,7 @@ import (
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/registry"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/searchcontexts"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -44,7 +45,7 @@ func init() {
 	oobmigration.ReturnEnterpriseMigrations = true
 }
 
-type EnterpriseInitializer = func(context.Context, dbutil.DB, *oobmigration.Runner, *enterprise.Services, *observation.Context) error
+type EnterpriseInitializer = func(context.Context, dbutil.DB, conftypes.UnifiedWatchable, *oobmigration.Runner, *enterprise.Services, *observation.Context) error
 
 var initFunctions = map[string]EnterpriseInitializer{
 	"authz":          authz.Init,
@@ -58,7 +59,7 @@ var initFunctions = map[string]EnterpriseInitializer{
 	"searchcontexts": searchcontexts.Init,
 }
 
-func enterpriseSetupHook(db database.DB, outOfBandMigrationRunner *oobmigration.Runner) enterprise.Services {
+func enterpriseSetupHook(db database.DB, conf conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner) enterprise.Services {
 	debug, _ := strconv.ParseBool(os.Getenv("DEBUG"))
 	if debug {
 		log.Println("enterprise edition")
@@ -76,7 +77,7 @@ func enterpriseSetupHook(db database.DB, outOfBandMigrationRunner *oobmigration.
 	}
 
 	for name, fn := range initFunctions {
-		if err := fn(ctx, db, outOfBandMigrationRunner, &enterpriseServices, observationContext); err != nil {
+		if err := fn(ctx, db, conf, outOfBandMigrationRunner, &enterpriseServices, observationContext); err != nil {
 			log.Fatal(fmt.Sprintf("failed to initialize %s: %s", name, err))
 		}
 	}

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
@@ -15,7 +15,6 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/uploadstore"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -264,7 +263,7 @@ func withUploadData(ctx context.Context, uploadStore uploadstore.Store, id int, 
 }
 
 // writeData transactionally writes the given grouped bundle data into the given LSIF store.
-func writeData(ctx context.Context, lsifStore LSIFStore, upload dbstore.Upload, repo *types.Repo, isDefaultBranch bool, groupedBundleData *precise.GroupedBundleDataChans) (err error) {
+func writeData(ctx context.Context, lsifStore LSIFStore, upload store.Upload, repo *types.Repo, isDefaultBranch bool, groupedBundleData *precise.GroupedBundleDataChans) (err error) {
 	// Upsert values used for documentation search that have high contention. We do this with the raw LSIF store
 	// instead of in the transaction below because the rows being upserted tend to have heavy contention.
 	repositoryNameID, languageNameID, err := lsifStore.WriteDocumentationSearchPrework(ctx, upload, repo, isDefaultBranch)

--- a/enterprise/cmd/precise-code-intel-worker/main.go
+++ b/enterprise/cmd/precise-code-intel-worker/main.go
@@ -47,8 +47,8 @@ func main() {
 	env.HandleHelpFlag()
 	conf.Init()
 	logging.Init()
-	tracer.Init()
-	sentry.Init()
+	tracer.Init(conf.DefaultClient())
+	sentry.Init(conf.DefaultClient())
 	trace.Init()
 
 	if err := config.Validate(); err != nil {
@@ -82,7 +82,7 @@ func main() {
 	// Initialize stores
 	dbStore := dbstore.NewWithDB(db, observationContext)
 	workerStore := dbstore.WorkerutilUploadStore(dbStore, observationContext)
-	lsifStore := lsifstore.NewStore(codeIntelDB, observationContext)
+	lsifStore := lsifstore.NewStore(codeIntelDB, conf.Get(), observationContext)
 	gitserverClient := gitserver.New(dbStore, observationContext)
 
 	uploadStore, err := uploadstore.CreateLazy(context.Background(), config.UploadStoreConfig, observationContext)
@@ -121,9 +121,9 @@ func main() {
 }
 
 func mustInitializeDB() *sql.DB {
-	postgresDSN := conf.Get().ServiceConnections.PostgresDSN
+	postgresDSN := conf.Get().ServiceConnections().PostgresDSN
 	conf.Watch(func() {
-		if newDSN := conf.Get().ServiceConnections.PostgresDSN; postgresDSN != newDSN {
+		if newDSN := conf.Get().ServiceConnections().PostgresDSN; postgresDSN != newDSN {
 			log.Fatalf("Detected database DSN change, restarting to take effect: %s", newDSN)
 		}
 	})
@@ -151,9 +151,9 @@ func mustInitializeDB() *sql.DB {
 }
 
 func mustInitializeCodeIntelDB() *sql.DB {
-	postgresDSN := conf.Get().ServiceConnections.CodeIntelPostgresDSN
+	postgresDSN := conf.Get().ServiceConnections().CodeIntelPostgresDSN
 	conf.Watch(func() {
-		if newDSN := conf.Get().ServiceConnections.CodeIntelPostgresDSN; postgresDSN != newDSN {
+		if newDSN := conf.Get().ServiceConnections().CodeIntelPostgresDSN; postgresDSN != newDSN {
 			log.Fatalf("Detected codeintel database DSN change, restarting to take effect: %s", newDSN)
 		}
 	})

--- a/enterprise/cmd/worker/internal/codeintel/lsifstore.go
+++ b/enterprise/cmd/worker/internal/codeintel/lsifstore.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/worker/memo"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
@@ -33,5 +34,5 @@ var initLSFIStore = memo.NewMemoizedConstructor(func() (interface{}, error) {
 		return nil, err
 	}
 
-	return lsifstore.NewStore(db, observationContext), nil
+	return lsifstore.NewStore(db, conf.Get(), observationContext), nil
 })

--- a/enterprise/internal/authz/authz_test.go
+++ b/enterprise/internal/authz/authz_test.go
@@ -470,7 +470,7 @@ func TestAuthzProvidersFromConfig(t *testing.T) {
 
 		allowAccessByDefault, authzProviders, seriousProblems, _ := ProvidersFromConfig(
 			context.Background(),
-			&test.cfg,
+			staticConfig(test.cfg.SiteConfiguration),
 			&store,
 		)
 		if allowAccessByDefault != test.expAuthzAllowAccessByDefault {
@@ -483,6 +483,12 @@ func TestAuthzProvidersFromConfig(t *testing.T) {
 			t.Errorf("seriousProblems: (actual) %+v != (expected) %+v", asJSON(t, seriousProblems), asJSON(t, test.expSeriousProblems))
 		}
 	}
+}
+
+type staticConfig schema.SiteConfiguration
+
+func (s staticConfig) SiteConfig() schema.SiteConfiguration {
+	return schema.SiteConfiguration(s)
 }
 
 func mustURLParse(t *testing.T, u string) *url.URL {

--- a/enterprise/internal/codeintel/stores/lsifstore/clear_test.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/clear_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/keegancsmith/sqlf"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -17,7 +18,7 @@ func TestClear(t *testing.T) {
 		t.Skip()
 	}
 	db := dbtesting.GetDB(t)
-	store := NewStore(db, &observation.TestContext)
+	store := NewStore(db, conf.DefaultClient(), &observation.TestContext)
 
 	for i := 0; i < 5; i++ {
 		query := sqlf.Sprintf("INSERT INTO lsif_data_metadata (dump_id, num_result_chunks) VALUES (%s, 0)", i+1)

--- a/enterprise/internal/codeintel/stores/lsifstore/data_write_documentation.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/data_write_documentation.go
@@ -739,7 +739,7 @@ func (s *Store) truncateDocumentationSearchIndexSize(ctx context.Context, tableS
 		return errors.Wrap(err, "counting table size")
 	}
 
-	searchIndexLimitFactor := conf.Get().ApidocsSearchIndexSizeLimitFactor
+	searchIndexLimitFactor := s.config.SiteConfig().ApidocsSearchIndexSizeLimitFactor
 	if searchIndexLimitFactor <= 0 {
 		searchIndexLimitFactor = 1.0
 	}

--- a/enterprise/internal/codeintel/stores/lsifstore/data_write_documentation_test.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/data_write_documentation_test.go
@@ -57,7 +57,7 @@ func TestWriteDocumentationUpload(t *testing.T) {
 	isDefaultBranch := true
 
 	db := dbtest.NewDB(t)
-	store := NewStore(db, &observation.TestContext)
+	store := NewStore(db, conf.DefaultClient(), &observation.TestContext)
 
 	{
 		tx, err := store.Transact(ctx)
@@ -99,7 +99,7 @@ func TestWriteDocumentationPathInfo(t *testing.T) {
 	ctx := context.Background()
 
 	db := dbtest.NewDB(t)
-	store := NewStore(db, &observation.TestContext)
+	store := NewStore(db, conf.DefaultClient(), &observation.TestContext)
 
 	pathInfo := &precise.DocumentationPathInfoData{
 		PathID:  "/github.com/sourcegraph/lsif-go/internal",
@@ -136,7 +136,7 @@ func TestWriteDocumentationMappings(t *testing.T) {
 	ctx := context.Background()
 
 	db := dbtest.NewDB(t)
-	store := NewStore(db, &observation.TestContext)
+	store := NewStore(db, conf.DefaultClient(), &observation.TestContext)
 
 	filePath := "internal/index/indexer.go"
 	mapping := precise.DocumentationMapping{

--- a/enterprise/internal/codeintel/stores/lsifstore/helpers_test.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -53,5 +54,5 @@ func populateTestStore(t testing.TB) *Store {
 		}
 	}
 
-	return NewStore(db, &observation.TestContext)
+	return NewStore(db, conf.DefaultClient(), &observation.TestContext)
 }

--- a/enterprise/internal/codeintel/stores/lsifstore/migration/diagnostics_count_test.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/migration/diagnostics_count_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -20,7 +21,7 @@ func TestDiagnosticsCountMigrator(t *testing.T) {
 		t.Skip()
 	}
 	db := dbtesting.GetDB(t)
-	store := lsifstore.NewStore(db, &observation.TestContext)
+	store := lsifstore.NewStore(db, conf.DefaultClient(), &observation.TestContext)
 	migrator := NewDiagnosticsCountMigrator(store, 250)
 	serializer := lsifstore.NewSerializer()
 

--- a/enterprise/internal/codeintel/stores/lsifstore/migration/document_column_split_test.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/migration/document_column_split_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -22,7 +23,7 @@ func TestDocumentColumnSplitMigrator(t *testing.T) {
 		t.Skip()
 	}
 	db := dbtesting.GetDB(t)
-	store := lsifstore.NewStore(db, &observation.TestContext)
+	store := lsifstore.NewStore(db, conf.DefaultClient(), &observation.TestContext)
 	migrator := NewDocumentColumnSplitMigrator(store, 250)
 	serializer := lsifstore.NewSerializer()
 

--- a/enterprise/internal/codeintel/stores/lsifstore/migration/locations_count_test.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/migration/locations_count_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -20,7 +21,7 @@ func TestLocationsCountMigrator(t *testing.T) {
 		t.Skip()
 	}
 	db := dbtesting.GetDB(t)
-	store := lsifstore.NewStore(db, &observation.TestContext)
+	store := lsifstore.NewStore(db, conf.DefaultClient(), &observation.TestContext)
 	migrator := NewLocationsCountMigrator(store, "lsif_data_definitions", 250)
 	serializer := lsifstore.NewSerializer()
 

--- a/enterprise/internal/codeintel/stores/lsifstore/migration/migrator_test.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/migration/migrator_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -16,7 +17,7 @@ func TestMigratorRemovesBoundsWithoutData(t *testing.T) {
 		t.Skip()
 	}
 	db := dbtesting.GetDB(t)
-	store := lsifstore.NewStore(db, &observation.TestContext)
+	store := lsifstore.NewStore(db, conf.DefaultClient(), &observation.TestContext)
 	driver := &testMigrationDriver{}
 	migrator := newMigrator(store, driver, migratorOptions{
 		tableName:     "t_test",

--- a/enterprise/internal/codeintel/stores/lsifstore/store.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -13,13 +14,15 @@ type Store struct {
 	*basestore.Store
 	serializer *Serializer
 	operations *operations
+	config     conftypes.SiteConfigQuerier
 }
 
-func NewStore(db dbutil.DB, observationContext *observation.Context) *Store {
+func NewStore(db dbutil.DB, siteConfig conftypes.SiteConfigQuerier, observationContext *observation.Context) *Store {
 	return &Store{
 		Store:      basestore.NewWithHandle(basestore.NewHandleWithDB(db, sql.TxOptions{})),
 		serializer: NewSerializer(),
 		operations: newOperations(observationContext),
+		config:     siteConfig,
 	}
 }
 
@@ -33,6 +36,7 @@ func (s *Store) Transact(ctx context.Context) (*Store, error) {
 		Store:      tx,
 		serializer: s.serializer,
 		operations: s.operations,
+		config:     s.config,
 	}, nil
 }
 

--- a/enterprise/internal/licensing/conf.go
+++ b/enterprise/internal/licensing/conf.go
@@ -2,12 +2,13 @@ package licensing
 
 import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 )
 
 func init() {
-	conf.ContributeValidator(func(cfg conf.Unified) conf.Problems {
-		if cfg.SiteConfiguration.LicenseKey != "" {
-			info, _, err := ParseProductLicenseKeyWithBuiltinOrGenerationKey(cfg.SiteConfiguration.LicenseKey)
+	conf.ContributeValidator(func(cfg conftypes.SiteConfigQuerier) conf.Problems {
+		if cfg.SiteConfig().LicenseKey != "" {
+			info, _, err := ParseProductLicenseKeyWithBuiltinOrGenerationKey(cfg.SiteConfig().LicenseKey)
 			if err != nil {
 				return conf.NewSiteProblems("should provide a valid license key")
 			} else if err = info.hasUnknownPlan(); EnforceTiers && err != nil {

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -25,7 +25,17 @@ import (
 //
 type Unified struct {
 	schema.SiteConfiguration
-	ServiceConnections conftypes.ServiceConnections
+	ServiceConnectionConfig conftypes.ServiceConnections
+}
+
+var _ conftypes.UnifiedQuerier = Unified{}
+
+func (u Unified) SiteConfig() schema.SiteConfiguration {
+	return u.SiteConfiguration
+}
+
+func (u Unified) ServiceConnections() conftypes.ServiceConnections {
+	return u.ServiceConnectionConfig
 }
 
 type configurationMode int
@@ -66,9 +76,7 @@ func getMode() configurationMode {
 	}
 }
 
-var (
-	configurationServerFrontendOnlyInitialized = make(chan struct{})
-)
+var configurationServerFrontendOnlyInitialized = make(chan struct{})
 
 func initDefaultClient() *client {
 	clientStore := newStore()
@@ -163,9 +171,9 @@ func InitConfigurationServerFrontendOnly(source ConfigurationSource) *Server {
 	// Install the passthrough configuration source for defaultClient. This is
 	// so that the frontend does not request configuration from itself via HTTP
 	// and instead only relies on the DB.
-	defaultClient().passthrough = source
+	DefaultClient().passthrough = source
 
-	go defaultClient().continuouslyUpdate(nil)
+	go DefaultClient().continuouslyUpdate(nil)
 	close(configurationServerFrontendOnlyInitialized)
 
 	startSiteConfigEscapeHatchWorker(source)

--- a/internal/conf/conftypes/unified.go
+++ b/internal/conf/conftypes/unified.go
@@ -1,0 +1,30 @@
+package conftypes
+
+import "github.com/sourcegraph/sourcegraph/schema"
+
+type UnifiedWatchable interface {
+	Watchable
+	UnifiedQuerier
+}
+
+type UnifiedQuerier interface {
+	ServiceConnectionQuerier
+	SiteConfigQuerier
+}
+
+type WatchableSiteConfig interface {
+	SiteConfigQuerier
+	Watchable
+}
+
+type ServiceConnectionQuerier interface {
+	ServiceConnections() ServiceConnections
+}
+
+type SiteConfigQuerier interface {
+	SiteConfig() schema.SiteConfiguration
+}
+
+type Watchable interface {
+	Watch(func())
+}

--- a/internal/conf/diff.go
+++ b/internal/conf/diff.go
@@ -12,7 +12,7 @@ import (
 // two configurations.
 func diff(before, after *Unified) (fields map[string]struct{}) {
 	diff := diffStruct(before.SiteConfiguration, after.SiteConfiguration, "")
-	for k, v := range diffStruct(before.ServiceConnections, after.ServiceConnections, "serviceConnections::") {
+	for k, v := range diffStruct(before.ServiceConnectionConfig, after.ServiceConnectionConfig, "serviceConnections::") {
 		diff[k] = v
 	}
 	return diff

--- a/internal/conf/helpers.go
+++ b/internal/conf/helpers.go
@@ -1,7 +1,9 @@
 package conf
 
-func HasExternalAuthProvider(c Unified) bool {
-	for _, p := range c.AuthProviders {
+import "github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+
+func HasExternalAuthProvider(c conftypes.SiteConfigQuerier) bool {
+	for _, p := range c.SiteConfig().AuthProviders {
 		if p.Builtin == nil { // not builtin implies SSO
 			return true
 		}

--- a/internal/conf/parse.go
+++ b/internal/conf/parse.go
@@ -33,7 +33,7 @@ func parseConfigData(data string, cfg interface{}) error {
 // ParseConfig parses the raw configuration.
 func ParseConfig(data conftypes.RawUnified) (*Unified, error) {
 	cfg := &Unified{
-		ServiceConnections: data.ServiceConnections,
+		ServiceConnectionConfig: data.ServiceConnections,
 	}
 	if err := parseConfigData(data.Site, &cfg.SiteConfiguration); err != nil {
 		return nil, err

--- a/internal/conf/reposource/custom.go
+++ b/internal/conf/reposource/custom.go
@@ -9,11 +9,12 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 )
 
 func init() {
-	conf.ContributeValidator(func(c conf.Unified) (problems conf.Problems) {
-		for _, c := range c.GitCloneURLToRepositoryName {
+	conf.ContributeValidator(func(c conftypes.SiteConfigQuerier) (problems conf.Problems) {
+		for _, c := range c.SiteConfig().GitCloneURLToRepositoryName {
 			if _, err := regexp.Compile(c.From); err != nil {
 				problems = append(problems, conf.NewSiteProblem(fmt.Sprintf("Not a valid regexp: %s. See the valid syntax: https://golang.org/pkg/regexp/", c.From)))
 			}

--- a/internal/conf/validate_custom.go
+++ b/internal/conf/validate_custom.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 )
 
-type Validator func(Unified) Problems
+type Validator func(conftypes.SiteConfigQuerier) Problems
 
 // ContributeValidator adds the site configuration validator function to the validation process. It
 // is called to validate site configuration. Any strings it returns are shown as validation
@@ -82,7 +82,7 @@ func validateCustom(cfg Unified) (problems Problems) {
 func TestValidator(t interface {
 	Errorf(format string, args ...interface{})
 	Helper()
-}, c Unified, f Validator, wantProblems Problems) {
+}, c conftypes.UnifiedQuerier, f Validator, wantProblems Problems) {
 	t.Helper()
 	problems := f(c)
 	wantSet := make(map[string]problemKind, len(wantProblems))

--- a/internal/encryption/keyring/ring.go
+++ b/internal/encryption/keyring/ring.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cockroachdb/errors"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/awskms"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/cache"
@@ -51,8 +52,8 @@ func Init(ctx context.Context) error {
 		mu.Unlock()
 	}
 
-	conf.ContributeValidator(func(cfg conf.Unified) conf.Problems {
-		if _, err := NewRing(ctx, cfg.EncryptionKeys); err != nil {
+	conf.ContributeValidator(func(cfg conftypes.SiteConfigQuerier) conf.Problems {
+		if _, err := NewRing(ctx, cfg.SiteConfig().EncryptionKeys); err != nil {
 			return conf.Problems{conf.NewSiteProblem(fmt.Sprintf("Invalid encryption.keys config: %s", err))}
 		}
 		return nil

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -30,6 +30,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/sourcegraph/go-rendezvous"
+
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -40,8 +41,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
 
-var clientFactory = httpcli.NewInternalClientFactory("gitserver")
-var defaultDoer, _ = clientFactory.Doer()
+var (
+	clientFactory  = httpcli.NewInternalClientFactory("gitserver")
+	defaultDoer, _ = clientFactory.Doer()
+)
 
 // DefaultClient is the default Client. Unless overwritten it is connected to servers specified by SRC_GIT_SERVERS.
 var DefaultClient = NewClient(defaultDoer)
@@ -61,7 +64,7 @@ func ResetClientMocks() {
 func NewClient(cli httpcli.Doer) *Client {
 	return &Client{
 		Addrs: func() []string {
-			return conf.Get().ServiceConnections.GitServers
+			return conf.Get().ServiceConnections().GitServers
 		},
 		HTTPClient:  cli,
 		HTTPLimiter: parallel.NewRun(500),

--- a/internal/repos/sources_test.go
+++ b/internal/repos/sources_test.go
@@ -32,7 +32,7 @@ import (
 
 func TestSources_ListRepos(t *testing.T) {
 	conf.Mock(&conf.Unified{
-		ServiceConnections: conftypes.ServiceConnections{
+		ServiceConnectionConfig: conftypes.ServiceConnections{
 			GitServers: []string{"127.0.0.1:3178"},
 		},
 	})

--- a/internal/sentry/sentry.go
+++ b/internal/sentry/sentry.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cockroachdb/sentry-go"
 	"github.com/inconshreveable/log15"
 
-	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 )
@@ -22,7 +22,7 @@ var sentryDebug, _ = strconv.ParseBool(env.Get("SENTRY_DEBUG", "false", "print d
 // environment variable as the DSN. It then watches site configuration for any
 // subsequent changes. SENTRY_DEBUG can be set as a boolean to print debug
 // messages.
-func Init() {
+func Init(c conftypes.WatchableSiteConfig) {
 	initClient := func(dsn string) error {
 		if dsn == "" {
 			return nil
@@ -55,12 +55,12 @@ func Init() {
 	}
 
 	go func() {
-		conf.Watch(func() {
-			if conf.Get().Log == nil {
+		c.Watch(func() {
+			if c.SiteConfig().Log == nil {
 				return
 			}
 
-			sentryConfig := conf.Get().Log.Sentry
+			sentryConfig := c.SiteConfig().Log.Sentry
 			if sentryConfig == nil {
 				return
 			}


### PR DESCRIPTION
This PR primarily introduces these changes:

1. Creates `SiteConfig()` and `ServiceConnections()` methods on `internal/conf.(*client)` and `internal/conf.Unified`
1. Creates commonly-used interfaces for (a subset of) the methods of `internal/conf.(*client)` and for `internal/conf.Unified`
1. Makes `internal/conf.(*client)` a type designed to be passed around by exporting `internal/conf.DefaultClient()`
	a. This reduces the reliance on the `internal/conf` package which has reliance on other widely used packages, instead shifting the reliance onto the (almost) interface-only `internal/conf/conftypes`
	b. It is expected that a config-type interface from point 2 is passed down the stacks rather than relying on the global `internal/conf.Get()`
1. Replaces use of `internal/conf.Get()` with calls to a passed-down `internal/conf.(*client)` in a select few areas.
	a. Other teams can adopt this at their own pace and to the extent they see suitable

This pattern should also allow for moving away from the existing format of mocking site-config once adoption is far enough.

**NOTE:** all names are subject to change. Please leave your name recommendations if you'd prefer different names.