### PR TITLE
update db schema for code monitor webhooks

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -376,24 +376,24 @@ Referenced by:
 
 # Table "public.cm_action_jobs"
 ```
-       Column       |           Type           | Collation | Nullable |                  Default                   
---------------------+--------------------------+-----------+----------+--------------------------------------------
- id                 | integer                  |           | not null | nextval('cm_action_jobs_id_seq'::regclass)
- email              | bigint                   |           |          | 
- state              | text                     |           |          | 'queued'::text
- failure_message    | text                     |           |          | 
- started_at         | timestamp with time zone |           |          | 
- finished_at        | timestamp with time zone |           |          | 
- process_after      | timestamp with time zone |           |          | 
- num_resets         | integer                  |           | not null | 0
- num_failures       | integer                  |           | not null | 0
- log_contents       | text                     |           |          | 
- trigger_event      | integer                  |           |          | 
- worker_hostname    | text                     |           | not null | ''::text
- last_heartbeat_at  | timestamp with time zone |           |          | 
- execution_logs     | json[]                   |           |          | 
- webhook            | bigint                   |           |          | 
- slack_notification | bigint                   |           |          | 
+      Column       |           Type           | Collation | Nullable |                  Default                   
+-------------------+--------------------------+-----------+----------+--------------------------------------------
+ id                | integer                  |           | not null | nextval('cm_action_jobs_id_seq'::regclass)
+ email             | bigint                   |           |          | 
+ state             | text                     |           |          | 'queued'::text
+ failure_message   | text                     |           |          | 
+ started_at        | timestamp with time zone |           |          | 
+ finished_at       | timestamp with time zone |           |          | 
+ process_after     | timestamp with time zone |           |          | 
+ num_resets        | integer                  |           | not null | 0
+ num_failures      | integer                  |           | not null | 0
+ log_contents      | text                     |           |          | 
+ trigger_event     | integer                  |           |          | 
+ worker_hostname   | text                     |           | not null | ''::text
+ last_heartbeat_at | timestamp with time zone |           |          | 
+ execution_logs    | json[]                   |           |          | 
+ webhook           | bigint                   |           |          | 
+ slack_webhook     | bigint                   |           |          | 
 Indexes:
     "cm_action_jobs_pkey" PRIMARY KEY, btree (id)
 Check constraints:
@@ -407,22 +407,22 @@ CASE
     ELSE 1
 END +
 CASE
-    WHEN slack_notification IS NULL THEN 0
+    WHEN slack_webhook IS NULL THEN 0
     ELSE 1
 END) = 1)
 Foreign-key constraints:
     "cm_action_jobs_email_fk" FOREIGN KEY (email) REFERENCES cm_emails(id) ON DELETE CASCADE
-    "cm_action_jobs_slack_notification_fkey" FOREIGN KEY (slack_notification) REFERENCES cm_slack_notifications(id) ON DELETE CASCADE
+    "cm_action_jobs_slack_webhook_fkey" FOREIGN KEY (slack_webhook) REFERENCES cm_slack_webhooks(id) ON DELETE CASCADE
     "cm_action_jobs_trigger_event_fk" FOREIGN KEY (trigger_event) REFERENCES cm_trigger_jobs(id) ON DELETE CASCADE
     "cm_action_jobs_webhook_fkey" FOREIGN KEY (webhook) REFERENCES cm_webhooks(id) ON DELETE CASCADE
 
 ```
 
-**email**: The ID of the cm_emails action to execute if this is an email job. Mutually exclusive with webhook and slack_notification
+**email**: The ID of the cm_emails action to execute if this is an email job. Mutually exclusive with webhook and slack_webhook
 
-**slack_notification**: The ID of the cm_slack_notifications action to execute if this is a slack notification job. Mutually exclusive with email and webhook
+**slack_webhook**: The ID of the cm_slack_webhook action to execute if this is a slack webhook job. Mutually exclusive with email and webhook
 
-**webhook**: The ID of the cm_webhooks action to execute if this is a webhook job. Mutually exclusive with email and slack_notification
+**webhook**: The ID of the cm_webhooks action to execute if this is a webhook job. Mutually exclusive with email and slack_webhook
 
 # Table "public.cm_emails"
 ```
@@ -471,7 +471,7 @@ Foreign-key constraints:
     "cm_monitors_user_id_fk" FOREIGN KEY (namespace_user_id) REFERENCES users(id) ON DELETE CASCADE
 Referenced by:
     TABLE "cm_emails" CONSTRAINT "cm_emails_monitor" FOREIGN KEY (monitor) REFERENCES cm_monitors(id) ON DELETE CASCADE
-    TABLE "cm_slack_notifications" CONSTRAINT "cm_slack_notifications_monitor_fkey" FOREIGN KEY (monitor) REFERENCES cm_monitors(id) ON DELETE CASCADE
+    TABLE "cm_slack_webhooks" CONSTRAINT "cm_slack_webhooks_monitor_fkey" FOREIGN KEY (monitor) REFERENCES cm_monitors(id) ON DELETE CASCADE
     TABLE "cm_queries" CONSTRAINT "cm_triggers_monitor" FOREIGN KEY (monitor) REFERENCES cm_monitors(id) ON DELETE CASCADE
     TABLE "cm_webhooks" CONSTRAINT "cm_webhooks_monitor_fkey" FOREIGN KEY (monitor) REFERENCES cm_monitors(id) ON DELETE CASCADE
 
@@ -518,11 +518,11 @@ Foreign-key constraints:
 
 ```
 
-# Table "public.cm_slack_notifications"
+# Table "public.cm_slack_webhooks"
 ```
-   Column   |           Type           | Collation | Nullable |                      Default                       
-------------+--------------------------+-----------+----------+----------------------------------------------------
- id         | bigint                   |           | not null | nextval('cm_slack_notifications_id_seq'::regclass)
+   Column   |           Type           | Collation | Nullable |                    Default                    
+------------+--------------------------+-----------+----------+-----------------------------------------------
+ id         | bigint                   |           | not null | nextval('cm_slack_webhooks_id_seq'::regclass)
  monitor    | bigint                   |           | not null | 
  url        | text                     |           | not null | 
  enabled    | boolean                  |           | not null | 
@@ -531,18 +531,18 @@ Foreign-key constraints:
  changed_by | integer                  |           | not null | 
  changed_at | timestamp with time zone |           | not null | now()
 Indexes:
-    "cm_slack_notifications_pkey" PRIMARY KEY, btree (id)
-    "cm_slack_notifications_monitor" btree (monitor)
+    "cm_slack_webhooks_pkey" PRIMARY KEY, btree (id)
+    "cm_slack_webhooks_monitor" btree (monitor)
 Foreign-key constraints:
-    "cm_slack_notifications_changed_by_fkey" FOREIGN KEY (changed_by) REFERENCES users(id) ON DELETE CASCADE
-    "cm_slack_notifications_created_by_fkey" FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE
-    "cm_slack_notifications_monitor_fkey" FOREIGN KEY (monitor) REFERENCES cm_monitors(id) ON DELETE CASCADE
+    "cm_slack_webhooks_changed_by_fkey" FOREIGN KEY (changed_by) REFERENCES users(id) ON DELETE CASCADE
+    "cm_slack_webhooks_created_by_fkey" FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE
+    "cm_slack_webhooks_monitor_fkey" FOREIGN KEY (monitor) REFERENCES cm_monitors(id) ON DELETE CASCADE
 Referenced by:
-    TABLE "cm_action_jobs" CONSTRAINT "cm_action_jobs_slack_notification_fkey" FOREIGN KEY (slack_notification) REFERENCES cm_slack_notifications(id) ON DELETE CASCADE
+    TABLE "cm_action_jobs" CONSTRAINT "cm_action_jobs_slack_webhook_fkey" FOREIGN KEY (slack_webhook) REFERENCES cm_slack_webhooks(id) ON DELETE CASCADE
 
 ```
 
-Slack notification actions configured on code monitors
+Slack webhook actions configured on code monitors
 
 **monitor**: The code monitor that the action is defined on
 
@@ -603,7 +603,7 @@ Referenced by:
 
 Webhook actions configured on code monitors
 
-**enabled**: Whether this Slack notification action is enabled. When not enabled, the action will not be run when its code monitor generates events
+**enabled**: Whether this Slack webhook action is enabled. When not enabled, the action will not be run when its code monitor generates events
 
 **monitor**: The code monitor that the action is defined on
 
@@ -2254,8 +2254,8 @@ Referenced by:
     TABLE "cm_monitors" CONSTRAINT "cm_monitors_created_by_fk" FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE
     TABLE "cm_monitors" CONSTRAINT "cm_monitors_user_id_fk" FOREIGN KEY (namespace_user_id) REFERENCES users(id) ON DELETE CASCADE
     TABLE "cm_recipients" CONSTRAINT "cm_recipients_user_id_fk" FOREIGN KEY (namespace_user_id) REFERENCES users(id) ON DELETE CASCADE
-    TABLE "cm_slack_notifications" CONSTRAINT "cm_slack_notifications_changed_by_fkey" FOREIGN KEY (changed_by) REFERENCES users(id) ON DELETE CASCADE
-    TABLE "cm_slack_notifications" CONSTRAINT "cm_slack_notifications_created_by_fkey" FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE
+    TABLE "cm_slack_webhooks" CONSTRAINT "cm_slack_webhooks_changed_by_fkey" FOREIGN KEY (changed_by) REFERENCES users(id) ON DELETE CASCADE
+    TABLE "cm_slack_webhooks" CONSTRAINT "cm_slack_webhooks_created_by_fkey" FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE
     TABLE "cm_queries" CONSTRAINT "cm_triggers_changed_by_fk" FOREIGN KEY (changed_by) REFERENCES users(id) ON DELETE CASCADE
     TABLE "cm_queries" CONSTRAINT "cm_triggers_created_by_fk" FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE
     TABLE "cm_webhooks" CONSTRAINT "cm_webhooks_changed_by_fkey" FOREIGN KEY (changed_by) REFERENCES users(id) ON DELETE CASCADE

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -376,29 +376,53 @@ Referenced by:
 
 # Table "public.cm_action_jobs"
 ```
-      Column       |           Type           | Collation | Nullable |                  Default                   
--------------------+--------------------------+-----------+----------+--------------------------------------------
- id                | integer                  |           | not null | nextval('cm_action_jobs_id_seq'::regclass)
- email             | bigint                   |           | not null | 
- state             | text                     |           |          | 'queued'::text
- failure_message   | text                     |           |          | 
- started_at        | timestamp with time zone |           |          | 
- finished_at       | timestamp with time zone |           |          | 
- process_after     | timestamp with time zone |           |          | 
- num_resets        | integer                  |           | not null | 0
- num_failures      | integer                  |           | not null | 0
- log_contents      | text                     |           |          | 
- trigger_event     | integer                  |           |          | 
- worker_hostname   | text                     |           | not null | ''::text
- last_heartbeat_at | timestamp with time zone |           |          | 
- execution_logs    | json[]                   |           |          | 
+       Column       |           Type           | Collation | Nullable |                  Default                   
+--------------------+--------------------------+-----------+----------+--------------------------------------------
+ id                 | integer                  |           | not null | nextval('cm_action_jobs_id_seq'::regclass)
+ email              | bigint                   |           |          | 
+ state              | text                     |           |          | 'queued'::text
+ failure_message    | text                     |           |          | 
+ started_at         | timestamp with time zone |           |          | 
+ finished_at        | timestamp with time zone |           |          | 
+ process_after      | timestamp with time zone |           |          | 
+ num_resets         | integer                  |           | not null | 0
+ num_failures       | integer                  |           | not null | 0
+ log_contents       | text                     |           |          | 
+ trigger_event      | integer                  |           |          | 
+ worker_hostname    | text                     |           | not null | ''::text
+ last_heartbeat_at  | timestamp with time zone |           |          | 
+ execution_logs     | json[]                   |           |          | 
+ webhook            | bigint                   |           |          | 
+ slack_notification | bigint                   |           |          | 
 Indexes:
     "cm_action_jobs_pkey" PRIMARY KEY, btree (id)
+Check constraints:
+    "cm_action_jobs_only_one_action_type" CHECK ((
+CASE
+    WHEN email IS NULL THEN 0
+    ELSE 1
+END +
+CASE
+    WHEN webhook IS NULL THEN 0
+    ELSE 1
+END +
+CASE
+    WHEN slack_notification IS NULL THEN 0
+    ELSE 1
+END) = 1)
 Foreign-key constraints:
     "cm_action_jobs_email_fk" FOREIGN KEY (email) REFERENCES cm_emails(id) ON DELETE CASCADE
+    "cm_action_jobs_slack_notification_fkey" FOREIGN KEY (slack_notification) REFERENCES cm_slack_notifications(id) ON DELETE CASCADE
     "cm_action_jobs_trigger_event_fk" FOREIGN KEY (trigger_event) REFERENCES cm_trigger_jobs(id) ON DELETE CASCADE
+    "cm_action_jobs_webhook_fkey" FOREIGN KEY (webhook) REFERENCES cm_webhooks(id) ON DELETE CASCADE
 
 ```
+
+**email**: The ID of the cm_emails action to execute if this is an email job. Mutually exclusive with webhook and slack_notification
+
+**slack_notification**: The ID of the cm_slack_notifications action to execute if this is a slack notification job. Mutually exclusive with email and webhook
+
+**webhook**: The ID of the cm_webhooks action to execute if this is a webhook job. Mutually exclusive with email and slack_notification
 
 # Table "public.cm_emails"
 ```
@@ -447,7 +471,9 @@ Foreign-key constraints:
     "cm_monitors_user_id_fk" FOREIGN KEY (namespace_user_id) REFERENCES users(id) ON DELETE CASCADE
 Referenced by:
     TABLE "cm_emails" CONSTRAINT "cm_emails_monitor" FOREIGN KEY (monitor) REFERENCES cm_monitors(id) ON DELETE CASCADE
+    TABLE "cm_slack_notifications" CONSTRAINT "cm_slack_notifications_monitor_fkey" FOREIGN KEY (monitor) REFERENCES cm_monitors(id) ON DELETE CASCADE
     TABLE "cm_queries" CONSTRAINT "cm_triggers_monitor" FOREIGN KEY (monitor) REFERENCES cm_monitors(id) ON DELETE CASCADE
+    TABLE "cm_webhooks" CONSTRAINT "cm_webhooks_monitor_fkey" FOREIGN KEY (monitor) REFERENCES cm_monitors(id) ON DELETE CASCADE
 
 ```
 
@@ -492,6 +518,36 @@ Foreign-key constraints:
 
 ```
 
+# Table "public.cm_slack_notifications"
+```
+   Column   |           Type           | Collation | Nullable |                      Default                       
+------------+--------------------------+-----------+----------+----------------------------------------------------
+ id         | bigint                   |           | not null | nextval('cm_slack_notifications_id_seq'::regclass)
+ monitor    | bigint                   |           | not null | 
+ url        | text                     |           | not null | 
+ enabled    | boolean                  |           | not null | 
+ created_by | integer                  |           | not null | 
+ created_at | timestamp with time zone |           | not null | now()
+ changed_by | integer                  |           | not null | 
+ changed_at | timestamp with time zone |           | not null | now()
+Indexes:
+    "cm_slack_notifications_pkey" PRIMARY KEY, btree (id)
+    "cm_slack_notifications_monitor" btree (monitor)
+Foreign-key constraints:
+    "cm_slack_notifications_changed_by_fkey" FOREIGN KEY (changed_by) REFERENCES users(id) ON DELETE CASCADE
+    "cm_slack_notifications_created_by_fkey" FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE
+    "cm_slack_notifications_monitor_fkey" FOREIGN KEY (monitor) REFERENCES cm_monitors(id) ON DELETE CASCADE
+Referenced by:
+    TABLE "cm_action_jobs" CONSTRAINT "cm_action_jobs_slack_notification_fkey" FOREIGN KEY (slack_notification) REFERENCES cm_slack_notifications(id) ON DELETE CASCADE
+
+```
+
+Slack notification actions configured on code monitors
+
+**monitor**: The code monitor that the action is defined on
+
+**url**: The Slack webhook URL we send the code monitor event to
+
 # Table "public.cm_trigger_jobs"
 ```
       Column       |           Type           | Collation | Nullable |                   Default                   
@@ -520,6 +576,38 @@ Referenced by:
     TABLE "cm_action_jobs" CONSTRAINT "cm_action_jobs_trigger_event_fk" FOREIGN KEY (trigger_event) REFERENCES cm_trigger_jobs(id) ON DELETE CASCADE
 
 ```
+
+# Table "public.cm_webhooks"
+```
+   Column   |           Type           | Collation | Nullable |                 Default                 
+------------+--------------------------+-----------+----------+-----------------------------------------
+ id         | bigint                   |           | not null | nextval('cm_webhooks_id_seq'::regclass)
+ monitor    | bigint                   |           | not null | 
+ url        | text                     |           | not null | 
+ enabled    | boolean                  |           | not null | 
+ created_by | integer                  |           | not null | 
+ created_at | timestamp with time zone |           | not null | now()
+ changed_by | integer                  |           | not null | 
+ changed_at | timestamp with time zone |           | not null | now()
+Indexes:
+    "cm_webhooks_pkey" PRIMARY KEY, btree (id)
+    "cm_webhooks_monitor" btree (monitor)
+Foreign-key constraints:
+    "cm_webhooks_changed_by_fkey" FOREIGN KEY (changed_by) REFERENCES users(id) ON DELETE CASCADE
+    "cm_webhooks_created_by_fkey" FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE
+    "cm_webhooks_monitor_fkey" FOREIGN KEY (monitor) REFERENCES cm_monitors(id) ON DELETE CASCADE
+Referenced by:
+    TABLE "cm_action_jobs" CONSTRAINT "cm_action_jobs_webhook_fkey" FOREIGN KEY (webhook) REFERENCES cm_webhooks(id) ON DELETE CASCADE
+
+```
+
+Webhook actions configured on code monitors
+
+**enabled**: Whether this Slack notification action is enabled. When not enabled, the action will not be run when its code monitor generates events
+
+**monitor**: The code monitor that the action is defined on
+
+**url**: The webhook URL we send the code monitor event to
 
 # Table "public.critical_and_site_config"
 ```
@@ -2166,8 +2254,12 @@ Referenced by:
     TABLE "cm_monitors" CONSTRAINT "cm_monitors_created_by_fk" FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE
     TABLE "cm_monitors" CONSTRAINT "cm_monitors_user_id_fk" FOREIGN KEY (namespace_user_id) REFERENCES users(id) ON DELETE CASCADE
     TABLE "cm_recipients" CONSTRAINT "cm_recipients_user_id_fk" FOREIGN KEY (namespace_user_id) REFERENCES users(id) ON DELETE CASCADE
+    TABLE "cm_slack_notifications" CONSTRAINT "cm_slack_notifications_changed_by_fkey" FOREIGN KEY (changed_by) REFERENCES users(id) ON DELETE CASCADE
+    TABLE "cm_slack_notifications" CONSTRAINT "cm_slack_notifications_created_by_fkey" FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE
     TABLE "cm_queries" CONSTRAINT "cm_triggers_changed_by_fk" FOREIGN KEY (changed_by) REFERENCES users(id) ON DELETE CASCADE
     TABLE "cm_queries" CONSTRAINT "cm_triggers_created_by_fk" FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE
+    TABLE "cm_webhooks" CONSTRAINT "cm_webhooks_changed_by_fkey" FOREIGN KEY (changed_by) REFERENCES users(id) ON DELETE CASCADE
+    TABLE "cm_webhooks" CONSTRAINT "cm_webhooks_created_by_fkey" FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE
     TABLE "discussion_comments" CONSTRAINT "discussion_comments_author_user_id_fkey" FOREIGN KEY (author_user_id) REFERENCES users(id) ON DELETE RESTRICT
     TABLE "discussion_mail_reply_tokens" CONSTRAINT "discussion_mail_reply_tokens_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE RESTRICT
     TABLE "discussion_threads" CONSTRAINT "discussion_threads_author_user_id_fkey" FOREIGN KEY (author_user_id) REFERENCES users(id) ON DELETE RESTRICT

--- a/migrations/frontend/1528395937_codemonitor_webhooks.down.sql
+++ b/migrations/frontend/1528395937_codemonitor_webhooks.down.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+ALTER TABLE cm_action_jobs
+	DROP CONSTRAINT IF EXISTS cm_action_jobs_only_one_action_type,
+	DROP COLUMN IF EXISTS slack_notification,
+	DROP COLUMN IF EXISTS webhook,
+	ALTER COLUMN email SET NOT NULL;
+
+DROP TABLE IF EXISTS cm_slack_notifications;
+DROP TABLE IF EXISTS cm_webhooks;
+
+COMMIT;

--- a/migrations/frontend/1528395937_codemonitor_webhooks.down.sql
+++ b/migrations/frontend/1528395937_codemonitor_webhooks.down.sql
@@ -2,11 +2,11 @@ BEGIN;
 
 ALTER TABLE cm_action_jobs
 	DROP CONSTRAINT IF EXISTS cm_action_jobs_only_one_action_type,
-	DROP COLUMN IF EXISTS slack_notification,
+	DROP COLUMN IF EXISTS slack_webhook,
 	DROP COLUMN IF EXISTS webhook,
 	ALTER COLUMN email SET NOT NULL;
 
-DROP TABLE IF EXISTS cm_slack_notifications;
+DROP TABLE IF EXISTS cm_slack_webhooks;
 DROP TABLE IF EXISTS cm_webhooks;
 
 COMMIT;

--- a/migrations/frontend/1528395937_codemonitor_webhooks.up.sql
+++ b/migrations/frontend/1528395937_codemonitor_webhooks.up.sql
@@ -20,8 +20,8 @@ COMMENT ON COLUMN cm_webhooks.url IS 'The webhook URL we send the code monitor e
 COMMENT ON COLUMN cm_webhooks.enabled IS 'Whether this webhook action is enabled. When not enabled, the action will not be run when its code monitor generates events';
 -- End cm_webhooks
 
--- Begin cm_slack_notifications
-CREATE TABLE IF NOT EXISTS cm_slack_notifications (
+-- Begin cm_slack_webhooks
+CREATE TABLE IF NOT EXISTS cm_slack_webhooks (
 	id BIGSERIAL PRIMARY KEY,
 	monitor BIGINT NOT NULL REFERENCES cm_monitors(id) ON DELETE CASCADE,
 	url TEXT NOT NULL,
@@ -32,32 +32,32 @@ CREATE TABLE IF NOT EXISTS cm_slack_notifications (
 	changed_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
 
-CREATE INDEX IF NOT EXISTS cm_slack_notifications_monitor ON cm_slack_notifications (monitor);
+CREATE INDEX IF NOT EXISTS cm_slack_webhooks_monitor ON cm_slack_webhooks (monitor);
 
-COMMENT ON TABLE cm_slack_notifications IS 'Slack notification actions configured on code monitors';
-COMMENT ON COLUMN cm_slack_notifications.monitor IS 'The code monitor that the action is defined on';
-COMMENT ON COLUMN cm_slack_notifications.url IS 'The Slack webhook URL we send the code monitor event to';
-COMMENT ON COLUMN cm_webhooks.enabled IS 'Whether this Slack notification action is enabled. When not enabled, the action will not be run when its code monitor generates events';
--- End cm_slack_notifications
+COMMENT ON TABLE cm_slack_webhooks IS 'Slack webhook actions configured on code monitors';
+COMMENT ON COLUMN cm_slack_webhooks.monitor IS 'The code monitor that the action is defined on';
+COMMENT ON COLUMN cm_slack_webhooks.url IS 'The Slack webhook URL we send the code monitor event to';
+COMMENT ON COLUMN cm_webhooks.enabled IS 'Whether this Slack webhook action is enabled. When not enabled, the action will not be run when its code monitor generates events';
+-- End cm_slack_webhooks
 
 -- Begin add non-email actions to cm_triggers
 ALTER TABLE cm_action_jobs
 	ALTER COLUMN email DROP NOT NULL, -- make email nullable (drop the not null constraint)
 	ADD COLUMN IF NOT EXISTS webhook BIGINT -- create a nullable webhook column
 		REFERENCES cm_webhooks(id) ON DELETE CASCADE,
-	ADD COLUMN IF NOT EXISTS slack_notification BIGINT  --create a nullable slack notification column
-		REFERENCES cm_slack_notifications(id) ON DELETE CASCADE,
-	ADD CONSTRAINT cm_action_jobs_only_one_action_type CHECK ( -- constrain that only one of email, webhook, and slack_notification is non-null
+	ADD COLUMN IF NOT EXISTS slack_webhook BIGINT  --create a nullable slack webhook column
+		REFERENCES cm_slack_webhooks(id) ON DELETE CASCADE,
+	ADD CONSTRAINT cm_action_jobs_only_one_action_type CHECK ( -- constrain that only one of email, webhook, and slack_webhook is non-null
 		( 
 			CASE WHEN email IS NULL THEN 0 ELSE 1 END
 			+ CASE WHEN webhook IS NULL THEN 0 ELSE 1 END 
-			+ CASE WHEN slack_notification IS NULL THEN 0 ELSE 1 END 
+			+ CASE WHEN slack_webhook IS NULL THEN 0 ELSE 1 END 
 		) = 1
 	);
 
-COMMENT ON COLUMN cm_action_jobs.email IS 'The ID of the cm_emails action to execute if this is an email job. Mutually exclusive with webhook and slack_notification';
-COMMENT ON COLUMN cm_action_jobs.webhook IS 'The ID of the cm_webhooks action to execute if this is a webhook job. Mutually exclusive with email and slack_notification';
-COMMENT ON COLUMN cm_action_jobs.slack_notification IS 'The ID of the cm_slack_notifications action to execute if this is a slack notification job. Mutually exclusive with email and webhook';
+COMMENT ON COLUMN cm_action_jobs.email IS 'The ID of the cm_emails action to execute if this is an email job. Mutually exclusive with webhook and slack_webhook';
+COMMENT ON COLUMN cm_action_jobs.webhook IS 'The ID of the cm_webhooks action to execute if this is a webhook job. Mutually exclusive with email and slack_webhook';
+COMMENT ON COLUMN cm_action_jobs.slack_webhook IS 'The ID of the cm_slack_webhook action to execute if this is a slack webhook job. Mutually exclusive with email and webhook';
 COMMENT ON CONSTRAINT cm_action_jobs_only_one_action_type ON cm_action_jobs IS 'Constrains that each queued code monitor action has exactly one action type';
 -- End add non-email actions to cm_triggers
 

--- a/migrations/frontend/1528395937_codemonitor_webhooks.up.sql
+++ b/migrations/frontend/1528395937_codemonitor_webhooks.up.sql
@@ -1,0 +1,64 @@
+BEGIN;
+
+-- Begin cm_webhooks
+CREATE TABLE IF NOT EXISTS cm_webhooks (
+	id BIGSERIAL PRIMARY KEY,
+	monitor BIGINT NOT NULL REFERENCES cm_monitors(id) ON DELETE CASCADE,
+	url TEXT NOT NULL,
+	enabled BOOLEAN NOT NULL,
+	created_by INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+	created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+	changed_by INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+	changed_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS cm_webhooks_monitor ON cm_webhooks (monitor);
+
+COMMENT ON TABLE cm_webhooks IS 'Webhook actions configured on code monitors';
+COMMENT ON COLUMN cm_webhooks.monitor IS 'The code monitor that the action is defined on';
+COMMENT ON COLUMN cm_webhooks.url IS 'The webhook URL we send the code monitor event to';
+COMMENT ON COLUMN cm_webhooks.enabled IS 'Whether this webhook action is enabled. When not enabled, the action will not be run when its code monitor generates events';
+-- End cm_webhooks
+
+-- Begin cm_slack_notifications
+CREATE TABLE IF NOT EXISTS cm_slack_notifications (
+	id BIGSERIAL PRIMARY KEY,
+	monitor BIGINT NOT NULL REFERENCES cm_monitors(id) ON DELETE CASCADE,
+	url TEXT NOT NULL,
+	enabled BOOLEAN NOT NULL,
+	created_by INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+	created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+	changed_by INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+	changed_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS cm_slack_notifications_monitor ON cm_slack_notifications (monitor);
+
+COMMENT ON TABLE cm_slack_notifications IS 'Slack notification actions configured on code monitors';
+COMMENT ON COLUMN cm_slack_notifications.monitor IS 'The code monitor that the action is defined on';
+COMMENT ON COLUMN cm_slack_notifications.url IS 'The Slack webhook URL we send the code monitor event to';
+COMMENT ON COLUMN cm_webhooks.enabled IS 'Whether this Slack notification action is enabled. When not enabled, the action will not be run when its code monitor generates events';
+-- End cm_slack_notifications
+
+-- Begin add non-email actions to cm_triggers
+ALTER TABLE cm_action_jobs
+	ALTER COLUMN email DROP NOT NULL, -- make email nullable (drop the not null constraint)
+	ADD COLUMN IF NOT EXISTS webhook BIGINT -- create a nullable webhook column
+		REFERENCES cm_webhooks(id) ON DELETE CASCADE,
+	ADD COLUMN IF NOT EXISTS slack_notification BIGINT  --create a nullable slack notification column
+		REFERENCES cm_slack_notifications(id) ON DELETE CASCADE,
+	ADD CONSTRAINT cm_action_jobs_only_one_action_type CHECK ( -- constrain that only one of email, webhook, and slack_notification is non-null
+		( 
+			CASE WHEN email IS NULL THEN 0 ELSE 1 END
+			+ CASE WHEN webhook IS NULL THEN 0 ELSE 1 END 
+			+ CASE WHEN slack_notification IS NULL THEN 0 ELSE 1 END 
+		) = 1
+	);
+
+COMMENT ON COLUMN cm_action_jobs.email IS 'The ID of the cm_emails action to execute if this is an email job. Mutually exclusive with webhook and slack_notification';
+COMMENT ON COLUMN cm_action_jobs.webhook IS 'The ID of the cm_webhooks action to execute if this is a webhook job. Mutually exclusive with email and slack_notification';
+COMMENT ON COLUMN cm_action_jobs.slack_notification IS 'The ID of the cm_slack_notifications action to execute if this is a slack notification job. Mutually exclusive with email and webhook';
+COMMENT ON CONSTRAINT cm_action_jobs_only_one_action_type ON cm_action_jobs IS 'Constrains that each queued code monitor action has exactly one action type';
+-- End add non-email actions to cm_triggers
+
+COMMIT;


### PR DESCRIPTION
This commit updates the db schema to add tables for webhook
and slack notification for code monitors. It should not change any
behavior because the new tables will always be empty, the new 
columns will always be nil, and the email column will still always be 
non-nil. I will update the wrapping store in a followup PR. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
