### PR TITLE
codemonitors: Clean up action job store

### DIFF
--- a/enterprise/internal/codemonitors/action_jobs.go
+++ b/enterprise/internal/codemonitors/action_jobs.go
@@ -8,6 +8,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
 
@@ -185,11 +186,7 @@ func scanActionJobs(rows *sql.Rows) ([]*ActionJob, error) {
 	return ajs, rows.Err()
 }
 
-type rowScanner interface {
-	Scan(...interface{}) error
-}
-
-func scanActionJob(row rowScanner) (*ActionJob, error) {
+func scanActionJob(row dbutil.Scanner) (*ActionJob, error) {
 	aj := &ActionJob{}
 	return aj, row.Scan(
 		&aj.Id,

--- a/enterprise/internal/codemonitors/action_jobs.go
+++ b/enterprise/internal/codemonitors/action_jobs.go
@@ -126,6 +126,7 @@ INSERT INTO cm_action_jobs (email, trigger_event)
 SELECT id, %s::integer from due EXCEPT SELECT id, %s::integer from busy ORDER BY id
 `
 
+// TODO(camdencheek): could we enqueue based on monitor ID rather than query ID? Would avoid joins above.
 func (s *Store) EnqueueActionEmailsForQueryIDInt64(ctx context.Context, queryID int64, triggerEventID int) (err error) {
 	return s.Store.Exec(ctx, sqlf.Sprintf(enqueueActionEmailFmtStr, queryID, triggerEventID, triggerEventID))
 }

--- a/enterprise/internal/codemonitors/action_jobs.go
+++ b/enterprise/internal/codemonitors/action_jobs.go
@@ -12,11 +12,9 @@ import (
 )
 
 type ActionJob struct {
-	Id                int
-	Email             *int64
-	Webhook           *int64
-	SlackNotification *int64
-	TriggerEvent      int
+	Id           int
+	Email        int64
+	TriggerEvent int
 
 	// Fields demanded by any dbworker.
 	State          string
@@ -45,8 +43,6 @@ type ActionJobMetadata struct {
 var ActionJobsColumns = []*sqlf.Query{
 	sqlf.Sprintf("cm_action_jobs.id"),
 	sqlf.Sprintf("cm_action_jobs.email"),
-	sqlf.Sprintf("cm_action_jobs.webhook"),
-	sqlf.Sprintf("cm_action_jobs.slack_notification"),
 	sqlf.Sprintf("cm_action_jobs.trigger_event"),
 	sqlf.Sprintf("cm_action_jobs.state"),
 	sqlf.Sprintf("cm_action_jobs.failure_message"),
@@ -198,8 +194,6 @@ func scanActionJob(row rowScanner) (*ActionJob, error) {
 	return aj, row.Scan(
 		&aj.Id,
 		&aj.Email,
-		&aj.Webhook,
-		&aj.SlackNotification,
 		&aj.TriggerEvent,
 		&aj.State,
 		&aj.FailureMessage,

--- a/enterprise/internal/codemonitors/action_jobs.go
+++ b/enterprise/internal/codemonitors/action_jobs.go
@@ -109,14 +109,14 @@ func (s *Store) TotalActionEmailEvents(ctx context.Context, emailID int64, trigg
 const enqueueActionEmailFmtStr = `
 WITH due AS (
 	SELECT e.id
-	FROM cm_emails e 
+	FROM cm_emails e
 	INNER JOIN cm_queries q ON e.monitor = q.monitor
 	WHERE q.id = %s AND e.enabled = true
 ),
 busy AS (
-    SELECT DISTINCT email as id FROM cm_action_jobs
-    WHERE state = 'queued'
-    OR state = 'processing'
+	SELECT DISTINCT email as id FROM cm_action_jobs
+	WHERE state = 'queued'
+	OR state = 'processing'
 )
 INSERT INTO cm_action_jobs (email, trigger_event)
 SELECT id, %s::integer from due EXCEPT SELECT id, %s::integer from busy ORDER BY id
@@ -128,11 +128,11 @@ func (s *Store) EnqueueActionEmailsForQueryIDInt64(ctx context.Context, queryID 
 }
 
 const getActionJobMetadataFmtStr = `
-SELECT 
-	cm.description, 
-	ctj.query_string, 
-	cm.id AS monitorID, 
-	ctj.num_results 
+SELECT
+	cm.description,
+	ctj.query_string,
+	cm.id AS monitorID,
+	ctj.num_results
 FROM cm_action_jobs caj
 INNER JOIN cm_trigger_jobs ctj on caj.trigger_event = ctj.id
 INNER JOIN cm_queries cq on cq.id = ctj.query

--- a/enterprise/internal/codemonitors/action_jobs.go
+++ b/enterprise/internal/codemonitors/action_jobs.go
@@ -84,6 +84,7 @@ func (s *Store) ReadActionEmailEvents(ctx context.Context, emailID int64, trigge
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	return scanActionJobs(rows)
 }
 
@@ -164,6 +165,7 @@ func ScanActionJobRecord(rows *sql.Rows, err error) (workerutil.Record, bool, er
 	if err != nil {
 		return &TriggerJobs{}, false, err
 	}
+	defer rows.Close()
 
 	records, err := scanActionJobs(rows)
 	if err != nil || len(records) == 0 {
@@ -173,8 +175,6 @@ func ScanActionJobRecord(rows *sql.Rows, err error) (workerutil.Record, bool, er
 }
 
 func scanActionJobs(rows *sql.Rows) ([]*ActionJob, error) {
-	defer rows.Close()
-
 	var ajs []*ActionJob
 	for rows.Next() {
 		aj, err := scanActionJob(rows)

--- a/enterprise/internal/codemonitors/action_jobs.go
+++ b/enterprise/internal/codemonitors/action_jobs.go
@@ -61,7 +61,18 @@ var ActionJobsColumns = []*sqlf.Query{
 }
 
 const readActionEmailEventsFmtStr = `
-SELECT id, email, trigger_event, state, failure_message, started_at, finished_at, process_after, num_resets, num_failures, log_contents
+SELECT 
+	id, 
+	email, 
+	trigger_event, 
+	state, 
+	failure_message, 
+	started_at, 
+	finished_at, 
+	process_after, 
+	num_resets, 
+	num_failures, 
+	log_contents
 FROM cm_action_jobs
 WHERE %s
 AND id > %s
@@ -130,12 +141,16 @@ func (s *Store) EnqueueActionEmailsForQueryIDInt64(ctx context.Context, queryID 
 }
 
 const getActionJobMetadataFmtStr = `
-select cm.description, ctj.query_string, cm.id as monitorID, ctj.num_results from
-cm_action_jobs caj
-inner join cm_trigger_jobs ctj on caj.trigger_event = ctj.id
-inner join cm_queries cq on cq.id = ctj.query
-inner join cm_monitors cm on cm.id = cq.monitor
-where caj.id = %s
+SELECT 
+	cm.description, 
+	ctj.query_string, 
+	cm.id AS monitorID, 
+	ctj.num_results 
+FROM cm_action_jobs caj
+INNER JOIN cm_trigger_jobs ctj on caj.trigger_event = ctj.id
+INNER JOIN cm_queries cq on cq.id = ctj.query
+INNER JOIN cm_monitors cm on cm.id = cq.monitor
+WHERE caj.id = %s
 `
 
 func (s *Store) GetActionJobMetadata(ctx context.Context, recordID int) (m *ActionJobMetadata, err error) {
@@ -149,7 +164,18 @@ func (s *Store) GetActionJobMetadata(ctx context.Context, recordID int) (m *Acti
 }
 
 const actionJobForIDFmtStr = `
-SELECT id, email, trigger_event, state, failure_message, started_at, finished_at, process_after, num_resets, num_failures, log_contents
+SELECT 
+	id, 
+	email, 
+	trigger_event, 
+	state, 
+	failure_message, 
+	started_at, 
+	finished_at, 
+	process_after, 
+	num_resets, 
+	num_failures, 
+	log_contents
 FROM cm_action_jobs
 WHERE id = %s
 `

--- a/enterprise/internal/codemonitors/action_jobs_test.go
+++ b/enterprise/internal/codemonitors/action_jobs_test.go
@@ -129,7 +129,7 @@ func TestScanActionJobs(t *testing.T) {
 	}
 	var rows *sql.Rows
 	rows, err = s.Query(ctx, sqlf.Sprintf(actionJobForIDFmtStr, sqlf.Join(ActionJobsColumns, ", "), testRecordID))
-	record, _, err := ScanActionJobs(rows, err)
+	record, _, err := ScanActionJobRecord(rows, err)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/codemonitors/action_jobs_test.go
+++ b/enterprise/internal/codemonitors/action_jobs_test.go
@@ -37,7 +37,7 @@ func TestEnqueueActionEmailsForQueryIDInt64QueryByRecordID(t *testing.T) {
 
 	want := &ActionJob{
 		Id:             1,
-		Email:          1,
+		Email:          int64Ptr(1),
 		TriggerEvent:   1,
 		State:          "queued",
 		FailureMessage: nil,
@@ -51,6 +51,10 @@ func TestEnqueueActionEmailsForQueryIDInt64QueryByRecordID(t *testing.T) {
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Fatalf("diff: %s", diff)
 	}
+}
+
+func int64Ptr(i int64) *int64 {
+	return &i
 }
 
 func TestGetActionJobMetadata(t *testing.T) {
@@ -124,7 +128,7 @@ func TestScanActionJobs(t *testing.T) {
 		t.Fatal(err)
 	}
 	var rows *sql.Rows
-	rows, err = s.Query(ctx, sqlf.Sprintf(actionJobForIDFmtStr, testRecordID))
+	rows, err = s.Query(ctx, sqlf.Sprintf(actionJobForIDFmtStr, sqlf.Join(ActionJobsColumns, ", "), testRecordID))
 	record, _, err := ScanActionJobs(rows, err)
 	if err != nil {
 		t.Fatal(err)

--- a/enterprise/internal/codemonitors/action_jobs_test.go
+++ b/enterprise/internal/codemonitors/action_jobs_test.go
@@ -37,7 +37,7 @@ func TestEnqueueActionEmailsForQueryIDInt64QueryByRecordID(t *testing.T) {
 
 	want := &ActionJob{
 		Id:             1,
-		Email:          int64Ptr(1),
+		Email:          1,
 		TriggerEvent:   1,
 		State:          "queued",
 		FailureMessage: nil,
@@ -51,10 +51,6 @@ func TestEnqueueActionEmailsForQueryIDInt64QueryByRecordID(t *testing.T) {
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Fatalf("diff: %s", diff)
 	}
-}
-
-func int64Ptr(i int64) *int64 {
-	return &i
 }
 
 func TestGetActionJobMetadata(t *testing.T) {

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -122,7 +122,7 @@ func createDBWorkerStoreForActionJobs(s *cm.Store) dbworkerstore.Store {
 		Name:              "code_monitors_action_jobs_worker_store",
 		TableName:         "cm_action_jobs",
 		ColumnExpressions: cm.ActionJobsColumns,
-		Scan:              cm.ScanActionJobs,
+		Scan:              cm.ScanActionJobRecord,
 		StalledMaxAge:     60 * time.Second,
 		RetryAfter:        10 * time.Second,
 		MaxNumRetries:     3,


### PR DESCRIPTION
This PR cleans up the action job methods on the code monitor
store a bit to simplify the code a bit. Details inline.

Stacked on #27474 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
