### PR TITLE
codemonitors: Make store aware of webhook and slack_webhook columns

### DIFF
--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -836,7 +836,7 @@ func (m *monitorEmail) Events(ctx context.Context, args *graphqlbackend.ListEven
 	for i, aj := range ajs {
 		events[i] = &monitorActionEvent{Resolver: m.Resolver, ActionJob: aj}
 	}
-	return &monitorActionEventConnection{events: events, totalCount: totalCount}, nil
+	return &monitorActionEventConnection{events: events, totalCount: int32(totalCount)}, nil
 }
 
 //

--- a/enterprise/internal/codemonitors/action_jobs.go
+++ b/enterprise/internal/codemonitors/action_jobs.go
@@ -14,7 +14,9 @@ import (
 
 type ActionJob struct {
 	Id           int
-	Email        int64
+	Email        *int64
+	Webhook      *int64
+	SlackWebhook *int64
 	TriggerEvent int
 
 	// Fields demanded by any dbworker.
@@ -44,6 +46,8 @@ type ActionJobMetadata struct {
 var ActionJobsColumns = []*sqlf.Query{
 	sqlf.Sprintf("cm_action_jobs.id"),
 	sqlf.Sprintf("cm_action_jobs.email"),
+	sqlf.Sprintf("cm_action_jobs.webhook"),
+	sqlf.Sprintf("cm_action_jobs.slack_webhook"),
 	sqlf.Sprintf("cm_action_jobs.trigger_event"),
 	sqlf.Sprintf("cm_action_jobs.state"),
 	sqlf.Sprintf("cm_action_jobs.failure_message"),
@@ -191,6 +195,8 @@ func scanActionJob(row dbutil.Scanner) (*ActionJob, error) {
 	return aj, row.Scan(
 		&aj.Id,
 		&aj.Email,
+		&aj.Webhook,
+		&aj.SlackWebhook,
 		&aj.TriggerEvent,
 		&aj.State,
 		&aj.FailureMessage,

--- a/enterprise/internal/codemonitors/action_jobs.go
+++ b/enterprise/internal/codemonitors/action_jobs.go
@@ -14,9 +14,9 @@ import (
 
 type ActionJob struct {
 	Id           int
-	Email        *int64
-	Webhook      *int64
-	SlackWebhook *int64
+	Email        *int
+	Webhook      *int
+	SlackWebhook *int
 	TriggerEvent int
 
 	// Fields demanded by any dbworker.
@@ -43,7 +43,9 @@ type ActionJobMetadata struct {
 	Query string
 }
 
-var ActionJobsColumns = []*sqlf.Query{
+// ActionJobColumns is the list of db columns used to populate an ActionJob struct.
+// This must stay in sync with the scanned columns in scanActionJob.
+var ActionJobColumns = []*sqlf.Query{
 	sqlf.Sprintf("cm_action_jobs.id"),
 	sqlf.Sprintf("cm_action_jobs.email"),
 	sqlf.Sprintf("cm_action_jobs.webhook"),
@@ -59,7 +61,64 @@ var ActionJobsColumns = []*sqlf.Query{
 	sqlf.Sprintf("cm_action_jobs.log_contents"),
 }
 
-const readActionEmailEventsFmtStr = `
+// ListActionEventsOpts is a struct that contains options for listing and
+// counting action events.
+type ListActionEventsOpts struct {
+	// TriggerEventID, if set, will filter to only action jobs that were
+	// created in response to the provided trigger event.  Refers to
+	// cm_trigger_jobs(id)
+	TriggerEventID *int
+
+	// EmailID, if set, will filter to only actions jobs that are executing the
+	// given email action. Refers to cm_emails(id)
+	EmailID *int
+
+	// WebhookID, if set, will filter to only actions jobs that are executing
+	// the given webhook action. Refers to cm_webhooks(id)
+	WebhookID *int
+
+	// WebhookID, if set, will filter to only actions jobs that are executing
+	// the given slack webhook action. Refers to cm_slack_webhooks(id)
+	SlackWebhookID *int
+
+	// First, if defined, limits the operation to only the first n results
+	First *int
+
+	// After, if defined, starts after the provided id. Refers to
+	// cm_action_jobs(id)
+	After *int
+}
+
+// Conds generates a set of conditions for a SQL WHERE clause
+func (o ListActionEventsOpts) Conds() *sqlf.Query {
+	var conds []*sqlf.Query
+	if o.TriggerEventID != nil {
+		conds = append(conds, sqlf.Sprintf("trigger_event = %s", *o.TriggerEventID))
+	}
+	if o.EmailID != nil {
+		conds = append(conds, sqlf.Sprintf("email = %s", *o.EmailID))
+	}
+	if o.WebhookID != nil {
+		conds = append(conds, sqlf.Sprintf("webhook = %s", *o.WebhookID))
+	}
+	if o.SlackWebhookID != nil {
+		conds = append(conds, sqlf.Sprintf("slack_webhook = %s", *o.SlackWebhookID))
+	}
+	if o.After != nil {
+		conds = append(conds, sqlf.Sprintf("id > %s", *o.After))
+	}
+	return sqlf.Join(conds, "AND")
+}
+
+// Limit generates an argument for a SQL LIMIT clause
+func (o ListActionEventsOpts) Limit() *sqlf.Query {
+	if o.First == nil {
+		return sqlf.Sprintf("ALL")
+	}
+	return sqlf.Sprintf("%s", *o.First)
+}
+
+const listActionsFmtStr = `
 SELECT %s -- ActionJobsColumns
 FROM cm_action_jobs
 WHERE %s
@@ -68,22 +127,15 @@ ORDER BY id ASC
 LIMIT %s;
 `
 
-func (s *Store) ReadActionEmailEvents(ctx context.Context, emailID int64, triggerEventID *int, args *graphqlbackend.ListEventsArgs) ([]*ActionJob, error) {
-	conditions := []*sqlf.Query{sqlf.Sprintf("email = %s", emailID)}
-	if triggerEventID != nil {
-		conditions = append(conditions, sqlf.Sprintf("trigger_event = %s", *triggerEventID))
-	}
-	after, err := unmarshalAfter(args.After)
-	if err != nil {
-		return nil, err
-	}
+// ListActionJobs lists events from cm_action_jobs using the provided options
+func (s *Store) ListActionJobs(ctx context.Context, opts ListActionEventsOpts) ([]*ActionJob, error) {
 	q := sqlf.Sprintf(
-		readActionEmailEventsFmtStr,
-		sqlf.Join(ActionJobsColumns, ","),
-		sqlf.Join(conditions, "AND"),
-		after,
-		args.First,
+		listActionsFmtStr,
+		sqlf.Join(ActionJobColumns, ","),
+		opts.Conds(),
+		opts.Limit(),
 	)
+
 	rows, err := s.Query(ctx, q)
 	if err != nil {
 		return nil, err
@@ -92,25 +144,48 @@ func (s *Store) ReadActionEmailEvents(ctx context.Context, emailID int64, trigge
 	return scanActionJobs(rows)
 }
 
-const totalActionEmailEventsFmtStr = `
+const countActionsFmtStr = `
 SELECT COUNT(*)
 FROM cm_action_jobs
 WHERE %s
+ORDER BY id ASC
+LIMIT %s
 `
 
-func (s *Store) TotalActionEmailEvents(ctx context.Context, emailID int64, triggerEventID *int) (totalCount int32, err error) {
-	var where *sqlf.Query
-	if triggerEventID == nil {
-		where = sqlf.Sprintf("email = %s", emailID)
-	} else {
-		where = sqlf.Sprintf("email = %s AND trigger_event = %s", emailID, *triggerEventID)
-	}
-	err = s.QueryRow(ctx, sqlf.Sprintf(totalActionEmailEventsFmtStr, where)).Scan(&totalCount)
-	if err != nil {
-		return -1, err
-	}
-	return totalCount, nil
+// CountActionJobs returns a count of the number of action jobs matching the provided list options
+func (s *Store) CountActionJobs(ctx context.Context, opts ListActionEventsOpts) (int, error) {
+	q := sqlf.Sprintf(
+		countActionsFmtStr,
+		opts.Conds(),
+		opts.Limit(),
+	)
+
+	var count int
+	err := s.QueryRow(ctx, q).Scan(&count)
+	return count, err
 }
+
+func (s *Store) ReadActionEmailEvents(ctx context.Context, emailID int64, triggerEventID *int, args *graphqlbackend.ListEventsArgs) ([]*ActionJob, error) {
+	after, err := unmarshalAfter(args.After)
+	if err != nil {
+		return nil, err
+	}
+	return s.ListActionJobs(ctx, ListActionEventsOpts{
+		TriggerEventID: triggerEventID,
+		EmailID:        intPtr(int(emailID)),
+		First:          intPtr(int(args.First)),
+		After:          intPtr(int(after)),
+	})
+}
+
+func (s *Store) TotalActionEmailEvents(ctx context.Context, emailID int64, triggerEventID *int) (int, error) {
+	return s.CountActionJobs(ctx, ListActionEventsOpts{
+		EmailID:        intPtr(int(emailID)),
+		TriggerEventID: triggerEventID,
+	})
+}
+
+func intPtr(i int) *int { return &i }
 
 const enqueueActionEmailFmtStr = `
 WITH due AS (
@@ -159,7 +234,7 @@ WHERE id = %s
 `
 
 func (s *Store) ActionJobForIDInt(ctx context.Context, recordID int) (*ActionJob, error) {
-	q := sqlf.Sprintf(actionJobForIDFmtStr, sqlf.Join(ActionJobsColumns, ", "), recordID)
+	q := sqlf.Sprintf(actionJobForIDFmtStr, sqlf.Join(ActionJobColumns, ", "), recordID)
 	row := s.QueryRow(ctx, q)
 	return scanActionJob(row)
 }

--- a/enterprise/internal/codemonitors/action_jobs.go
+++ b/enterprise/internal/codemonitors/action_jobs.go
@@ -122,7 +122,6 @@ const listActionsFmtStr = `
 SELECT %s -- ActionJobsColumns
 FROM cm_action_jobs
 WHERE %s
-AND id > %s
 ORDER BY id ASC
 LIMIT %s;
 `
@@ -148,7 +147,6 @@ const countActionsFmtStr = `
 SELECT COUNT(*)
 FROM cm_action_jobs
 WHERE %s
-ORDER BY id ASC
 LIMIT %s
 `
 

--- a/enterprise/internal/codemonitors/action_jobs_test.go
+++ b/enterprise/internal/codemonitors/action_jobs_test.go
@@ -37,7 +37,7 @@ func TestEnqueueActionEmailsForQueryIDInt64QueryByRecordID(t *testing.T) {
 
 	want := &ActionJob{
 		Id:             1,
-		Email:          1,
+		Email:          int64Ptr(1),
 		TriggerEvent:   1,
 		State:          "queued",
 		FailureMessage: nil,
@@ -52,6 +52,8 @@ func TestEnqueueActionEmailsForQueryIDInt64QueryByRecordID(t *testing.T) {
 		t.Fatalf("diff: %s", diff)
 	}
 }
+
+func int64Ptr(i int64) *int64 { return &i }
 
 func TestGetActionJobMetadata(t *testing.T) {
 	if testing.Short() {

--- a/enterprise/internal/codemonitors/action_jobs_test.go
+++ b/enterprise/internal/codemonitors/action_jobs_test.go
@@ -37,7 +37,7 @@ func TestEnqueueActionEmailsForQueryIDInt64QueryByRecordID(t *testing.T) {
 
 	want := &ActionJob{
 		Id:             1,
-		Email:          int64Ptr(1),
+		Email:          intPtr(1),
 		TriggerEvent:   1,
 		State:          "queued",
 		FailureMessage: nil,
@@ -52,8 +52,6 @@ func TestEnqueueActionEmailsForQueryIDInt64QueryByRecordID(t *testing.T) {
 		t.Fatalf("diff: %s", diff)
 	}
 }
-
-func int64Ptr(i int64) *int64 { return &i }
 
 func TestGetActionJobMetadata(t *testing.T) {
 	if testing.Short() {
@@ -126,7 +124,7 @@ func TestScanActionJobs(t *testing.T) {
 		t.Fatal(err)
 	}
 	var rows *sql.Rows
-	rows, err = s.Query(ctx, sqlf.Sprintf(actionJobForIDFmtStr, sqlf.Join(ActionJobsColumns, ", "), testRecordID))
+	rows, err = s.Query(ctx, sqlf.Sprintf(actionJobForIDFmtStr, sqlf.Join(ActionJobColumns, ", "), testRecordID))
 	record, _, err := ScanActionJobRecord(rows, err)
 	if err != nil {
 		t.Fatal(err)

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -121,7 +121,7 @@ func createDBWorkerStoreForActionJobs(s *cm.Store) dbworkerstore.Store {
 	return dbworkerstore.New(s.Handle(), dbworkerstore.Options{
 		Name:              "code_monitors_action_jobs_worker_store",
 		TableName:         "cm_action_jobs",
-		ColumnExpressions: cm.ActionJobsColumns,
+		ColumnExpressions: cm.ActionJobColumns,
 		Scan:              cm.ScanActionJobRecord,
 		StalledMaxAge:     60 * time.Second,
 		RetryAfter:        10 * time.Second,
@@ -202,36 +202,27 @@ func (r *actionRunner) Handle(ctx context.Context, record workerutil.Record) (er
 	}
 	defer func() { err = s.Done(err) }()
 
-	var (
-		j    *cm.ActionJob
-		m    *cm.ActionJobMetadata
-		e    *cm.MonitorEmail
-		recs []*cm.Recipient
-		data *email.TemplateDataNewSearchResults
-	)
-
-	var ok bool
-	j, ok = record.(*cm.ActionJob)
+	j, ok := record.(*cm.ActionJob)
 	if !ok {
 		return errors.Errorf("type assertion failed")
 	}
 
-	m, err = s.GetActionJobMetadata(ctx, record.RecordID())
+	m, err := s.GetActionJobMetadata(ctx, record.RecordID())
 	if err != nil {
 		return errors.Errorf("store.GetActionJobMetadata: %w", err)
 	}
 
-	e, err = s.ActionEmailByIDInt64(ctx, j.Email)
+	e, err := s.ActionEmailByIDInt64(ctx, j.Email)
 	if err != nil {
 		return errors.Errorf("store.ActionEmailByIDInt64: %w", err)
 	}
 
-	recs, err = s.AllRecipientsForEmailIDInt64(ctx, j.Email)
+	recs, err := s.AllRecipientsForEmailIDInt64(ctx, j.Email)
 	if err != nil {
 		return errors.Errorf("store.AllRecipientsForEmailIDInt64: %w", err)
 	}
 
-	data, err = email.NewTemplateDataForNewSearchResults(ctx, m.Description, m.Query, e, zeroOrVal(m.NumResults))
+	data, err := email.NewTemplateDataForNewSearchResults(ctx, m.Description, m.Query, e, zeroOrVal(m.NumResults))
 	if err != nil {
 		return errors.Errorf("email.NewTemplateDataForNewSearchResults: %w", err)
 	}


### PR DESCRIPTION
In #27474, I updated the database schema to add `webhook` and `slack_webhook`
columns and tables to  code monitors. In this PR, I update the store to be aware of those
types, and add `ListActionJobs` and `CountActionJobs` methods that handle listing
and counting for more than just emails. 

Stacked on #27475 
