### PR TITLE
sg: use commit date in 'sg live' output

### DIFF
--- a/dev/sg/live.go
+++ b/dev/sg/live.go
@@ -83,7 +83,7 @@ func printDeployedVersion(e environment) error {
 	}
 	pending.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Done updating list of commits"))
 
-	log, err := run.GitCmd("log", "--oneline", "-n", "20", `--pretty=format:%h|%ar|%an|%s`, "origin/main")
+	log, err := run.GitCmd("log", "--oneline", "-n", "20", `--pretty=format:%h|%cr|%an|%s`, "origin/main")
 	if err != nil {
 		pending.Complete(output.Linef(output.EmojiFailure, output.StyleWarning, "Failed: %s", err))
 		return err


### PR DESCRIPTION
Previously:
![previous_git_commit_date](https://user-images.githubusercontent.com/1185253/141448841-e1594208-b6cc-468f-b5d2-d84cf90475b9.png)


After:
![after_commit_date](https://user-images.githubusercontent.com/1185253/141448854-e123d37a-f7f8-4ad0-9213-dec4df29eed1.png)


