### PR TITLE
Fix OpenSearch for enterprise mode

### DIFF
--- a/cmd/frontend/auth/non_public.go
+++ b/cmd/frontend/auth/non_public.go
@@ -60,6 +60,7 @@ var (
 	// data or allow unprivileged users to perform undesired actions.
 	anonymousAccessibleAPIRoutes = map[string]struct{}{
 		router.RobotsTxt:          {},
+		router.OpenSearch:         {},
 		router.SitemapXmlGz:       {},
 		router.Favicon:            {},
 		router.Logout:             {},


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/5627.

### Description
OpenSearch didn't work for non-dotcom/cloud mode, because the endpoint was private.

### How to test
1. `sg start enterprise`
2. Try to add a search engine for the local Sourcegraph instance. See the issue described above.
