### PR TITLE
executor: Add telemetry info to dequeue request payload

### DIFF
--- a/enterprise/cmd/executor/config.go
+++ b/enterprise/cmd/executor/config.go
@@ -63,7 +63,7 @@ func (c *Config) Validate() error {
 	return c.BaseConfig.Validate()
 }
 
-func (c *Config) APIWorkerOptions() apiworker.Options {
+func (c *Config) APIWorkerOptions(telemetryOptions apiclient.TelemetryOptions) apiworker.Options {
 	return apiworker.Options{
 		VMPrefix:             c.VMPrefix,
 		QueueName:            c.QueueName,
@@ -72,7 +72,7 @@ func (c *Config) APIWorkerOptions() apiworker.Options {
 		ResourceOptions:      c.ResourceOptions(),
 		MaximumRuntimePerJob: c.MaximumRuntimePerJob,
 		GitServicePath:       "/.executors/git",
-		ClientOptions:        c.ClientOptions(),
+		ClientOptions:        c.ClientOptions(telemetryOptions),
 		RedactedValues: map[string]string{
 			// 🚨 SECURITY: Catch uses of the shared frontend token used to clone
 			// git repositories that make it into commands or stdout/stderr streams.
@@ -109,7 +109,7 @@ func (c *Config) ResourceOptions() command.ResourceOptions {
 	}
 }
 
-func (c *Config) ClientOptions() apiclient.Options {
+func (c *Config) ClientOptions(telemetryOptions apiclient.TelemetryOptions) apiclient.Options {
 	hn := hostname.Get()
 
 	return apiclient.Options{
@@ -119,6 +119,7 @@ func (c *Config) ClientOptions() apiclient.Options {
 		PathPrefix:        "/.executors/queue",
 		EndpointOptions:   c.EndpointOptions(),
 		BaseClientOptions: c.BaseClientOptions(),
+		TelemetryOptions:  telemetryOptions,
 	}
 }
 

--- a/enterprise/cmd/executor/internal/apiclient/client.go
+++ b/enterprise/cmd/executor/internal/apiclient/client.go
@@ -210,13 +210,13 @@ func (c *Client) Heartbeat(ctx context.Context, queueName string, jobIDs []int) 
 		ExecutorName: c.options.ExecutorName,
 		JobIDs:       jobIDs,
 
-		OS:            c.options.TelemetryOptions.OS,
-		Architecture:  c.options.TelemetryOptions.Arch,
-		Version:       c.options.TelemetryOptions.Version,
-		SrcCliVersion: c.options.TelemetryOptions.SrcCliVersion,
-		DockerVersion: c.options.TelemetryOptions.DockerVersion,
-		IgniteVersion: c.options.TelemetryOptions.IgniteVersion,
-		GitVersion:    c.options.TelemetryOptions.GitVersion,
+		OS:              c.options.TelemetryOptions.OS,
+		Architecture:    c.options.TelemetryOptions.Architecture,
+		ExecutorVersion: c.options.TelemetryOptions.ExecutorVersion,
+		SrcCliVersion:   c.options.TelemetryOptions.SrcCliVersion,
+		DockerVersion:   c.options.TelemetryOptions.DockerVersion,
+		IgniteVersion:   c.options.TelemetryOptions.IgniteVersion,
+		GitVersion:      c.options.TelemetryOptions.GitVersion,
 	})
 	if err != nil {
 		return nil, err

--- a/enterprise/cmd/executor/internal/apiclient/client_test.go
+++ b/enterprise/cmd/executor/internal/apiclient/client_test.go
@@ -348,7 +348,7 @@ func TestHeartbeat(t *testing.T) {
 		expectedPath:     "/.executors/queue/test_queue/heartbeat",
 		expectedUsername: "test",
 		expectedPassword: "hunter2",
-		expectedPayload:  `{"executorName": "deadbeef", "jobIds": [1, 2, 3]}`,
+		expectedPayload:  `{"architecture":"","dockerVersion":"","executorName":"deadbeef","executorVersion":"","gitVersion":"","igniteVersion":"","jobIds":[1,2,3],"os":"","srcCliVersion":""}`,
 		responseStatus:   http.StatusOK,
 		responsePayload:  `[1]`,
 	}
@@ -371,7 +371,7 @@ func TestHeartbeatBadResponse(t *testing.T) {
 		expectedPath:     "/.executors/queue/test_queue/heartbeat",
 		expectedUsername: "test",
 		expectedPassword: "hunter2",
-		expectedPayload:  `{"executorName": "deadbeef", "jobIds": [1, 2, 3]}`,
+		expectedPayload:  `{"architecture":"","dockerVersion":"","executorName":"deadbeef","executorVersion":"","gitVersion":"","igniteVersion":"","jobIds":[1,2,3],"os":"","srcCliVersion":""}`,
 		responseStatus:   http.StatusInternalServerError,
 		responsePayload:  ``,
 	}

--- a/enterprise/cmd/executor/internal/apiclient/telemetry.go
+++ b/enterprise/cmd/executor/internal/apiclient/telemetry.go
@@ -1,0 +1,90 @@
+package apiclient
+
+import (
+	"context"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"github.com/inconshreveable/log15"
+
+	"github.com/sourcegraph/sourcegraph/internal/version"
+)
+
+type telemetryOptions struct {
+	os            string
+	arch          string
+	version       string
+	srcCliVersion string
+	dockerVersion string
+	igniteVersion string
+	gitVersion    string
+}
+
+func newTelemetryOptions(ctx context.Context) telemetryOptions {
+	t := telemetryOptions{
+		os:      runtime.GOOS,
+		arch:    runtime.GOARCH,
+		version: version.Version(),
+	}
+
+	var err error
+
+	t.gitVersion, err = getGitVersion(ctx)
+	if err != nil {
+		log15.Error("Failed to get git version", "err", err)
+	}
+
+	t.srcCliVersion, err = getSrcVersion(ctx)
+	if err != nil {
+		log15.Error("Failed to get src-cli version", "err", err)
+	}
+
+	t.dockerVersion, err = getDockerVersion(ctx)
+	if err != nil {
+		log15.Error("Failed to get docker version", "err", err)
+	}
+
+	t.igniteVersion, err = getIgniteVersion(ctx)
+	if err != nil {
+		log15.Error("Failed to get ignite version", "err", err)
+	}
+
+	return t
+}
+
+func getGitVersion(ctx context.Context) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "version")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimPrefix(strings.TrimSpace(string(out)), "git version "), nil
+}
+
+func getSrcVersion(ctx context.Context) (string, error) {
+	cmd := exec.CommandContext(ctx, "src", "version", "-client-only")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimPrefix(strings.TrimSpace(string(out)), "Current version: "), nil
+}
+
+func getDockerVersion(ctx context.Context) (string, error) {
+	cmd := exec.CommandContext(ctx, "docker", "version", "-f", "{{.Server.Version}}")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func getIgniteVersion(ctx context.Context) (string, error) {
+	cmd := exec.CommandContext(ctx, "ignite", "version", "-o", "short")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/enterprise/cmd/executor/internal/apiclient/telemetry.go
+++ b/enterprise/cmd/executor/internal/apiclient/telemetry.go
@@ -12,20 +12,20 @@ import (
 )
 
 type TelemetryOptions struct {
-	OS            string
-	Arch          string
-	Version       string
-	SrcCliVersion string
-	DockerVersion string
-	IgniteVersion string
-	GitVersion    string
+	OS              string
+	Architecture    string
+	ExecutorVersion string
+	SrcCliVersion   string
+	DockerVersion   string
+	IgniteVersion   string
+	GitVersion      string
 }
 
 func NewTelemetryOptions(ctx context.Context) TelemetryOptions {
 	t := TelemetryOptions{
-		OS:      runtime.GOOS,
-		Arch:    runtime.GOARCH,
-		Version: version.Version(),
+		OS:              runtime.GOOS,
+		Architecture:    runtime.GOARCH,
+		ExecutorVersion: version.Version(),
 	}
 
 	var err error

--- a/enterprise/cmd/executor/internal/apiclient/telemetry.go
+++ b/enterprise/cmd/executor/internal/apiclient/telemetry.go
@@ -11,41 +11,41 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/version"
 )
 
-type telemetryOptions struct {
-	os            string
-	arch          string
-	version       string
-	srcCliVersion string
-	dockerVersion string
-	igniteVersion string
-	gitVersion    string
+type TelemetryOptions struct {
+	OS            string
+	Arch          string
+	Version       string
+	SrcCliVersion string
+	DockerVersion string
+	IgniteVersion string
+	GitVersion    string
 }
 
-func newTelemetryOptions(ctx context.Context) telemetryOptions {
-	t := telemetryOptions{
-		os:      runtime.GOOS,
-		arch:    runtime.GOARCH,
-		version: version.Version(),
+func NewTelemetryOptions(ctx context.Context) TelemetryOptions {
+	t := TelemetryOptions{
+		OS:      runtime.GOOS,
+		Arch:    runtime.GOARCH,
+		Version: version.Version(),
 	}
 
 	var err error
 
-	t.gitVersion, err = getGitVersion(ctx)
+	t.GitVersion, err = getGitVersion(ctx)
 	if err != nil {
 		log15.Error("Failed to get git version", "err", err)
 	}
 
-	t.srcCliVersion, err = getSrcVersion(ctx)
+	t.SrcCliVersion, err = getSrcVersion(ctx)
 	if err != nil {
 		log15.Error("Failed to get src-cli version", "err", err)
 	}
 
-	t.dockerVersion, err = getDockerVersion(ctx)
+	t.DockerVersion, err = getDockerVersion(ctx)
 	if err != nil {
 		log15.Error("Failed to get docker version", "err", err)
 	}
 
-	t.igniteVersion, err = getIgniteVersion(ctx)
+	t.IgniteVersion, err = getIgniteVersion(ctx)
 	if err != nil {
 		log15.Error("Failed to get ignite version", "err", err)
 	}

--- a/enterprise/internal/executor/client_types.go
+++ b/enterprise/internal/executor/client_types.go
@@ -66,13 +66,6 @@ type CliStep struct {
 }
 
 type DequeueRequest struct {
-	OS               string `json:"os"`
-	Architecture     string `json:"architecture"`
-	SrcCLIVersion    string `json:"srcCLIVersion"`
-	GitVersion       string `json:"gitVersion"`
-	DockerVersion    string `json:"dockerVersion"`
-	IgniteVersion    string `json:"igniteVersion"`
-	Version          string `json:"version"`
 	ExecutorName     string `json:"executorName"`
 	ExecutorHostname string `json:"executorHostname"`
 }
@@ -104,6 +97,16 @@ type MarkErroredRequest struct {
 type HeartbeatRequest struct {
 	ExecutorName string `json:"executorName"`
 	JobIDs       []int  `json:"jobIds"`
+
+	// Telemetry data.
+
+	OS            string `json:"os"`
+	Architecture  string `json:"architecture"`
+	SrcCliVersion string `json:"srcCliVersion"`
+	GitVersion    string `json:"gitVersion"`
+	DockerVersion string `json:"dockerVersion"`
+	IgniteVersion string `json:"igniteVersion"`
+	Version       string `json:"version"`
 }
 
 type CanceledRequest struct {

--- a/enterprise/internal/executor/client_types.go
+++ b/enterprise/internal/executor/client_types.go
@@ -66,6 +66,13 @@ type CliStep struct {
 }
 
 type DequeueRequest struct {
+	OS               string `json:"os"`
+	Architecture     string `json:"architecture"`
+	SrcCLIVersion    string `json:"srcCLIVersion"`
+	GitVersion       string `json:"gitVersion"`
+	DockerVersion    string `json:"dockerVersion"`
+	IgniteVersion    string `json:"igniteVersion"`
+	Version          string `json:"version"`
 	ExecutorName     string `json:"executorName"`
 	ExecutorHostname string `json:"executorHostname"`
 }

--- a/enterprise/internal/executor/client_types.go
+++ b/enterprise/internal/executor/client_types.go
@@ -100,13 +100,13 @@ type HeartbeatRequest struct {
 
 	// Telemetry data.
 
-	OS            string `json:"os"`
-	Architecture  string `json:"architecture"`
-	SrcCliVersion string `json:"srcCliVersion"`
-	GitVersion    string `json:"gitVersion"`
-	DockerVersion string `json:"dockerVersion"`
-	IgniteVersion string `json:"igniteVersion"`
-	Version       string `json:"version"`
+	OS              string `json:"os"`
+	Architecture    string `json:"architecture"`
+	SrcCliVersion   string `json:"srcCliVersion"`
+	GitVersion      string `json:"gitVersion"`
+	DockerVersion   string `json:"dockerVersion"`
+	IgniteVersion   string `json:"igniteVersion"`
+	ExecutorVersion string `json:"executorVersion"`
 }
 
 type CanceledRequest struct {

--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.33.6"
+const MinimumVersion = "3.33.7"


### PR DESCRIPTION
Requires https://github.com/sourcegraph/src-cli/pull/655.

This PR adds telemetry information to be displayed next to the executor hostname. This is supposed to help with issues/support requests.