### PR TITLE
graphqlutil: Move some useful helper functions into util package

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlutil/cursors.go
+++ b/cmd/frontend/graphqlbackend/graphqlutil/cursors.go
@@ -1,27 +1,25 @@
-package graphql
+package graphqlutil
 
 import (
 	"encoding/base64"
 	"strconv"
-
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 )
 
-// encodeCursor creates a PageInfo object from the given cursor. If the cursor is not
+// EncodeCursor creates a PageInfo object from the given cursor. If the cursor is not
 // defined, then an object indicating the end of the result set is returned. The cursor
 // is base64 encoded for transfer, and should be decoded using the function decodeCursor.
-func encodeCursor(val *string) *graphqlutil.PageInfo {
+func EncodeCursor(val *string) *PageInfo {
 	if val != nil {
-		return graphqlutil.NextPageCursor(base64.StdEncoding.EncodeToString([]byte(*val)))
+		return NextPageCursor(base64.StdEncoding.EncodeToString([]byte(*val)))
 	}
 
-	return graphqlutil.HasNextPage(false)
+	return HasNextPage(false)
 }
 
-// decodeCursor decodes the given cursor value. It is assumed to be a value previously
+// DecodeCursor decodes the given cursor value. It is assumed to be a value previously
 // returned from the function encodeCursor. An empty string is returned if no cursor is
 // supplied. Invalid cursors return errors.
-func decodeCursor(val *string) (string, error) {
+func DecodeCursor(val *string) (string, error) {
 	if val == nil {
 		return "", nil
 	}
@@ -34,24 +32,24 @@ func decodeCursor(val *string) (string, error) {
 	return string(decoded), nil
 }
 
-// encodeIntCursor creates a PageInfo object from the given new offset value. If the
+// EncodeIntCursor creates a PageInfo object from the given new offset value. If the
 // new offset value, then an object indicating the end of the result set is returned.
 // The cursor is base64 encoded for transfer, and should be decoded using the function
 // decodeIntCursor.
-func encodeIntCursor(val *int32) *graphqlutil.PageInfo {
+func EncodeIntCursor(val *int32) *PageInfo {
 	if val == nil {
-		return encodeCursor(nil)
+		return EncodeCursor(nil)
 	}
 
 	str := strconv.FormatInt(int64(*val), 10)
-	return encodeCursor(&str)
+	return EncodeCursor(&str)
 }
 
-// decodeIntCursor decodes the given integer cursor value. It is assumed to be a value
+// DecodeIntCursor decodes the given integer cursor value. It is assumed to be a value
 // previously returned from the function encodeIntCursor. The zero value is returned if
 // no cursor is supplied. Invalid cursors return errors.
-func decodeIntCursor(val *string) (int, error) {
-	cursor, err := decodeCursor(val)
+func DecodeIntCursor(val *string) (int, error) {
+	cursor, err := DecodeCursor(val)
 	if err != nil || cursor == "" {
 		return 0, err
 	}

--- a/cmd/frontend/graphqlbackend/graphqlutil/offset.go
+++ b/cmd/frontend/graphqlbackend/graphqlutil/offset.go
@@ -1,8 +1,8 @@
-package resolvers
+package graphqlutil
 
-// nextOffset determines the offset that should be used for a subsequent request.
+// NextOffset determines the offset that should be used for a subsequent request.
 // If there are no more results in the paged result set, this function returns nil.
-func nextOffset(offset, count, totalCount int) *int {
+func NextOffset(offset, count, totalCount int) *int {
 	if offset+count < totalCount {
 		val := offset + count
 		return &val

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/cursors_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/cursors_test.go
@@ -1,10 +1,14 @@
 package graphql
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+)
 
 func TestCursor(t *testing.T) {
 	expected := "test"
-	pageInfo := encodeCursor(&expected)
+	pageInfo := graphqlutil.EncodeCursor(&expected)
 
 	if !pageInfo.HasNextPage() {
 		t.Fatalf("expected next page")
@@ -13,7 +17,7 @@ func TestCursor(t *testing.T) {
 		t.Fatalf("unexpected nil cursor")
 	}
 
-	value, err := decodeCursor(pageInfo.EndCursor())
+	value, err := graphqlutil.DecodeCursor(pageInfo.EndCursor())
 	if err != nil {
 		t.Fatalf("unexpected error decoding cursor: %s", err)
 	}
@@ -23,7 +27,7 @@ func TestCursor(t *testing.T) {
 }
 
 func TestCursorEmpty(t *testing.T) {
-	pageInfo := encodeCursor(nil)
+	pageInfo := graphqlutil.EncodeCursor(nil)
 
 	if pageInfo.HasNextPage() {
 		t.Errorf("unexpected next page")
@@ -32,7 +36,7 @@ func TestCursorEmpty(t *testing.T) {
 		t.Errorf("unexpected encoded cursor: %s", *pageInfo.EndCursor())
 	}
 
-	value, err := decodeCursor(nil)
+	value, err := graphqlutil.DecodeCursor(nil)
 	if err != nil {
 		t.Fatalf("unexpected error decoding cursor: %s", err)
 	}
@@ -43,7 +47,7 @@ func TestCursorEmpty(t *testing.T) {
 
 func TestIntCursor(t *testing.T) {
 	expected := 42
-	pageInfo := encodeIntCursor(toInt32(&expected))
+	pageInfo := graphqlutil.EncodeIntCursor(toInt32(&expected))
 
 	if !pageInfo.HasNextPage() {
 		t.Fatalf("expected next page")
@@ -52,7 +56,7 @@ func TestIntCursor(t *testing.T) {
 		t.Fatalf("unexpected nil cursor")
 	}
 
-	value, err := decodeIntCursor(pageInfo.EndCursor())
+	value, err := graphqlutil.DecodeIntCursor(pageInfo.EndCursor())
 	if err != nil {
 		t.Fatalf("unexpected error decoding cursor: %s", err)
 	}
@@ -62,7 +66,7 @@ func TestIntCursor(t *testing.T) {
 }
 
 func TestIntCursorEmpty(t *testing.T) {
-	pageInfo := encodeIntCursor(nil)
+	pageInfo := graphqlutil.EncodeIntCursor(nil)
 
 	if pageInfo.HasNextPage() {
 		t.Errorf("unexpected next page")
@@ -71,7 +75,7 @@ func TestIntCursorEmpty(t *testing.T) {
 		t.Errorf("unexpected encoded cursor: %s", *pageInfo.EndCursor())
 	}
 
-	value, err := decodeIntCursor(nil)
+	value, err := graphqlutil.DecodeIntCursor(nil)
 	if err != nil {
 		t.Fatalf("unexpected error decoding cursor: %s", err)
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index_connection.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index_connection.go
@@ -47,5 +47,5 @@ func (r *IndexConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.Pa
 	if err := r.indexesResolver.Resolve(ctx); err != nil {
 		return nil, err
 	}
-	return encodeIntCursor(toInt32(r.indexesResolver.NextOffset)), nil
+	return graphqlutil.EncodeIntCursor(toInt32(r.indexesResolver.NextOffset)), nil
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/location_connection.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/location_connection.go
@@ -27,5 +27,5 @@ func (r *LocationConnectionResolver) Nodes(ctx context.Context) ([]gql.LocationR
 }
 
 func (r *LocationConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
-	return encodeCursor(r.cursor), nil
+	return graphqlutil.EncodeCursor(r.cursor), nil
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cockroachdb/errors"
 
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers"
 )
 
@@ -90,7 +91,7 @@ func (r *QueryResolver) References(ctx context.Context, args *gql.LSIFPagedQuery
 	if limit <= 0 {
 		return nil, ErrIllegalLimit
 	}
-	cursor, err := decodeCursor(args.After)
+	cursor, err := graphqlutil.DecodeCursor(args.After)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +109,7 @@ func (r *QueryResolver) Implementations(ctx context.Context, args *gql.LSIFPaged
 	if limit <= 0 {
 		return nil, ErrIllegalLimit
 	}
-	cursor, err := decodeCursor(args.After)
+	cursor, err := graphqlutil.DecodeCursor(args.After)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query_documentation.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query_documentation.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cockroachdb/errors"
 
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 )
 
 func (r *QueryResolver) DocumentationPage(ctx context.Context, args *gql.LSIFDocumentationPageArgs) (gql.DocumentationPageResolver, error) {
@@ -120,7 +121,7 @@ func (r *QueryResolver) DocumentationReferences(ctx context.Context, args *gql.L
 	if limit <= 0 {
 		return nil, ErrIllegalLimit
 	}
-	cursor, err := decodeCursor(args.After)
+	cursor, err := graphqlutil.DecodeCursor(args.After)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -489,7 +490,7 @@ func makeGetUploadsOptions(ctx context.Context, args *gql.LSIFRepositoryUploadsQ
 		}
 	}
 
-	offset, err := decodeIntCursor(args.After)
+	offset, err := graphqlutil.DecodeIntCursor(args.After)
 	if err != nil {
 		return store.GetUploadsOptions{}, err
 	}
@@ -515,7 +516,7 @@ func makeGetIndexesOptions(ctx context.Context, args *gql.LSIFRepositoryIndexesQ
 		return store.GetIndexesOptions{}, err
 	}
 
-	offset, err := decodeIntCursor(args.After)
+	offset, err := graphqlutil.DecodeIntCursor(args.After)
 	if err != nil {
 		return store.GetIndexesOptions{}, err
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver_test.go
@@ -114,7 +114,7 @@ func TestMakeGetUploadsOptions(t *testing.T) {
 			Query:           strPtr("q"),
 			State:           strPtr("s"),
 			IsLatestForRepo: boolPtr(true),
-			After:           encodeIntCursor(intPtr(25)).EndCursor(),
+			After:           graphqlutil.EncodeIntCursor(intPtr(25)).EndCursor(),
 		},
 		RepositoryID: graphql.ID(base64.StdEncoding.EncodeToString([]byte("Repo:50"))),
 	})
@@ -176,7 +176,7 @@ func TestMakeGetIndexesOptions(t *testing.T) {
 			},
 			Query: strPtr("q"),
 			State: strPtr("s"),
-			After: encodeIntCursor(intPtr(25)).EndCursor(),
+			After: graphqlutil.EncodeIntCursor(intPtr(25)).EndCursor(),
 		},
 		RepositoryID: graphql.ID(base64.StdEncoding.EncodeToString([]byte("Repo:50"))),
 	})

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/upload_connection.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/upload_connection.go
@@ -47,5 +47,5 @@ func (r *UploadConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.P
 	if err := r.uploadsResolver.Resolve(ctx); err != nil {
 		return nil, err
 	}
-	return encodeIntCursor(toInt32(r.uploadsResolver.NextOffset)), nil
+	return graphqlutil.EncodeIntCursor(toInt32(r.uploadsResolver.NextOffset)), nil
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/indexes.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/indexes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 )
 
@@ -41,7 +42,7 @@ func (r *IndexesResolver) resolve(ctx context.Context) error {
 	}
 
 	r.Indexes = indexes
-	r.NextOffset = nextOffset(r.opts.Offset, len(indexes), totalCount)
+	r.NextOffset = graphqlutil.NextOffset(r.opts.Offset, len(indexes), totalCount)
 	r.TotalCount = totalCount
 	return nil
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/uploads.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/uploads.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 )
 
@@ -41,7 +42,7 @@ func (r *UploadsResolver) resolve(ctx context.Context) error {
 	}
 
 	r.Uploads = uploads
-	r.NextOffset = nextOffset(r.opts.Offset, len(uploads), totalCount)
+	r.NextOffset = graphqlutil.NextOffset(r.opts.Offset, len(uploads), totalCount)
 	r.TotalCount = totalCount
 	return nil
 }


### PR DESCRIPTION
This PR moves some codeintel-defined utility functions into a shared (existing) graphqlutil package. This will help reduce some duplicated code in https://github.com/sourcegraph/sourcegraph/pull/27472 and https://github.com/sourcegraph/sourcegraph/pull/27395.