### PR TITLE
eventLogger: use anonymous user ID value for device ID

### DIFF
--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -202,7 +202,8 @@ export class EventLogger implements TelemetryService {
 
         let deviceID = cookies.get(DEVICE_ID_KEY)
         if (!deviceID) {
-            deviceID = uuid.v4()
+            // If device ID does not exist, use the anonymous user ID value so these are consolidated.
+            deviceID = anonymousUserID
             cookies.set(DEVICE_ID_KEY, deviceID, this.cookieSettings)
         }
 


### PR DESCRIPTION
Instead of generating a new UUID for device ID, we want to use the anonymous user ID value already generated. These two values serve the same purpose, but we have some users that have both deviceIDs and anonymous user IDs, while many in the past only have anonymous user IDs. Therefore, we need to maintain both the device ID and anonymous user ID fields. This allows us to properly count users in Amplitude.

This will help us 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
