### PR TITLE
Code Insights: Implement GQL update dashboard method

### DIFF
--- a/client/web/src/enterprise/insights/core/backend/code-insights-backend-context.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-backend-context.ts
@@ -25,6 +25,7 @@ export class FakeDefaultCodeInsightsBackend implements CodeInsightsBackend {
     // Dashboards
     public getDashboards = errorMockMethod('getDashboards')
     public getDashboardById = errorMockMethod('getDashboardById')
+    public getDashboardSubjects = errorMockMethod('getDashboardSubjects')
     public findDashboardByName = errorMockMethod('findDashboardByName')
     public createDashboard = errorMockMethod('createDashboard')
     public deleteDashboard = errorMockMethod('deleteDashboard')

--- a/client/web/src/enterprise/insights/core/backend/code-insights-backend-types.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-backend-types.ts
@@ -11,13 +11,16 @@ export interface DashboardCreateInput {
     visibility: string
     insightIds?: string[]
     type?: string
-    userIds?: string[]
 }
 
 export interface DashboardUpdateInput {
     previousDashboard: CustomInsightDashboard
     nextDashboardInput: DashboardCreateInput
     id?: string
+}
+
+export interface DashboardUpdateResult {
+    id: string
 }
 
 export interface DashboardDeleteInput {

--- a/client/web/src/enterprise/insights/core/backend/code-insights-backend-types.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-backend-types.ts
@@ -13,6 +13,10 @@ export interface DashboardCreateInput {
     type?: string
 }
 
+export interface DashboardCreateResult {
+    id: string
+}
+
 export interface DashboardUpdateInput {
     previousDashboard: CustomInsightDashboard
     nextDashboardInput: DashboardCreateInput

--- a/client/web/src/enterprise/insights/core/backend/code-insights-backend-types.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-backend-types.ts
@@ -3,7 +3,7 @@ import { LineChartContent } from 'sourcegraph'
 
 import { ViewContexts } from '@sourcegraph/shared/src/api/extension/extensionHostApi'
 
-import { ExtensionInsight, Insight, InsightDashboard, SettingsBasedInsightDashboard } from '../types'
+import { ExtensionInsight, Insight, InsightDashboard, CustomInsightDashboard } from '../types'
 import { SearchBasedBackendFilters, SearchBasedInsightSeries } from '../types/insight/search-insight'
 
 export interface DashboardCreateInput {
@@ -15,7 +15,7 @@ export interface DashboardCreateInput {
 }
 
 export interface DashboardUpdateInput {
-    previousDashboard: SettingsBasedInsightDashboard
+    previousDashboard: CustomInsightDashboard
     nextDashboardInput: DashboardCreateInput
     id?: string
 }

--- a/client/web/src/enterprise/insights/core/backend/code-insights-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-backend.ts
@@ -10,6 +10,7 @@ import { SupportedInsightSubject } from '../types/subjects'
 import {
     BackendInsightData,
     DashboardCreateInput,
+    DashboardCreateResult,
     DashboardDeleteInput,
     DashboardUpdateInput,
     DashboardUpdateResult,
@@ -41,7 +42,7 @@ export interface CodeInsightsBackend {
 
     findDashboardByName: (name: string) => Observable<InsightDashboard | null>
 
-    createDashboard: (input: DashboardCreateInput) => Observable<void>
+    createDashboard: (input: DashboardCreateInput) => Observable<DashboardCreateResult>
 
     updateDashboard: (input: DashboardUpdateInput) => Observable<DashboardUpdateResult>
 

--- a/client/web/src/enterprise/insights/core/backend/code-insights-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-backend.ts
@@ -34,7 +34,7 @@ export interface CodeInsightsBackend {
      */
     getDashboards: () => Observable<InsightDashboard[]>
 
-    getDashboardById: (dashboardId?: string) => Observable<InsightDashboard | undefined>
+    getDashboardById: (dashboardId?: string) => Observable<InsightDashboard | null>
 
     findDashboardByName: (name: string) => Observable<InsightDashboard | null>
 

--- a/client/web/src/enterprise/insights/core/backend/code-insights-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-backend.ts
@@ -37,6 +37,8 @@ export interface CodeInsightsBackend {
 
     getDashboardById: (dashboardId?: string) => Observable<InsightDashboard | null>
 
+    getDashboardSubjects: () => Observable<SupportedInsightSubject[]>
+
     findDashboardByName: (name: string) => Observable<InsightDashboard | null>
 
     createDashboard: (input: DashboardCreateInput) => Observable<void>

--- a/client/web/src/enterprise/insights/core/backend/code-insights-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-backend.ts
@@ -12,6 +12,7 @@ import {
     DashboardCreateInput,
     DashboardDeleteInput,
     DashboardUpdateInput,
+    DashboardUpdateResult,
     FindInsightByNameInput,
     GetBuiltInsightInput,
     GetLangStatsInsightContentInput,
@@ -40,7 +41,7 @@ export interface CodeInsightsBackend {
 
     createDashboard: (input: DashboardCreateInput) => Observable<void>
 
-    updateDashboard: (input: DashboardUpdateInput) => Observable<void>
+    updateDashboard: (input: DashboardUpdateInput) => Observable<DashboardUpdateResult>
 
     deleteDashboard: (input: DashboardDeleteInput) => Observable<void>
 

--- a/client/web/src/enterprise/insights/core/backend/code-insights-gql-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-gql-backend.ts
@@ -175,20 +175,7 @@ export class CodeInsightsGqlBackend implements CodeInsightsBackend {
 
     // We don't have insight visibility and subject levels in the new GQL API anymore.
     // it was part of setting-cascade based API.
-    public getInsightSubjects = (): Observable<SupportedInsightSubject[]> =>
-        from(
-            this.apolloClient.query<InsightSubjectsResult>({ query: GET_INSIGHTS_SUBJECTS_GQL })
-        ).pipe(
-            map(({ data }) => {
-                const { currentUser, site } = data
-
-                if (!currentUser) {
-                    return []
-                }
-
-                return [{ ...currentUser }, ...currentUser.organizations.nodes, site]
-            })
-        )
+    public getInsightSubjects = (): Observable<SupportedInsightSubject[]> => of([])
 
     public createInsight = (input: InsightCreateInput): Observable<unknown> => {
         const { insight, dashboard } = input
@@ -301,6 +288,21 @@ export class CodeInsightsGqlBackend implements CodeInsightsBackend {
     // This is only used to check for duplicate dashboards. Thi is not required for the new GQL API.
     // So we just return null to get the form to always accept.
     public findDashboardByName = (name: string): Observable<InsightDashboard | null> => of(null)
+
+    public getDashboardSubjects = (): Observable<SupportedInsightSubject[]> =>
+        from(
+            this.apolloClient.query<InsightSubjectsResult>({ query: GET_INSIGHTS_SUBJECTS_GQL })
+        ).pipe(
+            map(({ data }) => {
+                const { currentUser, site } = data
+
+                if (!currentUser) {
+                    return []
+                }
+
+                return [{ ...currentUser }, ...currentUser.organizations.nodes, site]
+            })
+        )
 
     public createDashboard = (input: DashboardCreateInput): Observable<void> => {
         if (!input.type) {

--- a/client/web/src/enterprise/insights/core/backend/code-insights-setting-cascade-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-setting-cascade-backend.ts
@@ -20,7 +20,7 @@ import { getUpdatedSubjectSettings } from '../../pages/insights/edit-insight/hoo
 import { addDashboardToSettings, removeDashboardFromSettings } from '../settings-action/dashboards'
 import { addInsight } from '../settings-action/insights'
 import { Insight, InsightDashboard, InsightTypePrefix, isRealDashboard } from '../types'
-import { isSettingsBasedInsightsDashboard } from '../types/dashboard/real-dashboard'
+import { isCustomInsightDashboard } from '../types/dashboard/real-dashboard'
 import { isSubjectInsightSupported, SupportedInsightSubject } from '../types/subjects'
 
 import { getBackendInsight } from './api/get-backend-insight'
@@ -151,9 +151,9 @@ export class CodeInsightsSettingsCascadeBackend implements CodeInsightsBackend {
         return of(getInsightsDashboards(subjects, final))
     }
 
-    public getDashboardById = (dashboardId?: string): Observable<InsightDashboard | undefined> =>
+    public getDashboardById = (dashboardId?: string): Observable<InsightDashboard | null> =>
         this.getDashboards().pipe(
-            switchMap(dashboards => of(findDashboardByUrlId(dashboards, dashboardId ?? 'all') ?? undefined))
+            switchMap(dashboards => of(findDashboardByUrlId(dashboards, dashboardId ?? 'all') ?? null))
         )
 
     public findDashboardByName = (name: string): Observable<InsightDashboard | null> =>
@@ -161,7 +161,7 @@ export class CodeInsightsSettingsCascadeBackend implements CodeInsightsBackend {
             switchMap(dashboards => {
                 const possibleDashboard = dashboards
                     .filter(isRealDashboard)
-                    .filter(isSettingsBasedInsightsDashboard)
+                    .filter(isCustomInsightDashboard)
                     .find(dashboard => dashboard.title === name)
 
                 return of(possibleDashboard ?? null)

--- a/client/web/src/enterprise/insights/core/backend/code-insights-setting-cascade-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-setting-cascade-backend.ts
@@ -1,3 +1,4 @@
+import { camelCase } from 'lodash'
 import { Observable, of } from 'rxjs'
 import { map, switchMap } from 'rxjs/operators'
 import { LineChartContent, PieChartContent } from 'sourcegraph'
@@ -44,7 +45,6 @@ import {
     ReachableInsight,
 } from './code-insights-backend-types'
 import { persistChanges } from './utils/persist-changes'
-import { camelCase } from 'lodash'
 
 export class CodeInsightsSettingsCascadeBackend implements CodeInsightsBackend {
     constructor(

--- a/client/web/src/enterprise/insights/core/backend/code-insights-setting-cascade-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-setting-cascade-backend.ts
@@ -253,8 +253,7 @@ export class CodeInsightsSettingsCascadeBackend implements CodeInsightsBackend {
         )
     }
 
-    public assignInsightsToDashboard = (input: DashboardUpdateInput): Observable<unknown> =>
-        this.updateDashboard(input)
+    public assignInsightsToDashboard = (input: DashboardUpdateInput): Observable<unknown> => this.updateDashboard(input)
 
     // Live preview fetchers
     public getSearchInsightContent = <D extends keyof ViewContexts>(

--- a/client/web/src/enterprise/insights/core/backend/code-insights-setting-cascade-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-setting-cascade-backend.ts
@@ -170,6 +170,9 @@ export class CodeInsightsSettingsCascadeBackend implements CodeInsightsBackend {
             })
         )
 
+    public getDashboardSubjects = (): Observable<SupportedInsightSubject[]> =>
+        this.getInsightSubjects()
+
     public createDashboard = (input: DashboardCreateInput): Observable<void> =>
         getSubjectSettings(input.visibility).pipe(
             switchMap(settings => {

--- a/client/web/src/enterprise/insights/core/backend/code-insights-setting-cascade-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-setting-cascade-backend.ts
@@ -253,7 +253,8 @@ export class CodeInsightsSettingsCascadeBackend implements CodeInsightsBackend {
         )
     }
 
-    public assignInsightsToDashboard = (input: DashboardUpdateInput): Observable<void> => this.updateDashboard(input)
+    public assignInsightsToDashboard = (input: DashboardUpdateInput): Observable<unknown> =>
+        this.updateDashboard(input)
 
     // Live preview fetchers
     public getSearchInsightContent = <D extends keyof ViewContexts>(

--- a/client/web/src/enterprise/insights/core/backend/gql/GetDashboardInsights.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql/GetDashboardInsights.ts
@@ -4,6 +4,7 @@ export const GET_DASHBOARD_INSIGHTS_GQL = gql`
     query GetDashboardInsights($id: ID) {
         insightsDashboards(id: $id) {
             nodes {
+                id
                 views {
                     nodes {
                         id

--- a/client/web/src/enterprise/insights/core/backend/gql/GetInsightSubjects.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql/GetInsightSubjects.ts
@@ -1,0 +1,29 @@
+import { gql } from '@apollo/client'
+
+export const GET_INSIGHTS_SUBJECTS_GQL = gql`
+    query InsightSubjects {
+        currentUser {
+            __typename
+            id
+            displayName
+            username
+            viewerCanAdminister
+
+            organizations {
+                nodes {
+                    __typename
+                    id
+                    name
+                    displayName
+                    viewerCanAdminister
+                }
+            }
+        }
+        site {
+            __typename
+            id
+            allowSiteSettingsEdits
+            viewerCanAdminister
+        }
+    }
+`

--- a/client/web/src/enterprise/insights/core/backend/utils/get-dashboard-grants.ts
+++ b/client/web/src/enterprise/insights/core/backend/utils/get-dashboard-grants.ts
@@ -8,18 +8,20 @@ import { DashboardCreateInput } from '../code-insights-backend-types'
  * @param input {object} - A DashboardCreateInput object
  * @param input.type {('personal'|'organization'|'global')} - The type of the dashboard
  * @param input.visibility {string} - Usually the user or organization id
- * @param input.userIds {string[]} - The user ids to grant permissions to
  * @returns - A properly formatted grants object
  */
 export const createDashboardGrants = (input: DashboardCreateInput): InsightsPermissionGrantsInput => {
     const grants: InsightsPermissionGrantsInput = {}
-    const { type, userIds, visibility } = input
+    const { type, visibility } = input
+
     if (type === 'personal') {
-        grants.users = userIds || []
+        grants.users = [visibility]
     }
+
     if (type === 'organization') {
         grants.organizations = [visibility]
     }
+
     if (type === 'global') {
         grants.global = true
     }

--- a/client/web/src/enterprise/insights/core/backend/utils/get-dashboard-grants.ts
+++ b/client/web/src/enterprise/insights/core/backend/utils/get-dashboard-grants.ts
@@ -11,8 +11,12 @@ import { DashboardCreateInput } from '../code-insights-backend-types'
  * @returns - A properly formatted grants object
  */
 export const createDashboardGrants = (input: DashboardCreateInput): InsightsPermissionGrantsInput => {
-    const grants: InsightsPermissionGrantsInput = {}
     const { type, visibility } = input
+    const grants: InsightsPermissionGrantsInput = {
+        users: [],
+        organizations: [],
+        global: false,
+    }
 
     if (type === 'personal') {
         grants.users = [visibility]

--- a/client/web/src/enterprise/insights/core/backend/utils/parse-dashboard-scope.ts
+++ b/client/web/src/enterprise/insights/core/backend/utils/parse-dashboard-scope.ts
@@ -1,4 +1,4 @@
-import { InsightsDashboardType } from '../../types'
+import { InsightsDashboardScope } from '../../types'
 
 /**
  * Helper function to parse the dashboard type from the grants object.
@@ -10,16 +10,16 @@ import { InsightsDashboardType } from '../../types'
  * @param grants.organizations {string[]}
  * @returns - The type of the dashboard
  */
-export const parseDashboardType = (grants?: {
+export const parseDashboardScope = (grants?: {
     global?: boolean
     users?: string[]
     organizations?: string[]
-}): InsightsDashboardType.Personal | InsightsDashboardType.Organization | InsightsDashboardType.Global => {
+}): InsightsDashboardScope => {
     if (grants?.global) {
-        return InsightsDashboardType.Global
+        return InsightsDashboardScope.Global
     }
     if (grants?.organizations?.length) {
-        return InsightsDashboardType.Organization
+        return InsightsDashboardScope.Organization
     }
-    return InsightsDashboardType.Personal
+    return InsightsDashboardScope.Personal
 }

--- a/client/web/src/enterprise/insights/core/settings-action/insights.ts
+++ b/client/web/src/enterprise/insights/core/settings-action/insights.ts
@@ -12,7 +12,7 @@ import {
     isLangStatsInsight,
     isVirtualDashboard,
 } from '../types'
-import { isSettingsBasedInsightsDashboard } from '../types/dashboard/real-dashboard'
+import { isCustomInsightDashboard } from '../types/dashboard/real-dashboard'
 
 import { addInsightToDashboard } from './dashboards'
 
@@ -42,7 +42,7 @@ const getInsightSettingKey = (insight: Insight): string[] => {
 
 export const addInsight = (settings: string, insight: Insight, dashboard: InsightDashboard | null): string => {
     const dashboardSettingKey =
-        !isVirtualDashboard(dashboard) && isSettingsBasedInsightsDashboard(dashboard)
+        dashboard && !isVirtualDashboard(dashboard) && isCustomInsightDashboard(dashboard)
             ? dashboard.settingsKey
             : undefined
 

--- a/client/web/src/enterprise/insights/core/types/dashboard/core.ts
+++ b/client/web/src/enterprise/insights/core/types/dashboard/core.ts
@@ -42,16 +42,9 @@ export interface InsightDashboard {
     scope: InsightsDashboardScope
     title: string
     insightIds?: string[]
-
-    /**
-     * Subject that has a particular dashboard, it can be personal setting
-     * or organization setting subject.
-     */
-    owner?: InsightDashboardOwner
-
     grants?: {
-        users?: string[]
-        organizations?: string[]
-        global?: boolean
+        users: string[]
+        organizations: string[]
+        global: boolean
     }
 }

--- a/client/web/src/enterprise/insights/core/types/dashboard/core.ts
+++ b/client/web/src/enterprise/insights/core/types/dashboard/core.ts
@@ -1,15 +1,7 @@
-import { InsightDashboard as InsightDashboardConfiguration } from '../../../../../schema/settings.schema'
-
 /**
  * All insights dashboards are separated on three categories.
  */
-export enum InsightsDashboardType {
-    /**
-     * This type of dashboard includes all insights from the personal and organization
-     * settings.
-     */
-    All = 'all',
-
+export enum InsightsDashboardScope {
     /**
      * This type of dashboard includes insights from the personal settings or from
      * dashboards that are stored in the personal settings (personal dashboard)
@@ -29,6 +21,12 @@ export enum InsightsDashboardType {
     Global = 'global',
 }
 
+export enum InsightsDashboardType {
+    Virtual = 'virtual',
+    BuiltIn = 'builtIn',
+    Custom = 'custom',
+}
+
 /**
  * Information about dashboard owner. It can be a user-type subject (personal dashboard), org subject
  * (org level dashboard)
@@ -38,12 +36,12 @@ export interface InsightDashboardOwner {
     name: string
 }
 
-export interface ExtendedInsightDashboard extends InsightDashboardConfiguration {
-    /**
-     * All dashboards that were created in users or org settings explicitly are
-     * custom dashboards.
-     */
-    type?: InsightsDashboardType.Personal | InsightsDashboardType.Organization | InsightsDashboardType.Global
+export interface InsightDashboard {
+    id: string
+    type: InsightsDashboardType
+    scope: InsightsDashboardScope
+    title: string
+    insightIds?: string[]
 
     /**
      * Subject that has a particular dashboard, it can be personal setting

--- a/client/web/src/enterprise/insights/core/types/dashboard/index.ts
+++ b/client/web/src/enterprise/insights/core/types/dashboard/index.ts
@@ -1,34 +1,35 @@
-import { InsightsDashboardType, InsightDashboardOwner } from './core'
-import { RealInsightDashboard, SettingsBasedInsightDashboard } from './real-dashboard'
+import { InsightDashboardOwner, InsightsDashboardScope, InsightsDashboardType } from './core'
+import { BuiltInInsightDashboard, CustomInsightDashboard, RealInsightDashboard } from './real-dashboard'
 import { VirtualInsightsDashboard } from './virtual-dashboard'
 
-/**
- * Main insight dashboard definition
- */
+export { InsightsDashboardScope, InsightsDashboardType }
+export type {
+    RealInsightDashboard,
+    VirtualInsightsDashboard,
+    CustomInsightDashboard,
+    BuiltInInsightDashboard,
+    InsightDashboardOwner,
+}
+
+/** Main insight dashboard definition */
 export type InsightDashboard = RealInsightDashboard | VirtualInsightsDashboard
 
-export { InsightsDashboardType }
-
-export type { RealInsightDashboard, VirtualInsightsDashboard, SettingsBasedInsightDashboard, InsightDashboardOwner }
-
-/**
- * Key for accessing insights dashboards in a subject settings.
- */
+/** Key for accessing insights dashboards in a subject settings. */
 export const INSIGHTS_DASHBOARDS_SETTINGS_KEY = 'insights.dashboards'
 
 // Type guards for code insights dashboards
-export const isOrganizationDashboard = (dashboard: InsightDashboard | undefined): dashboard is RealInsightDashboard =>
-    dashboard?.type === InsightsDashboardType.Organization
+export const isVirtualDashboard = (dashboard: InsightDashboard): dashboard is VirtualInsightsDashboard =>
+    dashboard.type === InsightsDashboardType.Virtual
 
-export const isPersonalDashboard = (dashboard: InsightDashboard | undefined): dashboard is RealInsightDashboard =>
-    dashboard?.type === InsightsDashboardType.Personal
+export const isRealDashboard = (dashboard: InsightDashboard): dashboard is RealInsightDashboard =>
+    dashboard.type === InsightsDashboardType.BuiltIn || dashboard.type === InsightsDashboardType.Custom
 
-export const isGlobalDashboard = (dashboard: InsightDashboard | undefined): dashboard is RealInsightDashboard =>
-    dashboard?.type === InsightsDashboardType.Global
+// Scope dashboard selectors
+export const isOrganizationDashboard = (dashboard: InsightDashboard): boolean =>
+    dashboard.scope === InsightsDashboardScope.Organization
 
-export const isVirtualDashboard = (
-    dashboard: InsightDashboard | undefined | null
-): dashboard is VirtualInsightsDashboard => dashboard?.type === InsightsDashboardType.All
+export const isPersonalDashboard = (dashboard: InsightDashboard): boolean =>
+    dashboard.scope === InsightsDashboardScope.Personal
 
-export const isRealDashboard = (dashboard: InsightDashboard | undefined): dashboard is RealInsightDashboard =>
-    isOrganizationDashboard(dashboard) || isPersonalDashboard(dashboard) || isGlobalDashboard(dashboard)
+export const isGlobalDashboard = (dashboard: InsightDashboard): boolean =>
+    dashboard.scope === InsightsDashboardScope.Global

--- a/client/web/src/enterprise/insights/core/types/dashboard/real-dashboard.ts
+++ b/client/web/src/enterprise/insights/core/types/dashboard/real-dashboard.ts
@@ -1,12 +1,12 @@
-import { ExtendedInsightDashboard } from './core'
+import { InsightDashboard, InsightsDashboardType } from './core'
 
 /**
  * Derived dashboard from the setting cascade subject.
  */
-export interface BuiltInInsightDashboard extends ExtendedInsightDashboard {
+export interface BuiltInInsightDashboard extends InsightDashboard {
     /**
-     * Property to distinguish between real user-created dashboard and virtual
-     * built-in dashboard. Currently we support 3 types of user built-in dashboard.
+     * Property to distinguish between real user-created dashboards and
+     * built-in dashboards. Currently we support 3 types of user built-in dashboard.
      *
      * "Personal" - all personal insights from personal settings (all users
      * have it by default)
@@ -15,28 +15,30 @@ export interface BuiltInInsightDashboard extends ExtendedInsightDashboard {
      *
      * "Global level" - all insights from site (global) setting subject.
      */
-    builtIn?: true
+    type: InsightsDashboardType.BuiltIn
 }
 
 /**
  * Explicitly created in the settings cascade insights dashboard.
  */
-export interface SettingsBasedInsightDashboard extends ExtendedInsightDashboard {
+export interface CustomInsightDashboard extends InsightDashboard {
+    type: InsightsDashboardType.Custom
+
     /**
      * Value of dashboard key in the settings for which the dashboard data is available.
      * Dashboard already has an id property but this id is UUID and will be used for further
      * BE migration.
      */
-    settingsKey?: string
+    settingsKey: string | null
 }
 
 /**
  * Insights dashboards that were created in a user/org settings.
  */
-export type RealInsightDashboard = SettingsBasedInsightDashboard | BuiltInInsightDashboard
+export type RealInsightDashboard = CustomInsightDashboard | BuiltInInsightDashboard
 
-export function isSettingsBasedInsightsDashboard(
-    dashboard: RealInsightDashboard | undefined | null
-): dashboard is SettingsBasedInsightDashboard {
-    return !!dashboard?.settingsKey
-}
+export const isBuiltInInsightDashboard = (dashboard: RealInsightDashboard): dashboard is BuiltInInsightDashboard =>
+    dashboard.type === InsightsDashboardType.BuiltIn
+
+export const isCustomInsightDashboard = (dashboard: RealInsightDashboard): dashboard is CustomInsightDashboard =>
+    dashboard.type === InsightsDashboardType.Custom

--- a/client/web/src/enterprise/insights/core/types/dashboard/real-dashboard.ts
+++ b/client/web/src/enterprise/insights/core/types/dashboard/real-dashboard.ts
@@ -1,4 +1,4 @@
-import { InsightDashboard, InsightsDashboardType } from './core'
+import { InsightDashboard, InsightDashboardOwner, InsightsDashboardType } from './core'
 
 /**
  * Derived dashboard from the setting cascade subject.
@@ -16,6 +16,12 @@ export interface BuiltInInsightDashboard extends InsightDashboard {
      * "Global level" - all insights from site (global) setting subject.
      */
     type: InsightsDashboardType.BuiltIn
+
+    /**
+     * Subject that has a particular dashboard, it can be personal setting
+     * or organization setting subject.
+     */
+    owner: InsightDashboardOwner
 }
 
 /**
@@ -30,6 +36,12 @@ export interface CustomInsightDashboard extends InsightDashboard {
      * BE migration.
      */
     settingsKey: string | null
+
+    /**
+     * Subject that has a particular dashboard, it can be personal setting
+     * or organization setting subject.
+     */
+    owner?: InsightDashboardOwner
 }
 
 /**

--- a/client/web/src/enterprise/insights/core/types/dashboard/virtual-dashboard.ts
+++ b/client/web/src/enterprise/insights/core/types/dashboard/virtual-dashboard.ts
@@ -1,11 +1,17 @@
-import { InsightsDashboardType } from './core'
+import { InsightDashboard, InsightsDashboardScope, InsightsDashboardType } from './core'
 
 /**
- * Special 'virtual' dashboard that includes all insights from the personal and organization
+ * Special 'virtual' dashboard that includes all insights from the personal and organization and global
  * level dashboards. Virtual dashboard doesn't exist in settings but lives only in a runtime.
  */
-export interface VirtualInsightsDashboard {
-    type: InsightsDashboardType.All
+export interface VirtualInsightsDashboard extends InsightDashboard {
+    type: InsightsDashboardType.Virtual
+    scope: InsightsDashboardScope.Personal
     id: string
     insightIds?: string[]
 }
+
+/**
+ * One of virtual dashboard id that contains all available for a user insights
+ */
+export const ALL_INSIGHTS_DASHBOARD_ID = 'all'

--- a/client/web/src/enterprise/insights/hooks/use-dashboards/use-dashboard.test.ts
+++ b/client/web/src/enterprise/insights/hooks/use-dashboards/use-dashboard.test.ts
@@ -1,4 +1,4 @@
-import { InsightsDashboardType } from '../../core/types'
+import { InsightsDashboardScope, InsightsDashboardType } from '../../core/types'
 
 import { ALL_INSIGHTS_DASHBOARD, getInsightsDashboards } from './use-dashboards'
 
@@ -83,8 +83,8 @@ describe('getInsightsDashboards', () => {
             ).toStrictEqual([
                 ALL_INSIGHTS_DASHBOARD,
                 {
-                    type: InsightsDashboardType.Organization,
-                    builtIn: true,
+                    type: InsightsDashboardType.BuiltIn,
+                    scope: InsightsDashboardScope.Organization,
                     id: '102',
                     title: 'Sourcegraph',
                     insightIds: [],
@@ -94,8 +94,8 @@ describe('getInsightsDashboards', () => {
                     },
                 },
                 {
-                    type: InsightsDashboardType.Personal,
-                    builtIn: true,
+                    type: InsightsDashboardType.BuiltIn,
+                    scope: InsightsDashboardScope.Personal,
                     title: 'Emir Kusturica',
                     id: '101',
                     insightIds: [],
@@ -141,9 +141,9 @@ describe('getInsightsDashboards', () => {
             ).toStrictEqual([
                 ALL_INSIGHTS_DASHBOARD,
                 {
-                    type: InsightsDashboardType.Personal,
+                    scope: InsightsDashboardScope.Personal,
+                    type: InsightsDashboardType.BuiltIn,
                     title: 'Emir Kusturica',
-                    builtIn: true,
                     id: '101',
                     insightIds: [],
                     owner: {
@@ -152,7 +152,8 @@ describe('getInsightsDashboards', () => {
                     },
                 },
                 {
-                    type: InsightsDashboardType.Personal,
+                    scope: InsightsDashboardScope.Personal,
+                    type: InsightsDashboardType.Custom,
                     id: '001',
                     title: 'Test Dashboard',
                     settingsKey: 'insights.dashboard.testDashboard',
@@ -163,7 +164,8 @@ describe('getInsightsDashboards', () => {
                     },
                 },
                 {
-                    type: InsightsDashboardType.Personal,
+                    scope: InsightsDashboardScope.Personal,
+                    type: InsightsDashboardType.Custom,
                     id: '002',
                     title: 'Another Test Dashboard',
                     settingsKey: 'insights.dashboard.anotherTestDashboard',
@@ -224,8 +226,8 @@ describe('getInsightsDashboards', () => {
             ).toStrictEqual([
                 ALL_INSIGHTS_DASHBOARD,
                 {
-                    type: InsightsDashboardType.Organization,
-                    builtIn: true,
+                    scope: InsightsDashboardScope.Organization,
+                    type: InsightsDashboardType.BuiltIn,
                     id: '102',
                     title: 'Sourcegraph',
                     insightIds: [],
@@ -235,7 +237,8 @@ describe('getInsightsDashboards', () => {
                     },
                 },
                 {
-                    type: InsightsDashboardType.Organization,
+                    scope: InsightsDashboardScope.Organization,
+                    type: InsightsDashboardType.Custom,
                     id: '001',
                     title: 'Test Dashboard',
                     settingsKey: 'insights.dashboard.testDashboard',
@@ -246,10 +249,10 @@ describe('getInsightsDashboards', () => {
                     },
                 },
                 {
-                    type: InsightsDashboardType.Personal,
+                    scope: InsightsDashboardScope.Personal,
+                    type: InsightsDashboardType.BuiltIn,
                     id: '101',
                     title: 'Emir Kusturica',
-                    builtIn: true,
                     insightIds: [],
                     owner: {
                         id: '101',
@@ -257,7 +260,8 @@ describe('getInsightsDashboards', () => {
                     },
                 },
                 {
-                    type: InsightsDashboardType.Personal,
+                    scope: InsightsDashboardScope.Personal,
+                    type: InsightsDashboardType.Custom,
                     id: '002',
                     title: 'Another Test Dashboard',
                     settingsKey: 'insights.dashboard.anotherTestDashboard',

--- a/client/web/src/enterprise/insights/hooks/use-dashboards/use-dashboards.ts
+++ b/client/web/src/enterprise/insights/hooks/use-dashboards/use-dashboards.ts
@@ -1,10 +1,10 @@
 import { useMemo } from 'react'
 
 import { ConfiguredSubjectOrError, SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
-import { isErrorLike, ErrorLike } from '@sourcegraph/shared/src/util/errors'
+import { ErrorLike, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 
 import { Settings } from '../../../../schema/settings.schema'
-import { InsightDashboard, InsightsDashboardType } from '../../core/types'
+import { InsightDashboard, InsightsDashboardScope, InsightsDashboardType } from '../../core/types'
 import { isSubjectInsightSupported } from '../../core/types/subjects'
 
 import { getInsightIdsFromSettings, getSubjectDashboards } from './utils'
@@ -14,7 +14,9 @@ import { getInsightIdsFromSettings, getSubjectDashboards } from './utils'
  */
 export const ALL_INSIGHTS_DASHBOARD: InsightDashboard = {
     id: 'all',
-    type: InsightsDashboardType.All,
+    type: InsightsDashboardType.Virtual,
+    scope: InsightsDashboardScope.Personal,
+    title: 'All Insights',
     insightIds: [],
 }
 

--- a/client/web/src/enterprise/insights/pages/dashboards/DasbhoardsRoutes.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/DasbhoardsRoutes.tsx
@@ -42,12 +42,7 @@ export const DashboardsRoutes: React.FunctionComponent<DashboardsRoutesProps> = 
 
                 <Route
                     path={`${match.url}/add-dashboard`}
-                    render={() => (
-                        <InsightsDashboardCreationPage
-                            telemetryService={telemetryService}
-                            authenticatedUser={authenticatedUser}
-                        />
-                    )}
+                    render={() => <InsightsDashboardCreationPage telemetryService={telemetryService} />}
                 />
             </Switch>
         </>

--- a/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.story.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.story.tsx
@@ -4,7 +4,6 @@ import React from 'react'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { WebStory } from '../../../../../components/WebStory'
-import { authUser } from '../../../../../search/panels/utils'
 import { CodeInsightsBackendContext } from '../../../core/backend/code-insights-backend-context'
 import { CodeInsightsSettingsCascadeBackend } from '../../../core/backend/code-insights-setting-cascade-backend'
 import { SETTINGS_CASCADE_MOCK } from '../../../mocks/settings-cascade'
@@ -30,6 +29,6 @@ const codeInsightsBackend = new CodeInsightsSettingsCascadeBackend(SETTINGS_CASC
 
 add('Page', () => (
     <CodeInsightsBackendContext.Provider value={codeInsightsBackend}>
-        <InsightsDashboardCreationPage telemetryService={NOOP_TELEMETRY_SERVICE} authenticatedUser={authUser} />
+        <InsightsDashboardCreationPage telemetryService={NOOP_TELEMETRY_SERVICE} />
     </CodeInsightsBackendContext.Provider>
 ))

--- a/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
@@ -27,9 +27,9 @@ export const InsightsDashboardCreationPage: React.FunctionComponent<InsightsDash
     const { telemetryService } = props
 
     const history = useHistory()
-    const { createDashboard, getInsightSubjects } = useContext(CodeInsightsBackendContext)
+    const { createDashboard, getDashboardSubjects } = useContext(CodeInsightsBackendContext)
 
-    const subjects = useObservable(useMemo(() => getInsightSubjects(), [getInsightSubjects]))
+    const subjects = useObservable(useMemo(() => getDashboardSubjects(), [getDashboardSubjects]))
 
     const handleSubmit = async (values: DashboardCreationFields): Promise<void | SubmissionErrors> => {
         try {

--- a/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
@@ -1,5 +1,4 @@
 import classNames from 'classnames'
-import { camelCase } from 'lodash'
 import React, { useContext, useMemo } from 'react'
 import { useHistory } from 'react-router-dom'
 
@@ -31,14 +30,14 @@ export const InsightsDashboardCreationPage: React.FunctionComponent<InsightsDash
 
     const subjects = useObservable(useMemo(() => getDashboardSubjects(), [getDashboardSubjects]))
 
-    const handleSubmit = async (values: DashboardCreationFields): Promise<void | SubmissionErrors> => {
+    const handleSubmit = async (values: DashboardCreationFields): Promise<SubmissionErrors> => {
         try {
-            await createDashboard(values).toPromise()
+            const createdDashboard = await createDashboard(values).toPromise()
 
             telemetryService.log('CodeInsightsDashboardCreationPageSubmitClick')
 
             // Navigate user to the dashboard page with new created dashboard
-            history.push(`/insights/dashboards/${camelCase(values.name)}`)
+            history.push(`/insights/dashboards/${createdDashboard.id}`)
         } catch (error) {
             return { [FORM_ERROR]: asError(error) }
         }

--- a/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
@@ -8,7 +8,6 @@ import { asError } from '@sourcegraph/shared/src/util/errors'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 import { PageHeader, Container, Button, LoadingSpinner } from '@sourcegraph/wildcard'
 
-import { authenticatedUser, AuthenticatedUser } from '../../../../../auth'
 import { LoaderButton } from '../../../../../components/LoaderButton'
 import { Page } from '../../../../../components/Page'
 import { PageTitle } from '../../../../../components/PageTitle'
@@ -22,9 +21,7 @@ import {
 } from './components/insights-dashboard-creation-content/InsightsDashboardCreationContent'
 import styles from './InsightsDashboardCreationPage.module.scss'
 
-interface InsightsDashboardCreationPageProps extends TelemetryProps {
-    authenticatedUser: AuthenticatedUser
-}
+interface InsightsDashboardCreationPageProps extends TelemetryProps {}
 
 export const InsightsDashboardCreationPage: React.FunctionComponent<InsightsDashboardCreationPageProps> = props => {
     const { telemetryService } = props
@@ -33,14 +30,10 @@ export const InsightsDashboardCreationPage: React.FunctionComponent<InsightsDash
     const { createDashboard, getInsightSubjects } = useContext(CodeInsightsBackendContext)
 
     const subjects = useObservable(useMemo(() => getInsightSubjects(), [getInsightSubjects]))
-    const user = useObservable(authenticatedUser)
 
     const handleSubmit = async (values: DashboardCreationFields): Promise<void | SubmissionErrors> => {
         try {
-            await createDashboard({
-                ...values,
-                userIds: user?.id ? [user?.id] : [],
-            }).toPromise()
+            await createDashboard(values).toPromise()
 
             telemetryService.log('CodeInsightsDashboardCreationPageSubmitClick')
 

--- a/client/web/src/enterprise/insights/pages/dashboards/creation/components/insights-dashboard-creation-content/InsightsDashboardCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/creation/components/insights-dashboard-creation-content/InsightsDashboardCreationContent.tsx
@@ -42,7 +42,7 @@ export interface InsightsDashboardCreationContentProps {
      */
     subjects: SupportedInsightSubject[]
 
-    onSubmit: (values: DashboardCreationFields) => SubmissionErrors | Promise<SubmissionErrors> | void
+    onSubmit: (values: DashboardCreationFields) => Promise<SubmissionErrors>
     children: (formAPI: FormAPI<DashboardCreationFields>) => ReactNode
 }
 
@@ -66,7 +66,7 @@ export const InsightsDashboardCreationContent: React.FunctionComponent<InsightsD
         initialValues: initialValues ?? { ...DASHBOARD_INITIAL_VALUES, visibility: userSubjectID },
         // Override onSubmit to pass type value
         // to correctly set the grants property for graphql api
-        onSubmit: async () => {
+        onSubmit: async (): Promise<SubmissionErrors> => {
             let type = 'organization'
             if (visibility.input.value === userSubjectID) {
                 type = 'personal'
@@ -76,7 +76,7 @@ export const InsightsDashboardCreationContent: React.FunctionComponent<InsightsD
                 type = 'global'
             }
 
-            await onSubmit({
+            return onSubmit({
                 name: name.input.value,
                 visibility: visibility.input.value,
                 type,

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardsPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardsPage.tsx
@@ -13,7 +13,7 @@ import { FeedbackPromptContent } from '../../../../../nav/Feedback/FeedbackPromp
 import { CodeInsightsIcon } from '../../../components'
 import { flipRightPosition } from '../../../components/context-menu/utils'
 import { Popover } from '../../../components/popover/Popover'
-import { InsightsDashboardType } from '../../../core/types'
+import { ALL_INSIGHTS_DASHBOARD_ID } from '../../../core/types/dashboard/virtual-dashboard'
 
 import { DashboardsContent } from './components/dashboards-content/DashboardsContent'
 import styles from './DashboardPage.module.scss'
@@ -46,7 +46,7 @@ export const DashboardsPage: React.FunctionComponent<DashboardsPageProps> = prop
     if (!dashboardID) {
         // In case if url doesn't have a dashboard id we should fallback on
         // built-in "All insights" dashboard
-        return <Redirect to={`${url}/${InsightsDashboardType.All}`} />
+        return <Redirect to={`${url}/${ALL_INSIGHTS_DASHBOARD_ID}`} />
     }
 
     return (

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/add-insight-modal/AddInsightModal.story.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/add-insight-modal/AddInsightModal.story.tsx
@@ -7,7 +7,7 @@ import { WebStory } from '../../../../../../../components/WebStory'
 import { Settings } from '../../../../../../../schema/settings.schema'
 import { CodeInsightsBackendContext } from '../../../../../core/backend/code-insights-backend-context'
 import { CodeInsightsSettingsCascadeBackend } from '../../../../../core/backend/code-insights-setting-cascade-backend'
-import { InsightsDashboardType, SettingsBasedInsightDashboard } from '../../../../../core/types'
+import { InsightsDashboardType, InsightsDashboardScope, CustomInsightDashboard } from '../../../../../core/types'
 
 import { AddInsightModal } from './AddInsightModal'
 
@@ -19,8 +19,9 @@ const { add } = storiesOf('web/insights/AddInsightModal', module)
         },
     })
 
-const dashboard: SettingsBasedInsightDashboard = {
-    type: InsightsDashboardType.Personal,
+const dashboard: CustomInsightDashboard = {
+    type: InsightsDashboardType.Custom,
+    scope: InsightsDashboardScope.Personal,
     id: '001',
     settingsKey: 'testDashboard',
     title: 'Test dashboard',

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/add-insight-modal/AddInsightModal.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/add-insight-modal/AddInsightModal.tsx
@@ -11,8 +11,8 @@ import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 
 import { FORM_ERROR, SubmissionErrors } from '../../../../../components/form/hooks/useForm'
 import { CodeInsightsBackendContext } from '../../../../../core/backend/code-insights-backend-context'
-import { parseDashboardType } from '../../../../../core/backend/utils/parse-dashboard-type'
-import { SettingsBasedInsightDashboard } from '../../../../../core/types'
+import { parseDashboardScope } from '../../../../../core/backend/utils/parse-dashboard-scope'
+import { CustomInsightDashboard } from '../../../../../core/types'
 
 import styles from './AddInsightModal.module.scss'
 import {
@@ -21,7 +21,7 @@ import {
 } from './components/add-insight-modal-content/AddInsightModalContent'
 
 export interface AddInsightModalProps {
-    dashboard: SettingsBasedInsightDashboard
+    dashboard: CustomInsightDashboard
     onClose: () => void
 }
 
@@ -47,7 +47,7 @@ export const AddInsightModal: React.FunctionComponent<AddInsightModalProps> = pr
     const handleSubmit = async (values: AddInsightFormValues): Promise<void | SubmissionErrors> => {
         try {
             const { insightIds } = values
-            const type = dashboard.grants && parseDashboardType(dashboard.grants)
+            const type = dashboard.grants && parseDashboardScope(dashboard.grants)
 
             await assignInsightsToDashboard({
                 id: dashboard.id,

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-select/DashboardSelect.story.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-select/DashboardSelect.story.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react'
 
 import { AuthenticatedUser } from '../../../../../../../auth'
 import { WebStory } from '../../../../../../../components/WebStory'
-import { InsightDashboard, InsightsDashboardType } from '../../../../../core/types'
+import { InsightDashboard, InsightsDashboardScope, InsightsDashboardType } from '../../../../../core/types'
 
 import { DashboardSelect } from './DashboardSelect'
 
@@ -17,10 +17,10 @@ const { add } = storiesOf('web/insights/DashboardSelect', module)
 
 const DASHBOARDS: InsightDashboard[] = [
     {
-        type: InsightsDashboardType.Personal,
+        scope: InsightsDashboardScope.Personal,
+        type: InsightsDashboardType.BuiltIn,
         id: '101',
         title: 'Personal',
-        builtIn: true,
         insightIds: [],
         owner: {
             id: '101',
@@ -28,10 +28,10 @@ const DASHBOARDS: InsightDashboard[] = [
         },
     },
     {
-        type: InsightsDashboardType.Personal,
+        scope: InsightsDashboardScope.Personal,
+        type: InsightsDashboardType.Custom,
         id: '102',
         title: 'Code Insights dashboard',
-        builtIn: false,
         settingsKey: 'codeInsightsDasbhoard',
         insightIds: [],
         owner: {
@@ -40,10 +40,10 @@ const DASHBOARDS: InsightDashboard[] = [
         },
     },
     {
-        type: InsightsDashboardType.Personal,
+        scope: InsightsDashboardScope.Personal,
+        type: InsightsDashboardType.Custom,
         id: '103',
         title: 'Experimental Insights dashboard',
-        builtIn: false,
         settingsKey: 'experimentalInsightsDashboard',
         insightIds: [],
         owner: {
@@ -52,10 +52,10 @@ const DASHBOARDS: InsightDashboard[] = [
         },
     },
     {
-        type: InsightsDashboardType.Organization,
+        scope: InsightsDashboardScope.Organization,
+        type: InsightsDashboardType.BuiltIn,
         id: '104',
         title: 'Sourcegraph',
-        builtIn: true,
         insightIds: [],
         owner: {
             id: '104',
@@ -63,10 +63,10 @@ const DASHBOARDS: InsightDashboard[] = [
         },
     },
     {
-        type: InsightsDashboardType.Organization,
+        scope: InsightsDashboardScope.Organization,
+        type: InsightsDashboardType.Custom,
         id: '105',
         title: 'Loooong looo0000ong name of dashboard',
-        builtIn: false,
         settingsKey: 'looonglooongDashboard',
         insightIds: [],
         owner: {
@@ -75,10 +75,10 @@ const DASHBOARDS: InsightDashboard[] = [
         },
     },
     {
-        type: InsightsDashboardType.Organization,
+        scope: InsightsDashboardScope.Organization,
+        type: InsightsDashboardType.Custom,
         id: '106',
         title: 'Loooong looo0000ong name of dashboard',
-        builtIn: false,
         settingsKey: 'looonglooongDashboard',
         insightIds: [],
         owner: {

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-select/components/menu-button/MenuButton.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-select/components/menu-button/MenuButton.tsx
@@ -4,7 +4,7 @@ import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
 import ChevronUpIcon from 'mdi-react/ChevronUpIcon'
 import React from 'react'
 
-import { InsightDashboard, InsightsDashboardType } from '../../../../../../../core/types'
+import { InsightDashboard, isRealDashboard } from '../../../../../../../core/types'
 import { getDashboardOwnerName, getDashboardTitle } from '../../helpers/get-dashboard-title'
 import { Badge } from '../badge/Badge'
 import { TruncatedText } from '../trancated-text/TrancatedText'
@@ -31,14 +31,10 @@ export const MenuButton: React.FunctionComponent<MenuButtonProps> = props => {
                     return <MenuButtonContent title="Unknown dashboard" isExpanded={isExpanded} />
                 }
 
-                if (dashboard.type === InsightsDashboardType.All) {
-                    return <MenuButtonContent title="All Insights" isExpanded={isExpanded} />
-                }
-
                 return (
                     <MenuButtonContent
                         title={getDashboardTitle(dashboard)}
-                        badge={getDashboardOwnerName(dashboard)}
+                        badge={isRealDashboard(dashboard) ? getDashboardOwnerName(dashboard) : undefined}
                         isExpanded={isExpanded}
                     />
                 )

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-select/helpers/get-dashboard-title.ts
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-select/helpers/get-dashboard-title.ts
@@ -1,13 +1,22 @@
-import { InsightsDashboardType, RealInsightDashboard } from '../../../../../../core/types'
+import {
+    InsightDashboard,
+    isGlobalDashboard,
+    isPersonalDashboard,
+    isVirtualDashboard,
+    RealInsightDashboard,
+} from '../../../../../../core/types'
+import { isBuiltInInsightDashboard } from '../../../../../../core/types/dashboard/real-dashboard'
 
 /**
  * Get formatted dashboard title for the dashboard select option.
  */
-export const getDashboardTitle = (dashboard: RealInsightDashboard): string => {
-    const { builtIn } = dashboard
+export const getDashboardTitle = (dashboard: InsightDashboard): string => {
+    if (isVirtualDashboard(dashboard)) {
+        return dashboard.title
+    }
 
-    if (builtIn) {
-        if (dashboard.type === InsightsDashboardType.Global) {
+    if (isBuiltInInsightDashboard(dashboard)) {
+        if (isGlobalDashboard(dashboard)) {
             return 'Global Insights'
         }
 
@@ -21,15 +30,13 @@ export const getDashboardTitle = (dashboard: RealInsightDashboard): string => {
  * Get formatted dashboard owner name. Used for list option badge element.
  */
 export const getDashboardOwnerName = (dashboard: RealInsightDashboard): string => {
-    const { type } = dashboard
-
-    if (type === InsightsDashboardType.Personal || dashboard.grants?.users?.length) {
+    if (isPersonalDashboard(dashboard)) {
         return 'Private'
     }
 
-    if (type === InsightsDashboardType.Global || dashboard.grants?.global) {
+    if (isGlobalDashboard(dashboard)) {
         return 'Global'
     }
 
-    return dashboard.owner?.name || dashboard.grants?.organizations?.[0] || 'Unknown'
+    return dashboard.owner?.name ?? dashboard.grants?.organizations?.[0] ?? 'Unknown'
 }

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
@@ -38,9 +38,9 @@ export const DashboardsContent: React.FunctionComponent<DashboardsContentProps> 
     const { dashboardID, telemetryService } = props
 
     const history = useHistory()
-    const { getDashboards, getInsightSubjects } = useContext(CodeInsightsBackendContext)
+    const { getDashboards, getDashboardSubjects } = useContext(CodeInsightsBackendContext)
 
-    const subjects = useObservable(useMemo(() => getInsightSubjects(), [getInsightSubjects]))
+    const subjects = useObservable(useMemo(() => getDashboardSubjects(), [getDashboardSubjects]))
     const dashboards = useObservable(useMemo(() => getDashboards(), [getDashboards]))
 
     // State to open/close add/remove insights modal UI

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
@@ -11,7 +11,7 @@ import { authenticatedUser } from '@sourcegraph/web/src/auth'
 import { HeroPage } from '../../../../../../../components/HeroPage'
 import { CodeInsightsBackendContext } from '../../../../../core/backend/code-insights-backend-context'
 import { isVirtualDashboard } from '../../../../../core/types'
-import { isSettingsBasedInsightsDashboard } from '../../../../../core/types/dashboard/real-dashboard'
+import { isCustomInsightDashboard } from '../../../../../core/types/dashboard/real-dashboard'
 import { AddInsightModal } from '../add-insight-modal/AddInsightModal'
 import { DashboardMenu, DashboardMenuAction } from '../dashboard-menu/DashboardMenu'
 import { DashboardSelect } from '../dashboard-select/DashboardSelect'
@@ -63,11 +63,13 @@ export const DashboardsContent: React.FunctionComponent<DashboardsContentProps> 
         switch (action) {
             case DashboardMenuAction.Configure: {
                 if (
+                    currentDashboard &&
                     !isVirtualDashboard(currentDashboard) &&
-                    isSettingsBasedInsightsDashboard(currentDashboard) &&
-                    currentDashboard.settingsKey
+                    isCustomInsightDashboard(currentDashboard)
                 ) {
-                    history.push(`/insights/dashboards/${currentDashboard.settingsKey}/edit`)
+                    const dashboardURL = currentDashboard.settingsKey ?? currentDashboard.id
+
+                    history.push(`/insights/dashboards/${dashboardURL}/edit`)
                 }
                 return
             }

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.story.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.story.tsx
@@ -3,7 +3,7 @@ import { noop } from 'lodash'
 import React from 'react'
 
 import { WebStory } from '../../../../../../../../../components/WebStory'
-import { InsightDashboard, InsightsDashboardType } from '../../../../../../../core/types'
+import { InsightDashboard, InsightsDashboardScope, InsightsDashboardType } from '../../../../../../../core/types'
 
 import { EmptyInsightDashboard } from './EmptyInsightDashboard'
 
@@ -17,16 +17,15 @@ const { add } = storiesOf('web/insights/EmptyInsightDashboard', module)
 
 add('EmptyInsightDashboard', () => {
     const dashboard: InsightDashboard = {
-        type: InsightsDashboardType.Personal,
+        scope: InsightsDashboardScope.Personal,
+        type: InsightsDashboardType.BuiltIn,
         id: '101',
         title: 'Personal',
-        builtIn: true,
         insightIds: [],
         owner: {
             id: '101',
             name: 'Pesonal',
         },
-        settingsKey: 'test',
     }
 
     return <EmptyInsightDashboard dashboard={dashboard} onAddInsight={noop} />

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/hooks/use-dashboard-select-handler.ts
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/hooks/use-dashboard-select-handler.ts
@@ -1,7 +1,7 @@
 import { useHistory } from 'react-router-dom'
 
 import { InsightDashboard, isVirtualDashboard } from '../../../../../../core/types'
-import { isSettingsBasedInsightsDashboard } from '../../../../../../core/types/dashboard/real-dashboard'
+import { isCustomInsightDashboard } from '../../../../../../core/types/dashboard/real-dashboard'
 
 type SelectHandler = (dashboard: InsightDashboard) => void
 
@@ -19,7 +19,7 @@ export function useDashboardSelectHandler(): SelectHandler {
             return
         }
 
-        if (isSettingsBasedInsightsDashboard(dashboard) && dashboard.settingsKey) {
+        if (isCustomInsightDashboard(dashboard) && dashboard.settingsKey) {
             history.push(`/insights/dashboards/${dashboard.settingsKey}`)
 
             return

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/utils/find-dashboard-by-url-id.ts
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/utils/find-dashboard-by-url-id.ts
@@ -1,5 +1,5 @@
 import { InsightDashboard, isVirtualDashboard } from '../../../../../../core/types'
-import { isSettingsBasedInsightsDashboard } from '../../../../../../core/types/dashboard/real-dashboard'
+import { isCustomInsightDashboard } from '../../../../../../core/types/dashboard/real-dashboard'
 
 /**
  * Returns dashboard configurations by URL query param - dashboardID.
@@ -21,8 +21,7 @@ export function findDashboardByUrlId(
         return (
             dashboard.id === dashboardID ||
             dashboard.title.toLowerCase() === dashboardID?.toLowerCase() ||
-            (isSettingsBasedInsightsDashboard(dashboard) &&
-                dashboard.settingsKey?.toLowerCase() === dashboardID?.toLowerCase())
+            (isCustomInsightDashboard(dashboard) && dashboard.settingsKey?.toLowerCase() === dashboardID?.toLowerCase())
         )
     })
 }

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/utils/is-dashboard-configurable.ts
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/utils/is-dashboard-configurable.ts
@@ -1,5 +1,5 @@
-import { InsightDashboard, isRealDashboard, SettingsBasedInsightDashboard } from '../../../../../../core/types'
-import { isSettingsBasedInsightsDashboard } from '../../../../../../core/types/dashboard/real-dashboard'
+import { InsightDashboard, isRealDashboard, CustomInsightDashboard } from '../../../../../../core/types'
+import { isCustomInsightDashboard } from '../../../../../../core/types/dashboard/real-dashboard'
 
 /**
  * Only dashboards that are stored in user/org/global settings can be edited.
@@ -9,6 +9,5 @@ import { isSettingsBasedInsightsDashboard } from '../../../../../../core/types/d
  */
 export const isDashboardConfigurable = (
     currentDashboard: InsightDashboard | undefined
-): currentDashboard is SettingsBasedInsightDashboard =>
-    isRealDashboard(currentDashboard) &&
-    (isSettingsBasedInsightsDashboard(currentDashboard) || !!currentDashboard.grants)
+): currentDashboard is CustomInsightDashboard =>
+    !!currentDashboard && isRealDashboard(currentDashboard) && isCustomInsightDashboard(currentDashboard)

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/delete-dashboard-modal/DeleteDashboardModal.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/delete-dashboard-modal/DeleteDashboardModal.tsx
@@ -10,13 +10,13 @@ import { Button } from '@sourcegraph/wildcard'
 
 import { ErrorAlert } from '../../../../../../../components/alerts'
 import { LoaderButton } from '../../../../../../../components/LoaderButton'
-import { SettingsBasedInsightDashboard } from '../../../../../core/types'
+import { CustomInsightDashboard } from '../../../../../core/types'
 
 import styles from './DeleteDashobardModal.module.scss'
 import { useDeleteDashboardHandler } from './hooks/use-delete-dashboard-handler'
 
 export interface DeleteDashboardModalProps {
-    dashboard: SettingsBasedInsightDashboard
+    dashboard: CustomInsightDashboard
     onClose: () => void
 }
 

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/delete-dashboard-modal/hooks/use-delete-dashboard-handler.ts
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/delete-dashboard-modal/hooks/use-delete-dashboard-handler.ts
@@ -3,10 +3,10 @@ import { useContext, useState } from 'react'
 import { ErrorLike, asError } from '@sourcegraph/shared/src/util/errors'
 
 import { CodeInsightsBackendContext } from '../../../../../../core/backend/code-insights-backend-context'
-import { SettingsBasedInsightDashboard } from '../../../../../../core/types'
+import { CustomInsightDashboard } from '../../../../../../core/types'
 
 export interface UseDeleteDashboardHandlerProps {
-    dashboard: SettingsBasedInsightDashboard
+    dashboard: CustomInsightDashboard
     onSuccess: () => void
 }
 

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/hooks/use-dashboard-permissions.ts
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/hooks/use-dashboard-permissions.ts
@@ -27,6 +27,15 @@ export function useDashboardPermissions(
     dashboard: InsightDashboard | undefined,
     supportedSubjects?: SupportedInsightSubject[]
 ): DashboardPermissions {
+    if (dashboard && 'grants' in dashboard) {
+        // This means we're using the graphql api.
+        // Since the api only returns info the user can see
+        // We can safely assume the user has permission to edit the dashboard
+        return {
+            isConfigurable: true,
+        }
+    }
+
     if (!dashboard) {
         return DEFAULT_DASHBOARD_PERMISSIONS
     }

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/hooks/use-dashboard-permissions.ts
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/hooks/use-dashboard-permissions.ts
@@ -1,5 +1,5 @@
-import { InsightDashboard, InsightsDashboardType, isRealDashboard, isVirtualDashboard } from '../../../../core/types'
-import { isSettingsBasedInsightsDashboard } from '../../../../core/types/dashboard/real-dashboard'
+import { InsightDashboard, InsightsDashboardScope, isRealDashboard, isVirtualDashboard } from '../../../../core/types'
+import { isCustomInsightDashboard } from '../../../../core/types/dashboard/real-dashboard'
 import { isGlobalSubject, SupportedInsightSubject } from '../../../../core/types/subjects'
 
 enum DashboardReasonDenied {
@@ -27,13 +27,8 @@ export function useDashboardPermissions(
     dashboard: InsightDashboard | undefined,
     supportedSubjects?: SupportedInsightSubject[]
 ): DashboardPermissions {
-    if (dashboard && 'grants' in dashboard) {
-        // This means we're using the graphql api.
-        // Since the api only returns info the user can see
-        // We can safely assume the user has permission to edit the dashboard
-        return {
-            isConfigurable: true,
-        }
+    if (!dashboard) {
+        return DEFAULT_DASHBOARD_PERMISSIONS
     }
 
     if (isVirtualDashboard(dashboard)) {
@@ -56,7 +51,7 @@ export function useDashboardPermissions(
 
     if (isRealDashboard(dashboard)) {
         // Settings based insights dashboards (custom dashboards created by users)
-        if (isSettingsBasedInsightsDashboard(dashboard)) {
+        if (isCustomInsightDashboard(dashboard)) {
             // Global scope permission handling
             if (isGlobalSubject(dashboardOwner)) {
                 const canBeEdited = dashboardOwner.viewerCanAdminister && dashboardOwner.allowSiteSettingsEdits
@@ -102,13 +97,11 @@ export function getTooltipMessage(
         case DashboardReasonDenied.PermissionDenied:
             return "You don't have permission to edit this dashboard"
         case DashboardReasonDenied.BuiltInCantBeEdited:
-            switch (dashboard.type) {
-                case InsightsDashboardType.All:
-                    return "This is an automatically created dashboard that lists all the insights you have access to. You can't edit this dashboard."
-                case InsightsDashboardType.Personal:
+            switch (dashboard.scope) {
+                case InsightsDashboardScope.Personal:
                     return "This is an automatically created dashboard that lists all your private insights. You can't edit this dashboard."
-                case InsightsDashboardType.Organization:
-                case InsightsDashboardType.Global:
+                case InsightsDashboardScope.Organization:
+                case InsightsDashboardScope.Global:
                     if (!dashboard.owner) {
                         throw new Error('TODO: support GraphQL API')
                     }

--- a/client/web/src/enterprise/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
@@ -18,7 +18,7 @@ import { CodeInsightsIcon } from '../../../components'
 import { FORM_ERROR } from '../../../components/form/hooks/useForm'
 import { CodeInsightsBackendContext } from '../../../core/backend/code-insights-backend-context'
 import { isVirtualDashboard } from '../../../core/types'
-import { isSettingsBasedInsightsDashboard } from '../../../core/types/dashboard/real-dashboard'
+import { isBuiltInInsightDashboard } from '../../../core/types/dashboard/real-dashboard'
 import {
     DashboardCreationFields,
     InsightsDashboardCreationContent,
@@ -58,7 +58,7 @@ export const EditDashboardPage: React.FunctionComponent<EditDashboardPageProps> 
     }
 
     // In case if we got null that means we couldn't find this dashboard
-    if (dashboard === null || isVirtualDashboard(dashboard) || !isSettingsBasedInsightsDashboard(dashboard)) {
+    if (dashboard === null || isVirtualDashboard(dashboard) || isBuiltInInsightDashboard(dashboard)) {
         return (
             <HeroPage
                 icon={MapSearchIcon}

--- a/client/web/src/enterprise/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
@@ -38,10 +38,10 @@ export const EditDashboardPage: React.FunctionComponent<EditDashboardPageProps> 
     const { dashboardId, authenticatedUser } = props
     const history = useHistory()
 
-    const { getDashboardById, getInsightSubjects, updateDashboard } = useContext(CodeInsightsBackendContext)
+    const { getDashboardById, getDashboardSubjects, updateDashboard } = useContext(CodeInsightsBackendContext)
 
     // Load edit dashboard information
-    const subjects = useObservable(useMemo(() => getInsightSubjects(), [getInsightSubjects]))
+    const subjects = useObservable(useMemo(() => getDashboardSubjects(), [getDashboardSubjects]))
 
     const dashboard = useObservable(
         useMemo(

--- a/client/web/src/enterprise/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
@@ -1,5 +1,4 @@
 import classNames from 'classnames'
-import { camelCase } from 'lodash'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import React, { useContext, useMemo } from 'react'
 import { useHistory } from 'react-router'
@@ -17,8 +16,9 @@ import { PageTitle } from '../../../../../components/PageTitle'
 import { CodeInsightsIcon } from '../../../components'
 import { FORM_ERROR } from '../../../components/form/hooks/useForm'
 import { CodeInsightsBackendContext } from '../../../core/backend/code-insights-backend-context'
-import { isVirtualDashboard } from '../../../core/types'
+import { CustomInsightDashboard, isVirtualDashboard } from '../../../core/types'
 import { isBuiltInInsightDashboard } from '../../../core/types/dashboard/real-dashboard'
+import { isGlobalSubject, SupportedInsightSubject } from '../../../core/types/subjects'
 import {
     DashboardCreationFields,
     InsightsDashboardCreationContent,
@@ -74,13 +74,6 @@ export const EditDashboardPage: React.FunctionComponent<EditDashboardPageProps> 
         )
     }
 
-    if (!dashboard.owner) {
-        throw new Error('TODO: support GraphQL API')
-    }
-
-    // Convert dashboard info to initial form values
-    const dashboardInitialValues = dashboard ? { name: dashboard.title, visibility: dashboard.owner.id } : undefined
-
     const handleSubmit = async (dashboardValues: DashboardCreationFields): Promise<void | unknown> => {
         if (!dashboard) {
             return
@@ -89,7 +82,7 @@ export const EditDashboardPage: React.FunctionComponent<EditDashboardPageProps> 
         const { name, visibility, type } = dashboardValues
 
         try {
-            await updateDashboard({
+            const updatedDashboard = await updateDashboard({
                 previousDashboard: dashboard,
                 nextDashboardInput: {
                     name,
@@ -98,7 +91,7 @@ export const EditDashboardPage: React.FunctionComponent<EditDashboardPageProps> 
                 },
             }).toPromise()
 
-            history.push(`/insights/dashboards/${camelCase(dashboardValues.name.trim())}`)
+            history.push(`/insights/dashboards/${updatedDashboard.id}`)
         } catch (error) {
             return { [FORM_ERROR]: asError(error) }
         }
@@ -126,7 +119,7 @@ export const EditDashboardPage: React.FunctionComponent<EditDashboardPageProps> 
 
             <Container className="mt-4">
                 <InsightsDashboardCreationContent
-                    initialValues={dashboardInitialValues}
+                    initialValues={getDashboardInitialValues(dashboard, subjects)}
                     subjects={subjects}
                     onSubmit={handleSubmit}
                 >
@@ -157,4 +150,29 @@ export const EditDashboardPage: React.FunctionComponent<EditDashboardPageProps> 
             </Container>
         </Page>
     )
+}
+
+function getDashboardInitialValues(
+    dashboard: CustomInsightDashboard,
+    subjects: SupportedInsightSubject[]
+): DashboardCreationFields | undefined {
+    if (dashboard.owner) {
+        return { name: dashboard.title, visibility: dashboard.owner.id }
+    }
+
+    if (dashboard.grants) {
+        const { users, organizations, global } = dashboard.grants
+        const globalSubject = subjects.find(isGlobalSubject)
+
+        if (global && globalSubject) {
+            return { name: dashboard.title, visibility: globalSubject.id }
+        }
+
+        return {
+            name: dashboard.title,
+            visibility: users[0] ?? organizations[0] ?? 'unkown',
+        }
+    }
+
+    return
 }

--- a/client/web/src/enterprise/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
@@ -14,7 +14,7 @@ import { LoaderButton } from '../../../../../components/LoaderButton'
 import { Page } from '../../../../../components/Page'
 import { PageTitle } from '../../../../../components/PageTitle'
 import { CodeInsightsIcon } from '../../../components'
-import { FORM_ERROR } from '../../../components/form/hooks/useForm'
+import { FORM_ERROR, SubmissionErrors } from '../../../components/form/hooks/useForm'
 import { CodeInsightsBackendContext } from '../../../core/backend/code-insights-backend-context'
 import { CustomInsightDashboard, isVirtualDashboard } from '../../../core/types'
 import { isBuiltInInsightDashboard } from '../../../core/types/dashboard/real-dashboard'
@@ -74,7 +74,7 @@ export const EditDashboardPage: React.FunctionComponent<EditDashboardPageProps> 
         )
     }
 
-    const handleSubmit = async (dashboardValues: DashboardCreationFields): Promise<void | unknown> => {
+    const handleSubmit = async (dashboardValues: DashboardCreationFields): Promise<SubmissionErrors> => {
         if (!dashboard) {
             return
         }

--- a/client/web/src/enterprise/insights/pages/insights/creation/InsightCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/InsightCreationPage.tsx
@@ -6,7 +6,7 @@ import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryServi
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 
 import { CodeInsightsBackendContext } from '../../../core/backend/code-insights-backend-context'
-import { parseDashboardType } from '../../../core/backend/utils/parse-dashboard-type'
+import { parseDashboardScope } from '../../../core/backend/utils/parse-dashboard-scope'
 import { InsightDashboard, isVirtualDashboard, Insight } from '../../../core/types'
 import { isUserSubject } from '../../../core/types/subjects'
 import { useQueryParameters } from '../../../hooks/use-query-parameters'
@@ -26,7 +26,7 @@ const getVisibilityFromDashboard = (dashboard: InsightDashboard | null): string 
 
     // If no owner, this is using the graphql api
     if (!dashboard.owner) {
-        return parseDashboardType(dashboard.grants)
+        return parseDashboardScope(dashboard.grants)
     }
 
     return dashboard.owner.id

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/live-preview-chart/SearchInsightLivePreview.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/live-preview-chart/SearchInsightLivePreview.tsx
@@ -65,6 +65,7 @@ export const SearchInsightLivePreview: React.FunctionComponent<SearchInsightLive
         series: liveSeries,
         repositories: getSanitizedRepositories(repositories),
         step: { [step]: stepValue },
+        disabled,
     })
 
     const liveDebouncedSettings = useDebounce(liveSettings, 500)
@@ -74,7 +75,7 @@ export const SearchInsightLivePreview: React.FunctionComponent<SearchInsightLive
         setLoading(true)
         setDataOrError(undefined)
 
-        if (disabled) {
+        if (liveDebouncedSettings.disabled) {
             setLoading(false)
 
             return
@@ -88,7 +89,7 @@ export const SearchInsightLivePreview: React.FunctionComponent<SearchInsightLive
         return () => {
             hasRequestCanceled = true
         }
-    }, [disabled, lastPreviewVersion, getSearchInsightContent, liveDebouncedSettings])
+    }, [lastPreviewVersion, getSearchInsightContent, liveDebouncedSettings])
 
     return (
         <LivePreviewContainer

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
@@ -72,7 +72,6 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
         step.input.onChange('months')
     }
 
-    const validEditSeries = editSeries.filter(series => series.valid)
     const repositoriesList = getSanitizedRepositories(repositories.input.value)
 
     // If some fields that needed to run live preview  are invalid
@@ -81,7 +80,6 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
         repositories.meta.validState === 'VALID' &&
         repositoriesList.length > 0 &&
         series.meta.validState === 'VALID' &&
-        validEditSeries.length &&
         stepValue.meta.validState === 'VALID' &&
         // For all repos mode we are not able to show the live preview chart
         !allReposMode.input.value

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
@@ -80,7 +80,8 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
     const allFieldsForPreviewAreValid =
         repositories.meta.validState === 'VALID' &&
         repositoriesList.length > 0 &&
-        (series.meta.validState === 'VALID' || validEditSeries.length) &&
+        series.meta.validState === 'VALID' &&
+        validEditSeries.length &&
         stepValue.meta.validState === 'VALID' &&
         // For all repos mode we are not able to show the live preview chart
         !allReposMode.input.value

--- a/client/web/src/integration/insights/edit-search-insights.test.ts
+++ b/client/web/src/integration/insights/edit-search-insights.test.ts
@@ -342,7 +342,9 @@ describe('Code insight edit insight page', () => {
 
         // Waiting for all important part of creation form will be rendered.
         await driver.page.waitForSelector('[data-testid="search-insight-edit-page-content"]')
-        await driver.page.waitForSelector('[data-testid="line-chart__content"] svg circle')
+        await driver.page.waitForSelector(
+            '[data-testid="line-chart__content"] [data-line-name="Imports of new graphql-operations types"] circle'
+        )
 
         await percySnapshotWithVariants(driver.page, 'Code insights edit page with search-based insight creation UI')
 

--- a/client/web/src/views/components/content/view-content/chart-view-content/charts/line/components/LineChartContent.tsx
+++ b/client/web/src/views/components/content/view-content/chart-view-content/charts/line/components/LineChartContent.tsx
@@ -311,6 +311,7 @@ export function LineChartContent<Datum extends object>(props: LineChartContentPr
                                     key={line.dataKey as string}
                                     // eslint-disable-next-line jsx-a11y/aria-role
                                     role="graphics-datagroup"
+                                    data-line-name={line.name ?? 'unknown'}
                                     aria-label={`Line ${index + 1} of ${series.length}. Name: ${
                                         line.name ?? 'unknown'
                                     }`}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/27219

## Context
This PR implements update dashboard methods in a way that users can change dashboard title and visibility attributes (personal, org, global dashboard visibility levels) 

This PR also adds some refactoring work about dashboard types. With this PR we explicitly manage type orthogonal dashboard types (dashboard scope/visibility - personal, org level, global and dashboard-type - built-in, virtual, custom) 

## How to test

To be able to test this PR you have to turn on new GQL API for Code Insights. To do that go to you settings and put `"codeInsightsGqlApi": true` in `experimentalFeatures` field.

- Check updating the title of the dashboard
- Check updating the visibility of dashboard 
- Check that non admin users can't create/update global dashboard 
- Chech that FE works with latest updated dashboard data within one session (without page refreshes) 