### PR TITLE
upgrade wget for ssl_client

### DIFF
--- a/docker-images/alpine-3.12/Dockerfile
+++ b/docker-images/alpine-3.12/Dockerfile
@@ -31,4 +31,5 @@ RUN apk update && apk add --no-cache \
     curl \ 
     mailcap \
     tini \ 
-    wget 
+    # Required due to ssl_clent upgrade with busybox
+    'wget=1.21.1-r1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main


### PR DESCRIPTION
related to CVE-2021-28831

Follows up: https://github.com/sourcegraph/sourcegraph/pull/27510

Without this upgrade wget is throwing:

```
Error relocating /usr/bin/wget: reallocarray: symbol not found
```