### PR TITLE
Fix omnibox opening in wrong tab

### DIFF
--- a/client/browser/CHANGELOG.md
+++ b/client/browser/CHANGELOG.md
@@ -13,7 +13,8 @@ All notable changes to Sourcegraph [Browser Extensions](./README.md) are documen
 
 ## Unreleased
 
-- Fix excessive "all websites" permissions for Safari [#issues/23542](https://github.com/sourcegraph/sourcegraph/issues/23542) [#pull/26832](https://github.com/sourcegraph/sourcegraph/pull/26832)
+- Fix omnibox opening in wrong tab [#issues/23475](https://github.com/sourcegraph/sourcegraph/issues/23475), [#pull/27525](https://github.com/sourcegraph/sourcegraph/pull/27525)
+- Fix excessive "all websites" permissions for Safari [#issues/23542](https://github.com/sourcegraph/sourcegraph/issues/23542), [#pull/26832](https://github.com/sourcegraph/sourcegraph/pull/26832)
 
 ## Chrome / Firefox v21.11.8.1804, Safari v1.7
 

--- a/client/browser/src/shared/cli/index.ts
+++ b/client/browser/src/shared/cli/index.ts
@@ -2,16 +2,28 @@ import { SearchCommand } from './search'
 
 export function initializeOmniboxInterface(): void {
     const searchCommand = new SearchCommand()
-    browser.omnibox.onInputChanged.addListener(async (query, suggest) => {
-        try {
-            const suggestions = await searchCommand.getSuggestions(query)
-            suggest(suggestions)
-        } catch (error) {
-            console.error('error getting suggestions', error)
+    // Note: This is needed because getting current active tab is asynchronous, and in a case when you switch tabs quickly, we mis-use wrong tab.
+    let currentTabId: number | undefined
+    let isOnEnterRunning = false
+
+    browser.tabs.onActivated.addListener(activeInfo => {
+        if (!isOnEnterRunning) {
+            currentTabId = activeInfo.tabId
         }
     })
 
-    browser.omnibox.onInputEntered.addListener(async (query, disposition) => {
-        await searchCommand.action(query, disposition)
+    browser.omnibox.onInputChanged.addListener((query, suggest) => {
+        searchCommand
+            .getSuggestions(query)
+            .then(suggest)
+            .catch(error => console.error('error getting suggestions', error))
+    })
+
+    browser.omnibox.onInputEntered.addListener((query, disposition) => {
+        isOnEnterRunning = true
+        searchCommand
+            .action(query, disposition, currentTabId)
+            .catch(error => console.error('error processing search query', error))
+            .finally(() => (isOnEnterRunning = false))
     })
 }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/23475.

#### Description

First of all, I think, this is a very rare case bug.

It happens because when enter is pressed the omnibox/src logic is running asynchronously in the background script, such as:
- getting current active tab
- getting sourcegraph URL

So if user switches really quickly active tab might change before omnibox handler logic detects current active tab.

This PR changes logic to store current active tab whenever it changes and freezes its value for the period of omnibox logic handler.

#### How to test

See issue description.

#### Before merging

- [ ] Add change log message to [client/browser/CHANGELOG.md](./client/browser/CHANGELOG.md), under "Unreleased" section. (if applicable)
