### PR TITLE
insights: add missing on delete for foreign key

### DIFF
--- a/migrations/codeinsights/1000000021_add_dirty_query_cascade.down.sql
+++ b/migrations/codeinsights/1000000021_add_dirty_query_cascade.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE insight_dirty_queries
+    DROP CONSTRAINT insight_dirty_queries_insight_series_id_fkey,
+    ADD CONSTRAINT insight_dirty_queries_insight_series_id_fkey FOREIGN KEY (insight_series_id) REFERENCES insight_series (id);
+
+COMMIT;

--- a/migrations/codeinsights/1000000021_add_dirty_query_cascade.up.sql
+++ b/migrations/codeinsights/1000000021_add_dirty_query_cascade.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE insight_dirty_queries
+    DROP CONSTRAINT insight_dirty_queries_insight_series_id_fkey,
+    ADD CONSTRAINT insight_dirty_queries_insight_series_id_fkey FOREIGN KEY (insight_series_id) REFERENCES insight_series (id) ON DELETE CASCADE;
+
+COMMIT;


### PR DESCRIPTION
Fixes #27530

Adds a cascade to the `insight_dirty_queries` FK to `insight_series`, so that series can be deleted in one operation.