### PR TITLE
remove Query method from CodeMonitorStore

### DIFF
--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -23,7 +23,6 @@ type CodeMonitorStore interface {
 	Now() time.Time
 	Clock() func() time.Time
 	Exec(ctx context.Context, query *sqlf.Query) error
-	Query(ctx context.Context, query *sqlf.Query) (*sql.Rows, error)
 
 	UpdateActionEmail(ctx context.Context, monitorID int64, action *graphqlbackend.EditActionArgs) (e *MonitorEmail, err error)
 	CreateActionEmail(ctx context.Context, monitorID int64, action *graphqlbackend.CreateActionArgs) (e *MonitorEmail, err error)


### PR DESCRIPTION
This removes the `Query` method from CodeMonitorStore by replacing the
last reference to it with the pre-existing store method `MonitorByIDInt64`

All the `ownerByID` is doing is fetching the of a monitor from the store,
then checking the permissions, but it rolls its own SQL rather than leaving
that to the store. Instead, this just fetches the whole monitor and returns
the owner ID. Most places this is called, we can make this more efficient 
by just checking the ID of an already-fetched monitor, but that's a larger
refactor than I want to tackle in this PR. 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
