### PR TITLE
add global limit for commit/diff search with paged repos

### DIFF
--- a/internal/search/commit/commit_new.go
+++ b/internal/search/commit/commit_new.go
@@ -33,12 +33,14 @@ type CommitSearch struct {
 }
 
 func (j *CommitSearch) Run(ctx context.Context, stream streaming.Sender, repos searchrepos.Pager) error {
+	totalSearched := 0
 	return repos.Paginate(ctx, nil, func(page *searchrepos.Resolved) error {
 		resultType := "commit"
 		if j.Diff {
 			resultType = "diff"
 		}
-		if err := CheckSearchLimits(j.HasTimeFilter, len(page.RepoRevs), resultType); err != nil {
+		totalSearched += len(page.RepoRevs)
+		if err := CheckSearchLimits(j.HasTimeFilter, totalSearched, resultType); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Previously, we would resolve all the repos at once, then check limits on
them and error if there were to many repos being searched. Now, we run
commit searches 500 repos at a time, which will always be below our
limits.

This is a problem because on sourcegrpah.com, some monitors will search
over every repo looking for something that doesn't exist. This is very
expensive and will time out every time.

Ideally, we will clean up the garbage code monitors on sourcegraph.com
and remove limits on commit/diff search (other than timeouts), but for
now, this bandaid should help reduce load.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
