### PR TITLE
make code monitor URL query identifiable

### DIFF
--- a/enterprise/internal/codemonitors/background/graphql.go
+++ b/enterprise/internal/codemonitors/background/graphql.go
@@ -130,7 +130,7 @@ func search(ctx context.Context, query string) (*gqlSearchResponse, error) {
 		return nil, errors.Wrap(err, "Encode")
 	}
 
-	url, err := gqlURL("Search")
+	url, err := gqlURL("CodeMonitorSearch")
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing frontend URL")
 	}


### PR DESCRIPTION
In our instrumentation, [we label graphql queries with the URL query string](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/trace/httptrace.go?L184-191).
Ideally, these should be somewhat unique to the caller so we can identify
the source of problematic or degraded queries. 


Previously, I [attempted to do this](https://github.com/sourcegraph/sourcegraph/pull/27536) with the GraphQL query name, 
but it turns out I was mistaken about where we get the label from. 