### PR TITLE
batches: fix alignment of `WorkspacesPreview` stories

### DIFF
--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.story.tsx
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.story.tsx
@@ -15,7 +15,7 @@ import { WorkspacesPreview } from './WorkspacesPreview'
 import { mockWorkspaceResolutionStatus, mockWorkspacesAndImportingChangesets } from './WorkspacesPreview.mock'
 
 const { add } = storiesOf('web/batches/CreateBatchChangePage/WorkspacesPreview', module).addDecorator(story => (
-    <div className="p-3 container">{story()}</div>
+    <div className="p-3 container d-flex flex-column align-items-center">{story()}</div>
 ))
 
 add('initial', () => (


### PR DESCRIPTION
I forgot to update the stories when I moved the container alignment styles to the parent. This just fixes that. 🙂