### PR TITLE
ssbc: Make execution input only ever contain exactly 1 workspace

### DIFF
--- a/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform.go
@@ -85,21 +85,19 @@ func transformRecord(ctx context.Context, s batchesStore, job *btypes.BatchSpecW
 
 	executionInput := batcheslib.WorkspacesExecutionInput{
 		RawSpec: batchSpec.RawSpec,
-		Workspaces: []*batcheslib.Workspace{
-			{
-				Repository: batcheslib.WorkspaceRepo{
-					ID:   string(graphqlbackend.MarshalRepositoryID(repo.ID)),
-					Name: string(repo.Name),
-				},
-				Branch: batcheslib.WorkspaceBranch{
-					Name:   workspace.Branch,
-					Target: batcheslib.Commit{OID: workspace.Commit},
-				},
-				Path:               workspace.Path,
-				OnlyFetchWorkspace: workspace.OnlyFetchWorkspace,
-				Steps:              workspace.Steps,
-				SearchResultPaths:  workspace.FileMatches,
+		Workspace: batcheslib.Workspace{
+			Repository: batcheslib.WorkspaceRepo{
+				ID:   string(graphqlbackend.MarshalRepositoryID(repo.ID)),
+				Name: string(repo.Name),
 			},
+			Branch: batcheslib.WorkspaceBranch{
+				Name:   workspace.Branch,
+				Target: batcheslib.Commit{OID: workspace.Commit},
+			},
+			Path:               workspace.Path,
+			OnlyFetchWorkspace: workspace.OnlyFetchWorkspace,
+			Steps:              workspace.Steps,
+			SearchResultPaths:  workspace.FileMatches,
 		},
 	}
 

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform_test.go
@@ -64,21 +64,19 @@ func TestTransformRecord(t *testing.T) {
 
 	wantInput := batcheslib.WorkspacesExecutionInput{
 		RawSpec: batchSpec.RawSpec,
-		Workspaces: []*batcheslib.Workspace{
-			{
-				Repository: batcheslib.WorkspaceRepo{
-					ID:   string(graphqlbackend.MarshalRepositoryID(workspace.RepoID)),
-					Name: "github.com/sourcegraph/sourcegraph",
-				},
-				Branch: batcheslib.WorkspaceBranch{
-					Name:   workspace.Branch,
-					Target: batcheslib.Commit{OID: workspace.Commit},
-				},
-				Path:               workspace.Path,
-				OnlyFetchWorkspace: workspace.OnlyFetchWorkspace,
-				Steps:              workspace.Steps,
-				SearchResultPaths:  workspace.FileMatches,
+		Workspace: batcheslib.Workspace{
+			Repository: batcheslib.WorkspaceRepo{
+				ID:   string(graphqlbackend.MarshalRepositoryID(workspace.RepoID)),
+				Name: "github.com/sourcegraph/sourcegraph",
 			},
+			Branch: batcheslib.WorkspaceBranch{
+				Name:   workspace.Branch,
+				Target: batcheslib.Commit{OID: workspace.Commit},
+			},
+			Path:               workspace.Path,
+			OnlyFetchWorkspace: workspace.OnlyFetchWorkspace,
+			Steps:              workspace.Steps,
+			SearchResultPaths:  workspace.FileMatches,
 		},
 	}
 

--- a/lib/batches/workspaces_execution_input.go
+++ b/lib/batches/workspaces_execution_input.go
@@ -1,8 +1,8 @@
 package batches
 
 type WorkspacesExecutionInput struct {
-	RawSpec    string       `json:"rawSpec"`
-	Workspaces []*Workspace `json:"workspaces"`
+	RawSpec   string    `json:"rawSpec"`
+	Workspace Workspace `json:"workspace"`
 }
 
 type Workspace struct {


### PR DESCRIPTION
We don't use this, so I don't think we should allow it.
