### PR TITLE
search: only marshal config for repos that have changed

### DIFF
--- a/cmd/frontend/internal/httpapi/search.go
+++ b/cmd/frontend/internal/httpapi/search.go
@@ -136,6 +136,18 @@ func (h *searchIndexerServer) serveConfiguration(w http.ResponseWriter, r *http.
 		reposMap[repo.ID] = repo
 	}
 
+	// If we used MinLastChanged, we should only return information for the
+	// repositories that we found from List.
+	if !minLastChanged.IsZero() {
+		filtered := indexedIDs[:0]
+		for _, id := range indexedIDs {
+			if _, ok := reposMap[id]; ok {
+				filtered = append(filtered, id)
+			}
+		}
+		indexedIDs = filtered
+	}
+
 	getRepoIndexOptions := func(repoID int32) (*searchbackend.RepoIndexOptions, error) {
 		if loadReposErr != nil {
 			return nil, loadReposErr


### PR DESCRIPTION
There was a subtle but benign bug in the previous code when using the
new "only get config for what has changed" issue. We would return a 404
error for every repository that hasn't changed. This would be ignored by
zoekt and as a side effect would just cause log and metric spam.

We fix the code path by only marshalling configuration for repositories
that have changed.