### PR TITLE
search: Track rendering of no results page

### DIFF
--- a/client/web/src/search/results/NoResultsPage.tsx
+++ b/client/web/src/search/results/NoResultsPage.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames'
 import CloseIcon from 'mdi-react/CloseIcon'
 import ExternalLinkIcon from 'mdi-react/ExternalLinkIcon'
-import React, { useCallback } from 'react'
+import React, { useCallback, useEffect } from 'react'
 
 import { Link } from '@sourcegraph/shared/src/components/Link'
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
@@ -200,6 +200,10 @@ export const NoResultsPage: React.FunctionComponent<NoResultsPageProps> = ({
         },
         [setHiddenSectionIds, telemetryService]
     )
+
+    useEffect(() => {
+        telemetryService.logViewEvent('NoResultsPage')
+    }, [telemetryService])
 
     return (
         <div className={styles.root}>


### PR DESCRIPTION
Closes #27368 

It seems using `logViewEvent` is a appropriate here, but please let me know if not.