### PR TITLE
codemonitors: Clean up CodeMonitorStore

### DIFF
--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -338,7 +338,7 @@ func (r *Resolver) updateCodeMonitor(ctx context.Context, args *graphqlbackend.U
 		if err != nil {
 			return nil, err
 		}
-		err = r.store.CreateRecipients(ctx, action.Email.Update.Recipients, e.Id)
+		err = r.store.CreateRecipients(ctx, action.Email.Update.Recipients, e.ID)
 		if err != nil {
 			return nil, err
 		}
@@ -536,7 +536,7 @@ type monitorQuery struct {
 }
 
 func (q *monitorQuery) ID() graphql.ID {
-	return relay.MarshalID(monitorTriggerQueryKind, q.Id)
+	return relay.MarshalID(monitorTriggerQueryKind, q.QueryTrigger.ID)
 }
 
 func (q *monitorQuery) Query() string {
@@ -544,11 +544,11 @@ func (q *monitorQuery) Query() string {
 }
 
 func (q *monitorQuery) Events(ctx context.Context, args *graphqlbackend.ListEventsArgs) (graphqlbackend.MonitorTriggerEventConnectionResolver, error) {
-	es, err := q.store.ListQueryTriggerJobs(ctx, q.Id, args)
+	es, err := q.store.ListQueryTriggerJobs(ctx, q.QueryTrigger.ID, args)
 	if err != nil {
 		return nil, err
 	}
-	totalCount, err := q.store.CountQueryTriggerJobs(ctx, q.Id)
+	totalCount, err := q.store.CountQueryTriggerJobs(ctx, q.QueryTrigger.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -597,7 +597,7 @@ type monitorTriggerEvent struct {
 }
 
 func (m *monitorTriggerEvent) ID() graphql.ID {
-	return relay.MarshalID(monitorTriggerEventKind, m.Id)
+	return relay.MarshalID(monitorTriggerEventKind, m.TriggerJob.ID)
 }
 
 // stateToStatus maps the state of the dbworker job to the public GraphQL status of
@@ -629,7 +629,7 @@ func (m *monitorTriggerEvent) Timestamp() (graphqlbackend.DateTime, error) {
 }
 
 func (m *monitorTriggerEvent) Actions(ctx context.Context, args *graphqlbackend.ListActionArgs) (graphqlbackend.MonitorActionConnectionResolver, error) {
-	return m.actionConnectionResolverWithTriggerID(ctx, &m.Id, m.monitorID, args)
+	return m.actionConnectionResolverWithTriggerID(ctx, &m.TriggerJob.ID, m.monitorID, args)
 }
 
 // ActionConnection
@@ -684,7 +684,7 @@ type monitorEmail struct {
 
 func (m *monitorEmail) Recipients(ctx context.Context, args *graphqlbackend.ListRecipientsArgs) (c graphqlbackend.MonitorActionEmailRecipientsConnectionResolver, err error) {
 	var ms []*cm.Recipient
-	ms, err = m.store.ListRecipientsForEmailAction(ctx, m.Id, args)
+	ms, err = m.store.ListRecipientsForEmailAction(ctx, m.EmailAction.ID, args)
 	if err != nil {
 		return nil, err
 	}
@@ -711,7 +711,7 @@ func (m *monitorEmail) Recipients(ctx context.Context, args *graphqlbackend.List
 	}
 
 	var total int32
-	total, err = m.store.CountRecipients(ctx, m.Id)
+	total, err = m.store.CountRecipients(ctx, m.EmailAction.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -731,7 +731,7 @@ func (m *monitorEmail) Header() string {
 }
 
 func (m *monitorEmail) ID() graphql.ID {
-	return relay.MarshalID(monitorActionEmailKind, m.Id)
+	return relay.MarshalID(monitorActionEmailKind, m.EmailAction.ID)
 }
 
 func (m *monitorEmail) Events(ctx context.Context, args *graphqlbackend.ListEventsArgs) (graphqlbackend.MonitorActionEventConnectionResolver, error) {
@@ -741,7 +741,7 @@ func (m *monitorEmail) Events(ctx context.Context, args *graphqlbackend.ListEven
 	}
 
 	ajs, err := m.store.ListActionJobs(ctx, cm.ListActionJobsOpts{
-		EmailID:        intPtr(int(m.Id)),
+		EmailID:        intPtr(int(m.EmailAction.ID)),
 		TriggerEventID: m.triggerEventID,
 		First:          intPtr(int(args.First)),
 		After:          after,
@@ -751,7 +751,7 @@ func (m *monitorEmail) Events(ctx context.Context, args *graphqlbackend.ListEven
 	}
 
 	totalCount, err := m.store.CountActionJobs(ctx, cm.ListActionJobsOpts{
-		EmailID:        intPtr(int(m.Id)),
+		EmailID:        intPtr(int(m.EmailAction.ID)),
 		TriggerEventID: m.triggerEventID,
 	})
 	if err != nil {
@@ -832,7 +832,7 @@ type monitorActionEvent struct {
 }
 
 func (m *monitorActionEvent) ID() graphql.ID {
-	return relay.MarshalID(monitorActionEventKind, m.Id)
+	return relay.MarshalID(monitorActionEventKind, m.ID)
 }
 
 func (m *monitorActionEvent) Status() (string, error) {

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -548,7 +548,7 @@ func (q *monitorQuery) Events(ctx context.Context, args *graphqlbackend.ListEven
 	if err != nil {
 		return nil, err
 	}
-	totalCount, err := q.store.TotalCountEventsForQueryIDInt64(ctx, q.Id)
+	totalCount, err := q.store.CountQueryTriggerJobs(ctx, q.Id)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -532,7 +532,7 @@ func (t *monitorTrigger) ToMonitorQuery() (graphqlbackend.MonitorQueryResolver, 
 //
 type monitorQuery struct {
 	*Resolver
-	*cm.MonitorQuery
+	*cm.QueryTrigger
 }
 
 func (q *monitorQuery) ID() graphql.ID {

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -66,7 +66,7 @@ func (r *Resolver) Monitors(ctx context.Context, userID int32, args *graphqlback
 		return nil, err
 	}
 
-	totalCount, err := r.store.TotalCountMonitors(ctx, userID)
+	totalCount, err := r.store.CountMonitors(ctx, userID)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -217,7 +217,7 @@ func (r *Resolver) ResetTriggerQueryTimestamps(ctx context.Context, args *graphq
 	if err != nil {
 		return nil, err
 	}
-	err = r.store.ResetTriggerQueryTimestamps(ctx, queryIDInt64)
+	err = r.store.ResetQueryTriggerTimestamps(ctx, queryIDInt64)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -483,7 +483,7 @@ func (m *monitor) Actions(ctx context.Context, args *graphqlbackend.ListActionAr
 	return m.actionConnectionResolverWithTriggerID(ctx, nil, m.Monitor.ID, args)
 }
 
-func (r *Resolver) actionConnectionResolverWithTriggerID(ctx context.Context, triggerEventID *int, monitorID int64, args *graphqlbackend.ListActionArgs) (graphqlbackend.MonitorActionConnectionResolver, error) {
+func (r *Resolver) actionConnectionResolverWithTriggerID(ctx context.Context, triggerEventID *int32, monitorID int64, args *graphqlbackend.ListActionArgs) (graphqlbackend.MonitorActionConnectionResolver, error) {
 	after, err := unmarshalAfter(args.After)
 	if err != nil {
 		return nil, err
@@ -679,7 +679,7 @@ type monitorEmail struct {
 	// If triggerEventID == nil, all events of this action will be returned.
 	// Otherwise, only those events of this action which are related to the specified
 	// trigger event will be returned.
-	triggerEventID *int
+	triggerEventID *int32
 }
 
 func (m *monitorEmail) Recipients(ctx context.Context, args *graphqlbackend.ListRecipientsArgs) (c graphqlbackend.MonitorActionEmailRecipientsConnectionResolver, err error) {

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -555,9 +555,9 @@ func (q *monitorQuery) Events(ctx context.Context, args *graphqlbackend.ListEven
 	events := make([]graphqlbackend.MonitorTriggerEventResolver, 0, len(es))
 	for _, e := range es {
 		events = append(events, graphqlbackend.MonitorTriggerEventResolver(&monitorTriggerEvent{
-			Resolver:    q.Resolver,
-			monitorID:   q.Monitor,
-			TriggerJobs: e,
+			Resolver:   q.Resolver,
+			monitorID:  q.Monitor,
+			TriggerJob: e,
 		}))
 	}
 	return &monitorTriggerEventConnection{Resolver: q.Resolver, events: events, totalCount: totalCount}, nil
@@ -592,7 +592,7 @@ func (a *monitorTriggerEventConnection) PageInfo(ctx context.Context) (*graphqlu
 //
 type monitorTriggerEvent struct {
 	*Resolver
-	*cm.TriggerJobs
+	*cm.TriggerJob
 	monitorID int64
 }
 

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -186,7 +186,7 @@ func (r *Resolver) UpdateCodeMonitor(ctx context.Context, args *graphqlbackend.U
 	}
 	defer func() { err = tx.store.Done(err) }()
 
-	err = tx.store.DeleteActionsInt64(ctx, toDelete, monitorID)
+	err = tx.store.DeleteEmailActions(ctx, toDelete, monitorID)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -265,7 +265,7 @@ func (r *Resolver) actionIDsForMonitorIDInt64(ctx context.Context, monitorID int
 	}
 	ids := make([]graphql.ID, len(emailActions))
 	for i, emailAction := range emailActions {
-		ids[i] = (&monitorEmail{MonitorEmail: emailAction}).ID()
+		ids[i] = (&monitorEmail{EmailAction: emailAction}).ID()
 	}
 	return ids, nil
 }
@@ -321,7 +321,7 @@ func (r *Resolver) updateCodeMonitor(ctx context.Context, args *graphqlbackend.U
 		}, nil
 	}
 	var emailID int64
-	var e *cm.MonitorEmail
+	var e *cm.EmailAction
 	for i, action := range args.Actions {
 		if action.Email == nil {
 			return nil, errors.Errorf("missing email object for action %d", i)
@@ -508,7 +508,7 @@ func (r *Resolver) actionConnectionResolverWithTriggerID(ctx context.Context, tr
 		actions = append(actions, &action{
 			email: &monitorEmail{
 				Resolver:       r,
-				MonitorEmail:   e,
+				EmailAction:    e,
 				triggerEventID: triggerEventID,
 			},
 		})
@@ -674,7 +674,7 @@ func (a *action) ToMonitorEmail() (graphqlbackend.MonitorEmailResolver, bool) {
 //
 type monitorEmail struct {
 	*Resolver
-	*cm.MonitorEmail
+	*cm.EmailAction
 
 	// If triggerEventID == nil, all events of this action will be returned.
 	// Otherwise, only those events of this action which are related to the specified
@@ -719,15 +719,15 @@ func (m *monitorEmail) Recipients(ctx context.Context, args *graphqlbackend.List
 }
 
 func (m *monitorEmail) Enabled() bool {
-	return m.MonitorEmail.Enabled
+	return m.EmailAction.Enabled
 }
 
 func (m *monitorEmail) Priority() string {
-	return m.MonitorEmail.Priority
+	return m.EmailAction.Priority
 }
 
 func (m *monitorEmail) Header() string {
-	return m.MonitorEmail.Header
+	return m.EmailAction.Header
 }
 
 func (m *monitorEmail) ID() graphql.ID {

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -832,7 +832,7 @@ type monitorActionEvent struct {
 }
 
 func (m *monitorActionEvent) ID() graphql.ID {
-	return relay.MarshalID(monitorActionEventKind, m.ID)
+	return relay.MarshalID(monitorActionEventKind, m.ActionJob.ID)
 }
 
 func (m *monitorActionEvent) Status() (string, error) {

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -711,7 +711,7 @@ func (m *monitorEmail) Recipients(ctx context.Context, args *graphqlbackend.List
 	}
 
 	var total int32
-	total, err = m.store.TotalCountRecipients(ctx, m.Id)
+	total, err = m.store.CountRecipients(ctx, m.Id)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -544,7 +544,7 @@ func (q *monitorQuery) Query() string {
 }
 
 func (q *monitorQuery) Events(ctx context.Context, args *graphqlbackend.ListEventsArgs) (graphqlbackend.MonitorTriggerEventConnectionResolver, error) {
-	es, err := q.store.GetEventsForQueryIDInt64(ctx, q.Id, args)
+	es, err := q.store.ListQueryTriggerJobs(ctx, q.Id, args)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -334,7 +334,7 @@ func (r *Resolver) updateCodeMonitor(ctx context.Context, args *graphqlbackend.U
 		if err != nil {
 			return nil, err
 		}
-		e, err = r.store.UpdateActionEmail(ctx, mo.ID, action)
+		e, err = r.store.UpdateEmailAction(ctx, mo.ID, action)
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -499,7 +499,7 @@ func (r *Resolver) actionConnectionResolverWithTriggerID(ctx context.Context, tr
 		return nil, err
 	}
 
-	totalCount, err := r.store.TotalCountActionEmails(ctx, monitorID)
+	totalCount, err := r.store.CountEmailActions(ctx, monitorID)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -684,7 +684,7 @@ type monitorEmail struct {
 
 func (m *monitorEmail) Recipients(ctx context.Context, args *graphqlbackend.ListRecipientsArgs) (c graphqlbackend.MonitorActionEmailRecipientsConnectionResolver, err error) {
 	var ms []*cm.Recipient
-	ms, err = m.store.RecipientsForEmailIDInt64(ctx, m.Id, args)
+	ms, err = m.store.ListRecipientsForEmailAction(ctx, m.Id, args)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -472,7 +472,7 @@ func (m *monitor) Owner(ctx context.Context) (n graphqlbackend.NamespaceResolver
 }
 
 func (m *monitor) Trigger(ctx context.Context) (graphqlbackend.MonitorTrigger, error) {
-	t, err := m.store.TriggerQueryByMonitorIDInt64(ctx, m.Monitor.ID)
+	t, err := m.store.GetQueryTriggerForMonitor(ctx, m.Monitor.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -309,7 +309,7 @@ func (r *Resolver) updateCodeMonitor(ctx context.Context, args *graphqlbackend.U
 		return nil, err
 	}
 	// Update trigger.
-	err = r.store.UpdateTriggerQuery(ctx, args)
+	err = r.store.UpdateQueryTrigger(ctx, args)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -61,7 +61,7 @@ func (r *Resolver) Monitors(ctx context.Context, userID int32, args *graphqlback
 	newArgs := *args
 	newArgs.First += 1
 
-	ms, err := r.store.Monitors(ctx, userID, &newArgs)
+	ms, err := r.store.ListMonitors(ctx, userID, &newArgs)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
@@ -384,7 +384,7 @@ func TestQueryMonitor(t *testing.T) {
 		func() error { return r.store.EnqueueQueryTriggerJobs(ctx) },
 		// To have a consistent state we have to log the number of search results for
 		// each completed trigger job.
-		func() error { return r.store.LogSearch(ctx, "", 1, 1) },
+		func() error { return r.store.UpdateTriggerJobWithResults(ctx, "", 1, 1) },
 	})
 	_, err = r.insertTestMonitorWithOpts(ctx, t, actionOpt, postHookOpt)
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
@@ -356,7 +356,7 @@ func TestQueryMonitor(t *testing.T) {
 	// in the database. After we create the monitor they fill the job tables and
 	// update the job status.
 	postHookOpt := WithPostHooks([]hook{
-		func() error { return r.store.EnqueueTriggerQueries(ctx) },
+		func() error { return r.store.EnqueueQueryTriggers(ctx) },
 		func() error { return r.store.EnqueueActionEmailsForQueryIDInt64(ctx, 1, 1) },
 		func() error {
 			return (&storetest.TestStore{CodeMonitorStore: r.store}).SetJobStatus(ctx, storetest.ActionJobs, storetest.Completed, 1)
@@ -381,7 +381,7 @@ func TestQueryMonitor(t *testing.T) {
 		// 1   1     completed
 		// 2   2     queued
 		// 3   1	 queued
-		func() error { return r.store.EnqueueTriggerQueries(ctx) },
+		func() error { return r.store.EnqueueQueryTriggers(ctx) },
 		// To have a consistent state we have to log the number of search results for
 		// each completed trigger job.
 		func() error { return r.store.LogSearch(ctx, "", 1, 1) },

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
@@ -356,7 +356,7 @@ func TestQueryMonitor(t *testing.T) {
 	// in the database. After we create the monitor they fill the job tables and
 	// update the job status.
 	postHookOpt := WithPostHooks([]hook{
-		func() error { return r.store.EnqueueQueryTriggers(ctx) },
+		func() error { return r.store.EnqueueQueryTriggerJobs(ctx) },
 		func() error { return r.store.EnqueueActionEmailsForQueryIDInt64(ctx, 1, 1) },
 		func() error {
 			return (&storetest.TestStore{CodeMonitorStore: r.store}).SetJobStatus(ctx, storetest.ActionJobs, storetest.Completed, 1)
@@ -381,7 +381,7 @@ func TestQueryMonitor(t *testing.T) {
 		// 1   1     completed
 		// 2   2     queued
 		// 3   1	 queued
-		func() error { return r.store.EnqueueQueryTriggers(ctx) },
+		func() error { return r.store.EnqueueQueryTriggerJobs(ctx) },
 		// To have a consistent state we have to log the number of search results for
 		// each completed trigger job.
 		func() error { return r.store.LogSearch(ctx, "", 1, 1) },

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
@@ -357,11 +357,11 @@ func TestQueryMonitor(t *testing.T) {
 	// update the job status.
 	postHookOpt := WithPostHooks([]hook{
 		func() error { return r.store.EnqueueQueryTriggerJobs(ctx) },
-		func() error { return r.store.EnqueueActionEmailsForQueryIDInt64(ctx, 1, 1) },
+		func() error { return r.store.EnqueueActionJobsForQuery(ctx, 1, 1) },
 		func() error {
 			return (&storetest.TestStore{CodeMonitorStore: r.store}).SetJobStatus(ctx, storetest.ActionJobs, storetest.Completed, 1)
 		},
-		func() error { return r.store.EnqueueActionEmailsForQueryIDInt64(ctx, 1, 1) },
+		func() error { return r.store.EnqueueActionJobsForQuery(ctx, 1, 1) },
 		// Set the job status of trigger job with id = 1 to "completed". Since we already
 		// created another monitor, there is still a second trigger job (id = 2) which
 		// remains in status queued.

--- a/enterprise/internal/codemonitors/action_emails.go
+++ b/enterprise/internal/codemonitors/action_emails.go
@@ -44,7 +44,7 @@ func (s *codeMonitorStore) CreateEmailAction(ctx context.Context, monitorID int6
 	return scanEmail(row)
 }
 
-func (s *codeMonitorStore) DeleteActionsInt64(ctx context.Context, actionIDs []int64, monitorID int64) error {
+func (s *codeMonitorStore) DeleteEmailActions(ctx context.Context, actionIDs []int64, monitorID int64) error {
 	if len(actionIDs) == 0 {
 		return nil
 	}

--- a/enterprise/internal/codemonitors/action_emails.go
+++ b/enterprise/internal/codemonitors/action_emails.go
@@ -61,7 +61,7 @@ FROM cm_emails
 WHERE monitor = %s;
 `
 
-func (s *codeMonitorStore) TotalCountActionEmails(ctx context.Context, monitorID int64) (int32, error) {
+func (s *codeMonitorStore) CountEmailActions(ctx context.Context, monitorID int64) (int32, error) {
 	var count int32
 	err := s.QueryRow(ctx, sqlf.Sprintf(totalCountActionEmailsFmtStr, monitorID)).Scan(&count)
 	return count, err

--- a/enterprise/internal/codemonitors/action_emails.go
+++ b/enterprise/internal/codemonitors/action_emails.go
@@ -15,7 +15,7 @@ import (
 )
 
 type EmailAction struct {
-	Id        int64
+	ID        int64
 	Monitor   int64
 	Enabled   bool
 	Priority  string
@@ -251,7 +251,7 @@ func scanEmails(rows *sql.Rows) ([]*EmailAction, error) {
 func scanEmail(scanner dbutil.Scanner) (*EmailAction, error) {
 	m := &EmailAction{}
 	err := scanner.Scan(
-		&m.Id,
+		&m.ID,
 		&m.Monitor,
 		&m.Enabled,
 		&m.Priority,

--- a/enterprise/internal/codemonitors/action_emails.go
+++ b/enterprise/internal/codemonitors/action_emails.go
@@ -49,7 +49,6 @@ func (s *codeMonitorStore) UpdateEmailAction(ctx context.Context, monitorID int6
 		return nil, err
 	}
 
-	now := s.Now()
 	a := actor.FromContext(ctx)
 	q := sqlf.Sprintf(
 		updateActionEmailFmtStr,
@@ -57,7 +56,7 @@ func (s *codeMonitorStore) UpdateEmailAction(ctx context.Context, monitorID int6
 		action.Email.Update.Priority,
 		action.Email.Update.Header,
 		a.UID,
-		now,
+		s.Now(),
 		actionID,
 		monitorID,
 		sqlf.Join(emailsColumns, ", "),

--- a/enterprise/internal/codemonitors/action_emails.go
+++ b/enterprise/internal/codemonitors/action_emails.go
@@ -26,7 +26,7 @@ type MonitorEmail struct {
 	ChangedAt time.Time
 }
 
-func (s *codeMonitorStore) UpdateActionEmail(ctx context.Context, monitorID int64, action *graphqlbackend.EditActionArgs) (*MonitorEmail, error) {
+func (s *codeMonitorStore) UpdateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.EditActionArgs) (*MonitorEmail, error) {
 	q, err := s.updateActionEmailQuery(ctx, monitorID, action.Email)
 	if err != nil {
 		return nil, err

--- a/enterprise/internal/codemonitors/action_emails.go
+++ b/enterprise/internal/codemonitors/action_emails.go
@@ -73,7 +73,7 @@ FROM cm_emails
 WHERE id = %s
 `
 
-func (s *codeMonitorStore) ActionEmailByIDInt64(ctx context.Context, emailID int64) (m *MonitorEmail, err error) {
+func (s *codeMonitorStore) GetEmailAction(ctx context.Context, emailID int64) (m *MonitorEmail, err error) {
 	q := sqlf.Sprintf(
 		actionEmailByIDFmtStr,
 		sqlf.Join(emailsColumns, ","),

--- a/enterprise/internal/codemonitors/action_emails.go
+++ b/enterprise/internal/codemonitors/action_emails.go
@@ -35,7 +35,7 @@ func (s *codeMonitorStore) UpdateEmailAction(ctx context.Context, monitorID int6
 	return scanEmail(row)
 }
 
-func (s *codeMonitorStore) CreateActionEmail(ctx context.Context, monitorID int64, action *graphqlbackend.CreateActionArgs) (*MonitorEmail, error) {
+func (s *codeMonitorStore) CreateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.CreateActionArgs) (*MonitorEmail, error) {
 	q, err := s.createActionEmailQuery(ctx, monitorID, action.Email)
 	if err != nil {
 		return nil, err

--- a/enterprise/internal/codemonitors/action_emails.go
+++ b/enterprise/internal/codemonitors/action_emails.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
-type MonitorEmail struct {
+type EmailAction struct {
 	Id        int64
 	Monitor   int64
 	Enabled   bool
@@ -26,7 +26,7 @@ type MonitorEmail struct {
 	ChangedAt time.Time
 }
 
-func (s *codeMonitorStore) UpdateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.EditActionArgs) (*MonitorEmail, error) {
+func (s *codeMonitorStore) UpdateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.EditActionArgs) (*EmailAction, error) {
 	q, err := s.updateActionEmailQuery(ctx, monitorID, action.Email)
 	if err != nil {
 		return nil, err
@@ -35,7 +35,7 @@ func (s *codeMonitorStore) UpdateEmailAction(ctx context.Context, monitorID int6
 	return scanEmail(row)
 }
 
-func (s *codeMonitorStore) CreateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.CreateActionArgs) (*MonitorEmail, error) {
+func (s *codeMonitorStore) CreateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.CreateActionArgs) (*EmailAction, error) {
 	q, err := s.createActionEmailQuery(ctx, monitorID, action.Email)
 	if err != nil {
 		return nil, err
@@ -73,7 +73,7 @@ FROM cm_emails
 WHERE id = %s
 `
 
-func (s *codeMonitorStore) GetEmailAction(ctx context.Context, emailID int64) (m *MonitorEmail, err error) {
+func (s *codeMonitorStore) GetEmailAction(ctx context.Context, emailID int64) (m *EmailAction, err error) {
 	q := sqlf.Sprintf(
 		actionEmailByIDFmtStr,
 		sqlf.Join(emailsColumns, ","),
@@ -163,7 +163,7 @@ LIMIT %s;
 `
 
 // ListEmailActions lists emails from cm_emails with the given opts
-func (s *codeMonitorStore) ListEmailActions(ctx context.Context, opts ListActionsOpts) ([]*MonitorEmail, error) {
+func (s *codeMonitorStore) ListEmailActions(ctx context.Context, opts ListActionsOpts) ([]*EmailAction, error) {
 	q := sqlf.Sprintf(
 		listEmailActionsFmtStr,
 		sqlf.Join(emailsColumns, ","),
@@ -234,8 +234,8 @@ var emailsColumns = []*sqlf.Query{
 	sqlf.Sprintf("cm_emails.changed_at"),
 }
 
-func scanEmails(rows *sql.Rows) ([]*MonitorEmail, error) {
-	var ms []*MonitorEmail
+func scanEmails(rows *sql.Rows) ([]*EmailAction, error) {
+	var ms []*EmailAction
 	for rows.Next() {
 		m, err := scanEmail(rows)
 		if err != nil {
@@ -248,8 +248,8 @@ func scanEmails(rows *sql.Rows) ([]*MonitorEmail, error) {
 
 // scanEmail scans a MonitorEmail from a *sql.Row or *sql.Rows.
 // It must be kept in sync with emailsColumns.
-func scanEmail(scanner dbutil.Scanner) (*MonitorEmail, error) {
-	m := &MonitorEmail{}
+func scanEmail(scanner dbutil.Scanner) (*EmailAction, error) {
+	m := &EmailAction{}
 	err := scanner.Scan(
 		&m.Id,
 		&m.Monitor,

--- a/enterprise/internal/codemonitors/action_jobs.go
+++ b/enterprise/internal/codemonitors/action_jobs.go
@@ -217,13 +217,13 @@ func (s *codeMonitorStore) ActionJobForIDInt(ctx context.Context, recordID int) 
 // ScanActionJobRecord implements the worker RecordScanFn
 func ScanActionJobRecord(rows *sql.Rows, err error) (workerutil.Record, bool, error) {
 	if err != nil {
-		return &TriggerJobs{}, false, err
+		return &TriggerJob{}, false, err
 	}
 	defer rows.Close()
 
 	records, err := scanActionJobs(rows)
 	if err != nil || len(records) == 0 {
-		return &TriggerJobs{}, false, err
+		return &TriggerJob{}, false, err
 	}
 	return records[0], true, nil
 }

--- a/enterprise/internal/codemonitors/action_jobs.go
+++ b/enterprise/internal/codemonitors/action_jobs.go
@@ -178,8 +178,9 @@ INSERT INTO cm_action_jobs (email, trigger_event)
 SELECT id, %s::integer from due EXCEPT SELECT id, %s::integer from busy ORDER BY id
 `
 
-// TODO(camdencheek): could we enqueue based on monitor ID rather than query ID? Would avoid joins above.
-func (s *codeMonitorStore) EnqueueActionEmailsForQueryIDInt64(ctx context.Context, queryID int64, triggerEventID int) (err error) {
+// TODO(camdencheek): could/should we enqueue based on monitor ID rather than query ID? Would avoid joins above.
+func (s *codeMonitorStore) EnqueueActionJobsForQuery(ctx context.Context, queryID int64, triggerEventID int) (err error) {
+	// TODO(camdencheek): Enqueue actions other than emails here
 	return s.Store.Exec(ctx, sqlf.Sprintf(enqueueActionEmailFmtStr, queryID, triggerEventID, triggerEventID))
 }
 

--- a/enterprise/internal/codemonitors/action_jobs.go
+++ b/enterprise/internal/codemonitors/action_jobs.go
@@ -12,7 +12,7 @@ import (
 )
 
 type ActionJob struct {
-	Id           int32
+	ID           int32
 	Email        *int64
 	Webhook      *int64
 	SlackWebhook *int64
@@ -30,7 +30,7 @@ type ActionJob struct {
 }
 
 func (a *ActionJob) RecordID() int {
-	return int(a.Id)
+	return int(a.ID)
 }
 
 type ActionJobMetadata struct {
@@ -244,7 +244,7 @@ func scanActionJobs(rows *sql.Rows) ([]*ActionJob, error) {
 func scanActionJob(row dbutil.Scanner) (*ActionJob, error) {
 	aj := &ActionJob{}
 	return aj, row.Scan(
-		&aj.Id,
+		&aj.ID,
 		&aj.Email,
 		&aj.Webhook,
 		&aj.SlackWebhook,

--- a/enterprise/internal/codemonitors/action_jobs.go
+++ b/enterprise/internal/codemonitors/action_jobs.go
@@ -208,7 +208,7 @@ FROM cm_action_jobs
 WHERE id = %s
 `
 
-func (s *codeMonitorStore) ActionJobForIDInt(ctx context.Context, recordID int) (*ActionJob, error) {
+func (s *codeMonitorStore) GetActionJob(ctx context.Context, recordID int) (*ActionJob, error) {
 	q := sqlf.Sprintf(actionJobForIDFmtStr, sqlf.Join(ActionJobColumns, ", "), recordID)
 	row := s.QueryRow(ctx, q)
 	return scanActionJob(row)

--- a/enterprise/internal/codemonitors/action_jobs.go
+++ b/enterprise/internal/codemonitors/action_jobs.go
@@ -12,10 +12,10 @@ import (
 )
 
 type ActionJob struct {
-	Id           int
-	Email        *int
-	Webhook      *int
-	SlackWebhook *int
+	Id           int32
+	Email        *int64
+	Webhook      *int64
+	SlackWebhook *int64
 	TriggerEvent int
 
 	// Fields demanded by any dbworker.
@@ -30,7 +30,7 @@ type ActionJob struct {
 }
 
 func (a *ActionJob) RecordID() int {
-	return a.Id
+	return int(a.Id)
 }
 
 type ActionJobMetadata struct {
@@ -66,7 +66,7 @@ type ListActionJobsOpts struct {
 	// TriggerEventID, if set, will filter to only action jobs that were
 	// created in response to the provided trigger event.  Refers to
 	// cm_trigger_jobs(id)
-	TriggerEventID *int
+	TriggerEventID *int32
 
 	// EmailID, if set, will filter to only actions jobs that are executing the
 	// given email action. Refers to cm_emails(id)

--- a/enterprise/internal/codemonitors/action_jobs_test.go
+++ b/enterprise/internal/codemonitors/action_jobs_test.go
@@ -30,7 +30,7 @@ func TestEnqueueActionEmailsForQueryIDInt64QueryByRecordID(t *testing.T) {
 	}
 
 	var got *ActionJob
-	got, err = s.ActionJobForIDInt(ctx, 1)
+	got, err = s.GetActionJob(ctx, 1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/codemonitors/action_jobs_test.go
+++ b/enterprise/internal/codemonitors/action_jobs_test.go
@@ -20,7 +20,7 @@ func TestEnqueueActionEmailsForQueryIDInt64QueryByRecordID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = s.EnqueueTriggerQueries(ctx)
+	err = s.EnqueueQueryTriggers(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +66,7 @@ func TestGetActionJobMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = s.EnqueueTriggerQueries(ctx)
+	err = s.EnqueueQueryTriggers(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +117,7 @@ func TestScanActionJobs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = s.EnqueueTriggerQueries(ctx)
+	err = s.EnqueueQueryTriggers(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/codemonitors/action_jobs_test.go
+++ b/enterprise/internal/codemonitors/action_jobs_test.go
@@ -36,7 +36,7 @@ func TestEnqueueActionEmailsForQueryIDInt64QueryByRecordID(t *testing.T) {
 	}
 
 	want := &ActionJob{
-		Id:             1,
+		ID:             1,
 		Email:          int64Ptr(1),
 		TriggerEvent:   1,
 		State:          "queued",

--- a/enterprise/internal/codemonitors/action_jobs_test.go
+++ b/enterprise/internal/codemonitors/action_jobs_test.go
@@ -37,7 +37,7 @@ func TestEnqueueActionEmailsForQueryIDInt64QueryByRecordID(t *testing.T) {
 
 	want := &ActionJob{
 		Id:             1,
-		Email:          intPtr(1),
+		Email:          int64Ptr(1),
 		TriggerEvent:   1,
 		State:          "queued",
 		FailureMessage: nil,
@@ -53,7 +53,7 @@ func TestEnqueueActionEmailsForQueryIDInt64QueryByRecordID(t *testing.T) {
 	}
 }
 
-func intPtr(i int) *int { return &i }
+func int64Ptr(i int64) *int64 { return &i }
 
 func TestGetActionJobMetadata(t *testing.T) {
 	if testing.Short() {

--- a/enterprise/internal/codemonitors/action_jobs_test.go
+++ b/enterprise/internal/codemonitors/action_jobs_test.go
@@ -24,7 +24,7 @@ func TestEnqueueActionEmailsForQueryIDInt64QueryByRecordID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = s.EnqueueActionEmailsForQueryIDInt64(ctx, 1, 1)
+	err = s.EnqueueActionJobsForQuery(ctx, 1, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +80,7 @@ func TestGetActionJobMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = s.EnqueueActionEmailsForQueryIDInt64(ctx, 1, 1)
+	err = s.EnqueueActionJobsForQuery(ctx, 1, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +121,7 @@ func TestScanActionJobs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = s.EnqueueActionEmailsForQueryIDInt64(ctx, testQueryID, testTriggerEventID)
+	err = s.EnqueueActionJobsForQuery(ctx, testQueryID, testTriggerEventID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/codemonitors/action_jobs_test.go
+++ b/enterprise/internal/codemonitors/action_jobs_test.go
@@ -76,7 +76,7 @@ func TestGetActionJobMetadata(t *testing.T) {
 		wantQuery            = testQuery + " after:\"" + s.Now().UTC().Format(time.RFC3339) + "\""
 		wantMonitorID  int64 = 1
 	)
-	err = s.LogSearch(ctx, wantQuery, wantNumResults, 1)
+	err = s.UpdateTriggerJobWithResults(ctx, wantQuery, wantNumResults, 1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/codemonitors/action_jobs_test.go
+++ b/enterprise/internal/codemonitors/action_jobs_test.go
@@ -20,7 +20,7 @@ func TestEnqueueActionEmailsForQueryIDInt64QueryByRecordID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = s.EnqueueQueryTriggers(ctx)
+	err = s.EnqueueQueryTriggerJobs(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +66,7 @@ func TestGetActionJobMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = s.EnqueueQueryTriggers(ctx)
+	err = s.EnqueueQueryTriggerJobs(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +117,7 @@ func TestScanActionJobs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = s.EnqueueQueryTriggers(ctx)
+	err = s.EnqueueQueryTriggerJobs(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/codemonitors/actions.go
+++ b/enterprise/internal/codemonitors/actions.go
@@ -12,7 +12,7 @@ func (s *codeMonitorStore) CreateActions(ctx context.Context, args []*graphqlbac
 		if err != nil {
 			return err
 		}
-		err = s.CreateRecipients(ctx, a.Email.Recipients, e.Id)
+		err = s.CreateRecipients(ctx, a.Email.Recipients, e.ID)
 		if err != nil {
 			return err
 		}

--- a/enterprise/internal/codemonitors/actions.go
+++ b/enterprise/internal/codemonitors/actions.go
@@ -8,7 +8,7 @@ import (
 
 func (s *codeMonitorStore) CreateActions(ctx context.Context, args []*graphqlbackend.CreateActionArgs, monitorID int64) error {
 	for _, a := range args {
-		e, err := s.CreateActionEmail(ctx, monitorID, a)
+		e, err := s.CreateEmailAction(ctx, monitorID, a)
 		if err != nil {
 			return err
 		}

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -68,7 +68,7 @@ func newTriggerJobsLogDeleter(ctx context.Context, store cm.CodeMonitorStore) go
 				return err
 			}
 			// Delete old logs, even if they have search results.
-			err = store.DeleteOldJobLogs(ctx, eventRetentionInDays)
+			err = store.DeleteOldTriggerJobs(ctx, eventRetentionInDays)
 			if err != nil {
 				return err
 			}

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -152,7 +152,7 @@ func (r *queryRunner) Handle(ctx context.Context, record workerutil.Record) (err
 		return err
 	}
 
-	m, err := s.MonitorByIDInt64(ctx, q.Monitor)
+	m, err := s.GetMonitor(ctx, q.Monitor)
 	if err != nil {
 		return err
 	}
@@ -255,7 +255,7 @@ func (r *actionRunner) Handle(ctx context.Context, record workerutil.Record) (er
 
 // newQueryWithAfterFilter constructs a new query which finds search results
 // introduced after the last time we queried.
-func newQueryWithAfterFilter(q *cm.MonitorQuery) string {
+func newQueryWithAfterFilter(q *cm.QueryTrigger) string {
 	// For q.LatestResult = nil we return a query string without after: filter, which
 	// effectively triggers actions immediately provided the query returns any
 	// results.

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -219,12 +219,12 @@ func (r *actionRunner) Handle(ctx context.Context, record workerutil.Record) (er
 
 	switch {
 	case j.Email != nil:
-		e, err := s.GetEmailAction(ctx, int64(*j.Email))
+		e, err := s.GetEmailAction(ctx, *j.Email)
 		if err != nil {
 			return errors.Errorf("store.ActionEmailByIDInt64: %w", err)
 		}
 
-		recs, err := s.ListAllRecipientsForEmailAction(ctx, int64(*j.Email))
+		recs, err := s.ListAllRecipientsForEmailAction(ctx, *j.Email)
 		if err != nil {
 			return errors.Errorf("store.AllRecipientsForEmailIDInt64: %w", err)
 		}

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -224,7 +224,7 @@ func (r *actionRunner) Handle(ctx context.Context, record workerutil.Record) (er
 			return errors.Errorf("store.ActionEmailByIDInt64: %w", err)
 		}
 
-		recs, err := s.AllRecipientsForEmailIDInt64(ctx, int64(*j.Email))
+		recs, err := s.ListAllRecipientsForEmailAction(ctx, int64(*j.Email))
 		if err != nil {
 			return errors.Errorf("store.AllRecipientsForEmailIDInt64: %w", err)
 		}

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -219,7 +219,7 @@ func (r *actionRunner) Handle(ctx context.Context, record workerutil.Record) (er
 
 	switch {
 	case j.Email != nil:
-		e, err := s.ActionEmailByIDInt64(ctx, int64(*j.Email))
+		e, err := s.GetEmailAction(ctx, int64(*j.Email))
 		if err != nil {
 			return errors.Errorf("store.ActionEmailByIDInt64: %w", err)
 		}

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -177,7 +177,7 @@ func (r *queryRunner) Handle(ctx context.Context, record workerutil.Record) (err
 	}
 	// Log next_run and latest_result to table cm_queries.
 	newLatestResult := latestResultTime(q.LatestResult, results, err)
-	err = s.SetTriggerQueryNextRun(ctx, q.Id, s.Clock()().Add(5*time.Minute), newLatestResult.UTC())
+	err = s.SetQueryTriggerNextRun(ctx, q.Id, s.Clock()().Add(5*time.Minute), newLatestResult.UTC())
 	if err != nil {
 		return err
 	}

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -38,7 +38,7 @@ func newTriggerQueryEnqueuer(ctx context.Context, store cm.CodeMonitorStore) gor
 	enqueueActive := goroutine.NewHandlerWithErrorMessage(
 		"code_monitors_trigger_query_enqueuer",
 		func(ctx context.Context) error {
-			return store.EnqueueQueryTriggers(ctx)
+			return store.EnqueueQueryTriggerJobs(ctx)
 		})
 	return goroutine.NewPeriodicGoroutine(ctx, 1*time.Minute, enqueueActive)
 }

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -170,7 +170,7 @@ func (r *queryRunner) Handle(ctx context.Context, record workerutil.Record) (err
 		numResults = len(results.Data.Search.Results.Results)
 	}
 	if numResults > 0 {
-		err := s.EnqueueActionEmailsForQueryIDInt64(ctx, q.Id, record.RecordID())
+		err := s.EnqueueActionJobsForQuery(ctx, q.Id, record.RecordID())
 		if err != nil {
 			return errors.Errorf("store.EnqueueActionEmailsForQueryIDInt64: %w", err)
 		}

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -170,14 +170,14 @@ func (r *queryRunner) Handle(ctx context.Context, record workerutil.Record) (err
 		numResults = len(results.Data.Search.Results.Results)
 	}
 	if numResults > 0 {
-		err := s.EnqueueActionJobsForQuery(ctx, q.QueryTrigger.ID, record.RecordID())
+		err := s.EnqueueActionJobsForQuery(ctx, q.ID, record.RecordID())
 		if err != nil {
 			return errors.Errorf("store.EnqueueActionEmailsForQueryIDInt64: %w", err)
 		}
 	}
 	// Log next_run and latest_result to table cm_queries.
 	newLatestResult := latestResultTime(q.LatestResult, results, err)
-	err = s.SetQueryTriggerNextRun(ctx, q.QueryTrigger.ID, s.Clock()().Add(5*time.Minute), newLatestResult.UTC())
+	err = s.SetQueryTriggerNextRun(ctx, q.ID, s.Clock()().Add(5*time.Minute), newLatestResult.UTC())
 	if err != nil {
 		return err
 	}

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -109,7 +109,7 @@ func createDBWorkerStoreForTriggerJobs(s cm.CodeMonitorStore) dbworkerstore.Stor
 		Name:              "code_monitors_trigger_jobs_worker_store",
 		TableName:         "cm_trigger_jobs",
 		ColumnExpressions: cm.TriggerJobsColumns,
-		Scan:              cm.ScanTriggerJobs,
+		Scan:              cm.ScanTriggerJobsRecord,
 		StalledMaxAge:     60 * time.Second,
 		RetryAfter:        10 * time.Second,
 		MaxNumRetries:     3,

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -170,14 +170,14 @@ func (r *queryRunner) Handle(ctx context.Context, record workerutil.Record) (err
 		numResults = len(results.Data.Search.Results.Results)
 	}
 	if numResults > 0 {
-		err := s.EnqueueActionJobsForQuery(ctx, q.Id, record.RecordID())
+		err := s.EnqueueActionJobsForQuery(ctx, q.QueryTrigger.ID, record.RecordID())
 		if err != nil {
 			return errors.Errorf("store.EnqueueActionEmailsForQueryIDInt64: %w", err)
 		}
 	}
 	// Log next_run and latest_result to table cm_queries.
 	newLatestResult := latestResultTime(q.LatestResult, results, err)
-	err = s.SetQueryTriggerNextRun(ctx, q.Id, s.Clock()().Add(5*time.Minute), newLatestResult.UTC())
+	err = s.SetQueryTriggerNextRun(ctx, q.QueryTrigger.ID, s.Clock()().Add(5*time.Minute), newLatestResult.UTC())
 	if err != nil {
 		return err
 	}

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -147,7 +147,7 @@ func (r *queryRunner) Handle(ctx context.Context, record workerutil.Record) (err
 	}
 	defer func() { err = s.Done(err) }()
 
-	q, err := s.GetQueryByRecordID(ctx, record.RecordID())
+	q, err := s.GetQueryTriggerForJob(ctx, record.RecordID())
 	if err != nil {
 		return err
 	}

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -38,7 +38,7 @@ func newTriggerQueryEnqueuer(ctx context.Context, store cm.CodeMonitorStore) gor
 	enqueueActive := goroutine.NewHandlerWithErrorMessage(
 		"code_monitors_trigger_query_enqueuer",
 		func(ctx context.Context) error {
-			return store.EnqueueTriggerQueries(ctx)
+			return store.EnqueueQueryTriggers(ctx)
 		})
 	return goroutine.NewPeriodicGoroutine(ctx, 1*time.Minute, enqueueActive)
 }

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -63,7 +63,7 @@ func newTriggerJobsLogDeleter(ctx context.Context, store cm.CodeMonitorStore) go
 		"code_monitors_trigger_jobs_log_deleter",
 		func(ctx context.Context) error {
 			// Delete logs without search results.
-			err := store.DeleteObsoleteJobLogs(ctx)
+			err := store.DeleteObsoleteTriggerJobs(ctx)
 			if err != nil {
 				return err
 			}
@@ -182,7 +182,7 @@ func (r *queryRunner) Handle(ctx context.Context, record workerutil.Record) (err
 		return err
 	}
 	// Log the actual query we ran and whether we got any new results.
-	err = s.LogSearch(ctx, newQuery, numResults, record.RecordID())
+	err = s.UpdateTriggerJobWithResults(ctx, newQuery, numResults, record.RecordID())
 	if err != nil {
 		return errors.Errorf("LogSearch: %w", err)
 	}

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -172,7 +172,7 @@ func (r *queryRunner) Handle(ctx context.Context, record workerutil.Record) (err
 	if numResults > 0 {
 		err := s.EnqueueActionJobsForQuery(ctx, q.ID, record.RecordID())
 		if err != nil {
-			return errors.Errorf("store.EnqueueActionEmailsForQueryIDInt64: %w", err)
+			return errors.Errorf("store.EnqueueActionJobsForQuery: %w", err)
 		}
 	}
 	// Log next_run and latest_result to table cm_queries.

--- a/enterprise/internal/codemonitors/background/workers_test.go
+++ b/enterprise/internal/codemonitors/background/workers_test.go
@@ -95,7 +95,7 @@ func TestActionRunner(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			record, err = ts.ActionJobForIDInt(ctx, 1)
+			record, err = ts.GetActionJob(ctx, 1)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/enterprise/internal/codemonitors/background/workers_test.go
+++ b/enterprise/internal/codemonitors/background/workers_test.go
@@ -91,7 +91,7 @@ func TestActionRunner(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = ts.EnqueueActionEmailsForQueryIDInt64(ctx, queryID, triggerEvent)
+			err = ts.EnqueueActionJobsForQuery(ctx, queryID, triggerEvent)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/enterprise/internal/codemonitors/background/workers_test.go
+++ b/enterprise/internal/codemonitors/background/workers_test.go
@@ -87,7 +87,7 @@ func TestActionRunner(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = ts.LogSearch(ctx, testQuery, tt.numResults, triggerEvent)
+			err = ts.UpdateTriggerJobWithResults(ctx, testQuery, tt.numResults, triggerEvent)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/enterprise/internal/codemonitors/background/workers_test.go
+++ b/enterprise/internal/codemonitors/background/workers_test.go
@@ -83,7 +83,7 @@ func TestActionRunner(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = ts.EnqueueTriggerQueries(ctx)
+			err = ts.EnqueueQueryTriggers(ctx)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/enterprise/internal/codemonitors/background/workers_test.go
+++ b/enterprise/internal/codemonitors/background/workers_test.go
@@ -83,7 +83,7 @@ func TestActionRunner(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = ts.EnqueueQueryTriggers(ctx)
+			err = ts.EnqueueQueryTriggerJobs(ctx)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/enterprise/internal/codemonitors/code_monitors.go
+++ b/enterprise/internal/codemonitors/code_monitors.go
@@ -21,7 +21,7 @@ func (s *codeMonitorStore) CreateCodeMonitor(ctx context.Context, args *graphqlb
 	}
 
 	// Create trigger.
-	err = txStore.CreateTriggerQuery(ctx, m.ID, args.Trigger)
+	err = txStore.CreateQueryTrigger(ctx, m.ID, args.Trigger)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/codemonitors/email/email.go
+++ b/enterprise/internal/codemonitors/email/email.go
@@ -40,7 +40,7 @@ type TemplateDataNewSearchResults struct {
 	IsTest                    bool
 }
 
-func NewTemplateDataForNewSearchResults(ctx context.Context, monitorDescription, queryString string, email *codemonitors.MonitorEmail, numResults int) (d *TemplateDataNewSearchResults, err error) {
+func NewTemplateDataForNewSearchResults(ctx context.Context, monitorDescription, queryString string, email *codemonitors.EmailAction, numResults int) (d *TemplateDataNewSearchResults, err error) {
 	var (
 		searchURL                 string
 		codeMonitorURL            string

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -18,12 +18,6 @@ import (
 // github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors) used
 // for unit testing.
 type MockCodeMonitorStore struct {
-	// ActionEmailByIDInt64Func is an instance of a mock function object
-	// controlling the behavior of the method ActionEmailByIDInt64.
-	ActionEmailByIDInt64Func *CodeMonitorStoreActionEmailByIDInt64Func
-	// ActionJobForIDIntFunc is an instance of a mock function object
-	// controlling the behavior of the method ActionJobForIDInt.
-	ActionJobForIDIntFunc *CodeMonitorStoreActionJobForIDIntFunc
 	// AllRecipientsForEmailIDInt64Func is an instance of a mock function
 	// object controlling the behavior of the method
 	// AllRecipientsForEmailIDInt64.
@@ -34,15 +28,18 @@ type MockCodeMonitorStore struct {
 	// CountActionJobsFunc is an instance of a mock function object
 	// controlling the behavior of the method CountActionJobs.
 	CountActionJobsFunc *CodeMonitorStoreCountActionJobsFunc
-	// CreateActionEmailFunc is an instance of a mock function object
-	// controlling the behavior of the method CreateActionEmail.
-	CreateActionEmailFunc *CodeMonitorStoreCreateActionEmailFunc
+	// CountEmailActionsFunc is an instance of a mock function object
+	// controlling the behavior of the method CountEmailActions.
+	CountEmailActionsFunc *CodeMonitorStoreCountEmailActionsFunc
 	// CreateActionsFunc is an instance of a mock function object
 	// controlling the behavior of the method CreateActions.
 	CreateActionsFunc *CodeMonitorStoreCreateActionsFunc
 	// CreateCodeMonitorFunc is an instance of a mock function object
 	// controlling the behavior of the method CreateCodeMonitor.
 	CreateCodeMonitorFunc *CodeMonitorStoreCreateCodeMonitorFunc
+	// CreateEmailActionFunc is an instance of a mock function object
+	// controlling the behavior of the method CreateEmailAction.
+	CreateEmailActionFunc *CodeMonitorStoreCreateEmailActionFunc
 	// CreateMonitorFunc is an instance of a mock function object
 	// controlling the behavior of the method CreateMonitor.
 	CreateMonitorFunc *CodeMonitorStoreCreateMonitorFunc
@@ -52,9 +49,9 @@ type MockCodeMonitorStore struct {
 	// CreateTriggerQueryFunc is an instance of a mock function object
 	// controlling the behavior of the method CreateTriggerQuery.
 	CreateTriggerQueryFunc *CodeMonitorStoreCreateTriggerQueryFunc
-	// DeleteActionsInt64Func is an instance of a mock function object
-	// controlling the behavior of the method DeleteActionsInt64.
-	DeleteActionsInt64Func *CodeMonitorStoreDeleteActionsInt64Func
+	// DeleteEmailActionsFunc is an instance of a mock function object
+	// controlling the behavior of the method DeleteEmailActions.
+	DeleteEmailActionsFunc *CodeMonitorStoreDeleteEmailActionsFunc
 	// DeleteMonitorFunc is an instance of a mock function object
 	// controlling the behavior of the method DeleteMonitor.
 	DeleteMonitorFunc *CodeMonitorStoreDeleteMonitorFunc
@@ -80,9 +77,15 @@ type MockCodeMonitorStore struct {
 	// ExecFunc is an instance of a mock function object controlling the
 	// behavior of the method Exec.
 	ExecFunc *CodeMonitorStoreExecFunc
+	// GetActionJobFunc is an instance of a mock function object controlling
+	// the behavior of the method GetActionJob.
+	GetActionJobFunc *CodeMonitorStoreGetActionJobFunc
 	// GetActionJobMetadataFunc is an instance of a mock function object
 	// controlling the behavior of the method GetActionJobMetadata.
 	GetActionJobMetadataFunc *CodeMonitorStoreGetActionJobMetadataFunc
+	// GetEmailActionFunc is an instance of a mock function object
+	// controlling the behavior of the method GetEmailAction.
+	GetEmailActionFunc *CodeMonitorStoreGetEmailActionFunc
 	// GetEventsForQueryIDInt64Func is an instance of a mock function object
 	// controlling the behavior of the method GetEventsForQueryIDInt64.
 	GetEventsForQueryIDInt64Func *CodeMonitorStoreGetEventsForQueryIDInt64Func
@@ -124,9 +127,6 @@ type MockCodeMonitorStore struct {
 	// ToggleMonitorFunc is an instance of a mock function object
 	// controlling the behavior of the method ToggleMonitor.
 	ToggleMonitorFunc *CodeMonitorStoreToggleMonitorFunc
-	// TotalCountActionEmailsFunc is an instance of a mock function object
-	// controlling the behavior of the method TotalCountActionEmails.
-	TotalCountActionEmailsFunc *CodeMonitorStoreTotalCountActionEmailsFunc
 	// TotalCountEventsForQueryIDInt64Func is an instance of a mock function
 	// object controlling the behavior of the method
 	// TotalCountEventsForQueryIDInt64.
@@ -144,9 +144,9 @@ type MockCodeMonitorStore struct {
 	// object controlling the behavior of the method
 	// TriggerQueryByMonitorIDInt64.
 	TriggerQueryByMonitorIDInt64Func *CodeMonitorStoreTriggerQueryByMonitorIDInt64Func
-	// UpdateActionEmailFunc is an instance of a mock function object
-	// controlling the behavior of the method UpdateActionEmail.
-	UpdateActionEmailFunc *CodeMonitorStoreUpdateActionEmailFunc
+	// UpdateEmailActionFunc is an instance of a mock function object
+	// controlling the behavior of the method UpdateEmailAction.
+	UpdateEmailActionFunc *CodeMonitorStoreUpdateEmailActionFunc
 	// UpdateMonitorFunc is an instance of a mock function object
 	// controlling the behavior of the method UpdateMonitor.
 	UpdateMonitorFunc *CodeMonitorStoreUpdateMonitorFunc
@@ -160,16 +160,6 @@ type MockCodeMonitorStore struct {
 // overwritten.
 func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 	return &MockCodeMonitorStore{
-		ActionEmailByIDInt64Func: &CodeMonitorStoreActionEmailByIDInt64Func{
-			defaultHook: func(context.Context, int64) (*MonitorEmail, error) {
-				return nil, nil
-			},
-		},
-		ActionJobForIDIntFunc: &CodeMonitorStoreActionJobForIDIntFunc{
-			defaultHook: func(context.Context, int) (*ActionJob, error) {
-				return nil, nil
-			},
-		},
 		AllRecipientsForEmailIDInt64Func: &CodeMonitorStoreAllRecipientsForEmailIDInt64Func{
 			defaultHook: func(context.Context, int64) ([]*Recipient, error) {
 				return nil, nil
@@ -185,9 +175,9 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 				return 0, nil
 			},
 		},
-		CreateActionEmailFunc: &CodeMonitorStoreCreateActionEmailFunc{
-			defaultHook: func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*MonitorEmail, error) {
-				return nil, nil
+		CountEmailActionsFunc: &CodeMonitorStoreCountEmailActionsFunc{
+			defaultHook: func(context.Context, int64) (int32, error) {
+				return 0, nil
 			},
 		},
 		CreateActionsFunc: &CodeMonitorStoreCreateActionsFunc{
@@ -197,6 +187,11 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 		},
 		CreateCodeMonitorFunc: &CodeMonitorStoreCreateCodeMonitorFunc{
 			defaultHook: func(context.Context, *graphqlbackend.CreateCodeMonitorArgs) (*Monitor, error) {
+				return nil, nil
+			},
+		},
+		CreateEmailActionFunc: &CodeMonitorStoreCreateEmailActionFunc{
+			defaultHook: func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*MonitorEmail, error) {
 				return nil, nil
 			},
 		},
@@ -215,7 +210,7 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 				return nil
 			},
 		},
-		DeleteActionsInt64Func: &CodeMonitorStoreDeleteActionsInt64Func{
+		DeleteEmailActionsFunc: &CodeMonitorStoreDeleteEmailActionsFunc{
 			defaultHook: func(context.Context, []int64, int64) error {
 				return nil
 			},
@@ -260,8 +255,18 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 				return nil
 			},
 		},
+		GetActionJobFunc: &CodeMonitorStoreGetActionJobFunc{
+			defaultHook: func(context.Context, int) (*ActionJob, error) {
+				return nil, nil
+			},
+		},
 		GetActionJobMetadataFunc: &CodeMonitorStoreGetActionJobMetadataFunc{
 			defaultHook: func(context.Context, int) (*ActionJobMetadata, error) {
+				return nil, nil
+			},
+		},
+		GetEmailActionFunc: &CodeMonitorStoreGetEmailActionFunc{
+			defaultHook: func(context.Context, int64) (*MonitorEmail, error) {
 				return nil, nil
 			},
 		},
@@ -330,11 +335,6 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 				return nil, nil
 			},
 		},
-		TotalCountActionEmailsFunc: &CodeMonitorStoreTotalCountActionEmailsFunc{
-			defaultHook: func(context.Context, int64) (int32, error) {
-				return 0, nil
-			},
-		},
 		TotalCountEventsForQueryIDInt64Func: &CodeMonitorStoreTotalCountEventsForQueryIDInt64Func{
 			defaultHook: func(context.Context, int64) (int32, error) {
 				return 0, nil
@@ -360,7 +360,7 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 				return nil, nil
 			},
 		},
-		UpdateActionEmailFunc: &CodeMonitorStoreUpdateActionEmailFunc{
+		UpdateEmailActionFunc: &CodeMonitorStoreUpdateEmailActionFunc{
 			defaultHook: func(context.Context, int64, *graphqlbackend.EditActionArgs) (*MonitorEmail, error) {
 				return nil, nil
 			},
@@ -383,12 +383,6 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 // implementation, unless overwritten.
 func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 	return &MockCodeMonitorStore{
-		ActionEmailByIDInt64Func: &CodeMonitorStoreActionEmailByIDInt64Func{
-			defaultHook: i.ActionEmailByIDInt64,
-		},
-		ActionJobForIDIntFunc: &CodeMonitorStoreActionJobForIDIntFunc{
-			defaultHook: i.ActionJobForIDInt,
-		},
 		AllRecipientsForEmailIDInt64Func: &CodeMonitorStoreAllRecipientsForEmailIDInt64Func{
 			defaultHook: i.AllRecipientsForEmailIDInt64,
 		},
@@ -398,14 +392,17 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 		CountActionJobsFunc: &CodeMonitorStoreCountActionJobsFunc{
 			defaultHook: i.CountActionJobs,
 		},
-		CreateActionEmailFunc: &CodeMonitorStoreCreateActionEmailFunc{
-			defaultHook: i.CreateEmailAction,
+		CountEmailActionsFunc: &CodeMonitorStoreCountEmailActionsFunc{
+			defaultHook: i.CountEmailActions,
 		},
 		CreateActionsFunc: &CodeMonitorStoreCreateActionsFunc{
 			defaultHook: i.CreateActions,
 		},
 		CreateCodeMonitorFunc: &CodeMonitorStoreCreateCodeMonitorFunc{
 			defaultHook: i.CreateCodeMonitor,
+		},
+		CreateEmailActionFunc: &CodeMonitorStoreCreateEmailActionFunc{
+			defaultHook: i.CreateEmailAction,
 		},
 		CreateMonitorFunc: &CodeMonitorStoreCreateMonitorFunc{
 			defaultHook: i.CreateMonitor,
@@ -416,7 +413,7 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 		CreateTriggerQueryFunc: &CodeMonitorStoreCreateTriggerQueryFunc{
 			defaultHook: i.CreateTriggerQuery,
 		},
-		DeleteActionsInt64Func: &CodeMonitorStoreDeleteActionsInt64Func{
+		DeleteEmailActionsFunc: &CodeMonitorStoreDeleteEmailActionsFunc{
 			defaultHook: i.DeleteEmailActions,
 		},
 		DeleteMonitorFunc: &CodeMonitorStoreDeleteMonitorFunc{
@@ -443,8 +440,14 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 		ExecFunc: &CodeMonitorStoreExecFunc{
 			defaultHook: i.Exec,
 		},
+		GetActionJobFunc: &CodeMonitorStoreGetActionJobFunc{
+			defaultHook: i.GetActionJob,
+		},
 		GetActionJobMetadataFunc: &CodeMonitorStoreGetActionJobMetadataFunc{
 			defaultHook: i.GetActionJobMetadata,
+		},
+		GetEmailActionFunc: &CodeMonitorStoreGetEmailActionFunc{
+			defaultHook: i.GetEmailAction,
 		},
 		GetEventsForQueryIDInt64Func: &CodeMonitorStoreGetEventsForQueryIDInt64Func{
 			defaultHook: i.GetEventsForQueryIDInt64,
@@ -485,9 +488,6 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 		ToggleMonitorFunc: &CodeMonitorStoreToggleMonitorFunc{
 			defaultHook: i.ToggleMonitor,
 		},
-		TotalCountActionEmailsFunc: &CodeMonitorStoreTotalCountActionEmailsFunc{
-			defaultHook: i.TotalCountActionEmails,
-		},
 		TotalCountEventsForQueryIDInt64Func: &CodeMonitorStoreTotalCountEventsForQueryIDInt64Func{
 			defaultHook: i.TotalCountEventsForQueryIDInt64,
 		},
@@ -503,7 +503,7 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 		TriggerQueryByMonitorIDInt64Func: &CodeMonitorStoreTriggerQueryByMonitorIDInt64Func{
 			defaultHook: i.TriggerQueryByMonitorIDInt64,
 		},
-		UpdateActionEmailFunc: &CodeMonitorStoreUpdateActionEmailFunc{
+		UpdateEmailActionFunc: &CodeMonitorStoreUpdateEmailActionFunc{
 			defaultHook: i.UpdateEmailAction,
 		},
 		UpdateMonitorFunc: &CodeMonitorStoreUpdateMonitorFunc{
@@ -513,231 +513,6 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 			defaultHook: i.UpdateTriggerQuery,
 		},
 	}
-}
-
-// CodeMonitorStoreActionEmailByIDInt64Func describes the behavior when the
-// ActionEmailByIDInt64 method of the parent MockCodeMonitorStore instance
-// is invoked.
-type CodeMonitorStoreActionEmailByIDInt64Func struct {
-	defaultHook func(context.Context, int64) (*MonitorEmail, error)
-	hooks       []func(context.Context, int64) (*MonitorEmail, error)
-	history     []CodeMonitorStoreActionEmailByIDInt64FuncCall
-	mutex       sync.Mutex
-}
-
-// ActionEmailByIDInt64 delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) ActionEmailByIDInt64(v0 context.Context, v1 int64) (*MonitorEmail, error) {
-	r0, r1 := m.ActionEmailByIDInt64Func.nextHook()(v0, v1)
-	m.ActionEmailByIDInt64Func.appendCall(CodeMonitorStoreActionEmailByIDInt64FuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the ActionEmailByIDInt64
-// method of the parent MockCodeMonitorStore instance is invoked and the
-// hook queue is empty.
-func (f *CodeMonitorStoreActionEmailByIDInt64Func) SetDefaultHook(hook func(context.Context, int64) (*MonitorEmail, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// ActionEmailByIDInt64 method of the parent MockCodeMonitorStore instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *CodeMonitorStoreActionEmailByIDInt64Func) PushHook(hook func(context.Context, int64) (*MonitorEmail, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
-// the given values.
-func (f *CodeMonitorStoreActionEmailByIDInt64Func) SetDefaultReturn(r0 *MonitorEmail, r1 error) {
-	f.SetDefaultHook(func(context.Context, int64) (*MonitorEmail, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushDefaultHook with a function that returns the given
-// values.
-func (f *CodeMonitorStoreActionEmailByIDInt64Func) PushReturn(r0 *MonitorEmail, r1 error) {
-	f.PushHook(func(context.Context, int64) (*MonitorEmail, error) {
-		return r0, r1
-	})
-}
-
-func (f *CodeMonitorStoreActionEmailByIDInt64Func) nextHook() func(context.Context, int64) (*MonitorEmail, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *CodeMonitorStoreActionEmailByIDInt64Func) appendCall(r0 CodeMonitorStoreActionEmailByIDInt64FuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// CodeMonitorStoreActionEmailByIDInt64FuncCall objects describing the
-// invocations of this function.
-func (f *CodeMonitorStoreActionEmailByIDInt64Func) History() []CodeMonitorStoreActionEmailByIDInt64FuncCall {
-	f.mutex.Lock()
-	history := make([]CodeMonitorStoreActionEmailByIDInt64FuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// CodeMonitorStoreActionEmailByIDInt64FuncCall is an object that describes
-// an invocation of method ActionEmailByIDInt64 on an instance of
-// MockCodeMonitorStore.
-type CodeMonitorStoreActionEmailByIDInt64FuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int64
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 *MonitorEmail
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c CodeMonitorStoreActionEmailByIDInt64FuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c CodeMonitorStoreActionEmailByIDInt64FuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// CodeMonitorStoreActionJobForIDIntFunc describes the behavior when the
-// ActionJobForIDInt method of the parent MockCodeMonitorStore instance is
-// invoked.
-type CodeMonitorStoreActionJobForIDIntFunc struct {
-	defaultHook func(context.Context, int) (*ActionJob, error)
-	hooks       []func(context.Context, int) (*ActionJob, error)
-	history     []CodeMonitorStoreActionJobForIDIntFuncCall
-	mutex       sync.Mutex
-}
-
-// ActionJobForIDInt delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) ActionJobForIDInt(v0 context.Context, v1 int) (*ActionJob, error) {
-	r0, r1 := m.ActionJobForIDIntFunc.nextHook()(v0, v1)
-	m.ActionJobForIDIntFunc.appendCall(CodeMonitorStoreActionJobForIDIntFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the ActionJobForIDInt
-// method of the parent MockCodeMonitorStore instance is invoked and the
-// hook queue is empty.
-func (f *CodeMonitorStoreActionJobForIDIntFunc) SetDefaultHook(hook func(context.Context, int) (*ActionJob, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// ActionJobForIDInt method of the parent MockCodeMonitorStore instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *CodeMonitorStoreActionJobForIDIntFunc) PushHook(hook func(context.Context, int) (*ActionJob, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
-// the given values.
-func (f *CodeMonitorStoreActionJobForIDIntFunc) SetDefaultReturn(r0 *ActionJob, r1 error) {
-	f.SetDefaultHook(func(context.Context, int) (*ActionJob, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushDefaultHook with a function that returns the given
-// values.
-func (f *CodeMonitorStoreActionJobForIDIntFunc) PushReturn(r0 *ActionJob, r1 error) {
-	f.PushHook(func(context.Context, int) (*ActionJob, error) {
-		return r0, r1
-	})
-}
-
-func (f *CodeMonitorStoreActionJobForIDIntFunc) nextHook() func(context.Context, int) (*ActionJob, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *CodeMonitorStoreActionJobForIDIntFunc) appendCall(r0 CodeMonitorStoreActionJobForIDIntFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of CodeMonitorStoreActionJobForIDIntFuncCall
-// objects describing the invocations of this function.
-func (f *CodeMonitorStoreActionJobForIDIntFunc) History() []CodeMonitorStoreActionJobForIDIntFuncCall {
-	f.mutex.Lock()
-	history := make([]CodeMonitorStoreActionJobForIDIntFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// CodeMonitorStoreActionJobForIDIntFuncCall is an object that describes an
-// invocation of method ActionJobForIDInt on an instance of
-// MockCodeMonitorStore.
-type CodeMonitorStoreActionJobForIDIntFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 *ActionJob
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c CodeMonitorStoreActionJobForIDIntFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c CodeMonitorStoreActionJobForIDIntFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
 }
 
 // CodeMonitorStoreAllRecipientsForEmailIDInt64Func describes the behavior
@@ -1065,37 +840,37 @@ func (c CodeMonitorStoreCountActionJobsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// CodeMonitorStoreCreateActionEmailFunc describes the behavior when the
-// CreateActionEmail method of the parent MockCodeMonitorStore instance is
+// CodeMonitorStoreCountEmailActionsFunc describes the behavior when the
+// CountEmailActions method of the parent MockCodeMonitorStore instance is
 // invoked.
-type CodeMonitorStoreCreateActionEmailFunc struct {
-	defaultHook func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*MonitorEmail, error)
-	hooks       []func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*MonitorEmail, error)
-	history     []CodeMonitorStoreCreateActionEmailFuncCall
+type CodeMonitorStoreCountEmailActionsFunc struct {
+	defaultHook func(context.Context, int64) (int32, error)
+	hooks       []func(context.Context, int64) (int32, error)
+	history     []CodeMonitorStoreCountEmailActionsFuncCall
 	mutex       sync.Mutex
 }
 
-// CreateActionEmail delegates to the next hook function in the queue and
+// CountEmailActions delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) CreateActionEmail(v0 context.Context, v1 int64, v2 *graphqlbackend.CreateActionArgs) (*MonitorEmail, error) {
-	r0, r1 := m.CreateActionEmailFunc.nextHook()(v0, v1, v2)
-	m.CreateActionEmailFunc.appendCall(CodeMonitorStoreCreateActionEmailFuncCall{v0, v1, v2, r0, r1})
+func (m *MockCodeMonitorStore) CountEmailActions(v0 context.Context, v1 int64) (int32, error) {
+	r0, r1 := m.CountEmailActionsFunc.nextHook()(v0, v1)
+	m.CountEmailActionsFunc.appendCall(CodeMonitorStoreCountEmailActionsFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
-// SetDefaultHook sets function that is called when the CreateActionEmail
+// SetDefaultHook sets function that is called when the CountEmailActions
 // method of the parent MockCodeMonitorStore instance is invoked and the
 // hook queue is empty.
-func (f *CodeMonitorStoreCreateActionEmailFunc) SetDefaultHook(hook func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*MonitorEmail, error)) {
+func (f *CodeMonitorStoreCountEmailActionsFunc) SetDefaultHook(hook func(context.Context, int64) (int32, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// CreateActionEmail method of the parent MockCodeMonitorStore instance
+// CountEmailActions method of the parent MockCodeMonitorStore instance
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *CodeMonitorStoreCreateActionEmailFunc) PushHook(hook func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*MonitorEmail, error)) {
+func (f *CodeMonitorStoreCountEmailActionsFunc) PushHook(hook func(context.Context, int64) (int32, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1103,21 +878,21 @@ func (f *CodeMonitorStoreCreateActionEmailFunc) PushHook(hook func(context.Conte
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *CodeMonitorStoreCreateActionEmailFunc) SetDefaultReturn(r0 *MonitorEmail, r1 error) {
-	f.SetDefaultHook(func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*MonitorEmail, error) {
+func (f *CodeMonitorStoreCountEmailActionsFunc) SetDefaultReturn(r0 int32, r1 error) {
+	f.SetDefaultHook(func(context.Context, int64) (int32, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *CodeMonitorStoreCreateActionEmailFunc) PushReturn(r0 *MonitorEmail, r1 error) {
-	f.PushHook(func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*MonitorEmail, error) {
+func (f *CodeMonitorStoreCountEmailActionsFunc) PushReturn(r0 int32, r1 error) {
+	f.PushHook(func(context.Context, int64) (int32, error) {
 		return r0, r1
 	})
 }
 
-func (f *CodeMonitorStoreCreateActionEmailFunc) nextHook() func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*MonitorEmail, error) {
+func (f *CodeMonitorStoreCountEmailActionsFunc) nextHook() func(context.Context, int64) (int32, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1130,39 +905,36 @@ func (f *CodeMonitorStoreCreateActionEmailFunc) nextHook() func(context.Context,
 	return hook
 }
 
-func (f *CodeMonitorStoreCreateActionEmailFunc) appendCall(r0 CodeMonitorStoreCreateActionEmailFuncCall) {
+func (f *CodeMonitorStoreCountEmailActionsFunc) appendCall(r0 CodeMonitorStoreCountEmailActionsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of CodeMonitorStoreCreateActionEmailFuncCall
+// History returns a sequence of CodeMonitorStoreCountEmailActionsFuncCall
 // objects describing the invocations of this function.
-func (f *CodeMonitorStoreCreateActionEmailFunc) History() []CodeMonitorStoreCreateActionEmailFuncCall {
+func (f *CodeMonitorStoreCountEmailActionsFunc) History() []CodeMonitorStoreCountEmailActionsFuncCall {
 	f.mutex.Lock()
-	history := make([]CodeMonitorStoreCreateActionEmailFuncCall, len(f.history))
+	history := make([]CodeMonitorStoreCountEmailActionsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// CodeMonitorStoreCreateActionEmailFuncCall is an object that describes an
-// invocation of method CreateActionEmail on an instance of
+// CodeMonitorStoreCountEmailActionsFuncCall is an object that describes an
+// invocation of method CountEmailActions on an instance of
 // MockCodeMonitorStore.
-type CodeMonitorStoreCreateActionEmailFuncCall struct {
+type CodeMonitorStoreCountEmailActionsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
 	Arg1 int64
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 *graphqlbackend.CreateActionArgs
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *MonitorEmail
+	Result0 int32
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -1170,13 +942,13 @@ type CodeMonitorStoreCreateActionEmailFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c CodeMonitorStoreCreateActionEmailFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c CodeMonitorStoreCountEmailActionsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c CodeMonitorStoreCreateActionEmailFuncCall) Results() []interface{} {
+func (c CodeMonitorStoreCountEmailActionsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -1400,6 +1172,121 @@ func (c CodeMonitorStoreCreateCodeMonitorFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c CodeMonitorStoreCreateCodeMonitorFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// CodeMonitorStoreCreateEmailActionFunc describes the behavior when the
+// CreateEmailAction method of the parent MockCodeMonitorStore instance is
+// invoked.
+type CodeMonitorStoreCreateEmailActionFunc struct {
+	defaultHook func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*MonitorEmail, error)
+	hooks       []func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*MonitorEmail, error)
+	history     []CodeMonitorStoreCreateEmailActionFuncCall
+	mutex       sync.Mutex
+}
+
+// CreateEmailAction delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockCodeMonitorStore) CreateEmailAction(v0 context.Context, v1 int64, v2 *graphqlbackend.CreateActionArgs) (*MonitorEmail, error) {
+	r0, r1 := m.CreateEmailActionFunc.nextHook()(v0, v1, v2)
+	m.CreateEmailActionFunc.appendCall(CodeMonitorStoreCreateEmailActionFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the CreateEmailAction
+// method of the parent MockCodeMonitorStore instance is invoked and the
+// hook queue is empty.
+func (f *CodeMonitorStoreCreateEmailActionFunc) SetDefaultHook(hook func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*MonitorEmail, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// CreateEmailAction method of the parent MockCodeMonitorStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *CodeMonitorStoreCreateEmailActionFunc) PushHook(hook func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*MonitorEmail, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *CodeMonitorStoreCreateEmailActionFunc) SetDefaultReturn(r0 *MonitorEmail, r1 error) {
+	f.SetDefaultHook(func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*MonitorEmail, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *CodeMonitorStoreCreateEmailActionFunc) PushReturn(r0 *MonitorEmail, r1 error) {
+	f.PushHook(func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*MonitorEmail, error) {
+		return r0, r1
+	})
+}
+
+func (f *CodeMonitorStoreCreateEmailActionFunc) nextHook() func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*MonitorEmail, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *CodeMonitorStoreCreateEmailActionFunc) appendCall(r0 CodeMonitorStoreCreateEmailActionFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of CodeMonitorStoreCreateEmailActionFuncCall
+// objects describing the invocations of this function.
+func (f *CodeMonitorStoreCreateEmailActionFunc) History() []CodeMonitorStoreCreateEmailActionFuncCall {
+	f.mutex.Lock()
+	history := make([]CodeMonitorStoreCreateEmailActionFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// CodeMonitorStoreCreateEmailActionFuncCall is an object that describes an
+// invocation of method CreateEmailAction on an instance of
+// MockCodeMonitorStore.
+type CodeMonitorStoreCreateEmailActionFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int64
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 *graphqlbackend.CreateActionArgs
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 *MonitorEmail
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c CodeMonitorStoreCreateEmailActionFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c CodeMonitorStoreCreateEmailActionFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -1738,37 +1625,37 @@ func (c CodeMonitorStoreCreateTriggerQueryFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
-// CodeMonitorStoreDeleteActionsInt64Func describes the behavior when the
-// DeleteActionsInt64 method of the parent MockCodeMonitorStore instance is
+// CodeMonitorStoreDeleteEmailActionsFunc describes the behavior when the
+// DeleteEmailActions method of the parent MockCodeMonitorStore instance is
 // invoked.
-type CodeMonitorStoreDeleteActionsInt64Func struct {
+type CodeMonitorStoreDeleteEmailActionsFunc struct {
 	defaultHook func(context.Context, []int64, int64) error
 	hooks       []func(context.Context, []int64, int64) error
-	history     []CodeMonitorStoreDeleteActionsInt64FuncCall
+	history     []CodeMonitorStoreDeleteEmailActionsFuncCall
 	mutex       sync.Mutex
 }
 
-// DeleteActionsInt64 delegates to the next hook function in the queue and
+// DeleteEmailActions delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) DeleteActionsInt64(v0 context.Context, v1 []int64, v2 int64) error {
-	r0 := m.DeleteActionsInt64Func.nextHook()(v0, v1, v2)
-	m.DeleteActionsInt64Func.appendCall(CodeMonitorStoreDeleteActionsInt64FuncCall{v0, v1, v2, r0})
+func (m *MockCodeMonitorStore) DeleteEmailActions(v0 context.Context, v1 []int64, v2 int64) error {
+	r0 := m.DeleteEmailActionsFunc.nextHook()(v0, v1, v2)
+	m.DeleteEmailActionsFunc.appendCall(CodeMonitorStoreDeleteEmailActionsFuncCall{v0, v1, v2, r0})
 	return r0
 }
 
-// SetDefaultHook sets function that is called when the DeleteActionsInt64
+// SetDefaultHook sets function that is called when the DeleteEmailActions
 // method of the parent MockCodeMonitorStore instance is invoked and the
 // hook queue is empty.
-func (f *CodeMonitorStoreDeleteActionsInt64Func) SetDefaultHook(hook func(context.Context, []int64, int64) error) {
+func (f *CodeMonitorStoreDeleteEmailActionsFunc) SetDefaultHook(hook func(context.Context, []int64, int64) error) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// DeleteActionsInt64 method of the parent MockCodeMonitorStore instance
+// DeleteEmailActions method of the parent MockCodeMonitorStore instance
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *CodeMonitorStoreDeleteActionsInt64Func) PushHook(hook func(context.Context, []int64, int64) error) {
+func (f *CodeMonitorStoreDeleteEmailActionsFunc) PushHook(hook func(context.Context, []int64, int64) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1776,7 +1663,7 @@ func (f *CodeMonitorStoreDeleteActionsInt64Func) PushHook(hook func(context.Cont
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *CodeMonitorStoreDeleteActionsInt64Func) SetDefaultReturn(r0 error) {
+func (f *CodeMonitorStoreDeleteEmailActionsFunc) SetDefaultReturn(r0 error) {
 	f.SetDefaultHook(func(context.Context, []int64, int64) error {
 		return r0
 	})
@@ -1784,13 +1671,13 @@ func (f *CodeMonitorStoreDeleteActionsInt64Func) SetDefaultReturn(r0 error) {
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *CodeMonitorStoreDeleteActionsInt64Func) PushReturn(r0 error) {
+func (f *CodeMonitorStoreDeleteEmailActionsFunc) PushReturn(r0 error) {
 	f.PushHook(func(context.Context, []int64, int64) error {
 		return r0
 	})
 }
 
-func (f *CodeMonitorStoreDeleteActionsInt64Func) nextHook() func(context.Context, []int64, int64) error {
+func (f *CodeMonitorStoreDeleteEmailActionsFunc) nextHook() func(context.Context, []int64, int64) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1803,27 +1690,27 @@ func (f *CodeMonitorStoreDeleteActionsInt64Func) nextHook() func(context.Context
 	return hook
 }
 
-func (f *CodeMonitorStoreDeleteActionsInt64Func) appendCall(r0 CodeMonitorStoreDeleteActionsInt64FuncCall) {
+func (f *CodeMonitorStoreDeleteEmailActionsFunc) appendCall(r0 CodeMonitorStoreDeleteEmailActionsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of CodeMonitorStoreDeleteActionsInt64FuncCall
+// History returns a sequence of CodeMonitorStoreDeleteEmailActionsFuncCall
 // objects describing the invocations of this function.
-func (f *CodeMonitorStoreDeleteActionsInt64Func) History() []CodeMonitorStoreDeleteActionsInt64FuncCall {
+func (f *CodeMonitorStoreDeleteEmailActionsFunc) History() []CodeMonitorStoreDeleteEmailActionsFuncCall {
 	f.mutex.Lock()
-	history := make([]CodeMonitorStoreDeleteActionsInt64FuncCall, len(f.history))
+	history := make([]CodeMonitorStoreDeleteEmailActionsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// CodeMonitorStoreDeleteActionsInt64FuncCall is an object that describes an
-// invocation of method DeleteActionsInt64 on an instance of
+// CodeMonitorStoreDeleteEmailActionsFuncCall is an object that describes an
+// invocation of method DeleteEmailActions on an instance of
 // MockCodeMonitorStore.
-type CodeMonitorStoreDeleteActionsInt64FuncCall struct {
+type CodeMonitorStoreDeleteEmailActionsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -1840,13 +1727,13 @@ type CodeMonitorStoreDeleteActionsInt64FuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c CodeMonitorStoreDeleteActionsInt64FuncCall) Args() []interface{} {
+func (c CodeMonitorStoreDeleteEmailActionsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c CodeMonitorStoreDeleteActionsInt64FuncCall) Results() []interface{} {
+func (c CodeMonitorStoreDeleteEmailActionsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
@@ -2712,6 +2599,116 @@ func (c CodeMonitorStoreExecFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
+// CodeMonitorStoreGetActionJobFunc describes the behavior when the
+// GetActionJob method of the parent MockCodeMonitorStore instance is
+// invoked.
+type CodeMonitorStoreGetActionJobFunc struct {
+	defaultHook func(context.Context, int) (*ActionJob, error)
+	hooks       []func(context.Context, int) (*ActionJob, error)
+	history     []CodeMonitorStoreGetActionJobFuncCall
+	mutex       sync.Mutex
+}
+
+// GetActionJob delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockCodeMonitorStore) GetActionJob(v0 context.Context, v1 int) (*ActionJob, error) {
+	r0, r1 := m.GetActionJobFunc.nextHook()(v0, v1)
+	m.GetActionJobFunc.appendCall(CodeMonitorStoreGetActionJobFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the GetActionJob method
+// of the parent MockCodeMonitorStore instance is invoked and the hook queue
+// is empty.
+func (f *CodeMonitorStoreGetActionJobFunc) SetDefaultHook(hook func(context.Context, int) (*ActionJob, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetActionJob method of the parent MockCodeMonitorStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *CodeMonitorStoreGetActionJobFunc) PushHook(hook func(context.Context, int) (*ActionJob, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *CodeMonitorStoreGetActionJobFunc) SetDefaultReturn(r0 *ActionJob, r1 error) {
+	f.SetDefaultHook(func(context.Context, int) (*ActionJob, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *CodeMonitorStoreGetActionJobFunc) PushReturn(r0 *ActionJob, r1 error) {
+	f.PushHook(func(context.Context, int) (*ActionJob, error) {
+		return r0, r1
+	})
+}
+
+func (f *CodeMonitorStoreGetActionJobFunc) nextHook() func(context.Context, int) (*ActionJob, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *CodeMonitorStoreGetActionJobFunc) appendCall(r0 CodeMonitorStoreGetActionJobFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of CodeMonitorStoreGetActionJobFuncCall
+// objects describing the invocations of this function.
+func (f *CodeMonitorStoreGetActionJobFunc) History() []CodeMonitorStoreGetActionJobFuncCall {
+	f.mutex.Lock()
+	history := make([]CodeMonitorStoreGetActionJobFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// CodeMonitorStoreGetActionJobFuncCall is an object that describes an
+// invocation of method GetActionJob on an instance of MockCodeMonitorStore.
+type CodeMonitorStoreGetActionJobFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 *ActionJob
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c CodeMonitorStoreGetActionJobFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c CodeMonitorStoreGetActionJobFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
 // CodeMonitorStoreGetActionJobMetadataFunc describes the behavior when the
 // GetActionJobMetadata method of the parent MockCodeMonitorStore instance
 // is invoked.
@@ -2822,6 +2819,117 @@ func (c CodeMonitorStoreGetActionJobMetadataFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c CodeMonitorStoreGetActionJobMetadataFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// CodeMonitorStoreGetEmailActionFunc describes the behavior when the
+// GetEmailAction method of the parent MockCodeMonitorStore instance is
+// invoked.
+type CodeMonitorStoreGetEmailActionFunc struct {
+	defaultHook func(context.Context, int64) (*MonitorEmail, error)
+	hooks       []func(context.Context, int64) (*MonitorEmail, error)
+	history     []CodeMonitorStoreGetEmailActionFuncCall
+	mutex       sync.Mutex
+}
+
+// GetEmailAction delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockCodeMonitorStore) GetEmailAction(v0 context.Context, v1 int64) (*MonitorEmail, error) {
+	r0, r1 := m.GetEmailActionFunc.nextHook()(v0, v1)
+	m.GetEmailActionFunc.appendCall(CodeMonitorStoreGetEmailActionFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the GetEmailAction
+// method of the parent MockCodeMonitorStore instance is invoked and the
+// hook queue is empty.
+func (f *CodeMonitorStoreGetEmailActionFunc) SetDefaultHook(hook func(context.Context, int64) (*MonitorEmail, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetEmailAction method of the parent MockCodeMonitorStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *CodeMonitorStoreGetEmailActionFunc) PushHook(hook func(context.Context, int64) (*MonitorEmail, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *CodeMonitorStoreGetEmailActionFunc) SetDefaultReturn(r0 *MonitorEmail, r1 error) {
+	f.SetDefaultHook(func(context.Context, int64) (*MonitorEmail, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *CodeMonitorStoreGetEmailActionFunc) PushReturn(r0 *MonitorEmail, r1 error) {
+	f.PushHook(func(context.Context, int64) (*MonitorEmail, error) {
+		return r0, r1
+	})
+}
+
+func (f *CodeMonitorStoreGetEmailActionFunc) nextHook() func(context.Context, int64) (*MonitorEmail, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *CodeMonitorStoreGetEmailActionFunc) appendCall(r0 CodeMonitorStoreGetEmailActionFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of CodeMonitorStoreGetEmailActionFuncCall
+// objects describing the invocations of this function.
+func (f *CodeMonitorStoreGetEmailActionFunc) History() []CodeMonitorStoreGetEmailActionFuncCall {
+	f.mutex.Lock()
+	history := make([]CodeMonitorStoreGetEmailActionFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// CodeMonitorStoreGetEmailActionFuncCall is an object that describes an
+// invocation of method GetEmailAction on an instance of
+// MockCodeMonitorStore.
+type CodeMonitorStoreGetEmailActionFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int64
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 *MonitorEmail
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c CodeMonitorStoreGetEmailActionFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c CodeMonitorStoreGetEmailActionFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -4262,119 +4370,6 @@ func (c CodeMonitorStoreToggleMonitorFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// CodeMonitorStoreTotalCountActionEmailsFunc describes the behavior when
-// the TotalCountActionEmails method of the parent MockCodeMonitorStore
-// instance is invoked.
-type CodeMonitorStoreTotalCountActionEmailsFunc struct {
-	defaultHook func(context.Context, int64) (int32, error)
-	hooks       []func(context.Context, int64) (int32, error)
-	history     []CodeMonitorStoreTotalCountActionEmailsFuncCall
-	mutex       sync.Mutex
-}
-
-// TotalCountActionEmails delegates to the next hook function in the queue
-// and stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) TotalCountActionEmails(v0 context.Context, v1 int64) (int32, error) {
-	r0, r1 := m.TotalCountActionEmailsFunc.nextHook()(v0, v1)
-	m.TotalCountActionEmailsFunc.appendCall(CodeMonitorStoreTotalCountActionEmailsFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// TotalCountActionEmails method of the parent MockCodeMonitorStore instance
-// is invoked and the hook queue is empty.
-func (f *CodeMonitorStoreTotalCountActionEmailsFunc) SetDefaultHook(hook func(context.Context, int64) (int32, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// TotalCountActionEmails method of the parent MockCodeMonitorStore instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *CodeMonitorStoreTotalCountActionEmailsFunc) PushHook(hook func(context.Context, int64) (int32, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
-// the given values.
-func (f *CodeMonitorStoreTotalCountActionEmailsFunc) SetDefaultReturn(r0 int32, r1 error) {
-	f.SetDefaultHook(func(context.Context, int64) (int32, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushDefaultHook with a function that returns the given
-// values.
-func (f *CodeMonitorStoreTotalCountActionEmailsFunc) PushReturn(r0 int32, r1 error) {
-	f.PushHook(func(context.Context, int64) (int32, error) {
-		return r0, r1
-	})
-}
-
-func (f *CodeMonitorStoreTotalCountActionEmailsFunc) nextHook() func(context.Context, int64) (int32, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *CodeMonitorStoreTotalCountActionEmailsFunc) appendCall(r0 CodeMonitorStoreTotalCountActionEmailsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// CodeMonitorStoreTotalCountActionEmailsFuncCall objects describing the
-// invocations of this function.
-func (f *CodeMonitorStoreTotalCountActionEmailsFunc) History() []CodeMonitorStoreTotalCountActionEmailsFuncCall {
-	f.mutex.Lock()
-	history := make([]CodeMonitorStoreTotalCountActionEmailsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// CodeMonitorStoreTotalCountActionEmailsFuncCall is an object that
-// describes an invocation of method TotalCountActionEmails on an instance
-// of MockCodeMonitorStore.
-type CodeMonitorStoreTotalCountActionEmailsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int64
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 int32
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c CodeMonitorStoreTotalCountActionEmailsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c CodeMonitorStoreTotalCountActionEmailsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
 // CodeMonitorStoreTotalCountEventsForQueryIDInt64Func describes the
 // behavior when the TotalCountEventsForQueryIDInt64 method of the parent
 // MockCodeMonitorStore instance is invoked.
@@ -4932,37 +4927,37 @@ func (c CodeMonitorStoreTriggerQueryByMonitorIDInt64FuncCall) Results() []interf
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// CodeMonitorStoreUpdateActionEmailFunc describes the behavior when the
-// UpdateActionEmail method of the parent MockCodeMonitorStore instance is
+// CodeMonitorStoreUpdateEmailActionFunc describes the behavior when the
+// UpdateEmailAction method of the parent MockCodeMonitorStore instance is
 // invoked.
-type CodeMonitorStoreUpdateActionEmailFunc struct {
+type CodeMonitorStoreUpdateEmailActionFunc struct {
 	defaultHook func(context.Context, int64, *graphqlbackend.EditActionArgs) (*MonitorEmail, error)
 	hooks       []func(context.Context, int64, *graphqlbackend.EditActionArgs) (*MonitorEmail, error)
-	history     []CodeMonitorStoreUpdateActionEmailFuncCall
+	history     []CodeMonitorStoreUpdateEmailActionFuncCall
 	mutex       sync.Mutex
 }
 
-// UpdateActionEmail delegates to the next hook function in the queue and
+// UpdateEmailAction delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) UpdateActionEmail(v0 context.Context, v1 int64, v2 *graphqlbackend.EditActionArgs) (*MonitorEmail, error) {
-	r0, r1 := m.UpdateActionEmailFunc.nextHook()(v0, v1, v2)
-	m.UpdateActionEmailFunc.appendCall(CodeMonitorStoreUpdateActionEmailFuncCall{v0, v1, v2, r0, r1})
+func (m *MockCodeMonitorStore) UpdateEmailAction(v0 context.Context, v1 int64, v2 *graphqlbackend.EditActionArgs) (*MonitorEmail, error) {
+	r0, r1 := m.UpdateEmailActionFunc.nextHook()(v0, v1, v2)
+	m.UpdateEmailActionFunc.appendCall(CodeMonitorStoreUpdateEmailActionFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
 }
 
-// SetDefaultHook sets function that is called when the UpdateActionEmail
+// SetDefaultHook sets function that is called when the UpdateEmailAction
 // method of the parent MockCodeMonitorStore instance is invoked and the
 // hook queue is empty.
-func (f *CodeMonitorStoreUpdateActionEmailFunc) SetDefaultHook(hook func(context.Context, int64, *graphqlbackend.EditActionArgs) (*MonitorEmail, error)) {
+func (f *CodeMonitorStoreUpdateEmailActionFunc) SetDefaultHook(hook func(context.Context, int64, *graphqlbackend.EditActionArgs) (*MonitorEmail, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// UpdateActionEmail method of the parent MockCodeMonitorStore instance
+// UpdateEmailAction method of the parent MockCodeMonitorStore instance
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *CodeMonitorStoreUpdateActionEmailFunc) PushHook(hook func(context.Context, int64, *graphqlbackend.EditActionArgs) (*MonitorEmail, error)) {
+func (f *CodeMonitorStoreUpdateEmailActionFunc) PushHook(hook func(context.Context, int64, *graphqlbackend.EditActionArgs) (*MonitorEmail, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -4970,7 +4965,7 @@ func (f *CodeMonitorStoreUpdateActionEmailFunc) PushHook(hook func(context.Conte
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *CodeMonitorStoreUpdateActionEmailFunc) SetDefaultReturn(r0 *MonitorEmail, r1 error) {
+func (f *CodeMonitorStoreUpdateEmailActionFunc) SetDefaultReturn(r0 *MonitorEmail, r1 error) {
 	f.SetDefaultHook(func(context.Context, int64, *graphqlbackend.EditActionArgs) (*MonitorEmail, error) {
 		return r0, r1
 	})
@@ -4978,13 +4973,13 @@ func (f *CodeMonitorStoreUpdateActionEmailFunc) SetDefaultReturn(r0 *MonitorEmai
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *CodeMonitorStoreUpdateActionEmailFunc) PushReturn(r0 *MonitorEmail, r1 error) {
+func (f *CodeMonitorStoreUpdateEmailActionFunc) PushReturn(r0 *MonitorEmail, r1 error) {
 	f.PushHook(func(context.Context, int64, *graphqlbackend.EditActionArgs) (*MonitorEmail, error) {
 		return r0, r1
 	})
 }
 
-func (f *CodeMonitorStoreUpdateActionEmailFunc) nextHook() func(context.Context, int64, *graphqlbackend.EditActionArgs) (*MonitorEmail, error) {
+func (f *CodeMonitorStoreUpdateEmailActionFunc) nextHook() func(context.Context, int64, *graphqlbackend.EditActionArgs) (*MonitorEmail, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -4997,27 +4992,27 @@ func (f *CodeMonitorStoreUpdateActionEmailFunc) nextHook() func(context.Context,
 	return hook
 }
 
-func (f *CodeMonitorStoreUpdateActionEmailFunc) appendCall(r0 CodeMonitorStoreUpdateActionEmailFuncCall) {
+func (f *CodeMonitorStoreUpdateEmailActionFunc) appendCall(r0 CodeMonitorStoreUpdateEmailActionFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of CodeMonitorStoreUpdateActionEmailFuncCall
+// History returns a sequence of CodeMonitorStoreUpdateEmailActionFuncCall
 // objects describing the invocations of this function.
-func (f *CodeMonitorStoreUpdateActionEmailFunc) History() []CodeMonitorStoreUpdateActionEmailFuncCall {
+func (f *CodeMonitorStoreUpdateEmailActionFunc) History() []CodeMonitorStoreUpdateEmailActionFuncCall {
 	f.mutex.Lock()
-	history := make([]CodeMonitorStoreUpdateActionEmailFuncCall, len(f.history))
+	history := make([]CodeMonitorStoreUpdateEmailActionFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// CodeMonitorStoreUpdateActionEmailFuncCall is an object that describes an
-// invocation of method UpdateActionEmail on an instance of
+// CodeMonitorStoreUpdateEmailActionFuncCall is an object that describes an
+// invocation of method UpdateEmailAction on an instance of
 // MockCodeMonitorStore.
-type CodeMonitorStoreUpdateActionEmailFuncCall struct {
+type CodeMonitorStoreUpdateEmailActionFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -5037,13 +5032,13 @@ type CodeMonitorStoreUpdateActionEmailFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c CodeMonitorStoreUpdateActionEmailFuncCall) Args() []interface{} {
+func (c CodeMonitorStoreUpdateEmailActionFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c CodeMonitorStoreUpdateActionEmailFuncCall) Results() []interface{} {
+func (c CodeMonitorStoreUpdateEmailActionFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -281,7 +281,7 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		GetQueryByRecordIDFunc: &CodeMonitorStoreGetQueryByRecordIDFunc{
-			defaultHook: func(context.Context, int) (*MonitorQuery, error) {
+			defaultHook: func(context.Context, int) (*QueryTrigger, error) {
 				return nil, nil
 			},
 		},
@@ -356,7 +356,7 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		TriggerQueryByMonitorIDInt64Func: &CodeMonitorStoreTriggerQueryByMonitorIDInt64Func{
-			defaultHook: func(context.Context, int64) (*MonitorQuery, error) {
+			defaultHook: func(context.Context, int64) (*QueryTrigger, error) {
 				return nil, nil
 			},
 		},
@@ -3162,15 +3162,15 @@ func (c CodeMonitorStoreGetMonitorFuncCall) Results() []interface{} {
 // GetQueryByRecordID method of the parent MockCodeMonitorStore instance is
 // invoked.
 type CodeMonitorStoreGetQueryByRecordIDFunc struct {
-	defaultHook func(context.Context, int) (*MonitorQuery, error)
-	hooks       []func(context.Context, int) (*MonitorQuery, error)
+	defaultHook func(context.Context, int) (*QueryTrigger, error)
+	hooks       []func(context.Context, int) (*QueryTrigger, error)
 	history     []CodeMonitorStoreGetQueryByRecordIDFuncCall
 	mutex       sync.Mutex
 }
 
 // GetQueryByRecordID delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) GetQueryByRecordID(v0 context.Context, v1 int) (*MonitorQuery, error) {
+func (m *MockCodeMonitorStore) GetQueryByRecordID(v0 context.Context, v1 int) (*QueryTrigger, error) {
 	r0, r1 := m.GetQueryByRecordIDFunc.nextHook()(v0, v1)
 	m.GetQueryByRecordIDFunc.appendCall(CodeMonitorStoreGetQueryByRecordIDFuncCall{v0, v1, r0, r1})
 	return r0, r1
@@ -3179,7 +3179,7 @@ func (m *MockCodeMonitorStore) GetQueryByRecordID(v0 context.Context, v1 int) (*
 // SetDefaultHook sets function that is called when the GetQueryByRecordID
 // method of the parent MockCodeMonitorStore instance is invoked and the
 // hook queue is empty.
-func (f *CodeMonitorStoreGetQueryByRecordIDFunc) SetDefaultHook(hook func(context.Context, int) (*MonitorQuery, error)) {
+func (f *CodeMonitorStoreGetQueryByRecordIDFunc) SetDefaultHook(hook func(context.Context, int) (*QueryTrigger, error)) {
 	f.defaultHook = hook
 }
 
@@ -3188,7 +3188,7 @@ func (f *CodeMonitorStoreGetQueryByRecordIDFunc) SetDefaultHook(hook func(contex
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *CodeMonitorStoreGetQueryByRecordIDFunc) PushHook(hook func(context.Context, int) (*MonitorQuery, error)) {
+func (f *CodeMonitorStoreGetQueryByRecordIDFunc) PushHook(hook func(context.Context, int) (*QueryTrigger, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3196,21 +3196,21 @@ func (f *CodeMonitorStoreGetQueryByRecordIDFunc) PushHook(hook func(context.Cont
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *CodeMonitorStoreGetQueryByRecordIDFunc) SetDefaultReturn(r0 *MonitorQuery, r1 error) {
-	f.SetDefaultHook(func(context.Context, int) (*MonitorQuery, error) {
+func (f *CodeMonitorStoreGetQueryByRecordIDFunc) SetDefaultReturn(r0 *QueryTrigger, r1 error) {
+	f.SetDefaultHook(func(context.Context, int) (*QueryTrigger, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *CodeMonitorStoreGetQueryByRecordIDFunc) PushReturn(r0 *MonitorQuery, r1 error) {
-	f.PushHook(func(context.Context, int) (*MonitorQuery, error) {
+func (f *CodeMonitorStoreGetQueryByRecordIDFunc) PushReturn(r0 *QueryTrigger, r1 error) {
+	f.PushHook(func(context.Context, int) (*QueryTrigger, error) {
 		return r0, r1
 	})
 }
 
-func (f *CodeMonitorStoreGetQueryByRecordIDFunc) nextHook() func(context.Context, int) (*MonitorQuery, error) {
+func (f *CodeMonitorStoreGetQueryByRecordIDFunc) nextHook() func(context.Context, int) (*QueryTrigger, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3252,7 +3252,7 @@ type CodeMonitorStoreGetQueryByRecordIDFuncCall struct {
 	Arg1 int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *MonitorQuery
+	Result0 *QueryTrigger
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -4818,15 +4818,15 @@ func (c CodeMonitorStoreTransactFuncCall) Results() []interface{} {
 // when the TriggerQueryByMonitorIDInt64 method of the parent
 // MockCodeMonitorStore instance is invoked.
 type CodeMonitorStoreTriggerQueryByMonitorIDInt64Func struct {
-	defaultHook func(context.Context, int64) (*MonitorQuery, error)
-	hooks       []func(context.Context, int64) (*MonitorQuery, error)
+	defaultHook func(context.Context, int64) (*QueryTrigger, error)
+	hooks       []func(context.Context, int64) (*QueryTrigger, error)
 	history     []CodeMonitorStoreTriggerQueryByMonitorIDInt64FuncCall
 	mutex       sync.Mutex
 }
 
 // TriggerQueryByMonitorIDInt64 delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) TriggerQueryByMonitorIDInt64(v0 context.Context, v1 int64) (*MonitorQuery, error) {
+func (m *MockCodeMonitorStore) TriggerQueryByMonitorIDInt64(v0 context.Context, v1 int64) (*QueryTrigger, error) {
 	r0, r1 := m.TriggerQueryByMonitorIDInt64Func.nextHook()(v0, v1)
 	m.TriggerQueryByMonitorIDInt64Func.appendCall(CodeMonitorStoreTriggerQueryByMonitorIDInt64FuncCall{v0, v1, r0, r1})
 	return r0, r1
@@ -4835,7 +4835,7 @@ func (m *MockCodeMonitorStore) TriggerQueryByMonitorIDInt64(v0 context.Context, 
 // SetDefaultHook sets function that is called when the
 // TriggerQueryByMonitorIDInt64 method of the parent MockCodeMonitorStore
 // instance is invoked and the hook queue is empty.
-func (f *CodeMonitorStoreTriggerQueryByMonitorIDInt64Func) SetDefaultHook(hook func(context.Context, int64) (*MonitorQuery, error)) {
+func (f *CodeMonitorStoreTriggerQueryByMonitorIDInt64Func) SetDefaultHook(hook func(context.Context, int64) (*QueryTrigger, error)) {
 	f.defaultHook = hook
 }
 
@@ -4844,7 +4844,7 @@ func (f *CodeMonitorStoreTriggerQueryByMonitorIDInt64Func) SetDefaultHook(hook f
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *CodeMonitorStoreTriggerQueryByMonitorIDInt64Func) PushHook(hook func(context.Context, int64) (*MonitorQuery, error)) {
+func (f *CodeMonitorStoreTriggerQueryByMonitorIDInt64Func) PushHook(hook func(context.Context, int64) (*QueryTrigger, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -4852,21 +4852,21 @@ func (f *CodeMonitorStoreTriggerQueryByMonitorIDInt64Func) PushHook(hook func(co
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *CodeMonitorStoreTriggerQueryByMonitorIDInt64Func) SetDefaultReturn(r0 *MonitorQuery, r1 error) {
-	f.SetDefaultHook(func(context.Context, int64) (*MonitorQuery, error) {
+func (f *CodeMonitorStoreTriggerQueryByMonitorIDInt64Func) SetDefaultReturn(r0 *QueryTrigger, r1 error) {
+	f.SetDefaultHook(func(context.Context, int64) (*QueryTrigger, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *CodeMonitorStoreTriggerQueryByMonitorIDInt64Func) PushReturn(r0 *MonitorQuery, r1 error) {
-	f.PushHook(func(context.Context, int64) (*MonitorQuery, error) {
+func (f *CodeMonitorStoreTriggerQueryByMonitorIDInt64Func) PushReturn(r0 *QueryTrigger, r1 error) {
+	f.PushHook(func(context.Context, int64) (*QueryTrigger, error) {
 		return r0, r1
 	})
 }
 
-func (f *CodeMonitorStoreTriggerQueryByMonitorIDInt64Func) nextHook() func(context.Context, int64) (*MonitorQuery, error) {
+func (f *CodeMonitorStoreTriggerQueryByMonitorIDInt64Func) nextHook() func(context.Context, int64) (*QueryTrigger, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -4909,7 +4909,7 @@ type CodeMonitorStoreTriggerQueryByMonitorIDInt64FuncCall struct {
 	Arg1 int64
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *MonitorQuery
+	Result0 *QueryTrigger
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -501,7 +501,7 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 			defaultHook: i.Transact,
 		},
 		TriggerQueryByMonitorIDInt64Func: &CodeMonitorStoreTriggerQueryByMonitorIDInt64Func{
-			defaultHook: i.TriggerQueryByMonitorIDInt64,
+			defaultHook: i.GetQueryTriggerForMonitor,
 		},
 		UpdateEmailActionFunc: &CodeMonitorStoreUpdateEmailActionFunc{
 			defaultHook: i.UpdateEmailAction,

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -420,7 +420,7 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 			defaultHook: i.DeleteMonitor,
 		},
 		DeleteObsoleteJobLogsFunc: &CodeMonitorStoreDeleteObsoleteJobLogsFunc{
-			defaultHook: i.DeleteObsoleteJobLogs,
+			defaultHook: i.DeleteObsoleteTriggerJobs,
 		},
 		DeleteOldJobLogsFunc: &CodeMonitorStoreDeleteOldJobLogsFunc{
 			defaultHook: i.DeleteOldJobLogs,
@@ -468,7 +468,7 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 			defaultHook: i.ListEmailActions,
 		},
 		LogSearchFunc: &CodeMonitorStoreLogSearchFunc{
-			defaultHook: i.LogSearch,
+			defaultHook: i.UpdateTriggerJobWithResults,
 		},
 		MonitorsFunc: &CodeMonitorStoreMonitorsFunc{
 			defaultHook: i.Monitors,

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -423,7 +423,7 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 			defaultHook: i.DeleteObsoleteTriggerJobs,
 		},
 		DeleteOldJobLogsFunc: &CodeMonitorStoreDeleteOldJobLogsFunc{
-			defaultHook: i.DeleteOldJobLogs,
+			defaultHook: i.DeleteOldTriggerJobs,
 		},
 		DeleteRecipientsFunc: &CodeMonitorStoreDeleteRecipientsFunc{
 			defaultHook: i.DeleteRecipients,

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -417,7 +417,7 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 			defaultHook: i.CreateTriggerQuery,
 		},
 		DeleteActionsInt64Func: &CodeMonitorStoreDeleteActionsInt64Func{
-			defaultHook: i.DeleteActionsInt64,
+			defaultHook: i.DeleteEmailActions,
 		},
 		DeleteMonitorFunc: &CodeMonitorStoreDeleteMonitorFunc{
 			defaultHook: i.DeleteMonitor,

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -399,7 +399,7 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 			defaultHook: i.CountActionJobs,
 		},
 		CreateActionEmailFunc: &CodeMonitorStoreCreateActionEmailFunc{
-			defaultHook: i.CreateActionEmail,
+			defaultHook: i.CreateEmailAction,
 		},
 		CreateActionsFunc: &CodeMonitorStoreCreateActionsFunc{
 			defaultHook: i.CreateActions,

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -495,7 +495,7 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 			defaultHook: i.CountMonitors,
 		},
 		TotalCountRecipientsFunc: &CodeMonitorStoreTotalCountRecipientsFunc{
-			defaultHook: i.TotalCountRecipients,
+			defaultHook: i.CountRecipients,
 		},
 		TransactFunc: &CodeMonitorStoreTransactFunc{
 			defaultHook: i.Transact,

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -471,7 +471,7 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 			defaultHook: i.UpdateTriggerJobWithResults,
 		},
 		MonitorsFunc: &CodeMonitorStoreMonitorsFunc{
-			defaultHook: i.Monitors,
+			defaultHook: i.ListMonitors,
 		},
 		NowFunc: &CodeMonitorStoreNowFunc{
 			defaultHook: i.Now,

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -435,7 +435,7 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 			defaultHook: i.EnqueueActionEmailsForQueryIDInt64,
 		},
 		EnqueueTriggerQueriesFunc: &CodeMonitorStoreEnqueueTriggerQueriesFunc{
-			defaultHook: i.EnqueueTriggerQueries,
+			defaultHook: i.EnqueueQueryTriggers,
 		},
 		ExecFunc: &CodeMonitorStoreExecFunc{
 			defaultHook: i.Exec,

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -492,7 +492,7 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 			defaultHook: i.TotalCountEventsForQueryIDInt64,
 		},
 		TotalCountMonitorsFunc: &CodeMonitorStoreTotalCountMonitorsFunc{
-			defaultHook: i.TotalCountMonitors,
+			defaultHook: i.CountMonitors,
 		},
 		TotalCountRecipientsFunc: &CodeMonitorStoreTotalCountRecipientsFunc{
 			defaultHook: i.TotalCountRecipients,

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -435,7 +435,7 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 			defaultHook: i.EnqueueActionEmailsForQueryIDInt64,
 		},
 		EnqueueTriggerQueriesFunc: &CodeMonitorStoreEnqueueTriggerQueriesFunc{
-			defaultHook: i.EnqueueQueryTriggers,
+			defaultHook: i.EnqueueQueryTriggerJobs,
 		},
 		ExecFunc: &CodeMonitorStoreExecFunc{
 			defaultHook: i.Exec,

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -384,7 +384,7 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 	return &MockCodeMonitorStore{
 		AllRecipientsForEmailIDInt64Func: &CodeMonitorStoreAllRecipientsForEmailIDInt64Func{
-			defaultHook: i.AllRecipientsForEmailIDInt64,
+			defaultHook: i.ListAllRecipientsForEmailAction,
 		},
 		ClockFunc: &CodeMonitorStoreClockFunc{
 			defaultHook: i.Clock,

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -504,7 +504,7 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 			defaultHook: i.TriggerQueryByMonitorIDInt64,
 		},
 		UpdateActionEmailFunc: &CodeMonitorStoreUpdateActionEmailFunc{
-			defaultHook: i.UpdateActionEmail,
+			defaultHook: i.UpdateEmailAction,
 		},
 		UpdateMonitorFunc: &CodeMonitorStoreUpdateMonitorFunc{
 			defaultHook: i.UpdateMonitor,

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -411,7 +411,7 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 			defaultHook: i.CreateRecipients,
 		},
 		CreateTriggerQueryFunc: &CodeMonitorStoreCreateTriggerQueryFunc{
-			defaultHook: i.CreateTriggerQuery,
+			defaultHook: i.CreateQueryTrigger,
 		},
 		DeleteEmailActionsFunc: &CodeMonitorStoreDeleteEmailActionsFunc{
 			defaultHook: i.DeleteEmailActions,
@@ -510,7 +510,7 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 			defaultHook: i.UpdateMonitor,
 		},
 		UpdateTriggerQueryFunc: &CodeMonitorStoreUpdateTriggerQueryFunc{
-			defaultHook: i.UpdateTriggerQuery,
+			defaultHook: i.UpdateQueryTrigger,
 		},
 	}
 }

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -450,7 +450,7 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 			defaultHook: i.GetEmailAction,
 		},
 		GetEventsForQueryIDInt64Func: &CodeMonitorStoreGetEventsForQueryIDInt64Func{
-			defaultHook: i.GetEventsForQueryIDInt64,
+			defaultHook: i.ListQueryTriggerJobs,
 		},
 		GetMonitorFunc: &CodeMonitorStoreGetMonitorFunc{
 			defaultHook: i.GetMonitor,

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -477,7 +477,7 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 			defaultHook: i.Now,
 		},
 		RecipientsForEmailIDInt64Func: &CodeMonitorStoreRecipientsForEmailIDInt64Func{
-			defaultHook: i.RecipientsForEmailIDInt64,
+			defaultHook: i.ListRecipientsForEmailAction,
 		},
 		ResetTriggerQueryTimestampsFunc: &CodeMonitorStoreResetTriggerQueryTimestampsFunc{
 			defaultHook: i.ResetQueryTriggerTimestamps,

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -18,10 +18,6 @@ import (
 // github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors) used
 // for unit testing.
 type MockCodeMonitorStore struct {
-	// AllRecipientsForEmailIDInt64Func is an instance of a mock function
-	// object controlling the behavior of the method
-	// AllRecipientsForEmailIDInt64.
-	AllRecipientsForEmailIDInt64Func *CodeMonitorStoreAllRecipientsForEmailIDInt64Func
 	// ClockFunc is an instance of a mock function object controlling the
 	// behavior of the method Clock.
 	ClockFunc *CodeMonitorStoreClockFunc
@@ -31,6 +27,15 @@ type MockCodeMonitorStore struct {
 	// CountEmailActionsFunc is an instance of a mock function object
 	// controlling the behavior of the method CountEmailActions.
 	CountEmailActionsFunc *CodeMonitorStoreCountEmailActionsFunc
+	// CountMonitorsFunc is an instance of a mock function object
+	// controlling the behavior of the method CountMonitors.
+	CountMonitorsFunc *CodeMonitorStoreCountMonitorsFunc
+	// CountQueryTriggerJobsFunc is an instance of a mock function object
+	// controlling the behavior of the method CountQueryTriggerJobs.
+	CountQueryTriggerJobsFunc *CodeMonitorStoreCountQueryTriggerJobsFunc
+	// CountRecipientsFunc is an instance of a mock function object
+	// controlling the behavior of the method CountRecipients.
+	CountRecipientsFunc *CodeMonitorStoreCountRecipientsFunc
 	// CreateActionsFunc is an instance of a mock function object
 	// controlling the behavior of the method CreateActions.
 	CreateActionsFunc *CodeMonitorStoreCreateActionsFunc
@@ -43,37 +48,38 @@ type MockCodeMonitorStore struct {
 	// CreateMonitorFunc is an instance of a mock function object
 	// controlling the behavior of the method CreateMonitor.
 	CreateMonitorFunc *CodeMonitorStoreCreateMonitorFunc
+	// CreateQueryTriggerFunc is an instance of a mock function object
+	// controlling the behavior of the method CreateQueryTrigger.
+	CreateQueryTriggerFunc *CodeMonitorStoreCreateQueryTriggerFunc
 	// CreateRecipientsFunc is an instance of a mock function object
 	// controlling the behavior of the method CreateRecipients.
 	CreateRecipientsFunc *CodeMonitorStoreCreateRecipientsFunc
-	// CreateTriggerQueryFunc is an instance of a mock function object
-	// controlling the behavior of the method CreateTriggerQuery.
-	CreateTriggerQueryFunc *CodeMonitorStoreCreateTriggerQueryFunc
 	// DeleteEmailActionsFunc is an instance of a mock function object
 	// controlling the behavior of the method DeleteEmailActions.
 	DeleteEmailActionsFunc *CodeMonitorStoreDeleteEmailActionsFunc
 	// DeleteMonitorFunc is an instance of a mock function object
 	// controlling the behavior of the method DeleteMonitor.
 	DeleteMonitorFunc *CodeMonitorStoreDeleteMonitorFunc
-	// DeleteObsoleteJobLogsFunc is an instance of a mock function object
-	// controlling the behavior of the method DeleteObsoleteJobLogs.
-	DeleteObsoleteJobLogsFunc *CodeMonitorStoreDeleteObsoleteJobLogsFunc
-	// DeleteOldJobLogsFunc is an instance of a mock function object
-	// controlling the behavior of the method DeleteOldJobLogs.
-	DeleteOldJobLogsFunc *CodeMonitorStoreDeleteOldJobLogsFunc
+	// DeleteObsoleteTriggerJobsFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// DeleteObsoleteTriggerJobs.
+	DeleteObsoleteTriggerJobsFunc *CodeMonitorStoreDeleteObsoleteTriggerJobsFunc
+	// DeleteOldTriggerJobsFunc is an instance of a mock function object
+	// controlling the behavior of the method DeleteOldTriggerJobs.
+	DeleteOldTriggerJobsFunc *CodeMonitorStoreDeleteOldTriggerJobsFunc
 	// DeleteRecipientsFunc is an instance of a mock function object
 	// controlling the behavior of the method DeleteRecipients.
 	DeleteRecipientsFunc *CodeMonitorStoreDeleteRecipientsFunc
 	// DoneFunc is an instance of a mock function object controlling the
 	// behavior of the method Done.
 	DoneFunc *CodeMonitorStoreDoneFunc
-	// EnqueueActionEmailsForQueryIDInt64Func is an instance of a mock
-	// function object controlling the behavior of the method
-	// EnqueueActionEmailsForQueryIDInt64.
-	EnqueueActionEmailsForQueryIDInt64Func *CodeMonitorStoreEnqueueActionEmailsForQueryIDInt64Func
-	// EnqueueTriggerQueriesFunc is an instance of a mock function object
-	// controlling the behavior of the method EnqueueTriggerQueries.
-	EnqueueTriggerQueriesFunc *CodeMonitorStoreEnqueueTriggerQueriesFunc
+	// EnqueueActionJobsForQueryFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// EnqueueActionJobsForQuery.
+	EnqueueActionJobsForQueryFunc *CodeMonitorStoreEnqueueActionJobsForQueryFunc
+	// EnqueueQueryTriggerJobsFunc is an instance of a mock function object
+	// controlling the behavior of the method EnqueueQueryTriggerJobs.
+	EnqueueQueryTriggerJobsFunc *CodeMonitorStoreEnqueueQueryTriggerJobsFunc
 	// ExecFunc is an instance of a mock function object controlling the
 	// behavior of the method Exec.
 	ExecFunc *CodeMonitorStoreExecFunc
@@ -86,73 +92,68 @@ type MockCodeMonitorStore struct {
 	// GetEmailActionFunc is an instance of a mock function object
 	// controlling the behavior of the method GetEmailAction.
 	GetEmailActionFunc *CodeMonitorStoreGetEmailActionFunc
-	// GetEventsForQueryIDInt64Func is an instance of a mock function object
-	// controlling the behavior of the method GetEventsForQueryIDInt64.
-	GetEventsForQueryIDInt64Func *CodeMonitorStoreGetEventsForQueryIDInt64Func
 	// GetMonitorFunc is an instance of a mock function object controlling
 	// the behavior of the method GetMonitor.
 	GetMonitorFunc *CodeMonitorStoreGetMonitorFunc
-	// GetQueryByRecordIDFunc is an instance of a mock function object
-	// controlling the behavior of the method GetQueryByRecordID.
-	GetQueryByRecordIDFunc *CodeMonitorStoreGetQueryByRecordIDFunc
+	// GetQueryTriggerForJobFunc is an instance of a mock function object
+	// controlling the behavior of the method GetQueryTriggerForJob.
+	GetQueryTriggerForJobFunc *CodeMonitorStoreGetQueryTriggerForJobFunc
+	// GetQueryTriggerForMonitorFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// GetQueryTriggerForMonitor.
+	GetQueryTriggerForMonitorFunc *CodeMonitorStoreGetQueryTriggerForMonitorFunc
 	// HandleFunc is an instance of a mock function object controlling the
 	// behavior of the method Handle.
 	HandleFunc *CodeMonitorStoreHandleFunc
 	// ListActionJobsFunc is an instance of a mock function object
 	// controlling the behavior of the method ListActionJobs.
 	ListActionJobsFunc *CodeMonitorStoreListActionJobsFunc
+	// ListAllRecipientsForEmailActionFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// ListAllRecipientsForEmailAction.
+	ListAllRecipientsForEmailActionFunc *CodeMonitorStoreListAllRecipientsForEmailActionFunc
 	// ListEmailActionsFunc is an instance of a mock function object
 	// controlling the behavior of the method ListEmailActions.
 	ListEmailActionsFunc *CodeMonitorStoreListEmailActionsFunc
-	// LogSearchFunc is an instance of a mock function object controlling
-	// the behavior of the method LogSearch.
-	LogSearchFunc *CodeMonitorStoreLogSearchFunc
-	// MonitorsFunc is an instance of a mock function object controlling the
-	// behavior of the method Monitors.
-	MonitorsFunc *CodeMonitorStoreMonitorsFunc
+	// ListMonitorsFunc is an instance of a mock function object controlling
+	// the behavior of the method ListMonitors.
+	ListMonitorsFunc *CodeMonitorStoreListMonitorsFunc
+	// ListQueryTriggerJobsFunc is an instance of a mock function object
+	// controlling the behavior of the method ListQueryTriggerJobs.
+	ListQueryTriggerJobsFunc *CodeMonitorStoreListQueryTriggerJobsFunc
+	// ListRecipientsForEmailActionFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// ListRecipientsForEmailAction.
+	ListRecipientsForEmailActionFunc *CodeMonitorStoreListRecipientsForEmailActionFunc
 	// NowFunc is an instance of a mock function object controlling the
 	// behavior of the method Now.
 	NowFunc *CodeMonitorStoreNowFunc
-	// RecipientsForEmailIDInt64Func is an instance of a mock function
+	// ResetQueryTriggerTimestampsFunc is an instance of a mock function
 	// object controlling the behavior of the method
-	// RecipientsForEmailIDInt64.
-	RecipientsForEmailIDInt64Func *CodeMonitorStoreRecipientsForEmailIDInt64Func
-	// ResetTriggerQueryTimestampsFunc is an instance of a mock function
-	// object controlling the behavior of the method
-	// ResetTriggerQueryTimestamps.
-	ResetTriggerQueryTimestampsFunc *CodeMonitorStoreResetTriggerQueryTimestampsFunc
-	// SetTriggerQueryNextRunFunc is an instance of a mock function object
-	// controlling the behavior of the method SetTriggerQueryNextRun.
-	SetTriggerQueryNextRunFunc *CodeMonitorStoreSetTriggerQueryNextRunFunc
+	// ResetQueryTriggerTimestamps.
+	ResetQueryTriggerTimestampsFunc *CodeMonitorStoreResetQueryTriggerTimestampsFunc
+	// SetQueryTriggerNextRunFunc is an instance of a mock function object
+	// controlling the behavior of the method SetQueryTriggerNextRun.
+	SetQueryTriggerNextRunFunc *CodeMonitorStoreSetQueryTriggerNextRunFunc
 	// ToggleMonitorFunc is an instance of a mock function object
 	// controlling the behavior of the method ToggleMonitor.
 	ToggleMonitorFunc *CodeMonitorStoreToggleMonitorFunc
-	// TotalCountEventsForQueryIDInt64Func is an instance of a mock function
-	// object controlling the behavior of the method
-	// TotalCountEventsForQueryIDInt64.
-	TotalCountEventsForQueryIDInt64Func *CodeMonitorStoreTotalCountEventsForQueryIDInt64Func
-	// TotalCountMonitorsFunc is an instance of a mock function object
-	// controlling the behavior of the method TotalCountMonitors.
-	TotalCountMonitorsFunc *CodeMonitorStoreTotalCountMonitorsFunc
-	// TotalCountRecipientsFunc is an instance of a mock function object
-	// controlling the behavior of the method TotalCountRecipients.
-	TotalCountRecipientsFunc *CodeMonitorStoreTotalCountRecipientsFunc
 	// TransactFunc is an instance of a mock function object controlling the
 	// behavior of the method Transact.
 	TransactFunc *CodeMonitorStoreTransactFunc
-	// TriggerQueryByMonitorIDInt64Func is an instance of a mock function
-	// object controlling the behavior of the method
-	// TriggerQueryByMonitorIDInt64.
-	TriggerQueryByMonitorIDInt64Func *CodeMonitorStoreTriggerQueryByMonitorIDInt64Func
 	// UpdateEmailActionFunc is an instance of a mock function object
 	// controlling the behavior of the method UpdateEmailAction.
 	UpdateEmailActionFunc *CodeMonitorStoreUpdateEmailActionFunc
 	// UpdateMonitorFunc is an instance of a mock function object
 	// controlling the behavior of the method UpdateMonitor.
 	UpdateMonitorFunc *CodeMonitorStoreUpdateMonitorFunc
-	// UpdateTriggerQueryFunc is an instance of a mock function object
-	// controlling the behavior of the method UpdateTriggerQuery.
-	UpdateTriggerQueryFunc *CodeMonitorStoreUpdateTriggerQueryFunc
+	// UpdateQueryTriggerFunc is an instance of a mock function object
+	// controlling the behavior of the method UpdateQueryTrigger.
+	UpdateQueryTriggerFunc *CodeMonitorStoreUpdateQueryTriggerFunc
+	// UpdateTriggerJobWithResultsFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// UpdateTriggerJobWithResults.
+	UpdateTriggerJobWithResultsFunc *CodeMonitorStoreUpdateTriggerJobWithResultsFunc
 }
 
 // NewMockCodeMonitorStore creates a new mock of the CodeMonitorStore
@@ -160,11 +161,6 @@ type MockCodeMonitorStore struct {
 // overwritten.
 func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 	return &MockCodeMonitorStore{
-		AllRecipientsForEmailIDInt64Func: &CodeMonitorStoreAllRecipientsForEmailIDInt64Func{
-			defaultHook: func(context.Context, int64) ([]*Recipient, error) {
-				return nil, nil
-			},
-		},
 		ClockFunc: &CodeMonitorStoreClockFunc{
 			defaultHook: func() func() time.Time {
 				return nil
@@ -176,6 +172,21 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		CountEmailActionsFunc: &CodeMonitorStoreCountEmailActionsFunc{
+			defaultHook: func(context.Context, int64) (int32, error) {
+				return 0, nil
+			},
+		},
+		CountMonitorsFunc: &CodeMonitorStoreCountMonitorsFunc{
+			defaultHook: func(context.Context, int32) (int32, error) {
+				return 0, nil
+			},
+		},
+		CountQueryTriggerJobsFunc: &CodeMonitorStoreCountQueryTriggerJobsFunc{
+			defaultHook: func(context.Context, int64) (int32, error) {
+				return 0, nil
+			},
+		},
+		CountRecipientsFunc: &CodeMonitorStoreCountRecipientsFunc{
 			defaultHook: func(context.Context, int64) (int32, error) {
 				return 0, nil
 			},
@@ -200,13 +211,13 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 				return nil, nil
 			},
 		},
-		CreateRecipientsFunc: &CodeMonitorStoreCreateRecipientsFunc{
-			defaultHook: func(context.Context, []graphqlgo.ID, int64) error {
+		CreateQueryTriggerFunc: &CodeMonitorStoreCreateQueryTriggerFunc{
+			defaultHook: func(context.Context, int64, *graphqlbackend.CreateTriggerArgs) error {
 				return nil
 			},
 		},
-		CreateTriggerQueryFunc: &CodeMonitorStoreCreateTriggerQueryFunc{
-			defaultHook: func(context.Context, int64, *graphqlbackend.CreateTriggerArgs) error {
+		CreateRecipientsFunc: &CodeMonitorStoreCreateRecipientsFunc{
+			defaultHook: func(context.Context, []graphqlgo.ID, int64) error {
 				return nil
 			},
 		},
@@ -220,12 +231,12 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 				return nil
 			},
 		},
-		DeleteObsoleteJobLogsFunc: &CodeMonitorStoreDeleteObsoleteJobLogsFunc{
+		DeleteObsoleteTriggerJobsFunc: &CodeMonitorStoreDeleteObsoleteTriggerJobsFunc{
 			defaultHook: func(context.Context) error {
 				return nil
 			},
 		},
-		DeleteOldJobLogsFunc: &CodeMonitorStoreDeleteOldJobLogsFunc{
+		DeleteOldTriggerJobsFunc: &CodeMonitorStoreDeleteOldTriggerJobsFunc{
 			defaultHook: func(context.Context, int) error {
 				return nil
 			},
@@ -240,12 +251,12 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 				return nil
 			},
 		},
-		EnqueueActionEmailsForQueryIDInt64Func: &CodeMonitorStoreEnqueueActionEmailsForQueryIDInt64Func{
+		EnqueueActionJobsForQueryFunc: &CodeMonitorStoreEnqueueActionJobsForQueryFunc{
 			defaultHook: func(context.Context, int64, int) error {
 				return nil
 			},
 		},
-		EnqueueTriggerQueriesFunc: &CodeMonitorStoreEnqueueTriggerQueriesFunc{
+		EnqueueQueryTriggerJobsFunc: &CodeMonitorStoreEnqueueQueryTriggerJobsFunc{
 			defaultHook: func(context.Context) error {
 				return nil
 			},
@@ -270,18 +281,18 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 				return nil, nil
 			},
 		},
-		GetEventsForQueryIDInt64Func: &CodeMonitorStoreGetEventsForQueryIDInt64Func{
-			defaultHook: func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error) {
-				return nil, nil
-			},
-		},
 		GetMonitorFunc: &CodeMonitorStoreGetMonitorFunc{
 			defaultHook: func(context.Context, int64) (*Monitor, error) {
 				return nil, nil
 			},
 		},
-		GetQueryByRecordIDFunc: &CodeMonitorStoreGetQueryByRecordIDFunc{
+		GetQueryTriggerForJobFunc: &CodeMonitorStoreGetQueryTriggerForJobFunc{
 			defaultHook: func(context.Context, int) (*QueryTrigger, error) {
+				return nil, nil
+			},
+		},
+		GetQueryTriggerForMonitorFunc: &CodeMonitorStoreGetQueryTriggerForMonitorFunc{
+			defaultHook: func(context.Context, int64) (*QueryTrigger, error) {
 				return nil, nil
 			},
 		},
@@ -295,18 +306,28 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 				return nil, nil
 			},
 		},
+		ListAllRecipientsForEmailActionFunc: &CodeMonitorStoreListAllRecipientsForEmailActionFunc{
+			defaultHook: func(context.Context, int64) ([]*Recipient, error) {
+				return nil, nil
+			},
+		},
 		ListEmailActionsFunc: &CodeMonitorStoreListEmailActionsFunc{
 			defaultHook: func(context.Context, ListActionsOpts) ([]*EmailAction, error) {
 				return nil, nil
 			},
 		},
-		LogSearchFunc: &CodeMonitorStoreLogSearchFunc{
-			defaultHook: func(context.Context, string, int, int) error {
-				return nil
+		ListMonitorsFunc: &CodeMonitorStoreListMonitorsFunc{
+			defaultHook: func(context.Context, int32, *graphqlbackend.ListMonitorsArgs) ([]*Monitor, error) {
+				return nil, nil
 			},
 		},
-		MonitorsFunc: &CodeMonitorStoreMonitorsFunc{
-			defaultHook: func(context.Context, int32, *graphqlbackend.ListMonitorsArgs) ([]*Monitor, error) {
+		ListQueryTriggerJobsFunc: &CodeMonitorStoreListQueryTriggerJobsFunc{
+			defaultHook: func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error) {
+				return nil, nil
+			},
+		},
+		ListRecipientsForEmailActionFunc: &CodeMonitorStoreListRecipientsForEmailActionFunc{
+			defaultHook: func(context.Context, int64, *graphqlbackend.ListRecipientsArgs) ([]*Recipient, error) {
 				return nil, nil
 			},
 		},
@@ -315,17 +336,12 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 				return time.Time{}
 			},
 		},
-		RecipientsForEmailIDInt64Func: &CodeMonitorStoreRecipientsForEmailIDInt64Func{
-			defaultHook: func(context.Context, int64, *graphqlbackend.ListRecipientsArgs) ([]*Recipient, error) {
-				return nil, nil
-			},
-		},
-		ResetTriggerQueryTimestampsFunc: &CodeMonitorStoreResetTriggerQueryTimestampsFunc{
+		ResetQueryTriggerTimestampsFunc: &CodeMonitorStoreResetQueryTriggerTimestampsFunc{
 			defaultHook: func(context.Context, int64) error {
 				return nil
 			},
 		},
-		SetTriggerQueryNextRunFunc: &CodeMonitorStoreSetTriggerQueryNextRunFunc{
+		SetQueryTriggerNextRunFunc: &CodeMonitorStoreSetQueryTriggerNextRunFunc{
 			defaultHook: func(context.Context, int64, time.Time, time.Time) error {
 				return nil
 			},
@@ -335,28 +351,8 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 				return nil, nil
 			},
 		},
-		TotalCountEventsForQueryIDInt64Func: &CodeMonitorStoreTotalCountEventsForQueryIDInt64Func{
-			defaultHook: func(context.Context, int64) (int32, error) {
-				return 0, nil
-			},
-		},
-		TotalCountMonitorsFunc: &CodeMonitorStoreTotalCountMonitorsFunc{
-			defaultHook: func(context.Context, int32) (int32, error) {
-				return 0, nil
-			},
-		},
-		TotalCountRecipientsFunc: &CodeMonitorStoreTotalCountRecipientsFunc{
-			defaultHook: func(context.Context, int64) (int32, error) {
-				return 0, nil
-			},
-		},
 		TransactFunc: &CodeMonitorStoreTransactFunc{
 			defaultHook: func(context.Context) (CodeMonitorStore, error) {
-				return nil, nil
-			},
-		},
-		TriggerQueryByMonitorIDInt64Func: &CodeMonitorStoreTriggerQueryByMonitorIDInt64Func{
-			defaultHook: func(context.Context, int64) (*QueryTrigger, error) {
 				return nil, nil
 			},
 		},
@@ -370,8 +366,13 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 				return nil, nil
 			},
 		},
-		UpdateTriggerQueryFunc: &CodeMonitorStoreUpdateTriggerQueryFunc{
+		UpdateQueryTriggerFunc: &CodeMonitorStoreUpdateQueryTriggerFunc{
 			defaultHook: func(context.Context, *graphqlbackend.UpdateCodeMonitorArgs) error {
+				return nil
+			},
+		},
+		UpdateTriggerJobWithResultsFunc: &CodeMonitorStoreUpdateTriggerJobWithResultsFunc{
+			defaultHook: func(context.Context, string, int, int) error {
 				return nil
 			},
 		},
@@ -383,9 +384,6 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 // implementation, unless overwritten.
 func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 	return &MockCodeMonitorStore{
-		AllRecipientsForEmailIDInt64Func: &CodeMonitorStoreAllRecipientsForEmailIDInt64Func{
-			defaultHook: i.ListAllRecipientsForEmailAction,
-		},
 		ClockFunc: &CodeMonitorStoreClockFunc{
 			defaultHook: i.Clock,
 		},
@@ -394,6 +392,15 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 		},
 		CountEmailActionsFunc: &CodeMonitorStoreCountEmailActionsFunc{
 			defaultHook: i.CountEmailActions,
+		},
+		CountMonitorsFunc: &CodeMonitorStoreCountMonitorsFunc{
+			defaultHook: i.CountMonitors,
+		},
+		CountQueryTriggerJobsFunc: &CodeMonitorStoreCountQueryTriggerJobsFunc{
+			defaultHook: i.CountQueryTriggerJobs,
+		},
+		CountRecipientsFunc: &CodeMonitorStoreCountRecipientsFunc{
+			defaultHook: i.CountRecipients,
 		},
 		CreateActionsFunc: &CodeMonitorStoreCreateActionsFunc{
 			defaultHook: i.CreateActions,
@@ -407,11 +414,11 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 		CreateMonitorFunc: &CodeMonitorStoreCreateMonitorFunc{
 			defaultHook: i.CreateMonitor,
 		},
+		CreateQueryTriggerFunc: &CodeMonitorStoreCreateQueryTriggerFunc{
+			defaultHook: i.CreateQueryTrigger,
+		},
 		CreateRecipientsFunc: &CodeMonitorStoreCreateRecipientsFunc{
 			defaultHook: i.CreateRecipients,
-		},
-		CreateTriggerQueryFunc: &CodeMonitorStoreCreateTriggerQueryFunc{
-			defaultHook: i.CreateQueryTrigger,
 		},
 		DeleteEmailActionsFunc: &CodeMonitorStoreDeleteEmailActionsFunc{
 			defaultHook: i.DeleteEmailActions,
@@ -419,10 +426,10 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 		DeleteMonitorFunc: &CodeMonitorStoreDeleteMonitorFunc{
 			defaultHook: i.DeleteMonitor,
 		},
-		DeleteObsoleteJobLogsFunc: &CodeMonitorStoreDeleteObsoleteJobLogsFunc{
+		DeleteObsoleteTriggerJobsFunc: &CodeMonitorStoreDeleteObsoleteTriggerJobsFunc{
 			defaultHook: i.DeleteObsoleteTriggerJobs,
 		},
-		DeleteOldJobLogsFunc: &CodeMonitorStoreDeleteOldJobLogsFunc{
+		DeleteOldTriggerJobsFunc: &CodeMonitorStoreDeleteOldTriggerJobsFunc{
 			defaultHook: i.DeleteOldTriggerJobs,
 		},
 		DeleteRecipientsFunc: &CodeMonitorStoreDeleteRecipientsFunc{
@@ -431,10 +438,10 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 		DoneFunc: &CodeMonitorStoreDoneFunc{
 			defaultHook: i.Done,
 		},
-		EnqueueActionEmailsForQueryIDInt64Func: &CodeMonitorStoreEnqueueActionEmailsForQueryIDInt64Func{
+		EnqueueActionJobsForQueryFunc: &CodeMonitorStoreEnqueueActionJobsForQueryFunc{
 			defaultHook: i.EnqueueActionJobsForQuery,
 		},
-		EnqueueTriggerQueriesFunc: &CodeMonitorStoreEnqueueTriggerQueriesFunc{
+		EnqueueQueryTriggerJobsFunc: &CodeMonitorStoreEnqueueQueryTriggerJobsFunc{
 			defaultHook: i.EnqueueQueryTriggerJobs,
 		},
 		ExecFunc: &CodeMonitorStoreExecFunc{
@@ -449,14 +456,14 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 		GetEmailActionFunc: &CodeMonitorStoreGetEmailActionFunc{
 			defaultHook: i.GetEmailAction,
 		},
-		GetEventsForQueryIDInt64Func: &CodeMonitorStoreGetEventsForQueryIDInt64Func{
-			defaultHook: i.ListQueryTriggerJobs,
-		},
 		GetMonitorFunc: &CodeMonitorStoreGetMonitorFunc{
 			defaultHook: i.GetMonitor,
 		},
-		GetQueryByRecordIDFunc: &CodeMonitorStoreGetQueryByRecordIDFunc{
+		GetQueryTriggerForJobFunc: &CodeMonitorStoreGetQueryTriggerForJobFunc{
 			defaultHook: i.GetQueryTriggerForJob,
+		},
+		GetQueryTriggerForMonitorFunc: &CodeMonitorStoreGetQueryTriggerForMonitorFunc{
+			defaultHook: i.GetQueryTriggerForMonitor,
 		},
 		HandleFunc: &CodeMonitorStoreHandleFunc{
 			defaultHook: i.Handle,
@@ -464,44 +471,35 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 		ListActionJobsFunc: &CodeMonitorStoreListActionJobsFunc{
 			defaultHook: i.ListActionJobs,
 		},
+		ListAllRecipientsForEmailActionFunc: &CodeMonitorStoreListAllRecipientsForEmailActionFunc{
+			defaultHook: i.ListAllRecipientsForEmailAction,
+		},
 		ListEmailActionsFunc: &CodeMonitorStoreListEmailActionsFunc{
 			defaultHook: i.ListEmailActions,
 		},
-		LogSearchFunc: &CodeMonitorStoreLogSearchFunc{
-			defaultHook: i.UpdateTriggerJobWithResults,
-		},
-		MonitorsFunc: &CodeMonitorStoreMonitorsFunc{
+		ListMonitorsFunc: &CodeMonitorStoreListMonitorsFunc{
 			defaultHook: i.ListMonitors,
+		},
+		ListQueryTriggerJobsFunc: &CodeMonitorStoreListQueryTriggerJobsFunc{
+			defaultHook: i.ListQueryTriggerJobs,
+		},
+		ListRecipientsForEmailActionFunc: &CodeMonitorStoreListRecipientsForEmailActionFunc{
+			defaultHook: i.ListRecipientsForEmailAction,
 		},
 		NowFunc: &CodeMonitorStoreNowFunc{
 			defaultHook: i.Now,
 		},
-		RecipientsForEmailIDInt64Func: &CodeMonitorStoreRecipientsForEmailIDInt64Func{
-			defaultHook: i.ListRecipientsForEmailAction,
-		},
-		ResetTriggerQueryTimestampsFunc: &CodeMonitorStoreResetTriggerQueryTimestampsFunc{
+		ResetQueryTriggerTimestampsFunc: &CodeMonitorStoreResetQueryTriggerTimestampsFunc{
 			defaultHook: i.ResetQueryTriggerTimestamps,
 		},
-		SetTriggerQueryNextRunFunc: &CodeMonitorStoreSetTriggerQueryNextRunFunc{
+		SetQueryTriggerNextRunFunc: &CodeMonitorStoreSetQueryTriggerNextRunFunc{
 			defaultHook: i.SetQueryTriggerNextRun,
 		},
 		ToggleMonitorFunc: &CodeMonitorStoreToggleMonitorFunc{
 			defaultHook: i.ToggleMonitor,
 		},
-		TotalCountEventsForQueryIDInt64Func: &CodeMonitorStoreTotalCountEventsForQueryIDInt64Func{
-			defaultHook: i.CountQueryTriggerJobs,
-		},
-		TotalCountMonitorsFunc: &CodeMonitorStoreTotalCountMonitorsFunc{
-			defaultHook: i.CountMonitors,
-		},
-		TotalCountRecipientsFunc: &CodeMonitorStoreTotalCountRecipientsFunc{
-			defaultHook: i.CountRecipients,
-		},
 		TransactFunc: &CodeMonitorStoreTransactFunc{
 			defaultHook: i.Transact,
-		},
-		TriggerQueryByMonitorIDInt64Func: &CodeMonitorStoreTriggerQueryByMonitorIDInt64Func{
-			defaultHook: i.GetQueryTriggerForMonitor,
 		},
 		UpdateEmailActionFunc: &CodeMonitorStoreUpdateEmailActionFunc{
 			defaultHook: i.UpdateEmailAction,
@@ -509,123 +507,13 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 		UpdateMonitorFunc: &CodeMonitorStoreUpdateMonitorFunc{
 			defaultHook: i.UpdateMonitor,
 		},
-		UpdateTriggerQueryFunc: &CodeMonitorStoreUpdateTriggerQueryFunc{
+		UpdateQueryTriggerFunc: &CodeMonitorStoreUpdateQueryTriggerFunc{
 			defaultHook: i.UpdateQueryTrigger,
 		},
+		UpdateTriggerJobWithResultsFunc: &CodeMonitorStoreUpdateTriggerJobWithResultsFunc{
+			defaultHook: i.UpdateTriggerJobWithResults,
+		},
 	}
-}
-
-// CodeMonitorStoreAllRecipientsForEmailIDInt64Func describes the behavior
-// when the AllRecipientsForEmailIDInt64 method of the parent
-// MockCodeMonitorStore instance is invoked.
-type CodeMonitorStoreAllRecipientsForEmailIDInt64Func struct {
-	defaultHook func(context.Context, int64) ([]*Recipient, error)
-	hooks       []func(context.Context, int64) ([]*Recipient, error)
-	history     []CodeMonitorStoreAllRecipientsForEmailIDInt64FuncCall
-	mutex       sync.Mutex
-}
-
-// AllRecipientsForEmailIDInt64 delegates to the next hook function in the
-// queue and stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) AllRecipientsForEmailIDInt64(v0 context.Context, v1 int64) ([]*Recipient, error) {
-	r0, r1 := m.AllRecipientsForEmailIDInt64Func.nextHook()(v0, v1)
-	m.AllRecipientsForEmailIDInt64Func.appendCall(CodeMonitorStoreAllRecipientsForEmailIDInt64FuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// AllRecipientsForEmailIDInt64 method of the parent MockCodeMonitorStore
-// instance is invoked and the hook queue is empty.
-func (f *CodeMonitorStoreAllRecipientsForEmailIDInt64Func) SetDefaultHook(hook func(context.Context, int64) ([]*Recipient, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// AllRecipientsForEmailIDInt64 method of the parent MockCodeMonitorStore
-// instance invokes the hook at the front of the queue and discards it.
-// After the queue is empty, the default hook function is invoked for any
-// future action.
-func (f *CodeMonitorStoreAllRecipientsForEmailIDInt64Func) PushHook(hook func(context.Context, int64) ([]*Recipient, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
-// the given values.
-func (f *CodeMonitorStoreAllRecipientsForEmailIDInt64Func) SetDefaultReturn(r0 []*Recipient, r1 error) {
-	f.SetDefaultHook(func(context.Context, int64) ([]*Recipient, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushDefaultHook with a function that returns the given
-// values.
-func (f *CodeMonitorStoreAllRecipientsForEmailIDInt64Func) PushReturn(r0 []*Recipient, r1 error) {
-	f.PushHook(func(context.Context, int64) ([]*Recipient, error) {
-		return r0, r1
-	})
-}
-
-func (f *CodeMonitorStoreAllRecipientsForEmailIDInt64Func) nextHook() func(context.Context, int64) ([]*Recipient, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *CodeMonitorStoreAllRecipientsForEmailIDInt64Func) appendCall(r0 CodeMonitorStoreAllRecipientsForEmailIDInt64FuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// CodeMonitorStoreAllRecipientsForEmailIDInt64FuncCall objects describing
-// the invocations of this function.
-func (f *CodeMonitorStoreAllRecipientsForEmailIDInt64Func) History() []CodeMonitorStoreAllRecipientsForEmailIDInt64FuncCall {
-	f.mutex.Lock()
-	history := make([]CodeMonitorStoreAllRecipientsForEmailIDInt64FuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// CodeMonitorStoreAllRecipientsForEmailIDInt64FuncCall is an object that
-// describes an invocation of method AllRecipientsForEmailIDInt64 on an
-// instance of MockCodeMonitorStore.
-type CodeMonitorStoreAllRecipientsForEmailIDInt64FuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int64
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []*Recipient
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c CodeMonitorStoreAllRecipientsForEmailIDInt64FuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c CodeMonitorStoreAllRecipientsForEmailIDInt64FuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
 }
 
 // CodeMonitorStoreClockFunc describes the behavior when the Clock method of
@@ -949,6 +837,342 @@ func (c CodeMonitorStoreCountEmailActionsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c CodeMonitorStoreCountEmailActionsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// CodeMonitorStoreCountMonitorsFunc describes the behavior when the
+// CountMonitors method of the parent MockCodeMonitorStore instance is
+// invoked.
+type CodeMonitorStoreCountMonitorsFunc struct {
+	defaultHook func(context.Context, int32) (int32, error)
+	hooks       []func(context.Context, int32) (int32, error)
+	history     []CodeMonitorStoreCountMonitorsFuncCall
+	mutex       sync.Mutex
+}
+
+// CountMonitors delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockCodeMonitorStore) CountMonitors(v0 context.Context, v1 int32) (int32, error) {
+	r0, r1 := m.CountMonitorsFunc.nextHook()(v0, v1)
+	m.CountMonitorsFunc.appendCall(CodeMonitorStoreCountMonitorsFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the CountMonitors method
+// of the parent MockCodeMonitorStore instance is invoked and the hook queue
+// is empty.
+func (f *CodeMonitorStoreCountMonitorsFunc) SetDefaultHook(hook func(context.Context, int32) (int32, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// CountMonitors method of the parent MockCodeMonitorStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *CodeMonitorStoreCountMonitorsFunc) PushHook(hook func(context.Context, int32) (int32, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *CodeMonitorStoreCountMonitorsFunc) SetDefaultReturn(r0 int32, r1 error) {
+	f.SetDefaultHook(func(context.Context, int32) (int32, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *CodeMonitorStoreCountMonitorsFunc) PushReturn(r0 int32, r1 error) {
+	f.PushHook(func(context.Context, int32) (int32, error) {
+		return r0, r1
+	})
+}
+
+func (f *CodeMonitorStoreCountMonitorsFunc) nextHook() func(context.Context, int32) (int32, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *CodeMonitorStoreCountMonitorsFunc) appendCall(r0 CodeMonitorStoreCountMonitorsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of CodeMonitorStoreCountMonitorsFuncCall
+// objects describing the invocations of this function.
+func (f *CodeMonitorStoreCountMonitorsFunc) History() []CodeMonitorStoreCountMonitorsFuncCall {
+	f.mutex.Lock()
+	history := make([]CodeMonitorStoreCountMonitorsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// CodeMonitorStoreCountMonitorsFuncCall is an object that describes an
+// invocation of method CountMonitors on an instance of
+// MockCodeMonitorStore.
+type CodeMonitorStoreCountMonitorsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int32
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 int32
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c CodeMonitorStoreCountMonitorsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c CodeMonitorStoreCountMonitorsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// CodeMonitorStoreCountQueryTriggerJobsFunc describes the behavior when the
+// CountQueryTriggerJobs method of the parent MockCodeMonitorStore instance
+// is invoked.
+type CodeMonitorStoreCountQueryTriggerJobsFunc struct {
+	defaultHook func(context.Context, int64) (int32, error)
+	hooks       []func(context.Context, int64) (int32, error)
+	history     []CodeMonitorStoreCountQueryTriggerJobsFuncCall
+	mutex       sync.Mutex
+}
+
+// CountQueryTriggerJobs delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockCodeMonitorStore) CountQueryTriggerJobs(v0 context.Context, v1 int64) (int32, error) {
+	r0, r1 := m.CountQueryTriggerJobsFunc.nextHook()(v0, v1)
+	m.CountQueryTriggerJobsFunc.appendCall(CodeMonitorStoreCountQueryTriggerJobsFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// CountQueryTriggerJobs method of the parent MockCodeMonitorStore instance
+// is invoked and the hook queue is empty.
+func (f *CodeMonitorStoreCountQueryTriggerJobsFunc) SetDefaultHook(hook func(context.Context, int64) (int32, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// CountQueryTriggerJobs method of the parent MockCodeMonitorStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *CodeMonitorStoreCountQueryTriggerJobsFunc) PushHook(hook func(context.Context, int64) (int32, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *CodeMonitorStoreCountQueryTriggerJobsFunc) SetDefaultReturn(r0 int32, r1 error) {
+	f.SetDefaultHook(func(context.Context, int64) (int32, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *CodeMonitorStoreCountQueryTriggerJobsFunc) PushReturn(r0 int32, r1 error) {
+	f.PushHook(func(context.Context, int64) (int32, error) {
+		return r0, r1
+	})
+}
+
+func (f *CodeMonitorStoreCountQueryTriggerJobsFunc) nextHook() func(context.Context, int64) (int32, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *CodeMonitorStoreCountQueryTriggerJobsFunc) appendCall(r0 CodeMonitorStoreCountQueryTriggerJobsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// CodeMonitorStoreCountQueryTriggerJobsFuncCall objects describing the
+// invocations of this function.
+func (f *CodeMonitorStoreCountQueryTriggerJobsFunc) History() []CodeMonitorStoreCountQueryTriggerJobsFuncCall {
+	f.mutex.Lock()
+	history := make([]CodeMonitorStoreCountQueryTriggerJobsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// CodeMonitorStoreCountQueryTriggerJobsFuncCall is an object that describes
+// an invocation of method CountQueryTriggerJobs on an instance of
+// MockCodeMonitorStore.
+type CodeMonitorStoreCountQueryTriggerJobsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int64
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 int32
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c CodeMonitorStoreCountQueryTriggerJobsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c CodeMonitorStoreCountQueryTriggerJobsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// CodeMonitorStoreCountRecipientsFunc describes the behavior when the
+// CountRecipients method of the parent MockCodeMonitorStore instance is
+// invoked.
+type CodeMonitorStoreCountRecipientsFunc struct {
+	defaultHook func(context.Context, int64) (int32, error)
+	hooks       []func(context.Context, int64) (int32, error)
+	history     []CodeMonitorStoreCountRecipientsFuncCall
+	mutex       sync.Mutex
+}
+
+// CountRecipients delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockCodeMonitorStore) CountRecipients(v0 context.Context, v1 int64) (int32, error) {
+	r0, r1 := m.CountRecipientsFunc.nextHook()(v0, v1)
+	m.CountRecipientsFunc.appendCall(CodeMonitorStoreCountRecipientsFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the CountRecipients
+// method of the parent MockCodeMonitorStore instance is invoked and the
+// hook queue is empty.
+func (f *CodeMonitorStoreCountRecipientsFunc) SetDefaultHook(hook func(context.Context, int64) (int32, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// CountRecipients method of the parent MockCodeMonitorStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *CodeMonitorStoreCountRecipientsFunc) PushHook(hook func(context.Context, int64) (int32, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *CodeMonitorStoreCountRecipientsFunc) SetDefaultReturn(r0 int32, r1 error) {
+	f.SetDefaultHook(func(context.Context, int64) (int32, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *CodeMonitorStoreCountRecipientsFunc) PushReturn(r0 int32, r1 error) {
+	f.PushHook(func(context.Context, int64) (int32, error) {
+		return r0, r1
+	})
+}
+
+func (f *CodeMonitorStoreCountRecipientsFunc) nextHook() func(context.Context, int64) (int32, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *CodeMonitorStoreCountRecipientsFunc) appendCall(r0 CodeMonitorStoreCountRecipientsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of CodeMonitorStoreCountRecipientsFuncCall
+// objects describing the invocations of this function.
+func (f *CodeMonitorStoreCountRecipientsFunc) History() []CodeMonitorStoreCountRecipientsFuncCall {
+	f.mutex.Lock()
+	history := make([]CodeMonitorStoreCountRecipientsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// CodeMonitorStoreCountRecipientsFuncCall is an object that describes an
+// invocation of method CountRecipients on an instance of
+// MockCodeMonitorStore.
+type CodeMonitorStoreCountRecipientsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int64
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 int32
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c CodeMonitorStoreCountRecipientsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c CodeMonitorStoreCountRecipientsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -1401,6 +1625,118 @@ func (c CodeMonitorStoreCreateMonitorFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
+// CodeMonitorStoreCreateQueryTriggerFunc describes the behavior when the
+// CreateQueryTrigger method of the parent MockCodeMonitorStore instance is
+// invoked.
+type CodeMonitorStoreCreateQueryTriggerFunc struct {
+	defaultHook func(context.Context, int64, *graphqlbackend.CreateTriggerArgs) error
+	hooks       []func(context.Context, int64, *graphqlbackend.CreateTriggerArgs) error
+	history     []CodeMonitorStoreCreateQueryTriggerFuncCall
+	mutex       sync.Mutex
+}
+
+// CreateQueryTrigger delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockCodeMonitorStore) CreateQueryTrigger(v0 context.Context, v1 int64, v2 *graphqlbackend.CreateTriggerArgs) error {
+	r0 := m.CreateQueryTriggerFunc.nextHook()(v0, v1, v2)
+	m.CreateQueryTriggerFunc.appendCall(CodeMonitorStoreCreateQueryTriggerFuncCall{v0, v1, v2, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the CreateQueryTrigger
+// method of the parent MockCodeMonitorStore instance is invoked and the
+// hook queue is empty.
+func (f *CodeMonitorStoreCreateQueryTriggerFunc) SetDefaultHook(hook func(context.Context, int64, *graphqlbackend.CreateTriggerArgs) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// CreateQueryTrigger method of the parent MockCodeMonitorStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *CodeMonitorStoreCreateQueryTriggerFunc) PushHook(hook func(context.Context, int64, *graphqlbackend.CreateTriggerArgs) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *CodeMonitorStoreCreateQueryTriggerFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, int64, *graphqlbackend.CreateTriggerArgs) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *CodeMonitorStoreCreateQueryTriggerFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, int64, *graphqlbackend.CreateTriggerArgs) error {
+		return r0
+	})
+}
+
+func (f *CodeMonitorStoreCreateQueryTriggerFunc) nextHook() func(context.Context, int64, *graphqlbackend.CreateTriggerArgs) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *CodeMonitorStoreCreateQueryTriggerFunc) appendCall(r0 CodeMonitorStoreCreateQueryTriggerFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of CodeMonitorStoreCreateQueryTriggerFuncCall
+// objects describing the invocations of this function.
+func (f *CodeMonitorStoreCreateQueryTriggerFunc) History() []CodeMonitorStoreCreateQueryTriggerFuncCall {
+	f.mutex.Lock()
+	history := make([]CodeMonitorStoreCreateQueryTriggerFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// CodeMonitorStoreCreateQueryTriggerFuncCall is an object that describes an
+// invocation of method CreateQueryTrigger on an instance of
+// MockCodeMonitorStore.
+type CodeMonitorStoreCreateQueryTriggerFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int64
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 *graphqlbackend.CreateTriggerArgs
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c CodeMonitorStoreCreateQueryTriggerFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c CodeMonitorStoreCreateQueryTriggerFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
 // CodeMonitorStoreCreateRecipientsFunc describes the behavior when the
 // CreateRecipients method of the parent MockCodeMonitorStore instance is
 // invoked.
@@ -1510,118 +1846,6 @@ func (c CodeMonitorStoreCreateRecipientsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c CodeMonitorStoreCreateRecipientsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
-}
-
-// CodeMonitorStoreCreateTriggerQueryFunc describes the behavior when the
-// CreateTriggerQuery method of the parent MockCodeMonitorStore instance is
-// invoked.
-type CodeMonitorStoreCreateTriggerQueryFunc struct {
-	defaultHook func(context.Context, int64, *graphqlbackend.CreateTriggerArgs) error
-	hooks       []func(context.Context, int64, *graphqlbackend.CreateTriggerArgs) error
-	history     []CodeMonitorStoreCreateTriggerQueryFuncCall
-	mutex       sync.Mutex
-}
-
-// CreateTriggerQuery delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) CreateTriggerQuery(v0 context.Context, v1 int64, v2 *graphqlbackend.CreateTriggerArgs) error {
-	r0 := m.CreateTriggerQueryFunc.nextHook()(v0, v1, v2)
-	m.CreateTriggerQueryFunc.appendCall(CodeMonitorStoreCreateTriggerQueryFuncCall{v0, v1, v2, r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the CreateTriggerQuery
-// method of the parent MockCodeMonitorStore instance is invoked and the
-// hook queue is empty.
-func (f *CodeMonitorStoreCreateTriggerQueryFunc) SetDefaultHook(hook func(context.Context, int64, *graphqlbackend.CreateTriggerArgs) error) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// CreateTriggerQuery method of the parent MockCodeMonitorStore instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *CodeMonitorStoreCreateTriggerQueryFunc) PushHook(hook func(context.Context, int64, *graphqlbackend.CreateTriggerArgs) error) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
-// the given values.
-func (f *CodeMonitorStoreCreateTriggerQueryFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, int64, *graphqlbackend.CreateTriggerArgs) error {
-		return r0
-	})
-}
-
-// PushReturn calls PushDefaultHook with a function that returns the given
-// values.
-func (f *CodeMonitorStoreCreateTriggerQueryFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, int64, *graphqlbackend.CreateTriggerArgs) error {
-		return r0
-	})
-}
-
-func (f *CodeMonitorStoreCreateTriggerQueryFunc) nextHook() func(context.Context, int64, *graphqlbackend.CreateTriggerArgs) error {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *CodeMonitorStoreCreateTriggerQueryFunc) appendCall(r0 CodeMonitorStoreCreateTriggerQueryFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of CodeMonitorStoreCreateTriggerQueryFuncCall
-// objects describing the invocations of this function.
-func (f *CodeMonitorStoreCreateTriggerQueryFunc) History() []CodeMonitorStoreCreateTriggerQueryFuncCall {
-	f.mutex.Lock()
-	history := make([]CodeMonitorStoreCreateTriggerQueryFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// CodeMonitorStoreCreateTriggerQueryFuncCall is an object that describes an
-// invocation of method CreateTriggerQuery on an instance of
-// MockCodeMonitorStore.
-type CodeMonitorStoreCreateTriggerQueryFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int64
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 *graphqlbackend.CreateTriggerArgs
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c CodeMonitorStoreCreateTriggerQueryFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c CodeMonitorStoreCreateTriggerQueryFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
@@ -1845,37 +2069,37 @@ func (c CodeMonitorStoreDeleteMonitorFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
-// CodeMonitorStoreDeleteObsoleteJobLogsFunc describes the behavior when the
-// DeleteObsoleteJobLogs method of the parent MockCodeMonitorStore instance
-// is invoked.
-type CodeMonitorStoreDeleteObsoleteJobLogsFunc struct {
+// CodeMonitorStoreDeleteObsoleteTriggerJobsFunc describes the behavior when
+// the DeleteObsoleteTriggerJobs method of the parent MockCodeMonitorStore
+// instance is invoked.
+type CodeMonitorStoreDeleteObsoleteTriggerJobsFunc struct {
 	defaultHook func(context.Context) error
 	hooks       []func(context.Context) error
-	history     []CodeMonitorStoreDeleteObsoleteJobLogsFuncCall
+	history     []CodeMonitorStoreDeleteObsoleteTriggerJobsFuncCall
 	mutex       sync.Mutex
 }
 
-// DeleteObsoleteJobLogs delegates to the next hook function in the queue
-// and stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) DeleteObsoleteJobLogs(v0 context.Context) error {
-	r0 := m.DeleteObsoleteJobLogsFunc.nextHook()(v0)
-	m.DeleteObsoleteJobLogsFunc.appendCall(CodeMonitorStoreDeleteObsoleteJobLogsFuncCall{v0, r0})
+// DeleteObsoleteTriggerJobs delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockCodeMonitorStore) DeleteObsoleteTriggerJobs(v0 context.Context) error {
+	r0 := m.DeleteObsoleteTriggerJobsFunc.nextHook()(v0)
+	m.DeleteObsoleteTriggerJobsFunc.appendCall(CodeMonitorStoreDeleteObsoleteTriggerJobsFuncCall{v0, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the
-// DeleteObsoleteJobLogs method of the parent MockCodeMonitorStore instance
-// is invoked and the hook queue is empty.
-func (f *CodeMonitorStoreDeleteObsoleteJobLogsFunc) SetDefaultHook(hook func(context.Context) error) {
+// DeleteObsoleteTriggerJobs method of the parent MockCodeMonitorStore
+// instance is invoked and the hook queue is empty.
+func (f *CodeMonitorStoreDeleteObsoleteTriggerJobsFunc) SetDefaultHook(hook func(context.Context) error) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// DeleteObsoleteJobLogs method of the parent MockCodeMonitorStore instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *CodeMonitorStoreDeleteObsoleteJobLogsFunc) PushHook(hook func(context.Context) error) {
+// DeleteObsoleteTriggerJobs method of the parent MockCodeMonitorStore
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *CodeMonitorStoreDeleteObsoleteTriggerJobsFunc) PushHook(hook func(context.Context) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1883,7 +2107,7 @@ func (f *CodeMonitorStoreDeleteObsoleteJobLogsFunc) PushHook(hook func(context.C
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *CodeMonitorStoreDeleteObsoleteJobLogsFunc) SetDefaultReturn(r0 error) {
+func (f *CodeMonitorStoreDeleteObsoleteTriggerJobsFunc) SetDefaultReturn(r0 error) {
 	f.SetDefaultHook(func(context.Context) error {
 		return r0
 	})
@@ -1891,13 +2115,13 @@ func (f *CodeMonitorStoreDeleteObsoleteJobLogsFunc) SetDefaultReturn(r0 error) {
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *CodeMonitorStoreDeleteObsoleteJobLogsFunc) PushReturn(r0 error) {
+func (f *CodeMonitorStoreDeleteObsoleteTriggerJobsFunc) PushReturn(r0 error) {
 	f.PushHook(func(context.Context) error {
 		return r0
 	})
 }
 
-func (f *CodeMonitorStoreDeleteObsoleteJobLogsFunc) nextHook() func(context.Context) error {
+func (f *CodeMonitorStoreDeleteObsoleteTriggerJobsFunc) nextHook() func(context.Context) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1910,28 +2134,28 @@ func (f *CodeMonitorStoreDeleteObsoleteJobLogsFunc) nextHook() func(context.Cont
 	return hook
 }
 
-func (f *CodeMonitorStoreDeleteObsoleteJobLogsFunc) appendCall(r0 CodeMonitorStoreDeleteObsoleteJobLogsFuncCall) {
+func (f *CodeMonitorStoreDeleteObsoleteTriggerJobsFunc) appendCall(r0 CodeMonitorStoreDeleteObsoleteTriggerJobsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// CodeMonitorStoreDeleteObsoleteJobLogsFuncCall objects describing the
+// CodeMonitorStoreDeleteObsoleteTriggerJobsFuncCall objects describing the
 // invocations of this function.
-func (f *CodeMonitorStoreDeleteObsoleteJobLogsFunc) History() []CodeMonitorStoreDeleteObsoleteJobLogsFuncCall {
+func (f *CodeMonitorStoreDeleteObsoleteTriggerJobsFunc) History() []CodeMonitorStoreDeleteObsoleteTriggerJobsFuncCall {
 	f.mutex.Lock()
-	history := make([]CodeMonitorStoreDeleteObsoleteJobLogsFuncCall, len(f.history))
+	history := make([]CodeMonitorStoreDeleteObsoleteTriggerJobsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// CodeMonitorStoreDeleteObsoleteJobLogsFuncCall is an object that describes
-// an invocation of method DeleteObsoleteJobLogs on an instance of
-// MockCodeMonitorStore.
-type CodeMonitorStoreDeleteObsoleteJobLogsFuncCall struct {
+// CodeMonitorStoreDeleteObsoleteTriggerJobsFuncCall is an object that
+// describes an invocation of method DeleteObsoleteTriggerJobs on an
+// instance of MockCodeMonitorStore.
+type CodeMonitorStoreDeleteObsoleteTriggerJobsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -1942,47 +2166,47 @@ type CodeMonitorStoreDeleteObsoleteJobLogsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c CodeMonitorStoreDeleteObsoleteJobLogsFuncCall) Args() []interface{} {
+func (c CodeMonitorStoreDeleteObsoleteTriggerJobsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c CodeMonitorStoreDeleteObsoleteJobLogsFuncCall) Results() []interface{} {
+func (c CodeMonitorStoreDeleteObsoleteTriggerJobsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
-// CodeMonitorStoreDeleteOldJobLogsFunc describes the behavior when the
-// DeleteOldJobLogs method of the parent MockCodeMonitorStore instance is
-// invoked.
-type CodeMonitorStoreDeleteOldJobLogsFunc struct {
+// CodeMonitorStoreDeleteOldTriggerJobsFunc describes the behavior when the
+// DeleteOldTriggerJobs method of the parent MockCodeMonitorStore instance
+// is invoked.
+type CodeMonitorStoreDeleteOldTriggerJobsFunc struct {
 	defaultHook func(context.Context, int) error
 	hooks       []func(context.Context, int) error
-	history     []CodeMonitorStoreDeleteOldJobLogsFuncCall
+	history     []CodeMonitorStoreDeleteOldTriggerJobsFuncCall
 	mutex       sync.Mutex
 }
 
-// DeleteOldJobLogs delegates to the next hook function in the queue and
+// DeleteOldTriggerJobs delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) DeleteOldJobLogs(v0 context.Context, v1 int) error {
-	r0 := m.DeleteOldJobLogsFunc.nextHook()(v0, v1)
-	m.DeleteOldJobLogsFunc.appendCall(CodeMonitorStoreDeleteOldJobLogsFuncCall{v0, v1, r0})
+func (m *MockCodeMonitorStore) DeleteOldTriggerJobs(v0 context.Context, v1 int) error {
+	r0 := m.DeleteOldTriggerJobsFunc.nextHook()(v0, v1)
+	m.DeleteOldTriggerJobsFunc.appendCall(CodeMonitorStoreDeleteOldTriggerJobsFuncCall{v0, v1, r0})
 	return r0
 }
 
-// SetDefaultHook sets function that is called when the DeleteOldJobLogs
+// SetDefaultHook sets function that is called when the DeleteOldTriggerJobs
 // method of the parent MockCodeMonitorStore instance is invoked and the
 // hook queue is empty.
-func (f *CodeMonitorStoreDeleteOldJobLogsFunc) SetDefaultHook(hook func(context.Context, int) error) {
+func (f *CodeMonitorStoreDeleteOldTriggerJobsFunc) SetDefaultHook(hook func(context.Context, int) error) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// DeleteOldJobLogs method of the parent MockCodeMonitorStore instance
+// DeleteOldTriggerJobs method of the parent MockCodeMonitorStore instance
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *CodeMonitorStoreDeleteOldJobLogsFunc) PushHook(hook func(context.Context, int) error) {
+func (f *CodeMonitorStoreDeleteOldTriggerJobsFunc) PushHook(hook func(context.Context, int) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1990,7 +2214,7 @@ func (f *CodeMonitorStoreDeleteOldJobLogsFunc) PushHook(hook func(context.Contex
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *CodeMonitorStoreDeleteOldJobLogsFunc) SetDefaultReturn(r0 error) {
+func (f *CodeMonitorStoreDeleteOldTriggerJobsFunc) SetDefaultReturn(r0 error) {
 	f.SetDefaultHook(func(context.Context, int) error {
 		return r0
 	})
@@ -1998,13 +2222,13 @@ func (f *CodeMonitorStoreDeleteOldJobLogsFunc) SetDefaultReturn(r0 error) {
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *CodeMonitorStoreDeleteOldJobLogsFunc) PushReturn(r0 error) {
+func (f *CodeMonitorStoreDeleteOldTriggerJobsFunc) PushReturn(r0 error) {
 	f.PushHook(func(context.Context, int) error {
 		return r0
 	})
 }
 
-func (f *CodeMonitorStoreDeleteOldJobLogsFunc) nextHook() func(context.Context, int) error {
+func (f *CodeMonitorStoreDeleteOldTriggerJobsFunc) nextHook() func(context.Context, int) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2017,27 +2241,28 @@ func (f *CodeMonitorStoreDeleteOldJobLogsFunc) nextHook() func(context.Context, 
 	return hook
 }
 
-func (f *CodeMonitorStoreDeleteOldJobLogsFunc) appendCall(r0 CodeMonitorStoreDeleteOldJobLogsFuncCall) {
+func (f *CodeMonitorStoreDeleteOldTriggerJobsFunc) appendCall(r0 CodeMonitorStoreDeleteOldTriggerJobsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of CodeMonitorStoreDeleteOldJobLogsFuncCall
-// objects describing the invocations of this function.
-func (f *CodeMonitorStoreDeleteOldJobLogsFunc) History() []CodeMonitorStoreDeleteOldJobLogsFuncCall {
+// History returns a sequence of
+// CodeMonitorStoreDeleteOldTriggerJobsFuncCall objects describing the
+// invocations of this function.
+func (f *CodeMonitorStoreDeleteOldTriggerJobsFunc) History() []CodeMonitorStoreDeleteOldTriggerJobsFuncCall {
 	f.mutex.Lock()
-	history := make([]CodeMonitorStoreDeleteOldJobLogsFuncCall, len(f.history))
+	history := make([]CodeMonitorStoreDeleteOldTriggerJobsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// CodeMonitorStoreDeleteOldJobLogsFuncCall is an object that describes an
-// invocation of method DeleteOldJobLogs on an instance of
+// CodeMonitorStoreDeleteOldTriggerJobsFuncCall is an object that describes
+// an invocation of method DeleteOldTriggerJobs on an instance of
 // MockCodeMonitorStore.
-type CodeMonitorStoreDeleteOldJobLogsFuncCall struct {
+type CodeMonitorStoreDeleteOldTriggerJobsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -2051,13 +2276,13 @@ type CodeMonitorStoreDeleteOldJobLogsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c CodeMonitorStoreDeleteOldJobLogsFuncCall) Args() []interface{} {
+func (c CodeMonitorStoreDeleteOldTriggerJobsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c CodeMonitorStoreDeleteOldJobLogsFuncCall) Results() []interface{} {
+func (c CodeMonitorStoreDeleteOldTriggerJobsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
@@ -2273,37 +2498,37 @@ func (c CodeMonitorStoreDoneFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
-// CodeMonitorStoreEnqueueActionEmailsForQueryIDInt64Func describes the
-// behavior when the EnqueueActionEmailsForQueryIDInt64 method of the parent
-// MockCodeMonitorStore instance is invoked.
-type CodeMonitorStoreEnqueueActionEmailsForQueryIDInt64Func struct {
+// CodeMonitorStoreEnqueueActionJobsForQueryFunc describes the behavior when
+// the EnqueueActionJobsForQuery method of the parent MockCodeMonitorStore
+// instance is invoked.
+type CodeMonitorStoreEnqueueActionJobsForQueryFunc struct {
 	defaultHook func(context.Context, int64, int) error
 	hooks       []func(context.Context, int64, int) error
-	history     []CodeMonitorStoreEnqueueActionEmailsForQueryIDInt64FuncCall
+	history     []CodeMonitorStoreEnqueueActionJobsForQueryFuncCall
 	mutex       sync.Mutex
 }
 
-// EnqueueActionEmailsForQueryIDInt64 delegates to the next hook function in
-// the queue and stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) EnqueueActionEmailsForQueryIDInt64(v0 context.Context, v1 int64, v2 int) error {
-	r0 := m.EnqueueActionEmailsForQueryIDInt64Func.nextHook()(v0, v1, v2)
-	m.EnqueueActionEmailsForQueryIDInt64Func.appendCall(CodeMonitorStoreEnqueueActionEmailsForQueryIDInt64FuncCall{v0, v1, v2, r0})
+// EnqueueActionJobsForQuery delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockCodeMonitorStore) EnqueueActionJobsForQuery(v0 context.Context, v1 int64, v2 int) error {
+	r0 := m.EnqueueActionJobsForQueryFunc.nextHook()(v0, v1, v2)
+	m.EnqueueActionJobsForQueryFunc.appendCall(CodeMonitorStoreEnqueueActionJobsForQueryFuncCall{v0, v1, v2, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the
-// EnqueueActionEmailsForQueryIDInt64 method of the parent
-// MockCodeMonitorStore instance is invoked and the hook queue is empty.
-func (f *CodeMonitorStoreEnqueueActionEmailsForQueryIDInt64Func) SetDefaultHook(hook func(context.Context, int64, int) error) {
+// EnqueueActionJobsForQuery method of the parent MockCodeMonitorStore
+// instance is invoked and the hook queue is empty.
+func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) SetDefaultHook(hook func(context.Context, int64, int) error) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// EnqueueActionEmailsForQueryIDInt64 method of the parent
-// MockCodeMonitorStore instance invokes the hook at the front of the queue
-// and discards it. After the queue is empty, the default hook function is
-// invoked for any future action.
-func (f *CodeMonitorStoreEnqueueActionEmailsForQueryIDInt64Func) PushHook(hook func(context.Context, int64, int) error) {
+// EnqueueActionJobsForQuery method of the parent MockCodeMonitorStore
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) PushHook(hook func(context.Context, int64, int) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2311,7 +2536,7 @@ func (f *CodeMonitorStoreEnqueueActionEmailsForQueryIDInt64Func) PushHook(hook f
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *CodeMonitorStoreEnqueueActionEmailsForQueryIDInt64Func) SetDefaultReturn(r0 error) {
+func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) SetDefaultReturn(r0 error) {
 	f.SetDefaultHook(func(context.Context, int64, int) error {
 		return r0
 	})
@@ -2319,13 +2544,13 @@ func (f *CodeMonitorStoreEnqueueActionEmailsForQueryIDInt64Func) SetDefaultRetur
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *CodeMonitorStoreEnqueueActionEmailsForQueryIDInt64Func) PushReturn(r0 error) {
+func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) PushReturn(r0 error) {
 	f.PushHook(func(context.Context, int64, int) error {
 		return r0
 	})
 }
 
-func (f *CodeMonitorStoreEnqueueActionEmailsForQueryIDInt64Func) nextHook() func(context.Context, int64, int) error {
+func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) nextHook() func(context.Context, int64, int) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2338,28 +2563,28 @@ func (f *CodeMonitorStoreEnqueueActionEmailsForQueryIDInt64Func) nextHook() func
 	return hook
 }
 
-func (f *CodeMonitorStoreEnqueueActionEmailsForQueryIDInt64Func) appendCall(r0 CodeMonitorStoreEnqueueActionEmailsForQueryIDInt64FuncCall) {
+func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) appendCall(r0 CodeMonitorStoreEnqueueActionJobsForQueryFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// CodeMonitorStoreEnqueueActionEmailsForQueryIDInt64FuncCall objects
-// describing the invocations of this function.
-func (f *CodeMonitorStoreEnqueueActionEmailsForQueryIDInt64Func) History() []CodeMonitorStoreEnqueueActionEmailsForQueryIDInt64FuncCall {
+// CodeMonitorStoreEnqueueActionJobsForQueryFuncCall objects describing the
+// invocations of this function.
+func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) History() []CodeMonitorStoreEnqueueActionJobsForQueryFuncCall {
 	f.mutex.Lock()
-	history := make([]CodeMonitorStoreEnqueueActionEmailsForQueryIDInt64FuncCall, len(f.history))
+	history := make([]CodeMonitorStoreEnqueueActionJobsForQueryFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// CodeMonitorStoreEnqueueActionEmailsForQueryIDInt64FuncCall is an object
-// that describes an invocation of method EnqueueActionEmailsForQueryIDInt64
-// on an instance of MockCodeMonitorStore.
-type CodeMonitorStoreEnqueueActionEmailsForQueryIDInt64FuncCall struct {
+// CodeMonitorStoreEnqueueActionJobsForQueryFuncCall is an object that
+// describes an invocation of method EnqueueActionJobsForQuery on an
+// instance of MockCodeMonitorStore.
+type CodeMonitorStoreEnqueueActionJobsForQueryFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -2376,47 +2601,47 @@ type CodeMonitorStoreEnqueueActionEmailsForQueryIDInt64FuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c CodeMonitorStoreEnqueueActionEmailsForQueryIDInt64FuncCall) Args() []interface{} {
+func (c CodeMonitorStoreEnqueueActionJobsForQueryFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c CodeMonitorStoreEnqueueActionEmailsForQueryIDInt64FuncCall) Results() []interface{} {
+func (c CodeMonitorStoreEnqueueActionJobsForQueryFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
-// CodeMonitorStoreEnqueueTriggerQueriesFunc describes the behavior when the
-// EnqueueTriggerQueries method of the parent MockCodeMonitorStore instance
-// is invoked.
-type CodeMonitorStoreEnqueueTriggerQueriesFunc struct {
+// CodeMonitorStoreEnqueueQueryTriggerJobsFunc describes the behavior when
+// the EnqueueQueryTriggerJobs method of the parent MockCodeMonitorStore
+// instance is invoked.
+type CodeMonitorStoreEnqueueQueryTriggerJobsFunc struct {
 	defaultHook func(context.Context) error
 	hooks       []func(context.Context) error
-	history     []CodeMonitorStoreEnqueueTriggerQueriesFuncCall
+	history     []CodeMonitorStoreEnqueueQueryTriggerJobsFuncCall
 	mutex       sync.Mutex
 }
 
-// EnqueueTriggerQueries delegates to the next hook function in the queue
+// EnqueueQueryTriggerJobs delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) EnqueueTriggerQueries(v0 context.Context) error {
-	r0 := m.EnqueueTriggerQueriesFunc.nextHook()(v0)
-	m.EnqueueTriggerQueriesFunc.appendCall(CodeMonitorStoreEnqueueTriggerQueriesFuncCall{v0, r0})
+func (m *MockCodeMonitorStore) EnqueueQueryTriggerJobs(v0 context.Context) error {
+	r0 := m.EnqueueQueryTriggerJobsFunc.nextHook()(v0)
+	m.EnqueueQueryTriggerJobsFunc.appendCall(CodeMonitorStoreEnqueueQueryTriggerJobsFuncCall{v0, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the
-// EnqueueTriggerQueries method of the parent MockCodeMonitorStore instance
-// is invoked and the hook queue is empty.
-func (f *CodeMonitorStoreEnqueueTriggerQueriesFunc) SetDefaultHook(hook func(context.Context) error) {
+// EnqueueQueryTriggerJobs method of the parent MockCodeMonitorStore
+// instance is invoked and the hook queue is empty.
+func (f *CodeMonitorStoreEnqueueQueryTriggerJobsFunc) SetDefaultHook(hook func(context.Context) error) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// EnqueueTriggerQueries method of the parent MockCodeMonitorStore instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *CodeMonitorStoreEnqueueTriggerQueriesFunc) PushHook(hook func(context.Context) error) {
+// EnqueueQueryTriggerJobs method of the parent MockCodeMonitorStore
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *CodeMonitorStoreEnqueueQueryTriggerJobsFunc) PushHook(hook func(context.Context) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2424,7 +2649,7 @@ func (f *CodeMonitorStoreEnqueueTriggerQueriesFunc) PushHook(hook func(context.C
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *CodeMonitorStoreEnqueueTriggerQueriesFunc) SetDefaultReturn(r0 error) {
+func (f *CodeMonitorStoreEnqueueQueryTriggerJobsFunc) SetDefaultReturn(r0 error) {
 	f.SetDefaultHook(func(context.Context) error {
 		return r0
 	})
@@ -2432,13 +2657,13 @@ func (f *CodeMonitorStoreEnqueueTriggerQueriesFunc) SetDefaultReturn(r0 error) {
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *CodeMonitorStoreEnqueueTriggerQueriesFunc) PushReturn(r0 error) {
+func (f *CodeMonitorStoreEnqueueQueryTriggerJobsFunc) PushReturn(r0 error) {
 	f.PushHook(func(context.Context) error {
 		return r0
 	})
 }
 
-func (f *CodeMonitorStoreEnqueueTriggerQueriesFunc) nextHook() func(context.Context) error {
+func (f *CodeMonitorStoreEnqueueQueryTriggerJobsFunc) nextHook() func(context.Context) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2451,28 +2676,28 @@ func (f *CodeMonitorStoreEnqueueTriggerQueriesFunc) nextHook() func(context.Cont
 	return hook
 }
 
-func (f *CodeMonitorStoreEnqueueTriggerQueriesFunc) appendCall(r0 CodeMonitorStoreEnqueueTriggerQueriesFuncCall) {
+func (f *CodeMonitorStoreEnqueueQueryTriggerJobsFunc) appendCall(r0 CodeMonitorStoreEnqueueQueryTriggerJobsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// CodeMonitorStoreEnqueueTriggerQueriesFuncCall objects describing the
+// CodeMonitorStoreEnqueueQueryTriggerJobsFuncCall objects describing the
 // invocations of this function.
-func (f *CodeMonitorStoreEnqueueTriggerQueriesFunc) History() []CodeMonitorStoreEnqueueTriggerQueriesFuncCall {
+func (f *CodeMonitorStoreEnqueueQueryTriggerJobsFunc) History() []CodeMonitorStoreEnqueueQueryTriggerJobsFuncCall {
 	f.mutex.Lock()
-	history := make([]CodeMonitorStoreEnqueueTriggerQueriesFuncCall, len(f.history))
+	history := make([]CodeMonitorStoreEnqueueQueryTriggerJobsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// CodeMonitorStoreEnqueueTriggerQueriesFuncCall is an object that describes
-// an invocation of method EnqueueTriggerQueries on an instance of
-// MockCodeMonitorStore.
-type CodeMonitorStoreEnqueueTriggerQueriesFuncCall struct {
+// CodeMonitorStoreEnqueueQueryTriggerJobsFuncCall is an object that
+// describes an invocation of method EnqueueQueryTriggerJobs on an instance
+// of MockCodeMonitorStore.
+type CodeMonitorStoreEnqueueQueryTriggerJobsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -2483,13 +2708,13 @@ type CodeMonitorStoreEnqueueTriggerQueriesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c CodeMonitorStoreEnqueueTriggerQueriesFuncCall) Args() []interface{} {
+func (c CodeMonitorStoreEnqueueQueryTriggerJobsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c CodeMonitorStoreEnqueueTriggerQueriesFuncCall) Results() []interface{} {
+func (c CodeMonitorStoreEnqueueQueryTriggerJobsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
@@ -2933,122 +3158,6 @@ func (c CodeMonitorStoreGetEmailActionFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// CodeMonitorStoreGetEventsForQueryIDInt64Func describes the behavior when
-// the GetEventsForQueryIDInt64 method of the parent MockCodeMonitorStore
-// instance is invoked.
-type CodeMonitorStoreGetEventsForQueryIDInt64Func struct {
-	defaultHook func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error)
-	hooks       []func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error)
-	history     []CodeMonitorStoreGetEventsForQueryIDInt64FuncCall
-	mutex       sync.Mutex
-}
-
-// GetEventsForQueryIDInt64 delegates to the next hook function in the queue
-// and stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) GetEventsForQueryIDInt64(v0 context.Context, v1 int64, v2 *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error) {
-	r0, r1 := m.GetEventsForQueryIDInt64Func.nextHook()(v0, v1, v2)
-	m.GetEventsForQueryIDInt64Func.appendCall(CodeMonitorStoreGetEventsForQueryIDInt64FuncCall{v0, v1, v2, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// GetEventsForQueryIDInt64 method of the parent MockCodeMonitorStore
-// instance is invoked and the hook queue is empty.
-func (f *CodeMonitorStoreGetEventsForQueryIDInt64Func) SetDefaultHook(hook func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetEventsForQueryIDInt64 method of the parent MockCodeMonitorStore
-// instance invokes the hook at the front of the queue and discards it.
-// After the queue is empty, the default hook function is invoked for any
-// future action.
-func (f *CodeMonitorStoreGetEventsForQueryIDInt64Func) PushHook(hook func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
-// the given values.
-func (f *CodeMonitorStoreGetEventsForQueryIDInt64Func) SetDefaultReturn(r0 []*TriggerJob, r1 error) {
-	f.SetDefaultHook(func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushDefaultHook with a function that returns the given
-// values.
-func (f *CodeMonitorStoreGetEventsForQueryIDInt64Func) PushReturn(r0 []*TriggerJob, r1 error) {
-	f.PushHook(func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error) {
-		return r0, r1
-	})
-}
-
-func (f *CodeMonitorStoreGetEventsForQueryIDInt64Func) nextHook() func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *CodeMonitorStoreGetEventsForQueryIDInt64Func) appendCall(r0 CodeMonitorStoreGetEventsForQueryIDInt64FuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// CodeMonitorStoreGetEventsForQueryIDInt64FuncCall objects describing the
-// invocations of this function.
-func (f *CodeMonitorStoreGetEventsForQueryIDInt64Func) History() []CodeMonitorStoreGetEventsForQueryIDInt64FuncCall {
-	f.mutex.Lock()
-	history := make([]CodeMonitorStoreGetEventsForQueryIDInt64FuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// CodeMonitorStoreGetEventsForQueryIDInt64FuncCall is an object that
-// describes an invocation of method GetEventsForQueryIDInt64 on an instance
-// of MockCodeMonitorStore.
-type CodeMonitorStoreGetEventsForQueryIDInt64FuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int64
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 *graphqlbackend.ListEventsArgs
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []*TriggerJob
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c CodeMonitorStoreGetEventsForQueryIDInt64FuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c CodeMonitorStoreGetEventsForQueryIDInt64FuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
 // CodeMonitorStoreGetMonitorFunc describes the behavior when the GetMonitor
 // method of the parent MockCodeMonitorStore instance is invoked.
 type CodeMonitorStoreGetMonitorFunc struct {
@@ -3158,37 +3267,37 @@ func (c CodeMonitorStoreGetMonitorFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// CodeMonitorStoreGetQueryByRecordIDFunc describes the behavior when the
-// GetQueryByRecordID method of the parent MockCodeMonitorStore instance is
-// invoked.
-type CodeMonitorStoreGetQueryByRecordIDFunc struct {
+// CodeMonitorStoreGetQueryTriggerForJobFunc describes the behavior when the
+// GetQueryTriggerForJob method of the parent MockCodeMonitorStore instance
+// is invoked.
+type CodeMonitorStoreGetQueryTriggerForJobFunc struct {
 	defaultHook func(context.Context, int) (*QueryTrigger, error)
 	hooks       []func(context.Context, int) (*QueryTrigger, error)
-	history     []CodeMonitorStoreGetQueryByRecordIDFuncCall
+	history     []CodeMonitorStoreGetQueryTriggerForJobFuncCall
 	mutex       sync.Mutex
 }
 
-// GetQueryByRecordID delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) GetQueryByRecordID(v0 context.Context, v1 int) (*QueryTrigger, error) {
-	r0, r1 := m.GetQueryByRecordIDFunc.nextHook()(v0, v1)
-	m.GetQueryByRecordIDFunc.appendCall(CodeMonitorStoreGetQueryByRecordIDFuncCall{v0, v1, r0, r1})
+// GetQueryTriggerForJob delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockCodeMonitorStore) GetQueryTriggerForJob(v0 context.Context, v1 int) (*QueryTrigger, error) {
+	r0, r1 := m.GetQueryTriggerForJobFunc.nextHook()(v0, v1)
+	m.GetQueryTriggerForJobFunc.appendCall(CodeMonitorStoreGetQueryTriggerForJobFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
-// SetDefaultHook sets function that is called when the GetQueryByRecordID
-// method of the parent MockCodeMonitorStore instance is invoked and the
-// hook queue is empty.
-func (f *CodeMonitorStoreGetQueryByRecordIDFunc) SetDefaultHook(hook func(context.Context, int) (*QueryTrigger, error)) {
+// SetDefaultHook sets function that is called when the
+// GetQueryTriggerForJob method of the parent MockCodeMonitorStore instance
+// is invoked and the hook queue is empty.
+func (f *CodeMonitorStoreGetQueryTriggerForJobFunc) SetDefaultHook(hook func(context.Context, int) (*QueryTrigger, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// GetQueryByRecordID method of the parent MockCodeMonitorStore instance
+// GetQueryTriggerForJob method of the parent MockCodeMonitorStore instance
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *CodeMonitorStoreGetQueryByRecordIDFunc) PushHook(hook func(context.Context, int) (*QueryTrigger, error)) {
+func (f *CodeMonitorStoreGetQueryTriggerForJobFunc) PushHook(hook func(context.Context, int) (*QueryTrigger, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3196,7 +3305,7 @@ func (f *CodeMonitorStoreGetQueryByRecordIDFunc) PushHook(hook func(context.Cont
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *CodeMonitorStoreGetQueryByRecordIDFunc) SetDefaultReturn(r0 *QueryTrigger, r1 error) {
+func (f *CodeMonitorStoreGetQueryTriggerForJobFunc) SetDefaultReturn(r0 *QueryTrigger, r1 error) {
 	f.SetDefaultHook(func(context.Context, int) (*QueryTrigger, error) {
 		return r0, r1
 	})
@@ -3204,13 +3313,13 @@ func (f *CodeMonitorStoreGetQueryByRecordIDFunc) SetDefaultReturn(r0 *QueryTrigg
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *CodeMonitorStoreGetQueryByRecordIDFunc) PushReturn(r0 *QueryTrigger, r1 error) {
+func (f *CodeMonitorStoreGetQueryTriggerForJobFunc) PushReturn(r0 *QueryTrigger, r1 error) {
 	f.PushHook(func(context.Context, int) (*QueryTrigger, error) {
 		return r0, r1
 	})
 }
 
-func (f *CodeMonitorStoreGetQueryByRecordIDFunc) nextHook() func(context.Context, int) (*QueryTrigger, error) {
+func (f *CodeMonitorStoreGetQueryTriggerForJobFunc) nextHook() func(context.Context, int) (*QueryTrigger, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3223,27 +3332,28 @@ func (f *CodeMonitorStoreGetQueryByRecordIDFunc) nextHook() func(context.Context
 	return hook
 }
 
-func (f *CodeMonitorStoreGetQueryByRecordIDFunc) appendCall(r0 CodeMonitorStoreGetQueryByRecordIDFuncCall) {
+func (f *CodeMonitorStoreGetQueryTriggerForJobFunc) appendCall(r0 CodeMonitorStoreGetQueryTriggerForJobFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of CodeMonitorStoreGetQueryByRecordIDFuncCall
-// objects describing the invocations of this function.
-func (f *CodeMonitorStoreGetQueryByRecordIDFunc) History() []CodeMonitorStoreGetQueryByRecordIDFuncCall {
+// History returns a sequence of
+// CodeMonitorStoreGetQueryTriggerForJobFuncCall objects describing the
+// invocations of this function.
+func (f *CodeMonitorStoreGetQueryTriggerForJobFunc) History() []CodeMonitorStoreGetQueryTriggerForJobFuncCall {
 	f.mutex.Lock()
-	history := make([]CodeMonitorStoreGetQueryByRecordIDFuncCall, len(f.history))
+	history := make([]CodeMonitorStoreGetQueryTriggerForJobFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// CodeMonitorStoreGetQueryByRecordIDFuncCall is an object that describes an
-// invocation of method GetQueryByRecordID on an instance of
+// CodeMonitorStoreGetQueryTriggerForJobFuncCall is an object that describes
+// an invocation of method GetQueryTriggerForJob on an instance of
 // MockCodeMonitorStore.
-type CodeMonitorStoreGetQueryByRecordIDFuncCall struct {
+type CodeMonitorStoreGetQueryTriggerForJobFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -3260,13 +3370,126 @@ type CodeMonitorStoreGetQueryByRecordIDFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c CodeMonitorStoreGetQueryByRecordIDFuncCall) Args() []interface{} {
+func (c CodeMonitorStoreGetQueryTriggerForJobFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c CodeMonitorStoreGetQueryByRecordIDFuncCall) Results() []interface{} {
+func (c CodeMonitorStoreGetQueryTriggerForJobFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// CodeMonitorStoreGetQueryTriggerForMonitorFunc describes the behavior when
+// the GetQueryTriggerForMonitor method of the parent MockCodeMonitorStore
+// instance is invoked.
+type CodeMonitorStoreGetQueryTriggerForMonitorFunc struct {
+	defaultHook func(context.Context, int64) (*QueryTrigger, error)
+	hooks       []func(context.Context, int64) (*QueryTrigger, error)
+	history     []CodeMonitorStoreGetQueryTriggerForMonitorFuncCall
+	mutex       sync.Mutex
+}
+
+// GetQueryTriggerForMonitor delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockCodeMonitorStore) GetQueryTriggerForMonitor(v0 context.Context, v1 int64) (*QueryTrigger, error) {
+	r0, r1 := m.GetQueryTriggerForMonitorFunc.nextHook()(v0, v1)
+	m.GetQueryTriggerForMonitorFunc.appendCall(CodeMonitorStoreGetQueryTriggerForMonitorFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// GetQueryTriggerForMonitor method of the parent MockCodeMonitorStore
+// instance is invoked and the hook queue is empty.
+func (f *CodeMonitorStoreGetQueryTriggerForMonitorFunc) SetDefaultHook(hook func(context.Context, int64) (*QueryTrigger, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetQueryTriggerForMonitor method of the parent MockCodeMonitorStore
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *CodeMonitorStoreGetQueryTriggerForMonitorFunc) PushHook(hook func(context.Context, int64) (*QueryTrigger, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *CodeMonitorStoreGetQueryTriggerForMonitorFunc) SetDefaultReturn(r0 *QueryTrigger, r1 error) {
+	f.SetDefaultHook(func(context.Context, int64) (*QueryTrigger, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *CodeMonitorStoreGetQueryTriggerForMonitorFunc) PushReturn(r0 *QueryTrigger, r1 error) {
+	f.PushHook(func(context.Context, int64) (*QueryTrigger, error) {
+		return r0, r1
+	})
+}
+
+func (f *CodeMonitorStoreGetQueryTriggerForMonitorFunc) nextHook() func(context.Context, int64) (*QueryTrigger, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *CodeMonitorStoreGetQueryTriggerForMonitorFunc) appendCall(r0 CodeMonitorStoreGetQueryTriggerForMonitorFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// CodeMonitorStoreGetQueryTriggerForMonitorFuncCall objects describing the
+// invocations of this function.
+func (f *CodeMonitorStoreGetQueryTriggerForMonitorFunc) History() []CodeMonitorStoreGetQueryTriggerForMonitorFuncCall {
+	f.mutex.Lock()
+	history := make([]CodeMonitorStoreGetQueryTriggerForMonitorFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// CodeMonitorStoreGetQueryTriggerForMonitorFuncCall is an object that
+// describes an invocation of method GetQueryTriggerForMonitor on an
+// instance of MockCodeMonitorStore.
+type CodeMonitorStoreGetQueryTriggerForMonitorFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int64
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 *QueryTrigger
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c CodeMonitorStoreGetQueryTriggerForMonitorFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c CodeMonitorStoreGetQueryTriggerForMonitorFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -3481,6 +3704,119 @@ func (c CodeMonitorStoreListActionJobsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
+// CodeMonitorStoreListAllRecipientsForEmailActionFunc describes the
+// behavior when the ListAllRecipientsForEmailAction method of the parent
+// MockCodeMonitorStore instance is invoked.
+type CodeMonitorStoreListAllRecipientsForEmailActionFunc struct {
+	defaultHook func(context.Context, int64) ([]*Recipient, error)
+	hooks       []func(context.Context, int64) ([]*Recipient, error)
+	history     []CodeMonitorStoreListAllRecipientsForEmailActionFuncCall
+	mutex       sync.Mutex
+}
+
+// ListAllRecipientsForEmailAction delegates to the next hook function in
+// the queue and stores the parameter and result values of this invocation.
+func (m *MockCodeMonitorStore) ListAllRecipientsForEmailAction(v0 context.Context, v1 int64) ([]*Recipient, error) {
+	r0, r1 := m.ListAllRecipientsForEmailActionFunc.nextHook()(v0, v1)
+	m.ListAllRecipientsForEmailActionFunc.appendCall(CodeMonitorStoreListAllRecipientsForEmailActionFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// ListAllRecipientsForEmailAction method of the parent MockCodeMonitorStore
+// instance is invoked and the hook queue is empty.
+func (f *CodeMonitorStoreListAllRecipientsForEmailActionFunc) SetDefaultHook(hook func(context.Context, int64) ([]*Recipient, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// ListAllRecipientsForEmailAction method of the parent MockCodeMonitorStore
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *CodeMonitorStoreListAllRecipientsForEmailActionFunc) PushHook(hook func(context.Context, int64) ([]*Recipient, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *CodeMonitorStoreListAllRecipientsForEmailActionFunc) SetDefaultReturn(r0 []*Recipient, r1 error) {
+	f.SetDefaultHook(func(context.Context, int64) ([]*Recipient, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *CodeMonitorStoreListAllRecipientsForEmailActionFunc) PushReturn(r0 []*Recipient, r1 error) {
+	f.PushHook(func(context.Context, int64) ([]*Recipient, error) {
+		return r0, r1
+	})
+}
+
+func (f *CodeMonitorStoreListAllRecipientsForEmailActionFunc) nextHook() func(context.Context, int64) ([]*Recipient, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *CodeMonitorStoreListAllRecipientsForEmailActionFunc) appendCall(r0 CodeMonitorStoreListAllRecipientsForEmailActionFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// CodeMonitorStoreListAllRecipientsForEmailActionFuncCall objects
+// describing the invocations of this function.
+func (f *CodeMonitorStoreListAllRecipientsForEmailActionFunc) History() []CodeMonitorStoreListAllRecipientsForEmailActionFuncCall {
+	f.mutex.Lock()
+	history := make([]CodeMonitorStoreListAllRecipientsForEmailActionFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// CodeMonitorStoreListAllRecipientsForEmailActionFuncCall is an object that
+// describes an invocation of method ListAllRecipientsForEmailAction on an
+// instance of MockCodeMonitorStore.
+type CodeMonitorStoreListAllRecipientsForEmailActionFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int64
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []*Recipient
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c CodeMonitorStoreListAllRecipientsForEmailActionFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c CodeMonitorStoreListAllRecipientsForEmailActionFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
 // CodeMonitorStoreListEmailActionsFunc describes the behavior when the
 // ListEmailActions method of the parent MockCodeMonitorStore instance is
 // invoked.
@@ -3593,147 +3929,36 @@ func (c CodeMonitorStoreListEmailActionsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// CodeMonitorStoreLogSearchFunc describes the behavior when the LogSearch
-// method of the parent MockCodeMonitorStore instance is invoked.
-type CodeMonitorStoreLogSearchFunc struct {
-	defaultHook func(context.Context, string, int, int) error
-	hooks       []func(context.Context, string, int, int) error
-	history     []CodeMonitorStoreLogSearchFuncCall
-	mutex       sync.Mutex
-}
-
-// LogSearch delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) LogSearch(v0 context.Context, v1 string, v2 int, v3 int) error {
-	r0 := m.LogSearchFunc.nextHook()(v0, v1, v2, v3)
-	m.LogSearchFunc.appendCall(CodeMonitorStoreLogSearchFuncCall{v0, v1, v2, v3, r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the LogSearch method of
-// the parent MockCodeMonitorStore instance is invoked and the hook queue is
-// empty.
-func (f *CodeMonitorStoreLogSearchFunc) SetDefaultHook(hook func(context.Context, string, int, int) error) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// LogSearch method of the parent MockCodeMonitorStore instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
-func (f *CodeMonitorStoreLogSearchFunc) PushHook(hook func(context.Context, string, int, int) error) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
-// the given values.
-func (f *CodeMonitorStoreLogSearchFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, string, int, int) error {
-		return r0
-	})
-}
-
-// PushReturn calls PushDefaultHook with a function that returns the given
-// values.
-func (f *CodeMonitorStoreLogSearchFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, string, int, int) error {
-		return r0
-	})
-}
-
-func (f *CodeMonitorStoreLogSearchFunc) nextHook() func(context.Context, string, int, int) error {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *CodeMonitorStoreLogSearchFunc) appendCall(r0 CodeMonitorStoreLogSearchFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of CodeMonitorStoreLogSearchFuncCall objects
-// describing the invocations of this function.
-func (f *CodeMonitorStoreLogSearchFunc) History() []CodeMonitorStoreLogSearchFuncCall {
-	f.mutex.Lock()
-	history := make([]CodeMonitorStoreLogSearchFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// CodeMonitorStoreLogSearchFuncCall is an object that describes an
-// invocation of method LogSearch on an instance of MockCodeMonitorStore.
-type CodeMonitorStoreLogSearchFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 string
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 int
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 int
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c CodeMonitorStoreLogSearchFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c CodeMonitorStoreLogSearchFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
-}
-
-// CodeMonitorStoreMonitorsFunc describes the behavior when the Monitors
-// method of the parent MockCodeMonitorStore instance is invoked.
-type CodeMonitorStoreMonitorsFunc struct {
+// CodeMonitorStoreListMonitorsFunc describes the behavior when the
+// ListMonitors method of the parent MockCodeMonitorStore instance is
+// invoked.
+type CodeMonitorStoreListMonitorsFunc struct {
 	defaultHook func(context.Context, int32, *graphqlbackend.ListMonitorsArgs) ([]*Monitor, error)
 	hooks       []func(context.Context, int32, *graphqlbackend.ListMonitorsArgs) ([]*Monitor, error)
-	history     []CodeMonitorStoreMonitorsFuncCall
+	history     []CodeMonitorStoreListMonitorsFuncCall
 	mutex       sync.Mutex
 }
 
-// Monitors delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) Monitors(v0 context.Context, v1 int32, v2 *graphqlbackend.ListMonitorsArgs) ([]*Monitor, error) {
-	r0, r1 := m.MonitorsFunc.nextHook()(v0, v1, v2)
-	m.MonitorsFunc.appendCall(CodeMonitorStoreMonitorsFuncCall{v0, v1, v2, r0, r1})
+// ListMonitors delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockCodeMonitorStore) ListMonitors(v0 context.Context, v1 int32, v2 *graphqlbackend.ListMonitorsArgs) ([]*Monitor, error) {
+	r0, r1 := m.ListMonitorsFunc.nextHook()(v0, v1, v2)
+	m.ListMonitorsFunc.appendCall(CodeMonitorStoreListMonitorsFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
 }
 
-// SetDefaultHook sets function that is called when the Monitors method of
-// the parent MockCodeMonitorStore instance is invoked and the hook queue is
-// empty.
-func (f *CodeMonitorStoreMonitorsFunc) SetDefaultHook(hook func(context.Context, int32, *graphqlbackend.ListMonitorsArgs) ([]*Monitor, error)) {
+// SetDefaultHook sets function that is called when the ListMonitors method
+// of the parent MockCodeMonitorStore instance is invoked and the hook queue
+// is empty.
+func (f *CodeMonitorStoreListMonitorsFunc) SetDefaultHook(hook func(context.Context, int32, *graphqlbackend.ListMonitorsArgs) ([]*Monitor, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// Monitors method of the parent MockCodeMonitorStore instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
-func (f *CodeMonitorStoreMonitorsFunc) PushHook(hook func(context.Context, int32, *graphqlbackend.ListMonitorsArgs) ([]*Monitor, error)) {
+// ListMonitors method of the parent MockCodeMonitorStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *CodeMonitorStoreListMonitorsFunc) PushHook(hook func(context.Context, int32, *graphqlbackend.ListMonitorsArgs) ([]*Monitor, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3741,7 +3966,7 @@ func (f *CodeMonitorStoreMonitorsFunc) PushHook(hook func(context.Context, int32
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *CodeMonitorStoreMonitorsFunc) SetDefaultReturn(r0 []*Monitor, r1 error) {
+func (f *CodeMonitorStoreListMonitorsFunc) SetDefaultReturn(r0 []*Monitor, r1 error) {
 	f.SetDefaultHook(func(context.Context, int32, *graphqlbackend.ListMonitorsArgs) ([]*Monitor, error) {
 		return r0, r1
 	})
@@ -3749,13 +3974,13 @@ func (f *CodeMonitorStoreMonitorsFunc) SetDefaultReturn(r0 []*Monitor, r1 error)
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *CodeMonitorStoreMonitorsFunc) PushReturn(r0 []*Monitor, r1 error) {
+func (f *CodeMonitorStoreListMonitorsFunc) PushReturn(r0 []*Monitor, r1 error) {
 	f.PushHook(func(context.Context, int32, *graphqlbackend.ListMonitorsArgs) ([]*Monitor, error) {
 		return r0, r1
 	})
 }
 
-func (f *CodeMonitorStoreMonitorsFunc) nextHook() func(context.Context, int32, *graphqlbackend.ListMonitorsArgs) ([]*Monitor, error) {
+func (f *CodeMonitorStoreListMonitorsFunc) nextHook() func(context.Context, int32, *graphqlbackend.ListMonitorsArgs) ([]*Monitor, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3768,26 +3993,26 @@ func (f *CodeMonitorStoreMonitorsFunc) nextHook() func(context.Context, int32, *
 	return hook
 }
 
-func (f *CodeMonitorStoreMonitorsFunc) appendCall(r0 CodeMonitorStoreMonitorsFuncCall) {
+func (f *CodeMonitorStoreListMonitorsFunc) appendCall(r0 CodeMonitorStoreListMonitorsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of CodeMonitorStoreMonitorsFuncCall objects
-// describing the invocations of this function.
-func (f *CodeMonitorStoreMonitorsFunc) History() []CodeMonitorStoreMonitorsFuncCall {
+// History returns a sequence of CodeMonitorStoreListMonitorsFuncCall
+// objects describing the invocations of this function.
+func (f *CodeMonitorStoreListMonitorsFunc) History() []CodeMonitorStoreListMonitorsFuncCall {
 	f.mutex.Lock()
-	history := make([]CodeMonitorStoreMonitorsFuncCall, len(f.history))
+	history := make([]CodeMonitorStoreListMonitorsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// CodeMonitorStoreMonitorsFuncCall is an object that describes an
-// invocation of method Monitors on an instance of MockCodeMonitorStore.
-type CodeMonitorStoreMonitorsFuncCall struct {
+// CodeMonitorStoreListMonitorsFuncCall is an object that describes an
+// invocation of method ListMonitors on an instance of MockCodeMonitorStore.
+type CodeMonitorStoreListMonitorsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -3807,13 +4032,245 @@ type CodeMonitorStoreMonitorsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c CodeMonitorStoreMonitorsFuncCall) Args() []interface{} {
+func (c CodeMonitorStoreListMonitorsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c CodeMonitorStoreMonitorsFuncCall) Results() []interface{} {
+func (c CodeMonitorStoreListMonitorsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// CodeMonitorStoreListQueryTriggerJobsFunc describes the behavior when the
+// ListQueryTriggerJobs method of the parent MockCodeMonitorStore instance
+// is invoked.
+type CodeMonitorStoreListQueryTriggerJobsFunc struct {
+	defaultHook func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error)
+	hooks       []func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error)
+	history     []CodeMonitorStoreListQueryTriggerJobsFuncCall
+	mutex       sync.Mutex
+}
+
+// ListQueryTriggerJobs delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockCodeMonitorStore) ListQueryTriggerJobs(v0 context.Context, v1 int64, v2 *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error) {
+	r0, r1 := m.ListQueryTriggerJobsFunc.nextHook()(v0, v1, v2)
+	m.ListQueryTriggerJobsFunc.appendCall(CodeMonitorStoreListQueryTriggerJobsFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the ListQueryTriggerJobs
+// method of the parent MockCodeMonitorStore instance is invoked and the
+// hook queue is empty.
+func (f *CodeMonitorStoreListQueryTriggerJobsFunc) SetDefaultHook(hook func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// ListQueryTriggerJobs method of the parent MockCodeMonitorStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *CodeMonitorStoreListQueryTriggerJobsFunc) PushHook(hook func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *CodeMonitorStoreListQueryTriggerJobsFunc) SetDefaultReturn(r0 []*TriggerJob, r1 error) {
+	f.SetDefaultHook(func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *CodeMonitorStoreListQueryTriggerJobsFunc) PushReturn(r0 []*TriggerJob, r1 error) {
+	f.PushHook(func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error) {
+		return r0, r1
+	})
+}
+
+func (f *CodeMonitorStoreListQueryTriggerJobsFunc) nextHook() func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *CodeMonitorStoreListQueryTriggerJobsFunc) appendCall(r0 CodeMonitorStoreListQueryTriggerJobsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// CodeMonitorStoreListQueryTriggerJobsFuncCall objects describing the
+// invocations of this function.
+func (f *CodeMonitorStoreListQueryTriggerJobsFunc) History() []CodeMonitorStoreListQueryTriggerJobsFuncCall {
+	f.mutex.Lock()
+	history := make([]CodeMonitorStoreListQueryTriggerJobsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// CodeMonitorStoreListQueryTriggerJobsFuncCall is an object that describes
+// an invocation of method ListQueryTriggerJobs on an instance of
+// MockCodeMonitorStore.
+type CodeMonitorStoreListQueryTriggerJobsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int64
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 *graphqlbackend.ListEventsArgs
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []*TriggerJob
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c CodeMonitorStoreListQueryTriggerJobsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c CodeMonitorStoreListQueryTriggerJobsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// CodeMonitorStoreListRecipientsForEmailActionFunc describes the behavior
+// when the ListRecipientsForEmailAction method of the parent
+// MockCodeMonitorStore instance is invoked.
+type CodeMonitorStoreListRecipientsForEmailActionFunc struct {
+	defaultHook func(context.Context, int64, *graphqlbackend.ListRecipientsArgs) ([]*Recipient, error)
+	hooks       []func(context.Context, int64, *graphqlbackend.ListRecipientsArgs) ([]*Recipient, error)
+	history     []CodeMonitorStoreListRecipientsForEmailActionFuncCall
+	mutex       sync.Mutex
+}
+
+// ListRecipientsForEmailAction delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockCodeMonitorStore) ListRecipientsForEmailAction(v0 context.Context, v1 int64, v2 *graphqlbackend.ListRecipientsArgs) ([]*Recipient, error) {
+	r0, r1 := m.ListRecipientsForEmailActionFunc.nextHook()(v0, v1, v2)
+	m.ListRecipientsForEmailActionFunc.appendCall(CodeMonitorStoreListRecipientsForEmailActionFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// ListRecipientsForEmailAction method of the parent MockCodeMonitorStore
+// instance is invoked and the hook queue is empty.
+func (f *CodeMonitorStoreListRecipientsForEmailActionFunc) SetDefaultHook(hook func(context.Context, int64, *graphqlbackend.ListRecipientsArgs) ([]*Recipient, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// ListRecipientsForEmailAction method of the parent MockCodeMonitorStore
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *CodeMonitorStoreListRecipientsForEmailActionFunc) PushHook(hook func(context.Context, int64, *graphqlbackend.ListRecipientsArgs) ([]*Recipient, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *CodeMonitorStoreListRecipientsForEmailActionFunc) SetDefaultReturn(r0 []*Recipient, r1 error) {
+	f.SetDefaultHook(func(context.Context, int64, *graphqlbackend.ListRecipientsArgs) ([]*Recipient, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *CodeMonitorStoreListRecipientsForEmailActionFunc) PushReturn(r0 []*Recipient, r1 error) {
+	f.PushHook(func(context.Context, int64, *graphqlbackend.ListRecipientsArgs) ([]*Recipient, error) {
+		return r0, r1
+	})
+}
+
+func (f *CodeMonitorStoreListRecipientsForEmailActionFunc) nextHook() func(context.Context, int64, *graphqlbackend.ListRecipientsArgs) ([]*Recipient, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *CodeMonitorStoreListRecipientsForEmailActionFunc) appendCall(r0 CodeMonitorStoreListRecipientsForEmailActionFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// CodeMonitorStoreListRecipientsForEmailActionFuncCall objects describing
+// the invocations of this function.
+func (f *CodeMonitorStoreListRecipientsForEmailActionFunc) History() []CodeMonitorStoreListRecipientsForEmailActionFuncCall {
+	f.mutex.Lock()
+	history := make([]CodeMonitorStoreListRecipientsForEmailActionFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// CodeMonitorStoreListRecipientsForEmailActionFuncCall is an object that
+// describes an invocation of method ListRecipientsForEmailAction on an
+// instance of MockCodeMonitorStore.
+type CodeMonitorStoreListRecipientsForEmailActionFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int64
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 *graphqlbackend.ListRecipientsArgs
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []*Recipient
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c CodeMonitorStoreListRecipientsForEmailActionFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c CodeMonitorStoreListRecipientsForEmailActionFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -3917,153 +4374,37 @@ func (c CodeMonitorStoreNowFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
-// CodeMonitorStoreRecipientsForEmailIDInt64Func describes the behavior when
-// the RecipientsForEmailIDInt64 method of the parent MockCodeMonitorStore
-// instance is invoked.
-type CodeMonitorStoreRecipientsForEmailIDInt64Func struct {
-	defaultHook func(context.Context, int64, *graphqlbackend.ListRecipientsArgs) ([]*Recipient, error)
-	hooks       []func(context.Context, int64, *graphqlbackend.ListRecipientsArgs) ([]*Recipient, error)
-	history     []CodeMonitorStoreRecipientsForEmailIDInt64FuncCall
-	mutex       sync.Mutex
-}
-
-// RecipientsForEmailIDInt64 delegates to the next hook function in the
-// queue and stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) RecipientsForEmailIDInt64(v0 context.Context, v1 int64, v2 *graphqlbackend.ListRecipientsArgs) ([]*Recipient, error) {
-	r0, r1 := m.RecipientsForEmailIDInt64Func.nextHook()(v0, v1, v2)
-	m.RecipientsForEmailIDInt64Func.appendCall(CodeMonitorStoreRecipientsForEmailIDInt64FuncCall{v0, v1, v2, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// RecipientsForEmailIDInt64 method of the parent MockCodeMonitorStore
-// instance is invoked and the hook queue is empty.
-func (f *CodeMonitorStoreRecipientsForEmailIDInt64Func) SetDefaultHook(hook func(context.Context, int64, *graphqlbackend.ListRecipientsArgs) ([]*Recipient, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// RecipientsForEmailIDInt64 method of the parent MockCodeMonitorStore
-// instance invokes the hook at the front of the queue and discards it.
-// After the queue is empty, the default hook function is invoked for any
-// future action.
-func (f *CodeMonitorStoreRecipientsForEmailIDInt64Func) PushHook(hook func(context.Context, int64, *graphqlbackend.ListRecipientsArgs) ([]*Recipient, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
-// the given values.
-func (f *CodeMonitorStoreRecipientsForEmailIDInt64Func) SetDefaultReturn(r0 []*Recipient, r1 error) {
-	f.SetDefaultHook(func(context.Context, int64, *graphqlbackend.ListRecipientsArgs) ([]*Recipient, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushDefaultHook with a function that returns the given
-// values.
-func (f *CodeMonitorStoreRecipientsForEmailIDInt64Func) PushReturn(r0 []*Recipient, r1 error) {
-	f.PushHook(func(context.Context, int64, *graphqlbackend.ListRecipientsArgs) ([]*Recipient, error) {
-		return r0, r1
-	})
-}
-
-func (f *CodeMonitorStoreRecipientsForEmailIDInt64Func) nextHook() func(context.Context, int64, *graphqlbackend.ListRecipientsArgs) ([]*Recipient, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *CodeMonitorStoreRecipientsForEmailIDInt64Func) appendCall(r0 CodeMonitorStoreRecipientsForEmailIDInt64FuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// CodeMonitorStoreRecipientsForEmailIDInt64FuncCall objects describing the
-// invocations of this function.
-func (f *CodeMonitorStoreRecipientsForEmailIDInt64Func) History() []CodeMonitorStoreRecipientsForEmailIDInt64FuncCall {
-	f.mutex.Lock()
-	history := make([]CodeMonitorStoreRecipientsForEmailIDInt64FuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// CodeMonitorStoreRecipientsForEmailIDInt64FuncCall is an object that
-// describes an invocation of method RecipientsForEmailIDInt64 on an
-// instance of MockCodeMonitorStore.
-type CodeMonitorStoreRecipientsForEmailIDInt64FuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int64
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 *graphqlbackend.ListRecipientsArgs
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []*Recipient
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c CodeMonitorStoreRecipientsForEmailIDInt64FuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c CodeMonitorStoreRecipientsForEmailIDInt64FuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// CodeMonitorStoreResetTriggerQueryTimestampsFunc describes the behavior
-// when the ResetTriggerQueryTimestamps method of the parent
+// CodeMonitorStoreResetQueryTriggerTimestampsFunc describes the behavior
+// when the ResetQueryTriggerTimestamps method of the parent
 // MockCodeMonitorStore instance is invoked.
-type CodeMonitorStoreResetTriggerQueryTimestampsFunc struct {
+type CodeMonitorStoreResetQueryTriggerTimestampsFunc struct {
 	defaultHook func(context.Context, int64) error
 	hooks       []func(context.Context, int64) error
-	history     []CodeMonitorStoreResetTriggerQueryTimestampsFuncCall
+	history     []CodeMonitorStoreResetQueryTriggerTimestampsFuncCall
 	mutex       sync.Mutex
 }
 
-// ResetTriggerQueryTimestamps delegates to the next hook function in the
+// ResetQueryTriggerTimestamps delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) ResetTriggerQueryTimestamps(v0 context.Context, v1 int64) error {
-	r0 := m.ResetTriggerQueryTimestampsFunc.nextHook()(v0, v1)
-	m.ResetTriggerQueryTimestampsFunc.appendCall(CodeMonitorStoreResetTriggerQueryTimestampsFuncCall{v0, v1, r0})
+func (m *MockCodeMonitorStore) ResetQueryTriggerTimestamps(v0 context.Context, v1 int64) error {
+	r0 := m.ResetQueryTriggerTimestampsFunc.nextHook()(v0, v1)
+	m.ResetQueryTriggerTimestampsFunc.appendCall(CodeMonitorStoreResetQueryTriggerTimestampsFuncCall{v0, v1, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the
-// ResetTriggerQueryTimestamps method of the parent MockCodeMonitorStore
+// ResetQueryTriggerTimestamps method of the parent MockCodeMonitorStore
 // instance is invoked and the hook queue is empty.
-func (f *CodeMonitorStoreResetTriggerQueryTimestampsFunc) SetDefaultHook(hook func(context.Context, int64) error) {
+func (f *CodeMonitorStoreResetQueryTriggerTimestampsFunc) SetDefaultHook(hook func(context.Context, int64) error) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// ResetTriggerQueryTimestamps method of the parent MockCodeMonitorStore
+// ResetQueryTriggerTimestamps method of the parent MockCodeMonitorStore
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *CodeMonitorStoreResetTriggerQueryTimestampsFunc) PushHook(hook func(context.Context, int64) error) {
+func (f *CodeMonitorStoreResetQueryTriggerTimestampsFunc) PushHook(hook func(context.Context, int64) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -4071,7 +4412,7 @@ func (f *CodeMonitorStoreResetTriggerQueryTimestampsFunc) PushHook(hook func(con
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *CodeMonitorStoreResetTriggerQueryTimestampsFunc) SetDefaultReturn(r0 error) {
+func (f *CodeMonitorStoreResetQueryTriggerTimestampsFunc) SetDefaultReturn(r0 error) {
 	f.SetDefaultHook(func(context.Context, int64) error {
 		return r0
 	})
@@ -4079,13 +4420,13 @@ func (f *CodeMonitorStoreResetTriggerQueryTimestampsFunc) SetDefaultReturn(r0 er
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *CodeMonitorStoreResetTriggerQueryTimestampsFunc) PushReturn(r0 error) {
+func (f *CodeMonitorStoreResetQueryTriggerTimestampsFunc) PushReturn(r0 error) {
 	f.PushHook(func(context.Context, int64) error {
 		return r0
 	})
 }
 
-func (f *CodeMonitorStoreResetTriggerQueryTimestampsFunc) nextHook() func(context.Context, int64) error {
+func (f *CodeMonitorStoreResetQueryTriggerTimestampsFunc) nextHook() func(context.Context, int64) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -4098,28 +4439,28 @@ func (f *CodeMonitorStoreResetTriggerQueryTimestampsFunc) nextHook() func(contex
 	return hook
 }
 
-func (f *CodeMonitorStoreResetTriggerQueryTimestampsFunc) appendCall(r0 CodeMonitorStoreResetTriggerQueryTimestampsFuncCall) {
+func (f *CodeMonitorStoreResetQueryTriggerTimestampsFunc) appendCall(r0 CodeMonitorStoreResetQueryTriggerTimestampsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// CodeMonitorStoreResetTriggerQueryTimestampsFuncCall objects describing
+// CodeMonitorStoreResetQueryTriggerTimestampsFuncCall objects describing
 // the invocations of this function.
-func (f *CodeMonitorStoreResetTriggerQueryTimestampsFunc) History() []CodeMonitorStoreResetTriggerQueryTimestampsFuncCall {
+func (f *CodeMonitorStoreResetQueryTriggerTimestampsFunc) History() []CodeMonitorStoreResetQueryTriggerTimestampsFuncCall {
 	f.mutex.Lock()
-	history := make([]CodeMonitorStoreResetTriggerQueryTimestampsFuncCall, len(f.history))
+	history := make([]CodeMonitorStoreResetQueryTriggerTimestampsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// CodeMonitorStoreResetTriggerQueryTimestampsFuncCall is an object that
-// describes an invocation of method ResetTriggerQueryTimestamps on an
+// CodeMonitorStoreResetQueryTriggerTimestampsFuncCall is an object that
+// describes an invocation of method ResetQueryTriggerTimestamps on an
 // instance of MockCodeMonitorStore.
-type CodeMonitorStoreResetTriggerQueryTimestampsFuncCall struct {
+type CodeMonitorStoreResetQueryTriggerTimestampsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -4133,47 +4474,47 @@ type CodeMonitorStoreResetTriggerQueryTimestampsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c CodeMonitorStoreResetTriggerQueryTimestampsFuncCall) Args() []interface{} {
+func (c CodeMonitorStoreResetQueryTriggerTimestampsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c CodeMonitorStoreResetTriggerQueryTimestampsFuncCall) Results() []interface{} {
+func (c CodeMonitorStoreResetQueryTriggerTimestampsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
-// CodeMonitorStoreSetTriggerQueryNextRunFunc describes the behavior when
-// the SetTriggerQueryNextRun method of the parent MockCodeMonitorStore
+// CodeMonitorStoreSetQueryTriggerNextRunFunc describes the behavior when
+// the SetQueryTriggerNextRun method of the parent MockCodeMonitorStore
 // instance is invoked.
-type CodeMonitorStoreSetTriggerQueryNextRunFunc struct {
+type CodeMonitorStoreSetQueryTriggerNextRunFunc struct {
 	defaultHook func(context.Context, int64, time.Time, time.Time) error
 	hooks       []func(context.Context, int64, time.Time, time.Time) error
-	history     []CodeMonitorStoreSetTriggerQueryNextRunFuncCall
+	history     []CodeMonitorStoreSetQueryTriggerNextRunFuncCall
 	mutex       sync.Mutex
 }
 
-// SetTriggerQueryNextRun delegates to the next hook function in the queue
+// SetQueryTriggerNextRun delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) SetTriggerQueryNextRun(v0 context.Context, v1 int64, v2 time.Time, v3 time.Time) error {
-	r0 := m.SetTriggerQueryNextRunFunc.nextHook()(v0, v1, v2, v3)
-	m.SetTriggerQueryNextRunFunc.appendCall(CodeMonitorStoreSetTriggerQueryNextRunFuncCall{v0, v1, v2, v3, r0})
+func (m *MockCodeMonitorStore) SetQueryTriggerNextRun(v0 context.Context, v1 int64, v2 time.Time, v3 time.Time) error {
+	r0 := m.SetQueryTriggerNextRunFunc.nextHook()(v0, v1, v2, v3)
+	m.SetQueryTriggerNextRunFunc.appendCall(CodeMonitorStoreSetQueryTriggerNextRunFuncCall{v0, v1, v2, v3, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the
-// SetTriggerQueryNextRun method of the parent MockCodeMonitorStore instance
+// SetQueryTriggerNextRun method of the parent MockCodeMonitorStore instance
 // is invoked and the hook queue is empty.
-func (f *CodeMonitorStoreSetTriggerQueryNextRunFunc) SetDefaultHook(hook func(context.Context, int64, time.Time, time.Time) error) {
+func (f *CodeMonitorStoreSetQueryTriggerNextRunFunc) SetDefaultHook(hook func(context.Context, int64, time.Time, time.Time) error) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// SetTriggerQueryNextRun method of the parent MockCodeMonitorStore instance
+// SetQueryTriggerNextRun method of the parent MockCodeMonitorStore instance
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *CodeMonitorStoreSetTriggerQueryNextRunFunc) PushHook(hook func(context.Context, int64, time.Time, time.Time) error) {
+func (f *CodeMonitorStoreSetQueryTriggerNextRunFunc) PushHook(hook func(context.Context, int64, time.Time, time.Time) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -4181,7 +4522,7 @@ func (f *CodeMonitorStoreSetTriggerQueryNextRunFunc) PushHook(hook func(context.
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *CodeMonitorStoreSetTriggerQueryNextRunFunc) SetDefaultReturn(r0 error) {
+func (f *CodeMonitorStoreSetQueryTriggerNextRunFunc) SetDefaultReturn(r0 error) {
 	f.SetDefaultHook(func(context.Context, int64, time.Time, time.Time) error {
 		return r0
 	})
@@ -4189,13 +4530,13 @@ func (f *CodeMonitorStoreSetTriggerQueryNextRunFunc) SetDefaultReturn(r0 error) 
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *CodeMonitorStoreSetTriggerQueryNextRunFunc) PushReturn(r0 error) {
+func (f *CodeMonitorStoreSetQueryTriggerNextRunFunc) PushReturn(r0 error) {
 	f.PushHook(func(context.Context, int64, time.Time, time.Time) error {
 		return r0
 	})
 }
 
-func (f *CodeMonitorStoreSetTriggerQueryNextRunFunc) nextHook() func(context.Context, int64, time.Time, time.Time) error {
+func (f *CodeMonitorStoreSetQueryTriggerNextRunFunc) nextHook() func(context.Context, int64, time.Time, time.Time) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -4208,28 +4549,28 @@ func (f *CodeMonitorStoreSetTriggerQueryNextRunFunc) nextHook() func(context.Con
 	return hook
 }
 
-func (f *CodeMonitorStoreSetTriggerQueryNextRunFunc) appendCall(r0 CodeMonitorStoreSetTriggerQueryNextRunFuncCall) {
+func (f *CodeMonitorStoreSetQueryTriggerNextRunFunc) appendCall(r0 CodeMonitorStoreSetQueryTriggerNextRunFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// CodeMonitorStoreSetTriggerQueryNextRunFuncCall objects describing the
+// CodeMonitorStoreSetQueryTriggerNextRunFuncCall objects describing the
 // invocations of this function.
-func (f *CodeMonitorStoreSetTriggerQueryNextRunFunc) History() []CodeMonitorStoreSetTriggerQueryNextRunFuncCall {
+func (f *CodeMonitorStoreSetQueryTriggerNextRunFunc) History() []CodeMonitorStoreSetQueryTriggerNextRunFuncCall {
 	f.mutex.Lock()
-	history := make([]CodeMonitorStoreSetTriggerQueryNextRunFuncCall, len(f.history))
+	history := make([]CodeMonitorStoreSetQueryTriggerNextRunFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// CodeMonitorStoreSetTriggerQueryNextRunFuncCall is an object that
-// describes an invocation of method SetTriggerQueryNextRun on an instance
+// CodeMonitorStoreSetQueryTriggerNextRunFuncCall is an object that
+// describes an invocation of method SetQueryTriggerNextRun on an instance
 // of MockCodeMonitorStore.
-type CodeMonitorStoreSetTriggerQueryNextRunFuncCall struct {
+type CodeMonitorStoreSetQueryTriggerNextRunFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -4249,13 +4590,13 @@ type CodeMonitorStoreSetTriggerQueryNextRunFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c CodeMonitorStoreSetTriggerQueryNextRunFuncCall) Args() []interface{} {
+func (c CodeMonitorStoreSetQueryTriggerNextRunFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c CodeMonitorStoreSetTriggerQueryNextRunFuncCall) Results() []interface{} {
+func (c CodeMonitorStoreSetQueryTriggerNextRunFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
@@ -4370,344 +4711,6 @@ func (c CodeMonitorStoreToggleMonitorFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// CodeMonitorStoreTotalCountEventsForQueryIDInt64Func describes the
-// behavior when the TotalCountEventsForQueryIDInt64 method of the parent
-// MockCodeMonitorStore instance is invoked.
-type CodeMonitorStoreTotalCountEventsForQueryIDInt64Func struct {
-	defaultHook func(context.Context, int64) (int32, error)
-	hooks       []func(context.Context, int64) (int32, error)
-	history     []CodeMonitorStoreTotalCountEventsForQueryIDInt64FuncCall
-	mutex       sync.Mutex
-}
-
-// TotalCountEventsForQueryIDInt64 delegates to the next hook function in
-// the queue and stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) TotalCountEventsForQueryIDInt64(v0 context.Context, v1 int64) (int32, error) {
-	r0, r1 := m.TotalCountEventsForQueryIDInt64Func.nextHook()(v0, v1)
-	m.TotalCountEventsForQueryIDInt64Func.appendCall(CodeMonitorStoreTotalCountEventsForQueryIDInt64FuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// TotalCountEventsForQueryIDInt64 method of the parent MockCodeMonitorStore
-// instance is invoked and the hook queue is empty.
-func (f *CodeMonitorStoreTotalCountEventsForQueryIDInt64Func) SetDefaultHook(hook func(context.Context, int64) (int32, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// TotalCountEventsForQueryIDInt64 method of the parent MockCodeMonitorStore
-// instance invokes the hook at the front of the queue and discards it.
-// After the queue is empty, the default hook function is invoked for any
-// future action.
-func (f *CodeMonitorStoreTotalCountEventsForQueryIDInt64Func) PushHook(hook func(context.Context, int64) (int32, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
-// the given values.
-func (f *CodeMonitorStoreTotalCountEventsForQueryIDInt64Func) SetDefaultReturn(r0 int32, r1 error) {
-	f.SetDefaultHook(func(context.Context, int64) (int32, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushDefaultHook with a function that returns the given
-// values.
-func (f *CodeMonitorStoreTotalCountEventsForQueryIDInt64Func) PushReturn(r0 int32, r1 error) {
-	f.PushHook(func(context.Context, int64) (int32, error) {
-		return r0, r1
-	})
-}
-
-func (f *CodeMonitorStoreTotalCountEventsForQueryIDInt64Func) nextHook() func(context.Context, int64) (int32, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *CodeMonitorStoreTotalCountEventsForQueryIDInt64Func) appendCall(r0 CodeMonitorStoreTotalCountEventsForQueryIDInt64FuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// CodeMonitorStoreTotalCountEventsForQueryIDInt64FuncCall objects
-// describing the invocations of this function.
-func (f *CodeMonitorStoreTotalCountEventsForQueryIDInt64Func) History() []CodeMonitorStoreTotalCountEventsForQueryIDInt64FuncCall {
-	f.mutex.Lock()
-	history := make([]CodeMonitorStoreTotalCountEventsForQueryIDInt64FuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// CodeMonitorStoreTotalCountEventsForQueryIDInt64FuncCall is an object that
-// describes an invocation of method TotalCountEventsForQueryIDInt64 on an
-// instance of MockCodeMonitorStore.
-type CodeMonitorStoreTotalCountEventsForQueryIDInt64FuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int64
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 int32
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c CodeMonitorStoreTotalCountEventsForQueryIDInt64FuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c CodeMonitorStoreTotalCountEventsForQueryIDInt64FuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// CodeMonitorStoreTotalCountMonitorsFunc describes the behavior when the
-// TotalCountMonitors method of the parent MockCodeMonitorStore instance is
-// invoked.
-type CodeMonitorStoreTotalCountMonitorsFunc struct {
-	defaultHook func(context.Context, int32) (int32, error)
-	hooks       []func(context.Context, int32) (int32, error)
-	history     []CodeMonitorStoreTotalCountMonitorsFuncCall
-	mutex       sync.Mutex
-}
-
-// TotalCountMonitors delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) TotalCountMonitors(v0 context.Context, v1 int32) (int32, error) {
-	r0, r1 := m.TotalCountMonitorsFunc.nextHook()(v0, v1)
-	m.TotalCountMonitorsFunc.appendCall(CodeMonitorStoreTotalCountMonitorsFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the TotalCountMonitors
-// method of the parent MockCodeMonitorStore instance is invoked and the
-// hook queue is empty.
-func (f *CodeMonitorStoreTotalCountMonitorsFunc) SetDefaultHook(hook func(context.Context, int32) (int32, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// TotalCountMonitors method of the parent MockCodeMonitorStore instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *CodeMonitorStoreTotalCountMonitorsFunc) PushHook(hook func(context.Context, int32) (int32, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
-// the given values.
-func (f *CodeMonitorStoreTotalCountMonitorsFunc) SetDefaultReturn(r0 int32, r1 error) {
-	f.SetDefaultHook(func(context.Context, int32) (int32, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushDefaultHook with a function that returns the given
-// values.
-func (f *CodeMonitorStoreTotalCountMonitorsFunc) PushReturn(r0 int32, r1 error) {
-	f.PushHook(func(context.Context, int32) (int32, error) {
-		return r0, r1
-	})
-}
-
-func (f *CodeMonitorStoreTotalCountMonitorsFunc) nextHook() func(context.Context, int32) (int32, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *CodeMonitorStoreTotalCountMonitorsFunc) appendCall(r0 CodeMonitorStoreTotalCountMonitorsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of CodeMonitorStoreTotalCountMonitorsFuncCall
-// objects describing the invocations of this function.
-func (f *CodeMonitorStoreTotalCountMonitorsFunc) History() []CodeMonitorStoreTotalCountMonitorsFuncCall {
-	f.mutex.Lock()
-	history := make([]CodeMonitorStoreTotalCountMonitorsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// CodeMonitorStoreTotalCountMonitorsFuncCall is an object that describes an
-// invocation of method TotalCountMonitors on an instance of
-// MockCodeMonitorStore.
-type CodeMonitorStoreTotalCountMonitorsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int32
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 int32
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c CodeMonitorStoreTotalCountMonitorsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c CodeMonitorStoreTotalCountMonitorsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// CodeMonitorStoreTotalCountRecipientsFunc describes the behavior when the
-// TotalCountRecipients method of the parent MockCodeMonitorStore instance
-// is invoked.
-type CodeMonitorStoreTotalCountRecipientsFunc struct {
-	defaultHook func(context.Context, int64) (int32, error)
-	hooks       []func(context.Context, int64) (int32, error)
-	history     []CodeMonitorStoreTotalCountRecipientsFuncCall
-	mutex       sync.Mutex
-}
-
-// TotalCountRecipients delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) TotalCountRecipients(v0 context.Context, v1 int64) (int32, error) {
-	r0, r1 := m.TotalCountRecipientsFunc.nextHook()(v0, v1)
-	m.TotalCountRecipientsFunc.appendCall(CodeMonitorStoreTotalCountRecipientsFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the TotalCountRecipients
-// method of the parent MockCodeMonitorStore instance is invoked and the
-// hook queue is empty.
-func (f *CodeMonitorStoreTotalCountRecipientsFunc) SetDefaultHook(hook func(context.Context, int64) (int32, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// TotalCountRecipients method of the parent MockCodeMonitorStore instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *CodeMonitorStoreTotalCountRecipientsFunc) PushHook(hook func(context.Context, int64) (int32, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
-// the given values.
-func (f *CodeMonitorStoreTotalCountRecipientsFunc) SetDefaultReturn(r0 int32, r1 error) {
-	f.SetDefaultHook(func(context.Context, int64) (int32, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushDefaultHook with a function that returns the given
-// values.
-func (f *CodeMonitorStoreTotalCountRecipientsFunc) PushReturn(r0 int32, r1 error) {
-	f.PushHook(func(context.Context, int64) (int32, error) {
-		return r0, r1
-	})
-}
-
-func (f *CodeMonitorStoreTotalCountRecipientsFunc) nextHook() func(context.Context, int64) (int32, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *CodeMonitorStoreTotalCountRecipientsFunc) appendCall(r0 CodeMonitorStoreTotalCountRecipientsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// CodeMonitorStoreTotalCountRecipientsFuncCall objects describing the
-// invocations of this function.
-func (f *CodeMonitorStoreTotalCountRecipientsFunc) History() []CodeMonitorStoreTotalCountRecipientsFuncCall {
-	f.mutex.Lock()
-	history := make([]CodeMonitorStoreTotalCountRecipientsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// CodeMonitorStoreTotalCountRecipientsFuncCall is an object that describes
-// an invocation of method TotalCountRecipients on an instance of
-// MockCodeMonitorStore.
-type CodeMonitorStoreTotalCountRecipientsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int64
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 int32
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c CodeMonitorStoreTotalCountRecipientsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c CodeMonitorStoreTotalCountRecipientsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
 // CodeMonitorStoreTransactFunc describes the behavior when the Transact
 // method of the parent MockCodeMonitorStore instance is invoked.
 type CodeMonitorStoreTransactFunc struct {
@@ -4811,119 +4814,6 @@ func (c CodeMonitorStoreTransactFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c CodeMonitorStoreTransactFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// CodeMonitorStoreTriggerQueryByMonitorIDInt64Func describes the behavior
-// when the TriggerQueryByMonitorIDInt64 method of the parent
-// MockCodeMonitorStore instance is invoked.
-type CodeMonitorStoreTriggerQueryByMonitorIDInt64Func struct {
-	defaultHook func(context.Context, int64) (*QueryTrigger, error)
-	hooks       []func(context.Context, int64) (*QueryTrigger, error)
-	history     []CodeMonitorStoreTriggerQueryByMonitorIDInt64FuncCall
-	mutex       sync.Mutex
-}
-
-// TriggerQueryByMonitorIDInt64 delegates to the next hook function in the
-// queue and stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) TriggerQueryByMonitorIDInt64(v0 context.Context, v1 int64) (*QueryTrigger, error) {
-	r0, r1 := m.TriggerQueryByMonitorIDInt64Func.nextHook()(v0, v1)
-	m.TriggerQueryByMonitorIDInt64Func.appendCall(CodeMonitorStoreTriggerQueryByMonitorIDInt64FuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// TriggerQueryByMonitorIDInt64 method of the parent MockCodeMonitorStore
-// instance is invoked and the hook queue is empty.
-func (f *CodeMonitorStoreTriggerQueryByMonitorIDInt64Func) SetDefaultHook(hook func(context.Context, int64) (*QueryTrigger, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// TriggerQueryByMonitorIDInt64 method of the parent MockCodeMonitorStore
-// instance invokes the hook at the front of the queue and discards it.
-// After the queue is empty, the default hook function is invoked for any
-// future action.
-func (f *CodeMonitorStoreTriggerQueryByMonitorIDInt64Func) PushHook(hook func(context.Context, int64) (*QueryTrigger, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
-// the given values.
-func (f *CodeMonitorStoreTriggerQueryByMonitorIDInt64Func) SetDefaultReturn(r0 *QueryTrigger, r1 error) {
-	f.SetDefaultHook(func(context.Context, int64) (*QueryTrigger, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushDefaultHook with a function that returns the given
-// values.
-func (f *CodeMonitorStoreTriggerQueryByMonitorIDInt64Func) PushReturn(r0 *QueryTrigger, r1 error) {
-	f.PushHook(func(context.Context, int64) (*QueryTrigger, error) {
-		return r0, r1
-	})
-}
-
-func (f *CodeMonitorStoreTriggerQueryByMonitorIDInt64Func) nextHook() func(context.Context, int64) (*QueryTrigger, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *CodeMonitorStoreTriggerQueryByMonitorIDInt64Func) appendCall(r0 CodeMonitorStoreTriggerQueryByMonitorIDInt64FuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// CodeMonitorStoreTriggerQueryByMonitorIDInt64FuncCall objects describing
-// the invocations of this function.
-func (f *CodeMonitorStoreTriggerQueryByMonitorIDInt64Func) History() []CodeMonitorStoreTriggerQueryByMonitorIDInt64FuncCall {
-	f.mutex.Lock()
-	history := make([]CodeMonitorStoreTriggerQueryByMonitorIDInt64FuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// CodeMonitorStoreTriggerQueryByMonitorIDInt64FuncCall is an object that
-// describes an invocation of method TriggerQueryByMonitorIDInt64 on an
-// instance of MockCodeMonitorStore.
-type CodeMonitorStoreTriggerQueryByMonitorIDInt64FuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int64
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 *QueryTrigger
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c CodeMonitorStoreTriggerQueryByMonitorIDInt64FuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c CodeMonitorStoreTriggerQueryByMonitorIDInt64FuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -5153,37 +5043,37 @@ func (c CodeMonitorStoreUpdateMonitorFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// CodeMonitorStoreUpdateTriggerQueryFunc describes the behavior when the
-// UpdateTriggerQuery method of the parent MockCodeMonitorStore instance is
+// CodeMonitorStoreUpdateQueryTriggerFunc describes the behavior when the
+// UpdateQueryTrigger method of the parent MockCodeMonitorStore instance is
 // invoked.
-type CodeMonitorStoreUpdateTriggerQueryFunc struct {
+type CodeMonitorStoreUpdateQueryTriggerFunc struct {
 	defaultHook func(context.Context, *graphqlbackend.UpdateCodeMonitorArgs) error
 	hooks       []func(context.Context, *graphqlbackend.UpdateCodeMonitorArgs) error
-	history     []CodeMonitorStoreUpdateTriggerQueryFuncCall
+	history     []CodeMonitorStoreUpdateQueryTriggerFuncCall
 	mutex       sync.Mutex
 }
 
-// UpdateTriggerQuery delegates to the next hook function in the queue and
+// UpdateQueryTrigger delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) UpdateTriggerQuery(v0 context.Context, v1 *graphqlbackend.UpdateCodeMonitorArgs) error {
-	r0 := m.UpdateTriggerQueryFunc.nextHook()(v0, v1)
-	m.UpdateTriggerQueryFunc.appendCall(CodeMonitorStoreUpdateTriggerQueryFuncCall{v0, v1, r0})
+func (m *MockCodeMonitorStore) UpdateQueryTrigger(v0 context.Context, v1 *graphqlbackend.UpdateCodeMonitorArgs) error {
+	r0 := m.UpdateQueryTriggerFunc.nextHook()(v0, v1)
+	m.UpdateQueryTriggerFunc.appendCall(CodeMonitorStoreUpdateQueryTriggerFuncCall{v0, v1, r0})
 	return r0
 }
 
-// SetDefaultHook sets function that is called when the UpdateTriggerQuery
+// SetDefaultHook sets function that is called when the UpdateQueryTrigger
 // method of the parent MockCodeMonitorStore instance is invoked and the
 // hook queue is empty.
-func (f *CodeMonitorStoreUpdateTriggerQueryFunc) SetDefaultHook(hook func(context.Context, *graphqlbackend.UpdateCodeMonitorArgs) error) {
+func (f *CodeMonitorStoreUpdateQueryTriggerFunc) SetDefaultHook(hook func(context.Context, *graphqlbackend.UpdateCodeMonitorArgs) error) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// UpdateTriggerQuery method of the parent MockCodeMonitorStore instance
+// UpdateQueryTrigger method of the parent MockCodeMonitorStore instance
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *CodeMonitorStoreUpdateTriggerQueryFunc) PushHook(hook func(context.Context, *graphqlbackend.UpdateCodeMonitorArgs) error) {
+func (f *CodeMonitorStoreUpdateQueryTriggerFunc) PushHook(hook func(context.Context, *graphqlbackend.UpdateCodeMonitorArgs) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -5191,7 +5081,7 @@ func (f *CodeMonitorStoreUpdateTriggerQueryFunc) PushHook(hook func(context.Cont
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *CodeMonitorStoreUpdateTriggerQueryFunc) SetDefaultReturn(r0 error) {
+func (f *CodeMonitorStoreUpdateQueryTriggerFunc) SetDefaultReturn(r0 error) {
 	f.SetDefaultHook(func(context.Context, *graphqlbackend.UpdateCodeMonitorArgs) error {
 		return r0
 	})
@@ -5199,13 +5089,13 @@ func (f *CodeMonitorStoreUpdateTriggerQueryFunc) SetDefaultReturn(r0 error) {
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *CodeMonitorStoreUpdateTriggerQueryFunc) PushReturn(r0 error) {
+func (f *CodeMonitorStoreUpdateQueryTriggerFunc) PushReturn(r0 error) {
 	f.PushHook(func(context.Context, *graphqlbackend.UpdateCodeMonitorArgs) error {
 		return r0
 	})
 }
 
-func (f *CodeMonitorStoreUpdateTriggerQueryFunc) nextHook() func(context.Context, *graphqlbackend.UpdateCodeMonitorArgs) error {
+func (f *CodeMonitorStoreUpdateQueryTriggerFunc) nextHook() func(context.Context, *graphqlbackend.UpdateCodeMonitorArgs) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -5218,27 +5108,27 @@ func (f *CodeMonitorStoreUpdateTriggerQueryFunc) nextHook() func(context.Context
 	return hook
 }
 
-func (f *CodeMonitorStoreUpdateTriggerQueryFunc) appendCall(r0 CodeMonitorStoreUpdateTriggerQueryFuncCall) {
+func (f *CodeMonitorStoreUpdateQueryTriggerFunc) appendCall(r0 CodeMonitorStoreUpdateQueryTriggerFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of CodeMonitorStoreUpdateTriggerQueryFuncCall
+// History returns a sequence of CodeMonitorStoreUpdateQueryTriggerFuncCall
 // objects describing the invocations of this function.
-func (f *CodeMonitorStoreUpdateTriggerQueryFunc) History() []CodeMonitorStoreUpdateTriggerQueryFuncCall {
+func (f *CodeMonitorStoreUpdateQueryTriggerFunc) History() []CodeMonitorStoreUpdateQueryTriggerFuncCall {
 	f.mutex.Lock()
-	history := make([]CodeMonitorStoreUpdateTriggerQueryFuncCall, len(f.history))
+	history := make([]CodeMonitorStoreUpdateQueryTriggerFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// CodeMonitorStoreUpdateTriggerQueryFuncCall is an object that describes an
-// invocation of method UpdateTriggerQuery on an instance of
+// CodeMonitorStoreUpdateQueryTriggerFuncCall is an object that describes an
+// invocation of method UpdateQueryTrigger on an instance of
 // MockCodeMonitorStore.
-type CodeMonitorStoreUpdateTriggerQueryFuncCall struct {
+type CodeMonitorStoreUpdateQueryTriggerFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -5252,12 +5142,128 @@ type CodeMonitorStoreUpdateTriggerQueryFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c CodeMonitorStoreUpdateTriggerQueryFuncCall) Args() []interface{} {
+func (c CodeMonitorStoreUpdateQueryTriggerFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c CodeMonitorStoreUpdateTriggerQueryFuncCall) Results() []interface{} {
+func (c CodeMonitorStoreUpdateQueryTriggerFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// CodeMonitorStoreUpdateTriggerJobWithResultsFunc describes the behavior
+// when the UpdateTriggerJobWithResults method of the parent
+// MockCodeMonitorStore instance is invoked.
+type CodeMonitorStoreUpdateTriggerJobWithResultsFunc struct {
+	defaultHook func(context.Context, string, int, int) error
+	hooks       []func(context.Context, string, int, int) error
+	history     []CodeMonitorStoreUpdateTriggerJobWithResultsFuncCall
+	mutex       sync.Mutex
+}
+
+// UpdateTriggerJobWithResults delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockCodeMonitorStore) UpdateTriggerJobWithResults(v0 context.Context, v1 string, v2 int, v3 int) error {
+	r0 := m.UpdateTriggerJobWithResultsFunc.nextHook()(v0, v1, v2, v3)
+	m.UpdateTriggerJobWithResultsFunc.appendCall(CodeMonitorStoreUpdateTriggerJobWithResultsFuncCall{v0, v1, v2, v3, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the
+// UpdateTriggerJobWithResults method of the parent MockCodeMonitorStore
+// instance is invoked and the hook queue is empty.
+func (f *CodeMonitorStoreUpdateTriggerJobWithResultsFunc) SetDefaultHook(hook func(context.Context, string, int, int) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// UpdateTriggerJobWithResults method of the parent MockCodeMonitorStore
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *CodeMonitorStoreUpdateTriggerJobWithResultsFunc) PushHook(hook func(context.Context, string, int, int) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *CodeMonitorStoreUpdateTriggerJobWithResultsFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, string, int, int) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *CodeMonitorStoreUpdateTriggerJobWithResultsFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, string, int, int) error {
+		return r0
+	})
+}
+
+func (f *CodeMonitorStoreUpdateTriggerJobWithResultsFunc) nextHook() func(context.Context, string, int, int) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *CodeMonitorStoreUpdateTriggerJobWithResultsFunc) appendCall(r0 CodeMonitorStoreUpdateTriggerJobWithResultsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// CodeMonitorStoreUpdateTriggerJobWithResultsFuncCall objects describing
+// the invocations of this function.
+func (f *CodeMonitorStoreUpdateTriggerJobWithResultsFunc) History() []CodeMonitorStoreUpdateTriggerJobWithResultsFuncCall {
+	f.mutex.Lock()
+	history := make([]CodeMonitorStoreUpdateTriggerJobWithResultsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// CodeMonitorStoreUpdateTriggerJobWithResultsFuncCall is an object that
+// describes an invocation of method UpdateTriggerJobWithResults on an
+// instance of MockCodeMonitorStore.
+type CodeMonitorStoreUpdateTriggerJobWithResultsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 int
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c CodeMonitorStoreUpdateTriggerJobWithResultsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c CodeMonitorStoreUpdateTriggerJobWithResultsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -489,7 +489,7 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 			defaultHook: i.ToggleMonitor,
 		},
 		TotalCountEventsForQueryIDInt64Func: &CodeMonitorStoreTotalCountEventsForQueryIDInt64Func{
-			defaultHook: i.TotalCountEventsForQueryIDInt64,
+			defaultHook: i.CountQueryTriggerJobs,
 		},
 		TotalCountMonitorsFunc: &CodeMonitorStoreTotalCountMonitorsFunc{
 			defaultHook: i.CountMonitors,

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -483,7 +483,7 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 			defaultHook: i.ResetQueryTriggerTimestamps,
 		},
 		SetTriggerQueryNextRunFunc: &CodeMonitorStoreSetTriggerQueryNextRunFunc{
-			defaultHook: i.SetTriggerQueryNextRun,
+			defaultHook: i.SetQueryTriggerNextRun,
 		},
 		ToggleMonitorFunc: &CodeMonitorStoreToggleMonitorFunc{
 			defaultHook: i.ToggleMonitor,

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -266,7 +266,7 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		GetEventsForQueryIDInt64Func: &CodeMonitorStoreGetEventsForQueryIDInt64Func{
-			defaultHook: func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJobs, error) {
+			defaultHook: func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error) {
 				return nil, nil
 			},
 		},
@@ -2829,15 +2829,15 @@ func (c CodeMonitorStoreGetActionJobMetadataFuncCall) Results() []interface{} {
 // the GetEventsForQueryIDInt64 method of the parent MockCodeMonitorStore
 // instance is invoked.
 type CodeMonitorStoreGetEventsForQueryIDInt64Func struct {
-	defaultHook func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJobs, error)
-	hooks       []func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJobs, error)
+	defaultHook func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error)
+	hooks       []func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error)
 	history     []CodeMonitorStoreGetEventsForQueryIDInt64FuncCall
 	mutex       sync.Mutex
 }
 
 // GetEventsForQueryIDInt64 delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) GetEventsForQueryIDInt64(v0 context.Context, v1 int64, v2 *graphqlbackend.ListEventsArgs) ([]*TriggerJobs, error) {
+func (m *MockCodeMonitorStore) GetEventsForQueryIDInt64(v0 context.Context, v1 int64, v2 *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error) {
 	r0, r1 := m.GetEventsForQueryIDInt64Func.nextHook()(v0, v1, v2)
 	m.GetEventsForQueryIDInt64Func.appendCall(CodeMonitorStoreGetEventsForQueryIDInt64FuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
@@ -2846,7 +2846,7 @@ func (m *MockCodeMonitorStore) GetEventsForQueryIDInt64(v0 context.Context, v1 i
 // SetDefaultHook sets function that is called when the
 // GetEventsForQueryIDInt64 method of the parent MockCodeMonitorStore
 // instance is invoked and the hook queue is empty.
-func (f *CodeMonitorStoreGetEventsForQueryIDInt64Func) SetDefaultHook(hook func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJobs, error)) {
+func (f *CodeMonitorStoreGetEventsForQueryIDInt64Func) SetDefaultHook(hook func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error)) {
 	f.defaultHook = hook
 }
 
@@ -2855,7 +2855,7 @@ func (f *CodeMonitorStoreGetEventsForQueryIDInt64Func) SetDefaultHook(hook func(
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *CodeMonitorStoreGetEventsForQueryIDInt64Func) PushHook(hook func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJobs, error)) {
+func (f *CodeMonitorStoreGetEventsForQueryIDInt64Func) PushHook(hook func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2863,21 +2863,21 @@ func (f *CodeMonitorStoreGetEventsForQueryIDInt64Func) PushHook(hook func(contex
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *CodeMonitorStoreGetEventsForQueryIDInt64Func) SetDefaultReturn(r0 []*TriggerJobs, r1 error) {
-	f.SetDefaultHook(func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJobs, error) {
+func (f *CodeMonitorStoreGetEventsForQueryIDInt64Func) SetDefaultReturn(r0 []*TriggerJob, r1 error) {
+	f.SetDefaultHook(func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *CodeMonitorStoreGetEventsForQueryIDInt64Func) PushReturn(r0 []*TriggerJobs, r1 error) {
-	f.PushHook(func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJobs, error) {
+func (f *CodeMonitorStoreGetEventsForQueryIDInt64Func) PushReturn(r0 []*TriggerJob, r1 error) {
+	f.PushHook(func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error) {
 		return r0, r1
 	})
 }
 
-func (f *CodeMonitorStoreGetEventsForQueryIDInt64Func) nextHook() func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJobs, error) {
+func (f *CodeMonitorStoreGetEventsForQueryIDInt64Func) nextHook() func(context.Context, int64, *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2923,7 +2923,7 @@ type CodeMonitorStoreGetEventsForQueryIDInt64FuncCall struct {
 	Arg2 *graphqlbackend.ListEventsArgs
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []*TriggerJobs
+	Result0 []*TriggerJob
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -480,7 +480,7 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 			defaultHook: i.RecipientsForEmailIDInt64,
 		},
 		ResetTriggerQueryTimestampsFunc: &CodeMonitorStoreResetTriggerQueryTimestampsFunc{
-			defaultHook: i.ResetTriggerQueryTimestamps,
+			defaultHook: i.ResetQueryTriggerTimestamps,
 		},
 		SetTriggerQueryNextRunFunc: &CodeMonitorStoreSetTriggerQueryNextRunFunc{
 			defaultHook: i.SetTriggerQueryNextRun,

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -191,7 +191,7 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		CreateEmailActionFunc: &CodeMonitorStoreCreateEmailActionFunc{
-			defaultHook: func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*MonitorEmail, error) {
+			defaultHook: func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*EmailAction, error) {
 				return nil, nil
 			},
 		},
@@ -266,7 +266,7 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		GetEmailActionFunc: &CodeMonitorStoreGetEmailActionFunc{
-			defaultHook: func(context.Context, int64) (*MonitorEmail, error) {
+			defaultHook: func(context.Context, int64) (*EmailAction, error) {
 				return nil, nil
 			},
 		},
@@ -296,7 +296,7 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		ListEmailActionsFunc: &CodeMonitorStoreListEmailActionsFunc{
-			defaultHook: func(context.Context, ListActionsOpts) ([]*MonitorEmail, error) {
+			defaultHook: func(context.Context, ListActionsOpts) ([]*EmailAction, error) {
 				return nil, nil
 			},
 		},
@@ -361,7 +361,7 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		UpdateEmailActionFunc: &CodeMonitorStoreUpdateEmailActionFunc{
-			defaultHook: func(context.Context, int64, *graphqlbackend.EditActionArgs) (*MonitorEmail, error) {
+			defaultHook: func(context.Context, int64, *graphqlbackend.EditActionArgs) (*EmailAction, error) {
 				return nil, nil
 			},
 		},
@@ -1179,15 +1179,15 @@ func (c CodeMonitorStoreCreateCodeMonitorFuncCall) Results() []interface{} {
 // CreateEmailAction method of the parent MockCodeMonitorStore instance is
 // invoked.
 type CodeMonitorStoreCreateEmailActionFunc struct {
-	defaultHook func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*MonitorEmail, error)
-	hooks       []func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*MonitorEmail, error)
+	defaultHook func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*EmailAction, error)
+	hooks       []func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*EmailAction, error)
 	history     []CodeMonitorStoreCreateEmailActionFuncCall
 	mutex       sync.Mutex
 }
 
 // CreateEmailAction delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) CreateEmailAction(v0 context.Context, v1 int64, v2 *graphqlbackend.CreateActionArgs) (*MonitorEmail, error) {
+func (m *MockCodeMonitorStore) CreateEmailAction(v0 context.Context, v1 int64, v2 *graphqlbackend.CreateActionArgs) (*EmailAction, error) {
 	r0, r1 := m.CreateEmailActionFunc.nextHook()(v0, v1, v2)
 	m.CreateEmailActionFunc.appendCall(CodeMonitorStoreCreateEmailActionFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
@@ -1196,7 +1196,7 @@ func (m *MockCodeMonitorStore) CreateEmailAction(v0 context.Context, v1 int64, v
 // SetDefaultHook sets function that is called when the CreateEmailAction
 // method of the parent MockCodeMonitorStore instance is invoked and the
 // hook queue is empty.
-func (f *CodeMonitorStoreCreateEmailActionFunc) SetDefaultHook(hook func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*MonitorEmail, error)) {
+func (f *CodeMonitorStoreCreateEmailActionFunc) SetDefaultHook(hook func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*EmailAction, error)) {
 	f.defaultHook = hook
 }
 
@@ -1205,7 +1205,7 @@ func (f *CodeMonitorStoreCreateEmailActionFunc) SetDefaultHook(hook func(context
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *CodeMonitorStoreCreateEmailActionFunc) PushHook(hook func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*MonitorEmail, error)) {
+func (f *CodeMonitorStoreCreateEmailActionFunc) PushHook(hook func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*EmailAction, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1213,21 +1213,21 @@ func (f *CodeMonitorStoreCreateEmailActionFunc) PushHook(hook func(context.Conte
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *CodeMonitorStoreCreateEmailActionFunc) SetDefaultReturn(r0 *MonitorEmail, r1 error) {
-	f.SetDefaultHook(func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*MonitorEmail, error) {
+func (f *CodeMonitorStoreCreateEmailActionFunc) SetDefaultReturn(r0 *EmailAction, r1 error) {
+	f.SetDefaultHook(func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*EmailAction, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *CodeMonitorStoreCreateEmailActionFunc) PushReturn(r0 *MonitorEmail, r1 error) {
-	f.PushHook(func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*MonitorEmail, error) {
+func (f *CodeMonitorStoreCreateEmailActionFunc) PushReturn(r0 *EmailAction, r1 error) {
+	f.PushHook(func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*EmailAction, error) {
 		return r0, r1
 	})
 }
 
-func (f *CodeMonitorStoreCreateEmailActionFunc) nextHook() func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*MonitorEmail, error) {
+func (f *CodeMonitorStoreCreateEmailActionFunc) nextHook() func(context.Context, int64, *graphqlbackend.CreateActionArgs) (*EmailAction, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1272,7 +1272,7 @@ type CodeMonitorStoreCreateEmailActionFuncCall struct {
 	Arg2 *graphqlbackend.CreateActionArgs
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *MonitorEmail
+	Result0 *EmailAction
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -2826,15 +2826,15 @@ func (c CodeMonitorStoreGetActionJobMetadataFuncCall) Results() []interface{} {
 // GetEmailAction method of the parent MockCodeMonitorStore instance is
 // invoked.
 type CodeMonitorStoreGetEmailActionFunc struct {
-	defaultHook func(context.Context, int64) (*MonitorEmail, error)
-	hooks       []func(context.Context, int64) (*MonitorEmail, error)
+	defaultHook func(context.Context, int64) (*EmailAction, error)
+	hooks       []func(context.Context, int64) (*EmailAction, error)
 	history     []CodeMonitorStoreGetEmailActionFuncCall
 	mutex       sync.Mutex
 }
 
 // GetEmailAction delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) GetEmailAction(v0 context.Context, v1 int64) (*MonitorEmail, error) {
+func (m *MockCodeMonitorStore) GetEmailAction(v0 context.Context, v1 int64) (*EmailAction, error) {
 	r0, r1 := m.GetEmailActionFunc.nextHook()(v0, v1)
 	m.GetEmailActionFunc.appendCall(CodeMonitorStoreGetEmailActionFuncCall{v0, v1, r0, r1})
 	return r0, r1
@@ -2843,7 +2843,7 @@ func (m *MockCodeMonitorStore) GetEmailAction(v0 context.Context, v1 int64) (*Mo
 // SetDefaultHook sets function that is called when the GetEmailAction
 // method of the parent MockCodeMonitorStore instance is invoked and the
 // hook queue is empty.
-func (f *CodeMonitorStoreGetEmailActionFunc) SetDefaultHook(hook func(context.Context, int64) (*MonitorEmail, error)) {
+func (f *CodeMonitorStoreGetEmailActionFunc) SetDefaultHook(hook func(context.Context, int64) (*EmailAction, error)) {
 	f.defaultHook = hook
 }
 
@@ -2851,7 +2851,7 @@ func (f *CodeMonitorStoreGetEmailActionFunc) SetDefaultHook(hook func(context.Co
 // GetEmailAction method of the parent MockCodeMonitorStore instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *CodeMonitorStoreGetEmailActionFunc) PushHook(hook func(context.Context, int64) (*MonitorEmail, error)) {
+func (f *CodeMonitorStoreGetEmailActionFunc) PushHook(hook func(context.Context, int64) (*EmailAction, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2859,21 +2859,21 @@ func (f *CodeMonitorStoreGetEmailActionFunc) PushHook(hook func(context.Context,
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *CodeMonitorStoreGetEmailActionFunc) SetDefaultReturn(r0 *MonitorEmail, r1 error) {
-	f.SetDefaultHook(func(context.Context, int64) (*MonitorEmail, error) {
+func (f *CodeMonitorStoreGetEmailActionFunc) SetDefaultReturn(r0 *EmailAction, r1 error) {
+	f.SetDefaultHook(func(context.Context, int64) (*EmailAction, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *CodeMonitorStoreGetEmailActionFunc) PushReturn(r0 *MonitorEmail, r1 error) {
-	f.PushHook(func(context.Context, int64) (*MonitorEmail, error) {
+func (f *CodeMonitorStoreGetEmailActionFunc) PushReturn(r0 *EmailAction, r1 error) {
+	f.PushHook(func(context.Context, int64) (*EmailAction, error) {
 		return r0, r1
 	})
 }
 
-func (f *CodeMonitorStoreGetEmailActionFunc) nextHook() func(context.Context, int64) (*MonitorEmail, error) {
+func (f *CodeMonitorStoreGetEmailActionFunc) nextHook() func(context.Context, int64) (*EmailAction, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2915,7 +2915,7 @@ type CodeMonitorStoreGetEmailActionFuncCall struct {
 	Arg1 int64
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *MonitorEmail
+	Result0 *EmailAction
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -3485,15 +3485,15 @@ func (c CodeMonitorStoreListActionJobsFuncCall) Results() []interface{} {
 // ListEmailActions method of the parent MockCodeMonitorStore instance is
 // invoked.
 type CodeMonitorStoreListEmailActionsFunc struct {
-	defaultHook func(context.Context, ListActionsOpts) ([]*MonitorEmail, error)
-	hooks       []func(context.Context, ListActionsOpts) ([]*MonitorEmail, error)
+	defaultHook func(context.Context, ListActionsOpts) ([]*EmailAction, error)
+	hooks       []func(context.Context, ListActionsOpts) ([]*EmailAction, error)
 	history     []CodeMonitorStoreListEmailActionsFuncCall
 	mutex       sync.Mutex
 }
 
 // ListEmailActions delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) ListEmailActions(v0 context.Context, v1 ListActionsOpts) ([]*MonitorEmail, error) {
+func (m *MockCodeMonitorStore) ListEmailActions(v0 context.Context, v1 ListActionsOpts) ([]*EmailAction, error) {
 	r0, r1 := m.ListEmailActionsFunc.nextHook()(v0, v1)
 	m.ListEmailActionsFunc.appendCall(CodeMonitorStoreListEmailActionsFuncCall{v0, v1, r0, r1})
 	return r0, r1
@@ -3502,7 +3502,7 @@ func (m *MockCodeMonitorStore) ListEmailActions(v0 context.Context, v1 ListActio
 // SetDefaultHook sets function that is called when the ListEmailActions
 // method of the parent MockCodeMonitorStore instance is invoked and the
 // hook queue is empty.
-func (f *CodeMonitorStoreListEmailActionsFunc) SetDefaultHook(hook func(context.Context, ListActionsOpts) ([]*MonitorEmail, error)) {
+func (f *CodeMonitorStoreListEmailActionsFunc) SetDefaultHook(hook func(context.Context, ListActionsOpts) ([]*EmailAction, error)) {
 	f.defaultHook = hook
 }
 
@@ -3511,7 +3511,7 @@ func (f *CodeMonitorStoreListEmailActionsFunc) SetDefaultHook(hook func(context.
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *CodeMonitorStoreListEmailActionsFunc) PushHook(hook func(context.Context, ListActionsOpts) ([]*MonitorEmail, error)) {
+func (f *CodeMonitorStoreListEmailActionsFunc) PushHook(hook func(context.Context, ListActionsOpts) ([]*EmailAction, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3519,21 +3519,21 @@ func (f *CodeMonitorStoreListEmailActionsFunc) PushHook(hook func(context.Contex
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *CodeMonitorStoreListEmailActionsFunc) SetDefaultReturn(r0 []*MonitorEmail, r1 error) {
-	f.SetDefaultHook(func(context.Context, ListActionsOpts) ([]*MonitorEmail, error) {
+func (f *CodeMonitorStoreListEmailActionsFunc) SetDefaultReturn(r0 []*EmailAction, r1 error) {
+	f.SetDefaultHook(func(context.Context, ListActionsOpts) ([]*EmailAction, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *CodeMonitorStoreListEmailActionsFunc) PushReturn(r0 []*MonitorEmail, r1 error) {
-	f.PushHook(func(context.Context, ListActionsOpts) ([]*MonitorEmail, error) {
+func (f *CodeMonitorStoreListEmailActionsFunc) PushReturn(r0 []*EmailAction, r1 error) {
+	f.PushHook(func(context.Context, ListActionsOpts) ([]*EmailAction, error) {
 		return r0, r1
 	})
 }
 
-func (f *CodeMonitorStoreListEmailActionsFunc) nextHook() func(context.Context, ListActionsOpts) ([]*MonitorEmail, error) {
+func (f *CodeMonitorStoreListEmailActionsFunc) nextHook() func(context.Context, ListActionsOpts) ([]*EmailAction, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3575,7 +3575,7 @@ type CodeMonitorStoreListEmailActionsFuncCall struct {
 	Arg1 ListActionsOpts
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []*MonitorEmail
+	Result0 []*EmailAction
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -4931,15 +4931,15 @@ func (c CodeMonitorStoreTriggerQueryByMonitorIDInt64FuncCall) Results() []interf
 // UpdateEmailAction method of the parent MockCodeMonitorStore instance is
 // invoked.
 type CodeMonitorStoreUpdateEmailActionFunc struct {
-	defaultHook func(context.Context, int64, *graphqlbackend.EditActionArgs) (*MonitorEmail, error)
-	hooks       []func(context.Context, int64, *graphqlbackend.EditActionArgs) (*MonitorEmail, error)
+	defaultHook func(context.Context, int64, *graphqlbackend.EditActionArgs) (*EmailAction, error)
+	hooks       []func(context.Context, int64, *graphqlbackend.EditActionArgs) (*EmailAction, error)
 	history     []CodeMonitorStoreUpdateEmailActionFuncCall
 	mutex       sync.Mutex
 }
 
 // UpdateEmailAction delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) UpdateEmailAction(v0 context.Context, v1 int64, v2 *graphqlbackend.EditActionArgs) (*MonitorEmail, error) {
+func (m *MockCodeMonitorStore) UpdateEmailAction(v0 context.Context, v1 int64, v2 *graphqlbackend.EditActionArgs) (*EmailAction, error) {
 	r0, r1 := m.UpdateEmailActionFunc.nextHook()(v0, v1, v2)
 	m.UpdateEmailActionFunc.appendCall(CodeMonitorStoreUpdateEmailActionFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
@@ -4948,7 +4948,7 @@ func (m *MockCodeMonitorStore) UpdateEmailAction(v0 context.Context, v1 int64, v
 // SetDefaultHook sets function that is called when the UpdateEmailAction
 // method of the parent MockCodeMonitorStore instance is invoked and the
 // hook queue is empty.
-func (f *CodeMonitorStoreUpdateEmailActionFunc) SetDefaultHook(hook func(context.Context, int64, *graphqlbackend.EditActionArgs) (*MonitorEmail, error)) {
+func (f *CodeMonitorStoreUpdateEmailActionFunc) SetDefaultHook(hook func(context.Context, int64, *graphqlbackend.EditActionArgs) (*EmailAction, error)) {
 	f.defaultHook = hook
 }
 
@@ -4957,7 +4957,7 @@ func (f *CodeMonitorStoreUpdateEmailActionFunc) SetDefaultHook(hook func(context
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *CodeMonitorStoreUpdateEmailActionFunc) PushHook(hook func(context.Context, int64, *graphqlbackend.EditActionArgs) (*MonitorEmail, error)) {
+func (f *CodeMonitorStoreUpdateEmailActionFunc) PushHook(hook func(context.Context, int64, *graphqlbackend.EditActionArgs) (*EmailAction, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -4965,21 +4965,21 @@ func (f *CodeMonitorStoreUpdateEmailActionFunc) PushHook(hook func(context.Conte
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *CodeMonitorStoreUpdateEmailActionFunc) SetDefaultReturn(r0 *MonitorEmail, r1 error) {
-	f.SetDefaultHook(func(context.Context, int64, *graphqlbackend.EditActionArgs) (*MonitorEmail, error) {
+func (f *CodeMonitorStoreUpdateEmailActionFunc) SetDefaultReturn(r0 *EmailAction, r1 error) {
+	f.SetDefaultHook(func(context.Context, int64, *graphqlbackend.EditActionArgs) (*EmailAction, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *CodeMonitorStoreUpdateEmailActionFunc) PushReturn(r0 *MonitorEmail, r1 error) {
-	f.PushHook(func(context.Context, int64, *graphqlbackend.EditActionArgs) (*MonitorEmail, error) {
+func (f *CodeMonitorStoreUpdateEmailActionFunc) PushReturn(r0 *EmailAction, r1 error) {
+	f.PushHook(func(context.Context, int64, *graphqlbackend.EditActionArgs) (*EmailAction, error) {
 		return r0, r1
 	})
 }
 
-func (f *CodeMonitorStoreUpdateEmailActionFunc) nextHook() func(context.Context, int64, *graphqlbackend.EditActionArgs) (*MonitorEmail, error) {
+func (f *CodeMonitorStoreUpdateEmailActionFunc) nextHook() func(context.Context, int64, *graphqlbackend.EditActionArgs) (*EmailAction, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -5024,7 +5024,7 @@ type CodeMonitorStoreUpdateEmailActionFuncCall struct {
 	Arg2 *graphqlbackend.EditActionArgs
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *MonitorEmail
+	Result0 *EmailAction
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -456,7 +456,7 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 			defaultHook: i.GetMonitor,
 		},
 		GetQueryByRecordIDFunc: &CodeMonitorStoreGetQueryByRecordIDFunc{
-			defaultHook: i.GetQueryByRecordID,
+			defaultHook: i.GetQueryTriggerForJob,
 		},
 		HandleFunc: &CodeMonitorStoreHandleFunc{
 			defaultHook: i.Handle,

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -432,7 +432,7 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 			defaultHook: i.Done,
 		},
 		EnqueueActionEmailsForQueryIDInt64Func: &CodeMonitorStoreEnqueueActionEmailsForQueryIDInt64Func{
-			defaultHook: i.EnqueueActionEmailsForQueryIDInt64,
+			defaultHook: i.EnqueueActionJobsForQuery,
 		},
 		EnqueueTriggerQueriesFunc: &CodeMonitorStoreEnqueueTriggerQueriesFunc{
 			defaultHook: i.EnqueueQueryTriggerJobs,

--- a/enterprise/internal/codemonitors/monitors.go
+++ b/enterprise/internal/codemonitors/monitors.go
@@ -171,7 +171,7 @@ ORDER BY id ASC
 LIMIT %s
 `
 
-func (s *codeMonitorStore) Monitors(ctx context.Context, userID int32, args *graphqlbackend.ListMonitorsArgs) ([]*Monitor, error) {
+func (s *codeMonitorStore) ListMonitors(ctx context.Context, userID int32, args *graphqlbackend.ListMonitorsArgs) ([]*Monitor, error) {
 	after, err := unmarshalAfter(args.After)
 	if err != nil {
 		return nil, err

--- a/enterprise/internal/codemonitors/monitors.go
+++ b/enterprise/internal/codemonitors/monitors.go
@@ -143,11 +143,22 @@ func (s *codeMonitorStore) ToggleMonitor(ctx context.Context, args *graphqlbacke
 	return scanMonitor(row)
 }
 
+const deleteMonitorFmtStr = `
+DELETE FROM cm_monitors
+WHERE id = %s
+`
+
 func (s *codeMonitorStore) DeleteMonitor(ctx context.Context, args *graphqlbackend.DeleteCodeMonitorArgs) error {
-	q, err := s.deleteMonitorQuery(ctx, args)
+	var monitorID int64
+	err := relay.UnmarshalSpec(args.Id, &monitorID)
 	if err != nil {
 		return err
 	}
+
+	q := sqlf.Sprintf(
+		deleteMonitorFmtStr,
+		monitorID,
+	)
 	return s.Exec(ctx, q)
 }
 
@@ -212,23 +223,6 @@ func monitorsQuery(userID int32, args *graphqlbackend.ListMonitorsArgs) (*sqlf.Q
 		userID,
 		after,
 		args.First,
-	), nil
-}
-
-const deleteMonitorFmtStr = `
-DELETE FROM cm_monitors
-WHERE id = %s
-`
-
-func (s *codeMonitorStore) deleteMonitorQuery(ctx context.Context, args *graphqlbackend.DeleteCodeMonitorArgs) (*sqlf.Query, error) {
-	var monitorID int64
-	err := relay.UnmarshalSpec(args.Id, &monitorID)
-	if err != nil {
-		return nil, err
-	}
-	return sqlf.Sprintf(
-		deleteMonitorFmtStr,
-		monitorID,
 	), nil
 }
 

--- a/enterprise/internal/codemonitors/monitors.go
+++ b/enterprise/internal/codemonitors/monitors.go
@@ -96,7 +96,6 @@ func (s *codeMonitorStore) UpdateMonitor(ctx context.Context, args *graphqlbacke
 		return nil, err
 	}
 
-	now := s.Now()
 	q := sqlf.Sprintf(
 		updateCodeMonitorFmtStr,
 		args.Monitor.Update.Description,
@@ -104,7 +103,7 @@ func (s *codeMonitorStore) UpdateMonitor(ctx context.Context, args *graphqlbacke
 		nilOrInt32(userID),
 		nilOrInt32(orgID),
 		a.UID,
-		now,
+		s.Now(),
 		monitorID,
 		sqlf.Join(monitorColumns, ", "),
 	)

--- a/enterprise/internal/codemonitors/monitors.go
+++ b/enterprise/internal/codemonitors/monitors.go
@@ -41,7 +41,7 @@ const insertCodeMonitorFmtStr = `
 INSERT INTO cm_monitors
 (created_at, created_by, changed_at, changed_by, description, enabled, namespace_user_id, namespace_org_id)
 VALUES (%s,%s,%s,%s,%s,%s,%s,%s)
-RETURNING %s;
+RETURNING %s; -- monitorColumns
 `
 
 func (s *codeMonitorStore) CreateMonitor(ctx context.Context, args *graphqlbackend.CreateMonitorArgs) (*Monitor, error) {
@@ -79,7 +79,7 @@ SET description = %s,
 	changed_by = %s,
 	changed_at = %s
 WHERE id = %s
-RETURNING %s;
+RETURNING %s; -- monitorColumns
 `
 
 func (s *codeMonitorStore) UpdateMonitor(ctx context.Context, args *graphqlbackend.UpdateCodeMonitorArgs) (*Monitor, error) {
@@ -119,7 +119,7 @@ SET enabled = %s,
 	changed_by = %s,
 	changed_at = %s
 WHERE id = %s
-RETURNING %s
+RETURNING %s -- monitorColumns
 `
 
 func (s *codeMonitorStore) ToggleMonitor(ctx context.Context, args *graphqlbackend.ToggleCodeMonitorArgs) (*Monitor, error) {
@@ -163,7 +163,7 @@ func (s *codeMonitorStore) DeleteMonitor(ctx context.Context, args *graphqlbacke
 }
 
 const monitorsFmtStr = `
-SELECT id, created_by, created_at, changed_by, changed_at, description, enabled, namespace_user_id, namespace_org_id
+SELECT %s -- monitorColumns
 FROM cm_monitors
 WHERE namespace_user_id = %s
 AND id > %s
@@ -178,6 +178,7 @@ func (s *codeMonitorStore) ListMonitors(ctx context.Context, userID int32, args 
 	}
 	q := sqlf.Sprintf(
 		monitorsFmtStr,
+		sqlf.Join(monitorColumns, ","),
 		userID,
 		after,
 		args.First,

--- a/enterprise/internal/codemonitors/monitors.go
+++ b/enterprise/internal/codemonitors/monitors.go
@@ -108,7 +108,7 @@ FROM cm_monitors
 WHERE namespace_user_id = %s;
 `
 
-func (s *codeMonitorStore) TotalCountMonitors(ctx context.Context, userID int32) (int32, error) {
+func (s *codeMonitorStore) CountMonitors(ctx context.Context, userID int32) (int32, error) {
 	var count int32
 	err := s.QueryRow(ctx, sqlf.Sprintf(totalCountMonitorsFmtStr, userID)).Scan(&count)
 	return count, err

--- a/enterprise/internal/codemonitors/queries.go
+++ b/enterprise/internal/codemonitors/queries.go
@@ -13,7 +13,7 @@ import (
 )
 
 type QueryTrigger struct {
-	Id           int64
+	ID           int64
 	Monitor      int64
 	QueryString  string
 	NextRun      time.Time
@@ -199,7 +199,7 @@ func (s *codeMonitorStore) SetQueryTriggerNextRun(ctx context.Context, triggerQu
 func scanTriggerQuery(scanner dbutil.Scanner) (*QueryTrigger, error) {
 	m := &QueryTrigger{}
 	err := scanner.Scan(
-		&m.Id,
+		&m.ID,
 		&m.Monitor,
 		&m.QueryString,
 		&m.NextRun,

--- a/enterprise/internal/codemonitors/queries.go
+++ b/enterprise/internal/codemonitors/queries.go
@@ -46,7 +46,7 @@ func (s *codeMonitorStore) CreateQueryTrigger(ctx context.Context, monitorID int
 	return s.Exec(ctx, q)
 }
 
-func (s *codeMonitorStore) UpdateTriggerQuery(ctx context.Context, args *graphqlbackend.UpdateCodeMonitorArgs) error {
+func (s *codeMonitorStore) UpdateQueryTrigger(ctx context.Context, args *graphqlbackend.UpdateCodeMonitorArgs) error {
 	q, err := s.updateTriggerQueryQuery(ctx, args)
 	if err != nil {
 		return err

--- a/enterprise/internal/codemonitors/queries.go
+++ b/enterprise/internal/codemonitors/queries.go
@@ -60,7 +60,7 @@ FROM cm_queries
 WHERE monitor = %s;
 `
 
-func (s *codeMonitorStore) TriggerQueryByMonitorIDInt64(ctx context.Context, monitorID int64) (*QueryTrigger, error) {
+func (s *codeMonitorStore) GetQueryTriggerForMonitor(ctx context.Context, monitorID int64) (*QueryTrigger, error) {
 	q := sqlf.Sprintf(
 		triggerQueryByMonitorFmtStr,
 		sqlf.Join(queryColumns, ","),

--- a/enterprise/internal/codemonitors/queries.go
+++ b/enterprise/internal/codemonitors/queries.go
@@ -93,7 +93,7 @@ SET latest_result = null,
 WHERE id = %s;
 `
 
-func (s *codeMonitorStore) ResetTriggerQueryTimestamps(ctx context.Context, queryID int64) error {
+func (s *codeMonitorStore) ResetQueryTriggerTimestamps(ctx context.Context, queryID int64) error {
 	return s.Exec(ctx, sqlf.Sprintf(resetTriggerQueryTimestamps, s.Now(), queryID))
 }
 

--- a/enterprise/internal/codemonitors/queries.go
+++ b/enterprise/internal/codemonitors/queries.go
@@ -2,7 +2,6 @@ package codemonitors
 
 import (
 	"context"
-	"database/sql"
 	"time"
 
 	"github.com/graph-gophers/graphql-go/relay"

--- a/enterprise/internal/codemonitors/queries.go
+++ b/enterprise/internal/codemonitors/queries.go
@@ -184,7 +184,7 @@ latest_result = %s
 WHERE id = %s
 `
 
-func (s *codeMonitorStore) SetTriggerQueryNextRun(ctx context.Context, triggerQueryID int64, next time.Time, latestResults time.Time) error {
+func (s *codeMonitorStore) SetQueryTriggerNextRun(ctx context.Context, triggerQueryID int64, next time.Time, latestResults time.Time) error {
 	q := sqlf.Sprintf(
 		setTriggerQueryNextRunFmtStr,
 		next,

--- a/enterprise/internal/codemonitors/queries.go
+++ b/enterprise/internal/codemonitors/queries.go
@@ -25,6 +25,8 @@ type MonitorQuery struct {
 	ChangedAt    time.Time
 }
 
+// queryColumns is the set of columns in cm_queries
+// It must be kept in sync with scanTriggerQuery
 var queryColumns = []*sqlf.Query{
 	sqlf.Sprintf("cm_queries.id"),
 	sqlf.Sprintf("cm_queries.monitor"),
@@ -205,6 +207,8 @@ func scanTriggerQueries(rows *sql.Rows) ([]*MonitorQuery, error) {
 	return ms, rows.Err()
 }
 
+// scanQueryTrigger scans a *sql.Rows or *sql.Row into a MonitorQuery
+// It must be kept in sync with queryColumns
 func scanTriggerQuery(scanner dbutil.Scanner) (*MonitorQuery, error) {
 	m := &MonitorQuery{}
 	err := scanner.Scan(

--- a/enterprise/internal/codemonitors/queries.go
+++ b/enterprise/internal/codemonitors/queries.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
-type MonitorQuery struct {
+type QueryTrigger struct {
 	Id           int64
 	Monitor      int64
 	QueryString  string
@@ -60,7 +60,7 @@ FROM cm_queries
 WHERE monitor = %s;
 `
 
-func (s *codeMonitorStore) TriggerQueryByMonitorIDInt64(ctx context.Context, monitorID int64) (*MonitorQuery, error) {
+func (s *codeMonitorStore) TriggerQueryByMonitorIDInt64(ctx context.Context, monitorID int64) (*QueryTrigger, error) {
 	q := sqlf.Sprintf(
 		triggerQueryByMonitorFmtStr,
 		sqlf.Join(queryColumns, ","),
@@ -76,7 +76,7 @@ FROM cm_queries
 WHERE id = %s;
 `
 
-func (s *codeMonitorStore) triggerQueryByIDInt64(ctx context.Context, queryID int64) (*MonitorQuery, error) {
+func (s *codeMonitorStore) triggerQueryByIDInt64(ctx context.Context, queryID int64) (*QueryTrigger, error) {
 	q := sqlf.Sprintf(
 		triggerQueryByIDFmtStr,
 		sqlf.Join(queryColumns, ","),
@@ -167,7 +167,7 @@ INNER JOIN cm_trigger_jobs j ON cm_queries.id = j.query
 WHERE j.id = %s
 `
 
-func (s *codeMonitorStore) GetQueryByRecordID(ctx context.Context, recordID int) (*MonitorQuery, error) {
+func (s *codeMonitorStore) GetQueryByRecordID(ctx context.Context, recordID int) (*QueryTrigger, error) {
 	q := sqlf.Sprintf(
 		getQueryByRecordIDFmtStr,
 		sqlf.Join(queryColumns, ","),
@@ -196,8 +196,8 @@ func (s *codeMonitorStore) SetTriggerQueryNextRun(ctx context.Context, triggerQu
 
 // scanQueryTrigger scans a *sql.Rows or *sql.Row into a MonitorQuery
 // It must be kept in sync with queryColumns
-func scanTriggerQuery(scanner dbutil.Scanner) (*MonitorQuery, error) {
-	m := &MonitorQuery{}
+func scanTriggerQuery(scanner dbutil.Scanner) (*QueryTrigger, error) {
+	m := &QueryTrigger{}
 	err := scanner.Scan(
 		&m.Id,
 		&m.Monitor,

--- a/enterprise/internal/codemonitors/queries.go
+++ b/enterprise/internal/codemonitors/queries.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"time"
 
-	"github.com/cockroachdb/errors"
 	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/keegancsmith/sqlf"
 
@@ -173,19 +172,8 @@ func (s *codeMonitorStore) GetQueryByRecordID(ctx context.Context, recordID int)
 		sqlf.Join(queryColumns, ","),
 		recordID,
 	)
-	rows, err := s.Query(ctx, q)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	ms, err := scanTriggerQueries(rows)
-	if err != nil {
-		return nil, err
-	}
-	if len(ms) != 1 {
-		return nil, errors.Errorf("query should have returned 1 row")
-	}
-	return ms[0], nil
+	row := s.QueryRow(ctx, q)
+	return scanTriggerQuery(row)
 }
 
 const setTriggerQueryNextRunFmtStr = `

--- a/enterprise/internal/codemonitors/queries.go
+++ b/enterprise/internal/codemonitors/queries.go
@@ -167,7 +167,7 @@ INNER JOIN cm_trigger_jobs j ON cm_queries.id = j.query
 WHERE j.id = %s
 `
 
-func (s *codeMonitorStore) GetQueryByRecordID(ctx context.Context, recordID int) (*QueryTrigger, error) {
+func (s *codeMonitorStore) GetQueryTriggerForJob(ctx context.Context, recordID int) (*QueryTrigger, error) {
 	q := sqlf.Sprintf(
 		getQueryByRecordIDFmtStr,
 		sqlf.Join(queryColumns, ","),

--- a/enterprise/internal/codemonitors/queries.go
+++ b/enterprise/internal/codemonitors/queries.go
@@ -60,7 +60,9 @@ WHERE monitor = %s;
 `
 
 func (s *codeMonitorStore) TriggerQueryByMonitorIDInt64(ctx context.Context, monitorID int64) (*MonitorQuery, error) {
-	return s.runTriggerQuery(ctx, sqlf.Sprintf(triggerQueryByMonitorFmtStr, monitorID))
+	q := sqlf.Sprintf(triggerQueryByMonitorFmtStr, monitorID)
+	row := s.QueryRow(ctx, q)
+	return scanTriggerQuery(row)
 }
 
 const triggerQueryByIDFmtStr = `
@@ -70,7 +72,9 @@ WHERE id = %s;
 `
 
 func (s *codeMonitorStore) triggerQueryByIDInt64(ctx context.Context, queryID int64) (*MonitorQuery, error) {
-	return s.runTriggerQuery(ctx, sqlf.Sprintf(triggerQueryByIDFmtStr, queryID))
+	q := sqlf.Sprintf(triggerQueryByIDFmtStr, queryID)
+	row := s.QueryRow(ctx, q)
+	return scanTriggerQuery(row)
 }
 
 const resetTriggerQueryTimestamps = `
@@ -130,7 +134,7 @@ func (s *codeMonitorStore) updateTriggerQueryQuery(ctx context.Context, args *gr
 	}
 
 	var monitorID int64
-	err := relay.UnmarshalSpec(args.Monitor.Id, &monitorID)
+	err = relay.UnmarshalSpec(args.Monitor.Id, &monitorID)
 	if err != nil {
 		return nil, err
 	}
@@ -216,9 +220,4 @@ func scanTriggerQuery(scanner dbutil.Scanner) (*MonitorQuery, error) {
 		&m.ChangedAt,
 	)
 	return m, err
-}
-
-func (s *codeMonitorStore) runTriggerQuery(ctx context.Context, q *sqlf.Query) (*MonitorQuery, error) {
-	row := s.QueryRow(ctx, q)
-	return scanTriggerQuery(row)
 }

--- a/enterprise/internal/codemonitors/queries.go
+++ b/enterprise/internal/codemonitors/queries.go
@@ -75,8 +75,6 @@ RETURNING %s;
 `
 
 func (s *codeMonitorStore) UpdateQueryTrigger(ctx context.Context, args *graphqlbackend.UpdateCodeMonitorArgs) error {
-	now := s.Now()
-	a := actor.FromContext(ctx)
 
 	var triggerID int64
 	err := relay.UnmarshalSpec(args.Trigger.Id, &triggerID)
@@ -90,6 +88,8 @@ func (s *codeMonitorStore) UpdateQueryTrigger(ctx context.Context, args *graphql
 		return err
 	}
 
+	now := s.Now()
+	a := actor.FromContext(ctx)
 	q := sqlf.Sprintf(
 		updateTriggerQueryFmtStr,
 		args.Trigger.Update.Query,

--- a/enterprise/internal/codemonitors/queries.go
+++ b/enterprise/internal/codemonitors/queries.go
@@ -38,7 +38,7 @@ var queryColumns = []*sqlf.Query{
 	sqlf.Sprintf("cm_queries.changed_at"),
 }
 
-func (s *codeMonitorStore) CreateTriggerQuery(ctx context.Context, monitorID int64, args *graphqlbackend.CreateTriggerArgs) error {
+func (s *codeMonitorStore) CreateQueryTrigger(ctx context.Context, monitorID int64, args *graphqlbackend.CreateTriggerArgs) error {
 	q, err := s.createTriggerQueryQuery(ctx, monitorID, args)
 	if err != nil {
 		return err

--- a/enterprise/internal/codemonitors/queries.go
+++ b/enterprise/internal/codemonitors/queries.go
@@ -195,18 +195,6 @@ func (s *codeMonitorStore) SetTriggerQueryNextRun(ctx context.Context, triggerQu
 	return s.Exec(ctx, q)
 }
 
-func scanTriggerQueries(rows *sql.Rows) ([]*MonitorQuery, error) {
-	var ms []*MonitorQuery
-	for rows.Next() {
-		m, err := scanTriggerQuery(rows)
-		if err != nil {
-			return nil, err
-		}
-		ms = append(ms, m)
-	}
-	return ms, rows.Err()
-}
-
 // scanQueryTrigger scans a *sql.Rows or *sql.Row into a MonitorQuery
 // It must be kept in sync with queryColumns
 func scanTriggerQuery(scanner dbutil.Scanner) (*MonitorQuery, error) {

--- a/enterprise/internal/codemonitors/queries.go
+++ b/enterprise/internal/codemonitors/queries.go
@@ -162,6 +162,7 @@ func (s *codeMonitorStore) GetQueryByRecordID(ctx context.Context, recordID int)
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	ms, err := scanTriggerQueries(rows)
 	if err != nil {
 		return nil, err
@@ -198,14 +199,7 @@ func scanTriggerQueries(rows *sql.Rows) ([]*MonitorQuery, error) {
 		}
 		ms = append(ms, m)
 	}
-	err := rows.Close()
-	if err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return ms, nil
+	return ms, rows.Err()
 }
 
 func scanTriggerQuery(scanner dbutil.Scanner) (*MonitorQuery, error) {

--- a/enterprise/internal/codemonitors/queries.go
+++ b/enterprise/internal/codemonitors/queries.go
@@ -219,17 +219,6 @@ func scanTriggerQuery(scanner dbutil.Scanner) (*MonitorQuery, error) {
 }
 
 func (s *codeMonitorStore) runTriggerQuery(ctx context.Context, q *sqlf.Query) (*MonitorQuery, error) {
-	rows, err := s.Query(ctx, q)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	ms, err := scanTriggerQueries(rows)
-	if err != nil {
-		return nil, err
-	}
-	if len(ms) == 0 {
-		return nil, errors.Errorf("operation failed. Query should have returned 1 row")
-	}
-	return ms[0], nil
+	row := s.QueryRow(ctx, q)
+	return scanTriggerQuery(row)
 }

--- a/enterprise/internal/codemonitors/queries_test.go
+++ b/enterprise/internal/codemonitors/queries_test.go
@@ -18,7 +18,7 @@ func TestQueryByRecordID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = s.EnqueueTriggerQueries(ctx)
+	err = s.EnqueueQueryTriggers(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,7 +54,7 @@ func TestTriggerQueryNextRun(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = s.EnqueueTriggerQueries(ctx)
+	err = s.EnqueueQueryTriggers(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/codemonitors/queries_test.go
+++ b/enterprise/internal/codemonitors/queries_test.go
@@ -27,7 +27,7 @@ func TestQueryByRecordID(t *testing.T) {
 		t.Fatal(err)
 	}
 	now := s.Now()
-	want := &MonitorQuery{
+	want := &QueryTrigger{
 		Id:           1,
 		Monitor:      m.ID,
 		QueryString:  testQuery,
@@ -70,7 +70,7 @@ func TestTriggerQueryNextRun(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := &MonitorQuery{
+	want := &QueryTrigger{
 		Id:           1,
 		Monitor:      m.ID,
 		QueryString:  testQuery,
@@ -99,7 +99,7 @@ func TestResetTriggerQueryTimestamps(t *testing.T) {
 		t.Fatal(err)
 	}
 	now := s.Now()
-	want := &MonitorQuery{
+	want := &QueryTrigger{
 		Id:           1,
 		Monitor:      m.ID,
 		QueryString:  testQuery,
@@ -127,7 +127,7 @@ func TestResetTriggerQueryTimestamps(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want = &MonitorQuery{
+	want = &QueryTrigger{
 		Id:           1,
 		Monitor:      m.ID,
 		QueryString:  testQuery,

--- a/enterprise/internal/codemonitors/queries_test.go
+++ b/enterprise/internal/codemonitors/queries_test.go
@@ -118,7 +118,7 @@ func TestResetTriggerQueryTimestamps(t *testing.T) {
 		t.Fatalf("diff: %s", diff)
 	}
 
-	err = s.ResetTriggerQueryTimestamps(ctx, 1)
+	err = s.ResetQueryTriggerTimestamps(ctx, 1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/codemonitors/queries_test.go
+++ b/enterprise/internal/codemonitors/queries_test.go
@@ -28,7 +28,7 @@ func TestQueryByRecordID(t *testing.T) {
 	}
 	now := s.Now()
 	want := &QueryTrigger{
-		Id:           1,
+		ID:           1,
 		Monitor:      m.ID,
 		QueryString:  testQuery,
 		NextRun:      now,
@@ -71,7 +71,7 @@ func TestTriggerQueryNextRun(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := &QueryTrigger{
-		Id:           1,
+		ID:           1,
 		Monitor:      m.ID,
 		QueryString:  testQuery,
 		NextRun:      wantNextRun,
@@ -100,7 +100,7 @@ func TestResetTriggerQueryTimestamps(t *testing.T) {
 	}
 	now := s.Now()
 	want := &QueryTrigger{
-		Id:           1,
+		ID:           1,
 		Monitor:      m.ID,
 		QueryString:  testQuery,
 		NextRun:      now,
@@ -128,7 +128,7 @@ func TestResetTriggerQueryTimestamps(t *testing.T) {
 		t.Fatal(err)
 	}
 	want = &QueryTrigger{
-		Id:           1,
+		ID:           1,
 		Monitor:      m.ID,
 		QueryString:  testQuery,
 		NextRun:      now,

--- a/enterprise/internal/codemonitors/queries_test.go
+++ b/enterprise/internal/codemonitors/queries_test.go
@@ -62,7 +62,7 @@ func TestTriggerQueryNextRun(t *testing.T) {
 	wantLatestResult := s.Now().Add(time.Minute)
 	wantNextRun := s.Now().Add(time.Hour)
 
-	err = s.SetTriggerQueryNextRun(ctx, 1, wantNextRun, wantLatestResult)
+	err = s.SetQueryTriggerNextRun(ctx, 1, wantNextRun, wantLatestResult)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/codemonitors/queries_test.go
+++ b/enterprise/internal/codemonitors/queries_test.go
@@ -18,7 +18,7 @@ func TestQueryByRecordID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = s.EnqueueQueryTriggers(ctx)
+	err = s.EnqueueQueryTriggerJobs(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,7 +54,7 @@ func TestTriggerQueryNextRun(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = s.EnqueueQueryTriggers(ctx)
+	err = s.EnqueueQueryTriggerJobs(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/codemonitors/queries_test.go
+++ b/enterprise/internal/codemonitors/queries_test.go
@@ -22,7 +22,7 @@ func TestQueryByRecordID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	got, err := s.GetQueryByRecordID(ctx, 1)
+	got, err := s.GetQueryTriggerForJob(ctx, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +66,7 @@ func TestTriggerQueryNextRun(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	got, err := s.GetQueryByRecordID(ctx, 1)
+	got, err := s.GetQueryTriggerForJob(ctx, 1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/codemonitors/recipients.go
+++ b/enterprise/internal/codemonitors/recipients.go
@@ -72,7 +72,7 @@ FROM cm_recipients
 WHERE email = %s
 `
 
-func (s *codeMonitorStore) AllRecipientsForEmailIDInt64(ctx context.Context, emailID int64) ([]*Recipient, error) {
+func (s *codeMonitorStore) ListAllRecipientsForEmailAction(ctx context.Context, emailID int64) ([]*Recipient, error) {
 	rows, err := s.Query(ctx, sqlf.Sprintf(allRecipientsForEmailIDInt64FmtStr, emailID))
 	if err != nil {
 		return nil, errors.Errorf("store.AllRecipientsForEmailIDInt64: %w", err)

--- a/enterprise/internal/codemonitors/recipients.go
+++ b/enterprise/internal/codemonitors/recipients.go
@@ -63,14 +63,7 @@ func scanRecipients(rows *sql.Rows) ([]*Recipient, error) {
 		}
 		ms = append(ms, m)
 	}
-	err := rows.Close()
-	if err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return ms, nil
+	return ms, rows.Err()
 }
 
 const allRecipientsForEmailIDInt64FmtStr = `

--- a/enterprise/internal/codemonitors/recipients.go
+++ b/enterprise/internal/codemonitors/recipients.go
@@ -100,7 +100,7 @@ FROM cm_recipients
 WHERE email = %s
 `
 
-func (s *codeMonitorStore) TotalCountRecipients(ctx context.Context, emailID int64) (int32, error) {
+func (s *codeMonitorStore) CountRecipients(ctx context.Context, emailID int64) (int32, error) {
 	var count int32
 	err := s.QueryRow(ctx, sqlf.Sprintf(totalCountRecipientsFmtStr, emailID)).Scan(&count)
 	return count, err

--- a/enterprise/internal/codemonitors/recipients.go
+++ b/enterprise/internal/codemonitors/recipients.go
@@ -36,7 +36,7 @@ func (s *codeMonitorStore) DeleteRecipients(ctx context.Context, emailID int64) 
 	return s.Exec(ctx, q)
 }
 
-func (s *codeMonitorStore) RecipientsForEmailIDInt64(ctx context.Context, emailID int64, args *graphqlbackend.ListRecipientsArgs) ([]*Recipient, error) {
+func (s *codeMonitorStore) ListRecipientsForEmailAction(ctx context.Context, emailID int64, args *graphqlbackend.ListRecipientsArgs) ([]*Recipient, error) {
 	q, err := readRecipientQuery(ctx, emailID, args)
 	if err != nil {
 		return nil, err

--- a/enterprise/internal/codemonitors/recipients.go
+++ b/enterprise/internal/codemonitors/recipients.go
@@ -86,7 +86,8 @@ func (s *codeMonitorStore) ListAllRecipientsForEmailAction(ctx context.Context, 
 
 const createRecipientFmtStr = `
 INSERT INTO cm_recipients (email, namespace_user_id, namespace_org_id)
-VALUES (%s,%s,%s)`
+VALUES (%s,%s,%s)
+`
 
 func (s *codeMonitorStore) createRecipient(ctx context.Context, recipient graphql.ID, emailID int64) error {
 	var userID, orgID int32

--- a/enterprise/internal/codemonitors/recipients.go
+++ b/enterprise/internal/codemonitors/recipients.go
@@ -69,23 +69,6 @@ func (s *codeMonitorStore) ListRecipientsForEmailAction(ctx context.Context, ema
 	return scanRecipients(rows)
 }
 
-func scanRecipients(rows *sql.Rows) ([]*Recipient, error) {
-	var ms []*Recipient
-	for rows.Next() {
-		m := &Recipient{}
-		if err := rows.Scan(
-			&m.ID,
-			&m.Email,
-			&m.NamespaceUserID,
-			&m.NamespaceOrgID,
-		); err != nil {
-			return nil, err
-		}
-		ms = append(ms, m)
-	}
-	return ms, rows.Err()
-}
-
 const allRecipientsForEmailIDInt64FmtStr = `
 SELECT id, email, namespace_user_id, namespace_org_id
 FROM cm_recipients
@@ -131,4 +114,21 @@ func nilOrInt32(n int32) *int32 {
 		return nil
 	}
 	return &n
+}
+
+func scanRecipients(rows *sql.Rows) ([]*Recipient, error) {
+	var ms []*Recipient
+	for rows.Next() {
+		m := &Recipient{}
+		if err := rows.Scan(
+			&m.ID,
+			&m.Email,
+			&m.NamespaceUserID,
+			&m.NamespaceOrgID,
+		); err != nil {
+			return nil, err
+		}
+		ms = append(ms, m)
+	}
+	return ms, rows.Err()
 }

--- a/enterprise/internal/codemonitors/recipients.go
+++ b/enterprise/internal/codemonitors/recipients.go
@@ -28,11 +28,16 @@ func (s *codeMonitorStore) CreateRecipients(ctx context.Context, recipients []gr
 	return nil
 }
 
+const deleteRecipientFmtStr = `
+DELETE FROM cm_recipients
+WHERE email = %s
+`
+
 func (s *codeMonitorStore) DeleteRecipients(ctx context.Context, emailID int64) error {
-	q, err := deleteRecipientsQuery(ctx, emailID)
-	if err != nil {
-		return err
-	}
+	q := sqlf.Sprintf(
+		deleteRecipientFmtStr,
+		emailID,
+	)
 	return s.Exec(ctx, q)
 }
 
@@ -104,15 +109,6 @@ func (s *codeMonitorStore) CountRecipients(ctx context.Context, emailID int64) (
 	var count int32
 	err := s.QueryRow(ctx, sqlf.Sprintf(totalCountRecipientsFmtStr, emailID)).Scan(&count)
 	return count, err
-}
-
-const deleteRecipientFmtStr = `DELETE FROM cm_recipients WHERE email = %s`
-
-func deleteRecipientsQuery(ctx context.Context, emailId int64) (*sqlf.Query, error) {
-	return sqlf.Sprintf(
-		deleteRecipientFmtStr,
-		emailId,
-	), nil
 }
 
 const readRecipientQueryFmtStr = `

--- a/enterprise/internal/codemonitors/recipients_test.go
+++ b/enterprise/internal/codemonitors/recipients_test.go
@@ -21,7 +21,7 @@ func TestAllRecipientsForEmailIDInt64(t *testing.T) {
 		wantEmailID     int64 = 1
 		wantRecipientID int64 = 1
 	)
-	rs, err := s.AllRecipientsForEmailIDInt64(ctx, wantEmailID)
+	rs, err := s.ListAllRecipientsForEmailAction(ctx, wantEmailID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -43,7 +43,7 @@ type CodeMonitorStore interface {
 
 	DeleteObsoleteTriggerJobs(ctx context.Context) error
 	UpdateTriggerJobWithResults(ctx context.Context, queryString string, numResults int, recordID int) error
-	DeleteOldJobLogs(ctx context.Context, retentionInDays int) error
+	DeleteOldTriggerJobs(ctx context.Context, retentionInDays int) error
 
 	EnqueueQueryTriggerJobs(ctx context.Context) error
 	ListQueryTriggerJobs(ctx context.Context, queryID int64, args *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error)

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -48,7 +48,7 @@ type CodeMonitorStore interface {
 	GetActionJob(ctx context.Context, recordID int) (*ActionJob, error)
 	CreateActions(ctx context.Context, args []*graphqlbackend.CreateActionArgs, monitorID int64) error
 
-	CreateTriggerQuery(ctx context.Context, monitorID int64, args *graphqlbackend.CreateTriggerArgs) (err error)
+	CreateQueryTrigger(ctx context.Context, monitorID int64, args *graphqlbackend.CreateTriggerArgs) (err error)
 	UpdateTriggerQuery(ctx context.Context, args *graphqlbackend.UpdateCodeMonitorArgs) (err error)
 	TriggerQueryByMonitorIDInt64(ctx context.Context, monitorID int64) (*QueryTrigger, error)
 	ResetTriggerQueryTimestamps(ctx context.Context, queryID int64) error

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -25,7 +25,7 @@ type CodeMonitorStore interface {
 	Exec(ctx context.Context, query *sqlf.Query) error
 
 	UpdateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.EditActionArgs) (e *MonitorEmail, err error)
-	CreateActionEmail(ctx context.Context, monitorID int64, action *graphqlbackend.CreateActionArgs) (e *MonitorEmail, err error)
+	CreateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.CreateActionArgs) (e *MonitorEmail, err error)
 	DeleteActionsInt64(ctx context.Context, actionIDs []int64, monitorID int64) (err error)
 	TotalCountActionEmails(ctx context.Context, monitorID int64) (count int32, err error)
 	ActionEmailByIDInt64(ctx context.Context, emailID int64) (m *MonitorEmail, err error)

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -24,10 +24,11 @@ type CodeMonitorStore interface {
 	Clock() func() time.Time
 	Exec(ctx context.Context, query *sqlf.Query) error
 
-	UpdateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.EditActionArgs) (e *MonitorEmail, err error)
-	CreateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.CreateActionArgs) (e *MonitorEmail, err error)
-	DeleteEmailActions(ctx context.Context, actionIDs []int64, monitorID int64) (err error)
-	TotalCountActionEmails(ctx context.Context, monitorID int64) (count int32, err error)
+	UpdateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.EditActionArgs) (*MonitorEmail, error)
+	CreateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.CreateActionArgs) (*MonitorEmail, error)
+	DeleteEmailActions(ctx context.Context, actionIDs []int64, monitorID int64) error
+	CountEmailActions(ctx context.Context, monitorID int64) (int32, error)
+
 	ActionEmailByIDInt64(ctx context.Context, emailID int64) (m *MonitorEmail, err error)
 	ListActionJobs(context.Context, ListActionJobsOpts) ([]*ActionJob, error)
 	CountActionJobs(context.Context, ListActionJobsOpts) (int, error)

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -32,7 +32,7 @@ type CodeMonitorStore interface {
 	DeleteMonitor(ctx context.Context, args *graphqlbackend.DeleteCodeMonitorArgs) error
 	GetMonitor(ctx context.Context, monitorID int64) (*Monitor, error)
 	Monitors(ctx context.Context, userID int32, args *graphqlbackend.ListMonitorsArgs) ([]*Monitor, error)
-	CountMonitors(ctx context.Context, userID int32) (count int32, err error)
+	CountMonitors(ctx context.Context, userID int32) (int32, error)
 
 	UpdateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.EditActionArgs) (*MonitorEmail, error)
 	CreateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.CreateActionArgs) (*MonitorEmail, error)
@@ -50,12 +50,12 @@ type CodeMonitorStore interface {
 
 	CreateTriggerQuery(ctx context.Context, monitorID int64, args *graphqlbackend.CreateTriggerArgs) (err error)
 	UpdateTriggerQuery(ctx context.Context, args *graphqlbackend.UpdateCodeMonitorArgs) (err error)
-	TriggerQueryByMonitorIDInt64(ctx context.Context, monitorID int64) (*MonitorQuery, error)
+	TriggerQueryByMonitorIDInt64(ctx context.Context, monitorID int64) (*QueryTrigger, error)
 	ResetTriggerQueryTimestamps(ctx context.Context, queryID int64) error
 	SetTriggerQueryNextRun(ctx context.Context, triggerQueryID int64, next time.Time, latestResults time.Time) error
 	EnqueueTriggerQueries(ctx context.Context) (err error)
 
-	GetQueryByRecordID(ctx context.Context, recordID int) (query *MonitorQuery, err error)
+	GetQueryByRecordID(ctx context.Context, recordID int) (query *QueryTrigger, err error)
 
 	CreateRecipients(ctx context.Context, recipients []graphql.ID, emailID int64) (err error)
 	DeleteRecipients(ctx context.Context, emailID int64) (err error)

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -51,12 +51,12 @@ type CodeMonitorStore interface {
 
 	CreateActions(ctx context.Context, args []*graphqlbackend.CreateActionArgs, monitorID int64) error
 
-	UpdateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.EditActionArgs) (*MonitorEmail, error)
-	CreateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.CreateActionArgs) (*MonitorEmail, error)
+	UpdateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.EditActionArgs) (*EmailAction, error)
+	CreateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.CreateActionArgs) (*EmailAction, error)
 	DeleteEmailActions(ctx context.Context, actionIDs []int64, monitorID int64) error
 	CountEmailActions(ctx context.Context, monitorID int64) (int32, error)
-	GetEmailAction(ctx context.Context, emailID int64) (*MonitorEmail, error)
-	ListEmailActions(context.Context, ListActionsOpts) ([]*MonitorEmail, error)
+	GetEmailAction(ctx context.Context, emailID int64) (*EmailAction, error)
+	ListEmailActions(context.Context, ListActionsOpts) ([]*EmailAction, error)
 
 	CreateRecipients(ctx context.Context, recipients []graphql.ID, emailID int64) error
 	DeleteRecipients(ctx context.Context, emailID int64) error

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -31,7 +31,7 @@ type CodeMonitorStore interface {
 	ToggleMonitor(ctx context.Context, args *graphqlbackend.ToggleCodeMonitorArgs) (*Monitor, error)
 	DeleteMonitor(ctx context.Context, args *graphqlbackend.DeleteCodeMonitorArgs) error
 	GetMonitor(ctx context.Context, monitorID int64) (*Monitor, error)
-	Monitors(ctx context.Context, userID int32, args *graphqlbackend.ListMonitorsArgs) ([]*Monitor, error)
+	ListMonitors(ctx context.Context, userID int32, args *graphqlbackend.ListMonitorsArgs) ([]*Monitor, error)
 	CountMonitors(ctx context.Context, userID int32) (int32, error)
 
 	CreateQueryTrigger(ctx context.Context, monitorID int64, args *graphqlbackend.CreateTriggerArgs) error

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -24,7 +24,7 @@ type CodeMonitorStore interface {
 	Clock() func() time.Time
 	Exec(ctx context.Context, query *sqlf.Query) error
 
-	UpdateActionEmail(ctx context.Context, monitorID int64, action *graphqlbackend.EditActionArgs) (e *MonitorEmail, err error)
+	UpdateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.EditActionArgs) (e *MonitorEmail, err error)
 	CreateActionEmail(ctx context.Context, monitorID int64, action *graphqlbackend.CreateActionArgs) (e *MonitorEmail, err error)
 	DeleteActionsInt64(ctx context.Context, actionIDs []int64, monitorID int64) (err error)
 	TotalCountActionEmails(ctx context.Context, monitorID int64) (count int32, err error)

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -54,7 +54,8 @@ type CodeMonitorStore interface {
 	GetQueryTriggerForMonitor(ctx context.Context, monitorID int64) (*QueryTrigger, error)
 	ResetQueryTriggerTimestamps(ctx context.Context, queryID int64) error
 	SetQueryTriggerNextRun(ctx context.Context, triggerQueryID int64, next time.Time, latestResults time.Time) error
-	EnqueueQueryTriggers(ctx context.Context) (err error)
+
+	EnqueueQueryTriggerJobs(ctx context.Context) (err error)
 
 	GetQueryByRecordID(ctx context.Context, recordID int) (query *QueryTrigger, err error)
 

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -57,6 +57,8 @@ type CodeMonitorStore interface {
 	GetQueryTriggerForJob(ctx context.Context, jobID int) (*QueryTrigger, error)
 
 	EnqueueQueryTriggerJobs(ctx context.Context) error
+	ListQueryTriggerJobs(ctx context.Context, queryID int64, args *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error)
+	CountQueryTriggerJobs(ctx context.Context, queryID int64) (int32, error)
 
 	CreateRecipients(ctx context.Context, recipients []graphql.ID, emailID int64) error
 	DeleteRecipients(ctx context.Context, emailID int64) error
@@ -67,9 +69,6 @@ type CodeMonitorStore interface {
 	DeleteObsoleteJobLogs(ctx context.Context) error
 	LogSearch(ctx context.Context, queryString string, numResults int, recordID int) error
 	DeleteOldJobLogs(ctx context.Context, retentionInDays int) error
-
-	ListQueryTriggerJobs(ctx context.Context, queryID int64, args *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error)
-	TotalCountEventsForQueryIDInt64(ctx context.Context, queryID int64) (int32, error)
 }
 
 // codeMonitorStore exposes methods to read and write codemonitors domain models

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -46,12 +46,13 @@ type CodeMonitorStore interface {
 	CountActionJobs(context.Context, ListActionJobsOpts) (int, error)
 	GetActionJobMetadata(ctx context.Context, recordID int) (*ActionJobMetadata, error)
 	GetActionJob(ctx context.Context, recordID int) (*ActionJob, error)
+
 	CreateActions(ctx context.Context, args []*graphqlbackend.CreateActionArgs, monitorID int64) error
 
 	CreateQueryTrigger(ctx context.Context, monitorID int64, args *graphqlbackend.CreateTriggerArgs) (err error)
 	UpdateQueryTrigger(ctx context.Context, args *graphqlbackend.UpdateCodeMonitorArgs) (err error)
 	GetQueryTriggerForMonitor(ctx context.Context, monitorID int64) (*QueryTrigger, error)
-	ResetTriggerQueryTimestamps(ctx context.Context, queryID int64) error
+	ResetQueryTriggerTimestamps(ctx context.Context, queryID int64) error
 	SetTriggerQueryNextRun(ctx context.Context, triggerQueryID int64, next time.Time, latestResults time.Time) error
 	EnqueueTriggerQueries(ctx context.Context) (err error)
 

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -24,43 +24,49 @@ type CodeMonitorStore interface {
 	Clock() func() time.Time
 	Exec(ctx context.Context, query *sqlf.Query) error
 
+	CreateCodeMonitor(ctx context.Context, args *graphqlbackend.CreateCodeMonitorArgs) (*Monitor, error)
+
+	CreateMonitor(ctx context.Context, args *graphqlbackend.CreateMonitorArgs) (*Monitor, error)
+	UpdateMonitor(ctx context.Context, args *graphqlbackend.UpdateCodeMonitorArgs) (*Monitor, error)
+	ToggleMonitor(ctx context.Context, args *graphqlbackend.ToggleCodeMonitorArgs) (*Monitor, error)
+	DeleteMonitor(ctx context.Context, args *graphqlbackend.DeleteCodeMonitorArgs) error
+	GetMonitor(ctx context.Context, monitorID int64) (*Monitor, error)
+	Monitors(ctx context.Context, userID int32, args *graphqlbackend.ListMonitorsArgs) ([]*Monitor, error)
+	TotalCountMonitors(ctx context.Context, userID int32) (count int32, err error)
+
 	UpdateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.EditActionArgs) (*MonitorEmail, error)
 	CreateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.CreateActionArgs) (*MonitorEmail, error)
 	DeleteEmailActions(ctx context.Context, actionIDs []int64, monitorID int64) error
 	CountEmailActions(ctx context.Context, monitorID int64) (int32, error)
 	GetEmailAction(ctx context.Context, emailID int64) (*MonitorEmail, error)
 	ListEmailActions(context.Context, ListActionsOpts) ([]*MonitorEmail, error)
+	EnqueueActionEmailsForQueryIDInt64(ctx context.Context, queryID int64, triggerEventID int) (err error)
 
 	ListActionJobs(context.Context, ListActionJobsOpts) ([]*ActionJob, error)
 	CountActionJobs(context.Context, ListActionJobsOpts) (int, error)
 	GetActionJobMetadata(ctx context.Context, recordID int) (*ActionJobMetadata, error)
 	GetActionJob(ctx context.Context, recordID int) (*ActionJob, error)
+	CreateActions(ctx context.Context, args []*graphqlbackend.CreateActionArgs, monitorID int64) error
 
-	EnqueueActionEmailsForQueryIDInt64(ctx context.Context, queryID int64, triggerEventID int) (err error)
-	CreateActions(ctx context.Context, args []*graphqlbackend.CreateActionArgs, monitorID int64) (err error)
-	CreateCodeMonitor(ctx context.Context, args *graphqlbackend.CreateCodeMonitorArgs) (m *Monitor, err error)
-	CreateMonitor(ctx context.Context, args *graphqlbackend.CreateMonitorArgs) (m *Monitor, err error)
-	UpdateMonitor(ctx context.Context, args *graphqlbackend.UpdateCodeMonitorArgs) (m *Monitor, err error)
-	ToggleMonitor(ctx context.Context, args *graphqlbackend.ToggleCodeMonitorArgs) (m *Monitor, err error)
-	DeleteMonitor(ctx context.Context, args *graphqlbackend.DeleteCodeMonitorArgs) (err error)
-	Monitors(ctx context.Context, userID int32, args *graphqlbackend.ListMonitorsArgs) ([]*Monitor, error)
-	GetMonitor(ctx context.Context, monitorID int64) (m *Monitor, err error)
-	TotalCountMonitors(ctx context.Context, userID int32) (count int32, err error)
 	CreateTriggerQuery(ctx context.Context, monitorID int64, args *graphqlbackend.CreateTriggerArgs) (err error)
 	UpdateTriggerQuery(ctx context.Context, args *graphqlbackend.UpdateCodeMonitorArgs) (err error)
 	TriggerQueryByMonitorIDInt64(ctx context.Context, monitorID int64) (*MonitorQuery, error)
 	ResetTriggerQueryTimestamps(ctx context.Context, queryID int64) error
-	GetQueryByRecordID(ctx context.Context, recordID int) (query *MonitorQuery, err error)
 	SetTriggerQueryNextRun(ctx context.Context, triggerQueryID int64, next time.Time, latestResults time.Time) error
+	EnqueueTriggerQueries(ctx context.Context) (err error)
+
+	GetQueryByRecordID(ctx context.Context, recordID int) (query *MonitorQuery, err error)
+
 	CreateRecipients(ctx context.Context, recipients []graphql.ID, emailID int64) (err error)
 	DeleteRecipients(ctx context.Context, emailID int64) (err error)
 	RecipientsForEmailIDInt64(ctx context.Context, emailID int64, args *graphqlbackend.ListRecipientsArgs) ([]*Recipient, error)
 	AllRecipientsForEmailIDInt64(ctx context.Context, emailID int64) (rs []*Recipient, err error)
 	TotalCountRecipients(ctx context.Context, emailID int64) (count int32, err error)
-	EnqueueTriggerQueries(ctx context.Context) (err error)
-	LogSearch(ctx context.Context, queryString string, numResults int, recordID int) error
+
 	DeleteObsoleteJobLogs(ctx context.Context) error
+	LogSearch(ctx context.Context, queryString string, numResults int, recordID int) error
 	DeleteOldJobLogs(ctx context.Context, retentionInDays int) error
+
 	GetEventsForQueryIDInt64(ctx context.Context, queryID int64, args *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error)
 	TotalCountEventsForQueryIDInt64(ctx context.Context, queryID int64) (totalCount int32, err error)
 }

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -53,7 +53,7 @@ type CodeMonitorStore interface {
 	UpdateQueryTrigger(ctx context.Context, args *graphqlbackend.UpdateCodeMonitorArgs) (err error)
 	GetQueryTriggerForMonitor(ctx context.Context, monitorID int64) (*QueryTrigger, error)
 	ResetQueryTriggerTimestamps(ctx context.Context, queryID int64) error
-	SetTriggerQueryNextRun(ctx context.Context, triggerQueryID int64, next time.Time, latestResults time.Time) error
+	SetQueryTriggerNextRun(ctx context.Context, triggerQueryID int64, next time.Time, latestResults time.Time) error
 	EnqueueTriggerQueries(ctx context.Context) (err error)
 
 	GetQueryByRecordID(ctx context.Context, recordID int) (query *QueryTrigger, err error)

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -61,7 +61,7 @@ type CodeMonitorStore interface {
 	CreateRecipients(ctx context.Context, recipients []graphql.ID, emailID int64) error
 	DeleteRecipients(ctx context.Context, emailID int64) error
 	ListRecipientsForEmailAction(ctx context.Context, emailID int64, args *graphqlbackend.ListRecipientsArgs) ([]*Recipient, error)
-	AllRecipientsForEmailIDInt64(ctx context.Context, emailID int64) ([]*Recipient, error)
+	ListAllRecipientsForEmailAction(ctx context.Context, emailID int64) ([]*Recipient, error)
 	TotalCountRecipients(ctx context.Context, emailID int64) (int32, error)
 
 	DeleteObsoleteJobLogs(ctx context.Context) error

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -49,7 +49,7 @@ type CodeMonitorStore interface {
 	CreateActions(ctx context.Context, args []*graphqlbackend.CreateActionArgs, monitorID int64) error
 
 	CreateQueryTrigger(ctx context.Context, monitorID int64, args *graphqlbackend.CreateTriggerArgs) (err error)
-	UpdateTriggerQuery(ctx context.Context, args *graphqlbackend.UpdateCodeMonitorArgs) (err error)
+	UpdateQueryTrigger(ctx context.Context, args *graphqlbackend.UpdateCodeMonitorArgs) (err error)
 	TriggerQueryByMonitorIDInt64(ctx context.Context, monitorID int64) (*QueryTrigger, error)
 	ResetTriggerQueryTimestamps(ctx context.Context, queryID int64) error
 	SetTriggerQueryNextRun(ctx context.Context, triggerQueryID int64, next time.Time, latestResults time.Time) error

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -42,7 +42,7 @@ type CodeMonitorStore interface {
 	GetQueryTriggerForJob(ctx context.Context, jobID int) (*QueryTrigger, error)
 
 	DeleteObsoleteTriggerJobs(ctx context.Context) error
-	LogSearch(ctx context.Context, queryString string, numResults int, recordID int) error
+	UpdateTriggerJobWithResults(ctx context.Context, queryString string, numResults int, recordID int) error
 	DeleteOldJobLogs(ctx context.Context, retentionInDays int) error
 
 	EnqueueQueryTriggerJobs(ctx context.Context) error

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -59,7 +59,7 @@ type CodeMonitorStore interface {
 	LogSearch(ctx context.Context, queryString string, numResults int, recordID int) error
 	DeleteObsoleteJobLogs(ctx context.Context) error
 	DeleteOldJobLogs(ctx context.Context, retentionInDays int) error
-	GetEventsForQueryIDInt64(ctx context.Context, queryID int64, args *graphqlbackend.ListEventsArgs) ([]*TriggerJobs, error)
+	GetEventsForQueryIDInt64(ctx context.Context, queryID int64, args *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error)
 	TotalCountEventsForQueryIDInt64(ctx context.Context, queryID int64) (totalCount int32, err error)
 }
 

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -54,7 +54,7 @@ type CodeMonitorStore interface {
 	GetQueryTriggerForMonitor(ctx context.Context, monitorID int64) (*QueryTrigger, error)
 	ResetQueryTriggerTimestamps(ctx context.Context, queryID int64) error
 	SetQueryTriggerNextRun(ctx context.Context, triggerQueryID int64, next time.Time, latestResults time.Time) error
-	EnqueueTriggerQueries(ctx context.Context) (err error)
+	EnqueueQueryTriggers(ctx context.Context) (err error)
 
 	GetQueryByRecordID(ctx context.Context, recordID int) (query *QueryTrigger, err error)
 

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -28,8 +28,8 @@ type CodeMonitorStore interface {
 	CreateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.CreateActionArgs) (*MonitorEmail, error)
 	DeleteEmailActions(ctx context.Context, actionIDs []int64, monitorID int64) error
 	CountEmailActions(ctx context.Context, monitorID int64) (int32, error)
+	GetEmailAction(ctx context.Context, emailID int64) (*MonitorEmail, error)
 
-	ActionEmailByIDInt64(ctx context.Context, emailID int64) (m *MonitorEmail, err error)
 	ListActionJobs(context.Context, ListActionJobsOpts) ([]*ActionJob, error)
 	CountActionJobs(context.Context, ListActionJobsOpts) (int, error)
 	ListEmailActions(context.Context, ListActionsOpts) ([]*MonitorEmail, error)

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -26,7 +26,7 @@ type CodeMonitorStore interface {
 
 	UpdateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.EditActionArgs) (e *MonitorEmail, err error)
 	CreateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.CreateActionArgs) (e *MonitorEmail, err error)
-	DeleteActionsInt64(ctx context.Context, actionIDs []int64, monitorID int64) (err error)
+	DeleteEmailActions(ctx context.Context, actionIDs []int64, monitorID int64) (err error)
 	TotalCountActionEmails(ctx context.Context, monitorID int64) (count int32, err error)
 	ActionEmailByIDInt64(ctx context.Context, emailID int64) (m *MonitorEmail, err error)
 	ListActionJobs(context.Context, ListActionJobsOpts) ([]*ActionJob, error)

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -29,13 +29,14 @@ type CodeMonitorStore interface {
 	DeleteEmailActions(ctx context.Context, actionIDs []int64, monitorID int64) error
 	CountEmailActions(ctx context.Context, monitorID int64) (int32, error)
 	GetEmailAction(ctx context.Context, emailID int64) (*MonitorEmail, error)
+	ListEmailActions(context.Context, ListActionsOpts) ([]*MonitorEmail, error)
 
 	ListActionJobs(context.Context, ListActionJobsOpts) ([]*ActionJob, error)
 	CountActionJobs(context.Context, ListActionJobsOpts) (int, error)
-	ListEmailActions(context.Context, ListActionsOpts) ([]*MonitorEmail, error)
-	EnqueueActionEmailsForQueryIDInt64(ctx context.Context, queryID int64, triggerEventID int) (err error)
 	GetActionJobMetadata(ctx context.Context, recordID int) (*ActionJobMetadata, error)
-	ActionJobForIDInt(ctx context.Context, recordID int) (*ActionJob, error)
+	GetActionJob(ctx context.Context, recordID int) (*ActionJob, error)
+
+	EnqueueActionEmailsForQueryIDInt64(ctx context.Context, queryID int64, triggerEventID int) (err error)
 	CreateActions(ctx context.Context, args []*graphqlbackend.CreateActionArgs, monitorID int64) (err error)
 	CreateCodeMonitor(ctx context.Context, args *graphqlbackend.CreateCodeMonitorArgs) (m *Monitor, err error)
 	CreateMonitor(ctx context.Context, args *graphqlbackend.CreateMonitorArgs) (m *Monitor, err error)

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -62,7 +62,7 @@ type CodeMonitorStore interface {
 	DeleteRecipients(ctx context.Context, emailID int64) error
 	ListRecipientsForEmailAction(ctx context.Context, emailID int64, args *graphqlbackend.ListRecipientsArgs) ([]*Recipient, error)
 	ListAllRecipientsForEmailAction(ctx context.Context, emailID int64) ([]*Recipient, error)
-	TotalCountRecipients(ctx context.Context, emailID int64) (int32, error)
+	CountRecipients(ctx context.Context, emailID int64) (int32, error)
 
 	DeleteObsoleteJobLogs(ctx context.Context) error
 	LogSearch(ctx context.Context, queryString string, numResults int, recordID int) error

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -34,21 +34,6 @@ type CodeMonitorStore interface {
 	Monitors(ctx context.Context, userID int32, args *graphqlbackend.ListMonitorsArgs) ([]*Monitor, error)
 	CountMonitors(ctx context.Context, userID int32) (int32, error)
 
-	UpdateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.EditActionArgs) (*MonitorEmail, error)
-	CreateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.CreateActionArgs) (*MonitorEmail, error)
-	DeleteEmailActions(ctx context.Context, actionIDs []int64, monitorID int64) error
-	CountEmailActions(ctx context.Context, monitorID int64) (int32, error)
-	GetEmailAction(ctx context.Context, emailID int64) (*MonitorEmail, error)
-	ListEmailActions(context.Context, ListActionsOpts) ([]*MonitorEmail, error)
-
-	ListActionJobs(context.Context, ListActionJobsOpts) ([]*ActionJob, error)
-	CountActionJobs(context.Context, ListActionJobsOpts) (int, error)
-	GetActionJobMetadata(ctx context.Context, recordID int) (*ActionJobMetadata, error)
-	GetActionJob(ctx context.Context, recordID int) (*ActionJob, error)
-	EnqueueActionJobsForQuery(ctx context.Context, queryID int64, triggerEventID int) error
-
-	CreateActions(ctx context.Context, args []*graphqlbackend.CreateActionArgs, monitorID int64) error
-
 	CreateQueryTrigger(ctx context.Context, monitorID int64, args *graphqlbackend.CreateTriggerArgs) error
 	UpdateQueryTrigger(ctx context.Context, args *graphqlbackend.UpdateCodeMonitorArgs) error
 	GetQueryTriggerForMonitor(ctx context.Context, monitorID int64) (*QueryTrigger, error)
@@ -56,9 +41,22 @@ type CodeMonitorStore interface {
 	SetQueryTriggerNextRun(ctx context.Context, triggerQueryID int64, next time.Time, latestResults time.Time) error
 	GetQueryTriggerForJob(ctx context.Context, jobID int) (*QueryTrigger, error)
 
+	DeleteObsoleteTriggerJobs(ctx context.Context) error
+	LogSearch(ctx context.Context, queryString string, numResults int, recordID int) error
+	DeleteOldJobLogs(ctx context.Context, retentionInDays int) error
+
 	EnqueueQueryTriggerJobs(ctx context.Context) error
 	ListQueryTriggerJobs(ctx context.Context, queryID int64, args *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error)
 	CountQueryTriggerJobs(ctx context.Context, queryID int64) (int32, error)
+
+	CreateActions(ctx context.Context, args []*graphqlbackend.CreateActionArgs, monitorID int64) error
+
+	UpdateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.EditActionArgs) (*MonitorEmail, error)
+	CreateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.CreateActionArgs) (*MonitorEmail, error)
+	DeleteEmailActions(ctx context.Context, actionIDs []int64, monitorID int64) error
+	CountEmailActions(ctx context.Context, monitorID int64) (int32, error)
+	GetEmailAction(ctx context.Context, emailID int64) (*MonitorEmail, error)
+	ListEmailActions(context.Context, ListActionsOpts) ([]*MonitorEmail, error)
 
 	CreateRecipients(ctx context.Context, recipients []graphql.ID, emailID int64) error
 	DeleteRecipients(ctx context.Context, emailID int64) error
@@ -66,9 +64,11 @@ type CodeMonitorStore interface {
 	ListAllRecipientsForEmailAction(ctx context.Context, emailID int64) ([]*Recipient, error)
 	CountRecipients(ctx context.Context, emailID int64) (int32, error)
 
-	DeleteObsoleteJobLogs(ctx context.Context) error
-	LogSearch(ctx context.Context, queryString string, numResults int, recordID int) error
-	DeleteOldJobLogs(ctx context.Context, retentionInDays int) error
+	ListActionJobs(context.Context, ListActionJobsOpts) ([]*ActionJob, error)
+	CountActionJobs(context.Context, ListActionJobsOpts) (int, error)
+	GetActionJobMetadata(ctx context.Context, recordID int) (*ActionJobMetadata, error)
+	GetActionJob(ctx context.Context, recordID int) (*ActionJob, error)
+	EnqueueActionJobsForQuery(ctx context.Context, queryID int64, triggerEventID int) error
 }
 
 // codeMonitorStore exposes methods to read and write codemonitors domain models

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -50,7 +50,7 @@ type CodeMonitorStore interface {
 
 	CreateQueryTrigger(ctx context.Context, monitorID int64, args *graphqlbackend.CreateTriggerArgs) (err error)
 	UpdateQueryTrigger(ctx context.Context, args *graphqlbackend.UpdateCodeMonitorArgs) (err error)
-	TriggerQueryByMonitorIDInt64(ctx context.Context, monitorID int64) (*QueryTrigger, error)
+	GetQueryTriggerForMonitor(ctx context.Context, monitorID int64) (*QueryTrigger, error)
 	ResetTriggerQueryTimestamps(ctx context.Context, queryID int64) error
 	SetTriggerQueryNextRun(ctx context.Context, triggerQueryID int64, next time.Time, latestResults time.Time) error
 	EnqueueTriggerQueries(ctx context.Context) (err error)

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -32,7 +32,7 @@ type CodeMonitorStore interface {
 	DeleteMonitor(ctx context.Context, args *graphqlbackend.DeleteCodeMonitorArgs) error
 	GetMonitor(ctx context.Context, monitorID int64) (*Monitor, error)
 	Monitors(ctx context.Context, userID int32, args *graphqlbackend.ListMonitorsArgs) ([]*Monitor, error)
-	TotalCountMonitors(ctx context.Context, userID int32) (count int32, err error)
+	CountMonitors(ctx context.Context, userID int32) (count int32, err error)
 
 	UpdateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.EditActionArgs) (*MonitorEmail, error)
 	CreateEmailAction(ctx context.Context, monitorID int64, action *graphqlbackend.CreateActionArgs) (*MonitorEmail, error)

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -40,12 +40,12 @@ type CodeMonitorStore interface {
 	CountEmailActions(ctx context.Context, monitorID int64) (int32, error)
 	GetEmailAction(ctx context.Context, emailID int64) (*MonitorEmail, error)
 	ListEmailActions(context.Context, ListActionsOpts) ([]*MonitorEmail, error)
-	EnqueueActionEmailsForQueryIDInt64(ctx context.Context, queryID int64, triggerEventID int) error
 
 	ListActionJobs(context.Context, ListActionJobsOpts) ([]*ActionJob, error)
 	CountActionJobs(context.Context, ListActionJobsOpts) (int, error)
 	GetActionJobMetadata(ctx context.Context, recordID int) (*ActionJobMetadata, error)
 	GetActionJob(ctx context.Context, recordID int) (*ActionJob, error)
+	EnqueueActionJobsForQuery(ctx context.Context, queryID int64, triggerEventID int) error
 
 	CreateActions(ctx context.Context, args []*graphqlbackend.CreateActionArgs, monitorID int64) error
 

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -60,7 +60,7 @@ type CodeMonitorStore interface {
 
 	CreateRecipients(ctx context.Context, recipients []graphql.ID, emailID int64) error
 	DeleteRecipients(ctx context.Context, emailID int64) error
-	RecipientsForEmailIDInt64(ctx context.Context, emailID int64, args *graphqlbackend.ListRecipientsArgs) ([]*Recipient, error)
+	ListRecipientsForEmailAction(ctx context.Context, emailID int64, args *graphqlbackend.ListRecipientsArgs) ([]*Recipient, error)
 	AllRecipientsForEmailIDInt64(ctx context.Context, emailID int64) ([]*Recipient, error)
 	TotalCountRecipients(ctx context.Context, emailID int64) (int32, error)
 

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -54,10 +54,9 @@ type CodeMonitorStore interface {
 	GetQueryTriggerForMonitor(ctx context.Context, monitorID int64) (*QueryTrigger, error)
 	ResetQueryTriggerTimestamps(ctx context.Context, queryID int64) error
 	SetQueryTriggerNextRun(ctx context.Context, triggerQueryID int64, next time.Time, latestResults time.Time) error
+	GetQueryTriggerForJob(ctx context.Context, jobID int) (query *QueryTrigger, err error)
 
 	EnqueueQueryTriggerJobs(ctx context.Context) (err error)
-
-	GetQueryByRecordID(ctx context.Context, recordID int) (query *QueryTrigger, err error)
 
 	CreateRecipients(ctx context.Context, recipients []graphql.ID, emailID int64) (err error)
 	DeleteRecipients(ctx context.Context, emailID int64) (err error)

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -40,7 +40,7 @@ type CodeMonitorStore interface {
 	CountEmailActions(ctx context.Context, monitorID int64) (int32, error)
 	GetEmailAction(ctx context.Context, emailID int64) (*MonitorEmail, error)
 	ListEmailActions(context.Context, ListActionsOpts) ([]*MonitorEmail, error)
-	EnqueueActionEmailsForQueryIDInt64(ctx context.Context, queryID int64, triggerEventID int) (err error)
+	EnqueueActionEmailsForQueryIDInt64(ctx context.Context, queryID int64, triggerEventID int) error
 
 	ListActionJobs(context.Context, ListActionJobsOpts) ([]*ActionJob, error)
 	CountActionJobs(context.Context, ListActionJobsOpts) (int, error)
@@ -49,27 +49,27 @@ type CodeMonitorStore interface {
 
 	CreateActions(ctx context.Context, args []*graphqlbackend.CreateActionArgs, monitorID int64) error
 
-	CreateQueryTrigger(ctx context.Context, monitorID int64, args *graphqlbackend.CreateTriggerArgs) (err error)
-	UpdateQueryTrigger(ctx context.Context, args *graphqlbackend.UpdateCodeMonitorArgs) (err error)
+	CreateQueryTrigger(ctx context.Context, monitorID int64, args *graphqlbackend.CreateTriggerArgs) error
+	UpdateQueryTrigger(ctx context.Context, args *graphqlbackend.UpdateCodeMonitorArgs) error
 	GetQueryTriggerForMonitor(ctx context.Context, monitorID int64) (*QueryTrigger, error)
 	ResetQueryTriggerTimestamps(ctx context.Context, queryID int64) error
 	SetQueryTriggerNextRun(ctx context.Context, triggerQueryID int64, next time.Time, latestResults time.Time) error
-	GetQueryTriggerForJob(ctx context.Context, jobID int) (query *QueryTrigger, err error)
+	GetQueryTriggerForJob(ctx context.Context, jobID int) (*QueryTrigger, error)
 
-	EnqueueQueryTriggerJobs(ctx context.Context) (err error)
+	EnqueueQueryTriggerJobs(ctx context.Context) error
 
-	CreateRecipients(ctx context.Context, recipients []graphql.ID, emailID int64) (err error)
-	DeleteRecipients(ctx context.Context, emailID int64) (err error)
+	CreateRecipients(ctx context.Context, recipients []graphql.ID, emailID int64) error
+	DeleteRecipients(ctx context.Context, emailID int64) error
 	RecipientsForEmailIDInt64(ctx context.Context, emailID int64, args *graphqlbackend.ListRecipientsArgs) ([]*Recipient, error)
-	AllRecipientsForEmailIDInt64(ctx context.Context, emailID int64) (rs []*Recipient, err error)
-	TotalCountRecipients(ctx context.Context, emailID int64) (count int32, err error)
+	AllRecipientsForEmailIDInt64(ctx context.Context, emailID int64) ([]*Recipient, error)
+	TotalCountRecipients(ctx context.Context, emailID int64) (int32, error)
 
 	DeleteObsoleteJobLogs(ctx context.Context) error
 	LogSearch(ctx context.Context, queryString string, numResults int, recordID int) error
 	DeleteOldJobLogs(ctx context.Context, retentionInDays int) error
 
 	GetEventsForQueryIDInt64(ctx context.Context, queryID int64, args *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error)
-	TotalCountEventsForQueryIDInt64(ctx context.Context, queryID int64) (totalCount int32, err error)
+	TotalCountEventsForQueryIDInt64(ctx context.Context, queryID int64) (int32, error)
 }
 
 // codeMonitorStore exposes methods to read and write codemonitors domain models

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -68,7 +68,7 @@ type CodeMonitorStore interface {
 	LogSearch(ctx context.Context, queryString string, numResults int, recordID int) error
 	DeleteOldJobLogs(ctx context.Context, retentionInDays int) error
 
-	GetEventsForQueryIDInt64(ctx context.Context, queryID int64, args *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error)
+	ListQueryTriggerJobs(ctx context.Context, queryID int64, args *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error)
 	TotalCountEventsForQueryIDInt64(ctx context.Context, queryID int64) (int32, error)
 }
 

--- a/enterprise/internal/codemonitors/trigger_jobs.go
+++ b/enterprise/internal/codemonitors/trigger_jobs.go
@@ -67,9 +67,9 @@ DELETE FROM cm_trigger_jobs
 WHERE finished_at < (NOW() - (%s * '1 day'::interval));
 `
 
-// DeleteOldJobLogs deletes trigger jobs which have finished and are older than
+// DeleteOldTriggerJobs deletes trigger jobs which have finished and are older than
 // 'retention' days. Due to cascading, action jobs will be deleted as well.
-func (s *codeMonitorStore) DeleteOldJobLogs(ctx context.Context, retentionInDays int) error {
+func (s *codeMonitorStore) DeleteOldTriggerJobs(ctx context.Context, retentionInDays int) error {
 	return s.Store.Exec(ctx, sqlf.Sprintf(deleteOldJobLogsFmtStr, retentionInDays))
 }
 

--- a/enterprise/internal/codemonitors/trigger_jobs.go
+++ b/enterprise/internal/codemonitors/trigger_jobs.go
@@ -34,7 +34,7 @@ INSERT INTO cm_trigger_jobs (query)
 SELECT id from due EXCEPT SELECT id from busy ORDER BY id
 `
 
-func (s *codeMonitorStore) EnqueueTriggerQueries(ctx context.Context) (err error) {
+func (s *codeMonitorStore) EnqueueTriggerQueries(ctx context.Context) error {
 	return s.Store.Exec(ctx, sqlf.Sprintf(enqueueTriggerQueryFmtStr))
 }
 
@@ -106,16 +106,14 @@ WHERE ((state = 'completed' AND results IS TRUE) OR (state != 'completed'))
 AND query = %s
 `
 
-func (s *codeMonitorStore) TotalCountEventsForQueryIDInt64(ctx context.Context, queryID int64) (totalCount int32, err error) {
+func (s *codeMonitorStore) TotalCountEventsForQueryIDInt64(ctx context.Context, queryID int64) (int32, error) {
 	q := sqlf.Sprintf(
 		totalCountEventsForQueryIDInt64FmtStr,
 		queryID,
 	)
-	err = s.Store.QueryRow(ctx, q).Scan(&totalCount)
-	if err != nil {
-		return -1, err
-	}
-	return totalCount, nil
+	var count int32
+	err := s.Store.QueryRow(ctx, q).Scan(&count)
+	return count, err
 }
 
 type TriggerJobs struct {

--- a/enterprise/internal/codemonitors/trigger_jobs.go
+++ b/enterprise/internal/codemonitors/trigger_jobs.go
@@ -83,7 +83,7 @@ ORDER BY id ASC
 LIMIT %s;
 `
 
-func (s *codeMonitorStore) GetEventsForQueryIDInt64(ctx context.Context, queryID int64, args *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error) {
+func (s *codeMonitorStore) ListQueryTriggerJobs(ctx context.Context, queryID int64, args *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error) {
 	after, err := unmarshalAfter(args.After)
 	if err != nil {
 		return nil, err

--- a/enterprise/internal/codemonitors/trigger_jobs.go
+++ b/enterprise/internal/codemonitors/trigger_jobs.go
@@ -14,6 +14,28 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
 
+type TriggerJob struct {
+	Id    int
+	Query int64
+
+	// The query we ran including after: filter.
+	QueryString *string
+
+	// Whether we got any results.
+	Results    *bool
+	NumResults *int
+
+	// Fields demanded for any dbworker.
+	State          string
+	FailureMessage *string
+	StartedAt      *time.Time
+	FinishedAt     *time.Time
+	ProcessAfter   *time.Time
+	NumResets      int32
+	NumFailures    int32
+	LogContents    *string
+}
+
 func (r *TriggerJob) RecordID() int {
 	return r.Id
 }
@@ -117,28 +139,6 @@ func (s *codeMonitorStore) CountQueryTriggerJobs(ctx context.Context, queryID in
 	var count int32
 	err := s.Store.QueryRow(ctx, q).Scan(&count)
 	return count, err
-}
-
-type TriggerJob struct {
-	Id    int
-	Query int64
-
-	// The query we ran including after: filter.
-	QueryString *string
-
-	// Whether we got any results.
-	Results    *bool
-	NumResults *int
-
-	// Fields demanded for any dbworker.
-	State          string
-	FailureMessage *string
-	StartedAt      *time.Time
-	FinishedAt     *time.Time
-	ProcessAfter   *time.Time
-	NumResets      int32
-	NumFailures    int32
-	LogContents    *string
 }
 
 func ScanTriggerJobsRecord(rows *sql.Rows, err error) (workerutil.Record, bool, error) {

--- a/enterprise/internal/codemonitors/trigger_jobs.go
+++ b/enterprise/internal/codemonitors/trigger_jobs.go
@@ -46,7 +46,7 @@ SET query_string = %s,
 WHERE id = %s
 `
 
-func (s *codeMonitorStore) LogSearch(ctx context.Context, queryString string, numResults int, recordID int) error {
+func (s *codeMonitorStore) UpdateTriggerJobWithResults(ctx context.Context, queryString string, numResults int, recordID int) error {
 	return s.Store.Exec(ctx, sqlf.Sprintf(logSearchFmtStr, queryString, numResults > 0, numResults, recordID))
 }
 

--- a/enterprise/internal/codemonitors/trigger_jobs.go
+++ b/enterprise/internal/codemonitors/trigger_jobs.go
@@ -15,7 +15,7 @@ import (
 )
 
 type TriggerJob struct {
-	Id    int
+	Id    int32
 	Query int64
 
 	// The query we ran including after: filter.
@@ -23,7 +23,7 @@ type TriggerJob struct {
 
 	// Whether we got any results.
 	Results    *bool
-	NumResults *int
+	NumResults *int32
 
 	// Fields demanded for any dbworker.
 	State          string
@@ -37,7 +37,7 @@ type TriggerJob struct {
 }
 
 func (r *TriggerJob) RecordID() int {
-	return r.Id
+	return int(r.Id)
 }
 
 const enqueueTriggerQueryFmtStr = `

--- a/enterprise/internal/codemonitors/trigger_jobs.go
+++ b/enterprise/internal/codemonitors/trigger_jobs.go
@@ -34,7 +34,7 @@ INSERT INTO cm_trigger_jobs (query)
 SELECT id from due EXCEPT SELECT id from busy ORDER BY id
 `
 
-func (s *codeMonitorStore) EnqueueQueryTriggers(ctx context.Context) error {
+func (s *codeMonitorStore) EnqueueQueryTriggerJobs(ctx context.Context) error {
 	return s.Store.Exec(ctx, sqlf.Sprintf(enqueueTriggerQueryFmtStr))
 }
 

--- a/enterprise/internal/codemonitors/trigger_jobs.go
+++ b/enterprise/internal/codemonitors/trigger_jobs.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
 
-func (r *TriggerJobs) RecordID() int {
+func (r *TriggerJob) RecordID() int {
 	return r.Id
 }
 
@@ -83,7 +83,7 @@ ORDER BY id ASC
 LIMIT %s;
 `
 
-func (s *codeMonitorStore) GetEventsForQueryIDInt64(ctx context.Context, queryID int64, args *graphqlbackend.ListEventsArgs) ([]*TriggerJobs, error) {
+func (s *codeMonitorStore) GetEventsForQueryIDInt64(ctx context.Context, queryID int64, args *graphqlbackend.ListEventsArgs) ([]*TriggerJob, error) {
 	after, err := unmarshalAfter(args.After)
 	if err != nil {
 		return nil, err
@@ -119,7 +119,7 @@ func (s *codeMonitorStore) TotalCountEventsForQueryIDInt64(ctx context.Context, 
 	return count, err
 }
 
-type TriggerJobs struct {
+type TriggerJob struct {
 	Id    int
 	Query int64
 
@@ -147,13 +147,13 @@ func ScanTriggerJobsRecord(rows *sql.Rows, err error) (workerutil.Record, bool, 
 	}
 	records, err := scanTriggerJobs(rows)
 	if err != nil || len(records) == 0 {
-		return &TriggerJobs{}, false, err
+		return &TriggerJob{}, false, err
 	}
 	return records[0], true, nil
 }
 
-func scanTriggerJobs(rows *sql.Rows) ([]*TriggerJobs, error) {
-	var js []*TriggerJobs
+func scanTriggerJobs(rows *sql.Rows) ([]*TriggerJob, error) {
+	var js []*TriggerJob
 	for rows.Next() {
 		j, err := scanTriggerJob(rows)
 		if err != nil {
@@ -164,8 +164,8 @@ func scanTriggerJobs(rows *sql.Rows) ([]*TriggerJobs, error) {
 	return js, rows.Err()
 }
 
-func scanTriggerJob(scanner dbutil.Scanner) (*TriggerJobs, error) {
-	m := &TriggerJobs{}
+func scanTriggerJob(scanner dbutil.Scanner) (*TriggerJob, error) {
+	m := &TriggerJob{}
 	err := scanner.Scan(
 		&m.Id,
 		&m.Query,

--- a/enterprise/internal/codemonitors/trigger_jobs.go
+++ b/enterprise/internal/codemonitors/trigger_jobs.go
@@ -15,7 +15,7 @@ import (
 )
 
 type TriggerJob struct {
-	Id    int32
+	ID    int32
 	Query int64
 
 	// The query we ran including after: filter.
@@ -37,7 +37,7 @@ type TriggerJob struct {
 }
 
 func (r *TriggerJob) RecordID() int {
-	return int(r.Id)
+	return int(r.ID)
 }
 
 const enqueueTriggerQueryFmtStr = `
@@ -167,7 +167,7 @@ func scanTriggerJobs(rows *sql.Rows) ([]*TriggerJob, error) {
 func scanTriggerJob(scanner dbutil.Scanner) (*TriggerJob, error) {
 	m := &TriggerJob{}
 	err := scanner.Scan(
-		&m.Id,
+		&m.ID,
 		&m.Query,
 		&m.QueryString,
 		&m.Results,

--- a/enterprise/internal/codemonitors/trigger_jobs.go
+++ b/enterprise/internal/codemonitors/trigger_jobs.go
@@ -56,9 +56,9 @@ WHERE results IS NOT TRUE
 AND state = 'completed'
 `
 
-// DeleteObsoleteJobLogs deletes all runs which are marked as completed and did
+// DeleteObsoleteTriggerJobs deletes all runs which are marked as completed and did
 // not return results.
-func (s *codeMonitorStore) DeleteObsoleteJobLogs(ctx context.Context) error {
+func (s *codeMonitorStore) DeleteObsoleteTriggerJobs(ctx context.Context) error {
 	return s.Store.Exec(ctx, sqlf.Sprintf(deleteObsoleteJobLogsFmtStr))
 }
 

--- a/enterprise/internal/codemonitors/trigger_jobs.go
+++ b/enterprise/internal/codemonitors/trigger_jobs.go
@@ -34,7 +34,7 @@ INSERT INTO cm_trigger_jobs (query)
 SELECT id from due EXCEPT SELECT id from busy ORDER BY id
 `
 
-func (s *codeMonitorStore) EnqueueTriggerQueries(ctx context.Context) error {
+func (s *codeMonitorStore) EnqueueQueryTriggers(ctx context.Context) error {
 	return s.Store.Exec(ctx, sqlf.Sprintf(enqueueTriggerQueryFmtStr))
 }
 

--- a/enterprise/internal/codemonitors/trigger_jobs.go
+++ b/enterprise/internal/codemonitors/trigger_jobs.go
@@ -141,7 +141,7 @@ type TriggerJobs struct {
 	LogContents    *string
 }
 
-func ScanTriggerJobs(rows *sql.Rows, err error) (workerutil.Record, bool, error) {
+func ScanTriggerJobsRecord(rows *sql.Rows, err error) (workerutil.Record, bool, error) {
 	if err != nil {
 		return nil, false, err
 	}

--- a/enterprise/internal/codemonitors/trigger_jobs.go
+++ b/enterprise/internal/codemonitors/trigger_jobs.go
@@ -109,7 +109,7 @@ WHERE ((state = 'completed' AND results IS TRUE) OR (state != 'completed'))
 AND query = %s
 `
 
-func (s *codeMonitorStore) TotalCountEventsForQueryIDInt64(ctx context.Context, queryID int64) (int32, error) {
+func (s *codeMonitorStore) CountQueryTriggerJobs(ctx context.Context, queryID int64) (int32, error) {
 	q := sqlf.Sprintf(
 		totalCountEventsForQueryIDInt64FmtStr,
 		queryID,

--- a/enterprise/internal/codemonitors/trigger_jobs_test.go
+++ b/enterprise/internal/codemonitors/trigger_jobs_test.go
@@ -49,7 +49,7 @@ func TestDeleteOldJobLogs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = s.DeleteOldJobLogs(ctx, retentionInDays)
+	err = s.DeleteOldTriggerJobs(ctx, retentionInDays)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/codemonitors/trigger_jobs_test.go
+++ b/enterprise/internal/codemonitors/trigger_jobs_test.go
@@ -29,7 +29,7 @@ func TestDeleteOldJobLogs(t *testing.T) {
 	}
 
 	// Add 1 job and date it back to a long time ago.
-	err = s.EnqueueQueryTriggers(ctx)
+	err = s.EnqueueQueryTriggerJobs(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +40,7 @@ func TestDeleteOldJobLogs(t *testing.T) {
 	}
 
 	// Add second job.
-	err = s.EnqueueQueryTriggers(ctx)
+	err = s.EnqueueQueryTriggerJobs(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/codemonitors/trigger_jobs_test.go
+++ b/enterprise/internal/codemonitors/trigger_jobs_test.go
@@ -29,7 +29,7 @@ func TestDeleteOldJobLogs(t *testing.T) {
 	}
 
 	// Add 1 job and date it back to a long time ago.
-	err = s.EnqueueTriggerQueries(ctx)
+	err = s.EnqueueQueryTriggers(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +40,7 @@ func TestDeleteOldJobLogs(t *testing.T) {
 	}
 
 	// Add second job.
-	err = s.EnqueueTriggerQueries(ctx)
+	err = s.EnqueueQueryTriggers(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Welcome to this monster housecleaning PR for CodeMonitor store. I started making small housecleaning PRs to bring our CodeMonitorStore up to current standards and make it a more idiomatic store, but there were many changes, so I decided it was better to rip off the band-aid and make one massive PR with all the changes. I could make these commits all separate PRs, but then it would take all week to get them reviewed, rebased, and merged.

_A brief tour of what you'll find in this PR:_
- Renaming methods to be more consistent and read more clearly (see Glossary for details)
- Inlining one-off query creation methods
- Use `QueryRow` where applicable for easier scanning/error handling
- Reuse defined list of columns between queries and scanners to ensure they always agree
- Make all integer types explicitly agree with the database integer types (`integer`/`serial` -> `int32` and `bigint`/`bigserial` -> `int64`)
- Always close `*sql.Rows` in the function where it was created
- Add comments
- Removed named return parameters
- Remove predeclared variables where not needed
- Add some comments (probably could still use more, particularly with the info in the glossary below)

_Glossary:_
- `Trigger`: an event that "triggers" a set of code monitor actions. Currently our only trigger is a `QueryTrigger`.
- `Action`: a response to a trigger event. Currently, our only action is `EmailAction`, but this will be expanded very soon to include `Webhook` and `SlackWebhook`. 
- `Job`: an asynchronously scheduled task that is executed by a worker. In the context of code monitors, this will be either a trigger job (execute a search and see if there are results) or an action job (send an email, execute a webhook, etc.)
- `TriggerJob`: an execution of a trigger check to see if there are any new events. In this case, all trigger jobs are search executions.
- `ActionJob`: an execution of a configured `Action`. Currently, only "send an email".
- `QueryTrigger`: a `Trigger` that checks if the results of a commit or diff search returns any new results
- `EmailAction`: an `Action` that sends an email to the configured recipient in response to an event from a `Trigger`

_Review notes:_
- Each commit is small, self-contained, and (I think) self-explanatory, so if you'd like to review this closely, I recommend looking at it commit-by-commit. 
- These changes are purely style changes. This should be no external change to behavior.

_What this PR does not cover:_
- Removing dependency on the `graphqlbackend` package
- Moving the store into `enterprise/internal/database` (dependent on the removal of `graphqlbackend` dependency)
- Removing dependency on the `workerutil` package
- Remove `dbconn.Global` in tests
- Use database `now()` rather than passing it in the query. This might not be reasonable depending on tests.
