### PR TITLE
chore: Turn off frontend platform issue notifications entirely

### DIFF
--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -12,7 +12,6 @@ jobs:
           with:
              recipients: |
                   team/extensibility=@muratsu
-                  team/frontend-platform=@pdubroy
                   team/cloud=@RafLeszczynski
                   team/search-product=@benvenker @lguychard
                   team/search-core=@jjeffwarner


### PR DESCRIPTION
Previous commit (#27575) turned off notification for everyone but me. This turns them off altogether.