### PR TITLE
batches: cleaner workspaces preview list

### DIFF
--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -19,12 +19,16 @@ $body-color: var(--body-color);
 $body-bg: var(--body-bg);
 $text-muted: var(--text-muted);
 
+// Exception that's used in $theme-colors.
+$gray-02: #eff2f5;
 // Exception that's used in [data-reach-dialog-overlay] background.
 $gray-04: #dbe2f0;
 // Exception that's used in $custom-select-indicator as SVG icon fill color.
 $gray-06: #798baf;
 // Exception that's used in $theme-colors and in --box-shadow variable.
 $gray-08: #343a4d;
+// Exception that's used in $theme-colors.
+$gray-09: #262b38;
 
 // Core semantic base colors.
 $primary: $blue;
@@ -48,14 +52,14 @@ $theme-colors: (
     // Gray (blueish) root palette.
     --white: #ffffff;
     --gray-01: #f9fafb;
-    --gray-02: #eff2f5;
+    --gray-02: #{$gray-02};
     --gray-03: #e6ebf2;
     --gray-04: #{$gray-04};
     --gray-05: #a6b6d9;
     --gray-06: #{$gray-06};
     --gray-07: #5e6e8c;
     --gray-08: #{$gray-08};
-    --gray-09: #262b38;
+    --gray-09: #{$gray-09};
     --gray-10: #1d212f;
     --gray-11: #181b26;
     --gray-12: #14171f;
@@ -145,6 +149,7 @@ $theme-colors: (
     --code-bg: var(--white);
     --intel-bg: var(--white);
     --subtle-bg: var(--gray-02);
+    --subtle-bg-2: #{rgba($gray-02, 0.6)};
     --search-input-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
     --code-line-highlight-color: var(--color-bg-2);
     --diff-add-bg: #eeffec;
@@ -200,6 +205,7 @@ $theme-colors: (
     --code-bg: var(--gray-10);
     --intel-bg: var(--gray-12);
     --subtle-bg: var(--gray-09);
+    --subtle-bg-2: #{rgba($gray-09, 0.2)};
     --search-input-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
     --code-line-highlight-color: var(--body-bg);
     --diff-add-bg: #224035;

--- a/client/web/src/enterprise/batches/create/backend.ts
+++ b/client/web/src/enterprise/batches/create/backend.ts
@@ -71,6 +71,9 @@ export const WORKSPACES_AND_IMPORTING_CHANGESETS = gql`
             id
             name
             url
+            defaultBranch {
+                id
+            }
         }
         ignored
         unsupported
@@ -81,6 +84,7 @@ export const WORKSPACES_AND_IMPORTING_CHANGESETS = gql`
             target {
                 oid
             }
+            url
         }
         path
         searchResultPaths

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.mock.ts
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.mock.ts
@@ -20,7 +20,7 @@ export const mockWorkspaceResolutionStatus = (
     },
 })
 
-const mockWorkspace = (
+export const mockWorkspace = (
     id: number,
     fields?: Partial<PreviewBatchSpecWorkspaceFields>
 ): PreviewBatchSpecWorkspaceFields => ({
@@ -34,10 +34,14 @@ const mockWorkspace = (
         id: `repo-${id}`,
         name: `github.com/my-org/repo-${id}`,
         url: 'superfake.com',
+        defaultBranch: {
+            id: 'main-branch-id',
+            ...fields?.repository?.defaultBranch,
+        },
         ...fields?.repository,
     },
     branch: {
-        id: `branch-${id}`,
+        id: 'main-branch-id',
         abbrevName: 'main',
         displayName: 'main',
         ...fields?.branch,
@@ -45,6 +49,7 @@ const mockWorkspace = (
             oid: 'asdf1234',
             ...fields?.branch?.target,
         },
+        url: 'superfake.com',
     },
 })
 

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.tsx
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.tsx
@@ -78,6 +78,7 @@ export const WorkspacesPreview: React.FunctionComponent<WorkspacesPreviewProps> 
             {batchSpecID && currentPreviewRequestTime && (
                 <WithBatchSpec
                     batchSpecID={batchSpecID}
+                    batchSpecStale={batchSpecStale}
                     setResolutionError={setResolutionError}
                     excludeRepo={excludeRepo}
                     currentPreviewRequestTime={currentPreviewRequestTime}
@@ -97,12 +98,15 @@ const getResolution = (queryResult?: WorkspaceResolutionStatusResult): Workspace
     queryResult?.node?.__typename === 'BatchSpec' ? queryResult.node.workspaceResolution : null
 
 interface WithBatchSpecProps
-    extends Required<Pick<WorkspacesPreviewProps, 'batchSpecID' | 'excludeRepo' | 'currentPreviewRequestTime'>> {
+    extends Required<
+        Pick<WorkspacesPreviewProps, 'batchSpecID' | 'batchSpecStale' | 'currentPreviewRequestTime' | 'excludeRepo'>
+    > {
     setResolutionError: (error: string) => void
 }
 
 const WithBatchSpec: React.FunctionComponent<WithBatchSpecProps> = ({
     batchSpecID,
+    batchSpecStale,
     currentPreviewRequestTime,
     setResolutionError,
     excludeRepo,
@@ -126,6 +130,7 @@ const WithBatchSpec: React.FunctionComponent<WithBatchSpecProps> = ({
                 <div className="d-flex flex-column align-items-center overflow-auto w-100">
                     <WorkspacesPreviewList
                         batchSpecID={batchSpecID}
+                        isStale={batchSpecStale}
                         setResolutionError={setResolutionError}
                         excludeRepo={excludeRepo}
                     />

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewList.tsx
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewList.tsx
@@ -1,11 +1,8 @@
-import CloseIcon from 'mdi-react/CloseIcon'
-import ContentSaveIcon from 'mdi-react/ContentSaveIcon'
 import ImportIcon from 'mdi-react/ImportIcon'
 import React from 'react'
 
 import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
 import { useQuery } from '@sourcegraph/shared/src/graphql/apollo'
-import { pluralize } from '@sourcegraph/shared/src/util/strings'
 import { LoadingSpinner } from '@sourcegraph/wildcard'
 
 import {
@@ -15,8 +12,15 @@ import {
 } from '../../../../graphql-operations'
 import { WORKSPACES_AND_IMPORTING_CHANGESETS } from '../backend'
 
+import { WorkspacesPreviewListItem } from './WorkspacesPreviewListItem'
+
 interface WorkspacesPreviewListProps {
     batchSpecID: Scalars['ID']
+    /**
+     * Whether or not the workspaces in this list are up-to-date with the current batch
+     * spec input YAML in the editor.
+     */
+    isStale: boolean
     setResolutionError: (error: string) => void
     /**
      * Function to automatically update repo query of input batch spec YAML to exclude the
@@ -27,6 +31,7 @@ interface WorkspacesPreviewListProps {
 
 export const WorkspacesPreviewList: React.FunctionComponent<WorkspacesPreviewListProps> = ({
     batchSpecID,
+    isStale,
     setResolutionError,
     excludeRepo,
 }) => {
@@ -54,36 +59,20 @@ export const WorkspacesPreviewList: React.FunctionComponent<WorkspacesPreviewLis
                 <span className="text-muted">No workspaces found</span>
             ) : (
                 <ul className="list-group p-1 mb-0 w-100">
-                    {workspaces?.nodes.map(item => (
-                        <li
-                            className="d-flex border-bottom mb-3 w-100"
-                            key={`${item.repository.id}_${item.branch.target.oid}_${item.path || '/'}`}
-                        >
-                            <button
-                                className="btn align-self-start p-0 m-0 mr-3"
-                                data-tooltip="Omit this repository from batch spec file"
-                                type="button"
-                                // TODO: Show warning that for monorepos, we will currently exclude all paths.
-                                onClick={() => excludeRepo(item.repository.name, item.branch.displayName)}
-                            >
-                                <CloseIcon className="icon-inline" />
-                            </button>
-                            {item.cachedResultFound && <ContentSaveIcon className="icon-inline" />}
-                            <div className="mb-2 flex-1">
-                                <p>
-                                    {item.repository.name}:{item.branch.abbrevName} Path: {item.path || '/'}
-                                </p>
-                                <p>
-                                    {item.searchResultPaths.length} {pluralize('result', item.searchResultPaths.length)}
-                                </p>
-                            </div>
-                        </li>
+                    {workspaces?.nodes.map((item, index) => (
+                        <WorkspacesPreviewListItem
+                            key={`${item.repository.id}-${item.branch.id}`}
+                            item={item}
+                            isStale={isStale}
+                            exclude={excludeRepo}
+                            variant={index % 2 === 0 ? 'light' : 'dark'}
+                        />
                     ))}
                 </ul>
             )}
             {importingChangesets && importingChangesets.totalCount > 0 && (
                 <>
-                    <h4 className="align-self-start w-100">Importing changesets</h4>
+                    <h4 className="align-self-start w-100 mt-4">Importing changesets</h4>
                     <ul className="w-100">
                         {importingChangesets?.nodes.map(node =>
                             node.__typename === 'VisibleChangesetSpec' ? (

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewListItem.module.scss
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewListItem.module.scss
@@ -14,8 +14,7 @@
 }
 
 .link-disabled {
-    // This color doesn't seem to be part of our codebase yet
-    color: #a6b5d9;
+    color: var(--text-disabled);
 }
 
 .status-container {

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewListItem.module.scss
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewListItem.module.scss
@@ -1,0 +1,23 @@
+.light {
+    // The light items just share the background color with the rest of the section.
+    background-color: none;
+}
+
+.dark {
+    background-color: var(--subtle-bg-2);
+}
+
+.link {
+    display: block;
+    font-size: 1rem;
+    padding-bottom: 0.125rem;
+}
+
+.link-disabled {
+    // This color doesn't seem to be part of our codebase yet
+    color: #a6b5d9;
+}
+
+.status-container {
+    width: 1rem;
+}

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewListItem.story.tsx
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewListItem.story.tsx
@@ -1,0 +1,166 @@
+import { storiesOf } from '@storybook/react'
+import { noop } from 'lodash'
+import React from 'react'
+
+import { WebStory } from '@sourcegraph/web/src/components/WebStory'
+
+import { mockWorkspace } from './WorkspacesPreview.mock'
+import { WorkspacesPreviewListItem } from './WorkspacesPreviewListItem'
+
+const { add } = storiesOf(
+    'web/batches/CreateBatchChangePage/WorkspacesPreview/ListItem',
+    module
+).addDecorator(story => <div className="list-group d-flex flex-column w-100">{story()}</div>)
+
+add('basic', () => (
+    <WebStory>
+        {props => (
+            <>
+                <WorkspacesPreviewListItem
+                    {...props}
+                    isStale={false}
+                    item={mockWorkspace(1)}
+                    variant="light"
+                    exclude={noop}
+                />
+                <WorkspacesPreviewListItem
+                    {...props}
+                    isStale={false}
+                    item={mockWorkspace(2)}
+                    variant="dark"
+                    exclude={noop}
+                />
+            </>
+        )}
+    </WebStory>
+))
+
+add('non-root path', () => (
+    <WebStory>
+        {props => (
+            <>
+                <WorkspacesPreviewListItem
+                    {...props}
+                    isStale={false}
+                    item={mockWorkspace(1, { path: 'path/to/workspace' })}
+                    variant="light"
+                    exclude={noop}
+                />
+                <WorkspacesPreviewListItem
+                    {...props}
+                    isStale={false}
+                    item={mockWorkspace(2, {
+                        path: 'a/really/deeply/nested/path/that/is/super/long/and/obnoxious/like/it/just/keeps/going',
+                    })}
+                    variant="dark"
+                    exclude={noop}
+                />
+            </>
+        )}
+    </WebStory>
+))
+
+add('non-default branch', () => (
+    <WebStory>
+        {props => (
+            <>
+                <WorkspacesPreviewListItem
+                    {...props}
+                    isStale={false}
+                    item={mockWorkspace(1, {
+                        branch: {
+                            id: 'not-main',
+                            abbrevName: 'not-main',
+                            displayName: 'not-main',
+                            url: 'idk.com',
+                            target: { oid: '1234' },
+                        },
+                    })}
+                    variant="light"
+                    exclude={noop}
+                />
+                <WorkspacesPreviewListItem
+                    {...props}
+                    isStale={false}
+                    item={mockWorkspace(2, {
+                        branch: {
+                            id: 'release 3.30',
+                            abbrevName: 'release 3.30',
+                            displayName: 'release 3.30',
+                            url: 'idk.com',
+                            target: { oid: '1234' },
+                        },
+                        path: '/testing/path',
+                    })}
+                    variant="dark"
+                    exclude={noop}
+                />
+            </>
+        )}
+    </WebStory>
+))
+
+add('cached', () => (
+    <WebStory>
+        {props => (
+            <>
+                <WorkspacesPreviewListItem
+                    {...props}
+                    isStale={false}
+                    item={mockWorkspace(1, { cachedResultFound: true })}
+                    variant="light"
+                    exclude={noop}
+                />
+                <WorkspacesPreviewListItem
+                    {...props}
+                    isStale={false}
+                    item={mockWorkspace(2, {
+                        cachedResultFound: true,
+                        branch: {
+                            id: 'release 3.30',
+                            abbrevName: 'release 3.30',
+                            displayName: 'release 3.30',
+                            url: 'idk.com',
+                            target: { oid: '1234' },
+                        },
+                        path: '/testing/path',
+                    })}
+                    variant="dark"
+                    exclude={noop}
+                />
+            </>
+        )}
+    </WebStory>
+))
+
+add('stale', () => (
+    <WebStory>
+        {props => (
+            <>
+                <WorkspacesPreviewListItem
+                    {...props}
+                    isStale={true}
+                    item={mockWorkspace(1)}
+                    variant="light"
+                    exclude={noop}
+                />
+                <WorkspacesPreviewListItem
+                    {...props}
+                    isStale={true}
+                    item={mockWorkspace(2, {
+                        branch: {
+                            id: 'release 3.30',
+                            abbrevName: 'release 3.30',
+                            displayName: 'release 3.30',
+                            url: 'idk.com',
+                            target: { oid: '1234' },
+                        },
+                        path: '/testing/path',
+                    })}
+                    variant="dark"
+                    exclude={noop}
+                />
+            </>
+        )}
+    </WebStory>
+))

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewListItem.tsx
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewListItem.tsx
@@ -1,0 +1,95 @@
+import classNames from 'classnames'
+import CloseIcon from 'mdi-react/CloseIcon'
+import ContentSaveIcon from 'mdi-react/ContentSaveIcon'
+import DeleteIcon from 'mdi-react/DeleteIcon'
+import SourceBranchIcon from 'mdi-react/SourceBranchIcon'
+import React, { useCallback, useState } from 'react'
+
+import { Link } from '@sourcegraph/shared/src/components/Link'
+
+import { PreviewBatchSpecWorkspaceFields } from '../../../../graphql-operations'
+
+import styles from './WorkspacesPreviewListItem.module.scss'
+
+interface WorkspacesPreviewListItemProps {
+    item: PreviewBatchSpecWorkspaceFields
+    /** Whether or not this item is stale */
+    isStale: boolean
+    /** Function to automatically update batch spec to exclude this item. */
+    exclude: (repo: string, branch: string) => void
+    /** Whether this item should take the lighter or darker variant of background color. */
+    variant: 'light' | 'dark'
+}
+
+export const WorkspacesPreviewListItem: React.FunctionComponent<WorkspacesPreviewListItemProps> = ({
+    item,
+    isStale,
+    exclude,
+    variant,
+}) => {
+    const [toBeExcluded, setToBeExcluded] = useState(false)
+
+    // TODO: https://github.com/sourcegraph/sourcegraph/issues/25085
+    const handleExclude = useCallback(() => {
+        setToBeExcluded(true)
+        exclude(item.repository.name, item.branch.displayName)
+    }, [exclude, item])
+
+    return (
+        <li
+            className={classNames(
+                'd-flex align-items-center px-2 py-3 w-100',
+                variant === 'light' ? styles.light : styles.dark
+            )}
+            key={`${item.repository.id}_${item.branch.target.oid}_${item.path || '/'}`}
+        >
+            <button
+                className="btn p-0 m-0 mr-2"
+                disabled={toBeExcluded}
+                data-tooltip={toBeExcluded ? undefined : 'Omit this repository from batch spec file'}
+                type="button"
+                onClick={handleExclude}
+            >
+                <CloseIcon className="icon-inline" />
+            </button>
+            <div className={classNames(styles.statusContainer, 'mr-2')}>
+                <StatusIcon status={toBeExcluded ? 'to-exclude' : item.cachedResultFound ? 'cached' : 'none'} />
+            </div>
+            <div className="flex-1">
+                <Link
+                    className={classNames(styles.link, (toBeExcluded || isStale) && styles.linkDisabled)}
+                    to={item.branch.url}
+                >
+                    {item.repository.name}:{item.branch.abbrevName}
+                </Link>
+                {item.path !== '' && item.path !== '/' ? <span className="d-block text-muted">{item.path}</span> : null}
+                {item.branch.id !== item.repository.defaultBranch?.id ? (
+                    <div className="d-flex align-items-center text-muted">
+                        <SourceBranchIcon className="icon-inline mr-1" />
+                        {item.branch.displayName}
+                    </div>
+                ) : null}
+            </div>
+        </li>
+    )
+}
+
+type StatusIconStatus = 'none' | 'cached' | 'to-exclude'
+
+const StatusIcon: React.FunctionComponent<{ status: StatusIconStatus }> = ({ status }) => {
+    switch (status) {
+        case 'none':
+            return null
+        case 'cached':
+            return (
+                <ContentSaveIcon className="icon-inline" data-tooltip="A cached result was found for this workspace." />
+            )
+        case 'to-exclude':
+            return (
+                <DeleteIcon
+                    className="icon-inline"
+                    data-tooltip="Your batch spec was modified to exclude this workspace. Preview again to update."
+                />
+            )
+    }
+}


### PR DESCRIPTION
Cleans up the individual items from the `WorkspacesPreviewList`. Next PR will be to properly paginate these with `useConnection` since we've identified that users with 2000+ changesets are going to be experiencing the most pain with this right now.

I'll let the [storybook stories](https://5f0f381c0e50750022dc6bf7-iuflhjwigz.chromatic.com/?path=/story/web-batches-createbatchchangepage-workspacespreview-listitem--basic) do most of the talking here, but some things of note:

- The `path` is hidden unless it's not the workspace root
- The `branch` is hidden unless it's not the repository default branch
- The workspace will take on the "stale" visual style if the user hit the button to auto-exclude it but hasn't updated their preview yet

I didn't add the triple dot menu or checkboxes/filters yet because we haven't implemented that stuff, but it still looks a lot better despite that I think. 😄

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
