### PR TITLE
extensibility: style hover tables

### DIFF
--- a/client/shared/src/hover/HoverOverlayContents/HoverOverlayContent/HoverOverlayContent.module.scss
+++ b/client/shared/src/hover/HoverOverlayContents/HoverOverlayContent/HoverOverlayContent.module.scss
@@ -20,4 +20,14 @@
         // which would prevent wrapping around the floating buttons.
         overflow: visible;
     }
+
+    // Table styles.
+    td {
+        padding-right: 1rem;
+    }
+    tbody {
+        tr {
+            border-top: 1px solid var(--border-color);
+        }
+    }
 }

--- a/client/shared/src/hover/HoverOverlayContents/HoverOverlayContent/HoverOverlayContent.module.scss
+++ b/client/shared/src/hover/HoverOverlayContents/HoverOverlayContent/HoverOverlayContent.module.scss
@@ -21,7 +21,7 @@
         overflow: visible;
     }
 
-    // Table styles.
+    // Table styles (see https://github.com/sourcegraph/sourcegraph/pull/27599)
     td {
         padding-right: 1rem;
     }


### PR DESCRIPTION
Style tables in rendered markdown for the Datadog Service Map extension ([figma](https://www.figma.com/file/FfGASaISn17NcURexEzgCc/Datadog-Popover?node-id=2%3A3472)).

| Before | After |
| --- | --- |
|  ![Screenshot from 2021-11-15 16-10-23](https://user-images.githubusercontent.com/37420160/141854869-1aecfc14-a739-439a-97e0-751d682559ae.png) | ![Screenshot from 2021-11-15 16-09-24](https://user-images.githubusercontent.com/37420160/141855010-7a8c2a3b-a8c7-4838-8503-32fb14020a54.png) |

(only the table styles addressed in this PR)
