### PR TITLE
Remove various unused imports

### DIFF
--- a/client/web/src/components/externalServices/AddExternalServicesPage.story.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicesPage.story.tsx
@@ -6,7 +6,6 @@ import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/teleme
 import { WebStory } from '../WebStory'
 
 import { AddExternalServicesPage } from './AddExternalServicesPage'
-import { fetchExternalService as _fetchExternalService } from './backend'
 import { codeHostExternalServices, nonCodeHostExternalServices } from './externalServices'
 
 const { add } = storiesOf('web/External services/AddExternalServicesPage', module)

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
@@ -18,13 +18,7 @@ import {
 } from '../../../graphql-operations'
 import { Description } from '../Description'
 
-import {
-    queryExternalChangesetWithFileDiffs as _queryExternalChangesetWithFileDiffs,
-    queryChangesetCountsOverTime as _queryChangesetCountsOverTime,
-    deleteBatchChange as _deleteBatchChange,
-    queryAllChangesetIDs as _queryAllChangesetIDs,
-    BATCH_CHANGE_BY_NAMESPACE,
-} from './backend'
+import { deleteBatchChange as _deleteBatchChange, BATCH_CHANGE_BY_NAMESPACE } from './backend'
 import { BatchChangeDetailsActionSection } from './BatchChangeDetailsActionSection'
 import { BatchChangeDetailsProps, BatchChangeDetailsTabs } from './BatchChangeDetailsTabs'
 import { BatchChangeInfoByline } from './BatchChangeInfoByline'

--- a/client/web/src/search/panels/CommunitySearchContextPanel.story.tsx
+++ b/client/web/src/search/panels/CommunitySearchContextPanel.story.tsx
@@ -5,7 +5,6 @@ import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/teleme
 import { WebStory } from '@sourcegraph/web/src/components/WebStory'
 
 import { CommunitySearchContextsPanel } from './CommunitySearchContextPanel'
-import { _fetchRecentSearches } from './utils'
 
 const { add } = storiesOf('web/search/panels/CommunitySearchContextPanel', module)
     .addParameters({


### PR DESCRIPTION
Just removes a couple imports that were not actually used in the files importing them. Because they were prefixed with `_`, they would not trigger the TS compiler.
