### PR TITLE
doc: fix quickstart formatting, clarify wording

### DIFF
--- a/doc/dev/background-information/sg/index.md
+++ b/doc/dev/background-information/sg/index.md
@@ -25,8 +25,8 @@
 
 ```
 
-`sg` is the CLI tool that Sourcegraph developers can use to develop Sourcegraph.
-Learn more about the tool's overall vision in [`sg` Vision](./vision.md).
+[`sg`](https://github.com/sourcegraph/sourcegraph/tree/main/dev/sg) is the CLI tool that Sourcegraph developers can use to develop Sourcegraph.
+Learn more about the tool's overall vision in [`sg` Vision](./vision.md), and how to use it in the [usage section](#usage).
 
 ## Quickstart
 
@@ -36,13 +36,15 @@ Learn more about the tool's overall vision in [`sg` Vision](./vision.md).
    curl --proto '=https' --tlsv1.2 -sSLf https://install.sg.dev | sh
    ```
 
-3. In your clone of [`sourcegraph/sourcegraph`](https://github.com/sourcegraph/sourcegraph), start the default Sourcegraph environment:
+2. In your clone of [`sourcegraph/sourcegraph`](https://github.com/sourcegraph/sourcegraph), start the default Sourcegraph environment:
 
    ```sh
    sg start
    ```
 
-   Once the `enterprise-web` process has finished compilation, open [`https://sourcegraph.test:3443`](https://sourcegraph.test:3443/) in your browser.
+3. Once the `enterprise-web` process has finished compilation, open [`https://sourcegraph.test:3443`](https://sourcegraph.test:3443/) in your browser.
+
+A more detailed introduction is available in the [development quickstart guide](../../getting-started/quickstart.md).
 
 ## Installation
 
@@ -62,7 +64,7 @@ That will download the latest release of `sg` from [here](https://github.com/sou
 
 Run the following in the root of `sourcegraph/sourcegraph`:
 
-```
+```sh
 ./dev/sg/install.sh
 ```
 
@@ -90,7 +92,7 @@ If you want full control over where the `sg` binary ends up, use this option.
 
 In the root of `sourcegraph/sourcegraph`, run:
 
-```
+```sh
 go build -o ~/my/path/sg ./dev/sg
 ```
 
@@ -270,9 +272,6 @@ specific to your work.
 
 You can run `sg run debug-env` to see the environment variables passed `sg`'s child processes.
 
-## Debugger
-To attach the [Delve](https://github.com/go-delve/delve) debugger, pass the environment variable `DELVE=true` into `sg`. [Read more here](https://docs.sourcegraph.com/dev/how-to/debug_live_code#debug-go-code)
-
 ### Examples
 
 #### Changing database configuration
@@ -319,12 +318,17 @@ commandsets:
 
 With that in `sg.config.overwrite.yaml` you can now run `sg start minimal-batches`.
 
+### Attach a debugger
+
+To attach the [Delve](https://github.com/go-delve/delve) debugger, pass the environment variable `DELVE=true` into `sg`. [Read more here](https://docs.sourcegraph.com/dev/how-to/debug_live_code#debug-go-code)
+
 ## Contributing to `sg`
 
 Want to hack on `sg`? Great! Here's how:
 
 1. Read through the [`sg` Vision](./vision.md) to get an idea of what `sg` should be in the long term.
-2. Look at the open [`sg` issues](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aopen+is%3Aissue+label%3Asg)
+2. Explore the [`sg` source code](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/dev/sg).
+3. Look at the open [`sg` issues](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aopen+is%3Aissue+label%3Asg).
 
 When you want to hack on `sg` it's best to be in the `dev/sg` directory and run it from there:
 

--- a/doc/dev/getting-started/quickstart.md
+++ b/doc/dev/getting-started/quickstart.md
@@ -1,16 +1,25 @@
-# Quickstart 
+# Development quickstart
 
->  NOTE: If you run into any troubles please consult the [deprecated quickstart instructions without `sg`](deprecated_quickstart.md) or reach out on Slack:
->  - [As an open source contributor](https://sourcegraph-community.slack.com/archives/C02BG0M0ZJ7)
->  - [As a Sourcegraph employee](https://sourcegraph.slack.com/archives/C01N83PS4TU)
+This is the quickstart guide for [developing Sourcegraph](../index.md).
+
+> NOTE: If you run into any troubles, you can alternatively consult the [deprecated quickstart instructions without `sg`](deprecated_quickstart.md) or reach out on Slack:
+>
+> - [As an open source contributor](https://sourcegraph-community.slack.com/archives/C02BG0M0ZJ7)
+> - [As a Sourcegraph employee](https://sourcegraph.slack.com/archives/C01N83PS4TU)
+>
+> You can also get help on our [developer experience discussion forum](https://github.com/sourcegraph/sourcegraph/discussions/categories/developer-experience).
+
+<span class="virtual-br"></span>
+
+> NOTE: Looking for how to deploy or use Sourcegraph? See our [getting started](../../index.md#getting-started) options.
 
 ## Install `sg`
 
-At Sourcegraph we use [`sg`](https://github.com/sourcegraph/sourcegraph/tree/main/dev/sg), the Sourcegraph developer tool, to manage our local development environment.
+At Sourcegraph we use [`sg`, the Sourcegraph developer tool](../background-information/sg/index.md), to manage our local development environment.
 
 To install `sg`, run the following in your terminal:
 
-```
+```sh
 curl --proto '=https' --tlsv1.2 -sSLf https://install.sg.dev | sh
 ```
 
@@ -20,7 +29,7 @@ See the [`sg` documentation](../background-information/sg/index.md) for more inf
 
 Open a terminal and run the following comming:
 
-```
+```sh
 sg setup
 ```
 
@@ -34,7 +43,7 @@ If you chose to run PostgreSQL and Redis **without Docker** they should already 
 
 If you chose to run Redis and PostgreSQL **with Docker** to then we need to run them:
 
-```
+```sh
 sg run redis-postgres
 ```
 
@@ -44,13 +53,13 @@ Keep this process running in a terminal window to keep the databases running. Fo
 
 **If you are a Sourcegraph employee**: start the local development server for Sourcegraph Enterprise with the following command:
 
-```
+```sh
 sg start
 ```
 
 **If you are not a Sourcegraph employee and don't have access to [the `dev-private` repository](https://github.com/sourcegraph/dev-private)**: you want to start Sourcegraph OSS, do this:
 
-```
+```sh
 sg start oss
 ```
 
@@ -64,7 +73,7 @@ Congratulations on making it to the end of the quickstart guide!
 
 If you want to run the server in different configurations (with the monitoring stack, with code insights enabled, Sourcegraph OSS, ...), run the following:
 
-```
+```sh
 sg start -help
 ```
 
@@ -72,13 +81,13 @@ That prints a list of possible configurations which you can start with `sg start
 
 For example, you can start Sourcegraph in the mode it uses on Sourcegraph.com by running the following in one terminal window
 
-```
+```sh
 sg start dotcom
 ```
 
 and then, in another terminal window, start the monitoring stack:
 
-```
+```sh
 sg start monitoring
 ```
 


### PR DESCRIPTION
- fix quickstart formatting
- clarify quickstart is for _development_ quickstart
- misc. tweaks