### PR TITLE
fix edit insight page on graphql api

### DIFF
--- a/client/web/src/enterprise/insights/core/backend/code-insights-gql-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-gql-backend.ts
@@ -314,7 +314,7 @@ export class CodeInsightsGqlBackend implements CodeInsightsBackend {
 
                 return [
                     {
-                        id: 'all',
+                        id: ALL_INSIGHTS_DASHBOARD_ID,
                         type: InsightsDashboardType.Virtual,
                         scope: InsightsDashboardScope.Personal,
                         title: 'All Insights',
@@ -338,7 +338,7 @@ export class CodeInsightsGqlBackend implements CodeInsightsBackend {
 
     public getDashboardById = (dashboardId?: string): Observable<InsightDashboard | null> => {
         // the 'all' dashboardId is not a real dashboard so return early
-        if (dashboardId === 'all') {
+        if (dashboardId === ALL_INSIGHTS_DASHBOARD_ID) {
             return of(null)
         }
 

--- a/client/web/src/enterprise/insights/core/backend/code-insights-gql-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-gql-backend.ts
@@ -336,8 +336,16 @@ export class CodeInsightsGqlBackend implements CodeInsightsBackend {
             })
         )
 
-    public getDashboardById = (dashboardId?: string): Observable<InsightDashboard | null> =>
-        this.getDashboards(dashboardId).pipe(map(dashboards => dashboards.find(({ id }) => id === dashboardId) ?? null))
+    public getDashboardById = (dashboardId?: string): Observable<InsightDashboard | null> => {
+        // the 'all' dashboardId is not a real dashboard so return early
+        if (dashboardId === 'all') {
+            return of(null)
+        }
+
+        return this.getDashboards(dashboardId).pipe(
+            map(dashboards => dashboards.find(({ id }) => id === dashboardId) ?? null)
+        )
+    }
 
     // This is only used to check for duplicate dashboards. Thi is not required for the new GQL API.
     // So we just return null to get the form to always accept.


### PR DESCRIPTION
Edit insights was trying to pass in 'all' as the
dashboardId to `getDashboardById`.
This doesn't exist, so the query was failing.
Just returning null early yields the expected result.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
