### PR TITLE
batches: paginate workspaces + import changesets previews

### DIFF
--- a/client/web/src/enterprise/batches/create/backend.ts
+++ b/client/web/src/enterprise/batches/create/backend.ts
@@ -41,24 +41,22 @@ export const WORKSPACE_RESOLUTION_STATUS = gql`
     }
 `
 
-export const WORKSPACES_AND_IMPORTING_CHANGESETS = gql`
-    query WorkspacesAndImportingChangesets($batchSpec: ID!) {
+export const WORKSPACES = gql`
+    query BatchSpecWorkspaces($batchSpec: ID!, $first: Int, $after: String) {
         node(id: $batchSpec) {
             __typename
             ... on BatchSpec {
                 workspaceResolution {
-                    workspaces(first: 10000) {
+                    __typename
+                    workspaces(first: $first, after: $after) {
+                        __typename
+                        totalCount
+                        pageInfo {
+                            hasNextPage
+                            endCursor
+                        }
                         nodes {
                             ...PreviewBatchSpecWorkspaceFields
-                        }
-                    }
-                }
-                importingChangesets(first: 10000) {
-                    totalCount
-                    nodes {
-                        __typename
-                        ... on VisibleChangesetSpec {
-                            ...PreviewBatchSpecImportingChangesetFields
                         }
                     }
                 }
@@ -67,21 +65,26 @@ export const WORKSPACES_AND_IMPORTING_CHANGESETS = gql`
     }
 
     fragment PreviewBatchSpecWorkspaceFields on BatchSpecWorkspace {
+        __typename
         repository {
+            __typename
             id
             name
             url
             defaultBranch {
+                __typename
                 id
             }
         }
         ignored
         unsupported
         branch {
+            __typename
             id
             abbrevName
             displayName
             target {
+                __typename
                 oid
             }
             url
@@ -90,8 +93,36 @@ export const WORKSPACES_AND_IMPORTING_CHANGESETS = gql`
         searchResultPaths
         cachedResultFound
     }
+`
+
+export const IMPORTING_CHANGESETS = gql`
+    query BatchSpecImportingChangesets($batchSpec: ID!, $first: Int, $after: String) {
+        node(id: $batchSpec) {
+            __typename
+            ... on BatchSpec {
+                importingChangesets(first: $first, after: $after) {
+                    __typename
+                    totalCount
+                    pageInfo {
+                        hasNextPage
+                        endCursor
+                    }
+                    nodes {
+                        __typename
+                        ... on VisibleChangesetSpec {
+                            ...PreviewBatchSpecImportingChangesetFields
+                        }
+                        ... on HiddenChangesetSpec {
+                            ...PreviewBatchSpecImportingHiddenChangesetFields
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     fragment PreviewBatchSpecImportingChangesetFields on VisibleChangesetSpec {
+        __typename
         id
         description {
             __typename
@@ -103,5 +134,10 @@ export const WORKSPACES_AND_IMPORTING_CHANGESETS = gql`
                 externalID
             }
         }
+    }
+
+    fragment PreviewBatchSpecImportingHiddenChangesetFields on HiddenChangesetSpec {
+        __typename
+        id
     }
 `

--- a/client/web/src/enterprise/batches/create/workspaces-preview/ImportingChangesetsPreviewList.module.scss
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/ImportingChangesetsPreviewList.module.scss
@@ -1,0 +1,3 @@
+.stale {
+    color: var(--text-disabled);
+}

--- a/client/web/src/enterprise/batches/create/workspaces-preview/ImportingChangesetsPreviewList.tsx
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/ImportingChangesetsPreviewList.tsx
@@ -1,0 +1,132 @@
+import ImportIcon from 'mdi-react/ImportIcon'
+import React from 'react'
+
+import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
+import { dataOrThrowErrors } from '@sourcegraph/shared/src/graphql/graphql'
+import {
+    useConnection,
+    UseConnectionResult,
+} from '@sourcegraph/web/src/components/FilteredConnection/hooks/useConnection'
+import {
+    ConnectionContainer,
+    ConnectionError,
+    ConnectionList,
+    ConnectionLoading,
+    ConnectionSummary,
+    ShowMoreButton,
+    SummaryContainer,
+} from '@sourcegraph/web/src/components/FilteredConnection/ui'
+
+import {
+    Scalars,
+    PreviewBatchSpecImportingChangesetFields,
+    BatchSpecImportingChangesetsResult,
+    BatchSpecImportingChangesetsVariables,
+} from '../../../../graphql-operations'
+import { IMPORTING_CHANGESETS } from '../backend'
+
+import styles from './ImportingChangesetsPreviewList.module.scss'
+
+interface ImportingChangesetsPreviewListProps {
+    batchSpecID: Scalars['ID']
+    /**
+     * Whether or not the changesets in this list are up-to-date with the current batch
+     * spec input YAML in the editor.
+     */
+    isStale: boolean
+}
+
+const CHANGESETS_COUNT = 100
+
+export const ImportingChangesetsPreviewList: React.FunctionComponent<ImportingChangesetsPreviewListProps> = ({
+    batchSpecID,
+    isStale,
+}) => {
+    const { connection, error, loading, hasNextPage, fetchMore } = useImportingChangesets(batchSpecID)
+
+    if (loading || connection?.totalCount === 0) {
+        return null
+    }
+
+    return (
+        <ConnectionContainer className="w-100">
+            <h4 className="align-self-start w-100 mt-4">Importing changesets</h4>
+            {error && <ConnectionError errors={[error.message]} />}
+            <ConnectionList className="list-group list-group-flush w-100">
+                {connection?.nodes.map(node =>
+                    node.__typename === 'VisibleChangesetSpec' ? (
+                        <li className="w-100" key={node.id}>
+                            <LinkOrSpan
+                                className={isStale ? styles.stale : undefined}
+                                to={
+                                    node.description.__typename === 'ExistingChangesetReference'
+                                        ? node.description.baseRepository.url
+                                        : undefined
+                                }
+                            >
+                                <ImportIcon className="icon-inline" />{' '}
+                                {node.description.__typename === 'ExistingChangesetReference' &&
+                                    node.description.baseRepository.name}
+                            </LinkOrSpan>{' '}
+                            #
+                            {node.description.__typename === 'ExistingChangesetReference' &&
+                                node.description.externalID}
+                        </li>
+                    ) : null
+                )}
+            </ConnectionList>
+            {loading && <ConnectionLoading />}
+            {connection && (
+                <SummaryContainer centered={true}>
+                    <ConnectionSummary
+                        noSummaryIfAllNodesVisible={true}
+                        first={CHANGESETS_COUNT}
+                        connection={connection}
+                        noun="imported changeset"
+                        pluralNoun="imported changesets"
+                        hasNextPage={hasNextPage}
+                        emptyElement={null}
+                    />
+                    {hasNextPage && <ShowMoreButton onClick={fetchMore} />}
+                </SummaryContainer>
+            )}
+        </ConnectionContainer>
+    )
+}
+
+const useImportingChangesets = (
+    batchSpecID: Scalars['ID']
+): UseConnectionResult<
+    PreviewBatchSpecImportingChangesetFields | { __typename: 'HiddenChangesetSpec'; id: Scalars['ID'] }
+> =>
+    useConnection<
+        BatchSpecImportingChangesetsResult,
+        BatchSpecImportingChangesetsVariables,
+        PreviewBatchSpecImportingChangesetFields | { __typename: 'HiddenChangesetSpec'; id: Scalars['ID'] }
+    >({
+        query: IMPORTING_CHANGESETS,
+        variables: {
+            batchSpec: batchSpecID,
+            after: null,
+            first: CHANGESETS_COUNT,
+        },
+        options: {
+            useURL: false,
+            fetchPolicy: 'cache-and-network',
+        },
+        getConnection: result => {
+            console.log(CHANGESETS_COUNT)
+            const data = dataOrThrowErrors(result)
+
+            if (!data.node) {
+                throw new Error(`Batch spec with ID ${batchSpecID} does not exist`)
+            }
+            if (data.node.__typename !== 'BatchSpec') {
+                throw new Error(`The given ID is a ${data.node.__typename as string}, not a BatchSpec`)
+            }
+            if (!data.node.importingChangesets) {
+                throw new Error(`No importing changesets resolution found for batch spec with ID ${batchSpecID}`)
+            }
+            return data.node.importingChangesets
+        },
+    })

--- a/client/web/src/enterprise/batches/create/workspaces-preview/ImportingChangesetsPreviewList.tsx
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/ImportingChangesetsPreviewList.tsx
@@ -36,7 +36,7 @@ interface ImportingChangesetsPreviewListProps {
     isStale: boolean
 }
 
-const CHANGESETS_COUNT = 100
+const CHANGESETS_PER_PAGE_COUNT = 100
 
 export const ImportingChangesetsPreviewList: React.FunctionComponent<ImportingChangesetsPreviewListProps> = ({
     batchSpecID,
@@ -80,7 +80,7 @@ export const ImportingChangesetsPreviewList: React.FunctionComponent<ImportingCh
                 <SummaryContainer centered={true}>
                     <ConnectionSummary
                         noSummaryIfAllNodesVisible={true}
-                        first={CHANGESETS_COUNT}
+                        first={CHANGESETS_PER_PAGE_COUNT}
                         connection={connection}
                         noun="imported changeset"
                         pluralNoun="imported changesets"
@@ -108,14 +108,13 @@ const useImportingChangesets = (
         variables: {
             batchSpec: batchSpecID,
             after: null,
-            first: CHANGESETS_COUNT,
+            first: CHANGESETS_PER_PAGE_COUNT,
         },
         options: {
             useURL: false,
             fetchPolicy: 'cache-and-network',
         },
         getConnection: result => {
-            console.log(CHANGESETS_COUNT)
             const data = dataOrThrowErrors(result)
 
             if (!data.node) {

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.story.tsx
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.story.tsx
@@ -9,10 +9,14 @@ import { getDocumentNode } from '@sourcegraph/shared/src/graphql/apollo'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { WebStory } from '@sourcegraph/web/src/components/WebStory'
 
-import { WORKSPACES_AND_IMPORTING_CHANGESETS, WORKSPACE_RESOLUTION_STATUS } from '../backend'
+import { WORKSPACES, IMPORTING_CHANGESETS, WORKSPACE_RESOLUTION_STATUS } from '../backend'
 
 import { WorkspacesPreview } from './WorkspacesPreview'
-import { mockWorkspaceResolutionStatus, mockWorkspacesAndImportingChangesets } from './WorkspacesPreview.mock'
+import {
+    mockWorkspaceResolutionStatus,
+    mockBatchSpecWorkspaces,
+    mockBatchSpecImportingChangesets,
+} from './WorkspacesPreview.mock'
 
 const { add } = storiesOf('web/batches/CreateBatchChangePage/WorkspacesPreview', module).addDecorator(story => (
     <div className="p-3 container d-flex flex-column align-items-center">{story()}</div>
@@ -73,13 +77,24 @@ add('first preview, error', () => {
     )
 })
 
-const WORKSPACES_AND_IMPORTING_CHANGESETS_MOCK: WildcardMockedResponse = {
+const WORKSPACES_MOCK: WildcardMockedResponse = {
     request: {
-        query: getDocumentNode(WORKSPACES_AND_IMPORTING_CHANGESETS),
+        query: getDocumentNode(WORKSPACES),
         variables: MATCH_ANY_PARAMETERS,
     },
     result: {
-        data: mockWorkspacesAndImportingChangesets(10, 2),
+        data: mockBatchSpecWorkspaces(50),
+    },
+    nMatches: Number.POSITIVE_INFINITY,
+}
+
+const IMPORTING_CHANGESETS_MOCK: WildcardMockedResponse = {
+    request: {
+        query: getDocumentNode(IMPORTING_CHANGESETS),
+        variables: MATCH_ANY_PARAMETERS,
+    },
+    result: {
+        data: mockBatchSpecImportingChangesets(50),
     },
     nMatches: Number.POSITIVE_INFINITY,
 }
@@ -96,7 +111,8 @@ add('first preview, success', () => {
             },
             nMatches: Number.POSITIVE_INFINITY,
         },
-        WORKSPACES_AND_IMPORTING_CHANGESETS_MOCK,
+        WORKSPACES_MOCK,
+        IMPORTING_CHANGESETS_MOCK,
     ])
 
     return (
@@ -130,7 +146,8 @@ add('first preview, stale', () => {
             },
             nMatches: Number.POSITIVE_INFINITY,
         },
-        WORKSPACES_AND_IMPORTING_CHANGESETS_MOCK,
+        WORKSPACES_MOCK,
+        IMPORTING_CHANGESETS_MOCK,
     ])
 
     return (

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.tsx
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../../../graphql-operations'
 import { WORKSPACE_RESOLUTION_STATUS } from '../backend'
 
+import { ImportingChangesetsPreviewList } from './ImportingChangesetsPreviewList'
 import { PreviewLoadingSpinner } from './PreviewLoadingSpinner'
 import { PreviewPrompt, PreviewPromptForm } from './PreviewPrompt'
 import styles from './WorkspacesPreview.module.scss'
@@ -132,6 +133,7 @@ const WithBatchSpec: React.FunctionComponent<WithBatchSpecProps> = ({
                         isStale={batchSpecStale}
                         excludeRepo={excludeRepo}
                     />
+                    <ImportingChangesetsPreviewList batchSpecID={batchSpecID} isStale={batchSpecStale} />
                 </div>
             ) : null}
         </>

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.tsx
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.tsx
@@ -130,7 +130,6 @@ const WithBatchSpec: React.FunctionComponent<WithBatchSpecProps> = ({
                     <WorkspacesPreviewList
                         batchSpecID={batchSpecID}
                         isStale={batchSpecStale}
-                        setResolutionError={setResolutionError}
                         excludeRepo={excludeRepo}
                     />
                 </div>

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewList.tsx
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewList.tsx
@@ -1,15 +1,27 @@
-import ImportIcon from 'mdi-react/ImportIcon'
 import React from 'react'
 
-import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
-import { useQuery } from '@sourcegraph/shared/src/graphql/apollo'
+import { dataOrThrowErrors } from '@sourcegraph/shared/src/graphql/graphql'
+import {
+    useConnection,
+    UseConnectionResult,
+} from '@sourcegraph/web/src/components/FilteredConnection/hooks/useConnection'
+import {
+    ConnectionContainer,
+    ConnectionError,
+    ConnectionList,
+    ConnectionLoading,
+    ConnectionSummary,
+    ShowMoreButton,
+    SummaryContainer,
+} from '@sourcegraph/web/src/components/FilteredConnection/ui'
 
 import {
-    WorkspacesAndImportingChangesetsResult,
-    WorkspacesAndImportingChangesetsVariables,
     Scalars,
+    PreviewBatchSpecWorkspaceFields,
+    BatchSpecWorkspacesResult,
+    BatchSpecWorkspacesVariables,
 } from '../../../../graphql-operations'
-import { WORKSPACES_AND_IMPORTING_CHANGESETS } from '../backend'
+import { WORKSPACES } from '../backend'
 
 import { PreviewLoadingSpinner } from './PreviewLoadingSpinner'
 import { WorkspacesPreviewListItem } from './WorkspacesPreviewListItem'
@@ -21,7 +33,6 @@ interface WorkspacesPreviewListProps {
      * spec input YAML in the editor.
      */
     isStale: boolean
-    setResolutionError: (error: string) => void
     /**
      * Function to automatically update repo query of input batch spec YAML to exclude the
      * provided repo + branch.
@@ -29,74 +40,77 @@ interface WorkspacesPreviewListProps {
     excludeRepo: (repo: string, branch: string) => void
 }
 
+const WORKSPACES_COUNT = 100
+
 export const WorkspacesPreviewList: React.FunctionComponent<WorkspacesPreviewListProps> = ({
     batchSpecID,
     isStale,
-    setResolutionError,
     excludeRepo,
 }) => {
-    const { data, loading } = useQuery<
-        WorkspacesAndImportingChangesetsResult,
-        WorkspacesAndImportingChangesetsVariables
-    >(WORKSPACES_AND_IMPORTING_CHANGESETS, {
-        variables: { batchSpec: batchSpecID },
-        // This data is intentionally transient, so there's no need to cache it.
-        fetchPolicy: 'no-cache',
-        // Report Apollo client errors back to the parent.
-        onError: error => setResolutionError(error.message),
-    })
+    const { connection, error, loading, hasNextPage, fetchMore } = useWorkspaces(batchSpecID)
 
     if (loading) {
         return <PreviewLoadingSpinner className="my-4" />
     }
 
-    const workspaces = data?.node?.__typename === 'BatchSpec' ? data.node.workspaceResolution?.workspaces : undefined
-    const importingChangesets = data?.node?.__typename === 'BatchSpec' ? data.node.importingChangesets : undefined
-
     return (
-        <>
-            {!workspaces || workspaces.nodes.length === 0 ? (
-                <span className="text-muted">No workspaces found</span>
-            ) : (
-                <ul className="list-group p-1 mb-0 w-100">
-                    {workspaces?.nodes.map((item, index) => (
-                        <WorkspacesPreviewListItem
-                            key={`${item.repository.id}-${item.branch.id}`}
-                            item={item}
-                            isStale={isStale}
-                            exclude={excludeRepo}
-                            variant={index % 2 === 0 ? 'light' : 'dark'}
-                        />
-                    ))}
-                </ul>
+        <ConnectionContainer className="w-100">
+            {error && <ConnectionError errors={[error.message]} />}
+            <ConnectionList className="list-group list-group-flush w-100">
+                {connection?.nodes?.map((node, index) => (
+                    <WorkspacesPreviewListItem
+                        key={`${node.repository.id}-${node.branch.id}`}
+                        item={node}
+                        isStale={isStale}
+                        exclude={excludeRepo}
+                        variant={index % 2 === 0 ? 'light' : 'dark'}
+                    />
+                ))}
+            </ConnectionList>
+            {loading && <ConnectionLoading />}
+            {connection && (
+                <SummaryContainer centered={true}>
+                    <ConnectionSummary
+                        noSummaryIfAllNodesVisible={true}
+                        first={WORKSPACES_COUNT}
+                        connection={connection}
+                        noun="workspace"
+                        pluralNoun="workspaces"
+                        hasNextPage={hasNextPage}
+                        emptyElement={<span className="text-muted">No workspaces found</span>}
+                    />
+                    {hasNextPage && <ShowMoreButton onClick={fetchMore} />}
+                </SummaryContainer>
             )}
-            {importingChangesets && importingChangesets.totalCount > 0 && (
-                <>
-                    <h4 className="align-self-start w-100 mt-4">Importing changesets</h4>
-                    <ul className="w-100">
-                        {importingChangesets?.nodes.map(node =>
-                            node.__typename === 'VisibleChangesetSpec' ? (
-                                <li className="w-100" key={node.id}>
-                                    <LinkOrSpan
-                                        to={
-                                            node.description.__typename === 'ExistingChangesetReference'
-                                                ? node.description.baseRepository.url
-                                                : undefined
-                                        }
-                                    >
-                                        <ImportIcon className="icon-inline" />{' '}
-                                        {node.description.__typename === 'ExistingChangesetReference' &&
-                                            node.description.baseRepository.name}
-                                    </LinkOrSpan>{' '}
-                                    #
-                                    {node.description.__typename === 'ExistingChangesetReference' &&
-                                        node.description.externalID}
-                                </li>
-                            ) : null
-                        )}
-                    </ul>
-                </>
-            )}
-        </>
+        </ConnectionContainer>
     )
 }
+
+const useWorkspaces = (batchSpecID: Scalars['ID']): UseConnectionResult<PreviewBatchSpecWorkspaceFields> =>
+    useConnection<BatchSpecWorkspacesResult, BatchSpecWorkspacesVariables, PreviewBatchSpecWorkspaceFields>({
+        query: WORKSPACES,
+        variables: {
+            batchSpec: batchSpecID,
+            after: null,
+            first: WORKSPACES_COUNT,
+        },
+        options: {
+            useURL: false,
+            fetchPolicy: 'cache-and-network',
+        },
+        getConnection: result => {
+            console.log(WORKSPACES_COUNT)
+            const data = dataOrThrowErrors(result)
+
+            if (!data.node) {
+                throw new Error(`Batch spec with ID ${batchSpecID} does not exist`)
+            }
+            if (data.node.__typename !== 'BatchSpec') {
+                throw new Error(`The given ID is a ${data.node.__typename as string}, not a BatchSpec`)
+            }
+            if (!data.node.workspaceResolution) {
+                throw new Error(`No workspace resolution found for batch spec with ID ${batchSpecID}`)
+            }
+            return data.node.workspaceResolution.workspaces
+        },
+    })

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewList.tsx
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewList.tsx
@@ -40,7 +40,7 @@ interface WorkspacesPreviewListProps {
     excludeRepo: (repo: string, branch: string) => void
 }
 
-const WORKSPACES_COUNT = 100
+const WORKSPACES_PER_PAGE_COUNT = 100
 
 export const WorkspacesPreviewList: React.FunctionComponent<WorkspacesPreviewListProps> = ({
     batchSpecID,
@@ -72,7 +72,7 @@ export const WorkspacesPreviewList: React.FunctionComponent<WorkspacesPreviewLis
                 <SummaryContainer centered={true}>
                     <ConnectionSummary
                         noSummaryIfAllNodesVisible={true}
-                        first={WORKSPACES_COUNT}
+                        first={WORKSPACES_PER_PAGE_COUNT}
                         connection={connection}
                         noun="workspace"
                         pluralNoun="workspaces"
@@ -92,14 +92,13 @@ const useWorkspaces = (batchSpecID: Scalars['ID']): UseConnectionResult<PreviewB
         variables: {
             batchSpec: batchSpecID,
             after: null,
-            first: WORKSPACES_COUNT,
+            first: WORKSPACES_PER_PAGE_COUNT,
         },
         options: {
             useURL: false,
             fetchPolicy: 'cache-and-network',
         },
         getConnection: result => {
-            console.log(WORKSPACES_COUNT)
             const data = dataOrThrowErrors(result)
 
             if (!data.node) {

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewListItem.module.scss
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewListItem.module.scss
@@ -13,7 +13,7 @@
     padding-bottom: 0.125rem;
 }
 
-.link-disabled {
+.link-stale {
     color: var(--text-disabled);
 }
 

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewListItem.story.tsx
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewListItem.story.tsx
@@ -69,11 +69,12 @@ add('non-default branch', () => (
                     isStale={false}
                     item={mockWorkspace(1, {
                         branch: {
+                            __typename: 'GitRef',
                             id: 'not-main',
                             abbrevName: 'not-main',
                             displayName: 'not-main',
                             url: 'idk.com',
-                            target: { oid: '1234' },
+                            target: { __typename: 'GitObject', oid: '1234' },
                         },
                     })}
                     variant="light"
@@ -84,11 +85,12 @@ add('non-default branch', () => (
                     isStale={false}
                     item={mockWorkspace(2, {
                         branch: {
+                            __typename: 'GitRef',
                             id: 'release 3.30',
                             abbrevName: 'release 3.30',
                             displayName: 'release 3.30',
                             url: 'idk.com',
-                            target: { oid: '1234' },
+                            target: { __typename: 'GitObject', oid: '1234' },
                         },
                         path: '/testing/path',
                     })}
@@ -117,11 +119,12 @@ add('cached', () => (
                     item={mockWorkspace(2, {
                         cachedResultFound: true,
                         branch: {
+                            __typename: 'GitRef',
                             id: 'release 3.30',
                             abbrevName: 'release 3.30',
                             displayName: 'release 3.30',
                             url: 'idk.com',
-                            target: { oid: '1234' },
+                            target: { __typename: 'GitObject', oid: '1234' },
                         },
                         path: '/testing/path',
                     })}
@@ -149,11 +152,12 @@ add('stale', () => (
                     isStale={true}
                     item={mockWorkspace(2, {
                         branch: {
+                            __typename: 'GitRef',
                             id: 'release 3.30',
                             abbrevName: 'release 3.30',
                             displayName: 'release 3.30',
                             url: 'idk.com',
-                            target: { oid: '1234' },
+                            target: { __typename: 'GitObject', oid: '1234' },
                         },
                         path: '/testing/path',
                     })}

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewListItem.tsx
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewListItem.tsx
@@ -57,7 +57,7 @@ export const WorkspacesPreviewListItem: React.FunctionComponent<WorkspacesPrevie
             </div>
             <div className="flex-1">
                 <Link
-                    className={classNames(styles.link, (toBeExcluded || isStale) && styles.linkDisabled)}
+                    className={classNames(styles.link, (toBeExcluded || isStale) && styles.linkStale)}
                     to={item.branch.url}
                 >
                     {item.repository.name}:{item.branch.abbrevName}


### PR DESCRIPTION
Refactors workspaces and importing changesets preview lists to support pagination with `useConnection` and the filtered connection API. No filters yet, and stale/loading states could use a bit of clean up, but one step closer nonetheless!
