### PR TITLE
Insights: removed redundant usage of 'new' on buttons and title and change to primary button

### DIFF
--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardsPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardsPage.tsx
@@ -58,14 +58,14 @@ export const DashboardsPage: React.FunctionComponent<DashboardsPageProps> = prop
                     actions={
                         <>
                             <Link to="/insights/add-dashboard" className="btn btn-outline-secondary mr-2">
-                                <PlusIcon className="icon-inline" /> Create new dashboard
+                                <PlusIcon className="icon-inline" /> Create dashboard
                             </Link>
                             <Link
                                 to={`/insights/create?dashboardId=${dashboardID}`}
                                 className="btn btn-secondary"
                                 onClick={handleAddMoreInsightClick}
                             >
-                                <PlusIcon className="icon-inline" /> Create new insight
+                                <PlusIcon className="icon-inline" /> Create insight
                             </Link>
                         </>
                     }

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
@@ -14,7 +14,7 @@ import { LinkWithQuery } from '../../../../components/link-with-query'
 import { LINE_CHART_DATA, PIE_CHART_DATA } from './charts-mock'
 import styles from './IntroCreationPage.module.scss'
 
-interface IntroCreationPageProps extends TelemetryProps {}
+interface IntroCreationPageProps extends TelemetryProps { }
 
 /** Displays intro page for insights creation UI. */
 export const IntroCreationPage: React.FunctionComponent<IntroCreationPageProps> = props => {
@@ -41,7 +41,7 @@ export const IntroCreationPage: React.FunctionComponent<IntroCreationPageProps> 
             <PageTitle title="Create code insights" />
 
             <div className="mb-5">
-                <h2>Create new insight</h2>
+                <h2>Create insight</h2>
 
                 <p className="text-muted">
                     Code insights analyze your code based on any search query.{' '}


### PR DESCRIPTION
The "Create new insight" button should be altered to be a Primary button and the text should be changed to read "Create code insight" on the index page header. 

The Create new dashboard button should read "Create dashboard":

![image](https://user-images.githubusercontent.com/11967660/141930793-0b433cb9-e4ff-460f-aa65-2548c6c316ba.png)

Additionally, on the create page, remove the word 'New' from the title:
![image](https://user-images.githubusercontent.com/11967660/141930767-e74c4656-0803-4664-bd53-e5029720964f.png)


