### PR TITLE
search results: fix odd scrolling in certain diff search scenarios

### DIFF
--- a/client/web/src/search/results/StreamingSearchResults.module.scss
+++ b/client/web/src/search/results/StreamingSearchResults.module.scss
@@ -42,7 +42,11 @@
     }
 
     &__container {
-        overflow-y: visible;
+        // Hack!! Fixes some possible nested scrolling on diff searches
+        // due to size calculations on diff results. The parent will scroll
+        // instead so this doesn't really hide anything.
+        overflow-y: hidden;
+
         overflow-x: hidden;
         grid-column: 2;
         grid-row: 3;


### PR DESCRIPTION
Repro video: 
https://user-images.githubusercontent.com/206864/141958053-75abb124-45c2-4361-b606-314a984e9487.mov

Repro URL: https://k8s.sgdev.org/search?q=repo%3A%5E%28ghe%5C.sgdev%5C.org%2Fsourcegraph%2Fadobe-adobe%5C.github%5C.com%29%24+type%3Adiff+after%3A2013-11-12T00%3A00%3A00%2B04%3A00+before%3A2015-11-12T00%3A00%3A00%2B03%3A00+if

We calculate the size for diff results and this causes the results to change in size. But because we never scroll to them, the results never actually load. So I think the browser gets stuck trying to scroll. Changing overflow for the streaming container from `visible` to `hidden` seems to fix the issue.