### PR TITLE
graphqlbackend: invited users can see orgs on dotcom

### DIFF
--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -41,7 +41,7 @@ func (r *schemaResolver) Organization(ctx context.Context, args struct{ Name str
 			}
 
 			// NOTE: We want to present a unified error to unauthorized users to prevent
-			// them differentiating service state by different error messages.
+			// them from differentiating service states by different error messages.
 			return &database.OrgNotFoundError{Message: fmt.Sprintf("name %s", args.Name)}
 		}
 		if err := hasAccess(); err != nil {

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -2,6 +2,7 @@ package graphqlbackend
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cockroachdb/errors"
 	"github.com/graph-gophers/graphql-go"
@@ -26,9 +27,25 @@ func (r *schemaResolver) Organization(ctx context.Context, args struct{ Name str
 	}
 	// 🚨 SECURITY: Only org members can get org details on Cloud
 	if envvar.SourcegraphDotComMode() {
-		err := backend.CheckOrgAccess(ctx, r.db, org.ID)
-		if err != nil {
-			return nil, errors.Newf("org not found: %s", args.Name)
+		hasAccess := func() error {
+			err := backend.CheckOrgAccess(ctx, r.db, org.ID)
+			if err == nil {
+				return nil
+			}
+
+			if a := actor.FromContext(ctx); a.IsAuthenticated() {
+				_, err = r.db.OrgInvitations().GetPending(ctx, org.ID, a.UID)
+				if err == nil {
+					return nil
+				}
+			}
+
+			// NOTE: We want to present a unified error to unauthorized users to prevent
+			// them differentiating service state by different error messages.
+			return &database.OrgNotFoundError{Message: fmt.Sprintf("name %s", args.Name)}
+		}
+		if err := hasAccess(); err != nil {
+			return nil, err
 		}
 	}
 	return &OrgResolver{db: r.db, org: org}, nil


### PR DESCRIPTION
Invited users should be able to see the organization basic info like its name (but nothing else), otherwise no one is able to accept invitations on Sourcegraph.com.

<img width="538" alt="CleanShot 2021-11-16 at 18 18 02@2x" src="https://user-images.githubusercontent.com/2946214/141967045-fa414dd6-29fb-46d9-b914-2328e300fa99.png">

---

Jira: CLOUD-138