### PR TITLE
graphqlbackend: do not swallow errors on scheduling perms syncs

### DIFF
--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -276,7 +276,14 @@ func (r *schemaResolver) RemoveUserFromOrganization(ctx context.Context, args *s
 	if err := database.OrgMembers(r.db).Remove(ctx, orgID, userID); err != nil {
 		return nil, err
 	}
-	r.repoupdaterClient.SchedulePermsSync(ctx, protocol.PermsSyncRequest{UserIDs: []int32{userID}})
+
+	err = r.repoupdaterClient.SchedulePermsSync(ctx, protocol.PermsSyncRequest{UserIDs: []int32{userID}})
+	if err != nil {
+		log15.Warn("schemaResolver.RemoveUserFromOrganization.SchedulePermsSync",
+			"userID", userID,
+			"error", err,
+		)
+	}
 	return nil, nil
 }
 
@@ -306,8 +313,15 @@ func (r *schemaResolver) AddUserToOrganization(ctx context.Context, args *struct
 	if _, err := database.OrgMembers(r.db).Create(ctx, orgID, userToInvite.ID); err != nil {
 		return nil, err
 	}
+
 	// Schedule permission sync for newly added user
-	r.repoupdaterClient.SchedulePermsSync(ctx, protocol.PermsSyncRequest{UserIDs: []int32{userToInvite.ID}})
+	err = r.repoupdaterClient.SchedulePermsSync(ctx, protocol.PermsSyncRequest{UserIDs: []int32{userToInvite.ID}})
+	if err != nil {
+		log15.Warn("schemaResolver.AddUserToOrganization.SchedulePermsSync",
+			"userID", userToInvite.ID,
+			"error", err,
+		)
+	}
 	return &EmptyResponse{}, nil
 }
 

--- a/cmd/frontend/graphqlbackend/org_invitations.go
+++ b/cmd/frontend/graphqlbackend/org_invitations.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
@@ -139,8 +140,15 @@ func (r *schemaResolver) RespondToOrganizationInvitation(ctx context.Context, ar
 		if _, err := database.OrgMembers(r.db).Create(ctx, orgID, a.UID); err != nil {
 			return nil, err
 		}
+
 		// Schedule permission sync for user that accepted the invite
-		r.repoupdaterClient.SchedulePermsSync(ctx, protocol.PermsSyncRequest{UserIDs: []int32{a.UID}})
+		err = r.repoupdaterClient.SchedulePermsSync(ctx, protocol.PermsSyncRequest{UserIDs: []int32{a.UID}})
+		if err != nil {
+			log15.Warn("schemaResolver.RespondToOrganizationInvitation.SchedulePermsSync",
+				"userID", a.UID,
+				"error", err,
+			)
+		}
 	}
 	return &EmptyResponse{}, nil
 }


### PR DESCRIPTION
Errors were not checked.
