### PR TITLE
graphqlbackend: reduce usage of `database.Mocks`

### DIFF
--- a/cmd/frontend/graphqlbackend/org_test.go
+++ b/cmd/frontend/graphqlbackend/org_test.go
@@ -169,13 +169,8 @@ func TestOrganizationRepositories(t *testing.T) {
 	orgs := dbmock.NewMockOrgStore()
 	orgs.GetByNameFunc.SetDefaultReturn(&types.Org{ID: 1, Name: "acme"}, nil)
 
-	database.Mocks.Repos.List = func(context.Context, database.ReposListOptions) (repos []*types.Repo, err error) {
-		return []*types.Repo{
-			{
-				Name: "acme-repo",
-			},
-		}, nil
-	}
+	repos := dbmock.NewMockRepoStore()
+	repos.ListFunc.SetDefaultReturn([]*types.Repo{{Name: "acme-repo"}}, nil)
 
 	users := dbmock.NewMockUserStore()
 	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 1}, nil)
@@ -188,6 +183,7 @@ func TestOrganizationRepositories(t *testing.T) {
 
 	db := dbmock.NewMockDB()
 	db.OrgsFunc.SetDefaultReturn(orgs)
+	db.ReposFunc.SetDefaultReturn(repos)
 	db.UsersFunc.SetDefaultReturn(users)
 	db.OrgMembersFunc.SetDefaultReturn(orgMembers)
 	db.FeatureFlagsFunc.SetDefaultReturn(featureFlags)

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -160,7 +160,7 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 			if opt2.LimitOffset != nil {
 				opt2.LimitOffset.Limit++
 			}
-			repos, err := backend.Repos.List(ctx, opt2)
+			repos, err := backend.NewRepos(r.db.Repos()).List(ctx, opt2)
 			if err != nil {
 				r.err = err
 				return

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -403,7 +403,7 @@ func (r *schemaResolver) ResolvePhabricatorDiff(ctx context.Context, args *struc
 	Description *string
 	Date        *string
 }) (*GitCommitResolver, error) {
-	repo, err := database.Repos(r.db).GetByName(ctx, api.RepoName(args.RepoName))
+	repo, err := r.db.Repos().GetByName(ctx, api.RepoName(args.RepoName))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/user_emails.go
+++ b/cmd/frontend/graphqlbackend/user_emails.go
@@ -265,12 +265,13 @@ func (r *schemaResolver) ResendVerificationEmail(ctx context.Context, args *rese
 		}
 	}
 
-	user, err := database.Users(r.db).GetByID(ctx, userID)
+	user, err := r.db.Users().GetByID(ctx, userID)
 	if err != nil {
 		return nil, err
 	}
 
-	lastSent, err := database.UserEmails(r.db).GetLatestVerificationSentEmail(ctx, args.Email)
+	userEmails := r.db.UserEmails()
+	lastSent, err := userEmails.GetLatestVerificationSentEmail(ctx, args.Email)
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +281,7 @@ func (r *schemaResolver) ResendVerificationEmail(ctx context.Context, args *rese
 		return nil, errors.New("Last verification email sent too recently")
 	}
 
-	email, verified, err := database.UserEmails(r.db).Get(ctx, userID, args.Email)
+	email, verified, err := userEmails.Get(ctx, userID, args.Email)
 	if err != nil {
 		return nil, err
 	}
@@ -293,7 +294,7 @@ func (r *schemaResolver) ResendVerificationEmail(ctx context.Context, args *rese
 		return nil, err
 	}
 
-	err = database.UserEmails(r.db).SetLastVerification(ctx, userID, email, code)
+	err = userEmails.SetLastVerification(ctx, userID, email, code)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR reduces usage of `database.Mocks` in the `cmd/frontend/graphqlbackend` package.

---

Part of #26113