### PR TITLE
webhooks: remove unnecessary logging

### DIFF
--- a/cmd/frontend/webhooks/middleware.go
+++ b/cmd/frontend/webhooks/middleware.go
@@ -17,10 +17,10 @@ import (
 // SetExternalServiceID attaches a specific external service ID to the current
 // webhook request for logging purposes.
 func SetExternalServiceID(ctx context.Context, id int64) {
+	// There's no else case here because it is expected that there's no setter
+	// if logging is disabled.
 	if setter, ok := ctx.Value(setterContextKey).(contextFunc); ok {
 		setter(id)
-	} else {
-		log15.Error("cannot get setter from context; this likely means that SetExternalServiceID has been called from outside a HTTP handler wrapped in LogMiddleware")
 	}
 }
 


### PR DESCRIPTION
We expect that there's no setter in the context if logging is disabled. While we could use `loggingEnabled()` to figure out whether to log, that means we have to access the configuration, and that feels unnecessary.

Credit to Erik for spotting this on k8s!