### PR TITLE
search: remove names from index list endpoint

### DIFF
--- a/cmd/frontend/internal/httpapi/search.go
+++ b/cmd/frontend/internal/httpapi/search.go
@@ -242,20 +242,16 @@ func (h *searchIndexerServer) serveList(w http.ResponseWriter, r *http.Request) 
 	// 1. Changing the schema from object of arrays to array of objects.
 	// 2. Stream out each object marshalled rather than marshall the full list in memory.
 
-	names := make([]string, 0, len(indexable))
 	ids := make([]api.RepoID, 0, len(indexable))
 
 	for _, r := range indexable {
-		names = append(names, string(r.Name))
 		ids = append(ids, r.ID)
 	}
 
 	data := struct {
-		RepoNames []string
-		RepoIDs   []api.RepoID
+		RepoIDs []api.RepoID
 	}{
-		RepoNames: names,
-		RepoIDs:   ids,
+		RepoIDs: ids,
 	}
 
 	return json.NewEncoder(w).Encode(&data)

--- a/cmd/frontend/internal/httpapi/search_test.go
+++ b/cmd/frontend/internal/httpapi/search_test.go
@@ -160,16 +160,10 @@ func TestReposIndex(t *testing.T) {
 			}
 
 			var data struct {
-				RepoNames []string
-				RepoIDs   []api.RepoID
+				RepoIDs []api.RepoID
 			}
 			if err := json.Unmarshal(body, &data); err != nil {
 				t.Fatal(err)
-			}
-			got := data.RepoNames
-
-			if !cmp.Equal(tc.want, got) {
-				t.Fatalf("names mismatch (-want +got):\n%s", cmp.Diff(tc.want, got))
 			}
 
 			wantIDs := make([]api.RepoID, len(tc.want))


### PR DESCRIPTION
We don't read this value anymore. Additionally this makes the payload
much larger so it is useful to avoid marshalling the name.
