### PR TITLE
Add note to functional implementation of insight additional pings

### DIFF
--- a/doc/dev/background-information/insights/code_insights_pings.md
+++ b/doc/dev/background-information/insights/code_insights_pings.md
@@ -105,7 +105,7 @@ https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegrap
 - Event Code: [InsightOrgVisible](https://sourcegraph.com/search?q=context:global+insightorgvisible+r:sourcegraph/sourcegraph%24&patternType=literal)
 - PRs: [#21671](https://github.com/sourcegraph/sourcegraph/pull/21671/files)
 - **Version Added:** 3.29
-- **Version(s) broken:** 3.31-3.32 ([fix PR](https://github.com/sourcegraph/sourcegraph/pull/26138))
+- **Version(s) broken:** 3.31+ (doesn't handle backend insights)
 
 ### First time insight creators count
 

--- a/doc/dev/background-information/insights/code_insights_pings.md
+++ b/doc/dev/background-information/insights/code_insights_pings.md
@@ -10,7 +10,7 @@ We keep this docs page up to date because pings are a vital component of our pro
 
 **Intended purpose:** To track how many times customers have created, edited, and removed insights, by week. 
 
-**Functional implementation:** This ping works by diffing settings files in case if users edit their settings in setting editor at the setting edit page, because insight configs are currently stored in settings files. 
+**Functional implementation:** The current implementation of Code Insights stores insight configurations in settings files. This ping works by diffing settings files if users edit their settings in the setting editor at the setting edit page.
 Also, we track insight creating/editing/deleting events in the creation UI form and insight context menu component with standard telemetry service calls.
 
 **Other considerations:** This is an "imperfect" ping because not all additions + removals directly translate to a new insight or a deleted insight, due to the complications with using settings files as a source of truth. We'll be fixing this when we migrate to a backend database. Note also we're using this as a "total insights" metric for the same imperfect reason (additions - removals = total created) and when we migrate to the backend database we should build an additional separate ping that is just "total insights existing on the instance" per week. 

--- a/doc/dev/background-information/insights/code_insights_pings.md
+++ b/doc/dev/background-information/insights/code_insights_pings.md
@@ -10,7 +10,8 @@ We keep this docs page up to date because pings are a vital component of our pro
 
 **Intended purpose:** To track how many times customers have created, edited, and removed insights, by week. 
 
-**Functional implementation:** This ping works by diffing settings files, because insight configs are currently stored in settings files. 
+**Functional implementation:** This ping works by diffing settings files in case if users edit their settings in setting editor at the setting edit page, because insight configs are currently stored in settings files. 
+Also, we track insight creating/editing/deleting events in the creation UI form and insight context menu component with standard telemetry service calls.
 
 **Other considerations:** This is an "imperfect" ping because not all additions + removals directly translate to a new insight or a deleted insight, due to the complications with using settings files as a source of truth. We'll be fixing this when we migrate to a backend database. Note also we're using this as a "total insights" metric for the same imperfect reason (additions - removals = total created) and when we migrate to the backend database we should build an additional separate ping that is just "total insights existing on the instance" per week. 
 

--- a/doc/dev/background-information/insights/code_insights_pings.md
+++ b/doc/dev/background-information/insights/code_insights_pings.md
@@ -105,7 +105,7 @@ https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegrap
 - Event Code: [InsightOrgVisible](https://sourcegraph.com/search?q=context:global+insightorgvisible+r:sourcegraph/sourcegraph%24&patternType=literal)
 - PRs: [#21671](https://github.com/sourcegraph/sourcegraph/pull/21671/files)
 - **Version Added:** 3.29
-- **Version(s) broken:** 3.31+ (doesn't handle backend insights)
+- **Version(s) broken:** 3.31-3.32 ([fix PR](https://github.com/sourcegraph/sourcegraph/pull/26138))
 
 ### First time insight creators count
 


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/27465

This PR slightly updates our functional implementation note about insight additional (edit, delete) pings and fixes broken versions status for org visible insights total count event