### PR TITLE
web: ignore the AbortError in Sentry

### DIFF
--- a/client/web/src/sentry/shouldErrorBeReported.ts
+++ b/client/web/src/sentry/shouldErrorBeReported.ts
@@ -19,7 +19,7 @@ export function isWebpackChunkError(value: unknown): boolean {
 }
 
 function isAbortError(value: unknown): boolean {
-    return isErrorLike(value) && value.name === 'AbortError'
+    return isErrorLike(value) && (value.name === 'AbortError' || value.message.startsWith('AbortError'))
 }
 
 function isNotAuthenticatedError(value: unknown): boolean {


### PR DESCRIPTION
Ignore `AbortError` in Sentry. [Example error](https://sentry.io/organizations/sourcegraph/issues/2753022416/?project=1391511&query=is%3Aunresolved&sort=freq&statsPeriod=14d).