### PR TITLE
Internal user authz

### DIFF
--- a/cmd/frontend/graphqlbackend/saved_searches.go
+++ b/cmd/frontend/graphqlbackend/saved_searches.go
@@ -42,18 +42,10 @@ func (r *schemaResolver) savedSearchByID(ctx context.Context, id graphql.ID) (*s
 
 	// 🚨 SECURITY: Make sure the current user has permission to get the saved
 	// search.
-	if ss.Config.UserID != nil {
-		if *ss.Config.UserID != actor.FromContext(ctx).UID {
-			return nil, &backend.InsufficientAuthorizationError{
-				Message: "current user has insufficient privileges to view saved search",
-			}
+	if ss.Config.UserID != actor.FromContext(ctx).UID {
+		return nil, &backend.InsufficientAuthorizationError{
+			Message: "current user has insufficient privileges to view saved search",
 		}
-	} else if ss.Config.OrgID != nil {
-		if err := backend.CheckOrgAccess(ctx, r.db, *ss.Config.OrgID); err != nil {
-			return nil, err
-		}
-	} else {
-		return nil, errors.New("failed to get saved search: no Org ID or User ID associated with saved search")
 	}
 
 	savedSearch := &savedSearchResolver{
@@ -65,7 +57,6 @@ func (r *schemaResolver) savedSearchByID(ctx context.Context, id graphql.ID) (*s
 			Notify:          ss.Config.Notify,
 			NotifySlack:     ss.Config.NotifySlack,
 			UserID:          ss.Config.UserID,
-			OrgID:           ss.Config.OrgID,
 			SlackWebhookURL: ss.Config.SlackWebhookURL,
 		},
 	}
@@ -89,21 +80,11 @@ func (r savedSearchResolver) Description() string { return r.s.Description }
 func (r savedSearchResolver) Query() string { return r.s.Query }
 
 func (r savedSearchResolver) Namespace(ctx context.Context) (*NamespaceResolver, error) {
-	if r.s.OrgID != nil {
-		n, err := NamespaceByID(ctx, r.db, MarshalOrgID(*r.s.OrgID))
-		if err != nil {
-			return nil, err
-		}
-		return &NamespaceResolver{n}, nil
+	n, err := NamespaceByID(ctx, r.db, MarshalUserID(r.s.UserID))
+	if err != nil {
+		return nil, err
 	}
-	if r.s.UserID != nil {
-		n, err := NamespaceByID(ctx, r.db, MarshalUserID(*r.s.UserID))
-		if err != nil {
-			return nil, err
-		}
-		return &NamespaceResolver{n}, nil
-	}
-	return nil, nil
+	return &NamespaceResolver{n}, nil
 }
 
 func (r savedSearchResolver) SlackWebhookURL() *string { return r.s.SlackWebhookURL }
@@ -159,28 +140,13 @@ func (r *schemaResolver) CreateSavedSearch(ctx context.Context, args *struct {
 	OrgID       *graphql.ID
 	UserID      *graphql.ID
 }) (*savedSearchResolver, error) {
-	var userID, orgID *int32
 	// 🚨 SECURITY: Make sure the current user has permission to create a saved search for the specified user or org.
-	if args.UserID != nil {
-		u, err := unmarshalSavedSearchID(*args.UserID)
-		if err != nil {
-			return nil, err
-		}
-		userID = &u
-		if err := backend.CheckSiteAdminOrSameUser(ctx, r.db, u); err != nil {
-			return nil, err
-		}
-	} else if args.OrgID != nil {
-		o, err := unmarshalSavedSearchID(*args.OrgID)
-		if err != nil {
-			return nil, err
-		}
-		orgID = &o
-		if err := backend.CheckOrgAccessOrSiteAdmin(ctx, r.db, o); err != nil {
-			return nil, err
-		}
-	} else {
-		return nil, errors.New("failed to create saved search: no Org ID or User ID associated with saved search")
+	uid, err := unmarshalSavedSearchID(*args.UserID)
+	if err != nil {
+		return nil, err
+	}
+	if err := backend.CheckSiteAdminOrSameUser(ctx, r.db, uid); err != nil {
+		return nil, err
 	}
 
 	if !queryHasPatternType(args.Query) {
@@ -192,8 +158,7 @@ func (r *schemaResolver) CreateSavedSearch(ctx context.Context, args *struct {
 		Query:       args.Query,
 		Notify:      args.NotifyOwner,
 		NotifySlack: args.NotifySlack,
-		UserID:      userID,
-		OrgID:       orgID,
+		UserID:      uid,
 	})
 	if err != nil {
 		return nil, err
@@ -211,28 +176,13 @@ func (r *schemaResolver) UpdateSavedSearch(ctx context.Context, args *struct {
 	OrgID       *graphql.ID
 	UserID      *graphql.ID
 }) (*savedSearchResolver, error) {
-	var userID, orgID *int32
 	// 🚨 SECURITY: Make sure the current user has permission to update a saved search for the specified user or org.
-	if args.UserID != nil {
-		u, err := unmarshalSavedSearchID(*args.UserID)
-		if err != nil {
-			return nil, err
-		}
-		userID = &u
-		if err := backend.CheckSiteAdminOrSameUser(ctx, r.db, u); err != nil {
-			return nil, err
-		}
-	} else if args.OrgID != nil {
-		o, err := unmarshalSavedSearchID(*args.OrgID)
-		if err != nil {
-			return nil, err
-		}
-		orgID = &o
-		if err := backend.CheckOrgAccessOrSiteAdmin(ctx, r.db, o); err != nil {
-			return nil, err
-		}
-	} else {
-		return nil, errors.New("failed to update saved search: no Org ID or User ID associated with saved search")
+	uid, err := unmarshalSavedSearchID(*args.UserID)
+	if err != nil {
+		return nil, err
+	}
+	if err := backend.CheckSiteAdminOrSameUser(ctx, r.db, uid); err != nil {
+		return nil, err
 	}
 
 	id, err := unmarshalSavedSearchID(args.ID)
@@ -250,8 +200,7 @@ func (r *schemaResolver) UpdateSavedSearch(ctx context.Context, args *struct {
 		Query:       args.Query,
 		Notify:      args.NotifyOwner,
 		NotifySlack: args.NotifySlack,
-		UserID:      userID,
-		OrgID:       orgID,
+		UserID:      uid,
 	})
 	if err != nil {
 		return nil, err
@@ -272,16 +221,8 @@ func (r *schemaResolver) DeleteSavedSearch(ctx context.Context, args *struct {
 		return nil, err
 	}
 	// 🚨 SECURITY: Make sure the current user has permission to delete a saved search for the specified user or org.
-	if ss.Config.UserID != nil {
-		if err := backend.CheckSiteAdminOrSameUser(ctx, r.db, *ss.Config.UserID); err != nil {
-			return nil, err
-		}
-	} else if ss.Config.OrgID != nil {
-		if err := backend.CheckOrgAccessOrSiteAdmin(ctx, r.db, *ss.Config.OrgID); err != nil {
-			return nil, err
-		}
-	} else {
-		return nil, errors.New("failed to delete saved search: no Org ID or User ID associated with saved search")
+	if err := backend.CheckSiteAdminOrSameUser(ctx, r.db, ss.Config.UserID); err != nil {
+		return nil, err
 	}
 	err = r.db.SavedSearches().Delete(ctx, id)
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/saved_searches.go
+++ b/cmd/frontend/graphqlbackend/saved_searches.go
@@ -140,6 +140,10 @@ func (r *schemaResolver) CreateSavedSearch(ctx context.Context, args *struct {
 	OrgID       *graphql.ID
 	UserID      *graphql.ID
 }) (*savedSearchResolver, error) {
+	if args.UserID == nil {
+		return nil, errors.New("a saved search must have a user owner")
+	}
+
 	// 🚨 SECURITY: Make sure the current user has permission to create a saved search for the specified user or org.
 	uid, err := unmarshalSavedSearchID(*args.UserID)
 	if err != nil {
@@ -176,6 +180,10 @@ func (r *schemaResolver) UpdateSavedSearch(ctx context.Context, args *struct {
 	OrgID       *graphql.ID
 	UserID      *graphql.ID
 }) (*savedSearchResolver, error) {
+	if args.UserID == nil {
+		return nil, errors.New("a saved search must have a user owner")
+	}
+
 	// 🚨 SECURITY: Make sure the current user has permission to update a saved search for the specified user or org.
 	uid, err := unmarshalSavedSearchID(*args.UserID)
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/saved_searches_test.go
+++ b/cmd/frontend/graphqlbackend/saved_searches_test.go
@@ -22,7 +22,7 @@ func TestSavedSearches(t *testing.T) {
 
 	ss := dbmock.NewMockSavedSearchStore()
 	ss.ListSavedSearchesByUserIDFunc.SetDefaultHook(func(_ context.Context, userID int32) ([]*types.SavedSearch, error) {
-		return []*types.SavedSearch{{ID: key, Description: "test query", Query: "test type:diff patternType:regexp", Notify: true, NotifySlack: false, UserID: &userID, OrgID: nil}}, nil
+		return []*types.SavedSearch{{ID: key, Description: "test query", Query: "test type:diff patternType:regexp", Notify: true, NotifySlack: false, UserID: userID}}, nil
 	})
 
 	db := dbmock.NewMockDB()
@@ -39,8 +39,7 @@ func TestSavedSearches(t *testing.T) {
 		Query:       "test type:diff patternType:regexp",
 		Notify:      true,
 		NotifySlack: false,
-		UserID:      &key,
-		OrgID:       nil,
+		UserID:      key,
 	}}}
 	if !reflect.DeepEqual(savedSearches, want) {
 		t.Errorf("got %v+, want %v+", savedSearches[0], want[0])
@@ -61,12 +60,11 @@ func TestSavedSearchByIDOwner(t *testing.T) {
 		&api.SavedQuerySpecAndConfig{
 			Spec: api.SavedQueryIDSpec{},
 			Config: api.ConfigSavedQuery{
-				UserID:      &userID,
+				UserID:      userID,
 				Description: "test query",
 				Query:       "test type:diff patternType:regexp",
 				Notify:      true,
 				NotifySlack: false,
-				OrgID:       nil,
 			},
 		},
 		nil,
@@ -92,8 +90,7 @@ func TestSavedSearchByIDOwner(t *testing.T) {
 			Query:       "test type:diff patternType:regexp",
 			Notify:      true,
 			NotifySlack: false,
-			UserID:      &userID,
-			OrgID:       nil,
+			UserID:      userID,
 		},
 	}
 
@@ -116,12 +113,11 @@ func TestSavedSearchByIDNonOwner(t *testing.T) {
 		&api.SavedQuerySpecAndConfig{
 			Spec: api.SavedQueryIDSpec{},
 			Config: api.ConfigSavedQuery{
-				UserID:      &userID,
+				UserID:      userID,
 				Description: "test query",
 				Query:       "test type:diff patternType:regexp",
 				Notify:      true,
 				NotifySlack: false,
-				OrgID:       nil,
 			},
 		},
 		nil,
@@ -158,7 +154,6 @@ func TestCreateSavedSearch(t *testing.T) {
 			Notify:      newSavedSearch.Notify,
 			NotifySlack: newSavedSearch.NotifySlack,
 			UserID:      newSavedSearch.UserID,
-			OrgID:       newSavedSearch.OrgID,
 		}, nil
 	})
 
@@ -184,8 +179,7 @@ func TestCreateSavedSearch(t *testing.T) {
 		Query:       "test type:diff patternType:regexp",
 		Notify:      true,
 		NotifySlack: false,
-		OrgID:       nil,
-		UserID:      &key,
+		UserID:      key,
 	}}
 
 	mockrequire.Called(t, ss.CreateFunc)
@@ -224,7 +218,6 @@ func TestUpdateSavedSearch(t *testing.T) {
 			Notify:      savedSearch.Notify,
 			NotifySlack: savedSearch.NotifySlack,
 			UserID:      savedSearch.UserID,
-			OrgID:       savedSearch.OrgID,
 		}, nil
 	})
 
@@ -252,8 +245,7 @@ func TestUpdateSavedSearch(t *testing.T) {
 		Query:       "test type:diff patternType:regexp",
 		Notify:      true,
 		NotifySlack: false,
-		OrgID:       nil,
-		UserID:      &key,
+		UserID:      key,
 	}}
 
 	mockrequire.Called(t, ss.UpdateFunc)
@@ -296,8 +288,7 @@ func TestDeleteSavedSearch(t *testing.T) {
 			Query:       "test type:diff",
 			Notify:      true,
 			NotifySlack: false,
-			UserID:      &key,
-			OrgID:       nil,
+			UserID:      key,
 		},
 	}, nil)
 

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -165,13 +165,7 @@ func serveSavedQueriesListAll(db database.DB) func(w http.ResponseWriter, r *htt
 
 		queries := make([]api.SavedQuerySpecAndConfig, 0, len(settings))
 		for _, s := range settings {
-			var spec api.SavedQueryIDSpec
-			if s.Config.UserID != nil {
-				spec = api.SavedQueryIDSpec{Subject: api.SettingsSubject{User: s.Config.UserID}, Key: s.Config.Key}
-			} else if s.Config.OrgID != nil {
-				spec = api.SavedQueryIDSpec{Subject: api.SettingsSubject{Org: s.Config.OrgID}, Key: s.Config.Key}
-			}
-
+			spec := api.SavedQueryIDSpec{Subject: api.SettingsSubject{User: &s.Config.UserID}, Key: s.Config.Key}
 			queries = append(queries, api.SavedQuerySpecAndConfig{
 				Spec:   spec,
 				Config: s.Config,

--- a/cmd/query-runner/graphql.go
+++ b/cmd/query-runner/graphql.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"runtime"
+	"strconv"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -120,7 +121,7 @@ type gqlSearchResponse struct {
 	Errors []interface{}
 }
 
-func search(ctx context.Context, query string) (*gqlSearchResponse, error) {
+func search(ctx context.Context, query string, userID int32) (*gqlSearchResponse, error) {
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(graphQLQuery{
 		Query:     gqlSearchQuery,
@@ -142,6 +143,7 @@ func search(ctx context.Context, query string) (*gqlSearchResponse, error) {
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", "sourcegraph/query-runner")
+	req.Header.Set("X-Sourcegraph-User-ID", strconv.FormatInt(int64(userID), 10))
 
 	resp, err := httpcli.InternalDoer.Do(req.WithContext(ctx))
 	if err != nil {

--- a/cmd/query-runner/main.go
+++ b/cmd/query-runner/main.go
@@ -210,7 +210,7 @@ func (e *executorT) runQuery(ctx context.Context, spec api.SavedQueryIDSpec, que
 	// fails in order to avoid e.g. failed saved queries from executing
 	// constantly and potentially causing harm to the system. We'll retry at
 	// our normal interval, regardless of errors.
-	v, execDuration, searchErr := performSearch(ctx, newQuery)
+	v, execDuration, searchErr := performSearch(ctx, newQuery, query.UserID)
 	if err := api.InternalClient.SavedQueriesSetInfo(ctx, &api.SavedQueryInfo{
 		Query:        query.Query,
 		LastExecuted: time.Now(),
@@ -235,12 +235,12 @@ func (e *executorT) runQuery(ctx context.Context, spec api.SavedQueryIDSpec, que
 	return nil
 }
 
-func performSearch(ctx context.Context, query string) (v *gqlSearchResponse, execDuration time.Duration, err error) {
+func performSearch(ctx context.Context, query string, userID int32) (v *gqlSearchResponse, execDuration time.Duration, err error) {
 	attempts := 0
 	for {
 		// Query for search results.
 		start := time.Now()
-		v, err := search(ctx, query)
+		v, err := search(ctx, query, userID)
 		execDuration := time.Since(start)
 		if err != nil {
 			return nil, execDuration, errors.Wrap(err, "search")

--- a/cmd/query-runner/main.go
+++ b/cmd/query-runner/main.go
@@ -210,10 +210,7 @@ func (e *executorT) runQuery(ctx context.Context, spec api.SavedQueryIDSpec, que
 	// fails in order to avoid e.g. failed saved queries from executing
 	// constantly and potentially causing harm to the system. We'll retry at
 	// our normal interval, regardless of errors.
-	if query.UserID == nil {
-		return errors.New("user ID must be non-null")
-	}
-	v, execDuration, searchErr := performSearch(ctx, newQuery, *query.UserID)
+	v, execDuration, searchErr := performSearch(ctx, newQuery, query.UserID)
 	if err := api.InternalClient.SavedQueriesSetInfo(ctx, &api.SavedQueryInfo{
 		Query:        query.Query,
 		LastExecuted: time.Now(),

--- a/cmd/query-runner/main.go
+++ b/cmd/query-runner/main.go
@@ -210,7 +210,10 @@ func (e *executorT) runQuery(ctx context.Context, spec api.SavedQueryIDSpec, que
 	// fails in order to avoid e.g. failed saved queries from executing
 	// constantly and potentially causing harm to the system. We'll retry at
 	// our normal interval, regardless of errors.
-	v, execDuration, searchErr := performSearch(ctx, newQuery, query.UserID)
+	if query.UserID == nil {
+		return errors.New("user ID must be non-null")
+	}
+	v, execDuration, searchErr := performSearch(ctx, newQuery, *query.UserID)
 	if err := api.InternalClient.SavedQueriesSetInfo(ctx, &api.SavedQueryInfo{
 		Query:        query.Query,
 		LastExecuted: time.Now(),

--- a/enterprise/internal/codemonitors/background/graphql.go
+++ b/enterprise/internal/codemonitors/background/graphql.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"runtime"
+	"strconv"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -120,7 +121,7 @@ type gqlSearchResponse struct {
 	Errors []interface{}
 }
 
-func search(ctx context.Context, query string) (*gqlSearchResponse, error) {
+func search(ctx context.Context, query string, userID int32) (*gqlSearchResponse, error) {
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(graphQLQuery{
 		Query:     gqlSearchQuery,
@@ -141,6 +142,7 @@ func search(ctx context.Context, query string) (*gqlSearchResponse, error) {
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Sourcegraph-User-ID", strconv.FormatInt(int64(userID), 10))
 	resp, err := httpcli.InternalDoer.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, errors.Wrap(err, "Post")

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -147,16 +147,21 @@ func (r *queryRunner) Handle(ctx context.Context, record workerutil.Record) (err
 	}
 	defer func() { err = s.Done(err) }()
 
-	var q *cm.MonitorQuery
-	q, err = s.GetQueryByRecordID(ctx, record.RecordID())
+	q, err := s.GetQueryByRecordID(ctx, record.RecordID())
 	if err != nil {
 		return err
 	}
+
+	m, err := s.MonitorByIDInt64(ctx, q.Monitor)
+	if err != nil {
+		return err
+	}
+
 	newQuery := newQueryWithAfterFilter(q)
 
 	// Search.
 	var results *gqlSearchResponse
-	results, err = search(ctx, newQuery)
+	results, err = search(ctx, newQuery, m.NamespaceUserID)
 	if err != nil {
 		return err
 	}

--- a/internal/api/internal_client.go
+++ b/internal/api/internal_client.go
@@ -48,8 +48,7 @@ type ConfigSavedQuery struct {
 	Query           string  `json:"query"`
 	Notify          bool    `json:"notify,omitempty"`
 	NotifySlack     bool    `json:"notifySlack,omitempty"`
-	UserID          *int32  `json:"userID"`
-	OrgID           *int32  `json:"orgID"`
+	UserID          int32   `json:"userID"`
 	SlackWebhookURL *string `json:"slackWebhookURL"`
 }
 

--- a/internal/api/internal_client.go
+++ b/internal/api/internal_client.go
@@ -48,7 +48,7 @@ type ConfigSavedQuery struct {
 	Query           string  `json:"query"`
 	Notify          bool    `json:"notify,omitempty"`
 	NotifySlack     bool    `json:"notifySlack,omitempty"`
-	UserID          *int32  `json:"userID"`
+	UserID          int32  `json:"userID"`
 	OrgID           *int32  `json:"orgID"`
 	SlackWebhookURL *string `json:"slackWebhookURL"`
 }

--- a/internal/api/internal_client.go
+++ b/internal/api/internal_client.go
@@ -48,7 +48,7 @@ type ConfigSavedQuery struct {
 	Query           string  `json:"query"`
 	Notify          bool    `json:"notify,omitempty"`
 	NotifySlack     bool    `json:"notifySlack,omitempty"`
-	UserID          int32  `json:"userID"`
+	UserID          *int32  `json:"userID"`
 	OrgID           *int32  `json:"orgID"`
 	SlackWebhookURL *string `json:"slackWebhookURL"`
 }

--- a/internal/database/dbmock/savedsearchstore_mock.go
+++ b/internal/database/dbmock/savedsearchstore_mock.go
@@ -35,9 +35,6 @@ type MockSavedSearchStore struct {
 	// ListAllFunc is an instance of a mock function object controlling the
 	// behavior of the method ListAll.
 	ListAllFunc *SavedSearchStoreListAllFunc
-	// ListSavedSearchesByOrgIDFunc is an instance of a mock function object
-	// controlling the behavior of the method ListSavedSearchesByOrgID.
-	ListSavedSearchesByOrgIDFunc *SavedSearchStoreListSavedSearchesByOrgIDFunc
 	// ListSavedSearchesByUserIDFunc is an instance of a mock function
 	// object controlling the behavior of the method
 	// ListSavedSearchesByUserID.
@@ -88,11 +85,6 @@ func NewMockSavedSearchStore() *MockSavedSearchStore {
 				return nil, nil
 			},
 		},
-		ListSavedSearchesByOrgIDFunc: &SavedSearchStoreListSavedSearchesByOrgIDFunc{
-			defaultHook: func(context.Context, int32) ([]*types.SavedSearch, error) {
-				return nil, nil
-			},
-		},
 		ListSavedSearchesByUserIDFunc: &SavedSearchStoreListSavedSearchesByUserIDFunc{
 			defaultHook: func(context.Context, int32) ([]*types.SavedSearch, error) {
 				return nil, nil
@@ -138,9 +130,6 @@ func NewMockSavedSearchStoreFrom(i database.SavedSearchStore) *MockSavedSearchSt
 		},
 		ListAllFunc: &SavedSearchStoreListAllFunc{
 			defaultHook: i.ListAll,
-		},
-		ListSavedSearchesByOrgIDFunc: &SavedSearchStoreListSavedSearchesByOrgIDFunc{
-			defaultHook: i.ListSavedSearchesByOrgID,
 		},
 		ListSavedSearchesByUserIDFunc: &SavedSearchStoreListSavedSearchesByUserIDFunc{
 			defaultHook: i.ListSavedSearchesByUserID,
@@ -790,119 +779,6 @@ func (c SavedSearchStoreListAllFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c SavedSearchStoreListAllFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// SavedSearchStoreListSavedSearchesByOrgIDFunc describes the behavior when
-// the ListSavedSearchesByOrgID method of the parent MockSavedSearchStore
-// instance is invoked.
-type SavedSearchStoreListSavedSearchesByOrgIDFunc struct {
-	defaultHook func(context.Context, int32) ([]*types.SavedSearch, error)
-	hooks       []func(context.Context, int32) ([]*types.SavedSearch, error)
-	history     []SavedSearchStoreListSavedSearchesByOrgIDFuncCall
-	mutex       sync.Mutex
-}
-
-// ListSavedSearchesByOrgID delegates to the next hook function in the queue
-// and stores the parameter and result values of this invocation.
-func (m *MockSavedSearchStore) ListSavedSearchesByOrgID(v0 context.Context, v1 int32) ([]*types.SavedSearch, error) {
-	r0, r1 := m.ListSavedSearchesByOrgIDFunc.nextHook()(v0, v1)
-	m.ListSavedSearchesByOrgIDFunc.appendCall(SavedSearchStoreListSavedSearchesByOrgIDFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// ListSavedSearchesByOrgID method of the parent MockSavedSearchStore
-// instance is invoked and the hook queue is empty.
-func (f *SavedSearchStoreListSavedSearchesByOrgIDFunc) SetDefaultHook(hook func(context.Context, int32) ([]*types.SavedSearch, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// ListSavedSearchesByOrgID method of the parent MockSavedSearchStore
-// instance invokes the hook at the front of the queue and discards it.
-// After the queue is empty, the default hook function is invoked for any
-// future action.
-func (f *SavedSearchStoreListSavedSearchesByOrgIDFunc) PushHook(hook func(context.Context, int32) ([]*types.SavedSearch, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
-// the given values.
-func (f *SavedSearchStoreListSavedSearchesByOrgIDFunc) SetDefaultReturn(r0 []*types.SavedSearch, r1 error) {
-	f.SetDefaultHook(func(context.Context, int32) ([]*types.SavedSearch, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushDefaultHook with a function that returns the given
-// values.
-func (f *SavedSearchStoreListSavedSearchesByOrgIDFunc) PushReturn(r0 []*types.SavedSearch, r1 error) {
-	f.PushHook(func(context.Context, int32) ([]*types.SavedSearch, error) {
-		return r0, r1
-	})
-}
-
-func (f *SavedSearchStoreListSavedSearchesByOrgIDFunc) nextHook() func(context.Context, int32) ([]*types.SavedSearch, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *SavedSearchStoreListSavedSearchesByOrgIDFunc) appendCall(r0 SavedSearchStoreListSavedSearchesByOrgIDFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// SavedSearchStoreListSavedSearchesByOrgIDFuncCall objects describing the
-// invocations of this function.
-func (f *SavedSearchStoreListSavedSearchesByOrgIDFunc) History() []SavedSearchStoreListSavedSearchesByOrgIDFuncCall {
-	f.mutex.Lock()
-	history := make([]SavedSearchStoreListSavedSearchesByOrgIDFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// SavedSearchStoreListSavedSearchesByOrgIDFuncCall is an object that
-// describes an invocation of method ListSavedSearchesByOrgID on an instance
-// of MockSavedSearchStore.
-type SavedSearchStoreListSavedSearchesByOrgIDFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int32
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []*types.SavedSearch
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c SavedSearchStoreListSavedSearchesByOrgIDFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c SavedSearchStoreListSavedSearchesByOrgIDFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/database/saved_searches_test.go
+++ b/internal/database/saved_searches_test.go
@@ -39,8 +39,7 @@ func TestSavedSearchesIsEmpty(t *testing.T) {
 		Description: "test",
 		Notify:      true,
 		NotifySlack: true,
-		UserID:      &userID,
-		OrgID:       nil,
+		UserID:      userID,
 	}
 	_, err = SavedSearches(db).Create(ctx, fake)
 	if err != nil {
@@ -75,8 +74,7 @@ func TestSavedSearchesCreate(t *testing.T) {
 		Description: "test",
 		Notify:      true,
 		NotifySlack: true,
-		UserID:      &userID,
-		OrgID:       nil,
+		UserID:      userID,
 	}
 	ss, err := SavedSearches(db).Create(ctx, fake)
 	if err != nil {
@@ -92,8 +90,7 @@ func TestSavedSearchesCreate(t *testing.T) {
 		Description: "test",
 		Notify:      true,
 		NotifySlack: true,
-		UserID:      &userID,
-		OrgID:       nil,
+		UserID:      userID,
 	}
 	if !reflect.DeepEqual(ss, want) {
 		t.Errorf("query is '%v', want '%v'", ss, want)
@@ -118,8 +115,7 @@ func TestSavedSearchesUpdate(t *testing.T) {
 		Description: "test",
 		Notify:      true,
 		NotifySlack: true,
-		UserID:      &userID,
-		OrgID:       nil,
+		UserID:      userID,
 	}
 	_, err = SavedSearches(db).Create(ctx, fake)
 	if err != nil {
@@ -132,8 +128,7 @@ func TestSavedSearchesUpdate(t *testing.T) {
 		Description: "test2",
 		Notify:      true,
 		NotifySlack: true,
-		UserID:      &userID,
-		OrgID:       nil,
+		UserID:      userID,
 	}
 
 	updatedSearch, err := SavedSearches(db).Update(ctx, updated)
@@ -164,8 +159,7 @@ func TestSavedSearchesDelete(t *testing.T) {
 		Description: "test",
 		Notify:      true,
 		NotifySlack: true,
-		UserID:      &userID,
-		OrgID:       nil,
+		UserID:      userID,
 	}
 	_, err = SavedSearches(db).Create(ctx, fake)
 	if err != nil {
@@ -205,8 +199,7 @@ func TestSavedSearchesGetByUserID(t *testing.T) {
 		Description: "test",
 		Notify:      true,
 		NotifySlack: true,
-		UserID:      &userID,
-		OrgID:       nil,
+		UserID:      userID,
 	}
 	ss, err := SavedSearches(db).Create(ctx, fake)
 	if err != nil {
@@ -226,8 +219,7 @@ func TestSavedSearchesGetByUserID(t *testing.T) {
 		Description: "test",
 		Notify:      true,
 		NotifySlack: true,
-		UserID:      &userID,
-		OrgID:       nil,
+		UserID:      userID,
 	}}
 	if !reflect.DeepEqual(savedSearch, want) {
 		t.Errorf("query is '%v+', want '%v+'", savedSearch, want)
@@ -252,8 +244,7 @@ func TestSavedSearchesGetByID(t *testing.T) {
 		Description: "test",
 		Notify:      true,
 		NotifySlack: true,
-		UserID:      &userID,
-		OrgID:       nil,
+		UserID:      userID,
 	}
 	ss, err := SavedSearches(db).Create(ctx, fake)
 	if err != nil {
@@ -273,8 +264,7 @@ func TestSavedSearchesGetByID(t *testing.T) {
 		Description: "test",
 		Notify:      true,
 		NotifySlack: true,
-		UserID:      &userID,
-		OrgID:       nil,
+		UserID:      userID,
 	}}
 
 	if diff := cmp.Diff(want, savedSearch); diff != "" {
@@ -300,8 +290,7 @@ func TestListSavedSearchesByUserID(t *testing.T) {
 		Description: "test",
 		Notify:      true,
 		NotifySlack: true,
-		UserID:      &userID,
-		OrgID:       nil,
+		UserID:      userID,
 	}
 	ss, err := SavedSearches(db).Create(ctx, fake)
 	if err != nil {
@@ -310,56 +299,6 @@ func TestListSavedSearchesByUserID(t *testing.T) {
 
 	if ss == nil {
 		t.Fatalf("no saved search returned, create failed")
-	}
-
-	org1, err := Orgs(db).Create(ctx, "org1", nil)
-	if err != nil {
-		t.Fatal("can't create org1", err)
-	}
-	org2, err := Orgs(db).Create(ctx, "org2", nil)
-	if err != nil {
-		t.Fatal("can't create org2", err)
-	}
-
-	orgFake := &types.SavedSearch{
-		Query:       "test",
-		Description: "test",
-		Notify:      true,
-		NotifySlack: true,
-		UserID:      nil,
-		OrgID:       &org1.ID,
-	}
-	orgSearch, err := SavedSearches(db).Create(ctx, orgFake)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if orgSearch == nil {
-		t.Fatalf("no saved search returned, org saved search create failed")
-	}
-
-	org2Fake := &types.SavedSearch{
-		Query:       "test",
-		Description: "test",
-		Notify:      true,
-		NotifySlack: true,
-		UserID:      nil,
-		OrgID:       &org2.ID,
-	}
-	org2Search, err := SavedSearches(db).Create(ctx, org2Fake)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if org2Search == nil {
-		t.Fatalf("no saved search returned, org2 saved search create failed")
-	}
-
-	_, err = OrgMembers(db).Create(ctx, org1.ID, userID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = OrgMembers(db).Create(ctx, org2.ID, userID)
-	if err != nil {
-		t.Fatal(err)
 	}
 
 	savedSearches, err := SavedSearches(db).ListSavedSearchesByUserID(ctx, userID)
@@ -373,24 +312,7 @@ func TestListSavedSearchesByUserID(t *testing.T) {
 		Description: "test",
 		Notify:      true,
 		NotifySlack: true,
-		UserID:      &userID,
-		OrgID:       nil,
-	}, {
-		ID:          2,
-		Query:       "test",
-		Description: "test",
-		Notify:      true,
-		NotifySlack: true,
-		UserID:      nil,
-		OrgID:       &org1.ID,
-	}, {
-		ID:          3,
-		Query:       "test",
-		Description: "test",
-		Notify:      true,
-		NotifySlack: true,
-		UserID:      nil,
-		OrgID:       &org2.ID,
+		UserID:      userID,
 	}}
 
 	if !reflect.DeepEqual(savedSearches, want) {

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -461,7 +461,7 @@ Referenced by:
  changed_at        | timestamp with time zone |           | not null | now()
  changed_by        | integer                  |           | not null | 
  enabled           | boolean                  |           | not null | true
- namespace_user_id | integer                  |           |          | 
+ namespace_user_id | integer                  |           | not null | 
  namespace_org_id  | integer                  |           |          | 
 Indexes:
     "cm_monitors_pkey" PRIMARY KEY, btree (id)
@@ -477,6 +477,8 @@ Referenced by:
     TABLE "cm_webhooks" CONSTRAINT "cm_webhooks_monitor_fkey" FOREIGN KEY (monitor) REFERENCES cm_monitors(id) ON DELETE CASCADE
 
 ```
+
+**namespace_org_id**: DEPRECATED: code monitors cannot be owned by an org
 
 # Table "public.cm_queries"
 ```

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1934,7 +1934,7 @@ Indexes:
  updated_at        | timestamp with time zone |           | not null | now()
  notify_owner      | boolean                  |           | not null | 
  notify_slack      | boolean                  |           | not null | 
- user_id           | integer                  |           |          | 
+ user_id           | integer                  |           | not null | 
  org_id            | integer                  |           |          | 
  slack_webhook_url | text                     |           |          | 
 Indexes:
@@ -1946,6 +1946,8 @@ Foreign-key constraints:
     "saved_searches_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id)
 
 ```
+
+**org_id**: DEPRECATED: saved searches must be owned by a user
 
 # Table "public.schema_migrations"
 ```

--- a/internal/database/users_test.go
+++ b/internal/database/users_test.go
@@ -627,7 +627,7 @@ func TestUsers_Delete(t *testing.T) {
 			if _, err := SavedSearches(db).Create(ctx, &types.SavedSearch{
 				Description: "desc",
 				Query:       "foo",
-				UserID:      &user.ID,
+				UserID:      user.ID,
 			}); err != nil {
 				t.Fatal(err)
 			}

--- a/internal/types/saved_searches.go
+++ b/internal/types/saved_searches.go
@@ -7,7 +7,6 @@ type SavedSearch struct {
 	Query           string  // the literal search query to be ran
 	Notify          bool    // whether or not to notify the owner(s) of this saved search via email
 	NotifySlack     bool    // whether or not to notify the owner(s) of this saved search via Slack
-	UserID          *int32  // if non-nil, the owner is this user. UserID/OrgID are mutually exclusive.
-	OrgID           *int32  // if non-nil, the owner is this organization. UserID/OrgID are mutually exclusive.
+	UserID          int32   // the owner of the saved search
 	SlackWebhookURL *string // if non-nil && NotifySlack == true, indicates that this Slack webhook URL should be used instead of the owners default Slack webhook.
 }

--- a/migrations/frontend/1528395941_remove-org-monitors.down.sql
+++ b/migrations/frontend/1528395941_remove-org-monitors.down.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+-- Insert migration here. See README.md. Highlights:
+--  * Always use IF EXISTS. eg: DROP TABLE IF EXISTS global_dep_private;
+--  * All migrations must be backward-compatible. Old versions of Sourcegraph
+--    need to be able to read/write post migration.
+--  * Historically we advised against transactions since we thought the
+--    migrate library handled it. However, it does not! /facepalm
+
+COMMIT;

--- a/migrations/frontend/1528395941_remove-org-monitors.down.sql
+++ b/migrations/frontend/1528395941_remove-org-monitors.down.sql
@@ -1,10 +1,5 @@
 BEGIN;
 
--- Insert migration here. See README.md. Highlights:
---  * Always use IF EXISTS. eg: DROP TABLE IF EXISTS global_dep_private;
---  * All migrations must be backward-compatible. Old versions of Sourcegraph
---    need to be able to read/write post migration.
---  * Historically we advised against transactions since we thought the
---    migrate library handled it. However, it does not! /facepalm
-
+ALTER TABLE cm_monitors
+	ALTER COLUMN namespace_user_id DROP NOT NULL;
 COMMIT;

--- a/migrations/frontend/1528395941_remove-org-monitors.up.sql
+++ b/migrations/frontend/1528395941_remove-org-monitors.up.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+DELETE FROM cm_monitors WHERE namespace_user_id IS NULL;
+COMMENT ON COLUMN cm_monitors.namespace_org_id IS 'DEPRECATED: code monitors cannot be owned by an org';
+
+ALTER TABLE cm_monitors 
+	ALTER COLUMN namespace_user_id SET NOT NULL;
+
+COMMIT;

--- a/migrations/frontend/1528395942_remove-org-saved-searches.down.sql
+++ b/migrations/frontend/1528395942_remove-org-saved-searches.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE saved_searches
+	ALTER COLUMN user_id DROP NOT NULL;
+
+COMMIT;

--- a/migrations/frontend/1528395942_remove-org-saved-searches.up.sql
+++ b/migrations/frontend/1528395942_remove-org-saved-searches.up.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+DELETE FROM saved_searches WHERE user_id IS NULL;
+
+ALTER TABLE saved_searches
+	ALTER COLUMN user_id SET NOT NULL;
+
+COMMENT ON COLUMN saved_searches.org_id IS 'DEPRECATED: saved searches must be owned by a user';
+
+COMMIT;


### PR DESCRIPTION
This updates code monitors and saved searches to run with the owning user ID. Additionally, it removes the possibility for code monitors and saved searches to be owned by an organization rather than a user. 

This updates the database layer to not reference the deprecated org_id columns on both tables, but does not go as far as changing the graphql API to not accept org IDs. However, it will now error if an org ID rather than a user is given. 

We are removing support for org-owned saved searches and code monitors because there is no clear way to handle permissions for running a query "as" an org. Currently, we run code monitors as site admin, which can leak information about the existence of search results for repos that a user does not have access to. This PR changes it so we run as the user who created the code monitor, so a user can't get information about any repos they don't already have access to. 
