### PR TITLE
sg: add --pristine-limits flag

### DIFF
--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -38,6 +38,7 @@ var (
 
 	rootFlagSet         = flag.NewFlagSet("sg", flag.ExitOnError)
 	verboseFlag         = rootFlagSet.Bool("v", false, "verbose mode")
+	pristineLimitsFlag  = rootFlagSet.Bool("pristine-limits", false, "prevent sg to update the opened file limits")
 	configFlag          = rootFlagSet.String("config", defaultConfigFile, "configuration file")
 	overwriteConfigFlag = rootFlagSet.String("overwrite", defaultConfigOverwriteFile, "configuration overwrites file that is gitignored and can be used to, for example, add credentials")
 
@@ -185,10 +186,13 @@ func main() {
 
 	checkSgVersion()
 
-	// We always try to set this, since we often want to watch files, start commands, etc.
-	if err := setMaxOpenFiles(); err != nil {
-		fmt.Printf("failed to set max open files: %s\n", err)
-		os.Exit(1)
+	if !*pristineLimitsFlag {
+		// Unless asked otherwise, we always try to set this, since we
+		// often want to watch files, start commands, etc...
+		if err := setMaxOpenFiles(); err != nil {
+			fmt.Printf("failed to set max open files: %s\n", err)
+			os.Exit(1)
+		}
 	}
 
 	if err := rootCommand.Run(ctx); err != nil {

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -38,7 +38,7 @@ var (
 
 	rootFlagSet         = flag.NewFlagSet("sg", flag.ExitOnError)
 	verboseFlag         = rootFlagSet.Bool("v", false, "verbose mode")
-	pristineLimitsFlag  = rootFlagSet.Bool("pristine-limits", false, "prevent sg to update the opened file limits")
+	pristineLimitsFlag  = rootFlagSet.Bool("pristine-limits", false, "prevent sg from updating maximum open files limits")
 	configFlag          = rootFlagSet.String("config", defaultConfigFile, "configuration file")
 	overwriteConfigFlag = rootFlagSet.String("overwrite", defaultConfigOverwriteFile, "configuration overwrites file that is gitignored and can be used to, for example, add credentials")
 


### PR DESCRIPTION
On bare-metal agents, the limit adjusting code fails. Attempts have been
made to fix that over there, but frustratingly it's still failing.

This flag will circumvent the problem and will unblock work around the
logs uploading on the bare-metal agents.

