### PR TITLE
insights: use primary postgres for oob migration

### DIFF
--- a/enterprise/internal/insights/migration/migration.go
+++ b/enterprise/internal/insights/migration/migration.go
@@ -36,7 +36,7 @@ func NewMigrator(insightsDB dbutil.DB, postgresDB dbutil.DB) oobmigration.Migrat
 	return &migrator{
 		insightsDB:                 insightsDB,
 		postgresDB:                 postgresDB,
-		settingsMigrationJobsStore: store.NewSettingsMigrationJobsStore(insightsDB),
+		settingsMigrationJobsStore: store.NewSettingsMigrationJobsStore(postgresDB),
 		settingsStore:              database.Settings(postgresDB),
 		insightStore:               *store.NewInsightStore(insightsDB),
 		dashboardStore:             store.NewDashboardStore(insightsDB),


### PR DESCRIPTION
Using the primary postgres (pgsql) as the migration store instead of the codeinsights-db.