### PR TITLE
Update private repository detection logic for Gitlab and Github

### DIFF
--- a/client/browser/CHANGELOG.md
+++ b/client/browser/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to Sourcegraph [Browser Extensions](./README.md) are documen
 
 - Fix omnibox opening in wrong tab [#issues/23475](https://github.com/sourcegraph/sourcegraph/issues/23475), [#pull/27525](https://github.com/sourcegraph/sourcegraph/pull/27525)
 - Fix excessive "all websites" permissions for Safari [#issues/23542](https://github.com/sourcegraph/sourcegraph/issues/23542), [#pull/26832](https://github.com/sourcegraph/sourcegraph/pull/26832)
+- Fix excessive "all websites" permissions for Safari [#issues/23542](https://github.com/sourcegraph/sourcegraph/issues/23542) [#pull/26832](https://github.com/sourcegraph/sourcegraph/pull/26832)
+- Update private repository detection logic for Gitlab and Github [#issues/27382](https://github.com/sourcegraph/sourcegraph/issues/27382), [#pull/27779](https://github.com/sourcegraph/sourcegraph/pull/27779)
 
 ## Chrome / Firefox v21.11.8.1804, Safari v1.7
 

--- a/client/browser/CHANGELOG.md
+++ b/client/browser/CHANGELOG.md
@@ -15,7 +15,6 @@ All notable changes to Sourcegraph [Browser Extensions](./README.md) are documen
 
 - Fix omnibox opening in wrong tab [#issues/23475](https://github.com/sourcegraph/sourcegraph/issues/23475), [#pull/27525](https://github.com/sourcegraph/sourcegraph/pull/27525)
 - Fix excessive "all websites" permissions for Safari [#issues/23542](https://github.com/sourcegraph/sourcegraph/issues/23542), [#pull/26832](https://github.com/sourcegraph/sourcegraph/pull/26832)
-- Fix excessive "all websites" permissions for Safari [#issues/23542](https://github.com/sourcegraph/sourcegraph/issues/23542) [#pull/26832](https://github.com/sourcegraph/sourcegraph/pull/26832)
 - Update private repository detection logic for Gitlab and Github [#issues/27382](https://github.com/sourcegraph/sourcegraph/issues/27382), [#pull/27779](https://github.com/sourcegraph/sourcegraph/pull/27779)
 
 ## Chrome / Firefox v21.11.8.1804, Safari v1.7

--- a/client/browser/src/browser-extension/scripts/backgroundPage.main.ts
+++ b/client/browser/src/browser-extension/scripts/backgroundPage.main.ts
@@ -21,6 +21,7 @@ import addDomainPermissionToggle from 'webext-domain-permission-toggle'
 import { createExtensionHostWorker } from '@sourcegraph/shared/src/api/extension/worker'
 import { GraphQLResult, requestGraphQLCommon } from '@sourcegraph/shared/src/graphql/graphql'
 import { EndpointPair } from '@sourcegraph/shared/src/platform/context'
+import { fetchCache } from '@sourcegraph/shared/src/util/fetchCache'
 import { isDefined } from '@sourcegraph/shared/src/util/types'
 
 import { getHeaders } from '../../shared/backend/headers'
@@ -212,6 +213,8 @@ async function main(): Promise<void> {
         async checkPrivateCloudError(tabId: number): Promise<boolean> {
             return Promise.resolve(!!tabPrivateCloudErrorCache.getTabHasPrivateCloudError(tabId))
         },
+
+        fetchCache,
     }
 
     // Handle calls from other scripts

--- a/client/browser/src/browser-extension/web-extension-api/runtime.ts
+++ b/client/browser/src/browser-extension/web-extension-api/runtime.ts
@@ -21,4 +21,5 @@ export const background: BackgroundPageApi = {
     requestGraphQL: messageSender('requestGraphQL'),
     notifyPrivateCloudError: messageSender('notifyPrivateCloudError'),
     checkPrivateCloudError: messageSender('checkPrivateCloudError'),
+    fetchCache: messageSender('fetchCache'),
 }

--- a/client/browser/src/browser-extension/web-extension-api/types.ts
+++ b/client/browser/src/browser-extension/web-extension-api/types.ts
@@ -1,4 +1,5 @@
 import { GraphQLResult } from '@sourcegraph/shared/src/graphql/graphql'
+import { fetchCache } from '@sourcegraph/shared/src/util/fetchCache'
 
 import { OptionFlagValues } from '../../shared/util/optionFlags'
 
@@ -83,6 +84,7 @@ export interface BackgroundPageApi {
     }): Promise<GraphQLResult<T>>
     notifyPrivateCloudError(hasPrivateCloudError: boolean): Promise<void>
     checkPrivateCloudError(tabId: number): Promise<boolean>
+    fetchCache: typeof fetchCache
 }
 
 /**

--- a/client/browser/src/integration/github.test.ts
+++ b/client/browser/src/integration/github.test.ts
@@ -20,9 +20,7 @@ describe('GitHub', () => {
             await driver.setExtensionSourcegraphUrl()
         }
     })
-    after(() => {
-        driver?.close()
-    })
+    after(() => driver?.close())
 
     let testContext: BrowserIntegrationTestContext
     beforeEach(async function () {

--- a/client/browser/src/integration/github.test.ts
+++ b/client/browser/src/integration/github.test.ts
@@ -20,7 +20,9 @@ describe('GitHub', () => {
             await driver.setExtensionSourcegraphUrl()
         }
     })
-    after(() => driver?.close())
+    after(() => {
+        driver?.close()
+    })
 
     let testContext: BrowserIntegrationTestContext
     beforeEach(async function () {
@@ -36,6 +38,13 @@ describe('GitHub', () => {
         })
         testContext.server.any('https://api.github.com/_private/browser/*').intercept((request, response) => {
             response.sendStatus(200)
+        })
+
+        testContext.server.any('https://api.github.com/repos/*').intercept((request, response) => {
+            response
+                .status(200)
+                .setHeader('Access-Control-Allow-Origin', 'https://github.com')
+                .send(JSON.stringify({ visibility: 'private' }))
         })
 
         testContext.overrideGraphQL({

--- a/client/browser/src/shared/code-hosts/bitbucket-cloud/context.ts
+++ b/client/browser/src/shared/code-hosts/bitbucket-cloud/context.ts
@@ -1,14 +1,14 @@
 import { CodeHostContext } from '../shared/codeHost'
 import { RepoURLParseError } from '../shared/errors'
 
-export function getContext(): CodeHostContext {
+export async function getContext(): Promise<CodeHostContext> {
     const rawRepoName = getRawRepoName()
 
-    return {
+    return Promise.resolve({
         rawRepoName,
         revision: '',
         privateRepository: false,
-    }
+    })
 }
 
 export function getRawRepoName(): string {

--- a/client/browser/src/shared/code-hosts/bitbucket/context.tsx
+++ b/client/browser/src/shared/code-hosts/bitbucket/context.tsx
@@ -45,7 +45,7 @@ function getRevisionSpecFromRevisionSelector(): RevisionSpec {
     )
 }
 
-export function getContext(): CodeHostContext {
+export async function getContext(): Promise<CodeHostContext> {
     const repoSpec = getRawRepoSpecFromLocation(window.location)
     let revisionSpec: Partial<RevisionSpec> = {}
     try {
@@ -53,9 +53,9 @@ export function getContext(): CodeHostContext {
     } catch {
         // RevSpec is optional in CodeHostContext
     }
-    return {
+    return Promise.resolve({
         ...repoSpec,
         ...revisionSpec,
         privateRepository: window.location.hostname !== 'bitbucket.org',
-    }
+    })
 }

--- a/client/browser/src/shared/code-hosts/gerrit/codeHost.ts
+++ b/client/browser/src/shared/code-hosts/gerrit/codeHost.ts
@@ -368,13 +368,13 @@ export const gerritCodeHost: CodeHost = {
     codeViewsRequireTokenization: true,
     // This overrides the default observeMutations because we need to handle shadow DOMS.
     observeMutations,
-    getContext() {
+    getContext: async () => {
         const { repoName, changeId, patchsetId } = parseGerritChange()
-        return {
+        return Promise.resolve({
             privateRepository: true, // Gerrit is always private. Despite the fact that permissions can be set to be publicly viewable.
             rawRepoName: repoName,
             revision: patchsetId && buildGerritChangeString(changeId, patchsetId),
-        }
+        })
     },
     check: checkIsGerrit,
     notificationClassNames: { 1: '', 2: '', 3: '', 4: '', 5: '' },

--- a/client/browser/src/shared/code-hosts/github/__snapshots__/util.test.ts.snap
+++ b/client/browser/src/shared/code-hosts/github/__snapshots__/util.test.ts.snap
@@ -4,6 +4,7 @@ exports[`util parseURL() blob page 1`] = `
 Object {
   "pageType": "blob",
   "rawRepoName": "github.com/sourcegraph/sourcegraph",
+  "repoName": "sourcegraph/sourcegraph",
   "revisionAndFilePath": "3.3/shared/src/hover/HoverOverlay.tsx",
 }
 `;
@@ -12,6 +13,7 @@ exports[`util parseURL() branch name with forward slashes 1`] = `
 Object {
   "pageType": "blob",
   "rawRepoName": "ghe.sgdev.org/beyang/mux",
+  "repoName": "beyang/mux",
   "revisionAndFilePath": "jr/branch/mux.go",
 }
 `;
@@ -20,6 +22,7 @@ exports[`util parseURL() commit page 1`] = `
 Object {
   "pageType": "commit",
   "rawRepoName": "github.com/sourcegraph/sourcegraph",
+  "repoName": "sourcegraph/sourcegraph",
 }
 `;
 
@@ -27,6 +30,7 @@ exports[`util parseURL() compare page 1`] = `
 Object {
   "pageType": "compare",
   "rawRepoName": "github.com/sourcegraph/sourcegraph-basic-code-intel",
+  "repoName": "sourcegraph/sourcegraph-basic-code-intel",
 }
 `;
 
@@ -34,6 +38,7 @@ exports[`util parseURL() pull request list 1`] = `
 Object {
   "pageType": "other",
   "rawRepoName": "github.com/sourcegraph/sourcegraph",
+  "repoName": "sourcegraph/sourcegraph",
 }
 `;
 
@@ -41,6 +46,7 @@ exports[`util parseURL() pull request page 1`] = `
 Object {
   "pageType": "pull",
   "rawRepoName": "github.com/sourcegraph/sourcegraph",
+  "repoName": "sourcegraph/sourcegraph",
 }
 `;
 
@@ -48,6 +54,7 @@ exports[`util parseURL() selections - range 1`] = `
 Object {
   "pageType": "blob",
   "rawRepoName": "github.com/sourcegraph/sourcegraph",
+  "repoName": "sourcegraph/sourcegraph",
   "revisionAndFilePath": "master/jest.config.base.js",
 }
 `;
@@ -56,6 +63,7 @@ exports[`util parseURL() selections - single line 1`] = `
 Object {
   "pageType": "blob",
   "rawRepoName": "github.com/sourcegraph/sourcegraph",
+  "repoName": "sourcegraph/sourcegraph",
   "revisionAndFilePath": "master/jest.config.base.js",
 }
 `;
@@ -64,6 +72,7 @@ exports[`util parseURL() snippet permalink 1`] = `
 Object {
   "pageType": "blob",
   "rawRepoName": "github.com/sourcegraph/sourcegraph",
+  "repoName": "sourcegraph/sourcegraph",
   "revisionAndFilePath": "6a91ccec97a46bfb511b7ff58d790554a7d075c8/client/browser/src/shared/repo/backend.tsx",
 }
 `;
@@ -72,6 +81,7 @@ exports[`util parseURL() tree page 1`] = `
 Object {
   "pageType": "tree",
   "rawRepoName": "github.com/sourcegraph/sourcegraph",
+  "repoName": "sourcegraph/sourcegraph",
   "revisionAndFilePath": "master/client",
 }
 `;
@@ -80,5 +90,6 @@ exports[`util parseURL() wiki page 1`] = `
 Object {
   "pageType": "other",
   "rawRepoName": "github.com/sourcegraph/sourcegraph",
+  "repoName": "sourcegraph/sourcegraph",
 }
 `;

--- a/client/browser/src/shared/code-hosts/github/codeHost.test.ts
+++ b/client/browser/src/shared/code-hosts/github/codeHost.test.ts
@@ -200,11 +200,11 @@ describe('github/codeHost', () => {
 
 describe('isPrivateRepository', () => {
     beforeAll(() => {
-        fetchCache.disableCache()
+        fetchCache.disable()
     })
 
     afterAll(() => {
-        fetchCache.enableCache()
+        fetchCache.enable()
     })
 
     it('returns [true] if not on "github.com"', async () => {

--- a/client/browser/src/shared/code-hosts/github/codeHost.test.ts
+++ b/client/browser/src/shared/code-hosts/github/codeHost.test.ts
@@ -235,28 +235,28 @@ describe('isPrivateRepository', () => {
             window.location = location
         })
 
-        it('return [true] on unsuccessful request', async () => {
+        it('returns [true] on unsuccessful request', async () => {
             fetch.mockRejectOnce(new Error('Error happened'))
 
             expect(await isPrivateRepository('test-org/test-repo')).toBeTruthy()
             expect(fetch).toHaveBeenCalledTimes(1)
         })
 
-        it('return [true] if empty response', async () => {
+        it('returns [true] if empty response', async () => {
             fetch.mockResponseOnce(JSON.stringify({}))
 
             expect(await isPrivateRepository('test-org/test-repo')).toBeTruthy()
             expect(fetch).toHaveBeenCalledTimes(1)
         })
 
-        it('return [true] from response', async () => {
+        it('returns [true] from response', async () => {
             fetch.mockResponseOnce(JSON.stringify({ private: true }))
 
             expect(await isPrivateRepository('test-org/test-repo')).toBeTruthy()
             expect(fetch).toHaveBeenCalledTimes(1)
         })
 
-        it('return [false] from response', async () => {
+        it('returns [false] from response', async () => {
             fetch.mockResponseOnce(JSON.stringify({ private: false }))
 
             expect(await isPrivateRepository('test-org/test-repo')).toBeFalsy()

--- a/client/browser/src/shared/code-hosts/github/codeHost.ts
+++ b/client/browser/src/shared/code-hosts/github/codeHost.ts
@@ -368,6 +368,9 @@ const searchEnhancement: CodeHost['searchEnhancement'] = {
     },
 }
 
+/**
+ * See https://docs.github.com/en/rest/reference/repos#get-a-repository
+ */
 export const isPrivateRepository = (repoName: string): Promise<boolean> => {
     if (window.location.hostname !== 'github.com') {
         return Promise.resolve(true)

--- a/client/browser/src/shared/code-hosts/github/codeHost.ts
+++ b/client/browser/src/shared/code-hosts/github/codeHost.ts
@@ -390,9 +390,9 @@ export const isPrivateRepository = (
         .then(response => {
             const rateLimit = response.headers['x-ratelimit-remaining']
             if (Number(rateLimit) <= 0) {
-                const error = new Error('Github rate limit exceeded.')
-                Sentry.captureException(error)
-                throw error
+                const rateLimitError = new Error('Github rate limit exceeded.')
+                Sentry.captureException(rateLimitError)
+                throw rateLimitError
             }
             return response
         })

--- a/client/browser/src/shared/code-hosts/github/codeHost.ts
+++ b/client/browser/src/shared/code-hosts/github/codeHost.ts
@@ -368,8 +368,7 @@ const searchEnhancement: CodeHost['searchEnhancement'] = {
     },
 }
 
-// NOTE: check success/error reponses
-const isPrivateRepository = (repoName: string): Promise<boolean> => {
+export const isPrivateRepository = (repoName: string): Promise<boolean> => {
     if (window.location.hostname !== 'github.com') {
         return Promise.resolve(true)
     }

--- a/client/browser/src/shared/code-hosts/github/util.tsx
+++ b/client/browser/src/shared/code-hosts/github/util.tsx
@@ -1,4 +1,4 @@
-import { RawRepoSpec } from '@sourcegraph/shared/src/util/url'
+import { RawRepoSpec, RepoSpec } from '@sourcegraph/shared/src/util/url'
 
 import { DiffResolvedRevisionSpec } from '../../repo'
 import { RepoURLParseError } from '../shared/errors'
@@ -225,6 +225,7 @@ export function getFilePath(): string {
 }
 
 type GitHubURL = RawRepoSpec &
+    RepoSpec &
     (
         | { pageType: 'commit' | 'pull' | 'compare' | 'other' }
         | {
@@ -251,7 +252,8 @@ export function parseURL(location: Pick<Location, 'host' | 'pathname' | 'href'> 
     if (!user || !ghRepoName) {
         throw new RepoURLParseError(`Could not parse repoName from GitHub url: ${location.href}`)
     }
-    const rawRepoName = `${host}/${user}/${ghRepoName}`
+    const repoName = `${user}/${ghRepoName}`
+    const rawRepoName = `${host}/${repoName}`
     switch (pageType) {
         case 'blob':
         case 'tree':
@@ -259,12 +261,13 @@ export function parseURL(location: Pick<Location, 'host' | 'pathname' | 'href'> 
                 pageType,
                 rawRepoName,
                 revisionAndFilePath: decodeURIComponent(rest.join('/')),
+                repoName,
             }
         case 'pull':
         case 'commit':
         case 'compare':
-            return { pageType, rawRepoName }
+            return { pageType, rawRepoName, repoName }
         default:
-            return { pageType: 'other', rawRepoName }
+            return { pageType: 'other', rawRepoName, repoName }
     }
 }

--- a/client/browser/src/shared/code-hosts/gitlab/codeHost.test.ts
+++ b/client/browser/src/shared/code-hosts/gitlab/codeHost.test.ts
@@ -1,8 +1,11 @@
+import fetch from 'jest-fetch-mock'
 import { readFile } from 'mz/fs'
+
+import { fetchCache } from '@sourcegraph/shared/src/util/fetchCache'
 
 import { testCodeHostMountGetters as testMountGetters, testToolbarMountGetter } from '../shared/codeHostTestUtils'
 
-import { getToolbarMount, gitlabCodeHost } from './codeHost'
+import { getToolbarMount, gitlabCodeHost, isPrivateRepository } from './codeHost'
 
 describe('gitlab/codeHost', () => {
     describe('gitlabCodeHost', () => {
@@ -102,6 +105,78 @@ describe('gitlab/codeHost', () => {
             ).toBe(
                 'https://gitlab.com/sourcegraph/jsonrpc2/merge_requests/1/diffs#9e1d3828a925c1eca74b74c20b58a9138f886d29_3_5'
             )
+        })
+    })
+})
+
+describe.only('isPrivateRepository', () => {
+    beforeAll(() => {
+        fetchCache.disableCache()
+    })
+
+    afterAll(() => {
+        fetchCache.enableCache()
+    })
+
+    it('returns [true] if not on "gitlab.com"', async () => {
+        expect(await isPrivateRepository('test-org/test-repo')).toBeTruthy()
+    })
+
+    describe('when on "gitlab.com"', () => {
+        const { location } = window
+
+        beforeAll(() => {
+            fetch.enableMocks()
+
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            delete window.location
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            window.location = new URL('https://gitlab.com')
+        })
+
+        beforeEach(() => {
+            fetch.mockClear()
+        })
+
+        afterAll(() => {
+            fetch.disableMocks()
+
+            window.location = location
+        })
+
+        it('return [true] on unsuccessful request', async () => {
+            fetch.mockRejectOnce(new Error('Error happened'))
+
+            expect(await isPrivateRepository('test-org/test-repo')).toBeTruthy()
+            expect(fetch).toHaveBeenCalledTimes(1)
+        })
+
+        it('return [true] if empty response', async () => {
+            fetch.mockResponseOnce(JSON.stringify({}))
+
+            expect(await isPrivateRepository('test-org/test-repo')).toBeTruthy()
+            expect(fetch).toHaveBeenCalledTimes(1)
+        })
+
+        it('return [true] from response', async () => {
+            fetch.mockResponseOnce(JSON.stringify({ visibility: 'private' }))
+
+            expect(await isPrivateRepository('test-org/test-repo')).toBeTruthy()
+
+            fetch.mockResponseOnce(JSON.stringify({ visibility: 'internal' }))
+
+            expect(await isPrivateRepository('test-org/test-repo')).toBeTruthy()
+
+            expect(fetch).toHaveBeenCalledTimes(2)
+        })
+
+        it('return [false] from response', async () => {
+            fetch.mockResponseOnce(JSON.stringify({ visibility: 'public' }))
+
+            expect(await isPrivateRepository('test-org/test-repo')).toBeFalsy()
+            expect(fetch).toHaveBeenCalledTimes(1)
         })
     })
 })

--- a/client/browser/src/shared/code-hosts/gitlab/codeHost.test.ts
+++ b/client/browser/src/shared/code-hosts/gitlab/codeHost.test.ts
@@ -146,21 +146,21 @@ describe('isPrivateRepository', () => {
             window.location = location
         })
 
-        it('returns [true] on unsuccessful request', async () => {
+        it('returns [private=true] on unsuccessful request', async () => {
             fetch.mockRejectOnce(new Error('Error happened'))
 
             expect(await isPrivateRepository('test-org/test-repo', fetchCache)).toBeTruthy()
             expect(fetch).toHaveBeenCalledTimes(1)
         })
 
-        it('returns [true] if empty response', async () => {
+        it('returns [private=true] if empty response', async () => {
             fetch.mockResponseOnce(JSON.stringify({}))
 
             expect(await isPrivateRepository('test-org/test-repo', fetchCache)).toBeTruthy()
             expect(fetch).toHaveBeenCalledTimes(1)
         })
 
-        it('returns [true] if rate-limit exceeded', async () => {
+        it('returns [private=true] if rate-limit exceeded', async () => {
             fetch.mockResponseOnce(
                 JSON.stringify({
                     visibility: 'public',
@@ -174,23 +174,17 @@ describe('isPrivateRepository', () => {
             expect(fetch).toHaveBeenCalledTimes(1)
         })
 
-        it('returns [true] from response', async () => {
+        it('returns correctly from API response', async () => {
             fetch.mockResponseOnce(JSON.stringify({ visibility: 'private' }))
-
             expect(await isPrivateRepository('test-org/test-repo', fetchCache)).toBeTruthy()
 
             fetch.mockResponseOnce(JSON.stringify({ visibility: 'internal' }))
-
             expect(await isPrivateRepository('test-org/test-repo', fetchCache)).toBeTruthy()
 
-            expect(fetch).toHaveBeenCalledTimes(2)
-        })
-
-        it('returns [false] from response', async () => {
             fetch.mockResponseOnce(JSON.stringify({ visibility: 'public' }))
-
             expect(await isPrivateRepository('test-org/test-repo', fetchCache)).toBeFalsy()
-            expect(fetch).toHaveBeenCalledTimes(1)
+
+            expect(fetch).toHaveBeenCalledTimes(3)
         })
     })
 })

--- a/client/browser/src/shared/code-hosts/gitlab/codeHost.test.ts
+++ b/client/browser/src/shared/code-hosts/gitlab/codeHost.test.ts
@@ -111,11 +111,11 @@ describe('gitlab/codeHost', () => {
 
 describe('isPrivateRepository', () => {
     beforeAll(() => {
-        fetchCache.disableCache()
+        fetchCache.disable()
     })
 
     afterAll(() => {
-        fetchCache.enableCache()
+        fetchCache.enable()
     })
 
     it('returns [true] if not on "gitlab.com"', async () => {

--- a/client/browser/src/shared/code-hosts/gitlab/codeHost.test.ts
+++ b/client/browser/src/shared/code-hosts/gitlab/codeHost.test.ts
@@ -109,7 +109,7 @@ describe('gitlab/codeHost', () => {
     })
 })
 
-describe.only('isPrivateRepository', () => {
+describe('isPrivateRepository', () => {
     beforeAll(() => {
         fetchCache.disableCache()
     })
@@ -146,21 +146,21 @@ describe.only('isPrivateRepository', () => {
             window.location = location
         })
 
-        it('return [true] on unsuccessful request', async () => {
+        it('returns [true] on unsuccessful request', async () => {
             fetch.mockRejectOnce(new Error('Error happened'))
 
             expect(await isPrivateRepository('test-org/test-repo')).toBeTruthy()
             expect(fetch).toHaveBeenCalledTimes(1)
         })
 
-        it('return [true] if empty response', async () => {
+        it('returns [true] if empty response', async () => {
             fetch.mockResponseOnce(JSON.stringify({}))
 
             expect(await isPrivateRepository('test-org/test-repo')).toBeTruthy()
             expect(fetch).toHaveBeenCalledTimes(1)
         })
 
-        it('return [true] from response', async () => {
+        it('returns [true] from response', async () => {
             fetch.mockResponseOnce(JSON.stringify({ visibility: 'private' }))
 
             expect(await isPrivateRepository('test-org/test-repo')).toBeTruthy()
@@ -172,7 +172,7 @@ describe.only('isPrivateRepository', () => {
             expect(fetch).toHaveBeenCalledTimes(2)
         })
 
-        it('return [false] from response', async () => {
+        it('returns [false] from response', async () => {
             fetch.mockResponseOnce(JSON.stringify({ visibility: 'public' }))
 
             expect(await isPrivateRepository('test-org/test-repo')).toBeFalsy()

--- a/client/browser/src/shared/code-hosts/gitlab/codeHost.ts
+++ b/client/browser/src/shared/code-hosts/gitlab/codeHost.ts
@@ -2,6 +2,7 @@ import { Omit } from 'utility-types'
 
 import { NotificationType } from '@sourcegraph/shared/src/api/extension/extensionHostApi'
 import { fetchCache } from '@sourcegraph/shared/src/util/fetchCache'
+import { subtypeOf } from '@sourcegraph/shared/src/util/types'
 import { toAbsoluteBlobURL } from '@sourcegraph/shared/src/util/url'
 
 import { CodeHost } from '../shared/codeHost'
@@ -143,7 +144,7 @@ export const isPrivateRepository = (projectId?: string): Promise<boolean> => {
         })
 }
 
-export const gitlabCodeHost: CodeHost = {
+export const gitlabCodeHost = subtypeOf<CodeHost>()({
     type: 'gitlab',
     name: 'GitLab',
     check: checkIsGitlab,
@@ -231,4 +232,4 @@ export const gitlabCodeHost: CodeHost = {
         }
         return null
     },
-}
+})

--- a/client/browser/src/shared/code-hosts/gitlab/codeHost.ts
+++ b/client/browser/src/shared/code-hosts/gitlab/codeHost.ts
@@ -132,7 +132,10 @@ const notificationClassNames = {
 }
 
 /**
- * See https://docs.gitlab.com/ee/api/projects.html#get-single-project
+ * Checks whether repository is private or not using Gitlab API
+ *
+ * @description see https://docs.gitlab.com/ee/api/projects.html#get-single-project
+ * @description see rate limit https://docs.gitlab.com/ee/user/admin_area/settings/user_and_ip_rate_limits.html#response-headers
  */
 export const isPrivateRepository = (projectId?: string, fetchCache = background.fetchCache): Promise<boolean> => {
     if (window.location.hostname !== 'gitlab.com' || !projectId) {
@@ -143,7 +146,6 @@ export const isPrivateRepository = (projectId?: string, fetchCache = background.
         cacheMaxAge: 60 * 60 * 1000, // 1 hour
     })
         .then(response => {
-            // See https://docs.gitlab.com/ee/user/admin_area/settings/user_and_ip_rate_limits.html#response-headers TODO:
             const rateLimit = response.headers['ratelimit-remaining']
             if (Number(rateLimit) <= 0) {
                 throw new Error('Gitlab rate limit exceeded.')

--- a/client/browser/src/shared/code-hosts/gitlab/codeHost.ts
+++ b/client/browser/src/shared/code-hosts/gitlab/codeHost.ts
@@ -148,13 +148,14 @@ export const isPrivateRepository = (projectId?: string, fetchCache = background.
         .then(response => {
             const rateLimit = response.headers['ratelimit-remaining']
             if (Number(rateLimit) <= 0) {
-                throw new Error('Gitlab rate limit exceeded.')
+                const rateLimitError = new Error('Gitlab rate limit exceeded.')
+                Sentry.captureException(rateLimitError)
+                throw rateLimitError
             }
             return response
         })
         .then(({ data }) => data?.visibility !== 'public')
         .catch(error => {
-            Sentry.captureException(error)
             console.warn('Failed to fetch repository visibility info.', error)
             return true
         })

--- a/client/browser/src/shared/code-hosts/gitlab/codeHost.ts
+++ b/client/browser/src/shared/code-hosts/gitlab/codeHost.ts
@@ -130,6 +130,9 @@ const notificationClassNames = {
     [NotificationType.Error]: 'alert alert-danger',
 }
 
+/**
+ * See https://docs.gitlab.com/ee/api/projects.html#get-single-project
+ */
 export const isPrivateRepository = (projectId?: string): Promise<boolean> => {
     if (window.location.hostname !== 'gitlab.com' || !projectId) {
         return Promise.resolve(true)

--- a/client/browser/src/shared/code-hosts/gitlab/codeHost.ts
+++ b/client/browser/src/shared/code-hosts/gitlab/codeHost.ts
@@ -129,7 +129,6 @@ const notificationClassNames = {
     [NotificationType.Error]: 'alert alert-danger',
 }
 
-// NOTE: check success/error responses
 export const isPrivateRepository = (projectId?: string): Promise<boolean> => {
     if (window.location.hostname !== 'gitlab.com' || !projectId) {
         return Promise.resolve(true)

--- a/client/browser/src/shared/code-hosts/gitlab/scrape.ts
+++ b/client/browser/src/shared/code-hosts/gitlab/scrape.ts
@@ -21,6 +21,7 @@ export interface GitLabInfo extends RawRepoSpec {
 
     owner: string
     projectName: string
+    projectId?: string
 }
 
 /**
@@ -64,11 +65,14 @@ export function getPageInfo(): GitLabInfo {
     const pageKind = getPageKindFromPathName(owner, projectName, window.location.pathname)
     const hostname = isExtension ? window.location.hostname : new URL(gon.gitlab_url).hostname
 
+    const projectId = document.querySelector<HTMLInputElement>('#search_project_id')?.value
+
     return {
         owner,
         projectName,
         rawRepoName: [hostname, owner, projectName].join('/'),
         pageKind,
+        projectId,
     }
 }
 

--- a/client/browser/src/shared/code-hosts/shared/ViewOnSourcegraphButton.test.tsx
+++ b/client/browser/src/shared/code-hosts/shared/ViewOnSourcegraphButton.test.tsx
@@ -14,7 +14,7 @@ describe('<ViewOnSourcegraphButton />', () => {
                     <ViewOnSourcegraphButton
                         codeHostType="test-codehost"
                         sourcegraphURL="https://test.com"
-                        getContext={() => ({ rawRepoName: 'test', privateRepository: false })}
+                        context={{ rawRepoName: 'test', privateRepository: false }}
                         className="test"
                         repoExistsOrError={true}
                         minimalUI={false}
@@ -30,7 +30,7 @@ describe('<ViewOnSourcegraphButton />', () => {
                     <ViewOnSourcegraphButton
                         codeHostType="test-codehost"
                         sourcegraphURL="https://test.com"
-                        getContext={() => ({ rawRepoName: 'test', privateRepository: false })}
+                        context={{ rawRepoName: 'test', privateRepository: false }}
                         className="test"
                         repoExistsOrError={true}
                         minimalUI={true}
@@ -46,11 +46,11 @@ describe('<ViewOnSourcegraphButton />', () => {
                     <ViewOnSourcegraphButton
                         codeHostType="test-codehost"
                         sourcegraphURL="https://test.com"
-                        getContext={() => ({
+                        context={{
                             rawRepoName: 'test',
                             revision: 'test',
                             privateRepository: false,
-                        })}
+                        }}
                         className="test"
                         repoExistsOrError={true}
                         minimalUI={false}
@@ -68,11 +68,11 @@ describe('<ViewOnSourcegraphButton />', () => {
                     <ViewOnSourcegraphButton
                         codeHostType="test-codehost"
                         sourcegraphURL="https://sourcegraph.com"
-                        getContext={() => ({
+                        context={{
                             rawRepoName: 'test',
                             revision: 'test',
                             privateRepository: false,
-                        })}
+                        }}
                         className="test"
                         repoExistsOrError={false}
                         onConfigureSourcegraphClick={noop}
@@ -89,11 +89,11 @@ describe('<ViewOnSourcegraphButton />', () => {
                     <ViewOnSourcegraphButton
                         codeHostType="test-codehost"
                         sourcegraphURL="https://sourcegraph.test"
-                        getContext={() => ({
+                        context={{
                             rawRepoName: 'test',
                             revision: 'test',
                             privateRepository: false,
-                        })}
+                        }}
                         className="test"
                         repoExistsOrError={false}
                         onConfigureSourcegraphClick={noop}
@@ -115,11 +115,11 @@ describe('<ViewOnSourcegraphButton />', () => {
                                 <ViewOnSourcegraphButton
                                     codeHostType="test-codehost"
                                     sourcegraphURL="https://test.com"
-                                    getContext={() => ({
+                                    context={{
                                         rawRepoName: 'test',
                                         revision: 'test',
                                         privateRepository: false,
-                                    })}
+                                    }}
                                     showSignInButton={true}
                                     className="test"
                                     repoExistsOrError={new HTTPStatusError(new Response('', { status: 401 }))}
@@ -140,11 +140,11 @@ describe('<ViewOnSourcegraphButton />', () => {
                         <ViewOnSourcegraphButton
                             codeHostType="test-codehost"
                             sourcegraphURL="https://test.com"
-                            getContext={() => ({
+                            context={{
                                 rawRepoName: 'test',
                                 revision: 'test',
                                 privateRepository: false,
-                            })}
+                            }}
                             showSignInButton={true}
                             className="test"
                             repoExistsOrError={new Error('Something unknown happened!')}

--- a/client/browser/src/shared/code-hosts/shared/ViewOnSourcegraphButton.tsx
+++ b/client/browser/src/shared/code-hosts/shared/ViewOnSourcegraphButton.tsx
@@ -18,7 +18,7 @@ export interface ViewOnSourcegraphButtonClassProps {
 
 interface ViewOnSourcegraphButtonProps extends ViewOnSourcegraphButtonClassProps {
     codeHostType: string
-    getContext: () => CodeHostContext
+    context: CodeHostContext
     sourcegraphURL: string
     minimalUI: boolean
     repoExistsOrError?: boolean | ErrorLike
@@ -38,7 +38,7 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphB
     codeHostType,
     repoExistsOrError,
     sourcegraphURL,
-    getContext,
+    context,
     minimalUI,
     onConfigureSourcegraphClick,
     showSignInButton,
@@ -54,7 +54,7 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphB
         iconClassName,
     }
 
-    const { rawRepoName, revision, privateRepository } = getContext()
+    const { rawRepoName, revision, privateRepository } = context
 
     const isPrivateCloudError =
         sourcegraphURL === DEFAULT_SOURCEGRAPH_URL && repoExistsOrError === false && privateRepository

--- a/client/shared/src/util/fetchCache.test.ts
+++ b/client/shared/src/util/fetchCache.test.ts
@@ -1,43 +1,76 @@
 import fetch from 'jest-fetch-mock'
+import MockDate from 'mockdate'
 
-import { fetchCache } from './fetchCache'
+import { fetchCache, FetchCacheReturnType } from './fetchCache'
+
+const EXPECTED_DATA = { foo: { bar: 'baz' } }
+const TEST_URL = '/test/api'
+
+const expectResponses = (responses: [FetchCacheReturnType<any>, FetchCacheReturnType<any>]): void => {
+    for (const actualResponse of responses) {
+        expect(actualResponse.data).toEqual(EXPECTED_DATA)
+    }
+}
 
 describe('memoizedFetch', () => {
     beforeAll(() => {
         fetch.enableMocks()
+        MockDate.reset()
     })
 
     beforeEach(() => {
         fetch.mockClear()
+        fetchCache.clear()
+        fetch.mockResponse(JSON.stringify(EXPECTED_DATA))
     })
 
     afterAll(() => {
         fetch.disableMocks()
     })
 
-    it('makes only single request for similar requests', async () => {
-        const expectedData = { foo: { bar: 'baz' } }
-        fetch.mockResponseOnce(JSON.stringify(expectedData))
+    it('makes single request for similar [...args]', async () => {
+        const responses = await Promise.all([fetchCache(1, TEST_URL), fetchCache(1, TEST_URL)])
 
-        const testUrl = '/test/api'
-        const responses = await Promise.all([fetchCache(testUrl), fetchCache(testUrl)])
-
-        for (const actualResponse of responses) {
-            expect(actualResponse.data).toEqual(expectedData)
-        }
+        expectResponses(responses)
         expect(fetch).toHaveBeenCalledTimes(1)
     })
 
-    it('makes multiple requests for different requests', async () => {
-        const expectedData = { foo: { bar: 'baz' } }
+    it('makes single request for similar [...args] with different maxAge', async () => {
+        const responses = await Promise.all([fetchCache(100, TEST_URL), fetchCache(1, TEST_URL)])
 
-        fetch.mockResponse(JSON.stringify(expectedData))
+        expectResponses(responses)
+        expect(fetch).toHaveBeenCalledTimes(1)
+    })
 
-        const responses = await Promise.all([fetchCache('/test/one'), fetchCache('/test/two')])
+    it('makes multiple requests when cache item is expired', async () => {
+        const responseOne = await fetchCache(1, TEST_URL)
+        await new Promise(resolve => setTimeout(resolve, 3))
+        const responseTwo = await fetchCache(1, TEST_URL)
 
-        for (const actualResponse of responses) {
-            expect(actualResponse.data).toEqual(expectedData)
-        }
+        expectResponses([responseOne, responseTwo])
         expect(fetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('makes multiple requests for different [...args]', async () => {
+        const responses = await Promise.all([fetchCache(1, '/test/api-1'), fetchCache(1, '/test/api-2')])
+
+        expectResponses(responses)
+        expect(fetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('makes multiple requests when (timeout = 0)', async () => {
+        const responses = await Promise.all([fetchCache(0, TEST_URL), fetchCache(0, TEST_URL)])
+
+        expectResponses(responses)
+        expect(fetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('makes multiple requests when caching is disabled', async () => {
+        fetchCache.disable()
+        const responses = await Promise.all([fetchCache(1, TEST_URL), fetchCache(1, TEST_URL)])
+
+        expectResponses(responses)
+        expect(fetch).toHaveBeenCalledTimes(2)
+        fetchCache.enable()
     })
 })

--- a/client/shared/src/util/fetchCache.test.ts
+++ b/client/shared/src/util/fetchCache.test.ts
@@ -1,18 +1,18 @@
 import fetch from 'jest-fetch-mock'
 import MockDate from 'mockdate'
 
-import { clearFetchCache, disableFetchCache, enableFetchCache, fetchCache, FetchCacheReturnType } from './fetchCache'
+import { clearFetchCache, disableFetchCache, enableFetchCache, fetchCache, FetchCacheResponse } from './fetchCache'
 
 const EXPECTED_DATA = { foo: { bar: 'baz' } }
 const TEST_URL = '/test/api'
 
-const expectResponses = (responses: [FetchCacheReturnType<any>, FetchCacheReturnType<any>]): void => {
+const expectResponses = (responses: FetchCacheResponse<any>[]): void => {
     for (const actualResponse of responses) {
         expect(actualResponse.data).toEqual(EXPECTED_DATA)
     }
 }
 
-describe('memoizedFetch', () => {
+describe('fetchCache', () => {
     beforeAll(() => {
         fetch.enableMocks()
         MockDate.reset()
@@ -30,44 +30,49 @@ describe('memoizedFetch', () => {
 
     it('makes single request for similar [...args]', async () => {
         const responses = await Promise.all([
-            fetchCache({ cacheMaxAge: 1, url: TEST_URL }),
-            fetchCache({ cacheMaxAge: 1, url: TEST_URL }),
-        ])
-
-        expectResponses(responses)
-        expect(fetch).toHaveBeenCalledTimes(1)
-    })
-
-    it('makes single request for similar [...args] with different maxAge', async () => {
-        const responses = await Promise.all([
             fetchCache({ cacheMaxAge: 100, url: TEST_URL }),
-            fetchCache({ cacheMaxAge: 1, url: TEST_URL }),
+            fetchCache({ cacheMaxAge: 500, url: TEST_URL }),
+            fetchCache({ cacheMaxAge: 1000, url: TEST_URL }),
         ])
 
         expectResponses(responses)
         expect(fetch).toHaveBeenCalledTimes(1)
     })
 
-    it('makes multiple requests when cache item is expired', async () => {
+    it('makes multiple requests for different [...args]', async () => {
+        const responses = await Promise.all([
+            fetchCache({ cacheMaxAge: 100, url: '/test/api-1' }),
+            fetchCache({ cacheMaxAge: 100, url: '/test/api-2' }),
+        ])
+
+        expectResponses(responses)
+        expect(fetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('makes multiple requests in case of fetch error', async () => {
+        expect.assertions(3)
+
+        fetch.mockRejectOnce(new Error('Some error'))
+        await fetchCache({ cacheMaxAge: 100, url: TEST_URL }).catch(error => expect(error).toBeTruthy())
+
+        await new Promise(resolve => setTimeout(resolve, 0))
+
+        const response = await fetchCache({ cacheMaxAge: 100, url: TEST_URL })
+        expect(response.data).toEqual(EXPECTED_DATA)
+
+        expect(fetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('makes multiple requests in case of cache expiration', async () => {
         const responseOne = await fetchCache({ cacheMaxAge: 1, url: TEST_URL })
-        await new Promise(resolve => setTimeout(resolve, 3))
+        await new Promise(resolve => setTimeout(resolve, 3)) // 3 millis passed
         const responseTwo = await fetchCache({ cacheMaxAge: 1, url: TEST_URL })
 
         expectResponses([responseOne, responseTwo])
         expect(fetch).toHaveBeenCalledTimes(2)
     })
 
-    it('makes multiple requests for different [...args]', async () => {
-        const responses = await Promise.all([
-            fetchCache({ cacheMaxAge: 1, url: '/test/api-1' }),
-            fetchCache({ cacheMaxAge: 1, url: '/test/api-2' }),
-        ])
-
-        expectResponses(responses)
-        expect(fetch).toHaveBeenCalledTimes(2)
-    })
-
-    it('makes multiple requests when (timeout = 0)', async () => {
+    it('makes multiple requests if [cacheMaxAge=0]', async () => {
         const responses = await Promise.all([
             fetchCache({ cacheMaxAge: 0, url: TEST_URL }),
             fetchCache({ cacheMaxAge: 0, url: TEST_URL }),
@@ -80,8 +85,8 @@ describe('memoizedFetch', () => {
     it('makes multiple requests when caching is disabled', async () => {
         disableFetchCache()
         const responses = await Promise.all([
-            fetchCache({ cacheMaxAge: 1, url: TEST_URL }),
-            fetchCache({ cacheMaxAge: 1, url: TEST_URL }),
+            fetchCache({ cacheMaxAge: 100, url: TEST_URL }),
+            fetchCache({ cacheMaxAge: 100, url: TEST_URL }),
         ])
 
         expectResponses(responses)

--- a/client/shared/src/util/fetchCache.test.ts
+++ b/client/shared/src/util/fetchCache.test.ts
@@ -1,0 +1,43 @@
+import fetch from 'jest-fetch-mock'
+
+import { fetchCache } from './fetchCache'
+
+describe('memoizedFetch', () => {
+    beforeAll(() => {
+        fetch.enableMocks()
+    })
+
+    beforeEach(() => {
+        fetch.mockClear()
+    })
+
+    afterAll(() => {
+        fetch.disableMocks()
+    })
+
+    it('makes only single request for similar requests', async () => {
+        const expectedData = { foo: { bar: 'baz' } }
+        fetch.mockResponseOnce(JSON.stringify(expectedData))
+
+        const testUrl = '/test/api'
+        const responses = await Promise.all([fetchCache(testUrl), fetchCache(testUrl)])
+
+        for (const actualResponse of responses) {
+            expect(actualResponse.data).toEqual(expectedData)
+        }
+        expect(fetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('makes multiple requests for different requests', async () => {
+        const expectedData = { foo: { bar: 'baz' } }
+
+        fetch.mockResponse(JSON.stringify(expectedData))
+
+        const responses = await Promise.all([fetchCache('/test/one'), fetchCache('/test/two')])
+
+        for (const actualResponse of responses) {
+            expect(actualResponse.data).toEqual(expectedData)
+        }
+        expect(fetch).toHaveBeenCalledTimes(2)
+    })
+})

--- a/client/shared/src/util/fetchCache.ts
+++ b/client/shared/src/util/fetchCache.ts
@@ -10,6 +10,7 @@ export interface FetchCacheReturnType<T> {
 }
 
 const cache = new Map<string, CacheItem>()
+// NOTE: try to use single promises cache
 const fetchesInProgress = new Map<string, Promise<FetchCacheReturnType<any>>>()
 
 let isEnabled = true

--- a/client/shared/src/util/fetchCache.ts
+++ b/client/shared/src/util/fetchCache.ts
@@ -9,7 +9,7 @@ export interface FetchCacheResponse<T> {
     headers: Record<string, string>
 }
 
-interface FetchCacheRequest extends RequestInit {
+export interface FetchCacheRequest extends RequestInit {
     /**
      * URL to fetch
      */

--- a/client/shared/src/util/fetchCache.ts
+++ b/client/shared/src/util/fetchCache.ts
@@ -1,0 +1,42 @@
+const cache = new Map<string, FetchCacheReturnType<any>>()
+const runningRequests = new Map<string, Promise<FetchCacheReturnType<any>>>()
+const INVALIDATE_TIMEOUT = 60 * 1000 // 1 minute
+
+interface FetchCacheReturnType<T> {
+    data: T
+    status: number
+}
+
+/**
+ * fetch API with cache
+ *
+ * @description Caches same argument requests for 1 minute
+ */
+export const fetchCache = async <T = any>(...args: Parameters<typeof fetch>): Promise<FetchCacheReturnType<T>> => {
+    const key = JSON.stringify(args)
+
+    if (cache.has(key)) {
+        return cache.get(key) as FetchCacheReturnType<T>
+    }
+
+    if (runningRequests.has(key)) {
+        return (await runningRequests.get(key)) as FetchCacheReturnType<T>
+    }
+
+    const request = fetch(...args)
+        .then(async response => {
+            const data = (await response.json()) as T
+            const result = { status: response.status, data }
+
+            cache.set(key, result)
+
+            setTimeout(() => cache.delete(key), INVALIDATE_TIMEOUT)
+
+            return result
+        })
+        .finally(() => runningRequests.delete(key))
+
+    runningRequests.set(key, request)
+
+    return request
+}

--- a/package.json
+++ b/package.json
@@ -266,6 +266,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^26.6.3",
     "jest-canvas-mock": "^2.3.0",
+    "jest-fetch-mock": "^3.0.3",
     "jest-mock-extended": "^2.0.2-beta2",
     "jsdom": "^15.2.1",
     "json-schema-ref-parser": "^9.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -423,7 +423,7 @@
   resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz#c7ff6303df71080ec7a4f5b8c003c58f1cf51037"
   integrity sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.10.5", "@babel/parser@^7.12.1", "@babel/parser@^7.12.11", "@babel/parser@^7.12.3", "@babel/parser@^7.12.7", "@babel/parser@^7.14.2", "@babel/parser@^7.14.5", "@babel/parser@^7.14.7", "@babel/parser@^7.7.5":
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.10.5", "@babel/parser@^7.12.1", "@babel/parser@^7.12.11", "@babel/parser@^7.12.3", "@babel/parser@^7.12.7", "@babel/parser@^7.14.2", "@babel/parser@^7.14.5", "@babel/parser@^7.14.7":
   version "7.14.7"
   resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz#6099720c8839ca865a2637e6c85852ead0bdb595"
   integrity sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==
@@ -1387,7 +1387,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/template@^7.10.4", "@babel/template@^7.12.13", "@babel/template@^7.12.7", "@babel/template@^7.14.5", "@babel/template@^7.3.3", "@babel/template@^7.7.4":
+"@babel/template@^7.10.4", "@babel/template@^7.12.13", "@babel/template@^7.12.7", "@babel/template@^7.14.5", "@babel/template@^7.3.3":
   version "7.14.5"
   resolved "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz#a9bc9d8b33354ff6e55a9c60d1109200a68974f4"
   integrity sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==
@@ -1411,7 +1411,7 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
-"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.12.1", "@babel/traverse@^7.12.11", "@babel/traverse@^7.12.9", "@babel/traverse@^7.13.0", "@babel/traverse@^7.14.2", "@babel/traverse@^7.14.5", "@babel/traverse@^7.7.4":
+"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.12.1", "@babel/traverse@^7.12.11", "@babel/traverse@^7.12.9", "@babel/traverse@^7.13.0", "@babel/traverse@^7.14.2", "@babel/traverse@^7.14.5":
   version "7.14.7"
   resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.7.tgz#64007c9774cfdc3abd23b0780bc18a3ce3631753"
   integrity sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==
@@ -2134,6 +2134,15 @@
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
+"@jest/environment@^25.5.0":
+  version "25.5.0"
+  resolved "https://registry.npmjs.org/@jest/environment/-/environment-25.5.0.tgz#aa33b0c21a716c65686638e7ef816c0e3a0c7b37"
+  integrity sha512-U2VXPEqL07E/V7pSZMSQCvV5Ea4lqOlT+0ZFijl/i316cRMHvZ4qC+jBdryd+lmRetjQo0YIQr6cVPNxxK87mA==
+  dependencies:
+    "@jest/fake-timers" "^25.5.0"
+    "@jest/types" "^25.5.0"
+    jest-mock "^25.5.0"
+
 "@jest/environment@^26.6.2":
   version "26.6.2"
   resolved "https://registry.npmjs.org/@jest/environment/-/environment-26.6.2.tgz#ba364cc72e221e79cc8f0a99555bf5d7577cf92c"
@@ -2143,6 +2152,17 @@
     "@jest/types" "^26.6.2"
     "@types/node" "*"
     jest-mock "^26.6.2"
+
+"@jest/fake-timers@^25.5.0":
+  version "25.5.0"
+  resolved "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-25.5.0.tgz#46352e00533c024c90c2bc2ad9f2959f7f114185"
+  integrity sha512-9y2+uGnESw/oyOI3eww9yaxdZyHq7XvprfP/eeoCsjqKYts2yRlsHS/SgjPDV8FyMfn2nbMy8YzUk6nyvdLOpQ==
+  dependencies:
+    "@jest/types" "^25.5.0"
+    jest-message-util "^25.5.0"
+    jest-mock "^25.5.0"
+    jest-util "^25.5.0"
+    lolex "^5.0.0"
 
 "@jest/fake-timers@^26.6.2":
   version "26.6.2"
@@ -2280,7 +2300,7 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@jest/types@^26.5.2", "@jest/types@^26.6.2":
+"@jest/types@^26.6.2":
   version "26.6.2"
   resolved "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
   integrity sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==
@@ -5377,6 +5397,11 @@
   dependencies:
     "@types/webpack" "^4"
 
+"@types/stack-utils@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
+  integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
 "@types/stack-utils@^2.0.0":
   version "2.0.0"
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
@@ -7648,11 +7673,6 @@ braces@^3.0.1, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
-
-browser-process-hrtime@^0.1.2:
-  version "0.1.3"
-  resolved "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz#616f00faef1df7ec1b5bf9cfe2bdc3170f26c7b4"
-  integrity sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==
 
 browser-process-hrtime@^1.0.0:
   version "1.0.0"
@@ -10008,7 +10028,7 @@ dicer@0.3.0:
   dependencies:
     streamsearch "0.1.2"
 
-diff-sequences@^26.5.0, diff-sequences@^26.6.2:
+diff-sequences@^26.6.2:
   version "26.6.2"
   resolved "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
   integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
@@ -11450,7 +11470,7 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
-expect@*, expect@^26.5.2, expect@^26.6.2:
+expect@*, expect@^26.6.2:
   version "26.6.2"
   resolved "https://registry.npmjs.org/expect/-/expect-26.6.2.tgz#c6b996bf26bf3fe18b67b2d0f51fc981ba934417"
   integrity sha512-9/hlOBkQl2l/PLHJx6JjoDF6xPKcJEsUlWKb23rKE7KzeDqUZKXKNMW27KIue5JMdBV9HgmoJPcc8HtO85t9IA==
@@ -14814,7 +14834,7 @@ jest-config@^26.6.3:
     micromatch "^4.0.2"
     pretty-format "^26.6.2"
 
-jest-diff@^26.0.0, jest-diff@^26.5.2, jest-diff@^26.6.2:
+jest-diff@^26.0.0, jest-diff@^26.6.2:
   version "26.6.2"
   resolved "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz#1aa7468b52c3a68d7d5c5fdcdfcd5e49bd164394"
   integrity sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==
@@ -14867,6 +14887,14 @@ jest-environment-node@^26.6.2:
     jest-mock "^26.6.2"
     jest-util "^26.6.2"
 
+jest-fetch-mock@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
+  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
+  dependencies:
+    cross-fetch "^3.0.4"
+    promise-polyfill "^8.1.3"
+
 jest-get-type@^26.3.0:
   version "26.3.0"
   resolved "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
@@ -14892,7 +14920,7 @@ jest-haste-map@^25.5.1:
   optionalDependencies:
     fsevents "^2.1.2"
 
-jest-haste-map@^26.5.2, jest-haste-map@^26.6.2:
+jest-haste-map@^26.6.2:
   version "26.6.2"
   resolved "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.2.tgz#dd7e60fe7dc0e9f911a23d79c5ff7fb5c2cafeaa"
   integrity sha512-easWIJXIw71B2RdR8kgqpjQrbMRWQBgiBwXYEhtGUTaX+doCjBheluShdDMeR8IMfJiTqH4+zfhtg29apJf/8w==
@@ -14960,7 +14988,7 @@ jest-leak-detector@^26.6.2:
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
 
-jest-matcher-utils@^26.5.2, jest-matcher-utils@^26.6.2:
+jest-matcher-utils@^26.6.2:
   version "26.6.2"
   resolved "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.6.2.tgz#8e6fd6e863c8b2d31ac6472eeb237bc595e53e7a"
   integrity sha512-llnc8vQgYcNqDrqRDXWwMr9i7rS5XFiCwvh6DTP7Jqa2mqpcCBBlpCbn+trkG0KNhPu/h8rzyBkriOtBstvWhw==
@@ -14970,7 +14998,21 @@ jest-matcher-utils@^26.5.2, jest-matcher-utils@^26.6.2:
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
 
-jest-message-util@^26.5.2, jest-message-util@^26.6.2:
+jest-message-util@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.npmjs.org/jest-message-util/-/jest-message-util-25.5.0.tgz#ea11d93204cc7ae97456e1d8716251185b8880ea"
+  integrity sha512-ezddz3YCT/LT0SKAmylVyWWIGYoKHOFOFXx3/nA4m794lfVUskMcwhip6vTgdVrOtYdjeQeis2ypzes9mZb4EA==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@jest/types" "^25.5.0"
+    "@types/stack-utils" "^1.0.1"
+    chalk "^3.0.0"
+    graceful-fs "^4.2.4"
+    micromatch "^4.0.2"
+    slash "^3.0.0"
+    stack-utils "^1.0.1"
+
+jest-message-util@^26.6.2:
   version "26.6.2"
   resolved "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.6.2.tgz#58173744ad6fc0506b5d21150b9be56ef001ca07"
   integrity sha512-rGiLePzQ3AzwUshu2+Rn+UMFk0pHN58sOG+IaJbk5Jxuqo3NYO1U2/MIR4S1sKgsoYSXSzdtSa0TgrmtUwEbmA==
@@ -14991,6 +15033,13 @@ jest-mock-extended@^2.0.2-beta2:
   integrity sha512-56zcpgRPs3YxQP0ejcaaNFxUinPyRxQCbuk7GGORZqEbAFuQVXWAAtru2tI1N4qcLBoDWEJ/hwUxwbEGY5hdyw==
   dependencies:
     ts-essentials "^7.0.3"
+
+jest-mock@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.npmjs.org/jest-mock/-/jest-mock-25.5.0.tgz#a91a54dabd14e37ecd61665d6b6e06360a55387a"
+  integrity sha512-eXWuTV8mKzp/ovHc5+3USJMYsTBhyQ+5A1Mak35dey/RG8GlM4YWVylZuGgVXinaW6tpvk/RSecmF37FKUlpXA==
+  dependencies:
+    "@jest/types" "^25.5.0"
 
 jest-mock@^26.6.2:
   version "26.6.2"
@@ -15024,7 +15073,7 @@ jest-resolve-dependencies@^26.6.3:
     jest-regex-util "^26.0.0"
     jest-snapshot "^26.6.2"
 
-jest-resolve@^26.5.2, jest-resolve@^26.6.2:
+jest-resolve@^26.6.2:
   version "26.6.2"
   resolved "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.6.2.tgz#a3ab1517217f469b504f1b56603c5bb541fbb507"
   integrity sha512-sOxsZOq25mT1wRsfHcbtkInS+Ek7Q8jCHUB0ZUTP0tc/c41QHriU/NunqMfCUWsL4H3MHpvQD4QR9kSYhS7UvQ==
@@ -15152,7 +15201,7 @@ jest-util@^25.5.0:
     is-ci "^2.0.0"
     make-dir "^3.0.0"
 
-jest-util@^26.5.2, jest-util@^26.6.2:
+jest-util@^26.6.2:
   version "26.6.2"
   resolved "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz#907535dbe4d5a6cb4c47ac9b926f6af29576cbc1"
   integrity sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==
@@ -16176,6 +16225,13 @@ log-update@^2.3.0:
     ansi-escapes "^3.0.0"
     cli-cursor "^2.0.0"
     wrap-ansi "^3.0.1"
+
+lolex@^5.0.0:
+  version "5.1.2"
+  resolved "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz#953694d098ce7c07bc5ed6d0e42bc6c0c6d5a367"
+  integrity sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
 
 longest-streak@^2.0.0:
   version "2.0.4"
@@ -19006,7 +19062,7 @@ pretty-error@^3.0.4:
     lodash "^4.17.20"
     renderkid "^2.0.6"
 
-pretty-format@^26.0.0, pretty-format@^26.5.2, pretty-format@^26.6.1, pretty-format@^26.6.2:
+pretty-format@^26.0.0, pretty-format@^26.6.2:
   version "26.6.2"
   resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
   integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
@@ -19103,6 +19159,11 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
+
+promise-polyfill@^8.1.3:
+  version "8.2.1"
+  resolved "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.1.tgz#1fa955b325bee4f6b8a4311e18148d4e5b46d254"
+  integrity sha512-3p9zj0cEHbp7NVUxEYUWjQlffXqnXaZIMPkAO7HhFh8u5636xLRDHOUo2vpWSK0T2mqm6fKLXYn1KP6PAZ2gKg==
 
 promise.allsettled@^1.0.0:
   version "1.0.2"
@@ -21676,6 +21737,13 @@ stack-trace@0.0.10:
   version "0.0.10"
   resolved "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
   integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
+
+stack-utils@^1.0.1:
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.5.tgz#a19b0b01947e0029c8e451d5d61a498f5bb1471b"
+  integrity sha512-KZiTzuV3CnSnSvgMRrARVCj+Ht7rMbauGDK0LdVFRGyenwdylpajAp4Q0i6SX8rEmbTpMMf6ryq2gb8pPq2WgQ==
+  dependencies:
+    escape-string-regexp "^2.0.0"
 
 stack-utils@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/27382

#### Description

This PR: 
- Updates private repository detection logic for Github & Gitlab by using corresponding REST APIs

> NOTE: it still sends repo names to check if the repo exists in Sourcegraph or not.

#### Before merging

- [ ] Test on different code hosts (if applicable)
    - [ ] GitHub
    - [ ] Gitlab
    - [ ] GitHub Enterprise
    - [ ] Refined GitHub
    - [ ] Phabricator
    - [ ] Phabricator integration
    - [ ] Bitbucket
    - [ ] Bitbucket integration

- [ ] Test on different browsers (if applicable)
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
- [ ] Add change log message to [client/browser/CHANGELOG.md](./client/browser/CHANGELOG.md), under "Unreleased" section. (if applicable)
