### PR TITLE
insights: Adds insights and dashboards from users and orgs

### DIFF
--- a/enterprise/internal/insights/migration/discovery.go
+++ b/enterprise/internal/insights/migration/discovery.go
@@ -1,0 +1,497 @@
+// Re-purposed and copied methods from discovery and other related methods.
+
+package migration
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/inconshreveable/log15"
+	"github.com/pkg/errors"
+	"github.com/segmentio/ksuid"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/insights"
+)
+
+func getLangStatsInsights(ctx context.Context, settingsRow api.Settings) ([]insights.LangStatsInsight, error) {
+	prefix := "codeStatsInsights."
+	var raw map[string]json.RawMessage
+	results := make([]insights.LangStatsInsight, 0)
+
+	raw, err := insights.FilterSettingJson(settingsRow.Contents, prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	for id, body := range raw {
+		var temp insights.LangStatsInsight
+		temp.ID = id
+		if err := json.Unmarshal(body, &temp); err != nil {
+			// a deprecated schema collides with this field name, so skip any deserialization errors
+			continue
+		}
+		temp.UserID = settingsRow.Subject.User
+		temp.OrgID = settingsRow.Subject.Org
+
+		results = append(results, temp)
+	}
+
+	return results, nil
+}
+
+func getFrontendInsights(ctx context.Context, settingsRow api.Settings) ([]insights.SearchInsight, error) {
+	prefix := "searchInsights."
+	var raw map[string]json.RawMessage
+	results := make([]insights.SearchInsight, 0)
+
+	raw, err := insights.FilterSettingJson(settingsRow.Contents, prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	for id, body := range raw {
+		var temp insights.SearchInsight
+		temp.ID = id
+		if err := json.Unmarshal(body, &temp); err != nil {
+			// a deprecated schema collides with this field name, so skip any deserialization errors
+			continue
+		}
+		temp.UserID = settingsRow.Subject.User
+		temp.OrgID = settingsRow.Subject.Org
+
+		results = append(results, temp)
+	}
+
+	return results, nil
+}
+
+func getBackendInsights(ctx context.Context, setting api.Settings) ([]insights.SearchInsight, error) {
+	prefix := "insights.allrepos"
+	var multi error
+
+	results := make([]insights.SearchInsight, 0)
+	perms := permissionAssociations{
+		userID: setting.Subject.User,
+		orgID:  setting.Subject.Org,
+	}
+
+	var raw map[string]json.RawMessage
+	raw, err := insights.FilterSettingJson(setting.Contents, prefix)
+	if err != nil {
+		multi = multierror.Append(multi, err)
+	}
+
+	for _, val := range raw {
+		// iterate for each instance of the prefix key in the settings. This should never be len > 1, but it's technically a map.
+		temp, err := unmarshalBackendInsights(val)
+		if err != nil {
+			// this isn't actually a total failure case, we could have partially parsed this dictionary.
+			multi = multierror.Append(multi, err)
+		}
+		results = append(results, temp.Insights(perms)...)
+	}
+
+	if multi != nil {
+		log15.Error("insights: deserialization errors parsing integrated insights", "error", multi)
+	}
+
+	return results, nil
+}
+
+func getDashboards(ctx context.Context, settingsRow api.Settings) ([]insights.SettingDashboard, error) {
+	prefix := "insights.dashboards"
+
+	results := make([]insights.SettingDashboard, 0)
+	var raw map[string]json.RawMessage
+	raw, err := insights.FilterSettingJson(settingsRow.Contents, prefix)
+	if err != nil {
+		return nil, err
+	}
+	for _, val := range raw {
+		// iterate for each instance of the prefix key in the settings. This should never be len > 1, but it's technically a map.
+		temp, err := unmarshalDashboard(val, settingsRow)
+		if err != nil {
+			continue
+		}
+		results = append(results, temp...)
+	}
+
+	return results, nil
+}
+
+type permissionAssociations struct {
+	userID *int32
+	orgID  *int32
+}
+
+type IntegratedInsights map[string]insights.SearchInsight
+
+func (i IntegratedInsights) Insights(perms permissionAssociations) []insights.SearchInsight {
+	results := make([]insights.SearchInsight, 0)
+	for key, insight := range i {
+		insight.ID = key // the insight ID is the value of the dict key
+
+		// each setting is owned by either a user or an organization, which needs to be mapped when this insight is synced
+		// to preserve permissions semantics
+		insight.UserID = perms.userID
+		insight.OrgID = perms.orgID
+
+		results = append(results, insight)
+	}
+	return results
+}
+
+func unmarshalBackendInsights(raw json.RawMessage) (IntegratedInsights, error) {
+	var dict map[string]json.RawMessage
+	var multi error
+	result := make(IntegratedInsights)
+
+	if err := json.Unmarshal(raw, &dict); err != nil {
+		return result, err
+	}
+
+	for id, body := range dict {
+		var temp insights.SearchInsight
+		if err := json.Unmarshal(body, &temp); err != nil {
+			multi = multierror.Append(multi, err)
+			continue
+		}
+		result[id] = temp
+	}
+
+	return result, multi
+}
+
+func unmarshalDashboard(raw json.RawMessage, settingsRow api.Settings) ([]insights.SettingDashboard, error) {
+	var dict map[string]json.RawMessage
+	var multi error
+	result := []insights.SettingDashboard{}
+
+	if err := json.Unmarshal(raw, &dict); err != nil {
+		return result, err
+	}
+
+	for id, body := range dict {
+		var temp insights.SettingDashboard
+		if err := json.Unmarshal(body, &temp); err != nil {
+			multi = multierror.Append(multi, err)
+			continue
+		}
+		temp.ID = id
+		temp.UserID = settingsRow.Subject.User
+		temp.OrgID = settingsRow.Subject.Org
+
+		result = append(result, temp)
+	}
+
+	return result, multi
+}
+
+func (m *migrator) migrateInsights(ctx context.Context, toMigrate []insights.SearchInsight, batch migrationBatch) int {
+	var count, skipped, errorCount int
+	for _, d := range toMigrate {
+		if d.ID == "" {
+			// we need a unique ID, and if for some reason this insight doesn't have one, it can't be migrated.
+			skipped++
+			continue
+		}
+		insight, err := m.insightStore.Get(ctx, store.InsightQueryArgs{ UniqueID: d.ID, WithoutAuthorization: true})
+		if err != nil {
+			skipped++
+			continue
+		}
+		if len(insight) > 0 {
+			count++
+			continue
+		}
+		err = migrateSeries(ctx, m.insightStore, d, batch)
+		if err != nil {
+			// we can't do anything about errors, so we will just skip it and log it
+			errorCount++
+			log15.Error("insights migration: error while migrating insight", "error", err)
+		}
+		count++
+	}
+	log15.Info("insights settings migration batch complete", "batch", batch, "count", count, "skipped", skipped, "errors", errorCount)
+	return count
+}
+
+// TODO: I bet maybe we can combine these to consolidate some of the common steps.
+func (m *migrator) migrateLangStatsInsights(ctx context.Context, toMigrate []insights.LangStatsInsight) int {
+	var count, skipped, errorCount int
+	for _, d := range toMigrate {
+		if d.ID == "" {
+			// we need a unique ID, and if for some reason this insight doesn't have one, it can't be migrated.
+			skipped++
+			continue
+		}
+		insight, err := m.insightStore.Get(ctx, store.InsightQueryArgs{ UniqueID: d.ID, WithoutAuthorization: true})
+		if err != nil {
+			skipped++
+			continue
+		}
+		if len(insight) > 0 {
+			count++
+			continue
+		}
+
+		err = migrateLangStatSeries(ctx, m.insightStore, d)
+		if err != nil {
+			// we can't do anything about errors, so we will just skip it and log it
+			errorCount++
+			log15.Error("insights migration: error while migrating insight", "error", err)
+		} else {
+			count++
+		}
+	}
+	log15.Info("insights settings migration batch complete", "batch", "langStats", "count", count, "skipped", skipped, "errors", errorCount)
+	return count
+}
+
+func migrateLangStatSeries(ctx context.Context, insightStore *store.InsightStore, from insights.LangStatsInsight) (err error) {
+	tx, err := insightStore.Transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { err = tx.Store.Done(err) }()
+
+	log15.Info("insights migration: attempting to migrate insight", "unique_id", from.ID)
+
+	view := types.InsightView{
+		Title:            from.Title,
+		UniqueID:         from.ID,
+		OtherThreshold:   &from.OtherThreshold,
+		PresentationType: types.Pie,
+	}
+	series := types.InsightSeries{
+		SeriesID:           ksuid.New().String(),
+		Repositories:       []string{from.Repository},
+		SampleIntervalUnit: string(types.Month),
+	}
+	var grants []store.InsightViewGrant
+	if from.UserID != nil {
+		grants = []store.InsightViewGrant{store.UserGrant(int(*from.UserID))}
+	} else if from.OrgID != nil {
+		grants = []store.InsightViewGrant{store.OrgGrant(int(*from.OrgID))}
+	} else {
+		grants = []store.InsightViewGrant{store.GlobalGrant()}
+	}
+
+	view, err = tx.CreateView(ctx, view, grants)
+	if err != nil {
+		return errors.Wrapf(err, "unable to migrate insight unique_id: %s", from.ID)
+	}
+	series, err = tx.CreateSeries(ctx, series)
+	if err != nil {
+		return errors.Wrapf(err, "unable to migrate insight unique_id: %s", from.ID)
+	}
+	err = tx.AttachSeriesToView(ctx, series, view, types.InsightViewSeriesMetadata{})
+	if err != nil {
+		return errors.Wrapf(err, "unable to migrate insight unique_id: %s", from.ID)
+	}
+
+	return nil
+}
+
+func migrateSeries(ctx context.Context, insightStore *store.InsightStore, from insights.SearchInsight, batch migrationBatch) (err error) {
+	tx, err := insightStore.Transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { err = tx.Store.Done(err) }()
+
+	log15.Info("insights migration: attempting to migrate insight", "unique_id", from.ID)
+	dataSeries := make([]types.InsightSeries, len(from.Series))
+	metadata := make([]types.InsightViewSeriesMetadata, len(from.Series))
+
+	for i, timeSeries := range from.Series {
+		temp := types.InsightSeries{
+			Query: timeSeries.Query,
+		}
+
+		if batch == frontend {
+			temp.Repositories = from.Repositories
+			if temp.Repositories == nil {
+				// this shouldn't be possible, but if for some reason we get here there is a malformed schema
+				return errors.New("invalid schema for frontend insight, missing repositories")
+			}
+			interval := parseTimeInterval(from)
+			temp.SampleIntervalUnit = string(interval.unit)
+			temp.SampleIntervalValue = interval.value
+			temp.SeriesID = ksuid.New().String() // this will cause some orphan records, but we can't use the query to match because of repo / time scope. We will purge orphan records at the end of this job.
+		} else if batch == backend {
+			temp.SampleIntervalUnit = string(types.Month)
+			temp.SampleIntervalValue = 1
+			temp.NextRecordingAfter = insights.NextRecording(time.Now())
+			temp.NextSnapshotAfter = insights.NextSnapshot(time.Now())
+			temp.SeriesID = discovery.Encode(timeSeries)
+		}
+
+		var series types.InsightSeries
+		// first check if this data series already exists (somebody already created an insight of this query), in which case we just need to attach the view to this data series
+		existing, err := tx.GetDataSeries(ctx, store.GetDataSeriesArgs{SeriesID: temp.SeriesID})
+		if err != nil {
+			return errors.Wrapf(err, "unable to migrate insight unique_id: %s series_id: %s", from.ID, temp.SeriesID)
+		} else if len(existing) > 0 {
+			series = existing[0]
+			log15.Info("insights migration: existing data series identified, attempting to construct and attach new view", "series_id", series.SeriesID, "unique_id", from.ID)
+		} else {
+			series, err = tx.CreateSeries(ctx, temp)
+			if err != nil {
+				return errors.Wrapf(err, "unable to migrate insight unique_id: %s series_id: %s", from.ID, temp.SeriesID)
+			}
+		}
+		dataSeries[i] = series
+
+		metadata[i] = types.InsightViewSeriesMetadata{
+			Label:  timeSeries.Name,
+			Stroke: timeSeries.Stroke,
+		}
+	}
+
+	view := types.InsightView{
+		Title:            from.Title,
+		Description:      from.Description,
+		UniqueID:         from.ID,
+		PresentationType: types.Line,
+	}
+
+	if from.Filters != nil {
+		view.Filters = types.InsightViewFilters{
+			IncludeRepoRegex: from.Filters.IncludeRepoRegexp,
+			ExcludeRepoRegex: from.Filters.ExcludeRepoRegexp,
+		}
+	}
+
+	var grants []store.InsightViewGrant
+	if from.UserID != nil {
+		grants = []store.InsightViewGrant{store.UserGrant(int(*from.UserID))}
+	} else if from.OrgID != nil {
+		grants = []store.InsightViewGrant{store.OrgGrant(int(*from.OrgID))}
+	} else {
+		grants = []store.InsightViewGrant{store.GlobalGrant()}
+	}
+
+	view, err = tx.CreateView(ctx, view, grants)
+	if err != nil {
+		return errors.Wrapf(err, "unable to migrate insight unique_id: %s", from.ID)
+	}
+
+	for i, insightSeries := range dataSeries {
+		err := tx.AttachSeriesToView(ctx, insightSeries, view, metadata[i])
+		if err != nil {
+			return errors.Wrapf(err, "unable to migrate insight unique_id: %s", from.ID)
+		}
+	}
+	return nil
+}
+
+func (m *migrator) migrateDashboards(ctx context.Context, toMigrate []insights.SettingDashboard) int {
+	var count, skipped, errorCount int
+	for _, d := range toMigrate {
+		if d.ID == "" {
+			// we need a unique ID, and if for some reason this insight doesn't have one, it can't be migrated.
+			skipped++
+			continue
+		}
+
+		// TODO: We need a store method to check for this. We can probably use some SQL query to determine
+		// if a dashboard is the same by comparing its title, attached insights and grants.
+		// insight, err := m.insightStore.Get(ctx, store.InsightQueryArgs{ UniqueID: d.ID, WithoutAuthorization: true})
+		// if err != nil {
+		// 	skipped++
+		// 	continue
+		// }
+		// if len(insight) > 0 {
+		// 	count++
+		// 	continue
+		// }
+
+		err := migrateDashboard(ctx, m.dashboardStore, d)
+		if err != nil {
+			// we can't do anything about errors, so we will just skip it and log it
+			errorCount++
+			log15.Error("insights migration: error while migrating insight", "error", err)
+		} else {
+			count++
+		}
+	}
+	log15.Info("insights settings migration batch complete", "batch", "langStats", "count", count, "skipped", skipped, "errors", errorCount)
+	return count
+}
+
+func migrateDashboard(ctx context.Context, dashboardStore *store.DBDashboardStore, from insights.SettingDashboard) (err error) {
+	tx, err := dashboardStore.Transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { err = tx.Store.Done(err) }()
+
+	dashboard := types.Dashboard{
+		Title:      from.Title,
+		InsightIDs: from.InsightIds,
+	}
+	log15.Info("insights migration: migrating dashboard", "settings_unique_id", from.ID)
+
+	var grants []store.DashboardGrant
+	if from.UserID != nil {
+		grants = []store.DashboardGrant{store.UserDashboardGrant(int(*from.UserID))}
+	} else if from.OrgID != nil {
+		grants = []store.DashboardGrant{store.OrgDashboardGrant(int(*from.OrgID))}
+	} else {
+		grants = []store.DashboardGrant{store.GlobalDashboardGrant()}
+	}
+	_, err = dashboardStore.CreateDashboard(ctx, store.CreateDashboardArgs{Dashboard: dashboard, Grants: grants})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// there seems to be some global insights with possibly old schema that have a step field
+func parseTimeInterval(insight insights.SearchInsight) timeInterval {
+	if insight.Step.Days != nil {
+		return timeInterval{
+			unit:  types.Day,
+			value: *insight.Step.Days,
+		}
+	} else if insight.Step.Hours != nil {
+		return timeInterval{
+			unit:  types.Hour,
+			value: *insight.Step.Hours,
+		}
+	} else if insight.Step.Weeks != nil {
+		return timeInterval{
+			unit:  types.Week,
+			value: *insight.Step.Weeks,
+		}
+	} else if insight.Step.Months != nil {
+		return timeInterval{
+			unit:  types.Month,
+			value: *insight.Step.Months,
+		}
+	} else if insight.Step.Years != nil {
+		return timeInterval{
+			unit:  types.Year,
+			value: *insight.Step.Years,
+		}
+	} else {
+		return timeInterval{
+			unit:  types.Month,
+			value: 1,
+		}
+	}
+}
+
+type timeInterval struct {
+	unit  types.IntervalUnit
+	value int
+}
+

--- a/enterprise/internal/insights/migration/discovery.go
+++ b/enterprise/internal/insights/migration/discovery.go
@@ -5,6 +5,7 @@ package migration
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -499,9 +500,9 @@ type timeInterval struct {
 
 func makeUniqueId(id string, subject api.SettingsSubject) string {
 	if subject.User != nil {
-		return id + "user-" + string(*subject.User)
+		return fmt.Sprintf("%s-user-%d", id, *subject.User)
 	} else if subject.Org != nil {
-		return id + "org-" + string(*subject.Org)
+		return fmt.Sprintf("%s-org-%d", id, *subject.Org)
 	} else {
 		return id
 	}

--- a/enterprise/internal/insights/migration/migration.go
+++ b/enterprise/internal/insights/migration/migration.go
@@ -170,7 +170,7 @@ func (m *migrator) performMigrationForRow(ctx context.Context, job store.Setting
 		subject = api.SettingsSubject{User: &userId}
 	} else if job.OrgId != nil {
 		orgId := int32(*job.OrgId)
-		subject = api.SettingsSubject{User: &orgId}
+		subject = api.SettingsSubject{Org: &orgId}
 	} else {
 		subject = api.SettingsSubject{Site: true}
 	}
@@ -187,6 +187,7 @@ func (m *migrator) performMigrationForRow(ctx context.Context, job store.Setting
 	}
 
 	// fmt.Println(settings)
+	fmt.Println("----------- Performing migration for row:", subject)
 
 	// First, migrate the 3 types of insights
 	langStatsInsights, err := getLangStatsInsights(ctx, *settings)
@@ -255,7 +256,7 @@ func (m *migrator) performMigrationForRow(ctx context.Context, job store.Setting
 	// idk, 10 retries? Call them runs even. So when a runthrough is completed it increments it. And if it gets to 10 that means something is
 	// seriously wrong and needs to be looked at? That can also be reset to 0 manually if need be to retry it again later.
 
-	return false, false, nil
+	return true, false, nil
 }
 
 // // Something like this? Maybe this doesn't need to be a helper function. We'll see.

--- a/enterprise/internal/insights/migration/migration.go
+++ b/enterprise/internal/insights/migration/migration.go
@@ -51,7 +51,6 @@ func (m *migrator) Progress(ctx context.Context) (float64, error) {
 		FROM (SELECT COUNT(*) AS count FROM insights_settings_migration_jobs WHERE completed_at IS NOT NULL) c1,
 			 (SELECT COUNT(*) AS count FROM insights_settings_migration_jobs) c2;
 	`)))
-	fmt.Println("Progress:", progress)
 	return progress, err
 }
 

--- a/enterprise/internal/insights/migration/migration.go
+++ b/enterprise/internal/insights/migration/migration.go
@@ -2,21 +2,20 @@ package migration
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/hashicorp/go-multierror"
-	"github.com/inconshreveable/log15"
-	"github.com/pkg/errors"
-	"github.com/segmentio/ksuid"
-
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
-	"github.com/sourcegraph/sourcegraph/internal/insights"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
+)
+
+type migrationBatch string
+
+const (
+	backend  migrationBatch = "backend"
+	frontend migrationBatch = "frontend"
 )
 
 type migrator struct {
@@ -25,8 +24,8 @@ type migrator struct {
 
 	settingsMigrationJobsStore store.SettingsMigrationJobsStore
 	settingsStore              database.SettingsStore
-	insightStore               store.InsightStore
-	dashboardStore             store.DashboardStore
+	insightStore               *store.InsightStore
+	dashboardStore             *store.DBDashboardStore
 }
 
 func NewMigrator(insightsDB dbutil.DB, postgresDB dbutil.DB) oobmigration.Migrator {
@@ -35,7 +34,7 @@ func NewMigrator(insightsDB dbutil.DB, postgresDB dbutil.DB) oobmigration.Migrat
 		postgresDB:                 postgresDB,
 		settingsMigrationJobsStore: store.NewSettingsMigrationJobsStore(insightsDB),
 		settingsStore:              database.Settings(postgresDB),
-		insightStore:               *store.NewInsightStore(insightsDB),
+		insightStore:               store.NewInsightStore(insightsDB),
 		dashboardStore:             store.NewDashboardStore(insightsDB),
 	}
 }
@@ -62,22 +61,6 @@ func (m *migrator) Up(ctx context.Context) (err error) {
 	// 	return err
 	// }
 	// defer func() { err = tx.Done(err) }()
-
-	allJobsQueued, err := m.EnsureAllJobsAreQueued(ctx)
-	if err != nil {
-		// log error?
-		// update a table with a failure, or increment a retry count?
-		return err
-	}
-	if !allJobsQueued {
-		fmt.Println("Not all jobs have yet been queued. Trying again.")
-		return nil
-	}
-
-	fmt.Println("All jobs queued!")
-
-	// If we make it here, it's because all the jobs are queued. We can now safely begin picking up
-	// work and doing the migrations.
 
 	migrationComplete, workCompleted, err := m.PerformGlobalMigration(ctx)
 	if err != nil {
@@ -106,72 +89,6 @@ func (m *migrator) Up(ctx context.Context) (err error) {
 // TODO: I don't think we need this at all, do we? What would it do? Should we use it to wipe out the jobs table to restart the migration?
 func (m *migrator) Down(ctx context.Context) (err error) {
 	return nil
-}
-
-func (m *migrator) EnsureAllJobsAreQueued(ctx context.Context) (bool, error) {
-	allSettings, err := insights.GetSettings(ctx, m.postgresDB, insights.All, "insight")
-	if err != nil {
-		return false, err
-	}
-
-	distinctSettings := getDistinctSettings(allSettings)
-	jobsCount, err := m.settingsMigrationJobsStore.CountSettingsMigrationJobs(ctx)
-	if err != nil {
-		return false, err
-	}
-	if jobsCount == len(distinctSettings) {
-		return true, nil
-	}
-
-	for _, settings := range distinctSettings {
-		userId := settings.Subject.User
-		orgId := settings.Subject.Org
-
-		m.settingsMigrationJobsStore.CreateSettingsMigrationJob(ctx, store.CreateSettingsMigrationJobArgs{
-			UserId:     userId,
-			OrgId:      orgId,
-		})
-	}
-
-	// TBD error handling here
-	// What if there's some error that keeps happening that we can't recover from? I can't think of what that
-	// might be, but should we try and account for it?
-
-	return false, nil
-}
-
-// We want the latest settings object for each distinct combination of (user, org, global). We don't care who authored it.
-func getDistinctSettings(allSettings []*api.Settings) []*api.Settings {
-	settingsMap := make(map[string]*api.Settings)
-
-	for _, settings := range allSettings {
-		key := "_"
-		if settings.Subject.User != nil {
-			key += string(*settings.Subject.User)
-		} else {
-			key += "_"
-		}
-		if settings.Subject.Org != nil {
-			key += string(*settings.Subject.Org)
-		} else {
-			key += "_"
-		}
-
-		if settingsMap[key] == nil {
-			settingsMap[key] = settings
-		} else {
-			if settingsMap[key].CreatedAt.Before(settings.CreatedAt) {
-				settingsMap[key] = settings
-			}
-		}
-	}
-
-	var distinctSettings []*api.Settings
-	for _, value := range settingsMap {
-		distinctSettings = append(distinctSettings, value)
-	}
-
-	return distinctSettings
 }
 
 // Instead of 3 different functions, maybe one that takes an argument? We'll see how much they have in common. Probably a lot.
@@ -261,14 +178,20 @@ func (m *migrator) performMigrationForRow(ctx context.Context, job store.Setting
 		return true, false, nil
 	}
 
-	// Okay so now we have 4 different things to do BEFORE creating the virtual dashboard.
-	// Let's worry about errors later.
-
 	// fmt.Println(settings)
 
 	langStatsInsights, err := getLangStatsInsights(ctx, *settings)
+	if err != nil {
+		return false, false, err
+	}
 	frontendInsights, err := getFrontendInsights(ctx, *settings)
+	if err != nil {
+		return false, false, err
+	}
 	backendInsights, err := getBackendInsights(ctx, *settings)
+	if err != nil {
+		return false, false, err
+	}
 
 	fmt.Println("lang stats:", langStatsInsights)
 	fmt.Println("frontend:", frontendInsights)
@@ -283,44 +206,40 @@ func (m *migrator) performMigrationForRow(ctx context.Context, job store.Setting
 	var migratedInsightsCount int
 	if totalInsights != job.MigratedInsights {
 		err = m.settingsMigrationJobsStore.UpdateTotalInsights(ctx, job.UserId, job.OrgId, totalInsights)
-		fmt.Println("About to migrate langstats insights")
 
 		migratedInsightsCount += m.migrateLangStatsInsights(ctx, langStatsInsights)
-		//migratedInsightsCount += m.migrateFrontendInsights(ctx, frontendInsights)
-		//migratedInsightsCount += m.migrateBackendInsights(ctx, backendInsights)
-		err = m.settingsMigrationJobsStore.UpdateMigratedInsights(ctx, job.UserId, job.OrgId, migratedInsightsCount)
-	}
+		migratedInsightsCount += m.migrateInsights(ctx, frontendInsights, frontend)
+		migratedInsightsCount += m.migrateInsights(ctx, backendInsights, backend)
 
-	if totalInsights != migratedInsightsCount {
-		return false, false, nil
+		err = m.settingsMigrationJobsStore.UpdateMigratedInsights(ctx, job.UserId, job.OrgId, migratedInsightsCount)
+		if totalInsights != migratedInsightsCount {
+			fmt.Println("Insights did not finish migrating. Exit.")
+			return false, false, nil
+		}
 	}
 
 	dashboards, err := getDashboards(ctx, *settings)
+	if err != nil {
+		return false, true, err
+	}
 	fmt.Println("dashboards:", dashboards)
 	totalDashboards := len(dashboards)
 	fmt.Println("total dashboards:", totalDashboards)
 
+	var migratedDashboardsCount int
 	if totalDashboards != job.MigratedDashboards {
-		err = m.settingsMigrationJobsStore.UpdateTotalDashboards(ctx, job.UserId, job.OrgId, totalInsights)
+		err = m.settingsMigrationJobsStore.UpdateTotalDashboards(ctx, job.UserId, job.OrgId, totalDashboards)
+
+		migratedDashboardsCount += m.migrateDashboards(ctx, dashboards)
+
+		err = m.settingsMigrationJobsStore.UpdateMigratedDashboards(ctx, job.UserId, job.OrgId, migratedDashboardsCount)
+		if totalDashboards != migratedDashboardsCount {
+			fmt.Println("Dashboards did not finish migrating. Exit.")
+			return false, true, nil
+		}
 	}
 
-	// Update row with total_dashboards. Then compare with migrated_dashboards. If they're equal, continue. If not,
-	// Try migrating all of these insights.
-
-	// Okay so yeah we can't wipe everything out. Let's migrate 4 groups these one at a time. Dashboards last.
-	// Hmm, dashboards can only succeed once all the insights have worked. Maybe we actually need to keep track
-	// of both insights and dashboards seprately.. like if all except 1 insight migrates we can't do the dashboards yet.
-	// Right?
-
-
-
-
-	// Caveats: we can't wipe everything out that already exists. We'll need to match on ids and check if something exists
-	// before creating it. This will also make it less of an all-or-nothing transaction. If we get errors on a few of these
-	// insights we can ignore them for now.
-
-	// Side note: maybe we want like, "total items" and "items migrated" rows on each job? Maybe that would be better than
-	// "completed_at", especially since we don't care when it was completed as much. We could have that too though if it helps at all.
+	// TODO: Create virtual dashboard here.
 
 	// Error handling: If we're keeping track of total vs completed insights/dashboards, maybe we just need a state for retries. We can do like
 	// idk, 10 retries? Call them runs even. So when a runthrough is completed it increments it. And if it gets to 10 that means something is
@@ -346,193 +265,3 @@ func (m *migrator) performMigrationForRow(ctx context.Context, job store.Setting
 // }
 
 // Okay so we're going to scan through each JSON blob 4 times. One for each of the 3 insight types, and once for dashboards.
-
-func getLangStatsInsights(ctx context.Context, settingsRow api.Settings) ([]insights.LangStatsInsight, error) {
-	prefix := "codeStatsInsights."
-	var raw map[string]json.RawMessage
-	results := make([]insights.LangStatsInsight, 0)
-
-	raw, err := insights.FilterSettingJson(settingsRow.Contents, prefix)
-	if err != nil {
-		return nil, err
-	}
-
-	for id, body := range raw {
-		var temp insights.LangStatsInsight
-		temp.ID = id
-		if err := json.Unmarshal(body, &temp); err != nil {
-			// a deprecated schema collides with this field name, so skip any deserialization errors
-			continue
-		}
-		temp.UserID = settingsRow.Subject.User
-		temp.OrgID = settingsRow.Subject.Org
-
-		results = append(results, temp)
-	}
-
-	return results, nil
-}
-
-func getFrontendInsights(ctx context.Context, settingsRow api.Settings) ([]insights.SearchInsight, error) {
-	prefix := "searchInsights."
-	var raw map[string]json.RawMessage
-	results := make([]insights.SearchInsight, 0)
-
-	raw, err := insights.FilterSettingJson(settingsRow.Contents, prefix)
-	if err != nil {
-		return nil, err
-	}
-
-	for id, body := range raw {
-		var temp insights.SearchInsight
-		temp.ID = id
-		if err := json.Unmarshal(body, &temp); err != nil {
-			// a deprecated schema collides with this field name, so skip any deserialization errors
-			continue
-		}
-		temp.UserID = settingsRow.Subject.User
-		temp.OrgID = settingsRow.Subject.Org
-
-		results = append(results, temp)
-	}
-
-	return results, nil
-}
-
-func getBackendInsights(ctx context.Context, settingsRow api.Settings) ([]insights.SearchInsight, error) {
-	prefix := "insights.allrepos"
-	var raw map[string]json.RawMessage
-	results := make([]insights.SearchInsight, 0)
-
-	raw, err := insights.FilterSettingJson(settingsRow.Contents, prefix)
-	if err != nil {
-		return nil, err
-	}
-
-	for id, body := range raw {
-		var temp insights.SearchInsight
-		temp.ID = id
-		if err := json.Unmarshal(body, &temp); err != nil {
-			// a deprecated schema collides with this field name, so skip any deserialization errors
-			continue
-		}
-		temp.UserID = settingsRow.Subject.User
-		temp.OrgID = settingsRow.Subject.Org
-
-		results = append(results, temp)
-	}
-
-	return results, nil
-}
-
-func getDashboards(ctx context.Context, settingsRow api.Settings) ([]insights.SettingDashboard, error) {
-	prefix := "insights.dashboards"
-
-	results := make([]insights.SettingDashboard, 0)
-	var raw map[string]json.RawMessage
-	raw, err := insights.FilterSettingJson(settingsRow.Contents, prefix)
-	if err != nil {
-		return nil, err
-	}
-	for _, val := range raw {
-		// iterate for each instance of the prefix key in the settings. This should never be len > 1, but it's technically a map.
-		temp, err := unmarshalDashboard(val, settingsRow)
-		if err != nil {
-			continue
-		}
-		results = append(results, temp...)
-	}
-
-	return results, nil
-}
-
-func unmarshalDashboard(raw json.RawMessage, settingsRow api.Settings) ([]insights.SettingDashboard, error) {
-	var dict map[string]json.RawMessage
-	var multi error
-	result := []insights.SettingDashboard{}
-
-	if err := json.Unmarshal(raw, &dict); err != nil {
-		return result, err
-	}
-
-	for id, body := range dict {
-		var temp insights.SettingDashboard
-		if err := json.Unmarshal(body, &temp); err != nil {
-			multi = multierror.Append(multi, err)
-			continue
-		}
-		temp.ID = id
-		temp.UserID = settingsRow.Subject.User
-		temp.OrgID = settingsRow.Subject.Org
-
-		result = append(result, temp)
-	}
-
-	return result, multi
-}
-
-func (m *migrator) migrateLangStatsInsights(ctx context.Context, toMigrate []insights.LangStatsInsight) int {
-	var count, skipped, errorCount int
-	for _, d := range toMigrate {
-		if d.ID == "" {
-			// we need a unique ID, and if for some reason this insight doesn't have one, it can't be migrated.
-			skipped++
-			continue
-		}
-		err := migrateLangStatSeries(ctx, &m.insightStore, d)
-		if err != nil {
-			// we can't do anything about errors, so we will just skip it and log it
-			errorCount++
-			log15.Error("insights migration: error while migrating insight", "error", err)
-		} else {
-			count++
-		}
-	}
-	log15.Info("insights settings migration batch complete", "batch", "langStats", "count", count, "skipped", skipped, "errors", errorCount)
-	return count
-}
-
-func migrateLangStatSeries(ctx context.Context, insightStore *store.InsightStore, from insights.LangStatsInsight) (err error) {
-	tx, err := insightStore.Transact(ctx)
-	if err != nil {
-		return err
-	}
-	defer func() { err = tx.Store.Done(err) }()
-
-	log15.Info("insights migration: attempting to migrate insight", "unique_id", from.ID)
-
-	view := types.InsightView{
-		Title:            from.Title,
-		UniqueID:         from.ID,
-		OtherThreshold:   &from.OtherThreshold,
-		PresentationType: types.Pie,
-	}
-	series := types.InsightSeries{
-		SeriesID:           ksuid.New().String(),
-		Repositories:       []string{from.Repository},
-		SampleIntervalUnit: string(types.Month),
-	}
-	var grants []store.InsightViewGrant
-	if from.UserID != nil {
-		grants = []store.InsightViewGrant{store.UserGrant(int(*from.UserID))}
-	} else if from.OrgID != nil {
-		grants = []store.InsightViewGrant{store.OrgGrant(int(*from.OrgID))}
-	} else {
-		grants = []store.InsightViewGrant{store.GlobalGrant()}
-	}
-
-	view, err = tx.CreateView(ctx, view, grants)
-	if err != nil {
-		return errors.Wrapf(err, "unable to migrate insight unique_id: %s", from.ID)
-	}
-	series, err = tx.CreateSeries(ctx, series)
-	if err != nil {
-		return errors.Wrapf(err, "unable to migrate insight unique_id: %s", from.ID)
-	}
-	err = tx.AttachSeriesToView(ctx, series, view, types.InsightViewSeriesMetadata{})
-	if err != nil {
-		return errors.Wrapf(err, "unable to migrate insight unique_id: %s", from.ID)
-	}
-
-	return nil
-}

--- a/enterprise/internal/insights/store/settings_migration_jobs_store.go
+++ b/enterprise/internal/insights/store/settings_migration_jobs_store.go
@@ -140,7 +140,6 @@ ON CONFLICT DO NOTHING;
 
 func (s *DBSettingsMigrationJobsStore) UpdateTotalInsights(ctx context.Context, userId *int, orgId *int, totalInsights int) error {
 	q := sqlf.Sprintf(updateTotalInsightsSql, totalInsights, getWhereForSubject(ctx, userId, orgId))
-	//fmt.Println(q)
 	row := s.QueryRow(ctx, q)
 	if row.Err() != nil {
 		return row.Err()
@@ -155,7 +154,6 @@ UPDATE settings_migration_jobs SET total_insights = %s WHERE %s
 
 func (s *DBSettingsMigrationJobsStore) UpdateMigratedInsights(ctx context.Context, userId *int, orgId *int, migratedInsights int) error {
 	q := sqlf.Sprintf(updateMigratedInsightsSql, migratedInsights, getWhereForSubject(ctx, userId, orgId))
-	//fmt.Println(q)
 	row := s.QueryRow(ctx, q)
 	if row.Err() != nil {
 		return row.Err()
@@ -170,7 +168,6 @@ UPDATE settings_migration_jobs SET migrated_insights = %s WHERE %s
 
 func (s *DBSettingsMigrationJobsStore) UpdateTotalDashboards(ctx context.Context, userId *int, orgId *int, totalDashboards int) error {
 	q := sqlf.Sprintf(updateTotalDashboardsSql, totalDashboards, getWhereForSubject(ctx, userId, orgId))
-	//fmt.Println(q)
 	row := s.QueryRow(ctx, q)
 	if row.Err() != nil {
 		return row.Err()
@@ -185,7 +182,6 @@ UPDATE settings_migration_jobs SET total_dashboards = %s WHERE %s
 
 func (s *DBSettingsMigrationJobsStore) UpdateMigratedDashboards(ctx context.Context, userId *int, orgId *int, migratedDashboards int) error {
 	q := sqlf.Sprintf(updateMigratedDashboardsSql, migratedDashboards, getWhereForSubject(ctx, userId, orgId))
-	//fmt.Println(q)
 	row := s.QueryRow(ctx, q)
 	if row.Err() != nil {
 		return row.Err()
@@ -211,7 +207,6 @@ SELECT COUNT(*) from settings_migration_jobs;
 func (s *DBSettingsMigrationJobsStore) IsJobTypeComplete(ctx context.Context, jobType SettingsMigrationJobType) (bool, error) {
 	where := getWhereForSubjectType(ctx, jobType)
 	q := sqlf.Sprintf(countIncompleteJobsSql, where)
-	//fmt.Println(q)
 
 	count, _, err := basestore.ScanFirstInt(s.Query(ctx, q))
 	return count == 0, err

--- a/enterprise/internal/insights/store/settings_migration_jobs_store.go
+++ b/enterprise/internal/insights/store/settings_migration_jobs_store.go
@@ -63,8 +63,8 @@ func (s *DBSettingsMigrationJobsStore) GetNextSettingsMigrationJobs(ctx context.
 
 const getSettingsMigrationJobsSql = `
 -- source: enterprise/internal/insights/store/settings_migration_jobs.go:GetSettingsMigrationJob
-SELECT user_id, org_id, global, total_insights, migrated_insights, total_dashboards, migrated_dashboards, runs,
-(CASE WHEN completed_at IS NULL THEN FALSE ELSE TRUE END) AS dashboard_created
+SELECT user_id, org_id, (CASE WHEN global IS NULL THEN FALSE ELSE TRUE END) AS global, total_insights, migrated_insights,
+total_dashboards, migrated_dashboards, runs, (CASE WHEN completed_at IS NULL THEN FALSE ELSE TRUE END) AS dashboard_created
 FROM insights_settings_migration_jobs
 WHERE %s AND completed_at IS NULL
 LIMIT 100


### PR DESCRIPTION
- `PerformBatchMigration` works for global, org, and user.
- insight ids are appended with their org or user id.
- Hooks up the new `createDashboard` method.

I tested this out locally with a larger settings file (55 insights, 9 dashboards) from k8s and didn't see any errors, and at a quick glance it seems to have worked. I'm sure there are some bugs, but roughly it's doing the trick. 