### PR TITLE
observability: rename OperationMetrics to REDMetrics

### DIFF
--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -31,7 +31,7 @@ import (
 )
 
 // metricsRecorder records operational metrics for methods.
-var metricsRecorder = metrics.NewOperationMetrics(prometheus.DefaultRegisterer, "updatecheck_client", metrics.WithLabels("method"))
+var metricsRecorder = metrics.NewREDMetrics(prometheus.DefaultRegisterer, "updatecheck_client", metrics.WithLabels("method"))
 
 // Status of the check for software updates for Sourcegraph.
 type Status struct {
@@ -79,7 +79,6 @@ func recordOperation(method string) func(*error) {
 func getAndMarshalSiteActivityJSON(ctx context.Context, db dbutil.DB, criticalOnly bool) (_ json.RawMessage, err error) {
 	defer recordOperation("getAndMarshalSiteActivityJSON")(&err)
 	siteActivity, err := usagestats.GetSiteUsageStats(ctx, db, criticalOnly)
-
 	if err != nil {
 		return nil, err
 	}
@@ -296,8 +295,8 @@ func getRedisVersion(dialFunc func() (redis.Conn, error)) (string, error) {
 
 	m, err := parseRedisInfo(buf)
 	return m["redis_version"], err
-
 }
+
 func parseRedisInfo(buf []byte) (map[string]string, error) {
 	var (
 		lines = bytes.Split(buf, []byte("\n"))
@@ -579,7 +578,6 @@ func check(db dbutil.DB) {
 	mu.Unlock()
 
 	updateVersion, err := doCheck()
-
 	if err != nil {
 		log15.Error("telemetry: updatecheck failed", "error", err)
 	}

--- a/cmd/repo-updater/repoupdater/observability.go
+++ b/cmd/repo-updater/repoupdater/observability.go
@@ -17,14 +17,14 @@ import (
 
 // HandlerMetrics encapsulates the Prometheus metrics of an http.Handler.
 type HandlerMetrics struct {
-	ServeHTTP *metrics.OperationMetrics
+	ServeHTTP *metrics.REDMetrics
 }
 
 // NewHandlerMetrics returns HandlerMetrics that need to be registered
 // in a Prometheus registry.
 func NewHandlerMetrics() HandlerMetrics {
 	return HandlerMetrics{
-		ServeHTTP: &metrics.OperationMetrics{
+		ServeHTTP: &metrics.REDMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Name: "src_repoupdater_http_handler_duration_seconds",
 				Help: "Time spent handling an HTTP request",

--- a/enterprise/cmd/executor/internal/apiclient/observability.go
+++ b/enterprise/cmd/executor/internal/apiclient/observability.go
@@ -18,7 +18,7 @@ type operations struct {
 }
 
 func newOperations(observationContext *observation.Context) *operations {
-	metrics := metrics.NewOperationMetrics(
+	metrics := metrics.NewREDMetrics(
 		observationContext.Registerer,
 		"apiworker_apiclient",
 		metrics.WithLabels("op"),

--- a/enterprise/cmd/executor/internal/command/observability.go
+++ b/enterprise/cmd/executor/internal/command/observability.go
@@ -24,7 +24,7 @@ type Operations struct {
 }
 
 func NewOperations(observationContext *observation.Context) *Operations {
-	metrics := metrics.NewOperationMetrics(
+	metrics := metrics.NewREDMetrics(
 		observationContext.Registerer,
 		"apiworker_command",
 		metrics.WithLabels("op"),

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/observability.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/observability.go
@@ -34,7 +34,7 @@ type operations struct {
 }
 
 func newOperations(observationContext *observation.Context) *operations {
-	metrics := metrics.NewOperationMetrics(
+	metrics := metrics.NewREDMetrics(
 		observationContext.Registerer,
 		"codeintel_resolvers",
 		metrics.WithLabels("op"),

--- a/enterprise/cmd/worker/internal/codeintel/commitgraph/observability.go
+++ b/enterprise/cmd/worker/internal/codeintel/commitgraph/observability.go
@@ -17,7 +17,7 @@ type operations struct {
 func newOperations(dbStore DBStore, observationContext *observation.Context) *operations {
 	commitUpdate := observationContext.Operation(observation.Op{
 		Name: "codeintel.commitUpdater",
-		Metrics: metrics.NewOperationMetrics(
+		Metrics: metrics.NewREDMetrics(
 			observationContext.Registerer,
 			"codeintel_commit_graph_processor",
 			metrics.WithCountHelp("Total number of method invocations."),

--- a/enterprise/cmd/worker/internal/codeintel/indexing/observability.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/observability.go
@@ -24,7 +24,7 @@ var (
 
 func newOperations(observationContext *observation.Context) *schedulerOperations {
 	once.Do(func() {
-		m := metrics.NewOperationMetrics(
+		m := metrics.NewREDMetrics(
 			observationContext.Registerer,
 			"codeintel_index_scheduler",
 			metrics.WithLabels("op"),
@@ -43,7 +43,7 @@ func newOperations(observationContext *observation.Context) *schedulerOperations
 			HandleIndexScheduler: op("indexing", "HandleIndexSchedule"),
 		}
 
-		m = metrics.NewOperationMetrics(
+		m = metrics.NewREDMetrics(
 			observationContext.Registerer,
 			"codeintel_dependency_repos",
 			metrics.WithLabels("op", "scheme", "new"),

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -89,7 +89,7 @@ var (
 // TODO: We should create one per observationContext.
 func newOperations(observationContext *observation.Context) *operations {
 	operationsOnce.Do(func() {
-		m := metrics.NewOperationMetrics(
+		m := metrics.NewREDMetrics(
 			observationContext.Registerer,
 			"batches_service",
 			metrics.WithLabels("op"),
@@ -1161,7 +1161,7 @@ func (s *Service) RetryBatchSpecWorkspaces(ctx context.Context, workspaceIDs []i
 	}
 
 	var errs *multierror.Error
-	var jobIDs = make([]int64, len(jobs))
+	jobIDs := make([]int64, len(jobs))
 
 	for i, j := range jobs {
 		if !j.State.Retryable() {

--- a/enterprise/internal/batches/store/store.go
+++ b/enterprise/internal/batches/store/store.go
@@ -283,7 +283,7 @@ var (
 // TODO: We should create one per observationContext.
 func newOperations(observationContext *observation.Context) *operations {
 	operationsOnce.Do(func() {
-		m := metrics.NewOperationMetrics(
+		m := metrics.NewREDMetrics(
 			observationContext.Registerer,
 			"batches_dbstore",
 			metrics.WithLabels("op"),

--- a/enterprise/internal/codeintel/autoindex/enqueuer/observability.go
+++ b/enterprise/internal/codeintel/autoindex/enqueuer/observability.go
@@ -14,7 +14,7 @@ type operations struct {
 }
 
 func newOperations(observationContext *observation.Context) *operations {
-	metrics := metrics.NewOperationMetrics(
+	metrics := metrics.NewREDMetrics(
 		observationContext.Registerer,
 		"codeintel_autoindex_enqueuer",
 		metrics.WithLabels("op"),

--- a/enterprise/internal/codeintel/gitserver/observability.go
+++ b/enterprise/internal/codeintel/gitserver/observability.go
@@ -26,7 +26,7 @@ type operations struct {
 }
 
 func newOperations(observationContext *observation.Context) *operations {
-	metrics := metrics.NewOperationMetrics(
+	metrics := metrics.NewREDMetrics(
 		observationContext.Registerer,
 		"codeintel_gitserver",
 		metrics.WithLabels("op"),

--- a/enterprise/internal/codeintel/repoupdater/observability.go
+++ b/enterprise/internal/codeintel/repoupdater/observability.go
@@ -13,7 +13,7 @@ type operations struct {
 }
 
 func newOperations(observationContext *observation.Context) *operations {
-	metrics := metrics.NewOperationMetrics(
+	metrics := metrics.NewREDMetrics(
 		observationContext.Registerer,
 		"codeintel_repoupdater",
 		metrics.WithLabels("op"),

--- a/enterprise/internal/codeintel/stores/dbstore/observability.go
+++ b/enterprise/internal/codeintel/stores/dbstore/observability.go
@@ -84,7 +84,7 @@ type operations struct {
 	writeVisibleUploads        *observation.Operation
 }
 
-func newOperations(observationContext *observation.Context, metrics *metrics.OperationMetrics) *operations {
+func newOperations(observationContext *observation.Context, metrics *metrics.REDMetrics) *operations {
 	op := func(name string) *observation.Operation {
 		return observationContext.Operation(observation.Op{
 			Name:              fmt.Sprintf("codeintel.dbstore.%s", name),

--- a/enterprise/internal/codeintel/stores/dbstore/store.go
+++ b/enterprise/internal/codeintel/stores/dbstore/store.go
@@ -18,7 +18,7 @@ type Store struct {
 
 func NewWithDB(db dbutil.DB, observationContext *observation.Context) *Store {
 	// Use same prometheus metric created by the OSS layer
-	operationsMetrics := dbstore.NewOperationsMetrics(observationContext)
+	operationsMetrics := dbstore.NewREDMetrics(observationContext)
 
 	return &Store{
 		Store:      dbstore.NewWithDB(db, observationContext, operationsMetrics),

--- a/enterprise/internal/codeintel/stores/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/observability.go
@@ -49,7 +49,7 @@ type operations struct {
 }
 
 func newOperations(observationContext *observation.Context) *operations {
-	metrics := metrics.NewOperationMetrics(
+	metrics := metrics.NewREDMetrics(
 		observationContext.Registerer,
 		"codeintel_lsifstore",
 		metrics.WithLabels("op"),

--- a/enterprise/internal/codeintel/stores/uploadstore/observability.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/observability.go
@@ -15,7 +15,7 @@ type operations struct {
 }
 
 func newOperations(observationContext *observation.Context) *operations {
-	metrics := metrics.NewOperationMetrics(
+	metrics := metrics.NewREDMetrics(
 		observationContext.Registerer,
 		"codeintel_uploadstore",
 		metrics.WithLabels("op"),

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -66,7 +66,7 @@ import (
 // to backfill them by enqueueing work for executing searches with `before:` and `after:` filter
 // ranges.
 func newInsightHistoricalEnqueuer(ctx context.Context, workerBaseStore *basestore.Store, dataSeriesStore store.DataSeriesStore, insightsStore *store.Store, observationContext *observation.Context) goroutine.BackgroundRoutine {
-	metrics := metrics.NewOperationMetrics(
+	metrics := metrics.NewREDMetrics(
 		observationContext.Registerer,
 		"insights_historical_enqueuer",
 		metrics.WithCountHelp("Total number of insights historical enqueuer executions"),

--- a/enterprise/internal/insights/background/insight_enqueuer.go
+++ b/enterprise/internal/insights/background/insight_enqueuer.go
@@ -27,7 +27,7 @@ import (
 // and webhook insights across all user settings, and enqueue work for the query runner and webhook
 // runner workers to perform.
 func newInsightEnqueuer(ctx context.Context, workerBaseStore *basestore.Store, insightStore store.DataSeriesStore, observationContext *observation.Context) goroutine.BackgroundRoutine {
-	metrics := metrics.NewOperationMetrics(
+	metrics := metrics.NewREDMetrics(
 		observationContext.Registerer,
 		"insights_enqueuer",
 		metrics.WithCountHelp("Total number of insights enqueuer executions"),

--- a/enterprise/internal/insights/background/queryrunner/cleaner.go
+++ b/enterprise/internal/insights/background/queryrunner/cleaner.go
@@ -19,7 +19,7 @@ import (
 // num_series*num_repos*num_timeframes jobs (example: 20*40,000*6 in an average case) which
 // can quickly add up to be millions of jobs left in a "completed" state in the DB.
 func NewCleaner(ctx context.Context, workerBaseStore *basestore.Store, observationContext *observation.Context) goroutine.BackgroundRoutine {
-	metrics := metrics.NewOperationMetrics(
+	metrics := metrics.NewREDMetrics(
 		observationContext.Registerer,
 		"insights_query_runner_cleaner",
 		metrics.WithCountHelp("Total number of insights queryrunner cleaner executions"),

--- a/enterprise/internal/insights/compression/observability.go
+++ b/enterprise/internal/insights/compression/observability.go
@@ -17,7 +17,7 @@ type operations struct {
 func newOperations(observationContext *observation.Context) *operations {
 	worker := observationContext.Operation(observation.Op{
 		Name: "CommitIndexer.Run",
-		Metrics: metrics.NewOperationMetrics(
+		Metrics: metrics.NewREDMetrics(
 			observationContext.Registerer,
 			"insights_commit_indexer",
 			metrics.WithCountHelp("Total number of commit indexer executions"),
@@ -26,7 +26,7 @@ func newOperations(observationContext *observation.Context) *operations {
 
 	getCommits := observationContext.Operation(observation.Op{
 		Name: "CommitIndexer.GetCommits",
-		Metrics: metrics.NewOperationMetrics(
+		Metrics: metrics.NewREDMetrics(
 			observationContext.Registerer,
 			"insights_commit_indexer_fetch",
 			metrics.WithCountHelp("Time for the commit indexer to fetch commits from gitserver."),

--- a/internal/codeintel/stores/dbstore/observability.go
+++ b/internal/codeintel/stores/dbstore/observability.go
@@ -12,8 +12,8 @@ type Operations struct {
 	getJVMDependencies *observation.Operation
 }
 
-func NewOperationsMetrics(observationContext *observation.Context) *metrics.OperationMetrics {
-	return metrics.NewOperationMetrics(
+func NewREDMetrics(observationContext *observation.Context) *metrics.REDMetrics {
+	return metrics.NewREDMetrics(
 		observationContext.Registerer,
 		"codeintel_dbstore",
 		metrics.WithLabels("op"),
@@ -21,7 +21,7 @@ func NewOperationsMetrics(observationContext *observation.Context) *metrics.Oper
 	)
 }
 
-func NewOperationsFromMetrics(observationContext *observation.Context, metrics *metrics.OperationMetrics) *Operations {
+func NewOperations(observationContext *observation.Context, metrics *metrics.REDMetrics) *Operations {
 	op := func(name string) *observation.Operation {
 		return observationContext.Operation(observation.Op{
 			Name:              fmt.Sprintf("codeintel.dbstore.%s", name),

--- a/internal/codeintel/stores/dbstore/store.go
+++ b/internal/codeintel/stores/dbstore/store.go
@@ -15,14 +15,14 @@ type Store struct {
 	operations *Operations
 }
 
-func NewWithDB(db dbutil.DB, observationContext *observation.Context, metrics *metrics.OperationMetrics) *Store {
+func NewWithDB(db dbutil.DB, observationContext *observation.Context, metrics *metrics.REDMetrics) *Store {
 	if metrics == nil {
-		metrics = NewOperationsMetrics(observationContext)
+		metrics = NewREDMetrics(observationContext)
 	}
 
 	return &Store{
 		Store:      basestore.NewWithDB(db, sql.TxOptions{}),
-		operations: NewOperationsFromMetrics(observationContext, metrics),
+		operations: NewOperations(observationContext, metrics),
 	}
 }
 

--- a/internal/extsvc/jvmpackages/coursier/coursier.go
+++ b/internal/extsvc/jvmpackages/coursier/coursier.go
@@ -40,7 +40,7 @@ func init() {
 		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
 		Registerer: prometheus.DefaultRegisterer,
 	}
-	operations = NewOperationsFromMetrics(observationContext)
+	operations = NewOperations(observationContext)
 
 	// Should only be set for gitserver for persistence, repo-updater will use ephemeral storage.
 	// repo-updater only performs existence checks which doesnt involve downloading any JARs (except for JDK),

--- a/internal/extsvc/jvmpackages/coursier/observability.go
+++ b/internal/extsvc/jvmpackages/coursier/observability.go
@@ -15,8 +15,8 @@ type Operations struct {
 	runCommand    *observation.Operation
 }
 
-func NewOperationsFromMetrics(observationContext *observation.Context) *Operations {
-	metrics := metrics.NewOperationMetrics(
+func NewOperations(observationContext *observation.Context) *Operations {
+	metrics := metrics.NewREDMetrics(
 		observationContext.Registerer,
 		"codeintel_coursier",
 		metrics.WithLabels("op"),

--- a/internal/metrics/operation.go
+++ b/internal/metrics/operation.go
@@ -7,15 +7,22 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// OperationMetrics contains three common metrics for any operation.
-type OperationMetrics struct {
-	Duration *prometheus.HistogramVec // How long did it take?
+// REDMetrics contains three common metrics for any operation.
+// It is modeled after the RED method, which defines three characteristics for
+// monitoring services:
+//
+//  - number (rate) of requests per second
+//  - number of errors/failed operations
+//  - amount of time per operation
+// https://thenewstack.io/monitoring-microservices-red-method/.
+type REDMetrics struct {
 	Count    *prometheus.CounterVec   // How many things were processed?
 	Errors   *prometheus.CounterVec   // How many errors occurred?
+	Duration *prometheus.HistogramVec // How long did it take?
 }
 
 // Observe registers an observation of a single operation.
-func (m *OperationMetrics) Observe(secs, count float64, err *error, lvals ...string) {
+func (m *REDMetrics) Observe(secs, count float64, err *error, lvals ...string) {
 	if m == nil {
 		return
 	}
@@ -28,7 +35,7 @@ func (m *OperationMetrics) Observe(secs, count float64, err *error, lvals ...str
 	}
 }
 
-type operationMetricOptions struct {
+type redMetricOptions struct {
 	subsystem       string
 	durationHelp    string
 	countHelp       string
@@ -37,21 +44,22 @@ type operationMetricOptions struct {
 	durationBuckets []float64
 }
 
-// OperationMetricsOption alter the default behavior of NewOperationMetrics.
-type OperationMetricsOption func(o *operationMetricOptions)
+// REDMetricsOption alter the default behavior of NewREDMetrics.
+type REDMetricsOption func(o *redMetricOptions)
 
 // WithSubsystem overrides the default subsystem for all metrics.
-func WithSubsystem(subsystem string) OperationMetricsOption {
-	return func(o *operationMetricOptions) { o.subsystem = subsystem }
+func WithSubsystem(subsystem string) REDMetricsOption {
+	return func(o *redMetricOptions) { o.subsystem = subsystem }
 }
 
 // WithDurationHelp overrides the default help text for duration metrics.
-func WithDurationHelp(text string) OperationMetricsOption {
-	return func(o *operationMetricOptions) { o.durationHelp = text }
+func WithDurationHelp(text string) REDMetricsOption {
+	return func(o *redMetricOptions) { o.durationHelp = text }
 }
 
-func WithDurationBuckets(buckets []float64) OperationMetricsOption {
-	return func(o *operationMetricOptions) {
+// WithDurationBuckets overrides the default histogram bucket values for duration metrics.
+func WithDurationBuckets(buckets []float64) REDMetricsOption {
+	return func(o *redMetricOptions) {
 		if len(buckets) != 0 {
 			o.durationBuckets = buckets
 		}
@@ -59,26 +67,26 @@ func WithDurationBuckets(buckets []float64) OperationMetricsOption {
 }
 
 // WithCountHelp overrides the default help text for count metrics.
-func WithCountHelp(text string) OperationMetricsOption {
-	return func(o *operationMetricOptions) { o.countHelp = text }
+func WithCountHelp(text string) REDMetricsOption {
+	return func(o *redMetricOptions) { o.countHelp = text }
 }
 
 // WithErrorsHelp overrides the default help text for errors metrics.
-func WithErrorsHelp(text string) OperationMetricsOption {
-	return func(o *operationMetricOptions) { o.errorsHelp = text }
+func WithErrorsHelp(text string) REDMetricsOption {
+	return func(o *redMetricOptions) { o.errorsHelp = text }
 }
 
 // WithLabels overrides the default labels for all metrics.
-func WithLabels(labels ...string) OperationMetricsOption {
-	return func(o *operationMetricOptions) { o.labels = labels }
+func WithLabels(labels ...string) REDMetricsOption {
+	return func(o *redMetricOptions) { o.labels = labels }
 }
 
-// NewOperationMetrics creates an OperationMetrics value. The metrics will be
+// NewREDMetrics creates an REDMetrics value. The metrics will be
 // immediately registered to the given registerer. This method panics on registration
 // error. The supplied metricPrefix should be underscore_cased as it is used in the
 // metric name.
-func NewOperationMetrics(r prometheus.Registerer, metricPrefix string, fns ...OperationMetricsOption) *OperationMetrics {
-	options := &operationMetricOptions{
+func NewREDMetrics(r prometheus.Registerer, metricPrefix string, fns ...REDMetricsOption) *REDMetrics {
+	options := &redMetricOptions{
 		subsystem:       "",
 		durationHelp:    fmt.Sprintf("Time in seconds spent performing successful %s operations", metricPrefix),
 		countHelp:       fmt.Sprintf("Total number of successful %s operations", metricPrefix),
@@ -125,22 +133,22 @@ func NewOperationMetrics(r prometheus.Registerer, metricPrefix string, fns ...Op
 	)
 	r.MustRegister(errors)
 
-	return &OperationMetrics{
+	return &REDMetrics{
 		Duration: duration,
 		Count:    count,
 		Errors:   errors,
 	}
 }
 
-type SingletonOperationMetrics struct {
+type SingletonREDnMetrics struct {
 	sync.Once
-	metrics *OperationMetrics
+	metrics *REDMetrics
 }
 
-// SingletonOperationMetrics returns an operation metrics instance. If no instance has been
+// Get returns a RED metrics instance. If no instance has been
 // created yet, one is constructed with the given create function. This method is safe to
 // access concurrently.
-func (m *SingletonOperationMetrics) Get(create func() *OperationMetrics) *OperationMetrics {
+func (m *SingletonREDnMetrics) Get(create func() *REDMetrics) *REDMetrics {
 	m.Do(func() {
 		m.metrics = create()
 	})

--- a/internal/observation/observation.go
+++ b/internal/observation/observation.go
@@ -22,7 +22,7 @@
 //         prometheus.DefaultRegisterer,
 //     )
 //
-//     metrics := metrics.NewOperationMetrics(
+//     metrics := metrics.NewREDMetrics(
 //         observationContext.Registerer,
 //         "thing",
 //         metrics.WithLabels("op"),
@@ -88,7 +88,9 @@ const (
 
 // Op configures an Operation instance.
 type Op struct {
-	Metrics *metrics.OperationMetrics
+	// Metrics sets the RED metrics triplet used to monitor & track metrics for this operation.
+	// This field is optional, with `nil` meaning no metrics will be tracked for this.
+	Metrics *metrics.REDMetrics
 	// Name configures the trace and error log names. This string should be of the
 	// format {GroupName}.{OperationName}, where both sections are title cased
 	// (e.g. Store.GetRepoByID).
@@ -125,12 +127,12 @@ func (c *Context) Operation(args Op) *Operation {
 // Operation represents an interesting section of code that can be invoked.
 type Operation struct {
 	context      *Context
-	metrics      *metrics.OperationMetrics
+	metrics      *metrics.REDMetrics
+	errorFilter  func(err error) ErrorFilterBehaviour
 	name         string
 	kebabName    string
 	metricLabels []string
 	logFields    []log.Field
-	errorFilter  func(err error) ErrorFilterBehaviour
 }
 
 // TraceLogger is returned from WithAndLogger and can be used to add timestamped key and

--- a/internal/oobmigration/observability.go
+++ b/internal/oobmigration/observability.go
@@ -14,7 +14,7 @@ type operations struct {
 }
 
 func newOperations(observationContext *observation.Context) *operations {
-	metrics := metrics.NewOperationMetrics(
+	metrics := metrics.NewREDMetrics(
 		observationContext.Registerer,
 		"oobmigration",
 		metrics.WithLabels("op", "migration"),

--- a/internal/repos/jvm_packages.go
+++ b/internal/repos/jvm_packages.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	observationContext *observation.Context
-	operationMetrics   *metrics.OperationMetrics
+	operationMetrics   *metrics.REDMetrics
 	once               sync.Once
 )
 
@@ -60,7 +60,7 @@ func (s *JVMPackagesSource) SetDB(db dbutil.DB) {
 			Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
 			Registerer: prometheus.DefaultRegisterer,
 		}
-		operationMetrics = dbstore.NewOperationsMetrics(observationContext)
+		operationMetrics = dbstore.NewREDMetrics(observationContext)
 	})
 	s.dbStore = dbstore.NewWithDB(db, observationContext, operationMetrics)
 }

--- a/internal/repos/observability.go
+++ b/internal/repos/observability.go
@@ -37,8 +37,8 @@ type observedSource struct {
 
 // SourceMetrics encapsulates the Prometheus metrics of a Source.
 type SourceMetrics struct {
-	ListRepos *metrics.OperationMetrics
-	GetRepo   *metrics.OperationMetrics
+	ListRepos *metrics.REDMetrics
+	GetRepo   *metrics.REDMetrics
 }
 
 // MustRegister registers all metrics in SourceMetrics in the given
@@ -56,7 +56,7 @@ func (sm SourceMetrics) MustRegister(r prometheus.Registerer) {
 // in a Prometheus registry.
 func NewSourceMetrics() SourceMetrics {
 	return SourceMetrics{
-		ListRepos: &metrics.OperationMetrics{
+		ListRepos: &metrics.REDMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Name: "src_repoupdater_source_duration_seconds",
 				Help: "Time spent sourcing repos",
@@ -70,7 +70,7 @@ func NewSourceMetrics() SourceMetrics {
 				Help: "Total number of sourcing errors",
 			}, []string{}),
 		},
-		GetRepo: &metrics.OperationMetrics{
+		GetRepo: &metrics.REDMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Name: "src_repoupdater_source_get_repo_duration_seconds",
 				Help: "Time spent calling GetRepo",
@@ -138,28 +138,28 @@ func (o *observedSource) GetRepo(ctx context.Context, path string) (sourced *typ
 
 // StoreMetrics encapsulates the Prometheus metrics of a Store.
 type StoreMetrics struct {
-	Transact                           *metrics.OperationMetrics
-	Done                               *metrics.OperationMetrics
-	CreateExternalServiceRepo          *metrics.OperationMetrics
-	UpdateExternalServiceRepo          *metrics.OperationMetrics
-	DeleteExternalServiceRepo          *metrics.OperationMetrics
-	DeleteExternalServiceReposNotIn    *metrics.OperationMetrics
-	UpsertRepos                        *metrics.OperationMetrics
-	UpsertSources                      *metrics.OperationMetrics
-	ListExternalRepoSpecs              *metrics.OperationMetrics
-	ListExternalServiceUserIDsByRepoID *metrics.OperationMetrics
-	ListExternalServiceRepoIDsByUserID *metrics.OperationMetrics
-	GetExternalService                 *metrics.OperationMetrics
-	SetClonedRepos                     *metrics.OperationMetrics
-	CountNotClonedRepos                *metrics.OperationMetrics
-	CountUserAddedRepos                *metrics.OperationMetrics
-	EnqueueSyncJobs                    *metrics.OperationMetrics
+	Transact                           *metrics.REDMetrics
+	Done                               *metrics.REDMetrics
+	CreateExternalServiceRepo          *metrics.REDMetrics
+	UpdateExternalServiceRepo          *metrics.REDMetrics
+	DeleteExternalServiceRepo          *metrics.REDMetrics
+	DeleteExternalServiceReposNotIn    *metrics.REDMetrics
+	UpsertRepos                        *metrics.REDMetrics
+	UpsertSources                      *metrics.REDMetrics
+	ListExternalRepoSpecs              *metrics.REDMetrics
+	ListExternalServiceUserIDsByRepoID *metrics.REDMetrics
+	ListExternalServiceRepoIDsByUserID *metrics.REDMetrics
+	GetExternalService                 *metrics.REDMetrics
+	SetClonedRepos                     *metrics.REDMetrics
+	CountNotClonedRepos                *metrics.REDMetrics
+	CountUserAddedRepos                *metrics.REDMetrics
+	EnqueueSyncJobs                    *metrics.REDMetrics
 }
 
 // MustRegister registers all metrics in StoreMetrics in the given
 // prometheus.Registerer. It panics in case of failure.
 func (sm StoreMetrics) MustRegister(r prometheus.Registerer) {
-	for _, om := range []*metrics.OperationMetrics{
+	for _, om := range []*metrics.REDMetrics{
 		sm.Transact,
 		sm.Done,
 		sm.ListExternalRepoSpecs,
@@ -184,7 +184,7 @@ func (sm StoreMetrics) MustRegister(r prometheus.Registerer) {
 // in a Prometheus registry.
 func NewStoreMetrics() StoreMetrics {
 	return StoreMetrics{
-		Transact: &metrics.OperationMetrics{
+		Transact: &metrics.REDMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Name: "src_repoupdater_store_transact_duration_seconds",
 				Help: "Time spent opening a transaction",
@@ -198,7 +198,7 @@ func NewStoreMetrics() StoreMetrics {
 				Help: "Total number of errors when opening a transaction",
 			}, []string{}),
 		},
-		Done: &metrics.OperationMetrics{
+		Done: &metrics.REDMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Name: "src_repoupdater_store_done_duration_seconds",
 				Help: "Time spent closing a transaction",
@@ -212,7 +212,7 @@ func NewStoreMetrics() StoreMetrics {
 				Help: "Total number of errors when closing a transaction",
 			}, []string{}),
 		},
-		CreateExternalServiceRepo: &metrics.OperationMetrics{
+		CreateExternalServiceRepo: &metrics.REDMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Name: "src_repocreater_store_create_external_service_repo_duration_seconds",
 				Help: "Time spent creating external service repos",
@@ -226,7 +226,7 @@ func NewStoreMetrics() StoreMetrics {
 				Help: "Total number of errors when creating external service repos",
 			}, []string{}),
 		},
-		UpdateExternalServiceRepo: &metrics.OperationMetrics{
+		UpdateExternalServiceRepo: &metrics.REDMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Name: "src_repoupdater_store_update_external_service_repo_duration_seconds",
 				Help: "Time spent updating external service repos",
@@ -240,7 +240,7 @@ func NewStoreMetrics() StoreMetrics {
 				Help: "Total number of errors when updating external service repos",
 			}, []string{}),
 		},
-		DeleteExternalServiceRepo: &metrics.OperationMetrics{
+		DeleteExternalServiceRepo: &metrics.REDMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Name: "src_repoupdater_store_delete_external_service_repo_duration_seconds",
 				Help: "Time spent deleting external service repos",
@@ -254,7 +254,7 @@ func NewStoreMetrics() StoreMetrics {
 				Help: "Total number of errors when deleting external service repos",
 			}, []string{}),
 		},
-		DeleteExternalServiceReposNotIn: &metrics.OperationMetrics{
+		DeleteExternalServiceReposNotIn: &metrics.REDMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Name: "src_repoupdater_store_delete_exernal_service_repos_not_in_duration_seconds",
 				Help: "Time spent calling DeleteExternalServiceReposNotIn",
@@ -268,7 +268,7 @@ func NewStoreMetrics() StoreMetrics {
 				Help: "Total number of errors when calling DeleteExternalServiceReposNotIn",
 			}, []string{}),
 		},
-		UpsertRepos: &metrics.OperationMetrics{
+		UpsertRepos: &metrics.REDMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Name: "src_repoupdater_store_upsert_repos_duration_seconds",
 				Help: "Time spent upserting repos",
@@ -282,7 +282,7 @@ func NewStoreMetrics() StoreMetrics {
 				Help: "Total number of errors when upserting repos",
 			}, []string{}),
 		},
-		UpsertSources: &metrics.OperationMetrics{
+		UpsertSources: &metrics.REDMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Name: "src_repoupdater_store_upsert_sources_duration_seconds",
 				Help: "Time spent upserting sources",
@@ -296,7 +296,7 @@ func NewStoreMetrics() StoreMetrics {
 				Help: "Total number of errors when upserting sources",
 			}, []string{}),
 		},
-		ListExternalRepoSpecs: &metrics.OperationMetrics{
+		ListExternalRepoSpecs: &metrics.REDMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Name: "src_repoupdater_store_list_external_repo_specs_duration_seconds",
 				Help: "Time spent listing external repo specs",
@@ -310,7 +310,7 @@ func NewStoreMetrics() StoreMetrics {
 				Help: "Total number of errors when listing external repo specs",
 			}, []string{}),
 		},
-		ListExternalServiceUserIDsByRepoID: &metrics.OperationMetrics{
+		ListExternalServiceUserIDsByRepoID: &metrics.REDMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Name: "src_repoupdater_store_list_external_service_user_ids_by_repo_id",
 				Help: "Time spent listing external service users",
@@ -324,7 +324,7 @@ func NewStoreMetrics() StoreMetrics {
 				Help: "Total number of errors when listing external service users",
 			}, []string{}),
 		},
-		ListExternalServiceRepoIDsByUserID: &metrics.OperationMetrics{
+		ListExternalServiceRepoIDsByUserID: &metrics.REDMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Name: "src_repoupdater_store_list_external_service_repo_ids_by_user_id",
 				Help: "Time spent listing external service repos",
@@ -338,7 +338,7 @@ func NewStoreMetrics() StoreMetrics {
 				Help: "Total number of errors when listing external service repos",
 			}, []string{}),
 		},
-		GetExternalService: &metrics.OperationMetrics{
+		GetExternalService: &metrics.REDMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Name: "src_external_serviceupdater_store_get_external_service_duration_seconds",
 				Help: "Time spent getting external_services",
@@ -352,7 +352,7 @@ func NewStoreMetrics() StoreMetrics {
 				Help: "Total number of errors when getting external_services",
 			}, []string{}),
 		},
-		SetClonedRepos: &metrics.OperationMetrics{
+		SetClonedRepos: &metrics.REDMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Name: "src_repoupdater_store_set_cloned_repos_duration_seconds",
 				Help: "Time spent setting cloned repos",
@@ -366,7 +366,7 @@ func NewStoreMetrics() StoreMetrics {
 				Help: "Total number of errors when setting cloned repos",
 			}, []string{}),
 		},
-		CountNotClonedRepos: &metrics.OperationMetrics{
+		CountNotClonedRepos: &metrics.REDMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Name: "src_repoupdater_store_count_not_cloned_repos_duration_seconds",
 				Help: "Time spent counting not-cloned repos",
@@ -380,7 +380,7 @@ func NewStoreMetrics() StoreMetrics {
 				Help: "Total number of errors when counting not-cloned repos",
 			}, []string{}),
 		},
-		CountUserAddedRepos: &metrics.OperationMetrics{
+		CountUserAddedRepos: &metrics.REDMetrics{
 			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 				Name: "src_repoupdater_store_count_user_added_repos",
 				Help: "Time spent counting the number of user added repos",

--- a/internal/workerutil/dbworker/store/observability.go
+++ b/internal/workerutil/dbworker/store/observability.go
@@ -21,7 +21,7 @@ type operations struct {
 }
 
 func newOperations(storeName string, observationContext *observation.Context) *operations {
-	metrics := metrics.NewOperationMetrics(
+	metrics := metrics.NewREDMetrics(
 		observationContext.Registerer,
 		fmt.Sprintf("workerutil_dbworker_store_%s", storeName),
 		metrics.WithLabels("op"),

--- a/internal/workerutil/observability.go
+++ b/internal/workerutil/observability.go
@@ -87,7 +87,7 @@ func NewMetrics(observationContext *observation.Context, prefix string, opts ...
 }
 
 func newOperations(observationContext *observation.Context, prefix string, keys, values []string, durationBuckets []float64) *operations {
-	metrics := metrics.NewOperationMetrics(
+	metrics := metrics.NewREDMetrics(
 		observationContext.Registerer,
 		prefix,
 		metrics.WithLabels(append(keys, "op")...),

--- a/monitoring/definitions/shared/observation.go
+++ b/monitoring/definitions/shared/observation.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Observation exports available shared observable and group constructors related
-// to the metrics emitted by internal/metrics.NewOperationMetrics in the Go backend.
+// to the metrics emitted by internal/metrics.NewREDMetrics in the Go backend.
 var Observation = observationConstructor{
 	Total:     Standard.Count("operations"),
 	Duration:  Standard.Duration("operation"),
@@ -76,7 +76,7 @@ type ObservationGroupOptions struct {
 //   - histogram of the format `src_{options.MetricNameRoot}_duration_seconds_bucket`
 //   - counter of the format `src_{options.MetricNameRoot}_errors_total`
 //
-// These metrics can be created via internal/metrics.NewOperationMetrics in the Go backend.
+// These metrics can be created via internal/metrics.NewREDMetrics in the Go backend.
 func (observationConstructor) NewGroup(containerName string, owner monitoring.ObservableOwner, options ObservationGroupOptions) monitoring.Group {
 	rows := make([]monitoring.Row, 0, 2)
 


### PR DESCRIPTION
To clarify purpose/intent, this PR renames OperationMetrics and related types/methods/functions to REDMetrics. Functionally nothing changes, this simply came about due to my repeated confusion about what OperationMetrics does in comparison to other similarly named types, making it immediately clear from the name that it configures the RED triplet of metrics as per https://thenewstack.io/monitoring-microservices-red-method/