### PR TITLE
ci: only generate semantic tags on main branch

### DIFF
--- a/enterprise/dev/ci/internal/ci/config.go
+++ b/enterprise/dev/ci/internal/ci/config.go
@@ -82,10 +82,17 @@ func NewConfig(now time.Time) Config {
 	// special tag adjustments based on run type
 	switch {
 	case runType.Is(TaggedRelease):
+		// This tag is used for publishing versioned releases.
+		//
 		// The Git tag "v1.2.3" should map to the Docker image "1.2.3" (without v prefix).
 		tag = strings.TrimPrefix(tag, "v")
-	default:
+	case runType.Is(MainBranch):
+		// This tag is used for deploying continuously. Only ever generate this on the
+		// main branch.
 		tag = fmt.Sprintf("%05d_%s_%.7s", buildNumber, now.Format("2006-01-02"), commit)
+	default:
+		// Encode branch inside build tag by default.
+		tag = fmt.Sprintf("%s_%05d_%s_%.7s", branch, buildNumber, now.Format("2006-01-02"), commit)
 	}
 	if runType.Is(ImagePatch, ImagePatchNoTest, ExecutorPatchNoTest) {
 		// Add additional patch suffix


### PR DESCRIPTION
See [INC-47](https://app.incident.io/incidents/47). As a result of us switching to semantic versions in deploy-sourcegraph-dot-com (see: https://github.com/sourcegraph/deploy-sourcegraph-dot-com/commit/1399713cb525b7e346a8e73663473a95df9d3c74), we lost the previous guard against unexpected deployments from other branches that we had when we used `insiders`.

This changes the pipeline to only generate these semantic versions in `main`, otherwise it encodes the branch into the tag.