### PR TITLE
compute: recognize structural output syntax

### DIFF
--- a/internal/compute/output_command_test.go
+++ b/internal/compute/output_command_test.go
@@ -66,7 +66,18 @@ func TestRun(t *testing.T) {
 	}
 
 	autogold.Want(
-		"template substitution",
+		"template substitution regexp",
 		"(1)\n(2)\n(3)\n").
 		Equal(t, test(`content:output((\d) -> ($1))`, "a 1 b 2 c 3"))
+
+	// If we are not on CI skip the test if comby is not installed.
+	if os.Getenv("CI") == "" && !comby.Exists() {
+		t.Skip("comby is not installed on the PATH. Try running 'bash <(curl -sL get.comby.dev)'.")
+	}
+
+	autogold.Want(
+		"template substitution structural",
+		">bar<").
+		Equal(t, test(`content:output.structural(foo(:[arg]) -> >:[arg]<)`, "foo(bar)"))
+
 }

--- a/internal/compute/query.go
+++ b/internal/compute/query.go
@@ -108,6 +108,8 @@ var ComputePredicateRegistry = query.PredicateRegistry{
 		"replace.regexp":     func() query.Predicate { return query.EmptyPredicate{} },
 		"replace.structural": func() query.Predicate { return query.EmptyPredicate{} },
 		"output":             func() query.Predicate { return query.EmptyPredicate{} },
+		"output.regexp":      func() query.Predicate { return query.EmptyPredicate{} },
+		"output.structural":  func() query.Predicate { return query.EmptyPredicate{} },
 	},
 }
 
@@ -175,12 +177,15 @@ func parseOutput(pattern *query.Pattern) (Command, bool, error) {
 
 	var matchPattern MatchPattern
 	switch name {
-	case "output":
+	case "output", "output.regexp":
 		var err error
 		matchPattern, err = toRegexpPattern(left)
 		if err != nil {
 			return nil, false, errors.Wrap(err, "output command")
 		}
+	case "output.structural":
+		// structural search doesn't do any match pattern validation
+		matchPattern = &Comby{Value: left}
 	default:
 		// unrecognized name
 		return nil, false, nil


### PR DESCRIPTION
Small "fix": I forgot to add `output.structural` as a recognized predicate in compute queries.