### PR TITLE
batches: remove workspaces preview loading story

### DIFF
--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.story.tsx
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.story.tsx
@@ -33,45 +33,6 @@ add('initial', () => (
     </WebStory>
 ))
 
-add('first preview, loading', () => {
-    const mocks = new WildcardMockLink([
-        {
-            request: {
-                query: getDocumentNode(WORKSPACE_RESOLUTION_STATUS),
-                variables: MATCH_ANY_PARAMETERS,
-            },
-            result: {
-                data: mockWorkspaceResolutionStatus(
-                    select(
-                        'Status',
-                        [BatchSpecWorkspaceResolutionState.QUEUED, BatchSpecWorkspaceResolutionState.PROCESSING],
-                        BatchSpecWorkspaceResolutionState.QUEUED
-                    )
-                ),
-            },
-            nMatches: Number.POSITIVE_INFINITY,
-        },
-    ])
-
-    return (
-        <WebStory>
-            {props => (
-                <MockedTestProvider link={mocks}>
-                    <WorkspacesPreview
-                        {...props}
-                        batchSpecID="fakelol"
-                        currentPreviewRequestTime="1234"
-                        previewDisabled={false}
-                        preview={noop}
-                        batchSpecStale={false}
-                        excludeRepo={noop}
-                    />
-                </MockedTestProvider>
-            )}
-        </WebStory>
-    )
-})
-
 add('first preview, error', () => {
     const mocks = new WildcardMockLink([
         {


### PR DESCRIPTION
Turns out a story with an animated loading spinner is not always going to look the same in the storybook story snapshots. 😝 I think it's fine not to cover this with a storybook so that the UI Review isn't constantly triggering on the difference.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
