### PR TITLE
Minor cleanup: Push error handling down in Coursier code.

### DIFF
--- a/internal/extsvc/jvmpackages/coursier/coursier.go
+++ b/internal/extsvc/jvmpackages/coursier/coursier.go
@@ -53,7 +53,7 @@ func init() {
 	}
 }
 
-func FetchSources(ctx context.Context, config *schema.JVMPackagesConnection, dependency reposource.MavenDependency) (_ []string, err error) {
+func FetchSources(ctx context.Context, config *schema.JVMPackagesConnection, dependency reposource.MavenDependency) (sourceCodeJarPath string, err error) {
 	ctx, endObservation := operations.fetchSources.With(ctx, &err, observation.Args{LogFields: []otlog.Field{
 		otlog.String("dependency", dependency.CoursierSyntax()),
 	}})
@@ -67,7 +67,7 @@ func FetchSources(ctx context.Context, config *schema.JVMPackagesConnection, dep
 			dependency.Version,
 		)
 		if err != nil {
-			return nil, err
+			return "", err
 		}
 		for _, outputPath := range output {
 			for _, srcPath := range []string{
@@ -76,13 +76,13 @@ func FetchSources(ctx context.Context, config *schema.JVMPackagesConnection, dep
 			} {
 				stat, err := os.Stat(srcPath)
 				if !os.IsNotExist(err) && stat.Mode().IsRegular() {
-					return []string{srcPath}, nil
+					return srcPath, nil
 				}
 			}
 		}
-		return nil, errors.Errorf("failed to find src.zip for JVM dependency %s", dependency)
+		return "", errors.Errorf("failed to find src.zip for JVM dependency %s", dependency)
 	}
-	return runCoursierCommand(
+	paths, err := runCoursierCommand(
 		ctx,
 		config,
 		// NOTE: make sure to update the method `coursierScript` in
@@ -94,13 +94,23 @@ func FetchSources(ctx context.Context, config *schema.JVMPackagesConnection, dep
 		"--intransitive", dependency.CoursierSyntax(),
 		"--classifier", "sources",
 	)
+	if err != nil {
+		return "", err
+	}
+	if len(paths) == 0 || (len(paths) == 1 && paths[0] == "") {
+		return "", errors.Errorf("no sources for dependency %s", dependency)
+	}
+	if len(paths) > 1 {
+		return "", errors.Errorf("expected single JAR path but found multiple: %v", paths)
+	}
+	return paths[0], nil
 }
 
-func FetchByteCode(ctx context.Context, config *schema.JVMPackagesConnection, dependency reposource.MavenDependency) (_ []string, err error) {
+func FetchByteCode(ctx context.Context, config *schema.JVMPackagesConnection, dependency reposource.MavenDependency) (byteCodeJarPath string, err error) {
 	ctx, endObservation := operations.fetchByteCode.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	return runCoursierCommand(
+	paths, err := runCoursierCommand(
 		ctx,
 		config,
 		// NOTE: make sure to update the method `coursierScript` in
@@ -111,6 +121,16 @@ func FetchByteCode(ctx context.Context, config *schema.JVMPackagesConnection, de
 		"--quiet", "--quiet",
 		"--intransitive", dependency.CoursierSyntax(),
 	)
+	if err != nil {
+		return "", err
+	}
+	if len(paths) == 0 || (paths[0] == "") {
+		return "", errors.Errorf("no bytecode jar for dependency %s", dependency)
+	}
+	if len(paths) > 1 {
+		return "", errors.Errorf("expected single JAR path but found multiple: %v", paths)
+	}
+	return paths[0], nil
 }
 
 func Exists(ctx context.Context, config *schema.JVMPackagesConnection, dependency reposource.MavenDependency) (exists bool, err error) {
@@ -120,9 +140,8 @@ func Exists(ctx context.Context, config *schema.JVMPackagesConnection, dependenc
 	defer endObservation(1, observation.Args{})
 
 	if dependency.IsJDK() {
-		var sources []string
-		sources, err = FetchSources(ctx, config, dependency)
-		return err == nil && len(sources) == 1, err
+		_, err = FetchSources(ctx, config, dependency)
+		return err == nil, err
 	}
 	_, err = runCoursierCommand(
 		ctx,
@@ -134,7 +153,7 @@ func Exists(ctx context.Context, config *schema.JVMPackagesConnection, dependenc
 	return err == nil, err
 }
 
-func runCoursierCommand(ctx context.Context, config *schema.JVMPackagesConnection, args ...string) (_ []string, err error) {
+func runCoursierCommand(ctx context.Context, config *schema.JVMPackagesConnection, args ...string) (stdoutLines []string, err error) {
 	ctx, cancel := context.WithTimeout(ctx, invocTimeout)
 	defer cancel()
 


### PR DESCRIPTION
Previously, we were handling errors at multiple call sites. Instead,
we can handle the error right after the Coursier command.

No functional change intended.