### PR TITLE
search: relax pattern interpretation of @ in repo searches

### DIFF
--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -3,6 +3,7 @@ package run
 import (
 	"context"
 	"math"
+	"strings"
 
 	"github.com/cockroachdb/errors"
 	otlog "github.com/opentracing/opentracing-go/log"
@@ -64,8 +65,27 @@ func (s *RepoSearch) Run(ctx context.Context, stream streaming.Sender, repos sea
 
 	if s.Args.PatternInfo.Pattern != "" {
 		opts.RepoFilters = append(make([]string, 0, len(opts.RepoFilters)), opts.RepoFilters...)
-		opts.RepoFilters = append(opts.RepoFilters, s.Args.PatternInfo.Pattern)
 		opts.CaseSensitiveRepoFilters = s.Args.Query.IsCaseSensitive()
+
+		patternPrefix := strings.SplitN(s.Args.PatternInfo.Pattern, "@", 2)
+		if len(patternPrefix) == 0 {
+			// No "@" in pattern? We're good.
+			opts.RepoFilters = append(opts.RepoFilters, s.Args.PatternInfo.Pattern)
+		} else if patternPrefix[0] != "" {
+			// Extend the repo search using the pattern value, but
+			// since the pattern contains @, only search the part
+			// prefixed by the first @. This because downstream
+			// logic will get confused by the presence of @ and try
+			// to resolve repo revisions. See #27816.
+			opts.RepoFilters = append(opts.RepoFilters, patternPrefix[0])
+		} else {
+			// This pattern starts with @, of the form "@thing". We can't
+			// consistently handle search repos of this form, because
+			// downstream logic will attempt to interpret "thing" as a repo
+			// revision, may fail, and cause us to raise an alert for any
+			// non `type:repo` search. Better to not attempt a repo search.
+			return nil
+		}
 	}
 
 	ctx, stream, cleanup := streaming.WithLimit(ctx, stream, s.Limit)


### PR DESCRIPTION
Addresses #27594. Tomas I don't have a quick wholistic solution for fixing this since the code paths substantially changed. What's happening with that change is described in #27816, and it's a consequence of "`type:repo` now works", the issue is that `type:repo` made assumptions about `@` that we cannot actually make now with the change. With this fix, at least we won't get the alert, but it does mean that:

`type:repo sourcegraph@main` is just interpreted as `type:repo: sourcegraph`, and the `@suffix` has no effect. If this seems like a low effort fix, it absolutely is. I don't have the capacity to fix up repo code even though this has been a thorn for a long time. I just don't want people to use `type:repo` any more. Use `repo:foo@bar` or `repo:foo rev:bar`. 

I think using a proper data type member in `RepoOptions` for rev, based on the contexts in which the pattern matters in repo searches is the right path.  A follow up of that would be to target the correct `RepoOptions` in a repo job. I may 