### PR TITLE
web: remove Link of username in site admin area on dotcom

### DIFF
--- a/client/web/src/site-admin/SiteAdminAllUsersPage.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage.tsx
@@ -106,8 +106,9 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
             <li className="list-group-item py-2">
                 <div className="d-flex align-items-center justify-content-between">
                     <div>
-                        {window.context.sourcegraphDotComMode && <strong>{this.props.node.username}</strong>}
-                        {!window.context.sourcegraphDotComMode && (
+                        {window.context.sourcegraphDotComMode ? (
+                            <strong>{this.props.node.username}</strong>
+                        ) : (
                             <Link to={`/users/${this.props.node.username}`}>
                                 <strong>{this.props.node.username}</strong>
                             </Link>

--- a/client/web/src/site-admin/SiteAdminAllUsersPage.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage.tsx
@@ -106,9 +106,12 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
             <li className="list-group-item py-2">
                 <div className="d-flex align-items-center justify-content-between">
                     <div>
-                        <Link to={`/users/${this.props.node.username}`}>
-                            <strong>{this.props.node.username}</strong>
-                        </Link>
+                        {window.context.sourcegraphDotComMode && <strong>{this.props.node.username}</strong>}
+                        {!window.context.sourcegraphDotComMode && (
+                            <Link to={`/users/${this.props.node.username}`}>
+                                <strong>{this.props.node.username}</strong>
+                            </Link>
+                        )}
                         <br />
                         <span className="text-muted">{this.props.node.displayName}</span>
                     </div>


### PR DESCRIPTION
This PR removes the Link of username in **Site admin > Users** page on Sourcegraph.com due to the fact site admins will see a 403 page anyway and the "Settings" button has been removed in https://github.com/sourcegraph/sourcegraph/pull/27399.

<img width="956" alt="CleanShot 2021-11-17 at 15 56 32@2x" src="https://user-images.githubusercontent.com/2946214/142159147-4c403f36-c7f9-430e-88fc-c1c7d47ec279.png">


Please feel free to suggest or direct push if there is a better syntax for achieving this!