### PR TITLE
Add x-requested-with to headers proxy

### DIFF
--- a/client/web/dev/utils/csrf/get-csrf-token-cookie-middleware.ts
+++ b/client/web/dev/utils/csrf/get-csrf-token-cookie-middleware.ts
@@ -4,6 +4,9 @@ import { CSRF_COOKIE_NAME } from './get-csrf-token-and-cookie'
 
 // Attach `CSRF_COOKIE_NAME` cookie to every response to avoid "CSRF token is invalid" API error.
 export const getCSRFTokenCookieMiddleware = (csrfCookieValue: string): RequestHandler => (request, response, next) => {
+    // Based on the PR https://github.com/sourcegraph/sourcegraph/pull/27313
+    // we should add a special header x-requested-with to all requests to
+    // pass trust logic on BE request resolver.
     request.headers['x-requested-with'] = 'Sourcegraph FE local server'
     response.cookie(CSRF_COOKIE_NAME, csrfCookieValue, { httpOnly: true })
     next()

--- a/client/web/dev/utils/csrf/get-csrf-token-cookie-middleware.ts
+++ b/client/web/dev/utils/csrf/get-csrf-token-cookie-middleware.ts
@@ -4,6 +4,7 @@ import { CSRF_COOKIE_NAME } from './get-csrf-token-and-cookie'
 
 // Attach `CSRF_COOKIE_NAME` cookie to every response to avoid "CSRF token is invalid" API error.
 export const getCSRFTokenCookieMiddleware = (csrfCookieValue: string): RequestHandler => (_request, response, next) => {
+    _request.headers['x-requested-with'] = 'Sourcegraph FE local server'
     response.cookie(CSRF_COOKIE_NAME, csrfCookieValue, { httpOnly: true })
     next()
 }

--- a/client/web/dev/utils/csrf/get-csrf-token-cookie-middleware.ts
+++ b/client/web/dev/utils/csrf/get-csrf-token-cookie-middleware.ts
@@ -3,8 +3,8 @@ import { RequestHandler } from 'express'
 import { CSRF_COOKIE_NAME } from './get-csrf-token-and-cookie'
 
 // Attach `CSRF_COOKIE_NAME` cookie to every response to avoid "CSRF token is invalid" API error.
-export const getCSRFTokenCookieMiddleware = (csrfCookieValue: string): RequestHandler => (_request, response, next) => {
-    _request.headers['x-requested-with'] = 'Sourcegraph FE local server'
+export const getCSRFTokenCookieMiddleware = (csrfCookieValue: string): RequestHandler => (request, response, next) => {
+    request.headers['x-requested-with'] = 'Sourcegraph FE local server'
     response.cookie(CSRF_COOKIE_NAME, csrfCookieValue, { httpOnly: true })
     next()
 }


### PR DESCRIPTION
Follow up for https://github.com/sourcegraph/sourcegraph/pull/27313

Based on the PR above we should send all requests with a special header `x-requested-with` in order to pass trust logic on BE request resolver. 