### PR TITLE
doc: document how to configure webhook logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 <!--
 ###################################### READ ME ###########################################
-### This changelog should always be read on `main` branch. Its contents on version   ###
+### This changelog should always be read on `main` branch. Its contents on version     ###
 ### branches do not necessarily reflect the changes that have gone into that branch.   ###
 ##########################################################################################
 -->
@@ -21,6 +21,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Added the "no results page", a help page shown if a search doesn't return any results [#26154](https://github.com/sourcegraph/sourcegraph/pull/26154)
 - Added monitoring page for Redis databases [#26967](https://github.com/sourcegraph/sourcegraph/issues/26967)
 - The search indexer only polls repositories that have been marked as changed. This reduces a large source of load in installations with a large number of repositories. If you notice index staleness, you can try disabling by setting the environment variable `SRC_SEARCH_INDEXER_EFFICIENT_POLLING_DISABLED` on `sourcegraph-frontend`. [#27058](https://github.com/sourcegraph/sourcegraph/issues/27058)
+- Added logging of incoming Batch Changes webhooks, which can be viewed by site admins. By default, sites without encryption will log webhooks for three days, while sites with encryption will not log webhooks without explicit configuration. [See the documentation for more details](https://docs.sourcegraph.com/admin/config/batch_changes#incoming-webhooks). [#26669](https://github.com/sourcegraph/sourcegraph/issues/26669)
 
 ### Changed
 

--- a/doc/admin/config/batch_changes.md
+++ b/doc/admin/config/batch_changes.md
@@ -105,7 +105,7 @@ To only allow changesets to be reconciled at 1 changeset per minute on (UTC) wee
 
 Sourcegraph can track incoming webhooks from code hosts to more easily debug issues with webhook delivery. These webhooks can be viewed by going to **Site Admin > Batch Changes > Incoming webhooks**.
 
-By default, sites without encryption enabled will retain three days of webhook logs. Sites with encryption will not retain webhook logs by default, as webhooks may include sensitive information; these sites can enable webhook logging and optionally configure encryption for them by using the settings below.
+By default, sites without [database encryption](encryption.md) enabled will retain three days of webhook logs. Sites with encryption will not retain webhook logs by default, as webhooks may include sensitive information; these sites can enable webhook logging and optionally configure encryption for them by using the settings below.
 
 ### Enabling webhook logging
 

--- a/doc/admin/config/batch_changes.md
+++ b/doc/admin/config/batch_changes.md
@@ -1,4 +1,4 @@
-# Configuring Batch Changes
+# Batch Changes site admin configuration reference
 
 [Batch Changes](../../batch_changes/index.md) is generally configured through the same [site configuration](site_config.md) and [code host configuration](../external_service/index.md) as the rest of Sourcegraph. However, Batch Changes features may require specific configuration, and those are documented here.
 
@@ -98,3 +98,46 @@ To only allow changesets to be reconciled at 1 changeset per minute on (UTC) wee
   }
 ]
 ```
+
+## Incoming webhooks
+
+> NOTE: This feature was added in Sourcegraph 3.33.
+
+Sourcegraph can track incoming webhooks from code hosts to more easily debug issues with webhook delivery. These webhooks can be viewed by going to **Site Admin > Batch Changes > Incoming webhooks**.
+
+By default, sites without encryption enabled will retain three days of webhook logs. Sites with encryption will not retain webhook logs by default, as webhooks may include sensitive information; these sites can enable webhook logging and optionally configure encryption for them by using the settings below.
+
+### Enabling webhook logging
+
+Webhook logging is controlled by the `webhook.logging` site configuration
+option. This option is an object with the following keys:
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | `boolean` | If `true`, incoming webhooks will be stored. | `true` if no site encryption is enabled; `false` otherwise. |
+| `retention` | `string` | The length of time to retain the webhooks, expressed as a valid [Go duration](https://pkg.go.dev/time#ParseDuration). | `72h` |
+
+#### Examples
+
+To disable webhook logging:
+
+```json
+{
+  "webhook.logging": {"enabled": false}
+}
+```
+
+To retain webhook logs for one day:
+
+```json
+{
+  "webhook.logging": {
+    "enabled": false,
+    "retention": "24h"
+  }
+}
+```
+
+### Encrypting webhook logs
+
+Webhook logs can be encrypted by specifying a `webhookLogKey` in the [on-disk database encryption site configuration](encryption.md).

--- a/doc/admin/config/encryption.md
+++ b/doc/admin/config/encryption.md
@@ -27,6 +27,10 @@ To enable encryption you must specify key config for each of the keys defined in
     // encrypts data in user_credentials and batch_changes_site_credentials
     "batchChangesCredentialKey": {
       // ...
+    },
+    // encrypts data in webhook_logs
+    "webhookLogKey": {
+      // ...
     }
   }
 }

--- a/doc/admin/index.md
+++ b/doc/admin/index.md
@@ -34,7 +34,8 @@ Administration is usually handled by site administrators are the admins responsi
 - [Setting the URL for your instance](url.md)
 - [Repository permissions](repo/permissions.md)
   - [Row-level security](repo/row_level_security.md)
-  
+- [Batch Changes](../batch_changes/how-tos/site_admin_configuration.md)
+
 For deployment configuration, please refer to the relevant [installation guide](./install/index.md).
 
 ## [Observability](observability.md)
@@ -48,6 +49,7 @@ For deployment configuration, please refer to the relevant [installation guide](
 - [Code intelligence and language servers](../code_intelligence/index.md)
 - [Sourcegraph extensions and extension registry](extensions/index.md)
 - [Search](search.md)
+- [Batch Changes](../batch_changes/index.md)
 - [Federation](federation/index.md)
 - [Pings](pings.md)
 - [Usage statistics](usage_statistics.md)

--- a/doc/batch_changes/how-tos/site_admin_configuration.md
+++ b/doc/batch_changes/how-tos/site_admin_configuration.md
@@ -1,16 +1,39 @@
 # Site admin configuration for Batch Changes
 
-
-
 #### Setup Batch Changes 
-1. Using Batch Changes requires a [code host connection](../../../admin/external_service/index.md) to a supported code host (currently GitHub, Bitbucket Server, and GitLab).
-1. (Optional) [Configure repository permissions](../../../admin/repo/permissions.md), which Batch Changes will respect.
-1. [Configure credentials](configuring_credentials.md).
-1. Setup webhooks to make sure changesets sync fast. See [Batch Changes effect on codehost rate limits](../references/requirements.md#batch-changes-effect-on-code-host-rate-limits).
-  * [GitHub](../../admin/external_service/github.md#webhooks)
-  * [Bitbucket Server](../../admin/external_service/bitbucket_server.md#webhooks)
-  * [GitLab](../../admin/external_service/gitlab.md#webhooks)
-5. (Optional) [Control the rate at which Batch Changes will publish changesets on code hosts](../../../admin/config/batch_changes.md#rollout-windows).
+
+<ol>
+  <li>
+    Using Batch Changes requires a <a href="../../../admin/external_service">code host connection</a> to a supported code host (currently GitHub, Bitbucket Server, and GitLab).
+  </li>
+  <li>
+    (Optional) <a href="../../../admin/repo/permissions">Configure repository permissions</a>, which Batch Changes will respect.
+  </li>
+  <li>
+    <a href="configuring_credentials">Configure credentials</a>.
+  </li>
+  <li>
+    Setup webhooks to make sure changesets sync fast. See <a href="../references/requirements#batch-changes-effect-on-code-host-rate-limits">Batch Changes effect on codehost rate limits</a>.
+    <ul>
+      <li>
+        <a href="../../admin/external_service/github#webhooks">GitHub</a>
+      </li>
+      <li>
+        <a href="../../admin/external_service/bitbucket_server#webhooks">Bitbucket Server</a>
+      </li>
+      <li>
+        <a href="../../admin/external_service/gitlab#webhooks">GitLab</a>
+      </li>
+    </ul>
+    <aside class="note">
+      NOTE: Incoming webhooks can be viewed in <strong>Site Admin &gt; Batch Changes &gt; Incoming webhooks</strong>. Webhook logging can be configured through the <a href="../../admin/config/batch_changes#incoming-webhooks">incoming webhooks site configuration</a>.
+    </aside>
+  </li>
+  <li>
+    (Optional) <a href="../../../admin/config/batch_changes#rollout-windows">Control the rate at which Batch Changes will publish changesets on code hosts</a>.
+  </li>
+</ol>
+
 
 #### Disable Batch Changes
 - [Disable Batch Changes](../explanations/permissions_in_batch_changes.md#disabling-batch-changes).

--- a/doc/batch_changes/index.md
+++ b/doc/batch_changes/index.md
@@ -108,7 +108,7 @@ Create a batch change by specifying a search query to get a list of repositories
 - [Batch spec YAML reference](references/batch_spec_yaml_reference.md)
 - [Batch spec templating](references/batch_spec_templating.md)
 - [Batch spec cheat sheet](references/batch_spec_cheat_sheet.md)
-- [Configuring Batch Changes publishing times](../admin/config/batch_changes.md)
+- [Site admin configuration reference](../admin/config/batch_changes.md)
 - [Troubleshooting](references/troubleshooting.md)
 - [FAQ](references/faq.md)
 - [CLI](../cli/references/batch/index.md)


### PR DESCRIPTION
This PR includes a conversion of a Markdown list to HTML because otherwise `docsite` does horrible things to the rendering. Don't ask.