### PR TITLE
unpaginate repos list for commit/diff search

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1697,7 +1697,7 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 	}
 
 	addCommitSearch := func(diff bool) {
-		j, err := commit.NewSearchJob(args.Query, diff, int(args.PatternInfo.FileMatchLimit))
+		j, err := commit.NewSearchJob(args.Query, diff, int(args.PatternInfo.FileMatchLimit), args.RepoOptions)
 		if err != nil {
 			agg.Error(err)
 			return


### PR DESCRIPTION
This collects the list of repos for commit/diff search before
executing the searches. This is necessary because we need to be able to
error if the number of repos to be searched is above the limit.
Currently, searches with too many repos will start searching, then time
out, returning no error. This is causing a massive increase in load on
gitserver with no way to identify which monitors are causing the
issue. 

This is a temporary measure, and will be reverted to the previous
implementation once we identify the bad code monitors that should be
disabled. This will add a bit of latency while it exists in this state.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
