### PR TITLE
Support filters for search based backend insights

### DIFF
--- a/client/web/src/enterprise/insights/core/backend/gql/GetInsightView.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql/GetInsightView.ts
@@ -5,8 +5,8 @@ import { gql } from '@apollo/client'
  * information.
  */
 export const GET_INSIGHT_VIEW_GQL = gql`
-    query GetInsightView($id: ID) {
-        insightViews(id: $id) {
+    query GetInsightView($id: ID, $filters: InsightViewFiltersInput) {
+        insightViews(id: $id, filters: $filters) {
             nodes {
                 id
                 dataSeries {

--- a/client/web/src/enterprise/insights/core/backend/gql/GetInsights.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql/GetInsights.ts
@@ -3,6 +3,14 @@ import { gql } from '@apollo/client'
 export const INSIGHT_VIEW_FRAGMENT = gql`
     fragment InsightViewNode on InsightView {
         id
+        defaultFilters {
+            includeRepoRegex
+            excludeRepoRegex
+        }
+        appliedFilters {
+            includeRepoRegex
+            excludeRepoRegex
+        }
         presentation {
             __typename
             ... on LineChartInsightViewPresentation {

--- a/client/web/src/enterprise/insights/core/backend/utils/insight-transformers.ts
+++ b/client/web/src/enterprise/insights/core/backend/utils/insight-transformers.ts
@@ -96,6 +96,10 @@ export const getInsightView = (insight: InsightViewNode): Insight | undefined =>
                     // In gql api we don't have this concept as visibility on FE.
                     // Insights have special system about visibility on BE only.
                     visibility: '',
+                    filters: {
+                        includeRepoRegexp: insight.appliedFilters.includeRepoRegex ?? '',
+                        excludeRepoRegexp: insight.appliedFilters.excludeRepoRegex ?? '',
+                    },
                 }
             }
 

--- a/client/web/src/enterprise/insights/core/backend/utils/insight-transformers.ts
+++ b/client/web/src/enterprise/insights/core/backend/utils/insight-transformers.ts
@@ -73,6 +73,7 @@ export const getInsightView = (insight: InsightViewNode): Insight | undefined =>
             )
 
             const series = insight.presentation.seriesPresentation.map(series => ({
+                id: series.seriesId,
                 name: series.label,
                 query:
                     insight.dataSeriesDefinitions.find(definition => definition.seriesId === series.seriesId)?.query ||

--- a/client/web/src/enterprise/insights/core/backend/utils/search-insight-to-gql-input.ts
+++ b/client/web/src/enterprise/insights/core/backend/utils/search-insight-to-gql-input.ts
@@ -40,6 +40,7 @@ export function prepareSearchInsightUpdateInput(
     const [unit, value] = getStepInterval(insight)
     const input: UpdateLineChartSearchInsightInput = {
         dataSeries: insight.series.map<LineChartSearchInsightDataSeriesInput>(series => ({
+            seriesId: series.id,
             query: series.query,
             options: {
                 label: series.name,

--- a/client/web/src/enterprise/insights/core/types/insight/search-insight.ts
+++ b/client/web/src/enterprise/insights/core/types/insight/search-insight.ts
@@ -4,7 +4,7 @@ import { Duration } from 'date-fns'
 // from these settings and insight schema json definitions.
 import {
     BackendInsight as SearchBasedBackendInsightSettings,
-    BackendInsightSeries as SearchBasedInsightSeries,
+    BackendInsightSeries,
     InsightFilters as SearchBasedBackendFilters,
 } from '../../../../../schema/settings.schema'
 
@@ -18,7 +18,7 @@ import { InsightExecutionType, InsightTypePrefix, InsightType, SyntheticInsightF
  * Note: In the same time extensions also have this type in their public API
  * Search based insight extension - https://github.com/sourcegraph/sourcegraph-search-insights/blob/1b204a579160bab4208a1266cf4ad6e735cdd774/package.json#L50
  */
-export type { SearchBasedInsightSeries, SearchBasedBackendFilters, SearchBasedBackendInsightSettings }
+export type { SearchBasedBackendFilters, SearchBasedBackendInsightSettings }
 
 /**
  * Search based insight supports two types of configuration
@@ -38,6 +38,7 @@ export interface SearchExtensionBasedInsight extends SearchBasedExtensionInsight
 export interface SearchBackendBasedInsight extends SearchBasedBackendInsightSettings, SyntheticInsightFields {
     type: InsightExecutionType.Backend
     viewType: InsightType.SearchBased
+    series: SearchBasedInsightSeries[]
 }
 
 /**
@@ -49,6 +50,10 @@ export interface SearchBasedExtensionInsightSettings {
     repositories: string[]
     series: SearchBasedInsightSeries[]
     step: Duration
+}
+
+export interface SearchBasedInsightSeries extends BackendInsightSeries {
+    id: string | null
 }
 
 /**

--- a/client/web/src/enterprise/insights/hooks/use-insight/use-insight.ts
+++ b/client/web/src/enterprise/insights/hooks/use-insight/use-insight.ts
@@ -116,6 +116,10 @@ export function parseInsightFromSubject(
             type: InsightExecutionType.Backend,
             viewType: type,
             ...insightConfiguration,
+            series: insightConfiguration.series.map((line, index) => ({
+                id: `${line.name}-${index}`,
+                ...line,
+            })),
         }
     }
 

--- a/client/web/src/enterprise/insights/hooks/use-insight/use-insight.ts
+++ b/client/web/src/enterprise/insights/hooks/use-insight/use-insight.ts
@@ -116,7 +116,7 @@ export function parseInsightFromSubject(
             type: InsightExecutionType.Backend,
             viewType: type,
             ...insightConfiguration,
-            series: insightConfiguration.series.map((line, index) => ({
+            series: insightConfiguration.series?.map((line, index) => ({
                 id: `${line.name}-${index}`,
                 ...line,
             })),

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
@@ -15,6 +15,8 @@ const requiredNameField = createRequiredValidator('Name is a required field for 
 const validQuery = createRequiredValidator('Query is a required field for data series.')
 
 interface FormSeriesInputProps {
+    id: string
+
     /** Series index. */
     index: number
 
@@ -53,6 +55,7 @@ interface FormSeriesInputProps {
 /** Displays form series input (three field - name field, query field and color picker). */
 export const FormSeriesInput: React.FunctionComponent<FormSeriesInputProps> = props => {
     const {
+        id,
         index,
         isSearchQueryDisabled,
         showValidationErrorsOnMount = false,
@@ -79,6 +82,7 @@ export const FormSeriesInput: React.FunctionComponent<FormSeriesInputProps> = pr
         },
         onSubmit: values =>
             onSubmit({
+                id,
                 name: values.seriesName,
                 query: values.seriesQuery,
                 stroke: values.seriesColor,
@@ -88,6 +92,7 @@ export const FormSeriesInput: React.FunctionComponent<FormSeriesInputProps> = pr
 
             onChange(
                 {
+                    id,
                     name: values.seriesName,
                     query: values.seriesQuery,
                     stroke: values.seriesColor,

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
@@ -15,7 +15,7 @@ const requiredNameField = createRequiredValidator('Name is a required field for 
 const validQuery = createRequiredValidator('Query is a required field for data series.')
 
 interface FormSeriesInputProps {
-    id: string
+    id: string | null
 
     /** Series index. */
     index: number

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series/FormSeries.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series/FormSeries.tsx
@@ -95,7 +95,7 @@ export const FormSeries: React.FunctionComponent<FormSeriesProps> = props => {
                 ) : (
                     line && (
                         <SeriesCard
-                            key={`${line.id}-card`}
+                            key={`${line.id ?? line.name}-card`}
                             isRemoveSeriesAvailable={!isBackendInsightEdit}
                             onEdit={() => onEditSeriesRequest(index)}
                             onRemove={() => onSeriesRemove(index)}

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/hooks/use-editable-series.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/hooks/use-editable-series.ts
@@ -79,10 +79,12 @@ export function useEditableSeries(props: UseEditableSeriesProps): UseEditableSer
         if (seriesValue[index]) {
             const newSeriesID = newEditSeries[index].id
 
-            setSeriesBeforeEdit({
-                ...seriesBeforeEdit,
-                [newSeriesID]: seriesValue[index],
-            })
+            if (newSeriesID) {
+                setSeriesBeforeEdit({
+                    ...seriesBeforeEdit,
+                    [newSeriesID]: seriesValue[index],
+                })
+            }
         }
 
         series.meta.setState(state => ({ ...state, value: newEditSeries }))
@@ -91,7 +93,8 @@ export function useEditableSeries(props: UseEditableSeriesProps): UseEditableSer
     const handleEditSeriesCancel = (index: number): void => {
         series.meta.setState(state => {
             const series = [...state.value]
-            const seriesValueBeforeEdit = seriesBeforeEdit[series[index].id]
+            const seriesId = series[index].id
+            const seriesValueBeforeEdit = seriesId && seriesBeforeEdit[seriesId]
 
             // If we have series by this index that means user activated
             // cancellation of edit mode of series that already exists

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/hooks/use-editable-series.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/hooks/use-editable-series.ts
@@ -7,8 +7,10 @@ import { DEFAULT_ACTIVE_COLOR } from '../../form-color-input/FormColorInput'
 
 import { remove, replace } from './helpers'
 
+export const EDIT_SERIES_PREFIX = 'runtime-series'
+
 export const createDefaultEditSeries = (series?: Partial<EditableDataSeries>): EditableDataSeries => ({
-    id: uuid.v4(),
+    id: `${EDIT_SERIES_PREFIX}.${uuid.v4()}`,
     ...defaultEditSeries,
     ...series,
 })

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/types.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/types.ts
@@ -4,7 +4,6 @@ import { SearchBasedInsightSeries } from '../../../../core/types/insight/search-
 export type InsightStep = 'hours' | 'days' | 'weeks' | 'months' | 'years'
 
 export interface EditableDataSeries extends SearchBasedInsightSeries {
-    id: string
     valid: boolean
     edit: boolean
 }

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/utils/insight-sanitizer.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/utils/insight-sanitizer.ts
@@ -2,6 +2,7 @@ import { camelCase } from 'lodash'
 
 import { InsightExecutionType, InsightType, InsightTypePrefix, SearchBasedInsight } from '../../../../../core/types'
 import { SearchBasedInsightSeries } from '../../../../../core/types/insight/search-insight'
+import { EDIT_SERIES_PREFIX } from '../components/search-insight-creation-content/hooks/use-editable-series'
 import { CreateInsightFormFields, EditableDataSeries } from '../types'
 
 export function getSanitizedRepositories(rawRepositories: string): string[] {
@@ -13,6 +14,7 @@ export function getSanitizedRepositories(rawRepositories: string): string[] {
 
 export function getSanitizedLine(line: EditableDataSeries): SearchBasedInsightSeries {
     return {
+        id: line.id?.startsWith(EDIT_SERIES_PREFIX) ? null : line.id,
         name: line.name.trim(),
         stroke: line.stroke,
         // Query field is a reg exp field for code insight query setting

--- a/client/web/src/integration/insights/edit-search-insights.test.ts
+++ b/client/web/src/integration/insights/edit-search-insights.test.ts
@@ -294,8 +294,10 @@ describe('Code insight edit insight page', () => {
 
         // Mock `Date.now` to stabilize timestamps
         await driver.page.evaluateOnNewDocument(() => {
+            const mockDate = new Date('June 1, 2021 00:00:00 UTC')
+            const offset = mockDate.getTimezoneOffset() * 60 * 1000
             // Number of ms between Unix epoch and June 31, 2021
-            const mockMs = new Date('June 1, 2021 00:00:00 UTC').getTime()
+            const mockMs = mockDate.getTime() + offset
             Date.now = () => mockMs
         })
 


### PR DESCRIPTION
## Context
This PR support drill-down filters for search-based backend insights. Most of the changes of this PR are related to respecting applied filters data from the gql API. Our UI already supports this since we have these filters in the setting-based API.

## Problems
- Seems like BE has some problems around filters. Be aware that the update insight mutation might not be working as expected and returns some errors. But if you refresh the page you should see that filters that you tried to apply should be in the drill-down panel. https://github.com/sourcegraph/sourcegraph/issues/27837

- Creation insight from the drill-down filter panel doesn't work since our BE doesn't support this field in creating Insight mutation. It should be fixed as soon as BE fixed that problem. 