### PR TITLE
executor: Simplify apiclient config

### DIFF
--- a/enterprise/cmd/executor/internal/apiclient/client.go
+++ b/enterprise/cmd/executor/internal/apiclient/client.go
@@ -27,9 +27,6 @@ type Options struct {
 	// ExecutorName is a unique identifier for the requesting executor.
 	ExecutorName string
 
-	// ExecutorHostname is the hostname of the system it is running on.
-	ExecutorHostname string
-
 	// PathPrefix is the path prefix added to all requests.
 	PathPrefix string
 
@@ -66,8 +63,7 @@ func (c *Client) Dequeue(ctx context.Context, queueName string, job *executor.Jo
 	defer endObservation(1, observation.Args{})
 
 	req, err := c.makeRequest("POST", fmt.Sprintf("%s/dequeue", queueName), executor.DequeueRequest{
-		ExecutorName:     c.options.ExecutorName,
-		ExecutorHostname: c.options.ExecutorHostname,
+		ExecutorName: c.options.ExecutorName,
 	})
 	if err != nil {
 		return false, err

--- a/enterprise/cmd/executor/internal/apiclient/client_test.go
+++ b/enterprise/cmd/executor/internal/apiclient/client_test.go
@@ -22,7 +22,7 @@ func TestDequeue(t *testing.T) {
 		expectedPath:     "/.executors/queue/test_queue/dequeue",
 		expectedUsername: "test",
 		expectedPassword: "hunter2",
-		expectedPayload:  `{"executorHostname": "", "executorName": "deadbeef"}`,
+		expectedPayload:  `{"executorName": "deadbeef"}`,
 		responseStatus:   http.StatusOK,
 		responsePayload:  `{"id": 42}`,
 	}
@@ -48,7 +48,7 @@ func TestDequeueNoRecord(t *testing.T) {
 		expectedPath:     "/.executors/queue/test_queue/dequeue",
 		expectedUsername: "test",
 		expectedPassword: "hunter2",
-		expectedPayload:  `{"executorHostname": "", "executorName": "deadbeef"}`,
+		expectedPayload:  `{"executorName": "deadbeef"}`,
 		responseStatus:   http.StatusNoContent,
 		responsePayload:  ``,
 	}
@@ -70,7 +70,7 @@ func TestDequeueBadResponse(t *testing.T) {
 		expectedPath:     "/.executors/queue/test_queue/dequeue",
 		expectedUsername: "test",
 		expectedPassword: "hunter2",
-		expectedPayload:  `{"executorHostname": "", "executorName": "deadbeef"}`,
+		expectedPayload:  `{"executorName": "deadbeef"}`,
 		responseStatus:   http.StatusInternalServerError,
 		responsePayload:  ``,
 	}

--- a/enterprise/cmd/frontend/internal/executorqueue/handler/handler_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/handler/handler_test.go
@@ -42,7 +42,7 @@ func TestDequeue(t *testing.T) {
 
 	handler := newHandler(executorStore, QueueOptions{Store: store, RecordTransformer: recordTransformer})
 
-	job, dequeued, err := handler.dequeue(context.Background(), "deadbeef", "test")
+	job, dequeued, err := handler.dequeue(context.Background(), "deadbeef")
 	if err != nil {
 		t.Fatalf("unexpected error dequeueing job: %s", err)
 	}
@@ -60,7 +60,7 @@ func TestDequeue(t *testing.T) {
 func TestDequeueNoRecord(t *testing.T) {
 	handler := newHandler(NewMockExecutorStore(), QueueOptions{Store: workerstoremocks.NewMockStore()})
 
-	_, dequeued, err := handler.dequeue(context.Background(), "deadbeef", "test")
+	_, dequeued, err := handler.dequeue(context.Background(), "deadbeef")
 	if err != nil {
 		t.Fatalf("unexpected error dequeueing job: %s", err)
 	}
@@ -82,7 +82,7 @@ func TestAddExecutionLogEntry(t *testing.T) {
 
 	handler := newHandler(executorStore, QueueOptions{Store: store, RecordTransformer: recordTransformer})
 
-	job, dequeued, err := handler.dequeue(context.Background(), "deadbeef", "test")
+	job, dequeued, err := handler.dequeue(context.Background(), "deadbeef")
 	if err != nil {
 		t.Fatalf("unexpected error dequeueing job: %s", err)
 	}
@@ -140,7 +140,7 @@ func TestUpdateExecutionLogEntry(t *testing.T) {
 
 	handler := newHandler(executorStore, QueueOptions{Store: store, RecordTransformer: recordTransformer})
 
-	job, dequeued, err := handler.dequeue(context.Background(), "deadbeef", "test")
+	job, dequeued, err := handler.dequeue(context.Background(), "deadbeef")
 	if err != nil {
 		t.Fatalf("unexpected error dequeueing job: %s", err)
 	}
@@ -199,7 +199,7 @@ func TestMarkComplete(t *testing.T) {
 
 	handler := newHandler(executorStore, QueueOptions{Store: store, RecordTransformer: recordTransformer})
 
-	job, dequeued, err := handler.dequeue(context.Background(), "deadbeef", "test")
+	job, dequeued, err := handler.dequeue(context.Background(), "deadbeef")
 	if err != nil {
 		t.Fatalf("unexpected error dequeueing job: %s", err)
 	}
@@ -255,7 +255,7 @@ func TestMarkErrored(t *testing.T) {
 
 	handler := newHandler(executorStore, QueueOptions{Store: store, RecordTransformer: recordTransformer})
 
-	job, dequeued, err := handler.dequeue(context.Background(), "deadbeef", "test")
+	job, dequeued, err := handler.dequeue(context.Background(), "deadbeef")
 	if err != nil {
 		t.Fatalf("unexpected error dequeueing job: %s", err)
 	}
@@ -314,7 +314,7 @@ func TestMarkFailed(t *testing.T) {
 
 	handler := newHandler(executorStore, QueueOptions{Store: store, RecordTransformer: recordTransformer})
 
-	job, dequeued, err := handler.dequeue(context.Background(), "deadbeef", "test")
+	job, dequeued, err := handler.dequeue(context.Background(), "deadbeef")
 	if err != nil {
 		t.Fatalf("unexpected error dequeueing job: %s", err)
 	}

--- a/enterprise/cmd/frontend/internal/executorqueue/handler/routes.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/handler/routes.go
@@ -44,7 +44,7 @@ func (h *handler) handleDequeue(w http.ResponseWriter, r *http.Request) {
 	var payload apiclient.DequeueRequest
 
 	h.wrapHandler(w, r, &payload, func() (int, interface{}, error) {
-		job, dequeued, err := h.dequeue(r.Context(), payload.ExecutorName, payload.ExecutorHostname)
+		job, dequeued, err := h.dequeue(r.Context(), payload.ExecutorName)
 		if !dequeued {
 			return http.StatusNoContent, nil, err
 		}

--- a/enterprise/internal/executor/client_types.go
+++ b/enterprise/internal/executor/client_types.go
@@ -66,8 +66,7 @@ type CliStep struct {
 }
 
 type DequeueRequest struct {
-	ExecutorName     string `json:"executorName"`
-	ExecutorHostname string `json:"executorHostname"`
+	ExecutorName string `json:"executorName"`
 }
 
 type AddExecutionLogEntryRequest struct {


### PR DESCRIPTION
And don't fail on upserting executor heartbeats, missing one of those is less impactful than missing heartbeats which ultimately cancels jobs.
