### PR TITLE
Add metric to track the display of the install browser extension popover

### DIFF
--- a/client/web/src/repo/actions/GoToCodeHostAction.story.tsx
+++ b/client/web/src/repo/actions/GoToCodeHostAction.story.tsx
@@ -14,8 +14,8 @@ import { WebStory } from '../../components/WebStory'
 import { InstallBrowserExtensionPopover } from './InstallBrowserExtensionPopover'
 
 const onClose = action('onClose')
-const onRejection = action('onRejection')
-const onClickInstall = action('onClickInstall')
+const onReject = action('onReject')
+const onInstall = action('onInstall')
 
 const { add } = storiesOf('web/repo/actions/InstallBrowserExtensionPopover', module).addDecorator(story => (
     <div className="container mt-3">{story()}</div>
@@ -41,11 +41,11 @@ add('GitHub', () => (
                         url=""
                         serviceKind={serviceKind}
                         onClose={onClose}
-                        onRejection={onRejection}
-                        onClickInstall={onClickInstall}
+                        onReject={onReject}
+                        onInstall={onInstall}
                         targetID={targetID}
                         isOpen={open}
-                        toggle={noop}
+                        onToggle={noop}
                     />
                 </>
             )
@@ -75,11 +75,11 @@ add(
                             url=""
                             serviceKind={serviceKind}
                             onClose={onClose}
-                            onRejection={onRejection}
-                            onClickInstall={onClickInstall}
+                            onReject={onReject}
+                            onInstall={onInstall}
                             targetID={targetID}
                             isOpen={open}
-                            toggle={noop}
+                            onToggle={noop}
                         />
                     </>
                 )
@@ -113,11 +113,11 @@ add(
                             url=""
                             serviceKind={serviceKind}
                             onClose={onClose}
-                            onRejection={onRejection}
-                            onClickInstall={onClickInstall}
+                            onReject={onReject}
+                            onInstall={onInstall}
                             targetID={targetID}
                             isOpen={open}
-                            toggle={noop}
+                            onToggle={noop}
                         />
                     </>
                 )
@@ -152,11 +152,11 @@ add(
                             url=""
                             serviceKind={serviceKind}
                             onClose={onClose}
-                            onRejection={onRejection}
-                            onClickInstall={onClickInstall}
+                            onReject={onReject}
+                            onInstall={onInstall}
                             targetID={targetID}
                             isOpen={open}
-                            toggle={noop}
+                            onToggle={noop}
                         />
                     </>
                 )

--- a/client/web/src/repo/actions/InstallBrowserExtensionPopover.tsx
+++ b/client/web/src/repo/actions/InstallBrowserExtensionPopover.tsx
@@ -17,10 +17,10 @@ interface Props {
     url: string
     serviceKind: ExternalServiceKind | null
     onClose: () => void
-    onRejection: () => void
-    onClickInstall: () => void
+    onReject: () => void
+    onInstall: () => void
     targetID: string
-    toggle: () => void
+    onToggle: () => void
     isOpen: boolean
 }
 
@@ -28,10 +28,10 @@ export const InstallBrowserExtensionPopover: React.FunctionComponent<Props> = ({
     url,
     serviceKind,
     onClose,
-    onRejection,
-    onClickInstall,
+    onReject,
+    onInstall,
     targetID,
-    toggle,
+    onToggle,
     isOpen,
 }) => {
     const { displayName, icon } = serviceKindDisplayNameAndIcon(serviceKind)
@@ -42,7 +42,7 @@ export const InstallBrowserExtensionPopover: React.FunctionComponent<Props> = ({
 
     return (
         <Popover
-            toggle={toggle}
+            toggle={onToggle}
             target={targetID}
             isOpen={isOpen}
             popperClassName={classNames('shadow border', styles.installBrowserExtensionPopover)}
@@ -87,7 +87,7 @@ export const InstallBrowserExtensionPopover: React.FunctionComponent<Props> = ({
                         <div className="d-flex justify-content-end">
                             <ButtonLink
                                 className="btn btn-outline-secondary mr-2"
-                                onSelect={onRejection}
+                                onSelect={onReject}
                                 to={url}
                                 {...linkProps}
                             >
@@ -105,7 +105,7 @@ export const InstallBrowserExtensionPopover: React.FunctionComponent<Props> = ({
 
                             <ButtonLink
                                 className="btn btn-primary mr-2"
-                                onSelect={onClickInstall}
+                                onSelect={onInstall}
                                 to="/help/integration/browser_extension"
                                 {...linkProps}
                             >


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/26319.

#### Description

This PR:
- Adds `BrowserExtensionPopupOpened` event when Install Browser Extension Popover is shown

#### How to test

- Run web and make popover to display locally
   - Update `sg.config.yml->web-standalone-http->SOURCEGRAPH_API_URL` to `https://sourcegraph.com`. This is just to avoid signing up for k8s.sgdev.org
   - Update https://github.com/sourcegraph/sourcegraph/blob/ab7de62d80cb5b1e6d1fcde4d13757dbada37f60/client/web/src/repo/RepoContainer.tsx#L339 to just `true` to avoid uninstalling bext and making all conditions work in order to display a popover
   - Start web `sg run web-standalone-http`
- Open any repo page home page, ex: http://localhost:3080/github.com/sourcegraph/sourcegraph
- Click on the "View on Github" icon and check in devTools->Network that event `BrowserExtensionPopupOpened` was sent
> Note: that events triggered within 1 sec are joined together in the network and sent as array of events


#### Before merging

- [ ] Test on different code hosts (if applicable)
    - [ ] GitHub
    - [ ] Gitlab
    - [ ] GitHub Enterprise
    - [ ] Refined GitHub
    - [ ] Phabricator
    - [ ] Phabricator integration
    - [ ] Bitbucket
    - [ ] Bitbucket integration

- [ ] Test on different browsers (if applicable)
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
- [ ] Add change log message to [client/browser/CHANGELOG.md](./client/browser/CHANGELOG.md), under "Unreleased" section. (if applicable)
