### PR TITLE
insights: check if dashboard exists before adding it

### DIFF
--- a/enterprise/internal/insights/migration/discovery.go
+++ b/enterprise/internal/insights/migration/discovery.go
@@ -393,12 +393,6 @@ func migrateSeries(ctx context.Context, insightStore *store.InsightStore, from i
 }
 
 func (m *migrator) migrateDashboards(ctx context.Context, toMigrate []insights.SettingDashboard) int {
-	tx, err := m.dashboardStore.Transact(ctx)
-	if err != nil {
-		return 0
-	}
-	defer func() { err = tx.Store.Done(err) }()
-
 	var count, skipped, errorCount int
 	for _, d := range toMigrate {
 		if d.ID == "" {
@@ -407,18 +401,7 @@ func (m *migrator) migrateDashboards(ctx context.Context, toMigrate []insights.S
 			continue
 		}
 
-		exists, err := tx.DashboardExists(ctx, d)
-		if err != nil {
-			// Skip?
-			skipped++
-			continue
-		}
-		if exists {
-			count++
-			continue
-		}
-
-		err = m.migrateDashboard(ctx, tx, d)
+		err := m.migrateDashboard(ctx, d)
 		if err != nil {
 			// we can't do anything about errors, so we will just skip it and log it
 			errorCount++

--- a/enterprise/internal/insights/migration/discovery.go
+++ b/enterprise/internal/insights/migration/discovery.go
@@ -401,7 +401,18 @@ func (m *migrator) migrateDashboards(ctx context.Context, toMigrate []insights.S
 			continue
 		}
 
-		err := m.migrateDashboard(ctx, d)
+		exists, err := m.dashboardExists(ctx, d)
+		if err != nil {
+			// Skip?
+			skipped++
+			continue
+		}
+		if exists {
+			count++
+			continue
+		}
+
+		err = m.migrateDashboard(ctx, d)
 		if err != nil {
 			// we can't do anything about errors, so we will just skip it and log it
 			errorCount++

--- a/enterprise/internal/insights/migration/migration.go
+++ b/enterprise/internal/insights/migration/migration.go
@@ -327,7 +327,21 @@ func (c migrationContext) buildUniqueIdCondition(insightId string) string {
 // 	// return nil
 // }
 
-func (m *migrator) migrateDashboard(ctx context.Context, tx *store.DBDashboardStore, from insights.SettingDashboard) (err error) {
+func (m *migrator) migrateDashboard(ctx context.Context, from insights.SettingDashboard) (err error) {
+	tx, err := m.dashboardStore.Transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { err = tx.Store.Done(err) }()
+
+	exists, err := tx.DashboardExists(ctx, from)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+
 	log15.Info("insights migration: migrating dashboard", "settings_unique_id", from.ID)
 
 	mc := migrationContext{}


### PR DESCRIPTION
Tested this out by resetting the `migrated_dashboards` count and making sure it didn't recreate all the dashboards, (which is what it used to do!) 