### PR TITLE
codeintel: Remove useless error on repo config policy page

### DIFF
--- a/client/web/src/enterprise/codeintel/configuration/CodeIntelConfigurationPolicyPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/CodeIntelConfigurationPolicyPage.tsx
@@ -116,7 +116,7 @@ export const CodeIntelConfigurationPolicyPage: FunctionComponent<CodeIntelConfig
 
                 <RetentionSettings policy={policy} setPolicy={setPolicy} />
 
-                {indexingEnabled && <IndexingSettings policy={policy} setPolicy={setPolicy} />}
+                {indexingEnabled && <IndexingSettings repo={repo} policy={policy} setPolicy={setPolicy} />}
             </Container>
 
             <div className="mb-3">

--- a/client/web/src/enterprise/codeintel/configuration/IndexSettings.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/IndexSettings.tsx
@@ -9,6 +9,7 @@ import { nullPolicy } from './usePoliciesConfigurations'
 
 export interface IndexingSettingsProps {
     policy: CodeIntelligenceConfigurationPolicyFields
+    repo?: { id: string }
     setPolicy: (
         updater: (
             policy: CodeIntelligenceConfigurationPolicyFields | undefined
@@ -19,6 +20,7 @@ export interface IndexingSettingsProps {
 
 export const IndexingSettings: FunctionComponent<IndexingSettingsProps> = ({
     policy,
+    repo,
     setPolicy,
     allowGlobalPolicies = window.context?.codeIntelAutoIndexingAllowGlobalPolicies,
 }) => {
@@ -44,7 +46,7 @@ export const IndexingSettings: FunctionComponent<IndexingSettingsProps> = ({
             </div>
 
             {!allowGlobalPolicies &&
-                policy.repository === null &&
+                repo === undefined &&
                 (policy.repositoryPatterns || []).length === 0 &&
                 policy.indexingEnabled && (
                     <div className="alert alert-danger">


### PR DESCRIPTION
We shouldn't show errors about global policies on repository-specific configuration policy pages.