### PR TITLE
compute: introduce template scanner

### DIFF
--- a/internal/compute/template.go
+++ b/internal/compute/template.go
@@ -1,0 +1,178 @@
+package compute
+
+import (
+	"encoding/json"
+	"strings"
+	"unicode/utf8"
+)
+
+// Template is just a list of Atom, where an Atom is either a Variable or a Constant string.
+type Template []Atom
+
+type Atom interface {
+	atom()
+	String() string
+}
+
+type Attribute string
+
+const (
+	LengthAttr Attribute = "length"
+	RangeAttr  Attribute = "range"
+)
+
+// Variable represents a variable in the template that may be substituted for. A
+// variable is optionally qualified by an attribute, which is data associated
+// with a variable (e.g., length, range). Attributes are currently unused, and
+// exist for future expansion.
+type Variable struct {
+	Name      string
+	Attribute Attribute
+}
+
+type Constant string
+
+func (Variable) atom() {}
+func (Constant) atom() {}
+
+func (v Variable) String() string {
+	if v.Attribute != "" {
+		return v.Name + "." + string(v.Attribute)
+	}
+	return v.Name
+}
+func (c Constant) String() string { return string(c) }
+
+const varAllowed = "abcdefghijklmnopqrstuvwxyzABCEDEFGHIJKLMNOPQRSTUVWXYZ1234567890_"
+
+// scanTemplate scans an input string to produce a Template. Recognized
+// metavariable syntax is `$(varAllowed+)`.
+func scanTemplate(buf []byte) (*Template, error) {
+	// Tracks whether the current token is a variable.
+	var isVariable bool
+
+	var start int
+	var r rune
+	var token []rune
+	var result []Atom
+
+	next := func() rune {
+		r, start := utf8.DecodeRune(buf)
+		buf = buf[start:]
+		return r
+	}
+
+	appendAtom := func(atom Atom) {
+		if a, ok := atom.(Constant); ok && len(a) == 0 {
+			return
+		}
+		if a, ok := atom.(Variable); ok && len(a.Name) == 0 {
+			return
+		}
+		result = append(result, atom)
+		// Reset token, but reuse the backing memory.
+		token = token[:0]
+	}
+
+	for len(buf) > 0 {
+		r = next()
+		switch r {
+		case '$':
+			if len(buf[start:]) > 0 {
+				if r, _ = utf8.DecodeRune(buf); strings.ContainsRune(varAllowed, r) {
+					// Start of a recognized variable.
+					if isVariable {
+						// We were busy scanning a variable.
+						appendAtom(Variable{Name: string(token)}) // Push variable.
+					} else {
+						// We were busy scanning a constant.
+						appendAtom(Constant(token))
+					}
+					token = append(token, '$')
+					isVariable = true
+					continue
+				}
+				// Something else, push the '$' we saw and continue.
+				token = append(token, '$')
+				isVariable = false
+				continue
+			}
+			// Trailing '$'
+			if isVariable {
+				appendAtom(Variable{Name: string(token)}) // Push variable.
+				isVariable = false
+			} else {
+				appendAtom(Constant(token))
+			}
+			token = append(token, '$')
+		case '\\':
+			if isVariable {
+				// We were busy scanning a variable. A '\' always terminates it.
+				appendAtom(Variable{Name: string(token)}) // Push variable.
+				isVariable = false
+			}
+			if len(buf[start:]) > 0 {
+				r = next()
+				switch r {
+				case 'n':
+					token = append(token, '\n')
+				case 'r':
+					token = append(token, '\r')
+				case 't':
+					token = append(token, '\t')
+				case '\\', '$', ' ', '.':
+					token = append(token, r)
+				default:
+					token = append(token, '\\', r)
+				}
+				continue
+			}
+			// Trailing '\'
+			token = append(token, '\\')
+		default:
+			if isVariable && !strings.ContainsRune(varAllowed, r) {
+				appendAtom(Variable{Name: string(token)}) // Push variable.
+				isVariable = false
+			}
+			token = append(token, r)
+		}
+	}
+	if len(token) > 0 {
+		if isVariable {
+			appendAtom(Variable{Name: string(token)})
+		} else {
+			appendAtom(Constant(token))
+		}
+	}
+	t := Template(result)
+	return &t, nil
+}
+
+func toJSON(atom Atom) interface{} {
+	switch a := atom.(type) {
+	case Constant:
+		return struct {
+			Value string `json:"constant"`
+		}{
+			Value: string(a),
+		}
+	case Variable:
+		return struct {
+			Name      string `json:"variable"`
+			Attribute string `json:"attribute,omitempty"`
+		}{
+			Name:      a.Name,
+			Attribute: string(a.Attribute),
+		}
+	}
+	panic("unreachable")
+}
+
+func toJSONString(template *Template) string {
+	var jsons []interface{}
+	for _, atom := range *template {
+		jsons = append(jsons, toJSON(atom))
+	}
+	json, _ := json.Marshal(jsons)
+	return string(json)
+}

--- a/internal/compute/template_test.go
+++ b/internal/compute/template_test.go
@@ -1,0 +1,63 @@
+package compute
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hexops/autogold"
+)
+
+func Test_scanTemplate(t *testing.T) {
+	test := func(input string) string {
+		t, err := scanTemplate([]byte(input))
+		if err != nil {
+			return fmt.Sprintf("Error: %s", err)
+		}
+		return toJSONString(t)
+	}
+
+	autogold.Want(
+		"basic template",
+		`[{"constant":"artifcats: "},{"variable":"$repo"}]`).
+		Equal(t, test("artifcats: $repo"))
+
+	autogold.Want(
+		"multiple $",
+		`[{"constant":"$"},{"variable":"$foo"},{"constant":" $"},{"variable":"$bar"}]`).
+		Equal(t, test("$$foo $$bar"))
+
+	autogold.Want(
+		"terminating variable",
+		`[{"variable":"$repo"},{"constant":"(derp)"}]`).
+		Equal(t, test(`$repo(derp)`))
+
+	autogold.Want(
+		"consecutive variables with separator",
+		`[{"variable":"$repo"},{"constant":":"},{"variable":"$file"},{"constant":" "},{"variable":"$content"}]`).
+		Equal(t, test(`$repo:$file $content`))
+
+	autogold.Want(
+		"consecutive variables no separator",
+		`[{"variable":"$repo"},{"variable":"$file"}]`).
+		Equal(t, test("$repo$file"))
+
+	autogold.Want(
+		"terminating variables with trailing $",
+		`[{"constant":"$"},{"variable":"$foo"},{"variable":"$bar"},{"constant":"$"}]`).
+		Equal(t, test("$$foo$bar$"))
+
+	autogold.Want(
+		"end-of-template variable",
+		`[{"variable":"$bar"}]`).
+		Equal(t, test("$bar"))
+
+	autogold.Want(
+		"space escaping",
+		`[{"variable":"$repo"},{"constant":" "}]`).
+		Equal(t, test(`$repo\ `))
+
+	autogold.Want(
+		"metachar escaping",
+		`[{"constant":"$repo "}]`).
+		Equal(t, test(`\$repo `))
+}


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/27883.

This introduces a small template scanner to recognize certain variables in an output template. For example, I'm going for a solution where you could express:

`(\w+) -> $repo $1` and it's possible to substitute `$repo` for a value of a repo for a match and `$1` still substitutes for the capture group `$1`. 

This might look like a big PR, but I assure you it's just same old scanner code used from other places, but tuned to recognize `$var` as variables.

> What about Go's templating package?

Yes, I will actually piggyback on top of Go's templating package to "execute" (substitute) variables for values. But I don't want to borrow the Go templating syntax like `{{...}}`, because:

(1) we already have a recognizable substitution syntax with `$1` using regex. The Go template package allows to set custom `Delims` but it wants a trailing delimiter, and that's not strictly necessary and breaks the consistency of `$blah` syntax. Also you don't get to control the escaping mechanisms.
(2) I don't want this our v0 template language to import the huge syntax surface area of Go's templating language. (1) Because it adds a ton of complexity and things I don't want to think about. We grow our own language based on need. (2) Some of the Go templating execution for conditional statements, etc., could allow people to construct fairly arbitrary and potentially expensive operations, and it's just too much right now.