### PR TITLE
compute: define builtin variables for template

### DIFF
--- a/internal/compute/template_test.go
+++ b/internal/compute/template_test.go
@@ -61,3 +61,41 @@ func Test_scanTemplate(t *testing.T) {
 		`[{"constant":"$repo "}]`).
 		Equal(t, test(`\$repo `))
 }
+
+func Test_templatize(t *testing.T) {
+	test := func(input string) string {
+		t, err := templatize(input)
+		if err != nil {
+			return fmt.Sprintf("Error: %s", err)
+		}
+		return t
+	}
+
+	autogold.Want(
+		"basic templatize",
+		"artifcats: {{.Repo}}").
+		Equal(t, test("artifcats: $repo"))
+
+	autogold.Want(
+		"exclude regex var in templatize",
+		"artifcats: {{.Repo}} $1").
+		Equal(t, test("artifcats: $repo $1"))
+}
+
+func Test_substituteMetaVariables(t *testing.T) {
+	test := func(input string, value interface{}) string {
+		t, err := substituteMetaVariables(input, value)
+		if err != nil {
+			return fmt.Sprintf("Error: %s", err)
+		}
+		return t
+	}
+
+	autogold.Want(
+		"substitute for meta values in interface",
+		"artifcats: $1 $foo hi").
+		Equal(t, test(
+			"artifcats: $1 $foo $author",
+			struct{ Author string }{Author: "hi"},
+		))
+}


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/27885.

This allows to specify some builtins like `$repo` in the output template, which are substituted for given some arbitrary data type. It does this by replacing recognized builtins like `$repo` with a Go template version like `{{ .Repo }}` that is then substituted based on some structs data.