### PR TITLE
Code Insights: [FE] Fix insight pings event names

### DIFF
--- a/client/web/src/enterprise/insights/hooks/use-delete-insight/use-delete-insight.ts
+++ b/client/web/src/enterprise/insights/hooks/use-delete-insight/use-delete-insight.ts
@@ -40,7 +40,7 @@ export function useDeleteInsight(): UseDeleteInsightAPI {
 
             try {
                 await deleteInsight(insight.id).toPromise()
-                eventLogger.log('Insight Removal', { insightType: insight.type }, { insightType: insight.type })
+                eventLogger.log('InsightRemoval', { insightType: insight.type }, { insightType: insight.type })
             } catch (error) {
                 // TODO [VK] Improve error UI for deleting
                 console.error(error)

--- a/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.tsx
@@ -80,7 +80,7 @@ export const LangStatsInsightCreationPage: React.FunctionComponent<LangStatsInsi
                 setInitialFormValues(undefined)
                 telemetryService.log('CodeInsightsCodeStatsCreationPageSubmitClick')
                 telemetryService.log(
-                    'Insight Addition',
+                    'InsightAddition',
                     { insightType: 'codeStatsInsights' },
                     { insightType: 'codeStatsInsights' }
                 )

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/SearchInsightCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/SearchInsightCreationPage.tsx
@@ -77,7 +77,7 @@ export const SearchInsightCreationPage: React.FunctionComponent<SearchInsightCre
 
                 telemetryService.log('CodeInsightsSearchBasedCreationPageSubmitClick')
                 telemetryService.log(
-                    'Insight Addition',
+                    'InsightAddition',
                     { insightType: 'searchInsights' },
                     { insightType: 'searchInsights' }
                 )

--- a/client/web/src/enterprise/insights/pages/insights/edit-insight/hooks/use-edit-page-handlers.ts
+++ b/client/web/src/enterprise/insights/pages/insights/edit-insight/hooks/use-edit-page-handlers.ts
@@ -42,7 +42,7 @@ export function useEditPageHandlers(props: UseHandleSubmitProps): useHandleSubmi
                 newInsight,
             }).toPromise()
 
-            eventLogger.log('Insight Edit', { insightType: newInsight.type }, { insightType: newInsight.type })
+            eventLogger.log('InsightEdit', { insightType: newInsight.type }, { insightType: newInsight.type })
 
             if (!dashboard || isVirtualDashboard(dashboard)) {
                 // Navigate user to the dashboard page with new created dashboard


### PR DESCRIPTION
## Context
This PR fixes insight pings event names. In the 3.33 release, we've made a mistake and with ping refactoring PR we also changed event tracking names on FE (but they stayed the same on the BE https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/usagestats/code_insights.go?L26&subtree=true). Cause of that we lost our ping data for 3.33 customers. 

@unclejustin I think it makes sense to kick off this PR again https://github.com/sourcegraph/sourcegraph/pull/24477 to avoid this problem in the future.

## How to test
1. Create/Edit/Delete insight with opened network tab.
2. Track that these pings events have the right names.
3. Check https://k8s.sgdev.org/site-admin/pings and track code insights latest pings have a different value (for example `WeeklyInsightCreators` ping

@coury-clark how often these pings on this page https://k8s.sgdev.org/site-admin/pings are sent?