### PR TITLE
Code Insights: Add separated line chart content generator fro gql api

### DIFF
--- a/client/web/src/enterprise/insights/core/backend/code-insights-gql-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-gql-backend.ts
@@ -60,7 +60,7 @@ import { GET_INSIGHTS_GQL, INSIGHT_VIEW_FRAGMENT } from './gql/GetInsights'
 import { GET_INSIGHTS_DASHBOARDS_GQL } from './gql/GetInsightsDashboards'
 import { GET_INSIGHTS_SUBJECTS_GQL } from './gql/GetInsightSubjects'
 import { GET_INSIGHT_VIEW_GQL } from './gql/GetInsightView'
-import { createLineChartContent } from './utils/create-line-chart-content'
+import { createLineChartContentFromIndexedSeries } from './utils/create-line-chart-content'
 import { createDashboardGrants } from './utils/get-dashboard-grants'
 import { getInsightView } from './utils/insight-transformers'
 import { parseDashboardScope } from './utils/parse-dashboard-scope'
@@ -164,7 +164,7 @@ export class CodeInsightsGqlBackend implements CodeInsightsBackend {
                     title: insight.title ?? insight.title,
                     // TODO: is this still used anywhere?
                     subtitle: '',
-                    content: [createLineChartContent({ series: data.dataSeries }, insight.series)],
+                    content: [createLineChartContentFromIndexedSeries(data.dataSeries, insight.series)],
                     isFetchingHistoricalData: data.dataSeries.some(
                         ({ status: { pendingJobs, backfillQueuedAt } }) => pendingJobs > 0 || backfillQueuedAt === null
                     ),

--- a/client/web/src/enterprise/insights/core/backend/gql/GetInsightView.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql/GetInsightView.ts
@@ -1,5 +1,22 @@
 import { gql } from '@apollo/client'
 
+const INSIGHT_DATA_SERIES_FRAGMENT = gql`
+    fragment InsightDataSeries on InsightsSeries {
+        seriesId
+        label
+        points {
+            dateTime
+            value
+        }
+        status {
+            backfillQueuedAt
+            completedJobs
+            pendingJobs
+            failedJobs
+        }
+    }
+`
+
 /**
  * GQL query for fetching insight data model with data series points and chart
  * information.
@@ -10,20 +27,10 @@ export const GET_INSIGHT_VIEW_GQL = gql`
             nodes {
                 id
                 dataSeries {
-                    seriesId
-                    label
-                    points {
-                        dateTime
-                        value
-                    }
-                    status {
-                        backfillQueuedAt
-                        completedJobs
-                        pendingJobs
-                        failedJobs
-                    }
+                    ...InsightDataSeries
                 }
             }
         }
     }
+    ${INSIGHT_DATA_SERIES_FRAGMENT}
 `

--- a/client/web/src/enterprise/insights/core/backend/utils/create-line-chart-content.ts
+++ b/client/web/src/enterprise/insights/core/backend/utils/create-line-chart-content.ts
@@ -1,5 +1,6 @@
 import { LineChartContent } from 'sourcegraph'
 
+import { InsightDataSeries } from '../../../../../graphql-operations'
 import { SearchBasedInsightSeries } from '../../types/insight/search-insight'
 
 interface InsightData {
@@ -46,6 +47,54 @@ export function createLineChartContent(
             name: sortedSeriesSettings[index]?.name ?? series.label,
             dataKey: `series${index}`,
             stroke: sortedSeriesSettings[index]?.stroke,
+        })),
+        xAxis: {
+            dataKey: 'dateTime',
+            scale: 'time',
+            type: 'number',
+        },
+    }
+}
+
+/**
+ * Generates line chart content for visx chart. Note that this function relays on the fact that
+ * all series are indexed. This generator is used only for GQL api, only there we have indexed series
+ * for setting-based api see {@link createLineChartContent}
+ *
+ * @param series - insight series with points data
+ * @param seriesDefinition - insight definition with line settings (color, name, query)
+ */
+export function createLineChartContentFromIndexedSeries(
+    series: InsightDataSeries[],
+    seriesDefinition: SearchBasedInsightSeries[] = []
+): LineChartContent<{ dateTime: number; [seriesKey: string]: number }, 'dateTime'> {
+    const dataByXValue = new Map<string, { dateTime: number; [seriesKey: string]: number }>()
+    const definitionMap = Object.fromEntries<SearchBasedInsightSeries>(
+        seriesDefinition.map(definition => [definition.id ?? '', definition])
+    )
+
+    for (const line of series) {
+        for (const point of line.points) {
+            let dataObject = dataByXValue.get(point.dateTime)
+            if (!dataObject) {
+                dataObject = {
+                    dateTime: Date.parse(point.dateTime),
+                    // Initialize all series to null (empty chart) value
+                    ...Object.fromEntries(series.map(line => [line.seriesId, null])),
+                }
+                dataByXValue.set(point.dateTime, dataObject)
+            }
+            dataObject[line.seriesId] = point.value
+        }
+    }
+
+    return {
+        chart: 'line',
+        data: [...dataByXValue.values()],
+        series: series.map(line => ({
+            name: definitionMap[line.seriesId]?.name ?? line.label,
+            dataKey: line.seriesId,
+            stroke: definitionMap[line.seriesId]?.stroke,
         })),
         xAxis: {
             dataKey: 'dateTime',


### PR DESCRIPTION
Related to this https://github.com/sourcegraph/sourcegraph/issues/27879 but doesn't close 

## Context
This PR implements a special line chart generator for GQL API. Prior to this PR generation of line, chart content was used sorted on BE and resorted to FE data series, we used a sorted list for series and definitions and mapped them with an index. With the new GQL API all data series and all their definitions are indexed (they have a unique `seriesId` field). Hence we can connect data series and their definitions by this id.

## How to test
1. Create search based insight with more than 1 series
2. Check that all series match their definitions in the live preview chart and insight on the dashboard page (data of series match with series name, color, query string)