### PR TITLE
search: do not rely on Stats.Repos for names in streaming

### DIFF
--- a/cmd/frontend/internal/search/metadata.go
+++ b/cmd/frontend/internal/search/metadata.go
@@ -2,13 +2,16 @@ package search
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cockroachdb/errors"
+	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+	streamapi "github.com/sourcegraph/sourcegraph/internal/search/streaming/api"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -29,4 +32,45 @@ func getEventRepoMetadata(ctx context.Context, db dbutil.DB, event streaming.Sea
 		repoMetadata[repo.ID] = repo
 	}
 	return repoMetadata, nil
+}
+
+// repoNamer returns a best-effort function which translates repository IDs
+// into names.
+func repoNamer(ctx context.Context, db dbutil.DB) streamapi.RepoNamer {
+	cache := map[api.RepoID]api.RepoName{}
+	repoStore := database.Repos(db)
+
+	return func(ids []api.RepoID) []api.RepoName {
+		// Strategy is to populate from cache. So we first populate the cache
+		// with IDs not already in the cache.
+		var missing []api.RepoID
+		for _, id := range ids {
+			if _, ok := cache[id]; !ok {
+				missing = append(missing, id)
+			}
+		}
+
+		if len(missing) > 0 {
+			err := repoStore.StreamMinimalRepos(ctx, database.ReposListOptions{
+				IDs: missing,
+			}, func(repo *types.MinimalRepo) {
+				cache[repo.ID] = repo.Name
+			})
+			if err != nil {
+				// repoNamer is best-effort, so we just log the error.
+				log15.Warn("streaming search repoNamer failed to list names", "error", err)
+			}
+		}
+
+		names := make([]api.RepoName, 0, len(ids))
+		for _, id := range ids {
+			if name, ok := cache[id]; ok {
+				names = append(names, name)
+			} else {
+				names = append(names, api.RepoName(fmt.Sprintf("UNKNOWN{ID=%d}", id)))
+			}
+		}
+
+		return names
+	}
 }

--- a/cmd/frontend/internal/search/progress.go
+++ b/cmd/frontend/internal/search/progress.go
@@ -1,7 +1,7 @@
 package search
 
 import (
-	"fmt"
+	"sort"
 	"time"
 
 	sgapi "github.com/sourcegraph/sourcegraph/internal/api"
@@ -17,6 +17,8 @@ type progressAggregator struct {
 	Limit        int
 	DisplayLimit int
 	Trace        string // may be empty
+
+	RepoNamer api.RepoNamer
 
 	// Dirty is true if p has changed since the last call to Current.
 	Dirty bool
@@ -48,9 +50,9 @@ func (p *progressAggregator) currentStats() api.ProgressStats {
 		ElapsedMilliseconds: int(time.Since(p.Start).Milliseconds()),
 		ExcludedArchived:    p.Stats.ExcludedArchived,
 		ExcludedForks:       p.Stats.ExcludedForks,
-		Timedout:            getNames(p.Stats, searchshared.RepoStatusTimedout),
-		Missing:             getNames(p.Stats, searchshared.RepoStatusMissing),
-		Cloning:             getNames(p.Stats, searchshared.RepoStatusCloning),
+		Timedout:            getRepos(p.Stats, searchshared.RepoStatusTimedout),
+		Missing:             getRepos(p.Stats, searchshared.RepoStatusMissing),
+		Cloning:             getRepos(p.Stats, searchshared.RepoStatusCloning),
 		LimitHit:            p.Stats.IsLimitHit,
 		SuggestedLimit:      suggestedLimit,
 		Trace:               p.Trace,
@@ -62,7 +64,7 @@ func (p *progressAggregator) currentStats() api.ProgressStats {
 func (p *progressAggregator) Current() api.Progress {
 	p.Dirty = false
 
-	return api.BuildProgressEvent(p.currentStats())
+	return api.BuildProgressEvent(p.currentStats(), p.RepoNamer)
 }
 
 // Final returns the current progress event, but with final fields set to
@@ -78,27 +80,22 @@ func (p *progressAggregator) Final() api.Progress {
 		s.RepositoriesCount = intPtr(c)
 	}
 
-	event := api.BuildProgressEvent(s)
+	event := api.BuildProgressEvent(s, p.RepoNamer)
 	event.Done = true
 	return event
 }
 
-type namerFunc string
-
-func (n namerFunc) Name() string {
-	return string(n)
-}
-
-func getNames(stats streaming.Stats, status searchshared.RepoStatus) []api.Namer {
-	var names []api.Namer
+func getRepos(stats streaming.Stats, status searchshared.RepoStatus) []sgapi.RepoID {
+	var repos []sgapi.RepoID
 	stats.Status.Filter(status, func(id sgapi.RepoID) {
-		if name, ok := stats.Repos[id]; ok {
-			names = append(names, namerFunc(name.Name))
-		} else {
-			names = append(names, namerFunc(fmt.Sprintf("UNKNOWN{ID=%d}", id)))
-		}
+		repos = append(repos, id)
 	})
-	return names
+	// Filter runs in a random order (map traversal), so we should sort to
+	// give deterministic messages between updates.
+	sort.Slice(repos, func(i, j int) bool {
+		return repos[i] < repos[j]
+	})
+	return repos
 }
 
 func intPtr(i int) *int {

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -105,6 +105,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Limit:        inputs.MaxResults(),
 		Trace:        trace.URL(trace.ID(ctx)),
 		DisplayLimit: displayLimit,
+		RepoNamer:    repoNamer(ctx, h.db),
 	}
 
 	sendProgress := func() {

--- a/internal/search/streaming/api/testdata/golden/TestSearchProgress/all.json
+++ b/internal/search/streaming/api/testdata/golden/TestSearchProgress/all.json
@@ -7,13 +7,13 @@
    {
     "reason": "repository-missing",
     "title": "2 missing",
-    "message": "2 repositories could not be searched. Try searching again or reducing the scope of your query with `repo:`, `context:` or other filters.\n* `missing-1`\n* `missing-2`",
+    "message": "2 repositories could not be searched. Try searching again or reducing the scope of your query with `repo:`, `context:` or other filters.\n* `repo-2`\n* `repo-3`",
     "severity": "info"
    },
    {
     "reason": "repository-cloning",
     "title": "1 cloning",
-    "message": "`cloning-1` could not be searched since it is still cloning. Try searching again or reducing the scope of your query with `repo:`,  `context:` or other filters.",
+    "message": "`repo-4` could not be searched since it is still cloning. Try searching again or reducing the scope of your query with `repo:`,  `context:` or other filters.",
     "severity": "info"
    },
    {
@@ -29,7 +29,7 @@
    {
     "reason": "shard-timeout",
     "title": "1 timed out",
-    "message": "`timedout-1` could not be searched in time. Try searching again or reducing the scope of your query with `repo:`,  `context:` or other filters.",
+    "message": "`repo-1` could not be searched in time. Try searching again or reducing the scope of your query with `repo:`,  `context:` or other filters.",
     "severity": "warn"
    },
    {

--- a/internal/search/streaming/api/testdata/golden/TestSearchProgress/timedout100.json
+++ b/internal/search/streaming/api/testdata/golden/TestSearchProgress/timedout100.json
@@ -7,7 +7,7 @@
    {
     "reason": "shard-timeout",
     "title": "100 timed out",
-    "message": "100 repositories could not be searched in time. Try searching again or reducing the scope of your query with `repo:`, `context:` or other filters.\n* `timedout-0`\n* `timedout-1`\n* `timedout-2`\n* `timedout-3`\n* `timedout-4`\n* `timedout-5`\n* `timedout-6`\n* `timedout-7`\n* `timedout-8`\n* `timedout-9`\n* ...",
+    "message": "100 repositories could not be searched in time. Try searching again or reducing the scope of your query with `repo:`, `context:` or other filters.\n* `repo-1`\n* `repo-2`\n* `repo-3`\n* `repo-4`\n* `repo-5`\n* `repo-6`\n* `repo-7`\n* `repo-8`\n* `repo-9`\n* `repo-10`\n* ...",
     "severity": "warn"
    }
   ]


### PR DESCRIPTION
Since the introduction of repo pagination Stats.Repos is a subset of the
universe of repositories. In particular we may not have entries for
repositories that timed out, etc. So we instead introduce the concept of
a "RepoNamer" which the progress event builder can use to translate
repository IDs into names. The implementation of this is a DB lookup
with a cache. We introduce a cache since progress events are regularly
sent out.

Note: while implementing this there are some improvements to the
progress internal API which can be done. I will save these for follow-up
PRs. This will include potentially removing how reponamer is smuggled
in.

Part of https://github.com/sourcegraph/sourcegraph/issues/27421