### PR TITLE
[cloud] Allow site-admin to add org members directly

### DIFF
--- a/cmd/frontend/graphqlbackend/org_invitations.go
+++ b/cmd/frontend/graphqlbackend/org_invitations.go
@@ -24,8 +24,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-func getUserToInviteToOrganization(ctx context.Context, db dbutil.DB, username string, orgID int32) (userToInvite *types.User, userEmailAddress string, err error) {
-	userToInvite, err = database.Users(db).GetByUsername(ctx, username)
+func getUserToInviteToOrganization(ctx context.Context, db database.DB, username string, orgID int32) (userToInvite *types.User, userEmailAddress string, err error) {
+	userToInvite, err = db.Users().GetByUsername(ctx, username)
 	if err != nil {
 		return nil, "", err
 	}
@@ -42,7 +42,7 @@ func getUserToInviteToOrganization(ctx context.Context, db dbutil.DB, username s
 		}
 	}
 
-	if _, err := database.OrgMembers(db).GetByOrgIDAndUserID(ctx, orgID, userToInvite.ID); err == nil {
+	if _, err := db.OrgMembers().GetByOrgIDAndUserID(ctx, orgID, userToInvite.ID); err == nil {
 		return nil, "", errors.New("user is already a member of the organization")
 	} else if !errors.HasType(err, &database.ErrOrgMemberNotFound{}) {
 		return nil, "", err


### PR DESCRIPTION
# Description

Allow site-admin to add org members directly

Only allow this behavior if site-admin is already a member of the org

# Testing

Unit tested heavily

## Manually testing

### New behavior
1. Start sg locally in dotcom mode: `EXTSVC_CONFIG_ALLOW_EDITS=true sg start dotcom`
2. Create an org
3. Create a second user
4. Add the user to the org without an invite by clicking on `Add User` button in the org members page

### Behavior on non-cloud

Same steps as above, because the behavior is the same.
