### PR TITLE
Add extra field to log browser extension version

### DIFF
--- a/client/browser/CHANGELOG.md
+++ b/client/browser/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to Sourcegraph [Browser Extensions](./README.md) are documen
 
 ## Unreleased
 
+- Add extra field to log browser extension version [#issues/27845](https://github.com/sourcegraph/sourcegraph/issues/27845), [pull/27902](https://github.com/sourcegraph/sourcegraph/pull/27902)
+
 ## Chrome v21.12.10.1012, Firefox v21.12.10.1048, Safari v1.9
 
 - Private cloud repositories should use hashed identifiers instead of repository names [pull/28621](https://github.com/sourcegraph/sourcegraph/pull/28621), [#pull/28387](https://github.com/sourcegraph/sourcegraph/pull/28387), [#issues/27922](https://github.com/sourcegraph/sourcegraph/issues/27922)

--- a/client/browser/src/shared/code-hosts/sourcegraph/inject.tsx
+++ b/client/browser/src/shared/code-hosts/sourcegraph/inject.tsx
@@ -1,4 +1,4 @@
-import { PlatformName, getPlatformName } from '../../util/context'
+import { PlatformName, getPlatformName, getExtensionVersion } from '../../util/context'
 
 export const EXTENSION_MARKER_ID = 'sourcegraph-app-background'
 
@@ -22,6 +22,7 @@ export function injectExtensionMarker(): void {
     const extensionMarker = document.createElement('div')
     extensionMarker.id = EXTENSION_MARKER_ID
     extensionMarker.dataset.platform = getPlatformName()
+    extensionMarker.dataset.version = getExtensionVersion()
     extensionMarker.style.display = 'none'
     document.body.append(extensionMarker)
 }
@@ -41,8 +42,8 @@ export function signalBrowserExtensionInstalled(): void {
 function dispatchSourcegraphEvents(): void {
     // Send custom webapp <-> extension registration event in case webapp listener is attached first.
     document.dispatchEvent(
-        new CustomEvent<{ platform: PlatformName }>('sourcegraph:browser-extension-registration', {
-            detail: { platform: getPlatformName() },
+        new CustomEvent<{ platform: PlatformName; version: string }>('sourcegraph:browser-extension-registration', {
+            detail: { platform: getPlatformName(), version: getExtensionVersion() },
         })
     )
 }

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -38,8 +38,9 @@ export class EventLogger implements TelemetryService {
     constructor() {
         // EventLogger is never teared down
         // eslint-disable-next-line rxjs/no-ignored-subscription
-        browserExtensionMessageReceived.subscribe(({ platform }) => {
-            this.log('BrowserExtensionConnectedToServer', { platform }, { platform })
+        browserExtensionMessageReceived.subscribe(({ platform, version }) => {
+            const args = { platform, version }
+            this.log('BrowserExtensionConnectedToServer', args, args)
 
             if (localStorage && localStorage.getItem('eventLogDebug') === 'true') {
                 console.debug('%cBrowser extension detected, sync completed', 'color: #aaa')


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/27845.

#### Description

This PR:
- Adds new `version` field to log browser extension version for `BrowserExtensionConnectedToServer` event

#### How to test

- Run browser extension `sg run bext`
- Run web locally `sg run web-standalone-http`
- Open http://localhost:3080/search
- Check DevTools -> Network tab and check `BrowserExtensionConnectedToServer` event contains `version` in argument and publicArgument fields


#### Before merging

- [ ] Test on different code hosts (if applicable)
    - [ ] GitHub
    - [ ] Gitlab
    - [ ] GitHub Enterprise
    - [ ] Refined GitHub
    - [ ] Phabricator
    - [ ] Phabricator integration
    - [ ] Bitbucket
    - [ ] Bitbucket integration

- [ ] Test on different browsers (if applicable)
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
- [ ] Add change log message to [client/browser/CHANGELOG.md](./client/browser/CHANGELOG.md), under "Unreleased" section. (if applicable)
