### PR TITLE
search: do not store repo name in progress.Stats.Repos

### DIFF
--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -160,7 +160,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if progress.Stats.Repos == nil {
-			progress.Stats.Repos = make(map[api.RepoID]types.MinimalRepo)
+			progress.Stats.Repos = make(map[api.RepoID]struct{})
 		}
 
 		for i, match := range event.Results {
@@ -174,7 +174,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 
 			if _, ok := progress.Stats.Repos[repo.ID]; !ok {
-				progress.Stats.Repos[repo.ID] = repo
+				progress.Stats.Repos[repo.ID] = struct{}{}
 			}
 
 			eventMatch := fromMatch(match, repoMetadata)

--- a/internal/search/run/aggregator.go
+++ b/internal/search/run/aggregator.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/unindexed"
 	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 func NewAggregator(db dbutil.DB, stream streaming.Sender) *Aggregator {
@@ -66,13 +65,13 @@ func (a *Aggregator) Send(event streaming.SearchEvent) {
 		a.results = append(a.results, event.Results...)
 
 		if a.stats.Repos == nil {
-			a.stats.Repos = make(map[api.RepoID]types.MinimalRepo)
+			a.stats.Repos = make(map[api.RepoID]struct{})
 		}
 
 		for _, r := range event.Results {
 			repo := r.RepoName()
 			if _, ok := a.stats.Repos[repo.ID]; !ok {
-				a.stats.Repos[repo.ID] = repo
+				a.stats.Repos[repo.ID] = struct{}{}
 			}
 		}
 	}

--- a/internal/search/streaming/progress.go
+++ b/internal/search/streaming/progress.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/search"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 // Stats contains fields that should be returned by all funcs
@@ -16,9 +15,8 @@ type Stats struct {
 	// IsLimitHit is true if we do not have all results that match the query.
 	IsLimitHit bool
 
-	// Repos that were matched by the repo-related filters. This should only
-	// be set once by search, when we have resolved Repos.
-	Repos map[api.RepoID]types.MinimalRepo
+	// Repos that were matched by the repo-related filters.
+	Repos map[api.RepoID]struct{}
 
 	// Status is a RepoStatusMap of repository search statuses.
 	Status search.RepoStatusMap
@@ -46,11 +44,11 @@ func (c *Stats) Update(other *Stats) {
 	c.IsIndexUnavailable = c.IsIndexUnavailable || other.IsIndexUnavailable
 
 	if c.Repos == nil && len(other.Repos) > 0 {
-		c.Repos = make(map[api.RepoID]types.MinimalRepo, len(other.Repos))
+		c.Repos = make(map[api.RepoID]struct{}, len(other.Repos))
 	}
-	for id, r := range other.Repos {
+	for id := range other.Repos {
 		if _, ok := c.Repos[id]; !ok {
-			c.Repos[id] = r
+			c.Repos[id] = struct{}{}
 		}
 	}
 


### PR DESCRIPTION
This is now just a set of repository IDs since we have removed all
dependencies on the name. This should allow us to do further
simplifications / prevent new dependencies on the name in the future.

Part of https://github.com/sourcegraph/sourcegraph/issues/27421