### PR TITLE
search: populate Stats.Repos before applying display limit

### DIFF
--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -159,10 +159,6 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if progress.Stats.Repos == nil {
-			progress.Stats.Repos = make(map[api.RepoID]struct{})
-		}
-
 		for i, match := range event.Results {
 			repo := match.RepoName()
 
@@ -171,10 +167,6 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			// searched repos that user shouldn't have access to.
 			if md, ok := repoMetadata[repo.ID]; !ok || md.Name != repo.Name {
 				continue
-			}
-
-			if _, ok := progress.Stats.Repos[repo.ID]; !ok {
-				progress.Stats.Repos[repo.ID] = struct{}{}
 			}
 
 			eventMatch := fromMatch(match, repoMetadata)


### PR DESCRIPTION
Our stats should be calculated before applying the display limit. IE
stats should be based on the match limit (count:). This moves the
calculation of Repos to before we apply the display limit. Additionally
it now lives inside of the progress agreggator rather than in the http
handler, which is more appropriate.

Depends on https://github.com/sourcegraph/sourcegraph/pull/27903

Part of https://github.com/sourcegraph/sourcegraph/pull/27903