### PR TITLE
search: GraphQL repositories field is based on matches

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1936,11 +1936,11 @@ type SearchResults {
     """
     sparkline: [Int!]!
     """
-    Repositories that were eligible to be searched.
+    Repositories from results.
     """
     repositories: [Repository!]!
     """
-    The number of repositories that were eligible to be searched (for clients
+    The number of repositories that had results (for clients
     that just wish to know how many without querying the, sometimes extremely
     large, list).
     """


### PR DESCRIPTION
Due to truncating that happens after result aggregation, we can't rely
on Stats.Repos to be only the results in Matches. As such we update the
resolver to calculate the set based on matches.

Fixes https://github.com/sourcegraph/sourcegraph/issues/27421