### PR TITLE
Add CodeInsightsGQLApiEnabled to jscontext.go

### DIFF
--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -95,6 +95,8 @@ type JSContext struct {
 	CodeIntelAutoIndexingEnabled             bool `json:"codeIntelAutoIndexingEnabled"`
 	CodeIntelAutoIndexingAllowGlobalPolicies bool `json:"codeIntelAutoIndexingAllowGlobalPolicies"`
 
+	CodeInsightsGQLApiEnabled bool `json:"CodeInsightsGQLApiEnabled"`
+
 	ProductResearchPageEnabled bool `json:"productResearchPageEnabled"`
 
 	ExperimentalFeatures schema.ExperimentalFeatures `json:"experimentalFeatures"`
@@ -196,6 +198,8 @@ func NewJSContextFromRequest(req *http.Request) JSContext {
 		ExecutorsEnabled:                         conf.ExecutorsEnabled(),
 		CodeIntelAutoIndexingEnabled:             conf.CodeIntelAutoIndexingEnabled(),
 		CodeIntelAutoIndexingAllowGlobalPolicies: conf.CodeIntelAutoIndexingAllowGlobalPolicies(),
+
+		CodeInsightsGQLApiEnabled: conf.CodeInsightsGQLApiEnabled(),
 
 		ProductResearchPageEnabled: conf.ProductResearchPageEnabled(),
 

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -251,12 +251,7 @@ func CodeIntelAutoIndexingPolicyRepositoryMatchLimit() int {
 
 func CodeInsightsGQLApiEnabled() bool {
 	enabled, _ := strconv.ParseBool(os.Getenv("ENABLE_CODE_INSIGHTS_SETTINGS_STORAGE"))
-
-	if enabled == false {
-		return false
-	}
-
-	return true
+	return !enabled
 }
 
 func ProductResearchPageEnabled() bool {

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -249,6 +249,16 @@ func CodeIntelAutoIndexingPolicyRepositoryMatchLimit() int {
 	return *val
 }
 
+func CodeInsightsGQLApiEnabled() bool {
+	enabled, _ := strconv.ParseBool(os.Getenv("ENABLE_CODE_INSIGHTS_SETTINGS_STORAGE"))
+
+	if enabled == false {
+		return false
+	}
+
+	return true
+}
+
 func ProductResearchPageEnabled() bool {
 	if enabled := Get().ProductResearchPageEnabled; enabled != nil {
 		return *enabled

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/27914

This PR adds code insights gql feature flag to jscontext 