### PR TITLE
Partially revert "Internal user authz (#27747)"

### DIFF
--- a/cmd/frontend/graphqlbackend/saved_searches_test.go
+++ b/cmd/frontend/graphqlbackend/saved_searches_test.go
@@ -22,7 +22,7 @@ func TestSavedSearches(t *testing.T) {
 
 	ss := dbmock.NewMockSavedSearchStore()
 	ss.ListSavedSearchesByUserIDFunc.SetDefaultHook(func(_ context.Context, userID int32) ([]*types.SavedSearch, error) {
-		return []*types.SavedSearch{{ID: key, Description: "test query", Query: "test type:diff patternType:regexp", UserID: userID}}, nil
+		return []*types.SavedSearch{{ID: key, Description: "test query", Query: "test type:diff patternType:regexp", UserID: &userID, OrgID: nil}}, nil
 	})
 
 	db := dbmock.NewMockDB()
@@ -37,7 +37,8 @@ func TestSavedSearches(t *testing.T) {
 		ID:          key,
 		Description: "test query",
 		Query:       "test type:diff patternType:regexp",
-		UserID:      key,
+		UserID:      &key,
+		OrgID:       nil,
 	}}}
 	if !reflect.DeepEqual(savedSearches, want) {
 		t.Errorf("got %v+, want %v+", savedSearches[0], want[0])
@@ -58,9 +59,10 @@ func TestSavedSearchByIDOwner(t *testing.T) {
 		&api.SavedQuerySpecAndConfig{
 			Spec: api.SavedQueryIDSpec{},
 			Config: api.ConfigSavedQuery{
-				UserID:      userID,
+				UserID:      &userID,
 				Description: "test query",
 				Query:       "test type:diff patternType:regexp",
+				OrgID:       nil,
 			},
 		},
 		nil,
@@ -84,7 +86,8 @@ func TestSavedSearchByIDOwner(t *testing.T) {
 			ID:          userID,
 			Description: "test query",
 			Query:       "test type:diff patternType:regexp",
-			UserID:      userID,
+			UserID:      &userID,
+			OrgID:       nil,
 		},
 	}
 
@@ -107,9 +110,10 @@ func TestSavedSearchByIDNonOwner(t *testing.T) {
 		&api.SavedQuerySpecAndConfig{
 			Spec: api.SavedQueryIDSpec{},
 			Config: api.ConfigSavedQuery{
-				UserID:      userID,
+				UserID:      &userID,
 				Description: "test query",
 				Query:       "test type:diff patternType:regexp",
+				OrgID:       nil,
 			},
 		},
 		nil,
@@ -146,6 +150,7 @@ func TestCreateSavedSearch(t *testing.T) {
 			Notify:      newSavedSearch.Notify,
 			NotifySlack: newSavedSearch.NotifySlack,
 			UserID:      newSavedSearch.UserID,
+			OrgID:       newSavedSearch.OrgID,
 		}, nil
 	})
 
@@ -171,7 +176,8 @@ func TestCreateSavedSearch(t *testing.T) {
 		Query:       "test type:diff patternType:regexp",
 		Notify:      true,
 		NotifySlack: false,
-		UserID:      key,
+		OrgID:       nil,
+		UserID:      &key,
 	}}
 
 	mockrequire.Called(t, ss.CreateFunc)
@@ -210,6 +216,7 @@ func TestUpdateSavedSearch(t *testing.T) {
 			Notify:      savedSearch.Notify,
 			NotifySlack: savedSearch.NotifySlack,
 			UserID:      savedSearch.UserID,
+			OrgID:       savedSearch.OrgID,
 		}, nil
 	})
 
@@ -235,7 +242,8 @@ func TestUpdateSavedSearch(t *testing.T) {
 		ID:          key,
 		Description: "updated query description",
 		Query:       "test type:diff patternType:regexp",
-		UserID:      key,
+		OrgID:       nil,
+		UserID:      &key,
 	}}
 
 	mockrequire.Called(t, ss.UpdateFunc)
@@ -276,7 +284,8 @@ func TestDeleteSavedSearch(t *testing.T) {
 			Key:         "1",
 			Description: "test query",
 			Query:       "test type:diff",
-			UserID:      key,
+			UserID:      &key,
+			OrgID:       nil,
 		},
 	}, nil)
 

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -165,7 +165,13 @@ func serveSavedQueriesListAll(db database.DB) func(w http.ResponseWriter, r *htt
 
 		queries := make([]api.SavedQuerySpecAndConfig, 0, len(settings))
 		for _, s := range settings {
-			spec := api.SavedQueryIDSpec{Subject: api.SettingsSubject{User: &s.Config.UserID}, Key: s.Config.Key}
+			var spec api.SavedQueryIDSpec
+			if s.Config.UserID != nil {
+				spec = api.SavedQueryIDSpec{Subject: api.SettingsSubject{User: s.Config.UserID}, Key: s.Config.Key}
+			} else if s.Config.OrgID != nil {
+				spec = api.SavedQueryIDSpec{Subject: api.SettingsSubject{Org: s.Config.OrgID}, Key: s.Config.Key}
+			}
+
 			queries = append(queries, api.SavedQuerySpecAndConfig{
 				Spec:   spec,
 				Config: s.Config,

--- a/cmd/query-runner/graphql.go
+++ b/cmd/query-runner/graphql.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"runtime"
-	"strconv"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -121,7 +120,7 @@ type gqlSearchResponse struct {
 	Errors []interface{}
 }
 
-func search(ctx context.Context, query string, userID int32) (*gqlSearchResponse, error) {
+func search(ctx context.Context, query string) (*gqlSearchResponse, error) {
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(graphQLQuery{
 		Query:     gqlSearchQuery,
@@ -143,7 +142,6 @@ func search(ctx context.Context, query string, userID int32) (*gqlSearchResponse
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", "sourcegraph/query-runner")
-	req.Header.Set("X-Sourcegraph-User-ID", strconv.FormatInt(int64(userID), 10))
 
 	resp, err := httpcli.InternalDoer.Do(req.WithContext(ctx))
 	if err != nil {

--- a/cmd/query-runner/main.go
+++ b/cmd/query-runner/main.go
@@ -210,7 +210,7 @@ func (e *executorT) runQuery(ctx context.Context, spec api.SavedQueryIDSpec, que
 	// fails in order to avoid e.g. failed saved queries from executing
 	// constantly and potentially causing harm to the system. We'll retry at
 	// our normal interval, regardless of errors.
-	v, execDuration, searchErr := performSearch(ctx, newQuery, query.UserID)
+	v, execDuration, searchErr := performSearch(ctx, newQuery)
 	if err := api.InternalClient.SavedQueriesSetInfo(ctx, &api.SavedQueryInfo{
 		Query:        query.Query,
 		LastExecuted: time.Now(),
@@ -235,12 +235,12 @@ func (e *executorT) runQuery(ctx context.Context, spec api.SavedQueryIDSpec, que
 	return nil
 }
 
-func performSearch(ctx context.Context, query string, userID int32) (v *gqlSearchResponse, execDuration time.Duration, err error) {
+func performSearch(ctx context.Context, query string) (v *gqlSearchResponse, execDuration time.Duration, err error) {
 	attempts := 0
 	for {
 		// Query for search results.
 		start := time.Now()
-		v, err := search(ctx, query, userID)
+		v, err := search(ctx, query)
 		execDuration := time.Since(start)
 		if err != nil {
 			return nil, execDuration, errors.Wrap(err, "search")

--- a/internal/api/internal_client.go
+++ b/internal/api/internal_client.go
@@ -48,7 +48,8 @@ type ConfigSavedQuery struct {
 	Query           string  `json:"query"`
 	Notify          bool    `json:"notify,omitempty"`
 	NotifySlack     bool    `json:"notifySlack,omitempty"`
-	UserID          int32   `json:"userID"`
+	UserID          *int32  `json:"userID"`
+	OrgID           *int32  `json:"orgID"`
 	SlackWebhookURL *string `json:"slackWebhookURL"`
 }
 

--- a/internal/database/dbmock/savedsearchstore_mock.go
+++ b/internal/database/dbmock/savedsearchstore_mock.go
@@ -35,6 +35,9 @@ type MockSavedSearchStore struct {
 	// ListAllFunc is an instance of a mock function object controlling the
 	// behavior of the method ListAll.
 	ListAllFunc *SavedSearchStoreListAllFunc
+	// ListSavedSearchesByOrgIDFunc is an instance of a mock function object
+	// controlling the behavior of the method ListSavedSearchesByOrgID.
+	ListSavedSearchesByOrgIDFunc *SavedSearchStoreListSavedSearchesByOrgIDFunc
 	// ListSavedSearchesByUserIDFunc is an instance of a mock function
 	// object controlling the behavior of the method
 	// ListSavedSearchesByUserID.
@@ -85,6 +88,11 @@ func NewMockSavedSearchStore() *MockSavedSearchStore {
 				return nil, nil
 			},
 		},
+		ListSavedSearchesByOrgIDFunc: &SavedSearchStoreListSavedSearchesByOrgIDFunc{
+			defaultHook: func(context.Context, int32) ([]*types.SavedSearch, error) {
+				return nil, nil
+			},
+		},
 		ListSavedSearchesByUserIDFunc: &SavedSearchStoreListSavedSearchesByUserIDFunc{
 			defaultHook: func(context.Context, int32) ([]*types.SavedSearch, error) {
 				return nil, nil
@@ -130,6 +138,9 @@ func NewMockSavedSearchStoreFrom(i database.SavedSearchStore) *MockSavedSearchSt
 		},
 		ListAllFunc: &SavedSearchStoreListAllFunc{
 			defaultHook: i.ListAll,
+		},
+		ListSavedSearchesByOrgIDFunc: &SavedSearchStoreListSavedSearchesByOrgIDFunc{
+			defaultHook: i.ListSavedSearchesByOrgID,
 		},
 		ListSavedSearchesByUserIDFunc: &SavedSearchStoreListSavedSearchesByUserIDFunc{
 			defaultHook: i.ListSavedSearchesByUserID,
@@ -779,6 +790,119 @@ func (c SavedSearchStoreListAllFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c SavedSearchStoreListAllFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// SavedSearchStoreListSavedSearchesByOrgIDFunc describes the behavior when
+// the ListSavedSearchesByOrgID method of the parent MockSavedSearchStore
+// instance is invoked.
+type SavedSearchStoreListSavedSearchesByOrgIDFunc struct {
+	defaultHook func(context.Context, int32) ([]*types.SavedSearch, error)
+	hooks       []func(context.Context, int32) ([]*types.SavedSearch, error)
+	history     []SavedSearchStoreListSavedSearchesByOrgIDFuncCall
+	mutex       sync.Mutex
+}
+
+// ListSavedSearchesByOrgID delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockSavedSearchStore) ListSavedSearchesByOrgID(v0 context.Context, v1 int32) ([]*types.SavedSearch, error) {
+	r0, r1 := m.ListSavedSearchesByOrgIDFunc.nextHook()(v0, v1)
+	m.ListSavedSearchesByOrgIDFunc.appendCall(SavedSearchStoreListSavedSearchesByOrgIDFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// ListSavedSearchesByOrgID method of the parent MockSavedSearchStore
+// instance is invoked and the hook queue is empty.
+func (f *SavedSearchStoreListSavedSearchesByOrgIDFunc) SetDefaultHook(hook func(context.Context, int32) ([]*types.SavedSearch, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// ListSavedSearchesByOrgID method of the parent MockSavedSearchStore
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *SavedSearchStoreListSavedSearchesByOrgIDFunc) PushHook(hook func(context.Context, int32) ([]*types.SavedSearch, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *SavedSearchStoreListSavedSearchesByOrgIDFunc) SetDefaultReturn(r0 []*types.SavedSearch, r1 error) {
+	f.SetDefaultHook(func(context.Context, int32) ([]*types.SavedSearch, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *SavedSearchStoreListSavedSearchesByOrgIDFunc) PushReturn(r0 []*types.SavedSearch, r1 error) {
+	f.PushHook(func(context.Context, int32) ([]*types.SavedSearch, error) {
+		return r0, r1
+	})
+}
+
+func (f *SavedSearchStoreListSavedSearchesByOrgIDFunc) nextHook() func(context.Context, int32) ([]*types.SavedSearch, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *SavedSearchStoreListSavedSearchesByOrgIDFunc) appendCall(r0 SavedSearchStoreListSavedSearchesByOrgIDFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// SavedSearchStoreListSavedSearchesByOrgIDFuncCall objects describing the
+// invocations of this function.
+func (f *SavedSearchStoreListSavedSearchesByOrgIDFunc) History() []SavedSearchStoreListSavedSearchesByOrgIDFuncCall {
+	f.mutex.Lock()
+	history := make([]SavedSearchStoreListSavedSearchesByOrgIDFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// SavedSearchStoreListSavedSearchesByOrgIDFuncCall is an object that
+// describes an invocation of method ListSavedSearchesByOrgID on an instance
+// of MockSavedSearchStore.
+type SavedSearchStoreListSavedSearchesByOrgIDFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int32
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []*types.SavedSearch
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c SavedSearchStoreListSavedSearchesByOrgIDFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c SavedSearchStoreListSavedSearchesByOrgIDFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/database/saved_searches.go
+++ b/internal/database/saved_searches.go
@@ -21,6 +21,7 @@ type SavedSearchStore interface {
 	GetByID(context.Context, int32) (*api.SavedQuerySpecAndConfig, error)
 	IsEmpty(context.Context) (bool, error)
 	ListAll(context.Context) ([]api.SavedQuerySpecAndConfig, error)
+	ListSavedSearchesByOrgID(ctx context.Context, orgID int32) ([]*types.SavedSearch, error)
 	ListSavedSearchesByUserID(ctx context.Context, userID int32) ([]*types.SavedSearch, error)
 	Transact(context.Context) (SavedSearchStore, error)
 	Update(context.Context, *types.SavedSearch) (*types.SavedSearch, error)
@@ -86,6 +87,7 @@ func (s *savedSearchStore) ListAll(ctx context.Context) (savedSearches []api.Sav
 		notify_owner,
 		notify_slack,
 		user_id,
+		org_id,
 		slack_webhook_url FROM saved_searches
 	`)
 	rows, err := s.Query(ctx, q)
@@ -102,11 +104,16 @@ func (s *savedSearchStore) ListAll(ctx context.Context) (savedSearches []api.Sav
 			&sq.Config.Notify,
 			&sq.Config.NotifySlack,
 			&sq.Config.UserID,
+			&sq.Config.OrgID,
 			&sq.Config.SlackWebhookURL); err != nil {
 			return nil, errors.Wrap(err, "Scan")
 		}
 		sq.Spec.Key = sq.Config.Key
-		sq.Spec.Subject.User = &sq.Config.UserID
+		if sq.Config.UserID != nil {
+			sq.Spec.Subject.User = sq.Config.UserID
+		} else if sq.Config.OrgID != nil {
+			sq.Spec.Subject.Org = sq.Config.OrgID
+		}
 
 		savedSearches = append(savedSearches, sq)
 	}
@@ -127,6 +134,7 @@ func (s *savedSearchStore) GetByID(ctx context.Context, id int32) (*api.SavedQue
 		notify_owner,
 		notify_slack,
 		user_id,
+		org_id,
 		slack_webhook_url
 		FROM saved_searches WHERE id=$1`, id).Scan(
 		&sq.Config.Key,
@@ -135,16 +143,22 @@ func (s *savedSearchStore) GetByID(ctx context.Context, id int32) (*api.SavedQue
 		&sq.Config.Notify,
 		&sq.Config.NotifySlack,
 		&sq.Config.UserID,
+		&sq.Config.OrgID,
 		&sq.Config.SlackWebhookURL)
 	if err != nil {
 		return nil, err
 	}
 	sq.Spec.Key = sq.Config.Key
-	sq.Spec.Subject.User = &sq.Config.UserID
+	if sq.Config.UserID != nil {
+		sq.Spec.Subject.User = sq.Config.UserID
+	} else if sq.Config.OrgID != nil {
+		sq.Spec.Subject.Org = sq.Config.OrgID
+	}
 	return &sq, err
 }
 
-// ListSavedSearchesByUserID lists all the saved searches associated with a user
+// ListSavedSearchesByUserID lists all the saved searches associated with a
+// user, including saved searches in organizations the user is a member of.
 //
 // 🚨 SECURITY: This method does NOT verify the user's identity or that the
 // user is an admin. It is the callers responsibility to ensure that only the
@@ -152,7 +166,23 @@ func (s *savedSearchStore) GetByID(ctx context.Context, id int32) (*api.SavedQue
 // saved searches.
 func (s *savedSearchStore) ListSavedSearchesByUserID(ctx context.Context, userID int32) ([]*types.SavedSearch, error) {
 	var savedSearches []*types.SavedSearch
+	orgs, err := OrgsWith(s).GetByUserID(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	var orgIDs []int32
+	for _, org := range orgs {
+		orgIDs = append(orgIDs, org.ID)
+	}
+	var orgConditions []*sqlf.Query
+	for _, orgID := range orgIDs {
+		orgConditions = append(orgConditions, sqlf.Sprintf("org_id=%d", orgID))
+	}
 	conds := sqlf.Sprintf("WHERE user_id=%d", userID)
+
+	if len(orgConditions) > 0 {
+		conds = sqlf.Sprintf("%v OR %v", conds, sqlf.Join(orgConditions, " OR "))
+	}
 
 	query := sqlf.Sprintf(`SELECT
 		id,
@@ -161,6 +191,7 @@ func (s *savedSearchStore) ListSavedSearchesByUserID(ctx context.Context, userID
 		notify_owner,
 		notify_slack,
 		user_id,
+		org_id,
 		slack_webhook_url
 		FROM saved_searches %v`, conds)
 
@@ -170,9 +201,45 @@ func (s *savedSearchStore) ListSavedSearchesByUserID(ctx context.Context, userID
 	}
 	for rows.Next() {
 		var ss types.SavedSearch
-		if err := rows.Scan(&ss.ID, &ss.Description, &ss.Query, &ss.Notify, &ss.NotifySlack, &ss.UserID, &ss.SlackWebhookURL); err != nil {
+		if err := rows.Scan(&ss.ID, &ss.Description, &ss.Query, &ss.Notify, &ss.NotifySlack, &ss.UserID, &ss.OrgID, &ss.SlackWebhookURL); err != nil {
 			return nil, errors.Wrap(err, "Scan(2)")
 		}
+		savedSearches = append(savedSearches, &ss)
+	}
+	return savedSearches, nil
+}
+
+// ListSavedSearchesByUserID lists all the saved searches associated with an
+// organization.
+//
+// 🚨 SECURITY: This method does NOT verify the user's identity or that the
+// user is an admin. It is the callers responsibility to ensure only admins or
+// members of the specified organization can access the returned saved
+// searches.
+func (s *savedSearchStore) ListSavedSearchesByOrgID(ctx context.Context, orgID int32) ([]*types.SavedSearch, error) {
+	var savedSearches []*types.SavedSearch
+	conds := sqlf.Sprintf("WHERE org_id=%d", orgID)
+	query := sqlf.Sprintf(`SELECT
+		id,
+		description,
+		query,
+		notify_owner,
+		notify_slack,
+		user_id,
+		org_id,
+		slack_webhook_url
+		FROM saved_searches %v`, conds)
+
+	rows, err := s.Query(ctx, query)
+	if err != nil {
+		return nil, errors.Wrap(err, "QueryContext")
+	}
+	for rows.Next() {
+		var ss types.SavedSearch
+		if err := rows.Scan(&ss.ID, &ss.Description, &ss.Query, &ss.Notify, &ss.NotifySlack, &ss.UserID, &ss.OrgID, &ss.SlackWebhookURL); err != nil {
+			return nil, errors.Wrap(err, "Scan")
+		}
+
 		savedSearches = append(savedSearches, &ss)
 	}
 	return savedSearches, nil
@@ -201,6 +268,7 @@ func (s *savedSearchStore) Create(ctx context.Context, newSavedSearch *types.Sav
 		Notify:      newSavedSearch.Notify,
 		NotifySlack: newSavedSearch.NotifySlack,
 		UserID:      newSavedSearch.UserID,
+		OrgID:       newSavedSearch.OrgID,
 	}
 
 	err = s.Handle().DB().QueryRowContext(ctx, `INSERT INTO saved_searches(
@@ -208,13 +276,15 @@ func (s *savedSearchStore) Create(ctx context.Context, newSavedSearch *types.Sav
 			query,
 			notify_owner,
 			notify_slack,
-			user_id
-		) VALUES($1, $2, $3, $4, $5) RETURNING id`,
+			user_id,
+			org_id
+		) VALUES($1, $2, $3, $4, $5, $6) RETURNING id`,
 		newSavedSearch.Description,
 		savedQuery.Query,
 		newSavedSearch.Notify,
 		newSavedSearch.NotifySlack,
 		newSavedSearch.UserID,
+		newSavedSearch.OrgID,
 	).Scan(&savedQuery.ID)
 	if err != nil {
 		return nil, err
@@ -240,6 +310,7 @@ func (s *savedSearchStore) Update(ctx context.Context, savedSearch *types.SavedS
 		Notify:          savedSearch.Notify,
 		NotifySlack:     savedSearch.NotifySlack,
 		UserID:          savedSearch.UserID,
+		OrgID:           savedSearch.OrgID,
 		SlackWebhookURL: savedSearch.SlackWebhookURL,
 	}
 
@@ -250,6 +321,7 @@ func (s *savedSearchStore) Update(ctx context.Context, savedSearch *types.SavedS
 		sqlf.Sprintf("notify_owner=%t", savedSearch.Notify),
 		sqlf.Sprintf("notify_slack=%t", savedSearch.NotifySlack),
 		sqlf.Sprintf("user_id=%v", savedSearch.UserID),
+		sqlf.Sprintf("org_id=%v", savedSearch.OrgID),
 		sqlf.Sprintf("slack_webhook_url=%v", savedSearch.SlackWebhookURL),
 	}
 

--- a/internal/database/users_test.go
+++ b/internal/database/users_test.go
@@ -627,7 +627,7 @@ func TestUsers_Delete(t *testing.T) {
 			if _, err := SavedSearches(db).Create(ctx, &types.SavedSearch{
 				Description: "desc",
 				Query:       "foo",
-				UserID:      user.ID,
+				UserID:      &user.ID,
 			}); err != nil {
 				t.Fatal(err)
 			}

--- a/internal/types/saved_searches.go
+++ b/internal/types/saved_searches.go
@@ -7,6 +7,7 @@ type SavedSearch struct {
 	Query           string  // the literal search query to be ran
 	Notify          bool    // whether or not to notify the owner(s) of this saved search via email
 	NotifySlack     bool    // whether or not to notify the owner(s) of this saved search via Slack
-	UserID          int32   // the owner of the saved search
+	UserID          *int32  // if non-nil, the owner is this user. UserID/OrgID are mutually exclusive.
+	OrgID           *int32  // if non-nil, the owner is this organization. UserID/OrgID are mutually exclusive.
 	SlackWebhookURL *string // if non-nil && NotifySlack == true, indicates that this Slack webhook URL should be used instead of the owners default Slack webhook.
 }


### PR DESCRIPTION
This partially reverts commit d4d88733744f1ac59fdab509798aa5f94e0908e1.
It rolls back the change where we removed the possibility for saved searches to
be owned by orgs.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
