### PR TITLE
conf: Expose ExecutorsEnabled to frontend if executor.accessToken is set

### DIFF
--- a/client/web/dev/utils/create-js-context.ts
+++ b/client/web/dev/utils/create-js-context.ts
@@ -27,6 +27,7 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
         batchChangesEnabled: true,
         batchChangesDisableWebhooksWarning: false,
         batchChangesWebhookLogsEnabled: true,
+        executorsEnabled: false,
         codeIntelAutoIndexingEnabled: false,
         codeIntelAutoIndexingAllowGlobalPolicies: false,
         externalServicesUserMode: 'public',

--- a/client/web/src/enterprise/site-admin/routes.ts
+++ b/client/web/src/enterprise/site-admin/routes.ts
@@ -161,12 +161,6 @@ export const enterpriseSiteAdminAreaRoutes: readonly SiteAdminAreaRoute[] = [
             'ExecutorsListPage'
         ),
         exact: true,
-        // TODO - expand this to executors enabled when SSBC need this page
-        // as well. Right now we don't have an easy way to check if the
-        // executor accessToken is set in site-config, but that should be
-        // the condition of showing this.
-        condition: ({ batchChangesEnabled, batchChangesExecutionEnabled }) =>
-            Boolean(window.context?.codeIntelAutoIndexingEnabled) ||
-            (batchChangesEnabled && batchChangesExecutionEnabled),
+        condition: () => Boolean(window.context?.executorsEnabled),
     },
 ]

--- a/client/web/src/enterprise/site-admin/sidebaritems.ts
+++ b/client/web/src/enterprise/site-admin/sidebaritems.ts
@@ -32,13 +32,7 @@ const maintenanceGroup: SiteAdminSideBarGroup = {
         {
             to: '/site-admin/executors',
             label: 'Executors',
-            // TODO - expand this to executors enabled when SSBC need this page
-            // as well. Right now we don't have an easy way to check if the
-            // executor accessToken is set in site-config, but that should be
-            // the condition of showing this.
-            condition: ({ batchChangesEnabled, batchChangesExecutionEnabled }) =>
-                Boolean(window.context?.codeIntelAutoIndexingEnabled) ||
-                (batchChangesEnabled && batchChangesExecutionEnabled),
+            condition: () => Boolean(window.context?.executorsEnabled),
         },
     ],
 }

--- a/client/web/src/integration/jscontext.ts
+++ b/client/web/src/integration/jscontext.ts
@@ -19,6 +19,7 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
     batchChangesEnabled: true,
     batchChangesDisableWebhooksWarning: false,
     batchChangesWebhookLogsEnabled: true,
+    executorsEnabled: true,
     codeIntelAutoIndexingEnabled: true,
     codeIntelAutoIndexingAllowGlobalPolicies: true,
     externalServicesUserMode: 'disabled',

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -99,6 +99,9 @@ export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'e
 
     batchChangesWebhookLogsEnabled: boolean
 
+    /** Whether executors are enabled on the site. */
+    executorsEnabled: boolean
+
     /** Whether the code intel auto-indexer feature is enabled on the site. */
     codeIntelAutoIndexingEnabled: boolean
 

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -88,6 +88,7 @@ type JSContext struct {
 	BatchChangesDisableWebhooksWarning bool `json:"batchChangesDisableWebhooksWarning"`
 	BatchChangesWebhookLogsEnabled     bool `json:"batchChangesWebhookLogsEnabled"`
 
+	ExecutorsEnabled                         bool `json:"executorsEnabled"`
 	CodeIntelAutoIndexingEnabled             bool `json:"codeIntelAutoIndexingEnabled"`
 	CodeIntelAutoIndexingAllowGlobalPolicies bool `json:"codeIntelAutoIndexingAllowGlobalPolicies"`
 
@@ -185,6 +186,7 @@ func NewJSContextFromRequest(req *http.Request) JSContext {
 		BatchChangesDisableWebhooksWarning: conf.Get().BatchChangesDisableWebhooksWarning,
 		BatchChangesWebhookLogsEnabled:     webhooks.LoggingEnabled(conf.Get()),
 
+		ExecutorsEnabled:                         conf.ExecutorsEnabled(),
 		CodeIntelAutoIndexingEnabled:             conf.CodeIntelAutoIndexingEnabled(),
 		CodeIntelAutoIndexingAllowGlobalPolicies: conf.CodeIntelAutoIndexingAllowGlobalPolicies(),
 

--- a/enterprise/cmd/frontend/internal/executorqueue/init.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/init.go
@@ -2,7 +2,6 @@ package executorqueue
 
 import (
 	"context"
-	"os"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -19,13 +18,7 @@ import (
 
 // Init initializes the executor endpoints required for use with the executor service.
 func Init(ctx context.Context, db dbutil.DB, conf conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context, services *codeintel.Services) error {
-	accessToken := func() string {
-		if accessToken := conf.SiteConfig().ExecutorsAccessToken; accessToken != "" {
-			return accessToken
-		}
-		// Fallback to old environment variable, for a smooth rollout.
-		return os.Getenv("EXECUTOR_FRONTEND_PASSWORD")
-	}
+	accessToken := func() string { return conf.SiteConfig().ExecutorsAccessToken }
 
 	// Register queues. If this set changes, be sure to also update the list of valid
 	// queue names in ./metrics/queue_allocation.go, and register a metrics exporter

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -222,6 +222,10 @@ func BatchChangesRestrictedToAdmins() bool {
 	return false
 }
 
+func ExecutorsEnabled() bool {
+	return Get().ExecutorsAccessToken != ""
+}
+
 func CodeIntelAutoIndexingEnabled() bool {
 	if enabled := Get().CodeIntelAutoIndexingEnabled; enabled != nil {
 		return *enabled


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/27866. Instead of creating a new flag to enable executors or document that you need to also enable another feature _first_ to get this set up, we should just guard the executor-specific pages when the accessToken is set in the site-config.

Side-effects: We now need to set the `executor.accessToken` in dev our clones of dev-private when working locally as I've removed the fallback environment variable (that happens to be set in sg.conf.yaml for the executor service to read).