### PR TITLE
remove the constraint disabling code monitors if it exists

### DIFF
--- a/migrations/frontend/1528395944_reenable-code-monitors.down.sql
+++ b/migrations/frontend/1528395944_reenable-code-monitors.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+
+COMMIT;

--- a/migrations/frontend/1528395944_reenable-code-monitors.up.sql
+++ b/migrations/frontend/1528395944_reenable-code-monitors.up.sql
@@ -1,0 +1,12 @@
+BEGIN;
+	-- If code monitors were disabled by a manual step, make
+	-- it possible to re-enable them by removing the constraint.
+	-- If an admin wants to restore the previous enabled state
+	-- from the backup table, they can run something like the following:
+	--     UPDATE cm_monitors
+	--     SET enabled = cm_monitors_enabled_backup.enabled
+	--     FROM cm_monitors_enabled_backup
+	--     WHERE cm_monitors.id = cm_monitors_enabled_backup.id;
+	ALTER TABLE cm_monitors
+	DROP CONSTRAINT IF EXISTS cm_monitors_cannot_be_enabled;
+COMMIT;


### PR DESCRIPTION
This removes the constraint from the cm_monitors table that forces all
code monitors to be disabled. This constraint may have been added
manually in order to disable code monitor notifications.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
