### PR TITLE
Handle SIGTERM signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
--
+- Sourcegraph services now listen to SIGTERM signals. This allows smoother rollouts in kubernetes deployments. [#27958](https://github.com/sourcegraph/sourcegraph/pull/27958)
 
 ### Fixed
 

--- a/cmd/github-proxy/github-proxy.go
+++ b/cmd/github-proxy/github-proxy.go
@@ -33,14 +33,7 @@ import (
 )
 
 var logRequests, _ = strconv.ParseBool(env.Get("LOG_REQUESTS", "", "log HTTP requests"))
-
-var gracefulShutdownTimeout = func() time.Duration {
-	d, _ := time.ParseDuration(env.Get("SRC_GRACEFUL_SHUTDOWN_TIMEOUT", "10s", "Graceful shutdown timeout"))
-	if d == 0 {
-		d = 10 * time.Second
-	}
-	return d
-}()
+var gracefulShutdownTimeout = env.MustGetDuration("SRC_GRACEFUL_SHUTDOWN_TIMEOUT", 10*time.Second, "Graceful shutdown timeout")
 
 const port = "3180"
 

--- a/cmd/github-proxy/github-proxy.go
+++ b/cmd/github-proxy/github-proxy.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/sentry"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -33,7 +34,6 @@ import (
 )
 
 var logRequests, _ = strconv.ParseBool(env.Get("LOG_REQUESTS", "", "log HTTP requests"))
-var gracefulShutdownTimeout = env.MustGetDuration("SRC_GRACEFUL_SHUTDOWN_TIMEOUT", 10*time.Second, "Graceful shutdown timeout")
 
 const port = "3180"
 
@@ -105,7 +105,7 @@ func main() {
 		signal.Notify(c, syscall.SIGINT, syscall.SIGHUP, syscall.SIGTERM)
 		<-c
 
-		ctx, cancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), goroutine.GracefulShutdownTimeout)
 		if err := s.Shutdown(ctx); err != nil {
 			log15.Error("graceful termination timeout", "error", err)
 		}

--- a/cmd/github-proxy/github-proxy.go
+++ b/cmd/github-proxy/github-proxy.go
@@ -109,7 +109,7 @@ func main() {
 
 	go func() {
 		c := make(chan os.Signal, 1)
-		signal.Notify(c, syscall.SIGINT, syscall.SIGHUP)
+		signal.Notify(c, syscall.SIGINT, syscall.SIGHUP, syscall.SIGTERM)
 		<-c
 
 		ctx, cancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/hostname"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
@@ -51,7 +52,6 @@ var (
 	syncRepoStateInterval        = env.MustGetDuration("SRC_REPOS_SYNC_STATE_INTERVAL", 10*time.Minute, "Interval between state syncs")
 	syncRepoStateBatchSize       = env.MustGetInt("SRC_REPOS_SYNC_STATE_BATCH_SIZE", 500, "Number of upserts to perform per batch")
 	syncRepoStateUpsertPerSecond = env.MustGetInt("SRC_REPOS_SYNC_STATE_UPSERT_PER_SEC", 500, "The number of upserted rows allowed per second across all gitserver instances")
-	gracefulShutdownTimeout      = env.MustGetDuration("SRC_GRACEFUL_SHUTDOWN_TIMEOUT", 10*time.Second, "Graceful shutdown timeout")
 )
 
 func main() {
@@ -188,7 +188,7 @@ func main() {
 	}()
 
 	// Wait for at most for the configured shutdown timeout.
-	ctx, cancel = context.WithTimeout(ctx, gracefulShutdownTimeout)
+	ctx, cancel = context.WithTimeout(ctx, goroutine.GracefulShutdownTimeout)
 	defer cancel()
 	// Stop accepting requests.
 	if err := srv.Shutdown(ctx); err != nil {

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -51,13 +51,7 @@ var (
 	syncRepoStateInterval        = env.MustGetDuration("SRC_REPOS_SYNC_STATE_INTERVAL", 10*time.Minute, "Interval between state syncs")
 	syncRepoStateBatchSize       = env.MustGetInt("SRC_REPOS_SYNC_STATE_BATCH_SIZE", 500, "Number of upserts to perform per batch")
 	syncRepoStateUpsertPerSecond = env.MustGetInt("SRC_REPOS_SYNC_STATE_UPSERT_PER_SEC", 500, "The number of upserted rows allowed per second across all gitserver instances")
-	gracefulShutdownTimeout      = func() time.Duration {
-		d, _ := time.ParseDuration(env.Get("SRC_GRACEFUL_SHUTDOWN_TIMEOUT", "10s", "Graceful shutdown timeout"))
-		if d == 0 {
-			d = 10 * time.Second
-		}
-		return d
-	}()
+	gracefulShutdownTimeout      = env.MustGetDuration("SRC_GRACEFUL_SHUTDOWN_TIMEOUT", 10*time.Second, "Graceful shutdown timeout")
 )
 
 func main() {

--- a/enterprise/cmd/executor/internal/worker/worker.go
+++ b/enterprise/cmd/executor/internal/worker/worker.go
@@ -116,7 +116,7 @@ func connectToFrontend(queueStore *apiclient.Client, options Options) bool {
 	defer ticker.Stop()
 
 	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, syscall.SIGHUP, syscall.SIGINT)
+	signal.Notify(signals, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM)
 	defer signal.Stop(signals)
 
 	for {

--- a/internal/goroutine/background.go
+++ b/internal/goroutine/background.go
@@ -47,7 +47,7 @@ type WaitableBackgroundRoutine interface {
 // immediately.
 func MonitorBackgroundRoutines(ctx context.Context, routines ...BackgroundRoutine) {
 	signals := make(chan os.Signal, 2)
-	signal.Notify(signals, syscall.SIGHUP, syscall.SIGINT)
+	signal.Notify(signals, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM)
 	monitorBackgroundRoutines(ctx, signals, routines...)
 }
 

--- a/internal/goroutine/background.go
+++ b/internal/goroutine/background.go
@@ -6,7 +6,12 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/env"
 )
+
+var GracefulShutdownTimeout = env.MustGetDuration("SRC_GRACEFUL_SHUTDOWN_TIMEOUT", 10*time.Second, "Graceful shutdown timeout")
 
 // StartableRoutine represents a component of a binary that consists of a long
 // running process.

--- a/internal/httpserver/server.go
+++ b/internal/httpserver/server.go
@@ -6,9 +6,11 @@ import (
 	"net/http"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/inconshreveable/log15"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 )
 
@@ -49,6 +51,16 @@ func (s *server) Start() {
 
 func (s *server) Stop() {
 	s.once.Do(func() {
+		// On kubernetes, we want to wait an additional 5 seconds after we receive a
+		// shutdown request to give some additional time for the endpoint changes
+		// to propagate to services talking to this server like the LB or ingress
+		// controller. We only do this in frontend and not on all services, because
+		// frontend is the only publicly exposed service where we don't control
+		// retries on connection failures (see httpcli.InternalClient).
+		if conf.DeployType() == conf.DeployKubernetes {
+			time.Sleep(5 * time.Second)
+		}
+
 		ctx, cancel := context.WithTimeout(context.Background(), goroutine.GracefulShutdownTimeout)
 		defer cancel()
 

--- a/internal/httpserver/server.go
+++ b/internal/httpserver/server.go
@@ -6,15 +6,11 @@ import (
 	"net/http"
 	"os"
 	"sync"
-	"time"
 
 	"github.com/inconshreveable/log15"
 
-	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 )
-
-var gracefulShutdownTimeout = env.MustGetDuration("SRC_GRACEFUL_SHUTDOWN_TIMEOUT", 10*time.Second, "Graceful shutdown timeout")
 
 type server struct {
 	server       *http.Server
@@ -53,7 +49,7 @@ func (s *server) Start() {
 
 func (s *server) Stop() {
 	s.once.Do(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), goroutine.GracefulShutdownTimeout)
 		defer cancel()
 
 		if err := s.server.Shutdown(ctx); err != nil {

--- a/internal/httpserver/server.go
+++ b/internal/httpserver/server.go
@@ -14,13 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 )
 
-var gracefulShutdownTimeout = func() time.Duration {
-	d, _ := time.ParseDuration(env.Get("SRC_GRACEFUL_SHUTDOWN_TIMEOUT", "10s", "Graceful shutdown timeout"))
-	if d == 0 {
-		d = 10 * time.Second
-	}
-	return d
-}()
+var gracefulShutdownTimeout = env.MustGetDuration("SRC_GRACEFUL_SHUTDOWN_TIMEOUT", 10*time.Second, "Graceful shutdown timeout")
 
 type server struct {
 	server       *http.Server


### PR DESCRIPTION
We want to handle SIGTERM in addition to SIGINT for graceful shutdowns. [They are the mechanism used by k8s to inform about an impending pod termination](https://cloud.google.com/blog/products/containers-kubernetes/kubernetes-best-practices-terminating-with-grace). We currently don't support this and our applications seem to just exit immediately when they receive a SIGTERM.
I don't really see what other harm this could cause, but I would love to capture k8s for an hour at some point to validate this is a good change. This should fix issues where gitserver is terminated during requests are currently being worked on (like git repo cloning or fetching) which we are seeing in server-side batch changes frequently. 

Closes https://github.com/sourcegraph/sourcegraph/issues/27947