### PR TITLE
ci: use a more recent version release for docsite

### DIFF
--- a/dev/docsite.sh
+++ b/dev/docsite.sh
@@ -4,7 +4,7 @@ set -euf -o pipefail
 
 pushd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null
 
-version=v1.8.2
+version=v1.8.4
 suffix="${version}_$(go env GOOS)_$(go env GOARCH)"
 url="https://github.com/sourcegraph/docsite/releases/download/${version}/docsite_${suffix}"
 


### PR DESCRIPTION
The `docsite.sh` check script was referring to `1.8.2` which notably fails on M1 Macs as we only started shipping `arm64` binaries in later releases.