### PR TITLE
#27965 - Update images to address CVE's

### DIFF
--- a/docker-images/grafana/Dockerfile
+++ b/docker-images/grafana/Dockerfile
@@ -37,7 +37,9 @@ ADD entry.sh /
 
 USER root
 
-RUN apk add --upgrade --no-cache apk-tools=~2.12 krb5-libs=1.18.4-r0 libssl1.1=1.1.1l-r0 openssl=1.1.1l-r0
+# @FIXME: Update redis image
+# Pin busybox=1.32.1-r7 https://github.com/sourcegraph/sourcegraph/issues/27965
+RUN apk add --upgrade --no-cache apk-tools=~2.12 krb5-libs=1.18.4-r0 libssl1.1=1.1.1l-r0 openssl=1.1.1l-r0 busybox=1.32.1-r7
 
 EXPOSE 3370
 USER grafana

--- a/docker-images/postgres-12.6-alpine/Dockerfile
+++ b/docker-images/postgres-12.6-alpine/Dockerfile
@@ -11,7 +11,9 @@ RUN apk add --no-cache nss su-exec shadow &&\
     chown -R postgres:postgres /var/lib/postgresql &&\
     chown -R postgres:postgres /var/run/postgresql
 
-RUN apk add --upgrade --no-cache libxml2=2.9.12-r0 libgcrypt=1.8.8-r1 apk-tools=2.12.7-r0
+# @FIXME: Update redis image
+# Pin busybox=1.32.1-r7 https://github.com/sourcegraph/sourcegraph/issues/27965
+RUN apk add --upgrade --no-cache libxml2=2.9.12-r0 libgcrypt=1.8.8-r1 apk-tools=2.12.7-r0 busybox=1.32.1-r7
 
 ENV POSTGRES_PASSWORD='' \
     POSTGRES_USER=sg \

--- a/docker-images/redis-cache/Dockerfile
+++ b/docker-images/redis-cache/Dockerfile
@@ -1,8 +1,13 @@
 FROM redis:5-alpine@sha256:fea243676a4d2d67f5990ddcbd4a56db9423b7f25e55758491e39988efc1cfbe
 
 RUN mkdir -p /redis-data && chown -R redis:redis /redis-data
+
+# @FIXME: Update redis image
+# Pin busybox=1.33.1-r6 https://github.com/sourcegraph/sourcegraph/issues/27965
+
 # hadolint ignore=DL3018
-RUN apk --no-cache add tini apk-tools=2.12.7-r0 libssl1.1=1.1.1l-r0
+RUN apk --no-cache add tini apk-tools=2.12.7-r0 libssl1.1=1.1.1l-r0 busybox=1.33.1-r6
+
 
 USER redis
 COPY redis.conf /etc/redis/redis.conf

--- a/docker-images/redis-store/Dockerfile
+++ b/docker-images/redis-store/Dockerfile
@@ -1,8 +1,12 @@
 FROM redis:5-alpine@sha256:fea243676a4d2d67f5990ddcbd4a56db9423b7f25e55758491e39988efc1cfbe
 
 RUN mkdir -p /redis-data && chown -R redis:redis /redis-data
+
+# @FIXME: Update redis image
+# Pin busybox=1.33.1-r6 https://github.com/sourcegraph/sourcegraph/issues/27965
+
 # hadolint ignore=DL3018
-RUN apk --no-cache add tini apk-tools=2.12.7-r0 libssl1.1=1.1.1l-r0
+RUN apk --no-cache add tini apk-tools=2.12.7-r0 libssl1.1=1.1.1l-r0 busybox=1.33.1-r6
 
 USER redis
 COPY redis.conf /etc/redis/redis.conf


### PR DESCRIPTION
Address: https://buildkite.com/sourcegraph/sourcegraph/builds/117180#annotation-Docker%20image%20security%20scan
