### PR TITLE
compute: create environment type for template substitution

### DIFF
--- a/internal/compute/template_test.go
+++ b/internal/compute/template_test.go
@@ -83,8 +83,8 @@ func Test_templatize(t *testing.T) {
 }
 
 func Test_substituteMetaVariables(t *testing.T) {
-	test := func(input string, value interface{}) string {
-		t, err := substituteMetaVariables(input, value)
+	test := func(input string, env *MetaEnvironment) string {
+		t, err := substituteMetaVariables(input, env)
 		if err != nil {
 			return fmt.Sprintf("Error: %s", err)
 		}
@@ -96,6 +96,6 @@ func Test_substituteMetaVariables(t *testing.T) {
 		"artifcats: $1 $foo hi").
 		Equal(t, test(
 			"artifcats: $1 $foo $author",
-			struct{ Author string }{Author: "hi"},
+			&MetaEnvironment{Author: "hi"},
 		))
 }


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/27888.

This maps some values in results to a flat environment of variables that may be referenced in a template. File and commit results are mapped for now, and only some of the more handy values like author, date, etc.