### PR TITLE
compute: expose commit metadata to output command

### DIFF
--- a/internal/compute/template.go
+++ b/internal/compute/template.go
@@ -262,12 +262,6 @@ func NewMetaEnvironment(r result.Match, content string) *MetaEnvironment {
 			Content: content,
 		}
 	case *result.CommitMatch:
-		var content string
-		if m.DiffPreview != nil {
-			content = m.DiffPreview.Value
-		} else {
-			content = string(m.Commit.Message)
-		}
 		return &MetaEnvironment{
 			Repo:    string(m.Repo.Name),
 			Commit:  string(m.Commit.ID),


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/27976.

This allows compute output commands to reference and substitute commit data like `$author` when a search query yields commit results.