### PR TITLE
Add example for finding private keys and GitHub access tokens

### DIFF
--- a/doc/code_search/tutorials/examples.md
+++ b/doc/code_search/tutorials/examples.md
@@ -65,6 +65,11 @@ file:package.json type:diff after:"1 week ago" select:repo
 repo:^github\.com/sourcegraph/sourcegraph$ type:diff file:contains.content("golang\.org/x/sync/errgroup") .Go
 ```
 
+[Find private keys and GitHub access tokens checked in to code](https://sourcegraph.com/search?q=context:global+%28-----BEGIN+PRIVATE+KEY------%29%7C%28%5C%22gh%5Bpousr%5D_%5BA-Za-z0-9_%5D%7B16%2C%7D%29%7C%28%5C%27gh%5Bpousr%5D_%5BA-Za-z0-9_%5D%7B16%2C%7D%29&patternType=regexp&case=yes)
+```sgquery
+(-----BEGIN PRIVATE KEY------)|(\"gh[pousr]_[A-Za-z0-9_]{16,})|(\'gh[pousr]_[A-Za-z0-9_]{16,}) patternType:regexp case:yes
+```
+
 ## When to use regex search mode
 
 Sourcegraph's default literal search mode is line-based and will not match across lines, so regex can be useful when you wish to do so:
@@ -81,7 +86,6 @@ Regex searches are also useful when searching boundaries that are not delimited 
 ```sgquery
 repo:^github\.com/sourcegraph/sourcegraph$ \bbtn-secondary\b
 ```
-
 
 ## When to use structural search mode
 

--- a/doc/code_search/tutorials/examples.md
+++ b/doc/code_search/tutorials/examples.md
@@ -4,6 +4,11 @@ Below are examples that search repositories on [Sourcegraph.com](https://sourceg
 
 > See [**search query syntax**](../reference/queries.md) reference.
 
+[Find private keys and GitHub access tokens checked in to code](https://sourcegraph.com/search?q=context:global+%28-----BEGIN+PRIVATE+KEY------%29%7C%28%5C%22gh%5Bpousr%5D_%5BA-Za-z0-9_%5D%7B16%2C%7D%29%7C%28%5C%27gh%5Bpousr%5D_%5BA-Za-z0-9_%5D%7B16%2C%7D%29&patternType=regexp&case=yes)
+```sgquery
+(-----BEGIN PRIVATE KEY------)|(\"gh[pousr]_[A-Za-z0-9_]{16,})|(\'gh[pousr]_[A-Za-z0-9_]{16,}) patternType:regexp case:yes
+```
+
 [Recent security-related changes on all branches](https://sourcegraph.com/search?q=type:diff+repo:github%5C.com/kubernetes/kubernetes%24+repo:%40*refs/heads/+after:"5+days+ago"+%5Cb%28auth%5B%5Eo%5D%5B%5Er%5D%7Csecurity%5Cb%7Ccve%7Cpassword%7Csecure%7Cunsafe%7Cperms%7Cpermissions%29&patternType=regexp)<br/>
 
 ```sgquery
@@ -63,11 +68,6 @@ file:package.json type:diff after:"1 week ago" select:repo
 
 ```sgquery
 repo:^github\.com/sourcegraph/sourcegraph$ type:diff file:contains.content("golang\.org/x/sync/errgroup") .Go
-```
-
-[Find private keys and GitHub access tokens checked in to code](https://sourcegraph.com/search?q=context:global+%28-----BEGIN+PRIVATE+KEY------%29%7C%28%5C%22gh%5Bpousr%5D_%5BA-Za-z0-9_%5D%7B16%2C%7D%29%7C%28%5C%27gh%5Bpousr%5D_%5BA-Za-z0-9_%5D%7B16%2C%7D%29&patternType=regexp&case=yes)
-```sgquery
-(-----BEGIN PRIVATE KEY------)|(\"gh[pousr]_[A-Za-z0-9_]{16,})|(\'gh[pousr]_[A-Za-z0-9_]{16,}) patternType:regexp case:yes
 ```
 
 ## When to use regex search mode


### PR DESCRIPTION
Note that I didn't use the more concise construction of this query for performance reasons filed in https://github.com/sourcegraph/sourcegraph/issues/27984