### PR TITLE
Initial prototype of BC lifecycle hooks

### DIFF
--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -212,6 +212,22 @@ type PublishChangesetsArgs struct {
 	Draft bool
 }
 
+type CreateBatchChangesLifecycleHookArgs struct {
+	ExpiresAt *DateTime
+	URL       string
+	Secret    string
+}
+
+type DeleteBatchChangesLifecycleHookArgs struct {
+	ID graphql.ID
+}
+
+type ListBatchChangesLifecycleHooksArgs struct {
+	First          int32
+	After          *string
+	IncludeExpired *bool
+}
+
 type ResolveWorkspacesForBatchSpecArgs struct {
 	BatchSpec        string
 	AllowIgnored     bool
@@ -262,6 +278,9 @@ type BatchChangesResolver interface {
 	CloseChangesets(ctx context.Context, args *CloseChangesetsArgs) (BulkOperationResolver, error)
 	PublishChangesets(ctx context.Context, args *PublishChangesetsArgs) (BulkOperationResolver, error)
 
+	CreateBatchChangesLifecycleHook(ctx context.Context, args *CreateBatchChangesLifecycleHookArgs) (BatchChangesLifecycleHookResolver, error)
+	DeleteBatchChangesLifecycleHook(ctx context.Context, args *DeleteBatchChangesLifecycleHookArgs) (*EmptyResponse, error)
+
 	// Queries
 	BatchChange(ctx context.Context, args *BatchChangeArgs) (BatchChangeResolver, error)
 	BatchChanges(cx context.Context, args *ListBatchChangesArgs) (BatchChangesConnectionResolver, error)
@@ -271,6 +290,8 @@ type BatchChangesResolver interface {
 	RepoDiffStat(ctx context.Context, repo *graphql.ID) (*DiffStat, error)
 
 	BatchSpecs(cx context.Context, args *ListBatchSpecArgs) (BatchSpecConnectionResolver, error)
+
+	BatchChangesLifecycleHooks(ctx context.Context, args *ListBatchChangesLifecycleHooksArgs) (BatchChangesLifecycleHookConnectionResolver, error)
 
 	NodeResolvers() map[string]NodeByIDFunc
 }
@@ -819,4 +840,19 @@ type BatchSpecWorkspaceEnvironmentVariableResolver interface {
 type BatchSpecWorkspaceOutputVariableResolver interface {
 	Name() string
 	Value() JSONValue
+}
+
+type BatchChangesLifecycleHookResolver interface {
+	ID() graphql.ID
+	CreatedAt() DateTime
+	UpdatedAt() DateTime
+	ExpiresAt() *DateTime
+	URL() string
+	Secret() string
+}
+
+type BatchChangesLifecycleHookConnectionResolver interface {
+	Nodes(ctx context.Context) ([]BatchChangesLifecycleHookResolver, error)
+	TotalCount(ctx context.Context) (int32, error)
+	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
 }

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2988,3 +2988,31 @@ input ChangesetSpecPublicationStateInput {
     """
     publicationState: PublishedValue!
 }
+
+type BatchChangesLifecycleHook implements Node {
+    id: ID!
+    createdAt: DateTime!
+    updatedAt: DateTime!
+    expiresAt: DateTime
+    url: String!
+    secret: String!
+}
+
+type BatchChangesLifecycleHookConnection {
+    nodes: [BatchChangesLifecycleHook!]!
+    totalCount: Int!
+    pageInfo: PageInfo!
+}
+
+extend type Mutation {
+    createBatchChangesLifecycleHook(expiresAt: DateTime, url: String!, secret: String!): BatchChangesLifecycleHook!
+    deleteBatchChangesLifecycleHook(id: ID!): EmptyResponse!
+}
+
+extend type Query {
+    batchChangesLifecycleHooks(
+        first: Int = 50
+        after: String
+        includeExpired: Boolean
+    ): BatchChangesLifecycleHookConnection!
+}

--- a/cmd/frontend/graphqlbackend/node.go
+++ b/cmd/frontend/graphqlbackend/node.go
@@ -249,4 +249,10 @@ func (r *NodeResolver) ToWebhookLog() (*webhookLogResolver, bool) {
 func (r *NodeResolver) ToExecutor() (*executorResolver, bool) {
 	n, ok := r.Node.(*executorResolver)
 	return n, ok
+
+}
+
+func (r *NodeResolver) ToBatchChangesLifecycleHook() (BatchChangesLifecycleHookResolver, bool) {
+	n, ok := r.Node.(BatchChangesLifecycleHookResolver)
+	return n, ok
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/lifecycle_hook.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/lifecycle_hook.go
@@ -1,0 +1,144 @@
+package resolvers
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
+	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+)
+
+const lifecycleHookIDKind = "BatchChangesLifecycleHook"
+
+func marshalLifecycleHookID(id int64) graphql.ID {
+	return relay.MarshalID(lifecycleHookIDKind, id)
+}
+
+func unmarshalLifecycleHookID(id graphql.ID) (hid int64, err error) {
+	err = relay.UnmarshalSpec(id, &hid)
+	return
+}
+
+func (r *Resolver) CreateBatchChangesLifecycleHook(
+	ctx context.Context,
+	args *graphqlbackend.CreateBatchChangesLifecycleHookArgs,
+) (graphqlbackend.BatchChangesLifecycleHookResolver, error) {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.store.DatabaseDB()); err != nil {
+		return nil, err
+	}
+
+	var expiresAt time.Time
+	if args.ExpiresAt != nil {
+		expiresAt = args.ExpiresAt.Time
+	}
+
+	hook := btypes.LifecycleHook{
+		ExpiresAt: expiresAt,
+		URL:       args.URL,
+		Secret:    args.Secret,
+	}
+	if err := r.store.CreateLifecycleHook(ctx, &hook); err != nil {
+		return nil, err
+	}
+
+	return &lifecycleHookResolver{
+		store: r.store,
+		hook:  &hook,
+	}, nil
+}
+
+func (r *Resolver) DeleteBatchChangesLifecycleHook(
+	ctx context.Context,
+	args *graphqlbackend.DeleteBatchChangesLifecycleHookArgs,
+) (*graphqlbackend.EmptyResponse, error) {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.store.DatabaseDB()); err != nil {
+		return nil, err
+	}
+
+	id, err := unmarshalLifecycleHookID(args.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := r.store.DeleteLifecycleHook(ctx, id); err != nil {
+		return nil, err
+	}
+
+	return &graphqlbackend.EmptyResponse{}, nil
+}
+
+func (r *Resolver) BatchChangesLifecycleHooks(
+	ctx context.Context,
+	args *graphqlbackend.ListBatchChangesLifecycleHooksArgs,
+) (graphqlbackend.BatchChangesLifecycleHookConnectionResolver, error) {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.store.DatabaseDB()); err != nil {
+		return nil, err
+	}
+
+	if err := validateFirstParamDefaults(args.First); err != nil {
+		return nil, err
+	}
+
+	opts := store.ListLifecycleHookOpts{
+		LimitOpts:      store.LimitOpts{Limit: int(args.First)},
+		IncludeExpired: false,
+	}
+
+	if args.After != nil {
+		cursor, err := strconv.ParseInt(*args.After, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		opts.Cursor = cursor
+	}
+
+	if args.IncludeExpired != nil && *args.IncludeExpired {
+		opts.IncludeExpired = true
+	}
+
+	return &lifecycleHookConnectionResolver{
+		store: r.store,
+		opts:  opts,
+	}, nil
+}
+
+type lifecycleHookResolver struct {
+	store *store.Store
+	hook  *btypes.LifecycleHook
+}
+
+var _ graphqlbackend.Node = &lifecycleHookResolver{}
+var _ graphqlbackend.BatchChangesLifecycleHookResolver = &lifecycleHookResolver{}
+
+func (r *lifecycleHookResolver) ID() graphql.ID {
+	return marshalLifecycleHookID(r.hook.ID)
+}
+
+func (r *lifecycleHookResolver) CreatedAt() graphqlbackend.DateTime {
+	return graphqlbackend.DateTime{Time: r.hook.CreatedAt}
+}
+
+func (r *lifecycleHookResolver) UpdatedAt() graphqlbackend.DateTime {
+	return graphqlbackend.DateTime{Time: r.hook.UpdatedAt}
+}
+
+func (r *lifecycleHookResolver) ExpiresAt() *graphqlbackend.DateTime {
+	if r.hook.ExpiresAt.IsZero() {
+		return nil
+	}
+	return &graphqlbackend.DateTime{Time: r.hook.ExpiresAt}
+}
+
+func (r *lifecycleHookResolver) URL() string {
+	return r.hook.URL
+}
+
+func (r *lifecycleHookResolver) Secret() string {
+	return r.hook.Secret
+}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/lifecycle_hook_conection.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/lifecycle_hook_conection.go
@@ -1,0 +1,78 @@
+package resolvers
+
+import (
+	"context"
+	"strconv"
+	"sync"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
+)
+
+type lifecycleHookConnectionResolver struct {
+	store *store.Store
+	opts  store.ListLifecycleHookOpts
+
+	once  sync.Once
+	hooks []graphqlbackend.BatchChangesLifecycleHookResolver
+	next  int64
+	err   error
+}
+
+var _ graphqlbackend.BatchChangesLifecycleHookConnectionResolver = &lifecycleHookConnectionResolver{}
+
+func (r *lifecycleHookConnectionResolver) Nodes(ctx context.Context) ([]graphqlbackend.BatchChangesLifecycleHookResolver, error) {
+	hooks, _, err := r.compute(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return hooks, nil
+}
+
+func (r *lifecycleHookConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
+	opts := store.CountLifecycleHooksOpts{
+		IncludeExpired: r.opts.IncludeExpired,
+	}
+
+	count, err := r.store.CountLifecycleHooks(ctx, opts)
+	if err != nil {
+		return 0, err
+	}
+
+	return int32(count), nil
+}
+
+func (r *lifecycleHookConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	_, next, err := r.compute(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if next == 0 {
+		return graphqlutil.HasNextPage(false), nil
+	}
+	return graphqlutil.NextPageCursor(strconv.FormatInt(next, 10)), nil
+}
+
+func (r *lifecycleHookConnectionResolver) compute(ctx context.Context) ([]graphqlbackend.BatchChangesLifecycleHookResolver, int64, error) {
+	r.once.Do(func() {
+		hooks, next, err := r.store.ListLifecycleHooks(ctx, r.opts)
+		if err != nil {
+			r.err = err
+			return
+		}
+
+		r.next = next
+		r.hooks = make([]graphqlbackend.BatchChangesLifecycleHookResolver, len(hooks))
+		for i := range hooks {
+			r.hooks[i] = &lifecycleHookResolver{
+				store: r.store,
+				hook:  hooks[i],
+			}
+		}
+	})
+
+	return r.hooks, r.next, r.err
+}

--- a/enterprise/internal/batches/background/background.go
+++ b/enterprise/internal/batches/background/background.go
@@ -3,6 +3,7 @@ package background
 import (
 	"context"
 
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/lifecycle"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/scheduler"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
@@ -22,8 +23,10 @@ func Routines(ctx context.Context, batchesStore *store.Store, cf *httpcli.Factor
 	batchSpecWorkspaceExecutionWorkerStore := NewBatchSpecWorkspaceExecutionWorkerStore(batchesStore.Handle(), observationContext)
 	batchSpecResolutionWorkerStore := newBatchSpecResolutionWorkerStore(batchesStore.Handle(), observationContext)
 
+	hookDispatcher := lifecycle.NewDispatcher(batchesStore)
+
 	routines := []goroutine.BackgroundRoutine{
-		newReconcilerWorker(ctx, batchesStore, reconcilerWorkerStore, gitserver.DefaultClient, sourcer, metrics),
+		newReconcilerWorker(ctx, batchesStore, reconcilerWorkerStore, gitserver.DefaultClient, hookDispatcher, sourcer, metrics),
 		newReconcilerWorkerResetter(reconcilerWorkerStore, metrics),
 
 		newSpecExpireJob(ctx, batchesStore),

--- a/enterprise/internal/batches/background/reconciler_worker.go
+++ b/enterprise/internal/batches/background/reconciler_worker.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/keegancsmith/sqlf"
 
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/lifecycle"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/reconciler"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
@@ -33,10 +34,11 @@ func newReconcilerWorker(
 	s *store.Store,
 	workerStore dbworkerstore.Store,
 	gitClient reconciler.GitserverClient,
+	hookDispatcher *lifecycle.Dispatcher,
 	sourcer sources.Sourcer,
 	metrics batchChangesMetrics,
 ) *workerutil.Worker {
-	r := reconciler.New(gitClient, sourcer, s)
+	r := reconciler.New(gitClient, hookDispatcher, sourcer, s)
 
 	options := workerutil.WorkerOptions{
 		Name:              "batches_reconciler_worker",

--- a/enterprise/internal/batches/lifecycle/batch_change.go
+++ b/enterprise/internal/batches/lifecycle/batch_change.go
@@ -1,0 +1,16 @@
+package lifecycle
+
+import (
+	"encoding/json"
+
+	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+)
+
+type batchChangeMarshaller struct {
+	batchChange *btypes.BatchChange
+}
+
+func (bcm *batchChangeMarshaller) MarshalJSON() ([]byte, error) {
+	// TODO: figure out what fields should be excluded.
+	return json.Marshal(bcm.batchChange)
+}

--- a/enterprise/internal/batches/lifecycle/changeset.go
+++ b/enterprise/internal/batches/lifecycle/changeset.go
@@ -1,0 +1,87 @@
+package lifecycle
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
+	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+type changesetEvent struct {
+	store *store.Store
+
+	verb      string
+	changeset *btypes.Changeset
+
+	once    sync.Once
+	payload []byte
+	err     error
+}
+
+var _ event = &changesetEvent{}
+
+func (e *changesetEvent) MarshalPayload(ctx context.Context) ([]byte, error) {
+	e.once.Do(func() {
+		repo, err := database.GlobalRepos.Get(ctx, e.changeset.RepoID)
+		if err != nil {
+			e.err = errors.Wrap(err, "getting repo")
+			return
+		}
+
+		batchChanges, _, err := e.store.ListBatchChanges(ctx, store.ListBatchChangesOpts{
+			ChangesetID: e.changeset.ID,
+		})
+		if err != nil {
+			e.err = errors.Wrap(err, "getting batch changes")
+			return
+		}
+
+		e.payload, e.err = changesetMarshaller{
+			changeset:    e.changeset,
+			batchChanges: batchChanges,
+			repo:         repo,
+		}.MarshalJSON()
+	})
+
+	return e.payload, e.err
+}
+
+type changesetMarshaller struct {
+	changeset    *btypes.Changeset
+	batchChanges []*btypes.BatchChange
+	repo         *types.Repo
+}
+
+func (cm changesetMarshaller) MarshalJSON() ([]byte, error) {
+	batchChanges := make([]batchChangeMarshaller, len(cm.batchChanges))
+	for i := range cm.batchChanges {
+		batchChanges[i].batchChange = cm.batchChanges[i]
+	}
+
+	return json.Marshal(struct {
+		ID                 int64
+		Repo               repoMarshaller
+		CreatedAt          time.Time
+		UpdatedAt          time.Time
+		BatchChanges       []batchChangeMarshaller
+		ExternalID         string
+		ExternalBranch     string
+		OwnedByBatchChange int64 `json:",omitempty"`
+	}{
+		ID:                 cm.changeset.ID,
+		Repo:               repoMarshaller{cm.repo},
+		CreatedAt:          cm.changeset.CreatedAt,
+		UpdatedAt:          cm.changeset.UpdatedAt,
+		BatchChanges:       batchChanges,
+		ExternalID:         cm.changeset.ExternalID,
+		ExternalBranch:     cm.changeset.ExternalBranch,
+		OwnedByBatchChange: cm.changeset.OwnedByBatchChangeID,
+	})
+}

--- a/enterprise/internal/batches/lifecycle/dispatcher.go
+++ b/enterprise/internal/batches/lifecycle/dispatcher.go
@@ -1,0 +1,106 @@
+package lifecycle
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"net/http"
+
+	"github.com/inconshreveable/log15"
+	"github.com/pkg/errors"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
+	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+)
+
+type Dispatcher struct {
+	store *store.Store
+
+	c chan event
+}
+
+func NewDispatcher(store *store.Store) *Dispatcher {
+	c := make(chan event, 0)
+
+	go func() {
+		// Since this is an internal process, this uses an internal actor.
+		ctx := actor.WithInternalActor(context.Background())
+
+		for e := range c {
+			if err := dispatchEvent(ctx, store, e); err != nil {
+				log15.Error("error dispatching lifecycle hook event", "err", err, "event", e)
+			}
+		}
+	}()
+
+	return &Dispatcher{store: store, c: c}
+}
+
+func (d *Dispatcher) ChangesetPublished(ctx context.Context, cs *btypes.Changeset) {
+	if d != nil {
+		d.c <- &changesetEvent{
+			store:     d.store,
+			verb:      "published",
+			changeset: cs,
+		}
+	}
+}
+
+func dispatchEvent(ctx context.Context, s *store.Store, e event) error {
+	payload, err := e.MarshalPayload(ctx)
+	if err != nil {
+		return errors.Wrap(err, "marshalling event payload")
+	}
+
+	// TODO: filter webhooks based on the methods to be added to the event.
+	//
+	// TODO: memoise this return value so we don't have to go back to the
+	// database every time.
+	hooks, _, err := s.ListLifecycleHooks(ctx, store.ListLifecycleHookOpts{})
+	if err != nil {
+		return errors.Wrap(err, "getting lifecycle hooks")
+	}
+
+	for _, hook := range hooks {
+		go func(hook *btypes.LifecycleHook) {
+			// Calculate signature.
+			hasher := hmac.New(sha256.New, []byte(hook.Secret))
+			if _, err := hasher.Write(payload); err != nil {
+				log15.Error("calcuating signature for payload", "err", err, "hook", hook)
+				return
+			}
+			sig := hasher.Sum(nil)
+
+			// Construct and send request.
+			buf := &bytes.Buffer{}
+			if _, err := buf.Write(payload); err != nil {
+				log15.Error("constructing request buffer", "err", err, "hook", hook)
+				return
+			}
+
+			req, err := http.NewRequestWithContext(ctx, "POST", hook.URL, buf)
+			if err != nil {
+				log15.Error("constructing request", "err", err, "hook", hook)
+			}
+
+			req.Header.Add("Content-Type", "application/json; charset=UTF-8")
+			req.Header.Add("X-Sourcegraph-Signature-256", base64.StdEncoding.EncodeToString(sig))
+
+			if resp, err := http.DefaultClient.Do(req); err != nil {
+				log15.Error("sending lifecycle hook", "err", err, "hook", hook)
+			} else if resp.StatusCode >= 400 {
+				log15.Warn("received error from lifecycle hook endpoint", "response", resp, "hook", hook)
+			} else if resp.StatusCode >= 300 {
+				// The default redirect policy should make this unlikely.
+				log15.Info("received redirect from lifecycle hook endpoint", "response", resp, "hook", hook)
+			} else {
+				log15.Debug("successful lifecycle hook", "response", resp, "hook", hook)
+			}
+		}(hook)
+	}
+
+	return nil
+}

--- a/enterprise/internal/batches/lifecycle/events.go
+++ b/enterprise/internal/batches/lifecycle/events.go
@@ -1,0 +1,12 @@
+package lifecycle
+
+import "context"
+
+type event interface {
+	// This doesn't use json.Marshaler because we want to be able to pass in a
+	// context.
+	MarshalPayload(ctx context.Context) ([]byte, error)
+
+	// TODO: add methods to access the things we would want to filter webhooks
+	// by: organisation, maybe repo, maybe user.
+}

--- a/enterprise/internal/batches/lifecycle/repo.go
+++ b/enterprise/internal/batches/lifecycle/repo.go
@@ -1,0 +1,16 @@
+package lifecycle
+
+import (
+	"encoding/json"
+
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+type repoMarshaller struct {
+	repo *types.Repo
+}
+
+func (rm repoMarshaller) MarshalJSON() ([]byte, error) {
+	// TODO: figure out what fields should be excluded here.
+	return json.Marshal(rm.repo)
+}

--- a/enterprise/internal/batches/reconciler/executor_test.go
+++ b/enterprise/internal/batches/reconciler/executor_test.go
@@ -504,6 +504,7 @@ func TestExecutor_ExecutePlan(t *testing.T) {
 			err := executePlan(
 				ctx,
 				gitClient,
+				nil,
 				sourcer,
 				// Don't actually sleep for the sake of testing.
 				true,
@@ -622,7 +623,7 @@ func TestExecutor_ExecutePlan_PublishedChangesetDuplicateBranch(t *testing.T) {
 	})
 	plan.Changeset = ct.BuildChangeset(ct.TestChangesetOpts{Repo: repo.ID})
 
-	err := executePlan(ctx, nil, sources.NewFakeSourcer(nil, &sources.FakeChangesetSource{}), true, cstore, plan)
+	err := executePlan(ctx, nil, nil, sources.NewFakeSourcer(nil, &sources.FakeChangesetSource{}), true, cstore, plan)
 	if err == nil {
 		t.Fatal("reconciler did not return error")
 	}
@@ -656,7 +657,7 @@ func TestExecutor_ExecutePlan_AvoidLoadingChangesetSource(t *testing.T) {
 
 		plan.AddOp(btypes.ReconcilerOperationClose)
 
-		err := executePlan(ctx, nil, sourcer, true, cstore, plan)
+		err := executePlan(ctx, nil, nil, sourcer, true, cstore, plan)
 		if err != ourError {
 			t.Fatalf("executePlan did not return expected error: %s", err)
 		}
@@ -669,7 +670,7 @@ func TestExecutor_ExecutePlan_AvoidLoadingChangesetSource(t *testing.T) {
 
 		plan.AddOp(btypes.ReconcilerOperationDetach)
 
-		err := executePlan(ctx, nil, sourcer, true, cstore, plan)
+		err := executePlan(ctx, nil, nil, sourcer, true, cstore, plan)
 		if err != nil {
 			t.Fatalf("executePlan returned unexpected error: %s", err)
 		}
@@ -1016,6 +1017,7 @@ func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
 			err := executePlan(
 				context.Background(),
 				gitClient,
+				nil,
 				sourcer,
 				true,
 				cstore,

--- a/enterprise/internal/batches/store/lifecycle_hooks.go
+++ b/enterprise/internal/batches/store/lifecycle_hooks.go
@@ -1,0 +1,243 @@
+package store
+
+import (
+	"context"
+
+	"github.com/keegancsmith/sqlf"
+
+	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+type CountLifecycleHooksOpts struct {
+	IncludeExpired bool
+}
+
+func (s *Store) CountLifecycleHooks(ctx context.Context, opts CountLifecycleHooksOpts) (count int, err error) {
+	ctx, endObservation := s.operations.countLifecycleHooks.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	q := countLifecycleHooksQuery(&opts)
+	return s.queryCount(ctx, q)
+}
+
+func (s *Store) CreateLifecycleHook(ctx context.Context, hook *btypes.LifecycleHook) (err error) {
+	ctx, endObservation := s.operations.createLifecycleHook.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	if hook.CreatedAt.IsZero() {
+		hook.CreatedAt = s.now()
+	}
+	if hook.UpdatedAt.IsZero() {
+		hook.UpdatedAt = s.now()
+	}
+
+	q := createLifecycleHookQuery(hook)
+	return s.query(ctx, q, func(sc dbutil.Scanner) error {
+		return scanLifecycleHook(hook, sc)
+	})
+}
+
+func (s *Store) DeleteLifecycleHook(ctx context.Context, id int64) (err error) {
+	ctx, endObservation := s.operations.deleteLifecycleHook.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	res, err := s.ExecResult(ctx, deleteLifecycleHookQuery(id))
+	if err != nil {
+		return err
+	}
+
+	if rows, err := res.RowsAffected(); err != nil {
+		return err
+	} else if rows == 0 {
+		return ErrNoResults
+	}
+	return nil
+}
+
+func (s *Store) GetLifecycleHook(ctx context.Context, id int64) (hook *btypes.LifecycleHook, err error) {
+	ctx, endObservation := s.operations.getLifecycleHook.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	hook = &btypes.LifecycleHook{}
+	q := getLifecycleHookQuery(id)
+	if err := s.query(ctx, q, func(sc dbutil.Scanner) error {
+		return scanLifecycleHook(hook, sc)
+	}); err != nil {
+		return nil, err
+	}
+
+	if hook.ID == 0 {
+		return nil, ErrNoResults
+	}
+
+	return hook, err
+}
+
+type ListLifecycleHookOpts struct {
+	LimitOpts
+	Cursor         int64
+	IncludeExpired bool
+}
+
+func (s *Store) ListLifecycleHooks(ctx context.Context, opts ListLifecycleHookOpts) (hooks []*btypes.LifecycleHook, next int64, err error) {
+	ctx, endObservation := s.operations.listLifecycleHooks.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	hooks = make([]*btypes.LifecycleHook, 0, opts.DBLimit())
+	q := listLifecycleHooksQuery(&opts)
+	if err := s.query(ctx, q, func(sc dbutil.Scanner) error {
+		hook := btypes.LifecycleHook{}
+		if err := scanLifecycleHook(&hook, sc); err != nil {
+			return err
+		}
+
+		hooks = append(hooks, &hook)
+		return nil
+	}); err != nil {
+		return nil, 0, err
+	}
+
+	if opts.Limit != 0 && len(hooks) == opts.DBLimit() {
+		next = hooks[len(hooks)-1].ID
+		hooks = hooks[:len(hooks)-1]
+	}
+
+	return hooks, next, err
+}
+
+const countLifecycleHooksQueryFmtstr = `
+-- source: enterprise/internal/batches/store/lifecycle_hooks.go:CountLifecycleHook
+
+SELECT
+	COUNT(id)
+FROM
+	batch_changes_lifecycle_hooks
+WHERE
+	%s
+`
+
+func countLifecycleHooksQuery(opts *CountLifecycleHooksOpts) *sqlf.Query {
+	preds := []*sqlf.Query{sqlf.Sprintf("TRUE")}
+	if !opts.IncludeExpired {
+		preds = append(preds, sqlf.Sprintf("expires_at IS NULL"))
+	}
+
+	return sqlf.Sprintf(
+		countLifecycleHooksQueryFmtstr,
+		sqlf.Join(preds, " AND "),
+	)
+}
+
+const createLifecycleHookQueryFmtstr = `
+-- source: enterprise/internal/batches/store/lifecycle_hooks.go:CreateLifecycleHook
+
+INSERT INTO batch_changes_lifecycle_hooks (
+	created_at,
+	updated_at,
+	expires_at,
+	url,
+	secret
+)
+VALUES
+	(%s, %s, %s, %s, %s)
+RETURNING
+	%s
+`
+
+func createLifecycleHookQuery(hook *btypes.LifecycleHook) *sqlf.Query {
+	return sqlf.Sprintf(
+		createLifecycleHookQueryFmtstr,
+		hook.CreatedAt,
+		hook.UpdatedAt,
+		nullTimeColumn(hook.ExpiresAt),
+		hook.URL,
+		hook.Secret,
+		sqlf.Join(lifecycleHookColumns, ", "),
+	)
+}
+
+const deleteLifecycleHookQueryFmtstr = `
+-- source: enterprise/internal/batches/store/lifecycle_hooks.go:DeleteLifecycleHook
+
+DELETE FROM
+	batch_changes_lifecycle_hooks
+WHERE
+	id = %s
+`
+
+func deleteLifecycleHookQuery(id int64) *sqlf.Query {
+	return sqlf.Sprintf(
+		deleteLifecycleHookQueryFmtstr,
+		id,
+	)
+}
+
+const getLifecycleHookQueryFmtstr = `
+-- source: enterprise/internal/batches/store/lifecycle_hooks.go:GetLifecycleHook
+
+SELECT
+	%s
+FROM
+	batch_changes_lifecycle_hooks
+WHERE
+	id = %s
+`
+
+func getLifecycleHookQuery(id int64) *sqlf.Query {
+	return sqlf.Sprintf(
+		getLifecycleHookQueryFmtstr,
+		sqlf.Join(lifecycleHookColumns, ", "),
+		id,
+	)
+}
+
+const listLifecycleHooksQueryFmtstr = `
+-- source: enterprise/internal/batches/store/lifecycle_hooks.go:ListLifecycleHooks
+
+SELECT
+	%s
+FROM
+	batch_changes_lifecycle_hooks
+WHERE
+	%s
+ORDER BY
+	id ASC
+`
+
+func listLifecycleHooksQuery(opts *ListLifecycleHookOpts) *sqlf.Query {
+	preds := []*sqlf.Query{sqlf.Sprintf("TRUE")}
+	if opts.Cursor != 0 {
+		preds = append(preds, sqlf.Sprintf("id >= %s", opts.Cursor))
+	}
+	if !opts.IncludeExpired {
+		preds = append(preds, sqlf.Sprintf("expires_at IS NULL"))
+	}
+
+	return sqlf.Sprintf(
+		listLifecycleHooksQueryFmtstr+opts.ToDB(),
+		sqlf.Join(lifecycleHookColumns, ", "),
+		sqlf.Join(preds, " AND "),
+	)
+}
+
+var lifecycleHookColumns = []*sqlf.Query{
+	sqlf.Sprintf("id"),
+	sqlf.Sprintf("created_at"),
+	sqlf.Sprintf("updated_at"),
+	sqlf.Sprintf("expires_at"),
+	sqlf.Sprintf("url"),
+	sqlf.Sprintf("secret"),
+}
+
+func scanLifecycleHook(hook *btypes.LifecycleHook, sc dbutil.Scanner) error {
+	return sc.Scan(
+		&hook.ID,
+		&hook.CreatedAt,
+		&hook.UpdatedAt,
+		&dbutil.NullTime{Time: &hook.ExpiresAt},
+		&hook.URL,
+		&hook.Secret,
+	)
+}

--- a/enterprise/internal/batches/store/store.go
+++ b/enterprise/internal/batches/store/store.go
@@ -272,6 +272,12 @@ type operations struct {
 	markUsedBatchSpecExecutionCacheEntry *observation.Operation
 	createBatchSpecExecutionCacheEntry   *observation.Operation
 	cleanBatchSpecExecutionCacheEntries  *observation.Operation
+
+	countLifecycleHooks *observation.Operation
+	createLifecycleHook *observation.Operation
+	getLifecycleHook    *observation.Operation
+	listLifecycleHooks  *observation.Operation
+	deleteLifecycleHook *observation.Operation
 }
 
 var (

--- a/enterprise/internal/batches/types/lifecycle_hook.go
+++ b/enterprise/internal/batches/types/lifecycle_hook.go
@@ -1,0 +1,12 @@
+package types
+
+import "time"
+
+type LifecycleHook struct {
+	ID        int64
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	ExpiresAt time.Time
+	URL       string
+	Secret    string
+}

--- a/migrations/frontend/1528395945_lifecycle_hooks.down.sql
+++ b/migrations/frontend/1528395945_lifecycle_hooks.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE IF EXISTS batch_changes_lifecycle_hooks;
+
+COMMIT;

--- a/migrations/frontend/1528395945_lifecycle_hooks.up.sql
+++ b/migrations/frontend/1528395945_lifecycle_hooks.up.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS batch_changes_lifecycle_hooks (
+    id BIGSERIAL PRIMARY KEY NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMP WITH TIME ZONE NULL,
+    url TEXT NOT NULL,
+    secret TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS
+    batch_changes_lifecycle_hooks_expires_at_idx
+ON
+    batch_changes_lifecycle_hooks (expires_at);
+
+COMMIT;


### PR DESCRIPTION
These are outgoing webhooks that are dispatched when interesting events occur in Batch Changes. In this initial commit, this is _only_ changeset publication, but this would be trivial to extend to other event types, particularly those originating in the reconciler.

Features that _are_ supported that we'll eventually need are basic HMAC signatures (inspired by GitHub's use of HMAC) and hook expiry.

Enough GraphQL has been built for a minimal site admin UI, but I haven't actually built it just yet.

Obvious things that are missing, besides the site admin UI, are allowing hooks to be registered only on specific organisations and repositories, along with the ability to filter which event types are sent to individual hooks.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
