### PR TITLE
Only return 401 on invalid access token

### DIFF
--- a/cmd/frontend/internal/httpapi/auth.go
+++ b/cmd/frontend/internal/httpapi/auth.go
@@ -3,6 +3,7 @@ package httpapi
 import (
 	"net/http"
 
+	"github.com/cockroachdb/errors"
 	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
@@ -70,13 +71,13 @@ func AccessTokenAuthMiddleware(db database.DB, next http.Handler) http.Handler {
 			}
 			subjectUserID, err := db.AccessTokens().Lookup(r.Context(), token, requiredScope)
 			if err != nil {
-				if err == database.ErrAccessTokenNotFound {
-					log15.Error("Invalid access token", "token", token, "err", err)
-					http.Error(w, "Invalid access token", http.StatusUnauthorized)
+				if err == database.ErrAccessTokenNotFound || errors.HasType(err, database.InvalidTokenError{}) {
+					log15.Error("Invalid access token.", "token", token, "err", err)
+					http.Error(w, "Invalid access token.", http.StatusUnauthorized)
 					return
 				}
 
-				log15.Error("Looking up access token", "token", token, "err", err)
+				log15.Error("Looking up access token.", "token", token, "err", err)
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}

--- a/cmd/frontend/internal/httpapi/auth.go
+++ b/cmd/frontend/internal/httpapi/auth.go
@@ -72,12 +72,12 @@ func AccessTokenAuthMiddleware(db database.DB, next http.Handler) http.Handler {
 			subjectUserID, err := db.AccessTokens().Lookup(r.Context(), token, requiredScope)
 			if err != nil {
 				if err == database.ErrAccessTokenNotFound || errors.HasType(err, database.InvalidTokenError{}) {
-					log15.Error("Invalid access token.", "token", token, "err", err)
+					log15.Error("AccessTokenAuthMiddleware.invalidAccessToken", "token", token, "error", err)
 					http.Error(w, "Invalid access token.", http.StatusUnauthorized)
 					return
 				}
 
-				log15.Error("Looking up access token.", "token", token, "err", err)
+				log15.Error("AccessTokenAuthMiddleware.lookingUpAccessToken.", "token", token, "error", err)
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}

--- a/cmd/frontend/internal/httpapi/auth.go
+++ b/cmd/frontend/internal/httpapi/auth.go
@@ -70,8 +70,14 @@ func AccessTokenAuthMiddleware(db database.DB, next http.Handler) http.Handler {
 			}
 			subjectUserID, err := db.AccessTokens().Lookup(r.Context(), token, requiredScope)
 			if err != nil {
-				log15.Error("Invalid access token.", "token", token, "err", err)
-				http.Error(w, "Invalid access token.", http.StatusUnauthorized)
+				if err == database.ErrAccessTokenNotFound {
+					log15.Error("Invalid access token", "token", token, "err", err)
+					http.Error(w, "Invalid access token", http.StatusUnauthorized)
+					return
+				}
+
+				log15.Error("Looking up access token", "token", token, "err", err)
+				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
 

--- a/cmd/frontend/internal/httpapi/auth_test.go
+++ b/cmd/frontend/internal/httpapi/auth_test.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/cockroachdb/errors"
 	mockrequire "github.com/derision-test/go-mockgen/testutil/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -76,7 +75,7 @@ func TestAccessTokenAuthMiddleware(t *testing.T) {
 		req.Header.Set("Authorization", "token badbad")
 
 		accessTokens := dbmock.NewMockAccessTokenStore()
-		accessTokens.LookupFunc.SetDefaultReturn(0, errors.New("x"))
+		accessTokens.LookupFunc.SetDefaultReturn(0, database.InvalidTokenError{})
 		db := dbmock.NewMockDB()
 		db.AccessTokensFunc.SetDefaultReturn(accessTokens)
 


### PR DESCRIPTION
The auth middleware returned 401 errors for all other kinds of errors as well. This was very confusing to me and seems incorrect as well. I saw logs about an access token being invalid so I dug for quite a bit until I found error messages in logs that revealed the real problem: on k8s the frontend couldn't connect to the database during a rollout.
