### PR TITLE
codeintel: Fix missing `done(err)` call in symbols

### DIFF
--- a/cmd/symbols/internal/symbols/fetch.go
+++ b/cmd/symbols/internal/symbols/fetch.go
@@ -62,6 +62,7 @@ func (s *Service) fetchRepositoryArchive(ctx context.Context, repo api.RepoName,
 
 	r, err := s.FetchTar(ctx, repo, commitID, paths)
 	if err != nil {
+		done(err)
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
The `symbols` service in prod is stalled right now because it's not calling `done(err)` and releasing the semaphore, which is causing all new search request goroutines to get stuck waiting for the semaphore.

This bug has existed for years, and only now shows up because #27932 is causing errors on big repos.

Either of these will fix the stalled `symbols` service:

- Merge and deploy this PR
- Deploy #27989 (merged, but not deployed yet)