### PR TITLE
graphqlbackend: reduce usage of `database.Mocks`

### DIFF
--- a/cmd/frontend/graphqlbackend/orgs_test.go
+++ b/cmd/frontend/graphqlbackend/orgs_test.go
@@ -1,13 +1,11 @@
 package graphqlbackend
 
 import (
-	"context"
 	"testing"
 
 	"github.com/graph-gophers/graphql-go/errors"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -55,17 +53,16 @@ func TestOrgs(t *testing.T) {
 }
 
 func TestListOrgsForCloud(t *testing.T) {
-	db := database.NewDB(nil)
-	resetMocks()
+	orig := envvar.SourcegraphDotComMode()
 	envvar.MockSourcegraphDotComMode(true)
-	database.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
-		return &types.User{SiteAdmin: true}, nil
-	}
+	defer envvar.MockSourcegraphDotComMode(orig)
 
-	t.Cleanup(func() {
-		resetMocks()
-		envvar.MockSourcegraphDotComMode(false)
-	})
+	users := dbmock.NewMockUserStore()
+	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: true}, nil)
+
+	db := dbmock.NewMockDB()
+	db.UsersFunc.SetDefaultReturn(users)
+
 	RunTests(t, []*Test{
 		{
 			Schema: mustParseGraphQLSchema(t, db),


### PR DESCRIPTION
This PR reduces usage of `database.Mocks` in the `cmd/frontend/graphqlbackend` package.

---

Part of #26113