### PR TITLE
Build and upload binaries of executor to GCP bucket

### DIFF
--- a/enterprise/cmd/executor/.gitignore
+++ b/enterprise/cmd/executor/.gitignore
@@ -1,0 +1,1 @@
+artifacts

--- a/enterprise/cmd/executor/build.sh
+++ b/enterprise/cmd/executor/build.sh
@@ -37,11 +37,11 @@ mkdir linux-amd64
 # Copy binary into new folder
 cp "$bin_name" linux-amd64/executor
 sha256sum linux-amd64/executor >>linux-amd64/executor_SHA256SUM
-cd -
+cd ..
 # Duplicate folder as "latest"
 rm -rf executor/latest
 cp -r "executor/$(git rev-parse HEAD)" executor/latest
-cd -
+cd ..
 
 echo "--- gcp secret"
 gcloud secrets versions access latest --secret=e2e-builder-sa-key --quiet --project=sourcegraph-ci >"$OUTPUT/builder-sa-key.json"

--- a/enterprise/cmd/executor/build.sh
+++ b/enterprise/cmd/executor/build.sh
@@ -36,6 +36,7 @@ git log -n1 >>info.txt
 mkdir linux-amd64
 # Copy binary into new folder
 cp "$bin_name" linux-amd64/executor
+sha256sum linux-amd64/executor >> linux-amd64/executor_SHA256SUM
 cd -
 # Duplicate folder as "latest"
 rm -rf executor/latest

--- a/enterprise/cmd/executor/build.sh
+++ b/enterprise/cmd/executor/build.sh
@@ -33,11 +33,11 @@ cd "executor/$(git rev-parse HEAD)"
 echo "executor built from https://github.com/sourcegraph/sourcegraph" >info.txt
 echo >>info.txt
 git log -n1 >>info.txt
-mkdir linux-amd64
+mkdir -p linux-amd64
 # Copy binary into new folder
 cp "$bin_name" linux-amd64/executor
 sha256sum linux-amd64/executor >>linux-amd64/executor_SHA256SUM
-cd ..
+cd ../..
 # Duplicate folder as "latest"
 rm -rf executor/latest
 cp -r "executor/$(git rev-parse HEAD)" executor/latest

--- a/enterprise/cmd/executor/build.sh
+++ b/enterprise/cmd/executor/build.sh
@@ -22,7 +22,25 @@ export CGO_ENABLED=0
 
 echo "--- go build"
 pkg="github.com/sourcegraph/sourcegraph/enterprise/cmd/executor"
-go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"
+bin_name="$OUTPUT/$(basename $pkg)"
+go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$bin_name" "$pkg"
+
+echo "--- create binary artifacts"
+mkdir -p artifacts && cd artifacts
+# Setup new release folder that contains binary, info text.
+mkdir -p "executor/$(git rev-parse HEAD)"
+cd "executor/$(git rev-parse HEAD)"
+echo "executor built from https://github.com/sourcegraph/sourcegraph" >info.txt
+echo >>info.txt
+git log -n1 >>info.txt
+mkdir linux-amd64
+# Copy binary into new folder
+cp "$bin_name" linux-amd64/executor
+cd -
+# Duplicate folder as "latest"
+rm -rf executor/latest
+cp -r "executor/$(git rev-parse HEAD)" executor/latest
+cd -
 
 echo "--- gcp secret"
 gcloud secrets versions access latest --secret=e2e-builder-sa-key --quiet --project=sourcegraph-ci >"$OUTPUT/builder-sa-key.json"

--- a/enterprise/cmd/executor/build.sh
+++ b/enterprise/cmd/executor/build.sh
@@ -43,25 +43,25 @@ echo "--- upload binary artifacts"
 gsutil cp -r artifacts/executor gs://sourcegraph-artifacts
 gsutil iam ch allUsers:objectViewer gs://sourcegraph-artifacts
 
-# echo "--- gcp secret"
-# gcloud secrets versions access latest --secret=e2e-builder-sa-key --quiet --project=sourcegraph-ci >"$OUTPUT/builder-sa-key.json"
+echo "--- gcp secret"
+gcloud secrets versions access latest --secret=e2e-builder-sa-key --quiet --project=sourcegraph-ci >"$OUTPUT/builder-sa-key.json"
 
-# echo "--- packer build"
+echo "--- packer build"
 
-# # Copy files into workspace.
-# cp -R ./image/* "$OUTPUT"
-# cp ../../../.tool-versions "$OUTPUT"
+# Copy files into workspace.
+cp -R ./image/* "$OUTPUT"
+cp ../../../.tool-versions "$OUTPUT"
 
-# export NAME
-# NAME=executor-$(git log -n1 --pretty=format:%h)-${BUILDKITE_BUILD_NUMBER}
-# export SRC_CLI_VERSION=${SRC_CLI_VERSION}
-# export AWS_EXECUTOR_AMI_ACCESS_KEY=${AWS_EXECUTOR_AMI_ACCESS_KEY}
-# export AWS_EXECUTOR_AMI_SECRET_KEY=${AWS_EXECUTOR_AMI_SECRET_KEY}
-# # This should prevent some occurrences of Failed waiting for AMI failures:
-# # https://austincloud.guru/2020/05/14/long-running-packer-builds-failing/
-# export AWS_MAX_ATTEMPTS=240
-# export AWS_POLL_DELAY_SECONDS=5
+export NAME
+NAME=executor-$(git log -n1 --pretty=format:%h)-${BUILDKITE_BUILD_NUMBER}
+export SRC_CLI_VERSION=${SRC_CLI_VERSION}
+export AWS_EXECUTOR_AMI_ACCESS_KEY=${AWS_EXECUTOR_AMI_ACCESS_KEY}
+export AWS_EXECUTOR_AMI_SECRET_KEY=${AWS_EXECUTOR_AMI_SECRET_KEY}
+# This should prevent some occurrences of Failed waiting for AMI failures:
+# https://austincloud.guru/2020/05/14/long-running-packer-builds-failing/
+export AWS_MAX_ATTEMPTS=240
+export AWS_POLL_DELAY_SECONDS=5
 
-# pushd "$OUTPUT" 1>/dev/null
-# packer build -force executor.json
-# popd 1>/dev/null
+pushd "$OUTPUT" 1>/dev/null
+packer build -force executor.json
+popd 1>/dev/null

--- a/enterprise/cmd/executor/build.sh
+++ b/enterprise/cmd/executor/build.sh
@@ -37,7 +37,7 @@ mkdir -p linux-amd64
 # Copy binary into new folder
 cp "$bin_name" linux-amd64/executor
 sha256sum linux-amd64/executor >>linux-amd64/executor_SHA256SUM
-cd ../../...
+cd ../../..
 # Upload the new release folder
 echo "--- upload binary artifacts"
 gsutil cp -r artifacts/executor gs://sourcegraph-artifacts

--- a/enterprise/cmd/executor/build.sh
+++ b/enterprise/cmd/executor/build.sh
@@ -36,7 +36,7 @@ git log -n1 >>info.txt
 mkdir linux-amd64
 # Copy binary into new folder
 cp "$bin_name" linux-amd64/executor
-sha256sum linux-amd64/executor >> linux-amd64/executor_SHA256SUM
+sha256sum linux-amd64/executor >>linux-amd64/executor_SHA256SUM
 cd -
 # Duplicate folder as "latest"
 rm -rf executor/latest

--- a/enterprise/cmd/executor/build.sh
+++ b/enterprise/cmd/executor/build.sh
@@ -26,10 +26,10 @@ bin_name="$OUTPUT/$(basename $pkg)"
 go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$bin_name" "$pkg"
 
 echo "--- create binary artifacts"
-mkdir -p artifacts && cd artifacts
 # Setup new release folder that contains binary, info text.
-mkdir -p "executor/$(git rev-parse HEAD)"
-cd "executor/$(git rev-parse HEAD)"
+mkdir -p "artifacts/executor/$(git rev-parse HEAD)"
+cd "artifacts/executor/$(git rev-parse HEAD)"
+
 echo "executor built from https://github.com/sourcegraph/sourcegraph" >info.txt
 echo >>info.txt
 git log -n1 >>info.txt
@@ -37,31 +37,31 @@ mkdir -p linux-amd64
 # Copy binary into new folder
 cp "$bin_name" linux-amd64/executor
 sha256sum linux-amd64/executor >>linux-amd64/executor_SHA256SUM
-cd ../..
-# Duplicate folder as "latest"
-rm -rf executor/latest
-cp -r "executor/$(git rev-parse HEAD)" executor/latest
-cd ..
+cd ../../...
+# Upload the new release folder
+echo "--- upload binary artifacts"
+gsutil cp -r artifacts/executor gs://sourcegraph-artifacts
+gsutil iam ch allUsers:objectViewer gs://sourcegraph-artifacts
 
-echo "--- gcp secret"
-gcloud secrets versions access latest --secret=e2e-builder-sa-key --quiet --project=sourcegraph-ci >"$OUTPUT/builder-sa-key.json"
+# echo "--- gcp secret"
+# gcloud secrets versions access latest --secret=e2e-builder-sa-key --quiet --project=sourcegraph-ci >"$OUTPUT/builder-sa-key.json"
 
-echo "--- packer build"
+# echo "--- packer build"
 
-# Copy files into workspace.
-cp -R ./image/* "$OUTPUT"
-cp ../../../.tool-versions "$OUTPUT"
+# # Copy files into workspace.
+# cp -R ./image/* "$OUTPUT"
+# cp ../../../.tool-versions "$OUTPUT"
 
-export NAME
-NAME=executor-$(git log -n1 --pretty=format:%h)-${BUILDKITE_BUILD_NUMBER}
-export SRC_CLI_VERSION=${SRC_CLI_VERSION}
-export AWS_EXECUTOR_AMI_ACCESS_KEY=${AWS_EXECUTOR_AMI_ACCESS_KEY}
-export AWS_EXECUTOR_AMI_SECRET_KEY=${AWS_EXECUTOR_AMI_SECRET_KEY}
-# This should prevent some occurrences of Failed waiting for AMI failures:
-# https://austincloud.guru/2020/05/14/long-running-packer-builds-failing/
-export AWS_MAX_ATTEMPTS=240
-export AWS_POLL_DELAY_SECONDS=5
+# export NAME
+# NAME=executor-$(git log -n1 --pretty=format:%h)-${BUILDKITE_BUILD_NUMBER}
+# export SRC_CLI_VERSION=${SRC_CLI_VERSION}
+# export AWS_EXECUTOR_AMI_ACCESS_KEY=${AWS_EXECUTOR_AMI_ACCESS_KEY}
+# export AWS_EXECUTOR_AMI_SECRET_KEY=${AWS_EXECUTOR_AMI_SECRET_KEY}
+# # This should prevent some occurrences of Failed waiting for AMI failures:
+# # https://austincloud.guru/2020/05/14/long-running-packer-builds-failing/
+# export AWS_MAX_ATTEMPTS=240
+# export AWS_POLL_DELAY_SECONDS=5
 
-pushd "$OUTPUT" 1>/dev/null
-packer build -force executor.json
-popd 1>/dev/null
+# pushd "$OUTPUT" 1>/dev/null
+# packer build -force executor.json
+# popd 1>/dev/null

--- a/enterprise/cmd/executor/release.sh
+++ b/enterprise/cmd/executor/release.sh
@@ -23,3 +23,4 @@ set -eu
 # Copy uploaded binary to 'latest'
 gsutil rm -rf gs://sourcegraph-artifacts/executor/latest || true
 gsutil cp -r gs://sourcegraph-artifacts/executor/$(git rev-parse HEAD) gs://sourcegraph-artifacts/executor/latest
+gsutil iam ch allUsers:objectViewer gs://sourcegraph-artifacts/executor/latest

--- a/enterprise/cmd/executor/release.sh
+++ b/enterprise/cmd/executor/release.sh
@@ -21,5 +21,5 @@ set -eu
 # aws ec2 modify-image-attribute --image-id "${AWS_AMI_ID}" --launch-permission "Add=[{Group=all}]"
 
 # Copy uploaded binary to 'latest'
-gsutil rm -r gs://sourcegraph-artifacts/executor/latest
+gsutil rm -rf gs://sourcegraph-artifacts/executor/latest
 gsutil cp -r gs://sourcegraph-artifacts/executor/$(git rev-parse HEAD) gs://sourcegraph-artifacts/executor/latest

--- a/enterprise/cmd/executor/release.sh
+++ b/enterprise/cmd/executor/release.sh
@@ -5,21 +5,21 @@
 cd "$(dirname "${BASH_SOURCE[0]}")"
 set -eu
 
-export AWS_ACCESS_KEY_ID="${AWS_EXECUTOR_AMI_ACCESS_KEY}"
-export AWS_SECRET_ACCESS_KEY="${AWS_EXECUTOR_AMI_SECRET_KEY}"
+# export AWS_ACCESS_KEY_ID="${AWS_EXECUTOR_AMI_ACCESS_KEY}"
+# export AWS_SECRET_ACCESS_KEY="${AWS_EXECUTOR_AMI_SECRET_KEY}"
 
-# Point to GCP boot disk image/AMI built by build.sh script
-NAME="executor-$(git log -n1 --pretty=format:%h)-${BUILDKITE_BUILD_NUMBER}"
-GOOGLE_IMAGE_NAME="${NAME}"
-AWS_AMI_ID=$(aws ec2 describe-images --filter "Name=name,Values=${NAME}" --query 'Images[*].[ImageId]' --output text)
+# # Point to GCP boot disk image/AMI built by build.sh script
+# NAME="executor-$(git log -n1 --pretty=format:%h)-${BUILDKITE_BUILD_NUMBER}"
+# GOOGLE_IMAGE_NAME="${NAME}"
+# AWS_AMI_ID=$(aws ec2 describe-images --filter "Name=name,Values=${NAME}" --query 'Images[*].[ImageId]' --output text)
 
-# Mark GCP boot disk as released and make it usable outside of Sourcegraph
-gcloud compute images add-labels --project=sourcegraph-ci "${GOOGLE_IMAGE_NAME}" --labels='released=true'
-gcloud compute images add-iam-policy-binding --project=sourcegraph-ci "${GOOGLE_IMAGE_NAME}" --member='allAuthenticatedUsers' --role='roles/compute.imageUser'
+# # Mark GCP boot disk as released and make it usable outside of Sourcegraph
+# gcloud compute images add-labels --project=sourcegraph-ci "${GOOGLE_IMAGE_NAME}" --labels='released=true'
+# gcloud compute images add-iam-policy-binding --project=sourcegraph-ci "${GOOGLE_IMAGE_NAME}" --member='allAuthenticatedUsers' --role='roles/compute.imageUser'
 
-# Make executor AMI usable outside of Sourcegraph
-aws ec2 modify-image-attribute --image-id "${AWS_AMI_ID}" --launch-permission "Add=[{Group=all}]"
+# # Make executor AMI usable outside of Sourcegraph
+# aws ec2 modify-image-attribute --image-id "${AWS_AMI_ID}" --launch-permission "Add=[{Group=all}]"
 
-# Upload release and 'latest' folder in 'artifacts' folder to GCP bucket
-gsutil cp -r artifacts/executor gs://sourcegraph-artifacts
-gsutil iam ch allUsers:objectViewer gs://sourcegraph-artifacts
+# Copy uploaded binary to 'latest'
+gsutil rm -r gs://sourcegraph-artifacts/executor/latest
+gsutil cp -r gs://sourcegraph-artifacts/executor/$(git rev-parse HEAD) gs://sourcegraph-artifacts/executor/latest

--- a/enterprise/cmd/executor/release.sh
+++ b/enterprise/cmd/executor/release.sh
@@ -22,5 +22,5 @@ aws ec2 modify-image-attribute --image-id "${AWS_AMI_ID}" --launch-permission "A
 
 # Copy uploaded binary to 'latest'
 gsutil rm -rf gs://sourcegraph-artifacts/executor/latest || true
-gsutil cp -r gs://sourcegraph-artifacts/executor/$(git rev-parse HEAD) gs://sourcegraph-artifacts/executor/latest
+gsutil cp -r "gs://sourcegraph-artifacts/executor/$(git rev-parse HEAD)" gs://sourcegraph-artifacts/executor/latest
 gsutil iam ch allUsers:objectViewer gs://sourcegraph-artifacts/executor/latest

--- a/enterprise/cmd/executor/release.sh
+++ b/enterprise/cmd/executor/release.sh
@@ -5,20 +5,20 @@
 cd "$(dirname "${BASH_SOURCE[0]}")"
 set -eu
 
-# export AWS_ACCESS_KEY_ID="${AWS_EXECUTOR_AMI_ACCESS_KEY}"
-# export AWS_SECRET_ACCESS_KEY="${AWS_EXECUTOR_AMI_SECRET_KEY}"
+export AWS_ACCESS_KEY_ID="${AWS_EXECUTOR_AMI_ACCESS_KEY}"
+export AWS_SECRET_ACCESS_KEY="${AWS_EXECUTOR_AMI_SECRET_KEY}"
 
-# # Point to GCP boot disk image/AMI built by build.sh script
-# NAME="executor-$(git log -n1 --pretty=format:%h)-${BUILDKITE_BUILD_NUMBER}"
-# GOOGLE_IMAGE_NAME="${NAME}"
-# AWS_AMI_ID=$(aws ec2 describe-images --filter "Name=name,Values=${NAME}" --query 'Images[*].[ImageId]' --output text)
+# Point to GCP boot disk image/AMI built by build.sh script
+NAME="executor-$(git log -n1 --pretty=format:%h)-${BUILDKITE_BUILD_NUMBER}"
+GOOGLE_IMAGE_NAME="${NAME}"
+AWS_AMI_ID=$(aws ec2 describe-images --filter "Name=name,Values=${NAME}" --query 'Images[*].[ImageId]' --output text)
 
-# # Mark GCP boot disk as released and make it usable outside of Sourcegraph
-# gcloud compute images add-labels --project=sourcegraph-ci "${GOOGLE_IMAGE_NAME}" --labels='released=true'
-# gcloud compute images add-iam-policy-binding --project=sourcegraph-ci "${GOOGLE_IMAGE_NAME}" --member='allAuthenticatedUsers' --role='roles/compute.imageUser'
+# Mark GCP boot disk as released and make it usable outside of Sourcegraph
+gcloud compute images add-labels --project=sourcegraph-ci "${GOOGLE_IMAGE_NAME}" --labels='released=true'
+gcloud compute images add-iam-policy-binding --project=sourcegraph-ci "${GOOGLE_IMAGE_NAME}" --member='allAuthenticatedUsers' --role='roles/compute.imageUser'
 
-# # Make executor AMI usable outside of Sourcegraph
-# aws ec2 modify-image-attribute --image-id "${AWS_AMI_ID}" --launch-permission "Add=[{Group=all}]"
+# Make executor AMI usable outside of Sourcegraph
+aws ec2 modify-image-attribute --image-id "${AWS_AMI_ID}" --launch-permission "Add=[{Group=all}]"
 
 # Copy uploaded binary to 'latest'
 gsutil rm -rf gs://sourcegraph-artifacts/executor/latest || true

--- a/enterprise/cmd/executor/release.sh
+++ b/enterprise/cmd/executor/release.sh
@@ -21,5 +21,5 @@ set -eu
 # aws ec2 modify-image-attribute --image-id "${AWS_AMI_ID}" --launch-permission "Add=[{Group=all}]"
 
 # Copy uploaded binary to 'latest'
-gsutil rm -rf gs://sourcegraph-artifacts/executor/latest
+gsutil rm -rf gs://sourcegraph-artifacts/executor/latest || true
 gsutil cp -r gs://sourcegraph-artifacts/executor/$(git rev-parse HEAD) gs://sourcegraph-artifacts/executor/latest

--- a/enterprise/cmd/executor/release.sh
+++ b/enterprise/cmd/executor/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# This script publishes the executor image built by build.sh
+# This script publishes the executor image and binary built by build.sh
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 set -eu
@@ -19,3 +19,7 @@ gcloud compute images add-iam-policy-binding --project=sourcegraph-ci "${GOOGLE_
 
 # Make executor AMI usable outside of Sourcegraph
 aws ec2 modify-image-attribute --image-id "${AWS_AMI_ID}" --launch-permission "Add=[{Group=all}]"
+
+# Upload release and 'latest' folder in 'artifacts' folder to GCP bucket
+gsutil cp -r artifacts/executor gs://sourcegraph-artifacts
+gsutil iam ch allUsers:objectViewer gs://sourcegraph-artifacts


### PR DESCRIPTION
This is modelled after `dev/src-expose/release.sh`: https://github.com/sourcegraph/sourcegraph/blob/main/dev/src-expose/release.sh

But it's split into two: build & release process.

The **build step** creates a directory/file structure that looks like this and uploads it to GCP:

```
$ tree enterprise/cmd/executor/artifacts
.
└── executor
    ├── 010b133ece7a79187cad209b27099232485a5476
    │   ├── info.txt
    │   └── linux-amd64
    │       ├── executor
    │       └── executor_SHA256SUM
```

The **release step** then deletes the current `latest` folder and copies the last release folder to `latest`:

* https://storage.googleapis.com/sourcegraph-artifacts/executor/latest/info.txt
* https://storage.googleapis.com/sourcegraph-artifacts/executor/latest/linux-amd64/executor
* https://storage.googleapis.com/sourcegraph-artifacts/executor/latest/linux-amd64/executor_SHA256SUM
