### PR TITLE
Executors release pipeline

### DIFF
--- a/enterprise/dev/ci/internal/ci/config.go
+++ b/enterprise/dev/ci/internal/ci/config.go
@@ -64,7 +64,12 @@ func NewConfig(now time.Time) Config {
 	var changedFiles []string
 	diffCommand := []string{"diff", "--name-only"}
 	if commit != "" {
-		diffCommand = append(diffCommand, "origin/main..."+commit)
+		if branch == "main" {
+			// On main, just look at the latest commit.
+			diffCommand = append(diffCommand, "@^")
+		} else {
+			diffCommand = append(diffCommand, "origin/main..."+commit)
+		}
 	} else {
 		diffCommand = append(diffCommand, "origin/main...")
 		// for testing

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -195,9 +195,9 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 
 		// Executor VM image
 		skipHashCompare := c.MessageFlags.SkipHashCompare || c.RunType.Is(ReleaseBranch)
-		if c.RunType.Is(MainDryRun, MainBranch) {
+		if c.RunType.Is(MainDryRun, MainBranch, ReleaseBranch) {
 			ops.Append(buildExecutor(c.Version, skipHashCompare))
-			if c.ChangedFiles.AffectsExecutorDockerRegistryMirror() {
+			if c.RunType.Is(ReleaseBranch) || c.ChangedFiles.AffectsExecutorDockerRegistryMirror() {
 				ops.Append(buildExecutorDockerMirror(c.Version))
 			}
 		}
@@ -226,9 +226,9 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			ops.Append(publishFinalDockerImage(c, dockerImage))
 		}
 		// Executor VM image
-		if c.RunType.Is(MainBranch) {
+		if c.RunType.Is(MainBranch, ReleaseBranch) {
 			ops.Append(publishExecutor(c.Version, skipHashCompare))
-			if c.ChangedFiles.AffectsExecutorDockerRegistryMirror() {
+			if c.RunType.Is(ReleaseBranch) || c.ChangedFiles.AffectsExecutorDockerRegistryMirror() {
 				ops.Append(publishExecutorDockerMirror(c.Version))
 			}
 		}

--- a/enterprise/dev/ci/internal/ci/runtype.go
+++ b/enterprise/dev/ci/internal/ci/runtype.go
@@ -61,7 +61,8 @@ func computeRunType(tag, branch string) RunType {
 		return ImagePatchNoTest
 	case branch == "docker-images-candidates-notest":
 		return CandidatesNoTest
-	case branch == "executor-patch-notest":
+	case branch == "executor-patch-notest",
+		strings.HasPrefix(branch, "executor-patch-notest/"):
 		return ExecutorPatchNoTest
 
 	case strings.HasPrefix(branch, "backend-integration/"):


### PR DESCRIPTION
Always run executor pipeline on release and fix running docker registry mirror pipeline on main.

Closes https://github.com/sourcegraph/sourcegraph/issues/26677