### PR TITLE
Backport notification fix to version 3.33

### DIFF
--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/NYTimes/gziphandler"
@@ -124,7 +125,7 @@ func healthCheckMiddleware(next http.Handler) http.Handler {
 func newInternalHTTPHandler(schema *graphql.Schema, db dbutil.DB, newCodeIntelUploadHandler enterprise.NewCodeIntelUploadHandler, rateLimitWatcher graphqlbackend.LimitWatcher) http.Handler {
 	internalMux := http.NewServeMux()
 	internalMux.Handle("/.internal/", gziphandler.GzipHandler(
-		withInternalActor(
+		withActor(
 			internalhttpapi.NewInternalHandler(
 				router.NewInternal(mux.NewRouter().PathPrefix("/.internal/").Subrouter()),
 				db,
@@ -141,14 +142,24 @@ func newInternalHTTPHandler(schema *graphql.Schema, db dbutil.DB, newCodeIntelUp
 	return h
 }
 
-// withInternalActor wraps an existing HTTP handler by setting an internal actor in the HTTP request
-// context.
+// withActor wraps an existing HTTP handler by setting an actor in the HTTP request context.
+// It takes a user ID from the X-Sourcegraph-User-ID request header and if that fails to parse,
+// defaults to an internal actor.
 //
 // 🚨 SECURITY: This should *never* be called to wrap externally accessible handlers (i.e., only use
-// for the internal endpoint), because internal requests will bypass repository permissions checks.
-func withInternalActor(h http.Handler) http.Handler {
+// for the internal endpoint), because internal requests can bypass repository permissions checks.
+func withActor(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		rWithActor := r.WithContext(actor.WithActor(r.Context(), &actor.Actor{Internal: true}))
+		var a actor.Actor
+
+		userID, err := strconv.ParseInt(r.Header.Get("X-Sourcegraph-User-ID"), 10, 32)
+		if err != nil || userID == 0 {
+			a.Internal = true
+		} else {
+			a.UID = int32(userID)
+		}
+
+		rWithActor := r.WithContext(actor.WithActor(r.Context(), &a))
 		h.ServeHTTP(w, rWithActor)
 	})
 }

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -141,7 +141,7 @@ BEGIN;
 DELETE FROM cm_monitors WHERE namespace_user_id IS NULL OR namespace_org_id IS NOT NULL;
 COMMENT ON COLUMN cm_monitors.namespace_org_id IS 'DEPRECATED: code monitors cannot be owned by an org';
 
--- Drop the table first to make this transaction idempotent
+-- Drop the constraint first to make this transaction idempotent
 ALTER TABLE cm_monitors
 	DROP CONSTRAINT IF EXISTS cm_monitors_cannot_be_org_owned;
 ALTER TABLE cm_monitors
@@ -153,7 +153,7 @@ ALTER TABLE cm_monitors
 UPDATE saved_searches
 SET (notify_owner, notify_slack) = (false, false);
 
--- Drop the table first to make this transaction idempotent
+-- Drop the constraint first to make this transaction idempotent
 ALTER TABLE saved_searches
 	DROP CONSTRAINT IF EXISTS saved_searches_notifications_disabled;
 ALTER TABLE saved_searches

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -143,10 +143,10 @@ COMMENT ON COLUMN cm_monitors.namespace_org_id IS 'DEPRECATED: code monitors can
 
 -- Drop the constraint first to make this transaction idempotent
 ALTER TABLE cm_monitors
-	DROP CONSTRAINT IF EXISTS cm_monitors_cannot_be_org_owned;
+	DROP CONSTRAINT IF EXISTS cm_monitors_cannot_be_org_owned_backport;
 ALTER TABLE cm_monitors
 	ALTER COLUMN namespace_user_id SET NOT NULL,
-	ADD CONSTRAINT cm_monitors_cannot_be_org_owned CHECK (
+	ADD CONSTRAINT cm_monitors_cannot_be_org_owned_backport CHECK (
 		namespace_org_id IS NULL
 	);
 
@@ -155,9 +155,9 @@ SET (notify_owner, notify_slack) = (false, false);
 
 -- Drop the constraint first to make this transaction idempotent
 ALTER TABLE saved_searches
-	DROP CONSTRAINT IF EXISTS saved_searches_notifications_disabled;
+	DROP CONSTRAINT IF EXISTS saved_searches_notifications_disabled_backport;
 ALTER TABLE saved_searches
-	ADD CONSTRAINT saved_searches_notifications_disabled CHECK (
+	ADD CONSTRAINT saved_searches_notifications_disabled_backport CHECK (
 		notify_owner = false
 		AND notify_slack = false
 	);

--- a/enterprise/internal/codemonitors/background/graphql.go
+++ b/enterprise/internal/codemonitors/background/graphql.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"runtime"
+	"strconv"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -120,7 +121,7 @@ type gqlSearchResponse struct {
 	Errors []interface{}
 }
 
-func search(ctx context.Context, query string) (*gqlSearchResponse, error) {
+func search(ctx context.Context, query string, userID int32) (*gqlSearchResponse, error) {
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(graphQLQuery{
 		Query:     gqlSearchQuery,
@@ -141,6 +142,7 @@ func search(ctx context.Context, query string) (*gqlSearchResponse, error) {
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Sourcegraph-UserID", strconv.FormatInt(int64(userID), 10))
 	resp, err := httpcli.InternalDoer.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, errors.Wrap(err, "Post")

--- a/enterprise/internal/codemonitors/background/graphql.go
+++ b/enterprise/internal/codemonitors/background/graphql.go
@@ -142,7 +142,7 @@ func search(ctx context.Context, query string, userID int32) (*gqlSearchResponse
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Sourcegraph-UserID", strconv.FormatInt(int64(userID), 10))
+	req.Header.Set("X-Sourcegraph-User-ID", strconv.FormatInt(int64(userID), 10))
 	resp, err := httpcli.InternalDoer.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, errors.Wrap(err, "Post")

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -152,11 +152,20 @@ func (r *queryRunner) Handle(ctx context.Context, record workerutil.Record) (err
 	if err != nil {
 		return err
 	}
+
+	m, err := s.MonitorByIDInt64(ctx, q.Monitor)
+	if err != nil {
+		return err
+	}
+
 	newQuery := newQueryWithAfterFilter(q)
 
+	if m.NamespaceUserID == nil {
+		return errors.New("code monitors cannot be owned by orgs")
+	}
+
 	// Search.
-	var results *gqlSearchResponse
-	results, err = search(ctx, newQuery)
+	results, err := search(ctx, newQuery, *m.NamespaceUserID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This backports the fixes we made to saved search and code monitor notifications onto version 3.33.
Patch release request [here](https://github.com/sourcegraph/sourcegraph/issues/27999). I didn't realize
we had release branches, which is why I didn't make this until now 😄 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
