### PR TITLE
search: remove spurious log

### DIFF
--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -15,7 +15,6 @@ import (
 	"github.com/google/zoekt/query"
 	"github.com/google/zoekt/stream"
 	"github.com/hashicorp/go-multierror"
-	"github.com/inconshreveable/log15"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -159,11 +158,8 @@ func (s *HorizontalSearcher) StreamSearch(ctx context.Context, q query.Q, opts *
 	}
 
 	metricReorderQueueSize.WithLabelValues().Observe(float64(resultQueueMaxLength))
-	if len(resultQueue) > 0 {
-		log15.Warn("HorizontalSearcher.Streamsearch: results not sent in core loop", "resultQueue", len(resultQueue))
-		for len(resultQueue) > 0 {
-			streamer.Send(heap.Pop(&resultQueue).(*zoekt.SearchResult))
-		}
+	for len(resultQueue) > 0 {
+		streamer.Send(heap.Pop(&resultQueue).(*zoekt.SearchResult))
 	}
 	return nil
 }


### PR DESCRIPTION
Previously we assumed most search results would be sent in the core loop
but this assumption is invalid and this log line is spamming production
logs.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
