### PR TITLE
Fix usage of gsutil iam ch

### DIFF
--- a/enterprise/cmd/executor/release.sh
+++ b/enterprise/cmd/executor/release.sh
@@ -23,4 +23,4 @@ aws ec2 modify-image-attribute --image-id "${AWS_AMI_ID}" --launch-permission "A
 # Copy uploaded binary to 'latest'
 gsutil rm -rf gs://sourcegraph-artifacts/executor/latest || true
 gsutil cp -r "gs://sourcegraph-artifacts/executor/$(git rev-parse HEAD)" gs://sourcegraph-artifacts/executor/latest
-gsutil iam ch allUsers:objectViewer gs://sourcegraph-artifacts/executor/latest
+gsutil iam ch allUsers:objectViewer gs://sourcegraph-artifacts


### PR DESCRIPTION
Previous call broke on `main`. `gsutil iam ch` only accepts a bucket name. 