### PR TITLE
Update minio envvars to new convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Sourcegraph services now listen to SIGTERM signals. This allows smoother rollouts in kubernetes deployments. [#27958](https://github.com/sourcegraph/sourcegraph/pull/27958)
 - The sourcegraph-frontend ingress now uses the networking.k8s.io/v1 api. This adds support for k8s v1.22 and later, and deprecates support for versions older than v1.18.x [#4029](https://github.com/sourcegraph/deploy-sourcegraph/pull/4029)
+- MinIO environment variables updated to use new names. This begins the deprecation of `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY`. [#26529](https://github.com/sourcegraph/sourcegraph/issues/26529)
 
 ### Fixed
 

--- a/cmd/server/shared/minio.go
+++ b/cmd/server/shared/minio.go
@@ -17,8 +17,8 @@ func maybeMinio() []string {
 	// Set default for MinIO auth and point at local MinIO endpoint
 	// All other variables will default to contacting a MinIO instance
 	// with our default credentials running in a sibling container.
-	SetDefaultEnv("MINIO_ACCESS_KEY", "AKIAIOSFODNN7EXAMPLE")
-	SetDefaultEnv("MINIO_SECRET_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+	SetDefaultEnv("MINIO_ROOT_USER", "AKIAIOSFODNN7EXAMPLE")
+	SetDefaultEnv("MINIO_ROOT_PASSWORD", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
 	SetDefaultEnv("PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT", "http://127.0.0.1:9000")
 
 	// Configure MinIO service

--- a/cmd/server/shared/minio.go
+++ b/cmd/server/shared/minio.go
@@ -19,6 +19,13 @@ func maybeMinio() []string {
 	// with our default credentials running in a sibling container.
 	SetDefaultEnv("MINIO_ROOT_USER", "AKIAIOSFODNN7EXAMPLE")
 	SetDefaultEnv("MINIO_ROOT_PASSWORD", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+
+	// Sunset deprecated MinIO environment variables (#26529)
+	// CI requires this change is merged before removal.
+	// Once sourcegraph/deploy-sourcegraph-docker passes CI, we can remove these.
+	SetDefaultEnv("MINIO_ACCESS_KEY", "AKIAIOSFODNN7EXAMPLE")
+	SetDefaultEnv("MINIO_SECRET_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+
 	SetDefaultEnv("PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT", "http://127.0.0.1:9000")
 
 	// Configure MinIO service

--- a/doc/admin/external_services/object_storage.md
+++ b/doc/admin/external_services/object_storage.md
@@ -2,8 +2,8 @@
 
 By default, Sourcegraph will use a MinIO server bundled with the instance to store precise code intelligence indexes uploaded by users. MinIO shouldn’t be accessible outside of the cluster/docker-compose network so it shouldn’t need anything other than the default credentials. However, if you do want to change the default credentials, you can supply the following environment variables to the MinIO container in your deployment:
 
-- `MINIO_ACCESS_KEY=<access key>`
-- `MINIO_SECRET_KEY=<secret key>`
+- `MINIO_ROOT_USER=<access key>`
+- `MINIO_ROOT_PASSWORD=<secret key>`
 
 Note that the access and secret keys are expected to be 20 and 40 characters in length, respectively, to match the format of AWS-generated keys.
 

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -81,8 +81,8 @@ env:
   NODE_ENV: development
 
   # Required for codeintel uploadstore
-  MINIO_ACCESS_KEY: AKIAIOSFODNN7EXAMPLE
-  MINIO_SECRET_KEY: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+  MINIO_ROOT_USER: AKIAIOSFODNN7EXAMPLE
+  MINIO_ROOT_PASSWORD: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
   PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT: http://localhost:9000
 
   # Required for frontend and executor to communicate
@@ -477,8 +477,8 @@ commands:
         --cpus=1 \
         --memory=1g \
         -p 0.0.0.0:9000:9000 \
-        -e 'MINIO_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE' \
-        -e 'MINIO_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY' \
+        -e 'MINIO_ROOT_USER=AKIAIOSFODNN7EXAMPLE' \
+        -e 'MINIO_ROOT_PASSWORD=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY' \
         -v "$MINIO_DISK":/data \
         $IMAGE server /data >"$MINIO_LOG_FILE" 2>&1
     install: |


### PR DESCRIPTION
Update minio environment variables to new convention. 
Addresses https://github.com/sourcegraph/sourcegraph/issues/26529.

[_Created by Sourcegraph batch change `kevin.wojkovich/minio-envvar-update`._](https://k8s.sgdev.org/users/kevin.wojkovich/batch-changes/minio-envvar-update)