### PR TITLE
Improve toggle usability by allowing a clickable label

### DIFF
--- a/client/branded/src/components/Toggle.module.scss
+++ b/client/branded/src/components/Toggle.module.scss
@@ -3,6 +3,9 @@
 }
 
 .toggle {
+    display: flex;
+    flex-direction: row;
+
     --toggle-bar-bg: var(--icon-color);
     --toggle-bar-bg-on: var(--primary);
     --toggle-knob-bg: var(--body-bg);
@@ -12,13 +15,15 @@
     --toggle-knob-disabled-opacity: 1;
     --toggle-bar-focus-box-shadow: 0 0 0 1px var(--body-bg), 0 0 0 0.1875rem var(--primary-2);
 
-    background: none;
-    border: none;
-    display: inline-block;
-    outline: none !important;
-    padding: 0;
-    position: relative;
-    width: var(--toggle-width);
+    button {
+        background: none;
+        border: none;
+        display: inline-block;
+        outline: none !important;
+        padding: 0;
+        position: relative;
+        width: var(--toggle-width);
+    }
 
     &:focus-visible {
         /* Move focus style to the rounded bar */
@@ -43,6 +48,10 @@
     &:focus-visible .bar {
         box-shadow: var(--toggle-bar-focus-box-shadow);
     }
+
+    .label {
+        cursor: pointer;
+    }
 }
 
 .bar {
@@ -52,6 +61,8 @@
     height: 1rem;
     width: 100%;
     position: absolute;
+    display: flex;
+    align-items: center;
 
     opacity: var(--toggle-bar-opacity);
     background-color: var(--toggle-bar-bg);
@@ -72,7 +83,6 @@
 
     height: 0.75rem;
     width: 0.75rem;
-    margin-top: 0.25rem;
     left: 0.125rem;
 
     position: relative;

--- a/client/branded/src/components/Toggle.module.scss
+++ b/client/branded/src/components/Toggle.module.scss
@@ -4,7 +4,7 @@
 
 .toggle {
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
 
     --toggle-bar-bg: var(--icon-color);
     --toggle-bar-bg-on: var(--primary);
@@ -16,13 +16,26 @@
     --toggle-bar-focus-box-shadow: 0 0 0 1px var(--body-bg), 0 0 0 0.1875rem var(--primary-2);
 
     button {
+        align-items: center;
         background: none;
         border: none;
-        display: inline-block;
+        display: flex;
+        flex-direction: row;
         outline: none !important;
         padding: 0;
         position: relative;
-        width: var(--toggle-width);
+        width: fit-content;
+
+        &:disabled {
+            --toggle-knob-bg: var(--icon-color);
+            --toggle-knob-bg-on: var(--icon-color);
+            --toggle-bar-bg: var(--input-disabled-bg);
+            --toggle-bar-bg-on: var(--input-disabled-bg);
+        }
+
+        &:disabled .knob {
+            opacity: var(--toggle-knob-disabled-opacity);
+        }
     }
 
     &:focus-visible {
@@ -30,27 +43,23 @@
         box-shadow: none;
     }
 
-    &:disabled {
-        --toggle-knob-bg: var(--icon-color);
-        --toggle-knob-bg-on: var(--icon-color);
-        --toggle-bar-bg: var(--input-disabled-bg);
-        --toggle-bar-bg-on: var(--input-disabled-bg);
-    }
-
     &:hover:enabled .bar {
         opacity: var(--toggle-bar-focus-opacity);
-    }
-
-    &:disabled .knob {
-        opacity: var(--toggle-knob-disabled-opacity);
     }
 
     &:focus-visible .bar {
         box-shadow: var(--toggle-bar-focus-box-shadow);
     }
 
-    .label {
+    .help-text {
+        margin-left: 0.5rem;
+        padding-left: var(--toggle-width);
+    }
+
+    label {
+        color: var(--body-color);
         cursor: pointer;
+        padding-left: 0.5rem;
     }
 }
 
@@ -59,8 +68,7 @@
     top: 2px;
     left: 0;
     height: 1rem;
-    width: 100%;
-    position: absolute;
+    width: var(--toggle-width);
     display: flex;
     align-items: center;
 

--- a/client/branded/src/components/Toggle.story.tsx
+++ b/client/branded/src/components/Toggle.story.tsx
@@ -7,14 +7,15 @@ import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
 import { Toggle } from './Toggle'
 
 const ToggleExample: typeof Toggle = ({ value, disabled, onToggle }) => (
-    <div className="d-flex align-items-baseline mb-2">
-        <Toggle value={value} onToggle={onToggle} disabled={disabled} title="Hello" className="mr-2" />
-        <div>
-            <label className="mb-0">
-                {disabled ? 'Disabled ' : ''}Toggle {value ? 'on' : 'off'}
-            </label>
-            <small className="field-message mt-0">This is helper text as needed</small>
-        </div>
+    <div className="mb-2">
+        <Toggle
+            value={value}
+            onToggle={onToggle}
+            disabled={disabled}
+            title="Hello"
+            label={(disabled ? "Disabled" : "") + " Toggle on"}
+            offLabel={(disabled ? "Disabled" : "") + " Toggle off"}
+            helpText="This is helper text as needed" />
     </div>
 )
 const onToggle = action('onToggle')

--- a/client/branded/src/components/Toggle.tsx
+++ b/client/branded/src/components/Toggle.tsx
@@ -15,7 +15,7 @@ interface Props {
      */
     onToggle?: (value: boolean) => void
 
-    onClick?: (event: React.MouseEvent<HTMLButtonElement> | React.MouseEvent<HTMLDivElement>) => void
+    onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void
 
     /** The title attribute (tooltip). */
     title?: string
@@ -54,7 +54,7 @@ export const Toggle: React.FunctionComponent<Props> = ({
     'aria-describedby': ariaDescribedby,
     'data-testid': dataTestId,
 }) => {
-    function onButtonClick(event: React.MouseEvent<HTMLButtonElement> | React.MouseEvent<HTMLDivElement>): void {
+    function onButtonClick(event: React.MouseEvent<HTMLButtonElement>): void {
         event.stopPropagation()
         if (!disabled && onToggle) {
             onToggle(!value)
@@ -68,7 +68,6 @@ export const Toggle: React.FunctionComponent<Props> = ({
         <div className={classNames(styles.toggle, className)}>
             <button
                 type="button"
-
                 id={id}
                 title={title}
                 value={value ? 1 : 0}
@@ -93,20 +92,17 @@ export const Toggle: React.FunctionComponent<Props> = ({
                         })}
                     />
                 </span>
+
+                {label &&
+                    <label className="mb-0">
+                        {offLabel ? (value ? label : offLabel) : label}
+                    </label>
+                }
             </button>
-            {(label || helpText) &&
-                <div>
-                    {label &&
-                        <div onClick={onButtonClick} className={classNames(styles.label, className)}>
-                            {offLabel ? (value ? label : offLabel) : label}
-                        </div>
-                    }
-                    {helpText &&
-                        <div className={classNames(className, "text-muted")}>
-                            {offHelpText ? (value ? helpText : offHelpText) : helpText}
-                        </div>
-                    }
-                </div>
+            {helpText &&
+                <small className={classNames(styles.helpText, "field-message mt-0", className)}>
+                    {offHelpText ? (value ? helpText : offHelpText) : helpText}
+                </small>
             }
         </div>
     )

--- a/client/branded/src/components/Toggle.tsx
+++ b/client/branded/src/components/Toggle.tsx
@@ -15,10 +15,15 @@ interface Props {
      */
     onToggle?: (value: boolean) => void
 
-    onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void
+    onClick?: (event: React.MouseEvent<HTMLButtonElement> | React.MouseEvent<HTMLDivElement>) => void
 
     /** The title attribute (tooltip). */
     title?: string
+
+    label?: string
+    offLabel?: string
+    helpText?: string
+    offHelpText?: string
 
     'aria-label'?: string
     'aria-labelledby'?: string
@@ -36,6 +41,10 @@ export const Toggle: React.FunctionComponent<Props> = ({
     className,
     id,
     title,
+    label,
+    offLabel,
+    helpText,
+    offHelpText,
     value,
     tabIndex,
     onToggle,
@@ -45,7 +54,7 @@ export const Toggle: React.FunctionComponent<Props> = ({
     'aria-describedby': ariaDescribedby,
     'data-testid': dataTestId,
 }) => {
-    function onButtonClick(event: React.MouseEvent<HTMLButtonElement>): void {
+    function onButtonClick(event: React.MouseEvent<HTMLButtonElement> | React.MouseEvent<HTMLDivElement>): void {
         event.stopPropagation()
         if (!disabled && onToggle) {
             onToggle(!value)
@@ -56,32 +65,49 @@ export const Toggle: React.FunctionComponent<Props> = ({
     }
 
     return (
-        <button
-            type="button"
-            className={classNames(styles.toggle, className)}
-            id={id}
-            title={title}
-            value={value ? 1 : 0}
-            onClick={onButtonClick}
-            tabIndex={tabIndex}
-            disabled={disabled}
-            role="switch"
-            aria-checked={value}
-            aria-label={ariaLabel}
-            aria-labelledby={ariaLabelledby}
-            aria-describedby={ariaDescribedby}
-            data-testid={dataTestId}
-        >
-            <span
-                className={classNames(styles.bar, {
-                    [styles.barOn]: value,
-                })}
-            />
-            <span
-                className={classNames(styles.knob, {
-                    [styles.knobOn]: value,
-                })}
-            />
-        </button>
+        <div className={classNames(styles.toggle, className)}>
+            <button
+                type="button"
+
+                id={id}
+                title={title}
+                value={value ? 1 : 0}
+                onClick={onButtonClick}
+                tabIndex={tabIndex}
+                disabled={disabled}
+                role="switch"
+                aria-checked={value}
+                aria-label={ariaLabel}
+                aria-labelledby={ariaLabelledby}
+                aria-describedby={ariaDescribedby}
+                data-testid={dataTestId}
+            >
+                <span
+                    className={classNames(styles.bar, {
+                        [styles.barOn]: value,
+                    })}
+                >
+                    <span
+                        className={classNames(styles.knob, {
+                            [styles.knobOn]: value,
+                        })}
+                    />
+                </span>
+            </button>
+            {(label || helpText) &&
+                <div>
+                    {label &&
+                        <div onClick={onButtonClick} className={classNames(styles.label, className)}>
+                            {offLabel ? (value ? label : offLabel) : label}
+                        </div>
+                    }
+                    {helpText &&
+                        <div className={classNames(className, "text-muted")}>
+                            {offHelpText ? (value ? helpText : offHelpText) : helpText}
+                        </div>
+                    }
+                </div>
+            }
+        </div>
     )
 }

--- a/client/branded/src/components/__snapshots__/Toggle.test.tsx.snap
+++ b/client/branded/src/components/__snapshots__/Toggle.test.tsx.snap
@@ -6,23 +6,27 @@ exports[`Toggle aria 1`] = `
   aria-label="test toggle"
   aria-labelledby="test-id-2"
 >
-  <button
-    aria-describedby="test-id-1"
-    aria-label="test toggle"
-    aria-labelledby="test-id-2"
+  <div
     className="toggle"
-    onClick={[Function]}
-    role="switch"
-    type="button"
-    value={0}
   >
-    <span
-      className="bar"
-    />
-    <span
-      className="knob"
-    />
-  </button>
+    <button
+      aria-describedby="test-id-1"
+      aria-label="test toggle"
+      aria-labelledby="test-id-2"
+      onClick={[Function]}
+      role="switch"
+      type="button"
+      value={0}
+    >
+      <span
+        className="bar"
+      >
+        <span
+          className="knob"
+        />
+      </span>
+    </button>
+  </div>
 </Toggle>
 `;
 
@@ -30,20 +34,24 @@ exports[`Toggle className 1`] = `
 <Toggle
   className="c"
 >
-  <button
+  <div
     className="toggle c"
-    onClick={[Function]}
-    role="switch"
-    type="button"
-    value={0}
   >
-    <span
-      className="bar"
-    />
-    <span
-      className="knob"
-    />
-  </button>
+    <button
+      onClick={[Function]}
+      role="switch"
+      type="button"
+      value={0}
+    >
+      <span
+        className="bar"
+      >
+        <span
+          className="knob"
+        />
+      </span>
+    </button>
+  </div>
 </Toggle>
 `;
 
@@ -52,21 +60,25 @@ exports[`Toggle disabled 1`] = `
   disabled={true}
   onToggle={[Function]}
 >
-  <button
+  <div
     className="toggle"
-    disabled={true}
-    onClick={[Function]}
-    role="switch"
-    type="button"
-    value={0}
   >
-    <span
-      className="bar"
-    />
-    <span
-      className="knob"
-    />
-  </button>
+    <button
+      disabled={true}
+      onClick={[Function]}
+      role="switch"
+      type="button"
+      value={0}
+    >
+      <span
+        className="bar"
+      >
+        <span
+          className="knob"
+        />
+      </span>
+    </button>
+  </div>
 </Toggle>
 `;
 
@@ -74,21 +86,25 @@ exports[`Toggle value is false 1`] = `
 <Toggle
   value={false}
 >
-  <button
-    aria-checked={false}
+  <div
     className="toggle"
-    onClick={[Function]}
-    role="switch"
-    type="button"
-    value={0}
   >
-    <span
-      className="bar"
-    />
-    <span
-      className="knob"
-    />
-  </button>
+    <button
+      aria-checked={false}
+      onClick={[Function]}
+      role="switch"
+      type="button"
+      value={0}
+    >
+      <span
+        className="bar"
+      >
+        <span
+          className="knob"
+        />
+      </span>
+    </button>
+  </div>
 </Toggle>
 `;
 
@@ -96,20 +112,24 @@ exports[`Toggle value is true 1`] = `
 <Toggle
   value={true}
 >
-  <button
-    aria-checked={true}
+  <div
     className="toggle"
-    onClick={[Function]}
-    role="switch"
-    type="button"
-    value={1}
   >
-    <span
-      className="bar barOn"
-    />
-    <span
-      className="knob knobOn"
-    />
-  </button>
+    <button
+      aria-checked={true}
+      onClick={[Function]}
+      role="switch"
+      type="button"
+      value={1}
+    >
+      <span
+        className="bar barOn"
+      >
+        <span
+          className="knob knobOn"
+        />
+      </span>
+    </button>
+  </div>
 </Toggle>
 `;

--- a/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormActionArea.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormActionArea.test.tsx.snap
@@ -67,22 +67,26 @@ exports[`FormActionArea Error is shown if code monitor has empty description 1`]
       class="d-flex align-items-center my-4"
     >
       <div>
-        <button
-          aria-checked="true"
-          aria-labelledby="code-monitoring-form-actions-enable-toggle"
+        <div
           class="toggle mr-2"
-          role="switch"
-          title="Enabled"
-          type="button"
-          value="1"
         >
-          <span
-            class="bar barOn"
-          />
-          <span
-            class="knob knobOn"
-          />
-        </button>
+          <button
+            aria-checked="true"
+            aria-labelledby="code-monitoring-form-actions-enable-toggle"
+            role="switch"
+            title="Enabled"
+            type="button"
+            value="1"
+          >
+            <span
+              class="bar barOn"
+            >
+              <span
+                class="knob knobOn"
+              />
+            </span>
+          </button>
+        </div>
       </div>
       <span
         id="code-monitoring-form-actions-enable-toggle"

--- a/client/web/src/extensions/__snapshots__/ExtensionCard.test.tsx.snap
+++ b/client/web/src/extensions/__snapshots__/ExtensionCard.test.tsx.snap
@@ -66,22 +66,26 @@ exports[`ExtensionCard renders 1`] = `
           >
             Disabled by default for all
           </span>
-          <button
-            aria-checked="false"
+          <div
             class="toggle mx-2"
-            data-testid="extension-toggle-x/y"
-            role="switch"
-            title="Click to enable"
-            type="button"
-            value="0"
           >
-            <span
-              class="bar"
-            />
-            <span
-              class="knob"
-            />
-          </button>
+            <button
+              aria-checked="false"
+              data-testid="extension-toggle-x/y"
+              role="switch"
+              title="Click to enable"
+              type="button"
+              value="0"
+            >
+              <span
+                class="bar"
+              >
+                <span
+                  class="knob"
+                />
+              </span>
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/client/web/src/extensions/__snapshots__/ExtensionToggle.test.tsx.snap
+++ b/client/web/src/extensions/__snapshots__/ExtensionToggle.test.tsx.snap
@@ -2,63 +2,75 @@
 
 exports[`ExtensionToggle extension disabled in settings 1`] = `
 <DocumentFragment>
-  <button
-    aria-checked="false"
+  <div
     class="toggle"
-    data-testid="extension-toggle-x/y"
-    role="switch"
-    title="Click to enable"
-    type="button"
-    value="0"
   >
-    <span
-      class="bar"
-    />
-    <span
-      class="knob"
-    />
-  </button>
+    <button
+      aria-checked="false"
+      data-testid="extension-toggle-x/y"
+      role="switch"
+      title="Click to enable"
+      type="button"
+      value="0"
+    >
+      <span
+        class="bar"
+      >
+        <span
+          class="knob"
+        />
+      </span>
+    </button>
+  </div>
 </DocumentFragment>
 `;
 
 exports[`ExtensionToggle extension enabled in settings 1`] = `
 <DocumentFragment>
-  <button
-    aria-checked="true"
+  <div
     class="toggle"
-    data-testid="extension-toggle-x/y"
-    role="switch"
-    title="Click to disable"
-    type="button"
-    value="1"
   >
-    <span
-      class="bar barOn"
-    />
-    <span
-      class="knob knobOn"
-    />
-  </button>
+    <button
+      aria-checked="true"
+      data-testid="extension-toggle-x/y"
+      role="switch"
+      title="Click to disable"
+      type="button"
+      value="1"
+    >
+      <span
+        class="bar barOn"
+      >
+        <span
+          class="knob knobOn"
+        />
+      </span>
+    </button>
+  </div>
 </DocumentFragment>
 `;
 
 exports[`ExtensionToggle extension not present in settings 1`] = `
 <DocumentFragment>
-  <button
-    aria-checked="false"
+  <div
     class="toggle"
-    data-testid="extension-toggle-x/y"
-    role="switch"
-    title="Click to enable"
-    type="button"
-    value="0"
   >
-    <span
-      class="bar"
-    />
-    <span
-      class="knob"
-    />
-  </button>
+    <button
+      aria-checked="false"
+      data-testid="extension-toggle-x/y"
+      role="switch"
+      title="Click to enable"
+      type="button"
+      value="0"
+    >
+      <span
+        class="bar"
+      >
+        <span
+          class="knob"
+        />
+      </span>
+    </button>
+  </div>
 </DocumentFragment>
 `;


### PR DESCRIPTION
Solves #17133 

This adds 4 additional properties to the Toggle component, namely:
label
offLabel
helpText
offHelpText

If only label/helpText is supplied, it will be the text next to the Toggle. If offLabel/offHelpText is supplied in addition to label/helpText, label/helpText will be used when the toggle is on, and offLabel/offHelpText used when the toggle is off.

First draft used a clickable div for the label, but upon further reading it seems that clickable divs don't play well with screen readers, so I opted to resize the button itself instead. This required me to make some changes to the bar and knob css, but it keeps the final component to having 1 element with which a user can interact, which I think is most friendly to screen readers (altho my knowledge here is admittedly very limited, so take it with a pinch of salt).
