### PR TITLE
Reduce mock user emails use

### DIFF
--- a/cmd/frontend/backend/users.go
+++ b/cmd/frontend/backend/users.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/randstring"
 )
 
@@ -16,11 +15,11 @@ func MakeRandomHardToGuessPassword() string {
 
 var MockMakePasswordResetURL func(ctx context.Context, userID int32) (*url.URL, error)
 
-func MakePasswordResetURL(ctx context.Context, db dbutil.DB, userID int32) (*url.URL, error) {
+func MakePasswordResetURL(ctx context.Context, db database.DB, userID int32) (*url.URL, error) {
 	if MockMakePasswordResetURL != nil {
 		return MockMakePasswordResetURL(ctx, userID)
 	}
-	resetCode, err := database.Users(db).RenewPasswordResetCode(ctx, userID)
+	resetCode, err := db.Users().RenewPasswordResetCode(ctx, userID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/users_randomize_password.go
+++ b/cmd/frontend/graphqlbackend/users_randomize_password.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/userpasswd"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 type randomizeUserPasswordResult struct {
@@ -28,13 +27,13 @@ func (r *randomizeUserPasswordResult) ResetPasswordURL() *string {
 	return &urlStr
 }
 
-func sendEmail(ctx context.Context, db dbutil.DB, userID int32, resetURL *url.URL) error {
-	user, err := database.Users(db).GetByID(ctx, userID)
+func sendEmail(ctx context.Context, db database.DB, userID int32, resetURL *url.URL) error {
+	user, err := db.Users().GetByID(ctx, userID)
 	if err != nil {
 		return err
 	}
 
-	email, _, err := database.UserEmails(db).GetPrimaryEmail(ctx, userID)
+	email, _, err := db.UserEmails().GetPrimaryEmail(ctx, userID)
 	if err != nil {
 		return err
 	}
@@ -65,7 +64,7 @@ func (r *schemaResolver) RandomizeUserPassword(ctx context.Context, args *struct
 		return nil, errors.Wrap(err, "cannot parse user ID")
 	}
 
-	if err := database.Users(r.db).RandomizePasswordAndClearPasswordResetRateLimit(ctx, userID); err != nil {
+	if err := r.db.Users().RandomizePasswordAndClearPasswordResetRateLimit(ctx, userID); err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/internal/auth/userpasswd/reset_password.go
+++ b/cmd/frontend/internal/auth/userpasswd/reset_password.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/txemail"
 	"github.com/sourcegraph/sourcegraph/internal/txemail/txtypes"
@@ -37,7 +36,7 @@ func SendResetPasswordURLEmail(ctx context.Context, email, username string, rese
 }
 
 // HandleResetPasswordInit initiates the builtin-auth password reset flow by sending a password-reset email.
-func HandleResetPasswordInit(db dbutil.DB) func(w http.ResponseWriter, r *http.Request) {
+func HandleResetPasswordInit(db database.DB) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if handleEnabledCheck(w) {
 			return
@@ -111,13 +110,13 @@ To reset the password for {{.Username}} on Sourcegraph, follow this link:
 })
 
 // HandleSetPasswordEmail sends the password reset email directly to the user for users created by site admins.
-func HandleSetPasswordEmail(ctx context.Context, db dbutil.DB, id int32) (string, error) {
-	e, _, err := database.UserEmails(db).GetPrimaryEmail(ctx, id)
+func HandleSetPasswordEmail(ctx context.Context, db database.DB, id int32) (string, error) {
+	e, _, err := db.UserEmails().GetPrimaryEmail(ctx, id)
 	if err != nil {
 		return "", errors.Wrap(err, "get user primary email")
 	}
 
-	usr, err := database.Users(db).GetByID(ctx, id)
+	usr, err := db.Users().GetByID(ctx, id)
 	if err != nil {
 		return "", errors.Wrap(err, "get user by ID")
 	}

--- a/internal/database/user_emails.go
+++ b/internal/database/user_emails.go
@@ -199,9 +199,6 @@ func (s *userEmailsStore) Remove(ctx context.Context, userID int32, email string
 // correct (not the one originally used when creating the user or adding the user email), then it
 // returns false.
 func (s *userEmailsStore) Verify(ctx context.Context, userID int32, email, code string) (bool, error) {
-	if Mocks.UserEmails.Verify != nil {
-		return Mocks.UserEmails.Verify(ctx, userID, email, code)
-	}
 	var dbCode sql.NullString
 	if err := s.Handle().DB().QueryRowContext(ctx, "SELECT verification_code FROM user_emails WHERE user_id=$1 AND email=$2", userID, email).Scan(&dbCode); err != nil {
 		return false, err

--- a/internal/database/user_emails.go
+++ b/internal/database/user_emails.go
@@ -247,9 +247,6 @@ func (s *userEmailsStore) SetVerified(ctx context.Context, userID int32, email s
 
 // SetLastVerification sets the "last_verification_sent_at" column to now() and updates the verification code for given email of the user.
 func (s *userEmailsStore) SetLastVerification(ctx context.Context, userID int32, email, code string) error {
-	if Mocks.UserEmails.SetLastVerification != nil {
-		return Mocks.UserEmails.SetLastVerification(ctx, userID, email, code)
-	}
 	res, err := s.Handle().DB().ExecContext(ctx, "UPDATE user_emails SET last_verification_sent_at=now(), verification_code = $3 WHERE user_id=$1 AND email=$2", userID, email, code)
 	if err != nil {
 		return err
@@ -267,10 +264,6 @@ func (s *userEmailsStore) SetLastVerification(ctx context.Context, userID int32,
 // GetLatestVerificationSentEmail returns the email with the lastest time of "last_verification_sent_at" column,
 // it excludes rows with "last_verification_sent_at IS NULL".
 func (s *userEmailsStore) GetLatestVerificationSentEmail(ctx context.Context, email string) (*UserEmail, error) {
-	if Mocks.UserEmails.GetLatestVerificationSentEmail != nil {
-		return Mocks.UserEmails.GetLatestVerificationSentEmail(ctx, email)
-	}
-
 	q := sqlf.Sprintf(`
 WHERE email=%s AND last_verification_sent_at IS NOT NULL
 ORDER BY last_verification_sent_at DESC

--- a/internal/database/user_emails.go
+++ b/internal/database/user_emails.go
@@ -107,9 +107,6 @@ func (s *userEmailsStore) GetInitialSiteAdminEmail(ctx context.Context) (email s
 // GetPrimaryEmail gets the oldest email associated with the user, preferring a verified email to an
 // unverified email.
 func (s *userEmailsStore) GetPrimaryEmail(ctx context.Context, id int32) (email string, verified bool, err error) {
-	if Mocks.UserEmails.GetPrimaryEmail != nil {
-		return Mocks.UserEmails.GetPrimaryEmail(ctx, id)
-	}
 	if err := s.Handle().DB().QueryRowContext(ctx, "SELECT email, verified_at IS NOT NULL AS verified FROM user_emails WHERE user_id=$1 AND is_primary",
 		id,
 	).Scan(&email, &verified); err != nil {
@@ -122,9 +119,6 @@ func (s *userEmailsStore) GetPrimaryEmail(ctx context.Context, id int32) (email 
 // The address must be verified.
 // All other addresses for the user will be set as not primary.
 func (s *userEmailsStore) SetPrimaryEmail(ctx context.Context, userID int32, email string) error {
-	if Mocks.UserEmails.SetPrimaryEmail != nil {
-		return Mocks.UserEmails.SetPrimaryEmail(ctx, userID, email)
-	}
 	tx, err := s.Transact(ctx)
 	if err != nil {
 		return err
@@ -160,10 +154,6 @@ func (s *userEmailsStore) SetPrimaryEmail(ctx context.Context, userID int32, ema
 
 // Get gets information about the user's associated email address.
 func (s *userEmailsStore) Get(ctx context.Context, userID int32, email string) (emailCanonicalCase string, verified bool, err error) {
-	if Mocks.UserEmails.Get != nil {
-		return Mocks.UserEmails.Get(userID, email)
-	}
-
 	if err := s.Handle().DB().QueryRowContext(ctx, "SELECT email, verified_at IS NOT NULL AS verified FROM user_emails WHERE user_id=$1 AND email=$2",
 		userID, email,
 	).Scan(&emailCanonicalCase, &verified); err != nil {
@@ -233,10 +223,6 @@ func (s *userEmailsStore) Verify(ctx context.Context, userID int32, email, code 
 // SetVerified bypasses the normal email verification code process and manually sets the verified
 // status for an email.
 func (s *userEmailsStore) SetVerified(ctx context.Context, userID int32, email string, verified bool) error {
-	if Mocks.UserEmails.SetVerified != nil {
-		return Mocks.UserEmails.SetVerified(ctx, userID, email, verified)
-	}
-
 	var res sql.Result
 	var err error
 	if verified {

--- a/internal/database/user_emails_mock.go
+++ b/internal/database/user_emails_mock.go
@@ -5,8 +5,7 @@ import (
 )
 
 type MockUserEmails struct {
-	GetLatestVerificationSentEmail func(ctx context.Context, email string) (*UserEmail, error)
-	GetVerifiedEmails              func(ctx context.Context, emails ...string) ([]*UserEmail, error)
-	ListByUser                     func(ctx context.Context, opt UserEmailsListOptions) ([]*UserEmail, error)
-	Verify                         func(ctx context.Context, userID int32, email, code string) (bool, error)
+	GetVerifiedEmails func(ctx context.Context, emails ...string) ([]*UserEmail, error)
+	ListByUser        func(ctx context.Context, opt UserEmailsListOptions) ([]*UserEmail, error)
+	Verify            func(ctx context.Context, userID int32, email, code string) (bool, error)
 }

--- a/internal/database/user_emails_mock.go
+++ b/internal/database/user_emails_mock.go
@@ -5,7 +5,6 @@ import (
 )
 
 type MockUserEmails struct {
-	SetPrimaryEmail                func(ctx context.Context, userID int32, email string) error
 	SetVerified                    func(ctx context.Context, userID int32, email string, verified bool) error
 	SetLastVerification            func(ctx context.Context, userID int32, email, code string) error
 	GetLatestVerificationSentEmail func(ctx context.Context, email string) (*UserEmail, error)

--- a/internal/database/user_emails_mock.go
+++ b/internal/database/user_emails_mock.go
@@ -5,7 +5,6 @@ import (
 )
 
 type MockUserEmails struct {
-	SetVerified                    func(ctx context.Context, userID int32, email string, verified bool) error
 	SetLastVerification            func(ctx context.Context, userID int32, email, code string) error
 	GetLatestVerificationSentEmail func(ctx context.Context, email string) (*UserEmail, error)
 	GetVerifiedEmails              func(ctx context.Context, emails ...string) ([]*UserEmail, error)

--- a/internal/database/user_emails_mock.go
+++ b/internal/database/user_emails_mock.go
@@ -5,7 +5,6 @@ import (
 )
 
 type MockUserEmails struct {
-	GetPrimaryEmail                func(ctx context.Context, id int32) (email string, verified bool, err error)
 	Get                            func(userID int32, email string) (emailCanonicalCase string, verified bool, err error)
 	SetPrimaryEmail                func(ctx context.Context, userID int32, email string) error
 	SetVerified                    func(ctx context.Context, userID int32, email string, verified bool) error

--- a/internal/database/user_emails_mock.go
+++ b/internal/database/user_emails_mock.go
@@ -5,7 +5,6 @@ import (
 )
 
 type MockUserEmails struct {
-	Get                            func(userID int32, email string) (emailCanonicalCase string, verified bool, err error)
 	SetPrimaryEmail                func(ctx context.Context, userID int32, email string) error
 	SetVerified                    func(ctx context.Context, userID int32, email string, verified bool) error
 	SetLastVerification            func(ctx context.Context, userID int32, email, code string) error

--- a/internal/database/user_emails_mock.go
+++ b/internal/database/user_emails_mock.go
@@ -7,5 +7,4 @@ import (
 type MockUserEmails struct {
 	GetVerifiedEmails func(ctx context.Context, emails ...string) ([]*UserEmail, error)
 	ListByUser        func(ctx context.Context, opt UserEmailsListOptions) ([]*UserEmail, error)
-	Verify            func(ctx context.Context, userID int32, email, code string) (bool, error)
 }

--- a/internal/database/user_emails_mock.go
+++ b/internal/database/user_emails_mock.go
@@ -5,7 +5,6 @@ import (
 )
 
 type MockUserEmails struct {
-	SetLastVerification            func(ctx context.Context, userID int32, email, code string) error
 	GetLatestVerificationSentEmail func(ctx context.Context, email string) (*UserEmail, error)
 	GetVerifiedEmails              func(ctx context.Context, emails ...string) ([]*UserEmail, error)
 	ListByUser                     func(ctx context.Context, opt UserEmailsListOptions) ([]*UserEmail, error)


### PR DESCRIPTION
This removes many of the `MockUserEmails` methods. If they were already
unused, this just deletes them. Otherwise, it rewrites tests that use them 
to use injectable db mocks.