### PR TITLE
e2e: disable search statistics tests

### DIFF
--- a/client/web/src/end-to-end/end-to-end.test.ts
+++ b/client/web/src/end-to-end/end-to-end.test.ts
@@ -1251,7 +1251,8 @@ describe('e2e test suite', () => {
         })
     })
 
-    describe('Search statistics', () => {
+    // This test frequently times out - disable for now.
+    describe.skip('Search statistics', () => {
         beforeEach(async () => {
             await driver.setUserSettings<Settings>({ experimentalFeatures: { searchStats: true } })
         })


### PR DESCRIPTION
The `search statistics` tests is currently our most frequently time-ing-out e2e test ([query](https://sourcegraph.grafana.net/goto/k1MHFStnk?orgId=1)) - this PR disables the test for now.