### PR TITLE
Use database.DB in enterprise init funcs

### DIFF
--- a/enterprise/cmd/frontend/internal/auth/githuboauth/config.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/config.go
@@ -6,11 +6,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-func Init(db dbutil.DB) {
+func Init(db database.DB) {
 	const pkgName = "githuboauth"
 	conf.ContributeValidator(func(cfg conftypes.SiteConfigQuerier) conf.Problems {
 		_, problems := parseConfig(cfg, db)
@@ -37,7 +37,7 @@ type Provider struct {
 	providers.Provider
 }
 
-func parseConfig(cfg conftypes.SiteConfigQuerier, db dbutil.DB) (ps []Provider, problems conf.Problems) {
+func parseConfig(cfg conftypes.SiteConfigQuerier, db database.DB) (ps []Provider, problems conf.Problems) {
 	for _, pr := range cfg.SiteConfig().AuthProviders {
 		if pr.Github == nil {
 			continue

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/config_test.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/config_test.go
@@ -9,13 +9,14 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/oauth"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestParseConfig(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 
 	spew.Config.DisablePointerAddresses = true
 	spew.Config.SortKeys = true

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/middleware.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/oauth"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -18,7 +18,7 @@ func init() {
 	})
 }
 
-func Middleware(db dbutil.DB) *auth.Middleware {
+func Middleware(db database.DB) *auth.Middleware {
 	return &auth.Middleware{
 		API: func(next http.Handler) http.Handler {
 			return oauth.NewHandler(db, extsvc.TypeGitHub, authPrefix, true, next)

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/middleware_test.go
@@ -16,8 +16,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/external/session"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/oauth"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -29,7 +29,7 @@ func TestMiddleware(t *testing.T) {
 	cleanup := session.ResetMockSessionStore(t)
 	defer cleanup()
 
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 
 	const mockUserID = 123
 
@@ -277,7 +277,7 @@ type MockProvider struct {
 	lastCallbackRequestURL *url.URL
 }
 
-func newMockProvider(t *testing.T, db dbutil.DB, clientID, clientSecret, baseURL string) *MockProvider {
+func newMockProvider(t *testing.T, db database.DB, clientID, clientSecret, baseURL string) *MockProvider {
 	var (
 		mp       MockProvider
 		problems []string

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/provider.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/oauth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -23,7 +22,7 @@ import (
 
 const sessionKey = "githuboauth@0"
 
-func parseProvider(p *schema.GitHubAuthProvider, db dbutil.DB, sourceCfg schema.AuthProviders) (provider *oauth.Provider, messages []string) {
+func parseProvider(p *schema.GitHubAuthProvider, db database.DB, sourceCfg schema.AuthProviders) (provider *oauth.Provider, messages []string) {
 	rawURL := p.GetURL()
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {
@@ -63,7 +62,7 @@ func parseProvider(p *schema.GitHubAuthProvider, db dbutil.DB, sourceCfg schema.
 				&oauth2Cfg,
 				oauth.SessionIssuer(db, &sessionIssuerHelper{
 					CodeHost:    codeHost,
-					db:          database.NewDB(db),
+					db:          db,
 					clientID:    p.ClientID,
 					allowSignup: p.AllowSignup,
 					allowOrgs:   p.AllowOrgs,

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/config.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/config.go
@@ -6,13 +6,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 const PkgName = "gitlaboauth"
 
-func Init(db dbutil.DB) {
+func Init(db database.DB) {
 	conf.ContributeValidator(func(cfg conftypes.SiteConfigQuerier) conf.Problems {
 		_, problems := parseConfig(cfg, db)
 		return problems
@@ -33,7 +33,7 @@ func Init(db dbutil.DB) {
 	}()
 }
 
-func parseConfig(cfg conftypes.SiteConfigQuerier, db dbutil.DB) (ps map[schema.GitLabAuthProvider]providers.Provider, problems conf.Problems) {
+func parseConfig(cfg conftypes.SiteConfigQuerier, db database.DB) (ps map[schema.GitLabAuthProvider]providers.Provider, problems conf.Problems) {
 	ps = make(map[schema.GitLabAuthProvider]providers.Provider)
 	for _, pr := range cfg.SiteConfig().AuthProviders {
 		if pr.Gitlab == nil {

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/config_test.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/config_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/oauth"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -22,7 +23,7 @@ func TestParseConfig(t *testing.T) {
 	spew.Config.SortKeys = true
 	spew.Config.SpewKeys = true
 
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 
 	type args struct {
 		cfg *conf.Unified

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/middleware.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/oauth"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -18,7 +18,7 @@ func init() {
 	})
 }
 
-func Middleware(db dbutil.DB) *auth.Middleware {
+func Middleware(db database.DB) *auth.Middleware {
 	return &auth.Middleware{
 		API: func(next http.Handler) http.Handler {
 			return oauth.NewHandler(db, extsvc.TypeGitLab, authPrefix, true, next)

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/middleware_test.go
@@ -16,8 +16,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/external/session"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/oauth"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -32,7 +32,7 @@ func TestMiddleware(t *testing.T) {
 
 	const mockUserID = 123
 
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, err := w.Write([]byte("got through"))
@@ -281,7 +281,7 @@ type MockProvider struct {
 	lastCallbackRequestURL *url.URL
 }
 
-func newMockProvider(t *testing.T, db dbutil.DB, clientID, clientSecret, baseURL string) *MockProvider {
+func newMockProvider(t *testing.T, db database.DB, clientID, clientSecret, baseURL string) *MockProvider {
 	var (
 		mp       MockProvider
 		problems []string

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/provider.go
@@ -11,14 +11,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/oauth"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 const sessionKey = "gitlaboauth@0"
 
-func parseProvider(db dbutil.DB, callbackURL string, p *schema.GitLabAuthProvider, sourceCfg schema.AuthProviders) (provider *oauth.Provider, messages []string) {
+func parseProvider(db database.DB, callbackURL string, p *schema.GitLabAuthProvider, sourceCfg schema.AuthProviders) (provider *oauth.Provider, messages []string) {
 	rawURL := p.Url
 	if rawURL == "" {
 		rawURL = "https://gitlab.com/"

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/session_test.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/session_test.go
@@ -30,7 +30,7 @@ func Test_CreateCodeHostConnectionHandlesExistingService(t *testing.T) {
 func createCodeHostConnectionHelper(t *testing.T, serviceExists bool) {
 	t.Helper()
 
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 
 	ctx := context.Background()
 	s := &sessionIssuerHelper{}

--- a/enterprise/cmd/frontend/internal/auth/httpheader/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/httpheader/middleware.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )
 
@@ -20,7 +19,7 @@ const providerType = "http-header"
 // requests to both the app and API and add headers.
 //
 // See the "func middleware" docs for more information.
-func Middleware(db dbutil.DB) *auth.Middleware {
+func Middleware(db database.DB) *auth.Middleware {
 	return &auth.Middleware{
 		API: middleware(db),
 		App: middleware(db),
@@ -37,7 +36,7 @@ func Middleware(db dbutil.DB) *auth.Middleware {
 // http://localhost:4080. See `-h` for flag help.
 //
 // 🚨 SECURITY
-func middleware(db dbutil.DB) func(next http.Handler) http.Handler {
+func middleware(db database.DB) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		const misconfiguredMessage = "Misconfigured http-header auth provider."
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -93,7 +92,7 @@ func middleware(db dbutil.DB) func(next http.Handler) http.Handler {
 					return
 				}
 			}
-			userID, safeErrMsg, err := auth.GetAndSaveUser(r.Context(), database.NewDB(db), auth.GetAndSaveUserOp{
+			userID, safeErrMsg, err := auth.GetAndSaveUser(r.Context(), db, auth.GetAndSaveUserOp{
 				UserProps: database.NewUser{Username: username, Email: rawEmail, EmailIsVerified: true},
 				ExternalAccount: extsvc.AccountSpec{
 					ServiceType: providerType,

--- a/enterprise/cmd/frontend/internal/auth/httpheader/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/httpheader/middleware_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -22,7 +23,7 @@ import (
 func TestMiddleware(t *testing.T) {
 	defer licensing.TestingSkipFeatureChecks()()
 
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 
 	handler := middleware(db)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		actor := actor.FromContext(r.Context())
@@ -184,7 +185,7 @@ func TestMiddleware(t *testing.T) {
 func TestMiddleware_stripPrefix(t *testing.T) {
 	defer licensing.TestingSkipFeatureChecks()()
 
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 
 	handler := middleware(db)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		actor := actor.FromContext(r.Context())

--- a/enterprise/cmd/frontend/internal/auth/init.go
+++ b/enterprise/cmd/frontend/internal/auth/init.go
@@ -14,11 +14,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/openidconnect"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/saml"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 // Init must be called by the frontend to initialize the auth middlewares.
-func Init(db dbutil.DB) {
+func Init(db database.DB) {
 	githuboauth.Init(db)
 	gitlaboauth.Init(db)
 

--- a/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
@@ -20,14 +20,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-func NewHandler(db dbutil.DB, serviceType, authPrefix string, isAPIHandler bool, next http.Handler) http.Handler {
+func NewHandler(db database.DB, serviceType, authPrefix string, isAPIHandler bool, next http.Handler) http.Handler {
 	oauthFlowHandler := http.StripPrefix(authPrefix, newOAuthFlowHandler(db, serviceType))
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Delegate to the auth flow handler
@@ -60,7 +59,7 @@ func NewHandler(db dbutil.DB, serviceType, authPrefix string, isAPIHandler bool,
 	})
 }
 
-func newOAuthFlowHandler(db dbutil.DB, serviceType string) http.Handler {
+func newOAuthFlowHandler(db database.DB, serviceType string) http.Handler {
 	mux := http.NewServeMux()
 	mux.Handle("/login", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		id := req.URL.Query().Get("pc")
@@ -106,7 +105,7 @@ var extraScopes = map[string][]string{
 	extsvc.TypeGitLab: {"api"},
 }
 
-func getExtraScopes(ctx context.Context, db dbutil.DB, serviceType string) ([]string, error) {
+func getExtraScopes(ctx context.Context, db database.DB, serviceType string) ([]string, error) {
 	// Extra scopes are only needed on Sourcegraph.com
 	if !envvar.SourcegraphDotComMode() {
 		return nil, nil

--- a/enterprise/cmd/frontend/internal/auth/oauth/session.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/session.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/cookie"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 type SessionData struct {
@@ -34,7 +33,7 @@ type SessionIssuerHelper interface {
 	SessionData(token *oauth2.Token) SessionData
 }
 
-func SessionIssuer(db dbutil.DB, s SessionIssuerHelper, sessionKey string) http.Handler {
+func SessionIssuer(db database.DB, s SessionIssuerHelper, sessionKey string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
@@ -99,7 +98,7 @@ func SessionIssuer(db dbutil.DB, s SessionIssuerHelper, sessionKey string) http.
 			return
 		}
 
-		user, err := database.Users(db).GetByID(r.Context(), actr.UID)
+		user, err := db.Users().GetByID(r.Context(), actr.UID)
 		if err != nil {
 			log15.Error("OAuth failed: error retrieving user from database.", "error", err)
 			http.Error(w, "Authentication failed. Try signing in again (and clearing cookies for the current site). The error was: could not initiate session.", http.StatusInternalServerError)

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/middleware.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/external/session"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 
 	"github.com/coreos/go-oidc"
 )
@@ -50,7 +49,7 @@ type userClaims struct {
 // a new session and session cookie. The expiration of the session is the expiration of the OIDC ID Token.
 //
 // 🚨 SECURITY
-func Middleware(db dbutil.DB) *auth.Middleware {
+func Middleware(db database.DB) *auth.Middleware {
 	return &auth.Middleware{
 		API: func(next http.Handler) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -67,7 +66,7 @@ func Middleware(db dbutil.DB) *auth.Middleware {
 
 // handleOpenIDConnectAuth performs OpenID Connect authentication (if configured) for HTTP requests,
 // both API requests and non-API requests.
-func handleOpenIDConnectAuth(db dbutil.DB, w http.ResponseWriter, r *http.Request, next http.Handler, isAPIRequest bool) {
+func handleOpenIDConnectAuth(db database.DB, w http.ResponseWriter, r *http.Request, next http.Handler, isAPIRequest bool) {
 	// Fixup URL path. We use "/.auth/callback" as the redirect URI for OpenID Connect, but the rest
 	// of this middleware's handlers expect paths of "/.auth/openidconnect/...", so add the
 	// "openidconnect" path component. We can't change the redirect URI because it is hardcoded in
@@ -113,7 +112,7 @@ var mockVerifyIDToken func(rawIDToken string) *oidc.IDToken
 // (http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth) on the Relying Party's end.
 //
 // 🚨 SECURITY
-func authHandler(db dbutil.DB) func(w http.ResponseWriter, r *http.Request) {
+func authHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		switch strings.TrimPrefix(r.URL.Path, authPrefix) {
 		case "/login":

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/user.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/user.go
@@ -10,14 +10,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )
 
 // getOrCreateUser gets or creates a user account based on the OpenID Connect token. It returns the
 // authenticated actor if successful; otherwise it returns an friendly error message (safeErrMsg)
 // that is safe to display to users, and a non-nil err with lower-level error details.
-func getOrCreateUser(ctx context.Context, db dbutil.DB, p *provider, idToken *oidc.IDToken, userInfo *oidc.UserInfo, claims *userClaims) (_ *actor.Actor, safeErrMsg string, err error) {
+func getOrCreateUser(ctx context.Context, db database.DB, p *provider, idToken *oidc.IDToken, userInfo *oidc.UserInfo, claims *userClaims) (_ *actor.Actor, safeErrMsg string, err error) {
 	if userInfo.Email == "" {
 		return nil, "Only users with an email address may authenticate to Sourcegraph.", errors.New("no email address in claims")
 	}
@@ -57,7 +56,7 @@ func getOrCreateUser(ctx context.Context, db dbutil.DB, p *provider, idToken *oi
 		UserClaims *userClaims    `json:"userClaims"`
 	}{IDToken: idToken, UserInfo: userInfo, UserClaims: claims})
 
-	userID, safeErrMsg, err := auth.GetAndSaveUser(ctx, database.NewDB(db), auth.GetAndSaveUserOp{
+	userID, safeErrMsg, err := auth.GetAndSaveUser(ctx, db, auth.GetAndSaveUserOp{
 		UserProps: database.NewUser{
 			Username:        login,
 			Email:           email,

--- a/enterprise/cmd/frontend/internal/auth/saml/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/saml/middleware.go
@@ -16,7 +16,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/external/session"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 // All SAML endpoints are under this path prefix.
@@ -26,7 +25,7 @@ const authPrefix = auth.AuthURLPrefix + "/saml"
 // enable the login flow an requiring login for all other endpoints.
 //
 // 🚨 SECURITY
-func Middleware(db dbutil.DB) *auth.Middleware {
+func Middleware(db database.DB) *auth.Middleware {
 	return &auth.Middleware{
 		API: func(next http.Handler) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -45,7 +44,7 @@ func Middleware(db dbutil.DB) *auth.Middleware {
 //
 // It uses github.com/russelhaering/gosaml2 and (unlike authHandler1) makes it possible to support
 // multiple auth providers with SAML and expose more SAML functionality.
-func authHandler(db dbutil.DB, w http.ResponseWriter, r *http.Request, next http.Handler, isAPIRequest bool) {
+func authHandler(db database.DB, w http.ResponseWriter, r *http.Request, next http.Handler, isAPIRequest bool) {
 	// Delegate to SAML ACS and metadata endpoint handlers.
 	if !isAPIRequest && strings.HasPrefix(r.URL.Path, auth.AuthURLPrefix+"/saml/") {
 		samlSPHandler(db)(w, r)
@@ -73,7 +72,7 @@ func authHandler(db dbutil.DB, w http.ResponseWriter, r *http.Request, next http
 	next.ServeHTTP(w, r)
 }
 
-func samlSPHandler(db dbutil.DB) func(w http.ResponseWriter, r *http.Request) {
+func samlSPHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		requestPath := strings.TrimPrefix(r.URL.Path, authPrefix)
 

--- a/enterprise/cmd/frontend/internal/auth/saml/user.go
+++ b/enterprise/cmd/frontend/internal/auth/saml/user.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )
 
@@ -86,7 +85,7 @@ func readAuthnResponse(p *provider, encodedResp string) (*authnResponseInfo, err
 // getOrCreateUser gets or creates a user account based on the SAML claims. It returns the
 // authenticated actor if successful; otherwise it returns an friendly error message (safeErrMsg)
 // that is safe to display to users, and a non-nil err with lower-level error details.
-func getOrCreateUser(ctx context.Context, db dbutil.DB, allowSignup bool, info *authnResponseInfo) (_ *actor.Actor, safeErrMsg string, err error) {
+func getOrCreateUser(ctx context.Context, db database.DB, allowSignup bool, info *authnResponseInfo) (_ *actor.Actor, safeErrMsg string, err error) {
 	var data extsvc.AccountData
 	data.SetAccountData(info.accountData)
 
@@ -95,7 +94,7 @@ func getOrCreateUser(ctx context.Context, db dbutil.DB, allowSignup bool, info *
 		return nil, fmt.Sprintf("Error normalizing the username %q. See https://docs.sourcegraph.com/admin/auth/#username-normalization.", info.unnormalizedUsername), err
 	}
 
-	userID, safeErrMsg, err := auth.GetAndSaveUser(ctx, database.NewDB(db), auth.GetAndSaveUserOp{
+	userID, safeErrMsg, err := auth.GetAndSaveUser(ctx, db, auth.GetAndSaveUserOp{
 		UserProps: database.NewUser{
 			Username:        username,
 			Email:           info.email,

--- a/enterprise/cmd/frontend/internal/authz/init.go
+++ b/enterprise/cmd/frontend/internal/authz/init.go
@@ -33,7 +33,7 @@ import (
 
 var clock = timeutil.Now
 
-func Init(ctx context.Context, db dbutil.DB, _ conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
+func Init(ctx context.Context, db database.DB, _ conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
 	database.ExternalServices = edb.NewExternalServicesStore
 	database.Authz = func(db dbutil.DB) database.AuthzStore {
 		return edb.NewAuthzStore(db, clock)

--- a/enterprise/cmd/frontend/internal/authz/init.go
+++ b/enterprise/cmd/frontend/internal/authz/init.go
@@ -134,7 +134,7 @@ func Init(ctx context.Context, db database.DB, _ conftypes.UnifiedWatchable, out
 			}
 
 			siteadminOrHandler := func(handler func()) {
-				err := backend.CheckCurrentUserIsSiteAdmin(r.Context(), database.NewDB(db))
+				err := backend.CheckCurrentUserIsSiteAdmin(r.Context(), db)
 				if err == nil {
 					// User is site admin, let them proceed.
 					next.ServeHTTP(w, r)

--- a/enterprise/cmd/frontend/internal/batches/init.go
+++ b/enterprise/cmd/frontend/internal/batches/init.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types/scheduler/window"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
@@ -20,7 +20,7 @@ import (
 // Init initializes the given enterpriseServices to include the required
 // resolvers for Batch Changes and sets up webhook handlers for changeset
 // events.
-func Init(ctx context.Context, db dbutil.DB, _ conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
+func Init(ctx context.Context, db database.DB, _ conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
 	// Validate site configuration.
 	conf.ContributeValidator(func(c conftypes.SiteConfigQuerier) (problems conf.Problems) {
 		if _, err := window.NewConfiguration(c.SiteConfig().BatchChangesRolloutWindows); err != nil {

--- a/enterprise/cmd/frontend/internal/codeintel/init.go
+++ b/enterprise/cmd/frontend/internal/codeintel/init.go
@@ -12,12 +12,12 @@ import (
 	codeintelgqlresolvers "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 )
 
-func Init(ctx context.Context, db dbutil.DB, conf conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context, services *Services) error {
+func Init(ctx context.Context, db database.DB, conf conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context, services *Services) error {
 	if err := registerMigrations(ctx, db, outOfBandMigrationRunner, services); err != nil {
 		return err
 	}
@@ -37,7 +37,7 @@ func Init(ctx context.Context, db dbutil.DB, conf conftypes.UnifiedWatchable, ou
 	return nil
 }
 
-func newResolver(ctx context.Context, db dbutil.DB, observationContext *observation.Context, services *Services) (gql.CodeIntelResolver, error) {
+func newResolver(ctx context.Context, db database.DB, observationContext *observation.Context, services *Services) (gql.CodeIntelResolver, error) {
 	policyMatcher := policies.NewMatcher(
 		services.gitserverClient,
 		policies.NoopExtractor,
@@ -63,7 +63,7 @@ func newResolver(ctx context.Context, db dbutil.DB, observationContext *observat
 	return codeintelgqlresolvers.NewResolver(db, innerResolver), nil
 }
 
-func newUploadHandler(ctx context.Context, conf conftypes.SiteConfigQuerier, db dbutil.DB, services *Services) (func(internal bool) http.Handler, error) {
+func newUploadHandler(ctx context.Context, conf conftypes.SiteConfigQuerier, db database.DB, services *Services) (func(internal bool) http.Handler, error) {
 	internalHandler, err := NewCodeIntelUploadHandler(ctx, conf, db, true, services)
 	if err != nil {
 		return nil, err

--- a/enterprise/cmd/frontend/internal/codeintel/services.go
+++ b/enterprise/cmd/frontend/internal/codeintel/services.go
@@ -20,7 +20,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/database/locker"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -37,7 +36,7 @@ type Services struct {
 	indexEnqueuer   *enqueuer.IndexEnqueuer
 }
 
-func NewServices(ctx context.Context, siteConfig conftypes.SiteConfigQuerier, db dbutil.DB) (*Services, error) {
+func NewServices(ctx context.Context, siteConfig conftypes.SiteConfigQuerier, db database.DB) (*Services, error) {
 	if err := config.UploadStoreConfig.Validate(); err != nil {
 		return nil, errors.Errorf("failed to load config: %s", err)
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/upload_handler.go
+++ b/enterprise/cmd/frontend/internal/codeintel/upload_handler.go
@@ -6,13 +6,13 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/httpapi"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 // NewCodeIntelUploadHandler creates a new code intel LSIF upload HTTP handler. This is used
 // by both the enterprise frontend codeintel init code to install handlers in the frontend API
 // as well as the the enterprise frontend executor init code to install handlers in the proxy.
-func NewCodeIntelUploadHandler(ctx context.Context, conf conftypes.SiteConfigQuerier, db dbutil.DB, internal bool, services *Services) (http.Handler, error) {
+func NewCodeIntelUploadHandler(ctx context.Context, conf conftypes.SiteConfigQuerier, db database.DB, internal bool, services *Services) (http.Handler, error) {
 	return httpapi.NewUploadHandler(
 		db,
 		&httpapi.DBStoreShim{Store: services.dbStore},

--- a/enterprise/cmd/frontend/internal/codemonitors/init.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/init.go
@@ -6,12 +6,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codemonitors/resolvers"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 )
 
-func Init(ctx context.Context, db dbutil.DB, _ conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
+func Init(ctx context.Context, db database.DB, _ conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
 	enterpriseServices.CodeMonitorsResolver = resolvers.NewResolver(db)
 	return nil
 }

--- a/enterprise/cmd/frontend/internal/dotcom/init.go
+++ b/enterprise/cmd/frontend/internal/dotcom/init.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/dotcom/productsubscription"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/dotcom/stripeutil"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 )
@@ -40,7 +40,7 @@ func (d dotcomRootResolver) NodeResolvers() map[string]graphqlbackend.NodeByIDFu
 
 var _ graphqlbackend.DotcomRootResolver = dotcomRootResolver{}
 
-func Init(ctx context.Context, db dbutil.DB, _ conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
+func Init(ctx context.Context, db database.DB, _ conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
 	stripeEnabled := stripeutil.ValidateAndPublishConfig()
 	// Only enabled on Sourcegraph.com or when Stripe is configured correctly.
 	if envvar.SourcegraphDotComMode() || stripeEnabled {

--- a/enterprise/cmd/frontend/internal/executorqueue/init.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/init.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
@@ -17,7 +16,7 @@ import (
 )
 
 // Init initializes the executor endpoints required for use with the executor service.
-func Init(ctx context.Context, db dbutil.DB, conf conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context, services *codeintel.Services) error {
+func Init(ctx context.Context, db database.DB, conf conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context, services *codeintel.Services) error {
 	accessToken := func() string { return conf.SiteConfig().ExecutorsAccessToken }
 
 	// Register queues. If this set changes, be sure to also update the list of valid
@@ -33,7 +32,7 @@ func Init(ctx context.Context, db dbutil.DB, conf conftypes.UnifiedWatchable, ou
 		return err
 	}
 
-	queueHandler, err := newExecutorQueueHandler(database.NewDB(db).Executors(), queueOptions, accessToken, handler)
+	queueHandler, err := newExecutorQueueHandler(db.Executors(), queueOptions, accessToken, handler)
 	if err != nil {
 		return err
 	}

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/batches/queue.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/batches/queue.go
@@ -9,13 +9,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	apiclient "github.com/sourcegraph/sourcegraph/enterprise/internal/executor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
 
-func QueueOptions(db dbutil.DB, accessToken func() string, observationContext *observation.Context) handler.QueueOptions {
+func QueueOptions(db database.DB, accessToken func() string, observationContext *observation.Context) handler.QueueOptions {
 	recordTransformer := func(ctx context.Context, record workerutil.Record) (apiclient.Job, error) {
 		batchesStore := store.New(db, observationContext, nil)
 		return transformRecord(ctx, batchesStore, record.(*btypes.BatchSpecWorkspaceExecutionJob), accessToken())

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/queue.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/queue.go
@@ -7,13 +7,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/executorqueue/handler"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	apiclient "github.com/sourcegraph/sourcegraph/enterprise/internal/executor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
 
-func QueueOptions(db dbutil.DB, accessToken func() string, observationContext *observation.Context) handler.QueueOptions {
+func QueueOptions(db database.DB, accessToken func() string, observationContext *observation.Context) handler.QueueOptions {
 	recordTransformer := func(ctx context.Context, record workerutil.Record) (apiclient.Job, error) {
 		return transformRecord(record.(store.Index), accessToken())
 	}

--- a/enterprise/cmd/frontend/internal/licensing/init/init.go
+++ b/enterprise/cmd/frontend/internal/licensing/init/init.go
@@ -24,7 +24,7 @@ import (
 
 // TODO(efritz) - de-globalize assignments in this function
 // TODO(efritz) - refactor licensing packages - this is a huge mess!
-func Init(ctx context.Context, db dbutil.DB, conf conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
+func Init(ctx context.Context, db database.DB, conf conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
 	// Enforce the license's max user count by preventing the creation of new users when the max is
 	// reached.
 	database.BeforeCreateUser = enforcement.NewBeforeCreateUserHook()

--- a/enterprise/cmd/frontend/internal/orgrepos/init.go
+++ b/enterprise/cmd/frontend/internal/orgrepos/init.go
@@ -7,12 +7,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/orgrepos/resolvers"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 )
 
-func Init(ctx context.Context, db dbutil.DB, _ conftypes.UnifiedWatchable, _ *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
+func Init(ctx context.Context, db database.DB, _ conftypes.UnifiedWatchable, _ *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
 	enterpriseServices.OrgRepositoryResolver = resolvers.NewResolver(database.NewDB(db))
 	return nil
 }

--- a/enterprise/cmd/frontend/internal/orgrepos/init.go
+++ b/enterprise/cmd/frontend/internal/orgrepos/init.go
@@ -12,6 +12,6 @@ import (
 )
 
 func Init(ctx context.Context, db database.DB, _ conftypes.UnifiedWatchable, _ *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
-	enterpriseServices.OrgRepositoryResolver = resolvers.NewResolver(database.NewDB(db))
+	enterpriseServices.OrgRepositoryResolver = resolvers.NewResolver(db)
 	return nil
 }

--- a/enterprise/cmd/frontend/internal/searchcontexts/init.go
+++ b/enterprise/cmd/frontend/internal/searchcontexts/init.go
@@ -12,6 +12,6 @@ import (
 )
 
 func Init(ctx context.Context, db database.DB, _ conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
-	enterpriseServices.SearchContextsResolver = resolvers.NewResolver(database.NewDB(db))
+	enterpriseServices.SearchContextsResolver = resolvers.NewResolver(db)
 	return nil
 }

--- a/enterprise/cmd/frontend/internal/searchcontexts/init.go
+++ b/enterprise/cmd/frontend/internal/searchcontexts/init.go
@@ -7,12 +7,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/searchcontexts/resolvers"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 )
 
-func Init(ctx context.Context, db dbutil.DB, _ conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
+func Init(ctx context.Context, db database.DB, _ conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
 	enterpriseServices.SearchContextsResolver = resolvers.NewResolver(database.NewDB(db))
 	return nil
 }

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -32,7 +32,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -46,7 +45,7 @@ func init() {
 	oobmigration.ReturnEnterpriseMigrations = true
 }
 
-type EnterpriseInitializer = func(context.Context, dbutil.DB, conftypes.UnifiedWatchable, *oobmigration.Runner, *enterprise.Services, *observation.Context) error
+type EnterpriseInitializer = func(context.Context, database.DB, conftypes.UnifiedWatchable, *oobmigration.Runner, *enterprise.Services, *observation.Context) error
 
 var initFunctions = map[string]EnterpriseInitializer{
 	"authz":          authz.Init,

--- a/enterprise/internal/insights/insights.go
+++ b/enterprise/internal/insights/insights.go
@@ -13,8 +13,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/resolvers"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 )
@@ -38,7 +38,7 @@ func IsEnabled() bool {
 }
 
 // Init initializes the given enterpriseServices to include the required resolvers for insights.
-func Init(ctx context.Context, postgres dbutil.DB, _ conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
+func Init(ctx context.Context, postgres database.DB, _ conftypes.UnifiedWatchable, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
 	if !IsEnabled() {
 		if conf.IsDeployTypeSingleDockerContainer(conf.DeployType()) {
 			enterpriseServices.InsightsResolver = resolvers.NewDisabledResolver("backend-run code insights are not available on single-container deployments")


### PR DESCRIPTION
This is just some incremental progress on propagating `database.DB` through
the backend. It's all very mechanical changes, just updating uses of `dbutil.DB` to
`database.DB`, and removing any `database.NewDB()` calls that are now redundant.
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
