### PR TITLE
Remove more `dbconn.Global`

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/integration_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/integration_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
@@ -130,7 +129,6 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			dbconn.Global = testDB
 			userID, err := database.ExternalAccounts(testDB).CreateUserAndSave(ctx, newUser, spec, extsvc.AccountData{})
 			if err != nil {
 				t.Fatal(err)
@@ -211,7 +209,6 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			dbconn.Global = testDB
 			userID, err := database.ExternalAccounts(testDB).CreateUserAndSave(ctx, newUser, spec, extsvc.AccountData{})
 			if err != nil {
 				t.Fatal(err)
@@ -315,8 +312,6 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			dbconn.Global = testDB
-
 			authData := json.RawMessage(fmt.Sprintf(`{"access_token": "%s"}`, token))
 			userID, err := database.ExternalAccounts(testDB).CreateUserAndSave(ctx, newUser, spec, extsvc.AccountData{
 				AuthData: &authData,
@@ -399,8 +394,6 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			dbconn.Global = testDB
 
 			authData := json.RawMessage(fmt.Sprintf(`{"access_token": "%s"}`, token))
 			userID, err := database.ExternalAccounts(testDB).CreateUserAndSave(ctx, newUser, spec, extsvc.AccountData{

--- a/enterprise/internal/codemonitors/action_jobs_test.go
+++ b/enterprise/internal/codemonitors/action_jobs_test.go
@@ -14,8 +14,8 @@ func TestEnqueueActionEmailsForQueryIDInt64QueryByRecordID(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx, s := newTestStore(t)
-	_, _, _, userCTX := newTestUser(ctx, t)
+	ctx, db, s := newTestStore(t)
+	_, _, _, userCTX := newTestUser(ctx, t, db)
 	_, err := s.insertTestMonitor(userCTX, t)
 	if err != nil {
 		t.Fatal(err)
@@ -60,8 +60,8 @@ func TestGetActionJobMetadata(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx, s := newTestStore(t)
-	_, _, _, userCTX := newTestUser(ctx, t)
+	ctx, db, s := newTestStore(t)
+	_, _, _, userCTX := newTestUser(ctx, t, db)
 	_, err := s.insertTestMonitor(userCTX, t)
 	if err != nil {
 		t.Fatal(err)
@@ -111,8 +111,8 @@ func TestScanActionJobs(t *testing.T) {
 		testQueryID        int64 = 1
 	)
 
-	ctx, s := newTestStore(t)
-	_, _, _, userCTX := newTestUser(ctx, t)
+	ctx, db, s := newTestStore(t)
+	_, _, _, userCTX := newTestUser(ctx, t, db)
 	_, err := s.insertTestMonitor(userCTX, t)
 	if err != nil {
 		t.Fatal(err)

--- a/enterprise/internal/codemonitors/background/workers_test.go
+++ b/enterprise/internal/codemonitors/background/workers_test.go
@@ -74,9 +74,9 @@ func TestActionRunner(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			//Empty database, preserve schema.
-			dbtesting.SetupGlobalTestDB(t)
+			db := dbtesting.GetDB(t)
 
-			_, _, _, userCtx := storetest.NewTestUser(ctx, t)
+			_, _, _, userCtx := storetest.NewTestUser(ctx, t, db)
 
 			// Run a complete pipeline from creation of a code monitor to sending of an email.
 			_, err = ts.InsertTestMonitor(userCtx, t)

--- a/enterprise/internal/codemonitors/main_test.go
+++ b/enterprise/internal/codemonitors/main_test.go
@@ -2,7 +2,6 @@ package codemonitors
 
 import (
 	"context"
-	"database/sql"
 	"testing"
 	"time"
 
@@ -12,8 +11,8 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 const (
@@ -54,28 +53,28 @@ func (s *codeMonitorStore) insertTestMonitor(ctx context.Context, t *testing.T) 
 	return s.CreateCodeMonitor(ctx, args)
 }
 
-func newTestStore(t *testing.T) (context.Context, *codeMonitorStore) {
+func newTestStore(t *testing.T) (context.Context, dbutil.DB, *codeMonitorStore) {
 	ctx := actor.WithInternalActor(context.Background())
 	db := dbtesting.GetDB(t)
 	now := time.Now().Truncate(time.Microsecond)
-	return ctx, NewStoreWithClock(db, func() time.Time { return now })
+	return ctx, db, NewStoreWithClock(db, func() time.Time { return now })
 }
 
-func newTestUser(ctx context.Context, t *testing.T) (name string, id int32, namespace graphql.ID, userContext context.Context) {
+func newTestUser(ctx context.Context, t *testing.T, db dbutil.DB) (name string, id int32, namespace graphql.ID, userContext context.Context) {
 	t.Helper()
 
 	name = "cm-user1"
-	id = insertTestUser(t, dbconn.Global, name, true)
+	id = insertTestUser(ctx, t, db, name, true)
 	namespace = relay.MarshalID("User", id)
 	ctx = actor.WithActor(ctx, actor.FromUser(id))
 	return name, id, namespace, ctx
 }
 
-func insertTestUser(t *testing.T, db *sql.DB, name string, isAdmin bool) (userID int32) {
+func insertTestUser(ctx context.Context, t *testing.T, db dbutil.DB, name string, isAdmin bool) (userID int32) {
 	t.Helper()
 
 	q := sqlf.Sprintf("INSERT INTO users (username, site_admin) VALUES (%s, %t) RETURNING id", name, isAdmin)
-	err := db.QueryRow(q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&userID)
+	err := db.QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&userID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/codemonitors/queries_test.go
+++ b/enterprise/internal/codemonitors/queries_test.go
@@ -12,8 +12,8 @@ func TestQueryByRecordID(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx, s := newTestStore(t)
-	_, id, _, userCTX := newTestUser(ctx, t)
+	ctx, db, s := newTestStore(t)
+	_, id, _, userCTX := newTestUser(ctx, t, db)
 	m, err := s.insertTestMonitor(userCTX, t)
 	if err != nil {
 		t.Fatal(err)
@@ -48,8 +48,8 @@ func TestTriggerQueryNextRun(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx, s := newTestStore(t)
-	_, id, _, userCTX := newTestUser(ctx, t)
+	ctx, db, s := newTestStore(t)
+	_, id, _, userCTX := newTestUser(ctx, t, db)
 	m, err := s.insertTestMonitor(userCTX, t)
 	if err != nil {
 		t.Fatal(err)
@@ -92,8 +92,8 @@ func TestResetTriggerQueryTimestamps(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx, s := newTestStore(t)
-	_, id, _, userCTX := newTestUser(ctx, t)
+	ctx, db, s := newTestStore(t)
+	_, id, _, userCTX := newTestUser(ctx, t, db)
 	m, err := s.insertTestMonitor(userCTX, t)
 	if err != nil {
 		t.Fatal(err)

--- a/enterprise/internal/codemonitors/recipients_test.go
+++ b/enterprise/internal/codemonitors/recipients_test.go
@@ -11,8 +11,8 @@ func TestAllRecipientsForEmailIDInt64(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx, s := newTestStore(t)
-	_, id, _, userCTX := newTestUser(ctx, t)
+	ctx, db, s := newTestStore(t)
+	_, id, _, userCTX := newTestUser(ctx, t, db)
 	_, err := s.insertTestMonitor(userCTX, t)
 	if err != nil {
 		t.Fatal(err)

--- a/enterprise/internal/codemonitors/storetest/monitor_creator.go
+++ b/enterprise/internal/codemonitors/storetest/monitor_creator.go
@@ -2,7 +2,6 @@ package storetest
 
 import (
 	"context"
-	"database/sql"
 	"testing"
 	"time"
 
@@ -13,8 +12,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 const (
@@ -66,21 +65,21 @@ func NewTestStore(t *testing.T) (context.Context, *TestStore) {
 	return ctx, &TestStore{codemonitors.NewStoreWithClock(db, func() time.Time { return now })}
 }
 
-func NewTestUser(ctx context.Context, t *testing.T) (name string, id int32, namespace graphql.ID, userContext context.Context) {
+func NewTestUser(ctx context.Context, t *testing.T, db dbutil.DB) (name string, id int32, namespace graphql.ID, userContext context.Context) {
 	t.Helper()
 
 	name = "cm-user1"
-	id = insertTestUser(t, dbconn.Global, name, true)
+	id = insertTestUser(t, db, name, true)
 	namespace = relay.MarshalID("User", id)
 	ctx = actor.WithActor(ctx, actor.FromUser(id))
 	return name, id, namespace, ctx
 }
 
-func insertTestUser(t *testing.T, db *sql.DB, name string, isAdmin bool) (userID int32) {
+func insertTestUser(t *testing.T, db dbutil.DB, name string, isAdmin bool) (userID int32) {
 	t.Helper()
 
 	q := sqlf.Sprintf("INSERT INTO users (username, site_admin) VALUES (%s, %t) RETURNING id", name, isAdmin)
-	err := db.QueryRow(q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&userID)
+	err := db.QueryRowContext(context.Background(), q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&userID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/codemonitors/trigger_jobs_test.go
+++ b/enterprise/internal/codemonitors/trigger_jobs_test.go
@@ -21,8 +21,8 @@ FROM cm_trigger_jobs;
 
 func TestDeleteOldJobLogs(t *testing.T) {
 	retentionInDays := 7
-	ctx, s := newTestStore(t)
-	_, _, _, userCTX := newTestUser(ctx, t)
+	ctx, db, s := newTestStore(t)
+	_, _, _, userCTX := newTestUser(ctx, t, db)
 	_, err := s.insertTestMonitor(userCTX, t)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/repos/integration_test.go
+++ b/internal/repos/integration_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -52,7 +51,6 @@ func TestIntegration(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			db := dbtest.NewFromDSN(t, *dsn)
-			dbconn.Global = db
 
 			store := repos.NewStore(db, sql.TxOptions{Isolation: sql.LevelReadCommitted})
 
@@ -62,8 +60,6 @@ func TestIntegration(t *testing.T) {
 			store.Log = lg
 			store.Metrics = repos.NewStoreMetrics()
 			store.Tracer = trace.Tracer{Tracer: opentracing.GlobalTracer()}
-
-			t.Cleanup(func() { dbconn.Global = nil })
 
 			tc.test(store)(t)
 		})


### PR DESCRIPTION
This removes a few more easy-to-remove references to `dbconn.Global`. 

8 down, 39 to go.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
