### PR TITLE
Move store comments to interface

### DIFF
--- a/internal/database/access_tokens.go
+++ b/internal/database/access_tokens.go
@@ -46,23 +46,84 @@ func (e InvalidTokenError) Error() string {
 	return fmt.Sprintf("invalid token: %s", e.err)
 }
 
+// accessTokenStore implements autocert.Cache
 type AccessTokenStore interface {
+	// Count counts all access tokens, except internal tokens, that satisfy the options (ignoring limit and offset).
+	//
+	// 🚨 SECURITY: The caller must ensure that the actor is permitted to count the tokens.
 	Count(context.Context, AccessTokensListOptions) (int, error)
+
+	// Create creates an access token for the specified user. The secret token value itself is
+	// returned. The caller is responsible for presenting this value to the end user; Sourcegraph does
+	// not retain it (only a hash of it).
+	//
+	// The secret token value is a long random string; it is what API clients must provide to
+	// authenticate their requests. We store the SHA-256 hash of the secret token value in the
+	// database. This lets us verify a token's validity (in the (*accessTokens).Lookup method) quickly,
+	// while still ensuring that an attacker who obtains the access_tokens DB table would not be able to
+	// impersonate a token holder. We don't use bcrypt because the original secret is a randomly
+	// generated string (not a password), so it's implausible for an attacker to brute-force the input
+	// space; also bcrypt is slow and would add noticeable latency to each request that supplied a
+	// token.
+	//
+	// 🚨 SECURITY: The caller must ensure that the actor is permitted to create tokens for the
+	// specified user (i.e., that the actor is either the user or a site admin).
 	Create(ctx context.Context, subjectUserID int32, scopes []string, note string, creatorUserID int32) (id int64, token string, err error)
+
+	// CreateInternal creates an *internal* access token for the specified user. An
+	// internal access token will be used by Sourcegraph to talk to its API from
+	// other services, i.e. executor jobs. Internal tokens do not show up in the UI.
+	//
+	// See the documentation for Create for more details.
+	//
+	// 🚨 SECURITY: The caller must ensure that the actor is permitted to create tokens for the
+	// specified user (i.e., that the actor is either the user or a site admin).
 	CreateInternal(ctx context.Context, subjectUserID int32, scopes []string, note string, creatorUserID int32) (id int64, token string, err error)
+
+	// DeleteByID deletes an access token given its ID.
+	//
+	// 🚨 SECURITY: The caller must ensure that the actor is permitted to delete the token.
 	DeleteByID(context.Context, int64) error
+
+	// DeleteByToken deletes an access token given the secret token value itself (i.e., the same value
+	// that an API client would use to authenticate).
 	DeleteByToken(ctx context.Context, tokenHexEncoded string) error
+
+	// GetByID retrieves the access token (if any) given its ID.
+	//
+	// 🚨 SECURITY: The caller must ensure that the actor is permitted to view this access token.
 	GetByID(context.Context, int64) (*AccessToken, error)
+
+	// GetByToken retrieves the access token (if any) given its hex encoded string.
+	//
+	// 🚨 SECURITY: The caller must ensure that the actor is permitted to view this access token.
 	GetByToken(ctx context.Context, tokenHexEncoded string) (*AccessToken, error)
+
+	// HardDeleteByID hard-deletes an access token given its ID.
+	//
+	// 🚨 SECURITY: The caller must ensure that the actor is permitted to delete the token.
 	HardDeleteByID(context.Context, int64) error
+
+	// List lists all access tokens that satisfy the options, except internal tokens.
+	//
+	// 🚨 SECURITY: The caller must ensure that the actor is permitted to list with the specified
+	// options.
 	List(context.Context, AccessTokensListOptions) ([]*AccessToken, error)
+
+	// Lookup looks up the access token. If it's valid and contains the required scope, it returns the
+	// subject's user ID. Otherwise ErrAccessTokenNotFound is returned.
+	//
+	// Calling Lookup also updates the access token's last-used-at date.
+	//
+	// 🚨 SECURITY: This returns a user ID if and only if the tokenHexEncoded corresponds to a valid,
+	// non-deleted access token.
 	Lookup(ctx context.Context, tokenHexEncoded, requiredScope string) (subjectUserID int32, err error)
+
 	Transact(context.Context) (AccessTokenStore, error)
 	With(basestore.ShareableStore) AccessTokenStore
 	basestore.ShareableStore
 }
 
-// accessTokenStore implements autocert.Cache
 type accessTokenStore struct {
 	*basestore.Store
 }
@@ -88,33 +149,10 @@ func (s *accessTokenStore) Transact(ctx context.Context) (AccessTokenStore, erro
 	return &accessTokenStore{Store: txBase}, err
 }
 
-// Create creates an access token for the specified user. The secret token value itself is
-// returned. The caller is responsible for presenting this value to the end user; Sourcegraph does
-// not retain it (only a hash of it).
-//
-// The secret token value is a long random string; it is what API clients must provide to
-// authenticate their requests. We store the SHA-256 hash of the secret token value in the
-// database. This lets us verify a token's validity (in the (*accessTokens).Lookup method) quickly,
-// while still ensuring that an attacker who obtains the access_tokens DB table would not be able to
-// impersonate a token holder. We don't use bcrypt because the original secret is a randomly
-// generated string (not a password), so it's implausible for an attacker to brute-force the input
-// space; also bcrypt is slow and would add noticeable latency to each request that supplied a
-// token.
-//
-// 🚨 SECURITY: The caller must ensure that the actor is permitted to create tokens for the
-// specified user (i.e., that the actor is either the user or a site admin).
 func (s *accessTokenStore) Create(ctx context.Context, subjectUserID int32, scopes []string, note string, creatorUserID int32) (id int64, token string, err error) {
 	return s.createToken(ctx, subjectUserID, scopes, note, creatorUserID, false)
 }
 
-// CreateInternal creates an *internal* access token for the specified user. An
-// internal access token will be used by Sourcegraph to talk to its API from
-// other services, i.e. executor jobs. Internal tokens do not show up in the UI.
-//
-// See the documentation for Create for more details.
-//
-// 🚨 SECURITY: The caller must ensure that the actor is permitted to create tokens for the
-// specified user (i.e., that the actor is either the user or a site admin).
 func (s *accessTokenStore) CreateInternal(ctx context.Context, subjectUserID int32, scopes []string, note string, creatorUserID int32) (id int64, token string, err error) {
 	return s.createToken(ctx, subjectUserID, scopes, note, creatorUserID, true)
 }
@@ -155,13 +193,6 @@ INSERT INTO access_tokens(subject_user_id, scopes, value_sha256, note, creator_u
 	return id, token, nil
 }
 
-// Lookup looks up the access token. If it's valid and contains the required scope, it returns the
-// subject's user ID. Otherwise ErrAccessTokenNotFound is returned.
-//
-// Calling Lookup also updates the access token's last-used-at date.
-//
-// 🚨 SECURITY: This returns a user ID if and only if the tokenHexEncoded corresponds to a valid,
-// non-deleted access token.
 func (s *accessTokenStore) Lookup(ctx context.Context, tokenHexEncoded, requiredScope string) (subjectUserID int32, err error) {
 	if requiredScope == "" {
 		return 0, errors.New("no scope provided in access token lookup")
@@ -195,16 +226,10 @@ RETURNING t.subject_user_id
 	return subjectUserID, nil
 }
 
-// GetByID retrieves the access token (if any) given its ID.
-//
-// 🚨 SECURITY: The caller must ensure that the actor is permitted to view this access token.
 func (s *accessTokenStore) GetByID(ctx context.Context, id int64) (*AccessToken, error) {
 	return s.get(ctx, []*sqlf.Query{sqlf.Sprintf("id=%d", id)})
 }
 
-// GetByToken retrieves the access token (if any) given its hex encoded string.
-//
-// 🚨 SECURITY: The caller must ensure that the actor is permitted to view this access token.
 func (s *accessTokenStore) GetByToken(ctx context.Context, tokenHexEncoded string) (*AccessToken, error) {
 	token, err := decodeToken(tokenHexEncoded)
 	if err != nil {
@@ -251,10 +276,6 @@ func (o AccessTokensListOptions) sqlConditions() []*sqlf.Query {
 	return conds
 }
 
-// List lists all access tokens that satisfy the options, except internal tokens.
-//
-// 🚨 SECURITY: The caller must ensure that the actor is permitted to list with the specified
-// options.
 func (s *accessTokenStore) List(ctx context.Context, opt AccessTokensListOptions) ([]*AccessToken, error) {
 	return s.list(ctx, opt.sqlConditions(), opt.LimitOffset)
 }
@@ -292,9 +313,6 @@ created_at DESC
 	return results, nil
 }
 
-// Count counts all access tokens, except internal tokens, that satisfy the options (ignoring limit and offset).
-//
-// 🚨 SECURITY: The caller must ensure that the actor is permitted to count the tokens.
 func (s *accessTokenStore) Count(ctx context.Context, opt AccessTokensListOptions) (int, error) {
 	q := sqlf.Sprintf("SELECT COUNT(*) FROM access_tokens WHERE (%s)", sqlf.Join(opt.sqlConditions(), ") AND ("))
 	var count int
@@ -304,16 +322,10 @@ func (s *accessTokenStore) Count(ctx context.Context, opt AccessTokensListOption
 	return count, nil
 }
 
-// DeleteByID deletes an access token given its ID.
-//
-// 🚨 SECURITY: The caller must ensure that the actor is permitted to delete the token.
 func (s *accessTokenStore) DeleteByID(ctx context.Context, id int64) error {
 	return s.delete(ctx, sqlf.Sprintf("id=%d", id))
 }
 
-// HardDeleteByID hard-deletes an access token given its ID.
-//
-// 🚨 SECURITY: The caller must ensure that the actor is permitted to delete the token.
 func (s *accessTokenStore) HardDeleteByID(ctx context.Context, id int64) error {
 	if Mocks.AccessTokens.HardDeleteByID != nil {
 		return Mocks.AccessTokens.HardDeleteByID(id)
@@ -332,8 +344,6 @@ func (s *accessTokenStore) HardDeleteByID(ctx context.Context, id int64) error {
 	return nil
 }
 
-// DeleteByToken deletes an access token given the secret token value itself (i.e., the same value
-// that an API client would use to authenticate).
 func (s *accessTokenStore) DeleteByToken(ctx context.Context, tokenHexEncoded string) error {
 	token, err := decodeToken(tokenHexEncoded)
 	if err != nil {

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -38,24 +38,104 @@ import (
 var BeforeCreateExternalService func(context.Context, dbutil.DB) error
 
 type ExternalServiceStore interface {
+	// Count counts all external services that satisfy the options (ignoring limit and offset).
+	//
+	// 🚨 SECURITY: The caller must ensure that the actor is a site admin or owner of the external service.
 	Count(ctx context.Context, opt ExternalServicesListOptions) (int, error)
+
+	// Create creates an external service.
+	//
+	// Since this method is used before the configuration server has started (search
+	// for "EXTSVC_CONFIG_FILE") you must pass the conf.Get function in so that an
+	// alternative can be used when the configuration server has not started,
+	// otherwise a panic would occur once pkg/conf's deadlock detector determines a
+	// deadlock occurred.
+	//
+	// 🚨 SECURITY: The caller must ensure that the actor is a site admin or owner
+	// of the external service. Otherwise, `es.NamespaceUserID` must be specified
+	// (i.e. non-nil) for a user-added external service.
+	//
+	// 🚨 SECURITY: The value of `es.Unrestricted` is disregarded and will always be
+	// recalculated based on whether "authorization" field is presented in
+	// `es.Config`. For Sourcegraph Cloud, the `es.Unrestricted` will always be
+	// false (i.e. enforce permissions).
 	Create(ctx context.Context, confGet func() *conf.Unified, es *types.ExternalService) error
+
+	// Delete deletes an external service.
+	//
+	// 🚨 SECURITY: The caller must ensure that the actor is a site admin or owner of the external service.
 	Delete(ctx context.Context, id int64) (err error)
+
+	// DistinctKinds returns the distinct list of external services kinds that are stored in the database.
 	DistinctKinds(ctx context.Context) ([]string, error)
-	Done(err error) error
+
+	// GetAffiliatedSyncErrors returns the most recent sync failure message for each
+	// external service affiliated with the supplied user. If the latest run did not
+	// have an error, the string will be empty. We fetch external services owned by
+	// the supplied user and if they are a site admin we additionally return site
+	// level external services. We exclude cloud_default repos as they are never
+	// synced.
 	GetAffiliatedSyncErrors(ctx context.Context, u *types.User) (map[int64]string, error)
+
+	// GetByID returns the external service for id.
+	//
+	// 🚨 SECURITY: The caller must ensure that the actor is a site admin or owner of the external service.
 	GetByID(ctx context.Context, id int64) (*types.ExternalService, error)
+
+	// GetLastSyncError returns the error associated with the latest sync of the
+	// supplied external service.
+	//
+	// 🚨 SECURITY: The caller must ensure that the actor is a site admin or owner of the external service
 	GetLastSyncError(ctx context.Context, id int64) (string, error)
+
+	// GetSyncJobs gets all sync jobs
 	GetSyncJobs(ctx context.Context) ([]*types.ExternalServiceSyncJob, error)
+
+	// List returns external services under given namespace.
+	// If no namespace is given, it returns all external services.
+	//
+	// 🚨 SECURITY: The caller must ensure one of the following:
+	// 	- The actor is a site admin
+	// 	- The opt.NamespaceUserID is same as authenticated user ID (i.e. actor.UID)
 	List(ctx context.Context, opt ExternalServicesListOptions) ([]*types.ExternalService, error)
+
+	// RepoCount returns the number of repos synced by the external service with the
+	// given id.
+	//
+	// 🚨 SECURITY: The caller must ensure that the actor is a site admin or owner of the external service.
 	RepoCount(ctx context.Context, id int64) (int32, error)
+
+	// SyncDue returns true if any of the supplied external services are due to sync
+	// now or within given duration from now.
 	SyncDue(ctx context.Context, intIDs []int64, d time.Duration) (bool, error)
-	Transact(ctx context.Context) (ExternalServiceStore, error)
+
+	// Update updates an external service.
+	//
+	// 🚨 SECURITY: The caller must ensure that the actor is a site admin,
+	// or has the legitimate access to the external service (i.e. the owner).
 	Update(ctx context.Context, ps []schema.AuthProviders, id int64, update *ExternalServiceUpdate) (err error)
+
+	// Upsert updates or inserts the given ExternalServices.
+	//
+	// NOTE: Deletion of an external service via Upsert is not allowed. Use Delete()
+	// instead.
+	//
+	// 🚨 SECURITY: The value of `es.Unrestricted` is disregarded and will always be
+	// recalculated based on whether "authorization" field is presented in
+	// `es.Config`. For Sourcegraph Cloud, the `es.Unrestricted` will always be
+	// false (i.e. enforce permissions).
 	Upsert(ctx context.Context, svcs ...*types.ExternalService) (err error)
+
+	// ValidateConfig validates the given external service configuration, and returns a normalized
+	// version of the configuration (i.e. valid JSON without comments).
+	// A positive opt.ID indicates we are updating an existing service, adding a new one otherwise.
 	ValidateConfig(ctx context.Context, opt ValidateExternalServiceConfigOptions) (normalized []byte, err error)
-	With(other basestore.ShareableStore) ExternalServiceStore
+
 	WithEncryptionKey(key encryption.Key) ExternalServiceStore
+
+	Transact(ctx context.Context) (ExternalServiceStore, error)
+	With(other basestore.ShareableStore) ExternalServiceStore
+	Done(err error) error
 	basestore.ShareableStore
 }
 
@@ -262,9 +342,6 @@ type ValidateExternalServiceConfigOptions struct {
 	NamespaceOrgID int32
 }
 
-// ValidateConfig validates the given external service configuration, and returns a normalized
-// version of the configuration (i.e. valid JSON without comments).
-// A positive opt.ID indicates we are updating an existing service, adding a new one otherwise.
 func (e *externalServiceStore) ValidateConfig(ctx context.Context, opt ValidateExternalServiceConfigOptions) (normalized []byte, err error) {
 	ext, ok := ExternalServiceKinds[opt.Kind]
 	if !ok {
@@ -580,22 +657,6 @@ func upsertAuthorizationToExternalService(kind, config string) (string, error) {
 	return config, nil
 }
 
-// Create creates an external service.
-//
-// Since this method is used before the configuration server has started (search
-// for "EXTSVC_CONFIG_FILE") you must pass the conf.Get function in so that an
-// alternative can be used when the configuration server has not started,
-// otherwise a panic would occur once pkg/conf's deadlock detector determines a
-// deadlock occurred.
-//
-// 🚨 SECURITY: The caller must ensure that the actor is a site admin or owner
-// of the external service. Otherwise, `es.NamespaceUserID` must be specified
-// (i.e. non-nil) for a user-added external service.
-//
-// 🚨 SECURITY: The value of `es.Unrestricted` is disregarded and will always be
-// recalculated based on whether "authorization" field is presented in
-// `es.Config`. For Sourcegraph Cloud, the `es.Unrestricted` will always be
-// false (i.e. enforce permissions).
 func (e *externalServiceStore) Create(ctx context.Context, confGet func() *conf.Unified, es *types.ExternalService) error {
 	if Mocks.ExternalServices.Create != nil {
 		return Mocks.ExternalServices.Create(ctx, confGet, es)
@@ -696,15 +757,6 @@ func (e *externalServiceStore) maybeDecryptConfig(ctx context.Context, config st
 	return decrypted.Secret(), nil
 }
 
-// Upsert updates or inserts the given ExternalServices.
-//
-// NOTE: Deletion of an external service via Upsert is not allowed. Use Delete()
-// instead.
-//
-// 🚨 SECURITY: The value of `es.Unrestricted` is disregarded and will always be
-// recalculated based on whether "authorization" field is presented in
-// `es.Config`. For Sourcegraph Cloud, the `es.Unrestricted` will always be
-// false (i.e. enforce permissions).
 func (e *externalServiceStore) Upsert(ctx context.Context, svcs ...*types.ExternalService) (err error) {
 	if Mocks.ExternalServices.Upsert != nil {
 		return Mocks.ExternalServices.Upsert(ctx, svcs...)
@@ -900,10 +952,6 @@ type ExternalServiceUpdate struct {
 	CloudDefault *bool
 }
 
-// Update updates an external service.
-//
-// 🚨 SECURITY: The caller must ensure that the actor is a site admin,
-// or has the legitimate access to the external service (i.e. the owner).
 func (e *externalServiceStore) Update(ctx context.Context, ps []schema.AuthProviders, id int64, update *ExternalServiceUpdate) (err error) {
 	if Mocks.ExternalServices.Update != nil {
 		return Mocks.ExternalServices.Update(ctx, ps, id, update)
@@ -1025,9 +1073,6 @@ func (e externalServiceNotFoundError) NotFound() bool {
 	return true
 }
 
-// Delete deletes an external service.
-//
-// 🚨 SECURITY: The caller must ensure that the actor is a site admin or owner of the external service.
 func (e *externalServiceStore) Delete(ctx context.Context, id int64) (err error) {
 	if Mocks.ExternalServices.Delete != nil {
 		return Mocks.ExternalServices.Delete(ctx, id)
@@ -1106,9 +1151,6 @@ CREATE TEMPORARY TABLE IF NOT EXISTS
 	return nil
 }
 
-// GetByID returns the external service for id.
-//
-// 🚨 SECURITY: The caller must ensure that the actor is a site admin or owner of the external service.
 func (e *externalServiceStore) GetByID(ctx context.Context, id int64) (*types.ExternalService, error) {
 	if Mocks.ExternalServices.GetByID != nil {
 		return Mocks.ExternalServices.GetByID(id)
@@ -1128,7 +1170,6 @@ func (e *externalServiceStore) GetByID(ctx context.Context, id int64) (*types.Ex
 	return ess[0], nil
 }
 
-// GetSyncJobs gets all sync jobs
 func (e *externalServiceStore) GetSyncJobs(ctx context.Context) ([]*types.ExternalServiceSyncJob, error) {
 	q := sqlf.Sprintf(`SELECT id, state, failure_message, started_at, finished_at, process_after, num_resets, external_service_id, num_failures
 FROM external_service_sync_jobs ORDER BY started_at desc
@@ -1164,10 +1205,6 @@ FROM external_service_sync_jobs ORDER BY started_at desc
 	return jobs, nil
 }
 
-// GetLastSyncError returns the error associated with the latest sync of the
-// supplied external service.
-//
-// 🚨 SECURITY: The caller must ensure that the actor is a site admin or owner of the external service
 func (e *externalServiceStore) GetLastSyncError(ctx context.Context, id int64) (string, error) {
 	if Mocks.ExternalServices.GetLastSyncError != nil {
 		return Mocks.ExternalServices.GetLastSyncError(id)
@@ -1185,12 +1222,6 @@ LIMIT 1
 	return lastError, err
 }
 
-// GetAffiliatedSyncErrors returns the most recent sync failure message for each
-// external service affiliated with the supplied user. If the latest run did not
-// have an error, the string will be empty. We fetch external services owned by
-// the supplied user and if they are a site admin we additionally return site
-// level external services. We exclude cloud_default repos as they are never
-// synced.
 func (e *externalServiceStore) GetAffiliatedSyncErrors(ctx context.Context, u *types.User) (map[int64]string, error) {
 	if Mocks.ExternalServices.ListSyncErrors != nil {
 		return Mocks.ExternalServices.ListSyncErrors(ctx)
@@ -1233,12 +1264,6 @@ ORDER BY es.id, essj.finished_at DESC
 	return messages, nil
 }
 
-// List returns external services under given namespace.
-// If no namespace is given, it returns all external services.
-//
-// 🚨 SECURITY: The caller must ensure one of the following:
-// 	- The actor is a site admin
-// 	- The opt.NamespaceUserID is same as authenticated user ID (i.e. actor.UID)
 func (e *externalServiceStore) List(ctx context.Context, opt ExternalServicesListOptions) ([]*types.ExternalService, error) {
 	if Mocks.ExternalServices.List != nil {
 		return Mocks.ExternalServices.List(opt)
@@ -1345,7 +1370,6 @@ func (e *externalServiceStore) List(ctx context.Context, opt ExternalServicesLis
 	return results, nil
 }
 
-// DistinctKinds returns the distinct list of external services kinds that are stored in the database.
 func (e *externalServiceStore) DistinctKinds(ctx context.Context) ([]string, error) {
 	q := sqlf.Sprintf(`
 SELECT ARRAY_AGG(DISTINCT(kind)::TEXT)
@@ -1365,9 +1389,6 @@ WHERE deleted_at IS NULL
 	return kinds, nil
 }
 
-// Count counts all external services that satisfy the options (ignoring limit and offset).
-//
-// 🚨 SECURITY: The caller must ensure that the actor is a site admin or owner of the external service.
 func (e *externalServiceStore) Count(ctx context.Context, opt ExternalServicesListOptions) (int, error) {
 	if Mocks.ExternalServices.Count != nil {
 		return Mocks.ExternalServices.Count(ctx, opt)
@@ -1381,10 +1402,6 @@ func (e *externalServiceStore) Count(ctx context.Context, opt ExternalServicesLi
 	return count, nil
 }
 
-// RepoCount returns the number of repos synced by the external service with the
-// given id.
-//
-// 🚨 SECURITY: The caller must ensure that the actor is a site admin or owner of the external service.
 func (e *externalServiceStore) RepoCount(ctx context.Context, id int64) (int32, error) {
 	q := sqlf.Sprintf("SELECT COUNT(*) FROM external_service_repos WHERE external_service_id = %s", id)
 	var count int32
@@ -1396,8 +1413,6 @@ func (e *externalServiceStore) RepoCount(ctx context.Context, id int64) (int32, 
 	return count, nil
 }
 
-// SyncDue returns true if any of the supplied external services are due to sync
-// now or within given duration from now.
 func (e *externalServiceStore) SyncDue(ctx context.Context, intIDs []int64, d time.Duration) (bool, error) {
 	if len(intIDs) == 0 {
 		return false, nil


### PR DESCRIPTION
This moves the comments for a few stores from the implementing structs
to the interface types. It doesn't do all of them, just the few I could get done
in my short timebox. 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
