### PR TITLE
Add initial support for NPM package registries

### DIFF
--- a/client/web/src/components/externalServices/externalServices.tsx
+++ b/client/web/src/components/externalServices/externalServices.tsx
@@ -6,6 +6,7 @@ import GithubIcon from 'mdi-react/GithubIcon'
 import GitIcon from 'mdi-react/GitIcon'
 import GitLabIcon from 'mdi-react/GitlabIcon'
 import LanguageJavaIcon from 'mdi-react/LanguageJavaIcon'
+import NpmIcon from 'mdi-react/NpmIcon'
 import React from 'react'
 
 import { PhabricatorIcon } from '@sourcegraph/shared/src/components/icons'
@@ -17,6 +18,7 @@ import githubSchemaJSON from '../../../../../schema/github.schema.json'
 import gitlabSchemaJSON from '../../../../../schema/gitlab.schema.json'
 import gitoliteSchemaJSON from '../../../../../schema/gitolite.schema.json'
 import jvmPackagesSchemaJSON from '../../../../../schema/jvm-packages.schema.json'
+import npmPackagesSchemaJSON from '../../../../../schema/npm-packages.schema.json'
 import otherExternalServiceSchemaJSON from '../../../../../schema/other_external_service.schema.json'
 import pagureSchemaJSON from '../../../../../schema/pagure.schema.json'
 import perforceSchemaJSON from '../../../../../schema/perforce.schema.json'
@@ -1233,6 +1235,39 @@ const PAGURE: AddExternalServiceOptions = {
     editorActions: [],
 }
 
+const NPM_PACKAGES: AddExternalServiceOptions = {
+    kind: ExternalServiceKind.NPMPACKAGES,
+    title: 'NPM Dependencies',
+    icon: NpmIcon,
+    jsonSchema: npmPackagesSchemaJSON,
+    defaultDisplayName: 'NPM Dependencies',
+    defaultConfig: `{
+  "registry": "https://registry.npmjs.org",
+  "dependencies": []
+}`,
+    instructions: (
+        <div>
+            <ol>
+                <li>
+                    In the configuration below, set <Field>registry</Field> to the applicable NPM registry. For example,
+                    <code>"https://registry.npmjs.mycompany.com"</code> or <code>"https://registry.npmjs.org"</code>.
+                    Note that this URL may not be the same as where packages can be searched (such as{' '}
+                    <code>https://www.npmjs.org</code>). If you're unsure about the exact URL URL for a custom registry,
+                    check the URLs for packages that have already been resolved, such as those in existing lock files
+                    like <code>yarn.lock</code>.
+                </li>
+                <li>
+                    In the configuration below, set <Field>dependencies</Field> to the list of packages that you want to
+                    manually add. For example,
+                    <code>"react@17.0.2"</code> or <code>"@types/lodash@4.14.177"</code>. Version ranges are not
+                    supported.
+                </li>
+            </ol>
+        </div>
+    ),
+    editorActions: [],
+}
+
 export const codeHostExternalServices: Record<string, AddExternalServiceOptions> = {
     github: GITHUB_DOTCOM,
     ghe: GITHUB_ENTERPRISE,
@@ -1247,6 +1282,7 @@ export const codeHostExternalServices: Record<string, AddExternalServiceOptions>
     ...(window.context?.experimentalFeatures?.perforce === 'enabled' ? { perforce: PERFORCE } : {}),
     ...(window.context?.experimentalFeatures?.jvmPackages === 'enabled' ? { jvmPackages: JVM_PACKAGES } : {}),
     ...(window.context?.experimentalFeatures?.pagure === 'enabled' ? { pagure: PAGURE } : {}),
+    ...(window.context?.experimentalFeatures?.npmPackages === 'enabled' ? { npmPackages: NPM_PACKAGES } : {}),
 }
 
 export const nonCodeHostExternalServices: Record<string, AddExternalServiceOptions> = {
@@ -1270,4 +1306,5 @@ export const defaultExternalServices: Record<ExternalServiceKind, AddExternalSer
     [ExternalServiceKind.PERFORCE]: PERFORCE,
     [ExternalServiceKind.JVMPACKAGES]: JVM_PACKAGES,
     [ExternalServiceKind.PAGURE]: PAGURE,
+    [ExternalServiceKind.NPMPACKAGES]: NPM_PACKAGES,
 }

--- a/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
+++ b/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
@@ -61,6 +61,7 @@ const helpTexts: Record<ExternalServiceKind, JSX.Element> = {
     [ExternalServiceKind.BITBUCKETCLOUD]: <span>Unsupported</span>,
     [ExternalServiceKind.GITOLITE]: <span>Unsupported</span>,
     [ExternalServiceKind.JVMPACKAGES]: <span>Unsupported</span>,
+    [ExternalServiceKind.NPMPACKAGES]: <span>Unsupported</span>,
     [ExternalServiceKind.PERFORCE]: <span>Unsupported</span>,
     [ExternalServiceKind.PHABRICATOR]: <span>Unsupported</span>,
     [ExternalServiceKind.AWSCODECOMMIT]: <span>Unsupported</span>,

--- a/client/web/src/enterprise/batches/settings/CodeHostSshPublicKey.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostSshPublicKey.tsx
@@ -15,6 +15,7 @@ const configInstructionLinks: Record<ExternalServiceKind, string> = {
     [ExternalServiceKind.BITBUCKETCLOUD]: 'unsupported',
     [ExternalServiceKind.GITOLITE]: 'unsupported',
     [ExternalServiceKind.JVMPACKAGES]: 'unsupported',
+    [ExternalServiceKind.NPMPACKAGES]: 'unsupported',
     [ExternalServiceKind.OTHER]: 'unsupported',
     [ExternalServiceKind.PERFORCE]: 'unsupported',
     [ExternalServiceKind.PAGURE]: 'unsupported',

--- a/client/web/src/site-admin/SiteAdminReportBugPage.tsx
+++ b/client/web/src/site-admin/SiteAdminReportBugPage.tsx
@@ -15,6 +15,7 @@ import githubSchemaJSON from '../../../../schema/github.schema.json'
 import gitlabSchemaJSON from '../../../../schema/gitlab.schema.json'
 import gitoliteSchemaJSON from '../../../../schema/gitolite.schema.json'
 import jvmPackagesSchemaJSON from '../../../../schema/jvm-packages.schema.json'
+import npmPackagesSchemaJSON from '../../../../schema/npm-packages.schema.json'
 import otherExternalServiceSchemaJSON from '../../../../schema/other_external_service.schema.json'
 import pagureSchemaJSON from '../../../../schema/pagure.schema.json'
 import perforceSchemaJSON from '../../../../schema/perforce.schema.json'
@@ -43,6 +44,7 @@ const externalServices: Record<ExternalServiceKind, JSONSchema> = {
     GITLAB: gitlabSchemaJSON,
     GITOLITE: gitoliteSchemaJSON,
     JVMPACKAGES: jvmPackagesSchemaJSON,
+    NPMPACKAGES: npmPackagesSchemaJSON,
     OTHER: otherExternalServiceSchemaJSON,
     PERFORCE: perforceSchemaJSON,
     PHABRICATOR: phabricatorSchemaJSON,

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2231,6 +2231,7 @@ enum ExternalServiceKind {
     GITLAB
     GITOLITE
     JVMPACKAGES
+    NPMPACKAGES
     OTHER
     PAGURE
     PERFORCE

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -319,6 +319,12 @@ func getVCSSyncer(ctx context.Context, externalServiceStore database.ExternalSer
 			return nil, err
 		}
 		return &server.JVMPackagesSyncer{Config: &c, DBStore: codeintelDB}, nil
+	case extsvc.TypeNPMPackages:
+		var c schema.NPMPackagesConnection
+		if err := extractOptions(&c); err != nil {
+			return nil, err
+		}
+		return &server.NPMPackagesSyncer{Config: &c}, nil
 	}
 	return &server.GitRepoSyncer{}, nil
 }

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -305,6 +305,7 @@ func (s *JVMPackagesSyncer) commitJar(ctx context.Context, dependency reposource
 		return err
 	}
 
+	// See [NOTE: LSIF-config-json] for details on why we use this JSON file.
 	jsonContents, err := json.Marshal(&lsifJavaJSON{
 		Kind:         dependency.MavenModule.LsifJavaKind(),
 		JVM:          jvmVersion,

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -135,7 +135,7 @@ func (s *JVMPackagesSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, dir G
 		}
 		// the gitPushDependencyTag method is reponsible for cleaning up temporary directories.
 		if err := s.gitPushDependencyTag(ctx, string(dir), dependency, i == 0); err != nil {
-			return errors.Wrapf(err, "error pushing dependency %q", dependency.CoursierSyntax())
+			return errors.Wrapf(err, "error pushing dependency %q", dependency.PackageManagerSyntax())
 		}
 	}
 
@@ -291,7 +291,7 @@ func (s *JVMPackagesSyncer) gitPushDependencyTag(ctx context.Context, bareGitDir
 func (s *JVMPackagesSyncer) commitJar(ctx context.Context, dependency reposource.MavenDependency,
 	workingDirectory, sourceCodeJarPath string, connection *schema.JVMPackagesConnection) error {
 	if err := unzipJarFile(sourceCodeJarPath, workingDirectory); err != nil {
-		return errors.Wrapf(err, "failed to unzip jar file for %s to %v", dependency.CoursierSyntax(), sourceCodeJarPath)
+		return errors.Wrapf(err, "failed to unzip jar file for %s to %v", dependency.PackageManagerSyntax(), sourceCodeJarPath)
 	}
 
 	file, err := os.Create(filepath.Join(workingDirectory, "lsif-java.json"))
@@ -325,12 +325,12 @@ func (s *JVMPackagesSyncer) commitJar(ctx context.Context, dependency reposource
 	}
 
 	// Use --no-verify for security reasons. See https://github.com/sourcegraph/sourcegraph/pull/23399
-	cmd = exec.CommandContext(ctx, "git", "commit", "--no-verify", "-m", dependency.CoursierSyntax(), "--date", stableGitCommitDate)
+	cmd = exec.CommandContext(ctx, "git", "commit", "--no-verify", "-m", dependency.PackageManagerSyntax(), "--date", stableGitCommitDate)
 	if _, err := runCommandInDirectory(ctx, cmd, workingDirectory, dependency); err != nil {
 		return err
 	}
 
-	cmd = exec.CommandContext(ctx, "git", "tag", "-m", dependency.CoursierSyntax(), dependency.GitTagFromVersion())
+	cmd = exec.CommandContext(ctx, "git", "tag", "-m", dependency.PackageManagerSyntax(), dependency.GitTagFromVersion())
 	if _, err := runCommandInDirectory(ctx, cmd, workingDirectory, dependency); err != nil {
 		return err
 	}

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -467,24 +467,6 @@ func roundJVMVersionToNearestStableVersion(javaVersion int) int {
 	return javaVersion
 }
 
-func runCommandInDirectory(ctx context.Context, cmd *exec.Cmd, workingDirectory string, dependency reposource.MavenDependency) (string, error) {
-	gitName := dependency.MavenModule.CoursierSyntax() + " authors"
-	gitEmail := "code-intel@sourcegraph.com"
-	cmd.Dir = workingDirectory
-	cmd.Env = append(cmd.Env, "EMAIL="+gitEmail)
-	cmd.Env = append(cmd.Env, "GIT_AUTHOR_NAME="+gitName)
-	cmd.Env = append(cmd.Env, "GIT_AUTHOR_EMAIL="+gitEmail)
-	cmd.Env = append(cmd.Env, "GIT_AUTHOR_DATE="+stableGitCommitDate)
-	cmd.Env = append(cmd.Env, "GIT_COMMITTER_NAME="+gitName)
-	cmd.Env = append(cmd.Env, "GIT_COMMITTER_EMAIL="+gitEmail)
-	cmd.Env = append(cmd.Env, "GIT_COMMITTER_DATE="+stableGitCommitDate)
-	output, err := runWith(ctx, cmd, false, nil)
-	if err != nil {
-		return "", errors.Wrapf(err, "command %s failed with output %s", cmd.Args, string(output))
-	}
-	return string(output), nil
-}
-
 type lsifJavaJSON struct {
 	Kind         string   `json:"kind"`
 	JVM          string   `json:"jvm"`

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages_test.go
@@ -23,19 +23,19 @@ import (
 )
 
 const (
-	exampleJar                = "sources.jar"
-	exampleByteCodeJar        = "bytes.jar"
-	exampleJar2               = "sources2.jar"
-	exampleByteCodeJar2       = "bytes2.jar"
-	exampleFilePath           = "Example.java"
-	exampleClassfilePath      = "Example.class"
-	exampleFileContents       = "package example;\npublic class Example {}\n"
-	exampleFileContents2      = "package example;\npublic class Example { public static final int x = 42; }\n"
-	examplePackageVersion     = "1.0.0"
-	examplePackageVersion2    = "2.0.0"
-	examplePackageDependency  = "org.example:example:1.0.0"
-	examplePackageDependency2 = "org.example:example:2.0.0"
-	examplePackageUrl         = "maven/org.example/example"
+	exampleJar               = "sources.jar"
+	exampleByteCodeJar       = "bytes.jar"
+	exampleJar2              = "sources2.jar"
+	exampleByteCodeJar2      = "bytes2.jar"
+	exampleFilePath          = "Example.java"
+	exampleClassfilePath     = "Example.class"
+	exampleFileContents      = "package example;\npublic class Example {}\n"
+	exampleFileContents2     = "package example;\npublic class Example { public static final int x = 42; }\n"
+	exampleVersion           = "1.0.0"
+	exampleVersion2          = "2.0.0"
+	exampleVersionedPackage  = "org.example:example:1.0.0"
+	exampleVersionedPackage2 = "org.example:example:2.0.0"
+	examplePackageUrl        = "maven/org.example/example"
 
 	// These magic numbers come from the table here https://en.wikipedia.org/wiki/Java_class_file#General_layout
 	java5MajorVersion  = 49
@@ -99,8 +99,8 @@ else
   exit 1
 fi
 `,
-		examplePackageVersion, path.Join(dir, exampleJar), path.Join(dir, exampleByteCodeJar),
-		examplePackageVersion2, path.Join(dir, exampleJar2), path.Join(dir, exampleByteCodeJar2),
+		exampleVersion, path.Join(dir, exampleJar), path.Join(dir, exampleByteCodeJar),
+		exampleVersion2, path.Join(dir, exampleJar2), path.Join(dir, exampleByteCodeJar2),
 	)
 	_, err = coursierPath.WriteString(script)
 	assert.Nil(t, err)
@@ -196,19 +196,19 @@ func TestJVMCloneCommand(t *testing.T) {
 	}
 	bareGitDirectory := path.Join(dir, "git")
 
-	s.runCloneCommand(t, bareGitDirectory, []string{examplePackageDependency})
+	s.runCloneCommand(t, bareGitDirectory, []string{exampleVersionedPackage})
 	assertCommandOutput(t,
 		exec.Command("git", "tag", "--list"),
 		bareGitDirectory,
 		"v1.0.0\n",
 	)
 	assertCommandOutput(t,
-		exec.Command("git", "show", fmt.Sprintf("v%s:%s", examplePackageVersion, exampleFilePath)),
+		exec.Command("git", "show", fmt.Sprintf("v%s:%s", exampleVersion, exampleFilePath)),
 		bareGitDirectory,
 		exampleFileContents,
 	)
 
-	s.runCloneCommand(t, bareGitDirectory, []string{examplePackageDependency, examplePackageDependency2})
+	s.runCloneCommand(t, bareGitDirectory, []string{exampleVersionedPackage, exampleVersionedPackage2})
 	assertCommandOutput(t,
 		exec.Command("git", "tag", "--list"),
 		bareGitDirectory,
@@ -216,33 +216,33 @@ func TestJVMCloneCommand(t *testing.T) {
 	)
 
 	assertCommandOutput(t,
-		exec.Command("git", "show", fmt.Sprintf("v%s:%s", examplePackageVersion, "lsif-java.json")),
+		exec.Command("git", "show", fmt.Sprintf("v%s:%s", exampleVersion, "lsif-java.json")),
 		bareGitDirectory,
 		// Assert that Java 8 is used for a library compiled with Java 5.
-		fmt.Sprintf(`{"kind":"maven","jvm":"%s","dependencies":["%s"]}`, "8", examplePackageDependency),
+		fmt.Sprintf(`{"kind":"maven","jvm":"%s","dependencies":["%s"]}`, "8", exampleVersionedPackage),
 	)
 	assertCommandOutput(t,
-		exec.Command("git", "show", fmt.Sprintf("v%s:%s", examplePackageVersion2, "lsif-java.json")),
+		exec.Command("git", "show", fmt.Sprintf("v%s:%s", exampleVersion2, "lsif-java.json")),
 		bareGitDirectory,
 		// Assert that Java 11 is used for a library compiled with Java 11.
-		fmt.Sprintf(`{"kind":"maven","jvm":"%s","dependencies":["%s"]}`, "11", examplePackageDependency2),
+		fmt.Sprintf(`{"kind":"maven","jvm":"%s","dependencies":["%s"]}`, "11", exampleVersionedPackage2),
 	)
 
 	assertCommandOutput(t,
-		exec.Command("git", "show", fmt.Sprintf("v%s:%s", examplePackageVersion, exampleFilePath)),
+		exec.Command("git", "show", fmt.Sprintf("v%s:%s", exampleVersion, exampleFilePath)),
 		bareGitDirectory,
 		exampleFileContents,
 	)
 
 	assertCommandOutput(t,
-		exec.Command("git", "show", fmt.Sprintf("v%s:%s", examplePackageVersion2, exampleFilePath)),
+		exec.Command("git", "show", fmt.Sprintf("v%s:%s", exampleVersion2, exampleFilePath)),
 		bareGitDirectory,
 		exampleFileContents2,
 	)
 
-	s.runCloneCommand(t, bareGitDirectory, []string{examplePackageDependency})
+	s.runCloneCommand(t, bareGitDirectory, []string{exampleVersionedPackage})
 	assertCommandOutput(t,
-		exec.Command("git", "show", fmt.Sprintf("v%s:%s", examplePackageVersion, exampleFilePath)),
+		exec.Command("git", "show", fmt.Sprintf("v%s:%s", exampleVersion, exampleFilePath)),
 		bareGitDirectory,
 		exampleFileContents,
 	)

--- a/cmd/gitserver/server/vcs_syncer_npm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages.go
@@ -386,20 +386,20 @@ func decompressTgz(tgzPath, destination string) (err error) {
 				return errors.Errorf("unrecognized type of header %+v in tarball %+v", header.Typeflag, path.Base(tgzPath))
 			}
 		}
-		return fmt.Errorf("number of files in tarball %s exceeded limit (10000)", path.Base(tgzPath))
+		return errors.Errorf("number of files in tarball %s exceeded limit (10000)", path.Base(tgzPath))
 	})
 }
 
 func copyTarFileEntry(header *tar.Header, tarReader *tar.Reader, outputPath string) (err error) {
 	if header.Size < 0 {
-		return fmt.Errorf("corrupt tar header with negative size %d bytes for %s",
+		return errors.Errorf("corrupt tar header with negative size %d bytes for %s",
 			header.Size, path.Base(outputPath))
 	}
 	// For reference, "pathological" code like SQLite's amalgamation file is
 	// about 7.9 MiB. So a 15 MiB limit seems good enough.
 	const sizeLimitMiB = 15
 	if header.Size >= (sizeLimitMiB * 1024 * 1024) {
-		return fmt.Errorf("file size for %s (%d bytes) exceeded limit (%d MiB)",
+		return errors.Errorf("file size for %s (%d bytes) exceeded limit (%d MiB)",
 			path.Base(outputPath), header.Size, sizeLimitMiB)
 	}
 	if err = os.MkdirAll(path.Dir(outputPath), 0700); err != nil {

--- a/cmd/gitserver/server/vcs_syncer_npm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages.go
@@ -1,0 +1,420 @@
+package server
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"github.com/inconshreveable/log15"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/npmpackages/npm"
+	"github.com/sourcegraph/sourcegraph/internal/vcs"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+var (
+	placeholderNPMDependency = reposource.NPMDependency{
+		NPMPackage: func() reposource.NPMPackage {
+			pkg, err := reposource.NewNPMPackage("sourcegraph", "placeholder")
+			if err != nil {
+				panic(fmt.Sprintf("expected placeholder package to parse but got %v", err))
+			}
+			return *pkg
+		}(),
+		Version: "1.0.0",
+	}
+)
+
+type NPMPackagesSyncer struct {
+	Config *schema.NPMPackagesConnection
+	// TODO: [npm-package-support-database] Add a *dbstore.Store here.
+}
+
+var _ VCSSyncer = &NPMPackagesSyncer{}
+
+func (s *NPMPackagesSyncer) Type() string {
+	return "npm_packages"
+}
+
+// IsCloneable checks to see if the VCS remote URL is cloneable. Any non-nil
+// error indicates there is a problem.
+func (s *NPMPackagesSyncer) IsCloneable(ctx context.Context, remoteURL *vcs.URL) error {
+	dependencies, err := s.packageDependencies(ctx, remoteURL.Path)
+	if err != nil {
+		return err
+	}
+
+	for _, dependency := range dependencies {
+		if err := npm.Exists(ctx, s.Config, dependency); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Similar to CloneCommand for JVMPackagesSyncer; it handles cloning itself
+// instead of returning a command that does the cloning.
+func (s *NPMPackagesSyncer) CloneCommand(ctx context.Context, remoteURL *vcs.URL, bareGitDirectory string) (*exec.Cmd, error) {
+	err := os.MkdirAll(bareGitDirectory, 0755)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "--bare", "init")
+	if _, err := runCommandInDirectory(ctx, cmd, bareGitDirectory, placeholderNPMDependency); err != nil {
+		return nil, err
+	}
+
+	// The Fetch method is responsible for cleaning up temporary directories.
+	if err := s.Fetch(ctx, remoteURL, GitDir(bareGitDirectory)); err != nil {
+		return nil, errors.Wrapf(err, "failed to fetch repo for %s", remoteURL)
+	}
+
+	// no-op command to satisfy VCSSyncer interface, see docstring for more details.
+	return exec.CommandContext(ctx, "git", "--version"), nil
+}
+
+// Fetch adds git tags for newly added dependency versions and removes git tags
+// for deleted versions.
+func (s *NPMPackagesSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, dir GitDir) error {
+	dependencies, err := s.packageDependencies(ctx, remoteURL.Path)
+	if err != nil {
+		return err
+	}
+
+	out, err := runCommandInDirectory(ctx, exec.CommandContext(ctx, "git", "tag"), string(dir), placeholderNPMDependency)
+	if err != nil {
+		return err
+	}
+
+	tags := map[string]bool{}
+	for _, line := range strings.Split(out, "\n") {
+		if len(line) == 0 {
+			continue
+		}
+		tags[line] = true
+	}
+
+	for i, dependency := range dependencies {
+		if tags[dependency.GitTagFromVersion()] {
+			continue
+		}
+		// the gitPushDependencyTag method is responsible for cleaning up temporary directories.
+		if err := s.gitPushDependencyTag(ctx, string(dir), dependency, i == 0); err != nil {
+			return errors.Wrapf(err, "error pushing dependency %q", dependency.PackageManagerSyntax())
+		}
+	}
+
+	dependencyTags := make(map[string]struct{}, len(dependencies))
+	for _, dependency := range dependencies {
+		dependencyTags[dependency.GitTagFromVersion()] = struct{}{}
+	}
+
+	for tag := range tags {
+		if _, isDependencyTag := dependencyTags[tag]; !isDependencyTag {
+			cmd := exec.CommandContext(ctx, "git", "tag", "-d", tag)
+			if _, err := runCommandInDirectory(ctx, cmd, string(dir), placeholderNPMDependency); err != nil {
+				log15.Error("Failed to delete git tag", "error", err, "tag", tag)
+				continue
+			}
+		}
+	}
+
+	return nil
+}
+
+// RemoteShowCommand returns the command to be executed for showing remote.
+func (s *NPMPackagesSyncer) RemoteShowCommand(ctx context.Context, remoteURL *vcs.URL) (cmd *exec.Cmd, err error) {
+	return exec.CommandContext(ctx, "git", "remote", "show", "./"), nil
+}
+
+// packageDependencies returns the list of NPM dependencies that belong to the
+// given URL path. The returned package dependencies are sorted in descending
+// semver order (newest first).
+//
+// For example, if the URL path represents pkg@1, and our configuration has
+// [otherPkg@1, pkg@2, pkg@3], we will return [pkg@3, pkg@2].
+func (s *NPMPackagesSyncer) packageDependencies(ctx context.Context, repoUrlPath string) (matchingDependencies []reposource.NPMDependency, err error) {
+	repoPackage, err := reposource.ParseNPMPackage(repoUrlPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		timedout []reposource.NPMDependency
+	)
+	for _, configDependencyString := range s.npmDependencies() {
+		if repoPackage.MatchesDependencyString(configDependencyString) {
+			depPtr, err := reposource.ParseNPMDependency(configDependencyString)
+			if err != nil {
+				return nil, err
+			}
+			configDependency := *depPtr
+
+			if err := npm.Exists(ctx, s.Config, configDependency); err != nil {
+				if errors.Is(err, context.DeadlineExceeded) {
+					timedout = append(timedout, configDependency)
+					continue
+				} else {
+					return nil, err
+				}
+			}
+			matchingDependencies = append(matchingDependencies, configDependency)
+			// Silently ignore non-existent dependencies because
+			// they are already logged out in the `GetRepo` method
+			// in internal/repos/jvm_packages.go.
+		}
+	}
+	if len(timedout) > 0 {
+		log15.Warn("non-zero number of timed-out npm invocations", "count", len(timedout), "dependencies", timedout)
+	}
+
+	// TODO: [npm-package-support-database] Implement DB code path.
+
+	if len(matchingDependencies) == 0 {
+		return nil, errors.Errorf("no NPM dependencies for URL path %s", repoUrlPath)
+	}
+
+	log15.Info("fetched npm artifact for repo path", "repoPath", repoUrlPath, "totalConfig", len(matchingDependencies))
+	reposource.SortNPMDependencies(matchingDependencies)
+	return matchingDependencies, nil
+}
+
+func (s *NPMPackagesSyncer) npmDependencies() []string {
+	if s.Config == nil || s.Config.Dependencies == nil {
+		return nil
+	}
+	return s.Config.Dependencies
+}
+
+// gitPushDependencyTag pushes a git tag to the given bareGitDirectory path. The
+// tag points to a commit that adds all sources of given dependency. When
+// isMainBranch is true, the main branch of the bare git directory will also be
+// updated to point to the same commit as the git tag.
+func (s *NPMPackagesSyncer) gitPushDependencyTag(ctx context.Context, bareGitDirectory string, dependency reposource.NPMDependency, isLatestVersion bool) error {
+	tmpDirectory, err := os.MkdirTemp("", "npm")
+	if err != nil {
+		return err
+	}
+	// Always clean up created temporary directories.
+	defer os.RemoveAll(tmpDirectory)
+
+	sourceCodePath, err := npm.FetchSources(ctx, s.Config, dependency)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(sourceCodePath)
+
+	cmd := exec.CommandContext(ctx, "git", "init")
+	if _, err := runCommandInDirectory(ctx, cmd, tmpDirectory, dependency); err != nil {
+		return err
+	}
+
+	err = s.commitTgz(ctx, dependency, tmpDirectory, sourceCodePath, s.Config)
+	if err != nil {
+		return err
+	}
+
+	cmd = exec.CommandContext(ctx, "git", "remote", "add", "origin", bareGitDirectory)
+	if _, err := runCommandInDirectory(ctx, cmd, tmpDirectory, dependency); err != nil {
+		return err
+	}
+
+	// Use --no-verify for security reasons. See https://github.com/sourcegraph/sourcegraph/pull/23399
+	cmd = exec.CommandContext(ctx, "git", "push", "--no-verify", "--force", "origin", "--tags")
+	if _, err := runCommandInDirectory(ctx, cmd, tmpDirectory, dependency); err != nil {
+		return err
+	}
+
+	if isLatestVersion {
+		defaultBranch, err := runCommandInDirectory(ctx, exec.CommandContext(ctx, "git", "rev-parse", "--abbrev-ref", "HEAD"), tmpDirectory, dependency)
+		if err != nil {
+			return err
+		}
+		// Use --no-verify for security reasons. See https://github.com/sourcegraph/sourcegraph/pull/23399
+		cmd = exec.CommandContext(ctx, "git", "push", "--no-verify", "--force", "origin", strings.TrimSpace(defaultBranch)+":latest", dependency.GitTagFromVersion())
+		if _, err := runCommandInDirectory(ctx, cmd, tmpDirectory, dependency); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// commitTgz creates a git commit in the given working directory that adds all
+// the file contents of the given tgz file.
+func (s *NPMPackagesSyncer) commitTgz(ctx context.Context, dependency reposource.NPMDependency,
+	workingDirectory, sourceCodeTgzPath string, connection *schema.NPMPackagesConnection) error {
+	if err := decompressTgz(sourceCodeTgzPath, workingDirectory); err != nil {
+		return errors.Wrapf(err, "failed to decompress gzipped tarball for %s to %v", dependency.PackageManagerSyntax(), sourceCodeTgzPath)
+	}
+
+	// See [NOTE: LSIF-config-json] for why we don't create a JSON file here
+	// like we do for Java.
+
+	cmd := exec.CommandContext(ctx, "git", "add", ".")
+	if _, err := runCommandInDirectory(ctx, cmd, workingDirectory, dependency); err != nil {
+		return err
+	}
+
+	// Use --no-verify for security reasons. See https://github.com/sourcegraph/sourcegraph/pull/23399
+	cmd = exec.CommandContext(ctx, "git", "commit", "--no-verify",
+		"-m", dependency.PackageManagerSyntax(), "--date", stableGitCommitDate)
+	if _, err := runCommandInDirectory(ctx, cmd, workingDirectory, dependency); err != nil {
+		return err
+	}
+
+	cmd = exec.CommandContext(ctx, "git", "tag",
+		"-m", dependency.PackageManagerSyntax(), dependency.GitTagFromVersion())
+	if _, err := runCommandInDirectory(ctx, cmd, workingDirectory, dependency); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func withTgz(tgzPath string, action func(*tar.Reader) error) (err error) {
+	ioReader, err := os.Open(tgzPath)
+	errMsg := "unable to decompress tgz file with package source"
+	if err != nil {
+		return errors.Wrap(err, errMsg)
+	}
+	gzipReader, err := gzip.NewReader(ioReader)
+	defer func() {
+		errClose := gzipReader.Close()
+		if err != nil {
+			err = errClose
+		}
+	}()
+	if err != nil {
+		return errors.Wrap(err, errMsg)
+	}
+	tarReader := tar.NewReader(gzipReader)
+
+	return action(tarReader)
+}
+
+// Decompress a tarball at tgzPath, putting the files under destination.
+//
+// Additionally, if all the files in the tarball have paths of the form
+// dir/<blah> for the same directory 'dir', the 'dir' will be stripped.
+func decompressTgz(tgzPath, destination string) (err error) {
+	// [NOTE: npm-strip-outermost-directory]
+	// In practice, NPM tarballs seem to contain a superfluous directory which
+	// contains the files. For example, if you extract react's tarball,
+	// all files will be under a package/ directory, and if you extract
+	// @types/lodash's files, all files are under lodash/.
+	//
+	// However, this additional directory has no meaning. Moreover, it makes
+	// the UX slightly worse, as when you navigate to a repo, you would see
+	// that it contains just 1 folder, and you'd need to click again to drill
+	// down further. So we strip the superfluous directory if we detect one.
+	//
+	// https://github.com/sourcegraph/sourcegraph/pull/28057#issuecomment-987890718
+	var superfluousDirName *string = nil
+	commonSuperfluousDirectory := true
+	err = withTgz(tgzPath, func(reader *tar.Reader) (err error) {
+		for {
+			header, err := reader.Next()
+			if err == io.EOF {
+				return nil
+			}
+			if err != nil {
+				return errors.Wrapf(err, "failed to read tar file %s", tgzPath)
+			}
+			switch header.Typeflag {
+			case tar.TypeReg:
+				components := strings.SplitN(header.Name, string(os.PathSeparator), 2)
+				if len(components) != 2 {
+					commonSuperfluousDirectory = false
+					return nil
+				}
+				outermostDir := components[0]
+				if superfluousDirName == nil {
+					superfluousDirName = &outermostDir
+				} else if *superfluousDirName != outermostDir {
+					commonSuperfluousDirectory = false
+					return nil
+				}
+			default:
+				continue
+			}
+		}
+	})
+	if err != nil {
+		return err
+	}
+	if !commonSuperfluousDirectory {
+		log15.Warn("found npm tarball which doesn't have all files in one top-level directory", "tarball", path.Base(tgzPath))
+	}
+
+	return withTgz(tgzPath, func(tarReader *tar.Reader) (err error) {
+		destinationDir := strings.TrimSuffix(destination, string(os.PathSeparator)) + string(os.PathSeparator)
+		count := 0
+		tarballFileLimit := 10000
+		for count < tarballFileLimit {
+			header, err := tarReader.Next()
+			if err == io.EOF {
+				return nil
+			}
+			name := header.Name
+			if commonSuperfluousDirectory {
+				name = strings.SplitN(name, string(os.PathSeparator), 2)[1]
+			}
+			cleanedOutputPath, isPotentiallyMalicious := isPotentiallyMaliciousFilepathInArchive(name, destinationDir)
+			if isPotentiallyMalicious {
+				continue
+			}
+			switch header.Typeflag {
+			case tar.TypeDir:
+				continue // We will create directories later; empty directories don't matter for git.
+			case tar.TypeReg:
+				err = copyTarFileEntry(header, tarReader, cleanedOutputPath)
+				if err != nil {
+					return err
+				}
+				count++
+			default:
+				return errors.Errorf("unrecognized type of header %+v in tarball %+v", header.Typeflag, path.Base(tgzPath))
+			}
+		}
+		return fmt.Errorf("number of files in tarball %s exceeded limit (10000)", path.Base(tgzPath))
+	})
+}
+
+func copyTarFileEntry(header *tar.Header, tarReader *tar.Reader, outputPath string) (err error) {
+	if header.Size < 0 {
+		return fmt.Errorf("corrupt tar header with negative size %d bytes for %s",
+			header.Size, path.Base(outputPath))
+	}
+	// For reference, "pathological" code like SQLite's amalgamation file is
+	// about 7.9 MiB. So a 15 MiB limit seems good enough.
+	const sizeLimitMiB = 15
+	if header.Size >= (sizeLimitMiB * 1024 * 1024) {
+		return fmt.Errorf("file size for %s (%d bytes) exceeded limit (%d MiB)",
+			path.Base(outputPath), header.Size, sizeLimitMiB)
+	}
+	if err = os.MkdirAll(path.Dir(outputPath), 0700); err != nil {
+		return err
+	}
+	outputFile, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		errClose := outputFile.Close()
+		if err != nil {
+			err = errClose
+		}
+	}()
+	_, err = io.CopyN(outputFile, tarReader, header.Size)
+	return err
+}

--- a/cmd/gitserver/server/vcs_syncer_npm_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages_test.go
@@ -1,0 +1,269 @@
+package server
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io/fs"
+	"net/url"
+	"os"
+	"os/exec"
+	"path"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/npmpackages/npm"
+	"github.com/sourcegraph/sourcegraph/internal/vcs"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+const (
+	exampleTSFilepath           = "Example.ts"
+	exampleJSFilepath           = "Example.js"
+	exampleTSFileContents       = "export X; interface X { x: number }"
+	exampleJSFileContents       = "var x = 1; var y = 'hello'; x = y;"
+	exampleNPMVersion           = "1.0.0"
+	exampleNPMVersion2          = "2.0.0-abc"
+	exampleNPMVersionedPackage  = "example@1.0.0"
+	exampleNPMVersionedPackage2 = "example@2.0.0-abc"
+	exampleTgz                  = "example-1.0.0.tgz"
+	exampleTgz2                 = "example-2.0.0-abc.tgz"
+	exampleNPMPackageURL        = "npm/example"
+)
+
+func TestNoMaliciousFilesNPM(t *testing.T) {
+	dir, err := os.MkdirTemp("", "")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	tgzPath := path.Join(dir, "malicious.tgz")
+	extractPath := path.Join(dir, "extracted")
+	assert.Nil(t, os.Mkdir(extractPath, os.ModePerm))
+
+	createMaliciousTgz(t, tgzPath)
+
+	s := NPMPackagesSyncer{
+		Config: &schema.NPMPackagesConnection{Dependencies: []string{}},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel now  to prevent any network IO
+	err = s.commitTgz(ctx, reposource.NPMDependency{}, extractPath, tgzPath, s.Config)
+	assert.NotNil(t, err)
+
+	dirEntries, err := os.ReadDir(extractPath)
+	baseline := []string{"src"}
+	assert.Nil(t, err)
+	paths := []string{}
+	for _, dirEntry := range dirEntries {
+		paths = append(paths, dirEntry.Name())
+	}
+	if !reflect.DeepEqual(baseline, paths) {
+		t.Errorf("expected paths: %v\n   found paths:%v", baseline, paths)
+	}
+}
+
+func createMaliciousTgz(t *testing.T, tgzPath string) {
+	fileInfos := []fileInfo{
+		{harmlessPath, []byte{}},
+	}
+	for _, filepath := range maliciousPaths {
+		fileInfos = append(fileInfos, fileInfo{filepath, []byte{}})
+	}
+	createTgz(t, tgzPath, fileInfos)
+}
+
+func TestNPMCloneCommand(t *testing.T) {
+	dir, err := os.MkdirTemp("", "")
+	assert.Nil(t, err)
+	defer func() { assert.Nil(t, os.RemoveAll(dir)) }()
+
+	createPlaceholderSourcesTgz(t, dir, exampleJSFileContents, exampleJSFilepath, exampleTgz)
+	createPlaceholderSourcesTgz(t, dir, exampleTSFileContents, exampleTSFilepath, exampleTgz2)
+
+	npm.NPMBinary = npmScript(t, dir)
+	s := NPMPackagesSyncer{
+		Config: &schema.NPMPackagesConnection{Dependencies: []string{}},
+	}
+	bareGitDirectory := path.Join(dir, "git")
+	s.runCloneCommand(t, bareGitDirectory, []string{exampleNPMVersionedPackage})
+	assertCommandOutput(t,
+		exec.Command("git", "tag", "--list"),
+		bareGitDirectory,
+		"v1.0.0\n")
+	assertCommandOutput(t,
+		exec.Command("git", "show", fmt.Sprintf("v%s:%s", exampleNPMVersion, exampleJSFilepath)),
+		bareGitDirectory,
+		exampleJSFileContents,
+	)
+
+	s.runCloneCommand(t, bareGitDirectory, []string{exampleNPMVersionedPackage, exampleNPMVersionedPackage2})
+
+	assertCommandOutput(t,
+		exec.Command("git", "tag", "--list"),
+		bareGitDirectory,
+		"v1.0.0\nv2.0.0-abc\n", // verify that the v2.0.0 tag got added
+	)
+	assertCommandOutput(t,
+		exec.Command("git", "show", fmt.Sprintf("v%s:%s", exampleNPMVersion, exampleJSFilepath)),
+		bareGitDirectory,
+		exampleJSFileContents,
+	)
+
+	assertCommandOutput(t,
+		exec.Command("git", "show", fmt.Sprintf("v%s:%s", exampleNPMVersion2, exampleTSFilepath)),
+		bareGitDirectory,
+		exampleTSFileContents,
+	)
+
+	s.runCloneCommand(t, bareGitDirectory, []string{exampleNPMVersionedPackage})
+	assertCommandOutput(t,
+		exec.Command("git", "show", fmt.Sprintf("v%s:%s", exampleNPMVersion, exampleJSFilepath)),
+		bareGitDirectory,
+		exampleJSFileContents,
+	)
+	assertCommandOutput(t,
+		exec.Command("git", "tag", "--list"),
+		bareGitDirectory,
+		"v1.0.0\n", // verify that the v2.0.0 tag has been removed.
+	)
+}
+
+func createPlaceholderSourcesTgz(t *testing.T, dir, contents, filename, tgzFilename string) {
+	createTgz(t, path.Join(dir, tgzFilename),
+		[]fileInfo{
+			{filename, []byte(contents)},
+		})
+}
+
+func npmScript(t *testing.T, dir string) string {
+	t.Helper()
+	npmPath, err := os.OpenFile(path.Join(dir, "npm"), os.O_CREATE|os.O_RDWR, 07777)
+	assert.Nil(t, err)
+	defer func() { assert.Nil(t, npmPath.Close()) }()
+	script := fmt.Sprintf(`#!/usr/bin/env bash
+CLASSIFIER="$1"
+ARG="$2"
+if [[ "$CLASSIFIER" =~ "view" ]]; then
+  if [[ "$ARG" =~ "%[1]s" || "$ARG" =~ "%[2]s" ]]; then
+    echo "$ARG"
+  else
+    # Mimicking NPM's buggy behavior:
+    # https://github.com/npm/cli/issues/3184#issuecomment-963387099
+    exit 0
+  fi
+elif [[ "$CLASSIFIER" =~ "pack" ]]; then
+  if [[ "$ARG" =~ "%[1]s" ]]; then
+    echo "[{\"filename\": \"%[3]s\"}]"
+  elif [[ "$ARG" =~ "%[2]s" ]]; then
+    echo "[{\"filename\": \"%[4]s\"}]"
+  fi
+else
+  echo "invalid arguments for fake npm script: $@"
+  exit 1
+fi
+`,
+		exampleNPMVersionedPackage, exampleNPMVersionedPackage2,
+		path.Join(dir, exampleTgz), path.Join(dir, exampleTgz2),
+	)
+	_, err = npmPath.WriteString(script)
+	assert.Nil(t, err)
+	return npmPath.Name()
+}
+
+func (s NPMPackagesSyncer) runCloneCommand(t *testing.T, bareGitDirectory string, dependencies []string) {
+	t.Helper()
+	packageURL := vcs.URL{URL: url.URL{Path: exampleNPMPackageURL}}
+	s.Config.Dependencies = dependencies
+	cmd, err := s.CloneCommand(context.Background(), &packageURL, bareGitDirectory)
+	assert.Nil(t, err)
+	assert.Nil(t, cmd.Run())
+}
+
+func createTgz(t *testing.T, tgzPath string, fileInfos []fileInfo) {
+	t.Helper()
+	ioWriter, err := os.Create(tgzPath)
+	assert.Nil(t, err)
+	gzipWriter := gzip.NewWriter(ioWriter)
+	tarWriter := tar.NewWriter(gzipWriter)
+	defer func() {
+		assert.Nil(t, tarWriter.Close())
+		assert.Nil(t, gzipWriter.Close())
+		assert.Nil(t, ioWriter.Close())
+	}()
+	for _, fileinfo := range fileInfos {
+		assert.Nil(t, addFileToTarball(t, tarWriter, fileinfo))
+	}
+}
+
+func addFileToTarball(t *testing.T, tarWriter *tar.Writer, info fileInfo) error {
+	t.Helper()
+	header, err := tar.FileInfoHeader(&info, "")
+	if err != nil {
+		return err
+	}
+	header.Name = info.path
+	if err = tarWriter.WriteHeader(header); err != nil {
+		return errors.Wrapf(err, "failed to write header for %s", info.path)
+	}
+	_, err = tarWriter.Write(info.contents)
+	return err
+}
+
+type fileInfo struct {
+	path     string
+	contents []byte
+}
+
+var _ fs.FileInfo = &fileInfo{}
+
+func (info *fileInfo) Name() string       { return path.Base(info.path) }
+func (info *fileInfo) Size() int64        { return int64(len(info.contents)) }
+func (info *fileInfo) Mode() fs.FileMode  { return 0600 }
+func (info *fileInfo) ModTime() time.Time { return time.Unix(0, 0) }
+func (info *fileInfo) IsDir() bool        { return false }
+func (info *fileInfo) Sys() interface{}   { return nil }
+
+func TestDecompressTgz(t *testing.T) {
+	table := []struct {
+		paths  []string
+		expect []string
+	}{
+		// Check that stripping the outermost shared directory works if all
+		// paths have a common outermost directory.
+		{[]string{"d/f1", "d/f2"}, []string{"f1", "f2"}},
+		{[]string{"d1/d2/f1", "d1/d2/f2"}, []string{"d2"}},
+		{[]string{"d1/f1", "d2/f2", "d3/f3"}, []string{"d1", "d2", "d3"}},
+	}
+
+	for _, testData := range table {
+		dir, err := os.MkdirTemp("", "")
+		assert.Nil(t, err)
+		defer func() { assert.Nil(t, os.RemoveAll(dir)) }()
+
+		tarballName := "test.tgz"
+		tgzPath := path.Join(dir, tarballName)
+		// Creating a tarball with empty files fails???
+		fileInfos := []fileInfo{}
+		for _, path := range testData.paths {
+			fileInfos = append(fileInfos, fileInfo{path: path, contents: []byte("x")})
+		}
+		createTgz(t, tgzPath, fileInfos)
+		assert.Nil(t, decompressTgz(tgzPath, dir))
+		dirEntries, err := os.ReadDir(dir)
+		assert.Nil(t, err)
+		dirEntryNames := []string{}
+		for _, entry := range dirEntries {
+			if entry.Name() == tarballName {
+				continue
+			}
+			dirEntryNames = append(dirEntryNames, entry.Name())
+		}
+		assert.True(t, reflect.DeepEqual(dirEntryNames, testData.expect))
+	}
+}

--- a/cmd/gitserver/server/vcs_syncer_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_packages.go
@@ -25,3 +25,29 @@ func runCommandInDirectory(ctx context.Context, cmd *exec.Cmd, workingDirectory 
 	}
 	return string(output), nil
 }
+
+func isPotentiallyMaliciousFilepathInArchive(filepath, destinationDir string) (outputPath string, _ bool) {
+	if strings.HasPrefix(filepath, ".git/") {
+		// For security reasons, don't unzip files under the `.git/`
+		// directory. See https://github.com/sourcegraph/security-issues/issues/163
+		return "", true
+	}
+	if strings.HasSuffix(filepath, "/") {
+		// Skip directory entries. Directory entries must end
+		// with a forward slash (even on Windows) according to
+		// `file.Name` docstring.
+		return "", true
+	}
+	if strings.HasPrefix(filepath, "/") {
+		// Skip absolute paths. While they are extracted relative to `destination`,
+		// they should be unimportant. Related issue https://github.com/golang/go/issues/48085#issuecomment-912659635
+		return "", true
+	}
+	cleanedOutputPath := path.Join(destinationDir, filepath)
+	if !strings.HasPrefix(cleanedOutputPath, destinationDir) {
+		// For security reasons, skip file if it's not a child
+		// of the target directory. See "Zip Slip Vulnerability".
+		return "", true
+	}
+	return cleanedOutputPath, false
+}

--- a/cmd/gitserver/server/vcs_syncer_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_packages.go
@@ -1,0 +1,27 @@
+package server
+
+import (
+	"context"
+	"github.com/cockroachdb/errors"
+	"os/exec"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
+)
+
+func runCommandInDirectory(ctx context.Context, cmd *exec.Cmd, workingDirectory string, dependency reposource.PackageDependency) (string, error) {
+	gitName := dependency.PackageManagerSyntax() + " authors"
+	gitEmail := "code-intel@sourcegraph.com"
+	cmd.Dir = workingDirectory
+	cmd.Env = append(cmd.Env, "EMAIL="+gitEmail)
+	cmd.Env = append(cmd.Env, "GIT_AUTHOR_NAME="+gitName)
+	cmd.Env = append(cmd.Env, "GIT_AUTHOR_EMAIL="+gitEmail)
+	cmd.Env = append(cmd.Env, "GIT_AUTHOR_DATE="+stableGitCommitDate)
+	cmd.Env = append(cmd.Env, "GIT_COMMITTER_NAME="+gitName)
+	cmd.Env = append(cmd.Env, "GIT_COMMITTER_EMAIL="+gitEmail)
+	cmd.Env = append(cmd.Env, "GIT_COMMITTER_DATE="+stableGitCommitDate)
+	output, err := runWith(ctx, cmd, false, nil)
+	if err != nil {
+		return "", errors.Wrapf(err, "command %s failed with output %s", cmd.Args, string(output))
+	}
+	return string(output), nil
+}

--- a/internal/conf/reposource/jvm_packages.go
+++ b/internal/conf/reposource/jvm_packages.go
@@ -72,7 +72,7 @@ func (d MavenDependency) IsJDK() bool {
 	return d.MavenModule.IsJDK()
 }
 
-func (d MavenDependency) CoursierSyntax() string {
+func (d MavenDependency) PackageManagerSyntax() string {
 	return fmt.Sprintf("%s:%s:%s", d.MavenModule.GroupID, d.MavenModule.ArtifactID, d.Version)
 }
 
@@ -84,7 +84,7 @@ func (d MavenDependency) LsifJavaDependencies() []string {
 	if d.IsJDK() {
 		return []string{}
 	}
-	return []string{d.CoursierSyntax()}
+	return []string{d.PackageManagerSyntax()}
 }
 
 // ParseMavenDependency parses a dependency string in the Coursier format (colon seperated group ID, artifact ID and version)

--- a/internal/conf/reposource/jvm_packages.go
+++ b/internal/conf/reposource/jvm_packages.go
@@ -49,6 +49,7 @@ func (m *MavenModule) CloneURL() string {
 	return cloneURL.String()
 }
 
+// See [NOTE: Dependency-terminology]
 type MavenDependency struct {
 	MavenModule
 	Version string

--- a/internal/conf/reposource/jvm_packages.go
+++ b/internal/conf/reposource/jvm_packages.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"sort"
-	"strconv"
 	"strings"
-	"unicode"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 )
@@ -135,58 +133,4 @@ func jdkModule() MavenModule {
 		GroupID:    "jdk",
 		ArtifactID: "jdk",
 	}
-}
-
-// versionGreaterThan return true if the version string a is "greater" than the
-// version string b using psuedo semantic versioning. Java package versions can
-// be arbitrary strings so this method must always succeed even if a version is
-// not using the semantic version format. The comparison is lexicographical by
-// default except for the digit parts which are compared numerically. For
-// example, versionGreaterThan return true when comparing 11.2.0 and 2.2.0
-// because the number 11 is larger than 2 (even if "2" is lexicographically
-// larger than "11").
-func versionGreaterThan(version1, version2 string) bool {
-	index := 0
-	end := len(version1)
-	if len(version2) < end {
-		end = len(version2)
-	}
-	for index < end {
-		rune1 := rune(version1[index])
-		rune2 := rune(version2[index])
-		if unicode.IsDigit(rune1) && unicode.IsDigit(rune2) {
-			int1 := versionParseInt(index, version1)
-			int2 := versionParseInt(index, version2)
-			if int1 == int2 {
-				index = versionNextNonDigitOffset(index, version1)
-			} else {
-				return int1 > int2
-			}
-		} else {
-			if rune1 == rune2 {
-				index += 1
-			} else {
-				return rune1 > rune2
-			}
-		}
-	}
-	return len(version1) < len(version2)
-}
-
-// versionParseInt returns the integer value of the number that appears at given
-// index of the given string.
-func versionParseInt(index int, a string) int {
-	end := versionNextNonDigitOffset(index, a)
-	value, _ := strconv.Atoi(a[index:end])
-	return value
-}
-
-// versionNextNonDigitOffset returns the offset of the next non-digit character
-// of the given string starting at the given index.
-func versionNextNonDigitOffset(index int, b string) int {
-	offset := index
-	for offset < len(b) && unicode.IsDigit(rune(b[offset])) {
-		offset += 1
-	}
-	return offset
 }

--- a/internal/conf/reposource/npm_packages.go
+++ b/internal/conf/reposource/npm_packages.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/cockroachdb/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
@@ -42,10 +44,10 @@ type NPMPackage struct {
 
 func NewNPMPackage(scope string, name string) (*NPMPackage, error) {
 	if scope != "" && !npmScopeRegex.MatchString(scope) {
-		return nil, fmt.Errorf("illegal scope %s (allowed characters: 0-9, a-z, _, -)", scope)
+		return nil, errors.Errorf("illegal scope %s (allowed characters: 0-9, a-z, _, -)", scope)
 	}
 	if !npmPackageNameRegex.MatchString(name) {
-		return nil, fmt.Errorf("illegal package name %s (allowed characters: 0-9, a-z, _, -)", name)
+		return nil, errors.Errorf("illegal package name %s (allowed characters: 0-9, a-z, _, -)", name)
 	}
 	return &NPMPackage{scope, name}, nil
 }
@@ -55,7 +57,7 @@ func NewNPMPackage(scope string, name string) (*NPMPackage, error) {
 func ParseNPMPackage(urlPath string) (*NPMPackage, error) {
 	match := npmURLRegex.FindStringSubmatch(urlPath)
 	if match == nil {
-		return nil, fmt.Errorf("expected path in npm/(scope/)?name format but found %s", urlPath)
+		return nil, errors.Errorf("expected path in npm/(scope/)?name format but found %s", urlPath)
 	}
 	result := make(map[string]string)
 	for i, groupName := range npmURLRegex.SubexpNames() {
@@ -156,7 +158,7 @@ func ParseNPMDependency(dependency string) (*NPMDependency, error) {
 	// (source: https://docs.npmjs.com/cli/v8/using-npm/scope)
 	match := scopedPackageNameRegex.FindStringSubmatch(dependency)
 	if match == nil {
-		return nil, fmt.Errorf("expected dependency in (@scope/)?name@version format but found %s", dependency)
+		return nil, errors.Errorf("expected dependency in (@scope/)?name@version format but found %s", dependency)
 	}
 	result := make(map[string]string)
 	for i, groupName := range scopedPackageNameRegex.SubexpNames() {

--- a/internal/conf/reposource/npm_packages.go
+++ b/internal/conf/reposource/npm_packages.go
@@ -1,0 +1,195 @@
+package reposource
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+)
+
+const (
+	// Exported for [NOTE: npm-tarball-filename-workaround].
+	NPMScopeRegexString       = `(?P<scope>[0-9a-z_\\-]+)`
+	npmPackageNameRegexString = `(?P<name>[0-9a-z_\\-]+)`
+)
+
+var (
+	npmScopeRegex          = regexp.MustCompile(`^` + NPMScopeRegexString + `$`)
+	npmPackageNameRegex    = regexp.MustCompile(`^` + npmPackageNameRegexString + `$`)
+	scopedPackageNameRegex = regexp.MustCompile(
+		`^(@` + NPMScopeRegexString + `/)?` +
+			npmPackageNameRegexString +
+			`@(?P<version>[0-9a-zA-Z_\\-]+(\.[0-9a-zA-Z_\\-]+)*)$`)
+	npmURLRegex = regexp.MustCompile(
+		`^npm/(` + NPMScopeRegexString + `/)?` +
+			npmPackageNameRegexString + `$`)
+)
+
+// An NPM package of the form (@scope/)?name.
+//
+// The fields are kept private to reduce risk of not handling the empty scope
+// case correctly.
+type NPMPackage struct {
+	// Optional scope () for a package, can potentially be "".
+	// For more details, see https://docs.npmjs.com/cli/v8/using-npm/scope
+	scope string
+	// Required name for a package, always non-empty.
+	name string
+}
+
+func NewNPMPackage(scope string, name string) (*NPMPackage, error) {
+	if scope != "" && !npmScopeRegex.MatchString(scope) {
+		return nil, fmt.Errorf("illegal scope %s (allowed characters: 0-9, a-z, _, -)", scope)
+	}
+	if !npmPackageNameRegex.MatchString(name) {
+		return nil, fmt.Errorf("illegal package name %s (allowed characters: 0-9, a-z, _, -)", name)
+	}
+	return &NPMPackage{scope, name}, nil
+}
+
+// ParseNPMPackage is a convenience function to parse a string in a
+// 'npm/(scope/)?name' format into an NPM package.
+func ParseNPMPackage(urlPath string) (*NPMPackage, error) {
+	match := npmURLRegex.FindStringSubmatch(urlPath)
+	if match == nil {
+		return nil, fmt.Errorf("expected path in npm/(scope/)?name format but found %s", urlPath)
+	}
+	result := make(map[string]string)
+	for i, groupName := range npmURLRegex.SubexpNames() {
+		if i != 0 && groupName != "" {
+			result[groupName] = match[i]
+		}
+	}
+	scope, name := result["scope"], result["name"]
+	return &NPMPackage{scope, name}, nil
+}
+
+type NPMPackageSerializationHelper struct {
+	Scope string
+	Name  string
+}
+
+var _ json.Marshaler = &NPMPackage{}
+var _ json.Unmarshaler = &NPMPackage{}
+
+func (pkg *NPMPackage) MarshalJSON() ([]byte, error) {
+	return json.Marshal(NPMPackageSerializationHelper{pkg.scope, pkg.name})
+}
+
+func (pkg *NPMPackage) UnmarshalJSON(data []byte) error {
+	var wrapper NPMPackageSerializationHelper
+	err := json.Unmarshal(data, &wrapper)
+	if err != nil {
+		return err
+	}
+	newPkg, err := NewNPMPackage(wrapper.Scope, wrapper.Name)
+	if err != nil {
+		return err
+	}
+	*pkg = *newPkg
+	return nil
+}
+
+// RepoName provides a name that is "globally unique" for a Sourcegraph instance.
+//
+// The returned value is used for repo:... in queries.
+func (pkg *NPMPackage) RepoName() api.RepoName {
+	if pkg.scope != "" {
+		return api.RepoName(fmt.Sprintf("npm/%s/%s", pkg.scope, pkg.name))
+	}
+	return api.RepoName("npm/" + pkg.name)
+}
+
+// CloneURL returns a "URL" that can later be used to download a repo.
+func (pkg *NPMPackage) CloneURL() string {
+	return string(pkg.RepoName())
+}
+
+// MatchesDependencyString checks if a dependency (= package + version pair)
+// refers to the same package as pkg.
+func (pkg NPMPackage) MatchesDependencyString(depPackageSyntax string) bool {
+	return strings.HasPrefix(depPackageSyntax, pkg.packageSyntax()+"@")
+}
+
+func (pkg NPMPackage) packageSyntax() string {
+	if pkg.scope != "" {
+		return fmt.Sprintf("@%s/%s", pkg.scope, pkg.name)
+	}
+	return pkg.name
+}
+
+// NPMDependency is a "versioned package" for use by npm commands, such as
+// `npm install`.
+//
+// See also: [NOTE: Dependency-terminology]
+//
+// Reference:  https://docs.npmjs.com/cli/v8/commands/npm-install
+type NPMDependency struct {
+	NPMPackage
+
+	// The version or tag (such as "latest") for a dependency.
+	//
+	// See https://docs.npmjs.com/cli/v8/using-npm/config#tag for more details
+	// about tags.
+	Version string
+}
+
+// ParseNPMDependency parses a string in a '(@scope/)?module@version' format into an NPMDependency.
+//
+// NPM supports many ways of specifying dependencies (https://docs.npmjs.com/cli/v8/commands/npm-install)
+// but we only support exact versions for now.
+func ParseNPMDependency(dependency string) (*NPMDependency, error) {
+	// We use slightly more restrictive validation compared to the official
+	// rules (https://github.com/npm/validate-npm-package-name#naming-rules).
+	//
+	// For example, NPM does not explicitly forbid package names with @ in them.
+	// However, there don't seem to be any such packages in practice (I searched
+	// 100k+ packages and got 0 hits). The web frontend relies on using '@' to
+	// split between the package and rev-like part of the URL, such as
+	// https://sourcegraph.com/github.com/golang/go@master, so avoiding '@' is
+	// important.
+	//
+	// Scope names follow the same rules as package names.
+	// (source: https://docs.npmjs.com/cli/v8/using-npm/scope)
+	match := scopedPackageNameRegex.FindStringSubmatch(dependency)
+	if match == nil {
+		return nil, fmt.Errorf("expected dependency in (@scope/)?name@version format but found %s", dependency)
+	}
+	result := make(map[string]string)
+	for i, groupName := range scopedPackageNameRegex.SubexpNames() {
+		if i != 0 && groupName != "" {
+			result[groupName] = match[i]
+		}
+	}
+	scope, name, version := result["scope"], result["name"], result["version"]
+	return &NPMDependency{NPMPackage{scope, name}, version}, nil
+}
+
+// PackageManagerSyntax returns the dependency in NPM/Yarn syntax. The returned
+// string can (for example) be passed to `npm install`.
+func (d NPMDependency) PackageManagerSyntax() string {
+	return fmt.Sprintf("%s@%s", d.NPMPackage.packageSyntax(), d.Version)
+}
+
+func (d NPMDependency) GitTagFromVersion() string {
+	return "v" + d.Version
+}
+
+// SortDependencies sorts the dependencies by the semantic version in descending
+// order. The latest version of a dependency becomes the first element of the
+// slice.
+func SortNPMDependencies(dependencies []NPMDependency) {
+	sort.Slice(dependencies, func(i, j int) bool {
+		iPkg, jPkg := dependencies[i].NPMPackage, dependencies[j].NPMPackage
+		if iPkg == jPkg {
+			return versionGreaterThan(dependencies[i].Version, dependencies[j].Version)
+		}
+		if iPkg.scope == jPkg.scope {
+			return iPkg.name > jPkg.name
+		}
+		return iPkg.scope > jPkg.scope
+	})
+}

--- a/internal/conf/reposource/npm_packages.go
+++ b/internal/conf/reposource/npm_packages.go
@@ -3,11 +3,11 @@ package reposource
 import (
 	"encoding/json"
 	"fmt"
-	"regexp"
 	"sort"
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
 const (
@@ -17,13 +17,13 @@ const (
 )
 
 var (
-	npmScopeRegex          = regexp.MustCompile(`^` + NPMScopeRegexString + `$`)
-	npmPackageNameRegex    = regexp.MustCompile(`^` + npmPackageNameRegexString + `$`)
-	scopedPackageNameRegex = regexp.MustCompile(
+	npmScopeRegex          = lazyregexp.New(`^` + NPMScopeRegexString + `$`)
+	npmPackageNameRegex    = lazyregexp.New(`^` + npmPackageNameRegexString + `$`)
+	scopedPackageNameRegex = lazyregexp.New(
 		`^(@` + NPMScopeRegexString + `/)?` +
 			npmPackageNameRegexString +
 			`@(?P<version>[0-9a-zA-Z_\\-]+(\.[0-9a-zA-Z_\\-]+)*)$`)
-	npmURLRegex = regexp.MustCompile(
+	npmURLRegex = lazyregexp.New(
 		`^npm/(` + NPMScopeRegexString + `/)?` +
 			npmPackageNameRegexString + `$`)
 )

--- a/internal/conf/reposource/npm_packages_test.go
+++ b/internal/conf/reposource/npm_packages_test.go
@@ -1,0 +1,73 @@
+package reposource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseNPMDependency(t *testing.T) {
+	table := []struct {
+		testName string
+		expect   bool
+	}{
+		{"@scope/package@1.2.3-abc", true},
+		{"package@latest", true},
+		{"@scope/package@latest", true},
+		{"package@1.2.3", true},
+		{"package-1.2.3", false},
+		{"@scope/package", false},
+		{"@weird.scope/package@1.2.3", false},
+		{"@scope/weird.package@1.2.3", false},
+		{"package@1$%", false},
+		{"@scope-package@1.2.3", false},
+		{"@/package@1.2.3", false},
+		{"@scope/@1.2.3", false},
+	}
+	for _, entry := range table {
+		dep, err := ParseNPMDependency(entry.testName)
+		if entry.expect && (err != nil) {
+			t.Errorf("expected success but got error '%s' when parsing %s",
+				err.Error(), entry.testName)
+		} else if !entry.expect && err == nil {
+			t.Errorf("expected error but successfully parsed %s into %+v", entry.testName, dep)
+		}
+	}
+}
+
+func TestSortNPMDependencies(t *testing.T) {
+	dependencies := []NPMDependency{
+		parseNPMDependencyOrPanic(t, "ac@1.2.0"),
+		parseNPMDependencyOrPanic(t, "ab@1.2.0.Final"),
+		parseNPMDependencyOrPanic(t, "aa@1.2.0"),
+		parseNPMDependencyOrPanic(t, "ab@1.2.0"),
+		parseNPMDependencyOrPanic(t, "ab@1.11.0"),
+		parseNPMDependencyOrPanic(t, "ab@1.2.0-M11"),
+		parseNPMDependencyOrPanic(t, "ab@1.2.0-M1"),
+		parseNPMDependencyOrPanic(t, "ab@1.2.0-RC11"),
+		parseNPMDependencyOrPanic(t, "ab@1.2.0-RC1"),
+		parseNPMDependencyOrPanic(t, "ab@1.1.0"),
+	}
+	expected := []NPMDependency{
+		parseNPMDependencyOrPanic(t, "ac@1.2.0"),
+		parseNPMDependencyOrPanic(t, "ab@1.11.0"),
+		parseNPMDependencyOrPanic(t, "ab@1.2.0"),
+		parseNPMDependencyOrPanic(t, "ab@1.2.0.Final"),
+		parseNPMDependencyOrPanic(t, "ab@1.2.0-RC11"),
+		parseNPMDependencyOrPanic(t, "ab@1.2.0-RC1"),
+		parseNPMDependencyOrPanic(t, "ab@1.2.0-M11"),
+		parseNPMDependencyOrPanic(t, "ab@1.2.0-M1"),
+		parseNPMDependencyOrPanic(t, "ab@1.1.0"),
+		parseNPMDependencyOrPanic(t, "aa@1.2.0"),
+	}
+	SortNPMDependencies(dependencies)
+	assert.Equal(t, expected, dependencies)
+}
+
+func parseNPMDependencyOrPanic(t *testing.T, value string) NPMDependency {
+	dependency, err := ParseNPMDependency(value)
+	if err != nil {
+		t.Fatalf("error=%s", err)
+	}
+	return *dependency
+}

--- a/internal/conf/reposource/package_version.go
+++ b/internal/conf/reposource/package_version.go
@@ -1,0 +1,58 @@
+package reposource
+
+import (
+	"strconv"
+	"unicode"
+)
+
+// versionGreaterThan is a generalized version of comparing two strings
+// using semantic versioning that allows for non-numeric characters.
+// When a non-numeric character is encountered, the comparison switches to
+// lexicographic.
+//
+// For example, 11.0x > 11.0a > 11.0 > 8.0.
+func versionGreaterThan(version1, version2 string) bool {
+	index := 0
+	end := len(version1)
+	if len(version2) < end {
+		end = len(version2)
+	}
+	for index < end {
+		rune1 := rune(version1[index])
+		rune2 := rune(version2[index])
+		if unicode.IsDigit(rune1) && unicode.IsDigit(rune2) {
+			int1 := versionParseInt(index, version1)
+			int2 := versionParseInt(index, version2)
+			if int1 == int2 {
+				index = versionNextNonDigitOffset(index, version1)
+			} else {
+				return int1 > int2
+			}
+		} else {
+			if rune1 == rune2 {
+				index += 1
+			} else {
+				return rune1 > rune2
+			}
+		}
+	}
+	return len(version1) < len(version2)
+}
+
+// versionParseInt returns the integer value of the number that appears at given
+// index of the given string.
+func versionParseInt(index int, a string) int {
+	end := versionNextNonDigitOffset(index, a)
+	value, _ := strconv.Atoi(a[index:end])
+	return value
+}
+
+// versionNextNonDigitOffset returns the offset of the next non-digit character
+// of the given string starting at the given index.
+func versionNextNonDigitOffset(index int, b string) int {
+	offset := index
+	for offset < len(b) && unicode.IsDigit(rune(b[offset])) {
+		offset += 1
+	}
+	return offset
+}

--- a/internal/conf/reposource/packages_helper.go
+++ b/internal/conf/reposource/packages_helper.go
@@ -20,8 +20,10 @@ package reposource
 // situations where there is no connotation of a dependency edge.
 
 type PackageDependency interface {
-	// Give the name of the dependency as used by the package manager, including version information.
-	PackageSyntax() string
+	// Give the name of the dependency as used by the package manager,
+	// including version information.
+	PackageManagerSyntax() string
 }
 
 var _ PackageDependency = MavenDependency{}
+var _ PackageDependency = NPMDependency{}

--- a/internal/conf/reposource/packages_helper.go
+++ b/internal/conf/reposource/packages_helper.go
@@ -1,0 +1,8 @@
+package reposource
+
+type PackageDependency interface {
+	// Give the name of the dependency as used by the package manager, including version information.
+	PackageSyntax() string
+}
+
+var _ PackageDependency = MavenDependency{}

--- a/internal/conf/reposource/packages_helper.go
+++ b/internal/conf/reposource/packages_helper.go
@@ -1,5 +1,24 @@
 package reposource
 
+// [NOTE: Dependency-terminology]
+// In a dependency graph of packages, such as when doing package resolution,
+// you have the notion of dependencies as a pair of a package + a version range
+// (potentially having only one version in the limiting case) + potentially
+// some other information. After resolution, dependencies are pinned to a
+// specific version.
+//
+// From the point of view of package repository support in Sourcegraph, the
+// notion of a dependency corresponds to the latter, since package resolution
+// is handled by the appropriate package manager, and we only deal with the frozen
+// dependency versions when generating LSIF.
+//
+// This is why a dependency can be represented as a package + version pair.
+//
+// One edge case here is the root of the graph, which is technically not a
+// dependency. However, we still use the same type to represent the root for
+// practical purposes. For naming values, prefer "VersionedPackage" for
+// situations where there is no connotation of a dependency edge.
+
 type PackageDependency interface {
 	// Give the name of the dependency as used by the package manager, including version information.
 	PackageSyntax() string

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -238,6 +238,7 @@ var ExternalServiceKinds = map[string]ExternalServiceKind{
 	extsvc.KindJVMPackages:     {CodeHost: true, JSONSchema: schema.JVMPackagesSchemaJSON},
 	extsvc.KindOther:           {CodeHost: true, JSONSchema: schema.OtherExternalServiceSchemaJSON},
 	extsvc.KindPagure:          {CodeHost: true, JSONSchema: schema.PagureSchemaJSON},
+	extsvc.KindNPMPackages:     {CodeHost: true, JSONSchema: schema.NPMPackagesSchemaJSON},
 	extsvc.KindPerforce:        {CodeHost: true, JSONSchema: schema.PerforceSchemaJSON},
 	extsvc.KindPhabricator:     {CodeHost: true, JSONSchema: schema.PhabricatorSchemaJSON},
 }

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -35,6 +35,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitolite"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/jvmpackages"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/npmpackages"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/perforce"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/phabricator"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -517,6 +518,8 @@ func scanRepo(rows *sql.Rows, r *types.Repo) (err error) {
 		r.Metadata = new(extsvc.OtherRepoMetadata)
 	case extsvc.TypeJVMPackages:
 		r.Metadata = new(jvmpackages.Metadata)
+	case extsvc.TypeNPMPackages:
+		r.Metadata = new(npmpackages.Metadata)
 	default:
 		log15.Warn("scanRepo - unknown service type", "typ", typ)
 		return nil

--- a/internal/extsvc/jvmpackages/coursier/coursier.go
+++ b/internal/extsvc/jvmpackages/coursier/coursier.go
@@ -55,7 +55,7 @@ func init() {
 
 func FetchSources(ctx context.Context, config *schema.JVMPackagesConnection, dependency reposource.MavenDependency) (sourceCodeJarPath string, err error) {
 	ctx, endObservation := operations.fetchSources.With(ctx, &err, observation.Args{LogFields: []otlog.Field{
-		otlog.String("dependency", dependency.CoursierSyntax()),
+		otlog.String("dependency", dependency.PackageManagerSyntax()),
 	}})
 	defer endObservation(1, observation.Args{})
 
@@ -91,7 +91,7 @@ func FetchSources(ctx context.Context, config *schema.JVMPackagesConnection, dep
 		// arguments appears at a specific index.
 		"fetch",
 		"--quiet", "--quiet",
-		"--intransitive", dependency.CoursierSyntax(),
+		"--intransitive", dependency.PackageManagerSyntax(),
 		"--classifier", "sources",
 	)
 	if err != nil {
@@ -119,7 +119,7 @@ func FetchByteCode(ctx context.Context, config *schema.JVMPackagesConnection, de
 		// arguments appears at a specific index.
 		"fetch",
 		"--quiet", "--quiet",
-		"--intransitive", dependency.CoursierSyntax(),
+		"--intransitive", dependency.PackageManagerSyntax(),
 	)
 	if err != nil {
 		return "", err
@@ -135,7 +135,7 @@ func FetchByteCode(ctx context.Context, config *schema.JVMPackagesConnection, de
 
 func Exists(ctx context.Context, config *schema.JVMPackagesConnection, dependency reposource.MavenDependency) (exists bool, err error) {
 	ctx, endObservation := operations.exists.With(ctx, &err, observation.Args{LogFields: []otlog.Field{
-		otlog.String("dependency", dependency.CoursierSyntax()),
+		otlog.String("dependency", dependency.PackageManagerSyntax()),
 	}})
 	defer endObservation(1, observation.Args{})
 
@@ -148,7 +148,7 @@ func Exists(ctx context.Context, config *schema.JVMPackagesConnection, dependenc
 		config,
 		"resolve",
 		"--quiet", "--quiet",
-		"--intransitive", dependency.CoursierSyntax(),
+		"--intransitive", dependency.PackageManagerSyntax(),
 	)
 	return err == nil, err
 }

--- a/internal/extsvc/npmpackages/npm/npm.go
+++ b/internal/extsvc/npmpackages/npm/npm.go
@@ -189,5 +189,5 @@ func parseNPMPackOutput(output string) (filename string, err error) {
 		}
 		return filename, nil
 	}
-	return "", fmt.Errorf("failed to parse npm pack's JSON output (%s): %s", errInfo, output)
+	return "", errors.Errorf("failed to parse npm pack's JSON output (%s): %s", errInfo, output)
 }

--- a/internal/extsvc/npmpackages/npm/npm.go
+++ b/internal/extsvc/npmpackages/npm/npm.go
@@ -1,0 +1,202 @@
+// Code for interfacing with Javascript and Typescript package registries such
+// as NPMJS.com.
+package npm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/inconshreveable/log15"
+	"github.com/opentracing/opentracing-go"
+	otlog "github.com/opentracing/opentracing-go/log"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
+	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+// Sourced from https://docs.npmjs.com/cli/v8/using-npm/config
+
+const (
+	npmConfigCacheEnvVar        = "NPM_CONFIG_CACHE"
+	npmConfigFetchTimeoutEnvVar = "NPM_CONFIG_FETCH_TIMEOUT"
+	npmConfigRegistryEnvVar     = "NPM_CONFIG_REGISTRY"
+)
+
+var (
+	NPMBinary = "npm"
+
+	// Register all npm config variables we use for testing.
+	npmUsedConfigVars = []string{
+		npmConfigCacheEnvVar,
+		npmConfigFetchTimeoutEnvVar,
+		npmConfigRegistryEnvVar,
+	}
+	npmCacheDir        string
+	observationContext *observation.Context
+	operations         *Operations
+	invocTimeout, _    = time.ParseDuration(
+		env.Get("SRC_NPM_TIMEOUT", "30s", "Time limit per NPM invocation, which is used to resolve NPM dependencies."))
+	incorrectTarballNameRegex = regexp.MustCompile("^@" + reposource.NPMScopeRegexString + "/")
+)
+
+func init() {
+	observationContext = &observation.Context{
+		Logger:     log15.Root(),
+		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
+		Registerer: prometheus.DefaultRegisterer,
+	}
+	operations = NewOperations(observationContext)
+
+	// Should only be set for gitserver for persistence, repo-updater will use ephemeral storage.
+	// repo-updater only performs existence checks which doesnt involve downloading any JARs (except for JDK),
+	// only POM files which are much lighter.
+	if reposDir := os.Getenv("SRC_REPOS_DIR"); reposDir != "" {
+		npmCacheDir = filepath.Join(reposDir, "npm")
+		if err := os.MkdirAll(npmCacheDir, os.ModePerm); err != nil {
+			log.Fatalf("failed to create npm cache dir in %s: %s", npmCacheDir, err)
+		}
+	}
+}
+
+func FetchSources(ctx context.Context, config *schema.NPMPackagesConnection, dependency reposource.NPMDependency) (filename string, err error) {
+	ctx, endObservation := operations.fetchSources.With(ctx, &err, observation.Args{LogFields: []otlog.Field{
+		otlog.String("dependency", dependency.PackageManagerSyntax()),
+	}})
+	defer endObservation(1, observation.Args{})
+
+	npmJsonOutput, err := runNPMCommand(ctx, config, "pack", dependency.PackageManagerSyntax(), "--json")
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to fetch sources for %s", dependency.PackageManagerSyntax())
+	}
+	// [ { "id": "packageName@version", ..., "filename": "tarball.tgz", ... } ]
+	var parsedJson interface{}
+	err = json.Unmarshal([]byte(npmJsonOutput), &parsedJson)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to parse npm pack's output '%s'", npmJsonOutput)
+	}
+	output, err := parseNPMPackOutput(npmJsonOutput)
+	return output, err
+}
+
+func Exists(ctx context.Context, config *schema.NPMPackagesConnection, dependency reposource.NPMDependency) (err error) {
+	if operations == nil {
+		fmt.Println("operations is nil!")
+	}
+	ctx, endObservation := operations.exists.With(ctx, &err, observation.Args{LogFields: []otlog.Field{
+		otlog.String("dependency", dependency.PackageManagerSyntax()),
+	}})
+	defer endObservation(1, observation.Args{})
+
+	out, err := runNPMCommand(
+		ctx,
+		config,
+		"view",
+		dependency.PackageManagerSyntax())
+	if err != nil {
+		return errors.Wrapf(err, "tried to check if npm package %s exists but failed", dependency.PackageManagerSyntax())
+	}
+	// Ideally, checking the exit code would be enough, but it's not, due to an
+	// NPM bug https://github.com/npm/cli/issues/3184#issuecomment-963387099 😔
+	if len(out) == 0 || (strings.TrimSpace(out) == "") {
+		return errors.Newf("npm package %s does not exist", dependency.PackageManagerSyntax())
+	}
+	return nil
+}
+
+func runNPMCommand(ctx context.Context, config *schema.NPMPackagesConnection, args ...string) (output string, err error) {
+	ctx, cancel := context.WithTimeout(ctx, invocTimeout)
+	defer cancel()
+
+	ctx, trace, endObservation := operations.runCommand.WithAndLogger(ctx, &err, observation.Args{LogFields: []otlog.Field{
+		otlog.String("registry", config.Registry),
+		otlog.String("args", strings.Join(args, ", ")),
+	}})
+	defer endObservation(1, observation.Args{})
+
+	cmd := exec.CommandContext(ctx, NPMBinary, args...)
+	// Make sure node is usable, but don't copy the full environment.
+	// See also: forwardedHostEnvVars
+	cmd.Env = []string{}
+	cmd.Env = append(cmd.Env, fmt.Sprintf("HOME=%s", os.Getenv("HOME")))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("PATH=%s", os.Getenv("PATH")))
+	// TODO: [npm-package-support-credentials] Unlike Coursier where credentials are passed directly,
+	// npm's API involves login/logout commands. My instinct is that doing a login+logout for every command
+	// is a bad idea. Maybe we can hoist out the login and logout operations? Say something like:
+	//     npmLoginToken, err := npm.Login(...)
+	//     if err != nil { ... }
+	//     defer func(){ errLogout := npmLoginToken.Logout(); if err == nil { err = errLogout } }()
+	//     npmLoginToken.doStuff(...)
+
+	registry := config.Registry
+	if len(registry) != 0 {
+		cmd.Env = append(
+			cmd.Env, fmt.Sprintf("%s=%s", npmConfigRegistryEnvVar, registry))
+	}
+
+	if npmCacheDir != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", npmConfigCacheEnvVar, npmCacheDir))
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", errors.Wrapf(err, "npm command %q failed with stderr %q and stdout %q", cmd, stderr, &stdout)
+	}
+	trace.Log(otlog.String("stdout", stdout.String()), otlog.String("stderr", stderr.String()))
+
+	return stdout.String(), nil
+}
+
+func parseNPMPackOutput(output string) (filename string, err error) {
+	var parsedJson interface{}
+	var errInfo string
+	if err = json.Unmarshal([]byte(output), &parsedJson); err != nil {
+		errInfo = err.Error()
+	} else if array, ok := parsedJson.([]interface{}); ok {
+		if len(array) == 1 {
+			if object, ok := array[0].(map[string]interface{}); ok {
+				if filename, ok := object["filename"]; ok {
+					if filenameStr, ok := filename.(string); ok {
+						// [NOTE: npm-tarball-filename-workaround]
+						// For scoped packages, npm gives the wrong output
+						// (tested with 7.20.1 and 8.1.2). The actual file will
+						// be saved at scope-package-version.tgz, but the
+						// filename field is @scope/package-version.tgz
+						//
+						// See https://github.com/npm/cli/issues/3405
+						if len(filenameStr) > 0 && filenameStr[0] == '@' {
+							filenameStr = incorrectTarballNameRegex.ReplaceAllString(filenameStr, "$1-")
+						}
+						return filenameStr, nil
+					} else {
+						errInfo = "expected string value for \"filename\" key"
+					}
+				} else {
+					errInfo = "missing filename key"
+				}
+			} else {
+				errInfo = "failed to create map[string] from first element"
+			}
+		} else {
+			errInfo = "expected output array to have 1 element"
+		}
+	} else {
+		errInfo = "expected output to be an array"
+	}
+	return "", fmt.Errorf("failed to parse npm pack's JSON output (%s): %s", errInfo, output)
+}

--- a/internal/extsvc/npmpackages/npm/npm_test.go
+++ b/internal/extsvc/npmpackages/npm/npm_test.go
@@ -1,0 +1,52 @@
+package npm
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test that all the NPM configuration variables are supported by NPM.
+// In case NPM removes/renames certain configuration variables on
+// changing versions, we should be able to flag that as a test failure.
+func TestNPMConfigurationVariablesAreSupported(t *testing.T) {
+	npmAvailableConfigVars, err := exec.Command("npm", "config", "ls", "-l").Output()
+	assert.Nil(t, err)
+	for _, configVar := range npmUsedConfigVars {
+		configVarKebabCase := convertScreamingSnakeCaseToKebabCase(strings.TrimPrefix(configVar, "NPM_CONFIG_"))
+		assert.True(t, strings.Contains(string(npmAvailableConfigVars), configVarKebabCase))
+	}
+}
+
+func convertScreamingSnakeCaseToKebabCase(s string) string {
+	return strings.ToLower(strings.ReplaceAll(s, "_", "-"))
+}
+
+func TestNPMPackOutput(t *testing.T) {
+	ref := func(s string) *string { return &s }
+	var table = []struct {
+		input  string
+		expect *string
+	}{
+		{`[{"filename": "a"}]`, ref("a")},
+		{`[{"id": "mypkg", "filename": "a"}]`, ref("a")},
+		{`[{"filename": "a"}, {"filename": "b"}]`, nil},
+		{`{"filename": "a"}`, nil},
+		{`[{"id": "mypkg"}]`, nil},
+		{`[{"filename": ["a"]}]`, nil},
+		// See [NOTE: npm-tarball-filename-workaround]
+		{`[{"filename": "@scope-abc/pkg"}]`, ref("scope-abc-pkg")},
+		{`[{"filename": "scope-pkg"}]`, ref("scope-pkg")},
+	}
+	for _, entry := range table {
+		output, err := parseNPMPackOutput(entry.input)
+		if entry.expect != nil {
+			assert.Nil(t, err)
+			assert.Equal(t, output, *entry.expect)
+		} else {
+			assert.NotNil(t, err)
+		}
+	}
+}

--- a/internal/extsvc/npmpackages/npm/npm_test.go
+++ b/internal/extsvc/npmpackages/npm/npm_test.go
@@ -1,6 +1,7 @@
 package npm
 
 import (
+	"fmt"
 	"os/exec"
 	"strings"
 	"testing"
@@ -44,9 +45,9 @@ func TestNPMPackOutput(t *testing.T) {
 		output, err := parseNPMPackOutput(entry.input)
 		if entry.expect != nil {
 			assert.Nil(t, err)
-			assert.Equal(t, output, *entry.expect)
+			assert.Equal(t, *entry.expect, output)
 		} else {
-			assert.NotNil(t, err)
+			assert.NotNil(t, err, fmt.Sprintf("with output = '%s' for input = '%s'", output, entry.input))
 		}
 	}
 }

--- a/internal/extsvc/npmpackages/npm/observability.go
+++ b/internal/extsvc/npmpackages/npm/observability.go
@@ -1,0 +1,44 @@
+package npm
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+type Operations struct {
+	fetchSources *observation.Operation
+	exists       *observation.Operation
+	runCommand   *observation.Operation
+}
+
+func NewOperations(observationContext *observation.Context) *Operations {
+	redMetrics := metrics.NewREDMetrics(
+		observationContext.Registerer,
+		"codeintel_npm",
+		metrics.WithLabels("op"),
+		metrics.WithCountHelp("Total number of method invocations."),
+	)
+
+	op := func(name string) *observation.Operation {
+		return observationContext.Operation(observation.Op{
+			Name:              fmt.Sprintf("codeintel.npm.%s", name),
+			MetricLabelValues: []string{name},
+			Metrics:           redMetrics,
+			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
+				if err != nil && strings.Contains(err.Error(), "not found") {
+					return observation.EmitForMetrics | observation.EmitForTraces
+				}
+				return observation.EmitForDefault
+			},
+		})
+	}
+
+	return &Operations{
+		fetchSources: op("FetchSources"),
+		exists:       op("Exists"),
+		runCommand:   op("RunCommand"),
+	}
+}

--- a/internal/extsvc/npmpackages/repos.go
+++ b/internal/extsvc/npmpackages/repos.go
@@ -1,0 +1,7 @@
+package npmpackages
+
+import "github.com/sourcegraph/sourcegraph/internal/conf/reposource"
+
+type Metadata struct {
+	Package reposource.NPMPackage
+}

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -84,6 +84,7 @@ const (
 	KindPhabricator     = "PHABRICATOR"
 	KindJVMPackages     = "JVMPACKAGES"
 	KindPagure          = "PAGURE"
+	KindNPMPackages     = "NPMPACKAGES"
 	KindOther           = "OTHER"
 )
 
@@ -125,6 +126,9 @@ const (
 
 	// TypePagure is the (api.ExternalRepoSpec).ServiceType value for Pagure projects.
 	TypePagure = "pagure"
+
+	// TypeNPMPackages is the (api.ExternalRepoSpec).ServiceType value for NPM packages (JavaScript/TypeScript ecosystem libraries).
+	TypeNPMPackages = "npmPackages"
 
 	// TypeOther is the (api.ExternalRepoSpec).ServiceType value for other projects.
 	TypeOther = "other"
@@ -199,6 +203,7 @@ var (
 	bbsLower = strings.ToLower(TypeBitbucketServer)
 	bbcLower = strings.ToLower(TypeBitbucketCloud)
 	jvmLower = strings.ToLower(TypeJVMPackages)
+	npmLower = strings.ToLower(TypeNPMPackages)
 )
 
 // ParseServiceType will return a ServiceType constant after doing a case insensitive match on s.
@@ -223,6 +228,8 @@ func ParseServiceType(s string) (string, bool) {
 		return TypePhabricator, true
 	case jvmLower:
 		return TypeJVMPackages, true
+	case npmLower:
+		return TypeNPMPackages, true
 	case TypePagure:
 		return TypePagure, true
 	case TypeOther:
@@ -299,6 +306,8 @@ func ParseConfig(kind, config string) (cfg interface{}, _ error) {
 		cfg = &schema.JVMPackagesConnection{}
 	case KindPagure:
 		cfg = &schema.PagureConnection{}
+	case KindNPMPackages:
+		cfg = &schema.NPMPackagesConnection{}
 	case KindOther:
 		cfg = &schema.OtherExternalServiceConnection{}
 	default:
@@ -531,6 +540,8 @@ func UniqueCodeHostIdentifier(kind, config string) (string, error) {
 		return c.P4Port, nil
 	case *schema.JVMPackagesConnection:
 		return KindJVMPackages, nil
+	case *schema.NPMPackagesConnection:
+		return KindNPMPackages, nil
 	case *schema.PagureConnection:
 		rawURL = c.Url
 	default:

--- a/internal/repos/clone_url.go
+++ b/internal/repos/clone_url.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitolite"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/jvmpackages"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/npmpackages"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/perforce"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/phabricator"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -75,6 +76,10 @@ func CloneURL(kind, config string, repo *types.Repo) (string, error) {
 	case *schema.JVMPackagesConnection:
 		if r, ok := repo.Metadata.(*jvmpackages.Metadata); ok {
 			return r.Module.CloneURL(), nil
+		}
+	case *schema.NPMPackagesConnection:
+		if r, ok := repo.Metadata.(*npmpackages.Metadata); ok {
+			return r.Package.CloneURL(), nil
 		}
 	default:
 		return "", errors.Errorf("unknown external service kind %q for repo %d", kind, repo.ID)

--- a/internal/repos/jvm_packages.go
+++ b/internal/repos/jvm_packages.go
@@ -137,7 +137,7 @@ func (s *JVMPackagesSource) listDependentRepos(ctx context.Context, results chan
 				if errors.Is(err, context.DeadlineExceeded) {
 					timedOut++
 				} else {
-					log15.Warn("jvm package not resolvable from coursier", "package", mavenDependency.CoursierSyntax())
+					log15.Warn("jvm package not resolvable from coursier", "package", mavenDependency.PackageManagerSyntax())
 				}
 				continue
 			}

--- a/internal/repos/npm_packages.go
+++ b/internal/repos/npm_packages.go
@@ -48,10 +48,6 @@ func (s *NPMPackagesSource) ListRepos(ctx context.Context, results chan SourceRe
 			Repo:   repo,
 		}
 	}
-	if err != nil {
-		results <- SourceResult{Err: err}
-		return
-	}
 	// TODO: [npm-package-support-database] Implement database code path here.
 }
 

--- a/internal/repos/npm_packages.go
+++ b/internal/repos/npm_packages.go
@@ -2,7 +2,8 @@ package repos
 
 import (
 	"context"
-	"fmt"
+
+	"github.com/cockroachdb/errors"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
@@ -25,7 +26,7 @@ type NPMPackagesSource struct {
 func NewNPMPackagesSource(svc *types.ExternalService) (*NPMPackagesSource, error) {
 	var c schema.NPMPackagesConnection
 	if err := jsonc.Unmarshal(svc.Config, &c); err != nil {
-		return nil, fmt.Errorf("external service id=%d config error: %s", svc.ID, err)
+		return nil, errors.Errorf("external service id=%d config error: %s", svc.ID, err)
 	}
 	return &NPMPackagesSource{svc: svc, config: &c}, nil
 }

--- a/internal/repos/npm_packages.go
+++ b/internal/repos/npm_packages.go
@@ -1,0 +1,115 @@
+package repos
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/npmpackages"
+	"github.com/sourcegraph/sourcegraph/internal/jsonc"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+// A NPMPackagesSource creates git repositories from `*-sources.tar.gz` files of
+// published NPM dependencies from the JS ecosystem.
+type NPMPackagesSource struct {
+	svc    *types.ExternalService
+	config *schema.NPMPackagesConnection
+}
+
+// NewNPMPackagesSource returns a new NPMSource from the given external
+// service.
+func NewNPMPackagesSource(svc *types.ExternalService) (*NPMPackagesSource, error) {
+	var c schema.NPMPackagesConnection
+	if err := jsonc.Unmarshal(svc.Config, &c); err != nil {
+		return nil, fmt.Errorf("external service id=%d config error: %s", svc.ID, err)
+	}
+	return &NPMPackagesSource{svc: svc, config: &c}, nil
+}
+
+var _ Source = &NPMPackagesSource{}
+
+// ListRepos returns all NPM artifacts accessible to all connections
+// configured in Sourcegraph via the external services configuration.
+func (s *NPMPackagesSource) ListRepos(ctx context.Context, results chan SourceResult) {
+	npmPackages, err := npmPackages(*s.config)
+	if err != nil {
+		results <- SourceResult{Err: err}
+		return
+	}
+	for _, npmPackage := range npmPackages {
+		repo := s.makeRepo(npmPackage)
+		results <- SourceResult{
+			Source: s,
+			Repo:   repo,
+		}
+	}
+	if err != nil {
+		results <- SourceResult{Err: err}
+		return
+	}
+	// TODO: [npm-package-support-database] Implement database code path here.
+}
+
+func (s *NPMPackagesSource) makeRepo(npmPackage reposource.NPMPackage) *types.Repo {
+	urn := s.svc.URN()
+	cloneURL := npmPackage.CloneURL()
+	repoName := npmPackage.RepoName()
+	return &types.Repo{
+		Name: repoName,
+		URI:  string(repoName),
+		ExternalRepo: api.ExternalRepoSpec{
+			ID:          string(repoName),
+			ServiceID:   extsvc.TypeNPMPackages,
+			ServiceType: extsvc.TypeNPMPackages,
+		},
+		Private: false,
+		Sources: map[string]*types.SourceInfo{
+			urn: {
+				ID:       urn,
+				CloneURL: cloneURL,
+			},
+		},
+		Metadata: &npmpackages.Metadata{
+			Package: npmPackage,
+		},
+	}
+}
+
+// ExternalServices returns a singleton slice containing the external service.
+func (s *NPMPackagesSource) ExternalServices() types.ExternalServices {
+	return types.ExternalServices{s.svc}
+}
+
+// npmPackages gets the list of applicable packages by de-duplicating dependencies
+// present in the configuration.
+func npmPackages(connection schema.NPMPackagesConnection) ([]reposource.NPMPackage, error) {
+	dependencies, err := npmDependencies(connection)
+	if err != nil {
+		return nil, err
+	}
+	npmPackages := []reposource.NPMPackage{}
+	isAdded := make(map[reposource.NPMPackage]bool)
+	for _, dep := range dependencies {
+		npmPackage := dep.NPMPackage
+		if _, added := isAdded[npmPackage]; !added {
+			npmPackages = append(npmPackages, npmPackage)
+		}
+		isAdded[npmPackage] = true
+	}
+	return npmPackages, nil
+}
+
+func npmDependencies(connection schema.NPMPackagesConnection) (dependencies []reposource.NPMDependency, err error) {
+	for _, dep := range connection.Dependencies {
+		dependency, err := reposource.ParseNPMDependency(dep)
+		if err != nil {
+			return nil, err
+		}
+		dependencies = append(dependencies, *dependency)
+	}
+	return dependencies, nil
+}

--- a/internal/repos/npm_packages.go
+++ b/internal/repos/npm_packages.go
@@ -95,7 +95,7 @@ func npmPackages(connection schema.NPMPackagesConnection) ([]reposource.NPMPacka
 	isAdded := make(map[reposource.NPMPackage]bool)
 	for _, dep := range dependencies {
 		npmPackage := dep.NPMPackage
-		if _, added := isAdded[npmPackage]; !added {
+		if !isAdded[npmPackage] {
 			npmPackages = append(npmPackages, npmPackage)
 		}
 		isAdded[npmPackage] = true

--- a/internal/repos/sources.go
+++ b/internal/repos/sources.go
@@ -62,6 +62,8 @@ func NewSource(svc *types.ExternalService, cf *httpcli.Factory) (Source, error) 
 		return NewJVMPackagesSource(svc)
 	case extsvc.KindPagure:
 		return NewPagureSource(svc, cf)
+	case extsvc.KindNPMPackages:
+		return NewNPMPackagesSource(svc)
 	case extsvc.KindOther:
 		return NewOtherSource(svc, cf)
 	default:

--- a/internal/types/secret.go
+++ b/internal/types/secret.go
@@ -108,6 +108,9 @@ func redactionInfo(cfg interface{}) ([]jsonStringField, error) {
 			return []jsonStringField{{[]string{"token"}, &cfg.Token}}, nil
 		}
 		return []jsonStringField{}, nil
+	case *schema.NPMPackagesConnection:
+		// TODO: [npm-package-support-credentials] Redact credentials here.
+		return []jsonStringField{}, nil
 	case *schema.OtherExternalServiceConnection:
 		return []jsonStringField{{[]string{"url"}, &cfg.Url}}, nil
 	default:

--- a/internal/types/secret_test.go
+++ b/internal/types/secret_test.go
@@ -70,6 +70,10 @@ func TestRoundTripRedactExternalServiceConfig(t *testing.T) {
 	pagureConfig := schema.PagureConnection{
 		Url: "https://src.fedoraproject.org",
 	}
+	npmPackagesConfig := schema.NPMPackagesConnection{
+		// TODO: [npm-package-support-credentials] Add a credential field here
+		Dependencies: []string{"placeholder"},
+	}
 	otherConfig := schema.OtherExternalServiceConnection{
 		Url:                   someSecret,
 		RepositoryPathPattern: "foo",
@@ -135,6 +139,11 @@ func TestRoundTripRedactExternalServiceConfig(t *testing.T) {
 			kind:      extsvc.KindPagure,
 			config:    &pagureConfig,
 			editField: func(cfg interface{}) *string { return &cfg.(*schema.PagureConnection).Pattern },
+		},
+		{
+			kind:      extsvc.KindNPMPackages,
+			config:    &npmPackagesConfig,
+			editField: func(cfg interface{}) *string { return &cfg.(*schema.NPMPackagesConnection).Dependencies[0] },
 		},
 		{
 			kind:   extsvc.KindOther,

--- a/schema/npm-packages.schema.json
+++ b/schema/npm-packages.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "npm-packages.schema.json#",
+  "title": "NPMPackagesConnection",
+  "description": "Configuration for a connection to an NPM packages repository.\nTODO: [npm-package-support-credentials] Add a credential field to NPMConfig.",
+  "allowComments": true,
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["registry"],
+  "properties": {
+    "registry": {
+      "description": "The URL at which the NPM registry can be found.",
+      "type": "string",
+      "default": "https://registry.npmjs.org",
+      "examples": ["https://npm-registry.mycompany.com"]
+    },
+    "rateLimit": {
+      "description": "Rate limit applied when making background API requests to the NPM registry.",
+      "title": "NPMRateLimit",
+      "type": "object",
+      "required": ["enabled", "requestsPerHour"],
+      "properties": {
+        "enabled": {
+          "description": "true if rate limiting is enabled.",
+          "type": "boolean",
+          "default": true
+        },
+        "requestsPerHour": {
+          "description": "Requests per hour permitted. This is an average, calculated per second. Internally, the burst limit is set to 100, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 100 requests immediately, provided that the complexity cost of each request is 1.",
+          "type": "number",
+          "default": 1000,
+          "minimum": 0
+        }
+      },
+      "default": {
+        "enabled": true,
+        "requestsPerHour": 1000
+      }
+    },
+    "dependencies": {
+      "description": "An array of \"(@scope/)?packageName@version\" strings specifying which NPM packages to mirror on Sourcegraph.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^(@[^@/]+/)?[^@]+@[^@]+$"
+      },
+      "examples": [["react@17.0.2"], ["react@latest", "@types/lodash@4.14.177"]]
+    }
+  }
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -577,6 +577,8 @@ type ExperimentalFeatures struct {
 	EventLogging string `json:"eventLogging,omitempty"`
 	// JvmPackages description: Allow adding JVM packages code host connections
 	JvmPackages string `json:"jvmPackages,omitempty"`
+	// NpmPackages description: Allow adding NPM packages code host connections
+	NpmPackages string `json:"npmPackages,omitempty"`
 	// Pagure description: Allow adding Pagure code host connections
 	Pagure string `json:"pagure,omitempty"`
 	// Perforce description: Allow adding Perforce code host connections
@@ -998,6 +1000,25 @@ type MountedEncryptionKey struct {
 	Keyname    string `json:"keyname"`
 	Type       string `json:"type"`
 	Version    string `json:"version,omitempty"`
+}
+
+// NPMPackagesConnection description: Configuration for a connection to an NPM packages repository.
+// TODO: [npm-package-support-credentials] Add a credential field to NPMConfig.
+type NPMPackagesConnection struct {
+	// Dependencies description: An array of "(@scope/)?packageName@version" strings specifying which NPM packages to mirror on Sourcegraph.
+	Dependencies []string `json:"dependencies,omitempty"`
+	// RateLimit description: Rate limit applied when making background API requests to the NPM registry.
+	RateLimit *NPMRateLimit `json:"rateLimit,omitempty"`
+	// Registry description: The URL at which the NPM registry can be found.
+	Registry string `json:"registry"`
+}
+
+// NPMRateLimit description: Rate limit applied when making background API requests to the NPM registry.
+type NPMRateLimit struct {
+	// Enabled description: true if rate limiting is enabled.
+	Enabled bool `json:"enabled"`
+	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second. Internally, the burst limit is set to 100, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 100 requests immediately, provided that the complexity cost of each request is 1.
+	RequestsPerHour float64 `json:"requestsPerHour"`
 }
 
 // NoOpEncryptionKey description: This encryption key is a no op, leaving your data in plaintext (not recommended).

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -154,6 +154,12 @@
             }
           }
         },
+        "npmPackages": {
+          "description": "Allow adding NPM packages code host connections",
+          "type": "string",
+          "enum": ["enabled", "disabled"],
+          "default": "enabled"
+        },
         "tls.external": {
           "description": "Global TLS/SSL settings for Sourcegraph to use when communicating with code hosts.",
           "type": "object",

--- a/schema/stringdata.go
+++ b/schema/stringdata.go
@@ -38,6 +38,10 @@ var GitoliteSchemaJSON string
 //go:embed jvm-packages.schema.json
 var JVMPackagesSchemaJSON string
 
+// NPMPackagesSchemaJSON is the content of the file "npm-packages.schema.json".
+//go:embed npm-packages.schema.json
+var NPMPackagesSchemaJSON string
+
 // OtherExternalServiceSchemaJSON is the content of the file "other_external_service.schema.json".
 //go:embed other_external_service.schema.json
 var OtherExternalServiceSchemaJSON string


### PR DESCRIPTION
Stacked on top of #28056 .

Bunch of initial commits are just no-ops moving things around. The last commit is a bit big, but that seemed kinda' hard to break into separate parts.

NOTE: Database support and support for credentials will be added in future PRs, I've just marked TODOs right now so that it is easier to identify all places which will need changes in the future.