### PR TITLE
search: lift commit/diff job construction out of doResults

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -713,6 +713,20 @@ func (r *searchResolver) toSearchInputs(q query.Q) (*search.TextParameters, []ru
 			}
 		}
 
+		if args.ResultTypes.Has(result.TypeCommit) || args.ResultTypes.Has(result.TypeDiff) {
+			repoOptions := r.toRepoOptions(args.Query, resolveRepositoriesOpts{})
+
+			diff := args.ResultTypes.Has(result.TypeDiff)
+			jobs = append(jobs, &commit.CommitSearch{
+				Query:         commit.QueryToGitQuery(args.Query, diff),
+				RepoOpts:      repoOptions,
+				Diff:          diff,
+				HasTimeFilter: commit.HasTimeFilter(args.Query),
+				Limit:         int(args.PatternInfo.FileMatchLimit),
+				Db:            r.db,
+			})
+		}
+
 		if r.PatternType == query.SearchTypeStructural && p.Pattern != "" {
 			typ := search.TextRequest
 			zoektQuery, err := search.QueryToZoektQuery(args.PatternInfo, typ)
@@ -1694,29 +1708,6 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 			Args:  args,
 			Limit: limit,
 		})
-	}
-
-	addCommitSearch := func(diff bool) {
-		j, err := commit.NewSearchJob(args.Query, diff, int(args.PatternInfo.FileMatchLimit), args.RepoOptions)
-		if err != nil {
-			agg.Error(err)
-			return
-		}
-
-		if err := j.ExpandUsernames(ctx, r.db); err != nil {
-			agg.Error(err)
-			return
-		}
-
-		jobs = append(jobs, j)
-	}
-
-	if args.ResultTypes.Has(result.TypeCommit) {
-		addCommitSearch(false)
-	}
-
-	if args.ResultTypes.Has(result.TypeDiff) {
-		addCommitSearch(true)
 	}
 
 	wgForJob := func(job run.Job) *sync.WaitGroup {

--- a/internal/search/commit/commit_new_test.go
+++ b/internal/search/commit/commit_new_test.go
@@ -66,7 +66,7 @@ func TestQueryToGitQuery(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			output := queryToGitQuery(tc.input, tc.diff)
+			output := QueryToGitQuery(tc.input, tc.diff)
 			require.Equal(t, tc.output, output)
 		})
 	}


### PR DESCRIPTION
Was working on promoting global searches to jobs, looked at some of the `repoOptions` stuff, and went ahead with this :-) 