### PR TITLE
Replace global classes with data-testid in browser integration tests

### DIFF
--- a/client/browser/src/integration/github.test.ts
+++ b/client/browser/src/integration/github.test.ts
@@ -85,13 +85,21 @@ describe('GitHub', () => {
             'https://github.com/sourcegraph/jsonrpc2/blob/4fb7cd90793ee6ab445f466b900e6bffb9b63d78/call_opt.go'
         )
 
-        await driver.page.waitForSelector('.code-view-toolbar .open-on-sourcegraph', { timeout: 10000 })
-        assert.strictEqual((await driver.page.$$('.code-view-toolbar .open-on-sourcegraph')).length, 1)
+        await driver.page.waitForSelector('[data-testid="code-view-toolbar"] [data-testid="open-on-sourcegraph"]', {
+            timeout: 10000,
+        })
+        assert.strictEqual(
+            (await driver.page.$$('[data-testid="code-view-toolbar"] [data-testid="open-on-sourcegraph"]')).length,
+            1
+        )
 
         await retry(async () => {
             assert.strictEqual(
                 await driver.page.evaluate(
-                    () => document.querySelector<HTMLAnchorElement>('.code-view-toolbar .open-on-sourcegraph')?.href
+                    () =>
+                        document.querySelector<HTMLAnchorElement>(
+                            '[data-testid="code-view-toolbar"] [data-testid="open-on-sourcegraph"]'
+                        )?.href
                 ),
                 `${driver.sourcegraphBaseUrl}/${repoName}@4fb7cd90793ee6ab445f466b900e6bffb9b63d78/-/blob/call_opt.go?utm_source=${driver.browserType}-extension`
             )
@@ -139,7 +147,7 @@ describe('GitHub', () => {
         await driver.page.goto(
             'https://github.com/sourcegraph/jsonrpc2/blob/4fb7cd90793ee6ab445f466b900e6bffb9b63d78/call_opt.go'
         )
-        await driver.page.waitForSelector('.code-view-toolbar .open-on-sourcegraph')
+        await driver.page.waitForSelector('[data-testid="code-view-toolbar"] [data-testid="open-on-sourcegraph"]')
 
         // Pause to give codeintellify time to register listeners for
         // tokenization (only necessary in CI, not sure why).

--- a/client/browser/src/integration/gitlab.test.ts
+++ b/client/browser/src/integration/gitlab.test.ts
@@ -82,13 +82,21 @@ describe('GitLab', () => {
         const url = 'https://gitlab.com/sourcegraph/jsonrpc2/blob/4fb7cd90793ee6ab445f466b900e6bffb9b63d78/call_opt.go'
         await driver.page.goto(url)
 
-        await driver.page.waitForSelector('.code-view-toolbar .open-on-sourcegraph', { timeout: 10000 })
-        assert.strictEqual((await driver.page.$$('.code-view-toolbar .open-on-sourcegraph')).length, 1)
+        await driver.page.waitForSelector('[data-testid="code-view-toolbar"] [data-testid="open-on-sourcegraph"]', {
+            timeout: 10000,
+        })
+        assert.strictEqual(
+            (await driver.page.$$('[data-testid="code-view-toolbar"] [data-testid="open-on-sourcegraph"]')).length,
+            1
+        )
 
         await retry(async () => {
             assert.strictEqual(
                 await driver.page.evaluate(
-                    () => document.querySelector<HTMLAnchorElement>('.code-view-toolbar .open-on-sourcegraph')?.href
+                    () =>
+                        document.querySelector<HTMLAnchorElement>(
+                            '[data-testid="code-view-toolbar"] [data-testid="open-on-sourcegraph"]'
+                        )?.href
                 ),
                 `${driver.sourcegraphBaseUrl}/${repoName}@4fb7cd90793ee6ab445f466b900e6bffb9b63d78/-/blob/call_opt.go?utm_source=${driver.browserType}-extension`
             )
@@ -136,7 +144,7 @@ describe('GitLab', () => {
         await driver.page.goto(
             'https://gitlab.com/sourcegraph/jsonrpc2/blob/4fb7cd90793ee6ab445f466b900e6bffb9b63d78/call_opt.go'
         )
-        await driver.page.waitForSelector('.code-view-toolbar .open-on-sourcegraph')
+        await driver.page.waitForSelector('[data-testid="code-view-toolbar"] [data-testid="open-on-sourcegraph"]')
 
         // Pause to give codeintellify time to register listeners for
         // tokenization (only necessary in CI, not sure why).

--- a/client/browser/src/shared/components/CodeViewToolbar.tsx
+++ b/client/browser/src/shared/components/CodeViewToolbar.tsx
@@ -57,7 +57,7 @@ export interface CodeViewToolbarProps
 }
 
 export const CodeViewToolbar: React.FunctionComponent<CodeViewToolbarProps> = props => (
-    <ul className={classNames('code-view-toolbar', props.className)}>
+    <ul className={classNames('code-view-toolbar', props.className)} data-testid="code-view-toolbar">
         {!props.hideActions && (
             <ActionsNavItems
                 {...props}

--- a/client/browser/src/shared/components/OpenDiffOnSourcegraph.tsx
+++ b/client/browser/src/shared/components/OpenDiffOnSourcegraph.tsx
@@ -74,6 +74,7 @@ export class OpenDiffOnSourcegraph extends React.Component<Props, State> {
             <SourcegraphIconButton
                 {...this.props}
                 className={classNames('open-on-sourcegraph', this.props.className)}
+                dataTestId="open-on-sourcegraph"
                 href={url}
             />
         )

--- a/client/browser/src/shared/components/OpenOnSourcegraph.tsx
+++ b/client/browser/src/shared/components/OpenOnSourcegraph.tsx
@@ -19,5 +19,12 @@ export const OpenOnSourcegraph: React.FunctionComponent<Props> = ({
 }) => {
     const url = new URL(toPrettyBlobURL({ repoName, revision, filePath }), sourcegraphURL)
     url.searchParams.set('utm_source', getPlatformName())
-    return <SourcegraphIconButton {...props} className={classNames('open-on-sourcegraph', className)} href={url.href} />
+    return (
+        <SourcegraphIconButton
+            {...props}
+            className={classNames('open-on-sourcegraph', className)}
+            dataTestId="open-on-sourcegraph"
+            href={url.href}
+        />
+    )
 }

--- a/client/browser/src/shared/components/SourcegraphIconButton.tsx
+++ b/client/browser/src/shared/components/SourcegraphIconButton.tsx
@@ -10,6 +10,8 @@ export interface SourcegraphIconButtonProps
     label?: string
     /** aria-label attribute */
     ariaLabel?: string
+    /** data-testid attribute */
+    dataTestId?: string
 }
 
 export const SourcegraphIconButton: React.FunctionComponent<SourcegraphIconButtonProps> = ({
@@ -22,6 +24,7 @@ export const SourcegraphIconButton: React.FunctionComponent<SourcegraphIconButto
     rel,
     target,
     title,
+    dataTestId,
 }) => (
     <a
         href={href}
@@ -31,6 +34,7 @@ export const SourcegraphIconButton: React.FunctionComponent<SourcegraphIconButto
         title={title}
         aria-label={ariaLabel}
         onClick={onClick}
+        data-testid={dataTestId}
     >
         <SourcegraphIcon className={iconClassName} /> {label}
     </a>


### PR DESCRIPTION
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
## Description
 Replace global classes with `data-testid` in browser integration tests

## Refs

[Gitstart Task](https://app.gitstart.com/tasks/26003)

## Success Criteria
Global CSS classes except for .test-* used in integration tests are replaced with data-testid attributes. Relevant files: client/browser/src/integration/*.test.ts
