### PR TITLE
Replace global classes with data-testid in web integration tests

### DIFF
--- a/client/web/src/enterprise/searchContexts/EditSearchContextPage.tsx
+++ b/client/web/src/enterprise/searchContexts/EditSearchContextPage.tsx
@@ -99,7 +99,7 @@ export const AuthenticatedEditSearchContextPage: React.FunctionComponent<EditSea
                         <SearchContextForm {...props} searchContext={searchContextOrError} onSubmit={onSubmit} />
                     )}
                     {isErrorLike(searchContextOrError) && (
-                        <div className="alert alert-danger">
+                        <div data-testid="search-contexts-alert-danger" className="alert alert-danger">
                             Error while loading the search context: <strong>{searchContextOrError.message}</strong>
                         </div>
                     )}

--- a/client/web/src/enterprise/searchContexts/SearchContextRepositoriesFormArea.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextRepositoriesFormArea.tsx
@@ -165,7 +165,7 @@ export const SearchContextRepositoriesFormArea: React.FunctionComponent<SearchCo
             >
                 {isValidConfig ? (
                     <span className="d-flex align-items-center">
-                        <span className="icon-inline text-success mr-1">
+                        <span data-testid="repositories-config-success" className="icon-inline text-success mr-1">
                             <CheckIcon />{' '}
                         </span>
                         <span>Valid configuration</span>

--- a/client/web/src/enterprise/searchContexts/SearchContextsListPage.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextsListPage.tsx
@@ -63,8 +63,8 @@ export const SearchContextsListPage: React.FunctionComponent<SearchContextsListP
     )
 
     return (
-        <div className="w-100">
-            <Page className="search-contexts-list-page">
+        <div data-testid="search-contexts-list-page" className="w-100">
+            <Page>
                 <PageHeader
                     path={[
                         {

--- a/client/web/src/integration/blob-viewer.test.ts
+++ b/client/web/src/integration/blob-viewer.test.ts
@@ -1169,7 +1169,7 @@ describe('Blob viewer', () => {
                 // After this point, we know whether or not the alert will be displayed for this page load.
                 await driver.page.waitFor(500)
                 assert(
-                    !(await driver.page.$('.install-browser-extension-alert')),
+                    !(await driver.page.$('[data-testid="install-browser-extension-alert"]')),
                     'Expected "Install browser extension" alert to not be displayed before user dismisses it once'
                 )
             })

--- a/client/web/src/integration/search-contexts.test.ts
+++ b/client/web/src/integration/search-contexts.test.ts
@@ -228,13 +228,15 @@ describe('Search contexts', () => {
 
         // Test configuration
         await driver.page.click('[data-testid="repositories-config-button"]')
-        await driver.page.waitForSelector('[data-testid="repositories-config-button"] .text-success')
+        await driver.page.waitForSelector(
+            '[data-testid="repositories-config-button"] [data-testid="repositories-config-success"]'
+        )
 
         // Click create
         await driver.page.click('[data-testid="search-context-submit-button"]')
 
         // Wait for submit request to finish and redirect to list page
-        await driver.page.waitForSelector('.search-contexts-list-page')
+        await driver.page.waitForSelector('[data-testid="search-contexts-list-page"]')
     })
 
     test('Edit search context', async () => {
@@ -331,13 +333,15 @@ describe('Search contexts', () => {
 
         // Test configuration
         await driver.page.click('[data-testid="repositories-config-button"]')
-        await driver.page.waitForSelector('[data-testid="repositories-config-button"] .text-success')
+        await driver.page.waitForSelector(
+            '[data-testid="repositories-config-button"] [data-testid="repositories-config-success"]'
+        )
 
         // Click save
         await driver.page.click('[data-testid="search-context-submit-button"]')
 
         // Wait for submit request to finish and redirect to list page
-        await driver.page.waitForSelector('.search-contexts-list-page')
+        await driver.page.waitForSelector('[data-testid="search-contexts-list-page"]')
     })
 
     test('Cannot edit search context without necessary permissions', async () => {
@@ -362,8 +366,10 @@ describe('Search contexts', () => {
 
         await driver.page.goto(driver.sourcegraphBaseUrl + '/contexts/context-1/edit')
 
-        await driver.page.waitForSelector('.alert-danger')
-        const errorText = await driver.page.evaluate(() => document.querySelector('.alert-danger')?.textContent)
+        await driver.page.waitForSelector('[data-testid="search-contexts-alert-danger"]')
+        const errorText = await driver.page.evaluate(
+            () => document.querySelector('[data-testid="search-contexts-alert-danger"]')?.textContent
+        )
         expect(errorText).toContain('You do not have sufficient permissions to edit this context.')
     })
 
@@ -414,7 +420,7 @@ describe('Search contexts', () => {
         await driver.page.click('[data-testid="confirm-delete-search-context"]')
 
         // Wait for delete request to finish and redirect to list page
-        await driver.page.waitForSelector('.search-contexts-list-page')
+        await driver.page.waitForSelector('[data-testid="search-contexts-list-page"]')
     })
 
     test('Infinite scrolling in dropdown menu', async () => {

--- a/client/web/src/integration/search-onboarding.test.ts
+++ b/client/web/src/integration/search-onboarding.test.ts
@@ -111,8 +111,8 @@ describe('Search onboarding', () => {
             await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
             await waitAndFocusInput()
             await driver.page.waitForSelector('.tour-card')
-            await driver.page.waitForSelector('.tour-language-button')
-            await driver.page.click('.tour-language-button')
+            await driver.page.waitForSelector('[data-testid="tour-language-button"]')
+            await driver.page.click('[data-testid="tour-language-button"]')
             await driver.page.waitForSelector('#monaco-query-input')
             const inputContents = await driver.page.evaluate(
                 () => document.querySelector('#monaco-query-input .view-lines')?.textContent
@@ -135,8 +135,8 @@ describe('Search onboarding', () => {
             await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
             await waitAndFocusInput()
             await driver.page.waitForSelector('.tour-card')
-            await driver.page.waitForSelector('.tour-repo-button')
-            await driver.page.click('.tour-repo-button')
+            await driver.page.waitForSelector('[data-testid="tour-repo-button"]')
+            await driver.page.click('[data-testid="tour-repo-button"]')
             await driver.page.waitForSelector('#monaco-query-input')
             const inputContents = await driver.page.evaluate(
                 () => document.querySelector('#monaco-query-input .view-lines')?.textContent
@@ -155,8 +155,8 @@ describe('Search onboarding', () => {
             await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
             await waitAndFocusInput()
             await driver.page.waitForSelector('.tour-card')
-            await driver.page.waitForSelector('.tour-language-button')
-            await driver.page.click('.tour-language-button')
+            await driver.page.waitForSelector('[data-testid="tour-language-button"]')
+            await driver.page.click('[data-testid="tour-language-button"]')
             await driver.page.waitForSelector('#monaco-query-input')
             const inputContents = await driver.page.evaluate(
                 () => document.querySelector('#monaco-query-input .view-lines')?.textContent
@@ -180,8 +180,8 @@ describe('Search onboarding', () => {
             await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
             await waitAndFocusInput()
             await driver.page.waitForSelector('.tour-card')
-            await driver.page.waitForSelector('.tour-repo-button')
-            await driver.page.click('.tour-repo-button')
+            await driver.page.waitForSelector('[data-testid="tour-repo-button"]')
+            await driver.page.click('[data-testid="tour-repo-button"]')
             await driver.page.waitForSelector('#monaco-query-input')
             const inputContents = await driver.page.evaluate(
                 () => document.querySelector('#monaco-query-input .view-lines')?.textContent
@@ -205,8 +205,8 @@ describe('Search onboarding', () => {
             await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
             await waitAndFocusInput()
             await driver.page.waitForSelector('.tour-card')
-            await driver.page.waitForSelector('.tour-repo-button')
-            await driver.page.click('.tour-repo-button')
+            await driver.page.waitForSelector('[data-testid="tour-repo-button"]')
+            await driver.page.click('[data-testid="tour-repo-button"]')
             await driver.page.waitForSelector('#monaco-query-input')
             const inputContents = await driver.page.evaluate(
                 () => document.querySelector('#monaco-query-input .view-lines')?.textContent

--- a/client/web/src/search/input/SearchOnboardingTour.ts
+++ b/client/web/src/search/input/SearchOnboardingTour.ts
@@ -74,8 +74,8 @@ function generateStep1(
     content.className = 'd-flex align-items-center'
     content.innerHTML = `
          <div class=${styles.title}>Get started</div>
-         <button type="button" class="btn btn-link p-0 ${styles.link} tour-language-button">Search a language</button>
-         <button type="button" class="btn btn-link p-0 ${styles.link} tour-repo-button">Search a repository</button>
+         <button type="button" data-testid="tour-language-button" class="btn btn-link p-0 ${styles.link} tour-language-button">Search a language</button>
+         <button type="button" data-testid="tour-repo-button" class="btn btn-link p-0 ${styles.link} tour-repo-button">Search a repository</button>
      `
     content.querySelector('.tour-language-button')?.addEventListener('click', () => {
         languageButtonHandler()


### PR DESCRIPTION
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distribution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
## Description
 Replace global classes with `data-testid` in web end-to-end tests

## Refs
[Gitstart Task](https://app.gitstart.com/tasks/25692)

## Success Criteria
Global CSS classes except for .test-* used in end-to-end tests are replaced with data-testid attributes. Relevant file: client/web/src/end-to-end/end-to-end.test.ts.

FIles to handle in this task

- client/web/src/integration/search-contexts.test.ts

- client/web/src/integration/search-onboarding.test.ts

-  client/web/src/integration/search.test.ts

- client/web/src/integration/settings.test.ts