### PR TITLE
ci: do not run annotate outside buildkite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,6 @@ sitemap_query.db
 
 # Trivy security vulnerability reports
 *-security-report.html
+
+# CI annotations lock
+.annotate.lock

--- a/dev/ci/annotate.sh
+++ b/dev/ci/annotate.sh
@@ -3,6 +3,10 @@
 cd "$(dirname "${BASH_SOURCE[0]}")/../../"
 set -e
 
+if [[ -z "$BUILDKITE" ]]; then
+  exit 0
+fi
+
 SECTION=''
 MARKDOWN='false'
 


### PR DESCRIPTION
The annotation code was not checking if it was on Buildkite or not, leading to failing scripts for the engineers running those locally. 

Context on slack https://sourcegraph.slack.com/archives/C01N83PS4TU/p1637610868261800