### PR TITLE
Adjust hierarchy on email settings page, fix alignment

### DIFF
--- a/client/web/src/user/settings/emails/UserEmail.tsx
+++ b/client/web/src/user/settings/emails/UserEmail.tsx
@@ -132,7 +132,7 @@ export const UserEmail: FunctionComponent<Props> = ({
     return (
         <>
             <div className="d-flex align-items-center justify-content-between">
-                <div>
+                <div className="d-flex align-items-center">
                     <span className="mr-2">{email}</span>
                     {verified && <span className="badge badge-success mr-1">Verified</span>}
                     {!verified && !verificationPending && (
@@ -153,7 +153,7 @@ export const UserEmail: FunctionComponent<Props> = ({
                         </span>
                     )}
                 </div>
-                <div>
+                <div className="d-flex align-items-center">
                     {viewerCanManuallyVerify && (
                         <button
                             type="button"

--- a/client/web/src/user/settings/emails/UserSettingsEmailsPage.module.scss
+++ b/client/web/src/user/settings/emails/UserSettingsEmailsPage.module.scss
@@ -12,8 +12,16 @@
     + .list-item {
         border-top: 1px solid var(--border-color);
     }
+
+    &:first-of-type {
+        padding-top: 0;
+    }
+
+    &:last-of-type {
+        padding-bottom: 0;
+    }
 }
 
 .email-form {
-    padding-top: 0.5rem;
+    padding-top: 1.5rem;
 }

--- a/client/web/src/user/settings/emails/UserSettingsEmailsPage.tsx
+++ b/client/web/src/user/settings/emails/UserSettingsEmailsPage.tsx
@@ -92,7 +92,6 @@ export const UserSettingsEmailsPage: FunctionComponent<Props> = ({ user }) => {
             {isErrorLike(emailActionError) && <ErrorAlert className="mt-2" error={emailActionError} />}
 
             <Container>
-                <h3>All configured emails</h3>
                 <ul className="list-group">
                     {emails.map(email => (
                         <li key={email.email} className={classNames('list-group-item', styles.listItem)}>
@@ -110,11 +109,11 @@ export const UserSettingsEmailsPage: FunctionComponent<Props> = ({ user }) => {
                         <li className={classNames('list-group-item text-muted', styles.listItem)}>No emails</li>
                     )}
                 </ul>
-                {/* re-fetch emails on onDidAdd to guarantee correct state */}
-                <AddUserEmailForm className={styles.emailForm} user={user.id} onDidAdd={fetchEmails} />
-                <hr className="my-4" />
-                <SetUserPrimaryEmailForm user={user.id} emails={emails} onDidSet={fetchEmails} />
             </Container>
+            {/* re-fetch emails on onDidAdd to guarantee correct state */}
+            <AddUserEmailForm className={styles.emailForm} user={user.id} onDidAdd={fetchEmails} />
+            <hr className="my-4" />
+            <SetUserPrimaryEmailForm user={user.id} emails={emails} onDidSet={fetchEmails} />
         </div>
     )
 }


### PR DESCRIPTION
In the redesign, we introduced a container element. This container is intended to improve hierarchy and layout, but as it was implemented on the "Emails" settings page, it was just a background for the content.

This PR rearranges the page content a bit to use the container intentfully to create better hierarchy of content, rather than as a background. It also fixes an issue with vertical centre alignment for the items in each email row.