### PR TITLE
ssbc: Reduce pressure of resolving workspaces

### DIFF
--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace.go
@@ -170,14 +170,14 @@ func (r *batchSpecWorkspaceResolver) computeStepResolvers(ctx context.Context) (
 		if err != nil {
 			return nil, err
 		}
-		entry, err := r.store.GetBatchSpecExecutionCacheEntry(ctx, store.GetBatchSpecExecutionCacheEntryOpts{
-			Key: rawKey,
+		entries, err := r.store.ListBatchSpecExecutionCacheEntries(ctx, store.ListBatchSpecExecutionCacheEntriesOpts{
+			Keys: []string{rawKey},
 		})
-		if err != nil && err != store.ErrNoResults {
+		if err != nil {
 			return nil, err
 		}
-		if err == nil {
-			if err := json.Unmarshal([]byte(entry.Value), &cachedResult); err != nil {
+		if len(entries) == 1 {
+			if err := json.Unmarshal([]byte(entries[0].Value), &cachedResult); err != nil {
 				return nil, err
 			}
 		}

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/batches/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/batches/mock_iface_test.go
@@ -22,13 +22,13 @@ type MockBatchesStore struct {
 	// GetBatchSpecFunc is an instance of a mock function object controlling
 	// the behavior of the method GetBatchSpec.
 	GetBatchSpecFunc *BatchesStoreGetBatchSpecFunc
-	// GetBatchSpecExecutionCacheEntryFunc is an instance of a mock function
-	// object controlling the behavior of the method
-	// GetBatchSpecExecutionCacheEntry.
-	GetBatchSpecExecutionCacheEntryFunc *BatchesStoreGetBatchSpecExecutionCacheEntryFunc
 	// GetBatchSpecWorkspaceFunc is an instance of a mock function object
 	// controlling the behavior of the method GetBatchSpecWorkspace.
 	GetBatchSpecWorkspaceFunc *BatchesStoreGetBatchSpecWorkspaceFunc
+	// ListBatchSpecExecutionCacheEntriesFunc is an instance of a mock
+	// function object controlling the behavior of the method
+	// ListBatchSpecExecutionCacheEntries.
+	ListBatchSpecExecutionCacheEntriesFunc *BatchesStoreListBatchSpecExecutionCacheEntriesFunc
 	// SetBatchSpecWorkspaceExecutionJobAccessTokenFunc is an instance of a
 	// mock function object controlling the behavior of the method
 	// SetBatchSpecWorkspaceExecutionJobAccessToken.
@@ -49,13 +49,13 @@ func NewMockBatchesStore() *MockBatchesStore {
 				return nil, nil
 			},
 		},
-		GetBatchSpecExecutionCacheEntryFunc: &BatchesStoreGetBatchSpecExecutionCacheEntryFunc{
-			defaultHook: func(context.Context, store.GetBatchSpecExecutionCacheEntryOpts) (*types.BatchSpecExecutionCacheEntry, error) {
+		GetBatchSpecWorkspaceFunc: &BatchesStoreGetBatchSpecWorkspaceFunc{
+			defaultHook: func(context.Context, store.GetBatchSpecWorkspaceOpts) (*types.BatchSpecWorkspace, error) {
 				return nil, nil
 			},
 		},
-		GetBatchSpecWorkspaceFunc: &BatchesStoreGetBatchSpecWorkspaceFunc{
-			defaultHook: func(context.Context, store.GetBatchSpecWorkspaceOpts) (*types.BatchSpecWorkspace, error) {
+		ListBatchSpecExecutionCacheEntriesFunc: &BatchesStoreListBatchSpecExecutionCacheEntriesFunc{
+			defaultHook: func(context.Context, store.ListBatchSpecExecutionCacheEntriesOpts) ([]*types.BatchSpecExecutionCacheEntry, error) {
 				return nil, nil
 			},
 		},
@@ -78,11 +78,11 @@ func NewMockBatchesStoreFrom(i BatchesStore) *MockBatchesStore {
 		GetBatchSpecFunc: &BatchesStoreGetBatchSpecFunc{
 			defaultHook: i.GetBatchSpec,
 		},
-		GetBatchSpecExecutionCacheEntryFunc: &BatchesStoreGetBatchSpecExecutionCacheEntryFunc{
-			defaultHook: i.GetBatchSpecExecutionCacheEntry,
-		},
 		GetBatchSpecWorkspaceFunc: &BatchesStoreGetBatchSpecWorkspaceFunc{
 			defaultHook: i.GetBatchSpecWorkspace,
+		},
+		ListBatchSpecExecutionCacheEntriesFunc: &BatchesStoreListBatchSpecExecutionCacheEntriesFunc{
+			defaultHook: i.ListBatchSpecExecutionCacheEntries,
 		},
 		SetBatchSpecWorkspaceExecutionJobAccessTokenFunc: &BatchesStoreSetBatchSpecWorkspaceExecutionJobAccessTokenFunc{
 			defaultHook: i.SetBatchSpecWorkspaceExecutionJobAccessToken,
@@ -299,119 +299,6 @@ func (c BatchesStoreGetBatchSpecFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// BatchesStoreGetBatchSpecExecutionCacheEntryFunc describes the behavior
-// when the GetBatchSpecExecutionCacheEntry method of the parent
-// MockBatchesStore instance is invoked.
-type BatchesStoreGetBatchSpecExecutionCacheEntryFunc struct {
-	defaultHook func(context.Context, store.GetBatchSpecExecutionCacheEntryOpts) (*types.BatchSpecExecutionCacheEntry, error)
-	hooks       []func(context.Context, store.GetBatchSpecExecutionCacheEntryOpts) (*types.BatchSpecExecutionCacheEntry, error)
-	history     []BatchesStoreGetBatchSpecExecutionCacheEntryFuncCall
-	mutex       sync.Mutex
-}
-
-// GetBatchSpecExecutionCacheEntry delegates to the next hook function in
-// the queue and stores the parameter and result values of this invocation.
-func (m *MockBatchesStore) GetBatchSpecExecutionCacheEntry(v0 context.Context, v1 store.GetBatchSpecExecutionCacheEntryOpts) (*types.BatchSpecExecutionCacheEntry, error) {
-	r0, r1 := m.GetBatchSpecExecutionCacheEntryFunc.nextHook()(v0, v1)
-	m.GetBatchSpecExecutionCacheEntryFunc.appendCall(BatchesStoreGetBatchSpecExecutionCacheEntryFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// GetBatchSpecExecutionCacheEntry method of the parent MockBatchesStore
-// instance is invoked and the hook queue is empty.
-func (f *BatchesStoreGetBatchSpecExecutionCacheEntryFunc) SetDefaultHook(hook func(context.Context, store.GetBatchSpecExecutionCacheEntryOpts) (*types.BatchSpecExecutionCacheEntry, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetBatchSpecExecutionCacheEntry method of the parent MockBatchesStore
-// instance invokes the hook at the front of the queue and discards it.
-// After the queue is empty, the default hook function is invoked for any
-// future action.
-func (f *BatchesStoreGetBatchSpecExecutionCacheEntryFunc) PushHook(hook func(context.Context, store.GetBatchSpecExecutionCacheEntryOpts) (*types.BatchSpecExecutionCacheEntry, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
-// the given values.
-func (f *BatchesStoreGetBatchSpecExecutionCacheEntryFunc) SetDefaultReturn(r0 *types.BatchSpecExecutionCacheEntry, r1 error) {
-	f.SetDefaultHook(func(context.Context, store.GetBatchSpecExecutionCacheEntryOpts) (*types.BatchSpecExecutionCacheEntry, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushDefaultHook with a function that returns the given
-// values.
-func (f *BatchesStoreGetBatchSpecExecutionCacheEntryFunc) PushReturn(r0 *types.BatchSpecExecutionCacheEntry, r1 error) {
-	f.PushHook(func(context.Context, store.GetBatchSpecExecutionCacheEntryOpts) (*types.BatchSpecExecutionCacheEntry, error) {
-		return r0, r1
-	})
-}
-
-func (f *BatchesStoreGetBatchSpecExecutionCacheEntryFunc) nextHook() func(context.Context, store.GetBatchSpecExecutionCacheEntryOpts) (*types.BatchSpecExecutionCacheEntry, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *BatchesStoreGetBatchSpecExecutionCacheEntryFunc) appendCall(r0 BatchesStoreGetBatchSpecExecutionCacheEntryFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// BatchesStoreGetBatchSpecExecutionCacheEntryFuncCall objects describing
-// the invocations of this function.
-func (f *BatchesStoreGetBatchSpecExecutionCacheEntryFunc) History() []BatchesStoreGetBatchSpecExecutionCacheEntryFuncCall {
-	f.mutex.Lock()
-	history := make([]BatchesStoreGetBatchSpecExecutionCacheEntryFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// BatchesStoreGetBatchSpecExecutionCacheEntryFuncCall is an object that
-// describes an invocation of method GetBatchSpecExecutionCacheEntry on an
-// instance of MockBatchesStore.
-type BatchesStoreGetBatchSpecExecutionCacheEntryFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 store.GetBatchSpecExecutionCacheEntryOpts
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 *types.BatchSpecExecutionCacheEntry
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c BatchesStoreGetBatchSpecExecutionCacheEntryFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c BatchesStoreGetBatchSpecExecutionCacheEntryFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
 // BatchesStoreGetBatchSpecWorkspaceFunc describes the behavior when the
 // GetBatchSpecWorkspace method of the parent MockBatchesStore instance is
 // invoked.
@@ -521,6 +408,119 @@ func (c BatchesStoreGetBatchSpecWorkspaceFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c BatchesStoreGetBatchSpecWorkspaceFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// BatchesStoreListBatchSpecExecutionCacheEntriesFunc describes the behavior
+// when the ListBatchSpecExecutionCacheEntries method of the parent
+// MockBatchesStore instance is invoked.
+type BatchesStoreListBatchSpecExecutionCacheEntriesFunc struct {
+	defaultHook func(context.Context, store.ListBatchSpecExecutionCacheEntriesOpts) ([]*types.BatchSpecExecutionCacheEntry, error)
+	hooks       []func(context.Context, store.ListBatchSpecExecutionCacheEntriesOpts) ([]*types.BatchSpecExecutionCacheEntry, error)
+	history     []BatchesStoreListBatchSpecExecutionCacheEntriesFuncCall
+	mutex       sync.Mutex
+}
+
+// ListBatchSpecExecutionCacheEntries delegates to the next hook function in
+// the queue and stores the parameter and result values of this invocation.
+func (m *MockBatchesStore) ListBatchSpecExecutionCacheEntries(v0 context.Context, v1 store.ListBatchSpecExecutionCacheEntriesOpts) ([]*types.BatchSpecExecutionCacheEntry, error) {
+	r0, r1 := m.ListBatchSpecExecutionCacheEntriesFunc.nextHook()(v0, v1)
+	m.ListBatchSpecExecutionCacheEntriesFunc.appendCall(BatchesStoreListBatchSpecExecutionCacheEntriesFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// ListBatchSpecExecutionCacheEntries method of the parent MockBatchesStore
+// instance is invoked and the hook queue is empty.
+func (f *BatchesStoreListBatchSpecExecutionCacheEntriesFunc) SetDefaultHook(hook func(context.Context, store.ListBatchSpecExecutionCacheEntriesOpts) ([]*types.BatchSpecExecutionCacheEntry, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// ListBatchSpecExecutionCacheEntries method of the parent MockBatchesStore
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *BatchesStoreListBatchSpecExecutionCacheEntriesFunc) PushHook(hook func(context.Context, store.ListBatchSpecExecutionCacheEntriesOpts) ([]*types.BatchSpecExecutionCacheEntry, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *BatchesStoreListBatchSpecExecutionCacheEntriesFunc) SetDefaultReturn(r0 []*types.BatchSpecExecutionCacheEntry, r1 error) {
+	f.SetDefaultHook(func(context.Context, store.ListBatchSpecExecutionCacheEntriesOpts) ([]*types.BatchSpecExecutionCacheEntry, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *BatchesStoreListBatchSpecExecutionCacheEntriesFunc) PushReturn(r0 []*types.BatchSpecExecutionCacheEntry, r1 error) {
+	f.PushHook(func(context.Context, store.ListBatchSpecExecutionCacheEntriesOpts) ([]*types.BatchSpecExecutionCacheEntry, error) {
+		return r0, r1
+	})
+}
+
+func (f *BatchesStoreListBatchSpecExecutionCacheEntriesFunc) nextHook() func(context.Context, store.ListBatchSpecExecutionCacheEntriesOpts) ([]*types.BatchSpecExecutionCacheEntry, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *BatchesStoreListBatchSpecExecutionCacheEntriesFunc) appendCall(r0 BatchesStoreListBatchSpecExecutionCacheEntriesFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// BatchesStoreListBatchSpecExecutionCacheEntriesFuncCall objects describing
+// the invocations of this function.
+func (f *BatchesStoreListBatchSpecExecutionCacheEntriesFunc) History() []BatchesStoreListBatchSpecExecutionCacheEntriesFuncCall {
+	f.mutex.Lock()
+	history := make([]BatchesStoreListBatchSpecExecutionCacheEntriesFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// BatchesStoreListBatchSpecExecutionCacheEntriesFuncCall is an object that
+// describes an invocation of method ListBatchSpecExecutionCacheEntries on
+// an instance of MockBatchesStore.
+type BatchesStoreListBatchSpecExecutionCacheEntriesFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 store.ListBatchSpecExecutionCacheEntriesOpts
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []*types.BatchSpecExecutionCacheEntry
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c BatchesStoreListBatchSpecExecutionCacheEntriesFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c BatchesStoreListBatchSpecExecutionCacheEntriesFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform_test.go
@@ -76,7 +76,7 @@ func TestTransformRecord(t *testing.T) {
 		return nil
 	})
 	store.DatabaseDBFunc.SetDefaultReturn(db)
-	store.GetBatchSpecExecutionCacheEntryFunc.SetDefaultReturn(entry, nil)
+	store.ListBatchSpecExecutionCacheEntriesFunc.SetDefaultReturn([]*btypes.BatchSpecExecutionCacheEntry{entry}, nil)
 
 	wantInput := batcheslib.WorkspacesExecutionInput{
 		RawSpec: batchSpec.RawSpec,

--- a/enterprise/internal/batches/background/batch_spec_workspace_creator.go
+++ b/enterprise/internal/batches/background/batch_spec_workspace_creator.go
@@ -74,8 +74,19 @@ func (r *batchSpecWorkspaceCreator) process(
 
 	log15.Info("resolved workspaces for batch spec", "job", job.ID, "spec", spec.ID, "workspaces", len(workspaces))
 
+	// All changeset specs to be created.
+	cs := make([]*btypes.ChangesetSpec, 0)
+	// Collect all IDs of used cache entries to mark them as recently used later.
+	usedCacheEntries := make([]int64, 0)
 	// Build DB workspaces and check for cache entries.
-	var ws []*btypes.BatchSpecWorkspace
+	ws := make([]*btypes.BatchSpecWorkspace, 0, len(workspaces))
+	// Collect all cache keys so we can look them up in a single query.
+	cacheKeyWorkspaces := make(map[string]struct {
+		dbWorkspace *btypes.BatchSpecWorkspace
+		workspace   *service.RepoWorkspace
+	})
+
+	// Build workspaces DB objects.
 	for _, w := range workspaces {
 		workspace := &btypes.BatchSpecWorkspace{
 			BatchSpecID:      spec.ID,
@@ -104,33 +115,58 @@ func (r *batchSpecWorkspaceCreator) process(
 		if err != nil {
 			return err
 		}
+		cacheKeyWorkspaces[rawKey] = struct {
+			dbWorkspace *btypes.BatchSpecWorkspace
+			workspace   *service.RepoWorkspace
+		}{
+			dbWorkspace: workspace,
+			workspace:   w,
+		}
+	}
 
-		entry, err := tx.GetBatchSpecExecutionCacheEntry(ctx, store.GetBatchSpecExecutionCacheEntryOpts{
-			Key: rawKey,
+	// Fetch all cache entries by their keys.
+	cacheKeys := make([]string, 0, len(cacheKeyWorkspaces))
+	for key := range cacheKeyWorkspaces {
+		cacheKeys = append(cacheKeys, key)
+	}
+	entriesByCacheKey := make(map[string]*btypes.BatchSpecExecutionCacheEntry)
+	changesetsByWorkspace := make(map[*btypes.BatchSpecWorkspace][]*btypes.ChangesetSpec)
+	if len(cacheKeys) > 0 {
+		entries, err := tx.ListBatchSpecExecutionCacheEntries(ctx, store.ListBatchSpecExecutionCacheEntriesOpts{
+			Keys: cacheKeys,
 		})
-		if err != nil && err != store.ErrNoResults {
-			return err
-		}
-		if err == store.ErrNoResults {
-			continue
-		}
-
-		workspace.CachedResultFound = true
-
-		changesetSpecs, err := changesetSpecsFromCache(spec, w, entry)
 		if err != nil {
 			return err
 		}
-		for _, spec := range changesetSpecs {
-			if err := tx.CreateChangesetSpec(ctx, spec); err != nil {
-				return err
-			}
-			workspace.ChangesetSpecIDs = append(workspace.ChangesetSpecIDs, spec.ID)
+		for _, entry := range entries {
+			entriesByCacheKey[entry.Key] = entry
+		}
+	}
+
+	// Check for an existing cache entry for each of the workspaces.
+	for rawKey, workspace := range cacheKeyWorkspaces {
+		entry, ok := entriesByCacheKey[rawKey]
+		if !ok {
+			continue
 		}
 
-		if err := tx.MarkUsedBatchSpecExecutionCacheEntry(ctx, entry.ID); err != nil {
+		workspace.dbWorkspace.CachedResultFound = true
+
+		// Build the changeset specs from the cache entry.
+		changesetSpecs, err := changesetSpecsFromCache(spec, workspace.workspace, entry)
+		if err != nil {
 			return err
 		}
+		cs = append(cs, changesetSpecs...)
+		changesetsByWorkspace[workspace.dbWorkspace] = changesetSpecs
+
+		// And mark the cache entries as used.
+		usedCacheEntries = append(usedCacheEntries, entry.ID)
+	}
+
+	// Mark all used cache entries as recently used for cache eviction purposes.
+	if err := tx.MarkUsedBatchSpecExecutionCacheEntries(ctx, usedCacheEntries); err != nil {
+		return err
 	}
 
 	// If there are "importChangesets" statements in the spec we evaluate
@@ -157,20 +193,28 @@ func (r *batchSpecWorkspaceCreator) process(
 	if err != nil {
 		return err
 	}
-	for _, cs := range specs {
-		repoID, err := graphqlbackend.UnmarshalRepositoryID(graphql.ID(cs.BaseRepository))
+	for _, c := range specs {
+		repoID, err := graphqlbackend.UnmarshalRepositoryID(graphql.ID(c.BaseRepository))
 		if err != nil {
 			return err
 		}
 		changesetSpec := &btypes.ChangesetSpec{
 			UserID:      spec.UserID,
 			RepoID:      repoID,
-			Spec:        cs,
+			Spec:        c,
 			BatchSpecID: spec.ID,
 		}
+		cs = append(cs, changesetSpec)
+	}
 
-		if err = tx.CreateChangesetSpec(ctx, changesetSpec); err != nil {
-			return err
+	if err = tx.CreateChangesetSpec(ctx, cs...); err != nil {
+		return err
+	}
+
+	// Associate the changeset specs with the workspace.
+	for workspace, changesetSpecs := range changesetsByWorkspace {
+		for _, spec := range changesetSpecs {
+			workspace.ChangesetSpecIDs = append(workspace.ChangesetSpecIDs, spec.ID)
 		}
 	}
 

--- a/enterprise/internal/batches/background/batch_spec_workspace_creator.go
+++ b/enterprise/internal/batches/background/batch_spec_workspace_creator.go
@@ -74,10 +74,6 @@ func (r *batchSpecWorkspaceCreator) process(
 
 	log15.Info("resolved workspaces for batch spec", "job", job.ID, "spec", spec.ID, "workspaces", len(workspaces))
 
-	// All changeset specs to be created.
-	cs := make([]*btypes.ChangesetSpec, 0)
-	// Collect all IDs of used cache entries to mark them as recently used later.
-	usedCacheEntries := make([]int64, 0)
 	// Build DB workspaces and check for cache entries.
 	ws := make([]*btypes.BatchSpecWorkspace, 0, len(workspaces))
 	// Collect all cache keys so we can look them up in a single query.
@@ -142,6 +138,11 @@ func (r *batchSpecWorkspaceCreator) process(
 			entriesByCacheKey[entry.Key] = entry
 		}
 	}
+
+	// All changeset specs to be created.
+	cs := make([]*btypes.ChangesetSpec, 0)
+	// Collect all IDs of used cache entries to mark them as recently used later.
+	usedCacheEntries := make([]int64, 0)
 
 	// Check for an existing cache entry for each of the workspaces.
 	for rawKey, workspace := range cacheKeyWorkspaces {

--- a/enterprise/internal/batches/background/batch_spec_workspace_creator_test.go
+++ b/enterprise/internal/batches/background/batch_spec_workspace_creator_test.go
@@ -286,10 +286,14 @@ func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 			t.Fatalf("changeset spec built from cache has wrong diff: %s", haveDiff)
 		}
 
-		reloadedEntry, err := s.GetBatchSpecExecutionCacheEntry(context.Background(), store.GetBatchSpecExecutionCacheEntryOpts{Key: entry.Key})
+		reloadedEntries, err := s.ListBatchSpecExecutionCacheEntries(context.Background(), store.ListBatchSpecExecutionCacheEntriesOpts{Keys: []string{entry.Key}})
 		if err != nil {
 			t.Fatal(err)
 		}
+		if len(reloadedEntries) != 1 {
+			t.Fatal("cache entry not found")
+		}
+		reloadedEntry := reloadedEntries[0]
 		if !reloadedEntry.LastUsedAt.Equal(now) {
 			t.Fatalf("cache entry LastUsedAt not updated. want=%s, have=%s", now, reloadedEntry.LastUsedAt)
 		}
@@ -327,10 +331,14 @@ func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 			},
 		})
 
-		reloadedEntry, err := s.GetBatchSpecExecutionCacheEntry(context.Background(), store.GetBatchSpecExecutionCacheEntryOpts{Key: entry.Key})
+		reloadedEntries, err := s.ListBatchSpecExecutionCacheEntries(context.Background(), store.ListBatchSpecExecutionCacheEntriesOpts{Keys: []string{entry.Key}})
 		if err != nil {
 			t.Fatal(err)
 		}
+		if len(reloadedEntries) != 1 {
+			t.Fatal("cache entry not found")
+		}
+		reloadedEntry := reloadedEntries[0]
 		if !reloadedEntry.LastUsedAt.IsZero() {
 			t.Fatalf("cache entry LastUsedAt updated, but should not be used: %s", reloadedEntry.LastUsedAt)
 		}

--- a/enterprise/internal/batches/background/batch_spec_workspace_execution_worker_test.go
+++ b/enterprise/internal/batches/background/batch_spec_workspace_execution_worker_test.go
@@ -164,10 +164,14 @@ stdout: {"operation":"UPLOADING_CHANGESET_SPECS","timestamp":"2021-09-09T13:20:3
 		}
 
 		for _, wantKey := range cacheEntryKeys {
-			entry, err := s.GetBatchSpecExecutionCacheEntry(ctx, store.GetBatchSpecExecutionCacheEntryOpts{Key: wantKey})
+			entries, err := s.ListBatchSpecExecutionCacheEntries(ctx, store.ListBatchSpecExecutionCacheEntriesOpts{Keys: []string{wantKey}})
 			if err != nil {
 				t.Fatal(err)
 			}
+			if len(entries) != 1 {
+				t.Fatal("cache entry not found")
+			}
+			entry := entries[0]
 
 			var cachedExecutionResult *execution.Result
 			if err := json.Unmarshal([]byte(entry.Value), &cachedExecutionResult); err != nil {

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -214,12 +214,12 @@ func (s *Service) CreateBatchSpec(ctx context.Context, opts CreateBatchSpecOpts)
 		return nil, err
 	}
 
-	for _, changesetSpec := range cs {
-		changesetSpec.BatchSpecID = spec.ID
-
-		if err := tx.UpdateChangesetSpec(ctx, changesetSpec); err != nil {
-			return nil, err
-		}
+	csIDs := make([]int64, 0, len(cs))
+	for _, c := range cs {
+		csIDs = append(csIDs, c.ID)
+	}
+	if err := tx.UpdateChangesetSpecBatchSpecID(ctx, csIDs, spec.ID); err != nil {
+		return nil, err
 	}
 
 	return spec, nil

--- a/enterprise/internal/batches/store/changeset_specs.go
+++ b/enterprise/internal/batches/store/changeset_specs.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"strconv"
 
@@ -14,6 +15,7 @@ import (
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/batch"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
@@ -21,29 +23,42 @@ import (
 
 // changesetSpecInsertColumns is the list of changeset_specs columns that are
 // modified when inserting or updating a changeset spec.
-var changesetSpecInsertColumns = []*sqlf.Query{
-	sqlf.Sprintf("rand_id"),
-	sqlf.Sprintf("spec"),
-	sqlf.Sprintf("batch_spec_id"),
-	sqlf.Sprintf("repo_id"),
-	sqlf.Sprintf("user_id"),
-	sqlf.Sprintf("diff_stat_added"),
-	sqlf.Sprintf("diff_stat_changed"),
-	sqlf.Sprintf("diff_stat_deleted"),
-	sqlf.Sprintf("created_at"),
-	sqlf.Sprintf("updated_at"),
+var changesetSpecInsertColumns = []string{
+	"rand_id",
+	"spec",
+	"batch_spec_id",
+	"repo_id",
+	"user_id",
+	"diff_stat_added",
+	"diff_stat_changed",
+	"diff_stat_deleted",
+	"created_at",
+	"updated_at",
 
 	// `external_id`, `head_ref`, `title` are (for now) write-only columns that
 	// contain normalized data from `spec` and are used for JOINs and WHERE
 	// conditions.
-	sqlf.Sprintf("external_id"),
-	sqlf.Sprintf("head_ref"),
-	sqlf.Sprintf("title"),
+	"external_id",
+	"head_ref",
+	"title",
 }
 
 // changesetSpecColumns are used by the changeset spec related Store methods to
 // insert, update and query changeset specs.
-var changesetSpecColumns = []*sqlf.Query{
+var changesetSpecColumns = []string{
+	"changeset_specs.id",
+	"changeset_specs.rand_id",
+	"changeset_specs.spec",
+	"changeset_specs.batch_spec_id",
+	"changeset_specs.repo_id",
+	"changeset_specs.user_id",
+	"changeset_specs.diff_stat_added",
+	"changeset_specs.diff_stat_changed",
+	"changeset_specs.diff_stat_deleted",
+	"changeset_specs.created_at",
+	"changeset_specs.updated_at",
+}
+var changesetSpecColumnsSQL = []*sqlf.Query{
 	sqlf.Sprintf("changeset_specs.id"),
 	sqlf.Sprintf("changeset_specs.rand_id"),
 	sqlf.Sprintf("changeset_specs.spec"),
@@ -57,142 +72,110 @@ var changesetSpecColumns = []*sqlf.Query{
 	sqlf.Sprintf("changeset_specs.updated_at"),
 }
 
-// CreateChangesetSpec creates the given ChangesetSpec.
-func (s *Store) CreateChangesetSpec(ctx context.Context, c *btypes.ChangesetSpec) (err error) {
-	ctx, endObservation := s.operations.createChangesetSpec.With(ctx, &err, observation.Args{})
-	defer endObservation(1, observation.Args{})
-
-	q, err := s.createChangesetSpecQuery(c)
-	if err != nil {
-		return err
-	}
-
-	return s.query(ctx, q, func(sc dbutil.Scanner) error { return scanChangesetSpec(c, sc) })
-}
-
-var createChangesetSpecQueryFmtstr = `
--- source: enterprise/internal/batches/store_changeset_specs.go:CreateChangesetSpec
-INSERT INTO changeset_specs (%s)
-VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-RETURNING %s`
-
-func (s *Store) createChangesetSpecQuery(c *btypes.ChangesetSpec) (*sqlf.Query, error) {
-	spec, err := jsonbColumn(c.Spec)
-	if err != nil {
-		return nil, err
-	}
-
-	if c.CreatedAt.IsZero() {
-		c.CreatedAt = s.now()
-	}
-
-	if c.UpdatedAt.IsZero() {
-		c.UpdatedAt = c.CreatedAt
-	}
-
-	var externalID, headRef, title *string
-	if c.Spec != nil {
-		if c.Spec.ExternalID != "" {
-			externalID = &c.Spec.ExternalID
-		}
-		if c.Spec.HeadRef != "" {
-			headRef = &c.Spec.HeadRef
-		}
-		if c.Spec.Title != "" {
-			title = &c.Spec.Title
-		}
-	}
-
-	if c.RandID == "" {
-		if c.RandID, err = RandomID(); err != nil {
-			return nil, errors.Wrap(err, "creating RandID failed")
-		}
-	}
-
-	return sqlf.Sprintf(
-		createChangesetSpecQueryFmtstr,
-		sqlf.Join(changesetSpecInsertColumns, ", "),
-		c.RandID,
-		spec,
-		nullInt64Column(c.BatchSpecID),
-		c.RepoID,
-		nullInt32Column(c.UserID),
-		c.DiffStatAdded,
-		c.DiffStatChanged,
-		c.DiffStatDeleted,
-		c.CreatedAt,
-		c.UpdatedAt,
-		&dbutil.NullString{S: externalID},
-		&dbutil.NullString{S: headRef},
-		&dbutil.NullString{S: title},
-		sqlf.Join(changesetSpecColumns, ", "),
-	), nil
-}
-
-// UpdateChangesetSpec updates the given ChangesetSpec.
-func (s *Store) UpdateChangesetSpec(ctx context.Context, c *btypes.ChangesetSpec) (err error) {
-	ctx, endObservation := s.operations.updateChangesetSpec.With(ctx, &err, observation.Args{LogFields: []log.Field{
-		log.Int("ID", int(c.ID)),
+// CreateChangesetSpec creates the given ChangesetSpecs.
+func (s *Store) CreateChangesetSpec(ctx context.Context, cs ...*btypes.ChangesetSpec) (err error) {
+	ctx, endObservation := s.operations.createChangesetSpec.With(ctx, &err, observation.Args{LogFields: []log.Field{
+		log.Int("Count", len(cs)),
 	}})
 	defer endObservation(1, observation.Args{})
 
-	q, err := s.updateChangesetSpecQuery(c)
-	if err != nil {
-		return err
-	}
+	inserter := func(inserter *batch.Inserter) error {
+		for _, c := range cs {
+			spec, err := jsonbColumn(c.Spec)
+			if err != nil {
+				return err
+			}
 
-	return s.query(ctx, q, func(sc dbutil.Scanner) error {
-		return scanChangesetSpec(c, sc)
-	})
+			if c.CreatedAt.IsZero() {
+				c.CreatedAt = s.now()
+			}
+
+			if c.UpdatedAt.IsZero() {
+				c.UpdatedAt = c.CreatedAt
+			}
+
+			var externalID, headRef, title *string
+			if c.Spec != nil {
+				if c.Spec.ExternalID != "" {
+					externalID = &c.Spec.ExternalID
+				}
+				if c.Spec.HeadRef != "" {
+					headRef = &c.Spec.HeadRef
+				}
+				if c.Spec.Title != "" {
+					title = &c.Spec.Title
+				}
+			}
+
+			if c.RandID == "" {
+				if c.RandID, err = RandomID(); err != nil {
+					return errors.Wrap(err, "creating RandID failed")
+				}
+			}
+
+			if err := inserter.Insert(
+				ctx,
+				c.RandID,
+				spec,
+				nullInt64Column(c.BatchSpecID),
+				c.RepoID,
+				nullInt32Column(c.UserID),
+				c.DiffStatAdded,
+				c.DiffStatChanged,
+				c.DiffStatDeleted,
+				c.CreatedAt,
+				c.UpdatedAt,
+				&dbutil.NullString{S: externalID},
+				&dbutil.NullString{S: headRef},
+				&dbutil.NullString{S: title},
+			); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+	i := -1
+	return batch.WithInserterWithReturn(
+		ctx,
+		s.Handle().DB(),
+		"changeset_specs",
+		changesetSpecInsertColumns,
+		"",
+		changesetSpecColumns,
+		func(rows *sql.Rows) error {
+			i++
+			return scanChangesetSpec(cs[i], rows)
+		},
+		inserter,
+	)
 }
 
-var updateChangesetSpecQueryFmtstr = `
--- source: enterprise/internal/batches/store_changeset_specs.go:UpdateChangesetSpec
+// UpdateChangesetSpecBatchSpecID updates the given ChangesetSpecs to be owned by the given batch spec.
+func (s *Store) UpdateChangesetSpecBatchSpecID(ctx context.Context, cs []int64, batchSpec int64) (err error) {
+	ctx, endObservation := s.operations.updateChangesetSpecBatchSpecID.With(ctx, &err, observation.Args{LogFields: []log.Field{
+		log.Int("Count", len(cs)),
+	}})
+	defer endObservation(1, observation.Args{})
+
+	q := s.updateChangesetSpecQuery(cs, batchSpec)
+
+	return s.Exec(ctx, q)
+}
+
+var updateChangesetSpecBatchSpecIDQueryFmtstr = `
+-- source: enterprise/internal/batches/store_changeset_specs.go:UpdateChangesetSpecBatchSpecID
 UPDATE changeset_specs
-SET (%s) = (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-WHERE id = %s
-RETURNING %s`
+SET batch_spec_id = %s
+WHERE id = ANY (%s)
+`
 
-func (s *Store) updateChangesetSpecQuery(c *btypes.ChangesetSpec) (*sqlf.Query, error) {
-	spec, err := jsonbColumn(c.Spec)
-	if err != nil {
-		return nil, err
-	}
-
-	c.UpdatedAt = s.now()
-
-	var externalID, headRef, title *string
-	if c.Spec != nil {
-		if c.Spec.ExternalID != "" {
-			externalID = &c.Spec.ExternalID
-		}
-		if c.Spec.HeadRef != "" {
-			headRef = &c.Spec.HeadRef
-		}
-		if c.Spec.Title != "" {
-			title = &c.Spec.Title
-		}
-	}
-
+func (s *Store) updateChangesetSpecQuery(cs []int64, batchSpec int64) *sqlf.Query {
 	return sqlf.Sprintf(
-		updateChangesetSpecQueryFmtstr,
-		sqlf.Join(changesetSpecInsertColumns, ", "),
-		c.RandID,
-		spec,
-		nullInt64Column(c.BatchSpecID),
-		c.RepoID,
-		nullInt32Column(c.UserID),
-		c.DiffStatAdded,
-		c.DiffStatChanged,
-		c.DiffStatDeleted,
-		c.CreatedAt,
-		c.UpdatedAt,
-		&dbutil.NullString{S: externalID},
-		&dbutil.NullString{S: headRef},
-		&dbutil.NullString{S: title},
-		c.ID,
-		sqlf.Join(changesetSpecColumns, ", "),
-	), nil
+		updateChangesetSpecBatchSpecIDQueryFmtstr,
+		batchSpec,
+		pq.Array(cs),
+	)
 }
 
 // DeleteChangesetSpec deletes the ChangesetSpec with the given ID.
@@ -325,7 +308,7 @@ func getChangesetSpecQuery(opts *GetChangesetSpecOpts) *sqlf.Query {
 
 	return sqlf.Sprintf(
 		getChangesetSpecsQueryFmtstr,
-		sqlf.Join(changesetSpecColumns, ", "),
+		sqlf.Join(changesetSpecColumnsSQL, ", "),
 		sqlf.Join(preds, "\n AND "),
 	)
 }
@@ -405,7 +388,7 @@ func listChangesetSpecsQuery(opts *ListChangesetSpecsOpts) *sqlf.Query {
 
 	return sqlf.Sprintf(
 		listChangesetSpecsQueryFmtstr+opts.LimitOpts.ToDB(),
-		sqlf.Join(changesetSpecColumns, ", "),
+		sqlf.Join(changesetSpecColumnsSQL, ", "),
 		sqlf.Join(preds, "\n AND "),
 	)
 }

--- a/enterprise/internal/batches/store/changeset_specs_test.go
+++ b/enterprise/internal/batches/store/changeset_specs_test.go
@@ -296,23 +296,17 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, clock 
 		})
 	})
 
-	t.Run("Update", func(t *testing.T) {
+	t.Run("UpdateChangesetSpecBatchSpecID", func(t *testing.T) {
 		for _, c := range changesetSpecs {
-			c.UserID += 1234
-			c.DiffStatAdded += 1234
-			c.DiffStatChanged += 1234
-			c.DiffStatDeleted += 1234
-
-			clock.Add(1 * time.Second)
-
-			want := c
-			want.UpdatedAt = clock.Now()
-
-			have := c.Clone()
-			if err := s.UpdateChangesetSpec(ctx, have); err != nil {
+			c.BatchSpecID = 10001
+			want := c.Clone()
+			if err := s.UpdateChangesetSpecBatchSpecID(ctx, []int64{c.ID}, 10001); err != nil {
 				t.Fatal(err)
 			}
-
+			have, err := s.GetChangesetSpecByID(ctx, c.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
 			if diff := cmp.Diff(have, want); diff != "" {
 				t.Fatal(diff)
 			}

--- a/enterprise/internal/batches/store/store.go
+++ b/enterprise/internal/batches/store/store.go
@@ -209,7 +209,7 @@ type operations struct {
 	getChangesetJob    *observation.Operation
 
 	createChangesetSpec                      *observation.Operation
-	updateChangesetSpec                      *observation.Operation
+	updateChangesetSpecBatchSpecID           *observation.Operation
 	deleteChangesetSpec                      *observation.Operation
 	countChangesetSpecs                      *observation.Operation
 	getChangesetSpec                         *observation.Operation
@@ -268,10 +268,10 @@ type operations struct {
 	setBatchSpecWorkspaceExecutionJobAccessToken   *observation.Operation
 	resetBatchSpecWorkspaceExecutionJobAccessToken *observation.Operation
 
-	getBatchSpecExecutionCacheEntry      *observation.Operation
-	markUsedBatchSpecExecutionCacheEntry *observation.Operation
-	createBatchSpecExecutionCacheEntry   *observation.Operation
-	cleanBatchSpecExecutionCacheEntries  *observation.Operation
+	listBatchSpecExecutionCacheEntries     *observation.Operation
+	markUsedBatchSpecExecutionCacheEntries *observation.Operation
+	createBatchSpecExecutionCacheEntry     *observation.Operation
+	cleanBatchSpecExecutionCacheEntries    *observation.Operation
 }
 
 var (
@@ -342,7 +342,7 @@ func newOperations(observationContext *observation.Context) *operations {
 			getChangesetJob:    op("GetChangesetJob"),
 
 			createChangesetSpec:                      op("CreateChangesetSpec"),
-			updateChangesetSpec:                      op("UpdateChangesetSpec"),
+			updateChangesetSpecBatchSpecID:           op("UpdateChangesetSpecBatchSpecID"),
 			deleteChangesetSpec:                      op("DeleteChangesetSpec"),
 			countChangesetSpecs:                      op("CountChangesetSpecs"),
 			getChangesetSpec:                         op("GetChangesetSpec"),
@@ -401,9 +401,9 @@ func newOperations(observationContext *observation.Context) *operations {
 			setBatchSpecWorkspaceExecutionJobAccessToken:   op("SetBatchSpecWorkspaceExecutionJobAccessToken"),
 			resetBatchSpecWorkspaceExecutionJobAccessToken: op("ResetBatchSpecWorkspaceExecutionJobAccessToken"),
 
-			getBatchSpecExecutionCacheEntry:      op("GetBatchSpecExecutionCacheEntry"),
-			markUsedBatchSpecExecutionCacheEntry: op("MarkUsedBatchSpecExecutionCacheEntry"),
-			createBatchSpecExecutionCacheEntry:   op("CreateBatchSpecExecutionCacheEntry"),
+			listBatchSpecExecutionCacheEntries:     op("ListBatchSpecExecutionCacheEntries"),
+			markUsedBatchSpecExecutionCacheEntries: op("MarkUsedBatchSpecExecutionCacheEntries"),
+			createBatchSpecExecutionCacheEntry:     op("CreateBatchSpecExecutionCacheEntry"),
 
 			cleanBatchSpecExecutionCacheEntries: op("CleanBatchSpecExecutionCacheEntries"),
 		}

--- a/enterprise/internal/batches/testing/changeset_spec.go
+++ b/enterprise/internal/batches/testing/changeset_spec.go
@@ -88,7 +88,7 @@ func BuildChangesetSpec(t *testing.T, opts TestSpecOpts) *btypes.ChangesetSpec {
 }
 
 type CreateChangesetSpecer interface {
-	CreateChangesetSpec(ctx context.Context, changesetSpec *btypes.ChangesetSpec) error
+	CreateChangesetSpec(ctx context.Context, changesetSpecs ...*btypes.ChangesetSpec) error
 }
 
 func CreateChangesetSpec(


### PR DESCRIPTION
This takes a very long time on k8s and the trace can't even be rendered, because it's too big. This should fix parts of it by removing N+1 SQL queries.
