### PR TITLE
repos: add Pagure code host support

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.17.2
+golang 1.17.1
 yarn 1.22.4
 fd 7.4.0
 shfmt 3.2.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.17.1
+golang 1.17.2
 yarn 1.22.4
 fd 7.4.0
 shfmt 3.2.0

--- a/client/web/src/components/externalServices/externalServices.tsx
+++ b/client/web/src/components/externalServices/externalServices.tsx
@@ -18,6 +18,7 @@ import gitlabSchemaJSON from '../../../../../schema/gitlab.schema.json'
 import gitoliteSchemaJSON from '../../../../../schema/gitolite.schema.json'
 import jvmPackagesSchemaJSON from '../../../../../schema/jvm-packages.schema.json'
 import otherExternalServiceSchemaJSON from '../../../../../schema/other_external_service.schema.json'
+import pagureSchemaJSON from '../../../../../schema/pagure.schema.json'
 import perforceSchemaJSON from '../../../../../schema/perforce.schema.json'
 import phabricatorSchemaJSON from '../../../../../schema/phabricator.schema.json'
 import { ExternalServiceKind } from '../../graphql-operations'
@@ -1211,6 +1212,27 @@ const JVM_PACKAGES: AddExternalServiceOptions = {
     editorActions: [],
 }
 
+const PAGURE: AddExternalServiceOptions = {
+    kind: ExternalServiceKind.PAGURE,
+    title: 'Pagure',
+    icon: GitIcon,
+    jsonSchema: pagureSchemaJSON,
+    defaultDisplayName: 'Pagure',
+    defaultConfig: `{
+  "url": "https://pagure.example.com",
+}`,
+    instructions: (
+        <div>
+            <ol>
+                <li>
+                    In the configuration below, set <Field>url</Field> to the URL of Pagure instance.
+                </li>
+            </ol>
+        </div>
+    ),
+    editorActions: [],
+}
+
 export const codeHostExternalServices: Record<string, AddExternalServiceOptions> = {
     github: GITHUB_DOTCOM,
     ghe: GITHUB_ENTERPRISE,
@@ -1224,6 +1246,7 @@ export const codeHostExternalServices: Record<string, AddExternalServiceOptions>
     git: GENERIC_GIT,
     ...(window.context?.experimentalFeatures?.perforce === 'enabled' ? { perforce: PERFORCE } : {}),
     ...(window.context?.experimentalFeatures?.jvmPackages === 'enabled' ? { jvmPackages: JVM_PACKAGES } : {}),
+    ...(window.context?.experimentalFeatures?.pagure === 'enabled' ? { pagure: PAGURE } : {}),
 }
 
 export const nonCodeHostExternalServices: Record<string, AddExternalServiceOptions> = {
@@ -1246,4 +1269,5 @@ export const defaultExternalServices: Record<ExternalServiceKind, AddExternalSer
     [ExternalServiceKind.AWSCODECOMMIT]: AWS_CODE_COMMIT,
     [ExternalServiceKind.PERFORCE]: PERFORCE,
     [ExternalServiceKind.JVMPACKAGES]: JVM_PACKAGES,
+    [ExternalServiceKind.PAGURE]: PAGURE,
 }

--- a/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
+++ b/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
@@ -64,6 +64,7 @@ const helpTexts: Record<ExternalServiceKind, JSX.Element> = {
     [ExternalServiceKind.PERFORCE]: <span>Unsupported</span>,
     [ExternalServiceKind.PHABRICATOR]: <span>Unsupported</span>,
     [ExternalServiceKind.AWSCODECOMMIT]: <span>Unsupported</span>,
+    [ExternalServiceKind.PAGURE]: <span>Unsupported</span>,
     [ExternalServiceKind.OTHER]: <span>Unsupported</span>,
 }
 

--- a/client/web/src/enterprise/batches/settings/CodeHostSshPublicKey.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostSshPublicKey.tsx
@@ -17,6 +17,7 @@ const configInstructionLinks: Record<ExternalServiceKind, string> = {
     [ExternalServiceKind.JVMPACKAGES]: 'unsupported',
     [ExternalServiceKind.OTHER]: 'unsupported',
     [ExternalServiceKind.PERFORCE]: 'unsupported',
+    [ExternalServiceKind.PAGURE]: 'unsupported',
     [ExternalServiceKind.PHABRICATOR]: 'unsupported',
 }
 

--- a/client/web/src/site-admin/SiteAdminReportBugPage.tsx
+++ b/client/web/src/site-admin/SiteAdminReportBugPage.tsx
@@ -16,6 +16,7 @@ import gitlabSchemaJSON from '../../../../schema/gitlab.schema.json'
 import gitoliteSchemaJSON from '../../../../schema/gitolite.schema.json'
 import jvmPackagesSchemaJSON from '../../../../schema/jvm-packages.schema.json'
 import otherExternalServiceSchemaJSON from '../../../../schema/other_external_service.schema.json'
+import pagureSchemaJSON from '../../../../schema/pagure.schema.json'
 import perforceSchemaJSON from '../../../../schema/perforce.schema.json'
 import phabricatorSchemaJSON from '../../../../schema/phabricator.schema.json'
 import settingsSchemaJSON from '../../../../schema/settings.schema.json'
@@ -45,6 +46,7 @@ const externalServices: Record<ExternalServiceKind, JSONSchema> = {
     OTHER: otherExternalServiceSchemaJSON,
     PERFORCE: perforceSchemaJSON,
     PHABRICATOR: phabricatorSchemaJSON,
+    PAGURE: pagureSchemaJSON,
 }
 
 const allConfigSchema = {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2233,9 +2233,10 @@ enum ExternalServiceKind {
     GITLAB
     GITOLITE
     JVMPACKAGES
+    OTHER
+    PAGURE
     PERFORCE
     PHABRICATOR
-    OTHER
 }
 
 """

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -236,9 +236,10 @@ var ExternalServiceKinds = map[string]ExternalServiceKind{
 	extsvc.KindGitLab:          {CodeHost: true, JSONSchema: schema.GitLabSchemaJSON},
 	extsvc.KindGitolite:        {CodeHost: true, JSONSchema: schema.GitoliteSchemaJSON},
 	extsvc.KindJVMPackages:     {CodeHost: true, JSONSchema: schema.JVMPackagesSchemaJSON},
+	extsvc.KindOther:           {CodeHost: true, JSONSchema: schema.OtherExternalServiceSchemaJSON},
+	extsvc.KindPagure:          {CodeHost: true, JSONSchema: schema.PagureSchemaJSON},
 	extsvc.KindPerforce:        {CodeHost: true, JSONSchema: schema.PerforceSchemaJSON},
 	extsvc.KindPhabricator:     {CodeHost: true, JSONSchema: schema.PhabricatorSchemaJSON},
-	extsvc.KindOther:           {CodeHost: true, JSONSchema: schema.OtherExternalServiceSchemaJSON},
 }
 
 // ExternalServiceKind describes a kind of external service.

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lib/pq"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/pagure"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -499,6 +500,8 @@ func scanRepo(rows *sql.Rows, r *types.Repo) (err error) {
 		r.Metadata = new(perforce.Depot)
 	case extsvc.TypePhabricator:
 		r.Metadata = new(phabricator.Repo)
+	case extsvc.TypePagure:
+		r.Metadata = new(pagure.Project)
 	case extsvc.TypeOther:
 		r.Metadata = new(extsvc.OtherRepoMetadata)
 	case extsvc.TypeJVMPackages:

--- a/internal/extsvc/pagure/client.go
+++ b/internal/extsvc/pagure/client.go
@@ -16,12 +16,9 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
-	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
-
-var requestCounter = metrics.NewRequestMeter("pagure", "Total number of requests sent to the Pagure API.")
 
 const (
 	defaultRateLimit      = rate.Limit(8) // 480/min or 28,800/hr

--- a/internal/extsvc/pagure/client.go
+++ b/internal/extsvc/pagure/client.go
@@ -1,0 +1,217 @@
+//nolint:bodyclose // Body is closed in Client.Do, but the response is still returned to provide access to the headers
+package pagure
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/inconshreveable/log15"
+	"golang.org/x/time/rate"
+
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
+	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+var requestCounter = metrics.NewRequestMeter("pagure", "Total number of requests sent to the Pagure API.")
+
+const (
+	defaultRateLimit      = rate.Limit(8) // 480/min or 28,800/hr
+	defaultRateLimitBurst = 500
+)
+
+// Client access a Pagure via the REST API.
+type Client struct {
+	// HTTP Client used to communicate with the API
+	httpClient httpcli.Doer
+
+	// Config is the code host connection config for this client
+	Config *schema.PagureConnection
+
+	// URL is the base URL of Pagure.
+	URL *url.URL
+
+	// RateLimit is the self-imposed rate limiter (since Pagure does not have a concept
+	// of rate limiting in HTTP response headers).
+	RateLimit *rate.Limiter
+}
+
+// NewClient returns an authenticated Pagure API client with
+// the provided configuration. If a nil httpClient is provided, http.DefaultClient
+// will be used.
+func NewClient(config *schema.PagureConnection, httpClient httpcli.Doer) (*Client, error) {
+	u, err := url.Parse(config.Url)
+	if err != nil {
+		return nil, err
+	}
+
+	if httpClient == nil {
+		httpClient = httpcli.ExternalDoer
+	}
+
+	// Normally our registry will return a default infinite limiter when nothing has been
+	// synced from config. However, we always want to ensure there is at least some form of rate
+	// limiting for Pagure.
+	defaultLimiter := rate.NewLimiter(defaultRateLimit, defaultRateLimitBurst)
+	l := ratelimit.DefaultRegistry.GetOrSet(u.String(), defaultLimiter)
+
+	return &Client{
+		httpClient: httpClient,
+		Config:     config,
+		URL:        u,
+		RateLimit:  l,
+	}, nil
+}
+
+// ListProjectsArgs defines options to be set on ListProjects method calls.
+type ListProjectsArgs struct {
+	Cursor    *Pagination
+	Tags      []string
+	Pattern   string
+	Namespace string
+	Fork      bool
+}
+
+// ListProjectsResponse defines a response struct returned from ListProjects method calls.
+type ListProjectsResponse struct {
+	*Pagination `json:"pagination"`
+	Projects    []*Project `json:"projects"`
+}
+
+func (c *Client) ListProjects(ctx context.Context, opts ListProjectsArgs) (*ListProjectsResponse, error) {
+	qs := make(url.Values)
+
+	if opts.Cursor == nil {
+		opts.Cursor = &Pagination{PerPage: 100, Page: 1}
+	}
+
+	opts.Cursor.EncodeTo(qs)
+	for _, tag := range opts.Tags {
+		if tag != "" {
+			qs.Add("tags", tag)
+		}
+	}
+
+	if opts.Pattern != "" {
+		qs.Set("pattern", opts.Pattern)
+	}
+
+	if opts.Namespace != "" {
+		qs.Set("namespace", opts.Namespace)
+	}
+
+	qs.Set("fork", strconv.FormatBool(opts.Fork))
+
+	u := url.URL{Path: "api/0/projects", RawQuery: qs.Encode()}
+
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp ListProjectsResponse
+	if _, err = c.do(ctx, req, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+func (c *Client) do(ctx context.Context, req *http.Request, result interface{}) (*http.Response, error) {
+	req.URL = c.URL.ResolveReference(req.URL)
+	if req.Header.Get("Content-Type") == "" && req.Method != "GET" {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	}
+
+	if c.Config.Token != "" {
+		req.Header.Add("Authorization", "token "+c.Config.Token)
+	}
+
+	startWait := time.Now()
+	if err := c.RateLimit.Wait(ctx); err != nil {
+		return nil, err
+	}
+
+	if d := time.Since(startWait); d > 200*time.Millisecond {
+		log15.Warn("Pagure self-enforced API rate limit: request delayed longer than expected due to rate limit", "delay", d)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	bs, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		return nil, errors.WithStack(&httpError{
+			URL:        req.URL,
+			StatusCode: resp.StatusCode,
+			Body:       bs,
+		})
+	}
+
+	return resp, json.Unmarshal(bs, result)
+}
+
+type Pagination struct {
+	First   string `json:"first"`
+	Last    string `json:"last"`
+	Next    string `json:"next"`
+	Page    int    `json:"page"`
+	Pages   int    `json:"pages"`
+	PerPage int    `json:"per_page"`
+	Prev    string `json:"prev"`
+}
+
+func (p *Pagination) EncodeTo(qs url.Values) {
+	if p == nil {
+		return
+	}
+
+	qs.Set("per_page", strconv.FormatInt(int64(p.PerPage), 10))
+	qs.Set("page", strconv.FormatInt(int64(p.Page), 10))
+}
+
+type Project struct {
+	Description string   `json:"description"`
+	FullURL     string   `json:"full_url"`
+	Fullname    string   `json:"fullname"`
+	ID          int      `json:"id"`
+	Name        string   `json:"name"`
+	Namespace   string   `json:"namespace"`
+	Parent      *Project `json:"parent,omitempty"`
+	Tags        []string `json:"tags"`
+	URLPath     string   `json:"url_path"`
+}
+
+type httpError struct {
+	StatusCode int
+	URL        *url.URL
+	Body       []byte
+}
+
+func (e *httpError) Error() string {
+	return fmt.Sprintf("Pagure API HTTP error: code=%d url=%q body=%q", e.StatusCode, e.URL, e.Body)
+}
+
+func (e *httpError) Unauthorized() bool {
+	return e.StatusCode == http.StatusUnauthorized
+}
+
+func (e *httpError) NotFound() bool {
+	return e.StatusCode == http.StatusNotFound
+}

--- a/internal/extsvc/pagure/client_test.go
+++ b/internal/extsvc/pagure/client_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
 )
 

--- a/internal/extsvc/pagure/client_test.go
+++ b/internal/extsvc/pagure/client_test.go
@@ -1,0 +1,41 @@
+package pagure
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
+)
+
+var update = flag.Bool("update", true, "update testdata")
+
+func TestClient_ListProjects(t *testing.T) {
+	cli, save := NewTestClient(t, "ListRepos", *update)
+	defer save()
+
+	ctx := context.Background()
+
+	args := ListProjectsArgs{
+		Cursor:  &Pagination{PerPage: 5, Page: 1},
+		Fork:    true,
+		Pattern: "tmux",
+	}
+
+	resp, err := cli.ListProjects(ctx, args)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testutil.AssertGolden(t, "testdata/golden/ListProjects.json", *update, resp)
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if !testing.Verbose() {
+		log15.Root().SetHandler(log15.LvlFilterHandler(log15.LvlError, log15.Root().GetHandler()))
+	}
+	os.Exit(m.Run())
+}

--- a/internal/extsvc/pagure/testdata/golden/ListProjects.json
+++ b/internal/extsvc/pagure/testdata/golden/ListProjects.json
@@ -1,0 +1,113 @@
+{
+  "pagination": {
+   "first": "https://src.fedoraproject.org/api/0/projects?per_page=5\u0026fork=true\u0026pattern=tmux\u0026page=1",
+   "last": "https://src.fedoraproject.org/api/0/projects?per_page=5\u0026fork=true\u0026pattern=tmux\u0026page=2",
+   "next": "https://src.fedoraproject.org/api/0/projects?per_page=5\u0026fork=true\u0026pattern=tmux\u0026page=2",
+   "page": 1,
+   "pages": 2,
+   "per_page": 5,
+   "prev": ""
+  },
+  "projects": [
+   {
+    "description": "The tmux rpms",
+    "full_url": "https://src.fedoraproject.org/fork/asn/rpms/tmux",
+    "fullname": "forks/asn/rpms/tmux",
+    "id": 27544,
+    "name": "tmux",
+    "namespace": "rpms",
+    "parent": {
+     "description": "The tmux rpms",
+     "full_url": "https://src.fedoraproject.org/rpms/tmux",
+     "fullname": "rpms/tmux",
+     "id": 22343,
+     "name": "tmux",
+     "namespace": "rpms",
+     "tags": [],
+     "url_path": "rpms/tmux"
+    },
+    "tags": [],
+    "url_path": "fork/asn/rpms/tmux"
+   },
+   {
+    "description": "The tmux rpms",
+    "full_url": "https://src.fedoraproject.org/fork/carlwgeorge/rpms/tmux",
+    "fullname": "forks/carlwgeorge/rpms/tmux",
+    "id": 36192,
+    "name": "tmux",
+    "namespace": "rpms",
+    "parent": {
+     "description": "The tmux rpms",
+     "full_url": "https://src.fedoraproject.org/rpms/tmux",
+     "fullname": "rpms/tmux",
+     "id": 22343,
+     "name": "tmux",
+     "namespace": "rpms",
+     "tags": [],
+     "url_path": "rpms/tmux"
+    },
+    "tags": [],
+    "url_path": "fork/carlwgeorge/rpms/tmux"
+   },
+   {
+    "description": "The tmux rpms",
+    "full_url": "https://src.fedoraproject.org/fork/bcl/rpms/tmux",
+    "fullname": "forks/bcl/rpms/tmux",
+    "id": 39507,
+    "name": "tmux",
+    "namespace": "rpms",
+    "parent": {
+     "description": "The tmux rpms",
+     "full_url": "https://src.fedoraproject.org/rpms/tmux",
+     "fullname": "rpms/tmux",
+     "id": 22343,
+     "name": "tmux",
+     "namespace": "rpms",
+     "tags": [],
+     "url_path": "rpms/tmux"
+    },
+    "tags": [],
+    "url_path": "fork/bcl/rpms/tmux"
+   },
+   {
+    "description": "The tmux rpms",
+    "full_url": "https://src.fedoraproject.org/fork/a7ndrew/rpms/tmux",
+    "fullname": "forks/a7ndrew/rpms/tmux",
+    "id": 44211,
+    "name": "tmux",
+    "namespace": "rpms",
+    "parent": {
+     "description": "The tmux rpms",
+     "full_url": "https://src.fedoraproject.org/rpms/tmux",
+     "fullname": "rpms/tmux",
+     "id": 22343,
+     "name": "tmux",
+     "namespace": "rpms",
+     "tags": [],
+     "url_path": "rpms/tmux"
+    },
+    "tags": [],
+    "url_path": "fork/a7ndrew/rpms/tmux"
+   },
+   {
+    "description": "The tmux rpms",
+    "full_url": "https://src.fedoraproject.org/fork/birkch/rpms/tmux",
+    "fullname": "forks/birkch/rpms/tmux",
+    "id": 47213,
+    "name": "tmux",
+    "namespace": "rpms",
+    "parent": {
+     "description": "The tmux rpms",
+     "full_url": "https://src.fedoraproject.org/rpms/tmux",
+     "fullname": "rpms/tmux",
+     "id": 22343,
+     "name": "tmux",
+     "namespace": "rpms",
+     "tags": [],
+     "url_path": "rpms/tmux"
+    },
+    "tags": [],
+    "url_path": "fork/birkch/rpms/tmux"
+   }
+  ]
+ }

--- a/internal/extsvc/pagure/testdata/vcr/ListRepos.yaml
+++ b/internal/extsvc/pagure/testdata/vcr/ListRepos.yaml
@@ -1,0 +1,194 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://src.fedoraproject.org/api/0/projects?fork=true&page=1&pattern=tmux&per_page=5
+    method: GET
+  response:
+    body: "{\n  \"args\": {\n    \"fork\": true, \n    \"namespace\": null, \n    \"owner\":
+      null, \n    \"page\": 1, \n    \"pattern\": \"tmux\", \n    \"per_page\": 5,
+      \n    \"short\": false, \n    \"tags\": [], \n    \"username\": null\n  }, \n
+      \ \"pagination\": {\n    \"first\": \"https://src.fedoraproject.org/api/0/projects?per_page=5&fork=true&pattern=tmux&page=1\",
+      \n    \"last\": \"https://src.fedoraproject.org/api/0/projects?per_page=5&fork=true&pattern=tmux&page=2\",
+      \n    \"next\": \"https://src.fedoraproject.org/api/0/projects?per_page=5&fork=true&pattern=tmux&page=2\",
+      \n    \"page\": 1, \n    \"pages\": 2, \n    \"per_page\": 5, \n    \"prev\":
+      null\n  }, \n  \"projects\": [\n    {\n      \"access_groups\": {\n        \"admin\":
+      [], \n        \"collaborator\": [], \n        \"commit\": [], \n        \"ticket\":
+      []\n      }, \n      \"access_users\": {\n        \"admin\": [], \n        \"collaborator\":
+      [], \n        \"commit\": [], \n        \"owner\": [\n          \"asn\"\n        ],
+      \n        \"ticket\": []\n      }, \n      \"close_status\": [], \n      \"custom_keys\":
+      [], \n      \"date_created\": \"1516987833\", \n      \"date_modified\": \"1516987833\",
+      \n      \"description\": \"The tmux rpms\", \n      \"full_url\": \"https://src.fedoraproject.org/fork/asn/rpms/tmux\",
+      \n      \"fullname\": \"forks/asn/rpms/tmux\", \n      \"id\": 27544, \n      \"milestones\":
+      {}, \n      \"name\": \"tmux\", \n      \"namespace\": \"rpms\", \n      \"parent\":
+      {\n        \"access_groups\": {\n          \"admin\": [], \n          \"collaborator\":
+      [], \n          \"commit\": [], \n          \"ticket\": []\n        }, \n        \"access_users\":
+      {\n          \"admin\": [\n            \"dcantrell\", \n            \"strobert\"\n
+      \         ], \n          \"collaborator\": [], \n          \"commit\": [\n            \"filiperosset\"\n
+      \         ], \n          \"owner\": [\n            \"slankes\"\n          ],
+      \n          \"ticket\": []\n        }, \n        \"close_status\": [], \n        \"custom_keys\":
+      [], \n        \"date_created\": \"1501875088\", \n        \"date_modified\":
+      \"1583420461\", \n        \"description\": \"The tmux rpms\", \n        \"full_url\":
+      \"https://src.fedoraproject.org/rpms/tmux\", \n        \"fullname\": \"rpms/tmux\",
+      \n        \"id\": 22343, \n        \"milestones\": {}, \n        \"name\": \"tmux\",
+      \n        \"namespace\": \"rpms\", \n        \"parent\": null, \n        \"priorities\":
+      {}, \n        \"tags\": [], \n        \"url_path\": \"rpms/tmux\", \n        \"user\":
+      {\n          \"full_url\": \"https://src.fedoraproject.org/user/slankes\", \n
+      \         \"fullname\": \"Sven Lankes\", \n          \"name\": \"slankes\",
+      \n          \"url_path\": \"user/slankes\"\n        }\n      }, \n      \"priorities\":
+      {}, \n      \"tags\": [], \n      \"url_path\": \"fork/asn/rpms/tmux\", \n      \"user\":
+      {\n        \"full_url\": \"https://src.fedoraproject.org/user/asn\", \n        \"fullname\":
+      \"Andreas Schneider\", \n        \"name\": \"asn\", \n        \"url_path\":
+      \"user/asn\"\n      }\n    }, \n    {\n      \"access_groups\": {\n        \"admin\":
+      [], \n        \"collaborator\": [], \n        \"commit\": [], \n        \"ticket\":
+      []\n      }, \n      \"access_users\": {\n        \"admin\": [], \n        \"collaborator\":
+      [], \n        \"commit\": [], \n        \"owner\": [\n          \"carlwgeorge\"\n
+      \       ], \n        \"ticket\": []\n      }, \n      \"close_status\": [],
+      \n      \"custom_keys\": [], \n      \"date_created\": \"1558757308\", \n      \"date_modified\":
+      \"1558757308\", \n      \"description\": \"The tmux rpms\", \n      \"full_url\":
+      \"https://src.fedoraproject.org/fork/carlwgeorge/rpms/tmux\", \n      \"fullname\":
+      \"forks/carlwgeorge/rpms/tmux\", \n      \"id\": 36192, \n      \"milestones\":
+      {}, \n      \"name\": \"tmux\", \n      \"namespace\": \"rpms\", \n      \"parent\":
+      {\n        \"access_groups\": {\n          \"admin\": [], \n          \"collaborator\":
+      [], \n          \"commit\": [], \n          \"ticket\": []\n        }, \n        \"access_users\":
+      {\n          \"admin\": [\n            \"dcantrell\", \n            \"strobert\"\n
+      \         ], \n          \"collaborator\": [], \n          \"commit\": [\n            \"filiperosset\"\n
+      \         ], \n          \"owner\": [\n            \"slankes\"\n          ],
+      \n          \"ticket\": []\n        }, \n        \"close_status\": [], \n        \"custom_keys\":
+      [], \n        \"date_created\": \"1501875088\", \n        \"date_modified\":
+      \"1583420461\", \n        \"description\": \"The tmux rpms\", \n        \"full_url\":
+      \"https://src.fedoraproject.org/rpms/tmux\", \n        \"fullname\": \"rpms/tmux\",
+      \n        \"id\": 22343, \n        \"milestones\": {}, \n        \"name\": \"tmux\",
+      \n        \"namespace\": \"rpms\", \n        \"parent\": null, \n        \"priorities\":
+      {}, \n        \"tags\": [], \n        \"url_path\": \"rpms/tmux\", \n        \"user\":
+      {\n          \"full_url\": \"https://src.fedoraproject.org/user/slankes\", \n
+      \         \"fullname\": \"Sven Lankes\", \n          \"name\": \"slankes\",
+      \n          \"url_path\": \"user/slankes\"\n        }\n      }, \n      \"priorities\":
+      {}, \n      \"tags\": [], \n      \"url_path\": \"fork/carlwgeorge/rpms/tmux\",
+      \n      \"user\": {\n        \"full_url\": \"https://src.fedoraproject.org/user/carlwgeorge\",
+      \n        \"fullname\": \"Carl George\", \n        \"name\": \"carlwgeorge\",
+      \n        \"url_path\": \"user/carlwgeorge\"\n      }\n    }, \n    {\n      \"access_groups\":
+      {\n        \"admin\": [], \n        \"collaborator\": [], \n        \"commit\":
+      [], \n        \"ticket\": []\n      }, \n      \"access_users\": {\n        \"admin\":
+      [], \n        \"collaborator\": [], \n        \"commit\": [], \n        \"owner\":
+      [\n          \"bcl\"\n        ], \n        \"ticket\": []\n      }, \n      \"close_status\":
+      [], \n      \"custom_keys\": [], \n      \"date_created\": \"1575432979\", \n
+      \     \"date_modified\": \"1575432979\", \n      \"description\": \"The tmux
+      rpms\", \n      \"full_url\": \"https://src.fedoraproject.org/fork/bcl/rpms/tmux\",
+      \n      \"fullname\": \"forks/bcl/rpms/tmux\", \n      \"id\": 39507, \n      \"milestones\":
+      {}, \n      \"name\": \"tmux\", \n      \"namespace\": \"rpms\", \n      \"parent\":
+      {\n        \"access_groups\": {\n          \"admin\": [], \n          \"collaborator\":
+      [], \n          \"commit\": [], \n          \"ticket\": []\n        }, \n        \"access_users\":
+      {\n          \"admin\": [\n            \"dcantrell\", \n            \"strobert\"\n
+      \         ], \n          \"collaborator\": [], \n          \"commit\": [\n            \"filiperosset\"\n
+      \         ], \n          \"owner\": [\n            \"slankes\"\n          ],
+      \n          \"ticket\": []\n        }, \n        \"close_status\": [], \n        \"custom_keys\":
+      [], \n        \"date_created\": \"1501875088\", \n        \"date_modified\":
+      \"1583420461\", \n        \"description\": \"The tmux rpms\", \n        \"full_url\":
+      \"https://src.fedoraproject.org/rpms/tmux\", \n        \"fullname\": \"rpms/tmux\",
+      \n        \"id\": 22343, \n        \"milestones\": {}, \n        \"name\": \"tmux\",
+      \n        \"namespace\": \"rpms\", \n        \"parent\": null, \n        \"priorities\":
+      {}, \n        \"tags\": [], \n        \"url_path\": \"rpms/tmux\", \n        \"user\":
+      {\n          \"full_url\": \"https://src.fedoraproject.org/user/slankes\", \n
+      \         \"fullname\": \"Sven Lankes\", \n          \"name\": \"slankes\",
+      \n          \"url_path\": \"user/slankes\"\n        }\n      }, \n      \"priorities\":
+      {}, \n      \"tags\": [], \n      \"url_path\": \"fork/bcl/rpms/tmux\", \n      \"user\":
+      {\n        \"full_url\": \"https://src.fedoraproject.org/user/bcl\", \n        \"fullname\":
+      \"Brian C. Lane\", \n        \"name\": \"bcl\", \n        \"url_path\": \"user/bcl\"\n
+      \     }\n    }, \n    {\n      \"access_groups\": {\n        \"admin\": [],
+      \n        \"collaborator\": [], \n        \"commit\": [], \n        \"ticket\":
+      []\n      }, \n      \"access_users\": {\n        \"admin\": [], \n        \"collaborator\":
+      [], \n        \"commit\": [], \n        \"owner\": [\n          \"a7ndrew\"\n
+      \       ], \n        \"ticket\": []\n      }, \n      \"close_status\": [],
+      \n      \"custom_keys\": [], \n      \"date_created\": \"1594976267\", \n      \"date_modified\":
+      \"1594976267\", \n      \"description\": \"The tmux rpms\", \n      \"full_url\":
+      \"https://src.fedoraproject.org/fork/a7ndrew/rpms/tmux\", \n      \"fullname\":
+      \"forks/a7ndrew/rpms/tmux\", \n      \"id\": 44211, \n      \"milestones\":
+      {}, \n      \"name\": \"tmux\", \n      \"namespace\": \"rpms\", \n      \"parent\":
+      {\n        \"access_groups\": {\n          \"admin\": [], \n          \"collaborator\":
+      [], \n          \"commit\": [], \n          \"ticket\": []\n        }, \n        \"access_users\":
+      {\n          \"admin\": [\n            \"dcantrell\", \n            \"strobert\"\n
+      \         ], \n          \"collaborator\": [], \n          \"commit\": [\n            \"filiperosset\"\n
+      \         ], \n          \"owner\": [\n            \"slankes\"\n          ],
+      \n          \"ticket\": []\n        }, \n        \"close_status\": [], \n        \"custom_keys\":
+      [], \n        \"date_created\": \"1501875088\", \n        \"date_modified\":
+      \"1583420461\", \n        \"description\": \"The tmux rpms\", \n        \"full_url\":
+      \"https://src.fedoraproject.org/rpms/tmux\", \n        \"fullname\": \"rpms/tmux\",
+      \n        \"id\": 22343, \n        \"milestones\": {}, \n        \"name\": \"tmux\",
+      \n        \"namespace\": \"rpms\", \n        \"parent\": null, \n        \"priorities\":
+      {}, \n        \"tags\": [], \n        \"url_path\": \"rpms/tmux\", \n        \"user\":
+      {\n          \"full_url\": \"https://src.fedoraproject.org/user/slankes\", \n
+      \         \"fullname\": \"Sven Lankes\", \n          \"name\": \"slankes\",
+      \n          \"url_path\": \"user/slankes\"\n        }\n      }, \n      \"priorities\":
+      {}, \n      \"tags\": [], \n      \"url_path\": \"fork/a7ndrew/rpms/tmux\",
+      \n      \"user\": {\n        \"full_url\": \"https://src.fedoraproject.org/user/a7ndrew\",
+      \n        \"fullname\": \"Andrew Spiers\", \n        \"name\": \"a7ndrew\",
+      \n        \"url_path\": \"user/a7ndrew\"\n      }\n    }, \n    {\n      \"access_groups\":
+      {\n        \"admin\": [], \n        \"collaborator\": [], \n        \"commit\":
+      [], \n        \"ticket\": []\n      }, \n      \"access_users\": {\n        \"admin\":
+      [], \n        \"collaborator\": [], \n        \"commit\": [], \n        \"owner\":
+      [\n          \"birkch\"\n        ], \n        \"ticket\": []\n      }, \n      \"close_status\":
+      [], \n      \"custom_keys\": [], \n      \"date_created\": \"1607457188\", \n
+      \     \"date_modified\": \"1607457188\", \n      \"description\": \"The tmux
+      rpms\", \n      \"full_url\": \"https://src.fedoraproject.org/fork/birkch/rpms/tmux\",
+      \n      \"fullname\": \"forks/birkch/rpms/tmux\", \n      \"id\": 47213, \n
+      \     \"milestones\": {}, \n      \"name\": \"tmux\", \n      \"namespace\":
+      \"rpms\", \n      \"parent\": {\n        \"access_groups\": {\n          \"admin\":
+      [], \n          \"collaborator\": [], \n          \"commit\": [], \n          \"ticket\":
+      []\n        }, \n        \"access_users\": {\n          \"admin\": [\n            \"dcantrell\",
+      \n            \"strobert\"\n          ], \n          \"collaborator\": [], \n
+      \         \"commit\": [\n            \"filiperosset\"\n          ], \n          \"owner\":
+      [\n            \"slankes\"\n          ], \n          \"ticket\": []\n        },
+      \n        \"close_status\": [], \n        \"custom_keys\": [], \n        \"date_created\":
+      \"1501875088\", \n        \"date_modified\": \"1583420461\", \n        \"description\":
+      \"The tmux rpms\", \n        \"full_url\": \"https://src.fedoraproject.org/rpms/tmux\",
+      \n        \"fullname\": \"rpms/tmux\", \n        \"id\": 22343, \n        \"milestones\":
+      {}, \n        \"name\": \"tmux\", \n        \"namespace\": \"rpms\", \n        \"parent\":
+      null, \n        \"priorities\": {}, \n        \"tags\": [], \n        \"url_path\":
+      \"rpms/tmux\", \n        \"user\": {\n          \"full_url\": \"https://src.fedoraproject.org/user/slankes\",
+      \n          \"fullname\": \"Sven Lankes\", \n          \"name\": \"slankes\",
+      \n          \"url_path\": \"user/slankes\"\n        }\n      }, \n      \"priorities\":
+      {}, \n      \"tags\": [], \n      \"url_path\": \"fork/birkch/rpms/tmux\", \n
+      \     \"user\": {\n        \"full_url\": \"https://src.fedoraproject.org/user/birkch\",
+      \n        \"fullname\": \"Christian Birk\", \n        \"name\": \"birkch\",
+      \n        \"url_path\": \"user/birkch\"\n      }\n    }\n  ], \n  \"total_projects\":
+      7\n}\n"
+    headers:
+      Apptime:
+      - D=226349
+      Content-Length:
+      - "11330"
+      Content-Security-Policy:
+      - default-src 'self'; script-src 'self' 'nonce-tuWCMCthbwwXKYhqKRbnaj9U0' https://apps.fedoraproject.org
+        https://mdapi.fedoraproject.org https://transtats.fedoraproject.org; style-src
+        'self' 'nonce-tuWCMCthbwwXKYhqKRbnaj9U0'; object-src 'none'; base-uri 'self';
+        img-src 'self' https:; connect-src 'self' https://pdc.fedoraproject.org https://apps.fedoraproject.org
+        https://mdapi.fedoraproject.org https://transtats.fedoraproject.org;
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Nov 2021 15:31:07 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Fedora-Appserver:
+      - pkgs01.iad2.fedoraproject.org
+      X-Fedora-Proxyserver:
+      - proxy10.iad2.fedoraproject.org
+      X-Fedora-Requestid:
+      - YZ0JO4v6RRO7ePcIdBY60wAAFZE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/internal/extsvc/pagure/testing.go
+++ b/internal/extsvc/pagure/testing.go
@@ -1,0 +1,74 @@
+package pagure
+
+import (
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dnaeon/go-vcr/cassette"
+
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+// NewTestClient returns a pagure.Client that records its interactions
+// to testdata/vcr/.
+func NewTestClient(t testing.TB, name string, update bool) (*Client, func()) {
+	t.Helper()
+
+	cassete := filepath.Join("testdata/vcr/", normalize(name))
+	rec, err := httptestutil.NewRecorder(cassete, update)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec.SetMatcher(ignoreHostMatcher)
+
+	hc, err := httpcli.NewFactory(nil, httptestutil.NewRecorderOpt(rec)).Doer()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	instanceURL := os.Getenv("PAGURE_URL")
+	if instanceURL == "" {
+		instanceURL = "https://src.fedoraproject.org"
+	}
+
+	c := &schema.PagureConnection{
+		Token: os.Getenv("PAGURE_TOKEN"),
+		Url:   instanceURL,
+	}
+
+	cli, err := NewClient(c, hc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return cli, func() {
+		if err := rec.Stop(); err != nil {
+			t.Errorf("failed to update test data: %s", err)
+		}
+	}
+}
+
+var normalizer = lazyregexp.New("[^A-Za-z0-9-]+")
+
+func normalize(path string) string {
+	return normalizer.ReplaceAllLiteralString(path, "-")
+}
+
+func ignoreHostMatcher(r *http.Request, i cassette.Request) bool {
+	if r.Method != i.Method {
+		return false
+	}
+	u, err := url.Parse(i.URL)
+	if err != nil {
+		return false
+	}
+	u.Host = r.URL.Host
+	u.Scheme = r.URL.Scheme
+	return r.URL.String() == u.String()
+}

--- a/internal/repos/clone_url.go
+++ b/internal/repos/clone_url.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/pagure"
 
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"
@@ -62,6 +63,10 @@ func CloneURL(kind, config string, repo *types.Repo) (string, error) {
 	case *schema.PhabricatorConnection:
 		if r, ok := repo.Metadata.(*phabricator.Repo); ok {
 			return phabricatorCloneURL(r, t), nil
+		}
+	case *schema.PagureConnection:
+		if r, ok := repo.Metadata.(*pagure.Project); ok {
+			return r.FullURL, nil
 		}
 	case *schema.OtherExternalServiceConnection:
 		if r, ok := repo.Metadata.(*extsvc.OtherRepoMetadata); ok {

--- a/internal/repos/pagure.go
+++ b/internal/repos/pagure.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/goware/urlx"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/pagure"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/pagure"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/internal/types"

--- a/internal/repos/pagure.go
+++ b/internal/repos/pagure.go
@@ -1,0 +1,123 @@
+package repos
+
+import (
+	"context"
+	"path"
+	"strconv"
+
+	"github.com/cockroachdb/errors"
+	"github.com/goware/urlx"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/pagure"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/jsonc"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+// A PagureSource yields repositories from a single Pagure connection configured
+// in Sourcegraph via the external services configuration.
+type PagureSource struct {
+	svc       *types.ExternalService
+	cli       *pagure.Client
+	serviceID string
+}
+
+// NewPagureSource returns a new PagureSource from the given external service.
+func NewPagureSource(svc *types.ExternalService, cf *httpcli.Factory) (*PagureSource, error) {
+	var c schema.PagureConnection
+	if err := jsonc.Unmarshal(svc.Config, &c); err != nil {
+		return nil, errors.Wrapf(err, "external service id=%d config error", svc.ID)
+	}
+
+	if cf == nil {
+		cf = httpcli.ExternalClientFactory
+	}
+
+	httpCli, err := cf.Doer()
+	if err != nil {
+		return nil, err
+	}
+
+	cli, err := pagure.NewClient(&c, httpCli)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PagureSource{
+		svc:       svc,
+		cli:       cli,
+		serviceID: extsvc.NormalizeBaseURL(cli.URL).String(),
+	}, nil
+}
+
+// ListRepos returns all Pagure repositories configured with this PagureSource's config.
+func (s *PagureSource) ListRepos(ctx context.Context, results chan SourceResult) {
+	args := pagure.ListProjectsArgs{
+		Cursor:    &pagure.Pagination{PerPage: 100, Page: 1},
+		Tags:      s.cli.Config.Tags,
+		Pattern:   s.cli.Config.Pattern,
+		Namespace: s.cli.Config.Namespace,
+		Fork:      s.cli.Config.Forks,
+	}
+
+	for {
+		page, err := s.cli.ListProjects(ctx, args)
+		if err != nil {
+			results <- SourceResult{Source: s, Err: err}
+			return
+		}
+
+		for _, p := range page.Projects {
+			repo, err := s.makeRepo(p)
+			if err != nil {
+				results <- SourceResult{Source: s, Err: err}
+				return
+			}
+			results <- SourceResult{Source: s, Repo: repo}
+		}
+
+		if page.Next == "" {
+			break
+		}
+
+		args.Cursor = page.Pagination
+	}
+}
+
+// ExternalServices returns a singleton slice containing the external service.
+func (s *PagureSource) ExternalServices() types.ExternalServices {
+	return types.ExternalServices{s.svc}
+}
+
+func (s *PagureSource) makeRepo(p *pagure.Project) (*types.Repo, error) {
+	urn := s.svc.URN()
+
+	fullURL, err := urlx.Parse(p.FullURL)
+	if err != nil {
+		return nil, err
+	}
+
+	name := path.Join(fullURL.Host, fullURL.Path)
+
+	return &types.Repo{
+		Name:        api.RepoName(name),
+		URI:         name,
+		Description: p.Description,
+		Fork:        p.Parent != nil,
+		ExternalRepo: api.ExternalRepoSpec{
+			ID:          strconv.FormatInt(int64(p.ID), 10),
+			ServiceType: extsvc.TypePagure,
+			ServiceID:   s.serviceID,
+		},
+		Sources: map[string]*types.SourceInfo{
+			urn: {
+				ID:       urn,
+				CloneURL: p.FullURL,
+			},
+		},
+		Metadata: p,
+	}, nil
+}

--- a/internal/repos/pagure_test.go
+++ b/internal/repos/pagure_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"

--- a/internal/repos/pagure_test.go
+++ b/internal/repos/pagure_test.go
@@ -1,0 +1,81 @@
+package repos
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func TestPagureSource_ListRepos(t *testing.T) {
+	assertAllReposListed := func(want []string) types.ReposAssertion {
+		return func(t testing.TB, rs types.Repos) {
+			t.Helper()
+
+			have := rs.Names()
+			sort.Strings(have)
+			sort.Strings(want)
+
+			if !reflect.DeepEqual(have, want) {
+				t.Error(cmp.Diff(have, want))
+			}
+		}
+	}
+
+	testCases := []struct {
+		name   string
+		assert types.ReposAssertion
+		conf   *schema.PagureConnection
+		err    string
+	}{
+		{
+			name: "pattern",
+			assert: assertAllReposListed([]string{
+				"src.fedoraproject.org/rpms/tmux",
+			}),
+			conf: &schema.PagureConnection{
+				Url:     "https://src.fedoraproject.org",
+				Pattern: "tmux",
+			},
+			err: "<nil>",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		tc.name = "PAGURE/" + tc.name
+		t.Run(tc.name, func(t *testing.T) {
+			cf, save := newClientFactory(t, tc.name)
+			defer save(t)
+
+			lg := log15.New()
+			lg.SetHandler(log15.DiscardHandler())
+
+			svc := &types.ExternalService{
+				Kind:   extsvc.KindPagure,
+				Config: marshalJSON(t, tc.conf),
+			}
+
+			src, err := NewPagureSource(svc, cf)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			repos, err := listAll(context.Background(), src)
+			if have, want := fmt.Sprint(err), tc.err; have != want {
+				t.Errorf("error:\nhave: %q\nwant: %q", have, want)
+			}
+
+			if tc.assert != nil {
+				tc.assert(t, repos)
+			}
+		})
+	}
+}

--- a/internal/repos/sources.go
+++ b/internal/repos/sources.go
@@ -60,6 +60,8 @@ func NewSource(svc *types.ExternalService, cf *httpcli.Factory) (Source, error) 
 		return NewPerforceSource(svc)
 	case extsvc.KindJVMPackages:
 		return NewJVMPackagesSource(svc)
+	case extsvc.KindPagure:
+		return NewPagureSource(svc, cf)
 	case extsvc.KindOther:
 		return NewOtherSource(svc, cf)
 	default:

--- a/internal/repos/testdata/sources/PAGURE/pattern.yaml
+++ b/internal/repos/testdata/sources/PAGURE/pattern.yaml
@@ -1,0 +1,68 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://src.fedoraproject.org/api/0/projects?fork=false&page=1&pattern=tmux&per_page=100
+    method: GET
+  response:
+    body: "{\n  \"args\": {\n    \"fork\": false, \n    \"namespace\": null, \n    \"owner\":
+      null, \n    \"page\": 1, \n    \"pattern\": \"tmux\", \n    \"per_page\": 100,
+      \n    \"short\": false, \n    \"tags\": [], \n    \"username\": null\n  }, \n
+      \ \"pagination\": {\n    \"first\": \"https://src.fedoraproject.org/api/0/projects?per_page=100&fork=false&pattern=tmux&page=1\",
+      \n    \"last\": \"https://src.fedoraproject.org/api/0/projects?per_page=100&fork=false&pattern=tmux&page=1\",
+      \n    \"next\": null, \n    \"page\": 1, \n    \"pages\": 1, \n    \"per_page\":
+      100, \n    \"prev\": null\n  }, \n  \"projects\": [\n    {\n      \"access_groups\":
+      {\n        \"admin\": [], \n        \"collaborator\": [], \n        \"commit\":
+      [], \n        \"ticket\": []\n      }, \n      \"access_users\": {\n        \"admin\":
+      [\n          \"dcantrell\", \n          \"strobert\"\n        ], \n        \"collaborator\":
+      [], \n        \"commit\": [\n          \"filiperosset\"\n        ], \n        \"owner\":
+      [\n          \"slankes\"\n        ], \n        \"ticket\": []\n      }, \n      \"close_status\":
+      [], \n      \"custom_keys\": [], \n      \"date_created\": \"1501875088\", \n
+      \     \"date_modified\": \"1583420461\", \n      \"description\": \"The tmux
+      rpms\", \n      \"full_url\": \"https://src.fedoraproject.org/rpms/tmux\", \n
+      \     \"fullname\": \"rpms/tmux\", \n      \"id\": 22343, \n      \"milestones\":
+      {}, \n      \"name\": \"tmux\", \n      \"namespace\": \"rpms\", \n      \"parent\":
+      null, \n      \"priorities\": {}, \n      \"tags\": [], \n      \"url_path\":
+      \"rpms/tmux\", \n      \"user\": {\n        \"full_url\": \"https://src.fedoraproject.org/user/slankes\",
+      \n        \"fullname\": \"Sven Lankes\", \n        \"name\": \"slankes\", \n
+      \       \"url_path\": \"user/slankes\"\n      }\n    }\n  ], \n  \"total_projects\":
+      1\n}\n"
+    headers:
+      Apptime:
+      - D=77282
+      Content-Length:
+      - "1633"
+      Content-Security-Policy:
+      - default-src 'self'; script-src 'self' 'nonce-L2i3v8SXpW1FBewhvPkDTP7mZ' https://apps.fedoraproject.org
+        https://mdapi.fedoraproject.org https://transtats.fedoraproject.org; style-src
+        'self' 'nonce-L2i3v8SXpW1FBewhvPkDTP7mZ'; object-src 'none'; base-uri 'self';
+        img-src 'self' https:; connect-src 'self' https://pdc.fedoraproject.org https://apps.fedoraproject.org
+        https://mdapi.fedoraproject.org https://transtats.fedoraproject.org;
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Nov 2021 15:40:20 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Fedora-Appserver:
+      - pkgs01.iad2.fedoraproject.org
+      X-Fedora-Proxyserver:
+      - proxy10.iad2.fedoraproject.org
+      X-Fedora-Requestid:
+      - YZ0LZMjvV8FYLIoWKLLqQgAABpc
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/internal/types/secret.go
+++ b/internal/types/secret.go
@@ -103,6 +103,8 @@ func redactionInfo(cfg interface{}) ([]jsonStringField, error) {
 		return []jsonStringField{}, nil
 	case *schema.JVMPackagesConnection:
 		return []jsonStringField{{[]string{"maven", "credentials"}, &cfg.Maven.Credentials}}, nil
+	case *schema.PagureConnection:
+		return []jsonStringField{{[]string{"token"}, &cfg.Token}}, nil
 	case *schema.OtherExternalServiceConnection:
 		return []jsonStringField{{[]string{"url"}, &cfg.Url}}, nil
 	default:

--- a/schema/pagure.schema.json
+++ b/schema/pagure.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "pagure.schema.json#",
+  "title": "PagureConnection",
+  "description": "Configuration for a connection to Pagure.",
+  "allowComments": true,
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "rateLimit": {
+      "description": "Rate limit applied when making API requests to Pagure.",
+      "title": "PagureRateLimit",
+      "type": "object",
+      "required": ["enabled", "requestsPerHour"],
+      "properties": {
+        "enabled": {
+          "description": "true if rate limiting is enabled.",
+          "type": "boolean",
+          "default": true
+        },
+        "requestsPerHour": {
+          "description": "Requests per hour permitted. This is an average, calculated per second. Internally, the burst limit is set to 500, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 500 requests immediately, provided that the complexity cost of each request is 1.",
+          "type": "number",
+          "default": 28800,
+          "minimum": 0
+        }
+      },
+      "default": {
+        "enabled": true,
+        "requestsPerHour": 28800
+      }
+    },
+    "url": {
+      "description": "URL of a Pagure instance, such as https://pagure.example.com",
+      "type": "string",
+      "examples": ["https://pagure.example.com"]
+    },
+    "token": {
+      "description": "API token for the Pagure instance.",
+      "type": "string",
+      "minLength": 1
+    },
+    "forks": {
+      "description": "If true, it includes forks in the returned projects.",
+      "type": "boolean",
+      "default": false
+    },
+    "pattern": {
+      "description": "Filters projects by pattern string.",
+      "type": "string",
+      "minLength": 1
+    },
+    "namespace": {
+      "description": "Filters projects by namespace.",
+      "type": "string",
+      "minLength": 1
+    },
+    "tags": {
+      "description": "Filters the projects returned by their tags.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -575,6 +575,8 @@ type ExperimentalFeatures struct {
 	EventLogging string `json:"eventLogging,omitempty"`
 	// JvmPackages description: Allow adding JVM packages code host connections
 	JvmPackages string `json:"jvmPackages,omitempty"`
+	// Pagure description: Allow adding Pagure code host connections
+	Pagure string `json:"pagure,omitempty"`
 	// Perforce description: Allow adding Perforce code host connections
 	Perforce string `json:"perforce,omitempty"`
 	// Ranking description: Experimental search result ranking options.
@@ -1186,6 +1188,32 @@ type Overrides struct {
 	Key string `json:"key,omitempty"`
 	// Limit description: The limit per hour, 'unlimited' or 'blocked'
 	Limit interface{} `json:"limit,omitempty"`
+}
+
+// PagureConnection description: Configuration for a connection to Pagure.
+type PagureConnection struct {
+	// Forks description: If true, it includes forks in the returned projects.
+	Forks bool `json:"forks,omitempty"`
+	// Namespace description: Filters projects by namespace.
+	Namespace string `json:"namespace,omitempty"`
+	// Pattern description: Filters projects by pattern string.
+	Pattern string `json:"pattern,omitempty"`
+	// RateLimit description: Rate limit applied when making API requests to Pagure.
+	RateLimit *PagureRateLimit `json:"rateLimit,omitempty"`
+	// Tags description: Filters the projects returned by their tags.
+	Tags []string `json:"tags,omitempty"`
+	// Token description: API token for the Pagure instance.
+	Token string `json:"token,omitempty"`
+	// Url description: URL of a Pagure instance, such as https://pagure.example.com
+	Url string `json:"url,omitempty"`
+}
+
+// PagureRateLimit description: Rate limit applied when making API requests to Pagure.
+type PagureRateLimit struct {
+	// Enabled description: true if rate limiting is enabled.
+	Enabled bool `json:"enabled"`
+	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second. Internally, the burst limit is set to 500, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 500 requests immediately, provided that the complexity cost of each request is 1.
+	RequestsPerHour float64 `json:"requestsPerHour"`
 }
 
 // ParentSourcegraph description: URL to fetch unreachable repository details from. Defaults to "https://sourcegraph.com"

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -125,6 +125,12 @@
           "enum": ["enabled", "disabled"],
           "default": "enabled"
         },
+        "pagure": {
+          "description": "Allow adding Pagure code host connections",
+          "type": "string",
+          "enum": ["enabled", "disabled"],
+          "default": "disabled"
+        },
         "subRepoPermissions": {
           "type": "object",
           "additionalProperties": false,

--- a/schema/stringdata.go
+++ b/schema/stringdata.go
@@ -50,6 +50,10 @@ var PerforceSchemaJSON string
 //go:embed phabricator.schema.json
 var PhabricatorSchemaJSON string
 
+// PagureSchemaJSON is the content of the file "pagure.schema.json".
+//go:embed pagure.schema.json
+var PagureSchemaJSON string
+
 // SettingsSchemaJSON is the content of the file "settings.schema.json".
 //go:embed settings.schema.json
 var SettingsSchemaJSON string


### PR DESCRIPTION
This commit adds Pagure code host support, disabled by default in site
config. This will allow us to sync repos from src.fedoraproject.org on
sourcegraph.com.

Part of #28028