### PR TITLE
database: include src.fedoraproject.org repos in ListIndexable

### DIFF
--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -1151,6 +1151,8 @@ WHERE
 	(
 		repo.stars >= %s
 		OR
+		lower(repo.name) LIKE 'src.fedoraproject.org/%%'
+		OR
 		repo.id IN (
 			SELECT
 				repo_id


### PR DESCRIPTION
Ideally we'd want Fedora project to be an org in Sourcegraph.com, but
we don't yet support any other code hosts than github.com or
gitlab.com, and search contexts aren't integrated with this code path,
so we choose the hacky, yet simpler, change.

Part of #28028



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
