### PR TITLE
Disable browser extension for private repositories when using cloud URL

### DIFF
--- a/client/browser/CHANGELOG.md
+++ b/client/browser/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to Sourcegraph [Browser Extensions](./README.md) are documen
 - Fix excessive "all websites" permissions for Safari [#issues/23542](https://github.com/sourcegraph/sourcegraph/issues/23542), [#pull/26832](https://github.com/sourcegraph/sourcegraph/pull/26832)
 - Update private repository detection logic for Gitlab and Github [#issues/27382](https://github.com/sourcegraph/sourcegraph/issues/27382), [#pull/27779](https://github.com/sourcegraph/sourcegraph/pull/27779)
 - Fix open file diff bug for Sourcegraph URL with trailing slash [#26832](https://github.com/sourcegraph/sourcegraph/pull/28058)
+- Disable (temporarily) browser extension for private repositories when using Sourcegraph Cloud URL [#issues/28070](https://github.com/sourcegraph/sourcegraph/issues/28070), [#pull/28089](https://github.com/sourcegraph/sourcegraph/pull/28089)
 
 ## Chrome / Firefox v21.11.8.1804, Safari v1.7
 

--- a/client/browser/README.md
+++ b/client/browser/README.md
@@ -140,8 +140,12 @@ Click reload for Sourcegraph at `about:debugging`
 ## Testing
 
 - Unit tests: `sg test bext`
-- Integration tests: `sg test bext-integration`
+- Integration tests:
+  - Install puppeteer: `yarn run download-puppeteer-browser`
+  - `EXTENSION_PERMISSIONS_ALL_URLS=true yarn --cwd client/browser build`
+  - `sg test bext-integration`
 - E2E tests:
+  - Install puppeteer: `yarn run download-puppeteer-browser`
   - `EXTENSION_PERMISSIONS_ALL_URLS=true yarn --cwd client/browser build`
   - `sg test bext-e2e`
 

--- a/client/browser/README.md
+++ b/client/browser/README.md
@@ -140,14 +140,8 @@ Click reload for Sourcegraph at `about:debugging`
 ## Testing
 
 - Unit tests: `sg test bext`
-- Integration tests:
-  - Install puppeteer: `yarn run download-puppeteer-browser`
-  - `EXTENSION_PERMISSIONS_ALL_URLS=true yarn --cwd client/browser build`
-  - `sg test bext-integration`
-- E2E tests:
-  - Install puppeteer: `yarn run download-puppeteer-browser`
-  - `EXTENSION_PERMISSIONS_ALL_URLS=true yarn --cwd client/browser build`
-  - `sg test bext-e2e`
+- Integration tests: `sg test bext-build` & `sg test bext-integration`
+- E2E tests: `sg test bext-build` & `sg test bext-e2e`
 
 ### E2E tests
 

--- a/client/browser/src/browser-extension/scripts/contentPage.main.ts
+++ b/client/browser/src/browser-extension/scripts/contentPage.main.ts
@@ -95,7 +95,7 @@ async function main(): Promise<void> {
         // eslint-disable-next-line rxjs/no-async-subscribe, @typescript-eslint/no-misused-promises
         observeSourcegraphURL(IS_EXTENSION).subscribe(async sourcegraphURL => {
             if (previousSubscription) {
-                console.log('[Sourcegraph] Detached code intelligence')
+                console.log('Sourcegraph detached code intelligence')
                 previousSubscription.unsubscribe()
             }
 
@@ -114,7 +114,7 @@ async function main(): Promise<void> {
                             const { privateRepository } = await codeHost.getContext()
                             if (privateRepository) {
                                 throw new Error(
-                                    'Code-intel for private repository on Sourcegraph Cloud is not supported yet.'
+                                    `Code intelligence for private repository is not supported when using Sourcegraph URL ${DEFAULT_SOURCEGRAPH_URL}`
                                 )
                             }
                         }
@@ -132,9 +132,9 @@ async function main(): Promise<void> {
                         await Promise.all(styleSheets.map(loadStyleSheet).map(waitForStyleSheet))
                     }
                 )
-                console.log('Attached code intelligence')
+                console.log('Sourcegraph attached code intelligence')
             } catch (error) {
-                console.warn('Code intelligence stopped working. Reason:', error?.message)
+                console.log('Sourcegraph code host integration stopped initialization. Reason:', error?.message)
             }
         })
     )

--- a/client/browser/src/browser-extension/scripts/contentPage.main.ts
+++ b/client/browser/src/browser-extension/scripts/contentPage.main.ts
@@ -5,7 +5,7 @@ import { first } from 'rxjs/operators'
 
 import { setLinkComponent, AnchorLink } from '@sourcegraph/shared/src/components/Link'
 
-import { determineCodeHost } from '../../shared/code-hosts/shared/codeHost'
+import { CodeHost, determineCodeHost } from '../../shared/code-hosts/shared/codeHost'
 import { injectCodeIntelligence } from '../../shared/code-hosts/shared/inject'
 import {
     checkIsSourcegraph,
@@ -15,10 +15,9 @@ import {
     signalBrowserExtensionInstalled,
 } from '../../shared/code-hosts/sourcegraph/inject'
 import { initSentry } from '../../shared/sentry'
-import { DEFAULT_SOURCEGRAPH_URL, getAssetsURL } from '../../shared/util/context'
+import { DEFAULT_SOURCEGRAPH_URL, getAssetsURL, observeSourcegraphURL } from '../../shared/util/context'
 import { featureFlags } from '../../shared/util/featureFlags'
 import { assertEnvironment } from '../environmentAssertion'
-import { storage } from '../web-extension-api/storage'
 
 const subscriptions = new Subscription()
 window.addEventListener('unload', () => subscriptions.unsubscribe(), { once: true })
@@ -91,34 +90,53 @@ async function main(): Promise<void> {
         .pipe(first())
         .toPromise()
 
-    const items = await storage.sync.get()
-    const sourcegraphURL = items.sourcegraphURL || DEFAULT_SOURCEGRAPH_URL
-
-    const isSourcegraphServer = checkIsSourcegraph(sourcegraphURL)
-    if (isSourcegraphServer) {
-        signalBrowserExtensionInstalled()
-        return
-    }
-
+    let previousSubscription: Subscription
     subscriptions.add(
-        await injectCodeIntelligence(
-            { sourcegraphURL, assetsURL: getAssetsURL(DEFAULT_SOURCEGRAPH_URL) },
-            IS_EXTENSION,
-            async function onCodeHostFound() {
-                const styleSheets = [
-                    {
-                        id: 'ext-style-sheet',
-                        path: 'css/style.bundle.css',
-                    },
-                    {
-                        id: 'ext-style-sheet-css-modules',
-                        path: 'css/inject.bundle.css',
-                    },
-                ]
-
-                await Promise.all(styleSheets.map(loadStyleSheet).map(waitForStyleSheet))
+        // eslint-disable-next-line rxjs/no-async-subscribe, @typescript-eslint/no-misused-promises
+        observeSourcegraphURL(IS_EXTENSION).subscribe(async sourcegraphURL => {
+            if (previousSubscription) {
+                console.log('[Sourcegraph] Detached code intelligence')
+                previousSubscription.unsubscribe()
             }
-        )
+
+            const isSourcegraphServer = checkIsSourcegraph(sourcegraphURL)
+            if (isSourcegraphServer) {
+                signalBrowserExtensionInstalled()
+                return
+            }
+
+            try {
+                previousSubscription = await injectCodeIntelligence(
+                    { sourcegraphURL, assetsURL: getAssetsURL(DEFAULT_SOURCEGRAPH_URL) },
+                    IS_EXTENSION,
+                    async function onCodeHostFound(codeHost: CodeHost) {
+                        if (sourcegraphURL === DEFAULT_SOURCEGRAPH_URL && codeHost.getContext) {
+                            const { privateRepository } = await codeHost.getContext()
+                            if (privateRepository) {
+                                throw new Error(
+                                    'Code-intel for private repository on Sourcegraph Cloud is not supported yet.'
+                                )
+                            }
+                        }
+                        const styleSheets = [
+                            {
+                                id: 'ext-style-sheet',
+                                path: 'css/style.bundle.css',
+                            },
+                            {
+                                id: 'ext-style-sheet-css-modules',
+                                path: 'css/inject.bundle.css',
+                            },
+                        ]
+
+                        await Promise.all(styleSheets.map(loadStyleSheet).map(waitForStyleSheet))
+                    }
+                )
+                console.log('Attached code intelligence')
+            } catch (error) {
+                console.warn('Code intelligence stopped working. Reason:', error?.message)
+            }
+        })
     )
 
     // Clean up susbscription if the native integration gets activated

--- a/client/browser/src/integration/github.test.ts
+++ b/client/browser/src/integration/github.test.ts
@@ -42,7 +42,7 @@ describe('GitHub', () => {
             response
                 .status(200)
                 .setHeader('Access-Control-Allow-Origin', 'https://github.com')
-                .send(JSON.stringify({ visibility: 'private' }))
+                .send(JSON.stringify({ private: 'true' }))
         })
 
         testContext.overrideGraphQL({

--- a/client/browser/src/integration/github.test.ts
+++ b/client/browser/src/integration/github.test.ts
@@ -42,7 +42,7 @@ describe('GitHub', () => {
             response
                 .status(200)
                 .setHeader('Access-Control-Allow-Origin', 'https://github.com')
-                .send(JSON.stringify({ private: 'true' }))
+                .send(JSON.stringify({ private: false }))
         })
 
         testContext.overrideGraphQL({

--- a/client/browser/src/integration/gitlab.test.ts
+++ b/client/browser/src/integration/gitlab.test.ts
@@ -36,6 +36,10 @@ describe('GitLab', () => {
             response.sendStatus(200)
         })
 
+        testContext.server.any('https://gitlab.com/api/v4/projects/*').intercept((request, response) => {
+            response.sendStatus(200).send(JSON.stringify({ visibility: 'public' }))
+        })
+
         testContext.overrideGraphQL({
             ViewerConfiguration: () => ({
                 viewerConfiguration: {

--- a/client/browser/src/shared/code-hosts/github/codeHost.ts
+++ b/client/browser/src/shared/code-hosts/github/codeHost.ts
@@ -385,6 +385,7 @@ export const isPrivateRepository = (
     }
     return fetchCache<{ private?: boolean }>({
         url: `https://api.github.com/repos/${repoName}`,
+        credentials: 'omit',
         cacheMaxAge: 60 * 60 * 1000, // 1 hour
     })
         .then(response => {

--- a/client/browser/src/shared/code-hosts/gitlab/scrape.ts
+++ b/client/browser/src/shared/code-hosts/gitlab/scrape.ts
@@ -1,6 +1,6 @@
 import { last, take } from 'lodash'
 
-import { FileSpec, RawRepoSpec, RevisionSpec } from '@sourcegraph/shared/src/util/url'
+import { FileSpec, RawRepoSpec, RepoSpec, RevisionSpec } from '@sourcegraph/shared/src/util/url'
 
 import { isExtension } from '../../context'
 import { commitIDFromPermalink } from '../../util/dom'
@@ -16,12 +16,11 @@ export enum GitLabPageKind {
 /**
  * General information that can be found on any GitLab page that we care about. (i.e. has code)
  */
-export interface GitLabInfo extends RawRepoSpec {
+export interface GitLabInfo extends RawRepoSpec, RepoSpec {
     pageKind: GitLabPageKind
 
     owner: string
     projectName: string
-    projectId?: string
 }
 
 /**
@@ -65,14 +64,12 @@ export function getPageInfo(): GitLabInfo {
     const pageKind = getPageKindFromPathName(owner, projectName, window.location.pathname)
     const hostname = isExtension ? window.location.hostname : new URL(gon.gitlab_url).hostname
 
-    const projectId = document.querySelector<HTMLInputElement>('#search_project_id')?.value
-
     return {
         owner,
         projectName,
         rawRepoName: [hostname, owner, projectName].join('/'),
+        repoName: projectFullName,
         pageKind,
-        projectId,
     }
 }
 

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -980,7 +980,7 @@ tests:
   bext:
     cmd: yarn --cwd client/browser test
 
-  bext-pretest:
+  bext-build:
     cmd: yarn run download-puppeteer-browser && EXTENSION_PERMISSIONS_ALL_URLS=true yarn --cwd client/browser build
 
   bext-integration:

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -980,12 +980,14 @@ tests:
   bext:
     cmd: yarn --cwd client/browser test
 
+  bext-pretest:
+    cmd: yarn run download-puppeteer-browser && EXTENSION_PERMISSIONS_ALL_URLS=true yarn --cwd client/browser build
+
   bext-integration:
     cmd: yarn --cwd client/browser test-integration
-    install: yarn run download-puppeteer-browser && EXTENSION_PERMISSIONS_ALL_URLS=true yarn --cwd client/browser build
 
   bext-e2e:
-    cmd: yarn run download-puppeteer-browser && yarn --cwd client/browser mocha ./src/end-to-end/github.test.ts ./src/end-to-end/gitlab.test.ts
+    cmd: yarn --cwd client/browser mocha ./src/end-to-end/github.test.ts ./src/end-to-end/gitlab.test.ts
     env:
       SOURCEGRAPH_BASE_URL: https://sourcegraph.com
       PERCY_BROWSER_EXECUTABLE: node_modules/puppeteer/.local-chromium/linux-901812/chrome-linux/chrome

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -982,6 +982,7 @@ tests:
 
   bext-integration:
     cmd: yarn --cwd client/browser test-integration
+    install: yarn run download-puppeteer-browser && EXTENSION_PERMISSIONS_ALL_URLS=true yarn --cwd client/browser build
 
   bext-e2e:
     cmd: yarn run download-puppeteer-browser && yarn --cwd client/browser mocha ./src/end-to-end/github.test.ts ./src/end-to-end/gitlab.test.ts


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/28070.

> Blocked by https://github.com/sourcegraph/sourcegraph/pull/27779 until its merged
#### Description

This PR:
- Temporarily disabled browser extension for private repositories when using cloud URL
> Until we figure out on the safe way to determine if repository exist on Sourcegraph or not

#### Before merging

- [ ] Test on different code hosts (if applicable)
    - [ ] GitHub
    - [ ] Gitlab
    - [ ] GitHub Enterprise
    - [ ] Refined GitHub
    - [ ] Phabricator
    - [ ] Phabricator integration
    - [ ] Bitbucket
    - [ ] Bitbucket integration

- [ ] Test on different browsers (if applicable)
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
- [x] Add change log message to [client/browser/CHANGELOG.md](./client/browser/CHANGELOG.md), under "Unreleased" section. (if applicable)
