### PR TITLE
all: set User-Agent in external HTTP requests (take 2)

### DIFF
--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -190,6 +190,10 @@ func configureRemoteGitCommand(cmd *exec.Cmd, tlsConf *tlsConfig) {
 	// And set a timeout to avoid indefinite hangs if the server is unreachable.
 	cmd.Env = append(cmd.Env, "GIT_SSH_COMMAND=ssh -o BatchMode=yes -o ConnectTimeout=30")
 
+	// Identify HTTP requests with a user agent. Please keep the git/ prefix because GitHub breaks the protocol v2
+	// negotiation of clone URLs without a `.git` suffix (which we use) without it. Don't ask.
+	cmd.Env = append(cmd.Env, "GIT_HTTP_USER_AGENT=git/Sourcegraph-Bot")
+
 	if tlsConf.SSLNoVerify {
 		cmd.Env = append(cmd.Env, "GIT_SSL_NO_VERIFY=true")
 	}

--- a/cmd/gitserver/server/serverutil_test.go
+++ b/cmd/gitserver/server/serverutil_test.go
@@ -17,6 +17,7 @@ func TestConfigureRemoteGitCommand(t *testing.T) {
 	expectedEnv := []string{
 		"GIT_ASKPASS=true",
 		"GIT_SSH_COMMAND=ssh -o BatchMode=yes -o ConnectTimeout=30",
+		"GIT_HTTP_USER_AGENT=git/Sourcegraph-Bot",
 	}
 	tests := []struct {
 		input        *exec.Cmd
@@ -82,6 +83,7 @@ func TestConfigureRemoteGitCommand_tls(t *testing.T) {
 	baseEnv := []string{
 		"GIT_ASKPASS=true",
 		"GIT_SSH_COMMAND=ssh -o BatchMode=yes -o ConnectTimeout=30",
+		"GIT_HTTP_USER_AGENT=git/Sourcegraph-Bot",
 	}
 
 	cases := []struct {

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -98,6 +98,7 @@ func NewExternalClientFactory() *Factory {
 	return NewFactory(
 		NewMiddleware(
 			ContextErrorMiddleware,
+			HeadersMiddleware("User-Agent", "Sourcegraph-Bot"),
 		),
 		NewTimeoutOpt(externalTimeout),
 		// ExternalTransportOpt needs to be before TracedTransportOpt and


### PR DESCRIPTION
This commit makes us set a User-Agent in external HTTP requests (both
in gitserver git commands and any requests done through the
httpcli.ExternalClientFactory).

Since src.fedoraproject.org is all open and doesn't require an access
token, they asked us to set a User-Agent to distinguish our traffic.

Part of #28028
