### PR TITLE
Revert "Revert "Revert "all: set User-Agent in external HTTP requests…

### DIFF
--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -190,9 +190,6 @@ func configureRemoteGitCommand(cmd *exec.Cmd, tlsConf *tlsConfig) {
 	// And set a timeout to avoid indefinite hangs if the server is unreachable.
 	cmd.Env = append(cmd.Env, "GIT_SSH_COMMAND=ssh -o BatchMode=yes -o ConnectTimeout=30")
 
-	// Identify HTTP requests with a user agent.
-	cmd.Env = append(cmd.Env, "GIT_HTTP_USER_AGENT=Sourcegraph-Bot")
-
 	if tlsConf.SSLNoVerify {
 		cmd.Env = append(cmd.Env, "GIT_SSL_NO_VERIFY=true")
 	}

--- a/cmd/gitserver/server/serverutil_test.go
+++ b/cmd/gitserver/server/serverutil_test.go
@@ -17,7 +17,6 @@ func TestConfigureRemoteGitCommand(t *testing.T) {
 	expectedEnv := []string{
 		"GIT_ASKPASS=true",
 		"GIT_SSH_COMMAND=ssh -o BatchMode=yes -o ConnectTimeout=30",
-		"GIT_HTTP_USER_AGENT=Sourcegraph-Bot",
 	}
 	tests := []struct {
 		input        *exec.Cmd
@@ -83,7 +82,6 @@ func TestConfigureRemoteGitCommand_tls(t *testing.T) {
 	baseEnv := []string{
 		"GIT_ASKPASS=true",
 		"GIT_SSH_COMMAND=ssh -o BatchMode=yes -o ConnectTimeout=30",
-		"GIT_HTTP_USER_AGENT=Sourcegraph-Bot",
 	}
 
 	cases := []struct {

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -98,7 +98,6 @@ func NewExternalClientFactory() *Factory {
 	return NewFactory(
 		NewMiddleware(
 			ContextErrorMiddleware,
-			HeadersMiddleware("User-Agent", "Sourcegraph-Bot"),
 		),
 		NewTimeoutOpt(externalTimeout),
 		// ExternalTransportOpt needs to be before TracedTransportOpt and


### PR DESCRIPTION
… (#28086)"""

This reverts commit f38bbfa6176f3546f43cf4c2c1f9c85fbc249c46.

I've rotated the token and the build is still broken by this change (initial revert passed on an agent with the old token, revert of revert failed on the new token)

It's likely the user agent set here is causing GHE to redirect us to a login page:

```
lvl=warn msg="error cloning repo" repo=github.com/sgtest/go-diff err="error cloning repo: repo github.com/sgtest/go-diff not cloneable: exit status 128 (output follows)\n\nfatal: unable to update url base from redirection:\n  asked for: https://<redacted>@ghe.sgdev.org/sgtest/go-diff/info/refs?service=git-upload-pack\n   redirect: https://ghe.sgdev.org/login?return_to=https%3A%2F%2Fghe.sgdev.org%2Fsgtest%2Fgo-diff%2Finfo%2Frefs%3Fservice%3Dgit-upload-pack"
```

This breaks access to all the test repositories we have hosted on ghe.sgdev.org (which shows up in the tests as `github.com` repositories despite not actually being github.com repositories for testing purposes, presumably: https://github.com/sourcegraph/sourcegraph/blob/452f894f8f2026bfa46bc97fc509fe2f90949097/dev/gqltest/search_test.go#L34-L46 )

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
