### PR TITLE
Allow Redis alerts to not have data

### DIFF
--- a/monitoring/definitions/postgres.go
+++ b/monitoring/definitions/postgres.go
@@ -31,6 +31,7 @@ func Postgres() *monitoring.Container {
 						Name:              "connections",
 						Description:       "active connections",
 						Owner:             monitoring.ObservableOwnerCoreApplication,
+						DataMustExist:     false, // not deployed on docker-compose
 						Query:             `sum by (job) (pg_stat_activity_count{datname!~"template.*|postgres|cloudsqladmin"})`,
 						Panel:             monitoring.Panel().LegendFormat("{{datname}}"),
 						Warning:           monitoring.Alert().LessOrEqual(5, nil).For(5 * time.Minute),
@@ -40,6 +41,7 @@ func Postgres() *monitoring.Container {
 						Name:              "transaction_durations",
 						Description:       "maximum transaction durations",
 						Owner:             monitoring.ObservableOwnerCoreApplication,
+						DataMustExist:     false, // not deployed on docker-compose
 						Query:             `sum by (datname) (pg_stat_activity_max_tx_duration{datname!~"template.*|postgres|cloudsqladmin"})`,
 						Panel:             monitoring.Panel().LegendFormat("{{datname}}").Unit(monitoring.Seconds),
 						Warning:           monitoring.Alert().GreaterOrEqual(0.3, nil).For(5 * time.Minute),
@@ -58,6 +60,7 @@ func Postgres() *monitoring.Container {
 							Name:              "postgres_up",
 							Description:       "database availability",
 							Owner:             monitoring.ObservableOwnerCoreApplication,
+							DataMustExist:     false, // not deployed on docker-compose
 							Query:             "pg_up",
 							Panel:             monitoring.Panel().LegendFormat("{{app}}"),
 							Critical:          monitoring.Alert().LessOrEqual(0, nil).For(5 * time.Minute),
@@ -65,12 +68,13 @@ func Postgres() *monitoring.Container {
 							Interpretation:    "A non-zero value indicates the database is online.",
 						},
 						monitoring.Observable{
-							Name:        "invalid_indexes",
-							Description: "invalid indexes (unusable by the query planner)",
-							Owner:       monitoring.ObservableOwnerCoreApplication,
-							Query:       "max by (relname)(pg_invalid_index_count)",
-							Panel:       monitoring.Panel().LegendFormat("{{relname}}"),
-							Critical:    monitoring.Alert().GreaterOrEqual(1, &sumAggregator).For(0),
+							Name:          "invalid_indexes",
+							Description:   "invalid indexes (unusable by the query planner)",
+							Owner:         monitoring.ObservableOwnerCoreApplication,
+							DataMustExist: false, // not deployed on docker-compose
+							Query:         "max by (relname)(pg_invalid_index_count)",
+							Panel:         monitoring.Panel().LegendFormat("{{relname}}"),
+							Critical:      monitoring.Alert().GreaterOrEqual(1, &sumAggregator).For(0),
 							PossibleSolutions: `
 								- Drop and re-create the invalid trigger - please contact Sourcegraph to supply the trigger definition.
 							`,
@@ -79,12 +83,13 @@ func Postgres() *monitoring.Container {
 					},
 					{
 						monitoring.Observable{
-							Name:        "pg_exporter_err",
-							Description: "errors scraping postgres exporter",
-							Owner:       monitoring.ObservableOwnerCoreApplication,
-							Query:       "pg_exporter_last_scrape_error",
-							Panel:       monitoring.Panel().LegendFormat("{{app}}"),
-							Warning:     monitoring.Alert().GreaterOrEqual(1, nil).For(5 * time.Minute),
+							Name:          "pg_exporter_err",
+							Description:   "errors scraping postgres exporter",
+							Owner:         monitoring.ObservableOwnerCoreApplication,
+							DataMustExist: false, // not deployed on docker-compose
+							Query:         "pg_exporter_last_scrape_error",
+							Panel:         monitoring.Panel().LegendFormat("{{app}}"),
+							Warning:       monitoring.Alert().GreaterOrEqual(1, nil).For(5 * time.Minute),
 							PossibleSolutions: `
 								- Ensure the Postgres exporter can access the Postgres database. Also, check the Postgres exporter logs for errors.
 							`,
@@ -94,6 +99,7 @@ func Postgres() *monitoring.Container {
 							Name:           "migration_in_progress",
 							Description:    "active schema migration",
 							Owner:          monitoring.ObservableOwnerCoreApplication,
+							DataMustExist:  false, // not deployed on docker-compose
 							Query:          "pg_sg_migration_status",
 							Panel:          monitoring.Panel().LegendFormat("{{app}}"),
 							Critical:       monitoring.Alert().GreaterOrEqual(1, nil).For(5 * time.Minute),

--- a/monitoring/definitions/redis.go
+++ b/monitoring/definitions/redis.go
@@ -29,8 +29,8 @@ func Redis() *monitoring.Container {
 							Description:   "redis-store availability",
 							Owner:         monitoring.ObservableOwnerDevOps,
 							Query:         `redis_up{app="redis-store"}`,
-							DataMustExist: true,
 							Panel:         monitoring.Panel().LegendFormat("{{app}}"),
+							DataMustExist: false, // not deployed on docker-compose
 							Critical:      monitoring.Alert().Less(1, nil).For(10 * time.Second),
 							PossibleSolutions: `
 								- Ensure redis-store is running
@@ -51,8 +51,9 @@ func Redis() *monitoring.Container {
 							Owner:         monitoring.ObservableOwnerDevOps,
 							Query:         `redis_up{app="redis-cache"}`,
 							Panel:         monitoring.Panel().LegendFormat("{{app}}"),
-							DataMustExist: true,
-							Critical:      monitoring.Alert().Less(1, nil).For(10 * time.Second),
+							DataMustExist: false, // not deployed on docker-compose
+
+							Critical: monitoring.Alert().Less(1, nil).For(10 * time.Second),
 							PossibleSolutions: `
 								- Ensure redis-cache is running
 							`,


### PR DESCRIPTION
We do not deploy the Redis exporter for Docker-compose and this was causing a high number of alerts

Fixes https://github.com/sourcegraph/sourcegraph/issues/28099

Unfortunately, this will need to be cherry-picked into the release 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
