### PR TITLE
Remove references to the unused last_external_service column in code

### DIFF
--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -43,10 +43,9 @@ func TestIterateRepoGitserverStatus(t *testing.T) {
 	}
 
 	gitserverRepo := &types.GitserverRepo{
-		RepoID:              repo1.ID,
-		ShardID:             "gitserver1",
-		CloneStatus:         types.CloneStatusNotCloned,
-		LastExternalService: 0,
+		RepoID:      repo1.ID,
+		ShardID:     "gitserver1",
+		CloneStatus: types.CloneStatusNotCloned,
 	}
 
 	// Create one GitServerRepo
@@ -126,10 +125,9 @@ func TestGitserverReposGetByID(t *testing.T) {
 	}
 
 	gitserverRepo := &types.GitserverRepo{
-		RepoID:              repo1.ID,
-		ShardID:             "test",
-		CloneStatus:         types.CloneStatusNotCloned,
-		LastExternalService: 0,
+		RepoID:      repo1.ID,
+		ShardID:     "test",
+		CloneStatus: types.CloneStatusNotCloned,
 	}
 
 	// Create GitServerRepo
@@ -365,10 +363,9 @@ func TestGitserverRepoUpsertNullShard(t *testing.T) {
 	}
 
 	gitserverRepo := &types.GitserverRepo{
-		RepoID:              repo1.ID,
-		ShardID:             "",
-		CloneStatus:         types.CloneStatusNotCloned,
-		LastExternalService: 0,
+		RepoID:      repo1.ID,
+		ShardID:     "",
+		CloneStatus: types.CloneStatusNotCloned,
 	}
 
 	// Create one GitServerRepo

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -454,8 +454,6 @@ type GitserverRepo struct {
 	// Usually represented by a gitserver hostname
 	ShardID     string
 	CloneStatus CloneStatus
-	// The last external service used to sync or clone this repo
-	LastExternalService int64
 	// The last error that occurred or empty if the last action was successful
 	LastError string
 	// The last time fetch was called.


### PR DESCRIPTION
UPDATE: 
Now splitting this into two PRs. This PR is just to remove the references to the column in the code. The follow-up PR will add the migrations to drop the column

[Link](https://github.com/sourcegraph/sourcegraph/issues/27422) to GH issue associated w/ this PR

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
