### PR TITLE
golang-migrate: Reduce use of api outside of dbconn

### DIFF
--- a/internal/database/dbconn/migration.go
+++ b/internal/database/dbconn/migration.go
@@ -60,21 +60,21 @@ func MigrateDB(db *sql.DB, database *Database) error {
 }
 
 func DoMigrateDB(db *sql.DB, database *Database) (func(), error) {
-	m, err := NewMigrate(db, database)
+	m, err := newMigrate(db, database)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := DoMigrate(m); err != nil {
+	if err := doMigrate(m); err != nil {
 		return nil, errors.Wrap(err, "Failed to migrate the DB. Please contact support@sourcegraph.com for further assistance")
 	}
 
 	return func() { m.Close() }, nil
 }
 
-// NewMigrate returns a new configured migration object for the given database. The migration can
+// newMigrate returns a new configured migration object for the given database. The migration can
 // be subsequently run by invoking `dbconn.DoMigrate`.
-func NewMigrate(db *sql.DB, database *Database) (*migrate.Migrate, error) {
+func newMigrate(db *sql.DB, database *Database) (*migrate.Migrate, error) {
 	driver, err := postgres.WithInstance(db, &postgres.Config{
 		MigrationsTable: database.MigrationsTable,
 	})
@@ -102,8 +102,8 @@ func NewMigrate(db *sql.DB, database *Database) (*migrate.Migrate, error) {
 	return m, nil
 }
 
-// DoMigrate runs all up migrations.
-func DoMigrate(m *migrate.Migrate) (err error) {
+// doMigrate runs all up migrations.
+func doMigrate(m *migrate.Migrate) (err error) {
 	err = m.Up()
 	if err == nil || err == migrate.ErrNoChange {
 		return nil

--- a/internal/database/dbconn/migration.go
+++ b/internal/database/dbconn/migration.go
@@ -55,14 +55,21 @@ var (
 )
 
 func MigrateDB(db *sql.DB, database *Database) error {
+	_, err := DoMigrateDB(db, database)
+	return err
+}
+
+func DoMigrateDB(db *sql.DB, database *Database) (func(), error) {
 	m, err := NewMigrate(db, database)
 	if err != nil {
-		return err
+		return nil, err
 	}
+
 	if err := DoMigrate(m); err != nil {
-		return errors.Wrap(err, "Failed to migrate the DB. Please contact support@sourcegraph.com for further assistance")
+		return nil, errors.Wrap(err, "Failed to migrate the DB. Please contact support@sourcegraph.com for further assistance")
 	}
-	return nil
+
+	return func() { m.Close() }, nil
 }
 
 // NewMigrate returns a new configured migration object for the given database. The migration can

--- a/internal/database/dbtest/dbtest.go
+++ b/internal/database/dbtest/dbtest.go
@@ -146,14 +146,12 @@ func initTemplateDB(t testing.TB, config *url.URL) {
 			dbconn.Frontend,
 			dbconn.CodeIntel,
 		} {
-			m, err := dbconn.NewMigrate(templateDB, database)
+			close, err := dbconn.DoMigrateDB(templateDB, database)
 			if err != nil {
-				t.Fatalf("failed to construct migrations: %s", err)
-			}
-			defer m.Close()
-			if err = dbconn.DoMigrate(m); err != nil {
 				t.Fatalf("failed to apply migrations: %s", err)
 			}
+
+			defer close()
 		}
 	})
 }


### PR DESCRIPTION
We will tackle the use of golang-migrate in the migration tests themselves as well as its use in sg. We'll end up replacing the logic of golang-migrate in-place, then extract it to be used by non-service entites.