### PR TITLE
authtest: wait longer for site config to be updated

### DIFF
--- a/dev/authtest/README.md
+++ b/dev/authtest/README.md
@@ -1,0 +1,1 @@
+While this test suite focuses on authentication and authorization related tests, you may still refer to [`dev/gqltest`'s README](../gqltest/README.md) for background and how to run it both locally and in CI.

--- a/dev/authtest/code_intel_test.go
+++ b/dev/authtest/code_intel_test.go
@@ -12,8 +12,6 @@ import (
 )
 
 func TestCodeIntelEndpoints(t *testing.T) {
-	t.Skip("Skipping this because it failed with 'ununknown commit 6ffc6072f5ed13d8e8782490705d9689cd2c546a'")
-
 	// Create a test user (authtest-user-code-intel) which is not a site admin, the
 	// user should receive access denied for LSIF endpoints of repositories the user
 	// does not have access to.
@@ -91,7 +89,7 @@ func TestCodeIntelEndpoints(t *testing.T) {
 
 		// Retry because the configuration update endpoint is eventually consistent
 		var lastBody string
-		err = gqltestutil.Retry(5*time.Second, func() error {
+		err = gqltestutil.Retry(10*time.Second, func() error {
 			resp, err := userClient.Post(*baseURL+"/.api/lsif/upload?commit=6ffc6072f5ed13d8e8782490705d9689cd2c546a&repository=github.com/sgtest/private", nil)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
Because our site configuration is eventually consistent, when the "read" endpoint will be able to see the changed value takes time and could be affected how busy the instance is. So let's wait a bit longer (unfortunate but we don't have an endpoint for waiting for site config updates and have to use polling).

Fix https://github.com/sourcegraph/sourcegraph/issues/28075