### PR TITLE
Propagate db through handlers

### DIFF
--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -22,7 +22,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/webhooks"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/globalstatedb"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
@@ -102,7 +102,7 @@ type JSContext struct {
 
 // NewJSContextFromRequest populates a JSContext struct from the HTTP
 // request.
-func NewJSContextFromRequest(req *http.Request) JSContext {
+func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 	actor := actor.FromContext(req.Context())
 
 	headers := make(map[string]string)
@@ -189,7 +189,7 @@ func NewJSContextFromRequest(req *http.Request) JSContext {
 
 		Branding: globals.Branding(),
 
-		BatchChangesEnabled:                enterprise.BatchChangesEnabledForUser(req.Context(), dbconn.Global) == nil,
+		BatchChangesEnabled:                enterprise.BatchChangesEnabledForUser(req.Context(), db) == nil,
 		BatchChangesDisableWebhooksWarning: conf.Get().BatchChangesDisableWebhooksWarning,
 		BatchChangesWebhookLogsEnabled:     webhooks.LoggingEnabled(conf.Get()),
 

--- a/cmd/frontend/internal/app/ui/handlers_docs.go
+++ b/cmd/frontend/internal/app/ui/handlers_docs.go
@@ -10,12 +10,13 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 )
 
-func serveRepoDocs(codeIntelResolver graphqlbackend.CodeIntelResolver) handlerFunc {
+func serveRepoDocs(db database.DB, codeIntelResolver graphqlbackend.CodeIntelResolver) handlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) error {
-		common, err := newCommon(w, r, "", index, serveError)
+		common, err := newCommon(w, r, db, "", index, serveError)
 		if err != nil {
 			return err
 		}

--- a/cmd/frontend/internal/app/ui/handlers_test.go
+++ b/cmd/frontend/internal/app/ui/handlers_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/siteid"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
 	"github.com/sourcegraph/sourcegraph/internal/database/globalstatedb"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
@@ -167,12 +168,12 @@ func TestNewCommon_repo_error(t *testing.T) {
 
 			code := 200
 			got := ""
-			serveError := func(w http.ResponseWriter, r *http.Request, err error, statusCode int) {
+			serveError := func(w http.ResponseWriter, r *http.Request, db database.DB, err error, statusCode int) {
 				got = err.Error()
 				code = statusCode
 			}
 
-			_, err = newCommon(httptest.NewRecorder(), req, "test", index, serveError)
+			_, err = newCommon(httptest.NewRecorder(), req, dbmock.NewMockDB(), "test", index, serveError)
 			if err != nil {
 				if got != "" || code != 200 {
 					t.Fatal("serveError called and error returned from newCommon")
@@ -401,7 +402,7 @@ func TestRedirectTreeOrBlob(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			handled, err := redirectTreeOrBlob(test.route, test.path, test.common, w, r)
+			handled, err := redirectTreeOrBlob(test.route, test.path, test.common, w, r, dbmock.NewMockDB())
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/frontend/internal/app/ui/raw.go
+++ b/cmd/frontend/internal/app/ui/raw.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/vfsutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
@@ -59,220 +60,222 @@ import (
 // - This route would ideally be using strict slashes, in order for us to support symlinks via HTTP redirects.
 //
 
-func serveRaw(w http.ResponseWriter, r *http.Request) (err error) {
-	var common *Common
-	for {
-		// newCommon provides various repository handling features that we want, so
-		// we use it but discard the resulting structure. It provides:
-		//
-		// - Repo redirection
-		// - Gitserver content updating
-		// - Consistent error handling (permissions, revision not found, repo not found, etc).
-		//
-		common, err = newCommon(w, r, globals.Branding().BrandName, noIndex, serveError)
-		if err != nil {
-			return err
-		}
-		if common == nil {
-			return nil // request was handled
-		}
-		if common.Repo == nil {
-			// Repository is cloning.
-			time.Sleep(5 * time.Second)
-			continue
-		}
-		break
-	}
-
-	requestedPath := mux.Vars(r)["Path"]
-	if !strings.HasPrefix(requestedPath, "/") {
-		requestedPath = "/" + requestedPath
-	}
-
-	if requestedPath == "/" && r.Method == "HEAD" {
-		_, err = gitserver.DefaultClient.RepoInfo(r.Context(), common.Repo.Name)
-		if err != nil {
-			w.WriteHeader(http.StatusNotFound)
-			return err
-		}
-		w.WriteHeader(http.StatusOK)
-		return nil
-	}
-
-	const (
-		textPlain       = "text/plain"
-		applicationZip  = "application/zip"
-		applicationXTar = "application/x-tar"
-	)
-
-	// Negotiate the content type.
-	contentTypeOffers := []string{textPlain, applicationZip, applicationXTar}
-	defaultOffer := textPlain
-	contentType := httputil.NegotiateContentType(r, contentTypeOffers, defaultOffer)
-
-	// Allow users to override the negotiated content type so that e.g. browser
-	// users can easily download tar/zip archives by adding ?format=zip etc. to
-	// the URL.
-	switch r.URL.Query().Get("format") {
-	case "zip":
-		contentType = applicationZip
-	case "tar":
-		contentType = applicationXTar
-	}
-
-	// Instrument to understand duration and errors
-	var (
-		start       = time.Now()
-		requestType = "unknown"
-		size        int64
-	)
-	defer func() {
-		duration := time.Since(start)
-		log15.Debug("raw endpoint", "repo", common.Repo.Name, "commit", common.CommitID, "contentType", contentType, "type", requestType, "path", requestedPath, "size", size, "duration", duration, "error", err)
-		var errorS string
-		switch {
-		case err == nil:
-			errorS = "nil"
-		case r.Context().Err() == context.Canceled:
-			errorS = "canceled"
-		case r.Context().Err() == context.DeadlineExceeded:
-			errorS = "timeout"
-		default:
-			errorS = "error"
-		}
-		metricRawDuration.WithLabelValues(contentType, requestType, errorS).Observe(duration.Seconds())
-	}()
-
-	switch contentType {
-	case applicationZip, applicationXTar:
-		// Set the proper filename field, so that downloading "/github.com/gorilla/mux/-/raw" gives us a
-		// "mux.zip" file (e.g. when downloading via a browser) or a .tar file depending on the contentType.
-		ext := ".zip"
-		if contentType == applicationXTar {
-			ext = ".tar"
-		}
-		downloadName := path.Base(string(common.Repo.Name)) + ext
-		w.Header().Set("X-Content-Type-Options", "nosniff")
-		w.Header().Set("Content-Type", contentType)
-		w.Header().Set("Content-Disposition", mime.FormatMediaType("Attachment", map[string]string{"filename": downloadName}))
-
-		format := vfsutil.ArchiveFormatZip
-		if contentType == applicationXTar {
-			format = vfsutil.ArchiveFormatTar
-		}
-		relativePath := strings.TrimPrefix(requestedPath, "/")
-		if relativePath == "" {
-			relativePath = "."
-		}
-
-		if relativePath == "." {
-			requestType = "rootarchive"
-		} else {
-			requestType = "patharchive"
-		}
-
-		metricRunning := metricRawArchiveRunning.WithLabelValues(string(format))
-		metricRunning.Inc()
-		defer metricRunning.Dec()
-
-		f, err := openArchiveReader(r.Context(), vfsutil.ArchiveOpts{
-			Repo:         common.Repo.Name,
-			Commit:       common.CommitID,
-			Format:       format,
-			RelativePath: relativePath,
-		})
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-
-		_, err = io.Copy(w, f)
-		return err
-
-	default:
-		// This case also applies for defaultOffer. Note that this is preferred
-		// over e.g. a 406 status code, according to the MDN:
-		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/406
-
-		// 🚨 SECURITY: Files are served under the same Sourcegraph domain, and
-		// may contain arbitrary contents (JS/HTML files, SVGs with JS in them,
-		// malware in the form of .exe, etc). Serving with any other content
-		// type is extremely dangerous unless we can guarantee the contents of
-		// the file ourselves. GitHub, Wikipedia, and Facebook all use a
-		// separate domain for exactly this reason (e.g. raw.githubusercontent.com).
-		//
-		// See also:
-		//
-		// - https://security.stackexchange.com/a/11779
-		// - https://security.stackexchange.com/a/12916
-		// - https://www.owasp.org/index.php/Unrestricted_File_Upload
-		// - https://wiki.mozilla.org/WebAppSec/Secure_Coding_Guidelines#Uploads
-		//
-		// We try to protect against:
-		//
-		// - Serving user-uploaded malicious JS/HTML, SVGs with JS, etc. in a
-		//   browser-interpreted form (not as literal text/plain content),
-		//   which would introduce XSS, session-cookie stealing, etc.
-		// - Serving user-uploaded malware, etc. which would flag our domain as
-		//   untrustworthy by Google, etc. (We do serve such malware, but only
-		//   with content type text/plain).
-		//
-		// We do NOT try to protect against:
-		//
-		// - Vulnerabilities in old browser versions / old IE versions that do
-		//   not respect "nosniff".
-		// - Vulnerabilities in Flash or Java (modern browsers should not run
-		//   them).
-		//
-		// Note: We do not use a Content-Disposition attachment here because we
-		// want files to be viewed in the browser only AND because doing so
-		// would mean that we are literally serving malware to users
-		// (i.e. browsers will auto-download it and not treat it as text).
-		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-		w.Header().Set("X-Content-Type-Options", "nosniff")
-
-		fi, err := git.Stat(r.Context(), common.Repo.Name, common.CommitID, requestedPath)
-		if err != nil {
-			if os.IsNotExist(err) {
-				requestType = "404"
-				http.Error(w, html.EscapeString(err.Error()), http.StatusNotFound)
-				return nil // request handled
-			}
-			return err
-		}
-
-		if fi.IsDir() {
-			requestType = "dir"
-			infos, err := git.ReadDir(r.Context(), common.Repo.Name, common.CommitID, requestedPath, false)
+func serveRaw(db database.DB) handlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) (err error) {
+		var common *Common
+		for {
+			// newCommon provides various repository handling features that we want, so
+			// we use it but discard the resulting structure. It provides:
+			//
+			// - Repo redirection
+			// - Gitserver content updating
+			// - Consistent error handling (permissions, revision not found, repo not found, etc).
+			//
+			common, err = newCommon(w, r, db, globals.Branding().BrandName, noIndex, serveError)
 			if err != nil {
 				return err
 			}
-			size = int64(len(infos))
-			var names []string
-			for _, info := range infos {
-				// A previous version of this code returned relative paths so we trim the paths
-				// here too so as not to break backwards compatibility
-				name := path.Base(info.Name())
-				if info.IsDir() {
-					name = name + "/"
-				}
-				names = append(names, name)
+			if common == nil {
+				return nil // request was handled
 			}
-			result := strings.Join(names, "\n")
-			fmt.Fprintf(w, "%s", template.HTMLEscapeString(result))
+			if common.Repo == nil {
+				// Repository is cloning.
+				time.Sleep(5 * time.Second)
+				continue
+			}
+			break
+		}
+
+		requestedPath := mux.Vars(r)["Path"]
+		if !strings.HasPrefix(requestedPath, "/") {
+			requestedPath = "/" + requestedPath
+		}
+
+		if requestedPath == "/" && r.Method == "HEAD" {
+			_, err = gitserver.DefaultClient.RepoInfo(r.Context(), common.Repo.Name)
+			if err != nil {
+				w.WriteHeader(http.StatusNotFound)
+				return err
+			}
+			w.WriteHeader(http.StatusOK)
 			return nil
 		}
 
-		// File
-		requestType = "file"
-		size = fi.Size()
-		f, err := git.NewFileReader(r.Context(), common.Repo.Name, common.CommitID, requestedPath)
-		if err != nil {
+		const (
+			textPlain       = "text/plain"
+			applicationZip  = "application/zip"
+			applicationXTar = "application/x-tar"
+		)
+
+		// Negotiate the content type.
+		contentTypeOffers := []string{textPlain, applicationZip, applicationXTar}
+		defaultOffer := textPlain
+		contentType := httputil.NegotiateContentType(r, contentTypeOffers, defaultOffer)
+
+		// Allow users to override the negotiated content type so that e.g. browser
+		// users can easily download tar/zip archives by adding ?format=zip etc. to
+		// the URL.
+		switch r.URL.Query().Get("format") {
+		case "zip":
+			contentType = applicationZip
+		case "tar":
+			contentType = applicationXTar
+		}
+
+		// Instrument to understand duration and errors
+		var (
+			start       = time.Now()
+			requestType = "unknown"
+			size        int64
+		)
+		defer func() {
+			duration := time.Since(start)
+			log15.Debug("raw endpoint", "repo", common.Repo.Name, "commit", common.CommitID, "contentType", contentType, "type", requestType, "path", requestedPath, "size", size, "duration", duration, "error", err)
+			var errorS string
+			switch {
+			case err == nil:
+				errorS = "nil"
+			case r.Context().Err() == context.Canceled:
+				errorS = "canceled"
+			case r.Context().Err() == context.DeadlineExceeded:
+				errorS = "timeout"
+			default:
+				errorS = "error"
+			}
+			metricRawDuration.WithLabelValues(contentType, requestType, errorS).Observe(duration.Seconds())
+		}()
+
+		switch contentType {
+		case applicationZip, applicationXTar:
+			// Set the proper filename field, so that downloading "/github.com/gorilla/mux/-/raw" gives us a
+			// "mux.zip" file (e.g. when downloading via a browser) or a .tar file depending on the contentType.
+			ext := ".zip"
+			if contentType == applicationXTar {
+				ext = ".tar"
+			}
+			downloadName := path.Base(string(common.Repo.Name)) + ext
+			w.Header().Set("X-Content-Type-Options", "nosniff")
+			w.Header().Set("Content-Type", contentType)
+			w.Header().Set("Content-Disposition", mime.FormatMediaType("Attachment", map[string]string{"filename": downloadName}))
+
+			format := vfsutil.ArchiveFormatZip
+			if contentType == applicationXTar {
+				format = vfsutil.ArchiveFormatTar
+			}
+			relativePath := strings.TrimPrefix(requestedPath, "/")
+			if relativePath == "" {
+				relativePath = "."
+			}
+
+			if relativePath == "." {
+				requestType = "rootarchive"
+			} else {
+				requestType = "patharchive"
+			}
+
+			metricRunning := metricRawArchiveRunning.WithLabelValues(string(format))
+			metricRunning.Inc()
+			defer metricRunning.Dec()
+
+			f, err := openArchiveReader(r.Context(), vfsutil.ArchiveOpts{
+				Repo:         common.Repo.Name,
+				Commit:       common.CommitID,
+				Format:       format,
+				RelativePath: relativePath,
+			})
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+
+			_, err = io.Copy(w, f)
+			return err
+
+		default:
+			// This case also applies for defaultOffer. Note that this is preferred
+			// over e.g. a 406 status code, according to the MDN:
+			// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/406
+
+			// 🚨 SECURITY: Files are served under the same Sourcegraph domain, and
+			// may contain arbitrary contents (JS/HTML files, SVGs with JS in them,
+			// malware in the form of .exe, etc). Serving with any other content
+			// type is extremely dangerous unless we can guarantee the contents of
+			// the file ourselves. GitHub, Wikipedia, and Facebook all use a
+			// separate domain for exactly this reason (e.g. raw.githubusercontent.com).
+			//
+			// See also:
+			//
+			// - https://security.stackexchange.com/a/11779
+			// - https://security.stackexchange.com/a/12916
+			// - https://www.owasp.org/index.php/Unrestricted_File_Upload
+			// - https://wiki.mozilla.org/WebAppSec/Secure_Coding_Guidelines#Uploads
+			//
+			// We try to protect against:
+			//
+			// - Serving user-uploaded malicious JS/HTML, SVGs with JS, etc. in a
+			//   browser-interpreted form (not as literal text/plain content),
+			//   which would introduce XSS, session-cookie stealing, etc.
+			// - Serving user-uploaded malware, etc. which would flag our domain as
+			//   untrustworthy by Google, etc. (We do serve such malware, but only
+			//   with content type text/plain).
+			//
+			// We do NOT try to protect against:
+			//
+			// - Vulnerabilities in old browser versions / old IE versions that do
+			//   not respect "nosniff".
+			// - Vulnerabilities in Flash or Java (modern browsers should not run
+			//   them).
+			//
+			// Note: We do not use a Content-Disposition attachment here because we
+			// want files to be viewed in the browser only AND because doing so
+			// would mean that we are literally serving malware to users
+			// (i.e. browsers will auto-download it and not treat it as text).
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			w.Header().Set("X-Content-Type-Options", "nosniff")
+
+			fi, err := git.Stat(r.Context(), common.Repo.Name, common.CommitID, requestedPath)
+			if err != nil {
+				if os.IsNotExist(err) {
+					requestType = "404"
+					http.Error(w, html.EscapeString(err.Error()), http.StatusNotFound)
+					return nil // request handled
+				}
+				return err
+			}
+
+			if fi.IsDir() {
+				requestType = "dir"
+				infos, err := git.ReadDir(r.Context(), common.Repo.Name, common.CommitID, requestedPath, false)
+				if err != nil {
+					return err
+				}
+				size = int64(len(infos))
+				var names []string
+				for _, info := range infos {
+					// A previous version of this code returned relative paths so we trim the paths
+					// here too so as not to break backwards compatibility
+					name := path.Base(info.Name())
+					if info.IsDir() {
+						name = name + "/"
+					}
+					names = append(names, name)
+				}
+				result := strings.Join(names, "\n")
+				fmt.Fprintf(w, "%s", template.HTMLEscapeString(result))
+				return nil
+			}
+
+			// File
+			requestType = "file"
+			size = fi.Size()
+			f, err := git.NewFileReader(r.Context(), common.Repo.Name, common.CommitID, requestedPath)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			_, err = io.Copy(w, f)
 			return err
 		}
-		defer f.Close()
-		_, err = io.Copy(w, f)
-		return err
 	}
 }
 

--- a/cmd/frontend/internal/app/ui/raw_test.go
+++ b/cmd/frontend/internal/app/ui/raw_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
@@ -73,7 +74,7 @@ func Test_serveRawWithHTTPRequestMethodHEAD(t *testing.T) {
 		req := httptest.NewRequest("HEAD", "/github.com/sourcegraph/sourcegraph/-/raw", nil)
 		w := httptest.NewRecorder()
 
-		err := serveRaw(w, req)
+		err := serveRaw(dbmock.NewMockDB())(w, req)
 		if err != nil {
 			t.Fatalf("Failed to invoke serveRaw: %v", err)
 		}
@@ -91,7 +92,7 @@ func Test_serveRawWithHTTPRequestMethodHEAD(t *testing.T) {
 		req := httptest.NewRequest("HEAD", "/github.com/sourcegraph/sourcegraph/-/raw", nil)
 		w := httptest.NewRecorder()
 
-		err := serveRaw(w, req)
+		err := serveRaw(dbmock.NewMockDB())(w, req)
 		if err == nil {
 			t.Fatal("Want error but got nil")
 		}
@@ -125,7 +126,7 @@ func Test_serveRawWithContentArchive(t *testing.T) {
 		req := httptest.NewRequest("GET", "/github.com/sourcegraph/sourcegraph/-/raw?format=zip", nil)
 		w := httptest.NewRecorder()
 
-		err := serveRaw(w, req)
+		err := serveRaw(dbmock.NewMockDB())(w, req)
 		if err != nil {
 			t.Fatalf("Failed to invoke serveRaw: %v", err)
 		}
@@ -164,7 +165,7 @@ func Test_serveRawWithContentArchive(t *testing.T) {
 		req := httptest.NewRequest("GET", "/github.com/sourcegraph/sourcegraph/-/raw?format=tar", nil)
 		w := httptest.NewRecorder()
 
-		err := serveRaw(w, req)
+		err := serveRaw(dbmock.NewMockDB())(w, req)
 		if err != nil {
 			t.Fatalf("Failed to invoke serveRaw: %v", err)
 		}
@@ -241,7 +242,7 @@ func Test_serveRawWithContentTypePlain(t *testing.T) {
 		req := httptest.NewRequest("GET", "/github.com/sourcegraph/sourcegraph/-/raw", nil)
 		w := httptest.NewRecorder()
 
-		err := serveRaw(w, req)
+		err := serveRaw(dbmock.NewMockDB())(w, req)
 		if err != nil {
 			t.Fatalf("Failed to invoke serveRaw: %v", err)
 		}
@@ -274,7 +275,7 @@ func Test_serveRawWithContentTypePlain(t *testing.T) {
 		req := httptest.NewRequest("GET", "/github.com/sourcegraph/sourcegraph/-/raw", nil)
 		w := httptest.NewRecorder()
 
-		err := serveRaw(w, req)
+		err := serveRaw(dbmock.NewMockDB())(w, req)
 		if err != nil {
 			t.Fatalf("Failed to invoke serveRaw: %v", err)
 		}
@@ -311,7 +312,7 @@ c.go`
 		req := httptest.NewRequest("GET", "/github.com/sourcegraph/sourcegraph/-/raw", nil)
 		w := httptest.NewRecorder()
 
-		err := serveRaw(w, req)
+		err := serveRaw(dbmock.NewMockDB())(w, req)
 		if err != nil {
 			t.Fatalf("Failed to invoke serveRaw: %v", err)
 		}
@@ -348,7 +349,7 @@ c.go`
 		req := httptest.NewRequest("GET", "/github.com/sourcegraph/sourcegraph/-/raw?format=exe", nil)
 		w := httptest.NewRecorder()
 
-		err := serveRaw(w, req)
+		err := serveRaw(dbmock.NewMockDB())(w, req)
 		if err != nil {
 			t.Fatalf("Failed to invoke serveRaw: %v", err)
 		}

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -220,49 +220,57 @@ func brandNameSubtitle(titles ...string) string {
 func initRouter(db database.DB, router *mux.Router, codeIntelResolver graphqlbackend.CodeIntelResolver) {
 	uirouter.Router = router // make accessible to other packages
 
-	// basic pages with static titles
-	router.Get(routeHome).Handler(handler(serveHome))
-	router.Get(routeThreads).Handler(handler(serveBrandedPageString("Threads", nil, noIndex)))
-	router.Get(routeInsights).Handler(handler(serveBrandedPageString("Insights", nil, index)))
-	router.Get(routeBatchChanges).Handler(handler(serveBrandedPageString("Batch Changes", nil, index)))
-	router.Get(routeCodeMonitoring).Handler(handler(serveBrandedPageString("Code Monitoring", nil, index)))
-	router.Get(routeContexts).Handler(handler(serveBrandedPageString("Search Contexts", nil, noIndex)))
-	router.Get(uirouter.RouteSignIn).Handler(handler(serveSignIn))
-	router.Get(uirouter.RouteSignUp).Handler(handler(serveBrandedPageString("Sign up", nil, index)))
-	router.Get(routeWelcome).Handler(handler(serveBrandedPageString("Welcome", nil, noIndex)))
-	router.Get(routeOrganizations).Handler(handler(serveBrandedPageString("Organization", nil, noIndex)))
-	router.Get(routeSettings).Handler(handler(serveBrandedPageString("Settings", nil, noIndex)))
-	router.Get(routeSiteAdmin).Handler(handler(serveBrandedPageString("Admin", nil, noIndex)))
-	router.Get(uirouter.RoutePasswordReset).Handler(handler(serveBrandedPageString("Reset password", nil, noIndex)))
-	router.Get(routeAPIConsole).Handler(handler(serveBrandedPageString("API console", nil, index)))
-	router.Get(routeRepoSettings).Handler(handler(serveBrandedPageString("Repository settings", nil, noIndex)))
-	router.Get(routeRepoCodeIntelligence).Handler(handler(serveBrandedPageString("Code intelligence", nil, noIndex)))
-	router.Get(routeRepoCommit).Handler(handler(serveBrandedPageString("Commit", nil, noIndex)))
-	router.Get(routeRepoBranches).Handler(handler(serveBrandedPageString("Branches", nil, noIndex)))
-	router.Get(routeRepoBatchChanges).Handler(handler(serveBrandedPageString("Batch Changes", nil, index)))
-	router.Get(routeRepoDocs).Handler(handler(serveRepoDocs(codeIntelResolver)))
-	router.Get(routeRepoCommits).Handler(handler(serveBrandedPageString("Commits", nil, noIndex)))
-	router.Get(routeRepoTags).Handler(handler(serveBrandedPageString("Tags", nil, noIndex)))
-	router.Get(routeRepoCompare).Handler(handler(serveBrandedPageString("Compare", nil, noIndex)))
-	router.Get(routeRepoStats).Handler(handler(serveBrandedPageString("Stats", nil, noIndex)))
-	router.Get(routeSurvey).Handler(handler(serveBrandedPageString("Survey", nil, noIndex)))
-	router.Get(routeSurveyScore).Handler(handler(serveBrandedPageString("Survey", nil, noIndex)))
-	router.Get(routeRegistry).Handler(handler(serveBrandedPageString("Registry", nil, noIndex)))
-	router.Get(routeExtensions).Handler(handler(serveBrandedPageString("Extensions", nil, index)))
-	router.Get(routeHelp).HandlerFunc(serveHelp)
-	router.Get(routeSnippets).Handler(handler(serveBrandedPageString("Snippets", nil, noIndex)))
-	router.Get(routeSubscriptions).Handler(handler(serveBrandedPageString("Subscriptions", nil, noIndex)))
-	router.Get(routeStats).Handler(handler(serveBrandedPageString("Stats", nil, noIndex)))
-	router.Get(routeViews).Handler(handler(serveBrandedPageString("View", nil, noIndex)))
-	router.Get(uirouter.RoutePingFromSelfHosted).Handler(handler(servePingFromSelfHosted))
+	brandedIndex := func(titles string) http.Handler {
+		return handler(db, serveBrandedPageString(db, titles, nil, index))
+	}
 
-	router.Get(routeUserSettings).Handler(handler(serveBrandedPageString("User settings", nil, noIndex)))
-	router.Get(routeUserRedirect).Handler(handler(serveBrandedPageString("User", nil, noIndex)))
-	router.Get(routeUser).Handler(handler(serveBasicPage(func(c *Common, r *http.Request) string {
+	brandedNoIndex := func(titles string) http.Handler {
+		return handler(db, serveBrandedPageString(db, titles, nil, noIndex))
+	}
+
+	// basic pages with static titles
+	router.Get(routeHome).Handler(handler(db, serveHome(db)))
+	router.Get(routeThreads).Handler(brandedNoIndex("Threads"))
+	router.Get(routeInsights).Handler(brandedIndex("Insights"))
+	router.Get(routeBatchChanges).Handler(brandedIndex("Batch Changes"))
+	router.Get(routeCodeMonitoring).Handler(brandedIndex("Code Monitoring"))
+	router.Get(routeContexts).Handler(brandedNoIndex("Search Contexts"))
+	router.Get(uirouter.RouteSignIn).Handler(handler(db, serveSignIn(db)))
+	router.Get(uirouter.RouteSignUp).Handler(brandedIndex("Sign up"))
+	router.Get(routeWelcome).Handler(brandedNoIndex("Welcome"))
+	router.Get(routeOrganizations).Handler(brandedNoIndex("Organization"))
+	router.Get(routeSettings).Handler(brandedNoIndex("Settings"))
+	router.Get(routeSiteAdmin).Handler(brandedNoIndex("Admin"))
+	router.Get(uirouter.RoutePasswordReset).Handler(brandedNoIndex("Reset password"))
+	router.Get(routeAPIConsole).Handler(brandedIndex("API console"))
+	router.Get(routeRepoSettings).Handler(brandedNoIndex("Repository settings"))
+	router.Get(routeRepoCodeIntelligence).Handler(brandedNoIndex("Code intelligence"))
+	router.Get(routeRepoCommit).Handler(brandedNoIndex("Commit"))
+	router.Get(routeRepoBranches).Handler(brandedNoIndex("Branches"))
+	router.Get(routeRepoBatchChanges).Handler(brandedIndex("Batch Changes"))
+	router.Get(routeRepoDocs).Handler(handler(db, serveRepoDocs(db, codeIntelResolver)))
+	router.Get(routeRepoCommits).Handler(brandedNoIndex("Commits"))
+	router.Get(routeRepoTags).Handler(brandedNoIndex("Tags"))
+	router.Get(routeRepoCompare).Handler(brandedNoIndex("Compare"))
+	router.Get(routeRepoStats).Handler(brandedNoIndex("Stats"))
+	router.Get(routeSurvey).Handler(brandedNoIndex("Survey"))
+	router.Get(routeSurveyScore).Handler(brandedNoIndex("Survey"))
+	router.Get(routeRegistry).Handler(brandedNoIndex("Registry"))
+	router.Get(routeExtensions).Handler(brandedIndex("Extensions"))
+	router.Get(routeHelp).HandlerFunc(serveHelp)
+	router.Get(routeSnippets).Handler(brandedNoIndex("Snippets"))
+	router.Get(routeSubscriptions).Handler(brandedNoIndex("Subscriptions"))
+	router.Get(routeStats).Handler(brandedNoIndex("Stats"))
+	router.Get(routeViews).Handler(brandedNoIndex("View"))
+	router.Get(uirouter.RoutePingFromSelfHosted).Handler(handler(db, servePingFromSelfHosted))
+
+	router.Get(routeUserSettings).Handler(brandedNoIndex("User settings"))
+	router.Get(routeUserRedirect).Handler(brandedNoIndex("User"))
+	router.Get(routeUser).Handler(handler(db, serveBasicPage(db, func(c *Common, r *http.Request) string {
 		return brandNameSubtitle(mux.Vars(r)["username"])
 	}, nil, noIndex)))
-	router.Get(routeSearchConsole).Handler(handler(serveBrandedPageString("Search console", nil, index)))
-	router.Get(routeSearchNotebook).Handler(handler(serveBrandedPageString("Search Notebook", nil, index)))
+	router.Get(routeSearchConsole).Handler(brandedIndex("Search console"))
+	router.Get(routeSearchNotebook).Handler(brandedIndex("Search Notebook"))
 
 	// Legacy redirects
 	if envvar.SourcegraphDotComMode() {
@@ -270,12 +278,12 @@ func initRouter(db database.DB, router *mux.Router, codeIntelResolver graphqlbac
 		router.Get(routeLegacyCareers).Handler(staticRedirectHandler("https://about.sourcegraph.com/jobs", http.StatusMovedPermanently))
 		router.Get(routeLegacyOldRouteDefLanding).Handler(http.HandlerFunc(serveOldRouteDefLanding))
 		router.Get(routeLegacyDefRedirectToDefLanding).Handler(http.HandlerFunc(serveDefRedirectToDefLanding))
-		router.Get(routeLegacyDefLanding).Handler(handler(serveDefLanding))
-		router.Get(routeLegacyRepoLanding).Handler(handler(serveRepoLanding))
+		router.Get(routeLegacyDefLanding).Handler(handler(db, serveDefLanding))
+		router.Get(routeLegacyRepoLanding).Handler(handler(db, serveRepoLanding))
 	}
 
 	// search
-	router.Get(routeSearch).Handler(handler(serveBasicPage(func(c *Common, r *http.Request) string {
+	router.Get(routeSearch).Handler(handler(db, serveBasicPage(db, func(c *Common, r *http.Request) string {
 		shortQuery := limitString(r.URL.Query().Get("q"), 25, true)
 		if shortQuery == "" {
 			return globals.Branding().BrandName
@@ -299,21 +307,21 @@ func initRouter(db database.DB, router *mux.Router, codeIntelResolver graphqlbac
 			r.URL.Path = "/" + aboutRedirects[mux.Vars(r)["Path"]]
 			http.Redirect(w, r, r.URL.String(), http.StatusTemporaryRedirect)
 		}))
-		router.Get(routeCommunitySearchContexts).Handler(handler(serveBrandedPageString("Community search context", nil, noIndex)))
+		router.Get(routeCommunitySearchContexts).Handler(brandedNoIndex("Community search context"))
 		cncfDescription := "Search all repositories in the Cloud Native Computing Foundation (CNCF)."
-		router.Get(routeCncf).Handler(handler(serveBrandedPageString("CNCF code search", &cncfDescription, index)))
+		router.Get(routeCncf).Handler(handler(db, serveBrandedPageString(db, "CNCF code search", &cncfDescription, index)))
 		router.Get(routeDevToolTime).Handler(staticRedirectHandler("https://info.sourcegraph.com/dev-tool-time", http.StatusMovedPermanently))
 	}
 
 	// repo
-	serveRepoHandler := handler(serveRepoOrBlob(routeRepo, func(c *Common, r *http.Request) string {
+	serveRepoHandler := handler(db, serveRepoOrBlob(db, routeRepo, func(c *Common, r *http.Request) string {
 		// e.g. "gorilla/mux - Sourcegraph"
 		return brandNameSubtitle(repoShortName(c.Repo.Name))
 	}))
 	router.Get(routeRepo).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Debug mode: register the __errorTest handler.
 		if env.InsecureDev && r.URL.Path == "/__errorTest" {
-			handler(serveErrorTest).ServeHTTP(w, r)
+			handler(db, serveErrorTest(db)).ServeHTTP(w, r)
 			return
 		}
 
@@ -325,25 +333,25 @@ func initRouter(db database.DB, router *mux.Router, codeIntelResolver graphqlbac
 	}))
 
 	// tree
-	router.Get(routeTree).Handler(handler(serveTree(func(c *Common, r *http.Request) string {
+	router.Get(routeTree).Handler(handler(db, serveTree(db, func(c *Common, r *http.Request) string {
 		// e.g. "src - gorilla/mux - Sourcegraph"
 		dirName := path.Base(mux.Vars(r)["Path"])
 		return brandNameSubtitle(dirName, repoShortName(c.Repo.Name))
 	})))
 
 	// blob
-	router.Get(routeBlob).Handler(handler(serveRepoOrBlob(routeBlob, func(c *Common, r *http.Request) string {
+	router.Get(routeBlob).Handler(handler(db, serveRepoOrBlob(db, routeBlob, func(c *Common, r *http.Request) string {
 		// e.g. "mux.go - gorilla/mux - Sourcegraph"
 		fileName := path.Base(mux.Vars(r)["Path"])
 		return brandNameSubtitle(fileName, repoShortName(c.Repo.Name))
 	})))
 
 	// raw
-	router.Get(routeRaw).Handler(handler(serveRaw))
+	router.Get(routeRaw).Handler(handler(db, serveRaw(db)))
 
 	// All other routes that are not found.
 	router.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		serveError(w, r, errors.New("route not found"), http.StatusNotFound)
+		serveError(w, r, db, errors.New("route not found"), http.StatusNotFound)
 	})
 }
 
@@ -398,15 +406,15 @@ func limitString(s string, n int, ellipsis bool) string {
 // 	serveError(w, r, err, http.MyStatusCode)
 //  return nil
 //
-func handler(f func(w http.ResponseWriter, r *http.Request) error) http.Handler {
+func handler(db database.DB, f handlerFunc) http.Handler {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if rec := recover(); rec != nil {
-				serveError(w, r, recoverError{recover: rec, stack: debug.Stack()}, http.StatusInternalServerError)
+				serveError(w, r, db, recoverError{recover: rec, stack: debug.Stack()}, http.StatusInternalServerError)
 			}
 		}()
 		if err := f(w, r); err != nil {
-			serveError(w, r, err, http.StatusInternalServerError)
+			serveError(w, r, db, err, http.StatusInternalServerError)
 		}
 	})
 	return trace.Route(gziphandler.GzipHandler(h))
@@ -424,8 +432,8 @@ func (r recoverError) Error() string {
 // serveError serves the error template with the specified error message. It is
 // assumed that the error message could accidentally contain sensitive data,
 // and as such is only presented to the user in debug mode.
-func serveError(w http.ResponseWriter, r *http.Request, err error, statusCode int) {
-	serveErrorNoDebug(w, r, err, statusCode, false, false)
+func serveError(w http.ResponseWriter, r *http.Request, db database.DB, err error, statusCode int) {
+	serveErrorNoDebug(w, r, db, err, statusCode, false, false)
 }
 
 // dangerouslyServeError is like serveError except it always shows the error to
@@ -433,8 +441,8 @@ func serveError(w http.ResponseWriter, r *http.Request, err error, statusCode in
 // sensitive information.
 //
 // See https://github.com/sourcegraph/sourcegraph/issues/9453
-func dangerouslyServeError(w http.ResponseWriter, r *http.Request, err error, statusCode int) {
-	serveErrorNoDebug(w, r, err, statusCode, false, true)
+func dangerouslyServeError(w http.ResponseWriter, r *http.Request, db database.DB, err error, statusCode int) {
+	serveErrorNoDebug(w, r, db, err, statusCode, false, true)
 }
 
 type pageError struct {
@@ -445,7 +453,7 @@ type pageError struct {
 }
 
 // serveErrorNoDebug should not be called by anyone except serveErrorTest.
-func serveErrorNoDebug(w http.ResponseWriter, r *http.Request, err error, statusCode int, nodebug, forceServeError bool) {
+func serveErrorNoDebug(w http.ResponseWriter, r *http.Request, db database.DB, err error, statusCode int, nodebug, forceServeError bool) {
 	w.WriteHeader(statusCode)
 	errorID := randstring.NewLen(6)
 
@@ -486,7 +494,7 @@ func serveErrorNoDebug(w http.ResponseWriter, r *http.Request, err error, status
 	delete(mux.Vars(r), "Repo")
 	var commonServeErr error
 	title := brandNameSubtitle(fmt.Sprintf("%v %s", statusCode, http.StatusText(statusCode)))
-	common, commonErr := newCommon(w, r, title, index, func(w http.ResponseWriter, r *http.Request, err error, statusCode int) {
+	common, commonErr := newCommon(w, r, db, title, index, func(w http.ResponseWriter, r *http.Request, db database.DB, err error, statusCode int) {
 		// Stub out serveError to newCommon so that it is not reentrant.
 		commonServeErr = err
 	})
@@ -524,17 +532,19 @@ func serveErrorNoDebug(w http.ResponseWriter, r *http.Request, err error, status
 // The `nodebug=true` parameter hides error messages (which is ALWAYS the case
 // in production), `error` controls the error message text, and status controls
 // the status code.
-func serveErrorTest(w http.ResponseWriter, r *http.Request) error {
-	if !env.InsecureDev {
-		w.WriteHeader(http.StatusNotFound)
+func serveErrorTest(db database.DB) handlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		if !env.InsecureDev {
+			w.WriteHeader(http.StatusNotFound)
+			return nil
+		}
+		q := r.URL.Query()
+		nodebug := q.Get("nodebug") == "true"
+		errorText := q.Get("error")
+		statusCode, _ := strconv.Atoi(q.Get("status"))
+		serveErrorNoDebug(w, r, db, errors.New(errorText), statusCode, nodebug, false)
 		return nil
 	}
-	q := r.URL.Query()
-	nodebug := q.Get("nodebug") == "true"
-	errorText := q.Get("error")
-	statusCode, _ := strconv.Atoi(q.Get("status"))
-	serveErrorNoDebug(w, r, errors.New(errorText), statusCode, nodebug, false)
-	return nil
 }
 
 func mapKeys(m map[string]string) (keys []string) {


### PR DESCRIPTION
This propagates a database handle through our http handlers. This has
been the biggest blocker to me getting rid of global db handles
entirely, since the remaining places we use dbconn.Global are largely
direct descendents of these handlers. I've been putting this change off
because it's very messy, and requires passing a db directly through a
bunch of functions, but I think this is the only way to move forward
here, so I'm ripping off the band-aid. There are a lot of circular references 
in our handlers which makes it impossible to isolate this change cleanly 
without just doing it all at once. I'm keeping this PR focused on the db 
propagation, but our handlers could use a bit of clean up to untangle them. 
This might also make it unnecessary to pass a db through _quite_ so many
functions.

I would recommend viewing without whitespace changes, because
there are a few big indentation changes. 

Anyways, this gets rid of one more instance of dbconn.Global, and will
enable getting rid of many more.

1 down, 37 to go.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
