### PR TITLE
graphqlbackend: reduce usage of `database.Mocks`

### DIFF
--- a/cmd/frontend/graphqlbackend/access_tokens_test.go
+++ b/cmd/frontend/graphqlbackend/access_tokens_test.go
@@ -111,7 +111,6 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 	})
 
 	t.Run("authenticated as site admin, using site-admin-only scopes", func(t *testing.T) {
-		resetMocks()
 		accessTokens := newMockAccessTokens(t, 1, []string{authz.ScopeSiteAdminSudo, authz.ScopeUserAll})
 		users := dbmock.NewMockUserStore()
 		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 1, SiteAdmin: true}, nil)

--- a/cmd/frontend/graphqlbackend/repository_mirror_test.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror_test.go
@@ -8,22 +8,24 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 func TestCheckMirrorRepositoryConnection(t *testing.T) {
-	resetMocks()
-
 	const repoName = api.RepoName("my/repo")
 
-	database.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
-		return &types.User{SiteAdmin: true}, nil
-	}
+	users := dbmock.NewMockUserStore()
+	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: true}, nil)
+
+	repos := dbmock.NewMockRepoStore()
+
+	db := dbmock.NewMockDB()
+	db.UsersFunc.SetDefaultReturn(users)
+	db.ReposFunc.SetDefaultReturn(repos)
 
 	t.Run("repository arg", func(t *testing.T) {
-		db := database.NewDB(nil)
 		backend.Mocks.Repos.Get = func(ctx context.Context, repoID api.RepoID) (*types.Repo, error) {
 			return &types.Repo{Name: repoName}, nil
 		}
@@ -36,7 +38,10 @@ func TestCheckMirrorRepositoryConnection(t *testing.T) {
 			}
 			return nil
 		}
-		defer func() { gitserver.MockIsRepoCloneable = nil }()
+		defer func() {
+			backend.Mocks = backend.MockServices{}
+			gitserver.MockIsRepoCloneable = nil
+		}()
 
 		RunTests(t, []*Test{
 			{
@@ -64,7 +69,6 @@ func TestCheckMirrorRepositoryConnection(t *testing.T) {
 	})
 
 	t.Run("name arg", func(t *testing.T) {
-		db := database.NewDB(nil)
 		backend.Mocks.Repos.GetByName = func(ctx context.Context, name api.RepoName) (*types.Repo, error) {
 			t.Fatal("want GetByName to not be called")
 			return nil, nil
@@ -78,7 +82,10 @@ func TestCheckMirrorRepositoryConnection(t *testing.T) {
 			}
 			return nil
 		}
-		defer func() { gitserver.MockIsRepoCloneable = nil }()
+		defer func() {
+			backend.Mocks = backend.MockServices{}
+			gitserver.MockIsRepoCloneable = nil
+		}()
 
 		RunTests(t, []*Test{
 			{
@@ -107,8 +114,6 @@ func TestCheckMirrorRepositoryConnection(t *testing.T) {
 }
 
 func TestCheckMirrorRepositoryRemoteURL(t *testing.T) {
-	resetMocks()
-
 	const repoName = "my/repo"
 
 	cases := []struct {
@@ -183,10 +188,11 @@ func TestCheckMirrorRepositoryRemoteURL(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.repoURL, func(t *testing.T) {
-			db := database.NewDB(nil)
-			database.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
-				return &types.User{SiteAdmin: true}, nil
-			}
+			users := dbmock.NewMockUserStore()
+			users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: true}, nil)
+
+			db := dbmock.NewMockDB()
+			db.UsersFunc.SetDefaultReturn(users)
 
 			backend.Mocks.Repos.GetByName = func(ctx context.Context, name api.RepoName) (*types.Repo, error) {
 				return &types.Repo{
@@ -195,6 +201,9 @@ func TestCheckMirrorRepositoryRemoteURL(t *testing.T) {
 					Sources:   map[string]*types.SourceInfo{"1": {CloneURL: tc.repoURL}},
 				}, nil
 			}
+			defer func() {
+				backend.Mocks = backend.MockServices{}
+			}()
 
 			RunTests(t, []*Test{
 				{

--- a/cmd/frontend/graphqlbackend/repository_test.go
+++ b/cmd/frontend/graphqlbackend/repository_test.go
@@ -24,7 +24,6 @@ import (
 const exampleCommitSHA1 = "1234567890123456789012345678901234567890"
 
 func TestRepository_Commit(t *testing.T) {
-	resetMocks()
 	backend.Mocks.Repos.ResolveRev = func(ctx context.Context, repo *types.Repo, rev string) (api.CommitID, error) {
 		assert.Equal(t, api.RepoID(2), repo.ID)
 		assert.Equal(t, "abc", rev)

--- a/cmd/frontend/graphqlbackend/search_filter_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_filter_suggestions.go
@@ -16,7 +16,7 @@ func (r *schemaResolver) SearchFilterSuggestions(ctx context.Context) (*searchFi
 	}
 
 	// List at most 10 repositories as default suggestions.
-	repos, err := backend.Repos.List(ctx, database.ReposListOptions{
+	repos, err := backend.NewRepos(r.db.Repos()).List(ctx, database.ReposListOptions{
 		OrderBy: database.RepoListOrderBy{
 			{
 				Field:      database.RepoListStars,

--- a/cmd/frontend/graphqlbackend/user_usage_stats_test.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats_test.go
@@ -4,20 +4,24 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/usagestatsdeprecated"
-	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 func TestUser_UsageStatistics(t *testing.T) {
-	resetMocks()
-	database.Mocks.Users.MockGetByID_Return(t, &types.User{ID: 1, Username: "alice"}, nil)
+	users := dbmock.NewMockUserStore()
+	users.GetByIDFunc.SetDefaultReturn(&types.User{ID: 1, Username: "alice"}, nil)
+
+	db := dbmock.NewMockDB()
+	db.UsersFunc.SetDefaultReturn(users)
+
 	usagestatsdeprecated.MockGetByUserID = func(userID int32) (*types.UserUsageStatistics, error) {
 		return &types.UserUsageStatistics{
 			SearchQueries: 2,
 		}, nil
 	}
 	defer func() { usagestatsdeprecated.MockGetByUserID = nil }()
-	db := database.NewDB(nil)
+
 	RunTests(t, []*Test{
 		{
 			Schema: mustParseGraphQLSchema(t, db),

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -94,7 +94,7 @@ func (r *userConnectionResolver) Nodes(ctx context.Context) ([]*UserResolver, er
 	if r.useCache() {
 		users, _, err = r.compute(ctx)
 	} else {
-		users, err = database.Users(r.db).List(ctx, &r.opt)
+		users, err = r.db.Users().List(ctx, &r.opt)
 	}
 	if err != nil {
 		return nil, err
@@ -121,7 +121,7 @@ func (r *userConnectionResolver) TotalCount(ctx context.Context) (int32, error) 
 	if r.useCache() {
 		_, count, err = r.compute(ctx)
 	} else {
-		count, err = database.Users(r.db).Count(ctx, &r.opt)
+		count, err = r.db.Users().Count(ctx, &r.opt)
 	}
 	return int32(count), err
 }

--- a/cmd/frontend/graphqlbackend/users_test.go
+++ b/cmd/frontend/graphqlbackend/users_test.go
@@ -1,23 +1,21 @@
 package graphqlbackend
 
 import (
-	"context"
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 func TestUsers(t *testing.T) {
-	resetMocks()
-	database.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
-		return &types.User{SiteAdmin: true}, nil
-	}
-	database.Mocks.Users.List = func(ctx context.Context, opt *database.UsersListOptions) ([]*types.User, error) {
-		return []*types.User{{Username: "user1"}, {Username: "user2"}}, nil
-	}
-	database.Mocks.Users.Count = func(context.Context, *database.UsersListOptions) (int, error) { return 2, nil }
-	db := database.NewDB(nil)
+	users := dbmock.NewMockUserStore()
+	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: true}, nil)
+	users.ListFunc.SetDefaultReturn([]*types.User{{Username: "user1"}, {Username: "user2"}}, nil)
+	users.CountFunc.SetDefaultReturn(2, nil)
+
+	db := dbmock.NewMockDB()
+	db.UsersFunc.SetDefaultReturn(users)
+
 	RunTests(t, []*Test{
 		{
 			Schema: mustParseGraphQLSchema(t, db),


### PR DESCRIPTION
This PR reduces usage of `database.Mocks` in the `cmd/frontend/graphqlbackend` package.

---

Part of #26113