### PR TITLE
Remove GlobalRepos

### DIFF
--- a/cmd/frontend/backend/go_importers.go
+++ b/cmd/frontend/backend/go_importers.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
@@ -32,7 +33,7 @@ var (
 // a special case used only on Sourcegraph.com for repository badges.
 //
 // TODO: The import path is not always the same as the repository name.
-func CountGoImporters(ctx context.Context, repo api.RepoName) (count int, err error) {
+func CountGoImporters(ctx context.Context, db database.DB, repo api.RepoName) (count int, err error) {
 	if MockCountGoImporters != nil {
 		return MockCountGoImporters(ctx, repo)
 	}
@@ -64,7 +65,7 @@ func CountGoImporters(ctx context.Context, repo api.RepoName) (count int, err er
 	defer cancel()
 
 	// Find all (possible) Go packages in the repository.
-	goPackages, err := listGoPackagesInRepoImprecise(ctx, repo)
+	goPackages, err := listGoPackagesInRepoImprecise(ctx, db, repo)
 	if err != nil {
 		return 0, err
 	}
@@ -115,7 +116,7 @@ func CountGoImporters(ctx context.Context, repo api.RepoName) (count int, err er
 // the repository. It computes the list based solely on the repository name (as a prefix) and
 // filenames in the repository; it does not parse or build the Go files to determine the list
 // precisely.
-func listGoPackagesInRepoImprecise(ctx context.Context, repoName api.RepoName) ([]string, error) {
+func listGoPackagesInRepoImprecise(ctx context.Context, db database.DB, repoName api.RepoName) ([]string, error) {
 	if !envvar.SourcegraphDotComMode() {
 		// 🚨 SECURITY: Avoid leaking information about private repositories that the viewer is not
 		// allowed to access.
@@ -124,7 +125,7 @@ func listGoPackagesInRepoImprecise(ctx context.Context, repoName api.RepoName) (
 		)
 	}
 
-	repo, err := Repos.GetByName(ctx, repoName)
+	repo, err := NewRepos(db.Repos()).GetByName(ctx, repoName)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/backend/go_importers_test.go
+++ b/cmd/frontend/backend/go_importers_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -57,7 +58,7 @@ func TestCountGoImporters(t *testing.T) {
 		}, nil
 	}
 
-	count, err := CountGoImporters(ctx, wantRepoName)
+	count, err := CountGoImporters(ctx, dbmock.NewMockDB(), wantRepoName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,7 +69,7 @@ func TestCountGoImporters(t *testing.T) {
 
 func TestListGoPackagesInRepoImprecise(t *testing.T) {
 	t.Run("disabled on non-Sourcegraph.com", func(t *testing.T) {
-		if _, err := listGoPackagesInRepoImprecise(context.Background(), "a"); err == nil || !strings.Contains(err.Error(), "only supported on Sourcegraph.com") {
+		if _, err := listGoPackagesInRepoImprecise(context.Background(), dbmock.NewMockDB(), "a"); err == nil || !strings.Contains(err.Error(), "only supported on Sourcegraph.com") {
 			t.Error("want listGoPackagesInRepoImprecise to only be supported on Sourcegraph.com")
 		}
 	})

--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -37,7 +37,7 @@ func (e ErrRepoSeeOther) Error() string {
 	return fmt.Sprintf("repo not found at this location, but might exist at %s", e.RedirectURL)
 }
 
-var cache = dbcache.NewIndexableReposLister(database.GlobalRepos)
+var reposCache = dbcache.ReposCache{}
 
 // NewRepos uses the provided `database.RepoStore` to initialize a new repos
 // store for the backend.
@@ -48,7 +48,7 @@ var cache = dbcache.NewIndexableReposLister(database.GlobalRepos)
 func NewRepos(repoStore database.RepoStore) *repos {
 	return &repos{
 		store: repoStore,
-		cache: cache,
+		cache: dbcache.NewIndexableReposListerWithCache(repoStore, &reposCache),
 	}
 }
 

--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -37,7 +37,7 @@ func (e ErrRepoSeeOther) Error() string {
 	return fmt.Sprintf("repo not found at this location, but might exist at %s", e.RedirectURL)
 }
 
-var Repos = &repos{
+var globalRepos = &repos{
 	store: database.GlobalRepos,
 	cache: dbcache.NewIndexableReposLister(database.GlobalRepos),
 }
@@ -51,7 +51,7 @@ var Repos = &repos{
 func NewRepos(repoStore database.RepoStore) *repos {
 	return &repos{
 		store: repoStore,
-		cache: Repos.cache,
+		cache: globalRepos.cache,
 	}
 }
 

--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -37,10 +37,7 @@ func (e ErrRepoSeeOther) Error() string {
 	return fmt.Sprintf("repo not found at this location, but might exist at %s", e.RedirectURL)
 }
 
-var globalRepos = &repos{
-	store: database.GlobalRepos,
-	cache: dbcache.NewIndexableReposLister(database.GlobalRepos),
-}
+var cache = dbcache.NewIndexableReposLister(database.GlobalRepos)
 
 // NewRepos uses the provided `database.RepoStore` to initialize a new repos
 // store for the backend.
@@ -51,7 +48,7 @@ var globalRepos = &repos{
 func NewRepos(repoStore database.RepoStore) *repos {
 	return &repos{
 		store: repoStore,
-		cache: globalRepos.cache,
+		cache: cache,
 	}
 }
 

--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -37,8 +37,6 @@ func (e ErrRepoSeeOther) Error() string {
 	return fmt.Sprintf("repo not found at this location, but might exist at %s", e.RedirectURL)
 }
 
-var reposCache = dbcache.ReposCache{}
-
 // NewRepos uses the provided `database.RepoStore` to initialize a new repos
 // store for the backend.
 //
@@ -48,7 +46,7 @@ var reposCache = dbcache.ReposCache{}
 func NewRepos(repoStore database.RepoStore) *repos {
 	return &repos{
 		store: repoStore,
-		cache: dbcache.NewIndexableReposListerWithCache(repoStore, &reposCache),
+		cache: dbcache.NewIndexableReposLister(repoStore),
 	}
 }
 

--- a/cmd/frontend/backend/repos_vcs_test.go
+++ b/cmd/frontend/backend/repos_vcs_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cockroachdb/errors"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
@@ -39,7 +40,7 @@ func TestRepos_ResolveRev_noRevSpecified_getsDefaultBranch(t *testing.T) {
 	defer git.ResetMocks()
 
 	// (no rev/branch specified)
-	commitID, err := Repos.ResolveRev(ctx, &types.Repo{Name: "a"}, "")
+	commitID, err := NewRepos(dbmock.NewMockRepoStore()).ResolveRev(ctx, &types.Repo{Name: "a"}, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,7 +79,7 @@ func TestRepos_ResolveRev_noCommitIDSpecified_resolvesRev(t *testing.T) {
 	}
 	defer git.ResetMocks()
 
-	commitID, err := Repos.ResolveRev(ctx, &types.Repo{Name: "a"}, "b")
+	commitID, err := NewRepos(dbmock.NewMockRepoStore()).ResolveRev(ctx, &types.Repo{Name: "a"}, "b")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +118,7 @@ func TestRepos_ResolveRev_commitIDSpecified_resolvesCommitID(t *testing.T) {
 	}
 	defer git.ResetMocks()
 
-	commitID, err := Repos.ResolveRev(ctx, &types.Repo{Name: "a"}, strings.Repeat("a", 40))
+	commitID, err := NewRepos(dbmock.NewMockRepoStore()).ResolveRev(ctx, &types.Repo{Name: "a"}, strings.Repeat("a", 40))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -156,7 +157,7 @@ func TestRepos_ResolveRev_commitIDSpecified_failsToResolve(t *testing.T) {
 	}
 	defer git.ResetMocks()
 
-	_, err := Repos.ResolveRev(ctx, &types.Repo{Name: "a"}, strings.Repeat("a", 40))
+	_, err := NewRepos(dbmock.NewMockRepoStore()).ResolveRev(ctx, &types.Repo{Name: "a"}, strings.Repeat("a", 40))
 	if !errors.Is(err, want) {
 		t.Fatalf("got err %v, want %v", err, want)
 	}
@@ -190,7 +191,7 @@ func TestRepos_GetCommit_repoupdaterError(t *testing.T) {
 	}
 	defer git.ResetMocks()
 
-	commit, err := Repos.GetCommit(ctx, &types.Repo{Name: "a"}, want)
+	commit, err := NewRepos(dbmock.NewMockRepoStore()).GetCommit(ctx, &types.Repo{Name: "a"}, want)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -251,7 +251,7 @@ func (r *GitCommitResolver) Languages(ctx context.Context) ([]string, error) {
 		return nil, err
 	}
 
-	inventory, err := backend.Repos.GetInventory(ctx, repo, api.CommitID(r.oid), false)
+	inventory, err := backend.NewRepos(r.db.Repos()).GetInventory(ctx, repo, api.CommitID(r.oid), false)
 	if err != nil {
 		return nil, err
 	}
@@ -269,7 +269,7 @@ func (r *GitCommitResolver) LanguageStatistics(ctx context.Context) ([]*language
 		return nil, err
 	}
 
-	inventory, err := backend.Repos.GetInventory(ctx, repo, api.CommitID(r.oid), false)
+	inventory, err := backend.NewRepos(r.db.Repos()).GetInventory(ctx, repo, api.CommitID(r.oid), false)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -171,7 +171,7 @@ func (r *RepositoryResolver) Commit(ctx context.Context, args *RepositoryCommitA
 		return nil, err
 	}
 
-	commitID, err := backend.Repos.ResolveRev(ctx, repo, args.Rev)
+	commitID, err := backend.NewRepos(r.db.Repos()).ResolveRev(ctx, repo, args.Rev)
 	if err != nil {
 		if errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
 			return nil, nil
@@ -219,13 +219,13 @@ func (r *RepositoryResolver) Language(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	commitID, err := backend.Repos.ResolveRev(ctx, repo, "")
+	commitID, err := backend.NewRepos(r.db.Repos()).ResolveRev(ctx, repo, "")
 	if err != nil {
 		// Comment: Should we return a nil error?
 		return "", err
 	}
 
-	inventory, err := backend.Repos.GetInventory(ctx, repo, commitID, false)
+	inventory, err := backend.NewRepos(r.db.Repos()).GetInventory(ctx, repo, commitID, false)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -221,7 +221,7 @@ func (r *schemaResolver) CheckMirrorRepositoryConnection(ctx context.Context, ar
 		if err != nil {
 			return nil, err
 		}
-		repo, err = backend.Repos.Get(ctx, repoID)
+		repo, err = backend.NewRepos(r.db.Repos()).Get(ctx, repoID)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/inventory"
@@ -115,7 +116,7 @@ func TestSearchResultsStatsLanguages(t *testing.T) {
 				return test.getFiles, nil
 			}
 
-			langs, err := searchResultsStatsLanguages(context.Background(), test.results)
+			langs, err := searchResultsStatsLanguages(context.Background(), dbmock.NewMockDB(), test.results)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -313,7 +313,7 @@ func (r *searchResolver) showLangSuggestions(ctx context.Context) ([]SearchSugge
 	}
 
 	// Only care about the first found repository.
-	repos, err := backend.Repos.List(ctx, database.ReposListOptions{
+	repos, err := backend.NewRepos(r.db.Repos()).List(ctx, database.ReposListOptions{
 		IncludePatterns: validValues,
 		LimitOffset: &database.LimitOffset{
 			Limit: 1,
@@ -327,12 +327,12 @@ func (r *searchResolver) showLangSuggestions(ctx context.Context) ([]SearchSugge
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
 
-	commitID, err := backend.Repos.ResolveRev(ctx, repo, "")
+	commitID, err := backend.NewRepos(r.db.Repos()).ResolveRev(ctx, repo, "")
 	if err != nil {
 		return nil, err
 	}
 
-	inventory, err := backend.Repos.GetInventory(ctx, repo, commitID, false)
+	inventory, err := backend.NewRepos(r.db.Repos()).GetInventory(ctx, repo, commitID, false)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/internal/app/app.go
+++ b/cmd/frontend/internal/app/app.go
@@ -38,7 +38,7 @@ func NewHandler(db database.DB) http.Handler {
 	r.Get(router.Favicon).Handler(trace.Route(http.HandlerFunc(favicon)))
 	r.Get(router.OpenSearch).Handler(trace.Route(http.HandlerFunc(openSearch)))
 
-	r.Get(router.RepoBadge).Handler(trace.Route(errorutil.Handler(serveRepoBadge)))
+	r.Get(router.RepoBadge).Handler(trace.Route(errorutil.Handler(serveRepoBadge(db))))
 
 	// Redirects
 	r.Get(router.OldToolsRedirect).Handler(trace.Route(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -50,7 +50,7 @@ func NewHandler(db database.DB) http.Handler {
 	})))
 
 	if envvar.SourcegraphDotComMode() {
-		r.Get(router.GoSymbolURL).Handler(trace.Route(errorutil.Handler(serveGoSymbolURL)))
+		r.Get(router.GoSymbolURL).Handler(trace.Route(errorutil.Handler(serveGoSymbolURL(db))))
 	}
 
 	r.Get(router.UI).Handler(ui.Router())

--- a/cmd/frontend/internal/app/badge.go
+++ b/cmd/frontend/internal/app/badge.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/routevar"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 // TODO(slimsag): once https://github.com/badges/shields/pull/828 is merged,
@@ -18,8 +19,8 @@ import (
 // duplication kludge.
 
 // NOTE: Keep in sync with services/backend/httpapi/repo_shield.go
-func badgeValue(r *http.Request) (int, error) {
-	totalRefs, err := backend.CountGoImporters(r.Context(), routevar.ToRepo(mux.Vars(r)))
+func badgeValue(r *http.Request, db database.DB) (int, error) {
+	totalRefs, err := backend.CountGoImporters(r.Context(), db, routevar.ToRepo(mux.Vars(r)))
 	if err != nil {
 		return 0, errors.Wrap(err, "Defs.TotalRefs")
 	}
@@ -40,26 +41,28 @@ func badgeValueFmt(totalRefs int) string {
 	return " " + desc
 }
 
-func serveRepoBadge(w http.ResponseWriter, r *http.Request) error {
-	value, err := badgeValue(r)
-	if err != nil {
-		return err
-	}
+func serveRepoBadge(db database.DB) func(http.ResponseWriter, *http.Request) error {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		value, err := badgeValue(r, db)
+		if err != nil {
+			return err
+		}
 
-	v := url.Values{}
-	v.Set("logo", "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA3Ny4wNzUgNzcuNyI+PHBhdGggZmlsbD0iI0ZGRiIgZD0iTTQ3LjMyMyA3Ny43Yy0zLjU5NCAwLTYuNzktMi4zOTYtNy43ODctNS45OWwtMTcuMTcyLTYxLjdjLS45OTgtNC4zOTMgMS41OTgtOC43ODYgNS45OS05Ljc4NCA0LjE5My0xIDguMzg3IDEuMzk3IDkuNTg0IDUuMzlsMTYuOTczIDYxLjdjMS4xOTggNC4zOTQtMS4zOTcgOC43ODYtNS41OSA5Ljk4NC0uNi4yLTEuMzk3LjQtMS45OTcuNHoiLz48cGF0aCBmaWxsPSIjRkZGIiBkPSJNMTcuMzcyIDcwLjcxYy00LjM5MyAwLTcuOTg3LTMuNTkzLTcuOTg3LTcuOTg1IDAtMS45OTcuOC0zLjk5NCAxLjk5Ny01LjM5Mkw1NC4xMTIgOS40MWMyLjk5NS0zLjM5MyA3Ljk4Ni0zLjU5MyAxMS4zOC0uNTk4czMuNTk1IDcuOTg3LjYgMTEuMzhsLTQyLjczIDQ3LjcyM2MtMS41OTcgMS43OTgtMy43OTQgMi43OTYtNS45OSAyLjc5NnoiLz48cGF0aCBmaWxsPSIjRkZGIiBkPSJNNjkuMDg3IDU2LjczNGMtLjc5OCAwLTEuNTk3LS4yLTIuNTk2LS40TDUuNTkgMzYuMzY4QzEuNCAzNC45Ny0uOTk3IDMwLjM3Ny40IDI2LjE4NGMxLjM5Ny00LjE5MyA1Ljk5LTYuNTkgMTAuMTgzLTUuMTlsNjAuOSAxOS45NjZjNC4xOTMgMS4zOTcgNi41OSA1Ljk5IDUuMTkgMTAuMTg0LS45OTYgMy4zOTQtMy45OSA1LjU5LTcuNTg2IDUuNTl6Ii8+PC9zdmc+")
+		v := url.Values{}
+		v.Set("logo", "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA3Ny4wNzUgNzcuNyI+PHBhdGggZmlsbD0iI0ZGRiIgZD0iTTQ3LjMyMyA3Ny43Yy0zLjU5NCAwLTYuNzktMi4zOTYtNy43ODctNS45OWwtMTcuMTcyLTYxLjdjLS45OTgtNC4zOTMgMS41OTgtOC43ODYgNS45OS05Ljc4NCA0LjE5My0xIDguMzg3IDEuMzk3IDkuNTg0IDUuMzlsMTYuOTczIDYxLjdjMS4xOTggNC4zOTQtMS4zOTcgOC43ODYtNS41OSA5Ljk4NC0uNi4yLTEuMzk3LjQtMS45OTcuNHoiLz48cGF0aCBmaWxsPSIjRkZGIiBkPSJNMTcuMzcyIDcwLjcxYy00LjM5MyAwLTcuOTg3LTMuNTkzLTcuOTg3LTcuOTg1IDAtMS45OTcuOC0zLjk5NCAxLjk5Ny01LjM5Mkw1NC4xMTIgOS40MWMyLjk5NS0zLjM5MyA3Ljk4Ni0zLjU5MyAxMS4zOC0uNTk4czMuNTk1IDcuOTg3LjYgMTEuMzhsLTQyLjczIDQ3LjcyM2MtMS41OTcgMS43OTgtMy43OTQgMi43OTYtNS45OSAyLjc5NnoiLz48cGF0aCBmaWxsPSIjRkZGIiBkPSJNNjkuMDg3IDU2LjczNGMtLjc5OCAwLTEuNTk3LS4yLTIuNTk2LS40TDUuNTkgMzYuMzY4QzEuNCAzNC45Ny0uOTk3IDMwLjM3Ny40IDI2LjE4NGMxLjM5Ny00LjE5MyA1Ljk5LTYuNTkgMTAuMTgzLTUuMTlsNjAuOSAxOS45NjZjNC4xOTMgMS4zOTcgNi41OSA1Ljk5IDUuMTkgMTAuMTg0LS45OTYgMy4zOTQtMy45OSA1LjU5LTcuNTg2IDUuNTl6Ii8+PC9zdmc+")
 
-	// Allow users to pick the style of badge.
-	if val := r.URL.Query().Get("style"); val != "" {
-		v.Set("style", val)
-	}
+		// Allow users to pick the style of badge.
+		if val := r.URL.Query().Get("style"); val != "" {
+			v.Set("style", val)
+		}
 
-	u := &url.URL{
-		Scheme:   "https",
-		Host:     "img.shields.io",
-		Path:     "/badge/used by-" + badgeValueFmt(value) + "-brightgreen.svg",
-		RawQuery: v.Encode(),
+		u := &url.URL{
+			Scheme:   "https",
+			Host:     "img.shields.io",
+			Path:     "/badge/used by-" + badgeValueFmt(value) + "-brightgreen.svg",
+			RawQuery: v.Encode(),
+		}
+		http.Redirect(w, r, u.String(), http.StatusTemporaryRedirect)
+		return nil
 	}
-	http.Redirect(w, r, u.String(), http.StatusTemporaryRedirect)
-	return nil
 }

--- a/cmd/frontend/internal/app/editor_test.go
+++ b/cmd/frontend/internal/app/editor_test.go
@@ -48,7 +48,7 @@ func TestEditorRev(t *testing.T) {
 		{strings.Repeat("d", 40), "@" + strings.Repeat("d", 40), true}, // default revision, explicit
 	}
 	for _, c := range cases {
-		got, err := editorRev(ctx, repoName, c.inputRev, c.beExplicit)
+		got, err := editorRev(ctx, dbmock.NewMockDB(), repoName, c.inputRev, c.beExplicit)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/frontend/internal/app/go_symbol_url.go
+++ b/cmd/frontend/internal/app/go_symbol_url.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/gosrc"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/vfsutil"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
@@ -35,64 +36,66 @@ import (
 // serveGoSymbolURL handles Go symbol URLs (e.g.,
 // https://sourcegraph.com/go/github.com/gorilla/mux/-/Vars) by
 // redirecting them to the file and line/column URL of the definition.
-func serveGoSymbolURL(w http.ResponseWriter, r *http.Request) error {
-	ctx := r.Context()
+func serveGoSymbolURL(db database.DB) func(http.ResponseWriter, *http.Request) error {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		ctx := r.Context()
 
-	spec, err := parseGoSymbolURLPath(r.URL.Path)
-	if err != nil {
-		return err
-	}
-
-	dir, err := gosrc.ResolveImportPath(httpcli.ExternalDoer, spec.Pkg)
-	if err != nil {
-		return err
-	}
-	cloneURL := dir.CloneURL
-
-	if cloneURL == "" || !strings.HasPrefix(cloneURL, "https://github.com") {
-		return errors.Errorf("non-github clone URL resolved for import path %s", spec.Pkg)
-	}
-
-	repoName := api.RepoName(strings.TrimSuffix(strings.TrimPrefix(cloneURL, "https://"), ".git"))
-	repo, err := backend.Repos.GetByName(ctx, repoName)
-	if err != nil {
-		return err
-	}
-
-	commitID, err := backend.Repos.ResolveRev(ctx, repo, "")
-	if err != nil {
-		return err
-	}
-	_ = commitID
-
-	vfs, err := repoVFS(r.Context(), repoName, commitID)
-	if err != nil {
-		return err
-	}
-
-	pkgPath := path.Join("/", dir.RepoPrefix, strings.TrimPrefix(dir.ImportPath, dir.ProjectRoot))
-	location, err := symbolLocation(r.Context(), vfs, commitID, spec, pkgPath)
-	if err != nil {
-		return err
-	}
-	if location == nil {
-		return &errcode.HTTPErr{
-			Status: http.StatusNotFound,
-			Err:    errors.New("symbol not found"),
+		spec, err := parseGoSymbolURLPath(r.URL.Path)
+		if err != nil {
+			return err
 		}
-	}
 
-	uri, err := url.Parse(string(location.URI))
-	if err != nil {
-		return err
+		dir, err := gosrc.ResolveImportPath(httpcli.ExternalDoer, spec.Pkg)
+		if err != nil {
+			return err
+		}
+		cloneURL := dir.CloneURL
+
+		if cloneURL == "" || !strings.HasPrefix(cloneURL, "https://github.com") {
+			return errors.Errorf("non-github clone URL resolved for import path %s", spec.Pkg)
+		}
+
+		repoName := api.RepoName(strings.TrimSuffix(strings.TrimPrefix(cloneURL, "https://"), ".git"))
+		repo, err := backend.NewRepos(db.Repos()).GetByName(ctx, repoName)
+		if err != nil {
+			return err
+		}
+
+		commitID, err := backend.NewRepos(db.Repos()).ResolveRev(ctx, repo, "")
+		if err != nil {
+			return err
+		}
+		_ = commitID
+
+		vfs, err := repoVFS(r.Context(), repoName, commitID)
+		if err != nil {
+			return err
+		}
+
+		pkgPath := path.Join("/", dir.RepoPrefix, strings.TrimPrefix(dir.ImportPath, dir.ProjectRoot))
+		location, err := symbolLocation(r.Context(), vfs, commitID, spec, pkgPath)
+		if err != nil {
+			return err
+		}
+		if location == nil {
+			return &errcode.HTTPErr{
+				Status: http.StatusNotFound,
+				Err:    errors.New("symbol not found"),
+			}
+		}
+
+		uri, err := url.Parse(string(location.URI))
+		if err != nil {
+			return err
+		}
+		filePath := uri.Fragment
+		dest := &url.URL{
+			Path:     "/" + path.Join(string(repo.Name), "-/blob", filePath),
+			Fragment: fmt.Sprintf("L%d:%d$references", location.Range.Start.Line+1, location.Range.Start.Character+1),
+		}
+		http.Redirect(w, r, dest.String(), http.StatusFound)
+		return nil
 	}
-	filePath := uri.Fragment
-	dest := &url.URL{
-		Path:     "/" + path.Join(string(repo.Name), "-/blob", filePath),
-		Fragment: fmt.Sprintf("L%d:%d$references", location.Range.Start.Line+1, location.Range.Start.Character+1),
-	}
-	http.Redirect(w, r, dest.String(), http.StatusFound)
-	return nil
 }
 
 type goSymbolSpec struct {

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -159,7 +159,7 @@ func newCommon(w http.ResponseWriter, r *http.Request, db database.DB, title str
 	if _, ok := mux.Vars(r)["Repo"]; ok {
 		// Common repo pages (blob, tree, etc).
 		var err error
-		common.Repo, common.CommitID, err = handlerutil.GetRepoAndRev(r.Context(), mux.Vars(r))
+		common.Repo, common.CommitID, err = handlerutil.GetRepoAndRev(r.Context(), db, mux.Vars(r))
 		isRepoEmptyError := routevar.ToRepoRev(mux.Vars(r)).Rev == "" && errors.HasType(err, &gitdomain.RevisionNotFoundError{}) // should reply with HTTP 200
 		if err != nil && !isRepoEmptyError {
 			var urlMovedError *handlerutil.URLMovedError

--- a/cmd/frontend/internal/app/ui/landing.go
+++ b/cmd/frontend/internal/app/ui/landing.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/handlerutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
@@ -21,18 +22,20 @@ var goSymbolReg = lazyregexp.New("/info/GoPackage/(.+)$")
 
 // serveRepoLanding simply redirects the old (sourcegraph.com/<repo>/-/info) repo landing page
 // URLs directly to the repo itself (sourcegraph.com/<repo>).
-func serveRepoLanding(w http.ResponseWriter, r *http.Request) error {
-	legacyRepoLandingCounter.Inc()
+func serveRepoLanding(db database.DB) func(http.ResponseWriter, *http.Request) error {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		legacyRepoLandingCounter.Inc()
 
-	repo, commitID, err := handlerutil.GetRepoAndRev(r.Context(), mux.Vars(r))
-	if err != nil {
-		if errcode.IsHTTPErrorCode(err, http.StatusNotFound) {
-			return &errcode.HTTPErr{Status: http.StatusNotFound, Err: err}
+		repo, commitID, err := handlerutil.GetRepoAndRev(r.Context(), db, mux.Vars(r))
+		if err != nil {
+			if errcode.IsHTTPErrorCode(err, http.StatusNotFound) {
+				return &errcode.HTTPErr{Status: http.StatusNotFound, Err: err}
+			}
+			return errors.Wrap(err, "GetRepoAndRev")
 		}
-		return errors.Wrap(err, "GetRepoAndRev")
+		http.Redirect(w, r, "/"+string(repo.Name)+"@"+string(commitID), http.StatusMovedPermanently)
+		return nil
 	}
-	http.Redirect(w, r, "/"+string(repo.Name)+"@"+string(commitID), http.StatusMovedPermanently)
-	return nil
 }
 
 func serveDefLanding(w http.ResponseWriter, r *http.Request) (err error) {

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -279,7 +279,7 @@ func initRouter(db database.DB, router *mux.Router, codeIntelResolver graphqlbac
 		router.Get(routeLegacyOldRouteDefLanding).Handler(http.HandlerFunc(serveOldRouteDefLanding))
 		router.Get(routeLegacyDefRedirectToDefLanding).Handler(http.HandlerFunc(serveDefRedirectToDefLanding))
 		router.Get(routeLegacyDefLanding).Handler(handler(db, serveDefLanding))
-		router.Get(routeLegacyRepoLanding).Handler(handler(db, serveRepoLanding))
+		router.Get(routeLegacyRepoLanding).Handler(handler(db, serveRepoLanding(db)))
 	}
 
 	// search

--- a/cmd/frontend/internal/handlerutil/repo.go
+++ b/cmd/frontend/internal/handlerutil/repo.go
@@ -9,16 +9,17 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/routevar"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 // GetRepo gets the repo (from the reposSvc) specified in the URL's
 // Repo route param. Callers should ideally check for a return error of type
 // URLMovedError and handle this scenario by warning or redirecting the user.
-func GetRepo(ctx context.Context, vars map[string]string) (*types.Repo, error) {
+func GetRepo(ctx context.Context, db database.DB, vars map[string]string) (*types.Repo, error) {
 	origRepo := routevar.ToRepo(vars)
 
-	repo, err := backend.Repos.GetByName(ctx, origRepo)
+	repo, err := backend.NewRepos(db.Repos()).GetByName(ctx, origRepo)
 	if err != nil {
 		return nil, err
 	}
@@ -31,13 +32,13 @@ func GetRepo(ctx context.Context, vars map[string]string) (*types.Repo, error) {
 }
 
 // getRepoRev resolves the repository and commit specified in the route vars.
-func getRepoRev(ctx context.Context, vars map[string]string, repoID api.RepoID) (api.RepoID, api.CommitID, error) {
+func getRepoRev(ctx context.Context, db database.DB, vars map[string]string, repoID api.RepoID) (api.RepoID, api.CommitID, error) {
 	repoRev := routevar.ToRepoRev(vars)
-	repo, err := backend.Repos.Get(ctx, repoID)
+	repo, err := backend.NewRepos(db.Repos()).Get(ctx, repoID)
 	if err != nil {
 		return repoID, "", err
 	}
-	commitID, err := backend.Repos.ResolveRev(ctx, repo, repoRev.Rev)
+	commitID, err := backend.NewRepos(db.Repos()).ResolveRev(ctx, repo, repoRev.Rev)
 	if err != nil {
 		return repoID, "", err
 	}
@@ -48,13 +49,13 @@ func getRepoRev(ctx context.Context, vars map[string]string, repoID api.RepoID) 
 // GetRepoAndRev returns the repo object and the commit ID for a repository. It may
 // also return custom error URLMovedError to allow special handling of this case,
 // such as for example redirecting the user.
-func GetRepoAndRev(ctx context.Context, vars map[string]string) (*types.Repo, api.CommitID, error) {
-	repo, err := GetRepo(ctx, vars)
+func GetRepoAndRev(ctx context.Context, db database.DB, vars map[string]string) (*types.Repo, api.CommitID, error) {
+	repo, err := GetRepo(ctx, db, vars)
 	if err != nil {
 		return repo, "", err
 	}
 
-	_, commitID, err := getRepoRev(ctx, vars, repo.ID)
+	_, commitID, err := getRepoRev(ctx, db, vars, repo.ID)
 	return repo, commitID, err
 }
 

--- a/cmd/frontend/internal/handlerutil/repo_test.go
+++ b/cmd/frontend/internal/handlerutil/repo_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -20,7 +21,7 @@ func TestGetRepo(t *testing.T) {
 			backend.Mocks.Repos = backend.MockRepos{}
 		})
 
-		_, err := GetRepo(context.Background(), map[string]string{"Repo": "repo1"})
+		_, err := GetRepo(context.Background(), dbmock.NewMockDB(), map[string]string{"Repo": "repo1"})
 		if !errors.HasType(err, &URLMovedError{}) {
 			t.Fatalf("err: want type *URLMovedError but got %T", err)
 		}

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -53,9 +53,9 @@ func NewHandler(db database.DB, m *mux.Router, schema *graphql.Schema, githubWeb
 	})
 
 	// Set handlers for the installed routes.
-	m.Get(apirouter.RepoShield).Handler(trace.Route(handler(serveRepoShield)))
+	m.Get(apirouter.RepoShield).Handler(trace.Route(handler(serveRepoShield(db))))
 
-	m.Get(apirouter.RepoRefresh).Handler(trace.Route(handler(serveRepoRefresh)))
+	m.Get(apirouter.RepoRefresh).Handler(trace.Route(handler(serveRepoRefresh(db))))
 
 	gh := webhooks.GitHubWebhook{
 		ExternalServices: database.ExternalServices(db),
@@ -120,7 +120,7 @@ func NewInternalHandler(m *mux.Router, db database.DB, schema *graphql.Schema, n
 
 	// zoekt-indexserver endpoints
 	indexer := &searchIndexerServer{
-		ListIndexable:       backend.Repos.ListIndexable,
+		ListIndexable:       backend.NewRepos(db.Repos()).ListIndexable,
 		RepoStore:           database.Repos(db),
 		SearchContextsStore: database.SearchContexts(db),
 		Indexers:            search.Indexers(),
@@ -130,7 +130,7 @@ func NewInternalHandler(m *mux.Router, db database.DB, schema *graphql.Schema, n
 	m.Get(apirouter.SearchConfiguration).Handler(trace.Route(handler(indexer.serveConfiguration)))
 	m.Get(apirouter.ReposIndex).Handler(trace.Route(handler(indexer.serveList)))
 
-	m.Get(apirouter.ReposGetByName).Handler(trace.Route(handler(serveReposGetByName)))
+	m.Get(apirouter.ReposGetByName).Handler(trace.Route(handler(serveReposGetByName(db))))
 	m.Get(apirouter.SettingsGetForSubject).Handler(trace.Route(handler(serveSettingsGetForSubject(db))))
 	m.Get(apirouter.SavedQueriesListAll).Handler(trace.Route(handler(serveSavedQueriesListAll(db))))
 	m.Get(apirouter.SavedQueriesGetInfo).Handler(trace.Route(handler(serveSavedQueriesGetInfo(db))))

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -25,19 +25,21 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
-func serveReposGetByName(w http.ResponseWriter, r *http.Request) error {
-	repoName := api.RepoName(mux.Vars(r)["RepoName"])
-	repo, err := backend.Repos.GetByName(r.Context(), repoName)
-	if err != nil {
-		return err
+func serveReposGetByName(db database.DB) func(http.ResponseWriter, *http.Request) error {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		repoName := api.RepoName(mux.Vars(r)["RepoName"])
+		repo, err := backend.NewRepos(db.Repos()).GetByName(r.Context(), repoName)
+		if err != nil {
+			return err
+		}
+		data, err := json.Marshal(repo)
+		if err != nil {
+			return err
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(data)
+		return nil
 	}
-	data, err := json.Marshal(repo)
-	if err != nil {
-		return err
-	}
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(data)
-	return nil
 }
 
 func servePhabricatorRepoCreate(db database.DB) func(w http.ResponseWriter, r *http.Request) error {

--- a/cmd/frontend/internal/httpapi/repo_refresh.go
+++ b/cmd/frontend/internal/httpapi/repo_refresh.go
@@ -6,17 +6,20 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/handlerutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 )
 
-func serveRepoRefresh(w http.ResponseWriter, r *http.Request) error {
-	ctx := r.Context()
+func serveRepoRefresh(db database.DB) func(http.ResponseWriter, *http.Request) error {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		ctx := r.Context()
 
-	repo, err := handlerutil.GetRepo(ctx, mux.Vars(r))
-	if err != nil {
+		repo, err := handlerutil.GetRepo(ctx, db, mux.Vars(r))
+		if err != nil {
+			return err
+		}
+
+		_, err = repoupdater.DefaultClient.EnqueueRepoUpdate(ctx, repo.Name)
 		return err
 	}
-
-	_, err = repoupdater.DefaultClient.EnqueueRepoUpdate(ctx, repo.Name)
-	return err
 }

--- a/cmd/frontend/internal/httpapi/repo_shield.go
+++ b/cmd/frontend/internal/httpapi/repo_shield.go
@@ -9,11 +9,12 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/routevar"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 // NOTE: Keep in sync with services/backend/httpapi/repo_shield.go
-func badgeValue(r *http.Request) (int, error) {
-	totalRefs, err := backend.CountGoImporters(r.Context(), routevar.ToRepo(mux.Vars(r)))
+func badgeValue(r *http.Request, db database.DB) (int, error) {
+	totalRefs, err := backend.CountGoImporters(r.Context(), db, routevar.ToRepo(mux.Vars(r)))
 	if err != nil {
 		return 0, errors.Wrap(err, "Defs.TotalRefs")
 	}
@@ -34,16 +35,18 @@ func badgeValueFmt(totalRefs int) string {
 	return " " + desc
 }
 
-func serveRepoShield(w http.ResponseWriter, r *http.Request) error {
-	value, err := badgeValue(r)
-	if err != nil {
-		return err
+func serveRepoShield(db database.DB) func(http.ResponseWriter, *http.Request) error {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		value, err := badgeValue(r, db)
+		if err != nil {
+			return err
+		}
+		return writeJSON(w, &struct {
+			// Note: Named lowercase because the JSON is consumed by shields.io JS
+			// code.
+			Value string `json:"value"`
+		}{
+			Value: badgeValueFmt(value),
+		})
 	}
-	return writeJSON(w, &struct {
-		// Note: Named lowercase because the JSON is consumed by shields.io JS
-		// code.
-		Value string `json:"value"`
-	}{
-		Value: badgeValueFmt(value),
-	})
 }

--- a/enterprise/cmd/frontend/internal/codeintel/httpapi/upload_handler.go
+++ b/enterprise/cmd/frontend/internal/codeintel/httpapi/upload_handler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
@@ -73,7 +74,7 @@ func (h *UploadHandler) handleEnqueue(w http.ResponseWriter, r *http.Request) {
 		// 🚨 SECURITY: It is critical to ensure if repository and commit exists after
 		// the above authz check. Otherwise, it is possible to use this endpoint to
 		// brute-force existence of repositories.
-		repo, ok := ensureRepoAndCommitExist(ctx, w, repoName, commit)
+		repo, ok := ensureRepoAndCommitExist(ctx, database.NewDB(h.db), w, repoName, commit)
 		if !ok {
 			return
 		}
@@ -387,11 +388,11 @@ func inferIndexer(r *http.Request) (string, error) {
 // 🚨 SECURITY: It is critical to call this function after necessary authz check
 // because this function would bypass authz to for testing if the repository and
 // commit exists in Sourcegraph.
-func ensureRepoAndCommitExist(ctx context.Context, w http.ResponseWriter, repoName, commit string) (*types.Repo, bool) {
+func ensureRepoAndCommitExist(ctx context.Context, db database.DB, w http.ResponseWriter, repoName, commit string) (*types.Repo, bool) {
 	// This function won't be able to see all repositories without bypassing authz.
 	ctx = actor.WithInternalActor(ctx)
 
-	repo, err := backend.Repos.GetByName(ctx, api.RepoName(repoName))
+	repo, err := backend.NewRepos(db.Repos()).GetByName(ctx, api.RepoName(repoName))
 	if err != nil {
 		if errcode.IsNotFound(err) {
 			http.Error(w, fmt.Sprintf("unknown repository %q", repoName), http.StatusNotFound)
@@ -402,7 +403,7 @@ func ensureRepoAndCommitExist(ctx context.Context, w http.ResponseWriter, repoNa
 		return nil, false
 	}
 
-	if _, err := backend.Repos.ResolveRev(ctx, repo, commit); err != nil {
+	if _, err := backend.NewRepos(db.Repos()).ResolveRev(ctx, repo, commit); err != nil {
 		if errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
 			http.Error(w, fmt.Sprintf("unknown commit %q", commit), http.StatusNotFound)
 			return nil, false

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/configuration_policy.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/configuration_policy.go
@@ -34,15 +34,16 @@ func (r *configurationPolicyResolver) Name() string {
 }
 
 func (r *configurationPolicyResolver) Repository(ctx context.Context) (*gql.RepositoryResolver, error) {
+	db := database.NewDB(dbconn.Global)
 	if r.configurationPolicy.RepositoryID == nil {
 		return nil, nil
 	}
-	repo, err := backend.Repos.Get(ctx, api.RepoID(*r.configurationPolicy.RepositoryID))
+	repo, err := backend.NewRepos(db.Repos()).Get(ctx, api.RepoID(*r.configurationPolicy.RepositoryID))
 	if err != nil {
 		return nil, err
 	}
 
-	return gql.NewRepositoryResolver(database.NewDB(dbconn.Global), repo), nil
+	return gql.NewRepositoryResolver(db, repo), nil
 }
 
 func (r *configurationPolicyResolver) RepositoryPatterns() *[]string {

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations.go
@@ -206,7 +206,7 @@ func (r *CachedLocationResolver) cachedPath(ctx context.Context, id api.RepoID, 
 // repo that has since been deleted. This method must be called only when constructing a resolver to
 // populate the cache.
 func (r *CachedLocationResolver) resolveRepository(ctx context.Context, id api.RepoID) (*gql.RepositoryResolver, error) {
-	repo, err := backend.Repos.Get(ctx, id)
+	repo, err := backend.NewRepos(r.db.Repos()).Get(ctx, id)
 	if err != nil {
 		if errcode.IsNotFound(err) {
 			return nil, nil

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
@@ -453,14 +453,15 @@ func (r *Resolver) PreviewRepositoryFilter(ctx context.Context, args *gql.Previe
 		return nil, err
 	}
 
+	db := database.NewDB(dbconn.Global)
 	resolvers := make([]*gql.RepositoryResolver, 0, len(ids))
 	for _, id := range ids {
-		repo, err := backend.Repos.Get(ctx, api.RepoID(id))
+		repo, err := backend.NewRepos(db.Repos()).Get(ctx, api.RepoID(id))
 		if err != nil {
 			return nil, err
 		}
 
-		resolvers = append(resolvers, gql.NewRepositoryResolver(database.NewDB(dbconn.Global), repo))
+		resolvers = append(resolvers, gql.NewRepositoryResolver(db, repo))
 	}
 
 	limitedCount := totalCount

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -54,6 +54,10 @@ func NewDB(inner dbutil.DB) DB {
 	return &db{basestore.NewWithDB(inner, sql.TxOptions{})}
 }
 
+func NewDBWith(other basestore.ShareableStore) DB {
+	return &db{basestore.NewWithHandle(other.Handle())}
+}
+
 type db struct {
 	*basestore.Store
 }

--- a/internal/database/dbcache/cached_indexable_repos.go
+++ b/internal/database/dbcache/cached_indexable_repos.go
@@ -36,18 +36,29 @@ func (c *cachedRepos) Repos() ([]types.MinimalRepo, bool) {
 
 func NewIndexableReposLister(store database.RepoStore) *IndexableReposLister {
 	return &IndexableReposLister{
-		store: store,
+		store:      store,
+		ReposCache: &ReposCache{},
 	}
+}
+
+func NewIndexableReposListerWithCache(store database.RepoStore, cache *ReposCache) *IndexableReposLister {
+	return &IndexableReposLister{
+		store:      store,
+		ReposCache: cache,
+	}
+}
+
+type ReposCache struct {
+	cacheAllRepos    atomic.Value
+	cachePublicRepos atomic.Value
+	mu               sync.Mutex
 }
 
 // IndexableReposLister holds the list of indexable repos which are cached for
 // indexableReposMaxAge.
 type IndexableReposLister struct {
 	store database.RepoStore
-
-	cacheAllRepos    atomic.Value
-	cachePublicRepos atomic.Value
-	mu               sync.Mutex
+	*ReposCache
 }
 
 // List lists ALL indexable repos. These include all repos with a minimum number of stars,

--- a/internal/database/dbcache/cached_indexable_repos.go
+++ b/internal/database/dbcache/cached_indexable_repos.go
@@ -34,21 +34,16 @@ func (c *cachedRepos) Repos() ([]types.MinimalRepo, bool) {
 	return append([]types.MinimalRepo{}, c.repos...), time.Since(c.fetched) > indexableReposMaxAge
 }
 
+var globalReposCache = reposCache{}
+
 func NewIndexableReposLister(store database.RepoStore) *IndexableReposLister {
 	return &IndexableReposLister{
 		store:      store,
-		ReposCache: &ReposCache{},
+		reposCache: &globalReposCache,
 	}
 }
 
-func NewIndexableReposListerWithCache(store database.RepoStore, cache *ReposCache) *IndexableReposLister {
-	return &IndexableReposLister{
-		store:      store,
-		ReposCache: cache,
-	}
-}
-
-type ReposCache struct {
+type reposCache struct {
 	cacheAllRepos    atomic.Value
 	cachePublicRepos atomic.Value
 	mu               sync.Mutex
@@ -58,7 +53,7 @@ type ReposCache struct {
 // indexableReposMaxAge.
 type IndexableReposLister struct {
 	store database.RepoStore
-	*ReposCache
+	*reposCache
 }
 
 // List lists ALL indexable repos. These include all repos with a minimum number of stars,

--- a/internal/database/stores.go
+++ b/internal/database/stores.go
@@ -1,7 +1,0 @@
-package database
-
-// Global reference to database stores using the global dbconn.Global connection handle.
-// Deprecated: Use store constructors instead.
-var (
-	GlobalRepos RepoStore = &repoStore{}
-)


### PR DESCRIPTION
This PR takes the steps needed to remove GlobalRepos, which
is the last of our global stores 🥳 

This PR comes in 5 commits:
1) Convert all uses of `backend.Repos` into `backend.NewRepos()`. This is the meat of this PR. It requires making sure there is a db available to pass in, which is what #28120 enabled
2) Now that the only use of the global `Repos` value is to get its cache, unwrap it to just leave the cache.
3) In order to remove the last use of `GlobalRepos`, we need to be able to create an `IndexableReposLister` with a shared cache and a passed-in db handle. This splits the cache type from the lister type so we can pass it in separately.
4) `GlobalRepos` is now unused, so remove it
5) Now that `GlobalRepos` is gone, we don't need `ensureStore`. 

Also, this gets rid of one more reference to`dbconn.Global` that was used in `ensureStore` methods. 

1 down, 33 to go.

Stacked on #28118 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
