### PR TITLE
bump golangci-lint version

### DIFF
--- a/cmd/frontend/internal/routevar/repo_test.go
+++ b/cmd/frontend/internal/routevar/repo_test.go
@@ -11,10 +11,7 @@ import (
 )
 
 func TestRepoPattern(t *testing.T) {
-	pat, err := regexp.Compile("^" + RepoPattern + "$")
-	if err != nil {
-		t.Fatal(err)
-	}
+	pat := regexp.MustCompile("^" + RepoPattern + "$")
 
 	tests := []struct {
 		input     string
@@ -62,10 +59,7 @@ func TestRepoPattern(t *testing.T) {
 }
 
 func TestRevPattern(t *testing.T) {
-	pat, err := regexp.Compile("^" + RevPattern + "$")
-	if err != nil {
-		t.Fatal(err)
-	}
+	pat := regexp.MustCompile("^" + RevPattern + "$")
 
 	tests := []struct {
 		input     string

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -793,7 +793,7 @@ func wrapCmdError(cmd *exec.Cmd, err error) error {
 // removeFileOlderThan removes path if its mtime is older than maxAge. If the
 // file is missing, no error is returned.
 func removeFileOlderThan(path string, maxAge time.Duration) error {
-	fi, err := os.Stat(filepath.Join(path))
+	fi, err := os.Stat(filepath.Clean(path))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil

--- a/dev/golangci-lint.sh
+++ b/dev/golangci-lint.sh
@@ -6,7 +6,7 @@ pushd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null
 
 mkdir -p .bin
 
-version="1.37.1"
+version="1.43.0"
 suffix="${version}-$(go env GOOS)-$(go env GOARCH)"
 target="$PWD/.bin/golangci-lint-${suffix}"
 url="https://github.com/golangci/golangci-lint/releases/download/v${version}/golangci-lint-${suffix}.tar.gz"

--- a/enterprise/internal/batches/service/mocks.go
+++ b/enterprise/internal/batches/service/mocks.go
@@ -10,7 +10,7 @@ type ServiceMocks struct {
 	ValidateAuthenticator func(ctx context.Context, externalServiceID, externalServiceType string, a auth.Authenticator) error
 }
 
-func (sm ServiceMocks) Reset() {
+func (sm *ServiceMocks) Reset() {
 	sm.ValidateAuthenticator = nil
 }
 

--- a/internal/cmd/progress-bot/main.go
+++ b/internal/cmd/progress-bot/main.go
@@ -480,6 +480,7 @@ func parseGitBlame(r io.Reader) (b GitBlame, err error) {
 		line := sc.Text()
 		switch n {
 		case 0: // commit ID
+			//nolint:gocritic
 			l.Ref = line[:strings.Index(line, " ")]
 		case 1:
 			l.Author.Name = strings.TrimPrefix(line, "author ")


### PR DESCRIPTION
This bumps the version of golangci-lint to the latest release, and fixes
the new issues that it now detects.

Seems the new version comes with some performance improvements
as well: on my machine, `./dev/check/go-lint.sh` dropped from 20.5s
to 14.1s. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
