### PR TITLE
docker: bump alpine base image from 3.12 to 3.14

### DIFF
--- a/dev/check/no-alpine-guard.sh
+++ b/dev/check/no-alpine-guard.sh
@@ -15,7 +15,7 @@ set +e
 ALPINE_MATCHES=$(git grep -e '\salpine\:' --and --not -e '^\s*//' --and --not -e 'CI\:LOCALHOST_OK' \
   ':(exclude)doc/admin/updates/docker_compose.md' \
   ':(exclude)docker-images/README.md' \
-  ':(exclude)docker-images/alpine-3.12/' \
+  ':(exclude)docker-images/alpine-3.14/' \
   ':(exclude)doc/batch_changes/' \
   ':(exclude)web/src/enterprise/batches/create/CreateBatchChangePage.tsx' \
   ':(exclude)*_test.go' \

--- a/docker-images/README.md
+++ b/docker-images/README.md
@@ -14,17 +14,6 @@ All images in this directory are built and published automatically on CI:
 - See [the handbook](https://handbook.sourcegraph.com/engineering/deployments) for more information
 - Or see [how to build a test image](https://handbook.sourcegraph.com/engineering/deployments#building-docker-images-for-a-specific-branch) if you need to build a test image without merging your change to `master` first.
 
-### Exception: `docker-images/alpine` is manually built and pushed as needed.
-
-```sh
-git checkout master
-cd docker-images/alpine
-IMAGE=sourcegraph/alpine:$MY_VERSION ./build.sh
-VERSION=$MY_VERSION ./release.sh
-```
-
-Note: `$MY_VERSION` above should reflect the underlying Alpine version. If changes are made without altering the underlying Alpine version, then bump the suffix. For example, use 3.10-1, 3.10-2, and so on. To find the current version, consult https://hub.docker.com/r/sourcegraph/alpine
-
 ## Adding a new image
 
 1. Create a `build.sh` and add your publishing script to it - the script should end with `docker tag ... "$IMAGE"`. See the scripts in this directory for examples.

--- a/docker-images/alpine-3.12/release.sh
+++ b/docker-images/alpine-3.12/release.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -ex
-cd "$(dirname "${BASH_SOURCE[0]}")"
-
-docker tag sourcegraph/alpine-3.12:"$VERSION" sourcegraph/alpine-3.12:latest
-docker push sourcegraph/alpine-3.12:"$VERSION"
-docker push sourcegraph/alpine-3.12:latest

--- a/docker-images/alpine-3.14/Dockerfile
+++ b/docker-images/alpine-3.14/Dockerfile
@@ -32,4 +32,4 @@ RUN apk update && apk add --no-cache \
     mailcap \
     tini \
     # Required due to ssl_clent upgrade with busybox
-    'wget=1.21.1-r1'
+    wget

--- a/docker-images/alpine-3.14/Dockerfile
+++ b/docker-images/alpine-3.14/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile defines the sourcegraph/alpine Docker image, which is the
 # base image used by all Sourcegraph Docker images.
 
-FROM alpine:3.12@sha256:a721d672be3cdaaf1285c2b60b76d81ab4a8a3cf5a7180a966f2c545305ad6de
+FROM alpine:3.14@sha256:635f0aa53d99017b38d1a0aa5b2082f7812b03e3cdb299103fe77b5c8a07f1d2
 
 LABEL org.opencontainers.image.url=https://sourcegraph.com/
 LABEL org.opencontainers.image.source=https://github.com/sourcegraph/sourcegraph/
@@ -24,12 +24,12 @@ RUN addgroup -g 101 -S sourcegraph && adduser -u 100 -S -G sourcegraph -h /home/
 # Install other packages that are desirable in ALL Sourcegraph Docker images.
 # hadolint ignore=DL3018
 RUN apk update && apk add --no-cache \
-    bind-tools \ 
-    # Requires the use of the edge repo for CVE-2021-28831 until a patched version is brought into the 3.12 mirror. 
+    bind-tools \
+    # Requires the use of the edge repo for CVE-2021-28831 until a patched version is brought into the 3.12 mirror.
     'busybox=1.34.1-r3' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
     ca-certificates \
-    curl \ 
+    curl \
     mailcap \
-    tini \ 
+    tini \
     # Required due to ssl_clent upgrade with busybox
-    'wget=1.21.1-r1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main
+    'wget=1.21.1-r1'

--- a/docker-images/alpine-3.14/build.sh
+++ b/docker-images/alpine-3.14/build.sh
@@ -3,4 +3,4 @@
 set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-docker build -t "${IMAGE:-sourcegraph/alpine-3.12}" .
+docker build -t "${IMAGE:-sourcegraph/alpine-3.14}" .

--- a/docker-images/alpine-3.14/update-all-dockerfiles.sh
+++ b/docker-images/alpine-3.14/update-all-dockerfiles.sh
@@ -35,7 +35,7 @@ get_new_tag_and_digest() {
 
 check_sd_installed
 
-REPO="sourcegraph/alpine-3.12"
+REPO="sourcegraph/alpine-3.14"
 
 MISSING_MESSAGE="Please provide the image tag either via the 'TAG' environent variable or as a shell script argument"
 TAG="${TAG:-${1:?"$MISSING_MESSAGE"}}"

--- a/enterprise/dev/ci/images/images.go
+++ b/enterprise/dev/ci/images/images.go
@@ -56,7 +56,7 @@ var SourcegraphDockerImages = append(DeploySourcegraphDockerImages,
 // Used to cross check images in the deploy-sourcegraph repo. If you are adding or removing an image to https://github.com/sourcegraph/deploy-sourcegraph
 // it must also be added to this list.
 var DeploySourcegraphDockerImages = []string{
-	"alpine-3.12",
+	"alpine-3.14",
 	"cadvisor",
 	"codeinsights-db",
 	"codeintel-db",


### PR DESCRIPTION
This bumps the version of alpine from 3.12 to 3.14. For now all other docker images still refer to sourcegraph/alpine-3.12. Once CI starts pushing 3.14, I will update all docker images to refer to sourcegraph/alpine-3.14 instead.

Why?

We want to use git >=2.30 on [gitserver](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/gitserver/Dockerfile?L38&subtree=true), which is incompatible with [the version of git-p4 (2.26.3) that ships with alpine 3.12](https://pkgs.alpinelinux.org/packages?name=git-p4&branch=v3.12&arch=x86_64). 

I also updated the README and deleted a script (release.sh) we we don't seem to use anymore.