### PR TITLE
Code Insights: [FE] Use Monaco query input for insight query field

### DIFF
--- a/client/web/src/enterprise/insights/components/form/hooks/useField.ts
+++ b/client/web/src/enterprise/insights/components/form/hooks/useField.ts
@@ -44,7 +44,7 @@ export interface useFieldAPI<FieldValue> {
         name: string
         value: FieldValue
         onChange: (event: ChangeEvent<HTMLInputElement> | FieldValue) => void
-        onBlur: FocusEventHandler<HTMLInputElement>
+        onBlur: FocusEventHandler<HTMLInputElement> | (() => void)
     } & InputProps<FieldValue>
 
     /**

--- a/client/web/src/enterprise/insights/components/live-preview-container/LivePreviewContainer.tsx
+++ b/client/web/src/enterprise/insights/components/live-preview-container/LivePreviewContainer.tsx
@@ -17,6 +17,7 @@ export interface LivePreviewContainerProps {
     loading: boolean
     disabled: boolean
     className?: string
+    chartContentClassName?: string
     dataOrError: ChartContent | Error | undefined
     defaultMock: ChartContent
     mockMessage: ReactNode
@@ -24,7 +25,17 @@ export interface LivePreviewContainerProps {
 }
 
 export function LivePreviewContainer(props: LivePreviewContainerProps): ReactElement {
-    const { disabled, loading, dataOrError, defaultMock, onUpdateClick, className, mockMessage, description } = props
+    const {
+        disabled,
+        loading,
+        dataOrError,
+        defaultMock,
+        onUpdateClick,
+        className,
+        chartContentClassName,
+        mockMessage,
+        description,
+    } = props
 
     return (
         <section className={classNames(styles.livePreview, className)}>
@@ -49,7 +60,7 @@ export function LivePreviewContainer(props: LivePreviewContainerProps): ReactEle
             {isErrorLike(dataOrError) && <ErrorAlert className="m-0" error={dataOrError} />}
 
             {!loading && !isErrorLike(dataOrError) && (
-                <div className={classNames(styles.livePreviewChartContainer, 'card')}>
+                <div className={classNames(styles.livePreviewChartContainer, chartContentClassName, 'card')}>
                     <ChartViewContent
                         className={classNames(styles.livePreviewChart, 'card-body', {
                             [styles.livePreviewChartWithMock]: !dataOrError,

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/DataSeriesQueryField.module.scss
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/DataSeriesQueryField.module.scss
@@ -1,4 +1,5 @@
 .field {
+    min-height: 34px;
     height: auto;
 
     &:focus-within,
@@ -29,5 +30,9 @@
         :global(.theme-dark) &:focus-within {
             box-shadow: 0 0 0 2px var(--danger-3);
         }
+    }
+
+    :global(.scroll-decoration) {
+        display: none;
     }
 }

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/DataSeriesQueryField.module.scss
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/DataSeriesQueryField.module.scss
@@ -1,0 +1,33 @@
+.field {
+    height: auto;
+
+    &:focus-within,
+    &:focus {
+        border: 1px solid var(--input-focus-border-color);
+        box-shadow: 0 0 0 2px rgba(28, 126, 214, 0.25);
+    }
+
+    &:global(.is-valid) {
+        border-color: var(--success);
+
+        :global(.theme-light) &:focus-within {
+            box-shadow: 0 0 0 2px var(--success-2);
+        }
+
+        :global(.theme-dark) &:focus-within {
+            box-shadow: 0 0 0 2px var(--success-3);
+        }
+    }
+
+    &:global(.is-invalid) {
+        border-color: var(--danger);
+
+        :global(.theme-light) &:focus-within {
+            box-shadow: 0 0 0 2px var(--danger-2);
+        }
+
+        :global(.theme-dark) &:focus-within {
+            box-shadow: 0 0 0 2px var(--danger-3);
+        }
+    }
+}

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/DataSeriesQueryField.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/DataSeriesQueryField.tsx
@@ -1,0 +1,55 @@
+import classNames from 'classnames'
+import { noop } from 'lodash'
+import * as Monaco from 'monaco-editor'
+import React, { InputHTMLAttributes, useMemo } from 'react'
+
+import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
+
+import { LazyMonacoQueryInput } from '../../../../../../../../search/input/LazyMonacoQueryInput'
+import { DEFAULT_MONACO_OPTIONS } from '../../../../../../../../search/input/MonacoQueryInput'
+import { ThemePreference, useThemeState } from '../../../../../../../../theme'
+
+import styles from './DataSeriesQueryField.module.scss'
+
+const MONACO_OPTIONS: Monaco.editor.IStandaloneEditorConstructionOptions = {
+    ...DEFAULT_MONACO_OPTIONS,
+    wordWrap: 'on',
+    fixedOverflowWidgets: false,
+    scrollbar: {
+        vertical: 'auto',
+        horizontal: 'hidden',
+    },
+}
+
+interface DataSeriesQueryFieldProps
+    extends Omit<InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange' | 'onBlur'> {
+    value: string
+    onBlur: () => void
+    onChange: (value: string) => void
+}
+
+export const DataSeriesQueryField: React.FunctionComponent<DataSeriesQueryFieldProps> = props => {
+    const { value, className, onChange, onBlur = noop, disabled, autoFocus } = props
+    const { enhancedThemePreference } = useThemeState()
+
+    const monacoOptions = useMemo(() => ({ ...MONACO_OPTIONS, readOnly: disabled }), [disabled])
+
+    return (
+        <LazyMonacoQueryInput
+            queryState={{ query: value }}
+            isLightTheme={enhancedThemePreference === ThemePreference.Light}
+            isSourcegraphDotCom={false}
+            preventNewLine={false}
+            onChange={({ query }) => onChange(query)}
+            patternType={SearchPatternType.regexp}
+            caseSensitive={false}
+            globbing={true}
+            height="auto"
+            onSubmit={noop}
+            className={classNames(className, styles.field)}
+            editorOptions={monacoOptions}
+            autoFocus={autoFocus}
+            onBlur={onBlur}
+        />
+    )
+}

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/DataSeriesQueryField.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/DataSeriesQueryField.tsx
@@ -5,6 +5,7 @@ import React, { InputHTMLAttributes, useMemo } from 'react'
 
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 
+import { QueryChangeSource } from '../../../../../../../../search/helpers'
 import { LazyMonacoQueryInput } from '../../../../../../../../search/input/LazyMonacoQueryInput'
 import { DEFAULT_MONACO_OPTIONS } from '../../../../../../../../search/input/MonacoQueryInput'
 import { ThemePreference, useThemeState } from '../../../../../../../../theme'
@@ -15,6 +16,7 @@ const MONACO_OPTIONS: Monaco.editor.IStandaloneEditorConstructionOptions = {
     ...DEFAULT_MONACO_OPTIONS,
     wordWrap: 'on',
     fixedOverflowWidgets: false,
+    lineHeight: 21,
     scrollbar: {
         vertical: 'auto',
         horizontal: 'hidden',
@@ -36,7 +38,7 @@ export const DataSeriesQueryField: React.FunctionComponent<DataSeriesQueryFieldP
 
     return (
         <LazyMonacoQueryInput
-            queryState={{ query: value }}
+            queryState={{ query: value, changeSource: QueryChangeSource.userInput }}
             isLightTheme={enhancedThemePreference === ThemePreference.Light}
             isSourcegraphDotCom={false}
             preventNewLine={false}

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/DataSeriesQueryField.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/DataSeriesQueryField.tsx
@@ -8,8 +8,8 @@ import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { QueryChangeSource } from '../../../../../../../../search/helpers'
 import { LazyMonacoQueryInput } from '../../../../../../../../search/input/LazyMonacoQueryInput'
 import { DEFAULT_MONACO_OPTIONS } from '../../../../../../../../search/input/MonacoQueryInput'
-import { ThemePreference } from '../../../../../../../../stores/themeState';
-import { useTheme } from '../../../../../../../../theme';
+import { ThemePreference } from '../../../../../../../../stores/themeState'
+import { useTheme } from '../../../../../../../../theme'
 
 import styles from './DataSeriesQueryField.module.scss'
 

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/DataSeriesQueryField.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/DataSeriesQueryField.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames'
 import { noop } from 'lodash'
 import * as Monaco from 'monaco-editor'
-import React, { InputHTMLAttributes, useMemo } from 'react'
+import React, { forwardRef, InputHTMLAttributes, useMemo } from 'react'
 
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 
@@ -31,7 +31,7 @@ interface DataSeriesQueryFieldProps
     onChange: (value: string) => void
 }
 
-export const DataSeriesQueryField: React.FunctionComponent<DataSeriesQueryFieldProps> = props => {
+export const DataSeriesQueryField: React.FunctionComponent<DataSeriesQueryFieldProps> = forwardRef(props => {
     const { value, className, onChange, onBlur = noop, disabled, autoFocus } = props
     const { enhancedThemePreference } = useTheme()
 
@@ -55,4 +55,4 @@ export const DataSeriesQueryField: React.FunctionComponent<DataSeriesQueryFieldP
             onBlur={onBlur}
         />
     )
-}
+})

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/DataSeriesQueryField.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/DataSeriesQueryField.tsx
@@ -8,7 +8,8 @@ import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { QueryChangeSource } from '../../../../../../../../search/helpers'
 import { LazyMonacoQueryInput } from '../../../../../../../../search/input/LazyMonacoQueryInput'
 import { DEFAULT_MONACO_OPTIONS } from '../../../../../../../../search/input/MonacoQueryInput'
-import { ThemePreference, useThemeState } from '../../../../../../../../theme'
+import { ThemePreference } from '../../../../../../../../stores/themeState';
+import { useTheme } from '../../../../../../../../theme';
 
 import styles from './DataSeriesQueryField.module.scss'
 
@@ -32,7 +33,7 @@ interface DataSeriesQueryFieldProps
 
 export const DataSeriesQueryField: React.FunctionComponent<DataSeriesQueryFieldProps> = props => {
     const { value, className, onChange, onBlur = noop, disabled, autoFocus } = props
-    const { enhancedThemePreference } = useThemeState()
+    const { enhancedThemePreference } = useTheme()
 
     const monacoOptions = useMemo(() => ({ ...MONACO_OPTIONS, readOnly: disabled }), [disabled])
 

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
@@ -11,6 +11,8 @@ import { createRequiredValidator } from '../../../../../../components/form/valid
 import { SearchBasedInsightSeries } from '../../../../../../core/types/insight/search-insight'
 import { DEFAULT_ACTIVE_COLOR, FormColorInput } from '../form-color-input/FormColorInput'
 
+import { DataSeriesQueryField } from './DataSeriesQueryField'
+
 const requiredNameField = createRequiredValidator('Name is a required field for data series.')
 const validQuery = createRequiredValidator('Query is a required field for data series.')
 
@@ -136,6 +138,7 @@ export const FormSeriesInput: React.FunctionComponent<FormSeriesInputProps> = pr
             <FormInput
                 title="Search query"
                 required={true}
+                as={DataSeriesQueryField}
                 placeholder="Example: patternType:regexp const\s\w+:\s(React\.)?FunctionComponent"
                 description={
                     <span>

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/live-preview-chart/SearchInsightLivePreview.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/live-preview-chart/SearchInsightLivePreview.tsx
@@ -117,6 +117,7 @@ export const SearchInsightLivePreview: React.FunctionComponent<SearchInsightLive
                     : null
             }
             className={className}
+            chartContentClassName="pt-4"
             onUpdateClick={() => setLastPreviewVersion(version => version + 1)}
         />
     )

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.test.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.test.tsx
@@ -14,6 +14,11 @@ import { SupportedInsightSubject } from '../../../../../../core/types/subjects'
 
 import { SearchInsightCreationContent, SearchInsightCreationContentProps } from './SearchInsightCreationContent'
 
+// Mock the Monaco input box to make this a shallow test
+jest.mock('../form-series-input/DataSeriesQueryField.tsx', () => ({
+    DataSeriesQueryField: (props: object) => <input {...props} />,
+}))
+
 const USER_TEST_SUBJECT: SupportedInsightSubject = {
     __typename: 'User' as const,
     id: 'user_test_id',

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
@@ -77,13 +77,12 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
     // If some fields that needed to run live preview  are invalid
     // we should disabled live chart preview
     const allFieldsForPreviewAreValid =
-        (repositories.meta.validState === 'VALID' &&
-            repositoriesList.length > 0 &&
-            series.meta.validState === 'VALID') ||
-        (editSeries.some(series => series.valid) &&
-            stepValue.meta.validState === 'VALID' &&
-            // For all repos mode we are not able to show the live preview chart
-            !allReposMode.input.value)
+        repositories.meta.validState === 'VALID' &&
+        repositoriesList.length > 0 &&
+        (series.meta.validState === 'VALID' || editSeries.some(series => series.valid)) &&
+        stepValue.meta.validState === 'VALID' &&
+        // For all repos mode we are not able to show the live preview chart
+        !allReposMode.input.value
 
     const hasFilledValue =
         values.series?.some(line => line.name !== '' || line.query !== '') ||

--- a/client/web/src/integration/insights/create-insights.test.ts
+++ b/client/web/src/integration/insights/create-insights.test.ts
@@ -168,10 +168,13 @@ describe('Code insight create insight page', () => {
         )
 
         // Add first series query
-        await driver.page.type(
-            '[data-testid="series-form"]:nth-child(1) input[name="seriesQuery"]',
-            'test series #1 query'
-        )
+        await driver.page.waitForSelector('[data-testid="series-form"]:nth-child(1) #monaco-query-input')
+        await driver.replaceText({
+            selector: '[data-testid="series-form"]:nth-child(1) #monaco-query-input',
+            newText: 'test series #1 query',
+            enterTextMethod: 'type',
+            selectMethod: 'keyboard',
+        })
 
         // Pick first series color
         await driver.page.click('[data-testid="series-form"]:nth-child(1) label[title="Cyan"]')
@@ -186,10 +189,13 @@ describe('Code insight create insight page', () => {
         )
 
         // Add second series query
-        await driver.page.type(
-            '[data-testid="series-form"]:nth-child(2) input[name="seriesQuery"]',
-            'test series #2 query'
-        )
+        await driver.page.waitForSelector('[data-testid="series-form"]:nth-child(1) #monaco-query-input')
+        await driver.replaceText({
+            selector: '[data-testid="series-form"]:nth-child(2) #monaco-query-input',
+            newText: 'test series #2 query',
+            enterTextMethod: 'type',
+            selectMethod: 'keyboard',
+        })
 
         // With two filled data series our mock for live preview should work - render line chart with two lines
         await driver.page.waitForSelector('[data-testid="line-chart__content"] svg circle')

--- a/client/web/src/integration/insights/edit-search-insights.test.ts
+++ b/client/web/src/integration/insights/edit-search-insights.test.ts
@@ -201,11 +201,15 @@ describe('Code insight edit insight page', () => {
             '[data-testid="series-form"]:nth-child(1) input[name="seriesName"]',
             'test edited series title'
         )
-        await clearAndType(
-            driver,
-            '[data-testid="series-form"]:nth-child(1) input[name="seriesQuery"]',
-            'test edited series query'
-        )
+
+        await driver.page.waitForSelector('[data-testid="series-form"]:nth-child(1) #monaco-query-input')
+        await driver.replaceText({
+            selector: '[data-testid="series-form"]:nth-child(1) #monaco-query-input',
+            newText: 'test edited series query',
+            enterTextMethod: 'type',
+            selectMethod: 'keyboard',
+        })
+
         await driver.page.click('[data-testid="series-form"]:nth-child(1) label[title="Cyan"]')
 
         // Remove second insight series
@@ -220,11 +224,14 @@ describe('Code insight edit insight page', () => {
             '[data-testid="series-form"]:nth-child(2) input[name="seriesName"]',
             'new test series title'
         )
-        await clearAndType(
-            driver,
-            '[data-testid="series-form"]:nth-child(2) input[name="seriesQuery"]',
-            'new test series query'
-        )
+
+        await driver.page.waitForSelector('[data-testid="series-form"]:nth-child(2) #monaco-query-input')
+        await driver.replaceText({
+            selector: '[data-testid="series-form"]:nth-child(2) #monaco-query-input',
+            newText: 'new test series query',
+            enterTextMethod: 'type',
+            selectMethod: 'keyboard',
+        })
 
         // Change visibility to test org by org ID mock - 'Org_test_id'
         await driver.page.click('input[name="visibility"][value="Org_test_id"]')

--- a/client/web/src/search/input/MonacoQueryInput.tsx
+++ b/client/web/src/search/input/MonacoQueryInput.tsx
@@ -297,6 +297,7 @@ export const MonacoQueryInput: React.FunctionComponent<MonacoQueryInputProps> = 
                     // and the filter is not scrolled into view.
                     editor.revealRange(toMonacoRange(queryState.revealRange, textModel))
                 }
+                editor.focus()
                 break
             }
             default: {
@@ -308,6 +309,7 @@ export const MonacoQueryInput: React.FunctionComponent<MonacoQueryInputProps> = 
                 }
                 editor.setPosition(position)
                 editor.revealPosition(position)
+                editor.focus()
             }
         }
     }, [editor, queryState])

--- a/client/web/src/theme.test.ts
+++ b/client/web/src/theme.test.ts
@@ -22,6 +22,7 @@ const mockSystemTheme = (systemTheme: 'light' | 'dark') => {
         throw new Error('unexpected matchMedia query')
     }
 }
+
 describe('useTheme()', () => {
     describe('defaults to system', () => {
         it('light', () => {
@@ -49,7 +50,7 @@ describe('useTheme()', () => {
         })
     })
 
-    describe.skip('respects theme preference', () => {
+    describe('respects theme preference', () => {
         it('light', () => {
             mockSystemTheme('dark')
             const { result } = renderHook(() => useThemeProps())

--- a/client/web/src/theme.test.ts
+++ b/client/web/src/theme.test.ts
@@ -22,7 +22,6 @@ const mockSystemTheme = (systemTheme: 'light' | 'dark') => {
         throw new Error('unexpected matchMedia query')
     }
 }
-
 describe('useTheme()', () => {
     describe('defaults to system', () => {
         it('light', () => {
@@ -50,7 +49,7 @@ describe('useTheme()', () => {
         })
     })
 
-    describe('respects theme preference', () => {
+    describe.skip('respects theme preference', () => {
         it('light', () => {
             mockSystemTheme('dark')
             const { result } = renderHook(() => useThemeProps())


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/21339
Note: this PR is based on https://github.com/sourcegraph/sourcegraph/pull/28101

## Context
This PR just adopts MonacoQueryInput for code insights data series field needs and reuses this component in the creation UI form. 

## Known issues 
- Query field doesn't provide good styles for a disabled state (it isn't a big problem cause we're going to allow editing this field on the edit page)
- Suggestions panel doesn't work if we have a multi-line query. It works only on the first line. (I think it's a problem with our suggestions system deep in code intel hook. We will solve this problem later in a separate issue)