### PR TITLE
repos: Only track GitHub rate limit tokens for site level services

### DIFF
--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -135,7 +135,7 @@ func newGithubSource(svc *types.ExternalService, c *schema.GitHubConnection, cf 
 		searchClient = github.NewV3SearchClient(apiURL, token, cli)
 	)
 
-	if svc.NamespaceUserID == 0 {
+	if svc.IsSiteOwned() {
 		for resource, monitor := range map[string]*ratelimit.Monitor{
 			"rest":    v3Client.RateLimitMonitor(),
 			"graphql": v4Client.RateLimitMonitor(),

--- a/internal/repos/types.go
+++ b/internal/repos/types.go
@@ -107,7 +107,7 @@ type ScopeCache interface {
 // Currently only GitHub and GitLab external services with user or org namespace are supported,
 // other code hosts will simply return an empty slice
 func GrantedScopes(ctx context.Context, cache ScopeCache, svc *types.ExternalService) ([]string, error) {
-	if (svc.NamespaceUserID == 0 && svc.NamespaceOrgID == 0) || (svc.Kind != extsvc.KindGitHub && svc.Kind != extsvc.KindGitLab) {
+	if svc.IsSiteOwned() || (svc.Kind != extsvc.KindGitHub && svc.Kind != extsvc.KindGitLab) {
 		return nil, nil
 	}
 	src, err := NewSource(svc, nil)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -505,6 +505,9 @@ func (e *ExternalService) URN() string {
 // IsDeleted returns true if the external service is deleted.
 func (e *ExternalService) IsDeleted() bool { return !e.DeletedAt.IsZero() }
 
+// IsSiteOwned returns true if the external service is owned by the site.
+func (e *ExternalService) IsSiteOwned() bool { return e.NamespaceUserID == 0 && e.NamespaceOrgID == 0 }
+
 // Update updates ExternalService e with the fields from the given newer ExternalService n,
 // returning true if modified.
 func (e *ExternalService) Update(n *ExternalService) (modified bool) {


### PR DESCRIPTION
Also, create the IsSiteOwned method on ExternalService.
