### PR TITLE
types: optional field redaction support

### DIFF
--- a/internal/types/secret.go
+++ b/internal/types/secret.go
@@ -104,7 +104,10 @@ func redactionInfo(cfg interface{}) ([]jsonStringField, error) {
 	case *schema.JVMPackagesConnection:
 		return []jsonStringField{{[]string{"maven", "credentials"}, &cfg.Maven.Credentials}}, nil
 	case *schema.PagureConnection:
-		return []jsonStringField{{[]string{"token"}, &cfg.Token}}, nil
+		if cfg.Token != "" {
+			return []jsonStringField{{[]string{"token"}, &cfg.Token}}, nil
+		}
+		return []jsonStringField{}, nil
 	case *schema.OtherExternalServiceConnection:
 		return []jsonStringField{{[]string{"url"}, &cfg.Url}}, nil
 	default:
@@ -166,7 +169,8 @@ func unredactFields(old, new string, cfg interface{}) (string, error) {
 	for _, field := range jsonStringFields {
 		v, err := jsonc.ReadProperty(new, field.path...)
 		if err != nil {
-			return new, err
+			// This field was deleted, so we skip any edits to it.
+			continue
 		}
 		stringValue, ok := v.(string)
 		if !ok {

--- a/internal/types/secret_test.go
+++ b/internal/types/secret_test.go
@@ -65,6 +65,9 @@ func TestRoundTripRedactExternalServiceConfig(t *testing.T) {
 			Dependencies: []string{"placeholder"},
 		},
 	}
+	pagureConfig := schema.PagureConnection{
+		Url: "https://src.fedoraproject.org",
+	}
 	otherConfig := schema.OtherExternalServiceConnection{
 		Url:                   someSecret,
 		RepositoryPathPattern: "foo",
@@ -124,6 +127,11 @@ func TestRoundTripRedactExternalServiceConfig(t *testing.T) {
 			kind:      extsvc.KindJVMPackages,
 			config:    &jvmPackagesConfig,
 			editField: func(cfg interface{}) *string { return &cfg.(*schema.JVMPackagesConnection).Maven.Dependencies[0] },
+		},
+		{
+			kind:      extsvc.KindPagure,
+			config:    &pagureConfig,
+			editField: func(cfg interface{}) *string { return &cfg.(*schema.PagureConnection).Pattern },
 		},
 		{
 			kind:   extsvc.KindOther,

--- a/internal/types/secret_test.go
+++ b/internal/types/secret_test.go
@@ -129,6 +129,7 @@ func TestRoundTripRedactExternalServiceConfig(t *testing.T) {
 			editField: func(cfg interface{}) *string { return &cfg.(*schema.JVMPackagesConnection).Maven.Dependencies[0] },
 		},
 		{
+			// Unlike the other test cases, this test covers skipping redaction of missing optional fields.
 			kind:      extsvc.KindPagure,
 			config:    &pagureConfig,
 			editField: func(cfg interface{}) *string { return &cfg.(*schema.PagureConnection).Pattern },


### PR DESCRIPTION
This adds support for redacting optional fields in external service
configs, particularly Pagure's optional token field.

Part of #28028



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
