### PR TITLE
remove internal/trace dependence on internal/conf

### DIFF
--- a/cmd/frontend/internal/app/errorutil/handlers.go
+++ b/cmd/frontend/internal/app/errorutil/handlers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/handlerutil"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
@@ -27,7 +28,7 @@ func Handler(h func(http.ResponseWriter, *http.Request) error) http.Handler {
 					ext.Error.Set(span, true)
 					span.SetTag("err", err)
 					traceID = trace.IDFromSpan(span)
-					traceURL = trace.URL(traceID)
+					traceURL = trace.URL(traceID, conf.ExternalURL())
 				}
 				log15.Error(
 					"App HTTP handler error response",

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -24,6 +24,7 @@ import (
 	uirouter "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/ui/router"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/routevar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/randstring"
@@ -463,7 +464,7 @@ func serveErrorNoDebug(w http.ResponseWriter, r *http.Request, db database.DB, e
 		ext.Error.Set(span, true)
 		span.SetTag("err", err)
 		span.SetTag("error-id", errorID)
-		traceURL = trace.URL(trace.IDFromSpan(span))
+		traceURL = trace.URL(trace.IDFromSpan(span), conf.ExternalURL())
 	}
 	log15.Error("ui HTTP handler error response", "method", r.Method, "request_uri", r.URL.RequestURI(), "status_code", statusCode, "error", err, "error_id", errorID, "trace", traceURL)
 

--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -101,7 +101,7 @@ func newExternalHTTPHandler(db database.DB, schema *graphql.Schema, gitHubWebhoo
 	h = middleware.SourcegraphComGoGetHandler(h)
 	h = internalauth.ForbidAllRequestsMiddleware(h)
 	h = internalauth.OverrideAuthMiddleware(db, h)
-	h = tracepkg.HTTPTraceMiddleware(h)
+	h = tracepkg.HTTPTraceMiddleware(h, conf.DefaultClient())
 	h = ot.Middleware(h)
 
 	return h, nil
@@ -135,7 +135,7 @@ func newInternalHTTPHandler(schema *graphql.Schema, db database.DB, newCodeIntel
 	))
 	h := http.Handler(internalMux)
 	h = gcontext.ClearHandler(h)
-	h = tracepkg.HTTPTraceMiddleware(h)
+	h = tracepkg.HTTPTraceMiddleware(h, conf.DefaultClient())
 	h = ot.Middleware(h)
 	return h
 }

--- a/cmd/frontend/internal/handlerutil/error_reporting.go
+++ b/cmd/frontend/internal/handlerutil/error_reporting.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/version"
@@ -77,7 +78,7 @@ func reportError(r *http.Request, status int, err error, panicked bool) {
 
 	// Add appdash span ID.
 	if traceID := trace.ID(r.Context()); traceID != "" {
-		pkt.Extra["trace"] = trace.URL(traceID)
+		pkt.Extra["trace"] = trace.URL(traceID, conf.ExternalURL())
 		pkt.Extra["traceID"] = traceID
 	}
 

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -25,6 +25,7 @@ import (
 	frontendsearch "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search"
 	registry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/api"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/webhooks"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -211,7 +212,7 @@ func (h *errorHandler) Handle(w http.ResponseWriter, r *http.Request, status int
 	}
 	http.Error(w, displayErrBody, status)
 	traceID := trace.ID(r.Context())
-	traceURL := trace.URL(traceID)
+	traceURL := trace.URL(traceID, conf.ExternalURL())
 
 	if status < 200 || status >= 500 {
 		log15.Error("API HTTP handler error response", "method", r.Method, "request_uri", r.URL.RequestURI(), "status_code", status, "error", err, "trace", traceURL, "traceID", traceID)

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	searchlogs "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/logs"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/honey"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
@@ -103,7 +104,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	progress := progressAggregator{
 		Start:        start,
 		Limit:        inputs.MaxResults(),
-		Trace:        trace.URL(trace.ID(ctx)),
+		Trace:        trace.URL(trace.ID(ctx), conf.ExternalURL()),
 		DisplayLimit: displayLimit,
 		RepoNamer:    repoNamer(ctx, h.db),
 	}

--- a/cmd/github-proxy/github-proxy.go
+++ b/cmd/github-proxy/github-proxy.go
@@ -90,7 +90,7 @@ func main() {
 		h = handlers.LoggingHandler(os.Stdout, h)
 	}
 	h = instrumentHandler(prometheus.DefaultRegisterer, h)
-	h = trace.HTTPTraceMiddleware(h)
+	h = trace.HTTPTraceMiddleware(h, conf.DefaultClient())
 	h = ot.Middleware(h)
 	http.Handle("/", h)
 

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -140,7 +140,7 @@ func main() {
 	// Create Handler now since it also initializes state
 
 	// TODO: Why do we set server state as a side effect of creating our handler?
-	handler := ot.Middleware(trace.HTTPTraceMiddleware(gitserver.Handler()))
+	handler := ot.Middleware(trace.HTTPTraceMiddleware(gitserver.Handler(), conf.DefaultClient()))
 
 	// Ready immediately
 	ready := make(chan struct{})

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -975,7 +975,7 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 		}
 		if traceID := trace.ID(ctx); traceID != "" {
 			ev.AddField("traceID", traceID)
-			ev.AddField("trace", trace.URL(traceID))
+			ev.AddField("trace", trace.URL(traceID, conf.ExternalURL()))
 		}
 		if honey.Enabled() {
 			_ = ev.Send()
@@ -1218,7 +1218,7 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 
 				if traceID := trace.ID(ctx); traceID != "" {
 					ev.AddField("traceID", traceID)
-					ev.AddField("trace", trace.URL(traceID))
+					ev.AddField("trace", trace.URL(traceID, conf.ExternalURL()))
 				}
 
 				if honey.Enabled() {
@@ -1452,7 +1452,7 @@ func (s *Server) p4exec(w http.ResponseWriter, r *http.Request, req *protocol.P4
 
 				if traceID := trace.ID(ctx); traceID != "" {
 					ev.AddField("traceID", traceID)
-					ev.AddField("trace", trace.URL(traceID))
+					ev.AddField("trace", trace.URL(traceID, conf.ExternalURL()))
 				}
 
 				_ = ev.Send()

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -339,7 +339,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	httpSrv := httpserver.NewFromAddr(addr, &http.Server{
 		ReadTimeout:  75 * time.Second,
 		WriteTimeout: 10 * time.Minute,
-		Handler:      ot.Middleware(trace.HTTPTraceMiddleware(authzBypass(handler))),
+		Handler:      ot.Middleware(trace.HTTPTraceMiddleware(authzBypass(handler), conf.DefaultClient())),
 	})
 	goroutine.MonitorBackgroundRoutines(ctx, httpSrv)
 }

--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -72,7 +72,7 @@ func main() {
 	}
 	service.Store.Start()
 
-	handler := ot.Middleware(trace.HTTPTraceMiddleware(service))
+	handler := ot.Middleware(trace.HTTPTraceMiddleware(service, conf.DefaultClient()))
 
 	host := ""
 	if env.InsecureDev {

--- a/cmd/symbols/main.go
+++ b/cmd/symbols/main.go
@@ -131,7 +131,7 @@ func main() {
 		log.Fatalln("Start:", err)
 	}
 
-	handler := ot.Middleware(trace.HTTPTraceMiddleware(service.Handler()))
+	handler := ot.Middleware(trace.HTTPTraceMiddleware(service.Handler(), conf.DefaultClient()))
 
 	host := ""
 	if env.InsecureDev {

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/observability.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/observability.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/inconshreveable/log15"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/honey"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -130,7 +131,7 @@ func createHoneyEvent(
 		fields["error"] = (*err).Error()
 	}
 	if traceID := trace.ID(ctx); traceID != "" {
-		fields["trace"] = trace.URL(traceID)
+		fields["trace"] = trace.URL(traceID, conf.ExternalURL())
 		fields["traceID"] = traceID
 	}
 

--- a/internal/observation/observation.go
+++ b/internal/observation/observation.go
@@ -220,7 +220,6 @@ func (op *Operation) WithAndLogger(ctx context.Context, err *error, args Args) (
 	}
 
 	if traceID := trace.ID(ctx); traceID != "" {
-		event.AddField("trace", trace.URL(traceID))
 		event.AddField("traceID", traceID)
 	}
 

--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 
 	"github.com/cockroachdb/errors"
@@ -140,7 +141,7 @@ var (
 //
 // 🚨 SECURITY: This handler is served to all clients, even on private servers to clients who have
 // not authenticated. It must not reveal any sensitive information.
-func HTTPTraceMiddleware(next http.Handler) http.Handler {
+func HTTPTraceMiddleware(next http.Handler, siteConfig conftypes.SiteConfigQuerier) http.Handler {
 	return sentry.Recoverer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
@@ -159,7 +160,7 @@ func HTTPTraceMiddleware(next http.Handler) http.Handler {
 		defer span.Finish()
 
 		traceID := IDFromSpan(span)
-		traceURL := URL(traceID)
+		traceURL := URL(traceID, siteConfig.SiteConfig().ExternalURL)
 
 		rw.Header().Set("X-Trace", traceURL)
 		ctx = opentracing.ContextWithSpan(ctx, span)

--- a/internal/trace/traceutil.go
+++ b/internal/trace/traceutil.go
@@ -16,7 +16,6 @@ import (
 	"github.com/uber/jaeger-client-go"
 	nettrace "golang.org/x/net/trace"
 
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
 
@@ -38,15 +37,15 @@ func IDFromSpan(span opentracing.Span) string {
 	return spanCtx.TraceID().String()
 }
 
-// URL returns a trace URL for the given trace ID
-func URL(traceID string) string {
+// URL returns a trace URL for the given trace ID at the given external URL.
+func URL(traceID, externalURL string) string {
 	if traceID == "" {
 		return ""
 	}
 
 	if os.Getenv("ENABLE_GRAFANA_CLOUD_TRACE_URL") != "true" {
 		// We proxy jaeger so we can construct URLs to traces.
-		return strings.TrimSuffix(conf.Get().ExternalURL, "/") + "/-/debug/jaeger/trace/" + traceID
+		return strings.TrimSuffix(externalURL, "/") + "/-/debug/jaeger/trace/" + traceID
 	}
 
 	return "https://sourcegraph.grafana.net/explore?orgId=1&left=" + url.QueryEscape(fmt.Sprintf(


### PR DESCRIPTION
See #wg-shipping-executors for context
TLDR executors cant import `internal/conf`, else it will attempt to ping internal frontend URL from not within