### PR TITLE
remove unused column gitserver: Migrations

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -946,16 +946,15 @@ Referenced by:
 
 # Table "public.gitserver_repos"
 ```
-        Column         |           Type           | Collation | Nullable |      Default       
------------------------+--------------------------+-----------+----------+--------------------
- repo_id               | integer                  |           | not null | 
- clone_status          | text                     |           | not null | 'not_cloned'::text
- last_external_service | bigint                   |           |          | 
- shard_id              | text                     |           | not null | 
- last_error            | text                     |           |          | 
- updated_at            | timestamp with time zone |           | not null | now()
- last_fetched          | timestamp with time zone |           | not null | now()
- last_changed          | timestamp with time zone |           | not null | now()
+    Column    |           Type           | Collation | Nullable |      Default       
+--------------+--------------------------+-----------+----------+--------------------
+ repo_id      | integer                  |           | not null | 
+ clone_status | text                     |           | not null | 'not_cloned'::text
+ shard_id     | text                     |           | not null | 
+ last_error   | text                     |           |          | 
+ updated_at   | timestamp with time zone |           | not null | now()
+ last_fetched | timestamp with time zone |           | not null | now()
+ last_changed | timestamp with time zone |           | not null | now()
 Indexes:
     "gitserver_repos_pkey" PRIMARY KEY, btree (repo_id)
     "gitserver_repos_cloned_status_idx" btree (repo_id) WHERE clone_status = 'cloned'::text

--- a/migrations/frontend/1528395945_drop_unused_last_external_service_column.down.sql
+++ b/migrations/frontend/1528395945_drop_unused_last_external_service_column.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE IF EXISTS gitserver_repos ADD COLUMN IF NOT EXISTS last_external_service bigint;
+
+COMMIT;

--- a/migrations/frontend/1528395945_drop_unused_last_external_service_column.up.sql
+++ b/migrations/frontend/1528395945_drop_unused_last_external_service_column.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE IF EXISTS gitserver_repos DROP COLUMN IF EXISTS last_external_service;
+
+COMMIT;


### PR DESCRIPTION
- Create up/down migrations for dropping `last_external_service` column from the gitserver_repos table
- Tested locally by running `sg migration up`, verifying the column was dropped in postgres, running `sg migration down` and verifying the column was added back correctly. 

Relates to https://github.com/sourcegraph/sourcegraph/issues/27422

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
