### PR TITLE
honeycomb: move search-specific honey to separate package to reduce imports in honey package

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -30,6 +30,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/honey"
+	searchhoney "github.com/sourcegraph/sourcegraph/internal/honey/search"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/commit"
@@ -1057,7 +1058,7 @@ func (r *searchResolver) logBatch(ctx context.Context, srr *SearchResultsResolve
 		if srr != nil {
 			n = len(srr.Matches)
 		}
-		ev := honey.SearchEvent(ctx, honey.SearchEventArgs{
+		ev := searchhoney.SearchEvent(ctx, searchhoney.SearchEventArgs{
 			OriginalQuery: r.rawQuery(),
 			Typ:           requestName,
 			Source:        requestSource,

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/honey"
+	searchhoney "github.com/sourcegraph/sourcegraph/internal/honey/search"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/run"
@@ -256,7 +257,7 @@ LOOP:
 
 	isSlow := time.Since(start) > searchlogs.LogSlowSearchesThreshold()
 	if honey.Enabled() || isSlow {
-		ev := honey.SearchEvent(ctx, honey.SearchEventArgs{
+		ev := searchhoney.SearchEvent(ctx, searchhoney.SearchEventArgs{
 			OriginalQuery: inputs.OriginalQuery,
 			Typ:           "stream",
 			Source:        string(trace.RequestSource(ctx)),

--- a/internal/honey/search/search.go
+++ b/internal/honey/search/search.go
@@ -1,9 +1,10 @@
-package honey
+package search
 
 import (
 	"context"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/honey"
 )
 
 type SearchEventArgs struct {
@@ -18,12 +19,12 @@ type SearchEventArgs struct {
 }
 
 // SearchEvent returns a honey event for the dataset "search".
-func SearchEvent(ctx context.Context, args SearchEventArgs) Event {
+func SearchEvent(ctx context.Context, args SearchEventArgs) honey.Event {
 	act := &actor.Actor{}
 	if a := actor.FromContext(ctx); a != nil {
 		act = a
 	}
-	ev := NewEvent("search")
+	ev := honey.NewEvent("search")
 	ev.AddField("query", args.OriginalQuery)
 	ev.AddField("actor_uid", act.UID)
 	ev.AddField("actor_internal", act.Internal)


### PR DESCRIPTION
`internal/honey` currently imports `internal/actor` -> `internal/types` -> `internal/extsvc/{...}` -> `internal/conf`. This affects executors for the same reasons outlined https://github.com/sourcegraph/sourcegraph/pull/28143, this PR contributes towards addressing this issue.