### PR TITLE
sg setup: install postgres and redis cli tools

### DIFF
--- a/dev/sg/sg_setup.go
+++ b/dev/sg/sg_setup.go
@@ -328,6 +328,13 @@ sudo apt install -y postgresql postgresql-contrib`,
 		command: `sudo systemctl enable --now postgresql
 sudo systemctl enable --now redis-server.service`,
 	},
+	{
+		ifBool: "docker",
+		prompt: `Even though you're going to run the database in docker you will probably want to install the CLI tooling for Redis and Postgres
+
+redis-tools will provide redis-cli and postgresql will provide createdb and createuser`,
+		command: `sudo apt install -y redis-tools postgresql postgresql-contrib`,
+	},
 	// step 4
 	{
 		ifBool: "docker",


### PR DESCRIPTION
The docker installation path does not recommend installing postgres or redis-tools however `createdb` is required.

`redis-cli` is just a nice-to-have.

Fixes https://github.com/sourcegraph/sourcegraph/issues/28171.

![image](https://user-images.githubusercontent.com/8784265/143395930-88bff991-f701-4eeb-8520-a3a10c0c7186.png)

