### PR TITLE
doc: document Stream API

### DIFF
--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -4,3 +4,4 @@ Sourcegraph exposes the following APIs:
 
 - [Sourcegraph GraphQL API](graphql/index.md), for accessing data stored or computed by Sourcegraph
 - [Sourcegraph Extension API](../extensions/index.md), for extending the functionality of Sourcegraph and other tools (including code hosts)
+- [Sourcegraph Stream API](stream_api/index.md), for consuming search results as a stream of events

--- a/doc/api/stream_api/index.md
+++ b/doc/api/stream_api/index.md
@@ -36,7 +36,7 @@ See [Example](#example-curl).
 The API responds with a stream of events. Each event consists of exactly two
 fields, event and data, one per line. Events are separated by 2 newline
 characters, `\n\n`. The value of `event:` is a always a string that describes the
-type of the event. The value of `data:` is always a JSON.
+type of the event. The value of `data:` is always JSON.
 
 ```text
 event: <event-type> // event 1

--- a/doc/api/stream_api/index.md
+++ b/doc/api/stream_api/index.md
@@ -1,0 +1,112 @@
+# Sourcegraph Stream API
+
+> NOTE:
+> The Stream API is still evolving. Although parts of it can be considered
+> stable, we don't guarantee backward compatibility just yet. This means it is
+> possible that fields are added, removed, or renamed. All backward incompatible changes to the
+> event stream format will be documented in the [CHANGELOG](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md).
+
+
+The Stream API is a simple way to consume search results and related metadata as
+a stream. The Sourcegraph UI calls the Stream API for all interactive searches.
+Compared to our [GraphQL API](../graphql/index.md), it offers shorter times to first results and 
+supports running exhaustive searches returning a large volume of results without
+putting pressure on the backend.
+
+## Request
+
+```bash
+curl --header "Accept: text/event-stream" \
+     --header "Authorization: token <access token>" \
+     --get \
+     --url "<Sourcegraph URL>/search/stream" \
+     --data-urlencode "q=<query>"
+```
+
+| parameter | description |
+| --- | --- |
+| access token | [Sourcegraph access token](https://docs.sourcegraph.com/cli/how-tos/creating_an_access_token) |
+| Sourcegraph URL | The URL of your instance of Sourcegraph or https://sourcegraph.com for Sourcegraph's Cloud instance. |
+| query | A Sourcegraph query string, see our [search query syntax](../../code_search/reference/queries.md) |
+
+See [Example](#example-curl).
+
+## Event stream format 
+
+The API responds with a stream of events. Each event consists of exactly two
+fields, event and data, one per line. Events are separated by 2 newline
+characters, `\n\n`. The value of `event:` is a always a string that describes the
+type of the event. The value of `data:` is always a JSON.
+
+```text
+event: <event-type> // event 1
+data: <JSON>
+
+event: <event-type> // event 2
+data: <JSON>
+
+...
+
+event: done // last event
+data: {}
+```
+
+> NOTE: 
+> Our format is a subset of the event stream format described for server-sent
+> events [here](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format). However, we do not guarantee compatiblity with any third-party clients written for server-sent events.
+
+### Event-types
+
+Events can be of the following types:
+
+| event-type | description |
+| --- | --- |
+| matches | matches can be of type content, path, commit, diff, symbol and repo |
+| progress | statistics such as match count, count of repositories with matches, and duration |
+| filters | suggestions for additional filters to further narrow down the search |
+| alert | info, warning and error messages |
+| done | always the last event |
+
+Refer to the [interface definitions of our typescript client](https://sourcegraph.com/github.com/sourcegraiiiph/sourcegraph/-/blob/client/shared/src/search/stream.ts?L12) to learn about the schema of the event-types. 
+
+## Example (curl) 
+
+On Sourcegraph Cloud we can queries without authentication.
+
+```bash
+curl --header "Accept: text/event-stream" \
+     --get \
+     --url "https://sourcegraph.com/search/stream" \
+     --data-urlencode "q=r:sourcegraph/sourcegraph doResults count:1"
+
+event: matches
+data: [{"type":"content","path":"cmd/frontend/graphqlbackend/search_results_stats_languages.go","repositoryID":42693708,"repository":"gitlab.com/rluna-open-source/code-management/sourcegraph/sourcegraph-2020","repoLastFetched":"2021-11-19T21:54:27.009309Z","branches":[""],"commit":"0725aa021040f3c864bd5043caf965e7bc1e7a51","hunks":null,"lineMatches":[{"line":"\t\tresults, err := srs.sr.doResults(ctx, args, jobs)","lineNumber":44,"offsetAndLengths":[[25,9]]}]}]
+
+event: progress
+data: {"done":false,"matchCount":1,"durationMs":39,"skipped":[{"reason":"shard-match-limit","title":"result limit hit","message":"Not all results have been returned due to hitting a match limit. Sourcegraph has limits for the number of results returned from a line, document and repository.","severity":"info","suggested":{"title":"increase limit","queryExpression":"count:1000"}}]}
+
+event: filters
+data: [{"value":"lang:go","label":"lang:go","count":3,"limitHit":false,"kind":"lang"},{"value":"repo:^gitlab\\.com/rluna-open-source/code-management/sourcegraph/sourcegraph-2020$","label":"gitlab.com/rluna-open-source/code-management/sourcegraph/sourcegraph-2020","count":3,"limitHit":true,"kind":"repo"}]
+
+event: progress
+data: {"done":true,"repositoriesCount":1,"matchCount":1,"durationMs":39,"skipped":[{"reason":"shard-match-limit","title":"result limit hit","message":"Not all results have been returned due to hitting a match limit. Sourcegraph has limits for the number of results returned from a line, document and repository.","severity":"info","suggested":{"title":"increase limit","queryExpression":"count:1000"}}]}
+
+event: done
+data: {}
+```
+
+## FAQ
+
+### Q: How can I run an exhaustive search directly against the Stream API?
+
+To search a pattern over all indexed repositories, add `count:all` and remove all repo filters. For example, to search all indexed repositories for the string "secret", you can run the following command
+
+```bash
+curl --header "Accept:text/event-stream" --get --url "https://sourcegraph.com/search/stream" --data-urlencode "q=secret count:all"
+```
+
+If you don't want to write your own client, you can also use Sourcegraph's [src-cli](https://github.com/sourcegraph/src-cli).
+
+```bash
+src search -stream "secret count:all"
+```

--- a/doc/api/stream_api/index.md
+++ b/doc/api/stream_api/index.md
@@ -35,7 +35,7 @@ See [Example](#example-curl).
 
 The API responds with a stream of events. Each event consists of exactly two
 fields, event and data, one per line. Events are separated by 2 newline
-characters, `\n\n`. The value of `event:` is a always a string that describes the
+characters, `\n\n`. The value of `event:` is always a string that describes the
 type of the event. The value of `data:` is always JSON.
 
 ```text

--- a/doc/api/stream_api/index.md
+++ b/doc/api/stream_api/index.md
@@ -73,8 +73,8 @@ Refer to the [interface definitions of our typescript client](https://sourcegrap
 
 On Sourcegraph Cloud we can run queries without authentication.
 
-```bash
-curl --header "Accept: text/event-stream" \
+```shellsession
+$ curl --header "Accept: text/event-stream" \
      --get \
      --url "https://sourcegraph.com/search/stream" \
      --data-urlencode "q=r:sourcegraph/sourcegraph doResults count:1"

--- a/doc/api/stream_api/index.md
+++ b/doc/api/stream_api/index.md
@@ -67,7 +67,7 @@ Events can be of the following types:
 | alert | info, warning and error messages |
 | done | always the last event |
 
-Refer to the [interface definitions of our typescript client](https://sourcegraph.com/github.com/sourcegraiiiph/sourcegraph/-/blob/client/shared/src/search/stream.ts?L12) to learn about the schema of the event-types. 
+Refer to the [interface definitions of our typescript client](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/shared/src/search/stream.ts?L12) to learn about the schema of the event-types. 
 
 ## Example (curl) 
 

--- a/doc/api/stream_api/index.md
+++ b/doc/api/stream_api/index.md
@@ -7,8 +7,8 @@
 > event stream format will be documented in the [CHANGELOG](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md).
 
 
-The Stream API is a simple way to consume search results and related metadata as
-a stream. The Sourcegraph UI calls the Stream API for all interactive searches.
+With the Stream API you can consume search results and related metadata as
+a stream of events. The Sourcegraph UI calls the Stream API for all interactive searches.
 Compared to our [GraphQL API](../graphql/index.md), it offers shorter times to first results and 
 supports running exhaustive searches returning a large volume of results without
 putting pressure on the backend.
@@ -20,7 +20,8 @@ curl --header "Accept: text/event-stream" \
      --header "Authorization: token <access token>" \
      --get \
      --url "<Sourcegraph URL>/search/stream" \
-     --data-urlencode "q=<query>"
+     --data-urlencode "q=<query>" \
+     [--data-urlencode "display=<display-limit>"]
 ```
 
 | parameter | description |
@@ -28,6 +29,7 @@ curl --header "Accept: text/event-stream" \
 | access token | [Sourcegraph access token](https://docs.sourcegraph.com/cli/how-tos/creating_an_access_token) |
 | Sourcegraph URL | The URL of your instance of Sourcegraph or https://sourcegraph.com for Sourcegraph's Cloud instance. |
 | query | A Sourcegraph query string, see our [search query syntax](../../code_search/reference/queries.md) |
+| display-limit | The maximum number of matches the backend returns. Defaults to -1 (no limit). If the backend finds more then display-limit results, it will keep searching and aggregating statistics, but the matches will not be returned anymore. Note that the display-limit is different from the query filter `count:` which causes the search to stop and return once we found `count:` matches. |
 
 See [Example](#example-curl).
 

--- a/doc/api/stream_api/index.md
+++ b/doc/api/stream_api/index.md
@@ -52,8 +52,8 @@ data: {}
 ```
 
 > NOTE: 
-> Our format is a subset of the event stream format described for server-sent
-> events [here](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format). However, we do not guarantee compatiblity with any third-party clients written for server-sent events.
+> Our format is a subset of the event stream format for [server-sent
+> events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format). However, we do not guarantee compatibility with any third-party clients written for server-sent events.
 
 ### Event-types
 

--- a/doc/api/stream_api/index.md
+++ b/doc/api/stream_api/index.md
@@ -71,7 +71,7 @@ Refer to the [interface definitions of our typescript client](https://sourcegrap
 
 ## Example (curl) 
 
-On Sourcegraph Cloud we can queries without authentication.
+On Sourcegraph Cloud we can run queries without authentication.
 
 ```bash
 curl --header "Accept: text/event-stream" \

--- a/doc/index.md
+++ b/doc/index.md
@@ -89,7 +89,7 @@ For next steps, visit the [Docker installation documentation](admin/install/dock
 ### Reference
 
 - [Query syntax reference](code_search/reference/queries.md)
-- [GraphQL API](api/graphql/index.md)
+- [API Documentation](api/index.md)
 - [Sourcegraph changelog](./CHANGELOG.md)
 
 ## Cloud documentation

--- a/doc/sidebar.md
+++ b/doc/sidebar.md
@@ -59,4 +59,4 @@ Keep it as a single list with at most 2 levels. (Anything else may not render co
 - <br/>
 - [★ Quick install](index.md#getting-started)
 - [★ Search query syntax](code_search/reference/queries.md)
-- [★ GraphQL API](api/graphql/index.md)
+- [★ API](api/index.md)


### PR DESCRIPTION
This adds a new doc page for our Stream API and updates the links in the sidebar to point to the API overview page instead of just to the GraphQL API doc page.

To review, check out the PR and call `sg run docsite`

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
