### PR TITLE
Remove all usages of dbconn.Global in registry

### DIFF
--- a/cmd/frontend/graphqlbackend/extension_registry.go
+++ b/cmd/frontend/graphqlbackend/extension_registry.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 var ErrExtensionsDisabled = errors.New("extensions are disabled in site configuration (contact the site admin to enable extensions)")
@@ -29,7 +29,7 @@ func (r *schemaResolver) ExtensionRegistry(ctx context.Context) (ExtensionRegist
 
 // ExtensionRegistry is the implementation of the GraphQL types ExtensionRegistry and
 // ExtensionRegistryMutation.
-var ExtensionRegistry func(db dbutil.DB) ExtensionRegistryResolver
+var ExtensionRegistry func(db database.DB) ExtensionRegistryResolver
 
 // ExtensionRegistryResolver is the interface for the GraphQL types ExtensionRegistry and
 // ExtensionRegistryMutation.
@@ -103,7 +103,7 @@ var NodeToRegistryExtension func(interface{}) (RegistryExtension, bool)
 
 // RegistryExtensionByID is called to look up values of GraphQL type RegistryExtension. It is
 // assigned at init time.
-var RegistryExtensionByID func(context.Context, dbutil.DB, graphql.ID) (RegistryExtension, error)
+var RegistryExtensionByID func(context.Context, database.DB, graphql.ID) (RegistryExtension, error)
 
 // RegistryExtension is the interface for the GraphQL type RegistryExtension.
 type RegistryExtension interface {

--- a/cmd/frontend/internal/app/app.go
+++ b/cmd/frontend/internal/app/app.go
@@ -65,7 +65,7 @@ func NewHandler(db database.DB) http.Handler {
 
 	r.Get(router.CheckUsernameTaken).Handler(trace.Route(http.HandlerFunc(userpasswd.HandleCheckUsernameTaken(db))))
 
-	r.Get(router.RegistryExtensionBundle).Handler(trace.Route(gziphandler.GzipHandler(http.HandlerFunc(registry.HandleRegistryExtensionBundle))))
+	r.Get(router.RegistryExtensionBundle).Handler(trace.Route(gziphandler.GzipHandler(http.HandlerFunc(registry.HandleRegistryExtensionBundle(db)))))
 
 	// Usage statistics ZIP download
 	r.Get(router.UsageStatsDownload).Handler(trace.Route(http.HandlerFunc(usageStatsArchiveHandler(db))))

--- a/cmd/frontend/internal/app/app.go
+++ b/cmd/frontend/internal/app/app.go
@@ -65,7 +65,7 @@ func NewHandler(db database.DB) http.Handler {
 
 	r.Get(router.CheckUsernameTaken).Handler(trace.Route(http.HandlerFunc(userpasswd.HandleCheckUsernameTaken(db))))
 
-	r.Get(router.RegistryExtensionBundle).Handler(trace.Route(gziphandler.GzipHandler(http.HandlerFunc(registry.HandleRegistryExtensionBundle(db)))))
+	r.Get(router.RegistryExtensionBundle).Handler(trace.Route(gziphandler.GzipHandler(registry.HandleRegistryExtensionBundle(db))))
 
 	// Usage statistics ZIP download
 	r.Get(router.UsageStatsDownload).Handler(trace.Route(http.HandlerFunc(usageStatsArchiveHandler(db))))

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -88,7 +88,7 @@ func NewHandler(db database.DB, m *mux.Router, schema *graphql.Schema, githubWeb
 	m.Get(apirouter.SrcCliVersion).Handler(trace.Route(handler(srcCliVersionServe)))
 	m.Get(apirouter.SrcCliDownload).Handler(trace.Route(handler(srcCliDownloadServe)))
 
-	m.Get(apirouter.Registry).Handler(trace.Route(handler(registry.HandleRegistry)))
+	m.Get(apirouter.Registry).Handler(trace.Route(handler(registry.HandleRegistry(db))))
 
 	m.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		log.Printf("API no route: %s %s from %s", r.Method, r.URL, r.Referer())

--- a/cmd/frontend/registry/api/extension_bundle.go
+++ b/cmd/frontend/registry/api/extension_bundle.go
@@ -9,7 +9,7 @@ import (
 // HandleRegistryExtensionBundle is called to handle HTTP requests for an extension's JavaScript
 // bundle and other assets. If there is no local extension registry, it returns an HTTP error
 // response.
-var HandleRegistryExtensionBundle = func(db database.DB) func(w http.ResponseWriter, r *http.Request) {
+var HandleRegistryExtensionBundle = func(db database.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "no local extension registry exists", http.StatusNotFound)
 	}

--- a/cmd/frontend/registry/api/extension_bundle.go
+++ b/cmd/frontend/registry/api/extension_bundle.go
@@ -1,10 +1,16 @@
 package api
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+)
 
 // HandleRegistryExtensionBundle is called to handle HTTP requests for an extension's JavaScript
 // bundle and other assets. If there is no local extension registry, it returns an HTTP error
 // response.
-var HandleRegistryExtensionBundle = func(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "no local extension registry exists", http.StatusNotFound)
+var HandleRegistryExtensionBundle = func(db database.DB) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no local extension registry exists", http.StatusNotFound)
+	}
 }

--- a/cmd/frontend/registry/api/extension_connection_graphql.go
+++ b/cmd/frontend/registry/api/extension_connection_graphql.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	registry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/client"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 // makePrioritizeExtensionIDsSet returns a set whose values are the elements of
@@ -36,7 +36,7 @@ func (r *extensionRegistryResolver) Extensions(ctx context.Context, args *graphq
 type registryExtensionConnectionResolver struct {
 	args graphqlbackend.RegistryExtensionConnectionArgs
 
-	db                           dbutil.DB
+	db                           database.DB
 	listRemoteRegistryExtensions func(_ context.Context, query string) ([]*registry.Extension, error)
 
 	// cache results because they are used by multiple fields
@@ -48,12 +48,12 @@ type registryExtensionConnectionResolver struct {
 var (
 	// ListLocalRegistryExtensions lists and returns local registry extensions according to the args. If
 	// there is no local extension registry, it is not implemented.
-	ListLocalRegistryExtensions func(context.Context, dbutil.DB, graphqlbackend.RegistryExtensionConnectionArgs) ([]graphqlbackend.RegistryExtension, error)
+	ListLocalRegistryExtensions func(context.Context, database.DB, graphqlbackend.RegistryExtensionConnectionArgs) ([]graphqlbackend.RegistryExtension, error)
 
 	// CountLocalRegistryExtensions returns the count of local registry extensions according to the
 	// args. Pagination-related args are ignored. If there is no local extension registry, it is not
 	// implemented.
-	CountLocalRegistryExtensions func(context.Context, dbutil.DB, graphqlbackend.RegistryExtensionConnectionArgs) (int, error)
+	CountLocalRegistryExtensions func(context.Context, database.DB, graphqlbackend.RegistryExtensionConnectionArgs) (int, error)
 )
 
 func (r *registryExtensionConnectionResolver) compute(ctx context.Context) ([]graphqlbackend.RegistryExtension, error) {

--- a/cmd/frontend/registry/api/extension_connection_graphql_test.go
+++ b/cmd/frontend/registry/api/extension_connection_graphql_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	registry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/client"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 func TestRegistryExtensionConnectionResolver(t *testing.T) {
@@ -21,7 +21,7 @@ func TestRegistryExtensionConnectionResolver(t *testing.T) {
 		return ids
 	}
 
-	ListLocalRegistryExtensions = func(context.Context, dbutil.DB, graphqlbackend.RegistryExtensionConnectionArgs) ([]graphqlbackend.RegistryExtension, error) {
+	ListLocalRegistryExtensions = func(context.Context, database.DB, graphqlbackend.RegistryExtensionConnectionArgs) ([]graphqlbackend.RegistryExtension, error) {
 		return nil, nil
 	}
 	defer func() {

--- a/cmd/frontend/registry/api/extension_graphql.go
+++ b/cmd/frontend/registry/api/extension_graphql.go
@@ -8,7 +8,7 @@ import (
 	"github.com/graph-gophers/graphql-go/relay"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 func init() {
@@ -45,9 +45,9 @@ func UnmarshalRegistryExtensionID(id graphql.ID) (registryExtensionID RegistryEx
 // RegistryExtensionByIDInt32 looks up and returns the registry extension in the database with the
 // given ID. If no such extension exists, an error is returned. The func is nil when there is no
 // local registry.
-var RegistryExtensionByIDInt32 func(context.Context, dbutil.DB, int32) (graphqlbackend.RegistryExtension, error)
+var RegistryExtensionByIDInt32 func(context.Context, database.DB, int32) (graphqlbackend.RegistryExtension, error)
 
-func registryExtensionByID(ctx context.Context, db dbutil.DB, id graphql.ID) (graphqlbackend.RegistryExtension, error) {
+func registryExtensionByID(ctx context.Context, db database.DB, id graphql.ID) (graphqlbackend.RegistryExtension, error) {
 	registryExtensionID, err := UnmarshalRegistryExtensionID(id)
 	if err != nil {
 		return nil, err

--- a/cmd/frontend/registry/api/extensions.go
+++ b/cmd/frontend/registry/api/extensions.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	registry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/client"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 )
 
@@ -74,7 +74,7 @@ func ParseExtensionID(extensionID string) (prefix, extensionIDWithoutPrefix stri
 
 // GetLocalExtensionByExtensionID looks up and returns the registry extension in the local registry
 // with the given extension ID. If there is no local extension registry, it is not implemented.
-var GetLocalExtensionByExtensionID func(ctx context.Context, db dbutil.DB, extensionIDWithoutPrefix string) (local graphqlbackend.RegistryExtension, err error)
+var GetLocalExtensionByExtensionID func(ctx context.Context, db database.DB, extensionIDWithoutPrefix string) (local graphqlbackend.RegistryExtension, err error)
 
 // GetExtensionByExtensionID gets the extension with the given extension ID.
 //
@@ -84,7 +84,7 @@ var GetLocalExtensionByExtensionID func(ctx context.Context, db dbutil.DB, exten
 // to the remote registry specified in site configuration (usually sourcegraph.com). The host must
 // be specified to refer to a local extension on the current Sourcegraph site (e.g.,
 // sourcegraph.example.com/publisher/name).
-func GetExtensionByExtensionID(ctx context.Context, db dbutil.DB, extensionID string) (local graphqlbackend.RegistryExtension, remote *registry.Extension, err error) {
+func GetExtensionByExtensionID(ctx context.Context, db database.DB, extensionID string) (local graphqlbackend.RegistryExtension, remote *registry.Extension, err error) {
 	_, extensionIDWithoutPrefix, isLocal, err := ParseExtensionID(extensionID)
 	if err != nil {
 		return nil, nil, err
@@ -207,13 +207,13 @@ func listRemoteRegistryExtensions(ctx context.Context, query string) ([]*registr
 
 // GetLocalFeaturedExtensions looks up and returns the featured registry extensions in the local registry
 // If this is not sourcegraph.com, it is not implemented.
-var GetLocalFeaturedExtensions func(ctx context.Context, db dbutil.DB) ([]graphqlbackend.RegistryExtension, error)
+var GetLocalFeaturedExtensions func(ctx context.Context, db database.DB) ([]graphqlbackend.RegistryExtension, error)
 
 // GetFeaturedExtensions returns the set of featured extensions.
 //
 // If this is sourcegraph.com, these are local extensions. Otherwise, these are remote extensions
 // retrieved from sourcegraph.com.
-func GetFeaturedExtensions(ctx context.Context, db dbutil.DB) ([]graphqlbackend.RegistryExtension, error) {
+func GetFeaturedExtensions(ctx context.Context, db database.DB) ([]graphqlbackend.RegistryExtension, error) {
 	if envvar.SourcegraphDotComMode() && GetLocalFeaturedExtensions != nil {
 		return GetLocalFeaturedExtensions(ctx, db)
 	}

--- a/cmd/frontend/registry/api/extensions_test.go
+++ b/cmd/frontend/registry/api/extensions_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	registry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/client"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 func TestSplitExtensionID(t *testing.T) {
@@ -101,14 +101,14 @@ type mockRegistryExtension struct {
 
 func TestGetExtensionByExtensionID(t *testing.T) {
 	ctx := context.Background()
-	db := new(dbtesting.MockDB)
+	db := database.NewDB(new(dbtesting.MockDB))
 
 	t.Run("root", func(t *testing.T) {
 		mockLocalRegistryExtensionIDPrefix = &strnilptr
 		defer func() { mockLocalRegistryExtensionIDPrefix = nil }()
 
 		t.Run("2-part", func(t *testing.T) {
-			GetLocalExtensionByExtensionID = func(ctx context.Context, db dbutil.DB, extensionID string) (graphqlbackend.RegistryExtension, error) {
+			GetLocalExtensionByExtensionID = func(ctx context.Context, db database.DB, extensionID string) (graphqlbackend.RegistryExtension, error) {
 				if want := "a/b"; extensionID != want {
 					t.Errorf("got %q, want %q", extensionID, want)
 				}
@@ -162,7 +162,7 @@ func TestGetExtensionByExtensionID(t *testing.T) {
 		})
 
 		t.Run("3-part", func(t *testing.T) {
-			GetLocalExtensionByExtensionID = func(ctx context.Context, db dbutil.DB, extensionID string) (graphqlbackend.RegistryExtension, error) {
+			GetLocalExtensionByExtensionID = func(ctx context.Context, db database.DB, extensionID string) (graphqlbackend.RegistryExtension, error) {
 				if want := "b/c"; extensionID != want {
 					t.Errorf("got %q, want %q", extensionID, want)
 				}

--- a/cmd/frontend/registry/api/featured_extensions.go
+++ b/cmd/frontend/registry/api/featured_extensions.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 type featuredExtensionsResolver struct {
@@ -14,7 +14,7 @@ type featuredExtensionsResolver struct {
 
 	featuredExtensions []graphqlbackend.RegistryExtension
 	err                error
-	db                 dbutil.DB
+	db                 database.DB
 }
 
 func (r *extensionRegistryResolver) FeaturedExtensions(ctx context.Context) (graphqlbackend.FeaturedExtensionsConnection, error) {

--- a/cmd/frontend/registry/api/http_api.go
+++ b/cmd/frontend/registry/api/http_api.go
@@ -1,10 +1,16 @@
 package api
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+)
 
 // HandleRegistry is called to handle HTTP requests for the extension registry. If there is no local
 // extension registry, it returns an HTTP error response.
-var HandleRegistry = func(w http.ResponseWriter, r *http.Request) error {
-	http.Error(w, "no local extension registry exists", http.StatusNotFound)
-	return nil
+var HandleRegistry = func(db database.DB) func(w http.ResponseWriter, r *http.Request) error {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		http.Error(w, "no local extension registry exists", http.StatusNotFound)
+		return nil
+	}
 }

--- a/enterprise/cmd/frontend/internal/registry/extension_bundle.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_bundle.go
@@ -15,7 +15,7 @@ import (
 	frontendregistry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/api"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/registry/stores"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
@@ -29,86 +29,88 @@ var sourceMappingURLLineRegex = lazyregexp.New(`(?m)\r?\n?^//# sourceMappingURL=
 
 // handleRegistryExtensionBundle serves the bundled JavaScript source file or the source map for an
 // extension in the registry as a raw JavaScript or JSON file.
-func handleRegistryExtensionBundle(w http.ResponseWriter, r *http.Request) {
-	if conf.Extensions() == nil {
-		w.WriteHeader(http.StatusNotFound)
-		return
-	}
-
-	filename := mux.Vars(r)["RegistryExtensionReleaseFilename"]
-	wantSourceMap := filepath.Ext(filename) == ".map"
-
-	releaseID, err := parseExtensionBundleFilename(filename)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-	bundle, sourceMap, err := stores.Releases(dbconn.Global).GetArtifacts(r.Context(), releaseID)
-	if errcode.IsNotFound(err) {
-		http.Error(w, err.Error(), http.StatusNotFound)
-		return
-	} else if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	// 🚨 SECURITY: Prevent this URL from being rendered as an HTML page by browsers (to prevent an
-	// XSS attack). That would let attackers upload an HTML file with inline JavaScript and then
-	// cause victims to visit it, thereby executing the attacker's JavaScript in the context of
-	// Sourcegraph's domain.
-	//
-	// Note that it IS safe for the file to be served as application/javascript. If an attacker
-	// references it in a <script> tag on the attacker's site, the JavaScript will execute in the
-	// context of the attacker's site, not Sourcegraph. The script file being hosted by Sourcegraph
-	// does not give it any privileges with respect to Sourcegraph's domain.
-	w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; sandbox")
-	w.Header().Set("X-Frame-Options", "deny")
-	w.Header().Set("X-Content-Type-Options", "nosniff")
-	w.Header().Set("X-XSS-Protection", "1; mode=block")
-
-	// 🚨 SECURITY sourcegraph.com only: downstream Sourcegraph sites' clients to access this file directly.
-	// On private registries, requests to fetch extension bundles are authenticated, and Access-Control headers
-	// should be preserved.
-	if envvar.SourcegraphDotComMode() {
-		w.Header().Del("Access-Control-Allow-Credentials") // credentials are not needed
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-	}
-
-	// We want to cache forever because an extension release is immutable, except that if the
-	// database is reset and and the registry_extension_releases.id sequence starts over, we don't
-	// want stale data from pre-reset. So, assume that the presence of a query string means that it
-	// includes some identifier that changes when the database is reset.
-	if r.URL.RawQuery != "" {
-		w.Header().Set("Cache-Control", "max-age=31536000, private, immutable")
-	}
-	var data []byte
-	if wantSourceMap {
-		if sourceMap == nil {
-			http.Error(w, "extension has no source map", http.StatusNotFound)
+func handleRegistryExtensionBundle(db database.DB) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if conf.Extensions() == nil {
+			w.WriteHeader(http.StatusNotFound)
 			return
 		}
-		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		data = sourceMap
-	} else {
-		w.Header().Set("Content-Type", "application/javascript; charset=utf-8")
-		data = sourceMappingURLLineRegex.ReplaceAll(bundle, []byte{})
-	}
-	_, _ = w.Write(data)
 
-	if !wantSourceMap && sourceMap != nil {
-		// Append `//# sourceMappingURL=` directive to JS bundle if we have a source map. It is
-		// necessary to provide the absolute URL because the JS bundle is not loaded directly (e.g.,
-		// via importScripts); it is saved to a blob URL and then executed, which means any relative
-		// source map URL would be interpreted relative to the blob URL (so a relative URL wouldn't
-		// work). Also, we can't rely on the original sourceMappingURL directive (if provided at
-		// publish time) because it has no way of knowing the absolute URL to the source map.
+		filename := mux.Vars(r)["RegistryExtensionReleaseFilename"]
+		wantSourceMap := filepath.Ext(filename) == ".map"
+
+		releaseID, err := parseExtensionBundleFilename(filename)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		bundle, sourceMap, err := stores.Releases(db).GetArtifacts(r.Context(), releaseID)
+		if errcode.IsNotFound(err) {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		} else if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		// 🚨 SECURITY: Prevent this URL from being rendered as an HTML page by browsers (to prevent an
+		// XSS attack). That would let attackers upload an HTML file with inline JavaScript and then
+		// cause victims to visit it, thereby executing the attacker's JavaScript in the context of
+		// Sourcegraph's domain.
 		//
-		// This implementation is not ideal because it means the JS bundle's contents depend on the
-		// external URL, which makes it technically not immutable. But given the blob URL constraint
-		// mentioned above, it's the best known solution.
-		if externalURL, _ := url.Parse(conf.Get().ExternalURL); externalURL != nil {
-			sourceMapURL := externalURL.ResolveReference(&url.URL{Path: path.Join(path.Dir(r.URL.Path), fmt.Sprintf("%d.map", releaseID))}).String()
-			fmt.Fprintf(w, "\n//# sourceMappingURL=%s", sourceMapURL)
+		// Note that it IS safe for the file to be served as application/javascript. If an attacker
+		// references it in a <script> tag on the attacker's site, the JavaScript will execute in the
+		// context of the attacker's site, not Sourcegraph. The script file being hosted by Sourcegraph
+		// does not give it any privileges with respect to Sourcegraph's domain.
+		w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; sandbox")
+		w.Header().Set("X-Frame-Options", "deny")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-XSS-Protection", "1; mode=block")
+
+		// 🚨 SECURITY sourcegraph.com only: downstream Sourcegraph sites' clients to access this file directly.
+		// On private registries, requests to fetch extension bundles are authenticated, and Access-Control headers
+		// should be preserved.
+		if envvar.SourcegraphDotComMode() {
+			w.Header().Del("Access-Control-Allow-Credentials") // credentials are not needed
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+		}
+
+		// We want to cache forever because an extension release is immutable, except that if the
+		// database is reset and and the registry_extension_releases.id sequence starts over, we don't
+		// want stale data from pre-reset. So, assume that the presence of a query string means that it
+		// includes some identifier that changes when the database is reset.
+		if r.URL.RawQuery != "" {
+			w.Header().Set("Cache-Control", "max-age=31536000, private, immutable")
+		}
+		var data []byte
+		if wantSourceMap {
+			if sourceMap == nil {
+				http.Error(w, "extension has no source map", http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			data = sourceMap
+		} else {
+			w.Header().Set("Content-Type", "application/javascript; charset=utf-8")
+			data = sourceMappingURLLineRegex.ReplaceAll(bundle, []byte{})
+		}
+		_, _ = w.Write(data)
+
+		if !wantSourceMap && sourceMap != nil {
+			// Append `//# sourceMappingURL=` directive to JS bundle if we have a source map. It is
+			// necessary to provide the absolute URL because the JS bundle is not loaded directly (e.g.,
+			// via importScripts); it is saved to a blob URL and then executed, which means any relative
+			// source map URL would be interpreted relative to the blob URL (so a relative URL wouldn't
+			// work). Also, we can't rely on the original sourceMappingURL directive (if provided at
+			// publish time) because it has no way of knowing the absolute URL to the source map.
+			//
+			// This implementation is not ideal because it means the JS bundle's contents depend on the
+			// external URL, which makes it technically not immutable. But given the blob URL constraint
+			// mentioned above, it's the best known solution.
+			if externalURL, _ := url.Parse(conf.Get().ExternalURL); externalURL != nil {
+				sourceMapURL := externalURL.ResolveReference(&url.URL{Path: path.Join(path.Dir(r.URL.Path), fmt.Sprintf("%d.map", releaseID))}).String()
+				fmt.Fprintf(w, "\n//# sourceMappingURL=%s", sourceMapURL)
+			}
 		}
 	}
 }

--- a/enterprise/cmd/frontend/internal/registry/extension_bundle.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_bundle.go
@@ -29,7 +29,7 @@ var sourceMappingURLLineRegex = lazyregexp.New(`(?m)\r?\n?^//# sourceMappingURL=
 
 // handleRegistryExtensionBundle serves the bundled JavaScript source file or the source map for an
 // extension in the registry as a raw JavaScript or JSON file.
-func handleRegistryExtensionBundle(db database.DB) func(w http.ResponseWriter, r *http.Request) {
+func handleRegistryExtensionBundle(db database.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if conf.Extensions() == nil {
 			w.WriteHeader(http.StatusNotFound)

--- a/enterprise/cmd/frontend/internal/registry/extension_connection_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_connection_graphql.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	registry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/api"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/registry/stores"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 func init() {
@@ -16,7 +16,7 @@ func init() {
 	registry.CountLocalRegistryExtensions = countLocalRegistryExtensions
 }
 
-func listLocalRegistryExtensions(ctx context.Context, db dbutil.DB, args graphqlbackend.RegistryExtensionConnectionArgs) ([]graphqlbackend.RegistryExtension, error) {
+func listLocalRegistryExtensions(ctx context.Context, db database.DB, args graphqlbackend.RegistryExtensionConnectionArgs) ([]graphqlbackend.RegistryExtension, error) {
 	if args.PrioritizeExtensionIDs != nil {
 		ids := filterStripLocalExtensionIDs(*args.PrioritizeExtensionIDs)
 		args.PrioritizeExtensionIDs = &ids
@@ -38,7 +38,7 @@ func listLocalRegistryExtensions(ctx context.Context, db dbutil.DB, args graphql
 		return nil, err
 	}
 
-	releasesByExtensionID, err := getLatestForBatch(ctx, vs)
+	releasesByExtensionID, err := getLatestForBatch(ctx, db, vs)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func listLocalRegistryExtensions(ctx context.Context, db dbutil.DB, args graphql
 	return ys, nil
 }
 
-func countLocalRegistryExtensions(ctx context.Context, db dbutil.DB, args graphqlbackend.RegistryExtensionConnectionArgs) (int, error) {
+func countLocalRegistryExtensions(ctx context.Context, db database.DB, args graphqlbackend.RegistryExtensionConnectionArgs) (int, error) {
 	opt, err := toDBExtensionsListOptions(args)
 	if err != nil {
 		return 0, err

--- a/enterprise/cmd/frontend/internal/registry/extension_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_graphql.go
@@ -13,12 +13,11 @@ import (
 	registry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/api"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/registry/stores"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 // extensionDBResolver implements the GraphQL type RegistryExtension.
 type extensionDBResolver struct {
-	db dbutil.DB
+	db database.DB
 	v  *stores.Extension
 
 	// Supplied as part of list endpoints, but

--- a/enterprise/cmd/frontend/internal/registry/extension_manifest.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_manifest.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/registry/stores"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
@@ -51,14 +51,14 @@ func getLatestRelease(ctx context.Context, releases stores.ReleaseStore, extensi
 // returns a nil manifest. If the manifest has no "url" field itself, a "url" field
 // pointing to the extension's bundle is inserted. It also returns the date that the
 // release was published.
-func getLatestForBatch(ctx context.Context, vs []*stores.Extension) (map[int32]*stores.Release, error) {
+func getLatestForBatch(ctx context.Context, db database.DB, vs []*stores.Extension) (map[int32]*stores.Release, error) {
 	var extensionIDs []int32
 	extensionIDMap := map[int32]string{}
 	for _, v := range vs {
 		extensionIDs = append(extensionIDs, v.ID)
 		extensionIDMap[v.ID] = v.NonCanonicalExtensionID
 	}
-	releases, err := stores.Releases(dbconn.Global).GetLatestBatch(ctx, extensionIDs, "release", false)
+	releases, err := stores.Releases(db).GetLatestBatch(ctx, extensionIDs, "release", false)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/registry/extensions.go
+++ b/enterprise/cmd/frontend/internal/registry/extensions.go
@@ -7,12 +7,12 @@ import (
 	registry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/api"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/registry/stores"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 func init() {
 	conf.DefaultRemoteRegistry = "https://sourcegraph.com/.api/registry"
-	registry.GetLocalExtensionByExtensionID = func(ctx context.Context, db dbutil.DB, extensionIDWithoutPrefix string) (graphqlbackend.RegistryExtension, error) {
+	registry.GetLocalExtensionByExtensionID = func(ctx context.Context, db database.DB, extensionIDWithoutPrefix string) (graphqlbackend.RegistryExtension, error) {
 		x, err := stores.Extensions(db).GetByExtensionID(ctx, extensionIDWithoutPrefix)
 		if err != nil {
 			return nil, err
@@ -23,7 +23,7 @@ func init() {
 		return &extensionDBResolver{db: db, v: x}, nil
 	}
 
-	registry.GetLocalFeaturedExtensions = func(ctx context.Context, db dbutil.DB) ([]graphqlbackend.RegistryExtension, error) {
+	registry.GetLocalFeaturedExtensions = func(ctx context.Context, db database.DB) ([]graphqlbackend.RegistryExtension, error) {
 		dbExtensions, err := stores.Extensions(db).GetFeaturedExtensions(ctx)
 		if err != nil {
 			return nil, err

--- a/enterprise/cmd/frontend/internal/registry/http_api.go
+++ b/enterprise/cmd/frontend/internal/registry/http_api.go
@@ -17,7 +17,7 @@ import (
 	registry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/client"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/registry/stores"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -30,13 +30,13 @@ func init() {
 // Funcs called by serveRegistry to get registry data. If fakeRegistryData is set, it is used as
 // the data source instead of the database.
 var (
-	registryList = func(ctx context.Context, opt stores.ExtensionsListOptions) ([]*registry.Extension, error) {
-		vs, err := stores.Extensions(dbconn.Global).List(ctx, opt)
+	registryList = func(ctx context.Context, db database.DB, opt stores.ExtensionsListOptions) ([]*registry.Extension, error) {
+		vs, err := stores.Extensions(db).List(ctx, opt)
 		if err != nil {
 			return nil, err
 		}
 
-		xs, err := toRegistryAPIExtensionBatch(ctx, vs)
+		xs, err := toRegistryAPIExtensionBatch(ctx, db, vs)
 		if err != nil {
 			return nil, err
 		}
@@ -56,30 +56,30 @@ var (
 		return ys, nil
 	}
 
-	registryGetByUUID = func(ctx context.Context, uuid string) (*registry.Extension, error) {
-		x, err := stores.Extensions(dbconn.Global).GetByUUID(ctx, uuid)
+	registryGetByUUID = func(ctx context.Context, db database.DB, uuid string) (*registry.Extension, error) {
+		x, err := stores.Extensions(db).GetByUUID(ctx, uuid)
 		if err != nil {
 			return nil, err
 		}
-		return toRegistryAPIExtension(ctx, x)
+		return toRegistryAPIExtension(ctx, db, x)
 	}
 
-	registryGetByExtensionID = func(ctx context.Context, extensionID string) (*registry.Extension, error) {
-		x, err := stores.Extensions(dbconn.Global).GetByExtensionID(ctx, extensionID)
+	registryGetByExtensionID = func(ctx context.Context, db database.DB, extensionID string) (*registry.Extension, error) {
+		x, err := stores.Extensions(db).GetByExtensionID(ctx, extensionID)
 		if err != nil {
 			return nil, err
 		}
-		return toRegistryAPIExtension(ctx, x)
+		return toRegistryAPIExtension(ctx, db, x)
 	}
 
-	registryGetFeaturedExtensions = func(ctx context.Context) ([]*registry.Extension, error) {
-		dbExtensions, err := stores.Extensions(dbconn.Global).GetFeaturedExtensions(ctx)
+	registryGetFeaturedExtensions = func(ctx context.Context, db database.DB) ([]*registry.Extension, error) {
+		dbExtensions, err := stores.Extensions(db).GetFeaturedExtensions(ctx)
 		if err != nil {
 			return nil, err
 		}
 		registryExtensions := []*registry.Extension{}
 		for _, x := range dbExtensions {
-			registryExtension, err := toRegistryAPIExtension(ctx, x)
+			registryExtension, err := toRegistryAPIExtension(ctx, db, x)
 			if err != nil {
 				continue
 			}
@@ -89,8 +89,8 @@ var (
 	}
 )
 
-func toRegistryAPIExtension(ctx context.Context, v *stores.Extension) (*registry.Extension, error) {
-	release, err := getLatestRelease(ctx, stores.Releases(dbconn.Global), v.NonCanonicalExtensionID, v.ID, "release")
+func toRegistryAPIExtension(ctx context.Context, db database.DB, v *stores.Extension) (*registry.Extension, error) {
+	release, err := getLatestRelease(ctx, stores.Releases(db), v.NonCanonicalExtensionID, v.ID, "release")
 	if err != nil {
 		return nil, err
 	}
@@ -102,8 +102,8 @@ func toRegistryAPIExtension(ctx context.Context, v *stores.Extension) (*registry
 	return newExtension(v, &release.Manifest, release.CreatedAt), nil
 }
 
-func toRegistryAPIExtensionBatch(ctx context.Context, vs []*stores.Extension) ([]*registry.Extension, error) {
-	releasesByExtensionID, err := getLatestForBatch(ctx, vs)
+func toRegistryAPIExtensionBatch(ctx context.Context, db database.DB, vs []*stores.Extension) ([]*registry.Extension, error) {
+	releasesByExtensionID, err := getLatestForBatch(ctx, db, vs)
 	if err != nil {
 		return nil, err
 	}
@@ -149,106 +149,108 @@ func (r *responseRecorder) WriteHeader(code int) {
 }
 
 // handleRegistry serves the external HTTP API for the extension registry.
-func handleRegistry(w http.ResponseWriter, r *http.Request) (err error) {
-	recorder := &responseRecorder{ResponseWriter: w, code: http.StatusOK}
-	w = recorder
+func handleRegistry(db database.DB) func(w http.ResponseWriter, r *http.Request) (err error) {
+	return func(w http.ResponseWriter, r *http.Request) (err error) {
+		recorder := &responseRecorder{ResponseWriter: w, code: http.StatusOK}
+		w = recorder
 
-	var operation string
-	defer func(began time.Time) {
-		seconds := time.Since(began).Seconds()
-		if err != nil && recorder.code == http.StatusOK {
-			recorder.code = http.StatusInternalServerError
+		var operation string
+		defer func(began time.Time) {
+			seconds := time.Since(began).Seconds()
+			if err != nil && recorder.code == http.StatusOK {
+				recorder.code = http.StatusInternalServerError
+			}
+			code := strconv.Itoa(recorder.code)
+			registryRequestsDuration.WithLabelValues(operation, code).Observe(seconds)
+		}(time.Now())
+
+		if conf.Extensions() == nil {
+			w.WriteHeader(http.StatusNotFound)
+			return nil
 		}
-		code := strconv.Itoa(recorder.code)
-		registryRequestsDuration.WithLabelValues(operation, code).Observe(seconds)
-	}(time.Now())
 
-	if conf.Extensions() == nil {
-		w.WriteHeader(http.StatusNotFound)
-		return nil
-	}
+		// Identify this response as coming from the registry API.
+		w.Header().Set(registry.MediaTypeHeaderName, registry.MediaType)
 
-	// Identify this response as coming from the registry API.
-	w.Header().Set(registry.MediaTypeHeaderName, registry.MediaType)
+		// The response differs based on some request headers, and we need to tell caches which ones.
+		//
+		// Accept, User-Agent: because these encode the registry client's API version, and responses are
+		// not cacheable across versions.
+		w.Header().Set("Vary", "Accept, User-Agent")
 
-	// The response differs based on some request headers, and we need to tell caches which ones.
-	//
-	// Accept, User-Agent: because these encode the registry client's API version, and responses are
-	// not cacheable across versions.
-	w.Header().Set("Vary", "Accept, User-Agent")
-
-	// Validate API version.
-	if v := r.Header.Get("Accept"); v != registry.AcceptHeader {
-		http.Error(w, fmt.Sprintf("invalid Accept header: expected %q", registry.AcceptHeader), http.StatusBadRequest)
-		return nil
-	}
-
-	// This handler can be mounted at either /.internal or /.api.
-	urlPath := r.URL.Path
-	switch {
-	case strings.HasPrefix(urlPath, "/.internal"):
-		urlPath = strings.TrimPrefix(urlPath, "/.internal")
-	case strings.HasPrefix(urlPath, "/.api"):
-		urlPath = strings.TrimPrefix(urlPath, "/.api")
-	}
-
-	const extensionsPath = "/registry/extensions"
-	var result interface{}
-	switch {
-	case urlPath == extensionsPath:
-		operation = "list"
-
-		query := r.URL.Query().Get("q")
-		var opt stores.ExtensionsListOptions
-		opt.Query, opt.Category, opt.Tag = parseExtensionQuery(query)
-		xs, err := registryList(r.Context(), opt)
-		if err != nil {
-			return err
+		// Validate API version.
+		if v := r.Header.Get("Accept"); v != registry.AcceptHeader {
+			http.Error(w, fmt.Sprintf("invalid Accept header: expected %q", registry.AcceptHeader), http.StatusBadRequest)
+			return nil
 		}
-		result = xs
 
-	case urlPath == extensionsPath+"/featured":
-		operation = "featured"
-		x, err := registryGetFeaturedExtensions(r.Context())
-		if err != nil {
-			return err
-		}
-		result = x
-
-	case strings.HasPrefix(urlPath, extensionsPath+"/"):
-		var (
-			spec = strings.TrimPrefix(urlPath, extensionsPath+"/")
-			x    *registry.Extension
-			err  error
-		)
+		// This handler can be mounted at either /.internal or /.api.
+		urlPath := r.URL.Path
 		switch {
-		case strings.HasPrefix(spec, "uuid/"):
-			operation = "get-by-uuid"
-			x, err = registryGetByUUID(r.Context(), strings.TrimPrefix(spec, "uuid/"))
-		case strings.HasPrefix(spec, "extension-id/"):
-			operation = "get-by-extension-id"
-			x, err = registryGetByExtensionID(r.Context(), strings.TrimPrefix(spec, "extension-id/"))
+		case strings.HasPrefix(urlPath, "/.internal"):
+			urlPath = strings.TrimPrefix(urlPath, "/.internal")
+		case strings.HasPrefix(urlPath, "/.api"):
+			urlPath = strings.TrimPrefix(urlPath, "/.api")
+		}
+
+		const extensionsPath = "/registry/extensions"
+		var result interface{}
+		switch {
+		case urlPath == extensionsPath:
+			operation = "list"
+
+			query := r.URL.Query().Get("q")
+			var opt stores.ExtensionsListOptions
+			opt.Query, opt.Category, opt.Tag = parseExtensionQuery(query)
+			xs, err := registryList(r.Context(), db, opt)
+			if err != nil {
+				return err
+			}
+			result = xs
+
+		case urlPath == extensionsPath+"/featured":
+			operation = "featured"
+			x, err := registryGetFeaturedExtensions(r.Context(), db)
+			if err != nil {
+				return err
+			}
+			result = x
+
+		case strings.HasPrefix(urlPath, extensionsPath+"/"):
+			var (
+				spec = strings.TrimPrefix(urlPath, extensionsPath+"/")
+				x    *registry.Extension
+				err  error
+			)
+			switch {
+			case strings.HasPrefix(spec, "uuid/"):
+				operation = "get-by-uuid"
+				x, err = registryGetByUUID(r.Context(), db, strings.TrimPrefix(spec, "uuid/"))
+			case strings.HasPrefix(spec, "extension-id/"):
+				operation = "get-by-extension-id"
+				x, err = registryGetByExtensionID(r.Context(), db, strings.TrimPrefix(spec, "extension-id/"))
+			default:
+				w.WriteHeader(http.StatusNotFound)
+				return nil
+			}
+			if x == nil || err != nil {
+				if x == nil || errcode.IsNotFound(err) {
+					w.Header().Set("Cache-Control", "max-age=5, private")
+					http.Error(w, "extension not found", http.StatusNotFound)
+					return nil
+				}
+				return err
+			}
+			result = x
+
 		default:
 			w.WriteHeader(http.StatusNotFound)
 			return nil
 		}
-		if x == nil || err != nil {
-			if x == nil || errcode.IsNotFound(err) {
-				w.Header().Set("Cache-Control", "max-age=5, private")
-				http.Error(w, "extension not found", http.StatusNotFound)
-				return nil
-			}
-			return err
-		}
-		result = x
 
-	default:
-		w.WriteHeader(http.StatusNotFound)
-		return nil
+		w.Header().Set("Cache-Control", "max-age=120, private")
+		return json.NewEncoder(w).Encode(result)
 	}
-
-	w.Header().Set("Cache-Control", "max-age=120, private")
-	return json.NewEncoder(w).Encode(result)
 }
 
 var (
@@ -280,28 +282,28 @@ func init() {
 		return xs, nil
 	}
 
-	registryList = func(ctx context.Context, opt stores.ExtensionsListOptions) ([]*registry.Extension, error) {
+	registryList = func(ctx context.Context, db database.DB, opt stores.ExtensionsListOptions) ([]*registry.Extension, error) {
 		xs, err := readFakeExtensions()
 		if err != nil {
 			return nil, err
 		}
 		return frontendregistry.FilterRegistryExtensions(xs, opt.Query), nil
 	}
-	registryGetByUUID = func(ctx context.Context, uuid string) (*registry.Extension, error) {
+	registryGetByUUID = func(ctx context.Context, db database.DB, uuid string) (*registry.Extension, error) {
 		xs, err := readFakeExtensions()
 		if err != nil {
 			return nil, err
 		}
 		return frontendregistry.FindRegistryExtension(xs, "uuid", uuid), nil
 	}
-	registryGetByExtensionID = func(ctx context.Context, extensionID string) (*registry.Extension, error) {
+	registryGetByExtensionID = func(ctx context.Context, db database.DB, extensionID string) (*registry.Extension, error) {
 		xs, err := readFakeExtensions()
 		if err != nil {
 			return nil, err
 		}
 		return frontendregistry.FindRegistryExtension(xs, "extensionID", extensionID), nil
 	}
-	registryGetFeaturedExtensions = func(ctx context.Context) ([]*registry.Extension, error) {
+	registryGetFeaturedExtensions = func(ctx context.Context, db database.DB) ([]*registry.Extension, error) {
 		return []*registry.Extension{}, nil
 	}
 }

--- a/enterprise/cmd/frontend/internal/registry/publisher_connection_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/publisher_connection_graphql.go
@@ -9,14 +9,13 @@ import (
 	frontendregistry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/api"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/registry/stores"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 func init() {
 	frontendregistry.ExtensionRegistry.PublishersFunc = extensionRegistryPublishers
 }
 
-func extensionRegistryPublishers(ctx context.Context, db dbutil.DB, args *graphqlutil.ConnectionArgs) (graphqlbackend.RegistryPublisherConnection, error) {
+func extensionRegistryPublishers(ctx context.Context, db database.DB, args *graphqlutil.ConnectionArgs) (graphqlbackend.RegistryPublisherConnection, error) {
 	var opt stores.PublishersListOptions
 	args.Set(&opt.LimitOffset)
 	return &registryPublisherConnection{opt: opt, db: db}, nil
@@ -30,7 +29,7 @@ type registryPublisherConnection struct {
 	once               sync.Once
 	registryPublishers []*stores.Publisher
 	err                error
-	db                 dbutil.DB
+	db                 database.DB
 }
 
 func (r *registryPublisherConnection) compute(ctx context.Context) ([]*stores.Publisher, error) {

--- a/enterprise/cmd/frontend/internal/registry/publisher_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/publisher_graphql.go
@@ -13,14 +13,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/registry/stores"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 func init() {
 	frontendregistry.ExtensionRegistry.ViewerPublishersFunc = extensionRegistryViewerPublishers
 }
 
-func extensionRegistryViewerPublishers(ctx context.Context, db dbutil.DB) ([]graphqlbackend.RegistryPublisher, error) {
+func extensionRegistryViewerPublishers(ctx context.Context, db database.DB) ([]graphqlbackend.RegistryPublisher, error) {
 	// The feature check here makes it so the any "New extension" form will show an error, so the
 	// user finds out before trying to submit the form that the feature is disabled.
 	if err := licensing.Check(licensing.FeatureExtensionRegistry); err != nil {
@@ -136,14 +135,14 @@ func unmarshalRegistryPublisherID(id graphql.ID) (*registryPublisherID, error) {
 // registry extension with the given publisher.
 //
 // 🚨 SECURITY
-func (p *registryPublisherID) viewerCanAdminister(ctx context.Context, db dbutil.DB) error {
+func (p *registryPublisherID) viewerCanAdminister(ctx context.Context, db database.DB) error {
 	switch {
 	case p.userID != 0:
 		// 🚨 SECURITY: Check that the current user is either the publisher or a site admin.
-		return backend.CheckSiteAdminOrSameUser(ctx, database.NewDB(db), p.userID)
+		return backend.CheckSiteAdminOrSameUser(ctx, db, p.userID)
 	case p.orgID != 0:
 		// 🚨 SECURITY: Check that the current user is a member of the publisher org.
-		return backend.CheckOrgAccessOrSiteAdmin(ctx, database.NewDB(db), p.orgID)
+		return backend.CheckOrgAccessOrSiteAdmin(ctx, db, p.orgID)
 	default:
 		return errRegistryUnknownPublisher
 	}

--- a/enterprise/cmd/frontend/internal/registry/registry_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/registry_graphql.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 )
 
@@ -23,7 +23,7 @@ func init() {
 	frontendregistry.ExtensionRegistry.PublishExtensionFunc = extensionRegistryPublishExtension
 }
 
-func registryExtensionByIDInt32(ctx context.Context, db dbutil.DB, id int32) (graphqlbackend.RegistryExtension, error) {
+func registryExtensionByIDInt32(ctx context.Context, db database.DB, id int32) (graphqlbackend.RegistryExtension, error) {
 	if conf.Extensions() == nil {
 		return nil, graphqlbackend.ErrExtensionsDisabled
 	}
@@ -37,7 +37,7 @@ func registryExtensionByIDInt32(ctx context.Context, db dbutil.DB, id int32) (gr
 	return &extensionDBResolver{db: db, v: x}, nil
 }
 
-func extensionRegistryCreateExtension(ctx context.Context, db dbutil.DB, args *graphqlbackend.ExtensionRegistryCreateExtensionArgs) (graphqlbackend.ExtensionRegistryMutationResult, error) {
+func extensionRegistryCreateExtension(ctx context.Context, db database.DB, args *graphqlbackend.ExtensionRegistryCreateExtensionArgs) (graphqlbackend.ExtensionRegistryMutationResult, error) {
 	if err := licensing.Check(licensing.FeatureExtensionRegistry); err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func extensionRegistryCreateExtension(ctx context.Context, db dbutil.DB, args *g
 	return &frontendregistry.ExtensionRegistryMutationResult{DB: db, ID: id}, nil
 }
 
-func viewerCanAdministerExtension(ctx context.Context, db dbutil.DB, id frontendregistry.RegistryExtensionID) error {
+func viewerCanAdministerExtension(ctx context.Context, db database.DB, id frontendregistry.RegistryExtensionID) error {
 	if id.LocalID == 0 {
 		return errors.New("unable to administer extension on remote registry")
 	}
@@ -70,7 +70,7 @@ func viewerCanAdministerExtension(ctx context.Context, db dbutil.DB, id frontend
 	return toRegistryPublisherID(extension).viewerCanAdminister(ctx, db)
 }
 
-func extensionRegistryUpdateExtension(ctx context.Context, db dbutil.DB, args *graphqlbackend.ExtensionRegistryUpdateExtensionArgs) (graphqlbackend.ExtensionRegistryMutationResult, error) {
+func extensionRegistryUpdateExtension(ctx context.Context, db database.DB, args *graphqlbackend.ExtensionRegistryUpdateExtensionArgs) (graphqlbackend.ExtensionRegistryMutationResult, error) {
 	id, err := frontendregistry.UnmarshalRegistryExtensionID(args.Extension)
 	if err != nil {
 		return nil, err
@@ -87,7 +87,7 @@ func extensionRegistryUpdateExtension(ctx context.Context, db dbutil.DB, args *g
 	return &frontendregistry.ExtensionRegistryMutationResult{DB: db, ID: id.LocalID}, nil
 }
 
-func extensionRegistryDeleteExtension(ctx context.Context, db dbutil.DB, args *graphqlbackend.ExtensionRegistryDeleteExtensionArgs) (*graphqlbackend.EmptyResponse, error) {
+func extensionRegistryDeleteExtension(ctx context.Context, db database.DB, args *graphqlbackend.ExtensionRegistryDeleteExtensionArgs) (*graphqlbackend.EmptyResponse, error) {
 	id, err := frontendregistry.UnmarshalRegistryExtensionID(args.Extension)
 	if err != nil {
 		return nil, err
@@ -104,7 +104,7 @@ func extensionRegistryDeleteExtension(ctx context.Context, db dbutil.DB, args *g
 	return &graphqlbackend.EmptyResponse{}, nil
 }
 
-func extensionRegistryPublishExtension(ctx context.Context, db dbutil.DB, args *graphqlbackend.ExtensionRegistryPublishExtensionArgs) (graphqlbackend.ExtensionRegistryMutationResult, error) {
+func extensionRegistryPublishExtension(ctx context.Context, db database.DB, args *graphqlbackend.ExtensionRegistryPublishExtensionArgs) (graphqlbackend.ExtensionRegistryMutationResult, error) {
 	if err := licensing.Check(licensing.FeatureExtensionRegistry); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Refactored dbutil.DB to database.DB and got rid of all dbconn.Global references in the registry code.

25 remaining, mostly in the setup logic for dbconn.Global :) 