### PR TITLE
[cloud] fix org invites not working if user is not logged in

### DIFF
--- a/client/web/src/org/OrgsArea.tsx
+++ b/client/web/src/org/OrgsArea.tsx
@@ -9,6 +9,7 @@ import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryServi
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
 import { AuthenticatedUser } from '../auth'
+import { withAuthenticatedUser } from '../auth/withAuthenticatedUser'
 import { BatchChangesProps } from '../batches'
 import { BreadcrumbsProps, BreadcrumbSetters } from '../components/Breadcrumbs'
 import { HeroPage } from '../components/HeroPage'
@@ -40,14 +41,14 @@ interface Props
     orgAreaRoutes: readonly OrgAreaRoute[]
     orgAreaHeaderNavItems: readonly OrgAreaHeaderNavItem[]
 
-    authenticatedUser: AuthenticatedUser | null
+    authenticatedUser: AuthenticatedUser
     isSourcegraphDotCom: boolean
 }
 
 /**
  * Renders a layout of a sidebar and a content area to display organization-related pages.
  */
-export const OrgsArea: React.FunctionComponent<Props> = props => (
+const AuthenticatedOrgsArea: React.FunctionComponent<Props> = props => (
     <Switch>
         <Route path={`${props.match.url}/new`} component={NewOrganizationPage} exact={true} />
         <Route
@@ -57,3 +58,5 @@ export const OrgsArea: React.FunctionComponent<Props> = props => (
         <Route component={NotFoundPage} />
     </Switch>
 )
+
+export const OrgsArea = withAuthenticatedUser(AuthenticatedOrgsArea)

--- a/client/web/src/org/area/OrgArea.tsx
+++ b/client/web/src/org/area/OrgArea.tsx
@@ -96,7 +96,7 @@ interface Props
     /**
      * The currently authenticated user.
      */
-    authenticatedUser: AuthenticatedUser | null
+    authenticatedUser: AuthenticatedUser
     isSourcegraphDotCom: boolean
 }
 


### PR DESCRIPTION
# Description

The fix is actually making sure the whole organizations section
can only be accessed by authenticated users. It does not really
make sense to allow non-authenticated users to view it.

# Related Jira issue
https://sourcegraph.atlassian.net/browse/CLOUD-152

# Testing locally

1. Run sg in cloud mode: `sg start dotcom`
2. Create an organization
3. Invite another user to the organization
4. In an incognito window, open the invite link immediately, without logging in
5. You should be redirected to the login screen
6. After logging in or signing up, you should be redirected back to the org invite screen