### PR TITLE
[cloud] Fix error shown to the user when org invite is declined

### DIFF
--- a/client/web/src/org/area/OrgArea.tsx
+++ b/client/web/src/org/area/OrgArea.tsx
@@ -274,7 +274,13 @@ export class OrgArea extends React.Component<Props> {
         )
     }
 
-    private onDidRespondToInvitation = (): void => this.refreshRequests.next()
+    private onDidRespondToInvitation = (accepted: boolean): void => {
+        if (!accepted) {
+            this.props.history.push('/user/settings')
+            return
+        }
+        this.refreshRequests.next()
+    }
 
     private onDidUpdateOrganization = (): void => this.refreshRequests.next()
 }

--- a/client/web/src/org/area/OrgInvitationPage.tsx
+++ b/client/web/src/org/area/OrgInvitationPage.tsx
@@ -31,7 +31,7 @@ interface Props extends OrgAreaPageProps {
     authenticatedUser: AuthenticatedUser
 
     /** Called when the viewer responds to the invitation. */
-    onDidRespondToInvitation: () => void
+    onDidRespondToInvitation: (accepted: boolean) => void
 }
 
 interface State {
@@ -77,7 +77,11 @@ export const OrgInvitationPage = withAuthenticatedUser(
                                     responseType,
                                 }).pipe(
                                     tap(() => eventLogger.log('OrgInvitationRespondedTo')),
-                                    tap(() => this.props.onDidRespondToInvitation()),
+                                    tap(() =>
+                                        this.props.onDidRespondToInvitation(
+                                            responseType === OrganizationInvitationResponseType.ACCEPT
+                                        )
+                                    ),
                                     concatMap(() => [
                                         // Refresh current user's list of organizations.
                                         refreshAuthenticatedUser(),


### PR DESCRIPTION
# Description

Fix error shown to the user when org invite is declined

# Related Jira issue:
https://sourcegraph.atlassian.net/browse/CLOUD-154
https://sourcegraph.atlassian.net/browse/CLOUD-153

# Related PR:
#28170 

# Testing locally
1. Run sg in cloud mode: `sg start dotcom`
2. Create an organization
2. Create an organization invite for another user
3. Login with the other user
4. Follow the invite link
5. Click on Decline
6. The user should be navigated to user settings
