### PR TITLE
Code Insights: Fix bad DnD events on view card action panel

### DIFF
--- a/client/web/src/views/components/view/View.tsx
+++ b/client/web/src/views/components/view/View.tsx
@@ -6,6 +6,8 @@ import { ErrorBoundary } from '../../../components/ErrorBoundary'
 
 import styles from './View.module.scss'
 
+const stopPropagation = (event: React.MouseEvent): void => event.stopPropagation()
+
 type ViewCardElementProps = React.DetailedHTMLProps<Omit<React.HTMLAttributes<HTMLElement>, 'contextMenu'>, HTMLElement>
 
 export interface ViewCardProps extends ViewCardElementProps {
@@ -45,7 +47,17 @@ export const View: React.FunctionComponent<PropsWithChildren<ViewCardProps>> = p
                             {subtitle}
                         </div>
 
-                        <div className={styles.action}>{actions}</div>
+                        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
+                        <div
+                            // View component usually is rendered within a view grid component. To suppress
+                            // bad click that lead to card DnD events in view grid we stop event bubbling for
+                            // clicks.
+                            onClick={stopPropagation}
+                            onMouseDown={stopPropagation}
+                            className={styles.action}
+                        >
+                            {actions}
+                        </div>
                     </header>
                 )}
 


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/27031

## Context
The problem: React-grid-layout and <ViewGrid /> component listen to all DnD start-like events such as clicks or mouse down events on view (code insights card) components. Because of that click on clickable elements within a card can lead to starting DnD flow hence we see red flashing and grid rerender.

View card component should catch click on clickable elements within a card to avoid starting DnD flow for this card.