### PR TITLE
sg: rename dot-com -> cloud

### DIFF
--- a/dev/sg/live.go
+++ b/dev/sg/live.go
@@ -18,7 +18,7 @@ type environment struct {
 }
 
 var environments = []environment{
-	{Name: "dot-com", URL: "https://sourcegraph.com"},
+	{Name: "cloud", URL: "https://sourcegraph.com"},
 	{Name: "k8s", URL: "https://k8s.sgdev.org"},
 }
 

--- a/doc/dev/background-information/sg/index.md
+++ b/doc/dev/background-information/sg/index.md
@@ -160,7 +160,7 @@ sg doctor
 
 ```bash
 # See which version is deployed on a preset environment
-sg live dot-com
+sg live cloud
 sg live k8s
 
 # See which version is deployed on a custom environment


### PR DESCRIPTION
Sourcegraph Cloud is now formally named Sourcegraph Cloud