### PR TITLE
fix esbuild manifest format

### DIFF
--- a/client/web/dev/esbuild/manifestPlugin.ts
+++ b/client/web/dev/esbuild/manifestPlugin.ts
@@ -9,8 +9,8 @@ import { WebpackManifest } from '../webpack/get-html-webpack-plugins'
 export const assetPathPrefix = '/.assets'
 
 export const getManifest = (): WebpackManifest => ({
-    appBundle: path.join(assetPathPrefix, 'scripts/app.js'),
-    cssBundle: path.join(assetPathPrefix, 'scripts/app.css'),
+    'app.js': path.join(assetPathPrefix, 'scripts/app.js'),
+    'app.css': path.join(assetPathPrefix, 'scripts/app.css'),
     isModule: true,
 })
 

--- a/client/web/dev/webpack/get-html-webpack-plugins.ts
+++ b/client/web/dev/webpack/get-html-webpack-plugins.ts
@@ -89,10 +89,10 @@ export const getHTMLWebpackPlugins = (): WebpackPluginInstance[] => {
             }
 
             return getHTMLPage({
-                appBundle,
-                cssBundle: getBundleFromPath(files.css, 'styles/app'),
-                runtimeBundle: getBundleFromPath(files.js, 'scripts/runtime'),
-                reactBundle: getBundleFromPath(files.js, 'scripts/react'),
+                'app.js': appBundle,
+                'app.css': getBundleFromPath(files.css, 'styles/app'),
+                'runtime.js': getBundleFromPath(files.js, 'scripts/runtime'),
+                'react.js': getBundleFromPath(files.js, 'scripts/react'),
             })
         }) as Options['templateContent'],
         filename: path.resolve(STATIC_ASSETS_PATH, 'index.html'),

--- a/client/web/dev/webpack/get-html-webpack-plugins.ts
+++ b/client/web/dev/webpack/get-html-webpack-plugins.ts
@@ -10,13 +10,13 @@ const { SOURCEGRAPH_HTTPS_PORT, NODE_ENV } = environmentConfig
 
 export interface WebpackManifest {
     /** Main app entry JS bundle */
-    appBundle: string
+    'app.js': string
     /** Main app entry CSS bundle, only used in production mode */
-    cssBundle?: string
+    'app.css'?: string
     /** Runtime bundle, only used in development mode */
-    runtimeBundle?: string
+    'runtime.js'?: string
     /** React entry bundle, only used in production mode */
-    reactBundle?: string
+    'react.js'?: string
     /** If script files should be treated as JS modules. Required for esbuild bundle. */
     isModule?: boolean
 }
@@ -29,10 +29,10 @@ export interface WebpackManifest {
  * between our development server and the actual production server.
  */
 export const getHTMLPage = ({
-    appBundle,
-    cssBundle,
-    runtimeBundle,
-    reactBundle,
+    'app.js': appBundle,
+    'app.css': cssBundle,
+    'runtime.js': runtimeBundle,
+    'react.js': reactBundle,
     isModule,
 }: WebpackManifest): string => `
 <!DOCTYPE html>


### PR DESCRIPTION
In #26594 the property names of the object that is serialized to webpack.manifest.json were changed from (eg) `app.js` to `appBundle` (and so on for CSS, runtime, and react). This broke esbuild by causing it to write an incorrect webpack.manifest.json file, which is how the Go frontend prints out the right `<script>` tags for HTML pages to load the scripts. This changes the property names written by esbuild back to the same ones that the Go frontend code expects (and the same ones that Webpack writes to the file).