### PR TITLE
sg setup: use SSH checkouts of git repos

### DIFF
--- a/dev/sg/sg_setup.go
+++ b/dev/sg/sg_setup.go
@@ -368,7 +368,7 @@ var cloneInstructions = []instruction{
 	{
 		prompt:  `Cloning the code`,
 		comment: `We're now going to clone the Sourcegraph repository. Make sure you execute the following command in a folder where you want to keep the repository. Command will create a new sub-folder (sourcegraph) in this folder.`,
-		command: `git clone https://github.com/sourcegraph/sourcegraph.git`,
+		command: `git clone git@github.com:sourcegraph/sourcegraph.git`,
 	},
 	{
 		prompt:    "Are you a Sourcegraph employee",
@@ -383,7 +383,7 @@ To illustrate:
  |-- dev-private
  +-- sourcegraph
 NOTE: Ensure that you periodically pull the latest changes from sourcegraph/dev-private as the secrets are updated from time to time.`,
-		command: `git clone https://github.com/sourcegraph/dev-private.git`,
+		command: `git clone git@github.com:sourcegraph/dev-private.git`,
 		ifBool:  "employee",
 	},
 }


### PR DESCRIPTION
This PR will update the two `git clone` command to use the `SSH` method for checking out a repository. Currently, they are using `HTTPS` which has some complications. GitHub has [recently removed](https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/) the ability to authenticate using username/password for git operations and now requires a personal access token be created and entered on every push to a remote (instead of a password). For frequent contributors, this could become an annoyance.

Ultimately, this is personal preference. Would love to get your thoughts.