### PR TITLE
gitserver: add janitor task for sg maintenance

### DIFF
--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -32,8 +32,8 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
-    # We require git>=2.34.1 because we use git-repack with flag --write-midx.
-    'git>=2.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
+    # We require git 2.34.1 because we use git-repack with flag --write-midx.
+    'git=~2.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
     git-p4 \
     && apk add --no-cache  \
     openssh-client \

--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -4,14 +4,14 @@
 # ignores.
 
 # Install p4 CLI (keep this up to date with cmd/server/Dockerfile)
-FROM sourcegraph/alpine-3.14:117816_2021-11-25_6eb4943@sha256:06d0ecb92132c7c40ce6476b2e72d633b55b1076a49411526985fa08cdfc16ab AS p4cli
+FROM sourcegraph/alpine-3.12:120059_2021-12-09_b34c7b2@sha256:9a1fde12f56fea02027cf4caeebdddfedb7b73bf8db6c16f7907a6e04a29134c AS p4cli
 
 # hadolint ignore=DL3003
 RUN wget http://cdist2.perforce.com/perforce/r20.1/bin.linux26x86_64/p4 && \
     mv p4 /usr/local/bin/p4 && \
     chmod +x /usr/local/bin/p4
 
-FROM sourcegraph/alpine-3.14:117816_2021-11-25_6eb4943@sha256:06d0ecb92132c7c40ce6476b2e72d633b55b1076a49411526985fa08cdfc16ab AS coursier
+FROM sourcegraph/alpine-3.12:120059_2021-12-09_b34c7b2@sha256:9a1fde12f56fea02027cf4caeebdddfedb7b73bf8db6c16f7907a6e04a29134c AS coursier
 
 # TODO(code-intel): replace with official streams when musl builds are upstreamed
 RUN wget -O coursier.zip https://github.com/sourcegraph/lsif-java/releases/download/v0.5.6/cs-musl.zip && \
@@ -19,7 +19,7 @@ RUN wget -O coursier.zip https://github.com/sourcegraph/lsif-java/releases/downl
     mv cs-musl /usr/local/bin/coursier && \
     chmod +x /usr/local/bin/coursier
 
-FROM sourcegraph/alpine-3.14:117816_2021-11-25_6eb4943@sha256:06d0ecb92132c7c40ce6476b2e72d633b55b1076a49411526985fa08cdfc16ab
+FROM sourcegraph/alpine-3.12:120059_2021-12-09_b34c7b2@sha256:9a1fde12f56fea02027cf4caeebdddfedb7b73bf8db6c16f7907a6e04a29134c
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"
@@ -32,10 +32,11 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
-    # Gitserver requires Git protocol v2 https://github.com/sourcegraph/sourcegraph/issues/13168
-    'git>=2.30' \
-    openssh-client \
+    # We require git>=2.30 because we use git maintenance.
+    'git>=2.30' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
     git-p4 \
+    && apk add --no-cache  \
+    openssh-client \
     python2 \
     python3
 

--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -4,14 +4,14 @@
 # ignores.
 
 # Install p4 CLI (keep this up to date with cmd/server/Dockerfile)
-FROM sourcegraph/alpine-3.12:120059_2021-12-09_b34c7b2@sha256:9a1fde12f56fea02027cf4caeebdddfedb7b73bf8db6c16f7907a6e04a29134c AS p4cli
+FROM sourcegraph/alpine-3.14:117816_2021-11-25_6eb4943@sha256:06d0ecb92132c7c40ce6476b2e72d633b55b1076a49411526985fa08cdfc16ab AS p4cli
 
 # hadolint ignore=DL3003
 RUN wget http://cdist2.perforce.com/perforce/r20.1/bin.linux26x86_64/p4 && \
     mv p4 /usr/local/bin/p4 && \
     chmod +x /usr/local/bin/p4
 
-FROM sourcegraph/alpine-3.12:120059_2021-12-09_b34c7b2@sha256:9a1fde12f56fea02027cf4caeebdddfedb7b73bf8db6c16f7907a6e04a29134c AS coursier
+FROM sourcegraph/alpine-3.14:117816_2021-11-25_6eb4943@sha256:06d0ecb92132c7c40ce6476b2e72d633b55b1076a49411526985fa08cdfc16ab AS coursier
 
 # TODO(code-intel): replace with official streams when musl builds are upstreamed
 RUN wget -O coursier.zip https://github.com/sourcegraph/lsif-java/releases/download/v0.5.6/cs-musl.zip && \
@@ -19,7 +19,7 @@ RUN wget -O coursier.zip https://github.com/sourcegraph/lsif-java/releases/downl
     mv cs-musl /usr/local/bin/coursier && \
     chmod +x /usr/local/bin/coursier
 
-FROM sourcegraph/alpine-3.12:120059_2021-12-09_b34c7b2@sha256:9a1fde12f56fea02027cf4caeebdddfedb7b73bf8db6c16f7907a6e04a29134c
+FROM sourcegraph/alpine-3.14:117816_2021-11-25_6eb4943@sha256:06d0ecb92132c7c40ce6476b2e72d633b55b1076a49411526985fa08cdfc16ab
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"
@@ -32,11 +32,10 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
-    # We require git>=2.30 because we use git maintenance.
-    'git>=2.30' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
-    git-p4 \
-    && apk add --no-cache  \
+    # Gitserver requires Git protocol v2 https://github.com/sourcegraph/sourcegraph/issues/13168
+    'git>=2.30' \
     openssh-client \
+    git-p4 \
     python2 \
     python3
 

--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -32,8 +32,8 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
-    # We require git>=2.30 because we use git maintenance.
-    'git>=2.30' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
+    # We require git>=2.34.1 because we use git-repack with flag --write-midx.
+    'git>=2.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
     git-p4 \
     && apk add --no-cache  \
     openssh-client \

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -52,9 +52,9 @@ const (
 // likely evolve into some form of site config value in the future.
 var enableGCAuto, _ = strconv.ParseBool(env.Get("SRC_ENABLE_GC_AUTO", "true", "Use git-gc during janitorial cleanup phases"))
 
-// git maintenance and git gc must not be enabled at the same time. However, both
+// sg maintenance and git gc must not be enabled at the same time. However, both
 // might be disabled at the same time, hence we need both SRC_ENABLE_GC_AUTO and
-// SRC_ENABLE_GIT_MAINTENANCE.
+// SRC_ENABLE_SG_MAINTENANCE.
 var enableSGMaintenance, _ = strconv.ParseBool(env.Get("SRC_ENABLE_SG_MAINTENANCE", "false", "Use sg maintenance during janitorial cleanup phases"))
 
 var (
@@ -92,6 +92,7 @@ const reposStatsName = "repos-stats.json"
 // 6. Perform garbage collection
 // 7. Re-clone repos after a while. (simulate git gc)
 // 8. Remove repos based on disk pressure.
+// 9. Perform sg-maintenance
 func (s *Server) cleanupRepos() {
 	janitorRunning.Set(1)
 	defer janitorRunning.Set(0)
@@ -284,8 +285,8 @@ func (s *Server) cleanupRepos() {
 
 	if enableSGMaintenance && !enableGCAuto {
 		// Run tasks to optimize Git repository data, speeding up other Git commands and
-		// reducing storage requirements for the repository. Note: performGC and
-		// performSGMaintenance must not be enabled at the same time.
+		// reducing storage requirements for the repository. Note: "garbage collect" and
+		// "sg maintenance" must not be enabled at the same time.
 		cleanups = append(cleanups, cleanupFn{"sg maintenance", performSGMaintenance})
 	}
 

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -778,7 +778,7 @@ func sgMaintenance(dir GitDir) error {
 	cmd := exec.Command("sh")
 	dir.Set(cmd)
 
-	var buf = new(bytes.Buffer)
+	buf := new(bytes.Buffer)
 	buf.WriteString(sgMaintenanceScript)
 	cmd.Stdin = buf
 

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -772,8 +772,8 @@ func gitGC(dir GitDir) error {
 // which means that git decides which of the tasks are run based on certain
 // thresholds.
 //
-// See https://sourcegraph.com/github.com/git/git/-/blob/Documentation/config/gc.txt and
-// https://sourcegraph.com/github.com/git/git/-/blob/Documentation/config/maintenance.txt
+// See https://sourcegraph.com/github.com/git/git@v2.34.0/-/blob/Documentation/config/gc.txt and
+// https://sourcegraph.com/github.com/git/git@v2.34.0/-/blob/Documentation/config/maintenance.txt
 // for more information about the thresholds.
 func gitMaintenance(dir GitDir) error {
 	cmd := exec.Command(

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -778,9 +778,7 @@ func sgMaintenance(dir GitDir) error {
 	cmd := exec.Command("sh")
 	dir.Set(cmd)
 
-	buf := new(bytes.Buffer)
-	buf.WriteString(sgMaintenanceScript)
-	cmd.Stdin = buf
+	cmd.Stdin = strings.NewReader(sgMaintenanceScript)
 
 	b, err := cmd.CombinedOutput()
 	if err != nil {

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -783,26 +783,33 @@ func gitMaintenance(dir GitDir) error {
 		"gc.auto=1",
 		"-c",
 		"gc.autoDetach=false",
+		// commit-graph runs when the number of reachable commits that are not in the
+		// commit-graph file is at least maintenance.commit-graph.auto.
+		"-c",
+		"maintenance.commit-graph.auto=100",
+		// loose-objects runs when the number of loose objects is at least
+		// maintenance.loose-objects.auto.
+		"-c",
+		"maintenance.loose-objects.auto=100",
+		// incremental-repack runs when the number of pack-files not in the
+		// multi-pack-index is at least maintenance.incremental-repack.
+		"-c",
+		"maintenance.incremental-repack.auto=10",
 		"maintenance",
 		"run",
-		// commit-graph runs when the number of reachable commits that are not in the
-		// commit-graph file is at least 100.
 		"--task",
 		"commit-graph",
 		"--task",
 		"prefetch",
-		// loose-objects runs when the number of loose objects is at least 100.
 		"--task",
 		"loose-objects",
-		// incremental-repack runs when the number of pack-files not in the
-		// multi-pack-index is at least 10.
 		"--task",
 		"incremental-repack",
 		"--task",
 		"gc",
 		// Initially it seemed appealing to use --schedule instead of --auto. However,
 		// --schedule=<schedule-frequency> merely runs tasks with task-frequency >=
-		// schedule-frequency and is not based on the last time the task ran. Which means
+		// schedule-frequency and is not based on the last time the task ran. This means
 		// we would still need a separate janitor job running at a different frequency.
 		//
 		// We control the aggressiveness of --auto with config parameters.

--- a/cmd/gitserver/server/sg_maintenance.sh
+++ b/cmd/gitserver/server/sg_maintenance.sh
@@ -1,18 +1,63 @@
 #!/usr/bin/env sh
 # This script runs several git commands with the goal to optimize the
-# performance of git for large repositories.  With the exception of "repack" and
-# "commit-graph write", the commands and their order follow the default
-# behavior of "git gc".
+# performance of git for large repositories.
+#
+# Relation to git gc and git maintenance:
+#
+# git-gc
+# ------
+# The order of commands in this script is based on the order in which git gc
+# calls the same commands. The following is a list of commands based on running
+# "GIT_TRACE2=1 git gc".
+#
+# git pack-refs --all --prune
+# git reflog expire --all
+# git repack -d -l -A --unpack-unreachable=2.weeks.ago
+# git prune --expire 2.weeks.ago
+# git worktree prune --expire 3.months.ago
+# git rerere gc
+# commit-graph (not traced)
+#
+# We deviate from git gc like follows:
+# - For "git repack" and "git commit-graph write" we choose a different set of
+# flags.
+# - We ommit the commands "git rerere" and "git worktree prune" because they
+# don't apply to our use-case.
+#
+# git-maintenance
+# ---------------
+# As of git 2.34.1, it is not possible to sufficiently fine-tune the tasks git
+# maintenance runs. The tasks are configurable with git config, but not all
+# flags are exposed as config parameters. For example, the task
+# "incremental-repack" does not allow setting --geometric=2. If future releases
+# of git allow us to set more parameters for "git maintenance", we should
+# consider switching from this script to "git maintenance".
 
 set -xe
+
+# Usually run by git gc. Pack heads and tags for efficient repository access.
+# --all Pack branch tips as well. Useful for a repository with many branches of
+# historical interest.
 git pack-refs --all --prune
+
+# Usually run by git gc. The "expire" subcommand prunes older reflog entries.
+# Entries older than expire time, or entries older than expire-unreachable time
+# and not reachable from the current tip, are removed from the reflog.
+# --all Process the reflogs of all references
 git reflog expire --all
 
 # With multi-pack-index and geometric packing, repacking should take time
-# proportional to the number of new objects.
+# proportional to the number of new objects. Inspired by
+# https://github.blog/2021-04-29-scaling-monorepo-maintenance/
 git repack --write-midx --write-bitmap-index -d --geometric=2
+
+# Usually run by git gc. Prune all unreachable objects form the object database.
 git prune --expire 2.weeks.ago
 
-# --changed-paths provides significant performance gains for getting the history
-# of a directory or a file with git log -- <path>
+# With the --changed-paths option, compute and write information about the
+# paths changed between a commit and its first parent. This operation can take
+# a while on large repositories. It provides significant performance gains for
+# getting history of a directory or a file with git log -- <path>. If this
+# option is given, future commit-graph writes will automatically assume that
+# this option was intended
 git commit-graph write --reachable --changed-paths

--- a/cmd/gitserver/server/sg_maintenance.sh
+++ b/cmd/gitserver/server/sg_maintenance.sh
@@ -49,6 +49,7 @@ git reflog expire --all
 # With multi-pack-index and geometric packing, repacking should take time
 # proportional to the number of new objects. Inspired by
 # https://github.blog/2021-04-29-scaling-monorepo-maintenance/
+# --write-midx reqiures git>=2.34.1.
 git repack --write-midx --write-bitmap-index -d --geometric=2
 
 # Usually run by git gc. Prune all unreachable objects form the object database.

--- a/cmd/gitserver/server/sg_maintenance.sh
+++ b/cmd/gitserver/server/sg_maintenance.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env /bin/sh
+# This script runs several git commands with the goal to optimize the
+# performance of git for large repositories.  With the exception of "repack" and
+# "commit-graph write", the commands and their order follow the default
+# behavior of "git gc".
+
+set -xe
+git pack-refs --all --prune
+git reflog expire --all
+
+# With multi-pack-index and geometric packing, repacking should take time
+# proportional to the number of new objects.
+git repack --write-midx --write-bitmap-index -d --geometric=2
+git prune --expire 2.weeks.ago
+
+# --changed-paths provides significant performance gains for getting the history
+# of a directory or a file with git log -- <path>
+git commit-graph write --reachable --changed-paths

--- a/cmd/gitserver/server/sg_maintenance.sh
+++ b/cmd/gitserver/server/sg_maintenance.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env /bin/sh
+#!/usr/bin/env sh
 # This script runs several git commands with the goal to optimize the
 # performance of git for large repositories.  With the exception of "repack" and
 # "commit-graph write", the commands and their order follow the default

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -34,8 +34,8 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache --verbose \
-    # We require git>=2.34.1 because we use git-repack with flag --write-midx.
-    'git>=2.34.1' \
+    # We require git 2.34.1 because we use git-repack with flag --write-midx.
+    'git=~2.34.1' \
     git-p4 \
     --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
     # NOTE that the Postgres version we run is different

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -34,8 +34,8 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache --verbose \
-    # We require git>=2.30 because we use git maintenance.
-    'git>=2.30' \
+    # We require git>=2.34.1 because we use git-repack with flag --write-midx.
+    'git>=2.34.1' \
     git-p4 \
     --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
     # NOTE that the Postgres version we run is different


### PR DESCRIPTION
This adds a janitor task "sg maintenance" to gitserver. For now, "sg maintenance" is disabled per default. Once we are confident enough, we can depricate the janitor job "git gc" in favor of "sg maintenance" and remove "SRC_ENABLE_GC_AUTO".

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
