### PR TITLE
Change overflow-y not to show scrollbar by default for Org invite

### DIFF
--- a/client/web/src/components/ModalPage.module.scss
+++ b/client/web/src/components/ModalPage.module.scss
@@ -8,7 +8,6 @@
 
     display: flex;
     flex-direction: column;
-    overflow-y: auto;
     align-content: center;
     justify-content: center;
 }

--- a/client/web/src/components/ModalPage.module.scss
+++ b/client/web/src/components/ModalPage.module.scss
@@ -8,7 +8,7 @@
 
     display: flex;
     flex-direction: column;
-    overflow-y: scroll;
+    overflow-y: auto;
     align-content: center;
     justify-content: center;
 }

--- a/client/web/src/enterprise/extensions/registry/RegistryNewExtensionPage.tsx
+++ b/client/web/src/enterprise/extensions/registry/RegistryNewExtensionPage.tsx
@@ -163,7 +163,7 @@ export const RegistryNewExtensionPage = withAuthenticatedUser(
             return (
                 <>
                     <PageTitle title="New extension" />
-                    <ModalPage className="mt-4 overflow-hidden">
+                    <ModalPage className="mt-4">
                         <h2 className="mb-4">
                             <PuzzleIcon className="icon-inline" /> New extension
                         </h2>


### PR DESCRIPTION
Old behaviour:
<img width="1910" alt="143471175-f72d06ab-4139-45ba-bb12-0305fab45d97" src="https://user-images.githubusercontent.com/1022220/143556959-976512f5-9df1-4a2d-9372-ea96f3199ca4.png">
New behaviour:
<img width="1111" alt="Screenshot 2021-11-26 at 10 16 20" src="https://user-images.githubusercontent.com/1022220/143556886-c3aadcf6-c39f-4784-830c-aa1acc532c5f.png">
### Testing locally
Run sg in cloud mode: sg start dotcom
Create an organization
Invite another user to the organization
Open login link, see page has no vertical bar to the right of invite card


