### PR TITLE
Revert "actor: remove dependency on database types"

### DIFF
--- a/internal/actor/actor.go
+++ b/internal/actor/actor.go
@@ -6,8 +6,12 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"sync"
+
+	"github.com/cockroachdb/errors"
 
 	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 // Actor represents an agent that accesses resources. It can represent an anonymous user, an
@@ -24,6 +28,11 @@ type Actor struct {
 	// to selectively display a logout link. (If the actor wasn't authenticated with a session
 	// cookie, logout would be ineffective.)
 	FromSessionCookie bool `json:"-"`
+
+	// user is populated lazily by (*Actor).User()
+	user     *types.User
+	userErr  error
+	userOnce sync.Once
 
 	// mockUser indicates this user was created in the context of a test.
 	mockUser bool
@@ -55,6 +64,22 @@ func (a *Actor) IsInternal() bool {
 // IsMockUser returns true if the Actor is a test user.
 func (a *Actor) IsMockUser() bool {
 	return a != nil && a.mockUser
+}
+
+type userFetcher interface {
+	GetByID(context.Context, int32) (*types.User, error)
+}
+
+// User returns the expanded types.User for the actor's ID. The ID is expanded to a full
+// types.User using the fetcher, which is likely a *database.UserStore.
+func (a *Actor) User(ctx context.Context, fetcher userFetcher) (*types.User, error) {
+	a.userOnce.Do(func() {
+		a.user, a.userErr = fetcher.GetByID(ctx, a.UID)
+	})
+	if a.user != nil && a.user.ID != a.UID {
+		return nil, errors.Errorf("actor UID (%d) and the ID of the cached User (%d) do not match", a.UID, a.user.ID)
+	}
+	return a.user, a.userErr
 }
 
 type key int


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#28149

Upon another reading, I'm pretty sure this is an incorrect implementation - the populated context returned from `ctxUserFromContext` never gets passed back up, and is thus an incorrect cache. Going to take another approach here, but reverting first