### PR TITLE
git-combine: synthesize a monorepo

### DIFF
--- a/dev/check/no-alpine-guard.sh
+++ b/dev/check/no-alpine-guard.sh
@@ -12,11 +12,12 @@ path_filter() {
 }
 
 set +e
-ALPINE_MATCHES=$(git grep -e '\salpine\:' --and --not -e '^\s*//' --and --not -e 'CI\:LOCALHOST_OK' \
+ALPINE_MATCHES=$(git grep -e '\salpine\:' --and --not -e '^\s*//' --and --not -e 'CI\:ALPINE_OK' \
   ':(exclude)doc/admin/updates/docker_compose.md' \
   ':(exclude)docker-images/README.md' \
   ':(exclude)docker-images/alpine-3.14/' \
   ':(exclude)doc/batch_changes/' \
+  ':(exclude)internal/cmd/git-combine/Dockerfile' \
   ':(exclude)web/src/enterprise/batches/create/CreateBatchChangePage.tsx' \
   ':(exclude)*_test.go' \
   ':(exclude)*vendor*' \

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gitchander/permutation v0.0.0-20210517125447-a5d73722e1b1
 	github.com/go-enry/go-enry/v2 v2.7.2
+	github.com/go-git/go-git/v5 v5.4.2
 	github.com/go-openapi/strfmt v0.21.0
 	github.com/go-redsync/redsync v1.4.2
 	github.com/gobwas/glob v0.2.3
@@ -204,7 +205,6 @@ require (
 	github.com/go-enry/go-oniguruma v1.2.1 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.3.1 // indirect
-	github.com/go-git/go-git/v5 v5.4.2 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-openapi/analysis v0.21.1 // indirect
 	github.com/go-openapi/errors v0.20.1 // indirect

--- a/internal/cmd/git-combine/Dockerfile
+++ b/internal/cmd/git-combine/Dockerfile
@@ -14,9 +14,9 @@ RUN go build .
 
 # Does not need to use sourcegraph-alpine since this is only deployed for
 # Sourcegraph.com.
-FROM alpine:3.15
+FROM alpine:3.15 # CI:ALPINE_OK
 
-RUN apk add --no-cache git ca-certificates
+RUN apk add --no-cache git ca-certificates tini
 
 COPY --from=builder /go/src/app/git-combine /usr/bin/
 
@@ -29,4 +29,4 @@ LABEL org.opencontainers.image.url=https://sourcegraph.com/
 LABEL org.opencontainers.image.source=https://github.com/sourcegraph/sourcegraph/tree/main/internal/cmd/git-combine
 LABEL org.opencontainers.image.documentation=https://github.com/sourcegraph/sourcegraph/blob/main/internal/cmd/git-combine/README.md
 
-CMD ["git-combine"]
+ENTRYPOINT ["/sbin/tini", "--", "git-combine"]

--- a/internal/cmd/git-combine/Dockerfile
+++ b/internal/cmd/git-combine/Dockerfile
@@ -6,8 +6,8 @@ ENV CGO_ENABLE=0
 
 # We only have one dependency. When building we just use the latest version of
 # it rather than maintaining our own go.mod just in this directory.
-RUN go mod init github.com/sourcegraph/sourcegraph/internal/cmd/git-combine
-RUN go get github.com/go-git/go-git/v5
+RUN go mod init github.com/sourcegraph/sourcegraph/internal/cmd/git-combine \
+    && go get github.com/go-git/go-git/v5
 
 COPY git-combine.go .
 RUN go build .
@@ -16,6 +16,7 @@ RUN go build .
 # Sourcegraph.com.
 FROM alpine:3.15
 
+# hadolint ignore=DL3018
 RUN apk add --no-cache git ca-certificates tini
 
 COPY --from=builder /go/src/app/git-combine /usr/bin/

--- a/internal/cmd/git-combine/Dockerfile
+++ b/internal/cmd/git-combine/Dockerfile
@@ -1,0 +1,32 @@
+FROM golang:1.17.3-alpine AS builder
+
+WORKDIR /go/src/app
+
+ENV CGO_ENABLE=0
+
+# We only have one dependency. When building we just use the latest version of
+# it rather than maintaining our own go.mod just in this directory.
+RUN go mod init github.com/sourcegraph/sourcegraph/internal/cmd/git-combine
+RUN go get github.com/go-git/go-git/v5
+
+COPY git-combine.go .
+RUN go build .
+
+# Does not need to use sourcegraph-alpine since this is only deployed for
+# Sourcegraph.com.
+FROM alpine:3.15
+
+RUN apk add --no-cache git ca-certificates
+
+COPY --from=builder /go/src/app/git-combine /usr/bin/
+
+ARG COMMIT_SHA="unknown"
+ARG VERSION="unknown"
+
+LABEL org.opencontainers.image.revision=${COMMIT_SHA}
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL org.opencontainers.image.url=https://sourcegraph.com/
+LABEL org.opencontainers.image.source=https://github.com/sourcegraph/sourcegraph/tree/main/internal/cmd/git-combine
+LABEL org.opencontainers.image.documentation=https://github.com/sourcegraph/sourcegraph/blob/main/internal/cmd/git-combine/README.md
+
+CMD ["git-combine"]

--- a/internal/cmd/git-combine/Dockerfile
+++ b/internal/cmd/git-combine/Dockerfile
@@ -14,7 +14,7 @@ RUN go build .
 
 # Does not need to use sourcegraph-alpine since this is only deployed for
 # Sourcegraph.com.
-FROM alpine:3.15 # CI:ALPINE_OK
+FROM alpine:3.15
 
 RUN apk add --no-cache git ca-certificates tini
 

--- a/internal/cmd/git-combine/README.md
+++ b/internal/cmd/git-combine/README.md
@@ -1,0 +1,40 @@
+### git-combine
+
+This command is used to synthesize a large monorepo from multiple
+repositories. It does this by translating commits from every upstream into a
+new commit containing the upstream contents as a sub directory.
+
+See https://github.com/sgtest/megarepo
+
+This is running in our production kubernetes cluster. https://github.com/sourcegraph/deploy-sourcegraph-dot-com/tree/release/configure/git-combine
+
+#### Building
+
+This is very rarely deployed, so it can be done manually with the build.sh script:
+
+``` shell
+./build.sh 0.0.2
+```
+
+#### Configuration
+
+This is the configuration of the repository running in production:
+
+``` shell
+git remote add --no-tags -t main grafana https://github.com/grafana/grafana.git
+git remote add --no-tags -t main rails https://github.com/rails/rails.git
+git remote add --no-tags -t main sourcegraph https://github.com/sourcegraph/sourcegraph.git
+git remote add --no-tags -t master chromium https://github.com/chromium/chromium.git
+git remote add --no-tags -t master elastic https://github.com/elastic/elasticsearch.git
+git remote add --no-tags -t master git https://github.com/git/git.git
+git remote add --no-tags -t master gitlab https://gitlab.com/gitlab-org/gitlab.git
+git remote add --no-tags -t master go https://github.com/golang/go.git
+git remote add --no-tags -t master homebrew https://github.com/Homebrew/homebrew-core.git
+git remote add --no-tags -t master kubernetes https://github.com/kubernetes/kubernetes.git
+git remote add --no-tags -t master linux https://github.com/torvalds/linux.git
+git remote add --no-tags -t master mongo https://github.com/mongodb/mongo.git
+git remote add --no-tags -t master nixpkgs https://github.com/NixOS/nixpkgs.git
+git remote add --no-tags -t master rust https://github.com/rust-lang/rust.git
+
+git remote add origin https://sourcegraph-bot:$ACCESS_TOKEN@github.com/sgtest/megarepo.git
+```

--- a/internal/cmd/git-combine/README.md
+++ b/internal/cmd/git-combine/README.md
@@ -12,7 +12,7 @@ This is running in our production kubernetes cluster. https://github.com/sourceg
 
 This is very rarely deployed, so it can be done manually with the build.sh script:
 
-``` shell
+```shell
 ./build.sh 0.0.2
 ```
 
@@ -20,12 +20,16 @@ This is very rarely deployed, so it can be done manually with the build.sh scrip
 
 This is the configuration of the repository running in production:
 
-``` shell
+```shell
+git remote add --no-tags -t main freeCodeCamp https://github.com/freeCodeCamp/freeCodeCamp.git
 git remote add --no-tags -t main grafana https://github.com/grafana/grafana.git
 git remote add --no-tags -t main rails https://github.com/rails/rails.git
 git remote add --no-tags -t main sourcegraph https://github.com/sourcegraph/sourcegraph.git
+git remote add --no-tags -t main vscode https://github.com/microsoft/vscode.git
+git remote add --no-tags -t master azure-docs https://github.com/MicrosoftDocs/azure-docs.git
 git remote add --no-tags -t master chromium https://github.com/chromium/chromium.git
 git remote add --no-tags -t master elastic https://github.com/elastic/elasticsearch.git
+git remote add --no-tags -t master flutter https://github.com/flutter/flutter.git
 git remote add --no-tags -t master git https://github.com/git/git.git
 git remote add --no-tags -t master gitlab https://gitlab.com/gitlab-org/gitlab.git
 git remote add --no-tags -t master go https://github.com/golang/go.git
@@ -35,6 +39,7 @@ git remote add --no-tags -t master linux https://github.com/torvalds/linux.git
 git remote add --no-tags -t master mongo https://github.com/mongodb/mongo.git
 git remote add --no-tags -t master nixpkgs https://github.com/NixOS/nixpkgs.git
 git remote add --no-tags -t master rust https://github.com/rust-lang/rust.git
+git remote add --no-tags -t master tensorflow https://github.com/tensorflow/tensorflow.git
 
 git remote add origin https://sourcegraph-bot:$ACCESS_TOKEN@github.com/sgtest/megarepo.git
 ```

--- a/internal/cmd/git-combine/README.md
+++ b/internal/cmd/git-combine/README.md
@@ -21,6 +21,10 @@ This is very rarely deployed, so it can be done manually with the build.sh scrip
 This is the configuration of the repository running in production:
 
 ```shell
+git init --bare megarepo.git
+cd megarepo.git
+git checkout -b main
+
 git remote add --no-tags -t main freeCodeCamp https://github.com/freeCodeCamp/freeCodeCamp.git
 git remote add --no-tags -t main grafana https://github.com/grafana/grafana.git
 git remote add --no-tags -t main rails https://github.com/rails/rails.git
@@ -41,6 +45,9 @@ git remote add --no-tags -t master rust https://github.com/rust-lang/rust.git
 git remote add --no-tags -t master tensorflow https://github.com/tensorflow/tensorflow.git
 
 git remote add origin https://sourcegraph-bot:$ACCESS_TOKEN@github.com/sgtest/megarepo.git
+
+git-combine
+git push -u origin main
 ```
 
 Add a file called `PAUSE` in the git-combine working directory and the daemon mode will stop running. This is useful when adding more remotes.

--- a/internal/cmd/git-combine/README.md
+++ b/internal/cmd/git-combine/README.md
@@ -43,3 +43,12 @@ git remote add --no-tags -t master tensorflow https://github.com/tensorflow/tens
 
 git remote add origin https://sourcegraph-bot:$ACCESS_TOKEN@github.com/sgtest/megarepo.git
 ```
+
+Add a file called `PAUSE` in the git-combine working directory and the daemon mode will stop running. This is useful when adding more remotes.
+
+This script will print the size of the working copy in Gb:
+
+```shell
+git ls-tree -r --long HEAD | awk '$4 != "-" { total += $4 } END { print
+total / 1024 / 1024 / 1024.0 }'
+```

--- a/internal/cmd/git-combine/README.md
+++ b/internal/cmd/git-combine/README.md
@@ -26,7 +26,6 @@ git remote add --no-tags -t main grafana https://github.com/grafana/grafana.git
 git remote add --no-tags -t main rails https://github.com/rails/rails.git
 git remote add --no-tags -t main sourcegraph https://github.com/sourcegraph/sourcegraph.git
 git remote add --no-tags -t main vscode https://github.com/microsoft/vscode.git
-git remote add --no-tags -t master azure-docs https://github.com/MicrosoftDocs/azure-docs.git
 git remote add --no-tags -t master chromium https://github.com/chromium/chromium.git
 git remote add --no-tags -t master elastic https://github.com/elastic/elasticsearch.git
 git remote add --no-tags -t master flutter https://github.com/flutter/flutter.git

--- a/internal/cmd/git-combine/build.sh
+++ b/internal/cmd/git-combine/build.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+version="$1"
+commit="$(git rev-parse HEAD)"
+image="us.gcr.io/sourcegraph-dev/git-combine:$version"
+
+if [[ !($version =~ ^[0-9]+\.[0-9]+\.[0-9]+$) ]]; then
+  echo -e "USAGE: build.sh VERSION\n\nVERSION is a string like 0.0.1"
+  exit 1
+fi
+
+set -x
+
+docker build \
+       --build-arg VERSION="$version" \
+       --build-arg COMMIT_SHA="$commit" \
+       --tag "$image" \
+       .
+
+docker push "$image"

--- a/internal/cmd/git-combine/build.sh
+++ b/internal/cmd/git-combine/build.sh
@@ -7,7 +7,7 @@ version="$1"
 commit="$(git rev-parse HEAD)"
 image="us.gcr.io/sourcegraph-dev/git-combine:$version"
 
-if [[ !($version =~ ^[0-9]+\.[0-9]+\.[0-9]+$) ]]; then
+if [[ ! ($version =~ ^[0-9]+\.[0-9]+\.[0-9]+$) ]]; then
   echo -e "USAGE: build.sh VERSION\n\nVERSION is a string like 0.0.1"
   exit 1
 fi
@@ -15,9 +15,9 @@ fi
 set -x
 
 docker build \
-       --build-arg VERSION="$version" \
-       --build-arg COMMIT_SHA="$commit" \
-       --tag "$image" \
-       .
+  --build-arg VERSION="$version" \
+  --build-arg COMMIT_SHA="$commit" \
+  --tag "$image" \
+  .
 
 docker push "$image"

--- a/internal/cmd/git-combine/git-combine.go
+++ b/internal/cmd/git-combine/git-combine.go
@@ -1,0 +1,426 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"log"
+	"math"
+	"os"
+	"os/exec"
+	"os/signal"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/filemode"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/plumbing/storer"
+)
+
+// Options are configurables for Combine.
+type Options struct {
+	// Limit is the maximum number of commits we import from each remote.
+	Limit int
+
+	Logger *log.Logger
+}
+
+func (o *Options) SetDefaults() {
+	if o.Limit == 0 {
+		o.Limit = math.MaxInt
+	}
+
+	if o.Logger == nil {
+		o.Logger = log.Default()
+	}
+}
+
+// Combine opens the git repository at path and transforms commits from all
+// non-origin remotes into commits onto HEAD.
+func Combine(path string, opt Options) error {
+	opt.SetDefaults()
+
+	log := opt.Logger
+
+	r, err := git.PlainOpen(path)
+	if err != nil {
+		return err
+	}
+
+	parentHash, initialRootTree, err := getHeadTree(r)
+	if err != nil {
+		return err
+	}
+
+	readmeHash, err := readmeObject(r.Storer)
+	if err != nil {
+		return err
+	}
+
+	conf, err := r.Config()
+	if err != nil {
+		return err
+	}
+
+	type dirCommit struct {
+		Dir    string
+		Commit *object.Commit
+		Seq    int
+	}
+
+	rootTree := map[string]plumbing.Hash{}
+	var commits []*dirCommit
+	for remote := range conf.Remotes {
+		if remote == "origin" {
+			continue
+		}
+
+		// we don't know what the remote HEAD is, so we hardcode the usual
+		// options and test if they exist.
+		var ref *plumbing.Reference
+		for _, name := range []string{"main", "master", "trunk", "development"} {
+			cand, err := storer.ResolveReference(r.Storer, plumbing.NewRemoteReferenceName(remote, name))
+			if err == nil {
+				ref = cand
+			}
+		}
+		if ref == nil {
+			log.Printf("ignoring remote %q since can't find HEAD branch", remote)
+			continue
+		}
+
+		iter, err := r.Log(&git.LogOptions{
+			From: ref.Hash(),
+		})
+		if err != nil {
+			return err
+		}
+
+		until, ok := initialRootTree[remote]
+		if ok {
+			rootTree[remote] = until
+		}
+
+		for i := 0; i < opt.Limit; i++ {
+			commit, err := iter.Next()
+			if err == io.EOF {
+				break
+			} else if err != nil {
+				return err
+			}
+
+			if commit.TreeHash == until {
+				break
+			}
+
+			commits = append(commits, &dirCommit{
+				Dir:    remote,
+				Seq:    i,
+				Commit: commit,
+			})
+		}
+	}
+
+	sort.Slice(commits, func(i, j int) bool {
+		a, b := commits[i], commits[j]
+		// Note: This less is not transitive since committer timestamps are
+		// not guaranteed to be monotonically increasing in git. We aren't
+		// necessarily looking to get 100% correctness when picking the order
+		// of commits, just a reasonable order.
+		if a.Dir == b.Dir {
+			return a.Seq > b.Seq
+		}
+		return a.Commit.Committer.When.Before(b.Commit.Committer.When)
+	})
+
+	for i, commit := range commits {
+		// This is the important line, "/dir" will now be the code (tree) for
+		// this commit. We don't touch the other entries, so the other
+		// directories will have the same code as the previous commit we
+		// created.
+		rootTree[commit.Dir] = commit.Commit.TreeHash
+
+		var entries []object.TreeEntry
+		for dir, hash := range rootTree {
+			entries = append(entries, object.TreeEntry{
+				Name: dir,
+				Mode: filemode.Dir,
+				Hash: hash,
+			})
+		}
+		entries = append(entries, object.TreeEntry{
+			Name: "README.md",
+			Mode: filemode.Regular,
+			Hash: readmeHash,
+		})
+		sort.Slice(entries, func(i, j int) bool {
+			return entries[i].Name < entries[j].Name
+		})
+
+		treeHash, err := storeObject(r.Storer, &object.Tree{
+			Entries: entries,
+		})
+		if err != nil {
+			return err
+		}
+
+		// TODO break links so we don't appear in upstream analytics. IE
+		// remove links from message, scrub author and committer, etc.
+		newCommit := &object.Commit{
+			Author: sanitizeSignature(commit.Commit.Author),
+			Committer: object.Signature{
+				Name:  "sourcegraph-bot",
+				Email: "no-reply@sourcegraph.com",
+				When:  commit.Commit.Committer.When,
+			},
+			Message:  sanitizeMessage(commit.Dir, commit.Commit),
+			TreeHash: treeHash,
+		}
+
+		// We just create a linear history. parentHash is zero if this is the
+		// first commit to HEAD.
+		if !parentHash.IsZero() {
+			newCommit.ParentHashes = []plumbing.Hash{parentHash}
+		}
+
+		parentHash, err = storeObject(r.Storer, newCommit)
+		if err != nil {
+			return err
+		}
+
+		if err := setHEAD(r.Storer, parentHash); err != nil {
+			return err
+		}
+
+		log.Printf("%d/%d created %s from %s %s", i+1, len(commits), parentHash, commit.Commit.Hash, commitTitle(newCommit))
+	}
+
+	return nil
+}
+
+func getHeadTree(r *git.Repository) (plumbing.Hash, map[string]plumbing.Hash, error) {
+	head, err := r.Head()
+	if err != nil {
+		return plumbing.ZeroHash, map[string]plumbing.Hash{}, nil
+	}
+
+	commit, err := r.CommitObject(head.Hash())
+	if err != nil {
+		return plumbing.ZeroHash, nil, err
+	}
+
+	tree, err := commit.Tree()
+	if err != nil {
+		return plumbing.ZeroHash, nil, err
+	}
+
+	dirs := map[string]plumbing.Hash{}
+	for _, entry := range tree.Entries {
+		if entry.Mode == filemode.Dir {
+			dirs[entry.Name] = entry.Hash
+		}
+	}
+	return commit.Hash, dirs, nil
+}
+
+func readmeObject(storer storer.EncodedObjectStorer) (plumbing.Hash, error) {
+	readme := []byte(`# megarepo
+
+This is a synthetic monorepo created by continuously applying commits from upstream projects into respective sub directories.
+
+See https://github.com/sourcegraph/sourcegraph/tree/main/internal/cmd/git-combine
+`)
+	obj := storer.NewEncodedObject()
+	obj.SetType(plumbing.BlobObject)
+	obj.SetSize(int64(len(readme)))
+
+	w, err := obj.Writer()
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+
+	if _, err := w.Write(readme); err != nil {
+		_ = w.Close()
+		return plumbing.ZeroHash, err
+	}
+
+	if err := w.Close(); err != nil {
+		return plumbing.ZeroHash, err
+	}
+
+	return storer.SetEncodedObject(obj)
+}
+
+func storeObject(storer storer.EncodedObjectStorer, obj interface {
+	Encode(plumbing.EncodedObject) error
+}) (plumbing.Hash, error) {
+	o := storer.NewEncodedObject()
+	if err := obj.Encode(o); err != nil {
+		return plumbing.ZeroHash, err
+	}
+
+	hash := o.Hash()
+	if storer.HasEncodedObject(hash) == nil {
+		return hash, nil
+	}
+
+	if _, err := storer.SetEncodedObject(o); err != nil {
+		return plumbing.ZeroHash, err
+	}
+
+	return hash, nil
+}
+
+func setHEAD(storer storer.ReferenceStorer, hash plumbing.Hash) error {
+	head, err := storer.Reference(plumbing.HEAD)
+	if err != nil {
+		return err
+	}
+
+	name := plumbing.HEAD
+	if head.Type() != plumbing.HashReference {
+		name = head.Target()
+	}
+
+	return storer.SetReference(plumbing.NewHashReference(name, hash))
+}
+
+func sanitizeSignature(sig object.Signature) object.Signature {
+	// We sanitize the email since that is how github connects up commits to
+	// authors. We intentionally break this connection since these are
+	// synthetic commits.
+	prefix := "no-reply"
+	if idx := strings.Index(sig.Email, "@"); idx > 0 {
+		prefix = sig.Email[:idx]
+	}
+	email := fmt.Sprintf("%s@%X.example.com", prefix, crc32.ChecksumIEEE([]byte(sig.Email)))
+
+	return object.Signature{
+		Name:  sig.Name,
+		Email: email,
+		When:  sig.When,
+	}
+}
+
+func sanitizeMessage(dir string, commit *object.Commit) string {
+	// There are lots of things that could link to other artificats in the
+	// commit message. So we play it safe and just remove the message.
+	return fmt.Sprintf("%s: %s\n\nCommit: %s\n", dir, commitTitle(commit), commit.Hash)
+}
+
+func commitTitle(commit *object.Commit) string {
+	title := commit.Message
+	if idx := strings.IndexByte(title, '\n'); idx > 0 {
+		title = title[:idx]
+	}
+	return strings.TrimSpace(title)
+}
+
+func getGitDir() (string, error) {
+	dir := os.Getenv("GIT_DIR")
+	if dir == "" {
+		return os.Getwd()
+	}
+	return dir, nil
+}
+
+func runGit(dir string, args ...string) error {
+	// they should be _much_ faster than this, but we set this incase git gets blocked.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	start := time.Now()
+	log.Printf("starting git %s", strings.Join(args, " "))
+	err := cmd.Run()
+	log.Printf("finished git in %s", time.Since(start))
+	return err
+}
+
+func doDaemon(dir string, ticker <-chan time.Time, done <-chan struct{}, opt Options) error {
+	isDone := func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}
+
+	for {
+		if err := runGit(dir, "fetch", "--all", "--no-tags"); err != nil {
+			return err
+		}
+
+		if isDone() {
+			return nil
+		}
+
+		if err := Combine(dir, opt); err != nil {
+			return err
+		}
+
+		if isDone() {
+			return nil
+		}
+
+		if err := runGit(dir, "push", "origin"); err != nil {
+			return err
+		}
+
+		select {
+		case <-ticker:
+		case <-done:
+			return nil
+		}
+	}
+}
+
+func main() {
+	daemon := flag.Bool("daemon", false, "run in daemon mode. This mode loops on fetch, combine, push.")
+	limit := flag.Int("limit", 0, "limits the number of commits imported from each remote. If 0 there is no limit.")
+
+	flag.Parse()
+
+	opt := Options{
+		Limit: *limit,
+	}
+
+	gitDir, err := getGitDir()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if *daemon {
+		ticker := time.NewTicker(time.Minute)
+		done := make(chan struct{}, 1)
+
+		go func() {
+			c := make(chan os.Signal, 1)
+			signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+			<-c
+			done <- struct{}{}
+		}()
+
+		err := doDaemon(gitDir, ticker.C, done, opt)
+		if err != nil {
+			log.Fatal(err)
+		}
+		return
+	}
+
+	err = Combine(gitDir, opt)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/internal/cmd/git-combine/git-combine.go
+++ b/internal/cmd/git-combine/git-combine.go
@@ -89,6 +89,7 @@ func Combine(path string, opt Options) error {
 			cand, err := storer.ResolveReference(r.Storer, plumbing.NewRemoteReferenceName(remote, name))
 			if err == nil {
 				ref = cand
+				break
 			}
 		}
 		if ref == nil {

--- a/internal/cmd/git-combine/git-combine.go
+++ b/internal/cmd/git-combine/git-combine.go
@@ -26,7 +26,9 @@ import (
 
 // Options are configurables for Combine.
 type Options struct {
-	// Limit is the maximum number of commits we import from each remote.
+	// Limit is the maximum number of commits we import from each remote. The
+	// memory usage of Combine is based on the number of unseen commits per
+	// remote. Limit is useful to specify when importing a large new upstream.
 	Limit int
 
 	Logger *log.Logger
@@ -392,7 +394,7 @@ func doDaemon(dir string, ticker <-chan time.Time, done <-chan struct{}, opt Opt
 
 func main() {
 	daemon := flag.Bool("daemon", false, "run in daemon mode. This mode loops on fetch, combine, push.")
-	limit := flag.Int("limit", 0, "limits the number of commits imported from each remote. If 0 there is no limit.")
+	limit := flag.Int("limit", 0, "limits the number of commits imported from each remote. If 0 there is no limit. Used to reduce memory usage when importing new large remotes.")
 
 	flag.Parse()
 

--- a/internal/cmd/git-combine/git-combine.go
+++ b/internal/cmd/git-combine/git-combine.go
@@ -72,7 +72,6 @@ func Combine(path string, opt Options) error {
 	type dirCommit struct {
 		dir    string
 		commit *object.Commit
-		seq    int
 	}
 
 	rootTree := map[string]plumbing.Hash{}
@@ -123,22 +122,13 @@ func Combine(path string, opt Options) error {
 
 			commits = append(commits, &dirCommit{
 				dir:    remote,
-				seq:    i,
 				commit: commit,
 			})
 		}
 	}
 
 	sort.Slice(commits, func(i, j int) bool {
-		a, b := commits[i], commits[j]
-		// Note: This less is not transitive since committer timestamps are
-		// not guaranteed to be monotonically increasing in git. We aren't
-		// necessarily looking to get 100% correctness when picking the order
-		// of commits, just a reasonable order.
-		if a.dir == b.dir {
-			return a.seq > b.seq
-		}
-		return a.commit.Committer.When.Before(b.commit.Committer.When)
+		return commits[i].commit.Committer.When.Before(commits[j].commit.Committer.When)
 	})
 
 	for i, commit := range commits {

--- a/internal/cmd/git-combine/git-combine_test.go
+++ b/internal/cmd/git-combine/git-combine_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestCombine(t *testing.T) {
+	tmp := t.TempDir()
+
+	dir := filepath.Join(tmp, "combined-repo.git")
+
+	setupPath := filepath.Join(tmp, "setup.sh")
+	if err := os.WriteFile(setupPath, []byte(`#!/usr/bin/env bash
+
+set -ex
+
+repo=$(git rev-parse --show-toplevel)
+
+mkdir -p "$DIR"
+cd "$DIR"
+git init --bare .
+
+git remote add --no-tags sourcegraph "$repo"
+git config --replace-all remote.origin.fetch '+HEAD:refs/remotes/sourcegraph/master'
+
+git fetch --depth 100 sourcegraph
+`), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("sh", setupPath)
+	cmd.Env = append(os.Environ(), "DIR="+dir)
+	if testing.Verbose() {
+		cmd.Stderr = os.Stderr
+	}
+	if err := cmd.Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	opt := Options{
+		Limit:  100,
+		Logger: log.New(io.Discard, "", 0),
+	}
+	if testing.Verbose() {
+		opt.Logger = log.Default()
+	}
+
+	if err := Combine(dir, opt); err != nil {
+		t.Fatal(err)
+	}
+
+	// We only test that we have commits now. If we don't, git show will fail.
+	cmd = exec.Command("git", "show")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This introduces a new command "git-combine" which will combine all
upstream HEAD branches into a single repository. For each commit
upstream it will create a new commit with the file contents as a
sub directory (the remote name).

Additionally this comes with a naive "daemon" mode which just runs git
fetch --all, git-combine, git push on a timer. This is running in
production right now and the result can be seen at
https://github.com/sgtest/megarepo

Fixes https://github.com/sourcegraph/sourcegraph/issues/27492