### PR TITLE
types: remove dependency on extsvc clients

### DIFF
--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 )
 
 func TestServer_handleRepoLookup(t *testing.T) {
@@ -357,7 +358,7 @@ func TestServer_RepoLookup(t *testing.T) {
 		stored      types.Repos
 		result      *protocol.RepoLookupResult
 		src         repos.Source
-		assert      types.ReposAssertion
+		assert      typestest.ReposAssertion
 		assertDelay time.Duration
 		err         string
 	}{
@@ -450,7 +451,7 @@ func TestServer_RepoLookup(t *testing.T) {
 					Commit: "github.com/foo/bar/commit/{commit}",
 				},
 			}},
-			assert: types.Assert.ReposEqual(githubRepository),
+			assert: typestest.Assert.ReposEqual(githubRepository),
 		},
 		{
 			name: "found - GitHub.com on Sourcegraph.com already exists",
@@ -485,7 +486,7 @@ func TestServer_RepoLookup(t *testing.T) {
 			src:    repos.NewFakeSource(&githubSource, github.ErrRepoNotFound),
 			result: &protocol.RepoLookupResult{ErrorNotFound: true},
 			err:    fmt.Sprintf("repository not found (name=%s notfound=%v)", api.RepoName("github.com/foo/bar"), true),
-			assert: types.Assert.ReposEqual(),
+			assert: typestest.Assert.ReposEqual(),
 		},
 		{
 			name: "unauthorized - GitHub.com on Sourcegraph.com",
@@ -495,7 +496,7 @@ func TestServer_RepoLookup(t *testing.T) {
 			src:    repos.NewFakeSource(&githubSource, &github.APIError{Code: http.StatusUnauthorized}),
 			result: &protocol.RepoLookupResult{ErrorUnauthorized: true},
 			err:    fmt.Sprintf("not authorized (name=%s noauthz=%v)", api.RepoName("github.com/foo/bar"), true),
-			assert: types.Assert.ReposEqual(),
+			assert: typestest.Assert.ReposEqual(),
 		},
 		{
 			name: "temporarily unavailable - GitHub.com on Sourcegraph.com",
@@ -509,7 +510,7 @@ func TestServer_RepoLookup(t *testing.T) {
 				api.RepoName("github.com/foo/bar"),
 				true,
 			),
-			assert: types.Assert.ReposEqual(),
+			assert: typestest.Assert.ReposEqual(),
 		},
 		{
 			name:   "found - gitlab.com on Sourcegraph.com",
@@ -533,7 +534,7 @@ func TestServer_RepoLookup(t *testing.T) {
 				},
 				ExternalRepo: gitlabRepository.ExternalRepo,
 			}},
-			assert: types.Assert.ReposEqual(gitlabRepository),
+			assert: typestest.Assert.ReposEqual(gitlabRepository),
 		},
 		{
 			name:   "found - gitlab.com on Sourcegraph.com already exists",
@@ -596,7 +597,7 @@ func TestServer_RepoLookup(t *testing.T) {
 				},
 			}},
 			assertDelay: time.Second,
-			assert:      types.Assert.ReposEqual(),
+			assert:      typestest.Assert.ReposEqual(),
 		},
 	}
 

--- a/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -920,7 +921,7 @@ func createGitLabRepo(t *testing.T, ctx context.Context, rstore database.RepoSto
 			ServiceType: extsvc.TypeGitLab,
 			ServiceID:   "https://gitlab.com/",
 		},
-	}).With(types.Opt.RepoSources(es.URN()))
+	}).With(typestest.Opt.RepoSources(es.URN()))
 	if err := rstore.Create(ctx, repo); err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/batches/store/batch_spec_workspaces_test.go
+++ b/enterprise/internal/batches/store/batch_spec_workspaces_test.go
@@ -11,7 +11,7 @@ import (
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
-	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
 )
 
@@ -20,7 +20,7 @@ func testStoreBatchSpecWorkspaces(t *testing.T, ctx context.Context, s *Store, c
 	esStore := database.ExternalServicesWith(s)
 
 	repo := ct.TestRepo(t, esStore, extsvc.KindGitHub)
-	deletedRepo := ct.TestRepo(t, esStore, extsvc.KindGitHub).With(types.Opt.RepoDeletedAt(clock.Now()))
+	deletedRepo := ct.TestRepo(t, esStore, extsvc.KindGitHub).With(typestest.Opt.RepoDeletedAt(clock.Now()))
 
 	if err := repoStore.Create(ctx, repo, deletedRepo); err != nil {
 		t.Fatal(err)

--- a/enterprise/internal/batches/store/bulk_operations_test.go
+++ b/enterprise/internal/batches/store/bulk_operations_test.go
@@ -11,7 +11,7 @@ import (
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
-	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 )
 
 func testStoreBulkOperations(t *testing.T, ctx context.Context, s *Store, clock ct.Clock) {
@@ -19,7 +19,7 @@ func testStoreBulkOperations(t *testing.T, ctx context.Context, s *Store, clock 
 	esStore := database.ExternalServicesWith(s)
 
 	repo := ct.TestRepo(t, esStore, extsvc.KindGitHub)
-	deletedRepo := ct.TestRepo(t, esStore, extsvc.KindGitHub).With(types.Opt.RepoDeletedAt(clock.Now()))
+	deletedRepo := ct.TestRepo(t, esStore, extsvc.KindGitHub).With(typestest.Opt.RepoDeletedAt(clock.Now()))
 
 	if err := repoStore.Create(ctx, repo, deletedRepo); err != nil {
 		t.Fatal(err)

--- a/enterprise/internal/batches/store/changeset_jobs_test.go
+++ b/enterprise/internal/batches/store/changeset_jobs_test.go
@@ -11,7 +11,7 @@ import (
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
-	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 )
 
 func testStoreChangesetJobs(t *testing.T, ctx context.Context, s *Store, clock ct.Clock) {
@@ -19,7 +19,7 @@ func testStoreChangesetJobs(t *testing.T, ctx context.Context, s *Store, clock c
 	esStore := database.ExternalServicesWith(s)
 
 	repo := ct.TestRepo(t, esStore, extsvc.KindGitHub)
-	deletedRepo := ct.TestRepo(t, esStore, extsvc.KindGitHub).With(types.Opt.RepoDeletedAt(clock.Now()))
+	deletedRepo := ct.TestRepo(t, esStore, extsvc.KindGitHub).With(typestest.Opt.RepoDeletedAt(clock.Now()))
 
 	if err := repoStore.Create(ctx, repo, deletedRepo); err != nil {
 		t.Fatal(err)

--- a/enterprise/internal/batches/store/changeset_specs_test.go
+++ b/enterprise/internal/batches/store/changeset_specs_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
 )
 
@@ -35,7 +36,7 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, clock 
 	esStore := database.ExternalServicesWith(s)
 
 	repo := ct.TestRepo(t, esStore, extsvc.KindGitHub)
-	deletedRepo := ct.TestRepo(t, esStore, extsvc.KindGitHub).With(types.Opt.RepoDeletedAt(clock.Now()))
+	deletedRepo := ct.TestRepo(t, esStore, extsvc.KindGitHub).With(typestest.Opt.RepoDeletedAt(clock.Now()))
 
 	if err := repoStore.Create(ctx, repo); err != nil {
 		t.Fatal(err)

--- a/enterprise/internal/batches/store/changesets_test.go
+++ b/enterprise/internal/batches/store/changesets_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
 )
 
@@ -58,7 +59,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 	if err := rs.Create(ctx, repo, otherRepo, gitlabRepo); err != nil {
 		t.Fatal(err)
 	}
-	deletedRepo := otherRepo.With(types.Opt.RepoDeletedAt(clock.Now()))
+	deletedRepo := otherRepo.With(typestest.Opt.RepoDeletedAt(clock.Now()))
 	if err := rs.Delete(ctx, deletedRepo.ID); err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/batches/store/codehost_test.go
+++ b/enterprise/internal/batches/store/codehost_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -51,7 +52,7 @@ func testStoreCodeHost(t *testing.T, ctx context.Context, s *Store, clock ct.Clo
 	if err := rs.Create(ctx, repo, otherRepo, gitlabRepo, bitbucketRepo, awsRepo); err != nil {
 		t.Fatal(err)
 	}
-	deletedRepo := otherRepo.With(types.Opt.RepoDeletedAt(clock.Now()))
+	deletedRepo := otherRepo.With(typestest.Opt.RepoDeletedAt(clock.Now()))
 	if err := rs.Delete(ctx, deletedRepo.ID); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/actor/actor.go
+++ b/internal/actor/actor.go
@@ -82,9 +82,9 @@ func (a *Actor) User(ctx context.Context, fetcher userFetcher) (*types.User, err
 	return a.user, a.userErr
 }
 
-type key int
+type contextKey int
 
-const actorKey key = iota
+const actorKey contextKey = iota
 
 // FromContext returns a new Actor instance from a given context.
 func FromContext(ctx context.Context) *Actor {

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -1553,7 +1554,7 @@ func TestExternalServicesStore_Upsert(t *testing.T) {
 
 	clock := timeutil.NewFakeClock(time.Now(), 0)
 
-	svcs := types.MakeExternalServices()
+	svcs := typestest.MakeExternalServices()
 
 	t.Run("no external services", func(t *testing.T) {
 		if err := ExternalServices(db).Upsert(ctx); err != nil {
@@ -1607,7 +1608,7 @@ func TestExternalServicesStore_Upsert(t *testing.T) {
 			}
 		}()
 
-		want := types.GenerateExternalServices(7, svcs...)
+		want := typestest.GenerateExternalServices(7, svcs...)
 
 		if err := tx.Upsert(ctx, want...); err != nil {
 			t.Fatalf("Upsert error: %s", err)
@@ -1691,7 +1692,7 @@ func TestExternalServicesStore_Upsert(t *testing.T) {
 			}
 		}()
 
-		want := types.GenerateExternalServices(7, svcs...)
+		want := typestest.GenerateExternalServices(7, svcs...)
 
 		if err := tx.Upsert(ctx, want...); err != nil {
 			t.Fatalf("Upsert error: %s", err)

--- a/internal/database/orgs_test.go
+++ b/internal/database/orgs_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 )
 
 func TestOrgs_ValidNames(t *testing.T) {
@@ -218,7 +219,7 @@ func TestOrgs_GetOrgsWithRepositoriesByUserID(t *testing.T) {
 	if err := ExternalServices(db).Create(ctx, confGet, service); err != nil {
 		t.Fatal(err)
 	}
-	repo := types.MakeGithubRepo(service)
+	repo := typestest.MakeGithubRepo(service)
 	if err := Repos(db).Create(ctx, repo); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/database/repos_db_test.go
+++ b/internal/database/repos_db_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 )
 
 /*
@@ -757,10 +758,10 @@ func TestRepos_List_ids(t *testing.T) {
 	db := dbtest.NewDB(t)
 	ctx := actor.WithInternalActor(context.Background())
 
-	mine := types.Repos(mustCreate(ctx, t, db, types.MakeGithubRepo()))
-	mine = append(mine, mustCreate(ctx, t, db, types.MakeGitlabRepo())...)
+	mine := types.Repos(mustCreate(ctx, t, db, typestest.MakeGithubRepo()))
+	mine = append(mine, mustCreate(ctx, t, db, typestest.MakeGitlabRepo())...)
 
-	yours := types.Repos(mustCreate(ctx, t, db, types.MakeGitoliteRepo()))
+	yours := types.Repos(mustCreate(ctx, t, db, typestest.MakeGitoliteRepo()))
 	all := append(mine, yours...)
 
 	tests := []struct {
@@ -1109,11 +1110,11 @@ func TestRepos_List_useOr(t *testing.T) {
 	db := dbtest.NewDB(t)
 	ctx := actor.WithInternalActor(context.Background())
 
-	archived := types.Repos{types.MakeGitlabRepo()}.With(func(r *types.Repo) { r.Archived = true })
+	archived := types.Repos{typestest.MakeGitlabRepo()}.With(func(r *types.Repo) { r.Archived = true })
 	archived = mustCreate(ctx, t, db, archived[0])
-	forks := types.Repos{types.MakeGitoliteRepo()}.With(func(r *types.Repo) { r.Fork = true })
+	forks := types.Repos{typestest.MakeGitoliteRepo()}.With(func(r *types.Repo) { r.Fork = true })
 	forks = mustCreate(ctx, t, db, forks[0])
-	cloned := types.Repos{types.MakeGithubRepo()}
+	cloned := types.Repos{typestest.MakeGithubRepo()}
 	cloned = mustCreateGitserverRepo(ctx, t, db, cloned[0], types.GitserverRepo{CloneStatus: types.CloneStatusCloned})
 
 	archivedAndForks := append(archived, forks...)
@@ -1154,7 +1155,7 @@ func TestRepos_List_externalServiceID(t *testing.T) {
 		return &conf.Unified{}
 	}
 
-	services := types.MakeExternalServices()
+	services := typestest.MakeExternalServices()
 	service1 := services[0]
 	service2 := services[1]
 	if err := ExternalServices(db).Create(ctx, confGet, service1); err != nil {
@@ -1164,12 +1165,12 @@ func TestRepos_List_externalServiceID(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mine := types.Repos{types.MakeGithubRepo(service1)}
+	mine := types.Repos{typestest.MakeGithubRepo(service1)}
 	if err := Repos(db).Create(ctx, mine...); err != nil {
 		t.Fatal(err)
 	}
 
-	yours := types.Repos{types.MakeGitlabRepo(service2)}
+	yours := types.Repos{typestest.MakeGitlabRepo(service2)}
 	if err := Repos(db).Create(ctx, yours...); err != nil {
 		t.Fatal(err)
 	}
@@ -1323,10 +1324,10 @@ func TestRepos_ListMinimalRepos_ids(t *testing.T) {
 	db := dbtest.NewDB(t)
 	ctx := actor.WithInternalActor(context.Background())
 
-	mine := types.Repos(mustCreate(ctx, t, db, types.MakeGithubRepo()))
-	mine = append(mine, mustCreate(ctx, t, db, types.MakeGitlabRepo())...)
+	mine := types.Repos(mustCreate(ctx, t, db, typestest.MakeGithubRepo()))
+	mine = append(mine, mustCreate(ctx, t, db, typestest.MakeGitlabRepo())...)
 
-	yours := types.Repos(mustCreate(ctx, t, db, types.MakeGitoliteRepo()))
+	yours := types.Repos(mustCreate(ctx, t, db, typestest.MakeGitoliteRepo()))
 	all := append(mine, yours...)
 
 	tests := []struct {
@@ -1646,11 +1647,11 @@ func TestRepos_ListMinimalRepos_useOr(t *testing.T) {
 	db := dbtest.NewDB(t)
 	ctx := actor.WithInternalActor(context.Background())
 
-	archived := types.Repos{types.MakeGitlabRepo()}.With(func(r *types.Repo) { r.Archived = true })
+	archived := types.Repos{typestest.MakeGitlabRepo()}.With(func(r *types.Repo) { r.Archived = true })
 	archived = mustCreate(ctx, t, db, archived[0])
-	forks := types.Repos{types.MakeGitoliteRepo()}.With(func(r *types.Repo) { r.Fork = true })
+	forks := types.Repos{typestest.MakeGitoliteRepo()}.With(func(r *types.Repo) { r.Fork = true })
 	forks = mustCreate(ctx, t, db, forks[0])
-	cloned := types.Repos{types.MakeGithubRepo()}
+	cloned := types.Repos{typestest.MakeGithubRepo()}
 	cloned = mustCreateGitserverRepo(ctx, t, db, cloned[0], types.GitserverRepo{CloneStatus: types.CloneStatusCloned})
 
 	archivedAndForks := append(archived, forks...)
@@ -1691,7 +1692,7 @@ func TestRepos_ListMinimalRepos_externalServiceID(t *testing.T) {
 		return &conf.Unified{}
 	}
 
-	services := types.MakeExternalServices()
+	services := typestest.MakeExternalServices()
 	service1 := services[0]
 	service2 := services[1]
 	if err := ExternalServices(db).Create(ctx, confGet, service1); err != nil {
@@ -1701,12 +1702,12 @@ func TestRepos_ListMinimalRepos_externalServiceID(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mine := types.Repos{types.MakeGithubRepo(service1)}
+	mine := types.Repos{typestest.MakeGithubRepo(service1)}
 	if err := Repos(db).Create(ctx, mine...); err != nil {
 		t.Fatal(err)
 	}
 
-	yours := types.Repos{types.MakeGitlabRepo(service2)}
+	yours := types.Repos{typestest.MakeGitlabRepo(service2)}
 	if err := Repos(db).Create(ctx, yours...); err != nil {
 		t.Fatal(err)
 	}
@@ -2134,13 +2135,13 @@ func TestGetFirstRepoNamesByCloneURL(t *testing.T) {
 		return &conf.Unified{}
 	}
 
-	services := types.MakeExternalServices()
+	services := typestest.MakeExternalServices()
 	service1 := services[0]
 	if err := ExternalServices(db).Create(ctx, confGet, service1); err != nil {
 		t.Fatal(err)
 	}
 
-	repo1 := types.MakeGithubRepo(service1)
+	repo1 := typestest.MakeGithubRepo(service1)
 	if err := Repos(db).Create(ctx, repo1); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 )
 
 func TestParseIncludePattern(t *testing.T) {
@@ -345,15 +346,15 @@ func TestRepos_Create(t *testing.T) {
 	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
-	svcs := types.MakeExternalServices()
+	svcs := typestest.MakeExternalServices()
 	if err := ExternalServices(db).Upsert(ctx, svcs...); err != nil {
 		t.Fatalf("Upsert error: %s", err)
 	}
 
-	msvcs := types.ExternalServicesToMap(svcs)
+	msvcs := typestest.ExternalServicesToMap(svcs)
 
-	repo1 := types.MakeGithubRepo(msvcs[extsvc.KindGitHub], msvcs[extsvc.KindBitbucketServer])
-	repo2 := types.MakeGitlabRepo(msvcs[extsvc.KindGitLab])
+	repo1 := typestest.MakeGithubRepo(msvcs[extsvc.KindGitHub], msvcs[extsvc.KindBitbucketServer])
+	repo2 := typestest.MakeGitlabRepo(msvcs[extsvc.KindGitLab])
 
 	t.Run("no repos should not fail", func(t *testing.T) {
 		if err := Repos(db).Create(ctx); err != nil {
@@ -362,7 +363,7 @@ func TestRepos_Create(t *testing.T) {
 	})
 
 	t.Run("many repos", func(t *testing.T) {
-		want := types.GenerateRepos(7, repo1, repo2)
+		want := typestest.GenerateRepos(7, repo1, repo2)
 
 		if err := Repos(db).Create(ctx, want...); err != nil {
 			t.Fatalf("Create error: %s", err)

--- a/internal/oobmigration/migrators_test.go
+++ b/internal/oobmigration/migrators_test.go
@@ -21,6 +21,7 @@ import (
 	et "github.com/sourcegraph/sourcegraph/internal/encryption/testing"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -66,7 +67,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 		requireProgressEqual(1)
 
 		// Create 10 external services
-		svcs := types.GenerateExternalServices(10, types.MakeExternalServices()...)
+		svcs := typestest.GenerateExternalServices(10, typestest.MakeExternalServices()...)
 		confGet := func() *conf.Unified {
 			return &conf.Unified{}
 		}
@@ -128,7 +129,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 		migrator.BatchSize = 10
 
 		// Create 10 external services
-		svcs := types.GenerateExternalServices(10, types.MakeExternalServices()...)
+		svcs := typestest.GenerateExternalServices(10, typestest.MakeExternalServices()...)
 		confGet := func() *conf.Unified {
 			return &conf.Unified{}
 		}
@@ -196,7 +197,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 		migrator.AllowDecrypt = true
 
 		// Create 10 external services
-		svcs := types.GenerateExternalServices(10, types.MakeExternalServices()...)
+		svcs := typestest.GenerateExternalServices(10, typestest.MakeExternalServices()...)
 		confGet := func() *conf.Unified {
 			return &conf.Unified{}
 		}
@@ -257,7 +258,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 		migrator.BatchSize = 10
 
 		// Create 10 external services
-		svcs := types.GenerateExternalServices(10, types.MakeExternalServices()...)
+		svcs := typestest.GenerateExternalServices(10, typestest.MakeExternalServices()...)
 		confGet := func() *conf.Unified {
 			return &conf.Unified{}
 		}
@@ -288,7 +289,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 		migrator.BatchSize = 10
 
 		// Create 10 external services
-		svcs := types.GenerateExternalServices(10, types.MakeExternalServices()...)
+		svcs := typestest.GenerateExternalServices(10, typestest.MakeExternalServices()...)
 		confGet := func() *conf.Unified {
 			return &conf.Unified{}
 		}

--- a/internal/repos/bitbucketcloud_test.go
+++ b/internal/repos/bitbucketcloud_test.go
@@ -16,11 +16,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestBitbucketCloudSource_ListRepos(t *testing.T) {
-	assertAllReposListed := func(want []string) types.ReposAssertion {
+	assertAllReposListed := func(want []string) typestest.ReposAssertion {
 		return func(t testing.TB, rs types.Repos) {
 			t.Helper()
 
@@ -36,7 +37,7 @@ func TestBitbucketCloudSource_ListRepos(t *testing.T) {
 
 	testCases := []struct {
 		name   string
-		assert types.ReposAssertion
+		assert typestest.ReposAssertion
 		conf   *schema.BitbucketCloudConnection
 		err    string
 	}{

--- a/internal/repos/github_test.go
+++ b/internal/repos/github_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/google/go-cmp/cmp"
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
@@ -26,6 +27,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -219,7 +221,7 @@ func TestMatchOrg(t *testing.T) {
 }
 
 func TestGithubSource_ListRepos(t *testing.T) {
-	assertAllReposListed := func(want []string) types.ReposAssertion {
+	assertAllReposListed := func(want []string) typestest.ReposAssertion {
 		return func(t testing.TB, rs types.Repos) {
 			t.Helper()
 
@@ -235,7 +237,7 @@ func TestGithubSource_ListRepos(t *testing.T) {
 
 	testCases := []struct {
 		name   string
-		assert types.ReposAssertion
+		assert typestest.ReposAssertion
 		mw     httpcli.Middleware
 		conf   *schema.GitHubConnection
 		err    string

--- a/internal/repos/perforce_test.go
+++ b/internal/repos/perforce_test.go
@@ -12,11 +12,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestPerforceSource_ListRepos(t *testing.T) {
-	assertAllReposListed := func(want []string) types.ReposAssertion {
+	assertAllReposListed := func(want []string) typestest.ReposAssertion {
 		return func(t testing.TB, rs types.Repos) {
 			t.Helper()
 
@@ -32,7 +33,7 @@ func TestPerforceSource_ListRepos(t *testing.T) {
 
 	testCases := []struct {
 		name   string
-		assert types.ReposAssertion
+		assert typestest.ReposAssertion
 		conf   *schema.PerforceConnection
 		err    string
 	}{

--- a/internal/repos/sources_test.go
+++ b/internal/repos/sources_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -42,7 +43,7 @@ func TestSources_ListRepos(t *testing.T) {
 		name   string
 		ctx    context.Context
 		svcs   types.ExternalServices
-		assert func(*types.ExternalService) types.ReposAssertion
+		assert func(*types.ExternalService) typestest.ReposAssertion
 		err    string
 	}
 
@@ -138,7 +139,7 @@ func TestSources_ListRepos(t *testing.T) {
 		testCases = append(testCases, testCase{
 			name: "excluded repos are never yielded",
 			svcs: svcs,
-			assert: func(s *types.ExternalService) types.ReposAssertion {
+			assert: func(s *types.ExternalService) typestest.ReposAssertion {
 				return func(t testing.TB, rs types.Repos) {
 					t.Helper()
 
@@ -284,7 +285,7 @@ func TestSources_ListRepos(t *testing.T) {
 		testCases = append(testCases, testCase{
 			name: "included repos that exist are yielded",
 			svcs: svcs,
-			assert: func(s *types.ExternalService) types.ReposAssertion {
+			assert: func(s *types.ExternalService) typestest.ReposAssertion {
 				return func(t testing.TB, rs types.Repos) {
 					t.Helper()
 
@@ -391,7 +392,7 @@ func TestSources_ListRepos(t *testing.T) {
 		testCases = append(testCases, testCase{
 			name: "repositoryPathPattern determines the repo name",
 			svcs: svcs,
-			assert: func(s *types.ExternalService) types.ReposAssertion {
+			assert: func(s *types.ExternalService) typestest.ReposAssertion {
 				return func(t testing.TB, rs types.Repos) {
 					t.Helper()
 
@@ -492,7 +493,7 @@ func TestSources_ListRepos(t *testing.T) {
 		testCases = append(testCases, testCase{
 			name: "nameTransformations updates the repo name",
 			svcs: svcs,
-			assert: func(s *types.ExternalService) types.ReposAssertion {
+			assert: func(s *types.ExternalService) typestest.ReposAssertion {
 				return func(t testing.TB, rs types.Repos) {
 					t.Helper()
 
@@ -531,7 +532,7 @@ func TestSources_ListRepos(t *testing.T) {
 		testCases = append(testCases, testCase{
 			name: "phabricator",
 			svcs: svcs,
-			assert: func(*types.ExternalService) types.ReposAssertion {
+			assert: func(*types.ExternalService) typestest.ReposAssertion {
 				return func(t testing.TB, rs types.Repos) {
 					t.Helper()
 
@@ -586,7 +587,7 @@ func TestSources_ListRepos(t *testing.T) {
 		testCases = append(testCases, testCase{
 			name: "bitbucketserver archived",
 			svcs: svcs,
-			assert: func(s *types.ExternalService) types.ReposAssertion {
+			assert: func(s *types.ExternalService) typestest.ReposAssertion {
 				return func(t testing.TB, rs types.Repos) {
 					t.Helper()
 

--- a/internal/repos/testing.go
+++ b/internal/repos/testing.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cockroachdb/errors"
 
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 )
 
 // NewFakeSourcer returns a Sourcer which always returns the given error and source,
@@ -42,7 +43,7 @@ func (s FakeSource) ListRepos(ctx context.Context, results chan SourceResult) {
 	}
 
 	for _, r := range s.repos {
-		results <- SourceResult{Source: s, Repo: r.With(types.Opt.RepoSources(s.svc.URN()))}
+		results <- SourceResult{Source: s, Repo: r.With(typestest.Opt.RepoSources(s.svc.URN()))}
 	}
 }
 

--- a/internal/types/typestest/typestest.go
+++ b/internal/types/typestest/typestest.go
@@ -1,4 +1,4 @@
-package types
+package typestest
 
 import (
 	"sort"
@@ -17,13 +17,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitolite"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-func MakeRepo(name, serviceID, serviceType string, services ...*ExternalService) *Repo {
+func MakeRepo(name, serviceID, serviceType string, services ...*types.ExternalService) *types.Repo {
 	clock := timeutil.NewFakeClock(time.Now(), 0)
 	now := clock.Now()
 
-	repo := Repo{
+	repo := types.Repo{
 		ExternalRepo: api.ExternalRepoSpec{
 			ID:          "1234",
 			ServiceType: serviceType,
@@ -33,11 +34,11 @@ func MakeRepo(name, serviceID, serviceType string, services ...*ExternalService)
 		URI:         name,
 		Description: "The description",
 		CreatedAt:   now,
-		Sources:     make(map[string]*SourceInfo),
+		Sources:     make(map[string]*types.SourceInfo),
 	}
 
 	for _, svc := range services {
-		repo.Sources[svc.URN()] = &SourceInfo{
+		repo.Sources[svc.URN()] = &types.SourceInfo{
 			ID: svc.URN(),
 		}
 	}
@@ -46,54 +47,54 @@ func MakeRepo(name, serviceID, serviceType string, services ...*ExternalService)
 }
 
 // MakeGithubRepo returns a configured Github repository.
-func MakeGithubRepo(services ...*ExternalService) *Repo {
+func MakeGithubRepo(services ...*types.ExternalService) *types.Repo {
 	repo := MakeRepo("github.com/foo/bar", "http://github.com", extsvc.TypeGitHub, services...)
 	repo.Metadata = new(github.Repository)
 	return repo
 }
 
 // MakeGitlabRepo returns a configured Gitlab repository.
-func MakeGitlabRepo(services ...*ExternalService) *Repo {
+func MakeGitlabRepo(services ...*types.ExternalService) *types.Repo {
 	repo := MakeRepo("gitlab.com/foo/bar", "http://gitlab.com", extsvc.TypeGitLab, services...)
 	repo.Metadata = new(gitlab.Project)
 	return repo
 }
 
 // MakeBitbucketServerRepo returns a configured Bitbucket Server repository.
-func MakeBitbucketServerRepo(services ...*ExternalService) *Repo {
+func MakeBitbucketServerRepo(services ...*types.ExternalService) *types.Repo {
 	repo := MakeRepo("bitbucketserver.mycorp.com/foo/bar", "http://bitbucketserver.mycorp.com", extsvc.TypeBitbucketServer, services...)
 	repo.Metadata = new(bitbucketserver.Repo)
 	return repo
 }
 
 // MakeAWSCodeCommitRepo returns a configured AWS Code Commit repository.
-func MakeAWSCodeCommitRepo(services ...*ExternalService) *Repo {
+func MakeAWSCodeCommitRepo(services ...*types.ExternalService) *types.Repo {
 	repo := MakeRepo("git-codecommit.us-west-1.amazonaws.com/stripe-go", "arn:aws:codecommit:us-west-1:999999999999:", extsvc.KindAWSCodeCommit, services...)
 	repo.Metadata = new(awscodecommit.Repository)
 	return repo
 }
 
 // MakeOtherRepo returns a configured repository from a custom host.
-func MakeOtherRepo(services ...*ExternalService) *Repo {
+func MakeOtherRepo(services ...*types.ExternalService) *types.Repo {
 	repo := MakeRepo("git-host.com/org/foo", "https://git-host.com/", extsvc.KindOther, services...)
 	repo.Metadata = new(extsvc.OtherRepoMetadata)
 	return repo
 }
 
 // MakeGitoliteRepo returns a configured Gitolite repository.
-func MakeGitoliteRepo(services ...*ExternalService) *Repo {
+func MakeGitoliteRepo(services ...*types.ExternalService) *types.Repo {
 	repo := MakeRepo("gitolite.mycorp.com/bar", "git@gitolite.mycorp.com", extsvc.KindGitolite, services...)
 	repo.Metadata = new(gitolite.Repo)
 	return repo
 }
 
 // GenerateRepos takes a list of base repos and generates n ones with different names.
-func GenerateRepos(n int, base ...*Repo) Repos {
+func GenerateRepos(n int, base ...*types.Repo) types.Repos {
 	if len(base) == 0 {
 		return nil
 	}
 
-	rs := make(Repos, 0, n)
+	rs := make(types.Repos, 0, n)
 	for i := 0; i < n; i++ {
 		id := strconv.Itoa(i)
 		r := base[i%len(base)].Clone()
@@ -104,12 +105,12 @@ func GenerateRepos(n int, base ...*Repo) Repos {
 	return rs
 }
 
-// MakeExternalServices creates one configured external service per kind and returns the list.
-func MakeExternalServices() ExternalServices {
+// Maketypes.ExternalServices creates one configured external service per kind and returns the list.
+func MakeExternalServices() types.ExternalServices {
 	clock := timeutil.NewFakeClock(time.Now(), 0)
 	now := clock.Now()
 
-	githubSvc := ExternalService{
+	githubSvc := types.ExternalService{
 		Kind:        extsvc.KindGitHub,
 		DisplayName: "Github - Test",
 		Config:      `{"url": "https://github.com", "token": "abc", "repositoryQuery": ["none"]}`,
@@ -117,7 +118,7 @@ func MakeExternalServices() ExternalServices {
 		UpdatedAt:   now,
 	}
 
-	gitlabSvc := ExternalService{
+	gitlabSvc := types.ExternalService{
 		Kind:        extsvc.KindGitLab,
 		DisplayName: "GitLab - Test",
 		Config:      `{"url": "https://gitlab.com", "token": "abc", "projectQuery": ["projects?membership=true&archived=no"]}`,
@@ -125,7 +126,7 @@ func MakeExternalServices() ExternalServices {
 		UpdatedAt:   now,
 	}
 
-	bitbucketServerSvc := ExternalService{
+	bitbucketServerSvc := types.ExternalService{
 		Kind:        extsvc.KindBitbucketServer,
 		DisplayName: "Bitbucket Server - Test",
 		Config:      `{"url": "https://bitbucket.com", "username": "foo", "token": "abc", "repositoryQuery": ["none"]}`,
@@ -133,7 +134,7 @@ func MakeExternalServices() ExternalServices {
 		UpdatedAt:   now,
 	}
 
-	bitbucketCloudSvc := ExternalService{
+	bitbucketCloudSvc := types.ExternalService{
 		Kind:        extsvc.KindBitbucketCloud,
 		DisplayName: "Bitbucket Cloud - Test",
 		Config:      `{"url": "https://bitbucket.com", "username": "foo", "appPassword": "abc"}`,
@@ -141,7 +142,7 @@ func MakeExternalServices() ExternalServices {
 		UpdatedAt:   now,
 	}
 
-	awsSvc := ExternalService{
+	awsSvc := types.ExternalService{
 		Kind:        extsvc.KindAWSCodeCommit,
 		DisplayName: "AWS Code - Test",
 		Config:      `{"region": "eu-west-1", "accessKeyID": "key", "secretAccessKey": "secret", "gitCredentials": {"username": "foo", "password": "bar"}}`,
@@ -149,7 +150,7 @@ func MakeExternalServices() ExternalServices {
 		UpdatedAt:   now,
 	}
 
-	otherSvc := ExternalService{
+	otherSvc := types.ExternalService{
 		Kind:        extsvc.KindOther,
 		DisplayName: "Other - Test",
 		Config:      `{"url": "https://other.com", "repos": ["none"]}`,
@@ -157,7 +158,7 @@ func MakeExternalServices() ExternalServices {
 		UpdatedAt:   now,
 	}
 
-	gitoliteSvc := ExternalService{
+	gitoliteSvc := types.ExternalService{
 		Kind:        extsvc.KindGitolite,
 		DisplayName: "Gitolite - Test",
 		Config:      `{"prefix": "foo", "host": "bar"}`,
@@ -165,7 +166,7 @@ func MakeExternalServices() ExternalServices {
 		UpdatedAt:   now,
 	}
 
-	return []*ExternalService{
+	return []*types.ExternalService{
 		&githubSvc,
 		&gitlabSvc,
 		&bitbucketServerSvc,
@@ -176,12 +177,12 @@ func MakeExternalServices() ExternalServices {
 	}
 }
 
-// GenerateExternalServices takes a list of base external services and generates n ones with different names.
-func GenerateExternalServices(n int, base ...*ExternalService) ExternalServices {
+// Generatetypes.ExternalServices takes a list of base external services and generates n ones with different names.
+func GenerateExternalServices(n int, base ...*types.ExternalService) types.ExternalServices {
 	if len(base) == 0 {
 		return nil
 	}
-	es := make(ExternalServices, 0, n)
+	es := make(types.ExternalServices, 0, n)
 	for i := 0; i < n; i++ {
 		id := strconv.Itoa(i)
 		r := base[i%len(base)].Clone()
@@ -193,8 +194,8 @@ func GenerateExternalServices(n int, base ...*ExternalService) ExternalServices 
 
 // ExternalServicesToMap is a helper function that returns a map whose key is the external service kind.
 // If two external services have the same kind, only the last one will be stored in the map.
-func ExternalServicesToMap(es ExternalServices) map[string]*ExternalService {
-	m := make(map[string]*ExternalService)
+func ExternalServicesToMap(es types.ExternalServices) map[string]*types.ExternalService {
+	m := make(map[string]*types.ExternalService)
 
 	for _, svc := range es {
 		m[svc.Kind] = svc
@@ -209,80 +210,80 @@ func ExternalServicesToMap(es ExternalServices) map[string]*ExternalService {
 
 // Opt contains functional options to be used in tests.
 var Opt = struct {
-	ExternalServiceID         func(int64) func(*ExternalService)
-	ExternalServiceModifiedAt func(time.Time) func(*ExternalService)
-	ExternalServiceDeletedAt  func(time.Time) func(*ExternalService)
-	RepoID                    func(api.RepoID) func(*Repo)
-	RepoName                  func(api.RepoName) func(*Repo)
-	RepoCreatedAt             func(time.Time) func(*Repo)
-	RepoModifiedAt            func(time.Time) func(*Repo)
-	RepoDeletedAt             func(time.Time) func(*Repo)
-	RepoSources               func(...string) func(*Repo)
-	RepoMetadata              func(interface{}) func(*Repo)
-	RepoExternalID            func(string) func(*Repo)
+	ExternalServiceID         func(int64) func(*types.ExternalService)
+	ExternalServiceModifiedAt func(time.Time) func(*types.ExternalService)
+	ExternalServiceDeletedAt  func(time.Time) func(*types.ExternalService)
+	RepoID                    func(api.RepoID) func(*types.Repo)
+	RepoName                  func(api.RepoName) func(*types.Repo)
+	RepoCreatedAt             func(time.Time) func(*types.Repo)
+	RepoModifiedAt            func(time.Time) func(*types.Repo)
+	RepoDeletedAt             func(time.Time) func(*types.Repo)
+	RepoSources               func(...string) func(*types.Repo)
+	RepoMetadata              func(interface{}) func(*types.Repo)
+	RepoExternalID            func(string) func(*types.Repo)
 }{
-	ExternalServiceID: func(n int64) func(*ExternalService) {
-		return func(e *ExternalService) {
+	ExternalServiceID: func(n int64) func(*types.ExternalService) {
+		return func(e *types.ExternalService) {
 			e.ID = n
 		}
 	},
-	ExternalServiceModifiedAt: func(ts time.Time) func(*ExternalService) {
-		return func(e *ExternalService) {
+	ExternalServiceModifiedAt: func(ts time.Time) func(*types.ExternalService) {
+		return func(e *types.ExternalService) {
 			e.UpdatedAt = ts
 			e.DeletedAt = time.Time{}
 		}
 	},
-	ExternalServiceDeletedAt: func(ts time.Time) func(*ExternalService) {
-		return func(e *ExternalService) {
+	ExternalServiceDeletedAt: func(ts time.Time) func(*types.ExternalService) {
+		return func(e *types.ExternalService) {
 			e.UpdatedAt = ts
 			e.DeletedAt = ts
 		}
 	},
-	RepoID: func(n api.RepoID) func(*Repo) {
-		return func(r *Repo) {
+	RepoID: func(n api.RepoID) func(*types.Repo) {
+		return func(r *types.Repo) {
 			r.ID = n
 		}
 	},
-	RepoName: func(name api.RepoName) func(*Repo) {
-		return func(r *Repo) {
+	RepoName: func(name api.RepoName) func(*types.Repo) {
+		return func(r *types.Repo) {
 			r.Name = name
 		}
 	},
-	RepoCreatedAt: func(ts time.Time) func(*Repo) {
-		return func(r *Repo) {
+	RepoCreatedAt: func(ts time.Time) func(*types.Repo) {
+		return func(r *types.Repo) {
 			r.CreatedAt = ts
 			r.UpdatedAt = ts
 			r.DeletedAt = time.Time{}
 		}
 	},
-	RepoModifiedAt: func(ts time.Time) func(*Repo) {
-		return func(r *Repo) {
+	RepoModifiedAt: func(ts time.Time) func(*types.Repo) {
+		return func(r *types.Repo) {
 			r.UpdatedAt = ts
 			r.DeletedAt = time.Time{}
 		}
 	},
-	RepoDeletedAt: func(ts time.Time) func(*Repo) {
-		return func(r *Repo) {
+	RepoDeletedAt: func(ts time.Time) func(*types.Repo) {
+		return func(r *types.Repo) {
 			r.UpdatedAt = ts
 			r.DeletedAt = ts
-			r.Sources = map[string]*SourceInfo{}
+			r.Sources = map[string]*types.SourceInfo{}
 		}
 	},
-	RepoSources: func(srcs ...string) func(*Repo) {
-		return func(r *Repo) {
-			r.Sources = map[string]*SourceInfo{}
+	RepoSources: func(srcs ...string) func(*types.Repo) {
+		return func(r *types.Repo) {
+			r.Sources = map[string]*types.SourceInfo{}
 			for _, src := range srcs {
-				r.Sources[src] = &SourceInfo{ID: src, CloneURL: "clone-url"}
+				r.Sources[src] = &types.SourceInfo{ID: src, CloneURL: "clone-url"}
 			}
 		}
 	},
-	RepoMetadata: func(md interface{}) func(*Repo) {
-		return func(r *Repo) {
+	RepoMetadata: func(md interface{}) func(*types.Repo) {
+		return func(r *types.Repo) {
 			r.Metadata = md
 		}
 	},
-	RepoExternalID: func(id string) func(*Repo) {
-		return func(r *Repo) {
+	RepoExternalID: func(id string) func(*types.Repo) {
+		return func(r *types.Repo) {
 			r.ExternalRepo.ID = id
 		}
 	},
@@ -293,32 +294,32 @@ var Opt = struct {
 //
 
 // A ReposAssertion performs an assertion on the given Repos.
-type ReposAssertion func(testing.TB, Repos)
+type ReposAssertion func(testing.TB, types.Repos)
 
 // An ExternalServicesAssertion performs an assertion on the given
-// ExternalServices.
-type ExternalServicesAssertion func(testing.TB, ExternalServices)
+// types.ExternalServices.
+type ExternalServicesAssertion func(testing.TB, types.ExternalServices)
 
 // Assert contains assertion functions to be used in tests.
 var Assert = struct {
-	ReposEqual                func(...*Repo) ReposAssertion
-	ReposOrderedBy            func(func(a, b *Repo) bool) ReposAssertion
-	ExternalServicesEqual     func(...*ExternalService) ExternalServicesAssertion
-	ExternalServicesOrderedBy func(func(a, b *ExternalService) bool) ExternalServicesAssertion
+	ReposEqual                func(...*types.Repo) ReposAssertion
+	ReposOrderedBy            func(func(a, b *types.Repo) bool) ReposAssertion
+	ExternalServicesEqual     func(...*types.ExternalService) ExternalServicesAssertion
+	ExternalServicesOrderedBy func(func(a, b *types.ExternalService) bool) ExternalServicesAssertion
 }{
-	ReposEqual: func(rs ...*Repo) ReposAssertion {
-		want := append(Repos{}, rs...).With(Opt.RepoID(0))
-		return func(t testing.TB, have Repos) {
+	ReposEqual: func(rs ...*types.Repo) ReposAssertion {
+		want := append(types.Repos{}, rs...).With(Opt.RepoID(0))
+		return func(t testing.TB, have types.Repos) {
 			t.Helper()
 			// Exclude auto-generated IDs from equality tests
-			have = append(Repos{}, have...).With(Opt.RepoID(0))
-			if diff := cmp.Diff(want, have, cmpopts.IgnoreFields(Repo{}, "CreatedAt", "UpdatedAt")); diff != "" {
+			have = append(types.Repos{}, have...).With(Opt.RepoID(0))
+			if diff := cmp.Diff(want, have, cmpopts.IgnoreFields(types.Repo{}, "CreatedAt", "UpdatedAt")); diff != "" {
 				t.Errorf("repos (-want +got): %s", diff)
 			}
 		}
 	},
-	ReposOrderedBy: func(ord func(a, b *Repo) bool) ReposAssertion {
-		return func(t testing.TB, have Repos) {
+	ReposOrderedBy: func(ord func(a, b *types.Repo) bool) ReposAssertion {
+		return func(t testing.TB, have types.Repos) {
 			t.Helper()
 			want := have.Clone()
 			sort.Slice(want, func(i, j int) bool {
@@ -329,19 +330,19 @@ var Assert = struct {
 			}
 		}
 	},
-	ExternalServicesEqual: func(es ...*ExternalService) ExternalServicesAssertion {
-		want := append(ExternalServices{}, es...).With(Opt.ExternalServiceID(0))
-		return func(t testing.TB, have ExternalServices) {
+	ExternalServicesEqual: func(es ...*types.ExternalService) ExternalServicesAssertion {
+		want := append(types.ExternalServices{}, es...).With(Opt.ExternalServiceID(0))
+		return func(t testing.TB, have types.ExternalServices) {
 			t.Helper()
 			// Exclude auto-generated IDs from equality tests
-			have = append(ExternalServices{}, have...).With(Opt.ExternalServiceID(0))
+			have = append(types.ExternalServices{}, have...).With(Opt.ExternalServiceID(0))
 			if diff := cmp.Diff(want, have); diff != "" {
 				t.Errorf("external services (-want +got): %s", cmp.Diff(want, have))
 			}
 		}
 	},
-	ExternalServicesOrderedBy: func(ord func(a, b *ExternalService) bool) ExternalServicesAssertion {
-		return func(t testing.TB, have ExternalServices) {
+	ExternalServicesOrderedBy: func(ord func(a, b *types.ExternalService) bool) ExternalServicesAssertion {
+		return func(t testing.TB, have types.ExternalServices) {
 			t.Helper()
 			want := have.Clone()
 			sort.Slice(want, func(i, j int) bool {


### PR DESCRIPTION
Another way to resolve the import cycle in https://github.com/sourcegraph/sourcegraph/pull/28117 , instead of the reverted https://github.com/sourcegraph/sourcegraph/pull/28149.

The import cycle is caused by `types` importing various `extsvc` packages that each have clients to their respective external services, causing an import of `httpcli`. However, these types are only used in testing - this moves those test types out into `types/typestest` (mirroring standard library conventions like [`http/httptest`](https://pkg.go.dev/net/http/httptest)). Diff only affects tests.