### PR TITLE
Fix workspaces not matching anything without in

### DIFF
--- a/enterprise/internal/batches/service/workspace_resolver.go
+++ b/enterprise/internal/batches/service/workspace_resolver.go
@@ -578,9 +578,14 @@ func findWorkspaces(
 	workspaceMatchers := make(map[batcheslib.WorkspaceConfiguration]glob.Glob)
 	var errs *multierror.Error
 	for _, conf := range spec.Workspaces {
-		g, err := glob.Compile(conf.In)
+		in := conf.In
+		// Empty `in` should fall back to matching all, instead of nothing.
+		if in == "" {
+			in = "*"
+		}
+		g, err := glob.Compile(in)
 		if err != nil {
-			errs = multierror.Append(errs, batcheslib.NewValidationError(errors.Errorf("failed to compile glob %q: %v", conf.In, err)))
+			errs = multierror.Append(errs, batcheslib.NewValidationError(errors.Errorf("failed to compile glob %q: %v", in, err)))
 		}
 		workspaceMatchers[conf] = g
 	}

--- a/enterprise/internal/batches/service/workspace_resolver_test.go
+++ b/enterprise/internal/batches/service/workspace_resolver_test.go
@@ -486,6 +486,24 @@ func TestFindWorkspaces(t *testing.T) {
 				{RepoRevision: repoRevs[2], Steps: steps, Path: "d/e/f", OnlyFetchWorkspace: true},
 			},
 		},
+		"workspace configuration without in matches all": {
+			spec: &batcheslib.BatchSpec{
+				Steps: steps,
+				Workspaces: []batcheslib.WorkspaceConfiguration{
+					{
+						RootAtLocationOf: "package.json",
+					},
+				},
+			},
+			finderResults: finderResults{
+				repoRevs[0].Key(): {"a/b"},
+				repoRevs[2].Key(): {"a/b"},
+			},
+			wantWorkspaces: []*RepoWorkspace{
+				{RepoRevision: repoRevs[0], Steps: steps, Path: "a/b"},
+				{RepoRevision: repoRevs[2], Steps: steps, Path: "a/b"},
+			},
+		},
 	}
 
 	for name, tt := range tests {


### PR DESCRIPTION
When `in` was omitted in a workspaces block, it would do nothing. This changes it to match everything instead, which is the original intended behavior.

