### PR TITLE
search: Add search.index.revisions to site config

### DIFF
--- a/cmd/frontend/internal/httpapi/search.go
+++ b/cmd/frontend/internal/httpapi/search.go
@@ -202,7 +202,6 @@ func (h *searchIndexerServer) serveConfiguration(w http.ResponseWriter, r *http.
 		&siteConfig,
 		getRepoIndexOptions,
 		getSearchContextRevisions,
-		searchbackend.SiteConfigRevisionsGetter(&siteConfig),
 		repoIDs...,
 	)
 	_, _ = w.Write(b)

--- a/cmd/frontend/internal/httpapi/search.go
+++ b/cmd/frontend/internal/httpapi/search.go
@@ -198,7 +198,13 @@ func (h *searchIndexerServer) serveConfiguration(w http.ResponseWriter, r *http.
 		repoIDs[i] = int32(indexedIDs[i])
 	}
 
-	b := searchbackend.GetIndexOptions(&siteConfig, getRepoIndexOptions, getSearchContextRevisions, repoIDs...)
+	b := searchbackend.GetIndexOptions(
+		&siteConfig,
+		getRepoIndexOptions,
+		getSearchContextRevisions,
+		searchbackend.SiteConfigRevisionsGetter(&siteConfig),
+		repoIDs...,
+	)
 	_, _ = w.Write(b)
 	return nil
 }

--- a/internal/search/backend/index_options.go
+++ b/internal/search/backend/index_options.go
@@ -223,9 +223,7 @@ func siteConfigRevisionsRuleFunc(c *schema.SiteConfiguration) revsRuleFunc {
 		cfg := c.ExperimentalFeatures
 
 		if len(cfg.SearchIndexBranches) != 0 {
-			branchesRevs := cfg.SearchIndexBranches[o.Name]
-			matched = make([]string, 0, len(branchesRevs)*2)
-			matched = append(matched, branchesRevs...)
+			matched = append(matched, cfg.SearchIndexBranches[o.Name]...)
 		}
 
 		for _, rule := range rules {

--- a/internal/search/backend/index_options_test.go
+++ b/internal/search/backend/index_options_test.go
@@ -143,7 +143,7 @@ func TestGetIndexOptions(t *testing.T) {
 	}, {
 		name: "conf index revisions",
 		conf: schema.SiteConfiguration{ExperimentalFeatures: &schema.ExperimentalFeatures{
-			SearchIndexRevisions: []*schema.SearchIndexRevisionRule{
+			SearchIndexRevisions: []*schema.SearchIndexRevisionsRule{
 				{Name: "repo-.*", Revisions: []string{"a"}},
 			},
 		}},
@@ -163,7 +163,7 @@ func TestGetIndexOptions(t *testing.T) {
 			SearchIndexBranches: map[string][]string{
 				"repo-01": {"a", "b"},
 			},
-			SearchIndexRevisions: []*schema.SearchIndexRevisionRule{
+			SearchIndexRevisions: []*schema.SearchIndexRevisionsRule{
 				{Name: "repo-.*", Revisions: []string{"a", "c"}},
 			},
 		}},

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -587,6 +587,8 @@ type ExperimentalFeatures struct {
 	RateLimitAnonymous int `json:"rateLimitAnonymous,omitempty"`
 	// SearchIndexBranches description: A map from repository name to a list of extra revs (branch, ref, tag, commit sha, etc) to index for a repository. We always index the default branch ("HEAD") and revisions in version contexts. This allows specifying additional revisions. Sourcegraph can index up to 64 branches per repository.
 	SearchIndexBranches map[string][]string `json:"search.index.branches,omitempty"`
+	// SearchIndexRevisions description: A map from regular expression to a list of extra revs (branch, ref, tag, commit sha, etc) to index for all repositories whose names match it. We always index the default branch ("HEAD") and revisions in version contexts. This allows specifying additional revisions. Sourcegraph can index up to 64 branches per repository.
+	SearchIndexRevisions map[string][]string `json:"search.index.revisions,omitempty"`
 	// SearchMultipleRevisionsPerRepository description: DEPRECATED. Always on. Will be removed in 3.19.
 	SearchMultipleRevisionsPerRepository *bool `json:"searchMultipleRevisionsPerRepository,omitempty"`
 	// StructuralSearch description: Enables structural search.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -587,8 +587,8 @@ type ExperimentalFeatures struct {
 	RateLimitAnonymous int `json:"rateLimitAnonymous,omitempty"`
 	// SearchIndexBranches description: A map from repository name to a list of extra revs (branch, ref, tag, commit sha, etc) to index for a repository. We always index the default branch ("HEAD") and revisions in version contexts. This allows specifying additional revisions. Sourcegraph can index up to 64 branches per repository.
 	SearchIndexBranches map[string][]string `json:"search.index.branches,omitempty"`
-	// SearchIndexRevisions description: A map from regular expression to a list of extra revs (branch, ref, tag, commit sha, etc) to index for all repositories whose names match it. We always index the default branch ("HEAD") and revisions in version contexts. This allows specifying additional revisions. Sourcegraph can index up to 64 branches per repository.
-	SearchIndexRevisions map[string][]string `json:"search.index.revisions,omitempty"`
+	// SearchIndexRevisions description: An array of objects describing rules for extra revisions (branch, ref, tag, commit sha, etc) to be indexed for all repositories that match them. We always index the default branch ("HEAD") and revisions in version contexts. This allows specifying additional revisions. Sourcegraph can index up to 64 branches per repository.
+	SearchIndexRevisions []*SearchIndexRevisionRule `json:"search.index.revisions,omitempty"`
 	// SearchMultipleRevisionsPerRepository description: DEPRECATED. Always on. Will be removed in 3.19.
 	SearchMultipleRevisionsPerRepository *bool `json:"searchMultipleRevisionsPerRepository,omitempty"`
 	// StructuralSearch description: Enables structural search.
@@ -1365,6 +1365,12 @@ type SMTPServerConfig struct {
 	Port int `json:"port"`
 	// Username description: The username to use when communicating with the SMTP server.
 	Username string `json:"username,omitempty"`
+}
+type SearchIndexRevisionRule struct {
+	// Name description: Regular expression which matches against the name of a repository (e.g. "github.com/owner/name").
+	Name string `json:"name,omitempty"`
+	// Revisions description: Revisions to index
+	Revisions []string `json:"revisions"`
 }
 
 // SearchLimits description: Limits that search applies for number of repositories searched and timeouts.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -588,7 +588,7 @@ type ExperimentalFeatures struct {
 	// SearchIndexBranches description: A map from repository name to a list of extra revs (branch, ref, tag, commit sha, etc) to index for a repository. We always index the default branch ("HEAD") and revisions in version contexts. This allows specifying additional revisions. Sourcegraph can index up to 64 branches per repository.
 	SearchIndexBranches map[string][]string `json:"search.index.branches,omitempty"`
 	// SearchIndexRevisions description: An array of objects describing rules for extra revisions (branch, ref, tag, commit sha, etc) to be indexed for all repositories that match them. We always index the default branch ("HEAD") and revisions in version contexts. This allows specifying additional revisions. Sourcegraph can index up to 64 branches per repository.
-	SearchIndexRevisions []*SearchIndexRevisionRule `json:"search.index.revisions,omitempty"`
+	SearchIndexRevisions []*SearchIndexRevisionsRule `json:"search.index.revisions,omitempty"`
 	// SearchMultipleRevisionsPerRepository description: DEPRECATED. Always on. Will be removed in 3.19.
 	SearchMultipleRevisionsPerRepository *bool `json:"searchMultipleRevisionsPerRepository,omitempty"`
 	// StructuralSearch description: Enables structural search.
@@ -1366,7 +1366,7 @@ type SMTPServerConfig struct {
 	// Username description: The username to use when communicating with the SMTP server.
 	Username string `json:"username,omitempty"`
 }
-type SearchIndexRevisionRule struct {
+type SearchIndexRevisionsRule struct {
 	// Name description: Regular expression which matches against the name of a repository (e.g. "^github\.com/owner/name$").
 	Name string `json:"name,omitempty"`
 	// Revisions description: Revisions to index

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1367,7 +1367,7 @@ type SMTPServerConfig struct {
 	Username string `json:"username,omitempty"`
 }
 type SearchIndexRevisionRule struct {
-	// Name description: Regular expression which matches against the name of a repository (e.g. "github.com/owner/name").
+	// Name description: Regular expression which matches against the name of a repository (e.g. "^github\.com/owner/name$").
 	Name string `json:"name,omitempty"`
 	// Revisions description: Revisions to index
 	Revisions []string `json:"revisions"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -210,16 +210,36 @@
           ]
         },
         "search.index.revisions": {
-          "description": "A map from regular expression to a list of extra revs (branch, ref, tag, commit sha, etc) to index for all repositories whose names match it. We always index the default branch (\"HEAD\") and revisions in version contexts. This allows specifying additional revisions. Sourcegraph can index up to 64 branches per repository.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "array",
-            "items": { "type": "string" }
+          "description": "An array of objects describing rules for extra revisions (branch, ref, tag, commit sha, etc) to be indexed for all repositories that match them. We always index the default branch (\"HEAD\") and revisions in version contexts. This allows specifying additional revisions. Sourcegraph can index up to 64 branches per repository.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "title": "SearchIndexRevisionRule",
+            "additionalProperties": false,
+            "required": ["revisions"],
+            "anyOf": [
+              { "required": ["name"] }
+            ],
+            "properties": {
+              "name": {
+                "description": "Regular expression which matches against the name of a repository (e.g. \"github.com/owner/name\").",
+                "type": "string",
+                "format": "regex"
+              },
+              "revisions": {
+                "description": "Revisions to index",
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
           },
           "examples": [
-            {
-              "github\\.com/sourcegraph/.*": ["3.17", "f6ca985c27486c2df5231ea3526caa4a4108ffb6", "v3.17.1"]
-            }
+            [{ "name": "^github.com/org/.*", "revisions": ["3.17", "f6ca985c27486c2df5231ea3526caa4a4108ffb6", "v3.17.1"] }]
           ]
         },
         "search.index.branches": {

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -209,6 +209,19 @@
             ]
           ]
         },
+        "search.index.revisions": {
+          "description": "A map from regular expression to a list of extra revs (branch, ref, tag, commit sha, etc) to index for all repositories whose names match it. We always index the default branch (\"HEAD\") and revisions in version contexts. This allows specifying additional revisions. Sourcegraph can index up to 64 branches per repository.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "examples": [
+            {
+              "github\\.com/sourcegraph/.*": ["3.17", "f6ca985c27486c2df5231ea3526caa4a4108ffb6", "v3.17.1"]
+            }
+          ]
+        },
         "search.index.branches": {
           "description": "A map from repository name to a list of extra revs (branch, ref, tag, commit sha, etc) to index for a repository. We always index the default branch (\"HEAD\") and revisions in version contexts. This allows specifying additional revisions. Sourcegraph can index up to 64 branches per repository.",
           "type": "object",

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -223,7 +223,7 @@
             ],
             "properties": {
               "name": {
-                "description": "Regular expression which matches against the name of a repository (e.g. \"github.com/owner/name\").",
+                "description": "Regular expression which matches against the name of a repository (e.g. \"^github\\.com/owner/name$\").",
                 "type": "string",
                 "format": "regex"
               },

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -212,7 +212,6 @@
         "search.index.revisions": {
           "description": "An array of objects describing rules for extra revisions (branch, ref, tag, commit sha, etc) to be indexed for all repositories that match them. We always index the default branch (\"HEAD\") and revisions in version contexts. This allows specifying additional revisions. Sourcegraph can index up to 64 branches per repository.",
           "type": "array",
-          "minItems": 1,
           "items": {
             "type": "object",
             "title": "SearchIndexRevisionsRule",
@@ -230,7 +229,6 @@
               "revisions": {
                 "description": "Revisions to index",
                 "type": "array",
-                "minItems": 1,
                 "items": {
                   "type": "string",
                   "minLength": 1

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -217,9 +217,7 @@
             "title": "SearchIndexRevisionsRule",
             "additionalProperties": false,
             "required": ["revisions"],
-            "anyOf": [
-              { "required": ["name"] }
-            ],
+            "anyOf": [{ "required": ["name"] }],
             "properties": {
               "name": {
                 "description": "Regular expression which matches against the name of a repository (e.g. \"^github\\.com/owner/name$\").",
@@ -237,7 +235,12 @@
             }
           },
           "examples": [
-            [{ "name": "^github.com/org/.*", "revisions": ["3.17", "f6ca985c27486c2df5231ea3526caa4a4108ffb6", "v3.17.1"] }]
+            [
+              {
+                "name": "^github.com/org/.*",
+                "revisions": ["3.17", "f6ca985c27486c2df5231ea3526caa4a4108ffb6", "v3.17.1"]
+              }
+            ]
           ]
         },
         "search.index.branches": {

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -215,7 +215,7 @@
           "minItems": 1,
           "items": {
             "type": "object",
-            "title": "SearchIndexRevisionRule",
+            "title": "SearchIndexRevisionsRule",
             "additionalProperties": false,
             "required": ["revisions"],
             "anyOf": [


### PR DESCRIPTION
This new config value in under experimental features allows mapping a
regex on repo name to a list of revisions to be indexed.

Part of #28028



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
