### PR TITLE
Fix undrafting changesets on GitLab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
--
+- Moving a changeset from draft state into published state was broken on GitLab code hosts. [#XX](https://github.com/sourcegraph/sourcegraph/pull/XX)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
-- Moving a changeset from draft state into published state was broken on GitLab code hosts. [#XX](https://github.com/sourcegraph/sourcegraph/pull/XX)
+- Moving a changeset from draft state into published state was broken on GitLab code hosts. [#28239](https://github.com/sourcegraph/sourcegraph/pull/28239)
 
 ### Removed
 

--- a/enterprise/internal/batches/sources/gitlab.go
+++ b/enterprise/internal/batches/sources/gitlab.go
@@ -418,7 +418,17 @@ func (s *GitLabSource) UpdateChangeset(ctx context.Context, c *Changeset) error 
 
 // UndraftChangeset marks the changeset as *not* work in progress anymore.
 func (s *GitLabSource) UndraftChangeset(ctx context.Context, c *Changeset) error {
+	mr, ok := c.Changeset.Metadata.(*gitlab.MergeRequest)
+	if !ok {
+		return errors.New("Changeset is not a GitLab merge request")
+	}
+
+	// Remove WIP prefix from title.
 	c.Title = gitlab.UnsetWIP(c.Title)
+	// And mark the mr as not WorkInProgress anymore, otherwise UpdateChangeset
+	// will prepend the WIP: prefix again.
+	mr.WorkInProgress = false
+
 	return s.UpdateChangeset(ctx, c)
 }
 


### PR DESCRIPTION
This was broken in #23947 when we fixed another issue around the WIP state, it effectively overwrote the title change we do in UndraftChangeset each time. This fixes it and adds a test to guard against regressions.

Closes https://github.com/sourcegraph/sourcegraph/issues/28236.
