### PR TITLE
graphqlbackend: reduce usage of `database.Mocks`

### DIFF
--- a/cmd/frontend/graphqlbackend/set_external_service_repos.go
+++ b/cmd/frontend/graphqlbackend/set_external_service_repos.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
@@ -24,7 +23,7 @@ func (r *schemaResolver) SetExternalServiceRepos(ctx context.Context, args struc
 		return nil, err
 	}
 
-	extsvcStore := database.ExternalServices(r.db)
+	extsvcStore := r.db.ExternalServices()
 	es, err := extsvcStore.GetByID(ctx, id)
 	if err != nil {
 		return nil, err

--- a/cmd/frontend/graphqlbackend/set_external_service_repos_test.go
+++ b/cmd/frontend/graphqlbackend/set_external_service_repos_test.go
@@ -5,13 +5,14 @@ import (
 	"context"
 	"io"
 	"net/http"
-	"reflect"
 	"testing"
 
-	"github.com/cockroachdb/errors"
+	mockrequire "github.com/derision-test/go-mockgen/testutil/require"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
-	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmock"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -19,54 +20,52 @@ import (
 )
 
 func TestSetExternalServiceRepos(t *testing.T) {
-	database.Mocks.ExternalServices.GetByID = func(id int64) (*types.ExternalService, error) {
-		return &types.ExternalService{
+	externalServices := dbmock.NewMockExternalServiceStore()
+	externalServices.GetByIDFunc.SetDefaultReturn(
+		&types.ExternalService{
 			DisplayName:     "test",
 			NamespaceUserID: 1,
 			Kind:            extsvc.KindGitHub,
-			Config: `{
-				  "authorization": {},
-				  "repositoryQuery": [
-				  ],
-				  "token": "not_actually_a_real_token_that_would_be_silly",
-				  "url": "https://github.com"
-			}`,
-		}, nil
-	}
-	database.Mocks.Users.GetByID = func(ctx context.Context, userID int32) (*types.User, error) {
-		return &types.User{
-			ID:        userID,
-			SiteAdmin: userID == 1,
-		}, nil
-	}
-	database.Mocks.Users.GetByCurrentAuthUser = func(ctx context.Context) (*types.User, error) {
-		return &types.User{ID: 1, SiteAdmin: true}, nil
-	}
-	var called bool
-	database.Mocks.ExternalServices.Upsert = func(ctx context.Context, services ...*types.ExternalService) error {
-		called = true
-		if len(services) != 1 {
-			return errors.Errorf("Expected 1, got %v", len(services))
-		}
+			Config: `
+{
+	"authorization": {},
+	"repositoryQuery": [],
+	"token": "not_actually_a_real_token_that_would_be_silly",
+	"url": "https://github.com"
+}`,
+		},
+		nil,
+	)
+	externalServices.UpsertFunc.SetDefaultHook(func(ctx context.Context, services ...*types.ExternalService) error {
+		require.Len(t, services, 1)
+
 		svc := services[0]
 		cfg, err := svc.Configuration()
-		if err != nil {
-			return errors.Errorf("Expected nil, got %s", err)
-		}
-		gh, ok := cfg.(*schema.GitHubConnection)
-		if !ok {
-			return errors.Errorf("Expected *schema.GitHubConnection, got %T", cfg)
-		}
-		if expected, got := []string{"foo", "bar", "baz"}, gh.Repos; !reflect.DeepEqual(expected, got) {
-			return errors.Errorf("Expected %s got %s", expected, got)
-		}
+		require.NoError(t, err)
+		require.IsType(t, &schema.GitHubConnection{}, cfg)
+
+		gh := cfg.(*schema.GitHubConnection)
+		assert.Equal(t, []string{"foo", "bar", "baz"}, gh.Repos)
 		return nil
-	}
+	})
+
+	users := dbmock.NewMockUserStore()
+	users.GetByIDFunc.SetDefaultHook(func(ctx context.Context, id int32) (*types.User, error) {
+		return &types.User{
+			ID:        id,
+			SiteAdmin: id == 1,
+		}, nil
+	})
+	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 1, SiteAdmin: true}, nil)
 	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{
 		Internal: true,
 		UID:      1,
 	})
+
+	db := dbmock.NewMockDB()
+	db.ExternalServicesFunc.SetDefaultReturn(externalServices)
+	db.UsersFunc.SetDefaultReturn(users)
 
 	oldClient := repoupdater.DefaultClient.HTTPClient
 	repoupdater.DefaultClient.HTTPClient = &http.Client{
@@ -77,12 +76,9 @@ func TestSetExternalServiceRepos(t *testing.T) {
 			}, nil
 		}),
 	}
-
 	defer func() {
-		database.Mocks = database.MockStores{}
 		repoupdater.DefaultClient.HTTPClient = oldClient
 	}()
-	db := database.NewDB(nil)
 
 	RunTests(t, []*Test{
 		{
@@ -102,7 +98,6 @@ func TestSetExternalServiceRepos(t *testing.T) {
 			ExpectedResult: `{"setExternalServiceRepos":{"alwaysNil":null}}`,
 		},
 	})
-	if !called {
-		t.Errorf("expected upsert to have been called, but it wasn't")
-	}
+
+	mockrequire.Called(t, externalServices.UpsertFunc)
 }

--- a/cmd/frontend/graphqlbackend/status_messages.go
+++ b/cmd/frontend/graphqlbackend/status_messages.go
@@ -77,7 +77,7 @@ func (r *statusMessageResolver) Message() (string, error) {
 
 func (r *statusMessageResolver) ExternalService(ctx context.Context) (*externalServiceResolver, error) {
 	id := r.message.ExternalServiceSyncError.ExternalServiceId
-	externalService, err := database.ExternalServices(r.db).GetByID(ctx, id)
+	externalService, err := r.db.ExternalServices().GetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR reduces usage of `database.Mocks` in the `cmd/frontend/graphqlbackend` package.

This is the result of a time-boxed effort.

---

Part of #26113