### PR TITLE
notebooks: line parsing

### DIFF
--- a/client/web/src/search/notebook/convertMarkdownToBlocks.test.ts
+++ b/client/web/src/search/notebook/convertMarkdownToBlocks.test.ts
@@ -27,7 +27,7 @@ Paragraph`
                     repositoryName: 'github.com/sourcegraph/sourcegraph',
                     revision: 'feature',
                     filePath: 'client/web/index.ts',
-                    lineRange: undefined,
+                    lineRange: null,
                 },
             },
         ])
@@ -60,6 +60,8 @@ Link to a file is inside text https://sourcegraph.com/github.com/sourcegraph/sou
 
 https://sourcegraph.com/github.com/sourcegraph/sourcegraph@feature/-/blob/client/web/index.ts?L101-123
 
+https://sourcegraph.com/github.com/sourcegraph/sourcegraph@feature/-/blob/client/web/index.ts?L101
+
 ### Third title
 
 https://example.com/a/b
@@ -77,7 +79,7 @@ https://example.com/a/b
                     repositoryName: 'github.com/sourcegraph/sourcegraph',
                     revision: 'feature',
                     filePath: 'client/web/index.ts',
-                    lineRange: undefined,
+                    lineRange: null,
                 },
             },
             {
@@ -94,6 +96,18 @@ https://example.com/a/b
                     lineRange: {
                         startLine: 100,
                         endLine: 123,
+                    },
+                },
+            },
+            {
+                type: 'file',
+                input: {
+                    repositoryName: 'github.com/sourcegraph/sourcegraph',
+                    revision: 'feature',
+                    filePath: 'client/web/index.ts',
+                    lineRange: {
+                        startLine: 100,
+                        endLine: 101,
                     },
                 },
             },

--- a/client/web/src/search/notebook/serialize.test.ts
+++ b/client/web/src/search/notebook/serialize.test.ts
@@ -1,4 +1,4 @@
-import { serializeBlockInput } from './serialize'
+import { parseLineRange, serializeBlockInput, serializeLineRange } from './serialize'
 
 const SOURCEGRAPH_URL = 'https://sourcegraph.com'
 
@@ -28,6 +28,7 @@ describe('serialize', () => {
                         repositoryName: 'github.com/sourcegraph/sourcegraph',
                         revision: 'feature',
                         filePath: 'client/web/index.ts',
+                        lineRange: null,
                     },
                 },
                 SOURCEGRAPH_URL
@@ -56,4 +57,15 @@ describe('serialize', () => {
             `${SOURCEGRAPH_URL}/github.com/sourcegraph/sourcegraph@feature/-/blob/client/web/index.ts?L101-123`
         )
     })
+
+    it('should serialize single line range', () =>
+        expect(serializeLineRange({ startLine: 123, endLine: 124 })).toStrictEqual('124'))
+
+    it('should serialize multi line range', () =>
+        expect(serializeLineRange({ startLine: 123, endLine: 321 })).toStrictEqual('124-321'))
+
+    it('should parse single line range', () => expect(parseLineRange('124')).toEqual({ startLine: 123, endLine: 124 }))
+
+    it('should parse multi line range', () =>
+        expect(parseLineRange('124-321')).toEqual({ startLine: 123, endLine: 321 }))
 })

--- a/client/web/src/search/notebook/serialize.ts
+++ b/client/web/src/search/notebook/serialize.ts
@@ -1,8 +1,9 @@
+import { IHighlightLineRange } from '@sourcegraph/shared/src/graphql/schema'
 import { toAbsoluteBlobURL } from '@sourcegraph/shared/src/util/url'
 
 import { parseBrowserRepoURL } from '../../util/url'
 
-import { Block, BlockInput } from '.'
+import { Block, BlockInput, FileBlockInput } from '.'
 
 export function serializeBlockInput(block: BlockInput, sourcegraphURL: string): string {
     switch (block.type) {
@@ -24,22 +25,64 @@ export function serializeBlockInput(block: BlockInput, sourcegraphURL: string): 
     }
 }
 
+function parseFileBlockInput(input: string): FileBlockInput {
+    try {
+        const { repoName, rawRevision, filePath, position, range } = parseBrowserRepoURL(input)
+
+        const lineRange = range
+            ? { startLine: range.start.line - 1, endLine: range.end.line }
+            : position
+            ? { startLine: position.line - 1, endLine: position.line }
+            : null
+
+        return {
+            repositoryName: repoName,
+            revision: rawRevision ?? '',
+            filePath: filePath ?? '',
+            lineRange,
+        }
+    } catch {
+        return {
+            repositoryName: '',
+            revision: '',
+            filePath: '',
+            lineRange: null,
+        }
+    }
+}
+
 export function deserializeBlockInput(type: Block['type'], input: string): BlockInput {
     switch (type) {
         case 'md':
         case 'query':
             return { type, input }
-        case 'file': {
-            const { repoName, rawRevision, filePath, range } = parseBrowserRepoURL(input)
-            return {
-                type,
-                input: {
-                    repositoryName: repoName,
-                    revision: rawRevision ?? '',
-                    filePath: filePath ?? '',
-                    lineRange: range ? { startLine: range.start.line - 1, endLine: range.end.line } : undefined,
-                },
-            }
-        }
+        case 'file':
+            return { type, input: parseFileBlockInput(input) }
     }
+}
+
+export function isSingleLineRange(lineRange: IHighlightLineRange | null): boolean {
+    return lineRange ? lineRange.startLine + 1 === lineRange.endLine : false
+}
+
+export function serializeLineRange(lineRange: IHighlightLineRange | null): string {
+    if (!lineRange) {
+        return ''
+    }
+
+    return isSingleLineRange(lineRange)
+        ? `${lineRange.startLine + 1}`
+        : `${lineRange.startLine + 1}-${lineRange.endLine}`
+}
+
+const LINE_RANGE_REGEX = /^(\d+)(-\d+)?$/
+
+export function parseLineRange(value: string): IHighlightLineRange | null {
+    const matches = value.match(LINE_RANGE_REGEX)
+    if (matches === null) {
+        return null
+    }
+    const startLine = parseInt(matches[1], 10) - 1
+    const endLine = matches[2] ? parseInt(matches[2].slice(1), 10) : startLine + 1
+    return { startLine, endLine }
 }


### PR DESCRIPTION
This PR fixes parsing single line ranges from file URLs, e.g. `https://sourcegraph.com/github.com/sourcegraph/sourcegraph@feature/-/blob/client/web/index.ts?L101`.

Additionally, it prepares functions for parsing line ranges in the format `123-321`, `123` to be used in file blocks.