### PR TITLE
[cloud] Fix site admin overview on Cloud returning an error

### DIFF
--- a/cmd/frontend/graphqlbackend/orgs.go
+++ b/cmd/frontend/graphqlbackend/orgs.go
@@ -55,10 +55,6 @@ func (r *orgConnectionResolver) Nodes(ctx context.Context) ([]*OrgResolver, erro
 }
 
 func (r *orgConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
-	// 🚨 SECURITY: Not allowed on Cloud.
-	if envvar.SourcegraphDotComMode() {
-		return 0, errors.New("counting organizations is not allowed")
-	}
 	// 🚨 SECURITY: Only site admins can count organisations.
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return 0, err

--- a/cmd/frontend/graphqlbackend/orgs_test.go
+++ b/cmd/frontend/graphqlbackend/orgs_test.go
@@ -60,8 +60,12 @@ func TestListOrgsForCloud(t *testing.T) {
 	users := dbmock.NewMockUserStore()
 	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: true}, nil)
 
+	orgs := dbmock.NewMockOrgStore()
+	orgs.CountFunc.SetDefaultReturn(42, nil)
+
 	db := dbmock.NewMockDB()
 	db.UsersFunc.SetDefaultReturn(users)
+	db.OrgsFunc.SetDefaultReturn(orgs)
 
 	RunTests(t, []*Test{
 		{
@@ -69,7 +73,7 @@ func TestListOrgsForCloud(t *testing.T) {
 			Query: `
 				{
 					organizations {
-						nodes { name }
+						nodes { name },
 						totalCount
 					}
 				}
@@ -80,11 +84,24 @@ func TestListOrgsForCloud(t *testing.T) {
 					Message: "listing organizations is not allowed",
 					Path:    []interface{}{string("organizations"), string("nodes")},
 				},
-				{
-					Message: "counting organizations is not allowed",
-					Path:    []interface{}{string("organizations"), string("totalCount")},
-				},
 			},
+		},
+		{
+			Schema: mustParseGraphQLSchema(t, db),
+			Query: `
+				{
+					organizations {
+						totalCount
+					}
+				}
+			`,
+			ExpectedResult: `
+				{
+					"organizations": {
+						"totalCount": 42
+					}
+				}
+			`,
 		},
 	})
 }


### PR DESCRIPTION
On Cloud the site admin is not allowed to get the total count of organizations. Fixed by not asking for that data in the graphQL query.