### PR TITLE
internal/extsvc/github: Reuse V3Client.GetVersion in V4Client

### DIFF
--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -50,9 +50,6 @@ type V4Client struct {
 
 	// rateLimit is our self imposed rate limiter.
 	rateLimit *rate.Limiter
-
-	// v3Client is an embedded V3Client to make REST API requests from the V4Client.
-	v3Client *V3Client
 }
 
 // NewV4Client creates a new GitHub GraphQL API client with an optional default

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -95,7 +95,6 @@ func NewV4Client(apiURL *url.URL, a auth.Authenticator, cli httpcli.Doer) *V4Cli
 		httpClient:       cli,
 		rateLimit:        rl,
 		rateLimitMonitor: rlm,
-		v3Client:         NewV3Client(apiURL, a, cli),
 	}
 }
 
@@ -330,8 +329,9 @@ func (c *V4Client) determineGitHubVersion(ctx context.Context) *semver.Version {
 
 // fetchGitHubVersion will attempt to identify the GitHub Enterprise Server's version.  If the
 // method is called by a client configured to use github.com, it will return allMatchingSemver.
-// Additinally if it fails to parse the version. or the API request fails with an error, it defaults
-// to returning allMatchingSemver as well.
+//
+// Additionally if it fails to parse the version. or the API request fails with an error, it
+// defaults to returning allMatchingSemver as well.
 func (c *V4Client) fetchGitHubVersion(ctx context.Context) (version *semver.Version) {
 	version = allMatchingSemver
 
@@ -339,8 +339,10 @@ func (c *V4Client) fetchGitHubVersion(ctx context.Context) (version *semver.Vers
 		return
 	}
 
-	v, err := c.v3Client.GetVersion(ctx)
-	if err == nil {
+	// Initiate a v3Client since this requires a V3 API request.
+	v3Client := NewV3Client(c.apiURL, c.auth, c.httpClient)
+	v, err := v3Client.GetVersion(ctx)
+	if err != nil {
 		log15.Warn("Failed to fetch GitHub enterprise version", "fetchGitHubVersion", "apiURL", c.apiURL, "err", err)
 		return
 	}


### PR DESCRIPTION
Fixes #28276. 
 
In this commit, we stop making a unique API request to /meta to
identify the GitHub Enterprise Server's version. It turns out that we
already have existing code to do this in the V3Client. As a result,
it's nicer to reuse the code with the trade-off of initialising the
V3Client within the V4Client when required.

This will not have any affect in the existing API quota usages of
the GraphQL client since the /meta endpoint is part of the REST API
itself and we continue to use the REST API with this change.

~Since docs.github.com is down at the moment with a `503:
Certificate Expired`,
[here's](https://web.archive.org/web/20210306150526/https://docs.github.com/en/enterprise-server@2.22/rest/reference/meta) an archive.org URL that worked for me
to verify that `/meta` is indeed under their REST API.~

Link to GitHub API docs: https://docs.github.com/en/enterprise-server@3.3/rest/reference/meta



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
