### PR TITLE
Fix DB migration

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1040,6 +1040,24 @@ Stores data points for a code insight that do not need to be queried directly, b
 
 **recording_time**: The time for which this dependency should be recorded at using the parents value.
 
+# Table "public.insights_settings_migration_jobs"
+```
+       Column        |            Type             | Collation | Nullable |                           Default                            
+---------------------+-----------------------------+-----------+----------+--------------------------------------------------------------
+ id                  | integer                     |           | not null | nextval('insights_settings_migration_jobs_id_seq'::regclass)
+ user_id             | integer                     |           |          | 
+ org_id              | integer                     |           |          | 
+ global              | boolean                     |           |          | 
+ settings_id         | integer                     |           | not null | 
+ total_insights      | integer                     |           | not null | 0
+ migrated_insights   | integer                     |           | not null | 0
+ total_dashboards    | integer                     |           | not null | 0
+ migrated_dashboards | integer                     |           | not null | 0
+ runs                | integer                     |           | not null | 0
+ completed_at        | timestamp without time zone |           |          | 
+
+```
+
 # Table "public.lsif_configuration_policies"
 ```
            Column            |           Type           | Collation | Nullable |                         Default                         

--- a/migrations/frontend/1528395945_settings_migration_out_of_band.down.sql
+++ b/migrations/frontend/1528395945_settings_migration_out_of_band.down.sql
@@ -3,7 +3,7 @@ BEGIN;
 DROP TABLE IF EXISTS insights_settings_migration_jobs;
 
 DELETE
-FROM sg.public.out_of_band_migrations
+FROM out_of_band_migrations
 WHERE id = 14;
 
 COMMIT;

--- a/migrations/frontend/1528395945_settings_migration_out_of_band.up.sql
+++ b/migrations/frontend/1528395945_settings_migration_out_of_band.up.sql
@@ -12,7 +12,6 @@ CREATE TABLE IF NOT EXISTS insights_settings_migration_jobs
     total_dashboards int NOT NULL DEFAULT 0,
     migrated_dashboards int NOT NULL DEFAULT 0,
     runs int NOT NULL DEFAULT 0,
-    error_msg TEXT,
     completed_at timestamp
 );
 
@@ -20,11 +19,12 @@ CREATE TABLE IF NOT EXISTS insights_settings_migration_jobs
 -- we can just go in the order of id rather than have a secondary index.
 
 -- global
-INSERT INTO insights_settings_migration_jobs (global, settings_id)
-SELECT TRUE, MAX(id)
+INSERT INTO insights_settings_migration_jobs (settings_id, global)
+SELECT id, TRUE
 FROM settings
-WHERE user_id IS NULL
-  AND org_id IS NULL;
+WHERE user_id IS NULL AND org_id IS NULL
+ORDER BY id DESC
+LIMIT 1;
 
 -- org
 INSERT INTO insights_settings_migration_jobs (settings_id, org_id)
@@ -45,6 +45,7 @@ INSERT INTO out_of_band_migrations(id, team, component, description, non_destruc
                                    apply_reverse, is_enterprise, introduced_version_major, introduced_version_minor)
 VALUES (14, 'code-insights', 'db.insights_settings_migration_jobs',
         'Migrating insight definitions from settings files to database tables as a last stage to use the GraphQL API.',
-        TRUE, FALSE, TRUE, 3, 34);
+        TRUE, FALSE, TRUE, 3, 34)
+ON CONFLICT DO NOTHING;
 
 COMMIT;


### PR DESCRIPTION
I narrowed down the build failure to the block that was migrating over the global row to the queue. I'm not sure exactly what the issue was, but my guess is it didn't like the use of `MAX`? 

Oh I also got rid of the `error_msg` column because it's not being used.