### PR TITLE
graphqlbackend: eliminate usage of `database.Mocks`

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -38,8 +38,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-var mockCount = func(_ context.Context, options database.ReposListOptions) (int, error) { return 0, nil }
-
 func TestSearchResults(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		// #25936: Some unit tests rely on external services that break


### PR DESCRIPTION
This PR eliminated usage of `database.Mocks` in the `cmd/frontend/graphqlbackend` package.

This is the last PR of the series. 

---

Part of #26113