### PR TITLE
notebooks: generic input for file block

### DIFF
--- a/client/web/src/search/notebook/fileBlock/SearchNotebookFileBlockInput.module.scss
+++ b/client/web/src/search/notebook/fileBlock/SearchNotebookFileBlockInput.module.scss
@@ -1,0 +1,20 @@
+.suggestions-list {
+    // Reach Combobox uses bold font to highlight non-matching parts of suggestions.
+    // We invert that here.
+    [data-suggested-value] {
+        font-weight: normal;
+    }
+
+    [data-user-value] {
+        font-weight: bold;
+    }
+}
+
+.suggestions-option {
+    display: block;
+    padding: 0.5rem;
+
+    &:hover {
+        background-color: var(--body-bg);
+    }
+}

--- a/client/web/src/search/notebook/fileBlock/SearchNotebookFileBlockInput.module.scss
+++ b/client/web/src/search/notebook/fileBlock/SearchNotebookFileBlockInput.module.scss
@@ -18,3 +18,7 @@
         background-color: var(--body-bg);
     }
 }
+
+.suggestions-popover {
+    background-color: var(--input-bg);
+}

--- a/client/web/src/search/notebook/fileBlock/SearchNotebookFileBlockInput.story.tsx
+++ b/client/web/src/search/notebook/fileBlock/SearchNotebookFileBlockInput.story.tsx
@@ -25,6 +25,23 @@ add('default', () => (
     </WebStory>
 ))
 
+add('default with suggestions', () => (
+    <WebStory>
+        {() => (
+            <SearchNotebookFileBlockInput
+                placeholder="File block input"
+                value="client/web/file"
+                onChange={noop}
+                onFocus={noop}
+                onBlur={noop}
+                isMacPlatform={false}
+                suggestions={['client/web/file1.tsx', 'client/web/file2.tsx', 'client/web/file3.tsx']}
+                testTriggerSuggestions={true}
+            />
+        )}
+    </WebStory>
+))
+
 add('valid', () => (
     <WebStory>
         {() => (

--- a/client/web/src/search/notebook/fileBlock/SearchNotebookFileBlockInput.story.tsx
+++ b/client/web/src/search/notebook/fileBlock/SearchNotebookFileBlockInput.story.tsx
@@ -7,7 +7,9 @@ import { WebStory } from '../../../components/WebStory'
 import { SearchNotebookFileBlockInput } from './SearchNotebookFileBlockInput'
 
 const { add } = storiesOf('web/search/notebook/fileBlock/SearchNotebookFileBlockInput', module).addDecorator(story => (
-    <div className="p-3 container">{story()}</div>
+    <div className="container" style={{ padding: '1rem 1rem 8rem 1rem' }}>
+        {story()}
+    </div>
 ))
 
 add('default', () => (

--- a/client/web/src/search/notebook/fileBlock/SearchNotebookFileBlockInput.story.tsx
+++ b/client/web/src/search/notebook/fileBlock/SearchNotebookFileBlockInput.story.tsx
@@ -1,0 +1,58 @@
+import { storiesOf } from '@storybook/react'
+import { noop } from 'lodash'
+import React from 'react'
+
+import { WebStory } from '../../../components/WebStory'
+
+import { SearchNotebookFileBlockInput } from './SearchNotebookFileBlockInput'
+
+const { add } = storiesOf('web/search/notebook/fileBlock/SearchNotebookFileBlockInput', module).addDecorator(story => (
+    <div className="p-3 container">{story()}</div>
+))
+
+add('default', () => (
+    <WebStory>
+        {() => (
+            <SearchNotebookFileBlockInput
+                placeholder="File block input"
+                value="client/web/file.tsx"
+                onChange={noop}
+                onFocus={noop}
+                onBlur={noop}
+                isMacPlatform={false}
+            />
+        )}
+    </WebStory>
+))
+
+add('valid', () => (
+    <WebStory>
+        {() => (
+            <SearchNotebookFileBlockInput
+                placeholder="File block input"
+                value="client/web/file.tsx"
+                onChange={noop}
+                onFocus={noop}
+                onBlur={noop}
+                isValid={true}
+                isMacPlatform={false}
+            />
+        )}
+    </WebStory>
+))
+
+add('invalid', () => (
+    <WebStory>
+        {() => (
+            <SearchNotebookFileBlockInput
+                placeholder="File block input"
+                value="client/web/file.tsx"
+                onChange={noop}
+                onFocus={noop}
+                onBlur={noop}
+                isValid={false}
+                isMacPlatform={false}
+            />
+        )}
+    </WebStory>
+))

--- a/client/web/src/search/notebook/fileBlock/SearchNotebookFileBlockInput.tsx
+++ b/client/web/src/search/notebook/fileBlock/SearchNotebookFileBlockInput.tsx
@@ -8,7 +8,7 @@ import {
 } from '@reach/combobox'
 import classNames from 'classnames'
 import { debounce } from 'lodash'
-import React, { useMemo, useState, useCallback } from 'react'
+import React, { useMemo, useState, useCallback, useRef, useEffect } from 'react'
 
 import { isModifierKeyPressed } from '../useBlockShortcuts'
 
@@ -28,6 +28,7 @@ interface SearchNotebookFileBlockInputProps {
     isValid?: boolean
     isMacPlatform: boolean
     dataTestId?: string
+    testTriggerSuggestions?: boolean
 }
 
 export const SearchNotebookFileBlockInput: React.FunctionComponent<SearchNotebookFileBlockInputProps> = ({
@@ -44,6 +45,7 @@ export const SearchNotebookFileBlockInput: React.FunctionComponent<SearchNoteboo
     isValid,
     isMacPlatform,
     dataTestId,
+    testTriggerSuggestions,
 }) => {
     const [inputValue, setInputValue] = useState(value)
     const debouncedOnChange = useMemo(() => debounce(onChange, 300), [onChange])
@@ -54,6 +56,14 @@ export const SearchNotebookFileBlockInput: React.FunctionComponent<SearchNoteboo
         },
         [debouncedOnChange, setInputValue]
     )
+
+    const inputReference = useRef<HTMLInputElement>(null)
+    useEffect(() => {
+        if (testTriggerSuggestions) {
+            inputReference.current?.focus()
+        }
+    }, [inputReference, testTriggerSuggestions])
+
     return (
         <Combobox
             openOnFocus={true}
@@ -73,6 +83,7 @@ export const SearchNotebookFileBlockInput: React.FunctionComponent<SearchNoteboo
         >
             <ComboboxInput
                 id={id}
+                ref={inputReference}
                 className={classNames(
                     inputClassName,
                     'form-control',

--- a/client/web/src/search/notebook/fileBlock/SearchNotebookFileBlockInput.tsx
+++ b/client/web/src/search/notebook/fileBlock/SearchNotebookFileBlockInput.tsx
@@ -1,0 +1,104 @@
+import {
+    Combobox,
+    ComboboxInput,
+    ComboboxOption,
+    ComboboxPopover,
+    ComboboxOptionText,
+    ComboboxList,
+} from '@reach/combobox'
+import classNames from 'classnames'
+import { debounce } from 'lodash'
+import React, { useMemo, useState, useCallback } from 'react'
+
+import { isModifierKeyPressed } from '../useBlockShortcuts'
+
+import styles from './SearchNotebookFileBlockInput.module.scss'
+
+interface SearchNotebookFileBlockInputProps {
+    id?: string
+    className?: string
+    inputClassName?: string
+    placeholder: string
+    value: string
+    onChange: (value: string) => void
+    onFocus: (event: React.FocusEvent<HTMLInputElement>) => void
+    onBlur: (event: React.FocusEvent<HTMLInputElement>) => void
+    suggestions?: string[]
+    suggestionsIcon?: JSX.Element
+    isValid?: boolean
+    isMacPlatform: boolean
+    dataTestId?: string
+}
+
+export const SearchNotebookFileBlockInput: React.FunctionComponent<SearchNotebookFileBlockInputProps> = ({
+    id,
+    className,
+    inputClassName,
+    placeholder,
+    value,
+    onChange,
+    onFocus,
+    onBlur,
+    suggestions,
+    suggestionsIcon,
+    isValid,
+    isMacPlatform,
+    dataTestId,
+}) => {
+    const [inputValue, setInputValue] = useState(value)
+    const debouncedOnChange = useMemo(() => debounce(onChange, 300), [onChange])
+    const onSelect = useCallback(
+        (value: string) => {
+            setInputValue(value)
+            debouncedOnChange(value)
+        },
+        [debouncedOnChange, setInputValue]
+    )
+    return (
+        <Combobox
+            openOnFocus={true}
+            onSelect={onSelect}
+            className={className}
+            onKeyDown={event => {
+                if (event.key === 'Escape') {
+                    const target = event.target as HTMLElement
+                    target.blur()
+                } else if (
+                    // Allow cmd+Enter/ctrl+Enter to propagate to run the block, stop all other events
+                    !(event.key === 'Enter' && isModifierKeyPressed(event.metaKey, event.ctrlKey, isMacPlatform))
+                ) {
+                    event.stopPropagation()
+                }
+            }}
+        >
+            <ComboboxInput
+                id={id}
+                className={classNames(
+                    inputClassName,
+                    'form-control',
+                    isValid === true && 'is-valid',
+                    isValid === false && 'is-invalid'
+                )}
+                value={inputValue}
+                placeholder={placeholder}
+                onChange={event => onSelect(event.target.value)}
+                onFocus={onFocus}
+                onBlur={onBlur}
+                data-testid={dataTestId}
+            />
+            {/* Only show suggestions popover for the latest input value */}
+            {suggestions && value === inputValue && (
+                <ComboboxPopover>
+                    <ComboboxList className={styles.suggestionsList}>
+                        {suggestions.map(suggestion => (
+                            <ComboboxOption className={styles.suggestionsOption} key={suggestion} value={suggestion}>
+                                {suggestionsIcon}
+                                <ComboboxOptionText />
+                            </ComboboxOption>
+                        ))}
+                    </ComboboxList>
+                </ComboboxPopover>
+            )}
+        </Combobox>
+    )
+}

--- a/client/web/src/search/notebook/fileBlock/SearchNotebookFileBlockInput.tsx
+++ b/client/web/src/search/notebook/fileBlock/SearchNotebookFileBlockInput.tsx
@@ -99,7 +99,7 @@ export const SearchNotebookFileBlockInput: React.FunctionComponent<SearchNoteboo
             />
             {/* Only show suggestions popover for the latest input value */}
             {suggestions && value === inputValue && (
-                <ComboboxPopover>
+                <ComboboxPopover className={styles.suggestionsPopover}>
                     <ComboboxList className={styles.suggestionsList}>
                         {suggestions.map(suggestion => (
                             <ComboboxOption className={styles.suggestionsOption} key={suggestion} value={suggestion}>

--- a/client/web/src/search/notebook/useBlockShortcuts.ts
+++ b/client/web/src/search/notebook/useBlockShortcuts.ts
@@ -12,6 +12,10 @@ interface UseBlockShortcutsOptions
     isMacPlatform: boolean
 }
 
+export function isModifierKeyPressed(isMetaKey: boolean, isCtrlKey: boolean, isMacPlatform: boolean): boolean {
+    return (isMacPlatform && isMetaKey) || (!isMacPlatform && isCtrlKey)
+}
+
 export const useBlockShortcuts = ({
     id,
     isMacPlatform,
@@ -24,7 +28,7 @@ export const useBlockShortcuts = ({
 }: UseBlockShortcutsOptions): { onKeyDown: (event: React.KeyboardEvent) => void } => {
     const onKeyDown = useCallback(
         (event: React.KeyboardEvent): void => {
-            const isModifierKeyDown = (isMacPlatform && event.metaKey) || (!isMacPlatform && event.ctrlKey)
+            const isModifierKeyDown = isModifierKeyPressed(event.metaKey, event.ctrlKey, isMacPlatform)
             if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
                 const direction = event.key === 'ArrowUp' ? 'up' : 'down'
                 if (isModifierKeyDown) {


### PR DESCRIPTION
*I'm splitting up the large file block PR into smaller chunks for easier reviewing. See the entire thing here: https://github.com/sourcegraph/sourcegraph/pull/28274*

This PR adds a generic input to be used in the file block. It will be used for the four inputs we need: repository name, file path, revision, and line range. It also supports optional suggestions (we'll use them for repositories and file paths).