### PR TITLE
codeintel: Move gitserver.Head and CommitExists

### DIFF
--- a/enterprise/internal/codeintel/gitserver/client.go
+++ b/enterprise/internal/codeintel/gitserver/client.go
@@ -58,16 +58,12 @@ func (c *Client) Head(ctx context.Context, repositoryID int) (_ string, revision
 	}})
 	defer endObservation(1, observation.Args{})
 
-	revision, err := c.execGitCommand(ctx, repositoryID, "rev-parse", "HEAD")
+	repo, err := c.repositoryIDToRepo(ctx, repositoryID)
 	if err != nil {
-		if errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
-			err = nil
-		}
-
 		return "", false, err
 	}
 
-	return revision, true, nil
+	return git.Head(ctx, repo)
 }
 
 // CommitDate returns the time that the given commit was committed. If the given revision does not exist,

--- a/enterprise/internal/codeintel/gitserver/client.go
+++ b/enterprise/internal/codeintel/gitserver/client.go
@@ -42,15 +42,11 @@ func (c *Client) CommitExists(ctx context.Context, repositoryID int, commit stri
 	}})
 	defer endObservation(1, observation.Args{})
 
-	out, err := c.execGitCommand(ctx, repositoryID, "cat-file", "-t", commit)
-	if err == nil {
-		return true, nil
+	repo, err := c.repositoryIDToRepo(ctx, repositoryID)
+	if err != nil {
+		return false, err
 	}
-
-	if strings.Contains(out, "Not a valid object name") {
-		err = nil
-	}
-	return false, err
+	return git.CommitExists(ctx, repo, api.CommitID(commit))
 }
 
 // Head determines the tip commit of the default branch for the given repository. If no HEAD revision exists

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -289,6 +289,21 @@ func FirstEverCommit(ctx context.Context, repo api.RepoName) (*gitdomain.Commit,
 	return GetCommit(ctx, repo, id, ResolveRevisionOptions{NoEnsureRevision: true})
 }
 
+// CommitExists determines if the given commit exists in the given repository.
+func CommitExists(ctx context.Context, repo api.RepoName, id api.CommitID) (bool, error) {
+	cmd := gitserver.DefaultClient.Command("git", "cat-file", "-t", string(id))
+	cmd.Repo = repo
+
+	out, err := cmd.Output(ctx)
+	if err == nil {
+		return true, nil
+	}
+	if bytes.Contains(out, []byte("Not a valid object name")) {
+		err = nil
+	}
+	return false, err
+}
+
 const (
 	partsPerCommit = 10 // number of \x00-separated fields per commit
 

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -304,6 +304,25 @@ func CommitExists(ctx context.Context, repo api.RepoName, id api.CommitID) (bool
 	return false, err
 }
 
+// Head determines the tip commit of the default branch for the given repository.
+// If no HEAD revision exists for the given repository (which occurs with empty
+// repositories), a false-valued flag is returned along with a nil error and
+// empty revision.
+func Head(ctx context.Context, repo api.RepoName) (_ string, revisionExists bool, err error) {
+	cmd := gitserver.DefaultClient.Command("git", "rev-parse", "HEAD")
+	cmd.Repo = repo
+
+	out, err := cmd.Output(ctx)
+	if err != nil {
+		if errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
+			err = nil
+		}
+		return "", false, err
+	}
+
+	return string(out), true, nil
+}
+
 const (
 	partsPerCommit = 10 // number of \x00-separated fields per commit
 

--- a/internal/vcs/git/commits_test.go
+++ b/internal/vcs/git/commits_test.go
@@ -203,6 +203,28 @@ func TestRepository_FirstEverCommit(t *testing.T) {
 	}
 }
 
+func TestHead(t *testing.T) {
+	t.Parallel()
+
+	gitCommands := []string{
+		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit --allow-empty -m foo --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
+	}
+	repo := MakeGitRepository(t, gitCommands...)
+	ctx := context.Background()
+
+	head, exists, err := Head(ctx, repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantHead := "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"
+	if head != wantHead {
+		t.Fatalf("Want %q, got %q", wantHead, head)
+	}
+	if !exists {
+		t.Fatal("Should exist")
+	}
+}
+
 func TestRepository_Commits(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/internal/vcs/git/commits_test.go
+++ b/internal/vcs/git/commits_test.go
@@ -225,6 +225,33 @@ func TestHead(t *testing.T) {
 	}
 }
 
+func TestCommitExists(t *testing.T) {
+	t.Parallel()
+
+	gitCommands := []string{
+		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit --allow-empty -m foo --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
+	}
+	repo := MakeGitRepository(t, gitCommands...)
+	ctx := context.Background()
+
+	wantCommit := api.CommitID("ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8")
+	exists, err := CommitExists(ctx, repo, wantCommit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Fatal("Should exist")
+	}
+
+	exists, err = CommitExists(ctx, repo, NonExistentCommitID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Fatal("Should not exist")
+	}
+}
+
 func TestRepository_Commits(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()


### PR DESCRIPTION
Move CommitExists and Head out of the codeintel client and into the git package.

Part of https://github.com/sourcegraph/sourcegraph/issues/27909