### PR TITLE
Improve Percy Test Coverage

### DIFF
--- a/client/web/src/integration/insights/create-insights.test.ts
+++ b/client/web/src/integration/insights/create-insights.test.ts
@@ -7,6 +7,7 @@ import { emptyResponse } from '@sourcegraph/shared/src/testing/integration/graph
 import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
 
 import { createWebIntegrationTestContext, WebIntegrationTestContext } from '../context'
+import { percySnapshotWithVariants } from '../utils'
 
 import {
     INSIGHT_TYPES_MIGRATION_BULK_SEARCH,
@@ -102,6 +103,8 @@ describe('Code insight create insight page', () => {
                 otherThreshold: 0.03,
             },
         })
+
+        await percySnapshotWithVariants(driver.page, 'Code insights create new language usage insight')
     })
 
     it('should update user/org settings if search based insight has been created', async () => {

--- a/client/web/src/integration/org.test.ts
+++ b/client/web/src/integration/org.test.ts
@@ -165,6 +165,8 @@ describe('Organizations', () => {
                     lastID: settingsID,
                     contents: updatedSettings,
                 })
+
+                await percySnapshotWithVariants(driver.page, 'Organization settings page')
             })
         })
         describe('Members tab', () => {
@@ -214,6 +216,8 @@ describe('Organizations', () => {
                     2,
                     'Expected members list to show 2 members.'
                 )
+
+                await percySnapshotWithVariants(driver.page, 'Organization members list')
 
                 // Override for the fetch post-removal
                 testContext.overrideGraphQL({


### PR DESCRIPTION
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
## Description
To improve web application visual test coverage by adding percy snapshot tests to more core functionalities.

## Refs
[Gitstart Task](https://app.gitstart.com/tasks/27778)
[SG Issue](https://github.com/sourcegraph/sourcegraph/issues/28129)

## Pages to covered

- [x]  Organisation settings page[: link](https://k8s.sgdev.org/organizations/sourcegraph/settings)
- [ ] API Console: [Link](https://k8s.sgdev.org/api/console)
- [x] Set up new language usage insight: [Link](https://k8s.sgdev.org/insights/create/lang-stats)

## Success criteria
1. Important parts of the web application not covered with visual tests are identified. 
    - 4h estimate.
    - use https://k8s.sgdev.org/ to explore pages that are not covered.
    - use this [Percy report](https://percy.io/Sourcegraph/Sourcegraph/builds/14121239/unchanged/798203119?activeBrowserFamilySlug=chrome&activeViewMode=new&activeWidth=1920&subcategories=approved&viewLayout=side-by-side) to see which pages are already covered.
2. Integration tests rendering these parts of the app are identified.
    - 4h estimate.
    - find integration tests here `client/web/src/integration/**.test.ts`.
    - see documentation on how to run integration tests locally [here](https://docs.sourcegraph.com/dev/how-to/testing#client-integration-tests).
3. Percy screenshots are added to the integration tests identified in the previous step.
    - 2h estimate.
    - use `percySnapshotWithVariants` to make a Percy snapshot for a selected page in the integration test.