### PR TITLE
Improve Percy test coverage

### DIFF
--- a/client/web/src/integration/batches.test.ts
+++ b/client/web/src/integration/batches.test.ts
@@ -858,6 +858,7 @@ describe('Batches', () => {
             await driver.page.goto(driver.sourcegraphBaseUrl + '/users/alice/settings/batch-changes')
             // View settings page.
             await driver.page.waitForSelector('.test-batches-settings-page')
+            await percySnapshotWithVariants(driver.page, 'User batch changes settings page')
             // Wait for list to load.
             await driver.page.waitForSelector('.test-code-host-connection-node')
             // Check no credential is configured.

--- a/client/web/src/integration/notebook.test.ts
+++ b/client/web/src/integration/notebook.test.ts
@@ -11,6 +11,7 @@ import { WebIntegrationTestContext, createWebIntegrationTestContext } from './co
 import { commonWebGraphQlResults } from './graphQlResults'
 import { siteGQLID, siteID } from './jscontext'
 import { highlightFileResult, mixedSearchStreamEvents } from './streaming-search-mocks'
+import { percySnapshotWithVariants } from './utils'
 
 const viewerSettings: Partial<WebGraphQlOperations> = {
     ViewerSettings: () => ({
@@ -102,6 +103,7 @@ describe('Search Notebook', () => {
         await driver.page.waitForSelector('[data-block-id]', { visible: true })
         const blockIds = await getBlockIds()
         expect(blockIds).toHaveLength(2)
+        await percySnapshotWithVariants(driver.page, 'Search notebook')
     })
 
     it('Should move, duplicate, and delete blocks', async () => {
@@ -177,5 +179,6 @@ describe('Search Notebook', () => {
             queryResultContainerSelector
         )
         expect(isResultContainerVisible).toBeTruthy()
+        await percySnapshotWithVariants(driver.page, 'Search notebook with markdown and query blocks')
     })
 })

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -129,6 +129,7 @@ describe('Search', () => {
                 selector: '#monaco-query-input .suggest-widget.visible span',
             })
             expect(await getSearchFieldValue(driver)).toStrictEqual('-file:')
+            await percySnapshotWithVariants(driver.page, 'Search home page')
         })
     })
 


### PR DESCRIPTION
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->

## Description 
We have some web application pages covered with visual tests via Percy. But a lot of core functionality is not covered, and it reduces our confidence in shipping visual changes.

## Refs
[Gitstart Task](https://app.gitstart.com/tasks/27775)
[SG Issue](https://github.com/sourcegraph/sourcegraph/issues/28129)

Pages to cover:
- [x] Home / Search page
- [x] Search Notebook
- [x] User Batch Changes


## Success Criteria
1) Important parts of the web application not covered with visual tests are identified.
4h estimate.
use https://k8s.sgdev.org/ to explore pages that are not covered.
use this Percy report to see which pages are already covered.
2) Integration tests rendering these parts of the app are identified.
4h estimate.
find integration tests here client/web/src/integration/**.test.ts.
see documentation on how to run integration tests locally here.
3) Percy screenshots are added to the integration tests identified in the previous step.
2h estimate.
use percySnapshotWithVariants to make a Percy snapshot for a selected page in the integration test
