### PR TITLE
Improve Percy Test Coverage

### DIFF
--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -83,7 +83,7 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
     const showList = userHasCodeMonitors !== 'loading' && !isErrorLike(userHasCodeMonitors) && currentTab === 'list'
 
     return (
-        <div className="code-monitoring-page">
+        <div className="code-monitoring-page" data-testid="code-monitoring-page">
             <PageTitle title="Code Monitoring" />
             <PageHeader
                 path={[

--- a/client/web/src/integration/code-monitoring.test.ts
+++ b/client/web/src/integration/code-monitoring.test.ts
@@ -61,10 +61,51 @@ describe('Code monitoring', () => {
                     final: JSON.stringify({}),
                 },
             }),
+            ListUserCodeMonitors: () => ({
+                node: {
+                    __typename: 'User',
+                    monitors: {
+                        nodes: [
+                            {
+                                id: 'Q29kZU1vbml0b3I6Mg==',
+                                description: 'Test123',
+                                enabled: true,
+                                actions: {
+                                    nodes: [
+                                        {
+                                            enabled: true,
+                                            id: 'Q29kZU1vbml0b3JBY3Rpb25FbWFpbDoy',
+                                            recipients: {
+                                                nodes: [{ id: 'VXNlcjoyNDc=' }],
+                                            },
+                                        },
+                                    ],
+                                },
+                                trigger: {
+                                    id: 'Q29kZU1vbml0b3JUcmlnZ2VyUXVlcnk6Mg==',
+                                    query:
+                                        'type:diff repo:sourcegraph/sourcegraph after:\\"1 week ago\\" filtered  patternType:literal',
+                                },
+                            },
+                        ],
+                        __typename: 'MonitorConnection',
+                        pageInfo: { endCursor: null, hasNextPage: false },
+                        totalCount: 1,
+                    },
+                },
+            }),
         })
     })
     afterEachSaveScreenshotIfFailed(() => driver.page)
     afterEach(() => testContext?.dispose())
+
+    describe('Code monitoring', () => {
+        it('is styled correctly', async () => {
+            await driver.page.goto(driver.sourcegraphBaseUrl + '/code-monitoring')
+            await driver.page.waitForSelector('[data-testid="code-monitoring-page"]')
+            await percySnapshotWithVariants(driver.page, 'Code monitor list')
+        })
+    })
 
     describe('Code monitoring form advances sequentially', () => {
         it('validates trigger query input', async () => {

--- a/client/web/src/savedSearches/SavedSearchForm.tsx
+++ b/client/web/src/savedSearches/SavedSearchForm.tsx
@@ -79,7 +79,7 @@ export const SavedSearchForm: React.FunctionComponent<SavedSearchFormProps> = pr
     const { query, description, notify, notifySlack, slackWebhookURL } = values
 
     return (
-        <div className="saved-search-form">
+        <div className="saved-search-form" data-testid="saved-search-form">
             <PageHeader
                 path={[{ text: props.title }]}
                 headingElement="h2"

--- a/client/web/src/savedSearches/SavedSearchListPage.tsx
+++ b/client/web/src/savedSearches/SavedSearchListPage.tsx
@@ -136,7 +136,7 @@ export class SavedSearchListPage extends React.Component<Props, State> {
 
     public render(): JSX.Element | null {
         return (
-            <div className={styles.savedSearchListPage}>
+            <div className={styles.savedSearchListPage} data-testid="saved-searches-list-page">
                 <PageHeader
                     path={[{ text: 'Saved searches' }]}
                     headingElement="h2"


### PR DESCRIPTION
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
## Description 
We have some web application pages covered with visual tests via Percy. But a lot of core functionality is not covered, and it reduces our confidence in shipping visual changes.


## Refs
[Gitstart Task](https://app.gitstart.com/tasks/27779)
[SG Issue](https://github.com/sourcegraph/sourcegraph/issues/28129)

Pages to cover:
- [x]  Code monitoring homepage: [Link](https://k8s.sgdev.org/code-monitoring?visible=1)
- [x]  Saved searches list: [Link](https://k8s.sgdev.org/users/gitstart/searches)
- [x]  Create saved search: [Link](https://k8s.sgdev.org/users/gitstart/searches/add)

## Success Criteria
1) Important parts of the web application not covered with visual tests are identified.
4h estimate.
use https://k8s.sgdev.org/ to explore pages that are not covered.
use this Percy report to see which pages are already covered.
2) Integration tests rendering these parts of the app are identified.
4h estimate.
find integration tests here client/web/src/integration/**.test.ts.
see documentation on how to run integration tests locally here.
3) Percy screenshots are added to the integration tests identified in the previous step.
2h estimate.
use percySnapshotWithVariants to make a Percy snapshot for a selected page in the integration test

