### PR TITLE
Improve Percy Test Coverage

### DIFF
--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
@@ -52,7 +52,10 @@ export const IntroCreationPage: React.FunctionComponent<IntroCreationPageProps> 
             </div>
 
             <div className={classNames(styles.createIntroPageInsights, 'pb-5')}>
-                <section className={classNames(styles.createIntroPageInsightCard, 'card card-body p-3')}>
+                <section
+                    className={classNames(styles.createIntroPageInsightCard, 'card card-body p-3')}
+                    data-testid="create-search-insights"
+                >
                     <h3>Based on your search query</h3>
 
                     <p>
@@ -78,7 +81,10 @@ export const IntroCreationPage: React.FunctionComponent<IntroCreationPageProps> 
                     </div>
                 </section>
 
-                <section className={classNames(styles.createIntroPageInsightCard, 'card card-body p-3')}>
+                <section
+                    className={classNames(styles.createIntroPageInsightCard, 'card card-body p-3')}
+                    data-testid="create-lang-usage-insight"
+                >
                     <h3>Language usage</h3>
 
                     <p>Shows language usage in your repository by lines of code.</p>
@@ -101,7 +107,10 @@ export const IntroCreationPage: React.FunctionComponent<IntroCreationPageProps> 
                     </div>
                 </section>
 
-                <section className={classNames(styles.createIntroPageInsightCard, 'card card-body p-3')}>
+                <section
+                    className={classNames(styles.createIntroPageInsightCard, 'card card-body p-3')}
+                    data-testid="explore-extensions"
+                >
                     <h3>Based on Sourcegraph extensions</h3>
 
                     <p>

--- a/client/web/src/integration/insights/create-insights.test.ts
+++ b/client/web/src/integration/insights/create-insights.test.ts
@@ -7,6 +7,7 @@ import { emptyResponse } from '@sourcegraph/shared/src/testing/integration/graph
 import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
 
 import { createWebIntegrationTestContext, WebIntegrationTestContext } from '../context'
+import { percySnapshotWithVariants } from '../utils'
 
 import {
     INSIGHT_TYPES_MIGRATION_BULK_SEARCH,
@@ -35,6 +36,28 @@ describe('Code insight create insight page', () => {
 
     afterEachSaveScreenshotIfFailed(() => driver.page)
     afterEach(() => testContext?.dispose())
+    it('is styled correctly, with welcome popup', async () => {
+        await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/create')
+
+        // Waiting for all important part page be rendered.
+        await driver.page.waitForSelector('[data-testid="create-search-insights"]')
+        await driver.page.waitForSelector('[data-testid="create-lang-usage-insight"]')
+        await driver.page.waitForSelector('[data-testid="explore-extensions"]')
+
+        await percySnapshotWithVariants(driver.page, 'Create new insight page — Welcome popup')
+    })
+
+    it('is styled correctly, without welcome popup', async () => {
+        overrideGraphQLExtensions({ testContext })
+        await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/create')
+
+        // Waiting for all important part page be rendered.
+        await driver.page.waitForSelector('[data-testid="create-search-insights"]')
+        await driver.page.waitForSelector('[data-testid="create-lang-usage-insight"]')
+        await driver.page.waitForSelector('[data-testid="explore-extensions"]')
+
+        await percySnapshotWithVariants(driver.page, 'Create new insight page')
+    })
 
     it('should update user/org setting if code stats insight has been created', async () => {
         overrideGraphQLExtensions({
@@ -87,8 +110,12 @@ describe('Code insight create insight page', () => {
         // charts - pie chart
         await driver.page.waitForSelector('[data-testid="pie-chart-arc-element"]')
 
+        // To blur repository input
+        await driver.page.click('input[name="title"]')
         // Change insight title
         await driver.page.type('input[name="title"]', 'Test insight title')
+
+        await percySnapshotWithVariants(driver.page, 'Code insights create new language usage insight')
 
         const addToUserConfigRequest = await testContext.waitForGraphQLRequest(async () => {
             await driver.page.click('[data-testid="insight-save-button"]')

--- a/client/web/src/integration/org.test.ts
+++ b/client/web/src/integration/org.test.ts
@@ -165,6 +165,8 @@ describe('Organizations', () => {
                     lastID: settingsID,
                     contents: updatedSettings,
                 })
+
+                await percySnapshotWithVariants(driver.page, 'Organization settings page')
             })
         })
         describe('Members tab', () => {
@@ -214,6 +216,8 @@ describe('Organizations', () => {
                     2,
                     'Expected members list to show 2 members.'
                 )
+
+                await percySnapshotWithVariants(driver.page, 'Organization members list')
 
                 // Override for the fetch post-removal
                 testContext.overrideGraphQL({


### PR DESCRIPTION
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
## Description
To improve web application visual test coverage by adding percy snapshot tests to more core functionalities.

## Refs
[Gitstart Task](https://app.gitstart.com/tasks/27778)
[SG Issue](https://github.com/sourcegraph/sourcegraph/issues/28129)

## Pages to covered

- [x]  Organisation settings page[: link](https://k8s.sgdev.org/organizations/sourcegraph/settings)
- [ ] API Console: [Link](https://k8s.sgdev.org/api/console)
- [x] Set up new language usage insight: [Link](https://k8s.sgdev.org/insights/create/lang-stats)

## Success criteria
1. Important parts of the web application not covered with visual tests are identified. 
    - 4h estimate.
    - use https://k8s.sgdev.org/ to explore pages that are not covered.
    - use this [Percy report](https://percy.io/Sourcegraph/Sourcegraph/builds/14121239/unchanged/798203119?activeBrowserFamilySlug=chrome&activeViewMode=new&activeWidth=1920&subcategories=approved&viewLayout=side-by-side) to see which pages are already covered.
2. Integration tests rendering these parts of the app are identified.
    - 4h estimate.
    - find integration tests here `client/web/src/integration/**.test.ts`.
    - see documentation on how to run integration tests locally [here](https://docs.sourcegraph.com/dev/how-to/testing#client-integration-tests).
3. Percy screenshots are added to the integration tests identified in the previous step.
    - 2h estimate.
    - use `percySnapshotWithVariants` to make a Percy snapshot for a selected page in the integration test.