### PR TITLE
remove test for disabled notifications

### DIFF
--- a/dev/authtest/site_admin_test.go
+++ b/dev/authtest/site_admin_test.go
@@ -170,14 +170,6 @@ mutation {
 	}
 }`,
 			}, {
-				name: "sendSavedSearchTestNotification",
-				query: `
-mutation {
-	sendSavedSearchTestNotification(id: "U2F2ZWRTZWFyY2g6MQ==") {
-		alwaysNil
-	}
-}`,
-			}, {
 				name: "createAccessToken.ScopeSiteAdminSudo",
 				query: `
 mutation CreateAccessToken($userID: ID!) {


### PR DESCRIPTION
This is causing backend integration tests to fail. The thing it is testing is now explicitly disabled, and will be removed from the API in the near future. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
