### PR TITLE
Upgrade timescaledb to 2.5.0

### DIFF
--- a/docker-images/codeinsights-db/Dockerfile
+++ b/docker-images/codeinsights-db/Dockerfile
@@ -1,4 +1,4 @@
-FROM timescale/timescaledb:2.0.0-pg12-oss
+FROM timescale/timescaledb:2.5.0-pg12-oss
 
 # hadolint ignore=DL3017
 RUN apk -U upgrade && apk add --no-cache \  


### PR DESCRIPTION
This PR upgrades timescaledb in the codeinsights-db image to get rid of a pesky CVE. We are not affected by it but keeps showing up in Trivy scans.

This closes https://github.com/sourcegraph/security-issues/issues/180 and https://github.com/sourcegraph/sourcegraph/issues/27972.
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
