### PR TITLE
internal/search: send lang: predicates to Zoekt for precise matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Sourcegraph services now listen to SIGTERM signals. This allows smoother rollouts in kubernetes deployments. [#27958](https://github.com/sourcegraph/sourcegraph/pull/27958)
 - The sourcegraph-frontend ingress now uses the networking.k8s.io/v1 api. This adds support for k8s v1.22 and later, and deprecates support for versions older than v1.18.x [#4029](https://github.com/sourcegraph/deploy-sourcegraph/pull/4029)
+- Indexed queries with language filters now use file contents to recognize languages. For example, `lang:matlab` will no longer return an Objective-C `main.m`. [#28370](https://github.com/sourcegraph/sourcegraph/pull/28370)
 
 ### Fixed
 

--- a/go.mod
+++ b/go.mod
@@ -350,7 +350,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20211202173641-f40c58ef8631
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20211208200749-d86fb30b50ba
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20211110092431-863f5b1ee51b

--- a/go.sum
+++ b/go.sum
@@ -1779,8 +1779,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20211202173641-f40c58ef8631 h1:MccIhnGDhAZl1SucMR08ck4P5QALTGj26ISLf/nNb/k=
-github.com/sourcegraph/zoekt v0.0.0-20211202173641-f40c58ef8631/go.mod h1:x1Zva3SbvSL4wCQnQ93LGTpQrXjKp8r8vyd09l/xCBE=
+github.com/sourcegraph/zoekt v0.0.0-20211208200749-d86fb30b50ba h1:fUfnRqbpRu3mJj4kA5BG41FSC3iCF3/2sT+BqWC9RIk=
+github.com/sourcegraph/zoekt v0.0.0-20211208200749-d86fb30b50ba/go.mod h1:Sx/PuFfor3D2/B5yTV9TqhTW48+85dR5o2tWD8VsASk=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/internal/search/query_converter_test.go
+++ b/internal/search/query_converter_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hexops/autogold"
+
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 
 	zoekt "github.com/google/zoekt/query"
@@ -166,6 +167,15 @@ func TestQueryToZoektQuery(t *testing.T) {
 				FilePatternsReposMustExclude: []string{`\.java$`, `\.xml$`},
 			},
 			Query: `foo (type:repo file:\.go$) (type:repo file:\.yaml$) -(type:repo file:\.java$) -(type:repo file:\.xml$)`,
+		},
+		{
+			Name: "language gets passed as both file include and lang: predicate",
+			Type: TextRequest,
+			Pattern: &TextPatternInfo{
+				IncludePatterns: []string{`\.go$`},
+				Languages:       []string{"go"},
+			},
+			Query: `file:"\\.go(?m:$)" lang:Go`,
 		},
 	}
 	for _, tt := range cases {
@@ -439,4 +449,6 @@ func TestToTextPatternInfo(t *testing.T) {
 	autogold.Want("104", `{"Pattern":"","IsNegated":false,"IsRegExp":true,"IsStructuralPat":false,"CombyRule":"","IsWordMatch":false,"IsCaseSensitive":false,"FileMatchLimit":30,"Index":"yes","Select":[],"IncludePatterns":["deploy"],"ExcludePattern":"","FilePatternsReposMustInclude":null,"FilePatternsReposMustExclude":null,"PathPatternsAreCaseSensitive":false,"PatternMatchesContent":false,"PatternMatchesPath":false,"Languages":null}`).Equal(t, test(`repo:sourcegraph-typescript$ type:file file:deploy`))
 
 	autogold.Want("105", `{"Pattern":"(foo\\d).*?(bar\\*)","IsNegated":false,"IsRegExp":true,"IsStructuralPat":false,"CombyRule":"","IsWordMatch":false,"IsCaseSensitive":false,"FileMatchLimit":30,"Index":"yes","Select":[],"IncludePatterns":null,"ExcludePattern":"","FilePatternsReposMustInclude":null,"FilePatternsReposMustExclude":null,"PathPatternsAreCaseSensitive":false,"PatternMatchesContent":false,"PatternMatchesPath":false,"Languages":null}`).Equal(t, test(`foo\d "bar*" patterntype:regexp`))
+
+	autogold.Want("106", `{"Pattern":"","IsNegated":false,"IsRegExp":true,"IsStructuralPat":false,"CombyRule":"","IsWordMatch":false,"IsCaseSensitive":false,"FileMatchLimit":30,"Index":"yes","Select":[],"IncludePatterns":["\\.go$"],"ExcludePattern":"(\\.java$)|(\\.jav$)","FilePatternsReposMustInclude":null,"FilePatternsReposMustExclude":null,"PathPatternsAreCaseSensitive":false,"PatternMatchesContent":false,"PatternMatchesPath":false,"Languages":["go"]}`).Equal(t, test(`lang:go -lang:java`))
 }


### PR DESCRIPTION
Following a Zoekt upgrade to compute more precise file language mappings
using go-enry to disambiguate languages with overlapping extensions,
passing down an explicit lang: predicate will improve the precision of
searches.

Depends on sourcegraph/zoekt#214

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
