### PR TITLE
fix malformed log line

### DIFF
--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -340,10 +340,10 @@ func (c *V4Client) fetchGitHubVersion(ctx context.Context) (version *semver.Vers
 	v3Client := NewV3Client(c.apiURL, c.auth, c.httpClient)
 	v, err := v3Client.GetVersion(ctx)
 	if err != nil {
-		log15.Warn("Failed to fetch GitHub enterprise version", 
-			"method", "fetchGitHubVersion", 
-			"apiURL", c.apiURL, 
-			"err", err
+		log15.Warn("Failed to fetch GitHub enterprise version",
+			"method", "fetchGitHubVersion",
+			"apiURL", c.apiURL,
+			"err", err,
 		)
 		return
 	}

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -340,7 +340,11 @@ func (c *V4Client) fetchGitHubVersion(ctx context.Context) (version *semver.Vers
 	v3Client := NewV3Client(c.apiURL, c.auth, c.httpClient)
 	v, err := v3Client.GetVersion(ctx)
 	if err != nil {
-		log15.Warn("Failed to fetch GitHub enterprise version", "fetchGitHubVersion", "apiURL", c.apiURL, "err", err)
+		log15.Warn("Failed to fetch GitHub enterprise version", 
+			"method", "fetchGitHubVersion", 
+			"apiURL", c.apiURL, 
+			"err", err
+		)
 		return
 	}
 


### PR DESCRIPTION
The key/value params in the log must be in pairs, otherwise the log
package will fail. This is likely the cause of the panic being observed
locally.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
