### PR TITLE
Add Scoop installation option for Windows

### DIFF
--- a/doc/cli/quickstart.md
+++ b/doc/cli/quickstart.md
@@ -41,6 +41,12 @@ Invoke-WebRequest https://sourcegraph.com/.api/src-cli/src_windows_amd64.exe -Ou
 $env:Path += ';C:\Program Files\Sourcegraph'
 ```
 
+or via [Scoop](https://scoop.sh/)
+
+```powershell
+scoop install sourcegraph-cli
+```
+
 For other options, please refer to [the Windows specific `src` documentation](explanations/windows.md).
 
 ## Connect to Sourcegraph


### PR DESCRIPTION
SourceGraph CLI is now available from the Main bucket in Scoop.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
