### PR TITLE
[CLOUD-151] Instrument encryption cache

### DIFF
--- a/internal/encryption/cache/metrics.go
+++ b/internal/encryption/cache/metrics.go
@@ -37,7 +37,7 @@ var (
 	evictTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "src_encryption_cache_eviction_total",
-			Help: "Total number of cache evictions encryption/cache",
+			Help: "Total number of cache evictions in encryption/cache",
 		},
 		[]string{},
 	)

--- a/internal/encryption/cache/metrics.go
+++ b/internal/encryption/cache/metrics.go
@@ -1,0 +1,44 @@
+package cache
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	hitTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "src_encryption_cache_hit_total",
+			Help: "Total number of cache hits in encryption/cache",
+		},
+		[]string{},
+	)
+	missTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "src_encryption_cache_miss_total",
+			Help: "Total number of cache misses in encryption/cache",
+		},
+		[]string{},
+	)
+	loadSuccessTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "src_encryption_cache_load_success_total",
+			Help: "Total number of successful cache loads in encryption/cache",
+		},
+		[]string{},
+	)
+	loadErrorTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "src_encryption_cache_load_error_total",
+			Help: "Total number of failed cache loads in encryption/cache",
+		},
+		[]string{},
+	)
+	evictTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "src_encryption_cache_eviction_total",
+			Help: "Total number of cache evictions encryption/cache",
+		},
+		[]string{},
+	)
+)


### PR DESCRIPTION
Adds instrumentation to encryption/cache - should make it possible for us to decide if we need to tune its size (to reduce the number of KMS queries).

### Testing
Enable encryption and encryption cache locally by adding 
```
  "encryption.keys": { "cacheSize":2048, "enableCache":true, "externalServiceKey": {"keyname": "external","type": "mounted","filepath": "/Users/rafal/dev/dev-private/enc.key"}},
``` 
to site config and observing metrics in Prometheus.