### PR TITLE
codeintel: Move gitserverclient.RefsDescriptions into the git package

### DIFF
--- a/cmd/frontend/backend/repos_vcs.go
+++ b/cmd/frontend/backend/repos_vcs.go
@@ -16,8 +16,8 @@ import (
 // If no rev is specified, HEAD is used.
 // Error cases:
 // * Repo does not exist: gitdomain.RepoNotExistError
-// * Commit does not exist: git.RevisionNotFoundError
-// * Empty repository: git.RevisionNotFoundError
+// * Commit does not exist: gitdomain.RevisionNotFoundError
+// * Empty repository: gitdomain.RevisionNotFoundError
 // * The user does not have permission: errcode.IsNotFound
 // * Other unexpected errors.
 func (s *repos) ResolveRev(ctx context.Context, repo *types.Repo, rev string) (commitID api.CommitID, err error) {

--- a/enterprise/cmd/worker/internal/codeintel/commitgraph/iface.go
+++ b/enterprise/cmd/worker/internal/codeintel/commitgraph/iface.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/database/locker"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
 
 type DBStore interface {
@@ -14,7 +15,7 @@ type DBStore interface {
 		ctx context.Context,
 		repositoryID int,
 		graph *gitserver.CommitGraph,
-		refDescriptions map[string][]gitserver.RefDescription,
+		refDescriptions map[string][]gitdomain.RefDescription,
 		maxAgeForNonStaleBranches, maxAgeForNonStaleTags time.Duration,
 		dirtyToken int,
 		now time.Time,
@@ -27,6 +28,6 @@ type Locker interface {
 }
 
 type GitserverClient interface {
-	RefDescriptions(ctx context.Context, repositoryID int) (map[string][]gitserver.RefDescription, error)
+	RefDescriptions(ctx context.Context, repositoryID int) (map[string][]gitdomain.RefDescription, error)
 	CommitGraph(ctx context.Context, repositoryID int, options gitserver.CommitGraphOptions) (*gitserver.CommitGraph, error)
 }

--- a/enterprise/cmd/worker/internal/codeintel/commitgraph/mock_iface_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/commitgraph/mock_iface_test.go
@@ -9,6 +9,7 @@ import (
 
 	gitserver "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
 	locker "github.com/sourcegraph/sourcegraph/internal/database/locker"
+	gitdomain "github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
 
 // MockDBStore is a mock implementation of the DBStore interface (from the
@@ -32,7 +33,7 @@ type MockDBStore struct {
 func NewMockDBStore() *MockDBStore {
 	return &MockDBStore{
 		CalculateVisibleUploadsFunc: &DBStoreCalculateVisibleUploadsFunc{
-			defaultHook: func(context.Context, int, *gitserver.CommitGraph, map[string][]gitserver.RefDescription, time.Duration, time.Duration, int, time.Time) error {
+			defaultHook: func(context.Context, int, *gitserver.CommitGraph, map[string][]gitdomain.RefDescription, time.Duration, time.Duration, int, time.Time) error {
 				return nil
 			},
 		},
@@ -54,7 +55,7 @@ func NewMockDBStore() *MockDBStore {
 func NewStrictMockDBStore() *MockDBStore {
 	return &MockDBStore{
 		CalculateVisibleUploadsFunc: &DBStoreCalculateVisibleUploadsFunc{
-			defaultHook: func(context.Context, int, *gitserver.CommitGraph, map[string][]gitserver.RefDescription, time.Duration, time.Duration, int, time.Time) error {
+			defaultHook: func(context.Context, int, *gitserver.CommitGraph, map[string][]gitdomain.RefDescription, time.Duration, time.Duration, int, time.Time) error {
 				panic("unexpected invocation of MockDBStore.CalculateVisibleUploads")
 			},
 		},
@@ -91,15 +92,15 @@ func NewMockDBStoreFrom(i DBStore) *MockDBStore {
 // CalculateVisibleUploads method of the parent MockDBStore instance is
 // invoked.
 type DBStoreCalculateVisibleUploadsFunc struct {
-	defaultHook func(context.Context, int, *gitserver.CommitGraph, map[string][]gitserver.RefDescription, time.Duration, time.Duration, int, time.Time) error
-	hooks       []func(context.Context, int, *gitserver.CommitGraph, map[string][]gitserver.RefDescription, time.Duration, time.Duration, int, time.Time) error
+	defaultHook func(context.Context, int, *gitserver.CommitGraph, map[string][]gitdomain.RefDescription, time.Duration, time.Duration, int, time.Time) error
+	hooks       []func(context.Context, int, *gitserver.CommitGraph, map[string][]gitdomain.RefDescription, time.Duration, time.Duration, int, time.Time) error
 	history     []DBStoreCalculateVisibleUploadsFuncCall
 	mutex       sync.Mutex
 }
 
 // CalculateVisibleUploads delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockDBStore) CalculateVisibleUploads(v0 context.Context, v1 int, v2 *gitserver.CommitGraph, v3 map[string][]gitserver.RefDescription, v4 time.Duration, v5 time.Duration, v6 int, v7 time.Time) error {
+func (m *MockDBStore) CalculateVisibleUploads(v0 context.Context, v1 int, v2 *gitserver.CommitGraph, v3 map[string][]gitdomain.RefDescription, v4 time.Duration, v5 time.Duration, v6 int, v7 time.Time) error {
 	r0 := m.CalculateVisibleUploadsFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6, v7)
 	m.CalculateVisibleUploadsFunc.appendCall(DBStoreCalculateVisibleUploadsFuncCall{v0, v1, v2, v3, v4, v5, v6, v7, r0})
 	return r0
@@ -108,7 +109,7 @@ func (m *MockDBStore) CalculateVisibleUploads(v0 context.Context, v1 int, v2 *gi
 // SetDefaultHook sets function that is called when the
 // CalculateVisibleUploads method of the parent MockDBStore instance is
 // invoked and the hook queue is empty.
-func (f *DBStoreCalculateVisibleUploadsFunc) SetDefaultHook(hook func(context.Context, int, *gitserver.CommitGraph, map[string][]gitserver.RefDescription, time.Duration, time.Duration, int, time.Time) error) {
+func (f *DBStoreCalculateVisibleUploadsFunc) SetDefaultHook(hook func(context.Context, int, *gitserver.CommitGraph, map[string][]gitdomain.RefDescription, time.Duration, time.Duration, int, time.Time) error) {
 	f.defaultHook = hook
 }
 
@@ -116,7 +117,7 @@ func (f *DBStoreCalculateVisibleUploadsFunc) SetDefaultHook(hook func(context.Co
 // CalculateVisibleUploads method of the parent MockDBStore instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *DBStoreCalculateVisibleUploadsFunc) PushHook(hook func(context.Context, int, *gitserver.CommitGraph, map[string][]gitserver.RefDescription, time.Duration, time.Duration, int, time.Time) error) {
+func (f *DBStoreCalculateVisibleUploadsFunc) PushHook(hook func(context.Context, int, *gitserver.CommitGraph, map[string][]gitdomain.RefDescription, time.Duration, time.Duration, int, time.Time) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -125,7 +126,7 @@ func (f *DBStoreCalculateVisibleUploadsFunc) PushHook(hook func(context.Context,
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *DBStoreCalculateVisibleUploadsFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, int, *gitserver.CommitGraph, map[string][]gitserver.RefDescription, time.Duration, time.Duration, int, time.Time) error {
+	f.SetDefaultHook(func(context.Context, int, *gitserver.CommitGraph, map[string][]gitdomain.RefDescription, time.Duration, time.Duration, int, time.Time) error {
 		return r0
 	})
 }
@@ -133,12 +134,12 @@ func (f *DBStoreCalculateVisibleUploadsFunc) SetDefaultReturn(r0 error) {
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *DBStoreCalculateVisibleUploadsFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, int, *gitserver.CommitGraph, map[string][]gitserver.RefDescription, time.Duration, time.Duration, int, time.Time) error {
+	f.PushHook(func(context.Context, int, *gitserver.CommitGraph, map[string][]gitdomain.RefDescription, time.Duration, time.Duration, int, time.Time) error {
 		return r0
 	})
 }
 
-func (f *DBStoreCalculateVisibleUploadsFunc) nextHook() func(context.Context, int, *gitserver.CommitGraph, map[string][]gitserver.RefDescription, time.Duration, time.Duration, int, time.Time) error {
+func (f *DBStoreCalculateVisibleUploadsFunc) nextHook() func(context.Context, int, *gitserver.CommitGraph, map[string][]gitdomain.RefDescription, time.Duration, time.Duration, int, time.Time) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -183,7 +184,7 @@ type DBStoreCalculateVisibleUploadsFuncCall struct {
 	Arg2 *gitserver.CommitGraph
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 map[string][]gitserver.RefDescription
+	Arg3 map[string][]gitdomain.RefDescription
 	// Arg4 is the value of the 5th argument passed to this method
 	// invocation.
 	Arg4 time.Duration
@@ -455,7 +456,7 @@ func NewMockGitserverClient() *MockGitserverClient {
 			},
 		},
 		RefDescriptionsFunc: &GitserverClientRefDescriptionsFunc{
-			defaultHook: func(context.Context, int) (map[string][]gitserver.RefDescription, error) {
+			defaultHook: func(context.Context, int) (map[string][]gitdomain.RefDescription, error) {
 				return nil, nil
 			},
 		},
@@ -472,7 +473,7 @@ func NewStrictMockGitserverClient() *MockGitserverClient {
 			},
 		},
 		RefDescriptionsFunc: &GitserverClientRefDescriptionsFunc{
-			defaultHook: func(context.Context, int) (map[string][]gitserver.RefDescription, error) {
+			defaultHook: func(context.Context, int) (map[string][]gitdomain.RefDescription, error) {
 				panic("unexpected invocation of MockGitserverClient.RefDescriptions")
 			},
 		},
@@ -609,15 +610,15 @@ func (c GitserverClientCommitGraphFuncCall) Results() []interface{} {
 // RefDescriptions method of the parent MockGitserverClient instance is
 // invoked.
 type GitserverClientRefDescriptionsFunc struct {
-	defaultHook func(context.Context, int) (map[string][]gitserver.RefDescription, error)
-	hooks       []func(context.Context, int) (map[string][]gitserver.RefDescription, error)
+	defaultHook func(context.Context, int) (map[string][]gitdomain.RefDescription, error)
+	hooks       []func(context.Context, int) (map[string][]gitdomain.RefDescription, error)
 	history     []GitserverClientRefDescriptionsFuncCall
 	mutex       sync.Mutex
 }
 
 // RefDescriptions delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockGitserverClient) RefDescriptions(v0 context.Context, v1 int) (map[string][]gitserver.RefDescription, error) {
+func (m *MockGitserverClient) RefDescriptions(v0 context.Context, v1 int) (map[string][]gitdomain.RefDescription, error) {
 	r0, r1 := m.RefDescriptionsFunc.nextHook()(v0, v1)
 	m.RefDescriptionsFunc.appendCall(GitserverClientRefDescriptionsFuncCall{v0, v1, r0, r1})
 	return r0, r1
@@ -626,7 +627,7 @@ func (m *MockGitserverClient) RefDescriptions(v0 context.Context, v1 int) (map[s
 // SetDefaultHook sets function that is called when the RefDescriptions
 // method of the parent MockGitserverClient instance is invoked and the hook
 // queue is empty.
-func (f *GitserverClientRefDescriptionsFunc) SetDefaultHook(hook func(context.Context, int) (map[string][]gitserver.RefDescription, error)) {
+func (f *GitserverClientRefDescriptionsFunc) SetDefaultHook(hook func(context.Context, int) (map[string][]gitdomain.RefDescription, error)) {
 	f.defaultHook = hook
 }
 
@@ -634,7 +635,7 @@ func (f *GitserverClientRefDescriptionsFunc) SetDefaultHook(hook func(context.Co
 // RefDescriptions method of the parent MockGitserverClient instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *GitserverClientRefDescriptionsFunc) PushHook(hook func(context.Context, int) (map[string][]gitserver.RefDescription, error)) {
+func (f *GitserverClientRefDescriptionsFunc) PushHook(hook func(context.Context, int) (map[string][]gitdomain.RefDescription, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -642,21 +643,21 @@ func (f *GitserverClientRefDescriptionsFunc) PushHook(hook func(context.Context,
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *GitserverClientRefDescriptionsFunc) SetDefaultReturn(r0 map[string][]gitserver.RefDescription, r1 error) {
-	f.SetDefaultHook(func(context.Context, int) (map[string][]gitserver.RefDescription, error) {
+func (f *GitserverClientRefDescriptionsFunc) SetDefaultReturn(r0 map[string][]gitdomain.RefDescription, r1 error) {
+	f.SetDefaultHook(func(context.Context, int) (map[string][]gitdomain.RefDescription, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *GitserverClientRefDescriptionsFunc) PushReturn(r0 map[string][]gitserver.RefDescription, r1 error) {
-	f.PushHook(func(context.Context, int) (map[string][]gitserver.RefDescription, error) {
+func (f *GitserverClientRefDescriptionsFunc) PushReturn(r0 map[string][]gitdomain.RefDescription, r1 error) {
+	f.PushHook(func(context.Context, int) (map[string][]gitdomain.RefDescription, error) {
 		return r0, r1
 	})
 }
 
-func (f *GitserverClientRefDescriptionsFunc) nextHook() func(context.Context, int) (map[string][]gitserver.RefDescription, error) {
+func (f *GitserverClientRefDescriptionsFunc) nextHook() func(context.Context, int) (map[string][]gitdomain.RefDescription, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -698,7 +699,7 @@ type GitserverClientRefDescriptionsFuncCall struct {
 	Arg1 int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 map[string][]gitserver.RefDescription
+	Result0 map[string][]gitdomain.RefDescription
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error

--- a/enterprise/cmd/worker/internal/codeintel/commitgraph/updater_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/commitgraph/updater_test.go
@@ -5,9 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
-
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 

--- a/enterprise/cmd/worker/internal/codeintel/commitgraph/updater_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/commitgraph/updater_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -25,7 +27,7 @@ func TestUpdater(t *testing.T) {
 
 	mockGitserverClient := NewMockGitserverClient()
 	mockGitserverClient.CommitGraphFunc.SetDefaultReturn(graph, nil)
-	mockGitserverClient.RefDescriptionsFunc.SetDefaultReturn(map[string][]gitserver.RefDescription{
+	mockGitserverClient.RefDescriptionsFunc.SetDefaultReturn(map[string][]gitdomain.RefDescription{
 		"b": {{IsDefaultBranch: true}},
 	}, nil)
 
@@ -71,7 +73,7 @@ func TestUpdaterNoUploads(t *testing.T) {
 	mockLocker.LockFunc.SetDefaultReturn(true, func(err error) error { return err }, nil)
 
 	mockGitserverClient := NewMockGitserverClient()
-	mockGitserverClient.RefDescriptionsFunc.SetDefaultReturn(map[string][]gitserver.RefDescription{
+	mockGitserverClient.RefDescriptionsFunc.SetDefaultReturn(map[string][]gitdomain.RefDescription{
 		"b": {{IsDefaultBranch: true}},
 	}, nil)
 
@@ -104,7 +106,7 @@ func TestUpdaterLocked(t *testing.T) {
 	mockLocker.LockFunc.SetDefaultReturn(false, nil, nil)
 
 	mockGitserverClient := NewMockGitserverClient()
-	mockGitserverClient.RefDescriptionsFunc.SetDefaultReturn(map[string][]gitserver.RefDescription{
+	mockGitserverClient.RefDescriptionsFunc.SetDefaultReturn(map[string][]gitdomain.RefDescription{
 		"b": {{IsDefaultBranch: true}},
 	}, nil)
 

--- a/enterprise/internal/codeintel/gitserver/client.go
+++ b/enterprise/internal/codeintel/gitserver/client.go
@@ -215,22 +215,14 @@ func ParseCommitGraph(lines []string) *CommitGraph {
 // RefDescription describes a commit at the head of a branch or tag.
 type RefDescription struct {
 	Name            string
-	Type            RefType
+	Type            gitdomain.RefType
 	IsDefaultBranch bool
 	CreatedDate     time.Time
 }
 
-type RefType int
-
-const (
-	RefTypeUnknown RefType = iota
-	RefTypeBranch
-	RefTypeTag
-)
-
-var refPrefixes = map[string]RefType{
-	"refs/heads/": RefTypeBranch,
-	"refs/tags/":  RefTypeTag,
+var refPrefixes = map[string]gitdomain.RefType{
+	"refs/heads/": gitdomain.RefTypeBranch,
+	"refs/tags/":  gitdomain.RefTypeTag,
 }
 
 // RefDescriptions returns a map from commits to descriptions of the tip of each
@@ -279,7 +271,7 @@ func parseRefDescriptions(lines []string) (map[string][]RefDescription, error) {
 		isDefaultBranch := parts[2] == "*"
 
 		var name string
-		var refType RefType
+		var refType gitdomain.RefType
 		for prefix, typ := range refPrefixes {
 			if strings.HasPrefix(parts[1], prefix) {
 				name = parts[1][len(prefix):]
@@ -287,7 +279,7 @@ func parseRefDescriptions(lines []string) (map[string][]RefDescription, error) {
 				break
 			}
 		}
-		if refType == RefTypeUnknown {
+		if refType == gitdomain.RefTypeUnknown {
 			return nil, errors.Errorf(`unexpected output from git for-each-ref "%s"`, line)
 		}
 

--- a/enterprise/internal/codeintel/gitserver/client.go
+++ b/enterprise/internal/codeintel/gitserver/client.go
@@ -402,11 +402,6 @@ func (c *Client) ResolveRevision(ctx context.Context, repositoryID int, versionS
 	return commitID, nil
 }
 
-// execGitCommand executes a git command for the given repository by identifier.
-func (c *Client) execGitCommand(ctx context.Context, repositoryID int, args ...string) (string, error) {
-	return c.execResolveRevGitCommand(ctx, repositoryID, "", args...)
-}
-
 // execResolveRevGitCommand executes a git command for the given repository by identifier if the
 // given revision is resolvable prior to running the command.
 func (c *Client) execResolveRevGitCommand(ctx context.Context, repositoryID int, revision string, args ...string) (string, error) {

--- a/enterprise/internal/codeintel/gitserver/client_test.go
+++ b/enterprise/internal/codeintel/gitserver/client_test.go
@@ -2,11 +2,8 @@ package gitserver
 
 import (
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
-
-	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
 
 func TestParseCommitGraph(t *testing.T) {
@@ -116,96 +113,5 @@ func TestParseCommitGraphPartial(t *testing.T) {
 	}
 	if diff := cmp.Diff(expectedOrder, graph.Order()); diff != "" {
 		t.Errorf("unexpected commit order (-want +got):\n%s", diff)
-	}
-}
-
-func TestParseRefDescriptions(t *testing.T) {
-	refDescriptions, err := parseRefDescriptions([]string{
-		"66a7ac584740245fc523da443a3f540a52f8af72:refs/heads/bl/symbols: :2021-01-18T16:46:51-08:00",
-		"58537c06cf7ba8a562a3f5208fb7a8efbc971d0e:refs/heads/bl/symbols-2: :2021-02-24T06:21:20-08:00",
-		"a40716031ae97ee7c5cdf1dec913567a4a7c50c8:refs/heads/ef/wtf: :2021-02-10T10:50:08-06:00",
-		"e2e283fdaf6ea4a419cdbad142bbfd4b730080f8:refs/heads/garo/go-and-typescript-lsif-indexing: :2020-04-29T16:45:46+00:00",
-		"c485d92c3d2065041bf29b3fe0b55ffac7e66b2a:refs/heads/garo/index-specific-files: :2021-03-01T13:09:42-08:00",
-		"ce30aee6cc56f39d0ac6fee03c4c151c08a8cd2e:refs/heads/master:*:2021-06-16T11:51:09-07:00",
-		"ec5cfc8ab33370c698273b1a097af73ea289c92b:refs/heads/nsc/bump-go-version: :2021-03-12T22:33:17+00:00",
-		"22b2c4f734f62060cae69da856fe3854defdcc87:refs/heads/nsc/markupcontent: :2021-05-03T23:50:02+01:00",
-		"9df3358a18792fa9dbd40d506f2e0ad23fc11ee8:refs/heads/nsc/random: :2021-02-10T16:29:06+00:00",
-		"a02b85b63345a1406d7a19727f7a5472c976e053:refs/heads/sg/document-symbols: :2021-04-08T15:33:03-07:00",
-		"234b0a484519129b251164ecb0674ec27d154d2f:refs/heads/symbols: :2021-01-01T22:51:55-08:00",
-		"c165bfff52e9d4f87891bba497e3b70fea144d89:refs/tags/v0.10.0: :2020-08-04T08:23:30-05:00",
-		"f73ee8ed601efea74f3b734eeb073307e1615606:refs/tags/v0.5.1: :2020-04-16T16:06:21-04:00",
-		"6057f7ed8d331c82030c713b650fc8fd2c0c2347:refs/tags/v0.5.2: :2020-04-16T16:20:26-04:00",
-		"7886287b8758d1baf19cf7b8253856128369a2a7:refs/tags/v0.5.3: :2020-04-16T16:55:58-04:00",
-		"b69f89473bbcc04dc52cafaf6baa504e34791f5a:refs/tags/v0.6.0: :2020-04-20T12:10:49-04:00",
-		"172b7fcf8b8c49b37b231693433586c2bfd1619e:refs/tags/v0.7.0: :2020-04-20T12:37:36-04:00",
-		"5bc35c78fb5fb388891ca944cd12d85fd6dede95:refs/tags/v0.8.0: :2020-05-05T12:53:18-05:00",
-		"14faa49ef098df9488536ca3c9b26d79e6bec4d6:refs/tags/v0.9.0: :2020-07-14T14:26:40-05:00",
-		"0a82af8b6914d8c81326eee5f3a7e1d1106547f1:refs/tags/v1.0.0: :2020-08-19T19:33:39-05:00",
-		"262defb72b96261a7d56b000d438c5c7ec6d0f3e:refs/tags/v1.1.0: :2020-08-21T14:15:44-05:00",
-		"806b96eb544e7e632a617c26402eccee6d67faed:refs/tags/v1.1.1: :2020-08-21T16:02:35-05:00",
-		"5d8865d6feacb4fce3313cade2c61dc29c6271e6:refs/tags/v1.1.2: :2020-08-22T13:45:26-05:00",
-		"8c45a5635cf0a4968cc8c9dac2d61c388b53251e:refs/tags/v1.1.3: :2020-08-25T10:10:46-05:00",
-		"fc212da31ce157ef0795e934381509c5a50654f6:refs/tags/v1.1.4: :2020-08-26T14:02:47-05:00",
-		"4fd8b2c3522df32ffc8be983d42c3a504cc75fbc:refs/tags/v1.2.0: :2020-09-07T09:52:43-05:00",
-		"9741f54aa0f14be1103b00c89406393ea4d8a08a:refs/tags/v1.3.0: :2021-02-10T23:21:31+00:00",
-		"b358977103d2d66e2a3fc5f8081075c2834c4936:refs/tags/v1.3.1: :2021-02-24T20:16:45+00:00",
-		"2882ad236da4b649b4c1259d815bf1a378e3b92f:refs/tags/v1.4.0: :2021-05-13T10:41:02-05:00",
-		"340b84452286c18000afad9b140a32212a82840a:refs/tags/v1.5.0: :2021-05-20T18:41:41-05:00",
-	})
-	if err != nil {
-		t.Fatalf("unexpected error parsing ref descriptions: %s", err)
-	}
-
-	mustParseDate := func(s string) time.Time {
-		date, err := time.Parse(time.RFC3339, s)
-		if err != nil {
-			t.Fatalf("unexpected error parsing date string: %s", err)
-		}
-
-		return date
-	}
-
-	makeBranch := func(name, createdDate string, isDefaultBranch bool) gitdomain.RefDescription {
-		return gitdomain.RefDescription{Name: name, Type: gitdomain.RefTypeBranch, IsDefaultBranch: isDefaultBranch, CreatedDate: mustParseDate(createdDate)}
-	}
-
-	makeTag := func(name, createdDate string) gitdomain.RefDescription {
-		return gitdomain.RefDescription{Name: name, Type: gitdomain.RefTypeTag, IsDefaultBranch: false, CreatedDate: mustParseDate(createdDate)}
-	}
-
-	expectedRefDescriptions := map[string][]gitdomain.RefDescription{
-		"66a7ac584740245fc523da443a3f540a52f8af72": {makeBranch("bl/symbols", "2021-01-18T16:46:51-08:00", false)},
-		"58537c06cf7ba8a562a3f5208fb7a8efbc971d0e": {makeBranch("bl/symbols-2", "2021-02-24T06:21:20-08:00", false)},
-		"a40716031ae97ee7c5cdf1dec913567a4a7c50c8": {makeBranch("ef/wtf", "2021-02-10T10:50:08-06:00", false)},
-		"e2e283fdaf6ea4a419cdbad142bbfd4b730080f8": {makeBranch("garo/go-and-typescript-lsif-indexing", "2020-04-29T16:45:46+00:00", false)},
-		"c485d92c3d2065041bf29b3fe0b55ffac7e66b2a": {makeBranch("garo/index-specific-files", "2021-03-01T13:09:42-08:00", false)},
-		"ce30aee6cc56f39d0ac6fee03c4c151c08a8cd2e": {makeBranch("master", "2021-06-16T11:51:09-07:00", true)},
-		"ec5cfc8ab33370c698273b1a097af73ea289c92b": {makeBranch("nsc/bump-go-version", "2021-03-12T22:33:17+00:00", false)},
-		"22b2c4f734f62060cae69da856fe3854defdcc87": {makeBranch("nsc/markupcontent", "2021-05-03T23:50:02+01:00", false)},
-		"9df3358a18792fa9dbd40d506f2e0ad23fc11ee8": {makeBranch("nsc/random", "2021-02-10T16:29:06+00:00", false)},
-		"a02b85b63345a1406d7a19727f7a5472c976e053": {makeBranch("sg/document-symbols", "2021-04-08T15:33:03-07:00", false)},
-		"234b0a484519129b251164ecb0674ec27d154d2f": {makeBranch("symbols", "2021-01-01T22:51:55-08:00", false)},
-		"c165bfff52e9d4f87891bba497e3b70fea144d89": {makeTag("v0.10.0", "2020-08-04T08:23:30-05:00")},
-		"f73ee8ed601efea74f3b734eeb073307e1615606": {makeTag("v0.5.1", "2020-04-16T16:06:21-04:00")},
-		"6057f7ed8d331c82030c713b650fc8fd2c0c2347": {makeTag("v0.5.2", "2020-04-16T16:20:26-04:00")},
-		"7886287b8758d1baf19cf7b8253856128369a2a7": {makeTag("v0.5.3", "2020-04-16T16:55:58-04:00")},
-		"b69f89473bbcc04dc52cafaf6baa504e34791f5a": {makeTag("v0.6.0", "2020-04-20T12:10:49-04:00")},
-		"172b7fcf8b8c49b37b231693433586c2bfd1619e": {makeTag("v0.7.0", "2020-04-20T12:37:36-04:00")},
-		"5bc35c78fb5fb388891ca944cd12d85fd6dede95": {makeTag("v0.8.0", "2020-05-05T12:53:18-05:00")},
-		"14faa49ef098df9488536ca3c9b26d79e6bec4d6": {makeTag("v0.9.0", "2020-07-14T14:26:40-05:00")},
-		"0a82af8b6914d8c81326eee5f3a7e1d1106547f1": {makeTag("v1.0.0", "2020-08-19T19:33:39-05:00")},
-		"262defb72b96261a7d56b000d438c5c7ec6d0f3e": {makeTag("v1.1.0", "2020-08-21T14:15:44-05:00")},
-		"806b96eb544e7e632a617c26402eccee6d67faed": {makeTag("v1.1.1", "2020-08-21T16:02:35-05:00")},
-		"5d8865d6feacb4fce3313cade2c61dc29c6271e6": {makeTag("v1.1.2", "2020-08-22T13:45:26-05:00")},
-		"8c45a5635cf0a4968cc8c9dac2d61c388b53251e": {makeTag("v1.1.3", "2020-08-25T10:10:46-05:00")},
-		"fc212da31ce157ef0795e934381509c5a50654f6": {makeTag("v1.1.4", "2020-08-26T14:02:47-05:00")},
-		"4fd8b2c3522df32ffc8be983d42c3a504cc75fbc": {makeTag("v1.2.0", "2020-09-07T09:52:43-05:00")},
-		"9741f54aa0f14be1103b00c89406393ea4d8a08a": {makeTag("v1.3.0", "2021-02-10T23:21:31+00:00")},
-		"b358977103d2d66e2a3fc5f8081075c2834c4936": {makeTag("v1.3.1", "2021-02-24T20:16:45+00:00")},
-		"2882ad236da4b649b4c1259d815bf1a378e3b92f": {makeTag("v1.4.0", "2021-05-13T10:41:02-05:00")},
-		"340b84452286c18000afad9b140a32212a82840a": {makeTag("v1.5.0", "2021-05-20T18:41:41-05:00")},
-	}
-	if diff := cmp.Diff(expectedRefDescriptions, refDescriptions); diff != "" {
-		t.Errorf("unexpected ref descriptions (-want +got):\n%s", diff)
 	}
 }

--- a/enterprise/internal/codeintel/gitserver/client_test.go
+++ b/enterprise/internal/codeintel/gitserver/client_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
 
 func TestParseCommitGraph(t *testing.T) {
@@ -164,11 +166,11 @@ func TestParseRefDescriptions(t *testing.T) {
 	}
 
 	makeBranch := func(name, createdDate string, isDefaultBranch bool) RefDescription {
-		return RefDescription{Name: name, Type: RefTypeBranch, IsDefaultBranch: isDefaultBranch, CreatedDate: mustParseDate(createdDate)}
+		return RefDescription{Name: name, Type: gitdomain.RefTypeBranch, IsDefaultBranch: isDefaultBranch, CreatedDate: mustParseDate(createdDate)}
 	}
 
 	makeTag := func(name, createdDate string) RefDescription {
-		return RefDescription{Name: name, Type: RefTypeTag, IsDefaultBranch: false, CreatedDate: mustParseDate(createdDate)}
+		return RefDescription{Name: name, Type: gitdomain.RefTypeTag, IsDefaultBranch: false, CreatedDate: mustParseDate(createdDate)}
 	}
 
 	expectedRefDescriptions := map[string][]RefDescription{

--- a/enterprise/internal/codeintel/gitserver/client_test.go
+++ b/enterprise/internal/codeintel/gitserver/client_test.go
@@ -165,15 +165,15 @@ func TestParseRefDescriptions(t *testing.T) {
 		return date
 	}
 
-	makeBranch := func(name, createdDate string, isDefaultBranch bool) RefDescription {
-		return RefDescription{Name: name, Type: gitdomain.RefTypeBranch, IsDefaultBranch: isDefaultBranch, CreatedDate: mustParseDate(createdDate)}
+	makeBranch := func(name, createdDate string, isDefaultBranch bool) gitdomain.RefDescription {
+		return gitdomain.RefDescription{Name: name, Type: gitdomain.RefTypeBranch, IsDefaultBranch: isDefaultBranch, CreatedDate: mustParseDate(createdDate)}
 	}
 
-	makeTag := func(name, createdDate string) RefDescription {
-		return RefDescription{Name: name, Type: gitdomain.RefTypeTag, IsDefaultBranch: false, CreatedDate: mustParseDate(createdDate)}
+	makeTag := func(name, createdDate string) gitdomain.RefDescription {
+		return gitdomain.RefDescription{Name: name, Type: gitdomain.RefTypeTag, IsDefaultBranch: false, CreatedDate: mustParseDate(createdDate)}
 	}
 
-	expectedRefDescriptions := map[string][]RefDescription{
+	expectedRefDescriptions := map[string][]gitdomain.RefDescription{
 		"66a7ac584740245fc523da443a3f540a52f8af72": {makeBranch("bl/symbols", "2021-01-18T16:46:51-08:00", false)},
 		"58537c06cf7ba8a562a3f5208fb7a8efbc971d0e": {makeBranch("bl/symbols-2", "2021-02-24T06:21:20-08:00", false)},
 		"a40716031ae97ee7c5cdf1dec913567a4a7c50c8": {makeBranch("ef/wtf", "2021-02-10T10:50:08-06:00", false)},

--- a/enterprise/internal/codeintel/policies/iface.go
+++ b/enterprise/internal/codeintel/policies/iface.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
 
 type GitserverClient interface {
 	ResolveRevision(ctx context.Context, repositoryID int, versionString string) (api.CommitID, error)
 	CommitDate(ctx context.Context, repositoryID int, commit string) (string, time.Time, bool, error)
-	RefDescriptions(ctx context.Context, repositoryID int) (map[string][]gitserver.RefDescription, error)
+	RefDescriptions(ctx context.Context, repositoryID int) (map[string][]gitdomain.RefDescription, error)
 	CommitsUniqueToBranch(ctx context.Context, repositoryID int, branchName string, isDefaultBranch bool, maxAge *time.Time) (map[string]time.Time, error)
 }

--- a/enterprise/internal/codeintel/policies/matcher.go
+++ b/enterprise/internal/codeintel/policies/matcher.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/gobwas/glob"
 
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 )
 
@@ -134,7 +133,7 @@ type branchRequestMeta struct {
 
 // matchTaggedCommits determines if the given commit (described by the tag-type ref given description) matches any tag-type
 // policies. For each match, a commit/policy pair will be added to the given context.
-func (m *Matcher) matchTaggedCommits(context matcherContext, commit string, refDescription gitserver.RefDescription, now time.Time) {
+func (m *Matcher) matchTaggedCommits(context matcherContext, commit string, refDescription gitdomain.RefDescription, now time.Time) {
 	visitor := func(policy dbstore.ConfigurationPolicy) {
 		policyDuration, _ := m.extractor(policy)
 
@@ -152,7 +151,7 @@ func (m *Matcher) matchTaggedCommits(context matcherContext, commit string, refD
 // policies. For each match, a commit/policy pair will be added to the given context. This method also adds matches for the tip
 // of the default branch (if configured to do so), and adds bookkeeping metadata to the context's branchRequests field when a
 // matching policy's intermediate commits should be checked.
-func (m *Matcher) matchBranchHeads(context matcherContext, commit string, refDescription gitserver.RefDescription, now time.Time) {
+func (m *Matcher) matchBranchHeads(context matcherContext, commit string, refDescription gitdomain.RefDescription, now time.Time) {
 	if refDescription.IsDefaultBranch && m.includeTipOfDefaultBranch {
 		// Add a match with no associated policy for the tip of the default branch
 		context.commitMap[commit] = append(context.commitMap[commit], PolicyMatch{
@@ -265,7 +264,7 @@ func (m *Matcher) matchCommitPolicies(ctx context.Context, context matcherContex
 	return nil
 }
 
-func (m *Matcher) forEachMatchingPolicy(context matcherContext, refDescription gitserver.RefDescription, targetObjectType dbstore.GitObjectType, f func(policy dbstore.ConfigurationPolicy), now time.Time) {
+func (m *Matcher) forEachMatchingPolicy(context matcherContext, refDescription gitdomain.RefDescription, targetObjectType dbstore.GitObjectType, f func(policy dbstore.ConfigurationPolicy), now time.Time) {
 	for _, policy := range context.policies {
 		if policy.Type == targetObjectType && m.policyMatchesRefDescription(context, policy, refDescription, now) {
 			f(policy)
@@ -273,7 +272,7 @@ func (m *Matcher) forEachMatchingPolicy(context matcherContext, refDescription g
 	}
 }
 
-func (m *Matcher) policyMatchesRefDescription(context matcherContext, policy dbstore.ConfigurationPolicy, refDescription gitserver.RefDescription, now time.Time) bool {
+func (m *Matcher) policyMatchesRefDescription(context matcherContext, policy dbstore.ConfigurationPolicy, refDescription gitdomain.RefDescription, now time.Time) bool {
 	if !context.patterns[policy.Pattern].Match(refDescription.Name) {
 		// Name doesn't match policy's pattern
 		return false

--- a/enterprise/internal/codeintel/policies/matcher.go
+++ b/enterprise/internal/codeintel/policies/matcher.go
@@ -5,12 +5,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
-
 	"github.com/cockroachdb/errors"
 	"github.com/gobwas/glob"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
 
 type Matcher struct {

--- a/enterprise/internal/codeintel/policies/matcher.go
+++ b/enterprise/internal/codeintel/policies/matcher.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
+
 	"github.com/cockroachdb/errors"
 	"github.com/gobwas/glob"
 
@@ -80,11 +82,11 @@ func (m *Matcher) CommitsDescribedByPolicy(ctx context.Context, repositoryID int
 	for commit, refDescriptions := range refDescriptions {
 		for _, refDescription := range refDescriptions {
 			switch refDescription.Type {
-			case gitserver.RefTypeTag:
+			case gitdomain.RefTypeTag:
 				// Match tagged commits
 				m.matchTaggedCommits(context, commit, refDescription, now)
 
-			case gitserver.RefTypeBranch:
+			case gitdomain.RefTypeBranch:
 				// Match tips of branches
 				m.matchBranchHeads(context, commit, refDescription, now)
 			}

--- a/enterprise/internal/codeintel/policies/matcher_common_test.go
+++ b/enterprise/internal/codeintel/policies/matcher_common_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
 )
 
@@ -60,7 +62,7 @@ func testUploadExpirerMockGitserverClient(defaultBranchName string, now time.Tim
 		for branch, commit := range branchHeads {
 			refDescriptions[commit] = append(refDescriptions[commit], gitserver.RefDescription{
 				Name:            branch,
-				Type:            gitserver.RefTypeBranch,
+				Type:            gitdomain.RefTypeBranch,
 				IsDefaultBranch: branch == defaultBranchName,
 				CreatedDate:     createdAt[commit],
 			})
@@ -69,7 +71,7 @@ func testUploadExpirerMockGitserverClient(defaultBranchName string, now time.Tim
 		for tag, commit := range tagHeads {
 			refDescriptions[commit] = append(refDescriptions[commit], gitserver.RefDescription{
 				Name:        tag,
-				Type:        gitserver.RefTypeTag,
+				Type:        gitdomain.RefTypeTag,
 				CreatedDate: createdAt[commit],
 			})
 		}

--- a/enterprise/internal/codeintel/policies/matcher_common_test.go
+++ b/enterprise/internal/codeintel/policies/matcher_common_test.go
@@ -5,8 +5,6 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
-
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
 )
 
 func testUploadExpirerMockGitserverClient(defaultBranchName string, now time.Time) *MockGitserverClient {
@@ -57,10 +55,10 @@ func testUploadExpirerMockGitserverClient(defaultBranchName string, now time.Tim
 		return commit, commitDate, ok, nil
 	}
 
-	refDescriptions := func(ctx context.Context, repositoryID int) (map[string][]gitserver.RefDescription, error) {
-		refDescriptions := map[string][]gitserver.RefDescription{}
+	refDescriptions := func(ctx context.Context, repositoryID int) (map[string][]gitdomain.RefDescription, error) {
+		refDescriptions := map[string][]gitdomain.RefDescription{}
 		for branch, commit := range branchHeads {
-			refDescriptions[commit] = append(refDescriptions[commit], gitserver.RefDescription{
+			refDescriptions[commit] = append(refDescriptions[commit], gitdomain.RefDescription{
 				Name:            branch,
 				Type:            gitdomain.RefTypeBranch,
 				IsDefaultBranch: branch == defaultBranchName,
@@ -69,7 +67,7 @@ func testUploadExpirerMockGitserverClient(defaultBranchName string, now time.Tim
 		}
 
 		for tag, commit := range tagHeads {
-			refDescriptions[commit] = append(refDescriptions[commit], gitserver.RefDescription{
+			refDescriptions[commit] = append(refDescriptions[commit], gitdomain.RefDescription{
 				Name:        tag,
 				Type:        gitdomain.RefTypeTag,
 				CreatedDate: createdAt[commit],

--- a/enterprise/internal/codeintel/policies/mock_iface_test.go
+++ b/enterprise/internal/codeintel/policies/mock_iface_test.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	"time"
 
-	gitserver "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
 	api "github.com/sourcegraph/sourcegraph/internal/api"
+	gitdomain "github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
 
 // MockGitserverClient is a mock implementation of the GitserverClient
@@ -46,7 +46,7 @@ func NewMockGitserverClient() *MockGitserverClient {
 			},
 		},
 		RefDescriptionsFunc: &GitserverClientRefDescriptionsFunc{
-			defaultHook: func(context.Context, int) (map[string][]gitserver.RefDescription, error) {
+			defaultHook: func(context.Context, int) (map[string][]gitdomain.RefDescription, error) {
 				return nil, nil
 			},
 		},
@@ -73,7 +73,7 @@ func NewStrictMockGitserverClient() *MockGitserverClient {
 			},
 		},
 		RefDescriptionsFunc: &GitserverClientRefDescriptionsFunc{
-			defaultHook: func(context.Context, int) (map[string][]gitserver.RefDescription, error) {
+			defaultHook: func(context.Context, int) (map[string][]gitdomain.RefDescription, error) {
 				panic("unexpected invocation of MockGitserverClient.RefDescriptions")
 			},
 		},
@@ -349,15 +349,15 @@ func (c GitserverClientCommitsUniqueToBranchFuncCall) Results() []interface{} {
 // RefDescriptions method of the parent MockGitserverClient instance is
 // invoked.
 type GitserverClientRefDescriptionsFunc struct {
-	defaultHook func(context.Context, int) (map[string][]gitserver.RefDescription, error)
-	hooks       []func(context.Context, int) (map[string][]gitserver.RefDescription, error)
+	defaultHook func(context.Context, int) (map[string][]gitdomain.RefDescription, error)
+	hooks       []func(context.Context, int) (map[string][]gitdomain.RefDescription, error)
 	history     []GitserverClientRefDescriptionsFuncCall
 	mutex       sync.Mutex
 }
 
 // RefDescriptions delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockGitserverClient) RefDescriptions(v0 context.Context, v1 int) (map[string][]gitserver.RefDescription, error) {
+func (m *MockGitserverClient) RefDescriptions(v0 context.Context, v1 int) (map[string][]gitdomain.RefDescription, error) {
 	r0, r1 := m.RefDescriptionsFunc.nextHook()(v0, v1)
 	m.RefDescriptionsFunc.appendCall(GitserverClientRefDescriptionsFuncCall{v0, v1, r0, r1})
 	return r0, r1
@@ -366,7 +366,7 @@ func (m *MockGitserverClient) RefDescriptions(v0 context.Context, v1 int) (map[s
 // SetDefaultHook sets function that is called when the RefDescriptions
 // method of the parent MockGitserverClient instance is invoked and the hook
 // queue is empty.
-func (f *GitserverClientRefDescriptionsFunc) SetDefaultHook(hook func(context.Context, int) (map[string][]gitserver.RefDescription, error)) {
+func (f *GitserverClientRefDescriptionsFunc) SetDefaultHook(hook func(context.Context, int) (map[string][]gitdomain.RefDescription, error)) {
 	f.defaultHook = hook
 }
 
@@ -374,7 +374,7 @@ func (f *GitserverClientRefDescriptionsFunc) SetDefaultHook(hook func(context.Co
 // RefDescriptions method of the parent MockGitserverClient instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *GitserverClientRefDescriptionsFunc) PushHook(hook func(context.Context, int) (map[string][]gitserver.RefDescription, error)) {
+func (f *GitserverClientRefDescriptionsFunc) PushHook(hook func(context.Context, int) (map[string][]gitdomain.RefDescription, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -382,21 +382,21 @@ func (f *GitserverClientRefDescriptionsFunc) PushHook(hook func(context.Context,
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *GitserverClientRefDescriptionsFunc) SetDefaultReturn(r0 map[string][]gitserver.RefDescription, r1 error) {
-	f.SetDefaultHook(func(context.Context, int) (map[string][]gitserver.RefDescription, error) {
+func (f *GitserverClientRefDescriptionsFunc) SetDefaultReturn(r0 map[string][]gitdomain.RefDescription, r1 error) {
+	f.SetDefaultHook(func(context.Context, int) (map[string][]gitdomain.RefDescription, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *GitserverClientRefDescriptionsFunc) PushReturn(r0 map[string][]gitserver.RefDescription, r1 error) {
-	f.PushHook(func(context.Context, int) (map[string][]gitserver.RefDescription, error) {
+func (f *GitserverClientRefDescriptionsFunc) PushReturn(r0 map[string][]gitdomain.RefDescription, r1 error) {
+	f.PushHook(func(context.Context, int) (map[string][]gitdomain.RefDescription, error) {
 		return r0, r1
 	})
 }
 
-func (f *GitserverClientRefDescriptionsFunc) nextHook() func(context.Context, int) (map[string][]gitserver.RefDescription, error) {
+func (f *GitserverClientRefDescriptionsFunc) nextHook() func(context.Context, int) (map[string][]gitdomain.RefDescription, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -438,7 +438,7 @@ type GitserverClientRefDescriptionsFuncCall struct {
 	Arg1 int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 map[string][]gitserver.RefDescription
+	Result0 map[string][]gitdomain.RefDescription
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error

--- a/enterprise/internal/codeintel/stores/dbstore/commits.go
+++ b/enterprise/internal/codeintel/stores/dbstore/commits.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
+
 	"github.com/keegancsmith/sqlf"
 	"github.com/opentracing/opentracing-go/log"
 
@@ -789,9 +791,9 @@ func sanitizeCommitInput(
 	maxAgeForNonStaleBranches time.Duration,
 	maxAgeForNonStaleTags time.Duration,
 ) *sanitizedCommitInput {
-	maxAges := map[gitserver.RefType]time.Duration{
-		gitserver.RefTypeBranch: maxAgeForNonStaleBranches,
-		gitserver.RefTypeTag:    maxAgeForNonStaleTags,
+	maxAges := map[gitdomain.RefType]time.Duration{
+		gitdomain.RefTypeBranch: maxAgeForNonStaleBranches,
+		gitdomain.RefTypeTag:    maxAgeForNonStaleTags,
 	}
 
 	nearestUploadsRowValues := make(chan []interface{})

--- a/enterprise/internal/codeintel/stores/dbstore/commits.go
+++ b/enterprise/internal/codeintel/stores/dbstore/commits.go
@@ -259,7 +259,7 @@ func (s *Store) CalculateVisibleUploads(
 	ctx context.Context,
 	repositoryID int,
 	commitGraph *gitserver.CommitGraph,
-	refDescriptions map[string][]gitserver.RefDescription,
+	refDescriptions map[string][]gitdomain.RefDescription,
 	maxAgeForNonStaleBranches time.Duration,
 	maxAgeForNonStaleTags time.Duration,
 	dirtyToken int,
@@ -787,7 +787,7 @@ type sanitizedCommitInput struct {
 func sanitizeCommitInput(
 	ctx context.Context,
 	graph *commitgraph.Graph,
-	refDescriptions map[string][]gitserver.RefDescription,
+	refDescriptions map[string][]gitdomain.RefDescription,
 	maxAgeForNonStaleBranches time.Duration,
 	maxAgeForNonStaleTags time.Duration,
 ) *sanitizedCommitInput {

--- a/enterprise/internal/codeintel/stores/dbstore/commits_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/commits_test.go
@@ -14,14 +14,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/commitgraph"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
 
 func TestHasRepository(t *testing.T) {

--- a/enterprise/internal/codeintel/stores/dbstore/commits_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/commits_test.go
@@ -220,7 +220,7 @@ func TestCalculateVisibleUploads(t *testing.T) {
 		strings.Join([]string{makeCommit(1)}, " "),
 	})
 
-	refDescriptions := map[string][]gitserver.RefDescription{
+	refDescriptions := map[string][]gitdomain.RefDescription{
 		makeCommit(8): {{IsDefaultBranch: true}},
 	}
 
@@ -278,7 +278,7 @@ func TestCalculateVisibleUploadsAlternateCommitGraph(t *testing.T) {
 		strings.Join([]string{makeCommit(1)}, " "),
 	})
 
-	refDescriptions := map[string][]gitserver.RefDescription{
+	refDescriptions := map[string][]gitdomain.RefDescription{
 		makeCommit(3): {{IsDefaultBranch: true}},
 	}
 
@@ -321,7 +321,7 @@ func TestCalculateVisibleUploadsDistinctRoots(t *testing.T) {
 		strings.Join([]string{makeCommit(1)}, " "),
 	})
 
-	refDescriptions := map[string][]gitserver.RefDescription{
+	refDescriptions := map[string][]gitdomain.RefDescription{
 		makeCommit(2): {{IsDefaultBranch: true}},
 	}
 
@@ -390,7 +390,7 @@ func TestCalculateVisibleUploadsOverlappingRoots(t *testing.T) {
 		strings.Join([]string{makeCommit(1)}, " "),
 	})
 
-	refDescriptions := map[string][]gitserver.RefDescription{
+	refDescriptions := map[string][]gitdomain.RefDescription{
 		makeCommit(6): {{IsDefaultBranch: true}},
 	}
 
@@ -446,7 +446,7 @@ func TestCalculateVisibleUploadsIndexerName(t *testing.T) {
 		strings.Join([]string{makeCommit(1)}, " "),
 	})
 
-	refDescriptions := map[string][]gitserver.RefDescription{
+	refDescriptions := map[string][]gitdomain.RefDescription{
 		makeCommit(5): {{IsDefaultBranch: true}},
 	}
 
@@ -490,7 +490,7 @@ func TestCalculateVisibleUploadsResetsDirtyFlag(t *testing.T) {
 		strings.Join([]string{makeCommit(1)}, " "),
 	})
 
-	refDescriptions := map[string][]gitserver.RefDescription{
+	refDescriptions := map[string][]gitdomain.RefDescription{
 		makeCommit(3): {{IsDefaultBranch: true}},
 	}
 
@@ -585,7 +585,7 @@ func TestCalculateVisibleUploadsNonDefaultBranches(t *testing.T) {
 	t1 := time.Now().Add(-time.Minute * 90) // > 1 hr
 	t2 := time.Now().Add(-time.Minute * 30) // < 1 hr
 
-	refDescriptions := map[string][]gitserver.RefDescription{
+	refDescriptions := map[string][]gitdomain.RefDescription{
 		// stale
 		makeCommit(2): {{Name: "v1", Type: gitdomain.RefTypeTag, CreatedDate: t1}},
 		makeCommit(9): {{Name: "feat1", Type: gitdomain.RefTypeBranch, CreatedDate: t1}},
@@ -694,7 +694,7 @@ func TestCalculateVisibleUploadsNonDefaultBranchesWithCustomRetentionConfigurati
 	t1 := time.Now().Add(-time.Minute * 90) // > 1 hr
 	t2 := time.Now().Add(-time.Minute * 30) // < 1 hr
 
-	refDescriptions := map[string][]gitserver.RefDescription{
+	refDescriptions := map[string][]gitdomain.RefDescription{
 		// stale
 		makeCommit(2): {{Name: "v1", Type: gitdomain.RefTypeTag, CreatedDate: t1}},
 		makeCommit(9): {{Name: "feat1", Type: gitdomain.RefTypeBranch, CreatedDate: t1}},
@@ -799,7 +799,7 @@ func BenchmarkCalculateVisibleUploads(b *testing.B) {
 		b.Fatalf("unexpected error reading benchmark commit graph: %s", err)
 	}
 
-	refDescriptions := map[string][]gitserver.RefDescription{
+	refDescriptions := map[string][]gitdomain.RefDescription{
 		makeCommit(3): {{IsDefaultBranch: true}},
 	}
 

--- a/enterprise/internal/codeintel/stores/dbstore/commits_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/commits_test.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/keegancsmith/sqlf"
 
@@ -585,14 +587,14 @@ func TestCalculateVisibleUploadsNonDefaultBranches(t *testing.T) {
 
 	refDescriptions := map[string][]gitserver.RefDescription{
 		// stale
-		makeCommit(2): {{Name: "v1", Type: gitserver.RefTypeTag, CreatedDate: t1}},
-		makeCommit(9): {{Name: "feat1", Type: gitserver.RefTypeBranch, CreatedDate: t1}},
+		makeCommit(2): {{Name: "v1", Type: gitdomain.RefTypeTag, CreatedDate: t1}},
+		makeCommit(9): {{Name: "feat1", Type: gitdomain.RefTypeBranch, CreatedDate: t1}},
 
 		// fresh
-		makeCommit(4):  {{Name: "v2", Type: gitserver.RefTypeTag, CreatedDate: t2}},
-		makeCommit(5):  {{Name: "v3", Type: gitserver.RefTypeTag, CreatedDate: t2}},
-		makeCommit(7):  {{Name: "main", Type: gitserver.RefTypeBranch, IsDefaultBranch: true, CreatedDate: t2}},
-		makeCommit(12): {{Name: "feat2", Type: gitserver.RefTypeBranch, CreatedDate: t2}},
+		makeCommit(4):  {{Name: "v2", Type: gitdomain.RefTypeTag, CreatedDate: t2}},
+		makeCommit(5):  {{Name: "v3", Type: gitdomain.RefTypeTag, CreatedDate: t2}},
+		makeCommit(7):  {{Name: "main", Type: gitdomain.RefTypeBranch, IsDefaultBranch: true, CreatedDate: t2}},
+		makeCommit(12): {{Name: "feat2", Type: gitdomain.RefTypeBranch, CreatedDate: t2}},
 	}
 
 	if err := store.CalculateVisibleUploads(context.Background(), 50, graph, refDescriptions, time.Hour, time.Hour, 0, time.Time{}); err != nil {
@@ -694,14 +696,14 @@ func TestCalculateVisibleUploadsNonDefaultBranchesWithCustomRetentionConfigurati
 
 	refDescriptions := map[string][]gitserver.RefDescription{
 		// stale
-		makeCommit(2): {{Name: "v1", Type: gitserver.RefTypeTag, CreatedDate: t1}},
-		makeCommit(9): {{Name: "feat1", Type: gitserver.RefTypeBranch, CreatedDate: t1}},
+		makeCommit(2): {{Name: "v1", Type: gitdomain.RefTypeTag, CreatedDate: t1}},
+		makeCommit(9): {{Name: "feat1", Type: gitdomain.RefTypeBranch, CreatedDate: t1}},
 
 		// fresh
-		makeCommit(4):  {{Name: "v2", Type: gitserver.RefTypeTag, CreatedDate: t2}},
-		makeCommit(5):  {{Name: "v3", Type: gitserver.RefTypeTag, CreatedDate: t2}},
-		makeCommit(7):  {{Name: "main", Type: gitserver.RefTypeBranch, IsDefaultBranch: true, CreatedDate: t2}},
-		makeCommit(12): {{Name: "feat2", Type: gitserver.RefTypeBranch, CreatedDate: t2}},
+		makeCommit(4):  {{Name: "v2", Type: gitdomain.RefTypeTag, CreatedDate: t2}},
+		makeCommit(5):  {{Name: "v3", Type: gitdomain.RefTypeTag, CreatedDate: t2}},
+		makeCommit(7):  {{Name: "main", Type: gitdomain.RefTypeBranch, IsDefaultBranch: true, CreatedDate: t2}},
+		makeCommit(12): {{Name: "feat2", Type: gitdomain.RefTypeBranch, CreatedDate: t2}},
 	}
 
 	if err := store.CalculateVisibleUploads(context.Background(), 50, graph, refDescriptions, time.Second, time.Second, 0, time.Time{}); err != nil {

--- a/internal/gitserver/gitdomain/common.go
+++ b/internal/gitserver/gitdomain/common.go
@@ -95,3 +95,11 @@ const (
 	RefTypeBranch
 	RefTypeTag
 )
+
+// RefDescription describes a commit at the head of a branch or tag.
+type RefDescription struct {
+	Name            string
+	Type            RefType
+	IsDefaultBranch bool
+	CreatedDate     time.Time
+}

--- a/internal/gitserver/gitdomain/common.go
+++ b/internal/gitserver/gitdomain/common.go
@@ -87,3 +87,11 @@ type Signature struct {
 	Email string    `json:"Email,omitempty"`
 	Date  time.Time `json:"Date"`
 }
+
+type RefType int
+
+const (
+	RefTypeUnknown RefType = iota
+	RefTypeBranch
+	RefTypeTag
+)

--- a/internal/vcs/git/commits_test.go
+++ b/internal/vcs/git/commits_test.go
@@ -646,3 +646,94 @@ func TestParseBranchesContaining(t *testing.T) {
 		t.Errorf("unexpected names (-want +got):\n%s", diff)
 	}
 }
+
+func TestParseRefDescriptions(t *testing.T) {
+	refDescriptions, err := parseRefDescriptions([]string{
+		"66a7ac584740245fc523da443a3f540a52f8af72:refs/heads/bl/symbols: :2021-01-18T16:46:51-08:00",
+		"58537c06cf7ba8a562a3f5208fb7a8efbc971d0e:refs/heads/bl/symbols-2: :2021-02-24T06:21:20-08:00",
+		"a40716031ae97ee7c5cdf1dec913567a4a7c50c8:refs/heads/ef/wtf: :2021-02-10T10:50:08-06:00",
+		"e2e283fdaf6ea4a419cdbad142bbfd4b730080f8:refs/heads/garo/go-and-typescript-lsif-indexing: :2020-04-29T16:45:46+00:00",
+		"c485d92c3d2065041bf29b3fe0b55ffac7e66b2a:refs/heads/garo/index-specific-files: :2021-03-01T13:09:42-08:00",
+		"ce30aee6cc56f39d0ac6fee03c4c151c08a8cd2e:refs/heads/master:*:2021-06-16T11:51:09-07:00",
+		"ec5cfc8ab33370c698273b1a097af73ea289c92b:refs/heads/nsc/bump-go-version: :2021-03-12T22:33:17+00:00",
+		"22b2c4f734f62060cae69da856fe3854defdcc87:refs/heads/nsc/markupcontent: :2021-05-03T23:50:02+01:00",
+		"9df3358a18792fa9dbd40d506f2e0ad23fc11ee8:refs/heads/nsc/random: :2021-02-10T16:29:06+00:00",
+		"a02b85b63345a1406d7a19727f7a5472c976e053:refs/heads/sg/document-symbols: :2021-04-08T15:33:03-07:00",
+		"234b0a484519129b251164ecb0674ec27d154d2f:refs/heads/symbols: :2021-01-01T22:51:55-08:00",
+		"c165bfff52e9d4f87891bba497e3b70fea144d89:refs/tags/v0.10.0: :2020-08-04T08:23:30-05:00",
+		"f73ee8ed601efea74f3b734eeb073307e1615606:refs/tags/v0.5.1: :2020-04-16T16:06:21-04:00",
+		"6057f7ed8d331c82030c713b650fc8fd2c0c2347:refs/tags/v0.5.2: :2020-04-16T16:20:26-04:00",
+		"7886287b8758d1baf19cf7b8253856128369a2a7:refs/tags/v0.5.3: :2020-04-16T16:55:58-04:00",
+		"b69f89473bbcc04dc52cafaf6baa504e34791f5a:refs/tags/v0.6.0: :2020-04-20T12:10:49-04:00",
+		"172b7fcf8b8c49b37b231693433586c2bfd1619e:refs/tags/v0.7.0: :2020-04-20T12:37:36-04:00",
+		"5bc35c78fb5fb388891ca944cd12d85fd6dede95:refs/tags/v0.8.0: :2020-05-05T12:53:18-05:00",
+		"14faa49ef098df9488536ca3c9b26d79e6bec4d6:refs/tags/v0.9.0: :2020-07-14T14:26:40-05:00",
+		"0a82af8b6914d8c81326eee5f3a7e1d1106547f1:refs/tags/v1.0.0: :2020-08-19T19:33:39-05:00",
+		"262defb72b96261a7d56b000d438c5c7ec6d0f3e:refs/tags/v1.1.0: :2020-08-21T14:15:44-05:00",
+		"806b96eb544e7e632a617c26402eccee6d67faed:refs/tags/v1.1.1: :2020-08-21T16:02:35-05:00",
+		"5d8865d6feacb4fce3313cade2c61dc29c6271e6:refs/tags/v1.1.2: :2020-08-22T13:45:26-05:00",
+		"8c45a5635cf0a4968cc8c9dac2d61c388b53251e:refs/tags/v1.1.3: :2020-08-25T10:10:46-05:00",
+		"fc212da31ce157ef0795e934381509c5a50654f6:refs/tags/v1.1.4: :2020-08-26T14:02:47-05:00",
+		"4fd8b2c3522df32ffc8be983d42c3a504cc75fbc:refs/tags/v1.2.0: :2020-09-07T09:52:43-05:00",
+		"9741f54aa0f14be1103b00c89406393ea4d8a08a:refs/tags/v1.3.0: :2021-02-10T23:21:31+00:00",
+		"b358977103d2d66e2a3fc5f8081075c2834c4936:refs/tags/v1.3.1: :2021-02-24T20:16:45+00:00",
+		"2882ad236da4b649b4c1259d815bf1a378e3b92f:refs/tags/v1.4.0: :2021-05-13T10:41:02-05:00",
+		"340b84452286c18000afad9b140a32212a82840a:refs/tags/v1.5.0: :2021-05-20T18:41:41-05:00",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error parsing ref descriptions: %s", err)
+	}
+
+	mustParseDate := func(s string) time.Time {
+		date, err := time.Parse(time.RFC3339, s)
+		if err != nil {
+			t.Fatalf("unexpected error parsing date string: %s", err)
+		}
+
+		return date
+	}
+
+	makeBranch := func(name, createdDate string, isDefaultBranch bool) gitdomain.RefDescription {
+		return gitdomain.RefDescription{Name: name, Type: gitdomain.RefTypeBranch, IsDefaultBranch: isDefaultBranch, CreatedDate: mustParseDate(createdDate)}
+	}
+
+	makeTag := func(name, createdDate string) gitdomain.RefDescription {
+		return gitdomain.RefDescription{Name: name, Type: gitdomain.RefTypeTag, IsDefaultBranch: false, CreatedDate: mustParseDate(createdDate)}
+	}
+
+	expectedRefDescriptions := map[string][]gitdomain.RefDescription{
+		"66a7ac584740245fc523da443a3f540a52f8af72": {makeBranch("bl/symbols", "2021-01-18T16:46:51-08:00", false)},
+		"58537c06cf7ba8a562a3f5208fb7a8efbc971d0e": {makeBranch("bl/symbols-2", "2021-02-24T06:21:20-08:00", false)},
+		"a40716031ae97ee7c5cdf1dec913567a4a7c50c8": {makeBranch("ef/wtf", "2021-02-10T10:50:08-06:00", false)},
+		"e2e283fdaf6ea4a419cdbad142bbfd4b730080f8": {makeBranch("garo/go-and-typescript-lsif-indexing", "2020-04-29T16:45:46+00:00", false)},
+		"c485d92c3d2065041bf29b3fe0b55ffac7e66b2a": {makeBranch("garo/index-specific-files", "2021-03-01T13:09:42-08:00", false)},
+		"ce30aee6cc56f39d0ac6fee03c4c151c08a8cd2e": {makeBranch("master", "2021-06-16T11:51:09-07:00", true)},
+		"ec5cfc8ab33370c698273b1a097af73ea289c92b": {makeBranch("nsc/bump-go-version", "2021-03-12T22:33:17+00:00", false)},
+		"22b2c4f734f62060cae69da856fe3854defdcc87": {makeBranch("nsc/markupcontent", "2021-05-03T23:50:02+01:00", false)},
+		"9df3358a18792fa9dbd40d506f2e0ad23fc11ee8": {makeBranch("nsc/random", "2021-02-10T16:29:06+00:00", false)},
+		"a02b85b63345a1406d7a19727f7a5472c976e053": {makeBranch("sg/document-symbols", "2021-04-08T15:33:03-07:00", false)},
+		"234b0a484519129b251164ecb0674ec27d154d2f": {makeBranch("symbols", "2021-01-01T22:51:55-08:00", false)},
+		"c165bfff52e9d4f87891bba497e3b70fea144d89": {makeTag("v0.10.0", "2020-08-04T08:23:30-05:00")},
+		"f73ee8ed601efea74f3b734eeb073307e1615606": {makeTag("v0.5.1", "2020-04-16T16:06:21-04:00")},
+		"6057f7ed8d331c82030c713b650fc8fd2c0c2347": {makeTag("v0.5.2", "2020-04-16T16:20:26-04:00")},
+		"7886287b8758d1baf19cf7b8253856128369a2a7": {makeTag("v0.5.3", "2020-04-16T16:55:58-04:00")},
+		"b69f89473bbcc04dc52cafaf6baa504e34791f5a": {makeTag("v0.6.0", "2020-04-20T12:10:49-04:00")},
+		"172b7fcf8b8c49b37b231693433586c2bfd1619e": {makeTag("v0.7.0", "2020-04-20T12:37:36-04:00")},
+		"5bc35c78fb5fb388891ca944cd12d85fd6dede95": {makeTag("v0.8.0", "2020-05-05T12:53:18-05:00")},
+		"14faa49ef098df9488536ca3c9b26d79e6bec4d6": {makeTag("v0.9.0", "2020-07-14T14:26:40-05:00")},
+		"0a82af8b6914d8c81326eee5f3a7e1d1106547f1": {makeTag("v1.0.0", "2020-08-19T19:33:39-05:00")},
+		"262defb72b96261a7d56b000d438c5c7ec6d0f3e": {makeTag("v1.1.0", "2020-08-21T14:15:44-05:00")},
+		"806b96eb544e7e632a617c26402eccee6d67faed": {makeTag("v1.1.1", "2020-08-21T16:02:35-05:00")},
+		"5d8865d6feacb4fce3313cade2c61dc29c6271e6": {makeTag("v1.1.2", "2020-08-22T13:45:26-05:00")},
+		"8c45a5635cf0a4968cc8c9dac2d61c388b53251e": {makeTag("v1.1.3", "2020-08-25T10:10:46-05:00")},
+		"fc212da31ce157ef0795e934381509c5a50654f6": {makeTag("v1.1.4", "2020-08-26T14:02:47-05:00")},
+		"4fd8b2c3522df32ffc8be983d42c3a504cc75fbc": {makeTag("v1.2.0", "2020-09-07T09:52:43-05:00")},
+		"9741f54aa0f14be1103b00c89406393ea4d8a08a": {makeTag("v1.3.0", "2021-02-10T23:21:31+00:00")},
+		"b358977103d2d66e2a3fc5f8081075c2834c4936": {makeTag("v1.3.1", "2021-02-24T20:16:45+00:00")},
+		"2882ad236da4b649b4c1259d815bf1a378e3b92f": {makeTag("v1.4.0", "2021-05-13T10:41:02-05:00")},
+		"340b84452286c18000afad9b140a32212a82840a": {makeTag("v1.5.0", "2021-05-20T18:41:41-05:00")},
+	}
+	if diff := cmp.Diff(expectedRefDescriptions, refDescriptions); diff != "" {
+		t.Errorf("unexpected ref descriptions (-want +got):\n%s", diff)
+	}
+}

--- a/internal/vcs/git/revisions.go
+++ b/internal/vcs/git/revisions.go
@@ -60,8 +60,8 @@ var resolveRevisionCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 //
 // Error cases:
 // * Repo does not exist: gitdomain.RepoNotExistError
-// * Commit does not exist: RevisionNotFoundError
-// * Empty repository: RevisionNotFoundError
+// * Commit does not exist: gitdomain.RevisionNotFoundError
+// * Empty repository: gitdomain.RevisionNotFoundError
 // * Other unexpected errors.
 func ResolveRevision(ctx context.Context, repo api.RepoName, spec string, opt ResolveRevisionOptions) (api.CommitID, error) {
 	if Mocks.ResolveRevision != nil {


### PR DESCRIPTION
This change moves `RefDescriptions` method out of the gitserver client package and into
the `vcs/git` package.

The `RefType` and `RefDescription` types were also moved into the `gitdomain` package:

Part of https://github.com/sourcegraph/sourcegraph/issues/27909