### PR TITLE
search: make missing repo revs error actually non-fatal

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -232,6 +232,23 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}
 	})
 
+	t.Run("non fatal missing repo revs", func(t *testing.T) {
+		results, err := client.SearchFiles("repo:sgtest rev:print-options NewHunksReader")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(results.Results) == 0 {
+			t.Fatal("want results, got none")
+		}
+
+		for _, r := range results.Results {
+			if want, have := "print-options", r.RevSpec.Expr; have != want {
+				t.Fatalf("want rev to be %q, got %q", want, have)
+			}
+		}
+	})
+
 	t.Run("context: search", func(t *testing.T) {
 		repo1, err := client.Repository("github.com/sgtest/java-langserver")
 		require.NoError(t, err)

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -86,7 +86,7 @@ func (r *Resolver) Paginate(ctx context.Context, op *search.RepoOptions, handle 
 		page, err := r.Resolve(ctx, opts)
 		if err != nil {
 			errs = multierror.Append(errs, err)
-			if !errors.As(err, &MissingRepoRevsError{}) { // Non-fatal errors
+			if !errors.Is(err, &MissingRepoRevsError{}) { // Non-fatal errors
 				break
 			}
 		}
@@ -319,7 +319,7 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 	}
 
 	if len(res.MissingRepoRevs) > 0 {
-		err = multierror.Append(err, &MissingRepoRevsError{Missing: res.MissingRepoRevs})
+		err = &MissingRepoRevsError{Missing: res.MissingRepoRevs}
 	}
 
 	return res, err

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -319,7 +319,7 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 	}
 
 	if len(res.MissingRepoRevs) > 0 {
-		err = &MissingRepoRevsError{Missing: res.MissingRepoRevs}
+		err = multierror.Append(err, &MissingRepoRevsError{Missing: res.MissingRepoRevs})
 	}
 
 	return res, err


### PR DESCRIPTION
While the intent of the code before was the it was non-fatal, the actual
behaviour was the opposite. This patch fixes it, so we can keep
searching valid repo revs.

Part of #28028



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
