### PR TITLE
Enable CGO on sg binary releases to fix "too many open files" bug

### DIFF
--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -56,6 +56,10 @@ jobs:
         arch:
           - amd64
           - arm64
+        exclude:
+          # Compiling for arm64 on Linux requires more work
+          - os: ubuntu-latest
+            node: arm64
 
     steps:
       - name: Checkout

--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -29,7 +29,7 @@ jobs:
           # ATTENTION: release_name is a duplicate from the last step in this
           # file, because I can't get workflow outputs to work. If you change
           # one, make sure you change the other.
-          release_name="THORSTEN-TESTING"
+          release_name="${today}-${short_sha}"
 
           echo "### sg snapshot release" >> /tmp/release-notes.md
           echo "" >> /tmp/release-notes.md
@@ -76,7 +76,6 @@ jobs:
           cd dev/sg
           export CGO_ENABLED=1
           export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
-          go env
           GOARCH=${{ matrix.arch }} go build -o "sg_$(go env GOOS)_${{ matrix.arch }}" -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
 
       - name: Build and upload Linux
@@ -84,14 +83,12 @@ jobs:
         run: |
           cd dev/sg
           export CGO_ENABLED=1
-          go env
           GOARCH=${{ matrix.arch }} go build -o "sg_$(go env GOOS)_${{ matrix.arch }}" -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
 
       - name: Upload release asset
         run: |
           cd dev/sg
           release_name="${{ needs.create_release.outputs.release_name }}"
-          go env
           gh release upload -R="${repo}" ${release_name} "sg_$(go env GOOS)_${{ matrix.arch }}"
         env:
           repo: sourcegraph/sg

--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -26,22 +26,22 @@ jobs:
           today=$(date +'%Y-%m-%d-%H-%M')
           short_sha=$(echo ${{ github.sha }} | cut -c1-8)
 
-          # # ATTENTION: release_name is a duplicate from the last step in this
-          # # file, because I can't get workflow outputs to work. If you change
-          # # one, make sure you change the other.
-          # release_name="THORSTEN-TESTING"
+          # ATTENTION: release_name is a duplicate from the last step in this
+          # file, because I can't get workflow outputs to work. If you change
+          # one, make sure you change the other.
+          release_name="THORSTEN-TESTING"
 
-          # echo "### sg snapshot release" >> /tmp/release-notes.md
-          # echo "" >> /tmp/release-notes.md
-          # echo "Commit: https://github.com/sourcegraph/sourcegraph/commit/${{github.sha}}" >> /tmp/release-notes.md
+          echo "### sg snapshot release" >> /tmp/release-notes.md
+          echo "" >> /tmp/release-notes.md
+          echo "Commit: https://github.com/sourcegraph/sourcegraph/commit/${{github.sha}}" >> /tmp/release-notes.md
 
-          # gh release delete -R="${repo}" ${release_name} || true
-          # gh release create -R="${repo}" ${release_name} --notes-file /tmp/release-notes.md
+          gh release delete -R="${repo}" ${release_name} || true
+          gh release create -R="${repo}" ${release_name} --notes-file /tmp/release-notes.md
 
-          # echo "::set-output name=release_name::${release_name}"
+          echo "::set-output name=release_name::${release_name}"
         env:
           repo: sourcegraph/sg
-          # GITHUB_TOKEN: ${{ secrets.SG_RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SG_RELEASE_TOKEN }}
 
   build:
     name: build
@@ -66,22 +66,6 @@ jobs:
         with:
           go-version: 1.17
 
-      - name: Get Go environment
-        id: go-env
-        run: |
-          echo "::set-output name=path::$(go env GOPATH)"
-          echo "::set-output name=exe::$(go env GOEXE)"
-          echo "::set-output name=hostos::$(go env GOHOSTOS)"
-          echo "::set-output name=hostarch::$(go env GOHOSTARCH)"
-          echo "::set-output name=cache::$(go env GOCACHE)"
-          echo "::set-output name=modcache::$(go env GOMODCACHE)"
-
-      # - name: Get asset name
-      #   id: asset
-      #   run: echo "::set-output name=filename::sg_${GOOS}_${GOARCH}${GOEXE}"
-      #   env:
-      #     GOEXE: ${{ steps.go-env.outputs.exe }}
-
       - name: Build release asset for macOS
         if: startsWith(matrix.os, 'macos-') == true
         run: |
@@ -97,28 +81,11 @@ jobs:
           export CGO_ENABLED=1
           go build -o "sg_$(go env GOOS)_$(go env GOARCH)" -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
 
-      # - name: Move asset to GOPATH/bin
-      #   if: ${{ steps.go-env.outputs.hostos != matrix.os || steps.go-env.outputs.hostarch != matrix.arch }}
-      #   working-directory: ${{ steps.go-env.outputs.path }}/bin/${{ matrix.os }}_${{ matrix.arch }}
-      #   run: mv sg"${GOEXE}" ..
-      #   env:
-      #     GOEXE: ${{ steps.go-env.outputs.exe }}
-
-      # - name: Move asset to workspace
-      #   working-directory: ${{ steps.go-env.outputs.path }}/bin
-      #   run: mv sg"${GOEXE}" "${workspace}"/"${filename}"
-      #   env:
-      #     GOEXE: ${{ steps.go-env.outputs.exe }}
-      #     workspace: ${{ github.workspace }}
-      #     filename: ${{ steps.asset.outputs.filename }}
-
       - name: Upload release asset
         run: |
-          # release_name="${{ needs.create_release.outputs.release_name }}"
-          ls -l "dev/sg/sg_$(go env GOOS)_$(go env GOARCH)"
-          echo "filename=${filename}"
-          # gh release upload -R="${repo}" ${release_name} "${filename}"
+          cd dev/sg
+          release_name="${{ needs.create_release.outputs.release_name }}"
+          gh release upload -R="${repo}" ${release_name} "sg_$(go env GOOS)_$(go env GOARCH)"
         env:
           repo: sourcegraph/sg
-          # filename: ${{ steps.asset.outputs.filename }}
-          # GITHUB_TOKEN: ${{ secrets.SG_RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SG_RELEASE_TOKEN }}

--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - mrn/testing-sg-cross-compiling
     paths:
       - 'dev/sg/**'
       - '.github/workflows/sg-binary-release.yml'

--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -66,29 +66,29 @@ jobs:
         with:
           go-version: 1.17
 
-      - name: Build release asset for macOS
+      - name: Build and upload macOS
         if: startsWith(matrix.os, 'macos-') == true
         run: |
           cd dev/sg
           export CGO_ENABLED=1
           export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
           go env
-          go build -o "sg_$(go env GOOS)_$(go env GOARCH)" -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
+          GOARCH=${{ matrix.arch }} go build -o "sg_$(go env GOOS)_${{ matrix.arch }}" -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
 
-      - name: Build release asset for Linux
+      - name: Build and upload Linux
         if: startsWith(matrix.os, 'ubuntu-') == true
         run: |
           cd dev/sg
           export CGO_ENABLED=1
           go env
-          go build -o "sg_$(go env GOOS)_$(go env GOARCH)" -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
+          GOARCH=${{ matrix.arch }} go build -o "sg_$(go env GOOS)_${{ matrix.arch }}" -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
 
       - name: Upload release asset
         run: |
           cd dev/sg
           release_name="${{ needs.create_release.outputs.release_name }}"
           go env
-          gh release upload -R="${repo}" ${release_name} "sg_$(go env GOOS)_$(go env GOARCH)"
+          gh release upload -R="${repo}" ${release_name} "sg_$(go env GOOS)_${{ matrix.arch }}"
         env:
           repo: sourcegraph/sg
           GITHUB_TOKEN: ${{ secrets.SG_RELEASE_TOKEN }}

--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -26,22 +26,22 @@ jobs:
           today=$(date +'%Y-%m-%d-%H-%M')
           short_sha=$(echo ${{ github.sha }} | cut -c1-8)
 
-          # ATTENTION: release_name is a duplicate from the last step in this
-          # file, because I can't get workflow outputs to work. If you change
-          # one, make sure you change the other.
-          release_name="THORSTEN-TESTING"
+          # # ATTENTION: release_name is a duplicate from the last step in this
+          # # file, because I can't get workflow outputs to work. If you change
+          # # one, make sure you change the other.
+          # release_name="THORSTEN-TESTING"
 
-          echo "### sg snapshot release" >> /tmp/release-notes.md
-          echo "" >> /tmp/release-notes.md
-          echo "Commit: https://github.com/sourcegraph/sourcegraph/commit/${{github.sha}}" >> /tmp/release-notes.md
+          # echo "### sg snapshot release" >> /tmp/release-notes.md
+          # echo "" >> /tmp/release-notes.md
+          # echo "Commit: https://github.com/sourcegraph/sourcegraph/commit/${{github.sha}}" >> /tmp/release-notes.md
 
-          gh release delete -R="${repo}" ${release_name} || true
-          gh release create -R="${repo}" ${release_name} --notes-file /tmp/release-notes.md
+          # gh release delete -R="${repo}" ${release_name} || true
+          # gh release create -R="${repo}" ${release_name} --notes-file /tmp/release-notes.md
 
-          echo "::set-output name=release_name::${release_name}"
+          # echo "::set-output name=release_name::${release_name}"
         env:
           repo: sourcegraph/sg
-          GITHUB_TOKEN: ${{ secrets.SG_RELEASE_TOKEN }}
+          # GITHUB_TOKEN: ${{ secrets.SG_RELEASE_TOKEN }}
 
   build:
     name: build
@@ -116,8 +116,9 @@ jobs:
         run: |
           release_name="${{ needs.create_release.outputs.release_name }}"
 
-          gh release upload -R="${repo}" ${release_name} "${filename}"
+          echo "filename=${filename}"
+          # gh release upload -R="${repo}" ${release_name} "${filename}"
         env:
           repo: sourcegraph/sg
           filename: ${{ steps.asset.outputs.filename }}
-          GITHUB_TOKEN: ${{ secrets.SG_RELEASE_TOKEN }}
+          # GITHUB_TOKEN: ${{ secrets.SG_RELEASE_TOKEN }}

--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -59,7 +59,7 @@ jobs:
         exclude:
           # Compiling for arm64 on Linux requires more work
           - os: ubuntu-latest
-            node: arm64
+            arch: arm64
 
     steps:
       - name: Checkout

--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Upload release asset
         run: |
           # release_name="${{ needs.create_release.outputs.release_name }}"
-          ls -l .
+          ls -l "dev/sg/sg_$(go env GOOS)_$(go env GOARCH)"
           echo "filename=${filename}"
           # gh release upload -R="${repo}" ${release_name} "${filename}"
         env:

--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -72,6 +72,7 @@ jobs:
           cd dev/sg
           export CGO_ENABLED=1
           export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
+          go env
           go build -o "sg_$(go env GOOS)_$(go env GOARCH)" -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
 
       - name: Build release asset for Linux
@@ -79,12 +80,14 @@ jobs:
         run: |
           cd dev/sg
           export CGO_ENABLED=1
+          go env
           go build -o "sg_$(go env GOOS)_$(go env GOARCH)" -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
 
       - name: Upload release asset
         run: |
           cd dev/sg
           release_name="${{ needs.create_release.outputs.release_name }}"
+          go env
           gh release upload -R="${repo}" ${release_name} "sg_$(go env GOOS)_$(go env GOARCH)"
         env:
           repo: sourcegraph/sg

--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -4,13 +4,14 @@ on:
   push:
     branches:
       - main
+      - mrn/testing-sg-cross-compiling
     paths:
       - 'dev/sg/**'
       - '.github/workflows/sg-binary-release.yml'
 
 env:
   GOFLAGS: -trimpath
-  CGO_ENABLED: '0'
+  CGO_ENABLED: '1'
 
 jobs:
   create_release:
@@ -28,7 +29,7 @@ jobs:
           # ATTENTION: release_name is a duplicate from the last step in this
           # file, because I can't get workflow outputs to work. If you change
           # one, make sure you change the other.
-          release_name="${today}-${short_sha}"
+          release_name="THORSTEN-TESTING"
 
           echo "### sg snapshot release" >> /tmp/release-notes.md
           echo "" >> /tmp/release-notes.md
@@ -45,27 +46,25 @@ jobs:
   build:
     name: build
     needs: [create_release]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os:
-          - linux
-          - darwin
+          - ubuntu-latest
+          - macos-latest
         arch:
           - amd64
           - arm64
-    env:
-      GOOS: ${{ matrix.os }}
-      GOARCH: ${{ matrix.arch }}
+
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
       - name: Install Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.17
-
-      - name: Checkout
-        uses: actions/checkout@v2
 
       - name: Get Go environment
         id: go-env
@@ -83,9 +82,20 @@ jobs:
         env:
           GOEXE: ${{ steps.go-env.outputs.exe }}
 
-      - name: Build release asset
+      - name: Build release asset for macOS
+        if: startsWith(matrix.os, 'macos-') == true
         run: |
-          cd dev/sg && go install -ldflags "-X main.BuildCommit=$(git rev-list -1 HEAD .)" .
+          cd dev/sg
+          export CGO_ENABLED=1
+          export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
+          go install -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
+
+      - name: Build release asset for Linux
+        if: startsWith(matrix.os, 'ubuntu-') == true
+        run: |
+          cd dev/sg
+          export CGO_ENABLED=1
+          go install -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
 
       - name: Move asset to GOPATH/bin
         if: ${{ steps.go-env.outputs.hostos != matrix.os || steps.go-env.outputs.hostarch != matrix.arch }}

--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -76,11 +76,11 @@ jobs:
           echo "::set-output name=cache::$(go env GOCACHE)"
           echo "::set-output name=modcache::$(go env GOMODCACHE)"
 
-      - name: Get asset name
-        id: asset
-        run: echo "::set-output name=filename::sg_${GOOS}_${GOARCH}${GOEXE}"
-        env:
-          GOEXE: ${{ steps.go-env.outputs.exe }}
+      # - name: Get asset name
+      #   id: asset
+      #   run: echo "::set-output name=filename::sg_${GOOS}_${GOARCH}${GOEXE}"
+      #   env:
+      #     GOEXE: ${{ steps.go-env.outputs.exe }}
 
       - name: Build release asset for macOS
         if: startsWith(matrix.os, 'macos-') == true
@@ -88,37 +88,37 @@ jobs:
           cd dev/sg
           export CGO_ENABLED=1
           export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
-          go install -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
+          go build -o "sg_$(go env GOOS)_$(go env GOARCH)" -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
 
       - name: Build release asset for Linux
         if: startsWith(matrix.os, 'ubuntu-') == true
         run: |
           cd dev/sg
           export CGO_ENABLED=1
-          go install -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
+          go build -o "sg_$(go env GOOS)_$(go env GOARCH)" -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
 
-      - name: Move asset to GOPATH/bin
-        if: ${{ steps.go-env.outputs.hostos != matrix.os || steps.go-env.outputs.hostarch != matrix.arch }}
-        working-directory: ${{ steps.go-env.outputs.path }}/bin/${{ matrix.os }}_${{ matrix.arch }}
-        run: mv sg"${GOEXE}" ..
-        env:
-          GOEXE: ${{ steps.go-env.outputs.exe }}
+      # - name: Move asset to GOPATH/bin
+      #   if: ${{ steps.go-env.outputs.hostos != matrix.os || steps.go-env.outputs.hostarch != matrix.arch }}
+      #   working-directory: ${{ steps.go-env.outputs.path }}/bin/${{ matrix.os }}_${{ matrix.arch }}
+      #   run: mv sg"${GOEXE}" ..
+      #   env:
+      #     GOEXE: ${{ steps.go-env.outputs.exe }}
 
-      - name: Move asset to workspace
-        working-directory: ${{ steps.go-env.outputs.path }}/bin
-        run: mv sg"${GOEXE}" "${workspace}"/"${filename}"
-        env:
-          GOEXE: ${{ steps.go-env.outputs.exe }}
-          workspace: ${{ github.workspace }}
-          filename: ${{ steps.asset.outputs.filename }}
+      # - name: Move asset to workspace
+      #   working-directory: ${{ steps.go-env.outputs.path }}/bin
+      #   run: mv sg"${GOEXE}" "${workspace}"/"${filename}"
+      #   env:
+      #     GOEXE: ${{ steps.go-env.outputs.exe }}
+      #     workspace: ${{ github.workspace }}
+      #     filename: ${{ steps.asset.outputs.filename }}
 
       - name: Upload release asset
         run: |
-          release_name="${{ needs.create_release.outputs.release_name }}"
-
+          # release_name="${{ needs.create_release.outputs.release_name }}"
+          ls -l .
           echo "filename=${filename}"
           # gh release upload -R="${repo}" ${release_name} "${filename}"
         env:
           repo: sourcegraph/sg
-          filename: ${{ steps.asset.outputs.filename }}
+          # filename: ${{ steps.asset.outputs.filename }}
           # GITHUB_TOKEN: ${{ secrets.SG_RELEASE_TOKEN }}


### PR DESCRIPTION
This fixes #28354 by using `CGO_ENABLED=1` when building `sg` binaries. We didn't do that in the past because we didn't know it was that easy to run on `macos-latest` in GitHub workflows.

And using `CGO_ENABLED=0` caused the file-watching library we're using - github.com/rjeczalik/notify - to fallback to `kqueue` to watch files on macOS. That in turn is not performant when watching files in large folders. It seems to open/stat every file in our repository which then lead to a "too many open files" error.

(You can see this in action if you compile `sg` with `CGO_ENABLED=0 go build -o sg .` and then run `sudo dtruss ./sg run github-proxy` on macOS. You'll see _ton_ of `open` and `stat` syscalls.)

With CGO enabled though, `notify` uses `FSEvents` on macOS which handles our repository much better.

And that also explains why building `sg` locally fixed the issue: locally we didn't turn CGO off.