### PR TITLE
codeintel:  Remove more uses of execResolveRevGitCommand

### DIFF
--- a/enterprise/internal/codeintel/gitserver/client.go
+++ b/enterprise/internal/codeintel/gitserver/client.go
@@ -74,31 +74,30 @@ func (c *Client) CommitDate(ctx context.Context, repositoryID int, commit string
 	}})
 	defer endObservation(1, observation.Args{})
 
-	out, err := c.execResolveRevGitCommand(ctx, repositoryID, commit, "show", "-s", "--format=%H:%cI", commit)
+	repo, err := c.repositoryIDToRepo(ctx, repositoryID)
 	if err != nil {
-		if errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
-			err = nil
-		}
-
-		return "", time.Time{}, false, err
-	}
-
-	line := strings.TrimSpace(out)
-	if line == "" {
 		return "", time.Time{}, false, nil
 	}
 
-	parts := strings.SplitN(line, ":", 2)
-	if len(parts) != 2 {
-		return "", time.Time{}, false, errors.Errorf(`unexpected output from git show "%s"`, line)
+	rev, tm, ok, err := git.CommitDate(ctx, repo, api.CommitID(commit))
+	if err == nil {
+		return rev, tm, ok, nil
 	}
 
-	duration, err := time.Parse(time.RFC3339, parts[1])
-	if err != nil {
-		return "", time.Time{}, false, errors.Errorf(`unexpected output from git show (bad date format) "%s"`, line)
+	// If the repo doesn't exist don't bother trying to resolve the commit.
+	// Otherwise, if we're returning an error, try to resolve revision that was the
+	// target of the command. If the revision fails to resolve, we return an instance
+	// of a RevisionNotFoundError error instead of an "exit 128".
+	if !gitdomain.IsRepoNotExist(err) {
+		if _, err := git.ResolveRevision(ctx, repo, commit, git.ResolveRevisionOptions{}); err != nil {
+			return "", time.Time{}, false, errors.Wrap(err, "git.ResolveRevision")
+		}
 	}
 
-	return parts[0], duration, true, nil
+	// If we didn't expect a particular revision to exist, or we did but it
+	// resolved without error, return the original error as the command had
+	// failed for another reason.
+	return "", time.Time{}, false, errors.Wrap(err, "git.CommitDate")
 }
 
 func (c *Client) RepoInfo(ctx context.Context, repos ...api.RepoName) (_ map[api.RepoName]*protocol.RepoInfo, err error) {
@@ -323,7 +322,7 @@ func (c *Client) RawContents(ctx context.Context, repositoryID int, commit, file
 	// If we didn't expect a particular revision to exist, or we did but it
 	// resolved without error, return the original error as the command had
 	// failed for another reason.
-	return nil, errors.Wrap(err, "gitserver.ReadFile")
+	return nil, errors.Wrap(err, "git.ReadFile")
 }
 
 // DirectoryChildren determines all children known to git for the given directory names via an invocation

--- a/enterprise/internal/codeintel/gitserver/client.go
+++ b/enterprise/internal/codeintel/gitserver/client.go
@@ -307,7 +307,7 @@ func (c *Client) RawContents(ctx context.Context, repositoryID int, commit, file
 
 	id, err := git.ResolveRevision(ctx, repo, commit, git.ResolveRevisionOptions{})
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "git.ResolveRevision")
 	}
 
 	out, err := git.ReadFile(ctx, repo, id, file, 0)

--- a/enterprise/internal/codeintel/gitserver/client.go
+++ b/enterprise/internal/codeintel/gitserver/client.go
@@ -300,12 +300,22 @@ func (c *Client) RawContents(ctx context.Context, repositoryID int, commit, file
 	}})
 	defer endObservation(1, observation.Args{})
 
-	out, err := c.execResolveRevGitCommand(ctx, repositoryID, commit, "show", fmt.Sprintf("%s:%s", commit, file))
+	repo, err := c.repositoryIDToRepo(ctx, repositoryID)
 	if err != nil {
 		return nil, err
 	}
 
-	return []byte(out), err
+	id, err := git.ResolveRevision(ctx, repo, commit, git.ResolveRevisionOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	out, err := git.ReadFile(ctx, repo, id, file, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	return out, err
 }
 
 // DirectoryChildren determines all children known to git for the given directory names via an invocation


### PR DESCRIPTION
This moves RawContents, ListFiles and CommitDate into the `git` package.

Because the old code tried to resolve the revision on error, we do the same here too,
but only inside the codeintel package.

Part of https://github.com/sourcegraph/sourcegraph/issues/27909