### PR TITLE
search: concurrent rev validation in repo resolution

### DIFF
--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -366,7 +366,7 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 		return Resolved{}, err
 	}
 
-	// Remove any repos that failed to have their revs validated.
+	// Remove any repos that failed to have their revs validated. We do this to preserve the original order.
 	valid := res.RepoRevs[:0]
 	for _, r := range res.RepoRevs {
 		if r != nil {

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -16,6 +16,7 @@ import (
 	"github.com/neelance/parallel"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -221,92 +222,126 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 		}
 	}
 
-	res := Resolved{
+	var res struct {
+		sync.Mutex
+		Resolved
+	}
+
+	res.Resolved = Resolved{
 		RepoRevs: make([]*search.RepositoryRevisions, 0, len(repos)),
 		RepoSet:  make(map[api.RepoID]types.MinimalRepo, len(repos)),
 		Next:     next,
 	}
 
+	sem := semaphore.NewWeighted(128) // same concurrency as filterRepoHasCommitAfter
+	g, ctx := errgroup.WithContext(ctx)
+
 	for _, repo := range repos {
-		var (
-			repoRev = search.RepositoryRevisions{Repo: repo}
-			revs    []search.RevisionSpecifier
-		)
-
-		if len(searchContextRepositoryRevisions) > 0 {
-			if scRepoRev := searchContextRepositoryRevisions[repo.ID]; scRepoRev != nil {
-				revs = scRepoRev.Revs
-			}
-		} else {
-			var clashingRevs []search.RevisionSpecifier
-			revs, clashingRevs = getRevsForMatchedRepo(repo.Name, includePatternRevs)
-
-			// if multiple specified revisions clash, report this usefully:
-			if len(revs) == 0 && clashingRevs != nil {
-				res.MissingRepoRevs = append(res.MissingRepoRevs, &search.RepositoryRevisions{
-					Repo: repo,
-					Revs: clashingRevs,
-				})
-			}
+		if err = sem.Acquire(ctx, 1); err != nil {
+			return res.Resolved, err
 		}
 
-		// We do in place filtering to reduce allocations. Common path is no
-		// filtering of revs.
-		if len(revs) > 0 {
-			repoRev.Revs = revs[:0]
-		}
+		repo := repo // avoid race
 
-		// Check if the repository actually has the revisions that the user specified.
-		for _, rev := range revs {
-			if rev.RefGlob != "" || rev.ExcludeRefGlob != "" {
-				// Do not validate ref patterns. A ref pattern matching 0 refs is not necessarily
-				// invalid, so it's not clear what validation would even mean.
-				repoRev.Revs = append(repoRev.Revs, rev)
-				continue
-			}
-			if rev.RevSpec == "" { // skip default branch resolution to save time
-				repoRev.Revs = append(repoRev.Revs, rev)
-				continue
-			}
+		g.Go(func() error {
+			defer sem.Release(1)
 
-			// Validate the revspec.
-			// Do not trigger a repo-updater lookup (e.g.,
-			// backend.{GitRepo,Repos.ResolveRev}) because that would slow this operation
-			// down by a lot (if we're looping over many repos). This means that it'll fail if a
-			// repo is not on gitserver.
-			//
-			// TODO(sqs): make this NOT send gitserver this revspec in EnsureRevision, to avoid
-			// searches like "repo:@foobar" (where foobar is an invalid revspec on most repos)
-			// taking a long time because they all ask gitserver to try to fetch from the remote
-			// repo.
-			trimmedRefSpec := strings.TrimPrefix(rev.RevSpec, "^") // handle negated revisions, such as ^<branch>, ^<tag>, or ^<commit>
-			if _, err := git.ResolveRevision(ctx, repoRev.GitserverRepo(), trimmedRefSpec, git.ResolveRevisionOptions{NoEnsureRevision: true}); err != nil {
-				if errors.Is(err, context.DeadlineExceeded) {
-					return Resolved{}, context.DeadlineExceeded
+			var (
+				repoRev = search.RepositoryRevisions{Repo: repo}
+				revs    []search.RevisionSpecifier
+			)
+
+			if len(searchContextRepositoryRevisions) > 0 {
+				if scRepoRev := searchContextRepositoryRevisions[repo.ID]; scRepoRev != nil {
+					revs = scRepoRev.Revs
 				}
-				if errors.HasType(err, gitdomain.BadCommitError{}) {
-					return Resolved{}, err
-				}
-				if errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
-					// The revspec does not exist, so don't include it, and report that it's missing.
-					if rev.RevSpec == "" {
-						// Report as HEAD not "" (empty string) to avoid user confusion.
-						rev.RevSpec = "HEAD"
-					}
+			} else {
+				var clashingRevs []search.RevisionSpecifier
+				revs, clashingRevs = getRevsForMatchedRepo(repo.Name, includePatternRevs)
+
+				// if multiple specified revisions clash, report this usefully:
+				if len(revs) == 0 && clashingRevs != nil {
+					res.Lock()
 					res.MissingRepoRevs = append(res.MissingRepoRevs, &search.RepositoryRevisions{
 						Repo: repo,
-						Revs: []search.RevisionSpecifier{{RevSpec: rev.RevSpec}},
+						Revs: clashingRevs,
 					})
+					res.Unlock()
 				}
-				// If err != nil and is not one of the err values checked for above, cloning and other errors will be handled later, so just ignore an error
-				// if there is one.
-				continue
 			}
-			repoRev.Revs = append(repoRev.Revs, rev)
-		}
 
-		res.RepoRevs = append(res.RepoRevs, &repoRev)
-		res.RepoSet[repoRev.Repo.ID] = repoRev.Repo
+			// We do in place filtering to reduce allocations. Common path is no
+			// filtering of revs.
+			if len(revs) > 0 {
+				repoRev.Revs = revs[:0]
+			}
+
+			// Check if the repository actually has the revisions that the user specified.
+			for _, rev := range revs {
+				if rev.RefGlob != "" || rev.ExcludeRefGlob != "" {
+					// Do not validate ref patterns. A ref pattern matching 0 refs is not necessarily
+					// invalid, so it's not clear what validation would even mean.
+					repoRev.Revs = append(repoRev.Revs, rev)
+					continue
+				}
+				if rev.RevSpec == "" { // skip default branch resolution to save time
+					repoRev.Revs = append(repoRev.Revs, rev)
+					continue
+				}
+
+				// Validate the revspec.
+				// Do not trigger a repo-updater lookup (e.g.,
+				// backend.{GitRepo,Repos.ResolveRev}) because that would slow this operation
+				// down by a lot (if we're looping over many repos). This means that it'll fail if a
+				// repo is not on gitserver.
+				//
+				// TODO(sqs): make this NOT send gitserver this revspec in EnsureRevision, to avoid
+				// searches like "repo:@foobar" (where foobar is an invalid revspec on most repos)
+				// taking a long time because they all ask gitserver to try to fetch from the remote
+				// repo.
+				trimmedRefSpec := strings.TrimPrefix(
+					rev.RevSpec,
+					"^",
+				) // handle negated revisions, such as ^<branch>, ^<tag>, or ^<commit>
+				if _, err := git.ResolveRevision(ctx, repoRev.GitserverRepo(), trimmedRefSpec, git.ResolveRevisionOptions{NoEnsureRevision: true}); err != nil {
+					if errors.Is(err, context.DeadlineExceeded) {
+						return context.DeadlineExceeded
+					}
+					if errors.HasType(err, gitdomain.BadCommitError{}) {
+						return err
+					}
+					if errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
+						// The revspec does not exist, so don't include it, and report that it's missing.
+						if rev.RevSpec == "" {
+							// Report as HEAD not "" (empty string) to avoid user confusion.
+							rev.RevSpec = "HEAD"
+						}
+						res.Lock()
+						res.MissingRepoRevs = append(res.MissingRepoRevs, &search.RepositoryRevisions{
+							Repo: repo,
+							Revs: []search.RevisionSpecifier{{RevSpec: rev.RevSpec}},
+						})
+						res.Unlock()
+					}
+					// If err != nil and is not one of the err values checked for above, cloning and other errors will be handled later, so just ignore an error
+					// if there is one.
+					continue
+				}
+				repoRev.Revs = append(repoRev.Revs, rev)
+			}
+
+			res.Lock()
+			res.RepoRevs = append(res.RepoRevs, &repoRev)
+			res.RepoSet[repoRev.Repo.ID] = repoRev.Repo
+			res.Unlock()
+
+			return nil
+		})
+
+	}
+
+	if err = g.Wait(); err != nil {
+		return res.Resolved, err
 	}
 
 	tr.LazyPrintf("Associate/validate revs - done")
@@ -322,7 +357,7 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 		err = multierror.Append(err, &MissingRepoRevsError{Missing: res.MissingRepoRevs})
 	}
 
-	return res, err
+	return res.Resolved, err
 }
 
 // Excluded computes the ExcludedRepos that the given RepoOptions would not match. This is

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -298,6 +298,10 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 				// searches like "repo:@foobar" (where foobar is an invalid revspec on most repos)
 				// taking a long time because they all ask gitserver to try to fetch from the remote
 				// repo.
+				if rev.RevSpec == "" {
+					rev.RevSpec = "HEAD"
+				}
+
 				trimmedRefSpec := strings.TrimPrefix(rev.RevSpec, "^") // handle negated revisions, such as ^<branch>, ^<tag>, or ^<commit>
 				commitID, err := git.ResolveRevision(ctx, repoRev.Repo.Name, trimmedRefSpec, git.ResolveRevisionOptions{NoEnsureRevision: true})
 				if err != nil {

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -238,7 +238,7 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 
 	for i, repo := range repos {
 		if err = sem.Acquire(ctx, 1); err != nil {
-			return res.Resolved, err
+			return Resolved{}, err
 		}
 
 		repo, i := repo, i // avoid race
@@ -340,7 +340,7 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 	}
 
 	if err = g.Wait(); err != nil {
-		return res.Resolved, err
+		return Resolved{}, err
 	}
 
 	// Remove any repos that failed to have their revs validated.

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -346,10 +346,12 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 				repoRev.Revs = append(repoRev.Revs, rev)
 			}
 
-			res.Lock()
-			res.RepoRevs[i] = &repoRev
-			res.RepoSet[repoRev.Repo.ID] = repoRev.Repo
-			res.Unlock()
+			if len(repoRev.Revs) > 0 {
+				res.Lock()
+				res.RepoRevs[i] = &repoRev
+				res.RepoSet[repoRev.Repo.ID] = repoRev.Repo
+				res.Unlock()
+			}
 
 			return nil
 		})

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -305,9 +305,10 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 				trimmedRefSpec := strings.TrimPrefix(rev.RevSpec, "^") // handle negated revisions, such as ^<branch>, ^<tag>, or ^<commit>
 				commitID, err := git.ResolveRevision(ctx, repoRev.Repo.Name, trimmedRefSpec, git.ResolveRevisionOptions{NoEnsureRevision: true})
 				if err != nil {
-					if errors.HasType(err, gitdomain.BadCommitError{}) {
+					if errors.Is(err, context.DeadlineExceeded) || errors.HasType(err, gitdomain.BadCommitError{}) {
 						return err
 					}
+
 					if errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
 						// The revspec does not exist, so don't include it, and report that it's missing.
 						if rev.RevSpec == "" {


### PR DESCRIPTION
This commit speeds up rev validation in repo resolution by making it
concurrent. This is before we're able to index all git refs.

Part of #28028



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
