### PR TITLE
Preselect radio button for org owners

### DIFF
--- a/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
@@ -386,7 +386,7 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
             radio: radioSelectOption,
             loaded: true,
         })
-    }, [fetchExternalServices, fetchAffiliatedRepos, fetchSelectedRepositories])
+    }, [fetchExternalServices, fetchAffiliatedRepos, fetchSelectedRepositories, isOrgOwner])
 
     useEffect(() => {
         fetchServicesAndAffiliatedRepos().catch(error => {

--- a/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
@@ -361,13 +361,14 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
          * number of affiliated repos equals to the number of selected repos -
          * set radio to 'all'
          * 2. if only some repos were selected - set radio to 'selected'
-         * 3. if no repos selected - empty state
+         * 3. if no repos selected or this is an org - set radio to 'selected'
+         * 4. otherwise, empty
          */
 
         const radioSelectOption =
             externalServices.length === codeHostsHaveSyncAllQuery.length && codeHostsHaveSyncAllQuery.every(Boolean)
                 ? 'all'
-                : selectedAffiliatedRepos.size > 0
+                : selectedAffiliatedRepos.size > 0 || isOrgOwner
                 ? 'selected'
                 : ''
 


### PR DESCRIPTION
Preselect the "Sync selected repositories" radio button when managing repositories for an Org
<img width="912" alt="Screenshot 2021-12-01 at 16 14 00" src="https://user-images.githubusercontent.com/1022220/144260852-285d30ff-47be-4e87-b61e-a96ca0b3d205.png">

### Testing
1. For an org without repositories, navigate to  "Manage repositories" view and observe the only visible radio button is preselecteed
2. For a user without repositories, navigate to  "Manage repositories" view and observe the "Sync selected repositories" is not selected
