### PR TITLE
symbols: Reduce number of idle goroutines

### DIFF
--- a/cmd/symbols/config.go
+++ b/cmd/symbols/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	cacheDir          string
 	cacheSizeMB       int
 	numCtagsProcesses int
+	requestBufferSize int
 }
 
 var config = &Config{}
@@ -35,4 +36,5 @@ func (c *Config) Load() {
 	c.cacheDir = c.Get("CACHE_DIR", "/tmp/symbols-cache", "directory in which to store cached symbols")
 	c.cacheSizeMB = c.GetInt("SYMBOLS_CACHE_SIZE_MB", "100000", "maximum size of the disk cache (in megabytes)")
 	c.numCtagsProcesses = c.GetInt("CTAGS_PROCESSES", strconv.Itoa(runtime.GOMAXPROCS(0)), "number of concurrent parser processes to run")
+	c.requestBufferSize = c.GetInt("REQUEST_BUFFER_SIZE", "8192", "maximum size of buffered parser request channel")
 }

--- a/cmd/symbols/internal/api/handler_test.go
+++ b/cmd/symbols/internal/api/handler_test.go
@@ -54,7 +54,7 @@ func TestHandler(t *testing.T) {
 	gitserverClient := NewMockGitserverClient()
 	gitserverClient.FetchTarFunc.SetDefaultHook(gitserver.CreateTestFetchTarFunc(files))
 
-	parser := parser.NewParser(parserPool, fetcher.NewRepositoryFetcher(gitserverClient, 15, &observation.TestContext), &observation.TestContext)
+	parser := parser.NewParser(parserPool, fetcher.NewRepositoryFetcher(gitserverClient, 15, &observation.TestContext), 0, 10, &observation.TestContext)
 	databaseWriter := writer.NewDatabaseWriter(tmpDir, gitserverClient, parser)
 	cachedDatabaseWriter := writer.NewCachedDatabaseWriter(databaseWriter, cache)
 	handler := NewHandler(cachedDatabaseWriter, &observation.TestContext)

--- a/cmd/symbols/main.go
+++ b/cmd/symbols/main.go
@@ -105,7 +105,7 @@ func main() {
 
 	gitserverClient := gitserver.NewClient(observationContext)
 	repositoryFetcher := fetcher.NewRepositoryFetcher(gitserverClient, 15, observationContext)
-	parser := parser.NewParser(parserPool, repositoryFetcher, observationContext)
+	parser := parser.NewParser(parserPool, repositoryFetcher, config.requestBufferSize, config.numCtagsProcesses, observationContext)
 	databaseWriter := writer.NewDatabaseWriter(config.cacheDir, gitserverClient, parser)
 	cachedDatabaseWriter := writer.NewCachedDatabaseWriter(databaseWriter, cache)
 	apiHandler := api.NewHandler(cachedDatabaseWriter, observationContext)


### PR DESCRIPTION
Instead of launching a goroutine that waits on a bounded parser pool for an object, we launch the maximum pool size number of goroutines to service all parse requests, then feed them work on a buffered channel. This should reduce memory as an item in a channel is less expensive than a goroutine (especially when we have 500k of them).