### PR TITLE
ssbc: Persist cache result on workspace

### DIFF
--- a/enterprise/cmd/frontend/internal/executorqueue/queues/batches/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/batches/mock_iface_test.go
@@ -25,10 +25,6 @@ type MockBatchesStore struct {
 	// GetBatchSpecWorkspaceFunc is an instance of a mock function object
 	// controlling the behavior of the method GetBatchSpecWorkspace.
 	GetBatchSpecWorkspaceFunc *BatchesStoreGetBatchSpecWorkspaceFunc
-	// ListBatchSpecExecutionCacheEntriesFunc is an instance of a mock
-	// function object controlling the behavior of the method
-	// ListBatchSpecExecutionCacheEntries.
-	ListBatchSpecExecutionCacheEntriesFunc *BatchesStoreListBatchSpecExecutionCacheEntriesFunc
 	// SetBatchSpecWorkspaceExecutionJobAccessTokenFunc is an instance of a
 	// mock function object controlling the behavior of the method
 	// SetBatchSpecWorkspaceExecutionJobAccessToken.
@@ -51,11 +47,6 @@ func NewMockBatchesStore() *MockBatchesStore {
 		},
 		GetBatchSpecWorkspaceFunc: &BatchesStoreGetBatchSpecWorkspaceFunc{
 			defaultHook: func(context.Context, store.GetBatchSpecWorkspaceOpts) (*types.BatchSpecWorkspace, error) {
-				return nil, nil
-			},
-		},
-		ListBatchSpecExecutionCacheEntriesFunc: &BatchesStoreListBatchSpecExecutionCacheEntriesFunc{
-			defaultHook: func(context.Context, store.ListBatchSpecExecutionCacheEntriesOpts) ([]*types.BatchSpecExecutionCacheEntry, error) {
 				return nil, nil
 			},
 		},
@@ -86,11 +77,6 @@ func NewStrictMockBatchesStore() *MockBatchesStore {
 				panic("unexpected invocation of MockBatchesStore.GetBatchSpecWorkspace")
 			},
 		},
-		ListBatchSpecExecutionCacheEntriesFunc: &BatchesStoreListBatchSpecExecutionCacheEntriesFunc{
-			defaultHook: func(context.Context, store.ListBatchSpecExecutionCacheEntriesOpts) ([]*types.BatchSpecExecutionCacheEntry, error) {
-				panic("unexpected invocation of MockBatchesStore.ListBatchSpecExecutionCacheEntries")
-			},
-		},
 		SetBatchSpecWorkspaceExecutionJobAccessTokenFunc: &BatchesStoreSetBatchSpecWorkspaceExecutionJobAccessTokenFunc{
 			defaultHook: func(context.Context, int64, int64) error {
 				panic("unexpected invocation of MockBatchesStore.SetBatchSpecWorkspaceExecutionJobAccessToken")
@@ -112,9 +98,6 @@ func NewMockBatchesStoreFrom(i BatchesStore) *MockBatchesStore {
 		},
 		GetBatchSpecWorkspaceFunc: &BatchesStoreGetBatchSpecWorkspaceFunc{
 			defaultHook: i.GetBatchSpecWorkspace,
-		},
-		ListBatchSpecExecutionCacheEntriesFunc: &BatchesStoreListBatchSpecExecutionCacheEntriesFunc{
-			defaultHook: i.ListBatchSpecExecutionCacheEntries,
 		},
 		SetBatchSpecWorkspaceExecutionJobAccessTokenFunc: &BatchesStoreSetBatchSpecWorkspaceExecutionJobAccessTokenFunc{
 			defaultHook: i.SetBatchSpecWorkspaceExecutionJobAccessToken,
@@ -440,119 +423,6 @@ func (c BatchesStoreGetBatchSpecWorkspaceFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c BatchesStoreGetBatchSpecWorkspaceFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// BatchesStoreListBatchSpecExecutionCacheEntriesFunc describes the behavior
-// when the ListBatchSpecExecutionCacheEntries method of the parent
-// MockBatchesStore instance is invoked.
-type BatchesStoreListBatchSpecExecutionCacheEntriesFunc struct {
-	defaultHook func(context.Context, store.ListBatchSpecExecutionCacheEntriesOpts) ([]*types.BatchSpecExecutionCacheEntry, error)
-	hooks       []func(context.Context, store.ListBatchSpecExecutionCacheEntriesOpts) ([]*types.BatchSpecExecutionCacheEntry, error)
-	history     []BatchesStoreListBatchSpecExecutionCacheEntriesFuncCall
-	mutex       sync.Mutex
-}
-
-// ListBatchSpecExecutionCacheEntries delegates to the next hook function in
-// the queue and stores the parameter and result values of this invocation.
-func (m *MockBatchesStore) ListBatchSpecExecutionCacheEntries(v0 context.Context, v1 store.ListBatchSpecExecutionCacheEntriesOpts) ([]*types.BatchSpecExecutionCacheEntry, error) {
-	r0, r1 := m.ListBatchSpecExecutionCacheEntriesFunc.nextHook()(v0, v1)
-	m.ListBatchSpecExecutionCacheEntriesFunc.appendCall(BatchesStoreListBatchSpecExecutionCacheEntriesFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// ListBatchSpecExecutionCacheEntries method of the parent MockBatchesStore
-// instance is invoked and the hook queue is empty.
-func (f *BatchesStoreListBatchSpecExecutionCacheEntriesFunc) SetDefaultHook(hook func(context.Context, store.ListBatchSpecExecutionCacheEntriesOpts) ([]*types.BatchSpecExecutionCacheEntry, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// ListBatchSpecExecutionCacheEntries method of the parent MockBatchesStore
-// instance invokes the hook at the front of the queue and discards it.
-// After the queue is empty, the default hook function is invoked for any
-// future action.
-func (f *BatchesStoreListBatchSpecExecutionCacheEntriesFunc) PushHook(hook func(context.Context, store.ListBatchSpecExecutionCacheEntriesOpts) ([]*types.BatchSpecExecutionCacheEntry, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
-// the given values.
-func (f *BatchesStoreListBatchSpecExecutionCacheEntriesFunc) SetDefaultReturn(r0 []*types.BatchSpecExecutionCacheEntry, r1 error) {
-	f.SetDefaultHook(func(context.Context, store.ListBatchSpecExecutionCacheEntriesOpts) ([]*types.BatchSpecExecutionCacheEntry, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushDefaultHook with a function that returns the given
-// values.
-func (f *BatchesStoreListBatchSpecExecutionCacheEntriesFunc) PushReturn(r0 []*types.BatchSpecExecutionCacheEntry, r1 error) {
-	f.PushHook(func(context.Context, store.ListBatchSpecExecutionCacheEntriesOpts) ([]*types.BatchSpecExecutionCacheEntry, error) {
-		return r0, r1
-	})
-}
-
-func (f *BatchesStoreListBatchSpecExecutionCacheEntriesFunc) nextHook() func(context.Context, store.ListBatchSpecExecutionCacheEntriesOpts) ([]*types.BatchSpecExecutionCacheEntry, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *BatchesStoreListBatchSpecExecutionCacheEntriesFunc) appendCall(r0 BatchesStoreListBatchSpecExecutionCacheEntriesFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// BatchesStoreListBatchSpecExecutionCacheEntriesFuncCall objects describing
-// the invocations of this function.
-func (f *BatchesStoreListBatchSpecExecutionCacheEntriesFunc) History() []BatchesStoreListBatchSpecExecutionCacheEntriesFuncCall {
-	f.mutex.Lock()
-	history := make([]BatchesStoreListBatchSpecExecutionCacheEntriesFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// BatchesStoreListBatchSpecExecutionCacheEntriesFuncCall is an object that
-// describes an invocation of method ListBatchSpecExecutionCacheEntries on
-// an instance of MockBatchesStore.
-type BatchesStoreListBatchSpecExecutionCacheEntriesFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 store.ListBatchSpecExecutionCacheEntriesOpts
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []*types.BatchSpecExecutionCacheEntry
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c BatchesStoreListBatchSpecExecutionCacheEntriesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c BatchesStoreListBatchSpecExecutionCacheEntriesFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/enterprise/internal/batches/background/batch_spec_workspace_creator.go
+++ b/enterprise/internal/batches/background/batch_spec_workspace_creator.go
@@ -78,8 +78,9 @@ func (r *batchSpecWorkspaceCreator) process(
 	ws := make([]*btypes.BatchSpecWorkspace, 0, len(workspaces))
 	// Collect all cache keys so we can look them up in a single query.
 	cacheKeyWorkspaces := make(map[string]struct {
-		dbWorkspace *btypes.BatchSpecWorkspace
-		repo        batcheslib.Repository
+		dbWorkspace   *btypes.BatchSpecWorkspace
+		repo          batcheslib.Repository
+		stepCacheKeys []string
 	})
 
 	// Build workspaces DB objects.
@@ -124,27 +125,45 @@ func (r *batchSpecWorkspaceCreator) process(
 			w.OnlyFetchWorkspace,
 			w.Steps,
 		)
+
 		rawKey, err := key.Key()
 		if err != nil {
 			return err
 		}
+
+		stepCacheKeys := make([]string, 0, len(workspace.Steps))
+		// Generate cache keys for all the step results as well.
+		for i := 0; i < len(workspace.Steps)-1; i++ {
+			key := cache.StepsCacheKey{ExecutionKey: &key, StepIndex: i}
+			rawStepKey, err := key.Key()
+			if err != nil {
+				return nil
+			}
+			stepCacheKeys = append(stepCacheKeys, rawStepKey)
+		}
+
 		cacheKeyWorkspaces[rawKey] = struct {
-			dbWorkspace *btypes.BatchSpecWorkspace
-			repo        batcheslib.Repository
+			dbWorkspace   *btypes.BatchSpecWorkspace
+			repo          batcheslib.Repository
+			stepCacheKeys []string
 		}{
-			dbWorkspace: workspace,
-			repo:        r,
+			dbWorkspace:   workspace,
+			repo:          r,
+			stepCacheKeys: stepCacheKeys,
 		}
 	}
 
 	// Fetch all cache entries by their keys.
 	cacheKeys := make([]string, 0, len(cacheKeyWorkspaces))
-	for key := range cacheKeyWorkspaces {
+	stepCacheKeys := make([]string, 0, len(cacheKeyWorkspaces))
+	for key, w := range cacheKeyWorkspaces {
 		cacheKeys = append(cacheKeys, key)
+
+		stepCacheKeys = append(stepCacheKeys, w.stepCacheKeys...)
 	}
 	entriesByCacheKey := make(map[string]*btypes.BatchSpecExecutionCacheEntry)
-	changesetsByWorkspace := make(map[*btypes.BatchSpecWorkspace][]*btypes.ChangesetSpec)
 	if len(cacheKeys) > 0 {
+		// TODO: Once implemented, enforce ownership of cache entries here.
 		entries, err := tx.ListBatchSpecExecutionCacheEntries(ctx, store.ListBatchSpecExecutionCacheEntriesOpts{
 			Keys: cacheKeys,
 		})
@@ -155,14 +174,42 @@ func (r *batchSpecWorkspaceCreator) process(
 			entriesByCacheKey[entry.Key] = entry
 		}
 	}
+	stepEntriesByCacheKey := make(map[string]*btypes.BatchSpecExecutionCacheEntry)
+	if len(stepCacheKeys) > 0 {
+		// TODO: Once implemented, enforce ownership of cache entries here.
+		entries, err := tx.ListBatchSpecExecutionCacheEntries(ctx, store.ListBatchSpecExecutionCacheEntriesOpts{
+			Keys: stepCacheKeys,
+		})
+		if err != nil {
+			return err
+		}
+		for _, entry := range entries {
+			stepEntriesByCacheKey[entry.Key] = entry
+		}
+	}
 
 	// All changeset specs to be created.
 	cs := make([]*btypes.ChangesetSpec, 0)
 	// Collect all IDs of used cache entries to mark them as recently used later.
 	usedCacheEntries := make([]int64, 0)
+	changesetsByWorkspace := make(map[*btypes.BatchSpecWorkspace][]*btypes.ChangesetSpec)
 
 	// Check for an existing cache entry for each of the workspaces.
 	for rawKey, workspace := range cacheKeyWorkspaces {
+		for idx, key := range workspace.stepCacheKeys {
+			if c, ok := stepEntriesByCacheKey[key]; ok {
+				var res execution.AfterStepResult
+				if err := json.Unmarshal([]byte(c.Value), &res); err != nil {
+					return err
+				}
+				workspace.dbWorkspace.SetStepCacheResult(idx+1, btypes.StepCacheResult{Key: key, Value: &res})
+			} else {
+				// Only add cache entries up until we don't have the cache entry
+				// for the previous step anymore.
+				break
+			}
+		}
+
 		entry, ok := entriesByCacheKey[rawKey]
 		if !ok {
 			continue

--- a/enterprise/internal/batches/types/batch_spec_workspace.go
+++ b/enterprise/internal/batches/types/batch_spec_workspace.go
@@ -5,7 +5,13 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
+	"github.com/sourcegraph/sourcegraph/lib/batches/execution"
 )
+
+type StepCacheResult struct {
+	Key   string
+	Value *execution.AfterStepResult
+}
 
 type BatchSpecWorkspace struct {
 	ID int64
@@ -24,9 +30,32 @@ type BatchSpecWorkspace struct {
 	Unsupported bool
 	Ignored     bool
 
-	Skipped           bool
+	// The persisted step cache results found for this execution.
+	StepCacheResults map[int]StepCacheResult
+
+	// Skipped is true if this workspace doesn't need to run. (Has no steps, has
+	// cached result, ...)
+	Skipped bool
+
+	// CachedResultFound indicates whether an overall execution result was found
+	// and used for creating the attached changeset specs.
 	CachedResultFound bool
 
 	CreatedAt time.Time
 	UpdatedAt time.Time
+}
+
+func (w *BatchSpecWorkspace) StepCacheResult(index int) (StepCacheResult, bool) {
+	if w.StepCacheResults == nil {
+		return StepCacheResult{}, false
+	}
+	c, ok := w.StepCacheResults[index]
+	return c, ok
+}
+
+func (w *BatchSpecWorkspace) SetStepCacheResult(index int, c StepCacheResult) {
+	if w.StepCacheResults == nil {
+		w.StepCacheResults = make(map[int]StepCacheResult)
+	}
+	w.StepCacheResults[index] = c
 }

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -170,6 +170,7 @@ Foreign-key constraints:
  unsupported          | boolean                  |           | not null | false
  skipped              | boolean                  |           | not null | false
  cached_result_found  | boolean                  |           | not null | false
+ step_cache_results   | jsonb                    |           | not null | '{}'::jsonb
 Indexes:
     "batch_spec_workspaces_pkey" PRIMARY KEY, btree (id)
 Check constraints:

--- a/migrations/frontend/1528395947_cache_entry_persist.down.sql
+++ b/migrations/frontend/1528395947_cache_entry_persist.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE batch_spec_workspaces DROP COLUMN IF EXISTS step_cache_results;
+
+COMMIT;

--- a/migrations/frontend/1528395947_cache_entry_persist.up.sql
+++ b/migrations/frontend/1528395947_cache_entry_persist.up.sql
@@ -1,5 +1,5 @@
 BEGIN;
 
-ALTER TABLE batch_spec_workspaces ADD COLUMN IF NOT EXISTS step_cache_results JSON NOT NULL DEFAULT '{}';
+ALTER TABLE batch_spec_workspaces ADD COLUMN IF NOT EXISTS step_cache_results JSONB NOT NULL DEFAULT '{}';
 
 COMMIT;

--- a/migrations/frontend/1528395947_cache_entry_persist.up.sql
+++ b/migrations/frontend/1528395947_cache_entry_persist.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE batch_spec_workspaces ADD COLUMN IF NOT EXISTS step_cache_results JSON NOT NULL DEFAULT '{}';
+
+COMMIT;


### PR DESCRIPTION
This PR fixes https://github.com/sourcegraph/sourcegraph/issues/28080. 

Before, we would lose cached status on steps when the cache is evicted. Also, when using the `noCache` option, we would still show step cache results briefly in the UI. This PR also enforces that we have step cache results available for all steps before the most recent cache result (before, we could have a result for step 3, but none for 1 and 2 and those would render incorrectly and have no diff etc).

The downside:
This duplicates a lot of data. This might become problematic in the future. This is a really easy and straightforward fix and I don't anticipate anyone before GA running into big trouble here, but if we think this is a big blocker, we can address this now as well.
An alternative solution would be to only store the link between step and cache result, as a foreign key. We could add a table workspace_step_cache_entries (workspace_id, cache_entry_id).

Then we would need to adjust our pruning algorithm:
- We don't count referenced cache entries in the total cache size when we calculate what to prune
- We do allow duplicates in the key column
  - and when reading cache entries for use, we do `SELECT max(id) .. GROUP BY key`
  - when inserting a new cache entry we
    - insert as before when there's no collision
    - update the record in place, when there are 0 references to this entry
    - create a new record

If we decide to proceed with this approach _for now_, because it fixes the issue at some additional storage cost, I'll put this PR description in a ticket for post beta work. Otherwise, I'll pick this up again and incorporate these suggestions into this PR. I don't have a strong preference but would err on the side of moving fast.