### PR TITLE
search: remove searchrepos.Resolved.RepoSet

### DIFF
--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -33,9 +33,6 @@ import (
 type Resolved struct {
 	RepoRevs []*search.RepositoryRevisions
 
-	// Perf improvement: we precompute this map during repo resolution to save time
-	// on the critical path.
-	RepoSet         map[api.RepoID]types.MinimalRepo
 	MissingRepoRevs []*search.RepositoryRevisions
 	OverLimit       bool
 
@@ -227,7 +224,6 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 
 	res.Resolved = Resolved{
 		RepoRevs: make([]*search.RepositoryRevisions, len(repos)),
-		RepoSet:  make(map[api.RepoID]types.MinimalRepo, len(repos)),
 		Next:     next,
 	}
 
@@ -354,7 +350,6 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 			if len(repoRev.Revs) > 0 {
 				res.Lock()
 				res.RepoRevs[i] = &repoRev
-				res.RepoSet[repoRev.Repo.ID] = repoRev.Repo
 				res.Unlock()
 			}
 

--- a/internal/search/repos/repos_test.go
+++ b/internal/search/repos/repos_test.go
@@ -350,7 +350,6 @@ func TestResolverPaginate(t *testing.T) {
 			pages: []Resolved{
 				{
 					RepoRevs: all.RepoRevs[:3],
-					RepoSet:  setOf(all.RepoRevs[:3]),
 					Next: types.MultiCursor{
 						{Column: "stars", Direction: "prev", Value: fmt.Sprint(all.RepoRevs[3].Repo.Stars)},
 						{Column: "id", Direction: "prev", Value: fmt.Sprint(all.RepoRevs[3].Repo.ID)},
@@ -358,7 +357,6 @@ func TestResolverPaginate(t *testing.T) {
 				},
 				{
 					RepoRevs: all.RepoRevs[3:],
-					RepoSet:  setOf(all.RepoRevs[3:]),
 				},
 			},
 		},
@@ -374,7 +372,6 @@ func TestResolverPaginate(t *testing.T) {
 			pages: []Resolved{
 				{
 					RepoRevs: all.RepoRevs[3:],
-					RepoSet:  setOf(all.RepoRevs[3:]),
 				},
 			},
 		},

--- a/internal/search/repos/repos_test.go
+++ b/internal/search/repos/repos_test.go
@@ -323,14 +323,6 @@ func TestResolverPaginate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	setOf := func(repos []*search.RepositoryRevisions) map[api.RepoID]types.MinimalRepo {
-		m := make(map[api.RepoID]types.MinimalRepo, len(repos))
-		for _, r := range repos {
-			m[r.Repo.ID] = r.Repo
-		}
-		return m
-	}
-
 	for _, tc := range []struct {
 		name  string
 		opts  search.RepoOptions


### PR DESCRIPTION
This field is no longer used after we introduced paginated repo
resolution.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
