### PR TITLE
searcher: enable actor.HTTPMiddleware

### DIFF
--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/search"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
@@ -75,7 +76,8 @@ func main() {
 	service.Store.Start()
 
 	// Set up handler middleware
-	handler := trace.HTTPTraceMiddleware(service, conf.DefaultClient())
+	handler := actor.HTTPMiddleware(service)
+	handler = trace.HTTPTraceMiddleware(handler, conf.DefaultClient())
 	handler = ot.Middleware(handler)
 
 	host := ""


### PR DESCRIPTION
Enables actor propagation from incoming requests for `searcher`, which will be required for work related to https://github.com/sourcegraph/sourcegraph/issues/27916 .

Closes https://github.com/sourcegraph/sourcegraph/issues/28412 . See https://github.com/sourcegraph/sourcegraph/pull/28117 for more details

Main-dry-run: https://buildkite.com/sourcegraph/sourcegraph/builds/118445