### PR TITLE
ot: rename Middleware to HTTPMiddleware for consistency

### DIFF
--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -101,7 +101,7 @@ func newExternalHTTPHandler(db database.DB, schema *graphql.Schema, gitHubWebhoo
 	h = internalauth.ForbidAllRequestsMiddleware(h)
 	h = internalauth.OverrideAuthMiddleware(db, h)
 	h = tracepkg.HTTPTraceMiddleware(h, conf.DefaultClient())
-	h = ot.Middleware(h)
+	h = ot.HTTPMiddleware(h)
 
 	return h, nil
 }
@@ -135,7 +135,7 @@ func newInternalHTTPHandler(schema *graphql.Schema, db database.DB, newCodeIntel
 	h := http.Handler(internalMux)
 	h = gcontext.ClearHandler(h)
 	h = tracepkg.HTTPTraceMiddleware(h, conf.DefaultClient())
-	h = ot.Middleware(h)
+	h = ot.HTTPMiddleware(h)
 	return h
 }
 

--- a/cmd/github-proxy/github-proxy.go
+++ b/cmd/github-proxy/github-proxy.go
@@ -84,7 +84,7 @@ func main() {
 	}
 	h = instrumentHandler(prometheus.DefaultRegisterer, h)
 	h = trace.HTTPTraceMiddleware(h, conf.DefaultClient())
-	h = ot.Middleware(h)
+	h = ot.HTTPMiddleware(h)
 	http.Handle("/", h)
 
 	host := ""

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -141,7 +141,7 @@ func main() {
 	// Create Handler now since it also initializes state
 
 	// TODO: Why do we set server state as a side effect of creating our handler?
-	handler := ot.Middleware(trace.HTTPTraceMiddleware(gitserver.Handler(), conf.DefaultClient()))
+	handler := ot.HTTPMiddleware(trace.HTTPTraceMiddleware(gitserver.Handler(), conf.DefaultClient()))
 
 	// Ready immediately
 	ready := make(chan struct{})

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -339,7 +339,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	httpSrv := httpserver.NewFromAddr(addr, &http.Server{
 		ReadTimeout:  75 * time.Second,
 		WriteTimeout: 10 * time.Minute,
-		Handler:      ot.Middleware(trace.HTTPTraceMiddleware(authzBypass(handler), conf.DefaultClient())),
+		Handler:      ot.HTTPMiddleware(trace.HTTPTraceMiddleware(authzBypass(handler), conf.DefaultClient())),
 	})
 	goroutine.MonitorBackgroundRoutines(ctx, httpSrv)
 }

--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -76,7 +76,7 @@ func main() {
 
 	// Set up handler middleware
 	handler := trace.HTTPTraceMiddleware(service, conf.DefaultClient())
-	handler = ot.Middleware(handler)
+	handler = ot.HTTPMiddleware(handler)
 
 	host := ""
 	if env.InsecureDev {

--- a/cmd/symbols/main.go
+++ b/cmd/symbols/main.go
@@ -113,7 +113,7 @@ func main() {
 	server := httpserver.NewFromAddr(addr, &http.Server{
 		ReadTimeout:  75 * time.Second,
 		WriteTimeout: 10 * time.Minute,
-		Handler:      ot.Middleware(trace.HTTPTraceMiddleware(apiHandler, conf.DefaultClient())),
+		Handler:      ot.HTTPMiddleware(trace.HTTPTraceMiddleware(apiHandler, conf.DefaultClient())),
 	})
 
 	evictionInterval := time.Second * 10

--- a/internal/trace/ot/ot.go
+++ b/internal/trace/ot/ot.go
@@ -39,13 +39,13 @@ func GetTracePolicy() TracePolicy {
 	return TracePolicy(trPolicy.Load())
 }
 
-// Middleware wraps the handler with the following:
+// HTTPMiddleware wraps the handler with the following:
 //
 // - If the HTTP header, X-Sourcegraph-Should-Trace, is set to a truthy value, set the
 //   shouldTraceKey context.Context value to true
-// - github.com/opentracing-contrib/go-stdlib/nethttp.Middleware, which creates a new span to track
+// - github.com/opentracing-contrib/go-stdlib/nethttp.HTTPMiddleware, which creates a new span to track
 //   the request handler from the global tracer.
-func Middleware(h http.Handler, opts ...nethttp.MWOption) http.Handler {
+func HTTPMiddleware(h http.Handler, opts ...nethttp.MWOption) http.Handler {
 	return MiddlewareWithTracer(opentracing.GlobalTracer(), h)
 }
 


### PR DESCRIPTION
Cosmetic change, pointed out here: https://github.com/sourcegraph/sourcegraph/pull/28117#discussion_r757290599