### PR TITLE
insights: Migrate InsightOrgVisible and InsightTimeIntervals pings to backend

### DIFF
--- a/enterprise/internal/insights/background/pings/insights_ping_aggregators.go
+++ b/enterprise/internal/insights/background/pings/insights_ping_aggregators.go
@@ -179,6 +179,8 @@ const insightIntervalCountsQuery = `
 SELECT COUNT(DISTINCT(ivs.insight_view_id)), series.sample_interval_value, series.sample_interval_unit FROM insight_series AS series
 JOIN insight_view_series AS ivs ON series.id = ivs.insight_series_id
 WHERE series.sample_interval_value != 0
+	AND series.sample_interval_value IS NOT NULL
+	AND series.sample_interval_unit IS NOT NULL
 GROUP BY series.sample_interval_value, series.sample_interval_unit;
 `
 

--- a/enterprise/internal/insights/background/pings/insights_ping_aggregators.go
+++ b/enterprise/internal/insights/background/pings/insights_ping_aggregators.go
@@ -1,0 +1,190 @@
+package pings
+
+import (
+	"context"
+	"fmt"
+
+	insightTypes "github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func (e *InsightsPingEmitter) GetTotalCountByViewType(ctx context.Context) (_ []types.InsightViewsCountPing, err error) {
+	rows, err := e.insightsDb.QueryContext(ctx, insightViewTotalCountQuery)
+	if err != nil {
+		return []types.InsightViewsCountPing{}, err
+	}
+	defer func() { err = rows.Close() }()
+
+	results := make([]types.InsightViewsCountPing, 0)
+	for rows.Next() {
+		stats := types.InsightViewsCountPing{}
+		if err := rows.Scan(&stats.ViewType, &stats.TotalCount); err != nil {
+			return []types.InsightViewsCountPing{}, err
+		}
+		results = append(results, stats)
+	}
+
+	return results, nil
+}
+
+func (e *InsightsPingEmitter) GetTotalCountByViewSeriesType(ctx context.Context) (_ []types.InsightViewSeriesCountPing, err error) {
+	q := fmt.Sprintf(insightViewSeriesTotalCountQuery, generationMethodCaseStr)
+	rows, err := e.insightsDb.QueryContext(ctx, q)
+	if err != nil {
+		return []types.InsightViewSeriesCountPing{}, err
+	}
+	defer func() { err = rows.Close() }()
+
+	results := make([]types.InsightViewSeriesCountPing, 0)
+	for rows.Next() {
+		stats := types.InsightViewSeriesCountPing{}
+		if err := rows.Scan(&stats.ViewType, &stats.GenerationType, &stats.TotalCount); err != nil {
+			return []types.InsightViewSeriesCountPing{}, err
+		}
+		results = append(results, stats)
+	}
+
+	return results, nil
+}
+
+func (e *InsightsPingEmitter) GetTotalCountBySeriesType(ctx context.Context) (_ []types.InsightSeriesCountPing, err error) {
+	q := fmt.Sprintf(insightSeriesTotalCountQuery, generationMethodCaseStr)
+	rows, err := e.insightsDb.QueryContext(ctx, q)
+	if err != nil {
+		return []types.InsightSeriesCountPing{}, err
+	}
+	defer func() { err = rows.Close() }()
+
+	results := make([]types.InsightSeriesCountPing, 0)
+	for rows.Next() {
+		stats := types.InsightSeriesCountPing{}
+		if err := rows.Scan(&stats.GenerationType, &stats.TotalCount); err != nil {
+			return []types.InsightSeriesCountPing{}, err
+		}
+		results = append(results, stats)
+	}
+
+	return results, nil
+}
+
+func (e *InsightsPingEmitter) GetIntervalCounts(ctx context.Context) (_ []types.InsightTimeIntervalPing, err error) {
+	rows, err := e.insightsDb.QueryContext(ctx, insightIntervalCountsQuery)
+	if err != nil {
+		return []types.InsightTimeIntervalPing{}, err
+	}
+	defer func() { err = rows.Close() }()
+
+	results := make([]types.InsightTimeIntervalPing, 0)
+	for rows.Next() {
+		var count, intervalValue int
+		var intervalUnit insightTypes.IntervalUnit
+		if err := rows.Scan(&count, &intervalValue, &intervalUnit); err != nil {
+			return []types.InsightTimeIntervalPing{}, err
+		}
+
+		results = append(results, types.InsightTimeIntervalPing{IntervalDays: getDays(intervalValue, intervalUnit), TotalCount: count})
+	}
+	regroupedResults := regroupIntervalCounts(results)
+	return regroupedResults, nil
+}
+
+func (e *InsightsPingEmitter) GetOrgVisibleInsightCounts(ctx context.Context) (_ []types.OrgVisibleInsightPing, err error) {
+	rows, err := e.insightsDb.QueryContext(ctx, orgVisibleInsightCountsQuery)
+	if err != nil {
+		return []types.OrgVisibleInsightPing{}, err
+	}
+	defer func() { err = rows.Close() }()
+
+	results := make([]types.OrgVisibleInsightPing, 0)
+	for rows.Next() {
+		var count int
+		var presentationType insightTypes.PresentationType
+		if err := rows.Scan(&presentationType, &count); err != nil {
+			return []types.OrgVisibleInsightPing{}, err
+		}
+
+		if presentationType == insightTypes.Line {
+			results = append(results, types.OrgVisibleInsightPing{Type: "search", TotalCount: count})
+		} else {
+			results = append(results, types.OrgVisibleInsightPing{Type: "lang-stats", TotalCount: count})
+		}
+	}
+	return results, nil
+}
+
+func getDays(intervalValue int, intervalUnit insightTypes.IntervalUnit) int {
+	switch intervalUnit {
+	case insightTypes.Month:
+		return intervalValue * 30
+	case insightTypes.Week:
+		return intervalValue * 7
+	case insightTypes.Day:
+		return intervalValue
+	case insightTypes.Hour:
+		// We can't return anything more granular than 1 day.
+		return 0
+	}
+	return 0
+}
+
+// This combines any groups of interval counts that have the same number of days.
+// Example: A group that had unit MONTH and value 1 alongside a group that had unit DAY and value 30.
+func regroupIntervalCounts(fromGroups []types.InsightTimeIntervalPing) []types.InsightTimeIntervalPing {
+	groupByDays := make(map[int]int)
+	newGroups := make([]types.InsightTimeIntervalPing, 0)
+
+	for _, g := range fromGroups {
+		groupByDays[g.IntervalDays] += g.TotalCount
+	}
+	for days, count := range groupByDays {
+		newGroups = append(newGroups, types.InsightTimeIntervalPing{IntervalDays: days, TotalCount: count})
+	}
+	return newGroups
+}
+
+const generationMethodCaseStr = `
+CASE
+   WHEN (sample_interval_unit = 'MONTH' AND sample_interval_value = 0) THEN 'language-stats'
+   WHEN (CARDINALITY(repositories) = 0 OR repositories IS NULL) THEN 'search-global'
+   ELSE 'search'
+END AS generation_method
+`
+
+const insightViewSeriesTotalCountQuery = `
+SELECT presentation_type,
+       %s,
+       COUNT(*)
+FROM insight_series
+         JOIN insight_view_series ivs ON insight_series.id = ivs.insight_series_id
+         JOIN insight_view iv ON ivs.insight_view_id = iv.id
+WHERE deleted_at IS NULL
+GROUP BY presentation_type, generation_method;
+`
+
+const insightSeriesTotalCountQuery = `
+SELECT %s,
+       COUNT(*)
+FROM insight_series
+WHERE deleted_at IS NULL
+GROUP BY generation_method;
+`
+
+const insightViewTotalCountQuery = `
+SELECT presentation_type, COUNT(*)
+FROM insight_view
+GROUP BY presentation_type;
+`
+
+const insightIntervalCountsQuery = `
+SELECT COUNT(DISTINCT(ivs.insight_view_id)), series.sample_interval_value, series.sample_interval_unit FROM insight_series AS series
+JOIN insight_view_series AS ivs ON series.id = ivs.insight_series_id
+WHERE series.sample_interval_value != 0
+GROUP BY series.sample_interval_value, series.sample_interval_unit;
+`
+
+const orgVisibleInsightCountsQuery = `
+SELECT iv.presentation_type, COUNT(iv.presentation_type) FROM insight_view AS iv
+JOIN insight_view_grants AS ivg ON iv.id = ivg.insight_view_id
+WHERE ivg.org_id IS NOT NULL
+GROUP BY iv.presentation_type;
+`

--- a/enterprise/internal/insights/background/pings/insights_ping_emitter.go
+++ b/enterprise/internal/insights/background/pings/insights_ping_emitter.go
@@ -3,7 +3,6 @@ package pings
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/usagestats"
@@ -40,6 +39,22 @@ type InsightsPingEmitter struct {
 func (e *InsightsPingEmitter) emit(ctx context.Context) error {
 	log15.Info("Emitting Code Insights Pings")
 
+	err := e.emitInsightTotalCounts(ctx)
+	if err != nil {
+		return errors.Wrap(err, "emitInsightTotalCounts")
+	}
+	err = e.emitIntervalCounts(ctx)
+	if err != nil {
+		return errors.Wrap(err, "emitIntervalCounts")
+	}
+	err = e.emitOrgVisibleInsightCounts(ctx)
+	if err != nil {
+		return errors.Wrap(err, "emitOrgVisibleInsightCounts")
+	}
+	return nil
+}
+
+func (e *InsightsPingEmitter) emitInsightTotalCounts(ctx context.Context) error {
 	var counts types.InsightTotalCounts
 	byViewType, err := e.GetTotalCountByViewType(ctx)
 	if err != nil {
@@ -66,7 +81,43 @@ func (e *InsightsPingEmitter) emit(ctx context.Context) error {
 
 	err = e.SaveEvent(ctx, usagestats.InsightsTotalCountPingName, marshal)
 	if err != nil {
-		return errors.Wrap(err, "InsightsPingEmit")
+		return errors.Wrap(err, "SaveEvent")
+	}
+	return nil
+}
+
+func (e *InsightsPingEmitter) emitIntervalCounts(ctx context.Context) error {
+	counts, err := e.GetIntervalCounts(ctx)
+	if err != nil {
+		return errors.Wrap(err, "GetIntervalCounts")
+	}
+
+	marshal, err := json.Marshal(counts)
+	if err != nil {
+		return errors.Wrap(err, "Marshal")
+	}
+
+	err = e.SaveEvent(ctx, usagestats.InsightsIntervalCountsPingName, marshal)
+	if err != nil {
+		return errors.Wrap(err, "SaveEvent")
+	}
+	return nil
+}
+
+func (e *InsightsPingEmitter) emitOrgVisibleInsightCounts(ctx context.Context) error {
+	counts, err := e.GetOrgVisibleInsightCounts(ctx)
+	if err != nil {
+		return errors.Wrap(err, "GetOrgVisibleInsightCounts")
+	}
+
+	marshal, err := json.Marshal(counts)
+	if err != nil {
+		return errors.Wrap(err, "Marshal")
+	}
+
+	err = e.SaveEvent(ctx, usagestats.InsightsOrgVisibleInsightsPingName, marshal)
+	if err != nil {
+		return errors.Wrap(err, "SaveEvent")
 	}
 	return nil
 }
@@ -87,107 +138,3 @@ func (e *InsightsPingEmitter) SaveEvent(ctx context.Context, name string, argume
 	}
 	return nil
 }
-
-func (e *InsightsPingEmitter) GetTotalCountByViewType(ctx context.Context) (_ []types.InsightViewsCountPing, err error) {
-	rows, err := e.insightsDb.QueryContext(ctx, insightViewTotalCountQuery)
-	if err != nil {
-		return nil, err
-	}
-
-	if err != nil {
-		return []types.InsightViewsCountPing{}, err
-	}
-	defer func() { err = rows.Close() }()
-
-	results := make([]types.InsightViewsCountPing, 0)
-	for rows.Next() {
-		stats := types.InsightViewsCountPing{}
-		if err := rows.Scan(&stats.ViewType, &stats.TotalCount); err != nil {
-			return []types.InsightViewsCountPing{}, err
-		}
-		results = append(results, stats)
-	}
-
-	return results, nil
-}
-
-func (e *InsightsPingEmitter) GetTotalCountByViewSeriesType(ctx context.Context) (_ []types.InsightViewSeriesCountPing, err error) {
-	q := fmt.Sprintf(insightViewSeriesTotalCountQuery, generationMethodCaseStr)
-	rows, err := e.insightsDb.QueryContext(ctx, q)
-	if err != nil {
-		return nil, err
-	}
-
-	if err != nil {
-		return []types.InsightViewSeriesCountPing{}, err
-	}
-	defer func() { err = rows.Close() }()
-
-	results := make([]types.InsightViewSeriesCountPing, 0)
-	for rows.Next() {
-		stats := types.InsightViewSeriesCountPing{}
-		if err := rows.Scan(&stats.ViewType, &stats.GenerationType, &stats.TotalCount); err != nil {
-			return []types.InsightViewSeriesCountPing{}, err
-		}
-		results = append(results, stats)
-	}
-
-	return results, nil
-}
-
-func (e *InsightsPingEmitter) GetTotalCountBySeriesType(ctx context.Context) (_ []types.InsightSeriesCountPing, err error) {
-	q := fmt.Sprintf(insightSeriesTotalCountQuery, generationMethodCaseStr)
-	rows, err := e.insightsDb.QueryContext(ctx, q)
-	if err != nil {
-		return nil, err
-	}
-
-	if err != nil {
-		return []types.InsightSeriesCountPing{}, err
-	}
-	defer func() { err = rows.Close() }()
-
-	results := make([]types.InsightSeriesCountPing, 0)
-	for rows.Next() {
-		stats := types.InsightSeriesCountPing{}
-		if err := rows.Scan(&stats.GenerationType, &stats.TotalCount); err != nil {
-			return []types.InsightSeriesCountPing{}, err
-		}
-		results = append(results, stats)
-	}
-
-	return results, nil
-}
-
-const generationMethodCaseStr = `
-CASE
-   WHEN (sample_interval_unit = 'MONTH' AND sample_interval_value = 0) THEN 'language-stats'
-   WHEN (CARDINALITY(repositories) = 0 OR repositories IS NULL) THEN 'search-global'
-   ELSE 'search'
-END AS generation_method
-`
-
-const insightViewSeriesTotalCountQuery = `
-SELECT presentation_type,
-       %s,
-       COUNT(*)
-FROM insight_series
-         JOIN insight_view_series ivs ON insight_series.id = ivs.insight_series_id
-         JOIN insight_view iv ON ivs.insight_view_id = iv.id
-WHERE deleted_at IS NULL
-GROUP BY presentation_type, generation_method;
-`
-
-const insightSeriesTotalCountQuery = `
-SELECT %s,
-       COUNT(*)
-FROM insight_series
-WHERE deleted_at IS NULL
-GROUP BY generation_method;
-`
-
-const insightViewTotalCountQuery = `
-SELECT presentation_type, COUNT(*)
-FROM insight_view
-GROUP BY presentation_type;
-`

--- a/internal/usagestats/code_insights_test.go
+++ b/internal/usagestats/code_insights_test.go
@@ -100,7 +100,7 @@ func TestCodeInsightsUsageStatistics(t *testing.T) {
 
 	want.WeeklyAggregatedUsage = wantedWeeklyUsage
 	want.InsightTimeIntervals = []types.InsightTimeIntervalPing{}
-	want.InsightOrgVisible = []types.OrgVisibleInsightPing{{Type: "search"}, {Type: "lang-stats"}}
+	want.InsightOrgVisible = []types.OrgVisibleInsightPing{}
 
 	if diff := cmp.Diff(want, have); diff != "" {
 		t.Fatal(diff)


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/24481

Note: Wait to merge this until after https://github.com/sourcegraph/sourcegraph/pull/27473

## Description
The `InsightOrgVisible` ping and the `InsightTimeIntervals` ping used to be calculated by parsing the settings. With this PR they are now calculated by querying the database.

I also did a bit of refactoring, which I hope makes this easier to extend in the future:
- Broke `insight_ping_emitter.go` into 2 files: one with the functions that collect/format the aggregates and the other with the emitter itself.
- Simplified the `emit` function by breaking out separate functions for each thing we want to emit.

Side note: I'm sorry the diff is so hard to read. I probably should have done the refactor in a separate commit.

## Testing Steps
I tested this by running the SQL queries against my local database and then verifying that the pings showed the correct values here: https://sourcegraph.test:3443/site-admin/pings

I also tested out the edge case where the `InsightTimeIntervals` get regrouped due to there being some kind of overlap (for example, 30 days vs 1 month.)