### PR TITLE
migrator: Add skeleton service

### DIFF
--- a/cmd/migrator/Dockerfile
+++ b/cmd/migrator/Dockerfile
@@ -1,0 +1,18 @@
+FROM sourcegraph/alpine-3.12:116273_2021-11-12_dbac772@sha256:78995f23b1dbadb35ba4a153adecde3f309ee3763888e4172e0f8dc05c9728d3
+
+ARG COMMIT_SHA="unknown"
+ARG DATE="unknown"
+ARG VERSION="unknown"
+
+LABEL org.opencontainers.image.revision=${COMMIT_SHA}
+LABEL org.opencontainers.image.created=${DATE}
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
+
+# hadolint ignore=DL3018
+RUN apk update && apk add --no-cache \
+    tini
+
+USER sourcegraph
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/migrator"]
+COPY migrator /usr/local/bin/

--- a/cmd/migrator/README.md
+++ b/cmd/migrator/README.md
@@ -1,0 +1,5 @@
+# Migrator
+
+The migrator service is deployed ahead of a Sourcegraph version upgrade to synchronously run database migrations required by the next version. Successful exit of the migrator denotes that the new version can be deployed. Database migrations are written to be backwards-compatible so that running the migrator for the next upgrade does not cause issues with a working instance.
+
+At this point in time, this service no-ops on invocation and is meant to be a development placeholder while we modify CI pipelines and upgrade instructions.

--- a/cmd/migrator/build.sh
+++ b/cmd/migrator/build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# This script builds the migrator docker image.
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+set -eu
+
+OUTPUT=$(mktemp -d -t sgdockerbuild_XXXXXXX)
+cleanup() {
+  rm -rf "$OUTPUT"
+}
+trap cleanup EXIT
+
+# Environment for building linux binaries
+export GO111MODULE=on
+export GOARCH=amd64
+export GOOS=linux
+export CGO_ENABLED=0
+
+echo "--- go build"
+pkg="github.com/sourcegraph/sourcegraph/cmd/migrator"
+go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"
+
+echo "--- docker build"
+docker build -f cmd/migrator/Dockerfile -t "$IMAGE" "$OUTPUT" \
+  --progress=plain \
+  --build-arg COMMIT_SHA \
+  --build-arg DATE \
+  --build-arg VERSION

--- a/cmd/migrator/main.go
+++ b/cmd/migrator/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Printf("GOOD TO GO :salute:\n")
+	os.Exit(0)
+}

--- a/enterprise/dev/ci/images/images.go
+++ b/enterprise/dev/ci/images/images.go
@@ -81,6 +81,7 @@ var DeploySourcegraphDockerImages = []string{
 	"symbols",
 	"syntax-highlighter",
 	"worker",
+	"migrator",
 }
 
 // CandidateImageTag provides the tag for a candidate image built for this Buildkite run.


### PR DESCRIPTION
Add no-op migrator service. Partial effort towards https://github.com/sourcegraph/sourcegraph/issues/25253. Next steps will be to include this in CI pipelines (https://github.com/sourcegraph/sourcegraph/issues/25255 and https://github.com/sourcegraph/sourcegraph/issues/25256), and expanding this service to actually run migrations synchronously.

Once this is in place we can stop running migrations on application startup and replace it with a check to ensure it's already up to date.