### PR TITLE
Improve Percy test coverage

### DIFF
--- a/client/web/src/integration/insights/insights-visual.test.ts
+++ b/client/web/src/integration/insights/insights-visual.test.ts
@@ -202,4 +202,14 @@ describe('[VISUAL] Code insights page', () => {
         await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/dashboards/all')
         await takeChartSnapshot('Code insights page with all types of insight')
     })
+
+    describe('Add dashboard page', () => {
+        it('is styled correctly', async () => {
+            overrideGraphQLExtensions({ testContext })
+            await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/add-dashboard')
+            await driver.page.waitForSelector('input[name="name"]')
+
+            await percySnapshotWithVariants(driver.page, 'Add new dashboard page')
+        })
+    })
 })

--- a/client/web/src/integration/insights/insights-visual.test.ts
+++ b/client/web/src/integration/insights/insights-visual.test.ts
@@ -209,7 +209,7 @@ describe('[VISUAL] Code insights page', () => {
             await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/add-dashboard')
             await driver.page.waitForSelector('input[name="name"]')
 
-            await percySnapshotWithVariants(driver.page, 'Add new dashboard page')
+            await percySnapshotWithVariants(driver.page, 'Code insights add new dashboard page')
         })
     })
 })

--- a/client/web/src/integration/sign-in.test.ts
+++ b/client/web/src/integration/sign-in.test.ts
@@ -1,0 +1,38 @@
+import { createDriverForTest, Driver } from '@sourcegraph/shared/src/testing/driver'
+import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
+
+import { createWebIntegrationTestContext, WebIntegrationTestContext } from './context'
+import { commonWebGraphQlResults } from './graphQlResults'
+import { percySnapshotWithVariants } from './utils'
+
+describe('SignIn', () => {
+    let driver: Driver
+    before(async () => {
+        driver = await createDriverForTest()
+    })
+    after(() => driver?.close())
+    let testContext: WebIntegrationTestContext
+    beforeEach(async function () {
+        testContext = await createWebIntegrationTestContext({
+            driver,
+            currentTest: this.currentTest!,
+            directory: __dirname,
+        })
+    })
+    afterEachSaveScreenshotIfFailed(() => driver.page)
+    afterEach(() => testContext?.dispose())
+
+    it('is styled correctly', async () => {
+        testContext.overrideGraphQL({
+            ...commonWebGraphQlResults,
+            CurrentAuthState: () => ({
+                currentUser: null,
+            }),
+        })
+        await driver.page.goto(driver.sourcegraphBaseUrl + '/sign-in')
+        await driver.page.waitForSelector('#username-or-email')
+        await driver.page.waitForSelector('input[name="password"]')
+
+        await percySnapshotWithVariants(driver.page, 'Sign in page')
+    })
+})

--- a/enterprise/dev/ci/internal/ci/web-integration-workloads.go
+++ b/enterprise/dev/ci/internal/ci/web-integration-workloads.go
@@ -1,6 +1,7 @@
 package ci
 
 import (
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -41,7 +42,7 @@ func getWebIntegrationFileNames() []string {
 
 func chunkItems(items []string, size int) [][]string {
 	lenItems := len(items)
-	lenChunks := lenItems/size + 1
+	lenChunks := int(math.Ceil(float64(lenItems) / float64(size)))
 	chunks := make([][]string, lenChunks)
 
 	for i := 0; i < lenChunks; i++ {


### PR DESCRIPTION
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
## Description
To improve web application visual test coverage by adding percy snapshot tests to more core functionalities.

## Refs
[Gitstart Task](https://app.gitstart.com/tasks/27777)

## Description
### Pages To Cover
- [x] SignIn Page: [Link](https://k8s.sgdev.org/sign-in)
- [x] Add Dashboad Page: [Link](https://k8s.sgdev.org/insights/add-dashboard)
- [x] Add Saved Search Form : [Link](https://k8s.sgdev.org/users/gitstart/searches/add)

## Success criteria
1. Important parts of the web application not covered with visual tests are identified. 
    - 4h estimate.
    - use https://k8s.sgdev.org/ to explore pages that are not covered.
    - use this [Percy report](https://percy.io/Sourcegraph/Sourcegraph/builds/14121239/unchanged/798203119?activeBrowserFamilySlug=chrome&activeViewMode=new&activeWidth=1920&subcategories=approved&viewLayout=side-by-side) to see which pages are already covered.
2. Integration tests rendering these parts of the app are identified.
    - 4h estimate.
    - find integration tests here `client/web/src/integration/**.test.ts`.
    - see documentation on how to run integration tests locally [here](https://docs.sourcegraph.com/dev/how-to/testing#client-integration-tests).
3. Percy screenshots are added to the integration tests identified in the previous step.
    - 2h estimate.
    - use `percySnapshotWithVariants` to make a Percy snapshot for a selected page in the integration test.
