### PR TITLE
Improve Percy test coverage

### DIFF
--- a/client/web/src/integration/batches.test.ts
+++ b/client/web/src/integration/batches.test.ts
@@ -479,6 +479,13 @@ describe('Batches', () => {
         })
     })
 
+    describe('Create batch changes', () => {
+        it('is styled correctly', async () => {
+            await driver.page.goto(driver.sourcegraphBaseUrl + '/batch-changes/create')
+            await percySnapshotWithVariants(driver.page, 'Create batch change')
+        })
+    })
+
     describe('Batch changes details', () => {
         for (const entityType of ['user', 'org'] as const) {
             it(`displays a single batch change for ${entityType}`, async () => {

--- a/client/web/src/integration/search-contexts.test.ts
+++ b/client/web/src/integration/search-contexts.test.ts
@@ -234,7 +234,7 @@ describe('Search contexts', () => {
         )
 
         // Take Snapshot
-        await percySnapshotWithVariants(driver.page, 'Create context page')
+        await percySnapshotWithVariants(driver.page, 'Create search context page')
 
         // Click create
         await driver.page.click('[data-testid="search-context-submit-button"]')

--- a/client/web/src/integration/search-contexts.test.ts
+++ b/client/web/src/integration/search-contexts.test.ts
@@ -14,6 +14,7 @@ import { WebIntegrationTestContext, createWebIntegrationTestContext } from './co
 import { createRepositoryRedirectResult } from './graphQlResponseHelpers'
 import { commonWebGraphQlResults } from './graphQlResults'
 import { siteGQLID, siteID } from './jscontext'
+import { percySnapshotWithVariants } from './utils'
 
 const commonSearchGraphQLResults: Partial<WebGraphQlOperations & SharedGraphQlOperations> = {
     ...commonWebGraphQlResults,
@@ -231,6 +232,9 @@ describe('Search contexts', () => {
         await driver.page.waitForSelector(
             '[data-testid="repositories-config-button"] [data-testid="repositories-config-success"]'
         )
+
+        // Take Snapshot
+        await percySnapshotWithVariants(driver.page, 'Create context page')
 
         // Click create
         await driver.page.click('[data-testid="search-context-submit-button"]')
@@ -497,6 +501,8 @@ describe('Search contexts', () => {
             {},
             searchContextsCount
         )
+
+        await percySnapshotWithVariants(driver.page, 'Search contexts list page')
     })
 
     test('Switching contexts with empty query', async () => {


### PR DESCRIPTION
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
## Description
To improve web application visual test coverage by adding percy snapshot tests to more core functionalities.

## Refs
[Gitstart Task](https://app.gitstart.com/tasks/27776)
[Sourcegraph Issue](https://github.com/sourcegraph/sourcegraph/issues/28129)

## Description
### Pages To Cover

- [x] Create Context page: [Link](https://k8s.sgdev.org/contexts/new)
- [x] Contexts list: [Link](https://k8s.sgdev.org/contexts)
- [x] Create batch change: [Link](https://k8s.sgdev.org/batch-changes/create)

## Success criteria
1. Important parts of the web application not covered with visual tests are identified. 
    - 4h estimate.
    - use https://k8s.sgdev.org/ to explore pages that are not covered.
    - use this [Percy report](https://percy.io/Sourcegraph/Sourcegraph/builds/14121239/unchanged/798203119?activeBrowserFamilySlug=chrome&activeViewMode=new&activeWidth=1920&subcategories=approved&viewLayout=side-by-side) to see which pages are already covered.
2. Integration tests rendering these parts of the app are identified.
    - 4h estimate.
    - find integration tests here `client/web/src/integration/**.test.ts`.
    - see documentation on how to run integration tests locally [here](https://docs.sourcegraph.com/dev/how-to/testing#client-integration-tests).
3. Percy screenshots are added to the integration tests identified in the previous step.
    - 2h estimate.
    - use `percySnapshotWithVariants` to make a Percy snapshot for a selected page in the integration test.