### PR TITLE
search: factor out private user repo lookup

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1538,6 +1538,43 @@ func withResultTypes(args search.TextParameters, forceTypes result.Types) search
 	return args
 }
 
+func privateReposForUser(ctx context.Context, db database.DB, repoOptions search.RepoOptions) []types.MinimalRepo {
+	userID := int32(0)
+
+	if envvar.SourcegraphDotComMode() {
+		if a := actor.FromContext(ctx); a != nil {
+			userID = a.UID
+		}
+	}
+
+	tr, ctx := trace.New(ctx, "privateReposForUser", strconv.Itoa(int(userID)))
+	defer tr.Finish()
+
+	// Get all private repos for the the current actor. On sourcegraph.com, those are
+	// only the repos directly added by the user. Otherwise it's all repos the user has
+	// access to on all connected code hosts / external services.
+	//
+	// TODO: We should use repos.Resolve here. However, the logic for
+	// UserID is different to repos.Resolve, so we need to work out how
+	// best to address that first.
+	userPrivateRepos, err := db.Repos().ListMinimalRepos(ctx, database.ReposListOptions{
+		UserID:         userID, // Zero valued when not in sourcegraph.com mode
+		OnlyPrivate:    true,
+		LimitOffset:    &database.LimitOffset{Limit: search.SearchLimits(conf.Get()).MaxRepos + 1},
+		OnlyForks:      repoOptions.OnlyForks,
+		NoForks:        repoOptions.NoForks,
+		OnlyArchived:   repoOptions.OnlyArchived,
+		NoArchived:     repoOptions.NoArchived,
+		ExcludePattern: repos.UnionRegExps(repoOptions.MinusRepoFilters),
+	})
+
+	if err != nil {
+		log15.Error("doResults: failed to list user private repos", "error", err, "user-id", userID)
+		tr.LazyPrintf("error resolving user private repos: %v", err)
+	}
+	return userPrivateRepos
+}
+
 // doResults is one of the highest level search functions that handles finding results.
 //
 // If forceOnlyResultType is specified, only results of the given type are returned,
@@ -1610,38 +1647,7 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 	// search results with resolved repos.
 	if globalSearch {
 		argsIndexed := *args
-
-		userID := int32(0)
-		if envvar.SourcegraphDotComMode() {
-			if a := actor.FromContext(ctx); a != nil {
-				userID = a.UID
-			}
-		}
-
-		// Get all private repos for the the current actor. On sourcegraph.com, those are
-		// only the repos directly added by the user. Otherwise it's all repos the user has
-		// access to on all connected code hosts / external services.
-		//
-		// TODO: We should use repos.Resolve here. However, the logic for
-		// UserID is different to repos.Resolve, so we need to work out how
-		// best to address that first.
-		userPrivateRepos, err := r.db.Repos().ListMinimalRepos(ctx, database.ReposListOptions{
-			UserID:         userID, // Zero valued when not in sourcegraph.com mode
-			OnlyPrivate:    true,
-			LimitOffset:    &database.LimitOffset{Limit: search.SearchLimits(conf.Get()).MaxRepos + 1},
-			OnlyForks:      args.RepoOptions.OnlyForks,
-			NoForks:        args.RepoOptions.NoForks,
-			OnlyArchived:   args.RepoOptions.OnlyArchived,
-			NoArchived:     args.RepoOptions.NoArchived,
-			ExcludePattern: repos.UnionRegExps(args.RepoOptions.MinusRepoFilters),
-		})
-
-		if err != nil {
-			log15.Error("doResults: failed to list user private repos", "error", err, "user-id", userID)
-			tr.LazyPrintf("error resolving user private repos: %v", err)
-		} else {
-			argsIndexed.UserPrivateRepos = userPrivateRepos
-		}
+		argsIndexed.UserPrivateRepos = privateReposForUser(ctx, r.db, args.RepoOptions)
 
 		wg := waitGroup(true)
 		if args.ResultTypes.Has(result.TypeFile | result.TypePath) {


### PR DESCRIPTION
As in title, just moving to a function. Needed because I want to call this for the global search jobs that just need private repos with a different control flow structure.