### PR TITLE
gitserver: use standardized actor propagation

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -139,9 +139,10 @@ func main() {
 	}
 
 	// Create Handler now since it also initializes state
-
 	// TODO: Why do we set server state as a side effect of creating our handler?
-	handler := ot.HTTPMiddleware(trace.HTTPTraceMiddleware(gitserver.Handler(), conf.DefaultClient()))
+	handler := gitserver.Handler()
+	handler = actor.HTTPMiddleware(handler)
+	handler = ot.HTTPMiddleware(trace.HTTPTraceMiddleware(handler, conf.DefaultClient()))
 
 	// Ready immediately
 	ready := make(chan struct{})

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -960,13 +960,13 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 		Observe(time.Since(searchStart).Seconds())
 
 	if honey.Enabled() || traceLogs {
-		actor := r.Header.Get("X-Sourcegraph-Actor")
+		act := actor.FromContext(ctx)
 		ev := honey.NewEvent("gitserver-search")
-		ev.SetSampleRate(honeySampleRate("", actor == "internal"))
+		ev.SetSampleRate(honeySampleRate("", act.IsInternal()))
 		ev.AddField("repo", args.Repo)
 		ev.AddField("revisions", args.Revisions)
 		ev.AddField("include_diff", args.IncludeDiff)
-		ev.AddField("actor", actor)
+		ev.AddField("actor", act.UIDString())
 		ev.AddField("query", args.Query.String())
 		ev.AddField("limit", args.Limit)
 		ev.AddField("duration_ms", time.Since(searchStart).Milliseconds())
@@ -1193,13 +1193,13 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 			isSlow := cmdDuration > shortGitCommandSlow(req.Args)
 			isSlowFetch := fetchDuration > 10*time.Second
 			if honey.Enabled() || traceLogs || isSlow || isSlowFetch {
-				actor := r.Header.Get("X-Sourcegraph-Actor")
+				act := actor.FromContext(ctx)
 				ev := honey.NewEvent("gitserver-exec")
-				ev.SetSampleRate(honeySampleRate(cmd, actor == "internal"))
+				ev.SetSampleRate(honeySampleRate(cmd, act.IsInternal()))
 				ev.AddField("repo", req.Repo)
 				ev.AddField("cmd", cmd)
 				ev.AddField("args", args)
-				ev.AddField("actor", actor)
+				ev.AddField("actor", act.UIDString())
 				ev.AddField("ensure_revision", req.EnsureRevision)
 				ev.AddField("ensure_revision_status", ensureRevisionStatus)
 				ev.AddField("client", r.UserAgent())
@@ -1430,13 +1430,13 @@ func (s *Server) p4exec(w http.ResponseWriter, r *http.Request, req *protocol.P4
 
 			isSlow := cmdDuration > 30*time.Second
 			if honey.Enabled() || traceLogs || isSlow {
-				actor := r.Header.Get("X-Sourcegraph-Actor")
+				act := actor.FromContext(ctx)
 				ev := honey.NewEvent("gitserver-p4exec")
-				ev.SetSampleRate(honeySampleRate(cmd, actor == "internal"))
+				ev.SetSampleRate(honeySampleRate(cmd, act.IsInternal()))
 				ev.AddField("p4port", req.P4Port)
 				ev.AddField("cmd", cmd)
 				ev.AddField("args", args)
-				ev.AddField("actor", actor)
+				ev.AddField("actor", act.UIDString())
 				ev.AddField("client", r.UserAgent())
 				ev.AddField("duration_ms", duration.Milliseconds())
 				ev.AddField("stdout_size", stdoutN)

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -961,6 +961,9 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 
 	if honey.Enabled() || traceLogs {
 		act := actor.FromContext(ctx)
+		if act.UID == 0 && !act.IsInternal() {
+			act = legacyActorFromReq(r)
+		}
 		ev := honey.NewEvent("gitserver-search")
 		ev.SetSampleRate(honeySampleRate("", act.IsInternal()))
 		ev.AddField("repo", args.Repo)
@@ -1194,6 +1197,9 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 			isSlowFetch := fetchDuration > 10*time.Second
 			if honey.Enabled() || traceLogs || isSlow || isSlowFetch {
 				act := actor.FromContext(ctx)
+				if act.UID == 0 && !act.IsInternal() {
+					act = legacyActorFromReq(r)
+				}
 				ev := honey.NewEvent("gitserver-exec")
 				ev.SetSampleRate(honeySampleRate(cmd, act.IsInternal()))
 				ev.AddField("repo", req.Repo)
@@ -1431,6 +1437,9 @@ func (s *Server) p4exec(w http.ResponseWriter, r *http.Request, req *protocol.P4
 			isSlow := cmdDuration > 30*time.Second
 			if honey.Enabled() || traceLogs || isSlow {
 				act := actor.FromContext(ctx)
+				if act.UID == 0 && !act.IsInternal() {
+					act = legacyActorFromReq(r)
+				}
 				ev := honey.NewEvent("gitserver-p4exec")
 				ev.SetSampleRate(honeySampleRate(cmd, act.IsInternal()))
 				ev.AddField("p4port", req.P4Port)
@@ -2475,4 +2484,18 @@ func isAbsoluteRevision(s string) bool {
 		}
 	}
 	return true
+}
+
+// legacyActorFromReq generates an actor using the legacy method of propagating
+// actors for gitserver observability, for the purposes of backcompat.
+//
+// TODO(@bobheadxi): Remove when all deployments are updated.
+func legacyActorFromReq(req *http.Request) *actor.Actor {
+	actStr := req.Header.Get("X-Sourcegraph-Actor")
+	if actStr == "internal" {
+		return &actor.Actor{Internal: true}
+	}
+	// Just let 0 value be ID for simplicity
+	actID, _ := strconv.Atoi(actStr)
+	return &actor.Actor{UID: int32(actID)}
 }

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/sourcegraph/go-rendezvous"
 
-	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitolite"
@@ -1025,7 +1024,6 @@ func (c *Client) do(ctx context.Context, repo api.RepoName, method, uri string, 
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", c.UserAgent)
-	req.Header.Set("X-Sourcegraph-Actor", userFromContext(ctx))
 	req = req.WithContext(ctx)
 
 	if c.HTTPLimiter != nil {
@@ -1040,17 +1038,6 @@ func (c *Client) do(ctx context.Context, repo api.RepoName, method, uri string, 
 	defer ht.Finish()
 
 	return c.HTTPClient.Do(req)
-}
-
-func userFromContext(ctx context.Context) string {
-	a := actor.FromContext(ctx)
-	if a == nil {
-		return "0"
-	}
-	if a.Internal {
-		return "internal"
-	}
-	return a.UIDString()
 }
 
 // CreateCommitFromPatch will attempt to create a commit from a patch

--- a/internal/repos/gitolite.go
+++ b/internal/repos/gitolite.go
@@ -42,8 +42,8 @@ func NewGitoliteSource(svc *types.ExternalService, cf *httpcli.Factory) (*Gitoli
 	gitserverDoer, err := cf.Doer(
 		httpcli.NewMaxIdleConnsPerHostOpt(500),
 		// The provided httpcli.Factory is one used for external services - however,
-		// GitoliteSource asks gitserver to gitolite instead, so we have to ensure
-		// that the actor transport used for internal clients is provided.
+		// GitoliteSource asks gitserver to communicate to gitolite instead, so we
+		// have to ensure that the actor transport used for internal clients is provided.
 		httpcli.ActorTransportOpt)
 	if err != nil {
 		return nil, err

--- a/internal/repos/gitolite.go
+++ b/internal/repos/gitolite.go
@@ -2,7 +2,6 @@ package repos
 
 import (
 	"context"
-	"net/http"
 	"strings"
 
 	"github.com/cockroachdb/errors"
@@ -40,12 +39,12 @@ func NewGitoliteSource(svc *types.ExternalService, cf *httpcli.Factory) (*Gitoli
 		return nil, errors.Wrapf(err, "external service id=%d config error", svc.ID)
 	}
 
-	hc, err := cf.Doer(func(c *http.Client) error {
-		if tr, ok := c.Transport.(*http.Transport); ok {
-			tr.MaxIdleConnsPerHost = 500
-		}
-		return nil
-	})
+	gitserverDoer, err := cf.Doer(
+		httpcli.NewMaxIdleConnsPerHostOpt(500),
+		// The provided httpcli.Factory is one used for external services - however,
+		// GitoliteSource asks gitserver to gitolite instead, so we have to ensure
+		// that the actor transport used for internal clients is provided.
+		httpcli.ActorTransportOpt)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +62,7 @@ func NewGitoliteSource(svc *types.ExternalService, cf *httpcli.Factory) (*Gitoli
 	return &GitoliteSource{
 		svc:     svc,
 		conn:    &c,
-		cli:     gitserver.NewClient(hc),
+		cli:     gitserver.NewClient(gitserverDoer),
 		exclude: exclude,
 	}, nil
 }


### PR DESCRIPTION
Removes the custom actor propagation that `gitserver` and `gitserver.Client` uses, in favour of leveraging the standardized actor propagation introduced in https://github.com/sourcegraph/sourcegraph/issues/27918. There should be no behavioural changes, since this actor data is only used for observability on the `gitserver` side, and serverside backcompat with the old header is retained for the time being.

One particular usage of `gitserver.Client`, in `NewGitoliteSource`, required adding the actor transport manually because the external source constructors are provided a `httpcli.ExternalClientFactory`, which does not have the actor propagation transport set up.

Closes https://github.com/sourcegraph/sourcegraph/issues/28448