### PR TITLE
search: move private user repo look up to repos package

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -24,7 +24,6 @@ import (
 	searchlogs "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/logs"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/deviceid"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
@@ -1538,43 +1537,6 @@ func withResultTypes(args search.TextParameters, forceTypes result.Types) search
 	return args
 }
 
-func privateReposForUser(ctx context.Context, db database.DB, repoOptions search.RepoOptions) []types.MinimalRepo {
-	userID := int32(0)
-
-	if envvar.SourcegraphDotComMode() {
-		if a := actor.FromContext(ctx); a != nil {
-			userID = a.UID
-		}
-	}
-
-	tr, ctx := trace.New(ctx, "privateReposForUser", strconv.Itoa(int(userID)))
-	defer tr.Finish()
-
-	// Get all private repos for the the current actor. On sourcegraph.com, those are
-	// only the repos directly added by the user. Otherwise it's all repos the user has
-	// access to on all connected code hosts / external services.
-	//
-	// TODO: We should use repos.Resolve here. However, the logic for
-	// UserID is different to repos.Resolve, so we need to work out how
-	// best to address that first.
-	userPrivateRepos, err := db.Repos().ListMinimalRepos(ctx, database.ReposListOptions{
-		UserID:         userID, // Zero valued when not in sourcegraph.com mode
-		OnlyPrivate:    true,
-		LimitOffset:    &database.LimitOffset{Limit: search.SearchLimits(conf.Get()).MaxRepos + 1},
-		OnlyForks:      repoOptions.OnlyForks,
-		NoForks:        repoOptions.NoForks,
-		OnlyArchived:   repoOptions.OnlyArchived,
-		NoArchived:     repoOptions.NoArchived,
-		ExcludePattern: repos.UnionRegExps(repoOptions.MinusRepoFilters),
-	})
-
-	if err != nil {
-		log15.Error("doResults: failed to list user private repos", "error", err, "user-id", userID)
-		tr.LazyPrintf("error resolving user private repos: %v", err)
-	}
-	return userPrivateRepos
-}
-
 // doResults is one of the highest level search functions that handles finding results.
 //
 // If forceOnlyResultType is specified, only results of the given type are returned,
@@ -1647,7 +1609,16 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 	// search results with resolved repos.
 	if globalSearch {
 		argsIndexed := *args
-		argsIndexed.UserPrivateRepos = privateReposForUser(ctx, r.db, args.RepoOptions)
+
+		userID := int32(0)
+
+		if envvar.SourcegraphDotComMode() {
+			if a := actor.FromContext(ctx); a != nil {
+				userID = a.UID
+			}
+		}
+
+		argsIndexed.UserPrivateRepos = repos.PrivateReposForUser(ctx, r.db, userID, args.RepoOptions)
 
 		wg := waitGroup(true)
 		if args.ResultTypes.Has(result.TypeFile | result.TypePath) {

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/hashicorp/go-multierror"
+	"github.com/inconshreveable/log15"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
@@ -692,4 +693,33 @@ func HandleRepoSearchResult(repoRev *search.RepositoryRevisions, limitHit, timed
 		Status:     search.RepoStatusSingleton(repoRev.Repo.ID, status),
 		IsLimitHit: limitHit,
 	}, fatalErr
+}
+
+func PrivateReposForUser(ctx context.Context, db database.DB, userID int32, repoOptions search.RepoOptions) []types.MinimalRepo {
+	tr, ctx := trace.New(ctx, "privateReposForUser", strconv.Itoa(int(userID)))
+	defer tr.Finish()
+
+	// Get all private repos for the the current actor. On sourcegraph.com, those are
+	// only the repos directly added by the user. Otherwise it's all repos the user has
+	// access to on all connected code hosts / external services.
+	//
+	// TODO: We should use repos.Resolve here. However, the logic for
+	// UserID is different to repos.Resolve, so we need to work out how
+	// best to address that first.
+	userPrivateRepos, err := db.Repos().ListMinimalRepos(ctx, database.ReposListOptions{
+		UserID:         userID, // Zero valued when not in sourcegraph.com mode
+		OnlyPrivate:    true,
+		LimitOffset:    &database.LimitOffset{Limit: search.SearchLimits(conf.Get()).MaxRepos + 1},
+		OnlyForks:      repoOptions.OnlyForks,
+		NoForks:        repoOptions.NoForks,
+		OnlyArchived:   repoOptions.OnlyArchived,
+		NoArchived:     repoOptions.NoArchived,
+		ExcludePattern: UnionRegExps(repoOptions.MinusRepoFilters),
+	})
+
+	if err != nil {
+		log15.Error("doResults: failed to list user private repos", "error", err, "user-id", userID)
+		tr.LazyPrintf("error resolving user private repos: %v", err)
+	}
+	return userPrivateRepos
 }


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/28449.

Mini epiphany: I think this function can actually live in the repos package, and this is useful now because (a) it de-bloats `graphqlbackend` and (b) I can call it from `unindexed` and `symbols` packages, where the global search jobs will live and resolve private repos from (in a few upcoming PRs, we won't need to reference this functionality in graphqlbackend).

This PR just moves and exports the function.