### PR TITLE
Fix browser extension flaky e2e tests

### DIFF
--- a/client/browser/src/end-to-end/shared.ts
+++ b/client/browser/src/end-to-end/shared.ts
@@ -98,6 +98,7 @@ export function testSingleFilePage({
             const [token] = await line.$x('.//span[text()="CallOption"]')
             await token.hover()
             await getDriver().page.waitForSelector('.test-tooltip-go-to-definition')
+            await getDriver().page.waitForSelector('.test-tooltip-content')
             await retry(async () => {
                 assert.strictEqual(
                     await getDriver().page.evaluate(


### PR DESCRIPTION
Seems like the browser extension e2e test for checking the `Hover popup -> "Go to definition" -> href` is flaky, because it gets updated.

Updated to use the similar approach from original hover regression tests: https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/regression/codeintel.test.ts?L382

### How to test
- `sg test bext-build`
- `sg test bext-e2e`