### PR TITLE
search: return repohascommitafter error when not nil

### DIFF
--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -372,6 +372,7 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 
 	tr.LazyPrintf("Associate/validate revs - done")
 
+	err = res.ErrorOrNil()
 	if len(res.MissingRepoRevs) > 0 {
 		err = multierror.Append(err, &MissingRepoRevsError{Missing: res.MissingRepoRevs})
 	}


### PR DESCRIPTION
Last commit that introduced concurrent rev validation merged with
repohascommitafter filtering didn't return the multierror aggregated.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
