### PR TITLE
zoekt: update to https://github.com/sourcegraph/zoekt/commit/f40c58ef8631c357fb37311bd17e510a789d3a14

### DIFF
--- a/dev/zoekt/update
+++ b/dev/zoekt/update
@@ -25,6 +25,6 @@ go mod edit "-replace=${upstream}=${module}"
 go mod download ${upstream}
 go mod tidy
 
-# Ensure we update go.sum by actually compiling some code which depends on
-# zoekt
+echo "Ensure we update go.sum by actually compiling some code which depends on zoekt."
+echo "We do this by running 'go test' without actually running any tests."
 go test -run '^$' github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend

--- a/go.mod
+++ b/go.mod
@@ -334,7 +334,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20211112135539-7ad19f686053
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20211202173641-f40c58ef8631
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20211110092431-863f5b1ee51b

--- a/go.sum
+++ b/go.sum
@@ -1710,8 +1710,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20211112135539-7ad19f686053 h1:HhQSgdbId+biRRj4JjM2sDlQL91RN9RyLpoJVii/tYA=
-github.com/sourcegraph/zoekt v0.0.0-20211112135539-7ad19f686053/go.mod h1:x1Zva3SbvSL4wCQnQ93LGTpQrXjKp8r8vyd09l/xCBE=
+github.com/sourcegraph/zoekt v0.0.0-20211202173641-f40c58ef8631 h1:MccIhnGDhAZl1SucMR08ck4P5QALTGj26ISLf/nNb/k=
+github.com/sourcegraph/zoekt v0.0.0-20211202173641-f40c58ef8631/go.mod h1:x1Zva3SbvSL4wCQnQ93LGTpQrXjKp8r8vyd09l/xCBE=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
Updates zoekt dependency to https://github.com/sourcegraph/zoekt/commit/f40c58ef8631c357fb37311bd17e510a789d3a14

Also adds some output to `./dev/zoekt/update` to indicate that the `go test` command is expected to not run any tests - was a bit worried when it came out with "no tests run"
