### PR TITLE
searcher: enable Google Cloud profiler profiler when running on sourcegraph.com

### DIFF
--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
+	"github.com/sourcegraph/sourcegraph/internal/profiler"
 	"github.com/sourcegraph/sourcegraph/internal/sentry"
 	"github.com/sourcegraph/sourcegraph/internal/store"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -49,6 +50,10 @@ func main() {
 	tracer.Init(conf.DefaultClient())
 	sentry.Init(conf.DefaultClient())
 	trace.Init()
+
+	if err := profiler.Init(); err != nil {
+		log.Fatalf("failed to start Google Cloud profiler: %s", err)
+	}
 
 	// Ready immediately
 	ready := make(chan struct{})


### PR DESCRIPTION
This enables us to use [Google Cloud's profiler](https://cloud.google.com/profiler/docs/profiling-go) for `searcher` get better information about its performance. This brings searcher in line with [some of our other services](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/profiler/profiler.go?L14:6#tab=references) (`frontend`, `worker`, etc.) that leverage this. 

See https://sourcegraph.slack.com/archives/C0NF93T1C/p1638465871385800 for context.