### PR TITLE
Add experimental features store

### DIFF
--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -126,7 +126,6 @@ export interface LayoutProps
 
     globbing: boolean
     showMultilineSearchConsole: boolean
-    showSearchNotebook: boolean
     isSourcegraphDotCom: boolean
     fetchSavedSearches: () => Observable<GQL.ISavedSearch[]>
     children?: never

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -83,6 +83,7 @@ import { listUserRepositories } from './site-admin/backend'
 import { SiteAdminAreaRoute } from './site-admin/SiteAdminArea'
 import { SiteAdminSideBarGroups } from './site-admin/SiteAdminSidebar'
 import { CodeHostScopeProvider } from './site/CodeHostScopeAlerts/CodeHostScopeProvider'
+import { setExperimentalFeaturesFromSettings } from './stores'
 import { eventLogger } from './tracking/eventLogger'
 import { withActivation } from './tracking/withActivation'
 import { UserAreaRoute } from './user/area/UserArea'
@@ -184,11 +185,6 @@ interface SourcegraphWebAppState extends SettingsCascadeProps {
     showMultilineSearchConsole: boolean
 
     /**
-     * Whether we show the search notebook.
-     */
-    showSearchNotebook: boolean
-
-    /**
      * Whether the code monitoring feature flag is enabled.
      */
     enableCodeMonitoring: boolean
@@ -272,7 +268,6 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
             showEnterpriseHomePanels: false,
             globbing: false,
             showMultilineSearchConsole: false,
-            showSearchNotebook: false,
             enableCodeMonitoring: false,
             // Disabling linter here as otherwise the application fails to compile. Bad lint?
             // See 7a137b201330eb2118c746f8cc5acddf63c1f039
@@ -306,6 +301,8 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
                 authenticatedUser.pipe(startWith(undefined)),
             ]).subscribe(
                 ([settingsCascade, authenticatedUser]) => {
+                    setExperimentalFeaturesFromSettings(settingsCascade)
+
                     this.setState(state => ({
                         settingsCascade,
                         authenticatedUser,
@@ -495,7 +492,6 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
                                                     showEnterpriseHomePanels={this.state.showEnterpriseHomePanels}
                                                     globbing={this.state.globbing}
                                                     showMultilineSearchConsole={this.state.showMultilineSearchConsole}
-                                                    showSearchNotebook={this.state.showSearchNotebook}
                                                     enableCodeMonitoring={this.state.enableCodeMonitoring}
                                                     fetchSavedSearches={fetchSavedSearches}
                                                     fetchRecentSearches={fetchRecentSearches}

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -105,8 +105,6 @@ export interface RepoContainerContext
 
     globbing: boolean
 
-    showSearchNotebook: boolean
-
     isMacPlatform: boolean
 
     isSourcegraphDotCom: boolean
@@ -146,7 +144,6 @@ interface RepoContainerProps
     authenticatedUser: AuthenticatedUser | null
     history: H.History
     globbing: boolean
-    showSearchNotebook: boolean
     isMacPlatform: boolean
     isSourcegraphDotCom: boolean
 }

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -75,8 +75,6 @@ export interface RepoRevisionContainerContext
 
     globbing: boolean
 
-    showSearchNotebook: boolean
-
     isMacPlatform: boolean
 
     isSourcegraphDotCom: boolean
@@ -122,8 +120,6 @@ interface RepoRevisionContainerProps
     history: H.History
 
     globbing: boolean
-
-    showSearchNotebook: boolean
 
     isMacPlatform: boolean
 

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -25,6 +25,7 @@ import { HeroPage } from '../../components/HeroPage'
 import { PageTitle } from '../../components/PageTitle'
 import { SearchContextProps, SearchStreamingProps } from '../../search'
 import { StreamingSearchResultsListProps } from '../../search/results/StreamingSearchResultsList'
+import { useExperimentalFeatures } from '../../stores'
 import { toTreeURL } from '../../util/url'
 import { FilePathBreadcrumbs } from '../FilePathBreadcrumbs'
 import { HoverThresholdProps } from '../RepoContainer'
@@ -64,7 +65,6 @@ interface Props
     globbing: boolean
     isMacPlatform: boolean
     isSourcegraphDotCom: boolean
-    showSearchNotebook: boolean
     repoUrl: string
 }
 
@@ -72,6 +72,7 @@ export const BlobPage: React.FunctionComponent<Props> = props => {
     const [wrapCode, setWrapCode] = useState(ToggleLineWrap.getValue())
     let renderMode = getModeFromURL(props.location)
     const { repoName, revision, commitID, filePath, isLightTheme, useBreadcrumb, mode, repoUrl } = props
+    const showSearchNotebook = useExperimentalFeatures(features => features.showSearchNotebook)
 
     // Log view event whenever a new Blob, or a Blob with a different render mode, is visited.
     useEffect(() => {
@@ -175,7 +176,7 @@ export const BlobPage: React.FunctionComponent<Props> = props => {
         blobInfoOrError &&
         !isErrorLike(blobInfoOrError) &&
         blobInfoOrError.filePath.endsWith(SEARCH_NOTEBOOK_FILE_EXTENSION) &&
-        props.showSearchNotebook
+        showSearchNotebook
 
     // If url explicitly asks for a certain rendering mode, renderMode is set to that mode, else it checks:
     // - If file contains richHTML and url does not include a line number: We render in richHTML.

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -10,6 +10,7 @@ import { BreadcrumbsProps, BreadcrumbSetters } from './components/Breadcrumbs'
 import type { LayoutProps } from './Layout'
 import type { ExtensionAlertProps } from './repo/RepoContainer'
 import { PageRoutes } from './routes.constants'
+import { useExperimentalFeatures } from './stores'
 import { ThemePreferenceProps } from './theme'
 import { UserExternalServicesOrRepositoriesUpdateProps } from './util'
 import { lazyComponent } from './util/lazyComponent'
@@ -87,7 +88,12 @@ export const routes: readonly LayoutRouteProps<any>[] = [
     },
     {
         path: PageRoutes.SearchNotebook,
-        render: props => (props.showSearchNotebook ? <SearchNotebookPage {...props} /> : <Redirect to="/search" />),
+        render: props =>
+            useExperimentalFeatures.getState().showSearchNotebook ? (
+                <SearchNotebookPage {...props} />
+            ) : (
+                <Redirect to="/search" />
+            ),
         exact: true,
     },
     {

--- a/client/web/src/stores/experimentalFeatures.ts
+++ b/client/web/src/stores/experimentalFeatures.ts
@@ -1,0 +1,16 @@
+import create from 'zustand'
+
+import { SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
+import { isErrorLike } from '@sourcegraph/shared/src/util/errors'
+
+import { SettingsExperimentalFeatures } from '../schema/settings.schema'
+
+export const useExperimentalFeatures = create<SettingsExperimentalFeatures>(() => ({}))
+
+export function setExperimentalFeaturesFromSettings(settingsCascade: SettingsCascadeOrError): void {
+    const experimentalFeatures: SettingsExperimentalFeatures =
+        (settingsCascade.final && !isErrorLike(settingsCascade.final) && settingsCascade.final.experimentalFeatures) ||
+        {}
+
+    useExperimentalFeatures.setState(experimentalFeatures, true)
+}

--- a/client/web/src/stores/index.ts
+++ b/client/web/src/stores/index.ts
@@ -11,3 +11,4 @@
 
 export { useNavbarQueryState } from './navbarSearchQueryState'
 export { useThemeState } from './themeState'
+export { useExperimentalFeatures, setExperimentalFeaturesFromSettings } from './experimentalFeatures'

--- a/client/web/src/util/settings.ts
+++ b/client/web/src/util/settings.ts
@@ -63,7 +63,6 @@ export function experimentalFeaturesFromSettings(
     showOnboardingTour: boolean
     showEnterpriseHomePanels: boolean
     showMultilineSearchConsole: boolean
-    showSearchNotebook: boolean
     showSearchContext: boolean
     showSearchContextManagement: boolean
     enableCodeMonitoring: boolean
@@ -79,7 +78,6 @@ export function experimentalFeaturesFromSettings(
         showSearchContext = true, // Default to true if not set
         showSearchContextManagement = true, // Default to true if not set
         showMultilineSearchConsole = false,
-        showSearchNotebook = false,
         codeMonitoring = true, // Default to true if not set
         // eslint-disable-next-line unicorn/prevent-abbreviations
         apiDocs = true, // Default to true if not set
@@ -91,7 +89,6 @@ export function experimentalFeaturesFromSettings(
         showSearchContextManagement,
         showEnterpriseHomePanels,
         showMultilineSearchConsole,
-        showSearchNotebook,
         enableCodeMonitoring: codeMonitoring,
         enableAPIDocs: apiDocs,
     }


### PR DESCRIPTION
I plan to add a new experimental feature and instead of adding a flag to the root component state I thought it would make sense to convert the experimental feature settings into a store.
As an example I also converted the `showSearchNotebook` setting to use the new store.