### PR TITLE
search: simplify defer functions

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -223,9 +223,7 @@ func (sr *SearchResultsResolver) ElapsedMilliseconds() int32 {
 
 func (sr *SearchResultsResolver) DynamicFilters(ctx context.Context) []*searchFilterResolver {
 	tr, _ := trace.New(ctx, "DynamicFilters", "", trace.Tag{Key: "resolver", Value: "SearchResultsResolver"})
-	defer func() {
-		tr.Finish()
-	}()
+	defer tr.Finish()
 
 	var filters streaming.SearchFilters
 	filters.Update(streaming.SearchEvent{
@@ -389,9 +387,7 @@ var (
 // been performed.
 func LogSearchLatency(ctx context.Context, db database.DB, si *run.SearchInputs, durationMs int32) {
 	tr, ctx := trace.New(ctx, "LogSearchLatency", "")
-	defer func() {
-		tr.Finish()
-	}()
+	defer tr.Finish()
 	var types []string
 	resultTypes, _ := si.Query.StringValues(query.FieldType)
 	for _, typ := range resultTypes {


### PR DESCRIPTION
Found more of these based on @keegancsmith previous suggestion: https://github.com/sourcegraph/sourcegraph/pull/28449#discussion_r760842034

This is over all the code via:

```
comby 'defer func() { :[x.]() }()' 'defer :[x]()' .go -i  
```

There are other examples where we could remove the wrapping `func() {...}()` but [in those cases](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+defer+func%28%29+%7B+:%5Bx.%5D%28:%5By%5D%29+%7D%28%29+lang:go&patternType=structural) I think it's not tasteful because the calls are larger expressions or close over arguments, so I just hit bodies that close over no arguments.

