### PR TITLE
codeintel: Optionally accept uploads for unresolvable commits

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/httpapi/upload_handler_state.go
+++ b/enterprise/cmd/frontend/internal/codeintel/httpapi/upload_handler_state.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/errors"
+	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -113,16 +114,16 @@ func ensureRepoAndCommitExist(ctx context.Context, db database.DB, repoName, com
 	// 2. Resolve commit
 
 	if _, err := backend.NewRepos(db.Repos()).ResolveRev(ctx, repo, commit); err != nil {
+		var reason string
 		if errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
-			return 0, http.StatusNotFound, errors.Errorf("unknown commit %q", commit)
-		}
-
-		// If the repository is currently being cloned (which is most likely to happen on dotcom),
-		// then we want to continue to queue the LSIF upload record to unblock the client, then have
-		// the worker wait until the rev is resolvable before starting to process.
-		if !gitdomain.IsCloneInProgress(err) {
+			reason = "commit not found"
+		} else if gitdomain.IsCloneInProgress(err) {
+			reason = "repository still cloning"
+		} else {
 			return 0, http.StatusInternalServerError, err
 		}
+
+		log15.Warn("Accepting LSIF upload with unresolvable commit", "reason", reason)
 	}
 
 	return int(repo.ID), 0, nil

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
@@ -106,7 +106,7 @@ func (h *handler) handle(ctx context.Context, upload store.Upload, traceLog obse
 		return false, errors.Wrap(err, "Repos.Get")
 	}
 
-	if requeued, err := requeueIfCloning(ctx, db, h.workerStore, upload, repo); err != nil || requeued {
+	if requeued, err := requeueIfCloningOrCommitUnknown(ctx, db, h.workerStore, upload, repo); err != nil || requeued {
 		return requeued, err
 	}
 
@@ -227,24 +227,37 @@ func inTransaction(ctx context.Context, dbStore DBStore, fn func(tx DBStore) err
 	return fn(tx)
 }
 
-// CloneInProgressDelay is the delay between processing attempts when a repo is currently being cloned.
-const CloneInProgressDelay = time.Minute
+// requeueDelay is the delay between processing attempts to process a record when waiting on
+// gitserver to refresh. We'll requeue a record with this delay while the repo is cloning or
+// while we're waiting for a commit to become available to the remote code host.
+const requeueDelay = time.Minute
 
-// requeueIfCloning ensures that the repo and revision are resolvable. If the repo does not exist, or
-// if the repo has finished cloning and the revision does not exist, then the upload will fail to process.
-// If the repo is currently cloning, then we'll requeue the upload to be tried again later. This will not
-// increase the reset count of the record (so this doesn't count against the upload as a legitimate attempt).
-func requeueIfCloning(ctx context.Context, db database.DB, workerStore dbworkerstore.Store, upload store.Upload, repo *types.Repo) (requeued bool, _ error) {
+// requeueIfCloningOrCommitUnknown ensures that the repo and revision are resolvable. If the repo is currently
+// cloning or if the commit does not exist, then the upload will be requeued and this function returns a true
+// valued flag. Otherwise, the repo does not exist or there is an unexpected infrastructure error, which we'll
+// fail on.
+func requeueIfCloningOrCommitUnknown(ctx context.Context, db database.DB, workerStore dbworkerstore.Store, upload store.Upload, repo *types.Repo) (requeued bool, _ error) {
 	_, err := backend.NewRepos(db.Repos()).ResolveRev(ctx, repo, upload.Commit)
-	if err == nil || !gitdomain.IsCloneInProgress(err) {
-		return false, errors.Wrap(err, "Repos.ResolveRev")
+	if err != nil {
+		// commit is resolvable
+		return false, nil
 	}
 
-	if err := workerStore.Requeue(ctx, upload.ID, time.Now().UTC().Add(CloneInProgressDelay)); err != nil {
+	var reason string
+	if errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
+		reason = "commit not found"
+	} else if gitdomain.IsCloneInProgress(err) {
+		reason = "repository still cloning"
+	} else {
+		return false, errors.Wrap(err, "repos.ResolveRev")
+	}
+
+	after := time.Now().UTC().Add(requeueDelay)
+
+	if err := workerStore.Requeue(ctx, upload.ID, after); err != nil {
 		return false, errors.Wrap(err, "store.Requeue")
 	}
-
-	log15.Warn("Requeued LSIF upload record (repository still cloning)", "id", upload.ID)
+	log15.Warn("Requeued LSIF upload record", "id", upload.ID, "reason", reason)
 	return true, nil
 }
 

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
@@ -238,7 +238,7 @@ const requeueDelay = time.Minute
 // fail on.
 func requeueIfCloningOrCommitUnknown(ctx context.Context, db database.DB, workerStore dbworkerstore.Store, upload store.Upload, repo *types.Repo) (requeued bool, _ error) {
 	_, err := backend.NewRepos(db.Repos()).ResolveRev(ctx, repo, upload.Commit)
-	if err != nil {
+	if err == nil {
 		// commit is resolvable
 		return false, nil
 	}

--- a/enterprise/cmd/worker/internal/codeintel/janitor/iface.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/iface.go
@@ -30,7 +30,7 @@ type DBStore interface {
 	DeleteUploadsStuckUploading(ctx context.Context, uploadedBefore time.Time) (int, error)
 	StaleSourcedCommits(ctx context.Context, threshold time.Duration, limit int, now time.Time) ([]dbstore.SourcedCommits, error)
 	UpdateSourcedCommits(ctx context.Context, repositoryID int, commit string, now time.Time) (int, int, error)
-	DeleteSourcedCommits(ctx context.Context, repositoryID int, commit string, now time.Time) (int, int, error)
+	DeleteSourcedCommits(ctx context.Context, repositoryID int, commit string, maximumCommitLag time.Duration, now time.Time) (int, int, int, error)
 	SelectPoliciesForRepositoryMembershipUpdate(ctx context.Context, batchSize int) (configurationPolicies []dbstore.ConfigurationPolicy, err error)
 	UpdateReposMatchingPatterns(ctx context.Context, patterns []string, policyID int, repositoryMatchLimit *int) (err error)
 }

--- a/enterprise/cmd/worker/internal/codeintel/janitor/mock_iface_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/mock_iface_test.go
@@ -97,8 +97,8 @@ func NewMockDBStore() *MockDBStore {
 			},
 		},
 		DeleteSourcedCommitsFunc: &DBStoreDeleteSourcedCommitsFunc{
-			defaultHook: func(context.Context, int, string, time.Time) (int, int, error) {
-				return 0, 0, nil
+			defaultHook: func(context.Context, int, string, time.Duration, time.Time) (int, int, int, error) {
+				return 0, 0, 0, nil
 			},
 		},
 		DeleteUploadsStuckUploadingFunc: &DBStoreDeleteUploadsStuckUploadingFunc{
@@ -199,7 +199,7 @@ func NewStrictMockDBStore() *MockDBStore {
 			},
 		},
 		DeleteSourcedCommitsFunc: &DBStoreDeleteSourcedCommitsFunc{
-			defaultHook: func(context.Context, int, string, time.Time) (int, int, error) {
+			defaultHook: func(context.Context, int, string, time.Duration, time.Time) (int, int, int, error) {
 				panic("unexpected invocation of MockDBStore.DeleteSourcedCommits")
 			},
 		},
@@ -587,24 +587,24 @@ func (c DBStoreDeleteIndexesWithoutRepositoryFuncCall) Results() []interface{} {
 // DeleteSourcedCommits method of the parent MockDBStore instance is
 // invoked.
 type DBStoreDeleteSourcedCommitsFunc struct {
-	defaultHook func(context.Context, int, string, time.Time) (int, int, error)
-	hooks       []func(context.Context, int, string, time.Time) (int, int, error)
+	defaultHook func(context.Context, int, string, time.Duration, time.Time) (int, int, int, error)
+	hooks       []func(context.Context, int, string, time.Duration, time.Time) (int, int, int, error)
 	history     []DBStoreDeleteSourcedCommitsFuncCall
 	mutex       sync.Mutex
 }
 
 // DeleteSourcedCommits delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockDBStore) DeleteSourcedCommits(v0 context.Context, v1 int, v2 string, v3 time.Time) (int, int, error) {
-	r0, r1, r2 := m.DeleteSourcedCommitsFunc.nextHook()(v0, v1, v2, v3)
-	m.DeleteSourcedCommitsFunc.appendCall(DBStoreDeleteSourcedCommitsFuncCall{v0, v1, v2, v3, r0, r1, r2})
-	return r0, r1, r2
+func (m *MockDBStore) DeleteSourcedCommits(v0 context.Context, v1 int, v2 string, v3 time.Duration, v4 time.Time) (int, int, int, error) {
+	r0, r1, r2, r3 := m.DeleteSourcedCommitsFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.DeleteSourcedCommitsFunc.appendCall(DBStoreDeleteSourcedCommitsFuncCall{v0, v1, v2, v3, v4, r0, r1, r2, r3})
+	return r0, r1, r2, r3
 }
 
 // SetDefaultHook sets function that is called when the DeleteSourcedCommits
 // method of the parent MockDBStore instance is invoked and the hook queue
 // is empty.
-func (f *DBStoreDeleteSourcedCommitsFunc) SetDefaultHook(hook func(context.Context, int, string, time.Time) (int, int, error)) {
+func (f *DBStoreDeleteSourcedCommitsFunc) SetDefaultHook(hook func(context.Context, int, string, time.Duration, time.Time) (int, int, int, error)) {
 	f.defaultHook = hook
 }
 
@@ -612,7 +612,7 @@ func (f *DBStoreDeleteSourcedCommitsFunc) SetDefaultHook(hook func(context.Conte
 // DeleteSourcedCommits method of the parent MockDBStore instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *DBStoreDeleteSourcedCommitsFunc) PushHook(hook func(context.Context, int, string, time.Time) (int, int, error)) {
+func (f *DBStoreDeleteSourcedCommitsFunc) PushHook(hook func(context.Context, int, string, time.Duration, time.Time) (int, int, int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -620,21 +620,21 @@ func (f *DBStoreDeleteSourcedCommitsFunc) PushHook(hook func(context.Context, in
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *DBStoreDeleteSourcedCommitsFunc) SetDefaultReturn(r0 int, r1 int, r2 error) {
-	f.SetDefaultHook(func(context.Context, int, string, time.Time) (int, int, error) {
-		return r0, r1, r2
+func (f *DBStoreDeleteSourcedCommitsFunc) SetDefaultReturn(r0 int, r1 int, r2 int, r3 error) {
+	f.SetDefaultHook(func(context.Context, int, string, time.Duration, time.Time) (int, int, int, error) {
+		return r0, r1, r2, r3
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *DBStoreDeleteSourcedCommitsFunc) PushReturn(r0 int, r1 int, r2 error) {
-	f.PushHook(func(context.Context, int, string, time.Time) (int, int, error) {
-		return r0, r1, r2
+func (f *DBStoreDeleteSourcedCommitsFunc) PushReturn(r0 int, r1 int, r2 int, r3 error) {
+	f.PushHook(func(context.Context, int, string, time.Duration, time.Time) (int, int, int, error) {
+		return r0, r1, r2, r3
 	})
 }
 
-func (f *DBStoreDeleteSourcedCommitsFunc) nextHook() func(context.Context, int, string, time.Time) (int, int, error) {
+func (f *DBStoreDeleteSourcedCommitsFunc) nextHook() func(context.Context, int, string, time.Duration, time.Time) (int, int, int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -678,7 +678,10 @@ type DBStoreDeleteSourcedCommitsFuncCall struct {
 	Arg2 string
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 time.Time
+	Arg3 time.Duration
+	// Arg4 is the value of the 5th argument passed to this method
+	// invocation.
+	Arg4 time.Time
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 int
@@ -687,19 +690,22 @@ type DBStoreDeleteSourcedCommitsFuncCall struct {
 	Result1 int
 	// Result2 is the value of the 3rd result returned from this method
 	// invocation.
-	Result2 error
+	Result2 int
+	// Result3 is the value of the 4th result returned from this method
+	// invocation.
+	Result3 error
 }
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c DBStoreDeleteSourcedCommitsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c DBStoreDeleteSourcedCommitsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+	return []interface{}{c.Result0, c.Result1, c.Result2, c.Result3}
 }
 
 // DBStoreDeleteUploadsStuckUploadingFunc describes the behavior when the

--- a/enterprise/cmd/worker/internal/codeintel/janitor/unknown_commits_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/unknown_commits_test.go
@@ -84,7 +84,7 @@ func testUnknownCommitsJanitor(t *testing.T, resolveRevisionFunc func(commit str
 	dbStore.DoneFunc.SetDefaultHook(func(err error) error { return err })
 	dbStore.StaleSourcedCommitsFunc.SetDefaultReturn(testSourcedCommits, nil)
 	clock := glock.NewMockClock()
-	janitor := newJanitor(dbStore, time.Minute, 100, newMetrics(&observation.TestContext), clock)
+	janitor := newJanitor(dbStore, time.Minute, 100, time.Minute, newMetrics(&observation.TestContext), clock)
 
 	if err := janitor.Handle(context.Background()); err != nil {
 		t.Fatalf("unexpected error running janitor: %s", err)

--- a/enterprise/cmd/worker/internal/codeintel/janitor_config.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor_config.go
@@ -38,7 +38,7 @@ func (c *janitorConfig) Load() {
 	c.CommitResolverTaskInterval = c.GetInterval("PRECISE_CODE_INTEL_COMMIT_RESOLVER_TASK_INTERVAL", "10s", "The frequency with which to run the periodic commit resolver task.")
 	c.CommitResolverMinimumTimeSinceLastCheck = c.GetInterval("PRECISE_CODE_INTEL_COMMIT_RESOLVER_MINIMUM_TIME_SINCE_LAST_CHECK", "24h", "The minimum time the commit resolver will re-check an upload or index record.")
 	c.CommitResolverBatchSize = c.GetInt("PRECISE_CODE_INTEL_COMMIT_RESOLVER_BATCH_SIZE", "100", "The maximum number of unique commits to resolve at a time.")
-	c.CommitResolverMaximumCommitLag = c.GetInterval("PRECISE_CODE_INTEL_COMMIT_RESOLVER_MAXIMUM_COMMIT_LAG", "0s", "The maximum acceptable delay between accepting an upload and its commit becoming resolvable.")
+	c.CommitResolverMaximumCommitLag = c.GetInterval("PRECISE_CODE_INTEL_COMMIT_RESOLVER_MAXIMUM_COMMIT_LAG", "0s", "The maximum acceptable delay between accepting an upload and its commit becoming resolvable. Be cautious about setting this to a large value, as uploads for unresolvable commits will be retried periodically during this interval.")
 	c.RepositoryProcessDelay = c.GetInterval("PRECISE_CODE_INTEL_RETENTION_REPOSITORY_PROCESS_DELAY", "24h", "The minimum frequency that the same repository's uploads can be considered for expiration.")
 	c.RepositoryBatchSize = c.GetInt("PRECISE_CODE_INTEL_RETENTION_REPOSITORY_BATCH_SIZE", "100", "The number of repositories to consider for expiration at a time.")
 	c.UploadProcessDelay = c.GetInterval("PRECISE_CODE_INTEL_RETENTION_UPLOAD_PROCESS_DELAY", "24h", "The minimum frequency that the same upload record can be considered for expiration.")

--- a/enterprise/cmd/worker/internal/codeintel/janitor_config.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor_config.go
@@ -15,6 +15,7 @@ type janitorConfig struct {
 	CommitResolverTaskInterval                          time.Duration
 	CommitResolverMinimumTimeSinceLastCheck             time.Duration
 	CommitResolverBatchSize                             int
+	CommitResolverMaximumCommitLag                      time.Duration
 	RepositoryProcessDelay                              time.Duration
 	RepositoryBatchSize                                 int
 	UploadProcessDelay                                  time.Duration
@@ -37,6 +38,7 @@ func (c *janitorConfig) Load() {
 	c.CommitResolverTaskInterval = c.GetInterval("PRECISE_CODE_INTEL_COMMIT_RESOLVER_TASK_INTERVAL", "10s", "The frequency with which to run the periodic commit resolver task.")
 	c.CommitResolverMinimumTimeSinceLastCheck = c.GetInterval("PRECISE_CODE_INTEL_COMMIT_RESOLVER_MINIMUM_TIME_SINCE_LAST_CHECK", "24h", "The minimum time the commit resolver will re-check an upload or index record.")
 	c.CommitResolverBatchSize = c.GetInt("PRECISE_CODE_INTEL_COMMIT_RESOLVER_BATCH_SIZE", "100", "The maximum number of unique commits to resolve at a time.")
+	c.CommitResolverMaximumCommitLag = c.GetInterval("PRECISE_CODE_INTEL_COMMIT_RESOLVER_MAXIMUM_COMMIT_LAG", "0s", "The maximum acceptable delay between accepting an upload and its commit becoming resolvable.")
 	c.RepositoryProcessDelay = c.GetInterval("PRECISE_CODE_INTEL_RETENTION_REPOSITORY_PROCESS_DELAY", "24h", "The minimum frequency that the same repository's uploads can be considered for expiration.")
 	c.RepositoryBatchSize = c.GetInt("PRECISE_CODE_INTEL_RETENTION_REPOSITORY_BATCH_SIZE", "100", "The number of repositories to consider for expiration at a time.")
 	c.UploadProcessDelay = c.GetInterval("PRECISE_CODE_INTEL_RETENTION_UPLOAD_PROCESS_DELAY", "24h", "The minimum frequency that the same upload record can be considered for expiration.")

--- a/enterprise/cmd/worker/internal/codeintel/janitor_job.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor_job.go
@@ -67,11 +67,21 @@ func (j *janitorJob) Routines(ctx context.Context) ([]goroutine.BackgroundRoutin
 		return nil, err
 	}
 
+
+
+
+
+
 	routines := []goroutine.BackgroundRoutine{
 		// Reconciliation and denormalization
 		janitor.NewDeletedRepositoryJanitor(dbStoreShim, janitorConfigInst.CleanupTaskInterval, metrics),
-		janitor.NewUnknownCommitJanitor(dbStoreShim, janitorConfigInst.CommitResolverMinimumTimeSinceLastCheck, janitorConfigInst.CommitResolverBatchSize, janitorConfigInst.CommitResolverTaskInterval, metrics),
+		janitor.NewUnknownCommitJanitor(dbStoreShim, janitorConfigInst.CommitResolverMinimumTimeSinceLastCheck, janitorConfigInst.CommitResolverBatchSize, janitorConfigInst.CommitResolverMaximumCommitLag, ,janitorConfigInst.CommitResolverTaskInterval, metrics),
 		janitor.NewRepositoryPatternMatcher(dbStoreShim, lsifStoreShim, janitorConfigInst.CleanupTaskInterval, janitorConfigInst.ConfigurationPolicyMembershipBatchSize, metrics),
+
+
+
+
+
 
 		// Expiration
 		janitor.NewAbandonedUploadJanitor(dbStoreShim, janitorConfigInst.UploadTimeout, janitorConfigInst.CleanupTaskInterval, metrics),

--- a/enterprise/cmd/worker/internal/codeintel/janitor_job.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor_job.go
@@ -67,21 +67,11 @@ func (j *janitorJob) Routines(ctx context.Context) ([]goroutine.BackgroundRoutin
 		return nil, err
 	}
 
-
-
-
-
-
 	routines := []goroutine.BackgroundRoutine{
 		// Reconciliation and denormalization
 		janitor.NewDeletedRepositoryJanitor(dbStoreShim, janitorConfigInst.CleanupTaskInterval, metrics),
-		janitor.NewUnknownCommitJanitor(dbStoreShim, janitorConfigInst.CommitResolverMinimumTimeSinceLastCheck, janitorConfigInst.CommitResolverBatchSize, janitorConfigInst.CommitResolverMaximumCommitLag, ,janitorConfigInst.CommitResolverTaskInterval, metrics),
+		janitor.NewUnknownCommitJanitor(dbStoreShim, janitorConfigInst.CommitResolverMinimumTimeSinceLastCheck, janitorConfigInst.CommitResolverBatchSize, janitorConfigInst.CommitResolverMaximumCommitLag, janitorConfigInst.CommitResolverTaskInterval, metrics),
 		janitor.NewRepositoryPatternMatcher(dbStoreShim, lsifStoreShim, janitorConfigInst.CleanupTaskInterval, janitorConfigInst.ConfigurationPolicyMembershipBatchSize, metrics),
-
-
-
-
-
 
 		// Expiration
 		janitor.NewAbandonedUploadJanitor(dbStoreShim, janitorConfigInst.UploadTimeout, janitorConfigInst.CleanupTaskInterval, metrics),

--- a/enterprise/internal/codeintel/stores/dbstore/janitor.go
+++ b/enterprise/internal/codeintel/stores/dbstore/janitor.go
@@ -170,7 +170,7 @@ SELECT
 
 const sourcedCommitsCandidateUploadsCTE = `
 candidate_uploads AS (
-	SELECT u.id
+	SELECT u.id, u.state, u.uploaded_at
 	FROM lsif_uploads u
 	WHERE u.repository_id = %s AND u.commit = %s
 
@@ -192,30 +192,46 @@ candidate_indexes AS (
 )
 `
 
-// DeleteSourcedCommits deletes each upload and index records belonging to the given repository identifier and
-// commit. Uploads are soft deleted and indexes are hard-deleted. This method returns the count of upload and
-// index records modified, respectively.
-func (s *Store) DeleteSourcedCommits(ctx context.Context, repositoryID int, commit string, now time.Time) (uploadsDeleted int, indexesDeleted int, err error) {
+// DeleteSourcedCommits deletes each upload and index records belonging to the given repository identifier
+// and commit. Uploads are soft deleted and indexes are hard-deleted. This method returns the count of upload
+// and index records modified.
+//
+// If a maximum commit lag is supplied, then any upload records in the uploading, queued, or processing states
+// younger than the provided lag will not be modified. This configurable parameter enables support for remote
+// code hosts that are not the source of truth; if we deleted all pending records without resolvable commits
+// introduce races between the customer's Sourcegraph instance and their CI (and their CI will usually win).
+func (s *Store) DeleteSourcedCommits(ctx context.Context, repositoryID int, commit string, maximumCommitLag time.Duration, now time.Time) (
+	uploadsUpdated int,
+	uploadsDeleted int,
+	indexesDeleted int,
+	err error,
+) {
 	ctx, traceLog, endObservation := s.operations.deleteSourcedCommits.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("repositoryID", repositoryID),
 		log.String("commit", commit),
 	}})
 	defer endObservation(1, observation.Args{})
 
-	uploadsDeleted, indexesDeleted, err = scanPairOfCounts(s.Query(ctx, sqlf.Sprintf(
+	now = now.UTC()
+	interval := int(maximumCommitLag / time.Second)
+
+	uploadsUpdated, uploadsDeleted, indexesDeleted, err = scanTripleOfCounts(s.Query(ctx, sqlf.Sprintf(
 		deleteSourcedCommitsQuery,
 		repositoryID, commit, // candidate_uploads
 		repositoryID, commit, // candidate_indexes
+		now, interval, // tagged_candidate_uploads
+		now, // update_uploads
 	)))
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, 0, err
 	}
 	traceLog(
+		log.Int("uploadsUpdated", uploadsUpdated),
 		log.Int("uploadsDeleted", uploadsDeleted),
 		log.Int("indexesDeleted", indexesDeleted),
 	)
 
-	return uploadsDeleted, indexesDeleted, nil
+	return uploadsUpdated, uploadsDeleted, indexesDeleted, nil
 }
 
 const deleteSourcedCommitsQuery = `
@@ -223,14 +239,22 @@ const deleteSourcedCommitsQuery = `
 WITH
 ` + sourcedCommitsCandidateUploadsCTE + `,
 ` + sourcedCommitsCandidateIndexesCTE + `,
+tagged_candidate_uploads AS (
+	SELECT
+		u.*,
+		(u.state IN ('uploading', 'queued', 'processing') AND %s - u.uploaded_at <= (%s * '1 second'::interval)) AS protected
+	FROM candidate_uploads u
+),
+update_uploads AS (
+	UPDATE lsif_uploads u
+	SET commit_last_checked_at = %s
+	WHERE EXISTS (SELECT 1 FROM tagged_candidate_uploads tu WHERE tu.id = u.id AND tu.protected)
+	RETURNING 1
+),
 delete_uploads AS (
 	UPDATE lsif_uploads u
 	SET state = CASE WHEN u.state = 'completed' THEN 'deleting' ELSE 'deleted' END
-	WHERE
-		u.id IN (SELECT id FROM candidate_uploads)
-		-- AND
-		-- TODO - put a timer on here
-		-- u.state NOT IN ('uploading', 'queued', 'processing')
+	WHERE EXISTS (SELECT 1 FROM tagged_candidate_uploads tu WHERE tu.id = u.id AND NOT tu.protected)
 	RETURNING 1
 ),
 delete_indexes AS (
@@ -239,8 +263,9 @@ delete_indexes AS (
 	RETURNING 1
 )
 SELECT
-	(SELECT COUNT(*) FROM delete_uploads) AS num_uploads,
-	(SELECT COUNT(*) FROM delete_indexes) AS num_indexes
+	(SELECT COUNT(*) FROM update_uploads) AS num_uploads_updated,
+	(SELECT COUNT(*) FROM delete_uploads) AS num_uploads_deleted,
+	(SELECT COUNT(*) FROM delete_indexes) AS num_indexes_deleted
 `
 
 func scanPairOfCounts(rows *sql.Rows, queryErr error) (value1, value2 int, err error) {
@@ -256,4 +281,19 @@ func scanPairOfCounts(rows *sql.Rows, queryErr error) (value1, value2 int, err e
 	}
 
 	return value1, value2, nil
+}
+
+func scanTripleOfCounts(rows *sql.Rows, queryErr error) (value1, value2, value3 int, err error) {
+	if queryErr != nil {
+		return 0, 0, 0, queryErr
+	}
+	defer func() { err = basestore.CloseRows(rows, err) }()
+
+	for rows.Next() {
+		if err := rows.Scan(&value1, &value2, &value3); err != nil {
+			return 0, 0, 0, err
+		}
+	}
+
+	return value1, value2, value3, nil
 }

--- a/enterprise/internal/codeintel/stores/dbstore/janitor.go
+++ b/enterprise/internal/codeintel/stores/dbstore/janitor.go
@@ -226,7 +226,11 @@ WITH
 delete_uploads AS (
 	UPDATE lsif_uploads u
 	SET state = CASE WHEN u.state = 'completed' THEN 'deleting' ELSE 'deleted' END
-	WHERE id IN (SELECT id FROM candidate_uploads)
+	WHERE
+		u.id IN (SELECT id FROM candidate_uploads)
+		-- AND
+		-- TODO - put a timer on here
+		-- u.state NOT IN ('uploading', 'queued', 'processing')
 	RETURNING 1
 ),
 delete_indexes AS (

--- a/enterprise/internal/codeintel/stores/dbstore/janitor.go
+++ b/enterprise/internal/codeintel/stores/dbstore/janitor.go
@@ -197,9 +197,10 @@ candidate_indexes AS (
 // and index records modified.
 //
 // If a maximum commit lag is supplied, then any upload records in the uploading, queued, or processing states
-// younger than the provided lag will not be modified. This configurable parameter enables support for remote
-// code hosts that are not the source of truth; if we deleted all pending records without resolvable commits
-// introduce races between the customer's Sourcegraph instance and their CI (and their CI will usually win).
+// younger than the provided lag will not be deleted, but its timestamp will be modified as if the sibling method
+// UpdateSourcedCommits was called instead. This configurable parameter enables support for remote code hosts
+// that are not the source of truth; if we deleted all pending records without resolvable commits introduce races
+// between the customer's Sourcegraph instance and their CI (and their CI will usually win).
 func (s *Store) DeleteSourcedCommits(ctx context.Context, repositoryID int, commit string, maximumCommitLag time.Duration, now time.Time) (
 	uploadsUpdated int,
 	uploadsDeleted int,

--- a/enterprise/internal/codeintel/stores/dbstore/janitor_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/janitor_test.go
@@ -143,7 +143,8 @@ func TestDeleteSourcedCommits(t *testing.T) {
 		Upload{ID: 3, RepositoryID: 51, Commit: makeCommit(4)},
 		Upload{ID: 4, RepositoryID: 51, Commit: makeCommit(5)},
 		Upload{ID: 5, RepositoryID: 52, Commit: makeCommit(7)},
-		Upload{ID: 6, RepositoryID: 52, Commit: makeCommit(7), State: "uploading"},
+		Upload{ID: 6, RepositoryID: 52, Commit: makeCommit(7), State: "uploading", UploadedAt: now.Add(-time.Minute * 90)},
+		Upload{ID: 7, RepositoryID: 52, Commit: makeCommit(7), State: "queued", UploadedAt: now.Add(-time.Minute * 30)},
 	)
 	insertIndexes(t, db,
 		Index{ID: 1, RepositoryID: 50, Commit: makeCommit(3)},
@@ -157,9 +158,8 @@ func TestDeleteSourcedCommits(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error refreshing commit resolvability: %s", err)
 	}
-	if uploadsUpdated != 0 {
-		// TODO - modify test to include this
-		t.Fatalf("unexpected number of uploads updated. want=%d have=%d", 0, uploadsUpdated)
+	if uploadsUpdated != 1 {
+		t.Fatalf("unexpected number of uploads updated. want=%d have=%d", 1, uploadsUpdated)
 	}
 	if uploadsDeleted != 2 {
 		t.Fatalf("unexpected number of uploads deleted. want=%d have=%d", 2, uploadsDeleted)
@@ -168,7 +168,7 @@ func TestDeleteSourcedCommits(t *testing.T) {
 		t.Fatalf("unexpected number of indexes deleted. want=%d have=%d", 1, indexesDeleted)
 	}
 
-	uploadStates, err := getUploadStates(db, 1, 2, 3, 4, 5, 6)
+	uploadStates, err := getUploadStates(db, 1, 2, 3, 4, 5, 6, 7)
 	if err != nil {
 		t.Fatalf("unexpected error fetching upload states: %s", err)
 	}
@@ -179,6 +179,7 @@ func TestDeleteSourcedCommits(t *testing.T) {
 		4: "completed",
 		5: "deleting",
 		6: "deleted",
+		7: "queued",
 	}
 	if diff := cmp.Diff(expectedUploadStates, uploadStates); diff != "" {
 		t.Errorf("unexpected upload states (-want +got):\n%s", diff)

--- a/enterprise/internal/codeintel/stores/dbstore/janitor_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/janitor_test.go
@@ -153,15 +153,19 @@ func TestDeleteSourcedCommits(t *testing.T) {
 		Index{ID: 5, RepositoryID: 50, Commit: makeCommit(1)},
 	)
 
-	uploadsUpdated, indexesUpdated, err := store.DeleteSourcedCommits(context.Background(), 52, makeCommit(7), now)
+	uploadsUpdated, uploadsDeleted, indexesDeleted, err := store.DeleteSourcedCommits(context.Background(), 52, makeCommit(7), time.Hour, now)
 	if err != nil {
 		t.Fatalf("unexpected error refreshing commit resolvability: %s", err)
 	}
-	if uploadsUpdated != 2 {
-		t.Fatalf("unexpected uploads updated. want=%d have=%d", 1, uploadsUpdated)
+	if uploadsUpdated != 0 {
+		// TODO - modify test to include this
+		t.Fatalf("unexpected number of uploads updated. want=%d have=%d", 0, uploadsUpdated)
 	}
-	if indexesUpdated != 1 {
-		t.Fatalf("unexpected indexes updated. want=%d have=%d", 1, indexesUpdated)
+	if uploadsDeleted != 2 {
+		t.Fatalf("unexpected number of uploads deleted. want=%d have=%d", 2, uploadsDeleted)
+	}
+	if indexesDeleted != 1 {
+		t.Fatalf("unexpected number of indexes deleted. want=%d have=%d", 1, indexesDeleted)
 	}
 
 	uploadStates, err := getUploadStates(db, 1, 2, 3, 4, 5, 6)


### PR DESCRIPTION
Fixes #28494.

Three changes:

- We enqueue upload records with unresolvable commits instead of returning a 500 error.
- We now requeue in the precise-code-intel worker when the commit is not resolvable. We previously only did this if the repo was still cloning.
- In the background process that removes uploads for unresolvable commits, we make an exception for uploads that have been uploaded within the _max commit lag_, supplied via environment variable. Not modifying this will simply delete a bunch of accepted uploads randomly in the background, creating a very hard to recreate user experience.