### PR TITLE
Clean up codemonitors tests

### DIFF
--- a/enterprise/internal/codemonitors/action_jobs_test.go
+++ b/enterprise/internal/codemonitors/action_jobs_test.go
@@ -10,10 +10,6 @@ import (
 )
 
 func TestEnqueueActionEmailsForQueryIDInt64QueryByRecordID(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-
 	ctx, db, s := newTestStore(t)
 	_, _, _, userCTX := newTestUser(ctx, t, db)
 	_, err := s.insertTestMonitor(userCTX, t)
@@ -48,10 +44,6 @@ func TestEnqueueActionEmailsForQueryIDInt64QueryByRecordID(t *testing.T) {
 func int64Ptr(i int64) *int64 { return &i }
 
 func TestGetActionJobMetadata(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-
 	ctx, db, s := newTestStore(t)
 	_, _, _, userCTX := newTestUser(ctx, t, db)
 	_, err := s.insertTestMonitor(userCTX, t)
@@ -84,10 +76,6 @@ func TestGetActionJobMetadata(t *testing.T) {
 }
 
 func TestScanActionJobs(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-
 	var (
 		testRecordID             = 1
 		testTriggerEventID       = 1

--- a/enterprise/internal/codemonitors/action_jobs_test.go
+++ b/enterprise/internal/codemonitors/action_jobs_test.go
@@ -1,7 +1,6 @@
 package codemonitors
 
 import (
-	"database/sql"
 	"testing"
 	"time"
 
@@ -21,8 +20,7 @@ func TestEnqueueActionEmailsForQueryIDInt64QueryByRecordID(t *testing.T) {
 	err = s.EnqueueActionJobsForQuery(ctx, 1, 1)
 	require.NoError(t, err)
 
-	var got *ActionJob
-	got, err = s.GetActionJob(ctx, 1)
+	got, err := s.GetActionJob(ctx, 1)
 	require.NoError(t, err)
 
 	want := &ActionJob{
@@ -93,8 +91,7 @@ func TestScanActionJobs(t *testing.T) {
 	err = s.EnqueueActionJobsForQuery(ctx, testQueryID, testTriggerEventID)
 	require.NoError(t, err)
 
-	var rows *sql.Rows
-	rows, err = s.Query(ctx, sqlf.Sprintf(actionJobForIDFmtStr, sqlf.Join(ActionJobColumns, ", "), testRecordID))
+	rows, err := s.Query(ctx, sqlf.Sprintf(actionJobForIDFmtStr, sqlf.Join(ActionJobColumns, ", "), testRecordID))
 	record, _, err := ScanActionJobRecord(rows, err)
 	require.NoError(t, err)
 

--- a/enterprise/internal/codemonitors/background/workers_test.go
+++ b/enterprise/internal/codemonitors/background/workers_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors/email"
@@ -36,7 +36,6 @@ func TestActionRunner(t *testing.T) {
 	var (
 		queryID      int64 = 1
 		triggerEvent       = 1
-		record       *codemonitors.ActionJob
 	)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -67,31 +66,23 @@ func TestActionRunner(t *testing.T) {
 
 			// Run a complete pipeline from creation of a code monitor to sending of an email.
 			_, err = ts.InsertTestMonitor(userCtx, t)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
+
 			err = ts.EnqueueQueryTriggerJobs(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
+
 			err = ts.UpdateTriggerJobWithResults(ctx, testQuery, tt.numResults, triggerEvent)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
+
 			err = ts.EnqueueActionJobsForQuery(ctx, queryID, triggerEvent)
-			if err != nil {
-				t.Fatal(err)
-			}
-			record, err = ts.GetActionJob(ctx, 1)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
+
+			record, err := ts.GetActionJob(ctx, 1)
+			require.NoError(t, err)
 
 			a := actionRunner{s}
 			err = a.Handle(ctx, record)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			want := email.TemplateDataNewSearchResults{
 				Priority:       "New",
@@ -101,9 +92,7 @@ func TestActionRunner(t *testing.T) {
 			}
 
 			want.NumberOfResultsWithDetail = tt.wantNumResultsText
-			if diff := cmp.Diff(got, want); diff != "" {
-				t.Fatalf("diff: %s", diff)
-			}
+			require.Equal(t, want, got)
 		})
 	}
 }

--- a/enterprise/internal/codemonitors/background/workers_test.go
+++ b/enterprise/internal/codemonitors/background/workers_test.go
@@ -56,7 +56,6 @@ func TestActionRunner(t *testing.T) {
 			}
 
 			// Create a TestStore.
-			var err error
 			now := time.Now()
 			clock := func() time.Time { return now }
 			s := codemonitors.NewStoreWithClock(db, clock)
@@ -65,7 +64,7 @@ func TestActionRunner(t *testing.T) {
 			_, _, _, userCtx := storetest.NewTestUser(ctx, t, db)
 
 			// Run a complete pipeline from creation of a code monitor to sending of an email.
-			_, err = ts.InsertTestMonitor(userCtx, t)
+			_, err := ts.InsertTestMonitor(userCtx, t)
 			require.NoError(t, err)
 
 			err = ts.EnqueueQueryTriggerJobs(ctx)

--- a/enterprise/internal/codemonitors/queries_test.go
+++ b/enterprise/internal/codemonitors/queries_test.go
@@ -8,10 +8,6 @@ import (
 )
 
 func TestQueryByRecordID(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-
 	ctx, db, s := newTestStore(t)
 	_, id, _, userCTX := newTestUser(ctx, t, db)
 	m, err := s.insertTestMonitor(userCTX, t)
@@ -39,10 +35,6 @@ func TestQueryByRecordID(t *testing.T) {
 }
 
 func TestTriggerQueryNextRun(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-
 	ctx, db, s := newTestStore(t)
 	_, id, _, userCTX := newTestUser(ctx, t, db)
 	m, err := s.insertTestMonitor(userCTX, t)
@@ -76,10 +68,6 @@ func TestTriggerQueryNextRun(t *testing.T) {
 }
 
 func TestResetTriggerQueryTimestamps(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-
 	ctx, db, s := newTestStore(t)
 	_, id, _, userCTX := newTestUser(ctx, t, db)
 	m, err := s.insertTestMonitor(userCTX, t)

--- a/enterprise/internal/codemonitors/queries_test.go
+++ b/enterprise/internal/codemonitors/queries_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 )
 
 func TestQueryByRecordID(t *testing.T) {
@@ -15,17 +15,14 @@ func TestQueryByRecordID(t *testing.T) {
 	ctx, db, s := newTestStore(t)
 	_, id, _, userCTX := newTestUser(ctx, t, db)
 	m, err := s.insertTestMonitor(userCTX, t)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	err = s.EnqueueQueryTriggerJobs(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	got, err := s.GetQueryTriggerForJob(ctx, 1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	now := s.Now()
 	want := &QueryTrigger{
 		ID:           1,
@@ -38,9 +35,7 @@ func TestQueryByRecordID(t *testing.T) {
 		ChangedBy:    id,
 		ChangedAt:    now,
 	}
-	if diff := cmp.Diff(got, want); diff != "" {
-		t.Fatalf("diff: %s", diff)
-	}
+	require.Equal(t, want, got)
 }
 
 func TestTriggerQueryNextRun(t *testing.T) {
@@ -51,25 +46,20 @@ func TestTriggerQueryNextRun(t *testing.T) {
 	ctx, db, s := newTestStore(t)
 	_, id, _, userCTX := newTestUser(ctx, t, db)
 	m, err := s.insertTestMonitor(userCTX, t)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	err = s.EnqueueQueryTriggerJobs(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	wantLatestResult := s.Now().Add(time.Minute)
 	wantNextRun := s.Now().Add(time.Hour)
 
 	err = s.SetQueryTriggerNextRun(ctx, 1, wantNextRun, wantLatestResult)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	got, err := s.GetQueryTriggerForJob(ctx, 1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	want := &QueryTrigger{
 		ID:           1,
 		Monitor:      m.ID,
@@ -82,9 +72,7 @@ func TestTriggerQueryNextRun(t *testing.T) {
 		ChangedAt:    s.Now(),
 	}
 
-	if diff := cmp.Diff(got, want); diff != "" {
-		t.Fatalf("diff: %s", diff)
-	}
+	require.Equal(t, want, got)
 }
 
 func TestResetTriggerQueryTimestamps(t *testing.T) {
@@ -95,9 +83,8 @@ func TestResetTriggerQueryTimestamps(t *testing.T) {
 	ctx, db, s := newTestStore(t)
 	_, id, _, userCTX := newTestUser(ctx, t, db)
 	m, err := s.insertTestMonitor(userCTX, t)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	now := s.Now()
 	want := &QueryTrigger{
 		ID:           1,
@@ -111,22 +98,16 @@ func TestResetTriggerQueryTimestamps(t *testing.T) {
 		ChangedAt:    now,
 	}
 	got, err := s.triggerQueryByIDInt64(ctx, 1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if diff := cmp.Diff(got, want); diff != "" {
-		t.Fatalf("diff: %s", diff)
-	}
+	require.NoError(t, err)
+
+	require.Equal(t, want, got)
 
 	err = s.ResetQueryTriggerTimestamps(ctx, 1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	got, err = s.triggerQueryByIDInt64(ctx, 1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	want = &QueryTrigger{
 		ID:           1,
 		Monitor:      m.ID,
@@ -139,7 +120,5 @@ func TestResetTriggerQueryTimestamps(t *testing.T) {
 		ChangedAt:    now,
 	}
 
-	if diff := cmp.Diff(got, want); diff != "" {
-		t.Fatalf("diff: %s", diff)
-	}
+	require.Equal(t, want, got)
 }

--- a/enterprise/internal/codemonitors/recipients_test.go
+++ b/enterprise/internal/codemonitors/recipients_test.go
@@ -7,10 +7,6 @@ import (
 )
 
 func TestAllRecipientsForEmailIDInt64(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-
 	ctx, db, s := newTestStore(t)
 	_, id, _, userCTX := newTestUser(ctx, t, db)
 	_, err := s.insertTestMonitor(userCTX, t)

--- a/enterprise/internal/codemonitors/recipients_test.go
+++ b/enterprise/internal/codemonitors/recipients_test.go
@@ -3,7 +3,7 @@ package codemonitors
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAllRecipientsForEmailIDInt64(t *testing.T) {
@@ -14,23 +14,20 @@ func TestAllRecipientsForEmailIDInt64(t *testing.T) {
 	ctx, db, s := newTestStore(t)
 	_, id, _, userCTX := newTestUser(ctx, t, db)
 	_, err := s.insertTestMonitor(userCTX, t)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	var (
 		wantEmailID     int64 = 1
 		wantRecipientID int64 = 1
 	)
 	rs, err := s.ListRecipients(ctx, ListRecipientsOpts{EmailID: &wantEmailID})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if diff := cmp.Diff(rs, []*Recipient{{
+	require.NoError(t, err)
+
+	want := []*Recipient{{
 		ID:              wantRecipientID,
 		Email:           wantEmailID,
 		NamespaceUserID: &id,
 		NamespaceOrgID:  nil,
-	}}); diff != "" {
-		t.Fatalf("diff: %s", diff)
-	}
+	}}
+	require.Equal(t, want, rs)
 }


### PR DESCRIPTION
Just a few QOL improvements for the codemonitors tests. No functionality changes, just making them easier to read at a glance as I prepare to add webhooks to them. 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
