### PR TITLE
search: create global text search job

### DIFF
--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -260,7 +260,7 @@ func (s *IndexedUniverseSearchRequest) Search(ctx context.Context, c streaming.S
 	if s.Args == nil {
 		return nil
 	}
-	return doZoektSearchGlobal(ctx, s.Args, c)
+	return DoZoektSearchGlobal(ctx, s.Args, c)
 }
 
 // IndexedRepos for a request over the indexed universe cannot answer which
@@ -437,7 +437,7 @@ func NewIndexedSubsetSearchRequest(ctx context.Context, repos []*search.Reposito
 	}, nil
 }
 
-func doZoektSearchGlobal(ctx context.Context, args *search.ZoektParameters, c streaming.Sender) error {
+func DoZoektSearchGlobal(ctx context.Context, args *search.ZoektParameters, c streaming.Sender) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 


### PR DESCRIPTION
This creates a global text search job. It's a big (and happy) shift. After this, only the global symbols text job remains to be done.

This change is net additions, but it's only because I'm holding off on deleting a ton of unused stuff once the symbol search job exists too.

Tests look good (I did push a [`backend-integration`](https://buildkite.com/sourcegraph/sourcegraph/builds/118774) build job after misnaming this branch :P). I'll be monitoring search blitz and such for stability/correctness on Sourcegraph.com after merging just in case there is some oversight that affects perf.