### PR TITLE
search: qualify repo subset symbol search job

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -697,7 +697,7 @@ func (r *searchResolver) toSearchInputs(q query.Q) (*search.TextParameters, []ru
 					Zoekt:          args.Zoekt,
 				}
 
-				jobs = append(jobs, &symbol.SymbolSearch{
+				jobs = append(jobs, &symbol.RepoSubsetSymbolSearch{
 					ZoektArgs:         zoektArgs,
 					PatternInfo:       args.PatternInfo,
 					Limit:             r.MaxResults(),
@@ -1688,7 +1688,7 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 			return waitGroup(args.ResultTypes.Without(result.TypeDiff) == 0)
 		case "Commit":
 			return waitGroup(args.ResultTypes.Without(result.TypeCommit) == 0)
-		case "Symbol":
+		case "RepoSubsetSymbol":
 			return waitGroup(args.ResultTypes.Without(result.TypeSymbol) == 0)
 		case "Repo":
 			return waitGroup(true)

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -405,7 +405,7 @@ func limitOrDefault(first *int32) int {
 	return int(*first)
 }
 
-type SymbolSearch struct {
+type RepoSubsetSymbolSearch struct {
 	ZoektArgs         *search.ZoektParameters
 	PatternInfo       *search.TextPatternInfo
 	Limit             int
@@ -415,7 +415,7 @@ type SymbolSearch struct {
 	OnMissingRepoRevs zoektutil.OnMissingRepoRevs
 }
 
-func (s *SymbolSearch) Run(ctx context.Context, stream streaming.Sender, repos searchrepos.Pager) error {
+func (s *RepoSubsetSymbolSearch) Run(ctx context.Context, stream streaming.Sender, repos searchrepos.Pager) error {
 	ctx, stream, cancel := streaming.WithLimit(ctx, stream, s.Limit)
 	defer cancel()
 
@@ -436,6 +436,6 @@ func (s *SymbolSearch) Run(ctx context.Context, stream streaming.Sender, repos s
 	})
 }
 
-func (*SymbolSearch) Name() string {
-	return "Symbol"
+func (*RepoSubsetSymbolSearch) Name() string {
+	return "RepoSubsetSymbol"
 }


### PR DESCRIPTION
Need to rename this to distinguish from upcoming `RepoUniverseSymbolSearch` AKA global symbol search. Exact naming to be revisited once the code is in place.