### PR TITLE
Use returned IDs for EnqueueActionJobsForQuery

### DIFF
--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
@@ -336,7 +336,7 @@ func TestQueryMonitor(t *testing.T) {
 	// in the database. After we create the monitor they fill the job tables and
 	// update the job status.
 	postHookOpt := WithPostHooks([]hook{
-		func() error { return r.store.EnqueueQueryTriggerJobs(ctx) },
+		func() error { _, err := r.store.EnqueueQueryTriggerJobs(ctx); return err },
 		func() error { return r.store.EnqueueActionJobsForQuery(ctx, 1, 1) },
 		func() error {
 			return (&storetest.TestStore{CodeMonitorStore: r.store}).SetJobStatus(ctx, storetest.ActionJobs, storetest.Completed, 1)
@@ -361,7 +361,7 @@ func TestQueryMonitor(t *testing.T) {
 		// 1   1     completed
 		// 2   2     queued
 		// 3   1	 queued
-		func() error { return r.store.EnqueueQueryTriggerJobs(ctx) },
+		func() error { _, err := r.store.EnqueueQueryTriggerJobs(ctx); return err },
 		// To have a consistent state we have to log the number of search results for
 		// each completed trigger job.
 		func() error { return r.store.UpdateTriggerJobWithResults(ctx, "", 1, 1) },

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
@@ -364,7 +364,7 @@ func TestQueryMonitor(t *testing.T) {
 		func() error { _, err := r.store.EnqueueQueryTriggerJobs(ctx); return err },
 		// To have a consistent state we have to log the number of search results for
 		// each completed trigger job.
-		func() error { return r.store.UpdateTriggerJobWithResults(ctx, "", 1, 1) },
+		func() error { return r.store.UpdateTriggerJobWithResults(ctx, 1, "", 1) },
 	})
 	_, err = r.insertTestMonitorWithOpts(ctx, t, actionOpt, postHookOpt)
 	if err != nil {

--- a/enterprise/internal/codemonitors/action_jobs.go
+++ b/enterprise/internal/codemonitors/action_jobs.go
@@ -179,9 +179,9 @@ SELECT id, %s::integer from due EXCEPT SELECT id, %s::integer from busy ORDER BY
 `
 
 // TODO(camdencheek): could/should we enqueue based on monitor ID rather than query ID? Would avoid joins above.
-func (s *codeMonitorStore) EnqueueActionJobsForQuery(ctx context.Context, queryID int64, triggerEventID int) (err error) {
+func (s *codeMonitorStore) EnqueueActionJobsForQuery(ctx context.Context, queryID int64, triggerJobID int32) (err error) {
 	// TODO(camdencheek): Enqueue actions other than emails here
-	return s.Store.Exec(ctx, sqlf.Sprintf(enqueueActionEmailFmtStr, queryID, triggerEventID, triggerEventID))
+	return s.Store.Exec(ctx, sqlf.Sprintf(enqueueActionEmailFmtStr, queryID, triggerJobID, triggerJobID))
 }
 
 const getActionJobMetadataFmtStr = `

--- a/enterprise/internal/codemonitors/action_jobs_test.go
+++ b/enterprise/internal/codemonitors/action_jobs_test.go
@@ -14,10 +14,11 @@ func TestEnqueueActionEmailsForQueryIDInt64QueryByRecordID(t *testing.T) {
 	_, err := s.insertTestMonitor(userCTX, t)
 	require.NoError(t, err)
 
-	_, err = s.EnqueueQueryTriggerJobs(ctx)
+	triggerJobs, err := s.EnqueueQueryTriggerJobs(ctx)
 	require.NoError(t, err)
+	require.Len(t, triggerJobs, 1)
 
-	err = s.EnqueueActionJobsForQuery(ctx, 1, 1)
+	err = s.EnqueueActionJobsForQuery(ctx, 1, triggerJobs[0].ID)
 	require.NoError(t, err)
 
 	got, err := s.GetActionJob(ctx, 1)
@@ -47,8 +48,9 @@ func TestGetActionJobMetadata(t *testing.T) {
 	_, err := s.insertTestMonitor(userCTX, t)
 	require.NoError(t, err)
 
-	_, err = s.EnqueueQueryTriggerJobs(ctx)
+	triggerJobs, err := s.EnqueueQueryTriggerJobs(ctx)
 	require.NoError(t, err)
+	require.Len(t, triggerJobs, 1)
 
 	var (
 		wantNumResults       = 42
@@ -58,7 +60,7 @@ func TestGetActionJobMetadata(t *testing.T) {
 	err = s.UpdateTriggerJobWithResults(ctx, 1, wantQuery, wantNumResults)
 	require.NoError(t, err)
 
-	err = s.EnqueueActionJobsForQuery(ctx, 1, 1)
+	err = s.EnqueueActionJobsForQuery(ctx, 1, triggerJobs[0].ID)
 	require.NoError(t, err)
 
 	got, err := s.GetActionJobMetadata(ctx, 1)
@@ -75,9 +77,8 @@ func TestGetActionJobMetadata(t *testing.T) {
 
 func TestScanActionJobs(t *testing.T) {
 	var (
-		testRecordID             = 1
-		testTriggerEventID int32 = 1
-		testQueryID        int64 = 1
+		testRecordID       = 1
+		testQueryID  int64 = 1
 	)
 
 	ctx, db, s := newTestStore(t)
@@ -85,10 +86,12 @@ func TestScanActionJobs(t *testing.T) {
 	_, err := s.insertTestMonitor(userCTX, t)
 	require.NoError(t, err)
 
-	_, err = s.EnqueueQueryTriggerJobs(ctx)
+	triggerJobs, err := s.EnqueueQueryTriggerJobs(ctx)
 	require.NoError(t, err)
+	require.Len(t, triggerJobs, 1)
+	triggerJobID := triggerJobs[0].ID
 
-	err = s.EnqueueActionJobsForQuery(ctx, testQueryID, testTriggerEventID)
+	err = s.EnqueueActionJobsForQuery(ctx, testQueryID, triggerJobID)
 	require.NoError(t, err)
 
 	rows, err := s.Query(ctx, sqlf.Sprintf(actionJobForIDFmtStr, sqlf.Join(ActionJobColumns, ", "), testRecordID))

--- a/enterprise/internal/codemonitors/action_jobs_test.go
+++ b/enterprise/internal/codemonitors/action_jobs_test.go
@@ -55,7 +55,7 @@ func TestGetActionJobMetadata(t *testing.T) {
 		wantQuery            = testQuery + " after:\"" + s.Now().UTC().Format(time.RFC3339) + "\""
 		wantMonitorID  int64 = 1
 	)
-	err = s.UpdateTriggerJobWithResults(ctx, wantQuery, wantNumResults, 1)
+	err = s.UpdateTriggerJobWithResults(ctx, 1, wantQuery, wantNumResults)
 	require.NoError(t, err)
 
 	err = s.EnqueueActionJobsForQuery(ctx, 1, 1)
@@ -76,7 +76,7 @@ func TestGetActionJobMetadata(t *testing.T) {
 func TestScanActionJobs(t *testing.T) {
 	var (
 		testRecordID             = 1
-		testTriggerEventID       = 1
+		testTriggerEventID int32 = 1
 		testQueryID        int64 = 1
 	)
 

--- a/enterprise/internal/codemonitors/action_jobs_test.go
+++ b/enterprise/internal/codemonitors/action_jobs_test.go
@@ -14,7 +14,7 @@ func TestEnqueueActionEmailsForQueryIDInt64QueryByRecordID(t *testing.T) {
 	_, err := s.insertTestMonitor(userCTX, t)
 	require.NoError(t, err)
 
-	err = s.EnqueueQueryTriggerJobs(ctx)
+	_, err = s.EnqueueQueryTriggerJobs(ctx)
 	require.NoError(t, err)
 
 	err = s.EnqueueActionJobsForQuery(ctx, 1, 1)
@@ -47,7 +47,7 @@ func TestGetActionJobMetadata(t *testing.T) {
 	_, err := s.insertTestMonitor(userCTX, t)
 	require.NoError(t, err)
 
-	err = s.EnqueueQueryTriggerJobs(ctx)
+	_, err = s.EnqueueQueryTriggerJobs(ctx)
 	require.NoError(t, err)
 
 	var (
@@ -85,7 +85,7 @@ func TestScanActionJobs(t *testing.T) {
 	_, err := s.insertTestMonitor(userCTX, t)
 	require.NoError(t, err)
 
-	err = s.EnqueueQueryTriggerJobs(ctx)
+	_, err = s.EnqueueQueryTriggerJobs(ctx)
 	require.NoError(t, err)
 
 	err = s.EnqueueActionJobsForQuery(ctx, testQueryID, testTriggerEventID)

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -148,7 +148,12 @@ func (r *queryRunner) Handle(ctx context.Context, record workerutil.Record) (err
 	}
 	defer func() { err = s.Done(err) }()
 
-	q, err := s.GetQueryTriggerForJob(ctx, record.RecordID())
+	triggerJob, ok := record.(*cm.TriggerJob)
+	if !ok {
+		return errors.Errorf("unexpected record type %T", record)
+	}
+
+	q, err := s.GetQueryTriggerForJob(ctx, triggerJob.ID)
 	if err != nil {
 		return err
 	}

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -176,7 +176,7 @@ func (r *queryRunner) Handle(ctx context.Context, record workerutil.Record) (err
 		numResults = len(results.Data.Search.Results.Results)
 	}
 	if numResults > 0 {
-		err := s.EnqueueActionJobsForQuery(ctx, q.ID, record.RecordID())
+		err := s.EnqueueActionJobsForQuery(ctx, q.ID, triggerJob.ID)
 		if err != nil {
 			return errors.Errorf("store.EnqueueActionJobsForQuery: %w", err)
 		}
@@ -188,7 +188,7 @@ func (r *queryRunner) Handle(ctx context.Context, record workerutil.Record) (err
 		return err
 	}
 	// Log the actual query we ran and whether we got any new results.
-	err = s.UpdateTriggerJobWithResults(ctx, newQuery, numResults, record.RecordID())
+	err = s.UpdateTriggerJobWithResults(ctx, triggerJob.ID, newQuery, numResults)
 	if err != nil {
 		return errors.Errorf("LogSearch: %w", err)
 	}

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -38,7 +38,8 @@ func newTriggerQueryEnqueuer(ctx context.Context, store cm.CodeMonitorStore) gor
 	enqueueActive := goroutine.NewHandlerWithErrorMessage(
 		"code_monitors_trigger_query_enqueuer",
 		func(ctx context.Context) error {
-			return store.EnqueueQueryTriggerJobs(ctx)
+			_, err := store.EnqueueQueryTriggerJobs(ctx)
+			return err
 		})
 	return goroutine.NewPeriodicGoroutine(ctx, 1*time.Minute, enqueueActive)
 }

--- a/enterprise/internal/codemonitors/background/workers_test.go
+++ b/enterprise/internal/codemonitors/background/workers_test.go
@@ -67,7 +67,7 @@ func TestActionRunner(t *testing.T) {
 			_, err := ts.InsertTestMonitor(userCtx, t)
 			require.NoError(t, err)
 
-			err = ts.EnqueueQueryTriggerJobs(ctx)
+			_, err = ts.EnqueueQueryTriggerJobs(ctx)
 			require.NoError(t, err)
 
 			err = ts.UpdateTriggerJobWithResults(ctx, testQuery, tt.numResults, triggerEvent)

--- a/enterprise/internal/codemonitors/background/workers_test.go
+++ b/enterprise/internal/codemonitors/background/workers_test.go
@@ -34,8 +34,7 @@ func TestActionRunner(t *testing.T) {
 	}
 
 	var (
-		queryID      int64 = 1
-		triggerEvent int32 = 1
+		queryID int64 = 1
 	)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -67,13 +66,15 @@ func TestActionRunner(t *testing.T) {
 			_, err := ts.InsertTestMonitor(userCtx, t)
 			require.NoError(t, err)
 
-			_, err = ts.EnqueueQueryTriggerJobs(ctx)
+			triggerJobs, err := ts.EnqueueQueryTriggerJobs(ctx)
+			require.NoError(t, err)
+			require.Len(t, triggerJobs, 1)
+			triggerEventID := triggerJobs[0].ID
+
+			err = ts.UpdateTriggerJobWithResults(ctx, triggerEventID, testQuery, tt.numResults)
 			require.NoError(t, err)
 
-			err = ts.UpdateTriggerJobWithResults(ctx, triggerEvent, testQuery, tt.numResults)
-			require.NoError(t, err)
-
-			err = ts.EnqueueActionJobsForQuery(ctx, queryID, triggerEvent)
+			err = ts.EnqueueActionJobsForQuery(ctx, queryID, triggerEventID)
 			require.NoError(t, err)
 
 			record, err := ts.GetActionJob(ctx, 1)

--- a/enterprise/internal/codemonitors/background/workers_test.go
+++ b/enterprise/internal/codemonitors/background/workers_test.go
@@ -35,7 +35,7 @@ func TestActionRunner(t *testing.T) {
 
 	var (
 		queryID      int64 = 1
-		triggerEvent       = 1
+		triggerEvent int32 = 1
 	)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -70,7 +70,7 @@ func TestActionRunner(t *testing.T) {
 			_, err = ts.EnqueueQueryTriggerJobs(ctx)
 			require.NoError(t, err)
 
-			err = ts.UpdateTriggerJobWithResults(ctx, testQuery, tt.numResults, triggerEvent)
+			err = ts.UpdateTriggerJobWithResults(ctx, triggerEvent, testQuery, tt.numResults)
 			require.NoError(t, err)
 
 			err = ts.EnqueueActionJobsForQuery(ctx, queryID, triggerEvent)

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -264,7 +264,7 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		GetQueryTriggerForJobFunc: &CodeMonitorStoreGetQueryTriggerForJobFunc{
-			defaultHook: func(context.Context, int) (*QueryTrigger, error) {
+			defaultHook: func(context.Context, int32) (*QueryTrigger, error) {
 				return nil, nil
 			},
 		},
@@ -471,7 +471,7 @@ func NewStrictMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		GetQueryTriggerForJobFunc: &CodeMonitorStoreGetQueryTriggerForJobFunc{
-			defaultHook: func(context.Context, int) (*QueryTrigger, error) {
+			defaultHook: func(context.Context, int32) (*QueryTrigger, error) {
 				panic("unexpected invocation of MockCodeMonitorStore.GetQueryTriggerForJob")
 			},
 		},
@@ -3224,15 +3224,15 @@ func (c CodeMonitorStoreGetMonitorFuncCall) Results() []interface{} {
 // GetQueryTriggerForJob method of the parent MockCodeMonitorStore instance
 // is invoked.
 type CodeMonitorStoreGetQueryTriggerForJobFunc struct {
-	defaultHook func(context.Context, int) (*QueryTrigger, error)
-	hooks       []func(context.Context, int) (*QueryTrigger, error)
+	defaultHook func(context.Context, int32) (*QueryTrigger, error)
+	hooks       []func(context.Context, int32) (*QueryTrigger, error)
 	history     []CodeMonitorStoreGetQueryTriggerForJobFuncCall
 	mutex       sync.Mutex
 }
 
 // GetQueryTriggerForJob delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) GetQueryTriggerForJob(v0 context.Context, v1 int) (*QueryTrigger, error) {
+func (m *MockCodeMonitorStore) GetQueryTriggerForJob(v0 context.Context, v1 int32) (*QueryTrigger, error) {
 	r0, r1 := m.GetQueryTriggerForJobFunc.nextHook()(v0, v1)
 	m.GetQueryTriggerForJobFunc.appendCall(CodeMonitorStoreGetQueryTriggerForJobFuncCall{v0, v1, r0, r1})
 	return r0, r1
@@ -3241,7 +3241,7 @@ func (m *MockCodeMonitorStore) GetQueryTriggerForJob(v0 context.Context, v1 int)
 // SetDefaultHook sets function that is called when the
 // GetQueryTriggerForJob method of the parent MockCodeMonitorStore instance
 // is invoked and the hook queue is empty.
-func (f *CodeMonitorStoreGetQueryTriggerForJobFunc) SetDefaultHook(hook func(context.Context, int) (*QueryTrigger, error)) {
+func (f *CodeMonitorStoreGetQueryTriggerForJobFunc) SetDefaultHook(hook func(context.Context, int32) (*QueryTrigger, error)) {
 	f.defaultHook = hook
 }
 
@@ -3250,7 +3250,7 @@ func (f *CodeMonitorStoreGetQueryTriggerForJobFunc) SetDefaultHook(hook func(con
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *CodeMonitorStoreGetQueryTriggerForJobFunc) PushHook(hook func(context.Context, int) (*QueryTrigger, error)) {
+func (f *CodeMonitorStoreGetQueryTriggerForJobFunc) PushHook(hook func(context.Context, int32) (*QueryTrigger, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3259,7 +3259,7 @@ func (f *CodeMonitorStoreGetQueryTriggerForJobFunc) PushHook(hook func(context.C
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *CodeMonitorStoreGetQueryTriggerForJobFunc) SetDefaultReturn(r0 *QueryTrigger, r1 error) {
-	f.SetDefaultHook(func(context.Context, int) (*QueryTrigger, error) {
+	f.SetDefaultHook(func(context.Context, int32) (*QueryTrigger, error) {
 		return r0, r1
 	})
 }
@@ -3267,12 +3267,12 @@ func (f *CodeMonitorStoreGetQueryTriggerForJobFunc) SetDefaultReturn(r0 *QueryTr
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *CodeMonitorStoreGetQueryTriggerForJobFunc) PushReturn(r0 *QueryTrigger, r1 error) {
-	f.PushHook(func(context.Context, int) (*QueryTrigger, error) {
+	f.PushHook(func(context.Context, int32) (*QueryTrigger, error) {
 		return r0, r1
 	})
 }
 
-func (f *CodeMonitorStoreGetQueryTriggerForJobFunc) nextHook() func(context.Context, int) (*QueryTrigger, error) {
+func (f *CodeMonitorStoreGetQueryTriggerForJobFunc) nextHook() func(context.Context, int32) (*QueryTrigger, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3312,7 +3312,7 @@ type CodeMonitorStoreGetQueryTriggerForJobFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
+	Arg1 int32
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 *QueryTrigger

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -229,7 +229,7 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		EnqueueActionJobsForQueryFunc: &CodeMonitorStoreEnqueueActionJobsForQueryFunc{
-			defaultHook: func(context.Context, int64, int) error {
+			defaultHook: func(context.Context, int64, int32) error {
 				return nil
 			},
 		},
@@ -344,7 +344,7 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		UpdateTriggerJobWithResultsFunc: &CodeMonitorStoreUpdateTriggerJobWithResultsFunc{
-			defaultHook: func(context.Context, string, int, int) error {
+			defaultHook: func(context.Context, int32, string, int) error {
 				return nil
 			},
 		},
@@ -436,7 +436,7 @@ func NewStrictMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		EnqueueActionJobsForQueryFunc: &CodeMonitorStoreEnqueueActionJobsForQueryFunc{
-			defaultHook: func(context.Context, int64, int) error {
+			defaultHook: func(context.Context, int64, int32) error {
 				panic("unexpected invocation of MockCodeMonitorStore.EnqueueActionJobsForQuery")
 			},
 		},
@@ -551,7 +551,7 @@ func NewStrictMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		UpdateTriggerJobWithResultsFunc: &CodeMonitorStoreUpdateTriggerJobWithResultsFunc{
-			defaultHook: func(context.Context, string, int, int) error {
+			defaultHook: func(context.Context, int32, string, int) error {
 				panic("unexpected invocation of MockCodeMonitorStore.UpdateTriggerJobWithResults")
 			},
 		},
@@ -2452,15 +2452,15 @@ func (c CodeMonitorStoreDoneFuncCall) Results() []interface{} {
 // the EnqueueActionJobsForQuery method of the parent MockCodeMonitorStore
 // instance is invoked.
 type CodeMonitorStoreEnqueueActionJobsForQueryFunc struct {
-	defaultHook func(context.Context, int64, int) error
-	hooks       []func(context.Context, int64, int) error
+	defaultHook func(context.Context, int64, int32) error
+	hooks       []func(context.Context, int64, int32) error
 	history     []CodeMonitorStoreEnqueueActionJobsForQueryFuncCall
 	mutex       sync.Mutex
 }
 
 // EnqueueActionJobsForQuery delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) EnqueueActionJobsForQuery(v0 context.Context, v1 int64, v2 int) error {
+func (m *MockCodeMonitorStore) EnqueueActionJobsForQuery(v0 context.Context, v1 int64, v2 int32) error {
 	r0 := m.EnqueueActionJobsForQueryFunc.nextHook()(v0, v1, v2)
 	m.EnqueueActionJobsForQueryFunc.appendCall(CodeMonitorStoreEnqueueActionJobsForQueryFuncCall{v0, v1, v2, r0})
 	return r0
@@ -2469,7 +2469,7 @@ func (m *MockCodeMonitorStore) EnqueueActionJobsForQuery(v0 context.Context, v1 
 // SetDefaultHook sets function that is called when the
 // EnqueueActionJobsForQuery method of the parent MockCodeMonitorStore
 // instance is invoked and the hook queue is empty.
-func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) SetDefaultHook(hook func(context.Context, int64, int) error) {
+func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) SetDefaultHook(hook func(context.Context, int64, int32) error) {
 	f.defaultHook = hook
 }
 
@@ -2478,7 +2478,7 @@ func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) SetDefaultHook(hook func
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) PushHook(hook func(context.Context, int64, int) error) {
+func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) PushHook(hook func(context.Context, int64, int32) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2487,7 +2487,7 @@ func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) PushHook(hook func(conte
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, int64, int) error {
+	f.SetDefaultHook(func(context.Context, int64, int32) error {
 		return r0
 	})
 }
@@ -2495,12 +2495,12 @@ func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) SetDefaultReturn(r0 erro
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, int64, int) error {
+	f.PushHook(func(context.Context, int64, int32) error {
 		return r0
 	})
 }
 
-func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) nextHook() func(context.Context, int64, int) error {
+func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) nextHook() func(context.Context, int64, int32) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2543,7 +2543,7 @@ type CodeMonitorStoreEnqueueActionJobsForQueryFuncCall struct {
 	Arg1 int64
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 int
+	Arg2 int32
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -4996,15 +4996,15 @@ func (c CodeMonitorStoreUpdateQueryTriggerFuncCall) Results() []interface{} {
 // when the UpdateTriggerJobWithResults method of the parent
 // MockCodeMonitorStore instance is invoked.
 type CodeMonitorStoreUpdateTriggerJobWithResultsFunc struct {
-	defaultHook func(context.Context, string, int, int) error
-	hooks       []func(context.Context, string, int, int) error
+	defaultHook func(context.Context, int32, string, int) error
+	hooks       []func(context.Context, int32, string, int) error
 	history     []CodeMonitorStoreUpdateTriggerJobWithResultsFuncCall
 	mutex       sync.Mutex
 }
 
 // UpdateTriggerJobWithResults delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) UpdateTriggerJobWithResults(v0 context.Context, v1 string, v2 int, v3 int) error {
+func (m *MockCodeMonitorStore) UpdateTriggerJobWithResults(v0 context.Context, v1 int32, v2 string, v3 int) error {
 	r0 := m.UpdateTriggerJobWithResultsFunc.nextHook()(v0, v1, v2, v3)
 	m.UpdateTriggerJobWithResultsFunc.appendCall(CodeMonitorStoreUpdateTriggerJobWithResultsFuncCall{v0, v1, v2, v3, r0})
 	return r0
@@ -5013,7 +5013,7 @@ func (m *MockCodeMonitorStore) UpdateTriggerJobWithResults(v0 context.Context, v
 // SetDefaultHook sets function that is called when the
 // UpdateTriggerJobWithResults method of the parent MockCodeMonitorStore
 // instance is invoked and the hook queue is empty.
-func (f *CodeMonitorStoreUpdateTriggerJobWithResultsFunc) SetDefaultHook(hook func(context.Context, string, int, int) error) {
+func (f *CodeMonitorStoreUpdateTriggerJobWithResultsFunc) SetDefaultHook(hook func(context.Context, int32, string, int) error) {
 	f.defaultHook = hook
 }
 
@@ -5022,7 +5022,7 @@ func (f *CodeMonitorStoreUpdateTriggerJobWithResultsFunc) SetDefaultHook(hook fu
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *CodeMonitorStoreUpdateTriggerJobWithResultsFunc) PushHook(hook func(context.Context, string, int, int) error) {
+func (f *CodeMonitorStoreUpdateTriggerJobWithResultsFunc) PushHook(hook func(context.Context, int32, string, int) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -5031,7 +5031,7 @@ func (f *CodeMonitorStoreUpdateTriggerJobWithResultsFunc) PushHook(hook func(con
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *CodeMonitorStoreUpdateTriggerJobWithResultsFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, string, int, int) error {
+	f.SetDefaultHook(func(context.Context, int32, string, int) error {
 		return r0
 	})
 }
@@ -5039,12 +5039,12 @@ func (f *CodeMonitorStoreUpdateTriggerJobWithResultsFunc) SetDefaultReturn(r0 er
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *CodeMonitorStoreUpdateTriggerJobWithResultsFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, string, int, int) error {
+	f.PushHook(func(context.Context, int32, string, int) error {
 		return r0
 	})
 }
 
-func (f *CodeMonitorStoreUpdateTriggerJobWithResultsFunc) nextHook() func(context.Context, string, int, int) error {
+func (f *CodeMonitorStoreUpdateTriggerJobWithResultsFunc) nextHook() func(context.Context, int32, string, int) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -5084,10 +5084,10 @@ type CodeMonitorStoreUpdateTriggerJobWithResultsFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 string
+	Arg1 int32
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 int
+	Arg2 string
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
 	Arg3 int

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -234,8 +234,8 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		EnqueueQueryTriggerJobsFunc: &CodeMonitorStoreEnqueueQueryTriggerJobsFunc{
-			defaultHook: func(context.Context) error {
-				return nil
+			defaultHook: func(context.Context) ([]*TriggerJob, error) {
+				return nil, nil
 			},
 		},
 		ExecFunc: &CodeMonitorStoreExecFunc{
@@ -441,7 +441,7 @@ func NewStrictMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		EnqueueQueryTriggerJobsFunc: &CodeMonitorStoreEnqueueQueryTriggerJobsFunc{
-			defaultHook: func(context.Context) error {
+			defaultHook: func(context.Context) ([]*TriggerJob, error) {
 				panic("unexpected invocation of MockCodeMonitorStore.EnqueueQueryTriggerJobs")
 			},
 		},
@@ -2565,24 +2565,24 @@ func (c CodeMonitorStoreEnqueueActionJobsForQueryFuncCall) Results() []interface
 // the EnqueueQueryTriggerJobs method of the parent MockCodeMonitorStore
 // instance is invoked.
 type CodeMonitorStoreEnqueueQueryTriggerJobsFunc struct {
-	defaultHook func(context.Context) error
-	hooks       []func(context.Context) error
+	defaultHook func(context.Context) ([]*TriggerJob, error)
+	hooks       []func(context.Context) ([]*TriggerJob, error)
 	history     []CodeMonitorStoreEnqueueQueryTriggerJobsFuncCall
 	mutex       sync.Mutex
 }
 
 // EnqueueQueryTriggerJobs delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) EnqueueQueryTriggerJobs(v0 context.Context) error {
-	r0 := m.EnqueueQueryTriggerJobsFunc.nextHook()(v0)
-	m.EnqueueQueryTriggerJobsFunc.appendCall(CodeMonitorStoreEnqueueQueryTriggerJobsFuncCall{v0, r0})
-	return r0
+func (m *MockCodeMonitorStore) EnqueueQueryTriggerJobs(v0 context.Context) ([]*TriggerJob, error) {
+	r0, r1 := m.EnqueueQueryTriggerJobsFunc.nextHook()(v0)
+	m.EnqueueQueryTriggerJobsFunc.appendCall(CodeMonitorStoreEnqueueQueryTriggerJobsFuncCall{v0, r0, r1})
+	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
 // EnqueueQueryTriggerJobs method of the parent MockCodeMonitorStore
 // instance is invoked and the hook queue is empty.
-func (f *CodeMonitorStoreEnqueueQueryTriggerJobsFunc) SetDefaultHook(hook func(context.Context) error) {
+func (f *CodeMonitorStoreEnqueueQueryTriggerJobsFunc) SetDefaultHook(hook func(context.Context) ([]*TriggerJob, error)) {
 	f.defaultHook = hook
 }
 
@@ -2591,7 +2591,7 @@ func (f *CodeMonitorStoreEnqueueQueryTriggerJobsFunc) SetDefaultHook(hook func(c
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *CodeMonitorStoreEnqueueQueryTriggerJobsFunc) PushHook(hook func(context.Context) error) {
+func (f *CodeMonitorStoreEnqueueQueryTriggerJobsFunc) PushHook(hook func(context.Context) ([]*TriggerJob, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2599,21 +2599,21 @@ func (f *CodeMonitorStoreEnqueueQueryTriggerJobsFunc) PushHook(hook func(context
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *CodeMonitorStoreEnqueueQueryTriggerJobsFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context) error {
-		return r0
+func (f *CodeMonitorStoreEnqueueQueryTriggerJobsFunc) SetDefaultReturn(r0 []*TriggerJob, r1 error) {
+	f.SetDefaultHook(func(context.Context) ([]*TriggerJob, error) {
+		return r0, r1
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *CodeMonitorStoreEnqueueQueryTriggerJobsFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context) error {
-		return r0
+func (f *CodeMonitorStoreEnqueueQueryTriggerJobsFunc) PushReturn(r0 []*TriggerJob, r1 error) {
+	f.PushHook(func(context.Context) ([]*TriggerJob, error) {
+		return r0, r1
 	})
 }
 
-func (f *CodeMonitorStoreEnqueueQueryTriggerJobsFunc) nextHook() func(context.Context) error {
+func (f *CodeMonitorStoreEnqueueQueryTriggerJobsFunc) nextHook() func(context.Context) ([]*TriggerJob, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2653,7 +2653,10 @@ type CodeMonitorStoreEnqueueQueryTriggerJobsFuncCall struct {
 	Arg0 context.Context
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 error
+	Result0 []*TriggerJob
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -2665,7 +2668,7 @@ func (c CodeMonitorStoreEnqueueQueryTriggerJobsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c CodeMonitorStoreEnqueueQueryTriggerJobsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // CodeMonitorStoreExecFunc describes the behavior when the Exec method of

--- a/enterprise/internal/codemonitors/queries.go
+++ b/enterprise/internal/codemonitors/queries.go
@@ -136,11 +136,11 @@ INNER JOIN cm_trigger_jobs j ON cm_queries.id = j.query
 WHERE j.id = %s
 `
 
-func (s *codeMonitorStore) GetQueryTriggerForJob(ctx context.Context, recordID int) (*QueryTrigger, error) {
+func (s *codeMonitorStore) GetQueryTriggerForJob(ctx context.Context, triggerJob int32) (*QueryTrigger, error) {
 	q := sqlf.Sprintf(
 		getQueryByRecordIDFmtStr,
 		sqlf.Join(queryColumns, ","),
-		recordID,
+		triggerJob,
 	)
 	row := s.QueryRow(ctx, q)
 	return scanTriggerQuery(row)

--- a/enterprise/internal/codemonitors/queries_test.go
+++ b/enterprise/internal/codemonitors/queries_test.go
@@ -13,7 +13,7 @@ func TestQueryByRecordID(t *testing.T) {
 	m, err := s.insertTestMonitor(userCTX, t)
 	require.NoError(t, err)
 
-	err = s.EnqueueQueryTriggerJobs(ctx)
+	_, err = s.EnqueueQueryTriggerJobs(ctx)
 	require.NoError(t, err)
 
 	got, err := s.GetQueryTriggerForJob(ctx, 1)
@@ -40,7 +40,7 @@ func TestTriggerQueryNextRun(t *testing.T) {
 	m, err := s.insertTestMonitor(userCTX, t)
 	require.NoError(t, err)
 
-	err = s.EnqueueQueryTriggerJobs(ctx)
+	_, err = s.EnqueueQueryTriggerJobs(ctx)
 	require.NoError(t, err)
 
 	wantLatestResult := s.Now().Add(time.Minute)

--- a/enterprise/internal/codemonitors/queries_test.go
+++ b/enterprise/internal/codemonitors/queries_test.go
@@ -13,10 +13,12 @@ func TestQueryByRecordID(t *testing.T) {
 	m, err := s.insertTestMonitor(userCTX, t)
 	require.NoError(t, err)
 
-	_, err = s.EnqueueQueryTriggerJobs(ctx)
+	triggerJobs, err := s.EnqueueQueryTriggerJobs(ctx)
 	require.NoError(t, err)
+	require.Len(t, triggerJobs, 1)
+	triggerJobID := triggerJobs[0].ID
 
-	got, err := s.GetQueryTriggerForJob(ctx, 1)
+	got, err := s.GetQueryTriggerForJob(ctx, triggerJobID)
 	require.NoError(t, err)
 
 	now := s.Now()
@@ -40,8 +42,10 @@ func TestTriggerQueryNextRun(t *testing.T) {
 	m, err := s.insertTestMonitor(userCTX, t)
 	require.NoError(t, err)
 
-	_, err = s.EnqueueQueryTriggerJobs(ctx)
+	triggerJobs, err := s.EnqueueQueryTriggerJobs(ctx)
 	require.NoError(t, err)
+	require.Len(t, triggerJobs, 1)
+	triggerJobID := triggerJobs[0].ID
 
 	wantLatestResult := s.Now().Add(time.Minute)
 	wantNextRun := s.Now().Add(time.Hour)
@@ -49,7 +53,7 @@ func TestTriggerQueryNextRun(t *testing.T) {
 	err = s.SetQueryTriggerNextRun(ctx, 1, wantNextRun, wantLatestResult)
 	require.NoError(t, err)
 
-	got, err := s.GetQueryTriggerForJob(ctx, 1)
+	got, err := s.GetQueryTriggerForJob(ctx, triggerJobID)
 	require.NoError(t, err)
 
 	want := &QueryTrigger{

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -35,7 +35,7 @@ type CodeMonitorStore interface {
 	GetQueryTriggerForMonitor(ctx context.Context, monitorID int64) (*QueryTrigger, error)
 	ResetQueryTriggerTimestamps(ctx context.Context, queryID int64) error
 	SetQueryTriggerNextRun(ctx context.Context, triggerQueryID int64, next time.Time, latestResults time.Time) error
-	GetQueryTriggerForJob(ctx context.Context, jobID int) (*QueryTrigger, error)
+	GetQueryTriggerForJob(ctx context.Context, triggerJob int32) (*QueryTrigger, error)
 	EnqueueQueryTriggerJobs(context.Context) ([]*TriggerJob, error)
 	ListQueryTriggerJobs(context.Context, ListTriggerJobsOpts) ([]*TriggerJob, error)
 	CountQueryTriggerJobs(ctx context.Context, queryID int64) (int32, error)

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -36,7 +36,7 @@ type CodeMonitorStore interface {
 	ResetQueryTriggerTimestamps(ctx context.Context, queryID int64) error
 	SetQueryTriggerNextRun(ctx context.Context, triggerQueryID int64, next time.Time, latestResults time.Time) error
 	GetQueryTriggerForJob(ctx context.Context, jobID int) (*QueryTrigger, error)
-	EnqueueQueryTriggerJobs(context.Context) error
+	EnqueueQueryTriggerJobs(context.Context) ([]*TriggerJob, error)
 	ListQueryTriggerJobs(context.Context, ListTriggerJobsOpts) ([]*TriggerJob, error)
 	CountQueryTriggerJobs(ctx context.Context, queryID int64) (int32, error)
 

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -41,7 +41,7 @@ type CodeMonitorStore interface {
 	CountQueryTriggerJobs(ctx context.Context, queryID int64) (int32, error)
 
 	DeleteObsoleteTriggerJobs(ctx context.Context) error
-	UpdateTriggerJobWithResults(ctx context.Context, queryString string, numResults int, recordID int) error
+	UpdateTriggerJobWithResults(ctx context.Context, triggerJobID int32, queryString string, numResults int) error
 	DeleteOldTriggerJobs(ctx context.Context, retentionInDays int) error
 
 	UpdateEmailAction(_ context.Context, id int64, _ *EmailActionArgs) (*EmailAction, error)
@@ -60,7 +60,7 @@ type CodeMonitorStore interface {
 	CountActionJobs(context.Context, ListActionJobsOpts) (int, error)
 	GetActionJobMetadata(ctx context.Context, recordID int) (*ActionJobMetadata, error)
 	GetActionJob(ctx context.Context, recordID int) (*ActionJob, error)
-	EnqueueActionJobsForQuery(ctx context.Context, queryID int64, triggerEventID int) error
+	EnqueueActionJobsForQuery(ctx context.Context, queryID int64, triggerJob int32) error
 }
 
 // codeMonitorStore exposes methods to read and write codemonitors domain models

--- a/enterprise/internal/codemonitors/trigger_jobs.go
+++ b/enterprise/internal/codemonitors/trigger_jobs.go
@@ -71,8 +71,8 @@ SET query_string = %s,
 WHERE id = %s
 `
 
-func (s *codeMonitorStore) UpdateTriggerJobWithResults(ctx context.Context, queryString string, numResults int, recordID int) error {
-	return s.Store.Exec(ctx, sqlf.Sprintf(logSearchFmtStr, queryString, numResults > 0, numResults, recordID))
+func (s *codeMonitorStore) UpdateTriggerJobWithResults(ctx context.Context, triggerJobID int32, queryString string, numResults int) error {
+	return s.Store.Exec(ctx, sqlf.Sprintf(logSearchFmtStr, queryString, numResults > 0, numResults, triggerJobID))
 }
 
 const deleteObsoleteJobLogsFmtStr = `

--- a/enterprise/internal/codemonitors/trigger_jobs_test.go
+++ b/enterprise/internal/codemonitors/trigger_jobs_test.go
@@ -28,18 +28,22 @@ func TestDeleteOldJobLogs(t *testing.T) {
 	require.NoError(t, err)
 
 	// Add 1 job and date it back to a long time ago.
-	_, err = s.EnqueueQueryTriggerJobs(ctx)
+	triggerJobs, err := s.EnqueueQueryTriggerJobs(ctx)
 	require.NoError(t, err)
+	require.Len(t, triggerJobs, 1)
+	firstTriggerJobID := triggerJobs[0].ID
 
 	longTimeAgo := s.Now().AddDate(0, 0, -(retentionInDays + 1))
-	err = s.Exec(ctx, sqlf.Sprintf(setToCompletedFmtStr, longTimeAgo, longTimeAgo, 1))
+	err = s.Exec(ctx, sqlf.Sprintf(setToCompletedFmtStr, longTimeAgo, longTimeAgo, firstTriggerJobID))
 	require.NoError(t, err)
 
 	// Add second job.
-	_, err = s.EnqueueQueryTriggerJobs(ctx)
+	triggerJobs, err = s.EnqueueQueryTriggerJobs(ctx)
 	require.NoError(t, err)
+	require.Len(t, triggerJobs, 1)
+	secondTriggerJobID := triggerJobs[0].ID
 
-	err = s.Exec(ctx, sqlf.Sprintf(setToCompletedFmtStr, s.Now(), s.Now(), 2))
+	err = s.Exec(ctx, sqlf.Sprintf(setToCompletedFmtStr, s.Now(), s.Now(), secondTriggerJobID))
 	require.NoError(t, err)
 
 	err = s.DeleteOldTriggerJobs(ctx, retentionInDays)

--- a/enterprise/internal/codemonitors/trigger_jobs_test.go
+++ b/enterprise/internal/codemonitors/trigger_jobs_test.go
@@ -28,7 +28,7 @@ func TestDeleteOldJobLogs(t *testing.T) {
 	require.NoError(t, err)
 
 	// Add 1 job and date it back to a long time ago.
-	err = s.EnqueueQueryTriggerJobs(ctx)
+	_, err = s.EnqueueQueryTriggerJobs(ctx)
 	require.NoError(t, err)
 
 	longTimeAgo := s.Now().AddDate(0, 0, -(retentionInDays + 1))
@@ -36,7 +36,7 @@ func TestDeleteOldJobLogs(t *testing.T) {
 	require.NoError(t, err)
 
 	// Add second job.
-	err = s.EnqueueQueryTriggerJobs(ctx)
+	_, err = s.EnqueueQueryTriggerJobs(ctx)
 	require.NoError(t, err)
 
 	err = s.Exec(ctx, sqlf.Sprintf(setToCompletedFmtStr, s.Now(), s.Now(), 2))


### PR DESCRIPTION
These tests have a bunch of hard-coded IDs. IDs should ideally be pretty opaque, so having tests that guess what ID the database inserts things with is problematic. These tests are brittle because of that, and they have a bunch of magic numbers that make them difficult to understand. On top of that, it makes it impossible to run these tests in transactions. 

To start fixing that, this PR makes EnqueueActionJobsForQuery return the list of jobs that it enqueued so we can use the IDs of those jobs later in the test. There will be a couple of followup PRs doing similar things for other store methods.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
