### PR TITLE
Change repo to apache/echarts

### DIFF
--- a/doc/code_intelligence/tutorials/indexing_ts_repo.md
+++ b/doc/code_intelligence/tutorials/indexing_ts_repo.md
@@ -32,14 +32,14 @@ We recommend that use the latest version of Sourcegraph and that you have a basi
 1. ["Sourcegraph quickstart"](../../index.md)
 1. ["Introduction to code intelligence"](../explanations/introduction_to_code_intelligence.md)
 
-For the purposes of the tutorial we’ll be using the following repository: [https://github.com/apache/incubator-echarts](https://github.com/apache/incubator-echarts). Before starting the tutorial, you should first ["Add the repo to Sourcegraph"](../how-to/add_a_repository.md).
+For the purposes of the tutorial we’ll be using the following repository: [https://github.com/apache/echarts](https://github.com/apache/echarts). Before starting the tutorial, you should first ["Add the repo to Sourcegraph"](../how-to/add_a_repository.md).
 
 
 ### Clone the TypeScript repository locally
 
 Clone the TypeScript repository by running: 
 ```
-git clone https://github.com/apache/incubator-echarts
+git clone https://github.com/apache/echarts.git
 ```
 
 ### Install Sourcegraph CLI


### PR DESCRIPTION
This is just to fix up the docs real quick, I think the issue with the naming change maybe something else altogether?

This sat stale for a little bit, but and I can't recall exactly but I believe having your repo set to add `apache/incubator-echarts` will correctly clone the repo to `apache/echarts` but the lsif uploads wont work

See issue: https://github.com/sourcegraph/sourcegraph/issues/28509

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
