### PR TITLE
sg: Remove extra character in sg config

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -712,7 +712,7 @@ checks:
 
   go-version:
     cmd: |
-      go_version=#$(go version | cut -d' ' -f 3 | sed 's/go//')
+      go_version=$(go version | cut -d' ' -f 3 | sed 's/go//')
       tools_version=$(cat .tool-versions | grep golang | sed 's/golang //')
       [ "$go_version" = "$tools_version" ] || (echo "➡️ Need go version $tools_version, but got $go_version instead" && exit 1)
     failMessage: 'Incorrect go version'


### PR DESCRIPTION
This character was causing a version mismatch when running `sg doctor` on my Machine (Ubuntu 20.04, WSL2). 

```
$ sg doctor
❌ Check "go-version" failed: 'bash -c go_version=#$(go version | cut -d' ' -f 3 | sed 's/go//')
tools_versi...
Incorrect go version
Check produced the following output:
--------------------------------------------------------------------------------
➡️ Need go version 1.17.3, but got #1.17.3 instead
```