### PR TITLE
batches: implement `createEmptyBatchChange` mutation

### DIFF
--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -71,6 +71,11 @@ type CreateBatchSpecArgs struct {
 	ChangesetSpecs []graphql.ID
 }
 
+type CreateEmptyBatchChangeArgs struct {
+	Namespace graphql.ID
+	Name      string
+}
+
 type CreateBatchSpecFromRawArgs struct {
 	BatchSpec        string
 	AllowIgnored     bool
@@ -234,6 +239,7 @@ type BatchChangesResolver interface {
 	//
 	CreateBatchChange(ctx context.Context, args *CreateBatchChangeArgs) (BatchChangeResolver, error)
 	CreateBatchSpec(ctx context.Context, args *CreateBatchSpecArgs) (BatchSpecResolver, error)
+	CreateEmptyBatchChange(ctx context.Context, args *CreateEmptyBatchChangeArgs) (BatchChangeResolver, error)
 	CreateBatchSpecFromRaw(ctx context.Context, args *CreateBatchSpecFromRawArgs) (BatchSpecResolver, error)
 	ReplaceBatchSpecInput(ctx context.Context, args *ReplaceBatchSpecInputArgs) (BatchSpecResolver, error)
 	DeleteBatchSpec(ctx context.Context, args *DeleteBatchSpecArgs) (*EmptyResponse, error)

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -1325,6 +1325,23 @@ extend type Mutation {
     ): BatchSpec!
 
     """
+    Creates a batch change with an empty batch spec, such as for drafting a new batch
+    change's batch spec. Use `replaceBatchSpecInput` to update the input batch spec after
+    creating.
+    """
+    createEmptyBatchChange(
+        """
+        The namespace (either a user or organization) that this batch change should belong to.
+        """
+        namespace: ID!
+
+        """
+        The (unique) name to identify the batch change by.
+        """
+        name: String!
+    ): BatchChange!
+
+    """
     Creates a batch spec and triggers a job to evaluate the workspaces. Consumers
     need to poll the batch spec until the resolution is completed to get a full
     list of all workspaces. This might become streaming so the results will come

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -1326,7 +1326,8 @@ extend type Mutation {
 
     """
     Creates a batch change with an empty batch spec, such as for drafting a new batch
-    change's batch spec. Use `replaceBatchSpecInput` to update the input batch spec after
+    change. The user creating the batch change must have permission to create it in the
+    namespace provided. Use `replaceBatchSpecInput` to update the input batch spec after
     creating.
     """
     createEmptyBatchChange(
@@ -1336,7 +1337,7 @@ extend type Mutation {
         namespace: ID!
 
         """
-        The (unique) name to identify the batch change by.
+        The (unique) name to identify the batch change by in its namespace.
         """
         name: String!
     ): BatchChange!

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
@@ -556,26 +556,26 @@ func TestCreateEmptyBatchChange(t *testing.T) {
 	var response struct{ CreateEmptyBatchChange apitest.BatchChange }
 	actorCtx := actor.WithActor(ctx, actor.FromUser(userID))
 
-	// First time it should work, because no batch change exists
+	// First time should work because no batch change exists
 	apitest.MustExec(actorCtx, t, s, input, &response, mutationCreateEmptyBatchChange)
 
 	if response.CreateEmptyBatchChange.ID == "" {
 		t.Fatalf("expected batch change to be created, but was not")
 	}
 
-	// TODO: Namespace + name should be required to be unique
-	// errors := apitest.Exec(actorCtx, t, s, input, &response, mutationCreateEmptyBatchChange)
+	// Second time should fail because namespace + name are not unique
+	errors := apitest.Exec(actorCtx, t, s, input, &response, mutationCreateEmptyBatchChange)
 
-	// if len(errors) != 1 {
-	// 	t.Fatalf("expected single errors, but got none")
-	// }
-	// if have, want := errors[0].Message, service.ErrMatchingBatchChangeExists.Error(); have != want {
-	// 	t.Fatalf("wrong error. want=%q, have=%q", want, have)
-	// }
+	if len(errors) != 1 {
+		t.Fatalf("expected single errors, but got none")
+	}
+	if have, want := errors[0].Message, service.ErrNameNotUnique.Error(); have != want {
+		t.Fatalf("wrong error. want=%q, have=%q", want, have)
+	}
 
-	// But a different namespace + the same name is okay
+	// But third time should work because a different namespace + the same name is okay
 	orgID := ct.InsertTestOrg(t, db, "my-org")
-	namespaceID2 := relay.MarshalID("User", orgID)
+	namespaceID2 := relay.MarshalID("Org", orgID)
 
 	input2 := map[string]interface{}{
 		"namespace": namespaceID2,

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
@@ -573,7 +573,7 @@ func TestCreateEmptyBatchChange(t *testing.T) {
 	// 	t.Fatalf("wrong error. want=%q, have=%q", want, have)
 	// }
 
-	// TODO: But a different namespace + the same name is okay
+	// But a different namespace + the same name is okay
 	orgID := ct.InsertTestOrg(t, db, "my-org")
 	namespaceID2 := relay.MarshalID("User", orgID)
 
@@ -582,7 +582,6 @@ func TestCreateEmptyBatchChange(t *testing.T) {
 		"name":      "my-batch-change",
 	}
 
-	// First time it should work, because no batch change exists
 	apitest.MustExec(actorCtx, t, s, input2, &response, mutationCreateEmptyBatchChange)
 
 	if response.CreateEmptyBatchChange.ID == "" {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -586,6 +587,23 @@ func TestCreateEmptyBatchChange(t *testing.T) {
 
 	if response.CreateEmptyBatchChange.ID == "" {
 		t.Fatalf("expected batch change to be created, but was not")
+	}
+
+	// This case should fail because the name fails validation
+	input3 := map[string]interface{}{
+		"namespace": namespaceID,
+		"name":      "not: valid:\nname",
+	}
+
+	errors = apitest.Exec(actorCtx, t, s, input3, &response, mutationCreateEmptyBatchChange)
+
+	if len(errors) != 1 {
+		t.Fatalf("expected single errors, but got none")
+	}
+
+	expError := "The batch change name can only contain word characters, dots and dashes."
+	if have, want := errors[0].Message, expError; !strings.Contains(have, "The batch change name can only contain word characters, dots and dashes.") {
+		t.Fatalf("wrong error. want to contain=%q, have=%q", want, have)
 	}
 }
 

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -151,6 +151,9 @@ type CreateEmptyBatchChangeOpts struct {
 	Name string
 }
 
+// CreateEmptyBatchChange creates a new batch change with an empty batch spec. It enforces
+// namespace permissions of the caller and validates that the combination of name +
+// namespace is unique.
 func (s *Service) CreateEmptyBatchChange(ctx context.Context, opts CreateEmptyBatchChangeOpts) (batchChange *btypes.BatchChange, err error) {
 	// Check whether the current user has access to either one of the namespaces.
 	err = s.CheckNamespaceAccess(ctx, opts.NamespaceUserID, opts.NamespaceOrgID)

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -145,10 +145,10 @@ func (s *Service) WithStore(store *store.Store) *Service {
 }
 
 type CreateEmptyBatchChangeOpts struct {
-	NamespaceUserID int32 `json:"namespace_user_id"`
-	NamespaceOrgID  int32 `json:"namespace_org_id"`
+	NamespaceUserID int32
+	NamespaceOrgID  int32
 
-	Name string `json:"name"`
+	Name string
 }
 
 func (s *Service) CreateEmptyBatchChange(ctx context.Context, opts CreateEmptyBatchChangeOpts) (batchChange *btypes.BatchChange, err error) {

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -187,7 +187,13 @@ func (s *Service) CreateEmptyBatchChange(ctx context.Context, opts CreateEmptyBa
 		return nil, ErrNameNotUnique
 	}
 
-	if err := s.store.CreateBatchSpec(ctx, batchSpec); err != nil {
+	tx, err := s.store.Transact(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { err = tx.Done(err) }()
+
+	if err := tx.CreateBatchSpec(ctx, batchSpec); err != nil {
 		return nil, err
 	}
 
@@ -197,7 +203,7 @@ func (s *Service) CreateEmptyBatchChange(ctx context.Context, opts CreateEmptyBa
 		NamespaceOrgID:  opts.NamespaceOrgID,
 		BatchSpecID:     batchSpec.ID,
 	}
-	if err := s.store.CreateBatchChange(ctx, batchChange); err != nil {
+	if err := tx.CreateBatchChange(ctx, batchChange); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -148,13 +148,13 @@ type CreateEmptyBatchChangeOpts struct {
 }
 
 func (s *Service) CreateEmptyBatchChange(ctx context.Context, opts CreateEmptyBatchChangeOpts) (batchChange *btypes.BatchChange, err error) {
-	fmt.Printf("CreateEmptyBatchChange: %+v\n", opts)
-
 	// Check whether the current user has access to either one of the namespaces.
 	err = s.CheckNamespaceAccess(ctx, opts.NamespaceUserID, opts.NamespaceOrgID)
 	if err != nil {
 		return nil, err
 	}
+
+	// TODO: Validate a unique combination of namespace + name
 
 	actor := actor.FromContext(ctx)
 	spec := &btypes.BatchSpec{
@@ -162,7 +162,8 @@ func (s *Service) CreateEmptyBatchChange(ctx context.Context, opts CreateEmptyBa
 		Spec:            &batcheslib.BatchSpec{Name: opts.Name},
 		NamespaceUserID: opts.NamespaceUserID,
 		NamespaceOrgID:  opts.NamespaceOrgID,
-		UserID:          actor.UID}
+		UserID:          actor.UID,
+	}
 
 	if err := s.store.CreateBatchSpec(ctx, spec); err != nil {
 		return nil, err


### PR DESCRIPTION
Implements the mutation `createEmptyBatchChange` described in the [empty batch spec RFC](https://docs.google.com/document/d/1In0aivqY0CJA4FFvnnp47R8RaWDWKQkUYa9LlvR83FE/edit#heading=h.h66kmofff76v) for initially creating a batch change from the SSBC UI. It takes `namespace` and `name` as required arguments, creates the batch change with an empty batch spec, and returns the new batch change's resolver.

I have one outstanding question I didn't address here but left TODO comments for, which is that, it's my understanding that we should enforce the combination of name + namespace should be unique for every batch change, but I'm not sure the best way to enforce this. I imagine we must already check this for batch specs executed from `src-cli`, but I couldn't find where that was happening.