### PR TITLE
return all test fixtures from insertTestMonitor

### DIFF
--- a/enterprise/internal/codemonitors/action_jobs_test.go
+++ b/enterprise/internal/codemonitors/action_jobs_test.go
@@ -11,14 +11,14 @@ import (
 func TestEnqueueActionEmailsForQuery(t *testing.T) {
 	ctx, db, s := newTestStore(t)
 	_, _, _, userCTX := newTestUser(ctx, t, db)
-	m, _, err := s.insertTestMonitor(userCTX, t)
+	fixtures, err := s.insertTestMonitor(userCTX, t)
 	require.NoError(t, err)
 
 	triggerJobs, err := s.EnqueueQueryTriggerJobs(ctx)
 	require.NoError(t, err)
 	require.Len(t, triggerJobs, 1)
 
-	actionJobs, err := s.EnqueueActionJobsForMonitor(ctx, m.ID, triggerJobs[0].ID)
+	actionJobs, err := s.EnqueueActionJobsForMonitor(ctx, fixtures.monitor.ID, triggerJobs[0].ID)
 	require.NoError(t, err)
 	require.Len(t, actionJobs, 2) // two actions are created by insertTestMonitor
 
@@ -43,7 +43,7 @@ func int64Ptr(i int64) *int64 { return &i }
 func TestGetActionJobMetadata(t *testing.T) {
 	ctx, db, s := newTestStore(t)
 	_, _, _, userCTX := newTestUser(ctx, t, db)
-	m, _, err := s.insertTestMonitor(userCTX, t)
+	fixtures, err := s.insertTestMonitor(userCTX, t)
 	require.NoError(t, err)
 
 	triggerJobs, err := s.EnqueueQueryTriggerJobs(ctx)
@@ -58,7 +58,7 @@ func TestGetActionJobMetadata(t *testing.T) {
 	err = s.UpdateTriggerJobWithResults(ctx, triggerJobID, wantQuery, wantNumResults)
 	require.NoError(t, err)
 
-	actionJobs, err := s.EnqueueActionJobsForMonitor(ctx, m.ID, triggerJobID)
+	actionJobs, err := s.EnqueueActionJobsForMonitor(ctx, fixtures.monitor.ID, triggerJobID)
 	require.NoError(t, err)
 	require.Len(t, actionJobs, 2)
 
@@ -69,7 +69,7 @@ func TestGetActionJobMetadata(t *testing.T) {
 		Description: testDescription,
 		Query:       wantQuery,
 		NumResults:  &wantNumResults,
-		MonitorID:   m.ID,
+		MonitorID:   fixtures.monitor.ID,
 	}
 	require.Equal(t, want, got)
 }
@@ -77,7 +77,7 @@ func TestGetActionJobMetadata(t *testing.T) {
 func TestScanActionJobs(t *testing.T) {
 	ctx, db, s := newTestStore(t)
 	_, _, _, userCTX := newTestUser(ctx, t, db)
-	m, _, err := s.insertTestMonitor(userCTX, t)
+	fixtures, err := s.insertTestMonitor(userCTX, t)
 	require.NoError(t, err)
 
 	triggerJobs, err := s.EnqueueQueryTriggerJobs(ctx)
@@ -85,7 +85,7 @@ func TestScanActionJobs(t *testing.T) {
 	require.Len(t, triggerJobs, 1)
 	triggerJobID := triggerJobs[0].ID
 
-	actionJobs, err := s.EnqueueActionJobsForMonitor(ctx, m.ID, triggerJobID)
+	actionJobs, err := s.EnqueueActionJobsForMonitor(ctx, fixtures.monitor.ID, triggerJobID)
 	require.NoError(t, err)
 	require.Len(t, actionJobs, 2)
 

--- a/enterprise/internal/codemonitors/queries_test.go
+++ b/enterprise/internal/codemonitors/queries_test.go
@@ -10,7 +10,7 @@ import (
 func TestQueryTriggerForJob(t *testing.T) {
 	ctx, db, s := newTestStore(t)
 	_, id, _, userCTX := newTestUser(ctx, t, db)
-	m, _, err := s.insertTestMonitor(userCTX, t)
+	fixtures, err := s.insertTestMonitor(userCTX, t)
 	require.NoError(t, err)
 
 	triggerJobs, err := s.EnqueueQueryTriggerJobs(ctx)
@@ -24,7 +24,7 @@ func TestQueryTriggerForJob(t *testing.T) {
 	now := s.Now()
 	want := &QueryTrigger{
 		ID:           got.ID, // ignore ID
-		Monitor:      m.ID,
+		Monitor:      fixtures.monitor.ID,
 		QueryString:  testQuery,
 		NextRun:      now,
 		LatestResult: &now,
@@ -39,7 +39,7 @@ func TestQueryTriggerForJob(t *testing.T) {
 func TestTriggerQueryNextRun(t *testing.T) {
 	ctx, db, s := newTestStore(t)
 	_, id, _, userCTX := newTestUser(ctx, t, db)
-	m, q, err := s.insertTestMonitor(userCTX, t)
+	fixtures, err := s.insertTestMonitor(userCTX, t)
 	require.NoError(t, err)
 
 	triggerJobs, err := s.EnqueueQueryTriggerJobs(ctx)
@@ -50,7 +50,7 @@ func TestTriggerQueryNextRun(t *testing.T) {
 	wantLatestResult := s.Now().Add(time.Minute)
 	wantNextRun := s.Now().Add(time.Hour)
 
-	err = s.SetQueryTriggerNextRun(ctx, q.ID, wantNextRun, wantLatestResult)
+	err = s.SetQueryTriggerNextRun(ctx, fixtures.query.ID, wantNextRun, wantLatestResult)
 	require.NoError(t, err)
 
 	got, err := s.GetQueryTriggerForJob(ctx, triggerJobID)
@@ -58,7 +58,7 @@ func TestTriggerQueryNextRun(t *testing.T) {
 
 	want := &QueryTrigger{
 		ID:           got.ID, // ignore ID
-		Monitor:      m.ID,
+		Monitor:      fixtures.monitor.ID,
 		QueryString:  testQuery,
 		NextRun:      wantNextRun,
 		LatestResult: &wantLatestResult,
@@ -74,7 +74,7 @@ func TestTriggerQueryNextRun(t *testing.T) {
 func TestResetTriggerQueryTimestamps(t *testing.T) {
 	ctx, db, s := newTestStore(t)
 	_, id, _, userCTX := newTestUser(ctx, t, db)
-	m, q, err := s.insertTestMonitor(userCTX, t)
+	fixtures, err := s.insertTestMonitor(userCTX, t)
 	require.NoError(t, err)
 
 	got, err := s.triggerQueryByIDInt64(ctx, 1)
@@ -83,7 +83,7 @@ func TestResetTriggerQueryTimestamps(t *testing.T) {
 	now := s.Now()
 	want := &QueryTrigger{
 		ID:           got.ID, // ignore ID
-		Monitor:      m.ID,
+		Monitor:      fixtures.monitor.ID,
 		QueryString:  testQuery,
 		NextRun:      now,
 		LatestResult: &now,
@@ -94,7 +94,7 @@ func TestResetTriggerQueryTimestamps(t *testing.T) {
 	}
 	require.Equal(t, want, got)
 
-	err = s.ResetQueryTriggerTimestamps(ctx, q.ID)
+	err = s.ResetQueryTriggerTimestamps(ctx, fixtures.query.ID)
 	require.NoError(t, err)
 
 	got, err = s.triggerQueryByIDInt64(ctx, 1)
@@ -102,7 +102,7 @@ func TestResetTriggerQueryTimestamps(t *testing.T) {
 
 	want = &QueryTrigger{
 		ID:           got.ID, // ignore ID
-		Monitor:      m.ID,
+		Monitor:      fixtures.monitor.ID,
 		QueryString:  testQuery,
 		NextRun:      now,
 		LatestResult: nil,

--- a/enterprise/internal/codemonitors/recipients_test.go
+++ b/enterprise/internal/codemonitors/recipients_test.go
@@ -9,7 +9,7 @@ import (
 func TestAllRecipientsForEmailIDInt64(t *testing.T) {
 	ctx, db, s := newTestStore(t)
 	_, id, _, userCTX := newTestUser(ctx, t, db)
-	_, _, err := s.insertTestMonitor(userCTX, t)
+	_, err := s.insertTestMonitor(userCTX, t)
 	require.NoError(t, err)
 
 	var (

--- a/enterprise/internal/codemonitors/trigger_jobs_test.go
+++ b/enterprise/internal/codemonitors/trigger_jobs_test.go
@@ -24,7 +24,7 @@ func TestDeleteOldJobLogs(t *testing.T) {
 	retentionInDays := 7
 	ctx, db, s := newTestStore(t)
 	_, _, _, userCTX := newTestUser(ctx, t, db)
-	_, _, err := s.insertTestMonitor(userCTX, t)
+	_, err := s.insertTestMonitor(userCTX, t)
 	require.NoError(t, err)
 
 	// Add 1 job and date it back to a long time ago.


### PR DESCRIPTION
Previously, emails and recipients werent returned from the `insertTestMonitor` method, so we didn't have access to the IDs. The size of the return values was getting a little out of hand, and will only get worse with more actions, so I updated it to return a struct with all the created db objects. 

Stacked on #28523 