### PR TITLE
database: more comprehensive tests of `Repos.ListMinimalRepos` with namespace

### DIFF
--- a/internal/database/repos_db_test.go
+++ b/internal/database/repos_db_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -383,41 +385,38 @@ func TestRepos_ListMinimalRepos_userID(t *testing.T) {
 		Password:              "p",
 		EmailVerificationCode: "c",
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	ctx = actor.WithActor(ctx, &actor.Actor{
 		UID: user.ID,
 	})
 
 	now := time.Now()
+	confGet := func() *conf.Unified { return &conf.Unified{} }
+	externalServices := ExternalServices(db)
+	repos := Repos(db)
 
-	// Create an external service
-	service := types.ExternalService{
+	// Create a user-owned external service and its repository
+	userExternalService := types.ExternalService{
 		Kind:            extsvc.KindGitHub,
-		DisplayName:     "Github - Test",
+		DisplayName:     "Github - User-owned",
 		Config:          `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc", "authorization": {}}`,
 		CreatedAt:       now,
 		UpdatedAt:       now,
 		NamespaceUserID: user.ID,
 	}
-	confGet := func() *conf.Unified {
-		return &conf.Unified{}
-	}
-	err = ExternalServices(db).Create(ctx, confGet, &service)
-	if err != nil {
-		t.Fatal(err)
-	}
+	err = externalServices.Create(ctx, confGet, &userExternalService)
+	require.NoError(t, err)
 
-	repo := &types.Repo{
+	userRepo := &types.Repo{
 		ExternalRepo: api.ExternalRepoSpec{
-			ID:          "r",
+			ID:          "github.com/sourcegraph/user",
 			ServiceType: extsvc.TypeGitHub,
 			ServiceID:   "https://github.com",
 		},
-		Name:        "github.com/sourcegraph/sourcegraph",
+		Name:        "github.com/sourcegraph/user",
 		Private:     true,
-		URI:         "uri",
+		URI:         "github.com/sourcegraph/user",
 		Description: "description",
 		Fork:        true,
 		Archived:    true,
@@ -425,29 +424,58 @@ func TestRepos_ListMinimalRepos_userID(t *testing.T) {
 		UpdatedAt:   now,
 		Metadata:    new(github.Repository),
 		Sources: map[string]*types.SourceInfo{
-			service.URN(): {
-				ID:       service.URN(),
-				CloneURL: "git@github.com:foo/bar.git",
+			userExternalService.URN(): {
+				ID:       userExternalService.URN(),
+				CloneURL: "git@github.com:sourcegraph/user.git",
 			},
 		},
 	}
-	err = Repos(db).Create(ctx, repo)
-	if err != nil {
-		t.Fatal(err)
+	err = repos.Create(ctx, userRepo)
+	require.NoError(t, err)
+
+	// Create a site-owned external service and its repository
+	siteExternalService := types.ExternalService{
+		Kind:        extsvc.KindGitHub,
+		DisplayName: "Github - Site-owned",
+		Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc", "authorization": {}}`,
+		CreatedAt:   now,
+		UpdatedAt:   now,
 	}
+	err = externalServices.Create(ctx, confGet, &siteExternalService)
+	require.NoError(t, err)
+
+	siteRepo := &types.Repo{
+		ExternalRepo: api.ExternalRepoSpec{
+			ID:          "github.com/sourcegraph/site",
+			ServiceType: extsvc.TypeGitHub,
+			ServiceID:   "https://github.com",
+		},
+		Name:        "github.com/sourcegraph/site",
+		Private:     true,
+		URI:         "github.com/sourcegraph/site",
+		Description: "description",
+		Fork:        true,
+		Archived:    true,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		Metadata:    new(github.Repository),
+		Sources: map[string]*types.SourceInfo{
+			siteExternalService.URN(): {
+				ID:       siteExternalService.URN(),
+				CloneURL: "git@github.com:sourcegraph/site.git",
+			},
+		},
+	}
+	err = repos.Create(ctx, siteRepo)
+	require.NoError(t, err)
+
+	have, err := repos.ListMinimalRepos(ctx, ReposListOptions{UserID: user.ID})
+	require.NoError(t, err)
 
 	want := []types.MinimalRepo{
-		{ID: repo.ID, Name: repo.Name},
+		{ID: userRepo.ID, Name: userRepo.Name},
 	}
-
-	have, err := Repos(db).ListMinimalRepos(ctx, ReposListOptions{UserID: user.ID})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if diff := cmp.Diff(have, want); diff != "" {
-		t.Fatalf(diff)
-	}
+	assert.Equal(t, want, have)
 }
 
 func TestRepos_ListMinimalRepos_orgID(t *testing.T) {
@@ -462,38 +490,34 @@ func TestRepos_ListMinimalRepos_orgID(t *testing.T) {
 	// Create an org
 	displayName := "Acme Corp"
 	org, err := Orgs(db).Create(ctx, "acme", &displayName)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	now := time.Now()
+	confGet := func() *conf.Unified { return &conf.Unified{} }
+	externalServices := ExternalServices(db)
+	repos := Repos(db)
 
-	// Create an external service
-	service := types.ExternalService{
+	// Create an org-owned external service and its repository
+	orgExternalService := types.ExternalService{
 		Kind:           extsvc.KindGitHub,
-		DisplayName:    "Github - Test",
+		DisplayName:    "Github - Org-owned",
 		Config:         `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc", "authorization": {}}`,
 		CreatedAt:      now,
 		UpdatedAt:      now,
 		NamespaceOrgID: org.ID,
 	}
-	confGet := func() *conf.Unified {
-		return &conf.Unified{}
-	}
-	err = ExternalServices(db).Create(ctx, confGet, &service)
-	if err != nil {
-		t.Fatal(err)
-	}
+	err = externalServices.Create(ctx, confGet, &orgExternalService)
+	require.NoError(t, err)
 
 	repo := &types.Repo{
 		ExternalRepo: api.ExternalRepoSpec{
-			ID:          "r",
+			ID:          "github.com/sourcegraph/org",
 			ServiceType: extsvc.TypeGitHub,
 			ServiceID:   "https://github.com",
 		},
-		Name:        "github.com/sourcegraph/sourcegraph",
+		Name:        "github.com/sourcegraph/org",
 		Private:     true,
-		URI:         "uri",
+		URI:         "github.com/sourcegraph/org",
 		Description: "description",
 		Fork:        true,
 		Archived:    true,
@@ -501,29 +525,58 @@ func TestRepos_ListMinimalRepos_orgID(t *testing.T) {
 		UpdatedAt:   now,
 		Metadata:    new(github.Repository),
 		Sources: map[string]*types.SourceInfo{
-			service.URN(): {
-				ID:       service.URN(),
+			orgExternalService.URN(): {
+				ID:       orgExternalService.URN(),
 				CloneURL: "git@github.com:foo/bar.git",
 			},
 		},
 	}
-	err = Repos(db).Create(ctx, repo)
-	if err != nil {
-		t.Fatal(err)
+	err = repos.Create(ctx, repo)
+	require.NoError(t, err)
+
+	// Create a site-owned external service and its repository
+	siteExternalService := types.ExternalService{
+		Kind:        extsvc.KindGitHub,
+		DisplayName: "Github - Site-owned",
+		Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc", "authorization": {}}`,
+		CreatedAt:   now,
+		UpdatedAt:   now,
 	}
+	err = externalServices.Create(ctx, confGet, &siteExternalService)
+	require.NoError(t, err)
+
+	siteRepo := &types.Repo{
+		ExternalRepo: api.ExternalRepoSpec{
+			ID:          "github.com/sourcegraph/site",
+			ServiceType: extsvc.TypeGitHub,
+			ServiceID:   "https://github.com",
+		},
+		Name:        "github.com/sourcegraph/site",
+		Private:     true,
+		URI:         "github.com/sourcegraph/site",
+		Description: "description",
+		Fork:        true,
+		Archived:    true,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		Metadata:    new(github.Repository),
+		Sources: map[string]*types.SourceInfo{
+			siteExternalService.URN(): {
+				ID:       siteExternalService.URN(),
+				CloneURL: "git@github.com:sourcegraph/site.git",
+			},
+		},
+	}
+	err = repos.Create(ctx, siteRepo)
+	require.NoError(t, err)
+
+	have, err := repos.ListMinimalRepos(ctx, ReposListOptions{OrgID: org.ID})
+	require.NoError(t, err)
 
 	want := []types.MinimalRepo{
 		{ID: repo.ID, Name: repo.Name},
 	}
-
-	have, err := Repos(db).ListMinimalRepos(ctx, ReposListOptions{OrgID: org.ID})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if diff := cmp.Diff(have, want); diff != "" {
-		t.Fatalf(diff)
-	}
+	assert.Equal(t, want, have)
 }
 
 func TestRepos_List_fork(t *testing.T) {


### PR DESCRIPTION
Existing tests for the `Repos.ListMinimalRepos` method are not sufficient in the sense that the test setups do not prove `Repos.ListMinimalRepos` will exclude repositories that are _not added_ by the user or the org.

---

Follow up of https://github.com/sourcegraph/sourcegraph/pull/26029#discussion_r730892833.