### PR TITLE
percy: capture images with base64 converted src

### DIFF
--- a/client/web/src/integration/utils.ts
+++ b/client/web/src/integration/utils.ts
@@ -42,6 +42,31 @@ const ColorSchemeToMonacoEditorClassName: Record<ColorScheme, string> = {
     dark: 'vs-dark',
     light: 'vs',
 }
+/**
+ * Percy couldn't capture <img /> since they have `src` values with testing domain name.
+ * We need to call this function before asking Percy to take snapshots,
+ * <img /> with base64 data would be visible on Percy snapshot
+ */
+export const convertImgSourceHttpToBase64 = async (page: Page): Promise<void> => {
+    await page.evaluate(() => {
+        const imgs = document.querySelectorAll('img')
+
+        for (const img of imgs) {
+            if (img.src.startsWith('data:image')) {
+                continue
+            }
+
+            const canvas = document.createElement('canvas')
+            canvas.width = img.width
+            canvas.height = img.height
+
+            const context = canvas.getContext('2d')
+            context?.drawImage(img, 0, 0)
+
+            img.src = canvas.toDataURL('image/png')
+        }
+    })
+}
 
 /**
  * Update all theme styling on the Sourcegraph webapp to match a color scheme.
@@ -109,10 +134,12 @@ export const percySnapshotWithVariants = async (
 
     // Theme-light
     await setColorScheme(page, 'light', config?.waitForCodeHighlighting)
+    await convertImgSourceHttpToBase64(page)
     await percySnapshot(page, `${name} - light theme`)
 
     // Theme-dark
     await setColorScheme(page, 'dark', config?.waitForCodeHighlighting)
+    await convertImgSourceHttpToBase64(page)
     await percySnapshot(page, `${name} - dark theme`)
 
     // Reset to light theme


### PR DESCRIPTION
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
## Description

Percy doesn't take screenshots of page at the time calling `percySnapshot` but captures DOM, CSS rules and uses them to render pages on their browsers including fetching assets, at that points, image `src` values still have the domain for testing, so Percy won't be able to capture them.

In this PR fixes that issue with converting all `img` `src` to base64 uri before calling `percySnapshot`

## Refs
[SourceGraph Issue](https://github.com/sourcegraph/sourcegraph/issues/20154)
[Gitstart Issue](https://app.gitstart.com/clients/sourcegraph/tickets/SG-20154)
