### PR TITLE
Code Insights: use env context variable for gql insight api on FE

### DIFF
--- a/client/web/dev/utils/create-js-context.ts
+++ b/client/web/dev/utils/create-js-context.ts
@@ -30,6 +30,7 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
         executorsEnabled: false,
         codeIntelAutoIndexingEnabled: false,
         codeIntelAutoIndexingAllowGlobalPolicies: false,
+        codeInsightsGqlApiEnabled: false,
         externalServicesUserMode: 'public',
         productResearchPageEnabled: true,
         csrfToken: 'qwerty',

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -31,7 +31,7 @@ import { ExtensionsAreaHeaderActionButton } from './extensions/ExtensionsAreaHea
 import { FeatureFlagProps } from './featureFlags/featureFlags'
 import { GlobalAlerts } from './global/GlobalAlerts'
 import { GlobalDebug } from './global/GlobalDebug'
-import { CodeInsightsProps } from './insights/types'
+import { CodeInsightsContextProps, CodeInsightsProps } from './insights/types'
 import { KeyboardShortcutsProps, KEYBOARD_SHORTCUT_SHOW_HELP } from './keyboardShortcuts/keyboardShortcuts'
 import { KeyboardShortcutsHelp } from './keyboardShortcuts/KeyboardShortcutsHelp'
 import styles from './Layout.module.scss'
@@ -92,6 +92,7 @@ export interface LayoutProps
         CodeIntelligenceProps,
         BatchChangesProps,
         CodeInsightsProps,
+        CodeInsightsContextProps,
         FeatureFlagProps {
     extensionAreaRoutes: readonly ExtensionAreaRoute[]
     extensionAreaHeaderNavItems: readonly ExtensionAreaHeaderNavItem[]

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -497,6 +497,9 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
                                                     showMultilineSearchConsole={this.state.showMultilineSearchConsole}
                                                     showSearchNotebook={this.state.showSearchNotebook}
                                                     enableCodeMonitoring={this.state.enableCodeMonitoring}
+                                                    isCodeInsightsGqlApiEnabled={
+                                                        window.context.codeInsightsGqlApiEnabled
+                                                    }
                                                     fetchSavedSearches={fetchSavedSearches}
                                                     fetchRecentSearches={fetchRecentSearches}
                                                     fetchRecentFileViews={fetchRecentFileViews}

--- a/client/web/src/insights/types.ts
+++ b/client/web/src/insights/types.ts
@@ -3,11 +3,20 @@ import React from 'react'
 import { ExtensionViewsSectionProps } from './sections/ExtensionViewsSection'
 
 /**
- * Common props for components (the homepage, the directory page) needing to render
- * Code Insights and extension views for the enterprise version and extension views
- * only for the OSS version.
+ * Common props for code insights consumer components (the homepage, the directory page)
+ * These props are needed for condition rendering of Code Insights and extension-like views.
+ * For the enterprise version it's code insights + extension views and for the OSS version
+ * it's extension views only.
  */
 export interface CodeInsightsProps {
     codeInsightsEnabled?: boolean
     extensionViews: React.FunctionComponent<ExtensionViewsSectionProps>
+}
+
+/**
+ * Props that are needed to tune code insights internal logic. Like switching different
+ * code insights api backend (setting-based vs gql based api)
+ */
+export interface CodeInsightsContextProps {
+    isCodeInsightsGqlApiEnabled: boolean
 }

--- a/client/web/src/integration/jscontext.ts
+++ b/client/web/src/integration/jscontext.ts
@@ -22,6 +22,7 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
     executorsEnabled: true,
     codeIntelAutoIndexingEnabled: true,
     codeIntelAutoIndexingAllowGlobalPolicies: true,
+    codeInsightsGqlApiEnabled: false,
     externalServicesUserMode: 'disabled',
     productResearchPageEnabled: true,
     csrfToken: 'test-csrf-token',

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -109,6 +109,9 @@ export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'e
     /** Whether global policies are enabled for auto-indexing. */
     codeIntelAutoIndexingAllowGlobalPolicies: boolean
 
+    /** Whether the new gql api for code insights is enabled. */
+    codeInsightsGqlApiEnabled: boolean
+
     /** Whether users are allowed to add their own code and at what permission level. */
     externalServicesUserMode: 'disabled' | 'public' | 'all' | 'unknown'
 

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -95,7 +95,7 @@ type JSContext struct {
 	CodeIntelAutoIndexingEnabled             bool `json:"codeIntelAutoIndexingEnabled"`
 	CodeIntelAutoIndexingAllowGlobalPolicies bool `json:"codeIntelAutoIndexingAllowGlobalPolicies"`
 
-	CodeInsightsGQLApiEnabled bool `json:"CodeInsightsGQLApiEnabled"`
+	CodeInsightsGQLApiEnabled bool `json:"codeInsightsGqlApiEnabled"`
 
 	ProductResearchPageEnabled bool `json:"productResearchPageEnabled"`
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1498,7 +1498,7 @@ type SettingsExperimentalFeatures struct {
 	CodeInsights *bool `json:"codeInsights,omitempty"`
 	// CodeInsightsAllRepos description: DEPRECATED: Enables the experimental ability to run an insight over all repositories on the instance.
 	CodeInsightsAllRepos *bool `json:"codeInsightsAllRepos,omitempty"`
-	// CodeInsightsGqlApi description: Enables gql api instead of using setting cascade as a main storage fro code insights entities
+	// CodeInsightsGqlApi description: DEPRECATED: Enables gql api instead of using setting cascade as a main storage fro code insights entities
 	CodeInsightsGqlApi *bool `json:"codeInsightsGqlApi,omitempty"`
 	// CodeMonitoring description: Enables code monitoring.
 	CodeMonitoring *bool `json:"codeMonitoring,omitempty"`

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -21,7 +21,8 @@
           }
         },
         "codeInsightsGqlApi": {
-          "description": "Enables gql api instead of using setting cascade as a main storage fro code insights entities",
+          "deprecated": true,
+          "description": "DEPRECATED: Enables gql api instead of using setting cascade as a main storage fro code insights entities",
           "type": "boolean",
           "default": false,
           "!go": {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/28513

This PR does a few things
- Changes a variable name to codeInsightsGqlApiEnabled in JSON body of JsContext struct on BE
- Deprecates a setting based experimental feature flag
- Uses `window.context` feature flag (the new one) in code insights main component to switch different API