### PR TITLE
searcher: listen for OS signals

### DIFF
--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -105,10 +105,12 @@ func main() {
 		}),
 	}
 
-	log15.Info("searcher: listening", "addr", server.Addr)
-	if err := server.ListenAndServe(); err != http.ErrServerClosed {
-		log.Fatal(err)
-	}
+	go func() {
+		log15.Info("searcher: listening", "addr", server.Addr)
+		if err := server.ListenAndServe(); err != http.ErrServerClosed {
+			log.Fatal(err)
+		}
+	}()
 
 	// Listen for shutdown signals. When we receive one attempt to clean up,
 	// but do an insta-shutdown if we receive more than one signal.


### PR DESCRIPTION
Currently we never start the signal listeners since
server.ListenAndServe blocks. This means we currently have no signal
handlers => instant shutdown on receiving a signal.

This was accidently introduced a month ago while refactoring graceful
shutdowns across services. Before that we correctly listened for SIGINT
only. See https://github.com/sourcegraph/sourcegraph/pull/27958