### PR TITLE
Source environment before running any command

### DIFF
--- a/dev/sg/sg_setup.go
+++ b/dev/sg/sg_setup.go
@@ -767,7 +767,7 @@ func fixCategoryAutomatically(ctx context.Context, category *dependencyCategory)
 func fixDependencyAutomatically(ctx context.Context, dep *dependency) error {
 	writeFingerPointingLine("Trying my hardest to fix %q automatically...", dep.name)
 
-	cmd := sourceExec(ctx, dep.InstructionsCommands(ctx))
+	cmd := execFreshShell(ctx, dep.InstructionsCommands(ctx))
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
@@ -949,10 +949,10 @@ func guessUserShell() (string, string, error) {
 	return shell, filepath.Join(home, shellrc), nil
 }
 
-// sourceExec returns a command wrapped in a new shell process, enabling
+// execFreshShell returns a command wrapped in a new shell process, enabling
 // changes added by various checks to be run. This negates the new to ask the
 // user to restart sg for many checks.
-func sourceExec(ctx context.Context, cmd string) *exec.Cmd {
+func execFreshShell(ctx context.Context, cmd string) *exec.Cmd {
 	command := fmt.Sprintf("source %s || true; %s", getUserShellConfigPath(ctx), cmd)
 	return exec.CommandContext(ctx, getUserShellPath(ctx), "-c", command)
 }
@@ -960,7 +960,7 @@ func sourceExec(ctx context.Context, cmd string) *exec.Cmd {
 // combinedSourceExec runs a command in a fresh shell environment,
 // and returns stderr and stdout combined, along with an error.
 func combinedSourceExec(ctx context.Context, cmd string) ([]byte, error) {
-	return sourceExec(ctx, cmd).CombinedOutput()
+	return execFreshShell(ctx, cmd).CombinedOutput()
 }
 
 func checkInPath(cmd string) func(context.Context) error {

--- a/dev/sg/sg_setup.go
+++ b/dev/sg/sg_setup.go
@@ -189,14 +189,6 @@ Follow the instructions at https://brew.sh to install it, then rerun 'sg setup'.
 		name: "Install base utilities (git, docker, ...)",
 		dependencies: []*dependency{
 			{name: "git", check: checkInPath("git"), instructionsCommands: stringer(`brew install git`)},
-			{
-				name:  "asdf",
-				check: checkCommandOutputContains("asdf", "version", false),
-				// Uses `&&` to avoid appending the shell config on failed installations attempts.
-				instructionsCommands: lazyString(func() string {
-					return `brew install asdf && echo ". /opt/homebrew/opt/asdf/libexec/asdf.sh" >> ` + userShellRC
-				}),
-			},
 			{name: "gnu-sed", check: checkInPath("gsed"), instructionsCommands: stringer("brew install gnu-sed")},
 			{name: "comby", check: checkInPath("comby"), instructionsCommands: stringer("brew install comby")},
 			{name: "pcre", check: checkInPath("pcregrep"), instructionsCommands: stringer(`brew install pcre`)},
@@ -260,6 +252,14 @@ NOTE: You can ignore this if you're not a Sourcegraph employee.
 		requiresRepository: true,
 		autoFixing:         true,
 		dependencies: []*dependency{
+			{
+				name:  "asdf",
+				check: checkCommandOutputContains("asdf", "version", false),
+				// Uses `&&` to avoid appending the shell config on failed installations attempts.
+				instructionsCommands: lazyString(func() string {
+					return `brew install asdf && echo ". /opt/homebrew/opt/asdf/libexec/asdf.sh" >> ` + userShellRC
+				}),
+			},
 			{
 				name:  "go",
 				check: checkCommandOutputContains("asdf current golang", ".tool-versions", false),

--- a/dev/sg/sg_setup.go
+++ b/dev/sg/sg_setup.go
@@ -27,8 +27,6 @@ import (
 )
 
 var (
-	userShell    string
-	userShellRC  string
 	setupFlagSet = flag.NewFlagSet("sg setup", flag.ExitOnError)
 	setupCommand = &ffcli.Command{
 		Name:       "setup",

--- a/dev/sg/sg_setup.go
+++ b/dev/sg/sg_setup.go
@@ -272,6 +272,9 @@ NOTE: You can ignore this if you're not a Sourcegraph employee.
 		name:               "Programming languages & tooling",
 		requiresRepository: true,
 		autoFixing:         true,
+		// autoFixingDependencies are only accounted for it the user asks to fix the category. Otherwise, they'll never be
+		// checked nor print an error, because the only thing that matters to run Sourcegraph are the final dependencies
+		// defined in the dependencies field itself.
 		autoFixingDependencies: []*dependency{
 			{
 				name:  "asdf",

--- a/dev/sg/sg_setup.go
+++ b/dev/sg/sg_setup.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -53,6 +54,16 @@ func setupExec(ctx context.Context, args []string) error {
 	// Fetch the current user shell and shell RC file
 	userShell, userShellRC = guessUserShell()
 
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	go func() {
+		for range c {
+			writeOrangeLine("\n💡 You may need to restart your shell for the changes to work in this terminal.")
+			writeOrangeLine("   Close this terminal and open a new one or type the following command and press ENTER: " + filepath.Base(userShell))
+			os.Exit(0)
+		}
+	}()
+
 	var categories []dependencyCategory
 	if currentOS == "darwin" {
 		categories = macOSDependencies
@@ -82,6 +93,7 @@ func setupExec(ctx context.Context, args []string) error {
 		writeOrangeLine("-------------------------------------")
 		writeOrangeLine("|        Welcome to sg setup!       |")
 		writeOrangeLine("-------------------------------------")
+		writeOrangeLine("Quit any time by typing ctrl-c\n")
 
 		for i, category := range categories {
 			idx := i + 1

--- a/dev/sg/sg_setup.go
+++ b/dev/sg/sg_setup.go
@@ -261,7 +261,8 @@ NOTE: You can ignore this if you're not a Sourcegraph employee.
 		autoFixing:         true,
 		dependencies: []*dependency{
 			{
-				name: "go", check: checkInPath("go"),
+				name:  "go",
+				check: checkCommandOutputContains("asdf current golang", ".tool-versions", false),
 				instructionsComment: `` +
 					`Souregraph requires Go to be installed.
 
@@ -279,7 +280,8 @@ asdf install golang
 `),
 			},
 			{
-				name: "yarn", check: checkInPath("yarn"),
+				name:  "yarn",
+				check: checkCommandOutputContains("asdf current yarn", ".tool-versions", false),
 				instructionsComment: `` +
 					`Souregraph requires Yarn to be installed.
 

--- a/dev/sg/sg_setup.go
+++ b/dev/sg/sg_setup.go
@@ -192,7 +192,7 @@ Follow the instructions at https://brew.sh to install it, then rerun 'sg setup'.
 			{name: "gnu-sed", check: checkInPath("gsed"), instructionsCommands: stringer("brew install gnu-sed")},
 			{name: "comby", check: checkInPath("comby"), instructionsCommands: stringer("brew install comby")},
 			{name: "pcre", check: checkInPath("pcregrep"), instructionsCommands: stringer(`brew install pcre`)},
-			{name: "sqlite", check: checkInPath("sqlite3"), instructionsCommands: stringer(`install sqlite`)},
+			{name: "sqlite", check: checkInPath("sqlite3"), instructionsCommands: stringer(`brew install sqlite`)},
 			{name: "jq", check: checkInPath("jq"), instructionsCommands: stringer(`brew install jq`)},
 			{name: "bash", check: checkCommandOutputContains("bash --version", "version 5", false), instructionsCommands: stringer(`brew install bash`)},
 			{

--- a/dev/sg/sg_setup.go
+++ b/dev/sg/sg_setup.go
@@ -258,7 +258,7 @@ NOTE: You can ignore this if you're not a Sourcegraph employee.
 	{
 		name:               "Programming languages & tooling",
 		requiresRepository: true,
-		// TODO: Can we provide an autofix here that installs asdf, reloads shell, installs language versions?
+		autoFixing:         true,
 		dependencies: []*dependency{
 			{
 				name: "go", check: checkInPath("go"),
@@ -299,7 +299,7 @@ asdf install yarn
 			},
 			{
 				name:  "node",
-				check: checkInPath("node"),
+				check: checkCommandOutputContains("asdf current nodejs", ".nvmrc", false),
 				instructionsComment: `` +
 					`Souregraph requires Node.JS to be installed.
 
@@ -313,7 +313,7 @@ programming languages and tools. Find out how to install asdf here:
 Once you have asdf, execute the commands below.`,
 				instructionsCommands: stringer(`
 asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git 
-echo 'legacy_version_file = yes' >> ~/.asdfrc
+touch ~/.asdfrc && cat ~/.asdfrc | grep "legacy_version_file = yes" || echo 'legacy_version_file = yes' >> ~/.asdfrc
 asdf install nodejs
 `),
 			},

--- a/dev/sg/sg_setup.go
+++ b/dev/sg/sg_setup.go
@@ -280,7 +280,7 @@ NOTE: You can ignore this if you're not a Sourcegraph employee.
 				check: checkCommandOutputContains("asdf", "version"),
 				instructionsCommandsBuilder: stringCommandBuilder(func(ctx context.Context) string {
 					// Uses `&&` to avoid appending the shell config on failed installations attempts.
-					return `brew install asdf && echo ". $HOMEBREW_PREFIX/opt/asdf/libexec/asdf.sh" >> ` + getUserShellConfigPath(ctx)
+					return `brew install asdf && echo ". ${HOMEBREW_PREFIX:-/usr/local}/opt/asdf/libexec/asdf.sh" >> ` + getUserShellConfigPath(ctx)
 				}),
 			},
 		},

--- a/dev/sg/sg_setup.go
+++ b/dev/sg/sg_setup.go
@@ -1075,7 +1075,6 @@ type dependency struct {
 	instructionsComment         string
 	instructionsCommands        string
 	instructionsCommandsBuilder commandBuilder
-	autoFixingCommands          string
 	requiresSgSetupRestart      bool
 }
 


### PR DESCRIPTION
Makes the programming languages section auto fixing. 

- ~I had to move the `asdf` installation step to the programming languages section, otherwise that section could be entered without being fixable.~ 
  - ~While not perfect, because running any other step than `asdf` will always fail, autofixing it will pick them in order and will work.~ 
  - `asdf` is an autofixing dependency and won't be installed if the language checks passes. It will if the user asks to autofix things. 
- ~Handles the cases where asdf is installed but the language isn't.~ breaks the independence from `asdf` promise, removed.  
  - ~`asdf` shim will be picked up, which incorrectly asserts that the language is present.~
  - ~It will check compliance with `.nvmrc` though we can remove that in another PR.~
- All commands being run are run in a fresh shell, which eliminates the need to restart `sg`. 
- Adds a message explaining to the user how to exit. A handler is set to print a warning about reloading the environment to get everything to work if they do.
  - Because we're sourcing the env before every step, it would be confusing to have the checks passing but not outside `sg setup`. 
- It picks the right shell configuration file based on the current shell.
