### PR TITLE
sg: fix retry check not returning soon enough

### DIFF
--- a/dev/sg/sg_setup.go
+++ b/dev/sg/sg_setup.go
@@ -1081,8 +1081,8 @@ func retryCheck(check dependencyCheck, retries int, sleep time.Duration) depende
 	return func(ctx context.Context) (err error) {
 		for i := 0; i < retries; i++ {
 			err = check(ctx)
-			if err != nil {
-				return err
+			if err == nil {
+				return nil
 			}
 			time.Sleep(sleep)
 		}


### PR DESCRIPTION
Fixes a small bug I introduced in #28360 that caused redis check to take longer than it should have. 
