### PR TITLE
Code Monitors: return all fixtures from insertTestMonitor

### DIFF
--- a/enterprise/internal/codemonitors/main_test.go
+++ b/enterprise/internal/codemonitors/main_test.go
@@ -20,8 +20,17 @@ const (
 	testDescription = "test description"
 )
 
-func (s *codeMonitorStore) insertTestMonitor(ctx context.Context, t *testing.T) (*Monitor, error) {
+type testFixtures struct {
+	monitor    *Monitor
+	query      *QueryTrigger
+	emails     [2]*EmailAction
+	recipients [2]*Recipient
+}
+
+func (s *codeMonitorStore) insertTestMonitor(ctx context.Context, t *testing.T) (*testFixtures, error) {
 	t.Helper()
+
+	fixtures := testFixtures{}
 
 	actions := []*EmailActionArgs{
 		{
@@ -37,7 +46,8 @@ func (s *codeMonitorStore) insertTestMonitor(ctx context.Context, t *testing.T) 
 	}
 	// Create monitor.
 	uid := actor.FromContext(ctx).UID
-	m, err := s.CreateMonitor(ctx, MonitorArgs{
+	var err error
+	fixtures.monitor, err = s.CreateMonitor(ctx, MonitorArgs{
 		Description:     testDescription,
 		Enabled:         true,
 		NamespaceUserID: &uid,
@@ -45,22 +55,22 @@ func (s *codeMonitorStore) insertTestMonitor(ctx context.Context, t *testing.T) 
 	require.NoError(t, err)
 
 	// Create trigger.
-	_, err = s.CreateQueryTrigger(ctx, m.ID, testQuery)
+	fixtures.query, err = s.CreateQueryTrigger(ctx, fixtures.monitor.ID, testQuery)
 	require.NoError(t, err)
 
-	for _, a := range actions {
-		e, err := s.CreateEmailAction(ctx, m.ID, &EmailActionArgs{
+	for i, a := range actions {
+		fixtures.emails[i], err = s.CreateEmailAction(ctx, fixtures.monitor.ID, &EmailActionArgs{
 			Enabled:  a.Enabled,
 			Priority: a.Priority,
 			Header:   a.Header,
 		})
 		require.NoError(t, err)
 
-		_, err = s.CreateRecipient(ctx, e.ID, &uid, nil)
+		fixtures.recipients[i], err = s.CreateRecipient(ctx, fixtures.emails[i].ID, &uid, nil)
 		require.NoError(t, err)
 		// TODO(camdencheek): add other action types (webhooks) here
 	}
-	return m, nil
+	return &fixtures, nil
 }
 
 func newTestStore(t *testing.T) (context.Context, dbutil.DB, *codeMonitorStore) {

--- a/enterprise/internal/codemonitors/queries_test.go
+++ b/enterprise/internal/codemonitors/queries_test.go
@@ -10,7 +10,7 @@ import (
 func TestQueryByRecordID(t *testing.T) {
 	ctx, db, s := newTestStore(t)
 	_, id, _, userCTX := newTestUser(ctx, t, db)
-	m, err := s.insertTestMonitor(userCTX, t)
+	fixtures, err := s.insertTestMonitor(userCTX, t)
 	require.NoError(t, err)
 
 	triggerJobs, err := s.EnqueueQueryTriggerJobs(ctx)
@@ -24,7 +24,7 @@ func TestQueryByRecordID(t *testing.T) {
 	now := s.Now()
 	want := &QueryTrigger{
 		ID:           1,
-		Monitor:      m.ID,
+		Monitor:      fixtures.monitor.ID,
 		QueryString:  testQuery,
 		NextRun:      now,
 		LatestResult: &now,
@@ -39,7 +39,7 @@ func TestQueryByRecordID(t *testing.T) {
 func TestTriggerQueryNextRun(t *testing.T) {
 	ctx, db, s := newTestStore(t)
 	_, id, _, userCTX := newTestUser(ctx, t, db)
-	m, err := s.insertTestMonitor(userCTX, t)
+	fixtures, err := s.insertTestMonitor(userCTX, t)
 	require.NoError(t, err)
 
 	triggerJobs, err := s.EnqueueQueryTriggerJobs(ctx)
@@ -58,7 +58,7 @@ func TestTriggerQueryNextRun(t *testing.T) {
 
 	want := &QueryTrigger{
 		ID:           1,
-		Monitor:      m.ID,
+		Monitor:      fixtures.monitor.ID,
 		QueryString:  testQuery,
 		NextRun:      wantNextRun,
 		LatestResult: &wantLatestResult,
@@ -74,13 +74,13 @@ func TestTriggerQueryNextRun(t *testing.T) {
 func TestResetTriggerQueryTimestamps(t *testing.T) {
 	ctx, db, s := newTestStore(t)
 	_, id, _, userCTX := newTestUser(ctx, t, db)
-	m, err := s.insertTestMonitor(userCTX, t)
+	fixtures, err := s.insertTestMonitor(userCTX, t)
 	require.NoError(t, err)
 
 	now := s.Now()
 	want := &QueryTrigger{
 		ID:           1,
-		Monitor:      m.ID,
+		Monitor:      fixtures.monitor.ID,
 		QueryString:  testQuery,
 		NextRun:      now,
 		LatestResult: &now,
@@ -102,7 +102,7 @@ func TestResetTriggerQueryTimestamps(t *testing.T) {
 
 	want = &QueryTrigger{
 		ID:           1,
-		Monitor:      m.ID,
+		Monitor:      fixtures.monitor.ID,
 		QueryString:  testQuery,
 		NextRun:      now,
 		LatestResult: nil,


### PR DESCRIPTION
This modifies insertTestMonitor to return all the fixtures it creates so we can
use the IDs of the created fixtures in tests

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
