### PR TITLE
Code Monitors: return created recipient from CreateRecipients

### DIFF
--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -278,7 +278,7 @@ func (r *Resolver) createRecipients(ctx context.Context, emailID int64, recipien
 			return errors.Wrap(err, "UnmarshalNamespaceID")
 		}
 
-		err := r.store.CreateRecipient(ctx, emailID, nilOrInt32(userID), nilOrInt32(orgID))
+		_, err := r.store.CreateRecipient(ctx, emailID, nilOrInt32(userID), nilOrInt32(orgID))
 		if err != nil {
 			return err
 		}

--- a/enterprise/internal/codemonitors/main_test.go
+++ b/enterprise/internal/codemonitors/main_test.go
@@ -56,7 +56,7 @@ func (s *codeMonitorStore) insertTestMonitor(ctx context.Context, t *testing.T) 
 		})
 		require.NoError(t, err)
 
-		err = s.CreateRecipient(ctx, e.ID, &uid, nil)
+		_, err = s.CreateRecipient(ctx, e.ID, &uid, nil)
 		require.NoError(t, err)
 		// TODO(camdencheek): add other action types (webhooks) here
 	}

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -194,8 +194,8 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		CreateRecipientFunc: &CodeMonitorStoreCreateRecipientFunc{
-			defaultHook: func(context.Context, int64, *int32, *int32) error {
-				return nil
+			defaultHook: func(context.Context, int64, *int32, *int32) (*Recipient, error) {
+				return nil, nil
 			},
 		},
 		DeleteEmailActionsFunc: &CodeMonitorStoreDeleteEmailActionsFunc{
@@ -401,7 +401,7 @@ func NewStrictMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		CreateRecipientFunc: &CodeMonitorStoreCreateRecipientFunc{
-			defaultHook: func(context.Context, int64, *int32, *int32) error {
+			defaultHook: func(context.Context, int64, *int32, *int32) (*Recipient, error) {
 				panic("unexpected invocation of MockCodeMonitorStore.CreateRecipient")
 			},
 		},
@@ -1691,24 +1691,24 @@ func (c CodeMonitorStoreCreateQueryTriggerFuncCall) Results() []interface{} {
 // CreateRecipient method of the parent MockCodeMonitorStore instance is
 // invoked.
 type CodeMonitorStoreCreateRecipientFunc struct {
-	defaultHook func(context.Context, int64, *int32, *int32) error
-	hooks       []func(context.Context, int64, *int32, *int32) error
+	defaultHook func(context.Context, int64, *int32, *int32) (*Recipient, error)
+	hooks       []func(context.Context, int64, *int32, *int32) (*Recipient, error)
 	history     []CodeMonitorStoreCreateRecipientFuncCall
 	mutex       sync.Mutex
 }
 
 // CreateRecipient delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) CreateRecipient(v0 context.Context, v1 int64, v2 *int32, v3 *int32) error {
-	r0 := m.CreateRecipientFunc.nextHook()(v0, v1, v2, v3)
-	m.CreateRecipientFunc.appendCall(CodeMonitorStoreCreateRecipientFuncCall{v0, v1, v2, v3, r0})
-	return r0
+func (m *MockCodeMonitorStore) CreateRecipient(v0 context.Context, v1 int64, v2 *int32, v3 *int32) (*Recipient, error) {
+	r0, r1 := m.CreateRecipientFunc.nextHook()(v0, v1, v2, v3)
+	m.CreateRecipientFunc.appendCall(CodeMonitorStoreCreateRecipientFuncCall{v0, v1, v2, v3, r0, r1})
+	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the CreateRecipient
 // method of the parent MockCodeMonitorStore instance is invoked and the
 // hook queue is empty.
-func (f *CodeMonitorStoreCreateRecipientFunc) SetDefaultHook(hook func(context.Context, int64, *int32, *int32) error) {
+func (f *CodeMonitorStoreCreateRecipientFunc) SetDefaultHook(hook func(context.Context, int64, *int32, *int32) (*Recipient, error)) {
 	f.defaultHook = hook
 }
 
@@ -1717,7 +1717,7 @@ func (f *CodeMonitorStoreCreateRecipientFunc) SetDefaultHook(hook func(context.C
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *CodeMonitorStoreCreateRecipientFunc) PushHook(hook func(context.Context, int64, *int32, *int32) error) {
+func (f *CodeMonitorStoreCreateRecipientFunc) PushHook(hook func(context.Context, int64, *int32, *int32) (*Recipient, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1725,21 +1725,21 @@ func (f *CodeMonitorStoreCreateRecipientFunc) PushHook(hook func(context.Context
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *CodeMonitorStoreCreateRecipientFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, int64, *int32, *int32) error {
-		return r0
+func (f *CodeMonitorStoreCreateRecipientFunc) SetDefaultReturn(r0 *Recipient, r1 error) {
+	f.SetDefaultHook(func(context.Context, int64, *int32, *int32) (*Recipient, error) {
+		return r0, r1
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *CodeMonitorStoreCreateRecipientFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, int64, *int32, *int32) error {
-		return r0
+func (f *CodeMonitorStoreCreateRecipientFunc) PushReturn(r0 *Recipient, r1 error) {
+	f.PushHook(func(context.Context, int64, *int32, *int32) (*Recipient, error) {
+		return r0, r1
 	})
 }
 
-func (f *CodeMonitorStoreCreateRecipientFunc) nextHook() func(context.Context, int64, *int32, *int32) error {
+func (f *CodeMonitorStoreCreateRecipientFunc) nextHook() func(context.Context, int64, *int32, *int32) (*Recipient, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1787,7 +1787,10 @@ type CodeMonitorStoreCreateRecipientFuncCall struct {
 	Arg3 *int32
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 error
+	Result0 *Recipient
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -1799,7 +1802,7 @@ func (c CodeMonitorStoreCreateRecipientFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c CodeMonitorStoreCreateRecipientFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // CodeMonitorStoreDeleteEmailActionsFunc describes the behavior when the

--- a/enterprise/internal/codemonitors/recipients.go
+++ b/enterprise/internal/codemonitors/recipients.go
@@ -26,10 +26,13 @@ var recipientColumns = []*sqlf.Query{
 const createRecipientFmtStr = `
 INSERT INTO cm_recipients (email, namespace_user_id, namespace_org_id)
 VALUES (%s,%s,%s)
+RETURNING %s
 `
 
-func (s *codeMonitorStore) CreateRecipient(ctx context.Context, emailID int64, userID, orgID *int32) error {
-	return s.Exec(ctx, sqlf.Sprintf(createRecipientFmtStr, emailID, userID, orgID))
+func (s *codeMonitorStore) CreateRecipient(ctx context.Context, emailID int64, userID, orgID *int32) (*Recipient, error) {
+	q := sqlf.Sprintf(createRecipientFmtStr, emailID, userID, orgID, sqlf.Join(recipientColumns, ","))
+	row := s.QueryRow(ctx, q)
+	return scanRecipient(row)
 }
 
 const deleteRecipientFmtStr = `

--- a/enterprise/internal/codemonitors/recipients.go
+++ b/enterprise/internal/codemonitors/recipients.go
@@ -16,6 +16,13 @@ type Recipient struct {
 	NamespaceOrgID  *int32
 }
 
+var recipientColumns = []*sqlf.Query{
+	sqlf.Sprintf("cm_recipients.id"),
+	sqlf.Sprintf("cm_recipients.email"),
+	sqlf.Sprintf("cm_recipients.namespace_user_id"),
+	sqlf.Sprintf("cm_recipients.namespace_org_id"),
+}
+
 const createRecipientFmtStr = `
 INSERT INTO cm_recipients (email, namespace_user_id, namespace_org_id)
 VALUES (%s,%s,%s)
@@ -63,7 +70,7 @@ func (l ListRecipientsOpts) Limit() *sqlf.Query {
 }
 
 const readRecipientQueryFmtStr = `
-SELECT id, email, namespace_user_id, namespace_org_id
+SELECT %s -- recipientColumns
 FROM cm_recipients
 WHERE %s
 ORDER BY id ASC
@@ -73,6 +80,7 @@ LIMIT %s;
 func (s *codeMonitorStore) ListRecipients(ctx context.Context, args ListRecipientsOpts) ([]*Recipient, error) {
 	q := sqlf.Sprintf(
 		readRecipientQueryFmtStr,
+		sqlf.Join(recipientColumns, ","),
 		args.Conds(),
 		args.Limit(),
 	)

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -51,7 +51,7 @@ type CodeMonitorStore interface {
 	GetEmailAction(ctx context.Context, emailID int64) (*EmailAction, error)
 	ListEmailActions(context.Context, ListActionsOpts) ([]*EmailAction, error)
 
-	CreateRecipient(ctx context.Context, emailID int64, userID, orgID *int32) error
+	CreateRecipient(ctx context.Context, emailID int64, userID, orgID *int32) (*Recipient, error)
 	DeleteRecipients(ctx context.Context, emailID int64) error
 	ListRecipients(context.Context, ListRecipientsOpts) ([]*Recipient, error)
 	CountRecipients(ctx context.Context, emailID int64) (int32, error)

--- a/enterprise/internal/codemonitors/storetest/monitor_creator.go
+++ b/enterprise/internal/codemonitors/storetest/monitor_creator.go
@@ -66,7 +66,7 @@ func (s *TestStore) InsertTestMonitor(ctx context.Context, t *testing.T) (*codem
 			return nil, err
 		}
 
-		err = s.CreateRecipient(ctx, e.ID, &uid, nil)
+		_, err = s.CreateRecipient(ctx, e.ID, &uid, nil)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This returns the created recipient from CreateRecipients so we can use its ID.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
