### PR TITLE
remove uses of the new dbpool in dbtest

### DIFF
--- a/internal/database/orgs_test.go
+++ b/internal/database/orgs_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestOrgs_ValidNames(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewFastTx(t)
+	db := dbtest.NewDB(t)
 	ctx := context.Background()
 
 	for _, test := range usernamesForTests {
@@ -39,7 +39,7 @@ func TestOrgs_ValidNames(t *testing.T) {
 
 func TestOrgs_Count(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewFastTx(t)
+	db := dbtest.NewDB(t)
 	ctx := context.Background()
 
 	org, err := Orgs(db).Create(ctx, "a", nil)
@@ -66,7 +66,7 @@ func TestOrgs_Count(t *testing.T) {
 
 func TestOrgs_Delete(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewFastTx(t)
+	db := dbtest.NewDB(t)
 	ctx := context.Background()
 
 	displayName := "a"
@@ -101,7 +101,7 @@ func TestOrgs_Delete(t *testing.T) {
 }
 
 func TestOrgs_GetByID(t *testing.T) {
-	createOrg := func(ctx context.Context, db *sql.Tx, name string, displayName string) *types.Org {
+	createOrg := func(ctx context.Context, db *sql.DB, name string, displayName string) *types.Org {
 		org, err := Orgs(db).Create(ctx, name, &displayName)
 		if err != nil {
 			t.Fatal(err)
@@ -110,7 +110,7 @@ func TestOrgs_GetByID(t *testing.T) {
 		return org
 	}
 
-	createUser := func(ctx context.Context, db *sql.Tx, name string) *types.User {
+	createUser := func(ctx context.Context, db *sql.DB, name string) *types.User {
 		user, err := Users(db).Create(ctx, NewUser{
 			Username: name,
 		})
@@ -121,7 +121,7 @@ func TestOrgs_GetByID(t *testing.T) {
 		return user
 	}
 
-	createOrgMember := func(ctx context.Context, db *sql.Tx, userID int32, orgID int32) *types.OrgMembership {
+	createOrgMember := func(ctx context.Context, db *sql.DB, userID int32, orgID int32) *types.OrgMembership {
 		member, err := OrgMembers(db).Create(ctx, orgID, userID)
 		if err != nil {
 			t.Fatal(err)
@@ -131,7 +131,7 @@ func TestOrgs_GetByID(t *testing.T) {
 	}
 
 	t.Parallel()
-	db := dbtest.NewFastTx(t)
+	db := dbtest.NewDB(t)
 	ctx := context.Background()
 
 	createOrg(ctx, db, "org1", "org1")
@@ -153,7 +153,7 @@ func TestOrgs_GetByID(t *testing.T) {
 }
 
 func TestOrgs_GetOrgsWithRepositoriesByUserID(t *testing.T) {
-	createOrg := func(ctx context.Context, db *sql.Tx, name string, displayName string) *types.Org {
+	createOrg := func(ctx context.Context, db *sql.DB, name string, displayName string) *types.Org {
 		org, err := Orgs(db).Create(ctx, name, &displayName)
 		if err != nil {
 			t.Fatal(err)
@@ -162,7 +162,7 @@ func TestOrgs_GetOrgsWithRepositoriesByUserID(t *testing.T) {
 		return org
 	}
 
-	createUser := func(ctx context.Context, db *sql.Tx, name string) *types.User {
+	createUser := func(ctx context.Context, db *sql.DB, name string) *types.User {
 		user, err := Users(db).Create(ctx, NewUser{
 			Username: name,
 		})
@@ -173,7 +173,7 @@ func TestOrgs_GetOrgsWithRepositoriesByUserID(t *testing.T) {
 		return user
 	}
 
-	createOrgMember := func(ctx context.Context, db *sql.Tx, userID int32, orgID int32) *types.OrgMembership {
+	createOrgMember := func(ctx context.Context, db *sql.DB, userID int32, orgID int32) *types.OrgMembership {
 		member, err := OrgMembers(db).Create(ctx, orgID, userID)
 		if err != nil {
 			t.Fatal(err)
@@ -183,7 +183,7 @@ func TestOrgs_GetOrgsWithRepositoriesByUserID(t *testing.T) {
 	}
 
 	t.Parallel()
-	db := dbtest.NewFastTx(t)
+	db := dbtest.NewDB(t)
 	ctx := context.Background()
 
 	org1 := createOrg(ctx, db, "org1", "org1")


### PR DESCRIPTION
This removes references to dbtest.NewFastTx because they are currently
causing some random failures. I don't immediately have the time to debug
these, so I'm just disabling them to avoid blocking other engineers
until I get the chance to stress test the new pool a bit more.

The failures for reference:
```
➜  database git:(main) go test -test.run '^TestOrgs'
--- FAIL: TestOrgs_GetByID (0.02s)
    orgs_test.go:134: error getting pool: sql: transaction has already been committed or rolled back
--- FAIL: TestOrgs_Delete (0.02s)
    orgs_test.go:69: error getting pool: sql: transaction has already been committed or rolled back
--- FAIL: TestOrgs_Count (0.02s)
    orgs_test.go:42: error getting pool: sql: transaction has already been committed or rolled back
--- FAIL: TestOrgs_ValidNames (0.02s)
    orgs_test.go:20: error getting pool: sql: transaction has already been committed or rolled back
--- FAIL: TestOrgs_GetOrgsWithRepositoriesByUserID (0.02s)
    orgs_test.go:186: error getting pool: sql: transaction has already been committed or rolled back
FAIL
exit status 1
FAIL	github.com/sourcegraph/sourcegraph/internal/database	0.265s
```