### PR TITLE
Code Monitors: make ActionJob.TriggerEvent match the db integer type

### DIFF
--- a/enterprise/internal/codemonitors/action_jobs.go
+++ b/enterprise/internal/codemonitors/action_jobs.go
@@ -16,7 +16,7 @@ type ActionJob struct {
 	Email        *int64
 	Webhook      *int64
 	SlackWebhook *int64
-	TriggerEvent int
+	TriggerEvent int32
 
 	// Fields demanded by any dbworker.
 	State          string


### PR DESCRIPTION
Just a simple PR to make this the correct integer type to refer to a trigger job ID.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
