### PR TITLE
Code Monitors: return enqueued jobs from EnqueueActionJobsForQuery

### DIFF
--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
@@ -337,11 +337,11 @@ func TestQueryMonitor(t *testing.T) {
 	// update the job status.
 	postHookOpt := WithPostHooks([]hook{
 		func() error { _, err := r.store.EnqueueQueryTriggerJobs(ctx); return err },
-		func() error { return r.store.EnqueueActionJobsForQuery(ctx, 1, 1) },
+		func() error { _, err := r.store.EnqueueActionJobsForQuery(ctx, 1, 1); return err },
 		func() error {
 			return (&storetest.TestStore{CodeMonitorStore: r.store}).SetJobStatus(ctx, storetest.ActionJobs, storetest.Completed, 1)
 		},
-		func() error { return r.store.EnqueueActionJobsForQuery(ctx, 1, 1) },
+		func() error { _, err := r.store.EnqueueActionJobsForQuery(ctx, 1, 1); return err },
 		// Set the job status of trigger job with id = 1 to "completed". Since we already
 		// created another monitor, there is still a second trigger job (id = 2) which
 		// remains in status queued.

--- a/enterprise/internal/codemonitors/action_jobs.go
+++ b/enterprise/internal/codemonitors/action_jobs.go
@@ -176,12 +176,25 @@ busy AS (
 )
 INSERT INTO cm_action_jobs (email, trigger_event)
 SELECT id, %s::integer from due EXCEPT SELECT id, %s::integer from busy ORDER BY id
+RETURNING %s
 `
 
 // TODO(camdencheek): could/should we enqueue based on monitor ID rather than query ID? Would avoid joins above.
-func (s *codeMonitorStore) EnqueueActionJobsForQuery(ctx context.Context, queryID int64, triggerJobID int32) (err error) {
+func (s *codeMonitorStore) EnqueueActionJobsForQuery(ctx context.Context, queryID int64, triggerJobID int32) ([]*ActionJob, error) {
 	// TODO(camdencheek): Enqueue actions other than emails here
-	return s.Store.Exec(ctx, sqlf.Sprintf(enqueueActionEmailFmtStr, queryID, triggerJobID, triggerJobID))
+	q := sqlf.Sprintf(
+		enqueueActionEmailFmtStr,
+		queryID,
+		triggerJobID,
+		triggerJobID,
+		sqlf.Join(ActionJobColumns, ","),
+	)
+	rows, err := s.Query(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanActionJobs(rows)
 }
 
 const getActionJobMetadataFmtStr = `
@@ -204,7 +217,7 @@ func (s *codeMonitorStore) GetActionJobMetadata(ctx context.Context, jobID int32
 }
 
 const actionJobForIDFmtStr = `
-SELECT %s -- ActionJobsColumns
+SELECT %s -- ActionJobColumns
 FROM cm_action_jobs
 WHERE id = %s
 `

--- a/enterprise/internal/codemonitors/action_jobs_test.go
+++ b/enterprise/internal/codemonitors/action_jobs_test.go
@@ -18,7 +18,7 @@ func TestEnqueueActionEmailsForQueryIDInt64QueryByRecordID(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, triggerJobs, 1)
 
-	err = s.EnqueueActionJobsForQuery(ctx, 1, triggerJobs[0].ID)
+	_, err = s.EnqueueActionJobsForQuery(ctx, 1, triggerJobs[0].ID)
 	require.NoError(t, err)
 
 	got, err := s.GetActionJob(ctx, 1)
@@ -60,7 +60,7 @@ func TestGetActionJobMetadata(t *testing.T) {
 	err = s.UpdateTriggerJobWithResults(ctx, 1, wantQuery, wantNumResults)
 	require.NoError(t, err)
 
-	err = s.EnqueueActionJobsForQuery(ctx, 1, triggerJobs[0].ID)
+	_, err = s.EnqueueActionJobsForQuery(ctx, 1, triggerJobs[0].ID)
 	require.NoError(t, err)
 
 	got, err := s.GetActionJobMetadata(ctx, 1)
@@ -91,7 +91,7 @@ func TestScanActionJobs(t *testing.T) {
 	require.Len(t, triggerJobs, 1)
 	triggerJobID := triggerJobs[0].ID
 
-	err = s.EnqueueActionJobsForQuery(ctx, testQueryID, triggerJobID)
+	_, err = s.EnqueueActionJobsForQuery(ctx, testQueryID, triggerJobID)
 	require.NoError(t, err)
 
 	rows, err := s.Query(ctx, sqlf.Sprintf(actionJobForIDFmtStr, sqlf.Join(ActionJobColumns, ", "), testRecordID))

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -176,7 +176,7 @@ func (r *queryRunner) Handle(ctx context.Context, record workerutil.Record) (err
 		numResults = len(results.Data.Search.Results.Results)
 	}
 	if numResults > 0 {
-		err := s.EnqueueActionJobsForQuery(ctx, q.ID, triggerJob.ID)
+		_, err := s.EnqueueActionJobsForQuery(ctx, q.ID, triggerJob.ID)
 		if err != nil {
 			return errors.Errorf("store.EnqueueActionJobsForQuery: %w", err)
 		}

--- a/enterprise/internal/codemonitors/background/workers_test.go
+++ b/enterprise/internal/codemonitors/background/workers_test.go
@@ -74,7 +74,7 @@ func TestActionRunner(t *testing.T) {
 			err = ts.UpdateTriggerJobWithResults(ctx, triggerEventID, testQuery, tt.numResults)
 			require.NoError(t, err)
 
-			err = ts.EnqueueActionJobsForQuery(ctx, queryID, triggerEventID)
+			_, err = ts.EnqueueActionJobsForQuery(ctx, queryID, triggerEventID)
 			require.NoError(t, err)
 
 			record, err := ts.GetActionJob(ctx, 1)

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -229,8 +229,8 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		EnqueueActionJobsForQueryFunc: &CodeMonitorStoreEnqueueActionJobsForQueryFunc{
-			defaultHook: func(context.Context, int64, int32) error {
-				return nil
+			defaultHook: func(context.Context, int64, int32) ([]*ActionJob, error) {
+				return nil, nil
 			},
 		},
 		EnqueueQueryTriggerJobsFunc: &CodeMonitorStoreEnqueueQueryTriggerJobsFunc{
@@ -436,7 +436,7 @@ func NewStrictMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		EnqueueActionJobsForQueryFunc: &CodeMonitorStoreEnqueueActionJobsForQueryFunc{
-			defaultHook: func(context.Context, int64, int32) error {
+			defaultHook: func(context.Context, int64, int32) ([]*ActionJob, error) {
 				panic("unexpected invocation of MockCodeMonitorStore.EnqueueActionJobsForQuery")
 			},
 		},
@@ -2458,24 +2458,24 @@ func (c CodeMonitorStoreDoneFuncCall) Results() []interface{} {
 // the EnqueueActionJobsForQuery method of the parent MockCodeMonitorStore
 // instance is invoked.
 type CodeMonitorStoreEnqueueActionJobsForQueryFunc struct {
-	defaultHook func(context.Context, int64, int32) error
-	hooks       []func(context.Context, int64, int32) error
+	defaultHook func(context.Context, int64, int32) ([]*ActionJob, error)
+	hooks       []func(context.Context, int64, int32) ([]*ActionJob, error)
 	history     []CodeMonitorStoreEnqueueActionJobsForQueryFuncCall
 	mutex       sync.Mutex
 }
 
 // EnqueueActionJobsForQuery delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) EnqueueActionJobsForQuery(v0 context.Context, v1 int64, v2 int32) error {
-	r0 := m.EnqueueActionJobsForQueryFunc.nextHook()(v0, v1, v2)
-	m.EnqueueActionJobsForQueryFunc.appendCall(CodeMonitorStoreEnqueueActionJobsForQueryFuncCall{v0, v1, v2, r0})
-	return r0
+func (m *MockCodeMonitorStore) EnqueueActionJobsForQuery(v0 context.Context, v1 int64, v2 int32) ([]*ActionJob, error) {
+	r0, r1 := m.EnqueueActionJobsForQueryFunc.nextHook()(v0, v1, v2)
+	m.EnqueueActionJobsForQueryFunc.appendCall(CodeMonitorStoreEnqueueActionJobsForQueryFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
 // EnqueueActionJobsForQuery method of the parent MockCodeMonitorStore
 // instance is invoked and the hook queue is empty.
-func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) SetDefaultHook(hook func(context.Context, int64, int32) error) {
+func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) SetDefaultHook(hook func(context.Context, int64, int32) ([]*ActionJob, error)) {
 	f.defaultHook = hook
 }
 
@@ -2484,7 +2484,7 @@ func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) SetDefaultHook(hook func
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) PushHook(hook func(context.Context, int64, int32) error) {
+func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) PushHook(hook func(context.Context, int64, int32) ([]*ActionJob, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2492,21 +2492,21 @@ func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) PushHook(hook func(conte
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, int64, int32) error {
-		return r0
+func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) SetDefaultReturn(r0 []*ActionJob, r1 error) {
+	f.SetDefaultHook(func(context.Context, int64, int32) ([]*ActionJob, error) {
+		return r0, r1
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, int64, int32) error {
-		return r0
+func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) PushReturn(r0 []*ActionJob, r1 error) {
+	f.PushHook(func(context.Context, int64, int32) ([]*ActionJob, error) {
+		return r0, r1
 	})
 }
 
-func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) nextHook() func(context.Context, int64, int32) error {
+func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) nextHook() func(context.Context, int64, int32) ([]*ActionJob, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2552,7 +2552,10 @@ type CodeMonitorStoreEnqueueActionJobsForQueryFuncCall struct {
 	Arg2 int32
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 error
+	Result0 []*ActionJob
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -2564,7 +2567,7 @@ func (c CodeMonitorStoreEnqueueActionJobsForQueryFuncCall) Args() []interface{} 
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c CodeMonitorStoreEnqueueActionJobsForQueryFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // CodeMonitorStoreEnqueueQueryTriggerJobsFunc describes the behavior when

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -60,7 +60,7 @@ type CodeMonitorStore interface {
 	CountActionJobs(context.Context, ListActionJobsOpts) (int, error)
 	GetActionJobMetadata(ctx context.Context, jobID int32) (*ActionJobMetadata, error)
 	GetActionJob(ctx context.Context, jobID int32) (*ActionJob, error)
-	EnqueueActionJobsForQuery(ctx context.Context, queryID int64, triggerJob int32) error
+	EnqueueActionJobsForQuery(ctx context.Context, queryID int64, triggerJob int32) ([]*ActionJob, error)
 }
 
 // codeMonitorStore exposes methods to read and write codemonitors domain models


### PR DESCRIPTION
Previously, EnqueueActionJobsForQuery wouldn't return the created jobs, so we
couldn't easily test it or do followup work with the jobs. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
