### PR TITLE
Code Monitors: use DB ID rather than RecordID

### DIFF
--- a/enterprise/internal/codemonitors/action_jobs.go
+++ b/enterprise/internal/codemonitors/action_jobs.go
@@ -197,8 +197,8 @@ INNER JOIN cm_monitors cm on cm.id = cq.monitor
 WHERE caj.id = %s
 `
 
-func (s *codeMonitorStore) GetActionJobMetadata(ctx context.Context, recordID int) (*ActionJobMetadata, error) {
-	row := s.Store.QueryRow(ctx, sqlf.Sprintf(getActionJobMetadataFmtStr, recordID))
+func (s *codeMonitorStore) GetActionJobMetadata(ctx context.Context, jobID int32) (*ActionJobMetadata, error) {
+	row := s.Store.QueryRow(ctx, sqlf.Sprintf(getActionJobMetadataFmtStr, jobID))
 	m := &ActionJobMetadata{}
 	return m, row.Scan(&m.Description, &m.Query, &m.MonitorID, &m.NumResults)
 }
@@ -209,8 +209,8 @@ FROM cm_action_jobs
 WHERE id = %s
 `
 
-func (s *codeMonitorStore) GetActionJob(ctx context.Context, recordID int) (*ActionJob, error) {
-	q := sqlf.Sprintf(actionJobForIDFmtStr, sqlf.Join(ActionJobColumns, ", "), recordID)
+func (s *codeMonitorStore) GetActionJob(ctx context.Context, jobID int32) (*ActionJob, error) {
+	q := sqlf.Sprintf(actionJobForIDFmtStr, sqlf.Join(ActionJobColumns, ", "), jobID)
 	row := s.QueryRow(ctx, q)
 	return scanActionJob(row)
 }

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -218,7 +218,7 @@ func (r *actionRunner) Handle(ctx context.Context, record workerutil.Record) (er
 		return errors.Errorf("type assertion failed")
 	}
 
-	m, err := s.GetActionJobMetadata(ctx, record.RecordID())
+	m, err := s.GetActionJobMetadata(ctx, j.ID)
 	if err != nil {
 		return errors.Errorf("store.GetActionJobMetadata: %w", err)
 	}

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -244,12 +244,12 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		GetActionJobFunc: &CodeMonitorStoreGetActionJobFunc{
-			defaultHook: func(context.Context, int) (*ActionJob, error) {
+			defaultHook: func(context.Context, int32) (*ActionJob, error) {
 				return nil, nil
 			},
 		},
 		GetActionJobMetadataFunc: &CodeMonitorStoreGetActionJobMetadataFunc{
-			defaultHook: func(context.Context, int) (*ActionJobMetadata, error) {
+			defaultHook: func(context.Context, int32) (*ActionJobMetadata, error) {
 				return nil, nil
 			},
 		},
@@ -451,12 +451,12 @@ func NewStrictMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		GetActionJobFunc: &CodeMonitorStoreGetActionJobFunc{
-			defaultHook: func(context.Context, int) (*ActionJob, error) {
+			defaultHook: func(context.Context, int32) (*ActionJob, error) {
 				panic("unexpected invocation of MockCodeMonitorStore.GetActionJob")
 			},
 		},
 		GetActionJobMetadataFunc: &CodeMonitorStoreGetActionJobMetadataFunc{
-			defaultHook: func(context.Context, int) (*ActionJobMetadata, error) {
+			defaultHook: func(context.Context, int32) (*ActionJobMetadata, error) {
 				panic("unexpected invocation of MockCodeMonitorStore.GetActionJobMetadata")
 			},
 		},
@@ -2787,15 +2787,15 @@ func (c CodeMonitorStoreExecFuncCall) Results() []interface{} {
 // GetActionJob method of the parent MockCodeMonitorStore instance is
 // invoked.
 type CodeMonitorStoreGetActionJobFunc struct {
-	defaultHook func(context.Context, int) (*ActionJob, error)
-	hooks       []func(context.Context, int) (*ActionJob, error)
+	defaultHook func(context.Context, int32) (*ActionJob, error)
+	hooks       []func(context.Context, int32) (*ActionJob, error)
 	history     []CodeMonitorStoreGetActionJobFuncCall
 	mutex       sync.Mutex
 }
 
 // GetActionJob delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) GetActionJob(v0 context.Context, v1 int) (*ActionJob, error) {
+func (m *MockCodeMonitorStore) GetActionJob(v0 context.Context, v1 int32) (*ActionJob, error) {
 	r0, r1 := m.GetActionJobFunc.nextHook()(v0, v1)
 	m.GetActionJobFunc.appendCall(CodeMonitorStoreGetActionJobFuncCall{v0, v1, r0, r1})
 	return r0, r1
@@ -2804,7 +2804,7 @@ func (m *MockCodeMonitorStore) GetActionJob(v0 context.Context, v1 int) (*Action
 // SetDefaultHook sets function that is called when the GetActionJob method
 // of the parent MockCodeMonitorStore instance is invoked and the hook queue
 // is empty.
-func (f *CodeMonitorStoreGetActionJobFunc) SetDefaultHook(hook func(context.Context, int) (*ActionJob, error)) {
+func (f *CodeMonitorStoreGetActionJobFunc) SetDefaultHook(hook func(context.Context, int32) (*ActionJob, error)) {
 	f.defaultHook = hook
 }
 
@@ -2812,7 +2812,7 @@ func (f *CodeMonitorStoreGetActionJobFunc) SetDefaultHook(hook func(context.Cont
 // GetActionJob method of the parent MockCodeMonitorStore instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *CodeMonitorStoreGetActionJobFunc) PushHook(hook func(context.Context, int) (*ActionJob, error)) {
+func (f *CodeMonitorStoreGetActionJobFunc) PushHook(hook func(context.Context, int32) (*ActionJob, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2821,7 +2821,7 @@ func (f *CodeMonitorStoreGetActionJobFunc) PushHook(hook func(context.Context, i
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *CodeMonitorStoreGetActionJobFunc) SetDefaultReturn(r0 *ActionJob, r1 error) {
-	f.SetDefaultHook(func(context.Context, int) (*ActionJob, error) {
+	f.SetDefaultHook(func(context.Context, int32) (*ActionJob, error) {
 		return r0, r1
 	})
 }
@@ -2829,12 +2829,12 @@ func (f *CodeMonitorStoreGetActionJobFunc) SetDefaultReturn(r0 *ActionJob, r1 er
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *CodeMonitorStoreGetActionJobFunc) PushReturn(r0 *ActionJob, r1 error) {
-	f.PushHook(func(context.Context, int) (*ActionJob, error) {
+	f.PushHook(func(context.Context, int32) (*ActionJob, error) {
 		return r0, r1
 	})
 }
 
-func (f *CodeMonitorStoreGetActionJobFunc) nextHook() func(context.Context, int) (*ActionJob, error) {
+func (f *CodeMonitorStoreGetActionJobFunc) nextHook() func(context.Context, int32) (*ActionJob, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2872,7 +2872,7 @@ type CodeMonitorStoreGetActionJobFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
+	Arg1 int32
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 *ActionJob
@@ -2897,15 +2897,15 @@ func (c CodeMonitorStoreGetActionJobFuncCall) Results() []interface{} {
 // GetActionJobMetadata method of the parent MockCodeMonitorStore instance
 // is invoked.
 type CodeMonitorStoreGetActionJobMetadataFunc struct {
-	defaultHook func(context.Context, int) (*ActionJobMetadata, error)
-	hooks       []func(context.Context, int) (*ActionJobMetadata, error)
+	defaultHook func(context.Context, int32) (*ActionJobMetadata, error)
+	hooks       []func(context.Context, int32) (*ActionJobMetadata, error)
 	history     []CodeMonitorStoreGetActionJobMetadataFuncCall
 	mutex       sync.Mutex
 }
 
 // GetActionJobMetadata delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) GetActionJobMetadata(v0 context.Context, v1 int) (*ActionJobMetadata, error) {
+func (m *MockCodeMonitorStore) GetActionJobMetadata(v0 context.Context, v1 int32) (*ActionJobMetadata, error) {
 	r0, r1 := m.GetActionJobMetadataFunc.nextHook()(v0, v1)
 	m.GetActionJobMetadataFunc.appendCall(CodeMonitorStoreGetActionJobMetadataFuncCall{v0, v1, r0, r1})
 	return r0, r1
@@ -2914,7 +2914,7 @@ func (m *MockCodeMonitorStore) GetActionJobMetadata(v0 context.Context, v1 int) 
 // SetDefaultHook sets function that is called when the GetActionJobMetadata
 // method of the parent MockCodeMonitorStore instance is invoked and the
 // hook queue is empty.
-func (f *CodeMonitorStoreGetActionJobMetadataFunc) SetDefaultHook(hook func(context.Context, int) (*ActionJobMetadata, error)) {
+func (f *CodeMonitorStoreGetActionJobMetadataFunc) SetDefaultHook(hook func(context.Context, int32) (*ActionJobMetadata, error)) {
 	f.defaultHook = hook
 }
 
@@ -2923,7 +2923,7 @@ func (f *CodeMonitorStoreGetActionJobMetadataFunc) SetDefaultHook(hook func(cont
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *CodeMonitorStoreGetActionJobMetadataFunc) PushHook(hook func(context.Context, int) (*ActionJobMetadata, error)) {
+func (f *CodeMonitorStoreGetActionJobMetadataFunc) PushHook(hook func(context.Context, int32) (*ActionJobMetadata, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2932,7 +2932,7 @@ func (f *CodeMonitorStoreGetActionJobMetadataFunc) PushHook(hook func(context.Co
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *CodeMonitorStoreGetActionJobMetadataFunc) SetDefaultReturn(r0 *ActionJobMetadata, r1 error) {
-	f.SetDefaultHook(func(context.Context, int) (*ActionJobMetadata, error) {
+	f.SetDefaultHook(func(context.Context, int32) (*ActionJobMetadata, error) {
 		return r0, r1
 	})
 }
@@ -2940,12 +2940,12 @@ func (f *CodeMonitorStoreGetActionJobMetadataFunc) SetDefaultReturn(r0 *ActionJo
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *CodeMonitorStoreGetActionJobMetadataFunc) PushReturn(r0 *ActionJobMetadata, r1 error) {
-	f.PushHook(func(context.Context, int) (*ActionJobMetadata, error) {
+	f.PushHook(func(context.Context, int32) (*ActionJobMetadata, error) {
 		return r0, r1
 	})
 }
 
-func (f *CodeMonitorStoreGetActionJobMetadataFunc) nextHook() func(context.Context, int) (*ActionJobMetadata, error) {
+func (f *CodeMonitorStoreGetActionJobMetadataFunc) nextHook() func(context.Context, int32) (*ActionJobMetadata, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2985,7 +2985,7 @@ type CodeMonitorStoreGetActionJobMetadataFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
+	Arg1 int32
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 *ActionJobMetadata

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -58,8 +58,8 @@ type CodeMonitorStore interface {
 
 	ListActionJobs(context.Context, ListActionJobsOpts) ([]*ActionJob, error)
 	CountActionJobs(context.Context, ListActionJobsOpts) (int, error)
-	GetActionJobMetadata(ctx context.Context, recordID int) (*ActionJobMetadata, error)
-	GetActionJob(ctx context.Context, recordID int) (*ActionJob, error)
+	GetActionJobMetadata(ctx context.Context, jobID int32) (*ActionJobMetadata, error)
+	GetActionJob(ctx context.Context, jobID int32) (*ActionJob, error)
 	EnqueueActionJobsForQuery(ctx context.Context, queryID int64, triggerJob int32) error
 }
 


### PR DESCRIPTION
This field references a database ID, but was using the record ID type (int)
rather than the database ID type (int32). This forces us to do a bunch of
casting to use it correctly.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
