### PR TITLE
Code Monitors: replace hard-coded IDs with returned IDs

### DIFF
--- a/enterprise/internal/codemonitors/action_jobs_test.go
+++ b/enterprise/internal/codemonitors/action_jobs_test.go
@@ -11,23 +11,21 @@ import (
 func TestEnqueueActionEmailsForQueryIDInt64QueryByRecordID(t *testing.T) {
 	ctx, db, s := newTestStore(t)
 	_, _, _, userCTX := newTestUser(ctx, t, db)
-	_, err := s.insertTestMonitor(userCTX, t)
+	fixtures, err := s.insertTestMonitor(userCTX, t)
 	require.NoError(t, err)
 
 	triggerJobs, err := s.EnqueueQueryTriggerJobs(ctx)
 	require.NoError(t, err)
 	require.Len(t, triggerJobs, 1)
 
-	_, err = s.EnqueueActionJobsForQuery(ctx, 1, triggerJobs[0].ID)
+	actionJobs, err := s.EnqueueActionJobsForQuery(ctx, fixtures.query.ID, triggerJobs[0].ID)
 	require.NoError(t, err)
-
-	got, err := s.GetActionJob(ctx, 1)
-	require.NoError(t, err)
+	require.Len(t, actionJobs, 2)
 
 	want := &ActionJob{
-		ID:             1,
-		Email:          int64Ptr(1),
-		TriggerEvent:   1,
+		ID:             actionJobs[0].ID, // ignore ID
+		Email:          &fixtures.emails[0].ID,
+		TriggerEvent:   triggerJobs[0].ID,
 		State:          "queued",
 		FailureMessage: nil,
 		StartedAt:      nil,
@@ -37,53 +35,13 @@ func TestEnqueueActionEmailsForQueryIDInt64QueryByRecordID(t *testing.T) {
 		NumFailures:    0,
 		LogContents:    nil,
 	}
-	require.Equal(t, want, got)
+	require.Equal(t, want, actionJobs[0])
 }
-
-func int64Ptr(i int64) *int64 { return &i }
 
 func TestGetActionJobMetadata(t *testing.T) {
 	ctx, db, s := newTestStore(t)
 	_, _, _, userCTX := newTestUser(ctx, t, db)
-	_, err := s.insertTestMonitor(userCTX, t)
-	require.NoError(t, err)
-
-	triggerJobs, err := s.EnqueueQueryTriggerJobs(ctx)
-	require.NoError(t, err)
-	require.Len(t, triggerJobs, 1)
-
-	var (
-		wantNumResults       = 42
-		wantQuery            = testQuery + " after:\"" + s.Now().UTC().Format(time.RFC3339) + "\""
-		wantMonitorID  int64 = 1
-	)
-	err = s.UpdateTriggerJobWithResults(ctx, 1, wantQuery, wantNumResults)
-	require.NoError(t, err)
-
-	_, err = s.EnqueueActionJobsForQuery(ctx, 1, triggerJobs[0].ID)
-	require.NoError(t, err)
-
-	got, err := s.GetActionJobMetadata(ctx, 1)
-	require.NoError(t, err)
-
-	want := &ActionJobMetadata{
-		Description: testDescription,
-		Query:       wantQuery,
-		NumResults:  &wantNumResults,
-		MonitorID:   wantMonitorID,
-	}
-	require.Equal(t, want, got)
-}
-
-func TestScanActionJobs(t *testing.T) {
-	var (
-		testRecordID       = 1
-		testQueryID  int64 = 1
-	)
-
-	ctx, db, s := newTestStore(t)
-	_, _, _, userCTX := newTestUser(ctx, t, db)
-	_, err := s.insertTestMonitor(userCTX, t)
+	fixtures, err := s.insertTestMonitor(userCTX, t)
 	require.NoError(t, err)
 
 	triggerJobs, err := s.EnqueueQueryTriggerJobs(ctx)
@@ -91,12 +49,48 @@ func TestScanActionJobs(t *testing.T) {
 	require.Len(t, triggerJobs, 1)
 	triggerJobID := triggerJobs[0].ID
 
-	_, err = s.EnqueueActionJobsForQuery(ctx, testQueryID, triggerJobID)
+	var (
+		wantNumResults = 42
+		wantQuery      = testQuery + " after:\"" + s.Now().UTC().Format(time.RFC3339) + "\""
+	)
+	err = s.UpdateTriggerJobWithResults(ctx, triggerJobID, wantQuery, wantNumResults)
 	require.NoError(t, err)
 
-	rows, err := s.Query(ctx, sqlf.Sprintf(actionJobForIDFmtStr, sqlf.Join(ActionJobColumns, ", "), testRecordID))
+	actionJobs, err := s.EnqueueActionJobsForQuery(ctx, fixtures.query.ID, triggerJobID)
+	require.NoError(t, err)
+	require.Len(t, actionJobs, 2)
+
+	got, err := s.GetActionJobMetadata(ctx, actionJobs[0].ID)
+	require.NoError(t, err)
+
+	want := &ActionJobMetadata{
+		Description: testDescription,
+		Query:       wantQuery,
+		NumResults:  &wantNumResults,
+		MonitorID:   fixtures.monitor.ID,
+	}
+	require.Equal(t, want, got)
+}
+
+func TestScanActionJobs(t *testing.T) {
+	ctx, db, s := newTestStore(t)
+	_, _, _, userCTX := newTestUser(ctx, t, db)
+	fixtures, err := s.insertTestMonitor(userCTX, t)
+	require.NoError(t, err)
+
+	triggerJobs, err := s.EnqueueQueryTriggerJobs(ctx)
+	require.NoError(t, err)
+	require.Len(t, triggerJobs, 1)
+	triggerJobID := triggerJobs[0].ID
+
+	actionJobs, err := s.EnqueueActionJobsForQuery(ctx, fixtures.query.ID, triggerJobID)
+	require.NoError(t, err)
+	require.Len(t, actionJobs, 2)
+	actionJobID := actionJobs[0].ID
+
+	rows, err := s.Query(ctx, sqlf.Sprintf(actionJobForIDFmtStr, sqlf.Join(ActionJobColumns, ", "), actionJobID))
 	record, _, err := ScanActionJobRecord(rows, err)
 	require.NoError(t, err)
 
-	require.Equal(t, testRecordID, record.RecordID())
+	require.Equal(t, int(actionJobID), record.RecordID())
 }

--- a/enterprise/internal/codemonitors/queries.go
+++ b/enterprise/internal/codemonitors/queries.go
@@ -103,22 +103,6 @@ func (s *codeMonitorStore) GetQueryTriggerForMonitor(ctx context.Context, monito
 	return scanTriggerQuery(row)
 }
 
-const triggerQueryByIDFmtStr = `
-SELECT %s -- queryColumns
-FROM cm_queries
-WHERE id = %s;
-`
-
-func (s *codeMonitorStore) triggerQueryByIDInt64(ctx context.Context, queryID int64) (*QueryTrigger, error) {
-	q := sqlf.Sprintf(
-		triggerQueryByIDFmtStr,
-		sqlf.Join(queryColumns, ","),
-		queryID,
-	)
-	row := s.QueryRow(ctx, q)
-	return scanTriggerQuery(row)
-}
-
 const resetTriggerQueryTimestamps = `
 UPDATE cm_queries
 SET latest_result = null,

--- a/enterprise/internal/codemonitors/recipients_test.go
+++ b/enterprise/internal/codemonitors/recipients_test.go
@@ -6,24 +6,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAllRecipientsForEmailIDInt64(t *testing.T) {
+func TestListRecipients(t *testing.T) {
 	ctx, db, s := newTestStore(t)
-	_, id, _, userCTX := newTestUser(ctx, t, db)
-	_, err := s.insertTestMonitor(userCTX, t)
+	_, _, _, userCTX := newTestUser(ctx, t, db)
+	fixtures, err := s.insertTestMonitor(userCTX, t)
 	require.NoError(t, err)
 
-	var (
-		wantEmailID     int64 = 1
-		wantRecipientID int64 = 1
-	)
-	rs, err := s.ListRecipients(ctx, ListRecipientsOpts{EmailID: &wantEmailID})
+	rs, err := s.ListRecipients(ctx, ListRecipientsOpts{EmailID: &fixtures.emails[0].ID})
 	require.NoError(t, err)
 
-	want := []*Recipient{{
-		ID:              wantRecipientID,
-		Email:           wantEmailID,
-		NamespaceUserID: &id,
-		NamespaceOrgID:  nil,
-	}}
-	require.Equal(t, want, rs)
+	require.Equal(t, []*Recipient{fixtures.recipients[0]}, rs)
 }

--- a/enterprise/internal/codemonitors/trigger_jobs_test.go
+++ b/enterprise/internal/codemonitors/trigger_jobs_test.go
@@ -53,10 +53,8 @@ func TestDeleteOldJobLogs(t *testing.T) {
 	require.NoError(t, err)
 	defer rows.Close()
 
-	var (
-		rowCount int
-		id       int
-	)
+	rowCount := 0
+	var id int32
 	for rows.Next() {
 		rowCount++
 		if rowCount > 1 {
@@ -65,5 +63,5 @@ func TestDeleteOldJobLogs(t *testing.T) {
 		err = rows.Scan(&id)
 		require.NoError(t, err)
 	}
-	require.Equal(t, 2, id)
+	require.Equal(t, secondTriggerJobID, id)
 }


### PR DESCRIPTION
This updates all the code monitor store tests to use the returned IDs
for followup work rather than guessing at the IDs the database will insert
new rows with. This way we can add new actions without breaking tests, and we 
can also run these in a transation where the IDs don't necessarily start at 0.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
