### PR TITLE
Code Monitors: enqueue by monitor rather than by query

### DIFF
--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
@@ -337,11 +337,11 @@ func TestQueryMonitor(t *testing.T) {
 	// update the job status.
 	postHookOpt := WithPostHooks([]hook{
 		func() error { _, err := r.store.EnqueueQueryTriggerJobs(ctx); return err },
-		func() error { _, err := r.store.EnqueueActionJobsForQuery(ctx, 1, 1); return err },
+		func() error { _, err := r.store.EnqueueActionJobsForMonitor(ctx, 1, 1); return err },
 		func() error {
 			return (&storetest.TestStore{CodeMonitorStore: r.store}).SetJobStatus(ctx, storetest.ActionJobs, storetest.Completed, 1)
 		},
-		func() error { _, err := r.store.EnqueueActionJobsForQuery(ctx, 1, 1); return err },
+		func() error { _, err := r.store.EnqueueActionJobsForMonitor(ctx, 1, 1); return err },
 		// Set the job status of trigger job with id = 1 to "completed". Since we already
 		// created another monitor, there is still a second trigger job (id = 2) which
 		// remains in status queued.

--- a/enterprise/internal/codemonitors/action_jobs.go
+++ b/enterprise/internal/codemonitors/action_jobs.go
@@ -164,10 +164,10 @@ func (s *codeMonitorStore) CountActionJobs(ctx context.Context, opts ListActionJ
 
 const enqueueActionEmailFmtStr = `
 WITH due AS (
-	SELECT e.id
-	FROM cm_emails e
-	INNER JOIN cm_queries q ON e.monitor = q.monitor
-	WHERE q.id = %s AND e.enabled = true
+	SELECT id
+	FROM cm_emails
+	WHERE monitor = %s 
+		AND enabled = true
 ),
 busy AS (
 	SELECT DISTINCT email as id FROM cm_action_jobs
@@ -180,11 +180,11 @@ RETURNING %s
 `
 
 // TODO(camdencheek): could/should we enqueue based on monitor ID rather than query ID? Would avoid joins above.
-func (s *codeMonitorStore) EnqueueActionJobsForQuery(ctx context.Context, queryID int64, triggerJobID int32) ([]*ActionJob, error) {
+func (s *codeMonitorStore) EnqueueActionJobsForMonitor(ctx context.Context, monitorID int64, triggerJobID int32) ([]*ActionJob, error) {
 	// TODO(camdencheek): Enqueue actions other than emails here
 	q := sqlf.Sprintf(
 		enqueueActionEmailFmtStr,
-		queryID,
+		monitorID,
 		triggerJobID,
 		triggerJobID,
 		sqlf.Join(ActionJobColumns, ","),

--- a/enterprise/internal/codemonitors/action_jobs_test.go
+++ b/enterprise/internal/codemonitors/action_jobs_test.go
@@ -18,7 +18,7 @@ func TestEnqueueActionEmailsForQueryIDInt64QueryByRecordID(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, triggerJobs, 1)
 
-	actionJobs, err := s.EnqueueActionJobsForQuery(ctx, fixtures.query.ID, triggerJobs[0].ID)
+	actionJobs, err := s.EnqueueActionJobsForMonitor(ctx, fixtures.monitor.ID, triggerJobs[0].ID)
 	require.NoError(t, err)
 	require.Len(t, actionJobs, 2)
 
@@ -56,7 +56,7 @@ func TestGetActionJobMetadata(t *testing.T) {
 	err = s.UpdateTriggerJobWithResults(ctx, triggerJobID, wantQuery, wantNumResults)
 	require.NoError(t, err)
 
-	actionJobs, err := s.EnqueueActionJobsForQuery(ctx, fixtures.query.ID, triggerJobID)
+	actionJobs, err := s.EnqueueActionJobsForMonitor(ctx, fixtures.monitor.ID, triggerJobID)
 	require.NoError(t, err)
 	require.Len(t, actionJobs, 2)
 
@@ -83,7 +83,7 @@ func TestScanActionJobs(t *testing.T) {
 	require.Len(t, triggerJobs, 1)
 	triggerJobID := triggerJobs[0].ID
 
-	actionJobs, err := s.EnqueueActionJobsForQuery(ctx, fixtures.query.ID, triggerJobID)
+	actionJobs, err := s.EnqueueActionJobsForMonitor(ctx, fixtures.monitor.ID, triggerJobID)
 	require.NoError(t, err)
 	require.Len(t, actionJobs, 2)
 	actionJobID := actionJobs[0].ID

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -176,7 +176,7 @@ func (r *queryRunner) Handle(ctx context.Context, record workerutil.Record) (err
 		numResults = len(results.Data.Search.Results.Results)
 	}
 	if numResults > 0 {
-		_, err := s.EnqueueActionJobsForQuery(ctx, q.ID, triggerJob.ID)
+		_, err := s.EnqueueActionJobsForMonitor(ctx, m.ID, triggerJob.ID)
 		if err != nil {
 			return errors.Errorf("store.EnqueueActionJobsForQuery: %w", err)
 		}

--- a/enterprise/internal/codemonitors/background/workers_test.go
+++ b/enterprise/internal/codemonitors/background/workers_test.go
@@ -33,9 +33,6 @@ func TestActionRunner(t *testing.T) {
 		},
 	}
 
-	var (
-		queryID int64 = 1
-	)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			db := dbtest.NewDB(t)
@@ -74,7 +71,7 @@ func TestActionRunner(t *testing.T) {
 			err = ts.UpdateTriggerJobWithResults(ctx, triggerEventID, testQuery, tt.numResults)
 			require.NoError(t, err)
 
-			_, err = ts.EnqueueActionJobsForQuery(ctx, queryID, triggerEventID)
+			_, err = ts.EnqueueActionJobsForMonitor(ctx, 1, triggerEventID)
 			require.NoError(t, err)
 
 			record, err := ts.GetActionJob(ctx, 1)

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -65,10 +65,10 @@ type MockCodeMonitorStore struct {
 	// DoneFunc is an instance of a mock function object controlling the
 	// behavior of the method Done.
 	DoneFunc *CodeMonitorStoreDoneFunc
-	// EnqueueActionJobsForQueryFunc is an instance of a mock function
+	// EnqueueActionJobsForMonitorFunc is an instance of a mock function
 	// object controlling the behavior of the method
-	// EnqueueActionJobsForQuery.
-	EnqueueActionJobsForQueryFunc *CodeMonitorStoreEnqueueActionJobsForQueryFunc
+	// EnqueueActionJobsForMonitor.
+	EnqueueActionJobsForMonitorFunc *CodeMonitorStoreEnqueueActionJobsForMonitorFunc
 	// EnqueueQueryTriggerJobsFunc is an instance of a mock function object
 	// controlling the behavior of the method EnqueueQueryTriggerJobs.
 	EnqueueQueryTriggerJobsFunc *CodeMonitorStoreEnqueueQueryTriggerJobsFunc
@@ -228,7 +228,7 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 				return nil
 			},
 		},
-		EnqueueActionJobsForQueryFunc: &CodeMonitorStoreEnqueueActionJobsForQueryFunc{
+		EnqueueActionJobsForMonitorFunc: &CodeMonitorStoreEnqueueActionJobsForMonitorFunc{
 			defaultHook: func(context.Context, int64, int32) ([]*ActionJob, error) {
 				return nil, nil
 			},
@@ -435,9 +435,9 @@ func NewStrictMockCodeMonitorStore() *MockCodeMonitorStore {
 				panic("unexpected invocation of MockCodeMonitorStore.Done")
 			},
 		},
-		EnqueueActionJobsForQueryFunc: &CodeMonitorStoreEnqueueActionJobsForQueryFunc{
+		EnqueueActionJobsForMonitorFunc: &CodeMonitorStoreEnqueueActionJobsForMonitorFunc{
 			defaultHook: func(context.Context, int64, int32) ([]*ActionJob, error) {
-				panic("unexpected invocation of MockCodeMonitorStore.EnqueueActionJobsForQuery")
+				panic("unexpected invocation of MockCodeMonitorStore.EnqueueActionJobsForMonitor")
 			},
 		},
 		EnqueueQueryTriggerJobsFunc: &CodeMonitorStoreEnqueueQueryTriggerJobsFunc{
@@ -611,8 +611,8 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 		DoneFunc: &CodeMonitorStoreDoneFunc{
 			defaultHook: i.Done,
 		},
-		EnqueueActionJobsForQueryFunc: &CodeMonitorStoreEnqueueActionJobsForQueryFunc{
-			defaultHook: i.EnqueueActionJobsForQuery,
+		EnqueueActionJobsForMonitorFunc: &CodeMonitorStoreEnqueueActionJobsForMonitorFunc{
+			defaultHook: i.EnqueueActionJobsForMonitor,
 		},
 		EnqueueQueryTriggerJobsFunc: &CodeMonitorStoreEnqueueQueryTriggerJobsFunc{
 			defaultHook: i.EnqueueQueryTriggerJobs,
@@ -2454,37 +2454,37 @@ func (c CodeMonitorStoreDoneFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
-// CodeMonitorStoreEnqueueActionJobsForQueryFunc describes the behavior when
-// the EnqueueActionJobsForQuery method of the parent MockCodeMonitorStore
-// instance is invoked.
-type CodeMonitorStoreEnqueueActionJobsForQueryFunc struct {
+// CodeMonitorStoreEnqueueActionJobsForMonitorFunc describes the behavior
+// when the EnqueueActionJobsForMonitor method of the parent
+// MockCodeMonitorStore instance is invoked.
+type CodeMonitorStoreEnqueueActionJobsForMonitorFunc struct {
 	defaultHook func(context.Context, int64, int32) ([]*ActionJob, error)
 	hooks       []func(context.Context, int64, int32) ([]*ActionJob, error)
-	history     []CodeMonitorStoreEnqueueActionJobsForQueryFuncCall
+	history     []CodeMonitorStoreEnqueueActionJobsForMonitorFuncCall
 	mutex       sync.Mutex
 }
 
-// EnqueueActionJobsForQuery delegates to the next hook function in the
+// EnqueueActionJobsForMonitor delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) EnqueueActionJobsForQuery(v0 context.Context, v1 int64, v2 int32) ([]*ActionJob, error) {
-	r0, r1 := m.EnqueueActionJobsForQueryFunc.nextHook()(v0, v1, v2)
-	m.EnqueueActionJobsForQueryFunc.appendCall(CodeMonitorStoreEnqueueActionJobsForQueryFuncCall{v0, v1, v2, r0, r1})
+func (m *MockCodeMonitorStore) EnqueueActionJobsForMonitor(v0 context.Context, v1 int64, v2 int32) ([]*ActionJob, error) {
+	r0, r1 := m.EnqueueActionJobsForMonitorFunc.nextHook()(v0, v1, v2)
+	m.EnqueueActionJobsForMonitorFunc.appendCall(CodeMonitorStoreEnqueueActionJobsForMonitorFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// EnqueueActionJobsForQuery method of the parent MockCodeMonitorStore
+// EnqueueActionJobsForMonitor method of the parent MockCodeMonitorStore
 // instance is invoked and the hook queue is empty.
-func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) SetDefaultHook(hook func(context.Context, int64, int32) ([]*ActionJob, error)) {
+func (f *CodeMonitorStoreEnqueueActionJobsForMonitorFunc) SetDefaultHook(hook func(context.Context, int64, int32) ([]*ActionJob, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// EnqueueActionJobsForQuery method of the parent MockCodeMonitorStore
+// EnqueueActionJobsForMonitor method of the parent MockCodeMonitorStore
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) PushHook(hook func(context.Context, int64, int32) ([]*ActionJob, error)) {
+func (f *CodeMonitorStoreEnqueueActionJobsForMonitorFunc) PushHook(hook func(context.Context, int64, int32) ([]*ActionJob, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2492,7 +2492,7 @@ func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) PushHook(hook func(conte
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) SetDefaultReturn(r0 []*ActionJob, r1 error) {
+func (f *CodeMonitorStoreEnqueueActionJobsForMonitorFunc) SetDefaultReturn(r0 []*ActionJob, r1 error) {
 	f.SetDefaultHook(func(context.Context, int64, int32) ([]*ActionJob, error) {
 		return r0, r1
 	})
@@ -2500,13 +2500,13 @@ func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) SetDefaultReturn(r0 []*A
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) PushReturn(r0 []*ActionJob, r1 error) {
+func (f *CodeMonitorStoreEnqueueActionJobsForMonitorFunc) PushReturn(r0 []*ActionJob, r1 error) {
 	f.PushHook(func(context.Context, int64, int32) ([]*ActionJob, error) {
 		return r0, r1
 	})
 }
 
-func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) nextHook() func(context.Context, int64, int32) ([]*ActionJob, error) {
+func (f *CodeMonitorStoreEnqueueActionJobsForMonitorFunc) nextHook() func(context.Context, int64, int32) ([]*ActionJob, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2519,28 +2519,28 @@ func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) nextHook() func(context.
 	return hook
 }
 
-func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) appendCall(r0 CodeMonitorStoreEnqueueActionJobsForQueryFuncCall) {
+func (f *CodeMonitorStoreEnqueueActionJobsForMonitorFunc) appendCall(r0 CodeMonitorStoreEnqueueActionJobsForMonitorFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// CodeMonitorStoreEnqueueActionJobsForQueryFuncCall objects describing the
-// invocations of this function.
-func (f *CodeMonitorStoreEnqueueActionJobsForQueryFunc) History() []CodeMonitorStoreEnqueueActionJobsForQueryFuncCall {
+// CodeMonitorStoreEnqueueActionJobsForMonitorFuncCall objects describing
+// the invocations of this function.
+func (f *CodeMonitorStoreEnqueueActionJobsForMonitorFunc) History() []CodeMonitorStoreEnqueueActionJobsForMonitorFuncCall {
 	f.mutex.Lock()
-	history := make([]CodeMonitorStoreEnqueueActionJobsForQueryFuncCall, len(f.history))
+	history := make([]CodeMonitorStoreEnqueueActionJobsForMonitorFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// CodeMonitorStoreEnqueueActionJobsForQueryFuncCall is an object that
-// describes an invocation of method EnqueueActionJobsForQuery on an
+// CodeMonitorStoreEnqueueActionJobsForMonitorFuncCall is an object that
+// describes an invocation of method EnqueueActionJobsForMonitor on an
 // instance of MockCodeMonitorStore.
-type CodeMonitorStoreEnqueueActionJobsForQueryFuncCall struct {
+type CodeMonitorStoreEnqueueActionJobsForMonitorFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -2560,13 +2560,13 @@ type CodeMonitorStoreEnqueueActionJobsForQueryFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c CodeMonitorStoreEnqueueActionJobsForQueryFuncCall) Args() []interface{} {
+func (c CodeMonitorStoreEnqueueActionJobsForMonitorFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c CodeMonitorStoreEnqueueActionJobsForQueryFuncCall) Results() []interface{} {
+func (c CodeMonitorStoreEnqueueActionJobsForMonitorFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -60,7 +60,7 @@ type CodeMonitorStore interface {
 	CountActionJobs(context.Context, ListActionJobsOpts) (int, error)
 	GetActionJobMetadata(ctx context.Context, jobID int32) (*ActionJobMetadata, error)
 	GetActionJob(ctx context.Context, jobID int32) (*ActionJob, error)
-	EnqueueActionJobsForQuery(ctx context.Context, queryID int64, triggerJob int32) ([]*ActionJob, error)
+	EnqueueActionJobsForMonitor(ctx context.Context, monitorID int64, triggerJob int32) ([]*ActionJob, error)
 }
 
 // codeMonitorStore exposes methods to read and write codemonitors domain models


### PR DESCRIPTION
Instead of enqueueing by query ID, instead queue actions that are defined for a
monitor. This is more intuitive and avoids an extra join.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
