### PR TITLE
Fix keyboard shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - Moving a changeset from draft state into published state was broken on GitLab code hosts. [#28239](https://github.com/sourcegraph/sourcegraph/pull/28239)
+- The shortcuts for toggling the History Panel and Line Wrap were not working on Mac. [#28574](https://github.com/sourcegraph/sourcegraph/pull/28574)
 
 ### Removed
 

--- a/client/web/src/repo/blob/actions/ToggleHistoryPanel.tsx
+++ b/client/web/src/repo/blob/actions/ToggleHistoryPanel.tsx
@@ -71,7 +71,7 @@ export class ToggleHistoryPanel extends React.PureComponent<
         // Toggle when the user presses 'alt+h' or 'opt+h'.
         this.subscriptions.add(
             fromEvent<KeyboardEvent>(window, 'keydown')
-                .pipe(filter(event => event.altKey && event.key === 'h'))
+                .pipe(filter(event => event.altKey && event.code === 'KeyH'))
                 .subscribe(event => {
                     event.preventDefault()
                     this.toggles.next()

--- a/client/web/src/repo/blob/actions/ToggleLineWrap.tsx
+++ b/client/web/src/repo/blob/actions/ToggleLineWrap.tsx
@@ -59,7 +59,7 @@ export class ToggleLineWrap extends React.PureComponent<
         this.subscriptions.add(
             fromEvent<KeyboardEvent>(window, 'keydown')
                 // Opt/alt+z shortcut
-                .pipe(filter(event => event.altKey && event.key === 'z'))
+                .pipe(filter(event => event.altKey && event.code === 'KeyZ'))
                 .subscribe(event => {
                     event.preventDefault()
                     this.updates.next(!this.state.value)


### PR DESCRIPTION

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
The shortcuts for toggling the History Panel and Line Wrap were not working on Mac because alt+h and alt+z are used to create special characters instead of returning key attributes. To fix this I replaced [KeyboardEvent.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) with [KeyboardEvent.code](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code).