### PR TITLE
pgsql-exporter: correct metric type

### DIFF
--- a/docker-images/postgres_exporter/config/04_standard_migration.yaml
+++ b/docker-images/postgres_exporter/config/04_standard_migration.yaml
@@ -9,5 +9,5 @@ pg_sg_migration:
   master: true
   metrics:
     - status:
-        usage: GAUGE"
+        usage: "GAUGE"
         description: Whether the migration applied successfully

--- a/docker-images/postgres_exporter/config/05_codeintel_migration.yaml
+++ b/docker-images/postgres_exporter/config/05_codeintel_migration.yaml
@@ -10,5 +10,5 @@ pg_sg_migration:
   master: true
   metrics:
     - status:
-        usage: GAUGE"
+        usage: "GAUGE"
         description: Whether the migration applied successfully


### PR DESCRIPTION
Hopefully fixes: https://github.com/sourcegraph/sourcegraph/issues/27387.

Tested in dogfood. After updating the image to my local version, the following metric shows on the `pgsql/metrics` endpoint:

```
# HELP pg_sg_migration_status Whether the migration applied successfully
# TYPE pg_sg_migration_status gauge
pg_sg_migration_status{server="localhost:5432"} 0
```
