### PR TITLE
insights: fixed insight data series global only flag fetching the appropriate series

### DIFF
--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -234,6 +234,7 @@ type historicalEnqueuer struct {
 
 func (h *historicalEnqueuer) Handler(ctx context.Context) error {
 	// Discover all insights on the instance.
+	log15.Debug("Fetching data series for historical")
 	foundInsights, err := h.dataSeriesStore.GetDataSeries(ctx, store.GetDataSeriesArgs{BackfillIncomplete: true, GlobalOnly: true})
 	if err != nil {
 		return errors.Wrap(err, "Discover")
@@ -501,7 +502,7 @@ func (h *historicalEnqueuer) buildSeries(ctx context.Context, bctx *buildSeriesC
 			log15.Error("null committer", "repo_id", bctx.repo.ID, "series_id", bctx.series.SeriesID, "from", bctx.execution.RecordingTime)
 			return
 		}
-		log15.Debug("nearest_commit", "repo_id", bctx.repo.ID, "series_id", bctx.series.SeriesID, "from", bctx.execution.RecordingTime, "revhash", nearestCommit.ID.Short(), "time", nearestCommit.Committer.Date)
+		// log15.Debug("nearest_commit", "repo_id", bctx.repo.ID, "series_id", bctx.series.SeriesID, "from", bctx.execution.RecordingTime, "revhash", nearestCommit.ID.Short(), "time", nearestCommit.Committer.Date)
 		revision = string(nearestCommit.ID)
 	}
 

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -502,7 +502,7 @@ func (h *historicalEnqueuer) buildSeries(ctx context.Context, bctx *buildSeriesC
 			log15.Error("null committer", "repo_id", bctx.repo.ID, "series_id", bctx.series.SeriesID, "from", bctx.execution.RecordingTime)
 			return
 		}
-		// log15.Debug("nearest_commit", "repo_id", bctx.repo.ID, "series_id", bctx.series.SeriesID, "from", bctx.execution.RecordingTime, "revhash", nearestCommit.ID.Short(), "time", nearestCommit.Committer.Date)
+		log15.Debug("nearest_commit", "repo_id", bctx.repo.ID, "series_id", bctx.series.SeriesID, "from", bctx.execution.RecordingTime, "revhash", nearestCommit.ID.Short(), "time", nearestCommit.Committer.Date)
 		revision = string(nearestCommit.ID)
 	}
 

--- a/enterprise/internal/insights/background/queryrunner/work_handler.go
+++ b/enterprise/internal/insights/background/queryrunner/work_handler.go
@@ -85,8 +85,6 @@ func (r *workHandler) Handle(ctx context.Context, record workerutil.Record) (err
 		return err
 	}
 
-	log15.Info("dequeue_job", "job", *job)
-
 	series, err := r.getSeries(ctx, job.SeriesID)
 	if err != nil {
 		return err

--- a/enterprise/internal/insights/compression/compression.go
+++ b/enterprise/internal/insights/compression/compression.go
@@ -129,13 +129,13 @@ func (c *CommitFilter) FilterFrames(ctx context.Context, frames []Frame, id api.
 			// 1. the commit index is sufficiently up to date
 			// 2. this time range [from, to) doesn't have any commits
 			// so we can skip this frame for this repo
-			log15.Info("insights: skipping query based on no commits", "for_time", frame.From, "repo_id", id)
+			log15.Debug("insights: skipping query based on no commits", "for_time", frame.From, "repo_id", id)
 			prev.SharedRecordings = append(prev.SharedRecordings, frame.From)
 			count++
 			continue
 		} else {
 			rev := commits[0]
-			log15.Info("insights: generating query with commit index revision", "rev", rev, "for_time", frame.From, "repo_id", id)
+			log15.Debug("insights: generating query with commit index revision", "rev", rev, "for_time", frame.From, "repo_id", id)
 			// as a small optimization we are collecting this revhash here since we already know this is
 			// the revision for which we need to query against
 			addToPlan(frame, string(rev.Commit))

--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -311,7 +311,7 @@ func (s *InsightStore) GetDataSeries(ctx context.Context, args GetDataSeriesArgs
 		preds = append(preds, sqlf.Sprintf("series_id = %s", args.SeriesID))
 	}
 	if args.GlobalOnly {
-		preds = append(preds, sqlf.Sprintf("repositories IS NULL OR CARDINALITY(repositories) = 0"))
+		preds = append(preds, sqlf.Sprintf("(repositories IS NULL OR CARDINALITY(repositories) = 0)"))
 	}
 
 	q := sqlf.Sprintf(getInsightDataSeriesSql, sqlf.Join(preds, "\n AND"))


### PR DESCRIPTION
Fixes a bug that would only appear if the condition for the `GlobalOnly` predicate was compounded with another predicate due to order of operations. This bug caused some series to endlessly backfill despite already having `backfill_completed_at` set to non-null.

Also taking a chance to remove / lower the log level of some really noisy logs.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
