### PR TITLE
actor: remove actor propagation backcompat measures

### DIFF
--- a/internal/actor/http_test.go
+++ b/internal/actor/http_test.go
@@ -103,13 +103,7 @@ func TestHTTPMiddleware(t *testing.T) {
 		headers: map[string]string{
 			headerKeyActorUID: "",
 		},
-		wantActor: &Actor{Internal: true},
-	}, {
-		name: "backcompat: legacy user actor header",
-		headers: map[string]string{
-			headerKeyLegacyActorUID: "1234",
-		},
-		wantActor: &Actor{UID: 1234},
+		wantActor: &Actor{Internal: false},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/sourcegraph/go-rendezvous"
 
-	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitolite"
@@ -1022,19 +1021,6 @@ func (c *Client) do(ctx context.Context, repo api.RepoName, method, uri string, 
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO(@bobheadxi): This is here for the purposes of backcompat, remove when
-	// deployments are updated.
-	req.Header.Set("X-Sourcegraph-Actor", func() string {
-		a := actor.FromContext(ctx)
-		if a == nil {
-			return "0"
-		}
-		if a.Internal {
-			return "internal"
-		}
-		return a.UIDString()
-	}())
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", c.UserAgent)


### PR DESCRIPTION
Removes backcompat measures introduced in https://github.com/sourcegraph/sourcegraph/pull/28117 and https://github.com/sourcegraph/sourcegraph/pull/28487 to enforce the new standard method of actor propagation from https://github.com/sourcegraph/sourcegraph/issues/27918.

Closes https://github.com/sourcegraph/sourcegraph/issues/28451

---

Going to merge this after the 3.35 branch cut scheduled for dec 17 (https://github.com/sourcegraph/sourcegraph/issues/28613). This should give plenty of time for all deployments to update, including on-prem instances