### PR TITLE
search: do not fetch if rev is missing when indexing

### DIFF
--- a/cmd/frontend/internal/httpapi/search.go
+++ b/cmd/frontend/internal/httpapi/search.go
@@ -161,7 +161,9 @@ func (h *searchIndexerServer) serveConfiguration(w http.ResponseWriter, r *http.
 		getVersion := func(branch string) (string, error) {
 			metricGetVersion.Inc()
 			// Do not to trigger a repo-updater lookup since this is a batch job.
-			commitID, err := git.ResolveRevision(ctx, repo.Name, branch, git.ResolveRevisionOptions{})
+			commitID, err := git.ResolveRevision(ctx, repo.Name, branch, git.ResolveRevisionOptions{
+				NoEnsureRevision: true,
+			})
 			if err != nil && errcode.HTTP(err) == http.StatusNotFound {
 				// GetIndexOptions wants an empty rev for a missing rev or empty
 				// repo.


### PR DESCRIPTION
It is possible that when asking for revisions that do not exist we get
blocked due to clone semaphores. This is the correct behaviour, since we
expect some branches to not exist. Zoekt polls, so we will converge to
indexing the branch once it exists on gitserver.