### PR TITLE
migration: Share postgres dsn resolution code

### DIFF
--- a/internal/database/migration/schemas/names.go
+++ b/internal/database/migration/schemas/names.go
@@ -1,0 +1,9 @@
+package schemas
+
+var SchemaNames []string
+
+func init() {
+	for _, schema := range Schemas {
+		SchemaNames = append(SchemaNames, schema.Name)
+	}
+}


### PR DESCRIPTION
Move the postgres DSN resolution done by the frontend into shared database code (may be refactored/reorganized later) so that it can later be used by the migrator instance as well. 

(It will need to have the same envvars as the frontend as it won't be guaranteed to be able to connect to a working frontend to get the service connection values during normal installation/upgrade flow)