### PR TITLE
searcher: remove hardcoded timeout in fetch

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -187,10 +187,6 @@ func (s *Store) fetch(ctx context.Context, repo api.RepoName, commit api.CommitI
 	}
 	fetchQueueSize.Dec()
 
-	// We expect git archive, even for large repos, to finish relatively
-	// quickly.
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
-
 	fetching.Inc()
 	span, ctx := ot.StartSpanFromContext(ctx, "Store.fetch")
 	ext.Component.Set(span, "store")


### PR DESCRIPTION
We have a passed in context which is managed by the diskcache.Store.
Lets rely on that instead of using a hardcoded timeout. This will likely
help remove an error that occurs on large monorepos. Currently
diskcache.Store has a timeout of 10min, but here we had it set to 2min.
So we effectively never waited more than 2min. Lets be consistent and
also wait 10min.