### PR TITLE
[Part 2 for #issues/27922] Add browser extension support for cloud private repositories

### DIFF
--- a/client/browser/CHANGELOG.md
+++ b/client/browser/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Sourcegraph [Browser Extensions](./README.md) are documen
 <!-- START CHANGELOG -->
 
 ## Unreleased
+- Private cloud repositories should use hashed identifiers instead of repository names [pull/28621](https://github.com/sourcegraph/sourcegraph/pull/28621), [#pull/28387](https://github.com/sourcegraph/sourcegraph/pull/28387), [#issues/27922](https://github.com/sourcegraph/sourcegraph/issues/27922)
 
 - Browser Extension Telemetry documentation [#pull/28689](https://github.com/sourcegraph/sourcegraph/pull/28689), [#issues/27383](https://github.com/sourcegraph/sourcegraph/issues/27383)
 

--- a/client/browser/CHANGELOG.md
+++ b/client/browser/CHANGELOG.md
@@ -12,7 +12,11 @@ All notable changes to Sourcegraph [Browser Extensions](./README.md) are documen
 <!-- START CHANGELOG -->
 
 ## Unreleased
+
 - Private cloud repositories should use hashed identifiers instead of repository names [pull/28621](https://github.com/sourcegraph/sourcegraph/pull/28621), [#pull/28387](https://github.com/sourcegraph/sourcegraph/pull/28387), [#issues/27922](https://github.com/sourcegraph/sourcegraph/issues/27922)
+
+  - Also, browser extension does not override native codehost tooltips whenever cannot inject code intelligence
+  - Also, browser extension shows "Sign In to Sourcegraph" button on private repository pages
 
 - Browser Extension Telemetry documentation [#pull/28689](https://github.com/sourcegraph/sourcegraph/pull/28689), [#issues/27383](https://github.com/sourcegraph/sourcegraph/issues/27383)
 

--- a/client/browser/src/browser-extension/scripts/contentPage.main.ts
+++ b/client/browser/src/browser-extension/scripts/contentPage.main.ts
@@ -5,7 +5,7 @@ import { first } from 'rxjs/operators'
 
 import { setLinkComponent, AnchorLink } from '@sourcegraph/shared/src/components/Link'
 
-import { CodeHost, determineCodeHost } from '../../shared/code-hosts/shared/codeHost'
+import { determineCodeHost } from '../../shared/code-hosts/shared/codeHost'
 import { injectCodeIntelligence } from '../../shared/code-hosts/shared/inject'
 import {
     checkIsSourcegraph,
@@ -109,15 +109,7 @@ async function main(): Promise<void> {
                 previousSubscription = await injectCodeIntelligence(
                     { sourcegraphURL, assetsURL: getAssetsURL(DEFAULT_SOURCEGRAPH_URL) },
                     IS_EXTENSION,
-                    async function onCodeHostFound(codeHost: CodeHost) {
-                        if (sourcegraphURL === DEFAULT_SOURCEGRAPH_URL && codeHost.getContext) {
-                            const { privateRepository } = await codeHost.getContext()
-                            if (privateRepository) {
-                                throw new Error(
-                                    `Code intelligence for private repository is not supported when using Sourcegraph URL ${DEFAULT_SOURCEGRAPH_URL}`
-                                )
-                            }
-                        }
+                    async function onCodeHostFound() {
                         const styleSheets = [
                             {
                                 id: 'ext-style-sheet',
@@ -134,7 +126,7 @@ async function main(): Promise<void> {
                 )
                 console.log('Sourcegraph attached code intelligence')
             } catch (error) {
-                console.log('Sourcegraph code host integration stopped initialization. Reason:', error?.message)
+                console.log('Sourcegraph code host integration stopped initialization. Reason:', error)
             }
         })
     )

--- a/client/browser/src/browser-extension/scripts/optionsPage.main.tsx
+++ b/client/browser/src/browser-extension/scripts/optionsPage.main.tsx
@@ -16,7 +16,7 @@ import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 import { fetchSite } from '../../shared/backend/server'
 import { isExtension } from '../../shared/context'
 import { initSentry } from '../../shared/sentry'
-import { observeSourcegraphURL, getExtensionVersion, DEFAULT_SOURCEGRAPH_URL } from '../../shared/util/context'
+import { observeSourcegraphURL, getExtensionVersion, isDefaultSourcegraphUrl } from '../../shared/util/context'
 import { featureFlags } from '../../shared/util/featureFlags'
 import {
     OptionFlagKey,
@@ -192,7 +192,7 @@ const Options: React.FunctionComponent = () => {
                 optionFlags={optionFlagsWithValues}
                 onChangeOptionFlag={handleChangeOptionFlag}
                 showPrivateRepositoryAlert={
-                    currentTabStatus?.status.hasPrivateCloudError && sourcegraphUrl === DEFAULT_SOURCEGRAPH_URL
+                    currentTabStatus?.status.hasPrivateCloudError && isDefaultSourcegraphUrl(sourcegraphUrl)
                 }
                 showSourcegraphCloudAlert={showSourcegraphCloudAlert}
                 permissionAlert={permissionAlert}

--- a/client/browser/src/shared/backend/userEvents.tsx
+++ b/client/browser/src/shared/backend/userEvents.tsx
@@ -3,7 +3,7 @@ import * as GQL from '@sourcegraph/shared/src/graphql/schema'
 import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
 
 import { UserEvent, EventSource } from '../../graphql-operations'
-import { DEFAULT_SOURCEGRAPH_URL } from '../util/context'
+import { isDefaultSourcegraphUrl } from '../util/context'
 
 /**
  * Log a user action on the associated self-hosted Sourcegraph instance (allows site admins on a private
@@ -49,7 +49,7 @@ export const logEvent = (
     requestGraphQL: PlatformContext['requestGraphQL']
 ): void => {
     // Only send the request if this is a private, self-hosted Sourcegraph instance.
-    if (event.url === DEFAULT_SOURCEGRAPH_URL) {
+    if (isDefaultSourcegraphUrl(event.url)) {
         return
     }
 

--- a/client/browser/src/shared/code-hosts/shared/ViewOnSourcegraphButton.tsx
+++ b/client/browser/src/shared/code-hosts/shared/ViewOnSourcegraphButton.tsx
@@ -6,7 +6,7 @@ import { isHTTPAuthError } from '@sourcegraph/shared/src/backend/fetch'
 import { ErrorLike, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 
 import { SourcegraphIconButton, SourcegraphIconButtonProps } from '../../components/SourcegraphIconButton'
-import { DEFAULT_SOURCEGRAPH_URL, getPlatformName } from '../../util/context'
+import { getPlatformName, isDefaultSourcegraphUrl } from '../../util/context'
 
 import { CodeHostContext } from './codeHost'
 import { SignInButton } from './SignInButton'
@@ -58,7 +58,7 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphB
     const { rawRepoName, revision, privateRepository } = context
 
     const isPrivateCloudError =
-        sourcegraphURL === DEFAULT_SOURCEGRAPH_URL && repoExistsOrError === false && privateRepository
+        isDefaultSourcegraphUrl(sourcegraphURL) && repoExistsOrError === false && privateRepository
 
     useEffect(() => {
         onPrivateCloudError(isPrivateCloudError)

--- a/client/browser/src/shared/code-hosts/shared/ViewOnSourcegraphButton.tsx
+++ b/client/browser/src/shared/code-hosts/shared/ViewOnSourcegraphButton.tsx
@@ -17,14 +17,14 @@ export interface ViewOnSourcegraphButtonClassProps {
     iconClassName?: string
 }
 
-interface ViewOnSourcegraphButtonProps extends ViewOnSourcegraphButtonClassProps {
-    codeHostType: string
+interface ViewOnSourcegraphButtonProps
+    extends ViewOnSourcegraphButtonClassProps,
+        Pick<ConfigureSourcegraphButtonProps, 'codeHostType' | 'onConfigureSourcegraphClick'> {
     context: CodeHostContext
     sourcegraphURL: string
     minimalUI: boolean
     repoExistsOrError?: boolean | ErrorLike
     showSignInButton?: boolean
-    onConfigureSourcegraphClick?: React.MouseEventHandler<HTMLAnchorElement>
 
     /**
      * A callback for when the user finished a sign in flow.
@@ -115,13 +115,10 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphB
 
     if (isPrivateCloudError) {
         return (
-            <SourcegraphIconButton
+            <ConfigureSourcegraphButton
+                codeHostType={codeHostType}
+                onConfigureSourcegraphClick={onConfigureSourcegraphClick}
                 {...commonProps}
-                href={new URL(snakeCase(codeHostType), 'https://docs.sourcegraph.com/integration/').href}
-                onClick={onConfigureSourcegraphClick}
-                label="Configure Sourcegraph"
-                title="Set up Sourcegraph for search and code intelligence on private repositories"
-                ariaLabel="Set up Sourcegraph for search and code intelligence on private repositories"
             />
         )
     }
@@ -155,3 +152,22 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphB
         />
     )
 }
+interface ConfigureSourcegraphButtonProps extends Partial<SourcegraphIconButtonProps> {
+    codeHostType: string
+    onConfigureSourcegraphClick?: React.MouseEventHandler<HTMLAnchorElement>
+}
+
+export const ConfigureSourcegraphButton: React.FunctionComponent<ConfigureSourcegraphButtonProps> = ({
+    onConfigureSourcegraphClick,
+    codeHostType,
+    ...commonProps
+}) => (
+    <SourcegraphIconButton
+        {...commonProps}
+        href={new URL(snakeCase(codeHostType), 'https://docs.sourcegraph.com/integration/').href}
+        onClick={onConfigureSourcegraphClick}
+        label="Configure Sourcegraph"
+        title="Set up Sourcegraph for search and code intelligence on private repositories"
+        ariaLabel="Set up Sourcegraph for search and code intelligence on private repositories"
+    />
+)

--- a/client/browser/src/shared/code-hosts/shared/codeHost.test.tsx
+++ b/client/browser/src/shared/code-hosts/shared/codeHost.test.tsx
@@ -158,7 +158,7 @@ describe('codeHost', () => {
         test('renders the hover overlay mount', async () => {
             const { extensionHostAPI } = await integrationTestContext()
             subscriptions.add(
-                handleCodeHost({
+                await handleCodeHost({
                     ...commonArguments(),
                     codeHost: {
                         type: 'github',
@@ -181,7 +181,7 @@ describe('codeHost', () => {
             const { extensionHostAPI } = await integrationTestContext()
             const commandPaletteMount = createTestElement()
             subscriptions.add(
-                handleCodeHost({
+                await handleCodeHost({
                     ...commonArguments(),
                     codeHost: {
                         type: 'github',
@@ -201,7 +201,7 @@ describe('codeHost', () => {
         test('creates a data-global-debug element and renders the debug menu if showGlobalDebug is true', async () => {
             const { extensionHostAPI } = await integrationTestContext()
             subscriptions.add(
-                handleCodeHost({
+                await handleCodeHost({
                     ...commonArguments(),
                     codeHost: {
                         type: 'github',
@@ -237,7 +237,7 @@ describe('codeHost', () => {
                 },
             }
             subscriptions.add(
-                handleCodeHost({
+                await handleCodeHost({
                     ...commonArguments(),
                     codeHost: {
                         type: 'github',
@@ -315,7 +315,7 @@ describe('codeHost', () => {
                 const line = document.createElement('div')
                 codeView.append(line)
                 subscriptions.add(
-                    handleCodeHost({
+                    await handleCodeHost({
                         ...commonArguments(),
                         codeHost: {
                             type: 'github',
@@ -436,7 +436,7 @@ describe('codeHost', () => {
                         parseInt(codeElement.parentElement!.getAttribute('line')!, 10),
                 }
                 subscriptions.add(
-                    handleCodeHost({
+                    await handleCodeHost({
                         ...commonArguments(),
                         codeHost: {
                             type: 'github',
@@ -595,7 +595,7 @@ describe('codeHost', () => {
                 { addedNodes: [document.body], removedNodes: [] },
             ])
             subscriptions.add(
-                handleCodeHost({
+                await handleCodeHost({
                     ...commonArguments(),
                     mutations,
                     codeHost: {
@@ -685,7 +685,7 @@ describe('codeHost', () => {
                 getLineNumberFromCodeElement: sinon.spy(() => 1),
             }
             subscriptions.add(
-                handleCodeHost({
+                await handleCodeHost({
                     ...commonArguments(),
                     codeHost: {
                         type: 'github',
@@ -734,7 +734,7 @@ describe('codeHost', () => {
                 getLineNumberFromCodeElement: sinon.spy(() => 1),
             }
             subscriptions.add(
-                handleCodeHost({
+                await handleCodeHost({
                     ...commonArguments(),
                     codeHost: {
                         type: 'github',
@@ -798,7 +798,7 @@ describe('codeHost', () => {
                 getLineNumberFromCodeElement: sinon.spy(() => 1),
             }
             subscriptions.add(
-                handleCodeHost({
+                await handleCodeHost({
                     ...commonArguments(),
                     codeHost: {
                         type: 'github',

--- a/client/browser/src/shared/code-hosts/shared/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/shared/codeHost.tsx
@@ -655,9 +655,7 @@ const onConfigureSourcegraphClick: React.MouseEventHandler<HTMLAnchorElement> = 
  * @returns boolean indicating whether it is safe to continue initialization
  *
  * Returns
- * - "false"
- *   - If could not parse repository name
- *   - Or if detected repository is private and not cloned in sourcegraph
+ * - "false": if could not parse repository name or if detected repository is private is not cloned in Sourcegraph Cloud
  * - "true" in all other cases
  *
  * Side-effect:
@@ -674,8 +672,8 @@ const isSafeToContinueCodeIntel = async ({
     if (!isDefaultSourcegraphUrl(sourcegraphURL) || !codeHost.getContext) {
         return true
     }
+    // This is only when connected to Sourcegraph Cloud and code host either GitLab or GitHub
     try {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const { privateRepository, rawRepoName } = await codeHost.getContext()
         if (!privateRepository) {
             // We can auto-clone public repos

--- a/client/browser/src/shared/code-hosts/shared/errors.ts
+++ b/client/browser/src/shared/code-hosts/shared/errors.ts
@@ -1,1 +1,2 @@
 export class RepoURLParseError extends Error {}
+export class NotAuthenticatedError extends Error {}

--- a/client/browser/src/shared/platform/worker.ts
+++ b/client/browser/src/shared/platform/worker.ts
@@ -1,11 +1,11 @@
 import { checkOk } from '@sourcegraph/shared/src/backend/fetch'
 
-import { DEFAULT_SOURCEGRAPH_URL } from '../util/context'
+import { isDefaultSourcegraphUrl } from '../util/context'
 
 export async function createBlobURLForBundle(bundleURL: string): Promise<string> {
     const { origin, hostname } = new URL(bundleURL)
     // Include credentials when fetching extensions from the private registry
-    const includeCredentials = origin !== DEFAULT_SOURCEGRAPH_URL && hostname !== 'localhost'
+    const includeCredentials = !isDefaultSourcegraphUrl(origin) && hostname !== 'localhost'
     const response = await fetch(bundleURL, {
         credentials: includeCredentials ? 'include' : 'omit',
     })

--- a/client/browser/src/shared/sentry/index.ts
+++ b/client/browser/src/shared/sentry/index.ts
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/browser'
 import { once } from 'lodash'
 
 import { isInPage } from '../context'
-import { DEFAULT_SOURCEGRAPH_URL, getExtensionVersion, observeSourcegraphURL } from '../util/context'
+import { getExtensionVersion, isDefaultSourcegraphUrl, observeSourcegraphURL } from '../util/context'
 import { observeOptionFlag } from '../util/optionFlags'
 
 const IS_EXTENSION = true
@@ -59,7 +59,7 @@ export function initSentry(script: 'content' | 'options' | 'background', codeHos
 
     observeSourcegraphURL(IS_EXTENSION).subscribe(url => {
         Sentry.configureScope(scope => {
-            scope.setTag('using_dot_com', url === DEFAULT_SOURCEGRAPH_URL ? 'true' : 'false')
+            scope.setTag('using_dot_com', isDefaultSourcegraphUrl(url) ? 'true' : 'false')
         })
     })
 }

--- a/client/browser/src/shared/util/context.tsx
+++ b/client/browser/src/shared/util/context.tsx
@@ -65,6 +65,6 @@ function isSafari(): boolean {
     return window.navigator.userAgent.includes('Safari') && !window.navigator.userAgent.includes('Chrome')
 }
 
-export function isDefaultSourcegraphUrl(url: string): boolean {
-    return url.replace(/\/$/, '') === DEFAULT_SOURCEGRAPH_URL
+export function isDefaultSourcegraphUrl(url?: string): boolean {
+    return url?.replace(/\/$/, '') === DEFAULT_SOURCEGRAPH_URL
 }

--- a/client/shared/src/util/hashCode.ts
+++ b/client/shared/src/util/hashCode.ts
@@ -2,7 +2,6 @@
  * Returns a hash code value for a string.
  *
  * The hash algorithm here is using Base64 encoding of a SHA256 hash
- *
  */
 export async function hashCode(input: string): Promise<string> {
     // See `SubtleCrypto` API docs:
@@ -12,4 +11,15 @@ export async function hashCode(input: string): Promise<string> {
     const hashArray = [...new Uint8Array(hashBuffer)]
 
     return btoa(String.fromCharCode(...hashArray))
+}
+
+/**
+ * Returns a sha256 hash code value in 'hex' for a string.
+ */
+export async function sha256(input: string): Promise<string> {
+    const messageUint8 = new TextEncoder().encode(input)
+    const hashBuffer = await crypto.subtle.digest('SHA-256', messageUint8)
+    const hashArray = [...new Uint8Array(hashBuffer)] // convert buffer to byte array
+    const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('') // convert bytes to hex string
+    return hashHex
 }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/27922. Blocked by https://github.com/sourcegraph/sourcegraph/pull/28387.

### Description
This PR:
- Adds back (secure) support for private repositories on Sourcegraph Cloud
> Note: as a **positive** side-effects:
> - browser extension does not override GitHub native tooltips when the repository is not cloned on Cloud
> - browser extension is immediately reinitialized on all open/active pages when Sourcegraph URL changes

### How to test
- `sg run bext`
- Set the extension to cloud URL (https://sourcegraph.com)
  - Open any public repo and make sure the browser extension works properly
  - Open any private repo which is cloned in Cloud and make sure the browser extension works properly
  - Open any private repo which is NOT cloned in Cloud and **make sure the browser extension does NOT work and does not make any requests except `SecureCheckRepoCloned` in extension background script -> Network tab**
- Set the extension to a self-hosted URL (https://k8s.sgdev.org)
  - Make that browser extension works as previously

### Screenshots

| Scenario | Screenshot |
| --: | :-- |
| cloud URL & private repo is cloned | ![image](https://user-images.githubusercontent.com/6717049/145415064-004f3abf-15d3-456b-954f-2863b8a1c309.png) |
| cloud URL & private repo is NOT cloned | ![image](https://user-images.githubusercontent.com/6717049/145415442-79a03e8b-de72-4586-8197-e26a56ea0970.png) |
| cloud URL & private repo && not sign in | ![image](https://user-images.githubusercontent.com/6717049/145416418-6a2eaa46-b7b3-433d-b464-21c02841c4ec.png) |
| cloud URL && public repo | ![image](https://user-images.githubusercontent.com/6717049/145414837-1f4931b0-507d-4c2a-8a43-dbeaf3dff5bf.png) |
| self-hosted URL | everything remains the same as previously |


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
