### PR TITLE
database: Add NewDefaultRunner

### DIFF
--- a/internal/database/migration/runner/iface.go
+++ b/internal/database/migration/runner/iface.go
@@ -15,5 +15,3 @@ type Store interface {
 	Up(ctx context.Context, migration definition.Definition) error
 	Down(ctx context.Context, migration definition.Definition) error
 }
-
-type StoreFactory func() (Store, error)

--- a/internal/database/migration/runner/runner.go
+++ b/internal/database/migration/runner/runner.go
@@ -2,22 +2,54 @@ package runner
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 
 	"github.com/inconshreveable/log15"
 
+	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/locker"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/store"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 type Runner struct {
 	storeFactories map[string]StoreFactory
 }
 
+type StoreFactory func() (Store, error)
+
 func NewRunner(storeFactories map[string]StoreFactory) *Runner {
 	return &Runner{
 		storeFactories: storeFactories,
 	}
+}
+
+func NewDefaultRunner(dsns map[string]string, appName string, observationContext *observation.Context) *Runner {
+	operations := store.NewOperations(observationContext)
+	makeFactory := func(
+		name string,
+		schema *schemas.Schema,
+		factory func(dsn, appName string, migrate bool) (*sql.DB, error),
+	) StoreFactory {
+		return func() (Store, error) {
+			db, err := factory(dsns[name], appName, false)
+			if err != nil {
+				return nil, err
+			}
+
+			return store.NewWithDB(db, schema.MigrationsTableName, operations), nil
+		}
+	}
+
+	storeFactoryMap := map[string]StoreFactory{
+		"frontend":     makeFactory("frontend", schemas.Frontend, dbconn.NewFrontendDB),
+		"codeintel":    makeFactory("codeintel", schemas.CodeIntel, dbconn.NewCodeIntelDB),
+		"codeinsights": makeFactory("codeinsights", schemas.CodeInsights, dbconn.NewCodeInsightsDB),
+	}
+
+	return NewRunner(storeFactoryMap)
 }
 
 type Options struct {


### PR DESCRIPTION
Add a better constructor for database migration runners that constructs a sufficient store factory.