### PR TITLE
add boolean flag to run repo update in the background or not in Syncer.SyncRepo

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -312,7 +312,7 @@ func (s *Server) repoLookup(ctx context.Context, args protocol.RepoLookupArgs) (
 
 	var repo *types.Repo
 	if s.SourcegraphDotComMode {
-		repo, err = s.Syncer.SyncRepo(ctx, args.Repo)
+		repo, err = s.Syncer.SyncRepo(ctx, args.Repo, true)
 	} else {
 		// TODO: Remove all call sites that RPC into repo-updater to just look-up
 		// a repo. They can simply ask the database instead.

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -579,9 +579,25 @@ func TestServer_RepoLookup(t *testing.T) {
 			stored: []*types.Repo{githubRepository.With(func(r *types.Repo) {
 				r.UpdatedAt = r.UpdatedAt.Add(-time.Hour)
 			})},
+			result: &protocol.RepoLookupResult{Repo: &protocol.RepoInfo{
+				ID: 7,
+				ExternalRepo: api.ExternalRepoSpec{
+					ID:          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+					ServiceType: extsvc.TypeGitHub,
+					ServiceID:   "https://github.com/",
+				},
+				Name:        "github.com/foo/bar",
+				Description: "The description",
+				VCS:         protocol.VCSInfo{URL: "git@github.com:foo/bar.git"},
+				Links: &protocol.RepoLinks{
+					Root:   "github.com/foo/bar",
+					Tree:   "github.com/foo/bar/tree/{rev}/{path}",
+					Blob:   "github.com/foo/bar/blob/{rev}/{path}",
+					Commit: "github.com/foo/bar/commit/{commit}",
+				},
+			}},
 			assertDelay: time.Second,
-			result:      &protocol.RepoLookupResult{ErrorNotFound: true},
-			err:         fmt.Sprintf("repository not found (name=%s notfound=%v)", githubRepository.Name, true),
+			assert:      typestest.Assert.ReposEqual(),
 		},
 	}
 

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -579,25 +579,9 @@ func TestServer_RepoLookup(t *testing.T) {
 			stored: []*types.Repo{githubRepository.With(func(r *types.Repo) {
 				r.UpdatedAt = r.UpdatedAt.Add(-time.Hour)
 			})},
-			result: &protocol.RepoLookupResult{Repo: &protocol.RepoInfo{
-				ID: 7,
-				ExternalRepo: api.ExternalRepoSpec{
-					ID:          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
-					ServiceType: extsvc.TypeGitHub,
-					ServiceID:   "https://github.com/",
-				},
-				Name:        "github.com/foo/bar",
-				Description: "The description",
-				VCS:         protocol.VCSInfo{URL: "git@github.com:foo/bar.git"},
-				Links: &protocol.RepoLinks{
-					Root:   "github.com/foo/bar",
-					Tree:   "github.com/foo/bar/tree/{rev}/{path}",
-					Blob:   "github.com/foo/bar/blob/{rev}/{path}",
-					Commit: "github.com/foo/bar/commit/{commit}",
-				},
-			}},
 			assertDelay: time.Second,
-			assert:      typestest.Assert.ReposEqual(),
+			result:      &protocol.RepoLookupResult{ErrorNotFound: true},
+			err:         fmt.Sprintf("repository not found (name=%s notfound=%v)", githubRepository.Name, true),
 		},
 	}
 

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -250,7 +250,7 @@ func (d Diff) Len() int {
 // because we don't sync our "cloud_default" code hosts in the background
 // since there are too many repos. Instead we use an incremental approach where we check for
 // changes everytime a user browses a repo.
-func (s *Syncer) SyncRepo(ctx context.Context, name api.RepoName) (repo *types.Repo, err error) {
+func (s *Syncer) SyncRepo(ctx context.Context, name api.RepoName, background bool) (repo *types.Repo, err error) {
 	tr, ctx := trace.New(ctx, "Syncer.SyncRepo", string(name))
 	defer tr.Finish()
 
@@ -273,6 +273,24 @@ func (s *Syncer) SyncRepo(ctx context.Context, name api.RepoName) (repo *types.R
 		if s.Now().Sub(repo.UpdatedAt) < time.Minute {
 			return repo, nil
 		}
+	}
+
+	if background && repo != nil {
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+			defer cancel()
+
+			// We don't care about the return value here, but we still want to ensure that
+			// only one is in flight at a time.
+			_, _, _ = s.syncGroup.Do(string(name), func() (interface{}, error) {
+				updatedRepo, err := s.syncRepo(ctx, codehost, name, repo)
+				if err != nil {
+					log15.Error("Error syncing repo in the background", "name", name, "error", err)
+				}
+				return updatedRepo, nil
+			})
+		}()
+		return repo, nil
 	}
 
 	updatedRepo, err, _ := s.syncGroup.Do(string(name), func() (interface{}, error) {

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -294,7 +294,7 @@ func (s *Syncer) SyncRepo(ctx context.Context, name api.RepoName, background boo
 	}
 
 	updatedRepo, err, _ := s.syncGroup.Do(string(name), func() (interface{}, error) {
-		return s.syncRepo(ctx, codehost, name, nil)
+		return s.syncRepo(ctx, codehost, name, repo)
 	})
 	if err != nil {
 		return nil, err

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -249,7 +249,8 @@ func (d Diff) Len() int {
 // SyncRepo syncs a single repository by name. It's only currently used on sourcegraph.com
 // because we don't sync our "cloud_default" code hosts in the background
 // since there are too many repos. Instead we use an incremental approach where we check for
-// changes everytime a user browses a repo.
+// changes everytime a user browses a repo. The "background" boolean flag indicates that we should run this
+// sync in the background vs block and call s.syncRepo synchronously.
 func (s *Syncer) SyncRepo(ctx context.Context, name api.RepoName, background bool) (repo *types.Repo, err error) {
 	tr, ctx := trace.New(ctx, "Syncer.SyncRepo", string(name))
 	defer tr.Finish()

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -695,7 +695,7 @@ func testSyncRepo(s *repos.Store) func(*testing.T) {
 					),
 				}
 
-				have, err := syncer.SyncRepo(ctx, tc.repo)
+				have, err := syncer.SyncRepo(ctx, tc.repo, true)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -1316,7 +1316,7 @@ func testSyncRepoMaintainsOtherSources(store *repos.Store) func(*testing.T) {
 				CloneURL: "cloneURL",
 			},
 		}
-		_, err := syncer.SyncRepo(ctx, githubRepo.Name)
+		_, err := syncer.SyncRepo(ctx, githubRepo.Name, true)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Background behind this change: In working to test https://github.com/sourcegraph/sourcegraph/pull/28522 I realized that the asynchronous nature of `syncer.SyncRepo` made testing unnecessarily difficult. It would be easier for this function to have synchronous behavior and then if we need the update to happen in the background, add the goroutine at a higher level for ease of testing these pieces. So, I'm proposing removing the goroutine from this function entirely. Below is my reasoning for why we can safely do that. 

Currently, this goroutine is never being touched. The only place in the code that `SyncRepo` is being called is the `repo-lookup` endpoint in `repo-updater` [query to validate this](https://sourcegraph.com/search?q=context%3Aglobal+repo%3Agithub.com%2Fsourcegraph%2Fsourcegraph+SyncRepo+-file%3A_test.go%24+patternType%3Aliteral+case%3Ayes)

If we look where the `RepoLookup` function in the repo updater client (which corresponds to this endpoint) is called, we see there are [3 cases](https://sourcegraph.com/search?q=context%3Aglobal+repo%3Agithub.com%2Fsourcegraph%2Fsourcegraph+RepoLookup+-file%3A_test.go%24+patternType%3Aliteral+case%3Ayes)

Cases:
1) [repos.Add](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/backend/repos.go?L147) since this is for adding new repos, `repo` will always be nil and `SyncRepo` will exit before the goroutine.
2) [set_user_public_repos.go](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/graphqlbackend/set_user_public_repos.go?L106) but if you look on line 102, you see that if the repo already exists we return, so we again have a nil repo and exit before the goroutine in `SyncRepo`
3) [dependency_indexing_scheduler.go](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/enterprise/cmd/worker/internal/codeintel/indexing/dependency_indexing_scheduler.go?L150) This is the only one I'm not sure about, since we could potentially be updating existing repos. However, I still think that in this case the functionality should be synchronous as opposed to asynchronous but I'd like to validate that with someone who knows this part of the code already. 

UPDATE: Adding in a boolean flag to do the sync (for non-nil repos) in the background or not and setting it to `true` so this shouldn't change any functionality. Then when I call this function in https://github.com/sourcegraph/sourcegraph/pull/28522 I can set that boolean to `false`


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
