### PR TITLE
migration: Move connection creation functions into a new package

### DIFF
--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -34,7 +34,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database/connections"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -95,7 +95,7 @@ func defaultExternalURL(nginxAddr, httpAddr string) *url.URL {
 // InitDB initializes and returns the global database connection and sets the
 // version of the frontend in our versions table.
 func InitDB() (*sql.DB, error) {
-	sqlDB, err := dbconn.NewFrontendDB("", "frontend", true)
+	sqlDB, err := connections.NewFrontendDB("", "frontend", true)
 	if err != nil {
 		return nil, errors.Errorf("failed to connect to frontend database: %s", err)
 	}

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -26,7 +26,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database/connections"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
@@ -270,7 +270,7 @@ func getDB() (dbutil.DB, error) {
 	dsn := conf.GetServiceConnectionValueAndRestartOnChange(func(serviceConnections conftypes.ServiceConnections) string {
 		return serviceConnections.PostgresDSN
 	})
-	return dbconn.NewFrontendDB(dsn, "gitserver", false)
+	return connections.NewFrontendDB(dsn, "gitserver", false)
 }
 
 func getVCSSyncer(ctx context.Context, externalServiceStore database.ExternalServiceStore, repoStore database.RepoStore,

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -27,7 +27,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database/connections"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -116,7 +116,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	dsn := conf.GetServiceConnectionValueAndRestartOnChange(func(serviceConnections conftypes.ServiceConnections) string {
 		return serviceConnections.PostgresDSN
 	})
-	sqlDB, err := dbconn.NewFrontendDB(dsn, "repo-updater", false)
+	sqlDB, err := connections.NewFrontendDB(dsn, "repo-updater", false)
 	if err != nil {
 		log.Fatalf("failed to initialize database store: %v", err)
 	}

--- a/cmd/worker/workerdb/db.go
+++ b/cmd/worker/workerdb/db.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/worker/memo"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database/connections"
 )
 
 // Init initializes and returns a connection to the frontend database.
@@ -25,7 +25,7 @@ var initDatabaseMemo = memo.NewMemoizedConstructor(func() (interface{}, error) {
 	dsn := conf.GetServiceConnectionValueAndRestartOnChange(func(serviceConnections conftypes.ServiceConnections) string {
 		return serviceConnections.PostgresDSN
 	})
-	db, err := dbconn.NewFrontendDB(dsn, "worker", false)
+	db, err := connections.NewFrontendDB(dsn, "worker", false)
 	if err != nil {
 		return nil, errors.Errorf("failed to connect to frontend database: %s", err)
 	}

--- a/dev/schemadoc/main.go
+++ b/dev/schemadoc/main.go
@@ -20,7 +20,7 @@ import (
 	_ "github.com/lib/pq"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database/connections"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
@@ -41,8 +41,8 @@ var schemas = map[string]struct {
 	destinationFilename string
 	factory             databaseFactory
 }{
-	"frontend":  {"schema.md", dbconn.NewFrontendDB},
-	"codeintel": {"schema.codeintel.md", dbconn.NewCodeIntelDB},
+	"frontend":  {"schema.md", connections.NewFrontendDB},
+	"codeintel": {"schema.codeintel.md", connections.NewCodeIntelDB},
 }
 
 // This script generates markdown formatted output containing descriptions of

--- a/enterprise/cmd/frontend/internal/codeintel/services.go
+++ b/enterprise/cmd/frontend/internal/codeintel/services.go
@@ -21,7 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database/connections"
 	"github.com/sourcegraph/sourcegraph/internal/database/locker"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -107,7 +107,7 @@ func mustInitializeCodeIntelDB() *sql.DB {
 	dsn := conf.GetServiceConnectionValueAndRestartOnChange(func(serviceConnections conftypes.ServiceConnections) string {
 		return serviceConnections.CodeIntelPostgresDSN
 	})
-	db, err := dbconn.NewCodeIntelDB(dsn, "frontend", true)
+	db, err := connections.NewCodeIntelDB(dsn, "frontend", true)
 	if err != nil {
 		log.Fatalf("Failed to connect to codeintel database: %s", err)
 	}

--- a/enterprise/cmd/precise-code-intel-worker/main.go
+++ b/enterprise/cmd/precise-code-intel-worker/main.go
@@ -23,7 +23,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database/connections"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -125,7 +125,7 @@ func mustInitializeDB() *sql.DB {
 	dsn := conf.GetServiceConnectionValueAndRestartOnChange(func(serviceConnections conftypes.ServiceConnections) string {
 		return serviceConnections.PostgresDSN
 	})
-	sqlDB, err := dbconn.NewFrontendDB(dsn, "precise-code-intel-worker", false)
+	sqlDB, err := connections.NewFrontendDB(dsn, "precise-code-intel-worker", false)
 	if err != nil {
 		log.Fatalf("Failed to connect to frontend database: %s", err)
 	}
@@ -151,7 +151,7 @@ func mustInitializeCodeIntelDB() *sql.DB {
 	dsn := conf.GetServiceConnectionValueAndRestartOnChange(func(serviceConnections conftypes.ServiceConnections) string {
 		return serviceConnections.CodeIntelPostgresDSN
 	})
-	db, err := dbconn.NewCodeIntelDB(dsn, "precise-code-intel-worker", true)
+	db, err := connections.NewCodeIntelDB(dsn, "precise-code-intel-worker", true)
 	if err != nil {
 		log.Fatalf("Failed to connect to codeintel database: %s", err)
 	}

--- a/enterprise/cmd/worker/internal/codeintel/codeinteldb.go
+++ b/enterprise/cmd/worker/internal/codeintel/codeinteldb.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/worker/memo"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database/connections"
 )
 
 // InitCodeIntelDatabase initializes and returns a connection to the codeintel db.
@@ -25,7 +25,7 @@ var initCodeIntelDatabaseMemo = memo.NewMemoizedConstructor(func() (interface{},
 	dsn := conf.GetServiceConnectionValueAndRestartOnChange(func(serviceConnections conftypes.ServiceConnections) string {
 		return serviceConnections.CodeIntelPostgresDSN
 	})
-	db, err := dbconn.NewCodeIntelDB(dsn, "worker", false)
+	db, err := connections.NewCodeIntelDB(dsn, "worker", false)
 	if err != nil {
 		return nil, errors.Errorf("failed to connect to codeintel database: %s", err)
 	}

--- a/enterprise/internal/insights/dbtesting/insights.go
+++ b/enterprise/internal/insights/dbtesting/insights.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/connections"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/internal/database/postgresdsn"
 )
@@ -28,7 +28,7 @@ func TimescaleDB(t testing.TB) (db *sql.DB, cleanup func()) {
 	}
 
 	timescaleDSN := postgresdsn.New("codeinsights", username, os.Getenv)
-	initConn, closeInitConn, err := connections.NewTestDB(timescaleDSN)
+	initConn, closeInitConn, err := newTestDB(timescaleDSN)
 	if err != nil {
 		t.Log("")
 		t.Log("README: To run these tests you need to have the codeinsights TimescaleDB running:")
@@ -63,7 +63,7 @@ func TimescaleDB(t testing.TB) (db *sql.DB, cleanup func()) {
 	}
 	u.Path = dbname
 	timescaleDSN = u.String()
-	db, closeDBConn, err := connections.NewTestDB(timescaleDSN, schemas.CodeInsights)
+	db, closeDBConn, err := newTestDB(timescaleDSN, schemas.CodeInsights)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,4 +88,15 @@ func TimescaleDB(t testing.TB) (db *sql.DB, cleanup func()) {
 		//}
 	}
 	return db, cleanup
+}
+
+// newTestDB connects to the given data source and returns the handle. After successful connection, the
+// schema version of the database will be compared against an expected version and the supplied migrations
+// may be run (taking an advisory lock to ensure exclusive access).
+//
+// This function returns a basestore-style callback that closes the database. This should be called instead
+// of calling Close directly on the database handle as it also handles closing migration objects associated
+// with the handle.
+func newTestDB(dsn string, schemas ...*schemas.Schema) (*sql.DB, func(err error) error, error) {
+	return dbconn.ConnectInternal(dsn, "", "", schemas)
 }

--- a/enterprise/internal/insights/dbtesting/insights.go
+++ b/enterprise/internal/insights/dbtesting/insights.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database/connections"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/internal/database/postgresdsn"
 )
@@ -28,7 +28,7 @@ func TimescaleDB(t testing.TB) (db *sql.DB, cleanup func()) {
 	}
 
 	timescaleDSN := postgresdsn.New("codeinsights", username, os.Getenv)
-	initConn, closeInitConn, err := dbconn.ConnectRawForTestDatabase(timescaleDSN)
+	initConn, closeInitConn, err := connections.NewTestDB(timescaleDSN)
 	if err != nil {
 		t.Log("")
 		t.Log("README: To run these tests you need to have the codeinsights TimescaleDB running:")
@@ -63,7 +63,7 @@ func TimescaleDB(t testing.TB) (db *sql.DB, cleanup func()) {
 	}
 	u.Path = dbname
 	timescaleDSN = u.String()
-	db, closeDBConn, err := dbconn.ConnectRawForTestDatabase(timescaleDSN, schemas.CodeInsights)
+	db, closeDBConn, err := connections.NewTestDB(timescaleDSN, schemas.CodeInsights)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/insights/insights.go
+++ b/enterprise/internal/insights/insights.go
@@ -17,7 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database/connections"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 )
@@ -73,7 +73,7 @@ func InitializeCodeInsightsDB(app string) (*sql.DB, error) {
 	dsn := conf.GetServiceConnectionValueAndRestartOnChange(func(serviceConnections conftypes.ServiceConnections) string {
 		return serviceConnections.CodeInsightsTimescaleDSN
 	})
-	db, err := dbconn.NewCodeInsightsDB(dsn, app, true)
+	db, err := connections.NewCodeInsightsDB(dsn, app, true)
 	if err != nil {
 		return nil, errors.Errorf("Failed to connect to codeinsights database: %s", err)
 	}

--- a/internal/database/connections/new.go
+++ b/internal/database/connections/new.go
@@ -63,14 +63,3 @@ func NewCodeInsightsDB(dsn, appName string, migrate bool) (*sql.DB, error) {
 	db, _, err := dbconn.ConnectInternal(dsn, appName, "codeinsight", migrations)
 	return db, err
 }
-
-// NewTestDB connects to the given data source and returns the handle. After successful connection, the
-// schema version of the database will be compared against an expected version and the supplied migrations
-// may be run (taking an advisory lock to ensure exclusive access).
-//
-// This function returns a basestore-style callback that closes the database. This should be called instead
-// of calling Close directly on the database handle as it also handles closing migration objects associated
-// with the handle.
-func NewTestDB(dsn string, schemas ...*schemas.Schema) (*sql.DB, func(err error) error, error) {
-	return dbconn.ConnectInternal(dsn, "", "", schemas)
-}

--- a/internal/database/connections/new.go
+++ b/internal/database/connections/new.go
@@ -64,9 +64,9 @@ func NewCodeInsightsDB(dsn, appName string, migrate bool) (*sql.DB, error) {
 	return db, err
 }
 
-// NewTestDB connects to the given data source and returns the handle. After successful
-// connection, the schema version of the database will be compared against an expected version and the
-// supplied migrations may be run (taking an advisory lock to ensure exclusive access).
+// NewTestDB connects to the given data source and returns the handle. After successful connection, the
+// schema version of the database will be compared against an expected version and the supplied migrations
+// may be run (taking an advisory lock to ensure exclusive access).
 //
 // This function returns a basestore-style callback that closes the database. This should be called instead
 // of calling Close directly on the database handle as it also handles closing migration objects associated

--- a/internal/database/connections/runner.go
+++ b/internal/database/connections/runner.go
@@ -1,0 +1,43 @@
+package connections
+
+import (
+	"database/sql"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/runner"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/store"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+
+func NewDefaultRunner(dsns map[string]string, appName string, observationContext *observation.Context) *runner.Runner {
+	operations := store.NewOperations(observationContext)
+	makeFactory := func(
+		name string,
+		schema *schemas.Schema,
+		factory func(dsn, appName string, migrate bool) (*sql.DB, error),
+	) runner.StoreFactory {
+		return func() (runner.Store, error) {
+			db, err := factory(dsns[name], appName, false)
+			if err != nil {
+				return nil, err
+			}
+
+			return store.NewWithDB(db, schema.MigrationsTableName, operations), nil
+		}
+	}
+
+
+
+
+	storeFactoryMap := map[string]runner.StoreFactory{
+		"frontend":     makeFactory("frontend", schemas.Frontend, NewFrontendDB),
+		"codeintel":    makeFactory("codeintel", schemas.CodeIntel, NewCodeIntelDB),
+		"codeinsights": makeFactory("codeinsights", schemas.CodeInsights, NewCodeInsightsDB),
+	}
+
+	return runner.NewRunner(storeFactoryMap)
+}
+
+
+

--- a/internal/database/connections/runner.go
+++ b/internal/database/connections/runner.go
@@ -9,7 +9,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
-
 func NewDefaultRunner(dsns map[string]string, appName string, observationContext *observation.Context) *runner.Runner {
 	operations := store.NewOperations(observationContext)
 	makeFactory := func(
@@ -27,9 +26,6 @@ func NewDefaultRunner(dsns map[string]string, appName string, observationContext
 		}
 	}
 
-
-
-
 	storeFactoryMap := map[string]runner.StoreFactory{
 		"frontend":     makeFactory("frontend", schemas.Frontend, NewFrontendDB),
 		"codeintel":    makeFactory("codeintel", schemas.CodeIntel, NewCodeIntelDB),
@@ -38,6 +34,3 @@ func NewDefaultRunner(dsns map[string]string, appName string, observationContext
 
 	return runner.NewRunner(storeFactoryMap)
 }
-
-
-

--- a/internal/database/dbconn/connect.go
+++ b/internal/database/dbconn/connect.go
@@ -9,18 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 )
 
-// ConnectRawForTestDatabase connects to the given data source and returns the handle. After successful
-// connection, the schema version of the database will be compared against an expected version and the
-// supplied migrations may be run (taking an advisory lock to ensure exclusive access).
-//
-// This function returns a basestore-style callback that closes the database. This should be called instead
-// of calling Close directly on the database handle as it also handles closing migration objects associated
-// with the handle.
-func ConnectRawForTestDatabase(dsn string, schemas ...*schemas.Schema) (*sql.DB, func(err error) error, error) {
-	return connect(dsn, "", "", schemas)
-}
-
-// Connect to the given data source and return the handle. After successful connection, the schema version
+// ConnectInternal connects to the given data source and return the handle. After successful connection, the schema version
 // of the database will be compared against an expected version and the supplied migrations may be run
 // (taking an advisory lock to ensure exclusive access).
 //
@@ -37,7 +26,7 @@ func ConnectRawForTestDatabase(dsn string, schemas ...*schemas.Schema) (*sql.DB,
 //
 // Note: github.com/jackc/pgx parses the environment as well. This function will also use the value
 // of PGDATASOURCE if supplied and dataSource is the empty string.
-func connect(dsn, appName, dbName string, schemas []*schemas.Schema) (*sql.DB, func(err error) error, error) {
+func ConnectInternal(dsn, appName, dbName string, schemas []*schemas.Schema) (*sql.DB, func(err error) error, error) {
 	cfg, err := buildConfig(dsn, appName)
 	if err != nil {
 		return nil, nil, err

--- a/internal/database/dbconn/connect.go
+++ b/internal/database/dbconn/connect.go
@@ -9,9 +9,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 )
 
-// ConnectInternal connects to the given data source and return the handle. After successful connection, the schema version
-// of the database will be compared against an expected version and the supplied migrations may be run
-// (taking an advisory lock to ensure exclusive access).
+// ConnectInternal connects to the given data source and return the handle. After successful connection,
+// the schema version of the database will be compared against an expected version and the supplied migrations
+// may be run (taking an advisory lock to ensure exclusive access).
 //
 // This function returns a basestore-style callback that closes the database. This should be called
 // instead of calling Close directly on the database handle as it also handles closing migration objects

--- a/internal/database/dbtest/dbtest.go
+++ b/internal/database/dbtest/dbtest.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/lib/pq"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/connections"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 )
 
@@ -176,11 +176,22 @@ func dbConn(t testing.TB, cfg *url.URL) *sql.DB {
 
 func dbConnInternal(t testing.TB, cfg *url.URL, schemas []*schemas.Schema) (*sql.DB, func(err error) error) {
 	t.Helper()
-	db, close, err := connections.NewTestDB(cfg.String(), schemas...)
+	db, close, err := newTestDB(cfg.String(), schemas...)
 	if err != nil {
 		t.Fatalf("failed to connect to database %q: %s", cfg, err)
 	}
 	return db, close
+}
+
+// newTestDB connects to the given data source and returns the handle. After successful connection, the
+// schema version of the database will be compared against an expected version and the supplied migrations
+// may be run (taking an advisory lock to ensure exclusive access).
+//
+// This function returns a basestore-style callback that closes the database. This should be called instead
+// of calling Close directly on the database handle as it also handles closing migration objects associated
+// with the handle.
+func newTestDB(dsn string, schemas ...*schemas.Schema) (*sql.DB, func(err error) error, error) {
+	return dbconn.ConnectInternal(dsn, "", "", schemas)
 }
 
 func dbExec(t testing.TB, db *sql.DB, q string, args ...interface{}) {

--- a/internal/database/dbtest/dbtest.go
+++ b/internal/database/dbtest/dbtest.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/lib/pq"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database/connections"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 )
 
@@ -176,7 +176,7 @@ func dbConn(t testing.TB, cfg *url.URL) *sql.DB {
 
 func dbConnInternal(t testing.TB, cfg *url.URL, schemas []*schemas.Schema) (*sql.DB, func(err error) error) {
 	t.Helper()
-	db, close, err := dbconn.ConnectRawForTestDatabase(cfg.String(), schemas...)
+	db, close, err := connections.NewTestDB(cfg.String(), schemas...)
 	if err != nil {
 		t.Fatalf("failed to connect to database %q: %s", cfg, err)
 	}

--- a/internal/database/dbtest/dbtest_fast.go
+++ b/internal/database/dbtest/dbtest_fast.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/lib/pq"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database/connections"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 )
 
@@ -202,7 +202,7 @@ func urlWithDB(u *url.URL, dbName string) *url.URL {
 }
 
 func newPoolFromURL(u *url.URL) (_ *testDatabasePool, _ func(err error) error, err error) {
-	db, closeDB, err := dbconn.ConnectRawForTestDatabase(u.String())
+	db, closeDB, err := connections.NewTestDB(u.String())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -213,7 +213,7 @@ func newPoolFromURL(u *url.URL) (_ *testDatabasePool, _ func(err error) error, e
 	_, _ = db.Exec("CREATE DATABASE dbtest_pool")
 
 	poolDBURL := urlWithDB(u, "dbtest_pool")
-	poolDB, closePoolDB, err := dbconn.ConnectRawForTestDatabase(poolDBURL.String())
+	poolDB, closePoolDB, err := connections.NewTestDB(poolDBURL.String())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -230,7 +230,7 @@ func newPoolFromURL(u *url.URL) (_ *testDatabasePool, _ func(err error) error, e
 			return nil, nil, err
 		}
 
-		poolDB, closePoolDB, err = dbconn.ConnectRawForTestDatabase(poolDBURL.String())
+		poolDB, closePoolDB, err = connections.NewTestDB(poolDBURL.String())
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/database/dbtest/dbtest_fast.go
+++ b/internal/database/dbtest/dbtest_fast.go
@@ -11,7 +11,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/lib/pq"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/connections"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 )
 
@@ -202,7 +201,7 @@ func urlWithDB(u *url.URL, dbName string) *url.URL {
 }
 
 func newPoolFromURL(u *url.URL) (_ *testDatabasePool, _ func(err error) error, err error) {
-	db, closeDB, err := connections.NewTestDB(u.String())
+	db, closeDB, err := newTestDB(u.String())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -213,7 +212,7 @@ func newPoolFromURL(u *url.URL) (_ *testDatabasePool, _ func(err error) error, e
 	_, _ = db.Exec("CREATE DATABASE dbtest_pool")
 
 	poolDBURL := urlWithDB(u, "dbtest_pool")
-	poolDB, closePoolDB, err := connections.NewTestDB(poolDBURL.String())
+	poolDB, closePoolDB, err := newTestDB(poolDBURL.String())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -230,7 +229,7 @@ func newPoolFromURL(u *url.URL) (_ *testDatabasePool, _ func(err error) error, e
 			return nil, nil, err
 		}
 
-		poolDB, closePoolDB, err = connections.NewTestDB(poolDBURL.String())
+		poolDB, closePoolDB, err = newTestDB(poolDBURL.String())
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/database/dbtest/pool.go
+++ b/internal/database/dbtest/pool.go
@@ -15,7 +15,6 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/connections"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 )
@@ -192,7 +191,7 @@ func (t *testDatabasePool) GetTemplate(ctx context.Context, u *url.URL, schemas 
 		return nil, errors.Wrap(err, "create template database")
 	}
 
-	_, closeTemplateDB, err := connections.NewTestDB(urlWithDB(u, tdb.Name).String(), schemas...)
+	_, closeTemplateDB, err := newTestDB(urlWithDB(u, tdb.Name).String(), schemas...)
 	if err != nil {
 		return nil, errors.Wrap(err, "migrate template DB")
 	}

--- a/internal/database/dbtest/pool.go
+++ b/internal/database/dbtest/pool.go
@@ -15,7 +15,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database/connections"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 )
@@ -192,7 +192,7 @@ func (t *testDatabasePool) GetTemplate(ctx context.Context, u *url.URL, schemas 
 		return nil, errors.Wrap(err, "create template database")
 	}
 
-	_, closeTemplateDB, err := dbconn.ConnectRawForTestDatabase(urlWithDB(u, tdb.Name).String(), schemas...)
+	_, closeTemplateDB, err := connections.NewTestDB(urlWithDB(u, tdb.Name).String(), schemas...)
 	if err != nil {
 		return nil, errors.Wrap(err, "migrate template DB")
 	}


### PR DESCRIPTION
This reorganization is necessary to prevent a future cyclic import when we use the migration runner instead of golang-migrate for dbconn/New* methods.