### PR TITLE
Make postgres exporter config pretty

### DIFF
--- a/docker-images/postgres_exporter/config/01_broken_indexes.yaml
+++ b/docker-images/postgres_exporter/config/01_broken_indexes.yaml
@@ -17,11 +17,11 @@ pg_invalid_index:
         NOT EXISTS (SELECT 1 FROM pg_stat_progress_create_index pci WHERE pci.index_relid = pi.indexrelid)
   metrics:
     - datname:
-        usage: LABEL
-        description: Name of current database
+        usage: "LABEL"
+        description: "Name of current database"
     - relname:
-        usage: LABEL
-        description: Name of the index
+        usage: "LABEL"
+        description: "Name of the index"
     - count:
-        usage: COUNTER
-        description: Non-zero value used to tag existence of an invalid index
+        usage: "COUNTER"
+        description: "Non-zero value used to tag existence of an invalid index"


### PR DESCRIPTION
~~Postgres exporter expects usage fields on config to be quoted~~
Make Postgres exporter config pretty. 

Still need to do some further investigation if these queries matter but this will at least stop others from thinking it may be a format issues



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
