### PR TITLE
codeintel: Fix line highlighting

### DIFF
--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -19,6 +19,7 @@ import {
 import {
     catchError,
     concatMap,
+    delay,
     distinctUntilChanged,
     filter,
     first,
@@ -345,6 +346,8 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
             () =>
                 locationPositions.pipe(
                     withLatestFrom(codeViewElements.pipe(filter(isDefined))),
+                    // Waits until React has finished `dangerouslySetInnerHTML`.
+                    delay(0),
                     tap(([position, codeView]) => {
                         const codeCells = getCodeElementsInRange({
                             codeView,

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -19,7 +19,6 @@ import {
 import {
     catchError,
     concatMap,
-    delay,
     distinctUntilChanged,
     filter,
     first,
@@ -340,14 +339,15 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
         )
     )
 
+    // Trigger line highlighting after React has finished putting new lines into the DOM via
+    // `dangerouslySetInnerHTML`.
+    useEffect(() => codeViewElements.next(codeViewReference.current))
+
     // Line highlighting when position in hash changes
     useObservable(
         useMemo(
             () =>
-                locationPositions.pipe(
-                    withLatestFrom(codeViewElements.pipe(filter(isDefined))),
-                    // Waits until React has finished `dangerouslySetInnerHTML`.
-                    delay(0),
+                combineLatest([locationPositions, codeViewElements.pipe(filter(isDefined))]).pipe(
                     tap(([position, codeView]) => {
                         const codeCells = getCodeElementsInRange({
                             codeView,


### PR DESCRIPTION
Prior to this change, we would highlight a line **before** React had finished `dangerouslySetInnerHTML`, and the highlighted line would get overwritten.

This also triggers line highlighting after each render so that we highlight the new line that React put in the DOM.

More discussion in [Slack](https://sourcegraph.slack.com/archives/C01C3NCGD40/p1638840724141100).