### PR TITLE
gitserver: bump git to >=2.30

### DIFF
--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -35,7 +35,7 @@ RUN apk add --no-cache \
     # We require git>=2.30 because we use git maintenance.
     'git>=2.30' \
     git-p4 \
-    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.13/main  \
+    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
     && apk add --no-cache \
     openssh-client \
     python2 \

--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -35,6 +35,7 @@ RUN apk add --no-cache \
     # We require git>=2.30 because we use git maintenance.
     'git>=2.30' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
     git-p4 \
+    && apk add --no-cache  \
     openssh-client \
     python2 \
     python3

--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -33,9 +33,14 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
     # Gitserver requires Git protocol v2 https://github.com/sourcegraph/sourcegraph/issues/13168
-    'git>=2.18' \
-    openssh-client \
+    git \
     git-p4 \
+    --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
+
+
+# hadolint ignore=DL3018
+RUN apk add --no-cache \
+    openssh-client \
     python2 \
     python3
 

--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -33,10 +33,8 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
     # We require git>=2.30 because we use git maintenance.
-    'git>=2.30' \
+    'git>=2.30' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
     git-p4 \
-    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
-    && apk add --no-cache \
     openssh-client \
     python2 \
     python3

--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -35,7 +35,7 @@ RUN apk add --no-cache \
     # We require git>=2.30 because we use git maintenance.
     'git>=2.30' \
     git-p4 \
-    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main  \
+    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.13/main  \
     && apk add --no-cache \
     openssh-client \
     python2 \

--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -32,14 +32,11 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
-    # Gitserver requires Git protocol v2 https://github.com/sourcegraph/sourcegraph/issues/13168
-    git \
+    # We require git>=2.30 because we use git maintenance.
+    'git>=2.30' \
     git-p4 \
-    --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
-
-
-# hadolint ignore=DL3018
-RUN apk add --no-cache \
+    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main  \
+    && apk add --no-cache \
     openssh-client \
     python2 \
     python3

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -37,7 +37,7 @@ RUN apk add --no-cache -verbose \
     # We require git>=2.30 because we use git maintenance.
     'git>=2.30' \
     git-p4 \
-    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.13/main  \
+    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
     && apk add --no-cache --verbose \
     # NOTE that the Postgres version we run is different
     # from our *Minimum Supported Version* which alone dictates

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -33,14 +33,12 @@ LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
 # hadolint ignore=DL3018
-RUN apk add --no-cache \
-    # Gitserver requires Git protocol v2 https://github.com/sourcegraph/sourcegraph/issues/13168
-    git \
+RUN apk add --no-cache -verbose \
+    # We require git>=2.30 because we use git maintenance.
+    'git>=2.30' \
     git-p4 \
-    --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
-
-# hadolint ignore=DL3018
-RUN apk update && apk add --no-cache --verbose \
+    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main  \
+    && apk add --no-cache --verbose \
     # NOTE that the Postgres version we run is different
     # from our *Minimum Supported Version* which alone dictates
     # the features we can depend on. See this link for more information:

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -35,9 +35,8 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 # hadolint ignore=DL3018
 RUN apk add --no-cache --verbose \
     # We require git>=2.30 because we use git maintenance.
-    'git>=2.30' \
+    'git>=2.30' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
     git-p4 \
-    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
     # NOTE that the Postgres version we run is different
     # from our *Minimum Supported Version* which alone dictates
     # the features we can depend on. See this link for more information:

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -35,12 +35,14 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 # hadolint ignore=DL3018
 RUN apk add --no-cache --verbose \
     # We require git>=2.30 because we use git maintenance.
-    'git>=2.30' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
+    'git>=2.30' \
     git-p4 \
+    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
     # NOTE that the Postgres version we run is different
     # from our *Minimum Supported Version* which alone dictates
     # the features we can depend on. See this link for more information:
     # https://github.com/sourcegraph/sourcegraph/blob/main/doc/dev/postgresql.md#version-requirements
+    && apk add --no-cache --verbose \
     'bash=5.0.17-r0' \
     'redis=~5.0' \
     python2 \

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -33,6 +33,13 @@ LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
 # hadolint ignore=DL3018
+RUN apk add --no-cache \
+    # Gitserver requires Git protocol v2 https://github.com/sourcegraph/sourcegraph/issues/13168
+    git \
+    git-p4 \
+    --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
+
+# hadolint ignore=DL3018
 RUN apk update && apk add --no-cache --verbose \
     # NOTE that the Postgres version we run is different
     # from our *Minimum Supported Version* which alone dictates
@@ -40,9 +47,6 @@ RUN apk update && apk add --no-cache --verbose \
     # https://github.com/sourcegraph/sourcegraph/blob/main/doc/dev/postgresql.md#version-requirements
     'bash=5.0.17-r0' \
     'redis=~5.0' \
-    # Gitserver requires Git protocol v2 https://github.com/sourcegraph/sourcegraph/issues/13168
-    'git>=2.18' \
-    git-p4 \
     python2 \
     python3 \
     'nginx>=1.18.0' openssh-client pcre sqlite-libs su-exec 'nodejs-current=14.5.0-r0' \

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -33,12 +33,11 @@ LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
 # hadolint ignore=DL3018
-RUN apk add --no-cache -verbose \
+RUN apk add --no-cache --verbose \
     # We require git>=2.30 because we use git maintenance.
     'git>=2.30' \
     git-p4 \
     --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
-    && apk add --no-cache --verbose \
     # NOTE that the Postgres version we run is different
     # from our *Minimum Supported Version* which alone dictates
     # the features we can depend on. See this link for more information:

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -37,7 +37,7 @@ RUN apk add --no-cache -verbose \
     # We require git>=2.30 because we use git maintenance.
     'git>=2.30' \
     git-p4 \
-    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main  \
+    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.13/main  \
     && apk add --no-cache --verbose \
     # NOTE that the Postgres version we run is different
     # from our *Minimum Supported Version* which alone dictates


### PR DESCRIPTION
This udpates gitserver and server images with newer versions of git and git-p4. We
want to use git>=2.30 to experiment with git maintenance.

This is a workaround for #28176  to unblock #28224.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
