### PR TITLE
Allow non-admins to use SSBC

### DIFF
--- a/enterprise/cmd/frontend/internal/batches/resolvers/apitest/types.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/apitest/types.go
@@ -225,6 +225,12 @@ type BatchSpec struct {
 	FailureMessage string
 }
 
+type BatchSpecConnection struct {
+	Nodes      []BatchSpec
+	TotalCount int
+	PageInfo   PageInfo
+}
+
 type BatchSpecWorkspaceResolution struct {
 	State string
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec.go
@@ -175,7 +175,10 @@ func (r *batchSpecResolver) ApplyURL(ctx context.Context) (*string, error) {
 		// 🚨 SECURITY: If the user didn't create the batch spec or is not a
 		// site-admin, we shouldn't show this information.
 		ok, err := r.computeCanAdminister(ctx)
-		if err != nil || !ok {
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
 			return nil, nil
 		}
 
@@ -378,7 +381,10 @@ func (r *batchSpecResolver) StartedAt(ctx context.Context) (*graphqlbackend.Date
 	// 🚨 SECURITY: If the user didn't create the batch spec or is not a
 	// site-admin, we shouldn't show this information.
 	ok, err := r.computeCanAdminister(ctx)
-	if err != nil || !ok {
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
 		return nil, nil
 	}
 
@@ -410,7 +416,10 @@ func (r *batchSpecResolver) FinishedAt(ctx context.Context) (*graphqlbackend.Dat
 	// 🚨 SECURITY: If the user didn't create the batch spec or is not a
 	// site-admin, we shouldn't show this information.
 	ok, err := r.computeCanAdminister(ctx)
-	if err != nil || !ok {
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
 		return nil, nil
 	}
 
@@ -438,7 +447,10 @@ func (r *batchSpecResolver) FailureMessage(ctx context.Context) (*string, error)
 	// 🚨 SECURITY: If the user didn't create the batch spec or is not a
 	// site-admin, we shouldn't show this information.
 	ok, err := r.computeCanAdminister(ctx)
-	if err != nil || !ok {
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
 		return nil, nil
 	}
 
@@ -512,7 +524,10 @@ func (r *batchSpecResolver) WorkspaceResolution(ctx context.Context) (graphqlbac
 	// 🚨 SECURITY: If the user didn't create the batch spec or is not a
 	// site-admin, we shouldn't show this information.
 	ok, err := r.computeCanAdminister(ctx)
-	if err != nil || !ok {
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
 		return nil, nil
 	}
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec.go
@@ -375,6 +375,13 @@ func (r *batchSpecResolver) StartedAt(ctx context.Context) (*graphqlbackend.Date
 		return nil, nil
 	}
 
+	// 🚨 SECURITY: If the user didn't create the batch spec or is not a
+	// site-admin, we shouldn't show this information.
+	ok, err := r.computeCanAdminister(ctx)
+	if err != nil || !ok {
+		return nil, nil
+	}
+
 	state, err := r.computeState(ctx)
 	if err != nil {
 		return nil, err
@@ -397,6 +404,13 @@ func (r *batchSpecResolver) StartedAt(ctx context.Context) (*graphqlbackend.Date
 
 func (r *batchSpecResolver) FinishedAt(ctx context.Context) (*graphqlbackend.DateTime, error) {
 	if !r.batchSpec.CreatedFromRaw {
+		return nil, nil
+	}
+
+	// 🚨 SECURITY: If the user didn't create the batch spec or is not a
+	// site-admin, we shouldn't show this information.
+	ok, err := r.computeCanAdminister(ctx)
+	if err != nil || !ok {
 		return nil, nil
 	}
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_connection.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_connection.go
@@ -38,7 +38,8 @@ func (r *batchSpecConnectionResolver) Nodes(ctx context.Context) ([]graphqlbacke
 
 func (r *batchSpecConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
 	count, err := r.store.CountBatchSpecs(ctx, store.CountBatchSpecsOpts{
-		BatchChangeID: r.opts.BatchChangeID,
+		BatchChangeID:                       r.opts.BatchChangeID,
+		ExcludeCreatedFromRawNotOwnedByUser: r.opts.ExcludeCreatedFromRawNotOwnedByUser,
 	})
 	return int32(count), err
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_test.go
@@ -484,7 +484,7 @@ func TestBatchSpecResolver_BatchSpecCreatedFromRaw(t *testing.T) {
 	queryAndAssertBatchSpec(t, userCtx, s, apiID, true, want)
 
 	// PERMISSIONS: Now we view the same batch spec but as another non-admin user.
-	// First, eeset state so that all fields should return something when viewed with
+	// First, reset state so that all fields should return something when viewed with
 	// correct permissions.
 	jobs[0].FinishedAt = minAgo(9)
 	setJobCompleted(t, ctx, bstore, jobs[0])

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_test.go
@@ -334,7 +334,7 @@ func TestBatchSpecResolver_BatchSpecCreatedFromRaw(t *testing.T) {
 		},
 	}
 
-	queryAndAssertBatchSpec(t, userCtx, s, apiID, true, want)
+	queryAndAssertBatchSpec(t, userCtx, s, apiID, want)
 
 	// Complete the workspace resolution
 	var workspaces []*btypes.BatchSpecWorkspace
@@ -348,7 +348,7 @@ func TestBatchSpecResolver_BatchSpecCreatedFromRaw(t *testing.T) {
 
 	setResolutionJobState(t, ctx, bstore, resolutionJob, btypes.BatchSpecResolutionJobStateCompleted)
 	want.WorkspaceResolution.State = btypes.BatchSpecResolutionJobStateCompleted.ToGraphQL()
-	queryAndAssertBatchSpec(t, userCtx, s, apiID, true, want)
+	queryAndAssertBatchSpec(t, userCtx, s, apiID, want)
 
 	// Now enqueue jobs
 	var jobs []*btypes.BatchSpecWorkspaceExecutionJob
@@ -361,26 +361,26 @@ func TestBatchSpecResolver_BatchSpecCreatedFromRaw(t *testing.T) {
 	}
 
 	want.State = "QUEUED"
-	queryAndAssertBatchSpec(t, userCtx, s, apiID, true, want)
+	queryAndAssertBatchSpec(t, userCtx, s, apiID, want)
 
 	// 1/3 jobs processing
 	jobs[1].StartedAt = minAgo(99)
 	setJobProcessing(t, ctx, bstore, jobs[1])
 	want.State = "PROCESSING"
 	want.StartedAt = graphqlbackend.DateTime{Time: jobs[1].StartedAt}
-	queryAndAssertBatchSpec(t, userCtx, s, apiID, true, want)
+	queryAndAssertBatchSpec(t, userCtx, s, apiID, want)
 
 	// 3/3 processing
 	setJobProcessing(t, ctx, bstore, jobs[0])
 	setJobProcessing(t, ctx, bstore, jobs[2])
 	// Expect same state
-	queryAndAssertBatchSpec(t, userCtx, s, apiID, true, want)
+	queryAndAssertBatchSpec(t, userCtx, s, apiID, want)
 
 	// 1/3 jobs complete, 2/3 processing
 	jobs[2].FinishedAt = minAgo(30)
 	setJobCompleted(t, ctx, bstore, jobs[2])
 	// Expect same state
-	queryAndAssertBatchSpec(t, userCtx, s, apiID, true, want)
+	queryAndAssertBatchSpec(t, userCtx, s, apiID, want)
 
 	// 3/3 jobs complete
 	jobs[0].FinishedAt = minAgo(9)
@@ -390,7 +390,7 @@ func TestBatchSpecResolver_BatchSpecCreatedFromRaw(t *testing.T) {
 	want.State = "COMPLETED"
 	want.ApplyURL = &applyUrl
 	want.FinishedAt = graphqlbackend.DateTime{Time: jobs[0].FinishedAt}
-	queryAndAssertBatchSpec(t, userCtx, s, apiID, true, want)
+	queryAndAssertBatchSpec(t, userCtx, s, apiID, want)
 
 	// 1/3 jobs is failed, 2/3 completed
 	message1 := "failure message"
@@ -400,7 +400,7 @@ func TestBatchSpecResolver_BatchSpecCreatedFromRaw(t *testing.T) {
 	want.FailureMessage = fmt.Sprintf("Failures:\n\n* %s\n", message1)
 	// We still want users to be able to apply batch specs that executed with errors
 	want.ApplyURL = &applyUrl
-	queryAndAssertBatchSpec(t, userCtx, s, apiID, true, want)
+	queryAndAssertBatchSpec(t, userCtx, s, apiID, want)
 
 	// 1/3 jobs is failed, 2/3 still processing
 	setJobProcessing(t, ctx, bstore, jobs[0])
@@ -408,7 +408,7 @@ func TestBatchSpecResolver_BatchSpecCreatedFromRaw(t *testing.T) {
 	want.State = "PROCESSING"
 	want.FinishedAt = graphqlbackend.DateTime{}
 	want.ApplyURL = nil
-	queryAndAssertBatchSpec(t, userCtx, s, apiID, true, want)
+	queryAndAssertBatchSpec(t, userCtx, s, apiID, want)
 
 	// 3/3 jobs canceling and processing
 	setJobCanceling(t, ctx, bstore, jobs[0])
@@ -417,7 +417,7 @@ func TestBatchSpecResolver_BatchSpecCreatedFromRaw(t *testing.T) {
 
 	want.State = "CANCELING"
 	want.FailureMessage = ""
-	queryAndAssertBatchSpec(t, userCtx, s, apiID, true, want)
+	queryAndAssertBatchSpec(t, userCtx, s, apiID, want)
 
 	// 3/3 canceling and failed
 	jobs[0].FinishedAt = minAgo(9)
@@ -435,7 +435,7 @@ func TestBatchSpecResolver_BatchSpecCreatedFromRaw(t *testing.T) {
 * canceled
 * canceled
 `
-	queryAndAssertBatchSpec(t, userCtx, s, apiID, true, want)
+	queryAndAssertBatchSpec(t, userCtx, s, apiID, want)
 
 	// 1/3 jobs is failed, 2/3 completed, but produced invalid changeset specs
 	jobs[0].FinishedAt = minAgo(9)
@@ -481,42 +481,22 @@ func TestBatchSpecResolver_BatchSpecCreatedFromRaw(t *testing.T) {
 	}
 	want.AllCodeHosts = codeHosts
 	want.OnlyWithoutCredential = codeHosts
-	queryAndAssertBatchSpec(t, userCtx, s, apiID, true, want)
+	queryAndAssertBatchSpec(t, userCtx, s, apiID, want)
 
 	// PERMISSIONS: Now we view the same batch spec but as another non-admin user.
-	// First, reset state so that all fields should return something when viewed with
-	// correct permissions.
-	jobs[0].FinishedAt = minAgo(9)
-	setJobCompleted(t, ctx, bstore, jobs[0])
-	jobs[1].FailureMessage = &message1
-	setJobFailed(t, ctx, bstore, jobs[1])
-	jobs[2].FinishedAt = minAgo(30)
-	setJobCompleted(t, ctx, bstore, jobs[2])
-
-	// Here's the fields we expect:
-	want.State = "FAILED"
-	want.FailureMessage = ""
-	want.ApplyURL = nil
-	want.WorkspaceResolution = apitest.BatchSpecWorkspaceResolution{}
-	want.FinishedAt = graphqlbackend.DateTime{}
-	want.StartedAt = graphqlbackend.DateTime{}
-	want.ViewerCanAdminister = false
-	// Because we can't query other user's details, we don't expect to get
-	// user-info/namespaces back:
-	want.Creator = nil
-	want.Namespace = apitest.UserOrg{}
-
+	// We want to response to be a 404, so an empty BatchSpec
+	want = apitest.BatchSpec{}
 	// Now we can query
 	otherUser := ct.CreateTestUser(t, db, false)
 	otherUserCtx := actor.WithActor(ctx, actor.FromUser(otherUser.ID))
 
-	queryAndAssertBatchSpec(t, otherUserCtx, s, apiID, false, want)
+	queryAndAssertBatchSpec(t, otherUserCtx, s, apiID, want)
 }
 
-func queryAndAssertBatchSpec(t *testing.T, ctx context.Context, s *graphql.Schema, id string, includeNamespace bool, want apitest.BatchSpec) {
+func queryAndAssertBatchSpec(t *testing.T, ctx context.Context, s *graphql.Schema, id string, want apitest.BatchSpec) {
 	t.Helper()
 
-	input := map[string]interface{}{"batchSpec": id, "includeNamespace": includeNamespace}
+	input := map[string]interface{}{"batchSpec": id}
 
 	var response struct{ Node apitest.BatchSpec }
 
@@ -612,7 +592,7 @@ const queryBatchSpecNode = `
 fragment u on User { id, databaseID, siteAdmin }
 fragment o on Org  { id, name }
 
-query($batchSpec: ID!, $includeNamespace: Boolean = true) {
+query($batchSpec: ID!) {
   node(id: $batchSpec) {
     __typename
 
@@ -621,8 +601,8 @@ query($batchSpec: ID!, $includeNamespace: Boolean = true) {
       originalInput
       parsedInput
 
-      creator  @include(if: $includeNamespace) { ...u }
-      namespace @include(if: $includeNamespace) {
+      creator { ...u }
+      namespace {
         ... on User { ...u }
         ... on Org  { ...o }
       }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/permissions_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/permissions_test.go
@@ -681,6 +681,10 @@ func TestPermissionLevels(t *testing.T) {
 					}`, userID)
 				},
 			},
+			// TODO: Add tests for "CreateBatchSpecFromRaw"
+			// TODO: Add tests for "ExecuteBatchSpec"
+			// TODO: Add tests for "ReplaceBatchSpecInput"
+			// TODO: Add tests for "RetryBatchSpecWorkspaceExecution"
 		}
 
 		for _, m := range mutations {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/permissions_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/permissions_test.go
@@ -121,9 +121,12 @@ func TestPermissionLevels(t *testing.T) {
 	createBatchSpecFromRaw := func(t *testing.T, s *store.Store, userID int32) (randID string, id int64) {
 		t.Helper()
 
+		// userCtx causes CreateBatchSpecFromRaw to set batchSpec.UserID to userID
+		userCtx := actor.WithActor(ctx, actor.FromUser(userID))
+
 		// We're using the service method here since it also creates a resolution job
 		svc := service.New(s)
-		spec, err := svc.CreateBatchSpecFromRaw(actor.WithInternalActor(ctx), service.CreateBatchSpecFromRawOpts{
+		spec, err := svc.CreateBatchSpecFromRaw(userCtx, service.CreateBatchSpecFromRawOpts{
 			RawSpec:         ct.TestRawBatchSpecYAML,
 			NamespaceUserID: userID,
 		})
@@ -543,6 +546,7 @@ func TestPermissionLevels(t *testing.T) {
 
 			for _, tc := range tests {
 				t.Run(tc.name, func(t *testing.T) {
+					fmt.Println("------------------" + tc.name)
 					_, batchSpecID := createBatchSpecFromRaw(t, cstore, tc.user)
 					workspaceID := createBatchSpecWorkspace(t, cstore, batchSpecID)
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/permissions_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/permissions_test.go
@@ -1506,7 +1506,7 @@ func assertAuthorizationResponse(
 	userID int32,
 	restrictToAdmins, wantDisabledErr, wantAuthErr bool,
 ) {
-	// t.Helper()
+	t.Helper()
 
 	actorCtx := actor.WithActor(ctx, actor.FromUser(userID))
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/permissions_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/permissions_test.go
@@ -664,72 +664,78 @@ func TestPermissionLevels(t *testing.T) {
 	t.Run("batch change mutations", func(t *testing.T) {
 		mutations := []struct {
 			name         string
-			mutationFunc func(batchChangeID, changesetID, batchSpecID string) string
+			mutationFunc func(userID, batchChangeID, changesetID, batchSpecID string) string
 		}{
 			{
 				name: "createBatchChange",
-				mutationFunc: func(batchChangeID, changesetID, batchSpecID string) string {
+				mutationFunc: func(userID, batchChangeID, changesetID, batchSpecID string) string {
 					return fmt.Sprintf(`mutation { createBatchChange(batchSpec: %q) { id } }`, batchSpecID)
 				},
 			},
 			{
 				name: "closeBatchChange",
-				mutationFunc: func(batchChangeID, changesetID, batchSpecID string) string {
+				mutationFunc: func(userID, batchChangeID, changesetID, batchSpecID string) string {
 					return fmt.Sprintf(`mutation { closeBatchChange(batchChange: %q, closeChangesets: false) { id } }`, batchChangeID)
 				},
 			},
 			{
 				name: "deleteBatchChange",
-				mutationFunc: func(batchChangeID, changesetID, batchSpecID string) string {
+				mutationFunc: func(userID, batchChangeID, changesetID, batchSpecID string) string {
 					return fmt.Sprintf(`mutation { deleteBatchChange(batchChange: %q) { alwaysNil } } `, batchChangeID)
 				},
 			},
 			{
 				name: "syncChangeset",
-				mutationFunc: func(batchChangeID, changesetID, batchSpecID string) string {
+				mutationFunc: func(userID, batchChangeID, changesetID, batchSpecID string) string {
 					return fmt.Sprintf(`mutation { syncChangeset(changeset: %q) { alwaysNil } }`, changesetID)
 				},
 			},
 			{
 				name: "reenqueueChangeset",
-				mutationFunc: func(batchChangeID, changesetID, batchSpecID string) string {
+				mutationFunc: func(userID, batchChangeID, changesetID, batchSpecID string) string {
 					return fmt.Sprintf(`mutation { reenqueueChangeset(changeset: %q) { id } }`, changesetID)
 				},
 			},
 			{
 				name: "applyBatchChange",
-				mutationFunc: func(batchChangeID, changesetID, batchSpecID string) string {
+				mutationFunc: func(userID, batchChangeID, changesetID, batchSpecID string) string {
 					return fmt.Sprintf(`mutation { applyBatchChange(batchSpec: %q) { id } }`, batchSpecID)
 				},
 			},
 			{
 				name: "moveBatchChange",
-				mutationFunc: func(batchChangeID, changesetID, batchSpecID string) string {
+				mutationFunc: func(userID, batchChangeID, changesetID, batchSpecID string) string {
 					return fmt.Sprintf(`mutation { moveBatchChange(batchChange: %q, newName: "foobar") { id } }`, batchChangeID)
 				},
 			},
 			{
 				name: "createChangesetComments",
-				mutationFunc: func(batchChangeID, changesetID, batchSpecID string) string {
+				mutationFunc: func(userID, batchChangeID, changesetID, batchSpecID string) string {
 					return fmt.Sprintf(`mutation { createChangesetComments(batchChange: %q, changesets: [%q], body: "test") { id } }`, batchChangeID, changesetID)
 				},
 			},
 			{
 				name: "reenqueueChangesets",
-				mutationFunc: func(batchChangeID, changesetID, batchSpecID string) string {
+				mutationFunc: func(userID, batchChangeID, changesetID, batchSpecID string) string {
 					return fmt.Sprintf(`mutation { reenqueueChangesets(batchChange: %q, changesets: [%q]) { id } }`, batchChangeID, changesetID)
 				},
 			},
 			{
 				name: "mergeChangesets",
-				mutationFunc: func(batchChangeID, changesetID, batchSpecID string) string {
+				mutationFunc: func(userID, batchChangeID, changesetID, batchSpecID string) string {
 					return fmt.Sprintf(`mutation { mergeChangesets(batchChange: %q, changesets: [%q]) { id } }`, batchChangeID, changesetID)
 				},
 			},
 			{
 				name: "closeChangesets",
-				mutationFunc: func(batchChangeID, changesetID, batchSpecID string) string {
+				mutationFunc: func(userID, batchChangeID, changesetID, batchSpecID string) string {
 					return fmt.Sprintf(`mutation { closeChangesets(batchChange: %q, changesets: [%q]) { id } }`, batchChangeID, changesetID)
+				},
+			},
+			{
+				name: "createEmptyBatchChange",
+				mutationFunc: func(userID, batchChangeID, changesetID, batchSpecID string) string {
+					return fmt.Sprintf(`mutation { createEmptyBatchChange(namespace: %q, name: "testing") { id } }`, userID)
 				},
 			},
 		}
@@ -787,6 +793,7 @@ func TestPermissionLevels(t *testing.T) {
 							}
 
 							mutation := m.mutationFunc(
+								string(graphqlbackend.MarshalUserID(tc.batchChangeAuthor)),
 								string(marshalBatchChangeID(batchChagneID)),
 								string(marshalChangesetID(changeset.ID)),
 								string(marshalBatchSpecRandID(batchSpecRandID)),

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -225,6 +225,10 @@ func (r *Resolver) batchSpecByID(ctx context.Context, id graphql.ID) (graphqlbac
 	}
 
 	opts := store.GetBatchSpecOpts{RandID: batchSpecRandID}
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.store.DatabaseDB()); err != nil {
+		opts.ExcludeCreatedFromRawNotOwnedByUser = actor.FromContext(ctx).UID
+	}
+
 	batchSpec, err := r.store.GetBatchSpec(ctx, opts)
 	if err != nil {
 		if err == store.ErrNoResults {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -1438,6 +1438,7 @@ func (r *Resolver) BatchSpecs(ctx context.Context, args *graphqlbackend.ListBatc
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
 	}
+	// TODO: This needs to filter out BatchSpecs that were created from raw
 
 	if err := validateFirstParamDefaults(args.First); err != nil {
 		return nil, err
@@ -1494,7 +1495,8 @@ func (r *Resolver) CreateBatchSpecFromRaw(ctx context.Context, args *graphqlback
 		tr.SetError(err)
 		tr.Finish()
 	}()
-	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
+
+	if err := batchChangesCreateAccess(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
 	}
 
@@ -1512,15 +1514,6 @@ func (r *Resolver) CreateBatchSpecFromRaw(ctx context.Context, args *graphqlback
 	}
 
 	return &batchSpecResolver{store: r.store, batchSpec: batchSpec}, nil
-}
-
-func (r *Resolver) DeleteBatchSpec(ctx context.Context, args *graphqlbackend.DeleteBatchSpecArgs) (*graphqlbackend.EmptyResponse, error) {
-	// TODO(ssbc): currently admin only.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.store.DatabaseDB()); err != nil {
-		return nil, err
-	}
-	// TODO(ssbc): not implemented
-	return nil, errors.New("not implemented yet")
 }
 
 func (r *Resolver) ExecuteBatchSpec(ctx context.Context, args *graphqlbackend.ExecuteBatchSpecArgs) (_ graphqlbackend.BatchSpecResolver, err error) {
@@ -1590,15 +1583,6 @@ func (r *Resolver) CancelBatchSpecExecution(ctx context.Context, args *graphqlba
 	return &batchSpecResolver{store: r.store, batchSpec: batchSpec}, nil
 }
 
-func (r *Resolver) CancelBatchSpecWorkspaceExecution(ctx context.Context, args *graphqlbackend.CancelBatchSpecWorkspaceExecutionArgs) (*graphqlbackend.EmptyResponse, error) {
-	// TODO(ssbc): currently admin only.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.store.DatabaseDB()); err != nil {
-		return nil, err
-	}
-	// TODO(ssbc): not implemented
-	return nil, errors.New("not implemented yet")
-}
-
 func (r *Resolver) RetryBatchSpecWorkspaceExecution(ctx context.Context, args *graphqlbackend.RetryBatchSpecWorkspaceExecutionArgs) (_ *graphqlbackend.EmptyResponse, err error) {
 	tr, ctx := trace.New(ctx, "Resolver.RetryBatchSpecWorkspaceExecution", fmt.Sprintf("Workspaces: %+v", args.BatchSpecWorkspaces))
 	defer func() {
@@ -1636,33 +1620,6 @@ func (r *Resolver) RetryBatchSpecWorkspaceExecution(ctx context.Context, args *g
 	}
 
 	return &graphqlbackend.EmptyResponse{}, nil
-}
-
-func (r *Resolver) RetryBatchSpecExecution(ctx context.Context, args *graphqlbackend.RetryBatchSpecExecutionArgs) (*graphqlbackend.EmptyResponse, error) {
-	// TODO(ssbc): currently admin only.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.store.DatabaseDB()); err != nil {
-		return nil, err
-	}
-	// TODO(ssbc): not implemented
-	return nil, errors.New("not implemented yet")
-}
-
-func (r *Resolver) EnqueueBatchSpecWorkspaceExecution(ctx context.Context, args *graphqlbackend.EnqueueBatchSpecWorkspaceExecutionArgs) (*graphqlbackend.EmptyResponse, error) {
-	// TODO(ssbc): currently admin only.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.store.DatabaseDB()); err != nil {
-		return nil, err
-	}
-	// TODO(ssbc): not implemented
-	return nil, errors.New("not implemented yet")
-}
-
-func (r *Resolver) ToggleBatchSpecAutoApply(ctx context.Context, args *graphqlbackend.ToggleBatchSpecAutoApplyArgs) (graphqlbackend.BatchSpecResolver, error) {
-	// TODO(ssbc): currently admin only.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.store.DatabaseDB()); err != nil {
-		return nil, err
-	}
-	// TODO(ssbc): not implemented
-	return nil, errors.New("not implemented yet")
 }
 
 func (r *Resolver) ReplaceBatchSpecInput(ctx context.Context, args *graphqlbackend.ReplaceBatchSpecInputArgs) (_ graphqlbackend.BatchSpecResolver, err error) {
@@ -1703,6 +1660,51 @@ func (r *Resolver) ReplaceBatchSpecInput(ctx context.Context, args *graphqlbacke
 	}
 
 	return &batchSpecResolver{store: r.store, batchSpec: batchSpec}, nil
+}
+
+func (r *Resolver) CancelBatchSpecWorkspaceExecution(ctx context.Context, args *graphqlbackend.CancelBatchSpecWorkspaceExecutionArgs) (*graphqlbackend.EmptyResponse, error) {
+	// TODO(ssbc): currently admin only.
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.store.DatabaseDB()); err != nil {
+		return nil, err
+	}
+	// TODO(ssbc): not implemented
+	return nil, errors.New("not implemented yet")
+}
+
+func (r *Resolver) RetryBatchSpecExecution(ctx context.Context, args *graphqlbackend.RetryBatchSpecExecutionArgs) (*graphqlbackend.EmptyResponse, error) {
+	// TODO(ssbc): currently admin only.
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.store.DatabaseDB()); err != nil {
+		return nil, err
+	}
+	// TODO(ssbc): not implemented
+	return nil, errors.New("not implemented yet")
+}
+
+func (r *Resolver) EnqueueBatchSpecWorkspaceExecution(ctx context.Context, args *graphqlbackend.EnqueueBatchSpecWorkspaceExecutionArgs) (*graphqlbackend.EmptyResponse, error) {
+	// TODO(ssbc): currently admin only.
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.store.DatabaseDB()); err != nil {
+		return nil, err
+	}
+	// TODO(ssbc): not implemented
+	return nil, errors.New("not implemented yet")
+}
+
+func (r *Resolver) ToggleBatchSpecAutoApply(ctx context.Context, args *graphqlbackend.ToggleBatchSpecAutoApplyArgs) (graphqlbackend.BatchSpecResolver, error) {
+	// TODO(ssbc): currently admin only.
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.store.DatabaseDB()); err != nil {
+		return nil, err
+	}
+	// TODO(ssbc): not implemented
+	return nil, errors.New("not implemented yet")
+}
+
+func (r *Resolver) DeleteBatchSpec(ctx context.Context, args *graphqlbackend.DeleteBatchSpecArgs) (*graphqlbackend.EmptyResponse, error) {
+	// TODO(ssbc): currently admin only.
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.store.DatabaseDB()); err != nil {
+		return nil, err
+	}
+	// TODO(ssbc): not implemented
+	return nil, errors.New("not implemented yet")
 }
 
 func parseBatchChangeState(s *string) (btypes.BatchChangeState, error) {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -373,8 +373,9 @@ func (r *Resolver) batchSpecWorkspaceByID(ctx context.Context, gqlID graphql.ID)
 
 	// 🚨 SECURITY: Check that the requesting user is either an admin or created the spec.
 	//
-	// TODO: This needs to be changed to check for namespace access and then
-	// check repository permissions and return hidden/visible workspaces accordingly.
+	// TODO: Once we introduce finer permissoins, this needs to be changed to
+	// check for namespace access and then check repository permissions and
+	// return hidden/visible workspaces accordingly.
 	if err := backend.CheckSiteAdminOrSameUser(ctx, r.store.DatabaseDB(), spec.UserID); err != nil {
 		return nil, err
 	}
@@ -1438,11 +1439,15 @@ func (r *Resolver) BatchSpecs(ctx context.Context, args *graphqlbackend.ListBatc
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
 	}
-	// TODO: This needs to filter out BatchSpecs that were created from raw
 
 	if err := validateFirstParamDefaults(args.First); err != nil {
 		return nil, err
 	}
+
+	// TODO: We need to check whether user is site-admin. If not, we need to
+	// add an opt that filters out BatchSpecs where created_from_raw = true &&
+	// user_id != actor.UID
+
 	opts := store.ListBatchSpecsOpts{
 		LimitOpts: store.LimitOpts{
 			Limit: int(args.First),

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
@@ -94,6 +94,9 @@ func TestNullIDResilience(t *testing.T) {
 		fmt.Sprintf(`mutation { publishChangesets(batchChange: %q, changesets: []) { id } }`, marshalBatchChangeID(0)),
 		fmt.Sprintf(`mutation { publishChangesets(batchChange: %q, changesets: [%q]) { id } }`, marshalBatchChangeID(1), marshalChangesetID(0)),
 		fmt.Sprintf(`mutation { executeBatchSpec(batchSpec: %q) { id } }`, marshalBatchSpecRandID("")),
+		fmt.Sprintf(`mutation { cancelBatchSpecExecution(batchSpec: %q) { id } }`, marshalBatchSpecRandID("")),
+		fmt.Sprintf(`mutation { replaceBatchSpecInput(previousSpec: %q, batchSpec: "name: testing") { id } }`, marshalBatchSpecRandID("")),
+		fmt.Sprintf(`mutation { retryBatchSpecWorkspaceExecution(batchSpecWorkspaces: [%q]) { alwaysNil } }`, marshalBatchSpecWorkspaceID(0)),
 	}
 
 	for _, m := range mutations {

--- a/enterprise/internal/batches/store/batch_specs.go
+++ b/enterprise/internal/batches/store/batch_specs.go
@@ -180,6 +180,8 @@ DELETE FROM batch_specs WHERE id = %s
 // counting batch specs.
 type CountBatchSpecsOpts struct {
 	BatchChangeID int64
+
+	ExcludeCreatedFromRawNotOwnedByUser int32
 }
 
 // CountBatchSpecs returns the number of code mods in the database.
@@ -214,6 +216,10 @@ ON
 	AND
 	batch_changes.namespace_org_id IS NOT DISTINCT FROM batch_specs.namespace_org_id`))
 		preds = append(preds, sqlf.Sprintf("batch_changes.id = %s", opts.BatchChangeID))
+	}
+
+	if opts.ExcludeCreatedFromRawNotOwnedByUser != 0 {
+		preds = append(preds, sqlf.Sprintf("(batch_specs.user_id = %s OR batch_specs.created_from_raw IS FALSE)", opts.ExcludeCreatedFromRawNotOwnedByUser))
 	}
 
 	if len(preds) == 0 {
@@ -360,6 +366,8 @@ type ListBatchSpecsOpts struct {
 	LimitOpts
 	Cursor        int64
 	BatchChangeID int64
+
+	ExcludeCreatedFromRawNotOwnedByUser int32
 }
 
 // ListBatchSpecs lists BatchSpecs with the given filters.
@@ -411,6 +419,10 @@ ON
 	AND
 	batch_changes.namespace_org_id IS NOT DISTINCT FROM batch_specs.namespace_org_id`))
 		preds = append(preds, sqlf.Sprintf("batch_changes.id = %s", opts.BatchChangeID))
+	}
+
+	if opts.ExcludeCreatedFromRawNotOwnedByUser != 0 {
+		preds = append(preds, sqlf.Sprintf("(batch_specs.user_id = %s OR batch_specs.created_from_raw IS FALSE)", opts.ExcludeCreatedFromRawNotOwnedByUser))
 	}
 
 	return sqlf.Sprintf(

--- a/enterprise/internal/batches/store/batch_specs.go
+++ b/enterprise/internal/batches/store/batch_specs.go
@@ -237,6 +237,8 @@ ON
 type GetBatchSpecOpts struct {
 	ID     int64
 	RandID string
+
+	ExcludeCreatedFromRawNotOwnedByUser int32
 }
 
 // GetBatchSpec gets a BatchSpec matching the given options.
@@ -279,6 +281,10 @@ func getBatchSpecQuery(opts *GetBatchSpecOpts) *sqlf.Query {
 
 	if opts.RandID != "" {
 		preds = append(preds, sqlf.Sprintf("rand_id = %s", opts.RandID))
+	}
+
+	if opts.ExcludeCreatedFromRawNotOwnedByUser != 0 {
+		preds = append(preds, sqlf.Sprintf("(user_id = %s OR created_from_raw IS FALSE)", opts.ExcludeCreatedFromRawNotOwnedByUser))
 	}
 
 	if len(preds) == 0 {


### PR DESCRIPTION
This fixes the first part of #27543 by allowing users to create batch specs for execution and to also view their own batch specs.

This implements the Stage 1 described here: https://github.com/sourcegraph/sourcegraph/issues/27543#issuecomment-987912774

I want to tackle the frontend work in another PR and the cache-access too.




