### PR TITLE
Wildcard V2: `<Alert />` Implementation

### DIFF
--- a/client/web/src/enterprise/batches/close/BatchChangeCloseAlert.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeCloseAlert.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useState } from 'react'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { isErrorLike, asError } from '@sourcegraph/shared/src/util/errors'
 import { pluralize } from '@sourcegraph/shared/src/util/strings'
+import { AlertLink } from '@sourcegraph/wildcard'
 
 import { ErrorAlert } from '../../../components/alerts'
 import { Scalars } from '../../../graphql-operations'
@@ -88,12 +89,9 @@ export const BatchChangeCloseAlert: React.FunctionComponent<BatchChangeCloseAler
                     {!viewerCanAdminister && (
                         <div className="alert alert-warning">
                             You don't have permission to close this batch change. See{' '}
-                            <a
-                                className="alert-link"
-                                href="https://docs.sourcegraph.com/batch_changes/explanations/permissions_in_batch_changes"
-                            >
+                            <AlertLink to="https://docs.sourcegraph.com/batch_changes/explanations/permissions_in_batch_changes">
                                 Permissions in batch changes
-                            </a>{' '}
+                            </AlertLink>{' '}
                             for more information about the batch changes permission model.
                         </div>
                     )}

--- a/client/web/src/enterprise/batches/detail/UnpublishedNotice.tsx
+++ b/client/web/src/enterprise/batches/detail/UnpublishedNotice.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames'
 import React from 'react'
 
 import { pluralize } from '@sourcegraph/shared/src/util/strings'
+import { AlertLink } from '@sourcegraph/wildcard'
 
 interface UnpublishedNoticeProps {
     unpublished: number
@@ -21,14 +22,13 @@ export const UnpublishedNotice: React.FunctionComponent<UnpublishedNoticeProps> 
         <div className={classNames('alert alert-secondary', className)}>
             {unpublished} unpublished {pluralize('changeset', unpublished, 'changesets')}. Select changeset(s) and
             choose the 'Publish changesets' action to publish them, or{' '}
-            <a
-                className="alert-link"
-                href="https://docs.sourcegraph.com/batch_changes/how-tos/publishing_changesets#publishing-changesets"
+            <AlertLink
+                to="https://docs.sourcegraph.com/batch_changes/how-tos/publishing_changesets#publishing-changesets"
                 rel="noopener"
                 target="_blank"
             >
                 read more about publishing changesets
-            </a>
+            </AlertLink>
             .
         </div>
     )

--- a/client/web/src/enterprise/batches/detail/bulk-operations/BulkOperationNode.tsx
+++ b/client/web/src/enterprise/batches/detail/bulk-operations/BulkOperationNode.tsx
@@ -8,10 +8,9 @@ import UploadIcon from 'mdi-react/UploadIcon'
 import React from 'react'
 
 import { Link } from '@sourcegraph/shared/src/components/Link'
-import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
 import { BulkOperationState, BulkOperationType } from '@sourcegraph/shared/src/graphql-operations'
 import { pluralize } from '@sourcegraph/shared/src/util/strings'
-import { Badge } from '@sourcegraph/wildcard'
+import { Badge, AlertLink } from '@sourcegraph/wildcard'
 
 import { ErrorMessage } from '../../../../components/alerts'
 import { Collapsible } from '../../../../components/Collapsible'
@@ -108,13 +107,13 @@ export const BulkOperationNode: React.FunctionComponent<BulkOperationNodeProps> 
                                     <span className="text-muted">On hidden repository</span>
                                 ) : (
                                     <>
-                                        <LinkOrSpan className="alert-link" to={error.changeset.externalURL?.url}>
+                                        <AlertLink to={error.changeset.externalURL?.url ?? ''}>
                                             {error.changeset.title} <ExternalLinkIcon className="icon-inline" />
-                                        </LinkOrSpan>{' '}
+                                        </AlertLink>{' '}
                                         on{' '}
-                                        <Link className="alert-link" to={error.changeset.repository.url}>
+                                        <AlertLink to={error.changeset.repository.url}>
                                             repository {error.changeset.repository.name}
-                                        </Link>
+                                        </AlertLink>
                                         .
                                     </>
                                 )}

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.module.scss
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.module.scss
@@ -47,3 +47,7 @@
         }
     }
 }
+
+.alert-heading {
+    color: inherit;
+}

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
@@ -222,7 +222,9 @@ export const ExternalChangesetNode: React.FunctionComponent<ExternalChangesetNod
 
 const SyncerError: React.FunctionComponent<{ syncerError: string }> = ({ syncerError }) => (
     <div className="alert alert-danger" role="alert">
-        <h4 className="alert-heading">Encountered error during last attempt to sync changeset data from code host</h4>
+        <h4 className={classNames(styles.alertHeading)}>
+            Encountered error during last attempt to sync changeset data from code host
+        </h4>
         <ErrorMessage error={syncerError} />
         <hr className="my-2" />
         <p className="mb-0">
@@ -240,7 +242,7 @@ const ChangesetError: React.FunctionComponent<{
 
     return (
         <div className="alert alert-danger" role="alert">
-            <h4 className="alert-heading">Failed to run operations on changeset</h4>
+            <h4 className={classNames(styles.alertHeading)}>Failed to run operations on changeset</h4>
             <ErrorMessage error={node.error} />
         </div>
     )

--- a/client/web/src/extensions/ExtensionRegistry.tsx
+++ b/client/web/src/extensions/ExtensionRegistry.tsx
@@ -1,6 +1,5 @@
 import * as H from 'history'
 import React, { useEffect, useState, useCallback } from 'react'
-import { Link } from 'react-router-dom'
 import { concat, of, timer } from 'rxjs'
 import { debounce, delay, map, switchMap, takeUntil, tap, distinctUntilChanged } from 'rxjs/operators'
 
@@ -14,6 +13,7 @@ import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { createAggregateError, ErrorLike, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 import { useLocalStorage } from '@sourcegraph/shared/src/util/useLocalStorage'
 import { useEventObservable } from '@sourcegraph/shared/src/util/useObservable'
+import { AlertLink } from '@sourcegraph/wildcard'
 
 import { PageTitle } from '../components/PageTitle'
 import {
@@ -360,9 +360,7 @@ export const ExtensionRegistry: React.FunctionComponent<Props> = props => {
                             {!authenticatedUser && (
                                 <div className="alert alert-info my-4">
                                     <span>An account is required to create, enable and disable extensions. </span>
-                                    <Link to="/sign-up?returnTo=/extensions">
-                                        <span className="alert-link">Register now!</span>
-                                    </Link>
+                                    <AlertLink to="/sign-up?returnTo=/extensions">Register now!</AlertLink>
                                 </div>
                             )}
                             <ExtensionsList

--- a/client/web/src/extensions/extension/ExtensionAreaHeader.tsx
+++ b/client/web/src/extensions/extension/ExtensionAreaHeader.tsx
@@ -1,13 +1,13 @@
 import classNames from 'classnames'
 import PuzzleOutlineIcon from 'mdi-react/PuzzleOutlineIcon'
 import React, { useState, useCallback, useMemo } from 'react'
-import { Link, NavLink, RouteComponentProps } from 'react-router-dom'
+import { NavLink, RouteComponentProps } from 'react-router-dom'
 
 import { isExtensionEnabled, splitExtensionID } from '@sourcegraph/shared/src/extensions/extension'
 import { ExtensionManifest } from '@sourcegraph/shared/src/schema/extensionSchema'
 import { isErrorLike } from '@sourcegraph/shared/src/util/errors'
 import { useTimeoutManager } from '@sourcegraph/shared/src/util/useTimeoutManager'
-import { PageHeader } from '@sourcegraph/wildcard'
+import { PageHeader, AlertLink } from '@sourcegraph/wildcard'
 
 import { NavItemWithIconDescriptor } from '../../util/contributions'
 import { ExtensionToggle } from '../ExtensionToggle'
@@ -115,9 +115,7 @@ export const ExtensionAreaHeader: React.FunctionComponent<ExtensionAreaHeaderPro
                                     {showCta && (
                                         <div className={classNames('alert alert-info mb-0 py-1', styles.alert)}>
                                             An account is required to create and configure extensions.{' '}
-                                            <Link to="/sign-up" className="alert-link">
-                                                Register now!
-                                            </Link>
+                                            <AlertLink to="/sign-up">Register now!</AlertLink>
                                         </div>
                                     )}
                                     {/* If site admin, render user toggle and site toggle (both small) */}

--- a/client/web/src/repo/actions/InstallBrowserExtensionAlert.tsx
+++ b/client/web/src/repo/actions/InstallBrowserExtensionAlert.tsx
@@ -1,6 +1,8 @@
 import CloseIcon from 'mdi-react/CloseIcon'
 import React from 'react'
 
+import { AlertLink } from '@sourcegraph/wildcard'
+
 import { ExternalLinkFields, ExternalServiceKind } from '../../graphql-operations'
 import { eventLogger } from '../../tracking/eventLogger'
 
@@ -55,29 +57,23 @@ export const InstallBrowserExtensionAlert: React.FunctionComponent<Props> = ({
                         <>
                             Sourcegraph's code intelligence will follow you to your code host. Your site admin set up
                             the Sourcegraph native integration for {displayName}.{' '}
-                            <a
-                                className="alert-link"
-                                href="https://docs.sourcegraph.com/integration/browser_extension"
+                            <AlertLink
+                                to="https://docs.sourcegraph.com/integration/browser_extension"
                                 target="_blank"
                                 rel="noopener"
                             >
                                 Learn more
-                            </a>{' '}
+                            </AlertLink>{' '}
                             or{' '}
-                            <a className="alert-link" href={externalLink.url} target="_blank" rel="noopener">
+                            <AlertLink to={externalLink.url} target="_blank" rel="noopener">
                                 try it out
-                            </a>
+                            </AlertLink>
                         </>
                     ) : isChrome ? (
                         <>
-                            <a
-                                href={CHROME_EXTENSION_STORE_LINK}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="alert-link"
-                            >
+                            <AlertLink to={CHROME_EXTENSION_STORE_LINK} target="_blank" rel="noopener noreferrer">
                                 Install the Sourcegraph browser extension
-                            </a>{' '}
+                            </AlertLink>{' '}
                             to add code intelligence{' '}
                             {serviceKind === ExternalServiceKind.GITHUB ||
                             serviceKind === ExternalServiceKind.BITBUCKETSERVER ||
@@ -105,14 +101,13 @@ export const InstallBrowserExtensionAlert: React.FunctionComponent<Props> = ({
                                 <>while browsing and reviewing code</>
                             )}{' '}
                             on {displayName}.{' '}
-                            <a
-                                href="/help/integration/browser_extension"
+                            <AlertLink
+                                to="/help/integration/browser_extension"
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                className="alert-link"
                             >
                                 Learn more about Sourcegraph Chrome and Firefox extensions
-                            </a>
+                            </AlertLink>
                         </>
                     )}
                 </p>
@@ -146,15 +141,14 @@ export const FirefoxAddonAlert: React.FunctionComponent<FirefoxAlertProps> = ({ 
         <div>
             <p className="font-weight-medium my-0 mr-3">
                 Sourcegraph is back at{' '}
-                <a
-                    href="https://addons.mozilla.org/en-US/firefox/addon/sourcegraph-for-firefox"
+                <AlertLink
+                    to="https://addons.mozilla.org/en-US/firefox/addon/sourcegraph-for-firefox"
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="alert-link"
                     onClick={onInstallLinkClick}
                 >
                     Firefox Add-ons
-                </a>{' '}
+                </AlertLink>{' '}
                 🎉️
             </p>
             <p className="mt-1 mb-0">

--- a/client/web/src/repo/actions/__snapshots__/InstallBrowserExtensionAlert.test.tsx.snap
+++ b/client/web/src/repo/actions/__snapshots__/InstallBrowserExtensionAlert.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`InstallBrowserExtensionAlert BITBUCKETSERVER (Chrome) 1`] = `
         class="my-0 mr-3"
       >
         <a
-          class="alert-link"
+          class="alertLink"
           href="https://chrome.google.com/webstore/detail/dgjhfomjieaadpoljlnidmbgkdffpack"
           rel="noopener noreferrer"
           target="_blank"
@@ -58,7 +58,7 @@ exports[`InstallBrowserExtensionAlert BITBUCKETSERVER (native integration) 1`] =
       >
         Sourcegraph's code intelligence will follow you to your code host. Your site admin set up the Sourcegraph native integration for Bitbucket Server. 
         <a
-          class="alert-link"
+          class="alertLink"
           href="https://docs.sourcegraph.com/integration/browser_extension"
           rel="noopener"
           target="_blank"
@@ -67,7 +67,7 @@ exports[`InstallBrowserExtensionAlert BITBUCKETSERVER (native integration) 1`] =
         </a>
          or 
         <a
-          class="alert-link"
+          class="alertLink"
           href=""
           rel="noopener"
           target="_blank"
@@ -111,7 +111,7 @@ exports[`InstallBrowserExtensionAlert BITBUCKETSERVER (non-Chrome) 1`] = `
       >
         Get code intelligence while browsing files and reviewing pull requests on Bitbucket Server. 
         <a
-          class="alert-link"
+          class="alertLink"
           href="/help/integration/browser_extension"
           rel="noopener noreferrer"
           target="_blank"
@@ -154,7 +154,7 @@ exports[`InstallBrowserExtensionAlert GITHUB (Chrome) 1`] = `
         class="my-0 mr-3"
       >
         <a
-          class="alert-link"
+          class="alertLink"
           href="https://chrome.google.com/webstore/detail/dgjhfomjieaadpoljlnidmbgkdffpack"
           rel="noopener noreferrer"
           target="_blank"
@@ -199,7 +199,7 @@ exports[`InstallBrowserExtensionAlert GITHUB (native integration) 1`] = `
       >
         Sourcegraph's code intelligence will follow you to your code host. Your site admin set up the Sourcegraph native integration for GitHub. 
         <a
-          class="alert-link"
+          class="alertLink"
           href="https://docs.sourcegraph.com/integration/browser_extension"
           rel="noopener"
           target="_blank"
@@ -208,7 +208,7 @@ exports[`InstallBrowserExtensionAlert GITHUB (native integration) 1`] = `
         </a>
          or 
         <a
-          class="alert-link"
+          class="alertLink"
           href=""
           rel="noopener"
           target="_blank"
@@ -252,7 +252,7 @@ exports[`InstallBrowserExtensionAlert GITHUB (non-Chrome) 1`] = `
       >
         Get code intelligence while browsing files and reviewing pull requests on GitHub. 
         <a
-          class="alert-link"
+          class="alertLink"
           href="/help/integration/browser_extension"
           rel="noopener noreferrer"
           target="_blank"
@@ -295,7 +295,7 @@ exports[`InstallBrowserExtensionAlert GITLAB (Chrome) 1`] = `
         class="my-0 mr-3"
       >
         <a
-          class="alert-link"
+          class="alertLink"
           href="https://chrome.google.com/webstore/detail/dgjhfomjieaadpoljlnidmbgkdffpack"
           rel="noopener noreferrer"
           target="_blank"
@@ -340,7 +340,7 @@ exports[`InstallBrowserExtensionAlert GITLAB (native integration) 1`] = `
       >
         Sourcegraph's code intelligence will follow you to your code host. Your site admin set up the Sourcegraph native integration for GitLab. 
         <a
-          class="alert-link"
+          class="alertLink"
           href="https://docs.sourcegraph.com/integration/browser_extension"
           rel="noopener"
           target="_blank"
@@ -349,7 +349,7 @@ exports[`InstallBrowserExtensionAlert GITLAB (native integration) 1`] = `
         </a>
          or 
         <a
-          class="alert-link"
+          class="alertLink"
           href=""
           rel="noopener"
           target="_blank"
@@ -393,7 +393,7 @@ exports[`InstallBrowserExtensionAlert GITLAB (non-Chrome) 1`] = `
       >
         Get code intelligence while browsing files and reviewing merge requests on GitLab. 
         <a
-          class="alert-link"
+          class="alertLink"
           href="/help/integration/browser_extension"
           rel="noopener noreferrer"
           target="_blank"
@@ -436,7 +436,7 @@ exports[`InstallBrowserExtensionAlert PHABRICATOR (Chrome) 1`] = `
         class="my-0 mr-3"
       >
         <a
-          class="alert-link"
+          class="alertLink"
           href="https://chrome.google.com/webstore/detail/dgjhfomjieaadpoljlnidmbgkdffpack"
           rel="noopener noreferrer"
           target="_blank"
@@ -481,7 +481,7 @@ exports[`InstallBrowserExtensionAlert PHABRICATOR (native integration) 1`] = `
       >
         Sourcegraph's code intelligence will follow you to your code host. Your site admin set up the Sourcegraph native integration for Phabricator. 
         <a
-          class="alert-link"
+          class="alertLink"
           href="https://docs.sourcegraph.com/integration/browser_extension"
           rel="noopener"
           target="_blank"
@@ -490,7 +490,7 @@ exports[`InstallBrowserExtensionAlert PHABRICATOR (native integration) 1`] = `
         </a>
          or 
         <a
-          class="alert-link"
+          class="alertLink"
           href=""
           rel="noopener"
           target="_blank"
@@ -534,7 +534,7 @@ exports[`InstallBrowserExtensionAlert PHABRICATOR (non-Chrome) 1`] = `
       >
         Get code intelligence while browsing and reviewing code on Phabricator. 
         <a
-          class="alert-link"
+          class="alertLink"
           href="/help/integration/browser_extension"
           rel="noopener noreferrer"
           target="_blank"

--- a/client/wildcard/src/components/Alert/Alert.module.scss
+++ b/client/wildcard/src/components/Alert/Alert.module.scss
@@ -5,10 +5,6 @@
     border: 1px solid transparent;
 }
 
-.alert-heading {
-    color: inherit;
-}
-
 .alert a:not(.btn) {
     font-weight: 500;
 
@@ -30,7 +26,8 @@
     color: var(--body-color);
     overflow: hidden;
     border-color: var(--alert-border-color);
-    // Apply `background-color` and `padding` only to `.alert-#{$name}` because we also use `.alert` elements without variants.
+
+    /* Apply `background-color` and `padding` only to .alert-variants because we also use `.alert` elements without variants. */
     background-color: var(--color-bg-1);
     padding: var(--alert-content-padding) var(--alert-content-padding) var(--alert-content-padding)
         calc(var(--alert-icon-block-width) + var(--alert-content-padding));
@@ -46,7 +43,7 @@
         height: 100%;
     }
 
-    // Alert icon background.
+    /* Alert icon background. */
     &::before {
         border: 2px solid var(--color-bg-1);
         border-top-left-radius: var(--border-radius);
@@ -58,7 +55,8 @@
         mask-repeat: no-repeat;
         mask-size: 1rem;
         mask-position: 50% 50%;
-        // Applied as a fill color for SVG icon because of the mask-image.
+
+        /* Applied as a fill color for SVG icon because of the mask-image. */
         background-color: var(--alert-icon-color);
     }
 }
@@ -66,12 +64,12 @@
 .alert-info {
     --alert-border-color: var(--info);
 
-    .theme-light & {
+    :global(.theme-light) & {
         --alert-icon-color: var(--info-3);
         --alert-icon-background-color: var(--info-4);
     }
 
-    .theme-dark & {
+    :global(.theme-dark) & {
         --alert-icon-color: var(--info);
         --alert-icon-background-color: var(--info-3);
     }
@@ -81,11 +79,11 @@
     --alert-border-color: var(--primary);
     --alert-icon-background-color: var(--primary-4);
 
-    .theme-light & {
+    :global(.theme-light) & {
         --alert-icon-color: var(--primary-3);
     }
 
-    .theme-dark & {
+    :global(.theme-dark) & {
         --alert-icon-color: var(--primary);
     }
 }
@@ -93,12 +91,12 @@
 .alert-secondary {
     --alert-icon-background-color: var(--secondary-4);
 
-    .theme-light & {
+    :global(.theme-light) & {
         --alert-border-color: var(--secondary-3);
         --alert-icon-color: var(--gray-06);
     }
 
-    .theme-dark & {
+    :global(.theme-dark) & {
         --alert-border-color: var(--secondary);
         --alert-icon-color: var(--gray-05);
     }
@@ -111,9 +109,7 @@
         // We cannot render SVG in HTML because then we will need to add it to every `.alert` element manually.
         // We can use it as a `mask-image` to apply CSS variables as a fill color.
         // Icon: mdi-react/Information
-        mask-image: url(escape-svg(
-            "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M13 9h-2V7h2m0 10h-2v-6h2m-1-9A10 10 0 002 12a10 10 0 0010 10 10 10 0 0010-10A10 10 0 0012 2z'/></svg>"
-        ));
+        mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M13 9h-2V7h2m0 10h-2v-6h2m-1-9A10 10 0 002 12a10 10 0 0010 10 10 10 0 0010-10A10 10 0 0012 2z'/></svg>");
     }
 }
 
@@ -121,19 +117,17 @@
     --alert-border-color: var(--warning);
     --alert-icon-background-color: var(--warning-4);
 
-    .theme-light & {
+    :global(.theme-light) & {
         --alert-icon-color: var(--warning-3);
     }
 
-    .theme-dark & {
+    :global(.theme-dark) & {
         --alert-icon-color: var(--warning);
     }
 
     &::after {
-        // Icon: mdi-react/Alert
-        mask-image: url(escape-svg(
-            "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M13 14h-2V9h2m0 9h-2v-2h2M1 21h22L12 2 1 21z'/></svg>"
-        ));
+        /* Icon: mdi-react/Alert */
+        mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M13 14h-2V9h2m0 9h-2v-2h2M1 21h22L12 2 1 21z'/></svg>");
     }
 }
 
@@ -141,19 +135,17 @@
     --alert-border-color: var(--danger);
     --alert-icon-background-color: var(--danger-4);
 
-    .theme-light & {
+    :global(.theme-light) & {
         --alert-icon-color: var(--danger-3);
     }
 
-    .theme-dark & {
+    :global(.theme-dark) & {
         --alert-icon-color: var(--danger);
     }
 
     &::after {
-        // Icon: mdi-react/AlertCircle
-        mask-image: url(escape-svg(
-            "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M13 13h-2V7h2m0 10h-2v-2h2M12 2A10 10 0 002 12a10 10 0 0010 10 10 10 0 0010-10A10 10 0 0012 2z'/></svg>"
-        ));
+        /* Icon: mdi-react/AlertCircle */
+        mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M13 13h-2V7h2m0 10h-2v-2h2M12 2A10 10 0 002 12a10 10 0 0010 10 10 10 0 0010-10A10 10 0 0012 2z'/></svg>");
     }
 }
 
@@ -161,19 +153,17 @@
     --alert-border-color: var(--success);
     --alert-icon-background-color: var(--success-4);
 
-    .theme-light & {
+    :global(.theme-light) & {
         --alert-icon-color: var(--success-3);
     }
 
-    .theme-dark & {
+    :global(.theme-dark) & {
         --alert-icon-color: var(--success);
     }
 
     &::after {
-        // Icon: mdi-react/CheckCircle
-        mask-image: url(escape-svg(
-            "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2m-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z'/></svg>"
-        ));
+        /* Icon: mdi-react/CheckCircle */
+        mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2m-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z'/></svg>");
     }
 }
 
@@ -181,18 +171,16 @@
     --alert-border-color: var(--merged);
     --alert-icon-background-color: var(--merged-4);
 
-    .theme-light & {
+    :global(.theme-light) & {
         --alert-icon-color: var(--merged-3);
     }
 
-    .theme-dark & {
+    :global(.theme-dark) & {
         --alert-icon-color: var(--merged);
     }
 
     &::after {
-        // Icon: mdi-react/SourceMerge
-        mask-image: url(escape-svg(
-            "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M7 3a3 3 0 013 3c0 1.29-.81 2.39-1.96 2.81.54 5 5.04 5.96 7.15 6.15A2.985 2.985 0 0118 13a3 3 0 013 3 3 3 0 01-3 3c-1.31 0-2.43-.84-2.84-2-4.25-.2-5.72-1.81-7.16-3.61v1.78c1.17.41 2 1.52 2 2.83a3 3 0 01-3 3 3 3 0 01-3-3c0-1.31.83-2.42 2-2.83V8.83A2.99 2.99 0 014 6a3 3 0 013-3m0 2a1 1 0 00-1 1 1 1 0 001 1 1 1 0 001-1 1 1 0 00-1-1m0 12a1 1 0 00-1 1 1 1 0 001 1 1 1 0 001-1 1 1 0 00-1-1m11-2a1 1 0 00-1 1 1 1 0 001 1 1 1 0 001-1 1 1 0 00-1-1z'/></svg>"
-        ));
+        /* Icon: mdi-react/SourceMerge */
+        mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M7 3a3 3 0 013 3c0 1.29-.81 2.39-1.96 2.81.54 5 5.04 5.96 7.15 6.15A2.985 2.985 0 0118 13a3 3 0 013 3 3 3 0 01-3 3c-1.31 0-2.43-.84-2.84-2-4.25-.2-5.72-1.81-7.16-3.61v1.78c1.17.41 2 1.52 2 2.83a3 3 0 01-3 3 3 3 0 01-3-3c0-1.31.83-2.42 2-2.83V8.83A2.99 2.99 0 014 6a3 3 0 013-3m0 2a1 1 0 00-1 1 1 1 0 001 1 1 1 0 001-1 1 1 0 00-1-1m0 12a1 1 0 00-1 1 1 1 0 001 1 1 1 0 001-1 1 1 0 00-1-1m11-2a1 1 0 00-1 1 1 1 0 001 1 1 1 0 001-1 1 1 0 00-1-1z'/></svg>");
     }
 }

--- a/client/wildcard/src/components/Alert/Alert.story.tsx
+++ b/client/wildcard/src/components/Alert/Alert.story.tsx
@@ -1,0 +1,75 @@
+import { action } from '@storybook/addon-actions'
+import { Story, Meta } from '@storybook/react'
+import classNames from 'classnames'
+import { flow } from 'lodash'
+import React from 'react'
+
+import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
+import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
+
+import 'storybook-addon-designs'
+
+import { Alert } from './Alert'
+import { ALERT_VARIANTS } from './constants'
+
+import { AlertLink } from '.'
+
+const preventDefault = <E extends React.SyntheticEvent>(event: E): E => {
+    event.preventDefault()
+    return event
+}
+
+const config: Meta = {
+    title: 'wildcard/Alert',
+    decorators: [
+        story => (
+            <BrandedStory styles={webStyles}>{() => <div className="container mt-3">{story()}</div>}</BrandedStory>
+        ),
+    ],
+    parameters: {
+        component: Alert,
+        design: [
+            {
+                type: 'figma',
+                name: 'Figma Light',
+                url:
+                    'https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/Design-Refresh-Systemization-source-of-truth?node-id=1563%3A196',
+            },
+            {
+                type: 'figma',
+                name: 'Figma Dark',
+                url:
+                    'https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/Design-Refresh-Systemization-source-of-truth?node-id=1563%3A525',
+            },
+        ],
+    },
+}
+
+export default config
+
+export const Alerts: Story = () => (
+    <>
+        <h1>Alerts</h1>
+        <p>
+            Provide contextual feedback messages for typical user actions with the handful of available and flexible
+            alert messages.
+        </p>
+        <div className="mb-2">
+            {ALERT_VARIANTS.map(variant => (
+                <Alert key={variant} variant={variant}>
+                    <h4>Too many matching repositories</h4>
+                    Use a 'repo:' or 'repogroup:' filter to narrow your search.
+                </Alert>
+            ))}
+            <Alert variant="info" className="d-flex align-items-center">
+                <div className="flex-grow-1">
+                    <h4>Too many matching repositories</h4>
+                    Use a 'repo:' or 'repogroup:' filter to narrow your search.
+                </div>
+                <AlertLink className="mr-2" to="/" onClick={flow(preventDefault, action(classNames('link clicked')))}>
+                    Dismiss
+                </AlertLink>
+            </Alert>
+        </div>
+    </>
+)

--- a/client/wildcard/src/components/Alert/Alert.test.tsx
+++ b/client/wildcard/src/components/Alert/Alert.test.tsx
@@ -1,0 +1,33 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+
+import { Alert } from './Alert'
+import { ALERT_VARIANTS } from './constants'
+
+describe('Alert', () => {
+    it('renders a simple Alert correctly', () => {
+        const { container } = render(<Alert>Simple Alert</Alert>)
+        expect(container.firstChild).toMatchInlineSnapshot(`
+            <div
+              class="alert"
+            >
+              Simple Alert
+            </div>
+        `)
+    })
+
+    it.each(ALERT_VARIANTS)("renders variant '%s' correctly", variant => {
+        const { container } = render(
+            <Alert variant={variant}>
+                <h4>Too many matching repositories</h4>
+                Use a 'repo:' or 'repogroup:' filter to narrow your search.
+            </Alert>
+        )
+        expect(container.firstChild).toMatchSnapshot()
+    })
+
+    it('renders Alert content correctly', () => {
+        const { container } = render(<Alert>Too many matching repositories</Alert>)
+        expect(container.firstChild).toHaveTextContent('Too many matching repositories')
+    })
+})

--- a/client/wildcard/src/components/Alert/Alert.tsx
+++ b/client/wildcard/src/components/Alert/Alert.tsx
@@ -1,0 +1,25 @@
+import classNames from 'classnames'
+import React from 'react'
+
+import { ForwardReferenceComponent } from '../../types'
+
+import styles from './Alert.module.scss'
+import { ALERT_VARIANTS } from './constants'
+import { getAlertStyle } from './utils'
+
+export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
+    variant?: typeof ALERT_VARIANTS[number]
+    as?: React.ElementType
+}
+
+export const Alert = React.forwardRef(
+    ({ children, as: Component = 'div', variant, className, ...attributes }, reference) => (
+        <Component
+            ref={reference}
+            className={classNames(styles.alert, variant && getAlertStyle({ variant }), className)}
+            {...attributes}
+        >
+            {children}
+        </Component>
+    )
+) as ForwardReferenceComponent<'div', AlertProps>

--- a/client/wildcard/src/components/Alert/AlertLink.module.scss
+++ b/client/wildcard/src/components/Alert/AlertLink.module.scss
@@ -1,0 +1,7 @@
+.alert-link {
+    font-weight: 500;
+
+    &:hover {
+        text-decoration: underline;
+    }
+}

--- a/client/wildcard/src/components/Alert/AlertLink.tsx
+++ b/client/wildcard/src/components/Alert/AlertLink.tsx
@@ -1,0 +1,14 @@
+import classNames from 'classnames'
+import React from 'react'
+
+import { Link, LinkProps } from '@sourcegraph/shared/src/components/Link'
+
+import styles from './AlertLink.module.scss'
+
+interface AlertLinkProps extends LinkProps {}
+
+export const AlertLink: React.FunctionComponent<AlertLinkProps> = ({ to, children, className, ...attributes }) => (
+    <Link to={to} className={classNames(styles.alertLink, className)} {...attributes}>
+        {children}
+    </Link>
+)

--- a/client/wildcard/src/components/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/client/wildcard/src/components/Alert/__snapshots__/Alert.test.tsx.snap
@@ -1,0 +1,78 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Alert renders variant 'danger' correctly 1`] = `
+<div
+  class="alert alertDanger"
+>
+  <h4>
+    Too many matching repositories
+  </h4>
+  Use a 'repo:' or 'repogroup:' filter to narrow your search.
+</div>
+`;
+
+exports[`Alert renders variant 'info' correctly 1`] = `
+<div
+  class="alert alertInfo"
+>
+  <h4>
+    Too many matching repositories
+  </h4>
+  Use a 'repo:' or 'repogroup:' filter to narrow your search.
+</div>
+`;
+
+exports[`Alert renders variant 'merged' correctly 1`] = `
+<div
+  class="alert alertMerged"
+>
+  <h4>
+    Too many matching repositories
+  </h4>
+  Use a 'repo:' or 'repogroup:' filter to narrow your search.
+</div>
+`;
+
+exports[`Alert renders variant 'primary' correctly 1`] = `
+<div
+  class="alert alertPrimary"
+>
+  <h4>
+    Too many matching repositories
+  </h4>
+  Use a 'repo:' or 'repogroup:' filter to narrow your search.
+</div>
+`;
+
+exports[`Alert renders variant 'secondary' correctly 1`] = `
+<div
+  class="alert alertSecondary"
+>
+  <h4>
+    Too many matching repositories
+  </h4>
+  Use a 'repo:' or 'repogroup:' filter to narrow your search.
+</div>
+`;
+
+exports[`Alert renders variant 'success' correctly 1`] = `
+<div
+  class="alert alertSuccess"
+>
+  <h4>
+    Too many matching repositories
+  </h4>
+  Use a 'repo:' or 'repogroup:' filter to narrow your search.
+</div>
+`;
+
+exports[`Alert renders variant 'warning' correctly 1`] = `
+<div
+  class="alert alertWarning"
+>
+  <h4>
+    Too many matching repositories
+  </h4>
+  Use a 'repo:' or 'repogroup:' filter to narrow your search.
+</div>
+`;

--- a/client/wildcard/src/components/Alert/constants.ts
+++ b/client/wildcard/src/components/Alert/constants.ts
@@ -1,0 +1,1 @@
+export const ALERT_VARIANTS = ['primary', 'secondary', 'success', 'danger', 'warning', 'info', 'merged'] as const

--- a/client/wildcard/src/components/Alert/index.ts
+++ b/client/wildcard/src/components/Alert/index.ts
@@ -1,0 +1,2 @@
+export * from './Alert'
+export * from './AlertLink'

--- a/client/wildcard/src/components/Alert/utils.ts
+++ b/client/wildcard/src/components/Alert/utils.ts
@@ -1,0 +1,12 @@
+import className from 'classnames'
+import { upperFirst } from 'lodash'
+
+import styles from './Alert.module.scss'
+import { ALERT_VARIANTS } from './constants'
+
+interface GetAlertStyleParameters {
+    variant: typeof ALERT_VARIANTS[number]
+}
+
+export const getAlertStyle = ({ variant }: GetAlertStyleParameters): string =>
+    className(styles[`alert${upperFirst(variant)}` as keyof typeof styles])

--- a/client/wildcard/src/components/index.ts
+++ b/client/wildcard/src/components/index.ts
@@ -1,4 +1,5 @@
 export { Button } from './Button'
+export { Alert, AlertLink } from './Alert'
 export { Container } from './Container'
 export { Checkbox, Input, RadioButton, Select, TextArea } from './Form'
 export { Grid } from './Grid'


### PR DESCRIPTION
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->

## Wildcard implementation of the `` component.
### See [Wildcard V2 - Planned work](https://docs.google.com/document/d/1NisbJPiadtt5jQw4vUUYJOr8dD6Urwn5V0mVq2wt6bE/edit#heading=h.g4cw92w3ouhw) for more context

Acceptance criteria
- [ ] Component is implemented within Wildcard
- [ ] Component has tests
- [ ] Component is accessible
- [ ] Component matches [Figma designs](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/Wildcard-Design-System?node-id=1563%3A196)

## Implementation details
- Create the `` component similar to the [<button> component.](https://github.com/sourcegraph/sourcegraph/tree/main/client/wildcard/src/components/Button)
- Copy `client/branded/src/global-styles/alert.scss` to the component folder and covert it to a CSS module.
- Move `.alert-heading` to `client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.module.scss`.
- Leave `.alert-link` as a global class for now. Keep it in the CSS module wrapped into a `:global()` keyword.
- Move `client/branded/src/global-styles/GlobalStylesStory/AlertsStory.tsx` ([link](https://storybook.sgdev.org/?path=/story/wildcard-button--all-buttons)) to the new component folder and update it it match other stories in the Wildcard package.
- Use the `</button><button> component` as a blueprint for the new component.
Component API: