### PR TITLE
migration: Do not allow `sqlf.Sprintf` to scape query placeholders

### DIFF
--- a/internal/database/migration/definition/read.go
+++ b/internal/database/migration/definition/read.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/keegancsmith/sqlf"
 
@@ -168,5 +169,8 @@ func readQueryFromFile(fs fs.FS, filepath string) (*sqlf.Query, error) {
 		return nil, err
 	}
 
-	return sqlf.Sprintf(string(contents)), nil
+	normalizedQuery := string(contents)
+	normalizedQuery = strings.ReplaceAll(normalizedQuery, "%", "%%")
+
+	return sqlf.Sprintf(normalizedQuery), nil
 }


### PR DESCRIPTION
Migration files containing literal '%' characters must be escaped so they're not replaced by `missing`/`nil` in the sprintf call.