### PR TITLE
add some alerts that are common when symbols is le struggle

### DIFF
--- a/doc/admin/how-to/monorepo-issues.md
+++ b/doc/admin/how-to/monorepo-issues.md
@@ -63,7 +63,7 @@ Selecting the Show History button while viewing a file initiates a request to [f
 
 ## Common alerts
 
-The following alerts are common to instance underprovisioned in relation to their monorepos, [learn more about alerts](https://docs.sourcegraph.com/admin/observability/alert_solutions):
+The following alerts are common to instances underprovisioned in relation to their monorepos, [learn more about alerts](https://docs.sourcegraph.com/admin/observability/alert_solutions):
 
 - frontend: 20s+ 99th percentile code-intel successful search request duration over 5m
 - frontend: 15s+ 90th percentile code-intel successful search request duration over 5m

--- a/doc/admin/how-to/monorepo-issues.md
+++ b/doc/admin/how-to/monorepo-issues.md
@@ -63,7 +63,7 @@ Selecting the Show History button while viewing a file initiates a request to [f
 
 ## Common alerts
 
-The following alerts are common to instance underprovisioned in relation to their monorepos:
+The following alerts are common to instance underprovisioned in relation to their monorepos, [learn more about alerts](https://docs.sourcegraph.com/admin/observability/alert_solutions):
 
 - frontend: 20s+ 99th percentile code-intel successful search request duration over 5m
 - frontend: 15s+ 90th percentile code-intel successful search request duration over 5m

--- a/doc/admin/how-to/monorepo-issues.md
+++ b/doc/admin/how-to/monorepo-issues.md
@@ -60,3 +60,12 @@ Hovering over a symbol results in a query for the definition. If the symbol is d
 ![Screen Shot 2021-11-15 at 1 10 16 AM](https://user-images.githubusercontent.com/13024338/141754063-2080c7c6-b5be-43c1-b9db-386e916d2968.png)
 
 Selecting the Show History button while viewing a file initiates a request to [fetch commits](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:%5Eclient/web/src/repo/RepoRevisionSidebarCommits%5C.tsx+function+fetchCommits%28&patternType=literal) for the file. This request is ultimately resolved by gitserver using functionality similar to git log. To improve performance allocate gitserver more CPU.
+
+## Common alerts
+
+The following alerts are common to instance underprovisioned in relation to their monorepos:
+
+- frontend: 20s+ 99th percentile code-intel successful search request duration over 5m
+- frontend: 15s+ 90th percentile code-intel successful search request duration over 5m
+- zoekt-webserver: 5% Indexed search request errors every 5m by code for 5m0s
+- symbols: 25+ current fetch queue size

--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -225,6 +225,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 - **Kubernetes:** Check CPU usage of zoekt-webserver in the indexed-search pod, consider increasing CPU limits in the `indexed-search.Deployment.yaml` if regularly hitting max CPU utilization.
 - **Docker Compose:** Check CPU usage on the Zoekt Web Server dashboard, consider increasing `cpus:` of the zoekt-webserver container in `docker-compose.yml` if regularly hitting max CPU utilization.
 - Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#frontend-99th-percentile-search-codeintel-request-duration).
+- This alert may indicate that your instance is struggling to process requests on a monorepo, [learn more here](../how-to/monorepo-issues.md).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -252,6 +253,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 - **Kubernetes:** Check CPU usage of zoekt-webserver in the indexed-search pod, consider increasing CPU limits in the `indexed-search.Deployment.yaml` if regularly hitting max CPU utilization.
 - **Docker Compose:** Check CPU usage on the Zoekt Web Server dashboard, consider increasing `cpus:` of the zoekt-webserver container in `docker-compose.yml` if regularly hitting max CPU utilization.
 - Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#frontend-90th-percentile-search-codeintel-request-duration).
+- This alert may indicate that your instance is struggling to process requests on a monorepo, [learn more here](../how-to/monorepo-issues.md).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json

--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -225,7 +225,6 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 - **Kubernetes:** Check CPU usage of zoekt-webserver in the indexed-search pod, consider increasing CPU limits in the `indexed-search.Deployment.yaml` if regularly hitting max CPU utilization.
 - **Docker Compose:** Check CPU usage on the Zoekt Web Server dashboard, consider increasing `cpus:` of the zoekt-webserver container in `docker-compose.yml` if regularly hitting max CPU utilization.
 - Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#frontend-99th-percentile-search-codeintel-request-duration).
-- This alert may indicate that your instance is struggling to process requests on a monorepo, [learn more here](../how-to/monorepo-issues.md).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -253,7 +252,6 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 - **Kubernetes:** Check CPU usage of zoekt-webserver in the indexed-search pod, consider increasing CPU limits in the `indexed-search.Deployment.yaml` if regularly hitting max CPU utilization.
 - **Docker Compose:** Check CPU usage on the Zoekt Web Server dashboard, consider increasing `cpus:` of the zoekt-webserver container in `docker-compose.yml` if regularly hitting max CPU utilization.
 - Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#frontend-90th-percentile-search-codeintel-request-duration).
-- This alert may indicate that your instance is struggling to process requests on a monorepo, [learn more here](../how-to/monorepo-issues.md).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json


### PR DESCRIPTION
These are alerts that Dropbox has been seeing. After looking at some logs for the slow searches they were all symbols searches. I've requested that they add another big gitserver on top of the one powerful one they've provisioned. I'm a little uncertain about the `symbols` alert here, but I think this is all accurate. The customer isn't reporting that any of their grafana provisioning for any of these services looks like its hitting limits. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
