### PR TITLE
web: fix authentication when using `sg start web-standalone`

### DIFF
--- a/client/web/dev/utils/get-api-proxy-settings.ts
+++ b/client/web/dev/utils/get-api-proxy-settings.ts
@@ -15,7 +15,7 @@ export const getAPIProxySettings = ({ apiURL }: GetAPIProxySettingsOptions): Opt
     changeOrigin: true,
     // Rewrite domain of `set-cookie` headers for all cookies received.
     cookieDomainRewrite: '',
-    onProxyRes: proxyResponse => {
+    onProxyRes: (proxyResponse, request, response) => {
         if (proxyResponse.headers['set-cookie']) {
             // Remove `Secure` and `SameSite` from `set-cookie` headers.
             const cookies = proxyResponse.headers['set-cookie'].map(cookie =>
@@ -24,6 +24,12 @@ export const getAPIProxySettings = ({ apiURL }: GetAPIProxySettingsOptions): Opt
 
             proxyResponse.headers['set-cookie'] = cookies
         }
+    },
+    onProxyReq: (proxyRequest, request, response) => {
+        // Not really clear why, but the `changeOrigin: true` setting does NOT add the correct
+        // Origin header to requests sent to k8s.sgdev.org, which e.g. breaks sign in and more. So
+        // we add it ourselves.
+        proxyRequest.setHeader('Origin', apiURL)
     },
     // TODO: share with `client/web/gulpfile.js`
     // Avoid crashing on "read ECONNRESET".

--- a/client/web/dev/utils/get-api-proxy-settings.ts
+++ b/client/web/dev/utils/get-api-proxy-settings.ts
@@ -15,7 +15,7 @@ export const getAPIProxySettings = ({ apiURL }: GetAPIProxySettingsOptions): Opt
     changeOrigin: true,
     // Rewrite domain of `set-cookie` headers for all cookies received.
     cookieDomainRewrite: '',
-    onProxyRes: (proxyResponse, request, response) => {
+    onProxyRes: proxyResponse => {
         if (proxyResponse.headers['set-cookie']) {
             // Remove `Secure` and `SameSite` from `set-cookie` headers.
             const cookies = proxyResponse.headers['set-cookie'].map(cookie =>
@@ -25,7 +25,7 @@ export const getAPIProxySettings = ({ apiURL }: GetAPIProxySettingsOptions): Opt
             proxyResponse.headers['set-cookie'] = cookies
         }
     },
-    onProxyReq: (proxyRequest, request, response) => {
+    onProxyReq: proxyRequest => {
         // Not really clear why, but the `changeOrigin: true` setting does NOT add the correct
         // Origin header to requests sent to k8s.sgdev.org, which e.g. breaks sign in and more. So
         // we add it ourselves.


### PR DESCRIPTION
Prior to this change, the proxy server that `sg start web-standalone` uses to proxy requests to https://k8s.sgdev.org did not send an appropriate `Origin` header (it sent `http://localhost:3080` or `https://sourcegraph.test`, NOT `https://k8s.sgdev.org` as we would expect.)

In #27313 (21 days ago) we hardened security by enforcing that requests to API endpoints that are not from trusted origins and do not have `X-Requested-With` will not be allowed to use session authentication. This introduced the issue for `sg start web-standalone` originally, and to workaround this @vovakulikov added `X-Requested-With` to all proxied requests in #27825

In #28572 (merged yesterday) I removed the proxy logic for CSRF tokens and due to a merge conflict also removed the `X-Requested-With` logic Vova had added.

Using `X-Requested-With` was a fine workaround-and bringing that logic back would've continued to workaround the issue-but sending the correct `Origin` header is better and will more closely mimic what is actually happening when code is deployed to production, so that is the fix I have made here.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>
