### PR TITLE
run e2e/qa/upgrade test on e2e queue

### DIFF
--- a/dev/ci/test/cleanup-display.sh
+++ b/dev/ci/test/cleanup-display.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
-PID=$(pgrep ffmpeg)
-kill "$PID"
+procs=(ffmpeg Xvfb)
+
+for p in "${procs[@]}"; do pgrep "$p" | xargs kill; done

--- a/dev/ci/test/e2e/test.sh
+++ b/dev/ci/test/e2e/test.sh
@@ -14,6 +14,9 @@ dev/ci/test/setup-display.sh
 cleanup() {
   cd "$root_dir"
   dev/ci/test/cleanup-display.sh
+  if [[ $(docker ps -aq | wc -l) -gt 0 ]]; then
+    docker rm -f "$(docker ps -aq)"
+  fi
 }
 trap cleanup EXIT
 

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -411,7 +411,7 @@ const vagrantServiceAccount = "buildkite@sourcegraph-ci.iam.gserviceaccount.com"
 func serverE2E(candidateTag string) operations.Operation {
 	return func(p *bk.Pipeline) {
 		p.AddStep(":chromium: Sourcegraph E2E",
-			bk.Agent("queue", "baremetal"),
+			bk.Agent("queue", "e2e-qa"),
 			// Run tests against the candidate server image
 			bk.DependsOn(candidateImageStepKey("server")),
 			bk.Env("CANDIDATE_VERSION", candidateTag),
@@ -427,7 +427,7 @@ func serverE2E(candidateTag string) operations.Operation {
 			bk.Env("TEST_USER_EMAIL", "test@sourcegraph.com"),
 			bk.Env("TEST_USER_PASSWORD", "supersecurepassword"),
 			bk.Env("INCLUDE_ADMIN_ONBOARDING", "false"),
-			bk.Cmd(".buildkite/vagrant-run.sh sourcegraph-e2e"),
+			bk.Cmd("./dev/ci/test/e2e/test.sh"),
 			bk.ArtifactPaths("./*.png", "./*.mp4", "./*.log"))
 	}
 }
@@ -435,7 +435,7 @@ func serverE2E(candidateTag string) operations.Operation {
 func serverQA(candidateTag string) operations.Operation {
 	return func(p *bk.Pipeline) {
 		p.AddStep(":docker::chromium: Sourcegraph QA",
-			bk.Agent("queue", "baremetal"),
+			bk.Agent("queue", "e2e-qa"),
 			// Run tests against the candidate server image
 			bk.DependsOn(candidateImageStepKey("server")),
 			bk.Env("CANDIDATE_VERSION", candidateTag),
@@ -453,7 +453,7 @@ func serverQA(candidateTag string) operations.Operation {
 			bk.Env("TEST_USER_EMAIL", "test@sourcegraph.com"),
 			bk.Env("TEST_USER_PASSWORD", "supersecurepassword"),
 			bk.Env("INCLUDE_ADMIN_ONBOARDING", "false"),
-			bk.Cmd(".buildkite/vagrant-run.sh sourcegraph-qa-test"),
+			bk.Cmd("./dev/ci/test/qa/test.sh"),
 			bk.ArtifactPaths("./*.png", "./*.mp4", "./*.log"))
 	}
 }
@@ -461,7 +461,7 @@ func serverQA(candidateTag string) operations.Operation {
 func testUpgrade(candidateTag, minimumUpgradeableVersion string) operations.Operation {
 	return func(p *bk.Pipeline) {
 		p.AddStep(":docker::arrow_double_up: Sourcegraph Upgrade",
-			bk.Agent("queue", "baremetal"),
+			bk.Agent("queue", "e2e-qa"),
 			// Run tests against the candidate server image
 			bk.DependsOn(candidateImageStepKey("server")),
 			bk.Env("CANDIDATE_VERSION", candidateTag),
@@ -478,7 +478,7 @@ func testUpgrade(candidateTag, minimumUpgradeableVersion string) operations.Oper
 			bk.Env("TEST_USER_EMAIL", "test@sourcegraph.com"),
 			bk.Env("TEST_USER_PASSWORD", "supersecurepassword"),
 			bk.Env("INCLUDE_ADMIN_ONBOARDING", "false"),
-			bk.Cmd(".buildkite/vagrant-run.sh sourcegraph-upgrade"),
+			bk.Cmd("./dev/ci/test/upgrade/test.sh"),
 			bk.ArtifactPaths("./*.png", "./*.mp4", "./*.log"))
 	}
 }


### PR DESCRIPTION
migrate tests off of vagrant and run them directly on a gcp vm. 

Follow up is to remove any old references to these tests once we're confident they're suitable and not buggy. 

Depends on https://github.com/sourcegraph/infrastructure/pull/2945


