### PR TITLE
Code Insights FE Hotfix: Fix inconsistent grid calculation state

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.tsx
@@ -1,5 +1,5 @@
 import { isEqual } from 'lodash'
-import React, { memo, useCallback, useState } from 'react'
+import React, { memo, useCallback, useEffect, useState } from 'react'
 import { Layout, Layouts } from 'react-grid-layout'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -29,6 +29,10 @@ export const SmartInsightsViewGrid: React.FunctionComponent<SmartInsightsViewGri
 
     const [layouts, setLayouts] = useState<Layouts>(insightLayoutGenerator(insights))
     const [resizingView, setResizeView] = useState<Layout | null>(null)
+
+    useEffect(() => {
+        setLayouts(insightLayoutGenerator(insights))
+    }, [insights])
 
     const handleLayoutChange = useCallback(
         (currentLayout: Layout[], allLayouts: Layouts): void => {

--- a/client/web/src/enterprise/insights/components/insights-view-grid/utils/grid-layout-generator.ts
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/utils/grid-layout-generator.ts
@@ -146,6 +146,10 @@ export const recalculateGridLayout = (nextLayouts: ReactGridLayouts, insights: I
         adjustedLayouts[key] = layout.map(item => {
             const insight = insightsMap[item.i]
 
+            if (!insight) {
+                return item
+            }
+
             const isManySeriesChart =
                 isSearchBasedInsight(insight) && insight.series.length > MINIMAL_SERIES_FOR_ASIDE_LEGEND
 


### PR DESCRIPTION
After this PR https://github.com/sourcegraph/sourcegraph/pull/28604 we started facing runtime problems with grid calculation state on the dashboard page with setting-based API. 

**TL;DR** the problem was with the inconsistent state of grid layouts. During dashboard switching, we change our list of insights (different dashboards could have different amounts of insights). Prior to this fix we always had initial state of insight layouts even if those layouts were generated for the previous dashboard's insights

This PR adds recalculation when the `SmartInsightsGrid` component receives a new list of insights. 