### PR TITLE
buildkite: move devx cron config into git

### DIFF
--- a/.buildkite/pipeline.devx-cron.yml
+++ b/.buildkite/pipeline.devx-cron.yml
@@ -1,4 +1,11 @@
+# DevX team crons.
+#
+# Configure here: https://buildkite.com/sourcegraph/devx-cron/settings/schedules
+# Condition various cron jobs on `build.message`. Each cron schedule can set a custom
+# "Build Message" to trigger the correct step(s).
+
 steps:
-  - command:
-      - $REPORT_SCRIPT
-    label: $REPORT_LABEL
+  - label: ":buildkite: :bar_chart: Report CI red time for the main branch"
+    if: build.message == "report-red-time"
+    command:
+      - dev/bkstats/run.sh

--- a/.buildkite/pipeline.devx-cron.yml
+++ b/.buildkite/pipeline.devx-cron.yml
@@ -9,3 +9,4 @@ steps:
     if: build.message == "report-red-time"
     command:
       - dev/bkstats/run.sh
+    agents: { queue: standard }


### PR DESCRIPTION
Right now it is declared in UI, we should track this in git history.

Also sets up a "framework" of triggering different steps on `build.message`, this will allow us to run multiple cron jobs here on multiple schedules.

Related to https://github.com/sourcegraph/sourcegraph/issues/25482 , which I plan to place on a cron