### PR TITLE
chore: Remove comments for table not guaranteed to exist

### DIFF
--- a/migrations/codeinsights/1000000002_comments.up.sql
+++ b/migrations/codeinsights/1000000002_comments.up.sql
@@ -1,9 +1,5 @@
 BEGIN;
 
-COMMENT ON TABLE codeinsights_schema_migrations IS 'Holds a single column storing the status of the most recent migration attempt.';
-COMMENT ON COLUMN codeinsights_schema_migrations.version IS 'The schema version that was the target of the most recent migration attempt.';
-COMMENT ON COLUMN codeinsights_schema_migrations.dirty IS 'Whether or not the most recent migration attempt failed.';
-
 COMMENT ON TABLE repo_names IS 'Records repository names, both historical and present, using a unique repository _name_ ID (unrelated to the repository ID.)';
 COMMENT ON COLUMN repo_names.id IS 'The repository _name_ ID.';
 COMMENT ON COLUMN repo_names.name IS 'The repository name string, with unique constraint for table entry deduplication and trigram index for e.g. regex filtering.';


### PR DESCRIPTION
`codeinsights_schema_migrations` will not be guaranteed to exist with the upcoming migration infrastructure when the first query file is ran.