### PR TITLE
migration: Add connection utils for tests

### DIFF
--- a/internal/database/connections/test/connect.go
+++ b/internal/database/connections/test/connect.go
@@ -1,0 +1,59 @@
+package connections
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/runner"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
+)
+
+// NewTestDB creates a new connection to the a database and applies the given migration.
+func NewTestDB(dsn string, schemas ...*schemas.Schema) (_ *sql.DB, err error) {
+	db, err := dbconn.Connect(dsn, "", "")
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			if closeErr := db.Close(); closeErr != nil {
+				err = multierror.Append(err, closeErr)
+			}
+		}
+	}()
+
+	options := runner.Options{
+		Up:          true,
+		SchemaNames: schemaNames(schemas),
+	}
+	if err := runner.NewRunner(newStoreFactoryMap(db, schemas)).Run(context.Background(), options); err != nil {
+		return nil, err
+	}
+
+	return db, nil
+}
+
+func newStoreFactoryMap(db *sql.DB, schemas []*schemas.Schema) map[string]runner.StoreFactory {
+	storeFactoryMap := make(map[string]runner.StoreFactory, len(schemas))
+	for _, schema := range schemas {
+		schema := schema
+
+		storeFactoryMap[schema.Name] = func(ctx context.Context) (runner.Store, error) {
+			return newMemoryStore(db), nil
+		}
+	}
+
+	return storeFactoryMap
+}
+
+func schemaNames(schemas []*schemas.Schema) []string {
+	names := make([]string, 0, len(schemas))
+	for _, schema := range schemas {
+		names = append(names, schema.Name)
+	}
+
+	return names
+}

--- a/internal/database/connections/test/connect.go
+++ b/internal/database/connections/test/connect.go
@@ -13,7 +13,7 @@ import (
 
 // NewTestDB creates a new connection to the a database and applies the given migration.
 func NewTestDB(dsn string, schemas ...*schemas.Schema) (_ *sql.DB, err error) {
-	db, err := dbconn.Connect(dsn, "", "")
+	db, _, err := dbconn.ConnectInternal(dsn, "", "", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/connections/test/store.go
+++ b/internal/database/connections/test/store.go
@@ -1,0 +1,46 @@
+package connections
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/definition"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/runner"
+)
+
+type memoryStore struct {
+	db         *sql.DB
+	version    int
+	versionSet bool
+	dirty      bool
+}
+
+func newMemoryStore(db *sql.DB) runner.Store {
+	return &memoryStore{
+		db: db,
+	}
+}
+
+func (s *memoryStore) Version(ctx context.Context) (int, bool, bool, error) {
+	return s.version, s.dirty, s.versionSet, nil
+}
+
+func (s *memoryStore) Lock(ctx context.Context) (bool, func(err error) error, error) {
+	return true, func(err error) error { return err }, nil
+}
+
+func (s *memoryStore) Up(ctx context.Context, migration definition.Definition) error {
+	return s.exec(ctx, migration, migration.UpQuery)
+}
+
+func (s *memoryStore) Down(ctx context.Context, migration definition.Definition) error {
+	return s.exec(ctx, migration, migration.DownQuery)
+}
+
+func (s *memoryStore) exec(ctx context.Context, migration definition.Definition, query *sqlf.Query) error {
+	_, err := s.db.ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
+	s.version, s.dirty, s.versionSet = migration.ID, s.dirty || err != nil, true
+	return err
+}

--- a/internal/database/connections/test/store.go
+++ b/internal/database/connections/test/store.go
@@ -10,6 +10,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/runner"
 )
 
+// memoryStore implements runner.Store but writes to migration metadata to any
+// underlying persistence layer.
 type memoryStore struct {
 	db         *sql.DB
 	version    int


### PR DESCRIPTION
Add `NewTestDB` that can be used for tests. This does not require the `internal/database/migration/store` package, which means that we will be free of import cycles when trying to test the migration packages themselves.

This implementation stores the migration state in memory rather in a table to avoid the cyclic dependency. The integration testing we have today is more than sufficient to catch the errors that could occur because we don't run our unit tests with the same store factory.
