### PR TITLE
migration: Thread observability context to store

### DIFF
--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -41,6 +41,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/httpserver"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 	"github.com/sourcegraph/sourcegraph/internal/profiler"
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
@@ -95,7 +96,7 @@ func defaultExternalURL(nginxAddr, httpAddr string) *url.URL {
 // InitDB initializes and returns the global database connection and sets the
 // version of the frontend in our versions table.
 func InitDB() (*sql.DB, error) {
-	sqlDB, err := connections.NewFrontendDB("", "frontend", true)
+	sqlDB, err := connections.NewFrontendDB("", "frontend", true, &observation.TestContext)
 	if err != nil {
 		return nil, errors.Errorf("failed to connect to frontend database: %s", err)
 	}

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -270,7 +270,7 @@ func getDB() (dbutil.DB, error) {
 	dsn := conf.GetServiceConnectionValueAndRestartOnChange(func(serviceConnections conftypes.ServiceConnections) string {
 		return serviceConnections.PostgresDSN
 	})
-	return connections.NewFrontendDB(dsn, "gitserver", false)
+	return connections.NewFrontendDB(dsn, "gitserver", false, &observation.TestContext)
 }
 
 func getVCSSyncer(ctx context.Context, externalServiceStore database.ExternalServiceStore, repoStore database.RepoStore,

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/httpserver"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/profiler"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
@@ -116,7 +117,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	dsn := conf.GetServiceConnectionValueAndRestartOnChange(func(serviceConnections conftypes.ServiceConnections) string {
 		return serviceConnections.PostgresDSN
 	})
-	sqlDB, err := connections.NewFrontendDB(dsn, "repo-updater", false)
+	sqlDB, err := connections.NewFrontendDB(dsn, "repo-updater", false, &observation.TestContext)
 	if err != nil {
 		log.Fatalf("failed to initialize database store: %v", err)
 	}

--- a/cmd/worker/workerdb/db.go
+++ b/cmd/worker/workerdb/db.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	connections "github.com/sourcegraph/sourcegraph/internal/database/connections/live"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 // Init initializes and returns a connection to the frontend database.
@@ -25,7 +26,7 @@ var initDatabaseMemo = memo.NewMemoizedConstructor(func() (interface{}, error) {
 	dsn := conf.GetServiceConnectionValueAndRestartOnChange(func(serviceConnections conftypes.ServiceConnections) string {
 		return serviceConnections.PostgresDSN
 	})
-	db, err := connections.NewFrontendDB(dsn, "worker", false)
+	db, err := connections.NewFrontendDB(dsn, "worker", false, &observation.TestContext)
 	if err != nil {
 		return nil, errors.Errorf("failed to connect to frontend database: %s", err)
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/services.go
+++ b/enterprise/cmd/frontend/internal/codeintel/services.go
@@ -107,7 +107,7 @@ func mustInitializeCodeIntelDB() *sql.DB {
 	dsn := conf.GetServiceConnectionValueAndRestartOnChange(func(serviceConnections conftypes.ServiceConnections) string {
 		return serviceConnections.CodeIntelPostgresDSN
 	})
-	db, err := connections.NewCodeIntelDB(dsn, "frontend", true)
+	db, err := connections.NewCodeIntelDB(dsn, "frontend", true, &observation.TestContext)
 	if err != nil {
 		log.Fatalf("Failed to connect to codeintel database: %s", err)
 	}

--- a/enterprise/cmd/precise-code-intel-worker/main.go
+++ b/enterprise/cmd/precise-code-intel-worker/main.go
@@ -125,7 +125,7 @@ func mustInitializeDB() *sql.DB {
 	dsn := conf.GetServiceConnectionValueAndRestartOnChange(func(serviceConnections conftypes.ServiceConnections) string {
 		return serviceConnections.PostgresDSN
 	})
-	sqlDB, err := connections.NewFrontendDB(dsn, "precise-code-intel-worker", false)
+	sqlDB, err := connections.NewFrontendDB(dsn, "precise-code-intel-worker", false, &observation.TestContext)
 	if err != nil {
 		log.Fatalf("Failed to connect to frontend database: %s", err)
 	}
@@ -151,7 +151,7 @@ func mustInitializeCodeIntelDB() *sql.DB {
 	dsn := conf.GetServiceConnectionValueAndRestartOnChange(func(serviceConnections conftypes.ServiceConnections) string {
 		return serviceConnections.CodeIntelPostgresDSN
 	})
-	db, err := connections.NewCodeIntelDB(dsn, "precise-code-intel-worker", true)
+	db, err := connections.NewCodeIntelDB(dsn, "precise-code-intel-worker", true, &observation.TestContext)
 	if err != nil {
 		log.Fatalf("Failed to connect to codeintel database: %s", err)
 	}

--- a/enterprise/cmd/worker/internal/codeintel/codeinteldb.go
+++ b/enterprise/cmd/worker/internal/codeintel/codeinteldb.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	connections "github.com/sourcegraph/sourcegraph/internal/database/connections/live"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 // InitCodeIntelDatabase initializes and returns a connection to the codeintel db.
@@ -25,7 +26,7 @@ var initCodeIntelDatabaseMemo = memo.NewMemoizedConstructor(func() (interface{},
 	dsn := conf.GetServiceConnectionValueAndRestartOnChange(func(serviceConnections conftypes.ServiceConnections) string {
 		return serviceConnections.CodeIntelPostgresDSN
 	})
-	db, err := connections.NewCodeIntelDB(dsn, "worker", false)
+	db, err := connections.NewCodeIntelDB(dsn, "worker", false, &observation.TestContext)
 	if err != nil {
 		return nil, errors.Errorf("failed to connect to codeintel database: %s", err)
 	}

--- a/enterprise/internal/insights/insights.go
+++ b/enterprise/internal/insights/insights.go
@@ -73,7 +73,7 @@ func InitializeCodeInsightsDB(app string) (*sql.DB, error) {
 	dsn := conf.GetServiceConnectionValueAndRestartOnChange(func(serviceConnections conftypes.ServiceConnections) string {
 		return serviceConnections.CodeInsightsTimescaleDSN
 	})
-	db, err := connections.NewCodeInsightsDB(dsn, app, true)
+	db, err := connections.NewCodeInsightsDB(dsn, app, true, &observation.TestContext)
 	if err != nil {
 		return nil, errors.Errorf("Failed to connect to codeinsights database: %s", err)
 	}

--- a/internal/database/connections/live/new.go
+++ b/internal/database/connections/live/new.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 // NewFrontendDB creates a new connection to the frontend database. After successful connection,
@@ -16,7 +17,7 @@ import (
 // the database schema is up to date.
 //
 // This connection is not expected to be closed but last the life of the calling application.
-func NewFrontendDB(dsn, appName string, migrate bool) (*sql.DB, error) {
+func NewFrontendDB(dsn, appName string, migrate bool, observationContext *observation.Context) (*sql.DB, error) {
 	migrations := []*schemas.Schema{schemas.Frontend}
 	if !migrate {
 		migrations = nil
@@ -35,7 +36,7 @@ func NewFrontendDB(dsn, appName string, migrate bool) (*sql.DB, error) {
 // the database schema is up to date.
 //
 // This connection is not expected to be closed but last the life of the calling application.
-func NewCodeIntelDB(dsn, appName string, migrate bool) (*sql.DB, error) {
+func NewCodeIntelDB(dsn, appName string, migrate bool, observationContext *observation.Context) (*sql.DB, error) {
 	migrations := []*schemas.Schema{schemas.CodeIntel}
 	if !migrate {
 		migrations = nil
@@ -54,7 +55,7 @@ func NewCodeIntelDB(dsn, appName string, migrate bool) (*sql.DB, error) {
 // the database schema is up to date.
 //
 // This connection is not expected to be closed but last the life of the calling application.
-func NewCodeInsightsDB(dsn, appName string, migrate bool) (*sql.DB, error) {
+func NewCodeInsightsDB(dsn, appName string, migrate bool, observationContext *observation.Context) (*sql.DB, error) {
 	migrations := []*schemas.Schema{schemas.CodeInsights}
 	if !migrate {
 		migrations = nil


### PR DESCRIPTION
This is a partial step towards making the `internal/database/connections` package use our own migration infrastructure (rather than golang migrate).