### PR TITLE
symbols: Prevent deadlock in larger repositories

### DIFF
--- a/cmd/symbols/internal/database/store/store.go
+++ b/cmd/symbols/internal/database/store/store.go
@@ -7,6 +7,7 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/jmoiron/sqlx"
 
+	"github.com/sourcegraph/sourcegraph/cmd/symbols/internal/parser"
 	"github.com/sourcegraph/sourcegraph/cmd/symbols/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
@@ -27,7 +28,7 @@ type Store interface {
 	CreateSymbolsTable(ctx context.Context) error
 	CreateSymbolIndexes(ctx context.Context) error
 	DeletePaths(ctx context.Context, paths []string) error
-	WriteSymbols(ctx context.Context, symbols <-chan result.Symbol) error
+	WriteSymbols(ctx context.Context, symbolOrErrors <-chan parser.SymbolOrError) error
 }
 
 type store struct {

--- a/cmd/symbols/internal/database/store/symbols.go
+++ b/cmd/symbols/internal/database/store/symbols.go
@@ -73,7 +73,11 @@ func (s *store) WriteSymbols(ctx context.Context, symbolOrErrors <-chan parser.S
 				return symbolOrError.Err
 			}
 
-			rows <- symbolToRow(symbolOrError.Symbol)
+			select {
+			case rows <- symbolToRow(symbolOrError.Symbol):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
 		}
 
 		return nil

--- a/cmd/symbols/internal/database/store/symbols.go
+++ b/cmd/symbols/internal/database/store/symbols.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/inconshreveable/log15"
 	"github.com/keegancsmith/sqlf"
 	"golang.org/x/sync/errgroup"
 
@@ -74,7 +73,6 @@ func (s *store) WriteSymbols(ctx context.Context, symbolOrErrors <-chan parser.S
 				return symbolOrError.Err
 			}
 
-			log15.Info("YEY!")
 			rows <- symbolToRow(symbolOrError.Symbol)
 		}
 

--- a/cmd/symbols/internal/database/writer/writer.go
+++ b/cmd/symbols/internal/database/writer/writer.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/symbols/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/diskcache"
-	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
 type DatabaseWriter interface {
@@ -67,7 +66,7 @@ func (w *databaseWriter) getNewestCommit(ctx context.Context, args types.SearchA
 }
 
 func (w *databaseWriter) writeDBFile(ctx context.Context, args types.SearchArgs, dbFile string) error {
-	return w.parseAndWriteInTransaction(ctx, args, nil, dbFile, func(tx store.Store, symbols <-chan result.Symbol) error {
+	return w.parseAndWriteInTransaction(ctx, args, nil, dbFile, func(tx store.Store, symbolOrErrors <-chan parser.SymbolOrError) error {
 		if err := tx.CreateMetaTable(ctx); err != nil {
 			return errors.Wrap(err, "store.CreateMetaTable")
 		}
@@ -77,7 +76,7 @@ func (w *databaseWriter) writeDBFile(ctx context.Context, args types.SearchArgs,
 		if err := tx.InsertMeta(ctx, string(args.CommitID)); err != nil {
 			return errors.Wrap(err, "store.InsertMeta")
 		}
-		if err := tx.WriteSymbols(ctx, symbols); err != nil {
+		if err := tx.WriteSymbols(ctx, symbolOrErrors); err != nil {
 			return errors.Wrap(err, "store.WriteSymbols")
 		}
 		if err := tx.CreateSymbolIndexes(ctx); err != nil {
@@ -129,14 +128,14 @@ func (w *databaseWriter) writeFileIncrementally(ctx context.Context, args types.
 		return false, err
 	}
 
-	return true, w.parseAndWriteInTransaction(ctx, args, addedOrModifiedPaths, dbFile, func(tx store.Store, symbols <-chan result.Symbol) error {
+	return true, w.parseAndWriteInTransaction(ctx, args, addedOrModifiedPaths, dbFile, func(tx store.Store, symbolOrErrors <-chan parser.SymbolOrError) error {
 		if err := tx.UpdateMeta(ctx, string(args.CommitID)); err != nil {
 			return errors.Wrap(err, "store.UpdateMeta")
 		}
 		if err := tx.DeletePaths(ctx, addedModifiedOrDeletedPaths); err != nil {
 			return errors.Wrap(err, "store.DeletePaths")
 		}
-		if err := tx.WriteSymbols(ctx, symbols); err != nil {
+		if err := tx.WriteSymbols(ctx, symbolOrErrors); err != nil {
 			return errors.Wrap(err, "store.WriteSymbols")
 		}
 
@@ -144,8 +143,8 @@ func (w *databaseWriter) writeFileIncrementally(ctx context.Context, args types.
 	})
 }
 
-func (w *databaseWriter) parseAndWriteInTransaction(ctx context.Context, args types.SearchArgs, paths []string, dbFile string, callback func(tx store.Store, symbols <-chan result.Symbol) error) (err error) {
-	symbols, err := w.parser.Parse(ctx, args, paths)
+func (w *databaseWriter) parseAndWriteInTransaction(ctx context.Context, args types.SearchArgs, paths []string, dbFile string, callback func(tx store.Store, symbolOrErrors <-chan parser.SymbolOrError) error) (err error) {
+	symbolOrErrors, err := w.parser.Parse(ctx, args, paths)
 	if err != nil {
 		return errors.Wrap(err, "parser.Parse")
 	}
@@ -153,13 +152,13 @@ func (w *databaseWriter) parseAndWriteInTransaction(ctx context.Context, args ty
 		if err != nil {
 			go func() {
 				// Drain channel on early exit
-				for range symbols {
+				for range symbolOrErrors {
 				}
 			}()
 		}
 	}()
 
 	return store.WithSQLiteStoreTransaction(ctx, dbFile, func(tx store.Store) error {
-		return callback(tx, symbols)
+		return callback(tx, symbolOrErrors)
 	})
 }

--- a/cmd/symbols/internal/fetcher/repository_fetcher.go
+++ b/cmd/symbols/internal/fetcher/repository_fetcher.go
@@ -47,12 +47,6 @@ func NewRepositoryFetcher(gitserverClient gitserver.GitserverClient, maximumConc
 func (f *repositoryFetcher) FetchRepositoryArchive(ctx context.Context, args types.SearchArgs, paths []string) <-chan parseRequestOrError {
 	requestCh := make(chan parseRequestOrError)
 
-	// Just skip this repo as it's clogging the pipes in Cloud
-	if string(args.Repo) == "github.com/sgtest/megarepo" {
-		close(requestCh)
-		return requestCh
-	}
-
 	go func() {
 		defer close(requestCh)
 


### PR DESCRIPTION
[In this code](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@6e51851fbb8a3457756853e278844d130f2d8db4/-/blob/cmd/symbols/internal/parser/parser.go?L78) we end up moving elements from `parseRequests` (buffered) to `symbols` (unbuffered). The consumer of the `symbols` channel is not yet activated as it requires the linked function to return. This requires the pipeline to stall once we fill the buffer on the requests. We'd usually sees something like this present itself immediately, but the buffer was large enough to make it seem to work without friction in dev.

Now we simply don't try to iterate the channel synchronously pre-return (which should never have worked). This requires a bit of refactor as now we have to expose an error where we didn't need to previously.