### PR TITLE
search: move repo job construction earlier in pipeline

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -819,6 +819,13 @@ func (r *searchResolver) toSearchInputs(q query.Q) (*search.TextParameters, []ru
 				OnMissingRepoRevs: zoektutil.MissingRepoRevStatus(r.stream),
 			})
 		}
+
+		if args.ResultTypes.Has(result.TypeRepo) {
+			jobs = append(jobs, &run.RepoSearch{
+				Args:  &args,
+				Limit: r.MaxResults(),
+			})
+		}
 	}
 	return &args, jobs, nil
 }
@@ -1685,13 +1692,6 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 			})
 
 			tr.LazyPrintf("sent excluded stats %#v", excluded)
-		})
-	}
-
-	if args.ResultTypes.Has(result.TypeRepo) {
-		jobs = append(jobs, &run.RepoSearch{
-			Args:  args,
-			Limit: limit,
 		})
 	}
 


### PR DESCRIPTION
We can move the repo job construction to `toSearchInputs` now since its clear nothing mutates `args` in between those steps. This helps lower the footprint of dependencies needed in `doResults`.