### PR TITLE
search: remove unused aggregator methods

### DIFF
--- a/internal/search/run/aggregator.go
+++ b/internal/search/run/aggregator.go
@@ -14,9 +14,6 @@ import (
 	searchrepos "github.com/sourcegraph/sourcegraph/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
-	"github.com/sourcegraph/sourcegraph/internal/search/symbol"
-	"github.com/sourcegraph/sourcegraph/internal/search/unindexed"
-	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
@@ -100,27 +97,4 @@ func (a *Aggregator) DoSearch(ctx context.Context, job Job, repos searchrepos.Pa
 
 	err = job.Run(ctx, a, repos)
 	return errors.Wrap(err, job.Name()+" search failed")
-}
-
-func (a *Aggregator) DoSymbolSearch(ctx context.Context, args *search.TextParameters, notSearcherOnly, globalSearch bool, limit int) (err error) {
-	tr, ctx := trace.New(ctx, "doSymbolSearch", "")
-	defer func() {
-		a.Error(err)
-		tr.SetError(err)
-		tr.Finish()
-	}()
-
-	err = symbol.Search(ctx, args, notSearcherOnly, globalSearch, limit, a)
-	return errors.Wrap(err, "symbol search failed")
-}
-
-func (a *Aggregator) DoFilePathSearch(ctx context.Context, zoektArgs zoektutil.IndexedSearchRequest, searcherArgs *search.SearcherParameters, notSearcherOnly bool, stream streaming.Sender) (err error) {
-	tr, ctx := trace.New(ctx, "doFilePathSearch", "")
-	defer func() {
-		a.Error(err)
-		tr.SetErrorIfNotContext(err)
-		tr.Finish()
-	}()
-
-	return unindexed.SearchFilesInRepos(ctx, zoektArgs, searcherArgs, notSearcherOnly, stream)
 }


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/28722. As in description. All searches go via `agg.DoSearch` now.