### PR TITLE
internal/extsvc/github: Simplify cachedGetRepository and its usage

### DIFF
--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -1677,15 +1677,13 @@ func nodeIDCacheKey(id string) string                   { return "1:" + id }
 var GetRepositoryMock func(ctx context.Context, owner, name string) (*Repository, error)
 
 // cachedGetRepository caches the getRepositoryFromAPI call.
-func (c *V3Client) cachedGetRepository(ctx context.Context, key string, getRepositoryFromAPI func(ctx context.Context) (repo *Repository, keys []string, err error), nocache bool) (*Repository, error) {
-	if !nocache {
-		if cached := c.getRepositoryFromCache(ctx, key); cached != nil {
-			reposGitHubCacheCounter.WithLabelValues("hit").Inc()
-			if cached.NotFound {
-				return nil, ErrRepoNotFound
-			}
-			return &cached.Repository, nil
+func (c *V3Client) cachedGetRepository(ctx context.Context, key string, getRepositoryFromAPI func(ctx context.Context) (repo *Repository, keys []string, err error)) (*Repository, error) {
+	if cached := c.getRepositoryFromCache(ctx, key); cached != nil {
+		reposGitHubCacheCounter.WithLabelValues("hit").Inc()
+		if cached.NotFound {
+			return nil, ErrRepoNotFound
 		}
+		return &cached.Repository, nil
 	}
 
 	repo, keys, err := getRepositoryFromAPI(ctx)

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -434,14 +434,17 @@ func (c *V3Client) GetRepository(ctx context.Context, owner, name string) (*Repo
 	}
 
 	key := ownerNameCacheKey(owner, name)
-	return c.cachedGetRepository(ctx, key, func(ctx context.Context) (repo *Repository, keys []string, err error) {
+
+	getRepoFromAPI := func(ctx context.Context) (repo *Repository, keys []string, err error) {
 		keys = append(keys, key)
 		repo, err = c.getRepositoryFromAPI(ctx, owner, name)
 		if repo != nil {
 			keys = append(keys, nodeIDCacheKey(repo.ID)) // also cache under GraphQL node ID
 		}
 		return repo, keys, err
-	}, false)
+	}
+
+	return c.cachedGetRepository(ctx, key, getRepoFromAPI)
 }
 
 // GetOrganization gets an org from GitHub by its login.


### PR DESCRIPTION
I was pairing with @mollylogue last week which is when the `nocache` falg tripped us up a little.

:point_right: **Note to reviewers:** The diff might be easier to check out with whitespaces disabled: https://github.com/sourcegraph/sourcegraph/pull/28725/files?diff=unified&w=1

As the name suggests, the method checks the cache before making an API
request. As a result it shouldn't really be accepting another
flag (`nocache`) to circumvent that process. A consumer can directly
use `getRepositoryFromAPI` if that was the requirement.

Additionally, the only place this method is used at the moment is in
the GitHub V3Client.GetRepository and the value of `nocache` is set to
`false`. As a result this is unreachable code and removing the
argument from the method's signature is a safe change. 

:information_source: Link to Sourcegraph query is [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@c9330b279f6f8562506de3beda6b51bbb30eb451/-/blob/internal/extsvc/github/v3.go?L437:11&subtree=true#tab=references).

Finally, in this commit we also remove the inline closure from
the invocation of `cachedGetRepository` and make it explicit to
improve readability.





<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
