### PR TITLE
batches: create batch change form

### DIFF
--- a/client/web/src/enterprise/batches/create/NamespaceSelector.tsx
+++ b/client/web/src/enterprise/batches/create/NamespaceSelector.tsx
@@ -39,9 +39,9 @@ export const NamespaceSelector: React.FunctionComponent<NamespaceSelectorProps> 
     )
 
     return (
-        <div className="form-group d-flex align-items-center">
-            <label className="text-nowrap mr-2 mb-0" htmlFor={NAMESPACE_SELECTOR_ID}>
-                <strong>Change namespace:</strong>
+        <div className="form-group">
+            <label className="text-nowrap mb-2" htmlFor={NAMESPACE_SELECTOR_ID}>
+                <strong>Namespace:</strong>
             </label>
             <select
                 className={classNames(styles.namespaceSelector, 'form-control')}

--- a/client/web/src/enterprise/batches/create/NewCreateBatchChangePage.module.scss
+++ b/client/web/src/enterprise/batches/create/NewCreateBatchChangePage.module.scss
@@ -1,5 +1,5 @@
 .namespace-selector {
-    max-width: 300px;
+    max-width: 180px;
 }
 
 .editor-layout-container {
@@ -18,4 +18,16 @@
     background: none;
     border: none;
     width: 30%;
+}
+
+.name-input {
+    max-width: 300px;
+}
+
+.settings-container {
+    align-self: center;
+    display: flex;
+    flex-direction: column;
+    width: 60%;
+    max-width: 1000px;
 }

--- a/client/web/src/enterprise/batches/create/NewCreateBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/NewCreateBatchChangePage.tsx
@@ -145,6 +145,7 @@ export const NewCreateBatchChangePage: React.FunctionComponent<CreateBatchChange
     const { executeBatchSpec, isLoading: isExecuting, error: executeError } = useExecuteBatchSpec(batchSpecID)
 
     // Disable the execute button if any of the following are true:
+    // * The batch change has not been created yet
     // * the batch spec code is invalid
     // * there was an error with the preview
     // * we're already in the middle of previewing or executing
@@ -153,7 +154,8 @@ export const NewCreateBatchChangePage: React.FunctionComponent<CreateBatchChange
     // * the current workspaces evaluation is not complete
     const [disableExecution, executionTooltip] = useMemo(() => {
         const disableExecution = Boolean(
-            isValid !== true ||
+            createEmptyBatchChangeData === undefined ||
+                isValid !== true ||
                 previewError ||
                 isLoadingPreview ||
                 isExecuting ||
@@ -163,7 +165,9 @@ export const NewCreateBatchChangePage: React.FunctionComponent<CreateBatchChange
         )
         // The execution tooltip only shows if the execute button is disabled, and explains why.
         const executionTooltip =
-            isValid === false || previewError
+            createEmptyBatchChangeData === undefined
+                ? "There's nothing to run yet."
+                : isValid === false || previewError
                 ? "There's a problem with your batch spec."
                 : !batchSpecID
                 ? 'Preview workspaces first before you run.'
@@ -175,6 +179,7 @@ export const NewCreateBatchChangePage: React.FunctionComponent<CreateBatchChange
 
         return [disableExecution, executionTooltip]
     }, [
+        createEmptyBatchChangeData,
         batchSpecID,
         isValid,
         previewError,

--- a/client/web/src/enterprise/batches/create/NewCreateBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/NewCreateBatchChangePage.tsx
@@ -64,7 +64,11 @@ export const NewCreateBatchChangePage: React.FunctionComponent<CreateBatchChange
 
     const [
         createEmptyBatchChange,
-        { data: createEmptyBatchChangeData, loading: createEmptyBatchChangeLoading },
+        {
+            data: createEmptyBatchChangeData,
+            loading: createEmptyBatchChangeLoading,
+            error: createEmptyBatchChangeError,
+        },
     ] = useMutation<CreateEmptyBatchChangeResult, CreateEmptyBatchChangeVariables>(CREATE_EMPTY_BATCH_CHANGE)
 
     const history = useHistory()
@@ -231,6 +235,7 @@ export const NewCreateBatchChangePage: React.FunctionComponent<CreateBatchChange
                 <div className={styles.settingsContainer}>
                     <h4>Batch specification settings</h4>
                     <Container>
+                        {createEmptyBatchChangeError && <ErrorAlert error={createEmptyBatchChangeError} />}
                         <NamespaceSelector
                             namespaces={namespaces}
                             selectedNamespace={selectedNamespace.id}

--- a/client/web/src/enterprise/batches/create/NewCreateBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/NewCreateBatchChangePage.tsx
@@ -54,6 +54,11 @@ export const NewCreateBatchChangePage: React.FunctionComponent<CreateBatchChange
     isLightTheme,
     settingsCascade,
 }) => {
+    const [
+        createEmptyBatchChange,
+        { data: createEmptyBatchChangeData, loading: createEmptyBatchChangeLoading },
+    ] = useMutation<CreateEmptyBatchChangeResult, CreateEmptyBatchChangeVariables>(CREATE_EMPTY_BATCH_CHANGE)
+
     const { namespaces, defaultSelectedNamespace } = useNamespaces(settingsCascade)
 
     // The namespace selected for creating the new batch spec under.

--- a/client/web/src/enterprise/batches/create/backend.ts
+++ b/client/web/src/enterprise/batches/create/backend.ts
@@ -19,6 +19,15 @@ export const CREATE_BATCH_SPEC_FROM_RAW = gql`
     }
 `
 
+export const CREATE_EMPTY_BATCH_CHANGE = gql`
+    mutation CreateEmptyBatchChange($namespace: ID!, $name: String!) {
+        createEmptyBatchChange(namespace: $namespace, name: $name) {
+            id
+            name
+        }
+    }
+`
+
 export const REPLACE_BATCH_SPEC_INPUT = gql`
     mutation ReplaceBatchSpecInput($previousSpec: ID!, $spec: String!, $noCache: Boolean!) {
         replaceBatchSpecInput(previousSpec: $previousSpec, batchSpec: $spec, noCache: $noCache) {


### PR DESCRIPTION
Note to self: This should be merged at the same time as the changes to omit the `name` field from the batch spec and to update the `createBatchSpecFromRaw` mutation to take the `batchChange` id as an arg, otherwise things will not work super well. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
