### PR TITLE
Prevent capture of errors coming from /go/* urls on Cloud environment.

### DIFF
--- a/cmd/frontend/internal/app/app.go
+++ b/cmd/frontend/internal/app/app.go
@@ -50,7 +50,9 @@ func NewHandler(db database.DB) http.Handler {
 	})))
 
 	if envvar.SourcegraphDotComMode() {
-		r.Get(router.GoSymbolURL).Handler(trace.Route(errorutil.Handler(serveGoSymbolURL(db))))
+		// This route has its error muted because the /go/* urls are deprecated and a common source
+		// of noise in Sentry due to having those pages still indexed in Google.
+		r.Get(router.GoSymbolURL).Handler(trace.Route(errorutil.HandlerWithErrorsMuted(serveGoSymbolURL(db))))
 	}
 
 	r.Get(router.UI).Handler(ui.Router())

--- a/internal/errcode/code.go
+++ b/internal/errcode/code.go
@@ -153,7 +153,7 @@ func IsTimeout(err error) bool {
 	return errors.As(err, &e) && e.Timeout()
 }
 
-// IsNonRetryable will check if err or one of its causes is a error that cannot be retried.
+// IsNonRetryable will check if err or one of its causes is an error that cannot be retried.
 func IsNonRetryable(err error) bool {
 	var e interface{ NonRetryable() bool }
 	return errors.As(err, &e) && e.NonRetryable()
@@ -167,3 +167,19 @@ func MakeNonRetryable(err error) error {
 type nonRetryableError struct{ error }
 
 func (nonRetryableError) NonRetryable() bool { return true }
+
+// IsMuted will check if err or one of its causes is an error that is muted.
+func IsMuted(err error) bool {
+	var e interface{ Muted() bool }
+	return errors.As(err, &e) && e.Muted()
+}
+
+// MakeMuted makes any error ignored by error reporting systems,
+// but is still logged.
+func MakeMuted(err error) error {
+	return mutedError{err}
+}
+
+type mutedError struct{ error }
+
+func (mutedError) Muted() bool { return true }

--- a/internal/sentry/sentry.go
+++ b/internal/sentry/sentry.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 )
 
@@ -82,6 +83,11 @@ func Init(c conftypes.WatchableSiteConfig) {
 }
 
 func captureError(err error, level sentry.Level, tags map[string]string) {
+	if errcode.IsMuted(err) {
+		// If the error is muted, skip capturing it.
+		return
+	}
+
 	event, extraDetails := errors.BuildSentryReport(err)
 
 	// Sentry uses the Type of the first exception as the issue title. By default,


### PR DESCRIPTION
Those errors are polluting our Sentry backlog and are extremely
numerous due to Google having indexed those pages.

These changes introduce a new type of errors, "Muted" which prevents
capture when they reach the Sentry error reporting code.

A convenient function has been added to `errorutil` to enable to
mute errors at the router level.

For example, in the last 48 hours, we have seen +1000 errors in total and are down to 56  after filtering out "/go/*" legacy urls. 

Questions
- Is the `Mute` terminology clear enough? 
- And if we're okay to silence that whole route itself obviously. 
  
