### PR TITLE
Update docs to upgrade pure_docker from 3.33 to 3.34.2 directly

### DIFF
--- a/doc/CODENOTIFY
+++ b/doc/CODENOTIFY
@@ -1,2 +1,2 @@
-**/admin/** @sourcegraph/distribution
+**/admin/** @sourcegraph/delivery
 dev/background-information/adding_ping_data.md @ebrodymoore @dadlerj

--- a/doc/admin/updates/pure_docker.md
+++ b/doc/admin/updates/pure_docker.md
@@ -16,7 +16,7 @@ To upgrade, please perform the changes in the following diff:
 ## 3.33 -> 3.34.2
 
 To upgrade, please perform the changes in the following diff:
-[https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/f1e4c1dc4bc44865254536f9fc71edcb60987025](https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/f1e4c1dc4bc44865254536f9fc71edcb60987025)
+[https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/d615dd5f63ec0984d60076aecf0bc598d9ffc1a8](https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/d615dd5f63ec0984d60076aecf0bc598d9ffc1a8)
 
 __Please upgrade directly to 3.34.2.__
 

--- a/doc/admin/updates/pure_docker.md
+++ b/doc/admin/updates/pure_docker.md
@@ -20,6 +20,8 @@ To upgrade, please perform the changes in the following diff:
 
 __Please upgrade directly to 3.34.2.__
 
+A bug in our 3.34 and 3.34.1 release causes some repositories from older Sourcegraph versions to not appear in search results due to a database change.
+
 *How smooth was this upgrade process for you? You can give us your feedback on this upgrade by filling out [this feedback form](https://share.hsforms.com/1aGeG7ALQQEGO6zyfauIiCA1n7ku?update_version=3.33).*
 
 ## 3.32 -> 3.33

--- a/doc/admin/updates/pure_docker.md
+++ b/doc/admin/updates/pure_docker.md
@@ -13,10 +13,12 @@ Each section comprehensively describes the changes needed in Docker images, envi
 To upgrade, please perform the changes in the following diff:
 [https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/e88d0f4615fc231576d37819b816576ac75b28d7](https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/e88d0f4615fc231576d37819b816576ac75b28d7)
 
-## 3.33 -> 3.34
+## 3.33 -> 3.34.2
 
 To upgrade, please perform the changes in the following diff:
-[https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/0c1c6d721653ba33853f4a26c8431a54730d12bf](https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/0c1c6d721653ba33853f4a26c8431a54730d12bf)
+[https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/f1e4c1dc4bc44865254536f9fc71edcb60987025](https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/f1e4c1dc4bc44865254536f9fc71edcb60987025)
+
+__Please upgrade directly to 3.34.2.__
 
 *How smooth was this upgrade process for you? You can give us your feedback on this upgrade by filling out [this feedback form](https://share.hsforms.com/1aGeG7ALQQEGO6zyfauIiCA1n7ku?update_version=3.33).*
 


### PR DESCRIPTION

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->

If customers haven't already upgrades from 3.33 to 3.34.x, they should go directly to 3.34.2.