### PR TITLE
observability: allow on-cancel observation finalizing and async error gathering

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/configuration.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/configuration.go
@@ -16,22 +16,19 @@ import (
 type IndexConfigurationResolver struct {
 	resolver     resolvers.Resolver
 	repositoryID int
-	op           *observation.Operation
+	errTracer    *observation.ErrorTracer
 }
 
-func NewIndexConfigurationResolver(resolver resolvers.Resolver, repositoryID int, op *observation.Operation) gql.IndexConfigurationResolver {
+func NewIndexConfigurationResolver(resolver resolvers.Resolver, repositoryID int, errTracer *observation.ErrorTracer) gql.IndexConfigurationResolver {
 	return &IndexConfigurationResolver{
 		resolver:     resolver,
 		repositoryID: repositoryID,
-		op:           op,
+		errTracer:    errTracer,
 	}
 }
 
 func (r *IndexConfigurationResolver) Configuration(ctx context.Context) (_ *string, err error) {
-	ctx, endObservatioin := r.op.With(ctx, &err, observation.Args{LogFields: []log.Field{
-		log.String("field", "configuration"),
-	}})
-	defer endObservatioin(1, observation.Args{})
+	defer r.errTracer.Collect(&err, log.String("indexConfigResolver.field", "configuration"))
 
 	configuration, exists, err := r.resolver.IndexConfiguration(ctx, r.repositoryID)
 	if err != nil {
@@ -45,10 +42,7 @@ func (r *IndexConfigurationResolver) Configuration(ctx context.Context) (_ *stri
 }
 
 func (r *IndexConfigurationResolver) InferredConfiguration(ctx context.Context) (_ *string, err error) {
-	ctx, endObservatioin := r.op.With(ctx, &err, observation.Args{LogFields: []log.Field{
-		log.String("field", "inferredConfiguration"),
-	}})
-	defer endObservatioin(1, observation.Args{})
+	defer r.errTracer.Collect(&err, log.String("indexConfigResolver.field", "inferredConfiguration"))
 
 	configuration, exists, err := r.resolver.InferredIndexConfiguration(ctx, r.repositoryID)
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/configuration.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/configuration.go
@@ -16,10 +16,10 @@ import (
 type IndexConfigurationResolver struct {
 	resolver     resolvers.Resolver
 	repositoryID int
-	errTracer    *observation.ErrorTracer
+	errTracer    *observation.ErrCollector
 }
 
-func NewIndexConfigurationResolver(resolver resolvers.Resolver, repositoryID int, errTracer *observation.ErrorTracer) gql.IndexConfigurationResolver {
+func NewIndexConfigurationResolver(resolver resolvers.Resolver, repositoryID int, errTracer *observation.ErrCollector) gql.IndexConfigurationResolver {
 	return &IndexConfigurationResolver{
 		resolver:     resolver,
 		repositoryID: repositoryID,

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/configuration_connection.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/configuration_connection.go
@@ -14,10 +14,10 @@ type codeIntelligenceConfigurationPolicyConnectionResolver struct {
 	db         database.DB
 	policies   []dbstore.ConfigurationPolicy
 	totalCount int
-	op         *observation.Operation
+	errTracer  *observation.ErrorTracer
 }
 
-func NewCodeIntelligenceConfigurationPolicyConnectionResolver(db database.DB, policies []dbstore.ConfigurationPolicy, totalCount int, op *observation.Operation) gql.CodeIntelligenceConfigurationPolicyConnectionResolver {
+func NewCodeIntelligenceConfigurationPolicyConnectionResolver(db database.DB, policies []dbstore.ConfigurationPolicy, totalCount int, errTracer *observation.ErrorTracer) gql.CodeIntelligenceConfigurationPolicyConnectionResolver {
 	return &codeIntelligenceConfigurationPolicyConnectionResolver{
 		db:         db,
 		policies:   policies,
@@ -28,7 +28,7 @@ func NewCodeIntelligenceConfigurationPolicyConnectionResolver(db database.DB, po
 func (r *codeIntelligenceConfigurationPolicyConnectionResolver) Nodes(ctx context.Context) ([]gql.CodeIntelligenceConfigurationPolicyResolver, error) {
 	resolvers := make([]gql.CodeIntelligenceConfigurationPolicyResolver, 0, len(r.policies))
 	for _, policy := range r.policies {
-		resolvers = append(resolvers, NewConfigurationPolicyResolver(r.db, policy, r.op))
+		resolvers = append(resolvers, NewConfigurationPolicyResolver(r.db, policy, r.errTracer))
 	}
 
 	return resolvers, nil

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/configuration_connection.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/configuration_connection.go
@@ -14,10 +14,10 @@ type codeIntelligenceConfigurationPolicyConnectionResolver struct {
 	db         database.DB
 	policies   []dbstore.ConfigurationPolicy
 	totalCount int
-	errTracer  *observation.ErrorTracer
+	errTracer  *observation.ErrCollector
 }
 
-func NewCodeIntelligenceConfigurationPolicyConnectionResolver(db database.DB, policies []dbstore.ConfigurationPolicy, totalCount int, errTracer *observation.ErrorTracer) gql.CodeIntelligenceConfigurationPolicyConnectionResolver {
+func NewCodeIntelligenceConfigurationPolicyConnectionResolver(db database.DB, policies []dbstore.ConfigurationPolicy, totalCount int, errTracer *observation.ErrCollector) gql.CodeIntelligenceConfigurationPolicyConnectionResolver {
 	return &codeIntelligenceConfigurationPolicyConnectionResolver{
 		db:         db,
 		policies:   policies,

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/configuration_policy.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/configuration_policy.go
@@ -19,10 +19,10 @@ import (
 type configurationPolicyResolver struct {
 	db                  database.DB
 	configurationPolicy store.ConfigurationPolicy
-	errTracer           *observation.ErrorTracer
+	errTracer           *observation.ErrCollector
 }
 
-func NewConfigurationPolicyResolver(db database.DB, configurationPolicy store.ConfigurationPolicy, op *observation.ErrorTracer) gql.CodeIntelligenceConfigurationPolicyResolver {
+func NewConfigurationPolicyResolver(db database.DB, configurationPolicy store.ConfigurationPolicy, op *observation.ErrCollector) gql.CodeIntelligenceConfigurationPolicyResolver {
 	return &configurationPolicyResolver{
 		db:                  db,
 		configurationPolicy: configurationPolicy,

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/configuration_policy.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/configuration_policy.go
@@ -19,14 +19,14 @@ import (
 type configurationPolicyResolver struct {
 	db                  database.DB
 	configurationPolicy store.ConfigurationPolicy
-	op                  *observation.Operation
+	errTracer           *observation.ErrorTracer
 }
 
-func NewConfigurationPolicyResolver(db database.DB, configurationPolicy store.ConfigurationPolicy, op *observation.Operation) gql.CodeIntelligenceConfigurationPolicyResolver {
+func NewConfigurationPolicyResolver(db database.DB, configurationPolicy store.ConfigurationPolicy, op *observation.ErrorTracer) gql.CodeIntelligenceConfigurationPolicyResolver {
 	return &configurationPolicyResolver{
 		db:                  db,
 		configurationPolicy: configurationPolicy,
-		op:                  op,
+		errTracer:           op,
 	}
 }
 
@@ -42,11 +42,11 @@ func (r *configurationPolicyResolver) Repository(ctx context.Context) (_ *gql.Re
 	if r.configurationPolicy.RepositoryID == nil {
 		return nil, nil
 	}
-	ctx, endObservation := r.op.With(ctx, &err, observation.Args{LogFields: []log.Field{
+
+	defer r.errTracer.Collect(&err,
 		log.Int("repoID", *r.configurationPolicy.RepositoryID),
 		log.String("configurationPolicyResolver.field", "repository"),
-	}})
-	defer endObservation(1, observation.Args{})
+	)
 
 	repo, err := backend.NewRepos(r.db.Repos()).Get(ctx, api.RepoID(*r.configurationPolicy.RepositoryID))
 	if err != nil {
@@ -61,12 +61,11 @@ func (r *configurationPolicyResolver) RepositoryPatterns() *[]string {
 }
 
 func (r *configurationPolicyResolver) Type() (_ gql.GitObjectType, err error) {
-	_, endObservation := r.op.With(context.Background(), &err, observation.Args{LogFields: []log.Field{
+	defer r.errTracer.Collect(&err,
 		log.Int("repoID", *r.configurationPolicy.RepositoryID),
 		log.String("configurationPolicyResolver.field", "type"),
 		log.String("policyType", string(r.configurationPolicy.Type)),
-	}})
-	defer endObservation(1, observation.Args{})
+	)
 
 	switch r.configurationPolicy.Type {
 	case store.GitObjectTypeCommit:

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index.go
@@ -21,10 +21,10 @@ type IndexResolver struct {
 	index            store.Index
 	prefetcher       *Prefetcher
 	locationResolver *CachedLocationResolver
-	traceErrs        *observation.ErrorTracer
+	traceErrs        *observation.ErrCollector
 }
 
-func NewIndexResolver(db database.DB, resolver resolvers.Resolver, index store.Index, prefetcher *Prefetcher, locationResolver *CachedLocationResolver, errTrace *observation.ErrorTracer) gql.LSIFIndexResolver {
+func NewIndexResolver(db database.DB, resolver resolvers.Resolver, index store.Index, prefetcher *Prefetcher, locationResolver *CachedLocationResolver, errTrace *observation.ErrCollector) gql.LSIFIndexResolver {
 	if index.AssociatedUploadID != nil {
 		// Request the next batch of upload fetches to contain the record's associated
 		// upload id, if one exists it exists. This allows the prefetcher.GetUploadByID

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index_connection.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index_connection.go
@@ -18,10 +18,10 @@ type IndexConnectionResolver struct {
 	indexesResolver  *resolvers.IndexesResolver
 	prefetcher       *Prefetcher
 	locationResolver *CachedLocationResolver
-	errTracer        *observation.ErrorTracer
+	errTracer        *observation.ErrCollector
 }
 
-func NewIndexConnectionResolver(db database.DB, resolver resolvers.Resolver, indexesResolver *resolvers.IndexesResolver, prefetcher *Prefetcher, locationResolver *CachedLocationResolver, errTracer *observation.ErrorTracer) gql.LSIFIndexConnectionResolver {
+func NewIndexConnectionResolver(db database.DB, resolver resolvers.Resolver, indexesResolver *resolvers.IndexesResolver, prefetcher *Prefetcher, locationResolver *CachedLocationResolver, errTracer *observation.ErrCollector) gql.LSIFIndexConnectionResolver {
 	return &IndexConnectionResolver{
 		db:               db,
 		resolver:         resolver,

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query.go
@@ -34,13 +34,13 @@ var ErrIllegalBounds = errors.New("illegal bounds")
 type QueryResolver struct {
 	resolver         resolvers.QueryResolver
 	locationResolver *CachedLocationResolver
-	errTracer        *observation.ErrorTracer
+	errTracer        *observation.ErrCollector
 }
 
 // NewQueryResolver creates a new QueryResolver with the given resolver that defines all code intel-specific
 // behavior. A cached location resolver instance is also given to the query resolver, which should be used
 // to resolve all location-related values.
-func NewQueryResolver(resolver resolvers.QueryResolver, locationResolver *CachedLocationResolver, errTracer *observation.ErrorTracer) gql.GitBlobLSIFDataResolver {
+func NewQueryResolver(resolver resolvers.QueryResolver, locationResolver *CachedLocationResolver, errTracer *observation.ErrCollector) gql.GitBlobLSIFDataResolver {
 	return &QueryResolver{
 		resolver:         resolver,
 		locationResolver: locationResolver,

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query.go
@@ -34,17 +34,17 @@ var ErrIllegalBounds = errors.New("illegal bounds")
 type QueryResolver struct {
 	resolver         resolvers.QueryResolver
 	locationResolver *CachedLocationResolver
-	op               *observation.Operation
+	errTracer        *observation.ErrorTracer
 }
 
 // NewQueryResolver creates a new QueryResolver with the given resolver that defines all code intel-specific
 // behavior. A cached location resolver instance is also given to the query resolver, which should be used
 // to resolve all location-related values.
-func NewQueryResolver(resolver resolvers.QueryResolver, locationResolver *CachedLocationResolver, op *observation.Operation) gql.GitBlobLSIFDataResolver {
+func NewQueryResolver(resolver resolvers.QueryResolver, locationResolver *CachedLocationResolver, errTracer *observation.ErrorTracer) gql.GitBlobLSIFDataResolver {
 	return &QueryResolver{
 		resolver:         resolver,
 		locationResolver: locationResolver,
-		op:               op,
+		errTracer:        errTracer,
 	}
 }
 
@@ -52,10 +52,7 @@ func (r *QueryResolver) ToGitTreeLSIFData() (gql.GitTreeLSIFDataResolver, bool) 
 func (r *QueryResolver) ToGitBlobLSIFData() (gql.GitBlobLSIFDataResolver, bool) { return r, true }
 
 func (r *QueryResolver) Stencil(ctx context.Context) (_ []gql.RangeResolver, err error) {
-	ctx, endObservation := r.op.With(ctx, &err, observation.Args{LogFields: []log.Field{
-		log.String("queryResolver.field", "stencil"),
-	}})
-	defer endObservation(1, observation.Args{})
+	defer r.errTracer.Collect(&err, log.String("queryResolver.field", "stencil"))
 
 	ranges, err := r.resolver.Stencil(ctx)
 	if err != nil {
@@ -71,10 +68,7 @@ func (r *QueryResolver) Stencil(ctx context.Context) (_ []gql.RangeResolver, err
 }
 
 func (r *QueryResolver) Ranges(ctx context.Context, args *gql.LSIFRangesArgs) (_ gql.CodeIntelligenceRangeConnectionResolver, err error) {
-	ctx, endObservation := r.op.With(ctx, &err, observation.Args{LogFields: []log.Field{
-		log.String("queryResolver.field", "ranges"),
-	}})
-	defer endObservation(1, observation.Args{})
+	defer r.errTracer.Collect(&err, log.String("queryResolver.field", "ranges"))
 
 	if args.StartLine < 0 || args.EndLine < args.StartLine {
 		return nil, ErrIllegalBounds
@@ -92,10 +86,7 @@ func (r *QueryResolver) Ranges(ctx context.Context, args *gql.LSIFRangesArgs) (_
 }
 
 func (r *QueryResolver) Definitions(ctx context.Context, args *gql.LSIFQueryPositionArgs) (_ gql.LocationConnectionResolver, err error) {
-	ctx, endObservation := r.op.With(ctx, &err, observation.Args{LogFields: []log.Field{
-		log.String("queryResolver.field", "definitions"),
-	}})
-	defer endObservation(1, observation.Args{})
+	defer r.errTracer.Collect(&err, log.String("queryResolver.field", "definitions"))
 
 	locations, err := r.resolver.Definitions(ctx, int(args.Line), int(args.Character))
 	if err != nil {
@@ -106,10 +97,7 @@ func (r *QueryResolver) Definitions(ctx context.Context, args *gql.LSIFQueryPosi
 }
 
 func (r *QueryResolver) References(ctx context.Context, args *gql.LSIFPagedQueryPositionArgs) (_ gql.LocationConnectionResolver, err error) {
-	ctx, endObservation := r.op.With(ctx, &err, observation.Args{LogFields: []log.Field{
-		log.String("queryResolver.field", "references"),
-	}})
-	defer endObservation(1, observation.Args{})
+	defer r.errTracer.Collect(&err, log.String("queryResolver.field", "references"))
 
 	limit := derefInt32(args.First, DefaultReferencesPageSize)
 	if limit <= 0 {
@@ -130,10 +118,7 @@ func (r *QueryResolver) References(ctx context.Context, args *gql.LSIFPagedQuery
 }
 
 func (r *QueryResolver) Implementations(ctx context.Context, args *gql.LSIFPagedQueryPositionArgs) (_ gql.LocationConnectionResolver, err error) {
-	ctx, endObservation := r.op.With(ctx, &err, observation.Args{LogFields: []log.Field{
-		log.String("queryResolver.field", "implementations"),
-	}})
-	defer endObservation(1, observation.Args{})
+	defer r.errTracer.Collect(&err, log.String("queryResolver.field", "implementations"))
 
 	limit := derefInt32(args.First, DefaultImplementationsPageSize)
 	if limit <= 0 {
@@ -154,10 +139,7 @@ func (r *QueryResolver) Implementations(ctx context.Context, args *gql.LSIFPaged
 }
 
 func (r *QueryResolver) Hover(ctx context.Context, args *gql.LSIFQueryPositionArgs) (_ gql.HoverResolver, err error) {
-	ctx, endObservation := r.op.With(ctx, &err, observation.Args{LogFields: []log.Field{
-		log.String("queryResolver.field", "hover"),
-	}})
-	defer endObservation(1, observation.Args{})
+	defer r.errTracer.Collect(&err, log.String("queryResolver.field", "hover"))
 
 	text, rx, exists, err := r.resolver.Hover(ctx, int(args.Line), int(args.Character))
 	if err != nil || !exists {
@@ -168,10 +150,7 @@ func (r *QueryResolver) Hover(ctx context.Context, args *gql.LSIFQueryPositionAr
 }
 
 func (r *QueryResolver) Diagnostics(ctx context.Context, args *gql.LSIFDiagnosticsArgs) (_ gql.DiagnosticConnectionResolver, err error) {
-	ctx, endObservation := r.op.With(ctx, &err, observation.Args{LogFields: []log.Field{
-		log.String("queryResolver.field", "diagnostics"),
-	}})
-	defer endObservation(1, observation.Args{})
+	defer r.errTracer.Collect(&err, log.String("queryResolver.field", "diagnostics"))
 
 	limit := derefInt32(args.First, DefaultDiagnosticsPageSize)
 	if limit <= 0 {
@@ -187,10 +166,7 @@ func (r *QueryResolver) Diagnostics(ctx context.Context, args *gql.LSIFDiagnosti
 }
 
 func (r *QueryResolver) Documentation(ctx context.Context, args *gql.LSIFQueryPositionArgs) (_ gql.DocumentationResolver, err error) {
-	ctx, endObservation := r.op.With(ctx, &err, observation.Args{LogFields: []log.Field{
-		log.String("queryResolver.field", "documentation"),
-	}})
-	defer endObservation(1, observation.Args{})
+	defer r.errTracer.Collect(&err, log.String("queryResolver.field", "documentation"))
 
 	documentations, err := r.resolver.Documentation(ctx, int(args.Line), int(args.Character))
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query_test.go
@@ -17,7 +17,7 @@ func TestRanges(t *testing.T) {
 	db := database.NewDB(nil)
 
 	mockResolver := resolvermocks.NewMockQueryResolver()
-	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), observation.TestOperation)
+	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), nil)
 
 	args := &gql.LSIFRangesArgs{StartLine: 10, EndLine: 20}
 	if _, err := resolver.Ranges(context.Background(), args); err != nil {
@@ -39,7 +39,7 @@ func TestDefinitions(t *testing.T) {
 	db := database.NewDB(nil)
 
 	mockResolver := resolvermocks.NewMockQueryResolver()
-	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), observation.TestOperation)
+	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), nil)
 
 	args := &gql.LSIFQueryPositionArgs{Line: 10, Character: 15}
 	if _, err := resolver.Definitions(context.Background(), args); err != nil {
@@ -61,7 +61,7 @@ func TestReferences(t *testing.T) {
 	db := database.NewDB(nil)
 
 	mockResolver := resolvermocks.NewMockQueryResolver()
-	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), observation.TestOperation)
+	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), nil)
 
 	offset := int32(25)
 	cursor := base64.StdEncoding.EncodeToString([]byte("test-cursor"))
@@ -100,7 +100,7 @@ func TestReferencesDefaultLimit(t *testing.T) {
 	db := database.NewDB(nil)
 
 	mockResolver := resolvermocks.NewMockQueryResolver()
-	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), observation.TestOperation)
+	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), nil)
 
 	args := &gql.LSIFPagedQueryPositionArgs{
 		LSIFQueryPositionArgs: gql.LSIFQueryPositionArgs{
@@ -126,7 +126,7 @@ func TestReferencesDefaultIllegalLimit(t *testing.T) {
 	db := database.NewDB(nil)
 
 	mockResolver := resolvermocks.NewMockQueryResolver()
-	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), observation.TestOperation)
+	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), observation.NewErrorTracer())
 
 	offset := int32(-1)
 	args := &gql.LSIFPagedQueryPositionArgs{
@@ -147,7 +147,7 @@ func TestHover(t *testing.T) {
 
 	mockResolver := resolvermocks.NewMockQueryResolver()
 	mockResolver.HoverFunc.SetDefaultReturn("text", lsifstore.Range{}, true, nil)
-	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), observation.TestOperation)
+	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), nil)
 
 	args := &gql.LSIFQueryPositionArgs{Line: 10, Character: 15}
 	if _, err := resolver.Hover(context.Background(), args); err != nil {
@@ -169,7 +169,7 @@ func TestDiagnostics(t *testing.T) {
 	db := database.NewDB(nil)
 
 	mockResolver := resolvermocks.NewMockQueryResolver()
-	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), observation.TestOperation)
+	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), nil)
 
 	offset := int32(25)
 	args := &gql.LSIFDiagnosticsArgs{
@@ -192,7 +192,7 @@ func TestDiagnosticsDefaultLimit(t *testing.T) {
 	db := database.NewDB(nil)
 
 	mockResolver := resolvermocks.NewMockQueryResolver()
-	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), observation.TestOperation)
+	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), nil)
 
 	args := &gql.LSIFDiagnosticsArgs{
 		ConnectionArgs: graphqlutil.ConnectionArgs{},
@@ -214,7 +214,7 @@ func TestDiagnosticsDefaultIllegalLimit(t *testing.T) {
 	db := database.NewDB(nil)
 
 	mockResolver := resolvermocks.NewMockQueryResolver()
-	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), observation.TestOperation)
+	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), nil)
 
 	offset := int32(-1)
 	args := &gql.LSIFDiagnosticsArgs{

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query_test.go
@@ -126,7 +126,7 @@ func TestReferencesDefaultIllegalLimit(t *testing.T) {
 	db := database.NewDB(nil)
 
 	mockResolver := resolvermocks.NewMockQueryResolver()
-	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), observation.NewErrorTracer())
+	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), observation.NewErrorCollector())
 
 	offset := int32(-1)
 	args := &gql.LSIFPagedQueryPositionArgs{
@@ -214,7 +214,7 @@ func TestDiagnosticsDefaultIllegalLimit(t *testing.T) {
 	db := database.NewDB(nil)
 
 	mockResolver := resolvermocks.NewMockQueryResolver()
-	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), nil)
+	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), observation.NewErrorCollector())
 
 	offset := int32(-1)
 	args := &gql.LSIFDiagnosticsArgs{

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/upload.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/upload.go
@@ -21,10 +21,10 @@ type UploadResolver struct {
 	upload           store.Upload
 	prefetcher       *Prefetcher
 	locationResolver *CachedLocationResolver
-	traceErrs        *observation.ErrorTracer
+	traceErrs        *observation.ErrCollector
 }
 
-func NewUploadResolver(db database.DB, resolver resolvers.Resolver, upload store.Upload, prefetcher *Prefetcher, locationResolver *CachedLocationResolver, traceErrs *observation.ErrorTracer) gql.LSIFUploadResolver {
+func NewUploadResolver(db database.DB, resolver resolvers.Resolver, upload store.Upload, prefetcher *Prefetcher, locationResolver *CachedLocationResolver, traceErrs *observation.ErrCollector) gql.LSIFUploadResolver {
 	if upload.AssociatedIndexID != nil {
 		// Request the next batch of index fetches to contain the record's associated
 		// index id, if one exists it exists. This allows the prefetcher.GetIndexByID

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/upload.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/upload.go
@@ -21,10 +21,10 @@ type UploadResolver struct {
 	upload           store.Upload
 	prefetcher       *Prefetcher
 	locationResolver *CachedLocationResolver
-	op               *observation.Operation
+	traceErrs        *observation.ErrorTracer
 }
 
-func NewUploadResolver(db database.DB, resolver resolvers.Resolver, upload store.Upload, prefetcher *Prefetcher, locationResolver *CachedLocationResolver, op *observation.Operation) gql.LSIFUploadResolver {
+func NewUploadResolver(db database.DB, resolver resolvers.Resolver, upload store.Upload, prefetcher *Prefetcher, locationResolver *CachedLocationResolver, traceErrs *observation.ErrorTracer) gql.LSIFUploadResolver {
 	if upload.AssociatedIndexID != nil {
 		// Request the next batch of index fetches to contain the record's associated
 		// index id, if one exists it exists. This allows the prefetcher.GetIndexByID
@@ -39,7 +39,7 @@ func NewUploadResolver(db database.DB, resolver resolvers.Resolver, upload store
 		upload:           upload,
 		prefetcher:       prefetcher,
 		locationResolver: locationResolver,
-		op:               op,
+		traceErrs:        traceErrs,
 	}
 }
 
@@ -69,18 +69,17 @@ func (r *UploadResolver) AssociatedIndex(ctx context.Context) (_ gql.LSIFIndexRe
 		return nil, nil
 	}
 
-	ctx, endObservation := r.op.With(ctx, &err, observation.Args{LogFields: []log.Field{
+	defer r.traceErrs.Collect(&err,
 		log.String("uploadResolver.field", "associatedIndex"),
 		log.Int("associatedIndex", *r.upload.AssociatedIndexID),
-	}})
-	defer endObservation(1, observation.Args{})
+	)
 
 	index, exists, err := r.prefetcher.GetIndexByID(ctx, *r.upload.AssociatedIndexID)
 	if err != nil || !exists {
 		return nil, err
 	}
 
-	return NewIndexResolver(r.db, r.resolver, index, r.prefetcher, r.locationResolver, r.op), nil
+	return NewIndexResolver(r.db, r.resolver, index, r.prefetcher, r.locationResolver, r.traceErrs), nil
 }
 
 func (r *UploadResolver) ProjectRoot(ctx context.Context) (*gql.GitTreeEntryResolver, error) {

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/upload_connection.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/upload_connection.go
@@ -18,10 +18,10 @@ type UploadConnectionResolver struct {
 	uploadsResolver  *resolvers.UploadsResolver
 	prefetcher       *Prefetcher
 	locationResolver *CachedLocationResolver
-	errTracer        *observation.ErrorTracer
+	errTracer        *observation.ErrCollector
 }
 
-func NewUploadConnectionResolver(db database.DB, resolver resolvers.Resolver, uploadsResolver *resolvers.UploadsResolver, prefetcher *Prefetcher, locationResolver *CachedLocationResolver, errTracer *observation.ErrorTracer) gql.LSIFUploadConnectionResolver {
+func NewUploadConnectionResolver(db database.DB, resolver resolvers.Resolver, uploadsResolver *resolvers.UploadsResolver, prefetcher *Prefetcher, locationResolver *CachedLocationResolver, errTracer *observation.ErrCollector) gql.LSIFUploadConnectionResolver {
 	return &UploadConnectionResolver{
 		resolver:         resolver,
 		uploadsResolver:  uploadsResolver,

--- a/go.mod
+++ b/go.mod
@@ -198,7 +198,7 @@ require (
 	github.com/bmatcuk/doublestar v1.3.4 // indirect
 	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d // indirect
 	github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f // indirect
-	github.com/cockroachdb/redact v1.1.3 // indirect
+	github.com/cockroachdb/redact v1.1.3
 	github.com/dave/jennifer v1.4.1 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/emirpasic/gods v1.12.0 // indirect

--- a/internal/observation/observation.go
+++ b/internal/observation/observation.go
@@ -56,6 +56,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cockroachdb/errors"
+	"github.com/hashicorp/go-multierror"
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -151,8 +153,38 @@ type Operation struct {
 type TraceLogger func(fields ...log.Field)
 
 // FinishFunc is the shape of the function returned by With and should be invoked within
-// a defer directly before the observed function returns.
+// a defer directly before the observed function returns or when a context is cancelled
+// with OnCancel.
 type FinishFunc func(count float64, args Args)
+
+// OnCancel allows for ending an observation when a context is cancelled as opposed to the
+// more common scenario of when the observed function returns through a defer. This can
+// be used for continuing an observation beyond the lifetime of a function if that function
+// returns more units of work that you want to observe as part of the original function.
+func (f FinishFunc) OnCancel(ctx context.Context, count float64, args Args) {
+	go func() {
+		<-ctx.Done()
+		f(count, args)
+	}()
+}
+
+type ErrorTracer struct {
+	multi       *multierror.Error
+	extraFields []log.Field
+}
+
+func NewErrorTracer() *ErrorTracer { return &ErrorTracer{multi: &multierror.Error{}} }
+
+func (e *ErrorTracer) Collect(err *error, fields ...log.Field) {
+	if err != nil && *err != nil {
+		e.multi.Errors = append(e.multi.Errors, *err)
+		e.extraFields = append(e.extraFields, fields...)
+	}
+}
+
+func (e *ErrorTracer) Error() string {
+	return e.multi.Error()
+}
 
 // Args configures the observation behavior of an invocation of an operation.
 type Args struct {
@@ -184,7 +216,34 @@ func (args Args) LogFieldPairs() []interface{} {
 	return pairs
 }
 
-// With prepares the necessary timers, loggers, and metrics to observe the invocation  of an
+// WithErrors prepares the necessary timers, loggers, and metrics to observe the invocation of an
+// operation. This method returns a modified context, an multi-error capturing type and a function to be deferred until the
+// end of the operation. It can be used with FinishFunc.OnCancel to capture multiple async errors.
+func (op *Operation) WithErrors(ctx context.Context, root *error, args Args) (context.Context, *ErrorTracer, FinishFunc) {
+	ctx, collector, _, endObservation := op.WithErrorsAndLogger(ctx, root, args)
+	return ctx, collector, endObservation
+}
+
+// WithErrorsAndLogger prepares the necessary timers, loggers, and metrics to observe the invocation of an
+// operation. This method returns a modified context, an multi-error capturing type, a function that will add a log field
+// to the active trace, and a function to be deferred until the end of the operation. It can be used with
+// FinishFunc.OnCancel to capture multiple async errors.
+func (op *Operation) WithErrorsAndLogger(ctx context.Context, root *error, args Args) (context.Context, *ErrorTracer, TraceLogger, FinishFunc) {
+	collector := NewErrorTracer()
+	err := error(collector)
+	ctx, traceLogger, endObservation := op.WithAndLogger(ctx, &err, args)
+	if root != nil {
+		endObservation = func(count float64, args Args) {
+			if *root != nil {
+				collector.multi.Errors = append(collector.multi.Errors, *root)
+			}
+			endObservation(count, args)
+		}
+	}
+	return ctx, collector, traceLogger, endObservation
+}
+
+// With prepares the necessary timers, loggers, and metrics to observe the invocation of an
 // operation. This method returns a modified context and a function to be deferred until the
 // end of the operation.
 func (op *Operation) With(ctx context.Context, err *error, args Args) (context.Context, FinishFunc) {
@@ -236,6 +295,10 @@ func (op *Operation) WithAndLogger(ctx context.Context, err *error, args Args) (
 		defaultFinishFields := []log.Field{log.Float64("count", count), log.Float64("elapsed", elapsed)}
 		logFields := mergeLogFields(defaultFinishFields, finishArgs.LogFields, args.LogFields)
 		metricLabels := mergeLabels(op.metricLabels, args.MetricLabelValues, finishArgs.MetricLabelValues)
+
+		if multi := new(ErrorTracer); err != nil && errors.As(*err, &multi) {
+			logFields = append(logFields, multi.extraFields...)
+		}
 
 		var (
 			logErr     = op.applyErrorFilter(err, EmitForLogs)


### PR DESCRIPTION
Previously, the observation package allowed only for observing a function from start to end. In the case of the GraphQL API, an entrypoint can return types that can be further resolved in an iterative yielding pattern, as opposed to recursively. As such, observing the entrypoint would not capture anything from the yielded sub-resolvers unless they too were observed independently. Our original approach did just that, passing down the named `*observation.Operation` for the entrypoint and starting a new observation off of that every time.

This PR allows for an observation to last beyond the return of the source function, and to be finished when a context is cancelled. To gather later sub-errors and args, and `ErrorTracer` type is introduced that can be passed around and defer collection of potential errors into a multierr. 