### PR TITLE
docker: bring back alpine 3.12

### DIFF
--- a/dev/check/no-alpine-guard.sh
+++ b/dev/check/no-alpine-guard.sh
@@ -15,6 +15,7 @@ set +e
 ALPINE_MATCHES=$(git grep -e '\salpine\:' --and --not -e '^\s*//' --and --not -e 'CI\:ALPINE_OK' \
   ':(exclude)doc/admin/updates/docker_compose.md' \
   ':(exclude)docker-images/README.md' \
+  ':(exclude)docker-images/alpine-3.12/' \
   ':(exclude)docker-images/alpine-3.14/' \
   ':(exclude)doc/batch_changes/' \
   ':(exclude)internal/cmd/git-combine/Dockerfile' \

--- a/docker-images/alpine-3.12/Dockerfile
+++ b/docker-images/alpine-3.12/Dockerfile
@@ -1,0 +1,35 @@
+# This Dockerfile defines the sourcegraph/alpine Docker image, which is the
+# base image used by all Sourcegraph Docker images.
+
+FROM alpine:3.12@sha256:74e5ad84a67e9b8ed7609b32dc2460b76175020923d7f494a73a851446222d18
+
+LABEL org.opencontainers.image.url=https://sourcegraph.com/
+LABEL org.opencontainers.image.source=https://github.com/sourcegraph/sourcegraph/
+LABEL org.opencontainers.image.documentation=https://docs.sourcegraph.com/
+
+# Add the sourcegraph group, user, and create the home directory.
+#
+# We use a static GID/UID assignment to ensure files can be chown'd to this
+# user on the host machine (where this user does not exist).
+# See https://github.com/sourcegraph/sourcegraph/issues/1884
+RUN addgroup -g 101 -S sourcegraph && adduser -u 100 -S -G sourcegraph -h /home/sourcegraph sourcegraph
+
+# Install bind-tools to ensure working DNS on user-defined Docker networks.
+#
+# IMPORTANT: Alpine by default does not come with some packages that are needed
+# for working DNS to other containers on a user-defined Docker network. Without
+# installing this package, nslookup, Go binaries, etc. will fail to contact
+# other Docker containers.
+# See https://github.com/sourcegraph/deploy-sourcegraph-docker/issues/1
+# Install other packages that are desirable in ALL Sourcegraph Docker images.
+# hadolint ignore=DL3018
+RUN apk update && apk add --no-cache \
+    bind-tools \
+    # Requires the use of the edge repo for CVE-2021-28831 until a patched version is brought into the 3.12 mirror.
+    'busybox=1.34.1-r3' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    ca-certificates \
+    curl \
+    mailcap \
+    tini \
+    # Required due to ssl_clent upgrade with busybox
+    'wget=1.21.1-r1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main

--- a/docker-images/alpine-3.12/README.md
+++ b/docker-images/alpine-3.12/README.md
@@ -1,0 +1,4 @@
+We are currently in the process of updating alpine from 3.12 to
+3.14 (https://github.com/sourcegraph/sourcegraph/pull/28176). During this process it might still be useful to bump our
+apline-3.12 to newer patch releases. For this reason we build both alpine 3.12 and 3.14 images. This folder should be
+removed once the upgrade to 3.14 is complete.

--- a/docker-images/alpine-3.12/build.sh
+++ b/docker-images/alpine-3.12/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -ex
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+docker build -t "${IMAGE:-sourcegraph/alpine-3.12}" .

--- a/enterprise/dev/ci/images/images.go
+++ b/enterprise/dev/ci/images/images.go
@@ -56,6 +56,7 @@ var SourcegraphDockerImages = append(DeploySourcegraphDockerImages,
 // Used to cross check images in the deploy-sourcegraph repo. If you are adding or removing an image to https://github.com/sourcegraph/deploy-sourcegraph
 // it must also be added to this list.
 var DeploySourcegraphDockerImages = []string{
+	"alpine-3.12",
 	"alpine-3.14",
 	"cadvisor",
 	"codeinsights-db",


### PR DESCRIPTION
While the upgrade to alpine 3.14 is ongoing, we still want to bump the
alpine-3.12 to a new patch release.

This reintroduces the alpine-3.12 docker image which I prematurely
removed in #28126.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
