### PR TITLE
chore: dbtest cleanup

### DIFF
--- a/internal/database/dbtest/dbtest.go
+++ b/internal/database/dbtest/dbtest.go
@@ -175,7 +175,7 @@ func wdHash() string {
 	h := fnv.New64()
 	wd, _ := os.Getwd()
 	h.Write([]byte(wd))
-	return strconv.Itoa(int(h.Sum64()))
+	return strconv.FormatUint(h.Sum64(), 10)
 }
 
 func dbConn(t testing.TB, cfg *url.URL) *sql.DB {
@@ -213,4 +213,5 @@ func dbExec(t testing.TB, db *sql.DB, q string, args ...interface{}) {
 
 const killClientConnsQuery = `
 SELECT pg_terminate_backend(pg_stat_activity.pid)
-FROM pg_stat_activity WHERE datname = $1`
+FROM pg_stat_activity WHERE datname = $1
+`

--- a/internal/database/dbtest/dbtest_fast.go
+++ b/internal/database/dbtest/dbtest_fast.go
@@ -39,7 +39,7 @@ func NewFastDBWithDSN(t testing.TB, dsn string) *sql.DB {
 
 	u, err := getDSN(dsn)
 	if err != nil {
-		t.Fatalf("failed to parse dsn: %s", err)
+		t.Fatalf("failed to parse dsn %q: %s", dsn, err)
 	}
 
 	pool, closeDB, err := newPoolFromURL(u)


### PR DESCRIPTION
Things I found while doing migrations work:

- Ensure that test databases aren't negative numbers (it looks weird as `sg-test-database--1234`).
- Formatting and error message cleanup