### PR TITLE
Conditionally run LSIF actions depending on changes

### DIFF
--- a/.github/workflows/lsif-go.yml
+++ b/.github/workflows/lsif-go.yml
@@ -1,0 +1,44 @@
+name: LSIF-Go
+on:
+  push:
+    paths:
+      - '**.go'
+
+jobs:
+  lsif-go:
+    # Skip running on forks
+    if: github.repository == 'sourcegraph/sourcegraph'
+    runs-on: ubuntu-latest
+    container: sourcegraph/lsif-go
+    strategy:
+      matrix:
+        root:
+          - ''
+          - lib
+    steps:
+      # Setup
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # Run lsif-go
+      - name: Run lsif-go
+        working-directory: ${{ matrix.root }}
+        # --dep-batch-size=100 avoids loading all deps into memory and getting OOM killed
+        run: lsif-go --no-animation --dep-batch-size=100
+
+      # Upload lsif-go data to Cloud, Dogfood, and Demo instances
+      - name: Upload lsif-go dump to Cloud
+        working-directory: ${{ matrix.root }}
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
+        env:
+          SRC_ENDPOINT: https://sourcegraph.com/
+      - name: Upload lsif-go dump to Dogfood
+        working-directory: ${{ matrix.root }}
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
+        env:
+          SRC_ENDPOINT: https://k8s.sgdev.org/
+      # - name: Upload lsif-go dump to Demo
+      #   working-directory: ${{ matrix.root }}
+      #   run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
+      #   env:
+      #     SRC_ENDPOINT: https://demo.sourcegraph.com/

--- a/.github/workflows/lsif-ts.yml
+++ b/.github/workflows/lsif-ts.yml
@@ -1,45 +1,10 @@
-name: LSIF
+name: LSIF-Ts
 on:
-  - push
+  push:
+    paths:
+      - '**.ts'
+      - '**.js'
 jobs:
-  lsif-go:
-    # Skip running on forks
-    if: github.repository == 'sourcegraph/sourcegraph'
-    runs-on: ubuntu-latest
-    container: sourcegraph/lsif-go
-    strategy:
-      matrix:
-        root:
-          - ''
-          - lib
-    steps:
-      # Setup
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      # Run lsif-go
-      - name: Run lsif-go
-        working-directory: ${{ matrix.root }}
-        # --dep-batch-size=100 avoids loading all deps into memory and getting OOM killed
-        run: lsif-go --no-animation --dep-batch-size=100
-
-      # Upload lsif-go data to Cloud, Dogfood, and Demo instances
-      - name: Upload lsif-go dump to Cloud
-        working-directory: ${{ matrix.root }}
-        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
-        env:
-          SRC_ENDPOINT: https://sourcegraph.com/
-      - name: Upload lsif-go dump to Dogfood
-        working-directory: ${{ matrix.root }}
-        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
-        env:
-          SRC_ENDPOINT: https://k8s.sgdev.org/
-      # - name: Upload lsif-go dump to Demo
-      #   working-directory: ${{ matrix.root }}
-      #   run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
-      #   env:
-      #     SRC_ENDPOINT: https://demo.sourcegraph.com/
-
   lsif-tsc-eslint:
     # Skip running on forks
     if: github.repository == 'sourcegraph/sourcegraph'


### PR DESCRIPTION
LSIF GitHub actions are systematically run on every PR, even when there are no changes related to the corresponding language. 

Because actions can filtered to only act on specific changes, this can be fixed but it requires splitting them into two separate actions, because we cannot perform that check at job level. 

<details>
  <summary>QA</summary>
  - https://github.com/sourcegraph/sourcegraph/runs/4461865614?check_suite_focus=true
<img width="971" alt="CleanShot 2021-12-08 at 20 21 37@2x" src="https://user-images.githubusercontent.com/10151/145271336-2b01f75f-321d-4749-bdbe-dbde8651b2ec.png">

  - https://github.com/sourcegraph/sourcegraph/runs/4461916516?check_suite_focus=true
<img width="939" alt="CleanShot 2021-12-08 at 20 22 49@2x" src="https://user-images.githubusercontent.com/10151/145271343-0c4281f1-7831-4232-b742-9f14f9c1d11c.png">
</details> 