### PR TITLE
database/connections/test: Simplify NewTestDB

### DIFF
--- a/enterprise/internal/insights/dbtesting/insights.go
+++ b/enterprise/internal/insights/dbtesting/insights.go
@@ -28,7 +28,7 @@ func TimescaleDB(t testing.TB) (db *sql.DB, cleanup func()) {
 	}
 
 	timescaleDSN := postgresdsn.New("codeinsights", username, os.Getenv)
-	initConn, closeInitConn, err := newTestDB(timescaleDSN)
+	initConn, err := newTestDB(timescaleDSN)
 	if err != nil {
 		t.Log("")
 		t.Log("README: To run these tests you need to have the codeinsights TimescaleDB running:")
@@ -63,17 +63,17 @@ func TimescaleDB(t testing.TB) (db *sql.DB, cleanup func()) {
 	}
 	u.Path = dbname
 	timescaleDSN = u.String()
-	db, closeDBConn, err := newTestDB(timescaleDSN, schemas.CodeInsights)
+	db, err = newTestDB(timescaleDSN, schemas.CodeInsights)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Perform DB migrations.
 	cleanup = func() {
-		if err := closeDBConn(nil); err != nil {
+		if err := db.Close(); err != nil {
 			t.Log(err)
 		}
-		defer closeInitConn(nil)
+		defer initConn.Close()
 		// It would be nice to cleanup by dropping the test DB we just created. But we can't:
 		//
 		// 	dropping test database ERROR: database "insights_test_testresolver_insights" is being accessed by other users (SQLSTATE 55006)
@@ -93,10 +93,6 @@ func TimescaleDB(t testing.TB) (db *sql.DB, cleanup func()) {
 // newTestDB connects to the given data source and returns the handle. After successful connection, the
 // schema version of the database will be compared against an expected version and the supplied migrations
 // may be run (taking an advisory lock to ensure exclusive access).
-//
-// This function returns a basestore-style callback that closes the database. This should be called instead
-// of calling Close directly on the database handle as it also handles closing migration objects associated
-// with the handle.
-func newTestDB(dsn string, schemas ...*schemas.Schema) (*sql.DB, func(err error) error, error) {
+func newTestDB(dsn string, schemas ...*schemas.Schema) (*sql.DB, error) {
 	return connections.NewTestDB(dsn, schemas...)
 }

--- a/internal/database/connections/test/connect.go
+++ b/internal/database/connections/test/connect.go
@@ -11,11 +11,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 )
 
-// NewTestDB creates a new connection to the a database and applies the given migration.
-func NewTestDB(dsn string, schemas ...*schemas.Schema) (_ *sql.DB, _ func(err error) error, err error) {
-	db, close, err := dbconn.ConnectInternal(dsn, "", "", nil)
+// NewTestDB creates a new connection to the a database and applies the given migrations.
+func NewTestDB(dsn string, schemas ...*schemas.Schema) (_ *sql.DB, err error) {
+	db, _, err := dbconn.ConnectInternal(dsn, "", "", nil)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	defer func() {
 		if err != nil {
@@ -30,10 +30,10 @@ func NewTestDB(dsn string, schemas ...*schemas.Schema) (_ *sql.DB, _ func(err er
 		SchemaNames: schemaNames(schemas),
 	}
 	if err := runner.NewRunner(newStoreFactoryMap(db, schemas)).Run(context.Background(), options); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return db, close, nil
+	return db, nil
 }
 
 func newStoreFactoryMap(db *sql.DB, schemas []*schemas.Schema) map[string]runner.StoreFactory {

--- a/internal/database/dbtest/dbtest.go
+++ b/internal/database/dbtest/dbtest.go
@@ -148,8 +148,7 @@ func initTemplateDB(t testing.TB, config *url.URL) {
 
 			cfgCopy := *config
 			cfgCopy.Path = "/" + templateName
-			_, close := dbConnInternal(t, &cfgCopy, schemas)
-			close(nil)
+			dbConnInternal(t, &cfgCopy, schemas).Close()
 		}
 
 		init("raw", nil)
@@ -179,27 +178,23 @@ func wdHash() string {
 }
 
 func dbConn(t testing.TB, cfg *url.URL) *sql.DB {
-	db, _ := dbConnInternal(t, cfg, nil)
+	db := dbConnInternal(t, cfg, nil)
 	return db
 }
 
-func dbConnInternal(t testing.TB, cfg *url.URL, schemas []*schemas.Schema) (*sql.DB, func(err error) error) {
+func dbConnInternal(t testing.TB, cfg *url.URL, schemas []*schemas.Schema) *sql.DB {
 	t.Helper()
-	db, close, err := newTestDB(cfg.String(), schemas...)
+	db, err := newTestDB(cfg.String(), schemas...)
 	if err != nil {
 		t.Fatalf("failed to connect to database %q: %s", cfg, err)
 	}
-	return db, close
+	return db
 }
 
 // newTestDB connects to the given data source and returns the handle. After successful connection, the
 // schema version of the database will be compared against an expected version and the supplied migrations
 // may be run (taking an advisory lock to ensure exclusive access).
-//
-// This function returns a basestore-style callback that closes the database. This should be called instead
-// of calling Close directly on the database handle as it also handles closing migration objects associated
-// with the handle.
-func newTestDB(dsn string, schemas ...*schemas.Schema) (*sql.DB, func(err error) error, error) {
+func newTestDB(dsn string, schemas ...*schemas.Schema) (*sql.DB, error) {
 	return connections.NewTestDB(dsn, schemas...)
 }
 

--- a/internal/database/dbtest/dbtest_fast.go
+++ b/internal/database/dbtest/dbtest_fast.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
 	"github.com/lib/pq"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
@@ -42,11 +43,11 @@ func NewFastDBWithDSN(t testing.TB, dsn string) *sql.DB {
 		t.Fatalf("failed to parse dsn %q: %s", dsn, err)
 	}
 
-	pool, closeDB, err := newPoolFromURL(u)
+	pool, err := newPoolFromURL(u)
 	if err != nil {
 		t.Fatalf("failed to create new pool: %s", err)
 	}
-	t.Cleanup(func() { closeDB(nil) })
+	t.Cleanup(func() { pool.Close() })
 
 	return newFromPool(t, u, pool)
 }
@@ -101,7 +102,7 @@ func getDefaultPool() (*testDatabasePool, *url.URL, error) {
 			return
 		}
 
-		defaultPool, _, defaultErr = newPoolFromURL(defaultURL)
+		defaultPool, defaultErr = newPoolFromURL(defaultURL)
 		if defaultErr != nil {
 			return
 		}
@@ -189,44 +190,48 @@ func urlWithDB(u *url.URL, dbName string) *url.URL {
 	return &uCopy
 }
 
-func newPoolFromURL(u *url.URL) (_ *testDatabasePool, _ func(err error) error, err error) {
-	db, closeDB, err := newTestDB(u.String())
+func newPoolFromURL(u *url.URL) (_ *testDatabasePool, err error) {
+	db, err := newTestDB(u.String())
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	defer func() { err = closeDB(err) }()
+	defer func() {
+		if closeErr := db.Close(); closeErr != nil {
+			err = multierror.Append(err, closeErr)
+		}
+	}()
 
 	// Ignore already exists error
 	// TODO: return error if it's not an already exists error
 	_, _ = db.Exec("CREATE DATABASE dbtest_pool")
 
 	poolDBURL := urlWithDB(u, "dbtest_pool")
-	poolDB, closePoolDB, err := newTestDB(poolDBURL.String())
+	poolDB, err := newTestDB(poolDBURL.String())
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	if !poolSchemaUpToDate(poolDB) {
-		if err := closePoolDB(nil); err != nil {
-			return nil, nil, err
+		if err := poolDB.Close(); err != nil {
+			return nil, err
 		}
 
 		if _, err = db.Exec("DROP DATABASE dbtest_pool"); err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		if _, err = db.Exec("CREATE DATABASE dbtest_pool"); err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 
-		poolDB, closePoolDB, err = newTestDB(poolDBURL.String())
+		poolDB, err = newTestDB(poolDBURL.String())
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 
 		if err := migratePoolDB(poolDB); err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	}
 
-	return newTestDatabasePool(poolDB), closePoolDB, nil
+	return newTestDatabasePool(poolDB), nil
 }

--- a/internal/database/dbtest/pool.go
+++ b/internal/database/dbtest/pool.go
@@ -191,12 +191,15 @@ func (t *testDatabasePool) GetTemplate(ctx context.Context, u *url.URL, schemas 
 		return nil, errors.Wrap(err, "create template database")
 	}
 
-	_, closeTemplateDB, err := newTestDB(urlWithDB(u, tdb.Name).String(), schemas...)
+	db, err := newTestDB(urlWithDB(u, tdb.Name).String(), schemas...)
 	if err != nil {
 		return nil, errors.Wrap(err, "migrate template DB")
 	}
+	if err := db.Close(); err != nil {
+		return nil, errors.Wrap(err, "close template DB")
+	}
 
-	return tdb, closeTemplateDB(nil)
+	return tdb, nil
 }
 
 const lockTemplateDBQuery = `


### PR DESCRIPTION
We used to return a wrapper around `db.Close()`, which we only used in order to close golang-migrate wrappers separately from the connection.

This PR removes that wrapper and calls `db.Close()` directly in the consumer.