### PR TITLE
diskcache: create custom context to pass parent context values through stack

### DIFF
--- a/internal/diskcache/cache.go
+++ b/internal/diskcache/cache.go
@@ -126,7 +126,7 @@ func (s *Store) OpenWithPath(ctx context.Context, key []string, fetcher FetcherW
 	go func(ctx context.Context) {
 		if s.BackgroundTimeout != 0 {
 			var cancel context.CancelFunc
-			ctx, cancel = context.WithTimeout(context.Background(), s.BackgroundTimeout)
+			ctx, cancel = WithIsolatedTimeout(ctx, s.BackgroundTimeout)
 			defer cancel()
 		}
 		f, err := doFetch(ctx, path, fetcher)

--- a/internal/diskcache/cache.go
+++ b/internal/diskcache/cache.go
@@ -126,7 +126,7 @@ func (s *Store) OpenWithPath(ctx context.Context, key []string, fetcher FetcherW
 	go func(ctx context.Context) {
 		if s.BackgroundTimeout != 0 {
 			var cancel context.CancelFunc
-			ctx, cancel = WithIsolatedTimeout(ctx, s.BackgroundTimeout)
+			ctx, cancel = withIsolatedTimeout(ctx, s.BackgroundTimeout)
 			defer cancel()
 		}
 		f, err := doFetch(ctx, path, fetcher)

--- a/internal/diskcache/context.go
+++ b/internal/diskcache/context.go
@@ -10,9 +10,9 @@ type isolatedTimeoutContext struct {
 	deadlineCtx context.Context
 }
 
-// WithIsolatedTimeout creates a context with a timeout isolated from any timeouts in any of the ancestor contexts.
+// withIsolatedTimeout creates a context with a timeout isolated from any timeouts in any of the ancestor contexts.
 // Context values are pulled from the parent context only.
-func WithIsolatedTimeout(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+func withIsolatedTimeout(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
 	deadlineCtx, cancelFunc := context.WithTimeout(context.Background(), timeout)
 	return &isolatedTimeoutContext{
 		parent:      parent,

--- a/internal/diskcache/context.go
+++ b/internal/diskcache/context.go
@@ -11,6 +11,7 @@ type isolatedTimeoutContext struct {
 }
 
 // WithIsolatedTimeout creates a context with a timeout isolated from any timeouts in any of the ancestor contexts.
+// Context values are pulled from the parent context only.
 func WithIsolatedTimeout(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
 	deadlineCtx, cancelFunc := context.WithTimeout(context.Background(), timeout)
 	return &isolatedTimeoutContext{

--- a/internal/diskcache/context.go
+++ b/internal/diskcache/context.go
@@ -1,0 +1,38 @@
+package diskcache
+
+import (
+	"context"
+	"time"
+)
+
+type isolatedTimeoutContext struct {
+	parent      context.Context
+	deadlineCtx context.Context
+}
+
+// WithIsolatedTimeout creates a context with a timeout isolated from any timeouts in any of the ancestor contexts.
+func WithIsolatedTimeout(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	deadlineCtx, cancelFunc := context.WithTimeout(context.Background(), timeout)
+	return &isolatedTimeoutContext{
+		parent:      parent,
+		deadlineCtx: deadlineCtx,
+	}, cancelFunc
+}
+
+var _ context.Context = &isolatedTimeoutContext{}
+
+func (c *isolatedTimeoutContext) Deadline() (time.Time, bool) {
+	return c.deadlineCtx.Deadline()
+}
+
+func (c *isolatedTimeoutContext) Done() <-chan struct{} {
+	return c.deadlineCtx.Done()
+}
+
+func (c *isolatedTimeoutContext) Err() error {
+	return c.deadlineCtx.Err()
+}
+
+func (c *isolatedTimeoutContext) Value(key interface{}) interface{} {
+	return c.parent.Value(key)
+}


### PR DESCRIPTION
Previously, context values wouldnt propagate to the disk-cache fetcher function from the calling function if a background timeout was set. This was done so that any timeouts of any ancestor contexts of the background timeout context would not cause an early context timeout.

This PR creates a custom context that has an isolated timeout while still being able to carry values down the stack.