### PR TITLE
sg: install.sh follow symlink before warning about it not being in $PATH

### DIFF
--- a/dev/sg/install.sh
+++ b/dev/sg/install.sh
@@ -77,6 +77,7 @@ echo "  sg installed to $target"
 # accordingly in terms of usage.
 
 set +e # Don't fail if it the check fails
+# We try to follow possible symlinks to display the actual path
 sg_in_path=$(readlink -f $(command -v sg))
 set -e
 

--- a/dev/sg/install.sh
+++ b/dev/sg/install.sh
@@ -77,7 +77,7 @@ echo "  sg installed to $target"
 # accordingly in terms of usage.
 
 set +e # Don't fail if it the check fails
-sg_in_path=$(command -v sg)
+sg_in_path=$(readlink -f $(command -v sg))
 set -e
 
 red_bg=$'\033[41m'


### PR DESCRIPTION
this is useful for users thank symlink it from their asdf golang dir into
a private bin dir, like:

    ln -s ~/.asdf/installs/golang/1.17.3/packages/bin/sg ~/.local/bin



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
