### PR TITLE
insights: log statistics about insight backfills for debugging

### DIFF
--- a/enterprise/internal/insights/background/historical_enqueuer_test.go
+++ b/enterprise/internal/insights/background/historical_enqueuer_test.go
@@ -141,6 +141,7 @@ func testHistoricalEnqueuer(t *testing.T, p *testParams) *testResults {
 		framesToBackfill:      func() int { return p.frames },
 		frameLength:           func() time.Duration { return 7 * 24 * time.Hour },
 		dataSeriesStore:       dataSeriesStore,
+		statistics:            make(statistics),
 	}
 
 	// If we do an iteration without any insights or repos, we should expect no sleep calls to be made.


### PR DESCRIPTION
Adding some statistics to get a better picture of a backfilled series. Just logging these for now, but if this becomes more useful we can put this in a table.
