### PR TITLE
codeintel: track if symbols parse is full/partial/cached in observability

### DIFF
--- a/cmd/symbols/internal/api/observability.go
+++ b/cmd/symbols/internal/api/observability.go
@@ -15,7 +15,7 @@ func newOperations(observationContext *observation.Context) *operations {
 	metrics := metrics.NewREDMetrics(
 		observationContext.Registerer,
 		"codeintel_symbols_api",
-		metrics.WithLabels("op"),
+		metrics.WithLabels("op", "parseAmount"),
 		metrics.WithCountHelp("Total number of method invocations."),
 		metrics.WithDurationBuckets([]float64{1, 2, 5, 10, 30, 60}),
 	)

--- a/cmd/symbols/internal/api/observability/parse_observation.go
+++ b/cmd/symbols/internal/api/observability/parse_observation.go
@@ -1,0 +1,39 @@
+package observability
+
+import (
+	"context"
+)
+
+type (
+	parseAmountKey int
+	parseAmount    string
+)
+
+const (
+	parseAmntKey parseAmountKey = iota
+
+	FullParse    parseAmount = "full-parse"
+	PartialParse parseAmount = "partial-parse"
+	CachedParse  parseAmount = "cached-parse"
+)
+
+func SeedParseAmount(ctx context.Context) context.Context {
+	// we use a pointer so that we can replace the value by dereferencing
+	// further down the callstack
+	amount := new(parseAmount)
+	return context.WithValue(ctx, parseAmntKey, amount)
+}
+
+func SetParseAmount(ctx context.Context, amount parseAmount) {
+	if amnt, ok := ctx.Value(parseAmntKey).(*parseAmount); ok {
+		*amnt = amount
+		return
+	}
+}
+
+func GetParseAmount(ctx context.Context) string {
+	if amnt, ok := ctx.Value(parseAmntKey).(*parseAmount); ok && amnt != nil {
+		return string(*amnt)
+	}
+	return ""
+}

--- a/cmd/symbols/internal/database/writer/cache.go
+++ b/cmd/symbols/internal/database/writer/cache.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 
+	"github.com/sourcegraph/sourcegraph/cmd/symbols/internal/api/observability"
 	"github.com/sourcegraph/sourcegraph/cmd/symbols/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/diskcache"
 )
@@ -37,6 +38,8 @@ func (w *cachedDatabaseWriter) GetOrCreateDatabaseFile(ctx context.Context, args
 		fmt.Sprintf("%s-%d", args.CommitID, symbolsDBVersion),
 	}
 
+	// set to noop parse originally, this will be overridden if the fetcher func below is called
+	observability.SetParseAmount(ctx, observability.CachedParse)
 	cacheFile, err := w.cache.OpenWithPath(ctx, key, func(fetcherCtx context.Context, tempDBFile string) error {
 		if err := w.databaseWriter.WriteDBFile(fetcherCtx, args, tempDBFile); err != nil {
 			return errors.Wrap(err, "databaseWriter.WriteDBFile")

--- a/cmd/symbols/internal/parser/parser.go
+++ b/cmd/symbols/internal/parser/parser.go
@@ -114,7 +114,9 @@ func (p *parser) Parse(ctx context.Context, args types.SearchArgs, paths []strin
 				}
 
 				atomic.AddUint32(&totalRequests, 1)
-				_ = p.handleParseRequest(ctx, symbolOrErrors, parseRequestOrError.ParseRequest, &totalSymbols)
+				if err := p.handleParseRequest(ctx, symbolOrErrors, parseRequestOrError.ParseRequest, &totalSymbols); err != nil {
+					log15.Error("error handling parse request", "error", err, "path", parseRequestOrError.ParseRequest.Path)
+				}
 			}
 		}()
 	}

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -10822,7 +10822,7 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100010` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_symbols_api_total{job=~"^symbols.*"}[5m]))`
+Query: `sum by (op,parseAmount)(increase(src_codeintel_symbols_api_total{job=~"^symbols.*"}[5m]))`
 
 </details>
 
@@ -10841,7 +10841,7 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100011` o
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_codeintel_symbols_api_duration_seconds_bucket{job=~"^symbols.*"}[5m])))`
+Query: `histogram_quantile(0.99, sum  by (le,op,parseAmount)(rate(src_codeintel_symbols_api_duration_seconds_bucket{job=~"^symbols.*"}[5m])))`
 
 </details>
 
@@ -10860,7 +10860,7 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100012` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_symbols_api_errors_total{job=~"^symbols.*"}[5m]))`
+Query: `sum by (op,parseAmount)(increase(src_codeintel_symbols_api_errors_total{job=~"^symbols.*"}[5m]))`
 
 </details>
 
@@ -10879,7 +10879,7 @@ To see this panel, visit `/-/debug/grafana/d/symbols/symbols?viewPanel=100013` o
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (op)(increase(src_codeintel_symbols_api_errors_total{job=~"^symbols.*"}[5m])) / (sum by (op)(increase(src_codeintel_symbols_api_total{job=~"^symbols.*"}[5m])) + sum by (op)(increase(src_codeintel_symbols_api_errors_total{job=~"^symbols.*"}[5m]))) * 100`
+Query: `sum by (op,parseAmount)(increase(src_codeintel_symbols_api_errors_total{job=~"^symbols.*"}[5m])) / (sum by (op,parseAmount)(increase(src_codeintel_symbols_api_total{job=~"^symbols.*"}[5m])) + sum by (op,parseAmount)(increase(src_codeintel_symbols_api_errors_total{job=~"^symbols.*"}[5m]))) * 100`
 
 </details>
 

--- a/monitoring/definitions/shared/codeintel.go
+++ b/monitoring/definitions/shared/codeintel.go
@@ -859,7 +859,7 @@ func (codeIntelligence) NewSymbolsAPIGroup(containerName string) monitoring.Grou
 				MetricNameRoot:        "codeintel_symbols_api",
 				MetricDescriptionRoot: "API",
 				Filters:               []string{},
-				By:                    []string{"op"},
+				By:                    []string{"op", "parseAmount"},
 			},
 		},
 		SharedObservationGroupOptions: SharedObservationGroupOptions{


### PR DESCRIPTION
It does THE THING:
![image](https://user-images.githubusercontent.com/18282288/145286160-3214bd52-316c-4c0c-9369-91f6f4619004.png)


To land after https://github.com/sourcegraph/sourcegraph/pull/28754