### PR TITLE
Code monitors: add execution code for generic webhook

### DIFF
--- a/enterprise/internal/codemonitors/background/slack_test.go
+++ b/enterprise/internal/codemonitors/background/slack_test.go
@@ -17,10 +17,11 @@ func TestSlackWebhook(t *testing.T) {
 
 	t.Run("no error", func(t *testing.T) {
 		action := actionArgs{
-			MonitorDescription: "My test monitor", MonitorURL: "https://google.com",
-			Query:      "repo:camdentest -file:id_rsa.pub BEGIN",
-			QueryURL:   "https://youtube.com",
-			NumResults: 31313,
+			MonitorDescription: "My test monitor",
+			MonitorURL:         "https://google.com",
+			Query:              "repo:camdentest -file:id_rsa.pub BEGIN",
+			QueryURL:           "https://youtube.com",
+			NumResults:         31313,
 		}
 
 		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -38,10 +39,11 @@ func TestSlackWebhook(t *testing.T) {
 
 	t.Run("error is returned", func(t *testing.T) {
 		action := actionArgs{
-			MonitorDescription: "My test monitor", MonitorURL: "https://google.com",
-			Query:      "repo:camdentest -file:id_rsa.pub BEGIN",
-			QueryURL:   "https://youtube.com",
-			NumResults: 31313,
+			MonitorDescription: "My test monitor",
+			MonitorURL:         "https://google.com",
+			Query:              "repo:camdentest -file:id_rsa.pub BEGIN",
+			QueryURL:           "https://youtube.com",
+			NumResults:         31313,
 		}
 
 		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/enterprise/internal/codemonitors/background/testdata/TestWebhook/error_is_returned.json
+++ b/enterprise/internal/codemonitors/background/testdata/TestWebhook/error_is_returned.json
@@ -1,0 +1,1 @@
+{"MonitorDescription":"My test monitor","MonitorURL":"https://google.com","Query":"repo:camdentest -file:id_rsa.pub BEGIN","QueryURL":"https://youtube.com","NumResults":31313}

--- a/enterprise/internal/codemonitors/background/testdata/TestWebhook/no_error.json
+++ b/enterprise/internal/codemonitors/background/testdata/TestWebhook/no_error.json
@@ -1,0 +1,1 @@
+{"MonitorDescription":"My test monitor","MonitorURL":"https://google.com","Query":"repo:camdentest -file:id_rsa.pub BEGIN","QueryURL":"https://youtube.com","NumResults":31313}

--- a/enterprise/internal/codemonitors/background/webhook.go
+++ b/enterprise/internal/codemonitors/background/webhook.go
@@ -1,0 +1,47 @@
+package background
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/cockroachdb/errors"
+
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+)
+
+func sendWebhookNotification(ctx context.Context, url string, args actionArgs) error {
+	return postWebhook(ctx, httpcli.ExternalDoer, url, args)
+}
+
+func postWebhook(ctx context.Context, doer httpcli.Doer, url string, args actionArgs) error {
+	raw, err := json.Marshal(args)
+	if err != nil {
+		return errors.Wrap(err, "marshal failed")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(raw))
+	if err != nil {
+		return errors.Wrap(err, "failed new request")
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := doer.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "failed to post webhook")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return StatusCodeError{
+			Code:   resp.StatusCode,
+			Status: resp.Status,
+			Body:   string(body),
+		}
+	}
+
+	return nil
+}

--- a/enterprise/internal/codemonitors/background/webhook_test.go
+++ b/enterprise/internal/codemonitors/background/webhook_test.go
@@ -12,9 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
 )
 
-func TestSlackWebhook(t *testing.T) {
-	t.Parallel()
-
+func TestWebhook(t *testing.T) {
 	t.Run("no error", func(t *testing.T) {
 		action := actionArgs{
 			MonitorDescription: "My test monitor", MonitorURL: "https://google.com",
@@ -32,7 +30,7 @@ func TestSlackWebhook(t *testing.T) {
 		defer s.Close()
 
 		client := s.Client()
-		err := postSlackWebhook(context.Background(), client, s.URL, slackPayload(action))
+		err := postWebhook(context.Background(), client, s.URL, action)
 		require.NoError(t, err)
 	})
 
@@ -53,7 +51,7 @@ func TestSlackWebhook(t *testing.T) {
 		defer s.Close()
 
 		client := s.Client()
-		err := postSlackWebhook(context.Background(), client, s.URL, slackPayload(action))
+		err := postWebhook(context.Background(), client, s.URL, action)
 		require.Error(t, err)
 	})
 }

--- a/enterprise/internal/codemonitors/background/webhook_test.go
+++ b/enterprise/internal/codemonitors/background/webhook_test.go
@@ -15,10 +15,11 @@ import (
 func TestWebhook(t *testing.T) {
 	t.Run("no error", func(t *testing.T) {
 		action := actionArgs{
-			MonitorDescription: "My test monitor", MonitorURL: "https://google.com",
-			Query:      "repo:camdentest -file:id_rsa.pub BEGIN",
-			QueryURL:   "https://youtube.com",
-			NumResults: 31313,
+			MonitorDescription: "My test monitor",
+			MonitorURL:         "https://google.com",
+			Query:              "repo:camdentest -file:id_rsa.pub BEGIN",
+			QueryURL:           "https://youtube.com",
+			NumResults:         31313,
 		}
 
 		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -36,10 +37,11 @@ func TestWebhook(t *testing.T) {
 
 	t.Run("error is returned", func(t *testing.T) {
 		action := actionArgs{
-			MonitorDescription: "My test monitor", MonitorURL: "https://google.com",
-			Query:      "repo:camdentest -file:id_rsa.pub BEGIN",
-			QueryURL:   "https://youtube.com",
-			NumResults: 31313,
+			MonitorDescription: "My test monitor",
+			MonitorURL:         "https://google.com",
+			Query:              "repo:camdentest -file:id_rsa.pub BEGIN",
+			QueryURL:           "https://youtube.com",
+			NumResults:         31313,
 		}
 
 		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This adds (mostly placeholder) code to execute a generic webhook. It
doesn't attempt to define the payload shape, so just directly marshals
the actionArgs struct for the time being. That is easy to change once
we've settled on a payload shape.

There's some duplicate code that I will try to clean up in followup PRs.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
