### PR TITLE
gitserver: add SG_PAUSE file

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -2003,6 +2003,11 @@ func (s *Server) doRepoUpdate(ctx context.Context, repo api.RepoName) error {
 	span.SetTag("repo", repo)
 	defer span.Finish()
 
+	if msg, ok := isPaused(filepath.Join(s.ReposDir, string(protocol.NormalizeRepo(repo)))); ok {
+		log15.Warn("doRepoUpdate paused", "repo", repo, "reason", msg)
+		return nil
+	}
+
 	s.repoUpdateLocksMu.Lock()
 	l, ok := s.repoUpdateLocks[repo]
 	if !ok {

--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -628,7 +628,7 @@ func isPaused(dir string) (string, bool) {
 	}
 	defer f.Close()
 	b := make([]byte, 40)
-	f.Read(b)
+	io.ReadFull(f, b)
 	return string(b), true
 }
 

--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -619,6 +619,19 @@ func fsync(path string) error {
 	return err
 }
 
+// isPaused returns true if a file "SG_PAUSE" is present in dir. If the file is
+// present, its first 40 bytes are returned as first argument.
+func isPaused(dir string) (string, bool) {
+	f, err := os.Open(filepath.Join(dir, "SG_PAUSE"))
+	if err != nil {
+		return "", false
+	}
+	defer f.Close()
+	b := make([]byte, 40)
+	f.Read(b)
+	return string(b), true
+}
+
 // bestEffortWalk is a filepath.Walk which ignores errors that can be passed
 // to walkFn. This is a common pattern used in gitserver for best effort work.
 //
@@ -631,6 +644,11 @@ func bestEffortWalk(root string, walkFn func(path string, info fs.FileInfo) erro
 	return filepath.Walk(root, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
 			return nil
+		}
+
+		if msg, ok := isPaused(path); ok {
+			log15.Warn("bestEffortWalk paused", "dir", path, "reason", msg)
+			return filepath.SkipDir
 		}
 
 		return walkFn(path, info)


### PR DESCRIPTION
With this change we can place a file "SG_PAUSE" in a repo's working
directory on gitsever to pause repo updates and cleanup operations.

The contents of SG_PAUSE are printed as log message.

This will help us experiment with different janitor jobs directly on
gitserver.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
