### PR TITLE
[cloud] Add org_stats table to hold business stats for organizations

### DIFF
--- a/cmd/frontend/graphqlbackend/affiliated_repositories_connection.go
+++ b/cmd/frontend/graphqlbackend/affiliated_repositories_connection.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+
 	"github.com/cockroachdb/errors"
 	"github.com/inconshreveable/log15"
 
@@ -149,6 +151,10 @@ func (a *affiliatedRepositoriesConnection) Nodes(ctx context.Context) ([]*codeHo
 			a.err = errors.New("failed to fetch from any code host")
 		}
 	})
+
+	if envvar.SourcegraphDotComMode() && a.orgID != 0 {
+		a.db.OrgStats().Upsert(ctx, a.orgID, int32(len(a.nodes)))
+	}
 
 	return a.nodes, a.err
 }

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -28,6 +28,7 @@ type DB interface {
 	OrgInvitations() OrgInvitationStore
 	OrgMembers() OrgMemberStore
 	Orgs() OrgStore
+	OrgStats() OrgStatsStore
 	Phabricator() PhabricatorStore
 	Repos() RepoStore
 	SavedSearches() SavedSearchStore
@@ -134,6 +135,10 @@ func (d *db) OrgMembers() OrgMemberStore {
 
 func (d *db) Orgs() OrgStore {
 	return OrgsWith(d.Store)
+}
+
+func (d *db) OrgStats() OrgStatsStore {
+	return OrgStatsWith(d.Store)
 }
 
 func (d *db) Phabricator() PhabricatorStore {

--- a/internal/database/dbmock/db_mock.go
+++ b/internal/database/dbmock/db_mock.go
@@ -57,8 +57,8 @@ type MockDB struct {
 	// OrgMembersFunc is an instance of a mock function object controlling
 	// the behavior of the method OrgMembers.
 	OrgMembersFunc *DBOrgMembersFunc
-	// OrgStatsFunc is an instance of a mock function object controlling
-	// the behavior of the method OrgStats.
+	// OrgStatsFunc is an instance of a mock function object controlling the
+	// behavior of the method OrgStats.
 	OrgStatsFunc *DBOrgStatsFunc
 	// OrgsFunc is an instance of a mock function object controlling the
 	// behavior of the method Orgs.
@@ -184,6 +184,11 @@ func NewMockDB() *MockDB {
 		},
 		OrgMembersFunc: &DBOrgMembersFunc{
 			defaultHook: func() database.OrgMemberStore {
+				return nil
+			},
+		},
+		OrgStatsFunc: &DBOrgStatsFunc{
+			defaultHook: func() database.OrgStatsStore {
 				return nil
 			},
 		},
@@ -349,6 +354,11 @@ func NewStrictMockDB() *MockDB {
 				panic("unexpected invocation of MockDB.OrgMembers")
 			},
 		},
+		OrgStatsFunc: &DBOrgStatsFunc{
+			defaultHook: func() database.OrgStatsStore {
+				panic("unexpected invocation of MockDB.OrgStats")
+			},
+		},
 		OrgsFunc: &DBOrgsFunc{
 			defaultHook: func() database.OrgStore {
 				panic("unexpected invocation of MockDB.Orgs")
@@ -482,6 +492,9 @@ func NewMockDBFrom(i database.DB) *MockDB {
 		},
 		OrgMembersFunc: &DBOrgMembersFunc{
 			defaultHook: i.OrgMembers,
+		},
+		OrgStatsFunc: &DBOrgStatsFunc{
+			defaultHook: i.OrgStats,
 		},
 		OrgsFunc: &DBOrgsFunc{
 			defaultHook: i.Orgs,
@@ -1948,8 +1961,8 @@ func (c DBOrgMembersFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
-// DBOrgStatsFunc describes the behavior when the OrgStats
-// method of the parent MockDB instance is invoked.
+// DBOrgStatsFunc describes the behavior when the OrgStats method of the
+// parent MockDB instance is invoked.
 type DBOrgStatsFunc struct {
 	defaultHook func() database.OrgStatsStore
 	hooks       []func() database.OrgStatsStore
@@ -1957,25 +1970,24 @@ type DBOrgStatsFunc struct {
 	mutex       sync.Mutex
 }
 
-// OrgStats delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
+// OrgStats delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
 func (m *MockDB) OrgStats() database.OrgStatsStore {
 	r0 := m.OrgStatsFunc.nextHook()()
 	m.OrgStatsFunc.appendCall(DBOrgStatsFuncCall{r0})
 	return r0
 }
 
-// SetDefaultHook sets function that is called when the OrgStats
-// method of the parent MockDB instance is invoked and the hook queue is
-// empty.
+// SetDefaultHook sets function that is called when the OrgStats method of
+// the parent MockDB instance is invoked and the hook queue is empty.
 func (f *DBOrgStatsFunc) SetDefaultHook(hook func() database.OrgStatsStore) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// OrgStats method of the parent MockDB instance invokes the hook at
-// the front of the queue and discards it. After the queue is empty, the
-// default hook function is invoked for any future action.
+// OrgStats method of the parent MockDB instance invokes the hook at the
+// front of the queue and discards it. After the queue is empty, the default
+// hook function is invoked for any future action.
 func (f *DBOrgStatsFunc) PushHook(hook func() database.OrgStatsStore) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
@@ -2017,8 +2029,8 @@ func (f *DBOrgStatsFunc) appendCall(r0 DBOrgStatsFuncCall) {
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of DBOrgStatsFuncCall objects describing
-// the invocations of this function.
+// History returns a sequence of DBOrgStatsFuncCall objects describing the
+// invocations of this function.
 func (f *DBOrgStatsFunc) History() []DBOrgStatsFuncCall {
 	f.mutex.Lock()
 	history := make([]DBOrgStatsFuncCall, len(f.history))
@@ -2028,8 +2040,8 @@ func (f *DBOrgStatsFunc) History() []DBOrgStatsFuncCall {
 	return history
 }
 
-// DBOrgStatsFuncCall is an object that describes an invocation of
-// method OrgStats on an instance of MockDB.
+// DBOrgStatsFuncCall is an object that describes an invocation of method
+// OrgStats on an instance of MockDB.
 type DBOrgStatsFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.

--- a/internal/database/dbmock/db_mock.go
+++ b/internal/database/dbmock/db_mock.go
@@ -57,6 +57,9 @@ type MockDB struct {
 	// OrgMembersFunc is an instance of a mock function object controlling
 	// the behavior of the method OrgMembers.
 	OrgMembersFunc *DBOrgMembersFunc
+	// OrgStatsFunc is an instance of a mock function object controlling
+	// the behavior of the method OrgStats.
+	OrgStatsFunc *DBOrgStatsFunc
 	// OrgsFunc is an instance of a mock function object controlling the
 	// behavior of the method Orgs.
 	OrgsFunc *DBOrgsFunc
@@ -1942,6 +1945,106 @@ func (c DBOrgMembersFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c DBOrgMembersFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// DBOrgStatsFunc describes the behavior when the OrgStats
+// method of the parent MockDB instance is invoked.
+type DBOrgStatsFunc struct {
+	defaultHook func() database.OrgStatsStore
+	hooks       []func() database.OrgStatsStore
+	history     []DBOrgStatsFuncCall
+	mutex       sync.Mutex
+}
+
+// OrgStats delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockDB) OrgStats() database.OrgStatsStore {
+	r0 := m.OrgStatsFunc.nextHook()()
+	m.OrgStatsFunc.appendCall(DBOrgStatsFuncCall{r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the OrgStats
+// method of the parent MockDB instance is invoked and the hook queue is
+// empty.
+func (f *DBOrgStatsFunc) SetDefaultHook(hook func() database.OrgStatsStore) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// OrgStats method of the parent MockDB instance invokes the hook at
+// the front of the queue and discards it. After the queue is empty, the
+// default hook function is invoked for any future action.
+func (f *DBOrgStatsFunc) PushHook(hook func() database.OrgStatsStore) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *DBOrgStatsFunc) SetDefaultReturn(r0 database.OrgStatsStore) {
+	f.SetDefaultHook(func() database.OrgStatsStore {
+		return r0
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *DBOrgStatsFunc) PushReturn(r0 database.OrgStatsStore) {
+	f.PushHook(func() database.OrgStatsStore {
+		return r0
+	})
+}
+
+func (f *DBOrgStatsFunc) nextHook() func() database.OrgStatsStore {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *DBOrgStatsFunc) appendCall(r0 DBOrgStatsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of DBOrgStatsFuncCall objects describing
+// the invocations of this function.
+func (f *DBOrgStatsFunc) History() []DBOrgStatsFuncCall {
+	f.mutex.Lock()
+	history := make([]DBOrgStatsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// DBOrgStatsFuncCall is an object that describes an invocation of
+// method OrgStats on an instance of MockDB.
+type DBOrgStatsFuncCall struct {
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 database.OrgStatsStore
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c DBOrgStatsFuncCall) Args() []interface{} {
+	return []interface{}{}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c DBOrgStatsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/org_stats.go
+++ b/internal/database/org_stats.go
@@ -1,0 +1,50 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+type OrgStatsStore interface {
+	Upsert(ctx context.Context, orgID int32, codeHostRepoCount int32) (*types.OrgStats, error)
+	With(basestore.ShareableStore) OrgStatsStore
+	basestore.ShareableStore
+}
+
+type orgStatsStore struct {
+	*basestore.Store
+}
+
+// OrgStats instantiates and returns a new OrgStatsStore with prepared statements.
+func OrgStats(db dbutil.DB) OrgStatsStore {
+	return &orgStatsStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
+}
+
+// OrgStatsWith instantiates and returns a new OrgStatsStore using the other store handle.
+func OrgStatsWith(other basestore.ShareableStore) OrgStatsStore {
+	return &orgStatsStore{Store: basestore.NewWithHandle(other.Handle())}
+}
+
+func (o *orgStatsStore) With(other basestore.ShareableStore) OrgStatsStore {
+	return &orgStatsStore{Store: o.Store.With(other)}
+}
+
+func (o *orgStatsStore) Upsert(ctx context.Context, orgID int32, codeHostRepoCount int32) (*types.OrgStats, error) {
+	newStatistic := &types.OrgStats{
+		OrgID:             orgID,
+		CodeHostRepoCount: codeHostRepoCount,
+	}
+	err := o.Handle().DB().QueryRowContext(
+		ctx,
+		"INSERT INTO org_stats(org_id, code_host_repo_count) VALUES($1, $2) ON CONFLICT (org_id) DO UPDATE SET code_host_repo_count = $2 RETURNING code_host_repo_count;",
+		newStatistic.OrgID, newStatistic.CodeHostRepoCount).Scan(&newStatistic.CodeHostRepoCount)
+	if err != nil {
+		return nil, err
+	}
+
+	return newStatistic, nil
+}

--- a/internal/database/org_stats_test.go
+++ b/internal/database/org_stats_test.go
@@ -1,0 +1,47 @@
+package database
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+)
+
+func TestOrgStats_Upsert(t *testing.T) {
+	db := dbtest.NewDB(t)
+	ctx := context.Background()
+
+	org, err := Orgs(db).Create(ctx, "org1", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("Succeeds to create stats for existing org", func(t *testing.T) {
+		stats, err := OrgStats(db).Upsert(ctx, org.ID, 42)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if stats.OrgID != org.ID || stats.CodeHostRepoCount != 42 {
+			t.Fatal("Incorrect data returned from DB write")
+		}
+	})
+
+	t.Run("Succeeds to update stats for existing org", func(t *testing.T) {
+		stats, err := OrgStats(db).Upsert(ctx, org.ID, 1024)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if stats.OrgID != org.ID || stats.CodeHostRepoCount != 1024 {
+			t.Fatal("Incorrect data returned from DB write")
+		}
+	})
+
+	t.Run("Fails to update stats for non-existing org", func(t *testing.T) {
+		_, err := OrgStats(db).Upsert(ctx, 42, 1)
+		if err == nil {
+			t.Fatal("Expected error when adding stats for non-existing organization")
+		}
+	})
+}

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1636,6 +1636,26 @@ Foreign-key constraints:
 
 ```
 
+# Table "public.org_stats"
+```
+        Column        |           Type           | Collation | Nullable | Default 
+----------------------+--------------------------+-----------+----------+---------
+ org_id               | integer                  |           | not null | 
+ code_host_repo_count | integer                  |           |          | 0
+ updated_at           | timestamp with time zone |           | not null | now()
+Indexes:
+    "org_stats_pkey" PRIMARY KEY, btree (org_id)
+Foreign-key constraints:
+    "org_stats_org_id_fkey" FOREIGN KEY (org_id) REFERENCES orgs(id) ON DELETE CASCADE DEFERRABLE
+
+```
+
+Business statistics for organizations
+
+**code_host_repo_count**: Count of repositories accessible on all code hosts for this organization.
+
+**org_id**: Org ID that the stats relate to.
+
 # Table "public.orgs"
 ```
       Column       |           Type           | Collation | Nullable |             Default              
@@ -1664,6 +1684,7 @@ Referenced by:
     TABLE "names" CONSTRAINT "names_org_id_fkey" FOREIGN KEY (org_id) REFERENCES orgs(id) ON UPDATE CASCADE ON DELETE CASCADE
     TABLE "org_invitations" CONSTRAINT "org_invitations_org_id_fkey" FOREIGN KEY (org_id) REFERENCES orgs(id)
     TABLE "org_members" CONSTRAINT "org_members_references_orgs" FOREIGN KEY (org_id) REFERENCES orgs(id) ON DELETE RESTRICT
+    TABLE "org_stats" CONSTRAINT "org_stats_org_id_fkey" FOREIGN KEY (org_id) REFERENCES orgs(id) ON DELETE CASCADE DEFERRABLE
     TABLE "registry_extensions" CONSTRAINT "registry_extensions_publisher_org_id_fkey" FOREIGN KEY (publisher_org_id) REFERENCES orgs(id)
     TABLE "saved_searches" CONSTRAINT "saved_searches_org_id_fkey" FOREIGN KEY (org_id) REFERENCES orgs(id)
     TABLE "search_contexts" CONSTRAINT "search_contexts_namespace_org_id_fk" FOREIGN KEY (namespace_org_id) REFERENCES orgs(id) ON DELETE CASCADE

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -678,6 +678,11 @@ type OrgMembership struct {
 	UpdatedAt time.Time
 }
 
+type OrgStats struct {
+	OrgID             int32
+	CodeHostRepoCount int32
+}
+
 type PhabricatorRepo struct {
 	ID       int32
 	Name     api.RepoName

--- a/migrations/frontend/1528395955_add_org_stats_table.down.sql
+++ b/migrations/frontend/1528395955_add_org_stats_table.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE IF EXISTS org_stats;
+
+COMMIT;

--- a/migrations/frontend/1528395955_add_org_stats_table.up.sql
+++ b/migrations/frontend/1528395955_add_org_stats_table.up.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS org_stats
+(
+    org_id INTEGER
+        REFERENCES orgs(id) ON DELETE CASCADE DEFERRABLE
+            PRIMARY KEY,
+    code_host_repo_count INTEGER DEFAULT 0
+);
+
+COMMENT ON TABLE org_stats IS 'Business statistics for organizations';
+COMMENT ON COLUMN org_stats.org_id IS 'Org ID that the stats relate to.';
+COMMENT ON COLUMN org_stats.code_host_repo_count IS 'Count of repositories accessible on all code hosts for this organization.';
+
+COMMIT;

--- a/migrations/frontend/1528395955_add_org_stats_table.up.sql
+++ b/migrations/frontend/1528395955_add_org_stats_table.up.sql
@@ -5,7 +5,8 @@ CREATE TABLE IF NOT EXISTS org_stats
     org_id INTEGER
         REFERENCES orgs(id) ON DELETE CASCADE DEFERRABLE
             PRIMARY KEY,
-    code_host_repo_count INTEGER DEFAULT 0
+    code_host_repo_count INTEGER DEFAULT 0,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
 
 COMMENT ON TABLE org_stats IS 'Business statistics for organizations';


### PR DESCRIPTION
# Description

We need this data to understand if organizations connect most of their repositories to sourcegraph.com or if they cherry pick only a few. This is a signal towards customers trust to Sourcegraph with their organization’s code

We have created a [team RFC](https://docs.google.com/document/d/1FceX9003yDdF5c34hLqZOrTi_tgDxsARBvkyplegy3U/edit#) to look at possible solutions and even though storing business metrics in DB seems like a bad practice, it was the least bad option from the lot.

The data are stored in a new table called `org_stats`. The table will be created for on-prem instances as well, but should be empty there, as we only collect the data on cloud instances. We also only collect the data for organization owned repositories only, so this should not affect private repositories for individuals.

# Related items
https://sourcegraph.atlassian.net/browse/CLOUD-156
https://docs.google.com/document/d/1FceX9003yDdF5c34hLqZOrTi_tgDxsARBvkyplegy3U/edit#

# Testing locally

1. Run sg in dotcom mode `sg start dotcom`
2. Create an organization
3. [Add a feature flag override for the organization](https://docs.google.com/document/d/1aVPCpl6PeaotawAD6DHswqKGIZ9ccW_qeMHXloU3luc/edit) to see the code host connections and repositories screens
4. Add code host connection
5. Go to Manage repositories screen
6. In Postgres, the `org_stats` table should now contain a new row with the number of repositories returned from `AffilatedRepositories` graphQL query.