### PR TITLE
all: remove support for dbtest.NewFromDSN

### DIFF
--- a/cmd/frontend/webhooks/github_webhooks_test.go
+++ b/cmd/frontend/webhooks/github_webhooks_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"flag"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -22,8 +21,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
-
-var dsn = flag.String("dsn", "", "Database connection string to use in integration tests")
 
 func TestGithubWebhookDispatchSuccess(t *testing.T) {
 	h := GitHubWebhook{}
@@ -111,7 +108,7 @@ func TestGithubWebhookExternalServices(t *testing.T) {
 
 	t.Parallel()
 
-	db := dbtest.NewFromDSN(t, *dsn)
+	db := dbtest.NewDB(t)
 
 	ctx := context.Background()
 

--- a/enterprise/cmd/repo-updater/internal/authz/integration_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/integration_test.go
@@ -38,8 +38,6 @@ func update(name string) bool {
 	return regexp.MustCompile(*updateRegex).MatchString(name)
 }
 
-var dsn = flag.String("dsn", "", "Database connection string to use in integration tests")
-
 // NOTE: To update VCR for these tests, please use the token of "sourcegraph-vcr"
 // for GITHUB_TOKEN, which can be found in 1Password.
 //
@@ -89,7 +87,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			}
 			cli := extsvcGitHub.NewV3Client(uri, &auth.OAuthBearerToken{Token: token}, doer)
 
-			testDB := dbtest.NewFromDSN(t, *dsn)
+			testDB := dbtest.NewDB(t)
 			ctx := actor.WithInternalActor(context.Background())
 
 			reposStore := repos.NewStore(testDB, sql.TxOptions{})
@@ -169,7 +167,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			}
 			cli := extsvcGitHub.NewV3Client(uri, &auth.OAuthBearerToken{Token: token}, doer)
 
-			testDB := dbtest.NewFromDSN(t, *dsn)
+			testDB := dbtest.NewDB(t)
 			ctx := actor.WithInternalActor(context.Background())
 
 			reposStore := repos.NewStore(testDB, sql.TxOptions{})
@@ -272,7 +270,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			}
 			cli := extsvcGitHub.NewV3Client(uri, &auth.OAuthBearerToken{Token: token}, doer)
 
-			testDB := dbtest.NewFromDSN(t, *dsn)
+			testDB := dbtest.NewDB(t)
 			ctx := actor.WithInternalActor(context.Background())
 
 			reposStore := repos.NewStore(testDB, sql.TxOptions{})
@@ -355,7 +353,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			}
 			cli := extsvcGitHub.NewV3Client(uri, &auth.OAuthBearerToken{Token: token}, doer)
 
-			testDB := dbtest.NewFromDSN(t, *dsn)
+			testDB := dbtest.NewDB(t)
 			ctx := actor.WithInternalActor(context.Background())
 
 			reposStore := repos.NewStore(testDB, sql.TxOptions{})

--- a/enterprise/internal/database/integration_test.go
+++ b/enterprise/internal/database/integration_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 )
 
-var dsn = flag.String("dsn", "", "Database connection string to use in integration tests")
-
 // Toggles particularly slow tests. To enable, use `go test` with this flag, for example:
 //
 //   go test -timeout 360s -v -run ^TestIntegration_PermsStore$ github.com/sourcegraph/sourcegraph/enterprise/internal/database -slow-tests
@@ -30,7 +28,7 @@ func TestIntegration_PermsStore(t *testing.T) {
 
 	t.Parallel()
 
-	db := dbtest.NewFromDSN(t, *dsn)
+	db := dbtest.NewDB(t)
 
 	for _, tc := range []struct {
 		name string

--- a/internal/database/dbtest/dbtest.go
+++ b/internal/database/dbtest/dbtest.go
@@ -56,28 +56,18 @@ var rng = rand.New(rand.NewSource(func() int64 {
 }()))
 var rngLock sync.Mutex
 
-// NewDB uses NewFromDSN to create a testing database, using the default DSN.
+// NewDB returns a connection to a clean, new temporary testing database with
+// the same schema as Sourcegraph's production Postgres database.
 func NewDB(t testing.TB) *sql.DB {
 	if os.Getenv("USE_FAST_DBTEST") != "" {
 		return NewFastDB(t)
 	}
-	return NewFromDSN(t, "")
+	return newFromDSN(t, "", "migrated")
 }
 
-// NewRawDB uses NewRawFromDSN to create a testing database, using the default DSN.
+// NewRawDB returns a connection to a clean, new temporary testing database.
 func NewRawDB(t testing.TB) *sql.DB {
-	return NewRawFromDSN(t, "")
-}
-
-// NewFromDSN returns a connection to a clean, new temporary testing database
-// with the same schema as Sourcegraph's production Postgres database.
-func NewFromDSN(t testing.TB, dsn string) *sql.DB {
-	return newFromDSN(t, dsn, "migrated")
-}
-
-// NewRawFromDSN returns a connection to a clean, new temporary testing database.
-func NewRawFromDSN(t testing.TB, dsn string) *sql.DB {
-	return newFromDSN(t, dsn, "raw")
+	return newFromDSN(t, "", "raw")
 }
 
 func newFromDSN(t testing.TB, dsn, templateNamespace string) *sql.DB {

--- a/internal/database/dbtest/dbtest_fast.go
+++ b/internal/database/dbtest/dbtest_fast.go
@@ -31,28 +31,6 @@ func NewFastDB(t testing.TB) *sql.DB {
 	return newFromPool(t, u, pool)
 }
 
-// NewFastDBWithDSN returns a clean database using the given connection string
-// that will be deleted at the end of the test
-func NewFastDBWithDSN(t testing.TB, dsn string) *sql.DB {
-	if testing.Short() {
-		t.Skip("skipping DB test since -short specified")
-	}
-	t.Helper()
-
-	u, err := getDSN(dsn)
-	if err != nil {
-		t.Fatalf("failed to parse dsn %q: %s", dsn, err)
-	}
-
-	pool, err := newPoolFromURL(u)
-	if err != nil {
-		t.Fatalf("failed to create new pool: %s", err)
-	}
-	t.Cleanup(func() { pool.Close() })
-
-	return newFromPool(t, u, pool)
-}
-
 // NewFastTx returns a transaction in a clean database. At the end of the test,
 // the transaction will be rolled back, and the clean database can be reused
 func NewFastTx(t testing.TB) *sql.Tx {

--- a/internal/repos/integration_test.go
+++ b/internal/repos/integration_test.go
@@ -2,7 +2,6 @@ package repos_test
 
 import (
 	"database/sql"
-	"flag"
 	"testing"
 
 	"github.com/cockroachdb/errors"
@@ -18,8 +17,6 @@ import (
 // roll-back the transaction a test case executes in.
 // This is meant to ensure each test case has a clean slate.
 var errRollback = errors.New("tx: rollback")
-
-var dsn = flag.String("dsn", "", "Database connection string to use in integration tests")
 
 func TestIntegration(t *testing.T) {
 	if testing.Short() {
@@ -50,7 +47,7 @@ func TestIntegration(t *testing.T) {
 		{"Syncer/SyncRepoMaintainsOtherSources", testSyncRepoMaintainsOtherSources},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			db := dbtest.NewFromDSN(t, *dsn)
+			db := dbtest.NewDB(t)
 
 			store := repos.NewStore(db, sql.TxOptions{Isolation: sql.LevelReadCommitted})
 


### PR DESCRIPTION
The custom DSN was only used via some tests to specify dsn via a command
line flag. However, this was never actually used. I believe most people
instead rely on specifying the PGDATASOURCE environment variable. It
also adds some complexity to support. Once this is gone, we can look
into relying on the postgres dsn package.
