### PR TITLE
dbtest: skip updateDSNFromEnv if PGDATASOURCE specified

### DIFF
--- a/internal/database/dbtest/dsn.go
+++ b/internal/database/dbtest/dsn.go
@@ -10,6 +10,11 @@ func getDSN(dsn string) (*url.URL, error) {
 		var ok bool
 		if dsn, ok = os.LookupEnv("PGDATASOURCE"); !ok {
 			dsn = `postgres://sourcegraph:sourcegraph@127.0.0.1:5432/sourcegraph?sslmode=disable&timezone=UTC`
+		} else {
+			// If the user specified PGDATASOURCE, don't try and mux in other
+			// environment variables. Our code which does that is not always
+			// correct. For example it fails on unix sockets.
+			return url.Parse(dsn)
 		}
 	}
 


### PR DESCRIPTION
This doesn't really make sense to do, since the user has already
specified the exact string to use. We still keep the update code since
that allows us to mutate the default test DSN.

This code could be better and I will follow-up with cleanups
here. However, this fix makes it possible for me to run db tests locally
again. Some recent refactors exposed issues in this code. In particular
I use a unix socket for my postgres, and the interactions with that
caused problems.
