### PR TITLE
codeintel: Cache github authz responses

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/httpapi/auth_github.go
+++ b/enterprise/cmd/frontend/internal/codeintel/httpapi/auth_github.go
@@ -40,7 +40,6 @@ func enforceAuthViaGitHub(ctx context.Context, query url.Values, repoName string
 		case nil:
 			githubAuthCache.Set(key, true)
 		case ErrGitHubUnauthorized:
-			// githubAuthCache.Set(key, false)
 			// Note: We explicitly do not store false here in case a user is
 			// adjusting permissions on a cache key. Storing false here would
 			// result in a cached rejection after the key has been modified

--- a/enterprise/cmd/frontend/internal/codeintel/httpapi/auth_github.go
+++ b/enterprise/cmd/frontend/internal/codeintel/httpapi/auth_github.go
@@ -40,7 +40,11 @@ func enforceAuthViaGitHub(ctx context.Context, query url.Values, repoName string
 		case nil:
 			githubAuthCache.Set(key, true)
 		case ErrGitHubUnauthorized:
-			githubAuthCache.Set(key, false)
+			// githubAuthCache.Set(key, false)
+			// Note: We explicitly do not store false here in case a user is
+			// adjusting permissions on a cache key. Storing false here would
+			// result in a cached rejection after the key has been modified
+			// on the code host.
 		default:
 		}
 	}()

--- a/enterprise/cmd/frontend/internal/codeintel/httpapi/auth_github_cache.go
+++ b/enterprise/cmd/frontend/internal/codeintel/httpapi/auth_github_cache.go
@@ -1,0 +1,27 @@
+package httpapi
+
+import "fmt"
+
+type GitHubAuthCache struct {
+	cache map[string]bool
+}
+
+var githubAuthCache = &GitHubAuthCache{
+	// TODO - replace with redis
+	cache: map[string]bool{},
+}
+
+func (c *GitHubAuthCache) Get(key string) (bool, bool, error) {
+	authorized, ok := c.cache[key]
+	return authorized, ok, nil
+}
+
+func (c *GitHubAuthCache) Set(key string, authorized bool) error {
+	c.cache[key] = authorized
+	return nil
+}
+
+func makeGitHubAuthCacheKey(githubToken, repoName string) string {
+	// TODO - hash for privacy
+	return fmt.Sprintf("%s:%s", githubToken, repoName)
+}


### PR DESCRIPTION
Previously, we would take the user-supplied github token on every LSIF upload and hit the GitHub API directly to see if the user has authorship over the target repo.

This PR adds a caching layer (via rcache, in Redis) for those responses for a particular github token/repository pair. Before serializing into the redis cache, we take a sum of the data so that we do not store user github tokens anywhere in our stack.

This should reduce the number of requests we make to github, especially when we have users (like ourselves) with high commit frequency and lots of upload jobs launching in quick sequence.