### PR TITLE
migration: Add Validate method to runner

### DIFF
--- a/internal/database/migration/runner/errors.go
+++ b/internal/database/migration/runner/errors.go
@@ -1,0 +1,13 @@
+package runner
+
+import "fmt"
+
+type SchemaOutOfDateError struct {
+	schemaName      string
+	currentVersion  int
+	expectedVersion int
+}
+
+func (e *SchemaOutOfDateError) Error() string {
+	return fmt.Sprintf("expected schema %q to be migrated to version %d, currently %d\n", e.schemaName, e.expectedVersion, e.currentVersion)
+}

--- a/internal/database/migration/runner/runner.go
+++ b/internal/database/migration/runner/runner.go
@@ -223,8 +223,11 @@ func (r *Runner) validateSchemas(ctx context.Context, schemaContexts map[string]
 	for schemaName, schemaContext := range schemaContexts {
 		definitions, err := schemaContext.schema.Definitions.UpFrom(schemaContext.version, 0)
 		if err != nil {
-			definitions, err := schemaContext.schema.Definitions.UpFrom(0, 0)
-			if err != nil {
+			definitions, innerErr := schemaContext.schema.Definitions.UpFrom(0, 0)
+			if innerErr != nil {
+				return innerErr
+			}
+			if len(definitions) == 0 {
 				return err
 			}
 

--- a/internal/database/migration/runner/runner_test.go
+++ b/internal/database/migration/runner/runner_test.go
@@ -2,12 +2,12 @@ package runner
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io/fs"
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/errors"
 	mockassert "github.com/derision-test/go-mockgen/testutil/assert"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/definition"


### PR DESCRIPTION
Add a `Validate` method to the migration runner that returns an error when the current database is **behind** of the current schema. Tests confirm that database versions in the *future* do not cause an error.