### PR TITLE
batches: support `createBatchSpecFromRaw` with existing batch change

### DIFF
--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -83,6 +83,7 @@ type CreateBatchSpecFromRawArgs struct {
 	Execute          bool
 	NoCache          bool
 	Namespace        *graphql.ID
+	BatchChange      *graphql.ID
 }
 
 type ReplaceBatchSpecInputArgs struct {

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -1362,8 +1362,8 @@ extend type Mutation {
         allowIgnored: Boolean = false
 
         """
-        If true, repos on unsupported codehosts will be included. Resulting changesets in these repos cannot
-        be published.
+        If true, repos on unsupported codehosts will be included. Resulting changesets in
+        these repos cannot be published.
         """
         allowUnsupported: Boolean = false
 
@@ -1382,12 +1382,22 @@ extend type Mutation {
         noCache: Boolean = false
 
         """
-        The namespace (either a user or organization). A batch spec can only be applied to (or
-        used to create) batch changes in this namespace.
+        The namespace (either a user or organization). A batch spec can only be applied to
+        (or used to create) batch changes in this namespace.
 
         Defaults to the user who created the batch spec.
+
+        TODO: Not implemented yet.
         """
         namespace: ID
+
+        """
+        The existing batch change that the new batch spec should be associated with, if
+        one exists.
+
+        If provided, the argument for `namespace` will be ignored.
+        """
+        batchChange: ID
     ): BatchSpec!
 
     """

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -1522,10 +1522,16 @@ func (r *Resolver) CreateBatchSpecFromRaw(ctx context.Context, args *graphqlback
 		return nil, err
 	}
 
+	batchChangeID, err := unmarshalBatchChangeID(*args.BatchChange)
+	if err != nil {
+		return nil, err
+	}
+
 	svc := service.New(r.store)
 	batchSpec, err := svc.CreateBatchSpecFromRaw(ctx, service.CreateBatchSpecFromRawOpts{
 		// TODO: Handle namespace like for CreateEmptyBatchChange
 		NamespaceUserID:  actor.FromContext(ctx).UID,
+		BatchChangeID:    batchChangeID,
 		RawSpec:          args.BatchSpec,
 		AllowIgnored:     args.AllowIgnored,
 		AllowUnsupported: args.AllowUnsupported,

--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -1541,6 +1541,11 @@ func TestService(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			if newSpec.ID == spec.ID {
+				t.Fatalf("new batch spec has same ID as old one: %d", newSpec.ID)
+			}
+
+			// Assert that batch change was updated with new batch spec id
 			batchChange, err = s.GetBatchChange(ctx, store.GetBatchChangeOpts{ID: batchChange.ID})
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
As another part of EM2.4, the mutation `createBatchSpecFromRaw` now takes as an additional optional argument a `batchChange` id, which, when provided, will be used to associate the batch spec that gets created to that existing batch change.

Corresponding changes to `replaceBatchSpecInput` can be found in the follow up PR #28827.
