### PR TITLE
search: don't fail on search if regexp pattern is not compatible with db dialect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Moving a changeset from draft state into published state was broken on GitLab code hosts. [#28239](https://github.com/sourcegraph/sourcegraph/pull/28239)
 - The shortcuts for toggling the History Panel and Line Wrap were not working on Mac. [#28574](https://github.com/sourcegraph/sourcegraph/pull/28574)
+- Fixed an issue where certain regexp syntax for repository searches caused the entire search, including non-repository searches, to fail with a parse error (issue affects only version 3.34). [#28826](https://github.com/sourcegraph/sourcegraph/pull/28826)
 
 ### Removed
 

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -1648,7 +1648,7 @@ func parseCursorConds(cs types.MultiCursor) (cond *sqlf.Query, err error) {
 // will be fast (even if there are many repos) because the query can be constrained
 // efficiently to only the repos in the group.
 func parseIncludePattern(pattern string) (exact, like []string, regexp string, err error) {
-	re, err := regexpsyntax.Parse(pattern, regexpsyntax.OneLine)
+	re, err := regexpsyntax.Parse(pattern, regexpsyntax.Perl)
 	if err != nil {
 		return nil, nil, "", err
 	}

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -91,6 +91,9 @@ func TestParseIncludePattern(t *testing.T) {
 				sqlf.Sprintf(`(name = ANY (%s) OR lower(name) LIKE %s)`, "%!s(*pq.StringArray=&[github.com/foo/bar])", "%sourcegraph%"),
 			},
 		},
+
+		// Recognize perl character class shorthand syntax.
+		`\s`: {regexp: `\s`},
 	}
 	for pattern, want := range tests {
 		exact, like, regexp, err := parseIncludePattern(pattern)


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/28781.

This follows the approach I mentioned in the issue, which is to validate up front whether a pattern can be used for a repo search, and only creates a repo search job if true. This does mean that valid patterns are potentially parsed twice by the DB parse function for repo search. This is small price to pay for making the semantics less broken,  and is actually a side effect of the fact that our query pipeline along the repo search code path is inverted from how we should structure it (like the rest of our query code), which is:

- Parse a data structure -> do validation up front -> fail if needed -> otherwise created valid internal representation, no more static validation here

(note validation is only done once)

By doing the validation up front for the repo search path, this PR establishes where the "right" place is to do this check (i.e., before performing any other real work). Ideally, what we want, is to also create the `sqlf` query up front, once we know that the regexp is valid, and that we will run a repo search job. In other words, ideally the repo search job will take the already-ready-and-validated DB repo query. I'm not investing myself in that effort right now, the repo code path is a different beast that I'll target another day maybe. Just laying out why this change follows a consistent and predictable architecture.

For repo search specifically, the current behavior is still imperfect because ideally, if a user ran _only_ a repo search, and expected a `\s` to match a repo name (unlikely, but possible), they would get 'no results' instead of a validation error (like "`\s` unsupported for repo search"). But this PR takes steps to at least be less conservative and allow the rest of a search to succeed.