### PR TITLE
batches: set up `/edit`, better namespace batch changes support

### DIFF
--- a/client/web/src/enterprise/batches/create/CreateBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateBatchChangePage.tsx
@@ -17,26 +17,22 @@ import { OldBatchChangePageContent } from './OldCreateBatchChangeContent'
 export interface CreateBatchChangePageProps extends SettingsCascadeProps<Settings>, ThemeProps {
     // TODO: This can go away once we only have the new SSBC create page
     headingElement: 'h1' | 'h2'
-    namespace: UserAreaUserFields | OrgAreaOrganizationFields
-    // TODO: This affects work on another branch
-    settingsInitiallyOpen?: boolean
+    /** The namespace the batch change should be created in, or that it already belongs to. */
+    namespace?: UserAreaUserFields | OrgAreaOrganizationFields
 }
 
+/**
+ * CreateBatchChangePage is a wrapper around the create/edit batch change page that
+ * determines if we should display the original create page or the new SSBC page.
+ */
 export const CreateBatchChangePage: React.FunctionComponent<CreateBatchChangePageProps> = ({
     settingsCascade,
     isLightTheme,
     headingElement,
     namespace,
-    // TODO: This affects work on another branch
-    settingsInitiallyOpen,
 }) =>
     isBatchChangesExecutionEnabled(settingsCascade) ? (
-        <NewCreateBatchChangePage
-            isLightTheme={isLightTheme}
-            settingsCascade={settingsCascade}
-            namespace={namespace}
-            settingsInitiallyOpen={settingsInitiallyOpen}
-        />
+        <NewCreateBatchChangePage isLightTheme={isLightTheme} settingsCascade={settingsCascade} namespace={namespace} />
     ) : (
         <Page>
             <PageTitle title="Create batch change" />

--- a/client/web/src/enterprise/batches/create/CreateBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateBatchChangePage.tsx
@@ -8,22 +8,35 @@ import { PageHeader } from '@sourcegraph/wildcard'
 import { isBatchChangesExecutionEnabled } from '../../../batches'
 import { BatchChangesIcon } from '../../../batches/icons'
 import { PageTitle } from '../../../components/PageTitle'
+import { OrgAreaOrganizationFields, UserAreaUserFields } from '../../../graphql-operations'
 import { Settings } from '../../../schema/settings.schema'
 
 import { NewCreateBatchChangePage } from './NewCreateBatchChangePage'
 import { OldBatchChangePageContent } from './OldCreateBatchChangeContent'
 
 export interface CreateBatchChangePageProps extends SettingsCascadeProps<Settings>, ThemeProps {
+    // TODO: This can go away once we only have the new SSBC create page
     headingElement: 'h1' | 'h2'
+    namespace: UserAreaUserFields | OrgAreaOrganizationFields
+    // TODO: This affects work on another branch
+    settingsInitiallyOpen?: boolean
 }
 
 export const CreateBatchChangePage: React.FunctionComponent<CreateBatchChangePageProps> = ({
     settingsCascade,
     isLightTheme,
     headingElement,
+    namespace,
+    // TODO: This affects work on another branch
+    settingsInitiallyOpen,
 }) =>
     isBatchChangesExecutionEnabled(settingsCascade) ? (
-        <NewCreateBatchChangePage isLightTheme={isLightTheme} settingsCascade={settingsCascade} />
+        <NewCreateBatchChangePage
+            isLightTheme={isLightTheme}
+            settingsCascade={settingsCascade}
+            namespace={namespace}
+            settingsInitiallyOpen={settingsInitiallyOpen}
+        />
     ) : (
         <Page>
             <PageTitle title="Create batch change" />

--- a/client/web/src/enterprise/batches/create/NewCreateBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/NewCreateBatchChangePage.tsx
@@ -128,6 +128,10 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({
     isLightTheme,
     settingsCascade,
 }) => {
+    // TODO: This will always be available once the "Create" form from the other
+    // branch is ready.
+    const batchSpecID = batchChange?.currentSpec.id
+
     const { namespaces, defaultSelectedNamespace } = useNamespaces(settingsCascade, namespace)
 
     // The namespace selected for creating the new batch spec under.
@@ -159,14 +163,11 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({
     // Manage the batch spec that was last submitted to the backend for the workspaces preview.
     const {
         previewBatchSpec,
-        batchSpecID,
         currentPreviewRequestTime,
         isLoading: isLoadingPreview,
         error: previewError,
         clearError: clearPreviewError,
-        // TODO: This will always be available once the "Create" form from the other
-        // branch is ready.
-    } = usePreviewBatchSpec(batchChange?.id || '', noCache, markUnstale)
+    } = usePreviewBatchSpec(batchSpecID || '', noCache, markUnstale)
 
     const clearErrorsAndHandleCodeChange = useCallback(
         (newCode: string) => {
@@ -207,7 +208,7 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({
                 previewError ||
                 isLoadingPreview ||
                 isExecuting ||
-                !batchSpecID ||
+                !currentPreviewRequestTime ||
                 batchSpecStale ||
                 workspacesPreviewResolution?.state !== BatchSpecWorkspaceResolutionState.COMPLETED
         )
@@ -217,7 +218,7 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({
                 ? "There's nothing to run yet."
                 : isValid === false || previewError
                 ? "There's a problem with your batch spec."
-                : !batchSpecID
+                : !currentPreviewRequestTime
                 ? 'Preview workspaces first before you run.'
                 : batchSpecStale
                 ? 'Update your workspaces preview before you run.'
@@ -228,7 +229,7 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({
         return [disableExecution, executionTooltip]
     }, [
         batchChange,
-        batchSpecID,
+        currentPreviewRequestTime,
         isValid,
         previewError,
         isLoadingPreview,

--- a/client/web/src/enterprise/batches/create/NewCreateBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/NewCreateBatchChangePage.tsx
@@ -1,6 +1,9 @@
+// TODO: Rename me to editor page
 import classNames from 'classnames'
 import React, { useCallback, useMemo, useState } from 'react'
 
+import { Scalars } from '@sourcegraph/shared/src/graphql-operations'
+import { useQuery } from '@sourcegraph/shared/src/graphql/apollo'
 import { BatchSpecWorkspaceResolutionState } from '@sourcegraph/shared/src/graphql/schema'
 import {
     SettingsCascadeProps,
@@ -13,9 +16,17 @@ import { ButtonTooltip } from '@sourcegraph/web/src/components/ButtonTooltip'
 import { PageHeader } from '@sourcegraph/wildcard'
 
 import { BatchChangesIcon } from '../../../batches/icons'
+import {
+    BatchChangeFields,
+    GetBatchChangeResult,
+    GetBatchChangeVariables,
+    OrgAreaOrganizationFields,
+    UserAreaUserFields,
+} from '../../../graphql-operations'
 import { Settings } from '../../../schema/settings.schema'
 import { BatchSpecDownloadLink } from '../BatchSpec'
 
+import { GET_BATCH_CHANGE } from './backend'
 import { MonacoBatchSpecEditor } from './editor/MonacoBatchSpecEditor'
 import helloWorldSample from './library/hello-world.batch.yaml'
 import { LibraryPane } from './library/LibraryPane'
@@ -48,13 +59,24 @@ const getNamespaceBatchChangesURL = (namespace: SettingsUserSubject | SettingsOr
     }
 }
 
-interface CreateBatchChangePageProps extends ThemeProps, SettingsCascadeProps<Settings> {}
+interface CreateBatchChangePageProps extends ThemeProps, SettingsCascadeProps<Settings> {
+    /** The namespace the batch change should be created in, or that it already belongs to. */
+    namespace?: UserAreaUserFields | OrgAreaOrganizationFields
+    /** The batch change name, if it already exists. */
+    batchChangeName?: BatchChangeFields['name']
+    // TODO: This affects work on another branch
+    settingsInitiallyOpen?: boolean
+}
 
 export const NewCreateBatchChangePage: React.FunctionComponent<CreateBatchChangePageProps> = ({
+    namespace,
+    batchChangeName,
+    // TODO: This affects work on another branch
+    settingsInitiallyOpen: _settingsInitiallyOpen = true,
     isLightTheme,
     settingsCascade,
 }) => {
-    const { namespaces, defaultSelectedNamespace } = useNamespaces(settingsCascade)
+    const { namespaces, defaultSelectedNamespace } = useNamespaces(settingsCascade, namespace)
 
     // The namespace selected for creating the new batch spec under.
     const [selectedNamespace, setSelectedNamespace] = useState<SettingsUserSubject | SettingsOrgSubject>(

--- a/client/web/src/enterprise/batches/create/NewCreateBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/NewCreateBatchChangePage.tsx
@@ -62,7 +62,7 @@ const getNamespaceBatchChangesURL = (namespace: SettingsUserSubject | SettingsOr
     }
 }
 
-interface NewCreateBatchChangePageProps extends ThemeProps, SettingsCascadeProps<Settings> {
+export interface NewCreateBatchChangePageProps extends ThemeProps, SettingsCascadeProps<Settings> {
     /** The namespace the batch change should be created in, or that it already belongs to. */
     namespace?: UserAreaUserFields | OrgAreaOrganizationFields
     /** The batch change name, if it already exists. */

--- a/client/web/src/enterprise/batches/create/NewCreateBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/NewCreateBatchChangePage.tsx
@@ -195,6 +195,7 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({
     const { executeBatchSpec, isLoading: isExecuting, error: executeError } = useExecuteBatchSpec(batchSpecID)
 
     // Disable the execute button if any of the following are true:
+    // * a batch spec has already been applied (the batch change is not a draft)
     // * the batch spec code is invalid
     // * there was an error with the preview
     // * we're already in the middle of previewing or executing
@@ -204,6 +205,7 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({
     const [disableExecution, executionTooltip] = useMemo(() => {
         const disableExecution = Boolean(
             batchChange === undefined ||
+                batchChange.lastApplier !== null ||
                 isValid !== true ||
                 previewError ||
                 isLoadingPreview ||
@@ -216,6 +218,8 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({
         const executionTooltip =
             batchChange === undefined
                 ? "There's nothing to run yet."
+                : batchChange.lastApplier !== null
+                ? 'This batch change has already had a spec applied.'
                 : isValid === false || previewError
                 ? "There's a problem with your batch spec."
                 : !currentPreviewRequestTime

--- a/client/web/src/enterprise/batches/create/backend.ts
+++ b/client/web/src/enterprise/batches/create/backend.ts
@@ -37,13 +37,17 @@ export const EXECUTE_BATCH_SPEC = gql`
     }
 `
 
-export const CREATE_BATCH_SPEC_FROM_RAW = gql`
-    mutation CreateBatchSpecFromRaw($spec: String!, $noCache: Boolean!, $batchChange: ID) {
-        createBatchSpecFromRaw(batchSpec: $spec, noCache: $noCache, batchChange: $batchChange) {
-            id
-        }
-    }
-`
+// TODO: This mutation will not be used until we support creating + executing a new batch
+// spec on an existing non-draft batch change. Use `CREATE_EMPTY_BATCH_CHANGE` and
+// `REPLACE_BATCH_SPEC_INPUT` for draft batch changes.
+//
+// export const CREATE_BATCH_SPEC_FROM_RAW = gql`
+//     mutation CreateBatchSpecFromRaw($spec: String!, $noCache: Boolean!, $batchChange: ID) {
+//         createBatchSpecFromRaw(batchSpec: $spec, noCache: $noCache, batchChange: $batchChange) {
+//             id
+//         }
+//     }
+// `
 
 export const REPLACE_BATCH_SPEC_INPUT = gql`
     mutation ReplaceBatchSpecInput($previousSpec: ID!, $spec: String!, $noCache: Boolean!) {

--- a/client/web/src/enterprise/batches/create/backend.ts
+++ b/client/web/src/enterprise/batches/create/backend.ts
@@ -23,6 +23,11 @@ export const GET_BATCH_CHANGE = gql`
             id
             originalInput
         }
+
+        # TODO: Replace me with state
+        lastApplier {
+            id
+        }
     }
 `
 

--- a/client/web/src/enterprise/batches/create/backend.ts
+++ b/client/web/src/enterprise/batches/create/backend.ts
@@ -1,5 +1,31 @@
 import { gql } from '@sourcegraph/shared/src/graphql/graphql'
 
+export const GET_BATCH_CHANGE = gql`
+    query GetBatchChange($namespace: ID!, $name: String!) {
+        batchChange(namespace: $namespace, name: $name) {
+            ...EditBatchChangeFields
+        }
+    }
+
+    fragment EditBatchChangeFields on BatchChange {
+        __typename
+        id
+        url
+        name
+        namespace {
+            id
+            namespaceName
+            url
+        }
+        description
+
+        currentSpec {
+            id
+            originalInput
+        }
+    }
+`
+
 export const EXECUTE_BATCH_SPEC = gql`
     mutation ExecuteBatchSpec($batchSpec: ID!) {
         executeBatchSpec(batchSpec: $batchSpec) {
@@ -12,8 +38,8 @@ export const EXECUTE_BATCH_SPEC = gql`
 `
 
 export const CREATE_BATCH_SPEC_FROM_RAW = gql`
-    mutation CreateBatchSpecFromRaw($spec: String!, $namespace: ID!, $noCache: Boolean!) {
-        createBatchSpecFromRaw(batchSpec: $spec, namespace: $namespace, noCache: $noCache) {
+    mutation CreateBatchSpecFromRaw($spec: String!, $noCache: Boolean!, $batchChange: ID) {
+        createBatchSpecFromRaw(batchSpec: $spec, noCache: $noCache, batchChange: $batchChange) {
             id
         }
     }

--- a/client/web/src/enterprise/batches/create/useBatchSpecPreview.ts
+++ b/client/web/src/enterprise/batches/create/useBatchSpecPreview.ts
@@ -2,7 +2,6 @@ import { useCallback, useMemo, useState } from 'react'
 
 import { Scalars } from '@sourcegraph/shared/src/graphql-operations'
 import { useMutation } from '@sourcegraph/shared/src/graphql/graphql'
-import { SettingsOrgSubject, SettingsUserSubject } from '@sourcegraph/shared/src/settings/settings'
 
 import {
     CreateBatchSpecFromRawResult,
@@ -44,12 +43,12 @@ interface UsePreviewBatchSpecResult {
  * YAML code to the backend to enqueue a batch spec resolution job to evaluate the
  * workspaces that a batch spec would run over.
  *
- * @param namespace The user or organization `SettingsSubject` which determines where the
- * resultant batch change would live.
+ * @param batchChangeID The id of the batch change that this batch spec should belong to.
+ * @param noCache Whether or not the batch spec should be executed with the cache disabled.
  * @param onComplete An optional (stable) callback to invoke when the mutation is complete.
  */
 export const usePreviewBatchSpec = (
-    namespace: SettingsUserSubject | SettingsOrgSubject,
+    batchChangeID: Scalars['ID'],
     noCache: boolean,
     onComplete?: () => void
 ): UsePreviewBatchSpecResult => {
@@ -97,7 +96,7 @@ export const usePreviewBatchSpec = (
                     ? replaceBatchSpecInput({ variables: { spec: code, previousSpec: batchSpecID, noCache } })
                     : // Otherwise, we're creating a new batch spec from the raw spec input YAML.
                       createBatchSpecFromRaw({
-                          variables: { spec: code, namespace: namespace.id, noCache },
+                          variables: { spec: code, batchChange: batchChangeID, noCache },
                       })
 
             return preview()
@@ -107,7 +106,7 @@ export const usePreviewBatchSpec = (
                 })
                 .catch(setError)
         },
-        [batchSpecID, namespace, noCache, createBatchSpecFromRaw, replaceBatchSpecInput, onComplete]
+        [batchSpecID, batchChangeID, noCache, createBatchSpecFromRaw, replaceBatchSpecInput, onComplete]
     )
 
     return {

--- a/client/web/src/enterprise/batches/create/useNamespaces.ts
+++ b/client/web/src/enterprise/batches/create/useNamespaces.ts
@@ -1,5 +1,4 @@
 import { useMemo } from 'react'
-import { useLocation } from 'react-router'
 
 import {
     SettingsOrgSubject,
@@ -9,6 +8,7 @@ import {
 } from '@sourcegraph/shared/src/settings/settings'
 import { isErrorLike } from '@sourcegraph/shared/src/util/errors'
 
+import { OrgAreaOrganizationFields, UserAreaUserFields } from '../../../graphql-operations'
 import { Settings } from '../../../schema/settings.schema'
 
 export interface UseNamespacesResult {
@@ -22,10 +22,12 @@ export interface UseNamespacesResult {
  * appropriate default namespace to select for the user.
  *
  * @param settingsCascade The current user's `Settings`.
+ * @param initialNamespace The initial namespace to select.
  */
-export const useNamespaces = (settingsCascade: SettingsCascadeOrError<Settings>): UseNamespacesResult => {
-    const location = useLocation()
-
+export const useNamespaces = (
+    settingsCascade: SettingsCascadeOrError<Settings>,
+    initialNamespace?: UserAreaUserFields | OrgAreaOrganizationFields
+): UseNamespacesResult => {
     // Gather all the available namespaces from the settings subjects.
     const rawNamespaces: SettingsSubject[] = useMemo(
         () =>
@@ -56,26 +58,14 @@ export const useNamespaces = (settingsCascade: SettingsCascadeOrError<Settings>)
         [userNamespace, organizationNamespaces]
     )
 
-    // Check if there's a namespace parameter in the URL.
-    const defaultNamespace = new URLSearchParams(location.search).get('namespace')
-
-    // The default namespace selected from the dropdown should match whatever was in the
-    // URL parameter, or else default to the user's namespace.
+    // The default namespace selected from the dropdown should match whatever the initial
+    // namespace was, or else default to the user's namespace.
     const defaultSelectedNamespace = useMemo(() => {
-        if (defaultNamespace) {
-            const lowerCaseDefaultNamespace = defaultNamespace.toLowerCase()
-            return (
-                namespaces.find(
-                    namespace =>
-                        namespace.displayName?.toLowerCase() === lowerCaseDefaultNamespace ||
-                        (namespace.__typename === 'User' &&
-                            namespace.username.toLowerCase() === lowerCaseDefaultNamespace) ||
-                        (namespace.__typename === 'Org' && namespace.name.toLowerCase() === lowerCaseDefaultNamespace)
-                ) || userNamespace
-            )
+        if (initialNamespace) {
+            return namespaces.find(namespace => namespace.id === initialNamespace.id) || userNamespace
         }
         return userNamespace
-    }, [namespaces, defaultNamespace, userNamespace])
+    }, [namespaces, initialNamespace, userNamespace])
 
     return {
         userNamespace,

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.tsx
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.tsx
@@ -58,11 +58,15 @@ export const WorkspacesPreview: React.FunctionComponent<WorkspacesPreviewProps> 
     // workspaces resolution failed, or if the batch spec YAML on the server is out of
     // date with the one in the editor.
     const [showPreviewPrompt, previewPromptForm] = useMemo(() => {
-        const showPreviewPrompt = !batchSpecID || resolutionError || batchSpecStale
-        const previewPromptForm: PreviewPromptForm = !batchSpecID ? 'Initial' : resolutionError ? 'Error' : 'Update'
+        const showPreviewPrompt = !currentPreviewRequestTime || resolutionError || batchSpecStale
+        const previewPromptForm: PreviewPromptForm = !currentPreviewRequestTime
+            ? 'Initial'
+            : resolutionError
+            ? 'Error'
+            : 'Update'
 
         return [showPreviewPrompt, previewPromptForm]
-    }, [batchSpecID, batchSpecStale, resolutionError])
+    }, [currentPreviewRequestTime, batchSpecStale, resolutionError])
 
     const clearErrorAndPreview = useCallback(() => {
         setResolutionError(undefined)

--- a/client/web/src/enterprise/organizations/routes.tsx
+++ b/client/web/src/enterprise/organizations/routes.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
-import { Redirect } from 'react-router'
 import { RouteComponentProps } from 'react-router'
 
 import { OrgAreaPageProps, OrgAreaRoute } from '../../org/area/OrgArea'
 import { orgAreaRoutes } from '../../org/area/routes'
 import { lazyComponent } from '../../util/lazyComponent'
+import { CreateBatchChangePage } from '../batches/create/CreateBatchChangePage'
 import { NewCreateBatchChangePage } from '../batches/create/NewCreateBatchChangePage'
 import { NamespaceBatchChangesAreaProps } from '../batches/global/GlobalBatchChangesArea'
 import { enterpriseNamespaceAreaRoutes } from '../namespaces/routes'
@@ -19,7 +19,7 @@ export const enterpriseOrganizationAreaRoutes: readonly OrgAreaRoute[] = [
     ...enterpriseNamespaceAreaRoutes,
     {
         path: '/batch-changes/create',
-        render: props => <Redirect to={`/batch-changes/create?namespace=${props.org.name}`} />,
+        render: props => <CreateBatchChangePage headingElement="h1" {...props} namespace={props.org} />,
         condition: ({ batchChangesEnabled }) => batchChangesEnabled,
         fullPage: true,
     },
@@ -30,7 +30,7 @@ export const enterpriseOrganizationAreaRoutes: readonly OrgAreaRoute[] = [
                 {...props}
                 namespace={props.org}
                 batchChangeName={match.params.batchChangeName}
-                initiallyOpenFormType={false}
+                settingsInitiallyOpen={false}
             />
         ),
         condition: ({ batchChangesEnabled, batchChangesExecutionEnabled }) =>

--- a/client/web/src/enterprise/organizations/routes.tsx
+++ b/client/web/src/enterprise/organizations/routes.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import { Redirect } from 'react-router'
+import { RouteComponentProps } from 'react-router'
 
-import { OrgAreaRoute } from '../../org/area/OrgArea'
+import { OrgAreaPageProps, OrgAreaRoute } from '../../org/area/OrgArea'
 import { orgAreaRoutes } from '../../org/area/routes'
 import { lazyComponent } from '../../util/lazyComponent'
+import { NewCreateBatchChangePage } from '../batches/create/NewCreateBatchChangePage'
 import { NamespaceBatchChangesAreaProps } from '../batches/global/GlobalBatchChangesArea'
 import { enterpriseNamespaceAreaRoutes } from '../namespaces/routes'
 
@@ -19,6 +21,21 @@ export const enterpriseOrganizationAreaRoutes: readonly OrgAreaRoute[] = [
         path: '/batch-changes/create',
         render: props => <Redirect to={`/batch-changes/create?namespace=${props.org.name}`} />,
         condition: ({ batchChangesEnabled }) => batchChangesEnabled,
+        fullPage: true,
+    },
+    {
+        path: '/batch-changes/:batchChangeName/edit',
+        render: ({ match, ...props }: OrgAreaPageProps & RouteComponentProps<{ batchChangeName: string }>) => (
+            <NewCreateBatchChangePage
+                {...props}
+                namespace={props.org}
+                batchChangeName={match.params.batchChangeName}
+                initiallyOpenFormType={false}
+            />
+        ),
+        condition: ({ batchChangesEnabled, batchChangesExecutionEnabled }) =>
+            batchChangesEnabled && batchChangesExecutionEnabled,
+        fullPage: true,
     },
     {
         path: '/batch-changes',

--- a/client/web/src/enterprise/organizations/routes.tsx
+++ b/client/web/src/enterprise/organizations/routes.tsx
@@ -4,14 +4,24 @@ import { RouteComponentProps } from 'react-router'
 import { OrgAreaPageProps, OrgAreaRoute } from '../../org/area/OrgArea'
 import { orgAreaRoutes } from '../../org/area/routes'
 import { lazyComponent } from '../../util/lazyComponent'
-import { CreateBatchChangePage } from '../batches/create/CreateBatchChangePage'
-import { NewCreateBatchChangePage } from '../batches/create/NewCreateBatchChangePage'
+import { CreateBatchChangePageProps } from '../batches/create/CreateBatchChangePage'
+import { NewCreateBatchChangePageProps } from '../batches/create/NewCreateBatchChangePage'
 import { NamespaceBatchChangesAreaProps } from '../batches/global/GlobalBatchChangesArea'
 import { enterpriseNamespaceAreaRoutes } from '../namespaces/routes'
 
 const NamespaceBatchChangesArea = lazyComponent<NamespaceBatchChangesAreaProps, 'NamespaceBatchChangesArea'>(
     () => import('../batches/global/GlobalBatchChangesArea'),
     'NamespaceBatchChangesArea'
+)
+
+const NewCreateBatchChangePage = lazyComponent<NewCreateBatchChangePageProps, 'NewCreateBatchChangePage'>(
+    () => import('../batches/create/NewCreateBatchChangePage'),
+    'NewCreateBatchChangePage'
+)
+
+const CreateBatchChangePage = lazyComponent<CreateBatchChangePageProps, 'CreateBatchChangePage'>(
+    () => import('../batches/create/CreateBatchChangePage'),
+    'CreateBatchChangePage'
 )
 
 export const enterpriseOrganizationAreaRoutes: readonly OrgAreaRoute[] = [

--- a/client/web/src/enterprise/organizations/routes.tsx
+++ b/client/web/src/enterprise/organizations/routes.tsx
@@ -26,12 +26,7 @@ export const enterpriseOrganizationAreaRoutes: readonly OrgAreaRoute[] = [
     {
         path: '/batch-changes/:batchChangeName/edit',
         render: ({ match, ...props }: OrgAreaPageProps & RouteComponentProps<{ batchChangeName: string }>) => (
-            <NewCreateBatchChangePage
-                {...props}
-                namespace={props.org}
-                batchChangeName={match.params.batchChangeName}
-                settingsInitiallyOpen={false}
-            />
+            <NewCreateBatchChangePage {...props} namespace={props.org} batchChangeName={match.params.batchChangeName} />
         ),
         condition: ({ batchChangesEnabled, batchChangesExecutionEnabled }) =>
             batchChangesEnabled && batchChangesExecutionEnabled,

--- a/client/web/src/enterprise/user/routes.tsx
+++ b/client/web/src/enterprise/user/routes.tsx
@@ -4,8 +4,8 @@ import { Redirect, RouteComponentProps } from 'react-router'
 import { userAreaRoutes } from '../../user/area/routes'
 import { UserAreaRoute, UserAreaRouteContext } from '../../user/area/UserArea'
 import { lazyComponent } from '../../util/lazyComponent'
-import { CreateBatchChangePage } from '../batches/create/CreateBatchChangePage'
-import { NewCreateBatchChangePage } from '../batches/create/NewCreateBatchChangePage'
+import { CreateBatchChangePageProps } from '../batches/create/CreateBatchChangePage'
+import { NewCreateBatchChangePageProps } from '../batches/create/NewCreateBatchChangePage'
 import { NamespaceBatchChangesAreaProps } from '../batches/global/GlobalBatchChangesArea'
 import { SHOW_BUSINESS_FEATURES } from '../dotcom/productSubscriptions/features'
 import { enterpriseNamespaceAreaRoutes } from '../namespaces/routes'
@@ -13,6 +13,16 @@ import { enterpriseNamespaceAreaRoutes } from '../namespaces/routes'
 const NamespaceBatchChangesArea = lazyComponent<NamespaceBatchChangesAreaProps, 'NamespaceBatchChangesArea'>(
     () => import('../batches/global/GlobalBatchChangesArea'),
     'NamespaceBatchChangesArea'
+)
+
+const NewCreateBatchChangePage = lazyComponent<NewCreateBatchChangePageProps, 'NewCreateBatchChangePage'>(
+    () => import('../batches/create/NewCreateBatchChangePage'),
+    'NewCreateBatchChangePage'
+)
+
+const CreateBatchChangePage = lazyComponent<CreateBatchChangePageProps, 'CreateBatchChangePage'>(
+    () => import('../batches/create/CreateBatchChangePage'),
+    'CreateBatchChangePage'
 )
 
 export const enterpriseUserAreaRoutes: readonly UserAreaRoute[] = [

--- a/client/web/src/enterprise/user/routes.tsx
+++ b/client/web/src/enterprise/user/routes.tsx
@@ -4,6 +4,7 @@ import { Redirect, RouteComponentProps } from 'react-router'
 import { userAreaRoutes } from '../../user/area/routes'
 import { UserAreaRoute, UserAreaRouteContext } from '../../user/area/UserArea'
 import { lazyComponent } from '../../util/lazyComponent'
+import { CreateBatchChangePage } from '../batches/create/CreateBatchChangePage'
 import { NewCreateBatchChangePage } from '../batches/create/NewCreateBatchChangePage'
 import { NamespaceBatchChangesAreaProps } from '../batches/global/GlobalBatchChangesArea'
 import { SHOW_BUSINESS_FEATURES } from '../dotcom/productSubscriptions/features'
@@ -32,7 +33,7 @@ export const enterpriseUserAreaRoutes: readonly UserAreaRoute[] = [
     },
     {
         path: '/batch-changes/create',
-        render: props => <Redirect to={`/batch-changes/create?namespace=${props.user.username}`} />,
+        render: props => <CreateBatchChangePage headingElement="h1" {...props} namespace={props.user} />,
         condition: ({ batchChangesEnabled }) => batchChangesEnabled,
         fullPage: true,
     },

--- a/client/web/src/enterprise/user/routes.tsx
+++ b/client/web/src/enterprise/user/routes.tsx
@@ -4,6 +4,7 @@ import { Redirect, RouteComponentProps } from 'react-router'
 import { userAreaRoutes } from '../../user/area/routes'
 import { UserAreaRoute, UserAreaRouteContext } from '../../user/area/UserArea'
 import { lazyComponent } from '../../util/lazyComponent'
+import { NewCreateBatchChangePage } from '../batches/create/NewCreateBatchChangePage'
 import { NamespaceBatchChangesAreaProps } from '../batches/global/GlobalBatchChangesArea'
 import { SHOW_BUSINESS_FEATURES } from '../dotcom/productSubscriptions/features'
 import { enterpriseNamespaceAreaRoutes } from '../namespaces/routes'
@@ -33,6 +34,21 @@ export const enterpriseUserAreaRoutes: readonly UserAreaRoute[] = [
         path: '/batch-changes/create',
         render: props => <Redirect to={`/batch-changes/create?namespace=${props.user.username}`} />,
         condition: ({ batchChangesEnabled }) => batchChangesEnabled,
+        fullPage: true,
+    },
+    {
+        path: '/batch-changes/:batchChangeName/edit',
+        render: ({ match, ...props }: UserAreaRouteContext & RouteComponentProps<{ batchChangeName: string }>) => (
+            <NewCreateBatchChangePage
+                {...props}
+                namespace={props.user}
+                batchChangeName={match.params.batchChangeName}
+                initiallyOpenFormType={false}
+            />
+        ),
+        condition: ({ batchChangesEnabled, batchChangesExecutionEnabled }) =>
+            batchChangesEnabled && batchChangesExecutionEnabled,
+        fullPage: true,
     },
     {
         path: '/batch-changes',

--- a/client/web/src/enterprise/user/routes.tsx
+++ b/client/web/src/enterprise/user/routes.tsx
@@ -44,7 +44,6 @@ export const enterpriseUserAreaRoutes: readonly UserAreaRoute[] = [
                 {...props}
                 namespace={props.user}
                 batchChangeName={match.params.batchChangeName}
-                initiallyOpenFormType={false}
             />
         ),
         condition: ({ batchChangesEnabled, batchChangesExecutionEnabled }) =>

--- a/client/web/src/org/area/OrgArea.tsx
+++ b/client/web/src/org/area/OrgArea.tsx
@@ -77,7 +77,9 @@ const NotFoundPage: React.FunctionComponent = () => (
     <HeroPage icon={MapSearchIcon} title="404: Not Found" subtitle="Sorry, the requested organization was not found." />
 )
 
-export interface OrgAreaRoute extends RouteDescriptor<OrgAreaPageProps> {}
+export interface OrgAreaRoute extends RouteDescriptor<OrgAreaPageProps> {
+    fullPage?: boolean
+}
 
 interface Props
     extends RouteComponentProps<{ name: string }>,
@@ -246,31 +248,40 @@ export class OrgArea extends React.Component<Props> {
         }
 
         return (
-            <Page className="org-area">
-                <OrgHeader {...this.props} {...context} navItems={this.props.orgAreaHeaderNavItems} />
-                <div className="container mt-3">
-                    <ErrorBoundary location={this.props.location}>
-                        <React.Suspense fallback={<LoadingSpinner className="icon-inline m-2" />}>
-                            <Switch>
-                                {this.props.orgAreaRoutes.map(
-                                    ({ path, exact, render, condition = () => true }) =>
-                                        condition(context) && (
-                                            <Route
-                                                path={this.props.match.url + path}
-                                                key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                                                exact={exact}
-                                                render={routeComponentProps =>
-                                                    render({ ...context, ...routeComponentProps })
-                                                }
-                                            />
-                                        )
-                                )}
-                                <Route key="hardcoded-key" component={NotFoundPage} />
-                            </Switch>
-                        </React.Suspense>
-                    </ErrorBoundary>
-                </div>
-            </Page>
+            <ErrorBoundary location={this.props.location}>
+                <React.Suspense fallback={<LoadingSpinner className="icon-inline m-2" />}>
+                    <Switch>
+                        {this.props.orgAreaRoutes.map(
+                            ({ path, exact, render, condition = () => true, fullPage }) =>
+                                condition(context) && (
+                                    <Route
+                                        path={this.props.match.url + path}
+                                        key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                                        exact={exact}
+                                        render={routeComponentProps =>
+                                            fullPage ? (
+                                                render({ ...context, ...routeComponentProps })
+                                            ) : (
+                                                <Page className="org-area">
+                                                    <OrgHeader
+                                                        {...this.props}
+                                                        {...context}
+                                                        navItems={this.props.orgAreaHeaderNavItems}
+                                                        className="mb-3"
+                                                    />
+                                                    <div className="container">
+                                                        {render({ ...context, ...routeComponentProps })}
+                                                    </div>
+                                                </Page>
+                                            )
+                                        }
+                                    />
+                                )
+                        )}
+                        <Route key="hardcoded-key" component={NotFoundPage} />
+                    </Switch>
+                </React.Suspense>
+            </ErrorBoundary>
         )
     }
 

--- a/client/web/src/user/area/UserArea.tsx
+++ b/client/web/src/user/area/UserArea.tsx
@@ -60,7 +60,9 @@ export const USER_AREA_USER_PROFILE = gql`
     ${UserAreaGQLFragment}
 `
 
-export interface UserAreaRoute extends RouteDescriptor<UserAreaRouteContext> {}
+export interface UserAreaRoute extends RouteDescriptor<UserAreaRouteContext> {
+    fullPage?: boolean
+}
 
 interface UserAreaProps
     extends RouteComponentProps<{ username: string }>,
@@ -184,33 +186,42 @@ export const UserArea: React.FunctionComponent<UserAreaProps> = ({
     }
 
     return (
-        <Page>
-            <UserAreaHeader {...props} {...context} navItems={props.userAreaHeaderNavItems} />
-            <div className="container mt-3">
-                <ErrorBoundary location={props.location}>
-                    <React.Suspense fallback={<LoadingSpinner className="icon-inline m-2" />}>
-                        <Switch>
-                            {userAreaRoutes.map(
-                                ({ path, exact, render, condition = () => true }) =>
-                                    condition(context) && (
-                                        <Route
-                                            render={routeComponentProps =>
-                                                render({ ...context, ...routeComponentProps })
-                                            }
-                                            path={url + path}
-                                            key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                                            exact={exact}
-                                        />
-                                    )
-                            )}
-                            <Route key="hardcoded-key">
-                                <NotFoundPage />
-                            </Route>
-                        </Switch>
-                    </React.Suspense>
-                </ErrorBoundary>
-            </div>
-        </Page>
+        <ErrorBoundary location={props.location}>
+            <React.Suspense fallback={<LoadingSpinner className="icon-inline m-2" />}>
+                <Switch>
+                    {userAreaRoutes.map(
+                        ({ path, exact, render, condition = () => true, fullPage }) =>
+                            condition(context) && (
+                                <Route
+                                    render={routeComponentProps =>
+                                        fullPage ? (
+                                            render({ ...context, ...routeComponentProps })
+                                        ) : (
+                                            <Page>
+                                                <UserAreaHeader
+                                                    {...props}
+                                                    {...context}
+                                                    className="mb-3"
+                                                    navItems={props.userAreaHeaderNavItems}
+                                                />
+                                                <div className="container">
+                                                    {render({ ...context, ...routeComponentProps })}
+                                                </div>
+                                            </Page>
+                                        )
+                                    }
+                                    path={url + path}
+                                    key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                                    exact={exact}
+                                />
+                            )
+                    )}
+                    <Route key="hardcoded-key">
+                        <NotFoundPage />
+                    </Route>
+                </Switch>
+            </React.Suspense>
+        </ErrorBoundary>
     )
 }
 


### PR DESCRIPTION
Another piece of EM2.4. The goal of this PR was to add support for visiting the route `users/courier-new/batch-changes/my-batch-change/edit` to open the SSBC editor for an existing batch change and be able to execute a new batch spec for it. **Currently, re-execution is disabled except for draft batch changes.**

Nothing actually points to this new route yet, so for now you can only get to it by manually typing it in. I've also flagged a couple things here with `TODO` comments that will almost immediately be improved by the batch change settings form (#28829).

In order for this to work, I needed to be able to define routes within the user and org namespaces that would not render the normal user/org area header, since our SSBC editor page wants to occupy the whole screen. You can see how this works by looking at the reordered component nesting in `UserArea` and `OrgArea`, where I then selectively render the `Page` container and `User/OrgHeader` unless the route asks for `fullPage: true`. I tried my best to verify that this didn't have adverse effects on the layout for other namespace pages or when the error boundary or suspense view are visible, but please double check me on that. 😅

Enabling this full-page support meant that I could also restore the URL `users/courier-new/batch-changes/create` as a way of creating a new batch change from a given namespace, as opposed to having to pass the namespace as a query parameter as I was doing before.

Here's a quick demo video of some of this in action:

https://user-images.githubusercontent.com/8942601/145515132-86edb89c-88c0-4309-aabf-f6345b72bcd9.mov

This PR depends on the mutation changes from #28825 and #28827 and is thus temporarily based on #28827.