### PR TITLE
sg: revert readlink -f

### DIFF
--- a/dev/sg/install.sh
+++ b/dev/sg/install.sh
@@ -77,8 +77,7 @@ echo "  sg installed to $target"
 # accordingly in terms of usage.
 
 set +e # Don't fail if it the check fails
-# We try to follow possible symlinks to display the actual path
-sg_in_path=$(readlink -f "$(command -v sg)")
+sg_in_path=$(command -v sg)
 set -e
 
 red_bg=$'\033[41m'


### PR DESCRIPTION
readlink does not support -f on BSD tools. As such this version of the
script fails on macOS with

```
sg installed to /Users/keegan/go/bin/sg
readlink: illegal option -- f
usage: readlink [-n] [file ...]
```

This reverts commit 925d5703b71a390219b00c9bb4a78521afe22dda.
This reverts commit 8e42a279f5d8b47875888ecb11f1bc4da05f8741.