### PR TITLE
dbtest: remove dsn from getDSN argument

### DIFF
--- a/internal/database/dbtest/dbtest.go
+++ b/internal/database/dbtest/dbtest.go
@@ -62,22 +62,22 @@ func NewDB(t testing.TB) *sql.DB {
 	if os.Getenv("USE_FAST_DBTEST") != "" {
 		return NewFastDB(t)
 	}
-	return newFromDSN(t, "", "migrated")
+	return newFromDSN(t, "migrated")
 }
 
 // NewRawDB returns a connection to a clean, new temporary testing database.
 func NewRawDB(t testing.TB) *sql.DB {
-	return newFromDSN(t, "", "raw")
+	return newFromDSN(t, "raw")
 }
 
-func newFromDSN(t testing.TB, dsn, templateNamespace string) *sql.DB {
+func newFromDSN(t testing.TB, templateNamespace string) *sql.DB {
 	if testing.Short() {
 		t.Skip("skipping DB test since -short specified")
 	}
 
-	config, err := getDSN(dsn)
+	config, err := getDSN()
 	if err != nil {
-		t.Fatalf("failed to parse dsn %q: %s", dsn, err)
+		t.Fatalf("failed to parse dsn: %s", err)
 	}
 
 	initTemplateDB(t, config)

--- a/internal/database/dbtest/dbtest_fast.go
+++ b/internal/database/dbtest/dbtest_fast.go
@@ -76,7 +76,7 @@ var (
 // us from opening a ton of parallel database connections per process.
 func getDefaultPool() (*testDatabasePool, *url.URL, error) {
 	defaultOnce.Do(func() {
-		defaultURL, defaultErr = getDSN("")
+		defaultURL, defaultErr = getDSN()
 		if defaultErr != nil {
 			return
 		}

--- a/internal/database/dbtest/dsn.go
+++ b/internal/database/dbtest/dsn.go
@@ -5,19 +5,12 @@ import (
 	"os"
 )
 
-func getDSN(dsn string) (*url.URL, error) {
-	if dsn == "" {
-		var ok bool
-		if dsn, ok = os.LookupEnv("PGDATASOURCE"); !ok {
-			dsn = `postgres://sourcegraph:sourcegraph@127.0.0.1:5432/sourcegraph?sslmode=disable&timezone=UTC`
-		} else {
-			// If the user specified PGDATASOURCE, don't try and mux in other
-			// environment variables. Our code which does that is not always
-			// correct. For example it fails on unix sockets.
-			return url.Parse(dsn)
-		}
+func getDSN() (*url.URL, error) {
+	if dsn, ok := os.LookupEnv("PGDATASOURCE"); ok {
+		return url.Parse(dsn)
 	}
 
+	dsn := `postgres://sourcegraph:sourcegraph@127.0.0.1:5432/sourcegraph?sslmode=disable&timezone=UTC`
 	u, err := url.Parse(dsn)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
dsn is always an empty string, so we can just remove it as an argument to getDSN. This commit should not change any behaviour.