### PR TITLE
dbtest: use postgresdsn

### DIFF
--- a/internal/database/dbtest/dsn_test.go
+++ b/internal/database/dbtest/dsn_test.go
@@ -1,0 +1,57 @@
+package dbtest
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestGetDSN(t *testing.T) {
+	// clear out PG envvars for this test
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "PG") {
+			t.Setenv(strings.Split(e, "=")[0], "")
+		}
+	}
+
+	cases := []struct {
+		Name string
+		Env  map[string]string
+		DSN  string
+	}{{
+		Name: "default",
+		DSN:  "postgres://sourcegraph:sourcegraph@127.0.0.1:5432/sourcegraph?sslmode=disable&timezone=UTC",
+	}, {
+		// test we mux into the default
+		Name: "PGDATABASE",
+		Env: map[string]string{
+			"PGDATABASE": "TESTDB",
+		},
+		DSN: "postgres://sourcegraph:sourcegraph@127.0.0.1:5432/TESTDB?sslmode=disable&timezone=UTC",
+	}, {
+		// if we have pgdatasource set, do not use the default
+		Name: "PGDATASOURCE",
+		Env: map[string]string{
+			"PGDATASOURCE": "postgres://ignore.other/env/vars",
+			"PGDATABASE":   "foo",
+			"PGUSER":       "bar",
+		},
+		DSN: "postgres://ignore.other/env/vars",
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			for k, v := range tc.Env {
+				t.Setenv(k, v)
+			}
+			u, err := getDSN()
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := u.String()
+			if got != tc.DSN {
+				t.Fatalf("unexpected:\ngot:  %s\nwant: %s", got, tc.DSN)
+			}
+		})
+	}
+}

--- a/internal/database/postgresdsn/postgresdsn.go
+++ b/internal/database/postgresdsn/postgresdsn.go
@@ -63,5 +63,11 @@ func New(prefix, currentUser string, getenv func(string) string) string {
 		dsn.RawQuery = qry.Encode()
 	}
 
+	if tz := env("PGTZ"); tz != "" {
+		qry := dsn.Query()
+		qry.Set("timezone", tz)
+		dsn.RawQuery = qry.Encode()
+	}
+
 	return dsn.String()
 }

--- a/internal/database/postgresdsn/postgresdsn_test.go
+++ b/internal/database/postgresdsn/postgresdsn_test.go
@@ -42,6 +42,18 @@ func TestNew(t *testing.T) {
 		},
 		dsn: "postgres://postgres@127.0.0.1/sourcegraph?sslmode=disable",
 	}, {
+		name: "dbtest",
+		env: map[string]string{
+			"PGHOST":     "127.0.0.1",
+			"PGPORT":     "5432",
+			"PGUSER":     "sourcegraph",
+			"PGPASSWORD": "sourcegraph",
+			"PGDATABASE": "sourcegraph",
+			"PGSSLMODE":  "disable",
+			"PGTZ":       "UTC",
+		},
+		dsn: "postgres://sourcegraph:sourcegraph@127.0.0.1:5432/sourcegraph?sslmode=disable&timezone=UTC",
+	}, {
 		name: "datasource",
 		env: map[string]string{
 			"PGDATASOURCE": "postgres://foo@bar/bam",


### PR DESCRIPTION
This commit removes some duplicate code we had around updating a DSN
based on PG envvars. The changes in behaviour are we now support reading
the PGTZ envvar in postgresdsn and for dbtest we ignore an empty
PGDATASOURCE (rather than only an unset one).

To achieve this we move from a hardcoded default DSN for dbtest to
instead providing the equivalent defaults as PG envvars. To ensure we
haven't regressed around the corner cases here we added a unit test for
getDSN. It isn't exhaustive, instead we can now rely on the tests we
have for postgresdsn.

Depends on https://github.com/sourcegraph/sourcegraph/pull/28833