### PR TITLE
Update about orgs page to include CTA for private beta access

### DIFF
--- a/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.tsx
+++ b/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.tsx
@@ -4,6 +4,7 @@ import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryServi
 import { PageTitle } from '@sourcegraph/web/src/components/PageTitle'
 import { SelfHostedCta } from '@sourcegraph/web/src/components/SelfHostedCta'
 import { Container, PageHeader } from '@sourcegraph/wildcard'
+import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
 
 import styles from './AboutOrganizationPage.module.scss'
 
@@ -23,21 +24,27 @@ export const AboutOrganizationPage: React.FunctionComponent<AboutOrganizationPag
                 description="Support for organizations is not currently available on Sourcegraph Cloud."
                 className="mb-3"
             />
-            <Container>
-                <SelfHostedCta
-                    contentClassName={styles.selfHostedCtaContent}
-                    page="organizations"
-                    telemetryService={telemetryService}
-                >
-                    <p className="mb-2">
-                        <strong>Run Sourcegraph self-hosted for more enterprise features</strong>
-                    </p>
-                    <p className="mb-2">
-                        For team oriented functionality, additional code hosts and enterprise only features, install
-                        Sourcegraph self-hosted.
-                    </p>
-                </SelfHostedCta>
+            <Container className="mb-4">
+                <h3>Private beta access for small teams now available</h3>
+                <p>Get instant access to code navigation and intelligence across your team’s private code and 2M open source repositories. Sourcegraph Cloud for teams brings enterprise advantages to small teams.</p>
+                <a href="https://share.hsforms.com/14OQ3RoPpQTOXvZlUpgx6-A1n7ku/" className="btn btn-primary" target="_blank" rel="noopener noreferrer">
+                    Sign up for private beta access <OpenInNewIcon className="icon-inline" />
+                </a>
             </Container>
+            <SelfHostedCta
+                contentClassName={styles.selfHostedCtaContent}
+                page="organizations"
+                telemetryService={telemetryService}
+            >
+                <p className="mb-2">
+                    <strong>Need more enterprise features? Run Sourcegraph self-hosted</strong>
+                </p>
+                <p className="mb-2">
+                    For additional code hosts and enterprise only features, install
+                    Sourcegraph self-hosted.
+                </p>
+            </SelfHostedCta>
+
         </>
     )
 }

--- a/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.tsx
+++ b/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.tsx
@@ -7,7 +7,6 @@ import { SelfHostedCta } from '@sourcegraph/web/src/components/SelfHostedCta'
 import { Container, PageHeader } from '@sourcegraph/wildcard'
 
 import styles from './AboutOrganizationPage.module.scss'
-
 interface AboutOrganizationPageProps extends TelemetryProps {}
 
 export const AboutOrganizationPage: React.FunctionComponent<AboutOrganizationPageProps> = ({ telemetryService }) => {
@@ -26,8 +25,16 @@ export const AboutOrganizationPage: React.FunctionComponent<AboutOrganizationPag
             />
             <Container className="mb-4">
                 <h3>Private beta access for small teams now available</h3>
-                <p>Get instant access to code navigation and intelligence across your team’s private code and 2M open source repositories. Sourcegraph Cloud for teams brings enterprise advantages to small teams.</p>
-                <a href="https://share.hsforms.com/14OQ3RoPpQTOXvZlUpgx6-A1n7ku/" className="btn btn-primary" target="_blank" rel="noopener noreferrer">
+                <p>
+                    Get instant access to code navigation and intelligence across your team’s private code and 2M open
+                    source repositories. Sourcegraph Cloud for teams brings enterprise advantages to small teams.
+                </p>
+                <a
+                    href="https://share.hsforms.com/14OQ3RoPpQTOXvZlUpgx6-A1n7ku/"
+                    className="btn btn-primary"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
                     Sign up for private beta access <OpenInNewIcon className="icon-inline" />
                 </a>
             </Container>
@@ -40,11 +47,9 @@ export const AboutOrganizationPage: React.FunctionComponent<AboutOrganizationPag
                     <strong>Need more enterprise features? Run Sourcegraph self-hosted</strong>
                 </p>
                 <p className="mb-2">
-                    For additional code hosts and enterprise only features, install
-                    Sourcegraph self-hosted.
+                    For additional code hosts and enterprise only features, install Sourcegraph self-hosted.
                 </p>
             </SelfHostedCta>
-
         </>
     )
 }

--- a/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.tsx
+++ b/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.tsx
@@ -1,5 +1,4 @@
 import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
-
 import React, { useEffect } from 'react'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'

--- a/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.tsx
+++ b/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.tsx
@@ -1,10 +1,11 @@
+import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
+
 import React, { useEffect } from 'react'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { PageTitle } from '@sourcegraph/web/src/components/PageTitle'
 import { SelfHostedCta } from '@sourcegraph/web/src/components/SelfHostedCta'
 import { Container, PageHeader } from '@sourcegraph/wildcard'
-import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
 
 import styles from './AboutOrganizationPage.module.scss'
 


### PR DESCRIPTION
Updates the "About organizations" page in settings to include a CTA for private beta access. Preserves, but rewords, the on-premise CTA.

We may need to update again to provide tracking around click-throughs on the CTA.