### PR TITLE
Revert "[cloud] Fix upsert of organization owned external services (#28806)"

### DIFF
--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -847,10 +847,10 @@ func (e *externalServiceStore) Upsert(ctx context.Context, svcs ...*types.Extern
 			&dbutil.NullTime{Time: &svcs[i].LastSyncAt},
 			&dbutil.NullTime{Time: &svcs[i].NextSyncAt},
 			&dbutil.NullInt32{N: &svcs[i].NamespaceUserID},
-			&dbutil.NullInt32{N: &svcs[i].NamespaceOrgID},
 			&svcs[i].Unrestricted,
 			&svcs[i].CloudDefault,
 			&encryptionKeyID,
+			&dbutil.NullInt32{N: &svcs[i].NamespaceOrgID},
 			&dbutil.NullBool{B: svcs[i].HasWebhooks},
 		)
 		if err != nil {
@@ -888,7 +888,6 @@ func (e *externalServiceStore) upsertExternalServicesQuery(ctx context.Context, 
 			nullTimeColumn(s.LastSyncAt),
 			nullTimeColumn(s.NextSyncAt),
 			nullInt32Column(s.NamespaceUserID),
-			nullInt32Column(s.NamespaceOrgID),
 			s.Unrestricted,
 			s.CloudDefault,
 			s.HasWebhooks,
@@ -902,7 +901,7 @@ func (e *externalServiceStore) upsertExternalServicesQuery(ctx context.Context, 
 }
 
 const upsertExternalServicesQueryValueFmtstr = `
-  (COALESCE(NULLIF(%s, 0), (SELECT nextval('external_services_id_seq'))), UPPER(%s), %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+  (COALESCE(NULLIF(%s, 0), (SELECT nextval('external_services_id_seq'))), UPPER(%s), %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 `
 
 const upsertExternalServicesQueryFmtstr = `
@@ -919,7 +918,6 @@ INSERT INTO external_services (
   last_sync_at,
   next_sync_at,
   namespace_user_id,
-  namespace_org_id,
   unrestricted,
   cloud_default,
   has_webhooks
@@ -937,7 +935,6 @@ SET
   last_sync_at       = excluded.last_sync_at,
   next_sync_at       = excluded.next_sync_at,
   namespace_user_id  = excluded.namespace_user_id,
-  namespace_org_id   = excluded.namespace_org_id,
   unrestricted       = excluded.unrestricted,
   cloud_default      = excluded.cloud_default,
   has_webhooks       = excluded.has_webhooks
@@ -952,10 +949,10 @@ RETURNING
 	last_sync_at,
 	next_sync_at,
 	namespace_user_id,
-	namespace_org_id,
 	unrestricted,
 	cloud_default,
 	encryption_key_id,
+	namespace_org_id,
 	has_webhooks
 `
 
@@ -1008,7 +1005,6 @@ func (e *externalServiceStore) Update(ctx context.Context, ps []schema.AuthProvi
 			Config:            *update.Config,
 			AuthProviders:     ps,
 			NamespaceUserID:   externalService.NamespaceUserID,
-			NamespaceOrgID:    externalService.NamespaceOrgID,
 		})
 		if err != nil {
 			return err

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -1628,17 +1628,6 @@ func TestExternalServicesStore_Upsert(t *testing.T) {
 	})
 
 	t.Run("many external services", func(t *testing.T) {
-		user, err := Users(db).Create(ctx, NewUser{Username: "alice"})
-		if err != nil {
-			t.Fatalf("Test setup error %s", err)
-		}
-		org, err := Orgs(db).Create(ctx, "acme", nil)
-		if err != nil {
-			t.Fatalf("Test setup error %s", err)
-		}
-
-		namespacedSvcs := typestest.MakeNamespacedExternalServices(user.ID, org.ID)
-
 		tx, err := ExternalServices(db).Transact(ctx)
 		if err != nil {
 			t.Fatalf("Transact error: %s", err)
@@ -1650,8 +1639,7 @@ func TestExternalServicesStore_Upsert(t *testing.T) {
 			}
 		}()
 
-		services := append(svcs, namespacedSvcs...)
-		want := typestest.GenerateExternalServices(11, services...)
+		want := typestest.GenerateExternalServices(7, svcs...)
 
 		if err := tx.Upsert(ctx, want...); err != nil {
 			t.Fatalf("Upsert error: %s", err)
@@ -1667,7 +1655,7 @@ func TestExternalServicesStore_Upsert(t *testing.T) {
 		sort.Sort(want)
 
 		have, err := tx.List(ctx, ExternalServicesListOptions{
-			Kinds: services.Kinds(),
+			Kinds: svcs.Kinds(),
 		})
 		if err != nil {
 			t.Fatalf("List error: %s", err)

--- a/internal/types/typestest/typestest.go
+++ b/internal/types/typestest/typestest.go
@@ -177,51 +177,6 @@ func MakeExternalServices() types.ExternalServices {
 	}
 }
 
-// MakeNamespacedExternalServices creates one configured external service per kind, per user or org.
-func MakeNamespacedExternalServices(userID int32, orgID int32) types.ExternalServices {
-	clock := timeutil.NewFakeClock(time.Now(), 0)
-	now := clock.Now()
-
-	services := []*types.ExternalService{}
-
-	if userID > 0 {
-		services = append(services, &types.ExternalService{
-			Kind:            extsvc.KindGitHub,
-			DisplayName:     "Github - User",
-			Config:          `{"url": "https://github.com", "token": "abc", "repositoryQuery": ["none"]}`,
-			CreatedAt:       now,
-			UpdatedAt:       now,
-			NamespaceUserID: userID,
-		}, &types.ExternalService{
-			Kind:            extsvc.KindGitLab,
-			DisplayName:     "GitLab - User",
-			Config:          `{"url": "https://gitlab.com", "token": "abc", "projectQuery": ["projects?membership=true&archived=no"]}`,
-			CreatedAt:       now,
-			UpdatedAt:       now,
-			NamespaceUserID: userID,
-		})
-	}
-	if orgID > 0 {
-		services = append(services, &types.ExternalService{
-			Kind:           extsvc.KindGitHub,
-			DisplayName:    "Github - Org",
-			Config:         `{"url": "https://github.com", "token": "abc", "repositoryQuery": ["none"]}`,
-			CreatedAt:      now,
-			UpdatedAt:      now,
-			NamespaceOrgID: orgID,
-		}, &types.ExternalService{
-			Kind:           extsvc.KindGitLab,
-			DisplayName:    "GitLab - Org",
-			Config:         `{"url": "https://gitlab.com", "token": "abc", "projectQuery": ["projects?membership=true&archived=no"]}`,
-			CreatedAt:      now,
-			UpdatedAt:      now,
-			NamespaceOrgID: orgID,
-		})
-	}
-
-	return services
-}
-
 // Generatetypes.ExternalServices takes a list of base external services and generates n ones with different names.
 func GenerateExternalServices(n int, base ...*types.ExternalService) types.ExternalServices {
 	if len(base) == 0 {


### PR DESCRIPTION
This reverts commit f92f8c5e79e2daaffef201764a8c642073965775 because it broke the build on `main`.

Example failure: https://buildkite.com/sourcegraph/sourcegraph/builds/120398#af1cea8c-1884-476d-b075-c6406dc96da5
