### PR TITLE
insights: skip conflicts when adding insight view to dashboard, and log duplicates in the migration

### DIFF
--- a/enterprise/internal/insights/migration/migration.go
+++ b/enterprise/internal/insights/migration/migration.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/inconshreveable/log15"
+
 	"github.com/cockroachdb/errors"
 	"github.com/hashicorp/go-multierror"
 
@@ -206,6 +208,7 @@ func (m *migrator) performMigrationForRow(ctx context.Context, jobStoreTx *store
 	for _, insight := range backendInsights {
 		allDefinedInsightIds = append(allDefinedInsightIds, insight.ID)
 	}
+	logDuplicates(allDefinedInsightIds)
 
 	totalInsights := len(langStatsInsights) + len(frontendInsights) + len(backendInsights)
 	var migratedInsightsCount int
@@ -264,6 +267,17 @@ func (m *migrator) performMigrationForRow(ctx context.Context, jobStoreTx *store
 	}
 
 	return nil
+}
+
+func logDuplicates(insightIds []string) {
+	set := make(map[string]struct{}, len(insightIds))
+	for _, id := range insightIds {
+		if _, ok := set[id]; ok {
+			log15.Info("insights setting oob-migration: duplicate insight ID", "uniqueId", id)
+		} else {
+			set[id] = struct{}{}
+		}
+	}
 }
 
 func specialCaseDashboardTitle(subjectName string) string {

--- a/enterprise/internal/insights/store/dashboard_store.go
+++ b/enterprise/internal/insights/store/dashboard_store.go
@@ -337,9 +337,9 @@ INSERT INTO dashboard_insight_view (dashboard_id, insight_view_id) (
 		ON ids.id = insight_view.unique_id
     WHERE unique_id = ANY(%s)
 	ORDER BY ids.ordering
-);
-`
+) ON CONFLICT DO NOTHING;
 
+`
 const updateDashboardSql = `
 -- source: enterprise/internal/insights/store/dashboard_store.go:UpdateDashboard
 UPDATE dashboard SET title = %s WHERE id = %s;


### PR DESCRIPTION
For some reason we are getting duplicate Insight Ids from settings when we perform the one time migration. This will skip conflicts, and log any duplicates for the purposes of debugging.