### PR TITLE
observability: augment TraceLogger to support tagging alongside logging

### DIFF
--- a/cmd/symbols/internal/api/search.go
+++ b/cmd/symbols/internal/api/search.go
@@ -18,7 +18,7 @@ import (
 const searchTimeout = 60 * time.Second
 
 func (h *apiHandler) handleSearchInternal(ctx context.Context, args types.SearchArgs) (_ *result.Symbols, err error) {
-	ctx, traceLog, endObservation := h.operations.search.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
+	ctx, trace, endObservation := h.operations.search.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.String("repo", string(args.Repo)),
 		log.String("commitID", string(args.CommitID)),
 		log.String("query", args.Query),
@@ -44,7 +44,7 @@ func (h *apiHandler) handleSearchInternal(ctx context.Context, args types.Search
 	if err != nil {
 		return nil, errors.Wrap(err, "databaseWriter.GetOrCreateDatabaseFile")
 	}
-	traceLog(log.String("dbFile", dbFile))
+	trace.Log(log.String("dbFile", dbFile))
 
 	var results result.Symbols
 	err = store.WithSQLiteStore(dbFile, func(db store.Store) (err error) {

--- a/cmd/symbols/internal/parser/parser.go
+++ b/cmd/symbols/internal/parser/parser.go
@@ -125,7 +125,7 @@ func (p *parser) Parse(ctx context.Context, args types.SearchArgs, paths []strin
 }
 
 func (p *parser) handleParseRequest(ctx context.Context, symbolOrErrors chan<- SymbolOrError, parseRequest fetcher.ParseRequest, totalSymbols *uint32) (err error) {
-	ctx, traceLog, endObservation := p.operations.handleParseRequest.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
+	ctx, trace, endObservation := p.operations.handleParseRequest.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("fileSize", len(parseRequest.Data)),
 	}})
 	defer endObservation(1, observation.Args{})
@@ -134,7 +134,7 @@ func (p *parser) handleParseRequest(ctx context.Context, symbolOrErrors chan<- S
 	if err != nil {
 		return err
 	}
-	traceLog(log.Event("acquired parser from pool"))
+	trace.Log(log.Event("acquired parser from pool"))
 
 	defer func() {
 		if err == nil {
@@ -161,7 +161,7 @@ func (p *parser) handleParseRequest(ctx context.Context, symbolOrErrors chan<- S
 	if err != nil {
 		return errors.Wrap(err, "parser.Parse")
 	}
-	traceLog(log.Int("numEntries", len(entries)))
+	trace.Log(log.Int("numEntries", len(entries)))
 
 	for _, e := range entries {
 		if !shouldPersistEntry(e) {

--- a/enterprise/cmd/frontend/internal/codeintel/httpapi/upload_handler.go
+++ b/enterprise/cmd/frontend/internal/codeintel/httpapi/upload_handler.go
@@ -77,7 +77,7 @@ func (h *UploadHandler) handleEnqueue(w http.ResponseWriter, r *http.Request) {
 	// easily. The remainder of the function simply serializes the result to the
 	// HTTP response writer.
 	payload, statusCode, err := func() (_ interface{}, statusCode int, err error) {
-		ctx, traceLog, endObservation := h.operations.handleEnqueue.WithAndLogger(r.Context(), &err, observation.Args{})
+		ctx, trace, endObservation := h.operations.handleEnqueue.WithAndLogger(r.Context(), &err, observation.Args{})
 		defer func() {
 			endObservation(1, observation.Args{LogFields: []log.Field{
 				log.Int("statusCode", statusCode),
@@ -88,7 +88,7 @@ func (h *UploadHandler) handleEnqueue(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			return nil, statusCode, err
 		}
-		traceLog(
+		trace.Log(
 			log.Int("repositoryID", uploadState.repositoryID),
 			log.Int("uploadID", uploadState.uploadID),
 			log.String("commit", uploadState.commit),

--- a/enterprise/cmd/frontend/internal/codeintel/httpapi/upload_handler_single.go
+++ b/enterprise/cmd/frontend/internal/codeintel/httpapi/upload_handler_single.go
@@ -17,7 +17,7 @@ import (
 // handleEnqueueSinglePayload handles a non-multipart upload. This creates an upload record
 // with state 'queued', proxies the data to the bundle manager, and returns the generated ID.
 func (h *UploadHandler) handleEnqueueSinglePayload(ctx context.Context, uploadState uploadState, body io.Reader) (_ interface{}, statusCode int, err error) {
-	ctx, traceLog, endObservation := h.operations.handleEnqueueSinglePayload.WithAndLogger(ctx, &err, observation.Args{})
+	ctx, trace, endObservation := h.operations.handleEnqueueSinglePayload.WithAndLogger(ctx, &err, observation.Args{})
 	defer func() {
 		endObservation(1, observation.Args{LogFields: []log.Field{
 			log.Int("statusCode", statusCode),
@@ -43,13 +43,13 @@ func (h *UploadHandler) handleEnqueueSinglePayload(ctx context.Context, uploadSt
 	if err != nil {
 		return nil, http.StatusInternalServerError, err
 	}
-	traceLog(log.Int("uploadID", id))
+	trace.Log(log.Int("uploadID", id))
 
 	size, err := h.uploadStore.Upload(ctx, fmt.Sprintf("upload-%d.lsif.gz", id), body)
 	if err != nil {
 		return nil, http.StatusInternalServerError, err
 	}
-	traceLog(log.Int("gzippedUploadSize", int(size)))
+	trace.Log(log.Int("gzippedUploadSize", int(size)))
 
 	if err := tx.MarkQueued(ctx, id, &size); err != nil {
 		return nil, http.StatusInternalServerError, err

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/documentation_query_definitions.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/documentation_query_definitions.go
@@ -12,7 +12,7 @@ import (
 // DocumentationDefinitions returns the list of source locations that define the symbol found at
 // the given documentation path ID, if any.
 func (r *queryResolver) DocumentationDefinitions(ctx context.Context, pathID string) (_ []AdjustedLocation, err error) {
-	ctx, traceLog, endObservation := observeResolver(ctx, &err, "DocumentationDefinitions", r.operations.definitions, slowDefinitionsRequestThreshold, observation.Args{
+	ctx, trace, endObservation := observeResolver(ctx, &err, "DocumentationDefinitions", r.operations.definitions, slowDefinitionsRequestThreshold, observation.Args{
 		LogFields: []log.Field{
 			log.Int("repositoryID", r.repositoryID),
 			log.String("commit", r.commit),
@@ -27,7 +27,7 @@ func (r *queryResolver) DocumentationDefinitions(ctx context.Context, pathID str
 	// going to be found in the "local" bundle, i.e. it's not possible for it to be in another
 	// repository.
 	for _, upload := range r.uploads {
-		traceLog(log.Int("uploadID", upload.ID))
+		trace.Log(log.Int("uploadID", upload.ID))
 		locations, _, err := r.lsifStore.DocumentationDefinitions(ctx, upload.ID, pathID, DefinitionsLimit, 0)
 		if err != nil {
 			return nil, errors.Wrap(err, "lsifStore.DocumentationDefinitions")

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/documentation_query_references.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/documentation_query_references.go
@@ -18,7 +18,7 @@ const defaultReferencesPageSize = 100
 // DocumentationReferences returns the list of source locations that reference the symbol found at
 // the given documentation path ID, if any.
 func (r *queryResolver) DocumentationReferences(ctx context.Context, pathID string, limit int, rawCursor string) (_ []AdjustedLocation, _ string, err error) {
-	ctx, traceLog, endObservation := observeResolver(ctx, &err, "DocumentationReferences", r.operations.documentationReferences, slowReferencesRequestThreshold, observation.Args{
+	ctx, trace, endObservation := observeResolver(ctx, &err, "DocumentationReferences", r.operations.documentationReferences, slowReferencesRequestThreshold, observation.Args{
 		LogFields: []log.Field{
 			log.Int("repositoryID", r.repositoryID),
 			log.String("commit", r.commit),
@@ -37,7 +37,7 @@ func (r *queryResolver) DocumentationReferences(ctx context.Context, pathID stri
 	// What we do here is first resolve the local definitions, then execute a standard references
 	// request on the first location we find.
 	for _, upload := range r.uploads {
-		traceLog(log.Int("uploadID", upload.ID))
+		trace.Log(log.Int("uploadID", upload.ID))
 
 		// Effectively replicate what we do in r.DocumentationDefinition in order to lookup the definition
 		// locations.

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/exists.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/exists.go
@@ -26,7 +26,7 @@ const numAncestors = 100
 // path is a prefix are returned. These dump IDs should be subsequently passed to invocations of
 // Definitions, References, and Hover.
 func (r *resolver) findClosestDumps(ctx context.Context, cachedCommitChecker *cachedCommitChecker, repositoryID int, commit, path string, exactPath bool, indexer string) (_ []store.Dump, err error) {
-	ctx, traceLog, endObservation := r.operations.findClosestDumps.WithAndLogger(ctx, &err, observation.Args{
+	ctx, trace, endObservation := r.operations.findClosestDumps.WithAndLogger(ctx, &err, observation.Args{
 		LogFields: []log.Field{
 			log.Int("repositoryID", repositoryID),
 			log.String("commit", commit),
@@ -41,7 +41,7 @@ func (r *resolver) findClosestDumps(ctx context.Context, cachedCommitChecker *ca
 	if err != nil {
 		return nil, err
 	}
-	traceLog(
+	trace.Log(
 		log.Int("numCandidates", len(candidates)),
 		log.String("candidates", uploadIDsToString(candidates)),
 	)
@@ -50,7 +50,7 @@ func (r *resolver) findClosestDumps(ctx context.Context, cachedCommitChecker *ca
 	if err != nil {
 		return nil, err
 	}
-	traceLog(
+	trace.Log(
 		log.Int("numCandidatesWithCommits", len(candidatesWithCommits)),
 		log.String("candidatesWithCommits", uploadIDsToString(candidatesWithCommits)),
 	)
@@ -74,7 +74,7 @@ func (r *resolver) findClosestDumps(ctx context.Context, cachedCommitChecker *ca
 
 		filtered = append(filtered, candidates[i])
 	}
-	traceLog(
+	trace.Log(
 		log.Int("numFiltered", len(filtered)),
 		log.String("filtered", uploadIDsToString(filtered)),
 	)

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
@@ -7,7 +7,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindex/enqueuer"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
-	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
@@ -40,12 +39,12 @@ type DBStore interface {
 	GetIndexesByIDs(ctx context.Context, ids ...int) ([]dbstore.Index, error)
 	GetIndexes(ctx context.Context, opts dbstore.GetIndexesOptions) ([]dbstore.Index, int, error)
 	DeleteIndexByID(ctx context.Context, id int) (bool, error)
-	GetConfigurationPolicies(ctx context.Context, opts store.GetConfigurationPoliciesOptions) ([]store.ConfigurationPolicy, int, error)
-	GetConfigurationPolicyByID(ctx context.Context, id int) (store.ConfigurationPolicy, bool, error)
-	CreateConfigurationPolicy(ctx context.Context, configurationPolicy store.ConfigurationPolicy) (store.ConfigurationPolicy, error)
-	UpdateConfigurationPolicy(ctx context.Context, policy store.ConfigurationPolicy) (err error)
+	GetConfigurationPolicies(ctx context.Context, opts dbstore.GetConfigurationPoliciesOptions) ([]dbstore.ConfigurationPolicy, int, error)
+	GetConfigurationPolicyByID(ctx context.Context, id int) (dbstore.ConfigurationPolicy, bool, error)
+	CreateConfigurationPolicy(ctx context.Context, configurationPolicy dbstore.ConfigurationPolicy) (dbstore.ConfigurationPolicy, error)
+	UpdateConfigurationPolicy(ctx context.Context, policy dbstore.ConfigurationPolicy) (err error)
 	DeleteConfigurationPolicyByID(ctx context.Context, id int) (err error)
-	GetIndexConfigurationByRepositoryID(ctx context.Context, repositoryID int) (store.IndexConfiguration, bool, error)
+	GetIndexConfigurationByRepositoryID(ctx context.Context, repositoryID int) (dbstore.IndexConfiguration, bool, error)
 	UpdateIndexConfigurationByRepositoryID(ctx context.Context, repositoryID int, data []byte) error
 	RepoIDsByGlobPatterns(ctx context.Context, patterns []string, limit, offset int) ([]int, int, error)
 }
@@ -74,6 +73,8 @@ type IndexEnqueuer interface {
 	InferIndexConfiguration(ctx context.Context, repositoryID int) (*config.IndexConfiguration, error)
 }
 
-type RepoUpdaterClient = enqueuer.RepoUpdaterClient
-type EnqueuerDBStore = enqueuer.DBStore
-type EnqueuerGitserverClient = enqueuer.GitserverClient
+type (
+	RepoUpdaterClient       = enqueuer.RepoUpdaterClient
+	EnqueuerDBStore         = enqueuer.DBStore
+	EnqueuerGitserverClient = enqueuer.GitserverClient
+)

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/observability.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/observability.go
@@ -87,9 +87,9 @@ func observeResolver(
 	observationArgs observation.Args,
 ) (context.Context, observation.TraceLogger, func()) {
 	start := time.Now()
-	ctx, traceLog, endObservation := operation.WithAndLogger(ctx, err, observationArgs)
+	ctx, trace, endObservation := operation.WithAndLogger(ctx, err, observationArgs)
 
-	return ctx, traceLog, func() {
+	return ctx, trace, func() {
 		duration := time.Since(start)
 		endObservation(1, observation.Args{})
 

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_definitions.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_definitions.go
@@ -17,7 +17,7 @@ const DefinitionsLimit = 100
 
 // Definitions returns the list of source locations that define the symbol at the given position.
 func (r *queryResolver) Definitions(ctx context.Context, line, character int) (_ []AdjustedLocation, err error) {
-	ctx, traceLog, endObservation := observeResolver(ctx, &err, "Definitions", r.operations.definitions, slowDefinitionsRequestThreshold, observation.Args{
+	ctx, trace, endObservation := observeResolver(ctx, &err, "Definitions", r.operations.definitions, slowDefinitionsRequestThreshold, observation.Args{
 		LogFields: []log.Field{
 			log.Int("repositoryID", r.repositoryID),
 			log.String("commit", r.commit),
@@ -43,7 +43,7 @@ func (r *queryResolver) Definitions(ctx context.Context, line, character int) (_
 	// traversal and should not require an additional moniker search in the same index.
 
 	for i := range adjustedUploads {
-		traceLog(log.Int("uploadID", adjustedUploads[i].Upload.ID))
+		trace.Log(log.Int("uploadID", adjustedUploads[i].Upload.ID))
 
 		locations, _, err := r.lsifStore.Definitions(
 			ctx,
@@ -68,7 +68,7 @@ func (r *queryResolver) Definitions(ctx context.Context, line, character int) (_
 	if err != nil {
 		return nil, err
 	}
-	traceLog(
+	trace.Log(
 		log.Int("numMonikers", len(orderedMonikers)),
 		log.String("monikers", monikersToString(orderedMonikers)),
 	)
@@ -80,7 +80,7 @@ func (r *queryResolver) Definitions(ctx context.Context, line, character int) (_
 	if err != nil {
 		return nil, err
 	}
-	traceLog(
+	trace.Log(
 		log.Int("numDefinitionUploads", len(uploads)),
 		log.String("definitionUploads", uploadIDsToString(uploads)),
 	)
@@ -90,7 +90,7 @@ func (r *queryResolver) Definitions(ctx context.Context, line, character int) (_
 	if err != nil {
 		return nil, err
 	}
-	traceLog(log.Int("numLocations", len(locations)))
+	trace.Log(log.Int("numLocations", len(locations)))
 
 	// Adjust the locations back to the appropriate range in the target commits. This adjusts
 	// locations within the repository the user is browsing so that it appears all definitions
@@ -100,7 +100,7 @@ func (r *queryResolver) Definitions(ctx context.Context, line, character int) (_
 	if err != nil {
 		return nil, err
 	}
-	traceLog(log.Int("numAdjustedLocations", len(adjustedLocations)))
+	trace.Log(log.Int("numAdjustedLocations", len(adjustedLocations)))
 
 	return adjustedLocations, nil
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_diagnostics.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_diagnostics.go
@@ -16,7 +16,7 @@ const slowDiagnosticsRequestThreshold = time.Second
 
 // Diagnostics returns the diagnostics for documents with the given path prefix.
 func (r *queryResolver) Diagnostics(ctx context.Context, limit int) (adjustedDiagnostics []AdjustedDiagnostic, _ int, err error) {
-	ctx, traceLog, endObservation := observeResolver(ctx, &err, "Diagnostics", r.operations.diagnostics, slowDiagnosticsRequestThreshold, observation.Args{
+	ctx, trace, endObservation := observeResolver(ctx, &err, "Diagnostics", r.operations.diagnostics, slowDiagnosticsRequestThreshold, observation.Args{
 		LogFields: []log.Field{
 			log.Int("repositoryID", r.repositoryID),
 			log.String("commit", r.commit),
@@ -36,7 +36,7 @@ func (r *queryResolver) Diagnostics(ctx context.Context, limit int) (adjustedDia
 	totalCount := 0
 
 	for i := range adjustedUploads {
-		traceLog(log.Int("uploadID", adjustedUploads[i].Upload.ID))
+		trace.Log(log.Int("uploadID", adjustedUploads[i].Upload.ID))
 
 		diagnostics, count, err := r.lsifStore.Diagnostics(
 			ctx,
@@ -64,7 +64,7 @@ func (r *queryResolver) Diagnostics(ctx context.Context, limit int) (adjustedDia
 	if len(adjustedDiagnostics) > limit {
 		adjustedDiagnostics = adjustedDiagnostics[:limit]
 	}
-	traceLog(
+	trace.Log(
 		log.Int("totalCount", totalCount),
 		log.Int("numDiagnostics", len(adjustedDiagnostics)),
 	)

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_documentation.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_documentation.go
@@ -20,7 +20,7 @@ const slowDocumentationPageRequestThreshold = time.Second
 //
 // nil, nil is returned if the page does not exist.
 func (r *queryResolver) DocumentationPage(ctx context.Context, pathID string) (_ *precise.DocumentationPageData, err error) {
-	ctx, traceLog, endObservation := observeResolver(ctx, &err, "DocumentationPage", r.operations.documentationPage, slowDocumentationPageRequestThreshold, observation.Args{
+	ctx, trace, endObservation := observeResolver(ctx, &err, "DocumentationPage", r.operations.documentationPage, slowDocumentationPageRequestThreshold, observation.Args{
 		LogFields: []log.Field{
 			log.Int("repositoryID", r.repositoryID),
 			log.String("commit", r.commit),
@@ -33,7 +33,7 @@ func (r *queryResolver) DocumentationPage(ctx context.Context, pathID string) (_
 	defer endObservation()
 
 	for i := range r.uploads {
-		traceLog(log.Int("uploadID", r.uploads[i].ID))
+		trace.Log(log.Int("uploadID", r.uploads[i].ID))
 
 		// In the case of multiple LSIF uploads, we merely return the most-recent page from a
 		// matching bundle.
@@ -55,7 +55,7 @@ const slowDocumentationPathInfoRequestThreshold = time.Second
 //
 // nil, nil is returned if the page does not exist.
 func (r *queryResolver) DocumentationPathInfo(ctx context.Context, pathID string) (_ *precise.DocumentationPathInfoData, err error) {
-	ctx, traceLog, endObservation := observeResolver(ctx, &err, "DocumentationPathInfo", r.operations.documentationPathInfo, slowDocumentationPathInfoRequestThreshold, observation.Args{
+	ctx, trace, endObservation := observeResolver(ctx, &err, "DocumentationPathInfo", r.operations.documentationPathInfo, slowDocumentationPathInfoRequestThreshold, observation.Args{
 		LogFields: []log.Field{
 			log.Int("repositoryID", r.repositoryID),
 			log.String("commit", r.commit),
@@ -68,7 +68,7 @@ func (r *queryResolver) DocumentationPathInfo(ctx context.Context, pathID string
 	defer endObservation()
 
 	for i := range r.uploads {
-		traceLog(log.Int("uploadID", r.uploads[i].ID))
+		trace.Log(log.Int("uploadID", r.uploads[i].ID))
 
 		// In the case of multiple LSIF uploads, we merely return the most-recent info from a
 		// matching bundle.

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_hover.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_hover.go
@@ -15,7 +15,7 @@ const slowHoverRequestThreshold = time.Second
 
 // Hover returns the hover text and range for the symbol at the given position.
 func (r *queryResolver) Hover(ctx context.Context, line, character int) (_ string, _ lsifstore.Range, _ bool, err error) {
-	ctx, traceLog, endObservation := observeResolver(ctx, &err, "Hover", r.operations.hover, slowHoverRequestThreshold, observation.Args{
+	ctx, trace, endObservation := observeResolver(ctx, &err, "Hover", r.operations.hover, slowHoverRequestThreshold, observation.Args{
 		LogFields: []log.Field{
 			log.Int("repositoryID", r.repositoryID),
 			log.String("commit", r.commit),
@@ -43,7 +43,7 @@ func (r *queryResolver) Hover(ctx context.Context, line, character int) (_ strin
 
 	for i := range adjustedUploads {
 		adjustedUpload := adjustedUploads[i]
-		traceLog(log.Int("uploadID", adjustedUpload.Upload.ID))
+		trace.Log(log.Int("uploadID", adjustedUpload.Upload.ID))
 
 		// Fetch hover text from the index
 		text, rn, exists, err := r.lsifStore.Hover(
@@ -93,7 +93,7 @@ func (r *queryResolver) Hover(ctx context.Context, line, character int) (_ strin
 	if err != nil {
 		return "", lsifstore.Range{}, false, err
 	}
-	traceLog(
+	trace.Log(
 		log.Int("numMonikers", len(orderedMonikers)),
 		log.String("monikers", monikersToString(orderedMonikers)),
 	)
@@ -105,7 +105,7 @@ func (r *queryResolver) Hover(ctx context.Context, line, character int) (_ strin
 	if err != nil {
 		return "", lsifstore.Range{}, false, err
 	}
-	traceLog(
+	trace.Log(
 		log.Int("numDefinitionUploads", len(uploads)),
 		log.String("definitionUploads", uploadIDsToString(uploads)),
 	)
@@ -116,7 +116,7 @@ func (r *queryResolver) Hover(ctx context.Context, line, character int) (_ strin
 	if err != nil {
 		return "", lsifstore.Range{}, false, err
 	}
-	traceLog(log.Int("numLocations", len(locations)))
+	trace.Log(log.Int("numLocations", len(locations)))
 
 	for i := range locations {
 		// Fetch hover text attached to a definition in the defining index

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_ranges.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_ranges.go
@@ -17,7 +17,7 @@ const slowRangesRequestThreshold = time.Second
 // results are partial and do not include references outside the current file, or any location that
 // requires cross-linking of bundles (cross-repo or cross-root).
 func (r *queryResolver) Ranges(ctx context.Context, startLine, endLine int) (adjustedRanges []AdjustedCodeIntelligenceRange, err error) {
-	ctx, traceLog, endObservation := observeResolver(ctx, &err, "Ranges", r.operations.ranges, slowRangesRequestThreshold, observation.Args{
+	ctx, trace, endObservation := observeResolver(ctx, &err, "Ranges", r.operations.ranges, slowRangesRequestThreshold, observation.Args{
 		LogFields: []log.Field{
 			log.Int("repositoryID", r.repositoryID),
 			log.String("commit", r.commit),
@@ -36,7 +36,7 @@ func (r *queryResolver) Ranges(ctx context.Context, startLine, endLine int) (adj
 	}
 
 	for i := range adjustedUploads {
-		traceLog(log.Int("uploadID", adjustedUploads[i].Upload.ID))
+		trace.Log(log.Int("uploadID", adjustedUploads[i].Upload.ID))
 
 		ranges, err := r.lsifStore.Ranges(
 			ctx,
@@ -61,7 +61,7 @@ func (r *queryResolver) Ranges(ctx context.Context, startLine, endLine int) (adj
 			adjustedRanges = append(adjustedRanges, adjustedRange)
 		}
 	}
-	traceLog(log.Int("numRanges", len(adjustedRanges)))
+	trace.Log(log.Int("numRanges", len(adjustedRanges)))
 
 	return adjustedRanges, nil
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_references_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_references_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/opentracing/opentracing-go/log"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
@@ -271,9 +270,8 @@ func TestIgnoredIDs(t *testing.T) {
 			ignoreIDs,
 			10,
 			0,
-			func(fields ...log.Field) {},
+			observation.TestTraceLogger,
 		)
-
 		if err != nil {
 			t.Fatalf("uploadIDsWithReferences: %s", err)
 		}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_stencil.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_stencil.go
@@ -16,7 +16,7 @@ const slowStencilRequestThreshold = time.Second
 
 // Stencil return all ranges within a single document.
 func (r *queryResolver) Stencil(ctx context.Context) (adjustedRanges []lsifstore.Range, err error) {
-	ctx, traceLog, endObservation := observeResolver(ctx, &err, "Stencil", r.operations.stencil, slowStencilRequestThreshold, observation.Args{
+	ctx, trace, endObservation := observeResolver(ctx, &err, "Stencil", r.operations.stencil, slowStencilRequestThreshold, observation.Args{
 		LogFields: []log.Field{
 			log.Int("repositoryID", r.repositoryID),
 			log.String("commit", r.commit),
@@ -33,7 +33,7 @@ func (r *queryResolver) Stencil(ctx context.Context) (adjustedRanges []lsifstore
 	}
 
 	for i := range adjustedUploads {
-		traceLog(log.Int("uploadID", adjustedUploads[i].Upload.ID))
+		trace.Log(log.Int("uploadID", adjustedUploads[i].Upload.ID))
 
 		ranges, err := r.lsifStore.Stencil(
 			ctx,
@@ -54,7 +54,7 @@ func (r *queryResolver) Stencil(ctx context.Context) (adjustedRanges []lsifstore
 			adjustedRanges = append(adjustedRanges, adjustedRange)
 		}
 	}
-	traceLog(log.Int("numRanges", len(adjustedRanges)))
+	trace.Log(log.Int("numRanges", len(adjustedRanges)))
 
 	return sortRanges(adjustedRanges), nil
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_util.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_util.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
@@ -135,7 +134,7 @@ func (r *queryResolver) orderedMonikers(ctx context.Context, adjustedUploads []a
 
 // monikerLocations returns the set of locations (within the given uploads) with an attached moniker
 // whose scheme+identifier matches any of the given monikers.
-func (r *queryResolver) monikerLocations(ctx context.Context, uploads []dbstore.Dump, orderedMonikers []precise.QualifiedMonikerData, tableName string, limit, offset int) ([]lsifstore.Location, int, error) {
+func (r *queryResolver) monikerLocations(ctx context.Context, uploads []store.Dump, orderedMonikers []precise.QualifiedMonikerData, tableName string, limit, offset int) ([]lsifstore.Location, int, error) {
 	ids := make([]int, 0, len(uploads))
 	for i := range uploads {
 		ids = append(ids, uploads[i].ID)
@@ -207,7 +206,7 @@ func (r *queryResolver) adjustRange(ctx context.Context, repositoryID int, commi
 
 // filterUploadsWithCommits removes the uploads for commits which are unknown to gitserver from the given
 // slice. The slice is filtered in-place and returned (to update the slice length).
-func filterUploadsWithCommits(ctx context.Context, cachedCommitChecker *cachedCommitChecker, uploads []dbstore.Dump) ([]dbstore.Dump, error) {
+func filterUploadsWithCommits(ctx context.Context, cachedCommitChecker *cachedCommitChecker, uploads []store.Dump) ([]store.Dump, error) {
 	filtered := uploads[:0]
 
 	for i := range uploads {
@@ -225,7 +224,7 @@ func filterUploadsWithCommits(ctx context.Context, cachedCommitChecker *cachedCo
 	return filtered, nil
 }
 
-func uploadIDsToString(vs []dbstore.Dump) string {
+func uploadIDsToString(vs []store.Dump) string {
 	ids := make([]string, 0, len(vs))
 	for _, v := range vs {
 		ids = append(ids, strconv.Itoa(v.ID))

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver.go
@@ -8,7 +8,6 @@ import (
 
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -44,7 +43,7 @@ type Resolver interface {
 	CommitGraph(ctx context.Context, repositoryID int) (gql.CodeIntelligenceCommitGraphResolver, error)
 	QueueAutoIndexJobsForRepo(ctx context.Context, repositoryID int, rev, configuration string) ([]store.Index, error)
 	PreviewRepositoryFilter(ctx context.Context, patterns []string, limit, offset int) (_ []int, totalCount int, repositoryMatchLimit *int, _ error)
-	PreviewGitObjectFilter(ctx context.Context, repositoryID int, gitObjectType dbstore.GitObjectType, pattern string) (map[string][]string, error)
+	PreviewGitObjectFilter(ctx context.Context, repositoryID int, gitObjectType store.GitObjectType, pattern string) (map[string][]string, error)
 	DocumentationSearch(ctx context.Context, query string, repos []string) ([]precise.DocumentationSearchResult, error)
 
 	UploadConnectionResolver(opts store.GetUploadsOptions) *UploadsResolver
@@ -254,8 +253,8 @@ func (r *resolver) PreviewRepositoryFilter(ctx context.Context, patterns []strin
 	return ids, totalCount, repositoryMatchLimit, nil
 }
 
-func (r *resolver) PreviewGitObjectFilter(ctx context.Context, repositoryID int, gitObjectType dbstore.GitObjectType, pattern string) (map[string][]string, error) {
-	policyMatches, err := r.policyMatcher.CommitsDescribedByPolicy(ctx, repositoryID, []dbstore.ConfigurationPolicy{{Type: gitObjectType, Pattern: pattern}}, timeutil.Now())
+func (r *resolver) PreviewGitObjectFilter(ctx context.Context, repositoryID int, gitObjectType store.GitObjectType, pattern string) (map[string][]string, error) {
+	policyMatches, err := r.policyMatcher.CommitsDescribedByPolicy(ctx, repositoryID, []store.ConfigurationPolicy{{Type: gitObjectType, Pattern: pattern}}, timeutil.Now())
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/handler_test.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/handler_test.go
@@ -10,13 +10,13 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/google/go-cmp/cmp"
-	"github.com/opentracing/opentracing-go/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	uploadstoremocks "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/uploadstore/mocks"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/bloomfilter"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
@@ -66,7 +66,7 @@ func TestHandle(t *testing.T) {
 		gitserverClient: gitserverClient,
 	}
 
-	requeued, err := handler.handle(context.Background(), upload, func(fields ...log.Field) {})
+	requeued, err := handler.handle(context.Background(), upload, observation.TestTraceLogger)
 	if err != nil {
 		t.Fatalf("unexpected error handling upload: %s", err)
 	} else if requeued {
@@ -200,7 +200,7 @@ func TestHandleError(t *testing.T) {
 		gitserverClient: gitserverClient,
 	}
 
-	requeued, err := handler.handle(context.Background(), upload, func(fields ...log.Field) {})
+	requeued, err := handler.handle(context.Background(), upload, observation.TestTraceLogger)
 	if err == nil {
 		t.Fatalf("unexpected nil error handling upload")
 	} else if !strings.Contains(err.Error(), "uh-oh!") {
@@ -255,7 +255,7 @@ func TestHandleCloneInProgress(t *testing.T) {
 		gitserverClient: gitserverClient,
 	}
 
-	requeued, err := handler.handle(context.Background(), upload, func(fields ...log.Field) {})
+	requeued, err := handler.handle(context.Background(), upload, observation.TestTraceLogger)
 	if err != nil {
 		t.Fatalf("unexpected error handling upload: %s", err)
 	} else if !requeued {

--- a/enterprise/cmd/worker/internal/codeintel/commitgraph/updater.go
+++ b/enterprise/cmd/worker/internal/codeintel/commitgraph/updater.go
@@ -103,7 +103,7 @@ func (u *Updater) tryUpdate(ctx context.Context, repositoryID, dirtyToken int) (
 // the repository can be unmarked as long as the repository is not marked as dirty again before
 // the update completes.
 func (u *Updater) update(ctx context.Context, repositoryID, dirtyToken int) (err error) {
-	ctx, traceLog, endObservation := u.operations.commitUpdate.WithAndLogger(ctx, &err, observation.Args{
+	ctx, trace, endObservation := u.operations.commitUpdate.WithAndLogger(ctx, &err, observation.Args{
 		LogFields: []log.Field{
 			log.Int("repositoryID", repositoryID),
 			log.Int("dirtyToken", dirtyToken),
@@ -116,13 +116,13 @@ func (u *Updater) update(ctx context.Context, repositoryID, dirtyToken int) (err
 	if err != nil {
 		return err
 	}
-	traceLog(log.Int("numCommitGraphKeys", len(commitGraph.Order())))
+	trace.Log(log.Int("numCommitGraphKeys", len(commitGraph.Order())))
 
 	refDescriptions, err := u.gitserverClient.RefDescriptions(ctx, repositoryID)
 	if err != nil {
 		return errors.Wrap(err, "gitserver.RefDescriptions")
 	}
-	traceLog(log.Int("numRefDescriptions", len(refDescriptions)))
+	trace.Log(log.Int("numRefDescriptions", len(refDescriptions)))
 
 	// Decorate the commit graph with the set of processed uploads are visible from each commit,
 	// then bulk update the denormalized view in Postgres. We call this with an empty graph as well

--- a/enterprise/internal/codeintel/stores/dbstore/commits.go
+++ b/enterprise/internal/codeintel/stores/dbstore/commits.go
@@ -127,14 +127,14 @@ func scanIntPairs(rows *sql.Rows, queryErr error) (_ map[int]int, err error) {
 // DirtyRepositories returns a map from repository identifiers to a dirty token for each repository whose commit
 // graph is out of date. This token should be passed to CalculateVisibleUploads in order to unmark the repository.
 func (s *Store) DirtyRepositories(ctx context.Context) (_ map[int]int, err error) {
-	ctx, traceLog, endObservation := s.operations.dirtyRepositories.WithAndLogger(ctx, &err, observation.Args{})
+	ctx, trace, endObservation := s.operations.dirtyRepositories.WithAndLogger(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
 	repositories, err := scanIntPairs(s.Store.Query(ctx, sqlf.Sprintf(dirtyRepositoriesQuery)))
 	if err != nil {
 		return nil, err
 	}
-	traceLog(log.Int("numRepositories", len(repositories)))
+	trace.Log(log.Int("numRepositories", len(repositories)))
 
 	return repositories, nil
 }
@@ -263,7 +263,7 @@ func (s *Store) CalculateVisibleUploads(
 	dirtyToken int,
 	now time.Time,
 ) (err error) {
-	ctx, traceLog, endObservation := s.operations.calculateVisibleUploads.WithAndLogger(ctx, &err, observation.Args{
+	ctx, trace, endObservation := s.operations.calculateVisibleUploads.WithAndLogger(ctx, &err, observation.Args{
 		LogFields: []log.Field{
 			log.Int("repositoryID", repositoryID),
 			log.Int("numCommitGraphKeys", len(commitGraph.Order())),
@@ -284,7 +284,7 @@ func (s *Store) CalculateVisibleUploads(
 	if err != nil {
 		return err
 	}
-	traceLog(
+	trace.Log(
 		log.String("maxAgeForNonStaleBranches", maxAgeForNonStaleBranches.String()),
 		log.String("maxAgeForNonStaleTags", maxAgeForNonStaleTags.String()),
 	)
@@ -295,7 +295,7 @@ func (s *Store) CalculateVisibleUploads(
 	if err != nil {
 		return err
 	}
-	traceLog(
+	trace.Log(
 		log.Int("numCommitGraphViewMetaKeys", len(commitGraphView.Meta)),
 		log.Int("numCommitGraphViewTokenKeys", len(commitGraphView.Tokens)),
 	)
@@ -410,7 +410,7 @@ WHERE repository_id = %s
 // caused massive table bloat on some instances. Storing into a temporary table and then inserting/updating/deleting
 // records into the persisted table minimizes the number of tuples we need to touch and drastically reduces table bloat.
 func (s *Store) writeVisibleUploads(ctx context.Context, sanitizedInput *sanitizedCommitInput) (err error) {
-	ctx, traceLog, endObservation := s.operations.writeVisibleUploads.WithAndLogger(ctx, &err, observation.Args{})
+	ctx, trace, endObservation := s.operations.writeVisibleUploads.WithAndLogger(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
 	if err := s.createTemporaryNearestUploadsTables(ctx); err != nil {
@@ -459,7 +459,7 @@ func (s *Store) writeVisibleUploads(ctx context.Context, sanitizedInput *sanitiz
 	if err := goroutine.Parallel(nearestUploadsWriter, nearestUploadsLinksWriter, uploadsVisibleAtTipWriter); err != nil {
 		return err
 	}
-	traceLog(
+	trace.Log(
 		log.Int("numNearestUploadsRecords", int(sanitizedInput.numNearestUploadsRecords)),
 		log.Int("numNearestUploadsLinksRecords", int(sanitizedInput.numNearestUploadsLinksRecords)),
 		log.Int("numUploadsVisibleAtTipRecords", int(sanitizedInput.numUploadsVisibleAtTipRecords)),
@@ -513,7 +513,7 @@ CREATE TEMPORARY TABLE t_lsif_uploads_visible_at_tip (
 // persistNearestUploads modifies the lsif_nearest_uploads table so that it has same data
 // as t_lsif_nearest_uploads for the given repository.
 func (s *Store) persistNearestUploads(ctx context.Context, repositoryID int) (err error) {
-	ctx, traceLog, endObservation := s.operations.persistNearestUploads.WithAndLogger(ctx, &err, observation.Args{})
+	ctx, trace, endObservation := s.operations.persistNearestUploads.WithAndLogger(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
 	rowsInserted, rowsUpdated, rowsDeleted, err := s.bulkTransfer(
@@ -525,7 +525,7 @@ func (s *Store) persistNearestUploads(ctx context.Context, repositoryID int) (er
 	if err != nil {
 		return err
 	}
-	traceLog(
+	trace.Log(
 		log.Int("lsif_nearest_uploads.ins", rowsInserted),
 		log.Int("lsif_nearest_uploads.upd", rowsUpdated),
 		log.Int("lsif_nearest_uploads.del", rowsDeleted),
@@ -564,7 +564,7 @@ WHERE
 // persistNearestUploadsLinks modifies the lsif_nearest_uploads_links table so that it has same
 // data as t_lsif_nearest_uploads_links for the given repository.
 func (s *Store) persistNearestUploadsLinks(ctx context.Context, repositoryID int) (err error) {
-	ctx, traceLog, endObservation := s.operations.persistNearestUploadsLinks.WithAndLogger(ctx, &err, observation.Args{})
+	ctx, trace, endObservation := s.operations.persistNearestUploadsLinks.WithAndLogger(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
 	rowsInserted, rowsUpdated, rowsDeleted, err := s.bulkTransfer(
@@ -576,7 +576,7 @@ func (s *Store) persistNearestUploadsLinks(ctx context.Context, repositoryID int
 	if err != nil {
 		return err
 	}
-	traceLog(
+	trace.Log(
 		log.Int("lsif_nearest_uploads_links.ins", rowsInserted),
 		log.Int("lsif_nearest_uploads_links.upd", rowsUpdated),
 		log.Int("lsif_nearest_uploads_links.del", rowsDeleted),
@@ -616,7 +616,7 @@ WHERE
 // persistUploadsVisibleAtTip modifies the lsif_uploads_visible_at_tip table so that it has same
 // data as t_lsif_uploads_visible_at_tip for the given repository.
 func (s *Store) persistUploadsVisibleAtTip(ctx context.Context, repositoryID int) (err error) {
-	ctx, traceLog, endObservation := s.operations.persistUploadsVisibleAtTip.WithAndLogger(ctx, &err, observation.Args{})
+	ctx, trace, endObservation := s.operations.persistUploadsVisibleAtTip.WithAndLogger(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
 	rowsInserted, rowsUpdated, rowsDeleted, err := s.bulkTransfer(
@@ -628,7 +628,7 @@ func (s *Store) persistUploadsVisibleAtTip(ctx context.Context, repositoryID int
 	if err != nil {
 		return err
 	}
-	traceLog(
+	trace.Log(
 		log.Int("lsif_uploads_visible_at_tip.ins", rowsInserted),
 		log.Int("lsif_uploads_visible_at_tip.upd", rowsUpdated),
 		log.Int("lsif_uploads_visible_at_tip.del", rowsDeleted),

--- a/enterprise/internal/codeintel/stores/dbstore/dumps.go
+++ b/enterprise/internal/codeintel/stores/dbstore/dumps.go
@@ -75,7 +75,7 @@ func scanDumps(rows *sql.Rows, queryErr error) (_ []Dump, err error) {
 
 // GetDumpsByIDs returns a set of dumps by identifiers.
 func (s *Store) GetDumpsByIDs(ctx context.Context, ids []int) (_ []Dump, err error) {
-	ctx, traceLog, endObservation := s.operations.getDumpsByIDs.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
+	ctx, trace, endObservation := s.operations.getDumpsByIDs.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("numIDs", len(ids)),
 		log.String("ids", intsToString(ids)),
 	}})
@@ -94,7 +94,7 @@ func (s *Store) GetDumpsByIDs(ctx context.Context, ids []int) (_ []Dump, err err
 	if err != nil {
 		return nil, err
 	}
-	traceLog(log.Int("numDumps", len(dumps)))
+	trace.Log(log.Int("numDumps", len(dumps)))
 
 	return dumps, nil
 }
@@ -143,7 +143,7 @@ FROM lsif_dumps_with_repository_name u WHERE u.id IN (%s)
 // splits the repository into multiple dumps. For this reason, the returned dumps are always sorted in most-recently-finished order to
 // prevent returning data from stale dumps.
 func (s *Store) FindClosestDumps(ctx context.Context, repositoryID int, commit, path string, rootMustEnclosePath bool, indexer string) (_ []Dump, err error) {
-	ctx, traceLog, endObservation := s.operations.findClosestDumps.WithAndLogger(ctx, &err, observation.Args{
+	ctx, trace, endObservation := s.operations.findClosestDumps.WithAndLogger(ctx, &err, observation.Args{
 		LogFields: []log.Field{
 			log.Int("repositoryID", repositoryID),
 			log.String("commit", commit),
@@ -161,7 +161,7 @@ func (s *Store) FindClosestDumps(ctx context.Context, repositoryID int, commit, 
 	if err != nil {
 		return nil, err
 	}
-	traceLog(log.Int("numDumps", len(dumps)))
+	trace.Log(log.Int("numDumps", len(dumps)))
 
 	return dumps, nil
 }
@@ -196,7 +196,7 @@ ORDER BY u.finished_at DESC
 // FindClosestDumpsFromGraphFragment returns the set of dumps that can most accurately answer queries for the given repository, commit,
 // path, and optional indexer by only considering the given fragment of the full git graph. See FindClosestDumps for additional details.
 func (s *Store) FindClosestDumpsFromGraphFragment(ctx context.Context, repositoryID int, commit, path string, rootMustEnclosePath bool, indexer string, commitGraph *gitdomain.CommitGraph) (_ []Dump, err error) {
-	ctx, traceLog, endObservation := s.operations.findClosestDumpsFromGraphFragment.WithAndLogger(ctx, &err, observation.Args{
+	ctx, trace, endObservation := s.operations.findClosestDumpsFromGraphFragment.WithAndLogger(ctx, &err, observation.Args{
 		LogFields: []log.Field{
 			log.Int("repositoryID", repositoryID),
 			log.String("commit", commit),
@@ -224,7 +224,7 @@ func (s *Store) FindClosestDumpsFromGraphFragment(ctx context.Context, repositor
 	if err != nil {
 		return nil, err
 	}
-	traceLog(
+	trace.Log(
 		log.Int("numCommitGraphViewMetaKeys", len(commitGraphView.Meta)),
 		log.Int("numCommitGraphViewTokenKeys", len(commitGraphView.Tokens)),
 	)
@@ -244,7 +244,7 @@ func (s *Store) FindClosestDumpsFromGraphFragment(ctx context.Context, repositor
 	if err != nil {
 		return nil, err
 	}
-	traceLog(log.Int("numDumps", len(dumps)))
+	trace.Log(log.Int("numDumps", len(dumps)))
 
 	return dumps, nil
 }
@@ -367,7 +367,7 @@ func makeFindClosestDumpConditions(path string, rootMustEnclosePath bool, indexe
 // commit, root, and indexer. This is necessary to perform during conversions before changing
 // the state of a processing upload to completed as there is a unique index on these four columns.
 func (s *Store) DeleteOverlappingDumps(ctx context.Context, repositoryID int, commit, root, indexer string) (err error) {
-	ctx, traceLog, endObservation := s.operations.deleteOverlappingDumps.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
+	ctx, trace, endObservation := s.operations.deleteOverlappingDumps.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("repositoryID", repositoryID),
 		log.String("commit", commit),
 		log.String("root", root),
@@ -379,7 +379,7 @@ func (s *Store) DeleteOverlappingDumps(ctx context.Context, repositoryID int, co
 	if err != nil {
 		return err
 	}
-	traceLog(log.Int("count", count))
+	trace.Log(log.Int("count", count))
 
 	return nil
 }

--- a/enterprise/internal/codeintel/stores/dbstore/indexes.go
+++ b/enterprise/internal/codeintel/stores/dbstore/indexes.go
@@ -237,7 +237,7 @@ type GetIndexesOptions struct {
 
 // GetIndexes returns a list of indexes and the total count of records matching the given conditions.
 func (s *Store) GetIndexes(ctx context.Context, opts GetIndexesOptions) (_ []Index, _ int, err error) {
-	ctx, traceLog, endObservation := s.operations.getIndexes.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
+	ctx, trace, endObservation := s.operations.getIndexes.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("repositoryID", opts.RepositoryID),
 		log.String("state", opts.State),
 		log.String("term", opts.Term),
@@ -279,7 +279,7 @@ func (s *Store) GetIndexes(ctx context.Context, opts GetIndexesOptions) (_ []Ind
 	if err != nil {
 		return nil, 0, err
 	}
-	traceLog(
+	trace.Log(
 		log.Int("totalCount", totalCount),
 		log.Int("numIndexes", len(indexes)),
 	)
@@ -489,7 +489,7 @@ DELETE FROM lsif_indexes WHERE id = %s RETURNING repository_id
 // DeletedRepositoryGracePeriod ago. This returns the repository identifier mapped to the number of indexes
 // that were removed for that repository.
 func (s *Store) DeleteIndexesWithoutRepository(ctx context.Context, now time.Time) (_ map[int]int, err error) {
-	ctx, traceLog, endObservation := s.operations.deleteIndexesWithoutRepository.WithAndLogger(ctx, &err, observation.Args{})
+	ctx, trace, endObservation := s.operations.deleteIndexesWithoutRepository.WithAndLogger(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
 	// TODO(efritz) - this would benefit from an index on repository_id. We currently have
@@ -504,7 +504,7 @@ func (s *Store) DeleteIndexesWithoutRepository(ctx context.Context, now time.Tim
 	for _, numDeleted := range repositories {
 		count += numDeleted
 	}
-	traceLog(
+	trace.Log(
 		log.Int("count", count),
 		log.Int("numRepositories", len(repositories)),
 	)

--- a/enterprise/internal/codeintel/stores/dbstore/janitor.go
+++ b/enterprise/internal/codeintel/stores/dbstore/janitor.go
@@ -62,7 +62,7 @@ func ScanSourcedCommits(rows *sql.Rows, queryErr error) (_ []SourcedCommits, err
 // paths and clean up that occupied (but useless) space. The output is of this method is
 // ordered by repository ID then by commit.
 func (s *Store) StaleSourcedCommits(ctx context.Context, minimumTimeSinceLastCheck time.Duration, limit int, now time.Time) (_ []SourcedCommits, err error) {
-	ctx, traceLog, endObservation := s.operations.staleSourcedCommits.WithAndLogger(ctx, &err, observation.Args{})
+	ctx, trace, endObservation := s.operations.staleSourcedCommits.WithAndLogger(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
 	now = now.UTC()
@@ -79,7 +79,7 @@ func (s *Store) StaleSourcedCommits(ctx context.Context, minimumTimeSinceLastChe
 	for _, commits := range sourcedCommits {
 		numCommits += len(commits.Commits)
 	}
-	traceLog(
+	trace.Log(
 		log.Int("numRepositories", len(sourcedCommits)),
 		log.Int("numCommits", numCommits),
 	)
@@ -123,7 +123,7 @@ GROUP BY repository_id, commit
 // to the given repository identifier and commit. This method returns the count of upload and index records
 // modified, respectively.
 func (s *Store) UpdateSourcedCommits(ctx context.Context, repositoryID int, commit string, now time.Time) (uploadsUpdated int, indexesUpdated int, err error) {
-	ctx, traceLog, endObservation := s.operations.updateSourcedCommits.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
+	ctx, trace, endObservation := s.operations.updateSourcedCommits.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("repositoryID", repositoryID),
 		log.String("commit", commit),
 	}})
@@ -138,7 +138,7 @@ func (s *Store) UpdateSourcedCommits(ctx context.Context, repositoryID int, comm
 	if err != nil {
 		return 0, 0, err
 	}
-	traceLog(
+	trace.Log(
 		log.Int("uploadsUpdated", uploadsUpdated),
 		log.Int("indexesUpdated", indexesUpdated),
 	)
@@ -207,7 +207,7 @@ func (s *Store) DeleteSourcedCommits(ctx context.Context, repositoryID int, comm
 	indexesDeleted int,
 	err error,
 ) {
-	ctx, traceLog, endObservation := s.operations.deleteSourcedCommits.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
+	ctx, trace, endObservation := s.operations.deleteSourcedCommits.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("repositoryID", repositoryID),
 		log.String("commit", commit),
 	}})
@@ -226,7 +226,7 @@ func (s *Store) DeleteSourcedCommits(ctx context.Context, repositoryID int, comm
 	if err != nil {
 		return 0, 0, 0, err
 	}
-	traceLog(
+	trace.Log(
 		log.Int("uploadsUpdated", uploadsUpdated),
 		log.Int("uploadsDeleted", uploadsDeleted),
 		log.Int("indexesDeleted", indexesDeleted),

--- a/enterprise/internal/codeintel/stores/dbstore/xrepo.go
+++ b/enterprise/internal/codeintel/stores/dbstore/xrepo.go
@@ -20,7 +20,7 @@ var DefinitionDumpsLimit, _ = strconv.ParseInt(env.Get("PRECISE_CODE_INTEL_DEFIN
 
 // DefinitionDumps returns the set of dumps that define at least one of the given monikers.
 func (s *Store) DefinitionDumps(ctx context.Context, monikers []precise.QualifiedMonikerData) (_ []Dump, err error) {
-	ctx, traceLog, endObservation := s.operations.definitionDumps.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
+	ctx, trace, endObservation := s.operations.definitionDumps.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("numMonikers", len(monikers)),
 		log.String("monikers", monikersToString(monikers)),
 	}})
@@ -39,7 +39,7 @@ func (s *Store) DefinitionDumps(ctx context.Context, monikers []precise.Qualifie
 	if err != nil {
 		return nil, err
 	}
-	traceLog(log.Int("numDumps", len(dumps)))
+	trace.Log(log.Int("numDumps", len(dumps)))
 
 	return dumps, nil
 }
@@ -117,7 +117,7 @@ rank() OVER (
 // it can be seen from the given index; otherwise, an index is visible if it can be seen from the tip of
 // the default branch of its own repository.
 func (s *Store) ReferenceIDsAndFilters(ctx context.Context, repositoryID int, commit string, monikers []precise.QualifiedMonikerData, limit, offset int) (_ PackageReferenceScanner, _ int, err error) {
-	ctx, traceLog, endObservation := s.operations.referenceIDsAndFilters.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
+	ctx, trace, endObservation := s.operations.referenceIDsAndFilters.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("repositoryID", repositoryID),
 		log.String("commit", commit),
 		log.Int("numMonikers", len(monikers)),
@@ -147,7 +147,7 @@ func (s *Store) ReferenceIDsAndFilters(ctx context.Context, repositoryID int, co
 	if err != nil {
 		return nil, 0, err
 	}
-	traceLog(log.Int("totalCount", totalCount))
+	trace.Log(log.Int("totalCount", totalCount))
 
 	rows, err := s.Query(ctx, sqlf.Sprintf(
 		referenceIDsAndFiltersQuery,

--- a/enterprise/internal/codeintel/stores/lsifstore/clear.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/clear.go
@@ -26,7 +26,7 @@ var tableNames = []string{
 }
 
 func (s *Store) Clear(ctx context.Context, bundleIDs ...int) (err error) {
-	ctx, traceLog, endObservation := s.operations.clear.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
+	ctx, trace, endObservation := s.operations.clear.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("numBundleIDs", len(bundleIDs)),
 		log.String("bundleIDs", intsToString(bundleIDs)),
 	}})
@@ -55,7 +55,7 @@ func (s *Store) Clear(ctx context.Context, bundleIDs ...int) (err error) {
 	}()
 
 	for _, tableName := range tableNames {
-		traceLog(log.String("tableName", tableName))
+		trace.Log(log.String("tableName", tableName))
 
 		if err := tx.Exec(ctx, sqlf.Sprintf(clearQuery, sqlf.Sprintf(tableName), sqlf.Join(ids, ","))); err != nil {
 			return err

--- a/enterprise/internal/codeintel/stores/lsifstore/data_write_documentation.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/data_write_documentation.go
@@ -42,7 +42,7 @@ func (s *Store) WriteDocumentationPages(
 	repositoryNameID int,
 	languageNameID int,
 ) (count uint32, err error) {
-	ctx, traceLog, endObservation := s.operations.writeDocumentationPages.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
+	ctx, trace, endObservation := s.operations.writeDocumentationPages.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("bundleID", upload.ID),
 		log.String("repo", upload.RepositoryName),
 		log.String("commit", upload.Commit),
@@ -54,8 +54,8 @@ func (s *Store) WriteDocumentationPages(
 		if err := recover(); err != nil {
 			stack := debug.Stack()
 			stdlog.Printf("API docs panic: %v\n%s", err, stack)
-			traceLog(log.String("API docs panic error", fmt.Sprint(err)))
-			traceLog(log.String("API docs panic stack", string(stack)))
+			trace.Log(log.String("API docs panic error", fmt.Sprint(err)))
+			trace.Log(log.String("API docs panic stack", string(stack)))
 		}
 	}()
 
@@ -92,7 +92,7 @@ func (s *Store) WriteDocumentationPages(
 	); err != nil {
 		return 0, err
 	}
-	traceLog(log.Int("numResultChunkRecords", int(count)))
+	trace.Log(log.Int("numResultChunkRecords", int(count)))
 
 	// Note: If someone disables API docs search indexing, uploads during that time will not be
 	// indexed even if it is turned back on. Only future uploads would be.
@@ -125,7 +125,7 @@ FROM t_lsif_data_documentation_pages source
 
 // WriteDocumentationPathInfo is called (transactionally) from the precise-code-intel-worker.
 func (s *Store) WriteDocumentationPathInfo(ctx context.Context, bundleID int, documentationPathInfo chan *precise.DocumentationPathInfoData) (count uint32, err error) {
-	ctx, traceLog, endObservation := s.operations.writeDocumentationPathInfo.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
+	ctx, trace, endObservation := s.operations.writeDocumentationPathInfo.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("bundleID", bundleID),
 	}})
 	defer endObservation(1, observation.Args{})
@@ -167,7 +167,7 @@ func (s *Store) WriteDocumentationPathInfo(ctx context.Context, bundleID int, do
 	); err != nil {
 		return 0, err
 	}
-	traceLog(log.Int("numResultChunkRecords", int(count)))
+	trace.Log(log.Int("numResultChunkRecords", int(count)))
 
 	// Insert the values from the temporary table into the target table. We select a
 	// parameterized dump id here since it is the same for all rows in this operation.
@@ -191,7 +191,7 @@ FROM t_lsif_data_documentation_path_info source
 
 // WriteDocumentationMappings is called (transactionally) from the precise-code-intel-worker.
 func (s *Store) WriteDocumentationMappings(ctx context.Context, bundleID int, mappings chan precise.DocumentationMapping) (count uint32, err error) {
-	ctx, traceLog, endObservation := s.operations.writeDocumentationMappings.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
+	ctx, trace, endObservation := s.operations.writeDocumentationMappings.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("bundleID", bundleID),
 	}})
 	defer endObservation(1, observation.Args{})
@@ -227,7 +227,7 @@ func (s *Store) WriteDocumentationMappings(ctx context.Context, bundleID int, ma
 	); err != nil {
 		return 0, err
 	}
-	traceLog(log.Int("numRecords", int(count)))
+	trace.Log(log.Int("numRecords", int(count)))
 
 	// Insert the values from the temporary table into the target table. We select a
 	// parameterized dump id here since it is the same for all rows in this operation.

--- a/enterprise/internal/codeintel/stores/lsifstore/diagnostics.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/diagnostics.go
@@ -12,7 +12,7 @@ import (
 // Diagnostics returns the diagnostics for the documents that have the given path prefix. This method
 // also returns the size of the complete result set to aid in pagination.
 func (s *Store) Diagnostics(ctx context.Context, bundleID int, prefix string, limit, offset int) (_ []Diagnostic, _ int, err error) {
-	ctx, traceLog, endObservation := s.operations.diagnostics.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
+	ctx, trace, endObservation := s.operations.diagnostics.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("bundleID", bundleID),
 		log.String("prefix", prefix),
 		log.Int("limit", limit),
@@ -24,13 +24,13 @@ func (s *Store) Diagnostics(ctx context.Context, bundleID int, prefix string, li
 	if err != nil {
 		return nil, 0, err
 	}
-	traceLog(log.Int("numDocuments", len(documentData)))
+	trace.Log(log.Int("numDocuments", len(documentData)))
 
 	totalCount := 0
 	for _, documentData := range documentData {
 		totalCount += len(documentData.Document.Diagnostics)
 	}
-	traceLog(log.Int("totalCount", totalCount))
+	trace.Log(log.Int("totalCount", totalCount))
 
 	diagnostics := make([]Diagnostic, 0, limit)
 	for _, documentData := range documentData {

--- a/enterprise/internal/codeintel/stores/lsifstore/documentation.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/documentation.go
@@ -312,7 +312,7 @@ func (s *Store) documentationDefinitions(
 	limit,
 	offset int,
 ) (_ []Location, _ int, err error) {
-	ctx, traceLog, endObservation := operation.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
+	ctx, trace, endObservation := operation.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("bundleID", bundleID),
 		log.String("resultID", string(resultID)),
 	}})
@@ -332,7 +332,7 @@ func (s *Store) documentationDefinitions(
 		return nil, 0, err
 	}
 
-	traceLog(log.Int("numRanges", len(documentData.Document.Ranges)))
+	trace.Log(log.Int("numRanges", len(documentData.Document.Ranges)))
 	var found *precise.RangeData
 	for _, rn := range documentData.Document.Ranges {
 		if rn.DocumentationResultID == resultID {
@@ -340,7 +340,7 @@ func (s *Store) documentationDefinitions(
 			break
 		}
 	}
-	traceLog(log.Bool("found", found == nil))
+	trace.Log(log.Bool("found", found == nil))
 	if found == nil {
 		return nil, 0, errors.New("not found")
 	}
@@ -350,7 +350,7 @@ func (s *Store) documentationDefinitions(
 	if err != nil {
 		return nil, 0, err
 	}
-	traceLog(log.Int("totalCount", totalCount))
+	trace.Log(log.Int("totalCount", totalCount))
 
 	locations := make([]Location, 0, limit)
 	for _, resultID := range orderedResultIDs {

--- a/enterprise/internal/codeintel/stores/lsifstore/hover.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/hover.go
@@ -12,7 +12,7 @@ import (
 
 // Hover returns the hover text of the symbol at the given position.
 func (s *Store) Hover(ctx context.Context, bundleID int, path string, line, character int) (_ string, _ Range, _ bool, err error) {
-	ctx, traceLog, endObservation := s.operations.hover.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
+	ctx, trace, endObservation := s.operations.hover.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("bundleID", bundleID),
 		log.String("path", path),
 		log.Int("line", line),
@@ -25,9 +25,9 @@ func (s *Store) Hover(ctx context.Context, bundleID int, path string, line, char
 		return "", Range{}, false, err
 	}
 
-	traceLog(log.Int("numRanges", len(documentData.Document.Ranges)))
+	trace.Log(log.Int("numRanges", len(documentData.Document.Ranges)))
 	ranges := precise.FindRanges(documentData.Document.Ranges, line, character)
-	traceLog(log.Int("numIntersectingRanges", len(ranges)))
+	trace.Log(log.Int("numIntersectingRanges", len(ranges)))
 
 	for _, r := range ranges {
 		if text, ok := documentData.Document.HoverResults[r.HoverResultID]; ok {

--- a/enterprise/internal/codeintel/stores/lsifstore/ranges.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/ranges.go
@@ -17,7 +17,7 @@ const MaximumRangesDefinitionLocations = 10000
 
 // Ranges returns definition, reference, implementation, hover, and documentation data for each range within the given span of lines.
 func (s *Store) Ranges(ctx context.Context, bundleID int, path string, startLine, endLine int) (_ []CodeIntelligenceRange, err error) {
-	ctx, traceLog, endObservation := s.operations.ranges.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
+	ctx, trace, endObservation := s.operations.ranges.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("bundleID", bundleID),
 		log.String("path", path),
 		log.Int("startLine", startLine),
@@ -30,9 +30,9 @@ func (s *Store) Ranges(ctx context.Context, bundleID int, path string, startLine
 		return nil, err
 	}
 
-	traceLog(log.Int("numRanges", len(documentData.Document.Ranges)))
+	trace.Log(log.Int("numRanges", len(documentData.Document.Ranges)))
 	ranges := precise.FindRangesInWindow(documentData.Document.Ranges, startLine, endLine)
-	traceLog(log.Int("numIntersectingRanges", len(ranges)))
+	trace.Log(log.Int("numIntersectingRanges", len(ranges)))
 
 	definitionResultIDs := extractResultIDs(ranges, func(r precise.RangeData) precise.ID { return r.DefinitionResultID })
 	definitionLocations, _, err := s.locations(ctx, bundleID, definitionResultIDs, MaximumRangesDefinitionLocations, 0)
@@ -78,7 +78,7 @@ func (s *Store) Ranges(ctx context.Context, bundleID int, path string, startLine
 
 // DocumentationAtPosition returns documentation path IDs found at the given position.
 func (s *Store) DocumentationAtPosition(ctx context.Context, bundleID int, path string, line, character int) (_ []string, err error) {
-	ctx, traceLog, endObservation := s.operations.documentationAtPosition.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
+	ctx, trace, endObservation := s.operations.documentationAtPosition.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("bundleID", bundleID),
 		log.String("path", path),
 		log.Int("line", line),
@@ -91,9 +91,9 @@ func (s *Store) DocumentationAtPosition(ctx context.Context, bundleID int, path 
 		return nil, err
 	}
 
-	traceLog(log.Int("numRanges", len(documentData.Document.Ranges)))
+	trace.Log(log.Int("numRanges", len(documentData.Document.Ranges)))
 	ranges := precise.FindRanges(documentData.Document.Ranges, line, character)
-	traceLog(log.Int("numIntersectingRanges", len(ranges)))
+	trace.Log(log.Int("numIntersectingRanges", len(ranges)))
 
 	documentationResultIDs := extractResultIDs(ranges, func(r precise.RangeData) precise.ID { return r.DocumentationResultID })
 	documentationPathIDs, err := s.documentationIDsToPathIDs(ctx, bundleID, documentationResultIDs)
@@ -131,7 +131,7 @@ LIMIT 1
 // identifiers. Like locations, this method returns a map from result set identifiers to another map from
 // document paths to locations within that document.
 func (s *Store) locationsWithinFile(ctx context.Context, bundleID int, ids []precise.ID, path string, documentData precise.DocumentData) (_ map[precise.ID][]Location, err error) {
-	ctx, traceLog, endObservation := s.operations.locationsWithinFile.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
+	ctx, trace, endObservation := s.operations.locationsWithinFile.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("bundleID", bundleID),
 		log.Int("numIDs", len(ids)),
 		log.String("ids", idsToString(ids)),
@@ -148,7 +148,7 @@ func (s *Store) locationsWithinFile(ctx context.Context, bundleID int, ids []pre
 	if err != nil {
 		return nil, err
 	}
-	traceLog(
+	trace.Log(
 		log.Int("numIndexes", len(indexes)),
 		log.String("indexes", intsToString(indexes)),
 	)
@@ -163,8 +163,8 @@ func (s *Store) locationsWithinFile(ctx context.Context, bundleID int, ids []pre
 	// Hydrate the locations result set by replacing range ids with their actual data from their
 	// containing document. This refines the map constructed in the previous step.
 	locationsByResultID := make(map[precise.ID][]Location, len(ids))
-	totalCount := s.readRangesFromDocument(bundleID, rangeIDsByResultID, locationsByResultID, path, documentData, traceLog)
-	traceLog(log.Int("numLocations", totalCount))
+	totalCount := s.readRangesFromDocument(bundleID, rangeIDsByResultID, locationsByResultID, path, documentData, trace)
+	trace.Log(log.Int("numLocations", totalCount))
 
 	return locationsByResultID, nil
 }

--- a/enterprise/internal/codeintel/stores/lsifstore/stencil.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/stencil.go
@@ -11,7 +11,7 @@ import (
 
 // Stencil return all ranges within a single document.
 func (s *Store) Stencil(ctx context.Context, bundleID int, path string) (_ []Range, err error) {
-	ctx, traceLog, endObservation := s.operations.stencil.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
+	ctx, trace, endObservation := s.operations.stencil.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("bundleID", bundleID),
 		log.String("path", path),
 	}})
@@ -22,7 +22,7 @@ func (s *Store) Stencil(ctx context.Context, bundleID int, path string) (_ []Ran
 		return nil, err
 	}
 
-	traceLog(log.Int("numRanges", len(documentData.Document.Ranges)))
+	trace.Log(log.Int("numRanges", len(documentData.Document.Ranges)))
 
 	ranges := make([]Range, 0, len(documentData.Document.Ranges))
 	for _, r := range documentData.Document.Ranges {

--- a/internal/extsvc/jvmpackages/coursier/coursier.go
+++ b/internal/extsvc/jvmpackages/coursier/coursier.go
@@ -157,7 +157,7 @@ func runCoursierCommand(ctx context.Context, config *schema.JVMPackagesConnectio
 	ctx, cancel := context.WithTimeout(ctx, invocTimeout)
 	defer cancel()
 
-	ctx, traceLog, endObservation := operations.runCommand.WithAndLogger(ctx, &err, observation.Args{LogFields: []otlog.Field{
+	ctx, trace, endObservation := operations.runCommand.WithAndLogger(ctx, &err, observation.Args{LogFields: []otlog.Field{
 		otlog.String("repositories", strings.Join(config.Maven.Repositories, "|")),
 		otlog.String("args", strings.Join(args, ", ")),
 	}})
@@ -183,7 +183,7 @@ func runCoursierCommand(ctx context.Context, config *schema.JVMPackagesConnectio
 	if err := cmd.Run(); err != nil {
 		return nil, errors.Wrapf(err, "coursier command %q failed with stderr %q and stdout %q", cmd, stderr, &stdout)
 	}
-	traceLog(otlog.String("stdout", stdout.String()), otlog.String("stderr", stderr.String()))
+	trace.Log(otlog.String("stdout", stdout.String()), otlog.String("stderr", stderr.String()))
 
 	if stdout.String() == "" {
 		return []string{}, nil

--- a/internal/trace/traceutil.go
+++ b/internal/trace/traceutil.go
@@ -142,6 +142,15 @@ func (t *Trace) LogFields(fields ...log.Field) {
 	t.trace.LazyLog(fieldsStringer(fields), false)
 }
 
+// TagFields adds fields to the opentracing.Span as tags
+// as well as as logs to the nettrace.Trace.
+func (t *Trace) TagFields(fields ...log.Field) {
+	for _, field := range fields {
+		t.span.SetTag(field.Key(), field.Value())
+	}
+	t.trace.LazyLog(fieldsStringer(fields), false)
+}
+
 // SetError declares that this trace and span resulted in an error.
 func (t *Trace) SetError(err error) {
 	if err == nil {

--- a/internal/workerutil/dbworker/store/store.go
+++ b/internal/workerutil/dbworker/store/store.go
@@ -419,7 +419,7 @@ var columnsUpdatedByDequeue = []string{
 //
 // The supplied conditions may use the alias provided in `ViewName`, if one was supplied.
 func (s *store) Dequeue(ctx context.Context, workerHostname string, conditions []*sqlf.Query) (_ workerutil.Record, _ bool, err error) {
-	ctx, traceLog, endObservation := s.operations.dequeue.WithAndLogger(ctx, &err, observation.Args{})
+	ctx, trace, endObservation := s.operations.dequeue.WithAndLogger(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
 	if s.InTransaction() {
@@ -469,7 +469,7 @@ func (s *store) Dequeue(ctx context.Context, workerHostname string, conditions [
 	if !exists {
 		return nil, false, nil
 	}
-	traceLog(log.Int("recordID", record.RecordID()))
+	trace.Log(log.Int("recordID", record.RecordID()))
 
 	return record, true, nil
 }
@@ -851,7 +851,7 @@ const defaultResetFailureMessage = "job processor died while handling this messa
 // identifiers the age of the record's last heartbeat timestamp for each record reset to queued and failed states,
 // respectively.
 func (s *store) ResetStalled(ctx context.Context) (resetLastHeartbeatsByIDs, failedLastHeartbeatsByIDs map[int]time.Duration, err error) {
-	ctx, traceLog, endObservation := s.operations.resetStalled.WithAndLogger(ctx, &err, observation.Args{})
+	ctx, trace, endObservation := s.operations.resetStalled.WithAndLogger(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
 	now := s.now()
@@ -871,7 +871,7 @@ func (s *store) ResetStalled(ctx context.Context) (resetLastHeartbeatsByIDs, fai
 	if err != nil {
 		return resetLastHeartbeatsByIDs, failedLastHeartbeatsByIDs, err
 	}
-	traceLog(log.Int("numResetIDs", len(resetLastHeartbeatsByIDs)))
+	trace.Log(log.Int("numResetIDs", len(resetLastHeartbeatsByIDs)))
 
 	resetFailureMessage := s.options.ResetFailureMessage
 	if resetFailureMessage == "" {
@@ -893,7 +893,7 @@ func (s *store) ResetStalled(ctx context.Context) (resetLastHeartbeatsByIDs, fai
 	if err != nil {
 		return resetLastHeartbeatsByIDs, failedLastHeartbeatsByIDs, err
 	}
-	traceLog(log.Int("numErroredIDs", len(failedLastHeartbeatsByIDs)))
+	trace.Log(log.Int("numErroredIDs", len(failedLastHeartbeatsByIDs)))
 
 	return resetLastHeartbeatsByIDs, failedLastHeartbeatsByIDs, nil
 }


### PR DESCRIPTION
To help the proliferation of The One Package, this PR augments `observation.TraceLogger` to allow adding tags to spans as opposed to only logs. For `x/net/trace.Trace`, it will still add logs as thats all it supports, but for `opentracing.Span`, it will add tags.

![image](https://user-images.githubusercontent.com/18282288/145623691-265a1461-064f-43c5-b814-bf42ecf3f06e.png)

