### PR TITLE
insights: More robust find-and-replace for series_ids in oob settings migration

### DIFF
--- a/enterprise/internal/insights/migration/migration.go
+++ b/enterprise/internal/insights/migration/migration.go
@@ -40,6 +40,7 @@ type migrator struct {
 	insightStore               *store.InsightStore
 	dashboardStore             *store.DBDashboardStore
 	orgStore                   database.OrgStore
+	workerBaseStore            *basestore.Store
 }
 
 func NewMigrator(insightsDB dbutil.DB, postgresDB dbutil.DB) oobmigration.Migrator {
@@ -51,6 +52,7 @@ func NewMigrator(insightsDB dbutil.DB, postgresDB dbutil.DB) oobmigration.Migrat
 		insightStore:               store.NewInsightStore(insightsDB),
 		dashboardStore:             store.NewDashboardStore(insightsDB),
 		orgStore:                   database.Orgs(postgresDB),
+		workerBaseStore:            basestore.NewWithDB(postgresDB, sql.TxOptions{}),
 	}
 }
 
@@ -404,12 +406,29 @@ func (m *migrator) migrateDashboard(ctx context.Context, from insights.SettingDa
 	return nil
 }
 
-func updateTimeSeriesReferences(handle dbutil.DB, ctx context.Context, oldId, newId string) error {
-	q := sqlf.Sprintf("update series_points set series_id = %s where series_id = %s", newId, oldId)
+func updateTimeSeriesReferences(handle dbutil.DB, ctx context.Context, oldId, newId string) (int, error) {
+	q := sqlf.Sprintf(`
+		WITH updated AS (
+			UPDATE series_points sp
+			SET series_id = %s
+			WHERE series_id = %s
+			RETURNING sp.series_id
+		)
+		SELECT count(*) FROM updated;
+	`, newId, oldId)
 	tempStore := basestore.NewWithDB(handle, sql.TxOptions{})
-	err := tempStore.Exec(ctx, q)
+	count, _, err := basestore.ScanFirstInt(tempStore.Query(ctx, q))
 	if err != nil {
-		return errors.Wrap(err, "updateTimeSeriesReferences")
+		return 0, errors.Wrap(err, "updateTimeSeriesReferences")
+	}
+	return count, nil
+}
+
+func updateTimeSeriesJobReferences(workerStore *basestore.Store, ctx context.Context, oldId, newId string) error {
+	q := sqlf.Sprintf("update insights_query_runner_jobs set series_id = %s where series_id = %s", newId, oldId)
+	err := workerStore.Exec(ctx, q)
+	if err != nil {
+		return errors.Wrap(err, "updateTimeSeriesJobReferences")
 	}
 	return nil
 }


### PR DESCRIPTION
This does two things:
1. If the find-and-replace in `updateTimeSeriesReferences` makes 0 updates, we do NOT stamp the `backfill_queued_at` so that it has a chance to calculate the points. I don't expect this case to happen, but we saw something like this happen on `k8s` so this is a guard against it.
2. Now it also does a find-and-replace on the `insights_query_runner_jobs.series_id` field as well. This is to handle a case where series points are being calculated when the migration is running; if we didn't do this, the series points would continue to be calculated with the old `series_id` and never included on the chart.

The if statements got a bit nested, but I think it makes enough sense for temporary code. Also let me know if you see any issues with the `workerStore` being included like that. It's not all part of the same transaction, but it's in a different database so I don't think there's much we can do about that.