### PR TITLE
ci: re-enable lsif-go and lsif-ts for demo.sourcegraph.com

### DIFF
--- a/.github/workflows/lsif-go.yml
+++ b/.github/workflows/lsif-go.yml
@@ -37,8 +37,8 @@ jobs:
         run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
         env:
           SRC_ENDPOINT: https://k8s.sgdev.org/
-      # - name: Upload lsif-go dump to Demo
-      #   working-directory: ${{ matrix.root }}
-      #   run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
-      #   env:
-      #     SRC_ENDPOINT: https://demo.sourcegraph.com/
+      - name: Upload lsif-go dump to Demo
+        working-directory: ${{ matrix.root }}
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
+        env:
+          SRC_ENDPOINT: https://demo.sourcegraph.com/

--- a/.github/workflows/lsif-ts.yml
+++ b/.github/workflows/lsif-ts.yml
@@ -46,11 +46,11 @@ jobs:
         run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
         env:
           SRC_ENDPOINT: https://k8s.sgdev.org/
-      # - name: Upload lsif-tsc dump to Demo
-      #   working-directory: ${{ matrix.root }}
-      #   run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
-      #   env:
-      #     SRC_ENDPOINT: https://demo.sourcegraph.com/
+      - name: Upload lsif-tsc dump to Demo
+        working-directory: ${{ matrix.root }}
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
+        env:
+          SRC_ENDPOINT: https://demo.sourcegraph.com/
 
       # Run lsif-eslint
       - name: Build TypeScript


### PR DESCRIPTION
This was previously disabled due to an issue with the demo instance eating up all its disk space with LSIF records (maybe https://github.com/sourcegraph/sourcegraph/issues/25691? )

This issue might be resolved, so I am optimistically re-enabling the uploads