### PR TITLE
ci: run LSIF on all main and release branch pushes

### DIFF
--- a/.github/workflows/lsif-go.yml
+++ b/.github/workflows/lsif-go.yml
@@ -1,6 +1,10 @@
-name: LSIF-Go
+name: lsif-ts
 on:
   push:
+    branches:
+      - main
+      - '[0-9]+.[0-9]+' # release branches
+  pull_request:
     paths:
       - '**.go'
 

--- a/.github/workflows/lsif-ts.yml
+++ b/.github/workflows/lsif-ts.yml
@@ -1,9 +1,14 @@
-name: LSIF-Ts
+name: lsif-ts
 on:
   push:
+    branches:
+      - main
+      - '[0-9]+.[0-9]+' # release branches
+  pull_request:
     paths:
       - '**.ts'
       - '**.js'
+
 jobs:
   lsif-tsc-eslint:
     # Skip running on forks


### PR DESCRIPTION
We don't want to clog up the pipeline with LSIF runs on _every_ push, but I also think we are good to run it on pushes to main. This change adjusts the condition to a few long-lived branches and pull requests that change certain paths.

Follow-up to https://github.com/sourcegraph/sourcegraph/commit/b41121d635581f64ac215ecbe1d6f3c1cdacf069 not triggering an LSIF upload for demo