### PR TITLE
gitserver: remove non-bare repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Sourcegraph services now listen to SIGTERM signals. This allows smoother rollouts in kubernetes deployments. [#27958](https://github.com/sourcegraph/sourcegraph/pull/27958)
 - The sourcegraph-frontend ingress now uses the networking.k8s.io/v1 api. This adds support for k8s v1.22 and later, and deprecates support for versions older than v1.18.x [#4029](https://github.com/sourcegraph/deploy-sourcegraph/pull/4029)
 - Indexed queries with language filters now use file contents to recognize languages. For example, `lang:matlab` will no longer return an Objective-C `main.m`. [#28370](https://github.com/sourcegraph/sourcegraph/pull/28370)
+- Non-bare repositories found on gitserver will be removed by a janitor job. [#28895](https://github.com/sourcegraph/sourcegraph/pull/28895)
 
 ### Fixed
 

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -125,10 +125,9 @@ func TestCleanupInactive(t *testing.T) {
 // relevant internal magic numbers and transformations change.
 func TestGitGCAuto(t *testing.T) {
 	// Create a test repository with detectable garbage that GC can prune.
-	root := t.TempDir()
-	repo := filepath.Join(root, "garbage-repo")
-	defer os.RemoveAll(root)
-	runCmd(t, root, "git", "init", repo)
+	wd := t.TempDir()
+	repo := filepath.Join(wd, "garbage-repo")
+	runCmd(t, wd, "git", "init", repo)
 
 	// First we need to generate a moderate number of commits.
 	for i := 0; i < 50; i++ {
@@ -148,6 +147,12 @@ func TestGitGCAuto(t *testing.T) {
 	// Bring everything back together in one branch.
 	runCmd(t, repo, "git", "checkout", "master")
 	runCmd(t, repo, "git", "merge", "secondary")
+
+	// Now create a bare repo like gitserver expects
+	root := t.TempDir()
+	wdRepo := repo
+	repo = filepath.Join(root, "garbage-repo")
+	runCmd(t, root, "git", "clone", "--bare", wdRepo, filepath.Join(repo, ".git"))
 
 	// `git count-objects -v` can indicate objects, packs, etc.
 	// We'll run this before and after to verify that an action

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -191,6 +191,7 @@ func TestCleanupExpired(t *testing.T) {
 	repoGCOld := path.Join(root, "repo-gc-old", ".git")
 	repoBoom := path.Join(root, "repo-boom", ".git")
 	repoCorrupt := path.Join(root, "repo-corrupt", ".git")
+	repoNonBare := path.Join(root, "repo-non-bare", ".git")
 	repoPerforce := path.Join(root, "repo-perforce", ".git")
 	repoPerforceGCOld := path.Join(root, "repo-perforce-gc-old", ".git")
 	repoRemoteURLScrub := path.Join(root, "repo-remote-url-scrub", ".git")
@@ -207,6 +208,10 @@ func TestCleanupExpired(t *testing.T) {
 		if err := cmd.Run(); err != nil {
 			t.Fatal(err)
 		}
+	}
+
+	if err := exec.Command("git", "init", filepath.Dir(repoNonBare)).Run(); err != nil {
+		t.Fatal(err)
 	}
 
 	getRemoteURL := func(ctx context.Context, name api.RepoName) (string, error) {
@@ -276,6 +281,10 @@ func TestCleanupExpired(t *testing.T) {
 	repoBoomTime := modTime(repoBoom)
 	repoBoomRecloneTime := recloneTime(repoBoom)
 
+	if _, err := os.Stat(repoNonBare); err != nil {
+		t.Fatal(err)
+	}
+
 	s := &Server{
 		ReposDir:         root,
 		GetRemoteURLFunc: getRemoteURL,
@@ -327,6 +336,10 @@ func TestCleanupExpired(t *testing.T) {
 		t.Fatalf("expected no output from git remote after URL scrubbing, got: %s", out)
 	} else if err != nil {
 		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(repoNonBare); err == nil {
+		t.Fatal("non-bare repo was not removed")
 	}
 }
 


### PR DESCRIPTION
Non-bare repositories fail to fetch since a fetch can't update HEAD when
you have a working copy. This leads to errors while users do operations
which result in a fetch. This becomes more common over time since the
repository won't update => bad UX. For this reason we remove the
repository and let other processes come in and clone (rather than using
reclone).

We have seen this occuring at a large customer who was experiencing some
FS corruption. It was then non-trivial to detect and clean up. This
motivated the addition of this janitor job.
