### PR TITLE
web: hide batch-changes video in Percy

### DIFF
--- a/client/web/src/enterprise/batches/list/GettingStarted.tsx
+++ b/client/web/src/enterprise/batches/list/GettingStarted.tsx
@@ -16,7 +16,7 @@ export const GettingStarted: React.FunctionComponent<GettingStartedProps> = ({ f
             <div className={classNames(styles.videoRow, 'row')}>
                 <div className="col-12 col-md-7">
                     <video
-                        className="w-100 h-auto shadow"
+                        className="w-100 h-auto shadow percy-hide"
                         width={1280}
                         height={720}
                         autoPlay={true}


### PR DESCRIPTION
Hides batch-changes Getting Started video from Percy to avoid flakes.

[Slack thread](https://sourcegraph.slack.com/archives/C01C3NCGD40/p1639186973209400).