### PR TITLE
ci: use athens proxy for go modules downloads

### DIFF
--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -270,6 +270,7 @@ var slowGoTestPackages = []string{
 // Adds the Go test step.
 func addGoTests(pipeline *bk.Pipeline) {
 	pipeline.AddStep(":go: Test",
+		bk.Env("GOPROXY", "http://athens-athens-proxy"),
 		bk.Cmd("./dev/ci/go-test.sh exclude "+strings.Join(slowGoTestPackages, " ")),
 		bk.Cmd("dev/ci/codecov.sh -c -F go"))
 
@@ -285,6 +286,7 @@ func addGoTests(pipeline *bk.Pipeline) {
 // Builds the OSS and Enterprise Go commands.
 func addGoBuild(pipeline *bk.Pipeline) {
 	pipeline.AddStep(":go: Build",
+		bk.Env("GOPROXY", "http://athens-athens-proxy"),
 		bk.Cmd("./dev/ci/go-build.sh"),
 	)
 }

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -13,6 +13,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/ci/operations"
 )
 
+var goAthensProxyURL = "http://athens-athens-proxy"
+
 // CoreTestOperationsOptions should be used ONLY to adjust the behaviour of specific steps,
 // e.g. by adding flags, and not as a condition for adding steps or commands.
 type CoreTestOperationsOptions struct {
@@ -270,7 +272,7 @@ var slowGoTestPackages = []string{
 // Adds the Go test step.
 func addGoTests(pipeline *bk.Pipeline) {
 	pipeline.AddStep(":go: Test",
-		bk.Env("GOPROXY", "http://athens-athens-proxy"),
+		bk.Env("GOPROXY", goAthensProxyURL),
 		bk.Cmd("./dev/ci/go-test.sh exclude "+strings.Join(slowGoTestPackages, " ")),
 		bk.Cmd("dev/ci/codecov.sh -c -F go"))
 
@@ -286,7 +288,7 @@ func addGoTests(pipeline *bk.Pipeline) {
 // Builds the OSS and Enterprise Go commands.
 func addGoBuild(pipeline *bk.Pipeline) {
 	pipeline.AddStep(":go: Build",
-		bk.Env("GOPROXY", "http://athens-athens-proxy"),
+		bk.Env("GOPROXY", goAthensProxyURL),
 		bk.Cmd("./dev/ci/go-build.sh"),
 	)
 }


### PR DESCRIPTION
Right now, it's not particularly useful as agents are caching downloads locally (see https://go.dev/ref/mod#module-cache) but when we'll go stateless, that will be an issue. 