### PR TITLE
Fix golangci-lint warnings in batches/service package

### DIFF
--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -48,7 +48,7 @@ func TestServicePermissionLevels(t *testing.T) {
 
 	repo, _ := ct.CreateTestRepo(t, ctx, db)
 
-	createTestData := func(t *testing.T, s *store.Store, svc *Service, author int32) (*btypes.BatchChange, *btypes.Changeset, *btypes.BatchSpec) {
+	createTestData := func(t *testing.T, s *store.Store, author int32) (*btypes.BatchChange, *btypes.Changeset, *btypes.BatchSpec) {
 		spec := testBatchSpec(author)
 		if err := s.CreateBatchSpec(ctx, spec); err != nil {
 			t.Fatal(err)
@@ -96,7 +96,7 @@ func TestServicePermissionLevels(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			batchChange, changeset, batchSpec := createTestData(t, s, svc, tc.batchChangeAuthor)
+			batchChange, changeset, batchSpec := createTestData(t, s, tc.batchChangeAuthor)
 			// Fresh context.Background() because the previous one is wrapped in AuthzBypas
 			currentUserCtx := actor.WithActor(context.Background(), actor.FromUser(tc.currentUser))
 
@@ -315,7 +315,7 @@ func TestService(t *testing.T) {
 		}
 
 		called := false
-		repoupdater.MockEnqueueChangesetSync = func(ctx context.Context, ids []int64) error {
+		repoupdater.MockEnqueueChangesetSync = func(_ context.Context, ids []int64) error {
 			if len(ids) != 1 && ids[0] != changeset.ID {
 				t.Fatalf("MockEnqueueChangesetSync received wrong ids: %+v", ids)
 			}

--- a/enterprise/internal/batches/service/workspace_resolver.go
+++ b/enterprise/internal/batches/service/workspace_resolver.go
@@ -181,7 +181,7 @@ func findIgnoredRepositories(ctx context.Context, repos []*RepoRevision) (map[*t
 			defer wg.Done()
 			for repo := range in {
 				hasBatchIgnore, err := hasBatchIgnoreFile(ctx, repo)
-				results <- result{repo, hasBatchIgnore, err}
+				out <- result{repo, hasBatchIgnore, err}
 			}
 		}(input, results)
 	}
@@ -652,8 +652,8 @@ func findWorkspaces(
 	for _, workspace := range workspacesByRepoRev {
 		steps, err := stepsForRepo(
 			spec,
-			string(workspace.RepoRevision.Repo.Name),
-			workspace.RepoRevision.FileMatches,
+			string(workspace.Repo.Name),
+			workspace.FileMatches,
 		)
 		if err != nil {
 			return nil, err

--- a/enterprise/internal/batches/service/workspace_resolver_test.go
+++ b/enterprise/internal/batches/service/workspace_resolver_test.go
@@ -382,7 +382,7 @@ func resolveWorkspacesAndCompare(t *testing.T, s *store.Store, u *types.User, ma
 }
 
 func newStreamSearchTestServer(t *testing.T, matches []streamhttp.EventMatch) string {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		type ev struct {
 			Name  string
 			Value interface{}
@@ -421,7 +421,7 @@ func mockDefaultBranches(t *testing.T, defaultBranches map[api.RepoName]defaultB
 }
 
 func mockBatchIgnores(t *testing.T, m map[api.CommitID]bool) {
-	git.Mocks.Stat = func(commit api.CommitID, name string) (fs.FileInfo, error) {
+	git.Mocks.Stat = func(commit api.CommitID, _ string) (fs.FileInfo, error) {
 		hasBatchIgnore, ok := m[commit]
 		if !ok {
 			return nil, fmt.Errorf("unknown commit: %s", commit)
@@ -435,7 +435,7 @@ func mockBatchIgnores(t *testing.T, m map[api.CommitID]bool) {
 }
 
 func mockResolveRevision(t *testing.T, branches map[string]api.CommitID) {
-	git.Mocks.ResolveRevision = func(spec string, opt git.ResolveRevisionOptions) (api.CommitID, error) {
+	git.Mocks.ResolveRevision = func(spec string, _ git.ResolveRevisionOptions) (api.CommitID, error) {
 		if commit, ok := branches[spec]; ok {
 			return commit, nil
 		}


### PR DESCRIPTION
Just ran across these while reviewing another PR