### PR TITLE
Fix mobile sidebar

### DIFF
--- a/client/shared/src/util/useMatchMedia.ts
+++ b/client/shared/src/util/useMatchMedia.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react'
 
 /**
  * Returns provided media query match and, by default, subscribes to its updates.
@@ -10,19 +10,19 @@ import { useEffect, useState } from 'react';
  * @returns `boolean`
  */
 export function useMatchMedia(query: string, observe = true): boolean {
-  const [isMatch, setIsMatch] = useState(window.matchMedia(query).matches)
+    const [isMatch, setIsMatch] = useState(window.matchMedia(query).matches)
 
-  useEffect(() => {
-    const handler = (event: MediaQueryListEvent): void => setIsMatch(event.matches)
-    if (observe) {
-      window.matchMedia(query).addEventListener('change', handler)
-    }
-    return () => {
-      if (observe) {
-        window.matchMedia(query).removeEventListener('change', handler)
-      }
-    }
-  }, [query, observe])
+    useEffect(() => {
+        const handler = (event: MediaQueryListEvent): void => setIsMatch(event.matches)
+        if (observe) {
+            window.matchMedia(query).addEventListener('change', handler)
+        }
+        return () => {
+            if (observe) {
+                window.matchMedia(query).removeEventListener('change', handler)
+            }
+        }
+    }, [query, observe])
 
-  return isMatch
+    return isMatch
 }

--- a/client/shared/src/util/useMatchMedia.ts
+++ b/client/shared/src/util/useMatchMedia.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Returns provided media query match and, by default, subscribes to its updates.
+ *
+ * Example: `const isSmallScreen = useMatchMedia('(max-width: 250px)')`
+ *
+ * @param query CSS media query to match
+ * @param observe Boolean flag indicating if you want to subscribe to updates, `true` by default
+ * @returns `boolean`
+ */
+export function useMatchMedia(query: string, observe = true): boolean {
+  const [isMatch, setIsMatch] = useState(window.matchMedia(query).matches)
+
+  useEffect(() => {
+    const handler = (event: MediaQueryListEvent): void => setIsMatch(event.matches)
+    if (observe) {
+      window.matchMedia(query).addEventListener('change', handler)
+    }
+    return () => {
+      if (observe) {
+        window.matchMedia(query).removeEventListener('change', handler)
+      }
+    }
+  }, [query, observe])
+
+  return isMatch
+}

--- a/client/shared/src/util/useMatchMedia.ts
+++ b/client/shared/src/util/useMatchMedia.ts
@@ -17,11 +17,7 @@ export function useMatchMedia(query: string, observe = true): boolean {
         if (observe) {
             window.matchMedia(query).addEventListener('change', handler)
         }
-        return () => {
-            if (observe) {
-                window.matchMedia(query).removeEventListener('change', handler)
-            }
-        }
+        return () => window.matchMedia(query).removeEventListener('change', handler)
     }, [query, observe])
 
     return isMatch

--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames'
 import * as H from 'history'
 import ChevronDoubleLeftIcon from 'mdi-react/ChevronDoubleLeftIcon'
 import ChevronDoubleRightIcon from 'mdi-react/ChevronDoubleRightIcon'
-import React, { useCallback } from 'react'
+import React, { useCallback, useState } from 'react'
 import { Button } from 'reactstrap'
 
 import { Resizable } from '@sourcegraph/shared/src/components/Resizable'
@@ -13,6 +13,7 @@ import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryServi
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { AbsoluteRepoFile } from '@sourcegraph/shared/src/util/url'
 import { useLocalStorage } from '@sourcegraph/shared/src/util/useLocalStorage'
+import { useMatchMedia } from '@sourcegraph/shared/src/util/useMatchMedia'
 
 import settingsSchemaJSON from '../../../../schema/settings.schema.json'
 import { Tree } from '../tree/Tree'
@@ -37,24 +38,29 @@ const SIDEBAR_KEY = 'repo-revision-sidebar-toggle'
  */
 export const RepoRevisionSidebar: React.FunctionComponent<Props> = props => {
     const [tabIndex, setTabIndex] = useLocalStorage(TABS_KEY, 0)
-    const [toggleSidebar, setToggleSidebar] = useLocalStorage(
+    const [persistedIsVisible, setPersistedIsVisible] = useLocalStorage(
         SIDEBAR_KEY,
         settingsSchemaJSON.properties.fileSidebarVisibleByDefault.default
     )
 
+    // ToDo: this media query should be extracted into some share place for better reuse
+    const isTouchScreen = useMatchMedia('(pointer: coarse), (hover: none)', false)
+    const [isVisible, setIsVisible] = useState(persistedIsVisible && !isTouchScreen);
+
     const handleTabsChange = useCallback((index: number) => setTabIndex(index), [setTabIndex])
-    const handleSidebarToggle = useCallback(() => {
+    const handleSidebarToggle = useCallback((value: boolean) => {
         props.telemetryService.log('FileTreeViewClicked', {
             action: 'click',
             label: 'expand / collapse file tree view',
         })
-        setToggleSidebar(!toggleSidebar)
-    }, [setToggleSidebar, toggleSidebar, props.telemetryService])
+        setPersistedIsVisible(value)
+        setIsVisible(value)
+    }, [setPersistedIsVisible, props.telemetryService])
     const handleSymbolClick = useCallback(() => props.telemetryService.log('SymbolTreeViewClicked'), [
         props.telemetryService,
     ])
 
-    if (!toggleSidebar) {
+    if (!isVisible) {
         return (
             <button
                 type="button"
@@ -62,7 +68,7 @@ export const RepoRevisionSidebar: React.FunctionComponent<Props> = props => {
                     'position-absolute btn btn-icon border-top border-bottom border-right mt-4',
                     styles.toggle
                 )}
-                onClick={handleSidebarToggle}
+                onClick={() => handleSidebarToggle(true)}
                 data-tooltip="Show sidebar"
             >
                 <ChevronDoubleRightIcon className="icon-inline" />
@@ -92,10 +98,10 @@ export const RepoRevisionSidebar: React.FunctionComponent<Props> = props => {
                                 </Tab>
                             </TabList>
                             <Button
-                                onClick={handleSidebarToggle}
+                                onClick={() => handleSidebarToggle(false)}
                                 className="bg-transparent border-0 ml-auto p-1 position-relative focus-behaviour"
-                                title="Close panel"
-                                data-tooltip="Collapse panel"
+                                title="Hide sidebar"
+                                data-tooltip="Hide sidebar"
                                 data-placement="right"
                             >
                                 <ChevronDoubleLeftIcon className={classNames('icon-inline', styles.closeIcon)} />

--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -45,17 +45,20 @@ export const RepoRevisionSidebar: React.FunctionComponent<Props> = props => {
 
     // ToDo: this media query should be extracted into some share place for better reuse
     const isTouchScreen = useMatchMedia('(pointer: coarse), (hover: none)', false)
-    const [isVisible, setIsVisible] = useState(persistedIsVisible && !isTouchScreen);
+    const [isVisible, setIsVisible] = useState(persistedIsVisible && !isTouchScreen)
 
     const handleTabsChange = useCallback((index: number) => setTabIndex(index), [setTabIndex])
-    const handleSidebarToggle = useCallback((value: boolean) => {
-        props.telemetryService.log('FileTreeViewClicked', {
-            action: 'click',
-            label: 'expand / collapse file tree view',
-        })
-        setPersistedIsVisible(value)
-        setIsVisible(value)
-    }, [setPersistedIsVisible, props.telemetryService])
+    const handleSidebarToggle = useCallback(
+        (value: boolean) => {
+            props.telemetryService.log('FileTreeViewClicked', {
+                action: 'click',
+                label: 'expand / collapse file tree view',
+            })
+            setPersistedIsVisible(value)
+            setIsVisible(value)
+        },
+        [setPersistedIsVisible, props.telemetryService]
+    )
     const handleSymbolClick = useCallback(() => props.telemetryService.log('SymbolTreeViewClicked'), [
         props.telemetryService,
     ])

--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -43,9 +43,8 @@ export const RepoRevisionSidebar: React.FunctionComponent<Props> = props => {
         settingsSchemaJSON.properties.fileSidebarVisibleByDefault.default
     )
 
-    // ToDo: this media query should be extracted into some share place for better reuse
-    const isTouchScreen = useMatchMedia('(pointer: coarse), (hover: none)', false)
-    const [isVisible, setIsVisible] = useState(persistedIsVisible && !isTouchScreen)
+    const isWideScreen = useMatchMedia('(min-width: 768px)', false)
+    const [isVisible, setIsVisible] = useState(persistedIsVisible && isWideScreen)
 
     const handleTabsChange = useCallback((index: number) => setTabIndex(index), [setTabIndex])
     const handleSidebarToggle = useCallback(


### PR DESCRIPTION
## Problem

File tree in the sidebar is visible on mobile devices (https://github.com/sourcegraph/sourcegraph/issues/25500) and occupies the most useful screen estate. 

## Solution

https://user-images.githubusercontent.com/2196347/145815780-69fd6a4e-7786-4f1e-8632-aa6eb185b8e0.mov

We persist sidebar toggle state to localStorage, so at first render two things have to be taken into account:

- persisted state
- `isTouchScreen` flag

In order to do so, we introduce a few changes:

- `useMatchMedia` hook to match any media query
- additional state in the `RepoRevisionSidebar` component so that at first render _and_ on mobile we always hide the sidebar, and when user toggles it - still persist the setting and toggle it in the UI

Additionally, titles are changed for better consistency. 

## Next steps

I dislike the fact that we now use ad-hoc media queries to detect mobile. Ideally it should be a single CSS var / CSS module export that defines what is a mobile/touch device (in our case, it's a `(pointer: coarse), (hover: none)` media-query) - which is later used in any CSS (and `NavDropdown.module.scss` where it's taken from originally) and in TS via importing it from the CSS module.