### PR TITLE
featureflag: handle flags not being set

### DIFF
--- a/internal/featureflag/flagset.go
+++ b/internal/featureflag/flagset.go
@@ -3,11 +3,17 @@ package featureflag
 type FlagSet map[string]bool
 
 func (f FlagSet) GetBool(flag string) (bool, bool) {
+	if f == nil {
+		return false, false
+	}
 	v, ok := f[flag]
 	return v, ok
 }
 
 func (f FlagSet) GetBoolOr(flag string, defaultVal bool) bool {
+	if f == nil {
+		return defaultVal
+	}
 	if v, ok := f[flag]; ok {
 		return v
 	}


### PR DESCRIPTION
If your context hasn't had feature flags set we FromContext returns a
nil FlagSet. This updates the implementation to handle a nil value as if
the feature flag is not set.