### PR TITLE
search: introduce ctx to QueryToZoektQuery

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -38,7 +38,7 @@ func (srs *searchResultsStats) Languages(ctx context.Context) ([]*languageStatis
 
 func (srs *searchResultsStats) getResults(ctx context.Context) (*SearchResultsResolver, error) {
 	srs.once.Do(func() {
-		args, jobs, err := srs.sr.toSearchInputs(srs.sr.Query)
+		args, jobs, err := srs.sr.toSearchInputs(ctx, srs.sr.Query)
 		if err != nil {
 			srs.srsErr = err
 			return

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -927,7 +927,7 @@ func TestIsGlobalSearch(t *testing.T) {
 				},
 			}
 
-			p, _, _ := resolver.toSearchInputs(resolver.Query)
+			p, _, _ := resolver.toSearchInputs(context.Background(), resolver.Query)
 			if p.Mode != tt.mode {
 				t.Fatalf("got %+v, want %+v", p.Mode, tt.mode)
 			}

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -362,7 +362,7 @@ func (r *searchResolver) showSymbolMatches(ctx context.Context) ([]SearchSuggest
 		return nil, nil
 	}
 
-	args, jobs, err := r.toSearchInputs(r.Query)
+	args, jobs, err := r.toSearchInputs(ctx, r.Query)
 	if err != nil {
 		return nil, err
 	}
@@ -447,7 +447,7 @@ func (r *searchResolver) showFilesWithTextMatches(first int32) suggester {
 		ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 		defer cancel()
 		if len(r.Query.Values(query.FieldDefault)) > 0 {
-			searchArgs, jobs, err := r.toSearchInputs(r.Query)
+			searchArgs, jobs, err := r.toSearchInputs(ctx, r.Query)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/search/query_converter.go
+++ b/internal/search/query_converter.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"context"
 	"regexp"
 	"regexp/syntax"
 	"strconv"
@@ -229,7 +230,7 @@ func parseRe(pattern string, filenameOnly bool, contentOnly bool, queryIsCaseSen
 	}, nil
 }
 
-func QueryToZoektQuery(p *TextPatternInfo, typ IndexedRequestType) (zoekt.Q, error) {
+func QueryToZoektQuery(ctx context.Context, p *TextPatternInfo, typ IndexedRequestType) (zoekt.Q, error) {
 	var and []zoekt.Q
 
 	var q zoekt.Q

--- a/internal/search/query_converter_test.go
+++ b/internal/search/query_converter_test.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"context"
 	"encoding/json"
 	"sort"
 	"testing"
@@ -184,7 +185,7 @@ func TestQueryToZoektQuery(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to parse %q: %v", tt.Query, err)
 			}
-			got, err := QueryToZoektQuery(tt.Pattern, tt.Type)
+			got, err := QueryToZoektQuery(context.Background(), tt.Pattern, tt.Type)
 			if err != nil {
 				t.Fatal("queryToZoektQuery failed:", err)
 			}

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -231,7 +231,7 @@ func NewIndexedSearchRequest(ctx context.Context, args *search.TextParameters, g
 	if ok {
 		return request, nil
 	}
-	q, err := search.QueryToZoektQuery(args.PatternInfo, typ)
+	q, err := search.QueryToZoektQuery(ctx, args.PatternInfo, typ)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -272,7 +272,7 @@ func TestIndexedSearch(t *testing.T) {
 				Repos:  zoektRepos,
 			}
 
-			zoektQuery, err := search.QueryToZoektQuery(tt.args.patternInfo, search.TextRequest)
+			zoektQuery, err := search.QueryToZoektQuery(context.Background(), tt.args.patternInfo, search.TextRequest)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
We want to be able to check feature flags. Alternatively we may want to
instead communicate this in the high level structs we pass
around. However, that was a more complicated change to understand but I
am happy to follow-up and do that. For now I want feature flags to allow
gating the new lang support which is causing some issues.