### PR TITLE
doc: update CLA-bot docs

### DIFF
--- a/doc/dev/contributing/accepting_contribution.md
+++ b/doc/dev/contributing/accepting_contribution.md
@@ -4,7 +4,7 @@ This page outlines how to accept a contribution to the [Sourcegraph repository](
 
 ## CLA-bot
 
-1. Check if a contributor signed the CLA [here](https://docs.google.com/spreadsheets/d/1_iBZh9PJi-05vTnlQ3GVeeRe8H3Wq1_FZ49aYrsHGLQ/edit?usp=sharing). All fields should be filled with valid data to proceed with the pull request. (This does not apply for Sourcegraph teammates.)
+1. For external contributors only: ensure that that contributor signed the [CLA](https://docs.google.com/spreadsheets/d/1_iBZh9PJi-05vTnlQ3GVeeRe8H3Wq1_FZ49aYrsHGLQ/edit?usp=sharing). All fields should be filled with valid data to proceed with the pull request. (This does not apply for Sourcegraph teammates.)
 2. If the CLA is signed — update the CLA-bot configuration [here](https://github.com/sourcegraph/clabot-config/edit/main/.clabot) by adding a contributor name to the `contributors` field, preserving the alphabetical order.
 3. Comment on the pull request: `@cla-bot check`.
 4. The `verification/cla-signed` workflow should become green. 🎉

--- a/doc/dev/contributing/accepting_contribution.md
+++ b/doc/dev/contributing/accepting_contribution.md
@@ -1,10 +1,10 @@
 # How to accept an external contribution
 
-This page outlines how to accept a contribution to the [Sourcegraph repository](https://github.com/sourcegraph/sourcegraph) from someone outside the Sourcegraph team.
+This page outlines how to accept a contribution to the [Sourcegraph repository](https://github.com/sourcegraph/sourcegraph).
 
 ## CLA-bot
 
-1. Check if a contributor signed the CLA [here](https://docs.google.com/spreadsheets/d/1_iBZh9PJi-05vTnlQ3GVeeRe8H3Wq1_FZ49aYrsHGLQ/edit?usp=sharing). All fields should be filled with valid data to proceed with the pull request.
+1. Check if a contributor signed the CLA [here](https://docs.google.com/spreadsheets/d/1_iBZh9PJi-05vTnlQ3GVeeRe8H3Wq1_FZ49aYrsHGLQ/edit?usp=sharing). All fields should be filled with valid data to proceed with the pull request. (This does not apply for Sourcegraph teammates.)
 2. If the CLA is signed — update the CLA-bot configuration [here](https://github.com/sourcegraph/clabot-config/edit/main/.clabot) by adding a contributor name to the `contributors` field, preserving the alphabetical order.
 3. Comment on the pull request: `@cla-bot check`.
 4. The `verification/cla-signed` workflow should become green. 🎉

--- a/doc/dev/contributing/accepting_contribution.md
+++ b/doc/dev/contributing/accepting_contribution.md
@@ -5,7 +5,7 @@ This page outlines how to accept a contribution to the [Sourcegraph repository](
 ## CLA-bot
 
 1. For external contributors only: ensure that that contributor signed the [CLA](https://docs.google.com/spreadsheets/d/1_iBZh9PJi-05vTnlQ3GVeeRe8H3Wq1_FZ49aYrsHGLQ/edit?usp=sharing). All fields should be filled with valid data to proceed with the pull request. (This does not apply for Sourcegraph teammates.)
-2. If the CLA is signed — update the CLA-bot configuration [here](https://github.com/sourcegraph/clabot-config/edit/main/.clabot) by adding a contributor name to the `contributors` field, preserving the alphabetical order.
+2. Update the CLA-bot configuration [here](https://github.com/sourcegraph/clabot-config/edit/main/.clabot) by adding a contributor name to the `contributors` field, preserving the alphabetical order.
 3. Comment on the pull request: `@cla-bot check`.
 4. The `verification/cla-signed` workflow should become green. 🎉
 


### PR DESCRIPTION
## Context

Every contributor must be added to the CLA-bot configuration to make the CLA-bot check pass. This PR update the documentation to reflect this fact.