### PR TITLE
search: optimize zoekt backed select:repo

### DIFF
--- a/cmd/searcher/search/zoekt_search.go
+++ b/cmd/searcher/search/zoekt_search.go
@@ -145,7 +145,7 @@ func zoektSearch(ctx context.Context, args *search.TextPatternInfo, branchRepos 
 
 	// Choose sensible values for k when we generalize this.
 	k := zoektutil.ResultCountFactor(numRepos, args.FileMatchLimit, false)
-	searchOpts := zoektutil.SearchOpts(ctx, k, args.FileMatchLimit)
+	searchOpts := zoektutil.SearchOpts(ctx, k, args.FileMatchLimit, nil)
 	searchOpts.Whole = true
 
 	// TODO(@camdencheek) TODO(@rvantonder) handle "timeout:..." values in this context.

--- a/go.mod
+++ b/go.mod
@@ -350,7 +350,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20211215184724-c8a2f8c3683e
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20211216165656-323fabe7e852
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20211110092431-863f5b1ee51b

--- a/go.sum
+++ b/go.sum
@@ -1395,8 +1395,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20211215184724-c8a2f8c3683e h1:avYGx1t1FFb8SfKYRTbMdBVCmxYQoF3tzSrgaOdwzZY=
-github.com/sourcegraph/zoekt v0.0.0-20211215184724-c8a2f8c3683e/go.mod h1:Sx/PuFfor3D2/B5yTV9TqhTW48+85dR5o2tWD8VsASk=
+github.com/sourcegraph/zoekt v0.0.0-20211216165656-323fabe7e852 h1:7+ijp4pjiNd+ALfo6gnWBvHAbGA82bJrNs4krwOLcBk=
+github.com/sourcegraph/zoekt v0.0.0-20211216165656-323fabe7e852/go.mod h1:Sx/PuFfor3D2/B5yTV9TqhTW48+85dR5o2tWD8VsASk=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -81,6 +81,7 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 			log.Bool("opts.estimate_doc_count", opts.EstimateDocCount),
 			log.Bool("opts.whole", opts.Whole),
 			log.Int("opts.shard_max_match_count", opts.ShardMaxMatchCount),
+			log.Int("opts.shard_repo_max_match_count", opts.ShardRepoMaxMatchCount),
 			log.Int("opts.total_max_match_count", opts.TotalMaxMatchCount),
 			log.Int("opts.shard_max_important_match", opts.ShardMaxImportantMatch),
 			log.Int("opts.total_max_important_match", opts.TotalMaxImportantMatch),

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -442,7 +442,7 @@ func DoZoektSearchGlobal(ctx context.Context, args *search.ZoektParameters, c st
 	defer cancel()
 
 	k := ResultCountFactor(0, args.FileMatchLimit, true)
-	searchOpts := SearchOpts(ctx, k, args.FileMatchLimit)
+	searchOpts := SearchOpts(ctx, k, args.FileMatchLimit, args.Select)
 
 	if deadline, ok := ctx.Deadline(); ok {
 		// If the user manually specified a timeout, allow zoekt to use all of the remaining timeout.
@@ -461,29 +461,6 @@ func DoZoektSearchGlobal(ctx context.Context, args *search.ZoektParameters, c st
 		defer cancel()
 	}
 
-	// PERF: if we are going to be selecting to repo results only anyways, we can
-	// just ask zoekt for only results of type repo.
-	if args.Select.Root() == filter.Repository {
-		repoList, err := args.Zoekt.List(ctx, args.Query, nil)
-		if err != nil {
-			return err
-		}
-
-		matches := make([]result.Match, 0, len(repoList.Repos))
-		for _, repo := range repoList.Repos {
-			matches = append(matches, &result.RepoMatch{
-				Name: api.RepoName(repo.Repository.Name),
-				ID:   api.RepoID(repo.Repository.ID),
-			})
-		}
-
-		c.Send(streaming.SearchEvent{
-			Results: matches,
-			Stats:   streaming.Stats{}, // TODO
-		})
-		return nil
-	}
-
 	return args.Zoekt.StreamSearch(ctx, args.Query, &searchOpts, backend.ZoektStreamFunc(func(event *zoekt.SearchResult) {
 		sendMatches(event, func(file *zoekt.FileMatch) (types.MinimalRepo, []string) {
 			repo := types.MinimalRepo{
@@ -491,7 +468,7 @@ func DoZoektSearchGlobal(ctx context.Context, args *search.ZoektParameters, c st
 				Name: api.RepoName(file.Repository),
 			}
 			return repo, []string{""}
-		}, args.Typ, c)
+		}, args.Typ, args.Select, c)
 	}))
 }
 
@@ -512,7 +489,7 @@ func zoektSearch(ctx context.Context, repos *IndexedRepoRevs, q zoektquery.Q, ty
 	finalQuery := zoektquery.NewAnd(&zoektquery.BranchesRepos{List: brs}, q)
 
 	k := ResultCountFactor(len(repos.repoRevs), fileMatchLimit, false)
-	searchOpts := SearchOpts(ctx, k, fileMatchLimit)
+	searchOpts := SearchOpts(ctx, k, fileMatchLimit, selector)
 
 	// Start event stream.
 	t0 := time.Now()
@@ -534,22 +511,10 @@ func zoektSearch(ctx context.Context, repos *IndexedRepoRevs, q zoektquery.Q, ty
 		defer cancel()
 	}
 
-	// PERF: if we are going to be selecting to repo results only anyways, we can just ask
-	// zoekt for only results of type repo.
-	if selector.Root() == filter.Repository {
-		return zoektSearchReposOnly(ctx, client, finalQuery, c, func() map[api.RepoID]*search.RepositoryRevisions {
-			repoRevMap := make(map[api.RepoID]*search.RepositoryRevisions, len(repos.repoRevs))
-			for _, r := range repos.repoRevs {
-				repoRevMap[r.Repo.ID] = r
-			}
-			return repoRevMap
-		})
-	}
-
 	foundResults := atomic.Bool{}
 	err := client.StreamSearch(ctx, finalQuery, &searchOpts, backend.ZoektStreamFunc(func(event *zoekt.SearchResult) {
 		foundResults.CAS(false, event.FileCount != 0 || event.MatchCount != 0)
-		sendMatches(event, repos.getRepoInputRev, typ, c)
+		sendMatches(event, repos.getRepoInputRev, typ, selector, c)
 	}))
 	if err != nil {
 		return err
@@ -569,7 +534,7 @@ func zoektSearch(ctx context.Context, repos *IndexedRepoRevs, q zoektquery.Q, ty
 	return nil
 }
 
-func sendMatches(event *zoekt.SearchResult, getRepoInputRev repoRevFunc, typ search.IndexedRequestType, c streaming.Sender) {
+func sendMatches(event *zoekt.SearchResult, getRepoInputRev repoRevFunc, typ search.IndexedRequestType, selector filter.SelectPath, c streaming.Sender) {
 	files := event.Files
 	limitHit := event.FilesSkipped+event.ShardsSkipped > 0
 
@@ -583,6 +548,14 @@ func sendMatches(event *zoekt.SearchResult, getRepoInputRev repoRevFunc, typ sea
 	matches := make([]result.Match, 0, len(files))
 	for _, file := range files {
 		repo, inputRevs := getRepoInputRev(&file)
+
+		if selector.Root() == filter.Repository {
+			matches = append(matches, &result.RepoMatch{
+				Name: repo.Name,
+				ID:   repo.ID,
+			})
+			continue
+		}
 
 		var lines []*result.LineMatch
 		if typ != search.SymbolRequest {
@@ -616,40 +589,6 @@ func sendMatches(event *zoekt.SearchResult, getRepoInputRev repoRevFunc, typ sea
 			IsLimitHit: limitHit,
 		},
 	})
-}
-
-// zoektSearchReposOnly is used when select:repo is set, in which case we can ask zoekt
-// only for the repos that contain matches for the query. This is a performance optimization,
-// and not required for proper function of select:repo.
-func zoektSearchReposOnly(ctx context.Context, client zoekt.Streamer, query zoektquery.Q, c streaming.Sender, getRepoRevMap func() map[api.RepoID]*search.RepositoryRevisions) error {
-	repoList, err := client.List(ctx, query, &zoekt.ListOptions{Minimal: true})
-	if err != nil {
-		return err
-	}
-
-	repoRevMap := getRepoRevMap()
-	if repoRevMap == nil {
-		return nil
-	}
-
-	matches := make([]result.Match, 0, len(repoList.Minimal))
-	for id := range repoList.Minimal {
-		rev, ok := repoRevMap[api.RepoID(id)]
-		if !ok {
-			continue
-		}
-
-		matches = append(matches, &result.RepoMatch{
-			Name: rev.Repo.Name,
-			ID:   rev.Repo.ID,
-		})
-	}
-
-	c.Send(streaming.SearchEvent{
-		Results: matches,
-		Stats:   streaming.Stats{}, // TODO
-	})
-	return nil
 }
 
 func zoektFileMatchToLineMatches(file *zoekt.FileMatch) []*result.LineMatch {

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -536,7 +536,14 @@ func zoektSearch(ctx context.Context, repos *IndexedRepoRevs, q zoektquery.Q, ty
 
 func sendMatches(event *zoekt.SearchResult, getRepoInputRev repoRevFunc, typ search.IndexedRequestType, selector filter.SelectPath, c streaming.Sender) {
 	files := event.Files
-	limitHit := event.FilesSkipped+event.ShardsSkipped > 0
+
+	limitHit := false
+	if selector.Root() == filter.Repository {
+		limitHit = event.ShardsSkipped > 0
+	} else {
+		limitHit = event.FilesSkipped+event.ShardsSkipped > 0
+	}
+
 
 	if len(files) == 0 {
 		c.Send(streaming.SearchEvent{


### PR DESCRIPTION
This commit makes Zoekt's handling of select:repo use a normal streaming
search rather than listing. This should make it a streaming search in
effect, massively improving time to first result while removing the need
for a list operation which has a bad impact on frontend memory usage.

Also updates Zoekt with:
- https://github.com/sourcegraph/zoekt/commit/323fabe eval: add ShardRepoMaxMatchCount
- https://github.com/sourcegraph/zoekt/commit/8945cee gitIndex: add more tracing context + log fetch duration
- https://github.com/sourcegraph/zoekt/commit/e04f226 all: fix misc linter warnings
- https://github.com/sourcegraph/zoekt/commit/a9b0bb7 rpc: panic if we fail to register srv.Searcher
- https://github.com/sourcegraph/zoekt/commit/428b58a read: handle error if we fail to read a section
- https://github.com/sourcegraph/zoekt/commit/24248b0 indexfile: log if we fail to Munmap
- https://github.com/sourcegraph/zoekt/commit/35c8634 all: handle most errcheck lints
- https://github.com/sourcegraph/zoekt/commit/88565fe all: fix errcheck lints in test files
- https://github.com/sourcegraph/zoekt/commit/c9fea67 use testIndexBuilder helper in index_test
- https://github.com/sourcegraph/zoekt/commit/f85523c section: remove error from writer.Write
- https://github.com/sourcegraph/zoekt/commit/804b1e2 all: ignore error from http.ResponseWriter.Write
- https://github.com/sourcegraph/zoekt/commit/66c3ccb all: ignore errcheck on defer builder.Finish
- https://github.com/sourcegraph/zoekt/commit/71c54bd all: handle IndexBuilder.Write failing in tests
- https://github.com/sourcegraph/zoekt/commit/073b68b all: handle error from builder.AddFile
- https://github.com/sourcegraph/zoekt/commit/ed3a166 all: explicitly ignore error for maxprocs.Set⏎ 


Fixes #22649
Part of #28799



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
