### PR TITLE
fix cleanup script

### DIFF
--- a/dev/ci/test/e2e/test.sh
+++ b/dev/ci/test/e2e/test.sh
@@ -15,9 +15,11 @@ cleanup() {
   cd "$root_dir"
   dev/ci/test/cleanup-display.sh
   if [[ $(docker ps -aq | wc -l) -gt 0 ]]; then
-    docker rm -f "$(docker ps -aq)"
+    # shellcheck disable=SC2046
+    docker rm -f $(docker ps -aq)
   fi
-  docker rmi -f "$(docker images -q)"
+  # shellcheck disable=SC2046
+  docker rmi -f $(docker images -q)
 }
 trap cleanup EXIT
 

--- a/dev/ci/test/qa/test.sh
+++ b/dev/ci/test/qa/test.sh
@@ -22,7 +22,8 @@ cleanup() {
   docker_logs
   cd "$root_dir"
   docker rm -f "$CONTAINER"
-  docker rmi -f "$(docker images -q)"
+  # shellcheck disable=SC2046
+  docker rmi -f $(docker images -q)
 
 }
 

--- a/dev/ci/test/upgrade/test.sh
+++ b/dev/ci/test/upgrade/test.sh
@@ -23,9 +23,11 @@ cleanup() {
   cd "$root_dir"
   dev/ci/test/cleanup-display.sh
   if [[ $(docker ps -aq | wc -l) -gt 0 ]]; then
-    docker rm -f "$(docker ps -aq)"
+    # shellcheck disable=SC2046
+    docker rm -f $(docker ps -aq)
   fi
-  docker rmi -f "$(docker images -q)"
+  # shellcheck disable=SC2046
+  docker rmi -f $(docker images -q)
 }
 
 # Run and initialize an old Sourcegraph release


### PR DESCRIPTION
Having this in quotes returns the list as one variable with `docker rmi` cannot read. This ensure the list is split and each image is actually deleted. 