### PR TITLE
observability: migrate diskcache to internal/observation

### DIFF
--- a/cmd/frontend/internal/vfsutil/cache.go
+++ b/cmd/frontend/internal/vfsutil/cache.go
@@ -46,12 +46,10 @@ func (f *cachedFile) Evict() {
 // single-flighting.
 func cachedFetch(ctx context.Context, component, key string, fetcher func(context.Context) (io.ReadCloser, error)) (ff *cachedFile, err error) {
 	initArchiveCacheDir()
-	s := &diskcache.Store{
-		// Dir uses component as a subdir to prevent conflicts between
-		// components with the same key.
-		Dir:       filepath.Join(ArchiveCacheDir, component),
-		Component: component,
-	}
+	// Dir uses component as a subdir to prevent conflicts between
+	// components with the same key.
+	s := diskcache.NewStore(filepath.Join(ArchiveCacheDir, component), component)
+
 	f, err := s.Open(ctx, []string{key}, fetcher)
 	if err != nil {
 		return nil, err

--- a/cmd/symbols/internal/api/handler_test.go
+++ b/cmd/symbols/internal/api/handler_test.go
@@ -34,11 +34,7 @@ func TestHandler(t *testing.T) {
 	}
 	defer func() { os.RemoveAll(tmpDir) }()
 
-	cache := &diskcache.Store{
-		Dir:               tmpDir,
-		Component:         "symbols",
-		BackgroundTimeout: 20 * time.Minute,
-	}
+	cache := diskcache.NewStore(tmpDir, "symbols", diskcache.WithBackgroundTimeout(20*time.Minute))
 
 	parserFactory := func() (ctags.Parser, error) {
 		return newMockParser("x", "y"), nil

--- a/cmd/symbols/internal/database/janitor/cache_evicter.go
+++ b/cmd/symbols/internal/database/janitor/cache_evicter.go
@@ -13,7 +13,7 @@ import (
 
 type cacheEvicter struct {
 	// cache is the disk backed cache.
-	cache *diskcache.Store
+	cache diskcache.Store
 
 	// maxCacheSizeBytes is the maximum size of the cache in bytes. Note that we can
 	// be larger than maxCacheSizeBytes temporarily between runs of this handler.
@@ -27,7 +27,7 @@ type cacheEvicter struct {
 var _ goroutine.Handler = &cacheEvicter{}
 var _ goroutine.ErrorHandler = &cacheEvicter{}
 
-func NewCacheEvicter(interval time.Duration, cache *diskcache.Store, maxCacheSizeBytes int64, metrics *Metrics) goroutine.BackgroundRoutine {
+func NewCacheEvicter(interval time.Duration, cache diskcache.Store, maxCacheSizeBytes int64, metrics *Metrics) goroutine.BackgroundRoutine {
 	return goroutine.NewPeriodicGoroutine(context.Background(), interval, &cacheEvicter{
 		cache:             cache,
 		maxCacheSizeBytes: maxCacheSizeBytes,

--- a/cmd/symbols/internal/database/writer/cache.go
+++ b/cmd/symbols/internal/database/writer/cache.go
@@ -17,10 +17,10 @@ type CachedDatabaseWriter interface {
 
 type cachedDatabaseWriter struct {
 	databaseWriter DatabaseWriter
-	cache          *diskcache.Store
+	cache          diskcache.Store
 }
 
-func NewCachedDatabaseWriter(databaseWriter DatabaseWriter, cache *diskcache.Store) CachedDatabaseWriter {
+func NewCachedDatabaseWriter(databaseWriter DatabaseWriter, cache diskcache.Store) CachedDatabaseWriter {
 	return &cachedDatabaseWriter{
 		databaseWriter: databaseWriter,
 		cache:          cache,

--- a/cmd/symbols/main.go
+++ b/cmd/symbols/main.go
@@ -92,11 +92,10 @@ func main() {
 		config.ctagsDebugLogs,
 	)
 
-	cache := &diskcache.Store{
-		Dir:               config.cacheDir,
-		Component:         "symbols",
-		BackgroundTimeout: 20 * time.Minute,
-	}
+	cache := diskcache.NewStore(config.cacheDir, "symbols",
+		diskcache.WithBackgroundTimeout(20*time.Minute),
+		diskcache.WithObservationContext(observationContext),
+	)
 
 	parserPool, err := parser.NewParserPool(ctagsParserFactory, config.numCtagsProcesses)
 	if err != nil {

--- a/internal/diskcache/cache_test.go
+++ b/internal/diskcache/cache_test.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"os"
 	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 func TestOpen(t *testing.T) {
@@ -15,9 +17,10 @@ func TestOpen(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	store := &Store{
-		Dir:       dir,
-		Component: "test",
+	store := &store{
+		dir:       dir,
+		component: "test",
+		observe:   newOperations(&observation.TestContext, "test"),
 	}
 
 	do := func() (*File, bool) {

--- a/internal/diskcache/observability.go
+++ b/internal/diskcache/observability.go
@@ -1,0 +1,45 @@
+package diskcache
+
+import (
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+type operations struct {
+	cachedFetch *observation.Operation
+	evict       *observation.Operation
+}
+
+func newOperations(observationContext *observation.Context, component string) *operations {
+	var m *metrics.REDMetrics
+	if observationContext.Registerer != nil {
+		m = metrics.NewREDMetrics(
+			observationContext.Registerer,
+			"diskcache",
+			metrics.WithLabels("component", "op"),
+		)
+	}
+
+	// we dont enable tracing for evict, as it doesnt take a context.Context
+	// so it cannot be part of a trace
+	evictObservationContext := &observation.Context{
+		Logger:       observationContext.Logger,
+		Registerer:   observationContext.Registerer,
+		HoneyDataset: observationContext.HoneyDataset,
+	}
+
+	op := func(name string, ctx *observation.Context) *observation.Operation {
+		return ctx.Operation(observation.Op{
+			Name:              fmt.Sprintf("diskcache.%s", name),
+			Metrics:           m,
+			MetricLabelValues: []string{component, name},
+		})
+	}
+
+	return &operations{
+		cachedFetch: op("Cached Fetch", observationContext),
+		evict:       op("Evict", evictObservationContext),
+	}
+}

--- a/internal/observation/snakecase.go
+++ b/internal/observation/snakecase.go
@@ -14,6 +14,9 @@ func toSnakeCase(s string) string {
 	dist.Grow(len(s) + len(s)/3) // avoid reallocation memory
 	for i := 0; i < len(s); i++ {
 		cur := s[i]
+		if cur == ' ' {
+			continue
+		}
 		// if - or _: write _
 		if cur == '-' || cur == '_' {
 			dist.WriteByte('_')

--- a/internal/observation/snakecase_test.go
+++ b/internal/observation/snakecase_test.go
@@ -30,6 +30,7 @@ var cases = []struct {
 	{"codeintel.GoodbyeBob", "codeintel.goodbye_bob"},
 	{"CodeInsights.HistoricalEnqueuer", "code_insights.historical_enqueuer"},
 	{"codeintel.autoindex-enqueuer", "codeintel.autoindex_enqueuer"},
+	{"diskcache.Cached Fetch", "diskcache.cached_fetch"},
 }
 
 func TestToSnakeCase(t *testing.T) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -74,7 +74,7 @@ type Store struct {
 	once sync.Once
 
 	// cache is the disk backed cache.
-	cache *diskcache.Store
+	cache diskcache.Store
 
 	// fetchLimiter limits concurrent calls to FetchTar.
 	fetchLimiter *mutablelimiter.Limiter
@@ -94,12 +94,10 @@ type FilterFunc func(hdr *tar.Header) bool
 func (s *Store) Start() {
 	s.once.Do(func() {
 		s.fetchLimiter = mutablelimiter.New(15)
-		s.cache = &diskcache.Store{
-			Dir:               s.Path,
-			Component:         "store",
-			BackgroundTimeout: 10 * time.Minute,
-			BeforeEvict:       s.ZipCache.delete,
-		}
+		s.cache = diskcache.NewStore(s.Path, "store",
+			diskcache.WithBackgroundTimeout(10*time.Minute),
+			diskcache.WithBeforeEvict(s.ZipCache.delete),
+		)
 		_ = os.MkdirAll(s.Path, 0700)
 		metrics.MustRegisterDiskMonitor(s.Path)
 		go s.watchAndEvict()

--- a/internal/store/zipcache.go
+++ b/internal/store/zipcache.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"golang.org/x/sys/unix"
+
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 // A ZipCache is a shared data structure that provides efficient access to a collection of zip files.
@@ -66,7 +68,7 @@ func (c *ZipCache) Get(path string) (*ZipFile, error) {
 	return zf, nil
 }
 
-func (c *ZipCache) delete(path string) {
+func (c *ZipCache) delete(path string, trace observation.TraceLogger) {
 	shard := c.shardFor(path)
 	shard.mu.Lock()
 	defer shard.mu.Unlock()


### PR DESCRIPTION
Brings `internal/diskcache` into the present/future by migrating its use of OpenTracing primitives to the `internal/observation` abstractions. This brings with it opt-in integration with Honeycomb as well as Prometheus.

![Honeycomb example](https://user-images.githubusercontent.com/18282288/145837050-44288b45-0945-4742-aec1-d536c23bdee6.png)
