### PR TITLE
store: move TempZipFromFiles helper to only call site

### DIFF
--- a/internal/store/testutil/zip.go
+++ b/internal/store/testutil/zip.go
@@ -3,10 +3,8 @@ package testutil
 import (
 	"archive/zip"
 	"bytes"
-	"context"
 	"os"
 
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/store"
 )
 
@@ -47,22 +45,6 @@ func MockZipFile(data []byte) (*store.ZipFile, error) {
 	// zf.f is intentionally left nil;
 	// this is an indicator that this is a mock ZipFile.
 	return zf, nil
-}
-
-func TempZipFromFiles(files map[string]string) (path string, cleanup func(), err error) {
-	s, cleanup, err := NewStore(files)
-	if err != nil {
-		return "", cleanup, err
-	}
-
-	ctx := context.Background()
-	repo := api.RepoName("foo")
-	var commit api.CommitID = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
-	path, err = s.PrepareZip(ctx, repo, commit)
-	if err != nil {
-		return "", cleanup, err
-	}
-	return path, cleanup, nil
 }
 
 func TempZipFileOnDisk(data []byte) (string, func(), error) {


### PR DESCRIPTION
This helper was reusing the store to create a zip file on disk. This is
a bit of overkill, so this commit simplifies the function.  Additionally
there is only one call site for this helper, so we can reduce the amount
of exported API.

I also noticed one latent issue where we ignored the errors returned by
the underlying functions we are testing. We now check those errors.
