### PR TITLE
migration: Run migration in server environment

### DIFF
--- a/cmd/server/build.sh
+++ b/cmd/server/build.sh
@@ -62,6 +62,7 @@ PACKAGES=(
   github.com/sourcegraph/sourcegraph/cmd/gitserver
   github.com/sourcegraph/sourcegraph/cmd/searcher
   github.com/sourcegraph/sourcegraph/cmd/symbols
+  github.com/sourcegraph/sourcegraph/cmd/migrator
   github.com/google/zoekt/cmd/zoekt-archive-index
   github.com/google/zoekt/cmd/zoekt-git-index
   github.com/google/zoekt/cmd/zoekt-sourcegraph-indexserver

--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -4,7 +4,6 @@
 package shared
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"flag"
@@ -252,13 +251,12 @@ func startProcesses(group *errgroup.Group, name string, procfile []string, optio
 func runMigrator() {
 	log.Println("Starting migrator")
 
-	var output bytes.Buffer
-	e := execer{Out: &output}
-
 	for _, schemaName := range []string{"frontend", "codeintel"} {
+		e := execer{}
 		e.Command("migrator", "up", "-db", schemaName)
+
 		if err := e.Error(); err != nil {
-			pgPrintf("Migrating %s schema failed:\n%s", schemaName, output.String())
+			pgPrintf("Migrating %s schema failed%s", schemaName)
 			log.Fatal(err.Error())
 		}
 	}

--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -4,6 +4,8 @@
 package shared
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -14,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/joho/godotenv"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/postgresdsn"
 	"github.com/sourcegraph/sourcegraph/internal/goreman"
@@ -174,15 +177,27 @@ func Main() {
 		procfile = append(procfile, redisCacheLine)
 	}
 
+	procfile = append(procfile, maybeZoektProcFile()...)
+
+	var (
+		postgresProcfile []string
+		restore, _       = strconv.ParseBool(os.Getenv("PGRESTORE"))
+	)
+
 	postgresLine, err := maybePostgresProcFile()
 	if err != nil {
 		log.Fatal(err)
 	}
 	if postgresLine != "" {
-		procfile = append(procfile, postgresLine)
+		if restore {
+			// If in restore mode, only run PostgreSQL
+			procfile = []string{postgresLine}
+		} else {
+			postgresProcfile = append(postgresProcfile, postgresLine)
+		}
+	} else if restore {
+		log.Fatal("PGRESTORE is set but a local Postgres instance is not configured")
 	}
-
-	procfile = append(procfile, maybeZoektProcFile()...)
 
 	// Shutdown if any process dies
 	procDiedAction := goreman.Shutdown
@@ -194,17 +209,59 @@ func Main() {
 		procDiedAction = goreman.Ignore
 	}
 
-	// If in restore mode, only run PostgreSQL
-	if restore, _ := strconv.ParseBool(os.Getenv("PGRESTORE")); restore {
-		procfile = []string{}
-		procfile = append(procfile, postgresLine)
+	runMigrations := !restore
+	run(procfile, postgresProcfile, runMigrations, procDiedAction)
+}
+
+func run(procfile, postgresProcfile []string, runMigrations bool, procDiedAction goreman.ProcDiedAction) {
+	if !runMigrations {
+		procfile = append(procfile, postgresProcfile...)
+		postgresProcfile = nil
 	}
 
-	err = goreman.Start([]byte(strings.Join(procfile, "\n")), goreman.Options{
+	group, _ := errgroup.WithContext(context.Background())
+
+	options := goreman.Options{
 		RPCAddr:        "127.0.0.1:5005",
 		ProcDiedAction: procDiedAction,
-	})
-	if err != nil {
+	}
+	startProcesses(group, "postgres", postgresProcfile, options)
+
+	if runMigrations {
+		// Run migrations before starting up the application but after
+		// starting any postgres instance within the server container.
+		runMigrator()
+	}
+
+	startProcesses(group, "all", procfile, options)
+
+	if err := group.Wait(); err != nil {
 		log.Fatal(err)
 	}
+}
+
+func startProcesses(group *errgroup.Group, name string, procfile []string, options goreman.Options) {
+	if len(procfile) == 0 {
+		return
+	}
+
+	log.Printf("Starting %s processes", name)
+	group.Go(func() error { return goreman.Start([]byte(strings.Join(procfile, "\n")), options) })
+}
+
+func runMigrator() {
+	log.Println("Starting migrator")
+
+	var output bytes.Buffer
+	e := execer{Out: &output}
+
+	for _, schemaName := range []string{"frontend", "codeintel"} {
+		e.Command("migrator", "up", "-db", schemaName)
+		if err := e.Error(); err != nil {
+			pgPrintf("Migrating %s schema failed:\n%s", schemaName, output.String())
+			log.Fatal(err.Error())
+		}
+	}
+
+	log.Println("Migrated postgres schemas.")
 }


### PR DESCRIPTION
Run the `migrator` on server startup. Instead of running all processes at once, we start the Postgres process (if one is defined), then run the migrator service as part of synchronous setup.

Once the migrations are complete, the remaining services are added to the goreman process watcher and the application boots as normal. Goreman behavior was altered to support this use case in #28952.