### PR TITLE
Code Insights: Fix problem with lang stats creation through all insights dashboard

### DIFF
--- a/client/web/src/enterprise/insights/core/backend/gql-api/code-insights-gql-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-api/code-insights-gql-backend.ts
@@ -190,7 +190,7 @@ export class CodeInsightsGqlBackend implements CodeInsightsBackend {
     public getDashboardById = (input: { dashboardId: string | undefined }): Observable<InsightDashboard | null> => {
         const { dashboardId } = input
 
-        // the 'all' dashboardId is not a real dashboard so return early
+        // the 'all' dashboardId is not a real dashboard so return nothing
         if (dashboardId === ALL_INSIGHTS_DASHBOARD_ID) {
             return of(null)
         }

--- a/client/web/src/enterprise/insights/core/backend/gql-api/methods/create-insight/serializators.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-api/methods/create-insight/serializators.ts
@@ -80,6 +80,7 @@ export function getSearchInsightCreateInput(
     if (dashboard && !isVirtualDashboard(dashboard)) {
         input.dashboards = [dashboard.id]
     }
+
     return input
 }
 
@@ -87,7 +88,7 @@ export function getLangStatsInsightCreateInput(
     insight: LangStatsInsight,
     dashboard: InsightDashboard | null
 ): PieChartSearchInsightInput {
-    return {
+    const input: PieChartSearchInsightInput = {
         // Query do not exist as setting for this type of insight, it's predefined
         // and locked on BE.
         // TODO: Remove this field as soon as BE removes this from GQL api.
@@ -97,6 +98,11 @@ export function getLangStatsInsightCreateInput(
             title: insight.title,
             otherThreshold: insight.otherThreshold,
         },
-        dashboards: [dashboard?.id ?? ''],
     }
+
+    if (dashboard && !isVirtualDashboard(dashboard)) {
+        input.dashboards = [dashboard.id]
+    }
+
+    return input
 }

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/hooks/use-dashboard-select-handler.ts
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/hooks/use-dashboard-select-handler.ts
@@ -14,7 +14,7 @@ export function useDashboardSelectHandler(): SelectHandler {
 
     return (dashboard: InsightDashboard): void => {
         if (isVirtualDashboard(dashboard)) {
-            history.push(`/insights/dashboards/${dashboard.type}`)
+            history.push(`/insights/dashboards/${dashboard.id}`)
 
             return
         }

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/utils/find-dashboard-by-url-id.ts
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/utils/find-dashboard-by-url-id.ts
@@ -13,9 +13,7 @@ export function findDashboardByUrlId(
 ): InsightDashboard | undefined {
     return dashboards.find(dashboard => {
         if (isVirtualDashboard(dashboard)) {
-            return (
-                dashboard.id === dashboardID.toLowerCase() || dashboard.type.toLowerCase() === dashboardID.toLowerCase()
-            )
+            return dashboard.id === dashboardID.toLowerCase()
         }
 
         return (


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/28925

This PR adds logic to lang stats creation to omit all insights dashboard in the `dashboard` field in the lang stats mutation variables field.

It also changes the virtual URL id resolving logic. This PR removes checks by dashboard type and uses only one way to check dashboard existing - its id.