### PR TITLE
Revert "featureflag: allow overriding FlagSet in tests (#28919)"

### DIFF
--- a/internal/featureflag/middleware.go
+++ b/internal/featureflag/middleware.go
@@ -11,7 +11,6 @@ import (
 )
 
 type flagContextKey struct{}
-type flagSetFetcher func(ctx context.Context) FlagSet
 
 type Store interface {
 	GetUserFlags(context.Context, int32) (map[string]bool, error)
@@ -29,59 +28,56 @@ func Middleware(ffs Store, next http.Handler) http.Handler {
 }
 
 func contextWithFeatureFlags(ffs Store, r *http.Request) context.Context {
-	var (
-		once    sync.Once
-		flagSet FlagSet
-	)
-	// fetcher is a lazy fetcher for a FlagSet, given an *http.Request. It
-	// will fetch the flags as required, once they're loaded from the
-	// context. This pattern prevents us from loading feature flags on every
-	// request, even when we don't end up using them.
-	fetcher := func(ctx context.Context) FlagSet {
-		once.Do(func() {
-			if a := actor.FromContext(ctx); a.IsAuthenticated() {
-				flags, err := ffs.GetUserFlags(ctx, a.UID)
-				if err == nil {
-					flagSet = FlagSet(flags)
-					return
-				}
-				// Continue if err != nil
-			}
-
-			if uid, ok := cookie.AnonymousUID(r); ok {
-				flags, err := ffs.GetAnonymousUserFlags(ctx, uid)
-				if err == nil {
-					flagSet = FlagSet(flags)
-					return
-				}
-				// Continue if err != nil
-			}
-
-			flags, err := ffs.GetGlobalFeatureFlags(ctx)
-			if err == nil {
-				flagSet = FlagSet(flags)
-			}
-		})
-
-		return flagSet
-	}
+	fetcher := &flagSetFetcher{ffs: ffs, r: r}
 	return context.WithValue(r.Context(), flagContextKey{}, fetcher)
+}
+
+// flagSetFetcher is a lazy fetcher for a FlagSet, given an *http.Request. It
+// will fetch the flags as required, once they're loaded from the context. This
+// pattern prevents us from loading feature flags on every request, even when
+// we don't end up using them.
+type flagSetFetcher struct {
+	r   *http.Request
+	ffs Store
+
+	once    sync.Once
+	flagSet FlagSet
+}
+
+func (f *flagSetFetcher) Fetch(ctx context.Context) FlagSet {
+	f.once.Do(func() {
+		if a := actor.FromContext(ctx); a.IsAuthenticated() {
+			flags, err := f.ffs.GetUserFlags(ctx, a.UID)
+			if err == nil {
+				f.flagSet = FlagSet(flags)
+				return
+			}
+			// Continue if err != nil
+		}
+
+		if uid, ok := cookie.AnonymousUID(f.r); ok {
+			flags, err := f.ffs.GetAnonymousUserFlags(ctx, uid)
+			if err == nil {
+				f.flagSet = FlagSet(flags)
+				return
+			}
+			// Continue if err != nil
+		}
+
+		flags, err := f.ffs.GetGlobalFeatureFlags(ctx)
+		if err == nil {
+			f.flagSet = FlagSet(flags)
+		}
+	})
+
+	return f.flagSet
 }
 
 // FromContext retrieves the current set of flags from the current
 // request's context.
 func FromContext(ctx context.Context) FlagSet {
 	if flags := ctx.Value(flagContextKey{}); flags != nil {
-		return flags.(flagSetFetcher)(ctx)
+		return flags.(*flagSetFetcher).Fetch(ctx)
 	}
 	return nil
-}
-
-// TestSetFlagsOnContext sets the flags on ctx. This should only be used by
-// tests. In non-test code you should rely on the store and middleware.
-func TestSetFlagsOnContext(ctx context.Context, flags FlagSet) context.Context {
-	fetcher := func(ctx context.Context) FlagSet {
-		return flags
-	}
-	return context.WithValue(ctx, flagContextKey{}, fetcher)
 }


### PR DESCRIPTION
This reverts commit 92429cd8d44f9a755b4a483c56ee4a604086fd83.

This PR panics in dev, so maybe it'll also fail in prod (?).

```
[enterprise-frontend] graphql: panic occurred: interface conversion: interface {} is func(context.Context) featureflag.FlagSet, not featureflag.flagSetFetcher
[enterprise-frontend] goroutine 3503 [running]:
[enterprise-frontend] github.com/graph-gophers/graphql-go/log.(*DefaultLogger).LogPanic(0x6d0a4e8, {0x5150a88, 0xc001e16c00}, {0x46b33a0, 0xc001e16c60})
[enterprise-frontend]   /Users/erik/Code/go/pkg/mod/github.com/graph-gophers/graphql-go@v1.2.0/log/log.go:21 +0x8b
[enterprise-frontend] github.com/graph-gophers/graphql-go/internal/exec.execFieldSelection.func2.1()
[enterprise-frontend]   /Users/erik/Code/go/pkg/mod/github.com/graph-gophers/graphql-go@v1.2.0/internal/exec/exec.go:190 +0xa8
[enterprise-frontend] panic({0x46b33a0, 0xc001e16c60})
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/runtime/panic.go:1047 +0x262
[enterprise-frontend] github.com/sourcegraph/sourcegraph/internal/featureflag.FromContext({0x5150a88, 0xc001e16c00})
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/internal/featureflag/middleware.go:75 +0xbb
[enterprise-frontend] github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend.(*schemaResolver).ViewerFeatureFlags(0xc00031e900, {0x5150a88, 0xc001e16c00})
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/feature_flags.go:130 +0x45
[enterprise-frontend] reflect.Value.call({0x4add5e0, 0xc00031e900, 0x34a13}, {0x4ae7a4d, 0x4}, {0xc0008d0c00, 0x1, 0x1})
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/reflect/value.go:543 +0xc05
[enterprise-frontend] reflect.Value.Call({0x4add5e0, 0xc00031e900, 0x34a13}, {0xc0008d0c00, 0x1, 0x1})
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/reflect/value.go:339 +0xb7
[enterprise-frontend] github.com/graph-gophers/graphql-go/internal/exec.execFieldSelection.func2(0xc000942070, {0x5150a88, 0xc001e16c00}, 0xc0008d0be8, 0xc002608400, 0xc002b27d78, {0x5150a88, 0xc001e16c00})
[enterprise-frontend]   /Users/erik/Code/go/pkg/mod/github.com/graph-gophers/graphql-go@v1.2.0/internal/exec/exec.go:214 +0x6dd
[enterprise-frontend] github.com/graph-gophers/graphql-go/internal/exec.execFieldSelection({0x5150a88, 0xc001e16c00}, 0xc000942070, 0xc0000ec620, 0xc002608400, 0xc0008d0be8, 0x1)
[enterprise-frontend]   /Users/erik/Code/go/pkg/mod/github.com/graph-gophers/graphql-go@v1.2.0/internal/exec/exec.go:234 +0x2f4
[enterprise-frontend] github.com/graph-gophers/graphql-go/internal/exec.(*Request).execSelections.func1(0xc002608400)
[enterprise-frontend]   /Users/erik/Code/go/pkg/mod/github.com/graph-gophers/graphql-go@v1.2.0/internal/exec/exec.go:84 +0x2c5
[enterprise-frontend] created by github.com/graph-gophers/graphql-go/internal/exec.(*Request).execSelections
[enterprise-frontend]   /Users/erik/Code/go/pkg/mod/github.com/graph-gophers/graphql-go@v1.2.0/internal/exec/exec.go:80 +0x878
[enterprise-frontend] context: context.Background.WithValue(type *http.contextKey, val <not Stringer>).WithValue(type *http.contextKey, val [::1]:3082).WithCancel.WithCancel.WithValue(type ot.key, val <not Stringer>).WithValue(type opentracing.contextKey, val <not Stringer>).WithValue(type opentracing.contextKey, val <not Stringer>).WithValue(type trace.key, val <not Stringer>).WithValue(type trace.key, val <not Stringer>).WithValue(type trace.key, val <not Stringer>).WithValue(type trace.key, val unknown).WithValue(type sessions.contextKey, val <not Stringer>).WithValue(type actor.contextKey, val Actor UID 1, internal false).WithValue(type featureflag.flagContextKey, val <not Stringer>).WithValue(type mux.contextKey, val <not Stringer>).WithValue(type mux.contextKey, val <not Stringer>).WithValue(type trace.key, val FetchFeatureFlags).WithValue(type trace.key, val <not Stringer>).WithValue(type trace.key, val 
[enterprise-frontend]                 query FetchFeatureFlags {
[enterprise-frontend]                     viewerFeatureFlags {
[enterprise-frontend]                         name
[enterprise-frontend]                         value
[enterprise-frontend]                     }
[enterprise-frontend]                 }
[enterprise-frontend]             )
[enterprise-frontend] graphql: panic occurred: interface conversion: interface {} is func(context.Context) featureflag.FlagSet, not featureflag.flagSetFetcher
[enterprise-frontend] goroutine 464 [running]:
[enterprise-frontend] github.com/graph-gophers/graphql-go/log.(*DefaultLogger).LogPanic(0x6d0a4e8, {0x5150a88, 0xc00244b380}, {0x46b33a0, 0xc00244b4a0})
[enterprise-frontend]   /Users/erik/Code/go/pkg/mod/github.com/graph-gophers/graphql-go@v1.2.0/log/log.go:21 +0x8b
[enterprise-frontend] github.com/graph-gophers/graphql-go/internal/exec.execFieldSelection.func2.1()
[enterprise-frontend]   /Users/erik/Code/go/pkg/mod/github.com/graph-gophers/graphql-go@v1.2.0/internal/exec/exec.go:190 +0xa8
[enterprise-frontend] panic({0x46b33a0, 0xc00244b4a0})
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/runtime/panic.go:1047 +0x262
[enterprise-frontend] github.com/sourcegraph/sourcegraph/internal/featureflag.FromContext({0x5150a88, 0xc00244b380})
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/internal/featureflag/middleware.go:75 +0xbb
[enterprise-frontend] github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend.(*schemaResolver).LogEvents(0xc00031e900, {0x5150a88, 0xc00244b380}, 0xc001e1e590)
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/user_usage_stats.go:164 +0x825
[enterprise-frontend] reflect.Value.call({0x4add5e0, 0xc00031e900, 0x18213}, {0x4ae7a4d, 0x4}, {0xc00244b470, 0x2, 0x2})
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/reflect/value.go:543 +0xc05
[enterprise-frontend] reflect.Value.Call({0x4add5e0, 0xc00031e900, 0x18213}, {0xc00244b470, 0x2, 0x2})
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/reflect/value.go:339 +0xb7
[enterprise-frontend] github.com/graph-gophers/graphql-go/internal/exec.execFieldSelection.func2(0xc000239180, {0x5150a88, 0xc00244b380}, 0xc00234cf60, 0xc002901680, 0xc002abe9c8, {0x5150a88, 0xc00244b380})
[enterprise-frontend]   /Users/erik/Code/go/pkg/mod/github.com/graph-gophers/graphql-go@v1.2.0/internal/exec/exec.go:214 +0x6dd
[enterprise-frontend] github.com/graph-gophers/graphql-go/internal/exec.execFieldSelection({0x5150a88, 0xc00244b380}, 0xc000239180, 0xc0000ec620, 0xc002901680, 0xc00234cf60, 0x1)
[enterprise-frontend]   /Users/erik/Code/go/pkg/mod/github.com/graph-gophers/graphql-go@v1.2.0/internal/exec/exec.go:234 +0x2f4
[enterprise-frontend] github.com/graph-gophers/graphql-go/internal/exec.(*Request).execSelections(0xc000239180, {0x5150a88, 0xc00244b380}, {0xc001680d30, 0x1, 0x1}, 0x0, 0xc0000ec620, {0x4add5e0, 0xc00031e900, ...}, ...)
[enterprise-frontend]   /Users/erik/Code/go/pkg/mod/github.com/graph-gophers/graphql-go@v1.2.0/internal/exec/exec.go:91 +0x3d9
[enterprise-frontend] github.com/graph-gophers/graphql-go/internal/exec.(*Request).Execute.func1(0xc000239180, {0x5150a88, 0xc00244b380}, 0xc0000ec620, 0xc0021893b0, 0xc002abef20)
[enterprise-frontend]   /Users/erik/Code/go/pkg/mod/github.com/graph-gophers/graphql-go@v1.2.0/internal/exec/exec.go:49 +0x394
[enterprise-frontend] github.com/graph-gophers/graphql-go/internal/exec.(*Request).Execute(0xc000239180, {0x5150a88, 0xc00244b380}, 0xc0000ec620, 0xc0021893b0)
[enterprise-frontend]   /Users/erik/Code/go/pkg/mod/github.com/graph-gophers/graphql-go@v1.2.0/internal/exec/exec.go:50 +0xd4
[enterprise-frontend] github.com/graph-gophers/graphql-go.(*Schema).exec(0xc0014ddbc0, {0x5150a88, 0xc00244a840}, {0xc0015ae700, 0x78}, {0xc0039db4c0, 0x9}, 0xc00244a900, 0xc0000ec620)
[enterprise-frontend]   /Users/erik/Code/go/pkg/mod/github.com/graph-gophers/graphql-go@v1.2.0/graphql.go:260 +0x14d8
[enterprise-frontend] github.com/graph-gophers/graphql-go.(*Schema).Exec(0xc0014ddbc0, {0x5150a88, 0xc00244a840}, {0xc0015ae700, 0x78}, {0x0, 0x0}, 0xc00244a900)
[enterprise-frontend]   /Users/erik/Code/go/pkg/mod/github.com/graph-gophers/graphql-go@v1.2.0/graphql.go:193 +0x125
[enterprise-frontend] github.com/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi.serveGraphQL.func1({0x512e8f0, 0xc000238150}, 0xc0024fca00)
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi/graphql.go:114 +0xf1c
[enterprise-frontend] github.com/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi.jsonMiddleware.func1.1({0x512e8f0, 0xc000238150}, 0xc0024fc700)
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi/httpapi.go:223 +0x90
[enterprise-frontend] github.com/sourcegraph/sourcegraph/cmd/frontend/internal/handlerutil.HandlerWithErrorReturn.ServeHTTP({0xc001603e30, 0xc001603e50, 0x0}, {0x512e8f0, 0xc000238150}, 0xc0024fc700)
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/cmd/frontend/internal/handlerutil/handler.go:53 +0x175
[enterprise-frontend] github.com/sourcegraph/sourcegraph/internal/trace.Route.func1({0x512e8f0, 0xc000238150}, 0xc0024fc700)
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/internal/trace/httptrace.go:282 +0x16c
[enterprise-frontend] net/http.HandlerFunc.ServeHTTP(0xc00088d3e0, {0x512e8f0, 0xc000238150}, 0xc0024fc700)
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x43
[enterprise-frontend] github.com/gorilla/mux.(*Router).ServeHTTP(0xc00031e6c0, {0x512e8f0, 0xc000238150}, 0xc0024fc700)
[enterprise-frontend]   /Users/erik/Code/go/pkg/mod/github.com/gorilla/mux@v1.8.0/mux.go:210 +0x262
[enterprise-frontend] github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/authz.Init.func6.1({0x512e8f0, 0xc000238150}, 0xc0024fc500)
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/authz/init.go:132 +0x505
[enterprise-frontend] net/http.HandlerFunc.ServeHTTP(0xc00252b680, {0x512e8f0, 0xc000238150}, 0xc0024fc500)
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x43
[enterprise-frontend] github.com/sourcegraph/sourcegraph/internal/featureflag.Middleware.func1({0x512e8f0, 0xc000238150}, 0xc0024fc400)
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/internal/featureflag/middleware.go:27 +0xf5
[enterprise-frontend] net/http.HandlerFunc.ServeHTTP(0xc00234fb90, {0x512e8f0, 0xc000238150}, 0xc0024fc400)
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x43
[enterprise-frontend] github.com/sourcegraph/sourcegraph/cmd/frontend/auth.glob..func1.1({0x512e8f0, 0xc000238150}, 0xc0024fc400)
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/cmd/frontend/auth/non_public.go:36 +0x106
[enterprise-frontend] net/http.HandlerFunc.ServeHTTP(0xc00088d4b8, {0x512e8f0, 0xc000238150}, 0xc0024fc400)
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x43
[enterprise-frontend] github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/openidconnect.handleOpenIDConnectAuth({0x51e51a0, 0xc00013f120}, {0x512e8f0, 0xc000238150}, 0xc0024fc400, {0x50f84a0, 0xc00088d4b8}, 0x1)
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/openidconnect/middleware.go:88 +0x4cf
[enterprise-frontend] github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/openidconnect.Middleware.func1.1({0x512e8f0, 0xc000238150}, 0xc0024fc400)
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/openidconnect/middleware.go:56 +0x71
[enterprise-frontend] net/http.HandlerFunc.ServeHTTP(0xc00234fbc0, {0x512e8f0, 0xc000238150}, 0xc0024fc400)
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x43
[enterprise-frontend] github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/saml.authHandler({0x51e51a0, 0xc00013f120}, {0x512e8f0, 0xc000238150}, 0xc0024fc400, {0x50f84a0, 0xc00234fbc0}, 0x1)
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/saml/middleware.go:56 +0x183
[enterprise-frontend] github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/saml.Middleware.func1.1({0x512e8f0, 0xc000238150}, 0xc0024fc400)
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/saml/middleware.go:32 +0x71
[enterprise-frontend] net/http.HandlerFunc.ServeHTTP(0xc00234fbf0, {0x512e8f0, 0xc000238150}, 0xc0024fc400)
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x43
[enterprise-frontend] github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/httpheader.middleware.func1.1({0x512e8f0, 0xc000238150}, 0xc0024fc400)
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/httpheader/middleware.go:50 +0xf15
[enterprise-frontend] net/http.HandlerFunc.ServeHTTP(0xc00234fc20, {0x512e8f0, 0xc000238150}, 0xc0024fc400)
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x43
[enterprise-frontend] github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/oauth.NewHandler.func1({0x512e8f0, 0xc000238150}, 0xc0024fc400)
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/oauth/middleware.go:42 +0x203
[enterprise-frontend] net/http.HandlerFunc.ServeHTTP(0xc00252b740, {0x512e8f0, 0xc000238150}, 0xc0024fc400)
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x43
[enterprise-frontend] github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/oauth.NewHandler.func1({0x512e8f0, 0xc000238150}, 0xc0024fc400)
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/oauth/middleware.go:42 +0x203
[enterprise-frontend] net/http.HandlerFunc.ServeHTTP(0xc00252b7c0, {0x512e8f0, 0xc000238150}, 0xc0024fc400)
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x43
[enterprise-frontend] github.com/sourcegraph/sourcegraph/cmd/frontend/internal/session.CookieMiddlewareWithCSRFSafety.func1({0x512e8f0, 0xc000238150}, 0xc0024fc400)
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/cmd/frontend/internal/session/session.go:327 +0x1c7
[enterprise-frontend] net/http.HandlerFunc.ServeHTTP(0xc00252b800, {0x512e8f0, 0xc000238150}, 0xc0024fc200)
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x43
[enterprise-frontend] github.com/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi.AccessTokenAuthMiddleware.func1({0x512e8f0, 0xc000238150}, 0xc0024fc200)
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi/auth.go:119 +0x16ca
[enterprise-frontend] net/http.HandlerFunc.ServeHTTP(0xc00234fe00, {0x512e8f0, 0xc000238150}, 0xc0024fc200)
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x43
[enterprise-frontend] github.com/NYTimes/gziphandler.GzipHandlerWithOpts.func1.1({0x512fd30, 0xc001e40ea0}, 0xc0024fc200)
[enterprise-frontend]   /Users/erik/Code/go/pkg/mod/github.com/!n!y!times/gziphandler@v1.1.1/gzip.go:336 +0x2c8
[enterprise-frontend] net/http.HandlerFunc.ServeHTTP(0xc00234ff20, {0x512fd30, 0xc001e40ea0}, 0xc0024fc200)
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x43
[enterprise-frontend] github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cli.secureHeadersMiddleware.func1({0x512fd30, 0xc001e40ea0}, 0xc0024fc200)
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/cmd/frontend/internal/cli/http.go:189 +0x171
[enterprise-frontend] net/http.HandlerFunc.ServeHTTP(0xc00237f7d0, {0x512fd30, 0xc001e40ea0}, 0xc0024fc200)
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x43
[enterprise-frontend] net/http.(*ServeMux).ServeHTTP(0xc001f11a40, {0x512fd30, 0xc001e40ea0}, 0xc0024fc200)
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/net/http/server.go:2424 +0x135
[enterprise-frontend] github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cli/middleware.Trace.func1({0x512fd30, 0xc001e40ea0}, 0xc0024fc200)
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/cmd/frontend/internal/cli/middleware/trace.go:27 +0x393
[enterprise-frontend] net/http.HandlerFunc.ServeHTTP(0xc00088dd10, {0x512fd30, 0xc001e40ea0}, 0xc0024fc200)
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x43
[enterprise-frontend] github.com/gorilla/context.ClearHandler.func1({0x512fd30, 0xc001e40ea0}, 0xc0024fc200)
[enterprise-frontend]   /Users/erik/Code/go/pkg/mod/github.com/gorilla/context@v1.1.1/context.go:141 +0xe6
[enterprise-frontend] net/http.HandlerFunc.ServeHTTP(0xc00088dd28, {0x512fd30, 0xc001e40ea0}, 0xc0024fc200)
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x43
[enterprise-frontend] github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cli.healthCheckMiddleware.func1({0x512fd30, 0xc001e40ea0}, 0xc0024fc200)
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/cmd/frontend/internal/cli/http.go:110 +0x22d
[enterprise-frontend] net/http.HandlerFunc.ServeHTTP(0xc00088dd40, {0x512fd30, 0xc001e40ea0}, 0xc0024fc200)
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x43
[enterprise-frontend] github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cli/middleware.BlackHole.func1({0x512fd30, 0xc001e40ea0}, 0xc0024fc200)
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/cmd/frontend/internal/cli/middleware/blackhole.go:17 +0xa9
[enterprise-frontend] net/http.HandlerFunc.ServeHTTP(0xc00088dd58, {0x512fd30, 0xc001e40ea0}, 0xc0024fc200)
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x43
[enterprise-frontend] github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cli/middleware.SourcegraphComGoGetHandler.func1({0x512fd30, 0xc001e40ea0}, 0xc0024fc200)
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/cmd/frontend/internal/cli/middleware/goimportpath.go:49 +0xed
[enterprise-frontend] net/http.HandlerFunc.ServeHTTP(0xc00088dd70, {0x512fd30, 0xc001e40ea0}, 0xc0024fc200)
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x43
[enterprise-frontend] github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth.ForbidAllRequestsMiddleware.func1({0x512fd30, 0xc001e40ea0}, 0xc0024fc200)
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/cmd/frontend/internal/auth/forbid_all.go:19 +0xa3
[enterprise-frontend] net/http.HandlerFunc.ServeHTTP(0xc00088dd88, {0x512fd30, 0xc001e40ea0}, 0xc0024fc200)
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x43
[enterprise-frontend] github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth.OverrideAuthMiddleware.func1({0x512fd30, 0xc001e40ea0}, 0xc0024fc200)
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/cmd/frontend/internal/auth/override.go:82 +0xc14
[enterprise-frontend] net/http.HandlerFunc.ServeHTTP(0xc00237f8c0, {0x512fd30, 0xc001e40ea0}, 0xc0024fc200)
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x43
[enterprise-frontend] github.com/felixge/httpsnoop.CaptureMetrics.func1({0x512fd30, 0xc001e40ea0})
[enterprise-frontend]   /Users/erik/Code/go/pkg/mod/github.com/felixge/httpsnoop@v1.0.2/capture_metrics.go:29 +0x55
[enterprise-frontend] github.com/felixge/httpsnoop.CaptureMetricsFn({0x512e710, 0xc002278700}, 0xc002ac2300)
[enterprise-frontend]   /Users/erik/Code/go/pkg/mod/github.com/felixge/httpsnoop@v1.0.2/capture_metrics.go:76 +0x302
[enterprise-frontend] github.com/felixge/httpsnoop.CaptureMetrics({0x50f84a0, 0xc00237f8c0}, {0x512e710, 0xc002278700}, 0xc0024fc200)
[enterprise-frontend]   /Users/erik/Code/go/pkg/mod/github.com/felixge/httpsnoop@v1.0.2/capture_metrics.go:28 +0xb8
[enterprise-frontend] github.com/sourcegraph/sourcegraph/internal/trace.HTTPMiddleware.func1({0x512e710, 0xc002278700}, 0xc0024fc100)
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/internal/trace/httptrace.go:179 +0x985
[enterprise-frontend] net/http.HandlerFunc.ServeHTTP(0xc00237f8f0, {0x512e710, 0xc002278700}, 0xc0024fc100)
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x43
[enterprise-frontend] github.com/sourcegraph/sourcegraph/internal/sentry.Recoverer.func1({0x512e710, 0xc002278700}, 0xc0024fc100)
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/internal/sentry/sentry.go:135 +0xf3
[enterprise-frontend] net/http.HandlerFunc.ServeHTTP(0xc00088dda0, {0x512e710, 0xc002278700}, 0xc0024fc100)
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x43
[enterprise-frontend] github.com/opentracing-contrib/go-stdlib/nethttp.MiddlewareFunc.func5({0x512e710, 0xc002278700}, 0xc0024fc100)
[enterprise-frontend]   /Users/erik/Code/go/pkg/mod/github.com/opentracing-contrib/go-stdlib@v1.0.0/nethttp/server.go:119 +0x546
[enterprise-frontend] net/http.HandlerFunc.ServeHTTP(0xc001f11ac0, {0x512e710, 0xc002278700}, 0xc0024fc100)
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x43
[enterprise-frontend] github.com/sourcegraph/sourcegraph/internal/trace/ot.MiddlewareWithTracer.func2({0x512e710, 0xc002278700}, 0xc0024fc000)
[enterprise-frontend]   /Users/erik/Code/sourcegraph/sourcegraph/internal/trace/ot/ot.go:70 +0x21e
[enterprise-frontend] net/http.HandlerFunc.ServeHTTP(0xc00088ddd0, {0x512e710, 0xc002278700}, 0xc0024fc000)
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/net/http/server.go:2046 +0x43
[enterprise-frontend] net/http.serverHandler.ServeHTTP({0xc0000ec7e0}, {0x512e710, 0xc002278700}, 0xc0024fc000)
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/net/http/server.go:2878 +0x47a
[enterprise-frontend] net/http.(*conn).serve(0xc0013385a0, {0x51509e0, 0xc0014db440})
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/net/http/server.go:1929 +0x18b8
[enterprise-frontend] created by net/http.(*Server).Serve
[enterprise-frontend]   /usr/local/Cellar/go/1.17.3/libexec/src/net/http/server.go:3033 +0xa38
[enterprise-frontend] context: context.Background.WithValue(type *http.contextKey, val <not Stringer>).WithValue(type *http.contextKey, val [::1]:3082).WithCancel.WithCancel.WithValue(type ot.key, val <not Stringer>).WithValue(type opentracing.contextKey, val <not Stringer>).WithValue(type opentracing.contextKey, val <not Stringer>).WithValue(type trace.key, val <not Stringer>).WithValue(type trace.key, val <not Stringer>).WithValue(type trace.key, val <not Stringer>).WithValue(type trace.key, val unknown).WithValue(type sessions.contextKey, val <not Stringer>).WithValue(type actor.contextKey, val Actor UID 1, internal false).WithValue(type featureflag.flagContextKey, val <not Stringer>).WithValue(type mux.contextKey, val <not Stringer>).WithValue(type mux.contextKey, val <not Stringer>).WithValue(type trace.key, val LogEvents).WithValue(type trace.key, val <not Stringer>).WithValue(type trace.key, val 
[enterprise-frontend]     mutation LogEvents($events: [Event!]) {
[enterprise-frontend]         logEvents(events: $events) {
[enterprise-frontend]             alwaysNil
[enterprise-frontend]         }
[enterprise-frontend]     }
```