### PR TITLE
ssbc: Fix empty batch change state in API and UI

### DIFF
--- a/client/web/src/enterprise/batches/BatchSpec.tsx
+++ b/client/web/src/enterprise/batches/BatchSpec.tsx
@@ -76,7 +76,7 @@ export const BatchSpecMeta: React.FunctionComponent<BatchSpecMetaProps> = ({
 }) => (
     <p className="mb-2">
         {lastApplier ? <Link to={lastApplier.url}>{lastApplier.username}</Link> : 'A deleted user'}{' '}
-        {createdAt === lastAppliedAt ? 'created' : 'updated'} this batch change <Timestamp date={lastAppliedAt} /> by
-        applying the following batch spec:
+        {createdAt === lastAppliedAt ? 'created' : 'updated'} this batch change{' '}
+        <Timestamp date={lastAppliedAt ?? createdAt} /> by applying the following batch spec:
     </p>
 )

--- a/client/web/src/enterprise/batches/close/BatchChangeClosePage.story.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeClosePage.story.tsx
@@ -45,7 +45,7 @@ const batchChangeDefaults: BatchChangeFields = {
         unpublished: 4,
     },
     createdAt: subDays(now, 5).toISOString(),
-    initialApplier: {
+    creator: {
         url: '/users/alice',
         username: 'alice',
     },

--- a/client/web/src/enterprise/batches/close/BatchChangeClosePage.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeClosePage.tsx
@@ -121,7 +121,7 @@ export const BatchChangeClosePage: React.FunctionComponent<BatchChangeClosePageP
                 byline={
                     <BatchChangeInfoByline
                         createdAt={batchChange.createdAt}
-                        initialApplier={batchChange.initialApplier}
+                        creator={batchChange.creator}
                         lastAppliedAt={batchChange.lastAppliedAt}
                         lastApplier={batchChange.lastApplier}
                     />

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.mock.ts
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.mock.ts
@@ -28,7 +28,7 @@ export const MOCK_BATCH_CHANGE: BatchChangeFields = {
         unpublished: 4,
     },
     createdAt: subDays(now, 5).toISOString(),
-    initialApplier: {
+    creator: {
         url: '/users/alice',
         username: 'alice',
     },

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
@@ -114,7 +114,7 @@ export const BatchChangeDetailsPage: React.FunctionComponent<BatchChangeDetailsP
                 byline={
                     <BatchChangeInfoByline
                         createdAt={batchChange.createdAt}
-                        initialApplier={batchChange.initialApplier}
+                        creator={batchChange.creator}
                         lastAppliedAt={batchChange.lastAppliedAt}
                         lastApplier={batchChange.lastApplier}
                     />

--- a/client/web/src/enterprise/batches/detail/BatchChangeInfoByline.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeInfoByline.story.tsx
@@ -18,9 +18,23 @@ add('Never updated', () => (
             <BatchChangeInfoByline
                 {...props}
                 createdAt={THREE_DAYS_AGO}
-                initialApplier={{ url: 'http://test.test/alice', username: 'alice' }}
+                creator={{ url: 'http://test.test/alice', username: 'alice' }}
                 lastAppliedAt={THREE_DAYS_AGO}
                 lastApplier={{ url: 'http://test.test/alice', username: 'alice' }}
+            />
+        )}
+    </WebStory>
+))
+
+add('Never updated (SSBC)', () => (
+    <WebStory>
+        {props => (
+            <BatchChangeInfoByline
+                {...props}
+                createdAt={THREE_DAYS_AGO}
+                creator={{ url: 'http://test.test/alice', username: 'alice' }}
+                lastAppliedAt={null}
+                lastApplier={null}
             />
         )}
     </WebStory>
@@ -32,7 +46,7 @@ add('Updated (same user)', () => (
             <BatchChangeInfoByline
                 {...props}
                 createdAt={THREE_DAYS_AGO}
-                initialApplier={{ url: 'http://test.test/alice', username: 'alice' }}
+                creator={{ url: 'http://test.test/alice', username: 'alice' }}
                 lastAppliedAt={subDays(new Date(), 1).toISOString()}
                 lastApplier={{ url: 'http://test.test/alice', username: 'alice' }}
             />
@@ -46,7 +60,7 @@ add('Updated (different users)', () => (
             <BatchChangeInfoByline
                 {...props}
                 createdAt={THREE_DAYS_AGO}
-                initialApplier={{ url: 'http://test.test/alice', username: 'alice' }}
+                creator={{ url: 'http://test.test/alice', username: 'alice' }}
                 lastAppliedAt={subDays(new Date(), 1).toISOString()}
                 lastApplier={{ url: 'http://test.test/bob', username: 'bob' }}
             />

--- a/client/web/src/enterprise/batches/detail/BatchChangeInfoByline.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeInfoByline.tsx
@@ -5,25 +5,25 @@ import { Link } from '@sourcegraph/shared/src/components/Link'
 import { Timestamp } from '../../../components/time/Timestamp'
 import { BatchChangeFields } from '../../../graphql-operations'
 
-interface Props extends Pick<BatchChangeFields, 'createdAt' | 'initialApplier' | 'lastAppliedAt' | 'lastApplier'> {}
+interface Props extends Pick<BatchChangeFields, 'createdAt' | 'creator' | 'lastAppliedAt' | 'lastApplier'> {}
 
 /**
  * The created/updated byline in the batch change header.
  */
 export const BatchChangeInfoByline: React.FunctionComponent<Props> = ({
     createdAt,
-    initialApplier,
+    creator,
     lastAppliedAt,
     lastApplier,
 }) => (
     <>
         Created <Timestamp date={createdAt} /> by{' '}
-        {initialApplier ? <Link to={initialApplier.url}>{initialApplier.username}</Link> : 'a deleted user'}
-        {lastAppliedAt !== createdAt && (
+        {creator ? <Link to={creator.url}>{creator.username}</Link> : 'a deleted user'}
+        {lastAppliedAt !== null && lastAppliedAt !== createdAt && (
             <>
                 <span className="mx-2">|</span>
                 Updated <Timestamp date={lastAppliedAt} />
-                {lastApplier?.username !== initialApplier?.username && (
+                {lastApplier?.username !== creator?.username && (
                     <> by {lastApplier ? <Link to={lastApplier.url}>{lastApplier.username}</Link> : 'a deleted user'}</>
                 )}
             </>

--- a/client/web/src/enterprise/batches/detail/backend.ts
+++ b/client/web/src/enterprise/batches/detail/backend.ts
@@ -106,7 +106,7 @@ const batchChangeFragment = gql`
         description
 
         createdAt
-        initialApplier {
+        creator {
             username
             url
         }

--- a/client/web/src/integration/batches.test.ts
+++ b/client/web/src/integration/batches.test.ts
@@ -300,7 +300,7 @@ function mockCommonGraphQLResponses(
                 createdAt: subDays(new Date(), 5).toISOString(),
                 updatedAt: subDays(new Date(), 5).toISOString(),
                 description: '### Very cool batch change',
-                initialApplier: {
+                creator: {
                     url: '/users/alice',
                     username: 'alice',
                 },

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -589,8 +589,9 @@ type BatchChangeResolver interface {
 	Name() string
 	Description() *string
 	InitialApplier(ctx context.Context) (*UserResolver, error)
+	Creator(ctx context.Context) (*UserResolver, error)
 	LastApplier(ctx context.Context) (*UserResolver, error)
-	LastAppliedAt() DateTime
+	LastAppliedAt() *DateTime
 	SpecCreator(ctx context.Context) (*UserResolver, error)
 	ViewerCanAdminister(ctx context.Context) (bool, error)
 	URL(ctx context.Context) (string, error)

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2179,11 +2179,22 @@ type BatchChange implements Node {
     The user that created the initial spec. In an org, this will be different from the namespace, or null if the user was deleted.
     """
     specCreator: User
+        @deprecated(
+            reason: "Unused. This always incorrectly returned the current batch specs creator, not the intial one. This field is deprecated and will be removed in a future release."
+        )
 
     """
     The user who created the batch change initially by applying the spec for the first time, or null if the user was deleted.
+
+    This is an alias of BatchChange.creator.
     """
     initialApplier: User
+        @deprecated(reason: "Use creator instead. This field is deprecated and will be removed in a future release.")
+
+    """
+    The user who created the batch change, or null if the user was deleted.
+    """
+    creator: User
 
     """
     The user who last updated the batch change by applying a spec to this batch change.
@@ -2213,9 +2224,10 @@ type BatchChange implements Node {
     updatedAt: DateTime!
 
     """
-    The date and time when the batch change was last updated with a new spec.
+    The date and time when the batch change was last updated with a new spec. Null, if a batch spec has never been
+    applied yet.
     """
-    lastAppliedAt: DateTime!
+    lastAppliedAt: DateTime
 
     """
     The date and time when the batch change was closed. If set, applying a spec for this batch change will fail with an error.

--- a/enterprise/cmd/frontend/internal/batches/resolvers/apitest/types.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/apitest/types.go
@@ -76,7 +76,7 @@ type BatchChange struct {
 	Name                    string
 	Description             string
 	SpecCreator             *User
-	InitialApplier          *User
+	Creator                 *User
 	LastApplier             *User
 	LastAppliedAt           string
 	ViewerCanAdminister     bool

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_change.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_change.go
@@ -31,6 +31,10 @@ type batchChangeResolver struct {
 	namespaceOnce sync.Once
 	namespace     graphqlbackend.NamespaceResolver
 	namespaceErr  error
+
+	batchSpecOnce sync.Once
+	batchSpec     *btypes.BatchSpec
+	batchSpecErr  error
 }
 
 const batchChangeIDKind = "BatchChange"
@@ -60,6 +64,10 @@ func (r *batchChangeResolver) Description() *string {
 }
 
 func (r *batchChangeResolver) InitialApplier(ctx context.Context) (*graphqlbackend.UserResolver, error) {
+	return r.Creator(ctx)
+}
+
+func (r *batchChangeResolver) Creator(ctx context.Context) (*graphqlbackend.UserResolver, error) {
 	user, err := graphqlbackend.UserByIDInt32(ctx, r.store.DatabaseDB(), r.batchChange.InitialApplierID)
 	if errcode.IsNotFound(err) {
 		return nil, nil
@@ -68,28 +76,37 @@ func (r *batchChangeResolver) InitialApplier(ctx context.Context) (*graphqlbacke
 }
 
 func (r *batchChangeResolver) LastApplier(ctx context.Context) (*graphqlbackend.UserResolver, error) {
+	if r.batchChange.LastApplierID == 0 {
+		return nil, nil
+	}
+
 	user, err := graphqlbackend.UserByIDInt32(ctx, r.store.DatabaseDB(), r.batchChange.LastApplierID)
 	if errcode.IsNotFound(err) {
 		return nil, nil
 	}
+
 	return user, err
 }
 
-func (r *batchChangeResolver) LastAppliedAt() graphqlbackend.DateTime {
-	return graphqlbackend.DateTime{Time: r.batchChange.LastAppliedAt}
+func (r *batchChangeResolver) LastAppliedAt() *graphqlbackend.DateTime {
+	if r.batchChange.LastAppliedAt.IsZero() {
+		return nil
+	}
+
+	return &graphqlbackend.DateTime{Time: r.batchChange.LastAppliedAt}
 }
 
 func (r *batchChangeResolver) SpecCreator(ctx context.Context) (*graphqlbackend.UserResolver, error) {
-	spec, err := r.store.GetBatchSpec(ctx, store.GetBatchSpecOpts{
-		ID: r.batchChange.BatchSpecID,
-	})
+	spec, err := r.computeBatchSpec(ctx)
 	if err != nil {
 		return nil, err
 	}
+
 	user, err := graphqlbackend.UserByIDInt32(ctx, r.store.DatabaseDB(), spec.UserID)
 	if errcode.IsNotFound(err) {
 		return nil, nil
 	}
+
 	return user, err
 }
 
@@ -131,6 +148,16 @@ func (r *batchChangeResolver) computeNamespace(ctx context.Context) (graphqlback
 	})
 
 	return r.namespace, r.namespaceErr
+}
+
+func (r *batchChangeResolver) computeBatchSpec(ctx context.Context) (*btypes.BatchSpec, error) {
+	r.batchSpecOnce.Do(func() {
+		r.batchSpec, r.batchSpecErr = r.store.GetBatchSpec(ctx, store.GetBatchSpecOpts{
+			ID: r.batchChange.BatchSpecID,
+		})
+	})
+
+	return r.batchSpec, r.batchSpecErr
 }
 
 func (r *batchChangeResolver) CreatedAt() graphqlbackend.DateTime {
@@ -242,7 +269,7 @@ func (r *batchChangeResolver) DiffStat(ctx context.Context) (*graphqlbackend.Dif
 }
 
 func (r *batchChangeResolver) CurrentSpec(ctx context.Context) (graphqlbackend.BatchSpecResolver, error) {
-	batchSpec, err := r.store.GetBatchSpec(ctx, store.GetBatchSpecOpts{ID: r.batchChange.BatchSpecID})
+	batchSpec, err := r.computeBatchSpec(ctx)
 	if err != nil {
 		// This spec should always exist, so fail hard on not found errors as well.
 		return nil, err

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_change.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_change.go
@@ -68,7 +68,7 @@ func (r *batchChangeResolver) InitialApplier(ctx context.Context) (*graphqlbacke
 }
 
 func (r *batchChangeResolver) Creator(ctx context.Context) (*graphqlbackend.UserResolver, error) {
-	user, err := graphqlbackend.UserByIDInt32(ctx, r.store.DatabaseDB(), r.batchChange.InitialApplierID)
+	user, err := graphqlbackend.UserByIDInt32(ctx, r.store.DatabaseDB(), r.batchChange.CreatorID)
 	if errcode.IsNotFound(err) {
 		return nil, nil
 	}
@@ -111,7 +111,7 @@ func (r *batchChangeResolver) SpecCreator(ctx context.Context) (*graphqlbackend.
 }
 
 func (r *batchChangeResolver) ViewerCanAdminister(ctx context.Context) (bool, error) {
-	return checkSiteAdminOrSameUser(ctx, r.store.DatabaseDB(), r.batchChange.InitialApplierID)
+	return checkSiteAdminOrSameUser(ctx, r.store.DatabaseDB(), r.batchChange.CreatorID)
 }
 
 func (r *batchChangeResolver) URL(ctx context.Context) (string, error) {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_connection.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_connection.go
@@ -40,7 +40,7 @@ func (r *batchChangesConnectionResolver) TotalCount(ctx context.Context) (int32,
 	opts := store.CountBatchChangesOpts{
 		ChangesetID:                   r.opts.ChangesetID,
 		State:                         r.opts.State,
-		InitialApplierID:              r.opts.InitialApplierID,
+		CreatorID:                     r.opts.CreatorID,
 		NamespaceUserID:               r.opts.NamespaceUserID,
 		NamespaceOrgID:                r.opts.NamespaceOrgID,
 		RepoID:                        r.opts.RepoID,

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_connection_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_connection_test.go
@@ -54,23 +54,23 @@ func TestBatchChangeConnectionResolver(t *testing.T) {
 	}
 
 	batchChange1 := &btypes.BatchChange{
-		Name:             "my-unique-name",
-		NamespaceUserID:  userID,
-		InitialApplierID: userID,
-		LastApplierID:    userID,
-		LastAppliedAt:    time.Now(),
-		BatchSpecID:      spec1.ID,
+		Name:            "my-unique-name",
+		NamespaceUserID: userID,
+		CreatorID:       userID,
+		LastApplierID:   userID,
+		LastAppliedAt:   time.Now(),
+		BatchSpecID:     spec1.ID,
 	}
 	if err := cstore.CreateBatchChange(ctx, batchChange1); err != nil {
 		t.Fatal(err)
 	}
 	batchChange2 := &btypes.BatchChange{
-		Name:             "my-other-unique-name",
-		NamespaceUserID:  userID,
-		InitialApplierID: userID,
-		LastApplierID:    userID,
-		LastAppliedAt:    time.Now(),
-		BatchSpecID:      spec2.ID,
+		Name:            "my-other-unique-name",
+		NamespaceUserID: userID,
+		CreatorID:       userID,
+		LastApplierID:   userID,
+		LastAppliedAt:   time.Now(),
+		BatchSpecID:     spec2.ID,
 	}
 	if err := cstore.CreateBatchChange(ctx, batchChange2); err != nil {
 		t.Fatal(err)
@@ -216,11 +216,11 @@ func TestBatchChangesListing(t *testing.T) {
 		createBatchSpec(t, spec)
 
 		batchChange := &btypes.BatchChange{
-			NamespaceUserID:  userID,
-			BatchSpecID:      spec.ID,
-			InitialApplierID: userID,
-			LastApplierID:    userID,
-			LastAppliedAt:    time.Now(),
+			NamespaceUserID: userID,
+			BatchSpecID:     spec.ID,
+			CreatorID:       userID,
+			LastApplierID:   userID,
+			LastAppliedAt:   time.Now(),
 		}
 		createBatchChange(t, batchChange)
 
@@ -298,11 +298,11 @@ func TestBatchChangesListing(t *testing.T) {
 		createBatchSpec(t, spec)
 
 		batchChange := &btypes.BatchChange{
-			NamespaceOrgID:   orgID,
-			BatchSpecID:      spec.ID,
-			InitialApplierID: userID,
-			LastApplierID:    userID,
-			LastAppliedAt:    time.Now(),
+			NamespaceOrgID: orgID,
+			BatchSpecID:    spec.ID,
+			CreatorID:      userID,
+			LastApplierID:  userID,
+			LastAppliedAt:  time.Now(),
 		}
 		createBatchChange(t, batchChange)
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_test.go
@@ -47,13 +47,13 @@ func TestBatchChangeResolver(t *testing.T) {
 	}
 
 	batchChange := &btypes.BatchChange{
-		Name:             "my-unique-name",
-		Description:      "The batch change description",
-		NamespaceOrgID:   orgID,
-		InitialApplierID: userID,
-		LastApplierID:    userID,
-		LastAppliedAt:    now,
-		BatchSpecID:      batchSpec.ID,
+		Name:           "my-unique-name",
+		Description:    "The batch change description",
+		NamespaceOrgID: orgID,
+		CreatorID:      userID,
+		LastApplierID:  userID,
+		LastAppliedAt:  now,
+		BatchSpecID:    batchSpec.ID,
 	}
 	if err := cstore.CreateBatchChange(ctx, batchChange); err != nil {
 		t.Fatal(err)
@@ -193,11 +193,11 @@ func TestBatchChangeResolver_BatchSpecs(t *testing.T) {
 		Name:        batchSpec1.Spec.Name,
 		Description: batchSpec1.Spec.Description,
 
-		NamespaceUserID:  userID,
-		InitialApplierID: userID,
-		LastApplierID:    userID,
-		LastAppliedAt:    now,
-		BatchSpecID:      batchSpec1.ID,
+		NamespaceUserID: userID,
+		CreatorID:       userID,
+		LastApplierID:   userID,
+		LastAppliedAt:   now,
+		BatchSpecID:     batchSpec1.ID,
 	}
 
 	if err := cstore.CreateBatchChange(ctx, batchChange); err != nil {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_test.go
@@ -68,17 +68,17 @@ func TestBatchChangeResolver(t *testing.T) {
 	namespaceAPIID := string(graphqlbackend.MarshalOrgID(orgID))
 	apiUser := &apitest.User{DatabaseID: userID, SiteAdmin: true}
 	wantBatchChange := apitest.BatchChange{
-		ID:             batchChangeAPIID,
-		Name:           batchChange.Name,
-		Description:    batchChange.Description,
-		Namespace:      apitest.UserOrg{ID: namespaceAPIID, Name: orgName},
-		InitialApplier: apiUser,
-		LastApplier:    apiUser,
-		SpecCreator:    apiUser,
-		LastAppliedAt:  marshalDateTime(t, now),
-		URL:            fmt.Sprintf("/organizations/%s/batch-changes/%s", orgName, batchChange.Name),
-		CreatedAt:      marshalDateTime(t, now),
-		UpdatedAt:      marshalDateTime(t, now),
+		ID:            batchChangeAPIID,
+		Name:          batchChange.Name,
+		Description:   batchChange.Description,
+		Namespace:     apitest.UserOrg{ID: namespaceAPIID, Name: orgName},
+		Creator:       apiUser,
+		LastApplier:   apiUser,
+		SpecCreator:   apiUser,
+		LastAppliedAt: marshalDateTime(t, now),
+		URL:           fmt.Sprintf("/organizations/%s/batch-changes/%s", orgName, batchChange.Name),
+		CreatedAt:     marshalDateTime(t, now),
+		UpdatedAt:     marshalDateTime(t, now),
 		// Not closed.
 		ClosedAt: "",
 	}
@@ -109,7 +109,7 @@ func TestBatchChangeResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	wantBatchChange.InitialApplier = nil
+	wantBatchChange.Creator = nil
 	wantBatchChange.LastApplier = nil
 	wantBatchChange.SpecCreator = nil
 
@@ -248,7 +248,7 @@ query($batchChange: ID!){
   node(id: $batchChange) {
     ... on BatchChange {
       id, name, description
-      initialApplier { ...u }
+      creator { ...u }
       lastApplier    { ...u }
       specCreator    { ...u }
       lastAppliedAt
@@ -272,7 +272,7 @@ fragment o on Org  { id, name }
 query($namespace: ID!, $name: String!){
   batchChange(namespace: $namespace, name: $name) {
     id, name, description
-    initialApplier { ...u }
+    creator { ...u }
     lastApplier    { ...u }
     specCreator    { ...u }
     lastAppliedAt

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_test.go
@@ -74,12 +74,12 @@ func TestBatchSpecResolver(t *testing.T) {
 	}
 
 	matchingBatchChange := &btypes.BatchChange{
-		Name:             spec.Spec.Name,
-		NamespaceOrgID:   orgID,
-		InitialApplierID: userID,
-		LastApplierID:    userID,
-		LastAppliedAt:    time.Now(),
-		BatchSpecID:      spec.ID,
+		Name:           spec.Spec.Name,
+		NamespaceOrgID: orgID,
+		CreatorID:      userID,
+		LastApplierID:  userID,
+		LastAppliedAt:  time.Now(),
+		BatchSpecID:    spec.ID,
 	}
 	if err := cstore.CreateBatchChange(ctx, matchingBatchChange); err != nil {
 		t.Fatal(err)

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
@@ -174,7 +174,7 @@ func (r *changesetResolver) BatchChanges(ctx context.Context, args *graphqlbacke
 	if !isSiteAdmin {
 		if args.ViewerCanAdminister != nil && *args.ViewerCanAdminister {
 			actor := actor.FromContext(ctx)
-			opts.InitialApplierID = actor.UID
+			opts.CreatorID = actor.UID
 		}
 	}
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_connection_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_connection_test.go
@@ -49,12 +49,12 @@ func TestChangesetConnectionResolver(t *testing.T) {
 	}
 
 	batchChange := &btypes.BatchChange{
-		Name:             "my-unique-name",
-		NamespaceUserID:  userID,
-		InitialApplierID: userID,
-		LastApplierID:    userID,
-		LastAppliedAt:    time.Now(),
-		BatchSpecID:      spec.ID,
+		Name:            "my-unique-name",
+		NamespaceUserID: userID,
+		CreatorID:       userID,
+		LastApplierID:   userID,
+		LastAppliedAt:   time.Now(),
+		BatchSpecID:     spec.ID,
 	}
 	if err := cstore.CreateBatchChange(ctx, batchChange); err != nil {
 		t.Fatal(err)

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_counts_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_counts_test.go
@@ -134,13 +134,13 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 	}
 
 	batchChange := &btypes.BatchChange{
-		Name:             "Test batch change",
-		Description:      "Testing changeset counts",
-		InitialApplierID: userID,
-		NamespaceUserID:  userID,
-		LastApplierID:    userID,
-		LastAppliedAt:    time.Now(),
-		BatchSpecID:      spec.ID,
+		Name:            "Test batch change",
+		Description:     "Testing changeset counts",
+		CreatorID:       userID,
+		NamespaceUserID: userID,
+		LastApplierID:   userID,
+		LastAppliedAt:   time.Now(),
+		BatchSpecID:     spec.ID,
 	}
 
 	err = cstore.CreateBatchChange(ctx, batchChange)

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_event_connection_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_event_connection_test.go
@@ -51,12 +51,12 @@ func TestChangesetEventConnectionResolver(t *testing.T) {
 	}
 
 	batchChange := &btypes.BatchChange{
-		Name:             "my-unique-name",
-		NamespaceUserID:  userID,
-		InitialApplierID: userID,
-		LastApplierID:    userID,
-		LastAppliedAt:    time.Now(),
-		BatchSpecID:      spec.ID,
+		Name:            "my-unique-name",
+		NamespaceUserID: userID,
+		CreatorID:       userID,
+		LastApplierID:   userID,
+		LastAppliedAt:   time.Now(),
+		BatchSpecID:     spec.ID,
 	}
 	if err := cstore.CreateBatchChange(ctx, batchChange); err != nil {
 		t.Fatal(err)

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_test.go
@@ -190,12 +190,12 @@ func TestChangesetResolver(t *testing.T) {
 	}
 
 	batchChange := &btypes.BatchChange{
-		Name:             "my-unique-name",
-		NamespaceUserID:  userID,
-		InitialApplierID: userID,
-		BatchSpecID:      spec.ID,
-		LastApplierID:    userID,
-		LastAppliedAt:    time.Now(),
+		Name:            "my-unique-name",
+		NamespaceUserID: userID,
+		CreatorID:       userID,
+		BatchSpecID:     spec.ID,
+		LastApplierID:   userID,
+		LastAppliedAt:   time.Now(),
 	}
 	if err := cstore.CreateBatchChange(ctx, batchChange); err != nil {
 		t.Fatal(err)

--- a/enterprise/cmd/frontend/internal/batches/resolvers/permissions_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/permissions_test.go
@@ -82,12 +82,12 @@ func TestPermissionLevels(t *testing.T) {
 		t.Helper()
 
 		c := &btypes.BatchChange{
-			Name:             name,
-			InitialApplierID: userID,
-			NamespaceUserID:  userID,
-			LastApplierID:    userID,
-			LastAppliedAt:    time.Now(),
-			BatchSpecID:      batchSpecID,
+			Name:            name,
+			CreatorID:       userID,
+			NamespaceUserID: userID,
+			LastApplierID:   userID,
+			LastAppliedAt:   time.Now(),
+			BatchSpecID:     batchSpecID,
 		}
 		if err := s.CreateBatchChange(ctx, c); err != nil {
 			t.Fatal(err)
@@ -1228,12 +1228,12 @@ func TestRepositoryPermissions(t *testing.T) {
 		}
 
 		batchChange := &btypes.BatchChange{
-			Name:             "my batch change",
-			InitialApplierID: userID,
-			NamespaceUserID:  userID,
-			LastApplierID:    userID,
-			LastAppliedAt:    time.Now(),
-			BatchSpecID:      spec.ID,
+			Name:            "my batch change",
+			CreatorID:       userID,
+			NamespaceUserID: userID,
+			LastApplierID:   userID,
+			LastAppliedAt:   time.Now(),
+			BatchSpecID:     spec.ID,
 		}
 		if err := cstore.CreateBatchChange(ctx, batchChange); err != nil {
 			t.Fatal(err)

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -703,7 +703,7 @@ func (r *Resolver) BatchChanges(ctx context.Context, args *graphqlbackend.ListBa
 	if !isSiteAdmin {
 		actor := actor.FromContext(ctx)
 		if args.ViewerCanAdminister != nil && *args.ViewerCanAdminister {
-			opts.InitialApplierID = actor.UID
+			opts.CreatorID = actor.UID
 		}
 
 		// 🚨 SECURITY: If the user is not an admin, we don't want to include

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
@@ -897,12 +897,12 @@ func TestMoveBatchChange(t *testing.T) {
 	}
 
 	batchChange := &btypes.BatchChange{
-		BatchSpecID:      batchSpec.ID,
-		Name:             "old-name",
-		InitialApplierID: userID,
-		LastApplierID:    userID,
-		LastAppliedAt:    time.Now(),
-		NamespaceUserID:  batchSpec.UserID,
+		BatchSpecID:     batchSpec.ID,
+		Name:            "old-name",
+		CreatorID:       userID,
+		LastApplierID:   userID,
+		LastAppliedAt:   time.Now(),
+		NamespaceUserID: batchSpec.UserID,
 	}
 	if err := cstore.CreateBatchChange(ctx, batchChange); err != nil {
 		t.Fatal(err)

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
@@ -461,9 +461,9 @@ func TestApplyBatchChange(t *testing.T) {
 			DatabaseID: userID,
 			SiteAdmin:  true,
 		},
-		InitialApplier: apiUser,
-		LastApplier:    apiUser,
-		LastAppliedAt:  marshalDateTime(t, now),
+		Creator:       apiUser,
+		LastApplier:   apiUser,
+		LastAppliedAt: marshalDateTime(t, now),
 		Changesets: apitest.ChangesetConnection{
 			Nodes: []apitest.Changeset{
 				{Typename: "ExternalChangeset", State: string(btypes.ChangesetStateProcessing)},
@@ -508,7 +508,7 @@ fragment u on User { id, databaseID, siteAdmin }
 fragment o on Org  { id, name }
 fragment batchChange on BatchChange {
 	id, name, description
-    initialApplier    { ...u }
+    creator           { ...u }
     lastApplier       { ...u }
     lastAppliedAt
     namespace {
@@ -852,9 +852,9 @@ func TestApplyOrCreateBatchSpecWithPublicationStates(t *testing.T) {
 						DatabaseID: userID,
 						SiteAdmin:  true,
 					},
-					InitialApplier: apiUser,
-					LastApplier:    apiUser,
-					LastAppliedAt:  marshalDateTime(t, now),
+					Creator:       apiUser,
+					LastApplier:   apiUser,
+					LastAppliedAt: marshalDateTime(t, now),
 					Changesets: apitest.ChangesetConnection{
 						Nodes: []apitest.Changeset{
 							{Typename: "ExternalChangeset", State: string(btypes.ChangesetStateProcessing)},
@@ -962,7 +962,7 @@ fragment o on Org  { id, name }
 mutation($batchChange: ID!, $newName: String, $newNamespace: ID){
   moveBatchChange(batchChange: $batchChange, newName: $newName, newNamespace: $newNamespace) {
 	id, name, description
-	initialApplier  { ...u }
+	creator { ...u }
 	namespace {
 		... on User { ...u }
 		... on Org  { ...o }

--- a/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketserver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketserver_test.go
@@ -105,13 +105,13 @@ func testBitbucketWebhook(db *sql.DB, userID int32) func(*testing.T) {
 		}
 
 		batchChange := &btypes.BatchChange{
-			Name:             "Test batch change",
-			Description:      "Testing THE WEBHOOKS",
-			InitialApplierID: userID,
-			NamespaceUserID:  userID,
-			LastApplierID:    userID,
-			LastAppliedAt:    clock(),
-			BatchSpecID:      spec.ID,
+			Name:            "Test batch change",
+			Description:     "Testing THE WEBHOOKS",
+			CreatorID:       userID,
+			NamespaceUserID: userID,
+			LastApplierID:   userID,
+			LastAppliedAt:   clock(),
+			BatchSpecID:     spec.ID,
 		}
 
 		err = s.CreateBatchChange(ctx, batchChange)

--- a/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
@@ -101,13 +101,13 @@ func testGitHubWebhook(db *sql.DB, userID int32) func(*testing.T) {
 		}
 
 		batchChange := &btypes.BatchChange{
-			Name:             "Test batch changes",
-			Description:      "Testing THE WEBHOOKS",
-			InitialApplierID: userID,
-			NamespaceUserID:  userID,
-			LastApplierID:    userID,
-			LastAppliedAt:    clock(),
-			BatchSpecID:      spec.ID,
+			Name:            "Test batch changes",
+			Description:     "Testing THE WEBHOOKS",
+			CreatorID:       userID,
+			NamespaceUserID: userID,
+			LastApplierID:   userID,
+			LastAppliedAt:   clock(),
+			BatchSpecID:     spec.ID,
 		}
 
 		err = s.CreateBatchChange(ctx, batchChange)

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -210,11 +210,11 @@ func (s *Service) CreateEmptyBatchChange(ctx context.Context, opts CreateEmptyBa
 	}
 
 	batchChange = &btypes.BatchChange{
-		Name:             opts.Name,
-		NamespaceUserID:  opts.NamespaceUserID,
-		NamespaceOrgID:   opts.NamespaceOrgID,
-		BatchSpecID:      batchSpec.ID,
-		InitialApplierID: actor.UID,
+		Name:            opts.Name,
+		NamespaceUserID: opts.NamespaceUserID,
+		NamespaceOrgID:  opts.NamespaceOrgID,
+		BatchSpecID:     batchSpec.ID,
+		CreatorID:       actor.UID,
 	}
 	if err := tx.CreateBatchChange(ctx, batchChange); err != nil {
 		return nil, err
@@ -714,7 +714,7 @@ func (s *Service) MoveBatchChange(ctx context.Context, opts MoveBatchChangeOpts)
 	}
 
 	// 🚨 SECURITY: Only the Author of the batch change can move it.
-	if err := backend.CheckSiteAdminOrSameUser(ctx, s.store.DatabaseDB(), batchChange.InitialApplierID); err != nil {
+	if err := backend.CheckSiteAdminOrSameUser(ctx, s.store.DatabaseDB(), batchChange.CreatorID); err != nil {
 		return nil, err
 	}
 	// Check if current user has access to target namespace if set.
@@ -754,7 +754,7 @@ func (s *Service) CloseBatchChange(ctx context.Context, id int64, closeChangeset
 		return batchChange, nil
 	}
 
-	if err := backend.CheckSiteAdminOrSameUser(ctx, s.store.DatabaseDB(), batchChange.InitialApplierID); err != nil {
+	if err := backend.CheckSiteAdminOrSameUser(ctx, s.store.DatabaseDB(), batchChange.CreatorID); err != nil {
 		return nil, err
 	}
 
@@ -796,7 +796,7 @@ func (s *Service) DeleteBatchChange(ctx context.Context, id int64) (err error) {
 		return err
 	}
 
-	if err := backend.CheckSiteAdminOrSameUser(ctx, s.store.DatabaseDB(), batchChange.InitialApplierID); err != nil {
+	if err := backend.CheckSiteAdminOrSameUser(ctx, s.store.DatabaseDB(), batchChange.CreatorID); err != nil {
 		return err
 	}
 
@@ -834,7 +834,7 @@ func (s *Service) EnqueueChangesetSync(ctx context.Context, id int64) (err error
 	)
 
 	for _, c := range batchChanges {
-		err := backend.CheckSiteAdminOrSameUser(ctx, s.store.DatabaseDB(), c.InitialApplierID)
+		err := backend.CheckSiteAdminOrSameUser(ctx, s.store.DatabaseDB(), c.CreatorID)
 		if err != nil {
 			authErr = err
 		} else {
@@ -885,7 +885,7 @@ func (s *Service) ReenqueueChangeset(ctx context.Context, id int64) (changeset *
 	)
 
 	for _, c := range attachedBatchChanges {
-		err := backend.CheckSiteAdminOrSameUser(ctx, s.store.DatabaseDB(), c.InitialApplierID)
+		err := backend.CheckSiteAdminOrSameUser(ctx, s.store.DatabaseDB(), c.CreatorID)
 		if err != nil {
 			authErr = err
 		} else {
@@ -1026,7 +1026,7 @@ func (s *Service) CreateChangesetJobs(ctx context.Context, batchChangeID int64, 
 	}
 
 	// 🚨 SECURITY: Only the author of the batch change can create jobs.
-	if err := backend.CheckSiteAdminOrSameUser(ctx, s.store.DatabaseDB(), batchChange.InitialApplierID); err != nil {
+	if err := backend.CheckSiteAdminOrSameUser(ctx, s.store.DatabaseDB(), batchChange.CreatorID); err != nil {
 		return bulkGroupID, err
 	}
 

--- a/enterprise/internal/batches/service/service_apply_batch_change.go
+++ b/enterprise/internal/batches/service/service_apply_batch_change.go
@@ -191,8 +191,8 @@ func (s *Service) ReconcileBatchChange(
 	batchChange.NamespaceUserID = batchSpec.NamespaceUserID
 	batchChange.Name = batchSpec.Spec.Name
 	a := actor.FromContext(ctx)
-	if batchChange.InitialApplierID == 0 {
-		batchChange.InitialApplierID = a.UID
+	if batchChange.CreatorID == 0 {
+		batchChange.CreatorID = a.UID
 	}
 	batchChange.LastApplierID = a.UID
 	batchChange.LastAppliedAt = s.clock()

--- a/enterprise/internal/batches/service/service_apply_batch_change_test.go
+++ b/enterprise/internal/batches/service/service_apply_batch_change_test.go
@@ -58,13 +58,13 @@ func TestServiceApplyBatchChange(t *testing.T) {
 			}
 
 			want := &btypes.BatchChange{
-				Name:             batchSpec.Spec.Name,
-				Description:      batchSpec.Spec.Description,
-				InitialApplierID: admin.ID,
-				LastApplierID:    admin.ID,
-				LastAppliedAt:    now,
-				NamespaceUserID:  batchSpec.NamespaceUserID,
-				BatchSpecID:      batchSpec.ID,
+				Name:            batchSpec.Spec.Name,
+				Description:     batchSpec.Spec.Description,
+				CreatorID:       admin.ID,
+				LastApplierID:   admin.ID,
+				LastAppliedAt:   now,
+				NamespaceUserID: batchSpec.NamespaceUserID,
+				BatchSpecID:     batchSpec.ID,
 
 				// Ignore these fields
 				ID:        batchChange.ID,
@@ -123,8 +123,8 @@ func TestServiceApplyBatchChange(t *testing.T) {
 				batchSpec := ct.CreateBatchSpec(t, ctx, store, "created-by-user", user.ID)
 				batchChange := ct.CreateBatchChange(t, ctx, store, "created-by-user", user.ID, batchSpec.ID)
 
-				if have, want := batchChange.InitialApplierID, user.ID; have != want {
-					t.Fatalf("batch change InitialApplierID is wrong. want=%d, have=%d", want, have)
+				if have, want := batchChange.CreatorID, user.ID; have != want {
+					t.Fatalf("batch change CreatorID is wrong. want=%d, have=%d", want, have)
 				}
 
 				if have, want := batchChange.LastApplierID, user.ID; have != want {
@@ -143,8 +143,8 @@ func TestServiceApplyBatchChange(t *testing.T) {
 					t.Fatalf("batch change ID is wrong. want=%d, have=%d", want, have)
 				}
 
-				if have, want := batchChange2.InitialApplierID, batchChange.InitialApplierID; have != want {
-					t.Fatalf("batch change InitialApplierID is wrong. want=%d, have=%d", want, have)
+				if have, want := batchChange2.CreatorID, batchChange.CreatorID; have != want {
+					t.Fatalf("batch change CreatorID is wrong. want=%d, have=%d", want, have)
 				}
 
 				if have, want := batchChange2.LastApplierID, admin.ID; have != want {

--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -633,13 +633,13 @@ func TestService(t *testing.T) {
 			}
 
 			c := &btypes.BatchChange{
-				InitialApplierID: authorID,
-				NamespaceUserID:  userID,
-				NamespaceOrgID:   orgID,
-				Name:             name,
-				LastApplierID:    authorID,
-				LastAppliedAt:    time.Now(),
-				BatchSpecID:      spec.ID,
+				CreatorID:       authorID,
+				NamespaceUserID: userID,
+				NamespaceOrgID:  orgID,
+				Name:            name,
+				LastApplierID:   authorID,
+				LastAppliedAt:   time.Now(),
+				BatchSpecID:     spec.ID,
 			}
 
 			if err := s.CreateBatchChange(ctx, c); err != nil {
@@ -742,14 +742,14 @@ func TestService(t *testing.T) {
 		}
 
 		matchingBatchChange := &btypes.BatchChange{
-			Name:             batchSpec.Spec.Name,
-			Description:      batchSpec.Spec.Description,
-			InitialApplierID: admin.ID,
-			NamespaceOrgID:   batchSpec.NamespaceOrgID,
-			NamespaceUserID:  batchSpec.NamespaceUserID,
-			BatchSpecID:      batchSpec.ID,
-			LastApplierID:    admin.ID,
-			LastAppliedAt:    time.Now(),
+			Name:            batchSpec.Spec.Name,
+			Description:     batchSpec.Spec.Description,
+			CreatorID:       admin.ID,
+			NamespaceOrgID:  batchSpec.NamespaceOrgID,
+			NamespaceUserID: batchSpec.NamespaceUserID,
+			BatchSpecID:     batchSpec.ID,
+			LastApplierID:   admin.ID,
+			LastAppliedAt:   time.Now(),
 		}
 		if err := s.CreateBatchChange(ctx, matchingBatchChange); err != nil {
 			t.Fatalf("failed to create batch change: %s\n", err)
@@ -2235,12 +2235,12 @@ func assertChangesetSpecsNotDeleted(t *testing.T, s *store.Store, specs []*btype
 
 func testBatchChange(user int32, spec *btypes.BatchSpec) *btypes.BatchChange {
 	c := &btypes.BatchChange{
-		Name:             "test-batch-change",
-		InitialApplierID: user,
-		NamespaceUserID:  user,
-		BatchSpecID:      spec.ID,
-		LastApplierID:    user,
-		LastAppliedAt:    time.Now(),
+		Name:            "test-batch-change",
+		CreatorID:       user,
+		NamespaceUserID: user,
+		BatchSpecID:     spec.ID,
+		LastApplierID:   user,
+		LastAppliedAt:   time.Now(),
 	}
 
 	return c
@@ -2249,7 +2249,7 @@ func testBatchChange(user int32, spec *btypes.BatchSpec) *btypes.BatchChange {
 func testDraftBatchChange(user int32, spec *btypes.BatchSpec) *btypes.BatchChange {
 	bc := testBatchChange(user, spec)
 	bc.LastAppliedAt = time.Time{}
-	bc.InitialApplierID = 0
+	bc.CreatorID = 0
 	bc.LastApplierID = 0
 	return bc
 }

--- a/enterprise/internal/batches/store/batch_changes.go
+++ b/enterprise/internal/batches/store/batch_changes.go
@@ -22,7 +22,7 @@ var batchChangeColumns = []*sqlf.Query{
 	sqlf.Sprintf("batch_changes.id"),
 	sqlf.Sprintf("batch_changes.name"),
 	sqlf.Sprintf("batch_changes.description"),
-	sqlf.Sprintf("batch_changes.initial_applier_id"),
+	sqlf.Sprintf("batch_changes.creator_id"),
 	sqlf.Sprintf("batch_changes.last_applier_id"),
 	sqlf.Sprintf("batch_changes.last_applied_at"),
 	sqlf.Sprintf("batch_changes.namespace_user_id"),
@@ -39,7 +39,7 @@ var batchChangeColumns = []*sqlf.Query{
 var batchChangeInsertColumns = []*sqlf.Query{
 	sqlf.Sprintf("name"),
 	sqlf.Sprintf("description"),
-	sqlf.Sprintf("initial_applier_id"),
+	sqlf.Sprintf("creator_id"),
 	sqlf.Sprintf("last_applier_id"),
 	sqlf.Sprintf("last_applied_at"),
 	sqlf.Sprintf("namespace_user_id"),
@@ -83,7 +83,7 @@ func (s *Store) createBatchChangeQuery(c *btypes.BatchChange) *sqlf.Query {
 		sqlf.Join(batchChangeInsertColumns, ", "),
 		c.Name,
 		c.Description,
-		nullInt32Column(c.InitialApplierID),
+		nullInt32Column(c.CreatorID),
 		nullInt32Column(c.LastApplierID),
 		nullTimeColumn(c.LastAppliedAt),
 		nullInt32Column(c.NamespaceUserID),
@@ -124,7 +124,7 @@ func (s *Store) updateBatchChangeQuery(c *btypes.BatchChange) *sqlf.Query {
 		sqlf.Join(batchChangeInsertColumns, ", "),
 		c.Name,
 		c.Description,
-		nullInt32Column(c.InitialApplierID),
+		nullInt32Column(c.CreatorID),
 		nullInt32Column(c.LastApplierID),
 		nullTimeColumn(c.LastAppliedAt),
 		nullInt32Column(c.NamespaceUserID),
@@ -160,7 +160,7 @@ type CountBatchChangesOpts struct {
 	State       btypes.BatchChangeState
 	RepoID      api.RepoID
 
-	InitialApplierID int32
+	CreatorID int32
 
 	NamespaceUserID int32
 	NamespaceOrgID  int32
@@ -211,8 +211,8 @@ func countBatchChangesQuery(opts *CountBatchChangesOpts, repoAuthzConds *sqlf.Qu
 		preds = append(preds, sqlf.Sprintf("batch_changes.closed_at IS NOT NULL"))
 	}
 
-	if opts.InitialApplierID != 0 {
-		preds = append(preds, sqlf.Sprintf("batch_changes.initial_applier_id = %d", opts.InitialApplierID))
+	if opts.CreatorID != 0 {
+		preds = append(preds, sqlf.Sprintf("batch_changes.creator_id = %d", opts.CreatorID))
 	}
 
 	if opts.NamespaceUserID != 0 {
@@ -435,7 +435,7 @@ type ListBatchChangesOpts struct {
 	Cursor      int64
 	State       btypes.BatchChangeState
 
-	InitialApplierID int32
+	CreatorID int32
 
 	NamespaceUserID int32
 	NamespaceOrgID  int32
@@ -508,8 +508,8 @@ func listBatchChangesQuery(opts *ListBatchChangesOpts, repoAuthzConds *sqlf.Quer
 		preds = append(preds, sqlf.Sprintf("batch_changes.closed_at IS NOT NULL"))
 	}
 
-	if opts.InitialApplierID != 0 {
-		preds = append(preds, sqlf.Sprintf("batch_changes.initial_applier_id = %d", opts.InitialApplierID))
+	if opts.CreatorID != 0 {
+		preds = append(preds, sqlf.Sprintf("batch_changes.creator_id = %d", opts.CreatorID))
 	}
 
 	if opts.NamespaceUserID != 0 {
@@ -564,7 +564,7 @@ func scanBatchChange(c *btypes.BatchChange, s dbutil.Scanner) error {
 		&c.ID,
 		&c.Name,
 		&dbutil.NullString{S: &c.Description},
-		&dbutil.NullInt32{N: &c.InitialApplierID},
+		&dbutil.NullInt32{N: &c.CreatorID},
 		&dbutil.NullInt32{N: &c.LastApplierID},
 		&dbutil.NullTime{Time: &c.LastAppliedAt},
 		&dbutil.NullInt32{N: &c.NamespaceUserID},

--- a/enterprise/internal/batches/store/batch_changes_test.go
+++ b/enterprise/internal/batches/store/batch_changes_test.go
@@ -28,9 +28,9 @@ func testStoreBatchChanges(t *testing.T, ctx context.Context, s *Store, clock ct
 				Name:        fmt.Sprintf("test-batch-change-%d", i),
 				Description: "All the Javascripts are belong to us",
 
-				InitialApplierID: int32(i) + 50,
-				LastAppliedAt:    clock.Now(),
-				LastApplierID:    int32(i) + 99,
+				CreatorID:     int32(i) + 50,
+				LastAppliedAt: clock.Now(),
+				LastApplierID: int32(i) + 99,
 
 				BatchSpecID: 1742 + int64(i),
 				ClosedAt:    clock.Now(),
@@ -44,7 +44,7 @@ func testStoreBatchChanges(t *testing.T, ctx context.Context, s *Store, clock ct
 			if i%2 == 0 {
 				c.NamespaceOrgID = int32(i) + 23
 			} else {
-				c.NamespaceUserID = c.InitialApplierID
+				c.NamespaceUserID = c.CreatorID
 			}
 
 			want := c.Clone()
@@ -174,7 +174,7 @@ func testStoreBatchChanges(t *testing.T, ctx context.Context, s *Store, clock ct
 
 		t.Run("OnlyForAuthor set", func(t *testing.T) {
 			for _, c := range cs {
-				count, err = s.CountBatchChanges(ctx, CountBatchChangesOpts{InitialApplierID: c.InitialApplierID})
+				count, err = s.CountBatchChanges(ctx, CountBatchChangesOpts{CreatorID: c.CreatorID})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -432,7 +432,7 @@ func testStoreBatchChanges(t *testing.T, ctx context.Context, s *Store, clock ct
 
 		t.Run("ListBatchChanges OnlyForAuthor set", func(t *testing.T) {
 			for _, c := range cs {
-				have, next, err := s.ListBatchChanges(ctx, ListBatchChangesOpts{InitialApplierID: c.InitialApplierID})
+				have, next, err := s.ListBatchChanges(ctx, ListBatchChangesOpts{CreatorID: c.CreatorID})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -491,7 +491,7 @@ func testStoreBatchChanges(t *testing.T, ctx context.Context, s *Store, clock ct
 		for _, c := range cs {
 			c.Name += "-updated"
 			c.Description += "-updated"
-			c.InitialApplierID++
+			c.CreatorID++
 			c.ClosedAt = c.ClosedAt.Add(5 * time.Second)
 
 			if c.NamespaceUserID != 0 {
@@ -822,24 +822,24 @@ func testUserDeleteCascades(t *testing.T, ctx context.Context, s *Store, clock c
 		}
 
 		ownedBatchChange := &btypes.BatchChange{
-			Name:             "owned",
-			NamespaceUserID:  user.ID,
-			InitialApplierID: user.ID,
-			LastApplierID:    user.ID,
-			LastAppliedAt:    clock.Now(),
-			BatchSpecID:      ownedSpec.ID,
+			Name:            "owned",
+			NamespaceUserID: user.ID,
+			CreatorID:       user.ID,
+			LastApplierID:   user.ID,
+			LastAppliedAt:   clock.Now(),
+			BatchSpecID:     ownedSpec.ID,
 		}
 		if err := s.CreateBatchChange(ctx, ownedBatchChange); err != nil {
 			t.Fatal(err)
 		}
 
 		unownedBatchChange := &btypes.BatchChange{
-			Name:             "unowned",
-			NamespaceOrgID:   orgID,
-			InitialApplierID: user.ID,
-			LastApplierID:    user.ID,
-			LastAppliedAt:    clock.Now(),
-			BatchSpecID:      ownedSpec.ID,
+			Name:           "unowned",
+			NamespaceOrgID: orgID,
+			CreatorID:      user.ID,
+			LastApplierID:  user.ID,
+			LastAppliedAt:  clock.Now(),
+			BatchSpecID:    ownedSpec.ID,
 		}
 		if err := s.CreateBatchChange(ctx, unownedBatchChange); err != nil {
 			t.Fatal(err)

--- a/enterprise/internal/batches/store/batch_specs_test.go
+++ b/enterprise/internal/batches/store/batch_specs_test.go
@@ -402,12 +402,12 @@ func testStoreBatchSpecs(t *testing.T, ctx context.Context, s *Store, clock ct.C
 
 			if tc.hasBatchChange {
 				batchChange := &btypes.BatchChange{
-					Name:             "not-blank",
-					InitialApplierID: 1,
-					NamespaceUserID:  1,
-					BatchSpecID:      batchSpec.ID,
-					LastApplierID:    1,
-					LastAppliedAt:    time.Now(),
+					Name:            "not-blank",
+					CreatorID:       1,
+					NamespaceUserID: 1,
+					BatchSpecID:     batchSpec.ID,
+					LastApplierID:   1,
+					LastAppliedAt:   time.Now(),
 				}
 				if err := s.CreateBatchChange(ctx, batchChange); err != nil {
 					t.Fatal(err)

--- a/enterprise/internal/batches/store/changeset_specs_test.go
+++ b/enterprise/internal/batches/store/changeset_specs_test.go
@@ -481,12 +481,12 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, clock 
 
 				if tc.batchSpecApplied {
 					batchChange := &btypes.BatchChange{
-						Name:             fmt.Sprintf("batch change for spec %d", batchSpec.ID),
-						BatchSpecID:      batchSpec.ID,
-						InitialApplierID: batchSpec.UserID,
-						NamespaceUserID:  batchSpec.NamespaceUserID,
-						LastApplierID:    batchSpec.UserID,
-						LastAppliedAt:    time.Now(),
+						Name:            fmt.Sprintf("batch change for spec %d", batchSpec.ID),
+						BatchSpecID:     batchSpec.ID,
+						CreatorID:       batchSpec.UserID,
+						NamespaceUserID: batchSpec.NamespaceUserID,
+						LastApplierID:   batchSpec.UserID,
+						LastAppliedAt:   time.Now(),
 					}
 					if err := s.CreateBatchChange(ctx, batchChange); err != nil {
 						t.Fatal(err)

--- a/enterprise/internal/batches/testing/batch_change.go
+++ b/enterprise/internal/batches/testing/batch_change.go
@@ -15,13 +15,13 @@ type CreateBatchChanger interface {
 
 func BuildBatchChange(store CreateBatchChanger, name string, userID int32, spec int64) *btypes.BatchChange {
 	b := &btypes.BatchChange{
-		InitialApplierID: userID,
-		LastApplierID:    userID,
-		LastAppliedAt:    store.Clock()(),
-		NamespaceUserID:  userID,
-		BatchSpecID:      spec,
-		Name:             name,
-		Description:      "batch change description",
+		CreatorID:       userID,
+		LastApplierID:   userID,
+		LastAppliedAt:   store.Clock()(),
+		NamespaceUserID: userID,
+		BatchSpecID:     spec,
+		Name:            name,
+		Description:     "batch change description",
 	}
 	return b
 }

--- a/enterprise/internal/batches/types/batch_change.go
+++ b/enterprise/internal/batches/types/batch_change.go
@@ -19,9 +19,9 @@ type BatchChange struct {
 
 	BatchSpecID int64
 
-	InitialApplierID int32
-	LastApplierID    int32
-	LastAppliedAt    time.Time
+	CreatorID     int32
+	LastApplierID int32
+	LastAppliedAt time.Time
 
 	NamespaceUserID int32
 	NamespaceOrgID  int32

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -26,20 +26,20 @@ Referenced by:
 
 # Table "public.batch_changes"
 ```
-       Column       |           Type           | Collation | Nullable |                  Default                  
---------------------+--------------------------+-----------+----------+-------------------------------------------
- id                 | bigint                   |           | not null | nextval('batch_changes_id_seq'::regclass)
- name               | text                     |           | not null | 
- description        | text                     |           |          | 
- initial_applier_id | integer                  |           |          | 
- namespace_user_id  | integer                  |           |          | 
- namespace_org_id   | integer                  |           |          | 
- created_at         | timestamp with time zone |           | not null | now()
- updated_at         | timestamp with time zone |           | not null | now()
- closed_at          | timestamp with time zone |           |          | 
- batch_spec_id      | bigint                   |           | not null | 
- last_applier_id    | bigint                   |           |          | 
- last_applied_at    | timestamp with time zone |           |          | 
+      Column       |           Type           | Collation | Nullable |                  Default                  
+-------------------+--------------------------+-----------+----------+-------------------------------------------
+ id                | bigint                   |           | not null | nextval('batch_changes_id_seq'::regclass)
+ name              | text                     |           | not null | 
+ description       | text                     |           |          | 
+ creator_id        | integer                  |           |          | 
+ namespace_user_id | integer                  |           |          | 
+ namespace_org_id  | integer                  |           |          | 
+ created_at        | timestamp with time zone |           | not null | now()
+ updated_at        | timestamp with time zone |           | not null | now()
+ closed_at         | timestamp with time zone |           |          | 
+ batch_spec_id     | bigint                   |           | not null | 
+ last_applier_id   | bigint                   |           |          | 
+ last_applied_at   | timestamp with time zone |           |          | 
 Indexes:
     "batch_changes_pkey" PRIMARY KEY, btree (id)
     "batch_changes_namespace_org_id" btree (namespace_org_id)
@@ -49,7 +49,7 @@ Check constraints:
     "batch_changes_name_not_blank" CHECK (name <> ''::text)
 Foreign-key constraints:
     "batch_changes_batch_spec_id_fkey" FOREIGN KEY (batch_spec_id) REFERENCES batch_specs(id) DEFERRABLE
-    "batch_changes_initial_applier_id_fkey" FOREIGN KEY (initial_applier_id) REFERENCES users(id) ON DELETE SET NULL DEFERRABLE
+    "batch_changes_initial_applier_id_fkey" FOREIGN KEY (creator_id) REFERENCES users(id) ON DELETE SET NULL DEFERRABLE
     "batch_changes_last_applier_id_fkey" FOREIGN KEY (last_applier_id) REFERENCES users(id) ON DELETE SET NULL DEFERRABLE
     "batch_changes_namespace_org_id_fkey" FOREIGN KEY (namespace_org_id) REFERENCES orgs(id) ON DELETE CASCADE DEFERRABLE
     "batch_changes_namespace_user_id_fkey" FOREIGN KEY (namespace_user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE
@@ -2359,7 +2359,7 @@ Check constraints:
 Referenced by:
     TABLE "access_tokens" CONSTRAINT "access_tokens_creator_user_id_fkey" FOREIGN KEY (creator_user_id) REFERENCES users(id)
     TABLE "access_tokens" CONSTRAINT "access_tokens_subject_user_id_fkey" FOREIGN KEY (subject_user_id) REFERENCES users(id)
-    TABLE "batch_changes" CONSTRAINT "batch_changes_initial_applier_id_fkey" FOREIGN KEY (initial_applier_id) REFERENCES users(id) ON DELETE SET NULL DEFERRABLE
+    TABLE "batch_changes" CONSTRAINT "batch_changes_initial_applier_id_fkey" FOREIGN KEY (creator_id) REFERENCES users(id) ON DELETE SET NULL DEFERRABLE
     TABLE "batch_changes" CONSTRAINT "batch_changes_last_applier_id_fkey" FOREIGN KEY (last_applier_id) REFERENCES users(id) ON DELETE SET NULL DEFERRABLE
     TABLE "batch_changes" CONSTRAINT "batch_changes_namespace_user_id_fkey" FOREIGN KEY (namespace_user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE
     TABLE "batch_spec_execution_cache_entries" CONSTRAINT "batch_spec_execution_cache_entries_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE

--- a/migrations/frontend/1528395959_batch_change_creator_id.down.sql
+++ b/migrations/frontend/1528395959_batch_change_creator_id.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE batch_changes RENAME COLUMN creator_id TO initial_applier_id;
+
+COMMIT;

--- a/migrations/frontend/1528395959_batch_change_creator_id.up.sql
+++ b/migrations/frontend/1528395959_batch_change_creator_id.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE batch_changes RENAME COLUMN initial_applier_id TO creator_id;
+
+COMMIT;


### PR DESCRIPTION
Currently, the creator is displayed as deleted. This fixes it and also makes the naming more clear now that we don't have immediate applies.
