### PR TITLE
Don't autofocus the search bar when changing pages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The sourcegraph-frontend ingress now uses the networking.k8s.io/v1 api. This adds support for k8s v1.22 and later, and deprecates support for versions older than v1.18.x [#4029](https://github.com/sourcegraph/deploy-sourcegraph/pull/4029)
 - Indexed queries with language filters now use file contents to recognize languages. For example, `lang:matlab` will no longer return an Objective-C `main.m`. [#28370](https://github.com/sourcegraph/sourcegraph/pull/28370)
 - Non-bare repositories found on gitserver will be removed by a janitor job. [#28895](https://github.com/sourcegraph/sourcegraph/pull/28895)
+- The search bar is no longer auto-focused when navigating between files. This change means that the keyboard shortcut Cmd+LeftArrow (or Ctrl-LeftArrow) now goes back to the browser's previous page instead of moving the cursor position to the first position of the search bar. [#28943](https://github.com/sourcegraph/sourcegraph/pull/28943)
 
 ### Fixed
 

--- a/client/web/src/search/input/MonacoQueryInput.tsx
+++ b/client/web/src/search/input/MonacoQueryInput.tsx
@@ -309,7 +309,6 @@ export const MonacoQueryInput: React.FunctionComponent<MonacoQueryInputProps> = 
                 }
                 editor.setPosition(position)
                 editor.revealPosition(position)
-                editor.focus()
             }
         }
     }, [editor, queryState])


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/28846

Previously, the search bar was auto-focused every time when loading
a new file. The search har overrides several shortcuts like "Cmd+Left"
requiring the user to move their mouse to the browser's "back" button to
go back in history (or unfocus the search bar).

Recording to motivate this change https://www.loom.com/share/8f8badb18eb24e24932a4a0c61f6b598



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
