### PR TITLE
workflows: fix lsif-go workflow name

### DIFF
--- a/.github/workflows/lsif-go.yml
+++ b/.github/workflows/lsif-go.yml
@@ -1,4 +1,4 @@
-name: lsif-ts
+name: lsif-go
 on:
   push:
     branches:


### PR DESCRIPTION
Typo from https://github.com/sourcegraph/sourcegraph/pull/28883