### PR TITLE
ci: give codeinsights-db a very generous DB_STARTUP_TIMEOUT

### DIFF
--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -34,7 +34,7 @@ echo "--- comby install"
 # For code insights test
 ./dev/codeinsights-db.sh &
 export CODEINSIGHTS_PGDATASOURCE=postgres://postgres:password@127.0.0.1:5435/postgres
-export DB_STARTUP_TIMEOUT=120s # codeinsights-db needs more time to start in some instances.
+export DB_STARTUP_TIMEOUT=360s # codeinsights-db needs more time to start in some instances.
 
 # We have multiple go.mod files and go list doesn't recurse into them.
 find . -name go.mod -exec dirname '{}' \; | while read -r d; do


### PR DESCRIPTION
Test sometimes fail with being unable to connect to this DB, this is a crude stopgap that bumps the timeout to give it more time to start up. https://sourcegraph.slack.com/archives/C01N83PS4TU/p1639411400449400

That said, this doesn't actually seem to fail all that often ([just a few affected builds over the past week](https://sourcegraph.grafana.net/explore?left=%5B%221638864000000%22,%221639555199000%22,%22grafanacloud-sourcegraph-logs%22,%7B%22expr%22:%22count%20(count_over_time(%7Bapp%3D%5C%22buildkite%5C%22,branch%3D%5C%22main%5C%22,state%3D%5C%22failed%5C%22%7D%20%7C%3D%20%5C%22Failed%20to%20connect%20to%20codeinsights%20database%5C%22%5B3h%5D))%22,%22instant%22:false,%22range%22:true,%22refId%22:%22A%22,%22datasource%22:%22grafanacloud-sourcegraph-logs%22%7D%5D&orgId=1)) so I think this is fine for now
