### PR TITLE
goreman: Support initialization stages

### DIFF
--- a/internal/goreman/proc.go
+++ b/internal/goreman/proc.go
@@ -18,7 +18,9 @@ var (
 
 // stop specified proc.
 func stopProc(proc string, kill bool) error {
+	procM.Lock()
 	p, ok := procs[proc]
+	procM.Unlock()
 	if !ok {
 		return errors.New("Unknown proc: " + proc)
 	}
@@ -50,13 +52,15 @@ func stopProc(proc string, kill bool) error {
 
 // start specified proc. if proc is started already, return nil.
 func startProc(proc string) error {
+	procM.Lock()
 	p, ok := procs[proc]
+	procM.Unlock()
 	if !ok {
 		return errors.New("Unknown proc: " + proc)
 	}
 
 	p.mu.Lock()
-	if procs[proc].cmd != nil {
+	if p.cmd != nil {
 		p.mu.Unlock()
 		return nil
 	}
@@ -83,40 +87,44 @@ func startProc(proc string) error {
 
 // startProcs starts the processes.
 func startProcs() {
-	for proc := range procs {
+	for _, proc := range names() {
 		_ = startProc(proc)
 	}
 }
 
+var waitProcsOnce sync.Once
+
 // waitProcs waits for processes to complete.
 func waitProcs() error {
-	go func() {
-		wg.Wait()
-		signals <- syscall.SIGINT
-	}()
-	signal.Notify(signals, syscall.SIGTERM, syscall.SIGINT, syscall.SIGHUP)
-	<-signals
+	waitProcsOnce.Do(func() {
+		go func() {
+			wg.Wait()
+			signals <- syscall.SIGINT
+		}()
+		signal.Notify(signals, syscall.SIGTERM, syscall.SIGINT, syscall.SIGHUP)
+		<-signals
 
-	stopped := make(chan struct{})
-	go func() {
-		stopProcs(false)
-		close(stopped)
-	}()
+		stopped := make(chan struct{})
+		go func() {
+			stopProcs(false)
+			close(stopped)
+		}()
 
-	// New signal chan to avoid built up buffered signals
-	sc2 := make(chan os.Signal, 10)
-	signal.Notify(sc2, syscall.SIGTERM, syscall.SIGINT, syscall.SIGHUP)
+		// New signal chan to avoid built up buffered signals
+		sc2 := make(chan os.Signal, 10)
+		signal.Notify(sc2, syscall.SIGTERM, syscall.SIGINT, syscall.SIGHUP)
 
-	select {
-	case <-sc2:
-		// Second signal received, do a hard exit
-		stopProcs(true)
-	case <-time.NewTimer(10 * time.Second).C:
-		// 10 seconds has passed, kill
-		stopProcs(true)
-	case <-stopped:
-		// Happy case, just continue
-	}
+		select {
+		case <-sc2:
+			// Second signal received, do a hard exit
+			stopProcs(true)
+		case <-time.NewTimer(10 * time.Second).C:
+			// 10 seconds has passed, kill
+			stopProcs(true)
+		case <-stopped:
+			// Happy case, just continue
+		}
+	})
 
 	return nil
 }
@@ -125,7 +133,7 @@ func stopProcs(kill bool) {
 	// TODO we probably need a well defined order for shutting down, since
 	// something may want to finish writing to postgres for example.
 	var wg sync.WaitGroup
-	for proc := range procs {
+	for _, proc := range names() {
 		wg.Add(1)
 		go func(proc string) {
 			defer wg.Done()
@@ -133,4 +141,15 @@ func stopProcs(kill bool) {
 		}(proc)
 	}
 	wg.Wait()
+}
+
+func names() (names []string) {
+	procM.Lock()
+	defer procM.Unlock()
+
+	for proc := range procs {
+		names = append(names, proc)
+	}
+
+	return names
 }


### PR DESCRIPTION
Update the `internal/goreman` package to support calling `Start` multiple times in order to add processes to an already running system on subsequent invocations.

This will be necessary to run migrations in the all-in-one Docker image, which will require postgres to be up (possibly running in goreman), then the migrator to run, then all other services to run.

We then can separate two _clusters_ of services: Postgres (and related) lines, then the remaining services.