### PR TITLE
prometheus: remove sha pin on quay.io/prometheus/busybox-linux-amd64

### DIFF
--- a/docker-images/prometheus/Dockerfile
+++ b/docker-images/prometheus/Dockerfile
@@ -13,7 +13,7 @@ FROM prom/alertmanager:v0.23.0@sha256:9ab73a421b65b80be072f96a88df756fc5b52a1bc8
 
 # Prepare final image
 # hadolint ignore=DL3007
-FROM quay.io/prometheus/busybox-linux-amd64:latest@sha256:97a9aacc097e5dbdec33b0d671adea0785e76d26ff2b979ee28570baf6a9155d
+FROM quay.io/prometheus/busybox-linux-amd64:latest
 
 # Should reflect versions above
 LABEL com.sourcegraph.prometheus.version=v2.31.1


### PR DESCRIPTION
This was just updated a few days ago in https://github.com/sourcegraph/sourcegraph/pull/28750 and already builds are failing again, presumably because the image was removed again. This removes the sha pin so we just use whatever is latest.