### PR TITLE
search: add Features type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ All notable changes to Sourcegraph are documented in this file.
 - External services will stop syncing if they exceed the user / site level limit for total number of repositories added. It will only continue syncing if the extra repositories are removed or the corresponding limit is increased, otherwise it will stop syncing for the very first repository each time the syncer attempts to sync the external service again. [#28674](https://github.com/sourcegraph/sourcegraph/pull/28674)
 - Sourcegraph services now listen to SIGTERM signals. This allows smoother rollouts in kubernetes deployments. [#27958](https://github.com/sourcegraph/sourcegraph/pull/27958)
 - The sourcegraph-frontend ingress now uses the networking.k8s.io/v1 api. This adds support for k8s v1.22 and later, and deprecates support for versions older than v1.18.x [#4029](https://github.com/sourcegraph/deploy-sourcegraph/pull/4029)
-- Indexed queries with language filters now use file contents to recognize languages. For example, `lang:matlab` will no longer return an Objective-C `main.m`. [#28370](https://github.com/sourcegraph/sourcegraph/pull/28370)
 - Non-bare repositories found on gitserver will be removed by a janitor job. [#28895](https://github.com/sourcegraph/sourcegraph/pull/28895)
 
 ### Fixed

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	searchrepos "github.com/sourcegraph/sourcegraph/internal/search/repos"
@@ -105,6 +106,7 @@ func NewSearchImplementer(ctx context.Context, db database.DB, args *SearchArgs)
 			Query:         plan.ToParseTree(),
 			OriginalQuery: args.Query,
 			UserSettings:  settings,
+			Features:      featureflag.FromContext(ctx),
 			PatternType:   searchType,
 			DefaultLimit:  defaultLimit,
 		},

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -563,6 +563,18 @@ func withMode(args search.TextParameters, st query.SearchType) search.TextParame
 	return args
 }
 
+func toFeatures(flags featureflag.FlagSet) search.Features {
+	if flags == nil {
+		flags = featureflag.FlagSet{}
+		metricFeatureFlagUnavailable.Inc()
+		log15.Warn("search feature flags are not available")
+	}
+
+	return search.Features{
+		ContentBasedLangFilters: flags.GetBoolOr("search-content-based-lang-detection", false),
+	}
+}
+
 // toSearchInputs converts a query parse tree to the _internal_ representation
 // needed to run a search. To understand why this conversion matters, think
 // about the fact that the query parse tree doesn't know anything about our
@@ -606,6 +618,7 @@ func (r *searchResolver) toSearchInputs(q query.Q) (*search.TextParameters, []ru
 	args := search.TextParameters{
 		PatternInfo: p,
 		Query:       q,
+		Features:    toFeatures(r.SearchInputs.Features),
 		Timeout:     search.TimeoutDuration(b),
 
 		// UseFullDeadline if timeout: set or we are streaming.
@@ -654,7 +667,7 @@ func (r *searchResolver) toSearchInputs(q query.Q) (*search.TextParameters, []ru
 
 			if args.ResultTypes.Has(result.TypeFile | result.TypePath) {
 				typ := search.TextRequest
-				zoektQuery, err := search.QueryToZoektQuery(args.PatternInfo, typ)
+				zoektQuery, err := search.QueryToZoektQuery(args.PatternInfo, &args.Features, typ)
 				if err != nil {
 					return nil, nil, err
 				}
@@ -686,7 +699,7 @@ func (r *searchResolver) toSearchInputs(q query.Q) (*search.TextParameters, []ru
 
 			if args.ResultTypes.Has(result.TypeSymbol) {
 				typ := search.SymbolRequest
-				zoektQuery, err := search.QueryToZoektQuery(args.PatternInfo, typ)
+				zoektQuery, err := search.QueryToZoektQuery(args.PatternInfo, &args.Features, typ)
 				if err != nil {
 					return nil, nil, err
 				}
@@ -718,7 +731,7 @@ func (r *searchResolver) toSearchInputs(q query.Q) (*search.TextParameters, []ru
 				// TODO(rvantonder): we don't always have to run
 				// this converter. It depends on whether we run
 				// a zoekt search at all.
-				zoektQuery, err := search.QueryToZoektQuery(args.PatternInfo, typ)
+				zoektQuery, err := search.QueryToZoektQuery(args.PatternInfo, &args.Features, typ)
 				if err != nil {
 					return nil, nil, err
 				}
@@ -751,7 +764,7 @@ func (r *searchResolver) toSearchInputs(q query.Q) (*search.TextParameters, []ru
 		if args.ResultTypes.Has(result.TypeSymbol) && args.PatternInfo.Pattern != "" {
 			if !skipUnindexed {
 				typ := search.SymbolRequest
-				zoektQuery, err := search.QueryToZoektQuery(args.PatternInfo, typ)
+				zoektQuery, err := search.QueryToZoektQuery(args.PatternInfo, &args.Features, typ)
 				if err != nil {
 					return nil, nil, err
 				}
@@ -791,7 +804,7 @@ func (r *searchResolver) toSearchInputs(q query.Q) (*search.TextParameters, []ru
 
 		if r.PatternType == query.SearchTypeStructural && p.Pattern != "" {
 			typ := search.TextRequest
-			zoektQuery, err := search.QueryToZoektQuery(args.PatternInfo, typ)
+			zoektQuery, err := search.QueryToZoektQuery(args.PatternInfo, &args.Features, typ)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -1891,3 +1904,8 @@ func (r *searchResolver) getExactFilePatterns() map[string]struct{} {
 		})
 	return m
 }
+
+var metricFeatureFlagUnavailable = promauto.NewCounter(prometheus.CounterOpts{
+	Name: "src_search_featureflag_unavailable",
+	Help: "temporary counter to check if we have feature flag available in practice.",
+})

--- a/internal/search/query_converter.go
+++ b/internal/search/query_converter.go
@@ -229,7 +229,7 @@ func parseRe(pattern string, filenameOnly bool, contentOnly bool, queryIsCaseSen
 	}, nil
 }
 
-func QueryToZoektQuery(p *TextPatternInfo, typ IndexedRequestType) (zoekt.Q, error) {
+func QueryToZoektQuery(p *TextPatternInfo, feat *Features, typ IndexedRequestType) (zoekt.Q, error) {
 	var and []zoekt.Q
 
 	var q zoekt.Q
@@ -311,7 +311,7 @@ func QueryToZoektQuery(p *TextPatternInfo, typ IndexedRequestType) (zoekt.Q, err
 	// corrected by the more precise language metadata. If this is a problem, indexed search
 	// queries should have a special query converter that produces *only* Language predicates
 	// instead of filepatterns.
-	if len(p.Languages) > 0 {
+	if len(p.Languages) > 0 && feat.ContentBasedLangFilters {
 		or := &zoekt.Or{}
 		for _, lang := range p.Languages {
 			lang, _ = enry.GetLanguageByAlias(lang) // Invariant: lang is valid.

--- a/internal/search/query_converter_test.go
+++ b/internal/search/query_converter_test.go
@@ -14,10 +14,11 @@ import (
 
 func TestQueryToZoektQuery(t *testing.T) {
 	cases := []struct {
-		Name    string
-		Type    IndexedRequestType
-		Pattern *TextPatternInfo
-		Query   string
+		Name     string
+		Type     IndexedRequestType
+		Pattern  *TextPatternInfo
+		Features Features
+		Query    string
 	}{
 		{
 			Name: "substr",
@@ -169,11 +170,23 @@ func TestQueryToZoektQuery(t *testing.T) {
 			Query: `foo (type:repo file:\.go$) (type:repo file:\.yaml$) -(type:repo file:\.java$) -(type:repo file:\.xml$)`,
 		},
 		{
+			Name: "TextPatternInfo.Languages is ignored",
+			Type: TextRequest,
+			Pattern: &TextPatternInfo{
+				IncludePatterns: []string{`\.go$`},
+				Languages:       []string{"go"},
+			},
+			Query: `file:"\\.go(?m:$)"`,
+		},
+		{
 			Name: "language gets passed as both file include and lang: predicate",
 			Type: TextRequest,
 			Pattern: &TextPatternInfo{
 				IncludePatterns: []string{`\.go$`},
 				Languages:       []string{"go"},
+			},
+			Features: Features{
+				ContentBasedLangFilters: true,
 			},
 			Query: `file:"\\.go(?m:$)" lang:Go`,
 		},
@@ -184,7 +197,7 @@ func TestQueryToZoektQuery(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to parse %q: %v", tt.Query, err)
 			}
-			got, err := QueryToZoektQuery(tt.Pattern, tt.Type)
+			got, err := QueryToZoektQuery(tt.Pattern, &tt.Features, tt.Type)
 			if err != nil {
 				t.Fatal("queryToZoektQuery failed:", err)
 			}

--- a/internal/search/run/run.go
+++ b/internal/search/run/run.go
@@ -3,6 +3,7 @@ package run
 import (
 	"context"
 
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	searchrepos "github.com/sourcegraph/sourcegraph/internal/search/repos"
@@ -17,6 +18,7 @@ type SearchInputs struct {
 	OriginalQuery string     // the raw string of the original search query
 	PatternType   query.SearchType
 	UserSettings  *schema.Settings
+	Features      featureflag.FlagSet
 
 	// DefaultLimit is the default limit to use if not specified in query.
 	DefaultLimit int

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -138,6 +138,7 @@ type SearcherParameters struct {
 type TextParameters struct {
 	PatternInfo *TextPatternInfo
 	RepoOptions RepoOptions
+	Features    Features
 	ResultTypes result.Types
 	Timeout     time.Duration
 
@@ -245,6 +246,24 @@ func (p *TextPatternInfo) String() string {
 	}
 
 	return fmt.Sprintf("TextPatternInfo{%s}", strings.Join(args, ","))
+}
+
+// Features describe feature flags for a request. This is state that differs
+// across users and time. It is created based on user feature flags and
+// configuration.
+//
+// The Feature struct should be initialized once per search request early on.
+//
+// The default value for a Feature should be the go zero value, such that
+// creating an empty Feature struct represents the usual search
+// experience. This is to avoid needing to update a large number of tests when
+// a new feature flag is introduced, and instead changes are localized to this
+// struct and read sites of a flag.
+type Features struct {
+	// ContentBasedLangFilters when true will use the language detected from
+	// the content of the file, rather than just file name patterns. This is
+	// currently just supported by Zoekt.
+	ContentBasedLangFilters bool
 }
 
 type RepoOptions struct {

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -231,7 +231,7 @@ func NewIndexedSearchRequest(ctx context.Context, args *search.TextParameters, g
 	if ok {
 		return request, nil
 	}
-	q, err := search.QueryToZoektQuery(args.PatternInfo, typ)
+	q, err := search.QueryToZoektQuery(args.PatternInfo, &args.Features, typ)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -272,7 +272,7 @@ func TestIndexedSearch(t *testing.T) {
 				Repos:  zoektRepos,
 			}
 
-			zoektQuery, err := search.QueryToZoektQuery(tt.args.patternInfo, search.TextRequest)
+			zoektQuery, err := search.QueryToZoektQuery(tt.args.patternInfo, &search.Features{}, search.TextRequest)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
We mint a new Features type which is part of the top level
SearchParameters. The purpose of this type will be to calculate the
feature flags once per search and then have a way to access them
everywhere in a type safe manor.

We hook up this type similarly to how we access UserSettings. At the
time of creating search inputs we query Sourcegraph specific stores to
set these fields. The intention of this pattern is to only create the
Feature struct once and never mutate it. Then every other access is a
read. This helps localize all changes for Features which will hopefully
become more frequently used tool by our team.

As a demonstration this commit also uses the new Feature type to disable
content based language queries. We are running into corner cases in that
feature and do not feel confident in releasing it to all customers
yet. This will allow us to continue testing it within the sourcegraph
org on sourcegraph.com as well as allow admins to enable it.