### PR TITLE
Simplify BatchChange.IsDraft()

### DIFF
--- a/enterprise/internal/batches/types/batch_change.go
+++ b/enterprise/internal/batches/types/batch_change.go
@@ -44,9 +44,4 @@ func (c *BatchChange) Closed() bool { return !c.ClosedAt.IsZero() }
 // IsDraft returns true when the BatchChange is a draft ("shallow") Batch
 // Change, i.e. it's associated with a BatchSpec but it hasn't been applied
 // yet.
-func (c *BatchChange) IsDraft() bool {
-	return c.BatchSpecID != 0 &&
-		c.LastAppliedAt.IsZero() &&
-		c.LastApplierID == 0 &&
-		c.InitialApplierID == 0
-}
+func (c *BatchChange) IsDraft() bool { return c.LastAppliedAt.IsZero() }


### PR DESCRIPTION
This is the result of the discussion with @eseliger and @courier-new
yesterday.

`LastAppliedAt.IsZero()` is the only safe indicator whether something is
a draft, since the user ids (`LastApplierID` and `InitialApplierID`)
could be 0 after a user is deleted and `BatchSpecID` we don't need to
check since it's non-nullable in the DB.
