### PR TITLE
sg: add a sg check command to run existing checks

### DIFF
--- a/dev/check/broken-urls.bash
+++ b/dev/check/broken-urls.bash
@@ -3,10 +3,12 @@
 set -e
 cd "$(dirname "${BASH_SOURCE[0]}")"/../..
 
-# Skip on non-default branches to avoid preventing us from building historical commits (eg when
+# When running on the CI, skip on non-default branches to avoid preventing us from building historical commits (eg when
 # backporting fixes).
-if [[ ! "$BUILDKITE_BRANCH" =~ ^(master|main)$ ]]; then
+if [[ ! -z "$BUILDKITE_BRANCH" ]]; then 
+  if [[ ! "$BUILDKITE_BRANCH" =~ ^main$ ]]; then
     exit 0
+  fi
 fi
 
 URL_MATCHES=$(git grep -h -e https://about.sourcegraph.com --and --not -e '^\s*//' --and --not -e 'CI\:URL_OK' -- '*.go' '*.js' '*.jsx' '*.ts' '*.tsx' '*.json' ':(exclude)vendor' | grep -Eo 'https://about.sourcegraph.com[^'"'"'`)>" ]+' | sed 's/\.$//' | sort -u)
@@ -32,3 +34,4 @@ EOF
 
     exit 1
 fi
+

--- a/dev/check/broken-urls.bash
+++ b/dev/check/broken-urls.bash
@@ -5,10 +5,10 @@ cd "$(dirname "${BASH_SOURCE[0]}")"/../..
 
 # When running on the CI, skip on non-default branches to avoid preventing us from building historical commits (eg when
 # backporting fixes).
-if [[ ! -z "$BUILDKITE_BRANCH" ]]; then 
-  if [[ ! "$BUILDKITE_BRANCH" =~ ^main$ ]]; then
-    exit 0
-  fi
+if [[ -n "$BUILDKITE_BRANCH" ]]; then
+    if [[ ! "$BUILDKITE_BRANCH" =~ ^main$ ]]; then
+        exit 0
+    fi
 fi
 
 URL_MATCHES=$(git grep -h -e https://about.sourcegraph.com --and --not -e '^\s*//' --and --not -e 'CI\:URL_OK' -- '*.go' '*.js' '*.jsx' '*.ts' '*.tsx' '*.json' ':(exclude)vendor' | grep -Eo 'https://about.sourcegraph.com[^'"'"'`)>" ]+' | sed 's/\.$//' | sort -u)
@@ -34,4 +34,3 @@ EOF
 
     exit 1
 fi
-

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -66,6 +66,7 @@ var (
 			versionCommand,
 			secretCommand,
 			setupCommand,
+			checkCommand,
 		},
 	}
 )

--- a/dev/sg/sg_check.go
+++ b/dev/sg/sg_check.go
@@ -182,13 +182,13 @@ type checkReport struct {
 }
 
 func printCheckReport(pending output.Pending, report *checkReport) {
-	msg := fmt.Sprintf(" (%ds)", report.duration/time.Second)
+	msg := fmt.Sprintf("%s (%ds)", report.header, report.duration/time.Second)
 	if report.err != nil {
-		pending.VerboseLine(output.Linef(output.EmojiFailure, output.StyleWarning, "%s %s", report.header, msg))
+		pending.VerboseLine(output.Linef(output.EmojiFailure, output.StyleWarning, msg))
 		pending.Verbose(report.output)
 		return
 	}
-	pending.VerboseLine(output.Linef(output.EmojiSuccess, output.StyleSuccess, "%s %s", report.header, msg))
+	pending.VerboseLine(output.Linef(output.EmojiSuccess, output.StyleSuccess, msg))
 }
 
 func runCheckScript(header string, script string) checkScriptFn {

--- a/dev/sg/sg_check.go
+++ b/dev/sg/sg_check.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/peterbourgon/ff/v3/ffcli"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/run"
+	"github.com/sourcegraph/sourcegraph/dev/sg/root"
+	"github.com/sourcegraph/sourcegraph/lib/output"
+)
+
+var (
+	checkFlagSet = flag.NewFlagSet("sg check", flag.ExitOnError)
+
+	checkShellFlagSet   = flag.NewFlagSet("sg check shell", flag.ExitOnError)
+	checkURLsFlagSet    = flag.NewFlagSet("sg check urls", flag.ExitOnError)
+	checkGoFlagSet      = flag.NewFlagSet("sg check go", flag.ExitOnError)
+	checkDocsiteFlagSet = flag.NewFlagSet("sg check docsite", flag.ExitOnError)
+	checkDockerFlagSet  = flag.NewFlagSet("sg check docker", flag.ExitOnError)
+	checkClientFlagSet  = flag.NewFlagSet("sg check client", flag.ExitOnError)
+
+	scriptChecks = map[string][]checkScriptFn{
+		"urls": {
+			runCheckScript("Broken urls", "dev/check/broken-urls.bash"),
+		},
+		"go": {
+			runCheckScript("Go format", "dev/check/gofmt.sh"),
+			runCheckScript("Go generate", "dev/check/go-generate.sh"),
+			runCheckScript("Go lint", "dev/check/go-lint.sh"),
+			runCheckScript("Go pkg/database/dbconn", "dev/check/go-dbconn-import.sh"),
+			runCheckScript("Go enterprise imports in OSS", "dev/check/go-enterprise-import.sh"),
+		},
+		"docsite": {
+			runCheckScript("Docsite lint", "dev/check/docsite.sh"),
+		},
+		"docker": {
+			runCheckScript("Docker forbidden alpine base images", "dev/check/no-alpine-guard.sh"),
+		},
+		"client": {
+			runCheckScript("Typescript imports in OSS", "dev/check/ts-enterprise-import.sh"),
+			runCheckScript("Inline templates", "dev/check/template-inlines.sh"),
+			runCheckScript("Yarn duplicate", "dev/check/yarn-deduplicate.sh"),
+			runCheckScript("SVG Compression", "dev/check/svgo.sh"),
+		},
+		"shell": {
+			runCheckScript("Shell formatting", "dev/check/shfmt.sh"),
+			runCheckScript("Shell lint", "dev/check/shellcheck.sh"),
+		},
+	}
+)
+
+var (
+	checkCommand = &ffcli.Command{
+		Name:       "check",
+		ShortUsage: "sg check [go|client|shell|docsite|docker|urls]",
+		ShortHelp:  "Run all checks on the codebase.",
+		LongHelp: `Run all checks on the codebase and display failures, if any. 
+Run sg check --help for a list of all checks.
+`,
+		FlagSet: checkFlagSet,
+		Exec: func(ctx context.Context, args []string) error {
+			var fns []checkScriptFn
+			for _, scriptFns := range scriptChecks {
+				fns = append(fns, scriptFns...)
+			}
+			return runCheckScriptsAndReport(fns...)(ctx, args)
+		},
+		Subcommands: []*ffcli.Command{
+			{
+				Name:      "urls",
+				ShortHelp: "Check for broken urls in the codebase.",
+				FlagSet:   checkURLsFlagSet,
+				Exec:      runCheckScriptsAndReport(scriptChecks["urls"]...),
+			},
+			{
+				Name:      "go",
+				ShortHelp: "Check go code for linting errors, forbidden imports, generated files...",
+				FlagSet:   checkGoFlagSet,
+				Exec:      runCheckScriptsAndReport(scriptChecks["go"]...),
+			},
+			{
+				Name:      "docsite",
+				FlagSet:   checkDocsiteFlagSet,
+				ShortHelp: "Check the code powering docs.sourcegraph.com for broken links and linting errors.",
+				Exec:      runCheckScriptsAndReport(scriptChecks["docsite"]...),
+			},
+			{
+				Name:      "docker",
+				FlagSet:   checkDockerFlagSet,
+				ShortHelp: "Check for forbidden docker base images",
+				Exec:      runCheckScriptsAndReport(scriptChecks["docker"]...),
+			},
+			{
+				Name:      "client",
+				FlagSet:   checkClientFlagSet,
+				ShortHelp: "Check client code for linting errors, forbidden imports, ...",
+				Exec:      runCheckScriptsAndReport(scriptChecks["client"]...),
+			},
+			{
+				Name:      "shell",
+				FlagSet:   checkShellFlagSet,
+				ShortHelp: "Check shell code for linting errors, formatting, ...",
+				Exec:      runCheckScriptsAndReport(scriptChecks["shell"]...),
+			},
+		},
+	}
+)
+
+type checkScriptFn func(context.Context) *checkReport
+
+// runCheckScriptsAndReport concurrently runs all fns and report as each check finishes. Returns an error
+// if any of the fns fails.
+func runCheckScriptsAndReport(fns ...checkScriptFn) func(context.Context, []string) error {
+	return func(ctx context.Context, _ []string) error {
+		_, err := root.RepositoryRoot()
+		if err != nil {
+			return err
+		}
+
+		// swawn a go routine for each check and increment count to report completion
+		var count int64
+		total := len(fns)
+		pending := out.Pending(output.Linef("", output.StylePending, "Running checks (done: 0/%d)", total))
+		var wg sync.WaitGroup
+		reportsCh := make(chan *checkReport)
+		wg.Add(total)
+		for _, fn := range fns {
+			go func(fn func(context.Context) *checkReport) {
+				report := fn(ctx)
+				atomic.AddInt64(&count, 1)
+				reportsCh <- report
+				wg.Done()
+			}(fn)
+		}
+		go func() {
+			wg.Wait()
+			close(reportsCh)
+		}()
+
+		// consume check reports
+		var hasErr bool
+		var messages []string
+		for report := range reportsCh {
+			pending.Destroy()
+			printCheckReport(report)
+			if count != int64(total) {
+				pending = out.Pending(output.Linef("", output.StylePending, "Running checks (done: %d/%d)", count, total))
+			}
+			if report.err != nil {
+				messages = append(messages, report.err.Error())
+				hasErr = true
+			}
+		}
+		// return the final error, if any
+		if hasErr {
+			return errors.Newf("failed checks: %s", strings.Join(messages, ", "))
+		}
+		return nil
+	}
+}
+
+type checkReport struct {
+	duration time.Duration
+	header   string
+	output   string
+	err      error
+}
+
+func printCheckReport(report *checkReport) {
+	timing := fmt.Sprintf(" (%ds)", report.duration/time.Second)
+	if report.err != nil {
+		writeFailureLine(report.header + timing)
+		out.Write(report.output)
+		return
+	}
+	writeSuccessLine(report.header + timing)
+}
+
+func runCheckScript(header string, script string) checkScriptFn {
+	return checkScriptFn(func(ctx context.Context) *checkReport {
+		start := time.Now()
+		out, err := run.BashInRoot(ctx, script, nil)
+		return &checkReport{
+			header:   header,
+			duration: time.Since(start),
+			output:   out,
+			err:      err,
+		}
+	})
+}

--- a/dev/sg/sg_check.go
+++ b/dev/sg/sg_check.go
@@ -160,7 +160,7 @@ func runCheckScriptsAndReport(fns ...checkScriptFn) func(context.Context, []stri
 			printCheckReport(pending, report)
 			pending.Updatef("Running checks (done: %d/%d)", count, total)
 			if report.err != nil {
-				messages = append(messages, report.err.Error())
+				messages = append(messages, report.header)
 				hasErr = true
 			}
 		}

--- a/dev/sg/sg_check.go
+++ b/dev/sg/sg_check.go
@@ -67,7 +67,7 @@ Run sg check --help for a list of all checks.
 		FlagSet: checkFlagSet,
 		Exec: func(ctx context.Context, args []string) error {
 			if len(args) > 0 {
-				return errors.New("unrecognized topic, please run sg check --help to list topics")
+				return errors.New("unrecognized command, please run sg check --help to list available checks")
 			}
 			var fns []checkScriptFn
 			for _, scriptFns := range scriptChecks {

--- a/doc/dev/background-information/sg/index.md
+++ b/doc/dev/background-information/sg/index.md
@@ -263,6 +263,7 @@ sg secret reset buildkite
 ```
 
 ### `sg check` - Run checks against local code 
+
 ```bash
 # Run all possible checks 
 sg check

--- a/doc/dev/background-information/sg/index.md
+++ b/doc/dev/background-information/sg/index.md
@@ -259,6 +259,25 @@ sg secret list
 
 # Remove the secrets associated with buildkite (sg ci build)
 sg secret reset buildkite
+
+```
+
+### `sg check` - Run checks against local code 
+```bash
+# Run all possible checks 
+sg check
+
+# Run only go related checks
+sg check go
+
+# Run only shell related checks
+sg check go
+
+# Run only client related checks
+sg check client 
+
+# List all available check groups 
+sg check --help
 ```
 
 ## Configuration


### PR DESCRIPTION
Adds a new command to sg, `sg check [topic]` which will concurrently run
every scripts currently run on the CI by the checks step. This is the
first step to remove bash scripts as it opens the way to write those in
Go which is much more reliable (but not exclusively). This is also the 
first step toward providing better annotations on failed builds.

It merges seamlessly with the existing check scripts through a helper
that wraps them for the time being.

The subcommands are organized by usage, focusing on what kind of
activity the user is currently doing. This opens up the path to
selectively run those checks on the CI, depending on the changes in the
PR being built.

Presently, it does not run frontend linters as this set of changes does
not modify in any way the CI steps, which are to be shipped in an
ulterior PR.

```
$ sg check --help
USAGE
  sg check [go|client|shell|docsite|docker|urls]

Run all checks on the codebase and display failures, if any.
Run sg check --help for a list of all checks.


SUBCOMMANDS
  urls     Check for broken urls in the codebase.
  go       Check go code for linting errors, forbidden imports, generated files...
  docsite  Check the code powering docs.sourcegraph.com for broken links and linting errors.
  docker   Check for forbidden docker base images
  client   Check client code for linting errors, forbidden imports, ...
  shell    Check shell code for linting errors, formatting, ...
```

```
$ sg check shell
✅ Shell formatting (0s)
❌ Shell lint (1s)
--- shellcheck
^^^ +++

In dev/ci/test/code-intel/test-against-server.sh line 22:
source /root/.profile
       ^------------^ SC1091: Not following: /root/.profile: openBinaryFile: does not exist (No such file or directory)

For more information:
  https://www.shellcheck.net/wiki/SC1091 -- Not following: /root/.profile: op...
^^^ +++

error: failed checks: 'bash -c dev/check/shellcheck.sh' failed: --- shellcheck
^^^ +++
In dev/ci/test/code-intel/test-against-server.sh line 22:
source /root/.profile
       ^------------^ SC1091: Not following: /root/.profile: openBinaryFile: does not exist (No such file or directory)
For more information:
  https://www.shellcheck.net/wiki/SC1091 -- Not following: /root/.profile: op...
^^^ +++: exit status 1
exit status 1
```