### PR TITLE
Manually revert #28883

### DIFF
--- a/.github/workflows/lsif-go.yml
+++ b/.github/workflows/lsif-go.yml
@@ -1,10 +1,6 @@
 name: lsif-go
 on:
   push:
-    branches:
-      - main
-      - '[0-9]+.[0-9]+' # release branches
-  pull_request:
     paths:
       - '**.go'
 

--- a/.github/workflows/lsif-ts.yml
+++ b/.github/workflows/lsif-ts.yml
@@ -1,10 +1,6 @@
 name: lsif-ts
 on:
   push:
-    branches:
-      - main
-      - '[0-9]+.[0-9]+' # release branches
-  pull_request:
     paths:
       - '**.ts'
       - '**.js'


### PR DESCRIPTION
See https://sourcegraph.slack.com/archives/C07KZF47K/p1639482287186000 this breaks code-intel because being triggered by a `pull_request` rather than a `push` changes the checkout behaviour.

QA: https://github.com/sourcegraph/sourcegraph/runs/4519842779?check_suite_focus=true

cc @bobheadxi (I totally did not foresee that when we merged the original PR Oo) 