### PR TITLE
Code Insights: Fix creation intro page layout (spacing and sizes)

### DIFF
--- a/client/web/src/enterprise/insights/modals/BetaConfirmationModal.tsx
+++ b/client/web/src/enterprise/insights/modals/BetaConfirmationModal.tsx
@@ -7,7 +7,7 @@ import { Button, useAutoFocus } from '@sourcegraph/wildcard'
 import { useTemporarySetting } from '../../../settings/temporary/useTemporarySetting'
 
 import styles from './BetaConfirmationModal.module.scss'
-import { FourLineChart, PieChart, ThreeLineChart } from './components/MediaCharts'
+import { FourLineChart, LangStatsInsightChart, ThreeLineChart } from './components/MediaCharts'
 
 export const BetaConfirmationModal: React.FunctionComponent = () => {
     const history = useHistory()
@@ -57,7 +57,7 @@ export const BetaConfirmationModalContent: React.FunctionComponent<BetaConfirmat
             <div className={styles.mediaHeroContent}>
                 <ThreeLineChart className={styles.chart} />
                 <FourLineChart className={styles.chart} />
-                <PieChart className={styles.chart} />
+                <LangStatsInsightChart className={styles.chart} />
             </div>
 
             <div className={styles.textContent}>

--- a/client/web/src/enterprise/insights/modals/components/MediaCharts.tsx
+++ b/client/web/src/enterprise/insights/modals/components/MediaCharts.tsx
@@ -132,7 +132,7 @@ export const FourLineChart: React.FunctionComponent<React.SVGProps<SVGSVGElement
     </svg>
 )
 
-export const PieChart: React.FunctionComponent<React.SVGProps<SVGSVGElement>> = props => (
+export const LangStatsInsightChart: React.FunctionComponent<React.SVGProps<SVGSVGElement>> = props => (
     <svg
         width="169"
         height="158"
@@ -174,7 +174,7 @@ export const PieChart: React.FunctionComponent<React.SVGProps<SVGSVGElement>> = 
     </svg>
 )
 
-export const CaptureGroupInsight: React.FunctionComponent<React.SVGProps<SVGSVGElement>> = props => (
+export const SearchBasedInsightChart: React.FunctionComponent<React.SVGProps<SVGSVGElement>> = props => (
     <svg
         width="185"
         height="126"
@@ -184,71 +184,105 @@ export const CaptureGroupInsight: React.FunctionComponent<React.SVGProps<SVGSVGE
         {...props}
         className={classNames(styles.chart, props.className)}
     >
-        <rect x="6" y="39" width="137" height="1" />
-        <rect x="6" y="16" width="137" height="1" />
-        <rect x="6" y="62" width="137" height="1" />
-        <rect x="6" y="85" width="137" height="1" />
-        <rect x="6" y="108" width="137" height="1" />
-        <rect x="170" y="16.5" width="15" height="1" />
-        <circle cx="165" cy="17" r="2" fill="var(--orange)" />
-        <rect x="170" y="52.5" width="15" height="1" />
-        <circle cx="165" cy="53" r="2" fill="var(--orange)" />
-        <rect x="170" y="88.5" width="15" height="1" />
-        <circle cx="165" cy="89" r="2" fill="var(--orange)" />
-        <rect x="170" y="61.5" width="15" height="1" />
-        <circle cx="165" cy="62" r="2" fill="var(--pink)" />
-        <rect x="170" y="25.5" width="15" height="1" />
-        <circle cx="165" cy="26" r="2" fill="var(--pink)" />
-        <rect x="170" y="70.5" width="15" height="1" />
-        <circle cx="165" cy="71" r="2" fill="var(--dark-blue)" />
-        <rect x="170" y="97.5" width="15" height="1" />
-        <circle cx="165" cy="98" r="2" fill="var(--pink)" />
-        <rect x="170" y="79.5" width="15" height="1" />
-        <circle cx="165" cy="80" r="2" fill="var(--light-green)" />
-        <rect x="170" y="34.5" width="15" height="1" />
-        <circle cx="165" cy="35" r="2" fill="var(--dark-blue)" />
-        <rect x="170" y="106.5" width="15" height="1" />
-        <circle cx="165" cy="107" r="2" fill="var(--dark-blue)" />
-        <rect x="170" y="43.5" width="15" height="1" />
-        <circle cx="165" cy="44" r="2" fill="var(--light-green)" />
-        <circle cx="7.5" cy="39.5" r="1.5" fill="var(--pink)" />
-        <circle cx="30" cy="39.5" r="1.5" fill="var(--pink)" />
-        <circle cx="51" cy="79" r="1.5" fill="var(--pink)" />
-        <circle cx="74" cy="85" r="1.5" fill="var(--pink)" />
-        <circle cx="95" cy="85" r="1.5" fill="var(--pink)" />
-        <circle cx="116.5" cy="74.7" r="1.5" fill="var(--pink)" />
-        <circle cx="139" cy="74.7" r="1.5" fill="var(--pink)" />
-        <circle cx="29.5" cy="85.5" r="1.5" fill="var(--dark-blue)" />
-        <circle cx="7.5" cy="107.5" r="1.5" fill="var(--dark-blue)" />
-        <circle cx="7.5" cy="94.5" r="1.5" fill="var(--light-green)" />
-        <circle cx="31.5" cy="94.5" r="1.5" fill="var(--light-green)" />
-        <circle cx="52" cy="108.5" r="1.5" fill="var(--light-green)" />
-        <circle cx="75" cy="99" r="1.5" fill="var(--light-green)" />
-        <circle cx="96.5" cy="98.5" r="1.5" fill="var(--light-green)" />
-        <circle cx="117" cy="62" r="1.5" fill="var(--light-green)" />
-        <circle cx="140.5" cy="62" r="1.5" fill="var(--light-green)" />
         <path
-            d="M6.5 108.5L29.5 85.5H51.5L73.8164 64.7647H95.3333L118 39.5H140.5"
-            stroke="var(--dark-blue)"
-            strokeWidth="1.2"
+            fill="var(--border-color-2)"
+            d="M6 39h137v1H6zM6 16h137v1H6zM6 62h137v1H6zM6 85h137v1H6zM6 108h137v1H6zM170 44.5h15v1h-15z"
         />
-        <path d="M7 39.5H30.2115L51 79.5L74 85H95.5769L116 75H139.5" stroke="var(--pink)" strokeWidth="1.2" />
-        <path d="M8 94.5H31.2115L52 108.5L75 99H96.5769L117 62H140.5" stroke="var(--light-green)" strokeWidth="1.2" />
+        <circle cx="165" cy="45" r="2" fill="var(--orange)" />
+        <path fill="var(--border-color-2)" d="M170 53.5h15v1h-15z" />
+        <circle cx="165" cy="54" r="2" fill="var(--pink)" />
+        <path fill="var(--border-color-2)" d="M170 62.5h15v1h-15z" />
+        <circle cx="165" cy="63" r="2" fill="var(--dark-blue)" />
+        <path fill="var(--border-color-2)" d="M170 71.5h15v1h-15z" />
+        <circle cx="165" cy="72" r="2" fill="var(--green)" />
+        <circle cx="8" cy="80" r="2" fill="var(--pink)" />
+        <circle cx="30.5" cy="85" r="2" fill="var(--pink)" />
+        <circle cx="51.5" cy="77.5" r="2" fill="var(--pink)" />
+        <circle cx="74.5" cy="93" r="2" fill="var(--pink)" />
+        <circle cx="95.5" cy="93" r="2" fill="var(--pink)" />
+        <circle cx="116" cy="107.2" r="2" fill="var(--pink)" />
+        <circle cx="139.5" cy="107.2" r="2" fill="var(--pink)" />
+        <circle cx="30" cy="32" r="2" fill="var(--dark-blue)" />
+        <circle cx="7" cy="61" r="2" fill="var(--dark-blue)" />
+        <circle cx="7" cy="47" r="2" fill="var(--green)" />
+        <circle cx="32" cy="63" r="2" fill="var(--green)" />
+        <circle cx="52.5" cy="53" r="2" fill="var(--green)" />
+        <circle cx="75.5" cy="52.5" r="2" fill="var(--green)" />
+        <circle cx="97" cy="36.5" r="2" fill="var(--green)" />
+        <circle cx="117.5" cy="22.5" r="2" fill="var(--green)" />
+        <circle cx="141" cy="22.5" r="2" fill="var(--green)" />
+        <path d="m6.5 62.5 23-31h22l22.316-12.735h21.517L118 33.5h22.5" stroke="var(--dark-blue)" strokeWidth="1.5" />
+        <path d="m7 79.5 23.212 6L51 77.5 74 93h21.577L116 107h23.5" stroke="var(--pink)" strokeWidth="1.5" />
+        <path d="m8 47.5 24.212 15L52 53.5l23-.5 21.577-16L117 23h23.5" stroke="var(--green)" strokeWidth="1.5" />
+        <path d="m8 104 21 .5 22.667-16 22.15-8H92l24.5-21 25-10" stroke="var(--orange)" strokeWidth="1.5" />
+        <circle cx="8.5" cy="103.5" r="2" fill="var(--orange)" />
+        <circle cx="29.5" cy="104" r="2" fill="var(--orange)" />
+        <circle cx="52" cy="88" r="2" fill="var(--orange)" />
+        <circle cx="74" cy="81" r="2" fill="var(--orange)" />
+        <circle cx="92.5" cy="80.5" r="2" fill="var(--orange)" />
+        <circle cx="117" cy="59.5" r="2" fill="var(--orange)" />
+        <circle cx="141" cy="49.5" r="2" fill="var(--orange)" />
+        <circle cx="118.5" cy="33.5" r="2" fill="var(--dark-blue)" />
+        <circle cx="141" cy="33.5" r="2" fill="var(--dark-blue)" />
+        <circle cx="96" cy="19" r="2" fill="var(--dark-blue)" />
+        <circle cx="74" cy="19" r="2" fill="var(--dark-blue)" />
+        <circle cx="51.5" cy="31" r="2" fill="var(--dark-blue)" />
+    </svg>
+)
+
+export const CaptureGroupInsightChart: React.FunctionComponent<React.SVGProps<SVGSVGElement>> = props => (
+    <svg
+        width="185"
+        height="126"
+        viewBox="0 0 185 126"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        {...props}
+        className={classNames(styles.chart, props.className)}
+    >
         <path
-            d="M8 87L29 17.5L51.6667 40.5H73.8164L92 17.5H116.5L141.5 40.5"
-            stroke="var(--orange)"
-            strokeWidth="1.2"
+            fill="var(--border-color-2)"
+            d="M6 39h137v1H6zM6 16h137v1H6zM6 62h137v1H6zM6 85h137v1H6zM6 108h137v1H6zM170 44.5h15v1h-15z"
         />
-        <circle cx="8" cy="87" r="1.5" fill="var(--orange)" />
-        <circle cx="29" cy="17.5" r="1.5" fill="var(--orange)" />
-        <circle cx="51.5" cy="40.5" r="1.5" fill="var(--orange)" />
-        <circle cx="73.5" cy="40.5" r="1.5" fill="var(--orange)" />
-        <circle cx="91.5" cy="18" r="1.5" fill="var(--orange)" />
-        <circle cx="116.5" cy="17.5" r="1.5" fill="var(--orange)" />
-        <circle cx="140.5" cy="39.5" r="1.5" fill="var(--orange)" />
-        <circle cx="118" cy="39.5" r="1.5" fill="var(--dark-blue)" />
-        <circle cx="95.5" cy="64.5" r="1.5" fill="var(--dark-blue)" />
-        <circle cx="73.5" cy="65" r="1.5" fill="var(--dark-blue)" />
-        <circle cx="51" cy="85.5" r="1.5" fill="var(--dark-blue)" />
+        <rect x="170" y="44.5" width="15" height="1" />
+        <circle cx="165" cy="45" r="2" fill="var(--orange)" />
+        <rect x="170" y="53.5" width="15" height="1" />
+        <circle cx="165" cy="54" r="2" fill="var(--pink)" />
+        <rect x="170" y="62.5" width="15" height="1" />
+        <circle cx="165" cy="63" r="2" fill="var(--dark-blue)" />
+        <rect x="170" y="71.5" width="15" height="1" />
+        <circle cx="165" cy="72" r="2" fill="var(--green)" />
+        <circle cx="8" cy="19.5" r="2" fill="var(--pink)" />
+        <circle cx="30.5" cy="19.5" r="2" fill="var(--pink)" />
+        <circle cx="51.5" cy="34" r="2" fill="var(--pink)" />
+        <circle cx="74.5" cy="34" r="2" fill="var(--pink)" />
+        <circle cx="95.5" cy="45" r="2" fill="var(--pink)" />
+        <circle cx="118" cy="45.2" r="2" fill="var(--pink)" />
+        <circle cx="141" cy="66.2" r="2" fill="var(--pink)" />
+        <circle cx="30" cy="86" r="2" fill="var(--dark-blue)" />
+        <circle cx="75.5" cy="99" r="2" fill="var(--green)" />
+        <circle cx="97" cy="99" r="2" fill="var(--green)" />
+        <circle cx="117.5" cy="86" r="2" fill="var(--green)" />
+        <circle cx="141" cy="86" r="2" fill="var(--green)" />
+        <path d="M29.5 85.5H51.5L73.8164 64.7647H95.3333L118 23.5H140.5" stroke="var(--dark-blue)" strokeWidth="1.5" />
+        <path d="M7 19.5H30.2115L51 34H74L95.5769 45H118L140.5 66" stroke="var(--pink)" strokeWidth="1.5" />
+        <path d="M75 99H96.5769L117 86H140.5" stroke="var(--green)" strokeWidth="1.5" />
+        <path d="M7 43H30L51.6667 72.5H73.8164L92 91.5H116.5L141.5 104.5" stroke="var(--orange)" strokeWidth="1.5" />
+        <circle cx="8" cy="43" r="2" fill="var(--orange)" />
+        <circle cx="29.5" cy="43" r="2" fill="var(--orange)" />
+        <circle cx="52" cy="72" r="2" fill="var(--orange)" />
+        <circle cx="74" cy="72.5" r="2" fill="var(--orange)" />
+        <circle cx="92" cy="91.5" r="2" fill="var(--orange)" />
+        <circle cx="117" cy="92" r="2" fill="var(--orange)" />
+        <circle cx="141" cy="104" r="2" fill="var(--orange)" />
+        <circle cx="118.5" cy="23.5" r="2" fill="var(--dark-blue)" />
+        <circle cx="141" cy="23.5" r="2" fill="var(--dark-blue)" />
+        <circle cx="96" cy="64.5" r="2" fill="var(--dark-blue)" />
+        <circle cx="74" cy="65.5" r="2" fill="var(--dark-blue)" />
+        <circle cx="51.5" cy="85.5" r="2" fill="var(--dark-blue)" />
+        <path
+            d="M177.882 104.625a5.261 5.261 0 0 1-.807.065c-.275 0-.541-.024-.808-.065v-2.834l-2.018 2.003a6.703 6.703 0 0 1-1.123-1.123l2.003-2.018h-2.834a5.284 5.284 0 0 1-.065-.808c0-.275.024-.541.065-.808h2.834l-2.003-2.018c.154-.202.315-.404.525-.598.194-.21.396-.371.598-.525l2.018 2.003v-2.834c.267-.04.533-.065.808-.065s.541.024.807.065v2.834l2.019-2.003c.404.315.808.719 1.123 1.123l-2.003 2.018h2.834c.041.267.065.533.065.808s-.024.541-.065.808h-2.834l2.003 2.018a4.462 4.462 0 0 1-.525.598c-.194.21-.396.371-.598.525l-2.019-2.003v2.834Zm-8.882 1.68a1.615 1.615 0 1 1 3.23 0 1.615 1.615 0 0 1-3.23 0Z"
+            fill="#A6B6D9"
+        />
     </svg>
 )

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.story.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.story.tsx
@@ -4,6 +4,8 @@ import React from 'react'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { WebStory } from '../../../../../../components/WebStory'
+import { CodeInsightsBackendContext } from '../../../../core/backend/code-insights-backend-context'
+import { CodeInsightsGqlBackend } from '../../../../core/backend/gql-api/code-insights-gql-backend'
 
 import { IntroCreationPage } from './IntroCreationPage'
 
@@ -17,4 +19,10 @@ export default {
     },
 } as Meta
 
-export const InsightIntroPageExample = () => <IntroCreationPage telemetryService={NOOP_TELEMETRY_SERVICE} />
+const API = new CodeInsightsGqlBackend({} as any)
+
+export const InsightIntroPageExample = () => (
+    <CodeInsightsBackendContext.Provider value={API}>
+        <IntroCreationPage telemetryService={NOOP_TELEMETRY_SERVICE} />
+    </CodeInsightsBackendContext.Provider>
+)

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.module.scss
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.module.scss
@@ -25,7 +25,7 @@
     display: flex;
     flex-direction: column;
     background-color: transparent;
-    margin-top: 1rem;
+    margin-top: 2rem;
     padding: 0;
 
     b {

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.module.scss
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.module.scss
@@ -62,23 +62,3 @@
     object-fit: contain;
     width: 3rem;
 }
-
-.capture-chart-wrapper {
-    position: relative;
-}
-
-.capture-chart-icon {
-    position: absolute;
-    bottom: 0;
-    right: 0;
-}
-
-.capture-group-icon {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 50%;
-    background-color: var(--color-bg-3);
-    width: 2rem;
-    height: 2rem;
-}

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.tsx
@@ -2,7 +2,11 @@ import classNames from 'classnames'
 import React from 'react'
 import { Link } from 'react-router-dom'
 
-import { CaptureGroupInsight, PieChart, ThreeLineChart } from '../../../../../modals/components/MediaCharts'
+import {
+    CaptureGroupInsightChart,
+    LangStatsInsightChart,
+    SearchBasedInsightChart,
+} from '../../../../../modals/components/MediaCharts'
 
 import styles from './InsightCards.module.scss'
 
@@ -45,7 +49,7 @@ const CardBody: React.FunctionComponent<{ title: string }> = props => {
 
 export const SearchInsightCard: React.FunctionComponent<CardProps> = props => (
     <Card {...props} footerText="Redis, PostgreSQL and SQLite database usage.">
-        <ThreeLineChart viewBox="0 0 169 148" className={styles.chart} />
+        <SearchBasedInsightChart className={styles.chart} />
         <CardBody title="Track">
             Insight <b>based on a custom Sourcegraph search query</b> that creates visualization of the data series you
             will define <b>manually.</b>
@@ -55,7 +59,7 @@ export const SearchInsightCard: React.FunctionComponent<CardProps> = props => (
 
 export const LangStatsInsightCard: React.FunctionComponent<CardProps> = props => (
     <Card {...props}>
-        <PieChart viewBox="0 0 169 148" className={styles.chart} />
+        <LangStatsInsightChart viewBox="0 0 169 148" className={styles.chart} />
         <CardBody title="Language usage">
             Shows usage of languages in your repository based on number of lines of code.
         </CardBody>
@@ -64,10 +68,7 @@ export const LangStatsInsightCard: React.FunctionComponent<CardProps> = props =>
 
 export const CaptureGroupInsightCard: React.FunctionComponent<CardProps> = props => (
     <Card {...props} footerText="Detecting and tracking language or package versions.">
-        <div className={styles.captureChartWrapper}>
-            <CaptureGroupInsight className={styles.chart} />
-            <CaptureGroupIcon className={styles.captureChartIcon} />
-        </div>
+        <CaptureGroupInsightChart className={styles.chart} />
 
         <CardBody title="Detect and track">
             Data series will be generated dynamically for each unique value from the
@@ -75,17 +76,6 @@ export const CaptureGroupInsightCard: React.FunctionComponent<CardProps> = props
             appear in the code base.
         </CardBody>
     </Card>
-)
-
-const CaptureGroupIcon: React.FunctionComponent<React.HTMLAttributes<HTMLElement>> = props => (
-    <div className={classNames(props.className, styles.captureGroupIcon)}>
-        <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path
-                d="M9.76238 9.82535C9.49591 9.86573 9.22943 9.88995 8.95488 9.88995C8.68033 9.88995 8.41386 9.86573 8.14738 9.82535V6.99103L6.12863 8.99363C5.72488 8.6787 5.32113 8.27495 5.00621 7.8712L7.00881 5.85245H4.17448C4.13411 5.58598 4.10988 5.3195 4.10988 5.04495C4.10988 4.7704 4.13411 4.50393 4.17448 4.23745H7.00881L5.00621 2.2187C5.15963 2.01683 5.32113 1.81495 5.53108 1.62115C5.72488 1.4112 5.92676 1.2497 6.12863 1.09628L8.14738 3.09888V0.264551C8.41386 0.224176 8.68033 0.199951 8.95488 0.199951C9.22943 0.199951 9.49591 0.224176 9.76238 0.264551V3.09888L11.7811 1.09628C12.1849 1.4112 12.5886 1.81495 12.9036 2.2187L10.901 4.23745H13.7353C13.7757 4.50393 13.7999 4.7704 13.7999 5.04495C13.7999 5.3195 13.7757 5.58598 13.7353 5.85245H10.901L12.9036 7.8712C12.7501 8.07308 12.5886 8.27495 12.3787 8.46875C12.1849 8.6787 11.983 8.8402 11.7811 8.99363L9.76238 6.99103V9.82535ZM0.879883 11.505C0.879883 11.0766 1.05003 10.6658 1.35291 10.363C1.65578 10.0601 2.06656 9.88995 2.49488 9.88995C2.92321 9.88995 3.33399 10.0601 3.63686 10.363C3.93973 10.6658 4.10988 11.0766 4.10988 11.505C4.10988 11.9333 3.93973 12.3441 3.63686 12.6469C3.33399 12.9498 2.92321 13.12 2.49488 13.12C2.06656 13.12 1.65578 12.9498 1.35291 12.6469C1.05003 12.3441 0.879883 11.9333 0.879883 11.505Z"
-                fill="var(--body-color)"
-            />
-        </svg>
-    </div>
 )
 
 export const ExtensionInsightsCard: React.FunctionComponent<CardProps> = props => (


### PR DESCRIPTION
Follow up for https://github.com/sourcegraph/sourcegraph/pull/28460

This PR updates
- chart preview card according to [the latest design spec ](https://www.figma.com/file/qomcHxvHjrwfS3We6NVHGh/Automatically-generated-data-series-%5Breview%5D?node-id=1665%3A28079)
- Spacing between card chart and card body (@AlicjaSuska since we go with "example block inside the card" way I set spacing for card body to 2rem instead of 2.5rem, visually it doesn't make any difference add it a little reduces the height of the card. 

Final result 
<img width="1281" alt="Screenshot 2021-12-14 at 15 35 52" src="https://user-images.githubusercontent.com/18492575/145999984-c6d11635-a968-49d2-92b4-e1c2bca70b82.png">


