### PR TITLE
Change "View files" button to "Browse files at @[commit]"

### DIFF
--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -192,10 +192,10 @@ export const GitCommitNode: React.FunctionComponent<GitCommitNodeProps> = ({
             <Link
                 className="btn btn-sm btn-outline-secondary align-center d-inline-flex"
                 to={node.tree.canonicalURL}
-                data-tooltip="View files at this commit"
+                data-tooltip="Browse files in the repository at this point in history"
             >
                 <FileDocumentIcon className="icon-inline mr-1" />
-                View files in commit
+                Browse files at @{node.abbreviatedOID}
             </Link>
             {diffModeSelector()}
         </div>


### PR DESCRIPTION
Changes "View files" button to have a clearer label. 
More details are available in the issue: https://github.com/sourcegraph/sourcegraph/issues/28972

## After the change
![image](https://user-images.githubusercontent.com/2196347/146014130-f260e67a-b5b9-484c-94f4-27e4d83561e5.png)
