### PR TITLE
Code Insights: Fix insights ping id types

### DIFF
--- a/client/web/src/enterprise/insights/components/creation-ui-kit/live-preview-container/LivePreviewContainer.tsx
+++ b/client/web/src/enterprise/insights/components/creation-ui-kit/live-preview-container/LivePreviewContainer.tsx
@@ -60,7 +60,6 @@ export function LivePreviewContainer(props: PropsWithChildren<LivePreviewContain
                         <View.Content
                             telemetryService={NOOP_TELEMETRY_SERVICE}
                             content={[dataOrError ?? defaultMock]}
-                            viewID="search-insight-live-preview"
                             layout={ChartViewContentLayout.ByContentSize}
                             className={classNames({ [styles.chartWithMock]: !dataOrError })}
                         />

--- a/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.tsx
@@ -34,6 +34,37 @@ export const SmartInsightsViewGrid: React.FunctionComponent<SmartInsightsViewGri
         setLayouts(insightLayoutGenerator(insights))
     }, [insights])
 
+    const trackUICustomization = useCallback(
+        (item: Layout) => {
+            try {
+                const insight = insights.find(insight => item.i === insight.id)
+
+                if (insight) {
+                    telemetryService.log(
+                        'InsightUICustomization',
+                        { insightType: insight.viewType },
+                        { insightType: insight.viewType }
+                    )
+                }
+            } catch {
+                // noop
+            }
+        },
+        [telemetryService, insights]
+    )
+
+    const handleResizeStart = useCallback(
+        (item: Layout) => {
+            setResizeView(item)
+            trackUICustomization(item)
+        },
+        [trackUICustomization]
+    )
+
+    const handleResizeStop = useCallback((item: Layout) => {
+        setResizeView(null)
+    }, [])
+
     const handleLayoutChange = useCallback(
         (currentLayout: Layout[], allLayouts: Layouts): void => {
             setLayouts(recalculateGridLayout(allLayouts, insights))
@@ -41,16 +72,12 @@ export const SmartInsightsViewGrid: React.FunctionComponent<SmartInsightsViewGri
         [insights]
     )
 
-    const handleResizeStop = useCallback((item: Layout) => {
-        setResizeView(null)
-    }, [])
-
     return (
         <ViewGrid
             layouts={layouts}
-            telemetryService={telemetryService}
-            onResizeStart={setResizeView}
+            onResizeStart={handleResizeStart}
             onResizeStop={handleResizeStop}
+            onDragStart={trackUICustomization}
             onLayoutChange={handleLayoutChange}
         >
             {insights.map(insight => (

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -178,7 +178,7 @@ export const BackendInsightView: React.FunctionComponent<BackendInsightProps> = 
                         <View.Content
                             telemetryService={telemetryService}
                             content={data.view.content}
-                            viewID={insight.id}
+                            viewTrackingType={insight.viewType}
                             containerClassName="be-insight-card"
                             alert={
                                 <BackendAlertOverlay

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/built-in-insight/BuiltInInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/built-in-insight/BuiltInInsight.tsx
@@ -81,7 +81,7 @@ export function BuiltInInsight<D extends keyof ViewContexts>(props: BuiltInInsig
                         <View.Content
                             telemetryService={telemetryService}
                             content={data.view.content}
-                            viewID={insight.id}
+                            viewTrackingType={insight.viewType}
                             containerClassName="extension-insight-card"
                         />
                     </LineChartSettingsContext.Provider>

--- a/client/web/src/enterprise/insights/sections/ExtensionViewsDirectorySection.tsx
+++ b/client/web/src/enterprise/insights/sections/ExtensionViewsDirectorySection.tsx
@@ -124,7 +124,7 @@ const ExtensionViewsDirectorySectionContent: React.FunctionComponent<ExtensionVi
     }
 
     return (
-        <ViewGrid viewIds={allViewIds} telemetryService={props.telemetryService} className={className}>
+        <ViewGrid viewIds={allViewIds} className={className}>
             {/* Render extension views for the directory page */}
             {extensionViews.map(view => (
                 <StaticView key={view.id} content={view} telemetryService={props.telemetryService} />

--- a/client/web/src/enterprise/insights/sections/ExtensionViewsHomepageSection.tsx
+++ b/client/web/src/enterprise/insights/sections/ExtensionViewsHomepageSection.tsx
@@ -77,7 +77,7 @@ const ExtensionViewsHomepageSectionContent: React.FunctionComponent<ExtensionVie
     const allViewIds = useMemo(() => [...extensionViews, ...insights].map(view => view.id), [extensionViews, insights])
 
     return (
-        <ViewGrid viewIds={allViewIds} telemetryService={telemetryService} className={className}>
+        <ViewGrid viewIds={allViewIds} className={className}>
             {/* Render extension views for the search page */}
             {extensionViews.map(view => (
                 <StaticView key={view.id} content={view} telemetryService={telemetryService} />

--- a/client/web/src/insights/sections/ExtensionViewsDirectorySection.tsx
+++ b/client/web/src/insights/sections/ExtensionViewsDirectorySection.tsx
@@ -63,10 +63,7 @@ export const ExtensionViewsDirectorySection: React.FunctionComponent<ExtensionVi
     }
 
     return (
-        <ViewGrid
-            viewIds={extensionViews.map(view => view.id)}
-            className={className}
-        >
+        <ViewGrid viewIds={extensionViews.map(view => view.id)} className={className}>
             {/* Render extension views for the directory page */}
             {extensionViews.map(view => (
                 <StaticView key={view.id} content={view} telemetryService={props.telemetryService} />

--- a/client/web/src/insights/sections/ExtensionViewsDirectorySection.tsx
+++ b/client/web/src/insights/sections/ExtensionViewsDirectorySection.tsx
@@ -65,7 +65,6 @@ export const ExtensionViewsDirectorySection: React.FunctionComponent<ExtensionVi
     return (
         <ViewGrid
             viewIds={extensionViews.map(view => view.id)}
-            telemetryService={props.telemetryService}
             className={className}
         >
             {/* Render extension views for the directory page */}

--- a/client/web/src/insights/sections/ExtensionViewsHomepageSection.tsx
+++ b/client/web/src/insights/sections/ExtensionViewsHomepageSection.tsx
@@ -40,11 +40,7 @@ export const ExtensionViewsHomepageSection: React.FunctionComponent<ExtensionVie
     }
 
     return (
-        <ViewGrid
-            viewIds={extensionViews.map(view => view.id)}
-            telemetryService={props.telemetryService}
-            className={className}
-        >
+        <ViewGrid viewIds={extensionViews.map(view => view.id)} className={className}>
             {/* Render extension views for the search page */}
             {extensionViews.map(view => (
                 <StaticView key={view.id} content={view} telemetryService={props.telemetryService} />

--- a/client/web/src/views/components/StaticView.tsx
+++ b/client/web/src/views/components/StaticView.tsx
@@ -43,7 +43,6 @@ export const StaticView = forwardRef<HTMLElement, StaticViewProps>((props, refer
                 <View.Content
                     telemetryService={telemetryService}
                     content={view.content}
-                    viewID={contentId}
                     containerClassName="insight-content-card"
                 />
             )}

--- a/client/web/src/views/components/view-grid/ViewGrid.story.tsx
+++ b/client/web/src/views/components/view-grid/ViewGrid.story.tsx
@@ -19,15 +19,11 @@ export default {
 } as Meta
 
 export const SimpleViewGrid: Story = () => (
-    <ViewGrid viewIds={['1', '2', '3']} telemetryService={NOOP_TELEMETRY_SERVICE}>
+    <ViewGrid viewIds={['1', '2', '3']}>
         <View.Root key="1" title="Empty view" />
 
         <View.Root key="2" title="View with chart">
-            <View.Content
-                viewID="unique view id"
-                content={[LINE_CHART_CONTENT_MOCK]}
-                telemetryService={NOOP_TELEMETRY_SERVICE}
-            />
+            <View.Content content={[LINE_CHART_CONTENT_MOCK]} telemetryService={NOOP_TELEMETRY_SERVICE} />
         </View.Root>
 
         <View.Root
@@ -43,11 +39,7 @@ export const SimpleViewGrid: Story = () => (
                 </>
             }
         >
-            <View.Content
-                viewID="unique view id"
-                content={[LINE_CHART_CONTENT_MOCK]}
-                telemetryService={NOOP_TELEMETRY_SERVICE}
-            />
+            <View.Content content={[LINE_CHART_CONTENT_MOCK]} telemetryService={NOOP_TELEMETRY_SERVICE} />
         </View.Root>
     </ViewGrid>
 )

--- a/client/web/src/views/components/view-grid/ViewGrid.tsx
+++ b/client/web/src/views/components/view-grid/ViewGrid.tsx
@@ -10,7 +10,6 @@ import {
     WidthProvider,
 } from 'react-grid-layout'
 
-import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { isFirefox } from '@sourcegraph/shared/src/util/browserDetection'
 
 import styles from './ViewGrid.module.scss'
@@ -71,13 +70,14 @@ export type ViewGridProps =
           viewIds?: never
       }
 
-interface ViewGridCommonProps extends TelemetryProps {
+interface ViewGridCommonProps {
     /** Custom classname for root element of the grid. */
     className?: string
 
     onLayoutChange?: (currentLayout: Layout[], allLayouts: Layouts) => void
     onResizeStart?: (newItem: Layout) => void
     onResizeStop?: (newItem: Layout) => void
+    onDragStart?: (newItem: Layout) => void
 }
 
 /**
@@ -87,49 +87,27 @@ export const ViewGrid: React.FunctionComponent<PropsWithChildren<ViewGridProps &
     const {
         layouts,
         viewIds = [],
-        telemetryService,
         children,
         className,
         onLayoutChange,
         onResizeStart = noop,
         onResizeStop = noop,
+        onDragStart = noop,
     } = props
 
-    const trackUICustomization = useCallback(
-        (item: Layout) => {
-            try {
-                telemetryService.log(
-                    'InsightUICustomization',
-                    { insightType: item.i.split('.')[0] },
-                    { insightType: item.i.split('.')[0] }
-                )
-            } catch {
-                // noop
-            }
-        },
-        [telemetryService]
-    )
-
     const handleResizeStart: ReactGridLayout.ItemCallback = useCallback(
-        (_layout, item, newItem) => {
-            onResizeStart(newItem)
-            trackUICustomization(item)
-        },
-        [trackUICustomization, onResizeStart]
+        (_layout, item, newItem) => onResizeStart(newItem),
+        [onResizeStart]
     )
 
     const handleResizeStop: ReactGridLayout.ItemCallback = useCallback(
-        (_layout, item, newItem) => {
-            onResizeStop(newItem)
-        },
+        (_layout, item, newItem) => onResizeStop(newItem),
         [onResizeStop]
     )
 
     const handleDragStart: ReactGridLayout.ItemCallback = useCallback(
-        (_layout, item, newItem) => {
-            trackUICustomization(item)
-        },
-        [trackUICustomization]
+        (_layout, item, newItem) => onDragStart(newItem),
+        [onDragStart]
     )
 
     // For Firefox we can't use css transform/translate to put view grid item in right place.

--- a/client/web/src/views/components/view/View.story.tsx
+++ b/client/web/src/views/components/view/View.story.tsx
@@ -69,7 +69,7 @@ export const EmptyView: Story = () => <View.Root {...standardViewProps} title="E
 
 export const ViewWithChartContent: Story = () => (
     <View.Root {...standardViewProps} title="Chart view" subtitle="Subtitle chart description">
-        <View.Content viewID="unique view id" content={[LINE_CHART_DATA]} telemetryService={NOOP_TELEMETRY_SERVICE} />
+        <View.Content content={[LINE_CHART_DATA]} telemetryService={NOOP_TELEMETRY_SERVICE} />
     </View.Root>
 )
 
@@ -122,6 +122,6 @@ export const ViewWithContextMenu: Story = () => (
             </>
         }
     >
-        <View.Content viewID="unique view id" content={[LINE_CHART_DATA]} telemetryService={NOOP_TELEMETRY_SERVICE} />
+        <View.Content content={[LINE_CHART_DATA]} telemetryService={NOOP_TELEMETRY_SERVICE} />
     </View.Root>
 )


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/27911

Previously in code insights components we used insight id also as an insight type (because id had special insights prefixes). With new GQl API this ins't a case anymore. New approach for tracking insight types is using insight.viewType as a type for tracking.
