### PR TITLE
web: add @oleggromov to the team/frontend-platform labeler config

### DIFF
--- a/.github/teams.yml
+++ b/.github/teams.yml
@@ -4,3 +4,4 @@ team/frontend-platform:
   - '@valerybugakov'
   - '@5h1ru'
   - '@pdubroy'
+  - '@oleggromov'


### PR DESCRIPTION
Adding @oleggromov to the team-labeler bot config. The `team/frontend-platform` label will be added to each of his PRs, which is required for our Slack automation configured in the [#frontend-platform-github-feed](https://sourcegraph.slack.com/archives/C01QBJPSM4H) channel.