### PR TITLE
Broken Link to Documentation Style Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The `doc` directory has additional documentation for developing and understandin
 - [Architecture](./doc/dev/background-information/architecture/index.md): high-level architecture
 - [Database setup](./doc/dev/background-information/postgresql.md): database best practices
 - [Go style guide](./doc/dev/background-information/languages/go.md)
-- [Documentation style guide](https://handbook.sourcegraph.com/engineering/product_documentation)
+- [Documentation style guide](https://handbook.sourcegraph.com/departments/product-engineering/engineering/process/product_documentation)
 - [GraphQL API](./doc/api/graphql/index.md): useful tips when modifying the GraphQL API
 - [Contributing](./CONTRIBUTING.md)
 


### PR DESCRIPTION
Broken link points to: https://handbook.sourcegraph.com/engineering/product_documentation

Updated to point at: https://handbook.sourcegraph.com/departments/product-engineering/engineering/process/product_documentation



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
