### PR TITLE
Code Insights: Fix insight card layout capture group

### DIFF
--- a/client/web/src/views/components/view/content/chart-view-content/charts/line/LineChart.module.scss
+++ b/client/web/src/views/components/view/content/chart-view-content/charts/line/LineChart.module.scss
@@ -18,6 +18,7 @@
     flex-grow: 1;
     min-height: 10rem;
     position: relative;
+    flex-basis: 50%;
 }
 
 .legend {
@@ -26,11 +27,11 @@
         flex-shrink: 0;
         min-width: 11rem;
         margin-left: 1rem;
-        width: 30%;
+        max-width: 30%;
     }
 }
 
-.legend-content {
+.legend-list {
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;

--- a/client/web/src/views/components/view/content/chart-view-content/charts/line/LineChart.tsx
+++ b/client/web/src/views/components/view/content/chart-view-content/charts/line/LineChart.tsx
@@ -49,23 +49,19 @@ export function LineChart<Datum extends object>(props: LineChartProps<Datum>): R
                     {({ width, height }) => <LineChartContent {...otherProps} width={width} height={height} />}
                 </ParentSize>
 
-                <ScrollBox
-                    as="ul"
-                    scrollEnabled={isHorizontal}
-                    aria-hidden={true}
-                    rootClassName={classNames({ [styles.legendHorizontal]: isHorizontal })}
-                    className={classNames(styles.legendContent, { [styles.legendContentHorizontal]: isHorizontal })}
-                >
-                    {props.series.map(line => (
-                        <li key={line.dataKey.toString()} className={styles.legendItem}>
-                            <div
-                                /* eslint-disable-next-line react/forbid-dom-props */
-                                style={{ backgroundColor: getLineStroke(line) }}
-                                className={styles.legendMark}
-                            />
-                            {line.name}
-                        </li>
-                    ))}
+                <ScrollBox aria-hidden={true} className={classNames({ [styles.legendHorizontal]: isHorizontal })}>
+                    <ul className={classNames(styles.legendList, { [styles.legendListHorizontal]: isHorizontal })}>
+                        {props.series.map(line => (
+                            <li key={line.dataKey.toString()} className={styles.legendItem}>
+                                <div
+                                    /* eslint-disable-next-line react/forbid-dom-props */
+                                    style={{ backgroundColor: getLineStroke(line) }}
+                                    className={styles.legendMark}
+                                />
+                                {line.name}
+                            </li>
+                        ))}
+                    </ul>
                 </ScrollBox>
             </div>
         </EventEmitterProvider>

--- a/client/web/src/views/components/view/content/chart-view-content/charts/line/components/scroll-box/ScrollBox.module.scss
+++ b/client/web/src/views/components/view/content/chart-view-content/charts/line/components/scroll-box/ScrollBox.module.scss
@@ -1,54 +1,40 @@
 .root {
     position: relative;
-}
+    overflow: auto;
 
-.fader,
-.scrollbox {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    top: 0;
-    left: 0;
+    &--with-top-fader {
+        .fader--top {
+            opacity: 1;
+        }
+    }
+
+    &--with-bottom-fader {
+        .fader--bottom {
+            opacity: 1;
+        }
+    }
 }
 
 .fader {
-    &::before,
-    &::after {
-        display: none;
-        content: '';
-        position: absolute;
-        z-index: 1;
-        height: 3rem;
-        width: 100%;
-    }
+    display: block;
+    content: '';
+    position: sticky;
+    z-index: 1;
+    height: 3rem;
+    width: 100%;
+    opacity: 0;
 
-    &::before {
+    &--top {
         top: 0;
-        left: 0;
-
         background: linear-gradient(0deg, rgba(249, 250, 251, 0) 0%, var(--card-bg) 100%);
     }
 
-    &::after {
-        bottom: 0;
-        left: 0;
-
+    &--bottom {
+        top: calc(100% - 3rem);
         background: linear-gradient(180deg, rgba(249, 250, 251, 0) 0%, var(--card-bg) 100%);
-    }
-
-    &--has-top-scroll {
-        &::before {
-            display: block;
-        }
-    }
-
-    &--has-bottom-scroll {
-        &::after {
-            display: block;
-        }
     }
 }
 
 .scrollbox {
-    overflow: auto;
+    margin-top: -6rem;
 }

--- a/client/web/src/views/components/view/content/chart-view-content/charts/line/components/scroll-box/ScrollBox.tsx
+++ b/client/web/src/views/components/view/content/chart-view-content/charts/line/components/scroll-box/ScrollBox.tsx
@@ -3,51 +3,55 @@ import React, { useEffect, useRef } from 'react'
 
 import styles from './ScrollBox.module.scss'
 
-const addShutterElementsToTarget = (element: HTMLDivElement, fader: HTMLDivElement): void => {
+const addShutterElementsToTarget = (element: HTMLDivElement): void => {
     const { scrollTop, scrollHeight, offsetHeight } = element
 
     if (scrollTop === 0) {
-        fader?.classList.remove(styles.faderHasTopScroll)
+        element.classList.remove(styles.rootWithTopFader)
     } else {
-        fader?.classList.add(styles.faderHasTopScroll)
+        element.classList.add(styles.rootWithTopFader)
     }
 
     if (offsetHeight + scrollTop === scrollHeight) {
-        fader?.classList.remove(styles.faderHasBottomScroll)
+        element.classList.remove(styles.rootWithBottomFader)
     } else {
-        fader?.classList.add(styles.faderHasBottomScroll)
+        element.classList.add(styles.rootWithBottomFader)
     }
 }
 
 interface ScrollBoxProps extends React.HTMLAttributes<HTMLDivElement> {
-    scrollEnabled?: boolean
-    as?: React.ElementType
-    rootClassName?: string
+    className?: string
 }
 
 export const ScrollBox: React.FunctionComponent<ScrollBoxProps> = props => {
-    const { children, as: Component = 'div', scrollEnabled = true, rootClassName, ...otherProps } = props
+    const { children, className, ...otherProps } = props
 
     const scrollBoxReference = useRef<HTMLDivElement>(null)
-    const faderReference = useRef<HTMLDivElement>(null)
 
     useEffect(() => {
-        const fader = faderReference.current
         const scrollBoxElement = scrollBoxReference.current
 
-        if (!scrollBoxElement || !fader || !scrollEnabled) {
+        if (!scrollBoxElement) {
             return
         }
 
         // On mount initial call
-        addShutterElementsToTarget(scrollBoxElement, fader)
+        addShutterElementsToTarget(scrollBoxElement)
+    })
+
+    useEffect(() => {
+        const scrollBoxElement = scrollBoxReference.current
+
+        if (!scrollBoxElement) {
+            return
+        }
 
         function onScroll(event: Event): void {
             if (!event.target) {
                 return
             }
 
-            addShutterElementsToTarget(event.target as HTMLDivElement, fader as HTMLDivElement)
+            addShutterElementsToTarget(event.target as HTMLDivElement)
 
             event.stopPropagation()
             event.preventDefault()
@@ -56,24 +60,16 @@ export const ScrollBox: React.FunctionComponent<ScrollBoxProps> = props => {
         scrollBoxElement.addEventListener('scroll', onScroll)
 
         return () => scrollBoxElement.removeEventListener('scroll', onScroll)
-    }, [scrollEnabled])
-
-    // If block doesn't have scroll content we render simple component without additional
-    // shutter elements for scroll visual effects
-    if (!scrollEnabled) {
-        return (
-            <Component {...otherProps} className={classNames(otherProps.className, rootClassName)}>
-                {children}
-            </Component>
-        )
-    }
+    }, [])
 
     return (
-        <div {...otherProps} className={classNames(styles.root, rootClassName)}>
-            <div ref={faderReference} className={styles.fader} />
-            <Component ref={scrollBoxReference} className={classNames(otherProps.className, styles.scrollbox)}>
-                {children}
-            </Component>
+        <div {...otherProps} ref={scrollBoxReference} className={classNames(styles.root, className)}>
+            <div className={classNames(styles.fader, styles.faderTop)} />
+            <div className={classNames(styles.fader, styles.faderBottom)} />
+
+            <div className={styles.scrollbox}>
+                { children }
+            </div>
         </div>
     )
 }

--- a/client/web/src/views/components/view/content/chart-view-content/charts/line/components/scroll-box/ScrollBox.tsx
+++ b/client/web/src/views/components/view/content/chart-view-content/charts/line/components/scroll-box/ScrollBox.tsx
@@ -67,9 +67,7 @@ export const ScrollBox: React.FunctionComponent<ScrollBoxProps> = props => {
             <div className={classNames(styles.fader, styles.faderTop)} />
             <div className={classNames(styles.fader, styles.faderBottom)} />
 
-            <div className={styles.scrollbox}>
-                { children }
-            </div>
+            <div className={styles.scrollbox}>{children}</div>
         </div>
     )
 }


### PR DESCRIPTION

This PR fixes the card layout styles in order to support cards with small sizes and a lot of content in the legend block. 

<table>
<tr><th>Card size</th><th>Result</th></tr>
<tr>
<th>Standard size (6 out of 12 columns)</th>
<th>
<img width="591" alt="Screenshot 2021-12-14 at 21 58 22" src="https://user-images.githubusercontent.com/18492575/146062278-9be85a08-4a33-4797-b04b-a6bbe1da4dda.png">

</th></tr>
<tr><th>
Middle size 5 out of 12 columns
</th><th>

<img width="508" alt="Screenshot 2021-12-14 at 21 59 27" src="https://user-images.githubusercontent.com/18492575/146062554-5a1c48c4-a896-4135-b695-6bf73600254d.png">
</th></tr>

<tr><th>Small size 4 out of 12 minimum width for capture group insight</th><th>
<img width="411" alt="Screenshot 2021-12-14 at 21 59 47" src="https://user-images.githubusercontent.com/18492575/146062664-80eff1c6-f0ea-46ed-8d8b-bd7ec6f109ff.png">

</th></tr>
</table>