### PR TITLE
release: do not bump minimumUpgradeableVersion on patches

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -401,12 +401,14 @@ cc @${config.captainGitHubUsername}
                             `comby -in-place 'latestReleaseDockerComposeOrPureDocker = newBuild(":[1]")' "latestReleaseDockerComposeOrPureDocker = newBuild(\\"${release.version}\\")" cmd/frontend/internal/app/updatecheck/handler.go`,
 
                             // Support current release as the "previous release" going forward
-                            `comby -in-place 'const minimumUpgradeableVersion = ":[1]"' 'const minimumUpgradeableVersion = "${release.version}"' enterprise/dev/ci/internal/ci/*.go`,
+                            notPatchRelease
+                                ? `comby -in-place 'const minimumUpgradeableVersion = ":[1]"' 'const minimumUpgradeableVersion = "${release.version}"' enterprise/dev/ci/internal/ci/*.go`
+                                : 'echo "Skipping minimumUpgradeableVersion bump on patch release"',
 
                             // Add a stub to add upgrade guide entries
                             notPatchRelease
                                 ? `${sed} -i -E '/GENERATE UPGRADE GUIDE ON RELEASE/a \\\n\\n${upgradeGuideEntry}' doc/admin/updates/*.md`
-                                : 'echo "Skipping upgrade guide entries"',
+                                : 'echo "Skipping upgrade guide entries on patch release"',
                         ],
                         ...prBodyAndDraftState(
                             ((): string[] => {

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -208,7 +208,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		}))
 
 		// Test upgrades from mininum upgradeable Sourcegraph version - updated by release tool
-		const minimumUpgradeableVersion = "3.34.2"
+		const minimumUpgradeableVersion = "3.34.0"
 
 		// Various integration tests
 		ops.Append(


### PR DESCRIPTION
[Upgrades are allowed to skip patches](https://docs.sourcegraph.com/admin/updates), so the upgrade tests should be from the previous non-patch release instead of just the previous release.