### PR TITLE
diskcache: fix use-after-finish for background fetch

### DIFF
--- a/internal/diskcache/cache.go
+++ b/internal/diskcache/cache.go
@@ -170,12 +170,19 @@ func (s *store) OpenWithPath(ctx context.Context, key []string, fetcher FetcherW
 	}
 	ch := make(chan result, 1)
 	go func(ctx context.Context) {
+		var err error
+		var f *File
+		ctx, trace, endObservation := s.observe.backgroundFetch.WithAndLogger(ctx, &err, observation.Args{LogFields: []otelog.Field{
+			otelog.Bool("withBackgroundTimeout", s.backgroundTimeout != 0),
+		}})
+		defer endObservation(1, observation.Args{})
+
 		if s.backgroundTimeout != 0 {
 			var cancel context.CancelFunc
 			ctx, cancel = withIsolatedTimeout(ctx, s.backgroundTimeout)
 			defer cancel()
 		}
-		f, err := doFetch(ctx, path, fetcher, trace)
+		f, err = doFetch(ctx, path, fetcher, trace)
 		ch <- result{f, err}
 	}(ctx)
 

--- a/internal/diskcache/observability.go
+++ b/internal/diskcache/observability.go
@@ -8,8 +8,9 @@ import (
 )
 
 type operations struct {
-	cachedFetch *observation.Operation
-	evict       *observation.Operation
+	cachedFetch     *observation.Operation
+	evict           *observation.Operation
+	backgroundFetch *observation.Operation
 }
 
 func newOperations(observationContext *observation.Context, component string) *operations {
@@ -39,7 +40,8 @@ func newOperations(observationContext *observation.Context, component string) *o
 	}
 
 	return &operations{
-		cachedFetch: op("Cached Fetch", observationContext),
-		evict:       op("Evict", evictObservationContext),
+		cachedFetch:     op("Cached Fetch", observationContext),
+		evict:           op("Evict", evictObservationContext),
+		backgroundFetch: op("Background Fetch", observationContext),
 	}
 }


### PR DESCRIPTION
From the people behind x/net/trace:
![image](https://user-images.githubusercontent.com/18282288/146069423-34177389-4391-4170-b5ed-24505cc9209c.png)

And a use-after-finish it indeed was. Hard to repro the panic locally as net/trace does a lot of things async and buffered, so my assumption is that the timing just happened to align with the moons and caused this.
