### PR TITLE
Code monitors: Expose webhooks through GraphQL

### DIFF
--- a/client/web/src/enterprise/code-monitoring/backend.ts
+++ b/client/web/src/enterprise/code-monitoring/backend.ts
@@ -57,12 +57,12 @@ const CodeMonitorFragment = gql`
                 ... on MonitorWebhook {
                     id
                     enabled
-					url
+                    url
                 }
                 ... on MonitorSlackWebhook {
                     id
                     enabled
-					url
+                    url
                 }
             }
         }
@@ -198,13 +198,13 @@ export const fetchCodeMonitor = (id: string): Observable<FetchCodeMonitorResult>
                             }
                             ... on MonitorWebhook {
                                 id
-								enabled
-								url
+                                enabled
+                                url
                             }
                             ... on MonitorSlackWebhook {
                                 id
-								enabled
-								url
+                                enabled
+                                url
                             }
                         }
                     }

--- a/client/web/src/enterprise/code-monitoring/backend.ts
+++ b/client/web/src/enterprise/code-monitoring/backend.ts
@@ -54,6 +54,16 @@ const CodeMonitorFragment = gql`
                         }
                     }
                 }
+                ... on MonitorWebhook {
+                    id
+                    enabled
+					url
+                }
+                ... on MonitorSlackWebhook {
+                    id
+                    enabled
+					url
+                }
             }
         }
     }
@@ -185,6 +195,16 @@ export const fetchCodeMonitor = (id: string): Observable<FetchCodeMonitorResult>
                                     }
                                 }
                                 enabled
+                            }
+                            ... on MonitorWebhook {
+                                id
+								enabled
+								url
+                            }
+                            ... on MonitorSlackWebhook {
+                                id
+								enabled
+								url
                             }
                         }
                     }

--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -155,7 +155,9 @@ type CreateTriggerArgs struct {
 }
 
 type CreateActionArgs struct {
-	Email *CreateActionEmailArgs
+	Email        *CreateActionEmailArgs
+	Webhook      *CreateActionWebhookArgs
+	SlackWebhook *CreateActionSlackWebhookArgs
 }
 
 type CreateActionEmailArgs struct {
@@ -163,6 +165,16 @@ type CreateActionEmailArgs struct {
 	Priority   string
 	Recipients []graphql.ID
 	Header     string
+}
+
+type CreateActionWebhookArgs struct {
+	Enabled bool
+	URL     string
+}
+
+type CreateActionSlackWebhookArgs struct {
+	Enabled bool
+	URL     string
 }
 
 type ToggleCodeMonitorArgs struct {
@@ -195,8 +207,20 @@ type EditActionEmailArgs struct {
 	Update *CreateActionEmailArgs
 }
 
+type EditActionWebhookArgs struct {
+	Id     *graphql.ID
+	Update *CreateActionWebhookArgs
+}
+
+type EditActionSlackWebhookArgs struct {
+	Id     *graphql.ID
+	Update *CreateActionSlackWebhookArgs
+}
+
 type EditActionArgs struct {
-	Email *EditActionEmailArgs
+	Email        *EditActionEmailArgs
+	Webhook      *EditActionWebhookArgs
+	SlackWebhook *EditActionSlackWebhookArgs
 }
 
 type EditTriggerArgs struct {

--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -72,7 +72,10 @@ type MonitorActionConnectionResolver interface {
 }
 
 type MonitorAction interface {
+	ID() graphql.ID
 	ToMonitorEmail() (MonitorEmailResolver, bool)
+	ToMonitorWebhook() (MonitorWebhookResolver, bool)
+	ToMonitorSlackWebhook() (MonitorSlackWebhookResolver, bool)
 }
 
 type MonitorEmailResolver interface {
@@ -81,6 +84,20 @@ type MonitorEmailResolver interface {
 	Priority() string
 	Header() string
 	Recipients(ctx context.Context, args *ListRecipientsArgs) (MonitorActionEmailRecipientsConnectionResolver, error)
+	Events(ctx context.Context, args *ListEventsArgs) (MonitorActionEventConnectionResolver, error)
+}
+
+type MonitorWebhookResolver interface {
+	ID() graphql.ID
+	Enabled() bool
+	URL() string
+	Events(ctx context.Context, args *ListEventsArgs) (MonitorActionEventConnectionResolver, error)
+}
+
+type MonitorSlackWebhookResolver interface {
+	ID() graphql.ID
+	Enabled() bool
+	URL() string
 	Events(ctx context.Context, args *ListEventsArgs) (MonitorActionEventConnectionResolver, error)
 }
 

--- a/cmd/frontend/graphqlbackend/code_monitors.graphql
+++ b/cmd/frontend/graphqlbackend/code_monitors.graphql
@@ -272,7 +272,7 @@ type MonitorActionConnection {
 """
 Supported actions for code monitors.
 """
-union MonitorAction = MonitorEmail
+union MonitorAction = MonitorEmail | MonitorWebhook | MonitorSlackWebhook
 
 """
 Email is one of the supported actions of code monitors.
@@ -328,6 +328,68 @@ The priority of an email action.
 enum MonitorEmailPriority {
     NORMAL
     CRITICAL
+}
+
+"""
+Webhook is one of the supported actions of code monitors.
+"""
+type MonitorWebhook implements Node {
+    """
+    The unique id of an email action.
+    """
+    id: ID!
+    """
+    Whether the email action is enabled or not.
+    """
+    enabled: Boolean!
+	"""
+	The endpoint the webhook event will be sent to
+	"""
+	url: String!
+    """
+    A list of events.
+    """
+    events(
+        """
+        Returns the first n events from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+    ): MonitorActionEventConnection!
+}
+
+"""
+SlackWebhook is one of the supported actions of code monitors.
+"""
+type MonitorSlackWebhook implements Node {
+    """
+    The unique id of an email action.
+    """
+    id: ID!
+    """
+    Whether the email action is enabled or not.
+    """
+    enabled: Boolean!
+	"""
+	The endpoint the Slack webhook event will be sent to
+	"""
+	url: String!
+    """
+    A list of events.
+    """
+    events(
+        """
+        Returns the first n events from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+    ): MonitorActionEventConnection!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/code_monitors.graphql
+++ b/cmd/frontend/graphqlbackend/code_monitors.graphql
@@ -462,6 +462,14 @@ input MonitorActionInput {
     An email action.
     """
     email: MonitorEmailInput
+    """
+    A webhook action.
+    """
+    webhook: MonitorWebhookInput
+    """
+    A Slack webhook action.
+    """
+    slackWebhook: MonitorSlackWebhookInput
 }
 
 """
@@ -485,6 +493,35 @@ input MonitorEmailInput {
     """
     header: String!
 }
+
+"""
+The input required to create a webhook action.
+"""
+input MonitorWebhookInput {
+    """
+    Whether the email action is enabled or not.
+    """
+    enabled: Boolean!
+	"""
+	The URL that will receive a payload when the action is triggered.
+	"""
+	url: String!
+}
+
+"""
+The input required to create a slack webhook action.
+"""
+input MonitorSlackWebhookInput {
+    """
+    Whether the slack webhook action is enabled or not.
+    """
+    enabled: Boolean!
+	"""
+	The URL that will receive a payload when the action is triggered.
+	"""
+	url: String!
+}
+
 """
 The input required to edit an action.
 """
@@ -493,6 +530,16 @@ input MonitorEditActionInput {
     An email action.
     """
     email: MonitorEditEmailInput
+
+    """
+    A webhook action.
+    """
+    webhook: MonitorEditWebhookInput
+
+    """
+    A Slack webhook action.
+    """
+    slackWebhook: MonitorEditSlackWebhookInput
 }
 
 """
@@ -507,4 +554,32 @@ input MonitorEditEmailInput {
     The desired state after the update.
     """
     update: MonitorEmailInput!
+}
+
+"""
+The input required to edit a webhook action.
+"""
+input MonitorEditWebhookInput {
+    """
+    The id of a webhook action.
+    """
+    id: ID
+    """
+    The desired state after the update.
+    """
+    update: MonitorWebhookInput!
+}
+
+"""
+The input required to edit a Slack webhook action.
+"""
+input MonitorEditSlackWebhookInput {
+    """
+    The id of a Slack webhook action.
+    """
+    id: ID
+    """
+    The desired state after the update.
+    """
+    update: MonitorSlackWebhookInput!
 }

--- a/cmd/frontend/graphqlbackend/code_monitors.graphql
+++ b/cmd/frontend/graphqlbackend/code_monitors.graphql
@@ -335,11 +335,11 @@ Webhook is one of the supported actions of code monitors.
 """
 type MonitorWebhook implements Node {
     """
-    The unique id of an email action.
+    The unique id of a webhook action.
     """
     id: ID!
     """
-    Whether the email action is enabled or not.
+    Whether the webhook action is enabled or not.
     """
     enabled: Boolean!
     """
@@ -366,11 +366,11 @@ SlackWebhook is one of the supported actions of code monitors.
 """
 type MonitorSlackWebhook implements Node {
     """
-    The unique id of an email action.
+    The unique id of an Slack webhook action.
     """
     id: ID!
     """
-    Whether the email action is enabled or not.
+    Whether the Slack webhook action is enabled or not.
     """
     enabled: Boolean!
     """
@@ -561,7 +561,7 @@ The input required to create a webhook action.
 """
 input MonitorWebhookInput {
     """
-    Whether the email action is enabled or not.
+    Whether the webhook action is enabled or not.
     """
     enabled: Boolean!
     """
@@ -571,11 +571,11 @@ input MonitorWebhookInput {
 }
 
 """
-The input required to create a slack webhook action.
+The input required to create a Slack webhook action.
 """
 input MonitorSlackWebhookInput {
     """
-    Whether the slack webhook action is enabled or not.
+    Whether the Slack webhook action is enabled or not.
     """
     enabled: Boolean!
     """

--- a/cmd/frontend/graphqlbackend/code_monitors.graphql
+++ b/cmd/frontend/graphqlbackend/code_monitors.graphql
@@ -342,10 +342,10 @@ type MonitorWebhook implements Node {
     Whether the email action is enabled or not.
     """
     enabled: Boolean!
-	"""
-	The endpoint the webhook event will be sent to
-	"""
-	url: String!
+    """
+    The endpoint the webhook event will be sent to
+    """
+    url: String!
     """
     A list of events.
     """
@@ -373,10 +373,10 @@ type MonitorSlackWebhook implements Node {
     Whether the email action is enabled or not.
     """
     enabled: Boolean!
-	"""
-	The endpoint the Slack webhook event will be sent to
-	"""
-	url: String!
+    """
+    The endpoint the Slack webhook event will be sent to
+    """
+    url: String!
     """
     A list of events.
     """
@@ -564,10 +564,10 @@ input MonitorWebhookInput {
     Whether the email action is enabled or not.
     """
     enabled: Boolean!
-	"""
-	The URL that will receive a payload when the action is triggered.
-	"""
-	url: String!
+    """
+    The URL that will receive a payload when the action is triggered.
+    """
+    url: String!
 }
 
 """
@@ -578,10 +578,10 @@ input MonitorSlackWebhookInput {
     Whether the slack webhook action is enabled or not.
     """
     enabled: Boolean!
-	"""
-	The URL that will receive a payload when the action is triggered.
-	"""
-	url: String!
+    """
+    The URL that will receive a payload when the action is triggered.
+    """
+    url: String!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/code_monitors.graphql
+++ b/cmd/frontend/graphqlbackend/code_monitors.graphql
@@ -609,7 +609,9 @@ The input required to edit an email action.
 """
 input MonitorEditEmailInput {
     """
-    The id of an email action.
+    The id of an email action. If unset, this will
+    be treated as a new email action and be created
+    rather than updated.
     """
     id: ID
     """
@@ -623,7 +625,9 @@ The input required to edit a webhook action.
 """
 input MonitorEditWebhookInput {
     """
-    The id of a webhook action.
+    The id of a webhook action. If unset, this will
+    be treated as a new webhook action and be created
+    rather than updated.
     """
     id: ID
     """
@@ -637,7 +641,9 @@ The input required to edit a Slack webhook action.
 """
 input MonitorEditSlackWebhookInput {
     """
-    The id of a Slack webhook action.
+    The id of a Slack webhook action. If unset, this will
+    be treated as a new Slack webhook action and be created
+    rather than updated.
     """
     id: ID
     """

--- a/cmd/frontend/graphqlbackend/node.go
+++ b/cmd/frontend/graphqlbackend/node.go
@@ -67,6 +67,16 @@ func (r *NodeResolver) ToMonitorEmail() (MonitorEmailResolver, bool) {
 	return n, ok
 }
 
+func (r *NodeResolver) ToMonitorWebhook() (MonitorWebhookResolver, bool) {
+	n, ok := r.Node.(MonitorWebhookResolver)
+	return n, ok
+}
+
+func (r *NodeResolver) ToMonitorSlackWebhook() (MonitorSlackWebhookResolver, bool) {
+	n, ok := r.Node.(MonitorSlackWebhookResolver)
+	return n, ok
+}
+
 func (r *NodeResolver) ToMonitorActionEvent() (MonitorActionEventResolver, bool) {
 	n, ok := r.Node.(MonitorActionEventResolver)
 	return n, ok

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/apitest/types.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/apitest/types.go
@@ -81,7 +81,7 @@ func (a *Action) UnmarshalJSON(b []byte) error {
 		a.SlackWebhook = &ActionSlackWebhook{}
 		return json.Unmarshal(b, &a.SlackWebhook)
 	default:
-		return errors.Errorf("unexpected typename %s", t.TypeName)
+		return errors.Errorf("unexpected typename %q", t.TypeName)
 	}
 }
 
@@ -98,12 +98,14 @@ type ActionWebhook struct {
 	Id      string
 	Enabled bool
 	URL     string
+	Events  ActionEventConnection
 }
 
 type ActionSlackWebhook struct {
 	Id      string
 	Enabled bool
 	URL     string
+	Events  ActionEventConnection
 }
 
 type RecipientsConnection struct {

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/apitest/types.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/apitest/types.go
@@ -1,6 +1,12 @@
 // Package apitest provided types used in testing.
 package apitest
 
+import (
+	"encoding/json"
+
+	"github.com/cockroachdb/errors"
+)
+
 type Response struct {
 	User User
 }
@@ -50,7 +56,33 @@ type ActionConnection struct {
 }
 
 type Action struct {
-	ActionEmail
+	Email        *ActionEmail
+	Webhook      *ActionWebhook
+	SlackWebhook *ActionSlackWebhook
+}
+
+func (a *Action) UnmarshalJSON(b []byte) error {
+	type typeUnmarshaller struct {
+		TypeName string `json:"__typename"`
+	}
+	var t typeUnmarshaller
+	if err := json.Unmarshal(b, &t); err != nil {
+		return err
+	}
+
+	switch t.TypeName {
+	case "MonitorEmail":
+		a.Email = &ActionEmail{}
+		return json.Unmarshal(b, &a.Email)
+	case "MonitorWebhook":
+		a.Webhook = &ActionWebhook{}
+		return json.Unmarshal(b, &a.Webhook)
+	case "MonitorSlackWebhook":
+		a.SlackWebhook = &ActionSlackWebhook{}
+		return json.Unmarshal(b, &a.SlackWebhook)
+	default:
+		return errors.Errorf("unexpected typename %s", t.TypeName)
+	}
 }
 
 type ActionEmail struct {
@@ -60,6 +92,18 @@ type ActionEmail struct {
 	Recipients RecipientsConnection
 	Header     string
 	Events     ActionEventConnection
+}
+
+type ActionWebhook struct {
+	Id      string
+	Enabled bool
+	URL     string
+}
+
+type ActionSlackWebhook struct {
+	Id      string
+	Enabled bool
+	URL     string
 }
 
 type RecipientsConnection struct {

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/main_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/main_test.go
@@ -9,23 +9,24 @@ import (
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/keegancsmith/sqlf"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-func insertTestUser(t *testing.T, db database.DB, name string, isAdmin bool) (userID int32) {
+func insertTestUser(t *testing.T, db database.DB, name string, isAdmin bool) *types.User {
 	t.Helper()
 
-	q := sqlf.Sprintf("INSERT INTO users (username, site_admin) VALUES (%s, %t) RETURNING id", name, isAdmin)
+	u, err := db.Users().Create(context.Background(), database.NewUser{Username: name})
+	require.NoError(t, err)
 
-	err := db.QueryRowContext(context.Background(), q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&userID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	err = db.Users().SetIsSiteAdmin(context.Background(), u.ID, isAdmin)
+	require.NoError(t, err)
 
-	return userID
+	return u
 }
 
 func addUserToOrg(t *testing.T, db database.DB, userID int32, orgID int32) {
@@ -94,15 +95,22 @@ func (r *Resolver) insertTestMonitorWithOpts(ctx context.Context, t *testing.T, 
 	t.Helper()
 
 	defaultOwner := relay.MarshalID("User", actor.FromContext(ctx).UID)
-	defaultAction := []*graphqlbackend.CreateActionArgs{
+	defaultActions := []*graphqlbackend.CreateActionArgs{
 		{Email: &graphqlbackend.CreateActionEmailArgs{
 			Enabled:    true,
 			Priority:   "NORMAL",
 			Recipients: []graphql.ID{defaultOwner},
-			Header:     "test header"}}}
+			Header:     "test header"}},
+		{Webhook: &graphqlbackend.CreateActionWebhookArgs{
+			Enabled: true,
+			URL:     "https://webhook.mcwebhook.face"}},
+		{SlackWebhook: &graphqlbackend.CreateActionSlackWebhookArgs{
+			Enabled: true,
+			URL:     "https://slackwebhook.mcslackwebhook.face"}},
+	}
 
 	options := options{
-		actions:   defaultAction,
+		actions:   defaultActions,
 		owner:     defaultOwner,
 		postHooks: nil,
 	}

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/main_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/main_test.go
@@ -101,12 +101,6 @@ func (r *Resolver) insertTestMonitorWithOpts(ctx context.Context, t *testing.T, 
 			Priority:   "NORMAL",
 			Recipients: []graphql.ID{defaultOwner},
 			Header:     "test header"}},
-		{Webhook: &graphqlbackend.CreateActionWebhookArgs{
-			Enabled: true,
-			URL:     "https://webhook.mcwebhook.face"}},
-		{SlackWebhook: &graphqlbackend.CreateActionSlackWebhookArgs{
-			Enabled: true,
-			URL:     "https://slackwebhook.mcslackwebhook.face"}},
 	}
 
 	options := options{

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -230,12 +230,10 @@ func (r *Resolver) UpdateCodeMonitor(ctx context.Context, args *graphqlbackend.U
 	}
 	defer func() { err = tx.store.Done(err) }()
 
-	err = tx.deleteActions(ctx, monitorID, toDelete)
-	if err != nil {
+	if err = tx.deleteActions(ctx, monitorID, toDelete); err != nil {
 		return nil, err
 	}
-	err = tx.createActions(ctx, monitorID, toCreate)
-	if err != nil {
+	if err = tx.createActions(ctx, monitorID, toCreate); err != nil {
 		return nil, err
 	}
 	m, err := tx.updateCodeMonitor(ctx, args)

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
@@ -375,7 +375,7 @@ func queryByUser(ctx context.Context, t *testing.T, schema *graphql.Schema, r *R
 						TotalCount: 2,
 						Nodes: []apitest.Action{
 							{
-								ActionEmail: apitest.ActionEmail{
+								Email: &apitest.ActionEmail{
 									Id:       string(relay.MarshalID(monitorActionEmailKind, 2)),
 									Enabled:  true,
 									Priority: "CRITICAL",
@@ -440,6 +440,7 @@ query($userName: String!, $actionCursor: String!){
 				createdAt
 				trigger {
 					... on MonitorQuery {
+						__typename
 						id
 						query
 						events(first:1) {
@@ -461,6 +462,7 @@ query($userName: String!, $actionCursor: String!){
 					totalCount
 					nodes{
 						... on MonitorEmail{
+							__typename
 							id
 							priority
 							header
@@ -561,7 +563,7 @@ func TestEditCodeMonitor(t *testing.T) {
 			},
 			Actions: apitest.ActionConnection{
 				Nodes: []apitest.Action{{
-					ActionEmail: apitest.ActionEmail{
+					Email: &apitest.ActionEmail{
 						Id:       string(relay.MarshalID(monitorActionEmailKind, 1)),
 						Enabled:  false,
 						Priority: "CRITICAL",
@@ -573,9 +575,8 @@ func TestEditCodeMonitor(t *testing.T) {
 							},
 						},
 						Header: "updated header action 1",
-					},
-				}, {
-					ActionEmail: apitest.ActionEmail{
+					}}, {
+					Email: &apitest.ActionEmail{
 						Id:       string(relay.MarshalID(monitorActionEmailKind, 3)),
 						Enabled:  true,
 						Priority: "NORMAL",
@@ -637,6 +638,7 @@ mutation ($monitorID: ID!, $triggerID: ID!, $actionID: ID!, $user1ID: ID!, $user
 	createdAt
 	trigger {
 	  ... on MonitorQuery {
+		  __typename
 		id
 		query
 	  }
@@ -644,6 +646,7 @@ mutation ($monitorID: ID!, $triggerID: ID!, $actionID: ID!, $user1ID: ID!, $user
 	actions {
 	  nodes {
 		... on MonitorEmail {
+			__typename
 		  id
 		  enabled
 		  priority
@@ -680,7 +683,7 @@ func recipientPaging(ctx context.Context, t *testing.T, schema *graphql.Schema, 
 				Nodes: []apitest.Monitor{{
 					Actions: apitest.ActionConnection{
 						Nodes: []apitest.Action{{
-							ActionEmail: apitest.ActionEmail{
+							Email: &apitest.ActionEmail{
 								Recipients: apitest.RecipientsConnection{
 									TotalCount: 2,
 									Nodes: []apitest.UserOrg{{
@@ -710,6 +713,7 @@ query($userName: String!, $recipientCursor: String!){
 				actions(first:1){
 					nodes{
 						... on MonitorEmail{
+							__typename
 							recipients(first:1, after:$recipientCursor){
 								totalCount
 								nodes {
@@ -749,7 +753,7 @@ func queryByID(ctx context.Context, t *testing.T, schema *graphql.Schema, r *Res
 				TotalCount: 2,
 				Nodes: []apitest.Action{
 					{
-						ActionEmail: apitest.ActionEmail{
+						Email: &apitest.ActionEmail{
 							Id:       string(relay.MarshalID(monitorActionEmailKind, 1)),
 							Enabled:  false,
 							Priority: "NORMAL",
@@ -768,7 +772,7 @@ func queryByID(ctx context.Context, t *testing.T, schema *graphql.Schema, r *Res
 						},
 					},
 					{
-						ActionEmail: apitest.ActionEmail{
+						Email: &apitest.ActionEmail{
 							Id:       string(relay.MarshalID(monitorActionEmailKind, 2)),
 							Enabled:  true,
 							Priority: "CRITICAL",
@@ -801,6 +805,7 @@ fragment o on Org { id, name }
 query ($id: ID!) {
   node(id: $id) {
     ... on Monitor {
+		__typename
       id
       description
       enabled
@@ -818,6 +823,7 @@ query ($id: ID!) {
       createdAt
       trigger {
         ... on MonitorQuery {
+			__typename
           id
           query
         }
@@ -826,6 +832,7 @@ query ($id: ID!) {
         totalCount
         nodes {
           ... on MonitorEmail {
+			  __typename
             id
             priority
             header
@@ -900,7 +907,7 @@ func actionPaging(ctx context.Context, t *testing.T, schema *graphql.Schema, use
 						TotalCount: 2,
 						Nodes: []apitest.Action{
 							{
-								ActionEmail: apitest.ActionEmail{
+								Email: &apitest.ActionEmail{
 									Id: string(relay.MarshalID(monitorActionEmailKind, 2)),
 								},
 							},
@@ -923,6 +930,7 @@ query($userName: String!, $actionCursor:String!){
 					totalCount
 					nodes {
 						... on MonitorEmail {
+							__typename
 							id
 						}
 					}
@@ -970,6 +978,7 @@ query($userName: String!, $triggerEventCursor: String!){
 			nodes{
 				trigger {
 					... on MonitorQuery {
+						__typename
 						events(first:1, after:$triggerEventCursor) {
 							totalCount
 							nodes {
@@ -1001,7 +1010,7 @@ func actionEventPaging(ctx context.Context, t *testing.T, schema *graphql.Schema
 						TotalCount: 2,
 						Nodes: []apitest.Action{
 							{
-								ActionEmail: apitest.ActionEmail{
+								Email: &apitest.ActionEmail{
 									Id: string(relay.MarshalID(monitorActionEmailKind, 2)),
 									Events: apitest.ActionEventConnection{
 										TotalCount: 2,
@@ -1032,6 +1041,7 @@ query($userName: String!, $actionCursor:String!, $actionEventCursor:String!){
 					totalCount
 					nodes {
 						... on MonitorEmail {
+							__typename
 							id
 							events(first:1, after:$actionEventCursor) {
 								totalCount

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
@@ -390,13 +390,13 @@ func TestQueryMonitor(t *testing.T) {
 func queryByUser(ctx context.Context, t *testing.T, schema *graphql.Schema, r *Resolver, user1 *testUser, user2 *testUser) {
 	input := map[string]interface{}{
 		"userName":     user1.name,
-		"actionCursor": relay.MarshalID(monitorActionEventKind, 1),
+		"actionCursor": relay.MarshalID(monitorActionEmailKind, 1),
 	}
 	response := apitest.Response{}
 	batchesApitest.MustExec(ctx, t, schema, input, &response, queryByUserFmtStr)
 
 	triggerEventEndCursor := string(relay.MarshalID(monitorTriggerEventKind, 1))
-	actionEventEndCursor := string(relay.MarshalID(monitorActionEventKind, 2))
+	actionEventEndCursor := string(relay.MarshalID(monitorActionEmailEventKind, 2))
 	want := apitest.Response{
 		User: apitest.User{
 			Monitors: apitest.MonitorConnection{
@@ -446,13 +446,13 @@ func queryByUser(ctx context.Context, t *testing.T, schema *graphql.Schema, r *R
 									Events: apitest.ActionEventConnection{
 										Nodes: []apitest.ActionEvent{
 											{
-												Id:        string(relay.MarshalID(monitorActionEventKind, 1)),
+												Id:        string(relay.MarshalID(monitorActionEmailEventKind, 1)),
 												Status:    "SUCCESS",
 												Timestamp: r.Now().UTC().Format(time.RFC3339),
 												Message:   nil,
 											},
 											{
-												Id:        string(relay.MarshalID(monitorActionEventKind, 2)),
+												Id:        string(relay.MarshalID(monitorActionEmailEventKind, 2)),
 												Status:    "PENDING",
 												Timestamp: r.Now().UTC().Format(time.RFC3339),
 												Message:   nil,
@@ -1063,7 +1063,7 @@ func actionEventPaging(ctx context.Context, t *testing.T, schema *graphql.Schema
 	queryInput := map[string]interface{}{
 		"userName":          user1.name,
 		"actionCursor":      string(relay.MarshalID(monitorActionEmailKind, 1)),
-		"actionEventCursor": relay.MarshalID(monitorActionEventKind, 1),
+		"actionEventCursor": relay.MarshalID(monitorActionEmailEventKind, 1),
 	}
 	got := apitest.Response{}
 	batchesApitest.MustExec(ctx, t, schema, queryInput, &got, actionEventPagingFmtStr)
@@ -1082,7 +1082,7 @@ func actionEventPaging(ctx context.Context, t *testing.T, schema *graphql.Schema
 										TotalCount: 2,
 										Nodes: []apitest.ActionEvent{
 											{
-												Id: string(relay.MarshalID(monitorActionEventKind, 2)),
+												Id: string(relay.MarshalID(monitorActionEmailEventKind, 2)),
 											},
 										},
 									},

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
@@ -533,7 +533,7 @@ func TestEditCodeMonitor(t *testing.T) {
 
 	// Update the code monitor.
 	// We update all fields, delete one action, and add a new action.
-	schema, err := graphqlbackend.NewSchema(database.NewDB(db), nil, nil, nil, nil, r, nil, nil, nil, nil, nil)
+	schema, err := graphqlbackend.NewSchema(db, nil, nil, nil, nil, r, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	updateInput := map[string]interface{}{
 		"monitorID": string(relay.MarshalID(MonitorKind, 1)),

--- a/enterprise/internal/codemonitors/action_emails.go
+++ b/enterprise/internal/codemonitors/action_emails.go
@@ -108,18 +108,6 @@ func (s *codeMonitorStore) DeleteEmailActions(ctx context.Context, actionIDs []i
 	return s.Exec(ctx, q)
 }
 
-const totalCountActionEmailsFmtStr = `
-SELECT COUNT(*)
-FROM cm_emails
-WHERE monitor = %s;
-`
-
-func (s *codeMonitorStore) CountEmailActions(ctx context.Context, monitorID int64) (int32, error) {
-	var count int32
-	err := s.QueryRow(ctx, sqlf.Sprintf(totalCountActionEmailsFmtStr, monitorID)).Scan(&count)
-	return count, err
-}
-
 const actionEmailByIDFmtStr = `
 SELECT %s -- EmailsColumns
 FROM cm_emails

--- a/enterprise/internal/codemonitors/mock_store_test.go
+++ b/enterprise/internal/codemonitors/mock_store_test.go
@@ -22,9 +22,6 @@ type MockCodeMonitorStore struct {
 	// CountActionJobsFunc is an instance of a mock function object
 	// controlling the behavior of the method CountActionJobs.
 	CountActionJobsFunc *CodeMonitorStoreCountActionJobsFunc
-	// CountEmailActionsFunc is an instance of a mock function object
-	// controlling the behavior of the method CountEmailActions.
-	CountEmailActionsFunc *CodeMonitorStoreCountEmailActionsFunc
 	// CountMonitorsFunc is an instance of a mock function object
 	// controlling the behavior of the method CountMonitors.
 	CountMonitorsFunc *CodeMonitorStoreCountMonitorsFunc
@@ -192,11 +189,6 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 		},
 		CountActionJobsFunc: &CodeMonitorStoreCountActionJobsFunc{
 			defaultHook: func(context.Context, ListActionJobsOpts) (int, error) {
-				return 0, nil
-			},
-		},
-		CountEmailActionsFunc: &CodeMonitorStoreCountEmailActionsFunc{
-			defaultHook: func(context.Context, int64) (int32, error) {
 				return 0, nil
 			},
 		},
@@ -462,11 +454,6 @@ func NewStrictMockCodeMonitorStore() *MockCodeMonitorStore {
 				panic("unexpected invocation of MockCodeMonitorStore.CountActionJobs")
 			},
 		},
-		CountEmailActionsFunc: &CodeMonitorStoreCountEmailActionsFunc{
-			defaultHook: func(context.Context, int64) (int32, error) {
-				panic("unexpected invocation of MockCodeMonitorStore.CountEmailActions")
-			},
-		},
 		CountMonitorsFunc: &CodeMonitorStoreCountMonitorsFunc{
 			defaultHook: func(context.Context, int32) (int32, error) {
 				panic("unexpected invocation of MockCodeMonitorStore.CountMonitors")
@@ -725,9 +712,6 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 		},
 		CountActionJobsFunc: &CodeMonitorStoreCountActionJobsFunc{
 			defaultHook: i.CountActionJobs,
-		},
-		CountEmailActionsFunc: &CodeMonitorStoreCountEmailActionsFunc{
-			defaultHook: i.CountEmailActions,
 		},
 		CountMonitorsFunc: &CodeMonitorStoreCountMonitorsFunc{
 			defaultHook: i.CountMonitors,
@@ -1088,118 +1072,6 @@ func (c CodeMonitorStoreCountActionJobsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c CodeMonitorStoreCountActionJobsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// CodeMonitorStoreCountEmailActionsFunc describes the behavior when the
-// CountEmailActions method of the parent MockCodeMonitorStore instance is
-// invoked.
-type CodeMonitorStoreCountEmailActionsFunc struct {
-	defaultHook func(context.Context, int64) (int32, error)
-	hooks       []func(context.Context, int64) (int32, error)
-	history     []CodeMonitorStoreCountEmailActionsFuncCall
-	mutex       sync.Mutex
-}
-
-// CountEmailActions delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) CountEmailActions(v0 context.Context, v1 int64) (int32, error) {
-	r0, r1 := m.CountEmailActionsFunc.nextHook()(v0, v1)
-	m.CountEmailActionsFunc.appendCall(CodeMonitorStoreCountEmailActionsFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the CountEmailActions
-// method of the parent MockCodeMonitorStore instance is invoked and the
-// hook queue is empty.
-func (f *CodeMonitorStoreCountEmailActionsFunc) SetDefaultHook(hook func(context.Context, int64) (int32, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// CountEmailActions method of the parent MockCodeMonitorStore instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *CodeMonitorStoreCountEmailActionsFunc) PushHook(hook func(context.Context, int64) (int32, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
-// the given values.
-func (f *CodeMonitorStoreCountEmailActionsFunc) SetDefaultReturn(r0 int32, r1 error) {
-	f.SetDefaultHook(func(context.Context, int64) (int32, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushDefaultHook with a function that returns the given
-// values.
-func (f *CodeMonitorStoreCountEmailActionsFunc) PushReturn(r0 int32, r1 error) {
-	f.PushHook(func(context.Context, int64) (int32, error) {
-		return r0, r1
-	})
-}
-
-func (f *CodeMonitorStoreCountEmailActionsFunc) nextHook() func(context.Context, int64) (int32, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *CodeMonitorStoreCountEmailActionsFunc) appendCall(r0 CodeMonitorStoreCountEmailActionsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of CodeMonitorStoreCountEmailActionsFuncCall
-// objects describing the invocations of this function.
-func (f *CodeMonitorStoreCountEmailActionsFunc) History() []CodeMonitorStoreCountEmailActionsFuncCall {
-	f.mutex.Lock()
-	history := make([]CodeMonitorStoreCountEmailActionsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// CodeMonitorStoreCountEmailActionsFuncCall is an object that describes an
-// invocation of method CountEmailActions on an instance of
-// MockCodeMonitorStore.
-type CodeMonitorStoreCountEmailActionsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int64
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 int32
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c CodeMonitorStoreCountEmailActionsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c CodeMonitorStoreCountEmailActionsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/enterprise/internal/codemonitors/store.go
+++ b/enterprise/internal/codemonitors/store.go
@@ -47,7 +47,6 @@ type CodeMonitorStore interface {
 	UpdateEmailAction(_ context.Context, id int64, _ *EmailActionArgs) (*EmailAction, error)
 	CreateEmailAction(ctx context.Context, monitorID int64, _ *EmailActionArgs) (*EmailAction, error)
 	DeleteEmailActions(ctx context.Context, actionIDs []int64, monitorID int64) error
-	CountEmailActions(ctx context.Context, monitorID int64) (int32, error)
 	GetEmailAction(ctx context.Context, emailID int64) (*EmailAction, error)
 	ListEmailActions(context.Context, ListActionsOpts) ([]*EmailAction, error)
 


### PR DESCRIPTION
This PR updates the GraphQL layer for code monitors to expose the new webhooks actions.

I apologize for the very large PR. I made multiple attempts to do this incrementally, but kept running into weirdness in the tests that forced me to fix something else, rebase, fix more tests, etc., so I gave up in order to land this so I can keep on track for the quarter. The commits are _somewhat_ incremental, but tests don't pass on each commit due to the above reasons. If someone wants to do a live review, I'm happy to do so if that's easier. 
