### PR TITLE
Code Insights: Fix re-fetching on insight creation through filter panel

### DIFF
--- a/client/web/src/enterprise/insights/core/backend/gql-api/code-insights-gql-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-api/code-insights-gql-backend.ts
@@ -74,6 +74,9 @@ export class CodeInsightsGqlBackend implements CodeInsightsBackend {
         return fromObservableQuery(
             this.apolloClient.watchQuery<GetDashboardInsightsResult>({
                 query: GET_DASHBOARD_INSIGHTS_GQL,
+                // Prevent unnecessary network request after mutation over dashboard or insights within
+                // current dashboard
+                nextFetchPolicy: 'cache-first',
                 variables: { id: dashboardId },
             })
         ).pipe(


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/29011

Prior to this PR, we had complex logic about updating local cache over dashboards after insight creating through filter panel (save as new). And cause this logic was updating the dashboard entity (we have to include a newly created insight to the dashboard that we are looking at) this triggered running gql query against our BE each time when we update local cache for dashboards entities. 

This PR simplifies this updating logic and fixes the re-fetching problem by setting nextFetchPolicy for the dashboard qql query.