### PR TITLE
Change greenhouse link to new careers site

### DIFF
--- a/client/web/src/search/home/SearchPageFooter.tsx
+++ b/client/web/src/search/home/SearchPageFooter.tsx
@@ -33,7 +33,7 @@ const footerLinkSections: { name: string; links: { name: string; to: string; eve
         name: 'Company',
         links: [
             { name: 'About', to: 'https://about.sourcegraph.com/' },
-            { name: 'Careers', to: 'https://boards.greenhouse.io/sourcegraph91' },
+            { name: 'Careers', to: 'https://about.sourcegraph.com/jobs/' },
             { name: 'Contact', to: 'https://about.sourcegraph.com/contact' },
         ],
     },


### PR DESCRIPTION
Change greenhouse link to new careers site on request from marketing: https://sourcegraph.slack.com/archives/C01LZKLRF0C/p1639525621340900