### PR TITLE
Revert "codeintel: Token-click jump to definition"

### DIFF
--- a/client/browser/src/shared/code-hosts/bitbucket-cloud/codeHost.ts
+++ b/client/browser/src/shared/code-hosts/bitbucket-cloud/codeHost.ts
@@ -163,6 +163,7 @@ export const bitbucketCloudCodeHost: CodeHost = {
     },
     hoverOverlayClassProps: {
         className: suffix('hover-overlay'),
+        closeButtonClassName: suffix('hover-overlay__close'),
         badgeClassName: suffix('hover-overlay__badge'),
         actionItemClassName: suffix('hover-overlay__action-item'),
         actionItemPressedClassName: suffix('hover-overlay__action-item-pressed'),
@@ -171,4 +172,7 @@ export const bitbucketCloudCodeHost: CodeHost = {
     },
     notificationClassNames: { 1: '', 2: '', 3: '', 4: '', 5: '' },
     codeViewsRequireTokenization: true,
+    // Virtualized code views make pinned hovers seemingly "float", since they're attached the the same line
+    // element whose content changes on scroll.
+    pinningEnabled: false,
 }

--- a/client/browser/src/shared/code-hosts/bitbucket/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/bitbucket/codeHost.tsx
@@ -263,6 +263,7 @@ export const bitbucketServerCodeHost: CodeHost = {
     hoverOverlayClassProps: {
         className: 'aui-dialog',
         actionItemClassName: 'aui-button hover-action-item--bitbucket-server',
+        closeButtonClassName: 'aui-button btn-icon--bitbucket-server',
         getAlertClassName: createNotificationClassNameGetter(notificationClassNames),
         iconClassName,
     },

--- a/client/browser/src/shared/code-hosts/github/codeHost.ts
+++ b/client/browser/src/shared/code-hosts/github/codeHost.ts
@@ -461,6 +461,7 @@ export const githubCodeHost: CodeHost = {
         className: 'Box',
         actionItemClassName: 'btn btn-secondary',
         actionItemPressedClassName: 'active',
+        closeButtonClassName: 'btn-octicon p-0 hover-overlay__close-button--github',
         badgeClassName: 'label hover-overlay__badge--github',
         getAlertClassName: createNotificationClassNameGetter(notificationClassNames, 'flash-full'),
         iconClassName,

--- a/client/browser/src/shared/code-hosts/gitlab/codeHost.ts
+++ b/client/browser/src/shared/code-hosts/gitlab/codeHost.ts
@@ -237,6 +237,7 @@ export const gitlabCodeHost = subtypeOf<CodeHost>()({
         className: 'card hover-overlay--gitlab',
         actionItemClassName: 'btn btn-secondary action-item--gitlab',
         actionItemPressedClassName: 'active',
+        closeButtonClassName: 'btn btn-transparent p-0 btn-icon--gitlab',
         iconClassName: 'square s16',
         getAlertClassName: createNotificationClassNameGetter(notificationClassNames),
     },

--- a/client/browser/src/shared/code-hosts/phabricator/codeHost.ts
+++ b/client/browser/src/shared/code-hosts/phabricator/codeHost.ts
@@ -196,6 +196,7 @@ export const phabricatorCodeHost: CodeHost = {
     hoverOverlayClassProps: {
         className: 'aphront-dialog-view hover-overlay--phabricator',
         actionItemClassName: 'button grey hover-overlay-action-item--phabricator',
+        closeButtonClassName: 'button grey btn-icon--phabricator',
         iconClassName: 'icon--phabricator',
         getAlertClassName: createNotificationClassNameGetter(notificationClassNames),
     },

--- a/client/browser/src/shared/code-hosts/shared/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/shared/codeHost.tsx
@@ -37,7 +37,7 @@ import {
 import { NotificationType, HoverAlert } from 'sourcegraph'
 
 import { TextDocumentDecoration, WorkspaceRoot } from '@sourcegraph/extension-api-types'
-import { ActionItemAction, urlForClientCommandOpen } from '@sourcegraph/shared/src/actions/ActionItem'
+import { ActionItemAction } from '@sourcegraph/shared/src/actions/ActionItem'
 import { wrapRemoteObservable } from '@sourcegraph/shared/src/api/client/api/common'
 import { HoverMerged } from '@sourcegraph/shared/src/api/client/types/hover'
 import { DecorationMapByLine } from '@sourcegraph/shared/src/api/extension/api/decorations'
@@ -291,6 +291,11 @@ export interface CodeHost extends ApplyLinkPreviewOptions {
      * Whether or not code views need to be tokenized. Defaults to false.
      */
     codeViewsRequireTokenization?: boolean
+
+    /**
+     * Whether or not hover tooltips can be pinned.
+     */
+    pinningEnabled?: boolean
 }
 
 /**
@@ -382,6 +387,9 @@ function initCodeIntelligence({
 } {
     const subscription = new Subscription()
 
+    /** Emits when the close button was clicked */
+    const closeButtonClicks = new Subject<MouseEvent>()
+
     /** Emits whenever the ref callback for the hover element is called */
     const hoverOverlayElements = new Subject<HTMLElement | null>()
 
@@ -404,6 +412,7 @@ function initCodeIntelligence({
         HoverMerged,
         ActionItemAction
     >({
+        closeButtonClicks,
         hoverOverlayElements,
         hoverOverlayRerenders: containerComponentUpdates.pipe(
             withLatestFrom(hoverOverlayElements),
@@ -466,6 +475,7 @@ function initCodeIntelligence({
                     hasPrivateCloudError ? of([]) : getHoverActions({ extensionsController, platformContext }, context)
                 )
             ),
+        pinningEnabled: codeHost.pinningEnabled ?? true,
         tokenize: codeHost.codeViewsRequireTokenization,
     })
 
@@ -475,6 +485,7 @@ function initCodeIntelligence({
     > {
         private subscription = new Subscription()
         private nextOverlayElement = hoverOverlayElements.next.bind(hoverOverlayElements)
+        private nextCloseButtonClick = closeButtonClicks.next.bind(closeButtonClicks)
 
         constructor(props: {}) {
             super(props)
@@ -488,56 +499,6 @@ function initCodeIntelligence({
                 hoverifier.hoverStateUpdates.subscribe(update => {
                     this.setState(update)
                 })
-            )
-            this.subscription.add(
-                hoverifier.hoverStateUpdates
-                    .pipe(
-                        switchMap(({ hoveredTokenElement: token, hoverOverlayProps }) => {
-                            if (token === undefined) {
-                                return EMPTY
-                            }
-                            if (hoverOverlayProps === undefined) {
-                                return EMPTY
-                            }
-
-                            const { actionsOrError } = hoverOverlayProps
-                            const definitionAction =
-                                Array.isArray(actionsOrError) &&
-                                actionsOrError.find(a => a.action.id === 'goToDefinition.preloaded' && !a.disabledWhen)
-
-                            const referenceAction =
-                                Array.isArray(actionsOrError) &&
-                                actionsOrError.find(a => a.action.id === 'findReferences' && !a.disabledWhen)
-
-                            const action = definitionAction || referenceAction
-                            if (!action) {
-                                return EMPTY
-                            }
-
-                            const def = urlForClientCommandOpen(action.action, window.location.hash)
-                            if (!def) {
-                                return EMPTY
-                            }
-
-                            const oldCursor = token.style.cursor
-                            token.style.cursor = 'pointer'
-
-                            return fromEvent(token, 'click').pipe(
-                                tap(() => {
-                                    const selection = window.getSelection()
-                                    if (selection !== null && selection.toString() !== '') {
-                                        return
-                                    }
-
-                                    const actionType = action === definitionAction ? 'definition' : 'reference'
-                                    telemetryService.log(`${actionType}CodeHost.click`)
-                                    window.location.href = def
-                                }),
-                                finalize(() => (token.style.cursor = oldCursor))
-                            )
-                        })
-                    )
-                    .subscribe()
             )
             if (codeHost.isLightTheme) {
                 this.subscription.add(
@@ -566,6 +527,7 @@ function initCodeIntelligence({
                     extensionsController={extensionsController}
                     platformContext={platformContext}
                     location={H.createLocation(window.location)}
+                    onCloseButtonClick={this.nextCloseButtonClick}
                     onAlertDismissed={onHoverAlertDismissed}
                     useBrandedLogo={true}
                 />

--- a/client/shared/src/actions/ActionItem.tsx
+++ b/client/shared/src/actions/ActionItem.tsx
@@ -229,8 +229,8 @@ export class ActionItem extends React.PureComponent<ActionItemProps, State> {
                 ? this.props.action.actionItem.pressed
                 : undefined
 
-        const altTo = this.props.altAction && urlForClientCommandOpen(this.props.altAction, this.props.location.hash)
-        const primaryTo = urlForClientCommandOpen(this.props.action, this.props.location.hash)
+        const altTo = this.props.altAction && urlForClientCommandOpen(this.props.altAction, this.props.location)
+        const primaryTo = urlForClientCommandOpen(this.props.action, this.props.location)
         const to = primaryTo || altTo
         // Open in new tab if an external link
         const newTabProps =
@@ -297,7 +297,7 @@ export class ActionItem extends React.PureComponent<ActionItemProps, State> {
         // Record action ID (but not args, which might leak sensitive data).
         this.props.telemetryService.log(action.id)
 
-        if (urlForClientCommandOpen(action, this.props.location.hash)) {
+        if (urlForClientCommandOpen(action, this.props.location)) {
             if (event.currentTarget.tagName === 'A' && event.currentTarget.hasAttribute('href')) {
                 // Do not execute the command. The <LinkOrButton>'s default event handler will do what we want (which
                 // is to open a URL). The only case where this breaks is if both the action and alt action are "open"
@@ -327,7 +327,7 @@ export class ActionItem extends React.PureComponent<ActionItemProps, State> {
 
 export function urlForClientCommandOpen(
     action: Pick<Evaluated<ActionContribution>, 'command' | 'commandArguments'>,
-    locationHash: string
+    location: H.Location
 ): string | undefined {
     if (action.command === 'open' && action.commandArguments) {
         const url = action.commandArguments[0]
@@ -342,7 +342,7 @@ export function urlForClientCommandOpen(
         if (typeof url !== 'string') {
             return undefined
         }
-        return urlForOpenPanel(url, locationHash)
+        return urlForOpenPanel(url, location.hash)
     }
 
     return undefined

--- a/client/shared/src/codeintellify/hoverifier.test.ts
+++ b/client/shared/src/codeintellify/hoverifier.test.ts
@@ -1,10 +1,11 @@
 import { isEqual } from 'lodash'
-import { EMPTY, NEVER, of, Subject, Subscription } from 'rxjs'
+import { EMPTY, NEVER, Observable, of, Subject, Subscription } from 'rxjs'
 import { delay, distinctUntilChanged, filter, first, map, takeWhile } from 'rxjs/operators'
 import { TestScheduler } from 'rxjs/testing'
 
 import { Range } from '@sourcegraph/extension-api-types'
 
+import { ErrorLike } from './errors'
 import { isDefined, propertyIsDefined } from './helpers'
 import {
     AdjustmentDirection,
@@ -15,14 +16,17 @@ import {
     PositionJump,
     TOOLTIP_DISPLAY_DELAY,
 } from './hoverifier'
+import { LOADING } from './loading'
 import { findPositionsFromEvents, SupportedMouseEvent } from './positions'
 import { CodeViewProps, DOM } from './testutils/dom'
 import {
+    createHoverAttachment,
     createStubActionsProvider,
     createStubHoverProvider,
     createStubDocumentHighlightProvider,
 } from './testutils/fixtures'
 import { dispatchMouseEventAtPositionImpure } from './testutils/mouse'
+import { HoverAttachment } from './types'
 
 describe('Hoverifier', () => {
     const dom = new DOM()
@@ -50,11 +54,13 @@ describe('Hoverifier', () => {
 
             scheduler.run(({ cold, expectObservable }) => {
                 const hoverifier = createHoverifier({
+                    closeButtonClicks: NEVER,
                     hoverOverlayElements: of(null),
                     hoverOverlayRerenders: EMPTY,
                     getHover: createStubHoverProvider({ range: hoverRange }, LOADER_DELAY + delayTime),
                     getDocumentHighlights: createStubDocumentHighlightProvider(),
                     getActions: () => of(null),
+                    pinningEnabled: true,
                 })
 
                 const positionJumps = new Subject<PositionJump>()
@@ -102,6 +108,177 @@ describe('Hoverifier', () => {
         }
     })
 
+    it('pins the overlay without it disappearing temporarily on mouseover then click', () => {
+        for (const codeView of testcases) {
+            const scheduler = new TestScheduler((a, b) => expect(a).toEqual(b))
+
+            const hover = {}
+            const delayTime = 10
+
+            scheduler.run(({ cold, expectObservable }) => {
+                const hoverifier = createHoverifier({
+                    closeButtonClicks: NEVER,
+                    hoverOverlayElements: of(null),
+                    hoverOverlayRerenders: EMPTY,
+                    getHover: createStubHoverProvider(hover, delayTime),
+                    getDocumentHighlights: createStubDocumentHighlightProvider(),
+                    getActions: createStubActionsProvider(['foo', 'bar'], delayTime),
+                    pinningEnabled: true,
+                })
+
+                const positionJumps = new Subject<PositionJump>()
+
+                const positionEvents = of(codeView.codeView).pipe(findPositionsFromEvents({ domFunctions: codeView }))
+
+                const subscriptions = new Subscription()
+
+                subscriptions.add(hoverifier)
+                subscriptions.add(
+                    hoverifier.hoverify({
+                        dom: codeView,
+                        positionEvents,
+                        positionJumps,
+                        resolveContext: () => codeView.revSpec,
+                    })
+                )
+
+                const hoverAndDefinitionUpdates = hoverifier.hoverStateUpdates.pipe(
+                    map(hoverState => !!hoverState.hoverOverlayProps),
+                    distinctUntilChanged(isEqual)
+                )
+
+                // If you need to debug this test, the following might help. Append this to the `outputDiagram`
+                // string below:
+                //
+                //   ` ${delayAfterMouseover - 1}ms c ${delayTime - 1}ms d`
+                //
+                // Also, add these properties to `outputValues`:
+                //
+                //   c: true, // the most important instant, right after the click to pin (must be true, meaning it doesn't disappear)
+                //   d: true,
+                //
+                // There should be no emissions at "c" or "d", so this will cause the test to fail. But those are
+                // the most likely instants where there would be an emission if pinning is causing a temporary
+                // disappearance of the overlay.
+                const delayAfterMouseover = 100
+                const outputDiagram = `${MOUSEOVER_DELAY}ms a ${delayTime - 1}ms b`
+                const outputValues: {
+                    [key: string]: boolean
+                } = {
+                    a: false,
+                    b: true,
+                }
+
+                // Mouseover https://sourcegraph.sgdev.org/github.com/gorilla/mux@cb4698366aa625048f3b815af6a0dea8aef9280a/-/blob/mux.go#L24:6
+                cold('a').subscribe(() =>
+                    dispatchMouseEventAtPositionImpure('mouseover', codeView, {
+                        line: 24,
+                        character: 6,
+                    })
+                )
+
+                // Click (to pin) https://sourcegraph.sgdev.org/github.com/gorilla/mux@cb4698366aa625048f3b815af6a0dea8aef9280a/-/blob/mux.go#L24:6
+                cold(`${MOUSEOVER_DELAY + delayTime + delayAfterMouseover}ms c`).subscribe(() =>
+                    dispatchMouseEventAtPositionImpure('click', codeView, {
+                        line: 24,
+                        character: 6,
+                    })
+                )
+
+                // Mouseover something else and ensure it remains pinned.
+                cold(`${MOUSEOVER_DELAY + delayTime + delayAfterMouseover + 100}ms d`).subscribe(() =>
+                    dispatchMouseEventAtPositionImpure('mouseover', codeView, {
+                        line: 25,
+                        character: 3,
+                    })
+                )
+
+                expectObservable(hoverAndDefinitionUpdates).toBe(outputDiagram, outputValues)
+            })
+        }
+    })
+
+    it('does not pin the overlay on click when pinningEnabled is false', () => {
+        for (const codeView of testcases) {
+            const scheduler = new TestScheduler((a, b) => expect(a).toEqual(b))
+
+            const hover = {}
+            const delayTime = 10
+
+            scheduler.run(({ cold, expectObservable }) => {
+                const hoverifier = createHoverifier({
+                    closeButtonClicks: NEVER,
+                    hoverOverlayElements: of(null),
+                    hoverOverlayRerenders: EMPTY,
+                    getHover: createStubHoverProvider(hover, delayTime),
+                    getDocumentHighlights: createStubDocumentHighlightProvider(),
+                    getActions: createStubActionsProvider(['foo', 'bar'], delayTime),
+                    pinningEnabled: false,
+                })
+
+                const positionJumps = new Subject<PositionJump>()
+
+                const positionEvents = of(codeView.codeView).pipe(findPositionsFromEvents({ domFunctions: codeView }))
+
+                const subscriptions = new Subscription()
+
+                subscriptions.add(hoverifier)
+                subscriptions.add(
+                    hoverifier.hoverify({
+                        dom: codeView,
+                        positionEvents,
+                        positionJumps,
+                        resolveContext: () => codeView.revSpec,
+                    })
+                )
+
+                const hoverAndDefinitionUpdates = hoverifier.hoverStateUpdates.pipe(
+                    map(hoverState => !!hoverState.hoverOverlayProps),
+                    distinctUntilChanged(isEqual)
+                )
+
+                const delayAfterMouseover = 100
+                const outputDiagram = `${MOUSEOVER_DELAY}ms a ${delayTime - 1}ms b ${
+                    MOUSEOVER_DELAY + delayAfterMouseover + 100 - 1
+                }ms c ${delayTime - 1}ms d`
+                const outputValues: {
+                    [key: string]: boolean
+                } = {
+                    a: false,
+                    b: true,
+                    c: false,
+                    d: true,
+                }
+
+                // Mouseover https://sourcegraph.sgdev.org/github.com/gorilla/mux@cb4698366aa625048f3b815af6a0dea8aef9280a/-/blob/mux.go#L24:6
+                cold('a').subscribe(() =>
+                    dispatchMouseEventAtPositionImpure('mouseover', codeView, {
+                        line: 24,
+                        character: 6,
+                    })
+                )
+
+                // Click (should not get pinned) https://sourcegraph.sgdev.org/github.com/gorilla/mux@cb4698366aa625048f3b815af6a0dea8aef9280a/-/blob/mux.go#L24:6
+                cold(`${MOUSEOVER_DELAY + delayTime + delayAfterMouseover}ms c`).subscribe(() =>
+                    dispatchMouseEventAtPositionImpure('click', codeView, {
+                        line: 24,
+                        character: 6,
+                    })
+                )
+
+                // Mouseover something else and ensure it doesn't get pinned.
+                cold(`${MOUSEOVER_DELAY + delayTime + delayAfterMouseover + 100}ms d`).subscribe(() =>
+                    dispatchMouseEventAtPositionImpure('mouseover', codeView, {
+                        line: 25,
+                        character: 3,
+                    })
+                )
+
+                expectObservable(hoverAndDefinitionUpdates).toBe(outputDiagram, outputValues)
+            })
+        }
+    })
+
     it('emits the currently hovered token', () => {
         for (const codeView of testcases) {
             const scheduler = new TestScheduler((a, b) => expect(a).toEqual(b))
@@ -111,11 +288,13 @@ describe('Hoverifier', () => {
 
             scheduler.run(({ cold, expectObservable }) => {
                 const hoverifier = createHoverifier({
+                    closeButtonClicks: NEVER,
                     hoverOverlayElements: of(null),
                     hoverOverlayRerenders: EMPTY,
                     getHover: createStubHoverProvider(hover, delayTime),
                     getDocumentHighlights: createStubDocumentHighlightProvider(),
                     getActions: createStubActionsProvider(['foo', 'bar'], delayTime),
+                    pinningEnabled: false,
                 })
 
                 const positionJumps = new Subject<PositionJump>()
@@ -163,6 +342,7 @@ describe('Hoverifier', () => {
     it('highlights document highlights', async () => {
         for (const codeViewProps of testcases) {
             const hoverifier = createHoverifier({
+                closeButtonClicks: NEVER,
                 hoverOverlayElements: of(null),
                 hoverOverlayRerenders: EMPTY,
                 getHover: createStubHoverProvider(),
@@ -172,6 +352,7 @@ describe('Hoverifier', () => {
                     { range: { start: { line: 120, character: 9 }, end: { line: 120, character: 15 } } },
                 ]),
                 getActions: () => of(null),
+                pinningEnabled: true,
                 documentHighlightClassName: 'test-highlight',
             })
             const positionJumps = new Subject<PositionJump>()
@@ -213,6 +394,7 @@ describe('Hoverifier', () => {
     it.skip('hides the hover overlay when the hovered token intersects with a scrollBoundary', async () => {
         const gitHubCodeView = testcases[1]
         const hoverifier = createHoverifier({
+            closeButtonClicks: NEVER,
             hoverOverlayElements: of(null),
             hoverOverlayRerenders: EMPTY,
             getHover: createStubHoverProvider({
@@ -223,6 +405,7 @@ describe('Hoverifier', () => {
             }),
             getDocumentHighlights: createStubDocumentHighlightProvider(),
             getActions: createStubActionsProvider(['foo', 'bar']),
+            pinningEnabled: true,
         })
         subscriptions.add(hoverifier)
         subscriptions.add(
@@ -258,6 +441,245 @@ describe('Hoverifier', () => {
         await hoverIsHidden
     })
 
+    describe('pinning', () => {
+        it('unpins upon clicking on a different position', () => {
+            for (const codeView of testcases) {
+                const scheduler = new TestScheduler((a, b) => expect(a).toEqual(b))
+
+                const delayTime = 10
+
+                scheduler.run(({ cold, expectObservable }) => {
+                    const hoverifier = createHoverifier({
+                        closeButtonClicks: NEVER,
+                        hoverOverlayElements: of(null),
+                        hoverOverlayRerenders: EMPTY,
+                        // Only show on line 24, not line 25 (which is the 2nd click event below).
+                        getHover: position =>
+                            position.line === 24
+                                ? createStubHoverProvider({}, delayTime)(position)
+                                : of({ isLoading: false, result: null }),
+                        getDocumentHighlights: createStubDocumentHighlightProvider(),
+                        getActions: position =>
+                            position.line === 24
+                                ? createStubActionsProvider(['foo', 'bar'], delayTime)(position)
+                                : of(null),
+                        pinningEnabled: true,
+                    })
+
+                    const positionJumps = new Subject<PositionJump>()
+
+                    const positionEvents = of(codeView.codeView).pipe(
+                        findPositionsFromEvents({ domFunctions: codeView })
+                    )
+
+                    const subscriptions = new Subscription()
+
+                    subscriptions.add(hoverifier)
+                    subscriptions.add(
+                        hoverifier.hoverify({
+                            dom: codeView,
+                            positionEvents,
+                            positionJumps,
+                            resolveContext: () => codeView.revSpec,
+                        })
+                    )
+
+                    const isPinned = hoverifier.hoverStateUpdates.pipe(
+                        map(
+                            hoverState =>
+                                !!hoverState.hoverOverlayProps && !!hoverState.hoverOverlayProps.showCloseButton
+                        ),
+                        distinctUntilChanged()
+                    )
+
+                    const outputDiagram = `${delayTime}ms a-c`
+                    const outputValues: {
+                        [key: string]: boolean
+                    } = {
+                        a: true,
+                        c: false,
+                    }
+
+                    // Click (to pin) https://sourcegraph.sgdev.org/github.com/gorilla/mux@cb4698366aa625048f3b815af6a0dea8aef9280a/-/blob/mux.go#L24:6
+                    cold('a').subscribe(() => {
+                        dispatchMouseEventAtPositionImpure('click', codeView, {
+                            line: 24,
+                            character: 6,
+                        })
+                    })
+
+                    // Click to another position and ensure the hover is no longer pinned.
+                    cold(`${delayTime}ms --c`).subscribe(() =>
+                        positionJumps.next({
+                            codeView: codeView.codeView,
+                            scrollElement: codeView.container,
+                            position: { line: 1, character: 1 },
+                        })
+                    )
+
+                    expectObservable(isPinned).toBe(outputDiagram, outputValues)
+                })
+            }
+        })
+
+        it('unpins upon navigation to an invalid or undefined position (such as a file with no particular position)', () => {
+            for (const codeView of testcases) {
+                const scheduler = new TestScheduler((a, b) => expect(a).toEqual(b))
+
+                scheduler.run(({ cold, expectObservable }) => {
+                    const hoverifier = createHoverifier({
+                        closeButtonClicks: NEVER,
+                        hoverOverlayElements: of(null),
+                        hoverOverlayRerenders: EMPTY,
+                        // Only show on line 24, not line 25 (which is the 2nd click event below).
+                        getHover: position =>
+                            position.line === 24
+                                ? createStubHoverProvider({})(position)
+                                : of({ isLoading: false, result: null }),
+                        getDocumentHighlights: createStubDocumentHighlightProvider(),
+                        getActions: position =>
+                            position.line === 24 ? createStubActionsProvider(['foo', 'bar'])(position) : of(null),
+                        pinningEnabled: true,
+                    })
+
+                    const positionJumps = new Subject<PositionJump>()
+
+                    const positionEvents = of(codeView.codeView).pipe(
+                        findPositionsFromEvents({ domFunctions: codeView })
+                    )
+
+                    const subscriptions = new Subscription()
+
+                    subscriptions.add(hoverifier)
+                    subscriptions.add(
+                        hoverifier.hoverify({
+                            dom: codeView,
+                            positionEvents,
+                            positionJumps,
+                            resolveContext: () => codeView.revSpec,
+                        })
+                    )
+
+                    const isPinned = hoverifier.hoverStateUpdates.pipe(
+                        map(hoverState => {
+                            if (!hoverState.hoverOverlayProps) {
+                                return 'hidden'
+                            }
+                            if (hoverState.hoverOverlayProps.showCloseButton) {
+                                return 'pinned'
+                            }
+                            return 'visible'
+                        }),
+                        distinctUntilChanged()
+                    )
+
+                    const outputDiagram = 'ab'
+                    const outputValues: {
+                        [key: string]: 'hidden' | 'pinned' | 'visible'
+                    } = {
+                        a: 'pinned',
+                        b: 'hidden',
+                    }
+
+                    // Click (to pin) https://sourcegraph.sgdev.org/github.com/gorilla/mux@cb4698366aa625048f3b815af6a0dea8aef9280a/-/blob/mux.go#L24:6
+                    cold('a').subscribe(() =>
+                        dispatchMouseEventAtPositionImpure('click', codeView, {
+                            line: 24,
+                            character: 6,
+                        })
+                    )
+
+                    // Click to another position and ensure the hover is no longer pinned.
+                    cold('-b').subscribe(() =>
+                        positionJumps.next({
+                            codeView: codeView.codeView,
+                            scrollElement: codeView.container,
+                            position: { line: undefined, character: undefined },
+                        })
+                    )
+
+                    expectObservable(isPinned).toBe(outputDiagram, outputValues)
+                })
+            }
+        })
+    })
+
+    it('emits loading and then state on click events', () => {
+        for (const codeView of testcases) {
+            const scheduler = new TestScheduler((a, b) => expect(a).toEqual(b))
+
+            const hoverDelayTime = 100
+            const actionsDelayTime = 150
+            const hover = {}
+            const actions = ['foo', 'bar']
+
+            scheduler.run(({ cold, expectObservable }) => {
+                const hoverifier = createHoverifier({
+                    closeButtonClicks: new Observable<MouseEvent>(),
+                    hoverOverlayElements: of(null),
+                    hoverOverlayRerenders: EMPTY,
+                    getHover: createStubHoverProvider(hover, LOADER_DELAY + hoverDelayTime),
+                    getDocumentHighlights: createStubDocumentHighlightProvider(),
+                    getActions: createStubActionsProvider(actions, LOADER_DELAY + actionsDelayTime),
+                    pinningEnabled: true,
+                })
+
+                const positionJumps = new Subject<PositionJump>()
+
+                const positionEvents = of(codeView.codeView).pipe(findPositionsFromEvents({ domFunctions: codeView }))
+
+                const subscriptions = new Subscription()
+
+                subscriptions.add(hoverifier)
+                subscriptions.add(
+                    hoverifier.hoverify({
+                        dom: codeView,
+                        positionEvents,
+                        positionJumps,
+                        resolveContext: () => codeView.revSpec,
+                    })
+                )
+
+                const hoverAndActionsUpdates = hoverifier.hoverStateUpdates.pipe(
+                    filter(propertyIsDefined('hoverOverlayProps')),
+                    map(({ hoverOverlayProps: { actionsOrError, hoverOrError } }) => ({
+                        actionsOrError,
+                        hoverOrError,
+                    })),
+                    distinctUntilChanged((a, b) => isEqual(a, b))
+                )
+
+                const inputDiagram = 'a'
+
+                // Subtract 1ms before "b" because "a" takes up 1ms.
+                const outputDiagram = `${LOADER_DELAY}ms ${hoverDelayTime}ms a ${
+                    actionsDelayTime - hoverDelayTime - 1
+                }ms b`
+
+                const outputValues: {
+                    [key: string]: {
+                        hoverOrError: typeof LOADING | HoverAttachment | null | ErrorLike
+                        actionsOrError: typeof LOADING | string[] | null | ErrorLike
+                    }
+                } = {
+                    // No hover is shown if it would just consist of LOADING.
+                    a: { hoverOrError: createHoverAttachment(hover), actionsOrError: LOADING },
+                    b: { hoverOrError: createHoverAttachment(hover), actionsOrError: actions },
+                }
+
+                // Click https://sourcegraph.sgdev.org/github.com/gorilla/mux@cb4698366aa625048f3b815af6a0dea8aef9280a/-/blob/mux.go#L24:6
+                cold(inputDiagram).subscribe(() =>
+                    dispatchMouseEventAtPositionImpure('click', codeView, {
+                        line: 24,
+                        character: 6,
+                    })
+                )
+
+                expectObservable(hoverAndActionsUpdates).toBe(outputDiagram, outputValues)
+            })
+        }
+    })
+
     it('debounces mousemove events before showing overlay', () => {
         for (const codeView of testcases) {
             const scheduler = new TestScheduler((a, b) => expect(a).toEqual(b))
@@ -266,11 +688,13 @@ describe('Hoverifier', () => {
 
             scheduler.run(({ cold, expectObservable }) => {
                 const hoverifier = createHoverifier({
+                    closeButtonClicks: new Observable<MouseEvent>(),
                     hoverOverlayElements: of(null),
                     hoverOverlayRerenders: EMPTY,
                     getHover: createStubHoverProvider(hover),
                     getDocumentHighlights: createStubDocumentHighlightProvider(),
                     getActions: () => of(null),
+                    pinningEnabled: true,
                 })
 
                 const positionJumps = new Subject<PositionJump>()
@@ -329,11 +753,13 @@ describe('Hoverifier', () => {
                 const hoverOverlayElement = document.createElement('div')
 
                 const hoverifier = createHoverifier({
+                    closeButtonClicks: new Observable<MouseEvent>(),
                     hoverOverlayElements: of(hoverOverlayElement),
                     hoverOverlayRerenders: EMPTY,
                     getHover: createStubHoverProvider(hover),
                     getDocumentHighlights: createStubDocumentHighlightProvider(),
                     getActions: () => of(null),
+                    pinningEnabled: true,
                 })
 
                 const positionJumps = new Subject<PositionJump>()
@@ -399,11 +825,13 @@ describe('Hoverifier', () => {
 
             scheduler.run(({ cold, expectObservable }) => {
                 const hoverifier = createHoverifier({
+                    closeButtonClicks: new Observable<MouseEvent>(),
                     hoverOverlayElements: of(null),
                     hoverOverlayRerenders: EMPTY,
                     getHover: createStubHoverProvider(hover),
                     getDocumentHighlights: createStubDocumentHighlightProvider(),
                     getActions: () => of(null),
+                    pinningEnabled: true,
                 })
 
                 const positionJumps = new Subject<PositionJump>()
@@ -485,11 +913,13 @@ describe('Hoverifier', () => {
                 }
 
                 const hoverifier = createHoverifier({
+                    closeButtonClicks: new Observable<MouseEvent>(),
                     hoverOverlayElements: of(null),
                     hoverOverlayRerenders: EMPTY,
                     getHover,
                     getDocumentHighlights,
                     getActions,
+                    pinningEnabled: true,
                 })
 
                 const positionJumps = new Subject<PositionJump>()
@@ -539,12 +969,14 @@ describe('Hoverifier', () => {
         it('hides the hover overlay when the code view is unhoverified', async () => {
             for (const codeView of testcases) {
                 const hoverifier = createHoverifier({
+                    closeButtonClicks: NEVER,
                     hoverOverlayElements: of(null),
                     hoverOverlayRerenders: EMPTY,
                     // It's important that getHover() and getActions() emit something
                     getHover: createStubHoverProvider({}),
                     getDocumentHighlights: createStubDocumentHighlightProvider(),
                     getActions: () => of([{}]).pipe(delay(50)),
+                    pinningEnabled: true,
                 })
                 const positionJumps = new Subject<PositionJump>()
                 const positionEvents = of(codeView.codeView).pipe(findPositionsFromEvents({ domFunctions: codeView }))
@@ -578,11 +1010,13 @@ describe('Hoverifier', () => {
         it('does not hide the hover overlay when a different code view is unhoverified', async () => {
             for (const codeViewProps of testcases) {
                 const hoverifier = createHoverifier({
+                    closeButtonClicks: NEVER,
                     hoverOverlayElements: of(null),
                     hoverOverlayRerenders: EMPTY,
                     getHover: createStubHoverProvider(),
                     getDocumentHighlights: createStubDocumentHighlightProvider(),
                     getActions: () => of(null),
+                    pinningEnabled: true,
                 })
                 const positionJumps = new Subject<PositionJump>()
                 const positionEvents = of(codeViewProps.codeView).pipe(

--- a/client/shared/src/codeintellify/hoverifier.ts
+++ b/client/shared/src/codeintellify/hoverifier.ts
@@ -14,6 +14,7 @@ import {
     Subscribable,
     SubscribableOrPromise,
     Subscription,
+    zip,
     race,
     MonoTypeOperatorFunction,
 } from 'rxjs'
@@ -34,6 +35,7 @@ import {
     delay,
     startWith,
 } from 'rxjs/operators'
+import { Key } from 'ts-key-enum'
 
 import { Position, Range } from '@sourcegraph/extension-api-types'
 
@@ -47,6 +49,7 @@ import {
     convertNode,
     DiffPart,
     DOMFunctions,
+    findElementWithOffset,
     getCodeElementsInRange,
     getTokenAtPositionOrRange,
     HoveredToken,
@@ -78,6 +81,11 @@ export interface HoverifierOptions<C extends object, D, A> {
         relativeElement: HTMLElement
     }>
 
+    /**
+     * Emit on this Observable when the close button in the HoverOverlay was clicked
+     */
+    closeButtonClicks: Subscribable<MouseEvent>
+
     hoverOverlayElements: Subscribable<HTMLElement | null>
 
     /**
@@ -94,6 +102,11 @@ export interface HoverifierOptions<C extends object, D, A> {
      * Called to get the actions to display in the hover.
      */
     getActions: ActionsProvider<C, A>
+
+    /**
+     * Whether or not hover tooltips can be pinned.
+     */
+    pinningEnabled: boolean
 
     /**
      * Whether or not code views need to be tokenized. Defaults to true.
@@ -271,6 +284,8 @@ export interface HoverState<C extends object, D, A> {
 interface InternalHoverifierState<C extends object, D, A> {
     hoverOrError?: typeof LOADING | (HoverAttachment & D) | null | ErrorLike
 
+    hoverOverlayIsFixed: boolean
+
     /** The desired position of the hover overlay */
     hoverOverlayPosition?: { left: number; top: number }
 
@@ -312,7 +327,7 @@ interface InternalHoverifierState<C extends object, D, A> {
  * (because there is no content, or because it is still loading).
  */
 const shouldRenderOverlay = (state: InternalHoverifierState<{}, {}, {}>): boolean =>
-    !state.mouseIsMoving &&
+    !(!state.hoverOverlayIsFixed && state.mouseIsMoving) &&
     ((!!state.hoverOrError && state.hoverOrError !== LOADING) ||
         (!!state.actionsOrError &&
             state.actionsOrError !== LOADING &&
@@ -337,6 +352,7 @@ const internalToExternalState = <C extends object, D, A>(
               overlayPosition: internalState.hoverOverlayPosition,
               hoverOrError: internalState.hoverOrError,
               hoveredToken: internalState.hoveredToken,
+              showCloseButton: internalState.hoverOverlayIsFixed,
               actionsOrError: internalState.actionsOrError,
           }
         : undefined,
@@ -395,11 +411,13 @@ export type ContextResolver<C extends object> = (hoveredToken: HoveredToken) => 
  * @template A The type of an action.
  */
 export function createHoverifier<C extends object, D, A>({
+    closeButtonClicks,
     hoverOverlayElements,
     hoverOverlayRerenders,
     getHover,
     getDocumentHighlights,
     getActions,
+    pinningEnabled,
     tokenize = true,
     selectionHighlightClassName = defaultSelectionHighlightClassName,
     documentHighlightClassName = defaultDocumentHighlightClassName,
@@ -408,6 +426,7 @@ export function createHoverifier<C extends object, D, A>({
     // Shared between all hoverified code views
     const container = createObservableStateContainer<InternalHoverifierState<C, D, A>>({
         hoveredTokenElement: undefined,
+        hoverOverlayIsFixed: false,
         hoveredToken: undefined,
         hoverOrError: undefined,
         hoverOverlayPosition: undefined,
@@ -444,6 +463,7 @@ export function createHoverifier<C extends object, D, A>({
     ): event is MouseEventTrigger & { eventType: T } => event.eventType === type
     const allCodeMouseMoves = allPositionsFromEvents.pipe(filter(isEventType('mousemove')), suppressWhileOverlayShown())
     const allCodeMouseOvers = allPositionsFromEvents.pipe(filter(isEventType('mouseover')), suppressWhileOverlayShown())
+    const allCodeClicks = allPositionsFromEvents.pipe(filter(isEventType('click')))
 
     const allPositionJumps = new Subject<PositionJump & EventOptions<C>>()
 
@@ -454,6 +474,17 @@ export function createHoverifier<C extends object, D, A>({
     const allUnhoverifies = new Subject<symbol>()
 
     const subscription = new Subscription()
+
+    /**
+     * click events on the code element, ignoring click events caused by the user selecting text.
+     * Selecting text should not mess with the hover, hover pinning nor the URL.
+     */
+    const codeClicksWithoutSelections = allCodeClicks.pipe(
+        filter(() => {
+            const selection = window.getSelection()
+            return selection === null || selection.toString() === ''
+        })
+    )
 
     // Mouse is moving, don't show the tooltip
     subscription.add(
@@ -484,6 +515,8 @@ export function createHoverifier<C extends object, D, A>({
             ...rest,
         })),
         debounceTime(MOUSEOVER_DELAY),
+        // Do not consider mouseovers while overlay is pinned
+        filter(() => !container.values.hoverOverlayIsFixed),
         switchMap(({ adjustPosition, codeView, resolveContext, position, ...rest }) =>
             adjustPosition && position
                 ? from(
@@ -506,6 +539,82 @@ export function createHoverifier<C extends object, D, A>({
         share()
     )
 
+    const codeClickTargets = codeClicksWithoutSelections.pipe(
+        filter(({ event }) => event.currentTarget !== null),
+        map(({ event, ...rest }) => ({
+            target: event.target as HTMLElement,
+            ...rest,
+        })),
+        switchMap(({ adjustPosition, codeView, resolveContext, position, ...rest }) =>
+            adjustPosition && position
+                ? from(
+                      adjustPosition({
+                          codeView,
+                          position: { ...position, ...resolveContext(position) },
+                          direction: AdjustmentDirection.CodeViewToActual,
+                      })
+                  ).pipe(
+                      map(({ line, character }) => ({
+                          codeView,
+                          resolveContext,
+                          position: { ...position, line, character },
+                          adjustPosition,
+                          ...rest,
+                      }))
+                  )
+                : of({ adjustPosition, codeView, resolveContext, position, ...rest })
+        ),
+        share()
+    )
+
+    /**
+     * Emits DOM elements at new positions found in the URL. When pinning is
+     * disabled, this does not emit at all because the tooltip doesn't get
+     * pinned at the jump target.
+     */
+    const jumpTargets = pinningEnabled
+        ? allPositionJumps.pipe(
+              // Only use line and character for comparison
+              map(({ position: { line, character, part }, ...rest }) => ({
+                  position: { line, character, part },
+                  ...rest,
+              })),
+              // Ignore same values
+              // It's important to do this before filtering otherwise navigating from
+              // a position, to a line-only position, back to the first position would get ignored
+              distinctUntilChanged((a, b) => isEqual(a, b)),
+              map(({ position, codeView, dom, overrideTokenize, ...rest }) => {
+                  let cell: HTMLElement | null
+                  let target: HTMLElement | undefined
+                  let part: DiffPart | undefined
+                  if (isPosition(position)) {
+                      cell = dom.getCodeElementFromLineNumber(codeView, position.line, position.part)
+                      if (cell) {
+                          target = findElementWithOffset(
+                              cell,
+                              { offsetStart: position.character },
+                              shouldTokenize({ tokenize, overrideTokenize })
+                          )
+                          if (target) {
+                              part = dom.getDiffCodePart?.(target)
+                          } else {
+                              console.warn('Could not find target for position in file', position)
+                          }
+                      }
+                  }
+                  return {
+                      ...rest,
+                      eventType: 'jump' as const,
+                      target,
+                      position: { ...position, part },
+                      codeView,
+                      dom,
+                      overrideTokenize,
+                  }
+              })
+          )
+        : EMPTY
+
     // REPOSITIONING
     // On every componentDidUpdate (after the component was rerendered, e.g. from a hover state update) resposition
     // the tooltip
@@ -516,7 +625,7 @@ export function createHoverifier<C extends object, D, A>({
         from(hoverOverlayRerenders)
             .pipe(
                 // with the latest target that came from either a mouseover, click or location change (whatever was the most recent)
-                withLatestFrom(merge(codeMouseOverTargets)),
+                withLatestFrom(merge(codeMouseOverTargets, codeClickTargets, jumpTargets)),
                 map(
                     ([
                         { hoverOverlayElement, relativeElement },
@@ -578,7 +687,7 @@ export function createHoverifier<C extends object, D, A>({
     )
 
     /** Emits new positions including context at which a tooltip needs to be shown from clicks, mouseovers and URL changes. */
-    const resolvedPositionEvents = merge(codeMouseOverTargets).pipe(
+    const resolvedPositionEvents = merge(codeMouseOverTargets, jumpTargets, codeClickTargets).pipe(
         map(({ position, resolveContext, eventType, ...rest }) => ({
             ...rest,
             eventType,
@@ -588,7 +697,9 @@ export function createHoverifier<C extends object, D, A>({
     )
 
     const resolvedPositions = resolvedPositionEvents.pipe(
-        // Suppress emissions from other events that refer to the same position as the current one.
+        // Suppress emissions from other events that refer to the same position as the current one. This makes it
+        // so the overlay doesn't temporarily disappear when, e.g., clicking to pin the overlay when it's already
+        // visible due to a mouseover.
         distinctUntilChanged((a, b) => isEqual(a.position, b.position))
     )
 
@@ -950,14 +1061,68 @@ export function createHoverifier<C extends object, D, A>({
             })
     )
 
+    if (pinningEnabled) {
+        // DEFERRED HOVER OVERLAY PINNING
+        // If the new position came from a click or the URL,
+        // and either the hover or the definition turn out non-empty, pin the tooltip.
+        // If they both turn out empty, unpin it so we don't end up with an invisible tooltip.
+        //
+        // zip together the corresponding hover and definition
+        subscription.add(
+            combineLatest([
+                zip(hoverObservables, actionObservables),
+                resolvedPositionEvents.pipe(map(({ eventType }) => eventType)),
+            ])
+                .pipe(
+                    switchMap(([[hoverObservable, actionObservable], eventType]) => {
+                        // If the position was triggered by a mouseover, never pin
+                        if (eventType !== 'click' && eventType !== 'jump') {
+                            return [false]
+                        }
+                        // combine the latest values for them, so we have access to both values
+                        // and can reevaluate our pinning decision whenever one of the two updates,
+                        // independent of the order in which they emit
+                        return combineLatest([hoverObservable, actionObservable]).pipe(
+                            map(([{ hoverOrError }, actionsOrError]) =>
+                                // In the time between the click/jump and the loader being displayed,
+                                // pin the hover overlay so mouseover events get ignored
+                                // If the hover comes back empty (and the definition) it will get unpinned again
+                                Boolean(
+                                    hoverOrError === undefined ||
+                                        (actionsOrError &&
+                                            !(Array.isArray(actionsOrError) && actionsOrError.length === 0) &&
+                                            !isErrorLike(actionsOrError))
+                                )
+                            )
+                        )
+                    })
+                )
+                .subscribe(hoverOverlayIsFixed => {
+                    container.update({ hoverOverlayIsFixed })
+                })
+        )
+    }
+
     const resetHover = (): void => {
         container.update({
+            hoverOverlayIsFixed: false,
             hoverOverlayPosition: undefined,
             hoverOrError: undefined,
             hoveredToken: undefined,
             actionsOrError: undefined,
         })
     }
+
+    // When the close button is clicked, unpin, hide and reset the hover
+    subscription.add(
+        merge(
+            closeButtonClicks,
+            fromEvent<KeyboardEvent>(window, 'keydown').pipe(filter(event => event.key === Key.Escape))
+        ).subscribe(event => {
+            event.preventDefault()
+            resetHover()
+        })
+    )
 
     // LOCATION CHANGES
     subscription.add(

--- a/client/shared/src/codeintellify/loading.ts
+++ b/client/shared/src/codeintellify/loading.ts
@@ -47,6 +47,7 @@ export const emitLoading = <TResult, TEmpty>(
     return merge(
         // `undefined` is used here as opposed to `emptyResultValue` to distinguish between "no result" and the time
         // between invocation and when a loader is shown.
+        // See for example "DEFERRED HOVER OVERLAY PINNING" in hoverifier.ts
         [undefined],
         // Show a loader if the provider is loading, has no result yet and hasn't emitted after LOADER_DELAY.
         // combineLatest() is used here to block on the loader delay.

--- a/client/shared/src/codeintellify/positions.test.ts
+++ b/client/shared/src/codeintellify/positions.test.ts
@@ -1,17 +1,61 @@
 import { of } from 'rxjs'
+import { filter, map } from 'rxjs/operators'
+import { TestScheduler } from 'rxjs/testing'
 
+import { Position } from '@sourcegraph/extension-api-types'
+
+import { propertyIsDefined } from './helpers'
 import { findPositionsFromEvents } from './positions'
-import { DOM } from './testutils/dom'
-import { createMouseEvent } from './testutils/mouse'
+import { CodeViewProps, DOM } from './testutils/dom'
+import { createMouseEvent, dispatchMouseEventAtPositionImpure } from './testutils/mouse'
+import { HoveredToken } from './tokenPosition'
 
 describe('positions', () => {
     const dom = new DOM()
-    const testcases = dom.createCodeViews()
-
     afterAll(dom.cleanup)
 
-    // Without this placeholder, jest throws an error saying there are no tests.
-    it('placeholder', () => {})
+    let testcases: CodeViewProps[] = []
+    beforeAll(() => {
+        testcases = dom.createCodeViews()
+    })
+
+    it('can find the position from a mouse event', () => {
+        for (const codeView of testcases) {
+            const scheduler = new TestScheduler((a, b) => expect(a).toEqual(b))
+
+            scheduler.run(({ cold, expectObservable }) => {
+                const diagram = '-ab'
+
+                const positions: { [key: string]: Position } = {
+                    a: { line: 5, character: 3 },
+                    b: { line: 18, character: 4 },
+                }
+
+                const tokens: { [key: string]: HoveredToken } = {
+                    a: {
+                        line: 5,
+                        character: 1,
+                    },
+                    b: {
+                        line: 18,
+                        character: 2,
+                    },
+                }
+
+                const clickedTokens = of(codeView.codeView).pipe(
+                    findPositionsFromEvents({ domFunctions: codeView }),
+                    filter(propertyIsDefined('position')),
+                    map(({ position: { line, character } }) => ({ line, character }))
+                )
+
+                cold<Position>(diagram, positions).subscribe(position =>
+                    dispatchMouseEventAtPositionImpure('click', codeView, position)
+                )
+
+                expectObservable(clickedTokens).toBe(diagram, tokens)
+            })
+        }
+    })
 
     for (const tokenize of [false, true]) {
         for (const codeView of testcases) {

--- a/client/shared/src/codeintellify/positions.ts
+++ b/client/shared/src/codeintellify/positions.ts
@@ -58,6 +58,23 @@ export const findPositionsFromEvents = ({
                     convertCodeElementIdempotent(code)
                 }
             })
+        ),
+        from(elements).pipe(
+            switchMap(element => fromEvent<MouseEvent>(element, 'click')),
+            map(event => ({ event, eventType: 'click' as const })),
+            // ignore click events caused by the user selecting text.
+            // Selecting text should not mess with the hover, hover pinning nor the URL.
+            filter(() => {
+                const selection = window.getSelection()
+                return selection === null || selection.toString() === ''
+            }),
+            filter(({ event }) => event.currentTarget !== null),
+            map(({ event, ...rest }) => ({
+                event,
+                target: event.target as HTMLElement,
+                codeView: event.currentTarget as HTMLElement,
+                ...rest,
+            }))
         )
     ).pipe(
         // Find out the position that was hovered over

--- a/client/shared/src/codeintellify/types.ts
+++ b/client/shared/src/codeintellify/types.ts
@@ -22,6 +22,9 @@ export interface HoverOverlayProps<C extends object, D, A> {
      */
     hoveredToken?: HoveredToken & C
 
+    /** Whether to show the close button for the hover overlay */
+    showCloseButton: boolean
+
     /**
      * Actions to display as buttons or links in the hover.
      */

--- a/client/shared/src/hover/HoverOverlay.fixtures.ts
+++ b/client/shared/src/hover/HoverOverlay.fixtures.ts
@@ -1,4 +1,5 @@
 import { action } from '@storybook/addon-actions'
+import { boolean } from '@storybook/addon-knobs'
 import { createMemoryHistory } from 'history'
 import { of } from 'rxjs'
 import { MarkupContent, Badged, AggregableBadge } from 'sourcegraph'
@@ -19,6 +20,7 @@ const NOOP_PLATFORM_CONTEXT: Pick<PlatformContext, 'forceUpdateTooltip' | 'setti
 }
 
 export const commonProps = (): HoverOverlayProps => ({
+    showCloseButton: boolean('showCloseButton', true),
     location: history.location,
     telemetryService: NOOP_TELEMETRY_SERVICE,
     extensionsController: NOOP_EXTENSIONS_CONTROLLER,
@@ -26,6 +28,7 @@ export const commonProps = (): HoverOverlayProps => ({
     isLightTheme: true,
     overlayPosition: { top: 16, left: 16 },
     onAlertDismissed: action('onAlertDismissed'),
+    onCloseButtonClick: action('onCloseButtonClick'),
 })
 
 export const FIXTURE_CONTENT: Badged<MarkupContent> = {

--- a/client/shared/src/hover/HoverOverlay.story.tsx
+++ b/client/shared/src/hover/HoverOverlay.story.tsx
@@ -30,6 +30,7 @@ registerHighlightContributions()
 const BITBUCKET_CLASS_PROPS: HoverOverlayClassProps = {
     className: 'aui-dialog',
     actionItemClassName: 'aui-button hover-action-item--bitbucket-server',
+    closeButtonClassName: 'aui-button btn-icon--bitbucket-server close',
     iconClassName: 'aui-icon',
     getAlertClassName: alertKind => {
         switch (alertKind) {

--- a/client/shared/src/hover/HoverOverlay.test.tsx
+++ b/client/shared/src/hover/HoverOverlay.test.tsx
@@ -19,6 +19,7 @@ describe('HoverOverlay', () => {
         telemetryService: NOOP_TELEMETRY_SERVICE,
         extensionsController: NOOP_EXTENSIONS_CONTROLLER,
         platformContext: NOOP_PLATFORM_CONTEXT,
+        showCloseButton: false,
         hoveredToken: { repoName: 'r', commitID: 'c', revision: 'v', filePath: 'f', line: 1, character: 2 },
         overlayPosition: { left: 0, top: 0 },
         isLightTheme: false,

--- a/client/shared/src/hover/HoverOverlay.tsx
+++ b/client/shared/src/hover/HoverOverlay.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames'
+import CloseIcon from 'mdi-react/CloseIcon'
 import React, { CSSProperties } from 'react'
 
 import { ActionItem, ActionItemComponentProps } from '../actions/ActionItem'
@@ -9,6 +10,7 @@ import { ThemeProps } from '../theme'
 import { isErrorLike } from '../util/errors'
 import { sanitizeClass } from '../util/strings'
 
+import { toNativeEvent } from './helpers'
 import hoverOverlayStyle from './HoverOverlay.module.scss'
 import type { HoverContext, HoverOverlayBaseProps, GetAlertClassName } from './HoverOverlay.types'
 import { HoverOverlayAlerts, HoverOverlayAlertsProps } from './HoverOverlayAlerts'
@@ -19,11 +21,15 @@ import { useLogTelemetryEvent } from './useLogTelemetryEvent'
 
 const LOADING = 'loading' as const
 
+const transformMouseEvent = (handler: (event: MouseEvent) => void) => (event: React.MouseEvent<HTMLElement>) =>
+    handler(toNativeEvent(event))
+
 export type { HoverContext }
 
 export interface HoverOverlayClassProps {
     /** An optional class name to apply to the outermost element of the HoverOverlay */
     className?: string
+    closeButtonClassName?: string
 
     iconClassName?: string
     badgeClassName?: string
@@ -46,6 +52,8 @@ export interface HoverOverlayProps
         PlatformContextProps<'forceUpdateTooltip' | 'settings'> {
     /** A ref callback to get the root overlay element. Use this to calculate the position. */
     hoverRef?: React.Ref<HTMLDivElement>
+    /** Called when the close button is clicked */
+    onCloseButtonClick?: (event: MouseEvent) => void
 
     /** Show Sourcegraph logo alongside prompt */
     useBrandedLogo?: boolean
@@ -76,9 +84,11 @@ export const HoverOverlay: React.FunctionComponent<HoverOverlayProps> = props =>
         platformContext,
         telemetryService,
         extensionsController,
+        showCloseButton,
         location,
 
         className,
+        closeButtonClassName,
         iconClassName,
         badgeClassName,
         actionItemClassName,
@@ -87,6 +97,7 @@ export const HoverOverlay: React.FunctionComponent<HoverOverlayProps> = props =>
 
         getAlertClassName,
         onAlertDismissed,
+        onCloseButtonClick,
 
         useBrandedLogo,
         useBrandedBadge,
@@ -111,9 +122,23 @@ export const HoverOverlay: React.FunctionComponent<HoverOverlayProps> = props =>
                 data-testid="hover-overlay-contents"
                 className={classNames(
                     style.hoverOverlayContents,
-                    hoverOrError === LOADING && style.hoverOverlayContentsLoading
+                    hoverOrError === LOADING && style.hoverOverlayContentsLoading,
+                    showCloseButton && style.hoverOverlayContentsWithCloseButton
                 )}
             >
+                {showCloseButton && (
+                    <button
+                        type="button"
+                        onClick={onCloseButtonClick ? transformMouseEvent(onCloseButtonClick) : undefined}
+                        className={classNames(
+                            hoverOverlayStyle.closeButton,
+                            closeButtonClassName,
+                            hoverOrError === LOADING && hoverOverlayStyle.closeButtonLoading
+                        )}
+                    >
+                        <CloseIcon className={iconClassName} />
+                    </button>
+                )}
                 <HoverOverlayContents
                     hoverOrError={hoverOrError}
                     iconClassName={iconClassName}

--- a/client/web/src/components/WebHoverOverlay/WebHoverOverlay.tsx
+++ b/client/web/src/components/WebHoverOverlay/WebHoverOverlay.tsx
@@ -1,9 +1,6 @@
 import classNames from 'classnames'
 import React, { useCallback, useEffect } from 'react'
-import { fromEvent } from 'rxjs'
-import { finalize, tap } from 'rxjs/operators'
 
-import { urlForClientCommandOpen } from '@sourcegraph/shared/src/actions/ActionItem'
 import { NotificationType } from '@sourcegraph/shared/src/api/extension/extensionHostApi'
 import { HoverOverlay, HoverOverlayProps } from '@sourcegraph/shared/src/hover/HoverOverlay'
 import { isErrorLike } from '@sourcegraph/shared/src/util/errors'
@@ -22,9 +19,7 @@ const iconKindToAlertKind = {
 const getAlertClassName: HoverOverlayProps['getAlertClassName'] = iconKind =>
     `alert alert-${iconKindToAlertKind[iconKind]}`
 
-export const WebHoverOverlay: React.FunctionComponent<
-    HoverOverlayProps & HoverThresholdProps & { hoveredTokenElement?: HTMLElement; nav?: (url: string) => void }
-> = props => {
+export const WebHoverOverlay: React.FunctionComponent<HoverOverlayProps & HoverThresholdProps> = props => {
     const [dismissedAlerts, setDismissedAlerts] = useLocalStorage<string[]>('WebHoverOverlay.dismissedAlerts', [])
     const onAlertDismissed = useCallback(
         (alertType: string) => {
@@ -55,56 +50,12 @@ export const WebHoverOverlay: React.FunctionComponent<
         }
     }, [hoveredToken?.filePath, hoveredToken?.line, hoveredToken?.character, onHoverShown, hoverHasValue])
 
-    useEffect(() => {
-        const token = props.hoveredTokenElement
-
-        const definitionAction =
-            Array.isArray(props.actionsOrError) &&
-            props.actionsOrError.find(a => a.action.id === 'goToDefinition.preloaded' && !a.disabledWhen)
-
-        const referenceAction =
-            Array.isArray(props.actionsOrError) &&
-            props.actionsOrError.find(a => a.action.id === 'findReferences' && !a.disabledWhen)
-
-        const action = definitionAction || referenceAction
-        if (!action) {
-            return undefined
-        }
-        const url = urlForClientCommandOpen(action.action, props.location.hash)
-
-        if (!token || !url || !props.nav) {
-            return
-        }
-
-        const nav = props.nav
-
-        const oldCursor = token.style.cursor
-        token.style.cursor = 'pointer'
-
-        const subscription = fromEvent(token, 'click')
-            .pipe(
-                tap(() => {
-                    const selection = window.getSelection()
-                    if (selection !== null && selection.toString() !== '') {
-                        return
-                    }
-
-                    const actionType = action === definitionAction ? 'definition' : 'reference'
-                    props.telemetryService.log(`${actionType}HoverOverlay.click`)
-                    nav(url)
-                }),
-                finalize(() => (token.style.cursor = oldCursor))
-            )
-            .subscribe()
-
-        return () => subscription.unsubscribe()
-    }, [props.actionsOrError, props.hoveredTokenElement, props.location.hash, props.nav, props.telemetryService])
-
     return (
         <HoverOverlay
             {...propsToUse}
             useBrandedBadge={true}
             className={classNames('card', styles.webHoverOverlay)}
+            closeButtonClassName={classNames('btn btn-icon', styles.webHoverOverlayCloseButton)}
             actionItemClassName="btn btn-sm btn-secondary border-0"
             onAlertDismissed={onAlertDismissed}
             getAlertClassName={getAlertClassName}

--- a/client/web/src/enterprise/batches/close/BatchChangeCloseChangesetsList.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeCloseChangesetsList.tsx
@@ -96,11 +96,17 @@ export const BatchChangeCloseChangesetsList: React.FunctionComponent<Props> = ({
         hoverOverlayElements,
     ])
 
+    const closeButtonClicks = useMemo(() => new Subject<MouseEvent>(), [])
+    const nextCloseButtonClick = useCallback((event: MouseEvent): void => closeButtonClicks.next(event), [
+        closeButtonClicks,
+    ])
+
     const componentRerenders = useMemo(() => new Subject<void>(), [])
 
     const hoverifier = useMemo(
         () =>
             createHoverifier<RepoSpec & RevisionSpec & FileSpec & ResolvedRevisionSpec, HoverMerged, ActionItemAction>({
+                closeButtonClicks,
                 hoverOverlayElements,
                 hoverOverlayRerenders: componentRerenders.pipe(
                     withLatestFrom(hoverOverlayElements, containerElements),
@@ -118,8 +124,16 @@ export const BatchChangeCloseChangesetsList: React.FunctionComponent<Props> = ({
                 getDocumentHighlights: hoveredToken =>
                     getDocumentHighlights(getLSPTextDocumentPositionParameters(hoveredToken), { extensionsController }),
                 getActions: context => getHoverActions({ extensionsController, platformContext }, context),
+                pinningEnabled: true,
             }),
-        [containerElements, extensionsController, hoverOverlayElements, platformContext, componentRerenders]
+        [
+            closeButtonClicks,
+            containerElements,
+            extensionsController,
+            hoverOverlayElements,
+            platformContext,
+            componentRerenders,
+        ]
     )
     useEffect(() => () => hoverifier.unsubscribe(), [hoverifier])
 
@@ -168,14 +182,13 @@ export const BatchChangeCloseChangesetsList: React.FunctionComponent<Props> = ({
                 {hoverState?.hoverOverlayProps && (
                     <WebHoverOverlay
                         {...hoverState.hoverOverlayProps}
-                        nav={url => history.push(url)}
-                        hoveredTokenElement={hoverState.hoveredTokenElement}
                         telemetryService={telemetryService}
                         extensionsController={extensionsController}
                         isLightTheme={isLightTheme}
                         location={location}
                         platformContext={platformContext}
                         hoverRef={nextOverlayElement}
+                        onCloseButtonClick={nextCloseButtonClick}
                     />
                 )}
             </Container>

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
@@ -192,11 +192,17 @@ const BatchChangeChangesetsImpl: React.FunctionComponent<Props> = ({
         hoverOverlayElements,
     ])
 
+    const closeButtonClicks = useMemo(() => new Subject<MouseEvent>(), [])
+    const nextCloseButtonClick = useCallback((event: MouseEvent): void => closeButtonClicks.next(event), [
+        closeButtonClicks,
+    ])
+
     const componentRerenders = useMemo(() => new Subject<void>(), [])
 
     const hoverifier = useMemo(
         () =>
             createHoverifier<RepoSpec & RevisionSpec & FileSpec & ResolvedRevisionSpec, HoverMerged, ActionItemAction>({
+                closeButtonClicks,
                 hoverOverlayElements,
                 hoverOverlayRerenders: componentRerenders.pipe(
                     withLatestFrom(hoverOverlayElements, containerElements),
@@ -214,8 +220,16 @@ const BatchChangeChangesetsImpl: React.FunctionComponent<Props> = ({
                 getDocumentHighlights: hoveredToken =>
                     getDocumentHighlights(getLSPTextDocumentPositionParameters(hoveredToken), { extensionsController }),
                 getActions: context => getHoverActions({ extensionsController, platformContext }, context),
+                pinningEnabled: true,
             }),
-        [containerElements, extensionsController, hoverOverlayElements, platformContext, componentRerenders]
+        [
+            closeButtonClicks,
+            containerElements,
+            extensionsController,
+            hoverOverlayElements,
+            platformContext,
+            componentRerenders,
+        ]
     )
     useEffect(() => () => hoverifier.unsubscribe(), [hoverifier])
 
@@ -300,14 +314,13 @@ const BatchChangeChangesetsImpl: React.FunctionComponent<Props> = ({
                 {hoverState?.hoverOverlayProps && (
                     <WebHoverOverlay
                         {...hoverState.hoverOverlayProps}
-                        nav={url => history.push(url)}
-                        hoveredTokenElement={hoverState.hoveredTokenElement}
                         telemetryService={telemetryService}
                         extensionsController={extensionsController}
                         isLightTheme={isLightTheme}
                         location={location}
                         platformContext={platformContext}
                         hoverRef={nextOverlayElement}
+                        onCloseButtonClick={nextCloseButtonClick}
                     />
                 )}
             </div>

--- a/client/web/src/extensions/components/StatusBar.tsx
+++ b/client/web/src/extensions/components/StatusBar.tsx
@@ -168,8 +168,7 @@ const StatusBarItem: React.FunctionComponent<
     const command = useMemo(() => statusBarItem.command, [statusBarItem.command])
 
     const to = useMemo(
-        () =>
-            command && urlForClientCommandOpen({ command: command.id, commandArguments: command.args }, location.hash),
+        () => command && urlForClientCommandOpen({ command: command.id, commandArguments: command.args }, location),
         [command, location]
     )
 

--- a/client/web/src/integration/blob-viewer.test.ts
+++ b/client/web/src/integration/blob-viewer.test.ts
@@ -145,6 +145,15 @@ describe('Blob viewer', () => {
 
     // Describes the ways the blob viewer can be extended through Sourcegraph extensions.
     describe('extensibility', () => {
+        const getHoverContents = async (): Promise<string[]> => {
+            // Search for any child of e2e-tooltip-content: as e2e-tooltip-content has display: contents,
+            // it will never be detected as visible by waitForSelector(), but its children will.
+            await driver.page.waitForSelector('.test-tooltip-content *', { visible: true })
+            return driver.page.evaluate(() =>
+                [...document.querySelectorAll('.test-tooltip-content')].map(content => content.textContent ?? '')
+            )
+        }
+
         beforeEach(() => {
             const userSettings: Settings = {
                 extensions: {
@@ -268,6 +277,19 @@ describe('Blob viewer', () => {
             await driver.page.goto(`${driver.sourcegraphBaseUrl}/${repositoryName}/-/blob/${fileName}`)
             await driver.page.waitForSelector('.test-repo-blob')
             // TODO
+        })
+
+        it('shows a hover overlay from a hover provider and updates the URL when a token is clicked', async () => {
+            await driver.page.goto(`${driver.sourcegraphBaseUrl}/github.com/sourcegraph/test/-/blob/test.ts`)
+
+            // Click on "log" in "console.log()" in line 2
+            await driver.page.waitForSelector('.test-log-token', { visible: true })
+            await driver.page.click('.test-log-token')
+
+            await driver.assertWindowLocation('/github.com/sourcegraph/test/-/blob/test.ts?L2:9')
+            assert.deepStrictEqual(await getHoverContents(), ['Test hover content\n'])
+            // Uncomment this snapshot once https://github.com/sourcegraph/sourcegraph/issues/15126 is resolved
+            // await percySnapshot(driver.page, this.test!.fullTitle())
         })
 
         interface MockExtension {
@@ -1067,7 +1089,7 @@ describe('Blob viewer', () => {
             const HOVER_THRESHOLD = 5
             const HOVER_COUNT_KEY = 'hover-count'
 
-            it.skip(`shows a popover about the browser extension when the user has seen ${HOVER_THRESHOLD} hovers and clicks "View on [code host]" button`, async () => {
+            it(`shows a popover about the browser extension when the user has seen ${HOVER_THRESHOLD} hovers and clicks "View on [code host]" button`, async () => {
                 testContext.server.get('https://github.com/*').intercept((request, response) => {
                     response.sendStatus(200)
                 })
@@ -1089,10 +1111,10 @@ describe('Blob viewer', () => {
                     'Expected popover to not be displayed before user reaches hover threshold'
                 )
 
-                // Hover over 'console' and 'log' 5 times combined
+                // Click 'console' and 'log' 5 times combined
                 await driver.page.waitForSelector('.test-log-token', { visible: true })
                 for (let index = 0; index < HOVER_THRESHOLD; index++) {
-                    await driver.page.hover(index % 2 === 0 ? '.test-log-token' : '.test-console-token')
+                    await driver.page.click(index % 2 === 0 ? '.test-log-token' : '.test-console-token')
                     await driver.page.waitForSelector('[data-testid="hover-overlay"]', { visible: true })
                 }
 
@@ -1113,7 +1135,7 @@ describe('Blob viewer', () => {
                 )
             })
 
-            it.skip(`shows an alert about the browser extension when the user has seen ${HOVER_THRESHOLD} hovers`, async () => {
+            it(`shows an alert about the browser extension when the user has seen ${HOVER_THRESHOLD} hovers`, async () => {
                 await driver.page.goto(`${driver.sourcegraphBaseUrl}/github.com/sourcegraph/test/-/blob/test.ts`)
                 await driver.page.evaluate(HOVER_COUNT_KEY => localStorage.removeItem(HOVER_COUNT_KEY), HOVER_COUNT_KEY)
                 await driver.page.reload()
@@ -1124,10 +1146,10 @@ describe('Blob viewer', () => {
                     'Expected "Install browser extension" alert to not be displayed before user reaches hover threshold'
                 )
 
-                // Hover over 'console' and 'log' $HOVER_THRESHOLD times combined
+                // Click 'console' and 'log' $HOVER_THRESHOLD times combined
                 await driver.page.waitForSelector('.test-log-token', { visible: true })
                 for (let index = 0; index < HOVER_THRESHOLD; index++) {
-                    await driver.page.hover(index % 2 === 0 ? '.test-log-token' : '.test-console-token')
+                    await driver.page.click(index % 2 === 0 ? '.test-log-token' : '.test-console-token')
                     await driver.page.waitForSelector('[data-testid="hover-overlay"]', { visible: true })
                 }
                 await driver.page.reload()

--- a/client/web/src/repo/commit/RepositoryCommitPage.tsx
+++ b/client/web/src/repo/commit/RepositoryCommitPage.tsx
@@ -122,6 +122,9 @@ export class RepositoryCommitPage extends React.Component<Props, State> {
     private nextRepositoryCommitPageElement = (element: HTMLElement | null): void =>
         this.repositoryCommitPageElements.next(element)
 
+    /** Emits when the close button was clicked */
+    private closeButtonClicks = new Subject<MouseEvent>()
+    private nextCloseButtonClick = (event: MouseEvent): void => this.closeButtonClicks.next(event)
     private subscriptions = new Subscription()
     private hoverifier: Hoverifier<
         RepoSpec & RevisionSpec & FileSpec & ResolvedRevisionSpec,
@@ -136,6 +139,7 @@ export class RepositoryCommitPage extends React.Component<Props, State> {
             HoverMerged,
             ActionItemAction
         >({
+            closeButtonClicks: this.closeButtonClicks,
             hoverOverlayElements: this.hoverOverlayElements,
             hoverOverlayRerenders: this.componentUpdates.pipe(
                 withLatestFrom(this.hoverOverlayElements, this.repositoryCommitPageElements),
@@ -151,6 +155,7 @@ export class RepositoryCommitPage extends React.Component<Props, State> {
             getDocumentHighlights: hoveredToken =>
                 getDocumentHighlights(this.getLSPTextDocumentPositionParams(hoveredToken), this.props),
             getActions: context => getHoverActions(this.props, context),
+            pinningEnabled: true,
         })
         this.subscriptions.add(this.hoverifier)
         this.onHandleDiffMode = this.onHandleDiffMode.bind(this)
@@ -299,10 +304,9 @@ export class RepositoryCommitPage extends React.Component<Props, State> {
                     <WebHoverOverlay
                         {...this.props}
                         {...this.state.hoverOverlayProps}
-                        nav={url => this.props.history.push(url)}
-                        hoveredTokenElement={this.state.hoveredTokenElement}
                         telemetryService={this.props.telemetryService}
                         hoverRef={this.nextOverlayElement}
+                        onCloseButtonClick={this.nextCloseButtonClick}
                     />
                 )}
             </div>

--- a/client/web/src/repo/compare/RepositoryCompareArea.tsx
+++ b/client/web/src/repo/compare/RepositoryCompareArea.tsx
@@ -97,6 +97,10 @@ export class RepositoryCompareArea extends React.Component<RepositoryCompareArea
     private nextRepositoryCompareAreaElement = (element: HTMLElement | null): void =>
         this.repositoryCompareAreaElements.next(element)
 
+    /** Emits when the close button was clicked */
+    private closeButtonClicks = new Subject<MouseEvent>()
+    private nextCloseButtonClick = (event: MouseEvent): void => this.closeButtonClicks.next(event)
+
     private subscriptions = new Subscription()
     private hoverifier: Hoverifier<
         RepoSpec & RevisionSpec & FileSpec & ResolvedRevisionSpec,
@@ -111,6 +115,7 @@ export class RepositoryCompareArea extends React.Component<RepositoryCompareArea
             HoverMerged,
             ActionItemAction
         >({
+            closeButtonClicks: this.closeButtonClicks,
             hoverOverlayElements: this.hoverOverlayElements,
             hoverOverlayRerenders: this.componentUpdates.pipe(
                 withLatestFrom(this.hoverOverlayElements, this.repositoryCompareAreaElements),
@@ -126,6 +131,7 @@ export class RepositoryCompareArea extends React.Component<RepositoryCompareArea
             getDocumentHighlights: hoveredToken =>
                 getDocumentHighlights(this.getLSPTextDocumentPositionParams(hoveredToken), this.props),
             getActions: context => getHoverActions(this.props, context),
+            pinningEnabled: true,
         })
         this.subscriptions.add(this.hoverifier)
         this.state = this.hoverifier.hoverState
@@ -212,10 +218,9 @@ export class RepositoryCompareArea extends React.Component<RepositoryCompareArea
                     <WebHoverOverlay
                         {...this.props}
                         {...this.state.hoverOverlayProps}
-                        nav={url => this.props.history.push(url)}
-                        hoveredTokenElement={this.state.hoveredTokenElement}
                         telemetryService={this.props.telemetryService}
                         hoverRef={this.nextOverlayElement}
+                        onCloseButtonClick={this.nextCloseButtonClick}
                     />
                 )}
             </div>


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#28520

This change caused a regression in the e2e tests: https://buildkite.com/sourcegraph/sourcegraph/builds/121420#1863d840-034a-4454-9190-39a98afe556b

Rolling back for now to fix builds. Also see https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1639527547213800