### PR TITLE
Add newcomers onboarding tour

### DIFF
--- a/client/shared/src/telemetry/telemetryService.ts
+++ b/client/shared/src/telemetry/telemetryService.ts
@@ -20,6 +20,13 @@ export interface TelemetryService {
      * Log a pageview event (by sending it to the server).
      */
     logViewEvent(eventName: string, eventProperties?: any, publicArgument?: any): void
+
+    /**
+     * Listen for event logs
+     *
+     * @returns a cleanup/removeEventListener function
+     */
+    addEventLogListener?(callback: (eventName: string) => void): () => void
 }
 
 /**

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -47,6 +47,7 @@ import { ExtensionAreaHeaderNavItem } from './extensions/extension/ExtensionArea
 import { ExtensionsAreaRoute } from './extensions/ExtensionsArea'
 import { ExtensionsAreaHeaderActionButton } from './extensions/ExtensionsAreaHeader'
 import { FeatureFlagName, fetchFeatureFlags, FlagSet } from './featureFlags/featureFlags'
+import { FeatureFlagsAgent } from './featureFlags/FeatureFlagsAgent'
 import { CodeInsightsProps } from './insights/types'
 import { KeyboardShortcutsProps } from './keyboardShortcuts/keyboardShortcuts'
 import { Layout, LayoutProps } from './Layout'
@@ -401,6 +402,7 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
                             <SearchResultsCacheProvider>
                                 <ScrollManager history={history}>
                                     <Router history={history} key={0}>
+                                        <FeatureFlagsAgent />
                                         <Route
                                             path="/"
                                             render={routeComponentProps => (

--- a/client/web/src/featureFlags/FeatureFlagsAgent.tsx
+++ b/client/web/src/featureFlags/FeatureFlagsAgent.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect } from 'react'
+
+/**
+ * Overrides feature flag based on initial URL query parameters
+ *
+ * @description
+ * To force enabled: "/?feature-flag-key=my-feature&feature-flag-value=true"
+ * To force disable: "/?feature-flag-key=my-feature&feature-flag-value=false"
+ * To remove local override: "/?feature-flag-key=my-feature"
+ */
+export const FeatureFlagsAgent = React.memo(() => {
+    useEffect(() => {
+        try {
+            const queryString = location.search
+            const urlParameters = new URLSearchParams(queryString)
+            const featureFlagKey = urlParameters.get('feature-flag-key')
+            if (!featureFlagKey) {
+                return
+            }
+            const featureFlagValue = urlParameters.get('feature-flag-value')
+            if (!featureFlagValue) {
+                localStorage.removeItem(featureFlagKey)
+            } else {
+                localStorage.setItem(featureFlagKey, Boolean(featureFlagValue).toString())
+            }
+        } catch (error) {
+            console.error(error)
+        }
+    }, [])
+    return null
+})

--- a/client/web/src/featureFlags/FeatureFlagsAgent.tsx
+++ b/client/web/src/featureFlags/FeatureFlagsAgent.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect } from 'react'
 
+import { getOverrideKey } from './lib/getOverrideKey'
+
 /**
  * Overrides feature flag based on initial URL query parameters
  *
@@ -19,9 +21,9 @@ export const FeatureFlagsAgent = React.memo(() => {
             }
             const featureFlagValue = urlParameters.get('feature-flag-value')
             if (!featureFlagValue) {
-                localStorage.removeItem(featureFlagKey)
+                localStorage.removeItem(getOverrideKey(featureFlagKey))
             } else {
-                localStorage.setItem(featureFlagKey, Boolean(featureFlagValue).toString())
+                localStorage.setItem(getOverrideKey(featureFlagKey), Boolean(featureFlagValue === 'true').toString())
             }
         } catch (error) {
             console.error(error)

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -6,11 +6,25 @@ import { dataOrThrowErrors, gql } from '@sourcegraph/shared/src/graphql/graphql'
 import { requestGraphQL } from '../backend/graphql'
 import { FetchFeatureFlagsResult } from '../graphql-operations'
 
+class ProxyMap<K extends string, V extends boolean> extends Map<K, V> {
+    constructor(private getter?: (key: K, value: V | undefined) => V | undefined) {
+        super()
+    }
+    public get(key: K): V | undefined {
+        const originalValue = super.get(key)
+        return this.getter ? this.getter(key, originalValue) : originalValue
+    }
+}
+
 // A union of all feature flags we currently have.
 // If there are no feature flags at the moment, this should be `never`.
-export type FeatureFlagName = 'search-notebook-onboarding' | 'test-flag' | 'signup-optimization'
+export type FeatureFlagName =
+    | 'search-notebook-onboarding'
+    | 'test-flag'
+    | 'signup-optimization'
+    | 'getting-started-tour'
 
-export type FlagSet = Map<FeatureFlagName, boolean>
+export type FlagSet = ProxyMap<FeatureFlagName, boolean>
 
 /**
  * Fetches the evaluated feature flags for the current user
@@ -30,7 +44,12 @@ export function fetchFeatureFlags(): Observable<FlagSet> {
     ).pipe(
         map(dataOrThrowErrors),
         map(data => {
-            const result = new Map<FeatureFlagName, boolean>()
+            const result = new ProxyMap<FeatureFlagName, boolean>((key: FeatureFlagName, value?: boolean):
+                | boolean
+                | undefined => {
+                const localValue = localStorage.getItem(key)
+                return typeof localValue !== 'undefined' && localValue !== null ? Boolean(localValue) : value
+            })
             for (const flag of data.viewerFeatureFlags) {
                 result.set(flag.name as FeatureFlagName, flag.value)
             }

--- a/client/web/src/featureFlags/lib/getOverrideKey.ts
+++ b/client/web/src/featureFlags/lib/getOverrideKey.ts
@@ -1,0 +1,1 @@
+export const getOverrideKey = (key: string): string => `featureFlagOverride-${key}`

--- a/client/web/src/onboarding-tour/OnboardingTour.module.scss
+++ b/client/web/src/onboarding-tour/OnboardingTour.module.scss
@@ -1,0 +1,146 @@
+.card {
+    padding: 0.1875rem;
+    background: linear-gradient(to right, #e4d3fc 0%, #d7f0fd 100%);
+    color: var(--body-color);
+    border-radius: 3px;
+
+    [data-reach-accordion-button] {
+        display: flex;
+        align-items: center;
+        margin-top: 0.5rem;
+        margin-bottom: 0.5rem;
+        cursor: pointer;
+
+        .arrow-icon-container {
+            margin-right: 0.25rem;
+            margin-left: -0.25rem;
+
+            svg {
+                transform: rotate(-90deg);
+            }
+        }
+
+        &[aria-expanded='true'] {
+            font-weight: bold;
+            .arrow-icon-container svg {
+                transform: none;
+            }
+        }
+    }
+
+    [data-reach-accordion-panel] {
+        margin-left: 1rem;
+        cursor: pointer;
+    }
+}
+
+.card-inner {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+    background-color: var(--color-bg-1);
+    padding: 0.75rem;
+    height: 100%;
+}
+
+.card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.card-title {
+    margin: 0;
+    font-size: 0.75rem;
+    font-weight: bold;
+    text-transform: uppercase;
+}
+
+.divider {
+    border: 0;
+    border-top: 1px solid var(--border-color);
+    width: 100%;
+    margin: 0.5rem 0;
+}
+
+.label {
+    margin-right: auto;
+    font-size: 0.875rem;
+    font-weight: normal;
+}
+
+.link {
+    &,
+    &:hover,
+    &:active {
+        text-decoration: none;
+        color: var(--body-color);
+    }
+}
+
+.is-fixed-height {
+    height: 7rem;
+    overflow-y: auto;
+    flex-grow: 1;
+
+    &::-webkit-scrollbar {
+        margin-left: 4px;
+        width: 4px;
+    }
+
+    &::-webkit-scrollbar-track {
+        border-radius: 3px;
+        box-shadow: inset 0 0 6px var(--color-bg-2);
+    }
+
+    &::-webkit-scrollbar-thumb {
+        border-radius: 3px;
+        box-shadow: inset 0 0 6px var(--text-muted);
+    }
+}
+
+.step {
+    display: flex;
+    margin-bottom: 0.5rem;
+}
+
+.progress-bar {
+    width: 0.9rem;
+    height: 0.9rem;
+    margin-right: 1px;
+
+    // stylelint-disable-next-line selector-class-pattern
+    :global(.CircularProgressbar-trail) {
+        stroke: var(--dropdown-border-color);
+    }
+    // stylelint-disable-next-line selector-class-pattern
+    :global(.CircularProgressbar-path) {
+        stroke: var(--oc-green-4);
+    }
+}
+
+.footer-text {
+    margin-left: 0.25rem;
+}
+
+.text {
+    margin: 1rem 0;
+}
+
+.info-panel {
+    padding: 0.5rem;
+    background-color: #ccedff;
+    border: 1px solid #a5d8ff;
+    border-radius: 3px;
+    color: var(--gray-08);
+}
+
+.icon-muted {
+    color: var(--icon-color);
+    opacity: 0.4;
+}
+
+.info-icon {
+    color: var(--icon-color);
+    margin-right: 0.25rem;
+}

--- a/client/web/src/onboarding-tour/OnboardingTour.module.scss
+++ b/client/web/src/onboarding-tour/OnboardingTour.module.scss
@@ -84,7 +84,9 @@
     flex-grow: 1;
 
     &::-webkit-scrollbar {
+        /* stylelint-disable-next-line declaration-property-unit-whitelist */
         margin-left: 4px;
+        /* stylelint-disable-next-line declaration-property-unit-whitelist */
         width: 4px;
     }
 
@@ -107,6 +109,7 @@
 .progress-bar {
     width: 0.9rem;
     height: 0.9rem;
+    /* stylelint-disable-next-line declaration-property-unit-whitelist */
     margin-right: 1px;
 
     // stylelint-disable-next-line selector-class-pattern

--- a/client/web/src/onboarding-tour/OnboardingTour.story.tsx
+++ b/client/web/src/onboarding-tour/OnboardingTour.story.tsx
@@ -1,6 +1,8 @@
 import { Meta, DecoratorFn } from '@storybook/react'
 import React from 'react'
 
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
+
 import { WebStory } from '../components/WebStory'
 
 import { OnboardingTour } from './OnboardingTour'
@@ -17,4 +19,4 @@ const config: Meta = {
 
 export default config
 
-export const Default: React.FunctionComponent = () => <OnboardingTour />
+export const Default: React.FunctionComponent = () => <OnboardingTour telemetryService={NOOP_TELEMETRY_SERVICE} />

--- a/client/web/src/onboarding-tour/OnboardingTour.story.tsx
+++ b/client/web/src/onboarding-tour/OnboardingTour.story.tsx
@@ -1,0 +1,20 @@
+import { Meta, DecoratorFn } from '@storybook/react'
+import React from 'react'
+
+import { WebStory } from '../components/WebStory'
+
+import { OnboardingTour } from './OnboardingTour'
+
+const decorator: DecoratorFn = story => <WebStory>{() => <div className="container mt-3">{story()}</div>}</WebStory>
+
+const config: Meta = {
+    title: 'web/OnboardingTour',
+    decorators: [decorator],
+    parameters: {
+        component: OnboardingTour,
+    },
+}
+
+export default config
+
+export const Default: React.FunctionComponent = () => <OnboardingTour />

--- a/client/web/src/onboarding-tour/OnboardingTour.tsx
+++ b/client/web/src/onboarding-tour/OnboardingTour.tsx
@@ -1,0 +1,287 @@
+import { Accordion, AccordionButton, AccordionItem, AccordionPanel } from '@reach/accordion'
+import classNames from 'classnames'
+import { groupBy } from 'lodash'
+import ArrowDropDownIcon from 'mdi-react/ArrowDropDownIcon'
+import CheckCircleIcon from 'mdi-react/CheckCircleIcon'
+import CloseIcon from 'mdi-react/CloseIcon'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { CircularProgressbar } from 'react-circular-progressbar'
+import ReactDOM from 'react-dom'
+import { Link, useLocation } from 'react-router-dom'
+
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { Button } from '@sourcegraph/wildcard'
+
+import { ErrorBoundary } from '../components/ErrorBoundary'
+
+import { OnboardingTourStepItem } from './lib/data'
+import { useOnboardingTour, useOnboardingTourCompletion, useOnboardingTourTracking } from './lib/useOnboardingTour'
+import styles from './OnboardingTour.module.scss'
+
+interface CardProps {
+    onClose: () => void
+    title: string
+    className?: string
+}
+
+const Card: React.FunctionComponent<CardProps> = ({ title, children, onClose, className }) => (
+    <article className={classNames(styles.card, className)}>
+        <div className={styles.cardInner}>
+            <header className={styles.cardHeader}>
+                <h3 className={classNames(styles.cardTitle)}>{title}</h3>
+                <CloseIcon onClick={onClose} className="icon-inline" size="1rem" />
+            </header>
+            {children}
+        </div>
+    </article>
+)
+const buildUriMarkers = (href: string, stepId: string): string => {
+    try {
+        const url = new URL(href, `${location.protocol}//${location.host}`)
+        url.searchParams.set('tour', 'true')
+        url.searchParams.set('stepId', stepId)
+        return url.toString().slice(url.origin.length)
+    } catch {
+        return '#'
+    }
+}
+
+const parseUriMarkers = (searchParameters: string): { isTour: boolean; stepId: string | null } => {
+    const parameters = new URLSearchParams(searchParameters)
+    const isTour = parameters.has('tour')
+    const stepId = parameters.get('stepId')
+    return { isTour, stepId }
+}
+
+interface OnboardingTourStepsListProps extends TelemetryProps {
+    className?: string
+    steps: OnboardingTourStepItem[]
+}
+
+const OnboardingTourStepsList: React.FunctionComponent<OnboardingTourStepsListProps> = ({
+    steps,
+    className,
+    telemetryService,
+}) => {
+    const location = useLocation()
+    const [expandedIndex, setExpandedIndex] = useState<number[]>([])
+    const { triggerEvent } = useOnboardingTourTracking(telemetryService)
+    const { onStepComplete } = useOnboardingTourCompletion()
+    const groups = useMemo(
+        () =>
+            Object.entries(groupBy(steps, 'group')).map(([title, steps]) => ({
+                title,
+                steps,
+                completed: Math.round((100 * steps.filter(step => step.isCompleted).length) / steps.length),
+            })),
+        [steps]
+    )
+
+    const toggleExpandedIndexes = useCallback((currentIndex: number) => {
+        setExpandedIndex(indexes => {
+            if (indexes.includes(currentIndex)) {
+                return indexes.filter(index => index !== currentIndex)
+            }
+
+            return [...indexes, currentIndex]
+        })
+    }, [])
+
+    useEffect(() => {
+        const { stepId } = parseUriMarkers(location.search)
+        const currentIndex = groups.findIndex(group => group.steps.find(step => step.id === stepId))
+        if (currentIndex >= 0) {
+            setExpandedIndex(indexes => [...indexes, currentIndex])
+        }
+    }, [location, groups])
+
+    return (
+        <Accordion className={className} index={expandedIndex} onChange={toggleExpandedIndexes}>
+            {groups.map(({ title, steps, completed }) => (
+                <AccordionItem key={title}>
+                    <AccordionButton as="div">
+                        <span className={styles.arrowIconContainer}>
+                            <ArrowDropDownIcon size="1rem" />
+                        </span>
+                        <span className={styles.label}>{title}</span>
+                        {completed < 100 ? (
+                            <CircularProgressbar className={styles.progressBar} strokeWidth={20} value={completed} />
+                        ) : (
+                            <CheckCircleIcon className={classNames('icon-inline', 'text-success')} size="1rem" />
+                        )}
+                    </AccordionButton>
+                    <AccordionPanel>
+                        {steps.map(step => {
+                            const linkProps = {
+                                onClick: () => {
+                                    triggerEvent(step.id + 'Clicked')
+                                    if (!step.completeAfterEvents) {
+                                        onStepComplete(step)
+                                    }
+                                },
+                                className: classNames(styles.label, styles.link),
+                            }
+                            return (
+                                <div key={step.id} className={styles.step}>
+                                    {step.to.startsWith('http') ? (
+                                        <a href={step.to} {...linkProps} target="_blank" rel="noopener noreferrer">
+                                            {step.title}
+                                        </a>
+                                    ) : (
+                                        <Link to={buildUriMarkers(step.to, step.id)} {...linkProps}>
+                                            {step.title}
+                                        </Link>
+                                    )}
+                                    <CheckCircleIcon
+                                        className={classNames(
+                                            'icon-inline',
+                                            step.isCompleted ? 'text-success' : styles.iconMuted
+                                        )}
+                                        size="1rem"
+                                    />
+                                </div>
+                            )
+                        })}
+                    </AccordionPanel>
+                </AccordionItem>
+            ))}
+        </Accordion>
+    )
+}
+
+interface OnboardingTourContentProps extends TelemetryProps {
+    isFixedHeight?: boolean
+    className?: string
+}
+
+export const OnboardingTourContent: React.FunctionComponent<OnboardingTourContentProps> = ({
+    className,
+    isFixedHeight,
+    telemetryService,
+}) => {
+    const { isClosed, isTourCompleted, steps, onClose, onRestart, onSignUp, onInstall } = useOnboardingTour(
+        telemetryService
+    )
+    const completedCount = useMemo(() => steps.filter(step => step.isCompleted).length, [steps])
+
+    if (isClosed) {
+        return null
+    }
+
+    if (isTourCompleted) {
+        return (
+            <Card title="Tour complete!" className={className} onClose={onClose}>
+                <p className={styles.text}>
+                    Install Sourcegraph locally or create an account to get powerful code search and other powerful
+                    features on your private code.
+                </p>
+                <div className="d-flex flex-column">
+                    <Link className="btn btn-primary align-self-start mb-2" to="/sign-up" onClick={onSignUp}>
+                        Sign up for Cloud
+                    </Link>
+                    <a
+                        className="btn btn-link shadow-none align-self-start pl-0 mb-2"
+                        href="https://docs.sourcegraph.com/admin/install?utm_campaign=inproduct-tour&utm_medium=direct_traffic&utm_source=inproduct-tour&utm_term=null&utm_content=complete"
+                        onClick={onInstall}
+                        target="_blank"
+                        rel="noreferrer noopener"
+                    >
+                        Install Sourcegraph locally
+                    </a>
+                    <Button variant="link" size="sm" className="align-self-start text-left pl-0" onClick={onRestart}>
+                        Restart
+                    </Button>
+                </div>
+            </Card>
+        )
+    }
+
+    return (
+        <Card title="Getting started" className={className} onClose={onClose}>
+            <hr className={styles.divider} />
+            <OnboardingTourStepsList
+                steps={steps}
+                telemetryService={telemetryService}
+                className={classNames({ [styles.isFixedHeight]: isFixedHeight })}
+            />
+            <footer>
+                <CheckCircleIcon className="icon-inline text-success" size="1rem" />
+                <span className={styles.footerText}>
+                    {completedCount} of {steps.length}
+                </span>
+            </footer>
+            <OnboardingTourAgent steps={steps} telemetryService={telemetryService} />
+        </Card>
+    )
+}
+
+export const OnboardingTour: React.FunctionComponent<OnboardingTourContentProps> = props => (
+    <ErrorBoundary
+        location={null}
+        render={error => (
+            <div>
+                Onboarding Tour. Something went wrong :(.
+                <pre>{JSON.stringify(error)}</pre>
+            </div>
+        )}
+    >
+        <OnboardingTourContent {...props} />
+    </ErrorBoundary>
+)
+
+interface OnboardingTourAgentProps extends Partial<TelemetryProps> {
+    steps: OnboardingTourStepItem[]
+}
+
+/**
+ * Agent component that tracks step completions and/or shows info popups
+ */
+const OnboardingTourAgent: React.FunctionComponent<OnboardingTourAgentProps> = React.memo(
+    ({ steps, telemetryService }) => {
+        const [info, setInfo] = useState<OnboardingTourStepItem['info'] | undefined>()
+        const { onStepComplete } = useOnboardingTourCompletion()
+
+        const location = useLocation()
+
+        useEffect(() => {
+            const filteredSteps = steps.filter(step => step.completeAfterEvents)
+            telemetryService?.addEventLogListener?.(eventName => {
+                const stepToComplete = filteredSteps.find(step => step.completeAfterEvents?.includes(eventName))
+                if (stepToComplete) {
+                    onStepComplete(stepToComplete)
+                }
+            })
+        }, [telemetryService, steps, onStepComplete])
+
+        useEffect(() => {
+            const { isTour, stepId } = parseUriMarkers(location.search)
+
+            if (!isTour || !stepId) {
+                return
+            }
+
+            const info = steps.find(step => stepId === step.id)?.info
+
+            if (info) {
+                setInfo(info)
+            }
+        }, [steps, location])
+
+        if (!info) {
+            return null
+        }
+
+        const domNode = document.querySelector(info.selector)
+        if (!domNode) {
+            return null
+        }
+
+        return ReactDOM.createPortal(
+            <div className={styles.infoPanel}>
+                <CheckCircleIcon className={classNames('icon-inline', styles.infoIcon)} size="1rem" />
+                <span dangerouslySetInnerHTML={{ __html: info.content }} />
+            </div>,
+            domNode
+        )
+    }
+)

--- a/client/web/src/onboarding-tour/lib/data.ts
+++ b/client/web/src/onboarding-tour/lib/data.ts
@@ -1,0 +1,96 @@
+const CODE_SEARCH = 'Code search use cases'
+const CODE_INTEL = 'The power of code intel'
+const TOOLS = 'Tools to improve workflow'
+
+export interface OnboardingTourStepItem {
+    id: string
+    /**
+     * Title of the group which step belongs
+     */
+    group: string
+    /**
+     * Title/name of the step
+     */
+    title: string
+    /**
+     * URL to redirect
+     */
+    to: string
+    /**
+     * Flag whether this step was completed of not
+     */
+    isCompleted: boolean
+    /**
+     * HTML text to show on page after redirecting to link
+     */
+    info?: {
+        selector: string
+        content: string
+    }
+    /**
+     * Log "${id}Completed" event and mark item as completed after one of the events is triggered
+     */
+    completeAfterEvents?: string[]
+}
+
+export const ONBOARDING_STEP_ITEMS: Omit<OnboardingTourStepItem, 'isCompleted'>[] = [
+    // Group: CODE_SEARCH
+    {
+        id: 'TourDiffSearch',
+        title: 'Find removed code in diffs',
+        group: CODE_SEARCH,
+        to:
+            '/search?q=context:global+repo:%5Egitlab%5C.com/sourcegraph/sourcegraph%24+type:diff+lang:go+select:commit.diff.removed+magic&patternType=literal',
+    },
+    {
+        id: 'TourCommitsSearch',
+        title: 'Find changes in commits',
+        group: CODE_SEARCH,
+        to:
+            '/search?q=context:global+repo:%5Egitlab%5C.com/sourcegraph/sourcegraph%24+type:commit+bump&patternType=literal',
+    },
+    {
+        id: 'TourSymbolsSearch',
+        title: 'Find symbols via a string',
+        group: CODE_SEARCH,
+        to: '/search?q=context:global+r:sourcegraph/sourcegraph%24+lang:go+type:symbol+auth&patternType=literal',
+    },
+    // Group: CODE_INTEL
+    {
+        id: 'TourFindReferences',
+        title: 'Find references',
+        group: CODE_INTEL,
+        info: {
+            selector: '.onboarding-tour-info-marker',
+            content: `<strong>FIND REFERENCES</strong><br/>
+            Hover over a token in the highlighted line to open code intel, then click ‘Find References’ to locate all calls of this code.`,
+        },
+        completeAfterEvents: ['findReferences'],
+        to: '/github.com/sourcegraph/sourcegraph/-/blob/internal/featureflag/featureflag.go?L9:6',
+    },
+    {
+        id: 'TourGoToDefinition',
+        title: 'Go to a definition',
+        group: CODE_INTEL,
+        info: {
+            selector: '.onboarding-tour-info-marker',
+            content: `<strong>GO TO DEFINITION</strong><br/>
+            Hover over a token in the highlighted line to open code intel, then click ‘Go to definition’ to locate a token definition.`,
+        },
+        completeAfterEvents: ['goToDefinition', 'goToDefinition.preloaded'],
+        to: '/github.com/sourcegraph/sourcegraph/-/blob/internal/repos/observability.go?L192:22',
+    },
+    // Group: TOOLS
+    {
+        id: 'TourEditorExtensions',
+        group: TOOLS,
+        title: 'IDE extentions',
+        to: 'https://docs.sourcegraph.com/integration/editor',
+    },
+    {
+        id: 'TourBrowserExtensions',
+        group: TOOLS,
+        title: 'Browser extensions',
+        to: 'https://docs.sourcegraph.com/integration/browser_extension',
+    },
+]

--- a/client/web/src/onboarding-tour/lib/useOnboardingTour.ts
+++ b/client/web/src/onboarding-tour/lib/useOnboardingTour.ts
@@ -1,0 +1,120 @@
+import { useCallback, useEffect, useMemo } from 'react'
+import { BehaviorSubject } from 'rxjs'
+
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
+
+import { OnboardingTourStepItem, ONBOARDING_STEP_ITEMS } from './data'
+
+const STORAGE_KEY = 'ONBOARDING_TOUR'
+
+interface OnboardingTourStore {
+    completedStepIds?: string[]
+    isClosed?: boolean
+    isCompleteEventTriggered?: boolean
+}
+
+const data = new BehaviorSubject<OnboardingTourStore>(
+    JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}') as OnboardingTourStore
+)
+
+// eslint-disable-next-line rxjs/no-ignored-subscription
+data.subscribe(data => localStorage.setItem(STORAGE_KEY, JSON.stringify(data)))
+
+const clear = (): void => {
+    localStorage.removeItem(STORAGE_KEY)
+    data.next({})
+}
+
+const set = <K extends keyof OnboardingTourStore>(key: K, value: OnboardingTourStore[K]): void => {
+    data.next({ ...data.value, [key]: value })
+}
+
+export function useOnboardingTourTracking(
+    telemetryService: TelemetryProps['telemetryService']
+): {
+    triggerEvent: (eventName: string) => void
+} {
+    const triggerEvent = useCallback(
+        (eventName: string) => {
+            const args = { language: 'Go', page: location.href }
+            telemetryService.log(eventName, args, args)
+            console.log('[TourEvents]', eventName, args)
+        },
+        [telemetryService]
+    )
+
+    return { triggerEvent }
+}
+
+export function useOnboardingTourCompletion(): {
+    onStepComplete: (step: OnboardingTourStepItem) => void
+} {
+    const store = useObservable(data)
+
+    const onStepComplete = useCallback(
+        (step: OnboardingTourStepItem) => {
+            set('completedStepIds', [...(store?.completedStepIds ?? []), step.id])
+        },
+        [store?.completedStepIds]
+    )
+
+    return { onStepComplete }
+}
+
+export function useOnboardingTour(
+    telemetryService: TelemetryProps['telemetryService']
+): {
+    steps: OnboardingTourStepItem[]
+    isTourCompleted: boolean
+    isClosed: boolean
+    onClose: () => void
+    onRestart: () => void
+    onSignUp: () => void
+    onInstall: () => void
+} {
+    const store = useObservable(data)
+    const { triggerEvent } = useOnboardingTourTracking(telemetryService)
+
+    const onClose = useCallback(() => {
+        set('isClosed', true)
+        // TODO: trigger event
+    }, [])
+
+    const onSignUp = useCallback(() => {
+        triggerEvent('TourSignUpClicked')
+    }, [triggerEvent])
+
+    const onInstall = useCallback(() => {
+        triggerEvent('TourInstallLocallyClicked')
+    }, [triggerEvent])
+
+    const onRestart = useCallback(() => {
+        clear()
+        // TODO: trigger event
+    }, [])
+
+    const { steps, isTourCompleted, isClosed } = useMemo(() => {
+        const steps = ONBOARDING_STEP_ITEMS.map(step => ({
+            ...step,
+            isCompleted: !!store?.completedStepIds?.includes(step.id),
+        }))
+        return {
+            steps,
+            isTourCompleted: steps.filter(step => step.isCompleted).length === steps.length,
+            isClosed: !!store?.isClosed,
+        }
+    }, [store])
+
+    useEffect(() => {
+        if (!store) {
+            return
+        }
+        if (isTourCompleted && !store.isCompleteEventTriggered) {
+            triggerEvent('TourComplete')
+            set('isCompleteEventTriggered', true)
+        }
+    }, [isTourCompleted, store, triggerEvent])
+
+    return { steps, isTourCompleted, isClosed, onClose, onRestart, onInstall, onSignUp }
+}

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -40,6 +40,7 @@ import { BreadcrumbSetters, BreadcrumbsProps } from '../components/Breadcrumbs'
 import { ErrorBoundary } from '../components/ErrorBoundary'
 import { HeroPage } from '../components/HeroPage'
 import { ActionItemsBarProps, useWebActionItems } from '../extensions/components/ActionItemsBar'
+import { FeatureFlagProps } from '../featureFlags/featureFlags'
 import { ExternalLinkFields, RepositoryFields } from '../graphql-operations'
 import { CodeInsightsProps } from '../insights/types'
 import { IS_CHROME } from '../marketing/util'
@@ -85,7 +86,8 @@ export interface RepoContainerContext
         Pick<StreamingSearchResultsListProps, 'fetchHighlightedFileLineRanges'>,
         CodeIntelligenceProps,
         BatchChangesProps,
-        CodeInsightsProps {
+        CodeInsightsProps,
+        FeatureFlagProps {
     repo: RepositoryFields
     authenticatedUser: AuthenticatedUser | null
     repoSettingsAreaRoutes: readonly RepoSettingsAreaRoute[]
@@ -127,7 +129,8 @@ interface RepoContainerProps
         Pick<StreamingSearchResultsListProps, 'fetchHighlightedFileLineRanges'>,
         CodeIntelligenceProps,
         BatchChangesProps,
-        CodeInsightsProps {
+        CodeInsightsProps,
+        FeatureFlagProps {
     repoContainerRoutes: readonly RepoContainerRoute[]
     repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[]
     repoHeaderActionButtons: readonly RepoHeaderActionButton[]

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -27,6 +27,7 @@ import { ErrorMessage } from '../components/alerts'
 import { BreadcrumbSetters } from '../components/Breadcrumbs'
 import { HeroPage } from '../components/HeroPage'
 import { ActionItemsBarProps } from '../extensions/components/ActionItemsBar'
+import { FeatureFlagProps } from '../featureFlags/featureFlags'
 import { RepositoryFields } from '../graphql-operations'
 import { CodeInsightsProps } from '../insights/types'
 import { PatternTypeProps, SearchContextProps, SearchStreamingProps } from '../search'
@@ -65,6 +66,7 @@ export interface RepoRevisionContainerContext
         SearchStreamingProps,
         Pick<StreamingSearchResultsListProps, 'fetchHighlightedFileLineRanges'>,
         BatchChangesProps,
+        FeatureFlagProps,
         CodeInsightsProps {
     repo: RepositoryFields
     resolvedRev: ResolvedRevision

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -66,8 +66,8 @@ export interface RepoRevisionContainerContext
         SearchStreamingProps,
         Pick<StreamingSearchResultsListProps, 'fetchHighlightedFileLineRanges'>,
         BatchChangesProps,
-        FeatureFlagProps,
-        CodeInsightsProps {
+        CodeInsightsProps,
+        FeatureFlagProps {
     repo: RepositoryFields
     resolvedRev: ResolvedRevision
 
@@ -99,6 +99,7 @@ interface RepoRevisionContainerProps
         RevisionSpec,
         BreadcrumbSetters,
         ActionItemsBarProps,
+        FeatureFlagProps,
         SearchStreamingProps,
         Pick<StreamingSearchResultsListProps, 'fetchHighlightedFileLineRanges'>,
         CodeIntelligenceProps,

--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -16,6 +16,7 @@ import { useLocalStorage } from '@sourcegraph/shared/src/util/useLocalStorage'
 import { useMatchMedia } from '@sourcegraph/shared/src/util/useMatchMedia'
 
 import settingsSchemaJSON from '../../../../schema/settings.schema.json'
+import { OnboardingTour } from '../onboarding-tour/OnboardingTour'
 import { Tree } from '../tree/Tree'
 
 import styles from './RepoRevisionSidebar.module.scss'
@@ -28,6 +29,7 @@ interface Props extends AbsoluteRepoFile, ExtensionsControllerProps, ThemeProps,
     className: string
     history: H.History
     location: H.Location
+    showOnboardingTour?: boolean
 }
 
 const SIZE_STORAGE_KEY = 'repo-revision-sidebar'
@@ -84,9 +86,12 @@ export const RepoRevisionSidebar: React.FunctionComponent<Props> = props => {
             handlePosition="right"
             storageKey={SIZE_STORAGE_KEY}
             element={
-                <div className="d-flex w-100">
+                <div className="d-flex flex-column w-100">
+                    {props.showOnboardingTour && (
+                        <OnboardingTour className="mb-1 mr-3" telemetryService={props.telemetryService} />
+                    )}
                     <Tabs
-                        className="w-100 test-repo-revision-sidebar pr-3"
+                        className="w-100 h-100 test-repo-revision-sidebar pr-3"
                         defaultIndex={tabIndex}
                         onChange={handleTabsChange}
                     >

--- a/client/web/src/repo/routes.tsx
+++ b/client/web/src/repo/routes.tsx
@@ -12,6 +12,7 @@ import {
 
 import { ErrorBoundary } from '../components/ErrorBoundary'
 import { ActionItemsBar } from '../extensions/components/ActionItemsBar'
+import { FeatureFlagProps } from '../featureFlags/featureFlags'
 import { Settings } from '../schema/settings.schema'
 import { lazyComponent } from '../util/lazyComponent'
 import { formatHash, formatLineOrPositionOrRange } from '../util/url'
@@ -130,8 +131,10 @@ export const repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[] 
             patternType,
             setPatternType,
             globbing,
+            featureFlags,
             ...context
-        }: RepoRevisionContainerContext &
+        }: FeatureFlagProps &
+            RepoRevisionContainerContext &
             RouteComponentProps<{
                 objectType: 'blob' | 'tree' | undefined
                 filePath: string | undefined
@@ -149,6 +152,9 @@ export const repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[] 
             const objectType: 'blob' | 'tree' = match.params.objectType || 'tree'
 
             const mode = getModeFromPath(filePath)
+
+            const showOnboardingTour =
+                context.isSourcegraphDotCom && !context.authenticatedUser && featureFlags.get('getting-started-tour')
 
             // Redirect OpenGrok-style line number hashes (#123, #123-321) to query parameter (?L123, ?L123-321)
             const hashLineNumberMatch = window.location.hash.match(/^#?(\d+)(-\d+)?$/)
@@ -196,11 +202,13 @@ export const repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[] 
                         className="repo-revision-container__sidebar"
                         isDir={objectType === 'tree'}
                         defaultBranch={defaultBranch || 'HEAD'}
+                        showOnboardingTour={showOnboardingTour}
                     />
                     {!hideRepoRevisionContent && (
                         // Add `.blob-status-bar__container` because this is the
                         // lowest common ancestor of Blob and the absolutely-positioned Blob status bar
                         <BlobStatusBarContainer>
+                            {showOnboardingTour && <div className="onboarding-tour-info-marker mr-3 mb-3" />}
                             <ErrorBoundary location={context.location}>
                                 {objectType === 'blob' ? (
                                     <BlobPage

--- a/client/web/src/search/documentation/ModalVideo.module.scss
+++ b/client/web/src/search/documentation/ModalVideo.module.scss
@@ -4,9 +4,14 @@
     &:hover button {
         text-decoration: underline;
     }
+
+    figure {
+        margin: 0;
+    }
 }
 
 .thumbnail-button {
+    width: 100%;
     position: relative;
     border: 1px solid var(--border-color);
     border-radius: var(--border-radius);
@@ -15,7 +20,7 @@
 }
 
 .thumbnail-image {
-    width: 11rem;
+    width: 100%;
     // Note: This is to reduce cumulative layout shift
     // It should be as close as possible to the source image aspect ratio
     aspect-ratio: 176/115;

--- a/client/web/src/search/documentation/ModalVideo.tsx
+++ b/client/web/src/search/documentation/ModalVideo.tsx
@@ -50,7 +50,11 @@ export const ModalVideo: React.FunctionComponent<ModalVideoProps> = ({
             <figure>
                 {thumbnailElement}
                 <figcaption>
-                    <button type="button" className="btn btn-link" onClick={() => toggleDialog(true)}>
+                    <button
+                        type="button"
+                        className="btn btn-link font-weight-normal p-0 pt-2 w-100"
+                        onClick={() => toggleDialog(true)}
+                    >
                         {title}
                     </button>
                 </figcaption>

--- a/client/web/src/search/home/LoggedOutHomepage.constants.ts
+++ b/client/web/src/search/home/LoggedOutHomepage.constants.ts
@@ -52,6 +52,39 @@ export const exampleNotebooks: SearchExample[] = [
     },
 ]
 
+export const exampleTripsAndTricks: SearchExample[] = [
+    {
+        label: 'Negation:',
+        trackEventName: 'HomepageExampleNegationClicked',
+        query: '-file:tests',
+        to: '/search?q=context:global+r:tests+-file:tests+-file:%28%5E%7C/%29vendor/+auth%28&patternType=literal',
+    },
+    {
+        label: 'Paths:',
+        trackEventName: 'HomepageExamplePathsClicked',
+        query: 'file:web/ui/',
+        to: '/search?q=context:global+r:mono/mono+file:web/ui/+transform+type:symbol&patternType=literal',
+    },
+    {
+        label: 'Search an org’s code:',
+        trackEventName: 'HomepageExampleOrgsClicked',
+        query: 'repo:sourcegraph/.*',
+        to: '/search?q=context:global+repo:sourcegraph/.*&patternType=literal',
+    },
+    {
+        label: 'Operators:',
+        trackEventName: 'HomepageExampleOperatorsClicked',
+        query: '(lang:Typescript or lang:javascript)',
+        to: '/search?q=context:global+%28lang:Typescript+or+lang:javascript%29&patternType=literal',
+    },
+    {
+        label: 'Escaping: ',
+        trackEventName: 'HomepageExampleEscapingClicked',
+        query: 'content:" with spaces"',
+        to: '/search?q=context:global+content:"+with+spaces"&patternType=literal',
+    },
+]
+
 /**
  * Source Sans Pro fonts: https://fonts.google.com/specimen/Source+Sans+Pro
  * Two families required for the `LoggedOutHomepage` UI: Regular 400 and Bold 700.

--- a/client/web/src/search/home/LoggedOutHomepage.module.scss
+++ b/client/web/src/search/home/LoggedOutHomepage.module.scss
@@ -117,6 +117,8 @@
 .thumbnail {
     width: 11rem;
     @media (--sm-breakpoint-down) {
+        margin-right: auto;
+        margin-left: auto;
         margin-top: 3.5rem;
         text-align: center;
     }

--- a/client/web/src/search/home/LoggedOutHomepage.module.scss
+++ b/client/web/src/search/home/LoggedOutHomepage.module.scss
@@ -115,6 +115,7 @@
 }
 
 .thumbnail {
+    width: 11rem;
     @media (--sm-breakpoint-down) {
         margin-top: 3.5rem;
         text-align: center;
@@ -182,4 +183,85 @@
 .self-host-section,
 .customer-section {
     margin-top: 4rem;
+}
+
+.content {
+    justify-content: center;
+    display: flex;
+    align-items: stretch;
+    margin: 0 auto;
+    gap: 2rem;
+    @media (--md-breakpoint-down) {
+        flex-wrap: wrap;
+    }
+    @media (--sm-breakpoint-down) {
+        flex-direction: column;
+    }
+}
+
+.video-card {
+    max-width: 15rem;
+    @media (--md-breakpoint-down) {
+        min-width: 100%;
+        order: 3;
+    }
+
+    @media (--sm-breakpoint-down) {
+        order: initial;
+    }
+}
+
+.onboarding-tour {
+    width: 18rem;
+
+    @media (--md-breakpoint-down) {
+        max-width: 50%;
+        flex: 1;
+    }
+
+    @media (--sm-breakpoint-down) {
+        max-width: 100%;
+        width: 100%;
+    }
+}
+
+.tips-and-tricks {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    max-width: 25rem;
+
+    @media (--md-breakpoint-down) {
+        min-width: 50%;
+        max-width: 100%;
+        flex: 1;
+    }
+
+    @media (--sm-breakpoint-down) {
+        max-width: 100%;
+        width: 100%;
+    }
+
+    &-examples {
+        display: flex;
+        flex-wrap: wrap;
+    }
+
+    &-example {
+        display: flex;
+        align-items: center;
+        margin: 0 2rem 0.75rem 0;
+    }
+
+    &-card {
+        margin-left: 0.25rem;
+        font-size: 0.75rem;
+        text-decoration: none !important;
+        padding: 0.25rem 0.75rem;
+        align-self: center;
+    }
+
+    &-more {
+        margin-top: auto;
+    }
 }

--- a/client/web/src/search/results/NoResultsPage.module.scss
+++ b/client/web/src/search/results/NoResultsPage.module.scss
@@ -51,6 +51,10 @@
 }
 
 .video-container {
+    figure {
+        width: 13rem;
+        margin-bottom: 1rem;
+    }
     figcaption {
         text-align: center;
     }
@@ -66,6 +70,7 @@
 
             > .video {
                 padding: 0 1rem;
+                margin: 0 0 1rem;
             }
         }
     }

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -234,6 +234,11 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
 
             <SearchSidebar
                 activation={props.activation}
+                showOnboardingTour={
+                    props.isSourcegraphDotCom &&
+                    !props.authenticatedUser &&
+                    props.featureFlags.get('getting-started-tour')
+                }
                 caseSensitive={caseSensitive}
                 patternType={props.patternType}
                 settingsCascade={props.settingsCascade}

--- a/client/web/src/search/results/sidebar/SearchSidebar.tsx
+++ b/client/web/src/search/results/sidebar/SearchSidebar.tsx
@@ -9,6 +9,7 @@ import { Filter } from '@sourcegraph/shared/src/search/stream'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
+import { OnboardingTour } from '../../../onboarding-tour/OnboardingTour'
 import { TemporarySettings } from '../../../settings/temporary/TemporarySettings'
 import { useTemporarySetting } from '../../../settings/temporary/useTemporarySetting'
 import { useNavbarQueryState } from '../../../stores'
@@ -30,6 +31,7 @@ export interface SearchSidebarProps
         TelemetryProps {
     filters?: Filter[]
     className?: string
+    showOnboardingTour?: boolean
 }
 
 export enum SectionID {
@@ -219,5 +221,10 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
         )
     }
 
-    return <div className={classNames(styles.searchSidebar, props.className)}>{body}</div>
+    return (
+        <div className={classNames(styles.searchSidebar, props.className)}>
+            {props.showOnboardingTour && <OnboardingTour className="mb-1" telemetryService={props.telemetryService} />}
+            {body}
+        </div>
+    )
 }

--- a/client/web/src/tracking/analyticsUtils.tsx
+++ b/client/web/src/tracking/analyticsUtils.tsx
@@ -74,12 +74,12 @@ const checkChromeExtensionInstalled = (): Observable<boolean> => {
 }
 
 /**
- * Indicates if the current user has the browser extension installed. It waits 1000ms for the browser
+ * Indicates if the current user has the browser extension installed. It waits 3000ms for the browser
  * extension to inject a DOM marker element, and if it doesn't, emits false
  */
 export const browserExtensionInstalled: Observable<boolean> = concat(
     checkChromeExtensionInstalled().pipe(filter(isInstalled => isInstalled)),
-    observeQuerySelector({ selector: EXTENSION_MARKER_ID, timeout: 1000 }).pipe(
+    observeQuerySelector({ selector: EXTENSION_MARKER_ID, timeout: 3000 }).pipe(
         mapTo(true),
         catchError(() => [false])
     )

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -22,6 +22,7 @@ export class EventLogger implements TelemetryService {
     private lastSourceURL?: string
     private deviceID = ''
     private eventID = 0
+    private listeners: Set<(eventName: string) => void> = new Set()
 
     private readonly cookieSettings: CookieAttributes = {
         // 365 days expiry, but renewed on activity.
@@ -83,6 +84,9 @@ export class EventLogger implements TelemetryService {
      * search queries. The contents of this parameter are sent to our analytics systems.
      */
     public log(eventLabel: string, eventProperties?: any, publicArgument?: any): void {
+        for (const listener of this.listeners) {
+            listener(eventLabel)
+        }
         if (window.context?.userAgentIsBot || !eventLabel) {
             return
         }
@@ -213,6 +217,11 @@ export class EventLogger implements TelemetryService {
         this.anonymousUserID = anonymousUserID
         this.cohortID = cohortID
         this.deviceID = deviceID
+    }
+
+    public addEventLogListener(callback: (eventName: string) => void): () => void {
+        this.listeners.add(callback)
+        return () => this.listeners.delete(callback)
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/27177 and https://github.com/sourcegraph/sourcegraph/issues/29420.

## Description
This PR:
- Adds a new onboarding tour for not signed-in users.
- Adds the ability to force override feature flags through initial URL parameters

## How to test
1. `sg start web-standalone`
2. Open the home page and force enable "getting started" tour: 
   1. `https://sourcegraph.test:3443/search?feature-flag-key=getting-started-tour&feature-flag-value=true`
   2. Go through the new tour widget and check it works properly
3. Open the home page and disable the "getting started" tour:
   1. `https://sourcegraph.test:3443/search?feature-flag-key=getting-started-tour`
   2. Check that onboarding tour doesn't show up and everything works as previously

## Screenshots
<details>

| Before | After |
| --: | :-- |
| ![image](https://user-images.githubusercontent.com/6717049/146940073-aeed41f4-dbfb-4186-a6ee-8f3f3643c477.png) | When tour is OPEN ![image](https://user-images.githubusercontent.com/6717049/146940108-71ae3a8e-dcbb-4729-b037-2f7dcea259fa.png) |
| | When tour is CLOSED ![image](https://user-images.githubusercontent.com/6717049/146940843-e77ce825-3407-4ab0-be0b-7d6c3ebc75f8.png) |
| ![image](https://user-images.githubusercontent.com/6717049/146940623-cb6f6d55-b976-4101-9321-6914a1cc0bce.png) | ![image](https://user-images.githubusercontent.com/6717049/146940605-7b15fffb-4c46-4111-918a-ae0fe6ca5289.png) |
| ![image](https://user-images.githubusercontent.com/6717049/146940735-0eaaecf7-3117-4cf3-b2cc-2db6c1b7af3e.png) | ![image](https://user-images.githubusercontent.com/6717049/146940696-3636c2f6-403b-4ef7-9c0c-ff7ef12b51ef.png) |

</details>

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
