### PR TITLE
search: normalize empty string as HEAD when indexing

### DIFF
--- a/internal/search/backend/index_options.go
+++ b/internal/search/backend/index_options.go
@@ -152,6 +152,10 @@ func getIndexOptions(
 		branches[rev] = struct{}{}
 	}
 
+	// empty string means HEAD which is already in the set. Rather than
+	// sanitize all inputs, just adjust the set before we start resolving.
+	delete(branches, "")
+
 	for branch := range branches {
 		v, err := opts.GetVersion(branch)
 		if err != nil {

--- a/internal/search/backend/index_options_test.go
+++ b/internal/search/backend/index_options_test.go
@@ -129,7 +129,7 @@ func TestGetIndexOptions(t *testing.T) {
 		},
 	}, {
 		name: "conf index branches",
-		conf: withBranches(schema.SiteConfiguration{}, REPO, "a"),
+		conf: withBranches(schema.SiteConfiguration{}, REPO, "a", "", "b"),
 		repo: REPO,
 		want: zoektIndexOptions{
 			RepoID:  1,
@@ -138,6 +138,7 @@ func TestGetIndexOptions(t *testing.T) {
 			Branches: []zoekt.RepositoryBranch{
 				{Name: "HEAD", Version: "!HEAD"},
 				{Name: "a", Version: "!a"},
+				{Name: "b", Version: "!b"},
 			},
 		},
 	}, {


### PR DESCRIPTION
I noticed in some logs that we are indexing in zoekt both HEAD and "",
which resolve to the same commit. This does not cause any issues, it is
just suboptimal. This ensures that we never index "", since we already
always index HEAD.