### PR TITLE
Make root slash in breadcrumbs lead to repo root with respect to revision

### DIFF
--- a/client/shared/src/util/url.test.ts
+++ b/client/shared/src/util/url.test.ts
@@ -14,6 +14,7 @@ import {
     RepoFile,
     encodeURIPathComponent,
     appendLineRangeQueryParameter,
+    toRepoURL,
 } from './url'
 
 /**
@@ -586,5 +587,15 @@ describe('appendLineRangeQueryParameter', () => {
                 'L24:24'
             )
         ).toBe('/github.com/sourcegraph/sourcegraph/-/blob/.gitattributes?L24:24&test=test')
+    })
+})
+
+describe('toRepoURL', () => {
+    it('generates absolute repo URL without a rev', () => {
+        expect(toRepoURL({ repoName: 'sourcegraph/sourcegraph' })).toBe('/sourcegraph/sourcegraph')
+    })
+
+    it('generates absolute repo URL with a rev', () => {
+        expect(toRepoURL({ repoName: 'sourcegraph/sourcegraph', revision: 'main' })).toBe('/sourcegraph/sourcegraph@main')
     })
 })

--- a/client/shared/src/util/url.test.ts
+++ b/client/shared/src/util/url.test.ts
@@ -596,6 +596,8 @@ describe('toRepoURL', () => {
     })
 
     it('generates absolute repo URL with a rev', () => {
-        expect(toRepoURL({ repoName: 'sourcegraph/sourcegraph', revision: 'main' })).toBe('/sourcegraph/sourcegraph@main')
+        expect(toRepoURL({ repoName: 'sourcegraph/sourcegraph', revision: 'main' })).toBe(
+            '/sourcegraph/sourcegraph@main'
+        )
     })
 })

--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -549,9 +549,7 @@ export function toAbsoluteBlobURL(
 }
 
 /**
- * Returns the URL path for the given repository name.
- *
- * @deprecated Obtain the repository's URL from the GraphQL Repository.url field instead.
+ * Returns the URL path for the given repository name and revision.
  */
 export function toRepoURL(target: RepoSpec & Partial<RevisionSpec>): string {
     return '/' + encodeRepoRevision(target)

--- a/client/web/src/repo/FilePathBreadcrumbs.tsx
+++ b/client/web/src/repo/FilePathBreadcrumbs.tsx
@@ -21,7 +21,6 @@ interface Props extends RepoRevision, TelemetryProps {
  */
 export const FilePathBreadcrumbs: React.FunctionComponent<Props> = ({
     repoName,
-    repoUrl,
     revision,
     filePath,
     isDir,

--- a/client/web/src/repo/FilePathBreadcrumbs.tsx
+++ b/client/web/src/repo/FilePathBreadcrumbs.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 
 import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { RepoRevision, toPrettyBlobURL } from '@sourcegraph/shared/src/util/url'
+import { toRepoURL, RepoRevision, toPrettyBlobURL } from '@sourcegraph/shared/src/util/url'
 
 import { toTreeURL } from '../util/url'
 
@@ -44,7 +44,7 @@ export const FilePathBreadcrumbs: React.FunctionComponent<Props> = ({
         <LinkOrSpan
             key="root-dir"
             className={classNames('test-breadcrumb-part-directory', styles.partDirectory)}
-            to={repoUrl}
+            to={toRepoURL({ repoName, revision })}
             aria-current={false}
             onClick={() => telemetryService.log('RootBreadcrumbClicked', { action: 'click', label: 'root directory' })}
         >


### PR DESCRIPTION
## Problem

Root slash link in the breadcrumbs was missing revision part of the URL (https://github.com/sourcegraph/sourcegraph/issues/26068).

## Solution

Output right URL by using `toRepoURL` helper, which accepts revision. For some reason, this function was "deprecated" a long ago in favor of `Repository.url`, which doesn't contain revision component. So I un-deprecated it.