### PR TITLE
Code Insights: [FE] Load and render insights partially based on their visibility in the viewport

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.tsx
@@ -27,7 +27,7 @@ const INSIGHT_PAGE_CONTEXT = {}
 export const SmartInsightsViewGrid: React.FunctionComponent<SmartInsightsViewGridProps> = memo(props => {
     const { telemetryService, insights } = props
 
-    const [layouts, setLayouts] = useState<Layouts>(insightLayoutGenerator(insights))
+    const [layouts, setLayouts] = useState<Layouts>({})
     const [resizingView, setResizeView] = useState<Layout | null>(null)
 
     useEffect(() => {

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -138,26 +138,28 @@ export const BackendInsightView: React.FunctionComponent<BackendInsightProps> = 
             title={insight.title}
             innerRef={mergedInsightCardReference}
             actions={
-                <>
-                    <DrillDownFiltersAction
-                        isOpen={isFiltersOpen}
-                        popoverTargetRef={insightCardReference}
-                        initialFiltersValue={filters}
-                        originalFiltersValue={originalInsightFilters}
-                        onFilterChange={setFilters}
-                        onFilterSave={handleFilterSave}
-                        onInsightCreate={handleInsightFilterCreation}
-                        onVisibilityChange={setIsFiltersOpen}
-                    />
-                    <InsightContextMenu
-                        insight={insight}
-                        dashboard={dashboard}
-                        menuButtonClassName="ml-1 d-inline-flex"
-                        zeroYAxisMin={zeroYAxisMin}
-                        onToggleZeroYAxisMin={() => setZeroYAxisMin(!zeroYAxisMin)}
-                        onDelete={() => handleDelete(insight)}
-                    />
-                </>
+                isVisible && (
+                    <>
+                        <DrillDownFiltersAction
+                            isOpen={isFiltersOpen}
+                            popoverTargetRef={insightCardReference}
+                            initialFiltersValue={filters}
+                            originalFiltersValue={originalInsightFilters}
+                            onFilterChange={setFilters}
+                            onFilterSave={handleFilterSave}
+                            onInsightCreate={handleInsightFilterCreation}
+                            onVisibilityChange={setIsFiltersOpen}
+                        />
+                        <InsightContextMenu
+                            insight={insight}
+                            dashboard={dashboard}
+                            menuButtonClassName="ml-1 d-inline-flex"
+                            zeroYAxisMin={zeroYAxisMin}
+                            onToggleZeroYAxisMin={() => setZeroYAxisMin(!zeroYAxisMin)}
+                            onDelete={() => handleDelete(insight)}
+                        />
+                    </>
+                )
             }
             className={classNames('be-insight-card', otherProps.className, {
                 [styles.cardWithFilters]: isFiltersOpen,
@@ -194,7 +196,7 @@ export const BackendInsightView: React.FunctionComponent<BackendInsightProps> = 
             {
                 // Passing children props explicitly to render any top-level content like
                 // resize-handler from the react-grid-layout library
-                otherProps.children
+                isVisible && otherProps.children
             }
         </View.Root>
     )

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -15,9 +15,9 @@ import { BackendInsight, InsightTypePrefix } from '../../../../core/types'
 import { SearchBasedBackendFilters } from '../../../../core/types/insight/search-insight'
 import { useDeleteInsight } from '../../../../hooks/use-delete-insight'
 import { useDistinctValue } from '../../../../hooks/use-distinct-value'
-import { useParallelRequests } from '../../../../hooks/use-parallel-requests/use-parallel-request'
 import { DashboardInsightsContext } from '../../../../pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsightsContext'
 import { FORM_ERROR, SubmissionErrors } from '../../../form/hooks/useForm'
+import { useInsightData } from '../../hooks/use-insight-data'
 import { InsightContextMenu } from '../insight-context-menu/InsightContextMenu'
 
 import { BackendAlertOverlay } from './BackendAlertOverlay'
@@ -67,7 +67,7 @@ export const BackendInsightView: React.FunctionComponent<BackendInsightProps> = 
     const debouncedFilters = useDebounce(useDistinctValue<SearchBasedBackendFilters>(filters), 500)
 
     // Loading the insight backend data
-    const { data, loading, error } = useParallelRequests(
+    const { data, loading, error, isVisible } = useInsightData(
         useCallback(
             () =>
                 getBackendInsightData({
@@ -75,7 +75,8 @@ export const BackendInsightView: React.FunctionComponent<BackendInsightProps> = 
                     filters: debouncedFilters,
                 }),
             [cachedInsight, debouncedFilters, getBackendInsightData]
-        )
+        ),
+        insightCardReference
     )
 
     // Handle insight delete action
@@ -164,7 +165,7 @@ export const BackendInsightView: React.FunctionComponent<BackendInsightProps> = 
         >
             {resizing ? (
                 <View.Banner>Resizing</View.Banner>
-            ) : loading || isDeleting ? (
+            ) : loading || isDeleting || !isVisible ? (
                 <View.LoadingContent text={isDeleting ? 'Deleting code insight' : 'Loading code insight'} />
             ) : isErrorLike(error) ? (
                 <View.ErrorContent error={error} title={insight.id}>

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/built-in-insight/BuiltInInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/built-in-insight/BuiltInInsight.tsx
@@ -65,14 +65,16 @@ export function BuiltInInsight<D extends keyof ViewContexts>(props: BuiltInInsig
             title={insight.title}
             className={classNames('extension-insight-card', otherProps.className)}
             actions={
-                <InsightContextMenu
-                    insight={insight}
-                    dashboard={dashboard}
-                    menuButtonClassName="ml-1 d-inline-flex"
-                    zeroYAxisMin={zeroYAxisMin}
-                    onToggleZeroYAxisMin={() => setZeroYAxisMin(!zeroYAxisMin)}
-                    onDelete={() => handleDelete(insight)}
-                />
+                isVisible && (
+                    <InsightContextMenu
+                        insight={insight}
+                        dashboard={dashboard}
+                        menuButtonClassName="ml-1 d-inline-flex"
+                        zeroYAxisMin={zeroYAxisMin}
+                        onToggleZeroYAxisMin={() => setZeroYAxisMin(!zeroYAxisMin)}
+                        onDelete={() => handleDelete(insight)}
+                    />
+                )
             }
         >
             {resizing ? (
@@ -96,7 +98,7 @@ export function BuiltInInsight<D extends keyof ViewContexts>(props: BuiltInInsig
             {
                 // Passing children props explicitly to render any top-level content like
                 // resize-handler from the react-grid-layout library
-                otherProps.children
+                isVisible && otherProps.children
             }
         </View.Root>
     )

--- a/client/web/src/enterprise/insights/components/insights-view-grid/hooks/use-insight-data.ts
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/hooks/use-insight-data.ts
@@ -13,6 +13,14 @@ export interface UseInsightDataResult<T> {
     query: (request: () => ObservableInput<T>) => void
 }
 
+/**
+ * This hook runs consumer request function in parallel with other requests that have
+ * been made by useInsightData hook if and only if the element {@link reference} prop
+ * is visible on the screen.
+ *
+ * @param request - consumer's request to run
+ * @param reference - consumer's element that should be visible to run consumer's request
+ */
 export function useInsightData<D>(
     request: () => ObservableInput<D>,
     reference: React.RefObject<HTMLElement>

--- a/client/web/src/enterprise/insights/components/insights-view-grid/hooks/use-insight-data.ts
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/hooks/use-insight-data.ts
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react'
+import { ObservableInput } from 'rxjs'
+
+import { ErrorLike } from '@sourcegraph/shared/src/util/errors'
+
+import { useLazyParallelRequest } from '../../../hooks/use-parallel-requests/use-parallel-request'
+
+export interface UseInsightDataResult<T> {
+    data: T | undefined
+    error: ErrorLike | undefined
+    loading: boolean
+    isVisible: boolean
+    query: (request: () => ObservableInput<T>) => void
+}
+
+export function useInsightData<D>(
+    request: () => ObservableInput<D>,
+    reference: React.RefObject<HTMLElement>
+): UseInsightDataResult<D> {
+    const { data, loading, error, query } = useLazyParallelRequest<D>()
+    const [isVisible, setVisibility] = useState<boolean>(false)
+    const [hasIntersected, setHasIntersected] = useState<boolean>(false)
+
+    useEffect(() => {
+        if (hasIntersected) {
+            // eslint-disable-next-line @typescript-eslint/unbound-method
+            const { unsubscribe } = query(request)
+
+            return unsubscribe
+        }
+
+        return
+    }, [hasIntersected, query, request])
+
+    useEffect(() => {
+        const element = reference.current
+
+        if (!element) {
+            return
+        }
+
+        function handleIntersection(entries: IntersectionObserverEntry[]): void {
+            const [entry] = entries
+
+            setVisibility(entry.isIntersecting)
+
+            if (entry.isIntersecting) {
+                setHasIntersected(true)
+            }
+        }
+
+        const observer = new IntersectionObserver(handleIntersection)
+
+        observer.observe(reference.current)
+
+        return () => observer.unobserve(element)
+    }, [reference])
+
+    return { data, loading, error, isVisible, query }
+}

--- a/client/web/src/enterprise/insights/core/backend/setting-based-api/code-insights-setting-cascade-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/setting-based-api/code-insights-setting-cascade-backend.ts
@@ -1,6 +1,6 @@
 import { camelCase } from 'lodash'
 import { Observable, of } from 'rxjs'
-import { map, mapTo, switchMap } from 'rxjs/operators'
+import { delay, map, mapTo, switchMap } from 'rxjs/operators'
 import { LineChartContent, PieChartContent } from 'sourcegraph'
 
 import { ViewContexts } from '@sourcegraph/shared/src/api/extension/extensionHostApi'
@@ -56,6 +56,9 @@ export class CodeInsightsSettingsCascadeBackend implements CodeInsightsBackend {
     // Insights
     public getInsights = (input: { dashboardId: string }): Observable<Insight[]> =>
         this.getDashboardById({ dashboardId: input.dashboardId }).pipe(
+            // Do not return insights immediately because it ruins partial
+            // rendering in the view grid component
+            delay(500),
             switchMap(dashboard => {
                 if (dashboard) {
                     const ids = dashboard.insightIds

--- a/client/web/src/enterprise/insights/core/backend/setting-based-api/code-insights-setting-cascade-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/setting-based-api/code-insights-setting-cascade-backend.ts
@@ -1,6 +1,6 @@
 import { camelCase } from 'lodash'
 import { Observable, of } from 'rxjs'
-import { delay, map, mapTo, switchMap } from 'rxjs/operators'
+import { map, mapTo, switchMap } from 'rxjs/operators'
 import { LineChartContent, PieChartContent } from 'sourcegraph'
 
 import { ViewContexts } from '@sourcegraph/shared/src/api/extension/extensionHostApi'
@@ -56,9 +56,6 @@ export class CodeInsightsSettingsCascadeBackend implements CodeInsightsBackend {
     // Insights
     public getInsights = (input: { dashboardId: string }): Observable<Insight[]> =>
         this.getDashboardById({ dashboardId: input.dashboardId }).pipe(
-            // Do not return insights immediately because it ruins partial
-            // rendering in the view grid component
-            delay(500),
             switchMap(dashboard => {
                 if (dashboard) {
                     const ids = dashboard.insightIds

--- a/client/web/src/enterprise/insights/hooks/use-parallel-requests/use-prallel-requests.test.ts
+++ b/client/web/src/enterprise/insights/hooks/use-parallel-requests/use-prallel-requests.test.ts
@@ -11,7 +11,9 @@ describe('useParallelRequests', () => {
     let useParallelRequests: <D>(request: () => ObservableInput<D>) => FetchResult<D>
 
     beforeEach(() => {
-        useParallelRequests = createUseParallelRequestsHook({ maxRequests: 1 })
+        const { query } = createUseParallelRequestsHook({ maxRequests: 1 })
+
+        useParallelRequests = query
     })
 
     describe('with single request', () => {

--- a/client/web/src/enterprise/insights/sections/ExtensionViewsHomepageSection.tsx
+++ b/client/web/src/enterprise/insights/sections/ExtensionViewsHomepageSection.tsx
@@ -53,6 +53,8 @@ export const ExtensionViewsHomepageSection: React.FunctionComponent<ExtensionVie
     )
 }
 
+const DEFAULT_CONTEXT = {}
+
 const ExtensionViewsHomepageSectionContent: React.FunctionComponent<ExtensionViewsSectionCommonProps> = props => {
     const { extensionsController, telemetryService, className } = props
     const { getInsights } = useContext(CodeInsightsBackendContext)
@@ -89,7 +91,7 @@ const ExtensionViewsHomepageSectionContent: React.FunctionComponent<ExtensionVie
                     insight={insight}
                     telemetryService={telemetryService}
                     where="homepage"
-                    context={{}}
+                    context={DEFAULT_CONTEXT}
                 />
             ))}
         </ViewGrid>


### PR DESCRIPTION
Closes part of https://github.com/sourcegraph/sourcegraph/issues/29024

## Context 

Prior to this PR, we load all insights cards on the dashboard. We do that partially in parallel by 2 but still, we load every chart/card on the page even if they do not fit in the viewport (if they're not visible). 

With these PR changes, we load and render insights only if they are visible and fit in the visible area. It isn't real virtualization because we still render empty cards (this is still needed for react-grid-layout layout processing) but it reduces the amount of network requests dramatically and makes it a little bit easier for the browser to render cards on the page (because cards outside of the viewport do not have heave content with many elements within the card)

Loom video about this change https://www.loom.com/share/13299acd03f244a2b352d5185def0912