### PR TITLE
Update visual details for the creation intro page

### DIFF
--- a/client/web/src/enterprise/insights/modals/components/MediaCharts.tsx
+++ b/client/web/src/enterprise/insights/modals/components/MediaCharts.tsx
@@ -188,6 +188,7 @@ export const SearchBasedInsightChart: React.FunctionComponent<React.SVGProps<SVG
             fill="var(--border-color-2)"
             d="M6 39h137v1H6zM6 16h137v1H6zM6 62h137v1H6zM6 85h137v1H6zM6 108h137v1H6zM170 44.5h15v1h-15z"
         />
+
         <circle cx="165" cy="45" r="2" fill="var(--orange)" />
         <path fill="var(--border-color-2)" d="M170 53.5h15v1h-15z" />
         <circle cx="165" cy="54" r="2" fill="var(--pink)" />
@@ -195,38 +196,42 @@ export const SearchBasedInsightChart: React.FunctionComponent<React.SVGProps<SVG
         <circle cx="165" cy="63" r="2" fill="var(--dark-blue)" />
         <path fill="var(--border-color-2)" d="M170 71.5h15v1h-15z" />
         <circle cx="165" cy="72" r="2" fill="var(--green)" />
-        <circle cx="8" cy="80" r="2" fill="var(--pink)" />
-        <circle cx="30.5" cy="85" r="2" fill="var(--pink)" />
-        <circle cx="51.5" cy="77.5" r="2" fill="var(--pink)" />
-        <circle cx="74.5" cy="93" r="2" fill="var(--pink)" />
-        <circle cx="95.5" cy="93" r="2" fill="var(--pink)" />
-        <circle cx="116" cy="107.2" r="2" fill="var(--pink)" />
-        <circle cx="139.5" cy="107.2" r="2" fill="var(--pink)" />
-        <circle cx="30" cy="32" r="2" fill="var(--dark-blue)" />
-        <circle cx="7" cy="61" r="2" fill="var(--dark-blue)" />
-        <circle cx="7" cy="47" r="2" fill="var(--green)" />
-        <circle cx="32" cy="63" r="2" fill="var(--green)" />
-        <circle cx="52.5" cy="53" r="2" fill="var(--green)" />
-        <circle cx="75.5" cy="52.5" r="2" fill="var(--green)" />
-        <circle cx="97" cy="36.5" r="2" fill="var(--green)" />
-        <circle cx="117.5" cy="22.5" r="2" fill="var(--green)" />
+        <circle cx="8" cy="109" r="2" fill="var(--pink)" />
+        <circle cx="30" cy="109" r="2" fill="var(--pink)" />
+        <circle cx="52" cy="109" r="2" fill="var(--pink)" />
+        <circle cx="74" cy="103.5" r="2" fill="var(--pink)" />
+        <circle cx="95.5" cy="99" r="2" fill="var(--pink)" />
+        <circle cx="118" cy="92" r="2" fill="var(--pink)" />
+        <circle cx="141.5" cy="100" r="2" fill="var(--pink)" />
+        <circle cx="30" cy="30" r="2" fill="var(--dark-blue)" />
+        <circle cx="8" cy="17" r="2" fill="var(--dark-blue)" />
+        <circle cx="8" cy="79" r="2" fill="var(--green)" />
+        <circle cx="30" cy="67" r="2" fill="var(--green)" />
+        <circle cx="52" cy="52.5" r="2" fill="var(--green)" />
+        <circle cx="74" cy="52.5" r="2" fill="var(--green)" />
+        <circle cx="96" cy="36.5" r="2" fill="var(--green)" />
+        <circle cx="118" cy="22.5" r="2" fill="var(--green)" />
         <circle cx="141" cy="22.5" r="2" fill="var(--green)" />
-        <path d="m6.5 62.5 23-31h22l22.316-12.735h21.517L118 33.5h22.5" stroke="var(--dark-blue)" strokeWidth="1.5" />
-        <path d="m7 79.5 23.212 6L51 77.5 74 93h21.577L116 107h23.5" stroke="var(--pink)" strokeWidth="1.5" />
-        <path d="m8 47.5 24.212 15L52 53.5l23-.5 21.577-16L117 23h23.5" stroke="var(--green)" strokeWidth="1.5" />
-        <path d="m8 104 21 .5 22.667-16 22.15-8H92l24.5-21 25-10" stroke="var(--orange)" strokeWidth="1.5" />
-        <circle cx="8.5" cy="103.5" r="2" fill="var(--orange)" />
-        <circle cx="29.5" cy="104" r="2" fill="var(--orange)" />
-        <circle cx="52" cy="88" r="2" fill="var(--orange)" />
-        <circle cx="74" cy="81" r="2" fill="var(--orange)" />
-        <circle cx="92.5" cy="80.5" r="2" fill="var(--orange)" />
-        <circle cx="117" cy="59.5" r="2" fill="var(--orange)" />
-        <circle cx="141" cy="49.5" r="2" fill="var(--orange)" />
-        <circle cx="118.5" cy="33.5" r="2" fill="var(--dark-blue)" />
-        <circle cx="141" cy="33.5" r="2" fill="var(--dark-blue)" />
-        <circle cx="96" cy="19" r="2" fill="var(--dark-blue)" />
-        <circle cx="74" cy="19" r="2" fill="var(--dark-blue)" />
-        <circle cx="51.5" cy="31" r="2" fill="var(--dark-blue)" />
+        <path
+            d="m8 17 21.5 12.5 22 7 22.316 53 21.517-72.735L118 31.5h22.5"
+            stroke="var(--dark-blue)"
+            strokeWidth="1.5"
+        />
+        <path d="M6.5 109H52l22-5.5 20.5-4L118 92l23 7.5" stroke="var(--pink)" strokeWidth="1.5" />
+        <path d="m7 79.5 23.212-12L52 53h22l22-16.5 22-14h22" stroke="var(--green)" strokeWidth="1.5" />
+        <path d="m8 100 21-5 22.667-8.5 22.15-22L96 81.5l21.5-8 24-24" stroke="var(--orange)" strokeWidth="1.5" />
+        <circle cx="8" cy="100" r="2" fill="var(--orange)" />
+        <circle cx="29.5" cy="95" r="2" fill="var(--orange)" />
+        <circle cx="52" cy="86" r="2" fill="var(--orange)" />
+        <circle cx="74" cy="65" r="2" fill="var(--orange)" />
+        <circle cx="96" cy="81.5" r="2" fill="var(--orange)" />
+        <circle cx="118" cy="73.5" r="2" fill="var(--orange)" />
+        <circle cx="141" cy="50" r="2" fill="var(--orange)" />
+        <circle cx="118" cy="32" r="2" fill="var(--dark-blue)" />
+        <circle cx="141" cy="32" r="2" fill="var(--dark-blue)" />
+        <circle cx="96" cy="17" r="2" fill="var(--dark-blue)" />
+        <circle cx="74" cy="90" r="2" fill="var(--dark-blue)" />
+        <circle cx="52" cy="37.5" r="2" fill="var(--dark-blue)" />
     </svg>
 )
 
@@ -234,9 +239,9 @@ export const CaptureGroupInsightChart: React.FunctionComponent<React.SVGProps<SV
     <svg
         width="185"
         height="126"
-        viewBox="0 0 185 126"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 185 126"
         {...props}
         className={classNames(styles.chart, props.className)}
     >
@@ -244,44 +249,47 @@ export const CaptureGroupInsightChart: React.FunctionComponent<React.SVGProps<SV
             fill="var(--border-color-2)"
             d="M6 39h137v1H6zM6 16h137v1H6zM6 62h137v1H6zM6 85h137v1H6zM6 108h137v1H6zM170 44.5h15v1h-15z"
         />
-        <rect x="170" y="44.5" width="15" height="1" />
         <circle cx="165" cy="45" r="2" fill="var(--orange)" />
-        <rect x="170" y="53.5" width="15" height="1" />
+        <path fill="var(--border-color-2)" d="M170 53.5h15v1h-15z" />
         <circle cx="165" cy="54" r="2" fill="var(--pink)" />
-        <rect x="170" y="62.5" width="15" height="1" />
+        <path fill="var(--border-color-2)" d="M170 62.5h15v1h-15z" />
         <circle cx="165" cy="63" r="2" fill="var(--dark-blue)" />
-        <rect x="170" y="71.5" width="15" height="1" />
+        <path fill="var(--border-color-2)" d="M170 71.5h15v1h-15z" />
         <circle cx="165" cy="72" r="2" fill="var(--green)" />
-        <circle cx="8" cy="19.5" r="2" fill="var(--pink)" />
-        <circle cx="30.5" cy="19.5" r="2" fill="var(--pink)" />
-        <circle cx="51.5" cy="34" r="2" fill="var(--pink)" />
-        <circle cx="74.5" cy="34" r="2" fill="var(--pink)" />
-        <circle cx="95.5" cy="45" r="2" fill="var(--pink)" />
-        <circle cx="118" cy="45.2" r="2" fill="var(--pink)" />
-        <circle cx="141" cy="66.2" r="2" fill="var(--pink)" />
-        <circle cx="30" cy="86" r="2" fill="var(--dark-blue)" />
-        <circle cx="75.5" cy="99" r="2" fill="var(--green)" />
-        <circle cx="97" cy="99" r="2" fill="var(--green)" />
-        <circle cx="117.5" cy="86" r="2" fill="var(--green)" />
-        <circle cx="141" cy="86" r="2" fill="var(--green)" />
-        <path d="M29.5 85.5H51.5L73.8164 64.7647H95.3333L118 23.5H140.5" stroke="var(--dark-blue)" strokeWidth="1.5" />
-        <path d="M7 19.5H30.2115L51 34H74L95.5769 45H118L140.5 66" stroke="var(--pink)" strokeWidth="1.5" />
-        <path d="M75 99H96.5769L117 86H140.5" stroke="var(--green)" strokeWidth="1.5" />
-        <path d="M7 43H30L51.6667 72.5H73.8164L92 91.5H116.5L141.5 104.5" stroke="var(--orange)" strokeWidth="1.5" />
-        <circle cx="8" cy="43" r="2" fill="var(--orange)" />
-        <circle cx="29.5" cy="43" r="2" fill="var(--orange)" />
-        <circle cx="52" cy="72" r="2" fill="var(--orange)" />
-        <circle cx="74" cy="72.5" r="2" fill="var(--orange)" />
-        <circle cx="92" cy="91.5" r="2" fill="var(--orange)" />
-        <circle cx="117" cy="92" r="2" fill="var(--orange)" />
-        <circle cx="141" cy="104" r="2" fill="var(--orange)" />
-        <circle cx="118.5" cy="23.5" r="2" fill="var(--dark-blue)" />
-        <circle cx="141" cy="23.5" r="2" fill="var(--dark-blue)" />
-        <circle cx="96" cy="64.5" r="2" fill="var(--dark-blue)" />
-        <circle cx="74" cy="65.5" r="2" fill="var(--dark-blue)" />
-        <circle cx="51.5" cy="85.5" r="2" fill="var(--dark-blue)" />
+        <circle cx="8" cy="57.5" r="2" fill="var(--pink)" />
+        <circle cx="30" cy="57.5" r="2" fill="var(--pink)" />
+        <circle cx="52" cy="39" r="2" fill="var(--pink)" />
+        <circle cx="74" cy="39" r="2" fill="var(--pink)" />
+        <circle cx="96" cy="39" r="2" fill="var(--pink)" />
+        <circle cx="118" cy="16.2" r="2" fill="var(--pink)" />
+        <circle cx="141" cy="16.2" r="2" fill="var(--pink)" />
+        <circle cx="30" cy="85.5" r="2" fill="var(--dark-blue)" />
+        <circle cx="8" cy="85.5" r="2" fill="var(--dark-blue)" />
+        <circle cx="8" cy="108.5" r="2" fill="var(--green)" />
+        <circle cx="30" cy="108.5" r="2" fill="var(--green)" />
+        <circle cx="52" cy="108.5" r="2" fill="var(--green)" />
+        <circle cx="74" cy="108.5" r="2" fill="var(--green)" />
+        <circle cx="96" cy="108.5" r="2" fill="var(--green)" />
+        <circle cx="118" cy="85" r="2" fill="var(--green)" />
+        <circle cx="141" cy="85" r="2" fill="var(--green)" />
+        <path d="M8 85.5h44.5l21.316-14.735h22.517L118 39.5h22.5" stroke="var(--dark-blue)" strokeWidth="1.5" />
+        <path d="M7 57.5h23.212L52 39h43.577L118 16h21.5" stroke="var(--pink)" strokeWidth="1.5" />
+        <path d="M8 108.5h87.577L118 85h22.5" stroke="var(--green)" strokeWidth="1.5" />
+        <path d="M8 39h22l21.667 10.5h22.15L96 59.5h45.5" stroke="var(--orange)" strokeWidth="1.5" />
+        <circle cx="8" cy="39" r="2" fill="var(--orange)" />
+        <circle cx="30" cy="39" r="2" fill="var(--orange)" />
+        <circle cx="52" cy="49.5" r="2" fill="var(--orange)" />
+        <circle cx="74" cy="49.5" r="2" fill="var(--orange)" />
+        <circle cx="96" cy="59.5" r="2" fill="var(--orange)" />
+        <circle cx="118" cy="59.5" r="2" fill="var(--orange)" />
+        <circle cx="141" cy="59.5" r="2" fill="var(--orange)" />
+        <circle cx="141" cy="39.5" r="2" fill="var(--dark-blue)" />
+        <circle cx="118" cy="40" r="2" fill="var(--dark-blue)" />
+        <circle cx="96" cy="71" r="2" fill="var(--dark-blue)" />
+        <circle cx="74" cy="71" r="2" fill="var(--dark-blue)" />
+        <circle cx="52" cy="85.5" r="2" fill="var(--dark-blue)" />
         <path
-            d="M177.882 104.625a5.261 5.261 0 0 1-.807.065c-.275 0-.541-.024-.808-.065v-2.834l-2.018 2.003a6.703 6.703 0 0 1-1.123-1.123l2.003-2.018h-2.834a5.284 5.284 0 0 1-.065-.808c0-.275.024-.541.065-.808h2.834l-2.003-2.018c.154-.202.315-.404.525-.598.194-.21.396-.371.598-.525l2.018 2.003v-2.834c.267-.04.533-.065.808-.065s.541.024.807.065v2.834l2.019-2.003c.404.315.808.719 1.123 1.123l-2.003 2.018h2.834c.041.267.065.533.065.808s-.024.541-.065.808h-2.834l2.003 2.018a4.462 4.462 0 0 1-.525.598c-.194.21-.396.371-.598.525l-2.019-2.003v2.834Zm-8.882 1.68a1.615 1.615 0 1 1 3.23 0 1.615 1.615 0 0 1-3.23 0Z"
+            d="M176.882 105.625a5.261 5.261 0 0 1-.807.065c-.275 0-.541-.024-.808-.065v-2.834l-2.018 2.003a6.703 6.703 0 0 1-1.123-1.123l2.003-2.018h-2.834a5.284 5.284 0 0 1-.065-.808c0-.275.024-.541.065-.808h2.834l-2.003-2.018c.154-.202.315-.404.525-.598.194-.21.396-.371.598-.525l2.018 2.003v-2.834c.267-.04.533-.065.808-.065s.541.024.807.065v2.834l2.019-2.003c.404.315.808.719 1.123 1.123l-2.003 2.018h2.834c.041.267.065.533.065.808s-.024.541-.065.808h-2.834l2.003 2.018a4.462 4.462 0 0 1-.525.598c-.194.21-.396.371-.598.525l-2.019-2.003v2.834Zm-8.882 1.68a1.615 1.615 0 1 1 3.23 0 1.615 1.615 0 0 1-3.23 0Z"
             fill="#A6B6D9"
         />
     </svg>

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.module.scss
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.module.scss
@@ -1,6 +1,5 @@
 .container {
     height: min-content;
-    max-width: 62.5rem;
 }
 
 .header {
@@ -9,7 +8,7 @@
 
 .section-content {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(22.75rem, 1fr));
     row-gap: 0.5rem;
     column-gap: 0.5rem;
 }
@@ -17,5 +16,5 @@
 .info {
     grid-column: 1 / -1;
     margin-top: 1rem;
-    margin-bottom: 2.5rem;
+    margin-bottom: 2rem;
 }

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.module.scss
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.module.scss
@@ -1,5 +1,6 @@
 .container {
     height: min-content;
+    max-width: 62.5rem;
 }
 
 .header {
@@ -11,8 +12,10 @@
     grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
     row-gap: 0.5rem;
     column-gap: 0.5rem;
+}
 
-    &--extension {
-        grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
-    }
+.info {
+    grid-column: 1 / -1;
+    margin-top: 1rem;
+    margin-bottom: 2.5rem;
 }

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.module.scss
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.module.scss
@@ -8,7 +8,11 @@
 
 .section-content {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(17rem, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
     row-gap: 0.5rem;
     column-gap: 0.5rem;
+
+    &--extension {
+        grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
+    }
 }

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
@@ -65,7 +65,7 @@ export const IntroCreationPage: React.FunctionComponent<IntroCreationPageProps> 
                     <>
                         Insights analyze your code based on any search query.{' '}
                         <a href="https://docs.sourcegraph.com/code_insights" target="_blank" rel="noopener">
-                            Learn more.
+                            Learn more
                         </a>
                     </>
                 }
@@ -94,7 +94,7 @@ export const IntroCreationPage: React.FunctionComponent<IntroCreationPageProps> 
                         target="_blank"
                         rel="noopener"
                     >
-                        use cases
+                        use cases.
                     </a>
                 </div>
 

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
@@ -86,20 +86,18 @@ export const IntroCreationPage: React.FunctionComponent<IntroCreationPageProps> 
                     data-testid="create-lang-usage-insight"
                     onClick={handleCreateCodeStatsInsightClick}
                 />
-            </div>
 
-            <footer className="mt-3">
-                Not sure which insight type to choose? Learn more about the{' '}
-                <a
-                    href="https://docs.sourcegraph.com/code_insights/references/common_use_cases"
-                    target="_blank"
-                    rel="noopener"
-                >
-                    use cases
-                </a>
-            </footer>
+                <div className={styles.info}>
+                    Not sure which insight type to choose? Learn more about the{' '}
+                    <a
+                        href="https://docs.sourcegraph.com/code_insights/references/common_use_cases"
+                        target="_blank"
+                        rel="noopener"
+                    >
+                        use cases
+                    </a>
+                </div>
 
-            <div className={classNames(styles.sectionContent, styles.sectionContentExtension, 'mt-5')}>
                 <ExtensionInsightsCard data-testid="explore-extensions" onClick={handleExploreExtensionsClick} />
             </div>
         </Page>

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
@@ -86,8 +86,6 @@ export const IntroCreationPage: React.FunctionComponent<IntroCreationPageProps> 
                     data-testid="create-lang-usage-insight"
                     onClick={handleCreateCodeStatsInsightClick}
                 />
-
-                <ExtensionInsightsCard data-testid="explore-extensions" onClick={handleExploreExtensionsClick} />
             </div>
 
             <footer className="mt-3">
@@ -100,6 +98,10 @@ export const IntroCreationPage: React.FunctionComponent<IntroCreationPageProps> 
                     use cases
                 </a>
             </footer>
+
+            <div className={classNames(styles.sectionContent, styles.sectionContentExtension, 'mt-5')}>
+                <ExtensionInsightsCard data-testid="explore-extensions" onClick={handleExploreExtensionsClick} />
+            </div>
         </Page>
     )
 }

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.module.scss
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.module.scss
@@ -3,7 +3,7 @@
     display: flex;
     flex-direction: column;
     box-shadow: var(--box-shadow);
-    font-size: 0.75rem;
+    font-size: 0.875rem;
     text-align: start;
 
     &:hover {
@@ -39,6 +39,10 @@
     }
 }
 
+.card-title {
+    color: var(--body-color);
+}
+
 // chart specific styles
 .chart {
     overflow: hidden;
@@ -60,5 +64,5 @@
 
 .image {
     object-fit: contain;
-    width: 3rem;
+    width: 1.75rem;
 }

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.module.scss
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.module.scss
@@ -2,13 +2,17 @@
 .card {
     display: flex;
     flex-direction: column;
-    box-shadow: var(--box-shadow);
+    box-shadow: 0 0 8px -6px rgba(36, 41, 54, 0.08);
     font-size: 0.875rem;
     text-align: start;
 
-    &:hover,
+    &:hover {
+        box-shadow: var(--dropdown-shadow);
+        border: 1px solid var(--border-color-2);
+    }
+
     &:focus {
-        box-shadow: 0 0 0 0.1875rem var(--primary);
+        box-shadow: var(--focus-box-shadow);
         outline: none;
     }
 
@@ -21,7 +25,7 @@
     display: flex;
     flex-direction: column;
     background-color: transparent;
-    margin-top: 1rem;
+    margin-top: 1.5rem;
     padding: 0;
 
     b {
@@ -38,6 +42,7 @@
 
 .card-title {
     color: var(--body-color);
+    margin-bottom: 0.5rem;
 }
 
 .card-footer {
@@ -57,6 +62,10 @@
     width: 100%;
     object-fit: contain;
     background-color: var(--body-bg);
+
+    :global(.theme-dark) & {
+        background-color: transparent;
+    }
 }
 
 .images {

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.module.scss
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.module.scss
@@ -45,6 +45,11 @@
     margin-bottom: 0.5rem;
 }
 
+.card-example-block {
+    margin-top: 0.5rem;
+    color: var(--body-color);
+}
+
 .card-footer {
     width: 100%;
     display: flex;

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.module.scss
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.module.scss
@@ -6,13 +6,9 @@
     font-size: 0.875rem;
     text-align: start;
 
-    &:hover {
-        background-color: var(--secondary-2);
-    }
-
+    &:hover,
     &:focus {
-        background-color: var(--secondary-2);
-        box-shadow: var(--focus-box-shadow);
+        box-shadow: 0 0 0 0.1875rem var(--primary);
         outline: none;
     }
 
@@ -25,11 +21,12 @@
     display: flex;
     flex-direction: column;
     background-color: transparent;
-    margin-top: 2rem;
+    margin-top: 1rem;
     padding: 0;
 
     b {
         display: contents;
+        font-weight: normal;
 
         // A bootstrap CSS class .card brings custom color styles that we should change
         // for b elements within a card accroding to our designs for this card.
@@ -43,13 +40,23 @@
     color: var(--body-color);
 }
 
+.card-footer {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    padding: 0.5rem;
+    background-color: var(--body-bg);
+    border: 1px solid var(--border-color);
+}
+
 // chart specific styles
 .chart {
     overflow: hidden;
-    height: 10rem;
+    padding: 1rem;
+    height: 10.5rem;
     width: 100%;
     object-fit: contain;
-    background-color: transparent;
+    background-color: var(--body-bg);
 }
 
 .images {

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.tsx
@@ -23,7 +23,7 @@ const Card: React.FunctionComponent<CardProps> = props => {
         <button {...otherProps} type="button" className={classNames(styles.card, 'card p-3', otherProps.className)}>
             {children}
 
-            <div className="btn btn-secondary mt-3 w-100">Create</div>
+            <div className="btn btn-sm btn-secondary mt-3 w-100">Create</div>
         </button>
     )
 }
@@ -38,7 +38,7 @@ const CardBody: React.FunctionComponent<CardBodyProps> = props => {
 
     return (
         <div className={classNames(styles.cardBody, className, 'card-body flex-1')}>
-            <h3 className={classNames(styles.cardTitle, 'mb-3')}>{title}</h3>
+            <h3 className={styles.cardTitle}>{title}</h3>
 
             <p className="d-flex flex-column text-muted m-0">{children}</p>
         </div>
@@ -46,9 +46,9 @@ const CardBody: React.FunctionComponent<CardBodyProps> = props => {
 }
 
 const CardExampleBlock: React.FunctionComponent = props => (
-    <footer className={styles.cardFooter}>
-        <small className="text-muted">Example use</small>
-        <span>{props.children}</span>
+    <footer className={classNames(styles.cardFooter, 'text-muted')}>
+        <small>Example use</small>
+        <small>{props.children}</small>
     </footer>
 )
 

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.tsx
@@ -10,36 +10,34 @@ import {
 
 import styles from './InsightCards.module.scss'
 
-interface CardProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-    footerText?: string
-}
+interface CardProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
 
 /**
  * Low-level styled component for building insight link card for
  * the creation page gallery.
  */
 const Card: React.FunctionComponent<CardProps> = props => {
-    const { children, footerText, ...otherProps } = props
+    const { children, ...otherProps } = props
 
     return (
         <button {...otherProps} type="button" className={classNames(styles.card, 'card p-3', otherProps.className)}>
             {children}
 
-            {footerText && (
-                <footer className="d-flex flex-column mt-3">
-                    <small className="text-muted">Example use</small>
-                    <span>{footerText}</span>
-                </footer>
-            )}
+            <div className="btn btn-secondary mt-3 w-100">Create</div>
         </button>
     )
 }
 
-const CardBody: React.FunctionComponent<{ title: string }> = props => {
-    const { title, children } = props
+interface CardBodyProps {
+    title: string
+    className?: string
+}
+
+const CardBody: React.FunctionComponent<CardBodyProps> = props => {
+    const { title, className, children } = props
 
     return (
-        <div className={classNames(styles.cardBody, 'card-body flex-1')}>
+        <div className={classNames(styles.cardBody, className, 'card-body flex-1')}>
             <h3 className={classNames(styles.cardTitle, 'mb-3')}>{title}</h3>
 
             <p className="d-flex flex-column text-muted m-0">{children}</p>
@@ -47,13 +45,22 @@ const CardBody: React.FunctionComponent<{ title: string }> = props => {
     )
 }
 
+const CardExampleBlock: React.FunctionComponent = props => (
+    <footer className={styles.cardFooter}>
+        <small className="text-muted">Example use</small>
+        <span>{props.children}</span>
+    </footer>
+)
+
 export const SearchInsightCard: React.FunctionComponent<CardProps> = props => (
-    <Card {...props} footerText="Redis, PostgreSQL and SQLite database usage.">
+    <Card {...props}>
         <SearchBasedInsightChart className={styles.chart} />
-        <CardBody title="Track changes">
+        <CardBody title="Track changes" className="mb-3">
             Insight <b>based on a custom Sourcegraph search query</b> that creates visualization of the data series you
             will define <b>manually.</b>
         </CardBody>
+
+        <CardExampleBlock>Redis, PostgreSQL and SQLite database usage.</CardExampleBlock>
     </Card>
 )
 
@@ -67,14 +74,16 @@ export const LangStatsInsightCard: React.FunctionComponent<CardProps> = props =>
 )
 
 export const CaptureGroupInsightCard: React.FunctionComponent<CardProps> = props => (
-    <Card {...props} footerText="Detecting and tracking language or package versions.">
+    <Card {...props}>
         <CaptureGroupInsightChart className={styles.chart} />
 
-        <CardBody title="Detect and track patterns">
+        <CardBody title="Detect and track patterns" className="mb-3">
             Data series will be generated dynamically for each unique value from the
             <b> regular expression capture group </b> included in the search query. Chart will be updated as new values
             appear in the code base.
         </CardBody>
+
+        <CardExampleBlock>Detecting and tracking language or package versions.</CardExampleBlock>
     </Card>
 )
 

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.tsx
@@ -46,9 +46,9 @@ const CardBody: React.FunctionComponent<CardBodyProps> = props => {
 }
 
 const CardExampleBlock: React.FunctionComponent = props => (
-    <footer className={classNames(styles.cardFooter, 'text-muted')}>
-        <small>Example use</small>
-        <small>{props.children}</small>
+    <footer className={styles.cardFooter}>
+        <small className="text-muted">Example use</small>
+        <small className={styles.cardExampleBlock}>{props.children}</small>
     </footer>
 )
 
@@ -60,7 +60,7 @@ export const SearchInsightCard: React.FunctionComponent<CardProps> = props => (
             will define <b>manually.</b>
         </CardBody>
 
-        <CardExampleBlock>Redis, PostgreSQL and SQLite database usage.</CardExampleBlock>
+        <CardExampleBlock>Tracking architecture, naming, or language migrations.</CardExampleBlock>
     </Card>
 )
 

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.tsx
@@ -40,7 +40,7 @@ const CardBody: React.FunctionComponent<{ title: string }> = props => {
 
     return (
         <div className={classNames(styles.cardBody, 'card-body flex-1')}>
-            <h3 className="mb-3">{title}</h3>
+            <h3 className={classNames(styles.cardTitle, 'mb-3')}>{title}</h3>
 
             <p className="d-flex flex-column text-muted m-0">{children}</p>
         </div>
@@ -50,7 +50,7 @@ const CardBody: React.FunctionComponent<{ title: string }> = props => {
 export const SearchInsightCard: React.FunctionComponent<CardProps> = props => (
     <Card {...props} footerText="Redis, PostgreSQL and SQLite database usage.">
         <SearchBasedInsightChart className={styles.chart} />
-        <CardBody title="Track">
+        <CardBody title="Track changes">
             Insight <b>based on a custom Sourcegraph search query</b> that creates visualization of the data series you
             will define <b>manually.</b>
         </CardBody>
@@ -70,7 +70,7 @@ export const CaptureGroupInsightCard: React.FunctionComponent<CardProps> = props
     <Card {...props} footerText="Detecting and tracking language or package versions.">
         <CaptureGroupInsightChart className={styles.chart} />
 
-        <CardBody title="Detect and track">
+        <CardBody title="Detect and track patterns">
             Data series will be generated dynamically for each unique value from the
             <b> regular expression capture group </b> included in the search query. Chart will be updated as new values
             appear in the code base.


### PR DESCRIPTION
Follow up for https://github.com/sourcegraph/sourcegraph/pull/28978

Fixes by Alicja feedback from the last PR and from Slack threads 

* update headers to 'track changes' and 'detect and track patterns'
* update the color of the headers and use case to body color in the light theme. Now, the color used is black (#0)
* update the charts used of the cards. I've made some changes regarding the alignment. New charts are available here
* thank you for the feedback regarding the extension icons. I think that 2.5 rem is too big - they look disproportional to other cards. I've increased the size slightly (to 28px) in the design. I think we should go with this size.

Also, I changed the layout of this page according to the experimental layout from @AlicjaSuska [here](https://www.figma.com/file/qomcHxvHjrwfS3We6NVHGh/Automatically-generated-data-series-%5Breview%5D?node-id=1828%3A36510)

I also changed the width of the container here based on feedback from Alicja 

<img width="1399" alt="Screenshot 2021-12-15 at 19 09 33" src="https://user-images.githubusercontent.com/18492575/146222309-88c6f159-ff20-4554-ac61-171545755cfe.png">
