### PR TITLE
insights: move permissionsValidator out of the global resolver and in…

### DIFF
--- a/enterprise/internal/insights/resolvers/dashboard_resolvers.go
+++ b/enterprise/internal/insights/resolvers/dashboard_resolvers.go
@@ -257,6 +257,8 @@ func (r *Resolver) CreateInsightsDashboard(ctx context.Context, args *graphqlbac
 }
 
 func (r *Resolver) UpdateInsightsDashboard(ctx context.Context, args *graphqlbackend.UpdateInsightsDashboardArgs) (graphqlbackend.InsightsDashboardPayloadResolver, error) {
+	permissionsValidator := PermissionsValidatorFromBase(&r.baseInsightResolver)
+
 	var dashboardGrants []store.DashboardGrant
 	if args.Input.Grants != nil {
 		parsedGrants, err := parseDashboardGrants(*args.Input.Grants)
@@ -273,7 +275,7 @@ func (r *Resolver) UpdateInsightsDashboard(ctx context.Context, args *graphqlbac
 		return nil, errors.New("unable to update a virtualized dashboard")
 	}
 
-	err = r.permissionsValidator.validateUserAccessForDashboard(ctx, int(dashboardID.Arg))
+	err = permissionsValidator.validateUserAccessForDashboard(ctx, int(dashboardID.Arg))
 	if err != nil {
 		return nil, err
 	}
@@ -282,8 +284,8 @@ func (r *Resolver) UpdateInsightsDashboard(ctx context.Context, args *graphqlbac
 		ID:     int(dashboardID.Arg),
 		Title:  args.Input.Title,
 		Grants: dashboardGrants,
-		UserID: r.permissionsValidator.userIds,
-		OrgID:  r.permissionsValidator.orgIds})
+		UserID: permissionsValidator.userIds,
+		OrgID:  permissionsValidator.orgIds})
 	if err != nil {
 		return nil, err
 	}
@@ -329,7 +331,9 @@ func (r *Resolver) DeleteInsightsDashboard(ctx context.Context, args *graphqlbac
 	if dashboardID.isVirtualized() {
 		return emptyResponse, nil
 	}
-	err = r.permissionsValidator.validateUserAccessForDashboard(ctx, int(dashboardID.Arg))
+
+	permissionsValidator := PermissionsValidatorFromBase(&r.baseInsightResolver)
+	err = permissionsValidator.validateUserAccessForDashboard(ctx, int(dashboardID.Arg))
 	if err != nil {
 		return nil, err
 	}
@@ -358,7 +362,8 @@ func (r *Resolver) AddInsightViewToDashboard(ctx context.Context, args *graphqlb
 	}
 	defer func() { err = tx.Done(err) }()
 
-	txValidator := r.permissionsValidator.WithBaseStore(tx.Store)
+	permissionsValidator := PermissionsValidatorFromBase(&r.baseInsightResolver)
+	txValidator := permissionsValidator.WithBaseStore(tx.Store)
 	err = txValidator.validateUserAccessForDashboard(ctx, int(dashboardID.Arg))
 	if err != nil {
 		return nil, err
@@ -408,7 +413,8 @@ func (r *Resolver) RemoveInsightViewFromDashboard(ctx context.Context, args *gra
 	}
 	defer func() { err = tx.Done(err) }()
 
-	txValidator := r.permissionsValidator.WithBaseStore(tx.Store)
+	permissionsValidator := PermissionsValidatorFromBase(&r.baseInsightResolver)
+	txValidator := permissionsValidator.WithBaseStore(tx.Store)
 	err = txValidator.validateUserAccessForDashboard(ctx, int(dashboardID.Arg))
 	if err != nil {
 		return nil, err

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -290,6 +290,7 @@ func (l *lineChartDataSeriesPresentationResolver) Color(ctx context.Context) (st
 
 func (r *Resolver) CreateLineChartSearchInsight(ctx context.Context, args *graphqlbackend.CreateLineChartSearchInsightArgs) (_ graphqlbackend.InsightViewPayloadResolver, err error) {
 	uid := actor.FromContext(ctx).UID
+	permissionsValidator := PermissionsValidatorFromBase(&r.baseInsightResolver)
 
 	tx, err := r.insightStore.Transact(ctx)
 	if err != nil {
@@ -335,7 +336,7 @@ func (r *Resolver) CreateLineChartSearchInsight(ctx context.Context, args *graph
 		}
 	}
 
-	return &insightPayloadResolver{baseInsightResolver: r.baseInsightResolver, validator: r.permissionsValidator, viewId: view.UniqueID}, nil
+	return &insightPayloadResolver{baseInsightResolver: r.baseInsightResolver, validator: permissionsValidator, viewId: view.UniqueID}, nil
 }
 
 func (r *Resolver) UpdateLineChartSearchInsight(ctx context.Context, args *graphqlbackend.UpdateLineChartSearchInsightArgs) (_ graphqlbackend.InsightViewPayloadResolver, err error) {
@@ -344,13 +345,14 @@ func (r *Resolver) UpdateLineChartSearchInsight(ctx context.Context, args *graph
 		return nil, err
 	}
 	defer func() { err = tx.Done(err) }()
+	permissionsValidator := PermissionsValidatorFromBase(&r.baseInsightResolver)
 
 	var insightViewId string
 	err = relay.UnmarshalSpec(args.Id, &insightViewId)
 	if err != nil {
 		return nil, errors.Wrap(err, "error unmarshalling the insight view id")
 	}
-	err = r.permissionsValidator.validateUserAccessForView(ctx, insightViewId)
+	err = permissionsValidator.validateUserAccessForView(ctx, insightViewId)
 	if err != nil {
 		return nil, err
 	}
@@ -424,7 +426,7 @@ func (r *Resolver) UpdateLineChartSearchInsight(ctx context.Context, args *graph
 			}
 		}
 	}
-	return &insightPayloadResolver{baseInsightResolver: r.baseInsightResolver, validator: r.permissionsValidator, viewId: insightViewId}, nil
+	return &insightPayloadResolver{baseInsightResolver: r.baseInsightResolver, validator: permissionsValidator, viewId: insightViewId}, nil
 }
 
 func (r *Resolver) CreatePieChartSearchInsight(ctx context.Context, args *graphqlbackend.CreatePieChartSearchInsightArgs) (_ graphqlbackend.InsightViewPayloadResolver, err error) {
@@ -433,6 +435,7 @@ func (r *Resolver) CreatePieChartSearchInsight(ctx context.Context, args *graphq
 		return nil, err
 	}
 	defer func() { err = tx.Done(err) }()
+	permissionsValidator := PermissionsValidatorFromBase(&r.baseInsightResolver)
 
 	uid := actor.FromContext(ctx).UID
 	view, err := tx.CreateView(ctx, types.InsightView{
@@ -489,7 +492,7 @@ func (r *Resolver) CreatePieChartSearchInsight(ctx context.Context, args *graphq
 		}
 	}
 
-	return &insightPayloadResolver{baseInsightResolver: r.baseInsightResolver, validator: r.permissionsValidator, viewId: view.UniqueID}, nil
+	return &insightPayloadResolver{baseInsightResolver: r.baseInsightResolver, validator: permissionsValidator, viewId: view.UniqueID}, nil
 }
 
 func (r *Resolver) UpdatePieChartSearchInsight(ctx context.Context, args *graphqlbackend.UpdatePieChartSearchInsightArgs) (_ graphqlbackend.InsightViewPayloadResolver, err error) {
@@ -498,13 +501,14 @@ func (r *Resolver) UpdatePieChartSearchInsight(ctx context.Context, args *graphq
 		return nil, err
 	}
 	defer func() { err = tx.Done(err) }()
+	permissionsValidator := PermissionsValidatorFromBase(&r.baseInsightResolver)
 
 	var insightViewId string
 	err = relay.UnmarshalSpec(args.Id, &insightViewId)
 	if err != nil {
 		return nil, errors.Wrap(err, "error unmarshalling the insight view id")
 	}
-	err = r.permissionsValidator.validateUserAccessForView(ctx, insightViewId)
+	err = permissionsValidator.validateUserAccessForView(ctx, insightViewId)
 	if err != nil {
 		return nil, err
 	}
@@ -538,7 +542,7 @@ func (r *Resolver) UpdatePieChartSearchInsight(ctx context.Context, args *graphq
 		return nil, errors.Wrap(err, "UpdateSeries")
 	}
 
-	return &insightPayloadResolver{baseInsightResolver: r.baseInsightResolver, validator: r.permissionsValidator, viewId: view.UniqueID}, nil
+	return &insightPayloadResolver{baseInsightResolver: r.baseInsightResolver, validator: permissionsValidator, viewId: view.UniqueID}, nil
 }
 
 type pieChartInsightViewPresentation struct {
@@ -856,8 +860,9 @@ func (r *Resolver) DeleteInsightView(ctx context.Context, args *graphqlbackend.D
 	if err != nil {
 		return nil, errors.Wrap(err, "error unmarshalling the insight view id")
 	}
+	permissionsValidator := PermissionsValidatorFromBase(&r.baseInsightResolver)
 
-	err = r.permissionsValidator.validateUserAccessForView(ctx, viewId)
+	err = permissionsValidator.validateUserAccessForView(ctx, viewId)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/insights/resolvers/resolver.go
+++ b/enterprise/internal/insights/resolvers/resolver.go
@@ -54,7 +54,6 @@ type Resolver struct {
 	insightMetadataStore store.InsightMetadataStore
 	dataSeriesStore      store.DataSeriesStore
 
-	permissionsValidator *InsightPermissionsValidator
 	baseInsightResolver
 }
 
@@ -72,7 +71,6 @@ func newWithClock(timescale, postgres dbutil.DB, clock func() time.Time) *Resolv
 		timeSeriesStore:      base.timeSeriesStore,
 		insightMetadataStore: base.insightStore,
 		dataSeriesStore:      base.insightStore,
-		permissionsValidator: PermissionsValidatorFromBase(base),
 	}
 }
 

--- a/enterprise/internal/insights/store/dashboard_store.go
+++ b/enterprise/internal/insights/store/dashboard_store.go
@@ -372,7 +372,7 @@ SELECT * FROM dashboard_grants where dashboard_id = %s
 `
 
 const getDashboardGrantsByPermissionsSql = `
--- source: enterprise/internal/insights/store/dashboard_store.go:GetDashboardGrants
+-- source: enterprise/internal/insights/store/dashboard_store.go:HasDashboardPermission
 SELECT count(*)
 FROM dashboard
 WHERE id = ANY (%s)


### PR DESCRIPTION
Fixes #29055

`Resolver` is instantiated globally per `frontend`, so the `permissionsValidator` was accidentally reusing values from incorrect users.

Also added some tests for the `HasDashboardPermission` function