### PR TITLE
gomod: zoekt does periodic config invalidation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -350,7 +350,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20211214144615-e6e6f428f5b3
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20211215184724-c8a2f8c3683e
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20211110092431-863f5b1ee51b

--- a/go.sum
+++ b/go.sum
@@ -1395,8 +1395,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20211214144615-e6e6f428f5b3 h1:bfyBfrgubCh73W2dPtOUsEG6ajfH//DyS0ABZOVxVOE=
-github.com/sourcegraph/zoekt v0.0.0-20211214144615-e6e6f428f5b3/go.mod h1:Sx/PuFfor3D2/B5yTV9TqhTW48+85dR5o2tWD8VsASk=
+github.com/sourcegraph/zoekt v0.0.0-20211215184724-c8a2f8c3683e h1:avYGx1t1FFb8SfKYRTbMdBVCmxYQoF3tzSrgaOdwzZY=
+github.com/sourcegraph/zoekt v0.0.0-20211215184724-c8a2f8c3683e/go.mod h1:Sx/PuFfor3D2/B5yTV9TqhTW48+85dR5o2tWD8VsASk=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
This is to help prevent us failing to notice a repo has updated in case
of an infrastructure failure.

- https://github.com/sourcegraph/zoekt/commit/c8a2f8c indexserver: scale configFingerprint reset time relative to corpus
- https://github.com/sourcegraph/zoekt/commit/5f722e5 indexserver: use batching in ForceIterateIndexOptions
- https://github.com/sourcegraph/zoekt/commit/e77e7bc indexserver: invadildate config fingerprint every ~15min
