### PR TITLE
observation: allow dataset-level honeycomb sample rate

### DIFF
--- a/internal/honey/dataset.go
+++ b/internal/honey/dataset.go
@@ -5,12 +5,24 @@ package honey
 // with a provided dataset name.
 type Dataset struct {
 	Name string
+	// SetSampleRate overrides the global sample rate for events of this dataset.
+	// Values less than or equal to 1 mean no sampling (aka all events are sent).
+	// If you want to send one event out of every 250, you would specify 250 here.
+	SampleRate uint
 }
 
 func (d *Dataset) Event() Event {
-	return NewEvent(d.Name)
+	event := NewEvent(d.Name)
+	if d.SampleRate > 1 {
+		event.SetSampleRate(d.SampleRate)
+	}
+	return event
 }
 
 func (d *Dataset) EventWithFields(fields map[string]interface{}) Event {
-	return NewEventWithFields(d.Name, fields)
+	event := NewEventWithFields(d.Name, fields)
+	if d.SampleRate > 1 {
+		event.SetSampleRate(d.SampleRate)
+	}
+	return event
 }

--- a/internal/observation/observation.go
+++ b/internal/observation/observation.go
@@ -330,6 +330,9 @@ func (op *Operation) WithAndLogger(ctx context.Context, err *error, args Args) (
 		metricLabels := mergeLabels(op.metricLabels, args.MetricLabelValues, finishArgs.MetricLabelValues)
 
 		if multi := new(ErrCollector); err != nil && errors.As(*err, &multi) {
+			if len(multi.multi.Errors) == 0 {
+				err = nil
+			}
 			logFields = append(logFields, multi.extraFields...)
 		}
 


### PR DESCRIPTION
Includes a fix for the error being considered non-nil when multierr has 0 errors collected (`0 errors occurred:` err string)