### PR TITLE
Bump kubectl version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -3,8 +3,7 @@ yarn 1.22.4
 fd 7.4.0
 shfmt 3.2.0
 shellcheck 0.7.1
-kubectl 1.17.3
+kubectl 1.21.7
 github-cli 2.0.0
 packer 1.6.6
 trivy 0.20.0
-


### PR DESCRIPTION
Our CI cluster runs a 1.21 at this moment



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
