### PR TITLE
insights: set first indexed recording as one interval after series cr…

### DIFF
--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -600,8 +600,16 @@ func (s *InsightStore) CreateSeries(ctx context.Context, series types.InsightSer
 	if series.CreatedAt.IsZero() {
 		series.CreatedAt = s.Now()
 	}
+	interval := timeseries.TimeInterval{
+		Unit:  types.IntervalUnit(series.SampleIntervalUnit),
+		Value: series.SampleIntervalValue,
+	}
+	if !interval.IsValid() {
+		interval = timeseries.DefaultInterval
+	}
+
 	if series.NextRecordingAfter.IsZero() {
-		series.NextRecordingAfter = s.Now()
+		series.NextRecordingAfter = interval.StepForwards(s.Now())
 	}
 	if series.NextSnapshotAfter.IsZero() {
 		series.NextSnapshotAfter = s.Now()

--- a/enterprise/internal/insights/timeseries/series.go
+++ b/enterprise/internal/insights/timeseries/series.go
@@ -11,12 +11,34 @@ type TimeInterval struct {
 	Value int
 }
 
+var DefaultInterval = TimeInterval{
+	Unit:  types.Month,
+	Value: 1,
+}
+
 func (t TimeInterval) StepBackwards(start time.Time) time.Time {
 	return t.step(start, backward)
 }
 
 func (t TimeInterval) StepForwards(start time.Time) time.Time {
 	return t.step(start, forward)
+}
+
+func (t TimeInterval) IsValid() bool {
+	validType := false
+	switch t.Unit {
+	case types.Year:
+		fallthrough
+	case types.Month:
+		fallthrough
+	case types.Week:
+		fallthrough
+	case types.Day:
+		fallthrough
+	case types.Hour:
+		validType = true
+	}
+	return validType && t.Value >= 0
 }
 
 type stepDirection int

--- a/enterprise/internal/insights/timeseries/series_test.go
+++ b/enterprise/internal/insights/timeseries/series_test.go
@@ -34,3 +34,85 @@ func TestStepForward(t *testing.T) {
 		})
 	}
 }
+
+func TestIsValid(t *testing.T) {
+	tests := []struct {
+		name     string
+		want     bool
+		interval TimeInterval
+	}{
+		{
+			name: "month valid",
+			want: true,
+			interval: TimeInterval{
+				Unit:  types.Month,
+				Value: 1,
+			},
+		},
+		{
+			name: "day valid",
+			want: true,
+			interval: TimeInterval{
+				Unit:  types.Day,
+				Value: 1,
+			},
+		},
+		{
+			name: "year valid",
+			want: true,
+			interval: TimeInterval{
+				Unit:  types.Year,
+				Value: 1,
+			},
+		},
+		{
+			name: "hour valid",
+			want: true,
+			interval: TimeInterval{
+				Unit:  types.Hour,
+				Value: 1,
+			},
+		},
+		{
+			name: "week valid",
+			want: true,
+			interval: TimeInterval{
+				Unit:  types.Week,
+				Value: 1,
+			},
+		},
+		{
+			name: "invalid type",
+			want: false,
+			interval: TimeInterval{
+				Unit:  types.IntervalUnit("asdf"),
+				Value: 1,
+			},
+		},
+		{
+			name: "invalid value",
+			want: false,
+			interval: TimeInterval{
+				Unit:  types.Week,
+				Value: -1,
+			},
+		},
+		{
+			name: "valid zero value",
+			want: true,
+			interval: TimeInterval{
+				Unit:  types.Week,
+				Value: 0,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.interval.IsValid()
+			want := test.want
+			if got != want {
+				t.Errorf("unexpected IsValid: want: %v got: %v", want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #29067

Now that we have custom intervals for global series, we have to be more aware of what the first recording should be. This will set the first recording to +1 interval in the future at creation time.

