### PR TITLE
doc: markdown formatting error

### DIFF
--- a/doc/admin/external_services/postgres.md
+++ b/doc/admin/external_services/postgres.md
@@ -9,7 +9,7 @@ If you choose to set up your own PostgreSQL server, please note **we strongly re
 1. Deploy _codeintel-db_ alongside the other Sourcegraph containers, i.e. not as a managed PostgreSQL instance.
 2. Deploy a separate PostgreSQL instance. The primary reason to not use the same Postgres instance for this data is because precise code intelligence data can take up a significant of space (given the amount of indexed repositories is large) and the performance of the database may impact the performance of the general application database. You'll most likely want to be able to scale their resources independently.
 
-We also recommend having backups for the _codeintel_db_ as a best practice. The reason behind this recommendation is that _codeintel-db_ data is uploaded via CI systems. If data is lost, Sourcegraph cannot automatically rebuild it from the repositories, which means you'd have to wait until it is re-uploaded from your CI systems. 
+We also recommend having backups for the _codeintel-db_ as a best practice. The reason behind this recommendation is that _codeintel-db_ data is uploaded via CI systems. If data is lost, Sourcegraph cannot automatically rebuild it from the repositories, which means you'd have to wait until it is re-uploaded from your CI systems.
 
 ## Instructions
 


### PR DESCRIPTION
Formatting error was causing weird italics in `codeintel-db`.

![Screen Shot 2021-12-15 at 17 05 54](https://user-images.githubusercontent.com/8784265/146278750-743d7e8e-e715-447a-95c8-027f554a292e.png)

