### PR TITLE
Code Insights: Remove org fallback in case if dashboard doesn't have proper owner name

### DIFF
--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-select/helpers/get-dashboard-title.ts
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-select/helpers/get-dashboard-title.ts
@@ -38,5 +38,5 @@ export const getDashboardOwnerName = (dashboard: RealInsightDashboard): string =
         return 'Global'
     }
 
-    return dashboard.owner?.name ?? dashboard.grants?.organizations?.[0] ?? 'Unknown'
+    return dashboard.owner?.name ?? ''
 }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/28579

In the new GQL (enabled by default) we change the concept around the dashboard owner. It's funny to say but we don't have a simple way to provide a badge with the owner name next to a picked dashboard in the dashboard select while we still support setting API. This PR just removes fallback on org ID in case if we don't have a proper owner name (which we don't have in GQL API) 
