### PR TITLE
Clarify migration version instructions

### DIFF
--- a/doc/admin/install/docker-compose/migrate.md
+++ b/doc/admin/install/docker-compose/migrate.md
@@ -9,7 +9,8 @@ Sourcegraph's core data (including user accounts, configuration, repository-meta
 ### Version requirements
 
 * This migration can only be done with Sourcegraph v3.13.1+. If you are not currently on at least this version, please upgrade first.
-* Do NOT attempt to upgrade at the same time as migrating to docker-compose. Use the docker-compose version corresponding to your current version. For example, if you are running the `sourcegraph/server` image version `v3.19.2` you must follow this guide using the Docker Compose deployment version `v3.19.2`.
+* Use the docker-compose version corresponding to your _current Sourcegraph version._ Do NOT attempt to upgrade at the same time as migrating to docker-compose. 
+* For example, if the Sourcegraph instance `sourcegraph/server` image is version `v3.19.2` you must follow this guide using the Docker Compose deployment version `v3.19.2`. That means you must migrate to a new instance that is on _the same version you took the Database dump from._
 
 ### Storage location change
 


### PR DESCRIPTION
Reworded version warning due to mistakes made by users that attempted migration to conflicting SG versions.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
