### PR TITLE
batches: drop `BatchChangeStateAny`

### DIFF
--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -1754,7 +1754,7 @@ func (r *Resolver) DeleteBatchSpec(ctx context.Context, args *graphqlbackend.Del
 
 func parseBatchChangeState(s *string) (btypes.BatchChangeState, error) {
 	if s == nil {
-		return btypes.BatchChangeStateAny, nil
+		return "", nil
 	}
 	switch *s {
 	case "OPEN":
@@ -1764,7 +1764,7 @@ func parseBatchChangeState(s *string) (btypes.BatchChangeState, error) {
 	case "DRAFT":
 		return btypes.BatchChangeStateDraft, nil
 	default:
-		return btypes.BatchChangeStateAny, errors.Errorf("unknown state %q", *s)
+		return "", errors.Errorf("unknown state %q", *s)
 	}
 }
 

--- a/enterprise/internal/batches/store/batch_changes_test.go
+++ b/enterprise/internal/batches/store/batch_changes_test.go
@@ -409,7 +409,7 @@ func testStoreBatchChanges(t *testing.T, ctx context.Context, s *Store, clock ct
 		}{
 			{
 				name:  "Any",
-				state: btypes.BatchChangeStateAny,
+				state: "",
 				want:  reversedBatchChanges,
 			},
 			{

--- a/enterprise/internal/batches/types/batch_change.go
+++ b/enterprise/internal/batches/types/batch_change.go
@@ -9,7 +9,6 @@ import (
 type BatchChangeState string
 
 const (
-	BatchChangeStateAny    BatchChangeState = "ANY"
 	BatchChangeStateOpen   BatchChangeState = "OPEN"
 	BatchChangeStateClosed BatchChangeState = "CLOSED"
 	BatchChangeStateDraft  BatchChangeState = "DRAFT"


### PR DESCRIPTION
Follow up on https://github.com/sourcegraph/sourcegraph/pull/28884#discussion_r767746339, drops the unused type for a batch change state so that there's not an invalid state on the GraphQL schema when we're resolving batch change state.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
