### PR TITLE
tests: Default to Polly.js passthrough rather than record

### DIFF
--- a/client/browser/README.md
+++ b/client/browser/README.md
@@ -160,7 +160,7 @@ It currently does not run in CI and is intended to be run manually for release t
 
 All test suites in `integration` run in CI. These tests run the browser extension against recordings of code hosts (using [Polly.JS](https://netflix.github.io/pollyjs/#/)) and mock data for our GraphQL API.
 
-To update all recordings, run `yarn record-integration`. To update a subset of recordings, run `RECORD=true SOURCEGRAPH_BASE_URL=https://sourcegraph.com yarn test-integration --grep=YOUR_PATTERN`, where `YOUR_PATTERN` is typically a test name.
+To update all recordings, run `yarn record-integration`. To update a subset of recordings, run `POLLYJS_MODE=record SOURCEGRAPH_BASE_URL=https://sourcegraph.com yarn test-integration --grep=YOUR_PATTERN`, where `YOUR_PATTERN` is typically a test name.
 
 ## Deploy
 

--- a/client/browser/scripts/record-integration.js
+++ b/client/browser/scripts/record-integration.js
@@ -17,7 +17,7 @@ const shelljs = require('shelljs')
 
   for (const testName of testNames) {
     shelljs.exec(
-      `RECORD=true SOURCEGRAPH_BASE_URL=https://sourcegraph.com yarn test-integration --grep='${testName}'`,
+      `POLLYJS_MODE=record SOURCEGRAPH_BASE_URL=https://sourcegraph.com yarn test-integration --grep='${testName}'`,
       (error, stdout, stderr) => {
         if (error) {
           console.error(error)

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -158,7 +158,7 @@ func addBrowserExt(pipeline *bk.Pipeline) {
 			bk.Env("BROWSER", browser),
 			bk.Env("LOG_BROWSER_CONSOLE", "true"),
 			bk.Env("SOURCEGRAPH_BASE_URL", "https://sourcegraph.com"),
-			bk.Env("RECORD", "false"), // ensure that we use existing recordings
+			bk.Env("POLLYJS_MODE", "replay"), // ensure that we use existing recordings
 			bk.Cmd("yarn --frozen-lockfile --network-timeout 60000"),
 			bk.Cmd("yarn --cwd client/shared run download-puppeteer-browser"),
 			bk.Cmd("yarn --cwd client/browser -s run build"),


### PR DESCRIPTION
When running E2E tests locally, you often want HTTP requests to pass through Polly without being recorded or replayed. This changes the default to `passthrough` while supporting `record` and `replay` via the `POLLYJS_MODE` environment variable.