### PR TITLE
tests: Let .assets/ pass through Polly

### DIFF
--- a/client/shared/src/testing/integration/context.ts
+++ b/client/shared/src/testing/integration/context.ts
@@ -162,7 +162,7 @@ export const createSharedIntegrationTestContext = async <
             .send('')
     })
 
-    server.get(new URL('/.assets/*path', driver.sourcegraphBaseUrl).href).passthrough()
+    server.get(new URL('/*path', driver.sourcegraphBaseUrl).href).passthrough()
 
     // GraphQL requests are not handled by HARs, but configured per-test.
     interface GraphQLRequestEvent<O extends TGraphQlOperationNames> {

--- a/client/shared/src/testing/integration/context.ts
+++ b/client/shared/src/testing/integration/context.ts
@@ -5,16 +5,14 @@ import { MODE, Polly, PollyServer } from '@pollyjs/core'
 import FSPersister from '@pollyjs/persister-fs'
 import { GraphQLError } from 'graphql'
 import { snakeCase } from 'lodash'
-import * as mime from 'mime-types'
 import { Test } from 'mocha'
-import { readFile, mkdir } from 'mz/fs'
+import { mkdir } from 'mz/fs'
 import pTimeout from 'p-timeout'
 import * as prettier from 'prettier'
 import { Subject, Subscription, throwError } from 'rxjs'
 import { first, timeoutWith } from 'rxjs/operators'
 
 import { ErrorGraphQLResult, SuccessGraphQLResult } from '../../graphql/graphql'
-import { asError } from '../../util/errors'
 import { keyExistsIn } from '../../util/types'
 import { recordCoverage } from '../coverage'
 import { Driver } from '../driver'
@@ -28,8 +26,6 @@ util.inspect.defaultOptions.maxStringLength = 80
 
 Polly.register(CdpAdapter as any)
 Polly.register(FSPersister)
-
-const ASSETS_DIRECTORY = path.resolve(__dirname, '../../../../../ui/assets')
 
 const checkPollyMode = (mode: string): MODE => {
     if (mode === 'record' || mode === 'replay' || mode === 'passthrough' || mode === 'stopped') {
@@ -166,30 +162,7 @@ export const createSharedIntegrationTestContext = async <
             .send('')
     })
 
-    // Serve assets from disk
-    server.get(new URL('/.assets/*path', driver.sourcegraphBaseUrl).href).intercept(async (request, response) => {
-        const asset = request.params.path
-        // Cache all responses for the entire lifetime of the test run
-        response.setHeader('Cache-Control', 'public, max-age=31536000, immutable')
-        try {
-            const content = await readFile(path.join(ASSETS_DIRECTORY, asset), {
-                // Polly doesn't support Buffers or streams at the moment
-                encoding: 'utf-8',
-            })
-            const contentType = mime.contentType(path.basename(asset))
-            if (contentType) {
-                response.type(contentType)
-            }
-            response.send(content)
-        } catch (error) {
-            if ((asError(error) as NodeJS.ErrnoException).code === 'ENOENT') {
-                response.sendStatus(404)
-            } else {
-                console.error(error)
-                response.status(500).send(asError(error).message)
-            }
-        }
-    })
+    server.get(new URL('/.assets/*path', driver.sourcegraphBaseUrl).href).passthrough()
 
     // GraphQL requests are not handled by HARs, but configured per-test.
     interface GraphQLRequestEvent<O extends TGraphQlOperationNames> {

--- a/doc/dev/how-to/testing.md
+++ b/doc/dev/how-to/testing.md
@@ -96,7 +96,7 @@ This utility method will let you print a URL that will visually render the DOM o
     })
 ```
 
-This page also provides some additional functionality that can make it easier to identify the correct query to use to access a particular DOM element. 
+This page also provides some additional functionality that can make it easier to identify the correct query to use to access a particular DOM element.
 
 ## Browser-based tests
 
@@ -230,12 +230,6 @@ The function returns the variables that were passed to the mutation, which can b
 
 Only use `testContext.waitForRequest()` for behavior you need to test, not to generally wait for parts of the application to load.
 Whether a query is made for loading is an implementation detail, instead assert and wait on the DOM using `waitForSelector()` or `retry()`.
-
-##### Mocking JSContext
-
-The backend provides the webapp with a context object under `window.context`.
-You can override this object in integration tests using `testContext.overrideJsContext()`.
-There is a default mock JSContext that you can extend with object spread syntax if needed.
 
 ### End-to-end tests
 


### PR DESCRIPTION
Prior to this change, you had to run `yarn build` before running E2E tests so that the `ui/assets` directory was populated.

After this change, `.assets/` will be served from the instance.

@felixfbecker Do you happen to remember why you decided to serve `.assets/` from disk in https://github.com/sourcegraph/sourcegraph/pull/12130 ?

Also asked in [Slack](https://sourcegraph.slack.com/archives/C01N83PS4TU/p1639606477483300)