### PR TITLE
images: remove all exact dependencies pins, add potential puppeteer fix

### DIFF
--- a/client/shared/src/testing/driver.ts
+++ b/client/shared/src/testing/driver.ts
@@ -765,7 +765,7 @@ export async function createDriverForTest(options?: Partial<DriverOptions>): Pro
     }
 
     const { loadExtension } = resolvedOptions
-    const args: string[] = []
+    const args: string[] = ['--no-sandbox']
     const launchOptions: LaunchOptions & BrowserLaunchArgumentOptions & BrowserConnectOptions = {
         ignoreHTTPSErrors: true,
         ...resolvedOptions,

--- a/client/shared/src/testing/driver.ts
+++ b/client/shared/src/testing/driver.ts
@@ -765,7 +765,7 @@ export async function createDriverForTest(options?: Partial<DriverOptions>): Pro
     }
 
     const { loadExtension } = resolvedOptions
-    const args: string[] = ['--no-sandbox']
+    const args: string[] = ['--no-sandbox'] // https://stackoverflow.com/a/61278676
     const launchOptions: LaunchOptions & BrowserLaunchArgumentOptions & BrowserConnectOptions = {
         ignoreHTTPSErrors: true,
         ...resolvedOptions,

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -43,11 +43,11 @@ RUN apk add --no-cache --verbose \
     # the features we can depend on. See this link for more information:
     # https://github.com/sourcegraph/sourcegraph/blob/main/doc/dev/postgresql.md#version-requirements
     && apk add --no-cache --verbose \
-    'bash=5.0.17-r0' \
+    'bash=~5.0.17' \
     'redis=~5.0' \
     python2 \
     python3 \
-    'nginx>=1.18.0' openssh-client pcre sqlite-libs su-exec 'nodejs-current=14.5.0-r0' \
+    'nginx>=1.18.0' openssh-client pcre sqlite-libs su-exec 'nodejs-current=~14.5.0' \
     postgresql=12.9-r0 \
     postgresql-contrib
 

--- a/docker-images/alpine-3.12/Dockerfile
+++ b/docker-images/alpine-3.12/Dockerfile
@@ -26,10 +26,10 @@ RUN addgroup -g 101 -S sourcegraph && adduser -u 100 -S -G sourcegraph -h /home/
 RUN apk update && apk add --no-cache \
     bind-tools \
     # Requires the use of the edge repo for CVE-2021-28831 until a patched version is brought into the 3.12 mirror.
-    'busybox=1.34.1-r4' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    'busybox=~1.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
     ca-certificates \
     curl \
     mailcap \
     tini \
     # Required due to ssl_clent upgrade with busybox
-    'wget=1.21.1-r1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main
+    'wget=~1.21.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main

--- a/docker-images/alpine-3.14/Dockerfile
+++ b/docker-images/alpine-3.14/Dockerfile
@@ -26,7 +26,7 @@ RUN addgroup -g 101 -S sourcegraph && adduser -u 100 -S -G sourcegraph -h /home/
 RUN apk update && apk add --no-cache \
     bind-tools \
     # Requires the use of the edge repo for CVE-2021-28831 until a patched version is brought into the 3.12 mirror.
-    'busybox=1.34.1-r4' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    'busybox=~1.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
     ca-certificates \
     curl \
     mailcap \

--- a/docker-images/cadvisor/Dockerfile
+++ b/docker-images/cadvisor/Dockerfile
@@ -13,10 +13,10 @@ LABEL org.opencontainers.image.source=https://github.com/sourcegraph/sourcegraph
 LABEL org.opencontainers.image.documentation=https://docs.sourcegraph.com/
 
 RUN apk add --upgrade --no-cache apk-tools=2.10.8-r0 krb5-libs=1.18.4-r0 \
-    # Requires the use of the edge repo for CVE-2021-28831 until a patched version is brought into the 3.12 mirror. 
-    'busybox=1.34.1-r4' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    # Requires the use of the edge repo for CVE-2021-28831 until a patched version is brought into the 3.12 mirror.
+    'busybox=~1.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
     # Required due to ssl_clent upgrade with busybox
-    'wget=1.21.1-r1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main
+    'wget=~1.21.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main
 
 # Reflects cAdvisor Dockerfile at https://github.com/google/cadvisor/blob/v0.39.2/deploy/Dockerfile
 # alongside additional Sourcegraph defaults.

--- a/docker-images/codeinsights-db/Dockerfile
+++ b/docker-images/codeinsights-db/Dockerfile
@@ -1,9 +1,9 @@
 FROM timescale/timescaledb:2.0.0-pg12-oss
 
 # hadolint ignore=DL3017
-RUN apk -U upgrade && apk add --no-cache \  
-    # Requires the use of the edge repo for CVE-2021-28831 until a patched version is brought into the 3.12 mirror. 
-    'busybox=1.34.1-r4' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+RUN apk -U upgrade && apk add --no-cache \
+    # Requires the use of the edge repo for CVE-2021-28831 until a patched version is brought into the 3.12 mirror.
+    'busybox=~1.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
     # Required due to ssl_clent upgrade with busybox
-    'wget=1.21.1-r1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main
+    'wget=~1.21.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main
 

--- a/docker-images/grafana/Dockerfile
+++ b/docker-images/grafana/Dockerfile
@@ -39,7 +39,7 @@ USER root
 
 # @FIXME: Update redis image
 # Pin busybox=1.32.1-r7 https://github.com/sourcegraph/sourcegraph/issues/27965
-RUN apk add --upgrade --no-cache apk-tools=~2.12 krb5-libs=1.18.4-r0 libssl1.1=1.1.1l-r0 openssl=1.1.1l-r0 busybox=1.32.1-r7
+RUN apk add --upgrade --no-cache apk-tools=~2.12 krb5-libs=~1.18.4 libssl1.1=~1.1.1l openssl=~1.1.1l busybox=~1.32.1
 
 EXPOSE 3370
 USER grafana

--- a/docker-images/postgres-12.6-alpine/Dockerfile
+++ b/docker-images/postgres-12.6-alpine/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add --no-cache nss su-exec shadow &&\
 
 # @FIXME: Update redis image
 # Pin busybox=1.32.1-r7 https://github.com/sourcegraph/sourcegraph/issues/27965
-RUN apk add --upgrade --no-cache libxml2=2.9.12-r0 libgcrypt=1.8.8-r1 apk-tools=2.12.7-r0 busybox=1.32.1-r7
+RUN apk add --upgrade --no-cache libxml2=~2.9.12 libgcrypt=~1.8.8 apk-tools=~2.12.7 busybox=~1.32.1
 
 ENV POSTGRES_PASSWORD='' \
     POSTGRES_USER=sg \

--- a/docker-images/syntax-highlighter/Dockerfile
+++ b/docker-images/syntax-highlighter/Dockerfile
@@ -15,7 +15,7 @@ RUN cp ./target/release/syntect_server /syntect_server
 ################################
 FROM golang:1.15.2-alpine@sha256:fc801399d044a8e01f125eeb5aa3f160a0d12d6e03ba17a1d0b22ce50dfede81 as hss
 
-RUN apk add --no-cache git=2.26.3-r0
+RUN apk add --no-cache git=~2.26.3
 RUN git clone https://github.com/slimsag/http-server-stabilizer /repo
 WORKDIR /repo
 RUN git checkout v1.0.4 && go build -o /http-server-stabilizer .


### PR DESCRIPTION
Pinned dependencies cause our builds to fail all the time as old versions are removed from registries - this removes all exact dependency pins.