### PR TITLE
[CLOUD-163] searchcontexts: only org member can search with org namespace on Cloud

### DIFF
--- a/internal/search/searchcontexts/search_contexts.go
+++ b/internal/search/searchcontexts/search_contexts.go
@@ -6,12 +6,14 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/errors"
+	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -54,21 +56,40 @@ func ResolveSearchContextSpec(ctx context.Context, db database.DB, searchContext
 
 	if IsGlobalSearchContextSpec(searchContextSpec) {
 		return GetGlobalSearchContext(), nil
-	} else if hasNamespaceName && hasSearchContextName {
+	}
+
+	if hasNamespaceName {
 		namespace, err := db.Namespaces().GetByName(ctx, parsedSearchContextSpec.NamespaceName)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "get namespace by name")
 		}
-		return db.SearchContexts().GetSearchContext(ctx, database.GetSearchContextOptions{
-			Name:            parsedSearchContextSpec.SearchContextName,
-			NamespaceUserID: namespace.User,
-			NamespaceOrgID:  namespace.Organization,
-		})
-	} else if hasNamespaceName && !hasSearchContextName {
-		namespace, err := db.Namespaces().GetByName(ctx, parsedSearchContextSpec.NamespaceName)
-		if err != nil {
-			return nil, err
+
+		// Only member of the organization can use search contexts under the
+		// organization namespace.
+		if namespace.Organization > 0 {
+			_, err = db.OrgMembers().GetByOrgIDAndUserID(ctx, namespace.Organization, actor.FromContext(ctx).UID)
+			if err != nil {
+				if errcode.IsNotFound(err) {
+					return nil, database.ErrNamespaceNotFound
+				}
+
+				log15.Error("ResolveSearchContextSpec.OrgMembers.GetByOrgIDAndUserID", "error", err)
+
+				// NOTE: We do want to return identical error as if the namespace not found in
+				// case of internal server error. Otherwise, we're leaking the information when
+				// error occurs.
+				return nil, database.ErrNamespaceNotFound
+			}
 		}
+
+		if hasSearchContextName {
+			return db.SearchContexts().GetSearchContext(ctx, database.GetSearchContextOptions{
+				Name:            parsedSearchContextSpec.SearchContextName,
+				NamespaceUserID: namespace.User,
+				NamespaceOrgID:  namespace.Organization,
+			})
+		}
+
 		if namespace.User == 0 && namespace.Organization == 0 {
 			return nil, errors.Errorf("search context %q not found", searchContextSpec)
 		}
@@ -77,6 +98,7 @@ func ResolveSearchContextSpec(ctx context.Context, db database.DB, searchContext
 		}
 		return GetOrganizationSearchContext(namespace.Organization, parsedSearchContextSpec.NamespaceName, parsedSearchContextSpec.NamespaceName), nil
 	}
+
 	// Check if instance-level context
 	return db.SearchContexts().GetSearchContext(ctx, database.GetSearchContextOptions{Name: parsedSearchContextSpec.SearchContextName})
 }

--- a/internal/search/searchcontexts/search_contexts.go
+++ b/internal/search/searchcontexts/search_contexts.go
@@ -65,8 +65,8 @@ func ResolveSearchContextSpec(ctx context.Context, db database.DB, searchContext
 		}
 
 		// Only member of the organization can use search contexts under the
-		// organization namespace.
-		if namespace.Organization > 0 {
+		// organization namespace on Sourcegraph Cloud.
+		if envvar.SourcegraphDotComMode() && namespace.Organization > 0 {
 			_, err = db.OrgMembers().GetByOrgIDAndUserID(ctx, namespace.Organization, actor.FromContext(ctx).UID)
 			if err != nil {
 				if errcode.IsNotFound(err) {

--- a/internal/search/searchcontexts/search_contexts_test.go
+++ b/internal/search/searchcontexts/search_contexts_test.go
@@ -124,12 +124,7 @@ func TestResolvingInvalidSearchContextSpecs(t *testing.T) {
 	}
 
 	ns := dbmock.NewMockNamespaceStore()
-	ns.GetByNameFunc.SetDefaultHook(func(ctx context.Context, name string) (*database.Namespace, error) {
-		if name == "org-not-member" {
-			return &database.Namespace{Name: name, Organization: 1}, nil
-		}
-		return &database.Namespace{}, nil
-	})
+	ns.GetByNameFunc.SetDefaultReturn(&database.Namespace{}, nil)
 
 	sc := dbmock.NewMockSearchContextsStore()
 	sc.GetSearchContextFunc.SetDefaultReturn(nil, errors.New("search context not found"))
@@ -161,6 +156,7 @@ func TestResolvingInvalidSearchContextSpecs_Cloud(t *testing.T) {
 		wantErr           string
 	}{
 		{name: "org not a member", searchContextSpec: "@org-not-member", wantErr: "namespace not found"},
+		{name: "org not a member with sub-context", searchContextSpec: "@org-not-member/random", wantErr: "namespace not found"},
 	}
 
 	ns := dbmock.NewMockNamespaceStore()


### PR DESCRIPTION
Limiting using search contexts under an organization namespace to only members of the organization on Sourcegraph Cloud.

_It is recommended to review [without whitespaces](https://github.com/sourcegraph/sourcegraph/pull/29091/files?w=1)._

Below is what it looks like in the UI:
<img width="926" alt="CleanShot 2021-12-16 at 14 54 29@2x" src="https://user-images.githubusercontent.com/2946214/146326779-f9c03774-30a9-4c5e-9f07-a0c7f0a0e9aa.png">

---

Jira: CLOUD-163