### PR TITLE
ci: disable User Settings regression test

### DIFF
--- a/client/web/src/regression/core.test.ts
+++ b/client/web/src/regression/core.test.ts
@@ -75,7 +75,8 @@ describe('Core functionality regression test suite', () => {
         await alwaysCleanupManager.destroyAll()
     })
 
-    test('2.2.1 User settings are saved and applied', async () => {
+    // TODO: Disabled because it's flaky. https://github.com/sourcegraph/sourcegraph/issues/29098
+    test.skip('2.2.1 User settings are saved and applied', async () => {
         const getSettings = async () => {
             await driver.page.waitForSelector('.test-settings-file .monaco-editor .view-lines')
             return driver.page.evaluate(() => {


### PR DESCRIPTION
The test looks flaky after the Puppeteer upgrade. It will probably be deleted based on [E2E survey results](https://docs.google.com/document/d/1pHlgAj3JderMVsP2rWMovh2mTSK8TBecriSHLZX6UHQ/edit#).
See https://github.com/sourcegraph/sourcegraph/issues/29098 for more details.