### PR TITLE
Retry once if updating Bitbucket PR fails due to outdated version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The shortcuts for toggling the History Panel and Line Wrap were not working on Mac. [#28574](https://github.com/sourcegraph/sourcegraph/pull/28574)
 - Suppresses docker-on-mac warning for Kubernetes, Docker Compose, and Pure Docker deployments. [#28405](https://github.com/sourcegraph/sourcegraph/pull/28821)
 - Fixed an issue where certain regexp syntax for repository searches caused the entire search, including non-repository searches, to fail with a parse error (issue affects only version 3.34). [#28826](https://github.com/sourcegraph/sourcegraph/pull/28826)
+- Modifying changesets on Bitbucket Server could previously fail if the local copy in Batch Changes was out of date. That has been fixed by retrying the operations in case of a 409 response. [#29100](https://github.com/sourcegraph/sourcegraph/pull/29100)
 
 ### Removed
 

--- a/enterprise/internal/batches/sources/bitbucketserver.go
+++ b/enterprise/internal/batches/sources/bitbucketserver.go
@@ -222,7 +222,26 @@ func (s BitbucketServerSource) UpdateChangeset(ctx context.Context, c *Changeset
 
 	updated, err := s.client.UpdatePullRequest(ctx, update)
 	if err != nil {
-		return err
+		if !bitbucketserver.IsPullRequestOutOfDate(err) {
+			return err
+		}
+
+		// If we have an outdated version of the pull request we extract the
+		// pull request that was returned with the error...
+		newestPR, err2 := bitbucketserver.ExtractPullRequest(err)
+		if err2 != nil {
+			return errors.Wrap(err, "failed to extract pull request after receiving error")
+		}
+
+		log15.Info("Updating Bitbucket Server PR failed because it's outdated. Retrying with newer version", "ID", pr.ID, "oldVersion", pr.Version, "newestVerssion", newestPR.Version)
+
+		// ... and try again, but this time with the newest version
+		update.Version = newestPR.Version
+		updated, err = s.client.UpdatePullRequest(ctx, update)
+		if err != nil {
+			// If that didn't work, we bail out
+			return err
+		}
 	}
 
 	return c.Changeset.SetMetadata(updated)

--- a/enterprise/internal/batches/sources/bitbucketserver_test.go
+++ b/enterprise/internal/batches/sources/bitbucketserver_test.go
@@ -362,9 +362,14 @@ func TestBitbucketServerSource_UpdateChangeset(t *testing.T) {
 		instanceURL = "https://bitbucket.sgdev.org"
 	}
 
-	pr := &bitbucketserver.PullRequest{ID: 43, Version: 5}
-	pr.ToRef.Repository.Slug = "automation-testing"
-	pr.ToRef.Repository.Project.Key = "SOUR"
+	successPR := &bitbucketserver.PullRequest{ID: 154, Version: 5}
+	successPR.ToRef.Repository.Slug = "automation-testing"
+	successPR.ToRef.Repository.Project.Key = "SOUR"
+
+	// This version is too low
+	outdatedPR := &bitbucketserver.PullRequest{ID: 155, Version: 1}
+	outdatedPR.ToRef.Repository.Slug = "automation-testing"
+	outdatedPR.ToRef.Repository.Project.Key = "SOUR"
 
 	testCases := []struct {
 		name string
@@ -377,7 +382,16 @@ func TestBitbucketServerSource_UpdateChangeset(t *testing.T) {
 				Title:     "This is a new title",
 				Body:      "This is a new body",
 				BaseRef:   "refs/heads/master",
-				Changeset: &btypes.Changeset{Metadata: pr},
+				Changeset: &btypes.Changeset{Metadata: successPR},
+			},
+		},
+		{
+			name: "outdated",
+			cs: &Changeset{
+				Title:     "This is a new title",
+				Body:      "This is a new body",
+				BaseRef:   "refs/heads/master",
+				Changeset: &btypes.Changeset{Metadata: outdatedPR},
 			},
 		},
 	}

--- a/enterprise/internal/batches/sources/bitbucketserver_test.go
+++ b/enterprise/internal/batches/sources/bitbucketserver_test.go
@@ -228,6 +228,11 @@ func TestBitbucketServerSource_CloseChangeset(t *testing.T) {
 	pr.ToRef.Repository.Slug = "automation-testing"
 	pr.ToRef.Repository.Project.Key = "SOUR"
 
+	// Version is too low
+	outdatedPR := &bitbucketserver.PullRequest{ID: 156, Version: 1}
+	outdatedPR.ToRef.Repository.Slug = "automation-testing"
+	outdatedPR.ToRef.Repository.Project.Key = "SOUR"
+
 	testCases := []struct {
 		name string
 		cs   *Changeset
@@ -237,6 +242,10 @@ func TestBitbucketServerSource_CloseChangeset(t *testing.T) {
 			name: "success",
 			cs:   &Changeset{Changeset: &btypes.Changeset{Metadata: pr}},
 		},
+		{
+			name: "outdated",
+			cs:   &Changeset{Changeset: &btypes.Changeset{Metadata: outdatedPR}},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -244,6 +253,8 @@ func TestBitbucketServerSource_CloseChangeset(t *testing.T) {
 		tc.name = "BitbucketServerSource_CloseChangeset_" + strings.ReplaceAll(tc.name, " ", "_")
 
 		t.Run(tc.name, func(t *testing.T) {
+			t.Logf("Updating fixtures: %t", update(tc.name))
+
 			cf, save := newClientFactory(t, tc.name)
 			defer save(t)
 
@@ -297,6 +308,11 @@ func TestBitbucketServerSource_ReopenChangeset(t *testing.T) {
 	pr.ToRef.Repository.Slug = "automation-testing"
 	pr.ToRef.Repository.Project.Key = "SOUR"
 
+	// Version is far too low
+	outdatedPR := &bitbucketserver.PullRequest{ID: 160, Version: 1}
+	outdatedPR.ToRef.Repository.Slug = "automation-testing"
+	outdatedPR.ToRef.Repository.Project.Key = "SOUR"
+
 	testCases := []struct {
 		name string
 		cs   *Changeset
@@ -305,6 +321,10 @@ func TestBitbucketServerSource_ReopenChangeset(t *testing.T) {
 		{
 			name: "success",
 			cs:   &Changeset{Changeset: &btypes.Changeset{Metadata: pr}},
+		},
+		{
+			name: "outdated",
+			cs:   &Changeset{Changeset: &btypes.Changeset{Metadata: outdatedPR}},
 		},
 	}
 
@@ -454,6 +474,11 @@ func TestBitbucketServerSource_CreateComment(t *testing.T) {
 	pr.ToRef.Repository.Slug = "automation-testing"
 	pr.ToRef.Repository.Project.Key = "SOUR"
 
+	// This version is too low
+	outdatedPR := &bitbucketserver.PullRequest{ID: 154, Version: 1}
+	outdatedPR.ToRef.Repository.Slug = "automation-testing"
+	outdatedPR.ToRef.Repository.Project.Key = "SOUR"
+
 	testCases := []struct {
 		name string
 		cs   *Changeset
@@ -462,6 +487,10 @@ func TestBitbucketServerSource_CreateComment(t *testing.T) {
 		{
 			name: "success",
 			cs:   &Changeset{Changeset: &btypes.Changeset{Metadata: pr}},
+		},
+		{
+			name: "outdated",
+			cs:   &Changeset{Changeset: &btypes.Changeset{Metadata: outdatedPR}},
 		},
 	}
 
@@ -500,6 +529,96 @@ func TestBitbucketServerSource_CreateComment(t *testing.T) {
 			if have, want := fmt.Sprint(err), tc.err; have != want {
 				t.Errorf("error:\nhave: %q\nwant: %q", have, want)
 			}
+		})
+	}
+}
+
+func TestBitbucketServerSource_MergeChangeset(t *testing.T) {
+	instanceURL := os.Getenv("BITBUCKET_SERVER_URL")
+	if instanceURL == "" {
+		// The test fixtures and golden files were generated with
+		// this config pointed to bitbucket.sgdev.org
+		instanceURL = "https://bitbucket.sgdev.org"
+	}
+
+	pr := &bitbucketserver.PullRequest{ID: 159, Version: 0}
+	pr.ToRef.Repository.Slug = "automation-testing"
+	pr.ToRef.Repository.Project.Key = "SOUR"
+
+	// Version is too low
+	outdatedPR := &bitbucketserver.PullRequest{ID: 157, Version: 1}
+	outdatedPR.ToRef.Repository.Slug = "automation-testing"
+	outdatedPR.ToRef.Repository.Project.Key = "SOUR"
+
+	// Version is also too low, but PR has a conflict too, we want err
+	conflictPR := &bitbucketserver.PullRequest{ID: 154, Version: 8}
+	conflictPR.ToRef.Repository.Slug = "automation-testing"
+	conflictPR.ToRef.Repository.Project.Key = "SOUR"
+
+	testCases := []struct {
+		name string
+		cs   *Changeset
+		err  string
+	}{
+		{
+			name: "success",
+			cs:   &Changeset{Changeset: &btypes.Changeset{Metadata: pr}},
+		},
+		{
+			name: "outdated",
+			cs:   &Changeset{Changeset: &btypes.Changeset{Metadata: outdatedPR}},
+		},
+		{
+			name: "conflict",
+			cs:   &Changeset{Changeset: &btypes.Changeset{Metadata: conflictPR}},
+			err:  "changeset cannot be merged:\nBitbucket API HTTP error: code=409 url=\"${INSTANCEURL}/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/154/merge?version=10\" body=\"{\\\"errors\\\":[{\\\"context\\\":null,\\\"message\\\":\\\"The pull request has conflicts and cannot be merged.\\\",\\\"exceptionName\\\":\\\"com.atlassian.bitbucket.pull.PullRequestMergeVetoedException\\\",\\\"conflicted\\\":true,\\\"vetoes\\\":[]}]}\"",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		tc.name = "BitbucketServerSource_MergeChangeset_" + strings.ReplaceAll(tc.name, " ", "_")
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Logf("Updating fixtures: %t", update(tc.name))
+
+			cf, save := newClientFactory(t, tc.name)
+			defer save(t)
+
+			lg := log15.New()
+			lg.SetHandler(log15.DiscardHandler())
+
+			svc := &types.ExternalService{
+				Kind: extsvc.KindBitbucketServer,
+				Config: marshalJSON(t, &schema.BitbucketServerConnection{
+					Url:   instanceURL,
+					Token: os.Getenv("BITBUCKET_SERVER_TOKEN"),
+				}),
+			}
+
+			bbsSrc, err := NewBitbucketServerSource(svc, cf)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ctx := context.Background()
+			if tc.err == "" {
+				tc.err = "<nil>"
+			}
+
+			tc.err = strings.ReplaceAll(tc.err, "${INSTANCEURL}", instanceURL)
+
+			err = bbsSrc.MergeChangeset(ctx, tc.cs, false)
+			if have, want := fmt.Sprint(err), tc.err; have != want {
+				t.Errorf("error:\nhave: %q\nwant: %q", have, want)
+			}
+
+			if err != nil {
+				return
+			}
+
+			pr := tc.cs.Changeset.Metadata.(*bitbucketserver.PullRequest)
+			testutil.AssertGolden(t, "testdata/golden/"+tc.name, update(tc.name), pr)
 		})
 	}
 }

--- a/enterprise/internal/batches/sources/testdata/golden/BitbucketServerSource_CloseChangeset_outdated
+++ b/enterprise/internal/batches/sources/testdata/golden/BitbucketServerSource_CloseChangeset_outdated
@@ -1,0 +1,55 @@
+{
+  "id": 156,
+  "version": 4,
+  "title": "horse horse adfadsfa",
+  "description": "",
+  "state": "DECLINED",
+  "open": false,
+  "closed": true,
+  "createdDate": 1639735227483,
+  "updatedDate": 1639735452438,
+  "fromRef": {
+   "id": "refs/heads/batches/test-comment-1",
+   "repository": {
+    "id": 10070,
+    "slug": "automation-testing",
+    "project": {
+     "key": "SOUR"
+    }
+   }
+  },
+  "toRef": {
+   "id": "refs/heads/master",
+   "repository": {
+    "id": 10070,
+    "slug": "automation-testing",
+    "project": {
+     "key": "SOUR"
+    }
+   }
+  },
+  "locked": false,
+  "author": {
+   "user": {
+    "name": "thorsten",
+    "emailAddress": "thorsten@sourcegraph.com",
+    "id": 104,
+    "displayName": "thorsten",
+    "active": true,
+    "slug": "thorsten",
+    "type": "NORMAL"
+   },
+   "role": "AUTHOR",
+   "approved": false,
+   "status": "UNAPPROVED"
+  },
+  "reviewers": [],
+  "participants": [],
+  "links": {
+   "self": [
+    {
+     "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/156"
+    }
+   ]
+  }
+ }

--- a/enterprise/internal/batches/sources/testdata/golden/BitbucketServerSource_MergeChangeset_outdated
+++ b/enterprise/internal/batches/sources/testdata/golden/BitbucketServerSource_MergeChangeset_outdated
@@ -1,0 +1,71 @@
+{
+  "id": 157,
+  "version": 7,
+  "title": "Merge merge",
+  "description": "asdfasdfasdf",
+  "state": "MERGED",
+  "open": false,
+  "closed": true,
+  "createdDate": 1639735561195,
+  "updatedDate": 1639736998761,
+  "fromRef": {
+   "id": "refs/heads/thorsten/READMEmd-1639735546623",
+   "repository": {
+    "id": 10070,
+    "slug": "automation-testing",
+    "project": {
+     "key": "SOUR"
+    }
+   }
+  },
+  "toRef": {
+   "id": "refs/heads/master",
+   "repository": {
+    "id": 10070,
+    "slug": "automation-testing",
+    "project": {
+     "key": "SOUR"
+    }
+   }
+  },
+  "locked": false,
+  "author": {
+   "user": {
+    "name": "thorsten",
+    "emailAddress": "thorsten@sourcegraph.com",
+    "id": 104,
+    "displayName": "thorsten",
+    "active": true,
+    "slug": "thorsten",
+    "type": "NORMAL"
+   },
+   "role": "AUTHOR",
+   "approved": false,
+   "status": "UNAPPROVED"
+  },
+  "reviewers": [
+   {
+    "user": {
+     "name": "erik",
+     "emailAddress": "erik@sourcegraph.com",
+     "id": 152,
+     "displayName": "Erik Seliger",
+     "active": true,
+     "slug": "erik",
+     "type": "NORMAL"
+    },
+    "lastReviewedCommit": "",
+    "role": "REVIEWER",
+    "approved": false,
+    "status": "UNAPPROVED"
+   }
+  ],
+  "participants": [],
+  "links": {
+   "self": [
+    {
+     "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/157"
+    }
+   ]
+  }
+ }

--- a/enterprise/internal/batches/sources/testdata/golden/BitbucketServerSource_MergeChangeset_success
+++ b/enterprise/internal/batches/sources/testdata/golden/BitbucketServerSource_MergeChangeset_success
@@ -1,0 +1,55 @@
+{
+  "id": 159,
+  "version": 2,
+  "title": "circle-ci.yml edited online with Bitbucket",
+  "description": "",
+  "state": "MERGED",
+  "open": false,
+  "closed": true,
+  "createdDate": 1639735976577,
+  "updatedDate": 1639735991619,
+  "fromRef": {
+   "id": "refs/heads/thorsten/circle-ciyml-1639735971065",
+   "repository": {
+    "id": 10070,
+    "slug": "automation-testing",
+    "project": {
+     "key": "SOUR"
+    }
+   }
+  },
+  "toRef": {
+   "id": "refs/heads/master",
+   "repository": {
+    "id": 10070,
+    "slug": "automation-testing",
+    "project": {
+     "key": "SOUR"
+    }
+   }
+  },
+  "locked": false,
+  "author": {
+   "user": {
+    "name": "thorsten",
+    "emailAddress": "thorsten@sourcegraph.com",
+    "id": 104,
+    "displayName": "thorsten",
+    "active": true,
+    "slug": "thorsten",
+    "type": "NORMAL"
+   },
+   "role": "AUTHOR",
+   "approved": false,
+   "status": "UNAPPROVED"
+  },
+  "reviewers": [],
+  "participants": [],
+  "links": {
+   "self": [
+    {
+     "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/159"
+    }
+   ]
+  }
+ }

--- a/enterprise/internal/batches/sources/testdata/golden/BitbucketServerSource_ReopenChangeset_outdated
+++ b/enterprise/internal/batches/sources/testdata/golden/BitbucketServerSource_ReopenChangeset_outdated
@@ -1,0 +1,55 @@
+{
+  "id": 160,
+  "version": 3,
+  "title": "another title",
+  "description": "",
+  "state": "OPEN",
+  "open": true,
+  "closed": false,
+  "createdDate": 1639737710940,
+  "updatedDate": 1639737755125,
+  "fromRef": {
+   "id": "refs/heads/thorsten/file3txt-1639737705647",
+   "repository": {
+    "id": 10070,
+    "slug": "automation-testing",
+    "project": {
+     "key": "SOUR"
+    }
+   }
+  },
+  "toRef": {
+   "id": "refs/heads/master",
+   "repository": {
+    "id": 10070,
+    "slug": "automation-testing",
+    "project": {
+     "key": "SOUR"
+    }
+   }
+  },
+  "locked": false,
+  "author": {
+   "user": {
+    "name": "thorsten",
+    "emailAddress": "thorsten@sourcegraph.com",
+    "id": 104,
+    "displayName": "thorsten",
+    "active": true,
+    "slug": "thorsten",
+    "type": "NORMAL"
+   },
+   "role": "AUTHOR",
+   "approved": false,
+   "status": "UNAPPROVED"
+  },
+  "reviewers": [],
+  "participants": [],
+  "links": {
+   "self": [
+    {
+     "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/160"
+    }
+   ]
+  }
+ }

--- a/enterprise/internal/batches/sources/testdata/golden/BitbucketServerSource_UpdateChangeset_outdated
+++ b/enterprise/internal/batches/sources/testdata/golden/BitbucketServerSource_UpdateChangeset_outdated
@@ -1,15 +1,15 @@
 {
-  "id": 154,
-  "version": 6,
+  "id": 155,
+  "version": 7,
   "title": "This is a new title",
   "description": "This is a new body",
   "state": "OPEN",
   "open": true,
   "closed": false,
-  "createdDate": 1639582116883,
-  "updatedDate": 1639652359417,
+  "createdDate": 1639650896484,
+  "updatedDate": 1639652359748,
   "fromRef": {
-   "id": "refs/heads/hello-world",
+   "id": "refs/heads/hello-world-18",
    "repository": {
     "id": 10070,
     "slug": "automation-testing",
@@ -48,7 +48,7 @@
   "links": {
    "self": [
     {
-     "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/154"
+     "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/155"
     }
    ]
   }

--- a/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_CloseChangeset_outdated.yaml
+++ b/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_CloseChangeset_outdated.yaml
@@ -1,0 +1,79 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/156/decline?version=1
+    method: POST
+  response:
+    body: '{"errors":[{"context":null,"message":"You are attempting to modify a pull
+      request based on out-of-date information.","exceptionName":"com.atlassian.bitbucket.pull.PullRequestOutOfDateException","currentVersion":3,"expectedVersion":1,"pullRequest":{"id":156,"version":3,"title":"horse
+      horse adfadsfa","state":"OPEN","open":true,"closed":false,"createdDate":1639735227483,"updatedDate":1639735411171,"fromRef":{"id":"refs/heads/batches/test-comment-1","displayId":"batches/test-comment-1","latestCommit":"e1eb87419b73f03cb96201993673d2f43eddb320","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"433511c512c568a6dbc308c2347879f9d6095849","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/156"}]}}}]}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 17 Dec 2021 10:04:11 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@9KC48Ux604x13406783x1'
+      X-Asessionid:
+      - 1rpmfhh
+      X-Auserid:
+      - "104"
+      X-Ausername:
+      - thorsten
+      X-Content-Type-Options:
+      - nosniff
+    status: 409 Conflict
+    code: 409
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/156/decline?version=3
+    method: POST
+  response:
+    body: '{"id":156,"version":4,"title":"horse horse adfadsfa","state":"DECLINED","open":false,"closed":true,"createdDate":1639735227483,"updatedDate":1639735452438,"closedDate":1639735452438,"fromRef":{"id":"refs/heads/batches/test-comment-1","displayId":"batches/test-comment-1","latestCommit":"e1eb87419b73f03cb96201993673d2f43eddb320","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"433511c512c568a6dbc308c2347879f9d6095849","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/156"}]}}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 17 Dec 2021 10:04:11 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@9KC48Ux604x13406785x0'
+      X-Asessionid:
+      - s36svp
+      X-Auserid:
+      - "104"
+      X-Ausername:
+      - thorsten
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_CreateComment_outdated.yaml
+++ b/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_CreateComment_outdated.yaml
@@ -1,0 +1,43 @@
+---
+version: 1
+interactions:
+- request:
+    body: |
+      {"text":"test-comment"}
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/154/comments?version=1
+    method: POST
+  response:
+    body: '{"properties":{"repositoryId":10070},"id":2958,"version":0,"text":"test-comment","author":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"createdDate":1639737545738,"updatedDate":1639737545738,"comments":[],"tasks":[],"severity":"NORMAL","state":"OPEN","permittedOperations":{"editable":true,"transitionable":true,"deletable":true}}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 17 Dec 2021 10:39:05 GMT
+      Location:
+      - https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/154/comments/2958?version=1
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@9KC48Ux639x13415405x0'
+      X-Asessionid:
+      - yecmmv
+      X-Auserid:
+      - "104"
+      X-Ausername:
+      - thorsten
+      X-Content-Type-Options:
+      - nosniff
+    status: 201 Created
+    code: 201
+    duration: ""

--- a/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_MergeChangeset_conflict.yaml
+++ b/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_MergeChangeset_conflict.yaml
@@ -1,0 +1,80 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/154/merge?version=8
+    method: POST
+  response:
+    body: '{"errors":[{"context":null,"message":"You are attempting to modify a pull
+      request based on out-of-date information.","exceptionName":"com.atlassian.bitbucket.pull.PullRequestOutOfDateException","currentVersion":10,"expectedVersion":8,"pullRequest":{"id":154,"version":10,"title":"This
+      is a new title","description":"This is a new body","state":"OPEN","open":true,"closed":false,"createdDate":1639582116883,"updatedDate":1639737255599,"fromRef":{"id":"refs/heads/hello-world","displayId":"hello-world","latestCommit":"fbb818b2ba432f906a8f5fa58cadcc74dc1bf865","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"2046f48cd2633f58f1a4c2aa7b5b1b613e34a24c","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/154"}]}}}]}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 17 Dec 2021 10:36:40 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@9KC48Ux636x13414828x0'
+      X-Asessionid:
+      - 1tmlymt
+      X-Auserid:
+      - "104"
+      X-Ausername:
+      - thorsten
+      X-Content-Type-Options:
+      - nosniff
+    status: 409 Conflict
+    code: 409
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/154/merge?version=10
+    method: POST
+  response:
+    body: '{"errors":[{"context":null,"message":"The pull request has conflicts and
+      cannot be merged.","exceptionName":"com.atlassian.bitbucket.pull.PullRequestMergeVetoedException","conflicted":true,"vetoes":[]}]}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 17 Dec 2021 10:36:40 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@9KC48Ux636x13414830x1'
+      X-Asessionid:
+      - xxs1k9
+      X-Auserid:
+      - "104"
+      X-Ausername:
+      - thorsten
+      X-Content-Type-Options:
+      - nosniff
+    status: 409 Conflict
+    code: 409
+    duration: ""

--- a/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_MergeChangeset_outdated.yaml
+++ b/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_MergeChangeset_outdated.yaml
@@ -1,0 +1,81 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/157/merge?version=1
+    method: POST
+  response:
+    body: '{"errors":[{"context":null,"message":"You are attempting to modify a pull
+      request based on out-of-date information.","exceptionName":"com.atlassian.bitbucket.pull.PullRequestOutOfDateException","currentVersion":5,"expectedVersion":1,"pullRequest":{"id":157,"version":5,"title":"Merge
+      merge","description":"asdfasdfasdf","state":"OPEN","open":true,"closed":false,"createdDate":1639735561195,"updatedDate":1639735907346,"fromRef":{"id":"refs/heads/thorsten/READMEmd-1639735546623","displayId":"thorsten/READMEmd-1639735546623","latestCommit":"e83c519d0dbda3865733acb9d26f4d2d85387006","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"d52c0d8cbe919825555e09d20879d3069bf774c9","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[{"user":{"name":"erik","emailAddress":"erik@sourcegraph.com","id":152,"displayName":"Erik
+      Seliger","active":true,"slug":"erik","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/erik"}]}},"role":"REVIEWER","approved":false,"status":"UNAPPROVED"}],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/157"}]}}}]}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 17 Dec 2021 10:29:58 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@9KC48Ux629x13413101x0'
+      X-Asessionid:
+      - 1ixxmla
+      X-Auserid:
+      - "104"
+      X-Ausername:
+      - thorsten
+      X-Content-Type-Options:
+      - nosniff
+    status: 409 Conflict
+    code: 409
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/157/merge?version=5
+    method: POST
+  response:
+    body: '{"id":157,"version":7,"title":"Merge merge","description":"asdfasdfasdf","state":"MERGED","open":false,"closed":true,"createdDate":1639735561195,"updatedDate":1639736998761,"closedDate":1639736998761,"fromRef":{"id":"refs/heads/thorsten/READMEmd-1639735546623","displayId":"thorsten/READMEmd-1639735546623","latestCommit":"e83c519d0dbda3865733acb9d26f4d2d85387006","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"d52c0d8cbe919825555e09d20879d3069bf774c9","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[{"user":{"name":"erik","emailAddress":"erik@sourcegraph.com","id":152,"displayName":"Erik
+      Seliger","active":true,"slug":"erik","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/erik"}]}},"role":"REVIEWER","approved":false,"status":"UNAPPROVED"}],"participants":[],"properties":{"mergeCommit":{"displayId":"2046f48cd26","id":"2046f48cd2633f58f1a4c2aa7b5b1b613e34a24c"}},"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/157"}]}}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 17 Dec 2021 10:29:58 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@9KC48Ux629x13413102x0'
+      X-Asessionid:
+      - 1wjblfm
+      X-Auserid:
+      - "104"
+      X-Ausername:
+      - thorsten
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_MergeChangeset_success.yaml
+++ b/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_MergeChangeset_success.yaml
@@ -1,0 +1,40 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/159/merge?version=0
+    method: POST
+  response:
+    body: '{"id":159,"version":2,"title":"circle-ci.yml edited online with Bitbucket","state":"MERGED","open":false,"closed":true,"createdDate":1639735976577,"updatedDate":1639735991619,"closedDate":1639735991619,"fromRef":{"id":"refs/heads/thorsten/circle-ciyml-1639735971065","displayId":"thorsten/circle-ciyml-1639735971065","latestCommit":"239f5065d670317131aa89b73e8aa845a40fc6a1","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"433511c512c568a6dbc308c2347879f9d6095849","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[],"participants":[],"properties":{"mergeCommit":{"displayId":"d52c0d8cbe9","id":"d52c0d8cbe919825555e09d20879d3069bf774c9"}},"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/159"}]}}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 17 Dec 2021 10:13:10 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@9KC48Ux613x13409168x0'
+      X-Asessionid:
+      - 3gvf9m
+      X-Auserid:
+      - "104"
+      X-Ausername:
+      - thorsten
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_ReopenChangeset_outdated.yaml
+++ b/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_ReopenChangeset_outdated.yaml
@@ -1,0 +1,79 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/160/reopen?version=1
+    method: POST
+  response:
+    body: '{"errors":[{"context":null,"message":"You are attempting to modify a pull
+      request based on out-of-date information.","exceptionName":"com.atlassian.bitbucket.pull.PullRequestOutOfDateException","currentVersion":2,"expectedVersion":1,"pullRequest":{"id":160,"version":2,"title":"another
+      title","state":"DECLINED","open":false,"closed":true,"createdDate":1639737710940,"updatedDate":1639737725761,"closedDate":1639737725761,"fromRef":{"id":"refs/heads/thorsten/file3txt-1639737705647","displayId":"thorsten/file3txt-1639737705647","latestCommit":"21f697613c1f3f136707aa41e859a14371582875","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"2046f48cd2633f58f1a4c2aa7b5b1b613e34a24c","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/160"}]}}}]}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 17 Dec 2021 10:42:34 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@9KC48Ux642x13416323x0'
+      X-Asessionid:
+      - 1j54hk8
+      X-Auserid:
+      - "104"
+      X-Ausername:
+      - thorsten
+      X-Content-Type-Options:
+      - nosniff
+    status: 409 Conflict
+    code: 409
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/160/reopen?version=2
+    method: POST
+  response:
+    body: '{"id":160,"version":3,"title":"another title","state":"OPEN","open":true,"closed":false,"createdDate":1639737710940,"updatedDate":1639737755125,"fromRef":{"id":"refs/heads/thorsten/file3txt-1639737705647","displayId":"thorsten/file3txt-1639737705647","latestCommit":"21f697613c1f3f136707aa41e859a14371582875","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"2046f48cd2633f58f1a4c2aa7b5b1b613e34a24c","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/160"}]}}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 17 Dec 2021 10:42:34 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@9KC48Ux642x13416324x0'
+      X-Asessionid:
+      - do565i
+      X-Auserid:
+      - "104"
+      X-Ausername:
+      - thorsten
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_UpdateChangeset_outdated.yaml
+++ b/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_UpdateChangeset_outdated.yaml
@@ -1,0 +1,82 @@
+---
+version: 1
+interactions:
+- request:
+    body: |
+      {"version":1,"title":"This is a new title","description":"This is a new body","toRef":{"id":"refs/heads/master","repository":{"id":0,"slug":"automation-testing","project":{"key":"SOUR"}}}}
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/155
+    method: PUT
+  response:
+    body: '{"errors":[{"context":null,"message":"You are attempting to modify a pull
+      request based on out-of-date information.","exceptionName":"com.atlassian.bitbucket.pull.PullRequestOutOfDateException","currentVersion":6,"expectedVersion":1,"pullRequest":{"id":155,"version":6,"title":"This
+      is a new title","description":"This is a new body","state":"OPEN","open":true,"closed":false,"createdDate":1639650896484,"updatedDate":1639652173617,"fromRef":{"id":"refs/heads/hello-world-18","displayId":"hello-world-18","latestCommit":"e2c9d5c55e423f44ada99645132dd80da3904269","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"433511c512c568a6dbc308c2347879f9d6095849","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/155"}]}}}]}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 16 Dec 2021 10:59:19 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@9KC48Ux659x13091408x0'
+      X-Asessionid:
+      - 1im3mtm
+      X-Auserid:
+      - "104"
+      X-Ausername:
+      - thorsten
+      X-Content-Type-Options:
+      - nosniff
+    status: 409 Conflict
+    code: 409
+    duration: ""
+- request:
+    body: |
+      {"version":6,"title":"This is a new title","description":"This is a new body","toRef":{"id":"refs/heads/master","repository":{"id":0,"slug":"automation-testing","project":{"key":"SOUR"}}}}
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/155
+    method: PUT
+  response:
+    body: '{"id":155,"version":7,"title":"This is a new title","description":"This
+      is a new body","state":"OPEN","open":true,"closed":false,"createdDate":1639650896484,"updatedDate":1639652359748,"fromRef":{"id":"refs/heads/hello-world-18","displayId":"hello-world-18","latestCommit":"e2c9d5c55e423f44ada99645132dd80da3904269","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"433511c512c568a6dbc308c2347879f9d6095849","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/155"}]}}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 16 Dec 2021 10:59:19 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@9KC48Ux659x13091409x0'
+      X-Asessionid:
+      - 1tgf1pb
+      X-Auserid:
+      - "104"
+      X-Ausername:
+      - thorsten
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_UpdateChangeset_success.yaml
+++ b/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_UpdateChangeset_success.yaml
@@ -8,42 +8,33 @@ interactions:
     headers:
       Content-Type:
       - application/json; charset=utf-8
-    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/43
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/154
     method: PUT
   response:
-    body: '{"id":43,"version":6,"title":"This is a new title","description":"This
-      is a new body","state":"OPEN","open":true,"closed":false,"createdDate":1580213993810,"updatedDate":1585578260504,"fromRef":{"id":"refs/heads/milton/file1txt-1580213978330","displayId":"milton/file1txt-1580213978330","latestCommit":"58301dcfa4b81ac8dcca5c8fad4216532f702237","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"e833db3fe2bdbc28b58cd72def1b0078e77aa171","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"milton","emailAddress":"dev@sourcegraph.com","id":1,"displayName":"milton
-      woof","active":true,"slug":"milton","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/milton"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/43"}]}}'
+    body: '{"id":154,"version":6,"title":"This is a new title","description":"This
+      is a new body","state":"OPEN","open":true,"closed":false,"createdDate":1639582116883,"updatedDate":1639652359417,"fromRef":{"id":"refs/heads/hello-world","displayId":"hello-world","latestCommit":"fbb818b2ba432f906a8f5fa58cadcc74dc1bf865","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"433511c512c568a6dbc308c2347879f9d6095849","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/154"}]}}'
     headers:
       Cache-Control:
       - private, no-cache
       - no-cache, no-transform
-      Cf-Cache-Status:
-      - DYNAMIC
-      Cf-Ray:
-      - 57c27e5b5f98492d-CPT
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 30 Mar 2020 14:24:20 GMT
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      - Thu, 16 Dec 2021 10:59:19 GMT
       Pragma:
       - no-cache
       Server:
-      - cloudflare
+      - Caddy
       Vary:
-      - X-AUSERNAME,Accept-Encoding
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@MWNSEUx864x614641x0'
-      X-Asen:
-      - SEN-11363689
+      - '@9KC48Ux659x13091406x0'
       X-Asessionid:
-      - hfje0f
+      - ygdxwm
       X-Auserid:
-      - "1"
+      - "104"
       X-Ausername:
-      - milton
+      - thorsten
       X-Content-Type-Options:
       - nosniff
     status: 200 OK

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -610,9 +610,9 @@ func (c *Client) CreatePullRequest(ctx context.Context, pr *PullRequest) error {
 	_, err = c.send(ctx, "POST", path, nil, payload, pr)
 	if err != nil {
 		if IsDuplicatePullRequest(err) {
-			pr, extractErr := ExtractDuplicatePullRequest(err)
+			pr, extractErr := ExtractExistingPullRequest(err)
 			if extractErr != nil {
-				log15.Error("Extracting existsing PR", "err", extractErr)
+				log15.Error("Extracting existing PR", "err", extractErr)
 			}
 			return &ErrAlreadyExists{
 				Existing: pr,
@@ -1381,11 +1381,26 @@ func IsDuplicatePullRequest(err error) bool {
 	return errors.As(err, &e) && e.DuplicatePullRequest()
 }
 
-// ExtractDuplicatePullRequest will attempt to extract a duplicate PR
-func ExtractDuplicatePullRequest(err error) (*PullRequest, error) {
+func IsPullRequestOutOfDate(err error) bool {
+	var e *httpError
+	return errors.As(err, &e) && e.PullRequestOutOfDateException()
+}
+
+// ExtractExistingPullRequest will attempt to extract the existing PR returned with an error.
+func ExtractExistingPullRequest(err error) (*PullRequest, error) {
 	var e *httpError
 	if errors.As(err, &e) {
 		return e.ExtractExistingPullRequest()
+	}
+
+	return nil, errors.Errorf("error does not contain existing PR")
+}
+
+// ExtractPullRequest will attempt to extract the PR returned with an error.
+func ExtractPullRequest(err error) (*PullRequest, error) {
+	var e *httpError
+	if errors.As(err, &e) {
+		return e.ExtractPullRequest()
 	}
 
 	return nil, errors.Errorf("error does not contain existing PR")
@@ -1425,12 +1440,19 @@ func (e *httpError) MergePreconditionFailedException() bool {
 	return e.StatusCode == 409
 }
 
+func (e *httpError) PullRequestOutOfDateException() bool {
+	return strings.Contains(string(e.Body), bitbucketPullRequestOutOfDateException)
+}
+
 const (
-	bitbucketDuplicatePRException       = "com.atlassian.bitbucket.pull.DuplicatePullRequestException"
-	bitbucketNoSuchLabelException       = "com.atlassian.bitbucket.label.NoSuchLabelException"
-	bitbucketNoSuchPullRequestException = "com.atlassian.bitbucket.pull.NoSuchPullRequestException"
+	bitbucketDuplicatePRException          = "com.atlassian.bitbucket.pull.DuplicatePullRequestException"
+	bitbucketNoSuchLabelException          = "com.atlassian.bitbucket.label.NoSuchLabelException"
+	bitbucketNoSuchPullRequestException    = "com.atlassian.bitbucket.pull.NoSuchPullRequestException"
+	bitbucketPullRequestOutOfDateException = "com.atlassian.bitbucket.pull.PullRequestOutOfDateException"
 )
 
+// ExtractExistingPullRequest will try to extract a PullRequest from the
+// ExistingPullRequest field of the first Error in the response body.
 func (e *httpError) ExtractExistingPullRequest() (*PullRequest, error) {
 	var dest struct {
 		Errors []struct {
@@ -1451,6 +1473,29 @@ func (e *httpError) ExtractExistingPullRequest() (*PullRequest, error) {
 	}
 
 	return nil, errors.New("existing PR not found")
+}
+
+// ExtractPullRequest will try to extract a PullRequest from the
+// PullRequest field of the first Error in the response body.
+func (e *httpError) ExtractPullRequest() (*PullRequest, error) {
+	var dest struct {
+		Errors []struct {
+			ExceptionName string
+			// This is different from ExistingPullRequest
+			PullRequest PullRequest
+		}
+	}
+
+	err := json.Unmarshal(e.Body, &dest)
+	if err != nil {
+		return nil, errors.Wrap(err, "unmarshalling error")
+	}
+
+	if len(dest.Errors) == 0 {
+		return nil, errors.New("existing PR not found")
+	}
+
+	return &dest.Errors[0].PullRequest, nil
 }
 
 // AuthenticatedUsername returns the username associated with the credentials

--- a/internal/extsvc/bitbucketserver/client_test.go
+++ b/internal/extsvc/bitbucketserver/client_test.go
@@ -1003,11 +1003,11 @@ func TestClient_MergePullRequest(t *testing.T) {
 			name: "not mergeable",
 			pr: func() *PullRequest {
 				pr := *pr
-				pr.ID = 146
-				pr.Version = 1
+				pr.ID = 154
+				pr.Version = 16
 				return &pr
 			},
-			err: "pull request cannot be merged",
+			err: "com.atlassian.bitbucket.pull.PullRequestMergeVetoedException",
 		},
 	} {
 		tc := tc

--- a/internal/extsvc/bitbucketserver/testdata/vcr/MergePullRequest-not-mergeable.yaml
+++ b/internal/extsvc/bitbucketserver/testdata/vcr/MergePullRequest-not-mergeable.yaml
@@ -7,13 +7,11 @@ interactions:
     headers:
       Content-Type:
       - application/json; charset=utf-8
-    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/146/merge?version=1
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/154/merge?version=16
     method: POST
   response:
-    body: '{"errors":[{"context":null,"message":"You are attempting to modify a pull
-      request based on out-of-date information.","exceptionName":"com.atlassian.bitbucket.pull.PullRequestOutOfDateException","currentVersion":2,"expectedVersion":1,"pullRequest":{"id":146,"version":2,"title":"file3.txt
-      edited online with Bitbucket","state":"MERGED","open":false,"closed":true,"createdDate":1623421327682,"updatedDate":1623421519622,"closedDate":1623421519622,"fromRef":{"id":"refs/heads/erik/file3txt-1623421319662","displayId":"erik/file3txt-1623421319662","latestCommit":"88e8840c12b7fba586f7e8aeb360d3dd638e7888","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"2475733b17fc2d527bb29e5f45540e76a8c3a9b6","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"erik","emailAddress":"erik@sourcegraph.com","id":152,"displayName":"Erik
-      Seliger","active":true,"slug":"erik","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/erik"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[{"user":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"role":"REVIEWER","approved":false,"status":"UNAPPROVED"}],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/146"}]}}}]}'
+    body: '{"errors":[{"context":null,"message":"The pull request has conflicts and
+      cannot be merged.","exceptionName":"com.atlassian.bitbucket.pull.PullRequestMergeVetoedException","conflicted":true,"vetoes":[]}]}'
     headers:
       Cache-Control:
       - private, no-cache
@@ -21,7 +19,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 11 Jun 2021 14:26:46 GMT
+      - Fri, 17 Dec 2021 11:10:30 GMT
       Pragma:
       - no-cache
       Server:
@@ -29,13 +27,13 @@ interactions:
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@TVP4VKx866x2732650x0'
+      - '@9KC48Ux670x13422639x1'
       X-Asessionid:
-      - 1isoou6
+      - 1bnzm6l
       X-Auserid:
-      - "152"
+      - "104"
       X-Ausername:
-      - erik
+      - thorsten
       X-Content-Type-Options:
       - nosniff
     status: 409 Conflict


### PR DESCRIPTION
This fixes #28962 by changing the `BitbucketServerSource` to retry the
`UpdatePullRequest` if it failed because the local copy of the
Sourcegraph pull request is outdated.

If we don't do that, we're trapped in a deadlock between the reconciler
and the syncer: the reconciler tries to update the PR and keeps failing
because the local copy is outdated and the syncer won't update the local
copy because the reconciler never sets the `changeset` to `completed`.

What the change here does is to "force" the update by using the newest
version that the server returns with its error and sending that along
with the update request.

That might sound questionable, but it's what we do for other code hosts
as well and is, essentially, how Batch Changes are supposed to work:
users describe the desired state in their batch spec and Sourcegraph
tries its best to make that happen. This is no different than how we
already overwrite commits that someone has pushed to a branch if a spec
is applied again.