### PR TITLE
Add sample rate for symbols service.

### DIFF
--- a/cmd/symbols/main.go
+++ b/cmd/symbols/main.go
@@ -80,7 +80,8 @@ func main() {
 		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
 		Registerer: prometheus.DefaultRegisterer,
 		HoneyDataset: &honey.Dataset{
-			Name: "codeintel-symbols",
+			Name:       "codeintel-symbols",
+			SampleRate: 5,
 		},
 	}
 


### PR DESCRIPTION
Noah mentioned that he got an email from Honeycomb about the symbols
service exceeding the rate limit.