### PR TITLE
sg setup: fix wrong number in header when showing category

### DIFF
--- a/dev/sg/sg_setup.go
+++ b/dev/sg/sg_setup.go
@@ -699,7 +699,7 @@ func getBool() bool {
 }
 
 func presentFailedCategoryWithOptions(ctx context.Context, categoryIdx int, category *dependencyCategory) error {
-	printCategoryHeaderAndDependencies(categoryIdx, category)
+	printCategoryHeaderAndDependencies(categoryIdx+1, category)
 
 	choices := map[int]string{1: "I want to fix these manually"}
 	if category.autoFixing {


### PR DESCRIPTION
This fixes the problem reported in https://github.com/sourcegraph/sourcegraph/pull/27563#discussion_r770109610

Turns out it's just the wrong header that's printed.