### PR TITLE
search: fix repo stats aggregation in HorizontalSearcher

### DIFF
--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -355,6 +355,7 @@ func (s *HorizontalSearcher) List(ctx context.Context, q query.Q, opts *zoekt.Li
 
 		aggregate.Repos = append(aggregate.Repos, r.rl.Repos...)
 		aggregate.Crashes += r.rl.Crashes
+		aggregate.Stats.Add(&r.rl.Stats)
 
 		for k, v := range r.rl.Minimal {
 			aggregate.Minimal[k] = v


### PR DESCRIPTION
I missed this in #28977, so we were still not showing the right lines of
code stats in the site admin overview.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
