### PR TITLE
batches: validate name match in batch spec editor

### DIFF
--- a/client/web/src/enterprise/batches/BatchSpec.tsx
+++ b/client/web/src/enterprise/batches/BatchSpec.tsx
@@ -23,11 +23,17 @@ const isJSON = (string: string): boolean => {
 export const getFileName = (name: string): string => `${kebabCase(name)}.batch.yaml`
 
 export interface BatchSpecProps extends ThemeProps {
+    name: string
     originalInput: BatchChangeFields['currentSpec']['originalInput']
     className?: string
 }
 
-export const BatchSpec: React.FunctionComponent<BatchSpecProps> = ({ originalInput, isLightTheme, className }) => {
+export const BatchSpec: React.FunctionComponent<BatchSpecProps> = ({
+    originalInput,
+    isLightTheme,
+    className,
+    name,
+}) => {
     // JSON is valid YAML, so the input might be JSON. In that case, we'll highlight and indent it
     // as JSON. This is especially nice when the input is a "minified" (no extraneous whitespace)
     // JSON document that's difficult to read unless indented.
@@ -37,7 +43,15 @@ export const BatchSpec: React.FunctionComponent<BatchSpecProps> = ({ originalInp
         originalInput,
     ])
 
-    return <MonacoBatchSpecEditor isLightTheme={isLightTheme} value={input} readOnly={true} className={className} />
+    return (
+        <MonacoBatchSpecEditor
+            batchChangeName={name}
+            isLightTheme={isLightTheme}
+            value={input}
+            readOnly={true}
+            className={className}
+        />
+    )
 }
 
 interface BatchSpecDownloadLinkProps extends BatchSpecProps, Pick<BatchChangeFields, 'name'> {

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -219,7 +219,8 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({
 
     // Manage the batch spec input YAML code that's being edited.
     const { code, debouncedCode, isValid, handleCodeChange, excludeRepo, errors: codeErrors } = useBatchSpecCode(
-        initialBatchSpecCode
+        initialBatchSpecCode,
+        batchChange.name
     )
 
     // Track whenever the batch spec code that is presently in the editor is newer than
@@ -355,6 +356,7 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({
                 <div className={styles.editorContainer}>
                     <h4>Batch spec</h4>
                     <MonacoBatchSpecEditor
+                        batchChangeName={batchChange.name}
                         className={styles.editor}
                         isLightTheme={isLightTheme}
                         value={code}

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
@@ -166,6 +166,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<BatchChangeDetailsT
                 </div>
                 <Container>
                     <BatchSpec
+                        name={batchChange.name}
                         originalInput={batchChange.currentSpec.originalInput}
                         isLightTheme={isLightTheme}
                         className={styles.batchSpec}

--- a/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
@@ -115,7 +115,13 @@ export const BatchSpecExecutionDetailsPage: React.FunctionComponent<BatchSpecExe
                 <Route render={() => <Redirect to={`${match.url}/execution`} />} path={match.url} exact={true} />
                 <Route
                     path={`${match.url}/edit`}
-                    render={() => <EditPage content={batchSpec.originalInput} isLightTheme={isLightTheme} />}
+                    render={() => (
+                        <EditPage
+                            name={batchSpec.description.name}
+                            content={batchSpec.originalInput}
+                            isLightTheme={isLightTheme}
+                        />
+                    )}
                     exact={true}
                 />
                 <Route
@@ -317,12 +323,13 @@ const WorkspaceStat: React.FunctionComponent<{ stat: number; label: string; icon
 )
 
 interface EditPageProps extends ThemeProps {
+    name: string
     content: string
 }
 
-const EditPage: React.FunctionComponent<EditPageProps> = ({ content, isLightTheme }) => (
+const EditPage: React.FunctionComponent<EditPageProps> = ({ name, content, isLightTheme }) => (
     <div className={classNames(styles.layoutContainer, 'h-100')}>
-        <BatchSpec originalInput={content} isLightTheme={isLightTheme} className={styles.batchSpec} />
+        <BatchSpec name={name} originalInput={content} isLightTheme={isLightTheme} className={styles.batchSpec} />
     </div>
 )
 

--- a/client/web/src/enterprise/batches/preview/BatchChangePreviewTabs.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchChangePreviewTabs.tsx
@@ -99,6 +99,7 @@ export const BatchChangePreviewTabs: React.FunctionComponent<BatchChangePreviewT
                 </div>
                 <Container>
                     <BatchSpec
+                        name={spec.description.name}
                         originalInput={spec.originalInput}
                         isLightTheme={isLightTheme}
                         className={styles.batchSpec}

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -191,6 +191,8 @@ func (s *Service) CreateEmptyBatchChange(ctx context.Context, opts CreateEmptyBa
 	}
 
 	// The combination of name + namespace must be unique
+	// TODO: Should name be case-insensitive unique? i.e. should "foo" and "Foo"
+	// be considered unique?
 	batchChange, err = s.GetBatchChangeMatchingBatchSpec(ctx, batchSpec)
 	if err != nil {
 		return nil, err
@@ -637,6 +639,7 @@ func (s *Service) GetBatchChangeMatchingBatchSpec(ctx context.Context, spec *bty
 	ctx, endObservation := s.operations.getBatchChangeMatchingBatchSpec.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
+	// TODO: Should name be case-insensitive? i.e. are "foo" and "Foo" the same?
 	opts := store.GetBatchChangeOpts{
 		Name:            spec.Spec.Name,
 		NamespaceUserID: spec.NamespaceUserID,

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -171,6 +171,7 @@ func (s *Service) CreateEmptyBatchChange(ctx context.Context, opts CreateEmptyBa
 	if err != nil {
 		return nil, errors.Wrap(err, "marshalling name")
 	}
+	// TODO: Should name require a minimum length?
 	spec, err := batcheslib.ParseBatchSpec(rawSpec, batcheslib.ParseBatchSpecOptions{})
 	if err != nil {
 		return nil, err

--- a/lib/batches/schema/batch_spec_stringdata.go
+++ b/lib/batches/schema/batch_spec_stringdata.go
@@ -2,8 +2,6 @@
 
 package schema
 
-// TODO: Should name require a minimum length?
-
 // BatchSpecJSON is the content of the file "../../../schema/batch_spec.schema.json".
 const BatchSpecJSON = `{
   "$id": "batch_spec.schema.json#",

--- a/lib/batches/schema/batch_spec_stringdata.go
+++ b/lib/batches/schema/batch_spec_stringdata.go
@@ -2,6 +2,8 @@
 
 package schema
 
+// TODO: Should name require a minimum length?
+
 // BatchSpecJSON is the content of the file "../../../schema/batch_spec.schema.json".
 const BatchSpecJSON = `{
   "$id": "batch_spec.schema.json#",


### PR DESCRIPTION
One of the last pieces for EM2.4. This will use the batch change name to dynamically produce the batch spec schema JSON with an exact match pattern for the name. The spec code will be considered invalid unless the name matches:

![image](https://user-images.githubusercontent.com/8942601/146436100-7a83978b-3a1d-4d94-89a9-109b08373fbb.png)

I also added comments for us to remember to think about if the name should have a minimum length requirement and be case-sensitive later. 🙂