### PR TITLE
Add pgcrypto extension to required extensions

### DIFF
--- a/doc/admin/postgres.md
+++ b/doc/admin/postgres.md
@@ -22,6 +22,7 @@ hstore
 intarray
 pg_stat_statements
 pg_trgm
+pgcrypto
 ```
 
 ## [Configuring PostgreSQL](./config/postgres-conf.md)


### PR DESCRIPTION
This was added recently but not updated in docs here.