### PR TITLE
zoekt: relax alert threshold for get_indexing_options from 10 to 20 min

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -4601,7 +4601,7 @@ with your code hosts connections or networking issues affecting communication wi
 **Descriptions**
 
 - <span class="badge badge-warning">warning</span> zoekt-indexserver: 100+ the number of repositories we failed to get indexing options over 5m for 1m0s
-- <span class="badge badge-critical">critical</span> zoekt-indexserver: 100+ the number of repositories we failed to get indexing options over 5m for 10m0s
+- <span class="badge badge-critical">critical</span> zoekt-indexserver: 100+ the number of repositories we failed to get indexing options over 5m for 20m0s
 
 **Possible solutions**
 

--- a/monitoring/definitions/zoekt_index_server.go
+++ b/monitoring/definitions/zoekt_index_server.go
@@ -100,7 +100,7 @@ func ZoektIndexServer() *monitoring.Container {
 							// This value can spike, so only if we have a
 							// sustained error rate do we alert.
 							Warning:  monitoring.Alert().GreaterOrEqual(100, nil).For(time.Minute),
-							Critical: monitoring.Alert().GreaterOrEqual(100, nil).For(10 * time.Minute),
+							Critical: monitoring.Alert().GreaterOrEqual(100, nil).For(20 * time.Minute),
 							Panel:    monitoring.Panel().Min(0),
 							Owner:    monitoring.ObservableOwnerSearchCore,
 							PossibleSolutions: `


### PR DESCRIPTION
gitserver isn't HA, so `critical_zoekt-indexserver_get_index_opt` ends up firing whenever gitserver is unavailable during a rollout.

@sourcegraph/repo-management  team has HA gitserver on their roadmap, so we're relaxing the alerting threshold to reduce fatigue until that lands.

See https://sourcegraph.slack.com/archives/C023ELQLV7F/p1639650293294000 for more context.