### PR TITLE
insights: change metrics prefix for oob migrator to avoid collisions with codeinsights db

### DIFF
--- a/enterprise/internal/insights/insights.go
+++ b/enterprise/internal/insights/insights.go
@@ -88,7 +88,7 @@ func RegisterMigrations(db database.DB, outOfBandMigrationRunner *oobmigration.R
 		return nil
 	}
 
-	timescale, err := InitializeCodeInsightsDB("worker")
+	timescale, err := InitializeCodeInsightsDB("worker-oobmigrator")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix a metrics collision after `oob-migrator` moved to `worker`

