### PR TITLE
Code Insights: [FE] Do not respect context filters in the 1 click creation flow

### DIFF
--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.test.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.test.ts
@@ -11,14 +11,25 @@ describe('getInsightDataFromQuery', () => {
     })
 
     describe('should return correct insight values ', () => {
-        it('with repo: and "test" pattern query', () => {
+        it('removes context from the query', () => {
             const queryString = 'context:global test repo:^github\\.com/sourcegraph/sourcegraph$  patterntype:literal'
 
             const result = getInsightDataFromQuery(queryString)
 
             expect(result).toStrictEqual({
                 repositories: ['^github\\.com/sourcegraph/sourcegraph$'],
-                seriesQuery: 'context:global test patterntype:literal',
+                seriesQuery: 'test patterntype:literal',
+            })
+        })
+
+        it('with repo: and "test" pattern query', () => {
+            const queryString = 'test repo:^github\\.com/sourcegraph/sourcegraph$  patterntype:literal'
+
+            const result = getInsightDataFromQuery(queryString)
+
+            expect(result).toStrictEqual({
+                repositories: ['^github\\.com/sourcegraph/sourcegraph$'],
+                seriesQuery: 'test patterntype:literal',
             })
         })
 
@@ -30,7 +41,7 @@ describe('getInsightDataFromQuery', () => {
 
             expect(result).toStrictEqual({
                 repositories: ['^github\\.com/sourcegraph/sourcegraph$', '^github\\.com/sourcegraph/about'],
-                seriesQuery: 'context:global test patterntype:literal',
+                seriesQuery: 'test patterntype:literal',
             })
         })
 
@@ -42,7 +53,7 @@ describe('getInsightDataFromQuery', () => {
 
             expect(result).toStrictEqual({
                 repositories: ['^github\\.com/sourcegraph/sourcegraph$|^github\\.com/sourcegraph/about'],
-                seriesQuery: 'context:global test patterntype:literal',
+                seriesQuery: 'test patterntype:literal',
             })
         })
 
@@ -54,7 +65,7 @@ describe('getInsightDataFromQuery', () => {
 
             expect(result).toStrictEqual({
                 repositories: ['^github\\.com/sourcegraph/sourcegraph$'],
-                seriesQuery: 'context:global "repo: " patterntype:literal',
+                seriesQuery: '"repo: " patterntype:literal',
             })
         })
     })

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.ts
@@ -1,9 +1,10 @@
 import { useContext, useEffect, useState } from 'react'
 
+import { FilterType } from '@sourcegraph/shared/out/src/search/query/filters'
 import { stringHuman } from '@sourcegraph/shared/src/search/query/printer'
 import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
-import { isRepoFilter } from '@sourcegraph/shared/src/search/query/validate'
-import { ErrorLike, asError } from '@sourcegraph/shared/src/util/errors'
+import { isFilterType, isRepoFilter } from '@sourcegraph/shared/src/search/query/validate'
+import { asError, ErrorLike } from '@sourcegraph/shared/src/util/errors'
 import { dedupeWhitespace } from '@sourcegraph/shared/src/util/strings'
 
 import { CodeInsightsBackendContext } from '../../../../../../core/backend/code-insights-backend-context'
@@ -49,11 +50,14 @@ export function getInsightDataFromQuery(searchQuery: string): InsightData {
 
     // Generate a string query from tokens without repo: filters for the insight
     // query field.
-    const tokensWithoutRepoFilters = tokens.filter(token => !isRepoFilter(token))
-    const humanReadableQueryString = stringHuman(tokensWithoutRepoFilters)
+    const tokensWithoutRepoFiltersAndContext = tokens.filter(
+        token => !isRepoFilter(token) && !isFilterType(token, FilterType.context)
+    )
+
+    const humanReadableQueryString = stringHuman(tokensWithoutRepoFiltersAndContext)
 
     return {
-        seriesQuery: dedupeWhitespace(humanReadableQueryString),
+        seriesQuery: dedupeWhitespace(humanReadableQueryString.trim()),
         repositories,
     }
 }

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.ts
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useState } from 'react'
 
-import { FilterType } from '@sourcegraph/shared/out/src/search/query/filters'
+import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
 import { stringHuman } from '@sourcegraph/shared/src/search/query/printer'
 import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
 import { isFilterType, isRepoFilter } from '@sourcegraph/shared/src/search/query/validate'


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/29133

## How to test
1. Create context
2. Set custom context for code search 
3. Try to search repo: any repo from your context here <some search query>
4. Click create code insights
5. See that your repo: filter has been resolved and you see repository from this filter in the repositories field and also see that you don't have context: filter in the search query field