### PR TITLE
codeintel: Check nil before dereference in graphql layer

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
@@ -327,9 +327,11 @@ func (r *Resolver) ConfigurationPolicyByID(ctx context.Context, id graphql.ID) (
 
 // 🚨 SECURITY: dbstore layer handles authz for GetConfigurationPolicies
 func (r *Resolver) CodeIntelligenceConfigurationPolicies(ctx context.Context, args *gql.CodeIntelligenceConfigurationPoliciesArgs) (_ gql.CodeIntelligenceConfigurationPolicyConnectionResolver, err error) {
-	ctx, traceErrs, endObservation := r.observationContext.configurationPolicies.WithErrors(ctx, &err, observation.Args{LogFields: []log.Field{
-		log.String("repoID", string(*args.Repository)),
-	}})
+	fields := []log.Field{}
+	if args.Repository != nil {
+		fields = append(fields, log.String("repoID", string(*args.Repository)))
+	}
+	ctx, traceErrs, endObservation := r.observationContext.configurationPolicies.WithErrors(ctx, &err, observation.Args{LogFields: fields})
 	endObservation.OnCancel(ctx, 1, observation.Args{})
 
 	offset, err := graphqlutil.DecodeIntCursor(args.After)


### PR DESCRIPTION
This currently panics in the UI. See https://sourcegraph.com/site-admin/code-intelligence/configuration?trace=1.