### PR TITLE
zoekt: surface dashboard to show difference between repos assigned v. tracked

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -12210,6 +12210,33 @@ Query: `sum(index_queue_len)`
 
 <br />
 
+#### zoekt-indexserver: indexed_queue_diff_assigned_tracked
+
+<p class="subtitle"># repos assigned - # repos tracked</p>
+
+zoekt-indexserver`s queue keeps track of all of its repositories, including those it has already finished processing.
+
+If there is a difference between
+- the number of repos that has been assigned to Zoekt, and
+- the number of repos that the queue thinks that it`s tracking
+
+, then there is likely _some_ sort of bug.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100110` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `index_num_assigned - index_queue_cap`
+
+</details>
+
+<br />
+
 ### Zoekt Index Server: Container monitoring (not available on server)
 
 #### zoekt-indexserver: container_missing

--- a/monitoring/definitions/zoekt_index_server.go
+++ b/monitoring/definitions/zoekt_index_server.go
@@ -135,6 +135,25 @@ func ZoektIndexServer() *monitoring.Container {
 							Interpretation: "A queue that is constantly growing could be a leading indicator of a bottleneck or under-provisioning",
 						},
 					},
+					{
+						{
+							Name:        "indexed_queue_diff_assigned_tracked",
+							Description: "# repos assigned - # repos tracked",
+							Query:       "index_num_assigned - index_queue_cap",
+							NoAlert:     true,
+							Panel:       monitoring.Panel().MinAuto().LegendFormat("difference [{{instance}}]"),
+							Owner:       monitoring.ObservableOwnerSearchCore,
+							Interpretation: `
+								zoekt-indexserver's queue keeps track of all of its repositories, including those it has already finished processing.
+
+								If there is a difference between
+								- the number of repos that has been assigned to Zoekt, and
+								- the number of repos that the queue thinks that it's tracking
+
+								, then there is likely _some_ sort of bug.
+							`,
+						},
+					},
 				},
 			},
 


### PR DESCRIPTION
Context:

> [zoekt-indexserver's queue] isn't a normal queue (ie a double linked list), it really is more of a simple scheduler. It is a priority queue, but it keeps track of repos which has already been popped off the queue. This is so it can assign a higher priority if a repo gets back in the queue if the commit needed to index changes / the last index failed / etc. As the help describes, t**his should be the same size as the number of repos assigned to the host**. So seeing this value is more useful for **confirming there aren't bugs**. Maybe a less prominent dashboard showing the difference between num assigned and this metric?

![Screen Shot 2021-12-16 at 3 41 06 PM](https://user-images.githubusercontent.com/9022011/146465230-dfb08b39-dea4-4831-8558-906f2c7cc90c.png)

I could create a new row for this dashboard and hide it by default, but maybe it's worth showing more prominently if there if this is already showing a bug in my local instance 😅 