### PR TITLE
Update the example use case for search insights

### DIFF
--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.tsx
@@ -48,7 +48,7 @@ const CardBody: React.FunctionComponent<{ title: string }> = props => {
 }
 
 export const SearchInsightCard: React.FunctionComponent<CardProps> = props => (
-    <Card {...props} footerText="Redis, PostgreSQL and SQLite database usage.">
+    <Card {...props} footerText="Tracking architecture, naming, or language migrations.">
         <SearchBasedInsightChart className={styles.chart} />
         <CardBody title="Track">
             Insight <b>based on a custom Sourcegraph search query</b> that creates visualization of the data series you


### PR DESCRIPTION
IMO this is a better description of the more common use cases we see, like python 2->3 migration, CSS modules migration, "whitelist/blacklist" -> denylist/allowlist migration, pants->bazel migration, kotlin<>java migrations, etc. 

Same length as other example for line-wrap parity (from browser console): 

![image](https://user-images.githubusercontent.com/11967660/146470852-fdf632cd-e051-4b47-a015-83ae1d9f1dd2.png)
