### PR TITLE
ssbc: Don't access cache when workspaces are skipped

### DIFF
--- a/enterprise/internal/batches/background/batch_spec_workspace_creator.go
+++ b/enterprise/internal/batches/background/batch_spec_workspace_creator.go
@@ -106,6 +106,12 @@ func (r *batchSpecWorkspaceCreator) process(
 		if spec.NoCache {
 			continue
 		}
+		if !spec.AllowIgnored && w.Ignored {
+			continue
+		}
+		if !spec.AllowUnsupported && w.Unsupported {
+			continue
+		}
 
 		r := batcheslib.Repository{
 			ID:          string(graphqlbackend.MarshalRepositoryID(w.Repo.ID)),


### PR DESCRIPTION
Could use a test, but should land before tomorrow evening (Friday, branch cut) so opening for early feedback already.