### PR TITLE
zoekt: expose dashboard for results of indexing jobs

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -12187,6 +12187,34 @@ Query: `sum(increase(get_index_options_error_total[5m]))`
 
 <br />
 
+#### zoekt-indexserver: indexed_job_results
+
+<p class="subtitle">Aggregate results of index jobs</p>
+
+This dashboard shows the outcomes of recently completed indexing jobs:
+
+Legend:
+- fail -> the indexing jobs failed
+- success -> the indexing job succeeded and the index was updated
+- success_meta -> the indexing job successed, but only metadata was updated
+- noop -> the indexing job succeed, but we didn`t need to update anything
+- empty -> the indexing job succeeded, but the index was empty (i.e. the repository is empty)
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100030` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum by (state) (index_state_count)`
+
+</details>
+
+<br />
+
 ### Zoekt Index Server: Indexing queue statistics
 
 #### zoekt-indexserver: indexed_queue_size

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -12078,27 +12078,6 @@ Query: `sum(index_num_assigned)`
 
 <br />
 
-#### zoekt-indexserver: repo_index_state
-
-<p class="subtitle">Indexing results over 5m (noop=no changes, empty=no branches to index)</p>
-
-A persistent failing state indicates some repositories cannot be indexed, perhaps due to size and timeouts.
-
-This panel has no related alerts.
-
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100010` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `sum by (state) (increase(index_repo_seconds_count[5m]))`
-
-</details>
-
-<br />
-
 #### zoekt-indexserver: repo_index_success_speed
 
 <p class="subtitle">Successful indexing durations</p>
@@ -12107,7 +12086,7 @@ Latency increases can indicate bottlenecks in the indexserver.
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100011` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100010` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12128,7 +12107,7 @@ Failures happening after a long time indicates timeouts.
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100012` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100011` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12187,11 +12166,13 @@ Query: `sum(increase(get_index_options_error_total[5m]))`
 
 <br />
 
-#### zoekt-indexserver: indexed_job_results
+### Zoekt Index Server: Indexing results
 
-<p class="subtitle">Aggregate results of index jobs (all instances)</p>
+#### zoekt-indexserver: indexed_job_results_all_instances
 
-This dashboard shows the outcomes of recently completed indexing jobs:
+<p class="subtitle">Index result state counts (aggregate)</p>
+
+This dashboard shows the outcomes of recently completed indexing jobs across all index-server instances.
 
 Legend:
 - fail -> the indexing jobs failed
@@ -12202,24 +12183,26 @@ Legend:
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100030` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100100` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (state) (index_state_count)`
+Query: `sum by (state) (index_state_count{state=~`${indexState:regex}`})`
 
 </details>
 
 <br />
 
-#### zoekt-indexserver: indexed_job_results_by_instance
+#### zoekt-indexserver: indexed_job_results_per_instance
 
-<p class="subtitle">Aggregate results of index jobs (per instance)</p>
+<p class="subtitle">Index result state counts (per instance)</p>
 
-This dashboard shows the outcomes of recently completed indexing jobs:
+This dashboard shows the outcomes of recently completed indexing jobs, split out across each index-server instance.
+
+You can use the "shard" filter at the top of the page to select a particular instance.
 
 Legend:
 - fail -> the indexing jobs failed
@@ -12230,14 +12213,56 @@ Legend:
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100031` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100101` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (instance, state) (index_state_count{instance=~"${shard:regex}"})`
+Query: `sum by (instance, state) (index_state_count{state=~`${indexState:regex}`,instance=~`${shard:regex}`})`
+
+</details>
+
+<br />
+
+#### zoekt-indexserver: repo_index_state
+
+<p class="subtitle">Index results duration over 5m (aggregate)</p>
+
+A persistent failing state indicates some repositories cannot be indexed, perhaps due to size and timeouts.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100110` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum by (state) (increase(index_repo_seconds_count{state=~`${indexState:regex}`}[5m]))`
+
+</details>
+
+<br />
+
+#### zoekt-indexserver: repo_index_state
+
+<p class="subtitle">Index results duration over 5m (per instance)</p>
+
+A persistent failing state indicates some repositories cannot be indexed, perhaps due to size and timeouts.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100111` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum by (instance, state) (increase(index_repo_seconds_count{state=~`${indexState:regex}`,instance=~`${shard:regex}`}[5m]))`
 
 </details>
 
@@ -12253,7 +12278,7 @@ A queue that is constantly growing could be a leading indicator of a bottleneck 
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100100` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100200` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12311,7 +12336,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100200` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100300` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12330,7 +12355,7 @@ Query: `count by(name) ((time() - container_last_seen{name=~"^zoekt-indexserver.
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-container-cpu-usage) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100201` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100301` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12349,7 +12374,7 @@ Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^zoekt-indexserver.
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-container-memory-usage) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100202` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100302` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12371,7 +12396,7 @@ When extremely high, this can indicate a resource usage problem, or can cause pr
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100203` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100303` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Core application team](https://handbook.sourcegraph.com/engineering/core-application).*</sub>
 
@@ -12392,7 +12417,7 @@ Query: `sum by(name) (rate(container_fs_reads_total{name=~"^zoekt-indexserver.*"
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-cpu-usage-long-term) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100300` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100400` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12411,7 +12436,7 @@ Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{na
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-memory-usage-long-term) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100301` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100401` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12430,7 +12455,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^z
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-cpu-usage-short-term) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100310` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100410` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12449,7 +12474,7 @@ Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^zoek
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-memory-usage-short-term) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100311` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100411` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12470,7 +12495,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^z
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-pods-available-percentage) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100400` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100500` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -12189,14 +12189,14 @@ Query: `sum(increase(get_index_options_error_total[5m]))`
 
 #### zoekt-indexserver: indexed_job_results
 
-<p class="subtitle">Aggregate results of index jobs</p>
+<p class="subtitle">Aggregate results of index jobs (all instances)</p>
 
 This dashboard shows the outcomes of recently completed indexing jobs:
 
 Legend:
 - fail -> the indexing jobs failed
 - success -> the indexing job succeeded and the index was updated
-- success_meta -> the indexing job successed, but only metadata was updated
+- success_meta -> the indexing job succeeded, but only metadata was updated
 - noop -> the indexing job succeed, but we didn`t need to update anything
 - empty -> the indexing job succeeded, but the index was empty (i.e. the repository is empty)
 
@@ -12210,6 +12210,34 @@ To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver
 <summary>Technical details</summary>
 
 Query: `sum by (state) (index_state_count)`
+
+</details>
+
+<br />
+
+#### zoekt-indexserver: indexed_job_results_by_instance
+
+<p class="subtitle">Aggregate results of index jobs (per instance)</p>
+
+This dashboard shows the outcomes of recently completed indexing jobs:
+
+Legend:
+- fail -> the indexing jobs failed
+- success -> the indexing job succeeded and the index was updated
+- success_meta -> the indexing job succeeded, but only metadata was updated
+- noop -> the indexing job succeed, but we didn`t need to update anything
+- empty -> the indexing job succeeded, but the index was empty (i.e. the repository is empty)
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100031` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum by (instance, state) (index_state_count{instance=~"${shard:regex}"})`
 
 </details>
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -12168,11 +12168,13 @@ Query: `sum(increase(get_index_options_error_total[5m]))`
 
 ### Zoekt Index Server: Indexing results
 
-#### zoekt-indexserver: indexed_job_results_all_instances
+#### zoekt-indexserver: repo_index_state_aggregate
 
-<p class="subtitle">Index result state counts (aggregate)</p>
+<p class="subtitle">Index results state counts over 5m (aggregate)</p>
 
 This dashboard shows the outcomes of recently completed indexing jobs across all index-server instances.
+
+A persistent failing state indicates some repositories cannot be indexed, perhaps due to size and timeouts.
 
 Legend:
 - fail -> the indexing jobs failed
@@ -12190,19 +12192,21 @@ To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (state) (index_state_count{state=~`${indexState:regex}`})`
+Query: `sum by (state) (increase(index_repo_seconds_count[5m]))`
 
 </details>
 
 <br />
 
-#### zoekt-indexserver: indexed_job_results_per_instance
+#### zoekt-indexserver: repo_index_state_per_instance
 
-<p class="subtitle">Index result state counts (per instance)</p>
+<p class="subtitle">Index results state counts over 5m (per instance)</p>
 
 This dashboard shows the outcomes of recently completed indexing jobs, split out across each index-server instance.
 
-You can use the "shard" filter at the top of the page to select a particular instance.
+(You can use the "shard" filter at the top of the page to select a particular instance.)
+
+A persistent failing state indicates some repositories cannot be indexed, perhaps due to size and timeouts.
 
 Legend:
 - fail -> the indexing jobs failed
@@ -12220,49 +12224,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (instance, state) (index_state_count{state=~`${indexState:regex}`,instance=~`${shard:regex}`})`
-
-</details>
-
-<br />
-
-#### zoekt-indexserver: repo_index_state
-
-<p class="subtitle">Index results duration over 5m (aggregate)</p>
-
-A persistent failing state indicates some repositories cannot be indexed, perhaps due to size and timeouts.
-
-This panel has no related alerts.
-
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100110` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `sum by (state) (increase(index_repo_seconds_count{state=~`${indexState:regex}`}[5m]))`
-
-</details>
-
-<br />
-
-#### zoekt-indexserver: repo_index_state
-
-<p class="subtitle">Index results duration over 5m (per instance)</p>
-
-A persistent failing state indicates some repositories cannot be indexed, perhaps due to size and timeouts.
-
-This panel has no related alerts.
-
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100111` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `sum by (instance, state) (increase(index_repo_seconds_count{state=~`${indexState:regex}`,instance=~`${shard:regex}`}[5m]))`
+Query: `sum by (instance, state) (increase(index_repo_seconds_count{instance=~`${shard:regex}`}[5m]))`
 
 </details>
 
@@ -12270,9 +12232,9 @@ Query: `sum by (instance, state) (increase(index_repo_seconds_count{state=~`${in
 
 ### Zoekt Index Server: Indexing queue statistics
 
-#### zoekt-indexserver: indexed_queue_size
+#### zoekt-indexserver: indexed_queue_size_aggregate
 
-<p class="subtitle">Number of outstanding index jobs</p>
+<p class="subtitle"># of outstanding index jobs (aggregate)</p>
 
 A queue that is constantly growing could be a leading indicator of a bottleneck or under-provisioning
 
@@ -12286,6 +12248,27 @@ To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver
 <summary>Technical details</summary>
 
 Query: `sum(index_queue_len)`
+
+</details>
+
+<br />
+
+#### zoekt-indexserver: indexed_queue_size_per_instance
+
+<p class="subtitle"># of outstanding index jobs (per instance)</p>
+
+A queue that is constantly growing could be a leading indicator of a bottleneck or under-provisioning
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100201` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `index_queue_len{instance=~`${shard:regex}`}`
 
 </details>
 
@@ -12305,7 +12288,7 @@ If there is a difference between
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100110` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100210` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -12170,7 +12170,7 @@ Query: `sum(increase(get_index_options_error_total[5m]))`
 
 #### zoekt-indexserver: repo_index_state_aggregate
 
-<p class="subtitle">Index results state counts over 5m (aggregate)</p>
+<p class="subtitle">Index results state count over 5m (aggregate)</p>
 
 This dashboard shows the outcomes of recently completed indexing jobs across all index-server instances.
 
@@ -12200,11 +12200,11 @@ Query: `sum by (state) (increase(index_repo_seconds_count[5m]))`
 
 #### zoekt-indexserver: repo_index_state_per_instance
 
-<p class="subtitle">Index results state counts over 5m (per instance)</p>
+<p class="subtitle">Index results state count over 5m (per instance)</p>
 
 This dashboard shows the outcomes of recently completed indexing jobs, split out across each index-server instance.
 
-(You can use the "shard" filter at the top of the page to select a particular instance.)
+(You can use the "instance" filter at the top of the page to select a particular instance.)
 
 A persistent failing state indicates some repositories cannot be indexed, perhaps due to size and timeouts.
 
@@ -12224,7 +12224,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (instance, state) (increase(index_repo_seconds_count{instance=~`${shard:regex}`}[5m]))`
+Query: `sum by (instance, state) (increase(index_repo_seconds_count{instance=~`${instance:regex}`}[5m]))`
 
 </details>
 
@@ -12268,7 +12268,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver
 <details>
 <summary>Technical details</summary>
 
-Query: `index_queue_len{instance=~`${shard:regex}`}`
+Query: `index_queue_len{instance=~`${instance:regex}`}`
 
 </details>
 

--- a/monitoring/definitions/zoekt_index_server.go
+++ b/monitoring/definitions/zoekt_index_server.go
@@ -119,6 +119,26 @@ func ZoektIndexServer() *monitoring.Container {
 							`,
 						},
 					},
+					{
+						{
+							Name:        "indexed_job_results",
+							Description: "aggregate results of index jobs",
+							Query:       "sum by (state) (index_state_count)", // sum up the distinct states across all index-server replicas
+							NoAlert:     true,
+							Panel:       monitoring.Panel().LegendFormat("{{state}}"),
+							Owner:       monitoring.ObservableOwnerSearchCore,
+							Interpretation: `
+								This dashboard shows the outcomes of recently completed indexing jobs:
+
+								Legend:
+								- fail -> the indexing jobs failed
+								- success -> the indexing job succeeded and the index was updated
+								- success_meta -> the indexing job successed, but only metadata was updated
+								- noop -> the indexing job succeed, but we didn't need to update anything
+								- empty -> the indexing job succeeded, but the index was empty (i.e. the repository is empty)
+							`,
+						},
+					},
 				},
 			},
 			{

--- a/monitoring/definitions/zoekt_index_server.go
+++ b/monitoring/definitions/zoekt_index_server.go
@@ -35,19 +35,6 @@ func ZoektIndexServer() *monitoring.Container {
 				AllValue:   ".*",
 				Current:    sdk.Current{Text: &sdk.StringSliceString{Value: []string{"all"}, Valid: true}, Value: "$__all"},
 			},
-			{
-				Label:      "Index state",
-				Name:       "indexState",
-				Type:       "query",
-				Datasource: monitoring.StringPtr("Prometheus"),
-				Query:      "label_values(index_state_count, state)",
-				Multi:      true,
-				Refresh:    sdk.BoolInt{Flag: true, Value: monitoring.Int64Ptr(2)}, // Refresh on time range change
-				Sort:       3,
-				IncludeAll: true,
-				AllValue:   ".*",
-				Current:    sdk.Current{Text: &sdk.StringSliceString{Value: []string{"all"}, Valid: true}, Value: "$__all"},
-			},
 		},
 		Groups: []monitoring.Group{
 			{
@@ -142,53 +129,9 @@ func ZoektIndexServer() *monitoring.Container {
 				Rows: []monitoring.Row{
 					{
 						{
-							Name:        "indexed_job_results_all_instances",
-							Description: "index result state counts (aggregate)",
-							Query:       "sum by (state) (index_state_count{state=~`${indexState:regex}`})", // sum up the distinct states across all index-server replicas
-							NoAlert:     true,
-							Panel: monitoring.Panel().LegendFormat("{{state}}").With(func(o monitoring.Observable, p *sdk.Panel) {
-								p.GraphPanel.Legend.RightSide = true
-							}),
-							Owner: monitoring.ObservableOwnerSearchCore,
-							Interpretation: `
-								This dashboard shows the outcomes of recently completed indexing jobs across all index-server instances.
-
-								Legend:
-								- fail -> the indexing jobs failed
-								- success -> the indexing job succeeded and the index was updated
-								- success_meta -> the indexing job succeeded, but only metadata was updated
-								- noop -> the indexing job succeed, but we didn't need to update anything
-								- empty -> the indexing job succeeded, but the index was empty (i.e. the repository is empty)
-							`,
-						},
-						{
-							Name:        "indexed_job_results_per_instance",
-							Description: "index result state counts (per instance)",
-							Query:       "sum by (instance, state) (index_state_count{state=~`${indexState:regex}`,instance=~`${shard:regex}`})",
-							NoAlert:     true,
-							Panel: monitoring.Panel().LegendFormat("{{instance}} {{state}}").With(func(o monitoring.Observable, p *sdk.Panel) {
-								p.GraphPanel.Legend.RightSide = true
-							}),
-							Owner: monitoring.ObservableOwnerSearchCore,
-							Interpretation: `
-								This dashboard shows the outcomes of recently completed indexing jobs, split out across each index-server instance.
-
-								You can use the "shard" filter at the top of the page to select a particular instance.
-
-								Legend:
-								- fail -> the indexing jobs failed
-								- success -> the indexing job succeeded and the index was updated
-								- success_meta -> the indexing job succeeded, but only metadata was updated
-								- noop -> the indexing job succeed, but we didn't need to update anything
-								- empty -> the indexing job succeeded, but the index was empty (i.e. the repository is empty)
-							`,
-						},
-					},
-					{
-						{
-							Name:        "repo_index_state",
-							Description: "index results duration over 5m (aggregate)",
-							Query:       "sum by (state) (increase(index_repo_seconds_count{state=~`${indexState:regex}`}[5m]))",
+							Name:        "repo_index_state_aggregate",
+							Description: "index results state counts over 5m (aggregate)",
+							Query:       "sum by (state) (increase(index_repo_seconds_count[5m]))",
 							NoAlert:     true,
 							Owner:       monitoring.ObservableOwnerSearchCore,
 							Panel: monitoring.Panel().LegendFormat("{{state}}").With(func(o monitoring.Observable, p *sdk.Panel) {
@@ -196,12 +139,23 @@ func ZoektIndexServer() *monitoring.Container {
 								p.GraphPanel.Yaxes[0].LogBase = 2  // log to show the huge number of "noop" or "empty"
 								p.GraphPanel.Tooltip.Shared = true // show multiple lines simultaneously
 							}),
-							Interpretation: "A persistent failing state indicates some repositories cannot be indexed, perhaps due to size and timeouts.",
+							Interpretation: `
+							This dashboard shows the outcomes of recently completed indexing jobs across all index-server instances.
+
+							A persistent failing state indicates some repositories cannot be indexed, perhaps due to size and timeouts.
+
+							Legend:
+							- fail -> the indexing jobs failed
+							- success -> the indexing job succeeded and the index was updated
+							- success_meta -> the indexing job succeeded, but only metadata was updated
+							- noop -> the indexing job succeed, but we didn't need to update anything
+							- empty -> the indexing job succeeded, but the index was empty (i.e. the repository is empty)
+						`,
 						},
 						{
-							Name:        "repo_index_state",
-							Description: "index results duration over 5m (per instance)",
-							Query:       "sum by (instance, state) (increase(index_repo_seconds_count{state=~`${indexState:regex}`,instance=~`${shard:regex}`}[5m]))",
+							Name:        "repo_index_state_per_instance",
+							Description: "index results state counts over 5m (per instance)",
+							Query:       "sum by (instance, state) (increase(index_repo_seconds_count{instance=~`${shard:regex}`}[5m]))",
 							NoAlert:     true,
 							Owner:       monitoring.ObservableOwnerSearchCore,
 							Panel: monitoring.Panel().LegendFormat("{{instance}} {{state}}").With(func(o monitoring.Observable, p *sdk.Panel) {
@@ -209,7 +163,20 @@ func ZoektIndexServer() *monitoring.Container {
 								p.GraphPanel.Yaxes[0].LogBase = 2  // log to show the huge number of "noop" or "empty"
 								p.GraphPanel.Tooltip.Shared = true // show multiple lines simultaneously
 							}),
-							Interpretation: "A persistent failing state indicates some repositories cannot be indexed, perhaps due to size and timeouts.",
+							Interpretation: `
+							This dashboard shows the outcomes of recently completed indexing jobs, split out across each index-server instance.
+
+							(You can use the "shard" filter at the top of the page to select a particular instance.)
+
+							A persistent failing state indicates some repositories cannot be indexed, perhaps due to size and timeouts.
+
+							Legend:
+							- fail -> the indexing jobs failed
+							- success -> the indexing job succeeded and the index was updated
+							- success_meta -> the indexing job succeeded, but only metadata was updated
+							- noop -> the indexing job succeed, but we didn't need to update anything
+							- empty -> the indexing job succeeded, but the index was empty (i.e. the repository is empty)
+						`,
 						},
 					},
 				},
@@ -219,11 +186,20 @@ func ZoektIndexServer() *monitoring.Container {
 				Rows: []monitoring.Row{
 					{
 						{
-							Name:           "indexed_queue_size",
-							Description:    "number of outstanding index jobs",
+							Name:           "indexed_queue_size_aggregate",
+							Description:    "# of outstanding index jobs (aggregate)",
 							Query:          "sum(index_queue_len)", // total queue size amongst all index-server replicas
 							NoAlert:        true,
 							Panel:          monitoring.Panel().LegendFormat("jobs"),
+							Owner:          monitoring.ObservableOwnerSearchCore,
+							Interpretation: "A queue that is constantly growing could be a leading indicator of a bottleneck or under-provisioning",
+						},
+						{
+							Name:           "indexed_queue_size_per_instance",
+							Description:    "# of outstanding index jobs (per instance)",
+							Query:          "index_queue_len{instance=~`${shard:regex}`}",
+							NoAlert:        true,
+							Panel:          monitoring.Panel().LegendFormat("{{instance}} jobs"),
 							Owner:          monitoring.ObservableOwnerSearchCore,
 							Interpretation: "A queue that is constantly growing could be a leading indicator of a bottleneck or under-provisioning",
 						},

--- a/monitoring/definitions/zoekt_index_server.go
+++ b/monitoring/definitions/zoekt_index_server.go
@@ -23,8 +23,8 @@ func ZoektIndexServer() *monitoring.Container {
 		NoSourcegraphDebugServer: true,
 		Templates: []sdk.TemplateVar{
 			{
-				Label:      "Shard",
-				Name:       "shard",
+				Label:      "Instance",
+				Name:       "instance",
 				Type:       "query",
 				Datasource: monitoring.StringPtr("Prometheus"),
 				Query:      "label_values(index_num_assigned, instance)",
@@ -130,7 +130,7 @@ func ZoektIndexServer() *monitoring.Container {
 					{
 						{
 							Name:        "repo_index_state_aggregate",
-							Description: "index results state counts over 5m (aggregate)",
+							Description: "index results state count over 5m (aggregate)",
 							Query:       "sum by (state) (increase(index_repo_seconds_count[5m]))",
 							NoAlert:     true,
 							Owner:       monitoring.ObservableOwnerSearchCore,
@@ -154,8 +154,8 @@ func ZoektIndexServer() *monitoring.Container {
 						},
 						{
 							Name:        "repo_index_state_per_instance",
-							Description: "index results state counts over 5m (per instance)",
-							Query:       "sum by (instance, state) (increase(index_repo_seconds_count{instance=~`${shard:regex}`}[5m]))",
+							Description: "index results state count over 5m (per instance)",
+							Query:       "sum by (instance, state) (increase(index_repo_seconds_count{instance=~`${instance:regex}`}[5m]))",
 							NoAlert:     true,
 							Owner:       monitoring.ObservableOwnerSearchCore,
 							Panel: monitoring.Panel().LegendFormat("{{instance}} {{state}}").With(func(o monitoring.Observable, p *sdk.Panel) {
@@ -166,7 +166,7 @@ func ZoektIndexServer() *monitoring.Container {
 							Interpretation: `
 							This dashboard shows the outcomes of recently completed indexing jobs, split out across each index-server instance.
 
-							(You can use the "shard" filter at the top of the page to select a particular instance.)
+							(You can use the "instance" filter at the top of the page to select a particular instance.)
 
 							A persistent failing state indicates some repositories cannot be indexed, perhaps due to size and timeouts.
 
@@ -197,7 +197,7 @@ func ZoektIndexServer() *monitoring.Container {
 						{
 							Name:           "indexed_queue_size_per_instance",
 							Description:    "# of outstanding index jobs (per instance)",
-							Query:          "index_queue_len{instance=~`${shard:regex}`}",
+							Query:          "index_queue_len{instance=~`${instance:regex}`}",
 							NoAlert:        true,
 							Panel:          monitoring.Panel().LegendFormat("{{instance}} jobs"),
 							Owner:          monitoring.ObservableOwnerSearchCore,


### PR DESCRIPTION
This change to zoekt-indexserver includes:
- a new drop down filter that lets you select to drill-down into a metrics for a particular Zoekt instance 
- renaming the `repo_index_state` dashboard to better reflect that the output is a a counter, not a histogram
- adding new dashboards for viewing the indexing state results per instance and viewing the indexing queue length per instance. 

![Screen Shot 2021-12-20 at 10 43 24 AM](https://user-images.githubusercontent.com/9022011/146817059-4d99006a-25c9-469a-9fb1-15fa215ef01f.png)

