### PR TITLE
search: remove args.Mode propagation to doResults

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1741,7 +1741,7 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 		wg.Add(1)
 		goroutine.Go(func() {
 			defer wg.Done()
-			_ = agg.DoSearch(ctx, job, repos, args.Mode)
+			_ = agg.DoSearch(ctx, job, repos)
 		})
 	}
 

--- a/internal/search/run/aggregator.go
+++ b/internal/search/run/aggregator.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
-	"github.com/sourcegraph/sourcegraph/internal/search"
 	searchrepos "github.com/sourcegraph/sourcegraph/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
@@ -86,9 +85,8 @@ func (a *Aggregator) Error(err error) {
 	}
 }
 
-func (a *Aggregator) DoSearch(ctx context.Context, job Job, repos searchrepos.Pager, mode search.GlobalSearchMode) (err error) {
+func (a *Aggregator) DoSearch(ctx context.Context, job Job, repos searchrepos.Pager) (err error) {
 	tr, ctx := trace.New(ctx, "DoSearch", job.Name())
-	tr.LogFields(trace.Stringer("global_search_mode", mode))
 	defer func() {
 		a.Error(err)
 		tr.SetErrorIfNotContext(err)


### PR DESCRIPTION
I'm making a sequence of changes so that `doResults` does not need that huge `args` (`TextSearchParameters`) struct any more. See inline comment.