### PR TITLE
search: add Required method to jobs

### DIFF
--- a/internal/search/commit/commit_new.go
+++ b/internal/search/commit/commit_new.go
@@ -33,6 +33,8 @@ type CommitSearch struct {
 	Limit         int
 
 	Db database.DB
+
+	IsRequired bool
 }
 
 func (j *CommitSearch) Run(ctx context.Context, stream streaming.Sender, repos searchrepos.Pager) error {
@@ -107,6 +109,10 @@ func (j CommitSearch) Name() string {
 		return "Diff"
 	}
 	return "Commit"
+}
+
+func (j CommitSearch) Required() bool {
+	return j.IsRequired
 }
 
 func (j *CommitSearch) ExpandUsernames(ctx context.Context, db dbutil.DB) (err error) {

--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -22,6 +22,8 @@ import (
 type RepoSearch struct {
 	Args  *search.TextParameters
 	Limit int
+
+	IsRequired bool
 }
 
 func (s *RepoSearch) Run(ctx context.Context, stream streaming.Sender, repos searchrepos.Pager) (err error) {
@@ -119,6 +121,10 @@ func (s *RepoSearch) Run(ctx context.Context, stream streaming.Sender, repos sea
 
 func (*RepoSearch) Name() string {
 	return "Repo"
+}
+
+func (s *RepoSearch) Required() bool {
+	return s.IsRequired
 }
 
 func repoRevsToRepoMatches(ctx context.Context, repos []*search.RepositoryRevisions) []result.Match {

--- a/internal/search/run/run.go
+++ b/internal/search/run/run.go
@@ -34,6 +34,13 @@ type SearchInputs struct {
 type Job interface {
 	Run(context.Context, streaming.Sender, searchrepos.Pager) error
 	Name() string
+
+	// Required sets whether the results of this job are required. If true,
+	// we must wait for its routines to complete. If false, the job is
+	// optional, expressing that we may cancel the job. We typically run a
+	// set of required and optional jobs concurrently, and cancel optional
+	// jobs once we've guaranteed some required results, or after a timeout.
+	Required() bool
 }
 
 // MaxResults computes the limit for the query.

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -417,6 +417,8 @@ type RepoSubsetSymbolSearch struct {
 	UseIndex          query.YesNoOnly
 	ContainsRefGlobs  bool
 	OnMissingRepoRevs zoektutil.OnMissingRepoRevs
+
+	IsRequired bool
 }
 
 func (s *RepoSubsetSymbolSearch) Run(ctx context.Context, stream streaming.Sender, repos searchrepos.Pager) error {
@@ -444,6 +446,10 @@ func (*RepoSubsetSymbolSearch) Name() string {
 	return "RepoSubsetSymbol"
 }
 
+func (s *RepoSubsetSymbolSearch) Required() bool {
+	return false
+}
+
 type RepoUniverseSymbolSearch struct {
 	GlobalZoektQuery *zoektutil.GlobalZoektQuery
 	ZoektArgs        *search.ZoektParameters
@@ -452,6 +458,8 @@ type RepoUniverseSymbolSearch struct {
 
 	RepoOptions search.RepoOptions
 	Db          database.DB
+
+	IsRequired bool
 }
 
 func (s *RepoUniverseSymbolSearch) Run(ctx context.Context, stream streaming.Sender, _ searchrepos.Pager) error {
@@ -478,4 +486,8 @@ func (s *RepoUniverseSymbolSearch) Run(ctx context.Context, stream streaming.Sen
 
 func (*RepoUniverseSymbolSearch) Name() string {
 	return "RepoUniverseSymbol"
+}
+
+func (s *RepoUniverseSymbolSearch) Required() bool {
+	return s.IsRequired
 }

--- a/internal/search/unindexed/structural.go
+++ b/internal/search/unindexed/structural.go
@@ -156,6 +156,8 @@ type StructuralSearch struct {
 	UseIndex          query.YesNoOnly
 	ContainsRefGlobs  bool
 	OnMissingRepoRevs zoektutil.OnMissingRepoRevs
+
+	IsRequired bool
 }
 
 func (s *StructuralSearch) Run(ctx context.Context, stream streaming.Sender, repos searchrepos.Pager) error {
@@ -182,4 +184,8 @@ func (s *StructuralSearch) Run(ctx context.Context, stream streaming.Sender, rep
 
 func (*StructuralSearch) Name() string {
 	return "Structural"
+}
+
+func (s *StructuralSearch) Required() bool {
+	return s.IsRequired
 }

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -315,6 +315,8 @@ type RepoSubsetTextSearch struct {
 	UseIndex          query.YesNoOnly
 	ContainsRefGlobs  bool
 	OnMissingRepoRevs zoektutil.OnMissingRepoRevs
+
+	IsRequired bool
 }
 
 func (t *RepoSubsetTextSearch) Run(ctx context.Context, stream streaming.Sender, repos searchrepos.Pager) error {
@@ -342,6 +344,10 @@ func (*RepoSubsetTextSearch) Name() string {
 	return "RepoSubsetText"
 }
 
+func (t *RepoSubsetTextSearch) Required() bool {
+	return t.IsRequired
+}
+
 type RepoUniverseTextSearch struct {
 	GlobalZoektQuery *zoektutil.GlobalZoektQuery
 	ZoektArgs        *search.ZoektParameters
@@ -350,6 +356,8 @@ type RepoUniverseTextSearch struct {
 	RepoOptions search.RepoOptions
 	Db          database.DB
 	UserID      int32
+
+	IsRequired bool
 }
 
 func (t *RepoUniverseTextSearch) Run(ctx context.Context, stream streaming.Sender, _ searchrepos.Pager) error {
@@ -377,4 +385,8 @@ func (t *RepoUniverseTextSearch) Run(ctx context.Context, stream streaming.Sende
 
 func (*RepoUniverseTextSearch) Name() string {
 	return "RepoUniverseText"
+}
+
+func (t *RepoUniverseTextSearch) Required() bool {
+	return t.IsRequired
 }


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/29168. This is in support of removing `args` from `doResults`. We currently depend on `args.resultTypes`, which we further use to decide whether a job is required or optional in. This PR adds scaffolding for jobs to say whether they are required or optional instead, so we don't need `resultTypes`. Note that an interface is needed (to check `Required()` in `doResults`, but this value is not static per job: a job is not always either required or optional on its own, but depends on whether other jobs exist (e.g., if a symbol search is exclusively run, it is required, but it might otherwise be included as part of other jobs, but optionally). Ergo, this decision must be made in `toSearchInputs` and sets the value appropriately.

Camden and I talked a while back about whether we really need to make this distinction between optional and required, now that we have streaming. Historically, I think this distinction mattered more for GQL, but even then it's dubious. The fact is, I think we don't (just keep streaming until we see enough results and then cancel), but _I'm going to pretend we need to keep it for now_ and just mechanically migrate this logic to `toSearchInputs`, because my goal is to get rid of `args`, not substantially rewrite this logic. Hopefully later we can remove the `Required()` method on jobs entirely.