### PR TITLE
frontend: Gracefully handle broken pipe error when highlighting

### DIFF
--- a/cmd/frontend/internal/highlight/highlight.go
+++ b/cmd/frontend/internal/highlight/highlight.go
@@ -211,6 +211,7 @@ func Code(ctx context.Context, p Params) (h template.HTML, aborted bool, err err
 		if problem == "" && strings.Contains(err.Error(), "broken pipe") {
 			problem = "broken pipe"
 		}
+
 		if problem != "" {
 			// A problem that can sometimes be expected has occurred. We will
 			// identify such problems through metrics/logs and resolve them on

--- a/cmd/frontend/internal/highlight/highlight.go
+++ b/cmd/frontend/internal/highlight/highlight.go
@@ -207,6 +207,7 @@ func Code(ctx context.Context, p Params) (h template.HTML, aborted bool, err err
 		case gosyntect.ErrHSSWorkerTimeout:
 			problem = "hss_worker_timeout"
 		}
+
 		if problem == "" && strings.Contains(err.Error(), "broken pipe") {
 			problem = "broken pipe"
 		}

--- a/cmd/frontend/internal/highlight/highlight.go
+++ b/cmd/frontend/internal/highlight/highlight.go
@@ -207,6 +207,9 @@ func Code(ctx context.Context, p Params) (h template.HTML, aborted bool, err err
 		case gosyntect.ErrHSSWorkerTimeout:
 			problem = "hss_worker_timeout"
 		}
+		if problem == "" && strings.Contains(err.Error(), "broken pipe") {
+			problem = "broken pipe"
+		}
 		if problem != "" {
 			// A problem that can sometimes be expected has occurred. We will
 			// identify such problems through metrics/logs and resolve them on


### PR DESCRIPTION
We currently handle a few know error types and we've received a support
reqeust from a customer that they're consistently seeing a broken pipe
error for a particular file.

This is most likely caused by a crash on syntect-server so instead of
showing an error to the user we fall back to rendering a non-highlighted
version of the file.

Closes: https://github.com/sourcegraph/customer/issues/594