### PR TITLE
search: prevent the rendering of the home page when navigating back to the search results

### DIFF
--- a/client/web/src/Layout.test.tsx
+++ b/client/web/src/Layout.test.tsx
@@ -22,8 +22,6 @@ jest.mock('./theme', () => ({
 describe('Layout', () => {
     const defaultProps: LayoutProps = ({
         // Parsed query components
-        parsedSearchQuery: 'r:golang/oauth2 test f:travis',
-        setParsedSearchQuery: () => {},
         patternType: SearchPatternType.literal,
         setPatternType: () => {},
         caseSensitive: false,
@@ -50,68 +48,6 @@ describe('Layout', () => {
 
     afterEach(() => {
         document.querySelector('#root')?.remove()
-    })
-
-    it('should update parsedSearchQuery if different between URL and context', () => {
-        const history = createBrowserHistory()
-        history.replace({ search: 'q=r:golang/oauth2+test+f:travis2&patternType=regexp' })
-
-        const setParsedSearchQuery = sinon.spy()
-
-        render(
-            <BrowserRouter>
-                <Layout
-                    {...defaultProps}
-                    history={history}
-                    location={history.location}
-                    setParsedSearchQuery={setParsedSearchQuery}
-                />
-            </BrowserRouter>
-        )
-
-        sinon.assert.called(setParsedSearchQuery)
-        sinon.assert.calledWith(setParsedSearchQuery, 'r:golang/oauth2 test f:travis2')
-    })
-
-    it('should not update parsedSearchQuery if URL and context are the same', () => {
-        const history = createBrowserHistory()
-        history.replace({ search: 'q=r:golang/oauth2+test+f:travis&patternType=regexp' })
-
-        const setParsedSearchQuery = sinon.spy()
-
-        render(
-            <BrowserRouter>
-                <Layout
-                    {...defaultProps}
-                    history={history}
-                    location={history.location}
-                    setParsedSearchQuery={setParsedSearchQuery}
-                />
-            </BrowserRouter>
-        )
-
-        sinon.assert.notCalled(setParsedSearchQuery)
-    })
-
-    it('should update parsedSearchQuery if changing to empty', () => {
-        const history = createBrowserHistory()
-        history.replace({ search: 'q=&patternType=regexp' })
-
-        const setParsedSearchQuery = sinon.spy()
-
-        render(
-            <BrowserRouter>
-                <Layout
-                    {...defaultProps}
-                    history={history}
-                    location={history.location}
-                    setParsedSearchQuery={setParsedSearchQuery}
-                />
-            </BrowserRouter>
-        )
-
-        sinon.assert.called(setParsedSearchQuery)
-        sinon.assert.calledWith(setParsedSearchQuery, '')
     })
 
     it('should update patternType if different between URL and context', () => {

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -53,7 +53,6 @@ import {
     PatternTypeProps,
     HomePanelsProps,
     SearchStreamingProps,
-    ParsedSearchQueryProps,
     parseSearchURL,
     SearchContextProps,
     getGlobalSearchContextFilter,
@@ -77,7 +76,6 @@ export interface LayoutProps
         KeyboardShortcutsProps,
         TelemetryProps,
         ActivationProps,
-        ParsedSearchQueryProps,
         PatternTypeProps,
         SearchContextProps,
         HomePanelsProps,
@@ -134,14 +132,12 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
     const isSearchNotebookPage = routeMatch?.startsWith('/search/notebook')
     const isRepositoryRelatedPage = routeMatch === '/:repoRevAndRest+' ?? false
 
-    // Update parsedSearchQuery, patternType, caseSensitivity, and selectedSearchContextSpec based on current URL
+    // Update patternType, caseSensitivity, and selectedSearchContextSpec based on current URL
     const {
         history,
-        parsedSearchQuery: currentQuery,
         patternType: currentPatternType,
         selectedSearchContextSpec,
         location,
-        setParsedSearchQuery,
         setPatternType,
         setSelectedSearchContextSpec,
     } = props
@@ -153,10 +149,6 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
     const searchContextSpec = useMemo(() => getGlobalSearchContextFilter(query)?.spec, [query])
 
     useEffect(() => {
-        if (query !== currentQuery) {
-            setParsedSearchQuery(query)
-        }
-
         // Only override filters from URL if there is a search query
         if (query) {
             if (patternType && patternType !== currentPatternType) {
@@ -170,11 +162,9 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
     }, [
         history,
         currentPatternType,
-        currentQuery,
         selectedSearchContextSpec,
         patternType,
         query,
-        setParsedSearchQuery,
         setPatternType,
         setSelectedSearchContextSpec,
         searchContextSpec,
@@ -223,6 +213,7 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
         ...breadcrumbProps,
         onExtensionAlertDismissed,
         isMacPlatform,
+        parsedSearchQuery: query,
     }
 
     return (
@@ -237,6 +228,7 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
                 <GlobalNavbar
                     {...props}
                     {...themeProps}
+                    parsedSearchQuery={query}
                     authRequired={!!authRequired}
                     showSearchBox={
                         isSearchRelatedPage &&

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -6,6 +6,7 @@ import { createBrowserHistory } from 'history'
 import ServerIcon from 'mdi-react/ServerIcon'
 import * as React from 'react'
 import { Route, Router } from 'react-router'
+import { ScrollManager } from 'react-scroll-manager'
 import { combineLatest, from, Subscription, fromEvent, of, Subject } from 'rxjs'
 import { catchError, distinctUntilChanged, map, startWith, switchMap } from 'rxjs/operators'
 
@@ -395,71 +396,73 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
                     <ShortcutProvider>
                         <TemporarySettingsProvider temporarySettingsStorage={temporarySettingsStorage}>
                             <SearchResultsCacheProvider>
-                                <Router history={history} key={0}>
-                                    <Route
-                                        path="/"
-                                        render={routeComponentProps => (
-                                            <CodeHostScopeProvider authenticatedUser={authenticatedUser}>
-                                                <LayoutWithActivation
-                                                    {...props}
-                                                    {...routeComponentProps}
-                                                    authenticatedUser={authenticatedUser}
-                                                    viewerSubject={this.state.viewerSubject}
-                                                    settingsCascade={this.state.settingsCascade}
-                                                    batchChangesEnabled={this.props.batchChangesEnabled}
-                                                    batchChangesExecutionEnabled={isBatchChangesExecutionEnabled(
-                                                        this.state.settingsCascade
-                                                    )}
-                                                    batchChangesWebhookLogsEnabled={
-                                                        window.context.batchChangesWebhookLogsEnabled
-                                                    }
-                                                    // Search query
-                                                    fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
-                                                    patternType={this.state.searchPatternType}
-                                                    setPatternType={this.setPatternType}
-                                                    // Extensions
-                                                    platformContext={this.platformContext}
-                                                    extensionsController={this.extensionsController}
-                                                    telemetryService={eventLogger}
-                                                    isSourcegraphDotCom={window.context.sourcegraphDotComMode}
-                                                    searchContextsEnabled={this.props.searchContextsEnabled}
-                                                    hasUserAddedRepositories={this.hasUserAddedRepositories()}
-                                                    hasUserAddedExternalServices={
-                                                        this.state.hasUserAddedExternalServices
-                                                    }
-                                                    selectedSearchContextSpec={this.getSelectedSearchContextSpec()}
-                                                    setSelectedSearchContextSpec={this.setSelectedSearchContextSpec}
-                                                    getUserSearchContextNamespaces={getUserSearchContextNamespaces}
-                                                    fetchAutoDefinedSearchContexts={fetchAutoDefinedSearchContexts}
-                                                    fetchSearchContexts={fetchSearchContexts}
-                                                    fetchSearchContextBySpec={fetchSearchContextBySpec}
-                                                    fetchSearchContext={fetchSearchContext}
-                                                    createSearchContext={createSearchContext}
-                                                    updateSearchContext={updateSearchContext}
-                                                    deleteSearchContext={deleteSearchContext}
-                                                    isSearchContextSpecAvailable={isSearchContextSpecAvailable}
-                                                    defaultSearchContextSpec={this.state.defaultSearchContextSpec}
-                                                    globbing={this.state.globbing}
-                                                    isCodeInsightsGqlApiEnabled={
-                                                        window.context.codeInsightsGqlApiEnabled
-                                                    }
-                                                    fetchSavedSearches={fetchSavedSearches}
-                                                    fetchRecentSearches={fetchRecentSearches}
-                                                    fetchRecentFileViews={fetchRecentFileViews}
-                                                    streamSearch={aggregateStreamingSearch}
-                                                    onUserExternalServicesOrRepositoriesUpdate={
-                                                        this.onUserExternalServicesOrRepositoriesUpdate
-                                                    }
-                                                    onSyncedPublicRepositoriesUpdate={
-                                                        this.onSyncedPublicRepositoriesUpdate
-                                                    }
-                                                    featureFlags={this.state.featureFlags}
-                                                />
-                                            </CodeHostScopeProvider>
-                                        )}
-                                    />
-                                    <SearchStack />
-                                </Router>
+                                <ScrollManager history={history}>
+                                    <Router history={history} key={0}>
+                                        <Route
+                                            path="/"
+                                            render={routeComponentProps => (
+                                                <CodeHostScopeProvider authenticatedUser={authenticatedUser}>
+                                                    <LayoutWithActivation
+                                                        {...props}
+                                                        {...routeComponentProps}
+                                                        authenticatedUser={authenticatedUser}
+                                                        viewerSubject={this.state.viewerSubject}
+                                                        settingsCascade={this.state.settingsCascade}
+                                                        batchChangesEnabled={this.props.batchChangesEnabled}
+                                                        batchChangesExecutionEnabled={isBatchChangesExecutionEnabled(
+                                                            this.state.settingsCascade
+                                                        )}
+                                                        batchChangesWebhookLogsEnabled={
+                                                            window.context.batchChangesWebhookLogsEnabled
+                                                        }
+                                                        // Search query
+                                                        fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
+                                                        patternType={this.state.searchPatternType}
+                                                        setPatternType={this.setPatternType}
+                                                        // Extensions
+                                                        platformContext={this.platformContext}
+                                                        extensionsController={this.extensionsController}
+                                                        telemetryService={eventLogger}
+                                                        isSourcegraphDotCom={window.context.sourcegraphDotComMode}
+                                                        searchContextsEnabled={this.props.searchContextsEnabled}
+                                                        hasUserAddedRepositories={this.hasUserAddedRepositories()}
+                                                        hasUserAddedExternalServices={
+                                                            this.state.hasUserAddedExternalServices
+                                                        }
+                                                        selectedSearchContextSpec={this.getSelectedSearchContextSpec()}
+                                                        setSelectedSearchContextSpec={this.setSelectedSearchContextSpec}
+                                                        getUserSearchContextNamespaces={getUserSearchContextNamespaces}
+                                                        fetchAutoDefinedSearchContexts={fetchAutoDefinedSearchContexts}
+                                                        fetchSearchContexts={fetchSearchContexts}
+                                                        fetchSearchContextBySpec={fetchSearchContextBySpec}
+                                                        fetchSearchContext={fetchSearchContext}
+                                                        createSearchContext={createSearchContext}
+                                                        updateSearchContext={updateSearchContext}
+                                                        deleteSearchContext={deleteSearchContext}
+                                                        isSearchContextSpecAvailable={isSearchContextSpecAvailable}
+                                                        defaultSearchContextSpec={this.state.defaultSearchContextSpec}
+                                                        globbing={this.state.globbing}
+                                                        isCodeInsightsGqlApiEnabled={
+                                                            window.context.codeInsightsGqlApiEnabled
+                                                        }
+                                                        fetchSavedSearches={fetchSavedSearches}
+                                                        fetchRecentSearches={fetchRecentSearches}
+                                                        fetchRecentFileViews={fetchRecentFileViews}
+                                                        streamSearch={aggregateStreamingSearch}
+                                                        onUserExternalServicesOrRepositoriesUpdate={
+                                                            this.onUserExternalServicesOrRepositoriesUpdate
+                                                        }
+                                                        onSyncedPublicRepositoriesUpdate={
+                                                            this.onSyncedPublicRepositoriesUpdate
+                                                        }
+                                                        featureFlags={this.state.featureFlags}
+                                                    />
+                                                </CodeHostScopeProvider>
+                                            )}
+                                        />
+                                        <SearchStack />
+                                    </Router>
+                                </ScrollManager>
                                 <Tooltip key={1} />
                                 <Notifications
                                     key={2}

--- a/client/web/src/communitySearchContexts/CommunitySearchContextPage.tsx
+++ b/client/web/src/communitySearchContexts/CommunitySearchContextPage.tsx
@@ -40,7 +40,7 @@ export interface CommunitySearchContextPageProps
         ThemePreferenceProps,
         ActivationProps,
         TelemetryProps,
-        Pick<ParsedSearchQueryProps, 'parsedSearchQuery'>,
+        ParsedSearchQueryProps,
         PatternTypeProps,
         KeyboardShortcutsProps,
         ExtensionsControllerProps<'executeCommand'>,

--- a/client/web/src/components/AppRouterContainer/AppRouterContainer.tsx
+++ b/client/web/src/components/AppRouterContainer/AppRouterContainer.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames'
 import React, { HTMLAttributes } from 'react'
+import { ElementScroller } from 'react-scroll-manager'
 
 import styles from './AppRouterContainer.module.scss'
 
@@ -10,7 +11,9 @@ export const AppRouterContainer: React.FunctionComponent<AppRouterContainerProps
     className,
     ...rest
 }) => (
-    <div className={classNames(styles.appRouterContainer, className)} {...rest}>
-        {children}
-    </div>
+    <ElementScroller scrollKey="app-router-container">
+        <div className={classNames(styles.appRouterContainer, className)} {...rest}>
+            {children}
+        </div>
+    </ElementScroller>
 )

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -66,7 +66,7 @@ interface Props
         ThemePreferenceProps,
         ExtensionAlertAnimationProps,
         ActivationProps,
-        Pick<ParsedSearchQueryProps, 'parsedSearchQuery'>,
+        ParsedSearchQueryProps,
         PatternTypeProps,
         SearchContextInputProps,
         CodeInsightsProps,

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -10,6 +10,7 @@ import { BreadcrumbsProps, BreadcrumbSetters } from './components/Breadcrumbs'
 import type { LayoutProps } from './Layout'
 import type { ExtensionAlertProps } from './repo/RepoContainer'
 import { PageRoutes } from './routes.constants'
+import { ParsedSearchQueryProps } from './search'
 import { getExperimentalFeatures, useExperimentalFeatures } from './stores'
 import { ThemePreferenceProps } from './theme'
 import { UserExternalServicesOrRepositoriesUpdateProps } from './util'
@@ -32,6 +33,7 @@ const SiteInitPage = lazyComponent(() => import('./site-admin/init/SiteInitPage'
 export interface LayoutRouteComponentProps<RouteParameters extends { [K in keyof RouteParameters]?: string }>
     extends RouteComponentProps<RouteParameters>,
         Omit<LayoutProps, 'match'>,
+        ParsedSearchQueryProps,
         ThemeProps,
         ThemePreferenceProps,
         BreadcrumbsProps,

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -30,7 +30,7 @@ export interface SearchPageProps
         ThemeProps,
         ThemePreferenceProps,
         ActivationProps,
-        Pick<ParsedSearchQueryProps, 'parsedSearchQuery'>,
+        ParsedSearchQueryProps,
         PatternTypeProps,
         KeyboardShortcutsProps,
         TelemetryProps,

--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -32,7 +32,7 @@ interface Props
         PatternTypeProps,
         KeyboardShortcutsProps,
         TelemetryProps,
-        Pick<ParsedSearchQueryProps, 'parsedSearchQuery'>,
+        ParsedSearchQueryProps,
         PlatformContextProps<'forceUpdateTooltip' | 'settings' | 'sourcegraphURL'>,
         Pick<SubmitSearchParameters, 'source'>,
         SearchContextInputProps {

--- a/client/web/src/search/index.tsx
+++ b/client/web/src/search/index.tsx
@@ -146,7 +146,6 @@ export function quoteIfNeeded(string: string): string {
 
 export interface ParsedSearchQueryProps {
     parsedSearchQuery: string
-    setParsedSearchQuery: (query: string) => void
 }
 
 export interface PatternTypeProps {

--- a/client/web/src/search/results/DidYouMean.tsx
+++ b/client/web/src/search/results/DidYouMean.tsx
@@ -116,7 +116,7 @@ function getQuerySuggestions(query: string, patternType: SearchPatternType): Sug
 }
 
 interface DidYouMeanProps
-    extends Pick<ParsedSearchQueryProps, 'parsedSearchQuery'>,
+    extends ParsedSearchQueryProps,
         Pick<PatternTypeProps, 'patternType'>,
         Pick<CaseSensitivityProps, 'caseSensitive'>,
         Pick<SearchContextProps, 'selectedSearchContextSpec'>,

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -40,7 +40,7 @@ import { StreamingSearchResultsList } from './StreamingSearchResultsList'
 export interface StreamingSearchResultsProps
     extends SearchStreamingProps,
         Pick<ActivationProps, 'activation'>,
-        Pick<ParsedSearchQueryProps, 'parsedSearchQuery'>,
+        ParsedSearchQueryProps,
         Pick<PatternTypeProps, 'patternType'>,
         Pick<SearchContextProps, 'selectedSearchContextSpec' | 'searchContextsEnabled'>,
         SettingsCascadeProps,

--- a/client/web/src/search/results/StreamingSearchResultsList.tsx
+++ b/client/web/src/search/results/StreamingSearchResultsList.tsx
@@ -4,7 +4,7 @@ import FileDocumentIcon from 'mdi-react/FileDocumentIcon'
 import FileIcon from 'mdi-react/FileIcon'
 import SourceCommitIcon from 'mdi-react/SourceCommitIcon'
 import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback } from 'react'
 import { Observable } from 'rxjs'
 
 import { FetchFileParameters } from '@sourcegraph/shared/src/components/CodeExcerpt'
@@ -28,9 +28,7 @@ import { SearchResult } from '../../components/SearchResult'
 
 import { NoResultsPage } from './NoResultsPage'
 import { StreamingSearchResultFooter } from './StreamingSearchResultsFooter'
-
-const initialItemsToShow = 15
-const incrementalItemsToShow = 10
+import { useItemsToShow } from './use-items-to-show'
 
 export interface StreamingSearchResultsListProps
     extends ThemeProps,
@@ -55,23 +53,8 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
     isSourcegraphDotCom,
     searchContextsEnabled,
 }) => {
-    const [itemsToShow, setItemsToShow] = useState(initialItemsToShow)
-    const onBottomHit = useCallback(
-        () => setItemsToShow(items => Math.min(results?.results.length || 0, items + incrementalItemsToShow)),
-        [results?.results.length]
-    )
-
-    // Reset scroll visibility state when new search is started
-    useEffect(() => {
-        setItemsToShow(initialItemsToShow)
-    }, [location.search])
-
-    const itemKey = useCallback((item: SearchMatch): string => {
-        if (item.type === 'content' || item.type === 'symbol') {
-            return `file:${getMatchUrl(item)}`
-        }
-        return getMatchUrl(item)
-    }, [])
+    const resultsNumber = results?.results.length || 0
+    const { itemsToShow, handleBottomHit } = useItemsToShow(location.search, resultsNumber)
 
     const logSearchResultClicked = useCallback(() => telemetryService.log('SearchResultClicked'), [telemetryService])
 
@@ -131,17 +114,17 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
             <VirtualList<SearchMatch>
                 className="mt-2"
                 itemsToShow={itemsToShow}
-                onShowMoreItems={onBottomHit}
+                onShowMoreItems={handleBottomHit}
                 items={results?.results || []}
                 itemProps={undefined}
                 itemKey={itemKey}
                 renderItem={renderResult}
             />
 
-            {itemsToShow >= (results?.results.length || 0) && (
+            {itemsToShow >= resultsNumber && (
                 <StreamingSearchResultFooter results={results}>
                     <>
-                        {results?.state === 'complete' && results?.results.length === 0 && (
+                        {results?.state === 'complete' && resultsNumber === 0 && (
                             <NoResultsPage
                                 searchContextsEnabled={searchContextsEnabled}
                                 isSourcegraphDotCom={isSourcegraphDotCom}
@@ -154,6 +137,13 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
             )}
         </>
     )
+}
+
+function itemKey(item: SearchMatch): string {
+    if (item.type === 'content' || item.type === 'symbol') {
+        return `file:${getMatchUrl(item)}`
+    }
+    return getMatchUrl(item)
 }
 
 function getFileMatchIcon(result: ContentMatch | SymbolMatch | PathMatch): React.ComponentType<{ className?: string }> {

--- a/client/web/src/search/results/use-items-to-show.test.ts
+++ b/client/web/src/search/results/use-items-to-show.test.ts
@@ -1,0 +1,83 @@
+import { act, renderHook } from '@testing-library/react-hooks'
+import { times } from 'lodash'
+
+import { INCREMENTAL_ITEMS_TO_SHOW, DEFAULT_INITIAL_ITEMS_TO_SHOW, useItemsToShow } from './use-items-to-show'
+
+const RESULTS_NUMBER = 50
+
+function renderUseItemsToShowHook(query = 'Hello there!') {
+    return renderHook(() => useItemsToShow(query, RESULTS_NUMBER))
+}
+
+function scrollToViewMoreResults(scrollNumber: number, handleBottomHit: () => void) {
+    // Do not await `act` call with sync logic. It's not a promise.
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    act(() => {
+        times(scrollNumber, handleBottomHit)
+    })
+}
+
+describe('useItemsToShow', () => {
+    afterEach(() => {
+        sessionStorage.clear()
+    })
+
+    it('returns expected default values', () => {
+        const { result } = renderUseItemsToShowHook()
+        const { itemsToShow, handleBottomHit } = result.current
+
+        expect(handleBottomHit).toEqual(expect.any(Function))
+        expect(itemsToShow).toBe(DEFAULT_INITIAL_ITEMS_TO_SHOW)
+    })
+
+    it('increases `itemsToShow` value on `handleBottomHit()` call', () => {
+        const { result: initialResult } = renderUseItemsToShowHook()
+        const { handleBottomHit } = initialResult.current
+
+        scrollToViewMoreResults(2, handleBottomHit)
+
+        const { result } = renderUseItemsToShowHook()
+        const { itemsToShow } = result.current
+
+        expect(itemsToShow).toBe(DEFAULT_INITIAL_ITEMS_TO_SHOW + INCREMENTAL_ITEMS_TO_SHOW * 2)
+    })
+
+    it('preserves current `itemsToShow` value on a component unmount', () => {
+        const { result: initialResult } = renderUseItemsToShowHook()
+        const { handleBottomHit } = initialResult.current
+
+        scrollToViewMoreResults(2, handleBottomHit)
+
+        const { unmount } = renderUseItemsToShowHook()
+        unmount()
+
+        const { result } = renderUseItemsToShowHook()
+        const { itemsToShow } = result.current
+
+        expect(itemsToShow).toBe(DEFAULT_INITIAL_ITEMS_TO_SHOW + INCREMENTAL_ITEMS_TO_SHOW * 2)
+    })
+
+    it("doesn't go over the current results number", () => {
+        const { result: initialResult } = renderUseItemsToShowHook()
+        const { handleBottomHit } = initialResult.current
+
+        scrollToViewMoreResults(20, handleBottomHit)
+
+        const { result } = renderUseItemsToShowHook()
+        const { itemsToShow } = result.current
+
+        expect(itemsToShow).toBe(RESULTS_NUMBER)
+    })
+
+    it('resets `itemsToShow` if a new query is provided', () => {
+        const { result: initialResult } = renderUseItemsToShowHook()
+        const { handleBottomHit } = initialResult.current
+
+        scrollToViewMoreResults(2, handleBottomHit)
+
+        const { result } = renderUseItemsToShowHook('New query here!')
+        const { itemsToShow } = result.current
+
+        expect(itemsToShow).toBe(DEFAULT_INITIAL_ITEMS_TO_SHOW)
+    })
+})

--- a/client/web/src/search/results/use-items-to-show.ts
+++ b/client/web/src/search/results/use-items-to-show.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useState } from 'react'
+
+export const DEFAULT_INITIAL_ITEMS_TO_SHOW = 15
+export const INCREMENTAL_ITEMS_TO_SHOW = 10
+
+/**
+ * Used to save number of search items user saw previously
+ * to restore scroll position on page-refresh or navigating back to search results.
+ */
+enum SessionStorageKeys {
+    itemsToShow = 'search-items-to-show',
+    query = 'search-items-to-show-for-query',
+}
+
+/**
+ * If a user browsed search results for the same query and scrolled through them ->
+ * return the number of items he saw to restore scroll position without multiple UI jumps.
+ *
+ * Otherwise, return the initial default value.
+ */
+function getInitialItemsToShowValue(query: string): number {
+    const previousQuery = sessionStorage.getItem(SessionStorageKeys.query)
+    const itemsToShow = sessionStorage.getItem(SessionStorageKeys.itemsToShow)
+
+    // In case of receiving new query — reset the state saved in sessionStorage.
+    if (previousQuery !== query) {
+        sessionStorage.setItem(SessionStorageKeys.query, query)
+        sessionStorage.setItem(SessionStorageKeys.itemsToShow, String(DEFAULT_INITIAL_ITEMS_TO_SHOW))
+
+        return DEFAULT_INITIAL_ITEMS_TO_SHOW
+    }
+
+    return Number(itemsToShow) || DEFAULT_INITIAL_ITEMS_TO_SHOW
+}
+
+interface UseItemsToShowResult {
+    itemsToShow: number
+    handleBottomHit: () => void
+}
+
+/**
+ * Preserves the number of items to show for the query by saving it in the session storage.
+ */
+export function useItemsToShow(query: string, resultsNumber: number): UseItemsToShowResult {
+    const [itemsToShow, setItemsToShow] = useState(() => getInitialItemsToShowValue(query))
+
+    const handleBottomHit = useCallback(
+        () =>
+            setItemsToShow(items => {
+                const itemsToShow = Math.min(resultsNumber, items + INCREMENTAL_ITEMS_TO_SHOW)
+                sessionStorage.setItem(SessionStorageKeys.itemsToShow, String(itemsToShow))
+
+                return itemsToShow
+            }),
+        [resultsNumber]
+    )
+
+    // Reset scroll visibility state when new search is started
+    useEffect(() => {
+        setItemsToShow(getInitialItemsToShowValue(query))
+    }, [query])
+
+    return {
+        itemsToShow,
+        handleBottomHit,
+    }
+}

--- a/package.json
+++ b/package.json
@@ -397,6 +397,7 @@
     "react-grid-layout": "1.3.0",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
+    "react-scroll-manager": "^1.0.3",
     "react-sticky-box": "^0.9.3",
     "react-stripe-elements": "^6.1.2",
     "react-textarea-autosize": "^8.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20040,6 +20040,13 @@ react-router@5.2.0, react-router@^5.2.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
+react-scroll-manager@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/react-scroll-manager/-/react-scroll-manager-1.0.3.tgz#06c4be39a874af0d3852f7961c65de2a30ae03ee"
+  integrity sha512-3eU+IygBqpWczvw0Rvl7TuRcQ53EVUTam+eBwUWS8kqLBB4o4eI3yDNvvLzUJ6iD/6kbyTC/sBb8HGGE0AybKQ==
+  dependencies:
+    prop-types "^15.7.2"
+
 react-select@^3.2.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/react-select/-/react-select-3.2.0.tgz#de9284700196f5f9b5277c5d850a9ce85f5c72fe"


### PR DESCRIPTION
## Context

### TLDR

We render the search home page when navigating back to search results from the blob view. Don't believe me? 
Go to [the cloud instance](https://sourcegraph.com/search), set a breakpoint in the `SearchPage.tsx` file in dev tools and try yourself!

### Details

Currently, we have `parsedSearchQuery` in the state of the `SourcegraphWebApp` component. 
1. Upon opening search results — its value is updated with the current search query. 
2. After opening any search result — its value is set to an empty string.
3. When we navigate back to search results we there's a delay in updating its value because:
    - The update is done in the `useEffect` hook in the `Layout` component, which is rendered after we figure out which React router route to use.
https://github.com/sourcegraph/sourcegraph/blob/ee1e1fe5af79de620292c6794dcbff2c6a47fe71/client/web/src/Layout.tsx#L155-L158
    - It means that the code responsible for deciding what to render doesn't have up-to-date `parsedSearchQuery` available on the initial render. It leads to rendering the `SearchPage` component, which we don't need, negatively affecting the perceived performance.
https://github.com/sourcegraph/sourcegraph/blob/ee1e1fe5af79de620292c6794dcbff2c6a47fe71/client/web/src/routes.tsx#L78-L82

## Changes

- This PR removes `parsedSearchQuery` from the state of the `SourcegraphWebApp` component.
    - It seems it's required only in the `SourcegraphWebApp` `componentDidMount` hook, and deleting it from the state doesn't break things.
- Uses `parsedSearchQuery` directly from the `Layout` component that we already have in place.

As a result — the `StreamingSearchResults` component is rendered right away when navigating back to search results without redundant intermediate steps.

Preparation to address https://github.com/sourcegraph/sourcegraph/issues/28845.