### PR TITLE
search: preserve scroll position on navigating back to search results 🎉

### DIFF
--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -6,6 +6,7 @@ import { createBrowserHistory } from 'history'
 import ServerIcon from 'mdi-react/ServerIcon'
 import * as React from 'react'
 import { Route, Router } from 'react-router'
+import { ScrollManager } from 'react-scroll-manager'
 import { combineLatest, from, Subscription, fromEvent, of, Subject } from 'rxjs'
 import { catchError, distinctUntilChanged, map, startWith, switchMap } from 'rxjs/operators'
 
@@ -395,71 +396,73 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
                     <ShortcutProvider>
                         <TemporarySettingsProvider temporarySettingsStorage={temporarySettingsStorage}>
                             <SearchResultsCacheProvider>
-                                <Router history={history} key={0}>
-                                    <Route
-                                        path="/"
-                                        render={routeComponentProps => (
-                                            <CodeHostScopeProvider authenticatedUser={authenticatedUser}>
-                                                <LayoutWithActivation
-                                                    {...props}
-                                                    {...routeComponentProps}
-                                                    authenticatedUser={authenticatedUser}
-                                                    viewerSubject={this.state.viewerSubject}
-                                                    settingsCascade={this.state.settingsCascade}
-                                                    batchChangesEnabled={this.props.batchChangesEnabled}
-                                                    batchChangesExecutionEnabled={isBatchChangesExecutionEnabled(
-                                                        this.state.settingsCascade
-                                                    )}
-                                                    batchChangesWebhookLogsEnabled={
-                                                        window.context.batchChangesWebhookLogsEnabled
-                                                    }
-                                                    // Search query
-                                                    fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
-                                                    patternType={this.state.searchPatternType}
-                                                    setPatternType={this.setPatternType}
-                                                    // Extensions
-                                                    platformContext={this.platformContext}
-                                                    extensionsController={this.extensionsController}
-                                                    telemetryService={eventLogger}
-                                                    isSourcegraphDotCom={window.context.sourcegraphDotComMode}
-                                                    searchContextsEnabled={this.props.searchContextsEnabled}
-                                                    hasUserAddedRepositories={this.hasUserAddedRepositories()}
-                                                    hasUserAddedExternalServices={
-                                                        this.state.hasUserAddedExternalServices
-                                                    }
-                                                    selectedSearchContextSpec={this.getSelectedSearchContextSpec()}
-                                                    setSelectedSearchContextSpec={this.setSelectedSearchContextSpec}
-                                                    getUserSearchContextNamespaces={getUserSearchContextNamespaces}
-                                                    fetchAutoDefinedSearchContexts={fetchAutoDefinedSearchContexts}
-                                                    fetchSearchContexts={fetchSearchContexts}
-                                                    fetchSearchContextBySpec={fetchSearchContextBySpec}
-                                                    fetchSearchContext={fetchSearchContext}
-                                                    createSearchContext={createSearchContext}
-                                                    updateSearchContext={updateSearchContext}
-                                                    deleteSearchContext={deleteSearchContext}
-                                                    isSearchContextSpecAvailable={isSearchContextSpecAvailable}
-                                                    defaultSearchContextSpec={this.state.defaultSearchContextSpec}
-                                                    globbing={this.state.globbing}
-                                                    isCodeInsightsGqlApiEnabled={
-                                                        window.context.codeInsightsGqlApiEnabled
-                                                    }
-                                                    fetchSavedSearches={fetchSavedSearches}
-                                                    fetchRecentSearches={fetchRecentSearches}
-                                                    fetchRecentFileViews={fetchRecentFileViews}
-                                                    streamSearch={aggregateStreamingSearch}
-                                                    onUserExternalServicesOrRepositoriesUpdate={
-                                                        this.onUserExternalServicesOrRepositoriesUpdate
-                                                    }
-                                                    onSyncedPublicRepositoriesUpdate={
-                                                        this.onSyncedPublicRepositoriesUpdate
-                                                    }
-                                                    featureFlags={this.state.featureFlags}
-                                                />
-                                            </CodeHostScopeProvider>
-                                        )}
-                                    />
-                                    <SearchStack />
-                                </Router>
+                                <ScrollManager history={history}>
+                                    <Router history={history} key={0}>
+                                        <Route
+                                            path="/"
+                                            render={routeComponentProps => (
+                                                <CodeHostScopeProvider authenticatedUser={authenticatedUser}>
+                                                    <LayoutWithActivation
+                                                        {...props}
+                                                        {...routeComponentProps}
+                                                        authenticatedUser={authenticatedUser}
+                                                        viewerSubject={this.state.viewerSubject}
+                                                        settingsCascade={this.state.settingsCascade}
+                                                        batchChangesEnabled={this.props.batchChangesEnabled}
+                                                        batchChangesExecutionEnabled={isBatchChangesExecutionEnabled(
+                                                            this.state.settingsCascade
+                                                        )}
+                                                        batchChangesWebhookLogsEnabled={
+                                                            window.context.batchChangesWebhookLogsEnabled
+                                                        }
+                                                        // Search query
+                                                        fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
+                                                        patternType={this.state.searchPatternType}
+                                                        setPatternType={this.setPatternType}
+                                                        // Extensions
+                                                        platformContext={this.platformContext}
+                                                        extensionsController={this.extensionsController}
+                                                        telemetryService={eventLogger}
+                                                        isSourcegraphDotCom={window.context.sourcegraphDotComMode}
+                                                        searchContextsEnabled={this.props.searchContextsEnabled}
+                                                        hasUserAddedRepositories={this.hasUserAddedRepositories()}
+                                                        hasUserAddedExternalServices={
+                                                            this.state.hasUserAddedExternalServices
+                                                        }
+                                                        selectedSearchContextSpec={this.getSelectedSearchContextSpec()}
+                                                        setSelectedSearchContextSpec={this.setSelectedSearchContextSpec}
+                                                        getUserSearchContextNamespaces={getUserSearchContextNamespaces}
+                                                        fetchAutoDefinedSearchContexts={fetchAutoDefinedSearchContexts}
+                                                        fetchSearchContexts={fetchSearchContexts}
+                                                        fetchSearchContextBySpec={fetchSearchContextBySpec}
+                                                        fetchSearchContext={fetchSearchContext}
+                                                        createSearchContext={createSearchContext}
+                                                        updateSearchContext={updateSearchContext}
+                                                        deleteSearchContext={deleteSearchContext}
+                                                        isSearchContextSpecAvailable={isSearchContextSpecAvailable}
+                                                        defaultSearchContextSpec={this.state.defaultSearchContextSpec}
+                                                        globbing={this.state.globbing}
+                                                        isCodeInsightsGqlApiEnabled={
+                                                            window.context.codeInsightsGqlApiEnabled
+                                                        }
+                                                        fetchSavedSearches={fetchSavedSearches}
+                                                        fetchRecentSearches={fetchRecentSearches}
+                                                        fetchRecentFileViews={fetchRecentFileViews}
+                                                        streamSearch={aggregateStreamingSearch}
+                                                        onUserExternalServicesOrRepositoriesUpdate={
+                                                            this.onUserExternalServicesOrRepositoriesUpdate
+                                                        }
+                                                        onSyncedPublicRepositoriesUpdate={
+                                                            this.onSyncedPublicRepositoriesUpdate
+                                                        }
+                                                        featureFlags={this.state.featureFlags}
+                                                    />
+                                                </CodeHostScopeProvider>
+                                            )}
+                                        />
+                                        <SearchStack />
+                                    </Router>
+                                </ScrollManager>
                                 <Tooltip key={1} />
                                 <Notifications
                                     key={2}

--- a/client/web/src/components/AppRouterContainer/AppRouterContainer.tsx
+++ b/client/web/src/components/AppRouterContainer/AppRouterContainer.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames'
 import React, { HTMLAttributes } from 'react'
+import { ElementScroller } from 'react-scroll-manager'
 
 import styles from './AppRouterContainer.module.scss'
 
@@ -10,7 +11,9 @@ export const AppRouterContainer: React.FunctionComponent<AppRouterContainerProps
     className,
     ...rest
 }) => (
-    <div className={classNames(styles.appRouterContainer, className)} {...rest}>
-        {children}
-    </div>
+    <ElementScroller scrollKey="app-router-container">
+        <div className={classNames(styles.appRouterContainer, className)} {...rest}>
+            {children}
+        </div>
+    </ElementScroller>
 )

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -318,7 +318,12 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
                     </div>
                 )}
 
-                <StreamingSearchResultsList {...props} results={results} allExpanded={allExpanded} />
+                <StreamingSearchResultsList
+                    {...props}
+                    parsedSearchQuery={query}
+                    results={results}
+                    allExpanded={allExpanded}
+                />
             </div>
         </div>
     )

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -318,12 +318,7 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
                     </div>
                 )}
 
-                <StreamingSearchResultsList
-                    {...props}
-                    parsedSearchQuery={query}
-                    results={results}
-                    allExpanded={allExpanded}
-                />
+                <StreamingSearchResultsList {...props} results={results} allExpanded={allExpanded} />
             </div>
         </div>
     )

--- a/client/web/src/search/results/StreamingSearchResultsList.tsx
+++ b/client/web/src/search/results/StreamingSearchResultsList.tsx
@@ -23,7 +23,7 @@ import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
-import { ParsedSearchQueryProps, SearchContextProps } from '..'
+import { SearchContextProps } from '..'
 import { SearchResult } from '../../components/SearchResult'
 
 import { NoResultsPage } from './NoResultsPage'
@@ -32,7 +32,6 @@ import { useItemsToShow } from './use-items-to-show'
 
 export interface StreamingSearchResultsListProps
     extends ThemeProps,
-        ParsedSearchQueryProps,
         SettingsCascadeProps,
         TelemetryProps,
         Pick<SearchContextProps, 'searchContextsEnabled'> {
@@ -44,7 +43,6 @@ export interface StreamingSearchResultsListProps
 }
 
 export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearchResultsListProps> = ({
-    parsedSearchQuery,
     results,
     location,
     allExpanded,
@@ -56,7 +54,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
     searchContextsEnabled,
 }) => {
     const resultsNumber = results?.results.length || 0
-    const { itemsToShow, handleBottomHit } = useItemsToShow(parsedSearchQuery, resultsNumber)
+    const { itemsToShow, handleBottomHit } = useItemsToShow(location.search, resultsNumber)
 
     const logSearchResultClicked = useCallback(() => telemetryService.log('SearchResultClicked'), [telemetryService])
 

--- a/client/web/src/search/results/StreamingSearchResultsList.tsx
+++ b/client/web/src/search/results/StreamingSearchResultsList.tsx
@@ -4,7 +4,7 @@ import FileDocumentIcon from 'mdi-react/FileDocumentIcon'
 import FileIcon from 'mdi-react/FileIcon'
 import SourceCommitIcon from 'mdi-react/SourceCommitIcon'
 import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback } from 'react'
 import { Observable } from 'rxjs'
 
 import { FetchFileParameters } from '@sourcegraph/shared/src/components/CodeExcerpt'
@@ -23,17 +23,16 @@ import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
-import { SearchContextProps } from '..'
+import { ParsedSearchQueryProps, SearchContextProps } from '..'
 import { SearchResult } from '../../components/SearchResult'
 
 import { NoResultsPage } from './NoResultsPage'
 import { StreamingSearchResultFooter } from './StreamingSearchResultsFooter'
-
-const initialItemsToShow = 15
-const incrementalItemsToShow = 10
+import { useItemsToShow } from './use-items-to-show'
 
 export interface StreamingSearchResultsListProps
     extends ThemeProps,
+        ParsedSearchQueryProps,
         SettingsCascadeProps,
         TelemetryProps,
         Pick<SearchContextProps, 'searchContextsEnabled'> {
@@ -45,6 +44,7 @@ export interface StreamingSearchResultsListProps
 }
 
 export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearchResultsListProps> = ({
+    parsedSearchQuery,
     results,
     location,
     allExpanded,
@@ -55,23 +55,8 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
     isSourcegraphDotCom,
     searchContextsEnabled,
 }) => {
-    const [itemsToShow, setItemsToShow] = useState(initialItemsToShow)
-    const onBottomHit = useCallback(
-        () => setItemsToShow(items => Math.min(results?.results.length || 0, items + incrementalItemsToShow)),
-        [results?.results.length]
-    )
-
-    // Reset scroll visibility state when new search is started
-    useEffect(() => {
-        setItemsToShow(initialItemsToShow)
-    }, [location.search])
-
-    const itemKey = useCallback((item: SearchMatch): string => {
-        if (item.type === 'content' || item.type === 'symbol') {
-            return `file:${getMatchUrl(item)}`
-        }
-        return getMatchUrl(item)
-    }, [])
+    const resultsNumber = results?.results.length || 0
+    const { itemsToShow, handleBottomHit } = useItemsToShow(parsedSearchQuery, resultsNumber)
 
     const logSearchResultClicked = useCallback(() => telemetryService.log('SearchResultClicked'), [telemetryService])
 
@@ -131,17 +116,17 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
             <VirtualList<SearchMatch>
                 className="mt-2"
                 itemsToShow={itemsToShow}
-                onShowMoreItems={onBottomHit}
+                onShowMoreItems={handleBottomHit}
                 items={results?.results || []}
                 itemProps={undefined}
                 itemKey={itemKey}
                 renderItem={renderResult}
             />
 
-            {itemsToShow >= (results?.results.length || 0) && (
+            {itemsToShow >= resultsNumber && (
                 <StreamingSearchResultFooter results={results}>
                     <>
-                        {results?.state === 'complete' && results?.results.length === 0 && (
+                        {results?.state === 'complete' && resultsNumber === 0 && (
                             <NoResultsPage
                                 searchContextsEnabled={searchContextsEnabled}
                                 isSourcegraphDotCom={isSourcegraphDotCom}
@@ -154,6 +139,13 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
             )}
         </>
     )
+}
+
+function itemKey(item: SearchMatch): string {
+    if (item.type === 'content' || item.type === 'symbol') {
+        return `file:${getMatchUrl(item)}`
+    }
+    return getMatchUrl(item)
 }
 
 function getFileMatchIcon(result: ContentMatch | SymbolMatch | PathMatch): React.ComponentType<{ className?: string }> {

--- a/client/web/src/search/results/use-items-to-show.test.ts
+++ b/client/web/src/search/results/use-items-to-show.test.ts
@@ -1,0 +1,83 @@
+import { act, renderHook } from '@testing-library/react-hooks'
+import { times } from 'lodash'
+
+import { INCREMENTAL_ITEMS_TO_SHOW, DEFAULT_INITIAL_ITEMS_TO_SHOW, useItemsToShow } from './use-items-to-show'
+
+const RESULTS_NUMBER = 50
+
+function renderUseItemsToShowHook(query = 'Hello there!') {
+    return renderHook(() => useItemsToShow(query, RESULTS_NUMBER))
+}
+
+function scrollToViewMoreResults(scrollNumber: number, handleBottomHit: () => void) {
+    // Do not await `act` call with sync logic. It's not a promise.
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    act(() => {
+        times(scrollNumber, handleBottomHit)
+    })
+}
+
+describe('useItemsToShow', () => {
+    afterEach(() => {
+        sessionStorage.clear()
+    })
+
+    it('returns expected default values', () => {
+        const { result } = renderUseItemsToShowHook()
+        const { itemsToShow, handleBottomHit } = result.current
+
+        expect(handleBottomHit).toEqual(expect.any(Function))
+        expect(itemsToShow).toBe(DEFAULT_INITIAL_ITEMS_TO_SHOW)
+    })
+
+    it('increases `itemsToShow` value on `handleBottomHit()` call', () => {
+        const { result: initialResult } = renderUseItemsToShowHook()
+        const { handleBottomHit } = initialResult.current
+
+        scrollToViewMoreResults(2, handleBottomHit)
+
+        const { result } = renderUseItemsToShowHook()
+        const { itemsToShow } = result.current
+
+        expect(itemsToShow).toBe(DEFAULT_INITIAL_ITEMS_TO_SHOW + INCREMENTAL_ITEMS_TO_SHOW * 2)
+    })
+
+    it('preserves current `itemsToShow` value on a component unmount', () => {
+        const { result: initialResult } = renderUseItemsToShowHook()
+        const { handleBottomHit } = initialResult.current
+
+        scrollToViewMoreResults(2, handleBottomHit)
+
+        const { unmount } = renderUseItemsToShowHook()
+        unmount()
+
+        const { result } = renderUseItemsToShowHook()
+        const { itemsToShow } = result.current
+
+        expect(itemsToShow).toBe(DEFAULT_INITIAL_ITEMS_TO_SHOW + INCREMENTAL_ITEMS_TO_SHOW * 2)
+    })
+
+    it("doesn't go over the current results number", () => {
+        const { result: initialResult } = renderUseItemsToShowHook()
+        const { handleBottomHit } = initialResult.current
+
+        scrollToViewMoreResults(20, handleBottomHit)
+
+        const { result } = renderUseItemsToShowHook()
+        const { itemsToShow } = result.current
+
+        expect(itemsToShow).toBe(RESULTS_NUMBER)
+    })
+
+    it('resets `itemsToShow` if a new query is provided', () => {
+        const { result: initialResult } = renderUseItemsToShowHook()
+        const { handleBottomHit } = initialResult.current
+
+        scrollToViewMoreResults(2, handleBottomHit)
+
+        const { result } = renderUseItemsToShowHook('New query here!')
+        const { itemsToShow } = result.current
+
+        expect(itemsToShow).toBe(DEFAULT_INITIAL_ITEMS_TO_SHOW)
+    })
+})

--- a/client/web/src/search/results/use-items-to-show.ts
+++ b/client/web/src/search/results/use-items-to-show.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useState } from 'react'
+
+export const DEFAULT_INITIAL_ITEMS_TO_SHOW = 15
+export const INCREMENTAL_ITEMS_TO_SHOW = 10
+
+/**
+ * Used to save number of search items user saw previously
+ * to restore scroll position on page-refresh or navigating back to search results.
+ */
+enum SessionStorageKeys {
+    itemsToShow = 'search-items-to-show',
+    query = 'search-items-to-show-for-query',
+}
+
+/**
+ * If a user browsed search results for the same query and scrolled through them ->
+ * return the number of items he saw to restore scroll position without multiple UI jumps.
+ *
+ * Otherwise, return the initial default value.
+ */
+function getInitialItemsToShowValue(query: string): number {
+    const previousQuery = sessionStorage.getItem(SessionStorageKeys.query)
+    const itemsToShow = sessionStorage.getItem(SessionStorageKeys.itemsToShow)
+
+    // In case of receiving new query — reset the state saved in sessionStorage.
+    if (previousQuery !== query) {
+        sessionStorage.setItem(SessionStorageKeys.query, query)
+        sessionStorage.setItem(SessionStorageKeys.itemsToShow, String(DEFAULT_INITIAL_ITEMS_TO_SHOW))
+
+        return DEFAULT_INITIAL_ITEMS_TO_SHOW
+    }
+
+    return Number(itemsToShow) || DEFAULT_INITIAL_ITEMS_TO_SHOW
+}
+
+interface UseItemsToShowResult {
+    itemsToShow: number
+    handleBottomHit: () => void
+}
+
+/**
+ * Preserves the number of items to show for the query by saving it in the session storage.
+ */
+export function useItemsToShow(query: string, resultsNumber: number): UseItemsToShowResult {
+    const [itemsToShow, setItemsToShow] = useState(() => getInitialItemsToShowValue(query))
+
+    const handleBottomHit = useCallback(
+        () =>
+            setItemsToShow(items => {
+                const itemsToShow = Math.min(resultsNumber, items + INCREMENTAL_ITEMS_TO_SHOW)
+                sessionStorage.setItem(SessionStorageKeys.itemsToShow, String(itemsToShow))
+
+                return itemsToShow
+            }),
+        [resultsNumber]
+    )
+
+    // Reset scroll visibility state when new search is started
+    useEffect(() => {
+        setItemsToShow(getInitialItemsToShowValue(query))
+    }, [query])
+
+    return {
+        itemsToShow,
+        handleBottomHit,
+    }
+}

--- a/package.json
+++ b/package.json
@@ -397,6 +397,7 @@
     "react-grid-layout": "1.3.0",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
+    "react-scroll-manager": "^1.0.3",
     "react-sticky-box": "^0.9.3",
     "react-stripe-elements": "^6.1.2",
     "react-textarea-autosize": "^8.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20040,6 +20040,13 @@ react-router@5.2.0, react-router@^5.2.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
+react-scroll-manager@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/react-scroll-manager/-/react-scroll-manager-1.0.3.tgz#06c4be39a874af0d3852f7961c65de2a30ae03ee"
+  integrity sha512-3eU+IygBqpWczvw0Rvl7TuRcQ53EVUTam+eBwUWS8kqLBB4o4eI3yDNvvLzUJ6iD/6kbyTC/sBb8HGGE0AybKQ==
+  dependencies:
+    prop-types "^15.7.2"
+
 react-select@^3.2.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/react-select/-/react-select-3.2.0.tgz#de9284700196f5f9b5277c5d850a9ce85f5c72fe"


### PR DESCRIPTION
## Context

The scroll position is not preserved when going back to search results.

## Changes

**TLDR** The scroll position is now preserved for page refresh and back navigation 🎉 

This PR does two things:
- Adds `ScrollManager` that tracks the scroll position of the search results container, persists it to session storage, and restores it on back navigation or page refresh.
    - [react-scroll-manager](https://github.com/trevorr/react-scroll-manager) is used to handle scroll position info.
- To avoid multiple UI jumps required to reach the previous scroll position, we need to render all items that the user already scrolled through. It's done by extending the `itemsToShow` state used in `StreamingSearchResultsList`.
    - It tracks the number of items shown for the last query and persists this info to session storage. 
    - See `use-items-to-show.test.ts` with tests for all important use-cases.

https://user-images.githubusercontent.com/3846380/146541677-b48456d9-eaa5-42bd-a550-6fbeb97fc248.mov

Should be merged together with https://github.com/sourcegraph/sourcegraph/pull/29176.
Closes https://github.com/sourcegraph/sourcegraph/issues/28845.