### PR TITLE
search-blitz: select:repo, and, or queries

### DIFF
--- a/internal/cmd/search-blitz/queries.txt
+++ b/internal/cmd/search-blitz/queries.txt
@@ -84,3 +84,15 @@ repo:^github\.com/sgtest/megarepo$ type:diff   author:camden before:"february 1 
 
 # mono_commit_small
 repo:^github\.com/sgtest/megarepo$ type:commit author:camden before:"february 1 2021"
+
+# literal_small_select_repo
+patterntype:literal --exclude-task=test select:repo
+
+# literal_large_select_repo
+patterntype:literal lang:go -file:vendor/ count:1000 cfssl select:repo
+
+# and_regex
+patterntype:regexp \beven\b and \bintelligence\b and \bdream\b and \bsimplest\b
+
+# or_regex
+patterntype:regexp \bdeadbeeeeef\b or \bdeadbeeeeeef\b or \bdeadBEEEEEF\b or \bdeadbeeeeef\b or \bdeadbeeeeeef\b or \bdeadBEEEEEF\b or \bdoResults\b


### PR DESCRIPTION
This commit adds a few more queries to search blitz that cover
select:repo, and, or queries.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
