### PR TITLE
Remove CSS transition from selected line

### DIFF
--- a/client/web/src/repo/blob/Blob.module.scss
+++ b/client/web/src/repo/blob/Blob.module.scss
@@ -38,8 +38,6 @@
     }
 
     tr {
-        transition: background 200ms ease-out;
-
         &:global(.selected) {
             background: var(--code-selection-bg);
         }


### PR DESCRIPTION
I want to remove this because it feels like Sourcegraph can't keep up
with the clicks. It feels slow.

In fact: when I said to someone else that I bet it's a CSS transition
why this is slow they said "nah, looks like something's loading in the
background"



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
