### PR TITLE
sg: be consistent and always use stdout.Out, not global out

### DIFF
--- a/dev/sg/live.go
+++ b/dev/sg/live.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/mod/semver"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/run"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
@@ -42,7 +43,7 @@ func getEnvironment(name string) (result environment, found bool) {
 }
 
 func printDeployedVersion(e environment) error {
-	pending := out.Pending(output.Linef("", output.StylePending, "Fetching newest version on %q...", e.Name))
+	pending := stdout.Out.Pending(output.Linef("", output.StylePending, "Fetching newest version on %q...", e.Name))
 
 	resp, err := http.Get(e.URL + "/__version")
 	if err != nil {
@@ -60,7 +61,7 @@ func printDeployedVersion(e environment) error {
 
 	bodyStr := string(body)
 	if semver.IsValid("v" + bodyStr) {
-		out.WriteLine(output.Linef(
+		stdout.Out.WriteLine(output.Linef(
 			output.EmojiLightbulb, output.StyleLogo,
 			"Live on %q: v%s",
 			e.Name, bodyStr,
@@ -75,7 +76,7 @@ func printDeployedVersion(e environment) error {
 	buildDate := elems[1]
 	buildSha := elems[2]
 
-	pending = out.Pending(output.Line("", output.StylePending, "Running 'git fetch' to update list of commits..."))
+	pending = stdout.Out.Pending(output.Line("", output.StylePending, "Running 'git fetch' to update list of commits..."))
 	_, err = run.GitCmd("fetch", "-q")
 	if err != nil {
 		pending.Complete(output.Linef(output.EmojiFailure, output.StyleWarning, "Failed: %s", err))
@@ -89,15 +90,15 @@ func printDeployedVersion(e environment) error {
 		return err
 	}
 
-	out.Write("")
+	stdout.Out.Write("")
 	line := output.Linef(
 		output.EmojiLightbulb, output.StyleLogo,
 		"Live on %q: %s%s%s %s(built on %s)",
 		e.Name, output.StyleBold, buildSha, output.StyleReset, output.StyleLogo, buildDate,
 	)
-	out.WriteLine(line)
+	stdout.Out.WriteLine(line)
 
-	out.Write("")
+	stdout.Out.Write("")
 
 	var shaFound bool
 	for _, logLine := range strings.Split(log, "\n") {
@@ -116,12 +117,12 @@ func printDeployedVersion(e environment) error {
 		}
 
 		line := output.Linef(emoji, style, "%s (%s, %s): %s", sha, timestamp, author, message)
-		out.WriteLine(line)
+		stdout.Out.WriteLine(line)
 	}
 
 	if !shaFound {
 		line := output.Linef(output.EmojiWarning, output.StyleWarning, "Deployed SHA %s not found in last 20 commits on origin/main :(", buildSha)
-		out.WriteLine(line)
+		stdout.Out.WriteLine(line)
 	}
 
 	return nil

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -30,8 +30,6 @@ var secretsStore *secrets.Store
 var (
 	BuildCommit = "dev"
 
-	out = stdout.Out
-
 	// globalConf is the global config. If a command needs to access it, it *must* call
 	// `parseConf` before.
 	globalConf *Config

--- a/dev/sg/printing.go
+++ b/dev/sg/printing.go
@@ -1,27 +1,30 @@
 package main
 
-import "github.com/sourcegraph/sourcegraph/lib/output"
+import (
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
+	"github.com/sourcegraph/sourcegraph/lib/output"
+)
 
 func writeOrangeLinef(fmtStr string, args ...interface{}) {
-	out.WriteLine(output.Linef("", output.CombineStyles(output.StyleBold, output.StyleOrange), fmtStr, args...))
+	stdout.Out.WriteLine(output.Linef("", output.CombineStyles(output.StyleBold, output.StyleOrange), fmtStr, args...))
 }
 
 func writeSuccessLinef(fmtStr string, args ...interface{}) {
-	out.WriteLine(output.Linef(output.EmojiSuccess, output.StyleSuccess, fmtStr, args...))
+	stdout.Out.WriteLine(output.Linef(output.EmojiSuccess, output.StyleSuccess, fmtStr, args...))
 }
 
 func writeFailureLinef(fmtStr string, args ...interface{}) {
-	out.WriteLine(output.Linef(output.EmojiFailure, output.StyleWarning, fmtStr, args...))
+	stdout.Out.WriteLine(output.Linef(output.EmojiFailure, output.StyleWarning, fmtStr, args...))
 }
 
 func writeWarningLinef(fmtStr string, args ...interface{}) {
-	out.WriteLine(output.Linef(output.EmojiWarningSign, output.StyleYellow, fmtStr, args...))
+	stdout.Out.WriteLine(output.Linef(output.EmojiWarningSign, output.StyleYellow, fmtStr, args...))
 }
 
 func writeSkippedLinef(fmtStr string, args ...interface{}) {
-	out.WriteLine(output.Linef(output.EmojiQuestionMark, output.StyleGrey, fmtStr, args...))
+	stdout.Out.WriteLine(output.Linef(output.EmojiQuestionMark, output.StyleGrey, fmtStr, args...))
 }
 
 func writeFingerPointingLinef(fmtStr string, args ...interface{}) {
-	out.WriteLine(output.Linef(output.EmojiFingerPointRight, output.StyleBold, fmtStr, args...))
+	stdout.Out.WriteLine(output.Linef(output.EmojiFingerPointRight, output.StyleBold, fmtStr, args...))
 }

--- a/dev/sg/sg_ci.go
+++ b/dev/sg/sg_ci.go
@@ -107,7 +107,7 @@ Note that Sourcegraph's CI pipelines are under our enterprise license: https://g
 			ShortHelp: "Get the status of the CI run associated with the currently checked out branch",
 			FlagSet:   ciStatusFlagSet,
 			Exec: func(ctx context.Context, args []string) error {
-				client, err := bk.NewClient(ctx, out)
+				client, err := bk.NewClient(ctx, stdout.Out)
 				if err != nil {
 					return err
 				}
@@ -130,7 +130,7 @@ Note that Sourcegraph's CI pipelines are under our enterprise license: https://g
 				printBuildOverview(build)
 
 				if *ciStatusWaitFlag && build.FinishedAt == nil {
-					pending := out.Pending(output.Linef("", output.StylePending, "Waiting for %d jobs...", len(build.Jobs)))
+					pending := stdout.Out.Pending(output.Linef("", output.StylePending, "Waiting for %d jobs...", len(build.Jobs)))
 					err := statusTicker(ctx, func() (bool, error) {
 						// get the next update
 						build, err = client.GetMostRecentBuild(ctx, "sourcegraph", branch)
@@ -180,14 +180,14 @@ Note that Sourcegraph's CI pipelines are under our enterprise license: https://g
 					}
 					commit = strings.TrimSpace(commit)
 					if commit != *build.Commit {
-						out.WriteLine(output.Linef("⚠️", output.StyleSuggestion,
+						stdout.Out.WriteLine(output.Linef("⚠️", output.StyleSuggestion,
 							"The currently checked out commit %q does not match the commit of the build found, %q.\nHave you pushed your most recent changes yet?",
 							commit, *build.Commit))
 					}
 				}
 
 				if failed {
-					out.WriteLine(output.Linef(output.EmojiLightbulb, output.StyleSuggestion,
+					stdout.Out.WriteLine(output.Linef(output.EmojiLightbulb, output.StyleSuggestion,
 						"Some jobs have failed - try using 'sg ci logs' to see what went wrong, or go to the build page: %s", *build.WebURL))
 				}
 
@@ -199,7 +199,7 @@ Note that Sourcegraph's CI pipelines are under our enterprise license: https://g
 			ShortHelp: "Manually request a build for the currently checked out commit and branch (e.g. to trigger builds on forks)",
 			LongHelp:  "Manually request a Buildkite build for the currently checked out commit and branch. This is most useful when triggering builds for PRs from forks (such as those from external contributors), which do not trigger Buildkite builds automatically for security reasons (we do not want to run insecure code on our infrastructure by default!)",
 			Exec: func(ctx context.Context, args []string) error {
-				client, err := bk.NewClient(ctx, out)
+				client, err := bk.NewClient(ctx, stdout.Out)
 				if err != nil {
 					return err
 				}
@@ -217,13 +217,13 @@ Note that Sourcegraph's CI pipelines are under our enterprise license: https://g
 					}
 				}
 
-				out.WriteLine(output.Linef("", output.StylePending, "Requesting build for branch %q at %q...", branch, commit))
+				stdout.Out.WriteLine(output.Linef("", output.StylePending, "Requesting build for branch %q at %q...", branch, commit))
 
 				// simple check to see if commit is in origin, this is non blocking but
 				// we ask for confirmation to double check.
 				remoteBranches, err := run.TrimResult(run.GitCmd("branch", "-r", "--contains", commit))
 				if err != nil || len(remoteBranches) == 0 || !allLinesPrefixed(strings.Split(remoteBranches, "\n"), "origin/") {
-					out.WriteLine(output.Linef(output.EmojiWarning, output.StyleReset,
+					stdout.Out.WriteLine(output.Linef(output.EmojiWarning, output.StyleReset,
 						"Commit %q not found in in local 'origin/' branches - you might be triggering a build for a fork. Make sure all code has been reviewed before continuing.",
 						commit))
 					response, err := open.Prompt("Continue? (yes/no)")
@@ -239,7 +239,7 @@ Note that Sourcegraph's CI pipelines are under our enterprise license: https://g
 				if err != nil {
 					return fmt.Errorf("failed to trigger build for branch %q at %q: %w", branch, commit, err)
 				}
-				out.WriteLine(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Created build: %s", *build.WebURL))
+				stdout.Out.WriteLine(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Created build: %s", *build.WebURL))
 				return nil
 			},
 		}, {
@@ -254,7 +254,7 @@ From there, you can start exploring logs with the Grafana explore panel.
 `,
 			FlagSet: ciLogsFlagSet,
 			Exec: func(ctx context.Context, args []string) error {
-				client, err := bk.NewClient(ctx, out)
+				client, err := bk.NewClient(ctx, stdout.Out)
 				if err != nil {
 					return err
 				}
@@ -273,7 +273,7 @@ From there, you can start exploring logs with the Grafana explore panel.
 				if err != nil {
 					return fmt.Errorf("failed to get most recent build for branch %q: %w", branch, err)
 				}
-				out.WriteLine(output.Linef("", output.StylePending, "Fetching logs for %s ...",
+				stdout.Out.WriteLine(output.Linef("", output.StylePending, "Fetching logs for %s ...",
 					*build.WebURL))
 
 				options := bk.ExportLogsOpts{
@@ -285,7 +285,7 @@ From there, you can start exploring logs with the Grafana explore panel.
 					return err
 				}
 				if len(logs) == 0 {
-					out.WriteLine(output.Line("", output.StyleSuggestion,
+					stdout.Out.WriteLine(output.Line("", output.StyleSuggestion,
 						fmt.Sprintf("No logs found matching the given parameters (job: %q, state: %q).", options.JobQuery, options.State)))
 					return nil
 				}
@@ -295,12 +295,12 @@ From there, you can start exploring logs with the Grafana explore panel.
 					// Buildkite's timestamp thingo causes log lines to not render in terminal
 					bkTimestamp := regexp.MustCompile(`\x1b_bk;t=\d{13}\x07`) // \x1b is ESC, \x07 is BEL
 					for _, log := range logs {
-						block := out.Block(output.Linef(output.EmojiInfo, output.StyleUnderline, "%s",
+						block := stdout.Out.Block(output.Linef(output.EmojiInfo, output.StyleUnderline, "%s",
 							*log.JobMeta.Name))
 						block.Write(bkTimestamp.ReplaceAllString(*log.Content, ""))
 						block.Close()
 					}
-					out.WriteLine(output.Linef("", output.StyleSuccess, "Found and output logs for %d jobs.", len(logs)))
+					stdout.Out.WriteLine(output.Linef("", output.StyleSuccess, "Found and output logs for %d jobs.", len(logs)))
 
 				default:
 					lokiURL, err := url.Parse(*ciLogsOutFlag)
@@ -308,13 +308,13 @@ From there, you can start exploring logs with the Grafana explore panel.
 						return fmt.Errorf("invalid Loki target: %w", err)
 					}
 					lokiClient := loki.NewLokiClient(lokiURL)
-					out.WriteLine(output.Linef("", output.StylePending, "Pushing to Loki instance at %q", lokiURL.Host))
+					stdout.Out.WriteLine(output.Linef("", output.StylePending, "Pushing to Loki instance at %q", lokiURL.Host))
 
 					var (
 						pushedEntries int
 						pushedStreams int
 						pushErrs      []string
-						pending       = out.Pending(output.Linef("", output.StylePending, "Processing logs..."))
+						pending       = stdout.Out.Pending(output.Linef("", output.StylePending, "Processing logs..."))
 					)
 					for i, log := range logs {
 						job := log.JobMeta.Job
@@ -360,7 +360,7 @@ From there, you can start exploring logs with the Grafana explore panel.
 
 					if pushErrs != nil {
 						failedStreams := len(logs) - pushedStreams
-						out.WriteLine(output.Linef(output.EmojiFailure, output.StyleWarning,
+						stdout.Out.WriteLine(output.Linef(output.EmojiFailure, output.StyleWarning,
 							"Failed to push %d streams: \n - %s", failedStreams, strings.Join(pushErrs, "\n - ")))
 						if failedStreams == len(logs) {
 							return errors.New("failed to push all logs")
@@ -384,15 +384,15 @@ func allLinesPrefixed(lines []string, match string) bool {
 }
 
 func printBuildOverview(build *buildkite.Build) {
-	out.WriteLine(output.Linef("", output.StyleBold, "Most recent build: %s", *build.WebURL))
-	out.Writef("Commit:\t\t%s\nMessage:\t%s\nAuthor:\t\t%s <%s>",
+	stdout.Out.WriteLine(output.Linef("", output.StyleBold, "Most recent build: %s", *build.WebURL))
+	stdout.Out.Writef("Commit:\t\t%s\nMessage:\t%s\nAuthor:\t\t%s <%s>",
 		*build.Commit, *build.Message, build.Author.Name, build.Author.Email)
 }
 
 func printBuildResults(build *buildkite.Build, notify bool) (failed bool) {
-	out.Writef("Started:\t%s", build.StartedAt)
+	stdout.Out.Writef("Started:\t%s", build.StartedAt)
 	if build.FinishedAt != nil {
-		out.Writef("Finished:\t%s (elapsed: %s)", build.FinishedAt, build.FinishedAt.Sub(build.StartedAt.Time))
+		stdout.Out.Writef("Finished:\t%s (elapsed: %s)", build.FinishedAt, build.FinishedAt.Sub(build.StartedAt.Time))
 	}
 
 	// Valid states: running, scheduled, passed, failed, blocked, canceled, canceling, skipped, not_run, waiting
@@ -417,7 +417,7 @@ func printBuildResults(build *buildkite.Build, notify bool) (failed bool) {
 	default:
 		style = output.StyleWarning
 	}
-	block := out.Block(output.Linef("", style, "Status:\t\t%s %s", emoji, *build.State))
+	block := stdout.Out.Block(output.Linef("", style, "Status:\t\t%s %s", emoji, *build.State))
 
 	// Inspect jobs individually.
 	failedSummary := []string{"Failed jobs:"}

--- a/dev/sg/sg_doctor.go
+++ b/dev/sg/sg_doctor.go
@@ -8,6 +8,7 @@ import (
 	"github.com/peterbourgon/ff/v3/ffcli"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/run"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
 )
 
 var (
@@ -27,7 +28,7 @@ See the "checks:" in the configuration file.`,
 func doctorExec(ctx context.Context, args []string) error {
 	ok, errLine := parseConf(*configFlag, *overwriteConfigFlag)
 	if !ok {
-		out.WriteLine(errLine)
+		stdout.Out.WriteLine(errLine)
 		os.Exit(1)
 	}
 

--- a/dev/sg/sg_live.go
+++ b/dev/sg/sg_live.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
@@ -41,12 +42,12 @@ func constructLiveCmdLongHelp() string {
 
 func liveExec(ctx context.Context, args []string) error {
 	if len(args) == 0 {
-		out.WriteLine(output.Linef("", output.StyleWarning, "No environment specified"))
+		stdout.Out.WriteLine(output.Linef("", output.StyleWarning, "No environment specified"))
 		return flag.ErrHelp
 	}
 
 	if len(args) != 1 {
-		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: too many arguments"))
+		stdout.Out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: too many arguments"))
 		return flag.ErrHelp
 	}
 
@@ -55,7 +56,7 @@ func liveExec(ctx context.Context, args []string) error {
 		if customURL, err := url.Parse(args[0]); err == nil {
 			e = environment{Name: customURL.Host, URL: customURL.String()}
 		} else {
-			out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: environment %q not found, or is not a valid URL :(", args[0]))
+			stdout.Out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: environment %q not found, or is not a valid URL :(", args[0]))
 			return flag.ErrHelp
 		}
 	}

--- a/dev/sg/sg_rfc.go
+++ b/dev/sg/sg_rfc.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/peterbourgon/ff/v3/ffcli"
+
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/rfc"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
 )
 
 var (
@@ -28,21 +30,21 @@ func rfcExec(ctx context.Context, args []string) error {
 
 	switch args[0] {
 	case "list":
-		return rfc.List(ctx, out)
+		return rfc.List(ctx, stdout.Out)
 
 	case "search":
 		if len(args) != 2 {
 			return errors.New("no search query given")
 		}
 
-		return rfc.Search(ctx, args[1], out)
+		return rfc.Search(ctx, args[1], stdout.Out)
 
 	case "open":
 		if len(args) != 2 {
 			return errors.New("no number given")
 		}
 
-		return rfc.Open(ctx, args[1], out)
+		return rfc.Open(ctx, args[1], stdout.Out)
 	}
 
 	return nil

--- a/dev/sg/sg_run.go
+++ b/dev/sg/sg_run.go
@@ -11,6 +11,7 @@ import (
 	"github.com/peterbourgon/ff/v3/ffcli"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/run"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
@@ -29,12 +30,12 @@ var (
 func runExec(ctx context.Context, args []string) error {
 	ok, errLine := parseConf(*configFlag, *overwriteConfigFlag)
 	if !ok {
-		out.WriteLine(errLine)
+		stdout.Out.WriteLine(errLine)
 		os.Exit(1)
 	}
 
 	if len(args) == 0 {
-		out.WriteLine(output.Linef("", output.StyleWarning, "No command specified"))
+		stdout.Out.WriteLine(output.Linef("", output.StyleWarning, "No command specified"))
 		return flag.ErrHelp
 	}
 
@@ -42,7 +43,7 @@ func runExec(ctx context.Context, args []string) error {
 	for _, arg := range args {
 		cmd, ok := globalConf.Commands[arg]
 		if !ok {
-			out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: command %q not found :(", arg))
+			stdout.Out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: command %q not found :(", arg))
 			return flag.ErrHelp
 		}
 		cmds = append(cmds, cmd)

--- a/dev/sg/sg_secret.go
+++ b/dev/sg/sg_secret.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
@@ -68,8 +70,8 @@ func listSecretExec(ctx context.Context, args []string) error {
 	if err := loadSecrets(); err != nil {
 		return err
 	}
-	out.WriteLine(output.Linef("", output.StyleBold, "Secrets:"))
+	stdout.Out.WriteLine(output.Linef("", output.StyleBold, "Secrets:"))
 	keys := secretsStore.Keys()
-	out.WriteLine(output.Linef("", output.StyleWarning, strings.Join(keys, ", ")))
+	stdout.Out.WriteLine(output.Linef("", output.StyleWarning, strings.Join(keys, ", ")))
 	return nil
 }

--- a/dev/sg/sg_team.go
+++ b/dev/sg/sg_team.go
@@ -7,8 +7,10 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/peterbourgon/ff/v3/ffcli"
+
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/open"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/slack"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
 )
 
 var (
@@ -36,7 +38,7 @@ func teammateExec(ctx context.Context, args []string) error {
 		if err != nil {
 			return err
 		}
-		out.Writef(str)
+		stdout.Out.Writef(str)
 		return nil
 	case "handbook":
 		if len(args) < 2 {

--- a/dev/sg/sg_tests.go
+++ b/dev/sg/sg_tests.go
@@ -8,6 +8,7 @@ import (
 	"github.com/peterbourgon/ff/v3/ffcli"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/run"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
@@ -26,18 +27,18 @@ var (
 func testExec(ctx context.Context, args []string) error {
 	ok, errLine := parseConf(*configFlag, *overwriteConfigFlag)
 	if !ok {
-		out.WriteLine(errLine)
+		stdout.Out.WriteLine(errLine)
 		os.Exit(1)
 	}
 
 	if len(args) == 0 {
-		out.WriteLine(output.Linef("", output.StyleWarning, "No test suite specified"))
+		stdout.Out.WriteLine(output.Linef("", output.StyleWarning, "No test suite specified"))
 		return flag.ErrHelp
 	}
 
 	cmd, ok := globalConf.Tests[args[0]]
 	if !ok {
-		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: test suite %q not found :(", args[0]))
+		stdout.Out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: test suite %q not found :(", args[0]))
 		return flag.ErrHelp
 	}
 

--- a/dev/sg/sg_version.go
+++ b/dev/sg/sg_version.go
@@ -5,6 +5,8 @@ import (
 	"flag"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
 )
 
 var (
@@ -19,6 +21,6 @@ var (
 )
 
 func versionExec(ctx context.Context, args []string) error {
-	out.Write(BuildCommit)
+	stdout.Out.Write(BuildCommit)
 	return nil
 }


### PR DESCRIPTION
This changes all the places that previously used `out` (defined in `main.go`) to use `stdout.Out`. Still a global, yes. But now the same one is used everywhere and can be used from `sg/internal` packages