### PR TITLE
Fix filter creation flow for capture group insight

### DIFF
--- a/client/web/src/enterprise/insights/core/backend/gql-api/methods/create-insight/create-insight.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-api/methods/create-insight/create-insight.ts
@@ -10,8 +10,6 @@ import {
     GetDashboardInsightsVariables,
     InsightViewNode,
     PieChartSearchInsightInput,
-    UpdateLineChartSearchInsightResult,
-    UpdateLineChartSearchInsightVariables,
 } from '../../../../../../../graphql-operations'
 import {
     CaptureGroupInsight,
@@ -21,12 +19,11 @@ import {
     isVirtualDashboard,
     SearchBasedInsight,
 } from '../../../../types'
-import { SearchBackendBasedInsight } from '../../../../types/insight/search-insight'
 import { InsightCreateInput } from '../../../code-insights-backend-types'
 import { createInsightView } from '../../deserialization/create-insight-view'
 import { GET_DASHBOARD_INSIGHTS_GQL } from '../../gql/GetDashboardInsights'
 import { INSIGHT_VIEW_FRAGMENT } from '../../gql/GetInsights'
-import { getSearchInsightUpdateInput } from '../update-insight/serializators'
+import { updateInsight, UpdateResult } from '../update-insight/update-insight'
 
 import { getInsightCreateGqlInput, getLangStatsInsightCreateInput } from './serializators'
 
@@ -74,7 +71,6 @@ function createSearchBasedInsight(
     // supports filters in the create insight mutation.
     // TODO: Remove this imperative logic as soon as be supports filters
     if (insight.type === InsightExecutionType.Backend && insight.filters) {
-        const filters = insight.filters
         return from(
             apolloClient.mutate<FirstStepCreateSearchBasedInsightResult>({
                 mutation: gql`
@@ -97,25 +93,12 @@ function createSearchBasedInsight(
                     return of()
                 }
 
-                const createdInsight = createInsightView(
-                    data.createLineChartSearchInsight.view
-                ) as SearchBackendBasedInsight
+                const createdInsight = createInsightView(data.createLineChartSearchInsight.view)
 
-                const input = getSearchInsightUpdateInput({ ...createdInsight, filters })
-
-                return apolloClient.mutate<UpdateLineChartSearchInsightResult, UpdateLineChartSearchInsightVariables>({
-                    mutation: gql`
-                        mutation UpdateLineChartSearchInsight($input: UpdateLineChartSearchInsightInput!, $id: ID!) {
-                            updateLineChartSearchInsight(input: $input, id: $id) {
-                                view {
-                                    ...InsightViewNode
-                                }
-                            }
-                        }
-                        ${INSIGHT_VIEW_FRAGMENT}
-                    `,
-                    variables: { input, id: createdInsight.id },
-                    update(cache, result) {
+                return updateInsight(
+                    apolloClient,
+                    { oldInsight: createdInsight, newInsight: createdInsight },
+                    (cache, result) => {
                         const { data } = result
 
                         if (!data) {
@@ -123,8 +106,8 @@ function createSearchBasedInsight(
                         }
 
                         searchInsightCreationOptimisticUpdate(cache, data, dashboard)
-                    },
-                })
+                    }
+                )
             })
         )
     }
@@ -150,13 +133,18 @@ function createSearchBasedInsight(
  * add newly created insight to the cache dashboard that insight was crated from.
  */
 function searchInsightCreationOptimisticUpdate(
-    cache: ApolloCache<object>,
-    data: UpdateLineChartSearchInsightResult,
+    cache: ApolloCache<unknown>,
+    data: UpdateResult,
     dashboard: InsightDashboard | null
 ): void {
+    const createInsightIdRaw =
+        'updateLineChartSearchInsight' in data
+            ? data.updateLineChartSearchInsight.view.id
+            : data.updatePieChartSearchInsight.view.id
+
     const createdInsightId = cache.identify({
         __typename: 'InsightView',
-        id: data.updateLineChartSearchInsight.view.id,
+        id: createInsightIdRaw,
     })
 
     const cachedInsight = cache.readFragment<InsightViewNode>({

--- a/client/web/src/enterprise/insights/core/backend/gql-api/methods/create-insight/create-insight.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-api/methods/create-insight/create-insight.ts
@@ -93,7 +93,10 @@ function createSearchBasedInsight(
                     return of()
                 }
 
-                const createdInsight = createInsightView(data.createLineChartSearchInsight.view)
+                const createdInsight = {
+                    ...createInsightView(data.createLineChartSearchInsight.view),
+                    filters: insight.filters,
+                }
 
                 return updateInsight(
                     apolloClient,

--- a/client/web/src/enterprise/insights/core/backend/gql-api/methods/update-insight/update-insight.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-api/methods/update-insight/update-insight.ts
@@ -1,4 +1,6 @@
 import { ApolloClient } from '@apollo/client'
+import { ApolloCache } from '@apollo/client/cache'
+import { MutationUpdaterFunction } from '@apollo/client/core/types'
 import { from, Observable } from 'rxjs'
 
 import {
@@ -18,7 +20,14 @@ import {
     getSearchInsightUpdateInput,
 } from './serializators'
 
-export const updateInsight = (client: ApolloClient<unknown>, input: InsightUpdateInput): Observable<unknown> => {
+type UpdateVariables = UpdateLineChartSearchInsightVariables | UpdateLangStatsInsightVariables
+export type UpdateResult = UpdateLineChartSearchInsightResult | UpdateLangStatsInsightResult
+
+export const updateInsight = (
+    client: ApolloClient<unknown>,
+    input: InsightUpdateInput,
+    update?: MutationUpdaterFunction<UpdateResult, UpdateVariables, unknown, ApolloCache<unknown>>
+): Observable<unknown> => {
     const insight = input.newInsight
     const oldInsight = input.oldInsight
 
@@ -28,6 +37,7 @@ export const updateInsight = (client: ApolloClient<unknown>, input: InsightUpdat
                 client.mutate<UpdateLineChartSearchInsightResult, UpdateLineChartSearchInsightVariables>({
                     mutation: UPDATE_LINE_CHART_SEARCH_INSIGHT_GQL,
                     variables: { input: getSearchInsightUpdateInput(insight), id: oldInsight.id },
+                    update,
                 })
             )
         }
@@ -37,6 +47,7 @@ export const updateInsight = (client: ApolloClient<unknown>, input: InsightUpdat
                 client.mutate<UpdateLineChartSearchInsightResult, UpdateLineChartSearchInsightVariables>({
                     mutation: UPDATE_LINE_CHART_SEARCH_INSIGHT_GQL,
                     variables: { input: getCaptureGroupInsightUpdateInput(insight), id: oldInsight.id },
+                    update,
                 })
             )
         }
@@ -49,6 +60,7 @@ export const updateInsight = (client: ApolloClient<unknown>, input: InsightUpdat
                         id: oldInsight.id,
                         input: getLangStatsInsightUpdateInput(insight),
                     },
+                    update,
                 })
             )
         }


### PR DESCRIPTION

Prior to this PR if you tried to create capture group insight through drill-down filters flow (save s new view button) you see FE runtime error about that we couldn't parse response properly `map isn't a function of undefined`. 

This PR utilizes create handler and reuse update handler for handling all possible insight types. 

## How to test
- Try to create capture group and other insights through drill-down filters (with filters and without) 
- Tyr to edit capture group insight or search based insight 