### PR TITLE
insights: fix missing language stats generation method and just in time values in oob migration

### DIFF
--- a/enterprise/internal/insights/migration/discovery.go
+++ b/enterprise/internal/insights/migration/discovery.go
@@ -277,6 +277,8 @@ func migrateLangStatSeries(ctx context.Context, insightStore *store.InsightStore
 		SeriesID:           ksuid.New().String(),
 		Repositories:       []string{from.Repository},
 		SampleIntervalUnit: string(types.Month),
+		JustInTime:         true,
+		GenerationMethod:   types.LanguageStats,
 	}
 	var grants []store.InsightViewGrant
 	if from.UserID != nil {


### PR DESCRIPTION
Fixes missing values in the OOB migration for language stats insights.