### PR TITLE
tos consent: fix qa tests and some extra fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - Search contexts can now be defined with a restricted search query as an alternative to a specific list of repositories and revisions. This feature is _beta_ and may change in the following releases. Allowed filters: `repo`, `rev`, `file`, `lang`, `case`, `fork`, `visibility`. `OR`, `AND` expressions are also allowed. To enable this feature to all users, set `experimentalFeatures.searchContextsQuery` to true in global settings. You'll then see a "Create context" button from the search results page and a "Query" input field in the search contexts form. If you want revisions specified in these query based search contexts to be indexed, set `experimentalFeatures.search.index.query.contexts` to true in site configuration. [#29327](https://github.com/sourcegraph/sourcegraph/pull/29327)
+- More explicit Terms of Service and Privacy Policy consent has been added to Sourcegraph Server. [#28716](https://github.com/sourcegraph/sourcegraph/issues/28716)
 
 ### Changed
 
@@ -51,7 +52,6 @@ All notable changes to Sourcegraph are documented in this file.
 - Code Insights is persisted entirely in the `codeinsights-db` database. A migration will automatically be performed to move any defined insights and dashboards from your user, org, or global settings files.
 - The GraphQL API for Code Insights has entered beta. [docs](https://docs.sourcegraph.com/code_insights/references/code_insights_graphql_api)
 - The `SRC_GIT_SERVICE_MAX_EGRESS_BYTES_PER_SECOND` environment variable to control the egress throughput of gitserver's git service (e.g. used by zoekt-index-server to clone repos to index). Set to -1 for no limit. [#29197](https://github.com/sourcegraph/sourcegraph/pull/29197)
-- More explicit Terms of Service and Privacy Policy consent has been added to Sourcegraph Server. [#28716](https://github.com/sourcegraph/sourcegraph/issues/28716)
 - Search suggestions via the GraphQL API were deprecated last release and are now no longer available. Suggestions now work only with the search streaming API. [#29283](https://github.com/sourcegraph/sourcegraph/pull/29283)
 
 ### Changed

--- a/client/web/src/Layout.test.tsx
+++ b/client/web/src/Layout.test.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { BrowserRouter } from 'react-router-dom'
 import { NEVER } from 'rxjs'
 
+import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { extensionsController } from '@sourcegraph/shared/src/util/searchTestHelpers'
 
 import { SearchPatternType } from './graphql-operations'
@@ -56,9 +57,11 @@ describe('Layout', () => {
         useNavbarQueryState.setState({ searchPatternType: SearchPatternType.literal })
 
         render(
-            <BrowserRouter>
-                <Layout {...defaultProps} history={history} location={history.location} />
-            </BrowserRouter>
+            <MockedTestProvider>
+                <BrowserRouter>
+                    <Layout {...defaultProps} history={history} location={history.location} />
+                </BrowserRouter>
+            </MockedTestProvider>
         )
 
         expect(useNavbarQueryState.getState().searchPatternType).toBe(SearchPatternType.regexp)
@@ -71,9 +74,11 @@ describe('Layout', () => {
         useNavbarQueryState.setState({ searchPatternType: SearchPatternType.literal })
 
         render(
-            <BrowserRouter>
-                <Layout {...defaultProps} history={history} location={history.location} />
-            </BrowserRouter>
+            <MockedTestProvider>
+                <BrowserRouter>
+                    <Layout {...defaultProps} history={history} location={history.location} />
+                </BrowserRouter>
+            </MockedTestProvider>
         )
 
         expect(useNavbarQueryState.getState().searchPatternType).toBe(SearchPatternType.literal)
@@ -86,9 +91,11 @@ describe('Layout', () => {
         useNavbarQueryState.setState({ searchCaseSensitivity: false })
 
         render(
-            <BrowserRouter>
-                <Layout {...defaultProps} history={history} location={history.location} />
-            </BrowserRouter>
+            <MockedTestProvider>
+                <BrowserRouter>
+                    <Layout {...defaultProps} history={history} location={history.location} />
+                </BrowserRouter>
+            </MockedTestProvider>
         )
 
         expect(useNavbarQueryState.getState().searchCaseSensitivity).toBe(true)
@@ -101,9 +108,11 @@ describe('Layout', () => {
         useNavbarQueryState.setState({ searchCaseSensitivity: false })
 
         render(
-            <BrowserRouter>
-                <Layout {...defaultProps} history={history} location={history.location} />
-            </BrowserRouter>
+            <MockedTestProvider>
+                <BrowserRouter>
+                    <Layout {...defaultProps} history={history} location={history.location} />
+                </BrowserRouter>
+            </MockedTestProvider>
         )
 
         expect(useNavbarQueryState.getState().searchCaseSensitivity).toBe(false)

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useCallback, useEffect, useMemo } from 'react'
+import React, { Suspense, useCallback, useEffect, useMemo, useState } from 'react'
 import { Redirect, Route, RouteComponentProps, Switch, matchPath } from 'react-router'
 import { Observable } from 'rxjs'
 
@@ -16,6 +16,7 @@ import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 import { LoadingSpinner } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser, authRequired as authRequiredObservable } from './auth'
+import { TosConsentModal } from './auth/TosConsentModal'
 import { BatchChangesProps } from './batches'
 import { CodeIntelligenceProps } from './codeintel'
 import { communitySearchContextsRoutes } from './communitySearchContexts/routes'
@@ -180,9 +181,25 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
     }, [startExtensionAlertAnimation])
 
     useScrollToLocationHash(props.location)
+
+    const [tosAccepted, setTosAccepted] = useState(false)
+    useEffect(() => setTosAccepted(!props.authenticatedUser || props.authenticatedUser.tosAccepted), [
+        props.authenticatedUser,
+    ])
+    const afterTosAccepted = useCallback(() => {
+        setTosAccepted(true)
+    }, [])
+
     // Remove trailing slash (which is never valid in any of our URLs).
     if (props.location.pathname !== '/' && props.location.pathname.endsWith('/')) {
         return <Redirect to={{ ...props.location, pathname: props.location.pathname.slice(0, -1) }} />
+    }
+
+    // If a user has not accepted the Terms of Service yet, show the modal to force them to accept
+    // before continuing to use Sourcegraph. This is only done on self-hosted Sourcegraph Server;
+    // cloud users are all considered to have accepted regarless of the value of `tosAccepted`.
+    if (!props.isSourcegraphDotCom && !tosAccepted) {
+        return <TosConsentModal afterTosAccepted={afterTosAccepted} />
     }
 
     const context: LayoutRouteComponentProps<any> = {

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -182,7 +182,7 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
 
     useScrollToLocationHash(props.location)
 
-    const [tosAccepted, setTosAccepted] = useState(false)
+    const [tosAccepted, setTosAccepted] = useState(true) // Assume TOS has been accepted so that we don't show the TOS modal on initial load
     useEffect(() => setTosAccepted(!props.authenticatedUser || props.authenticatedUser.tosAccepted), [
         props.authenticatedUser,
     ])

--- a/client/web/src/auth.ts
+++ b/client/web/src/auth.ts
@@ -48,6 +48,7 @@ export function refreshAuthenticatedUser(): Observable<never> {
                 }
                 viewerCanAdminister
                 tags
+                tosAccepted
             }
         }
     `).pipe(

--- a/client/web/src/auth/SignUpForm.tsx
+++ b/client/web/src/auth/SignUpForm.tsx
@@ -21,7 +21,7 @@ import { LoaderButton } from '../components/LoaderButton'
 import { FeatureFlagProps } from '../featureFlags/featureFlags'
 import { AuthProvider, SourcegraphContext } from '../jscontext'
 import { ANONYMOUS_USER_ID_KEY, eventLogger, FIRST_SOURCE_URL_KEY, LAST_SOURCE_URL_KEY } from '../tracking/eventLogger'
-import { enterpriseTrial, signupTerms } from '../util/features'
+import { enterpriseTrial } from '../util/features'
 
 import { OrDivider } from './OrDivider'
 import { maybeAddPostSignUpRedirect, PasswordInput, UsernameInput } from './SignInSignUpCommon'
@@ -288,7 +288,7 @@ export const SignUpForm: React.FunctionComponent<SignUpFormProps> = ({
                     </>
                 )}
 
-                {!experimental && signupTerms && (
+                {!experimental && (
                     <p className="mt-3 mb-0">
                         <small className="form-text text-muted">
                             By signing up, you agree to our {/* eslint-disable-next-line react/jsx-no-target-blank */}

--- a/client/web/src/auth/TosConsentModal.module.scss
+++ b/client/web/src/auth/TosConsentModal.module.scss
@@ -1,0 +1,22 @@
+.container {
+    display: flex;
+    height: 100%;
+    flex-direction: column;
+    padding: 1.5rem;
+}
+
+.icon {
+    width: 1.75rem;
+    height: 1.75rem;
+    margin-bottom: 1.5rem;
+    flex-shrink: 0;
+}
+
+.content {
+    display: flex;
+    flex-grow: 1;
+    align-self: center;
+    flex-direction: column;
+    justify-content: center;
+    max-width: 38rem;
+}

--- a/client/web/src/auth/TosConsentModal.story.tsx
+++ b/client/web/src/auth/TosConsentModal.story.tsx
@@ -1,0 +1,10 @@
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+
+import { WebStory } from '../components/WebStory'
+
+import { TosConsentModal } from './TosConsentModal'
+
+const { add } = storiesOf('web/auth/TosConsentModal', module)
+
+add('standard', () => <WebStory>{() => <TosConsentModal afterTosAccepted={() => {}} />}</WebStory>)

--- a/client/web/src/auth/TosConsentModal.test.tsx
+++ b/client/web/src/auth/TosConsentModal.test.tsx
@@ -1,0 +1,66 @@
+import { MockedProvider } from '@apollo/client/testing'
+import { fireEvent, render } from '@testing-library/react'
+import React from 'react'
+import * as sinon from 'sinon'
+
+import { MockedTestProvider, waitForNextApolloResponse } from '@sourcegraph/shared/src/testing/apollo'
+
+import { SET_TOS_ACCEPTED_MUTATION, TosConsentModal } from './TosConsentModal'
+
+describe('TosConsentModal', () => {
+    it('should call afterTosAccepted if request was successful', async () => {
+        const mocks = [
+            {
+                request: {
+                    query: SET_TOS_ACCEPTED_MUTATION,
+                },
+                result: { data: { alwaysNil: null } },
+            },
+        ]
+
+        const afterTosAccepted = sinon.spy()
+        const component = render(
+            <MockedProvider mocks={mocks}>
+                <TosConsentModal afterTosAccepted={afterTosAccepted} />
+            </MockedProvider>
+        )
+
+        const checkbox = component.getByLabelText(/I agree/)
+        fireEvent.click(checkbox)
+
+        const button = component.getByText(/Agree and continue/)
+        fireEvent.click(button)
+
+        await waitForNextApolloResponse()
+
+        expect(afterTosAccepted.calledOnce).toBeTruthy()
+    })
+
+    it('should not call afterTosAccepted if there was an error', async () => {
+        const mocks = [
+            {
+                request: {
+                    query: SET_TOS_ACCEPTED_MUTATION,
+                },
+                error: new Error('An error occurred'),
+            },
+        ]
+
+        const afterTosAccepted = sinon.spy()
+        const component = render(
+            <MockedTestProvider mocks={mocks}>
+                <TosConsentModal afterTosAccepted={afterTosAccepted} />
+            </MockedTestProvider>
+        )
+
+        const checkbox = component.getByLabelText(/I agree/)
+        fireEvent.click(checkbox)
+
+        const button = component.getByText(/Agree and continue/)
+        fireEvent.click(button)
+
+        await waitForNextApolloResponse()
+
+        expect(afterTosAccepted.notCalled).toBeTruthy()
+    })
+})

--- a/client/web/src/auth/TosConsentModal.tsx
+++ b/client/web/src/auth/TosConsentModal.tsx
@@ -1,0 +1,84 @@
+import { gql, useMutation } from '@apollo/client'
+import React, { useCallback, useState } from 'react'
+
+import { LoaderButton } from '../components/LoaderButton'
+
+import { SourcegraphIcon } from './icons'
+import styles from './TosConsentModal.module.scss'
+
+export const SET_TOS_ACCEPTED_MUTATION = gql`
+    mutation {
+        setTosAccepted {
+            alwaysNil
+        }
+    }
+`
+
+export const TosConsentModal: React.FunctionComponent<{ afterTosAccepted: () => void }> = ({ afterTosAccepted }) => {
+    const [agree, setAgree] = useState(false)
+
+    const onAgreeChanged = useCallback((event: React.ChangeEvent<HTMLInputElement>): void => {
+        setAgree(event.target.checked)
+    }, [])
+
+    const [setTosAccepted, { loading, error }] = useMutation(SET_TOS_ACCEPTED_MUTATION)
+
+    const onSubmit = useCallback(
+        async (event: React.FormEvent<HTMLFormElement>): Promise<void> => {
+            event.preventDefault()
+
+            try {
+                await setTosAccepted()
+                afterTosAccepted()
+            } catch (error) {
+                console.error(error)
+            }
+        },
+        [afterTosAccepted, setTosAccepted]
+    )
+
+    return (
+        <div className={styles.container}>
+            <SourcegraphIcon className={styles.icon} />
+            <div className={styles.content}>
+                <h1>We respect your data privacy</h1>
+                <p className="mb-5">
+                    We take data privacy seriously. We collect only what we need to provide a great experience, and we
+                    never have access to your private data or code.
+                </p>
+                <form onSubmit={onSubmit}>
+                    <div className="form-group">
+                        <div className="form-check">
+                            <label className="form-check-label">
+                                <input type="checkbox" className="form-check-input" onChange={onAgreeChanged} /> I agree
+                                to Sourcegraph's{' '}
+                                <a href="https://about.sourcegraph.com/terms" target="_blank" rel="noopener">
+                                    Terms of Service
+                                </a>{' '}
+                                and{' '}
+                                <a href="https://about.sourcegraph.com/privacy" target="_blank" rel="noopener">
+                                    Privacy Policy
+                                </a>{' '}
+                                (required)
+                            </label>
+                        </div>
+                    </div>
+                    <LoaderButton
+                        loading={loading}
+                        label="Agree and continue"
+                        type="submit"
+                        disabled={!agree}
+                        className="btn btn-primary mt-4"
+                    />
+                </form>
+                <p className="mt-5">
+                    If you do not agree, <a href="/-/sign-out">Sign Out</a> and contact your site admin to have your
+                    account deleted.
+                </p>
+                {error && (
+                    <div className="alert alert-danger mt-4">Error accepting Terms of Service: {error.message}</div>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/client/web/src/auth/TosConsentModal.tsx
+++ b/client/web/src/auth/TosConsentModal.tsx
@@ -72,7 +72,7 @@ export const TosConsentModal: React.FunctionComponent<{ afterTosAccepted: () => 
                     />
                 </form>
                 <p className="mt-5">
-                    If you do not agree, <a href="/-/sign-out">Sign Out</a> and contact your site admin to have your
+                    If you do not agree, <a href="/-/sign-out">sign out</a> and contact your site admin to have your
                     account deleted.
                 </p>
                 {error && (

--- a/client/web/src/auth/__snapshots__/SignUpPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignUpPage.test.tsx.snap
@@ -276,6 +276,31 @@ exports[`SignUpPage renders sign up page (server) 1`] = `
               Register
             </button>
           </div>
+          <p
+            class="mt-3 mb-0"
+          >
+            <small
+              class="form-text text-muted"
+            >
+              By signing up, you agree to our 
+              <a
+                href="https://about.sourcegraph.com/terms"
+                rel="noopener"
+                target="_blank"
+              >
+                Terms of Service
+              </a>
+               and 
+              <a
+                href="https://about.sourcegraph.com/privacy"
+                rel="noopener"
+                target="_blank"
+              >
+                Privacy Policy
+              </a>
+              .
+            </small>
+          </p>
         </form>
         <p
           class="mt-3"

--- a/client/web/src/communitySearchContexts/CommunitySearchContextPage.story.tsx
+++ b/client/web/src/communitySearchContexts/CommunitySearchContextPage.story.tsx
@@ -68,6 +68,7 @@ const authUser: AuthenticatedUser = {
     tags: [],
     viewerCanAdminister: true,
     databaseID: 0,
+    tosAccepted: true,
 }
 
 const repositories: ISearchContextRepositoryRevisions[] = [

--- a/client/web/src/enterprise/code-monitoring/testing/util.ts
+++ b/client/web/src/enterprise/code-monitoring/testing/util.ts
@@ -19,6 +19,7 @@ export const mockUser: AuthenticatedUser = {
         nodes: [],
     },
     session: { __typename: 'Session', canSignOut: true },
+    tosAccepted: true,
 }
 
 export const mockCodeMonitorFields: CodeMonitorFields = {

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.story.tsx
@@ -294,5 +294,6 @@ Policies.args = {
             __typename: 'Session',
             canSignOut: true,
         },
+        tosAccepted: true,
     },
 }

--- a/client/web/src/enterprise/searchContexts/SearchContextForm.story.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.story.tsx
@@ -74,6 +74,7 @@ const authUser: AuthenticatedUser = {
     tags: [],
     viewerCanAdminister: true,
     databaseID: 0,
+    tosAccepted: true,
 }
 
 const deleteSearchContext = sinon.fake(() => NEVER)

--- a/client/web/src/integration/extension-registry.test.ts
+++ b/client/web/src/integration/extension-registry.test.ts
@@ -180,6 +180,7 @@ describe('Extension Registry', () => {
                     displayName: 'test',
                     siteAdmin: true,
                     tags: [],
+                    tosAccepted: true,
                     url: '/users/test',
                     settingsURL: '/users/test/settings',
                     organizations: { nodes: [] },

--- a/client/web/src/integration/graphQlResults.ts
+++ b/client/web/src/integration/graphQlResults.ts
@@ -21,6 +21,7 @@ export const commonWebGraphQlResults: Partial<WebGraphQlOperations & SharedGraph
             displayName: null,
             siteAdmin: true,
             tags: [],
+            tosAccepted: true,
             url: '/users/test',
             settingsURL: '/users/test/settings',
             organizations: { nodes: [] },

--- a/client/web/src/integration/insights/utils/override-insights-graphql.ts
+++ b/client/web/src/integration/insights/utils/override-insights-graphql.ts
@@ -73,6 +73,7 @@ export function overrideGraphQLExtensions(props: OverrideGraphQLExtensionsProps)
                 displayName: null,
                 siteAdmin: true,
                 tags: [],
+                tosAccepted: true,
                 url: '/users/test',
                 settingsURL: '/users/test/settings',
                 organizations: {

--- a/client/web/src/regression/codeintel.test.ts
+++ b/client/web/src/regression/codeintel.test.ts
@@ -11,7 +11,7 @@ import { Config, getConfig } from '@sourcegraph/shared/src/testing/config'
 import { Driver } from '@sourcegraph/shared/src/testing/driver'
 import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
 
-import { ensureTestExternalService, getUser, setUserSiteAdmin } from './util/api'
+import { ensureTestExternalService, getUser, setTosAccepted, setUserSiteAdmin } from './util/api'
 import { GraphQLClient } from './util/GraphQlClient'
 import { ensureLoggedInOrCreateTestUser, getGlobalSettings } from './util/helpers'
 import { getTestTools } from './util/init'
@@ -87,6 +87,7 @@ describe('Code intelligence regression test suite', () => {
             throw new Error(`test user ${testUsername} does not exist`)
         }
         await setUserSiteAdmin(gqlClient, user.id, true)
+        await setTosAccepted(gqlClient, user.id)
 
         outerResourceManager.add('Global setting', 'codeIntel.includeForks', await setIncludeForks(gqlClient, true))
     })

--- a/client/web/src/regression/core.test.ts
+++ b/client/web/src/regression/core.test.ts
@@ -11,6 +11,7 @@ import { getConfig } from '@sourcegraph/shared/src/testing/config'
 import { Driver } from '@sourcegraph/shared/src/testing/driver'
 import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
 
+import { getUser, setTosAccepted } from './util/api'
 import { GraphQLClient, createGraphQLClient } from './util/GraphQlClient'
 import {
     ensureLoggedInOrCreateTestUser,
@@ -50,6 +51,11 @@ describe('Core functionality regression test suite', () => {
                 ...config,
             })
         )
+        const user = await getUser(gqlClient, testUsername)
+        if (!user) {
+            throw new Error(`test user ${testUsername} does not exist`)
+        }
+        await setTosAccepted(gqlClient, user.id)
         screenshots = new ScreenshotVerifier(driver)
     })
 

--- a/client/web/src/regression/util/api.ts
+++ b/client/web/src/regression/util/api.ts
@@ -375,6 +375,21 @@ export async function setUserSiteAdmin(gqlClient: GraphQLClient, userID: GQL.ID,
         .toPromise()
 }
 
+export async function setTosAccepted(gqlClient: GraphQLClient, userID: GQL.ID): Promise<void> {
+    await gqlClient
+        .mutateGraphQL(
+            gql`
+                mutation SetTosAccepted($userID: ID!) {
+                    setTosAccepted(userID: $userID) {
+                        alwaysNil
+                    }
+                }
+            `,
+            { userID }
+        )
+        .toPromise()
+}
+
 /**
  * TODO(beyang): remove this after the corresponding API in the main code has been updated to use a
  * dependency-injected `requestGraphQL`.

--- a/client/web/src/search/input/SearchContextCtaPrompt.story.tsx
+++ b/client/web/src/search/input/SearchContextCtaPrompt.story.tsx
@@ -35,6 +35,7 @@ const authUser: AuthenticatedUser = {
     tags: ['AllowUserExternalServicePublic'],
     viewerCanAdminister: true,
     databaseID: 0,
+    tosAccepted: true,
 }
 
 add(

--- a/client/web/src/search/panels/utils.ts
+++ b/client/web/src/search/panels/utils.ts
@@ -25,6 +25,7 @@ export const authUser: AuthenticatedUser = {
     tags: [],
     viewerCanAdminister: true,
     databaseID: 0,
+    tosAccepted: true,
 }
 
 export const org: IOrg = {

--- a/client/web/src/site-admin/init/SiteInitPage.tsx
+++ b/client/web/src/site-admin/init/SiteInitPage.tsx
@@ -17,6 +17,7 @@ import styles from './SiteInitPage.module.scss'
 const initSite = async (args: SignUpArguments): Promise<void> => {
     const pingUrl = new URL('https://sourcegraph.com/ping-from-self-hosted')
     pingUrl.searchParams.set('email', args.email)
+    pingUrl.searchParams.set('tos_accepted', 'true') // Terms of Service are required to be accepted
 
     await fetch(pingUrl.toString(), {
         credentials: 'include',

--- a/client/web/src/site-admin/init/__snapshots__/SiteInitPage.test.tsx.snap
+++ b/client/web/src/site-admin/init/__snapshots__/SiteInitPage.test.tsx.snap
@@ -123,6 +123,31 @@ exports[`SiteInitPage normal 1`] = `
               Create admin account & continue
             </button>
           </div>
+          <p
+            class="mt-3 mb-0"
+          >
+            <small
+              class="form-text text-muted"
+            >
+              By signing up, you agree to our 
+              <a
+                href="https://about.sourcegraph.com/terms"
+                rel="noopener"
+                target="_blank"
+              >
+                Terms of Service
+              </a>
+               and 
+              <a
+                href="https://about.sourcegraph.com/privacy"
+                rel="noopener"
+                target="_blank"
+              >
+                Privacy Policy
+              </a>
+              .
+            </small>
+          </p>
         </form>
       </div>
     </div>

--- a/client/web/src/util/features.tsx
+++ b/client/web/src/util/features.tsx
@@ -10,11 +10,6 @@
 export const showDotComMarketing = window.context?.sourcegraphDotComMode
 
 /**
- * Whether the signup form should show terms and privacy policy links.
- */
-export const signupTerms = window.context?.sourcegraphDotComMode
-
-/**
  * Whether the signup form should show the Enterprise trial checkbox
  */
 export const enterpriseTrial = window.context ? !window.context.sourcegraphDotComMode : false

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -218,9 +218,12 @@ type Mutation {
     """
     createPassword(newPassword: String!): EmptyResponse
     """
-    Sets the current user to accept the site's Terms of Service and Privacy Policy.
+    Sets the user to accept the site's Terms of Service and Privacy Policy.
+    If the ID is ommitted, the current user is assumed.
+
+    Only the user or site admins may perform this mutation.
     """
-    setTosAccepted: EmptyResponse!
+    setTosAccepted(userID: ID): EmptyResponse!
     """
     Creates an access token that grants the privileges of the specified user (referred to as the access token's
     "subject" user after token creation). The result is the access token value, which the caller is responsible

--- a/cmd/frontend/hubspot/contacts.go
+++ b/cmd/frontend/hubspot/contacts.go
@@ -45,6 +45,7 @@ type ContactProperties struct {
 	FirstSourceURL  string `json:"first_source_url"`
 	LastSourceURL   string `json:"last_source_url"`
 	DatabaseID      int32  `json:"database_id"`
+	HasAgreedToToS  bool   `json:"has_agreed_to_tos_and_pp"`
 }
 
 // ContactResponse represents HubSpot user properties returned

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -481,6 +481,7 @@ func servePingFromSelfHosted(w http.ResponseWriter, r *http.Request) error {
 		return nil
 	}
 	email := r.URL.Query().Get("email")
+	tosAccepted := r.URL.Query().Get("tos_accepted")
 
 	firstSourceURLCookie, err := r.Cookie("sourcegraphSourceUrl")
 	var firstSourceURL string
@@ -501,6 +502,7 @@ func servePingFromSelfHosted(w http.ResponseWriter, r *http.Request) error {
 		AnonymousUserID: anonymousUserId,
 		FirstSourceURL:  firstSourceURL,
 		LastSourceURL:   lastSourceURL,
+		HasAgreedToToS:  tosAccepted == "true",
 	})
 	return nil
 }

--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -116,9 +116,9 @@ func getUsersActiveTodayCount(ctx context.Context) (_ int, err error) {
 	return usagestatsdeprecated.GetUsersActiveTodayCount(ctx)
 }
 
-func getInitialSiteAdminEmail(ctx context.Context, db database.DB) (_ string, err error) {
-	defer recordOperation("getInitialSiteAdminEmail")(&err)
-	return database.UserEmails(db).GetInitialSiteAdminEmail(ctx)
+func getInitialSiteAdminInfo(ctx context.Context, db database.DB) (_ string, _ bool, err error) {
+	defer recordOperation("getInitialSiteAdminInfo")(&err)
+	return database.UserEmails(db).GetInitialSiteAdminInfo(ctx)
 }
 
 func getAndMarshalBatchChangesUsageJSON(ctx context.Context, db database.DB) (_ json.RawMessage, err error) {
@@ -350,9 +350,9 @@ func updateBody(ctx context.Context, db database.DB) (io.Reader, error) {
 		logFunc("telemetry: database.Users.Count failed", "error", err)
 	}
 	r.TotalUsers = int32(totalUsers)
-	r.InitialAdminEmail, err = getInitialSiteAdminEmail(ctx, db)
+	r.InitialAdminEmail, r.TosAccepted, err = getInitialSiteAdminInfo(ctx, db)
 	if err != nil {
-		logFunc("telemetry: database.UserEmails.GetInitialSiteAdminEmail failed", "error", err)
+		logFunc("telemetry: database.UserEmails.GetInitialSiteAdminInfo failed", "error", err)
 	}
 
 	r.DependencyVersions, err = getDependencyVersions(ctx, db, logFunc)

--- a/cmd/frontend/internal/app/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/updatecheck/handler.go
@@ -195,6 +195,7 @@ type pingRequest struct {
 	CodeMonitoringUsage json.RawMessage `json:"codeMonitoringUsage"`
 	CodeHostVersions    json.RawMessage `json:"codeHostVersions"`
 	InitialAdminEmail   string          `json:"initAdmin"`
+	TosAccepted         bool            `json:"tosAccepted"`
 	TotalUsers          int32           `json:"totalUsers"`
 	HasRepos            bool            `json:"repos"`
 	EverSearched        bool            `json:"searched"`
@@ -237,6 +238,7 @@ func readPingRequestFromQuery(q url.Values) (*pingRequest, error) {
 		HasRepos:             toBool(q.Get("repos")),
 		EverSearched:         toBool(q.Get("searched")),
 		EverFindRefs:         toBool(q.Get("refs")),
+		TosAccepted:          toBool(q.Get("tosAccepted")),
 	}, nil
 }
 
@@ -345,7 +347,7 @@ func logPing(r *http.Request, pr *pingRequest, hasUpdate bool) {
 		now := time.Now().UTC()
 		rounded := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 		millis := rounded.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))
-		go hubspotutil.SyncUser(pr.InitialAdminEmail, "", &hubspot.ContactProperties{IsServerAdmin: true, LatestPing: millis})
+		go hubspotutil.SyncUser(pr.InitialAdminEmail, "", &hubspot.ContactProperties{IsServerAdmin: true, LatestPing: millis, HasAgreedToToS: pr.TosAccepted})
 	}
 }
 

--- a/cmd/frontend/internal/auth/userpasswd/handlers.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers.go
@@ -118,6 +118,7 @@ func handleSignUp(db database.DB, w http.ResponseWriter, r *http.Request, failIf
 		Password:              creds.Password,
 		FailIfNotInitialUser:  failIfNewUserIsNotInitialSiteAdmin,
 		EnforcePasswordLength: true,
+		TosAccepted:           true, // Users created via the signup form are considered to have accepted the Terms of Service.
 	}
 	if failIfNewUserIsNotInitialSiteAdmin {
 		// The email of the initial site admin is considered to be verified.

--- a/internal/database/mocks.go
+++ b/internal/database/mocks.go
@@ -31423,9 +31423,9 @@ type MockUserEmailsStore struct {
 	// GetFunc is an instance of a mock function object controlling the
 	// behavior of the method Get.
 	GetFunc *UserEmailsStoreGetFunc
-	// GetInitialSiteAdminEmailFunc is an instance of a mock function object
-	// controlling the behavior of the method GetInitialSiteAdminEmail.
-	GetInitialSiteAdminEmailFunc *UserEmailsStoreGetInitialSiteAdminEmailFunc
+	// GetInitialSiteAdminInfoFunc is an instance of a mock function object
+	// controlling the behavior of the method GetInitialSiteAdminInfo.
+	GetInitialSiteAdminInfoFunc *UserEmailsStoreGetInitialSiteAdminInfoFunc
 	// GetLatestVerificationSentEmailFunc is an instance of a mock function
 	// object controlling the behavior of the method
 	// GetLatestVerificationSentEmail.
@@ -31485,9 +31485,9 @@ func NewMockUserEmailsStore() *MockUserEmailsStore {
 				return "", false, nil
 			},
 		},
-		GetInitialSiteAdminEmailFunc: &UserEmailsStoreGetInitialSiteAdminEmailFunc{
-			defaultHook: func(context.Context) (string, error) {
-				return "", nil
+		GetInitialSiteAdminInfoFunc: &UserEmailsStoreGetInitialSiteAdminInfoFunc{
+			defaultHook: func(context.Context) (string, bool, error) {
+				return "", false, nil
 			},
 		},
 		GetLatestVerificationSentEmailFunc: &UserEmailsStoreGetLatestVerificationSentEmailFunc{
@@ -31572,9 +31572,9 @@ func NewStrictMockUserEmailsStore() *MockUserEmailsStore {
 				panic("unexpected invocation of MockUserEmailsStore.Get")
 			},
 		},
-		GetInitialSiteAdminEmailFunc: &UserEmailsStoreGetInitialSiteAdminEmailFunc{
-			defaultHook: func(context.Context) (string, error) {
-				panic("unexpected invocation of MockUserEmailsStore.GetInitialSiteAdminEmail")
+		GetInitialSiteAdminInfoFunc: &UserEmailsStoreGetInitialSiteAdminInfoFunc{
+			defaultHook: func(context.Context) (string, bool, error) {
+				panic("unexpected invocation of MockUserEmailsStore.GetInitialSiteAdminInfo")
 			},
 		},
 		GetLatestVerificationSentEmailFunc: &UserEmailsStoreGetLatestVerificationSentEmailFunc{
@@ -31654,8 +31654,8 @@ func NewMockUserEmailsStoreFrom(i UserEmailsStore) *MockUserEmailsStore {
 		GetFunc: &UserEmailsStoreGetFunc{
 			defaultHook: i.Get,
 		},
-		GetInitialSiteAdminEmailFunc: &UserEmailsStoreGetInitialSiteAdminEmailFunc{
-			defaultHook: i.GetInitialSiteAdminEmail,
+		GetInitialSiteAdminInfoFunc: &UserEmailsStoreGetInitialSiteAdminInfoFunc{
+			defaultHook: i.GetInitialSiteAdminInfo,
 		},
 		GetLatestVerificationSentEmailFunc: &UserEmailsStoreGetLatestVerificationSentEmailFunc{
 			defaultHook: i.GetLatestVerificationSentEmail,
@@ -32026,37 +32026,37 @@ func (c UserEmailsStoreGetFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
-// UserEmailsStoreGetInitialSiteAdminEmailFunc describes the behavior when
-// the GetInitialSiteAdminEmail method of the parent MockUserEmailsStore
+// UserEmailsStoreGetInitialSiteAdminInfoFunc describes the behavior when
+// the GetInitialSiteAdminInfo method of the parent MockUserEmailsStore
 // instance is invoked.
-type UserEmailsStoreGetInitialSiteAdminEmailFunc struct {
-	defaultHook func(context.Context) (string, error)
-	hooks       []func(context.Context) (string, error)
-	history     []UserEmailsStoreGetInitialSiteAdminEmailFuncCall
+type UserEmailsStoreGetInitialSiteAdminInfoFunc struct {
+	defaultHook func(context.Context) (string, bool, error)
+	hooks       []func(context.Context) (string, bool, error)
+	history     []UserEmailsStoreGetInitialSiteAdminInfoFuncCall
 	mutex       sync.Mutex
 }
 
-// GetInitialSiteAdminEmail delegates to the next hook function in the queue
+// GetInitialSiteAdminInfo delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockUserEmailsStore) GetInitialSiteAdminEmail(v0 context.Context) (string, error) {
-	r0, r1 := m.GetInitialSiteAdminEmailFunc.nextHook()(v0)
-	m.GetInitialSiteAdminEmailFunc.appendCall(UserEmailsStoreGetInitialSiteAdminEmailFuncCall{v0, r0, r1})
-	return r0, r1
+func (m *MockUserEmailsStore) GetInitialSiteAdminInfo(v0 context.Context) (string, bool, error) {
+	r0, r1, r2 := m.GetInitialSiteAdminInfoFunc.nextHook()(v0)
+	m.GetInitialSiteAdminInfoFunc.appendCall(UserEmailsStoreGetInitialSiteAdminInfoFuncCall{v0, r0, r1, r2})
+	return r0, r1, r2
 }
 
 // SetDefaultHook sets function that is called when the
-// GetInitialSiteAdminEmail method of the parent MockUserEmailsStore
-// instance is invoked and the hook queue is empty.
-func (f *UserEmailsStoreGetInitialSiteAdminEmailFunc) SetDefaultHook(hook func(context.Context) (string, error)) {
+// GetInitialSiteAdminInfo method of the parent MockUserEmailsStore instance
+// is invoked and the hook queue is empty.
+func (f *UserEmailsStoreGetInitialSiteAdminInfoFunc) SetDefaultHook(hook func(context.Context) (string, bool, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// GetInitialSiteAdminEmail method of the parent MockUserEmailsStore
-// instance invokes the hook at the front of the queue and discards it.
-// After the queue is empty, the default hook function is invoked for any
-// future action.
-func (f *UserEmailsStoreGetInitialSiteAdminEmailFunc) PushHook(hook func(context.Context) (string, error)) {
+// GetInitialSiteAdminInfo method of the parent MockUserEmailsStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *UserEmailsStoreGetInitialSiteAdminInfoFunc) PushHook(hook func(context.Context) (string, bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -32064,21 +32064,21 @@ func (f *UserEmailsStoreGetInitialSiteAdminEmailFunc) PushHook(hook func(context
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *UserEmailsStoreGetInitialSiteAdminEmailFunc) SetDefaultReturn(r0 string, r1 error) {
-	f.SetDefaultHook(func(context.Context) (string, error) {
-		return r0, r1
+func (f *UserEmailsStoreGetInitialSiteAdminInfoFunc) SetDefaultReturn(r0 string, r1 bool, r2 error) {
+	f.SetDefaultHook(func(context.Context) (string, bool, error) {
+		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *UserEmailsStoreGetInitialSiteAdminEmailFunc) PushReturn(r0 string, r1 error) {
-	f.PushHook(func(context.Context) (string, error) {
-		return r0, r1
+func (f *UserEmailsStoreGetInitialSiteAdminInfoFunc) PushReturn(r0 string, r1 bool, r2 error) {
+	f.PushHook(func(context.Context) (string, bool, error) {
+		return r0, r1, r2
 	})
 }
 
-func (f *UserEmailsStoreGetInitialSiteAdminEmailFunc) nextHook() func(context.Context) (string, error) {
+func (f *UserEmailsStoreGetInitialSiteAdminInfoFunc) nextHook() func(context.Context) (string, bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -32091,28 +32091,28 @@ func (f *UserEmailsStoreGetInitialSiteAdminEmailFunc) nextHook() func(context.Co
 	return hook
 }
 
-func (f *UserEmailsStoreGetInitialSiteAdminEmailFunc) appendCall(r0 UserEmailsStoreGetInitialSiteAdminEmailFuncCall) {
+func (f *UserEmailsStoreGetInitialSiteAdminInfoFunc) appendCall(r0 UserEmailsStoreGetInitialSiteAdminInfoFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// UserEmailsStoreGetInitialSiteAdminEmailFuncCall objects describing the
+// UserEmailsStoreGetInitialSiteAdminInfoFuncCall objects describing the
 // invocations of this function.
-func (f *UserEmailsStoreGetInitialSiteAdminEmailFunc) History() []UserEmailsStoreGetInitialSiteAdminEmailFuncCall {
+func (f *UserEmailsStoreGetInitialSiteAdminInfoFunc) History() []UserEmailsStoreGetInitialSiteAdminInfoFuncCall {
 	f.mutex.Lock()
-	history := make([]UserEmailsStoreGetInitialSiteAdminEmailFuncCall, len(f.history))
+	history := make([]UserEmailsStoreGetInitialSiteAdminInfoFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// UserEmailsStoreGetInitialSiteAdminEmailFuncCall is an object that
-// describes an invocation of method GetInitialSiteAdminEmail on an instance
+// UserEmailsStoreGetInitialSiteAdminInfoFuncCall is an object that
+// describes an invocation of method GetInitialSiteAdminInfo on an instance
 // of MockUserEmailsStore.
-type UserEmailsStoreGetInitialSiteAdminEmailFuncCall struct {
+type UserEmailsStoreGetInitialSiteAdminInfoFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -32121,19 +32121,22 @@ type UserEmailsStoreGetInitialSiteAdminEmailFuncCall struct {
 	Result0 string
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
-	Result1 error
+	Result1 bool
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 error
 }
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c UserEmailsStoreGetInitialSiteAdminEmailFuncCall) Args() []interface{} {
+func (c UserEmailsStoreGetInitialSiteAdminInfoFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c UserEmailsStoreGetInitialSiteAdminEmailFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c UserEmailsStoreGetInitialSiteAdminInfoFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
 // UserEmailsStoreGetLatestVerificationSentEmailFunc describes the behavior

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -188,6 +188,10 @@ type NewUser struct {
 	// EnforcePasswordLength is whether should enforce minimum and maximum password length requirement.
 	// Users created by non-builtin auth providers do not have a password thus no need to check.
 	EnforcePasswordLength bool `json:"-"` // forbid this field being set by JSON, just in case
+
+	// TosAccepted is whether the user is created with the terms of service accepted already.
+	TosAccepted bool `json:"-"` // forbid this field being set by JSON, just in case
+
 }
 
 // Create creates a new user in the database.
@@ -303,8 +307,8 @@ func (u *userStore) CreateInTransaction(ctx context.Context, info NewUser) (newU
 	var siteAdmin bool
 	err = u.QueryRow(
 		ctx,
-		sqlf.Sprintf("INSERT INTO users(username, display_name, avatar_url, created_at, updated_at, passwd, invalidated_sessions_at, site_admin) VALUES(%s, %s, %s, %s, %s, %s, %s, %s AND NOT EXISTS(SELECT * FROM users)) RETURNING id, site_admin",
-			info.Username, info.DisplayName, avatarURL, createdAt, updatedAt, passwd, invalidatedSessionsAt, !alreadyInitialized)).Scan(&id, &siteAdmin)
+		sqlf.Sprintf("INSERT INTO users(username, display_name, avatar_url, created_at, updated_at, passwd, invalidated_sessions_at, tos_accepted, site_admin) VALUES(%s, %s, %s, %s, %s, %s, %s, %s, %s AND NOT EXISTS(SELECT * FROM users)) RETURNING id, site_admin",
+			info.Username, info.DisplayName, avatarURL, createdAt, updatedAt, passwd, invalidatedSessionsAt, info.TosAccepted, !alreadyInitialized)).Scan(&id, &siteAdmin)
 	if err != nil {
 		var e *pgconn.PgError
 		if errors.As(err, &e) {


### PR DESCRIPTION
Fixes #28716

This is a large PR. Please review by commit:
1. Revert the revert of this feature due to the failing test
2. Fix failing test
3. Minor UI fixes (fix "sign out" capitalization from https://github.com/sourcegraph/sourcegraph/pull/29020#pullrequestreview-834561801 and flash of content)
4. Set HubSpot flag `has_agreed_to_tos_and_pp` on pings based on user ToS consent status
5. Update changelog to correctly reflect when Terms of Service consent was added