### PR TITLE
Convert a bunch of tests using global perms mocks

### DIFF
--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -255,7 +255,7 @@ func (r *schemaResolver) UpdateUser(ctx context.Context, args *updateUserArgs) (
 // CurrentUser returns the authenticated user if any. If there is no authenticated user, it returns
 // (nil, nil). If some other error occurs, then the error is returned.
 func CurrentUser(ctx context.Context, db database.DB) (*UserResolver, error) {
-	user, err := database.Users(db).GetByCurrentAuthUser(ctx)
+	user, err := db.Users().GetByCurrentAuthUser(ctx)
 	if err != nil {
 		if errcode.IsNotFound(err) || err == database.ErrNoCurrentUser {
 			return nil, nil

--- a/enterprise/cmd/frontend/internal/authz/resolvers/repositories.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/repositories.go
@@ -58,7 +58,7 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 
 		// TODO(asdine): GetByIDs now returns the complete repo information rather that only a subset.
 		// Ensure this doesn't have an impact on performance and switch to using ListMinimalRepos if needed.
-		r.repos, r.err = database.Repos(r.db).GetByIDs(ctx, repoIDs...)
+		r.repos, r.err = r.db.Repos().GetByIDs(ctx, repoIDs...)
 		if r.err != nil {
 			return
 		}

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -29,7 +29,7 @@ import (
 var errDisabledSourcegraphDotCom = errors.New("not enabled on sourcegraph.com")
 
 type Resolver struct {
-	store             edb.PermsStore
+	db                edb.EnterpriseDB
 	repoupdaterClient interface {
 		SchedulePermsSync(ctx context.Context, args protocol.PermsSyncRequest) error
 	}
@@ -56,7 +56,7 @@ func (r *Resolver) checkLicense() error {
 
 func NewResolver(db database.DB, clock func() time.Time) graphqlbackend.AuthzResolver {
 	return &Resolver{
-		store:             edb.Perms(db, clock),
+		db:                edb.NewEnterpriseDB(db),
 		repoupdaterClient: repoupdater.DefaultClient,
 	}
 }
@@ -71,7 +71,7 @@ func (r *Resolver) SetRepositoryPermissionsForUsers(ctx context.Context, args *g
 	}
 
 	// 🚨 SECURITY: Only site admins can mutate repository permissions.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, database.NewDB(r.store.Handle().DB())); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 
@@ -80,7 +80,7 @@ func (r *Resolver) SetRepositoryPermissionsForUsers(ctx context.Context, args *g
 		return nil, err
 	}
 	// Make sure the repo ID is valid.
-	if _, err = database.Repos(r.store.Handle().DB()).Get(ctx, repoID); err != nil {
+	if _, err = r.db.Repos().Get(ctx, repoID); err != nil {
 		return nil, err
 	}
 
@@ -107,7 +107,7 @@ func (r *Resolver) SetRepositoryPermissionsForUsers(ctx context.Context, args *g
 	cfg := globals.PermissionsUserMapping()
 	switch cfg.BindID {
 	case "email":
-		emails, err := database.UserEmailsWith(r.store).GetVerifiedEmails(ctx, bindIDs...)
+		emails, err := r.db.UserEmails().GetVerifiedEmails(ctx, bindIDs...)
 		if err != nil {
 			return nil, err
 		}
@@ -118,7 +118,7 @@ func (r *Resolver) SetRepositoryPermissionsForUsers(ctx context.Context, args *g
 		}
 
 	case "username":
-		users, err := database.Users(r.store.Handle().DB()).GetByUsernames(ctx, bindIDs...)
+		users, err := r.db.Users().GetByUsernames(ctx, bindIDs...)
 		if err != nil {
 			return nil, err
 		}
@@ -137,7 +137,7 @@ func (r *Resolver) SetRepositoryPermissionsForUsers(ctx context.Context, args *g
 		pendingBindIDs = append(pendingBindIDs, id)
 	}
 
-	txs, err := r.store.Transact(ctx)
+	txs, err := r.db.Perms().Transact(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "start transaction")
 	}
@@ -164,7 +164,7 @@ func (r *Resolver) ScheduleRepositoryPermissionsSync(ctx context.Context, args *
 	}
 
 	// 🚨 SECURITY: Only site admins can query repository permissions.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, database.NewDB(r.store.Handle().DB())); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 
@@ -188,7 +188,7 @@ func (r *Resolver) ScheduleUserPermissionsSync(ctx context.Context, args *graphq
 	}
 
 	// 🚨 SECURITY: Only site admins can query repository permissions.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, database.NewDB(r.store.Handle().DB())); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 
@@ -216,7 +216,7 @@ func (r *Resolver) AuthorizedUserRepositories(ctx context.Context, args *graphql
 	}
 
 	// 🚨 SECURITY: Only site admins can query repository permissions.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, database.NewDB(r.store.Handle().DB())); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 
@@ -228,10 +228,10 @@ func (r *Resolver) AuthorizedUserRepositories(ctx context.Context, args *graphql
 	if args.Email != nil {
 		bindID = *args.Email
 		// 🚨 SECURITY: It is critical to ensure the email is verified.
-		user, err = database.Users(r.store.Handle().DB()).GetByVerifiedEmail(ctx, *args.Email)
+		user, err = r.db.Users().GetByVerifiedEmail(ctx, *args.Email)
 	} else if args.Username != nil {
 		bindID = *args.Username
-		user, err = database.Users(r.store.Handle().DB()).GetByUsername(ctx, *args.Username)
+		user, err = r.db.Users().GetByUsername(ctx, *args.Username)
 	} else {
 		return nil, errors.New("neither email nor username is given to identify a user")
 	}
@@ -246,7 +246,7 @@ func (r *Resolver) AuthorizedUserRepositories(ctx context.Context, args *graphql
 			Perm:   authz.Read, // Note: We currently only support read for repository permissions.
 			Type:   authz.PermRepos,
 		}
-		err = r.store.LoadUserPermissions(ctx, p)
+		err = r.db.Perms().LoadUserPermissions(ctx, p)
 		ids = p.IDs
 	} else {
 		p := &authz.UserPendingPermissions{
@@ -256,7 +256,7 @@ func (r *Resolver) AuthorizedUserRepositories(ctx context.Context, args *graphql
 			Perm:        authz.Read, // Note: We currently only support read for repository permissions.
 			Type:        authz.PermRepos,
 		}
-		err = r.store.LoadUserPendingPermissions(ctx, p)
+		err = r.db.Perms().LoadUserPendingPermissions(ctx, p)
 		ids = p.IDs
 	}
 	if err != nil && err != authz.ErrPermsNotFound {
@@ -268,7 +268,7 @@ func (r *Resolver) AuthorizedUserRepositories(ctx context.Context, args *graphql
 	}
 
 	return &repositoryConnectionResolver{
-		db:    database.NewDB(r.store.Handle().DB()),
+		db:    r.db,
 		ids:   ids,
 		first: args.First,
 		after: args.After,
@@ -277,16 +277,16 @@ func (r *Resolver) AuthorizedUserRepositories(ctx context.Context, args *graphql
 
 func (r *Resolver) UsersWithPendingPermissions(ctx context.Context) ([]string, error) {
 	// 🚨 SECURITY: Only site admins can query repository permissions.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, database.NewDB(r.store.Handle().DB())); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 
-	return r.store.ListPendingUsers(ctx, authz.SourcegraphServiceType, authz.SourcegraphServiceID)
+	return r.db.Perms().ListPendingUsers(ctx, authz.SourcegraphServiceType, authz.SourcegraphServiceID)
 }
 
 func (r *Resolver) AuthorizedUsers(ctx context.Context, args *graphqlbackend.RepoAuthorizedUserArgs) (graphqlbackend.UserConnectionResolver, error) {
 	// 🚨 SECURITY: Only site admins can query repository permissions.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, database.NewDB(r.store.Handle().DB())); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 
@@ -295,7 +295,7 @@ func (r *Resolver) AuthorizedUsers(ctx context.Context, args *graphqlbackend.Rep
 		return nil, err
 	}
 	// Make sure the repo ID is valid.
-	if _, err = database.Repos(r.store.Handle().DB()).Get(ctx, repoID); err != nil {
+	if _, err = r.db.Repos().Get(ctx, repoID); err != nil {
 		return nil, err
 	}
 
@@ -303,7 +303,7 @@ func (r *Resolver) AuthorizedUsers(ctx context.Context, args *graphqlbackend.Rep
 		RepoID: int32(repoID),
 		Perm:   authz.Read, // Note: We currently only support read for repository permissions.
 	}
-	err = r.store.LoadRepoPermissions(ctx, p)
+	err = r.db.Perms().LoadRepoPermissions(ctx, p)
 	if err != nil && err != authz.ErrPermsNotFound {
 		return nil, err
 	}
@@ -313,7 +313,7 @@ func (r *Resolver) AuthorizedUsers(ctx context.Context, args *graphqlbackend.Rep
 	}
 
 	return &userConnectionResolver{
-		db:    database.NewDB(r.store.Handle().DB()),
+		db:    r.db,
 		ids:   p.UserIDs,
 		first: args.First,
 		after: args.After,
@@ -343,7 +343,7 @@ func (r *permissionsInfoResolver) UpdatedAt() graphqlbackend.DateTime {
 
 func (r *Resolver) RepositoryPermissionsInfo(ctx context.Context, id graphql.ID) (graphqlbackend.PermissionsInfoResolver, error) {
 	// 🚨 SECURITY: Only site admins can query repository permissions.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, database.NewDB(r.store.Handle().DB())); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 
@@ -352,7 +352,7 @@ func (r *Resolver) RepositoryPermissionsInfo(ctx context.Context, id graphql.ID)
 		return nil, err
 	}
 	// Make sure the repo ID is valid and not soft-deleted.
-	if _, err = database.Repos(r.store.Handle().DB()).Get(ctx, repoID); err != nil {
+	if _, err = r.db.Repos().Get(ctx, repoID); err != nil {
 		return nil, err
 	}
 
@@ -360,7 +360,7 @@ func (r *Resolver) RepositoryPermissionsInfo(ctx context.Context, id graphql.ID)
 		RepoID: int32(repoID),
 		Perm:   authz.Read, // Note: We currently only support read for repository permissions.
 	}
-	err = r.store.LoadRepoPermissions(ctx, p)
+	err = r.db.Perms().LoadRepoPermissions(ctx, p)
 	if err != nil && err != authz.ErrPermsNotFound {
 		return nil, err
 	}
@@ -378,7 +378,7 @@ func (r *Resolver) RepositoryPermissionsInfo(ctx context.Context, id graphql.ID)
 
 func (r *Resolver) UserPermissionsInfo(ctx context.Context, id graphql.ID) (graphqlbackend.PermissionsInfoResolver, error) {
 	// 🚨 SECURITY: Only site admins can query user permissions.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, database.NewDB(r.store.Handle().DB())); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 
@@ -387,7 +387,7 @@ func (r *Resolver) UserPermissionsInfo(ctx context.Context, id graphql.ID) (grap
 		return nil, err
 	}
 	// Make sure the user ID is valid and not soft-deleted.
-	if _, err = database.Users(r.store.Handle().DB()).GetByID(ctx, userID); err != nil {
+	if _, err = r.db.Users().GetByID(ctx, userID); err != nil {
 		return nil, err
 	}
 
@@ -396,7 +396,7 @@ func (r *Resolver) UserPermissionsInfo(ctx context.Context, id graphql.ID) (grap
 		Perm:   authz.Read, // Note: We currently only support read for repository permissions.
 		Type:   authz.PermRepos,
 	}
-	err = r.store.LoadUserPermissions(ctx, p)
+	err = r.db.Perms().LoadUserPermissions(ctx, p)
 	if err != nil && err != authz.ErrPermsNotFound {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -34,17 +34,12 @@ func clock() time.Time {
 	return time.Unix(0, atomic.LoadInt64(&now))
 }
 
-var (
-	parseSchemaErr error
-	parsedSchema   *graphql.Schema
-)
-
 func mustParseGraphQLSchema(t *testing.T, db database.DB) *graphql.Schema {
 	t.Helper()
 
 	parsedSchema, err := graphqlbackend.NewSchema(db, nil, nil, nil, NewResolver(db, clock), nil, nil, nil, nil, nil, nil)
 	if err != nil {
-		t.Fatal(parseSchemaErr)
+		t.Fatal(err)
 	}
 
 	return parsedSchema

--- a/enterprise/cmd/frontend/internal/authz/resolvers/users.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/users.go
@@ -56,7 +56,7 @@ func (r *userConnectionResolver) compute(ctx context.Context) ([]*types.User, *g
 			}
 		}
 
-		r.users, r.err = database.Users(r.db).List(ctx, &database.UsersListOptions{
+		r.users, r.err = r.db.Users().List(ctx, &database.UsersListOptions{
 			UserIDs: userIDs,
 		})
 		if r.err != nil {


### PR DESCRIPTION
Now that we have a mockable `PermsStore` interface, this converts a bunch of tests that use the global perms mocks to instead use injected mocks. This is particularly exciting because the inability to mock out the perms store (because we didn't have a way to mock enterprise stores before #29204) was blocking the conversion of a bunch of these tests. 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
