### PR TITLE
reduce timeout

### DIFF
--- a/dev/ci/test/cluster/cluster-test.sh
+++ b/dev/ci/test/cluster/cluster-test.sh
@@ -60,7 +60,7 @@ function cluster_setup() {
   popd
   echo "--- wait for ready"
   kubectl get pods -n "$NAMESPACE"
-  time kubectl wait --for=condition=Ready -l app=sourcegraph-frontend pod --timeout=20m -n "$NAMESPACE"
+  time kubectl wait --for=condition=Ready -l app=sourcegraph-frontend pod --timeout=5m -n "$NAMESPACE"
   set -e
   set -o pipefail
 }


### PR DESCRIPTION
reduce this timeout to 5m. If a cluster hasn't been deployed in that time it's safe to assume a migration has failed or there is another issue and holding up tests otherwise doesn't make sense. 

