### PR TITLE
Revert "search: move args.FullDeadline dep out of doResults (#29173)"

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -844,22 +844,12 @@ func (r *searchResolver) toSearchInputs(q query.Q) (*search.TextParameters, []ru
 	for _, job := range jobs {
 		switch j := job.(type) {
 		case *commit.CommitSearch:
-			if args.UseFullDeadline {
-				j.IsRequired = true
-				continue
-			}
-
 			if job.Name() == "Diff" {
 				j.IsRequired = (args.ResultTypes.Without(result.TypeDiff) == 0)
 			} else {
 				j.IsRequired = (args.ResultTypes.Without(result.TypeCommit) == 0)
 			}
 		case *symbol.RepoSubsetSymbolSearch:
-			if args.UseFullDeadline {
-				j.IsRequired = true
-				continue
-			}
-
 			j.IsRequired = (args.ResultTypes.Without(result.TypeSymbol) == 0)
 		case *symbol.RepoUniverseSymbolSearch:
 			j.IsRequired = true
@@ -1684,6 +1674,10 @@ func (r *searchResolver) doResults(ctx context.Context, args *search.TextParamet
 	)
 
 	waitGroup := func(required bool) *sync.WaitGroup {
+		if args.UseFullDeadline {
+			// When a custom timeout is specified, all searches are required and get the full timeout.
+			return &requiredWg
+		}
 		if required {
 			return &requiredWg
 		}


### PR DESCRIPTION
This reverts commit 61a14870ae863e670951be7660a8ed76db8edb32.

This is consistently failing QA tests on main. 

https://buildkite.com/sourcegraph/sourcegraph/builds/122407#b27b4964-c970-457d-b37d-d56ad3ad8d61/239-423