### PR TITLE
source LOKI url from profile

### DIFF
--- a/enterprise/dev/upload-build-logs.sh
+++ b/enterprise/dev/upload-build-logs.sh
@@ -20,6 +20,8 @@ fi
 
 set -euo pipefail
 
+source /root/.profile
+
 cd "$(dirname "${BASH_SOURCE[0]}")"/../..
 
 if hash go 2>/dev/null; then


### PR DESCRIPTION
Attempting to fix issues where the LOKI url var is empty. 

I suspect that because we don't source the variable from the profile, if the [logic](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/enterprise/dev/upload-build-logs.sh?L25) in the script isn't executed to get the secret, we end up with an empty var when trying to upload. 

I don't fully grasp the logic in that upload script, but I hope this keeps the logs flowing and the pipline clean. 

fixes https://github.com/sourcegraph/sourcegraph/issues/29053