### PR TITLE
fix revsToGitArgs

### DIFF
--- a/internal/gitserver/search/search.go
+++ b/internal/gitserver/search/search.go
@@ -241,7 +241,7 @@ func revsToGitArgs(revs []protocol.RevisionSpecifier) []string {
 		} else if rev.RefGlob != "" {
 			revArgs = append(revArgs, "--glob="+rev.RefGlob)
 		} else if rev.ExcludeRefGlob != "" {
-			revArgs = append(revArgs, "--exclude="+rev.RefGlob)
+			revArgs = append(revArgs, "--exclude="+rev.ExcludeRefGlob)
 		} else {
 			revArgs = append(revArgs, "HEAD")
 		}

--- a/internal/gitserver/search/search_test.go
+++ b/internal/gitserver/search/search_test.go
@@ -513,3 +513,43 @@ func (authorNameGenerator) Generate(rand *rand.Rand, size int) reflect.Value {
 	}
 	return reflect.ValueOf(buf)
 }
+
+func Test_revsToGitArgs(t *testing.T) {
+	cases := []struct {
+		name     string
+		revSpecs []protocol.RevisionSpecifier
+		expected []string
+	}{{
+		name: "explicit HEAD",
+		revSpecs: []protocol.RevisionSpecifier{{
+			RevSpec: "HEAD",
+		}},
+		expected: []string{"HEAD"},
+	}, {
+		name:     "implicit HEAD",
+		revSpecs: []protocol.RevisionSpecifier{{}},
+		expected: []string{"HEAD"},
+	}, {
+		name: "glob",
+		revSpecs: []protocol.RevisionSpecifier{{
+			RefGlob: "refs/heads/*",
+		}},
+		expected: []string{"--glob=refs/heads/*"},
+	}, {
+		name: "glob with excluded",
+		revSpecs: []protocol.RevisionSpecifier{{
+			RefGlob: "refs/heads/*",
+		}, {
+			ExcludeRefGlob: "refs/heads/cc/*",
+		}},
+		expected: []string{
+			"--glob=refs/heads/*",
+			"--exclude=refs/heads/cc/*",
+		},
+	}}
+
+	for _, tc := range cases {
+		got := revsToGitArgs(tc.revSpecs)
+		require.Equal(t, tc.expected, got)
+	}
+}


### PR DESCRIPTION
Previously, when there was an excluded glob, we would instead add an
exclude argument using the ref glob field. This would always be an empty
string, which breaks things.

Fixes https://github.com/sourcegraph/sourcegraph/commit/edf60788f87d5555770a473c1149b037d060e0ab#r62163904

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
