### PR TITLE
notebooks: fix file block header overflow

### DIFF
--- a/client/web/src/search/notebook/fileBlock/SearchNotebookFileBlock.module.scss
+++ b/client/web/src/search/notebook/fileBlock/SearchNotebookFileBlock.module.scss
@@ -16,6 +16,7 @@
     border-bottom: 1px solid var(--border-color);
     border-top-left-radius: var(--border-radius);
     border-top-right-radius: var(--border-radius);
+    overflow-wrap: break-word;
 }
 
 .header-file-link:not(:hover) {


### PR DESCRIPTION
Now:
<img width="580" alt="Screenshot 2021-12-20 at 08 12 27" src="https://user-images.githubusercontent.com/6417322/146726916-20868b29-189a-4246-8eb6-1e80764881d3.png">

Fixed:
<img width="522" alt="Screenshot 2021-12-20 at 08 12 50" src="https://user-images.githubusercontent.com/6417322/146726924-09e7cc2e-24df-43af-9d05-f925de6971d2.png">

