### PR TITLE
web: ignore network errors in Sentry

### DIFF
--- a/client/web/src/sentry/shouldErrorBeReported.ts
+++ b/client/web/src/sentry/shouldErrorBeReported.ts
@@ -7,7 +7,7 @@ export function shouldErrorBeReported(error: unknown): boolean {
         return error.status < 500
     }
 
-    if (isWebpackChunkError(error) || isAbortError(error) || isNotAuthenticatedError(error)) {
+    if (isWebpackChunkError(error) || isAbortError(error) || isNotAuthenticatedError(error) || isNetworkError(error)) {
         return false
     }
 
@@ -15,7 +15,7 @@ export function shouldErrorBeReported(error: unknown): boolean {
 }
 
 export function isWebpackChunkError(value: unknown): boolean {
-    return isErrorLike(value) && value.name === 'ChunkLoadError'
+    return isErrorLike(value) && (value.name === 'ChunkLoadError' || /loading css chunk/gi.test(value.message))
 }
 
 function isAbortError(value: unknown): boolean {
@@ -24,4 +24,8 @@ function isAbortError(value: unknown): boolean {
 
 function isNotAuthenticatedError(value: unknown): boolean {
     return isErrorLike(value) && value.message.includes('not authenticated')
+}
+
+function isNetworkError(value: unknown): boolean {
+    return isErrorLike(value) && /(networkerror|failed to fetch|load failed)/gi.test(value.message)
 }


### PR DESCRIPTION
## Changes

1. Ignore Network errors because they are not helpful for us in Sentry.
2. Ignore chunk loading errors because there's no way to handle them gracefully at the moment. 