### PR TITLE
search: fix negative Content size

### DIFF
--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -119,6 +119,19 @@ interface State {
     error?: Error
 }
 
+function prettyBytesBigint(bytes: bigint):string {
+  let unit = 0
+  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+  const threshold = BigInt(1000);
+
+  while (bytes >= threshold) {
+    bytes /= threshold;
+    unit += 1;
+  }
+
+  return bytes.toString() + ' ' + units[unit];
+}
+
 /**
  * The repository settings index page.
  */
@@ -197,7 +210,7 @@ export class RepoSettingsIndexPage extends React.PureComponent<Props, State> {
                                                 <tr>
                                                     <th>Content size</th>
                                                     <td>
-                                                        {prettyBytes(this.state.textSearchIndex.status.contentByteSize)}{' '}
+                                                        {prettyBytesBigint(BigInt(this.state.textSearchIndex.status.contentByteSize))}{' '}
                                                         ({this.state.textSearchIndex.status.contentFilesCount}{' '}
                                                         {pluralize(
                                                             'file',

--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -119,7 +119,7 @@ interface State {
     error?: Error
 }
 
-function prettyBytesBigint(bytes: bigint):string {
+function prettyBytesBigint(bytes: bigint): string {
   let unit = 0
   const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
   const threshold = BigInt(1000);

--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -120,16 +120,16 @@ interface State {
 }
 
 function prettyBytesBigint(bytes: bigint): string {
-  let unit = 0
-  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
-  const threshold = BigInt(1000);
+    let unit = 0
+    const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+    const threshold = BigInt(1000)
 
-  while (bytes >= threshold) {
-    bytes /= threshold;
-    unit += 1;
-  }
+    while (bytes >= threshold) {
+        bytes /= threshold
+        unit += 1
+    }
 
-  return bytes.toString() + ' ' + units[unit];
+    return bytes.toString() + ' ' + units[unit]
 }
 
 /**
@@ -210,7 +210,9 @@ export class RepoSettingsIndexPage extends React.PureComponent<Props, State> {
                                                 <tr>
                                                     <th>Content size</th>
                                                     <td>
-                                                        {prettyBytesBigint(BigInt(this.state.textSearchIndex.status.contentByteSize))}{' '}
+                                                        {prettyBytesBigint(
+                                                            BigInt(this.state.textSearchIndex.status.contentByteSize)
+                                                        )}{' '}
                                                         ({this.state.textSearchIndex.status.contentFilesCount}{' '}
                                                         {pluralize(
                                                             'file',

--- a/cmd/frontend/graphqlbackend/repository_text_search_index.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index.go
@@ -78,8 +78,8 @@ func (r *repositoryTextSearchIndexStatus) UpdatedAt() DateTime {
 	return DateTime{Time: r.entry.IndexMetadata.IndexTime}
 }
 
-func (r *repositoryTextSearchIndexStatus) ContentByteSize() int32 {
-	return int32(r.entry.Stats.ContentBytes)
+func (r *repositoryTextSearchIndexStatus) ContentByteSize() BigInt {
+	return BigInt{r.entry.Stats.ContentBytes}
 }
 
 func (r *repositoryTextSearchIndexStatus) ContentFilesCount() int32 {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2790,7 +2790,7 @@ type RepositoryTextSearchIndexStatus {
     """
     The byte size of the original content.
     """
-    contentByteSize: Int!
+    contentByteSize: BigInt!
     """
     The number of files in the original content.
     """


### PR DESCRIPTION
The GraphQL field `contentByteSize` is defined as `Int` which is not enough
to represent content size of very big repositories. For some customers
and for our megarepo we see negative content size on the index status
page in site admin view.

I had to make changes in frontend as well, because frontend uses a
function `prettyBytes` to format the output but unfortunately it only
takes `number` as input. Hence I wrote a little custom function.

Once this PR is in a good shape we should also convert other fields to
BigInt.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
