### PR TITLE
fix code style scope

### DIFF
--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/search-query-checks/SearchQueryChecks.module.scss
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/search-query-checks/SearchQueryChecks.module.scss
@@ -31,8 +31,8 @@
         top: 3px;
         opacity: 0.4;
     }
-}
 
-code {
-    font-weight: 600;
+    code {
+        font-weight: 600;
+    }
 }


### PR DESCRIPTION
This is a quick fix to address the global scoping of the `code` element. This simply moves `code` up into the nested wrapper class so that this style does not affect all `code` elements.