### PR TITLE
Code Insights: Fix bad scrollable legend layout for small amount of legends

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.story.tsx
@@ -7,6 +7,7 @@ import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/teleme
 import { WebStory } from '../../../../components/WebStory'
 import {
     LINE_CHART_CONTENT_MOCK,
+    LINE_CHART_TESTS_CASES_EXAMPLE,
     LINE_CHART_WITH_HUGE_NUMBER_OF_LINES,
     LINE_CHART_WITH_MANY_LINES,
 } from '../../../../views/mocks/charts-content'
@@ -187,7 +188,7 @@ class StoryBackendWithManyLinesCharts extends CodeInsightsSettingsCascadeBackend
                         ? insight.series.length >= 15
                             ? LINE_CHART_WITH_HUGE_NUMBER_OF_LINES
                             : LINE_CHART_WITH_MANY_LINES
-                        : LINE_CHART_CONTENT_MOCK,
+                        : LINE_CHART_TESTS_CASES_EXAMPLE,
                 ],
                 isFetchingHistoricalData: false,
             },

--- a/client/web/src/views/components/view/content/chart-view-content/charts/line/LineChart.module.scss
+++ b/client/web/src/views/components/view/content/chart-view-content/charts/line/LineChart.module.scss
@@ -22,7 +22,10 @@
 }
 
 .legend {
+    margin-top: 0.75rem;
+
     &--horizontal {
+        margin-top: 0;
         flex-grow: 1;
         flex-shrink: 0;
         min-width: 11rem;
@@ -39,11 +42,10 @@
     // Reset ul styles (bullets, paddings, margins)
     list-style: none;
     margin: 0;
-    padding: 0.75rem 0 0 0;
+    padding: 0;
     line-height: 1.2;
 
     &--horizontal {
-        padding-top: 0;
         flex-wrap: nowrap;
         flex-direction: column;
     }

--- a/client/web/src/views/components/view/content/chart-view-content/charts/line/LineChart.tsx
+++ b/client/web/src/views/components/view/content/chart-view-content/charts/line/LineChart.tsx
@@ -49,7 +49,10 @@ export function LineChart<Datum extends object>(props: LineChartProps<Datum>): R
                     {({ width, height }) => <LineChartContent {...otherProps} width={width} height={height} />}
                 </ParentSize>
 
-                <ScrollBox aria-hidden={true} className={classNames({ [styles.legendHorizontal]: isHorizontal })}>
+                <ScrollBox
+                    aria-hidden={true}
+                    className={classNames(styles.legend, { [styles.legendHorizontal]: isHorizontal })}
+                >
                     <ul className={classNames(styles.legendList, { [styles.legendListHorizontal]: isHorizontal })}>
                         {props.series.map(line => (
                             <li key={line.dataKey.toString()} className={styles.legendItem}>

--- a/client/web/src/views/components/view/content/chart-view-content/charts/line/components/scroll-box/ScrollBox.module.scss
+++ b/client/web/src/views/components/view/content/chart-view-content/charts/line/components/scroll-box/ScrollBox.module.scss
@@ -1,6 +1,10 @@
 .root {
     position: relative;
-    overflow: auto;
+    padding: 0;
+
+    &--with-scroll {
+        overflow: auto;
+    }
 
     &--with-top-fader {
         .fader--top {
@@ -36,5 +40,8 @@
 }
 
 .scrollbox {
-    margin-top: -6rem;
+
+    &--with-scroll {
+        margin-top: -6rem;
+    }
 }

--- a/client/web/src/views/components/view/content/chart-view-content/charts/line/components/scroll-box/ScrollBox.module.scss
+++ b/client/web/src/views/components/view/content/chart-view-content/charts/line/components/scroll-box/ScrollBox.module.scss
@@ -21,27 +21,35 @@
 
 .fader {
     display: block;
-    content: '';
     position: sticky;
     z-index: 1;
-    height: 3rem;
+    height: 0;
     width: 100%;
     opacity: 0;
 
     &--top {
         top: 0;
-        background: linear-gradient(0deg, rgba(249, 250, 251, 0) 0%, var(--card-bg) 100%);
+
+        &::before {
+            content: '';
+            display: block;
+            position: absolute;
+            width: 100%;
+            height: 3rem;
+            background: linear-gradient(0deg, rgba(249, 250, 251, 0) 0%, var(--card-bg) 100%);
+        }
     }
 
     &--bottom {
         top: calc(100% - 3rem);
-        background: linear-gradient(180deg, rgba(249, 250, 251, 0) 0%, var(--card-bg) 100%);
-    }
-}
 
-.scrollbox {
-
-    &--with-scroll {
-        margin-top: -6rem;
+        &::before {
+            content: '';
+            display: block;
+            position: absolute;
+            width: 100%;
+            height: 3rem;
+            background: linear-gradient(180deg, rgba(249, 250, 251, 0) 0%, var(--card-bg) 100%);
+        }
     }
 }

--- a/client/web/src/views/mocks/charts-content.ts
+++ b/client/web/src/views/mocks/charts-content.ts
@@ -42,6 +42,60 @@ export const LINE_CHART_CONTENT_MOCK: LineChartContent<any, string> = {
     },
 }
 
+export const LINE_CHART_TESTS_CASES_EXAMPLE: LineChartContent<any, string> = {
+    chart: 'line',
+    data: [
+        { x: 1588965700286 - 4 * 24 * 60 * 60 * 1000, a: 4000, b: 15000, c: 12000, d: 11000, f: 13000 },
+        { x: 1588965700286 - 3 * 24 * 60 * 60 * 1000, a: 4000, b: 26000, c: 14000, d: 11000, f: 5000 },
+        { x: 1588965700286 - 2 * 24 * 60 * 60 * 1000, a: 5600, b: 20000, c: 15000, d: 13000, f: 63000 },
+        { x: 1588965700286 - 1 * 24 * 60 * 60 * 1000, a: 9800, b: 19000, c: 9000, d: 8000, f: 13000 },
+        { x: 1588965700286, a: 12300, b: 17000, c: 8000, d: 8500, f: 16000 },
+    ],
+    series: [
+        {
+            dataKey: 'a',
+            name: 'React Test renderer',
+            stroke: 'var(--blue)',
+            linkURLs: [
+                '#A:1st_data_point',
+                '#A:2nd_data_point',
+                '#A:3rd_data_point',
+                '#A:4th_data_point',
+                '#A:5th_data_point',
+            ],
+        },
+        {
+            dataKey: 'b',
+            name: 'Enzyme',
+            stroke: 'var(--pink)',
+            linkURLs: [
+                '#B:1st_data_point',
+                '#B:2nd_data_point',
+                '#B:3rd_data_point',
+                '#B:4th_data_point',
+                '#B:5th_data_point',
+            ],
+        },
+        {
+            dataKey: 'c',
+            name: 'React Testing Library',
+            stroke: 'var(--red)',
+            linkURLs: [
+                '#B:1st_data_point',
+                '#B:2nd_data_point',
+                '#B:3rd_data_point',
+                '#B:4th_data_point',
+                '#B:5th_data_point',
+            ],
+        },
+    ],
+    xAxis: {
+        dataKey: 'x',
+        scale: 'time',
+        type: 'number',
+    },
+}
+
 export const LINE_CHART_WITH_MANY_LINES: LineChartContent<any, string> = {
     chart: 'line',
     data: [


### PR DESCRIPTION

Prior to this PR we again got a problem with overflowed content in the insight card legend block layout. 
The problem is even if the legend block doesn't have overflowed items we still have a scrollbar there. 
This problem doesn't appear in the Safari browser (that's the reason why I missed this, remained for myself - do not forget to test layout issues in different browsers) 

https://user-images.githubusercontent.com/18492575/146811513-e353c32e-faea-49e1-857d-6f0db0be7eeb.mov

This PR changes the scroll box component in a way to avoid this problem in Chrome, Safari, and Firefox. 
