### PR TITLE
Update visibility explanations

### DIFF
--- a/doc/code_insights/explanations/administration_and_security_of_code_insights.md
+++ b/doc/code_insights/explanations/administration_and_security_of_code_insights.md
@@ -1,11 +1,5 @@
 # Administration and security of Code Insights
 
-## Enable Code Insights for all users 
-
-To enable code insights for all users – which will add an "Insights" link in the Sourcegraph navigation bar menu and allow others to create their own insights – add the following to your organization settings at `sourcegraph.example.com/organizations/[your_org]/settings`:
-
-`"experimentalFeatures": { "codeInsights": true }`
-
 ## Code Insights enforce user permissions 
 
 Users can only create code insights that include repositories they have access to. Moreover, when creating code insights, the repository field will *not* validate nor show users repositories they would not have access to otherwise. 

--- a/doc/code_insights/explanations/viewing_code_insights.md
+++ b/doc/code_insights/explanations/viewing_code_insights.md
@@ -24,7 +24,7 @@ To add insights to your own custom dashboard, see [Creating a custom dashboard o
 
 ### Dashboard visibility
 
-A Dashboard's visibility level owns the visibility of code insights on the dashboard. If you add an Insight that was on a private dashboard to an organization or global dashboard, now people with access to that dashboard can view the insight. When you first create an insight, it defaults to appearing on the dashboard from which you clicked the "create" button. TODO::CONFIRM If you create an insight directly on the create page or from the default dashboard, it [seems to appear on the default dashboard? but what is the visibility?]. 
+A Dashboard's visibility level owns the visibility of code insights on the dashboard. If you add an Insight that was on a private dashboard to an organization or global dashboard, now people with access to that dashboard can view the insight. When you first create an insight, it defaults to appearing on the dashboard from which you clicked the "create" button. If you create an insight directly on the create page or from the default dashboard, it will appear on the default dashboard. 
 
 ### Insights still enforce individual permissions regardless of dashboard visibility
 

--- a/doc/code_insights/explanations/viewing_code_insights.md
+++ b/doc/code_insights/explanations/viewing_code_insights.md
@@ -13,28 +13,18 @@ The main way to view code insights is on a dashboard page. Dashboards have a uni
 There are three possible visibility levels:
 
 - Private: visible only to you
-- Shared with an organization: visible to everyone in the organization
+- Shared with [an organization](../../../admin/organizations.md): visible to everyone in the organization
 - Global: visible to everyone on the Sourcegraph instance
-
-> Global visibility is currently only available if your instance is not [using a separate global settings file](../../../admin/config/advanced_config_file.md#global-settings). Global visibility regardless of settings file setup will arrive by October 2021.
-
-> The **quick workaround** is to [make an organization and easily add all users to it](../../../admin/organizations.md).
 
 ### Built-in dashboards
 
-The following dashboards exist on every instance:
-
-- "All insights": this dashboard contains all the insights defined on the instance that are visible to this specific user
-- "[Username] insights": this dashboard contains all the insights that are created by a user and set to "private" visibility
-- "Global insights": this dashboard contains all the insights that are set to global visibility
-
-If the instance has organizations, there will also be an "[Organization name] insights" dashboard for each organization, visible to members of the organization, that contains all insights set to that organization's visibility level.
+A default "dashboard" of all insights visible to a user appears as the homepage for the Insights navigation bar item. 
 
 To add insights to your own custom dashboard, see [Creating a custom dashboard of code insights](../how-tos/creating_a_custom_dashboard_of_code_insights.md).
 
-### Dashboard visibility respects insights' visibility
+### Dashboard visibility
 
-A Dashboard's visibility level respects the visibility levels you [set when you created the insight](../quickstart.md#7-set-the-visibility-of-your-insight). You can't add an insight with "Private" visibility to an organization dashboard, but you can add an insight with organization visibility to your private dashboard (assuming you're in the organization).
+A Dashboard's visibility level owns the visibility of code insights on the dashboard. If you add an Insight that was on a private dashboard to an organization or global dashboard, now people with access to that dashboard can view the insight. When you first create an insight, it defaults to appearing on the dashboard from which you clicked the "create" button. TODO::CONFIRM If you create an insight directly on the create page or from the default dashboard, it [seems to appear on the default dashboard? but what is the visibility?]. 
 
 ### Insights still enforce individual permissions regardless of dashboard visibility
 

--- a/doc/code_insights/how-tos/creating_a_custom_dashboard_of_code_insights.md
+++ b/doc/code_insights/how-tos/creating_a_custom_dashboard_of_code_insights.md
@@ -15,12 +15,8 @@ Click "Create new dashboard" in the top right corner and name your dashboard. Da
 Set a visibility level for your dashboard. Dashboards [respect insights' permissions](../explanations/viewing_code_insights.md#dashboard-visibility-respects-insights-visibility), so don't create an organization-shared dashboard if you have private insights you want to attach to it. 
 
 - Private: visible only to you 
-- Shared with an organization: visible to everyone in the organization 
+- Shared with [an organization](../../admin/organizations.md): visible to everyone in the organization 
 - Global: visible to everyone on the Sourcegraph instance 
-
-> Global visibility is currently only available if your instance is not [using a separate global settings file](../../admin/config/advanced_config_file.md#global-settings). Global visibility regardless of settings file setup will arrive by October 2021. 
-
-> The **quick workaround** is to [make an organization and easily add all users to it](../../admin/organizations.md). 
 
 Then click "Create dashboard." 
 

--- a/doc/code_insights/language_insight_quickstart.md
+++ b/doc/code_insights/language_insight_quickstart.md
@@ -40,12 +40,6 @@ This determines below what % the insight groups all other languages into an 'Oth
 
 Example: if the Threshold is set to 3%, and 2% of your code is in python and 2% of your code is in ruby, then both will be grouped into 'Other' and the value for 'Other' will be 4%. 
 
-### 6. Set the visibility of your insight
-
-This controls who else can see your insight. 
-
-Anything set to "Private" won't be visible by anyone else.  Otherwise, everyone in the selected organization can see your insight (if they have also enabled [the feature flag](quickstart.md#1-enable-the-experimental-feature-flag)).
-
-### 7. Click "create code insight" to view and save your insight
+### 6. Click "create code insight" to view and save your insight
 
 You'll be taken to the sourcegraph.example.com/insights page and can view your insight.

--- a/doc/code_insights/quickstart.md
+++ b/doc/code_insights/quickstart.md
@@ -63,21 +63,15 @@ You can also select the color of your data series.
 
 Enter a descriptive **Title** for the chart, like `Count of TODOs in [repository name]`.
 
-### 7. Set the visibility of your insight
-
-This controls who else can see your insight.
-
-Anything set to "Private" won't be visible by anyone else. Otherwise, everyone in the selected organization can see your insight (if they have also enabled [the feature flag](#1-enable-the-experimental-feature-flag)).
-
-### 8. Set the distance between data points to 1 month
+### 7. Set the distance between data points to 1 month
 
 The code insights prototypes currently show you seven datapoints for each data series. Your code insight will therefore show you results for a time horizon that is 6 * [distance between datapoints]. Setting it to one month means you'll see the results over the last six months.
 
-### 9. Click "create code insight" and view your insight.
+### 8. Click "create code insight" and view your insight.
 
 You'll be taken to the sourcegraph.example.com/insights page and can view your insight.
 
-### 10. Filter your insight to explore it further 
+### 9. Filter your insight to explore it further 
 
 Click the filter button in the top right of an insight card to open the filters panel. This allows you to filter the insight down to a subset of repositories through inclusion or exclusion using regular expressions.
 For more details, see [How to filter an insight](./how-tos/filtering_an_insight.md).


### PR DESCRIPTION
Insights no longer have direct visibility settings. 

I'm still a teeny bit hand-wavey on some of the details, so if someone from the frontend @unclejustin @vovakulikov and @CristinaBirkel could review the Dashboard visibility section which I tagged with `TODO::CONFIRM` that is much appreciated! 