### PR TITLE
Doc: github default branch

### DIFF
--- a/doc/admin/external_service/github.md
+++ b/doc/admin/external_service/github.md
@@ -131,7 +131,7 @@ GitHub connections support the following configuration options, which are specif
 
 ## Default branch
 
-GitHub uses the default branch of a repository for searches and the search results will be shown from the default branch. If you'd like the search results to be displayed from another branch by default, you may [change a repo's default branch on the github repo settings page](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/changing-the-default-branch). If this is not an option, consider using [search contexts](https://docs.sourcegraph.com/code_search/how-to/search_contexts) instead. 
+Sourcegraph displays search results from the default branch of a repository when no `revision:` parameter is specified. If you'd like the search results to be displayed from another branch by default, you may [change a repo's default branch on the github repo settings page](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/changing-the-default-branch). If this is not an option, consider using [search contexts](https://docs.sourcegraph.com/code_search/how-to/search_contexts) instead. 
 
 ## Troubleshooting
 

--- a/doc/admin/external_service/github.md
+++ b/doc/admin/external_service/github.md
@@ -129,6 +129,10 @@ GitHub connections support the following configuration options, which are specif
 
 <div markdown-func=jsonschemadoc jsonschemadoc:path="admin/external_service/github.schema.json">[View page on docs.sourcegraph.com](https://docs.sourcegraph.com/admin/external_service/github) to see rendered content.</div>
 
+## Default branch
+
+GitHub uses the master branch as the default branch of a repository. This means that searches targeting a synched github repo will automatically default to results from the master branch. If however you'd like search results to be displayed from another repository by default you may [change a repo's default branch on the github repo settings page](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/changing-the-default-branch). If this is not an option consider using [search contexts](https://docs.sourcegraph.com/code_search/how-to/search_contexts) instead. 
+
 ## Troubleshooting
 
 ### Hitting GitHub Search API rate limit with repositoryQuery

--- a/doc/admin/external_service/github.md
+++ b/doc/admin/external_service/github.md
@@ -131,7 +131,7 @@ GitHub connections support the following configuration options, which are specif
 
 ## Default branch
 
-GitHub uses the master branch as the default branch of a repository. This means that searches targeting a synched github repo will automatically default to results from the master branch. If however you'd like search results to be displayed from another repository by default you may [change a repo's default branch on the github repo settings page](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/changing-the-default-branch). If this is not an option consider using [search contexts](https://docs.sourcegraph.com/code_search/how-to/search_contexts) instead. 
+GitHub uses the default branch of a repository for searches and the search results will be shown from the default branch. If you'd like the search results to be displayed from another branch by default, you may [change a repo's default branch on the github repo settings page](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/changing-the-default-branch). If this is not an option, consider using [search contexts](https://docs.sourcegraph.com/code_search/how-to/search_contexts) instead. 
 
 ## Troubleshooting
 

--- a/doc/admin/external_service/github.md
+++ b/doc/admin/external_service/github.md
@@ -131,7 +131,7 @@ GitHub connections support the following configuration options, which are specif
 
 ## Default branch
 
-Sourcegraph displays search results from the default branch of a repository when no `revision:` parameter is specified. If you'd like the search results to be displayed from another branch by default, you may [change a repo's default branch on the github repo settings page](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/changing-the-default-branch). If this is not an option, consider using [search contexts](https://docs.sourcegraph.com/code_search/how-to/search_contexts) instead. 
+Sourcegraph displays search results from the default branch of a repository when no `revision:` [parameter](https://docs.sourcegraph.com/code_search/reference/queries#repository-revisions) is specified. If you'd like the search results to be displayed from another branch by default, you may [change a repo's default branch on the github repo settings page](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/changing-the-default-branch). If this is not an option, consider using [search contexts](https://docs.sourcegraph.com/code_search/how-to/search_contexts) instead. 
 
 ## Troubleshooting
 


### PR DESCRIPTION
Let customers know default branch is configurable on a repos github page, and is respected in default search results

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
