### PR TITLE
[SG-29236] fix: percy flaky snapshot on Batch change details page

### DIFF
--- a/client/web/src/integration/batches.test.ts
+++ b/client/web/src/integration/batches.test.ts
@@ -33,11 +33,13 @@ import { createWebIntegrationTestContext, WebIntegrationTestContext } from './co
 import { commonWebGraphQlResults } from './graphQlResults'
 import { percySnapshotWithVariants } from './utils'
 
+const now = new Date()
+
 const batchChangeListNode: ListBatchChange = {
     id: 'batch123',
     url: '/users/alice/batch-changes/test-batch-change',
     name: 'test-batch-change',
-    createdAt: subDays(new Date(), 5).toISOString(),
+    createdAt: subDays(now, 5).toISOString(),
     changesetsStats: { closed: 4, merged: 10, open: 5 },
     closedAt: null,
     description: null,
@@ -137,7 +139,7 @@ const ChangesetCountsOverTime: (variables: ChangesetCountsOverTimeVariables) => 
         changesetCountsOverTime: [
             {
                 closed: 12,
-                date: subDays(new Date(), 2).toISOString(),
+                date: subDays(now, 2).toISOString(),
                 merged: 10,
                 openApproved: 3,
                 openChangesRequested: 1,
@@ -147,7 +149,7 @@ const ChangesetCountsOverTime: (variables: ChangesetCountsOverTimeVariables) => 
             },
             {
                 closed: 12,
-                date: subDays(new Date(), 1).toISOString(),
+                date: subDays(now, 1).toISOString(),
                 merged: 10,
                 openApproved: 23,
                 openChangesRequested: 1,
@@ -183,8 +185,8 @@ const BatchChangeChangesets: (variables: BatchChangeChangesetsVariables) => Batc
                     __typename: 'ExternalChangeset',
                     body: 'body123',
                     checkState: ChangesetCheckState.PASSED,
-                    createdAt: subDays(new Date(), 5).toISOString(),
-                    updatedAt: subDays(new Date(), 5).toISOString(),
+                    createdAt: subDays(now, 5).toISOString(),
+                    updatedAt: subDays(now, 5).toISOString(),
                     diffStat: {
                         __typename: 'DiffStat',
                         added: 100,
@@ -299,8 +301,8 @@ function mockCommonGraphQLResponses(
                     draft: 2,
                 },
                 closedAt: null,
-                createdAt: subDays(new Date(), 5).toISOString(),
-                updatedAt: subDays(new Date(), 5).toISOString(),
+                createdAt: subDays(now, 5).toISOString(),
+                updatedAt: subDays(now, 5).toISOString(),
                 description: '### Very cool batch change',
                 creator: {
                     url: '/users/alice',
@@ -314,7 +316,7 @@ function mockCommonGraphQLResponses(
                 diffStat: { added: 1000, changed: 2000, deleted: 1000, __typename: 'DiffStat' },
                 url: `${namespaceURL}/batch-changes/test-batch-change`,
                 viewerCanAdminister: true,
-                lastAppliedAt: subDays(new Date(), 5).toISOString(),
+                lastAppliedAt: subDays(now, 5).toISOString(),
                 lastApplier: {
                     url: '/users/bob',
                     username: 'bob',
@@ -555,7 +557,7 @@ describe('Batches', () => {
                 testContext.overrideGraphQL({
                     ...commonWebGraphQlResults,
                     ...batchChangeLicenseGraphQlResults,
-                    ...mockCommonGraphQLResponses(entityType, { closedAt: subDays(new Date(), 1).toISOString() }),
+                    ...mockCommonGraphQLResponses(entityType, { closedAt: subDays(now, 1).toISOString() }),
                     BatchChangeChangesets,
                     ChangesetCountsOverTime,
                     ExternalChangesetFileDiffs,
@@ -612,7 +614,7 @@ describe('Batches', () => {
                             __typename: 'BatchSpec',
                             id: 'spec123',
                             appliesToBatchChange: null,
-                            createdAt: subDays(new Date(), 2).toISOString(),
+                            createdAt: subDays(now, 2).toISOString(),
                             creator: {
                                 username: 'alice',
                                 url: '/users/alice',
@@ -628,7 +630,7 @@ describe('Batches', () => {
                                 changed: 100,
                                 deleted: 182,
                             },
-                            expiresAt: addDays(new Date(), 3).toISOString(),
+                            expiresAt: addDays(now, 3).toISOString(),
                             namespace:
                                 entityType === 'user'
                                     ? {
@@ -709,7 +711,7 @@ describe('Batches', () => {
                                                     },
                                                     title: 'Changeset title',
                                                 },
-                                                expiresAt: addDays(new Date(), 3).toISOString(),
+                                                expiresAt: addDays(now, 3).toISOString(),
                                                 id: 'changesetspec123',
                                                 type: ChangesetSpecType.BRANCH,
                                             },


### PR DESCRIPTION
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
### Descriptions

- The minor different times between 2 call of `new Date()` makes condition check `lastAppliedAt !== null && lastAppliedAt !== createdAt` failed and causes percy snapshot changes.
- In this PR, we create a var for `new Date()` and use it in mocking data to fix the issue

### Refs

- [SourceGraph Issue](https://github.com/sourcegraph/sourcegraph/issues/29236)
- [GitStart ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-29236)