### PR TITLE
ci: source profile before strict error handling

### DIFF
--- a/enterprise/dev/upload-build-logs.sh
+++ b/enterprise/dev/upload-build-logs.sh
@@ -18,9 +18,9 @@ if [ "$1" == "-h" ]; then
   exit 1
 fi
 
-set -euo pipefail
-
 source /root/.profile
+
+set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")"/../..
 


### PR DESCRIPTION
Otherwise, this will cause errors such as `/root/.bashrc: line 6: PS1: unbound variable`
which will prevent uploading the logs.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
