### PR TITLE
[cloud] Add a way for site-admins to toggle code feature flag for orgs

### DIFF
--- a/client/web/src/enterprise/organizations/EarlyAccessOrgsCodeForm.tsx
+++ b/client/web/src/enterprise/organizations/EarlyAccessOrgsCodeForm.tsx
@@ -1,0 +1,132 @@
+import React, { FunctionComponent, useCallback, useState } from 'react'
+
+import { Form } from '@sourcegraph/branded/src/components/Form'
+import { gql, useLazyQuery, useMutation } from '@sourcegraph/shared/src/graphql/graphql'
+import { IFeatureFlagOverride } from '@sourcegraph/shared/src/graphql/schema'
+import { Input } from '@sourcegraph/wildcard'
+
+import { LoaderButton } from '../../components/LoaderButton'
+import { Maybe, OrganizationVariables } from '../../graphql-operations'
+
+const ORG_CODE_FLAG = 'org-code'
+
+interface OrgResult {
+    organization: Maybe<{
+        id: string
+    }>
+}
+
+interface FeatureFlagOverrideResult {
+    createFeatureFlagOverride: Maybe<IFeatureFlagOverride>
+}
+
+interface FeatureFlagOverrideVariables {
+    namespace: string
+    flagName: string
+    value: boolean
+}
+
+export const ORG_ID_BY_NAME = gql`
+    query OrganizationIDByName($name: String!) {
+        organization(name: $name) {
+            id
+        }
+    }
+`
+
+export const CREATE_FEATURE_FLAG_OVERRIDE = gql`
+    mutation CreateFeatureFlagOverride($namespace: ID!, $flagName: String!, $value: Boolean!) {
+        createFeatureFlagOverride(namespace: $namespace, flagName: $flagName, value: $value) {
+            __typename
+        }
+    }
+`
+/**
+ * Form that sets a feature flag override for org-code flag, based on organization name.
+ * This enables 2 screens - organization code host connections and organization repositories.
+ *
+ * On submit, there are 2 requests in series - first gets the organization ID by name,
+ * second sets the feature flag override based on the ID from first request.
+ *
+ * This implementation is a quick hack for making our lives easier while in early access
+ * stage. IMO it's not worth a lot of effort as it is throwaway work once we are in GA.
+ */
+export const EarlyAccessOrgsCodeForm: FunctionComponent<any> = () => {
+    const [name, setName] = useState<string>('')
+
+    const [updateFeatureFlag, { data, loading: flagLoading, error: flagError }] = useMutation<
+        FeatureFlagOverrideResult,
+        FeatureFlagOverrideVariables
+    >(CREATE_FEATURE_FLAG_OVERRIDE, {
+        onError: apolloError => console.error('Error when creating feature flag override', apolloError),
+    })
+
+    const [getOrgID, { loading: orgLoading, error: orgError }] = useLazyQuery<OrgResult, OrganizationVariables>(
+        ORG_ID_BY_NAME,
+        {
+            onCompleted: ({ organization }) => {
+                const id = organization?.id
+                if (id) {
+                    return updateFeatureFlag({
+                        variables: {
+                            namespace: id,
+                            flagName: ORG_CODE_FLAG,
+                            value: true,
+                        },
+                    })
+                }
+                return
+            },
+        }
+    )
+
+    const onSubmit = useCallback<React.FormEventHandler>(
+        event => {
+            event.preventDefault()
+            return getOrgID({
+                variables: {
+                    name,
+                },
+            })
+        },
+        [getOrgID, name]
+    )
+
+    const onChange = useCallback<React.ChangeEventHandler<HTMLInputElement>>(
+        event => {
+            setName(event.target.value)
+            // clear the success message on input change
+            if (data) {
+                data.createFeatureFlagOverride = null
+            }
+        },
+        [data]
+    )
+
+    const loading = orgLoading || flagLoading
+    const error = orgError || flagError
+
+    return (
+        <Form onSubmit={onSubmit}>
+            <h2>Organizations code early access</h2>
+            <p>Type in an organization name to enable early access for organization code host and repositories.</p>
+
+            <div className="d-flex justify-content-start align-items-end">
+                <Input label="Name" value={name} onChange={onChange} className="mb-0" />
+                <LoaderButton
+                    className="btn btn-primary ml-3"
+                    type="submit"
+                    loading={loading}
+                    disabled={loading || name.trim().length < 3}
+                    alwaysShowLabel={true}
+                    label="Enable"
+                />
+            </div>
+
+            {error && <div className="mt-3 alert alert-danger">{error.message}</div>}
+            {data?.createFeatureFlagOverride && (
+                <div className="mt-3 mb-0 alert alert-success">Feature flag override created.</div>
+            )}
+        </Form>
+    )
+}

--- a/client/web/src/enterprise/site-admin/routes.ts
+++ b/client/web/src/enterprise/site-admin/routes.ts
@@ -163,4 +163,10 @@ export const enterpriseSiteAdminAreaRoutes: readonly SiteAdminAreaRoute[] = [
         exact: true,
         condition: () => Boolean(window.context?.executorsEnabled),
     },
+    // Organization routes
+    {
+        path: '/organizations/early-access-orgs-code',
+        render: lazyComponent(() => import('../organizations/EarlyAccessOrgsCodeForm'), 'EarlyAccessOrgsCodeForm'),
+        exact: true,
+    },
 ]

--- a/client/web/src/site-admin/SiteAdminOrgsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminOrgsPage.tsx
@@ -128,9 +128,18 @@ export const SiteAdminOrgsPage: React.FunctionComponent<Props> = ({ telemetrySer
                 organizations.
             </p>
             {window.context.sourcegraphDotComMode ? (
-                <div className="alert alert-info">
-                    Only organization members can view & modify organization settings.
-                </div>
+                <>
+                    <div className="alert alert-info">
+                        Only organization members can view & modify organization settings.
+                    </div>
+                    <h3>Enable early access</h3>
+                    <div className="d-flex justify-content-between align-items-center mb-3">
+                        <p>Enable early access for organization code host connections and repositories on Cloud.</p>
+                        <Link to="./organizations/early-access-orgs-code" className="btn btn-outline-primary">
+                            Enable early access
+                        </Link>
+                    </div>
+                </>
             ) : (
                 <FilteredConnection<OrganizationFields, Omit<OrgNodeProps, 'node'>>
                     className="list-group list-group-flush mt-3"

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -32,8 +32,7 @@ func (r *schemaResolver) Organization(ctx context.Context, args struct{ Name str
 				return nil
 			}
 
-			a := actor.FromContext(ctx)
-			if a.IsAuthenticated() {
+			if a := actor.FromContext(ctx); a.IsAuthenticated() {
 				_, err = r.db.OrgInvitations().GetPending(ctx, org.ID, a.UID)
 				if err == nil {
 					return nil

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -28,12 +28,12 @@ func (r *schemaResolver) Organization(ctx context.Context, args struct{ Name str
 	// 🚨 SECURITY: Only org members can get org details on Cloud
 	if envvar.SourcegraphDotComMode() {
 		hasAccess := func() error {
-			err := backend.CheckOrgAccess(ctx, r.db, org.ID)
-			if err == nil {
+			if backend.CheckOrgAccess(ctx, r.db, org.ID) == nil {
 				return nil
 			}
 
-			if a := actor.FromContext(ctx); a.IsAuthenticated() {
+			a := actor.FromContext(ctx)
+			if a.IsAuthenticated() {
 				_, err = r.db.OrgInvitations().GetPending(ctx, org.ID, a.UID)
 				if err == nil {
 					return nil
@@ -45,6 +45,11 @@ func (r *schemaResolver) Organization(ctx context.Context, args struct{ Name str
 			return &database.OrgNotFoundError{Message: fmt.Sprintf("name %s", args.Name)}
 		}
 		if err := hasAccess(); err != nil {
+			// site admin can access org ID
+			if backend.CheckCurrentUserIsSiteAdmin(ctx, r.db) == nil {
+				onlyOrgID := &types.Org{ID: org.ID}
+				return &OrgResolver{db: r.db, org: onlyOrgID}, nil
+			}
 			return nil, err
 		}
 	}


### PR DESCRIPTION
# Description

This allows organizations to access code host connections and repositories
features in the org settings.

# Related Jira issue
https://sourcegraph.atlassian.net/browse/CLOUD-166

# Screenshots

<img width="952" alt="Screenshot 2021-12-21 at 14 11 19" src="https://user-images.githubusercontent.com/9974711/146936245-64d83087-f10e-4cd4-bbc1-e45f19779b1b.png">
<img width="942" alt="Screenshot 2021-12-21 at 14 11 27" src="https://user-images.githubusercontent.com/9974711/146936259-6dff9c28-65df-426f-922e-0d21f7806ac2.png">
<img width="933" alt="Screenshot 2021-12-21 at 14 12 18" src="https://user-images.githubusercontent.com/9974711/146936252-4ba11fff-6f52-4dc7-b602-92d01618cd66.png">
<img width="934" alt="Screenshot 2021-12-21 at 14 11 54" src="https://user-images.githubusercontent.com/9974711/146936255-1159c866-8538-435b-8d92-964cc4a18252.png">
<img width="932" alt="Screenshot 2021-12-21 at 14 11 40" src="https://user-images.githubusercontent.com/9974711/146936258-fb1ab6d9-89e6-4af5-8a97-5635c56f19fe.png">


# Testing locally
1. Run sg in dotcom mode: `EXTSVC_CONFIG_ALLOW_EDITS=true sg start dotcom`
2. Make sure you have a feature flag defined: `org-code` feature flag with a default value of `false`
3. Create an organization
4. Go to org settings page - code host connections and repositories *should not* be visible
5. Go to Site admin -> Organizations, click on `Enable early access`
6. Type in the name of the organization and click on `Enable`
7. Success message should appear
8. Go back to org settings page - code host connections and repositories *should be visible*


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
