### PR TITLE
frontend: enable feature flags in internal handler

### DIFF
--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -118,12 +118,14 @@ func newInternalHTTPHandler(schema *graphql.Schema, db database.DB, newCodeIntel
 	internalMux := http.NewServeMux()
 	internalMux.Handle("/.internal/", gziphandler.GzipHandler(
 		actor.HTTPMiddleware(
-			internalhttpapi.NewInternalHandler(
-				router.NewInternal(mux.NewRouter().PathPrefix("/.internal/").Subrouter()),
-				db,
-				schema,
-				newCodeIntelUploadHandler,
-				rateLimitWatcher,
+			featureflag.Middleware(database.FeatureFlags(db),
+				internalhttpapi.NewInternalHandler(
+					router.NewInternal(mux.NewRouter().PathPrefix("/.internal/").Subrouter()),
+					db,
+					schema,
+					newCodeIntelUploadHandler,
+					rateLimitWatcher,
+				),
 			),
 		),
 	))


### PR DESCRIPTION
Many internal requests that act as a user need feature flags loaded in
the context. In production we're seeing lots of log spam like this:

> t=2021-12-21T12:37:23+0000 lvl=warn msg="search feature flags are not available"



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
