### PR TITLE
web: improve `<Button />` type

### DIFF
--- a/client/shared/src/components/Link.tsx
+++ b/client/shared/src/components/Link.tsx
@@ -25,7 +25,7 @@ export type LinkProps = { to: string | H.LocationDescriptor<any>; ref?: React.Re
  *
  * @see setLinkComponent
  */
-export let Link: React.ComponentType<LinkProps>
+export let Link: React.FunctionComponent<LinkProps>
 
 if (process.env.NODE_ENV !== 'production') {
     // Fail with helpful message if setLinkComponent has not been called when the <Link> component is used.

--- a/client/web/src/batches/RepoBatchChangesButton.tsx
+++ b/client/web/src/batches/RepoBatchChangesButton.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import React, { FC, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 
@@ -31,7 +32,10 @@ export const RepoBatchChangesButton: FC<RepoBatchChangesButtonProps> = ({
     const { open, merged } = stats.changesetsStats
 
     return (
-        <Link className={className} to={`/${encodeURIPathComponent(repoName)}/-/batch-changes`}>
+        <Link
+            className={classNames('btn btn-outline-secondary', className)}
+            to={`/${encodeURIPathComponent(repoName)}/-/batch-changes`}
+        >
             <BatchChangesIcon className="icon-inline" /> Batch Changes
             {open > 0 && (
                 <Badge

--- a/client/web/src/enterprise/site-admin/productSubscription/ProductSubscriptionStatus.tsx
+++ b/client/web/src/enterprise/site-admin/productSubscription/ProductSubscriptionStatus.tsx
@@ -123,7 +123,6 @@ export const ProductSubscriptionStatus: React.FunctionComponent<Props> = ({ clas
                                 <a
                                     href="https://about.sourcegraph.com/pricing"
                                     className="btn btn-primary btn-sm"
-                                    // eslint-disable-next-line react/jsx-no-target-blank
                                     target="_blank"
                                     rel="noopener"
                                 >
@@ -142,7 +141,6 @@ export const ProductSubscriptionStatus: React.FunctionComponent<Props> = ({ clas
                                     <a
                                         href="http://about.sourcegraph.com/contact/sales"
                                         className="btn btn-primary btn-sm"
-                                        // eslint-disable-next-line react/jsx-no-target-blank
                                         target="_blank"
                                         rel="noopener"
                                         data-tooltip="Buy a Sourcegraph Enterprise subscription to get a license key"

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -399,12 +399,7 @@ export const TreePage: React.FunctionComponent<Props> = ({
                                                 <BrainIcon className="icon-inline" /> Code Intelligence
                                             </Link>
                                         )}
-                                        {batchChangesEnabled && (
-                                            <RepoBatchChangesButton
-                                                className="btn btn-outline-secondary"
-                                                repoName={repo.name}
-                                            />
-                                        )}
+                                        {batchChangesEnabled && <RepoBatchChangesButton repoName={repo.name} />}
                                         {repo.viewerCanAdminister && (
                                             <Link
                                                 className="btn btn-outline-secondary"

--- a/client/wildcard/src/components/Button/Button.tsx
+++ b/client/wildcard/src/components/Button/Button.tsx
@@ -1,6 +1,8 @@
 import classNames from 'classnames'
 import React from 'react'
 
+import { ForwardReferenceComponent } from '../../types'
+
 import { BUTTON_VARIANTS, BUTTON_SIZES } from './constants'
 import { getButtonSize, getButtonStyle } from './utils'
 
@@ -44,7 +46,7 @@ export interface ButtonProps
  * Tips:
  * - Avoid using button styling for links where possible. Buttons should typically trigger an action, links should navigate to places.
  */
-export const Button: React.FunctionComponent<ButtonProps> = React.forwardRef(
+export const Button = React.forwardRef(
     (
         { children, as: Component = 'button', type = 'button', variant, size, outline, className, ...attributes },
         reference
@@ -63,4 +65,4 @@ export const Button: React.FunctionComponent<ButtonProps> = React.forwardRef(
             {children}
         </Component>
     )
-)
+) as ForwardReferenceComponent<'button', ButtonProps>

--- a/client/wildcard/src/components/Button/story/Button.story.tsx
+++ b/client/wildcard/src/components/Button/story/Button.story.tsx
@@ -1,5 +1,5 @@
 import { boolean, select } from '@storybook/addon-knobs'
-import { Meta } from '@storybook/react'
+import { Meta, Story } from '@storybook/react'
 import SearchIcon from 'mdi-react/SearchIcon'
 import React from 'react'
 
@@ -11,7 +11,7 @@ import { BUTTON_VARIANTS, BUTTON_SIZES } from '../constants'
 
 import { ButtonVariants } from './ButtonVariants'
 
-const Story: Meta = {
+const config: Meta = {
     title: 'wildcard/Button',
 
     decorators: [
@@ -31,9 +31,9 @@ const Story: Meta = {
     },
 }
 
-export default Story
+export default config
 
-export const Simple = () => (
+export const Simple: Story = () => (
     <Button
         variant={select('Variant', BUTTON_VARIANTS, 'primary')}
         size={select('Size', BUTTON_SIZES, undefined)}
@@ -44,7 +44,7 @@ export const Simple = () => (
     </Button>
 )
 
-export const AllButtons = () => (
+export const AllButtons: Story = () => (
     <>
         <h1>Buttons</h1>
         <h2>Variants</h2>
@@ -63,7 +63,6 @@ export const AllButtons = () => (
         <Button
             variant="secondary"
             as="a"
-            // @ts-expect-error (providing `as` changes possible props)
             href="https://example.com"
             target="_blank"
             rel="noopener noreferrer"

--- a/client/wildcard/src/components/Button/story/ButtonVariants.tsx
+++ b/client/wildcard/src/components/Button/story/ButtonVariants.tsx
@@ -15,22 +15,21 @@ interface ButtonVariantsProps extends Pick<ButtonProps, 'size' | 'outline' | 'as
 export const ButtonVariants: React.FunctionComponent<ButtonVariantsProps> = ({
     variants,
     size,
-    as,
     outline,
     icon: Icon,
 }) => (
     <div className={styles.grid}>
         {variants.map(variant => (
             <React.Fragment key={variant}>
-                <Button as={as} variant={variant} size={size} outline={outline} onClick={console.log}>
+                <Button variant={variant} size={size} outline={outline} onClick={console.log}>
                     {Icon && <Icon className="icon-inline mr-1" />}
                     {startCase(variant)}
                 </Button>
-                <Button as={as} variant={variant} size={size} outline={outline} onClick={console.log} className="focus">
+                <Button variant={variant} size={size} outline={outline} onClick={console.log} className="focus">
                     {Icon && <Icon className="icon-inline mr-1" />}
                     Focus
                 </Button>
-                <Button as={as} variant={variant} size={size} outline={outline} onClick={console.log} disabled={true}>
+                <Button variant={variant} size={size} outline={outline} onClick={console.log} disabled={true}>
                     {Icon && <Icon className="icon-inline mr-1" />}
                     Disabled
                 </Button>


### PR DESCRIPTION
## Context

To allow doing `<Button as={Whatever} whateverProp={true} />` use `ForwardReferenceComponent`.