### PR TITLE
Default to Java 8 for Maven artifacts with no classfiles

### DIFF
--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -489,7 +489,11 @@ func classFileMajorVersion(byteCodeJarPath string) (string, error) {
 		return version, nil
 	}
 
-	return "", errors.Errorf("failed to infer JVM version for jar %s because it doesn't contain any classfiles", byteCodeJarPath)
+	// We didn't find any `*.class` files so we can use any Java version.
+	// Maven don't have to contain classfiles, some artifacts like
+	// 'io.smallrye:smallrye-health-ui:3.1.1' only contain HTML/css/png/js
+	// files.
+	return "8", nil
 }
 
 func classFileEntryMajorVersion(byteCodeJarPath string, zipEntry *zip.File) (string, error) {


### PR DESCRIPTION

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
