### PR TITLE
ci: disable cluster QA test due to flakiness

### DIFF
--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -479,6 +479,7 @@ func testUpgrade(candidateTag, minimumUpgradeableVersion string) operations.Oper
 	}
 }
 
+// Flaky deployment. See https://github.com/sourcegraph/sourcegraph/issues/25977
 func clusterQA(candidateTag string) operations.Operation {
 	return func(p *bk.Pipeline) {
 		p.AddStep(":k8s: Sourcegraph Cluster (deploy-sourcegraph) QA",

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -480,22 +480,22 @@ func testUpgrade(candidateTag, minimumUpgradeableVersion string) operations.Oper
 }
 
 // Flaky deployment. See https://github.com/sourcegraph/sourcegraph/issues/25977
-func clusterQA(candidateTag string) operations.Operation {
-	return func(p *bk.Pipeline) {
-		p.AddStep(":k8s: Sourcegraph Cluster (deploy-sourcegraph) QA",
-			bk.DependsOn(candidateImageStepKey("frontend")),
-			bk.Env("CANDIDATE_VERSION", candidateTag),
-			bk.Env("DOCKER_CLUSTER_IMAGES_TXT", strings.Join(images.DeploySourcegraphDockerImages, "\n")),
-			bk.Env("NO_CLEANUP", "false"),
-			bk.Env("SOURCEGRAPH_BASE_URL", "http://127.0.0.1:7080"),
-			bk.Env("SOURCEGRAPH_SUDO_USER", "admin"),
-			bk.Env("TEST_USER_EMAIL", "test@sourcegraph.com"),
-			bk.Env("TEST_USER_PASSWORD", "supersecurepassword"),
-			bk.Env("INCLUDE_ADMIN_ONBOARDING", "false"),
-			bk.Cmd("./dev/ci/test/cluster/cluster-test.sh"),
-			bk.ArtifactPaths("./*.png", "./*.mp4", "./*.log"))
-	}
-}
+// func clusterQA(candidateTag string) operations.Operation {
+// 	return func(p *bk.Pipeline) {
+// 		p.AddStep(":k8s: Sourcegraph Cluster (deploy-sourcegraph) QA",
+// 			bk.DependsOn(candidateImageStepKey("frontend")),
+// 			bk.Env("CANDIDATE_VERSION", candidateTag),
+// 			bk.Env("DOCKER_CLUSTER_IMAGES_TXT", strings.Join(images.DeploySourcegraphDockerImages, "\n")),
+// 			bk.Env("NO_CLEANUP", "false"),
+// 			bk.Env("SOURCEGRAPH_BASE_URL", "http://127.0.0.1:7080"),
+// 			bk.Env("SOURCEGRAPH_SUDO_USER", "admin"),
+// 			bk.Env("TEST_USER_EMAIL", "test@sourcegraph.com"),
+// 			bk.Env("TEST_USER_PASSWORD", "supersecurepassword"),
+// 			bk.Env("INCLUDE_ADMIN_ONBOARDING", "false"),
+// 			bk.Cmd("./dev/ci/test/cluster/cluster-test.sh"),
+// 			bk.ArtifactPaths("./*.png", "./*.mp4", "./*.log"))
+// 	}
+// }
 
 // candidateImageStepKey is the key for the given app (see the `images` package). Useful for
 // adding dependencies on a step.

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -215,7 +215,8 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			codeIntelQA(c.candidateImageTag()),
 			serverE2E(c.candidateImageTag()),
 			serverQA(c.candidateImageTag()),
-			clusterQA(c.candidateImageTag()),
+			// Flaky deployment. See https://github.com/sourcegraph/sourcegraph/issues/25977
+			// clusterQA(c.candidateImageTag()),
 			testUpgrade(c.candidateImageTag(), minimumUpgradeableVersion))
 
 		// All operations before this point are required


### PR DESCRIPTION
See https://github.com/sourcegraph/sourcegraph/issues/25977

QA: 

```
~/work/sourcegraph  main-dry-run/devx/ci-disable-cluster-test $ sg ci preview | grep k8s
~/work/sourcegraph  main-dry-run/devx/ci-disable-cluster-test $ git co main
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
~/work/sourcegraph  main $ sg ci preview | grep k8s
        :k8s: Sourcegraph Cluster (deploy-sourcegraph) QA
        :github: :date: :k8s: Trigger k8s updates if current commit is tip of 'main'
~/work/sourcegraph  main $
```
