### PR TITLE
[cloud] Set org creation user tag by site admins

### DIFF
--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -56,6 +56,8 @@ import {
     OrgRepositoriesResult,
     OrgRepositoriesTotalCountVariables,
     UserRepositoriesTotalCountVariables,
+    SetUserTagResult,
+    SetUserTagVariables,
 } from '../graphql-operations'
 
 type UserRepositories = (NonNullable<UserRepositoriesResult['node']> & { __typename: 'User' })['repositories']
@@ -87,6 +89,7 @@ export function fetchAllUsers(args: { first?: number; query?: string }): Observa
                                 name
                             }
                         }
+                        tags
                     }
                     totalCount
                 }
@@ -857,6 +860,26 @@ export function createUser(username: string, email: string | undefined): Observa
     ).pipe(
         map(dataOrThrowErrors),
         map(data => data.createUser)
+    )
+}
+
+export function setUserTag(node: string, tag: string, present: boolean = true): Observable<void> {
+    return requestGraphQL<SetUserTagResult, SetUserTagVariables>(
+        gql`
+            mutation SetUserTag($node: ID!, $tag: String!, $present: Boolean!) {
+                setTag(node: $node, tag: $tag, present: $present) {
+                    alwaysNil
+                }
+            }
+        `,
+        { node, tag, present }
+    ).pipe(
+        map(dataOrThrowErrors),
+        map(data => {
+            if (!data.setTag) {
+                throw createInvalidGraphQLMutationResponseError('SetUserTag')
+            }
+        })
     )
 }
 


### PR DESCRIPTION
# Description

This allows site admins to toggle organization creation user tag.
The user tag guards the org creation feature in both UI and graphql endpoints.

Since this is mostly going to be used to guard organization creation in early access of Cloud for small organizations, I don't think we should put in effort for testing. This is mostly throwaway work once we release GA.

# Related Jira issue
https://sourcegraph.atlassian.net/browse/CLOUD-167

# Screenshots
<img width="933" alt="Screenshot 2021-12-21 at 17 39 43" src="https://user-images.githubusercontent.com/9974711/146966801-e29a4327-857d-4c43-bd62-fb4cbb35247e.png">
<img width="930" alt="Screenshot 2021-12-21 at 17 39 50" src="https://user-images.githubusercontent.com/9974711/146966808-35f0aadf-a391-4003-a8d2-bdb093d84c41.png">

# Testing locally

1. Run sg in dotcom mode
2. Go to Site-admin -> Users
3. You should now see a new button in each row
  a. If a user does have `CreateOrg` user tag, the button should have a label `Disable org creation`
  b. Otherwise the button should have a label `Enable org creation`
4. Clicking on the button is toggling the user tag for the user in Postgres
5. After toggling org creation *ON*, the user should be able to see `New organization` button in user settings sidebar



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
