### PR TITLE
dev: update handbook paths for release tool templates

### DIFF
--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -11,7 +11,7 @@
 {
     // Captain information
     "captainSlackUsername": "Crystal Augustus",
-    "captainGitHubUsername": "@caugustus-sourcegraph",
+    "captainGitHubUsername": "caugustus-sourcegraph",
     // Release versions
     "previousRelease": "3.35.0",
     "upcomingRelease": "3.36.0",

--- a/dev/release/src/github.ts
+++ b/dev/release/src/github.ts
@@ -99,21 +99,21 @@ const getTemplates = () => {
     const releaseIssue: IssueTemplate = {
         owner: 'sourcegraph',
         repo: 'handbook',
-        path: 'content/product-engineering/engineering/releases/release_issue_template.md',
+        path: 'content/departments/product-engineering/engineering/process/releases/release_issue_template.md',
         titleSuffix: IssueTitleSuffix.RELEASE_TRACKING,
         labels: [IssueLabel.RELEASE_TRACKING, IssueLabel.RELEASE],
     }
     const patchReleaseIssue: IssueTemplate = {
         owner: 'sourcegraph',
         repo: 'handbook',
-        path: 'content/product-engineering/engineering/releases/patch_release_issue_template.md',
+        path: 'content/departments/product-engineering/engineering/process/releases/patch_release_issue_template.md',
         titleSuffix: IssueTitleSuffix.PATCH_TRACKING,
         labels: [IssueLabel.RELEASE_TRACKING, IssueLabel.PATCH],
     }
     const upgradeManagedInstanceIssue: IssueTemplate = {
         owner: 'sourcegraph',
         repo: 'handbook',
-        path: 'content/product-engineering/engineering/releases/upgrade_managed_issue_template.md',
+        path: 'content/departments/product-engineering/engineering/process/releases/upgrade_managed_issue_template.md',
         titleSuffix: IssueTitleSuffix.MANAGED_TRACKING,
         labels: [IssueLabel.RELEASE_TRACKING, IssueLabel.MANAGED],
     }


### PR DESCRIPTION
The handbook is undergoing reorganization. The paths to templates used by the template were relocated.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
