### PR TITLE
cmd/gitserver: add p4-fusion installation to gitserver Docker image

### DIFF
--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -95,5 +95,5 @@ USER sourcegraph
 
 WORKDIR /
 
-#ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/gitserver"]
-#COPY gitserver /usr/local/bin/
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/gitserver"]
+COPY gitserver /usr/local/bin/

--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -82,7 +82,7 @@ RUN ./generate_cache.sh Release
 RUN ./build.sh
 
 WORKDIR /usr/local/bin
-# Move exe file to /usr/local/bin where other executives are located
+# Move exe file to /usr/local/bin where other executables are located
 RUN mv ./p4-fusion-1.2/build/p4-fusion/p4-fusion ./ && rm -rf /usr/local/bin/p4-fusion-1.2
 # p4-fusion installation completed here
 

--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -45,7 +45,8 @@ RUN apk add --no-cache \
     cmake \
     make \
     python2 \
-    python3
+    python3 \
+    bash
 
 COPY --from=p4cli /usr/local/bin/p4 /usr/local/bin/p4
 
@@ -58,9 +59,10 @@ RUN tar zxf /lib-x64.tgz --directory /
 
 # p4-fusion installation
 # Fetching p4 sources archive
-RUN wget https://github.com/salesforce/p4-fusion/archive/refs/tags/v1.2.zip && \
-    mv v1.2.zip /usr/local/bin && \
-    unzip /usr/local/bin/v1.2.zip -d /usr/local/bin
+RUN wget https://github.com/salesforce/p4-fusion/archive/refs/tags/v1.4.tar.gz && \
+    mv v1.4.tar.gz /usr/local/bin && \
+    mkdir -p /usr/local/bin/p4-fusion-src && \
+    tar -C /usr/local/bin/p4-fusion-src -xzvf /usr/local/bin/v1.4.tar.gz --strip 1
 
 # We need a specific version of OpenSSL
 RUN wget https://www.openssl.org/source/openssl-1.0.2t.tar.gz && tar -xzvf openssl-1.0.2t.tar.gz
@@ -71,19 +73,19 @@ RUN ./config && make && make install
 
 # We also need Helix Core C++ API to build p4-fusion
 RUN wget https://www.perforce.com/downloads/perforce/r21.1/bin.linux26x86_64/p4api.tgz && \
-    mkdir -p /usr/local/bin/p4-fusion-1.2/vendor/helix-core-api/linux && \
-    mv p4api.tgz /usr/local/bin/p4-fusion-1.2/vendor/helix-core-api/linux && \
-    tar -C /usr/local/bin/p4-fusion-1.2/vendor/helix-core-api/linux -xzvf /usr/local/bin/p4-fusion-1.2/vendor/helix-core-api/linux/p4api.tgz --strip 1
+    mkdir -p /usr/local/bin/p4-fusion-src/vendor/helix-core-api/linux && \
+    mv p4api.tgz /usr/local/bin/p4-fusion-src/vendor/helix-core-api/linux && \
+    tar -C /usr/local/bin/p4-fusion-src/vendor/helix-core-api/linux -xzvf /usr/local/bin/p4-fusion-src/vendor/helix-core-api/linux/p4api.tgz --strip 1
 
-WORKDIR /usr/local/bin/p4-fusion-1.2
+WORKDIR /usr/local/bin/p4-fusion-src
 
 # Build p4-fusion
-RUN ./generate_cache.sh Release
+RUN bash -c './generate_cache.sh Release'
 RUN ./build.sh
 
 WORKDIR /usr/local/bin
 # Move exe file to /usr/local/bin where other executables are located
-RUN mv ./p4-fusion-1.2/build/p4-fusion/p4-fusion ./ && rm -rf /usr/local/bin/p4-fusion-1.2
+RUN mv /usr/local/bin/p4-fusion-src/build/p4-fusion/p4-fusion /usr/local/bin && rm -rf /usr/local/bin/p4-fusion-src
 # p4-fusion installation completed here
 
 RUN mkdir -p /data/repos && chown -R sourcegraph:sourcegraph /data/repos

--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -59,10 +59,10 @@ RUN tar zxf /lib-x64.tgz --directory /
 
 # p4-fusion installation
 # Fetching p4 sources archive
-RUN wget https://github.com/salesforce/p4-fusion/archive/refs/tags/v1.4.tar.gz && \
-    mv v1.4.tar.gz /usr/local/bin && \
+RUN wget https://github.com/salesforce/p4-fusion/archive/refs/tags/v1.5.tar.gz && \
+    mv v1.5.tar.gz /usr/local/bin && \
     mkdir -p /usr/local/bin/p4-fusion-src && \
-    tar -C /usr/local/bin/p4-fusion-src -xzvf /usr/local/bin/v1.4.tar.gz --strip 1
+    tar -C /usr/local/bin/p4-fusion-src -xzvf /usr/local/bin/v1.5.tar.gz --strip 1
 
 # We need a specific version of OpenSSL
 RUN wget https://www.openssl.org/source/openssl-1.0.2t.tar.gz && tar -xzvf openssl-1.0.2t.tar.gz
@@ -80,12 +80,14 @@ RUN wget https://www.perforce.com/downloads/perforce/r21.1/bin.linux26x86_64/p4a
 WORKDIR /usr/local/bin/p4-fusion-src
 
 # Build p4-fusion
-RUN bash -c './generate_cache.sh Release'
+RUN ./generate_cache.sh Release
 RUN ./build.sh
 
 WORKDIR /usr/local/bin
-# Move exe file to /usr/local/bin where other executables are located
-RUN mv /usr/local/bin/p4-fusion-src/build/p4-fusion/p4-fusion /usr/local/bin && rm -rf /usr/local/bin/p4-fusion-src
+# Move exe file to /usr/local/bin where other executables are located; delete src directory and archive
+RUN mv /usr/local/bin/p4-fusion-src/build/p4-fusion/p4-fusion /usr/local/bin && \
+    rm -rf /usr/local/bin/p4-fusion-src && \
+    rm /usr/local/bin/v1.5.tar.gz
 # p4-fusion installation completed here
 
 RUN mkdir -p /data/repos && chown -R sourcegraph:sourcegraph /data/repos
@@ -93,5 +95,5 @@ USER sourcegraph
 
 WORKDIR /
 
-ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/gitserver"]
-COPY gitserver /usr/local/bin/
+#ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/gitserver"]
+#COPY gitserver /usr/local/bin/

--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -38,10 +38,11 @@ RUN apk add --no-cache \
     git-p4 \
     && apk add --no-cache  \
     openssh-client \
-    # We require g++, gcc, perl and make to install openssl
+    # We require g++, gcc, perl and make to install openssl and p4-fusion
     g++ \
     gcc \
 	perl \
+    cmake \
     make \
     python2 \
     python3
@@ -54,6 +55,36 @@ COPY --from=coursier /usr/local/bin/coursier /usr/local/bin/coursier
 # please refer to https://blog.tilander.org/docker-perforce/
 ADD https://github.com/jtilander/p4d/raw/4600d741720f85d77852dcca7c182e96ad613358/lib/lib-x64.tgz /
 RUN tar zxf /lib-x64.tgz --directory /
+
+# p4-fusion installation
+# Fetching p4 sources archive
+RUN wget https://github.com/salesforce/p4-fusion/archive/refs/tags/v1.2.zip && \
+    mv v1.2.zip /usr/local/bin && \
+    unzip /usr/local/bin/v1.2.zip -d /usr/local/bin
+
+# We need a specific version of OpenSSL
+RUN wget https://www.openssl.org/source/openssl-1.0.2t.tar.gz && tar -xzvf openssl-1.0.2t.tar.gz
+
+WORKDIR /openssl-1.0.2t
+
+RUN ./config && make && make install
+
+# We also need Helix Core C++ API to build p4-fusion
+RUN wget https://www.perforce.com/downloads/perforce/r21.1/bin.linux26x86_64/p4api.tgz && \
+    mkdir -p /usr/local/bin/p4-fusion-1.2/vendor/helix-core-api/linux && \
+    mv p4api.tgz /usr/local/bin/p4-fusion-1.2/vendor/helix-core-api/linux && \
+    tar -C /usr/local/bin/p4-fusion-1.2/vendor/helix-core-api/linux -xzvf /usr/local/bin/p4-fusion-1.2/vendor/helix-core-api/linux/p4api.tgz --strip 1
+
+WORKDIR /usr/local/bin/p4-fusion-1.2
+
+# Build p4-fusion
+RUN ./generate_cache.sh Release
+RUN ./build.sh
+
+WORKDIR /usr/local/bin
+# Move exe file to /usr/local/bin where other executives are located
+RUN mv ./p4-fusion-1.2/build/p4-fusion/p4-fusion ./ && rm -rf /usr/local/bin/p4-fusion-1.2
+# p4-fusion installation completed here
 
 RUN mkdir -p /data/repos && chown -R sourcegraph:sourcegraph /data/repos
 USER sourcegraph


### PR DESCRIPTION
I ended up installing p4-fusion directly in resulting image, because using latest alpine and git and building `p4-fusion` as a stage and copying the files to resulting container seem to lose some files which are needed for successful `p4-fusion` launch.

Container size increased from 570 MB to 688 MB

Closes https://github.com/sourcegraph/sourcegraph/issues/26926

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
