### PR TITLE
monitoring: add panels for shard merging

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -12512,7 +12512,7 @@ This number should be consistent if the number of indexed repositories doesn`t c
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100200` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100300` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12535,14 +12535,14 @@ This number should be consistent if the number of indexed repositories doesn`t c
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100201` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100301` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(index_number_compound_shards) by (instance)`
+Query: `sum(index_number_compound_shards{instance=~`${instance:regex}`}) by (instance)`
 
 </details>
 
@@ -12559,7 +12559,7 @@ Since the target compound shard size is set on start of zoekt-indexserver, the a
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100210` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100310` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12582,7 +12582,7 @@ This curve should be flat. Any deviation should be investigated.
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100211` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100311` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12603,14 +12603,14 @@ Number of errors during shard merging aggregated over all instances.
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100220` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100320` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(index_shard_merging_duration_seconds_count{error="true"}) per (app)`
+Query: `sum(index_shard_merging_duration_seconds_count{error="true"}) by (app)`
 
 </details>
 
@@ -12624,14 +12624,14 @@ Number of errors during shard merging per instance.
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100221` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100321` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(index_shard_merging_duration_seconds_count{error="true"}) per (instance)`
+Query: `sum(index_shard_merging_duration_seconds_count{instance=~`${instance:regex}`, error=-"true"}) by (instance)`
 
 </details>
 
@@ -12645,7 +12645,7 @@ Set to 1 if shard merging is running.
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100230` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100330` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12666,7 +12666,7 @@ Set to 1 if vacuum is running.
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100231` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100331` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12697,7 +12697,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100300` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100400` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12716,7 +12716,7 @@ Query: `count by(name) ((time() - container_last_seen{name=~"^zoekt-indexserver.
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-container-cpu-usage) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100301` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100401` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12735,7 +12735,7 @@ Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^zoekt-indexserver.
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-container-memory-usage) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100302` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100402` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12757,7 +12757,7 @@ When extremely high, this can indicate a resource usage problem, or can cause pr
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100303` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100403` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Core application team](https://handbook.sourcegraph.com/engineering/core-application).*</sub>
 
@@ -12778,7 +12778,7 @@ Query: `sum by(name) (rate(container_fs_reads_total{name=~"^zoekt-indexserver.*"
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-cpu-usage-long-term) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100400` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100500` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12797,7 +12797,7 @@ Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{na
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-memory-usage-long-term) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100401` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100501` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12816,7 +12816,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^z
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-cpu-usage-short-term) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100410` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100510` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12835,7 +12835,7 @@ Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^zoek
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-memory-usage-short-term) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100411` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100511` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12856,7 +12856,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^z
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-pods-available-percentage) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100500` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100600` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -12500,6 +12500,185 @@ Query: `index_queue_len{instance=~`${instance:regex}`}`
 
 <br />
 
+### Zoekt Index Server: Compound shards
+
+#### zoekt-indexserver: compound_shards_aggregate
+
+<p class="subtitle"># of compound shards (aggregate)</p>
+
+The total number of compound shards aggregated over all instances.
+
+This number should be consistent if the number of indexed repositories doesn`t change.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100200` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(index_number_compound_shards) by (app)`
+
+</details>
+
+<br />
+
+#### zoekt-indexserver: compound_shards_per_instance
+
+<p class="subtitle"># of compound shards (per instance)</p>
+
+The total number of compound shards per instance.
+
+This number should be consistent if the number of indexed repositories doesn`t change.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100201` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(index_number_compound_shards) by (instance)`
+
+</details>
+
+<br />
+
+#### zoekt-indexserver: average_shard_merging_duration_success
+
+<p class="subtitle">Average successful shard merging duration over 1 hour</p>
+
+Average duration of a successful merge over the last hour.
+
+The duration depends on the target compound shard size. The larger the compound shard the longer a merge will take.
+Since the target compound shard size is set on start of zoekt-indexserver, the average duration should be consistent.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100210` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(rate(index_shard_merging_duration_seconds_sum{error="false"}[1h])) / sum(rate(index_shard_merging_duration_seconds_count{error="false"}[1h]))`
+
+</details>
+
+<br />
+
+#### zoekt-indexserver: average_shard_merging_duration_error
+
+<p class="subtitle">Average failed shard merging duration over 1 hour</p>
+
+Average duration of a failed merge over the last hour.
+
+This curve should be flat. Any deviation should be investigated.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100211` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(rate(index_shard_merging_duration_seconds_sum{error="true"}[1h])) / sum(rate(index_shard_merging_duration_seconds_count{error="true"}[1h]))`
+
+</details>
+
+<br />
+
+#### zoekt-indexserver: shard_merging_errors_aggregate
+
+<p class="subtitle">Number of errors during shard merging (aggregate)</p>
+
+Number of errors during shard merging aggregated over all instances.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100220` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(index_shard_merging_duration_seconds_count{error="true"}) per (app)`
+
+</details>
+
+<br />
+
+#### zoekt-indexserver: shard_merging_duration_per_instance
+
+<p class="subtitle">Number of errors during shard merging (per instance)</p>
+
+Number of errors during shard merging per instance.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100221` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(index_shard_merging_duration_seconds_count{error="true"}) per (instance)`
+
+</details>
+
+<br />
+
+#### zoekt-indexserver: shard_merging_merge_running_per_instance
+
+<p class="subtitle">If shard merging is running (per instance)</p>
+
+Set to 1 if shard merging is running.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100230` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `max by (instance) (index_shard_merging_running)`
+
+</details>
+
+<br />
+
+#### zoekt-indexserver: shard_merging_vacuum_running_per_instance
+
+<p class="subtitle">If vacuum is running (per instance)</p>
+
+Set to 1 if vacuum is running.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver?viewPanel=100231` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `max by (instance) (index_vacuum_running)`
+
+</details>
+
+<br />
+
 ### Zoekt Index Server: Container monitoring (not available on server)
 
 #### zoekt-indexserver: container_missing

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -12500,7 +12500,7 @@ Query: `index_queue_len{instance=~`${instance:regex}`}`
 
 <br />
 
-### Zoekt Index Server: Compound shards
+### Zoekt Index Server: Compound shards (experimental)
 
 #### zoekt-indexserver: compound_shards_aggregate
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -12631,7 +12631,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(index_shard_merging_duration_seconds_count{instance=~`${instance:regex}`, error=-"true"}) by (instance)`
+Query: `sum(index_shard_merging_duration_seconds_count{instance=~`${instance:regex}`, error="true"}) by (instance)`
 
 </details>
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -12616,7 +12616,7 @@ Query: `sum(index_shard_merging_duration_seconds_count{error="true"}) by (app)`
 
 <br />
 
-#### zoekt-indexserver: shard_merging_duration_per_instance
+#### zoekt-indexserver: shard_merging_errors_per_instance
 
 <p class="subtitle">Number of errors during shard merging (per instance)</p>
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -12652,7 +12652,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (instance) (index_shard_merging_running)`
+Query: `max by (instance) (index_shard_merging_running{instance=~`${instance:regex}`})`
 
 </details>
 
@@ -12673,7 +12673,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt-indexserver/zoekt-indexserver
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (instance) (index_vacuum_running)`
+Query: `max by (instance) (index_vacuum_running{instance=~`${instance:regex}`})`
 
 </details>
 

--- a/monitoring/definitions/zoekt_index_server.go
+++ b/monitoring/definitions/zoekt_index_server.go
@@ -316,7 +316,7 @@ func ZoektIndexServer() *monitoring.Container {
 						{
 							Name:        "shard_merging_errors_aggregate",
 							Description: "number of errors during shard merging (aggregate)",
-							Query:       `sum(index_shard_merging_duration_seconds_count{error="true"}) by (app)`,
+							Query:       "sum(index_shard_merging_duration_seconds_count{error=\"true\"}) by (app)",
 							NoAlert:     true,
 							Panel:       monitoring.Panel().LegendFormat("aggregate").Unit(monitoring.Number),
 							Owner:       monitoring.ObservableOwnerSearchCore,
@@ -327,7 +327,7 @@ func ZoektIndexServer() *monitoring.Container {
 						{
 							Name:        "shard_merging_errors_per_instance",
 							Description: "number of errors during shard merging (per instance)",
-							Query:       "sum(index_shard_merging_duration_seconds_count{instance=~`${instance:regex}`, error=-\"true\"}) by (instance)",
+							Query:       "sum(index_shard_merging_duration_seconds_count{instance=~`${instance:regex}`, error=\"true\"}) by (instance)",
 							NoAlert:     true,
 							Panel:       monitoring.Panel().LegendFormat("{{instance}}").Unit(monitoring.Number),
 							Owner:       monitoring.ObservableOwnerSearchCore,

--- a/monitoring/definitions/zoekt_index_server.go
+++ b/monitoring/definitions/zoekt_index_server.go
@@ -272,7 +272,7 @@ func ZoektIndexServer() *monitoring.Container {
 						{
 							Name:        "compound_shards_per_instance",
 							Description: "# of compound shards (per instance)",
-							Query:       "sum(index_number_compound_shards) by (instance)",
+							Query:       "sum(index_number_compound_shards{instance=~`${instance:regex}`}) by (instance)",
 							NoAlert:     true,
 							Panel:       monitoring.Panel().LegendFormat("{{instance}}}").Unit(monitoring.Number),
 							Owner:       monitoring.ObservableOwnerSearchCore,
@@ -287,7 +287,7 @@ func ZoektIndexServer() *monitoring.Container {
 						{
 							Name:        "average_shard_merging_duration_success",
 							Description: "average successful shard merging duration over 1 hour",
-							Query:       `sum(rate(index_shard_merging_duration_seconds_sum{error="false"}[1h])) / sum(rate(index_shard_merging_duration_seconds_count{error="false"}[1h]))`,
+							Query:       "sum(rate(index_shard_merging_duration_seconds_sum{error=\"false\"}[1h])) / sum(rate(index_shard_merging_duration_seconds_count{error=\"false\"}[1h]))",
 							NoAlert:     true,
 							Panel:       monitoring.Panel().LegendFormat("average").Unit(monitoring.Seconds),
 							Owner:       monitoring.ObservableOwnerSearchCore,
@@ -301,7 +301,7 @@ func ZoektIndexServer() *monitoring.Container {
 						{
 							Name:        "average_shard_merging_duration_error",
 							Description: "average failed shard merging duration over 1 hour",
-							Query:       `sum(rate(index_shard_merging_duration_seconds_sum{error="true"}[1h])) / sum(rate(index_shard_merging_duration_seconds_count{error="true"}[1h]))`,
+							Query:       "sum(rate(index_shard_merging_duration_seconds_sum{error=\"true\"}[1h])) / sum(rate(index_shard_merging_duration_seconds_count{error=\"true\"}[1h]))",
 							NoAlert:     true,
 							Panel:       monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds),
 							Owner:       monitoring.ObservableOwnerSearchCore,
@@ -316,7 +316,7 @@ func ZoektIndexServer() *monitoring.Container {
 						{
 							Name:        "shard_merging_errors_aggregate",
 							Description: "number of errors during shard merging (aggregate)",
-							Query:       `sum(index_shard_merging_duration_seconds_count{error="true"}) per (app)`,
+							Query:       `sum(index_shard_merging_duration_seconds_count{error="true"}) by (app)`,
 							NoAlert:     true,
 							Panel:       monitoring.Panel().LegendFormat("aggregate").Unit(monitoring.Number),
 							Owner:       monitoring.ObservableOwnerSearchCore,
@@ -327,7 +327,7 @@ func ZoektIndexServer() *monitoring.Container {
 						{
 							Name:        "shard_merging_duration_per_instance",
 							Description: "number of errors during shard merging (per instance)",
-							Query:       `sum(index_shard_merging_duration_seconds_count{error="true"}) per (instance)`,
+							Query:       "sum(index_shard_merging_duration_seconds_count{instance=~`${instance:regex}`, error=-\"true\"}) by (instance)",
 							NoAlert:     true,
 							Panel:       monitoring.Panel().LegendFormat("{{instance}}").Unit(monitoring.Number),
 							Owner:       monitoring.ObservableOwnerSearchCore,

--- a/monitoring/definitions/zoekt_index_server.go
+++ b/monitoring/definitions/zoekt_index_server.go
@@ -285,7 +285,7 @@ func ZoektIndexServer() *monitoring.Container {
 					{
 						{
 							Name:        "average_shard_merging_duration_success",
-							Description: "Average successful shard merging duration over 1 hour",
+							Description: "average successful shard merging duration over 1 hour",
 							Query:       `sum(rate(index_shard_merging_duration_seconds_sum{error="false"}[1h])) / sum(rate(index_shard_merging_duration_seconds_count{error="false"}[1h]))`,
 							NoAlert:     true,
 							Panel:       monitoring.Panel().LegendFormat("average").Unit(monitoring.Seconds),
@@ -299,7 +299,7 @@ func ZoektIndexServer() *monitoring.Container {
 						},
 						{
 							Name:        "average_shard_merging_duration_error",
-							Description: "Average failed shard merging duration over 1 hour",
+							Description: "average failed shard merging duration over 1 hour",
 							Query:       `sum(rate(index_shard_merging_duration_seconds_sum{error="true"}[1h])) / sum(rate(index_shard_merging_duration_seconds_count{error="true"}[1h]))`,
 							NoAlert:     true,
 							Panel:       monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds),
@@ -314,7 +314,7 @@ func ZoektIndexServer() *monitoring.Container {
 					{
 						{
 							Name:        "shard_merging_errors_aggregate",
-							Description: "Number of errors during shard merging (aggregate)",
+							Description: "number of errors during shard merging (aggregate)",
 							Query:       `sum(index_shard_merging_duration_seconds_count{error="true"}) per (app)`,
 							NoAlert:     true,
 							Panel:       monitoring.Panel().LegendFormat("aggregate").Unit(monitoring.Number),
@@ -325,7 +325,7 @@ func ZoektIndexServer() *monitoring.Container {
 						},
 						{
 							Name:        "shard_merging_duration_per_instance",
-							Description: "Number of errors during shard merging (per instance)",
+							Description: "number of errors during shard merging (per instance)",
 							Query:       `sum(index_shard_merging_duration_seconds_count{error="true"}) per (instance)`,
 							NoAlert:     true,
 							Panel:       monitoring.Panel().LegendFormat("{{instance}}").Unit(monitoring.Number),
@@ -338,7 +338,7 @@ func ZoektIndexServer() *monitoring.Container {
 					{
 						{
 							Name:        "shard_merging_merge_running_per_instance",
-							Description: "If shard merging is running (per instance)",
+							Description: "if shard merging is running (per instance)",
 							Query:       "max by (instance) (index_shard_merging_running)",
 							NoAlert:     true,
 							Panel:       monitoring.Panel().LegendFormat("{{instance}}").Unit(monitoring.Number),
@@ -349,7 +349,7 @@ func ZoektIndexServer() *monitoring.Container {
 						},
 						{
 							Name:        "shard_merging_vacuum_running_per_instance",
-							Description: "If vacuum is running (per instance)",
+							Description: "if vacuum is running (per instance)",
 							Query:       "max by (instance) (index_vacuum_running)",
 							NoAlert:     true,
 							Panel:       monitoring.Panel().LegendFormat("{{instance}}").Unit(monitoring.Number),

--- a/monitoring/definitions/zoekt_index_server.go
+++ b/monitoring/definitions/zoekt_index_server.go
@@ -252,7 +252,8 @@ func ZoektIndexServer() *monitoring.Container {
 				},
 			},
 			{
-				Title: "Compound shards",
+				Title:  "Compound shards (experimental)",
+				Hidden: true,
 				Rows: []monitoring.Row{
 					{
 						{

--- a/monitoring/definitions/zoekt_index_server.go
+++ b/monitoring/definitions/zoekt_index_server.go
@@ -251,6 +251,75 @@ func ZoektIndexServer() *monitoring.Container {
 					},
 				},
 			},
+			{
+				Title: "Compound shards",
+				Rows: []monitoring.Row{
+					{
+						{
+							Name:        "compound_shards_aggregate",
+							Description: "# of compound shards (aggregate)",
+							Query:       "sum(index_number_compound_shards) by (app)",
+							Panel:       monitoring.Panel().LegendFormat("aggregate").Unit(monitoring.Number),
+							Owner:       monitoring.ObservableOwnerSearchCore,
+						},
+						{
+							Name:        "compound_shards_per_instance",
+							Description: "# of compound shards (per instance)",
+							Query:       "sum(index_number_compound_shards) by (instance)",
+							Panel:       monitoring.Panel().LegendFormat("{{instance}}}").Unit(monitoring.Number),
+							Owner:       monitoring.ObservableOwnerSearchCore,
+						},
+					},
+					{
+						{
+							Name:        "average_shard_merging_duration_success",
+							Description: "Average successful shard merging duration",
+							Query:       `sum(rate(index_shard_merging_duration_seconds_sum{error="false"}[1h])) / sum(rate(index_shard_merging_duration_seconds_count{error="false"}[1h]))`,
+							Panel:       monitoring.Panel().LegendFormat("average").Unit(monitoring.Seconds),
+							Owner:       monitoring.ObservableOwnerSearchCore,
+						},
+						{
+							Name:        "average_shard_merging_duration_error",
+							Description: "Average failed shard merging duration",
+							Query:       `sum(rate(index_shard_merging_duration_seconds_sum{error="true"}[1h])) / sum(rate(index_shard_merging_duration_seconds_count{error="true"}[1h]))`,
+							Panel:       monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds),
+							Owner:       monitoring.ObservableOwnerSearchCore,
+						},
+					},
+					{
+						{
+							Name:        "shard_merging_errors_aggregate",
+							Description: "Average successful shard merging duration (aggregate)",
+							Query:       `sum(index_shard_merging_duration_seconds_count{error="true"}) per (app)`,
+							Panel:       monitoring.Panel().LegendFormat("aggregate").Unit(monitoring.Number),
+							Owner:       monitoring.ObservableOwnerSearchCore,
+						},
+						{
+							Name:        "shard_merging_duration_per_instance",
+							Description: "Average failed shard merging duration (per instance)",
+							Query:       `sum(index_shard_merging_duration_seconds_count{error="true"}) per (instance)`,
+							Panel:       monitoring.Panel().LegendFormat("{{instance}}").Unit(monitoring.Number),
+							Owner:       monitoring.ObservableOwnerSearchCore,
+						},
+					},
+					{
+						{
+							Name:        "shard_merging_merge_running_per_instance",
+							Description: "If shard merging is running (per instance)",
+							Query:       "max by (instance) (index_shard_merging_running)",
+							Panel:       monitoring.Panel().LegendFormat("{{instance}}").Unit(monitoring.Number),
+							Owner:       monitoring.ObservableOwnerSearchCore,
+						},
+						{
+							Name:        "shard_merging_vacuum_running_per_instance",
+							Description: "If vacuum is running (per instance)",
+							Query:       "max by (instance) (index_vacuum_running)",
+							Panel:       monitoring.Panel().LegendFormat("{{instance}}").Unit(monitoring.Number),
+							Owner:       monitoring.ObservableOwnerSearchCore,
+						},
+					},
+				},
+			},
 
 			// Note:
 			// zoekt_indexserver and zoekt_webserver are deployed together as part of the indexed-search service

--- a/monitoring/definitions/zoekt_index_server.go
+++ b/monitoring/definitions/zoekt_index_server.go
@@ -340,7 +340,7 @@ func ZoektIndexServer() *monitoring.Container {
 						{
 							Name:        "shard_merging_merge_running_per_instance",
 							Description: "if shard merging is running (per instance)",
-							Query:       "max by (instance) (index_shard_merging_running)",
+							Query:       "max by (instance) (index_shard_merging_running{instance=~`${instance:regex}`})",
 							NoAlert:     true,
 							Panel:       monitoring.Panel().LegendFormat("{{instance}}").Unit(monitoring.Number),
 							Owner:       monitoring.ObservableOwnerSearchCore,
@@ -351,7 +351,7 @@ func ZoektIndexServer() *monitoring.Container {
 						{
 							Name:        "shard_merging_vacuum_running_per_instance",
 							Description: "if vacuum is running (per instance)",
-							Query:       "max by (instance) (index_vacuum_running)",
+							Query:       "max by (instance) (index_vacuum_running{instance=~`${instance:regex}`})",
 							NoAlert:     true,
 							Panel:       monitoring.Panel().LegendFormat("{{instance}}").Unit(monitoring.Number),
 							Owner:       monitoring.ObservableOwnerSearchCore,

--- a/monitoring/definitions/zoekt_index_server.go
+++ b/monitoring/definitions/zoekt_index_server.go
@@ -259,47 +259,80 @@ func ZoektIndexServer() *monitoring.Container {
 							Name:        "compound_shards_aggregate",
 							Description: "# of compound shards (aggregate)",
 							Query:       "sum(index_number_compound_shards) by (app)",
+							NoAlert:     true,
 							Panel:       monitoring.Panel().LegendFormat("aggregate").Unit(monitoring.Number),
 							Owner:       monitoring.ObservableOwnerSearchCore,
+							Interpretation: `
+								The total number of compound shards aggregated over all instances.
+
+								This number should be consistent if the number of indexed repositories doesn't change.
+							`,
 						},
 						{
 							Name:        "compound_shards_per_instance",
 							Description: "# of compound shards (per instance)",
 							Query:       "sum(index_number_compound_shards) by (instance)",
+							NoAlert:     true,
 							Panel:       monitoring.Panel().LegendFormat("{{instance}}}").Unit(monitoring.Number),
 							Owner:       monitoring.ObservableOwnerSearchCore,
+							Interpretation: `
+								The total number of compound shards per instance.
+
+								This number should be consistent if the number of indexed repositories doesn't change.
+							`,
 						},
 					},
 					{
 						{
 							Name:        "average_shard_merging_duration_success",
-							Description: "Average successful shard merging duration",
+							Description: "Average successful shard merging duration over 1 hour",
 							Query:       `sum(rate(index_shard_merging_duration_seconds_sum{error="false"}[1h])) / sum(rate(index_shard_merging_duration_seconds_count{error="false"}[1h]))`,
+							NoAlert:     true,
 							Panel:       monitoring.Panel().LegendFormat("average").Unit(monitoring.Seconds),
 							Owner:       monitoring.ObservableOwnerSearchCore,
+							Interpretation: `
+								Average duration of a successful merge over the last hour.
+
+								The duration depends on the target compound shard size. The larger the compound shard the longer a merge will take.
+								Since the target compound shard size is set on start of zoekt-indexserver, the average duration should be consistent.
+							`,
 						},
 						{
 							Name:        "average_shard_merging_duration_error",
-							Description: "Average failed shard merging duration",
+							Description: "Average failed shard merging duration over 1 hour",
 							Query:       `sum(rate(index_shard_merging_duration_seconds_sum{error="true"}[1h])) / sum(rate(index_shard_merging_duration_seconds_count{error="true"}[1h]))`,
+							NoAlert:     true,
 							Panel:       monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds),
 							Owner:       monitoring.ObservableOwnerSearchCore,
+							Interpretation: `
+								Average duration of a failed merge over the last hour.
+
+								This curve should be flat. Any deviation should be investigated.
+							`,
 						},
 					},
 					{
 						{
 							Name:        "shard_merging_errors_aggregate",
-							Description: "Average successful shard merging duration (aggregate)",
+							Description: "Number of errors during shard merging (aggregate)",
 							Query:       `sum(index_shard_merging_duration_seconds_count{error="true"}) per (app)`,
+							NoAlert:     true,
 							Panel:       monitoring.Panel().LegendFormat("aggregate").Unit(monitoring.Number),
 							Owner:       monitoring.ObservableOwnerSearchCore,
+							Interpretation: `
+								Number of errors during shard merging aggregated over all instances.
+							`,
 						},
 						{
 							Name:        "shard_merging_duration_per_instance",
-							Description: "Average failed shard merging duration (per instance)",
+							Description: "Number of errors during shard merging (per instance)",
 							Query:       `sum(index_shard_merging_duration_seconds_count{error="true"}) per (instance)`,
+							NoAlert:     true,
 							Panel:       monitoring.Panel().LegendFormat("{{instance}}").Unit(monitoring.Number),
 							Owner:       monitoring.ObservableOwnerSearchCore,
+							Interpretation: `
+								Number of errors during shard merging per instance.
+							`,
 						},
 					},
 					{
@@ -307,15 +340,23 @@ func ZoektIndexServer() *monitoring.Container {
 							Name:        "shard_merging_merge_running_per_instance",
 							Description: "If shard merging is running (per instance)",
 							Query:       "max by (instance) (index_shard_merging_running)",
+							NoAlert:     true,
 							Panel:       monitoring.Panel().LegendFormat("{{instance}}").Unit(monitoring.Number),
 							Owner:       monitoring.ObservableOwnerSearchCore,
+							Interpretation: `
+								Set to 1 if shard merging is running.
+							`,
 						},
 						{
 							Name:        "shard_merging_vacuum_running_per_instance",
 							Description: "If vacuum is running (per instance)",
 							Query:       "max by (instance) (index_vacuum_running)",
+							NoAlert:     true,
 							Panel:       monitoring.Panel().LegendFormat("{{instance}}").Unit(monitoring.Number),
 							Owner:       monitoring.ObservableOwnerSearchCore,
+							Interpretation: `
+								Set to 1 if vacuum is running.
+							`,
 						},
 					},
 				},

--- a/monitoring/definitions/zoekt_index_server.go
+++ b/monitoring/definitions/zoekt_index_server.go
@@ -325,7 +325,7 @@ func ZoektIndexServer() *monitoring.Container {
 							`,
 						},
 						{
-							Name:        "shard_merging_duration_per_instance",
+							Name:        "shard_merging_errors_per_instance",
 							Description: "number of errors during shard merging (per instance)",
 							Query:       "sum(index_shard_merging_duration_seconds_count{instance=~`${instance:regex}`, error=-\"true\"}) by (instance)",
 							NoAlert:     true,


### PR DESCRIPTION
This is adds several panels to the dashboard of indexserver to monitor shard merging.
The row is hidden by default and marked as experimental until we roll out shard merging officially.

Some of the panels show no data because we don't have any merge errors in the observed time frame.

![image](https://user-images.githubusercontent.com/26413131/148185268-f8e1e344-0899-4459-9f56-b1338f3a4fdf.png)
