### PR TITLE
Prevent Sentry from capturing errs without a cause

### DIFF
--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 
-	"github.com/cockroachdb/errors"
 	"github.com/felixge/httpsnoop"
 	"github.com/gorilla/mux"
 	"github.com/inconshreveable/log15"
@@ -252,7 +251,9 @@ func HTTPMiddleware(next http.Handler, siteConfig conftypes.SiteConfigQuerier) h
 		// Notify sentry if the status code indicates our system had an error (e.g. 5xx).
 		if m.Code >= 500 {
 			if requestErrorCause == nil {
-				requestErrorCause = errors.WithStack(&httpErr{status: m.Code, method: r.Method, path: r.URL.Path})
+				// This creates loads of events on which we do not have the stack trace and that are barely usable.
+				// requestErrorCause = errors.WithStack(&httpErr{status: m.Code, method: r.Method, path: r.URL.Path})
+				return
 			}
 
 			sentry.CaptureError(requestErrorCause, map[string]string{

--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -2,7 +2,6 @@ package trace
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"os"
 	"strconv"
@@ -273,6 +272,17 @@ func HTTPMiddleware(next http.Handler, siteConfig conftypes.SiteConfigQuerier) h
 	}))
 }
 
+// Associated with the above comment aobut the load of events.
+// type httpErr struct {
+// 	status int
+// 	method string
+// 	path   string
+// }
+//
+// func (e *httpErr) Error() string {
+// 	return fmt.Sprintf("HTTP status %d, %s %s", e.status, e.method, e.path)
+// }
+
 func Route(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		if p, ok := r.Context().Value(routeNameKey).(*string); ok {
@@ -305,14 +315,4 @@ func SetRouteName(r *http.Request, routeName string) {
 	if p, ok := r.Context().Value(routeNameKey).(*string); ok {
 		*p = routeName
 	}
-}
-
-type httpErr struct {
-	status int
-	method string
-	path   string
-}
-
-func (e *httpErr) Error() string {
-	return fmt.Sprintf("HTTP status %d, %s %s", e.status, e.method, e.path)
 }


### PR DESCRIPTION
This change removes [errors of this kind](https://sentry.io/organizations/sourcegraph/issues/2844927109/?project=5596888&query=is%3Aunresolved&sort=freq&statsPeriod=14d) as they are effectively without a stack trace. For now disabling Sentry would be okay but this enables to at least keep errors which are properly emitted. 