### PR TITLE
FIX: codemod browser-extension/after-install-page/AfterInstallPageContent browser-extension/options-menu/OptionsPage shared/code-hosts/*/style web/src/SourcegraphWebApp components to CSS modules

### DIFF
--- a/client/browser/src/browser-extension/pages/after_install.html
+++ b/client/browser/src/browser-extension/pages/after_install.html
@@ -4,6 +4,7 @@
         <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
         <title>Sourcegraph browser extension</title>
         <meta name="color-scheme" content="light dark" />
+        <link href="./css/branded-style.bundle.css" rel="stylesheet" type="text/css" />
         <link href="./css/after-install.bundle.css" rel="stylesheet" type="text/css" />
     </head>
     <body>


### PR DESCRIPTION
## Description:
Fix for issue reported on #28443 [here](https://github.com/sourcegraph/sourcegraph/pull/28443#issuecomment-999675680)

- [SG Issue](https://github.com/sourcegraph/sourcegraph/issues/28261)

## Success criteria:

The stylesheets in the following directories are converted to CSS modules.

- [x]  client/browser/src/browser-extension/after-install-page/AfterInstallPageContent.scss
- [x] client/browser/src/browser-extension/options-menu/OptionsPage.scss
- [x] client/browser/src/shared/code-hosts/*/style.scss
- [x] client/web/src/SourcegraphWebApp.scss — app__error and app__error-text classes.