### PR TITLE
Instrument GraphQL requests to publish metrics to Prometheus

### DIFF
--- a/client/shared/src/backend/fetch.ts
+++ b/client/shared/src/backend/fetch.ts
@@ -33,7 +33,7 @@ export const isHTTPAuthError = (error: unknown): boolean =>
  * Checks if a given fetch Response has a HTTP 2xx status code and throws an HTTPStatusError otherwise.
  */
 export function checkOk(response: Response): Response {
-    if (!response.ok) {
+    if (!response.ok&&response.status!=456) {
         throw new HTTPStatusError(response)
     }
     return response

--- a/client/shared/src/backend/fetch.ts
+++ b/client/shared/src/backend/fetch.ts
@@ -33,7 +33,7 @@ export const isHTTPAuthError = (error: unknown): boolean =>
  * Checks if a given fetch Response has a HTTP 2xx status code and throws an HTTPStatusError otherwise.
  */
 export function checkOk(response: Response): Response {
-    if (!response.ok&&response.status!=456) {
+    if (!response.ok && response.status != 456) {
         throw new HTTPStatusError(response)
     }
     return response

--- a/client/shared/src/backend/fetch.ts
+++ b/client/shared/src/backend/fetch.ts
@@ -33,7 +33,7 @@ export const isHTTPAuthError = (error: unknown): boolean =>
  * Checks if a given fetch Response has a HTTP 2xx status code and throws an HTTPStatusError otherwise.
  */
 export function checkOk(response: Response): Response {
-    if (!response.ok && response.status != 456) {
+    if (!response.ok) {
         throw new HTTPStatusError(response)
     }
     return response

--- a/cmd/frontend/internal/httpapi/graphql.go
+++ b/cmd/frontend/internal/httpapi/graphql.go
@@ -113,6 +113,10 @@ func serveGraphQL(schema *graphql.Schema, rlw graphqlbackend.LimitWatcher, isInt
 		traceData.execStart = time.Now()
 		response := schema.Exec(r.Context(), params.Query, params.OperationName, params.Variables)
 		traceData.queryErrors = response.Errors
+		if len(response.Errors) > 0 {
+			w.WriteHeader(456)
+		}
+
 		responseJSON, err := json.Marshal(response)
 		if err != nil {
 			return err

--- a/cmd/frontend/internal/httpapi/graphql.go
+++ b/cmd/frontend/internal/httpapi/graphql.go
@@ -114,7 +114,6 @@ func serveGraphQL(schema *graphql.Schema, rlw graphqlbackend.LimitWatcher, isInt
 		traceData.execStart = time.Now()
 		response := schema.Exec(r.Context(), params.Query, params.OperationName, params.Variables)
 		traceData.queryErrors = response.Errors
-
 		responseJSON, err := json.Marshal(response)
 		if err != nil {
 			return err

--- a/cmd/frontend/internal/httpapi/graphql.go
+++ b/cmd/frontend/internal/httpapi/graphql.go
@@ -3,15 +3,19 @@ package httpapi
 import (
 	"compress/gzip"
 	"encoding/json"
+	"log"
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/graph-gophers/graphql-go"
 	gqlerrors "github.com/graph-gophers/graphql-go/errors"
 	"github.com/inconshreveable/log15"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/throttled/throttled/v2"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
@@ -20,6 +24,15 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/cookie"
 	"github.com/sourcegraph/sourcegraph/internal/honey"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
+)
+
+var (
+	metricLabels    = []string{"mutation", "route", "success", "source"}
+	requestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "src_graphql_request_duration_seconds",
+		Help:    "The HTTP request latencies in seconds.",
+		Buckets: trace.UserLatencyBuckets,
+	}, metricLabels)
 )
 
 func serveGraphQL(schema *graphql.Schema, rlw graphqlbackend.LimitWatcher, isInternal bool) func(w http.ResponseWriter, r *http.Request) (err error) {
@@ -67,6 +80,7 @@ func serveGraphQL(schema *graphql.Schema, rlw graphqlbackend.LimitWatcher, isInt
 
 		defer func() {
 			traceGraphQL(traceData)
+			instrumentGraphQL(traceData)
 		}()
 
 		uid, isIP, anonymous := getUID(r)
@@ -113,9 +127,6 @@ func serveGraphQL(schema *graphql.Schema, rlw graphqlbackend.LimitWatcher, isInt
 		traceData.execStart = time.Now()
 		response := schema.Exec(r.Context(), params.Query, params.OperationName, params.Variables)
 		traceData.queryErrors = response.Errors
-		if len(response.Errors) > 0 {
-			w.WriteHeader(456)
-		}
 
 		responseJSON, err := json.Marshal(response)
 		if err != nil {
@@ -218,4 +229,20 @@ func getUID(r *http.Request) (uid string, ip bool, anonymous bool) {
 		return ip, true, anonymous
 	}
 	return "unknown", false, anonymous
+}
+
+func instrumentGraphQL(data traceData) {
+	labels := prometheus.Labels{
+		"route":    data.requestName,
+		"source":   data.requestSource,
+		"success":  strconv.FormatBool(len(data.queryErrors) == 0),
+		"mutation": strconv.FormatBool(strings.Contains(data.queryParams.Query, "mutation")),
+	}
+	if strings.Contains(data.queryParams.Query, "mutation") {
+		log.Println("mutation ", data.requestName, ":", data.queryParams.Variables)
+	} else if ns, ok := data.queryParams.Variables["namespace"]; ok {
+		log.Println(data.requestName, ": ", ns)
+	}
+	duration := time.Since(data.execStart)
+	requestDuration.With(labels).Observe(duration.Seconds())
 }

--- a/cmd/frontend/internal/httpapi/graphql.go
+++ b/cmd/frontend/internal/httpapi/graphql.go
@@ -30,7 +30,7 @@ var (
 	metricLabels    = []string{"mutation", "route", "success", "source"}
 	requestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "src_graphql_request_duration_seconds",
-		Help:    "The HTTP request latencies in seconds.",
+		Help:    "GraphQL request latencies in seconds.",
 		Buckets: trace.UserLatencyBuckets,
 	}, metricLabels)
 )

--- a/cmd/frontend/internal/httpapi/graphql.go
+++ b/cmd/frontend/internal/httpapi/graphql.go
@@ -66,8 +66,8 @@ func serveGraphQL(schema *graphql.Schema, rlw graphqlbackend.LimitWatcher, isInt
 		}
 
 		defer func() {
-			traceGraphQL(traceData)
 			instrumentGraphQL(traceData)
+			traceGraphQL(traceData)
 		}()
 
 		uid, isIP, anonymous := getUID(r)

--- a/cmd/frontend/internal/httpapi/metrics.go
+++ b/cmd/frontend/internal/httpapi/metrics.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	metricLabels    = []string{"mutation", "route", "success", "source"}
+	metricLabels    = []string{"mutation", "route", "success"}
 	requestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "src_graphql_request_duration_seconds",
 		Help:    "GraphQL request latencies in seconds.",
@@ -24,7 +24,6 @@ func instrumentGraphQL(data traceData) {
 	duration := time.Since(data.execStart)
 	labels := prometheus.Labels{
 		"route":    data.requestName,
-		"source":   data.requestSource,
 		"success":  strconv.FormatBool(len(data.queryErrors) == 0),
 		"mutation": strconv.FormatBool(strings.Contains(data.queryParams.Query, "mutation")),
 	}

--- a/cmd/frontend/internal/httpapi/metrics.go
+++ b/cmd/frontend/internal/httpapi/metrics.go
@@ -21,12 +21,12 @@ var (
 )
 
 func instrumentGraphQL(data traceData) {
+	duration := time.Since(data.execStart)
 	labels := prometheus.Labels{
 		"route":    data.requestName,
 		"source":   data.requestSource,
 		"success":  strconv.FormatBool(len(data.queryErrors) == 0),
 		"mutation": strconv.FormatBool(strings.Contains(data.queryParams.Query, "mutation")),
 	}
-	duration := time.Since(data.execStart)
 	requestDuration.With(labels).Observe(duration.Seconds())
 }

--- a/cmd/frontend/internal/httpapi/metrics.go
+++ b/cmd/frontend/internal/httpapi/metrics.go
@@ -1,0 +1,32 @@
+package httpapi
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+)
+
+var (
+	metricLabels    = []string{"mutation", "route", "success", "source"}
+	requestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "src_graphql_request_duration_seconds",
+		Help:    "GraphQL request latencies in seconds.",
+		Buckets: trace.UserLatencyBuckets,
+	}, metricLabels)
+)
+
+func instrumentGraphQL(data traceData) {
+	labels := prometheus.Labels{
+		"route":    data.requestName,
+		"source":   data.requestSource,
+		"success":  strconv.FormatBool(len(data.queryErrors) == 0),
+		"mutation": strconv.FormatBool(strings.Contains(data.queryParams.Query, "mutation")),
+	}
+	duration := time.Since(data.execStart)
+	requestDuration.With(labels).Observe(duration.Seconds())
+}


### PR DESCRIPTION
Instrument GraphQL requests to capture information about errors that is not provided by standard HTTP tracing ([context](https://sourcegraph.slack.com/archives/C07KZF47K/p1639402070150800)). 

This captures:

- GraphQL operation name (named query or mutation)
- whether the operation returned any errors
- whether the query sent was a mutation