### PR TITLE
enterprise: Special case handling of internal repo in FetchRepoPerms

### DIFF
--- a/enterprise/internal/authz/github/client.go
+++ b/enterprise/internal/authz/github/client.go
@@ -37,11 +37,12 @@ type client interface {
 	ListOrganizationMembers(ctx context.Context, owner string, page int, adminsOnly bool) (users []*github.Collaborator, hasNextPage bool, _ error)
 	ListTeamMembers(ctx context.Context, owner, team string, page int) (users []*github.Collaborator, hasNextPage bool, _ error)
 
+	GetAuthenticatedOAuthScopes(ctx context.Context) ([]string, error)
 	GetAuthenticatedUserOrgsDetailsAndMembership(ctx context.Context, page int) (orgs []github.OrgDetailsAndMembership, hasNextPage bool, rateLimitCost int, err error)
 	GetAuthenticatedUserTeams(ctx context.Context, page int) (teams []*github.Team, hasNextPage bool, rateLimitCost int, err error)
 	GetOrganization(ctx context.Context, login string) (org *github.OrgDetails, err error)
+	GetRepository(ctx context.Context, owner, name string) (*github.Repository, error)
 
-	GetAuthenticatedOAuthScopes(ctx context.Context) ([]string, error)
 	WithToken(token string) client
 }
 
@@ -72,6 +73,7 @@ type mockClient struct {
 	MockGetAuthenticatedUserTeams                    func(ctx context.Context, page int) (teams []*github.Team, hasNextPage bool, rateLimitCost int, err error)
 	MockGetOrganization                              func(ctx context.Context, login string) (org *github.OrgDetails, err error)
 	MockGetAuthenticatedOAuthScopes                  func(ctx context.Context) ([]string, error)
+	MockGetRepository                                func(ctx context.Context, owner, repo string) (*github.Repository, error)
 	MockWithToken                                    func(token string) client
 }
 
@@ -117,6 +119,10 @@ func (m *mockClient) GetOrganization(ctx context.Context, login string) (org *gi
 
 func (m *mockClient) GetAuthenticatedOAuthScopes(ctx context.Context) ([]string, error) {
 	return m.MockGetAuthenticatedOAuthScopes(ctx)
+}
+
+func (m *mockClient) GetRepository(ctx context.Context, owner, name string) (*github.Repository, error) {
+	return m.MockGetRepository(ctx, owner, name)
 }
 
 func (m *mockClient) WithToken(token string) client {

--- a/enterprise/internal/authz/github/client.go
+++ b/enterprise/internal/authz/github/client.go
@@ -9,20 +9,18 @@ import (
 
 // 🚨 SECURITY: Call sites should take care to provide this valid values and use the return
 // value appropriately to ensure org repo access are only provided to valid users.
-func canViewOrgRepos(odm *github.OrgDetailsAndMembership) bool {
-	if odm == nil {
+func canViewOrgRepos(org *github.OrgDetailsAndMembership) bool {
+	if org == nil {
 		return false
 	}
-
-	// If user is active org admin, they can see all org repos.
-	if odm.IsAdmin() {
+	// If user is active org admin, they can see all org repos
+	if org.OrgMembership != nil && org.OrgMembership.State == "active" && org.OrgMembership.Role == "admin" {
 		return true
 	}
-
 	// https://github.com/organizations/$ORG/settings/member_privileges -> "Base permissions"
-	return odm.OrgDetails != nil && (odm.DefaultRepositoryPermission == "read" ||
-		odm.DefaultRepositoryPermission == "write" ||
-		odm.DefaultRepositoryPermission == "admin")
+	return org.OrgDetails != nil && (org.DefaultRepositoryPermission == "read" ||
+		org.DefaultRepositoryPermission == "write" ||
+		org.DefaultRepositoryPermission == "admin")
 }
 
 // client defines the set of GitHub API client methods used by the authz provider.

--- a/enterprise/internal/authz/github/client.go
+++ b/enterprise/internal/authz/github/client.go
@@ -37,12 +37,12 @@ type client interface {
 	ListOrganizationMembers(ctx context.Context, owner string, page int, adminsOnly bool) (users []*github.Collaborator, hasNextPage bool, _ error)
 	ListTeamMembers(ctx context.Context, owner, team string, page int) (users []*github.Collaborator, hasNextPage bool, _ error)
 
-	GetAuthenticatedOAuthScopes(ctx context.Context) ([]string, error)
 	GetAuthenticatedUserOrgsDetailsAndMembership(ctx context.Context, page int) (orgs []github.OrgDetailsAndMembership, hasNextPage bool, rateLimitCost int, err error)
 	GetAuthenticatedUserTeams(ctx context.Context, page int) (teams []*github.Team, hasNextPage bool, rateLimitCost int, err error)
 	GetOrganization(ctx context.Context, login string) (org *github.OrgDetails, err error)
 	GetRepository(ctx context.Context, owner, name string) (*github.Repository, error)
 
+	GetAuthenticatedOAuthScopes(ctx context.Context) ([]string, error)
 	WithToken(token string) client
 }
 

--- a/enterprise/internal/authz/github/client.go
+++ b/enterprise/internal/authz/github/client.go
@@ -70,9 +70,10 @@ type mockClient struct {
 	MockGetAuthenticatedUserOrgsDetailsAndMembership func(ctx context.Context, page int) (orgs []github.OrgDetailsAndMembership, hasNextPage bool, rateLimitCost int, err error)
 	MockGetAuthenticatedUserTeams                    func(ctx context.Context, page int) (teams []*github.Team, hasNextPage bool, rateLimitCost int, err error)
 	MockGetOrganization                              func(ctx context.Context, login string) (org *github.OrgDetails, err error)
-	MockGetAuthenticatedOAuthScopes                  func(ctx context.Context) ([]string, error)
 	MockGetRepository                                func(ctx context.Context, owner, repo string) (*github.Repository, error)
-	MockWithToken                                    func(token string) client
+
+	MockGetAuthenticatedOAuthScopes func(ctx context.Context) ([]string, error)
+	MockWithToken                   func(token string) client
 }
 
 func (m *mockClient) ListAffiliatedRepositories(ctx context.Context, visibility github.Visibility, page int, affiliations ...github.RepositoryAffiliation) ([]*github.Repository, bool, int, error) {
@@ -115,12 +116,12 @@ func (m *mockClient) GetOrganization(ctx context.Context, login string) (org *gi
 	return m.MockGetOrganization(ctx, login)
 }
 
-func (m *mockClient) GetAuthenticatedOAuthScopes(ctx context.Context) ([]string, error) {
-	return m.MockGetAuthenticatedOAuthScopes(ctx)
-}
-
 func (m *mockClient) GetRepository(ctx context.Context, owner, name string) (*github.Repository, error) {
 	return m.MockGetRepository(ctx, owner, name)
+}
+
+func (m *mockClient) GetAuthenticatedOAuthScopes(ctx context.Context) ([]string, error) {
+	return m.MockGetAuthenticatedOAuthScopes(ctx)
 }
 
 func (m *mockClient) WithToken(token string) client {

--- a/enterprise/internal/authz/github/client.go
+++ b/enterprise/internal/authz/github/client.go
@@ -9,18 +9,20 @@ import (
 
 // 🚨 SECURITY: Call sites should take care to provide this valid values and use the return
 // value appropriately to ensure org repo access are only provided to valid users.
-func canViewOrgRepos(org *github.OrgDetailsAndMembership) bool {
-	if org == nil {
+func canViewOrgRepos(odm *github.OrgDetailsAndMembership) bool {
+	if odm == nil {
 		return false
 	}
-	// If user is active org admin, they can see all org repos
-	if org.OrgMembership != nil && org.OrgMembership.State == "active" && org.OrgMembership.Role == "admin" {
+
+	// If user is active org admin, they can see all org repos.
+	if odm.IsAdmin() {
 		return true
 	}
+
 	// https://github.com/organizations/$ORG/settings/member_privileges -> "Base permissions"
-	return org.OrgDetails != nil && (org.DefaultRepositoryPermission == "read" ||
-		org.DefaultRepositoryPermission == "write" ||
-		org.DefaultRepositoryPermission == "admin")
+	return odm.OrgDetails != nil && (odm.DefaultRepositoryPermission == "read" ||
+		odm.DefaultRepositoryPermission == "write" ||
+		odm.DefaultRepositoryPermission == "admin")
 }
 
 // client defines the set of GitHub API client methods used by the authz provider.

--- a/enterprise/internal/authz/github/github.go
+++ b/enterprise/internal/authz/github/github.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cockroachdb/errors"
 
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
@@ -537,6 +538,23 @@ func (p *Provider) getRepoAffiliatedGroups(ctx context.Context, owner, name stri
 			p.groupsCache.invalidateGroup(&group)
 		}
 		groups = append(groups, repoAffiliatedGroup{cachedGroup: group, adminsOnly: adminsOnly})
+	}
+
+	var r *github.Repository
+	// The visibility field on a repo is only returned if this feature flag is set. As a result
+	// there's no point in making an extra API call if this feature flag is not set explicitly.
+	if conf.ExperimentalFeatures().EnableGithubInternalRepoVisibility {
+		r, err = p.client.GetRepository(ctx, owner, name)
+		if err != nil {
+			// Maybe the repo doesn't belong to this org? Or Another error occurred in trying to get the
+			// repo. Either way,
+			return
+		}
+
+		if org != nil && r.Visibility == github.VisibilityInternal {
+			syncGroup(owner, "", false)
+			return
+		}
 	}
 
 	odm := github.OrgDetailsAndMembership{OrgDetails: org}

--- a/enterprise/internal/authz/github/github.go
+++ b/enterprise/internal/authz/github/github.go
@@ -540,10 +540,10 @@ func (p *Provider) getRepoAffiliatedGroups(ctx context.Context, owner, name stri
 		groups = append(groups, repoAffiliatedGroup{cachedGroup: group, adminsOnly: adminsOnly})
 	}
 
-	var r *github.Repository
 	// The visibility field on a repo is only returned if this feature flag is set. As a result
 	// there's no point in making an extra API call if this feature flag is not set explicitly.
 	if conf.ExperimentalFeatures().EnableGithubInternalRepoVisibility {
+		var r *github.Repository
 		r, err = p.client.GetRepository(ctx, owner, name)
 		if err != nil {
 			// Maybe the repo doesn't belong to this org? Or Another error occurred in trying to get the

--- a/enterprise/internal/authz/github/github.go
+++ b/enterprise/internal/authz/github/github.go
@@ -557,13 +557,12 @@ func (p *Provider) getRepoAffiliatedGroups(ctx context.Context, owner, name stri
 		}
 	}
 
-	odm := github.OrgDetailsAndMembership{OrgDetails: org}
-	allOrgMembersCanRead := canViewOrgRepos(&odm)
+	allOrgMembersCanRead := canViewOrgRepos(&github.OrgDetailsAndMembership{OrgDetails: org})
 	if allOrgMembersCanRead {
 		// 🚨 SECURITY: Iff all members of this org can view this repo, indicate that all members should
 		// be sync'd.
 		syncGroup(owner, "", false)
-	} else if odm.IsAdmin() {
+	} else {
 		// 🚨 SECURITY: Sync *only admins* of this org
 		syncGroup(owner, "", true)
 

--- a/enterprise/internal/authz/github/github.go
+++ b/enterprise/internal/authz/github/github.go
@@ -547,7 +547,7 @@ func (p *Provider) getRepoAffiliatedGroups(ctx context.Context, owner, name stri
 		r, err = p.client.GetRepository(ctx, owner, name)
 		if err != nil {
 			// Maybe the repo doesn't belong to this org? Or Another error occurred in trying to get the
-			// repo. Either way,
+			// repo. Either way, we are not going to syncGroup for this repo.
 			return
 		}
 

--- a/enterprise/internal/authz/github/github.go
+++ b/enterprise/internal/authz/github/github.go
@@ -539,12 +539,13 @@ func (p *Provider) getRepoAffiliatedGroups(ctx context.Context, owner, name stri
 		groups = append(groups, repoAffiliatedGroup{cachedGroup: group, adminsOnly: adminsOnly})
 	}
 
-	allOrgMembersCanRead := canViewOrgRepos(&github.OrgDetailsAndMembership{OrgDetails: org})
+	odm := github.OrgDetailsAndMembership{OrgDetails: org}
+	allOrgMembersCanRead := canViewOrgRepos(&odm)
 	if allOrgMembersCanRead {
 		// 🚨 SECURITY: Iff all members of this org can view this repo, indicate that all members should
 		// be sync'd.
 		syncGroup(owner, "", false)
-	} else {
+	} else if odm.IsAdmin() {
 		// 🚨 SECURITY: Sync *only admins* of this org
 		syncGroup(owner, "", true)
 

--- a/enterprise/internal/authz/github/github_test.go
+++ b/enterprise/internal/authz/github/github_test.go
@@ -770,7 +770,8 @@ func TestProvider_FetchRepoPerms(t *testing.T) {
 
 				// These account IDs will have access to the internal repo.
 				wantAccountIDs := []extsvc.AccountID{
-					// mockListCollaborators members only because the feature is disabled.
+					// expect mockListCollaborators members only - we do not want to include org members
+					// if internal repository support is not enabled.
 					"57463526",
 					"67471",
 					"187831",

--- a/enterprise/internal/authz/github/github_test.go
+++ b/enterprise/internal/authz/github/github_test.go
@@ -754,7 +754,7 @@ func TestProvider_FetchRepoPerms(t *testing.T) {
 				MockGetOrganization: func(ctx context.Context, login string) (org *github.OrgDetails, err error) {
 					if login == "org" {
 						return &github.OrgDetails{
-							DefaultRepositoryPermission: "read",
+							DefaultRepositoryPermission: "none",
 						}, nil
 					}
 

--- a/enterprise/internal/authz/github/github_test.go
+++ b/enterprise/internal/authz/github/github_test.go
@@ -761,7 +761,6 @@ func TestProvider_FetchRepoPerms(t *testing.T) {
 			p.groupsCache = memCache
 
 			t.Run("feature flag disabled", func(t *testing.T) {
-
 				accountIDs, err := p.FetchRepoPerms(
 					context.Background(), &mockOrgRepo, authz.FetchPermsOptions{},
 				)

--- a/enterprise/internal/authz/github/github_test.go
+++ b/enterprise/internal/authz/github/github_test.go
@@ -803,7 +803,8 @@ func TestProvider_FetchRepoPerms(t *testing.T) {
 					"57463526",
 					"67471",
 					"187831",
-					// dedpulicated MockListOrganizationMembers users as well since the feature is enabled
+					// expect dedpulicated MockListOrganizationMembers users as well since we want to grant access
+					// to org members as well if the target repo has visibility "internal"
 					"1234",
 					"5678",
 				}

--- a/enterprise/internal/authz/github/github_test.go
+++ b/enterprise/internal/authz/github/github_test.go
@@ -561,12 +561,6 @@ func TestProvider_FetchRepoPerms(t *testing.T) {
 			},
 		}
 
-		mockInternalOrgRepo = github.Repository{
-			ID:         "github_repo_id",
-			IsPrivate:  true,
-			Visibility: github.VisibilityInternal,
-		}
-
 		mockListCollaborators = func(ctx context.Context, owner, repo string, page int, affiliation github.CollaboratorAffiliation) ([]*github.Collaborator, bool, error) {
 			switch page {
 			case 1:
@@ -721,6 +715,12 @@ func TestProvider_FetchRepoPerms(t *testing.T) {
 		})
 
 		t.Run("internal repo in org", func(t *testing.T) {
+			mockInternalOrgRepo := github.Repository{
+				ID:         "github_repo_id",
+				IsPrivate:  true,
+				Visibility: github.VisibilityInternal,
+			}
+
 			p := NewProvider("", ProviderOptions{
 				GitHubURL: mustURL(t, "https://github.com"),
 			})

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -330,18 +330,6 @@ type OrgDetailsAndMembership struct {
 	*OrgMembership
 }
 
-// IsAdmin will return true if the membership details for the given OrgDetailsAndMembership has an
-// "active" state and the role is set to "admin". Otherwise it will return false.
-func (o *OrgDetailsAndMembership) IsAdmin() bool {
-	if o.OrgMembership != nil &&
-		o.OrgMembership.State == "active" &&
-		o.OrgMembership.Role == "admin" {
-		return true
-	}
-
-	return false
-}
-
 // GetAuthenticatedUserOrgsDetailsAndMembership returns the organizations associated with the currently
 // authenticated user as well as additional information about each org by making API
 // requests for each org (see `OrgDetails` and `OrgMembership` docs for more details).

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -330,6 +330,18 @@ type OrgDetailsAndMembership struct {
 	*OrgMembership
 }
 
+// IsAdmin will return true if the membership details for the given OrgDetailsAndMembership has an
+// "active" state and the role is set to "admin". Otherwise it will return false.
+func (o *OrgDetailsAndMembership) IsAdmin() bool {
+	if o.OrgMembership != nil &&
+		o.OrgMembership.State == "active" &&
+		o.OrgMembership.Role == "admin" {
+		return true
+	}
+
+	return false
+}
+
 // GetAuthenticatedUserOrgsDetailsAndMembership returns the organizations associated with the currently
 // authenticated user as well as additional information about each org by making API
 // requests for each org (see `OrgDetails` and `OrgMembership` docs for more details).


### PR DESCRIPTION
Should fix #25904. 

~~Stacked on top of #30097.~~

Post merge follow up: Verify if user centric sync can overwrite repo centric sync with respect to internal repos.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
