### PR TITLE
[SG-29326] fix: alignment Issues on Toggle component

### DIFF
--- a/client/branded/src/components/Toggle.module.scss
+++ b/client/branded/src/components/Toggle.module.scss
@@ -14,11 +14,14 @@
 
     background: none;
     border: none;
-    display: inline-block;
     outline: none !important;
     padding: 0;
     position: relative;
     width: var(--toggle-width);
+
+    height: 1rem;
+    display: inline-flex;
+    align-items: center;
 
     &:focus-visible {
         /* Move focus style to the rounded bar */
@@ -45,9 +48,12 @@
     }
 }
 
+.inline-center {
+    margin-top: 0.125rem;
+}
+
 .bar {
     border-radius: 1rem;
-    top: 2px;
     left: 0;
     height: 1rem;
     width: 100%;
@@ -72,7 +78,6 @@
 
     height: 0.75rem;
     width: 0.75rem;
-    margin-top: 0.25rem;
     left: 0.125rem;
 
     position: relative;

--- a/client/branded/src/components/Toggle.tsx
+++ b/client/branded/src/components/Toggle.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames'
 import * as React from 'react'
 
+import { TOGGLE_DISPLAY } from './constants'
 import styles from './Toggle.module.scss'
 
 interface Props {
@@ -9,6 +10,9 @@ interface Props {
 
     /** The DOM ID of the element. */
     id?: string
+
+    /** inline-center adds an extra margin-top to centralise text around toggle, defaults to inline-center */
+    display?: typeof TOGGLE_DISPLAY[number]
 
     /**
      * Called when the user changes the input's value.
@@ -40,6 +44,7 @@ export const Toggle: React.FunctionComponent<Props> = ({
     tabIndex,
     onToggle,
     onClick,
+    display = 'inline-center',
     'aria-label': ariaLabel,
     'aria-labelledby': ariaLabelledby,
     'aria-describedby': ariaDescribedby,
@@ -58,7 +63,7 @@ export const Toggle: React.FunctionComponent<Props> = ({
     return (
         <button
             type="button"
-            className={classNames(styles.toggle, className)}
+            className={classNames(styles.toggle, className, display === 'inline-center' && styles.inlineCenter)}
             id={id}
             title={title}
             value={value ? 1 : 0}

--- a/client/branded/src/components/__snapshots__/Toggle.test.tsx.snap
+++ b/client/branded/src/components/__snapshots__/Toggle.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Toggle aria 1`] = `
     aria-describedby="test-id-1"
     aria-label="test toggle"
     aria-labelledby="test-id-2"
-    class="toggle"
+    class="toggle inlineCenter"
     role="switch"
     type="button"
     value="0"
@@ -24,7 +24,7 @@ exports[`Toggle aria 1`] = `
 exports[`Toggle className 1`] = `
 <DocumentFragment>
   <button
-    class="toggle c"
+    class="toggle c inlineCenter"
     role="switch"
     type="button"
     value="0"
@@ -42,7 +42,7 @@ exports[`Toggle className 1`] = `
 exports[`Toggle disabled 1`] = `
 <DocumentFragment>
   <button
-    class="toggle"
+    class="toggle inlineCenter"
     data-testid="toggle"
     disabled=""
     role="switch"
@@ -63,7 +63,7 @@ exports[`Toggle value is false 1`] = `
 <DocumentFragment>
   <button
     aria-checked="false"
-    class="toggle"
+    class="toggle inlineCenter"
     role="switch"
     type="button"
     value="0"
@@ -82,7 +82,7 @@ exports[`Toggle value is true 1`] = `
 <DocumentFragment>
   <button
     aria-checked="true"
-    class="toggle"
+    class="toggle inlineCenter"
     role="switch"
     type="button"
     value="1"

--- a/client/branded/src/components/constants.ts
+++ b/client/branded/src/components/constants.ts
@@ -1,0 +1,1 @@
+export const TOGGLE_DISPLAY = ['inline', 'inline-center'] as const

--- a/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.tsx
@@ -236,8 +236,8 @@ const IncludeArchivedToggle: React.FunctionComponent<{
     includeArchived: boolean
     onToggle: () => void
 }> = ({ includeArchived, onToggle }) => (
-    <div className="d-flex align-items-center justify-content-between text-nowrap mb-2">
-        <label htmlFor="include-archived" className="mb-0 pt-1">
+    <div className="d-flex align-items-center justify-content-between text-nowrap mb-2 pt-1">
+        <label htmlFor="include-archived" className="mb-0">
             Include archived
         </label>
         <Toggle
@@ -246,6 +246,7 @@ const IncludeArchivedToggle: React.FunctionComponent<{
             onToggle={onToggle}
             title="Include archived changesets"
             className="ml-2"
+            display="inline"
         />
     </div>
 )

--- a/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormActionArea.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormActionArea.test.tsx.snap
@@ -71,7 +71,7 @@ exports[`FormActionArea Error is shown if code monitor has empty description 1`]
         <button
           aria-checked="true"
           aria-labelledby="code-monitoring-form-actions-enable-toggle"
-          class="toggle mr-2"
+          class="toggle mr-2 inlineCenter"
           role="switch"
           title="Enabled"
           type="button"

--- a/client/web/src/extensions/__snapshots__/ExtensionCard.test.tsx.snap
+++ b/client/web/src/extensions/__snapshots__/ExtensionCard.test.tsx.snap
@@ -68,7 +68,7 @@ exports[`ExtensionCard renders 1`] = `
           </span>
           <button
             aria-checked="false"
-            class="toggle mx-2"
+            class="toggle mx-2 inlineCenter"
             data-testid="extension-toggle-x/y"
             role="switch"
             title="Click to enable"

--- a/client/web/src/extensions/__snapshots__/ExtensionToggle.test.tsx.snap
+++ b/client/web/src/extensions/__snapshots__/ExtensionToggle.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`ExtensionToggle extension disabled in settings 1`] = `
 <DocumentFragment>
   <button
     aria-checked="false"
-    class="toggle"
+    class="toggle inlineCenter"
     data-testid="extension-toggle-x/y"
     role="switch"
     title="Click to enable"
@@ -25,7 +25,7 @@ exports[`ExtensionToggle extension enabled in settings 1`] = `
 <DocumentFragment>
   <button
     aria-checked="true"
-    class="toggle"
+    class="toggle inlineCenter"
     data-testid="extension-toggle-x/y"
     role="switch"
     title="Click to disable"
@@ -46,7 +46,7 @@ exports[`ExtensionToggle extension not present in settings 1`] = `
 <DocumentFragment>
   <button
     aria-checked="false"
-    class="toggle"
+    class="toggle inlineCenter"
     data-testid="extension-toggle-x/y"
     role="switch"
     title="Click to enable"

--- a/client/wildcard/src/components/Card/story/Card.story.tsx
+++ b/client/wildcard/src/components/Card/story/Card.story.tsx
@@ -5,9 +5,8 @@ import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
 import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
 import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
 
-import { Button, Grid } from '..'
-
-import { Card, CardBody, CardHeader, CardSubtitle, CardText, CardTitle } from '.'
+import { Card, CardBody, CardHeader, CardSubtitle, CardText, CardTitle } from '..'
+import { Button, Grid } from '../..'
 
 const config: Meta = {
     title: 'wildcard/Card',
@@ -76,7 +75,13 @@ const cardItem = (
                 <CardSubtitle>New search result → Sends email notifications, delivers webhook</CardSubtitle>
             </div>
             <div className="d-flex align-items-center">
-                <Toggle onClick={() => {}} value={true} className="mr-3" disabled={false} />
+                <Toggle
+                    display="inline"
+                    onClick={() => {}}
+                    value={true}
+                    className="mr-3 align-item-baseline"
+                    disabled={false}
+                />
                 <Button variant="link">Edit</Button>
             </div>
         </CardBody>


### PR DESCRIPTION
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->

### Problem statement

Currently, whenever the toggle element is used, Due to margin and positioning, it's always Misaligned horizontally. below is an image depicting this
![pr fix](https://user-images.githubusercontent.com/38866525/147292631-7dca8add-828e-4900-b359-5507e097e34e.png)

##  Refs

- [SourceGraph Issue](https://github.com/sourcegraph/sourcegraph/issues/29326)
- [GitStart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-29326)
- [Comment](https://github.com/sourcegraph/sourcegraph/pull/28764#pullrequestreview-839361424)
- [#28764 (review)](https://github.com/sourcegraph/sourcegraph/pull/28764#issuecomment-999775399)
