### PR TITLE
HK: Replace literal "/search" with corresponding route constant

### DIFF
--- a/client/web/src/auth/PostSignUpPage.tsx
+++ b/client/web/src/auth/PostSignUpPage.tsx
@@ -8,6 +8,7 @@ import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
 import { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { BrandLogo } from '@sourcegraph/web/src/components/branding/BrandLogo'
 import { HeroPage } from '@sourcegraph/web/src/components/HeroPage'
+import { PageRoutes } from '@sourcegraph/web/src/routes.constants'
 
 import { AuthenticatedUser } from '../auth'
 import { PageTitle } from '../components/PageTitle'
@@ -25,7 +26,6 @@ import { useExternalServices } from './useExternalServices'
 import { CodeHostsConnection } from './welcome/CodeHostsConnection'
 import { Footer } from './welcome/Footer'
 import { StartSearching } from './welcome/StartSearching'
-import { PageRoutes } from '@sourcegraph/web/src/routes.constants'
 
 interface PostSignUpPage {
     authenticatedUser: AuthenticatedUser

--- a/client/web/src/auth/PostSignUpPage.tsx
+++ b/client/web/src/auth/PostSignUpPage.tsx
@@ -25,6 +25,7 @@ import { useExternalServices } from './useExternalServices'
 import { CodeHostsConnection } from './welcome/CodeHostsConnection'
 import { Footer } from './welcome/Footer'
 import { StartSearching } from './welcome/StartSearching'
+import { PageRoutes } from '@sourcegraph/web/src/routes.constants'
 
 interface PostSignUpPage {
     authenticatedUser: AuthenticatedUser
@@ -141,7 +142,7 @@ export const PostSignUpPage: FunctionComponent<PostSignUpPage> = ({
                             {hasErrors && (
                                 <div className="alert alert-danger mb-4" role="alert">
                                     Sorry, something went wrong. Try refreshing the page or{' '}
-                                    <Link to="/search">skip to code search</Link>.
+                                    <Link to={PageRoutes.Search}>skip to code search</Link>.
                                 </div>
                             )}
                             <h2>Get started with Sourcegraph</h2>

--- a/client/web/src/auth/welcome/StartSearching.tsx
+++ b/client/web/src/auth/welcome/StartSearching.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react'
 
 import { ErrorLike, isErrorLike } from '@sourcegraph/common'
 import { Link } from '@sourcegraph/shared/src/components/Link'
+import { PageRoutes } from '@sourcegraph/web/src/routes.constants'
 
 import { AuthenticatedUser } from '../../auth'
 import { eventLogger } from '../../tracking/eventLogger'
@@ -16,7 +17,6 @@ import { useRepoCloningStatus } from '../useRepoCloningStatus'
 import { selectedReposVar, useSaveSelectedRepos, MinSelectedRepo } from '../useSelectedRepos'
 
 import styles from './StartSearching.module.scss'
-import { PageRoutes } from '@sourcegraph/web/src/routes.constants'
 
 interface StartSearching {
     user: AuthenticatedUser

--- a/client/web/src/auth/welcome/StartSearching.tsx
+++ b/client/web/src/auth/welcome/StartSearching.tsx
@@ -16,6 +16,7 @@ import { useRepoCloningStatus } from '../useRepoCloningStatus'
 import { selectedReposVar, useSaveSelectedRepos, MinSelectedRepo } from '../useSelectedRepos'
 
 import styles from './StartSearching.module.scss'
+import { PageRoutes } from '@sourcegraph/web/src/routes.constants'
 
 interface StartSearching {
     user: AuthenticatedUser
@@ -203,7 +204,7 @@ export const StartSearching: React.FunctionComponent<StartSearching> = ({
             {showAlert && (
                 <div className="alert alert-warning mt-4">
                     Cloning your repositories is taking a long time. You can wait for cloning to finish, or{' '}
-                    <Link to="/search" onClick={trackBannerClick}>
+                    <Link to={PageRoutes.Search} onClick={trackBannerClick}>
                         continue to Sourcegraph now
                     </Link>{' '}
                     while cloning continues in the background. Note that you can only search repos that have finished

--- a/client/web/src/nav/NavBar/NavBar.tsx
+++ b/client/web/src/nav/NavBar/NavBar.tsx
@@ -5,6 +5,7 @@ import ChevronUpIcon from 'mdi-react/ChevronUpIcon'
 import MenuIcon from 'mdi-react/MenuIcon'
 import React, { useEffect, useRef, useState } from 'react'
 import { LinkProps, NavLink as RouterLink } from 'react-router-dom'
+import { PageRoutes } from '@sourcegraph/web/src/routes.constants'
 
 import navActionStyles from './NavAction.module.scss'
 import navBarStyles from './NavBar.module.scss'
@@ -57,7 +58,7 @@ const useOutsideClickDetector = (
 export const NavBar = ({ children, logo }: NavBarProps): JSX.Element => (
     <nav aria-label="Main Menu" className={navBarStyles.navbar}>
         <h1 className={navBarStyles.logo}>
-            <RouterLink className="d-flex align-items-center" to="/search">
+            <RouterLink className="d-flex align-items-center" to={PageRoutes.Search}>
                 {logo}
             </RouterLink>
         </h1>

--- a/client/web/src/nav/NavBar/NavBar.tsx
+++ b/client/web/src/nav/NavBar/NavBar.tsx
@@ -5,6 +5,7 @@ import ChevronUpIcon from 'mdi-react/ChevronUpIcon'
 import MenuIcon from 'mdi-react/MenuIcon'
 import React, { useEffect, useRef, useState } from 'react'
 import { LinkProps, NavLink as RouterLink } from 'react-router-dom'
+
 import { PageRoutes } from '@sourcegraph/web/src/routes.constants'
 
 import navActionStyles from './NavAction.module.scss'

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -74,7 +74,7 @@ function passThroughToServer(): React.ReactNode {
 export const routes: readonly LayoutRouteProps<any>[] = [
     {
         path: PageRoutes.Index,
-        render: () => <Redirect to="/search" />,
+        render: () => <Redirect to={PageRoutes.Search} />,
         exact: true,
     },
     {
@@ -88,7 +88,7 @@ export const routes: readonly LayoutRouteProps<any>[] = [
             getExperimentalFeatures().showMultilineSearchConsole ? (
                 <SearchConsolePage {...props} />
             ) : (
-                <Redirect to="/search" />
+                <Redirect to={PageRoutes.Search} />
             ),
         exact: true,
     },
@@ -98,7 +98,7 @@ export const routes: readonly LayoutRouteProps<any>[] = [
             useExperimentalFeatures.getState().showSearchNotebook ? (
                 <SearchNotebookPage {...props} />
             ) : (
-                <Redirect to="/search" />
+                <Redirect to={PageRoutes.Search} />
             ),
         exact: true,
     },
@@ -137,7 +137,7 @@ export const routes: readonly LayoutRouteProps<any>[] = [
                     setSelectedSearchContextSpec={props.setSelectedSearchContextSpec}
                 />
             ) : (
-                <Redirect to="/search" />
+                <Redirect to={PageRoutes.Search} />
             ),
 
         exact: true,

--- a/client/web/src/search/home/SearchPageFooter.tsx
+++ b/client/web/src/search/home/SearchPageFooter.tsx
@@ -8,6 +8,7 @@ import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { BrandLogo } from '../../components/branding/BrandLogo'
 
 import styles from './SearchPageFooter.module.scss'
+import { PageRoutes } from '@sourcegraph/web/src/routes.constants'
 
 const footerLinkSections: { name: string; links: { name: string; to: string; eventName?: string }[] }[] = [
     {
@@ -74,7 +75,7 @@ export const SearchPageFooter: React.FunctionComponent<
 
     return isSourcegraphDotCom ? (
         <footer className={styles.footer}>
-            <Link to="/search" aria-label="Home" className="flex-shrink-0">
+            <Link to={PageRoutes.Search} aria-label="Home" className="flex-shrink-0">
                 <BrandLogo isLightTheme={isLightTheme} variant="symbol" className={styles.logo} />
             </Link>
 

--- a/client/web/src/search/home/SearchPageFooter.tsx
+++ b/client/web/src/search/home/SearchPageFooter.tsx
@@ -4,11 +4,11 @@ import React from 'react'
 import { Link } from '@sourcegraph/shared/src/components/Link'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
+import { PageRoutes } from '@sourcegraph/web/src/routes.constants'
 
 import { BrandLogo } from '../../components/branding/BrandLogo'
 
 import styles from './SearchPageFooter.module.scss'
-import { PageRoutes } from '@sourcegraph/web/src/routes.constants'
 
 const footerLinkSections: { name: string; links: { name: string; to: string; eventName?: string }[] }[] = [
     {

--- a/client/web/src/site-admin/init/SiteInitPage.tsx
+++ b/client/web/src/site-admin/init/SiteInitPage.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { Redirect } from 'react-router'
 
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
+import { PageRoutes } from '@sourcegraph/web/src/routes.constants'
 
 import { AuthenticatedUser } from '../../auth'
 import { SignUpArguments, SignUpForm } from '../../auth/SignUpForm'
@@ -12,7 +13,6 @@ import { SourcegraphContext } from '../../jscontext'
 import { submitTrialRequest } from '../../marketing/backend'
 
 import styles from './SiteInitPage.module.scss'
-import { PageRoutes } from 'src/routes.constants'
 
 const initSite = async (args: SignUpArguments): Promise<void> => {
     const pingUrl = new URL('https://sourcegraph.com/ping-from-self-hosted')

--- a/client/web/src/site-admin/init/SiteInitPage.tsx
+++ b/client/web/src/site-admin/init/SiteInitPage.tsx
@@ -12,6 +12,7 @@ import { SourcegraphContext } from '../../jscontext'
 import { submitTrialRequest } from '../../marketing/backend'
 
 import styles from './SiteInitPage.module.scss'
+import { PageRoutes } from 'src/routes.constants'
 
 const initSite = async (args: SignUpArguments): Promise<void> => {
     const pingUrl = new URL('https://sourcegraph.com/ping-from-self-hosted')
@@ -67,7 +68,7 @@ export const SiteInitPage: React.FunctionComponent<Props> = ({
     featureFlags,
 }) => {
     if (!needsSiteInit) {
-        return <Redirect to="/search" />
+        return <Redirect to={PageRoutes.Search} />
     }
 
     return (

--- a/client/web/src/tracking/withActivation.tsx
+++ b/client/web/src/tracking/withActivation.tsx
@@ -15,6 +15,7 @@ import { dataOrThrowErrors, gql } from '@sourcegraph/shared/src/graphql/graphql'
 import { AuthenticatedUser } from '../auth'
 import { queryGraphQL } from '../backend/graphql'
 import { logUserEvent, logEvent } from '../user/settings/backend'
+import { PageRoutes } from '@sourcegraph/web/src/routes.constants'
 
 /**
  * Fetches activation status from server.
@@ -137,7 +138,7 @@ const getActivationSteps = (authenticatedUser: AuthenticatedUser): ActivationSte
             title: 'Search your code',
             detail: (
                 <span>
-                    Head to the <a href="/search">homepage</a> and perform a search query on your code.{' '}
+                    Head to the <a href={PageRoutes.Search}>homepage</a> and perform a search query on your code.{' '}
                     <strong>Example:</strong> type 'lang:' and select a language
                 </span>
             ),

--- a/client/web/src/tracking/withActivation.tsx
+++ b/client/web/src/tracking/withActivation.tsx
@@ -11,11 +11,11 @@ import {
 } from '@sourcegraph/shared/src/components/activation/Activation'
 import { UserEvent } from '@sourcegraph/shared/src/graphql-operations'
 import { dataOrThrowErrors, gql } from '@sourcegraph/shared/src/graphql/graphql'
+import { PageRoutes } from '@sourcegraph/web/src/routes.constants'
 
 import { AuthenticatedUser } from '../auth'
 import { queryGraphQL } from '../backend/graphql'
 import { logUserEvent, logEvent } from '../user/settings/backend'
-import { PageRoutes } from '@sourcegraph/web/src/routes.constants'
 
 /**
  * Fetches activation status from server.


### PR DESCRIPTION
## Problem
Somewhere in the codebase we've had literal `"/search"` URL, which is error-prone should we ever want to change URL.

## Solution
Import `PageRoutes` and use constant instead of the literal value.

NB: I haven't replaced values in tests and stories.