### PR TITLE
cmd/repo-updater: fix counting user/org added repos

### DIFF
--- a/internal/repos/integration_test.go
+++ b/internal/repos/integration_test.go
@@ -42,6 +42,7 @@ func TestIntegration(t *testing.T) {
 		{"Syncer/OrphanedRepos", testOrphanedRepo},
 		{"Syncer/DeleteExternalService", testDeleteExternalService},
 		{"Syncer/AbortSyncWhenThereIsRepoLimitError", testAbortSyncWhenThereIsRepoLimitError},
+		{"Syncer/UserAndOrgReposAreCountedCorrectly", testUserAndOrgReposAreCountedCorrectly},
 		{"Syncer/UserAddedRepos", testUserAddedRepos},
 		{"Syncer/NameConflictOnRename", testNameOnConflictOnRename},
 		{"Syncer/ConflictingSyncers", testConflictingSyncers},

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -170,7 +170,7 @@ func (s *Store) CountNamespacedRepos(ctx context.Context, userID, orgID int32) (
 const countTotalNamespacedReposQueryFmtstr = `
 SELECT COUNT(DISTINCT(repo_id))
 FROM external_service_repos
-WHERE user_id IS NOT NULL OR org_id IS NOT NULL`
+WHERE (user_id IS NOT NULL OR org_id IS NOT NULL)`
 
 // DeleteExternalServiceReposNotIn calls DeleteExternalServiceRepo for every repo not in the given ids that is owned
 // by the given external service. We run one query per repo rather than one batch query in order to reduce the chances


### PR DESCRIPTION
This fixes an issue when user/org count of added repos in fact counted total repos added both by user and org, not separately

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
