### PR TITLE
Add link unfurl query to GraphQL API

### DIFF
--- a/cmd/frontend/graphqlbackend/link_metadata.go
+++ b/cmd/frontend/graphqlbackend/link_metadata.go
@@ -1,0 +1,34 @@
+package graphqlbackend
+
+import (
+	"context"
+	"sync"
+)
+
+type LinkMetadataResolver struct {
+	once sync.Once
+	URL  string
+}
+
+type linkMetadataArgs struct {
+	URL string
+}
+
+func (r *schemaResolver) LinkMetadata(ctx context.Context, args *linkMetadataArgs) *LinkMetadataResolver {
+	return &LinkMetadataResolver{sync.Once{}, args.URL}
+}
+
+func (*LinkMetadataResolver) ImageURL() *string {
+	image := "image"
+	return strptr(image)
+}
+
+func (*LinkMetadataResolver) Title() *string {
+	title := "title-fake"
+	return strptr(title)
+}
+
+func (*LinkMetadataResolver) Description() *string {
+	description := "description-mock"
+	return strptr(description)
+}

--- a/cmd/frontend/graphqlbackend/link_metadata.go
+++ b/cmd/frontend/graphqlbackend/link_metadata.go
@@ -2,8 +2,10 @@ package graphqlbackend
 
 import (
 	"context"
+	"golang.org/x/net/html"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 )
 
@@ -19,44 +21,119 @@ type linkMetadataArgs struct {
 	URL string
 }
 
+type LinkMetadata struct {
+	title       *string
+	description *string
+	imageUrl    *string
+}
+
 func (r *schemaResolver) LinkMetadata(ctx context.Context, args *linkMetadataArgs) *LinkMetadataResolver {
 	return &LinkMetadataResolver{sync.Once{}, args.URL, ""}
 }
 
-func (r *LinkMetadataResolver) retrieveMetaTags(url string) string {
+func (r *LinkMetadataResolver) retrieveHtml(url string) string {
 	r.once.Do(func() {
 		resp, err := http.Get(url)
 		if err != nil {
 			return
 		}
-		defer resp.Body.Close()
+		defer func(Body io.ReadCloser) {
+			err := Body.Close()
+			if err != nil {
+				// TODO: Handle error
+			}
+		}(resp.Body)
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return
 		}
 
 		r.html = string(body)
-
-		// TODO: parse HTML, return map of meta tag name to value.
 	})
 
 	return r.html
 }
 
-func (r *LinkMetadataResolver) ImageURL() *string {
-	html := r.retrieveMetaTags(r.URL)
+func parseBody(body string) LinkMetadata {
+	metaTags := extractAllMetaTags(body)
 
-	return strptr(html)
+	title := extractField(metaTags, []string{"og:title", "twitter:title", "title"})
+	description := extractField(metaTags, []string{"og:description", "twitter:description", "description"})
+	imageUrl := extractField(metaTags, []string{"og:image", "twitter:image", "image"})
+	return LinkMetadata{title, description, imageUrl}
+}
+
+func extractAllMetaTags(body string) map[string]string {
+	tokenizer := html.NewTokenizer(strings.NewReader(body))
+	metaTags := make(map[string]string)
+	inHead := false
+	for {
+		tokenType := tokenizer.Next()
+		if tokenType == html.ErrorToken {
+			// Returning io.EOF indicates success.
+			if tokenizer.Err() == io.EOF {
+				break
+			} else {
+				// Swallows unexpected error
+				break
+			}
+		} else if tokenType == html.StartTagToken || (inHead && tokenType == html.SelfClosingTagToken) {
+			token := tokenizer.Token()
+			if token.Data == "head" {
+				inHead = true
+			}
+			if inHead && token.Data == "meta" {
+				attributes := convertTokenToAttributeMap(token)
+				if attributes["property"] != "" {
+					metaTags[attributes["property"]] = attributes["content"]
+				} else if attributes["name"] != "" {
+					metaTags[attributes["name"]] = attributes["content"]
+				}
+			}
+		} else if inHead && tokenType == html.EndTagToken {
+			token := tokenizer.Token()
+			if token.Data == "head" {
+				return metaTags
+			}
+		}
+	}
+	return metaTags
+}
+
+func convertTokenToAttributeMap(token html.Token) map[string]string {
+	attributeMap := map[string]string{}
+	for _, attr := range token.Attr {
+		attributeMap[attr.Key] = attr.Val
+	}
+	return attributeMap
+}
+
+func extractField(metaTags map[string]string, fieldNames []string) *string {
+	for _, fieldName := range fieldNames {
+		if metaTags[fieldName] != "" {
+			return strptr(metaTags[fieldName])
+		}
+	}
+	return nil
 }
 
 func (r *LinkMetadataResolver) Title() *string {
-	html := r.retrieveMetaTags(r.URL)
+	htmlSource := r.retrieveHtml(r.URL)
+	linkMetadata := parseBody(htmlSource)
 
-	return strptr(html)
+	return linkMetadata.title
 }
 
 func (r *LinkMetadataResolver) Description() *string {
-	html := r.retrieveMetaTags(r.URL)
+	htmlSource := r.retrieveHtml(r.URL)
+	linkMetadata := parseBody(htmlSource)
 
-	return strptr(html)
+	return linkMetadata.description
+}
+
+func (r *LinkMetadataResolver) ImageURL() *string {
+	htmlSource := r.retrieveHtml(r.URL)
+	linkMetadata := parseBody(htmlSource)
+
+	return linkMetadata.imageUrl
 }

--- a/cmd/frontend/graphqlbackend/link_metadata.go
+++ b/cmd/frontend/graphqlbackend/link_metadata.go
@@ -102,7 +102,7 @@ func (r *LinkMetadataResolver) retrieveHtml(url string) string {
 		defer func(Body io.ReadCloser) {
 			err := Body.Close()
 			if err != nil {
-				// TODO: Handle error
+				log15.Info("Could not load HTML content for unfurling.", "url", url)
 			}
 		}(resp.Body)
 		body, err := io.ReadAll(resp.Body)

--- a/cmd/frontend/graphqlbackend/link_metadata.go
+++ b/cmd/frontend/graphqlbackend/link_metadata.go
@@ -2,12 +2,17 @@ package graphqlbackend
 
 import (
 	"context"
+	"io"
+	"net/http"
 	"sync"
 )
 
 type LinkMetadataResolver struct {
 	once sync.Once
 	URL  string
+
+	// Cache results because they are used by multiple fields
+	html string
 }
 
 type linkMetadataArgs struct {
@@ -15,20 +20,43 @@ type linkMetadataArgs struct {
 }
 
 func (r *schemaResolver) LinkMetadata(ctx context.Context, args *linkMetadataArgs) *LinkMetadataResolver {
-	return &LinkMetadataResolver{sync.Once{}, args.URL}
+	return &LinkMetadataResolver{sync.Once{}, args.URL, ""}
 }
 
-func (*LinkMetadataResolver) ImageURL() *string {
-	image := "image"
-	return strptr(image)
+func (r *LinkMetadataResolver) retrieveMetaTags(url string) string {
+	r.once.Do(func() {
+		resp, err := http.Get(url)
+		if err != nil {
+			return
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return
+		}
+
+		r.html = string(body)
+
+		// TODO: parse HTML, return map of meta tag name to value.
+	})
+
+	return r.html
 }
 
-func (*LinkMetadataResolver) Title() *string {
-	title := "title-fake"
-	return strptr(title)
+func (r *LinkMetadataResolver) ImageURL() *string {
+	html := r.retrieveMetaTags(r.URL)
+
+	return strptr(html)
 }
 
-func (*LinkMetadataResolver) Description() *string {
-	description := "description-mock"
-	return strptr(description)
+func (r *LinkMetadataResolver) Title() *string {
+	html := r.retrieveMetaTags(r.URL)
+
+	return strptr(html)
+}
+
+func (r *LinkMetadataResolver) Description() *string {
+	html := r.retrieveMetaTags(r.URL)
+
+	return strptr(html)
 }

--- a/cmd/frontend/graphqlbackend/link_metadata.go
+++ b/cmd/frontend/graphqlbackend/link_metadata.go
@@ -85,9 +85,15 @@ func (m *LinkMetadata) fromJSON(jsonBytes []byte) error {
 	if err := json.Unmarshal(jsonBytes, &temp); err != nil {
 		return err
 	} else {
-		m.title = strptr(temp["title"])
-		m.description = strptr(temp["description"])
-		m.imageUrl = strptr(temp["imageUrl"])
+		if temp["title"] != "" {
+			m.title = strptr(temp["title"])
+		}
+		if temp["description"] != "" {
+			m.description = strptr(temp["description"])
+		}
+		if temp["imageUrl"] != "" {
+			m.imageUrl = strptr(temp["imageUrl"])
+		}
 		return nil
 	}
 }

--- a/cmd/frontend/graphqlbackend/link_metadata_test.go
+++ b/cmd/frontend/graphqlbackend/link_metadata_test.go
@@ -1,17 +1,150 @@
 package graphqlbackend
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestLinkMetadata(t *testing.T) {
-	t.Run("valid", func(t *testing.T) {
-		if !true {
-			t.Fatal("fail!")
+	title := "title"
+	description := "description"
+	imageUrl := "imageUrl"
+
+	t.Run("can parse valid HTML", func(t *testing.T) {
+		html := fmt.Sprintf(`<!DOCTYPE html>
+<html lang="en" data-color-mode="dark" data-light-theme="light" data-dark-theme="dark">
+  <head>
+    <meta charset="utf-8">
+    <link rel="dns-prefetch" href="https://github.githubassets.com">
+    <meta name="viewport" content="test">
+    <title>sourcegraph/sourcegraph: Universal code search (self-hosted)</title>
+    <meta name="description" content="test">
+    <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="GitHub">
+    <meta property="fb:app_id" content="test">
+    <meta name="apple-itunes-app" content="test" />
+    <meta name="twitter:image:src" content="test" />
+    <meta name="twitter:site" content="test" />
+    <meta name="twitter:title" content="test" />
+    <meta name="twitter:description" content="test" />
+    <meta property="og:image" content="%s" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:title" content="%s" />
+    <meta property="og:url" content="test" />
+    <meta property="og:description" content="%s" />
+    <link rel="assets" href="https://github.githubassets.com/">
+    <!-- To prevent page flashing, the optimizely JS needs to be loaded in the
+         <head> tag before the DOM renders -->
+    <meta name="hostname" content="github.com">
+    <script type="application/json" id="memex_keyboard_shortcuts_preference">"all"</script>
+    <meta name="theme-color" content="#1e2327">
+    <meta name="color-scheme" content="dark light" />
+  </head>
+  <body class="logged-in env-production page-responsive" style="word-wrap: break-word;">
+    <div class="position-relative js-header-wrapper "></div>
+  </body>
+</html>`, imageUrl, title, description)
+
+		linkMetadata := parseBody(html)
+
+		if linkMetadata.title == nil {
+			t.Errorf("title is nil when it should be a value")
+		} else if *linkMetadata.title != title {
+			t.Errorf("got %q want %q", *linkMetadata.title, title)
+		}
+		if linkMetadata.description == nil {
+			t.Errorf("description is nil when it should be a value")
+		} else if *linkMetadata.description != description {
+			t.Errorf("got %q want %q", *linkMetadata.description, description)
+		}
+		if linkMetadata.imageUrl == nil {
+			t.Errorf("imageUrl is nil when it should be a value")
+		} else if *linkMetadata.imageUrl != imageUrl {
+			t.Errorf("got %q want %q", *linkMetadata.imageUrl, imageUrl)
 		}
 	})
 
-	t.Run("invalid", func(t *testing.T) {
-		if !true {
-			t.Fatal("fail!")
+	t.Run("prefers og: then twitter: then naked", func(t *testing.T) {
+		html := fmt.Sprintf(`<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="description" content="test">
+    <meta name="title" content="test">
+    <meta property="og:title" content="%s" />
+    <meta property="image" content="%s" />
+    <meta name="twitter:title" content="test" />
+    <meta name="twitter:description" content="%s" />
+  </head>
+</html>`, title, imageUrl, description)
+
+		linkMetadata := parseBody(html)
+
+		if linkMetadata.title == nil {
+			t.Errorf("title is nil when it should be a value")
+		} else if *linkMetadata.title != title {
+			t.Errorf("got %q want %q", *linkMetadata.title, title)
+		}
+		if linkMetadata.description == nil {
+			t.Errorf("description is nil when it should be a value")
+		} else if *linkMetadata.description != description {
+			t.Errorf("got %q want %q", *linkMetadata.description, description)
+		}
+		if linkMetadata.imageUrl == nil {
+			t.Errorf("imageUrl is nil when it should be a value")
+		} else if *linkMetadata.imageUrl != imageUrl {
+			t.Errorf("got %q want %q", *linkMetadata.imageUrl, imageUrl)
+		}
+	})
+
+	t.Run("returns nil value if no metadata is found for a field", func(t *testing.T) {
+		html := fmt.Sprintf(`<!DOCTYPE html>
+<html>
+  <head>
+    <meta property="og:title" content="%s" />
+  </head>
+</html>`, title)
+
+		linkMetadata := parseBody(html)
+
+		if linkMetadata.title == nil {
+			t.Errorf("title is nil when it should be a value")
+		} else if *linkMetadata.title != title {
+			t.Errorf("got %q want %q", *linkMetadata.title, title)
+		}
+		if linkMetadata.description != nil {
+			t.Errorf("description should be nil")
+		}
+		if linkMetadata.imageUrl != nil {
+			t.Errorf("imageUrl should be nil")
+		}
+	})
+
+	t.Run("returns a struct of three nil references if no metadata is found for any fields", func(t *testing.T) {
+		html := fmt.Sprintf(`<!DOCTYPE html>
+<html>
+  <head>
+  </head>
+</html>`)
+
+		linkMetadata := parseBody(html)
+
+		if linkMetadata.title != nil {
+			t.Errorf("title should be nil")
+		}
+		if linkMetadata.description != nil {
+			t.Errorf("description should be nil")
+		}
+		if linkMetadata.imageUrl != nil {
+			t.Errorf("imageUrl should be nil")
+		}
+	})
+
+	t.Run("returns nil values on invalid/weird HTML", func(t *testing.T) {
+		html := `abc<!DOCTYPE html><html><meta charset="UTF-8" /><title>Invalid HTML Example</title></head><body>`
+
+		linkMetadata := parseBody(html)
+
+		if linkMetadata.title != nil || linkMetadata.description != nil || linkMetadata.imageUrl != nil {
+			t.Errorf("all fields should be nil")
 		}
 	})
 }

--- a/cmd/frontend/graphqlbackend/link_metadata_test.go
+++ b/cmd/frontend/graphqlbackend/link_metadata_test.go
@@ -1,0 +1,17 @@
+package graphqlbackend
+
+import "testing"
+
+func TestLinkMetadata(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		if !true {
+			t.Fatal("fail!")
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		if !true {
+			t.Fatal("fail!")
+		}
+	})
+}

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1471,6 +1471,27 @@ type Query {
         """
         after: String
     ): ExecutorConnection!
+    """
+    Retrieve metadata for a webpage from <meta> tags.
+    """
+    linkMetadata(url: String!): LinkMetadata
+}
+
+type LinkMetadata {
+    """
+    URL of image
+    """
+    imageURL: String
+
+    """
+    TODO
+    """
+    title: String
+
+    """
+    TODO
+    """
+    description: String
 }
 
 """


### PR DESCRIPTION
Closes #15735 (onboarding task for @vdavid).

TODO
- [x] Add query to GraphQL schema
- [x] Make HTTP request for URL
- [x] Parse HTML and return relevant meta tags
- [x] Follow redirects when making a request to the URL
- [x] Add tests
- [x] Add caching

This endpoint will be used by the [link-preview-expander](https://github.com/sourcegraph/sourcegraph-link-preview-expander/tree/HEAD) Sourcegraph extension.