### PR TITLE
Fix bkstats handling of empty details, clarify CLI parameters

### DIFF
--- a/dev/bkstats/README.md
+++ b/dev/bkstats/README.md
@@ -6,7 +6,7 @@ Owned by the [DevX team](https://handbook.sourcegraph.com/departments/product-en
 ## Usage
 
 ```
-$ go run main.go -token $BUILDKITE_API_TOKEN -date 2021-10-22 -pipeline sourcegraph
+$ go run main.go -buildkite.token $BUILDKITE_API_TOKEN -date 2021-10-22 -buildkite.pipeline sourcegraph
 # ...
 On 2021-10-22, the pipeline was red for 1h8m32.856s
 ```

--- a/dev/bkstats/main.go
+++ b/dev/bkstats/main.go
@@ -20,10 +20,10 @@ var shortDateFormat = "2006-01-02"
 var longDateFormat = "2006-01-02 15:04 (MST)"
 
 func init() {
-	flag.StringVar(&token, "token", "", "mandatory buildkite token")
+	flag.StringVar(&token, "buildkite.token", "", "mandatory buildkite token")
 	flag.StringVar(&date, "date", "", "date for builds")
-	flag.StringVar(&pipeline, "pipeline", "sourcegraph", "name of the pipeline to inspect")
-	flag.StringVar(&slack, "slack", "", "Slack Webhook URL to post the results on")
+	flag.StringVar(&pipeline, "buildkite.pipeline", "sourcegraph", "name of the pipeline to inspect")
+	flag.StringVar(&slack, "slack.webhook", "", "Slack Webhook URL to post the results on")
 }
 
 type event struct {
@@ -166,7 +166,18 @@ func postOnSlack(report *report) error {
 					Text: report.summary,
 				},
 			},
-			{
+		},
+	}
+
+	if len(report.details) > 0 {
+		// Add the details block only if there are details, otherwise Slack API will
+		// consider the block to be invalid and will reject it.
+		var text string
+		for _, detail := range report.details {
+			text += "• " + detail + " \n"
+		}
+		slackBody.Blocks = append(slackBody.Blocks,
+			slackBlock{
 				Type: "context",
 				Elements: []slackText{
 					{
@@ -175,7 +186,7 @@ func postOnSlack(report *report) error {
 					},
 				},
 			},
-		},
+		)
 	}
 
 	body, err := json.MarshalIndent(slackBody, "", "  ")

--- a/dev/bkstats/run.sh
+++ b/dev/bkstats/run.sh
@@ -25,6 +25,6 @@ set -eu
 pushd dev/bkstats
 
 echo "--- Posting report on Slack"
-go run main.go -token="$BUILDKITE_TOKEN" -slack="$WEBHOOK_URL"
+go run main.go -buildkite.token="$BUILDKITE_TOKEN" -slack.webhook="$WEBHOOK_URL"
 
 popd


### PR DESCRIPTION
This fixes the issue seen in https://buildkite.com/sourcegraph/devx-cron/builds/61#f1dea139-f088-482d-b402-0fbf2a66fd6d 