### PR TITLE
branded: remove Bootstrap Style `@import bootstrap/scss/progress`

### DIFF
--- a/client/branded/src/global-styles/index.scss
+++ b/client/branded/src/global-styles/index.scss
@@ -82,9 +82,6 @@ $dropdown-padding-y: $dropdown-item-padding-y;
 $table-cell-padding: 0.625rem;
 $table-border-color: var(--border-color);
 
-// Progress
-$progress-height: auto;
-
 $hr-border-color: var(--border-color);
 $hr-margin-y: 0.25rem;
 
@@ -105,7 +102,6 @@ $spacer: 1rem;
 @import 'bootstrap/scss/reboot';
 @import 'bootstrap/scss/utilities';
 @import 'bootstrap/scss/grid';
-@import 'bootstrap/scss/progress';
 @import 'bootstrap/scss/transitions';
 
 // Modified in `./buttons.scss`
@@ -138,6 +134,7 @@ $spacer: 1rem;
 @import './forms';
 @import './highlight';
 @import './tabs';
+@import './progress';
 
 * {
     box-sizing: border-box;

--- a/client/branded/src/global-styles/progress.scss
+++ b/client/branded/src/global-styles/progress.scss
@@ -1,0 +1,32 @@
+:root {
+    --progress-height: auto;
+    --progress-font-size: 0.65625rem;
+    --progress-background-color: #e9ecef;
+    --progress-border-radius: var(--border-radius);
+    --progress-box-shadow: inset 0 0.1rem 0.1rem rgba(var(--black), 0.1);
+    --progress-bar-color: var(--white);
+    --progress-bar-bg: var(--primary);
+}
+
+.progress {
+    display: flex;
+    height: var(--progress-height);
+    overflow: hidden; // force rounded corners by cropping it
+    line-height: 0;
+    font-size: var(--progress-font-size);
+    background-color: var(--progress-background-color);
+    border-radius: var(--border-radius);
+    box-shadow: var(--progress-box-shadow);
+}
+
+.progress-bar {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    overflow: hidden;
+    color: var(--progress-bar-color);
+    text-align: center;
+    white-space: nowrap;
+    background-color: var(--progress-bar-bg);
+    transition: width 0.6s ease;
+}


### PR DESCRIPTION
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
## Problem Statement
We depend on Bootstrap styles in our global styles a lot. But we don't plan to move forward with Bootstrap because we're working on our design system called Wildcard. To ease the transition to our styles and gain more control over visual changes, we want to move Bootstrap styles that we need into our codebase and eventually drop Bootstrap dependency.

## Success Criteria
1) All highlighted imports has been removed
2) All css rules currently used from the imports are now available in style sheets

## Gitstart Issue
[Gitstart Task](https://app.gitstart.com/clients/sourcegraph/tickets/SG-29355)
[SourceGraph Issue](https://github.com/sourcegraph/sourcegraph/issues/29355)

## Implementation Details
let's also remove the following imports and copy CSS rules that we need to our CSS files:
1) `@import 'bootstrap/scss/progress'`
