### PR TITLE
Grafana: Create optional directories to silence errors when overrides aren't present

### DIFF
--- a/docker-images/grafana/Dockerfile
+++ b/docker-images/grafana/Dockerfile
@@ -37,6 +37,10 @@ ADD entry.sh /
 
 USER root
 
+# Create optional folders to avoid error logs about missing dirs
+RUN mkdir /sg_grafana_additional_dashboards
+RUN mkdir /sg_config_grafana/provisioning/plugins
+
 # @FIXME: Update redis image
 # Pin busybox=1.32.1-r7 https://github.com/sourcegraph/sourcegraph/issues/27965
 RUN apk add --upgrade --no-cache apk-tools=~2.12 krb5-libs=~1.18.4 libssl1.1=~1.1.1l openssl=~1.1.1l busybox=~1.32.1

--- a/docker-images/grafana/Dockerfile
+++ b/docker-images/grafana/Dockerfile
@@ -39,7 +39,7 @@ USER root
 
 # Create optional folders to avoid error logs about missing dirs
 RUN mkdir /sg_grafana_additional_dashboards
-RUN mkdir /sg_config_grafana/provisioning/plugins
+RUN mkdir /sg_config_grafana/provisioning/plugins && chown grafana:root /sg_config_grafana/provisioning/plugins
 
 # @FIXME: Update redis image
 # Pin busybox=1.32.1-r7 https://github.com/sourcegraph/sourcegraph/issues/27965


### PR DESCRIPTION
Silences log errors related to missing directories when additional dashboards aren't provided and plugins aren't installed. These empty folders can still be overwritten by mounting volumes (in docker-compose or Kubernetes).

See https://github.com/sourcegraph/sourcegraph/issues/29351 for more context.

The `plugins` error occurs on both docker-compose and Kubernetes installations, but only displays at startup time. The `sg_grafana_additional_dashboards` error occurs continuously on Kubernetes installations, but not docker-compose (since we [mount a volume here](https://sourcegraph.com/github.com/sourcegraph/deploy-sourcegraph-docker/-/blob/docker-compose/docker-compose.yaml?L426)). An alternative solution would be to add a similar `sg_grafana_additional_dashboards` volume mount for Kubernetes, and ignore the plugins alert, but this seemed like the better option.