### PR TITLE
git: Apply sub-repo permissions to git.ReadDir and git.Stat

### DIFF
--- a/cmd/frontend/backend/go_importers.go
+++ b/cmd/frontend/backend/go_importers.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
@@ -134,7 +135,7 @@ func listGoPackagesInRepoImprecise(ctx context.Context, db database.DB, repoName
 	if err != nil {
 		return nil, err
 	}
-	fis, err := git.ReadDir(ctx, repo.Name, commitID, "", true)
+	fis, err := git.ReadDir(ctx, authz.DefaultSubRepoPermsChecker, repo.Name, commitID, "", true)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/backend/inventory.go
+++ b/cmd/frontend/backend/inventory.go
@@ -43,7 +43,7 @@ func InventoryContext(repo api.RepoName, commitID api.CommitID, forceEnhancedLan
 		ReadTree: func(ctx context.Context, path string) ([]fs.FileInfo, error) {
 			// TODO: As a perf optimization, we could read multiple levels of the Git tree at once
 			// to avoid sequential tree traversal calls.
-			return git.ReadDir(ctx, repo, commitID, path, false)
+			return git.ReadDir(ctx, authz.DefaultSubRepoPermsChecker, repo, commitID, path, false)
 		},
 		NewFileReader: func(ctx context.Context, path string) (io.ReadCloser, error) {
 			return git.NewFileReader(ctx, repo, commitID, path, authz.DefaultSubRepoPermsChecker)

--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -205,7 +206,7 @@ func (s *repos) GetInventory(ctx context.Context, repo *types.Repo, commitID api
 		return nil, err
 	}
 
-	root, err := git.Stat(ctx, repo.Name, commitID, "")
+	root, err := git.Stat(ctx, authz.DefaultSubRepoPermsChecker, repo.Name, commitID, "")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -207,7 +207,7 @@ func (r *GitCommitResolver) Tree(ctx context.Context, args *struct {
 	defer span.Finish()
 	span.SetTag("path", args.Path)
 
-	stat, err := git.Stat(ctx, r.gitRepo, api.CommitID(r.oid), args.Path)
+	stat, err := git.Stat(ctx, authz.DefaultSubRepoPermsChecker, r.gitRepo, api.CommitID(r.oid), args.Path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -226,7 +226,7 @@ func (r *GitCommitResolver) Tree(ctx context.Context, args *struct {
 func (r *GitCommitResolver) Blob(ctx context.Context, args *struct {
 	Path string
 }) (*GitTreeEntryResolver, error) {
-	stat, err := git.Stat(ctx, r.gitRepo, api.CommitID(r.oid), args.Path)
+	stat, err := git.Stat(ctx, authz.DefaultSubRepoPermsChecker, r.gitRepo, api.CommitID(r.oid), args.Path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil

--- a/cmd/frontend/graphqlbackend/git_tree.go
+++ b/cmd/frontend/graphqlbackend/git_tree.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
@@ -44,6 +45,7 @@ func (r *GitTreeEntryResolver) entries(ctx context.Context, args *gitTreeEntryCo
 
 	entries, err := git.ReadDir(
 		ctx,
+		authz.DefaultSubRepoPermsChecker,
 		r.commit.repoResolver.RepoName(),
 		api.CommitID(r.commit.OID()),
 		r.Path(),

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -218,6 +218,7 @@ func (r *GitTreeEntryResolver) IsSingleChild(ctx context.Context, args *gitTreeE
 	}
 	entries, err := git.ReadDir(
 		ctx,
+		authz.DefaultSubRepoPermsChecker,
 		r.commit.repoResolver.RepoName(),
 		api.CommitID(r.commit.OID()),
 		path.Dir(r.Path()),

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/handlerutil"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/routevar"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/cookie"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -347,7 +348,7 @@ func redirectTreeOrBlob(routeName, path string, common *Common, w http.ResponseW
 		}
 		return false, nil
 	}
-	stat, err := git.Stat(r.Context(), common.Repo.Name, common.CommitID, path)
+	stat, err := git.Stat(r.Context(), authz.DefaultSubRepoPermsChecker, common.Repo.Name, common.CommitID, path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			serveError(w, r, db, err, http.StatusNotFound)

--- a/cmd/frontend/internal/app/ui/raw.go
+++ b/cmd/frontend/internal/app/ui/raw.go
@@ -233,7 +233,7 @@ func serveRaw(db database.DB) handlerFunc {
 			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 			w.Header().Set("X-Content-Type-Options", "nosniff")
 
-			fi, err := git.Stat(r.Context(), common.Repo.Name, common.CommitID, requestedPath)
+			fi, err := git.Stat(r.Context(), authz.DefaultSubRepoPermsChecker, common.Repo.Name, common.CommitID, requestedPath)
 			if err != nil {
 				if os.IsNotExist(err) {
 					requestType = "404"
@@ -245,7 +245,7 @@ func serveRaw(db database.DB) handlerFunc {
 
 			if fi.IsDir() {
 				requestType = "dir"
-				infos, err := git.ReadDir(r.Context(), common.Repo.Name, common.CommitID, requestedPath, false)
+				infos, err := git.ReadDir(r.Context(), authz.DefaultSubRepoPermsChecker, common.Repo.Name, common.CommitID, requestedPath, false)
 				if err != nil {
 					return err
 				}

--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -49,6 +49,12 @@ func enterpriseInit(
 
 	codemonitorsBackground.StartBackgroundJobs(ctx, db)
 
+	var err error
+	ossAuthz.DefaultSubRepoPermsChecker, err = ossAuthz.NewSubRepoPermsClient(ossDB.SubRepoPerms(db))
+	if err != nil {
+		log.Fatalf("Failed to create sub-repo client: %v", err)
+	}
+
 	// No Batch Changes on dotcom, so we don't need to spawn the
 	// background jobs for this feature.
 	if !envvar.SourcegraphDotComMode() {

--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -49,12 +49,6 @@ func enterpriseInit(
 
 	codemonitorsBackground.StartBackgroundJobs(ctx, db)
 
-	var err error
-	ossAuthz.DefaultSubRepoPermsChecker, err = ossAuthz.NewSubRepoPermsClient(ossDB.SubRepoPerms(db))
-	if err != nil {
-		log.Fatalf("Failed to create sub-repo client: %v", err)
-	}
-
 	// No Batch Changes on dotcom, so we don't need to spawn the
 	// background jobs for this feature.
 	if !envvar.SourcegraphDotComMode() {

--- a/enterprise/internal/batches/service/workspace_resolver.go
+++ b/enterprise/internal/batches/service/workspace_resolver.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/api/internalapi"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
@@ -442,7 +443,7 @@ func hasBatchIgnoreFile(ctx context.Context, r *RepoRevision) (_ bool, err error
 	}()
 
 	const path = ".batchignore"
-	stat, err := git.Stat(ctx, r.Repo.Name, r.Commit, path)
+	stat, err := git.Stat(ctx, authz.DefaultSubRepoPermsChecker, r.Repo.Name, r.Commit, path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil

--- a/enterprise/internal/codeintel/gitserver/client.go
+++ b/enterprise/internal/codeintel/gitserver/client.go
@@ -316,7 +316,7 @@ func (c *Client) FileExists(ctx context.Context, repositoryID int, commit, file 
 		return false, errors.Wrap(err, "git.ResolveRevision")
 	}
 
-	if _, err := git.Stat(ctx, repo, api.CommitID(commit), file); err != nil {
+	if _, err := git.Stat(ctx, authz.DefaultSubRepoPermsChecker, repo, api.CommitID(commit), file); err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
 		}

--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -2,6 +2,7 @@ package authz
 
 import (
 	"context"
+	"io/fs"
 	"path"
 	"strconv"
 	"time"
@@ -338,6 +339,31 @@ func FilterActorPath(ctx context.Context, checker SubRepoPermissionChecker, a *a
 	perms, err := ActorPermissions(ctx, checker, a, RepoContent{
 		Repo: repo,
 		Path: path,
+	})
+	if err != nil {
+		return false, errors.Wrap(err, "checking sub-repo permissions")
+	}
+	return perms.Include(Read), nil
+}
+
+func FilterActorFileInfos(ctx context.Context, checker SubRepoPermissionChecker, a *actor.Actor, repo api.RepoName, fis []fs.FileInfo) ([]fs.FileInfo, error) {
+	filtered := make([]fs.FileInfo, 0, len(fis))
+	for _, fi := range fis {
+		include, err := FilterActorFileInfo(ctx, checker, a, repo, fi)
+		if err != nil {
+			return nil, err
+		}
+		if include {
+			filtered = append(filtered, fi)
+		}
+	}
+	return filtered, nil
+}
+
+func FilterActorFileInfo(ctx context.Context, checker SubRepoPermissionChecker, a *actor.Actor, repo api.RepoName, fi fs.FileInfo) (bool, error) {
+	perms, err := ActorPermissions(ctx, checker, a, RepoContent{
+		Repo: repo,
+		Path: fi.Name(),
 	})
 	if err != nil {
 		return false, errors.Wrap(err, "checking sub-repo permissions")

--- a/internal/vcs/git/blob.go
+++ b/internal/vcs/git/blob.go
@@ -147,7 +147,7 @@ func (br *blobReader) convertError(err error) error {
 	}
 	if strings.Contains(err.Error(), "fatal: bad object ") {
 		// Could be a git submodule.
-		fi, err := Stat(br.ctx, br.repo, br.commit, br.name)
+		fi, err := Stat(br.ctx, authz.DefaultSubRepoPermsChecker, br.repo, br.commit, br.name)
 		if err != nil {
 			return err
 		}

--- a/internal/vcs/git/tree.go
+++ b/internal/vcs/git/tree.go
@@ -66,8 +66,8 @@ func ReadDir(
 			return
 		}
 		a := actor.FromContext(ctx)
-		filtered, err := authz.FilterActorFileInfos(ctx, checker, a, repo, files)
-		if err != nil {
+		filtered, filteringErr := authz.FilterActorFileInfos(ctx, checker, a, repo, files)
+		if filteringErr != nil {
 			err = errors.Wrap(err, "filtering paths")
 			files = nil
 			return

--- a/internal/vcs/git/tree_test.go
+++ b/internal/vcs/git/tree_test.go
@@ -54,7 +54,7 @@ func TestRepository_FileSystem_Symlinks(t *testing.T) {
 	ctx := context.Background()
 
 	// file1 should be a file.
-	file1Info, err := Stat(ctx, repo, commitID, "file1")
+	file1Info, err := Stat(ctx, authz.DefaultSubRepoPermsChecker, repo, commitID, "file1")
 	if err != nil {
 		t.Fatalf("fs.Stat(file1): %s", err)
 	}
@@ -74,7 +74,7 @@ func TestRepository_FileSystem_Symlinks(t *testing.T) {
 
 	// Check symlinks are links
 	for symlink := range symlinks {
-		fi, err := lStat(ctx, repo, commitID, symlink)
+		fi, err := lStat(ctx, authz.DefaultSubRepoPermsChecker, repo, commitID, symlink)
 		if err != nil {
 			t.Fatalf("fs.lStat(%s): %s", symlink, err)
 		}
@@ -86,7 +86,7 @@ func TestRepository_FileSystem_Symlinks(t *testing.T) {
 
 	// Also check the FileInfo returned by ReadDir to ensure it's
 	// consistent with the FileInfo returned by lStat.
-	entries, err := ReadDir(ctx, repo, commitID, ".", false)
+	entries, err := ReadDir(ctx, authz.DefaultSubRepoPermsChecker, repo, commitID, ".", false)
 	if err != nil {
 		t.Fatalf("fs.ReadDir(.): %s", err)
 	}
@@ -104,7 +104,7 @@ func TestRepository_FileSystem_Symlinks(t *testing.T) {
 	}
 
 	for symlink, size := range symlinks {
-		fi, err := Stat(ctx, repo, commitID, symlink)
+		fi, err := Stat(ctx, authz.DefaultSubRepoPermsChecker, repo, commitID, symlink)
 		if err != nil {
 			t.Fatalf("fs.Stat(%s): %s", symlink, err)
 		}
@@ -160,13 +160,13 @@ func TestRepository_FileSystem(t *testing.T) {
 
 	for label, test := range tests {
 		// notafile should not exist.
-		if _, err := Stat(ctx, test.repo, test.first, "notafile"); !os.IsNotExist(err) {
+		if _, err := Stat(ctx, authz.DefaultSubRepoPermsChecker, test.repo, test.first, "notafile"); !os.IsNotExist(err) {
 			t.Errorf("%s: fs1.Stat(notafile): got err %v, want os.IsNotExist", label, err)
 			continue
 		}
 
 		// dir1 should exist and be a dir.
-		dir1Info, err := Stat(ctx, test.repo, test.first, "dir1")
+		dir1Info, err := Stat(ctx, authz.DefaultSubRepoPermsChecker, test.repo, test.first, "dir1")
 		if err != nil {
 			t.Errorf("%s: fs1.Stat(dir1): %s", label, err)
 			continue
@@ -185,7 +185,7 @@ func TestRepository_FileSystem(t *testing.T) {
 		}
 
 		// dir1 should contain one entry: file1.
-		dir1Entries, err := ReadDir(ctx, test.repo, test.first, "dir1", false)
+		dir1Entries, err := ReadDir(ctx, authz.DefaultSubRepoPermsChecker, test.repo, test.first, "dir1", false)
 		if err != nil {
 			t.Errorf("%s: fs1.ReadDir(dir1): %s", label, err)
 			continue
@@ -206,7 +206,7 @@ func TestRepository_FileSystem(t *testing.T) {
 		}
 
 		// dir2 should not exist
-		_, err = ReadDir(ctx, test.repo, test.first, "dir2", false)
+		_, err = ReadDir(ctx, authz.DefaultSubRepoPermsChecker, test.repo, test.first, "dir2", false)
 		if !os.IsNotExist(err) {
 			t.Errorf("%s: fs1.ReadDir(dir2): should not exist: %s", label, err)
 			continue
@@ -221,7 +221,7 @@ func TestRepository_FileSystem(t *testing.T) {
 		if !bytes.Equal(file1Data, []byte("infile1")) {
 			t.Errorf("%s: got file1Data == %q, want %q", label, string(file1Data), "infile1")
 		}
-		file1Info, err = Stat(ctx, test.repo, test.first, "dir1/file1")
+		file1Info, err = Stat(ctx, authz.DefaultSubRepoPermsChecker, test.repo, test.first, "dir1/file1")
 		if err != nil {
 			t.Errorf("%s: fs1.Stat(dir1/file1): %s", label, err)
 			continue
@@ -250,7 +250,7 @@ func TestRepository_FileSystem(t *testing.T) {
 		}
 
 		// file1 should also exist in the 2nd commit.
-		if _, err := Stat(ctx, test.repo, test.second, "dir1/file1"); err != nil {
+		if _, err := Stat(ctx, authz.DefaultSubRepoPermsChecker, test.repo, test.second, "dir1/file1"); err != nil {
 			t.Errorf("%s: fs2.Stat(dir1/file1): %s", label, err)
 			continue
 		}
@@ -260,7 +260,7 @@ func TestRepository_FileSystem(t *testing.T) {
 		}
 
 		// root should exist (via Stat).
-		root, err := Stat(ctx, test.repo, test.second, ".")
+		root, err := Stat(ctx, authz.DefaultSubRepoPermsChecker, test.repo, test.second, ".")
 		if err != nil {
 			t.Errorf("%s: fs2.Stat(.): %s", label, err)
 			continue
@@ -270,7 +270,7 @@ func TestRepository_FileSystem(t *testing.T) {
 		}
 
 		// root should have 2 entries: dir1 and file 2.
-		rootEntries, err := ReadDir(ctx, test.repo, test.second, ".", false)
+		rootEntries, err := ReadDir(ctx, authz.DefaultSubRepoPermsChecker, test.repo, test.second, ".", false)
 		if err != nil {
 			t.Errorf("%s: fs2.ReadDir(.): %s", label, err)
 			continue
@@ -287,7 +287,7 @@ func TestRepository_FileSystem(t *testing.T) {
 		}
 
 		// dir1 should still only contain one entry: file1.
-		dir1Entries, err = ReadDir(ctx, test.repo, test.second, "dir1", false)
+		dir1Entries, err = ReadDir(ctx, authz.DefaultSubRepoPermsChecker, test.repo, test.second, "dir1", false)
 		if err != nil {
 			t.Errorf("%s: fs1.ReadDir(dir1): %s", label, err)
 			continue
@@ -301,7 +301,7 @@ func TestRepository_FileSystem(t *testing.T) {
 		}
 
 		// rootEntries should be empty for third commit
-		rootEntries, err = ReadDir(ctx, test.repo, test.third, ".", false)
+		rootEntries, err = ReadDir(ctx, authz.DefaultSubRepoPermsChecker, test.repo, test.third, ".", false)
 		if err != nil {
 			t.Errorf("%s: fs3.ReadDir(.): %s", label, err)
 			continue
@@ -354,7 +354,7 @@ func TestRepository_FileSystem_quoteChars(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		entries, err := ReadDir(ctx, test.repo, commitID, ".", false)
+		entries, err := ReadDir(ctx, authz.DefaultSubRepoPermsChecker, test.repo, commitID, ".", false)
 		if err != nil {
 			t.Errorf("%s: fs.ReadDir(.): %s", label, err)
 			continue
@@ -371,7 +371,7 @@ func TestRepository_FileSystem_quoteChars(t *testing.T) {
 		}
 
 		for _, name := range wantNames {
-			stat, err := Stat(ctx, test.repo, commitID, name)
+			stat, err := Stat(ctx, authz.DefaultSubRepoPermsChecker, test.repo, commitID, name)
 			if err != nil {
 				t.Errorf("%s: Stat(%q): %s", label, name, err)
 				continue
@@ -442,13 +442,13 @@ func TestRepository_FileSystem_gitSubmodules(t *testing.T) {
 
 		// Check the submodule fs.FileInfo both when it's returned by
 		// Stat and when it's returned in a list by ReadDir.
-		submod, err := Stat(ctx, test.repo, commitID, "submod")
+		submod, err := Stat(ctx, authz.DefaultSubRepoPermsChecker, test.repo, commitID, "submod")
 		if err != nil {
 			t.Errorf("%s: fs.Stat(submod): %s", label, err)
 			continue
 		}
 		checkSubmoduleFileInfo(label+" (Stat)", submod)
-		entries, err := ReadDir(ctx, test.repo, commitID, ".", false)
+		entries, err := ReadDir(ctx, authz.DefaultSubRepoPermsChecker, test.repo, commitID, ".", false)
 		if err != nil {
 			t.Errorf("%s: fs.ReadDir(.): %s", label, err)
 			continue
@@ -673,6 +673,68 @@ func TestListDirectoryChildren(t *testing.T) {
 		"dir3/": nil,
 	}
 	if diff := cmp.Diff(expected, children); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestStat(t *testing.T) {
+	t.Parallel()
+
+	gitCommands := []string{
+		"mkdir dir1",
+		"touch dir1/file1",
+		"git add dir1/file1",
+		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit -m commit1 --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
+	}
+
+	dir := InitGitRepository(t, gitCommands...)
+	repo := api.RepoName(filepath.Base(dir))
+
+	if resp, err := gitserver.DefaultClient.RequestRepoUpdate(context.Background(), repo, 0); err != nil {
+		t.Fatal(err)
+	} else if resp.Error != "" {
+		t.Fatal(resp.Error)
+	}
+
+	commitID := api.CommitID(ComputeCommitHash(dir, true))
+
+	ctx := context.Background()
+
+	checker := authz.NewMockSubRepoPermissionChecker()
+	// Start disabled
+	checker.EnabledFunc.SetDefaultHook(func() bool {
+		return false
+	})
+
+	fileInfo, err := Stat(ctx, checker, repo, commitID, "dir1/file1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "dir1/file1"
+	if diff := cmp.Diff(want, fileInfo.Name()); diff != "" {
+		t.Fatal(diff)
+	}
+
+	// With filtering
+	checker.EnabledFunc.SetDefaultHook(func() bool {
+		return true
+	})
+	checker.PermissionsFunc.SetDefaultHook(func(ctx context.Context, i int32, content authz.RepoContent) (authz.Perms, error) {
+		if strings.HasPrefix(content.Path, "dir2") {
+			return authz.Read, nil
+		}
+		return authz.None, nil
+	})
+	ctx = actor.WithActor(ctx, &actor.Actor{
+		UID: 1,
+	})
+
+	_, err = Stat(ctx, checker, repo, commitID, "dir1/file1")
+	if err == nil {
+		t.Fatal(err)
+	}
+	want = "ls-tree dir1/file1: file does not exist"
+	if diff := cmp.Diff(want, err.Error()); diff != "" {
 		t.Fatal(diff)
 	}
 }


### PR DESCRIPTION
~~I am not really sure about whether initialisation of `authz.DefaultSubRepoPermsChecker` is in the right place.~~

Another thing is that I initially thought to add filtering in `lsTree` function, but later I realised that it can lead to some bugs because `git.Stat` uses first `fs.FileInfo` element out of an array returned from `lsTree` and this can probably be shifted after the filtering is applied. 

And due to the fact that both `git.Stat` and `git.ReadDir` depend on `lsTree`, I decided to open a single PR for both these commands. That's why this PR still contain both commands at once, I hope this is not the problem. If it is, I can separate them after I am back.

**UPD: now this PR is ready for review**

Closes https://github.com/sourcegraph/sourcegraph/issues/28267 and https://github.com/sourcegraph/sourcegraph/issues/28265
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
