### PR TITLE
Fix sg broken release process

### DIFF
--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -14,13 +14,13 @@ env:
   CGO_ENABLED: '1'
 
 jobs:
-  commit_sg:
+  touch_sg:
     name: Touch sourcegraph/sg
     steps:
       - name: checkout-sourcegraph-sg
         uses: actions/checkout@v2
         with: 
-        repository: sourcegraph/sg
+          repository: sourcegraph/sg
       - name: touch-sourcegraph-sg
         run: |
           today=$(date +'%Y-%m-%d-%H-%M')
@@ -31,6 +31,7 @@ jobs:
 
   create_release:
     name: create-github-release
+    needs: touch_sg
     runs-on: ubuntu-latest
     outputs:
       release_name: ${{ steps.release.outputs.release_name }}

--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - devx/fix-sg-releases
     paths:
       - 'dev/sg/**'
       - '.github/workflows/sg-binary-release.yml'
@@ -13,6 +14,21 @@ env:
   CGO_ENABLED: '1'
 
 jobs:
+  commit_sg:
+    name: Touch sourcegraph/sg
+    steps:
+      - name: checkout-sourcegraph-sg
+        uses: actions/checkout@v2
+        with: 
+        repository: sourcegraph/sg
+      - name: touch-sourcegraph-sg
+        run: |
+          today=$(date +'%Y-%m-%d-%H-%M')
+          sed -i 's/Latest release: .*/Latest release: '"$today"'/' README.md 
+          git add README.md
+          git commit -m "Update to latest release"
+          git push
+
   create_release:
     name: create-github-release
     runs-on: ubuntu-latest

--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - name: checkout-sourcegraph-sg
         uses: actions/checkout@v2
+        runs-on: ubuntu-latest
         with: 
           repository: sourcegraph/sg
       - name: touch-sourcegraph-sg

--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v2
         with: 
           repository: sourcegraph/sg
+          token: ${{ secrets.SG_RELEASE_TOKEN }}
       - name: touch-sourcegraph-sg
         run: |
           today=$(date +'%Y-%m-%d-%H-%M')

--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - devx/fix-sg-releases
     paths:
       - 'dev/sg/**'
       - '.github/workflows/sg-binary-release.yml'

--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -16,10 +16,10 @@ env:
 jobs:
   touch_sg:
     name: Touch sourcegraph/sg
+    runs-on: ubuntu-latest
     steps:
       - name: checkout-sourcegraph-sg
         uses: actions/checkout@v2
-        runs-on: ubuntu-latest
         with: 
           repository: sourcegraph/sg
       - name: touch-sourcegraph-sg

--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -26,6 +26,8 @@ jobs:
         run: |
           today=$(date +'%Y-%m-%d-%H-%M')
           sed -i 's/Latest release: .*/Latest release: '"$today"'/' README.md 
+          git config user.name github-actions
+          git config user.email github-actions@github.com
           git add README.md
           git commit -m "Update to latest release"
           git push


### PR DESCRIPTION
Because at some point, when they are too many releases, GitHub stops
making `latest` point at them, the current release process is broken. 
Until I made a commit on the `main` branch, none of the successful GHA
created release were flagged as the latest one, which always caused 
scripts to download a version from 19 days ago, which was the last that 
was successfully marked as latest.

This commit introduces an additional step that commits automatically on
each release in sourcegraph/sg README to make sure we always have a
proper sha1 associated with that release and can always have `latest`
properly updated.

See successful run here: https://github.com/sourcegraph/sourcegraph/runs/4692599347?check_suite_focus=true and its release https://github.com/sourcegraph/sg/releases/tag/2022-01-03-15-30-acc7e848 