### PR TITLE
Remove unused global mock methods

### DIFF
--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -176,10 +176,6 @@ RETURNING user_id
 }
 
 func (s *userExternalAccountsStore) AssociateUserAndSave(ctx context.Context, userID int32, spec extsvc.AccountSpec, data extsvc.AccountData) (err error) {
-	if Mocks.ExternalAccounts.AssociateUserAndSave != nil {
-		return Mocks.ExternalAccounts.AssociateUserAndSave(userID, spec, data)
-	}
-
 	// This "upsert" may cause us to return an ephemeral failure due to a race condition, but it
 	// won't result in inconsistent data.  Wrap in transaction.
 
@@ -495,13 +491,12 @@ func (s *userExternalAccountsStore) listSQL(opt ExternalAccountsListOptions) (co
 
 // MockExternalAccounts mocks the Stores.ExternalAccounts DB store.
 type MockExternalAccounts struct {
-	AssociateUserAndSave func(userID int32, spec extsvc.AccountSpec, data extsvc.AccountData) error
-	CreateUserAndSave    func(NewUser, extsvc.AccountSpec, extsvc.AccountData) (createdUserID int32, err error)
-	Delete               func(id int32) error
-	List                 func(ExternalAccountsListOptions) ([]*extsvc.Account, error)
-	Count                func(ExternalAccountsListOptions) (int, error)
-	TouchExpired         func(ctx context.Context, id int32) error
-	TouchLastValid       func(ctx context.Context, id int32) error
+	CreateUserAndSave func(NewUser, extsvc.AccountSpec, extsvc.AccountData) (createdUserID int32, err error)
+	Delete            func(id int32) error
+	List              func(ExternalAccountsListOptions) ([]*extsvc.Account, error)
+	Count             func(ExternalAccountsListOptions) (int, error)
+	TouchExpired      func(ctx context.Context, id int32) error
+	TouchLastValid    func(ctx context.Context, id int32) error
 }
 
 // MaybeEncrypt encrypts data with the given key returns the id of the key. If the key is nil, it returns the data unchanged.

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -133,10 +133,6 @@ func (s *userExternalAccountsStore) Get(ctx context.Context, id int32) (*extsvc.
 }
 
 func (s *userExternalAccountsStore) LookupUserAndSave(ctx context.Context, spec extsvc.AccountSpec, data extsvc.AccountData) (userID int32, err error) {
-	if Mocks.ExternalAccounts.LookupUserAndSave != nil {
-		return Mocks.ExternalAccounts.LookupUserAndSave(spec, data)
-	}
-
 	var (
 		encrypted, keyID string
 	)
@@ -499,7 +495,6 @@ func (s *userExternalAccountsStore) listSQL(opt ExternalAccountsListOptions) (co
 
 // MockExternalAccounts mocks the Stores.ExternalAccounts DB store.
 type MockExternalAccounts struct {
-	LookupUserAndSave    func(extsvc.AccountSpec, extsvc.AccountData) (userID int32, err error)
 	AssociateUserAndSave func(userID int32, spec extsvc.AccountSpec, data extsvc.AccountData) error
 	CreateUserAndSave    func(NewUser, extsvc.AccountSpec, extsvc.AccountData) (createdUserID int32, err error)
 	Delete               func(id int32) error

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -129,9 +129,6 @@ func (s *userExternalAccountsStore) getEncryptionKey() encryption.Key {
 }
 
 func (s *userExternalAccountsStore) Get(ctx context.Context, id int32) (*extsvc.Account, error) {
-	if Mocks.ExternalAccounts.Get != nil {
-		return Mocks.ExternalAccounts.Get(id)
-	}
 	return s.getBySQL(ctx, sqlf.Sprintf("WHERE id=%d AND deleted_at IS NULL LIMIT 1", id))
 }
 
@@ -502,7 +499,6 @@ func (s *userExternalAccountsStore) listSQL(opt ExternalAccountsListOptions) (co
 
 // MockExternalAccounts mocks the Stores.ExternalAccounts DB store.
 type MockExternalAccounts struct {
-	Get                  func(id int32) (*extsvc.Account, error)
 	LookupUserAndSave    func(extsvc.AccountSpec, extsvc.AccountData) (userID int32, err error)
 	AssociateUserAndSave func(userID int32, spec extsvc.AccountSpec, data extsvc.AccountData) error
 	CreateUserAndSave    func(NewUser, extsvc.AccountSpec, extsvc.AccountData) (createdUserID int32, err error)

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -264,10 +264,6 @@ AND deleted_at IS NULL
 }
 
 func (s *userExternalAccountsStore) CreateUserAndSave(ctx context.Context, newUser NewUser, spec extsvc.AccountSpec, data extsvc.AccountData) (createdUserID int32, err error) {
-	if Mocks.ExternalAccounts.CreateUserAndSave != nil {
-		return Mocks.ExternalAccounts.CreateUserAndSave(newUser, spec, data)
-	}
-
 	tx, err := s.Transact(ctx)
 	if err != nil {
 		return 0, err
@@ -491,12 +487,11 @@ func (s *userExternalAccountsStore) listSQL(opt ExternalAccountsListOptions) (co
 
 // MockExternalAccounts mocks the Stores.ExternalAccounts DB store.
 type MockExternalAccounts struct {
-	CreateUserAndSave func(NewUser, extsvc.AccountSpec, extsvc.AccountData) (createdUserID int32, err error)
-	Delete            func(id int32) error
-	List              func(ExternalAccountsListOptions) ([]*extsvc.Account, error)
-	Count             func(ExternalAccountsListOptions) (int, error)
-	TouchExpired      func(ctx context.Context, id int32) error
-	TouchLastValid    func(ctx context.Context, id int32) error
+	Delete         func(id int32) error
+	List           func(ExternalAccountsListOptions) ([]*extsvc.Account, error)
+	Count          func(ExternalAccountsListOptions) (int, error)
+	TouchExpired   func(ctx context.Context, id int32) error
+	TouchLastValid func(ctx context.Context, id int32) error
 }
 
 // MaybeEncrypt encrypts data with the given key returns the id of the key. If the key is nil, it returns the data unchanged.

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -341,10 +341,6 @@ WHERE id = $1
 }
 
 func (s *userExternalAccountsStore) Delete(ctx context.Context, id int32) error {
-	if Mocks.ExternalAccounts.Delete != nil {
-		return Mocks.ExternalAccounts.Delete(id)
-	}
-
 	res, err := s.Handle().DB().ExecContext(ctx, "UPDATE user_external_accounts SET deleted_at=now() WHERE id=$1 AND deleted_at IS NULL", id)
 	if err != nil {
 		return err
@@ -487,7 +483,6 @@ func (s *userExternalAccountsStore) listSQL(opt ExternalAccountsListOptions) (co
 
 // MockExternalAccounts mocks the Stores.ExternalAccounts DB store.
 type MockExternalAccounts struct {
-	Delete         func(id int32) error
 	List           func(ExternalAccountsListOptions) ([]*extsvc.Account, error)
 	Count          func(ExternalAccountsListOptions) (int, error)
 	TouchExpired   func(ctx context.Context, id int32) error

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -365,10 +365,6 @@ type ExternalAccountsListOptions struct {
 }
 
 func (s *userExternalAccountsStore) List(ctx context.Context, opt ExternalAccountsListOptions) (acct []*extsvc.Account, err error) {
-	if Mocks.ExternalAccounts.List != nil {
-		return Mocks.ExternalAccounts.List(opt)
-	}
-
 	tr, ctx := trace.New(ctx, "UserExternalAccountsStore.List", "")
 	defer func() {
 		if err != nil {
@@ -483,7 +479,6 @@ func (s *userExternalAccountsStore) listSQL(opt ExternalAccountsListOptions) (co
 
 // MockExternalAccounts mocks the Stores.ExternalAccounts DB store.
 type MockExternalAccounts struct {
-	List           func(ExternalAccountsListOptions) ([]*extsvc.Account, error)
 	Count          func(ExternalAccountsListOptions) (int, error)
 	TouchExpired   func(ctx context.Context, id int32) error
 	TouchLastValid func(ctx context.Context, id int32) error

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -384,10 +384,6 @@ func (s *userExternalAccountsStore) List(ctx context.Context, opt ExternalAccoun
 }
 
 func (s *userExternalAccountsStore) Count(ctx context.Context, opt ExternalAccountsListOptions) (int, error) {
-	if Mocks.ExternalAccounts.Count != nil {
-		return Mocks.ExternalAccounts.Count(opt)
-	}
-
 	conds := s.listSQL(opt)
 	q := sqlf.Sprintf("SELECT COUNT(*) FROM user_external_accounts WHERE %s", sqlf.Join(conds, "AND"))
 	var count int
@@ -479,7 +475,6 @@ func (s *userExternalAccountsStore) listSQL(opt ExternalAccountsListOptions) (co
 
 // MockExternalAccounts mocks the Stores.ExternalAccounts DB store.
 type MockExternalAccounts struct {
-	Count          func(ExternalAccountsListOptions) (int, error)
 	TouchExpired   func(ctx context.Context, id int32) error
 	TouchLastValid func(ctx context.Context, id int32) error
 }

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -968,10 +968,6 @@ type ExternalServiceUpdate struct {
 }
 
 func (e *externalServiceStore) Update(ctx context.Context, ps []schema.AuthProviders, id int64, update *ExternalServiceUpdate) (err error) {
-	if Mocks.ExternalServices.Update != nil {
-		return Mocks.ExternalServices.Update(ctx, ps, id, update)
-	}
-
 	var (
 		normalized  []byte
 		keyID       string
@@ -1491,7 +1487,6 @@ type MockExternalServices struct {
 	Create         func(ctx context.Context, confGet func() *conf.Unified, externalService *types.ExternalService) error
 	ListSyncErrors func(ctx context.Context) (map[int64]string, error)
 	List           func(opt ExternalServicesListOptions) ([]*types.ExternalService, error)
-	Update         func(ctx context.Context, ps []schema.AuthProviders, id int64, update *ExternalServiceUpdate) error
 	Count          func(ctx context.Context, opt ExternalServicesListOptions) (int, error)
 	Upsert         func(ctx context.Context, services ...*types.ExternalService) error
 	Transact       func(ctx context.Context) (ExternalServiceStore, error)

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -1090,10 +1090,6 @@ func (e externalServiceNotFoundError) NotFound() bool {
 }
 
 func (e *externalServiceStore) Delete(ctx context.Context, id int64) (err error) {
-	if Mocks.ExternalServices.Delete != nil {
-		return Mocks.ExternalServices.Delete(ctx, id)
-	}
-
 	tx, err := e.transact(ctx)
 	if err != nil {
 		return err
@@ -1501,7 +1497,6 @@ func configurationHasWebhooks(config interface{}) bool {
 // MockExternalServices mocks the external services store.
 type MockExternalServices struct {
 	Create           func(ctx context.Context, confGet func() *conf.Unified, externalService *types.ExternalService) error
-	Delete           func(ctx context.Context, id int64) error
 	GetByID          func(id int64) (*types.ExternalService, error)
 	GetLastSyncError func(id int64) (string, error)
 	ListSyncErrors   func(ctx context.Context) (map[int64]string, error)

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -1214,10 +1214,6 @@ FROM external_service_sync_jobs ORDER BY started_at desc
 }
 
 func (e *externalServiceStore) GetLastSyncError(ctx context.Context, id int64) (string, error) {
-	if Mocks.ExternalServices.GetLastSyncError != nil {
-		return Mocks.ExternalServices.GetLastSyncError(id)
-	}
-
 	q := sqlf.Sprintf(`
 SELECT failure_message from external_service_sync_jobs
 WHERE external_service_id = %d
@@ -1492,13 +1488,12 @@ func configurationHasWebhooks(config interface{}) bool {
 
 // MockExternalServices mocks the external services store.
 type MockExternalServices struct {
-	Create           func(ctx context.Context, confGet func() *conf.Unified, externalService *types.ExternalService) error
-	GetLastSyncError func(id int64) (string, error)
-	ListSyncErrors   func(ctx context.Context) (map[int64]string, error)
-	List             func(opt ExternalServicesListOptions) ([]*types.ExternalService, error)
-	Update           func(ctx context.Context, ps []schema.AuthProviders, id int64, update *ExternalServiceUpdate) error
-	Count            func(ctx context.Context, opt ExternalServicesListOptions) (int, error)
-	Upsert           func(ctx context.Context, services ...*types.ExternalService) error
-	Transact         func(ctx context.Context) (ExternalServiceStore, error)
-	Done             func(error) error
+	Create         func(ctx context.Context, confGet func() *conf.Unified, externalService *types.ExternalService) error
+	ListSyncErrors func(ctx context.Context) (map[int64]string, error)
+	List           func(opt ExternalServicesListOptions) ([]*types.ExternalService, error)
+	Update         func(ctx context.Context, ps []schema.AuthProviders, id int64, update *ExternalServiceUpdate) error
+	Count          func(ctx context.Context, opt ExternalServicesListOptions) (int, error)
+	Upsert         func(ctx context.Context, services ...*types.ExternalService) error
+	Transact       func(ctx context.Context) (ExternalServiceStore, error)
+	Done           func(error) error
 }

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -1164,10 +1164,6 @@ CREATE TEMPORARY TABLE IF NOT EXISTS
 }
 
 func (e *externalServiceStore) GetByID(ctx context.Context, id int64) (*types.ExternalService, error) {
-	if Mocks.ExternalServices.GetByID != nil {
-		return Mocks.ExternalServices.GetByID(id)
-	}
-
 	opt := ExternalServicesListOptions{
 		IDs: []int64{id},
 	}
@@ -1497,7 +1493,6 @@ func configurationHasWebhooks(config interface{}) bool {
 // MockExternalServices mocks the external services store.
 type MockExternalServices struct {
 	Create           func(ctx context.Context, confGet func() *conf.Unified, externalService *types.ExternalService) error
-	GetByID          func(id int64) (*types.ExternalService, error)
 	GetLastSyncError func(id int64) (string, error)
 	ListSyncErrors   func(ctx context.Context) (map[int64]string, error)
 	List             func(opt ExternalServicesListOptions) ([]*types.ExternalService, error)

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -262,10 +262,6 @@ func (s *repoStore) GetByHashedName(ctx context.Context, repoHashedName api.Repo
 // GetByIDs returns a list of repositories by given IDs. The number of results list could be less
 // than the candidate list due to no repository is associated with some IDs.
 func (s *repoStore) GetByIDs(ctx context.Context, ids ...api.RepoID) (_ []*types.Repo, err error) {
-	if Mocks.Repos.GetByIDs != nil {
-		return Mocks.Repos.GetByIDs(ctx, ids...)
-	}
-
 	tr, ctx := trace.New(ctx, "repos.GetByIDs", "")
 	defer func() {
 		tr.SetError(err)

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -288,10 +288,6 @@ func (s *repoStore) GetReposSetByIDs(ctx context.Context, ids ...api.RepoID) (ma
 }
 
 func (s *repoStore) Count(ctx context.Context, opt ReposListOptions) (ct int, err error) {
-	if Mocks.Repos.Count != nil {
-		return Mocks.Repos.Count(ctx, opt)
-	}
-
 	tr, ctx := trace.New(ctx, "repos.Count", "")
 	defer func() {
 		if err != nil {
@@ -1535,10 +1531,6 @@ LIMIT 1
 // match the given clone url. If not repo is found, an empty string and nil error
 // are returned.
 func (s *repoStore) GetFirstRepoNamesByCloneURL(ctx context.Context, cloneURL string) (api.RepoName, error) {
-	if Mocks.Repos.GetFirstRepoNamesByCloneURL != nil {
-		return Mocks.Repos.GetFirstRepoNamesByCloneURL(ctx, cloneURL)
-	}
-
 	name, _, err := basestore.ScanFirstString(s.Query(ctx, sqlf.Sprintf(getFirstRepoNamesByCloneURLQueryFmtstr, cloneURL)))
 	if err != nil {
 		return "", err

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -310,6 +310,10 @@ func (s *repoStore) Count(ctx context.Context, opt ReposListOptions) (ct int, er
 // Metadata returns repo metadata used to decorate search results. The returned slice may be smaller than the
 // number of IDs given if a repo with the given ID does not exist.
 func (s *repoStore) Metadata(ctx context.Context, ids ...api.RepoID) (_ []*types.SearchedRepo, err error) {
+	if Mocks.Repos.Metadata != nil {
+		return Mocks.Repos.Metadata(ctx, ids...)
+	}
+
 	tr, ctx := trace.New(ctx, "repos.Metadata", "")
 	defer func() {
 		tr.SetError(err)

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -195,10 +195,6 @@ func logPrivateRepoAccessGranted(ctx context.Context, db dbutil.DB, ids []api.Re
 //
 // When a repo isn't found or has been blocked, an error is returned.
 func (s *repoStore) GetByName(ctx context.Context, nameOrURI api.RepoName) (_ *types.Repo, err error) {
-	if Mocks.Repos.GetByName != nil {
-		return Mocks.Repos.GetByName(ctx, nameOrURI)
-	}
-
 	tr, ctx := trace.New(ctx, "repos.GetByName", "")
 	defer func() {
 		tr.SetError(err)
@@ -326,10 +322,6 @@ func (s *repoStore) Count(ctx context.Context, opt ReposListOptions) (ct int, er
 // Metadata returns repo metadata used to decorate search results. The returned slice may be smaller than the
 // number of IDs given if a repo with the given ID does not exist.
 func (s *repoStore) Metadata(ctx context.Context, ids ...api.RepoID) (_ []*types.SearchedRepo, err error) {
-	if Mocks.Repos.Metadata != nil {
-		return Mocks.Repos.Metadata(ctx, ids...)
-	}
-
 	tr, ctx := trace.New(ctx, "repos.Metadata", "")
 	defer func() {
 		tr.SetError(err)

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -237,10 +237,6 @@ func (s *repoStore) GetByName(ctx context.Context, nameOrURI api.RepoName) (_ *t
 // RepoHashedName is the repository hashed name.
 // When a repo isn't found or has been blocked, an error is returned.
 func (s *repoStore) GetByHashedName(ctx context.Context, repoHashedName api.RepoHashedName) (_ *types.Repo, err error) {
-	if Mocks.Repos.GetByHashedName != nil {
-		return Mocks.Repos.GetByHashedName(ctx, repoHashedName)
-	}
-
 	tr, ctx := trace.New(ctx, "repos.GetByHashedName", "")
 	defer func() {
 		tr.SetError(err)

--- a/internal/database/repos_mock.go
+++ b/internal/database/repos_mock.go
@@ -9,7 +9,6 @@ import (
 
 type MockRepos struct {
 	Get                         func(ctx context.Context, repo api.RepoID) (*types.Repo, error)
-	GetByIDs                    func(ctx context.Context, ids ...api.RepoID) ([]*types.Repo, error)
 	List                        func(v0 context.Context, v1 ReposListOptions) ([]*types.Repo, error)
 	ListMinimalRepos            func(v0 context.Context, v1 ReposListOptions) ([]types.MinimalRepo, error)
 	Metadata                    func(ctx context.Context, ids ...api.RepoID) ([]*types.SearchedRepo, error)

--- a/internal/database/repos_mock.go
+++ b/internal/database/repos_mock.go
@@ -9,7 +9,6 @@ import (
 
 type MockRepos struct {
 	Get                         func(ctx context.Context, repo api.RepoID) (*types.Repo, error)
-	GetByName                   func(ctx context.Context, repo api.RepoName) (*types.Repo, error)
 	GetByHashedName             func(ctx context.Context, repo api.RepoHashedName) (*types.Repo, error) // TODO:
 	GetByIDs                    func(ctx context.Context, ids ...api.RepoID) ([]*types.Repo, error)
 	List                        func(v0 context.Context, v1 ReposListOptions) ([]*types.Repo, error)

--- a/internal/database/repos_mock.go
+++ b/internal/database/repos_mock.go
@@ -9,7 +9,6 @@ import (
 
 type MockRepos struct {
 	Get                         func(ctx context.Context, repo api.RepoID) (*types.Repo, error)
-	GetByHashedName             func(ctx context.Context, repo api.RepoHashedName) (*types.Repo, error) // TODO:
 	GetByIDs                    func(ctx context.Context, ids ...api.RepoID) ([]*types.Repo, error)
 	List                        func(v0 context.Context, v1 ReposListOptions) ([]*types.Repo, error)
 	ListMinimalRepos            func(v0 context.Context, v1 ReposListOptions) ([]types.MinimalRepo, error)

--- a/internal/database/repos_mock.go
+++ b/internal/database/repos_mock.go
@@ -2,8 +2,6 @@ package database
 
 import (
 	"context"
-	"testing"
-	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -24,69 +22,4 @@ type MockRepos struct {
 	// TODO: we're knowingly taking on a little tech debt by placing these here for now.
 	ListExternalServiceUserIDsByRepoID func(ctx context.Context, repoID api.RepoID) ([]int32, error)
 	ListExternalServiceRepoIDsByUserID func(ctx context.Context, userID int32) ([]api.RepoID, error)
-}
-
-func (s *MockRepos) MockGet(t *testing.T, wantRepo api.RepoID) (called *bool) {
-	called = new(bool)
-	s.Get = func(ctx context.Context, repo api.RepoID) (*types.Repo, error) {
-		*called = true
-		if repo != wantRepo {
-			t.Errorf("got repo %d, want %d", repo, wantRepo)
-			return nil, &RepoNotFoundErr{ID: repo}
-		}
-		return &types.Repo{ID: repo}, nil
-	}
-	return
-}
-
-func (s *MockRepos) MockGet_Return(t *testing.T, returns *types.Repo) (called *bool) {
-	called = new(bool)
-	s.Get = func(ctx context.Context, repo api.RepoID) (*types.Repo, error) {
-		*called = true
-		if repo != returns.ID {
-			t.Errorf("got repo %d, want %d", repo, returns.ID)
-			return nil, &RepoNotFoundErr{ID: repo}
-		}
-		return returns, nil
-	}
-	return
-}
-
-func (s *MockRepos) MockGetByName(t testing.TB, want api.RepoName, repo api.RepoID) (called *bool) {
-	called = new(bool)
-	s.GetByName = func(ctx context.Context, name api.RepoName) (*types.Repo, error) {
-		*called = true
-		if name != want {
-			t.Errorf("got repo name %q, want %q", name, want)
-			return nil, &RepoNotFoundErr{Name: name}
-		}
-		return &types.Repo{ID: repo, Name: name, CreatedAt: time.Now()}, nil
-	}
-	return
-}
-
-func (s *MockRepos) MockList(t testing.TB, wantRepos ...api.RepoName) (called *bool) {
-	called = new(bool)
-	s.List = func(ctx context.Context, opt ReposListOptions) ([]*types.Repo, error) {
-		*called = true
-		repos := make([]*types.Repo, len(wantRepos))
-		for i, repo := range wantRepos {
-			repos[i] = &types.Repo{Name: repo}
-		}
-		return repos, nil
-	}
-	return
-}
-
-func (s *MockRepos) MockListMinimalRepos(t testing.TB, wantRepos ...api.RepoName) (called *bool) {
-	called = new(bool)
-	s.ListMinimalRepos = func(ctx context.Context, opt ReposListOptions) ([]types.MinimalRepo, error) {
-		*called = true
-		repos := make([]types.MinimalRepo, len(wantRepos))
-		for i, repo := range wantRepos {
-			repos[i] = types.MinimalRepo{Name: repo}
-		}
-		return repos, nil
-	}
-	return
 }

--- a/internal/database/repos_mock.go
+++ b/internal/database/repos_mock.go
@@ -12,7 +12,6 @@ type MockRepos struct {
 	List                        func(v0 context.Context, v1 ReposListOptions) ([]*types.Repo, error)
 	ListMinimalRepos            func(v0 context.Context, v1 ReposListOptions) ([]types.MinimalRepo, error)
 	Metadata                    func(ctx context.Context, ids ...api.RepoID) ([]*types.SearchedRepo, error)
-	Create                      func(ctx context.Context, repos ...*types.Repo) (err error)
 	Count                       func(ctx context.Context, opt ReposListOptions) (int, error)
 	GetFirstRepoNamesByCloneURL func(ctx context.Context, cloneURL string) (api.RepoName, error)
 

--- a/internal/database/repos_mock.go
+++ b/internal/database/repos_mock.go
@@ -8,11 +8,10 @@ import (
 )
 
 type MockRepos struct {
-	Get                         func(ctx context.Context, repo api.RepoID) (*types.Repo, error)
-	List                        func(v0 context.Context, v1 ReposListOptions) ([]*types.Repo, error)
-	ListMinimalRepos            func(v0 context.Context, v1 ReposListOptions) ([]types.MinimalRepo, error)
-	Metadata                    func(ctx context.Context, ids ...api.RepoID) ([]*types.SearchedRepo, error)
-	GetFirstRepoNamesByCloneURL func(ctx context.Context, cloneURL string) (api.RepoName, error)
+	Get              func(ctx context.Context, repo api.RepoID) (*types.Repo, error)
+	List             func(v0 context.Context, v1 ReposListOptions) ([]*types.Repo, error)
+	ListMinimalRepos func(v0 context.Context, v1 ReposListOptions) ([]types.MinimalRepo, error)
+	Metadata         func(ctx context.Context, ids ...api.RepoID) ([]*types.SearchedRepo, error)
 
 	// TODO: we're knowingly taking on a little tech debt by placing these here for now.
 	ListExternalServiceUserIDsByRepoID func(ctx context.Context, repoID api.RepoID) ([]int32, error)

--- a/internal/database/repos_mock.go
+++ b/internal/database/repos_mock.go
@@ -12,7 +12,6 @@ type MockRepos struct {
 	List                        func(v0 context.Context, v1 ReposListOptions) ([]*types.Repo, error)
 	ListMinimalRepos            func(v0 context.Context, v1 ReposListOptions) ([]types.MinimalRepo, error)
 	Metadata                    func(ctx context.Context, ids ...api.RepoID) ([]*types.SearchedRepo, error)
-	Count                       func(ctx context.Context, opt ReposListOptions) (int, error)
 	GetFirstRepoNamesByCloneURL func(ctx context.Context, cloneURL string) (api.RepoName, error)
 
 	// TODO: we're knowingly taking on a little tech debt by placing these here for now.

--- a/internal/database/sub_repo_perms_store.go
+++ b/internal/database/sub_repo_perms_store.go
@@ -62,19 +62,11 @@ func (s *subRepoPermsStore) With(other basestore.ShareableStore) SubRepoPermsSto
 
 // Transact begins a new transaction and make a new SubRepoPermsStore over it.
 func (s *subRepoPermsStore) Transact(ctx context.Context) (SubRepoPermsStore, error) {
-	if Mocks.SubRepoPerms.Transact != nil {
-		return Mocks.SubRepoPerms.Transact(ctx)
-	}
-
 	txBase, err := s.Store.Transact(ctx)
 	return &subRepoPermsStore{Store: txBase}, err
 }
 
 func (s *subRepoPermsStore) Done(err error) error {
-	if Mocks.SubRepoPerms.Transact != nil {
-		return err
-	}
-
 	return s.Store.Done(err)
 }
 
@@ -191,6 +183,5 @@ WHERE user_id = %s
 }
 
 type MockSubRepoPerms struct {
-	Transact       func(ctx context.Context) (*subRepoPermsStore, error)
 	UpsertWithSpec func(ctx context.Context, userID int32, spec api.ExternalRepoSpec, perms authz.SubRepoPermissions) error
 }

--- a/internal/database/user_emails.go
+++ b/internal/database/user_emails.go
@@ -277,10 +277,6 @@ LIMIT 1
 // GetVerifiedEmails returns a list of verified emails from the candidate list. Some emails are excluded
 // from the results list because of unverified or simply don't exist.
 func (s *userEmailsStore) GetVerifiedEmails(ctx context.Context, emails ...string) ([]*UserEmail, error) {
-	if Mocks.UserEmails.GetVerifiedEmails != nil {
-		return Mocks.UserEmails.GetVerifiedEmails(ctx, emails...)
-	}
-
 	if len(emails) == 0 {
 		return []*UserEmail{}, nil
 	}

--- a/internal/database/user_emails_mock.go
+++ b/internal/database/user_emails_mock.go
@@ -5,6 +5,5 @@ import (
 )
 
 type MockUserEmails struct {
-	GetVerifiedEmails func(ctx context.Context, emails ...string) ([]*UserEmail, error)
-	ListByUser        func(ctx context.Context, opt UserEmailsListOptions) ([]*UserEmail, error)
+	ListByUser func(ctx context.Context, opt UserEmailsListOptions) ([]*UserEmail, error)
 }

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -1160,10 +1160,6 @@ func (u *userStore) SetTag(ctx context.Context, userID int32, tag string, presen
 // HasTag reports whether the context actor has the given tag.
 // If not, it returns false and a nil error.
 func (u *userStore) HasTag(ctx context.Context, userID int32, tag string) (bool, error) {
-	if Mocks.Users.HasTag != nil {
-		return Mocks.Users.HasTag(ctx, userID, tag)
-	}
-
 	var tags []string
 	err := u.QueryRow(ctx, sqlf.Sprintf("SELECT tags FROM users WHERE id = %s", userID)).Scan(pq.Array(&tags))
 	if err != nil {

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -656,10 +656,6 @@ func (u *userStore) SetIsSiteAdmin(ctx context.Context, id int32, isSiteAdmin bo
 // invited too many users, or some other error occurred). If the user has
 // quota remaining, their quota is decremented and ok is true.
 func (u *userStore) CheckAndDecrementInviteQuota(ctx context.Context, userID int32) (ok bool, err error) {
-	if Mocks.Users.CheckAndDecrementInviteQuota != nil {
-		return Mocks.Users.CheckAndDecrementInviteQuota(ctx, userID)
-	}
-
 	var quotaRemaining int32
 	q := sqlf.Sprintf(`
 	UPDATE users SET invite_quota=(invite_quota - 1)

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -911,9 +911,6 @@ var (
 )
 
 func (u *userStore) RenewPasswordResetCode(ctx context.Context, id int32) (string, error) {
-	if Mocks.Users.RenewPasswordResetCode != nil {
-		return Mocks.Users.RenewPasswordResetCode(ctx, id)
-	}
 	if _, err := u.GetByID(ctx, id); err != nil {
 		return "", err
 	}
@@ -1061,10 +1058,6 @@ WHERE id=%s
 // A randomized password is used (instead of an empty password) to avoid bugs where an empty password
 // is considered to be no password. The random password is expected to be irretrievable.
 func (u *userStore) RandomizePasswordAndClearPasswordResetRateLimit(ctx context.Context, id int32) error {
-	if Mocks.Users.RandomizePasswordAndClearPasswordResetRateLimit != nil {
-		return Mocks.Users.RandomizePasswordAndClearPasswordResetRateLimit(ctx, id)
-	}
-
 	passwd, err := hashPassword(randstring.NewLen(36))
 	if err != nil {
 		return err

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -208,10 +208,6 @@ type NewUser struct {
 // order to avoid a race condition where multiple initial site admins could be created or zero site
 // admins could be created.
 func (u *userStore) Create(ctx context.Context, info NewUser) (newUser *types.User, err error) {
-	if Mocks.Users.Create != nil {
-		return Mocks.Users.Create(ctx, info)
-	}
-
 	tx, err := u.Transact(ctx)
 	if err != nil {
 		return nil, err
@@ -246,10 +242,6 @@ func CheckPasswordLength(pw string) error {
 // transaction. It must execute in a transaction because the post-user-creation
 // hooks must run atomically with the user creation.
 func (u *userStore) CreateInTransaction(ctx context.Context, info NewUser) (newUser *types.User, err error) {
-	if Mocks.Users.Create != nil {
-		return Mocks.Users.Create(ctx, info)
-	}
-
 	if !u.InTransaction() {
 		return nil, errors.New("must run within a transaction")
 	}

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -640,10 +640,6 @@ func logUserDeletionEvent(ctx context.Context, db dbutil.DB, id int32, name Secu
 
 // SetIsSiteAdmin sets the user with the given ID to be or not to be the site admin.
 func (u *userStore) SetIsSiteAdmin(ctx context.Context, id int32, isSiteAdmin bool) error {
-	if Mocks.Users.SetIsSiteAdmin != nil {
-		return Mocks.Users.SetIsSiteAdmin(id, isSiteAdmin)
-	}
-
 	if BeforeSetUserIsSiteAdmin != nil {
 		if err := BeforeSetUserIsSiteAdmin(isSiteAdmin); err != nil {
 			return err

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -445,10 +445,6 @@ type UserUpdate struct {
 
 // Update updates a user's profile information.
 func (u *userStore) Update(ctx context.Context, id int32, update UserUpdate) (err error) {
-	if Mocks.Users.Update != nil {
-		return Mocks.Users.Update(id, update)
-	}
-
 	tx, err := u.Transact(ctx)
 	if err != nil {
 		return err

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -786,10 +786,6 @@ type UsersListOptions struct {
 }
 
 func (u *userStore) List(ctx context.Context, opt *UsersListOptions) (_ []*types.User, err error) {
-	if Mocks.Users.List != nil {
-		return Mocks.Users.List(ctx, opt)
-	}
-
 	tr, ctx := trace.New(ctx, "database.Users.List", fmt.Sprintf("%+v", opt))
 	defer func() {
 		tr.SetError(err)

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -502,10 +502,6 @@ func (u *userStore) Update(ctx context.Context, id int32, update UserUpdate) (er
 
 // Delete performs a soft-delete of the user and all resources associated with this user.
 func (u *userStore) Delete(ctx context.Context, id int32) (err error) {
-	if Mocks.Users.Delete != nil {
-		return Mocks.Users.Delete(ctx, id)
-	}
-
 	tx, err := u.Transact(ctx)
 	if err != nil {
 		return err

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -547,10 +547,6 @@ func (u *userStore) Delete(ctx context.Context, id int32) (err error) {
 
 // HardDelete removes the user and all resources associated with this user.
 func (u *userStore) HardDelete(ctx context.Context, id int32) (err error) {
-	if Mocks.Users.HardDelete != nil {
-		return Mocks.Users.HardDelete(ctx, id)
-	}
-
 	// Wrap in transaction because we delete from multiple tables.
 	tx, err := u.Transact(ctx)
 	if err != nil {

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -683,9 +683,6 @@ func (u *userStore) GetByID(ctx context.Context, id int32) (*types.User, error) 
 // has a matching *unverified* email address, they will not be returned by this method. At most one
 // user may have any given verified email address.
 func (u *userStore) GetByVerifiedEmail(ctx context.Context, email string) (*types.User, error) {
-	if Mocks.Users.GetByVerifiedEmail != nil {
-		return Mocks.Users.GetByVerifiedEmail(ctx, email)
-	}
 	return u.getOneBySQL(ctx, sqlf.Sprintf("WHERE id=(SELECT user_id FROM user_emails WHERE email=%s AND verified_at IS NOT NULL) AND deleted_at IS NULL LIMIT 1", email))
 }
 
@@ -699,10 +696,6 @@ func (u *userStore) GetByUsername(ctx context.Context, username string) (*types.
 // GetByUsernames returns a list of users by given usernames. The number of results list could be less
 // than the candidate list due to no user is associated with some usernames.
 func (u *userStore) GetByUsernames(ctx context.Context, usernames ...string) ([]*types.User, error) {
-	if Mocks.Users.GetByUsernames != nil {
-		return Mocks.Users.GetByUsernames(ctx, usernames...)
-	}
-
 	if len(usernames) == 0 {
 		return []*types.User{}, nil
 	}

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -1179,10 +1179,6 @@ func (u *userStore) HasTag(ctx context.Context, userID int32, tag string) (bool,
 
 // Tags returns a map with all the tags currently belonging to the user.
 func (u *userStore) Tags(ctx context.Context, userID int32) (map[string]bool, error) {
-	if Mocks.Users.Tags != nil {
-		return Mocks.Users.Tags(ctx, userID)
-	}
-
 	var tags []string
 	err := u.QueryRow(ctx, sqlf.Sprintf("SELECT tags FROM users WHERE id = %s", userID)).Scan(pq.Array(&tags))
 	if err != nil {

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -724,10 +724,6 @@ func (u *userStore) GetByCurrentAuthUser(ctx context.Context) (*types.User, erro
 }
 
 func (u *userStore) InvalidateSessionsByID(ctx context.Context, id int32) (err error) {
-	if Mocks.Users.InvalidateSessionsByID != nil {
-		return Mocks.Users.InvalidateSessionsByID(ctx, id)
-	}
-
 	tx, err := u.Transact(ctx)
 	if err != nil {
 		return err

--- a/internal/database/users_mock.go
+++ b/internal/database/users_mock.go
@@ -8,7 +8,6 @@ import (
 )
 
 type MockUsers struct {
-	CheckAndDecrementInviteQuota                    func(ctx context.Context, userID int32) (bool, error)
 	GetByID                                         func(ctx context.Context, id int32) (*types.User, error)
 	GetByUsername                                   func(ctx context.Context, username string) (*types.User, error)
 	GetByUsernames                                  func(ctx context.Context, usernames ...string) ([]*types.User, error)

--- a/internal/database/users_mock.go
+++ b/internal/database/users_mock.go
@@ -12,7 +12,6 @@ type MockUsers struct {
 	GetByUsername                                   func(ctx context.Context, username string) (*types.User, error)
 	GetByCurrentAuthUser                            func(ctx context.Context) (*types.User, error)
 	Count                                           func(ctx context.Context, opt *UsersListOptions) (int, error)
-	Tags                                            func(ctx context.Context, userID int32) (map[string]bool, error)
 	RandomizePasswordAndClearPasswordResetRateLimit func(ctx context.Context, userID int32) error
 	RenewPasswordResetCode                          func(ctx context.Context, id int32) (string, error)
 }

--- a/internal/database/users_mock.go
+++ b/internal/database/users_mock.go
@@ -8,7 +8,6 @@ import (
 )
 
 type MockUsers struct {
-	HardDelete                                      func(ctx context.Context, id int32) error
 	SetIsSiteAdmin                                  func(id int32, isSiteAdmin bool) error
 	SetTosAccepted                                  func(id int32) error
 	CheckAndDecrementInviteQuota                    func(ctx context.Context, userID int32) (bool, error)

--- a/internal/database/users_mock.go
+++ b/internal/database/users_mock.go
@@ -8,12 +8,11 @@ import (
 )
 
 type MockUsers struct {
-	GetByID                                         func(ctx context.Context, id int32) (*types.User, error)
-	GetByUsername                                   func(ctx context.Context, username string) (*types.User, error)
-	GetByCurrentAuthUser                            func(ctx context.Context) (*types.User, error)
-	Count                                           func(ctx context.Context, opt *UsersListOptions) (int, error)
-	RandomizePasswordAndClearPasswordResetRateLimit func(ctx context.Context, userID int32) error
-	RenewPasswordResetCode                          func(ctx context.Context, id int32) (string, error)
+	GetByID                func(ctx context.Context, id int32) (*types.User, error)
+	GetByUsername          func(ctx context.Context, username string) (*types.User, error)
+	GetByCurrentAuthUser   func(ctx context.Context) (*types.User, error)
+	Count                  func(ctx context.Context, opt *UsersListOptions) (int, error)
+	RenewPasswordResetCode func(ctx context.Context, id int32) (string, error)
 }
 
 func (s *MockUsers) MockGetByID_Return(t *testing.T, returns *types.User, returnsErr error) (called *bool) {

--- a/internal/database/users_mock.go
+++ b/internal/database/users_mock.go
@@ -12,7 +12,6 @@ type MockUsers struct {
 	GetByUsername                                   func(ctx context.Context, username string) (*types.User, error)
 	GetByCurrentAuthUser                            func(ctx context.Context) (*types.User, error)
 	Count                                           func(ctx context.Context, opt *UsersListOptions) (int, error)
-	List                                            func(ctx context.Context, opt *UsersListOptions) ([]*types.User, error)
 	InvalidateSessionsByID                          func(ctx context.Context, id int32) error
 	HasTag                                          func(ctx context.Context, userID int32, tag string) (bool, error)
 	Tags                                            func(ctx context.Context, userID int32) (map[string]bool, error)

--- a/internal/database/users_mock.go
+++ b/internal/database/users_mock.go
@@ -10,7 +10,6 @@ import (
 type MockUsers struct {
 	GetByID                                         func(ctx context.Context, id int32) (*types.User, error)
 	GetByUsername                                   func(ctx context.Context, username string) (*types.User, error)
-	GetByUsernames                                  func(ctx context.Context, usernames ...string) ([]*types.User, error)
 	GetByCurrentAuthUser                            func(ctx context.Context) (*types.User, error)
 	GetByVerifiedEmail                              func(ctx context.Context, email string) (*types.User, error)
 	Count                                           func(ctx context.Context, opt *UsersListOptions) (int, error)

--- a/internal/database/users_mock.go
+++ b/internal/database/users_mock.go
@@ -11,7 +11,6 @@ type MockUsers struct {
 	GetByID                                         func(ctx context.Context, id int32) (*types.User, error)
 	GetByUsername                                   func(ctx context.Context, username string) (*types.User, error)
 	GetByCurrentAuthUser                            func(ctx context.Context) (*types.User, error)
-	GetByVerifiedEmail                              func(ctx context.Context, email string) (*types.User, error)
 	Count                                           func(ctx context.Context, opt *UsersListOptions) (int, error)
 	List                                            func(ctx context.Context, opt *UsersListOptions) ([]*types.User, error)
 	InvalidateSessionsByID                          func(ctx context.Context, id int32) error

--- a/internal/database/users_mock.go
+++ b/internal/database/users_mock.go
@@ -8,7 +8,6 @@ import (
 )
 
 type MockUsers struct {
-	Delete                                          func(ctx context.Context, id int32) error
 	HardDelete                                      func(ctx context.Context, id int32) error
 	SetIsSiteAdmin                                  func(id int32, isSiteAdmin bool) error
 	SetTosAccepted                                  func(id int32) error

--- a/internal/database/users_mock.go
+++ b/internal/database/users_mock.go
@@ -12,7 +12,6 @@ type MockUsers struct {
 	GetByUsername                                   func(ctx context.Context, username string) (*types.User, error)
 	GetByCurrentAuthUser                            func(ctx context.Context) (*types.User, error)
 	Count                                           func(ctx context.Context, opt *UsersListOptions) (int, error)
-	HasTag                                          func(ctx context.Context, userID int32, tag string) (bool, error)
 	Tags                                            func(ctx context.Context, userID int32) (map[string]bool, error)
 	RandomizePasswordAndClearPasswordResetRateLimit func(ctx context.Context, userID int32) error
 	RenewPasswordResetCode                          func(ctx context.Context, id int32) (string, error)

--- a/internal/database/users_mock.go
+++ b/internal/database/users_mock.go
@@ -8,7 +8,6 @@ import (
 )
 
 type MockUsers struct {
-	Update                                          func(userID int32, update UserUpdate) error
 	Delete                                          func(ctx context.Context, id int32) error
 	HardDelete                                      func(ctx context.Context, id int32) error
 	SetIsSiteAdmin                                  func(id int32, isSiteAdmin bool) error

--- a/internal/database/users_mock.go
+++ b/internal/database/users_mock.go
@@ -8,7 +8,6 @@ import (
 )
 
 type MockUsers struct {
-	Create                                          func(ctx context.Context, info NewUser) (newUser *types.User, err error)
 	Update                                          func(userID int32, update UserUpdate) error
 	Delete                                          func(ctx context.Context, id int32) error
 	HardDelete                                      func(ctx context.Context, id int32) error

--- a/internal/database/users_mock.go
+++ b/internal/database/users_mock.go
@@ -12,7 +12,6 @@ type MockUsers struct {
 	GetByUsername                                   func(ctx context.Context, username string) (*types.User, error)
 	GetByCurrentAuthUser                            func(ctx context.Context) (*types.User, error)
 	Count                                           func(ctx context.Context, opt *UsersListOptions) (int, error)
-	InvalidateSessionsByID                          func(ctx context.Context, id int32) error
 	HasTag                                          func(ctx context.Context, userID int32, tag string) (bool, error)
 	Tags                                            func(ctx context.Context, userID int32) (map[string]bool, error)
 	RandomizePasswordAndClearPasswordResetRateLimit func(ctx context.Context, userID int32) error

--- a/internal/database/users_mock.go
+++ b/internal/database/users_mock.go
@@ -8,11 +8,10 @@ import (
 )
 
 type MockUsers struct {
-	GetByID                func(ctx context.Context, id int32) (*types.User, error)
-	GetByUsername          func(ctx context.Context, username string) (*types.User, error)
-	GetByCurrentAuthUser   func(ctx context.Context) (*types.User, error)
-	Count                  func(ctx context.Context, opt *UsersListOptions) (int, error)
-	RenewPasswordResetCode func(ctx context.Context, id int32) (string, error)
+	GetByID              func(ctx context.Context, id int32) (*types.User, error)
+	GetByUsername        func(ctx context.Context, username string) (*types.User, error)
+	GetByCurrentAuthUser func(ctx context.Context) (*types.User, error)
+	Count                func(ctx context.Context, opt *UsersListOptions) (int, error)
 }
 
 func (s *MockUsers) MockGetByID_Return(t *testing.T, returns *types.User, returnsErr error) (called *bool) {

--- a/internal/database/users_mock.go
+++ b/internal/database/users_mock.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"context"
-	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -12,13 +11,4 @@ type MockUsers struct {
 	GetByUsername        func(ctx context.Context, username string) (*types.User, error)
 	GetByCurrentAuthUser func(ctx context.Context) (*types.User, error)
 	Count                func(ctx context.Context, opt *UsersListOptions) (int, error)
-}
-
-func (s *MockUsers) MockGetByID_Return(t *testing.T, returns *types.User, returnsErr error) (called *bool) {
-	called = new(bool)
-	s.GetByID = func(ctx context.Context, id int32) (*types.User, error) {
-		*called = true
-		return returns, returnsErr
-	}
-	return
 }

--- a/internal/database/users_mock.go
+++ b/internal/database/users_mock.go
@@ -8,7 +8,6 @@ import (
 )
 
 type MockUsers struct {
-	SetIsSiteAdmin                                  func(id int32, isSiteAdmin bool) error
 	SetTosAccepted                                  func(id int32) error
 	CheckAndDecrementInviteQuota                    func(ctx context.Context, userID int32) (bool, error)
 	GetByID                                         func(ctx context.Context, id int32) (*types.User, error)

--- a/internal/database/users_mock.go
+++ b/internal/database/users_mock.go
@@ -8,7 +8,6 @@ import (
 )
 
 type MockUsers struct {
-	SetTosAccepted                                  func(id int32) error
 	CheckAndDecrementInviteQuota                    func(ctx context.Context, userID int32) (bool, error)
 	GetByID                                         func(ctx context.Context, id int32) (*types.User, error)
 	GetByUsername                                   func(ctx context.Context, username string) (*types.User, error)


### PR DESCRIPTION
This PR removes a bunch of now-unused global mocks. It should be possible now to write all new tests with the new injected DB mocks, so there is no good reason to keep these around. Also, it makes it more clear how much work is left to remove the global mocks entirely.

Very mechanical change. The process is just:
1) Find references on the mock struct field
2) If the only reference is where the global mock is checked for nil-ness, remove it


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
