### PR TITLE
remove MockRepos.Get

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	resolvermocks "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -96,16 +95,6 @@ func TestDeleteLSIFIndexUnauthenticated(t *testing.T) {
 }
 
 func TestMakeGetUploadsOptions(t *testing.T) {
-	t.Cleanup(func() {
-		database.Mocks.Repos.Get = nil
-	})
-	database.Mocks.Repos.Get = func(v0 context.Context, id api.RepoID) (*types.Repo, error) {
-		if id != 50 {
-			t.Errorf("unexpected repository name. want=%d have=%d", 50, id)
-		}
-		return &types.Repo{ID: 50}, nil
-	}
-
 	opts, err := makeGetUploadsOptions(context.Background(), &gql.LSIFRepositoryUploadsQueryArgs{
 		LSIFUploadsQueryArgs: &gql.LSIFUploadsQueryArgs{
 			ConnectionArgs: graphqlutil.ConnectionArgs{
@@ -159,16 +148,6 @@ func TestMakeGetUploadsOptionsDefaults(t *testing.T) {
 }
 
 func TestMakeGetIndexesOptions(t *testing.T) {
-	t.Cleanup(func() {
-		database.Mocks.Repos.Get = nil
-	})
-	database.Mocks.Repos.Get = func(v0 context.Context, id api.RepoID) (*types.Repo, error) {
-		if id != 50 {
-			t.Errorf("unexpected repository name. want=%d have=%d", 50, id)
-		}
-		return &types.Repo{ID: 50}, nil
-	}
-
 	opts, err := makeGetIndexesOptions(context.Background(), &gql.LSIFRepositoryIndexesQueryArgs{
 		LSIFIndexesQueryArgs: &gql.LSIFIndexesQueryArgs{
 			ConnectionArgs: graphqlutil.ConnectionArgs{

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -116,10 +116,6 @@ func (s *repoStore) Transact(ctx context.Context) (RepoStore, error) {
 // Get finds and returns the repo with the given repository ID from the database.
 // When a repo isn't found or has been blocked, an error is returned.
 func (s *repoStore) Get(ctx context.Context, id api.RepoID) (_ *types.Repo, err error) {
-	if Mocks.Repos.Get != nil {
-		return Mocks.Repos.Get(ctx, id)
-	}
-
 	tr, ctx := trace.New(ctx, "repos.Get", "")
 	defer func() {
 		tr.SetError(err)

--- a/internal/database/repos_mock.go
+++ b/internal/database/repos_mock.go
@@ -8,7 +8,6 @@ import (
 )
 
 type MockRepos struct {
-	Get              func(ctx context.Context, repo api.RepoID) (*types.Repo, error)
 	List             func(v0 context.Context, v1 ReposListOptions) ([]*types.Repo, error)
 	ListMinimalRepos func(v0 context.Context, v1 ReposListOptions) ([]types.MinimalRepo, error)
 	Metadata         func(ctx context.Context, ids ...api.RepoID) ([]*types.SearchedRepo, error)


### PR DESCRIPTION
Just a small PR that gets rid of the remaining references to `MockRepos.Get`, replacing them with injected mocks. 