### PR TITLE
Fix: CTA margins

### DIFF
--- a/client/web/src/repo/actions/InstallBrowserExtensionAlert.tsx
+++ b/client/web/src/repo/actions/InstallBrowserExtensionAlert.tsx
@@ -48,7 +48,7 @@ export const InstallBrowserExtensionAlert: React.FunctionComponent<Props> = ({
 
     return (
         <div
-            className="alert alert-info m-2 d-flex justify-content-between flex-shrink-0"
+            className="alert alert-info m-3 d-flex justify-content-between flex-shrink-0"
             data-testid="install-browser-extension-alert"
         >
             <div className="d-flex align-items-center">

--- a/client/web/src/repo/actions/InstallBrowserExtensionAlert.tsx
+++ b/client/web/src/repo/actions/InstallBrowserExtensionAlert.tsx
@@ -137,7 +137,7 @@ export function isFirefoxCampaignActive(currentMs: number): boolean {
 }
 
 export const FirefoxAddonAlert: React.FunctionComponent<FirefoxAlertProps> = ({ onAlertDismissed, displayName }) => (
-    <div className="alert alert-info m-2 d-flex justify-content-between flex-shrink-0 percy-hide">
+    <div className="alert alert-info m-3 d-flex justify-content-between flex-shrink-0 percy-hide">
         <div>
             <p className="font-weight-medium my-0 mr-3">
                 Sourcegraph is back at{' '}

--- a/client/web/src/repo/actions/__snapshots__/InstallBrowserExtensionAlert.test.tsx.snap
+++ b/client/web/src/repo/actions/__snapshots__/InstallBrowserExtensionAlert.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`InstallBrowserExtensionAlert BITBUCKETSERVER (Chrome) 1`] = `
 <DocumentFragment>
   <div
-    class="alert alert-info m-2 d-flex justify-content-between flex-shrink-0"
+    class="alert alert-info m-3 d-flex justify-content-between flex-shrink-0"
     data-testid="install-browser-extension-alert"
   >
     <div
@@ -47,7 +47,7 @@ exports[`InstallBrowserExtensionAlert BITBUCKETSERVER (Chrome) 1`] = `
 exports[`InstallBrowserExtensionAlert BITBUCKETSERVER (native integration) 1`] = `
 <DocumentFragment>
   <div
-    class="alert alert-info m-2 d-flex justify-content-between flex-shrink-0"
+    class="alert alert-info m-3 d-flex justify-content-between flex-shrink-0"
     data-testid="install-browser-extension-alert"
   >
     <div
@@ -100,7 +100,7 @@ exports[`InstallBrowserExtensionAlert BITBUCKETSERVER (native integration) 1`] =
 exports[`InstallBrowserExtensionAlert BITBUCKETSERVER (non-Chrome) 1`] = `
 <DocumentFragment>
   <div
-    class="alert alert-info m-2 d-flex justify-content-between flex-shrink-0"
+    class="alert alert-info m-3 d-flex justify-content-between flex-shrink-0"
     data-testid="install-browser-extension-alert"
   >
     <div
@@ -144,7 +144,7 @@ exports[`InstallBrowserExtensionAlert BITBUCKETSERVER (non-Chrome) 1`] = `
 exports[`InstallBrowserExtensionAlert GITHUB (Chrome) 1`] = `
 <DocumentFragment>
   <div
-    class="alert alert-info m-2 d-flex justify-content-between flex-shrink-0"
+    class="alert alert-info m-3 d-flex justify-content-between flex-shrink-0"
     data-testid="install-browser-extension-alert"
   >
     <div
@@ -188,7 +188,7 @@ exports[`InstallBrowserExtensionAlert GITHUB (Chrome) 1`] = `
 exports[`InstallBrowserExtensionAlert GITHUB (native integration) 1`] = `
 <DocumentFragment>
   <div
-    class="alert alert-info m-2 d-flex justify-content-between flex-shrink-0"
+    class="alert alert-info m-3 d-flex justify-content-between flex-shrink-0"
     data-testid="install-browser-extension-alert"
   >
     <div
@@ -241,7 +241,7 @@ exports[`InstallBrowserExtensionAlert GITHUB (native integration) 1`] = `
 exports[`InstallBrowserExtensionAlert GITHUB (non-Chrome) 1`] = `
 <DocumentFragment>
   <div
-    class="alert alert-info m-2 d-flex justify-content-between flex-shrink-0"
+    class="alert alert-info m-3 d-flex justify-content-between flex-shrink-0"
     data-testid="install-browser-extension-alert"
   >
     <div
@@ -285,7 +285,7 @@ exports[`InstallBrowserExtensionAlert GITHUB (non-Chrome) 1`] = `
 exports[`InstallBrowserExtensionAlert GITLAB (Chrome) 1`] = `
 <DocumentFragment>
   <div
-    class="alert alert-info m-2 d-flex justify-content-between flex-shrink-0"
+    class="alert alert-info m-3 d-flex justify-content-between flex-shrink-0"
     data-testid="install-browser-extension-alert"
   >
     <div
@@ -329,7 +329,7 @@ exports[`InstallBrowserExtensionAlert GITLAB (Chrome) 1`] = `
 exports[`InstallBrowserExtensionAlert GITLAB (native integration) 1`] = `
 <DocumentFragment>
   <div
-    class="alert alert-info m-2 d-flex justify-content-between flex-shrink-0"
+    class="alert alert-info m-3 d-flex justify-content-between flex-shrink-0"
     data-testid="install-browser-extension-alert"
   >
     <div
@@ -382,7 +382,7 @@ exports[`InstallBrowserExtensionAlert GITLAB (native integration) 1`] = `
 exports[`InstallBrowserExtensionAlert GITLAB (non-Chrome) 1`] = `
 <DocumentFragment>
   <div
-    class="alert alert-info m-2 d-flex justify-content-between flex-shrink-0"
+    class="alert alert-info m-3 d-flex justify-content-between flex-shrink-0"
     data-testid="install-browser-extension-alert"
   >
     <div
@@ -426,7 +426,7 @@ exports[`InstallBrowserExtensionAlert GITLAB (non-Chrome) 1`] = `
 exports[`InstallBrowserExtensionAlert PHABRICATOR (Chrome) 1`] = `
 <DocumentFragment>
   <div
-    class="alert alert-info m-2 d-flex justify-content-between flex-shrink-0"
+    class="alert alert-info m-3 d-flex justify-content-between flex-shrink-0"
     data-testid="install-browser-extension-alert"
   >
     <div
@@ -470,7 +470,7 @@ exports[`InstallBrowserExtensionAlert PHABRICATOR (Chrome) 1`] = `
 exports[`InstallBrowserExtensionAlert PHABRICATOR (native integration) 1`] = `
 <DocumentFragment>
   <div
-    class="alert alert-info m-2 d-flex justify-content-between flex-shrink-0"
+    class="alert alert-info m-3 d-flex justify-content-between flex-shrink-0"
     data-testid="install-browser-extension-alert"
   >
     <div
@@ -523,7 +523,7 @@ exports[`InstallBrowserExtensionAlert PHABRICATOR (native integration) 1`] = `
 exports[`InstallBrowserExtensionAlert PHABRICATOR (non-Chrome) 1`] = `
 <DocumentFragment>
   <div
-    class="alert alert-info m-2 d-flex justify-content-between flex-shrink-0"
+    class="alert alert-info m-3 d-flex justify-content-between flex-shrink-0"
     data-testid="install-browser-extension-alert"
   >
     <div


### PR DESCRIPTION
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
As mentioned by @rrhyne in this[ Slack Thread](https://sourcegraph.slack.com/archives/C01T0BL4EFN/p1641248315005700), the browser extension currently does not align with the other elements on screen:
![image](https://user-images.githubusercontent.com/68532117/147990096-ac4e97ce-4198-47bf-9816-09d21c000757.png)
![image](https://user-images.githubusercontent.com/68532117/147990106-6467b671-f76d-456e-96a8-285819a7ed45.png)

Fixed by updating margin from 2 to 3 to match the other elements:
![image](https://user-images.githubusercontent.com/68532117/147990160-d2ea024d-b7cd-49b3-9c94-26781e14cd17.png)
![image](https://user-images.githubusercontent.com/68532117/147990298-89c328ca-93c3-44b9-b23f-d6cf1d757ed3.png)
