### PR TITLE
Do not parse current browser location for every symbol

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebarSymbols.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarSymbols.tsx
@@ -26,28 +26,17 @@ import { parseBrowserRepoURL } from '../util/url'
 
 import styles from './RepoRevisionSidebarSymbols.module.scss'
 
-function symbolIsActive(symbolLocation: string, currentLocation: H.Location): boolean {
-    const current = parseBrowserRepoURL(H.createPath(currentLocation))
-    const symbol = parseBrowserRepoURL(symbolLocation)
-    return (
-        current.repoName === symbol.repoName &&
-        current.revision === symbol.revision &&
-        current.filePath === symbol.filePath &&
-        isEqual(current.position, symbol.position)
-    )
-}
-
 const symbolIsActiveTrue = (): boolean => true
 const symbolIsActiveFalse = (): boolean => false
 
 interface SymbolNodeProps {
     node: SymbolNodeFields
-    location: H.Location
     onHandleClick: () => void
+    isActive: boolean
 }
 
-const SymbolNode: React.FunctionComponent<SymbolNodeProps> = ({ node, location, onHandleClick }) => {
-    const isActiveFunc = symbolIsActive(node.url, location) ? symbolIsActiveTrue : symbolIsActiveFalse
+const SymbolNode: React.FunctionComponent<SymbolNodeProps> = ({ node, onHandleClick, isActive }) => {
+    const isActiveFunc = isActive ? symbolIsActiveTrue : symbolIsActiveFalse
     return (
         <li className={styles.repoRevisionSidebarSymbolsNode} data-tooltip={node.location.resource.path}>
             <NavLink
@@ -183,6 +172,17 @@ export const RepoRevisionSidebarSymbols: React.FunctionComponent<RepoRevisionSid
         />
     )
 
+    const currentLocation = parseBrowserRepoURL(H.createPath(location))
+    const isSymbolActive = (symbolUrl: string): boolean => {
+        const symbolLocation = parseBrowserRepoURL(symbolUrl)
+        return (
+            currentLocation.repoName === symbolLocation.repoName &&
+            currentLocation.revision === symbolLocation.revision &&
+            currentLocation.filePath === symbolLocation.filePath &&
+            isEqual(currentLocation.position, symbolLocation.position)
+        )
+    }
+
     return (
         <ConnectionContainer className={classNames('h-100', styles.repoRevisionSidebarSymbols)} compact={true}>
             <ConnectionForm
@@ -200,7 +200,12 @@ export const RepoRevisionSidebarSymbols: React.FunctionComponent<RepoRevisionSid
                 <ConnectionList compact={true}>
                     <Tooltip />
                     {connection.nodes.map((node, index) => (
-                        <SymbolNode key={index} node={node} location={location} onHandleClick={onHandleSymbolClick} />
+                        <SymbolNode
+                            key={index}
+                            node={node}
+                            onHandleClick={onHandleSymbolClick}
+                            isActive={isSymbolActive(node.url)}
+                        />
                     ))}
                 </ConnectionList>
             )}

--- a/client/web/src/repo/RepoRevisionSidebarSymbols.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarSymbols.tsx
@@ -26,9 +26,6 @@ import { parseBrowserRepoURL } from '../util/url'
 
 import styles from './RepoRevisionSidebarSymbols.module.scss'
 
-const symbolIsActiveTrue = (): boolean => true
-const symbolIsActiveFalse = (): boolean => false
-
 interface SymbolNodeProps {
     node: SymbolNodeFields
     onHandleClick: () => void
@@ -36,7 +33,7 @@ interface SymbolNodeProps {
 }
 
 const SymbolNode: React.FunctionComponent<SymbolNodeProps> = ({ node, onHandleClick, isActive }) => {
-    const isActiveFunc = isActive ? symbolIsActiveTrue : symbolIsActiveFalse
+    const isActiveFunc = (): boolean => isActive
     return (
         <li className={styles.repoRevisionSidebarSymbolsNode} data-tooltip={node.location.resource.path}>
             <NavLink


### PR DESCRIPTION
Doesn't help with the [slow hovers](https://sourcegraph.slack.com/archives/C01LTKUHRL3/p1641303291183600) but it still feels better to not parse the current url every time we render a symbol.
