### PR TITLE
Remove additional unused global mock stores

### DIFF
--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -311,10 +311,6 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
 }
 
 func (s *userExternalAccountsStore) TouchExpired(ctx context.Context, id int32) error {
-	if Mocks.ExternalAccounts.TouchExpired != nil {
-		return Mocks.ExternalAccounts.TouchExpired(ctx, id)
-	}
-
 	_, err := s.Handle().DB().ExecContext(ctx, `
 -- source: internal/database/external_accounts.go:UserExternalAccountsStore.TouchExpired
 UPDATE user_external_accounts
@@ -325,10 +321,6 @@ WHERE id = $1
 }
 
 func (s *userExternalAccountsStore) TouchLastValid(ctx context.Context, id int32) error {
-	if Mocks.ExternalAccounts.TouchLastValid != nil {
-		return Mocks.ExternalAccounts.TouchLastValid(ctx, id)
-	}
-
 	_, err := s.Handle().DB().ExecContext(ctx, `
 -- source: internal/database/external_accounts.go:UserExternalAccountsStore.TouchLastValid
 UPDATE user_external_accounts
@@ -471,12 +463,6 @@ func (s *userExternalAccountsStore) listSQL(opt ExternalAccountsListOptions) (co
 	}
 
 	return conds
-}
-
-// MockExternalAccounts mocks the Stores.ExternalAccounts DB store.
-type MockExternalAccounts struct {
-	TouchExpired   func(ctx context.Context, id int32) error
-	TouchLastValid func(ctx context.Context, id int32) error
 }
 
 // MaybeEncrypt encrypts data with the given key returns the id of the key. If the key is nil, it returns the data unchanged.

--- a/internal/database/mockstores.go
+++ b/internal/database/mockstores.go
@@ -12,7 +12,6 @@ type MockStores struct {
 	AccessTokens MockAccessTokens
 
 	Repos        MockRepos
-	UserEmails   MockUserEmails
 	SubRepoPerms MockSubRepoPerms
 
 	ExternalAccounts MockExternalAccounts

--- a/internal/database/mockstores.go
+++ b/internal/database/mockstores.go
@@ -9,11 +9,7 @@ var Mocks MockStores
 //   internal/database/mocks.go. If you came here looking for a store that isn't listed,
 //   consider passing in the generated db or stores from there.
 type MockStores struct {
-	AccessTokens MockAccessTokens
-
-	Repos MockRepos
-
-	ExternalAccounts MockExternalAccounts
-
+	AccessTokens     MockAccessTokens
+	Repos            MockRepos
 	ExternalServices MockExternalServices
 }

--- a/internal/database/mockstores.go
+++ b/internal/database/mockstores.go
@@ -11,8 +11,7 @@ var Mocks MockStores
 type MockStores struct {
 	AccessTokens MockAccessTokens
 
-	Repos        MockRepos
-	SubRepoPerms MockSubRepoPerms
+	Repos MockRepos
 
 	ExternalAccounts MockExternalAccounts
 

--- a/internal/database/sub_repo_perms_store.go
+++ b/internal/database/sub_repo_perms_store.go
@@ -92,10 +92,6 @@ SET
 // external repo spec to map to out internal repo id. If there is no mapping,
 // nothing is written.
 func (s *subRepoPermsStore) UpsertWithSpec(ctx context.Context, userID int32, spec api.ExternalRepoSpec, perms authz.SubRepoPermissions) error {
-	if Mocks.SubRepoPerms.UpsertWithSpec != nil {
-		return Mocks.SubRepoPerms.UpsertWithSpec(ctx, userID, spec, perms)
-	}
-
 	q := sqlf.Sprintf(`
 INSERT INTO sub_repo_permissions (user_id, repo_id, path_includes, path_excludes, version, updated_at)
 SELECT %s, id, %s, %s, %s, now()
@@ -180,8 +176,4 @@ WHERE user_id = %s
 	}
 
 	return result, nil
-}
-
-type MockSubRepoPerms struct {
-	UpsertWithSpec func(ctx context.Context, userID int32, spec api.ExternalRepoSpec, perms authz.SubRepoPermissions) error
 }

--- a/internal/database/user_emails.go
+++ b/internal/database/user_emails.go
@@ -299,10 +299,6 @@ type UserEmailsListOptions struct {
 
 // ListByUser returns a list of emails that are associated to the given user.
 func (s *userEmailsStore) ListByUser(ctx context.Context, opt UserEmailsListOptions) ([]*UserEmail, error) {
-	if Mocks.UserEmails.ListByUser != nil {
-		return Mocks.UserEmails.ListByUser(ctx, opt)
-	}
-
 	conds := []*sqlf.Query{
 		sqlf.Sprintf("user_id=%s", opt.UserID),
 	}

--- a/internal/database/user_emails_mock.go
+++ b/internal/database/user_emails_mock.go
@@ -1,9 +1,0 @@
-package database
-
-import (
-	"context"
-)
-
-type MockUserEmails struct {
-	ListByUser func(ctx context.Context, opt UserEmailsListOptions) ([]*UserEmail, error)
-}


### PR DESCRIPTION
This removes a few global mock stores that are no longer used (thanks @unknwon!)

Stacked on #29421 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
