### PR TITLE
make initsg more friendly for local use

### DIFF
--- a/dev/ci/test/cluster/cluster-test.sh
+++ b/dev/ci/test/cluster/cluster-test.sh
@@ -86,7 +86,7 @@ function test_setup() {
   # Load variables set up by init-server, disabling `-x` to avoid printing variables, setting +u to avoid blowing up on ubound ones
   set +x +u
   # shellcheck disable=SC1091
-  source /root/.profile
+  source /root/.sg_envrc
   set -x -u
 
   echo "--- TEST: Checking Sourcegraph instance is accessible"

--- a/dev/ci/test/code-intel/test-against-server.sh
+++ b/dev/ci/test/code-intel/test-against-server.sh
@@ -19,7 +19,7 @@ pushd dev/ci/test/code-intel || exit 1
 "${SG_ROOT}/init-sg" initSG
 # Disable `-x` to avoid printing secrets
 set +x
-source /root/.profile
+source /root/.sg_envrc
 set -x
 "${SG_ROOT}/init-sg" addRepos -config repos.json
 popd || exit 1

--- a/dev/ci/test/code-intel/test-against-server.sh
+++ b/dev/ci/test/code-intel/test-against-server.sh
@@ -19,6 +19,7 @@ pushd dev/ci/test/code-intel || exit 1
 "${SG_ROOT}/init-sg" initSG
 # Disable `-x` to avoid printing secrets
 set +x
+# shellcheck disable=SC1091
 source /root/.sg_envrc
 set -x
 "${SG_ROOT}/init-sg" addRepos -config repos.json

--- a/dev/ci/test/qa/test.sh
+++ b/dev/ci/test/qa/test.sh
@@ -49,7 +49,7 @@ popd
 # Load variables set up by init-server, disabling `-x` to avoid printing variables
 set +x
 # shellcheck disable=SC1091
-source /root/.profile
+source /root/.sg_envrc
 set -x
 
 echo "--- TEST: Checking Sourcegraph instance is accessible"

--- a/dev/ci/test/upgrade/test.sh
+++ b/dev/ci/test/upgrade/test.sh
@@ -43,7 +43,7 @@ popd
 # Load variables set up by init-server, disabling `-x` to avoid printing variables
 set +x
 # shellcheck disable=SC1091
-source /root/.profile
+source /root/.sg_envrc
 set -x
 
 # Stop old Sourcegraph release

--- a/internal/cmd/init-sg/main.go
+++ b/internal/cmd/init-sg/main.go
@@ -28,7 +28,7 @@ var (
 	addReposConfig = addRepos.String("config", "", "Path to the external service config. (Required)")
 
 	home    = os.Getenv("HOME")
-	profile = home + "/.profile"
+	profile = home + "/.sg_envrc"
 )
 
 func main() {
@@ -98,7 +98,7 @@ func initSourcegraph() {
 	}
 
 	envvar := "export SOURCEGRAPH_SUDO_TOKEN=" + token
-	file, err := os.OpenFile(profile, os.O_APPEND|os.O_WRONLY, 0755)
+	file, err := os.Create(profile)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This makes initsg friendlier for local dev use and doesn't interfere with `.profile` that may otherwise have variables set. 

It also switches to use `os.create` in order to avoid a list of old tokens being appended to. We no longer have stateless agents and until we do this is a way to ensure we're not continuously appending to a list of envvars. 