### PR TITLE
monitoring: create uniform variables API for dashboards

### DIFF
--- a/doc/dev/how-to/monitoring_local_dev.md
+++ b/doc/dev/how-to/monitoring_local_dev.md
@@ -36,7 +36,7 @@ kubectl port-forward svc/prometheus 9090:30090
 Then, you can start up a standalone Grafana using:
 
 ```sh
-./dev/grafana.sh
+sg run grafana
 ```
 
 Dashboards will be available at `localhost:3030`.
@@ -53,7 +53,7 @@ Running just Prometheus is a convenient way to validate the generated recording 
 You can start up a standalone Prometheus using:
 
 ```sh
-./dev/prometheus.sh
+sg run prometheus
 ```
 
 The loaded generated recording and alert rules are available at `http://localhost:9090/rules`.
@@ -91,7 +91,7 @@ The docsite is used to serve generated monitoring documentation, such as the [al
 You can spin it up by running:
 
 ```sh
-yarn docsite:serve
+sg run docsite
 ```
 
 Learn more about docsite development in the [product documentation implementation guide](documentation_implementation.md).
@@ -107,10 +107,10 @@ This means that you can:
 * Run the generator to regenerate and reload monitoring services
 * Validate the result of your changes immediately (for example, by checking Prometheus rules in `/rules` or Grafana dashboards in `/-/debug/grafana`)
 
-To run the generator and trigger a reload:
+To run the generator and trigger a reload on changes:
 
 ```sh
-RELOAD=true go generate ./monitoring
+sg run monitoring-generator
 ```
 
 Make sure to provide the following parameters as well, where relevant:

--- a/monitoring/definitions/executor.go
+++ b/monitoring/definitions/executor.go
@@ -1,8 +1,6 @@
 package definitions
 
 import (
-	"github.com/grafana-tools/sdk"
-
 	"github.com/sourcegraph/sourcegraph/monitoring/definitions/shared"
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
@@ -17,35 +15,16 @@ func Executor() *monitoring.Container {
 		Name:        "executor",
 		Title:       "Executor",
 		Description: `Executes jobs in an isolated environment.`,
-		Templates: []sdk.TemplateVar{
+		Variables: []monitoring.ContainerVariable{
 			{
-				Label:      "Queue name",
-				Name:       "queue",
-				AllValue:   ".*",
-				Current:    sdk.Current{Text: &sdk.StringSliceString{Value: []string{"all"}, Valid: true}, Value: "$__all"},
-				IncludeAll: true,
-				Options: []sdk.Option{
-					{Text: "all", Value: "$__all", Selected: true},
-					{Text: "batches", Value: "batches"},
-					{Text: "codeintel", Value: "codeintel"},
-				},
-				Query: "batches,codeintel",
-				Type:  "custom",
+				Label:   "Queue name",
+				Name:    "queue",
+				Options: []string{"batches", "codeintel"},
 			},
 			{
-				Label:      "Compute Instance",
-				Name:       "instance",
-				AllValue:   ".*",
-				IncludeAll: true,
-				Query:      "label_values(node_exporter_build_info{job=\"sourcegraph-code-intel-indexer-nodes\"}, instance)",
-				Type:       "query",
-				Datasource: monitoring.StringPtr("Prometheus"),
-				Sort:       1,
-				Refresh: sdk.BoolInt{
-					Flag:  true,
-					Value: monitoring.Int64Ptr(1),
-				},
-				Hide: 0,
+				Label: "Compute instance",
+				Name:  "instance",
+				Query: "label_values(node_exporter_build_info{job=\"sourcegraph-code-intel-indexer-nodes\"}, instance)",
 			},
 		},
 		Groups: []monitoring.Group{

--- a/monitoring/definitions/git_server.go
+++ b/monitoring/definitions/git_server.go
@@ -25,19 +25,12 @@ func GitServer() *monitoring.Container {
 		Name:        "gitserver",
 		Title:       "Git Server",
 		Description: "Stores, manages, and operates Git repositories.",
-		Templates: []sdk.TemplateVar{
+		Variables: []monitoring.ContainerVariable{
 			{
-				Label:      "Shard",
-				Name:       "shard",
-				Type:       "query",
-				Datasource: monitoring.StringPtr("Prometheus"),
-				Query:      "label_values(src_gitserver_exec_running, instance)",
-				Multi:      true,
-				Refresh:    sdk.BoolInt{Flag: true, Value: monitoring.Int64Ptr(2)}, // Refresh on time range change
-				Sort:       3,
-				IncludeAll: true,
-				AllValue:   ".*",
-				Current:    sdk.Current{Text: &sdk.StringSliceString{Value: []string{"all"}, Valid: true}, Value: "$__all"},
+				Label: "Shard",
+				Name:  "shard",
+				Query: "label_values(src_gitserver_exec_running, instance)",
+				Multi: true,
 			},
 		},
 		Groups: []monitoring.Group{

--- a/monitoring/definitions/zoekt_index_server.go
+++ b/monitoring/definitions/zoekt_index_server.go
@@ -21,19 +21,12 @@ func ZoektIndexServer() *monitoring.Container {
 		Title:                    "Zoekt Index Server",
 		Description:              "Indexes repositories and populates the search index.",
 		NoSourcegraphDebugServer: true,
-		Templates: []sdk.TemplateVar{
+		Variables: []monitoring.ContainerVariable{
 			{
-				Label:      "Instance",
-				Name:       "instance",
-				Type:       "query",
-				Datasource: monitoring.StringPtr("Prometheus"),
-				Query:      "label_values(index_num_assigned, instance)",
-				Multi:      true,
-				Refresh:    sdk.BoolInt{Flag: true, Value: monitoring.Int64Ptr(2)}, // Refresh on time range change
-				Sort:       3,
-				IncludeAll: true,
-				AllValue:   ".*",
-				Current:    sdk.Current{Text: &sdk.StringSliceString{Value: []string{"all"}, Valid: true}, Value: "$__all"},
+				Label: "Instance",
+				Name:  "instance",
+				Query: "label_values(index_num_assigned, instance)",
+				Multi: true,
 			},
 		},
 		Groups: []monitoring.Group{

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -27,8 +27,9 @@ type Container struct {
 	// is responsible for, so that the impact of issues in it is clear.
 	Description string
 
-	// List of Template Variables to apply to the dashboard
-	Templates []sdk.TemplateVar
+	// Variables define the variables that can be to applied to the dashboard for this
+	// container, such as instances or shards.
+	Variables []ContainerVariable
 
 	// Groups of observable information about the container.
 	Groups []Group
@@ -51,6 +52,11 @@ func (c *Container) validate() error {
 	if c.Description != withPeriod(c.Description) || c.Description != upperFirst(c.Description) {
 		return errors.Errorf("Description must be sentence starting with an uppercase letter and ending with period; found \"%s\"", c.Description)
 	}
+	for i, v := range c.Variables {
+		if err := v.validate(); err != nil {
+			return errors.Errorf("Variable %d %q: %v", i, c.Name, err)
+		}
+	}
 	for i, g := range c.Groups {
 		if err := g.validate(); err != nil {
 			return errors.Errorf("Group %d %q: %v", i, g.Title, err)
@@ -72,20 +78,15 @@ func (c *Container) renderDashboard() *sdk.Board {
 	board.SharedCrosshair = true
 	board.Editable = false
 	board.AddTags("builtin")
-	board.Templating.List = append([]sdk.TemplateVar{{
-		Label:      "Filter alert level",
-		Name:       "alert_level",
-		AllValue:   ".*",
-		Current:    sdk.Current{Text: &sdk.StringSliceString{Value: []string{"all"}, Valid: true}, Value: "$__all"},
-		IncludeAll: true,
-		Options: []sdk.Option{
-			{Text: "all", Value: "$__all", Selected: true},
-			{Text: "critical", Value: "critical"},
-			{Text: "warning", Value: "warning"},
-		},
-		Query: "critical,warning",
-		Type:  "custom",
-	}}, c.Templates...)
+	alertLevelVariable := ContainerVariable{
+		Label:   "Alert level",
+		Name:    "alert_level",
+		Options: []string{"critical", "warning"},
+	}
+	board.Templating.List = []sdk.TemplateVar{alertLevelVariable.toGrafanaTemplateVar()}
+	for _, variable := range c.Variables {
+		board.Templating.List = append(board.Templating.List, variable.toGrafanaTemplateVar())
+	}
 	board.Annotations.List = []sdk.Annotation{{
 		Name:       "Alert events",
 		Datasource: StringPtr("Prometheus"),
@@ -328,6 +329,78 @@ func (c *Container) renderRules() (*promRulesFile, error) {
 	return &promRulesFile{
 		Groups: []promGroup{group},
 	}, nil
+}
+
+// ContainerVariable describes a template variable that can be applied container dashboard
+// for filtering purposes.
+type ContainerVariable struct {
+	// Name is the name of the variable to substitute the value for, e.g. "alert_level"
+	// to replace "$alert_level" in queries
+	Name string
+	// Label is a human-readable name for the variable, e.g. "Alert level"
+	Label string
+
+	// Query is the query to generate the possible values. Cannot be used in conjunction
+	// with Options
+	Query string
+	// Options are the pre-defined possible values for this variable. Cannot be used in
+	// conjunction with Query
+	Options []string
+
+	// Multi indicates whether or not to allow multi-selection for this variable filter
+	Multi bool
+}
+
+func (c *ContainerVariable) validate() error {
+	if c.Name == "" {
+		return errors.New("ContainerVariable.Name is required")
+	}
+	if c.Label == "" {
+		return errors.New("ContainerVariable.Label is required")
+	}
+	if c.Query != "" && len(c.Options) > 0 {
+		return errors.New("ContainerVariable.Query and ContainerVariable.Options cannot both be set")
+	}
+	return nil
+}
+
+// toGrafanaTemplateVar generates the Grafana template variable configuration for this
+// container variable.
+func (c *ContainerVariable) toGrafanaTemplateVar() sdk.TemplateVar {
+	variable := sdk.TemplateVar{
+		Name:  c.Name,
+		Label: c.Label,
+		Multi: c.Multi,
+
+		Datasource: StringPtr("Prometheus"),
+		IncludeAll: true,
+
+		AllValue: ".*",
+		// Apply the AllValue to a template variable by default
+		Current: sdk.Current{Text: &sdk.StringSliceString{Value: []string{"all"}, Valid: true}, Value: "$__all"},
+	}
+
+	switch {
+	case c.Query != "":
+		variable.Type = "query"
+		variable.Query = c.Query
+		variable.Refresh = sdk.BoolInt{
+			Flag:  true,
+			Value: Int64Ptr(2), // Refresh on time range change
+		}
+		variable.Sort = 3
+
+	case len(c.Options) > 0:
+		variable.Type = "custom"
+		variable.Query = strings.Join(c.Options, ",")
+		// Add the AllValue as a default
+		variable.Options = []sdk.Option{{Text: "all", Value: "$__all", Selected: true}}
+		for _, option := range c.Options {
+			variable.Options = append(variable.Options, sdk.Option{Text: option, Value: option})
+		}
+	}
+
+	return variable
 }
 
 // Group describes a group of observable information about a container.

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -358,7 +358,7 @@ func (c *ContainerVariable) validate() error {
 	if c.Label == "" {
 		return errors.New("ContainerVariable.Label is required")
 	}
-	if c.Query != "" && len(c.Options) > 0 {
+	if c.Query == "" && len(c.Options) == 0 {
 		return errors.New("ContainerVariable.Query and ContainerVariable.Options cannot both be set")
 	}
 	return nil


### PR DESCRIPTION
Creates a uniform `Variables` API, `ContainerVariable`, that abstracts away a lot of the behind-the-scenes dashboard config and potential gotchas to make it easier to define template variables on dashboards. API docs: https://sourcegraph.com/github.com/sourcegraph/sourcegraph@monitoring/variables-api/-/docs/monitoring/monitoring?ContainerVariable

Poked around with the local dev instructions and the dashboards still work correctly I think, and also updated the dev instructions to use `sg` 😎 

Closes https://github.com/sourcegraph/sourcegraph/issues/29416