### PR TITLE
Warn users against updating to 3.35 for the time being

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ## 3.35.0
 
+**⚠️ We are currently investigating issues related to Code Insights on this release. Users are advised to hold off on upgrading to 3.35 until a fix is available.**
+
 ### Added
 
 - Individual batch changes can publish multiple changesets to the same repository by specifying multiple target branches using the [`on.branches`](https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#on-repository) attribute. [#25228](https://github.com/sourcegraph/sourcegraph/issues/25228)

--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -12,6 +12,8 @@ Each section comprehensively describes the steps needed to upgrade, and any manu
 
 ## 3.34 -> 3.35
 
+> WARNING: **We are currently investigating issues related to Code Insights on this release. Users are advised to hold off on upgrading to 3.35 until a fix is available.**
+
 The `query-runner` service has been decommissioned in the 3.35.0 release and will be removed during the upgrade.
 
 Follow the [standard upgrade procedure](../install/docker-compose/operations.md#upgrade) to upgrade your deployment.

--- a/doc/admin/updates/kubernetes.md
+++ b/doc/admin/updates/kubernetes.md
@@ -12,6 +12,8 @@ and any manual migration steps you must perform.
 
 ## 3.34 -> 3.35
 
+> WARNING: **We are currently investigating issues related to Code Insights on this release. Users are advised to hold off on upgrading to 3.35 until a fix is available.**
+
 The query-runner deployment has been removed, so if you deploy with a method other than the `kubectl-apply-all.sh`, a manual removal of the deployment may be necessary.
 Follow the [standard upgrade procedure](../install/kubernetes/update.md) to upgrade your deployment.
 

--- a/doc/admin/updates/pure_docker.md
+++ b/doc/admin/updates/pure_docker.md
@@ -10,6 +10,8 @@ Each section comprehensively describes the changes needed in Docker images, envi
 
 ## 3.34 -> 3.35
 
+> WARNING: **We are currently investigating issues related to Code Insights on this release. Users are advised to hold off on upgrading to 3.35 until a fix is available.**
+
 The `query-runner` service has been decomissioned in the 3.35.0 release. You can safely remove the `query-runner` service from your installation.
 
 To upgrade, please perform the changes in the following diff:


### PR DESCRIPTION
Recommend against upgrading to 3.35 until investigation is completed on https://github.com/sourcegraph/sourcegraph/issues/29393

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
