### PR TITLE
enable enterprise mode oob migrations after oobmigrator moved to worker

### DIFF
--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -34,16 +34,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
-	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
 func main() {
 	shared.Main(enterpriseSetupHook)
-}
-
-func init() {
-	oobmigration.ReturnEnterpriseMigrations = true
 }
 
 type EnterpriseInitializer = func(context.Context, database.DB, conftypes.UnifiedWatchable, *enterprise.Services, *observation.Context) error

--- a/enterprise/cmd/worker/main.go
+++ b/enterprise/cmd/worker/main.go
@@ -46,6 +46,10 @@ func main() {
 	shared.Start(additionalJobs, registerEnterpriseMigrations)
 }
 
+func init() {
+	oobmigration.ReturnEnterpriseMigrations = true
+}
+
 // setAuthProviders waits for the database to be initialized, then periodically refreshes the
 // global authz providers. This changes the repositories that are visible for reads based on the
 // current actor stored in an operation's context, which is likely an internal actor for many of


### PR DESCRIPTION
When the oob migration runner moved from `frontend` to `worker`, this bit of configuration got left behind to enable enterprise deployments to have enterprise oob migrations.