### PR TITLE
search: use /.api/search/stream for backend integration tests

### DIFF
--- a/internal/gqltestutil/search.go
+++ b/internal/gqltestutil/search.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"path"
 	"sort"
-	"strings"
 
 	"github.com/cockroachdb/errors"
 
@@ -705,7 +705,7 @@ func (s *SearchStreamClient) DeleteSearchContext(id string) error {
 }
 
 func (s *SearchStreamClient) search(query string, dec streamhttp.FrontendStreamDecoder) error {
-	req, err := streamhttp.NewRequest(strings.TrimRight(s.Client.baseURL, "/")+"/.api", query)
+	req, err := streamhttp.NewRequest(path.Join(s.Client.baseURL, ".api"), query)
 	if err != nil {
 		return err
 	}

--- a/internal/gqltestutil/search.go
+++ b/internal/gqltestutil/search.go
@@ -709,7 +709,7 @@ func (s *SearchStreamClient) search(query string, dec streamhttp.FrontendStreamD
 	if err != nil {
 		return err
 	}
-	// NOTE: This header is required to authenticate our session with a session cookie, see:
+	// Note: Sending this header enables us to use session cookie auth without sending a trusted Origin header.
 	// https://docs.sourcegraph.com/dev/security/csrf_security_model#authentication-in-api-endpoints
 	req.Header.Set("X-Requested-With", "Sourcegraph")
 	s.Client.addCookies(req)

--- a/internal/gqltestutil/search.go
+++ b/internal/gqltestutil/search.go
@@ -708,6 +708,9 @@ func (s *SearchStreamClient) search(query string, dec streamhttp.FrontendStreamD
 	if err != nil {
 		return err
 	}
+	// NOTE: This header is required to authenticate our session with a session cookie, see:
+	// https://docs.sourcegraph.com/dev/security/csrf_security_model#authentication-in-api-endpoints
+	req.Header.Set("X-Requested-With", "Sourcegraph")
 	s.Client.addCookies(req)
 
 	resp, err := http.DefaultClient.Do(req)

--- a/internal/gqltestutil/search.go
+++ b/internal/gqltestutil/search.go
@@ -704,7 +704,7 @@ func (s *SearchStreamClient) DeleteSearchContext(id string) error {
 }
 
 func (s *SearchStreamClient) search(query string, dec streamhttp.FrontendStreamDecoder) error {
-	req, err := streamhttp.NewRequest(s.Client.baseURL, query)
+	req, err := streamhttp.NewRequest(s.Client.baseURL+"/.api", query)
 	if err != nil {
 		return err
 	}

--- a/internal/gqltestutil/search.go
+++ b/internal/gqltestutil/search.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"path"
 	"sort"
+	"strings"
 
 	"github.com/cockroachdb/errors"
 
@@ -705,7 +705,7 @@ func (s *SearchStreamClient) DeleteSearchContext(id string) error {
 }
 
 func (s *SearchStreamClient) search(query string, dec streamhttp.FrontendStreamDecoder) error {
-	req, err := streamhttp.NewRequest(path.Join(s.Client.baseURL, ".api"), query)
+	req, err := streamhttp.NewRequest(strings.TrimRight(s.Client.baseURL, "/")+"/.api", query)
 	if err != nil {
 		return err
 	}

--- a/internal/gqltestutil/search.go
+++ b/internal/gqltestutil/search.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strings"
 
 	"github.com/cockroachdb/errors"
 
@@ -704,7 +705,7 @@ func (s *SearchStreamClient) DeleteSearchContext(id string) error {
 }
 
 func (s *SearchStreamClient) search(query string, dec streamhttp.FrontendStreamDecoder) error {
-	req, err := streamhttp.NewRequest(s.Client.baseURL+"/.api", query)
+	req, err := streamhttp.NewRequest(strings.TrimRight(s.Client.baseURL, "/")+"/.api", query)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Relates to #29399 

use /.api/search/stream instead of /search/stream for integration tests.

backend integration test run: https://buildkite.com/sourcegraph/sourcegraph/builds/123982
