### PR TITLE
search: Handle empty repository revisions in context UI

### DIFF
--- a/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
@@ -192,6 +192,11 @@ export const SearchContextForm: React.FunctionComponent<SearchContextFormProps> 
                         return of(configErrorResult)
                     }
                     const repositoryNames = config.map(({ repository }) => repository)
+
+                    if (repositoryNames.length === 0) {
+                        return of({ type: 'repositories', repositories: [] } as RepositoriesParseResult)
+                    }
+
                     return fetchRepositoriesByNames(repositoryNames).pipe(
                         map(repositories => {
                             const repositoryNameToID = new Map(repositories.map(({ id, name }) => [name, id]))


### PR DESCRIPTION
When passing an empty list of repository names on dotcom, we'd try to
load ALL repos in the instance. This makes it so we don't send a request
to the backend unless we have names to check.

Follow up from #29327



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
