### PR TITLE
search: promote "required" property of search jobs before doResults

### DIFF
--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -447,7 +447,7 @@ func (*RepoSubsetSymbolSearch) Name() string {
 }
 
 func (s *RepoSubsetSymbolSearch) Required() bool {
-	return false
+	return s.IsRequired
 }
 
 type RepoUniverseSymbolSearch struct {


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/29172 was reverted because it broke tests and the main build. I found the cause (see inline comment). This unreverts the commit + adds the one line fix. This time the PR passes `main-dry-run` so we're actually green.