### PR TITLE
compute: fix match-only command to add all matches on a single line

### DIFF
--- a/internal/compute/match_only_command.go
+++ b/internal/compute/match_only_command.go
@@ -17,40 +17,38 @@ func (c *MatchOnly) String() string {
 	return fmt.Sprintf("Match only: %s", c.MatchPattern.String())
 }
 
-func fromRegexpMatches(matches [][]int, namedGroups []string, lineValue string, lineNumber int) Match {
+func fromRegexpMatches(submatches []int, namedGroups []string, lineValue string, lineNumber int) Match {
 	env := make(Environment)
 	var firstValue string
 	var firstRange Range
-	for _, m := range matches {
-		// iterate over pairs of offsets. Cf. FindAllStringSubmatchIndex
-		// https://pkg.go.dev/regexp#Regexp.FindAllStringSubmatchIndex.
-		for j := 0; j < len(m); j += 2 {
-			start := m[j]
-			end := m[j+1]
-			if start == -1 || end == -1 {
-				// The entire regexp matched, but a capture
-				// group inside it did not. Ignore this entry.
-				continue
-			}
-			value := lineValue[start:end]
-			range_ := newRange(lineNumber, lineNumber, start, end)
-
-			if j == 0 {
-				// The first submatch is the overall match
-				// value. Don't add this to the Environment
-				firstValue = value
-				firstRange = range_
-				continue
-			}
-
-			var v string
-			if namedGroups[j/2] == "" {
-				v = strconv.Itoa(j / 2)
-			} else {
-				v = namedGroups[j/2]
-			}
-			env[v] = Data{Value: value, Range: range_}
+	// iterate over pairs of offsets. Cf. FindAllStringSubmatchIndex
+	// https://pkg.go.dev/regexp#Regexp.FindAllStringSubmatchIndex.
+	for j := 0; j < len(submatches); j += 2 {
+		start := submatches[j]
+		end := submatches[j+1]
+		if start == -1 || end == -1 {
+			// The entire regexp matched, but a capture
+			// group inside it did not. Ignore this entry.
+			continue
 		}
+		value := lineValue[start:end]
+		range_ := newRange(lineNumber, lineNumber, start, end)
+
+		if j == 0 {
+			// The first submatch is the overall match
+			// value. Don't add this to the Environment
+			firstValue = value
+			firstRange = range_
+			continue
+		}
+
+		var v string
+		if namedGroups[j/2] == "" {
+			v = strconv.Itoa(j / 2)
+		} else {
+			v = namedGroups[j/2]
+		}
+		env[v] = Data{Value: value, Range: range_}
 	}
 	return Match{Value: firstValue, Range: firstRange, Environment: env}
 }
@@ -58,9 +56,8 @@ func fromRegexpMatches(matches [][]int, namedGroups []string, lineValue string, 
 func matchOnly(fm *result.FileMatch, r *regexp.Regexp) *MatchContext {
 	matches := make([]Match, 0, len(fm.LineMatches))
 	for _, l := range fm.LineMatches {
-		regexpMatches := r.FindAllStringSubmatchIndex(l.Preview, -1)
-		if len(regexpMatches) > 0 {
-			matches = append(matches, fromRegexpMatches(regexpMatches, r.SubexpNames(), l.Preview, int(l.LineNumber)))
+		for _, submatches := range r.FindAllStringSubmatchIndex(l.Preview, -1) {
+			matches = append(matches, fromRegexpMatches(submatches, r.SubexpNames(), l.Preview, int(l.LineNumber)))
 		}
 	}
 	return &MatchContext{Matches: matches, Path: fm.Path}

--- a/internal/compute/match_only_command_test.go
+++ b/internal/compute/match_only_command_test.go
@@ -137,4 +137,75 @@ func Test_matchOnly(t *testing.T) {
   ],
   "path": "bedge"
 }`).Equal(t, test("a(b(c))(de)f(g)h", match))
+
+	autogold.Want("compute regexp submatch includes all matches on line", `{
+  "matches": [
+    {
+      "value": "a",
+      "range": {
+        "start": {
+          "offset": -1,
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "offset": -1,
+          "line": 1,
+          "column": 1
+        }
+      },
+      "environment": {
+        "1": {
+          "value": "a",
+          "range": {
+            "start": {
+              "offset": -1,
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "offset": -1,
+              "line": 1,
+              "column": 1
+            }
+          }
+        }
+      }
+    },
+    {
+      "value": "g",
+      "range": {
+        "start": {
+          "offset": -1,
+          "line": 1,
+          "column": 6
+        },
+        "end": {
+          "offset": -1,
+          "line": 1,
+          "column": 7
+        }
+      },
+      "environment": {
+        "1": {
+          "value": "g",
+          "range": {
+            "start": {
+              "offset": -1,
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "offset": -1,
+              "line": 1,
+              "column": 7
+            }
+          }
+        }
+      }
+    }
+  ],
+  "path": "bedge"
+}`).Equal(t, test("([ag])", match))
+
 }


### PR DESCRIPTION
Fixes #29459. When multiple regex matches happened on a single line, only the first would be populated for compute results. (Previously all _subgroups_ were populated, but not all of the overall matches)