### PR TITLE
release: Add new get-started page to about batch change

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -437,6 +437,7 @@ cc @${config.captainGitHubUsername}
                         title: defaultPRMessage,
                         edits: [
                             `${sed} -i -E 's/sourcegraph\\/server:${versionRegex}/sourcegraph\\/server:${release.version}/g' 'website/src/components/GetStarted.tsx'`,
+                            `${sed} -i -E 's/sourcegraph\\/server:${versionRegex}/sourcegraph\\/server:${release.version}/g' 'website/src/pages/get-started.tsx'`,
                         ],
                         ...prBodyAndDraftState(
                             [],


### PR DESCRIPTION
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
Marketing added a new getting-started page to the About site. This adds the new page to the batch change to automatically update version numbers for the release.