### PR TITLE
monitoring: fix typo in panel legend

### DIFF
--- a/monitoring/definitions/zoekt_index_server.go
+++ b/monitoring/definitions/zoekt_index_server.go
@@ -267,7 +267,7 @@ func ZoektIndexServer() *monitoring.Container {
 							Description: "# of compound shards (per instance)",
 							Query:       "sum(index_number_compound_shards{instance=~`${instance:regex}`}) by (instance)",
 							NoAlert:     true,
-							Panel:       monitoring.Panel().LegendFormat("{{instance}}}").Unit(monitoring.Number),
+							Panel:       monitoring.Panel().LegendFormat("{{instance}}").Unit(monitoring.Number),
 							Owner:       monitoring.ObservableOwnerSearchCore,
 							Interpretation: `
 								The total number of compound shards per instance.


### PR DESCRIPTION
This removes the '}' in the panel's legend.

![image](https://user-images.githubusercontent.com/26413131/148347172-259815f3-722e-4902-9441-ef125ed496d4.png)



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
