### PR TITLE
search: Handle empty repository revisions in GraphQL resolver

### DIFF
--- a/enterprise/cmd/frontend/internal/searchcontexts/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/searchcontexts/resolvers/resolvers.go
@@ -69,7 +69,7 @@ func (r *Resolver) SearchContextBySpec(ctx context.Context, args graphqlbackend.
 	return &searchContextResolver{searchContext, r.db}, nil
 }
 
-func (r *Resolver) CreateSearchContext(ctx context.Context, args graphqlbackend.CreateSearchContextArgs) (graphqlbackend.SearchContextResolver, error) {
+func (r *Resolver) CreateSearchContext(ctx context.Context, args graphqlbackend.CreateSearchContextArgs) (_ graphqlbackend.SearchContextResolver, err error) {
 	var namespaceUserID, namespaceOrgID int32
 	if args.SearchContext.Namespace != nil {
 		err := graphqlbackend.UnmarshalNamespaceID(*args.SearchContext.Namespace, &namespaceUserID, &namespaceOrgID)
@@ -78,9 +78,12 @@ func (r *Resolver) CreateSearchContext(ctx context.Context, args graphqlbackend.
 		}
 	}
 
-	repositoryRevisions, err := r.repositoryRevisionsFromInputArgs(ctx, args.Repositories)
-	if err != nil {
-		return nil, err
+	var repositoryRevisions []*types.SearchContextRepositoryRevisions
+	if len(args.Repositories) > 0 {
+		repositoryRevisions, err = r.repositoryRevisionsFromInputArgs(ctx, args.Repositories)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	searchContext, err := searchcontexts.CreateSearchContextWithRepositoryRevisions(
@@ -108,9 +111,12 @@ func (r *Resolver) UpdateSearchContext(ctx context.Context, args graphqlbackend.
 		return nil, err
 	}
 
-	repositoryRevisions, err := r.repositoryRevisionsFromInputArgs(ctx, args.Repositories)
-	if err != nil {
-		return nil, err
+	var repositoryRevisions []*types.SearchContextRepositoryRevisions
+	if len(args.Repositories) > 0 {
+		repositoryRevisions, err = r.repositoryRevisionsFromInputArgs(ctx, args.Repositories)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	original, err := searchcontexts.ResolveSearchContextSpec(ctx, r.db, searchContextSpec)


### PR DESCRIPTION
This is another similar instance to yesterday's #29448. This time the
culprit is in `RepoStore().GetSetByIDs`, which will return all repos in
the database if no IDs are given.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
