### PR TITLE
Implement browser extension Sourcegraph URL dropdown for ease of URL switching

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/browser_extension.md
+++ b/.github/PULL_REQUEST_TEMPLATE/browser_extension.md
@@ -3,18 +3,16 @@ Closes https://github.com/sourcegraph/sourcegraph/issues/TODO.
 
 #### Description
 
-TODO: Add brief description.
-
-
-#### Screenshots (if applicable)
-| Before | After |
-| -: | :- |
-| | |
+TODO: Add a brief description of what PR includes.
 
 #### How to test
 
-TODO: Describe how to test for PR reviewers
+TODO: Describe how to test for PR reviewers.
 
+#### Screenshots (TODO: if applicable)
+| Before | After |
+| -: | :- |
+| | |
 
 #### Before merging
 

--- a/client/browser/CHANGELOG.md
+++ b/client/browser/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to Sourcegraph [Browser Extensions](./README.md) are documen
 ## Unreleased
 
 - Add extra field to log browser extension version [#issues/27845](https://github.com/sourcegraph/sourcegraph/issues/27845), [pull/27902](https://github.com/sourcegraph/sourcegraph/pull/27902)
+- Implement Sourcegraph URL dropdown for ease of URL switching [#issues/29030](https://github.com/sourcegraph/sourcegraph/issues/29030), [#pull/29471](https://github.com/sourcegraph/sourcegraph/pull/29471)
 
 ## Chrome v21.12.10.1012, Firefox v21.12.10.1048, Safari v1.9
 

--- a/client/browser/src/browser-extension/options-menu/OptionsPage.module.scss
+++ b/client/browser/src/browser-extension/options-menu/OptionsPage.module.scss
@@ -41,3 +41,40 @@
     padding: 0.5rem;
     border-radius: 100%;
 }
+
+.popover[data-reach-combobox-popover] {
+    margin: 0;
+    padding: 0.25rem 0;
+    background: var(--color-bg-1);
+    border: 1px solid var(--border-color);
+    border-radius: 3px;
+    box-shadow: var(--dropdown-shadow);
+
+    :global(.theme-dark) & {
+        background-color: var(--input-bg);
+    }
+
+    &,
+    [data-suggested-value] {
+        font-size: 0.875rem;
+        font-weight: normal;
+    }
+
+    [data-reach-combobox-list] {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    [data-reach-combobox-option] {
+        list-style: none;
+        margin: 0;
+        padding: 0.5rem 0.75rem;
+        cursor: pointer;
+
+        &:hover,
+        &[aria-selected='true'] {
+            background: var(--color-bg-3);
+        }
+    }
+}

--- a/client/browser/src/browser-extension/options-menu/OptionsPage.story.tsx
+++ b/client/browser/src/browser-extension/options-menu/OptionsPage.story.tsx
@@ -69,7 +69,6 @@ UrlValidationError.storyName = 'URL validation error'
 
 export const AskingForPermission: Story = () => (
     <OptionsPageWrapper
-        currentHost="github.com"
         permissionAlert={{ name: 'GitHub', icon: GithubIcon }}
         requestPermissionsHandler={requestPermissionsHandler}
     />
@@ -78,19 +77,11 @@ export const AskingForPermission: Story = () => (
 AskingForPermission.storyName = 'Asking for permission'
 
 export const OnPrivateRepository: Story = () => (
-    <OptionsPageWrapper
-        currentHost="github.com"
-        showPrivateRepositoryAlert={true}
-        requestPermissionsHandler={requestPermissionsHandler}
-    />
+    <OptionsPageWrapper showPrivateRepositoryAlert={true} requestPermissionsHandler={requestPermissionsHandler} />
 )
 
 OnPrivateRepository.storyName = 'On private repository'
 
 export const OnSourcegraphCloud: Story = () => (
-    <OptionsPageWrapper
-        currentHost="sourcegraph.com"
-        requestPermissionsHandler={requestPermissionsHandler}
-        showSourcegraphCloudAlert={true}
-    />
+    <OptionsPageWrapper requestPermissionsHandler={requestPermissionsHandler} showSourcegraphCloudAlert={true} />
 )

--- a/client/browser/src/browser-extension/options-menu/OptionsPage.story.tsx
+++ b/client/browser/src/browser-extension/options-menu/OptionsPage.story.tsx
@@ -6,7 +6,6 @@ import React, { useState } from 'react'
 import { Observable, of } from 'rxjs'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
-import { subtypeOf } from '@sourcegraph/shared/src/util/types'
 
 import brandedStyles from '../../branded.scss'
 
@@ -14,17 +13,6 @@ import { OptionsPage, OptionsPageProps } from './OptionsPage'
 
 const validateSourcegraphUrl = (): Observable<string | undefined> => of(undefined)
 const invalidSourcegraphUrl = (): Observable<string | undefined> => of('Arbitrary error string')
-
-const commonProps = () =>
-    subtypeOf<Partial<OptionsPageProps>>()({
-        onChangeOptionFlag: action('onChangeOptionFlag'),
-        optionFlags: [
-            { key: 'allowErrorReporting', label: 'Allow error reporting', value: false },
-            { key: 'experimentalLinkPreviews', label: 'Experimental link previews', value: false },
-        ],
-        version: text('version', '0.0.0'),
-        onChangeSourcegraphUrl: action('onChangeSourcegraphUrl'),
-    })
 
 const requestPermissionsHandler = action('requestPermission')
 
@@ -38,43 +26,41 @@ const config: Meta = {
 
 export default config
 
-export const Default: Story = () => (
+const OptionsPageWrapper: React.FunctionComponent<Partial<OptionsPageProps>> = props => (
     <OptionsPage
-        {...commonProps()}
-        showPrivateRepositoryAlert={boolean('isCurrentRepositoryPrivate', false)}
-        showSourcegraphCloudAlert={boolean('showSourcegraphCloudAlert', false)}
-        validateSourcegraphUrl={validateSourcegraphUrl}
-        onToggleActivated={action('onToggleActivated')}
-        isActivated={true}
-        sourcegraphUrl={text('sourcegraphUrl', 'https://sourcegraph.com')}
         isFullPage={true}
+        isActivated={true}
+        onToggleActivated={action('onToggleActivated')}
+        optionFlags={[
+            { key: 'allowErrorReporting', label: 'Allow error reporting', value: false },
+            { key: 'experimentalLinkPreviews', label: 'Experimental link previews', value: false },
+        ]}
+        onChangeOptionFlag={action('onChangeOptionFlag')}
+        version={text('version', '0.0.0')}
+        sourcegraphUrl={text('sourcegraphUrl', 'https://sourcegraph.com')}
+        validateSourcegraphUrl={validateSourcegraphUrl}
+        onChangeSourcegraphUrl={action('onChangeSourcegraphUrl')}
+        showPrivateRepositoryAlert={boolean('showPrivateRepositoryAlert', false)}
+        showSourcegraphCloudAlert={boolean('showSourcegraphCloudAlert', false)}
+        suggestedSourcegraphUrls={['https://k8s.sgdev.org', 'https://sourcegraph.com']}
+        {...props}
     />
 )
+
+export const Default: Story = () => <OptionsPageWrapper />
+
 export const Interactive: Story = () => {
     const [isActivated, setIsActivated] = useState(false)
-    return (
-        <OptionsPage
-            {...commonProps()}
-            isActivated={isActivated}
-            onToggleActivated={setIsActivated}
-            validateSourcegraphUrl={validateSourcegraphUrl}
-            sourcegraphUrl={text('sourcegraphUrl', 'https://sourcegraph.com')}
-            showPrivateRepositoryAlert={boolean('showPrivateRepositoryAlert', false)}
-            showSourcegraphCloudAlert={boolean('showSourcegraphCloudAlert', false)}
-            isFullPage={true}
-        />
-    )
+    return <OptionsPageWrapper isActivated={isActivated} onToggleActivated={setIsActivated} />
 }
 export const UrlValidationError: Story = () => {
     const [isActivated, setIsActivated] = useState(false)
     return (
-        <OptionsPage
-            {...commonProps()}
+        <OptionsPageWrapper
             isActivated={isActivated}
             onToggleActivated={setIsActivated}
             validateSourcegraphUrl={invalidSourcegraphUrl}
             sourcegraphUrl={text('sourcegraphUrl', 'https://not-sourcegraph.com')}
-            isFullPage={true}
         />
     )
 }
@@ -82,13 +68,7 @@ export const UrlValidationError: Story = () => {
 UrlValidationError.storyName = 'URL validation error'
 
 export const AskingForPermission: Story = () => (
-    <OptionsPage
-        {...commonProps()}
-        validateSourcegraphUrl={validateSourcegraphUrl}
-        onToggleActivated={action('onToggleActivated')}
-        isActivated={true}
-        sourcegraphUrl={text('sourcegraphUrl', 'https://sourcegraph.com')}
-        isFullPage={true}
+    <OptionsPageWrapper
         currentHost="github.com"
         permissionAlert={{ name: 'GitHub', icon: GithubIcon }}
         requestPermissionsHandler={requestPermissionsHandler}
@@ -98,13 +78,7 @@ export const AskingForPermission: Story = () => (
 AskingForPermission.storyName = 'Asking for permission'
 
 export const OnPrivateRepository: Story = () => (
-    <OptionsPage
-        {...commonProps()}
-        validateSourcegraphUrl={validateSourcegraphUrl}
-        onToggleActivated={action('onToggleActivated')}
-        isActivated={true}
-        sourcegraphUrl={text('sourcegraphUrl', 'https://sourcegraph.com')}
-        isFullPage={true}
+    <OptionsPageWrapper
         currentHost="github.com"
         showPrivateRepositoryAlert={true}
         requestPermissionsHandler={requestPermissionsHandler}
@@ -114,13 +88,7 @@ export const OnPrivateRepository: Story = () => (
 OnPrivateRepository.storyName = 'On private repository'
 
 export const OnSourcegraphCloud: Story = () => (
-    <OptionsPage
-        {...commonProps()}
-        validateSourcegraphUrl={validateSourcegraphUrl}
-        onToggleActivated={action('onToggleActivated')}
-        isActivated={true}
-        sourcegraphUrl={text('sourcegraphUrl', 'https://sourcegraph.com')}
-        isFullPage={true}
+    <OptionsPageWrapper
         currentHost="sourcegraph.com"
         requestPermissionsHandler={requestPermissionsHandler}
         showSourcegraphCloudAlert={true}

--- a/client/browser/src/browser-extension/options-menu/OptionsPage.tsx
+++ b/client/browser/src/browser-extension/options-menu/OptionsPage.tsx
@@ -1,8 +1,10 @@
+import { Combobox, ComboboxInput, ComboboxOption, ComboboxPopover, ComboboxList } from '@reach/combobox'
 import classNames from 'classnames'
 import BookOpenPageVariantIcon from 'mdi-react/BookOpenPageVariantIcon'
 import CheckCircleOutlineIcon from 'mdi-react/CheckCircleOutlineIcon'
 import EarthIcon from 'mdi-react/EarthIcon'
 import LockIcon from 'mdi-react/LockIcon'
+import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Observable } from 'rxjs'
 
@@ -12,11 +14,11 @@ import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
 import { useInputValidation, deriveInputClassName } from '@sourcegraph/shared/src/util/useInputValidation'
 import { Button } from '@sourcegraph/wildcard'
 
-import { knownCodeHosts } from '../knownCodeHosts'
-
 import { OptionsPageContainer } from './components/OptionsPageContainer'
 import styles from './OptionsPage.module.scss'
 import { OptionsPageAdvancedSettings } from './OptionsPageAdvancedSettings'
+
+import '@reach/combobox/styles.css'
 
 export interface OptionsPageProps {
     version: string
@@ -25,6 +27,9 @@ export interface OptionsPageProps {
     sourcegraphUrl: string
     validateSourcegraphUrl: (url: string) => Observable<string | undefined>
     onChangeSourcegraphUrl: (url: string) => void
+
+    // Suggested Sourcegraph URLs
+    suggestedSourcegraphUrls: string[]
 
     // Option flags
     optionFlags: { key: string; label: string; value: boolean }[]
@@ -38,12 +43,16 @@ export interface OptionsPageProps {
     showSourcegraphCloudAlert?: boolean
     permissionAlert?: { name: string; icon?: React.ComponentType<{ className?: string }> }
     requestPermissionsHandler?: React.MouseEventHandler
-    currentHost?: string
 }
 
 // "Error code" constants for Sourcegraph URL validation
 export const URL_FETCH_ERROR = 'URL_FETCH_ERROR'
 export const URL_AUTH_ERROR = 'URL_AUTH_ERROR'
+
+const NEW_TAB_LINK_PROPS: Pick<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'rel' | 'target'> = {
+    target: '_blank',
+    rel: 'noopener noreferrer',
+}
 
 export const OptionsPage: React.FunctionComponent<OptionsPageProps> = ({
     version,
@@ -59,48 +68,18 @@ export const OptionsPage: React.FunctionComponent<OptionsPageProps> = ({
     optionFlags,
     onChangeOptionFlag,
     onChangeSourcegraphUrl,
-    currentHost,
+    suggestedSourcegraphUrls,
 }) => {
     const [showAdvancedSettings, setShowAdvancedSettings] = useState(false)
-    const urlInputReference = useRef<HTMLInputElement | null>(null)
-    const [urlState, nextUrlFieldChange, nextUrlInputElement] = useInputValidation(
-        useMemo(
-            () => ({
-                initialValue: sourcegraphUrl,
-                synchronousValidators: [],
-                asynchronousValidators: [validateSourcegraphUrl],
-            }),
-            [sourcegraphUrl, validateSourcegraphUrl]
-        )
-    )
-
-    const urlInputElements = useCallback(
-        (urlInputElement: HTMLInputElement | null) => {
-            urlInputReference.current = urlInputElement
-            nextUrlInputElement(urlInputElement)
-        },
-        [nextUrlInputElement]
-    )
 
     const toggleAdvancedSettings = useCallback(
         () => setShowAdvancedSettings(showAdvancedSettings => !showAdvancedSettings),
         []
     )
 
-    const linkProps: Pick<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'rel' | 'target'> = {
-        target: '_blank',
-        rel: 'noopener noreferrer',
-    }
-
-    useEffect(() => {
-        if (urlState.kind === 'VALID') {
-            onChangeSourcegraphUrl(urlState.value)
-        }
-    }, [onChangeSourcegraphUrl, urlState])
-
     return (
         <OptionsPageContainer className="shadow" isFullPage={isFullPage}>
-            <section className={styles.section}>
+            <section className={classNames(styles.section, 'pb-2')}>
                 <div className="d-flex justify-content-between">
                     <SourcegraphLogo className={styles.logo} />
                     <div>
@@ -114,64 +93,23 @@ export const OptionsPage: React.FunctionComponent<OptionsPageProps> = ({
                 </div>
                 <div className={styles.version}>v{version}</div>
             </section>
-            <CodeHostsSection currentHost={currentHost} />
+            <section className={styles.section}>
+                Get code intelligence tooltips while browsing and reviewing code on your code host.{' '}
+                <a href="https://docs.sourcegraph.com/integration/browser_extension#features" {...NEW_TAB_LINK_PROPS}>
+                    Learn more
+                </a>{' '}
+                about the extension and compatible code hosts.
+            </section>
             <section className={classNames('border-0', styles.section)}>
-                {/* eslint-disable-next-line react/forbid-elements */}
-                <form onSubmit={preventDefault} noValidate={true}>
-                    <label htmlFor="sourcegraph-url">Sourcegraph URL</label>
-                    <LoaderInput
-                        loading={urlState.kind === 'LOADING'}
-                        className={classNames(deriveInputClassName(urlState))}
-                    >
-                        <input
-                            className={classNames(
-                                'form-control',
-                                deriveInputClassName(urlState),
-                                'test-sourcegraph-url'
-                            )}
-                            id="sourcegraph-url"
-                            type="url"
-                            pattern="^https://.*"
-                            value={urlState.value}
-                            onChange={nextUrlFieldChange}
-                            ref={urlInputElements}
-                            spellCheck={false}
-                            required={true}
-                        />
-                    </LoaderInput>
-                    {urlState.kind === 'LOADING' ? (
-                        <small className="text-muted d-block mt-1">Checking...</small>
-                    ) : urlState.kind === 'INVALID' ? (
-                        <small className="invalid-feedback">
-                            {urlState.reason === URL_FETCH_ERROR ? (
-                                'Incorrect Sourcegraph instance address'
-                            ) : urlState.reason === URL_AUTH_ERROR ? (
-                                <>
-                                    Authentication to Sourcegraph failed.{' '}
-                                    <a href={urlState.value} {...linkProps}>
-                                        Sign in to your instance
-                                    </a>{' '}
-                                    to continue
-                                </>
-                            ) : urlInputReference.current?.validity.typeMismatch ? (
-                                'Please enter a valid URL, including the protocol prefix (e.g. https://sourcegraph.example.com).'
-                            ) : urlInputReference.current?.validity.patternMismatch ? (
-                                'The browser extension can only work over HTTPS in modern browsers.'
-                            ) : (
-                                urlState.reason
-                            )}
-                        </small>
-                    ) : (
-                        <small className="valid-feedback test-valid-sourcegraph-url-feedback">Looks good!</small>
-                    )}
-                </form>
-                <p className="mt-3 mb-1">
+                <SourcegraphURLForm
+                    value={sourcegraphUrl}
+                    suggestions={suggestedSourcegraphUrls}
+                    onChange={onChangeSourcegraphUrl}
+                    validate={validateSourcegraphUrl}
+                />
+                <p className="mt-2 mb-0">
                     <small>Enter the URL of your Sourcegraph instance to use the extension on private code.</small>
                 </p>
-
-                <a href="https://docs.sourcegraph.com/integration/browser_extension#privacy" {...linkProps}>
-                    <small>How do we keep your code private?</small>
-                </a>
             </section>
 
             {permissionAlert && (
@@ -182,9 +120,21 @@ export const OptionsPage: React.FunctionComponent<OptionsPageProps> = ({
 
             {showPrivateRepositoryAlert && <PrivateRepositoryAlert />}
             <section className={styles.section}>
+                <a
+                    href="https://docs.sourcegraph.com/integration/browser_extension#privacy"
+                    {...NEW_TAB_LINK_PROPS}
+                    className="d-block mb-1"
+                >
+                    <small>How do we keep your code private?</small> <OpenInNewIcon size="0.75rem" className="ml-2" />
+                </a>
                 <p className="mb-0">
-                    <Button className="p-0" onClick={toggleAdvancedSettings} variant="link" size="sm">
-                        <small>{showAdvancedSettings ? 'Hide' : 'Show'} advanced settings</small>
+                    <Button
+                        className="p-0 shadow-none font-weight-normal"
+                        onClick={toggleAdvancedSettings}
+                        variant="link"
+                        size="sm"
+                    >
+                        {showAdvancedSettings ? 'Hide' : 'Show'} advanced settings
                     </Button>
                 </p>
                 {showAdvancedSettings && (
@@ -193,13 +143,13 @@ export const OptionsPage: React.FunctionComponent<OptionsPageProps> = ({
             </section>
             <section className="d-flex">
                 <div className={styles.splitSectionPart}>
-                    <a href="https://sourcegraph.com/search" {...linkProps}>
+                    <a href="https://sourcegraph.com/search" {...NEW_TAB_LINK_PROPS}>
                         <EarthIcon className="icon-inline mr-2" />
                         Sourcegraph Cloud
                     </a>
                 </div>
                 <div className={styles.splitSectionPart}>
-                    <a href="https://docs.sourcegraph.com" {...linkProps}>
+                    <a href="https://docs.sourcegraph.com" {...NEW_TAB_LINK_PROPS}>
                         <BookOpenPageVariantIcon className="icon-inline mr-2" />
                         Documentation
                     </a>
@@ -262,25 +212,6 @@ const PrivateRepositoryAlert: React.FunctionComponent = () => (
     </section>
 )
 
-const CodeHostsSection: React.FunctionComponent<{ currentHost?: string }> = ({ currentHost }) => (
-    <section className={styles.section}>
-        <p>Get code intelligence tooltips while browsing files and reading PRs on your code host.</p>
-        <div>
-            {knownCodeHosts.map(({ host, icon: Icon }) => (
-                <span
-                    key={host}
-                    className={classNames(styles.icon, {
-                        // Use `endsWith` in order to match subdomains.
-                        'bg-3': currentHost?.endsWith(host),
-                    })}
-                >
-                    {Icon && <Icon />}
-                </span>
-            ))}
-        </div>
-    </section>
-)
-
 const SourcegraphCloudAlert: React.FunctionComponent = () => (
     <section className={classNames('bg-2', styles.section)}>
         <h4>
@@ -293,4 +224,122 @@ const SourcegraphCloudAlert: React.FunctionComponent = () => (
 
 function preventDefault(event: React.FormEvent<HTMLFormElement>): void {
     event.preventDefault()
+}
+
+interface SourcegraphURLFormProps {
+    value: OptionsPageProps['sourcegraphUrl']
+    validate: OptionsPageProps['validateSourcegraphUrl']
+    onChange: OptionsPageProps['onChangeSourcegraphUrl']
+    suggestions: OptionsPageProps['sourcegraphUrl'][]
+}
+
+export const SourcegraphURLForm: React.FunctionComponent<SourcegraphURLFormProps> = ({
+    value,
+    validate,
+    suggestions,
+    onChange,
+}) => {
+    const urlInputReference = useRef<HTMLInputElement | null>(null)
+
+    const [urlState, nextUrlFieldChange, nextUrlInputElement] = useInputValidation(
+        useMemo(
+            () => ({
+                initialValue: value,
+                synchronousValidators: [],
+                asynchronousValidators: [validate],
+            }),
+            [value, validate]
+        )
+    )
+
+    const urlInputElements = useCallback(
+        (urlInputElement: HTMLInputElement | null) => {
+            urlInputReference.current = urlInputElement
+            nextUrlInputElement(urlInputElement)
+        },
+        [nextUrlInputElement]
+    )
+
+    /**
+     * BEGIN: Workaround for reach/combobox undesirably expanded
+     *
+     * @see https://github.com/reach/reach-ui/issues/755
+     */
+    const [hasInteracted, setHasInteracted] = useState(false)
+    const onFocus = useCallback(() => {
+        if (!hasInteracted) {
+            setHasInteracted(true)
+        }
+    }, [hasInteracted])
+    /**
+     * END: Workaround for reach/combobox undesirably expanded
+     */
+
+    useEffect(() => {
+        if (urlState.kind === 'VALID') {
+            onChange(urlState.value)
+        }
+    }, [onChange, urlState])
+
+    return (
+        // eslint-disable-next-line react/forbid-elements
+        <form onSubmit={preventDefault} noValidate={true}>
+            <label htmlFor="sourcegraph-url">Sourcegraph URL</label>
+            <Combobox openOnFocus={true} onSelect={nextUrlFieldChange}>
+                <LoaderInput loading={urlState.kind === 'LOADING'} className={deriveInputClassName(urlState)}>
+                    <ComboboxInput
+                        type="url"
+                        required={true}
+                        spellCheck={false}
+                        autoComplete="off"
+                        autocomplete={false}
+                        pattern="^https://.*"
+                        onFocus={onFocus}
+                        id="sourcegraph-url"
+                        ref={urlInputElements}
+                        value={urlState.value}
+                        onChange={nextUrlFieldChange}
+                        className={classNames('form-control', 'test-sourcegraph-url', deriveInputClassName(urlState))}
+                    />
+                </LoaderInput>
+
+                {suggestions.length > 1 && hasInteracted && (
+                    <ComboboxPopover className={styles.popover}>
+                        <ComboboxList>
+                            {suggestions.map(suggestion => (
+                                <ComboboxOption key={suggestion} value={suggestion} />
+                            ))}
+                        </ComboboxList>
+                    </ComboboxPopover>
+                )}
+            </Combobox>
+            <div className="mt-2">
+                {urlState.kind === 'LOADING' ? (
+                    <small className="d-block text-muted">Checking...</small>
+                ) : urlState.kind === 'INVALID' ? (
+                    <small className="d-block invalid-feedback">
+                        {urlState.reason === URL_FETCH_ERROR ? (
+                            'Incorrect Sourcegraph instance address'
+                        ) : urlState.reason === URL_AUTH_ERROR ? (
+                            <>
+                                Authentication to Sourcegraph failed.{' '}
+                                <a href={urlState.value} {...NEW_TAB_LINK_PROPS}>
+                                    Sign in to your instance
+                                </a>{' '}
+                                to continue
+                            </>
+                        ) : urlInputReference.current?.validity.typeMismatch ? (
+                            'Please enter a valid URL, including the protocol prefix (e.g. https://sourcegraph.example.com).'
+                        ) : urlInputReference.current?.validity.patternMismatch ? (
+                            'The browser extension can only work over HTTPS in modern browsers.'
+                        ) : (
+                            urlState.reason
+                        )}
+                    </small>
+                ) : (
+                    <small className="d-block valid-feedback test-valid-sourcegraph-url-feedback">Looks good!</small>
+                )}
+            </div>
+        </form>
+    )
 }

--- a/client/browser/src/browser-extension/options-menu/OptionsPageAdvancedSettings.tsx
+++ b/client/browser/src/browser-extension/options-menu/OptionsPageAdvancedSettings.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import React from 'react'
 
 interface OptionsPageAdvancedSettingsProps {
@@ -9,25 +10,29 @@ export const OptionsPageAdvancedSettings: React.FunctionComponent<OptionsPageAdv
     optionFlags,
     onChangeOptionFlag,
 }) => (
-    <section className="mt-3">
-        <h6>
-            <small>Configuration</small>
-        </h6>
-        <div>
-            {optionFlags.map(({ label, key, value }) => (
-                <div className="form-check" key={key}>
-                    <label className="form-check-label">
-                        <input
-                            id={key}
-                            onChange={event => onChangeOptionFlag(key, event.target.checked)}
-                            className="form-check-input"
-                            type="checkbox"
-                            checked={value}
-                        />{' '}
-                        {label}
-                    </label>
-                </div>
+    <section className="mt-2">
+        <ul className="p-0 m-0">
+            {optionFlags.map(({ label, key, value }, index) => (
+                <li className="form-check" key={key}>
+                    <small>
+                        <label
+                            className={classNames(
+                                'form-check-label cursor-pointer d-flex align-items-center font-weight-normal',
+                                { 'mb-2': index !== optionFlags.length - 1 }
+                            )}
+                        >
+                            <input
+                                id={key}
+                                onChange={event => onChangeOptionFlag(key, event.target.checked)}
+                                className="form-check-input mb-0 mt-0"
+                                type="checkbox"
+                                checked={value}
+                            />{' '}
+                            {label}
+                        </label>
+                    </small>
+                </li>
             ))}
-        </div>
+        </ul>
     </section>
 )

--- a/client/browser/src/browser-extension/options-menu/components/OptionsPageContainer.module.scss
+++ b/client/browser/src/browser-extension/options-menu/components/OptionsPageContainer.module.scss
@@ -1,5 +1,5 @@
 .options-page {
-    width: 26rem;
+    width: 23rem;
 
     &--full {
         margin: 8rem auto;

--- a/client/browser/src/browser-extension/scripts/optionsPage.main.tsx
+++ b/client/browser/src/browser-extension/scripts/optionsPage.main.tsx
@@ -2,30 +2,28 @@
 import '../../shared/polyfills'
 
 import { uniq } from 'lodash'
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { render } from 'react-dom'
-import { from, noop, Observable, combineLatest } from 'rxjs'
-import { catchError, map, mapTo } from 'rxjs/operators'
+import { from, noop, Observable } from 'rxjs'
+import { catchError, distinctUntilChanged, map, mapTo } from 'rxjs/operators'
 import { Optional } from 'utility-types'
 
 import { asError } from '@sourcegraph/common'
 import { GraphQLResult } from '@sourcegraph/http-client'
 import { AnchorLink, setLinkComponent } from '@sourcegraph/shared/src/components/Link'
-import { isFirefox } from '@sourcegraph/shared/src/util/browserDetection'
+import { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 
 import { fetchSite } from '../../shared/backend/server'
-import { isExtension } from '../../shared/context'
 import { initSentry } from '../../shared/sentry'
+import { ConditionalTelemetryService, EventLogger } from '../../shared/tracking/eventLogger'
 import { observeSourcegraphURL, getExtensionVersion, isDefaultSourcegraphUrl } from '../../shared/util/context'
 import { featureFlags } from '../../shared/util/featureFlags'
 import {
     OptionFlagKey,
-    OptionFlagWithValue,
-    assignOptionFlagValues,
-    observeOptionFlags,
-    shouldOverrideSendTelemetry,
     optionFlagDefinitions,
+    observeSendTelemetry,
+    observeOptionFlagsWithValues,
 } from '../../shared/util/optionFlags'
 import { assertEnvironment } from '../environmentAssertion'
 import { KnownCodeHost, knownCodeHosts } from '../knownCodeHosts'
@@ -77,19 +75,19 @@ const fetchCurrentTabStatus = async (): Promise<TabStatus> => {
 }
 
 // Make GraphQL requests from background page
-function requestGraphQL<T, V = object>(options: {
+const createRequestGraphQL = (sourcegraphURL: string) => <T, V = object>(options: {
     request: string
     variables: V
-    sourcegraphURL?: string
-}): Observable<GraphQLResult<T>> {
-    return from(background.requestGraphQL<T, V>(options))
-}
+}): Observable<GraphQLResult<T>> =>
+    from(
+        background.requestGraphQL<T, V>({ ...options, sourcegraphURL })
+    )
 
 const version = getExtensionVersion()
 const isFullPage = !new URLSearchParams(window.location.search).get('popup')
 
 const validateSourcegraphUrl = (url: string): Observable<string | undefined> =>
-    fetchSite(options => requestGraphQL({ ...options, sourcegraphURL: url })).pipe(
+    fetchSite(options => createRequestGraphQL(url)(options)).pipe(
         mapTo(undefined),
         catchError(error => {
             const { message } = asError(error)
@@ -106,26 +104,11 @@ const validateSourcegraphUrl = (url: string): Observable<string | undefined> =>
         })
     )
 
-const observeOptionFlagsWithValues = (): Observable<OptionFlagWithValue[]> => {
-    const overrideSendTelemetry: Observable<boolean> = observeSourcegraphURL(IS_EXTENSION).pipe(
-        map(sourcegraphUrl => shouldOverrideSendTelemetry(isFirefox(), isExtension, sourcegraphUrl))
-    )
-
-    return combineLatest([observeOptionFlags(), overrideSendTelemetry]).pipe(
-        map(([flags, override]) => {
-            const definitions = assignOptionFlagValues(flags)
-            if (override) {
-                return definitions.filter(flag => flag.key !== 'sendTelemetry')
-            }
-            return definitions
-        })
-    )
-}
-
 const observingIsActivated = observeStorageKey('sync', 'disableExtension').pipe(map(isDisabled => !isDisabled))
 const observingPreviouslyUsedUrls = observeStorageKey('sync', 'previouslyUsedURLs')
-const observingSourcegraphUrl = observeSourcegraphURL(true)
-const observingOptionFlagsWithValues = observeOptionFlagsWithValues()
+const observingSourcegraphUrl = observeSourcegraphURL(true).pipe(distinctUntilChanged())
+const observingOptionFlagsWithValues = observeOptionFlagsWithValues(IS_EXTENSION)
+const observingSendTelemetry = observeSendTelemetry(IS_EXTENSION)
 
 function handleToggleActivated(isActivated: boolean): void {
     storage.sync.set({ disableExtension: !isActivated }).catch(console.error)
@@ -146,8 +129,24 @@ function buildRequestPermissionsHandler({ protocol, host }: TabStatus) {
     }
 }
 
+function useTelemetryService(sourcegraphUrl: string | undefined): TelemetryService {
+    const telemetryService = useMemo(
+        () =>
+            new ConditionalTelemetryService(
+                new EventLogger(createRequestGraphQL(sourcegraphUrl!), sourcegraphUrl!),
+                observingSendTelemetry
+            ),
+        [sourcegraphUrl]
+    )
+
+    useEffect(() => () => telemetryService.unsubscribe(), [telemetryService])
+    return telemetryService
+}
+
 const Options: React.FunctionComponent = () => {
     const sourcegraphUrl = useObservable(observingSourcegraphUrl)
+    const [previousSourcegraphUrl, setPreviousSourcegraphUrl] = useState(sourcegraphUrl)
+    const telemetryService = useTelemetryService(sourcegraphUrl)
     const previouslyUsedUrls = useObservable(observingPreviouslyUsedUrls)
     const isActivated = useObservable(observingIsActivated)
     const optionFlagsWithValues = useObservable(observingOptionFlagsWithValues)
@@ -180,11 +179,30 @@ const Options: React.FunctionComponent = () => {
 
     const handleChangeSourcegraphUrl = useCallback(
         (url: string): void => {
-            storage.sync.set({ sourcegraphURL: url }).catch(console.error)
-            storage.sync.set({ previouslyUsedURLs: uniq([...(previouslyUsedUrls || []), url]) }).catch(console.error)
+            if (sourcegraphUrl === url) {
+                return
+            }
+            storage.sync
+                .set({ sourcegraphURL: url, previouslyUsedURLs: uniq([...(previouslyUsedUrls || []), url]) })
+                .catch(console.error)
         },
-        [previouslyUsedUrls]
+        [previouslyUsedUrls, sourcegraphUrl]
     )
+
+    useEffect(() => {
+        setPreviousSourcegraphUrl(sourcegraphUrl)
+    }, [sourcegraphUrl])
+
+    useEffect(() => {
+        if (
+            previousSourcegraphUrl !== sourcegraphUrl &&
+            isDefaultSourcegraphUrl(sourcegraphUrl) &&
+            previouslyUsedUrls &&
+            previouslyUsedUrls.length >= 2
+        ) {
+            telemetryService.log('Bext_NumberURLs')
+        }
+    }, [sourcegraphUrl, telemetryService, previouslyUsedUrls, previousSourcegraphUrl])
 
     return (
         <ThemeWrapper>

--- a/client/browser/src/browser-extension/web-extension-api/types.ts
+++ b/client/browser/src/browser-extension/web-extension-api/types.ts
@@ -43,7 +43,14 @@ export const featureFlagDefaults: FeatureFlags = {
 }
 
 interface SourcegraphURL {
+    /**
+     * Current connected/active sourcegraph URL
+     */
     sourcegraphURL: string
+    /**
+     * All previously successfully used sourcegraph URLs
+     */
+    previouslyUsedURLs?: string[]
 }
 
 export interface SyncStorageItems extends SourcegraphURL {

--- a/client/browser/src/shared/backend/userEvents.tsx
+++ b/client/browser/src/shared/backend/userEvents.tsx
@@ -3,7 +3,6 @@ import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
 import * as GQL from '@sourcegraph/shared/src/schema'
 
 import { UserEvent, EventSource } from '../../graphql-operations'
-import { isDefaultSourcegraphUrl } from '../util/context'
 
 /**
  * Log a user action on the associated self-hosted Sourcegraph instance (allows site admins on a private
@@ -41,18 +40,12 @@ export const logUserEvent = (
 }
 
 /**
- * Log a raw user action on the associated self-hosted Sourcegraph instance (allows site admins on a private
- * Sourcegraph instance to see a count of unique users on a daily, weekly, and monthly basis).
+ * Log a raw user action on the associated Sourcegraph instance
  */
 export const logEvent = (
     event: { name: string; userCookieID: string; url: string; argument?: string | {} },
     requestGraphQL: PlatformContext['requestGraphQL']
 ): void => {
-    // Only send the request if this is a private, self-hosted Sourcegraph instance.
-    if (isDefaultSourcegraphUrl(event.url)) {
-        return
-    }
-
     requestGraphQL<GQL.IMutation>({
         request: gql`
             mutation logEvent(

--- a/client/browser/src/shared/code-hosts/shared/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/shared/codeHost.tsx
@@ -67,7 +67,6 @@ import { getModeFromPath } from '@sourcegraph/shared/src/languages'
 import { URLToFileContext } from '@sourcegraph/shared/src/platform/context'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { isFirefox } from '@sourcegraph/shared/src/util/browserDetection'
 import { asObservable } from '@sourcegraph/shared/src/util/rxjs/asObservable'
 import { isInstanceOf, property } from '@sourcegraph/shared/src/util/types'
 import {
@@ -90,16 +89,11 @@ import { CodeViewToolbar, CodeViewToolbarClassProps } from '../../components/Cod
 import { isExtension, isInPage } from '../../context'
 import { SourcegraphIntegrationURLs, BrowserPlatformContext } from '../../platform/context'
 import { resolveRevision, retryWhenCloneInProgressError, resolvePrivateRepo } from '../../repo/backend'
-import { EventLogger, ConditionalTelemetryService } from '../../tracking/eventLogger'
-import {
-    DEFAULT_SOURCEGRAPH_URL,
-    getPlatformName,
-    isDefaultSourcegraphUrl,
-    observeSourcegraphURL,
-} from '../../util/context'
+import { ConditionalTelemetryService, EventLogger } from '../../tracking/eventLogger'
+import { DEFAULT_SOURCEGRAPH_URL, getPlatformName, isDefaultSourcegraphUrl } from '../../util/context'
 import { MutationRecordLike, querySelectorOrSelf } from '../../util/dom'
 import { featureFlags } from '../../util/featureFlags'
-import { shouldOverrideSendTelemetry, observeOptionFlag } from '../../util/optionFlags'
+import { observeSendTelemetry } from '../../util/optionFlags'
 import { bitbucketCloudCodeHost } from '../bitbucket-cloud/codeHost'
 import { bitbucketServerCodeHost } from '../bitbucket/codeHost'
 import { gerritCodeHost } from '../gerrit/codeHost'
@@ -1480,21 +1474,20 @@ export function injectCodeIntelligenceToCodeHost(
 
     subscriptions.add(extensionsController)
 
-    const overrideSendTelemetry = observeSourcegraphURL(isExtension).pipe(
-        map(sourcegraphUrl => shouldOverrideSendTelemetry(isFirefox(), isExtension, sourcegraphUrl))
+    const isTelemetryEnabled = combineLatest([
+        observeSendTelemetry(isExtension),
+        from(codeHost.getContext?.().then(context => context.privateRepository) ?? Promise.resolve(true)),
+    ]).pipe(
+        map(
+            ([sendTelemetry, isPrivateRepo]) =>
+                sendTelemetry &&
+                /** Enable telemetry if: a) this is a self-hosted Sourcegraph instance; b) or public repository; */
+                (!isDefaultSourcegraphUrl(sourcegraphURL) || !isPrivateRepo)
+        )
     )
 
-    const observeSendTelemetry = combineLatest([overrideSendTelemetry, observeOptionFlag('sendTelemetry')]).pipe(
-        map(([override, sendTelemetry]) => {
-            if (override) {
-                return true
-            }
-            return sendTelemetry
-        })
-    )
-
-    const innerTelemetryService = new EventLogger(isExtension, requestGraphQL)
-    const telemetryService = new ConditionalTelemetryService(innerTelemetryService, observeSendTelemetry)
+    const innerTelemetryService = new EventLogger(requestGraphQL, sourcegraphURL)
+    const telemetryService = new ConditionalTelemetryService(innerTelemetryService, isTelemetryEnabled)
     subscriptions.add(telemetryService)
 
     let codeHostSubscription: Subscription

--- a/client/browser/src/shared/util/optionFlags.ts
+++ b/client/browser/src/shared/util/optionFlags.ts
@@ -1,10 +1,12 @@
-import { Observable, of } from 'rxjs'
+import { combineLatest, Observable, of } from 'rxjs'
 import { map, distinctUntilChanged } from 'rxjs/operators'
+
+import { isFirefox } from '@sourcegraph/shared/src/util/browserDetection'
 
 import { observeStorageKey } from '../../browser-extension/web-extension-api/storage'
 import { isExtension } from '../context'
 
-import { isDefaultSourcegraphUrl } from './context'
+import { isDefaultSourcegraphUrl, observeSourcegraphURL } from './context'
 
 const OPTION_FLAGS_SYNC_STORAGE_KEY = 'featureFlags'
 
@@ -48,22 +50,22 @@ const optionFlagDefaults: OptionFlagValues = {
     experimentalTextFieldCompletion: false,
 }
 
-export function assignOptionFlagValues(values: OptionFlagValues): OptionFlagWithValue[] {
-    return optionFlagDefinitions.map(flag => ({ ...flag, value: values[flag.key] }))
-}
+const assignOptionFlagValues = (values: OptionFlagValues): OptionFlagWithValue[] =>
+    optionFlagDefinitions.map(flag => ({ ...flag, value: values[flag.key] }))
 
 /**
  * Apply default values to option flags, taking a partial option flag values
  * object and returning a complete option flag values object.
  */
-export function applyOptionFlagDefaults(values: Partial<OptionFlagValues> | undefined): OptionFlagValues {
-    return { ...optionFlagDefaults, ...values }
-}
+const applyOptionFlagDefaults = (values: Partial<OptionFlagValues> | undefined): OptionFlagValues => ({
+    ...optionFlagDefaults,
+    ...values,
+})
 
 /**
  * Observe the option flags object, with default values already applied.
  */
-export const observeOptionFlags = (): Observable<OptionFlagValues> => {
+const observeOptionFlags = (): Observable<OptionFlagValues> => {
     const optionFlagsStorageObservable = isExtension
         ? observeStorageKey('sync', OPTION_FLAGS_SYNC_STORAGE_KEY)
         : of(undefined)
@@ -81,19 +83,49 @@ export function observeOptionFlag(key: OptionFlagKey): Observable<boolean> {
 }
 
 /**
- * Determine if the sendTelemetry option flag should be overriden.
+ * Determine if the sendTelemetry option flag should be overridden.
  *
- * This function encapsulates the logic of when telemetry should be overriden.
+ * This function encapsulates the logic of when telemetry should be overridden.
  */
-export function shouldOverrideSendTelemetry(isFirefox: boolean, isExtension: boolean, sourcegraphUrl: string): boolean {
-    const isFirefoxExtension = isFirefox && isExtension
-    if (!isFirefoxExtension) {
-        return true
-    }
+const shouldOverrideSendTelemetry = (isExtension: boolean): Observable<boolean> =>
+    observeSourcegraphURL(isExtension).pipe(
+        map(sourcegraphUrl => {
+            const isFirefoxExtension = isFirefox() && isExtension
+            if (!isFirefoxExtension) {
+                return true
+            }
 
-    if (!isDefaultSourcegraphUrl(sourcegraphUrl)) {
-        return true
-    }
+            if (!isDefaultSourcegraphUrl(sourcegraphUrl)) {
+                return true
+            }
 
-    return false
-}
+            return false
+        })
+    )
+
+/**
+ * Determine if the sendTelemetry is enabled
+ */
+export const observeSendTelemetry = (isExtension: boolean): Observable<boolean> =>
+    combineLatest([shouldOverrideSendTelemetry(isExtension), observeOptionFlag('sendTelemetry')]).pipe(
+        map(([override, sendTelemetry]) => {
+            if (override) {
+                return true
+            }
+            return sendTelemetry
+        })
+    )
+
+/**
+ * A list of option flags with values
+ */
+export const observeOptionFlagsWithValues = (isExtension: boolean): Observable<OptionFlagWithValue[]> =>
+    combineLatest([observeOptionFlags(), shouldOverrideSendTelemetry(isExtension)]).pipe(
+        map(([flags, override]) => {
+            const definitions = assignOptionFlagValues(flags)
+            if (override) {
+                return definitions.filter(flag => flag.key !== 'sendTelemetry')
+            }
+            return definitions
+        })
+    )

--- a/client/shared/src/util/useInputValidation.ts
+++ b/client/shared/src/util/useInputValidation.ts
@@ -77,7 +77,7 @@ export function useInputValidation(
     options: ValidationOptions
 ): [
     InputValidationState,
-    (changeEvent: React.ChangeEvent<HTMLInputElement>) => void,
+    (eventOrValue: React.ChangeEvent<HTMLInputElement> | string) => void,
     (inputElement: ValidatingHTMLElement | null) => void,
     (override: InputValidationEvent) => void
 ] {
@@ -124,11 +124,17 @@ export function useInputValidation(
     const [nextInputValidationEvent] = useEventObservable(validationPipeline)
 
     // "Adapter" for React change events to input validation events
-    const nextReactChangeEvent = useCallback(
-        (event: React.ChangeEvent<HTMLInputElement>): void => {
-            event.preventDefault()
+    const nextChangeEvent = useCallback(
+        (eventOrValue: React.ChangeEvent<HTMLInputElement> | string): void => {
+            let value
+            if (typeof eventOrValue === 'string') {
+                value = eventOrValue
+            } else {
+                eventOrValue.preventDefault()
+                value = eventOrValue.target.value
+            }
             // Always validate on change events
-            nextInputValidationEvent({ value: event.target.value, validate: true })
+            nextInputValidationEvent({ value, validate: true })
         },
         [nextInputValidationEvent]
     )
@@ -141,7 +147,7 @@ export function useInputValidation(
         [nextInputValidationEvent]
     )
 
-    return [inputState, nextReactChangeEvent, nextInputReference, overrideState]
+    return [inputState, nextChangeEvent, nextInputReference, overrideState]
 }
 
 /**


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/29030.
Closes https://github.com/sourcegraph/sourcegraph/issues/25778.

#### Description

This PR:
- Implement browser extension Sourcegraph URL dropdown for ease of URL switching
- Updates options page UI

#### How to test

1. `sg run bext`
2. Open browser extension options page
3. Check that the input field suggests **all previously successfully validated URLs**

#### Screenshots
| Before | After |
| -: | :- |
|![image](https://user-images.githubusercontent.com/6717049/148399252-95d2de29-af50-41ca-8bbf-f3bdeec4ed95.png) | ![image](https://user-images.githubusercontent.com/6717049/148399303-cc6b53c6-6d5b-4077-befa-54d3185e5d3b.png) |
| n/a | ![image](https://user-images.githubusercontent.com/6717049/148399399-09b3c0db-55ef-4a1a-b805-dc7e586e601d.png) |
| ![image](https://user-images.githubusercontent.com/6717049/148399557-630a3a6c-4fcf-4c21-92b7-6599258bb3d3.png) | ![image](https://user-images.githubusercontent.com/6717049/148399524-fd9116a0-c6ad-4cc2-b227-d48720f41618.png) |
|![image](https://user-images.githubusercontent.com/6717049/148399603-a74c22cb-2804-4ad9-a44a-3e20bf9000ab.png) | ![image](https://user-images.githubusercontent.com/6717049/148399632-5776f877-c8e0-4053-a0cc-fe5b16b92ff8.png) |

#### Before merging

- [ ] Test on different code hosts (if applicable)
    - [ ] GitHub
    - [ ] Gitlab
    - [ ] GitHub Enterprise
    - [ ] Refined GitHub
    - [ ] Phabricator
    - [ ] Phabricator integration
    - [ ] Bitbucket
    - [ ] Bitbucket integration

- [ ] Test on different browsers (if applicable)
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
- [x] Add change log message to [client/browser/CHANGELOG.md](./client/browser/CHANGELOG.md), under "Unreleased" section. (if applicable)
