### PR TITLE
insights: Add docs for known oob migration issue

### DIFF
--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -14,6 +14,8 @@ Each section comprehensively describes the steps needed to upgrade, and any manu
 
 **Due to issues related to Code Insights on the 3.35.0 release, users are advised to upgrade to 3.35.1 as soon as possible.**
 
+There is a [known issue](../../code_insights/how-tos/Troubleshooting.md#oob-migration-is-not-at-100) with the Code Insights out-of-band settings migration not reaching 100% complete.
+
 ## 3.34 -> 3.35.1
 
 **Due to issues related to Code Insights on the 3.35.0 release, users are advised to upgrade directly to 3.35.1.**

--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -14,7 +14,7 @@ Each section comprehensively describes the steps needed to upgrade, and any manu
 
 **Due to issues related to Code Insights on the 3.35.0 release, users are advised to upgrade to 3.35.1 as soon as possible.**
 
-There is a [known issue](../../code_insights/how-tos/Troubleshooting.md#oob-migration-is-not-at-100) with the Code Insights out-of-band settings migration not reaching 100% complete.
+There is a [known issue](../../code_insights/how-tos/Troubleshooting.md#oob-migration-has-made-progress-but-is-stuck-before-reaching-100) with the Code Insights out-of-band settings migration not reaching 100% complete when encountering deleted users or organizations.
 
 ## 3.34 -> 3.35.1
 

--- a/doc/admin/updates/kubernetes.md
+++ b/doc/admin/updates/kubernetes.md
@@ -17,6 +17,8 @@ and any manual migration steps you must perform.
 The query-runner deployment has been removed, so if you deploy with a method other than the `kubectl-apply-all.sh`, a manual removal of the deployment may be necessary.
 Follow the [standard upgrade procedure](../install/kubernetes/update.md) to upgrade your deployment.
 
+There is a [known issue](../../code_insights/how-tos/Troubleshooting.md#oob-migration-is-not-at-100) with the Code Insights out-of-band settings migration not reaching 100% complete.
+
 *How smooth was this upgrade process for you? You can give us your feedback on this upgrade by filling out [this feedback form](https://share.hsforms.com/1aGeG7ALQQEGO6zyfauIiCA1n7ku?update_version=3.34).*
 
 ## 3.33 -> 3.34

--- a/doc/admin/updates/kubernetes.md
+++ b/doc/admin/updates/kubernetes.md
@@ -17,7 +17,7 @@ and any manual migration steps you must perform.
 The query-runner deployment has been removed, so if you deploy with a method other than the `kubectl-apply-all.sh`, a manual removal of the deployment may be necessary.
 Follow the [standard upgrade procedure](../install/kubernetes/update.md) to upgrade your deployment.
 
-There is a [known issue](../../code_insights/how-tos/Troubleshooting.md#oob-migration-is-not-at-100) with the Code Insights out-of-band settings migration not reaching 100% complete.
+There is a [known issue](../../code_insights/how-tos/Troubleshooting.md#oob-migration-has-made-progress-but-is-stuck-before-reaching-100) with the Code Insights out-of-band settings migration not reaching 100% complete when encountering deleted users or organizations.
 
 *How smooth was this upgrade process for you? You can give us your feedback on this upgrade by filling out [this feedback form](https://share.hsforms.com/1aGeG7ALQQEGO6zyfauIiCA1n7ku?update_version=3.34).*
 

--- a/doc/admin/updates/pure_docker.md
+++ b/doc/admin/updates/pure_docker.md
@@ -11,6 +11,8 @@ Each section comprehensively describes the changes needed in Docker images, envi
 ## 3.35.0 -> 3.35.1
 **Due to issues related to Code Insights on the 3.35.0 release, users are advised to upgrade to 3.35.1 as soon as possible.**
 
+There is a [known issue](../../code_insights/how-tos/Troubleshooting.md#oob-migration-is-not-at-100) with the Code Insights out-of-band settings migration not reaching 100% complete.
+
 To upgrade, please perform the changes in the following diff:
 [https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/ba0d94eb945fd3371ed888e4b7177828b33acd3d](https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/ba0d94eb945fd3371ed888e4b7177828b33acd3d)
 

--- a/doc/admin/updates/pure_docker.md
+++ b/doc/admin/updates/pure_docker.md
@@ -11,7 +11,7 @@ Each section comprehensively describes the changes needed in Docker images, envi
 ## 3.35.0 -> 3.35.1
 **Due to issues related to Code Insights on the 3.35.0 release, users are advised to upgrade to 3.35.1 as soon as possible.**
 
-There is a [known issue](../../code_insights/how-tos/Troubleshooting.md#oob-migration-is-not-at-100) with the Code Insights out-of-band settings migration not reaching 100% complete.
+There is a [known issue](../../code_insights/how-tos/Troubleshooting.md#oob-migration-has-made-progress-but-is-stuck-before-reaching-100) with the Code Insights out-of-band settings migration not reaching 100% complete when encountering deleted users or organizations.
 
 To upgrade, please perform the changes in the following diff:
 [https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/ba0d94eb945fd3371ed888e4b7177828b33acd3d](https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/ba0d94eb945fd3371ed888e4b7177828b33acd3d)

--- a/doc/admin/updates/server.md
+++ b/doc/admin/updates/server.md
@@ -10,6 +10,8 @@ This document describes the exact changes needed to update a single-node Sourceg
 ## 3.35.0 -> 3.35.1
 **Due to issues related to Code Insights on the 3.35.0 release, users are advised to upgrade to 3.35.1 as soon as possible.**
 
+There is a [known issue](../../code_insights/how-tos/Troubleshooting.md#oob-migration-is-not-at-100) with the Code Insights out-of-band settings migration not reaching 100% complete.
+
 ## 3.34 -> 3.35.1
 
 **Due to issues related to Code Insights on the 3.35.0 release, Users are advised to upgrade directly to 3.35.1.**

--- a/doc/admin/updates/server.md
+++ b/doc/admin/updates/server.md
@@ -10,7 +10,7 @@ This document describes the exact changes needed to update a single-node Sourceg
 ## 3.35.0 -> 3.35.1
 **Due to issues related to Code Insights on the 3.35.0 release, users are advised to upgrade to 3.35.1 as soon as possible.**
 
-There is a [known issue](../../code_insights/how-tos/Troubleshooting.md#oob-migration-is-not-at-100) with the Code Insights out-of-band settings migration not reaching 100% complete.
+There is a [known issue](../../code_insights/how-tos/Troubleshooting.md#oob-migration-has-made-progress-but-is-stuck-before-reaching-100) with the Code Insights out-of-band settings migration not reaching 100% complete when encountering deleted users or organizations.
 
 ## 3.34 -> 3.35.1
 

--- a/doc/code_insights/how-tos/Troubleshooting.md
+++ b/doc/code_insights/how-tos/Troubleshooting.md
@@ -79,10 +79,10 @@ update insights_query_runner_jobs
 where id = ?;
 ```
 
-## OOB Migration is not at 100%
+## OOB Migration has made progress, but is stuck before reaching 100%
 This out-of-band migration is titled: **Migrating insight definitions from settings files to database tables as a last stage to use the GraphQL API.**
 
-The out-of-band migration shouldn't take more than an hour to complete. (It really shouldn't take more than a few minutes.) So if the progress hasn't reached 100% at this time there's definitely an issue.
+The out-of-band migration shouldn't take more than an hour to complete. (It really shouldn't take more than a few minutes.) If the progress hasn't reached 100% in this duration some records may be stuck due to errors.
 
 Known issues:
 - Deleted users/orgs will cause processing errors, and those jobs wil need to be manually marked as complete.

--- a/doc/code_insights/how-tos/Troubleshooting.md
+++ b/doc/code_insights/how-tos/Troubleshooting.md
@@ -78,3 +78,28 @@ update insights_query_runner_jobs
     set state = 'failed'
 where id = ?;
 ```
+
+## OOB Migration is not at 100%
+This out-of-band migration is titled: **Migrating insight definitions from settings files to database tables as a last stage to use the GraphQL API.**
+
+The out-of-band migration shouldn't take more than an hour to complete. (It really shouldn't take more than a few minutes.) So if the progress hasn't reached 100% at this time there's definitely an issue.
+
+Known issues:
+- Deleted users/orgs will cause processing errors, and those jobs wil need to be manually marked as complete.
+
+### Diagnose and Resolve
+1. First check the Recent Errors under the migration in the UI.
+    1. If the error messages are all: `UserStoreGetById: user not found`
+        - This is caused by deleted users. It will be safe to mark these rows as completed by running the following against `pgsql`:
+          ```sql
+          UPDATE insights_settings_migration_jobs SET completed_at = NOW() WHERE completed_at IS NULL;
+          ```
+
+    2. If the error messages are all: `OrgStoreGetByID: org not found`
+        - This is caused by deleted orgs. In this case, mark just the org rows as completed by running the following against `pgsql`:
+          ```sql
+          UPDATE insights_settings_migration_jobs SET completed_at = NOW() WHERE completed_at IS NULL AND org_id IS NOT NULL;
+          ```
+
+        - Note: this only completes the failing org jobs. You may then see the `user not found` error above, and will still need to mark the rest of the jobs as complete.
+    3. If the error messages are neither of those two things, this is not currently a known issue. Contact support and we can help!


### PR DESCRIPTION
Docs only change. This adds some steps to resolve a known issue with the oob settings migration. Namely, that deleted users/orgs cause the migration to get stuck on those jobs.

Kevin: please let me know if those references are not in the right places, thanks!