### PR TITLE
Add team to devops notify

### DIFF
--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -23,5 +23,5 @@ jobs:
                   team/security=@dcomas
                   team/dev-experience=@taylorsperry @jhchabran @kstretch9
                   team/repo-management=@jplahn @dan-mckean
-                  team/devops=@daxmc99 @JenRed777 @danieldides
+                  team/devops=@sourcegraph/cloud-devops
                   team/cloud-growth=@muratsu @rrhyne


### PR DESCRIPTION
We can switch this later but for now, this ensures everyone on the team sees new issues as they come in.
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
