### PR TITLE
images: update dependencies to always use >=

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,11 @@
+ignored:
+# We use Alpine, and Alpine packages only keep the most recent few releases of packages,
+# with older releases being dropped on a regular basis. This means pinning versions as
+# enforced in https://github.com/hadolint/hadolint/wiki/DL3018 causing frequent build
+# failures due to missing packages or mismatched inter-package dependencies, at which
+# point we just upgrade anyway, negating the use for pinning packages. There are no build
+# reproducibility advantages either since we cannot rebuild an image if a package version
+# required is no longer available.
+#
+# To force the inclusion of a security patch, use 'package>=$version' instead of pinning.
+- DL3018

--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -31,7 +31,6 @@ LABEL org.opencontainers.image.created=${DATE}
 LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
-# hadolint ignore=DL3018
 RUN apk add --no-cache \
     # We require git 2.34.1 because we use git-repack with flag --write-midx.
     'git>=2.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \

--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -34,14 +34,14 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
     # We require git 2.34.1 because we use git-repack with flag --write-midx.
-    'git=~2.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
+    'git>=2.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
     git-p4 \
     && apk add --no-cache  \
     openssh-client \
     # We require g++, gcc, perl and make to install openssl and p4-fusion
     g++ \
     gcc \
-	perl \
+    perl \
     cmake \
     make \
     python2 \

--- a/cmd/migrator/Dockerfile
+++ b/cmd/migrator/Dockerfile
@@ -9,7 +9,6 @@ LABEL org.opencontainers.image.created=${DATE}
 LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
-# hadolint ignore=DL3018
 RUN apk update && apk add --no-cache \
     tini
 

--- a/cmd/searcher/Dockerfile
+++ b/cmd/searcher/Dockerfile
@@ -5,7 +5,6 @@
 
 FROM sourcegraph/alpine-3.12:120059_2021-12-09_b34c7b2@sha256:9a1fde12f56fea02027cf4caeebdddfedb7b73bf8db6c16f7907a6e04a29134c
 
-# hadolint ignore=DL3018
 RUN apk --no-cache add pcre sqlite-libs
 
 # The comby/comby image is a small binary-only distribution. See the bin and src directories

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -35,7 +35,7 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 # hadolint ignore=DL3018
 RUN apk add --no-cache --verbose \
     # We require git 2.34.1 because we use git-repack with flag --write-midx.
-    'git=~2.34.1' \
+    'git>=2.34.1' \
     git-p4 \
     --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
     # NOTE that the Postgres version we run is different
@@ -43,11 +43,11 @@ RUN apk add --no-cache --verbose \
     # the features we can depend on. See this link for more information:
     # https://github.com/sourcegraph/sourcegraph/blob/main/doc/dev/postgresql.md#version-requirements
     && apk add --no-cache --verbose \
-    'bash=~5.0.17' \
-    'redis=~5.0' \
+    'bash>=5.0.17' \
+    'redis>=5.0' \
     python2 \
     python3 \
-    'nginx>=1.18.0' openssh-client pcre sqlite-libs su-exec 'nodejs-current=~14.5.0' \
+    'nginx>=1.18.0' openssh-client pcre sqlite-libs su-exec 'nodejs-current>=14.5.0' \
     postgresql=12.9-r0 \
     postgresql-contrib
 

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -32,7 +32,6 @@ LABEL org.opencontainers.image.created=${DATE}
 LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
-# hadolint ignore=DL3018
 RUN apk add --no-cache --verbose \
     # We require git 2.34.1 because we use git-repack with flag --write-midx.
     'git>=2.34.1' \
@@ -82,7 +81,6 @@ COPY --from=sourcegraph/prometheus:server /prometheus.sh /prometheus.sh
 # hadolint ignore=DL3022
 COPY --from=sourcegraph/prometheus:server /usr/share/prometheus /usr/share/prometheus
 
-# hadolint ignore=DL3018
 RUN set -ex && \
     addgroup -S grafana && \
     adduser -S -G grafana grafana && \

--- a/cmd/symbols/Dockerfile
+++ b/cmd/symbols/Dockerfile
@@ -23,7 +23,6 @@ LABEL org.opencontainers.image.created=${DATE}
 LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
-# hadolint ignore=DL3018
 RUN apk add --no-cache bind-tools ca-certificates mailcap tini
 
 COPY ctags-install-alpine.sh /ctags-install-alpine.sh

--- a/cmd/worker/Dockerfile
+++ b/cmd/worker/Dockerfile
@@ -9,7 +9,6 @@ LABEL org.opencontainers.image.created=${DATE}
 LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
-# hadolint ignore=DL3018
 RUN apk update && apk add --no-cache \
     tini
 

--- a/dev/src-expose/Dockerfile
+++ b/dev/src-expose/Dockerfile
@@ -9,7 +9,6 @@ LABEL org.opencontainers.image.created=${DATE}
 LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
-# hadolint ignore=DL3018
 RUN apk add --no-cache git
 
 # Ensures that a directory with the correct permissions exist in the image. Without this, in Docker Compose

--- a/docker-images/alpine-3.12/Dockerfile
+++ b/docker-images/alpine-3.12/Dockerfile
@@ -22,7 +22,6 @@ RUN addgroup -g 101 -S sourcegraph && adduser -u 100 -S -G sourcegraph -h /home/
 # other Docker containers.
 # See https://github.com/sourcegraph/deploy-sourcegraph-docker/issues/1
 # Install other packages that are desirable in ALL Sourcegraph Docker images.
-# hadolint ignore=DL3018
 RUN apk update && apk add --no-cache \
     bind-tools \
     # Requires the use of the edge repo for CVE-2021-28831 until a patched version is brought into the 3.12 mirror.

--- a/docker-images/alpine-3.12/Dockerfile
+++ b/docker-images/alpine-3.12/Dockerfile
@@ -26,10 +26,10 @@ RUN addgroup -g 101 -S sourcegraph && adduser -u 100 -S -G sourcegraph -h /home/
 RUN apk update && apk add --no-cache \
     bind-tools \
     # Requires the use of the edge repo for CVE-2021-28831 until a patched version is brought into the 3.12 mirror.
-    'busybox=~1.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    'busybox>=1.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
     ca-certificates \
     curl \
     mailcap \
     tini \
     # Required due to ssl_clent upgrade with busybox
-    'wget=~1.21.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main
+    'wget>=1.21.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main

--- a/docker-images/alpine-3.14/Dockerfile
+++ b/docker-images/alpine-3.14/Dockerfile
@@ -26,7 +26,7 @@ RUN addgroup -g 101 -S sourcegraph && adduser -u 100 -S -G sourcegraph -h /home/
 RUN apk update && apk add --no-cache \
     bind-tools \
     # Requires the use of the edge repo for CVE-2021-28831 until a patched version is brought into the 3.12 mirror.
-    'busybox=~1.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    'busybox>=1.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
     ca-certificates \
     curl \
     mailcap \

--- a/docker-images/alpine-3.14/Dockerfile
+++ b/docker-images/alpine-3.14/Dockerfile
@@ -22,7 +22,6 @@ RUN addgroup -g 101 -S sourcegraph && adduser -u 100 -S -G sourcegraph -h /home/
 # other Docker containers.
 # See https://github.com/sourcegraph/deploy-sourcegraph-docker/issues/1
 # Install other packages that are desirable in ALL Sourcegraph Docker images.
-# hadolint ignore=DL3018
 RUN apk update && apk add --no-cache \
     bind-tools \
     # Requires the use of the edge repo for CVE-2021-28831 until a patched version is brought into the 3.12 mirror.

--- a/docker-images/cadvisor/Dockerfile
+++ b/docker-images/cadvisor/Dockerfile
@@ -14,9 +14,9 @@ LABEL org.opencontainers.image.documentation=https://docs.sourcegraph.com/
 
 RUN apk add --upgrade --no-cache apk-tools=2.10.8-r0 krb5-libs=1.18.4-r0 \
     # Requires the use of the edge repo for CVE-2021-28831 until a patched version is brought into the 3.12 mirror.
-    'busybox=~1.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    'busybox>=1.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
     # Required due to ssl_clent upgrade with busybox
-    'wget=~1.21.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main
+    'wget>=1.21.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main
 
 # Reflects cAdvisor Dockerfile at https://github.com/google/cadvisor/blob/v0.39.2/deploy/Dockerfile
 # alongside additional Sourcegraph defaults.

--- a/docker-images/cadvisor/build.sh
+++ b/docker-images/cadvisor/build.sh
@@ -2,7 +2,7 @@
 cd "$(dirname "${BASH_SOURCE[0]}")"
 set -ex
 
-docker build --no-cache -t "${IMAGE:-'sourcegraph/cadvisor'}" . \
+docker build --no-cache -t "${IMAGE:-"sourcegraph/cadvisor"}" . \
   --progress=plain \
   --build-arg COMMIT_SHA \
   --build-arg DATE \

--- a/docker-images/codeinsights-db/Dockerfile
+++ b/docker-images/codeinsights-db/Dockerfile
@@ -3,7 +3,7 @@ FROM timescale/timescaledb:2.0.0-pg12-oss
 # hadolint ignore=DL3017
 RUN apk -U upgrade && apk add --no-cache \
     # Requires the use of the edge repo for CVE-2021-28831 until a patched version is brought into the 3.12 mirror.
-    'busybox=~1.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    'busybox>=1.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
     # Required due to ssl_clent upgrade with busybox
-    'wget=~1.21.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main
+    'wget>=1.21.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main
 

--- a/docker-images/grafana/Dockerfile
+++ b/docker-images/grafana/Dockerfile
@@ -43,7 +43,7 @@ RUN mkdir /sg_config_grafana/provisioning/plugins && chown grafana:root /sg_conf
 
 # @FIXME: Update redis image
 # Pin busybox=1.32.1-r7 https://github.com/sourcegraph/sourcegraph/issues/27965
-RUN apk add --upgrade --no-cache apk-tools=~2.12 krb5-libs=~1.18.4 libssl1.1=~1.1.1l openssl=~1.1.1l busybox=~1.32.1
+RUN apk add --upgrade --no-cache apk-tools>=2.12 krb5-libs>=1.18.4 libssl1.1>=1.1.1l openssl>=1.1.1l busybox>=1.32.1
 
 EXPOSE 3370
 USER grafana

--- a/docker-images/jaeger-agent/Dockerfile
+++ b/docker-images/jaeger-agent/Dockerfile
@@ -5,7 +5,6 @@ FROM jaegertracing/jaeger-agent:${JAEGER_VERSION} as base
 
 FROM sourcegraph/alpine-3.12:120059_2021-12-09_b34c7b2@sha256:9a1fde12f56fea02027cf4caeebdddfedb7b73bf8db6c16f7907a6e04a29134c
 USER root
-# hadolint ignore=DL3018
 RUN apk --no-cache add bash curl apk-tools=2.10.8-r0
 
 COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/docker-images/jaeger-all-in-one/Dockerfile
+++ b/docker-images/jaeger-all-in-one/Dockerfile
@@ -8,7 +8,6 @@ FROM jaegertracing/all-in-one:${JAEGER_VERSION} as base
 FROM sourcegraph/alpine-3.12:120059_2021-12-09_b34c7b2@sha256:9a1fde12f56fea02027cf4caeebdddfedb7b73bf8db6c16f7907a6e04a29134c
 USER root
 RUN apk update
-# hadolint ignore=DL3018
 RUN apk --no-cache add bash curl apk-tools=2.10.8-r0 krb5-libs=1.18.4-r0
 
 COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/docker-images/postgres-12.6-alpine/Dockerfile
+++ b/docker-images/postgres-12.6-alpine/Dockerfile
@@ -2,7 +2,6 @@ FROM postgres:12.6-alpine@sha256:faf54a67a58ecf4d21e3e68b9a3b33f81a11e8a78653004
 
 # We modify the postgres user/group to reconcile with our previous debian based images
 # and avoid issues with customers migrating.
-# hadolint ignore=DL3018
 RUN apk add --no-cache nss su-exec shadow &&\
     groupmod -g 99 ping &&\
     usermod -u 999 postgres &&\

--- a/docker-images/postgres-12.6-alpine/Dockerfile
+++ b/docker-images/postgres-12.6-alpine/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add --no-cache nss su-exec shadow &&\
 
 # @FIXME: Update redis image
 # Pin busybox=1.32.1-r7 https://github.com/sourcegraph/sourcegraph/issues/27965
-RUN apk add --upgrade --no-cache libxml2=~2.9.12 libgcrypt=~1.8.8 apk-tools=~2.12.7 busybox=~1.32.1
+RUN apk add --upgrade --no-cache libxml2>=2.9.12 libgcrypt>=1.8.8 apk-tools>=2.12.7 busybox>=1.32.1
 
 ENV POSTGRES_PASSWORD='' \
     POSTGRES_USER=sg \

--- a/docker-images/redis-cache/Dockerfile
+++ b/docker-images/redis-cache/Dockerfile
@@ -5,7 +5,6 @@ RUN mkdir -p /redis-data && chown -R redis:redis /redis-data
 # @FIXME: Update redis image
 # Pin busybox=1.33.1-r6 https://github.com/sourcegraph/sourcegraph/issues/27965
 
-# hadolint ignore=DL3018
 RUN apk --no-cache add tini apk-tools=2.12.7-r0 libssl1.1=1.1.1l-r0 busybox=1.33.1-r6
 
 

--- a/docker-images/redis-store/Dockerfile
+++ b/docker-images/redis-store/Dockerfile
@@ -5,7 +5,6 @@ RUN mkdir -p /redis-data && chown -R redis:redis /redis-data
 # @FIXME: Update redis image
 # Pin busybox=1.33.1-r6 https://github.com/sourcegraph/sourcegraph/issues/27965
 
-# hadolint ignore=DL3018
 RUN apk --no-cache add tini apk-tools=2.12.7-r0 libssl1.1=1.1.1l-r0 busybox=1.33.1-r6
 
 USER redis

--- a/docker-images/syntax-highlighter/Dockerfile
+++ b/docker-images/syntax-highlighter/Dockerfile
@@ -15,7 +15,7 @@ RUN cp ./target/release/syntect_server /syntect_server
 ################################
 FROM golang:1.15.2-alpine@sha256:fc801399d044a8e01f125eeb5aa3f160a0d12d6e03ba17a1d0b22ce50dfede81 as hss
 
-RUN apk add --no-cache git=~2.26.3
+RUN apk add --no-cache git>=2.26.3
 RUN git clone https://github.com/slimsag/http-server-stabilizer /repo
 WORKDIR /repo
 RUN git checkout v1.0.4 && go build -o /http-server-stabilizer .

--- a/enterprise/cmd/precise-code-intel-worker/Dockerfile
+++ b/enterprise/cmd/precise-code-intel-worker/Dockerfile
@@ -9,7 +9,6 @@ LABEL org.opencontainers.image.created=${DATE}
 LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
-# hadolint ignore=DL3018
 RUN apk update && apk add --no-cache \
     tini
 

--- a/enterprise/cmd/worker/Dockerfile
+++ b/enterprise/cmd/worker/Dockerfile
@@ -9,7 +9,6 @@ LABEL org.opencontainers.image.created=${DATE}
 LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
-# hadolint ignore=DL3018
 RUN apk update && apk add --no-cache \
     tini
 

--- a/internal/cmd/git-combine/Dockerfile
+++ b/internal/cmd/git-combine/Dockerfile
@@ -16,7 +16,6 @@ RUN go build .
 # Sourcegraph.com.
 FROM alpine:3.15
 
-# hadolint ignore=DL3018
 RUN apk add --no-cache git ca-certificates tini
 
 COPY --from=builder /go/src/app/git-combine /usr/bin/

--- a/internal/cmd/progress-bot/Dockerfile
+++ b/internal/cmd/progress-bot/Dockerfile
@@ -13,7 +13,6 @@ FROM sourcegraph/alpine-3.12:120059_2021-12-09_b34c7b2@sha256:9a1fde12f56fea0202
 # hadolint ignore=DL3002
 USER root
 
-# hadolint ignore=DL3018
 RUN apk add --no-cache ca-certificates git bash
 
 WORKDIR /

--- a/internal/cmd/resources-report/Dockerfile
+++ b/internal/cmd/resources-report/Dockerfile
@@ -13,7 +13,6 @@ FROM sourcegraph/alpine-3.12:120059_2021-12-09_b34c7b2@sha256:9a1fde12f56fea0202
 # hadolint ignore=DL3002
 USER root
 
-# hadolint ignore=DL3018
 RUN apk add --no-cache ca-certificates
 
 COPY --from=builder /bin/resources-report /usr/local/bin/


### PR DESCRIPTION
Alpine packages only keep the most recent few releases, with older releases being dropped on a regular basis.

We enforce versions, it seems, mostly to ensure the inclusion of particular security patches. Since _not_ upgrading will only break our builds, and when we run into issues we just upgrade anyway, we should just only ever pin minimum versions - even the usage of `=~` introduced in https://github.com/sourcegraph/sourcegraph/pull/29090 might be too specific, since that seems to be introducing inter-package dependency awkwardness, [such as now](https://buildkite.com/sourcegraph/sourcegraph/builds/124481):

```
#6 1.373 ERROR: unable to select packages:
#6 1.393   busybox-1.31.1-r21:
#6 1.393     breaks: world[busybox~1.34.1]
#6 1.393     satisfies: ca-certificates-20191127-r7[/bin/sh]
#6 1.393                alpine-baselayout-3.2.0-r7[/bin/sh]
```

To make this the new standard, also adds a `hadolint.yml` to disable [DL3018](https://github.com/hadolint/hadolint/wiki/DL3018) by default