### PR TITLE
search frontend: helper to detect operators for queries with context

### DIFF
--- a/client/shared/src/search/query/transformer.test.ts
+++ b/client/shared/src/search/query/transformer.test.ts
@@ -114,11 +114,17 @@ describe('sanitizeQueryForTelemetry', () => {
 })
 
 describe('parenthesizeQueryWithGlobalContext', () => {
-    test('query without context', () => expect(parenthesizeQueryWithGlobalContext('a or b')).toEqual('a or b'))
+    test('query without context', () =>
+        expect(parenthesizeQueryWithGlobalContext('a or b')).toMatchInlineSnapshot('a or b'))
 
-    test('query with global context filter', () =>
-        expect(parenthesizeQueryWithGlobalContext('context:ctx a or b')).toEqual('context:ctx (a or b)'))
+    test('do not parenthesize query without operators', () =>
+        expect(parenthesizeQueryWithGlobalContext('context:ctx a')).toMatchInlineSnapshot('context:ctx a'))
 
-    test('query with nested context', () =>
-        expect(parenthesizeQueryWithGlobalContext('(context:ctx a) or b')).toEqual('(context:ctx a) or b'))
+    test('parenthesize query with global context filter', () =>
+        expect(parenthesizeQueryWithGlobalContext('context:ctx a or b')).toMatchInlineSnapshot('context:ctx (a or b)'))
+
+    test('do not parenthesize query with nested context', () =>
+        expect(parenthesizeQueryWithGlobalContext('(context:ctx a) or b')).toMatchInlineSnapshot(
+            '(context:ctx a) or b'
+        ))
 })

--- a/client/shared/src/search/query/validate.ts
+++ b/client/shared/src/search/query/validate.ts
@@ -84,6 +84,12 @@ export function filterExists(
     )
 }
 
+/** Returns true if the query contains operators. */
+export const operatorExists = (query: string): boolean => {
+    const result = scanSearchQuery(query)
+    return result.type === 'success' && result.term.some(term => term.type === 'keyword')
+}
+
 /**
  * Returns true if the query contains a pattern.
  */


### PR DESCRIPTION
It should be sufficient to check whether a query contains operators to decide whether to parenthesize the query in an input field when there's an existing global context.

The principled way to think about this is that we have two components:

```
(context)           (thing user entered)
```

what we're shooting for is to create a tree like:

```
              and
            /     \
(context)           (thing user entered)
```

we could parse the query and construct the above tree (where we add only a new operator and child nodes, and do not reference anything to do with the syntax of parentheses), and then serialize it back to a string (which does the parenthesizing for us mechanically and correctly) which we then send to the back end. 

The current approach of just parenthesizing `thing user entered` is naive but sufficient to approximate this when we look at operators, because (a) it closely preserves the syntax and (b) doesn't need me to go and write a serializer. Writing a serializer is easy if we don't care about the original ordering of terms, whitespace, and so on in the original query, but writing a good one to preserve all this (e.g., for error messages and so on) can be tricky and time consuming. The takeaway here is: this naive approach is OK but if it needs evolve we may eventually need to go the principled route, so keep this in mind.

