### PR TITLE
settings: Deep merge experimental features

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -82,7 +82,7 @@ func NewSearchImplementer(ctx context.Context, db database.DB, args *SearchArgs)
 	}
 	tr.LazyPrintf("parsing done")
 
-	if settings.ExperimentalFeatures != nil && settings.ExperimentalFeatures.SearchContextsQuery {
+	if settings.ExperimentalFeatures != nil && getBoolPtr(settings.ExperimentalFeatures.SearchContextsQuery, false) {
 		// Replace each context in the query with its repository query if any.
 		plan, err = substituteSearchContexts(ctx, db, plan)
 		if err != nil {

--- a/cmd/frontend/graphqlbackend/settings_cascade.go
+++ b/cmd/frontend/graphqlbackend/settings_cascade.go
@@ -149,6 +149,7 @@ var settingsFieldMergeDepths = map[string]int{
 	"Quicklinks":             1,
 	"Motd":                   1,
 	"Extensions":             1,
+	"ExperimentalFeatures":   1,
 }
 
 func mergeSettingsLeft(left, right *schema.Settings) *schema.Settings {

--- a/cmd/frontend/graphqlbackend/settings_cascade_test.go
+++ b/cmd/frontend/graphqlbackend/settings_cascade_test.go
@@ -75,7 +75,7 @@ func TestMergeSettings(t *testing.T) {
 			CodeIntelligenceAutoIndexPopularRepoLimit: 1, // This is the zero value, so will not override a previous non-zero value
 		},
 	}, {
-		name: "shallow override struct pointer",
+		name: "deep merge struct pointer",
 		left: &schema.Settings{
 			ExperimentalFeatures: &schema.SettingsExperimentalFeatures{
 				ShowSearchNotebook: boolPtr(true),
@@ -88,6 +88,7 @@ func TestMergeSettings(t *testing.T) {
 		},
 		expected: &schema.Settings{
 			ExperimentalFeatures: &schema.SettingsExperimentalFeatures{
+				ShowSearchNotebook:          boolPtr(true),
 				ShowSearchContextManagement: boolPtr(false),
 			},
 		},

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1544,7 +1544,7 @@ type SettingsExperimentalFeatures struct {
 	// FuzzyFinderCaseInsensitiveFileCountThreshold description: The maximum number of files a repo can have to use case-insensitive fuzzy finding
 	FuzzyFinderCaseInsensitiveFileCountThreshold *float64 `json:"fuzzyFinderCaseInsensitiveFileCountThreshold,omitempty"`
 	// SearchContextsQuery description: Enables query based search contexts
-	SearchContextsQuery bool `json:"searchContextsQuery,omitempty"`
+	SearchContextsQuery *bool `json:"searchContextsQuery,omitempty"`
 	// SearchStats description: Enables a button on the search results page that shows language statistics about the results for a search query.
 	SearchStats *bool `json:"searchStats,omitempty"`
 	// SearchStreaming description: DEPRECATED: This feature is now permanently enabled. Enables streaming search support.

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -65,7 +65,10 @@
         "searchContextsQuery": {
           "description": "Enables query based search contexts",
           "type": "boolean",
-          "default": false
+          "default": false,
+          "!go": {
+            "pointer": true
+          }
         },
         "searchStats": {
           "description": "Enables a button on the search results page that shows language statistics about the results for a search query.",


### PR DESCRIPTION
This commit makes us deep merge experimental features, so that the
presence of that config field in user settings doesn't overwrite all
values in the correspondent org settings.

I don't know why this wasn't the behaviour already. I think it makes
sense, otherwise users can't overwrite a specific experimental feature
without overwriting all others.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
