### PR TITLE
search frontend: highlight query filter separator ':' specially

### DIFF
--- a/client/branded/src/global-styles/code.scss
+++ b/client/branded/src/global-styles/code.scss
@@ -45,3 +45,8 @@ kbd {
 .search-keyword {
     color: var(--search-keyword-color);
 }
+
+// Color of the `:` separator of the context dropdown, for example.
+.search-filter-separator {
+    color: var(--search-filter-separator-color);
+}

--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -142,6 +142,7 @@ $theme-colors: (
     --border-active-color: var(--primary);
     --search-query-text-color: var(--gray-12);
     --search-filter-keyword-color: var(--primary);
+    --search-filter-separator-color: var(--oc-gray-6);
     --search-keyword-color: var(--purple);
     --infobar-warning-color: var(--oc-red-8);
     --icon-color: var(--gray-06);
@@ -198,6 +199,7 @@ $theme-colors: (
     --border-active-color: #4393e7;
     --search-query-text-color: var(--gray-04);
     --search-filter-keyword-color: #4393e7;
+    --search-filter-separator-color: var(--oc-gray-6);
     --search-keyword-color: var(--pink);
     --infobar-warning-color: #f05151;
     --icon-color: var(--gray-05);

--- a/client/shared/src/search/query/decoratedToken.test.ts
+++ b/client/shared/src/search/query/decoratedToken.test.ts
@@ -21,6 +21,10 @@ describe('getMonacoTokens()', () => {
                 "scopes": "field"
               },
               {
+                "startIndex": 1,
+                "scopes": "metaFilterSeparator"
+              },
+              {
                 "startIndex": 2,
                 "scopes": "metaRegexpAssertion"
               },
@@ -53,6 +57,10 @@ describe('getMonacoTokens()', () => {
                 "scopes": "field"
               },
               {
+                "startIndex": 27,
+                "scopes": "metaFilterSeparator"
+              },
+              {
                 "startIndex": 28,
                 "scopes": "identifier"
               },
@@ -76,6 +84,10 @@ describe('getMonacoTokens()', () => {
                 "scopes": "field"
               },
               {
+                "startIndex": 1,
+                "scopes": "metaFilterSeparator"
+              },
+              {
                 "startIndex": 2,
                 "scopes": "identifier"
               },
@@ -90,6 +102,10 @@ describe('getMonacoTokens()', () => {
               {
                 "startIndex": 5,
                 "scopes": "field"
+              },
+              {
+                "startIndex": 6,
+                "scopes": "metaFilterSeparator"
               },
               {
                 "startIndex": 7,
@@ -459,6 +475,10 @@ describe('getMonacoTokens()', () => {
                 "scopes": "field"
               },
               {
+                "startIndex": 4,
+                "scopes": "metaFilterSeparator"
+              },
+              {
                 "startIndex": 5,
                 "scopes": "metaRegexpAssertion"
               },
@@ -479,6 +499,10 @@ describe('getMonacoTokens()', () => {
                 "scopes": "field"
               },
               {
+                "startIndex": 16,
+                "scopes": "metaFilterSeparator"
+              },
+              {
                 "startIndex": 17,
                 "scopes": "identifier"
               },
@@ -489,6 +513,10 @@ describe('getMonacoTokens()', () => {
               {
                 "startIndex": 20,
                 "scopes": "field"
+              },
+              {
+                "startIndex": 24,
+                "scopes": "metaFilterSeparator"
               },
               {
                 "startIndex": 25,
@@ -505,6 +533,10 @@ describe('getMonacoTokens()', () => {
               {
                 "startIndex": 28,
                 "scopes": "field"
+              },
+              {
+                "startIndex": 32,
+                "scopes": "metaFilterSeparator"
               },
               {
                 "startIndex": 33,
@@ -589,6 +621,10 @@ describe('getMonacoTokens()', () => {
               {
                 "startIndex": 0,
                 "scopes": "field"
+              },
+              {
+                "startIndex": 4,
+                "scopes": "metaFilterSeparator"
               },
               {
                 "startIndex": 5,
@@ -743,6 +779,10 @@ describe('getMonacoTokens()', () => {
                 "scopes": "field"
               },
               {
+                "startIndex": 1,
+                "scopes": "metaFilterSeparator"
+              },
+              {
                 "startIndex": 2,
                 "scopes": "identifier"
               },
@@ -781,6 +821,10 @@ describe('getMonacoTokens()', () => {
               {
                 "startIndex": 0,
                 "scopes": "field"
+              },
+              {
+                "startIndex": 1,
+                "scopes": "metaFilterSeparator"
               },
               {
                 "startIndex": 2,
@@ -837,6 +881,10 @@ describe('getMonacoTokens()', () => {
               {
                 "startIndex": 0,
                 "scopes": "field"
+              },
+              {
+                "startIndex": 4,
+                "scopes": "metaFilterSeparator"
               },
               {
                 "startIndex": 5,
@@ -899,6 +947,10 @@ describe('getMonacoTokens()', () => {
                 "scopes": "field"
               },
               {
+                "startIndex": 1,
+                "scopes": "metaFilterSeparator"
+              },
+              {
                 "startIndex": 2,
                 "scopes": "identifier"
               },
@@ -947,6 +999,10 @@ describe('getMonacoTokens()', () => {
                 "scopes": "field"
               },
               {
+                "startIndex": 1,
+                "scopes": "metaFilterSeparator"
+              },
+              {
                 "startIndex": 2,
                 "scopes": "identifier"
               },
@@ -976,6 +1032,10 @@ describe('getMonacoTokens()', () => {
               {
                 "startIndex": 0,
                 "scopes": "field"
+              },
+              {
+                "startIndex": 4,
+                "scopes": "metaFilterSeparator"
               },
               {
                 "startIndex": 5,
@@ -1017,6 +1077,10 @@ describe('getMonacoTokens()', () => {
                 "scopes": "field"
               },
               {
+                "startIndex": 4,
+                "scopes": "metaFilterSeparator"
+              },
+              {
                 "startIndex": 5,
                 "scopes": "identifier"
               },
@@ -1027,6 +1091,10 @@ describe('getMonacoTokens()', () => {
               {
                 "startIndex": 9,
                 "scopes": "field"
+              },
+              {
+                "startIndex": 12,
+                "scopes": "metaFilterSeparator"
               },
               {
                 "startIndex": 13,
@@ -1061,6 +1129,10 @@ describe('getMonacoTokens()', () => {
                 "scopes": "field"
               },
               {
+                "startIndex": 4,
+                "scopes": "metaFilterSeparator"
+              },
+              {
                 "startIndex": 5,
                 "scopes": "identifier"
               },
@@ -1071,6 +1143,10 @@ describe('getMonacoTokens()', () => {
               {
                 "startIndex": 24,
                 "scopes": "field"
+              },
+              {
+                "startIndex": 28,
+                "scopes": "metaFilterSeparator"
               },
               {
                 "startIndex": 29,
@@ -1087,6 +1163,10 @@ describe('getMonacoTokens()', () => {
               {
                 "startIndex": 0,
                 "scopes": "field"
+              },
+              {
+                "startIndex": 4,
+                "scopes": "metaFilterSeparator"
               },
               {
                 "startIndex": 5,
@@ -1152,6 +1232,10 @@ describe('getMonacoTokens()', () => {
                 "scopes": "field"
               },
               {
+                "startIndex": 7,
+                "scopes": "metaFilterSeparator"
+              },
+              {
                 "startIndex": 8,
                 "scopes": "metaContextPrefix"
               },
@@ -1170,6 +1254,10 @@ describe('getMonacoTokens()', () => {
               {
                 "startIndex": 0,
                 "scopes": "field"
+              },
+              {
+                "startIndex": 1,
+                "scopes": "metaFilterSeparator"
               },
               {
                 "startIndex": 2,
@@ -1212,6 +1300,10 @@ describe('getMonacoTokens()', () => {
                 "scopes": "field"
               },
               {
+                "startIndex": 32,
+                "scopes": "metaFilterSeparator"
+              },
+              {
                 "startIndex": 33,
                 "scopes": "identifier"
               },
@@ -1237,6 +1329,10 @@ describe('getMonacoTokens()', () => {
               {
                 "startIndex": 0,
                 "scopes": "field"
+              },
+              {
+                "startIndex": 1,
+                "scopes": "metaFilterSeparator"
               },
               {
                 "startIndex": 2,
@@ -1280,6 +1376,10 @@ describe('getMonacoTokens()', () => {
               {
                 "startIndex": 0,
                 "scopes": "field"
+              },
+              {
+                "startIndex": 4,
+                "scopes": "metaFilterSeparator"
               },
               {
                 "startIndex": 5,
@@ -1326,6 +1426,10 @@ describe('getMonacoTokens()', () => {
                 "scopes": "field"
               },
               {
+                "startIndex": 4,
+                "scopes": "metaFilterSeparator"
+              },
+              {
                 "startIndex": 5,
                 "scopes": "metaPredicateNameAccess"
               },
@@ -1336,6 +1440,10 @@ describe('getMonacoTokens()', () => {
               {
                 "startIndex": 14,
                 "scopes": "field"
+              },
+              {
+                "startIndex": 18,
+                "scopes": "metaFilterSeparator"
               },
               {
                 "startIndex": 19,

--- a/client/shared/src/search/query/hover.test.ts
+++ b/client/shared/src/search/query/hover.test.ts
@@ -36,7 +36,7 @@ describe('getHoverResult()', () => {
     test('returns hover contents for filters', () => {
         const input = 'repo:sourcegraph file:code_intelligence'
         const scannedQuery = toSuccess(scanSearchQuery(input))
-        expect(getHoverResult(scannedQuery, new Position(1, 4), editor.createModel(input))).toMatchInlineSnapshot(`
+        expect(getHoverResult(scannedQuery, new Position(1, 3), editor.createModel(input))).toMatchInlineSnapshot(`
             {
               "contents": [
                 {
@@ -47,7 +47,7 @@ describe('getHoverResult()', () => {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
                 "startColumn": 1,
-                "endColumn": 6
+                "endColumn": 5
               }
             }
         `)
@@ -62,7 +62,7 @@ describe('getHoverResult()', () => {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
                 "startColumn": 18,
-                "endColumn": 23
+                "endColumn": 22
               }
             }
         `)
@@ -97,7 +97,7 @@ describe('getHoverResult()', () => {
                 "startLineNumber": 1,
                 "endLineNumber": 1,
                 "startColumn": 1,
-                "endColumn": 6
+                "endColumn": 5
               }
             }
         `)

--- a/client/web/src/components/MonacoEditor.tsx
+++ b/client/web/src/components/MonacoEditor.tsx
@@ -46,6 +46,7 @@ const darkRules: monaco.editor.ITokenThemeRule[] = [
     { token: 'closingParen', foreground: '#d68cf3' }, // --search-keyword-color
     { token: 'comment', foreground: '#ffa94d' }, // --oc-orange-4
     // Sourcegraph decorated language tokens
+    { token: 'metaFilterSeparator', foreground: '#868e96' }, // --oc-gray-6
     { token: 'metaRepoRevisionSeparator', foreground: '#4393e7' }, // --search-filter-keyword-color
     { token: 'metaContextPrefix', foreground: '#d68cf3' }, // --search-keyword-color
     { token: 'metaPredicateNameAccess', foreground: '#d68cf3' }, // --search-keyword-color
@@ -106,6 +107,7 @@ const lightRules: monaco.editor.ITokenThemeRule[] = [
     { token: 'closingParen', foreground: '#a112ff' }, // --search-keyword-color
     { token: 'comment', foreground: '#d9480f' }, // --oc-orange-9
     // Sourcegraph decorated language tokens
+    { token: 'metaFilterSeparator', foreground: '#868e96' }, // --oc-gray-6
     { token: 'metaRepoRevisionSeparator', foreground: '#0b70db' }, // --search-filter-keyword-color
     { token: 'metaContextPrefix', foreground: '#a112ff' }, // --search-keyword-color
     { token: 'metaPredicateNameAccess', foreground: '#a112ff' }, // --search-keyword-color

--- a/client/web/src/components/SyntaxHighlightedSearchQuery.tsx
+++ b/client/web/src/components/SyntaxHighlightedSearchQuery.tsx
@@ -12,8 +12,9 @@ export const SyntaxHighlightedSearchQuery: React.FunctionComponent<{ query: stri
                       return (
                           <Fragment key={token.range.start}>
                               <span className="search-filter-keyword">
-                                  {query.slice(token.field.range.start, token.field.range.end)}:
+                                  {query.slice(token.field.range.start, token.field.range.end)}
                               </span>
+                              <span className="search-filter-separator">:</span>
                               {token.value ? <>{query.slice(token.value.range.start, token.value.range.end)}</> : null}
                           </Fragment>
                       )

--- a/client/web/src/components/__snapshots__/SyntaxHighlightedSearchQuery.test.tsx.snap
+++ b/client/web/src/components/__snapshots__/SyntaxHighlightedSearchQuery.test.tsx.snap
@@ -8,13 +8,23 @@ exports[`SyntaxHighlightedSearchQuery should syntax highlight filter 1`] = `
     <span
       class="search-filter-keyword"
     >
-      repo:
+      repo
+    </span>
+    <span
+      class="search-filter-separator"
+    >
+      :
     </span>
     sourcegraph 
     <span
       class="search-filter-keyword"
     >
-      lang:
+      lang
+    </span>
+    <span
+      class="search-filter-separator"
+    >
+      :
     </span>
     go
   </span>
@@ -29,7 +39,12 @@ exports[`SyntaxHighlightedSearchQuery should syntax highlight filter and operato
     <span
       class="search-filter-keyword"
     >
-      repo:
+      repo
+    </span>
+    <span
+      class="search-filter-separator"
+    >
+      :
     </span>
     sourcegraph test 
     <span
@@ -50,7 +65,12 @@ exports[`SyntaxHighlightedSearchQuery should syntax highlight negated filter 1`]
     <span
       class="search-filter-keyword"
     >
-      -lang:
+      -lang
+    </span>
+    <span
+      class="search-filter-separator"
+    >
+      :
     </span>
     ts test
   </span>

--- a/client/web/src/search/input/SearchContextDropdown.test.tsx
+++ b/client/web/src/search/input/SearchContextDropdown.test.tsx
@@ -130,7 +130,7 @@ describe('SearchContextDropdown', () => {
                 </MockTemporarySettings>
             )
 
-            userEvent.click(screen.getByRole('button', { name: /context:/ }))
+            userEvent.click(screen.getByRole('button', { name: /context/ }))
 
             expect(screen.queryByRole('button', { name: /Don't show this again/ })).not.toBeInTheDocument()
         })
@@ -146,7 +146,7 @@ describe('SearchContextDropdown', () => {
                 </MockTemporarySettings>
             )
 
-            userEvent.click(screen.getByRole('button', { name: /context:/ }))
+            userEvent.click(screen.getByRole('button', { name: /context/ }))
 
             expect(screen.getByRole('button', { name: /Don't show this again/ })).toBeInTheDocument()
         })
@@ -169,7 +169,7 @@ describe('SearchContextDropdown', () => {
                 </MockTemporarySettings>
             )
 
-            userEvent.click(screen.getByRole('button', { name: /context:/ }))
+            userEvent.click(screen.getByRole('button', { name: /context/ }))
 
             expect(screen.queryByRole('button', { name: /Don't show this again/ })).not.toBeInTheDocument()
         })
@@ -185,7 +185,7 @@ describe('SearchContextDropdown', () => {
                 </MockTemporarySettings>
             )
 
-            userEvent.click(screen.getByRole('button', { name: /context:/ }))
+            userEvent.click(screen.getByRole('button', { name: /context/ }))
 
             expect(screen.queryByRole('button', { name: /Don't show this again/ })).not.toBeInTheDocument()
         })
@@ -201,7 +201,7 @@ describe('SearchContextDropdown', () => {
                 </MockTemporarySettings>
             )
 
-            userEvent.click(screen.getByRole('button', { name: /context:/ }))
+            userEvent.click(screen.getByRole('button', { name: /context/ }))
 
             expect(screen.queryByRole('button', { name: /Don't show this againr/ })).not.toBeInTheDocument()
         })
@@ -222,7 +222,7 @@ describe('SearchContextDropdown', () => {
                 </MockTemporarySettings>
             )
 
-            userEvent.click(screen.getByRole('button', { name: /context:/ }))
+            userEvent.click(screen.getByRole('button', { name: /context/ }))
 
             // would need some time for animation before the button becomes clickable
             // otherwise we would get `unable to click element as it has or inherits pointer-events set to "none".` error

--- a/client/web/src/search/input/SearchContextDropdown.tsx
+++ b/client/web/src/search/input/SearchContextDropdown.tsx
@@ -120,7 +120,8 @@ export const SearchContextDropdown: React.FunctionComponent<SearchContextDropdow
                 data-tooltip={disabledTooltipText}
             >
                 <code className={classNames('test-selected-search-context-spec', styles.buttonContent)}>
-                    <span className="search-filter-keyword">context:</span>
+                    <span className="search-filter-keyword">context</span>
+                    <span className="search-filter-separator">:</span>
                     {selectedSearchContextSpec?.startsWith('@') ? (
                         <>
                             <span className="search-keyword">@</span>

--- a/client/web/src/search/panels/__snapshots__/RecentSearchesPanel.test.tsx.snap
+++ b/client/web/src/search/panels/__snapshots__/RecentSearchesPanel.test.tsx.snap
@@ -82,7 +82,12 @@ exports[`RecentSearchesPanel Show More button is shown if more pages are availab
                     <span
                       class="search-filter-keyword"
                     >
-                      r:
+                      r
+                    </span>
+                    <span
+                      class="search-filter-separator"
+                    >
+                      :
                     </span>
                     sourcegraph
                   </span>
@@ -199,7 +204,12 @@ exports[`RecentSearchesPanel Show More button loads more items 1`] = `
                     <span
                       class="search-filter-keyword"
                     >
-                      r:
+                      r
+                    </span>
+                    <span
+                      class="search-filter-separator"
+                    >
+                      :
                     </span>
                     sourcegraph
                   </span>
@@ -316,7 +326,12 @@ exports[`RecentSearchesPanel consecutive identical searches are correctly merged
                     <span
                       class="search-filter-keyword"
                     >
-                      r:
+                      r
+                    </span>
+                    <span
+                      class="search-filter-separator"
+                    >
+                      :
                     </span>
                     sourcegraph
                   </span>
@@ -423,7 +438,12 @@ exports[`RecentSearchesPanel searches with no argument are skipped 1`] = `
                     <span
                       class="search-filter-keyword"
                     >
-                      r:
+                      r
+                    </span>
+                    <span
+                      class="search-filter-separator"
+                    >
+                      :
                     </span>
                     sourcegraph
                   </span>

--- a/client/web/src/search/panels/__snapshots__/RepositoriesPanel.test.tsx.snap
+++ b/client/web/src/search/panels/__snapshots__/RepositoriesPanel.test.tsx.snap
@@ -40,7 +40,12 @@ exports[`RepositoriesPanel Both r: and repo: filters are tracked 1`] = `
                 <span
                   class="search-filter-keyword"
                 >
-                  repo:
+                  repo
+                </span>
+                <span
+                  class="search-filter-separator"
+                >
+                  :
                 </span>
                 sourcegraph
               </span>
@@ -60,7 +65,12 @@ exports[`RepositoriesPanel Both r: and repo: filters are tracked 1`] = `
                 <span
                   class="search-filter-keyword"
                 >
-                  repo:
+                  repo
+                </span>
+                <span
+                  class="search-filter-separator"
+                >
+                  :
                 </span>
                 test
               </span>
@@ -113,7 +123,12 @@ exports[`RepositoriesPanel Show More button is shown if more pages are available
                 <span
                   class="search-filter-keyword"
                 >
-                  repo:
+                  repo
+                </span>
+                <span
+                  class="search-filter-separator"
+                >
+                  :
                 </span>
                 test
               </span>
@@ -133,7 +148,12 @@ exports[`RepositoriesPanel Show More button is shown if more pages are available
                 <span
                   class="search-filter-keyword"
                 >
-                  repo:
+                  repo
+                </span>
+                <span
+                  class="search-filter-separator"
+                >
+                  :
                 </span>
                 sourcegraph
               </span>
@@ -153,7 +173,12 @@ exports[`RepositoriesPanel Show More button is shown if more pages are available
                 <span
                   class="search-filter-keyword"
                 >
-                  repo:
+                  repo
+                </span>
+                <span
+                  class="search-filter-separator"
+                >
+                  :
                 </span>
                 test-two
               </span>
@@ -216,7 +241,12 @@ exports[`RepositoriesPanel Show More button loads more items 1`] = `
                 <span
                   class="search-filter-keyword"
                 >
-                  repo:
+                  repo
+                </span>
+                <span
+                  class="search-filter-separator"
+                >
+                  :
                 </span>
                 test
               </span>
@@ -236,7 +266,12 @@ exports[`RepositoriesPanel Show More button loads more items 1`] = `
                 <span
                   class="search-filter-keyword"
                 >
-                  repo:
+                  repo
+                </span>
+                <span
+                  class="search-filter-separator"
+                >
+                  :
                 </span>
                 sourcegraph
               </span>
@@ -256,7 +291,12 @@ exports[`RepositoriesPanel Show More button loads more items 1`] = `
                 <span
                   class="search-filter-keyword"
                 >
-                  repo:
+                  repo
+                </span>
+                <span
+                  class="search-filter-separator"
+                >
+                  :
                 </span>
                 test-two
               </span>
@@ -319,7 +359,12 @@ exports[`RepositoriesPanel consecutive searches with identical repo filters are 
                 <span
                   class="search-filter-keyword"
                 >
-                  repo:
+                  repo
+                </span>
+                <span
+                  class="search-filter-separator"
+                >
+                  :
                 </span>
                 test
               </span>
@@ -339,7 +384,12 @@ exports[`RepositoriesPanel consecutive searches with identical repo filters are 
                 <span
                   class="search-filter-keyword"
                 >
-                  repo:
+                  repo
+                </span>
+                <span
+                  class="search-filter-separator"
+                >
+                  :
                 </span>
                 sourcegraph
               </span>

--- a/client/web/src/search/results/progress/__snapshots__/StreamingProgressSkippedPopover.test.tsx.snap
+++ b/client/web/src/search/results/progress/__snapshots__/StreamingProgressSkippedPopover.test.tsx.snap
@@ -314,7 +314,12 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
           <span
             class="search-filter-keyword"
           >
-            timeout:
+            timeout
+          </span>
+          <span
+            class="search-filter-separator"
+          >
+            :
           </span>
           2m
         </span>
@@ -353,7 +358,12 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
           <span
             class="search-filter-keyword"
           >
-            archived:
+            archived
+          </span>
+          <span
+            class="search-filter-separator"
+          >
+            :
           </span>
           yes
         </span>
@@ -375,7 +385,12 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
           <span
             class="search-filter-keyword"
           >
-            archived:
+            archived
+          </span>
+          <span
+            class="search-filter-separator"
+          >
+            :
           </span>
           yes
         </span>

--- a/client/web/src/search/results/sidebar/__snapshots__/FilterLink.test.tsx.snap
+++ b/client/web/src/search/results/sidebar/__snapshots__/FilterLink.test.tsx.snap
@@ -17,7 +17,12 @@ exports[`FilterLink should have correct links for dynamic filters 1`] = `
         <span
           class="search-filter-keyword"
         >
-          lang:
+          lang
+        </span>
+        <span
+          class="search-filter-separator"
+        >
+          :
         </span>
         go
       </span>
@@ -44,7 +49,12 @@ exports[`FilterLink should have correct links for dynamic filters 1`] = `
         <span
           class="search-filter-keyword"
         >
-          lang:
+          lang
+        </span>
+        <span
+          class="search-filter-separator"
+        >
+          :
         </span>
         typescript
       </span>
@@ -71,7 +81,12 @@ exports[`FilterLink should have correct links for dynamic filters 1`] = `
         <span
           class="search-filter-keyword"
         >
-          -file:
+          -file
+        </span>
+        <span
+          class="search-filter-separator"
+        >
+          :
         </span>
         _test\\.go$
       </span>


### PR DESCRIPTION
It's prettier.

### Now

<img width="575" alt="Screen Shot 2022-01-07 at 12 36 36 PM" src="https://user-images.githubusercontent.com/888624/148606089-73fb15b2-f378-418c-a7ec-c3a17ef0624c.png">
<img width="573" alt="Screen Shot 2022-01-07 at 12 36 19 PM" src="https://user-images.githubusercontent.com/888624/148606097-bd3bde38-a4ad-4b35-afdd-5a39def4c755.png">

---

### Previously

<img width="573" alt="Screen Shot 2022-01-07 at 12 55 50 PM" src="https://user-images.githubusercontent.com/888624/148606285-38644995-2385-4c0f-9d14-a132fc8e7c14.png">
<img width="570" alt="Screen Shot 2022-01-07 at 12 56 10 PM" src="https://user-images.githubusercontent.com/888624/148606276-949f1d3f-8534-4451-9516-3b4f491d7f51.png">


