### PR TITLE
auth: eliminate usage of global DB mocks

### DIFF
--- a/enterprise/cmd/frontend/internal/auth/githuboauth/main_test.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/main_test.go
@@ -1,0 +1,17 @@
+package githuboauth
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/inconshreveable/log15"
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if !testing.Verbose() {
+		log15.Root().SetHandler(log15.DiscardHandler())
+	}
+	os.Exit(m.Run())
+}

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/session.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/session.go
@@ -158,7 +158,7 @@ func (s *sessionIssuerHelper) CreateCodeHostConnection(ctx context.Context, toke
 	// this point we may already have a code host and we just need to update the
 	// token with the new one.
 
-	tx, err := database.ExternalServices(s.db).Transact(ctx)
+	tx, err := s.db.ExternalServices().Transact(ctx)
 	if err != nil {
 		return
 	}

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/session.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/session.go
@@ -100,7 +100,7 @@ func (s *sessionIssuerHelper) CreateCodeHostConnection(ctx context.Context, toke
 	// this point we may already have a code host and we just need to update the
 	// token with the new one.
 
-	tx, err := database.ExternalServices(s.db).Transact(ctx)
+	tx, err := s.db.ExternalServices().Transact(ctx)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
This PR eliminates usage of `database.Mocks` in the `auth/` package.

This is the result of a time-boxed effort.

---

Part of #26113