### PR TITLE
Use repo param in gitserver.CommitsUniqueToBranch

### DIFF
--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -147,6 +147,7 @@ func CommitsUniqueToBranch(ctx context.Context, repo api.RepoName, branchName st
 	}
 
 	cmd := gitserver.DefaultClient.Command("git", args...)
+	cmd.Repo = repo
 	out, err := cmd.CombinedOutput(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This fixes a regression that was, I think, introduced in
1ad4ea26c183a516f24a50990078854aa1a894b0.

It shows up as errors like these:

    [enterprise-worker] ERROR codeintel.gitserver.CommitsUniqueToBranch, error: repository does not exist: , count: 1, elapsed: 0.009333636, repositoryID: 7, branchName: tj/update-repo-integration, isDefaultBranch: false
    [enterprise-worker] ERROR Failed to expire old codeintel records, error: gitserver.CommitsUniqueToBranch: repository does not exist:

Note "repository does not exist:" and *no* repository name.
