### PR TITLE
Revert "search: concurrent evaluation of OR queries (#29281)"

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1013,13 +1013,8 @@ func testSearchClient(t *testing.T, client searchClient) {
 			{
 				name:            `Or distributive property on commits deduplicates and merges`,
 				query:           `repo:^github\.com/sgtest/go-diff$ type:commit (message:add or message:file)`,
-				exactMatchCount: 30,
+				exactMatchCount: 35,
 				skip:            skipStream,
-			},
-			{
-				name:            `Exact default count is respected in OR queries`,
-				query:           `foo OR bar OR (type:repo diff)`,
-				exactMatchCount: 30,
 			},
 		}
 		for _, test := range tests {

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -142,18 +142,12 @@ func (fm *FileMatch) Limit(limit int) int {
 }
 
 func (fm *FileMatch) Key() Key {
-	k := Key{
+	return Key{
 		TypeRank: rankFileMatch,
 		Repo:     fm.Repo.Name,
 		Commit:   fm.CommitID,
 		Path:     fm.Path,
 	}
-
-	if fm.InputRev != nil {
-		k.Rev = *fm.InputRev
-	}
-
-	return k
 }
 
 // LineMatch is the struct used by vscode to receive search results for a line

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -192,9 +192,9 @@ func TestIndexedSearch(t *testing.T) {
 			},
 			wantMatchCount: 3,
 			wantMatchKeys: []result.Key{
-				{Repo: "foo/bar", Rev: "HEAD", Commit: "1", Path: "baz.go"},
-				{Repo: "foo/bar", Rev: "dev", Commit: "1", Path: "baz.go"},
-				{Repo: "foo/bar", Rev: "dev", Commit: "2", Path: "bam.go"},
+				{Repo: "foo/bar", Commit: "1", Path: "baz.go"},
+				{Repo: "foo/bar", Commit: "1", Path: "baz.go"},
+				{Repo: "foo/bar", Commit: "2", Path: "bam.go"},
 			},
 			wantMatchInputRevs: []string{
 				"HEAD",
@@ -225,7 +225,7 @@ func TestIndexedSearch(t *testing.T) {
 			},
 			wantUnindexed: makeRepositoryRevisions("foo/bar@unindexed"),
 			wantMatchKeys: []result.Key{
-				{Repo: "foo/bar", Rev: "HEAD", Commit: "1", Path: "baz.go"},
+				{Repo: "foo/bar", Commit: "1", Path: "baz.go"},
 			},
 			wantMatchCount:     1,
 			wantMatchInputRevs: []string{"HEAD"},


### PR DESCRIPTION
This reverts commit b640ccb91494ec35388d91b0da888d28a13f4cbf.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
