### PR TITLE
user invites: web: remove out-of-band margin from welcome page

### DIFF
--- a/client/web/src/auth/PostSignUpPage.module.scss
+++ b/client/web/src/auth/PostSignUpPage.module.scss
@@ -1,8 +1,6 @@
 @import 'wildcard/src/global-styles/breakpoints';
 
 .post-signup-page {
-    margin-top: 7rem;
-    margin-bottom: 5rem;
     align-self: flex-start;
 
     @keyframes ellipsis {

--- a/client/web/src/auth/PostSignUpPage.tsx
+++ b/client/web/src/auth/PostSignUpPage.tsx
@@ -135,7 +135,7 @@ export const PostSignUpPage: FunctionComponent<PostSignUpPage> = ({
             <div className={classNames(signInSignUpCommonStyles.signinSignupPage, styles.postSignupPage)}>
                 <PageTitle title="Welcome" />
                 <HeroPage
-                    lessPadding={true}
+                    lessPadding={false}
                     className="text-left"
                     body={
                         <div className={classNames('pb-1', styles.container)}>


### PR DESCRIPTION
The `/welcome` page previously had out of band margins which would make the third step page needlessly scroll (as the hero page has 100% height assignment) in Firefox.

This fixes the issue by using the proper API to add margin to the top of the hero page.

Before (not shown here is that there is a scrollbar with 50-100px of scrolling: https://user-images.githubusercontent.com/3173176/148840226-a1b27c98-71ae-41c5-b879-3edfe4a17911.png

After: https://user-images.githubusercontent.com/3173176/148840292-80c2fdda-df1c-40b6-9e9c-dfecdf770267.png

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>