### PR TITLE
migrations: Deprecate use of _number of migrations_ in commands

### DIFF
--- a/dev/sg/sg_db.go
+++ b/dev/sg/sg_db.go
@@ -200,9 +200,9 @@ func dbResetPGExec(ctx context.Context, args []string) error {
 	}
 
 	options := runner.Options{
-		Up:            true,
-		NumMigrations: 0,
-		SchemaNames:   schemaNames,
+		Up:              true,
+		TargetMigration: 0,
+		SchemaNames:     schemaNames,
 	}
 
 	return connections.RunnerFromDSNs(dsnMap, "sg", storeFactory).Run(ctx, options)

--- a/doc/dev/background-information/sg/index.md
+++ b/doc/dev/background-information/sg/index.md
@@ -173,25 +173,17 @@ sg live -help
 ### `sg migration` - Run or manipulate database migrations
 
 ```bash
-# Migrate local default database up
+# Migrate local default database up all the way
 sg migration up
 
 # Migrate specific database down one migration
-sg migration down --db codeintel -n 1
+sg migration down --db codeintel
 
 # Add new migration for specific database
 sg migration add --db codeintel 'add missing index'
 
 # Squash migrations for default database
 sg migration squash
-
-# Fixup your migrations comapred to main for databases
-sg migration fixup
-
-# To see what operations `sg migration fixup` will run, you can check with
-sg migration fixup -run=false
-
-# Or to run for only one database, you can use the -db flag, as in other operations.
 ```
 
 ### `sg rfc` - List or open Sourcegraph RFCs

--- a/internal/database/connections/live/migration_test.go
+++ b/internal/database/connections/live/migration_test.go
@@ -55,8 +55,8 @@ func testMigrations(t *testing.T, name string, schema *schemas.Schema) {
 		// Run down to the root "squashed commits" migration. We don't go
 		// any farther than that because it would require a fresh database,
 		// and that doesn't adequately test upgrade idempotency.
-		NumMigrations: schema.Definitions.Count() - 1,
-		SchemaNames:   []string{name},
+		TargetMigration: schema.Definitions.First(),
+		SchemaNames:     []string{name},
 	}
 
 	//

--- a/internal/database/migration/cliutil/flags.go
+++ b/internal/database/migration/cliutil/flags.go
@@ -79,7 +79,7 @@ func Down(commandName string, run RunFunc, out *output.Output) *ffcli.Command {
 	var (
 		downFlagSet          = flag.NewFlagSet(fmt.Sprintf("%s down", commandName), flag.ExitOnError)
 		downDatabaseNameFlag = downFlagSet.String("db", "", "The target database instance.")
-		downTargetFlag       = downFlagSet.Int("target", 1, "Un-apply all migrations ahead of this target.")
+		downTargetFlag       = downFlagSet.Int("target", 0, "Reset all migrations defined after this target.")
 	)
 
 	execDown := func(ctx context.Context, args []string) error {
@@ -93,8 +93,14 @@ func Down(commandName string, run RunFunc, out *output.Output) *ffcli.Command {
 			return flag.ErrHelp
 		}
 
-		if *downTargetFlag == 0 {
-			out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: invalid number of migrations"))
+		suppliedTarget := false
+		downFlagSet.Visit(func(f *flag.Flag) {
+			if f.Name == "target" {
+				suppliedTarget = true
+			}
+		})
+		if !suppliedTarget {
+			out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: explicit target must be supplied for down migration"))
 			return flag.ErrHelp
 		}
 

--- a/internal/database/migration/cliutil/flags.go
+++ b/internal/database/migration/cliutil/flags.go
@@ -79,7 +79,7 @@ func Down(commandName string, run RunFunc, out *output.Output) *ffcli.Command {
 	var (
 		downFlagSet          = flag.NewFlagSet(fmt.Sprintf("%s down", commandName), flag.ExitOnError)
 		downDatabaseNameFlag = downFlagSet.String("db", "", "The target database instance.")
-		downTargetFlag       = downFlagSet.Int("target", 0, "Reset all migrations defined after this target.")
+		downTargetFlag       = downFlagSet.Int("target", 0, "Reset all migrations defined after this target. The default invocation reverts the current migration.")
 	)
 
 	execDown := func(ctx context.Context, args []string) error {
@@ -90,17 +90,6 @@ func Down(commandName string, run RunFunc, out *output.Output) *ffcli.Command {
 
 		if *downDatabaseNameFlag == "" {
 			out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: supply -db to migrate a specific database"))
-			return flag.ErrHelp
-		}
-
-		suppliedTarget := false
-		downFlagSet.Visit(func(f *flag.Flag) {
-			if f.Name == "target" {
-				suppliedTarget = true
-			}
-		})
-		if !suppliedTarget {
-			out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: explicit target must be supplied for down migration"))
 			return flag.ErrHelp
 		}
 

--- a/internal/database/migration/cliutil/flags.go
+++ b/internal/database/migration/cliutil/flags.go
@@ -37,7 +37,7 @@ func Up(commandName string, run RunFunc, out *output.Output) *ffcli.Command {
 	var (
 		upFlagSet          = flag.NewFlagSet(fmt.Sprintf("%s up", commandName), flag.ExitOnError)
 		upDatabaseNameFlag = upFlagSet.String("db", "all", `The target database instance. Supply "all" (the default) to migrate all databases.`)
-		upNFlag            = upFlagSet.Int("n", 0, "How many migrations to apply. Zero (the default) applies all migrations.")
+		upTargetFlag       = upFlagSet.Int("target", 0, "Apply all migrations up to this target. Zero (the default) applies all migrations.")
 	)
 
 	execUp := func(ctx context.Context, args []string) error {
@@ -46,7 +46,7 @@ func Up(commandName string, run RunFunc, out *output.Output) *ffcli.Command {
 			return flag.ErrHelp
 		}
 
-		if *upDatabaseNameFlag == "all" && *upNFlag != 0 {
+		if *upDatabaseNameFlag == "all" && *upTargetFlag != 0 {
 			out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: supply -db to migrate a specific database"))
 			return flag.ErrHelp
 		}
@@ -59,9 +59,9 @@ func Up(commandName string, run RunFunc, out *output.Output) *ffcli.Command {
 		}
 
 		return run(ctx, runner.Options{
-			Up:            true,
-			NumMigrations: *upNFlag,
-			SchemaNames:   databaseNames,
+			Up:              true,
+			TargetMigration: *upTargetFlag,
+			SchemaNames:     databaseNames,
 		})
 	}
 
@@ -79,7 +79,7 @@ func Down(commandName string, run RunFunc, out *output.Output) *ffcli.Command {
 	var (
 		downFlagSet          = flag.NewFlagSet(fmt.Sprintf("%s down", commandName), flag.ExitOnError)
 		downDatabaseNameFlag = downFlagSet.String("db", "", "The target database instance.")
-		downNFlag            = downFlagSet.Int("n", 1, "How many migrations to apply.")
+		downTargetFlag       = downFlagSet.Int("target", 1, "Un-apply all migrations ahead of this target.")
 	)
 
 	execDown := func(ctx context.Context, args []string) error {
@@ -93,15 +93,15 @@ func Down(commandName string, run RunFunc, out *output.Output) *ffcli.Command {
 			return flag.ErrHelp
 		}
 
-		if *downNFlag == 0 {
+		if *downTargetFlag == 0 {
 			out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: invalid number of migrations"))
 			return flag.ErrHelp
 		}
 
 		return run(ctx, runner.Options{
-			Up:            false,
-			NumMigrations: *downNFlag,
-			SchemaNames:   []string{*downDatabaseNameFlag},
+			Up:              false,
+			TargetMigration: *downTargetFlag,
+			SchemaNames:     []string{*downDatabaseNameFlag},
 		})
 	}
 

--- a/internal/database/migration/cliutil/flags.go
+++ b/internal/database/migration/cliutil/flags.go
@@ -67,7 +67,7 @@ func Up(commandName string, run RunFunc, out *output.Output) *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "up",
-		ShortUsage: fmt.Sprintf("%s up [-db=all] [-n=0]", commandName),
+		ShortUsage: fmt.Sprintf("%s up [-db=all] [-target=0]", commandName),
 		ShortHelp:  "Run up migrations",
 		FlagSet:    upFlagSet,
 		Exec:       execUp,
@@ -79,7 +79,7 @@ func Down(commandName string, run RunFunc, out *output.Output) *ffcli.Command {
 	var (
 		downFlagSet          = flag.NewFlagSet(fmt.Sprintf("%s down", commandName), flag.ExitOnError)
 		downDatabaseNameFlag = downFlagSet.String("db", "", "The target database instance.")
-		downTargetFlag       = downFlagSet.Int("target", 0, "Reset all migrations defined after this target. The default invocation reverts the current migration.")
+		downTargetFlag       = downFlagSet.Int("target", 0, "Reset all migrations defined after this target. Zero (the default) reverts the latest migration.")
 	)
 
 	execDown := func(ctx context.Context, args []string) error {
@@ -102,7 +102,7 @@ func Down(commandName string, run RunFunc, out *output.Output) *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "down",
-		ShortUsage: fmt.Sprintf("%s down -db=... [-n=1]", commandName),
+		ShortUsage: fmt.Sprintf("%s down -db=... [-target=0]", commandName),
 		ShortHelp:  "Run down migrations",
 		FlagSet:    downFlagSet,
 		Exec:       execDown,

--- a/internal/database/migration/definition/definition.go
+++ b/internal/database/migration/definition/definition.go
@@ -23,6 +23,10 @@ func (ds *Definitions) Count() int {
 	return len(ds.definitions)
 }
 
+func (ds *Definitions) First() int {
+	return ds.definitions[0].ID
+}
+
 func (ds *Definitions) GetByID(id int) (Definition, bool) {
 	for _, definition := range ds.definitions {
 		if definition.ID == id {
@@ -31,6 +35,14 @@ func (ds *Definitions) GetByID(id int) (Definition, bool) {
 	}
 
 	return Definition{}, false
+}
+
+func (ds *Definitions) UpTo(id, target int) ([]Definition, error) {
+	if target < id {
+		return nil, errors.Newf("migration %d is behind version %d", target, id)
+	}
+
+	return ds.UpFrom(id, target-id)
 }
 
 func (ds *Definitions) UpFrom(id, n int) ([]Definition, error) {
@@ -52,6 +64,14 @@ func (ds *Definitions) UpFrom(id, n int) ([]Definition, error) {
 	}
 
 	return slice, nil
+}
+
+func (ds *Definitions) DownTo(id, target int) ([]Definition, error) {
+	if id < target {
+		return nil, errors.Newf("migration %d is ahead of version %d", target, id)
+	}
+
+	return ds.DownFrom(id, id-target)
 }
 
 func (ds *Definitions) DownFrom(id, n int) ([]Definition, error) {

--- a/internal/database/migration/definition/definition_test.go
+++ b/internal/database/migration/definition/definition_test.go
@@ -98,21 +98,19 @@ func TestDownFrom(t *testing.T) {
 		{ID: 15, UpFilename: "15.up.sql"},
 	}}
 
-	t.Run("no limit", func(t *testing.T) {
+	t.Run("zero", func(t *testing.T) {
 		// middle of sequence
 		ds, err := definitions.DownFrom(14, 0)
 		if err != nil {
 			t.Fatalf("unexpected error")
 		}
+		if len(ds) != 0 {
+			var definitionIDs []int
+			for _, definition := range ds {
+				definitionIDs = append(definitionIDs, definition.ID)
+			}
 
-		var definitionIDs []int
-		for _, definition := range ds {
-			definitionIDs = append(definitionIDs, definition.ID)
-		}
-
-		expectedIDs := []int{14, 13, 12, 11}
-		if diff := cmp.Diff(expectedIDs, definitionIDs); diff != "" {
-			t.Fatalf("unexpected ids (-want +got):\n%s", diff)
+			t.Fatalf("expected no definitions, got %v", definitionIDs)
 		}
 	})
 

--- a/internal/database/migration/runner/run.go
+++ b/internal/database/migration/runner/run.go
@@ -123,6 +123,10 @@ func (r *Runner) runSchemaUp(ctx context.Context, options Options, schemaContext
 func (r *Runner) runSchemaDown(ctx context.Context, options Options, schemaContext schemaContext) error {
 	log15.Info("Downgrading schema", "schema", schemaContext.schema.Name)
 
+	if options.TargetMigration == 0 {
+		options.TargetMigration = schemaContext.schemaVersion.version - 1
+	}
+
 	definitions, err := schemaContext.schema.Definitions.DownTo(schemaContext.schemaVersion.version, options.TargetMigration)
 	if err != nil {
 		return err

--- a/internal/database/migration/runner/run.go
+++ b/internal/database/migration/runner/run.go
@@ -9,9 +9,9 @@ import (
 )
 
 type Options struct {
-	Up            bool
-	NumMigrations int
-	SchemaNames   []string
+	Up              bool
+	TargetMigration int
+	SchemaNames     []string
 
 	// Parallel controls whether we run schema migrations concurrently or not. By default,
 	// we run schema migrations sequentially. This is to ensure that in testing, where the
@@ -45,7 +45,7 @@ func (r *Runner) runSchema(ctx context.Context, options Options, schemaContext s
 	// Determine if we are upgrading to the latest schema. There are some properties around
 	// contention which we want to accept on normal "upgrade to latest" behavior, but want to
 	// alert on when a user is downgrading or upgrading to a specific version.
-	upgradingToLatest := options.Up && options.NumMigrations == 0
+	upgradingToLatest := options.Up && options.TargetMigration == 0
 
 	if !upgradingToLatest {
 		// If the database is dirty, then either the last attempted migration had failed,
@@ -104,7 +104,7 @@ func (r *Runner) runSchema(ctx context.Context, options Options, schemaContext s
 func (r *Runner) runSchemaUp(ctx context.Context, options Options, schemaContext schemaContext) (err error) {
 	log15.Info("Upgrading schema", "schema", schemaContext.schema.Name)
 
-	definitions, err := schemaContext.schema.Definitions.UpFrom(schemaContext.schemaVersion.version, options.NumMigrations)
+	definitions, err := schemaContext.schema.Definitions.UpTo(schemaContext.schemaVersion.version, options.TargetMigration)
 	if err != nil {
 		return err
 	}
@@ -123,7 +123,7 @@ func (r *Runner) runSchemaUp(ctx context.Context, options Options, schemaContext
 func (r *Runner) runSchemaDown(ctx context.Context, options Options, schemaContext schemaContext) error {
 	log15.Info("Downgrading schema", "schema", schemaContext.schema.Name)
 
-	definitions, err := schemaContext.schema.Definitions.DownFrom(schemaContext.schemaVersion.version, options.NumMigrations)
+	definitions, err := schemaContext.schema.Definitions.DownTo(schemaContext.schemaVersion.version, options.TargetMigration)
 	if err != nil {
 		return err
 	}

--- a/internal/database/migration/runner/run_test.go
+++ b/internal/database/migration/runner/run_test.go
@@ -17,9 +17,9 @@ func TestRunnerRun(t *testing.T) {
 		store := testStoreWithVersion(10000, false)
 
 		if err := testRunner(store).Run(ctx, Options{
-			Up:            true,
-			NumMigrations: 2,
-			SchemaNames:   []string{"well-formed"},
+			Up:              true,
+			TargetMigration: 10000 + 2,
+			SchemaNames:     []string{"well-formed"},
 		}); err != nil {
 			t.Fatalf("unexpected error running upgrade: %s", err)
 		}
@@ -32,9 +32,9 @@ func TestRunnerRun(t *testing.T) {
 		store := testStoreWithVersion(10003, false)
 
 		if err := testRunner(store).Run(ctx, Options{
-			Up:            false,
-			NumMigrations: 2,
-			SchemaNames:   []string{"well-formed"},
+			Up:              false,
+			TargetMigration: 10003 - 2,
+			SchemaNames:     []string{"well-formed"},
 		}); err != nil {
 			t.Fatalf("unexpected error running downgrade: %s", err)
 		}
@@ -48,9 +48,9 @@ func TestRunnerRun(t *testing.T) {
 		store.UpFunc.PushReturn(fmt.Errorf("uh-oh"))
 
 		if err := testRunner(store).Run(ctx, Options{
-			Up:            true,
-			NumMigrations: 1,
-			SchemaNames:   []string{"query-error"},
+			Up:              true,
+			TargetMigration: 10000 + 1,
+			SchemaNames:     []string{"query-error"},
 		}); err == nil || !strings.Contains(err.Error(), "uh-oh") {
 			t.Fatalf("unexpected error running upgrade. want=%q have=%q", "uh-oh", err)
 		}
@@ -64,9 +64,9 @@ func TestRunnerRun(t *testing.T) {
 		store.DownFunc.PushReturn(fmt.Errorf("uh-oh"))
 
 		if err := testRunner(store).Run(ctx, Options{
-			Up:            false,
-			NumMigrations: 1,
-			SchemaNames:   []string{"query-error"},
+			Up:              false,
+			TargetMigration: 10001 - 1,
+			SchemaNames:     []string{"query-error"},
 		}); err == nil || !strings.Contains(err.Error(), "uh-oh") {
 			t.Fatalf("unexpected error running downgrade. want=%q have=%q", "uh-oh", err)
 		}
@@ -77,9 +77,9 @@ func TestRunnerRun(t *testing.T) {
 
 	t.Run("unknown schema", func(t *testing.T) {
 		if err := testRunner(testStoreWithVersion(10000, false)).Run(ctx, Options{
-			Up:            true,
-			NumMigrations: 1,
-			SchemaNames:   []string{"unknown"},
+			Up:              true,
+			TargetMigration: 10000 + 1,
+			SchemaNames:     []string{"unknown"},
 		}); err == nil || !strings.Contains(err.Error(), "unknown schema") {
 			t.Fatalf("unexpected error running upgrade. want=%q have=%q", "unknown schema", err)
 		}
@@ -89,9 +89,9 @@ func TestRunnerRun(t *testing.T) {
 		store := testStoreWithVersion(10000, true)
 
 		if err := testRunner(store).Run(ctx, Options{
-			Up:            true,
-			NumMigrations: 1,
-			SchemaNames:   []string{"well-formed"},
+			Up:              true,
+			TargetMigration: 10000 + 1,
+			SchemaNames:     []string{"well-formed"},
 		}); err == nil || !strings.Contains(err.Error(), "dirty database") {
 			t.Fatalf("unexpected error running upgrade. want=%q have=%q", "dirty database", err)
 		}
@@ -102,9 +102,9 @@ func TestRunnerRun(t *testing.T) {
 		store.VersionFunc.SetDefaultReturn(10001, true, true, nil)
 
 		if err := testRunner(store).Run(ctx, Options{
-			Up:            true,
-			NumMigrations: 0,
-			SchemaNames:   []string{"well-formed"},
+			Up:              true,
+			TargetMigration: 10002 + 0,
+			SchemaNames:     []string{"well-formed"},
 		}); err == nil || !strings.Contains(err.Error(), "dirty database") {
 			t.Fatalf("unexpected error running upgrade. want=%q have=%q", "dirty database", err)
 		}
@@ -116,9 +116,9 @@ func TestRunnerRun(t *testing.T) {
 		store.TryLockFunc.SetDefaultReturn(false, func(err error) error { return err }, nil)
 
 		if err := testRunner(store).Run(ctx, Options{
-			Up:            true,
-			NumMigrations: 1,
-			SchemaNames:   []string{"well-formed"},
+			Up:              true,
+			TargetMigration: 10000 + 1,
+			SchemaNames:     []string{"well-formed"},
 		}); err == nil || !strings.Contains(err.Error(), "contention") {
 			t.Fatalf("unexpected error running upgrade. want=%q have=%q", "contention", err)
 		}
@@ -129,9 +129,9 @@ func TestRunnerRun(t *testing.T) {
 		store.VersionFunc.PushReturn(10001, false, true, nil)
 
 		if err := testRunner(store).Run(ctx, Options{
-			Up:            true,
-			NumMigrations: 1,
-			SchemaNames:   []string{"well-formed"},
+			Up:              true,
+			TargetMigration: 10002 + 1,
+			SchemaNames:     []string{"well-formed"},
 		}); err == nil || !strings.Contains(err.Error(), "contention") {
 			t.Fatalf("unexpected error running upgrade. want=%q have=%q", "contention", err)
 		}

--- a/internal/database/migration/runner/testdata/query-error/10000_squashed.down.sql
+++ b/internal/database/migration/runner/testdata/query-error/10000_squashed.down.sql
@@ -1,0 +1,1 @@
+--- Squashed

--- a/internal/database/migration/runner/testdata/query-error/10000_squashed.up.sql
+++ b/internal/database/migration/runner/testdata/query-error/10000_squashed.up.sql
@@ -1,0 +1,1 @@
+--- Squashed

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -19,8 +19,8 @@ The migration path for each database instance is the same and is described below
 Up migrations will happen automatically in development on service startup. In production environments, they are run by the [`migrator`](../cmd/migrator) instance. You can run migrations manually during development via `sg`:
 
 - `sg migration up` runs all migrations to the latest version
-- `sg migration up -db=frontend -n=3` runs three _up_ migrations (relative to the current database version) on the frontend database
-- `sg migration down -db=codeintel -n=1` runs one _down_ migration (relative to the current database version) on the codeintel database
+- `sg migration up -db=frontend -target=<version>` runs up migrations (relative to the current database version) on the frontend database until it hits the target version
+- `sg migration down -db=codeintel` runs one _down_ migration (relative to the current database version) on the codeintel database
 
 ## Adding a migration
 


### PR DESCRIPTION
Fixes #29544. This PR replaces the concept of migrating _n versions_ up or down with the concept of migrating _to_ a target version.

This changes the UI of `sg migration` as well as the migrator instance (which should currently have no explicit users that aren't default arguments).