### PR TITLE
search: use minimal search arguments

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -38,12 +38,12 @@ func (srs *searchResultsStats) Languages(ctx context.Context) ([]*languageStatis
 
 func (srs *searchResultsStats) getResults(ctx context.Context) (*SearchResultsResolver, error) {
 	srs.once.Do(func() {
-		args, jobs, err := srs.sr.toSearchInputs(srs.sr.Query)
+		jobs, repoOptions, timeout, err := srs.sr.toSearchInputs(srs.sr.Query)
 		if err != nil {
 			srs.srsErr = err
 			return
 		}
-		results, err := srs.sr.doResults(ctx, args, jobs)
+		results, err := srs.sr.doResults(ctx, jobs, repoOptions, timeout)
 		if err != nil {
 			srs.srsErr = err
 			return


### PR DESCRIPTION
This removes the dependency on `args search.TextParameters` from the point at which we create search jobs. It means our toplevel search functions take a 3-tuple of just the list of `jobs`, `search.RepoOptions`, and the `timeout` value. Compare this to the massive footprint of [`TextParameters`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@7db7d396346284fd0f8f79f130f38b16fb1d3d70/-/blob/internal/search/types.go?L138-167&subtree=true) previously, tracking much state that is irrelevant to the now search jobs.

There's opportunity to merge some of the above toplevel functions so we don't have to keep propagating this 3-tuple. Will do some of that in a follow up. See inline for more comments.

The build should pass, if it doesn't it's probably a flake, so I'm putting it up for review before it's green.