### PR TITLE
Ensure sign up form help icon doesn't wrap by itself

### DIFF
--- a/client/web/src/auth/SignUpForm.tsx
+++ b/client/web/src/auth/SignUpForm.tsx
@@ -246,11 +246,12 @@ export const SignUpForm: React.FunctionComponent<SignUpFormProps> = ({
                                     type="checkbox"
                                     onChange={onRequestTrialFieldChange}
                                 />
-                                Try Sourcegraph Enterprise free for 30 days{' '}
-                                {/* eslint-disable-next-line react/jsx-no-target-blank */}
-                                <a target="_blank" rel="noopener" href="https://about.sourcegraph.com/pricing">
-                                    <HelpCircleOutlineIcon className="icon-inline" />
-                                </a>
+                                Try Sourcegraph Enterprise free for <span className='text-nowrap'>30 days{' '}
+                                    {/* eslint-disable-next-line react/jsx-no-target-blank */}
+                                    <a target="_blank" rel="noopener" href="https://about.sourcegraph.com/pricing">
+                                        <HelpCircleOutlineIcon className="icon-inline" />
+                                    </a>
+                                </span>
                             </label>
                         </div>
                     </div>

--- a/client/web/src/auth/SignUpForm.tsx
+++ b/client/web/src/auth/SignUpForm.tsx
@@ -246,8 +246,9 @@ export const SignUpForm: React.FunctionComponent<SignUpFormProps> = ({
                                     type="checkbox"
                                     onChange={onRequestTrialFieldChange}
                                 />
-                                Try Sourcegraph Enterprise free for <span className='text-nowrap'>30 days{' '}
-                                    {/* eslint-disable-next-line react/jsx-no-target-blank */}
+                                Try Sourcegraph Enterprise free for{' '}
+                                <span className="text-nowrap">
+                                    30 days {/* eslint-disable-next-line react/jsx-no-target-blank */}
                                     <a target="_blank" rel="noopener" href="https://about.sourcegraph.com/pricing">
                                         <HelpCircleOutlineIcon className="icon-inline" />
                                     </a>


### PR DESCRIPTION
Refer to conversation in Slack: https://sourcegraph.slack.com/archives/C01C3NCGD40/p164128828824590

![CleanShot 2021-12-30 at 11 56 20@2x](https://user-images.githubusercontent.com/492942/148908691-ba77c0de-3e89-4984-a970-d3aa7c31c8df.png)