### PR TITLE
Truncate fetched buildSha if it is longer than the one we get from git log

### DIFF
--- a/dev/sg/live.go
+++ b/dev/sg/live.go
@@ -110,6 +110,9 @@ func printDeployedVersion(e environment) error {
 
 		var emoji = "  "
 		var style = output.StylePending
+		if len(buildSha) > len(sha) {
+			buildSha = buildSha[:len(sha)]
+		}
 		if sha[0:len(buildSha)] == buildSha {
 			emoji = "🚀"
 			style = output.StyleLogo


### PR DESCRIPTION
[https://sourcegraph.com/__version](https://sourcegraph.com/__version) returns `124976_2022-01-11_49efaad8e7da01f5d974c36763055e6bfb1a722d` as current version, which caused a slice overflow in `sg live` (that expects 10 char long sha).


Error
```
panic: runtime error: slice bounds out of range [:40] with length 10

goroutine 1 [running]:
main.printDeployedVersion({{0x1057d1bf9, 0x5}, {0x1057e8771, 0x17}})
	/Users/rafal/dev/sourcegraph/dev/sg/live.go:113 +0x149c
```