### PR TITLE
web: codemod the `<Link class="btn" />` component

### DIFF
--- a/client/web/src/api/ApiConsole.tsx
+++ b/client/web/src/api/ApiConsole.tsx
@@ -6,7 +6,7 @@ import { from as fromPromise, Subject, Subscription } from 'rxjs'
 import { catchError, debounceTime } from 'rxjs/operators'
 
 import { asError, ErrorLike, isErrorLike } from '@sourcegraph/common'
-import { LoadingSpinner } from '@sourcegraph/wildcard'
+import { LoadingSpinner, Button } from '@sourcegraph/wildcard'
 
 import { ErrorAlert } from '../components/alerts'
 import { PageTitle } from '../components/PageTitle'
@@ -174,9 +174,9 @@ export class ApiConsole extends React.PureComponent<Props, State> {
                                 label="Prettify"
                             />
                             <GraphiQL.Button onClick={this.handleToggleHistory} title="Show History" label="History" />
-                            <Link className="btn btn-link" to="/help/api/graphql">
+                            <Button to="/help/api/graphql" variant="link" as={Link}>
                                 Docs
-                            </Link>
+                            </Button>
                             <div className="alert alert-warning py-1 mb-0 ml-2 text-nowrap">
                                 <small>
                                     The API console uses <strong>real production data.</strong>

--- a/client/web/src/batches/RepoBatchChangesButton.tsx
+++ b/client/web/src/batches/RepoBatchChangesButton.tsx
@@ -1,10 +1,9 @@
-import classNames from 'classnames'
 import React, { FC, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 
 import { encodeURIPathComponent } from '@sourcegraph/shared/src/util/url'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
-import { Badge } from '@sourcegraph/wildcard'
+import { Badge, Button } from '@sourcegraph/wildcard'
 
 import { queryRepoChangesetsStats as _queryRepoChangesetsStats } from './backend'
 import { BatchChangesIcon } from './icons'
@@ -32,9 +31,12 @@ export const RepoBatchChangesButton: FC<RepoBatchChangesButtonProps> = ({
     const { open, merged } = stats.changesetsStats
 
     return (
-        <Link
-            className={classNames('btn btn-outline-secondary', className)}
+        <Button
+            className={className}
             to={`/${encodeURIPathComponent(repoName)}/-/batch-changes`}
+            variant="secondary"
+            outline={true}
+            as={Link}
         >
             <BatchChangesIcon className="icon-inline" /> Batch Changes
             {open > 0 && (
@@ -55,6 +57,6 @@ export const RepoBatchChangesButton: FC<RepoBatchChangesButtonProps> = ({
                     {merged}
                 </Badge>
             )}
-        </Link>
+        </Button>
     )
 }

--- a/client/web/src/components/diff/FileDiffNode.tsx
+++ b/client/web/src/components/diff/FileDiffNode.tsx
@@ -131,13 +131,15 @@ export const FileDiffNode: React.FunctionComponent<FileDiffNodeProps> = ({
                     <div className={styles.headerActions}>
                         {/* We only have a 'view' component for GitBlobs, but not for `VirtualFile`s. */}
                         {node.mostRelevantFile.__typename === 'GitBlob' && (
-                            <Link
+                            <Button
                                 to={node.mostRelevantFile.url}
-                                className="btn btn-sm btn-link"
                                 data-tooltip="View file at revision"
+                                variant="link"
+                                size="sm"
+                                as={Link}
                             >
                                 View
-                            </Link>
+                            </Button>
                         )}
                     </div>
                 </div>

--- a/client/web/src/components/externalServices/ExternalServiceNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceNode.tsx
@@ -60,13 +60,16 @@ export const ExternalServiceNode: React.FunctionComponent<ExternalServiceNodePro
                     {node.displayName}
                 </div>
                 <div>
-                    <Link
-                        className="btn btn-secondary btn-sm test-edit-external-service-button"
+                    <Button
+                        className="test-edit-external-service-button"
                         to={`${routingPrefix}/external-services/${node.id}`}
                         data-tooltip="External service settings"
+                        variant="secondary"
+                        size="sm"
+                        as={Link}
                     >
                         <SettingsIcon className="icon-inline" /> Edit
-                    </Link>{' '}
+                    </Button>{' '}
                     <Button
                         className="test-delete-external-service-button"
                         onClick={onDelete}

--- a/client/web/src/components/externalServices/ExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicesPage.tsx
@@ -9,6 +9,7 @@ import { isErrorLike, ErrorLike } from '@sourcegraph/common'
 import { ActivationProps } from '@sourcegraph/shared/src/components/activation/Activation'
 import { Link } from '@sourcegraph/shared/src/components/Link'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { Button } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { ListExternalServiceFields, Scalars, ExternalServicesResult } from '../../graphql-operations'
@@ -89,12 +90,14 @@ export const ExternalServicesPage: React.FunctionComponent<Props> = ({
             <div className="d-flex justify-content-between align-items-center mb-3">
                 <h2 className="mb-0">Manage code hosts</h2>
                 {!isManagingOtherUser && (
-                    <Link
-                        className="btn btn-primary test-goto-add-external-service-page"
+                    <Button
+                        className="test-goto-add-external-service-page"
                         to={`${routingPrefix}/external-services/new`}
+                        variant="primary"
+                        as={Link}
                     >
                         <AddIcon className="icon-inline" /> Add code host
-                    </Link>
+                    </Button>
                 )}
             </div>
             <p className="mt-2">Manage code host connections to sync repositories.</p>

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsActionSection.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsActionSection.tsx
@@ -66,17 +66,20 @@ export const BatchChangeDetailsActionSection: React.FunctionComponent<BatchChang
     return (
         <div className="d-flex">
             {showEditButton && (
-                <Link to={`${location.pathname}/edit`} className="mr-2 btn btn-secondary">
+                <Button to={`${location.pathname}/edit`} className="mr-2" variant="secondary" as={Link}>
                     <PencilIcon className="icon-inline" /> Edit
-                </Link>
+                </Button>
             )}
-            <Link
+            <Button
                 to={`${location.pathname}/close`}
-                className="btn btn-outline-danger test-batches-close-btn"
+                className="test-batches-close-btn"
                 data-tooltip="View a preview of all changes that will happen when you close this batch change."
+                variant="danger"
+                outline={true}
+                as={Link}
             >
                 <DeleteIcon className="icon-inline" /> Close
-            </Link>
+            </Button>
         </div>
     )
 }

--- a/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
@@ -268,9 +268,9 @@ const BatchSpecActions: React.FunctionComponent<BatchSpecActionsProps> = ({ batc
                     {!location.pathname.endsWith('preview') &&
                         batchSpec.applyURL &&
                         batchSpec.state === BatchSpecState.COMPLETED && (
-                            <Link to="preview" className="btn btn-primary">
+                            <Button to="preview" variant="primary" as={Link}>
                                 Preview
-                            </Link>
+                            </Button>
                         )}
                     {batchSpec.viewerCanRetry && batchSpec.state !== BatchSpecState.COMPLETED && (
                         // TODO: Add a second button to allow retrying an entire batch spec,
@@ -293,14 +293,16 @@ const BatchSpecActions: React.FunctionComponent<BatchSpecActionsProps> = ({ batc
                     {!location.pathname.endsWith('preview') &&
                         batchSpec.applyURL &&
                         batchSpec.state === BatchSpecState.FAILED && (
-                            <Link
-                                className="btn btn-outline-warning"
+                            <Button
                                 to="preview"
                                 data-tooltip="Execution didn't finish successfully in all workspaces. The batch spec might have less changeset specs than expected."
+                                variant="warning"
+                                outline={true}
+                                as={Link}
                             >
                                 <AlertCircleIcon className="icon-inline mb-0 mr-2 text-warning" />
                                 Preview
-                            </Link>
+                            </Button>
                         )}
                 </div>
                 {isErrorLike(isCanceling) && <ErrorAlert error={isCanceling} />}

--- a/client/web/src/enterprise/batches/list/NewBatchChangeButton.tsx
+++ b/client/web/src/enterprise/batches/list/NewBatchChangeButton.tsx
@@ -2,11 +2,12 @@ import PlusIcon from 'mdi-react/PlusIcon'
 import React from 'react'
 
 import { Link, LinkProps } from '@sourcegraph/shared/src/components/Link'
+import { Button } from '@sourcegraph/wildcard'
 
 interface NewBatchChangeButtonProps extends Pick<LinkProps, 'to'> {}
 
 export const NewBatchChangeButton: React.FunctionComponent<NewBatchChangeButtonProps> = ({ to }) => (
-    <Link to={to} className="btn btn-primary">
+    <Button to={to} variant="primary" as={Link}>
         <PlusIcon className="icon-inline" /> Create batch change
-    </Link>
+    </Button>
 )

--- a/client/web/src/enterprise/batches/repo/BatchChangeNode.tsx
+++ b/client/web/src/enterprise/batches/repo/BatchChangeNode.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from 'react'
 
 import { Link } from '@sourcegraph/shared/src/components/Link'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
+import { Button } from '@sourcegraph/wildcard'
 
 import { Timestamp } from '../../../components/time/Timestamp'
 import { RepoBatchChange } from '../../../graphql-operations'
@@ -44,9 +45,17 @@ export const BatchChangeNode: React.FunctionComponent<BatchChangeNodeProps> = ({
                         {node.changesets.totalCount} changesets total (showing first {MAX_CHANGESETS_COUNT})
                     </span>
                 </small>
-                <Link className="d-block btn btn-sm btn-link" to={node.url} target="_blank" rel="noopener noreferrer">
+                <Button
+                    className="d-block"
+                    to={node.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    variant="link"
+                    size="sm"
+                    as={Link}
+                >
                     See all
-                </Link>
+                </Button>
             </div>
         ) : null
 

--- a/client/web/src/enterprise/code-monitoring/CodeMonitorList.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitorList.tsx
@@ -32,10 +32,10 @@ const CodeMonitorEmptyList: React.FunctionComponent<{ authenticatedUser: Authent
     <div className="text-center">
         <h2 className="text-muted mb-2">No code monitors have been created.</h2>
         {authenticatedUser ? (
-            <Link to="/code-monitoring/new" className="btn btn-primary">
+            <Button to="/code-monitoring/new" variant="primary" as={Link}>
                 <PlusIcon className="icon-inline" />
                 Create a code monitor
-            </Link>
+            </Button>
         ) : (
             <CodeMonitorSignUpLink eventName="SignUpPLGMonitor_EmptyList" text="Sign up to create a code monitor" />
         )}

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 
 import { Link } from '@sourcegraph/shared/src/components/Link'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
+import { Button } from '@sourcegraph/wildcard'
 
 import styles from './CodeMonitoringGettingStarted.module.scss'
 import { CodeMonitorSignUpLink } from './CodeMonitoringSignUpLink'
@@ -86,10 +87,10 @@ export const CodeMonitoringGettingStarted: React.FunctionComponent<CodeMonitorin
                         <li>Identify use of deprecated libraries</li>
                     </ul>
                     {isSignedIn ? (
-                        <Link to="/code-monitoring/new" className={classNames('btn btn-primary', styles.createButton)}>
+                        <Button to="/code-monitoring/new" className={styles.createButton} variant="primary" as={Link}>
                             <PlusIcon className="icon-inline mr-2" />
                             Create a code monitor
-                        </Link>
+                        </Button>
                     ) : (
                         <CodeMonitorSignUpLink
                             className={styles.createButton}

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringNode.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringNode.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames'
 import * as H from 'history'
 import React, { useState, useCallback, useMemo } from 'react'
 import { Observable, concat, of } from 'rxjs'
@@ -111,12 +110,14 @@ export const CodeMonitorNode: React.FunctionComponent<CodeMonitorNodeProps> = ({
                             disabled={toggleMonitorOrError === LOADING}
                         />
                     </div>
-                    <Link
+                    <Button
                         to={`${location.pathname}/${node.id}`}
-                        className={classNames('btn btn-link', styles.editButton)}
+                        className={styles.editButton}
+                        variant="link"
+                        as={Link}
                     >
                         Edit
-                    </Link>
+                    </Button>
                 </div>
             </div>
             {isErrorLike(toggleMonitorOrError) && (

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -9,7 +9,7 @@ import { Link } from '@sourcegraph/shared/src/components/Link'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
-import { PageHeader, LoadingSpinner } from '@sourcegraph/wildcard'
+import { PageHeader, LoadingSpinner, Button } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { CodeMonitoringLogo } from '../../code-monitoring/CodeMonitoringLogo'
@@ -96,10 +96,10 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
                     userHasCodeMonitors !== 'loading' &&
                     !isErrorLike(userHasCodeMonitors) &&
                     authenticatedUser && (
-                        <Link to="/code-monitoring/new" className="btn btn-primary">
+                        <Button to="/code-monitoring/new" variant="primary" as={Link}>
                             <PlusIcon className="icon-inline" />
                             Create
-                        </Link>
+                        </Button>
                     )
                 }
                 description={

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringSignUpLink.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringSignUpLink.tsx
@@ -1,7 +1,7 @@
-import classNames from 'classnames'
 import React from 'react'
 
 import { Link } from '@sourcegraph/shared/src/components/Link'
+import { Button } from '@sourcegraph/wildcard'
 
 import { eventLogger } from '../../tracking/eventLogger'
 
@@ -14,12 +14,14 @@ export const CodeMonitorSignUpLink: React.FunctionComponent<{
         eventLogger.log(eventName)
     }
     return (
-        <Link
+        <Button
             onClick={onClick}
             to={`/sign-up?returnTo=${encodeURIComponent('/code-monitoring/new')}&src=Monitor`}
-            className={classNames('btn btn-primary', className)}
+            className={className}
+            variant="primary"
+            as={Link}
         >
             {text}
-        </Link>
+        </Button>
     )
 }

--- a/client/web/src/enterprise/extensions/extension/RegistryExtensionManagePage.tsx
+++ b/client/web/src/enterprise/extensions/extension/RegistryExtensionManagePage.tsx
@@ -185,12 +185,14 @@ export const RegistryExtensionManagePage = withAuthenticatedUser(
                     <div className={classNames('card mt-5', styles.otherActions)}>
                         <div className="card-header">Other actions</div>
                         <div className="card-body">
-                            <Link
+                            <Button
                                 to={`${this.props.extension.registryExtension.url}/-/releases/new`}
-                                className="btn btn-success mr-2"
+                                className="mr-2"
+                                variant="success"
+                                as={Link}
                             >
                                 Publish new release
-                            </Link>
+                            </Button>
                             <RegistryExtensionDeleteButton
                                 extension={this.props.extension.registryExtension}
                                 onDidUpdate={this.onDidDelete}

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardsPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardsPage.tsx
@@ -5,7 +5,7 @@ import { Redirect } from 'react-router-dom'
 
 import { Link } from '@sourcegraph/shared/src/components/Link'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { PageHeader } from '@sourcegraph/wildcard'
+import { PageHeader, Button } from '@sourcegraph/wildcard'
 
 import { Page } from '../../../../../components/Page'
 import { CodeInsightsIcon } from '../../../components'
@@ -53,16 +53,23 @@ export const DashboardsPage: React.FunctionComponent<DashboardsPageProps> = prop
                     path={[{ icon: CodeInsightsIcon }, { text: 'Insights' }]}
                     actions={
                         <>
-                            <Link to="/insights/add-dashboard" className="btn btn-outline-secondary mr-2">
+                            <Button
+                                to="/insights/add-dashboard"
+                                className="mr-2"
+                                variant="secondary"
+                                outline={true}
+                                as={Link}
+                            >
                                 <PlusIcon className="icon-inline" /> Create new dashboard
-                            </Link>
-                            <Link
+                            </Button>
+                            <Button
                                 to={`/insights/create?dashboardId=${dashboardID}`}
-                                className="btn btn-secondary"
                                 onClick={handleAddMoreInsightClick}
+                                variant="secondary"
+                                as={Link}
                             >
                                 <PlusIcon className="icon-inline" /> Create new insight
-                            </Link>
+                            </Button>
                         </>
                     }
                     className="mb-3"

--- a/client/web/src/enterprise/searchContexts/SearchContextPage.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextPage.tsx
@@ -18,7 +18,7 @@ import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 import { Page } from '@sourcegraph/web/src/components/Page'
 import { PageTitle } from '@sourcegraph/web/src/components/PageTitle'
 import { Timestamp } from '@sourcegraph/web/src/components/time/Timestamp'
-import { Badge, Container, PageHeader, LoadingSpinner } from '@sourcegraph/wildcard'
+import { Badge, Container, PageHeader, LoadingSpinner, Button } from '@sourcegraph/wildcard'
 
 import { SyntaxHighlightedSearchQuery } from '../../components/SyntaxHighlightedSearchQuery'
 import { SearchContextProps } from '../../search'
@@ -189,13 +189,14 @@ export const SearchContextPage: React.FunctionComponent<SearchContextPageProps> 
                                 ]}
                                 actions={
                                     searchContextOrError.viewerCanManage && (
-                                        <Link
+                                        <Button
                                             to={`/contexts/${searchContextOrError.spec}/edit`}
-                                            className="btn btn-secondary"
                                             data-testid="edit-search-context-link"
+                                            variant="secondary"
+                                            as={Link}
                                         >
                                             Edit
-                                        </Link>
+                                        </Button>
                                     )
                                 }
                             />

--- a/client/web/src/enterprise/searchContexts/SearchContextsListPage.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextsListPage.tsx
@@ -6,7 +6,7 @@ import React, { useCallback, useState } from 'react'
 
 import { Link } from '@sourcegraph/shared/src/components/Link'
 import { Page } from '@sourcegraph/web/src/components/Page'
-import { PageHeader } from '@sourcegraph/wildcard'
+import { PageHeader, Button } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { SearchContextProps } from '../../search'
@@ -76,10 +76,10 @@ export const SearchContextsListPage: React.FunctionComponent<SearchContextsListP
                         },
                     ]}
                     actions={
-                        <Link to="/contexts/new" className="btn btn-primary">
+                        <Button to="/contexts/new" variant="primary" as={Link}>
                             <PlusIcon className="icon-inline" />
                             Create search context
-                        </Link>
+                        </Button>
                     }
                     description={
                         <span className="text-muted">

--- a/client/web/src/enterprise/site-admin/SiteAdminExternalAccountsPage.tsx
+++ b/client/web/src/enterprise/site-admin/SiteAdminExternalAccountsPage.tsx
@@ -7,6 +7,7 @@ import { map } from 'rxjs/operators'
 import { createAggregateError } from '@sourcegraph/common'
 import { Scalars } from '@sourcegraph/shared/src/graphql-operations'
 import { gql } from '@sourcegraph/shared/src/graphql/graphql'
+import { Button } from '@sourcegraph/wildcard'
 
 import { requestGraphQL } from '../../backend/graphql'
 import { FilteredConnection } from '../../components/FilteredConnection'
@@ -59,9 +60,9 @@ export class SiteAdminExternalAccountsPage extends React.Component<Props> {
                 <PageTitle title="External accounts" />
                 <div className="d-flex justify-content-between align-items-center mb-3">
                     <h2 className="mb-0">External user accounts</h2>
-                    <Link to="/site-admin/auth/providers" className="btn btn-secondary">
+                    <Button to="/site-admin/auth/providers" variant="secondary" as={Link}>
                         View auth providers
-                    </Link>
+                    </Button>
                 </div>
                 <p>
                     An external account (on an <Link to="/site-admin/auth/providers">authentication provider</Link>) is

--- a/client/web/src/enterprise/site-admin/SiteAdminRegistryExtensionsPage.tsx
+++ b/client/web/src/enterprise/site-admin/SiteAdminRegistryExtensionsPage.tsx
@@ -95,13 +95,15 @@ class RegistryExtensionNodeSiteAdminRow extends React.PureComponent<
                     </div>
                     <div className="d-flex align-items-center">
                         {this.props.node.viewerCanAdminister && (
-                            <Link
+                            <Button
                                 to={`${this.props.node.url}/-/manage`}
-                                className="btn btn-secondary btn-sm"
                                 title="Manage extension"
+                                variant="secondary"
+                                size="sm"
+                                as={Link}
                             >
                                 Manage
-                            </Link>
+                            </Button>
                         )}
                         {!this.props.node.isLocal && this.props.node.remoteURL && this.props.node.registryName && (
                             <a
@@ -186,12 +188,12 @@ export class SiteAdminRegistryExtensionsPage extends React.PureComponent<Props> 
                 <div className="d-flex justify-content-between align-items-center mb-3">
                     <h2 className="mb-0">Registry extensions</h2>
                     <div>
-                        <Link className="btn btn-link mr-sm-2" to="/extensions">
+                        <Button className="mr-sm-2" to="/extensions" variant="link" as={Link}>
                             View extensions
-                        </Link>
-                        <Link className="btn btn-primary" to="/extensions/registry/new">
+                        </Button>
+                        <Button to="/extensions/registry/new" variant="primary" as={Link}>
                             <AddIcon className="icon-inline" /> Publish new extension
-                        </Link>
+                        </Button>
                     </div>
                 </div>
                 <p>

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
@@ -134,9 +134,9 @@ export const SiteAdminProductSubscriptionPage: React.FunctionComponent<Props> = 
         <div className="site-admin-product-subscription-page">
             <PageTitle title="Product subscription" />
             <div className="mb-2">
-                <Link to="/site-admin/dotcom/product/subscriptions" className="btn btn-link btn-sm">
+                <Button to="/site-admin/dotcom/product/subscriptions" variant="link" size="sm" as={Link}>
                     <ArrowLeftIcon className="icon-inline" /> All subscriptions
-                </Link>
+                </Button>
             </div>
             {productSubscription === LOADING ? (
                 <LoadingSpinner />

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionsPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionsPage.tsx
@@ -7,6 +7,7 @@ import { map } from 'rxjs/operators'
 
 import { dataOrThrowErrors, gql } from '@sourcegraph/shared/src/graphql/graphql'
 import * as GQL from '@sourcegraph/shared/src/graphql/schema'
+import { Button } from '@sourcegraph/wildcard'
 
 import { queryGraphQL } from '../../../../backend/graphql'
 import { FilteredConnection } from '../../../../components/FilteredConnection'
@@ -37,10 +38,10 @@ export const SiteAdminProductSubscriptionsPage: React.FunctionComponent<Props> =
             <PageTitle title="Product subscriptions" />
             <div className="d-flex justify-content-between align-items-center mb-3">
                 <h2 className="mb-0">Product subscriptions</h2>
-                <Link to="/site-admin/dotcom/product/subscriptions/new" className="btn btn-primary">
+                <Button to="/site-admin/dotcom/product/subscriptions/new" variant="primary" as={Link}>
                     <AddIcon className="icon-inline" />
                     Create product subscription
-                </Link>
+                </Button>
             </div>
             <FilteredSiteAdminProductSubscriptionConnection
                 className="mt-3"

--- a/client/web/src/enterprise/user/productSubscriptions/BackToAllSubscriptionsLink.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/BackToAllSubscriptionsLink.tsx
@@ -3,11 +3,12 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 
 import * as GQL from '@sourcegraph/shared/src/graphql/schema'
+import { Button } from '@sourcegraph/wildcard'
 
 export const BackToAllSubscriptionsLink: React.FunctionComponent<{ user: Pick<GQL.IUser, 'settingsURL'> }> = ({
     user,
 }) => (
-    <Link to={`${user.settingsURL!}/subscriptions`} className="btn btn-link btn-sm mb-3">
+    <Button to={`${user.settingsURL!}/subscriptions`} className="mb-3" variant="link" size="sm" as={Link}>
         <ArrowLeftIcon className="icon-inline" /> All subscriptions
-    </Link>
+    </Button>
 )

--- a/client/web/src/enterprise/user/productSubscriptions/ProductSubscriptionBilling.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/ProductSubscriptionBilling.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 
 import * as GQL from '@sourcegraph/shared/src/graphql/schema'
+import { Button } from '@sourcegraph/wildcard'
 
 import { ProductSubscriptionLabel } from '../../dotcom/productSubscriptions/ProductSubscriptionLabel'
 
@@ -14,9 +15,9 @@ export const ProductSubscriptionBilling: React.FunctionComponent<{
                 <th className="text-nowrap align-middle">Plan</th>
                 <td className="w-100 d-flex align-items-center justify-content-between">
                     <ProductSubscriptionLabel productSubscription={productSubscription} planField="name" />
-                    <Link to={`${productSubscription.url}/edit`} className="btn btn-secondary btn-sm">
+                    <Button to={`${productSubscription.url}/edit`} variant="secondary" size="sm" as={Link}>
                         Change plan or add/remove users
-                    </Link>
+                    </Button>
                 </td>
             </tr>
         </tbody>

--- a/client/web/src/enterprise/user/productSubscriptions/ProductSubscriptionForm.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/ProductSubscriptionForm.tsx
@@ -103,7 +103,6 @@ const _ProductSubscriptionForm: React.FunctionComponent<Props & ReactStripeEleme
     afterPrimaryButton,
     isLightTheme,
     stripe,
-    history,
 }) => {
     if (!stripe) {
         throw new Error('billing service is not available')
@@ -221,16 +220,19 @@ const _ProductSubscriptionForm: React.FunctionComponent<Props & ReactStripeEleme
                         />
                         {!accountID && (
                             <div className="form-group mt-3">
-                                <Link
+                                <Button
                                     to={`/sign-up?returnTo=${encodeURIComponent(
                                         `/subscriptions/new${productSubscriptionInputForLocationHash(
                                             productSubscriptionInput
                                         )}`
                                     )}`}
-                                    className="btn btn-lg btn-primary w-100 center"
+                                    className="w-100 center"
+                                    variant="primary"
+                                    size="lg"
+                                    as={Link}
                                 >
                                     Create account or sign in to continue
-                                </Link>
+                                </Button>
                                 <small className="form-text text-muted">
                                     A user account on Sourcegraph.com is required to create a subscription so you can
                                     view the license key and invoice.

--- a/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsEditProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsEditProductSubscriptionPage.tsx
@@ -11,7 +11,7 @@ import { gql } from '@sourcegraph/shared/src/graphql/graphql'
 import * as GQL from '@sourcegraph/shared/src/graphql/schema'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { useEventObservable, useObservable } from '@sourcegraph/shared/src/util/useObservable'
-import { LoadingSpinner } from '@sourcegraph/wildcard'
+import { LoadingSpinner, Button } from '@sourcegraph/wildcard'
 
 import { mutateGraphQL, queryGraphQL } from '../../../backend/graphql'
 import { ErrorAlert } from '../../../components/alerts'
@@ -105,9 +105,9 @@ export const UserSubscriptionsEditProductSubscriptionPage: React.FunctionCompone
                 <ErrorAlert className="my-2" error={productSubscription} />
             ) : (
                 <>
-                    <Link to={productSubscription.url} className="btn btn-link btn-sm mb-3">
+                    <Button to={productSubscription.url} className="mb-3" variant="link" size="sm" as={Link}>
                         <ArrowLeftIcon className="icon-inline" /> Subscription
-                    </Link>
+                    </Button>
                     <h2>Upgrade or change subscription {productSubscription.name}</h2>
                     <ProductSubscriptionForm
                         accountID={user.id}

--- a/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionsPage.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionsPage.tsx
@@ -7,7 +7,7 @@ import { map } from 'rxjs/operators'
 import { createAggregateError } from '@sourcegraph/common'
 import { gql } from '@sourcegraph/shared/src/graphql/graphql'
 import * as GQL from '@sourcegraph/shared/src/graphql/schema'
-import { Container, PageHeader } from '@sourcegraph/wildcard'
+import { Container, PageHeader, Button } from '@sourcegraph/wildcard'
 
 import { queryGraphQL } from '../../../backend/graphql'
 import { FilteredConnection } from '../../../components/FilteredConnection'
@@ -81,9 +81,9 @@ export const UserSubscriptionsProductSubscriptionsPage: React.FunctionComponent<
                 headingElement="h2"
                 path={[{ text: 'Subscriptions' }]}
                 actions={
-                    <Link to={`${props.match.path}/new`} className="btn btn-primary text-nowrap">
+                    <Button to={`${props.match.path}/new`} className="text-nowrap" variant="primary" as={Link}>
                         New subscription
-                    </Link>
+                    </Button>
                 }
                 description={
                     <>

--- a/client/web/src/enterprise/user/productSubscriptions/__snapshots__/ProductSubscriptionForm.test.tsx.snap
+++ b/client/web/src/enterprise/user/productSubscriptions/__snapshots__/ProductSubscriptionForm.test.tsx.snap
@@ -168,7 +168,7 @@ exports[`ProductSubscriptionForm new subscription for anonymous viewer (no accou
             class="form-group mt-3"
           >
             <a
-              class="btn btn-lg btn-primary w-100 center"
+              class="btn btn-primary btn-lg w-100 center"
               href="/sign-up?returnTo=%2Fsubscriptions%2Fnew"
             >
               Create account or sign in to continue

--- a/client/web/src/extensions/ExtensionsAreaHeader.tsx
+++ b/client/web/src/extensions/ExtensionsAreaHeader.tsx
@@ -2,7 +2,7 @@ import PuzzleOutlineIcon from 'mdi-react/PuzzleOutlineIcon'
 import * as React from 'react'
 import { Link, RouteComponentProps } from 'react-router-dom'
 
-import { PageHeader } from '@sourcegraph/wildcard'
+import { PageHeader, Button } from '@sourcegraph/wildcard'
 
 import { ActionButtonDescriptor } from '../util/contributions'
 
@@ -30,9 +30,16 @@ export const ExtensionsAreaHeader: React.FunctionComponent<ExtensionsAreaHeaderP
                 actions={props.actionButtons.map(
                     ({ condition = () => true, to, icon: Icon, label, tooltip }) =>
                         condition(props) && (
-                            <Link className="btn ml-2 btn-secondary" to={to(props)} data-tooltip={tooltip} key={label}>
+                            <Button
+                                className="ml-2"
+                                to={to(props)}
+                                data-tooltip={tooltip}
+                                key={label}
+                                variant="secondary"
+                                as={Link}
+                            >
                                 {Icon && <Icon className="icon-inline" />} {label}
-                            </Link>
+                            </Button>
                         )
                 )}
             />

--- a/client/web/src/extensions/extension/RegistryExtensionManifestPage.tsx
+++ b/client/web/src/extensions/extension/RegistryExtensionManifestPage.tsx
@@ -25,9 +25,14 @@ export const ExtensionNoManifestAlert: React.FunctionComponent<{
         {extension.registryExtension?.viewerCanAdminister && (
             <>
                 <br />
-                <Link className="mt-3 btn btn-primary" to={`${extension.registryExtension.url}/-/releases/new`}>
+                <Button
+                    className="mt-3"
+                    to={`${extension.registryExtension.url}/-/releases/new`}
+                    variant="primary"
+                    as={Link}
+                >
                     Publish first release of extension
-                </Link>
+                </Button>
             </>
         )}
     </div>
@@ -84,12 +89,13 @@ export class RegistryExtensionManifestPage extends React.PureComponent<Props, St
                             </Button>
                         )}{' '}
                         {this.props.extension.registryExtension?.viewerCanAdminister && (
-                            <Link
-                                className="btn btn-primary"
+                            <Button
                                 to={`${this.props.extension.registryExtension.url}/-/releases/new`}
+                                variant="primary"
+                                as={Link}
                             >
                                 Publish new release
-                            </Link>
+                            </Button>
                         )}
                     </div>
                 </div>

--- a/client/web/src/extensions/extension/RegistryExtensionOverviewPage.tsx
+++ b/client/web/src/extensions/extension/RegistryExtensionOverviewPage.tsx
@@ -10,6 +10,7 @@ import { isErrorLike, isDefined } from '@sourcegraph/common'
 import { splitExtensionID } from '@sourcegraph/shared/src/extensions/extension'
 import { ExtensionCategory, ExtensionManifest } from '@sourcegraph/shared/src/schema/extensionSchema'
 import { isEncodedImage } from '@sourcegraph/shared/src/util/icon'
+import { Button } from '@sourcegraph/wildcard'
 
 import { PageTitle } from '../../components/PageTitle'
 import { Timestamp } from '../../components/time/Timestamp'
@@ -181,12 +182,15 @@ export const RegistryExtensionOverviewPage: React.FunctionComponent<Props> = ({
                         <ul className="list-inline" data-testid="test-registry-extension-categories">
                             {categories.map(category => (
                                 <li key={category} className="list-inline-item mb-2">
-                                    <Link
+                                    <Button
                                         to={urlToExtensionsQuery({ category })}
-                                        className="btn btn-outline-secondary btn-sm"
+                                        variant="secondary"
+                                        outline={true}
+                                        size="sm"
+                                        as={Link}
                                     >
                                         {category}
-                                    </Link>
+                                    </Button>
                                 </li>
                             ))}
                         </ul>
@@ -202,12 +206,16 @@ export const RegistryExtensionOverviewPage: React.FunctionComponent<Props> = ({
                             <ul className="list-inline">
                                 {extension.manifest.tags.map(tag => (
                                     <li key={tag} className="list-inline-item mb-2">
-                                        <Link
+                                        <Button
                                             to={urlToExtensionsQuery({ query: extensionsQuery({ tag }) })}
-                                            className={classNames('btn btn-outline-secondary btn-sm', styles.tag)}
+                                            className={styles.tag}
+                                            variant="secondary"
+                                            outline={true}
+                                            size="sm"
+                                            as={Link}
                                         >
                                             {tag}
-                                        </Link>
+                                        </Button>
                                     </li>
                                 ))}
                             </ul>

--- a/client/web/src/extensions/extension/RegistryExtensionReadme.tsx
+++ b/client/web/src/extensions/extension/RegistryExtensionReadme.tsx
@@ -6,6 +6,7 @@ import { isErrorLike } from '@sourcegraph/common'
 import { Markdown } from '@sourcegraph/shared/src/components/Markdown'
 import { ConfiguredRegistryExtension } from '@sourcegraph/shared/src/extensions/extension'
 import { renderMarkdown } from '@sourcegraph/shared/src/util/markdown'
+import { Button } from '@sourcegraph/wildcard'
 
 import { ExtensionNoManifestAlert } from './RegistryExtensionManifestPage'
 
@@ -20,9 +21,14 @@ const PublishNewManifestAlert: React.FunctionComponent<{
         {extension.registryExtension?.viewerCanAdminister && (
             <>
                 <br />
-                <Link className="mt-3 btn btn-primary" to={`${extension.registryExtension.url}/-/releases/new`}>
+                <Button
+                    className="mt-3"
+                    to={`${extension.registryExtension.url}/-/releases/new`}
+                    variant="primary"
+                    as={Link}
+                >
                     {buttonLabel}
-                </Link>
+                </Button>
             </>
         )}
     </div>

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -20,7 +20,7 @@ import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
-import { ProductStatusBadge } from '@sourcegraph/wildcard'
+import { ProductStatusBadge, Button } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'
 import { BatchChangesProps } from '../batches'
@@ -291,12 +291,19 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
                         <>
                             <NavAction>
                                 <div>
-                                    <Link className="btn btn-sm btn-outline-secondary mr-1" to="/sign-in">
+                                    <Button
+                                        className="mr-1"
+                                        to="/sign-in"
+                                        variant="secondary"
+                                        outline={true}
+                                        size="sm"
+                                        as={Link}
+                                    >
                                         Log in
-                                    </Link>
-                                    <Link className={classNames('btn btn-sm', styles.signUp)} to="/sign-up">
+                                    </Button>
+                                    <Button className={styles.signUp} to="/sign-up" size="sm" as={Link}>
                                         Sign up
-                                    </Link>
+                                    </Button>
                                 </div>
                             </NavAction>
                         </>

--- a/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
@@ -235,7 +235,7 @@ exports[`GlobalNavbar default 1`] = `
       >
         <div>
           <a
-            class="btn btn-sm btn-outline-secondary mr-1"
+            class="btn btn-outline-secondary btn-sm mr-1"
             to="/sign-in"
           >
             Log in
@@ -510,7 +510,7 @@ exports[`GlobalNavbar low-profile 1`] = `
       >
         <div>
           <a
-            class="btn btn-sm btn-outline-secondary mr-1"
+            class="btn btn-outline-secondary btn-sm mr-1"
             to="/sign-in"
           >
             Log in

--- a/client/web/src/onboarding-tour/OnboardingTour.tsx
+++ b/client/web/src/onboarding-tour/OnboardingTour.tsx
@@ -176,9 +176,15 @@ export const OnboardingTourContent: React.FunctionComponent<OnboardingTourConten
                     features on your private code.
                 </p>
                 <div className="d-flex flex-column">
-                    <Link className="btn btn-primary align-self-start mb-2" to="/sign-up" onClick={onSignUp}>
+                    <Button
+                        className="align-self-start mb-2"
+                        to="/sign-up"
+                        onClick={onSignUp}
+                        variant="primary"
+                        as={Link}
+                    >
                         Sign up for Cloud
-                    </Link>
+                    </Button>
                     <a
                         className="btn btn-link shadow-none align-self-start pl-0 mb-2"
                         href="https://docs.sourcegraph.com/admin/install?utm_campaign=inproduct-tour&utm_medium=direct_traffic&utm_source=inproduct-tour&utm_term=null&utm_content=complete"

--- a/client/web/src/org/area/OrgHeader.tsx
+++ b/client/web/src/org/area/OrgHeader.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Link, NavLink, RouteComponentProps } from 'react-router-dom'
 
-import { PageHeader } from '@sourcegraph/wildcard'
+import { PageHeader, Button } from '@sourcegraph/wildcard'
 
 import { BatchChangesProps } from '../../batches'
 import { NavItemWithIconDescriptor } from '../../util/contributions'
@@ -90,9 +90,14 @@ export const OrgHeader: React.FunctionComponent<Props> = ({
                         {org.viewerPendingInvitation?.respondURL && (
                             <div className="pb-1">
                                 <small className="mr-2">Join organization:</small>
-                                <Link to={org.viewerPendingInvitation.respondURL} className="btn btn-success btn-sm">
+                                <Button
+                                    to={org.viewerPendingInvitation.respondURL}
+                                    variant="success"
+                                    size="sm"
+                                    as={Link}
+                                >
                                     View invitation
-                                </Link>
+                                </Button>
                             </div>
                         )}
                     </div>

--- a/client/web/src/org/area/OrgInvitationPage.tsx
+++ b/client/web/src/org/area/OrgInvitationPage.tsx
@@ -151,9 +151,9 @@ export const OrgInvitationPage = withAuthenticatedUser(
                                     >
                                         Join {this.props.org.name}
                                     </Button>
-                                    <Link className="btn btn-link" to={orgURL(this.props.org.name)}>
+                                    <Button to={orgURL(this.props.org.name)} variant="link" as={Link}>
                                         Go to {this.props.org.name}'s profile
-                                    </Link>
+                                    </Button>
                                 </div>
                                 <div>
                                     <Button

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -234,16 +234,20 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
                 element: (
                     <>
                         <div className="d-inline-flex btn-group">
-                            <Link
+                            <Button
                                 to={
                                     resolvedRevisionOrError && !isErrorLike(resolvedRevisionOrError)
                                         ? resolvedRevisionOrError.rootTreeURL
                                         : repoOrError.url
                                 }
-                                className="btn btn-sm btn-outline-secondary text-nowrap test-repo-header-repo-link"
+                                className="text-nowrap test-repo-header-repo-link"
+                                variant="secondary"
+                                outline={true}
+                                size="sm"
+                                as={Link}
                             >
                                 <SourceRepositoryIcon className="icon-inline" /> {displayRepoName(repoOrError.name)}
-                            </Link>
+                            </Button>
                             <Button
                                 id="repo-popover"
                                 className={styles.repoChange}

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -188,14 +188,18 @@ export const GitCommitNode: React.FunctionComponent<GitCommitNodeProps> = ({
 
     const viewFilesCommitElement = node.tree && (
         <div className="d-flex justify-content-between">
-            <Link
-                className="btn btn-sm btn-outline-secondary align-center d-inline-flex"
+            <Button
+                className="align-center d-inline-flex"
                 to={node.tree.canonicalURL}
                 data-tooltip="Browse files in the repository at this point in history"
+                variant="secondary"
+                outline={true}
+                size="sm"
+                as={Link}
             >
                 <FileDocumentIcon className="icon-inline mr-1" />
                 Browse files at @{node.abbreviatedOID}
-            </Link>
+            </Button>
             {diffModeSelector()}
         </div>
     )
@@ -219,13 +223,14 @@ export const GitCommitNode: React.FunctionComponent<GitCommitNodeProps> = ({
                                 {!showSHAAndParentsRow && (
                                     <div>
                                         <div className="btn-group btn-group-sm mr-2" role="group">
-                                            <Link
-                                                className="btn btn-secondary"
+                                            <Button
                                                 to={node.canonicalURL}
                                                 data-tooltip="View this commit"
+                                                variant="secondary"
+                                                as={Link}
                                             >
                                                 <strong>{oidElement}</strong>
-                                            </Link>
+                                            </Button>
                                             <Button
                                                 onClick={() => copyToClipboard(node.oid)}
                                                 data-tooltip={
@@ -237,13 +242,15 @@ export const GitCommitNode: React.FunctionComponent<GitCommitNodeProps> = ({
                                             </Button>
                                         </div>
                                         {node.tree && (
-                                            <Link
-                                                className="btn btn-sm btn-secondary"
+                                            <Button
                                                 to={node.tree.canonicalURL}
                                                 data-tooltip="View files at this commit"
+                                                variant="secondary"
+                                                size="sm"
+                                                as={Link}
                                             >
                                                 <FileDocumentIcon className="icon-inline mr-1" />
-                                            </Link>
+                                            </Button>
                                         )}
                                     </div>
                                 )}

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -349,30 +349,40 @@ export const TreePage: React.FunctionComponent<Props> = ({
                                     {repo.description && <p>{repo.description}</p>}
                                     <div className="btn-group">
                                         {enableAPIDocs && (
-                                            <Link
-                                                className="btn btn-outline-secondary"
+                                            <Button
                                                 to={`${treeOrError.url}/-/docs`}
+                                                variant="secondary"
+                                                outline={true}
+                                                as={Link}
                                             >
                                                 <BookOpenBlankVariantIcon className="icon-inline" /> API docs
-                                            </Link>
+                                            </Button>
                                         )}
-                                        <Link className="btn btn-outline-secondary" to={`${treeOrError.url}/-/commits`}>
+                                        <Button
+                                            to={`${treeOrError.url}/-/commits`}
+                                            variant="secondary"
+                                            outline={true}
+                                            as={Link}
+                                        >
                                             <SourceCommitIcon className="icon-inline" /> Commits
-                                        </Link>
-                                        <Link
-                                            className="btn btn-outline-secondary"
+                                        </Button>
+                                        <Button
                                             to={`/${encodeURIPathComponent(repo.name)}/-/branches`}
+                                            variant="secondary"
+                                            outline={true}
+                                            as={Link}
                                         >
                                             <SourceBranchIcon className="icon-inline" /> Branches
-                                        </Link>
-                                        <Link
-                                            className="btn btn-outline-secondary"
+                                        </Button>
+                                        <Button
                                             to={`/${encodeURIPathComponent(repo.name)}/-/tags`}
+                                            variant="secondary"
+                                            outline={true}
+                                            as={Link}
                                         >
                                             <TagIcon className="icon-inline" /> Tags
-                                        </Link>
-                                        <Link
-                                            className="btn btn-outline-secondary"
+                                        </Button>
+                                        <Button
                                             to={
                                                 revision
                                                     ? `/${encodeURIPathComponent(
@@ -380,31 +390,40 @@ export const TreePage: React.FunctionComponent<Props> = ({
                                                       )}/-/compare/...${encodeURIComponent(revision)}`
                                                     : `/${encodeURIPathComponent(repo.name)}/-/compare`
                                             }
+                                            variant="secondary"
+                                            outline={true}
+                                            as={Link}
                                         >
                                             <HistoryIcon className="icon-inline" /> Compare
-                                        </Link>
-                                        <Link
-                                            className="btn btn-outline-secondary"
+                                        </Button>
+                                        <Button
                                             to={`/${encodeURIPathComponent(repo.name)}/-/stats/contributors`}
+                                            variant="secondary"
+                                            outline={true}
+                                            as={Link}
                                         >
                                             <AccountIcon className="icon-inline" /> Contributors
-                                        </Link>
+                                        </Button>
                                         {codeIntelligenceEnabled && (
-                                            <Link
-                                                className="btn btn-outline-secondary"
+                                            <Button
                                                 to={`/${encodeURIPathComponent(repo.name)}/-/code-intelligence`}
+                                                variant="secondary"
+                                                outline={true}
+                                                as={Link}
                                             >
                                                 <BrainIcon className="icon-inline" /> Code Intelligence
-                                            </Link>
+                                            </Button>
                                         )}
                                         {batchChangesEnabled && <RepoBatchChangesButton repoName={repo.name} />}
                                         {repo.viewerCanAdminister && (
-                                            <Link
-                                                className="btn btn-outline-secondary"
+                                            <Button
                                                 to={`/${encodeURIPathComponent(repo.name)}/-/settings`}
+                                                variant="secondary"
+                                                outline={true}
+                                                as={Link}
                                             >
                                                 <SettingsIcon className="icon-inline" /> Settings
-                                            </Link>
+                                            </Button>
                                         )}
                                     </div>
                                 </>

--- a/client/web/src/savedSearches/SavedSearchForm.tsx
+++ b/client/web/src/savedSearches/SavedSearchForm.tsx
@@ -150,9 +150,9 @@ export const SavedSearchForm: React.FunctionComponent<SavedSearchFormProps> = pr
                                     <strong>New:</strong> Watch your code for changes with code monitoring to get
                                     notifications.
                                 </div>
-                                <Link to={codeMonitoringUrl} className="btn btn-primary">
+                                <Button to={codeMonitoringUrl} variant="primary" as={Link}>
                                     Go to code monitoring →
-                                </Link>
+                                </Button>
                             </div>
                         </div>
                     )}

--- a/client/web/src/savedSearches/SavedSearchListPage.tsx
+++ b/client/web/src/savedSearches/SavedSearchListPage.tsx
@@ -79,13 +79,16 @@ class SavedSearchNode extends React.PureComponent<NodeProps, NodeState> {
                     </Link>
                 </div>
                 <div>
-                    <Link
-                        className="btn btn-secondary btn-sm test-edit-saved-search-button"
+                    <Button
+                        className="test-edit-saved-search-button"
                         to={`${this.props.match.path}/${this.props.savedSearch.id}`}
                         data-tooltip="Saved search settings"
+                        variant="secondary"
+                        size="sm"
+                        as={Link}
                     >
                         <SettingsIcon className="icon-inline" /> Settings
-                    </Link>{' '}
+                    </Button>{' '}
                     <Button
                         className="test-delete-saved-search-button"
                         onClick={this.onDelete}
@@ -143,12 +146,14 @@ export class SavedSearchListPage extends React.Component<Props, State> {
                     headingElement="h2"
                     description="Manage notifications and alerts for specific search queries."
                     actions={
-                        <Link
+                        <Button
                             to={`${this.props.match.path}/add`}
-                            className="btn btn-primary test-add-saved-search-button"
+                            className="test-add-saved-search-button"
+                            variant="primary"
+                            as={Link}
                         >
                             <PlusIcon className="icon-inline" /> Add saved search
-                        </Link>
+                        </Button>
                     }
                     className="mb-3"
                 />

--- a/client/web/src/search/input/SearchContextCtaPrompt.tsx
+++ b/client/web/src/search/input/SearchContextCtaPrompt.tsx
@@ -61,13 +61,16 @@ export const SearchContextCtaPrompt: React.FunctionComponent<SearchContextCtaPro
             </div>
             <div className="text-muted">{copyText}</div>
 
-            <Link
-                className={classNames('btn btn-primary btn-sm', styles.searchContextCtaPromptButton)}
+            <Button
+                className={styles.searchContextCtaPromptButton}
                 to={linkTo}
                 onClick={onClick}
+                variant="primary"
+                size="sm"
+                as={Link}
             >
                 {buttonText}
-            </Link>
+            </Button>
             <Button
                 className={classNames('border-0 ml-2', styles.searchContextCtaPromptButton)}
                 onClick={onDismissClick}

--- a/client/web/src/search/input/SearchContextMenu.tsx
+++ b/client/web/src/search/input/SearchContextMenu.tsx
@@ -337,13 +337,16 @@ export const SearchContextMenu: React.FunctionComponent<SearchContextMenuProps> 
                 </Button>
                 <span className="flex-grow-1" />
                 {showSearchContextManagement && (
-                    <Link
+                    <Button
                         to="/contexts"
-                        className={classNames('btn btn-link btn-sm', styles.footerButton)}
+                        className={styles.footerButton}
                         onClick={() => closeMenu()}
+                        variant="link"
+                        size="sm"
+                        as={Link}
                     >
                         Manage contexts
-                    </Link>
+                    </Button>
                 )}
             </div>
         </div>

--- a/client/web/src/search/panels/SavedSearchesPanel.tsx
+++ b/client/web/src/search/panels/SavedSearchesPanel.tsx
@@ -55,14 +55,16 @@ export const SavedSearchesPanel: React.FunctionComponent<Props> = ({
                 Use saved searches to alert you to uses of a favorite API, or changes to code you need to monitor.
             </small>
             {authenticatedUser && (
-                <Link
+                <Button
                     to={`/users/${authenticatedUser.username}/searches/add`}
                     onClick={logEvent('SavedSearchesPanelCreateButtonClicked', { source: 'empty view' })}
-                    className="btn btn-secondary mt-2 align-self-center"
+                    className="mt-2 align-self-center"
+                    variant="secondary"
+                    as={Link}
                 >
                     <PlusIcon className="icon-inline" />
                     Create a saved search
-                </Link>
+                </Button>
             )}
         </EmptyPanelContainer>
     )
@@ -129,13 +131,16 @@ export const SavedSearchesPanel: React.FunctionComponent<Props> = ({
         <ActionButtonGroup>
             <div className="btn-group btn-group-sm">
                 {authenticatedUser && (
-                    <Link
+                    <Button
                         to={`/users/${authenticatedUser.username}/searches/add`}
-                        className="btn btn-outline-secondary mr-2"
+                        className="mr-2"
                         onClick={logEvent('SavedSearchesPanelCreateButtonClicked', { source: 'toolbar' })}
+                        variant="secondary"
+                        outline={true}
+                        as={Link}
                     >
                         +
-                    </Link>
+                    </Button>
                 )}
             </div>
             <div className="btn-group btn-group-sm">

--- a/client/web/src/search/results/ButtonDropdownCta.tsx
+++ b/client/web/src/search/results/ButtonDropdownCta.tsx
@@ -4,6 +4,7 @@ import { ButtonDropdown, DropdownMenu, DropdownToggle } from 'reactstrap'
 
 import { Link } from '@sourcegraph/shared/src/components/Link'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { Button } from '@sourcegraph/wildcard'
 
 import { CloudSignUpSource } from '../../auth/CloudSignUpPage'
 
@@ -77,13 +78,14 @@ export const ButtonDropdownCta: React.FunctionComponent<ButtonDropdownCtaProps> 
                         <div className={classNames('text-muted', styles.copyText)}>{copyText}</div>
                     </div>
                 </div>
-                <Link
-                    className="btn btn-primary"
+                <Button
                     to={`/sign-up?src=${source}&returnTo=${encodeURIComponent(returnTo)}`}
                     onClick={onClick}
+                    variant="primary"
+                    as={Link}
                 >
                     Sign up for Sourcegraph
-                </Link>
+                </Button>
             </DropdownMenu>
         </ButtonDropdown>
     )

--- a/client/web/src/search/results/SearchAlert.tsx
+++ b/client/web/src/search/results/SearchAlert.tsx
@@ -5,6 +5,7 @@ import { Markdown } from '@sourcegraph/shared/src/components/Markdown'
 import { AggregateStreamingSearchResults } from '@sourcegraph/shared/src/search/stream'
 import { renderMarkdown } from '@sourcegraph/shared/src/util/markdown'
 import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
+import { Button } from '@sourcegraph/wildcard'
 
 import { SearchPatternType } from '../../graphql-operations'
 
@@ -38,8 +39,7 @@ export const SearchAlert: React.FunctionComponent<SearchAlertProps> = ({
                 <ul className="list-unstyled">
                     {alert.proposedQueries.map(proposedQuery => (
                         <li key={proposedQuery.query}>
-                            <Link
-                                className="btn btn-secondary btn-sm"
+                            <Button
                                 data-testid="proposed-query-link"
                                 to={
                                     '/search?' +
@@ -50,9 +50,12 @@ export const SearchAlert: React.FunctionComponent<SearchAlertProps> = ({
                                         searchContextSpec
                                     )
                                 }
+                                variant="secondary"
+                                size="sm"
+                                as={Link}
                             >
                                 {proposedQuery.query || proposedQuery.description}
-                            </Link>
+                            </Button>
                             {proposedQuery.query && proposedQuery.description && ` — ${proposedQuery.description}`}
                         </li>
                     ))}

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -16,6 +16,7 @@ import { StreamSearchOptions } from '@sourcegraph/shared/src/search/stream'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
+import { Button } from '@sourcegraph/wildcard'
 
 import { SearchStreamingProps, ParsedSearchQueryProps, SearchContextProps } from '..'
 import { AuthenticatedUser } from '../../auth'
@@ -315,13 +316,14 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
                                 searches and more.
                             </div>
                         </div>
-                        <Link
-                            className="btn btn-primary"
+                        <Button
                             to={`/sign-up?src=SearchCTA&returnTo=${encodeURIComponent('/user/settings/repositories')}`}
                             onClick={onSignUpClick}
+                            variant="primary"
+                            as={Link}
                         >
                             Create a free account
-                        </Link>
+                        </Button>
                     </div>
                 )}
 

--- a/client/web/src/site-admin/SiteAdminAllUsersPage.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage.tsx
@@ -146,12 +146,14 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
                             </>
                         )}
                         {!window.context.sourcegraphDotComMode && (
-                                <Link
-                                    className="btn btn-sm btn-secondary"
+                                <Button
                                     to={`${userURL(this.props.node.username)}/settings`}
+                                    variant="secondary"
+                                    size="sm"
+                                    as={Link}
                                 >
                                     <SettingsIcon className="icon-inline" /> Settings
-                                </Link>
+                                </Button>
                             ) &&
                             ' '}
                         {this.props.node.id !== this.props.authenticatedUser.id && (
@@ -415,9 +417,9 @@ export class SiteAdminAllUsersPage extends React.Component<Props, State> {
                 <div className="d-flex justify-content-between align-items-center mb-3">
                     <h2 className="mb-0">Users</h2>
                     <div>
-                        <Link to="/site-admin/users/new" className="btn btn-primary">
+                        <Button to="/site-admin/users/new" variant="primary" as={Link}>
                             <AddIcon className="icon-inline" /> Create user account
-                        </Link>
+                        </Button>
                     </div>
                 </div>
                 <FilteredConnection<GQL.IUser, Omit<UserNodeProps, 'node'>>

--- a/client/web/src/site-admin/SiteAdminOrgsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminOrgsPage.tsx
@@ -34,7 +34,7 @@ interface OrgNodeProps {
     history: H.History
 }
 
-const OrgNode: React.FunctionComponent<OrgNodeProps> = ({ node, history, onDidUpdate }) => {
+const OrgNode: React.FunctionComponent<OrgNodeProps> = ({ node, onDidUpdate }) => {
     const [loading, setLoading] = useState<boolean | Error>(false)
 
     const deleteOrg = useCallback(() => {
@@ -66,17 +66,21 @@ const OrgNode: React.FunctionComponent<OrgNodeProps> = ({ node, history, onDidUp
                     <span className="text-muted">{node.displayName}</span>
                 </div>
                 <div>
-                    <Link
+                    <Button
                         to={`${orgURL(node.name)}/settings`}
-                        className="btn btn-sm btn-secondary"
                         data-tooltip="Organization settings"
+                        variant="secondary"
+                        size="sm"
+                        as={Link}
                     >
                         <SettingsIcon className="icon-inline" /> Settings
-                    </Link>{' '}
-                    <Link
+                    </Button>{' '}
+                    <Button
                         to={`${orgURL(node.name)}/settings/members`}
-                        className="btn btn-sm btn-secondary"
                         data-tooltip="Organization members"
+                        variant="secondary"
+                        size="sm"
+                        as={Link}
                     >
                         <AccountIcon className="icon-inline" />{' '}
                         {node.members && (
@@ -84,7 +88,7 @@ const OrgNode: React.FunctionComponent<OrgNodeProps> = ({ node, history, onDidUp
                                 {node.members.totalCount} {pluralize('member', node.members.totalCount)}
                             </>
                         )}
-                    </Link>{' '}
+                    </Button>{' '}
                     <Button
                         onClick={deleteOrg}
                         disabled={loading === true}
@@ -119,9 +123,9 @@ export const SiteAdminOrgsPage: React.FunctionComponent<Props> = ({ telemetrySer
             <PageTitle title="Organizations - Admin" />
             <div className="d-flex justify-content-between align-items-center mb-3">
                 <h2 className="mb-0">Organizations</h2>
-                <Link to="/organizations/new" className="btn btn-primary test-create-org-button">
+                <Button to="/organizations/new" className="test-create-org-button" variant="primary" as={Link}>
                     <AddIcon className="icon-inline" /> Create organization
-                </Link>
+                </Button>
             </div>
             <p>
                 An organization is a set of users with associated configuration. See{' '}
@@ -136,9 +140,9 @@ export const SiteAdminOrgsPage: React.FunctionComponent<Props> = ({ telemetrySer
                     <h3>Enable early access</h3>
                     <div className="d-flex justify-content-between align-items-center mb-3">
                         <p>Enable early access for organization code host connections and repositories on Cloud.</p>
-                        <Link to="./organizations/early-access-orgs-code" className="btn btn-outline-primary">
+                        <Button to="./organizations/early-access-orgs-code" variant="primary" outline={true} as={Link}>
                             Enable early access
-                        </Link>
+                        </Button>
                     </div>
                 </>
             ) : (

--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -8,7 +8,7 @@ import { Observable } from 'rxjs'
 
 import { RepoLink } from '@sourcegraph/shared/src/components/RepoLink'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { LoadingSpinner } from '@sourcegraph/wildcard'
+import { LoadingSpinner, Button } from '@sourcegraph/wildcard'
 
 import {
     FilteredConnection,
@@ -50,18 +50,20 @@ const RepositoryNode: React.FunctionComponent<RepositoryNodeProps> = ({ node }) 
             </div>
             <div className="repository-node__actions">
                 {!node.mirrorInfo.cloneInProgress && !node.mirrorInfo.cloned && (
-                    <Link className="btn btn-sm btn-secondary" to={node.url}>
+                    <Button to={node.url} variant="secondary" size="sm" as={Link}>
                         <CloudDownloadIcon className="icon-inline" /> Clone now
-                    </Link>
+                    </Button>
                 )}{' '}
                 {
-                    <Link
-                        className="btn btn-secondary btn-sm"
+                    <Button
                         to={`/${node.name}/-/settings`}
                         data-tooltip="Repository settings"
+                        variant="secondary"
+                        size="sm"
+                        as={Link}
                     >
                         <SettingsIcon className="icon-inline" /> Settings
-                    </Link>
+                    </Button>
                 }{' '}
             </div>
         </div>

--- a/client/web/src/site-admin/overview/SiteAdminOverviewPage.tsx
+++ b/client/web/src/site-admin/overview/SiteAdminOverviewPage.tsx
@@ -12,7 +12,7 @@ import * as GQL from '@sourcegraph/shared/src/graphql/schema'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { numberWithCommas, pluralize } from '@sourcegraph/shared/src/util/strings'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
-import { LoadingSpinner } from '@sourcegraph/wildcard'
+import { LoadingSpinner, Button } from '@sourcegraph/wildcard'
 
 import { queryGraphQL } from '../../backend/graphql'
 import { ErrorAlert } from '../../components/alerts'
@@ -262,13 +262,14 @@ export const SiteAdminOverviewPage: React.FunctionComponent<Props> = ({
                                                 <div className="site-admin-overview-page__detail-header">
                                                     <h2>Weekly unique users</h2>
                                                     <h3>
-                                                        <Link
+                                                        <Button
                                                             to="/site-admin/usage-statistics"
-                                                            className="btn btn-secondary"
+                                                            variant="secondary"
+                                                            as={Link}
                                                         >
                                                             View all usage statistics{' '}
                                                             <OpenInNewIcon className="icon-inline" />
-                                                        </Link>
+                                                        </Button>
                                                     </h3>
                                                 </div>
                                             }

--- a/client/web/src/user/settings/UserSettingsSidebar.tsx
+++ b/client/web/src/user/settings/UserSettingsSidebar.tsx
@@ -95,9 +95,9 @@ export const UserSettingsSidebar: React.FunctionComponent<UserSettingsSidebarPro
                             </SidebarNavItem>
                         ) : (
                             <div className={styles.newOrgBtnWrapper}>
-                                <Link to="/organizations/new" className="btn btn-outline-secondary btn-sm">
+                                <Button to="/organizations/new" variant="secondary" outline={true} size="sm" as={Link}>
                                     <AddIcon className="icon-inline" /> New organization
-                                </Link>
+                                </Button>
                             </div>
                         ))}
                 </SidebarGroup>

--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenPage.tsx
@@ -199,12 +199,14 @@ export const UserSettingsCreateAccessTokenPage: React.FunctionComponent<Props> =
                         {creationOrError === 'loading' ? <LoadingSpinner /> : <AddIcon className="icon-inline" />}{' '}
                         Generate token
                     </Button>
-                    <Link
-                        className="btn btn-secondary ml-2 test-create-access-token-cancel"
+                    <Button
+                        className="ml-2 test-create-access-token-cancel"
                         to={match.url.replace(/\/new$/, '')}
+                        variant="secondary"
+                        as={Link}
                     >
                         Cancel
-                    </Link>
+                    </Button>
                 </div>
             </Form>
 

--- a/client/web/src/user/settings/accessTokens/UserSettingsTokensPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsTokensPage.tsx
@@ -7,7 +7,7 @@ import { map } from 'rxjs/operators'
 
 import { dataOrThrowErrors, gql } from '@sourcegraph/shared/src/graphql/graphql'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Container, PageHeader } from '@sourcegraph/wildcard'
+import { Container, PageHeader, Button } from '@sourcegraph/wildcard'
 
 import { requestGraphQL } from '../../../backend/graphql'
 import { FilteredConnection } from '../../../components/FilteredConnection'
@@ -82,9 +82,9 @@ export const UserSettingsTokensPage: React.FunctionComponent<Props> = ({
                 path={[{ text: 'Access tokens' }]}
                 description="Access tokens may be used to access the Sourcegraph API."
                 actions={
-                    <Link className="btn btn-primary" to={`${match.url}/new`}>
+                    <Button to={`${match.url}/new`} variant="primary" as={Link}>
                         <AddIcon className="icon-inline" /> Generate new token
-                    </Link>
+                    </Button>
                 }
                 className="mb-3"
             />

--- a/client/web/src/user/settings/codeHosts/OrgUserNeedsCodeHost.tsx
+++ b/client/web/src/user/settings/codeHosts/OrgUserNeedsCodeHost.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 
-import { Container } from '@sourcegraph/wildcard'
+import { Container, Button } from '@sourcegraph/wildcard'
 
 import { useExternalServices } from '../../../auth/useExternalServices'
 import { ListExternalServiceFields } from '../../../graphql-operations'
@@ -41,9 +41,9 @@ export const OrgUserNeedsCodeHost: React.FunctionComponent<OrgUserNeedsCodeHost>
                     Connect with {missingString} to start searching across the {orgDisplayName} organization's private
                     repositories on Sourcegraph.
                 </p>
-                <Link className="btn btn-primary" to={`/users/${user.username}/settings/code-hosts`}>
+                <Button to={`/users/${user.username}/settings/code-hosts`} variant="primary" as={Link}>
                     Connect with {missingString}
-                </Link>
+                </Button>
             </Container>
         )
     }

--- a/client/web/src/user/settings/repositories/SettingsRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/SettingsRepositoriesPage.tsx
@@ -18,7 +18,7 @@ import {
 } from '@sourcegraph/web/src/components/FilteredConnection'
 import { PageTitle } from '@sourcegraph/web/src/components/PageTitle'
 import { SelfHostedCtaLink } from '@sourcegraph/web/src/components/SelfHostedCtaLink'
-import { Container, PageHeader, ProductStatusBadge, LoadingSpinner } from '@sourcegraph/wildcard'
+import { Container, PageHeader, ProductStatusBadge, LoadingSpinner, Button } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../../auth'
 import { requestGraphQL } from '../../../backend/graphql'
@@ -343,37 +343,41 @@ export const SettingsRepositoriesPage: React.FunctionComponent<Props> = ({
                 actions={
                     <span>
                         {hasRepos ? (
-                            <Link
-                                className="btn btn-primary"
+                            <Button
                                 to={`${routingPrefix}/repositories/manage`}
                                 onClick={logManageRepositoriesClick}
+                                variant="primary"
+                                as={Link}
                             >
                                 Manage repositories
-                            </Link>
+                            </Button>
                         ) : isUserOwner ? (
-                            <Link
-                                className="btn btn-primary"
+                            <Button
                                 to={`${routingPrefix}/repositories/manage`}
                                 onClick={logManageRepositoriesClick}
+                                variant="primary"
+                                as={Link}
                             >
                                 <AddIcon className="icon-inline" /> Add repositories
-                            </Link>
+                            </Button>
                         ) : externalServices && externalServices.length !== 0 ? (
-                            <Link
-                                className="btn btn-primary"
+                            <Button
                                 to={`${routingPrefix}/repositories/manage`}
                                 onClick={logManageRepositoriesClick}
+                                variant="primary"
+                                as={Link}
                             >
                                 <AddIcon className="icon-inline" /> Add repositories
-                            </Link>
+                            </Button>
                         ) : (
-                            <Link
-                                className="btn btn-primary"
+                            <Button
                                 to={`${routingPrefix}/code-hosts`}
                                 onClick={logManageRepositoriesClick}
+                                variant="primary"
+                                as={Link}
                             >
                                 <AddIcon className="icon-inline" /> Connect code hosts
-                            </Link>
+                            </Button>
                         )}
                     </span>
                 }

--- a/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
@@ -8,7 +8,7 @@ import { Form } from '@sourcegraph/branded/src/components/Form'
 import { asError, ErrorLike, isErrorLike } from '@sourcegraph/common'
 import { Link } from '@sourcegraph/shared/src/components/Link'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { ProductStatusBadge, Container, PageSelector, RadioButton, TextArea } from '@sourcegraph/wildcard'
+import { ProductStatusBadge, Container, PageSelector, RadioButton, TextArea, Button } from '@sourcegraph/wildcard'
 
 import { ALLOW_NAVIGATION, AwayPrompt } from '../../../components/AwayPrompt'
 import {
@@ -901,12 +901,14 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
                     disabled={fetchingRepos === 'loading' || !didRepoSelectionChange()}
                 />
 
-                <Link
-                    className="btn btn-secondary test-goto-add-external-service-page"
+                <Button
+                    className="test-goto-add-external-service-page"
                     to={`${routingPrefix}/repositories`}
+                    variant="secondary"
+                    as={Link}
                 >
                     Cancel
-                </Link>
+                </Button>
             </Form>
         </UserSettingReposContainer>
     )


### PR DESCRIPTION
## Context

Automated migration of the `<Link className="btn" />` element to [the `<Button />` Wildcard component](https://github.com/sourcegraph/sourcegraph/blob/main/client/wildcard/src/components/Button/Button.tsx) powered by the codemod created in [the this repo](https://github.com/sourcegraph/codemod). The codemod implementation is coming to the repo via a series of pull requests started [here](https://github.com/sourcegraph/codemod/pull/57). I will add the reference here once it's live.

### Notes

- Only `<Link />` was transformed in this PR. Other components and elements like `<a className="btn" />` will be codemodded in a follow-up PR.
- Classes `btn-icon`, `btn-block` will be addressed separately.

Part of https://github.com/sourcegraph/sourcegraph/issues/29318.
Related to https://github.com/sourcegraph/codemod/issues/31.