### PR TITLE
Code Insights: Remove `allowSiteSettingsEdits` checks

### DIFF
--- a/client/web/src/enterprise/insights/components/creation-ui-kit/visibility-picker/VisibilityPicker.tsx
+++ b/client/web/src/enterprise/insights/components/creation-ui-kit/visibility-picker/VisibilityPicker.tsx
@@ -36,6 +36,8 @@ export interface VisibilityPickerProps {
 
 /**
  * Shared component for visibility field for creation UI pages.
+ *
+ * @deprecated - it's used only for setting based API which is deprecated.
  */
 export const VisibilityPicker: React.FunctionComponent<VisibilityPickerProps> = props => {
     const { value, subjects, onChange, labelClassName } = props

--- a/client/web/src/enterprise/insights/pages/dashboards/creation/components/insights-dashboard-creation-content/InsightsDashboardCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/creation/components/insights-dashboard-creation-content/InsightsDashboardCreationContent.tsx
@@ -60,7 +60,6 @@ export const InsightsDashboardCreationContent: React.FunctionComponent<InsightsD
 
     // We always have global subject in our settings cascade
     const globalSubject = subjects.find(isGlobalSubject)
-    const canGlobalSubjectBeEdited = globalSubject?.allowSiteSettingsEdits && globalSubject?.viewerCanAdminister
 
     const { ref, handleSubmit, formAPI } = useForm<DashboardCreationFields>({
         initialValues: initialValues ?? { ...DASHBOARD_INITIAL_VALUES, visibility: userSubjectID },
@@ -116,7 +115,6 @@ export const InsightsDashboardCreationContent: React.FunctionComponent<InsightsD
     })
 
     return (
-        // eslint-disable-next-line react/forbid-elements
         <form noValidate={true} ref={ref} onSubmit={handleSubmit}>
             <FormInput
                 required={true}
@@ -180,7 +178,7 @@ export const InsightsDashboardCreationContent: React.FunctionComponent<InsightsD
                     className="mr-3 flex-grow-0"
                     labelTooltipText={getGlobalSubjectTooltipText(globalSubject)}
                     labelTooltipPosition="bottom"
-                    disabled={!canGlobalSubjectBeEdited}
+                    disabled={!globalSubject?.viewerCanAdminister}
                     onChange={visibility.input.onChange}
                 />
             </FormGroup>

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/hooks/use-dashboard-permissions.ts
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/hooks/use-dashboard-permissions.ts
@@ -67,7 +67,7 @@ export function useDashboardPermissions(
         if (isCustomInsightDashboard(dashboard)) {
             // Global scope permission handling
             if (isGlobalSubject(dashboardOwner)) {
-                const canBeEdited = dashboardOwner.viewerCanAdminister && dashboardOwner.allowSiteSettingsEdits
+                const canBeEdited = dashboardOwner.viewerCanAdminister
 
                 if (!canBeEdited) {
                     return {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/29482

## Context

Code Insights can work with two different backends (data providers) 
1. Setting cascade (deprecated way)
2. Real GQL backend (currently primary backend)

So in the setting cascade world, it might be a case when setting cascade is locked for writing operations and we have a special field in the setting cascade about this case `allowSiteSettingsEdits`. 

This PR removes checks by that field in the dashboard creation and edit UI. Because it's no anymore relevant since we use the new GQL based backend. 

It's safe to just delete this from UI for both API because for setting cascade UI we have an error message banner in forms in case if some operation is forbidden. 