### PR TITLE
tos consent: fix hubspot sync

### DIFF
--- a/cmd/frontend/hubspot/contacts.go
+++ b/cmd/frontend/hubspot/contacts.go
@@ -66,6 +66,7 @@ func newAPIValues(h *ContactProperties) *apiProperties {
 	apiProps.set("first_source_url", h.FirstSourceURL)
 	apiProps.set("last_source_url", h.LastSourceURL)
 	apiProps.set("database_id", h.DatabaseID)
+	apiProps.set("has_agreed_to_tos_and_pp", h.HasAgreedToToS)
 	return apiProps
 }
 


### PR DESCRIPTION
Fix syncing of Terms of Service acceptance to HubSpot to actually set the property.
