### PR TITLE
monitoring: search-blitz - add additional graphs to track p90 and p75 latencies of queries

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -927,27 +927,27 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: mean_successful_sentinel_duration_5m
+## frontend: mean_successful_sentinel_duration_1h30m
 
-<p class="subtitle">mean successful sentinel search duration over 5m</p>
+<p class="subtitle">mean successful sentinel search duration over 1h30m</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 5s+ mean successful sentinel search duration over 5m for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 8s+ mean successful sentinel search duration over 5m for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 5s+ mean successful sentinel search duration over 1h30m for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 8s+ mean successful sentinel search duration over 1h30m for 30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#frontend-mean-successful-sentinel-duration-5m).
+- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#frontend-mean-successful-sentinel-duration-1h30m).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_mean_successful_sentinel_duration_5m",
-  "critical_frontend_mean_successful_sentinel_duration_5m"
+  "warning_frontend_mean_successful_sentinel_duration_1h30m",
+  "critical_frontend_mean_successful_sentinel_duration_1h30m"
 ]
 ```
 
@@ -955,27 +955,27 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: mean_sentinel_stream_latency_5m
+## frontend: mean_sentinel_stream_latency_1h30m
 
-<p class="subtitle">mean sentinel stream latency over 5m</p>
+<p class="subtitle">mean sentinel stream latency over 1h30m</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 2s+ mean sentinel stream latency over 5m for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 3s+ mean sentinel stream latency over 5m for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 2s+ mean sentinel stream latency over 1h30m for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 3s+ mean sentinel stream latency over 1h30m for 30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#frontend-mean-sentinel-stream-latency-5m).
+- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#frontend-mean-sentinel-stream-latency-1h30m).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_mean_sentinel_stream_latency_5m",
-  "critical_frontend_mean_sentinel_stream_latency_5m"
+  "warning_frontend_mean_sentinel_stream_latency_1h30m",
+  "critical_frontend_mean_sentinel_stream_latency_1h30m"
 ]
 ```
 
@@ -983,27 +983,27 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: 90th_percentile_successful_sentinel_duration_5m
+## frontend: 90th_percentile_successful_sentinel_duration_1h30m
 
-<p class="subtitle">90th percentile successful sentinel search duration over 5m</p>
+<p class="subtitle">90th percentile successful sentinel search duration over 1h30m</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 5s+ 90th percentile successful sentinel search duration over 5m for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 10s+ 90th percentile successful sentinel search duration over 5m for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 5s+ 90th percentile successful sentinel search duration over 1h30m for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 10s+ 90th percentile successful sentinel search duration over 1h30m for 30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#frontend-90th-percentile-successful-sentinel-duration-5m).
+- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#frontend-90th-percentile-successful-sentinel-duration-1h30m).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_90th_percentile_successful_sentinel_duration_5m",
-  "critical_frontend_90th_percentile_successful_sentinel_duration_5m"
+  "warning_frontend_90th_percentile_successful_sentinel_duration_1h30m",
+  "critical_frontend_90th_percentile_successful_sentinel_duration_1h30m"
 ]
 ```
 
@@ -1011,27 +1011,27 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: 90th_percentile_sentinel_stream_latency_5m
+## frontend: 90th_percentile_sentinel_stream_latency_1h30m
 
-<p class="subtitle">90th percentile sentinel stream latency over 5m</p>
+<p class="subtitle">90th percentile sentinel stream latency over 1h30m</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 4s+ 90th percentile sentinel stream latency over 5m for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 6s+ 90th percentile sentinel stream latency over 5m for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 4s+ 90th percentile sentinel stream latency over 1h30m for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 6s+ 90th percentile sentinel stream latency over 1h30m for 30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#frontend-90th-percentile-sentinel-stream-latency-5m).
+- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#frontend-90th-percentile-sentinel-stream-latency-1h30m).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_90th_percentile_sentinel_stream_latency_5m",
-  "critical_frontend_90th_percentile_sentinel_stream_latency_5m"
+  "warning_frontend_90th_percentile_sentinel_stream_latency_1h30m",
+  "critical_frontend_90th_percentile_sentinel_stream_latency_1h30m"
 ]
 ```
 

--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -941,7 +941,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#frontend-mean-successful-sentinel-duration-1h30m).
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-mean-successful-sentinel-duration-1h30m).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -957,19 +957,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 ## frontend: mean_sentinel_stream_latency_1h30m
 
-<p class="subtitle">mean sentinel stream latency over 1h30m</p>
+<p class="subtitle">mean successful sentinel stream latency over 1h30m</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 2s+ mean sentinel stream latency over 1h30m for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 3s+ mean sentinel stream latency over 1h30m for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 2s+ mean successful sentinel stream latency over 1h30m for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 3s+ mean successful sentinel stream latency over 1h30m for 30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#frontend-mean-sentinel-stream-latency-1h30m).
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-mean-sentinel-stream-latency-1h30m).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -997,7 +997,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#frontend-90th-percentile-successful-sentinel-duration-1h30m).
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-90th-percentile-successful-sentinel-duration-1h30m).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -1013,19 +1013,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 ## frontend: 90th_percentile_sentinel_stream_latency_1h30m
 
-<p class="subtitle">90th percentile sentinel stream latency over 1h30m</p>
+<p class="subtitle">90th percentile successful sentinel stream latency over 1h30m</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 4s+ 90th percentile sentinel stream latency over 1h30m for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 6s+ 90th percentile sentinel stream latency over 1h30m for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 4s+ 90th percentile successful sentinel stream latency over 1h30m for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 6s+ 90th percentile successful sentinel stream latency over 1h30m for 30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#frontend-90th-percentile-sentinel-stream-latency-1h30m).
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-90th-percentile-sentinel-stream-latency-1h30m).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -2782,6 +2782,8 @@ Query: `sum by(app) (up{app=~".*(frontend|sourcegraph-frontend)"}) / count by (a
 
 <p class="subtitle">Mean successful sentinel search duration over 1h30m</p>
 
+Mean search duration for all successful sentinel queries
+
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-successful-sentinel-duration-1h30m) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102300` on your Sourcegraph instance.
@@ -2799,7 +2801,9 @@ Query: `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*"
 
 #### frontend: mean_sentinel_stream_latency_1h30m
 
-<p class="subtitle">Mean sentinel stream latency over 1h30m</p>
+<p class="subtitle">Mean successful sentinel stream latency over 1h30m</p>
+
+Mean time to first result for all successful streaming sentinel queries
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-sentinel-stream-latency-1h30m) for 2 alerts related to this panel.
 
@@ -2820,6 +2824,8 @@ Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*
 
 <p class="subtitle">90th percentile successful sentinel search duration over 1h30m</p>
 
+90th percentile search duration for all successful sentinel queries
+
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-successful-sentinel-duration-1h30m) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102310` on your Sourcegraph instance.
@@ -2837,7 +2843,9 @@ Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_respo
 
 #### frontend: 90th_percentile_sentinel_stream_latency_1h30m
 
-<p class="subtitle">90th percentile sentinel stream latency over 1h30m</p>
+<p class="subtitle">90th percentile successful sentinel stream latency over 1h30m</p>
+
+90th percentile time to first result for all successful streaming sentinel queries
 
 Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-sentinel-stream-latency-1h30m) for 2 alerts related to this panel.
 
@@ -2858,7 +2866,7 @@ Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_strea
 
 <p class="subtitle">Mean successful sentinel search duration by query over 1h30m</p>
 
-- The mean search duration for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
+Mean search duration for successful sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
 This panel has no related alerts.
 
@@ -2877,9 +2885,9 @@ Query: `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*"
 
 #### frontend: mean_sentinel_stream_latency_by_query_1h30m
 
-<p class="subtitle">Mean sentinel stream latency by query over 1h30m</p>
+<p class="subtitle">Mean successful sentinel stream latency by query over 1h30m</p>
 
-- The mean streaming search latency for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
+Mean time to first result for successful streaming sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
 This panel has no related alerts.
 
@@ -2898,9 +2906,9 @@ Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*
 
 #### frontend: 90th_percentile_successful_sentinel_duration_by_query_1h30m
 
-<p class="subtitle">90th percentile sentinel search duration by query over 1h30m</p>
+<p class="subtitle">90th percentile successful sentinel search duration by query over 1h30m</p>
 
-- The 90th percentile search duration for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
+90th percentile search duration for successful sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
 This panel has no related alerts.
 
@@ -2917,11 +2925,11 @@ Query: `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bu
 
 <br />
 
-#### frontend: 90th_percentile_stream_latency_by_query_1h30m
+#### frontend: 90th_percentile_successful_stream_latency_by_query_1h30m
 
-<p class="subtitle">90th percentile stream latency by query over 1h30m</p>
+<p class="subtitle">90th percentile successful sentinel stream latency by query over 1h30m</p>
 
-- The 90th percentile search latency for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
+90th percentile time to first result for successful streaming sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
 This panel has no related alerts.
 
@@ -2938,11 +2946,11 @@ Query: `histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_b
 
 <br />
 
-#### frontend: 90th_percentile_duration_by_query_1h30m
+#### frontend: 90th_percentile_unsuccessful_duration_by_query_1h30m
 
 <p class="subtitle">90th percentile unsuccessful sentinel search duration by query over 1h30m</p>
 
-- The 90th percentile search duration of _unsuccessful_ sentinel queries (by error or timeout), broken down by query. Useful for debugging how the performance of failed requests affect UX.
+90th percentile search duration of _unsuccessful_ sentinel queries (by error or timeout), broken down by query. Useful for debugging how the performance of failed requests affect UX.
 
 This panel has no related alerts.
 
@@ -2961,9 +2969,9 @@ Query: `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bu
 
 #### frontend: 75th_percentile_successful_sentinel_duration_by_query_1h30m
 
-<p class="subtitle">75th percentile sentinel search duration by query over 1h30m</p>
+<p class="subtitle">75th percentile successful sentinel search duration by query over 1h30m</p>
 
-- The 75th percentile search duration for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
+75th percentile search duration of successful sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
 This panel has no related alerts.
 
@@ -2980,11 +2988,11 @@ Query: `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bu
 
 <br />
 
-#### frontend: 75th_percentile_stream_latency_by_query_1h30m
+#### frontend: 75th_percentile_successful_stream_latency_by_query_1h30m
 
-<p class="subtitle">75th percentile stream latency by query over 1h30m</p>
+<p class="subtitle">75th percentile successful sentinel stream latency by query over 1h30m</p>
 
-- The 75th percentile search latency for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
+75th percentile time to first result for successful streaming sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
 This panel has no related alerts.
 
@@ -3001,11 +3009,11 @@ Query: `histogram_quantile(0.75, sum(rate(src_search_streaming_latency_seconds_b
 
 <br />
 
-#### frontend: 75th_percentile_duration_by_query_1h30m
+#### frontend: 75th_percentile_unsuccessful_duration_by_query_1h30m
 
 <p class="subtitle">75th percentile unsuccessful sentinel search duration by query over 1h30m</p>
 
-- The 75th percentile search duration of _unsuccessful_ sentinel queries (by error or timeout), broken down by query. Useful for debugging how the performance of failed requests affect UX.
+75th percentile search duration of _unsuccessful_ sentinel queries (by error or timeout), broken down by query. Useful for debugging how the performance of failed requests affect UX.
 
 This panel has no related alerts.
 
@@ -3026,7 +3034,7 @@ Query: `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bu
 
 <p class="subtitle">Unsuccessful status rate per 1h30m</p>
 
-- The rate of unsuccessful sentinel queries, broken down by failure type.
+The rate of unsuccessful sentinel queries, broken down by failure type.
 
 This panel has no related alerts.
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -2896,9 +2896,9 @@ Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*
 
 <br />
 
-#### frontend: p90_successful_sentinel_duration_by_query_5m
+#### frontend: 90th_percentile_successful_sentinel_duration_by_query_5m
 
-<p class="subtitle">P90 successful sentinel search duration by query over 5m</p>
+<p class="subtitle">90th percentile sentinel search duration by query over 5m</p>
 
 - The 90th percentile search duration for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -2917,9 +2917,9 @@ Query: `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bu
 
 <br />
 
-#### frontend: p90_sentinel_stream_latency_by_query_5m
+#### frontend: 90th_percentile_stream_latency_by_query_5m
 
-<p class="subtitle">P90 sentinel stream latency by query over 5m</p>
+<p class="subtitle">90th percentile stream latency by query over 5m</p>
 
 - The 90th percentile search latency for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -2938,9 +2938,9 @@ Query: `histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_b
 
 <br />
 
-#### frontend: p90_failed_duration_by_query_5m
+#### frontend: 90th_percentile_duration_by_query_5m
 
-<p class="subtitle">P90 failed sentinel search duration by query over 5m</p>
+<p class="subtitle">90th percentile sentinel search duration by query over 5m</p>
 
 - The 90th percentile search duration of _unsuccessful_ sentinel queries (by error or timeout), broken down by query. Useful for debugging how the performance of failed requests affect UX.
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -2896,6 +2896,90 @@ Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*
 
 <br />
 
+#### frontend: p90_successful_sentinel_duration_by_query_5m
+
+<p class="subtitle">P90 successful sentinel search duration by query over 5m</p>
+
+- The 90th percentile search duration for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102330` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/engineering/search).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[5m])) by (le, source))`
+
+</details>
+
+<br />
+
+#### frontend: p90_sentinel_stream_latency_by_query_5m
+
+<p class="subtitle">P90 sentinel stream latency by query over 5m</p>
+
+- The 90th percentile search latency for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102331` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/engineering/search).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[5m])) by (le, source))`
+
+</details>
+
+<br />
+
+#### frontend: p90_failed_duration_by_query_5m
+
+<p class="subtitle">P90 failed sentinel search duration by query over 5m</p>
+
+- The 90th percentile search duration for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102340` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/engineering/search).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status=~`(timeout|error|partial_timeout)`}[5m])) by (le, source))`
+
+</details>
+
+<br />
+
+#### frontend: p90_sentinel_stream_latency_by_query_5m
+
+<p class="subtitle">P90 sentinel stream latency by query over 5m</p>
+
+- The 90th percentile search latency for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102341` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/engineering/search).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[5m])) by (le, source))`
+
+</details>
+
+<br />
+
 #### frontend: unsuccessful_status_rate_5m
 
 <p class="subtitle">Unsuccessful status rate per 5m</p>
@@ -2904,7 +2988,7 @@ Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102330` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102350` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/engineering/search).*</sub>
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -2778,11 +2778,11 @@ Query: `sum by(app) (up{app=~".*(frontend|sourcegraph-frontend)"}) / count by (a
 
 ### Frontend: Sentinel queries (only on sourcegraph.com)
 
-#### frontend: mean_successful_sentinel_duration_5m
+#### frontend: mean_successful_sentinel_duration_1h30m
 
-<p class="subtitle">Mean successful sentinel search duration over 5m</p>
+<p class="subtitle">Mean successful sentinel search duration over 1h30m</p>
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-successful-sentinel-duration-5m) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-successful-sentinel-duration-1h30m) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102300` on your Sourcegraph instance.
 
@@ -2791,17 +2791,17 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102300`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[5m])) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[5m]))`
+Query: `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[1h30m])) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[1h30m]))`
 
 </details>
 
 <br />
 
-#### frontend: mean_sentinel_stream_latency_5m
+#### frontend: mean_sentinel_stream_latency_1h30m
 
-<p class="subtitle">Mean sentinel stream latency over 5m</p>
+<p class="subtitle">Mean sentinel stream latency over 1h30m</p>
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-sentinel-stream-latency-5m) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-sentinel-stream-latency-1h30m) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102301` on your Sourcegraph instance.
 
@@ -2810,17 +2810,17 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102301`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[5m])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[5m]))`
+Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[1h30m])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[1h30m]))`
 
 </details>
 
 <br />
 
-#### frontend: 90th_percentile_successful_sentinel_duration_5m
+#### frontend: 90th_percentile_successful_sentinel_duration_1h30m
 
-<p class="subtitle">90th percentile successful sentinel search duration over 5m</p>
+<p class="subtitle">90th percentile successful sentinel search duration over 1h30m</p>
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-successful-sentinel-duration-5m) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-successful-sentinel-duration-1h30m) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102310` on your Sourcegraph instance.
 
@@ -2829,17 +2829,17 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102310`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[5m]), "source", "$1", "source", "searchblitz_(.*)")))`
+Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m]), "source", "$1", "source", "searchblitz_(.*)")))`
 
 </details>
 
 <br />
 
-#### frontend: 90th_percentile_sentinel_stream_latency_5m
+#### frontend: 90th_percentile_sentinel_stream_latency_1h30m
 
-<p class="subtitle">90th percentile sentinel stream latency over 5m</p>
+<p class="subtitle">90th percentile sentinel stream latency over 1h30m</p>
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-sentinel-stream-latency-5m) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-sentinel-stream-latency-1h30m) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102311` on your Sourcegraph instance.
 
@@ -2848,15 +2848,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102311`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[5m]), "source", "$1", "source", "searchblitz_(.*)")))`
+Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m]), "source", "$1", "source", "searchblitz_(.*)")))`
 
 </details>
 
 <br />
 
-#### frontend: mean_successful_sentinel_duration_by_query_5m
+#### frontend: mean_successful_sentinel_duration_by_query_1h30m
 
-<p class="subtitle">Mean successful sentinel search duration by query over 5m</p>
+<p class="subtitle">Mean successful sentinel search duration by query over 1h30m</p>
 
 - The mean search duration for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -2869,15 +2869,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102320`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[5m])) by (source) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[5m])) by (source)`
+Query: `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[1h30m])) by (source) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[1h30m])) by (source)`
 
 </details>
 
 <br />
 
-#### frontend: mean_sentinel_stream_latency_by_query_5m
+#### frontend: mean_sentinel_stream_latency_by_query_1h30m
 
-<p class="subtitle">Mean sentinel stream latency by query over 5m</p>
+<p class="subtitle">Mean sentinel stream latency by query over 1h30m</p>
 
 - The mean streaming search latency for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -2890,15 +2890,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102321`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[5m])) by (source) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[5m])) by (source)`
+Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[1h30m])) by (source) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[1h30m])) by (source)`
 
 </details>
 
 <br />
 
-#### frontend: 90th_percentile_successful_sentinel_duration_by_query_5m
+#### frontend: 90th_percentile_successful_sentinel_duration_by_query_1h30m
 
-<p class="subtitle">90th percentile sentinel search duration by query over 5m</p>
+<p class="subtitle">90th percentile sentinel search duration by query over 1h30m</p>
 
 - The 90th percentile search duration for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -2911,15 +2911,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102330`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[5m])) by (le, source))`
+Query: `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m])) by (le, source))`
 
 </details>
 
 <br />
 
-#### frontend: 90th_percentile_stream_latency_by_query_5m
+#### frontend: 90th_percentile_stream_latency_by_query_1h30m
 
-<p class="subtitle">90th percentile stream latency by query over 5m</p>
+<p class="subtitle">90th percentile stream latency by query over 1h30m</p>
 
 - The 90th percentile search latency for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -2932,15 +2932,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102331`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[5m])) by (le, source))`
+Query: `histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m])) by (le, source))`
 
 </details>
 
 <br />
 
-#### frontend: 90th_percentile_duration_by_query_5m
+#### frontend: 90th_percentile_duration_by_query_1h30m
 
-<p class="subtitle">90th percentile sentinel search duration by query over 5m</p>
+<p class="subtitle">90th percentile unsuccessful sentinel search duration by query over 1h30m</p>
 
 - The 90th percentile search duration of _unsuccessful_ sentinel queries (by error or timeout), broken down by query. Useful for debugging how the performance of failed requests affect UX.
 
@@ -2953,17 +2953,17 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102340`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[5m])) by (le, source))`
+Query: `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[1h30m])) by (le, source))`
 
 </details>
 
 <br />
 
-#### frontend: unsuccessful_status_rate_5m
+#### frontend: 75th_percentile_successful_sentinel_duration_by_query_1h30m
 
-<p class="subtitle">Unsuccessful status rate per 5m</p>
+<p class="subtitle">75th percentile sentinel search duration by query over 1h30m</p>
 
-- The rate of unsuccessful sentinel queries, broken down by failure type.
+- The 75th percentile search duration for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
 This panel has no related alerts.
 
@@ -2974,7 +2974,70 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102350`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_graphql_search_response{source=~"searchblitz.*", status!="success"}[5m])) by (status)`
+Query: `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m])) by (le, source))`
+
+</details>
+
+<br />
+
+#### frontend: 75th_percentile_stream_latency_by_query_1h30m
+
+<p class="subtitle">75th percentile stream latency by query over 1h30m</p>
+
+- The 75th percentile search latency for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102351` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/engineering/search).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `histogram_quantile(0.75, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m])) by (le, source))`
+
+</details>
+
+<br />
+
+#### frontend: 75th_percentile_duration_by_query_1h30m
+
+<p class="subtitle">75th percentile unsuccessful sentinel search duration by query over 1h30m</p>
+
+- The 75th percentile search duration of _unsuccessful_ sentinel queries (by error or timeout), broken down by query. Useful for debugging how the performance of failed requests affect UX.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102360` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/engineering/search).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[1h30m])) by (le, source))`
+
+</details>
+
+<br />
+
+#### frontend: unsuccessful_status_rate_1h30m
+
+<p class="subtitle">Unsuccessful status rate per 1h30m</p>
+
+- The rate of unsuccessful sentinel queries, broken down by failure type.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102370` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/engineering/search).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(rate(src_graphql_search_response{source=~"searchblitz.*", status!="success"}[1h30m])) by (status)`
 
 </details>
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -2942,7 +2942,7 @@ Query: `histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_b
 
 <p class="subtitle">P90 failed sentinel search duration by query over 5m</p>
 
-- The 90th percentile search duration for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
+- The 90th percentile search duration of _unsuccessful_ sentinel queries (by error or timeout), broken down by query. Useful for debugging how the performance of failed requests affect UX.
 
 This panel has no related alerts.
 
@@ -2953,28 +2953,7 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102340`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status=~`(timeout|error|partial_timeout)`}[5m])) by (le, source))`
-
-</details>
-
-<br />
-
-#### frontend: p90_sentinel_stream_latency_by_query_5m
-
-<p class="subtitle">P90 sentinel stream latency by query over 5m</p>
-
-- The 90th percentile search latency for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
-
-This panel has no related alerts.
-
-To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102341` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Search team](https://handbook.sourcegraph.com/engineering/search).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[5m])) by (le, source))`
+Query: `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[5m])) by (le, source))`
 
 </details>
 
@@ -2984,7 +2963,7 @@ Query: `histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_b
 
 <p class="subtitle">Unsuccessful status rate per 5m</p>
 
-- The rate of unsuccessful sentinel query, broken down by failure type
+- The rate of unsuccessful sentinel queries, broken down by failure type.
 
 This panel has no related alerts.
 

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -582,11 +582,11 @@ func Frontend() *monitoring.Container {
 				Rows: []monitoring.Row{
 					{
 						{
-							Name:        "mean_successful_sentinel_duration_5m",
-							Description: "mean successful sentinel search duration over 5m",
+							Name:        "mean_successful_sentinel_duration_1h30m",
+							Description: "mean successful sentinel search duration over 1h30m",
 							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
 							// since these panels relate to metrics that don't exist on a customer instance.
-							Query:    `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[5m])) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[5m]))`,
+							Query:    `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[1h30m])) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[1h30m]))`,
 							Warning:  monitoring.Alert().GreaterOrEqual(5, nil).For(15 * time.Minute),
 							Critical: monitoring.Alert().GreaterOrEqual(8, nil).For(30 * time.Minute),
 							Panel:    monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(monitoring.PanelOptions.NoLegend()),
@@ -598,11 +598,11 @@ func Frontend() *monitoring.Container {
 							`,
 						},
 						{
-							Name:        "mean_sentinel_stream_latency_5m",
-							Description: "mean sentinel stream latency over 5m",
+							Name:        "mean_sentinel_stream_latency_1h30m",
+							Description: "mean sentinel stream latency over 1h30m",
 							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
 							// since these panels relate to metrics that don't exist on a customer instance.
-							Query:    `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[5m])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[5m]))`,
+							Query:    `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[1h30m])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[1h30m]))`,
 							Warning:  monitoring.Alert().GreaterOrEqual(2, nil).For(15 * time.Minute),
 							Critical: monitoring.Alert().GreaterOrEqual(3, nil).For(30 * time.Minute),
 							Panel: monitoring.Panel().LegendFormat("latency").Unit(monitoring.Seconds).With(
@@ -619,11 +619,11 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:        "90th_percentile_successful_sentinel_duration_5m",
-							Description: "90th percentile successful sentinel search duration over 5m",
+							Name:        "90th_percentile_successful_sentinel_duration_1h30m",
+							Description: "90th percentile successful sentinel search duration over 1h30m",
 							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
 							// since these panels relate to metrics that don't exist on a customer instance.
-							Query:    `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[5m]), "source", "$1", "source", "searchblitz_(.*)")))`,
+							Query:    `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m]), "source", "$1", "source", "searchblitz_(.*)")))`,
 							Warning:  monitoring.Alert().GreaterOrEqual(5, nil).For(15 * time.Minute),
 							Critical: monitoring.Alert().GreaterOrEqual(10, nil).For(30 * time.Minute),
 							Panel:    monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(monitoring.PanelOptions.NoLegend()),
@@ -635,11 +635,11 @@ func Frontend() *monitoring.Container {
 							`,
 						},
 						{
-							Name:        "90th_percentile_sentinel_stream_latency_5m",
-							Description: "90th percentile sentinel stream latency over 5m",
+							Name:        "90th_percentile_sentinel_stream_latency_1h30m",
+							Description: "90th percentile sentinel stream latency over 1h30m",
 							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
 							// since these panels relate to metrics that don't exist on a customer instance.
-							Query:    `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[5m]), "source", "$1", "source", "searchblitz_(.*)")))`,
+							Query:    `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m]), "source", "$1", "source", "searchblitz_(.*)")))`,
 							Warning:  monitoring.Alert().GreaterOrEqual(4, nil).For(15 * time.Minute),
 							Critical: monitoring.Alert().GreaterOrEqual(6, nil).For(30 * time.Minute),
 							Panel: monitoring.Panel().LegendFormat("latency").Unit(monitoring.Seconds).With(
@@ -656,9 +656,9 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:        "mean_successful_sentinel_duration_by_query_5m",
-							Description: "mean successful sentinel search duration by query over 5m",
-							Query:       `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[5m])) by (source) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[5m])) by (source)`,
+							Name:        "mean_successful_sentinel_duration_by_query_1h30m",
+							Description: "mean successful sentinel search duration by query over 1h30m",
+							Query:       `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[1h30m])) by (source) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[1h30m])) by (source)`,
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.LegendOnRight(),
@@ -672,9 +672,9 @@ func Frontend() *monitoring.Container {
 							`,
 						},
 						{
-							Name:        "mean_sentinel_stream_latency_by_query_5m",
-							Description: "mean sentinel stream latency by query over 5m",
-							Query:       `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[5m])) by (source) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[5m])) by (source)`,
+							Name:        "mean_sentinel_stream_latency_by_query_1h30m",
+							Description: "mean sentinel stream latency by query over 1h30m",
+							Query:       `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[1h30m])) by (source) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[1h30m])) by (source)`,
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.LegendOnRight(),
@@ -690,9 +690,9 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:        "90th_percentile_successful_sentinel_duration_by_query_5m",
-							Description: "90th percentile sentinel search duration by query over 5m",
-							Query:       `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[5m])) by (le, source))`,
+							Name:        "90th_percentile_successful_sentinel_duration_by_query_1h30m",
+							Description: "90th percentile sentinel search duration by query over 1h30m",
+							Query:       `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m])) by (le, source))`,
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.LegendOnRight(),
@@ -706,9 +706,9 @@ func Frontend() *monitoring.Container {
 							`,
 						},
 						{
-							Name:        "90th_percentile_stream_latency_by_query_5m",
-							Description: "90th percentile stream latency by query over 5m",
-							Query:       `histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[5m])) by (le, source))`,
+							Name:        "90th_percentile_stream_latency_by_query_1h30m",
+							Description: "90th percentile stream latency by query over 1h30m",
+							Query:       `histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m])) by (le, source))`,
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.LegendOnRight(),
@@ -724,9 +724,9 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:        "90th_percentile_duration_by_query_5m",
-							Description: "90th percentile sentinel search duration by query over 5m",
-							Query:       "histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[5m])) by (le, source))",
+							Name:        "90th_percentile_duration_by_query_1h30m",
+							Description: "90th percentile unsuccessful sentinel search duration by query over 1h30m",
+							Query:       "histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[1h30m])) by (le, source))",
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{source}}").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.LegendOnRight(),
@@ -742,9 +742,61 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:        "unsuccessful_status_rate_5m",
-							Description: "unsuccessful status rate per 5m",
-							Query:       `sum(rate(src_graphql_search_response{source=~"searchblitz.*", status!="success"}[5m])) by (status)`,
+							Name:        "75th_percentile_successful_sentinel_duration_by_query_1h30m",
+							Description: "75th percentile sentinel search duration by query over 1h30m",
+							Query:       `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m])) by (le, source))`,
+							NoAlert:     true,
+							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
+								monitoring.PanelOptions.LegendOnRight(),
+								monitoring.PanelOptions.HoverShowAll(),
+								monitoring.PanelOptions.HoverSort("descending"),
+								monitoring.PanelOptions.Fill(0),
+							),
+							Owner: monitoring.ObservableOwnerSearch,
+							Interpretation: `
+								- The 75th percentile search duration for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
+							`,
+						},
+						{
+							Name:        "75th_percentile_stream_latency_by_query_1h30m",
+							Description: "75th percentile stream latency by query over 1h30m",
+							Query:       `histogram_quantile(0.75, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m])) by (le, source))`,
+							NoAlert:     true,
+							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
+								monitoring.PanelOptions.LegendOnRight(),
+								monitoring.PanelOptions.HoverShowAll(),
+								monitoring.PanelOptions.HoverSort("descending"),
+								monitoring.PanelOptions.Fill(0),
+							),
+							Owner: monitoring.ObservableOwnerSearch,
+							Interpretation: `
+								- The 75th percentile search latency for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
+							`,
+						},
+					},
+					{
+						{
+							Name:        "75th_percentile_duration_by_query_1h30m",
+							Description: "75th percentile unsuccessful sentinel search duration by query over 1h30m",
+							Query:       "histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[1h30m])) by (le, source))",
+							NoAlert:     true,
+							Panel: monitoring.Panel().LegendFormat("{{source}}").Unit(monitoring.Seconds).With(
+								monitoring.PanelOptions.LegendOnRight(),
+								monitoring.PanelOptions.HoverShowAll(),
+								monitoring.PanelOptions.HoverSort("descending"),
+								monitoring.PanelOptions.Fill(0),
+							),
+							Owner: monitoring.ObservableOwnerSearch,
+							Interpretation: `
+								- The 75th percentile search duration of _unsuccessful_ sentinel queries (by error or timeout), broken down by query. Useful for debugging how the performance of failed requests affect UX.
+							`,
+						},
+					},
+					{
+						{
+							Name:        "unsuccessful_status_rate_1h30m",
+							Description: "unsuccessful status rate per 1h30m",
+							Query:       `sum(rate(src_graphql_search_response{source=~"searchblitz.*", status!="success"}[1h30m])) by (status)`,
 							NoAlert:     true,
 							Panel:       monitoring.Panel().LegendFormat("{{status}}"),
 							Owner:       monitoring.ObservableOwnerSearch,

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -586,11 +586,12 @@ func Frontend() *monitoring.Container {
 							Description: "mean successful sentinel search duration over 1h30m",
 							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
 							// since these panels relate to metrics that don't exist on a customer instance.
-							Query:    `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[1h30m])) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[1h30m]))`,
-							Warning:  monitoring.Alert().GreaterOrEqual(5, nil).For(15 * time.Minute),
-							Critical: monitoring.Alert().GreaterOrEqual(8, nil).For(30 * time.Minute),
-							Panel:    monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(monitoring.PanelOptions.NoLegend()),
-							Owner:    monitoring.ObservableOwnerSearch,
+							Query:          `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[1h30m])) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[1h30m]))`,
+							Warning:        monitoring.Alert().GreaterOrEqual(5, nil).For(15 * time.Minute),
+							Critical:       monitoring.Alert().GreaterOrEqual(8, nil).For(30 * time.Minute),
+							Panel:          monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(monitoring.PanelOptions.NoLegend()),
+							Owner:          monitoring.ObservableOwnerSearch,
+							Interpretation: `Mean search duration for all successful sentinel queries`,
 							PossibleSolutions: `
 								- Look at the breakdown by query to determine if a specific query type is being affected
 								- Check for high CPU usage on zoekt-webserver
@@ -599,7 +600,7 @@ func Frontend() *monitoring.Container {
 						},
 						{
 							Name:        "mean_sentinel_stream_latency_1h30m",
-							Description: "mean sentinel stream latency over 1h30m",
+							Description: "mean successful sentinel stream latency over 1h30m",
 							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
 							// since these panels relate to metrics that don't exist on a customer instance.
 							Query:    `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[1h30m])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[1h30m]))`,
@@ -609,7 +610,8 @@ func Frontend() *monitoring.Container {
 								monitoring.PanelOptions.NoLegend(),
 								monitoring.PanelOptions.ColorOverride("latency", "#8AB8FF"),
 							),
-							Owner: monitoring.ObservableOwnerSearch,
+							Owner:          monitoring.ObservableOwnerSearch,
+							Interpretation: `Mean time to first result for all successful streaming sentinel queries`,
 							PossibleSolutions: `
 								- Look at the breakdown by query to determine if a specific query type is being affected
 								- Check for high CPU usage on zoekt-webserver
@@ -623,11 +625,12 @@ func Frontend() *monitoring.Container {
 							Description: "90th percentile successful sentinel search duration over 1h30m",
 							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
 							// since these panels relate to metrics that don't exist on a customer instance.
-							Query:    `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m]), "source", "$1", "source", "searchblitz_(.*)")))`,
-							Warning:  monitoring.Alert().GreaterOrEqual(5, nil).For(15 * time.Minute),
-							Critical: monitoring.Alert().GreaterOrEqual(10, nil).For(30 * time.Minute),
-							Panel:    monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(monitoring.PanelOptions.NoLegend()),
-							Owner:    monitoring.ObservableOwnerSearch,
+							Query:          `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m]), "source", "$1", "source", "searchblitz_(.*)")))`,
+							Warning:        monitoring.Alert().GreaterOrEqual(5, nil).For(15 * time.Minute),
+							Critical:       monitoring.Alert().GreaterOrEqual(10, nil).For(30 * time.Minute),
+							Panel:          monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(monitoring.PanelOptions.NoLegend()),
+							Owner:          monitoring.ObservableOwnerSearch,
+							Interpretation: `90th percentile search duration for all successful sentinel queries`,
 							PossibleSolutions: `
 								- Look at the breakdown by query to determine if a specific query type is being affected
 								- Check for high CPU usage on zoekt-webserver
@@ -636,7 +639,7 @@ func Frontend() *monitoring.Container {
 						},
 						{
 							Name:        "90th_percentile_sentinel_stream_latency_1h30m",
-							Description: "90th percentile sentinel stream latency over 1h30m",
+							Description: "90th percentile successful sentinel stream latency over 1h30m",
 							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
 							// since these panels relate to metrics that don't exist on a customer instance.
 							Query:    `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m]), "source", "$1", "source", "searchblitz_(.*)")))`,
@@ -646,7 +649,8 @@ func Frontend() *monitoring.Container {
 								monitoring.PanelOptions.NoLegend(),
 								monitoring.PanelOptions.ColorOverride("latency", "#8AB8FF"),
 							),
-							Owner: monitoring.ObservableOwnerSearch,
+							Owner:          monitoring.ObservableOwnerSearch,
+							Interpretation: `90th percentile time to first result for all successful streaming sentinel queries`,
 							PossibleSolutions: `
 								- Look at the breakdown by query to determine if a specific query type is being affected
 								- Check for high CPU usage on zoekt-webserver
@@ -666,14 +670,12 @@ func Frontend() *monitoring.Container {
 								monitoring.PanelOptions.HoverSort("descending"),
 								monitoring.PanelOptions.Fill(0),
 							),
-							Owner: monitoring.ObservableOwnerSearch,
-							Interpretation: `
-								- The mean search duration for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
-							`,
+							Owner:          monitoring.ObservableOwnerSearch,
+							Interpretation: `Mean search duration for successful sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.`,
 						},
 						{
 							Name:        "mean_sentinel_stream_latency_by_query_1h30m",
-							Description: "mean sentinel stream latency by query over 1h30m",
+							Description: "mean successful sentinel stream latency by query over 1h30m",
 							Query:       `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[1h30m])) by (source) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[1h30m])) by (source)`,
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
@@ -682,16 +684,14 @@ func Frontend() *monitoring.Container {
 								monitoring.PanelOptions.HoverSort("descending"),
 								monitoring.PanelOptions.Fill(0),
 							),
-							Owner: monitoring.ObservableOwnerSearch,
-							Interpretation: `
-								- The mean streaming search latency for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
-							`,
+							Owner:          monitoring.ObservableOwnerSearch,
+							Interpretation: `Mean time to first result for successful streaming sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.`,
 						},
 					},
 					{
 						{
 							Name:        "90th_percentile_successful_sentinel_duration_by_query_1h30m",
-							Description: "90th percentile sentinel search duration by query over 1h30m",
+							Description: "90th percentile successful sentinel search duration by query over 1h30m",
 							Query:       `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m])) by (le, source))`,
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
@@ -700,14 +700,12 @@ func Frontend() *monitoring.Container {
 								monitoring.PanelOptions.HoverSort("descending"),
 								monitoring.PanelOptions.Fill(0),
 							),
-							Owner: monitoring.ObservableOwnerSearch,
-							Interpretation: `
-								- The 90th percentile search duration for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
-							`,
+							Owner:          monitoring.ObservableOwnerSearch,
+							Interpretation: `90th percentile search duration for successful sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.`,
 						},
 						{
-							Name:        "90th_percentile_stream_latency_by_query_1h30m",
-							Description: "90th percentile stream latency by query over 1h30m",
+							Name:        "90th_percentile_successful_stream_latency_by_query_1h30m",
+							Description: "90th percentile successful sentinel stream latency by query over 1h30m",
 							Query:       `histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m])) by (le, source))`,
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
@@ -716,15 +714,13 @@ func Frontend() *monitoring.Container {
 								monitoring.PanelOptions.HoverSort("descending"),
 								monitoring.PanelOptions.Fill(0),
 							),
-							Owner: monitoring.ObservableOwnerSearch,
-							Interpretation: `
-								- The 90th percentile search latency for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
-							`,
+							Owner:          monitoring.ObservableOwnerSearch,
+							Interpretation: `90th percentile time to first result for successful streaming sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.`,
 						},
 					},
 					{
 						{
-							Name:        "90th_percentile_duration_by_query_1h30m",
+							Name:        "90th_percentile_unsuccessful_duration_by_query_1h30m",
 							Description: "90th percentile unsuccessful sentinel search duration by query over 1h30m",
 							Query:       "histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[1h30m])) by (le, source))",
 							NoAlert:     true,
@@ -734,16 +730,14 @@ func Frontend() *monitoring.Container {
 								monitoring.PanelOptions.HoverSort("descending"),
 								monitoring.PanelOptions.Fill(0),
 							),
-							Owner: monitoring.ObservableOwnerSearch,
-							Interpretation: `
-								- The 90th percentile search duration of _unsuccessful_ sentinel queries (by error or timeout), broken down by query. Useful for debugging how the performance of failed requests affect UX.
-							`,
+							Owner:          monitoring.ObservableOwnerSearch,
+							Interpretation: `90th percentile search duration of _unsuccessful_ sentinel queries (by error or timeout), broken down by query. Useful for debugging how the performance of failed requests affect UX.`,
 						},
 					},
 					{
 						{
 							Name:        "75th_percentile_successful_sentinel_duration_by_query_1h30m",
-							Description: "75th percentile sentinel search duration by query over 1h30m",
+							Description: "75th percentile successful sentinel search duration by query over 1h30m",
 							Query:       `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m])) by (le, source))`,
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
@@ -752,14 +746,12 @@ func Frontend() *monitoring.Container {
 								monitoring.PanelOptions.HoverSort("descending"),
 								monitoring.PanelOptions.Fill(0),
 							),
-							Owner: monitoring.ObservableOwnerSearch,
-							Interpretation: `
-								- The 75th percentile search duration for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
-							`,
+							Owner:          monitoring.ObservableOwnerSearch,
+							Interpretation: `75th percentile search duration of successful sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.`,
 						},
 						{
-							Name:        "75th_percentile_stream_latency_by_query_1h30m",
-							Description: "75th percentile stream latency by query over 1h30m",
+							Name:        "75th_percentile_successful_stream_latency_by_query_1h30m",
+							Description: "75th percentile successful sentinel stream latency by query over 1h30m",
 							Query:       `histogram_quantile(0.75, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m])) by (le, source))`,
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
@@ -768,15 +760,13 @@ func Frontend() *monitoring.Container {
 								monitoring.PanelOptions.HoverSort("descending"),
 								monitoring.PanelOptions.Fill(0),
 							),
-							Owner: monitoring.ObservableOwnerSearch,
-							Interpretation: `
-								- The 75th percentile search latency for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
-							`,
+							Owner:          monitoring.ObservableOwnerSearch,
+							Interpretation: `75th percentile time to first result for successful streaming sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.`,
 						},
 					},
 					{
 						{
-							Name:        "75th_percentile_duration_by_query_1h30m",
+							Name:        "75th_percentile_unsuccessful_duration_by_query_1h30m",
 							Description: "75th percentile unsuccessful sentinel search duration by query over 1h30m",
 							Query:       "histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[1h30m])) by (le, source))",
 							NoAlert:     true,
@@ -786,23 +776,19 @@ func Frontend() *monitoring.Container {
 								monitoring.PanelOptions.HoverSort("descending"),
 								monitoring.PanelOptions.Fill(0),
 							),
-							Owner: monitoring.ObservableOwnerSearch,
-							Interpretation: `
-								- The 75th percentile search duration of _unsuccessful_ sentinel queries (by error or timeout), broken down by query. Useful for debugging how the performance of failed requests affect UX.
-							`,
+							Owner:          monitoring.ObservableOwnerSearch,
+							Interpretation: `75th percentile search duration of _unsuccessful_ sentinel queries (by error or timeout), broken down by query. Useful for debugging how the performance of failed requests affect UX.`,
 						},
 					},
 					{
 						{
-							Name:        "unsuccessful_status_rate_1h30m",
-							Description: "unsuccessful status rate per 1h30m",
-							Query:       `sum(rate(src_graphql_search_response{source=~"searchblitz.*", status!="success"}[1h30m])) by (status)`,
-							NoAlert:     true,
-							Panel:       monitoring.Panel().LegendFormat("{{status}}"),
-							Owner:       monitoring.ObservableOwnerSearch,
-							Interpretation: `
-								- The rate of unsuccessful sentinel queries, broken down by failure type.
-							`,
+							Name:           "unsuccessful_status_rate_1h30m",
+							Description:    "unsuccessful status rate per 1h30m",
+							Query:          `sum(rate(src_graphql_search_response{source=~"searchblitz.*", status!="success"}[1h30m])) by (status)`,
+							NoAlert:        true,
+							Panel:          monitoring.Panel().LegendFormat("{{status}}"),
+							Owner:          monitoring.ObservableOwnerSearch,
+							Interpretation: `The rate of unsuccessful sentinel queries, broken down by failure type.`,
 						},
 					},
 				},

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -690,6 +690,58 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
+							Name:        "p90_successful_sentinel_duration_by_query_5m",
+							Description: "p90 successful sentinel search duration by query over 5m",
+							Query:       `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[5m])) by (le, source))`,
+							NoAlert:     true,
+							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
+								monitoring.PanelOptions.LegendOnRight(),
+								monitoring.PanelOptions.HoverShowAll(),
+								monitoring.PanelOptions.HoverSort("descending"),
+								monitoring.PanelOptions.Fill(0),
+							),
+							Owner: monitoring.ObservableOwnerSearch,
+							Interpretation: `
+								- The 90th percentile search duration for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
+							`,
+						},
+						{
+							Name:        "p90_sentinel_stream_latency_by_query_5m",
+							Description: "p90 sentinel stream latency by query over 5m",
+							Query:       `histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[5m])) by (le, source))`,
+							NoAlert:     true,
+							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
+								monitoring.PanelOptions.LegendOnRight(),
+								monitoring.PanelOptions.HoverShowAll(),
+								monitoring.PanelOptions.HoverSort("descending"),
+								monitoring.PanelOptions.Fill(0),
+							),
+							Owner: monitoring.ObservableOwnerSearch,
+							Interpretation: `
+								- The 90th percentile search latency for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
+							`,
+						},
+					},
+					{
+						{
+							Name:        "p90_failed_duration_by_query_5m",
+							Description: "p90 failed sentinel search duration by query over 5m",
+							Query:       "histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[5m])) by (le, source))",
+							NoAlert:     true,
+							Panel: monitoring.Panel().LegendFormat("{{source}}").Unit(monitoring.Seconds).With(
+								monitoring.PanelOptions.LegendOnRight(),
+								monitoring.PanelOptions.HoverShowAll(),
+								monitoring.PanelOptions.HoverSort("descending"),
+								monitoring.PanelOptions.Fill(0),
+							),
+							Owner: monitoring.ObservableOwnerSearch,
+							Interpretation: `
+								- The 90th percentile search duration of _unsuccessful_ sentinel queries (by error or timeout), broken down by query. Useful for debugging how the performance of failed requests affect UX.
+							`,
+						},
+					},
+					{
+						{
 							Name:        "unsuccessful_status_rate_5m",
 							Description: "unsuccessful status rate per 5m",
 							Query:       `sum(rate(src_graphql_search_response{source=~"searchblitz.*", status!="success"}[5m])) by (status)`,
@@ -697,7 +749,7 @@ func Frontend() *monitoring.Container {
 							Panel:       monitoring.Panel().LegendFormat("{{status}}"),
 							Owner:       monitoring.ObservableOwnerSearch,
 							Interpretation: `
-								- The rate of unsuccessful sentinel query, broken down by failure type
+								- The rate of unsuccessful sentinel queries, broken down by failure type.
 							`,
 						},
 					},

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -690,8 +690,8 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:        "p90_successful_sentinel_duration_by_query_5m",
-							Description: "p90 successful sentinel search duration by query over 5m",
+							Name:        "90th_percentile_successful_sentinel_duration_by_query_5m",
+							Description: "90th percentile sentinel search duration by query over 5m",
 							Query:       `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[5m])) by (le, source))`,
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
@@ -706,8 +706,8 @@ func Frontend() *monitoring.Container {
 							`,
 						},
 						{
-							Name:        "p90_sentinel_stream_latency_by_query_5m",
-							Description: "p90 sentinel stream latency by query over 5m",
+							Name:        "90th_percentile_stream_latency_by_query_5m",
+							Description: "90th percentile stream latency by query over 5m",
 							Query:       `histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[5m])) by (le, source))`,
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
@@ -724,8 +724,8 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:        "p90_failed_duration_by_query_5m",
-							Description: "p90 failed sentinel search duration by query over 5m",
+							Name:        "90th_percentile_duration_by_query_5m",
+							Description: "90th percentile sentinel search duration by query over 5m",
 							Query:       "histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[5m])) by (le, source))",
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{source}}").Unit(monitoring.Seconds).With(


### PR DESCRIPTION
This PR adds 3 additional graphs to `search-blitz` to track p90 latencies of sentinel queries. The latencies of successful and failed queries are broken out into separate graphs, along with another graph that aggregates successful+failed queries together. 

![Screen Shot 2022-01-11 at 10 47 40 AM](https://user-images.githubusercontent.com/9022011/149003211-8bbf2067-1fe7-43d2-91ad-cf14a1ee3bd3.png)

Questions:

- Should we consider adding more buckets to the histogram? The graphs look pretty choppy - many more granularity would help?

https://github.com/sourcegraph/sourcegraph/blob/82251e9550fd753af44fb2f282c3fe966403549d/cmd/frontend/graphqlbackend/search_results.go#L375-L380

- Why do we use both "latency" and "duration" in graph titles? Compare the following graphs - they're tracking the same metric, they only differ in whether or not they filter out failed requests:

https://github.com/sourcegraph/sourcegraph/blob/82251e9550fd753af44fb2f282c3fe966403549d/monitoring/definitions/frontend.go#L659-L689