### PR TITLE
dev/ci: fix default version format

### DIFF
--- a/enterprise/dev/ci/images/images.go
+++ b/enterprise/dev/ci/images/images.go
@@ -15,9 +15,6 @@ const (
 	SourcegraphDockerDevRegistry = "us.gcr.io/sourcegraph-dev"
 	// SourcegraphDockerPublishRegistry is a public registry for final images, and does not require authentication to pull from.
 	SourcegraphDockerPublishRegistry = "index.docker.io/sourcegraph"
-	MainBranchTagPublishFormat       = "%05d_%10s_%7s"
-	DefaultTagDateFormat             = "2006-01-02"
-	DefaultBranchTagFormat           = "%s_%05d_%10s_%7s" // encodes branch inside the tag as well
 )
 
 // DevRegistryImage returns the name of the image for the given app and tag on the

--- a/enterprise/dev/ci/internal/ci/config.go
+++ b/enterprise/dev/ci/internal/ci/config.go
@@ -93,10 +93,10 @@ func NewConfig(now time.Time) Config {
 	case runType.Is(MainBranch):
 		// This tag is used for deploying continuously. Only ever generate this on the
 		// main branch.
-		tag = fmt.Sprintf(images.MainBranchTagPublishFormat, buildNumber, now.Format(images.DefaultTagDateFormat), commit)
+		tag = fmt.Sprintf("%05d_%10s_%7s", buildNumber, now.Format("2006-01-02"), commit)
 	default:
 		// Encode branch inside build tag by default.
-		tag = fmt.Sprintf(images.DefaultBranchTagFormat, strings.ReplaceAll(branch, "/", "-"), buildNumber, now.Format(images.DefaultBranchTagFormat), commit)
+		tag = fmt.Sprintf("%s_%05d_%10s_%7s", strings.ReplaceAll(branch, "/", "-"), buildNumber, now.Format("2006-01-02"), commit)
 	}
 	if runType.Is(ImagePatch, ImagePatchNoTest, ExecutorPatchNoTest) {
 		// Add additional patch suffix


### PR DESCRIPTION
The version generator was broken in #29158 because the formatting for date was incorrect