### PR TITLE
batches: add fork documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Search contexts can now be defined with a restricted search query as an alternative to a specific list of repositories and revisions. This feature is _beta_ and may change in the following releases. Allowed filters: `repo`, `rev`, `file`, `lang`, `case`, `fork`, `visibility`. `OR`, `AND` expressions are also allowed. To enable this feature to all users, set `experimentalFeatures.searchContextsQuery` to true in global settings. You'll then see a "Create context" button from the search results page and a "Query" input field in the search contexts form. If you want revisions specified in these query based search contexts to be indexed, set `experimentalFeatures.search.index.query.contexts` to true in site configuration. [#29327](https://github.com/sourcegraph/sourcegraph/pull/29327)
 - More explicit Terms of Service and Privacy Policy consent has been added to Sourcegraph Server. [#28716](https://github.com/sourcegraph/sourcegraph/issues/28716)
+- Batch changes will be created on forks of the upstream repository if the new `batchChanges.enforceForks` site setting is enabled. [#17879](https://github.com/sourcegraph/sourcegraph/issues/17879)
 
 ### Changed
 

--- a/doc/admin/config/batch_changes.md
+++ b/doc/admin/config/batch_changes.md
@@ -148,7 +148,7 @@ Webhook logs can be encrypted by specifying a `webhookLogKey` in the [on-disk da
 
 Sourcegraph can be configured to push branches created by Batch Changes to a fork of the repository, rather than the repository itself, by enabling the `batchChanges.enforceForks` site configuration option.
 
-If enabled, branches will be pushed to a fork within the user's namespace; for example, a changeset that opens a pull request against https://github.com/org/project would push the branch to https://github.com/user/project, creating the fork if necessary. Note that if a [global service account](../../batch_changes/how-tos/configuring_credentials#global-service-account-tokens) is in use, then the fork will be created in the namespace of the service account, **not** the user.
+If enabled, branches will be pushed to a fork within the user's namespace; for example, a changeset that opens a pull request against https://github.com/org/project would push the branch to https://github.com/user/project, creating the fork if necessary. Note that if a [global service account](../../batch_changes/how-tos/configuring_credentials.md#global-service-account-tokens) is in use, then the fork will be created in the namespace of the service account, **not** the user.
 
 ### Examples
 

--- a/doc/admin/config/batch_changes.md
+++ b/doc/admin/config/batch_changes.md
@@ -141,3 +141,21 @@ To retain webhook logs for one day:
 ### Encrypting webhook logs
 
 Webhook logs can be encrypted by specifying a `webhookLogKey` in the [on-disk database encryption site configuration](encryption.md).
+
+## Forks
+
+> NOTE: This feature was added in Sourcegraph 3.36.
+
+Sourcegraph can be configured to push branches created by Batch Changes to a fork of the repository, rather than the repository itself, by enabling the `batchChanges.enforceForks` site configuration option.
+
+If enabled, branches will be pushed to a fork within the user's namespace; for example, a changeset that opens a pull request against https://github.com/org/project would push the branch to https://github.com/user/project, creating the fork if necessary. Note that if a [global service account](../../batch_changes/how-tos/configuring_credentials#global-service-account-tokens) is in use, then the fork will be created in the namespace of the service account, **not** the user.
+
+### Examples
+
+To enable forks, update the site configuration to include:
+
+```json
+{
+  "batchChanges.enforceForks": true
+}
+```

--- a/doc/batch_changes/how-tos/configuring_credentials.md
+++ b/doc/batch_changes/how-tos/configuring_credentials.md
@@ -83,6 +83,8 @@ Global credentials are usable by all users of the Sourcegraph instance who have 
 
 Sourcegraph also uses the global service account to [track existing changesets](./tracking_existing_changesets.md) and keep changesets up to date. If no global service account token is set, we can currently fall back to the [token configured for the code host connection](#code-host-connection-tokens). However, this fallback will be deprecated in the future, so for this reason we highly recommend setting up a global service account.
 
+If [forks are enabled](../../admin/config/batch_changes.md#forks), then note that repositories will also be forked into the service account.
+
 ### Adding a token
 
 Adding a global service account token is done through the Batch Changes section of the site admin area:

--- a/doc/batch_changes/how-tos/publishing_changesets.md
+++ b/doc/batch_changes/how-tos/publishing_changesets.md
@@ -119,7 +119,7 @@ Then run the `src batch preview` command again, or `src batch apply` to immediat
 Publishing a changeset will:
 
 - Create a commit with the changes from the patches for that repository.
-- Push a branch using the branch name you defined in the batch spec with [`changesetTemplate.branch`](../references/batch_spec_yaml_reference.md#changesettemplate-branch).
+- Push a branch using the branch name you defined in the batch spec with [`changesetTemplate.branch`](../references/batch_spec_yaml_reference.md#changesettemplate-branch). If [forks are enabled](../../admin/config/batch_changes.md#forks), then the branch will be pushed to a fork of the repository.
 - Create a changeset (e.g., GitHub pull request) on the code host for review and merging.
 
 > NOTE: When pushing the branch Sourcegraph will use a **force push**. Make sure that the branch names are unused, otherwise previous commits will be overwritten.

--- a/doc/batch_changes/how-tos/site_admin_configuration.md
+++ b/doc/batch_changes/how-tos/site_admin_configuration.md
@@ -30,7 +30,14 @@
     </aside>
   </li>
   <li>
-    (Optional) <a href="../../../admin/config/batch_changes#rollout-windows">Control the rate at which Batch Changes will publish changesets on code hosts</a>.
+    Configure any desired optional features, such as:
+    <ul>
+      <li>
+        <a href="../../../admin/config/batch_changes#rollout-windows">Rollout windows</a>, which control the rate at which Batch Changes will publish changesets on code hosts.
+      </li>
+      <li>
+        <a href="../../../admin/config/batch_changes#forks">Forks</a>, which push branches created by Batch Changes onto forks of the upstream repository instead than the repository itself.
+    </ul>
   </li>
 </ol>
 
@@ -38,4 +45,3 @@
 #### Disable Batch Changes
 - [Disable Batch Changes](../explanations/permissions_in_batch_changes.md#disabling-batch-changes).
 - [Disable Batch Changes for non-site-admin users](../explanations/permissions_in_batch_changes.md#disabling-batch-changes-for-non-site-admin-users).
-


### PR DESCRIPTION
This is fairly minimal, as befits an admin-only site configuration option.

I did check the credential scopes as part of this work: no new scopes are required to fork repositories on any of our supported code hosts. (Which is honestly sort of terrifying, but I'm not arguing.)

Closes #17879.