### PR TITLE
CI: Install yarn deps prior to generate

### DIFF
--- a/dev/proto-generate.sh
+++ b/dev/proto-generate.sh
@@ -4,6 +4,12 @@ set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.." # cd to repo root dir
 
+echo "--- yarn in root"
+# mutex is necessary since CI runs various yarn installs in parallel
+yarn --mutex network --frozen-lockfile --network-timeout 60000
+
+echo "--- buf"
+
 GOBIN="$PWD/.bin" go install golang.org/x/tools/cmd/goimports
 GOBIN="$PWD/.bin" go install github.com/bufbuild/buf/cmd/buf
 GOBIN="$PWD/.bin" go install google.golang.org/protobuf/cmd/protoc-gen-go


### PR DESCRIPTION
70f8bcb introduced a go generate dependency on a TS generator for protobuf. This ensures that the dependency is installed prior to the task running.