### PR TITLE
Code Insights: Remove `allowSiteSettingsEdits` check in dashboard visibility tooltip

### DIFF
--- a/client/web/src/enterprise/insights/pages/dashboards/creation/components/insights-dashboard-creation-content/utils/get-global-subject-tooltip-text.ts
+++ b/client/web/src/enterprise/insights/pages/dashboards/creation/components/insights-dashboard-creation-content/utils/get-global-subject-tooltip-text.ts
@@ -8,11 +8,5 @@ export function getGlobalSubjectTooltipText(globalSubject: SettingsSiteSubject |
         return
     }
 
-    const globalSubjectAdminCheckMessage = globalSubject.viewerCanAdminister
-        ? undefined
-        : 'Only site admins can create global dashboards'
-
-    return globalSubject.allowSiteSettingsEdits
-        ? globalSubjectAdminCheckMessage
-        : 'The global subject cannot be edited since your Sourcegraph instance is using a separate settings file'
+    return !globalSubject.viewerCanAdminister ? 'Only site admins can create global dashboards' : undefined
 }


### PR DESCRIPTION
Follow up for https://github.com/sourcegraph/sourcegraph/pull/29572

This PR just removes `allowSiteSettingsEdits` checks in the dashboard tooltip copy since this check isn't needed for GQL API and it's ok not to have it in the setting cascade API either (submit operation will fail with appropriate error and error message UI in there). 