### PR TITLE
dev/ci: put backend, code-intel integration tests on baremetal

### DIFF
--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -339,6 +339,7 @@ func addDockerfileLint(pipeline *bk.Pipeline) {
 func backendIntegrationTests(candidateImageTag string) operations.Operation {
 	return func(pipeline *bk.Pipeline) {
 		pipeline.AddStep(":chains: Backend integration tests",
+			bk.Agent("queue", "baremetal"),
 			// Run tests against the candidate server image
 			bk.DependsOn(candidateImageStepKey("server")),
 			bk.Env("IMAGE",
@@ -423,6 +424,7 @@ func triggerUpdaterPipeline(pipeline *bk.Pipeline) {
 func codeIntelQA(candidateTag string) operations.Operation {
 	return func(p *bk.Pipeline) {
 		p.AddStep(":docker::brain: Code Intel QA",
+			bk.Agent("queue", "baremetal"),
 			// Run tests against the candidate server image
 			bk.DependsOn(candidateImageStepKey("server")),
 			bk.Env("CANDIDATE_VERSION", candidateTag),


### PR DESCRIPTION
We are seeing weird state issues where servers are starting up _already initialized_, somehow: https://buildkite.com/sourcegraph/sourcegraph/builds/125178#535b15a3-fb00-4dbb-85ee-0f5ab71ffb32/360-385

Only seems to show up on the non-e2e-agent-tests: https://sourcegraph.grafana.net/goto/xFEEwH1nk?orgId=1 - maybe it's something with the agents?