### PR TITLE
set default clock on codeMonitorStore

### DIFF
--- a/enterprise/internal/database/database.go
+++ b/enterprise/internal/database/database.go
@@ -29,7 +29,7 @@ type enterpriseDB struct {
 }
 
 func (edb *enterpriseDB) CodeMonitors() CodeMonitorStore {
-	return &codeMonitorStore{Store: basestore.NewWithHandle(edb.Handle())}
+	return &codeMonitorStore{Store: basestore.NewWithHandle(edb.Handle()), now: time.Now}
 }
 
 func (edb *enterpriseDB) Perms() PermsStore {


### PR DESCRIPTION
When using the enterprise DB store, the new CodeMonitors method was
returning a store without the injected clock set. This caused a panic
when creating a code monitor (and probably doing other operations as
well).

This is a very small portion of the code that is not covered by the existing tests, but it does demonstrate the need for full integration tests on code monitors.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
