### PR TITLE
monitoring: use streaming endpoint for search duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - Issue preventing searches from completing when certain patterns contain `@`. [#29489](https://github.com/sourcegraph/sourcegraph/pull/29489)
+- The grafana dashboard for "successful search request duration" reports the time for streaming search which is used by the browser. Previously it reported the GraphQL time which the browser no longer uses. [#29625](https://github.com/sourcegraph/sourcegraph/pull/29625)
 
 ### Removed
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -27,7 +27,7 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100000`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.99, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="browser",request_name!="CodeIntelSearch"}[5m])))`
+Query: `histogram_quantile(0.99, sum by (le)(rate(src_search_streaming_latency_seconds_bucket{source="browser"}[5m])))`
 
 </details>
 
@@ -46,7 +46,7 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100001`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="browser",request_name!="CodeIntelSearch"}[5m])))`
+Query: `histogram_quantile(0.90, sum by (le)(rate(src_search_streaming_latency_seconds_bucket{source="browser"}[5m])))`
 
 </details>
 
@@ -284,7 +284,7 @@ Query: `sum by (alert_type)(increase(src_graphql_search_response{status="alert",
 
 <br />
 
-### Frontend: Search API usage at a glance
+### Frontend: Search GraphQL API usage at a glance
 
 #### frontend: 99th_percentile_search_api_request_duration
 

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -23,7 +23,7 @@ func Frontend() *monitoring.Container {
 						{
 							Name:        "99th_percentile_search_request_duration",
 							Description: "99th percentile successful search request duration over 5m",
-							Query:       `histogram_quantile(0.99, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="browser",request_name!="CodeIntelSearch"}[5m])))`,
+							Query:       `histogram_quantile(0.99, sum by (le)(rate(src_search_streaming_latency_seconds_bucket{source="browser"}[5m])))`,
 
 							Warning: monitoring.Alert().GreaterOrEqual(20, nil),
 							Panel:   monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds),
@@ -38,7 +38,7 @@ func Frontend() *monitoring.Container {
 						{
 							Name:        "90th_percentile_search_request_duration",
 							Description: "90th percentile successful search request duration over 5m",
-							Query:       `histogram_quantile(0.90, sum by (le)(rate(src_graphql_field_seconds_bucket{type="Search",field="results",error="false",source="browser",request_name!="CodeIntelSearch"}[5m])))`,
+							Query:       `histogram_quantile(0.90, sum by (le)(rate(src_search_streaming_latency_seconds_bucket{source="browser"}[5m])))`,
 
 							Warning: monitoring.Alert().GreaterOrEqual(15, nil),
 							Panel:   monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds),
@@ -218,7 +218,7 @@ func Frontend() *monitoring.Container {
 				},
 			},
 			{
-				Title:  "Search API usage at a glance",
+				Title:  "Search GraphQL API usage at a glance",
 				Hidden: true,
 				Rows: []monitoring.Row{
 					{


### PR DESCRIPTION
The browser no longer goes via GraphQL so this metric was always empty.

There are still valid references to the GraphQL metric. These are for "GraphQL API" usage (which still exists) and for CodeIntel which still uses GraphQL.