### PR TITLE
ci: make server volume unique per build

### DIFF
--- a/dev/run-server-image.sh
+++ b/dev/run-server-image.sh
@@ -3,7 +3,8 @@
 
 IMAGE=${IMAGE:-sourcegraph/server:${TAG:-insiders}}
 URL=${URL:-"http://localhost:7080"}
-DATA=/tmp/sourcegraph
+IDENTIFIER=${BUILDKITE_JOB_ID:-$(openssl rand -hex 12)}
+DATA="/tmp/sourcegraph-$IDENTIFIER"
 
 echo "--- Checking for existing Sourcegraph instance at $URL"
 if curl --output /dev/null --silent --head --fail "$URL"; then

--- a/dev/run-server-image.sh
+++ b/dev/run-server-image.sh
@@ -3,7 +3,7 @@
 
 IMAGE=${IMAGE:-sourcegraph/server:${TAG:-insiders}}
 URL=${URL:-"http://localhost:7080"}
-IDENTIFIER=${BUILDKITE_JOB_ID:-$(openssl rand -hex 12)}
+IDENTIFIER="${BUILDKITE_JOB_ID:-$(openssl rand -hex 12)}"
 DATA="/tmp/sourcegraph-$IDENTIFIER"
 
 echo "--- Checking for existing Sourcegraph instance at $URL"
@@ -29,7 +29,7 @@ esac
 
 if [ "$clean" != "n" ] && [ "$clean" != "N" ]; then
   echo "--- Deleting $DATA"
-  rm -rf $DATA
+  rm -rf "$DATA"
 fi
 
 echo "--- Starting server ${IMAGE}"
@@ -38,6 +38,6 @@ docker run "$@" \
   --rm \
   -e SRC_LOG_LEVEL=dbug \
   -e DEBUG=t \
-  --volume $DATA/config:/etc/sourcegraph \
-  --volume $DATA/data:/var/opt/sourcegraph \
+  --volume "$DATA/config:/etc/sourcegraph" \
+  --volume "$DATA/data:/var/opt/sourcegraph" \
   "$IMAGE"

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -341,7 +341,6 @@ func backendIntegrationTests(candidateImageTag string) operations.Operation {
 		pipeline.AddStep(":chains: Backend integration tests",
 			// Run tests against the candidate server image
 			bk.DependsOn(candidateImageStepKey("server")),
-			bk.Parallelism(10),
 			bk.Env("IMAGE",
 				images.DevRegistryImage("server", candidateImageTag)),
 			bk.Cmd("dev/ci/integration/backend/run.sh"),
@@ -427,7 +426,6 @@ func codeIntelQA(candidateTag string) operations.Operation {
 			// Run tests against the candidate server image
 			bk.DependsOn(candidateImageStepKey("server")),
 			bk.Env("CANDIDATE_VERSION", candidateTag),
-			bk.Parallelism(10),
 			bk.Env("SOURCEGRAPH_BASE_URL", "http://127.0.0.1:7080"),
 			bk.Env("SOURCEGRAPH_SUDO_USER", "admin"),
 			bk.Env("TEST_USER_EMAIL", "test@sourcegraph.com"),

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -341,6 +341,7 @@ func backendIntegrationTests(candidateImageTag string) operations.Operation {
 		pipeline.AddStep(":chains: Backend integration tests",
 			// Run tests against the candidate server image
 			bk.DependsOn(candidateImageStepKey("server")),
+			bk.Parallelism(10),
 			bk.Env("IMAGE",
 				images.DevRegistryImage("server", candidateImageTag)),
 			bk.Cmd("dev/ci/integration/backend/run.sh"),
@@ -426,7 +427,7 @@ func codeIntelQA(candidateTag string) operations.Operation {
 			// Run tests against the candidate server image
 			bk.DependsOn(candidateImageStepKey("server")),
 			bk.Env("CANDIDATE_VERSION", candidateTag),
-
+			bk.Parallelism(10),
 			bk.Env("SOURCEGRAPH_BASE_URL", "http://127.0.0.1:7080"),
 			bk.Env("SOURCEGRAPH_SUDO_USER", "admin"),
 			bk.Env("TEST_USER_EMAIL", "test@sourcegraph.com"),


### PR DESCRIPTION
It passed twice, with with 10 runs for both codeintelQA and backend integrations https://buildkite.com/sourcegraph/sourcegraph/builds/125255#1a078d31-63d1-479b-82e9-f7343163634c