### PR TITLE
Add user setting to specify max number of references in panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Search contexts can now be defined with a restricted search query as an alternative to a specific list of repositories and revisions. This feature is _beta_ and may change in the following releases. Allowed filters: `repo`, `rev`, `file`, `lang`, `case`, `fork`, `visibility`. `OR`, `AND` expressions are also allowed. To enable this feature to all users, set `experimentalFeatures.searchContextsQuery` to true in global settings. You'll then see a "Create context" button from the search results page and a "Query" input field in the search contexts form. If you want revisions specified in these query based search contexts to be indexed, set `experimentalFeatures.search.index.query.contexts` to true in site configuration. [#29327](https://github.com/sourcegraph/sourcegraph/pull/29327)
 - More explicit Terms of Service and Privacy Policy consent has been added to Sourcegraph Server. [#28716](https://github.com/sourcegraph/sourcegraph/issues/28716)
 - Batch changes will be created on forks of the upstream repository if the new `batchChanges.enforceForks` site setting is enabled. [#17879](https://github.com/sourcegraph/sourcegraph/issues/17879)
+- Maximum number of references/definitions shown in panel can be adjusted in settings with `codeIntelligence.maxPanelResults`. If not set, a hardcoded limit of 500 was used. [#29629](https://github.com/sourcegraph/sourcegraph/29629)
 
 ### Changed
 

--- a/client/branded/src/components/panel/Panel.tsx
+++ b/client/branded/src/components/panel/Panel.tsx
@@ -52,6 +52,11 @@ export interface PanelViewWithComponent extends PanelViewData {
      * The location provider whose results to render in the panel view.
      */
     locationProvider?: Observable<MaybeLoadingResult<Location[]>>
+    /**
+     * Maximum number of results to show from locationProvider. If not set,
+     * MAXIMUM_LOCATION_RESULTS will be used.
+     */
+    maxLocationResults?: number
 
     /**
      * The React element to render in the panel view.

--- a/client/branded/src/components/panel/views/PanelView.tsx
+++ b/client/branded/src/components/panel/views/PanelView.tsx
@@ -38,6 +38,7 @@ export const PanelView = React.memo<Props>(props => (
             <HierarchicalLocationsView
                 location={props.location}
                 locations={props.panelView.locationProvider}
+                maxLocationResults={props.panelView.maxLocationResults}
                 defaultGroup={props.repoName}
                 isLightTheme={props.isLightTheme}
                 fetchHighlightedFileLineRanges={props.fetchHighlightedFileLineRanges}

--- a/client/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/client/web/src/repo/blob/panel/BlobPanel.tsx
@@ -102,7 +102,7 @@ export function useBlobPanelViews({
                         selector: null,
                         priority,
 
-                        maxLocationResults: id === 'references' ? maxReferences : undefined,
+                        maxLocationResults: id === 'references' || id === 'def' ? maxReferences : undefined,
                         // This disable directive is necessary because TypeScript is not yet smart
                         // enough to know that (typeof params & typeof extraParams) is P.
                         //
@@ -205,7 +205,7 @@ export function useBlobPanelViews({
 
 function maxReferencesFromSettings(settingsCascade: SettingsCascadeOrError<Settings>): number | undefined {
     if (settingsCascade.final && !isErrorLike(settingsCascade.final)) {
-        return settingsCascade.final['codeIntelligence.maxReferences'] as number
+        return settingsCascade.final['codeIntelligence.maxPanelResults'] as number
     }
     return undefined
 }

--- a/client/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/client/web/src/repo/blob/panel/BlobPanel.tsx
@@ -5,18 +5,20 @@ import { map, mapTo, switchMap, tap } from 'rxjs/operators'
 
 import { BuiltinPanelView, useBuiltinPanelViews } from '@sourcegraph/branded/src/components/panel/Panel'
 import { MaybeLoadingResult } from '@sourcegraph/codeintellify'
+import { isErrorLike } from '@sourcegraph/common'
 import * as clientType from '@sourcegraph/extension-api-types'
 import { wrapRemoteObservable } from '@sourcegraph/shared/src/api/client/api/common'
 import { ReferenceParameters, TextDocumentPositionParameters } from '@sourcegraph/shared/src/api/protocol'
 import { Activation, ActivationProps } from '@sourcegraph/shared/src/components/activation/Activation'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { Scalars } from '@sourcegraph/shared/src/graphql-operations'
+import { Settings, SettingsCascadeOrError, SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { AbsoluteRepoFile, ModeSpec, parseQueryAndHash, UIPositionSpec } from '@sourcegraph/shared/src/util/url'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 
 import { RepoRevisionSidebarCommits } from '../../RepoRevisionSidebarCommits'
 
-interface Props extends AbsoluteRepoFile, ModeSpec, ExtensionsControllerProps, ActivationProps {
+interface Props extends AbsoluteRepoFile, ModeSpec, SettingsCascadeProps, ExtensionsControllerProps, ActivationProps {
     location: H.Location
     history: H.History
     repoID: Scalars['ID']
@@ -54,6 +56,7 @@ export function useBlobPanelViews({
     repoID,
     location,
     history,
+    settingsCascade,
 }: Props): void {
     const subscriptions = useMemo(() => new Subscription(), [])
 
@@ -76,6 +79,8 @@ export function useBlobPanelViews({
         )
     )
 
+    const maxReferences = maxReferencesFromSettings(settingsCascade)
+
     // Creates source for definition and reference panels
     const createLocationProvider = useCallback(
         <P extends TextDocumentPositionParameters>(
@@ -97,6 +102,7 @@ export function useBlobPanelViews({
                         selector: null,
                         priority,
 
+                        maxLocationResults: id === 'references' ? maxReferences : undefined,
                         // This disable directive is necessary because TypeScript is not yet smart
                         // enough to know that (typeof params & typeof extraParams) is P.
                         //
@@ -114,7 +120,7 @@ export function useBlobPanelViews({
                     }
                 })
             ),
-        [activeCodeEditorPositions]
+        [activeCodeEditorPositions, maxReferences]
     )
 
     // Source for history panel
@@ -195,4 +201,11 @@ export function useBlobPanelViews({
     )
 
     useEffect(() => () => subscriptions.unsubscribe(), [subscriptions])
+}
+
+function maxReferencesFromSettings(settingsCascade: SettingsCascadeOrError<Settings>): number | undefined {
+    if (settingsCascade.final && !isErrorLike(settingsCascade.final)) {
+        return settingsCascade.final['codeIntelligence.maxReferences'] as number
+    }
+    return undefined
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1466,6 +1466,8 @@ type Settings struct {
 	CodeIntelligenceAutoIndexPopularRepoLimit int `json:"codeIntelligence.autoIndexPopularRepoLimit,omitempty"`
 	// CodeIntelligenceAutoIndexRepositoryGroups description: A list of search.repositoryGroups that have auto-indexing enabled.
 	CodeIntelligenceAutoIndexRepositoryGroups []string `json:"codeIntelligence.autoIndexRepositoryGroups,omitempty"`
+	// CodeIntelligenceMaxReferences description: Up to this number of references are shown in the references panel.
+	CodeIntelligenceMaxReferences int `json:"codeIntelligence.maxReferences,omitempty"`
 	// ExperimentalFeatures description: Experimental features to enable or disable. Features that are now enabled by default are marked as deprecated.
 	ExperimentalFeatures *SettingsExperimentalFeatures `json:"experimentalFeatures,omitempty"`
 	// Extensions description: The Sourcegraph extensions to use. Enable an extension by adding a property `"my/extension": true` (where `my/extension` is the extension ID). Override a previously enabled extension and disable it by setting its value to `false`.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1466,8 +1466,8 @@ type Settings struct {
 	CodeIntelligenceAutoIndexPopularRepoLimit int `json:"codeIntelligence.autoIndexPopularRepoLimit,omitempty"`
 	// CodeIntelligenceAutoIndexRepositoryGroups description: A list of search.repositoryGroups that have auto-indexing enabled.
 	CodeIntelligenceAutoIndexRepositoryGroups []string `json:"codeIntelligence.autoIndexRepositoryGroups,omitempty"`
-	// CodeIntelligenceMaxReferences description: Up to this number of references are shown in the references panel.
-	CodeIntelligenceMaxReferences int `json:"codeIntelligence.maxReferences,omitempty"`
+	// CodeIntelligenceMaxPanelResults description: Maximum number of references/definitions (or other code intelligence results provided by extensions) shown in the panel. If not set a default value will be used to ensure best performance.
+	CodeIntelligenceMaxPanelResults int `json:"codeIntelligence.maxPanelResults,omitempty"`
 	// ExperimentalFeatures description: Experimental features to enable or disable. Features that are now enabled by default are marked as deprecated.
 	ExperimentalFeatures *SettingsExperimentalFeatures `json:"experimentalFeatures,omitempty"`
 	// Extensions description: The Sourcegraph extensions to use. Enable an extension by adding a property `"my/extension": true` (where `my/extension` is the extension ID). Override a previously enabled extension and disable it by setting its value to `false`.

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -299,6 +299,10 @@
       "minimum": 0,
       "default": 0
     },
+    "codeIntelligence.maxReferences": {
+      "description": "Maximum number of references shown in the references panel.",
+      "type": "integer"
+    },
     "search.contextLines": {
       "description": "The default number of lines to show as context below and above search results. Default is 1.",
       "type": "integer",

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -299,8 +299,8 @@
       "minimum": 0,
       "default": 0
     },
-    "codeIntelligence.maxReferences": {
-      "description": "Maximum number of references shown in the references panel.",
+    "codeIntelligence.maxPanelResults": {
+      "description": "Maximum number of references/definitions (or other code intelligence results provided by extensions) shown in the panel. If not set a default value will be used to ensure best performance.",
       "type": "integer"
     },
     "search.contextLines": {


### PR DESCRIPTION
This is a first step towards fixing #28480 by allowing users to overwrite how many references are shown in the panel.

Also tagging @sourcegraph/frontend-platform here because I touched some components here.

https://user-images.githubusercontent.com/1185253/149158840-76b76c3e-4af2-441c-8507-d23285e8cf54.mp4


