### PR TITLE
honeycomb: slice-wrap values for multiple insert of same key

### DIFF
--- a/internal/honey/slice_wrapper.go
+++ b/internal/honey/slice_wrapper.go
@@ -1,0 +1,42 @@
+package honey
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// wrapper type for interface{} slice that marshals to a plain string
+// in which values are comma separated and strings are unquoted aka
+// []string{"asdf", "fdsa"} would render as the JSON string "asdf, fdsa".
+type sliceWrapper []interface{}
+
+func (s sliceWrapper) MarshalJSON() ([]byte, error) {
+	if s == nil || len(s) == 0 {
+		return nil, nil
+	}
+
+	var b bytes.Buffer
+
+	for _, val := range (s)[:len(s)-1] {
+		out, err := json.Marshal(val)
+		if err != nil {
+			return nil, err
+		}
+		if out[0] == '"' {
+			out = out[1 : len(out)-1]
+		}
+		b.Write(out)
+		b.Write([]byte(", "))
+	}
+
+	out, err := json.Marshal(s[len(s)-1])
+	if err != nil {
+		return nil, err
+	}
+	if out[0] == '"' {
+		out = out[1 : len(out)-1]
+	}
+	b.Write(out)
+
+	return json.Marshal(b.String())
+}


### PR DESCRIPTION
Currently, if `AddField` n co are called multiple times for the same key, only the last value remains. This can happen using the `observation` package with the traceLogger. 

With this PR, if a key is added multiple times, it will be wrapped in a slice after the second insert and that slice appended to thereafter. 

We apply a custom JSON marshalling scheme for (subjectively) optimal representation in Honeycomb. Image 1 shows what it would look like normally, Image 2 shows the custom marshalling:

![image](https://user-images.githubusercontent.com/18282288/149207285-125eba66-22b7-4801-921b-00c5b9684acd.png)
![image](https://user-images.githubusercontent.com/18282288/149207313-cfcbfd6d-3155-4819-9332-3284c88f8819.png)
