### PR TITLE
Fix data key for FE chart links object

### DIFF
--- a/client/web/src/enterprise/insights/core/backend/core/api/get-search-insight-content/get-search-insight-content.ts
+++ b/client/web/src/enterprise/insights/core/backend/core/api/get-search-insight-content/get-search-insight-content.ts
@@ -162,7 +162,7 @@ export async function getInsightContent(inputs: GetInsightContentInput): Promise
 
                     url.searchParams.set('q', diffQuery)
 
-                    return [date, url.href]
+                    return [date.getTime(), url.href]
                 })
             ),
         })),


### PR DESCRIPTION
Follow up for https://github.com/sourcegraph/sourcegraph/pull/29587

Apparently, we use timestamps as keys for x-axis. We should the sample date format as a key for the link URL map. 