### PR TITLE
dev/ci: fix commit encoding in versions

### DIFF
--- a/dev/sg/internal/images/images_test.go
+++ b/dev/sg/internal/images/images_test.go
@@ -17,11 +17,11 @@ func TestParseTag(t *testing.T) {
 	}{
 		{
 			"base",
-			"12345_2021-01-02_abcdefg",
+			"12345_2021-01-02_abcdefghijkl",
 			&SgImageTag{
 				buildNum:  12345,
 				date:      "2021-01-02",
-				shortSHA1: "abcdefg",
+				shortSHA1: "abcdefghijkl",
 			},
 			false,
 		},
@@ -57,13 +57,13 @@ func Test_findLatestTag(t *testing.T) {
 	}{
 		{
 			"base",
-			[]string{"v3.25.2", "12345_2022-01-01_asbcefg"},
-			"12345_2022-01-01_asbcefg",
+			[]string{"v3.25.2", "12345_2022-01-01_abcdefghijkl"},
+			"12345_2022-01-01_abcdefghijkl",
 		},
 		{
 			"higher_build_first",
-			[]string{"99981_2022-01-15_999999a", "99982_2022-01-29_999999b"},
-			"99982_2022-01-29_999999b",
+			[]string{"99981_2022-01-15_999999a", "99982_2022-01-29_abcdefghijkl"},
+			"99982_2022-01-29_abcdefghijkl",
 		},
 	}
 	for _, tt := range tests {

--- a/enterprise/dev/ci/internal/ci/config.go
+++ b/enterprise/dev/ci/internal/ci/config.go
@@ -93,10 +93,10 @@ func NewConfig(now time.Time) Config {
 	case runType.Is(MainBranch):
 		// This tag is used for deploying continuously. Only ever generate this on the
 		// main branch.
-		tag = fmt.Sprintf("%05d_%10s_%7s", buildNumber, now.Format("2006-01-02"), commit)
+		tag = fmt.Sprintf("%05d_%10s_%.7s", buildNumber, now.Format("2006-01-02"), commit)
 	default:
 		// Encode branch inside build tag by default.
-		tag = fmt.Sprintf("%s_%05d_%10s_%7s", strings.ReplaceAll(branch, "/", "-"), buildNumber, now.Format("2006-01-02"), commit)
+		tag = fmt.Sprintf("%s_%05d_%10s_%.7s", strings.ReplaceAll(branch, "/", "-"), buildNumber, now.Format("2006-01-02"), commit)
 	}
 	if runType.Is(ImagePatch, ImagePatchNoTest, ExecutorPatchNoTest) {
 		// Add additional patch suffix

--- a/enterprise/dev/ci/internal/ci/config.go
+++ b/enterprise/dev/ci/internal/ci/config.go
@@ -93,10 +93,10 @@ func NewConfig(now time.Time) Config {
 	case runType.Is(MainBranch):
 		// This tag is used for deploying continuously. Only ever generate this on the
 		// main branch.
-		tag = fmt.Sprintf("%05d_%10s_%.7s", buildNumber, now.Format("2006-01-02"), commit)
+		tag = fmt.Sprintf("%05d_%10s_%.12s", buildNumber, now.Format("2006-01-02"), commit)
 	default:
 		// Encode branch inside build tag by default.
-		tag = fmt.Sprintf("%s_%05d_%10s_%.7s", strings.ReplaceAll(branch, "/", "-"), buildNumber, now.Format("2006-01-02"), commit)
+		tag = fmt.Sprintf("%s_%05d_%10s_%.12s", strings.ReplaceAll(branch, "/", "-"), buildNumber, now.Format("2006-01-02"), commit)
 	}
 	if runType.Is(ImagePatch, ImagePatchNoTest, ExecutorPatchNoTest) {
 		// Add additional patch suffix


### PR DESCRIPTION
from @daxmc99 : 

> Apparently, %7s does nothing but %.7s restricts the printing to the first 7 chars