### PR TITLE
fix a panic caused by a new format from sourcegraph __version returning the full revhash

### DIFF
--- a/dev/sg/live.go
+++ b/dev/sg/live.go
@@ -110,7 +110,6 @@ func printDeployedVersion(e environment) error {
 
 		var emoji = "  "
 		var style = output.StylePending
-
 		if sha[0:len(buildSha)] == buildSha {
 			emoji = "🚀"
 			style = output.StyleLogo

--- a/dev/sg/live.go
+++ b/dev/sg/live.go
@@ -74,7 +74,7 @@ func printDeployedVersion(e environment) error {
 	}
 
 	buildDate := elems[1]
-	buildSha := elems[2][0:7]
+	buildSha := elems[2]
 
 	pending = stdout.Out.Pending(output.Line("", output.StylePending, "Running 'git fetch' to update list of commits..."))
 	_, err = run.GitCmd("fetch", "-q")
@@ -84,7 +84,7 @@ func printDeployedVersion(e environment) error {
 	}
 	pending.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Done updating list of commits"))
 
-	log, err := run.GitCmd("log", "--oneline", "-n", "20", `--pretty=format:%h|%cr|%an|%s`, "origin/main")
+	log, err := run.GitCmd("log", "--oneline", "-n", "20", `--pretty=format:%H|%cr|%an|%s`, "origin/main")
 	if err != nil {
 		pending.Complete(output.Linef(output.EmojiFailure, output.StyleWarning, "Failed: %s", err))
 		return err
@@ -117,7 +117,7 @@ func printDeployedVersion(e environment) error {
 			shaFound = true
 		}
 
-		line := output.Linef(emoji, style, "%s (%s, %s): %s", sha, timestamp, author, message)
+		line := output.Linef(emoji, style, "%s (%s, %s): %s", sha[0:7], timestamp, author, message)
 		stdout.Out.WriteLine(line)
 	}
 

--- a/dev/sg/live.go
+++ b/dev/sg/live.go
@@ -74,7 +74,7 @@ func printDeployedVersion(e environment) error {
 	}
 
 	buildDate := elems[1]
-	buildSha := elems[2]
+	buildSha := elems[2][0:7]
 
 	pending = stdout.Out.Pending(output.Line("", output.StylePending, "Running 'git fetch' to update list of commits..."))
 	_, err = run.GitCmd("fetch", "-q")
@@ -110,6 +110,7 @@ func printDeployedVersion(e environment) error {
 
 		var emoji = "  "
 		var style = output.StylePending
+
 		if sha[0:len(buildSha)] == buildSha {
 			emoji = "🚀"
 			style = output.StyleLogo


### PR DESCRIPTION
Return the full hash for the revision list, but only display the first 7 digits.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
