### PR TITLE
dev: run server cleanup after run, use stable dir for local use

### DIFF
--- a/dev/ci/integration/run-integration.sh
+++ b/dev/ci/integration/run-integration.sh
@@ -15,6 +15,9 @@ fi
 
 URL="http://localhost:7080"
 
+# In CI, provide a directory unique to this job
+export DATA="/tmp/sourcegraph-data-${BUILDKITE_JOB_ID:-$(openssl rand -hex 12)}"
+
 function docker_cleanup() {
   echo "--- docker cleanup"
   if [[ $(docker ps -aq | wc -l) -gt 0 ]]; then
@@ -26,6 +29,9 @@ function docker_cleanup() {
     docker rmi -f $(docker images -q)
   fi
   docker volume prune -f
+
+  echo "--- Deleting $DATA"
+  rm -rf "$DATA"
 }
 
 # Do a pre-run cleanup

--- a/dev/ci/integration/upgrade/test.sh
+++ b/dev/ci/integration/upgrade/test.sh
@@ -8,12 +8,18 @@ set -ex
 
 URL="${1:-"http://localhost:7080"}"
 
-docker_logs() {
+# In CI, provide a directory unique to this job
+export DATA="/tmp/sourcegraph-data-${BUILDKITE_JOB_ID:-$(openssl rand -hex 12)}"
+
+cleanup() {
   echo "--- dump server logs"
   docker logs --timestamps "$CONTAINER" >"$root_dir/$CONTAINER.log" 2>&1
+
+  echo "--- Deleting $DATA"
+  rm -rf "$DATA"
 }
 
-trap docker_logs EXIT
+trap cleanup EXIT
 
 # Run and initialize an old Sourcegraph release
 echo "--- start sourcegraph $MINIMUM_UPGRADEABLE_VERSION"

--- a/dev/run-server-image.sh
+++ b/dev/run-server-image.sh
@@ -3,8 +3,9 @@
 
 IMAGE=${IMAGE:-sourcegraph/server:${TAG:-insiders}}
 URL=${URL:-"http://localhost:7080"}
-IDENTIFIER="${BUILDKITE_JOB_ID:-$(openssl rand -hex 12)}"
-DATA="/tmp/sourcegraph-$IDENTIFIER"
+
+# In CI, provide a directory unique to this job
+DATA="/tmp/sourcegraph-${BUILDKITE_JOB_ID:-"server"}"
 
 echo "--- Checking for existing Sourcegraph instance at $URL"
 if curl --output /dev/null --silent --head --fail "$URL"; then

--- a/dev/run-server-image.sh
+++ b/dev/run-server-image.sh
@@ -3,9 +3,7 @@
 
 IMAGE=${IMAGE:-sourcegraph/server:${TAG:-insiders}}
 URL=${URL:-"http://localhost:7080"}
-
-# In CI, provide a directory unique to this job
-DATA="/tmp/sourcegraph-${BUILDKITE_JOB_ID:-"server"}"
+DATA=${DATA:-"/tmp/sourcegraph-data"}
 
 echo "--- Checking for existing Sourcegraph instance at $URL"
 if curl --output /dev/null --silent --head --fail "$URL"; then
@@ -28,14 +26,9 @@ case "$CLEAN" in
     ;;
 esac
 
-function clean_data() {
+if [ "$clean" != "n" ] && [ "$clean" != "N" ]; then
   echo "--- Deleting $DATA"
   rm -rf "$DATA"
-}
-
-if [ "$clean" != "n" ] && [ "$clean" != "N" ]; then
-  clean_data
-  trap clean_data EXIT
 fi
 
 echo "--- Starting server ${IMAGE}"

--- a/dev/run-server-image.sh
+++ b/dev/run-server-image.sh
@@ -27,9 +27,14 @@ case "$CLEAN" in
     ;;
 esac
 
-if [ "$clean" != "n" ] && [ "$clean" != "N" ]; then
+function clean_data() {
   echo "--- Deleting $DATA"
   rm -rf "$DATA"
+}
+
+if [ "$clean" != "n" ] && [ "$clean" != "N" ]; then
+  clean_data
+  trap clean_data EXIT
 fi
 
 echo "--- Starting server ${IMAGE}"


### PR DESCRIPTION
Because we generate a random dir these dirs no longer get cleaned up after the job, and we risk potentially using up a lot of disk.

- tests now configure dirs for buildkite runs, instead of run-server-image
- tests now clean up the target dir before _and_ after the script
- local usage of run-server-image no longer uses a random dir
