### PR TITLE
user invites: web: add "invite by sending link" functionality to welcome page

### DIFF
--- a/client/web/src/auth/CloudSignUpPage.module.scss
+++ b/client/web/src/auth/CloudSignUpPage.module.scss
@@ -64,10 +64,20 @@
     position: relative;
 }
 
-.page-heading {
+.page-heading,
+.page-heading-invited-by {
     margin: 0;
     padding-top: 1.5rem;
     padding-bottom: 1rem;
+}
+
+.page-heading-invited-by {
+    font-weight: normal;
+    margin-top: 2rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid var(--border-color);
+    margin-bottom: 1.5rem;
+    margin-top: -1.5rem;
 }
 
 .contents {
@@ -89,7 +99,8 @@
     margin-bottom: 2rem;
 }
 
-.sign-up-wrapper {
+.sign-up-wrapper,
+.sign-up-wrapper-invited-by {
     position: absolute;
     top: -7.5rem;
     right: 0;
@@ -103,6 +114,10 @@
         position: static;
         margin-top: 2rem;
     }
+}
+
+.sign-up-wrapper-invited-by {
+    top: -3.5rem;
 }
 
 .sign-up-button {
@@ -155,4 +170,9 @@
 .helper-text {
     font-size: 0.875rem;
     line-height: 1.5;
+}
+
+.avatar {
+    width: 3rem !important;
+    height: 3rem !important;
 }

--- a/client/web/src/auth/CloudSignUpPage.module.scss
+++ b/client/web/src/auth/CloudSignUpPage.module.scss
@@ -73,7 +73,6 @@
 
 .page-heading-invited-by {
     font-weight: normal;
-    margin-top: 2rem;
     padding-bottom: 1.5rem;
     border-bottom: 1px solid var(--border-color);
     margin-bottom: 1.5rem;

--- a/client/web/src/auth/CloudSignUpPage.tsx
+++ b/client/web/src/auth/CloudSignUpPage.tsx
@@ -71,14 +71,11 @@ export const CloudSignUpPage: React.FunctionComponent<Props> = ({
     const title = sourceIsValid ? SourceToTitleMap[source as CloudSignUpSource] : defaultTitle
 
     const invitedBy = queryWithUseEmailToggled.get('invitedBy')
-    const { data } = useQuery<UserAreaUserProfileResult, UserAreaUserProfileVariables>(
-        USER_AREA_USER_PROFILE,
-        {
-            variables: { username: invitedBy || '', siteAdmin: false },
-            skip: !invitedBy,
-        }
-    )
-    const invitedByUser = data?.user;
+    const { data } = useQuery<UserAreaUserProfileResult, UserAreaUserProfileVariables>(USER_AREA_USER_PROFILE, {
+        variables: { username: invitedBy || '', siteAdmin: false },
+        skip: !invitedBy,
+    })
+    const invitedByUser = data?.user
 
     const logEvent = (type: AuthProvider['serviceType']): void => {
         const eventType = type === 'builtin' ? 'form' : type
@@ -165,24 +162,42 @@ export const CloudSignUpPage: React.FunctionComponent<Props> = ({
                     </div>
                 </div>
 
-                {!invitedBy && <div className={styles.limitWidth}>
-                    <h2 className={classNames('d-flex', 'align-items-center', styles.pageHeading)}>
-                        {title}
-                    </h2>
-                </div>}
+                {!invitedBy && (
+                    <div className={styles.limitWidth}>
+                        <h2 className={classNames('d-flex', 'align-items-center', styles.pageHeading)}>{title}</h2>
+                    </div>
+                )}
             </header>
 
             <div className={classNames(styles.contents, styles.limitWidth)}>
                 <div className={styles.contentsLeft}>
-                    {invitedByUser ? <>
-                        <h2 className={classNames('d-flex', 'align-items-center', invitedByUser ? styles.pageHeadingInvitedBy : styles.pageHeading)}>
-                            {invitedByUser ? <>
-                                <UserAvatar className={classNames('icon-inline', 'mr-3', styles.avatar)} user={invitedByUser} />
-                                <strong className="mr-1">{invitedBy}</strong> has invited you to join Sourcegraph
-                            </> : title}
-                        </h2>
-                        With a Sourcegraph account, you can:
-                    </> : 'With a Sourcegraph account, you can also:'}
+                    {invitedByUser ? (
+                        <>
+                            <h2
+                                className={classNames(
+                                    'd-flex',
+                                    'align-items-center',
+                                    invitedByUser ? styles.pageHeadingInvitedBy : styles.pageHeading
+                                )}
+                            >
+                                {invitedByUser ? (
+                                    <>
+                                        <UserAvatar
+                                            className={classNames('icon-inline', 'mr-3', styles.avatar)}
+                                            user={invitedByUser}
+                                        />
+                                        <strong className="mr-1">{invitedBy}</strong> has invited you to join
+                                        Sourcegraph
+                                    </>
+                                ) : (
+                                    title
+                                )}
+                            </h2>
+                            With a Sourcegraph account, you can:
+                        </>
+                    ) : (
+                        'With a Sourcegraph account, you can also:'
+                    )}
                     <ul className={styles.featureList}>
                         <li>
                             <div className="d-flex align-items-center">

--- a/client/web/src/auth/CloudSignUpPage.tsx
+++ b/client/web/src/auth/CloudSignUpPage.tsx
@@ -3,13 +3,17 @@ import ChevronLeftIcon from 'mdi-react/ChevronLeftIcon'
 import React from 'react'
 import { Link, useLocation } from 'react-router-dom'
 
+import { useQuery } from '@sourcegraph/shared/src/graphql/graphql'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { ProductStatusBadge } from '@sourcegraph/wildcard'
 
 import { BrandLogo } from '../components/branding/BrandLogo'
 import { FeatureFlagProps } from '../featureFlags/featureFlags'
+import { UserAreaUserProfileResult, UserAreaUserProfileVariables } from '../graphql-operations'
 import { AuthProvider, SourcegraphContext } from '../jscontext'
+import { USER_AREA_USER_PROFILE } from '../user/area/UserArea'
+import { UserAvatar } from '../user/UserAvatar'
 
 import styles from './CloudSignUpPage.module.scss'
 import { ExternalsAuth } from './ExternalsAuth'
@@ -65,6 +69,16 @@ export const CloudSignUpPage: React.FunctionComponent<Props> = ({
     const sourceIsValid = source && Object.keys(SourceToTitleMap).includes(source)
     const defaultTitle = isSignupOptimised ? SourceToTitleMap.OptimisedContext : SourceToTitleMap.Context // Use Context as default
     const title = sourceIsValid ? SourceToTitleMap[source as CloudSignUpSource] : defaultTitle
+
+    const invitedBy = queryWithUseEmailToggled.get('invitedBy')
+    const { data } = useQuery<UserAreaUserProfileResult, UserAreaUserProfileVariables>(
+        USER_AREA_USER_PROFILE,
+        {
+            variables: { username: invitedBy || '', siteAdmin: false },
+            skip: !invitedBy,
+        }
+    )
+    const invitedByUser = data?.user;
 
     const logEvent = (type: AuthProvider['serviceType']): void => {
         const eventType = type === 'builtin' ? 'form' : type
@@ -151,14 +165,24 @@ export const CloudSignUpPage: React.FunctionComponent<Props> = ({
                     </div>
                 </div>
 
-                <div className={styles.limitWidth}>
-                    <h2 className={styles.pageHeading}>{title}</h2>
-                </div>
+                {!invitedBy && <div className={styles.limitWidth}>
+                    <h2 className={classNames('d-flex', 'align-items-center', styles.pageHeading)}>
+                        {title}
+                    </h2>
+                </div>}
             </header>
 
             <div className={classNames(styles.contents, styles.limitWidth)}>
                 <div className={styles.contentsLeft}>
-                    With a Sourcegraph account, you can also:
+                    {invitedByUser ? <>
+                        <h2 className={classNames('d-flex', 'align-items-center', invitedByUser ? styles.pageHeadingInvitedBy : styles.pageHeading)}>
+                            {invitedByUser ? <>
+                                <UserAvatar className={classNames('icon-inline', 'mr-3', styles.avatar)} user={invitedByUser} />
+                                <strong className="mr-1">{invitedBy}</strong> has invited you to join Sourcegraph
+                            </> : title}
+                        </h2>
+                        With a Sourcegraph account, you can:
+                    </> : 'With a Sourcegraph account, you can also:'}
                     <ul className={styles.featureList}>
                         <li>
                             <div className="d-flex align-items-center">
@@ -179,7 +203,7 @@ export const CloudSignUpPage: React.FunctionComponent<Props> = ({
                     />
                 </div>
 
-                <div className={styles.signUpWrapper}>
+                <div className={invitedBy ? styles.signUpWrapperInvitedBy : styles.signUpWrapper}>
                     <h2>Create a free account</h2>
                     {isSignupOptimised ? renderSignupOptimized() : renderAuthMethod()}
 

--- a/client/web/src/auth/PostSignUpPage.tsx
+++ b/client/web/src/auth/PostSignUpPage.tsx
@@ -138,40 +138,44 @@ export const PostSignUpPage: FunctionComponent<PostSignUpPage> = ({
                     lessPadding={false}
                     className="text-left"
                     body={
-                        <div className={classNames('pb-1', styles.container)}>
-                            {hasErrors && (
-                                <div className="alert alert-danger mb-4" role="alert">
-                                    Sorry, something went wrong. Try refreshing the page or{' '}
-                                    <Link to={PageRoutes.Search}>skip to code search</Link>.
-                                </div>
-                            )}
-                            <h2>Get started with Sourcegraph</h2>
-                            <p className="text-muted pb-3">
-                                Three quick steps to add your repositories and get searching with Sourcegraph
-                            </p>
-                            <div className="mt-4 pb-3">
+                        <div className='pb-1 d-flex flex-column align-items-center w-100'>
+                            <div className={styles.container}>
+                                {hasErrors && (
+                                    <div className="alert alert-danger mb-4" role="alert">
+                                        Sorry, something went wrong. Try refreshing the page or{' '}
+                                        <Link to={PageRoutes.Search}>skip to code search</Link>.
+                                    </div>
+                                )}
+                                <h2>Get started with Sourcegraph</h2>
+                                <p className="text-muted pb-3">
+                                    Three quick steps to add your repositories and get searching with Sourcegraph
+                                </p>
+                            </div>
+                            <div className='mt-4 pb-3 d-flex flex-column align-items-center'>
                                 <Steps initialStep={1}>
-                                    <StepList numeric={true}>
+                                    <StepList numeric={true} className={styles.container}>
                                         <Step borderColor="purple">Connect with code hosts</Step>
                                         <Step borderColor="blue">Add repositories</Step>
                                         <Step borderColor="orange">Start searching</Step>
                                     </StepList>
                                     <StepPanels>
                                         <StepPanel>
-                                            <CodeHostsConnection
-                                                user={user}
-                                                onNavigation={(called: boolean) => {
-                                                    isOAuthCall.current = called
-                                                }}
-                                                loading={loadingServices}
-                                                onError={onError}
-                                                externalServices={externalServices}
-                                                context={context}
-                                                refetch={refetchExternalServices}
-                                            />
+                                            <div className={styles.container}>
+                                                <CodeHostsConnection
+                                                    user={user}
+                                                    onNavigation={(called: boolean) => {
+                                                        isOAuthCall.current = called
+                                                    }}
+                                                    loading={loadingServices}
+                                                    onError={onError}
+                                                    externalServices={externalServices}
+                                                    context={context}
+                                                    refetch={refetchExternalServices}
+                                                />
+                                        </div>
                                         </StepPanel>
                                         <StepPanel>
-                                            <div className="mt-5">
+                                            <div className={classNames('mt-5', styles.container)}>
                                                 <h3>Add repositories</h3>
                                                 <p className="text-muted mb-4">
                                                     Choose repositories you own or collaborate on from your code hosts.
@@ -197,6 +201,7 @@ export const PostSignUpPage: FunctionComponent<PostSignUpPage> = ({
                                         </StepPanel>
                                         <StepPanel>
                                             <StartSearching
+                                                className={styles.container}
                                                 user={user}
                                                 repoSelectionMode={repoSelectionMode}
                                                 onUserExternalServicesOrRepositoriesUpdate={

--- a/client/web/src/auth/PostSignUpPage.tsx
+++ b/client/web/src/auth/PostSignUpPage.tsx
@@ -138,7 +138,7 @@ export const PostSignUpPage: FunctionComponent<PostSignUpPage> = ({
                     lessPadding={false}
                     className="text-left"
                     body={
-                        <div className='pb-1 d-flex flex-column align-items-center w-100'>
+                        <div className="pb-1 d-flex flex-column align-items-center w-100">
                             <div className={styles.container}>
                                 {hasErrors && (
                                     <div className="alert alert-danger mb-4" role="alert">
@@ -151,7 +151,7 @@ export const PostSignUpPage: FunctionComponent<PostSignUpPage> = ({
                                     Three quick steps to add your repositories and get searching with Sourcegraph
                                 </p>
                             </div>
-                            <div className='mt-4 pb-3 d-flex flex-column align-items-center'>
+                            <div className="mt-4 pb-3 d-flex flex-column align-items-center">
                                 <Steps initialStep={1}>
                                     <StepList numeric={true} className={styles.container}>
                                         <Step borderColor="purple">Connect with code hosts</Step>
@@ -172,7 +172,7 @@ export const PostSignUpPage: FunctionComponent<PostSignUpPage> = ({
                                                     context={context}
                                                     refetch={refetchExternalServices}
                                                 />
-                                        </div>
+                                            </div>
                                         </StepPanel>
                                         <StepPanel>
                                             <div className={classNames('mt-5', styles.container)}>

--- a/client/web/src/auth/SignUpPage.test.tsx
+++ b/client/web/src/auth/SignUpPage.test.tsx
@@ -5,7 +5,6 @@ import { MemoryRouter } from 'react-router'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
-import { RenderWithRouterResult } from '@sourcegraph/shared/src/testing/render-with-router'
 
 import { AuthenticatedUser } from '../auth'
 import { FeatureFlagName } from '../featureFlags/featureFlags'

--- a/client/web/src/auth/SignUpPage.test.tsx
+++ b/client/web/src/auth/SignUpPage.test.tsx
@@ -4,6 +4,8 @@ import React from 'react'
 import { MemoryRouter } from 'react-router'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
+import { RenderWithRouterResult } from '@sourcegraph/shared/src/testing/render-with-router'
 
 import { AuthenticatedUser } from '../auth'
 import { FeatureFlagName } from '../featureFlags/featureFlags'
@@ -34,20 +36,22 @@ describe('SignUpPage', () => {
     it('renders sign up page (server)', () => {
         expect(
             render(
-                <MemoryRouter>
-                    <SignUpPage
-                        {...commonProps}
-                        authenticatedUser={null}
-                        context={{
-                            allowSignup: true,
-                            sourcegraphDotComMode: false,
-                            experimentalFeatures: { enablePostSignupFlow: false },
-                            authProviders,
-                            xhrHeaders: {},
-                        }}
-                        telemetryService={NOOP_TELEMETRY_SERVICE}
-                    />
-                </MemoryRouter>
+                <MockedTestProvider mocks={[]}>
+                    <MemoryRouter>
+                        <SignUpPage
+                            {...commonProps}
+                            authenticatedUser={null}
+                            context={{
+                                allowSignup: true,
+                                sourcegraphDotComMode: false,
+                                experimentalFeatures: { enablePostSignupFlow: false },
+                                authProviders,
+                                xhrHeaders: {},
+                            }}
+                            telemetryService={NOOP_TELEMETRY_SERVICE}
+                        />
+                    </MemoryRouter>
+                </MockedTestProvider>
             ).asFragment()
         ).toMatchSnapshot()
     })
@@ -55,20 +59,22 @@ describe('SignUpPage', () => {
     it('renders sign up page (cloud)', () => {
         expect(
             render(
-                <MemoryRouter>
-                    <SignUpPage
-                        {...commonProps}
-                        authenticatedUser={null}
-                        context={{
-                            allowSignup: true,
-                            sourcegraphDotComMode: true,
-                            experimentalFeatures: { enablePostSignupFlow: false },
-                            authProviders,
-                            xhrHeaders: {},
-                        }}
-                        telemetryService={NOOP_TELEMETRY_SERVICE}
-                    />
-                </MemoryRouter>
+                <MockedTestProvider mocks={[]}>
+                    <MemoryRouter>
+                        <SignUpPage
+                            {...commonProps}
+                            authenticatedUser={null}
+                            context={{
+                                allowSignup: true,
+                                sourcegraphDotComMode: true,
+                                experimentalFeatures: { enablePostSignupFlow: false },
+                                authProviders,
+                                xhrHeaders: {},
+                            }}
+                            telemetryService={NOOP_TELEMETRY_SERVICE}
+                        />
+                    </MemoryRouter>
+                </MockedTestProvider>
             ).asFragment()
         ).toMatchSnapshot()
     })
@@ -84,20 +90,22 @@ describe('SignUpPage', () => {
 
         expect(
             render(
-                <MemoryRouter>
-                    <SignUpPage
-                        {...commonProps}
-                        authenticatedUser={mockUser}
-                        context={{
-                            allowSignup: true,
-                            sourcegraphDotComMode: false,
-                            experimentalFeatures: { enablePostSignupFlow: false },
-                            authProviders,
-                            xhrHeaders: {},
-                        }}
-                        telemetryService={NOOP_TELEMETRY_SERVICE}
-                    />
-                </MemoryRouter>
+                <MockedTestProvider mocks={[]}>
+                    <MemoryRouter>
+                        <SignUpPage
+                            {...commonProps}
+                            authenticatedUser={mockUser}
+                            context={{
+                                allowSignup: true,
+                                sourcegraphDotComMode: false,
+                                experimentalFeatures: { enablePostSignupFlow: false },
+                                authProviders,
+                                xhrHeaders: {},
+                            }}
+                            telemetryService={NOOP_TELEMETRY_SERVICE}
+                        />
+                    </MemoryRouter>
+                </MockedTestProvider>
             ).asFragment()
         ).toMatchSnapshot()
     })

--- a/client/web/src/auth/SignUpPage.tsx
+++ b/client/web/src/auth/SignUpPage.tsx
@@ -18,7 +18,7 @@ import { getReturnTo, maybeAddPostSignUpRedirect } from './SignInSignUpCommon'
 import signInSignUpCommonStyles from './SignInSignUpCommon.module.scss'
 import { SignUpArguments, SignUpForm } from './SignUpForm'
 
-interface SignUpPageProps extends ThemeProps, TelemetryProps, FeatureFlagProps {
+export interface SignUpPageProps extends ThemeProps, TelemetryProps, FeatureFlagProps {
     authenticatedUser: AuthenticatedUser | null
     context: Pick<
         SourcegraphContext,

--- a/client/web/src/auth/Steps/Steps.tsx
+++ b/client/web/src/auth/Steps/Steps.tsx
@@ -15,6 +15,7 @@ export interface StepProps {
 
 interface StepListProps {
     numeric: boolean
+    className?: string
     children: React.ReactElement<StepProps> | React.ReactElement<StepProps, string | React.JSXElementConstructor<any>>[]
 }
 
@@ -70,7 +71,7 @@ export const Step: React.FunctionComponent<StepProps> = ({ children, borderColor
     )
 }
 
-export const StepList: React.FunctionComponent<StepListProps> = ({ children, numeric }) => {
+export const StepList: React.FunctionComponent<StepListProps> = ({ children, numeric, className }) => {
     const { state, dispatch } = useStepsContext()
 
     const { initialStep } = state
@@ -104,7 +105,7 @@ export const StepList: React.FunctionComponent<StepListProps> = ({ children, num
     })
 
     return (
-        <nav>
+        <nav className={className}>
             {numeric ? (
                 <ol className={stepsStyles.listNumeric}>{element}</ol>
             ) : (

--- a/client/web/src/auth/__snapshots__/SignUpPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignUpPage.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`SignUpPage renders sign up page (cloud) 1`] = `
         class="limitWidth"
       >
         <h2
-          class="pageHeading"
+          class="d-flex align-items-center pageHeading"
         >
           Easily search the code you care about.
         </h2>

--- a/client/web/src/auth/welcome/Footer.tsx
+++ b/client/web/src/auth/welcome/Footer.tsx
@@ -15,7 +15,7 @@ export const Footer: React.FunctionComponent<Props> = ({ onFinish }) => {
     const { setStep, currentIndex, currentStep } = useSteps()
 
     return (
-        <div className="d-flex align-items-center justify-content-end mt-4">
+        <div className="d-flex align-items-center justify-content-end mt-4 w-100">
             {!currentStep.isLastStep && (
                 <Link
                     to="https://docs.sourcegraph.com/code_search/explanations/code_visibility_on_sourcegraph_cloud"

--- a/client/web/src/auth/welcome/StartSearching.module.scss
+++ b/client/web/src/auth/welcome/StartSearching.module.scss
@@ -6,3 +6,7 @@
     vertical-align: bottom;
     animation: ellipsis steps(4, end) 1500ms infinite;
 }
+
+.title-description {
+    height: 5.75rem;
+}

--- a/client/web/src/auth/welcome/StartSearching.tsx
+++ b/client/web/src/auth/welcome/StartSearching.tsx
@@ -146,7 +146,7 @@ export const StartSearching: React.FunctionComponent<StartSearching> = ({
 
     const inviteURL = `${window.context.externalURL}?invitedBy=${user.username}`
     return (
-        <div className='m5-5 d-flex'>
+        <div className="m5-5 d-flex">
             <div className={classNames(className, 'mx-2')}>
                 <div className={styles.titleDescription}>
                     <h3>Introduce your friends to Sourcegraph</h3>
@@ -160,11 +160,7 @@ export const StartSearching: React.FunctionComponent<StartSearching> = ({
                             <h4 className="m-0">Invite by sending a link</h4>
                         </div>
                     </header>
-                    <CopyableText
-                        className="mb-3 ml-3 mr-3 flex-1"
-                        text={inviteURL}
-                        size={inviteURL.length}
-                    />
+                    <CopyableText className="mb-3 ml-3 mr-3 flex-1" text={inviteURL} size={inviteURL.length} />
                 </div>
             </div>
             <div className={classNames(className, 'mx-2')}>
@@ -234,8 +230,8 @@ export const StartSearching: React.FunctionComponent<StartSearching> = ({
                         <Link to={PageRoutes.Search} onClick={trackBannerClick}>
                             continue to Sourcegraph now
                         </Link>{' '}
-                        while cloning continues in the background. Note that you can only search repos that have finished
-                        cloning. Check status at any time in{' '}
+                        while cloning continues in the background. Note that you can only search repos that have
+                        finished cloning. Check status at any time in{' '}
                         <Link to="user/settings/repositories" onClick={trackBannerClick}>
                             Settings → Repositories
                         </Link>

--- a/client/web/src/auth/welcome/StartSearching.tsx
+++ b/client/web/src/auth/welcome/StartSearching.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react'
 
 import { ErrorLike, isErrorLike } from '@sourcegraph/common'
 import { Link } from '@sourcegraph/shared/src/components/Link'
+import { CopyableText } from '@sourcegraph/web/src/components/CopyableText'
 import { PageRoutes } from '@sourcegraph/web/src/routes.constants'
 
 import { AuthenticatedUser } from '../../auth'
@@ -24,6 +25,7 @@ interface StartSearching {
     onUserExternalServicesOrRepositoriesUpdate: UserExternalServicesOrRepositoriesUpdateProps['onUserExternalServicesOrRepositoriesUpdate']
     setSelectedSearchContextSpec: (spec: string) => void
     onError: (error: ErrorLike) => void
+    className?: string
 }
 
 const SIXTY_SECONDS = 60000
@@ -71,6 +73,7 @@ export const StartSearching: React.FunctionComponent<StartSearching> = ({
     repoSelectionMode,
     setSelectedSearchContextSpec,
     onError,
+    className,
 }) => {
     const { externalServices, errorServices, loadingServices } = useExternalServices(user.id)
     const saveSelectedRepos = useSaveSelectedRepos()
@@ -141,80 +144,105 @@ export const StartSearching: React.FunctionComponent<StartSearching> = ({
         }
     }, [currentIndex, setComplete, showAlert, isDoneCloning, fetchError])
 
+    const inviteURL = `${window.context.externalURL}?invitedBy=${user.username}`
     return (
-        <div className="mt-5">
-            <h3>Fetching repositories...</h3>
-            <p className="text-muted mb-4">
-                We’re cloning your repos to Sourcegraph. In just a few moments, you can make your first search!
-            </p>
-            <div className="border overflow-hidden rounded">
-                <header>
-                    <div className="py-3 px-4 d-flex justify-content-between align-items-center">
-                        <h4 className="m-0">Activity log</h4>
-                        <small className="m-0 text-muted">{statusSummary}</small>
-                    </div>
-                </header>
-                <Terminal>
-                    {!isDoneCloning && (
-                        <TerminalLine>
-                            <code className={classNames('mb-2', styles.loading)}>Cloning Repositories</code>
-                        </TerminalLine>
-                    )}
-                    {isLoading && (
-                        <TerminalLine>
-                            <TerminalTitle>
-                                <code className={classNames('mb-2', styles.loading)}>Loading</code>
-                            </TerminalTitle>
-                        </TerminalLine>
-                    )}
-                    {fetchError && (
-                        <TerminalLine>
-                            <TerminalTitle>
-                                <code className="mb-2">Unexpected error</code>
-                            </TerminalTitle>
-                        </TerminalLine>
-                    )}
-                    {!isLoading &&
-                        !isDoneCloning &&
-                        cloningStatusLines?.map(({ id, title, details, progress }) => (
-                            <div key={id} className="mb-2">
-                                <TerminalLine>
-                                    <TerminalTitle>{title}</TerminalTitle>
-                                </TerminalLine>
-                                <TerminalLine>
-                                    <TerminalDetails>{details}</TerminalDetails>
-                                </TerminalLine>
-                                <TerminalLine>
-                                    <TerminalProgress character="#" progress={progress} />
-                                </TerminalLine>
-                            </div>
-                        ))}
-                    {isDoneCloning && (
-                        <>
-                            <TerminalLine>
-                                <TerminalTitle>Done!</TerminalTitle>
-                            </TerminalLine>
-                            <TerminalLine>
-                                <LogoAscii />
-                            </TerminalLine>
-                        </>
-                    )}
-                </Terminal>
-            </div>
-            {showAlert && (
-                <div className="alert alert-warning mt-4">
-                    Cloning your repositories is taking a long time. You can wait for cloning to finish, or{' '}
-                    <Link to={PageRoutes.Search} onClick={trackBannerClick}>
-                        continue to Sourcegraph now
-                    </Link>{' '}
-                    while cloning continues in the background. Note that you can only search repos that have finished
-                    cloning. Check status at any time in{' '}
-                    <Link to="user/settings/repositories" onClick={trackBannerClick}>
-                        Settings → Repositories
-                    </Link>
-                    .
+        <div className='m5-5 d-flex'>
+            <div className={classNames(className, 'mx-2')}>
+                <div className={styles.titleDescription}>
+                    <h3>Introduce your friends to Sourcegraph</h3>
+                    <p className="text-muted mb-4">
+                        Help your friends and co-workers level up with powerful code search.
+                    </p>
                 </div>
-            )}
+                <div className="border overflow-hidden rounded">
+                    <header>
+                        <div className="py-3 px-4 d-flex justify-content-between align-items-center">
+                            <h4 className="m-0">Invite by sending a link</h4>
+                        </div>
+                    </header>
+                    <CopyableText
+                        className="mb-3 ml-3 mr-3 flex-1"
+                        text={inviteURL}
+                        size={inviteURL.length}
+                    />
+                </div>
+            </div>
+            <div className={classNames(className, 'mx-2')}>
+                <div className={styles.titleDescription}>
+                    <h3>Fetching repositories...</h3>
+                    <p className="text-muted mb-4">
+                        We’re cloning your repos to Sourcegraph. In just a few moments, you can make your first search!
+                    </p>
+                </div>
+                <div className="border overflow-hidden rounded">
+                    <header>
+                        <div className="py-3 px-4 d-flex justify-content-between align-items-center">
+                            <h4 className="m-0">Activity log</h4>
+                            <small className="m-0 text-muted">{statusSummary}</small>
+                        </div>
+                    </header>
+                    <Terminal>
+                        {!isDoneCloning && (
+                            <TerminalLine>
+                                <code className={classNames('mb-2', styles.loading)}>Cloning Repositories</code>
+                            </TerminalLine>
+                        )}
+                        {isLoading && (
+                            <TerminalLine>
+                                <TerminalTitle>
+                                    <code className={classNames('mb-2', styles.loading)}>Loading</code>
+                                </TerminalTitle>
+                            </TerminalLine>
+                        )}
+                        {fetchError && (
+                            <TerminalLine>
+                                <TerminalTitle>
+                                    <code className="mb-2">Unexpected error</code>
+                                </TerminalTitle>
+                            </TerminalLine>
+                        )}
+                        {!isLoading &&
+                            !isDoneCloning &&
+                            cloningStatusLines?.map(({ id, title, details, progress }) => (
+                                <div key={id} className="mb-2">
+                                    <TerminalLine>
+                                        <TerminalTitle>{title}</TerminalTitle>
+                                    </TerminalLine>
+                                    <TerminalLine>
+                                        <TerminalDetails>{details}</TerminalDetails>
+                                    </TerminalLine>
+                                    <TerminalLine>
+                                        <TerminalProgress character="#" progress={progress} />
+                                    </TerminalLine>
+                                </div>
+                            ))}
+                        {isDoneCloning && (
+                            <>
+                                <TerminalLine>
+                                    <TerminalTitle>Done!</TerminalTitle>
+                                </TerminalLine>
+                                <TerminalLine>
+                                    <LogoAscii />
+                                </TerminalLine>
+                            </>
+                        )}
+                    </Terminal>
+                </div>
+                {showAlert && (
+                    <div className="alert alert-warning mt-4">
+                        Cloning your repositories is taking a long time. You can wait for cloning to finish, or{' '}
+                        <Link to={PageRoutes.Search} onClick={trackBannerClick}>
+                            continue to Sourcegraph now
+                        </Link>{' '}
+                        while cloning continues in the background. Note that you can only search repos that have finished
+                        cloning. Check status at any time in{' '}
+                        <Link to="user/settings/repositories" onClick={trackBannerClick}>
+                            Settings → Repositories
+                        </Link>
+                        .
+                    </div>
+                )}
+            </div>
         </div>
     )
 }


### PR DESCRIPTION
Pretty simple change, when you are on the third stage of the welcome screen of Sourcegraph.com (i.e. you're waiting for your repositories to clone), there's now a way for you to copy a link to invite friends/coworkers to Sourcegraph:

<img width="1904" alt="image" src="https://user-images.githubusercontent.com/3173176/149245200-b3f01a7f-0cca-4617-93c4-d78a439ef77f.png">

When they visit that link, it's got your username in the URL `?invitedBy=slimsag` and so it renders some decorations to show who invited you:

<img width="1904" alt="image" src="https://user-images.githubusercontent.com/3173176/149245014-cb2fc333-9776-4cba-8b71-a2e58b1a808c.png">

A few notes:

1. I did not fix the text color issue on the welcome page, that's not a new issue on this page. I will fix it in a follow-up PR.
2. I have not yet added event logging, I will do so in a follow-up PR.
3. Testing the welcome page (actually getting to it) is a huge pain, I plan to make that easier for us soon.
4. The cloud sign up page CSS is a mess, it's using a lot of negative margins and absolute positions.. I'd like to clean that up soon. @rrhyne can I also get rid of the `signup-optimization` feature flag which complicates this page? Do we want it on by default?

Up next, we'll make inviting people easier via sending emails and suggesting you invite collaborators from the repos you add.
