### PR TITLE
[CLOUD-202] Enforce feature flag check for the GitHub App setup handler

### DIFF
--- a/enterprise/cmd/frontend/internal/app/app.go
+++ b/enterprise/cmd/frontend/internal/app/app.go
@@ -102,7 +102,7 @@ func newGitHubAppCloudSetupHandler(db database.DB, apiURL *url.URL, client githu
 		actor := actor.FromContext(r.Context())
 		err := checkIfUserCanInstallGitHubApp(r.Context(), db, actor.UID)
 		if err != nil {
-			w.WriteHeader(http.StatusBadRequest)
+			w.WriteHeader(http.StatusForbidden)
 			_, _ = w.Write([]byte(err.Error()))
 			return
 		}

--- a/enterprise/cmd/frontend/internal/app/app_test.go
+++ b/enterprise/cmd/frontend/internal/app/app_test.go
@@ -65,9 +65,9 @@ func TestNewGitHubAppCloudSetupHandler(t *testing.T) {
 		h.ServeHTTP(resp, req)
 
 		assert.Equal(t, http.StatusForbidden, resp.Code)
-		assert.Equal(t, "Sourcegraph Cloud GitHub App setup is not enabled for the authenticated user", resp.Body.String())
+		assert.Equal(t, "Sourcegraph Cloud GitHub App setup is not enabled for the organization", resp.Body.String())
 	})
-	featureFlags.GetUserFlagsFunc.SetDefaultReturn(map[string]bool{"github-app-cloud": true}, nil)
+	featureFlags.GetOrgFeatureFlagFunc.SetDefaultReturn(true, nil)
 
 	t.Run("not an organization member", func(t *testing.T) {
 		orgMembers.GetByOrgIDAndUserIDFunc.SetDefaultReturn(nil, nil)

--- a/enterprise/cmd/frontend/internal/app/app_test.go
+++ b/enterprise/cmd/frontend/internal/app/app_test.go
@@ -34,11 +34,13 @@ func TestNewGitHubAppCloudSetupHandler(t *testing.T) {
 		}, nil
 	})
 	externalServices := database.NewMockExternalServiceStore()
+	featureFlags := database.NewMockFeatureFlagStore()
 	db := database.NewMockDB()
 	db.UsersFunc.SetDefaultReturn(users)
 	db.OrgMembersFunc.SetDefaultReturn(orgMembers)
 	db.OrgsFunc.SetDefaultReturn(orgs)
 	db.ExternalServicesFunc.SetDefaultReturn(externalServices)
+	db.FeatureFlagsFunc.SetDefaultReturn(featureFlags)
 
 	apiURL, err := url.Parse("https://github.com")
 	require.NoError(t, err)
@@ -57,6 +59,15 @@ func TestNewGitHubAppCloudSetupHandler(t *testing.T) {
 	require.Nil(t, err)
 
 	h := newGitHubAppCloudSetupHandler(db, apiURL, client)
+
+	t.Run("feature flag not enabled", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+		h.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, "Sourcegraph Cloud GitHub App setup is not enabled for the authenticated user", resp.Body.String())
+	})
+	featureFlags.GetUserFlagsFunc.SetDefaultReturn(map[string]bool{"github-app-cloud": true}, nil)
 
 	t.Run("not an organization member", func(t *testing.T) {
 		orgMembers.GetByOrgIDAndUserIDFunc.SetDefaultReturn(nil, nil)

--- a/enterprise/cmd/frontend/internal/app/app_test.go
+++ b/enterprise/cmd/frontend/internal/app/app_test.go
@@ -64,7 +64,7 @@ func TestNewGitHubAppCloudSetupHandler(t *testing.T) {
 		resp := httptest.NewRecorder()
 		h.ServeHTTP(resp, req)
 
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, http.StatusForbidden, resp.Code)
 		assert.Equal(t, "Sourcegraph Cloud GitHub App setup is not enabled for the authenticated user", resp.Body.String())
 	})
 	featureFlags.GetUserFlagsFunc.SetDefaultReturn(map[string]bool{"github-app-cloud": true}, nil)


### PR DESCRIPTION
This PR adds a feature flag check for the Sourcegraph Cloud GitHub App setup handler.

An error is displayed for organizations without having the feature flag:

<img width="663" alt="CleanShot 2022-01-13 at 14 52 25@2x" src="https://user-images.githubusercontent.com/2946214/149281709-b0265b59-7f47-4e09-a35a-b849e8cf7999.png">

(the response string in the screenshot is outdated, but the behavior is the same)

### Testing

For testing locally, please follow the [local testing guide](https://docs.google.com/document/d/1FYTIPLsT4CAT0jPHoCbTb7JcS8dySX4am_rmQZlVJVE/edit#).

---

Jira: CLOUD-202