### PR TITLE
tests: use glob for jest `projects` field

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,20 +1,6 @@
 // @ts-check
 
 /** @type {import('@jest/types').Config.InitialOptions} */
-const config = require('./jest.config.base')
-
-/** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  projects: [
-    'client/browser/jest.config.js',
-    'client/build-config/jest.config.js',
-    'client/common/jest.config.js',
-    'client/codeintellify/jest.config.js',
-    'client/shared/jest.config.js',
-    'client/branded/jest.config.js',
-    'client/web/jest.config.js',
-    'client/wildcard/jest.config.js',
-    'client/template-parser/jest.config.js',
-    'client/storybook/jest.config.js',
-  ],
+  projects: ['client/*/jest.config.js'],
 }


### PR DESCRIPTION
## Context

We were a lot of smaller packages to the `client` folder lately, and it would be nice to simplify the setup required to get them up and running. It seems that using glob to find all packages with `jest.config.js` works. It removes one place that needs to be updated when adding a new package to the `client` folder.
