### PR TITLE
ci: improve prettier output

### DIFF
--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -301,8 +301,7 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
          * Don't subscribe to this event when there wasn't an authenticated user,
          * as it could lead to an infinite loop of 401 -> reload -> 401
          */
-        this.subscriptions.add(
-            authenticatedUser
+        this.subscriptions.add(authenticatedUser
                 .pipe(
                     switchMap(authenticatedUser =>
                         authenticatedUser ? fromEvent<ErrorEvent>(window, 'error') : of(null)

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -301,7 +301,8 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
          * Don't subscribe to this event when there wasn't an authenticated user,
          * as it could lead to an infinite loop of 401 -> reload -> 401
          */
-        this.subscriptions.add(authenticatedUser
+        this.subscriptions.add(
+            authenticatedUser
                 .pipe(
                     switchMap(authenticatedUser =>
                         authenticatedUser ? fromEvent<ErrorEvent>(window, 'error') : of(null)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "prettier": "prettier '**/{*.{js?(on),ts?(x),graphql,md,scss},.*.js?(on)}' --write --list-different --config prettier.config.js",
-    "prettier-check": "yarn -s run prettier --write=false",
+    "prettier-check": "yarn -s run prettier --write=false --check --list-different=false --loglevel=warn",
     "all:eslint": "DOCSITE_LIST=\"$(./dev/docsite.sh -config doc/docsite.json ls)\" dev/foreach-ts-project.sh yarn -s run eslint --quiet",
     "all:stylelint": "yarn --cwd client/web run stylelint && yarn --cwd client/shared run stylelint && yarn --cwd client/branded run stylelint && yarn --cwd client/browser run stylelint && yarn --cwd client/wildcard run stylelint",
     "build-ts": "tsc -b tsconfig.all.json",


### PR DESCRIPTION
## Context

Minor improvement to `prettier-check` output using [the `--check` flag](https://prettier.io/docs/en/cli.html#--check).
[Relevant thread](https://github.com/prettier/prettier/issues/6885) from the prettier repo for context.

As a follow-up, we can also consider using [the approach](https://github.com/sourcegraph/interviews/pull/211) with automatic formatting in the main Sourcegraph repo.

### Before

<img width="1167" alt="CleanShot 2022-01-11 at 10 48 49@2x" src="https://user-images.githubusercontent.com/3846380/149322059-9902a990-3767-4281-8012-578efcc26548.png">

### After 

<img width="1148" alt="Screen Shot 2022-01-13 at 12 29 50" src="https://user-images.githubusercontent.com/3846380/149322455-9c5c8c01-f4b8-419c-b569-afd912074f43.png">
