### PR TITLE
ci: Attempt at making puppeteer tests more stable

### DIFF
--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -184,7 +184,7 @@ func addBrowserExt(pipeline *bk.Pipeline) {
 }
 
 func clientIntegrationTests(pipeline *bk.Pipeline) {
-	chunkSize := 3
+	chunkSize := 2
 	prepStepKey := "puppeteer:prep"
 	skipGitCloneStep := bk.Plugin("uber-workflow/run-without-clone", "")
 


### PR DESCRIPTION
After inspecting the failures, https://buildkite.com/sourcegraph/sourcegraph/builds/125306 (see also [this graph](https://sourcegraph.grafana.net/d/iBBWbxFnk/ci?orgId=1&from=now-7d&to=now&viewPanel=13) ), display failures are ruled out. Instead, the browser appears to die or simply close the tab without any obvious reason. Correlating the memory usage which often reaches 100% on these steps, it's possible that's what is causing those issues.

Before considering increasing the allocated memory, we can split the tests to lessen the memory consumption of a given run. So rather than ending up with 6 puppeteer chunks, we now have 9. I want to observe the failure rate on the chunks in the upcoming days to see if that improves the stability. 

