### PR TITLE
[SG-27727]Wildcard V2: <Select /> Lint rule

### DIFF
--- a/client/eslint-plugin-wildcard/lib/index.js
+++ b/client/eslint-plugin-wildcard/lib/index.js
@@ -24,6 +24,10 @@ module.exports = {
                 message: 'Use the <Button /> component from @sourcegraph/wildcard instead.',
               },
               {
+                element: 'select',
+                message: 'Use the <Select /> component from @sourcegraph/wildcard instead.',
+              },
+              {
                 element: 'textarea',
                 message: 'Use the <TextArea /> component from @sourcegraph/wildcard instead.',
               },


### PR DESCRIPTION
## Description

- Eslint rule to enforce the `<Select />` Wildcard component.
- See [Wildcard V2 - Planned work](https://docs.google.com/document/d/1NisbJPiadtt5jQw4vUUYJOr8dD6Urwn5V0mVq2wt6bE/edit#heading=h.g4cw92w3ouhw) for more context
 
 ## Acceptance criteria
- [ ]  Eslint rule is added to enforce usage
- [ ]  Eslint rule is implemented in the Sourcegraph repository

## Refs:

- [SourceGraph issue](https://github.com/sourcegraph/sourcegraph/issues/27727)
- [GitStart ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-29434)