### PR TITLE
Rename NPMPackage field to Package.

### DIFF
--- a/cmd/gitserver/server/vcs_syncer_npm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	placeholderNPMDependency = reposource.NPMDependency{
-		NPMPackage: func() reposource.NPMPackage {
+		Package: func() reposource.NPMPackage {
 			pkg, err := reposource.NewNPMPackage("sourcegraph", "placeholder")
 			if err != nil {
 				panic(fmt.Sprintf("expected placeholder package to parse but got %v", err))
@@ -199,8 +199,8 @@ func (s *NPMPackagesSyncer) packageDependencies(ctx context.Context, repoUrlPath
 		}
 		if *repoPackage == *parsedDbPackage {
 			matchingDependencies = append(matchingDependencies, reposource.NPMDependency{
-				NPMPackage: *parsedDbPackage,
-				Version:    dbDep.Version,
+				Package: *parsedDbPackage,
+				Version: dbDep.Version,
 			})
 		}
 	}

--- a/internal/conf/reposource/npm_packages.go
+++ b/internal/conf/reposource/npm_packages.go
@@ -76,7 +76,7 @@ func ParseNPMPackageFromPackageSyntax(pkg string) (*NPMPackage, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &dep.NPMPackage, nil
+	return &dep.Package, nil
 }
 
 type NPMPackageSerializationHelper struct {
@@ -126,6 +126,11 @@ func (pkg NPMPackage) MatchesDependencyString(depPackageSyntax string) bool {
 	return strings.HasPrefix(depPackageSyntax, pkg.PackageSyntax()+"@")
 }
 
+// Format a package using (@scope/)?name syntax.
+//
+// This is largely for "lower-level" code interacting with the NPM API.
+//
+// In most cases, you want to use NPMDependency's PackageManagerSyntax() instead.
 func (pkg NPMPackage) PackageSyntax() string {
 	if pkg.scope != "" {
 		return fmt.Sprintf("@%s/%s", pkg.scope, pkg.name)
@@ -140,7 +145,7 @@ func (pkg NPMPackage) PackageSyntax() string {
 //
 // Reference:  https://docs.npmjs.com/cli/v8/commands/npm-install
 type NPMDependency struct {
-	NPMPackage
+	Package NPMPackage
 
 	// The version or tag (such as "latest") for a dependency.
 	//
@@ -183,7 +188,7 @@ func ParseNPMDependency(dependency string) (*NPMDependency, error) {
 // PackageManagerSyntax returns the dependency in NPM/Yarn syntax. The returned
 // string can (for example) be passed to `npm install`.
 func (d NPMDependency) PackageManagerSyntax() string {
-	return fmt.Sprintf("%s@%s", d.NPMPackage.PackageSyntax(), d.Version)
+	return fmt.Sprintf("%s@%s", d.Package.PackageSyntax(), d.Version)
 }
 
 func (d NPMDependency) GitTagFromVersion() string {
@@ -195,7 +200,7 @@ func (d NPMDependency) GitTagFromVersion() string {
 // slice.
 func SortNPMDependencies(dependencies []NPMDependency) {
 	sort.Slice(dependencies, func(i, j int) bool {
-		iPkg, jPkg := dependencies[i].NPMPackage, dependencies[j].NPMPackage
+		iPkg, jPkg := dependencies[i].Package, dependencies[j].Package
 		if iPkg == jPkg {
 			return versionGreaterThan(dependencies[i].Version, dependencies[j].Version)
 		}

--- a/internal/repos/npm_packages.go
+++ b/internal/repos/npm_packages.go
@@ -85,12 +85,12 @@ func (s *NPMPackagesSource) ListRepos(ctx context.Context, results chan SourceRe
 				log15.Error("failed to parse npm package name retrieved from database", "package", dbDep.Package)
 				continue
 			}
-			npmDependency := reposource.NPMDependency{NPMPackage: *parsedDbPackage, Version: dbDep.Version}
+			npmDependency := reposource.NPMDependency{Package: *parsedDbPackage, Version: dbDep.Version}
 			if err = npm.Exists(ctx, s.config, npmDependency); err != nil {
 				log15.Warn("failed to resolve npm dependency", "package", npmDependency.PackageManagerSyntax(), "message", err)
 				continue
 			}
-			repo := s.makeRepo(npmDependency.NPMPackage)
+			repo := s.makeRepo(npmDependency.Package)
 			totalDBResolved++
 			results <- SourceResult{Source: s, Repo: repo}
 		}
@@ -150,7 +150,7 @@ func npmPackages(connection schema.NPMPackagesConnection) ([]reposource.NPMPacka
 	npmPackages := []reposource.NPMPackage{}
 	isAdded := make(map[reposource.NPMPackage]bool)
 	for _, dep := range dependencies {
-		npmPackage := dep.NPMPackage
+		npmPackage := dep.Package
 		if !isAdded[npmPackage] {
 			npmPackages = append(npmPackages, npmPackage)
 		}

--- a/internal/repos/npm_packages_test.go
+++ b/internal/repos/npm_packages_test.go
@@ -142,7 +142,7 @@ func TestListRepos(t *testing.T) {
 	for _, dep := range dependencies {
 		dep, err := reposource.ParseNPMDependency(dep)
 		require.Nil(t, err)
-		expectedRepoURLs = append(expectedRepoURLs, string(dep.RepoName()))
+		expectedRepoURLs = append(expectedRepoURLs, string(dep.Package.RepoName()))
 	}
 	sort.Strings(expectedRepoURLs)
 	// Compare after uniquing after addressing [FIXME: deduplicate-listed-repos].
@@ -157,7 +157,7 @@ func insertDependencies(t *testing.T, ctx context.Context, s *dbstore.Store, dep
 		rows, err :=
 			s.Store.Query(ctx, sqlf.Sprintf(
 				`INSERT INTO lsif_dependency_repos (scheme, name, version) VALUES (%s, %s, %s)`,
-				dbstore.NPMPackagesScheme, dep.NPMPackage.PackageSyntax(), dep.Version))
+				dbstore.NPMPackagesScheme, dep.Package.PackageSyntax(), dep.Version))
 		require.Nil(t, err)
 		for rows.Next() {
 		}


### PR DESCRIPTION
The additional "NPM" prefix lead to an implicit conversion,
creating needless confusion because the PackageSyntax() method
of NPMPackage was also available for NPMDependency, alongside
PackageManagerSyntax().

No functional change intended.