### PR TITLE
Fix for issue in PostSignUp page https://sourcegraph.atlassian.net/browse/CLOUD-131

### DIFF
--- a/client/web/src/auth/PostSignUpPage.tsx
+++ b/client/web/src/auth/PostSignUpPage.tsx
@@ -4,7 +4,6 @@ import { useLocation, useHistory } from 'react-router'
 
 import { ErrorLike } from '@sourcegraph/common'
 import { Link } from '@sourcegraph/shared/src/components/Link'
-import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
 import { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { BrandLogo } from '@sourcegraph/web/src/components/branding/BrandLogo'
 import { HeroPage } from '@sourcegraph/web/src/components/HeroPage'
@@ -123,14 +122,7 @@ export const PostSignUpPage: FunctionComponent<PostSignUpPage> = ({
 
     return (
         <>
-            <LinkOrSpan to={getReturnTo(location)} className={styles.logoLink}>
-                <BrandLogo
-                    className={classNames('ml-3 mt-3', styles.logo)}
-                    isLightTheme={true}
-                    variant="symbol"
-                    onClick={event => finishWelcomeFlow(event, { eventName: 'BrandLogo_Clicked' })}
-                />
-            </LinkOrSpan>
+            <BrandLogo className={classNames('ml-3 mt-3', styles.logo)} isLightTheme={true} variant="symbol" />
 
             <div className={classNames(signInSignUpCommonStyles.signinSignupPage, styles.postSignupPage)}>
                 <PageTitle title="Welcome" />


### PR DESCRIPTION
fixing issue 
https://sourcegraph.atlassian.net/browse/CLOUD-131

After investigation into the post-signup flow analytics, we learned that about 5% of signups end up clicking the asterisk logo in the post-signup flow, and end up getting removed from the flow with no ability to return to it.

We should remove the link from the asterisk and let users make an explicit choice between continuing with the post-signup flow, or selecting "Not right now."