### PR TITLE
Code Insights: Add insight live preview button

### DIFF
--- a/client/web/src/components/MonacoEditor.tsx
+++ b/client/web/src/components/MonacoEditor.tsx
@@ -187,6 +187,14 @@ interface Props extends ThemeProps {
 
     /** Keyboard shortcut to focus the Monaco editor. */
     keyboardShortcutForFocus?: KeyboardShortcut
+
+    /**
+     * NOTE: This is currently only used for Insights code through
+     * the MonacoField component: client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.tsx
+     *
+     * Issue to improve this: https://github.com/sourcegraph/sourcegraph/issues/29438
+     */
+    placeholder?: string
 }
 
 interface State {
@@ -278,6 +286,7 @@ export class MonacoEditor extends React.PureComponent<Props, State> {
                         height: this.state.computedHeight,
                         position: 'relative',
                     }}
+                    data-placeholder={this.props.placeholder}
                     ref={this.setRef}
                     id={this.props.id}
                     className={classNames(this.props.className, this.props.border !== false && 'border rounded')}

--- a/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.module.scss
+++ b/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.module.scss
@@ -55,24 +55,11 @@
         display: none;
     }
 
-    &::before {
-        content: attr(data-placeholder);
-        display: none;
-        position: absolute;
-        z-index: 1;
-        color: var(--text-muted);
-        width: 100%;
-        top: 50%;
-        transform: translateY(-50%);
-        overflow: hidden;
-        text-overflow: ellipsis;
-        background-color: transparent;
-        pointer-events: none;
-    }
-
-    &--with-placeholder {
-        &::before {
-            display: block;
+    &:global(.with-invalid-icon) {
+        &:global(.is-invalid)::before,
+        :global(.is-valid)::before {
+            // Bootstrap styles for form control with validation icon
+            padding-right: calc(1.4285714286em + 0.75rem);
         }
     }
 
@@ -81,4 +68,34 @@
         border: none;
         box-shadow: none;
     }
+}
+
+.editor {
+    position: relative;
+
+    &--with-placeholder::before {
+        display: block !important;
+    }
+
+    &::before {
+        content: attr(data-placeholder);
+        display: none;
+        position: absolute;
+        z-index: 1;
+        color: var(--text-muted);
+        height: 100%;
+        width: 100%;
+        padding-right: 0.5rem;
+        pointer-events: none;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    //&:global(.with-invalid-icon) {
+    //    &:global(.is-invalid)::before, :global(.is-valid)::before {
+    //        // Bootstrap styles for form control with validation icon
+    //        padding-right: calc(1.4285714286em + 0.75rem);
+    //    }
+    //}
 }

--- a/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.module.scss
+++ b/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.module.scss
@@ -1,7 +1,17 @@
-.field {
-    min-height: 34px;
-    height: auto;
+.container {
+    display: flex;
+    min-width: 0;
     position: relative;
+    padding: 0.375rem 0.75rem !important;
+    background-image: none !important;
+
+    .monaco-field {
+        background-position: right 0.75rem top 0.175rem !important;
+    }
+}
+
+.focus-container {
+    height: auto;
 
     &:focus-within,
     &:focus {
@@ -32,6 +42,14 @@
             box-shadow: 0 0 0 2px var(--danger-3);
         }
     }
+}
+
+.monaco-field {
+    position: relative;
+    display: flex;
+    width: 100%;
+    min-width: 0;
+    height: auto;
 
     :global(.scroll-decoration) {
         display: none;
@@ -44,6 +62,8 @@
         z-index: 1;
         color: var(--text-muted);
         width: 100%;
+        top: 50%;
+        transform: translateY(-50%);
         overflow: hidden;
         text-overflow: ellipsis;
         background-color: transparent;
@@ -54,5 +74,11 @@
         &::before {
             display: block;
         }
+    }
+
+    &--without-field-styles {
+        padding: 0;
+        border: none;
+        box-shadow: none;
     }
 }

--- a/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.module.scss
+++ b/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.module.scss
@@ -55,14 +55,6 @@
         display: none;
     }
 
-    &:global(.with-invalid-icon) {
-        &:global(.is-invalid)::before,
-        :global(.is-valid)::before {
-            // Bootstrap styles for form control with validation icon
-            padding-right: calc(1.4285714286em + 0.75rem);
-        }
-    }
-
     &--without-field-styles {
         padding: 0;
         border: none;
@@ -91,11 +83,4 @@
         text-overflow: ellipsis;
         white-space: nowrap;
     }
-
-    //&:global(.with-invalid-icon) {
-    //    &:global(.is-invalid)::before, :global(.is-valid)::before {
-    //        // Bootstrap styles for form control with validation icon
-    //        padding-right: calc(1.4285714286em + 0.75rem);
-    //    }
-    //}
 }

--- a/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.module.scss
+++ b/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.module.scss
@@ -55,6 +55,11 @@
         display: none;
     }
 
+    :global(.monaco-editor),
+    :global(.monaco-editor-background) {
+        background-color: var(--input-bg) !important;
+    }
+
     &--without-field-styles {
         padding: 0;
         border: none;

--- a/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.story.tsx
+++ b/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.story.tsx
@@ -6,7 +6,7 @@ import { Button } from '@sourcegraph/wildcard'
 
 import { WebStory } from '../../../../../components/WebStory'
 
-import { MonacoContainer, MonacoField } from './MonacoField'
+import * as Monaco from './MonacoField'
 
 export default {
     title: 'web/insights/form/MonacoField',
@@ -21,56 +21,56 @@ before:2021-12-23T00:00:00+03:00 database.NewDB
 
 export const SimpleMonacoField = () => (
     <div className="d-flex flex-column" style={{ gap: '2rem', width: 400 }}>
-        <MonacoField value="" placeholder="Example: type:diff repo:sourcegrph/* " />
+        <Monaco.Field value="" placeholder="Example: type:diff repo:sourcegrph/* " />
 
-        <MonacoField value="repo:github.com/sourcegraph/sourcegraph" />
+        <Monaco.Field value="repo:github.com/sourcegraph/sourcegraph" />
 
-        <MonacoField value={MULTI_LINE_VALUE} />
+        <Monaco.Field value={MULTI_LINE_VALUE} />
 
-        <MonacoField value="repo:github.com/sourcegraph/sourcegraph" className="is-valid" />
+        <Monaco.Field value="repo:github.com/sourcegraph/sourcegraph" className="is-valid" />
 
-        <MonacoField value="repo:github.com/sourcegraph/sourcegraph" className="is-invalid" />
+        <Monaco.Field value="repo:github.com/sourcegraph/sourcegraph" className="is-invalid" />
 
-        <MonacoField value="repo:github.com/sourcegraph/sourcegraph" className="is-invalid" />
+        <Monaco.Field value="repo:github.com/sourcegraph/sourcegraph" className="is-invalid" />
 
-        <MonacoContainer>
-            <MonacoField value="" placeholder="Example: type:diff repo:sourcegrph/* " />
+        <Monaco.Root>
+            <Monaco.Field value="" placeholder="Example: type:diff repo:sourcegrph/* " />
             <Button className="btn-icon" disabled={true}>
                 <RegexIcon
                     size={21}
                     data-tooltip="Regular expression is the only pattern type usable with capture groups and it’s enabled by default for this search input."
                 />
             </Button>
-        </MonacoContainer>
+        </Monaco.Root>
 
-        <MonacoContainer>
-            <MonacoField value="repo:github.com/sourcegraph/sourcegraph" />
+        <Monaco.Root>
+            <Monaco.Field value="repo:github.com/sourcegraph/sourcegraph" />
             <Button className="btn-icon" disabled={true}>
                 <RegexIcon
                     size={21}
                     data-tooltip="Regular expression is the only pattern type usable with capture groups and it’s enabled by default for this search input."
                 />
             </Button>
-        </MonacoContainer>
+        </Monaco.Root>
 
-        <MonacoContainer>
-            <MonacoField value="repo:github.com/sourcegraph/sourcegraph" className="is-valid" />
+        <Monaco.Root>
+            <Monaco.Field value="repo:github.com/sourcegraph/sourcegraph" className="is-valid" />
             <Button className="btn-icon" disabled={true}>
                 <RegexIcon
                     size={21}
                     data-tooltip="Regular expression is the only pattern type usable with capture groups and it’s enabled by default for this search input."
                 />
             </Button>
-        </MonacoContainer>
+        </Monaco.Root>
 
-        <MonacoContainer>
-            <MonacoField value="repo:github.com/sourcegraph/sourcegraph" className="is-invalid" />
+        <Monaco.Root>
+            <Monaco.Field value="repo:github.com/sourcegraph/sourcegraph" className="is-invalid" />
             <Button className="btn-icon" disabled={true}>
                 <RegexIcon
                     size={21}
                     data-tooltip="Regular expression is the only pattern type usable with capture groups and it’s enabled by default for this search input."
                 />
             </Button>
-        </MonacoContainer>
+        </Monaco.Root>
     </div>
 )

--- a/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.story.tsx
+++ b/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.story.tsx
@@ -1,0 +1,76 @@
+import { Meta } from '@storybook/react'
+import RegexIcon from 'mdi-react/RegexIcon'
+import React from 'react'
+
+import { Button } from '@sourcegraph/wildcard'
+
+import { WebStory } from '../../../../../components/WebStory'
+
+import { MonacoContainer, MonacoField } from './MonacoField'
+
+export default {
+    title: 'web/insights/form/MonacoField',
+    decorators: [story => <WebStory>{() => story()}</WebStory>],
+} as Meta
+
+const MULTI_LINE_VALUE = `
+repo:^(github\\.com/sourcegraph/sourcegraph)$
+type:diff after:2021-12-16T00:00:00+03:00
+before:2021-12-23T00:00:00+03:00 database.NewDB
+`.trim()
+
+export const SimpleMonacoField = () => (
+    <div className="d-flex flex-column" style={{ gap: '2rem', width: 400 }}>
+        <MonacoField value="" placeholder="Example: type:diff repo:sourcegrph/* " />
+
+        <MonacoField value="repo:github.com/sourcegraph/sourcegraph" />
+
+        <MonacoField value={MULTI_LINE_VALUE} />
+
+        <MonacoField value="repo:github.com/sourcegraph/sourcegraph" className="is-valid" />
+
+        <MonacoField value="repo:github.com/sourcegraph/sourcegraph" className="is-invalid" />
+
+        <MonacoField value="repo:github.com/sourcegraph/sourcegraph" className="is-invalid" />
+
+        <MonacoContainer>
+            <MonacoField value="" placeholder="Example: type:diff repo:sourcegrph/* " />
+            <Button className="btn-icon" disabled={true}>
+                <RegexIcon
+                    size={21}
+                    data-tooltip="Regular expression is the only pattern type usable with capture groups and it’s enabled by default for this search input."
+                />
+            </Button>
+        </MonacoContainer>
+
+        <MonacoContainer>
+            <MonacoField value="repo:github.com/sourcegraph/sourcegraph" />
+            <Button className="btn-icon" disabled={true}>
+                <RegexIcon
+                    size={21}
+                    data-tooltip="Regular expression is the only pattern type usable with capture groups and it’s enabled by default for this search input."
+                />
+            </Button>
+        </MonacoContainer>
+
+        <MonacoContainer>
+            <MonacoField value="repo:github.com/sourcegraph/sourcegraph" className="is-valid" />
+            <Button className="btn-icon" disabled={true}>
+                <RegexIcon
+                    size={21}
+                    data-tooltip="Regular expression is the only pattern type usable with capture groups and it’s enabled by default for this search input."
+                />
+            </Button>
+        </MonacoContainer>
+
+        <MonacoContainer>
+            <MonacoField value="repo:github.com/sourcegraph/sourcegraph" className="is-invalid" />
+            <Button className="btn-icon" disabled={true}>
+                <RegexIcon
+                    size={21}
+                    data-tooltip="Regular expression is the only pattern type usable with capture groups and it’s enabled by default for this search input."
+                />
+            </Button>
+        </MonacoContainer>
+    </div>
+)

--- a/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.story.tsx
+++ b/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.story.tsx
@@ -6,7 +6,7 @@ import { Button } from '@sourcegraph/wildcard'
 
 import { WebStory } from '../../../../../components/WebStory'
 
-import * as Monaco from './MonacoField'
+import * as Monaco from '.'
 
 export default {
     title: 'web/insights/form/MonacoField',

--- a/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.tsx
+++ b/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.tsx
@@ -22,7 +22,7 @@ const MonacoFieldContext = createContext<Context>({ renderedWithinFocusContainer
 
 const MONACO_CONTAINER_MARK = { renderedWithinFocusContainer: true }
 
-export const MonacoContainer = forwardRef((props, reference) => {
+const MonacoFocusContainer = forwardRef((props, reference) => {
     const { as: Component = 'div', className, children, ...otherProps } = props
 
     return (
@@ -54,14 +54,14 @@ const MONACO_OPTIONS: Monaco.editor.IStandaloneEditorConstructionOptions = {
     },
 }
 
-export interface MonacoFieldProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange' | 'onBlur'> {
+interface MonacoFieldProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange' | 'onBlur'> {
     value: string
     patternType?: SearchPatternType
     onBlur?: () => void
     onChange?: (value: string) => void
 }
 
-export const MonacoField = forwardRef<HTMLInputElement, MonacoFieldProps>((props, reference) => {
+const MonacoField = forwardRef<HTMLInputElement, MonacoFieldProps>((props, reference) => {
     const {
         value,
         className,
@@ -109,3 +109,16 @@ export const MonacoField = forwardRef<HTMLInputElement, MonacoFieldProps>((props
         />
     )
 })
+
+const Root = MonacoFocusContainer
+const Field = MonacoField
+
+export {
+    MonacoFocusContainer,
+    MonacoField,
+    //
+    Root,
+    Field
+}
+
+export type { MonacoFieldProps }

--- a/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.tsx
+++ b/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.tsx
@@ -22,7 +22,7 @@ const MonacoFieldContext = createContext<Context>({ renderedWithinFocusContainer
 
 const MONACO_CONTAINER_MARK = { renderedWithinFocusContainer: true }
 
-const MonacoFocusContainer = forwardRef((props, reference) => {
+export const MonacoFocusContainer = forwardRef((props, reference) => {
     const { as: Component = 'div', className, children, ...otherProps } = props
 
     return (
@@ -54,14 +54,14 @@ const MONACO_OPTIONS: Monaco.editor.IStandaloneEditorConstructionOptions = {
     },
 }
 
-interface MonacoFieldProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange' | 'onBlur'> {
+export interface MonacoFieldProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange' | 'onBlur'> {
     value: string
     patternType?: SearchPatternType
     onBlur?: () => void
     onChange?: (value: string) => void
 }
 
-const MonacoField = forwardRef<HTMLInputElement, MonacoFieldProps>((props, reference) => {
+export const MonacoField = forwardRef<HTMLInputElement, MonacoFieldProps>((props, reference) => {
     const {
         value,
         className,
@@ -99,26 +99,13 @@ const MonacoField = forwardRef<HTMLInputElement, MonacoFieldProps>((props, refer
             placeholder={placeholder}
             onSubmit={noop}
             className={classNames(className, styles.monacoField, 'form-control', 'with-invalid-icon', {
-                [styles.monacoFieldWithPlaceholder]: !value,
                 [styles.focusContainer]: !renderedWithinFocusContainer,
                 [styles.monacoFieldWithoutFieldStyles]: renderedWithinFocusContainer,
             })}
             editorOptions={monacoOptions}
+            editorClassName={classNames(styles.editor, { [styles.editorWithPlaceholder]: !value })}
             autoFocus={autoFocus}
             onBlur={onBlur}
         />
     )
 })
-
-const Root = MonacoFocusContainer
-const Field = MonacoField
-
-export {
-    MonacoFocusContainer,
-    MonacoField,
-    //
-    Root,
-    Field
-}
-
-export type { MonacoFieldProps }

--- a/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.tsx
+++ b/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.tsx
@@ -1,9 +1,10 @@
 import classNames from 'classnames'
 import { noop } from 'lodash'
 import * as Monaco from 'monaco-editor'
-import React, { forwardRef, InputHTMLAttributes, useImperativeHandle, useMemo } from 'react'
+import React, { createContext, forwardRef, InputHTMLAttributes, useContext, useImperativeHandle, useMemo } from 'react'
 
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
+import { ForwardReferenceComponent } from '@sourcegraph/wildcard'
 
 import { QueryChangeSource } from '../../../../../search/helpers'
 import { LazyMonacoQueryInput } from '../../../../../search/input/LazyMonacoQueryInput'
@@ -12,6 +13,35 @@ import { ThemePreference } from '../../../../../stores/themeState'
 import { useTheme } from '../../../../../theme'
 
 import styles from './MonacoField.module.scss'
+
+interface Context {
+    renderedWithinFocusContainer: boolean
+}
+
+const MonacoFieldContext = createContext<Context>({ renderedWithinFocusContainer: false })
+
+const MONACO_CONTAINER_MARK = { renderedWithinFocusContainer: true }
+
+export const MonacoContainer = forwardRef((props, reference) => {
+    const { as: Component = 'div', className, children, ...otherProps } = props
+
+    return (
+        <MonacoFieldContext.Provider value={MONACO_CONTAINER_MARK}>
+            <Component
+                {...otherProps}
+                className={classNames(
+                    'form-control',
+                    'with-invalid-icon',
+                    styles.container,
+                    styles.focusContainer,
+                    className
+                )}
+            >
+                {children}
+            </Component>
+        </MonacoFieldContext.Provider>
+    )
+}) as ForwardReferenceComponent<'div'>
 
 const MONACO_OPTIONS: Monaco.editor.IStandaloneEditorConstructionOptions = {
     ...DEFAULT_MONACO_OPTIONS,
@@ -25,23 +55,25 @@ const MONACO_OPTIONS: Monaco.editor.IStandaloneEditorConstructionOptions = {
 }
 
 export interface MonacoFieldProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange' | 'onBlur'> {
-    patternType?: SearchPatternType
     value: string
-    onBlur: () => void
-    onChange: (value: string) => void
+    patternType?: SearchPatternType
+    onBlur?: () => void
+    onChange?: (value: string) => void
 }
 
 export const MonacoField = forwardRef<HTMLInputElement, MonacoFieldProps>((props, reference) => {
     const {
         value,
         className,
-        onChange,
+        onChange = noop,
         onBlur = noop,
         disabled,
         autoFocus,
         placeholder,
         patternType = SearchPatternType.regexp,
     } = props
+
+    const { renderedWithinFocusContainer } = useContext(MonacoFieldContext)
 
     // Monaco doesn't have any native input elements, so we mock
     // ref here to avoid React warnings in console about zero usage of
@@ -66,7 +98,11 @@ export const MonacoField = forwardRef<HTMLInputElement, MonacoFieldProps>((props
             height="auto"
             placeholder={placeholder}
             onSubmit={noop}
-            className={classNames(className, styles.field, { [styles.fieldWithPlaceholder]: !value })}
+            className={classNames(className, styles.monacoField, 'form-control', 'with-invalid-icon', {
+                [styles.monacoFieldWithPlaceholder]: !value,
+                [styles.focusContainer]: !renderedWithinFocusContainer,
+                [styles.monacoFieldWithoutFieldStyles]: renderedWithinFocusContainer,
+            })}
             editorOptions={monacoOptions}
             autoFocus={autoFocus}
             onBlur={onBlur}

--- a/client/web/src/enterprise/insights/components/form/monaco-field/MonacoPreviewLink.module.scss
+++ b/client/web/src/enterprise/insights/components/form/monaco-field/MonacoPreviewLink.module.scss
@@ -1,0 +1,14 @@
+.preview-link {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    gap: 4px;
+
+    color: var(--primary);
+    background-color: var(--color-bg-2);
+    border: 1px solid var(--border-color);
+}
+
+.preview-icon {
+    fill: var(--primary) !important;
+}

--- a/client/web/src/enterprise/insights/components/form/monaco-field/MonacoPreviewLink.tsx
+++ b/client/web/src/enterprise/insights/components/form/monaco-field/MonacoPreviewLink.tsx
@@ -1,0 +1,27 @@
+import classNames from 'classnames'
+import LinkExternalIcon from 'mdi-react/OpenInNewIcon'
+import React, { useMemo } from 'react'
+import { Link } from 'react-router-dom'
+
+import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
+import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
+import { Button } from '@sourcegraph/wildcard'
+
+import styles from './MonacoPreviewLink.module.scss'
+
+export interface MonacoPreviewLinkProps {
+    query: string
+    patternType: SearchPatternType
+    className?: string
+}
+
+export const MonacoPreviewLink: React.FunctionComponent<MonacoPreviewLinkProps> = props => {
+    const { query, patternType, className } = props
+    const queryURL = useMemo(() => `/search?${buildSearchURLQuery(query, patternType, false)}`, [patternType, query])
+
+    return (
+        <Button className={classNames(styles.previewLink, className)} to={queryURL} variant="link" as={Link}>
+            Preview results <LinkExternalIcon size={14} className={styles.previewLink} />
+        </Button>
+    )
+}

--- a/client/web/src/enterprise/insights/components/form/monaco-field/MonacoPreviewLink.tsx
+++ b/client/web/src/enterprise/insights/components/form/monaco-field/MonacoPreviewLink.tsx
@@ -21,7 +21,7 @@ export const MonacoPreviewLink: React.FunctionComponent<MonacoPreviewLinkProps> 
 
     return (
         <Button className={classNames(styles.previewLink, className)} to={queryURL} variant="link" as={Link}>
-            Preview results <LinkExternalIcon size={14} className={styles.previewLink} />
+            Preview results <LinkExternalIcon size={18} className={styles.previewLink} />
         </Button>
     )
 }

--- a/client/web/src/enterprise/insights/components/form/monaco-field/index.ts
+++ b/client/web/src/enterprise/insights/components/form/monaco-field/index.ts
@@ -1,0 +1,18 @@
+import { MonacoField, MonacoFocusContainer, MonacoFieldProps } from './MonacoField'
+import { MonacoPreviewLink } from './MonacoPreviewLink'
+
+const Root = MonacoFocusContainer
+const Field = MonacoField
+const PreviewLink = MonacoPreviewLink
+
+export {
+    MonacoFocusContainer,
+    MonacoField,
+    MonacoPreviewLink,
+    //
+    Root,
+    Field,
+    PreviewLink,
+}
+
+export type { MonacoFieldProps }

--- a/client/web/src/enterprise/insights/components/form/query-input/InsightQueryInput.module.scss
+++ b/client/web/src/enterprise/insights/components/form/query-input/InsightQueryInput.module.scss
@@ -1,0 +1,21 @@
+.root {
+    position: relative;
+    width: 100%;
+    display: flex;
+}
+
+.input-wrapper {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+}
+
+.regex-button {
+    align-self: flex-start;
+    background-color: var(--input-disabled-bg);
+}
+
+.preview-button {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-left-width: 0;
+}

--- a/client/web/src/enterprise/insights/components/form/query-input/InsightQueryInput.tsx
+++ b/client/web/src/enterprise/insights/components/form/query-input/InsightQueryInput.tsx
@@ -1,0 +1,33 @@
+import classNames from 'classnames'
+import React, { forwardRef } from 'react'
+
+import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
+
+import type { MonacoFieldProps } from '../monaco-field'
+import * as Monaco from '../monaco-field'
+
+import styles from './InsightQueryInput.module.scss'
+
+export interface InsightQueryInputProps extends MonacoFieldProps {
+    patternType: SearchPatternType
+}
+
+export const InsightQueryInput = forwardRef<HTMLInputElement, InsightQueryInputProps>((props, reference) => {
+    const { children, patternType } = props
+
+    return (
+        <div className={styles.root}>
+            {children ? (
+                <Monaco.Root className={classNames(props.className, styles.inputWrapper)}>
+                    <Monaco.Field {...props} ref={reference} className={props.className} />
+
+                    {children}
+                </Monaco.Root>
+            ) : (
+                <Monaco.Field {...props} ref={reference} className={props.className} />
+            )}
+
+            <Monaco.PreviewLink query={props.value} patternType={patternType} className={styles.previewButton} />
+        </div>
+    )
+})

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/query-input/CaptureGroupQueryInput.module.scss
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/query-input/CaptureGroupQueryInput.module.scss
@@ -1,21 +1,4 @@
-.root {
-    position: relative;
-    width: 100%;
-    display: flex;
-}
-
-.input-wrapper {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-}
-
 .regex-button {
     align-self: flex-start;
     background-color: var(--input-disabled-bg);
-}
-
-.preview-button {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-    border-left: 0;
 }

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/query-input/CaptureGroupQueryInput.module.scss
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/query-input/CaptureGroupQueryInput.module.scss
@@ -1,21 +1,21 @@
 .root {
     position: relative;
     width: 100%;
+    display: flex;
 }
 
-.input {
-    &:global(.is-invalid),
-    &:global(.is-valid) {
-        // Shift valid and invalid bootstrap icons to the left in order to make a space for
-        // regexp icon
-        padding-right: calc(1.4285714286rem + 2.25rem);
-        background-position: top calc(0.3571428571rem + 0.2075rem) right calc(0.3571428571rem + 1.861875rem);
-    }
+.input-wrapper {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
 }
 
 .regex-button {
+    align-self: flex-start;
     background-color: var(--input-disabled-bg);
-    position: absolute;
-    top: 0.375rem;
-    right: 0.375rem;
+}
+
+.preview-button {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-left: 0;
 }

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/query-input/CaptureGroupQueryInput.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/query-input/CaptureGroupQueryInput.tsx
@@ -5,18 +5,15 @@ import { Link } from 'react-router-dom'
 
 import { Button } from '@sourcegraph/wildcard'
 
-import {
-    MonacoContainer,
-    MonacoField,
-    MonacoFieldProps,
-} from '../../../../../../components/form/monaco-field/MonacoField'
+import * as Monaco from '../../../../../../components/form/monaco-field/MonacoField'
+import type { MonacoFieldProps } from '../../../../../../components/form/monaco-field/MonacoField'
 
 import styles from './CaptureGroupQueryInput.module.scss'
 
 export const CaptureGroupQueryInput = forwardRef<HTMLInputElement, MonacoFieldProps>((props, reference) => (
     <div className={styles.root}>
-        <MonacoContainer className={classNames(props.className, styles.inputWrapper)}>
-            <MonacoField {...props} ref={reference} className={props.className} />
+        <Monaco.Root className={classNames(props.className, styles.inputWrapper)}>
+            <Monaco.Field {...props} ref={reference} className={props.className} />
 
             <Button className={classNames('btn-icon', styles.regexButton)} disabled={true}>
                 <RegexIcon
@@ -24,7 +21,7 @@ export const CaptureGroupQueryInput = forwardRef<HTMLInputElement, MonacoFieldPr
                     data-tooltip="Regular expression is the only pattern type usable with capture groups and it’s enabled by default for this search input."
                 />
             </Button>
-        </MonacoContainer>
+        </Monaco.Root>
 
         <Button className={styles.previewButton} to="preview" variant="secondary" as={Link}>
             Hello

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/query-input/CaptureGroupQueryInput.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/query-input/CaptureGroupQueryInput.tsx
@@ -1,30 +1,22 @@
 import classNames from 'classnames'
 import RegexIcon from 'mdi-react/RegexIcon'
 import React, { forwardRef } from 'react'
-import { Link } from 'react-router-dom'
 
+import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { Button } from '@sourcegraph/wildcard'
 
-import * as Monaco from '../../../../../../components/form/monaco-field/MonacoField'
-import type { MonacoFieldProps } from '../../../../../../components/form/monaco-field/MonacoField'
+import type { MonacoFieldProps } from '../../../../../../components/form/monaco-field'
+import { InsightQueryInput } from '../../../../../../components/form/query-input/InsightQueryInput'
 
 import styles from './CaptureGroupQueryInput.module.scss'
 
 export const CaptureGroupQueryInput = forwardRef<HTMLInputElement, MonacoFieldProps>((props, reference) => (
-    <div className={styles.root}>
-        <Monaco.Root className={classNames(props.className, styles.inputWrapper)}>
-            <Monaco.Field {...props} ref={reference} className={props.className} />
-
-            <Button className={classNames('btn-icon', styles.regexButton)} disabled={true}>
-                <RegexIcon
-                    size={21}
-                    data-tooltip="Regular expression is the only pattern type usable with capture groups and it’s enabled by default for this search input."
-                />
-            </Button>
-        </Monaco.Root>
-
-        <Button className={styles.previewButton} to="preview" variant="secondary" as={Link}>
-            Hello
+    <InsightQueryInput {...props} ref={reference} patternType={SearchPatternType.regexp}>
+        <Button className={classNames('btn-icon', styles.regexButton)} disabled={true}>
+            <RegexIcon
+                size={21}
+                data-tooltip="Regular expression is the only pattern type usable with capture groups and it’s enabled by default for this search input."
+            />
         </Button>
-    </div>
+    </InsightQueryInput>
 ))

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/query-input/CaptureGroupQueryInput.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/query-input/CaptureGroupQueryInput.tsx
@@ -1,22 +1,33 @@
 import classNames from 'classnames'
 import RegexIcon from 'mdi-react/RegexIcon'
 import React, { forwardRef } from 'react'
+import { Link } from 'react-router-dom'
 
 import { Button } from '@sourcegraph/wildcard'
 
-import { MonacoField, MonacoFieldProps } from '../../../../../../components/form/monaco-field/MonacoField'
+import {
+    MonacoContainer,
+    MonacoField,
+    MonacoFieldProps,
+} from '../../../../../../components/form/monaco-field/MonacoField'
 
 import styles from './CaptureGroupQueryInput.module.scss'
 
 export const CaptureGroupQueryInput = forwardRef<HTMLInputElement, MonacoFieldProps>((props, reference) => (
     <div className={styles.root}>
-        <MonacoField {...props} ref={reference} className={classNames(styles.input, props.className)} />
+        <MonacoContainer className={classNames(props.className, styles.inputWrapper)}>
+            <MonacoField {...props} ref={reference} className={props.className} />
 
-        <Button className={classNames('btn-icon', styles.regexButton)} disabled={true}>
-            <RegexIcon
-                size={24}
-                data-tooltip="Regular expression is the only pattern type usable with capture groups and it’s enabled by default for this search input."
-            />
+            <Button className={classNames('btn-icon', styles.regexButton)} disabled={true}>
+                <RegexIcon
+                    size={21}
+                    data-tooltip="Regular expression is the only pattern type usable with capture groups and it’s enabled by default for this search input."
+                />
+            </Button>
+        </MonacoContainer>
+
+        <Button className={styles.previewButton} to="preview" variant="secondary" as={Link}>
+            Hello
         </Button>
     </div>
 ))

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
@@ -4,10 +4,11 @@ import { noop } from 'rxjs'
 
 import { Button } from '@sourcegraph/wildcard'
 
+import { SearchPatternType } from '../../../../../../../../graphql-operations'
 import { FormInput } from '../../../../../../components/form/form-input/FormInput'
 import { useField } from '../../../../../../components/form/hooks/useField'
 import { useForm } from '../../../../../../components/form/hooks/useForm'
-import { MonacoField } from '../../../../../../components/form/monaco-field/MonacoField'
+import { InsightQueryInput } from '../../../../../../components/form/query-input/InsightQueryInput'
 import { createRequiredValidator } from '../../../../../../components/form/validators'
 import { EditableDataSeries } from '../../types'
 import { DEFAULT_ACTIVE_COLOR, FormColorInput } from '../form-color-input/FormColorInput'
@@ -134,7 +135,8 @@ export const FormSeriesInput: React.FunctionComponent<FormSeriesInputProps> = pr
             <FormInput
                 title="Search query"
                 required={true}
-                as={MonacoField}
+                as={InsightQueryInput}
+                patternType={SearchPatternType.literal}
                 placeholder="Example: patternType:regexp const\s\w+:\s(React\.)?FunctionComponent"
                 description={<QueryFieldDescription isSearchQueryDisabled={isSearchQueryDisabled} />}
                 valid={(hasQueryControlledValue || queryField.meta.touched) && queryField.meta.validState === 'VALID'}

--- a/client/web/src/search/input/MonacoQueryInput.module.scss
+++ b/client/web/src/search/input/MonacoQueryInput.module.scss
@@ -1,4 +1,7 @@
 .monaco-query-input {
+    flex: 1;
+    min-width: 0;
+
     :global(.monaco-editor) {
         /* Disable stylelint for Monaco modifications */
         /* stylelint-disable*/

--- a/client/web/src/search/input/MonacoQueryInput.tsx
+++ b/client/web/src/search/input/MonacoQueryInput.tsx
@@ -88,6 +88,8 @@ export interface MonacoQueryInputProps
      * Issue to improve this: https://github.com/sourcegraph/sourcegraph/issues/29438
      */
     placeholder?: string
+
+    editorClassName?: string
 }
 
 /**
@@ -163,6 +165,7 @@ export const MonacoQueryInput: React.FunctionComponent<MonacoQueryInputProps> = 
     preventNewLine = true,
     editorOptions,
     onHandleFuzzyFinder,
+    editorClassName,
     caseSensitive,
     keyboardShortcutForFocus,
     onEditorCreated: onEditorCreatedCallback,
@@ -381,7 +384,6 @@ export const MonacoQueryInput: React.FunctionComponent<MonacoQueryInputProps> = 
     return (
         <div
             ref={setContainer}
-            data-placeholder={placeholder}
             className={classNames('flex-grow-1 flex-shrink-past-contents', className)}
             onFocus={onFocus}
         >
@@ -395,8 +397,9 @@ export const MonacoQueryInput: React.FunctionComponent<MonacoQueryInputProps> = 
                 onEditorCreated={onEditorCreated}
                 options={editorOptions ?? DEFAULT_MONACO_OPTIONS}
                 border={false}
+                placeholder={placeholder}
                 keyboardShortcutForFocus={KEYBOARD_SHORTCUT_FOCUS_SEARCHBAR}
-                className={classNames('test-query-input', styles.monacoQueryInput)}
+                className={classNames('test-query-input', styles.monacoQueryInput, editorClassName)}
             />
         </div>
     )

--- a/client/web/src/search/results/SearchAlert.tsx
+++ b/client/web/src/search/results/SearchAlert.tsx
@@ -27,11 +27,7 @@ export const SearchAlert: React.FunctionComponent<SearchAlertProps> = ({
     <div className="alert alert-info my-2 mr-3" data-testid="alert-container">
         <h3>{alert.title}</h3>
 
-        {alert.description && (
-            <p>
-                <Markdown dangerousInnerHTML={renderMarkdown(alert.description)} />
-            </p>
-        )}
+        {alert.description && <Markdown className="mb-3" dangerousInnerHTML={renderMarkdown(alert.description)} />}
 
         {alert.proposedQueries && (
             <>


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/28878

## Context
This PR adds a preview button/link component for capture group and search-based insight creation UIs. Also this PR re-implements Code Insights MonacoInput abstraction in a way that it could be reused in different parts of the product. 

<table>
<tr><th>Search based<th/><th>Capture group<th/></tr>
<tr><th><img width="490" alt="Screenshot 2022-01-14 at 03 37 10" src="https://user-images.githubusercontent.com/18492575/149431203-e496794e-847f-4e68-92b1-3ebde5f38adb.png"><th/><th>
<img width="621" alt="Screenshot 2022-01-14 at 03 37 00" src="https://user-images.githubusercontent.com/18492575/149431194-96ffc49a-7396-4c89-a0ef-5dbb8074d70e.png">
<th/></tr>
</table>

## TODO
- [x] Restructure Monaco query field
- [x] Add storybook stories for it
- [x] Adopt these new components in the code insight creation UI