### PR TITLE
 fix snakecase special case when acronym is pluralized 

### DIFF
--- a/internal/observation/snakecase.go
+++ b/internal/observation/snakecase.go
@@ -41,8 +41,11 @@ func toSnakeCase(s string) string {
 		if i < len(s)-1 {
 			next := s[i+1]
 			if next >= 'a' && next <= 'z' {
-				if (last != '.' && last != '_' && last != '-') &&
-					(last != 'I' || cur != 'D' || next != 's') { // special case "...IDs..."
+				isLastCapital := last >= 'A' && last <= 'Z'
+				// specialize pluralized acronyms but not 'Is', so
+				if cur == 'I' && next == 's' {
+					dist.WriteByte('_')
+				} else if last != '.' && last != '_' && last != '-' && (!isLastCapital || next != 's') {
 					dist.WriteByte('_')
 				}
 				dist.WriteByte(cur + 32)

--- a/internal/observation/snakecase.go
+++ b/internal/observation/snakecase.go
@@ -41,7 +41,8 @@ func toSnakeCase(s string) string {
 		if i < len(s)-1 {
 			next := s[i+1]
 			if next >= 'a' && next <= 'z' {
-				if last != '.' && last != '_' && last != '-' {
+				if (last != '.' && last != '_' && last != '-') &&
+					(last != 'I' || cur != 'D' || next != 's') { // special case "...IDs..."
 					dist.WriteByte('_')
 				}
 				dist.WriteByte(cur + 32)

--- a/internal/observation/snakecase_test.go
+++ b/internal/observation/snakecase_test.go
@@ -31,6 +31,7 @@ var cases = []struct {
 	{"CodeInsights.HistoricalEnqueuer", "code_insights.historical_enqueuer"},
 	{"codeintel.autoindex-enqueuer", "codeintel.autoindex_enqueuer"},
 	{"diskcache.Cached Fetch", "diskcache.cached_fetch"},
+	{"uploadIDsWithReferences", "upload_ids_with_references"},
 }
 
 func TestToSnakeCase(t *testing.T) {

--- a/internal/observation/snakecase_test.go
+++ b/internal/observation/snakecase_test.go
@@ -6,7 +6,7 @@ var cases = []struct {
 	args string
 	want string
 }{
-	/* {"", ""},
+	{"", ""},
 	{"camelCase", "camel_case"},
 	{"PascalCase", "pascal_case"},
 	{"snake_case", "snake_case"},
@@ -25,7 +25,7 @@ var cases = []struct {
 	{"Id0Value", "id0_value"},
 	{"ID0Value", "id0_value"},
 	{"MyLIFEIsAwesomE", "my_life_is_awesom_e"},
-	{"Japan125Canada130Australia150", "japan125_canada130_australia150"}, */
+	{"Japan125Canada130Australia150", "japan125_canada130_australia150"},
 	{"codeintel.uploadHandler", "codeintel.upload_handler"},
 	{"codeintel.GoodbyeBob", "codeintel.goodbye_bob"},
 	{"CodeInsights.HistoricalEnqueuer", "code_insights.historical_enqueuer"},


### PR DESCRIPTION
Fixes error where e.g. `uploadIDsWithReferences` -> `upload_i_ds_with_references`. We special case cases of `Is` e.g. `HTTPIsEnabled` -> `http_is_enabled`.

The check `(!isLastCapital || next != 's')` in English says:
"given the current letter is a capital letter:"
- if the prev letter wasnt a capital letter, add `_` (e.g. tes**t**Enabled)
- else if the prev letter _was_ a capital letter and the next one isnt an `s` (in the case of HTT**P**R**e** and not in the case of **I**D**s**), also add `_` so that HTTPRe -> http_re