### PR TITLE
monitoring generator: replace ContainerVariable with separate function constructors + use interval variables in search-blitz

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -927,27 +927,27 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: mean_successful_sentinel_duration_1h30m
+## frontend: mean_successful_sentinel_duration
 
-<p class="subtitle">mean successful sentinel search duration over 1h30m</p>
+<p class="subtitle">mean successful sentinel search duration</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 5s+ mean successful sentinel search duration over 1h30m for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 8s+ mean successful sentinel search duration over 1h30m for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 5s+ mean successful sentinel search duration for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 8s+ mean successful sentinel search duration for 30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-mean-successful-sentinel-duration-1h30m).
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-mean-successful-sentinel-duration).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_mean_successful_sentinel_duration_1h30m",
-  "critical_frontend_mean_successful_sentinel_duration_1h30m"
+  "warning_frontend_mean_successful_sentinel_duration",
+  "critical_frontend_mean_successful_sentinel_duration"
 ]
 ```
 
@@ -955,27 +955,27 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: mean_sentinel_stream_latency_1h30m
+## frontend: mean_sentinel_stream_latency
 
-<p class="subtitle">mean successful sentinel stream latency over 1h30m</p>
+<p class="subtitle">mean successful sentinel stream latency</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 2s+ mean successful sentinel stream latency over 1h30m for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 3s+ mean successful sentinel stream latency over 1h30m for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 2s+ mean successful sentinel stream latency for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 3s+ mean successful sentinel stream latency for 30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-mean-sentinel-stream-latency-1h30m).
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-mean-sentinel-stream-latency).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_mean_sentinel_stream_latency_1h30m",
-  "critical_frontend_mean_sentinel_stream_latency_1h30m"
+  "warning_frontend_mean_sentinel_stream_latency",
+  "critical_frontend_mean_sentinel_stream_latency"
 ]
 ```
 
@@ -983,27 +983,27 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: 90th_percentile_successful_sentinel_duration_1h30m
+## frontend: 90th_percentile_successful_sentinel_duration
 
-<p class="subtitle">90th percentile successful sentinel search duration over 1h30m</p>
+<p class="subtitle">90th percentile successful sentinel search duration</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 5s+ 90th percentile successful sentinel search duration over 1h30m for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 10s+ 90th percentile successful sentinel search duration over 1h30m for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 5s+ 90th percentile successful sentinel search duration for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 10s+ 90th percentile successful sentinel search duration for 30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-90th-percentile-successful-sentinel-duration-1h30m).
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-90th-percentile-successful-sentinel-duration).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_90th_percentile_successful_sentinel_duration_1h30m",
-  "critical_frontend_90th_percentile_successful_sentinel_duration_1h30m"
+  "warning_frontend_90th_percentile_successful_sentinel_duration",
+  "critical_frontend_90th_percentile_successful_sentinel_duration"
 ]
 ```
 
@@ -1011,27 +1011,27 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: 90th_percentile_sentinel_stream_latency_1h30m
+## frontend: 90th_percentile_sentinel_stream_latency
 
-<p class="subtitle">90th percentile successful sentinel stream latency over 1h30m</p>
+<p class="subtitle">90th percentile successful sentinel stream latency</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 4s+ 90th percentile successful sentinel stream latency over 1h30m for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 6s+ 90th percentile successful sentinel stream latency over 1h30m for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 4s+ 90th percentile successful sentinel stream latency for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 6s+ 90th percentile successful sentinel stream latency for 30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-90th-percentile-sentinel-stream-latency-1h30m).
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-90th-percentile-sentinel-stream-latency).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_90th_percentile_sentinel_stream_latency_1h30m",
-  "critical_frontend_90th_percentile_sentinel_stream_latency_1h30m"
+  "warning_frontend_90th_percentile_sentinel_stream_latency",
+  "critical_frontend_90th_percentile_sentinel_stream_latency"
 ]
 ```
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -2778,13 +2778,13 @@ Query: `sum by(app) (up{app=~".*(frontend|sourcegraph-frontend)"}) / count by (a
 
 ### Frontend: Sentinel queries (only on sourcegraph.com)
 
-#### frontend: mean_successful_sentinel_duration_1h30m
+#### frontend: mean_successful_sentinel_duration
 
-<p class="subtitle">Mean successful sentinel search duration over 1h30m</p>
+<p class="subtitle">Mean successful sentinel search duration</p>
 
 Mean search duration for all successful sentinel queries
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-successful-sentinel-duration-1h30m) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-successful-sentinel-duration) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102300` on your Sourcegraph instance.
 
@@ -2793,19 +2793,19 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102300`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[1h30m])) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[1h30m]))`
+Query: `sum(rate(src_search_response_latency_seconds_sum{source=~`searchblitz.*`, status=`success`}[$sentinel_sampling_duration])) / sum(rate(src_search_response_latency_seconds_count{source=~`searchblitz.*`, status=`success`}[$sentinel_sampling_duration]))`
 
 </details>
 
 <br />
 
-#### frontend: mean_sentinel_stream_latency_1h30m
+#### frontend: mean_sentinel_stream_latency
 
-<p class="subtitle">Mean successful sentinel stream latency over 1h30m</p>
+<p class="subtitle">Mean successful sentinel stream latency</p>
 
 Mean time to first result for all successful streaming sentinel queries
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-sentinel-stream-latency-1h30m) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-sentinel-stream-latency) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102301` on your Sourcegraph instance.
 
@@ -2814,19 +2814,19 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102301`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[1h30m])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[1h30m]))`
+Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[$sentinel_sampling_duration])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[$sentinel_sampling_duration]))`
 
 </details>
 
 <br />
 
-#### frontend: 90th_percentile_successful_sentinel_duration_1h30m
+#### frontend: 90th_percentile_successful_sentinel_duration
 
-<p class="subtitle">90th percentile successful sentinel search duration over 1h30m</p>
+<p class="subtitle">90th percentile successful sentinel search duration</p>
 
 90th percentile search duration for all successful sentinel queries
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-successful-sentinel-duration-1h30m) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-successful-sentinel-duration) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102310` on your Sourcegraph instance.
 
@@ -2835,19 +2835,19 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102310`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m]), "source", "$1", "source", "searchblitz_(.*)")))`
+Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration]), "source", "$1", "source", "searchblitz_(.*)")))`
 
 </details>
 
 <br />
 
-#### frontend: 90th_percentile_sentinel_stream_latency_1h30m
+#### frontend: 90th_percentile_sentinel_stream_latency
 
-<p class="subtitle">90th percentile successful sentinel stream latency over 1h30m</p>
+<p class="subtitle">90th percentile successful sentinel stream latency</p>
 
 90th percentile time to first result for all successful streaming sentinel queries
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-sentinel-stream-latency-1h30m) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-sentinel-stream-latency) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102311` on your Sourcegraph instance.
 
@@ -2856,15 +2856,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102311`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m]), "source", "$1", "source", "searchblitz_(.*)")))`
+Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[$sentinel_sampling_duration]), "source", "$1", "source", "searchblitz_(.*)")))`
 
 </details>
 
 <br />
 
-#### frontend: mean_successful_sentinel_duration_by_query_1h30m
+#### frontend: mean_successful_sentinel_duration_by_query
 
-<p class="subtitle">Mean successful sentinel search duration by query over 1h30m</p>
+<p class="subtitle">Mean successful sentinel search duration by query</p>
 
 Mean search duration for successful sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -2877,15 +2877,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102320`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[1h30m])) by (source) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[1h30m])) by (source)`
+Query: `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (source) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (source)`
 
 </details>
 
 <br />
 
-#### frontend: mean_sentinel_stream_latency_by_query_1h30m
+#### frontend: mean_sentinel_stream_latency_by_query
 
-<p class="subtitle">Mean successful sentinel stream latency by query over 1h30m</p>
+<p class="subtitle">Mean successful sentinel stream latency by query</p>
 
 Mean time to first result for successful streaming sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -2898,15 +2898,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102321`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[1h30m])) by (source) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[1h30m])) by (source)`
+Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (source) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (source)`
 
 </details>
 
 <br />
 
-#### frontend: 90th_percentile_successful_sentinel_duration_by_query_1h30m
+#### frontend: 90th_percentile_successful_sentinel_duration_by_query
 
-<p class="subtitle">90th percentile successful sentinel search duration by query over 1h30m</p>
+<p class="subtitle">90th percentile successful sentinel search duration by query</p>
 
 90th percentile search duration for successful sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -2919,15 +2919,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102330`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m])) by (le, source))`
+Query: `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (le, source))`
 
 </details>
 
 <br />
 
-#### frontend: 90th_percentile_successful_stream_latency_by_query_1h30m
+#### frontend: 90th_percentile_successful_stream_latency_by_query
 
-<p class="subtitle">90th percentile successful sentinel stream latency by query over 1h30m</p>
+<p class="subtitle">90th percentile successful sentinel stream latency by query</p>
 
 90th percentile time to first result for successful streaming sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -2940,15 +2940,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102331`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m])) by (le, source))`
+Query: `histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (le, source))`
 
 </details>
 
 <br />
 
-#### frontend: 90th_percentile_unsuccessful_duration_by_query_1h30m
+#### frontend: 90th_percentile_unsuccessful_duration_by_query
 
-<p class="subtitle">90th percentile unsuccessful sentinel search duration by query over 1h30m</p>
+<p class="subtitle">90th percentile unsuccessful sentinel search duration by query</p>
 
 90th percentile search duration of _unsuccessful_ sentinel queries (by error or timeout), broken down by query. Useful for debugging how the performance of failed requests affect UX.
 
@@ -2961,15 +2961,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102340`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[1h30m])) by (le, source))`
+Query: `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[$sentinel_sampling_duration])) by (le, source))`
 
 </details>
 
 <br />
 
-#### frontend: 75th_percentile_successful_sentinel_duration_by_query_1h30m
+#### frontend: 75th_percentile_successful_sentinel_duration_by_query
 
-<p class="subtitle">75th percentile successful sentinel search duration by query over 1h30m</p>
+<p class="subtitle">75th percentile successful sentinel search duration by query</p>
 
 75th percentile search duration of successful sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -2982,15 +2982,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102350`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m])) by (le, source))`
+Query: `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (le, source))`
 
 </details>
 
 <br />
 
-#### frontend: 75th_percentile_successful_stream_latency_by_query_1h30m
+#### frontend: 75th_percentile_successful_stream_latency_by_query
 
-<p class="subtitle">75th percentile successful sentinel stream latency by query over 1h30m</p>
+<p class="subtitle">75th percentile successful sentinel stream latency by query</p>
 
 75th percentile time to first result for successful streaming sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -3003,15 +3003,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102351`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m])) by (le, source))`
+Query: `histogram_quantile(0.75, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (le, source))`
 
 </details>
 
 <br />
 
-#### frontend: 75th_percentile_unsuccessful_duration_by_query_1h30m
+#### frontend: 75th_percentile_unsuccessful_duration_by_query
 
-<p class="subtitle">75th percentile unsuccessful sentinel search duration by query over 1h30m</p>
+<p class="subtitle">75th percentile unsuccessful sentinel search duration by query</p>
 
 75th percentile search duration of _unsuccessful_ sentinel queries (by error or timeout), broken down by query. Useful for debugging how the performance of failed requests affect UX.
 
@@ -3024,15 +3024,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102360`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[1h30m])) by (le, source))`
+Query: `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[$sentinel_sampling_duration])) by (le, source))`
 
 </details>
 
 <br />
 
-#### frontend: unsuccessful_status_rate_1h30m
+#### frontend: unsuccessful_status_rate
 
-<p class="subtitle">Unsuccessful status rate per 1h30m</p>
+<p class="subtitle">Unsuccessful status rate</p>
 
 The rate of unsuccessful sentinel queries, broken down by failure type.
 
@@ -3045,7 +3045,7 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102370`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_graphql_search_response{source=~"searchblitz.*", status!="success"}[1h30m])) by (status)`
+Query: `sum(rate(src_graphql_search_response{source=~"searchblitz.*", status!="success"}[$sentinel_sampling_duration])) by (status)`
 
 </details>
 

--- a/monitoring/definitions/executor.go
+++ b/monitoring/definitions/executor.go
@@ -1,6 +1,7 @@
 package definitions
 
 import (
+	"github.com/grafana-tools/sdk"
 	"github.com/sourcegraph/sourcegraph/monitoring/definitions/shared"
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
@@ -15,17 +16,19 @@ func Executor() *monitoring.Container {
 		Name:        "executor",
 		Title:       "Executor",
 		Description: `Executes jobs in an isolated environment.`,
-		Variables: []monitoring.ContainerVariable{
-			{
+		Variables: []sdk.TemplateVar{
+			monitoring.SelectorFromOptionsVariable(monitoring.SelectorFromOptionsArgs{
 				Label:   "Queue name",
 				Name:    "queue",
 				Options: []string{"batches", "codeintel"},
-			},
-			{
+				Multi:   true,
+			}),
+			monitoring.SelectorFromQueryVariable(monitoring.SelectorFromQueryArgs{
 				Label: "Compute instance",
 				Name:  "instance",
 				Query: "label_values(node_exporter_build_info{job=\"sourcegraph-code-intel-indexer-nodes\"}, instance)",
-			},
+				Multi: true,
+			}),
 		},
 		Groups: []monitoring.Group{
 			shared.CodeIntelligence.NewExecutorQueueGroup(queueContainerName),

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/monitoring/definitions/shared"
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
+
+	"github.com/grafana-tools/sdk"
 )
 
 func Frontend() *monitoring.Container {
@@ -15,6 +17,22 @@ func Frontend() *monitoring.Container {
 		Name:        "frontend",
 		Title:       "Frontend",
 		Description: "Serves all end-user browser and API requests.",
+		Variables: []sdk.TemplateVar{
+			monitoring.SelectorFromIntervalsVariable(monitoring.SelectorFromIntervalArgs{
+				Name:  "sentinel_sampling_duration",
+				Label: "Sentinel query sampling duration",
+				Intervals: []time.Duration{
+					1 * time.Minute,
+					5 * time.Minute,
+					10 * time.Minute,
+					30 * time.Minute,
+					1 * time.Hour,
+					90 * time.Minute,
+					3 * time.Hour,
+				},
+				Default: 90 * time.Minute,
+			}),
+		},
 		Groups: []monitoring.Group{
 			{
 				Title: "Search at a glance",
@@ -582,11 +600,11 @@ func Frontend() *monitoring.Container {
 				Rows: []monitoring.Row{
 					{
 						{
-							Name:        "mean_successful_sentinel_duration_1h30m",
-							Description: "mean successful sentinel search duration over 1h30m",
+							Name:        "mean_successful_sentinel_duration",
+							Description: "mean successful sentinel search duration",
 							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
 							// since these panels relate to metrics that don't exist on a customer instance.
-							Query:          `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[1h30m])) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[1h30m]))`,
+							Query:          "sum(rate(src_search_response_latency_seconds_sum{source=~`searchblitz.*`, status=`success`}[$sentinel_sampling_duration])) / sum(rate(src_search_response_latency_seconds_count{source=~`searchblitz.*`, status=`success`}[$sentinel_sampling_duration]))",
 							Warning:        monitoring.Alert().GreaterOrEqual(5, nil).For(15 * time.Minute),
 							Critical:       monitoring.Alert().GreaterOrEqual(8, nil).For(30 * time.Minute),
 							Panel:          monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(monitoring.PanelOptions.NoLegend()),
@@ -599,11 +617,11 @@ func Frontend() *monitoring.Container {
 							`,
 						},
 						{
-							Name:        "mean_sentinel_stream_latency_1h30m",
-							Description: "mean successful sentinel stream latency over 1h30m",
+							Name:        "mean_sentinel_stream_latency",
+							Description: "mean successful sentinel stream latency",
 							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
 							// since these panels relate to metrics that don't exist on a customer instance.
-							Query:    `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[1h30m])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[1h30m]))`,
+							Query:    `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[$sentinel_sampling_duration])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[$sentinel_sampling_duration]))`,
 							Warning:  monitoring.Alert().GreaterOrEqual(2, nil).For(15 * time.Minute),
 							Critical: monitoring.Alert().GreaterOrEqual(3, nil).For(30 * time.Minute),
 							Panel: monitoring.Panel().LegendFormat("latency").Unit(monitoring.Seconds).With(
@@ -621,11 +639,11 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:        "90th_percentile_successful_sentinel_duration_1h30m",
-							Description: "90th percentile successful sentinel search duration over 1h30m",
+							Name:        "90th_percentile_successful_sentinel_duration",
+							Description: "90th percentile successful sentinel search duration",
 							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
 							// since these panels relate to metrics that don't exist on a customer instance.
-							Query:          `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m]), "source", "$1", "source", "searchblitz_(.*)")))`,
+							Query:          `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration]), "source", "$1", "source", "searchblitz_(.*)")))`,
 							Warning:        monitoring.Alert().GreaterOrEqual(5, nil).For(15 * time.Minute),
 							Critical:       monitoring.Alert().GreaterOrEqual(10, nil).For(30 * time.Minute),
 							Panel:          monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(monitoring.PanelOptions.NoLegend()),
@@ -638,11 +656,11 @@ func Frontend() *monitoring.Container {
 							`,
 						},
 						{
-							Name:        "90th_percentile_sentinel_stream_latency_1h30m",
-							Description: "90th percentile successful sentinel stream latency over 1h30m",
+							Name:        "90th_percentile_sentinel_stream_latency",
+							Description: "90th percentile successful sentinel stream latency",
 							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
 							// since these panels relate to metrics that don't exist on a customer instance.
-							Query:    `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m]), "source", "$1", "source", "searchblitz_(.*)")))`,
+							Query:    `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[$sentinel_sampling_duration]), "source", "$1", "source", "searchblitz_(.*)")))`,
 							Warning:  monitoring.Alert().GreaterOrEqual(4, nil).For(15 * time.Minute),
 							Critical: monitoring.Alert().GreaterOrEqual(6, nil).For(30 * time.Minute),
 							Panel: monitoring.Panel().LegendFormat("latency").Unit(monitoring.Seconds).With(
@@ -660,9 +678,9 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:        "mean_successful_sentinel_duration_by_query_1h30m",
-							Description: "mean successful sentinel search duration by query over 1h30m",
-							Query:       `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[1h30m])) by (source) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[1h30m])) by (source)`,
+							Name:        "mean_successful_sentinel_duration_by_query",
+							Description: "mean successful sentinel search duration by query",
+							Query:       `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (source) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (source)`,
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.LegendOnRight(),
@@ -674,9 +692,9 @@ func Frontend() *monitoring.Container {
 							Interpretation: `Mean search duration for successful sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.`,
 						},
 						{
-							Name:        "mean_sentinel_stream_latency_by_query_1h30m",
-							Description: "mean successful sentinel stream latency by query over 1h30m",
-							Query:       `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[1h30m])) by (source) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[1h30m])) by (source)`,
+							Name:        "mean_sentinel_stream_latency_by_query",
+							Description: "mean successful sentinel stream latency by query",
+							Query:       `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (source) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (source)`,
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.LegendOnRight(),
@@ -690,9 +708,9 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:        "90th_percentile_successful_sentinel_duration_by_query_1h30m",
-							Description: "90th percentile successful sentinel search duration by query over 1h30m",
-							Query:       `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m])) by (le, source))`,
+							Name:        "90th_percentile_successful_sentinel_duration_by_query",
+							Description: "90th percentile successful sentinel search duration by query",
+							Query:       `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (le, source))`,
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.LegendOnRight(),
@@ -704,9 +722,9 @@ func Frontend() *monitoring.Container {
 							Interpretation: `90th percentile search duration for successful sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.`,
 						},
 						{
-							Name:        "90th_percentile_successful_stream_latency_by_query_1h30m",
-							Description: "90th percentile successful sentinel stream latency by query over 1h30m",
-							Query:       `histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m])) by (le, source))`,
+							Name:        "90th_percentile_successful_stream_latency_by_query",
+							Description: "90th percentile successful sentinel stream latency by query",
+							Query:       `histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (le, source))`,
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.LegendOnRight(),
@@ -720,9 +738,9 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:        "90th_percentile_unsuccessful_duration_by_query_1h30m",
-							Description: "90th percentile unsuccessful sentinel search duration by query over 1h30m",
-							Query:       "histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[1h30m])) by (le, source))",
+							Name:        "90th_percentile_unsuccessful_duration_by_query",
+							Description: "90th percentile unsuccessful sentinel search duration by query",
+							Query:       "histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[$sentinel_sampling_duration])) by (le, source))",
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{source}}").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.LegendOnRight(),
@@ -736,9 +754,9 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:        "75th_percentile_successful_sentinel_duration_by_query_1h30m",
-							Description: "75th percentile successful sentinel search duration by query over 1h30m",
-							Query:       `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m])) by (le, source))`,
+							Name:        "75th_percentile_successful_sentinel_duration_by_query",
+							Description: "75th percentile successful sentinel search duration by query",
+							Query:       `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (le, source))`,
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.LegendOnRight(),
@@ -750,9 +768,9 @@ func Frontend() *monitoring.Container {
 							Interpretation: `75th percentile search duration of successful sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.`,
 						},
 						{
-							Name:        "75th_percentile_successful_stream_latency_by_query_1h30m",
-							Description: "75th percentile successful sentinel stream latency by query over 1h30m",
-							Query:       `histogram_quantile(0.75, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m])) by (le, source))`,
+							Name:        "75th_percentile_successful_stream_latency_by_query",
+							Description: "75th percentile successful sentinel stream latency by query",
+							Query:       `histogram_quantile(0.75, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (le, source))`,
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.LegendOnRight(),
@@ -766,9 +784,9 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:        "75th_percentile_unsuccessful_duration_by_query_1h30m",
-							Description: "75th percentile unsuccessful sentinel search duration by query over 1h30m",
-							Query:       "histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[1h30m])) by (le, source))",
+							Name:        "75th_percentile_unsuccessful_duration_by_query",
+							Description: "75th percentile unsuccessful sentinel search duration by query",
+							Query:       "histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[$sentinel_sampling_duration])) by (le, source))",
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{source}}").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.LegendOnRight(),
@@ -782,9 +800,9 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:           "unsuccessful_status_rate_1h30m",
-							Description:    "unsuccessful status rate per 1h30m",
-							Query:          `sum(rate(src_graphql_search_response{source=~"searchblitz.*", status!="success"}[1h30m])) by (status)`,
+							Name:           "unsuccessful_status_rate",
+							Description:    "unsuccessful status rate",
+							Query:          `sum(rate(src_graphql_search_response{source=~"searchblitz.*", status!="success"}[$sentinel_sampling_duration])) by (status)`,
 							NoAlert:        true,
 							Panel:          monitoring.Panel().LegendFormat("{{status}}"),
 							Owner:          monitoring.ObservableOwnerSearch,

--- a/monitoring/definitions/git_server.go
+++ b/monitoring/definitions/git_server.go
@@ -25,13 +25,13 @@ func GitServer() *monitoring.Container {
 		Name:        "gitserver",
 		Title:       "Git Server",
 		Description: "Stores, manages, and operates Git repositories.",
-		Variables: []monitoring.ContainerVariable{
-			{
+		Variables: []sdk.TemplateVar{
+			monitoring.SelectorFromQueryVariable(monitoring.SelectorFromQueryArgs{
 				Label: "Shard",
 				Name:  "shard",
 				Query: "label_values(src_gitserver_exec_running, instance)",
 				Multi: true,
-			},
+			}),
 		},
 		Groups: []monitoring.Group{
 			{

--- a/monitoring/definitions/zoekt_index_server.go
+++ b/monitoring/definitions/zoekt_index_server.go
@@ -22,13 +22,13 @@ func ZoektIndexServer() *monitoring.Container {
 		Title:                    "Zoekt Index Server",
 		Description:              "Indexes repositories and populates the search index.",
 		NoSourcegraphDebugServer: true,
-		Variables: []monitoring.ContainerVariable{
-			{
+		Variables: []sdk.TemplateVar{
+			monitoring.SelectorFromQueryVariable(monitoring.SelectorFromQueryArgs{
 				Label: "Instance",
 				Name:  "instance",
 				Query: "label_values(index_num_assigned, instance)",
 				Multi: true,
-			},
+			}),
 		},
 		Groups: []monitoring.Group{
 			{


### PR DESCRIPTION
This PR does two major things:

1. It rips out the `monitoring.ContainerVariable` abstraction in favor of separate friendly helper functions that generate `sdk.TemplateVars` directly:
	- Different Grafana variable types have conflicting needs and requirements that that can't be meshed together cleanly in a sum type like `monitoring.ContainerVariable`was going to turn out to be. Consider the [interval variable type](https://grafana.com/docs/grafana/v7.2/variables/variable-types/add-interval-variable/) that I wanted to add. The notion of an "All" value or "multiple selection" doesn't really make sense with time intervals, but the logic in `toGrafanaTemplateVar` hard-codes this. The logic to handle this correctly would be messy because it needs to consider all possible states of `monitoring.ContainerVariable`'s fields.
		- The end result of continuing to use `monitoring.ContainerVariable` would be basically a "pass-through" type that would end up duplicating most/all of the underlying fields of `sdk.TemplateVariable` with no added functionality. 
		- Using separate helper functions for different kinds variables makes the logic much nicer. We can assume the user's intent (I want make a selector using a query / I want to populate a selector with time intervals) without having to consider all possible states of what the fields of `monitoring.ContainerVariable` could be in. This lets us do things like ignore checking to see which of the sub-fields are populated before we know what the value of `TemplateVariable.Type` should be - it's already known depending on which helper function you call. 
		- Using separate helper functions cleans up the interface. As a user, you don't need to understand what the "options" slice should be if you're just creating a variable that's populated with a query. 
		- Entire classes of errors are avoided (not possible to accidentally specify both `options` and `query` in the same variable, as an example)
	- Going back to using the `sdk.TemplateVariable` type in the `monitoring.Containers` struct allows us to drop down and have full access to Grafana's variable API when we need it (when we require customization that the helper functions don't offer). The helper functions generate `sdk.TemplateVariable`s, so we don't lose any ease-of-use here.
	
1. (As a motivating example) Using the interval variable helper function that was added in the previous step, the search-blitz dashboard now lets you select the sampling duration for its queries (5m, 1hr30m, etc.): 
![Screen Shot 2022-01-13 at 2 05 24 PM](https://user-images.githubusercontent.com/9022011/149416473-dc4f6073-14a3-4d87-9a13-79645a21875f.png)

