### PR TITLE
update pings for non-broken pings in 3.35

### DIFF
--- a/doc/dev/background-information/insights/code_insights_pings.md
+++ b/doc/dev/background-information/insights/code_insights_pings.md
@@ -19,7 +19,7 @@ Also, we track insight creating/editing/deleting events in the creation UI form 
 - Event Code: [InsightAddition](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+%27InsightAddition%27&patternType=literal), [InsightEdit](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+%27InsightEdit%27&patternType=literal), [InsightRemoval](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+%27InsightRemoval%27&patternType=literal)
 - PRs: [#17805](https://github.com/sourcegraph/sourcegraph/pull/17805/files)
 - **Version Added:** 3.25
-- **Version(s) broken:**  3.31+ (does not count backend insights) ([fix PR](https://github.com/sourcegraph/sourcegraph/pull/25317))
+- **Version(s) broken:**  3.31-3.35 (does not count backend insights) ([fix PR](https://github.com/sourcegraph/sourcegraph/pull/25317))
 
 
 ### Hovers count
@@ -105,7 +105,7 @@ https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegrap
 - Event Code: [InsightOrgVisible](https://sourcegraph.com/search?q=context:global+insightorgvisible+r:sourcegraph/sourcegraph%24&patternType=literal)
 - PRs: [#21671](https://github.com/sourcegraph/sourcegraph/pull/21671/files)
 - **Version Added:** 3.29
-- **Version(s) broken:** 3.31+ (doesn't handle backend insights)
+- **Version(s) broken:** 3.31-3.35 (doesn't handle backend insights) [fix PR](https://github.com/sourcegraph/sourcegraph/pull/28425)
 
 ### First time insight creators count
 
@@ -118,7 +118,7 @@ https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegrap
 - Aggregation: By week
 - Event Code: [WeeklyFirstTimeInsightCreators](https://sourcegraph.com/search?q=context:global+WeeklyFirstTimeInsightCreators+r:sourcegraph/sourcegraph%24&patternType=regexp)
 - **Version Added:** 3.25
-- **Version(s) broken:** 3.31+ (doesn't handle backend insights, other bugs)
+- **Version(s) broken:** 3.31-3.35 (doesn't handle backend insights, other bugs)
 
 ### Total count of insights grouped by step size (days)
 
@@ -131,7 +131,7 @@ https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegrap
 - Aggregation: total 
 - Event Code: [GetTimeStepCount](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+GetTimeStepCounts&patternType=literal)
 - **Version added:** 3.29
-- **Version(s) broken:** 3.31+ 
+- **Version(s) broken:** 3.31-3.35 [fix PR](https://github.com/sourcegraph/sourcegraph/pull/28425)
 
 ### Code Insights View/Click Creation Funnels
 

--- a/doc/dev/background-information/insights/code_insights_pings.md
+++ b/doc/dev/background-information/insights/code_insights_pings.md
@@ -19,7 +19,7 @@ Also, we track insight creating/editing/deleting events in the creation UI form 
 - Event Code: [InsightAddition](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+%27InsightAddition%27&patternType=literal), [InsightEdit](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+%27InsightEdit%27&patternType=literal), [InsightRemoval](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+%27InsightRemoval%27&patternType=literal)
 - PRs: [#17805](https://github.com/sourcegraph/sourcegraph/pull/17805/files)
 - **Version Added:** 3.25
-- **Version(s) broken:**  3.31-3.35 (does not count backend insights) ([fix PR](https://github.com/sourcegraph/sourcegraph/pull/25317))
+- **Version(s) broken:**  3.31-3.35.0 (does not count backend insights) ([fix PR](https://github.com/sourcegraph/sourcegraph/pull/25317))
 
 
 ### Hovers count
@@ -97,15 +97,15 @@ https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegrap
 
 **Intended purpose:** To track how many insights are visible by more than just the creator of the insight. 
 
-**Functional implementation:** we pull this out of the organization settings files (but this will change after the migration out of settings files). 
+**Functional implementation:** we gather this on the backend from TODO what table maybe?
 
-**Other considerations:** We should migrate this ping to use the new database after we finish the settings migration. 
+**Other considerations:** N/A
 
 - Aggregation: total time, by insight type
 - Event Code: [InsightOrgVisible](https://sourcegraph.com/search?q=context:global+insightorgvisible+r:sourcegraph/sourcegraph%24&patternType=literal)
 - PRs: [#21671](https://github.com/sourcegraph/sourcegraph/pull/21671/files)
 - **Version Added:** 3.29
-- **Version(s) broken:** 3.31-3.35 (doesn't handle backend insights) [fix PR](https://github.com/sourcegraph/sourcegraph/pull/28425)
+- **Version(s) broken:** 3.31-3.35.0 (doesn't handle backend insights) [fix PR](https://github.com/sourcegraph/sourcegraph/pull/28425)
 
 ### First time insight creators count
 
@@ -113,25 +113,25 @@ https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegrap
 
 **Functional implementation:** This metric queries the insight table for new addition events, then filters by unique IDs that appeared for the first time that week. 
 
-**Other considerations:** This is broken and needs to be migrated when we migrate Insight Addition event. 
+**Other considerations:** TODO does this ping include creators who create via the API? 
 
 - Aggregation: By week
 - Event Code: [WeeklyFirstTimeInsightCreators](https://sourcegraph.com/search?q=context:global+WeeklyFirstTimeInsightCreators+r:sourcegraph/sourcegraph%24&patternType=regexp)
 - **Version Added:** 3.25
-- **Version(s) broken:** 3.31-3.35 (doesn't handle backend insights, other bugs)
+- **Version(s) broken:** 3.31-3.35.0 (doesn't handle backend insights, other bugs)
 
 ### Total count of insights grouped by step size (days)
 
 **Intended purpose:** To track the x-axis (time window) set by users on frontend insights, to help prioritize features related to setting time windows. 
 
-**Functional implementation:** this metric runs on the backend over all the insights gathered from the settings files. 
+**Functional implementation:** this metric runs on the backend over all the insights. 
 
-**Other considerations:** This ping should be updated when we update the ability to set a custom time window on the backend. 
+**Other considerations:** N/A
 
 - Aggregation: total 
 - Event Code: [GetTimeStepCount](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+GetTimeStepCounts&patternType=literal)
 - **Version added:** 3.29
-- **Version(s) broken:** 3.31-3.35 [fix PR](https://github.com/sourcegraph/sourcegraph/pull/28425)
+- **Version(s) broken:** 3.31-3.35.0 [fix PR](https://github.com/sourcegraph/sourcegraph/pull/28425)
 
 ### Code Insights View/Click Creation Funnels
 


### PR DESCRIPTION
Updating pings docs with fixes from 3.35
Also, I tested additions / removals / edits with two search insights, one JIT and one global, and they seem to be working fine. This will propagate to first time creators as well.

<img width="1062" alt="CleanShot 2022-01-13 at 13 24 35@2x" src="https://user-images.githubusercontent.com/5090588/149405986-2347f78e-424e-4971-a4a7-c9442a48bde9.png">
<img width="1078" alt="CleanShot 2022-01-13 at 13 37 01@2x" src="https://user-images.githubusercontent.com/5090588/149406058-991ee442-4477-44f9-b9b7-9086db5fab51.png">
<img width="1073" alt="CleanShot 2022-01-13 at 13 37 31@2x" src="https://user-images.githubusercontent.com/5090588/149406065-5d64549c-40e1-4f07-b5f1-017e37bb4a9c.png">

