### PR TITLE
insights: remove restriction for global capture groups insights

### DIFF
--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -829,11 +829,6 @@ func createAndAttachSeries(ctx context.Context, tx *store.InsightStore, view typ
 		dynamic = *series.GeneratedFromCaptureGroups
 	}
 
-	err = validateLineChartSearchInsightInput(series)
-	if err != nil {
-		return err
-	}
-
 	// Don't try to match on just-in-time series, since they are not recorded
 	if !service.IsJustInTime(series.RepositoryScope.Repositories) {
 		matchingSeries, foundSeries, err = tx.FindMatchingSeries(ctx, store.MatchSeriesArgs{
@@ -876,17 +871,6 @@ func createAndAttachSeries(ctx context.Context, tx *store.InsightStore, view typ
 	})
 	if err != nil {
 		return errors.Wrap(err, "AttachSeriesToView")
-	}
-	return nil
-}
-
-func validateLineChartSearchInsightInput(series graphqlbackend.LineChartSearchInsightDataSeriesInput) error {
-	var generated bool
-	if series.GeneratedFromCaptureGroups != nil {
-		generated = *series.GeneratedFromCaptureGroups
-	}
-	if len(series.RepositoryScope.Repositories) == 0 && generated {
-		return errors.New("generated capture group search insights are not supported globally")
 	}
 	return nil
 }

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers_test.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers_test.go
@@ -7,74 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
-
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 )
-
-func TestValidateLineChartSearchInsightInput(t *testing.T) {
-	btrue := true
-	bfalse := false
-	t.Run("should pass validation with capture groups", func(t *testing.T) {
-		input := graphqlbackend.LineChartSearchInsightDataSeriesInput{
-			Query: "",
-			TimeScope: graphqlbackend.TimeScopeInput{StepInterval: &graphqlbackend.TimeIntervalStepInput{
-				Unit:  "MONTH",
-				Value: 1,
-			}},
-			RepositoryScope: graphqlbackend.RepositoryScopeInput{Repositories: []string{"github.com/mycompany/myrepo"}},
-			Options: graphqlbackend.LineChartDataSeriesOptionsInput{
-				Label:     addrStr("mylabel"),
-				LineColor: addrStr("red"),
-			},
-			GeneratedFromCaptureGroups: &btrue,
-		}
-
-		err := validateLineChartSearchInsightInput(input)
-		if err != nil {
-			t.Error(err)
-		}
-	})
-	t.Run("should pass validation without capture groups", func(t *testing.T) {
-		input := graphqlbackend.LineChartSearchInsightDataSeriesInput{
-			Query: "",
-			TimeScope: graphqlbackend.TimeScopeInput{StepInterval: &graphqlbackend.TimeIntervalStepInput{
-				Unit:  "MONTH",
-				Value: 1,
-			}},
-			RepositoryScope: graphqlbackend.RepositoryScopeInput{Repositories: []string{}},
-			Options: graphqlbackend.LineChartDataSeriesOptionsInput{
-				Label:     addrStr("mylabel"),
-				LineColor: addrStr("red"),
-			},
-			GeneratedFromCaptureGroups: &bfalse,
-		}
-
-		err := validateLineChartSearchInsightInput(input)
-		if err != nil {
-			t.Error(err)
-		}
-	})
-	t.Run("fails because global capture groups", func(t *testing.T) {
-		input := graphqlbackend.LineChartSearchInsightDataSeriesInput{
-			Query: "",
-			TimeScope: graphqlbackend.TimeScopeInput{StepInterval: &graphqlbackend.TimeIntervalStepInput{
-				Unit:  "MONTH",
-				Value: 1,
-			}},
-			RepositoryScope: graphqlbackend.RepositoryScopeInput{Repositories: []string{}},
-			Options: graphqlbackend.LineChartDataSeriesOptionsInput{
-				Label:     addrStr("mylabel"),
-				LineColor: addrStr("red"),
-			},
-			GeneratedFromCaptureGroups: &btrue,
-		}
-
-		err := validateLineChartSearchInsightInput(input)
-		if err == nil {
-			t.Error(err)
-		}
-	})
-}
 
 func addrStr(input string) *string {
 	return &input


### PR DESCRIPTION
Remove the validation that the capture group insight was restricted to set of repos.

``` json
{
  "input":{
    "options": {

    },
    "dataSeries": {
      "options": {
        "label": "mylabel123",
        "lineColor": "red"
      },
      "generatedFromCaptureGroups": true,
      "repositoryScope": {
        "repositories": []
      },
      "query": "file:go\\.mod$ go\\s*(\\d\\.\\d+) patterntype:regexp count:all",
      "timeScope": {
        "stepInterval": {
          "unit": "MONTH",
          "value": 6
        }
      }
    },
    "options": {
      "title": "from API global capture group insight"
    }
  }
}
```
``` json
{
  "data": {
    "createLineChartSearchInsight": {
      "view": {
        "id": "aW5zaWdodF92aWV3OiIyM2V2QTdxQlBTT0tVZGc2VVg3U0hqSE1YdTYi"
      }
    }
  }
}
```
<img width="1052" alt="image" src="https://user-images.githubusercontent.com/5090588/149407805-7c6cc37e-3c71-4f14-9138-66e23499932a.png">

