### PR TITLE
code monitors: extract email action to its own component

### DIFF
--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.test.tsx
@@ -35,11 +35,11 @@ describe('CreateCodeMonitorPage', () => {
     }
     let clock: sinon.SinonFakeTimers
 
-    beforeAll(() => {
+    beforeEach(() => {
         clock = sinon.useFakeTimers()
     })
 
-    afterAll(() => {
+    afterEach(() => {
         clock.restore()
     })
 
@@ -68,6 +68,10 @@ describe('CreateCodeMonitorPage', () => {
         userEvent.click(screen.getByTestId('form-action-toggle-email-notification'))
 
         userEvent.click(screen.getByTestId('submit-action'))
+
+        act(() => {
+            clock.tick(600)
+        })
 
         userEvent.click(screen.getByTestId('submit-monitor'))
 
@@ -103,6 +107,10 @@ describe('CreateCodeMonitorPage', () => {
         userEvent.click(screen.getByTestId('form-action-toggle-email-notification'))
         userEvent.click(screen.getByTestId('submit-action'))
 
+        act(() => {
+            clock.tick(600)
+        })
+
         // Pressing enter calls createCodeMonitor when all sections are complete
         userEvent.click(screen.getByTestId('submit-monitor'))
 
@@ -112,6 +120,6 @@ describe('CreateCodeMonitorPage', () => {
     test('Actions area button is disabled while trigger is incomplete', () => {
         render(<CreateCodeMonitorPage {...props} />)
         const actionButton = screen.getByTestId('form-action-toggle-email-notification')
-        expect(actionButton).toBeDisabled()
+        expect(actionButton).toHaveClass('disabled')
     })
 })

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
@@ -57,12 +57,15 @@ const AuthenticatedCreateCodeMonitorPage: React.FunctionComponent<CreateCodeMoni
                 trigger: { query: codeMonitor.trigger.query },
 
                 actions: codeMonitor.actions.nodes.map(action => ({
-                    email: {
-                        enabled: action.enabled,
-                        priority: MonitorEmailPriority.NORMAL,
-                        recipients: [authenticatedUser.id],
-                        header: '',
-                    },
+                    email:
+                        action.__typename === 'MonitorEmail'
+                            ? {
+                                  enabled: action.enabled,
+                                  priority: MonitorEmailPriority.NORMAL,
+                                  recipients: [authenticatedUser.id],
+                                  header: '',
+                              }
+                            : undefined,
                 })),
             })
         },

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.story.tsx
@@ -34,7 +34,6 @@ add('Example', () => (
 add('Disabled toggles', () => {
     const monitor = cloneDeep(mockCodeMonitor) // Deep clone so we can manipulate this object
     monitor.node.enabled = false
-    monitor.node.actions.enabled = false
     monitor.node.actions.nodes[0].enabled = false
 
     return (

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
@@ -112,10 +112,12 @@ describe('ManageCodeMonitorPage', () => {
 
     test('Save button is disabled when no changes have been made, enabled when changes have been made', () => {
         render(<ManageCodeMonitorPage {...props} />)
+
         const submitButton = screen.getByTestId('submit-monitor')
         expect(submitButton).toBeDisabled()
 
         userEvent.type(screen.getByTestId('name-input'), 'Test code monitor updated')
+
         expect(submitButton).toBeEnabled()
     })
 

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
@@ -83,15 +83,18 @@ const AuthenticatedManageCodeMonitorPage: React.FunctionComponent<ManageCodeMoni
                 },
                 { id: codeMonitor.trigger.id, update: { query: codeMonitor.trigger.query } },
                 codeMonitor.actions.nodes.map(action => ({
-                    email: {
-                        id: action.id,
-                        update: {
-                            enabled: action.enabled,
-                            priority: MonitorEmailPriority.NORMAL,
-                            recipients: [authenticatedUser.id],
-                            header: '',
-                        },
-                    },
+                    email:
+                        action.__typename === 'MonitorEmail'
+                            ? {
+                                  id: action.id || null, // Convert empty string to null so action is created
+                                  update: {
+                                      enabled: action.enabled,
+                                      priority: MonitorEmailPriority.NORMAL,
+                                      recipients: [authenticatedUser.id],
+                                      header: '',
+                                  },
+                              }
+                            : undefined,
                 }))
             ),
         [authenticatedUser.id, match.params.id, updateCodeMonitor]

--- a/client/web/src/enterprise/code-monitoring/backend.ts
+++ b/client/web/src/enterprise/code-monitoring/backend.ts
@@ -182,6 +182,7 @@ export const fetchCodeMonitor = (id: string): Observable<FetchCodeMonitorResult>
                     enabled
                     actions {
                         nodes {
+                            __typename
                             ... on MonitorEmail {
                                 id
                                 recipients {

--- a/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.module.scss
+++ b/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.module.scss
@@ -19,10 +19,11 @@
         border-radius: 4px;
         border: 1px solid var(--border-color);
 
-        &:hover:not(:disabled) {
+        &:hover:not(:global(.disabled)):not(:disabled) {
             /* stylelint-disable-next-line declaration-property-unit-whitelist */
             padding: calc(1rem - 1px);
             border: 2px solid var(--border-active-color);
+            cursor: pointer;
         }
     }
 }

--- a/client/web/src/enterprise/code-monitoring/components/FormActionArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormActionArea.tsx
@@ -1,20 +1,11 @@
-import classNames from 'classnames'
-import React, { useState, useCallback, useEffect } from 'react'
-import { Observable } from 'rxjs'
-import { delay, startWith, tap, mergeMap, catchError } from 'rxjs/operators'
-
-import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
-import { asError, isErrorLike } from '@sourcegraph/common'
-import { useEventObservable } from '@sourcegraph/shared/src/util/useObservable'
-import { Button } from '@sourcegraph/wildcard'
+import React, { useEffect, useState } from 'react'
 
 import { AuthenticatedUser } from '../../../auth'
-import { CodeMonitorFields, MonitorEmailPriority } from '../../../graphql-operations'
-import { triggerTestEmailAction } from '../backend'
+import { CodeMonitorFields } from '../../../graphql-operations'
 
-import styles from './FormActionArea.module.scss'
+import { EmailAction } from './actions/EmailAction'
 
-interface ActionAreaProps {
+export interface ActionAreaProps {
     actions: CodeMonitorFields['actions']
     actionsCompleted: boolean
     setActionsCompleted: (completed: boolean) => void
@@ -27,7 +18,7 @@ interface ActionAreaProps {
     cardLinkClassName?: string
 }
 
-const LOADING = 'LOADING' as const
+export type MonitorAction = CodeMonitorFields['actions']['nodes'][number]
 
 /**
  * TODO farhan: this component is built with the assumption that each monitor has exactly one email action.
@@ -45,220 +36,42 @@ export const FormActionArea: React.FunctionComponent<ActionAreaProps> = ({
     cardBtnClassName,
     cardLinkClassName,
 }) => {
-    const [showEmailNotificationForm, setShowEmailNotificationForm] = useState(false)
-    const toggleEmailNotificationForm: React.FormEventHandler = useCallback(event => {
-        event.preventDefault()
-        setShowEmailNotificationForm(show => !show)
-    }, [])
+    const [emailAction, setEmailAction] = useState<MonitorAction | undefined>(
+        actions.nodes.find(action => action.__typename === 'MonitorEmail')
+    )
+    const [emailActionCompleted, setEmailActionCompleted] = useState(!!emailAction && actionsCompleted)
 
-    const [emailNotificationEnabled, setEmailNotificationEnabled] = useState(
-        actions.nodes[0] ? actions.nodes[0].enabled : true
-    )
-
-    const toggleEmailNotificationEnabled: (enabled: boolean) => void = useCallback(
-        enabled => {
-            setEmailNotificationEnabled(enabled)
-            onActionsChange({
-                // TODO farhan: refactor to accomodate more than one action.
-                nodes: [{ id: actions.nodes[0].id, recipients: { nodes: [{ id: authenticatedUser.id }] }, enabled }],
-            })
-        },
-        [authenticatedUser, onActionsChange, actions.nodes]
-    )
-
-    const completeForm: React.FormEventHandler = useCallback(
-        event => {
-            event.preventDefault()
-            setShowEmailNotificationForm(false)
-            setActionsCompleted(true)
-            if (actions.nodes.length === 0) {
-                // We are creating a new monitor if there are no actions yet.
-                // The ID can be empty here, since we'll generate a new ID when we send the creation request.
-                onActionsChange({
-                    nodes: [{ id: '', enabled: true, recipients: { nodes: [{ id: authenticatedUser.id }] } }],
-                })
-            }
-        },
-        [setActionsCompleted, setShowEmailNotificationForm, actions.nodes.length, authenticatedUser.id, onActionsChange]
-    )
-    const cancelForm: React.FormEventHandler = useCallback(
-        event => {
-            event.preventDefault()
-            setShowEmailNotificationForm(false)
-        },
-        [setShowEmailNotificationForm]
-    )
-
-    const [isTestEmailSent, setIsTestEmailSent] = useState(false)
-    const [triggerTestEmailActionRequest, triggerTestEmailResult] = useEventObservable(
-        useCallback(
-            (click: Observable<React.MouseEvent<HTMLButtonElement>>) =>
-                click.pipe(
-                    mergeMap(() =>
-                        triggerTestEmailAction({
-                            namespace: authenticatedUser.id,
-                            description,
-                            email: {
-                                enabled: true,
-                                priority: MonitorEmailPriority.NORMAL,
-                                recipients: [authenticatedUser.id],
-                                header: '',
-                            },
-                        }).pipe(
-                            delay(1000),
-                            startWith(LOADING),
-                            tap(value => {
-                                if (value !== LOADING) {
-                                    setIsTestEmailSent(true)
-                                }
-                            }),
-                            catchError(error => [asError(error)])
-                        )
-                    )
-                ),
-            [authenticatedUser, description]
-        )
-    )
+    // Form is completed only if all set actions are completed and all incomplete actions are unset,
+    // and there is at least one completed action.
+    // (Currently there is only one action, but more will be added.)
+    useEffect(() => {
+        setActionsCompleted(!!emailAction && emailActionCompleted)
+    }, [emailAction, emailActionCompleted, setActionsCompleted])
 
     useEffect(() => {
-        if ((isTestEmailSent && !description) || !showEmailNotificationForm) {
-            setIsTestEmailSent(false)
+        const actions: CodeMonitorFields['actions'] = { nodes: [] }
+        if (emailAction) {
+            actions.nodes.push(emailAction)
         }
-    }, [isTestEmailSent, description, showEmailNotificationForm])
-
-    const sendTestEmailButtonText =
-        triggerTestEmailResult === LOADING
-            ? 'Sending email...'
-            : isTestEmailSent
-            ? 'Test email sent!'
-            : 'Send test email'
-    const isSendTestEmailButtonDisabled = triggerTestEmailResult === LOADING || isTestEmailSent || !description
+        onActionsChange(actions)
+    }, [emailAction, onActionsChange])
 
     return (
         <>
             <h3 className="mb-1">Actions</h3>
             <span className="text-muted">Run any number of actions in response to an event</span>
-            {/* This should be its own component when you can add multiple email actions */}
-            {showEmailNotificationForm && (
-                <div className={classNames(cardClassName, 'card p-3')}>
-                    <div className="font-weight-bold">Send email notifications</div>
-                    <span className="text-muted">Deliver email notifications to specified recipients.</span>
-                    <div className="form-group mt-4 test-action-form" data-testid="action-form">
-                        <label htmlFor="code-monitoring-form-actions-recipients">Recipients</label>
-                        <input
-                            id="code-monitoring-form-actions-recipients"
-                            type="text"
-                            className="form-control mb-2"
-                            value={`${authenticatedUser.email || ''} (you)`}
-                            disabled={true}
-                            autoFocus={true}
-                            required={true}
-                        />
-                        <small className="text-muted">
-                            Code monitors are currently limited to sending emails to your primary email address.
-                        </small>
-                    </div>
-                    <div className="flex mt-1">
-                        <Button
-                            className={classNames(
-                                'mr-2',
-                                isSendTestEmailButtonDisabled ? 'btn-secondary' : 'btn-outline-secondary'
-                            )}
-                            disabled={isSendTestEmailButtonDisabled}
-                            onClick={triggerTestEmailActionRequest}
-                            size="sm"
-                        >
-                            {sendTestEmailButtonText}
-                        </Button>
-                        {isTestEmailSent && triggerTestEmailResult !== LOADING && (
-                            <Button className="p-0" onClick={triggerTestEmailActionRequest} variant="link" size="sm">
-                                Send again
-                            </Button>
-                        )}
-                        {!description && (
-                            <div className={classNames('mt-2', styles.testActionError)}>
-                                Please provide a name for the code monitor before sending a test
-                            </div>
-                        )}
-                        {isErrorLike(triggerTestEmailResult) && (
-                            <div className={classNames('mt-2', styles.testActionError)}>
-                                {triggerTestEmailResult.message}
-                            </div>
-                        )}
-                    </div>
-                    <div className="d-flex align-items-center my-4">
-                        <div>
-                            <Toggle
-                                title="Enabled"
-                                value={emailNotificationEnabled}
-                                onToggle={toggleEmailNotificationEnabled}
-                                className="mr-2"
-                                aria-labelledby="code-monitoring-form-actions-enable-toggle"
-                            />
-                        </div>
-                        <span id="code-monitoring-form-actions-enable-toggle">
-                            {emailNotificationEnabled ? 'Enabled' : 'Disabled'}
-                        </span>
-                    </div>
-                    <div>
-                        <Button
-                            type="submit"
-                            data-testid="submit-action"
-                            className="mr-1 test-submit-action"
-                            onClick={completeForm}
-                            onSubmit={completeForm}
-                            variant="secondary"
-                        >
-                            Continue
-                        </Button>
-                        <Button onClick={cancelForm} outline={true} variant="secondary">
-                            Cancel
-                        </Button>
-                    </div>
-                </div>
-            )}
-            {!showEmailNotificationForm && (
-                <Button
-                    data-testid="form-action-toggle-email-notification"
-                    className={classNames('card test-action-button', cardBtnClassName)}
-                    aria-label="Edit action: Send email notifications"
-                    disabled={disabled}
-                    onClick={toggleEmailNotificationForm}
-                >
-                    <div className="d-flex justify-content-between align-items-center w-100">
-                        <div>
-                            <div
-                                className={classNames(
-                                    'font-weight-bold',
-                                    !actionsCompleted && classNames(cardLinkClassName, 'btn-link')
-                                )}
-                            >
-                                Send email notifications
-                            </div>
-                            {actionsCompleted ? (
-                                <span className="text-muted" data-testid="existing-action-email">
-                                    {authenticatedUser.email}
-                                </span>
-                            ) : (
-                                <span className="text-muted">Deliver email notifications to specified recipients.</span>
-                            )}
-                        </div>
-                        {actionsCompleted && (
-                            <div className="d-flex align-items-center">
-                                <div>
-                                    <Toggle
-                                        title="Enabled"
-                                        value={emailNotificationEnabled}
-                                        onToggle={toggleEmailNotificationEnabled}
-                                        className="mr-3"
-                                    />
-                                </div>
-                                <div className="btn-link">Edit</div>
-                            </div>
-                        )}
-                    </div>
-                </Button>
-            )}
+            <EmailAction
+                disabled={disabled}
+                action={emailAction}
+                setAction={setEmailAction}
+                actionCompleted={emailActionCompleted}
+                setActionCompleted={setEmailActionCompleted}
+                authenticatedUser={authenticatedUser}
+                cardClassName={cardClassName}
+                cardBtnClassName={cardBtnClassName}
+                cardLinkClassName={cardLinkClassName}
+                description={description}
+            />
             <small className="text-muted">
                 What other actions would you like to take?{' '}
                 <a href="mailto:feedback@sourcegraph.com" target="_blank" rel="noopener">

--- a/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormActionArea.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormActionArea.test.tsx.snap
@@ -91,20 +91,24 @@ exports[`FormActionArea Error is shown if code monitor has empty description 1`]
         Enabled
       </span>
     </div>
-    <div>
-      <button
-        class="btn btn-secondary mr-1 test-submit-action"
-        data-testid="submit-action"
-        type="submit"
-      >
-        Continue
-      </button>
-      <button
-        class="btn btn-outline-secondary"
-        type="button"
-      >
-        Cancel
-      </button>
+    <div
+      class="d-flex justify-content-between"
+    >
+      <div>
+        <button
+          class="btn btn-secondary mr-1 test-submit-action"
+          data-testid="submit-action"
+          type="submit"
+        >
+          Continue
+        </button>
+        <button
+          class="btn btn-outline-secondary"
+          type="button"
+        >
+          Cancel
+        </button>
+      </div>
     </div>
   </div>
   <small

--- a/client/web/src/enterprise/code-monitoring/components/actions/EmailAction.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/EmailAction.tsx
@@ -1,0 +1,284 @@
+import classNames from 'classnames'
+import React, { useState, useCallback, useEffect } from 'react'
+import { Observable } from 'rxjs'
+import { delay, startWith, tap, mergeMap, catchError } from 'rxjs/operators'
+
+import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
+import { asError, isErrorLike } from '@sourcegraph/common'
+import { useEventObservable } from '@sourcegraph/shared/src/util/useObservable'
+import { Button } from '@sourcegraph/wildcard'
+
+import { AuthenticatedUser } from '../../../../auth'
+import { MonitorEmailPriority } from '../../../../graphql-operations'
+import { triggerTestEmailAction } from '../../backend'
+import { MonitorAction } from '../FormActionArea'
+import styles from '../FormActionArea.module.scss'
+
+const LOADING = 'LOADING' as const
+
+interface EmailActionProps {
+    action?: MonitorAction
+    setAction: (action?: MonitorAction) => void
+    actionCompleted: boolean
+    setActionCompleted: (actionCompleted: boolean) => void
+    disabled: boolean
+    authenticatedUser: AuthenticatedUser
+    description: string
+    cardClassName?: string
+    cardBtnClassName?: string
+    cardLinkClassName?: string
+}
+
+export const EmailAction: React.FunctionComponent<EmailActionProps> = ({
+    action,
+    setAction,
+    actionCompleted,
+    setActionCompleted,
+    disabled,
+    authenticatedUser,
+    description,
+    cardClassName,
+    cardBtnClassName,
+    cardLinkClassName,
+}) => {
+    const [showEmailNotificationForm, setShowEmailNotificationForm] = useState(false)
+    const toggleEmailNotificationForm: React.FormEventHandler = useCallback(
+        event => {
+            if (!disabled) {
+                setShowEmailNotificationForm(show => !show)
+            }
+        },
+        [disabled]
+    )
+
+    const [emailNotificationEnabled, setEmailNotificationEnabled] = useState(action ? action.enabled : true)
+
+    const toggleEmailNotificationEnabled: (enabled: boolean) => void = useCallback(
+        enabled => {
+            setEmailNotificationEnabled(enabled)
+            setAction({
+                __typename: 'MonitorEmail',
+                id: action?.id ?? '',
+                recipients: { nodes: [{ id: authenticatedUser.id }] },
+                enabled,
+            })
+        },
+        [action?.id, authenticatedUser.id, setAction]
+    )
+
+    const completeForm: React.FormEventHandler = useCallback(
+        event => {
+            event.preventDefault()
+            setShowEmailNotificationForm(false)
+            setActionCompleted(true)
+            if (!action) {
+                // We are creating a new monitor if there are no actions yet.
+                // The ID can be empty here, since we'll generate a new ID when we send the creation request.
+                setAction({
+                    __typename: 'MonitorEmail',
+                    id: '',
+                    recipients: { nodes: [{ id: authenticatedUser.id }] },
+                    enabled: true,
+                })
+            }
+        },
+        [action, authenticatedUser.id, setAction, setActionCompleted]
+    )
+
+    const cancelForm: React.FormEventHandler = useCallback(
+        event => {
+            event.preventDefault()
+            setShowEmailNotificationForm(false)
+        },
+        [setShowEmailNotificationForm]
+    )
+
+    const clearForm: () => void = useCallback(() => {
+        setShowEmailNotificationForm(false)
+        setAction(undefined)
+        setActionCompleted(false)
+    }, [setAction, setActionCompleted])
+
+    const [isTestEmailSent, setIsTestEmailSent] = useState(false)
+    const [triggerTestEmailActionRequest, triggerTestEmailResult] = useEventObservable(
+        useCallback(
+            (click: Observable<React.MouseEvent<HTMLButtonElement>>) =>
+                click.pipe(
+                    mergeMap(() =>
+                        triggerTestEmailAction({
+                            namespace: authenticatedUser.id,
+                            description,
+                            email: {
+                                enabled: true,
+                                priority: MonitorEmailPriority.NORMAL,
+                                recipients: [authenticatedUser.id],
+                                header: '',
+                            },
+                        }).pipe(
+                            delay(1000),
+                            startWith(LOADING),
+                            tap(value => {
+                                if (value !== LOADING) {
+                                    setIsTestEmailSent(true)
+                                }
+                            }),
+                            catchError(error => [asError(error)])
+                        )
+                    )
+                ),
+            [authenticatedUser, description]
+        )
+    )
+
+    useEffect(() => {
+        if ((isTestEmailSent && !description) || !showEmailNotificationForm) {
+            setIsTestEmailSent(false)
+        }
+    }, [isTestEmailSent, description, showEmailNotificationForm])
+
+    const sendTestEmailButtonText =
+        triggerTestEmailResult === LOADING
+            ? 'Sending email...'
+            : isTestEmailSent
+            ? 'Test email sent!'
+            : 'Send test email'
+    const isSendTestEmailButtonDisabled = triggerTestEmailResult === LOADING || isTestEmailSent || !description
+
+    // When the action is completed, the wrapper cannot be a button because we show nested buttons inside it.
+    // Use a div instead. The edit button will still allow keyboard users to activate the form.
+    const CollapsedWrapperElement = actionCompleted ? 'div' : Button
+
+    return (
+        <>
+            {showEmailNotificationForm && (
+                <div className={classNames(cardClassName, 'card p-3')}>
+                    <div className="font-weight-bold">Send email notifications</div>
+                    <span className="text-muted">Deliver email notifications to specified recipients.</span>
+                    <div className="form-group mt-4 test-action-form" data-testid="action-form">
+                        <label htmlFor="code-monitoring-form-actions-recipients">Recipients</label>
+                        <input
+                            id="code-monitoring-form-actions-recipients"
+                            type="text"
+                            className="form-control mb-2"
+                            value={`${authenticatedUser.email || ''} (you)`}
+                            disabled={true}
+                            autoFocus={true}
+                            required={true}
+                        />
+                        <small className="text-muted">
+                            Code monitors are currently limited to sending emails to your primary email address.
+                        </small>
+                    </div>
+                    <div className="flex mt-1">
+                        <Button
+                            className={classNames(
+                                'mr-2',
+                                isSendTestEmailButtonDisabled ? 'btn-secondary' : 'btn-outline-secondary'
+                            )}
+                            disabled={isSendTestEmailButtonDisabled}
+                            onClick={triggerTestEmailActionRequest}
+                            size="sm"
+                        >
+                            {sendTestEmailButtonText}
+                        </Button>
+                        {isTestEmailSent && triggerTestEmailResult !== LOADING && (
+                            <Button className="p-0" onClick={triggerTestEmailActionRequest} variant="link" size="sm">
+                                Send again
+                            </Button>
+                        )}
+                        {!description && (
+                            <div className={classNames('mt-2', styles.testActionError)}>
+                                Please provide a name for the code monitor before sending a test
+                            </div>
+                        )}
+                        {isErrorLike(triggerTestEmailResult) && (
+                            <div className={classNames('mt-2', styles.testActionError)}>
+                                {triggerTestEmailResult.message}
+                            </div>
+                        )}
+                    </div>
+                    <div className="d-flex align-items-center my-4">
+                        <div>
+                            <Toggle
+                                title="Enabled"
+                                value={emailNotificationEnabled}
+                                onToggle={toggleEmailNotificationEnabled}
+                                className="mr-2"
+                                aria-labelledby="code-monitoring-form-actions-enable-toggle"
+                            />
+                        </div>
+                        <span id="code-monitoring-form-actions-enable-toggle">
+                            {emailNotificationEnabled ? 'Enabled' : 'Disabled'}
+                        </span>
+                    </div>
+                    <div className="d-flex justify-content-between">
+                        <div>
+                            <Button
+                                type="submit"
+                                data-testid="submit-action"
+                                className="mr-1 test-submit-action"
+                                onClick={completeForm}
+                                onSubmit={completeForm}
+                                variant="secondary"
+                            >
+                                Continue
+                            </Button>
+                            <Button onClick={cancelForm} outline={true} variant="secondary">
+                                Cancel
+                            </Button>
+                        </div>
+                        {action && (
+                            <Button onClick={clearForm} outline={true} variant="danger">
+                                Delete
+                            </Button>
+                        )}
+                    </div>
+                </div>
+            )}
+            {!showEmailNotificationForm && (
+                <CollapsedWrapperElement
+                    data-testid="form-action-toggle-email-notification"
+                    className={classNames('card test-action-button', cardBtnClassName, disabled && 'disabled')}
+                    disabled={disabled}
+                    aria-label="Edit action: Send email notifications"
+                    onClick={toggleEmailNotificationForm}
+                >
+                    <div className="d-flex justify-content-between align-items-center w-100">
+                        <div>
+                            <div
+                                className={classNames(
+                                    'font-weight-bold',
+                                    !actionCompleted && classNames(cardLinkClassName, 'btn-link')
+                                )}
+                            >
+                                Send email notifications
+                            </div>
+                            {actionCompleted ? (
+                                <span className="text-muted" data-testid="existing-action-email">
+                                    {authenticatedUser.email}
+                                </span>
+                            ) : (
+                                <span className="text-muted">Deliver email notifications to specified recipients.</span>
+                            )}
+                        </div>
+                        {actionCompleted && (
+                            <div className="d-flex align-items-center">
+                                <div>
+                                    <Toggle
+                                        title="Enabled"
+                                        value={emailNotificationEnabled}
+                                        onToggle={toggleEmailNotificationEnabled}
+                                        className="mr-3"
+                                    />
+                                </div>
+                                <Button variant="link" className="p-0">
+                                    Edit
+                                </Button>
+                            </div>
+                        )}
+                    </div>
+                </CollapsedWrapperElement>
+            )}
+        </>
+    )
+}

--- a/client/web/src/enterprise/code-monitoring/testing/util.ts
+++ b/client/web/src/enterprise/code-monitoring/testing/util.ts
@@ -41,10 +41,13 @@ export const mockCodeMonitor = {
         enabled: true,
         owner: { id: 'test-id', namespaceName: 'test-user' },
         actions: {
-            id: 'test-0',
-            enabled: true,
             nodes: [
-                { id: 'test-action-0', enabled: true, recipients: { nodes: [{ id: 'baz-0', url: '/user/test' }] } },
+                {
+                    __typename: 'MonitorEmail',
+                    id: 'test-action-0',
+                    enabled: true,
+                    recipients: { nodes: [{ id: 'baz-0', url: '/user/test' }] },
+                },
             ],
         },
         trigger: { id: 'test-0', query: 'test' },

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -217,7 +217,7 @@ func (r *Resolver) UpdateCodeMonitor(ctx context.Context, args *graphqlbackend.U
 	}
 
 	toCreate, toDelete, err := splitActionIDs(ctx, args, actionIDs)
-	if len(toDelete) == len(actionIDs) {
+	if len(toDelete) == len(actionIDs) && len(toCreate) == 0 {
 		return nil, errors.Errorf("you tried to delete all actions, but every monitor must be connected to at least 1 action")
 	}
 


### PR DESCRIPTION
In preparation for adding Slack and webhook actions to code monitors, the email action has to be extracted into its own component. Code monitors have also been made action type aware and actions can now be deleted (this required a small backend bugfix).