### PR TITLE
Code Insights: Respect `patternType` filter in query string value in Monaco syntax highlight theme

### DIFF
--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
@@ -4,7 +4,6 @@ import { noop } from 'rxjs'
 
 import { Button } from '@sourcegraph/wildcard'
 
-import { SearchPatternType } from '../../../../../../../../graphql-operations'
 import { FormInput } from '../../../../../../components/form/form-input/FormInput'
 import { useField } from '../../../../../../components/form/hooks/useField'
 import { useForm } from '../../../../../../components/form/hooks/useForm'
@@ -12,6 +11,8 @@ import { InsightQueryInput } from '../../../../../../components/form/query-input
 import { createRequiredValidator } from '../../../../../../components/form/validators'
 import { EditableDataSeries } from '../../types'
 import { DEFAULT_ACTIVE_COLOR, FormColorInput } from '../form-color-input/FormColorInput'
+
+import { getQueryPatternTypeFilter } from './get-pattern-type-filter'
 
 const requiredNameField = createRequiredValidator('Name is a required field for data series.')
 const validQuery = createRequiredValidator('Query is a required field for data series.')
@@ -136,7 +137,7 @@ export const FormSeriesInput: React.FunctionComponent<FormSeriesInputProps> = pr
                 title="Search query"
                 required={true}
                 as={InsightQueryInput}
-                patternType={SearchPatternType.literal}
+                patternType={getQueryPatternTypeFilter(queryField.input.value)}
                 placeholder="Example: patternType:regexp const\s\w+:\s(React\.)?FunctionComponent"
                 description={<QueryFieldDescription isSearchQueryDisabled={isSearchQueryDisabled} />}
                 valid={(hasQueryControlledValue || queryField.meta.touched) && queryField.meta.validState === 'VALID'}

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/get-pattern-type-filter.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/get-pattern-type-filter.ts
@@ -1,0 +1,26 @@
+import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
+import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
+import { FilterKind, findFilter } from '@sourcegraph/shared/src/search/query/query'
+
+/**
+ * Returns pattern type filter value if it's represented in the query string,
+ * otherwise returns default value for patternType filter - literal
+ */
+export function getQueryPatternTypeFilter(query: string): SearchPatternType {
+    const patternType = findFilter(query, FilterType.patterntype, FilterKind.Global)
+
+    if (patternType?.value) {
+        switch (patternType.value.value) {
+            case SearchPatternType.regexp:
+                return SearchPatternType.regexp
+            case SearchPatternType.structural:
+                return SearchPatternType.structural
+            case SearchPatternType.literal:
+                return SearchPatternType.literal
+            default:
+                return SearchPatternType.literal
+        }
+    }
+
+    return SearchPatternType.literal
+}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/29647

This PR is a preparation step for https://github.com/sourcegraph/sourcegraph/issues/29645
It adds analysis logic and by that, we take into account the value of `patternType` in a query string value and change Monaco highlight logic accordingly 