### PR TITLE
buildchecker: add command for generating historical trends

### DIFF
--- a/dev/buildchecker/README.md
+++ b/dev/buildchecker/README.md
@@ -14,6 +14,14 @@ go run ./dev/buildchecker/ # directly
 
 Also see the [`buildchecker` GitHub Action workflow](../../.github/workflows/buildchecker.yml) where this program is run on an automated basis.
 
+### History
+
+```sh
+go run ./dev/buildchecker -buildkite.token=$BUILDKITE_TOKEN -failures.timeout=999 -created.from="2021-08-01" history
+```
+
+Writes aggregated data, including the builds it finds, to a few files. To load builds from a file instead of fetching from Buildkite, use `-load-from="$FILE"`.
+
 ## Development
 
 - `branch_test.go` contains integration tests against the GitHub API. Normally runs against recordings in `testdata` - to update `testdata`, run the tests with the `-update` flag.

--- a/dev/buildchecker/checker.go
+++ b/dev/buildchecker/checker.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/buildkite/go-buildkite/v3/buildkite"
@@ -21,6 +20,8 @@ type CommitInfo struct {
 	Author string
 
 	AuthorSlackID string
+
+	Build *buildkite.Build
 }
 
 type CheckResults struct {
@@ -59,10 +60,12 @@ func CheckBuilds(ctx context.Context, branch BranchLocker, teammates team.Teamma
 
 	// if failed, check if failures are consecutive
 	var exceeded bool
-	results.FailedCommits, exceeded = checkConsecutiveFailures(
+	results.FailedCommits, exceeded, _ = checkConsecutiveFailures(
 		builds[max(firstFailedBuildIndex-1, 0):], // Check builds starting with the one we found
 		opts.FailuresThreshold,
-		opts.BuildTimeout)
+		opts.BuildTimeout,
+		false,
+		false)
 	if !exceeded {
 		fmt.Println("threshold not exceeded")
 		results.Action, err = branch.Unlock(ctx)
@@ -103,56 +106,57 @@ func isBuildFailed(build buildkite.Build, timeout time.Duration) bool {
 		return true
 	}
 	// Created, but not done
-	if build.CreatedAt != nil && build.FinishedAt == nil {
+	if timeout > 0 && build.CreatedAt != nil && build.FinishedAt == nil {
 		// Failed if exceeded timeout
 		return time.Now().After(build.CreatedAt.Add(timeout))
 	}
 	return false
 }
 
-func buildSummary(build buildkite.Build) string {
-	summary := []string{*build.Commit}
-	if build.State != nil {
-		summary = append(summary, *build.State)
-	}
-	if build.CreatedAt != nil {
-		summary = append(summary, "started: "+build.CreatedAt.String())
-	}
-	if build.FinishedAt != nil {
-		summary = append(summary, "finished: "+build.FinishedAt.String())
-	}
-	return strings.Join(summary, ", ")
-}
-
-func checkConsecutiveFailures(builds []buildkite.Build, threshold int, timeout time.Duration) (failedCommits []CommitInfo, thresholdExceeded bool) {
+func checkConsecutiveFailures(
+	builds []buildkite.Build,
+	threshold int,
+	timeout time.Duration,
+	returnAll bool,
+	includeBuild bool,
+) (failedCommits []CommitInfo, thresholdExceeded bool, buildsScanned int) {
 	failedCommits = []CommitInfo{}
 
 	var consecutiveFailures int
-	for _, b := range builds {
-		if !isBuildFailed(b, timeout) {
-			fmt.Printf("build %d not failed: %+v\n", *b.Number, buildSummary(b))
-
-			if !isBuildPassed(b) {
-				// we're only safe if non-failures are actually passed, otherwise
-				// keep looking
-				continue
-			}
+	var build buildkite.Build
+	for buildsScanned, build = range builds {
+		if isBuildPassed(build) {
+			// If we find a passed build we are done
 			return
+		} else if !isBuildFailed(build, timeout) {
+			// we're only safe if non-failures are actually passed, otherwise
+			// keep looking
+			continue
 		}
 
 		var author string
-		if b.Author != nil {
-			author = fmt.Sprintf("%s (%s)", b.Author.Name, b.Author.Email)
+		if build.Author != nil {
+			author = fmt.Sprintf("%s (%s)", build.Author.Name, build.Author.Email)
 		}
 
+		// Process this build as a failure
 		consecutiveFailures += 1
-		failedCommits = append(failedCommits, CommitInfo{
-			Commit: *b.Commit,
+		commit := CommitInfo{
 			Author: author,
-		})
-		fmt.Printf("build %d is a failure: count %d, %s\n", *b.Number, consecutiveFailures, buildSummary(b))
+		}
+		if build.Commit != nil {
+			commit.Commit = *build.Commit
+		}
+		if includeBuild {
+			b := build // copy
+			commit.Build = &b
+		}
+		failedCommits = append(failedCommits, commit)
 		if consecutiveFailures >= threshold {
-			return failedCommits, true
+			thresholdExceeded = true
+			if !returnAll {
+				return
+			}
 		}
 	}
 

--- a/dev/buildchecker/checker_test.go
+++ b/dev/buildchecker/checker_test.go
@@ -238,7 +238,7 @@ func TestCheckConsecutiveFailures(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotCommits, gotThresholdExceeded := checkConsecutiveFailures(tt.args.builds, tt.args.threshold, tt.args.timeout)
+			gotCommits, gotThresholdExceeded, _ := checkConsecutiveFailures(tt.args.builds, tt.args.threshold, tt.args.timeout, false, false)
 			assert.Equal(t, tt.wantThresholdExceeded, gotThresholdExceeded, "thresholdExceeded")
 
 			wantCommits := []CommitInfo{}

--- a/dev/buildchecker/history.go
+++ b/dev/buildchecker/history.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/buildkite/go-buildkite/v3/buildkite"
+)
+
+func generateHistory(builds []buildkite.Build, windowStart time.Time, opts CheckOptions) (totals map[string]int, flakes map[string]int, incidents map[string]int) {
+	// day:count
+	totals = make(map[string]int)
+	for _, b := range builds {
+		totals[buildDate(b)] += 1
+	}
+	// day:count
+	flakes = make(map[string]int)
+	// day:minutes
+	incidents = make(map[string]int)
+
+	// Scan over all builds
+	scanBuilds := builds
+	lastPassedBuild := windowStart
+	for len(scanBuilds) > 0 {
+		var firstFailedBuildIndex int
+		for i, b := range scanBuilds {
+			if isBuildFailed(b, opts.BuildTimeout) {
+				firstFailedBuildIndex = i
+				break
+			} else if isBuildPassed(b) {
+				lastPassedBuild = b.CreatedAt.Time
+			}
+		}
+		scanBuilds = scanBuilds[max(firstFailedBuildIndex-1, 0):]
+
+		failed, exceeded, scanned := checkConsecutiveFailures(
+			scanBuilds, opts.FailuresThreshold, opts.BuildTimeout, true, true)
+		if exceeded {
+			// Time from last passed build to oldest build in series
+			firstFailed := failed[len(failed)-1]
+			redTime := lastPassedBuild.Sub(firstFailed.Build.CreatedAt.Time)
+			incidents[buildDate(*firstFailed.Build)] += int(redTime.Minutes())
+		} else {
+			for _, f := range failed {
+				// Raw count of failed builds on date
+				flakes[buildDate(*f.Build)] += 1
+			}
+		}
+
+		if len(scanBuilds) > scanned {
+			// Set most recent passed build in last batch
+			for _, b := range scanBuilds[:scanned+1] {
+				if isBuildPassed(b) {
+					lastPassedBuild = b.CreatedAt.Time
+				}
+			}
+			// Scan next batch
+			scanBuilds = scanBuilds[scanned+1:]
+		} else {
+			scanBuilds = []buildkite.Build{}
+		}
+	}
+
+	return
+}
+
+func buildDate(build buildkite.Build) string {
+	return build.CreatedAt.Format("2006/01/02")
+}
+
+func mapToRecords(m map[string]int) (records [][]string) {
+	for k, v := range m {
+		records = append(records, []string{k, strconv.Itoa(v)})
+	}
+	// Sort by date ascending
+	sort.Slice(records, func(i, j int) bool {
+		iDate, _ := time.Parse("2006/01/02", records[i][0])
+		jDate, _ := time.Parse("2006/01/02", records[j][0])
+		return iDate.Before(jDate)
+	})
+	// TODO Fill in the gaps maybe?
+	// prev := records[0]
+	// for _, r := range records {
+	// 	rDate, _ := time.Parse("2006/01/02", r[0])
+	// 	prevDate, _ := time.Parse("2006/01/02", prev[0])
+	// 	if rDate.Sub(prevDate) > 24*time.Hour {
+	// 		records = append(a[:index+1], a[index:]...)
+	// 		a[index] = value
+	// 	}
+	// 	prev = r
+	// }
+	return
+}

--- a/dev/buildchecker/history_test.go
+++ b/dev/buildchecker/history_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/buildkite/go-buildkite/v3/buildkite"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateHistory(t *testing.T) {
+	day := time.Date(2006, 01, 02, 0, 0, 0, 0, time.UTC)
+	dayString := day.Format("2006/01/02")
+
+	tests := []struct {
+		name                    string
+		builds                  []buildkite.Build
+		wantFlakes              map[string]int
+		wantConsecutiveFailures map[string]int
+	}{{
+		name: "consecutive failures",
+		builds: []buildkite.Build{{
+			CreatedAt: &buildkite.Timestamp{Time: day.Add(2 * time.Hour)},
+			State:     buildkite.String("failed"),
+		}, {
+			CreatedAt: &buildkite.Timestamp{Time: day.Add(1 * time.Hour)},
+			State:     buildkite.String("failed"),
+		}, {
+			CreatedAt: &buildkite.Timestamp{Time: day.Add(5 * time.Minute)},
+			State:     buildkite.String("failed"),
+		}, {
+			CreatedAt: &buildkite.Timestamp{Time: day},
+			State:     buildkite.String("failed"),
+		}},
+		wantFlakes: map[string]int{},
+		wantConsecutiveFailures: map[string]int{
+			dayString: 60 * 2,
+		},
+	}, {
+		name: "passed, then consecutive failures",
+		builds: []buildkite.Build{{
+			CreatedAt: &buildkite.Timestamp{Time: day.Add(2 * time.Hour)},
+			State:     buildkite.String("passed"),
+		}, {
+			CreatedAt: &buildkite.Timestamp{Time: day.Add(1 * time.Hour)},
+			State:     buildkite.String("failed"),
+		}, {
+			CreatedAt: &buildkite.Timestamp{Time: day.Add(30 * time.Minute)},
+			State:     buildkite.String("failed"),
+		}, {
+			CreatedAt: &buildkite.Timestamp{Time: day},
+			State:     buildkite.String("failed"),
+		}},
+		wantFlakes: map[string]int{},
+		wantConsecutiveFailures: map[string]int{
+			dayString: 60 * 2,
+		},
+	}, {
+		name: "mixed flakes",
+		builds: []buildkite.Build{{
+			CreatedAt: &buildkite.Timestamp{Time: day.Add(2 * time.Hour)},
+			State:     buildkite.String("passed"),
+		}, {
+			CreatedAt: &buildkite.Timestamp{Time: day.Add(1 * time.Hour)},
+			State:     buildkite.String("failed"),
+		}, {
+			CreatedAt: &buildkite.Timestamp{Time: day.Add(30 * time.Minute)},
+			State:     buildkite.String("passed"),
+		}, {
+			CreatedAt: &buildkite.Timestamp{Time: day.Add(5 * time.Minute)},
+			State:     buildkite.String("failed"),
+		}, {
+			CreatedAt: &buildkite.Timestamp{Time: day},
+			State:     buildkite.String("failed"),
+		}},
+		wantFlakes: map[string]int{
+			dayString: 3,
+		},
+		wantConsecutiveFailures: map[string]int{},
+	}, {
+		name: "flake -> consecutive",
+		builds: []buildkite.Build{{
+			CreatedAt: &buildkite.Timestamp{Time: day.Add(2 * time.Hour)},
+			State:     buildkite.String("failed"),
+		}, {
+			CreatedAt: &buildkite.Timestamp{Time: day.Add(1 * time.Hour)},
+			State:     buildkite.String("passed"),
+		}, {
+			CreatedAt: &buildkite.Timestamp{Time: day.Add(30 * time.Minute)},
+			State:     buildkite.String("failed"),
+		}, {
+			CreatedAt: &buildkite.Timestamp{Time: day.Add(5 * time.Minute)},
+			State:     buildkite.String("failed"),
+		}, {
+			CreatedAt: &buildkite.Timestamp{Time: day},
+			State:     buildkite.String("failed"),
+		}},
+		wantFlakes: map[string]int{
+			dayString: 1,
+		},
+		wantConsecutiveFailures: map[string]int{
+			dayString: 60,
+		},
+	}, {
+		name: "consecutive -> flake",
+		builds: []buildkite.Build{{
+			CreatedAt: &buildkite.Timestamp{Time: day.Add(2 * time.Hour)},
+			State:     buildkite.String("failed"),
+		}, {
+			CreatedAt: &buildkite.Timestamp{Time: day.Add(1 * time.Hour)},
+			State:     buildkite.String("failed"),
+		}, {
+			CreatedAt: &buildkite.Timestamp{Time: day.Add(30 * time.Minute)},
+			State:     buildkite.String("failed"),
+		}, {
+			CreatedAt: &buildkite.Timestamp{Time: day.Add(5 * time.Minute)},
+			State:     buildkite.String("passed"),
+		}, {
+			CreatedAt: &buildkite.Timestamp{Time: day},
+			State:     buildkite.String("failed"),
+		}},
+		wantFlakes: map[string]int{
+			dayString: 1,
+		},
+		wantConsecutiveFailures: map[string]int{
+			dayString: 90,
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			println("--- " + t.Name())
+			_, gotFlakes, gotConsecutiveFailures := generateHistory(tt.builds, day.Add(2*time.Hour), CheckOptions{
+				FailuresThreshold: 3,
+				BuildTimeout:      0, // disable timeout check
+			})
+			assert.Equal(t, gotFlakes, tt.wantFlakes, "flakes")
+			assert.Equal(t, gotConsecutiveFailures, tt.wantConsecutiveFailures, "consecutive failures")
+		})
+	}
+}

--- a/dev/buildchecker/main.go
+++ b/dev/buildchecker/main.go
@@ -2,13 +2,17 @@ package main
 
 import (
 	"context"
+	"encoding/csv"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/buildkite/go-buildkite/v3/buildkite"
+	"github.com/cockroachdb/errors"
 	"github.com/google/go-github/v41/github"
 	"github.com/slack-go/slack"
 	"golang.org/x/oauth2"
@@ -16,32 +20,63 @@ import (
 	"github.com/sourcegraph/sourcegraph/dev/internal/team"
 )
 
-func main() {
-	var (
-		ctx                   = context.Background()
-		buildkiteToken        string
-		githubToken           string
-		slackToken            string
-		slackAnnounceWebhooks string
-		slackDebugWebhook     string
-		pipeline              string
-		branch                string
-		threshold             int
-		timeoutMins           int
-	)
+// Flags denotes shared Buildchecker flags.
+type Flags struct {
+	BuildkiteToken      string
+	Pipeline            string
+	Branch              string
+	FailuresThreshold   int
+	FailuresTimeoutMins int
+}
 
-	flag.StringVar(&buildkiteToken, "buildkite.token", "", "mandatory buildkite token")
-	flag.StringVar(&githubToken, "github.token", "", "mandatory github token")
-	flag.StringVar(&slackToken, "slack.token", "", "mandatory slack api token")
-	flag.StringVar(&slackAnnounceWebhooks, "slack.announce-webhook", "", "Slack Webhook URL to post the results on (comma-delimited for multiple values)")
-	flag.StringVar(&slackDebugWebhook, "slack.debug-webhook", "", "Slack Webhook URL to post debug results on")
-	flag.StringVar(&pipeline, "pipeline", "sourcegraph", "name of the pipeline to inspect")
-	flag.StringVar(&branch, "branch", "main", "name of the branch to inspect")
-	flag.IntVar(&threshold, "failures.threshold", 3, "failures required to trigger an incident")
-	flag.IntVar(&timeoutMins, "failures.timeout", 40, "duration of a run required to be considered a failure (minutes)")
+func (f *Flags) Parse() {
+	flag.StringVar(&f.BuildkiteToken, "buildkite.token", "", "mandatory buildkite token")
+	flag.StringVar(&f.Pipeline, "pipeline", "sourcegraph", "name of the pipeline to inspect")
+	flag.StringVar(&f.Branch, "branch", "main", "name of the branch to inspect")
+	flag.IntVar(&f.FailuresThreshold, "failures.threshold", 3, "failures required to trigger an incident")
+	flag.IntVar(&f.FailuresTimeoutMins, "failures.timeout", 40, "duration of a run required to be considered a failure (minutes)")
 	flag.Parse()
+}
 
-	config, err := buildkite.NewTokenConfig(buildkiteToken, false)
+func main() {
+	ctx := context.Background()
+
+	// Define and parse all flags
+	flags := &Flags{}
+
+	checkFlags := &cmdCheckFlags{}
+	flag.StringVar(&checkFlags.githubToken, "github.token", "", "mandatory github token")
+	flag.StringVar(&checkFlags.slackToken, "slack.token", "", "mandatory slack api token")
+	flag.StringVar(&checkFlags.slackAnnounceWebhooks, "slack.announce-webhook", "", "Slack Webhook URL to post the results on (comma-delimited for multiple values)")
+	flag.StringVar(&checkFlags.slackDebugWebhook, "slack.debug-webhook", "", "Slack Webhook URL to post debug results on")
+
+	historyFlags := &cmdHistoryFlags{}
+	flag.StringVar(&historyFlags.createdFromDate, "created.from", "", "date in YYYY-MM-DD format")
+	flag.StringVar(&historyFlags.createdToDate, "created.to", "", "date in YYYY-MM-DD format")
+	flag.StringVar(&historyFlags.loadFrom, "load-from", "", "file to load builds from")
+	flag.StringVar(&historyFlags.writeTo, "write-to", "builds.json", "file to write builds to (unused if loading from file)")
+
+	flags.Parse()
+
+	switch flag.Arg(0) {
+	case "history":
+		cmdHistory(ctx, flags, historyFlags)
+
+	default:
+		cmdCheck(ctx, flags, checkFlags)
+	}
+}
+
+type cmdCheckFlags struct {
+	slackToken  string
+	githubToken string
+
+	slackAnnounceWebhooks string
+	slackDebugWebhook     string
+}
+
+func cmdCheck(ctx context.Context, flags *Flags, checkFlags *cmdCheckFlags) {
+	config, err := buildkite.NewTokenConfig(flags.BuildkiteToken, false)
 	if err != nil {
 		log.Fatal("buildkite.NewTokenConfig: ", err)
 	}
@@ -50,16 +85,15 @@ func main() {
 
 	// GitHub client
 	ghc := github.NewClient(oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: githubToken},
+		&oauth2.Token{AccessToken: checkFlags.githubToken},
 	)))
 
 	// Slack client
-	slc := slack.New(slackToken)
+	slc := slack.New(checkFlags.slackToken)
 
 	// Newest is returned first https://buildkite.com/docs/apis/rest-api/builds#list-builds-for-a-pipeline
-	builds, _, err := bkc.Builds.ListByPipeline("sourcegraph", pipeline, &buildkite.BuildsListOptions{
-		// Branch: branch,
-		Branch: "main",
+	builds, _, err := bkc.Builds.ListByPipeline("sourcegraph", flags.Pipeline, &buildkite.BuildsListOptions{
+		Branch: flags.Branch,
 		// Fix to high page size just in case, default is 30
 		// https://buildkite.com/docs/apis/rest-api#pagination
 		ListOptions: buildkite.ListOptions{PerPage: 99},
@@ -69,13 +103,13 @@ func main() {
 	}
 
 	opts := CheckOptions{
-		FailuresThreshold: threshold,
-		BuildTimeout:      time.Duration(timeoutMins) * time.Minute,
+		FailuresThreshold: flags.FailuresThreshold,
+		BuildTimeout:      time.Duration(flags.FailuresTimeoutMins) * time.Minute,
 	}
 	log.Printf("running buildchecker over %d builds with option: %+v\n", len(builds), opts)
 	results, err := CheckBuilds(
 		ctx,
-		NewBranchLocker(ghc, "sourcegraph", "sourcegraph", branch),
+		NewBranchLocker(ghc, "sourcegraph", "sourcegraph", flags.Branch),
 		team.NewTeammateResolver(ghc, slc),
 		builds,
 		opts,
@@ -89,7 +123,7 @@ func main() {
 	lockModified := results.Action != nil
 	if lockModified {
 		summary := slackSummary(results.LockBranch, results.FailedCommits)
-		announceWebhooks := strings.Split(slackAnnounceWebhooks, ",")
+		announceWebhooks := strings.Split(checkFlags.slackAnnounceWebhooks, ",")
 
 		// Post update first to avoid invisible changes
 		if oneSucceeded, err := postSlackUpdate(announceWebhooks, summary); !oneSucceeded {
@@ -107,7 +141,7 @@ func main() {
 	POST:
 		// If post works, do the thing
 		if err := results.Action(); err != nil {
-			_, slackErr := postSlackUpdate([]string{slackDebugWebhook}, fmt.Sprintf("Failed to execute action (%+v): %s", results, err))
+			_, slackErr := postSlackUpdate([]string{checkFlags.slackDebugWebhook}, fmt.Sprintf("Failed to execute action (%+v): %s", results, err))
 			if slackErr != nil {
 				log.Fatal("postSlackUpdate: ", err)
 			}
@@ -115,4 +149,135 @@ func main() {
 			log.Fatal("results.Action: ", err)
 		}
 	}
+}
+
+type cmdHistoryFlags struct {
+	createdFromDate string
+	createdToDate   string
+	loadFrom        string
+	writeTo         string
+}
+
+func cmdHistory(ctx context.Context, flags *Flags, historyFlags *cmdHistoryFlags) {
+	// Buildkite client
+	config, err := buildkite.NewTokenConfig(flags.BuildkiteToken, false)
+	if err != nil {
+		log.Fatal("buildkite.NewTokenConfig: ", err)
+	}
+	bkc := buildkite.NewClient(config.Client())
+
+	// Time range
+	createdFrom := time.Now().Add(-24 * time.Hour)
+	if historyFlags.createdFromDate != "" {
+		createdFrom, err = time.Parse("2006-01-02", historyFlags.createdFromDate)
+		if err != nil {
+			log.Fatal("time.Parse createdFromDate: ", err)
+		}
+	}
+	createdTo := time.Now()
+	if historyFlags.createdToDate != "" {
+		createdTo, err = time.Parse("2006-01-02", historyFlags.createdToDate)
+		if err != nil {
+			log.Fatal("time.Parse createdFromDate: ", err)
+		}
+	}
+	log.Printf("listing createdFrom: %s, createdTo: %s\n", createdFrom.Format(time.RFC3339), createdTo.Format(time.RFC3339))
+
+	// Get builds
+	var builds []buildkite.Build
+	if historyFlags.loadFrom == "" {
+		log.Println("fetching builds from Buildkite")
+		var nextPage = 1
+		var pages int
+		for nextPage > 0 {
+			pages++
+
+			// Newest is returned first https://buildkite.com/docs/apis/rest-api/builds#list-builds-for-a-pipeline
+			pageBuilds, resp, err := bkc.Builds.ListByPipeline("sourcegraph", flags.Pipeline, &buildkite.BuildsListOptions{
+				Branch:             flags.Branch,
+				CreatedFrom:        createdFrom,
+				CreatedTo:          createdTo,
+				IncludeRetriedJobs: false,
+				ListOptions: buildkite.ListOptions{
+					Page: nextPage,
+					// Fix to high page size just in case, default is 30
+					// https://buildkite.com/docs/apis/rest-api#pagination
+					PerPage: 99,
+				},
+			})
+			if err != nil {
+				log.Fatal("Builds.ListByPipeline: ", err)
+			}
+
+			builds = append(builds, pageBuilds...)
+			nextPage = resp.NextPage
+		}
+
+		buildsJSON, err := json.Marshal(&builds)
+		if err != nil {
+			log.Fatal("json.Marshal(&builds): ", err)
+		}
+		if historyFlags.writeTo != "" {
+			if err := os.WriteFile(historyFlags.writeTo, buildsJSON, os.ModePerm); err != nil {
+				log.Fatal("os.WriteFile: ", err)
+			}
+			log.Println("wrote to " + historyFlags.writeTo)
+		}
+	} else {
+		log.Printf("loading builds from %s\n", historyFlags.loadFrom)
+		data, err := os.ReadFile(historyFlags.loadFrom)
+		if err != nil {
+			log.Fatal("os.ReadFile: ", err)
+		}
+		var cachedBuilds []buildkite.Build
+		if err := json.Unmarshal(data, &cachedBuilds); err != nil {
+			log.Fatal("json.Unmarshal: ", err)
+		}
+		for _, b := range cachedBuilds {
+			if b.CreatedAt.Before(createdFrom) || b.CreatedAt.After(createdTo) {
+				continue
+			}
+			builds = append(builds, b)
+		}
+	}
+	log.Printf("loaded %d builds\n", len(builds))
+
+	// Mark retried builds as failed
+	var inferredFail int
+	for _, b := range builds {
+		for _, j := range b.Jobs {
+			if j.RetriesCount > 0 {
+				failed := "failed"
+				b.State = &failed
+				inferredFail += 1
+			}
+		}
+	}
+	log.Printf("inferred %d builds as failed", inferredFail)
+
+	// Generate history
+	totals, flakes, incidents := generateHistory(builds, createdTo, CheckOptions{
+		FailuresThreshold: flags.FailuresThreshold,
+		BuildTimeout:      time.Duration(flags.FailuresTimeoutMins) * time.Minute,
+	})
+
+	// Write to files
+	var errs error
+	errs = errors.CombineErrors(errs, writeCSV("./totals.csv", mapToRecords(totals)))
+	errs = errors.CombineErrors(errs, writeCSV("./flakes.csv", mapToRecords(flakes)))
+	errs = errors.CombineErrors(errs, writeCSV("./incidents.csv", mapToRecords(incidents)))
+	if errs != nil {
+		log.Fatal("csv.WriteAll: ", errs)
+	}
+
+	log.Println("done!")
+}
+
+func writeCSV(p string, records [][]string) error {
+	f, err := os.Create(p)
+	if err != nil {
+		log.Fatal("os.OpenFile: ", err)
+	}
+	fCsv := csv.NewWriter(f)
+	return fCsv.WriteAll(records)
 }


### PR DESCRIPTION
```sh
go run ./dev/buildchecker \
	-buildkite.token=$BUILDKITE_TOKEN \
	-failures.timeout=999 \
	-created.from="2021-08-01" \
	history
```

```
2022/01/13 23:04:35 loaded 3716 builds
2022/01/13 23:04:35 inferred 437 builds as failed
```

Exported: https://docs.google.com/spreadsheets/d/1uDMUWAJeDxI6Xfer4vL_YYszPZaCqp9s8uhsNIv32VY/edit#gid=0

Discussion: https://sourcegraph.slack.com/archives/C02MWRMAFR8/p1642145938000100?thread_ts=1642092534.093300&cid=C02MWRMAFR8