### PR TITLE
add warning about intended src serve git behavior

### DIFF
--- a/doc/admin/external_service/src_serve_git.md
+++ b/doc/admin/external_service/src_serve_git.md
@@ -23,7 +23,7 @@ The most common use-case for `src serve-git` is to create git repos that do not 
 - Using `git p4` to serve up Perforce repositories.
 - Serve up local repositories to Sourcegraph while trialling it.
 
-> WARNING: `src serve git` is not intended to be used to serve repos from a code host which is already configured to be synced by a seperate code host config. For instance if you have a self managed Gitlab code host, it is not advised to use `src serve git` to serve repos on the gitlab server. 
+> WARNING: `src serve-git` is not intended to be used to serve repos from a code host which is already configured to be synced by a seperate code host config. For instance if you have a self managed Gitlab code host, it is not advised to use `src serve-git` to serve repos on the gitlab server. 
 
 ## Quickstart
 

--- a/doc/admin/external_service/src_serve_git.md
+++ b/doc/admin/external_service/src_serve_git.md
@@ -23,6 +23,8 @@ The most common use-case for `src serve-git` is to create git repos that do not 
 - Using `git p4` to serve up Perforce repositories.
 - Serve up local repositories to Sourcegraph while trialling it.
 
+> WARNING: `src serve git` is not intended to be used to serve repos from a code host which is already configured to be synced by a seperate code host config. For instance if you have a self managed Gitlab code host, it is not advised to use `src serve git` to serve repos on the gitlab server. 
+
 ## Quickstart
 
 1. [Install Sourcegraph CLI](https://github.com/sourcegraph/src-cli#installation) (`src`).


### PR DESCRIPTION
Adding warning about src serve git in relation to --
https://github.com/sourcegraph/customer/issues/619

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
