### PR TITLE
extension api: allow ext to specify max results in panels

### DIFF
--- a/client/branded/src/components/panel/Panel.tsx
+++ b/client/branded/src/components/panel/Panel.tsx
@@ -174,9 +174,11 @@ export const Panel = React.memo<Props>(props => {
                                     )
                                     .map((panelView: PanelViewWithComponent) => {
                                         const locationProviderID = panelView.component?.locationProvider
+                                        const maxLocations = panelView.component?.maxLocationResults
                                         if (locationProviderID) {
                                             const panelViewWithProvider: PanelViewWithComponent = {
                                                 ...panelView,
+                                                maxLocationResults: maxLocations,
                                                 locationProvider: wrapRemoteObservable(
                                                     extensionHostAPI.getActiveCodeEditorPosition()
                                                 ).pipe(

--- a/client/extension-api/package.json
+++ b/client/extension-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sourcegraph",
-  "version": "25.4.0",
+  "version": "25.5.0",
   "license": "Apache-2.0",
   "description": "Sourcegraph extension API: build extensions that enhance reading and reviewing code in your existing tools",
   "author": "Sourcegraph",

--- a/client/extension-api/src/sourcegraph.d.ts
+++ b/client/extension-api/src/sourcegraph.d.ts
@@ -757,14 +757,16 @@ declare module 'sourcegraph' {
         priority: number
 
         /**
-         * Display the results of the location provider (with the given ID) in this panel below the
-         * {@link PanelView#contents}.
+         * Display the results of the location provider (with the given ID) in
+         * this panel below the {@link PanelView#contents}. If
+         * maxLocationResults is set, then only maxLocationResults will be shown
+         * in the panel.
          *
          * Experimental. Subject to change or removal without notice.
          *
          * @internal
          */
-        component: { locationProvider: string } | null
+        component: { locationProvider: string; maxLocationResults?: number } | null
 
         /**
          * A selector that defines the documents this panel is applicable to.


### PR DESCRIPTION
Follow up to #29629 to allow extensions to also use the user-configured
`codeIntelligence.maxPanelResults` setting to tell the Sourcegraph how
many results are shown in provided panel.

**IMPORTANT**: I do not know how to publish a new version of the `extension-api`, so will need pointers there.
