### PR TITLE
Code Insights: Use dynamic based on step value and type props copy for data series time interval

### DIFF
--- a/client/web/src/enterprise/insights/components/creation-ui-kit/code-insight-time-step-picker/CodeInsightTimeStepPicker.tsx
+++ b/client/web/src/enterprise/insights/components/creation-ui-kit/code-insight-time-step-picker/CodeInsightTimeStepPicker.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import React, { ChangeEvent, FocusEventHandler, forwardRef } from 'react'
+import React, { ChangeEvent, FocusEventHandler, forwardRef, ReactNode } from 'react'
 
 import { InsightStep } from '../../../pages/insights/creation/search-insight/types'
 import { FormGroup } from '../../form/form-group/FormGroup'
@@ -10,6 +10,7 @@ import styles from './CodeInsightTimeStepPicker.module.scss'
 
 interface CodeInsightTimeStepPickerProps {
     value: string | number
+    numberOfPoints: number
     name?: string
     valid?: boolean
     disabled?: boolean
@@ -34,6 +35,7 @@ export const CodeInsightTimeStepPicker = forwardRef<HTMLInputElement, CodeInsigh
             name,
             value,
             stepType,
+            numberOfPoints,
             onChange,
             onStepTypeChange,
             onBlur,
@@ -44,7 +46,7 @@ export const CodeInsightTimeStepPicker = forwardRef<HTMLInputElement, CodeInsigh
             <FormGroup
                 name="insight step group"
                 title="Granularity: distance between data points"
-                description="The prototype supports timeframe up to 7 datapoints (for example: 2 weeks x 7 = 14 weeks timeframe)"
+                description={getDescriptionText({ stepValue: +value, stepType, numberOfPoints })}
                 error={error}
                 className="mt-4"
                 labelClassName={styles.groupLabel}
@@ -116,3 +118,37 @@ export const CodeInsightTimeStepPicker = forwardRef<HTMLInputElement, CodeInsigh
         )
     }
 )
+
+interface DescriptionTextOptions {
+    numberOfPoints: number
+    stepType: InsightStep
+    stepValue: number
+}
+
+function getDescriptionText(options: DescriptionTextOptions): ReactNode {
+    const { stepType, stepValue, numberOfPoints } = options
+    // Remove s at the end of stepType value, in the singular. We need to do this
+    // because Intl accepts only singular value of units.
+    const unit = stepType.slice(0, -1)
+
+    const pastUnits = (stepValue * numberOfPoints - 1).toLocaleString('en-GB', {
+        unit,
+        style: 'unit',
+        unitDisplay: 'long',
+    })
+
+    const everyUnit = stepValue.toLocaleString('en-GB', {
+        unit,
+        style: 'unit',
+        unitDisplay: 'long',
+    })
+
+    const everyUnitText = stepValue < 2 ? everyUnit.slice(2) : everyUnit
+
+    return (
+        <span>
+            The prototype supports timeframe up to {numberOfPoints} datapoints: past <b>{pastUnits} of data</b>, one
+            datapoint every {everyUnitText}.
+        </span>
+    )
+}

--- a/client/web/src/enterprise/insights/components/creation-ui-kit/code-insight-time-step-picker/CodeInsightTimeStepPicker.tsx
+++ b/client/web/src/enterprise/insights/components/creation-ui-kit/code-insight-time-step-picker/CodeInsightTimeStepPicker.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import React, { ChangeEvent, FocusEventHandler, forwardRef, ReactNode } from 'react'
+import React, { ChangeEvent, FocusEventHandler, forwardRef } from 'react'
 
 import { InsightStep } from '../../../pages/insights/creation/search-insight/types'
 import { FormGroup } from '../../form/form-group/FormGroup'
@@ -7,6 +7,7 @@ import { FormInput } from '../../form/form-input/FormInput'
 import { FormRadioInput } from '../../form/form-radio-input/FormRadioInput'
 
 import styles from './CodeInsightTimeStepPicker.module.scss'
+import { getDescriptionText } from './get-interval-descrtiption-text/get-interval-description-text'
 
 interface CodeInsightTimeStepPickerProps {
     value: string | number
@@ -118,37 +119,3 @@ export const CodeInsightTimeStepPicker = forwardRef<HTMLInputElement, CodeInsigh
         )
     }
 )
-
-interface DescriptionTextOptions {
-    numberOfPoints: number
-    stepType: InsightStep
-    stepValue: number
-}
-
-function getDescriptionText(options: DescriptionTextOptions): ReactNode {
-    const { stepType, stepValue, numberOfPoints } = options
-    // Remove s at the end of stepType value, in the singular. We need to do this
-    // because Intl accepts only singular value of units.
-    const unit = stepType.slice(0, -1)
-
-    const pastUnits = (stepValue * numberOfPoints - 1).toLocaleString('en-GB', {
-        unit,
-        style: 'unit',
-        unitDisplay: 'long',
-    })
-
-    const everyUnit = stepValue.toLocaleString('en-GB', {
-        unit,
-        style: 'unit',
-        unitDisplay: 'long',
-    })
-
-    const everyUnitText = stepValue < 2 ? everyUnit.slice(2) : everyUnit
-
-    return (
-        <span>
-            The prototype supports timeframe up to {numberOfPoints} datapoints: past <b>{pastUnits} of data</b>, one
-            datapoint every {everyUnitText}.
-        </span>
-    )
-}

--- a/client/web/src/enterprise/insights/components/creation-ui-kit/code-insight-time-step-picker/get-interval-descrtiption-text/get-interval-description-text.tsx
+++ b/client/web/src/enterprise/insights/components/creation-ui-kit/code-insight-time-step-picker/get-interval-descrtiption-text/get-interval-description-text.tsx
@@ -1,0 +1,97 @@
+import React, { ReactNode } from 'react'
+
+import { InsightStep } from '../../../../pages/insights/creation/search-insight/types'
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+declare namespace Intl {
+    type ListType = 'conjunction' | 'disjunction'
+
+    interface ListFormatOptions {
+        localeMatcher?: 'lookup' | 'best fit'
+        type?: ListType
+        style?: 'long' | 'short' | 'narrow'
+    }
+
+    class ListFormat {
+        constructor(locales?: string | string[], options?: ListFormatOptions)
+
+        public format: (items: string[]) => string
+    }
+}
+
+const LIST_FORMATTER = new Intl.ListFormat('en', { style: 'long', type: 'conjunction' })
+
+const INTERVALS = [
+    { type: 'years', inMinutes: 60 * 24 * 7 * 5 * 12 },
+    { type: 'months', inMinutes: 60 * 24 * 7 * 5 },
+    { type: 'weeks', inMinutes: 60 * 24 * 7 },
+    { type: 'days', inMinutes: 60 * 24 },
+    { type: 'hours', inMinutes: 60 },
+]
+
+interface DescriptionTextOptions {
+    numberOfPoints: number
+    stepType: InsightStep
+    stepValue: number
+}
+
+export function getDescriptionText(options: DescriptionTextOptions): ReactNode {
+    const { stepType, stepValue, numberOfPoints } = options
+    // Remove s at the end of stepType value, in the singular. We need to do this
+    // because Intl accepts only singular value of units.
+    const unit = stepType.slice(0, -1)
+
+    const intervalText = formatDuration({ [stepType]: stepValue * (numberOfPoints - 1) })
+    const everyUnit = stepValue.toLocaleString('en-GB', {
+        unit,
+        style: 'unit',
+        unitDisplay: 'long',
+    })
+
+    const everyUnitText = stepValue < 2 ? everyUnit.slice(2) : everyUnit
+
+    return (
+        <span>
+            The prototype supports timeframe up to {numberOfPoints} datapoints: past <b>{intervalText} of data</b>, one
+            datapoint every {everyUnitText}.
+        </span>
+    )
+}
+
+export function formatDuration(duration: Duration): string {
+    const intervalParts = []
+    let intervalInMinutes = toMinutes(duration)
+
+    for (const interval of INTERVALS) {
+        const amount = Math.floor(intervalInMinutes / interval.inMinutes)
+
+        intervalInMinutes -= amount * interval.inMinutes
+
+        if (amount !== 0) {
+            intervalParts.push({ unit: interval.type.slice(0, -1), value: amount })
+        }
+    }
+
+    const formattedIntervals = intervalParts.map(interval =>
+        interval.value.toLocaleString('en-GB', {
+            unit: interval.unit,
+            style: 'unit',
+            unitDisplay: 'long',
+        })
+    )
+
+    return LIST_FORMATTER.format(formattedIntervals)
+}
+
+const toMinutes = (duration: Duration): number => {
+    const { minutes = 0, hours = 0, days = 0, weeks = 0, months = 0, years = 0 } = duration
+
+    return (
+        minutes +
+        hours * 60 +
+        days * 24 * 60 +
+        weeks * 60 * 24 * 7 +
+        months * 60 * 24 * 7 * 5 +
+        years * 60 * 24 * 7 * 5 * 12
+    )
+}

--- a/client/web/src/enterprise/insights/components/creation-ui-kit/code-insight-time-step-picker/get-interval-descrtiption-text/get-interval-description.text.test.ts
+++ b/client/web/src/enterprise/insights/components/creation-ui-kit/code-insight-time-step-picker/get-interval-descrtiption-text/get-interval-description.text.test.ts
@@ -1,0 +1,39 @@
+import { formatDuration } from './get-interval-description-text'
+
+describe('formatDuration should work properly ', () => {
+    it('with minutes', () => {
+        expect(formatDuration({ minutes: 60 })).toStrictEqual('1 hour')
+    })
+
+    it('with hours', () => {
+        expect(formatDuration({ hours: 24 })).toStrictEqual('1 day')
+    })
+
+    it('with hours and days', () => {
+        expect(formatDuration({ hours: 36 })).toStrictEqual('1 day and 12 hours')
+    })
+
+    it('with days', () => {
+        expect(formatDuration({ days: 7 })).toStrictEqual('1 week')
+    })
+
+    it('with days and week', () => {
+        expect(formatDuration({ days: 10 })).toStrictEqual('1 week and 3 days')
+    })
+
+    it('with weeks', () => {
+        expect(formatDuration({ weeks: 5 })).toStrictEqual('1 month')
+    })
+
+    it('with weeks and months', () => {
+        expect(formatDuration({ weeks: 6 })).toStrictEqual('1 month and 1 week')
+    })
+
+    it('with mounts', () => {
+        expect(formatDuration({ months: 36 })).toStrictEqual('3 years')
+    })
+
+    it('with mounts and years', () => {
+        expect(formatDuration({ months: 40 })).toStrictEqual('3 years and 4 months')
+    })
+})

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/CaptureGoupCreationForm.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/CaptureGoupCreationForm.tsx
@@ -178,6 +178,7 @@ export const CaptureGroupCreationForm: React.FunctionComponent<CaptureGroupCreat
                     errorInputState={stepValue.meta.touched && stepValue.meta.validState === 'INVALID'}
                     stepType={step.input.value}
                     onStepTypeChange={step.input.onChange}
+                    numberOfPoints={7}
                 />
             </FormGroup>
 

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
@@ -196,6 +196,7 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
                     errorInputState={stepValue.meta.touched && stepValue.meta.validState === 'INVALID'}
                     stepType={step.input.value}
                     onStepTypeChange={step.input.onChange}
+                    numberOfPoints={allReposMode.input.value ? 12 : 7}
                 />
             </FormGroup>
 


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/29265

[Designs](https://www.figma.com/file/pF4IGUhCYTj9JyIWILhXrC/Fix-incorrect-copy-update-on-timeframe%2C-and-modify-for-backend-availability-%2329265-%5Breview%5D?node-id=275%3A1628)

Note that in designs you see can see a slightly different type of time interval component compared to current implementation. This PR is only about copy. The time interval component would be changed in a separate PR later.