### PR TITLE
Log cloud UTM campaign entrypoints as a standalone event

### DIFF
--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -91,12 +91,12 @@ export class EventLogger implements TelemetryService {
             return
         }
         serverAdmin.trackAction(eventLabel, eventProperties, publicArgument)
-        this.logToConsole(eventLabel, eventProperties)
+        this.logToConsole(eventLabel, eventProperties, publicArgument)
     }
 
-    private logToConsole(eventLabel: string, object?: any): void {
+    private logToConsole(eventLabel: string, eventProperties?: any, publicArgument?: any): void {
         if (localStorage && localStorage.getItem('eventLogDebug') === 'true') {
-            console.debug('%cEVENT %s', 'color: #aaa', eventLabel, object)
+            console.debug('%cEVENT %s', 'color: #aaa', eventLabel, eventProperties, publicArgument)
         }
     }
 
@@ -255,17 +255,25 @@ function pageViewQueryParameters(url: string): EventQueryParameters {
     const parsedUrl = new URL(url)
 
     const utmSource = parsedUrl.searchParams.get('utm_source')
+    const utmCampaign = parsedUrl.searchParams.get('utm_campaign')
+
+    const utmProps = {
+        utm_campaign: utmCampaign || undefined,
+        utm_source: utmSource || undefined,
+        utm_medium: parsedUrl.searchParams.get('utm_medium') || undefined,
+        utm_term: parsedUrl.searchParams.get('utm_term') || undefined,
+        utm_content: parsedUrl.searchParams.get('utm_content') || undefined,
+    }
+
     if (utmSource === 'saved-search-email') {
         eventLogger.log('SavedSearchEmailClicked')
     } else if (utmSource === 'saved-search-slack') {
         eventLogger.log('SavedSearchSlackClicked')
     } else if (utmSource === 'code-monitoring-email') {
         eventLogger.log('CodeMonitorEmailLinkClicked')
+    } else if (utmSource === 'hubspot' && utmCampaign?.match(/^cloud-onboarding-email(.*)$/)) {
+        eventLogger.log('UTMCampaignLinkClicked', utmProps, utmProps)
     }
 
-    return {
-        utm_campaign: parsedUrl.searchParams.get('utm_campaign') || undefined,
-        utm_source: parsedUrl.searchParams.get('utm_source') || undefined,
-        utm_medium: parsedUrl.searchParams.get('utm_medium') || undefined,
-    }
+    return utmProps
 }


### PR DESCRIPTION
Fixes #29483

In order to better understand the effects of different cloud marketing campaigns, we want to log these UTM parameters when a link is clicked. 

Based on the spreadsheet in #29483 we look for all UTM campaigns with `utm_source` thatequal `hubspot` and `utm_capaign` that start with `cloud-onboarding-email`. Including on-premise events wouldn't do anything as those events are not sent to analytics tools and we'd have to build a custom aggregation on the on-prem instances.

__⚠️ Note: The UTM params are tracked as the public arguments (the third arggument of the log method) which should include them in our analytics data.__

## Test Plan

- Go to `https://sourcegraph.test:3443/search?utm_source=hubspot&utm_campaign=cloud-onboarding-email6&utm_source=somethign&utm_term=learn-how-to-do-that-here&utm_content`
- Enable log debugging (`localStorage.setItem('eventLogDebug', true)` in the console).
- Verify that the new event is logged: ![Screenshot 2022-01-17 at 10 33 21](https://user-images.githubusercontent.com/458591/149744353-3630715b-8213-4e97-865b-8f25a3179fed.png)

![Screenshot 2022-01-18 at 13 57 34](https://user-images.githubusercontent.com/458591/149941573-b275eeef-bb3a-4887-bec8-b6febb791896.png)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
