### PR TITLE
bk: Log successful uploads to Buildkite analytics

### DIFF
--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -67,7 +67,7 @@ EOF
     --header 'Content-Type: application/json' \
     --data-binary @-
 
-  echo -e "\n:information_source: Succesfully uploaded test results to Buildkite analytics"
+  echo "--- :information_source: Succesfully uploaded test results to Buildkite analytics"
 
   return "$test_exit_code"
 }

--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -67,7 +67,7 @@ EOF
     --header 'Content-Type: application/json' \
     --data-binary @-
 
-  echo "--- :information_source: Succesfully uploaded test results to Buildkite analytics"
+  echo -e "\n--- :information_source: Succesfully uploaded test results to Buildkite analytics"
 
   return "$test_exit_code"
 }

--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -67,7 +67,7 @@ EOF
     --header 'Content-Type: application/json' \
     --data-binary @-
 
-  echo ":info: Succesfully uploaded test results to Buildkite analytics"
+  echo -e "\n:information_source: Succesfully uploaded test results to Buildkite analytics"
 
   return "$test_exit_code"
 }

--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -67,6 +67,8 @@ EOF
     --header 'Content-Type: application/json' \
     --data-binary @-
 
+  echo ":info: Succesfully uploaded test results to Buildkite analytics"
+
   return "$test_exit_code"
 }
 

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -15,6 +15,7 @@ import (
 
 var goAthensProxyURL = "http://athens-athens-proxy"
 
+// TODO Trigger change
 // CoreTestOperationsOptions should be used ONLY to adjust the behaviour of specific steps,
 // e.g. by adding flags, and not as a condition for adding steps or commands.
 type CoreTestOperationsOptions struct {

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -15,7 +15,6 @@ import (
 
 var goAthensProxyURL = "http://athens-athens-proxy"
 
-// TODO Trigger change
 // CoreTestOperationsOptions should be used ONLY to adjust the behaviour of specific steps,
 // e.g. by adding flags, and not as a condition for adding steps or commands.
 type CoreTestOperationsOptions struct {


### PR DESCRIPTION
For an unknown reason at the moment, we're seeing data from bk analytics in all branches but the `main` branch. This PR adds a logging message so we can double-check it before reaching out to the support. 
