### PR TITLE
web: Fork cloud sign-up page for VS Code users

### DIFF
--- a/client/web/src/auth/SignUpPage.tsx
+++ b/client/web/src/auth/SignUpPage.tsx
@@ -17,6 +17,7 @@ import { SourcegraphIcon } from './icons'
 import { getReturnTo, maybeAddPostSignUpRedirect } from './SignInSignUpCommon'
 import signInSignUpCommonStyles from './SignInSignUpCommon.module.scss'
 import { SignUpArguments, SignUpForm } from './SignUpForm'
+import { VsCodeSignUpPage } from './VsCodeSignUpPage'
 
 export interface SignUpPageProps extends ThemeProps, TelemetryProps, FeatureFlagProps {
     authenticatedUser: AuthenticatedUser | null
@@ -74,6 +75,20 @@ export const SignUpPage: React.FunctionComponent<SignUpPageProps> = ({
 
             return Promise.resolve()
         })
+
+    if (query.get('vs-code')) {
+        return (
+            <VsCodeSignUpPage
+                source={query.get('src')}
+                onSignUp={handleSignUp}
+                isLightTheme={isLightTheme}
+                showEmailForm={query.has(ShowEmailFormQueryParameter)}
+                context={context}
+                telemetryService={telemetryService}
+                featureFlags={featureFlags}
+            />
+        )
+    }
 
     if (context.sourcegraphDotComMode) {
         return (

--- a/client/web/src/auth/SignUpPage.tsx
+++ b/client/web/src/auth/SignUpPage.tsx
@@ -76,7 +76,7 @@ export const SignUpPage: React.FunctionComponent<SignUpPageProps> = ({
             return Promise.resolve()
         })
 
-    if (query.get('vs-code')) {
+    if (query.get('editor') === 'vscode') {
         return (
             <VsCodeSignUpPage
                 source={query.get('src')}

--- a/client/web/src/auth/VsCodeSignUpPage.module.scss
+++ b/client/web/src/auth/VsCodeSignUpPage.module.scss
@@ -1,0 +1,200 @@
+@import 'wildcard/src/global-styles/breakpoints';
+
+.page {
+    flex-grow: 1;
+    isolation: isolate;
+}
+
+.header-background-1 {
+    position: absolute;
+    width: 100vw;
+    top: 0;
+    bottom: 0;
+}
+
+.header-background-2 {
+    position: absolute;
+    width: 100vw;
+    top: 0;
+    bottom: 0;
+
+    :global(.theme-light) & {
+        background: radial-gradient(
+            72.88% 750.51% at 102.36% 110.93%,
+            #30b4fe 2.34%,
+            rgba(114, 183, 253, 0.15) 54.59%,
+            rgba(221, 236, 251, 0) 100%
+        );
+    }
+
+    mix-blend-mode: multiply;
+}
+
+.header-background-3 {
+    position: absolute;
+    width: 100vw;
+    top: 0;
+    bottom: 0;
+
+    :global(.theme-light) & {
+        background: linear-gradient(
+            82.41deg,
+            rgba(114, 252, 226, 0.3) 13.74%,
+            rgba(182, 251, 238, 0.3) 34.35%,
+            rgba(210, 250, 247, 0) 96.66%
+        );
+    }
+
+    mix-blend-mode: multiply;
+}
+
+.limit-width {
+    max-width: 64rem;
+    margin-left: auto;
+    margin-right: auto;
+    padding-left: 2rem;
+    padding-right: 2rem;
+}
+
+.logo {
+    width: 14.0625rem;
+    height: 2.375rem;
+    margin-top: 6rem;
+    margin-bottom: 1rem;
+    position: relative;
+}
+
+.page-heading,
+.page-heading-invited-by {
+    margin: 0;
+    padding-top: 1.5rem;
+    padding-bottom: 1rem;
+}
+
+.page-heading-invited-by {
+    font-weight: normal;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid var(--border-color);
+    margin-bottom: 1.5rem;
+    margin-top: -1.5rem;
+}
+
+.contents {
+    font-size: 1rem;
+    padding-top: 1.75rem;
+    position: relative;
+}
+
+.contents-left {
+    max-width: 30rem;
+}
+
+.feature-list {
+    margin: 2rem 0;
+}
+
+.companies-header {
+    font-size: 0.875rem;
+    margin-bottom: 2rem;
+}
+
+.sign-up-wrapper,
+.sign-up-wrapper-invited-by {
+    position: absolute;
+    top: -7.5rem;
+    right: 0;
+    width: 27.5rem;
+    background-color: var(--code-bg);
+    box-shadow: 0 2px 10px rgba(0, 27, 76, 0.16);
+    border-radius: 0.5rem;
+    padding: 3.5rem;
+
+    @media (--sm-breakpoint-down) {
+        position: static;
+        margin-top: 2rem;
+    }
+}
+
+.sign-up-wrapper-invited-by {
+    top: -3.5rem;
+}
+
+.sign-up-button {
+    display: flex;
+    align-items: center;
+    border: none;
+    width: 100%;
+    padding: 0.75rem 1rem;
+    border-radius: 4px;
+}
+
+.github-button {
+    margin-bottom: 0.75rem;
+    margin-top: 1.5rem;
+
+    :global(.theme-dark) & {
+        background-color: var(--gray-03);
+        color: var(--gray-08);
+    }
+
+    :global(.theme-light) & {
+        background: #212529;
+        color: var(--white);
+    }
+}
+
+.gitlab-button {
+    background-color: #6e49cb;
+    margin-bottom: 1rem;
+
+    :global(.theme-dark) & {
+        color: var(--gray-04);
+    }
+
+    :global(.theme-light) & {
+        color: var(--white);
+    }
+}
+
+.separator {
+    margin-top: 1.5rem;
+    margin-bottom: 2rem;
+}
+
+.back-icon {
+    margin-left: -0.25rem; // Negative margin so icon aligns with form taking internal padding into account.
+    margin-right: 0.25rem;
+}
+
+.helper-text {
+    font-size: 0.875rem;
+    line-height: 1.5;
+}
+
+.avatar {
+    width: 3rem !important;
+    height: 3rem !important;
+}
+
+.subtitle {
+    margin-bottom: 2rem;
+    border-bottom: 1px solid var(--border-color-2);
+}
+
+.page-heading {
+    font-size: 1rem;
+    font-weight: bold;
+    margin-top: 0;
+    margin-bottom: 1rem;
+}
+
+.icon-cirlce {
+    border-radius: 100%;
+    background-color: var(--theme-bg-selection);
+    width: 3rem;
+    height: 3rem;
+    padding: 0.25rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}

--- a/client/web/src/auth/VsCodeSignUpPage.module.scss
+++ b/client/web/src/auth/VsCodeSignUpPage.module.scss
@@ -5,19 +5,20 @@
     isolation: isolate;
 }
 
-.header-background-1 {
+.header-background-1,
+.header-background-2,
+.header-background-3 {
+    height: 9.375rem;
+    width: 100%;
     position: absolute;
-    width: 100vw;
     top: 0;
-    bottom: 0;
+
+    @media (--xs-breakpoint-down) {
+        height: 4rem;
+    }
 }
 
-.header-background-2 {
-    position: absolute;
-    width: 100vw;
-    top: 0;
-    bottom: 0;
-
+.header-background-1 {
     :global(.theme-light) & {
         background: radial-gradient(
             72.88% 750.51% at 102.36% 110.93%,
@@ -30,12 +31,7 @@
     mix-blend-mode: multiply;
 }
 
-.header-background-3 {
-    position: absolute;
-    width: 100vw;
-    top: 0;
-    bottom: 0;
-
+.header-background-2 {
     :global(.theme-light) & {
         background: linear-gradient(
             82.41deg,
@@ -48,49 +44,78 @@
     mix-blend-mode: multiply;
 }
 
-.limit-width {
-    max-width: 64rem;
-    margin-left: auto;
-    margin-right: auto;
-    padding-left: 2rem;
-    padding-right: 2rem;
-}
-
 .logo {
     width: 14.0625rem;
     height: 2.375rem;
-    margin-top: 6rem;
     margin-bottom: 1rem;
     position: relative;
 }
 
-.page-heading,
-.page-heading-invited-by {
-    margin: 0;
-    padding-top: 1.5rem;
-    padding-bottom: 1rem;
-}
-
-.page-heading-invited-by {
-    font-weight: normal;
-    padding-bottom: 1.5rem;
-    border-bottom: 1px solid var(--border-color);
-    margin-bottom: 1.5rem;
-    margin-top: -1.5rem;
-}
-
-.contents {
+.page-heading {
     font-size: 1rem;
-    padding-top: 1.75rem;
-    position: relative;
+    font-weight: normal;
+    margin: 0;
+    padding-top: 1rem;
+    white-space: nowrap;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid var(--border-color);
+    margin-bottom: 1rem;
+    margin-top: -1.5rem;
+
+    @media (--xs-breakpoint-down) {
+        display: flex;
+        flex-direction: column;
+    }
 }
 
-.contents-left {
+.left-or-right-container {
+    @media (--md-breakpoint-down) {
+        flex-direction: column;
+        align-items: center;
+    }
+    @media (--xs-breakpoint-down) {
+        margin-bottom: 0 !important;
+    }
+}
+
+.left-or-right {
+    height: 100%;
+    margin-top: 6rem;
+    margin-left: 2.5rem;
+    margin-right: 2.5rem;
     max-width: 30rem;
+    font-size: 1rem;
+    z-index: 1;
+
+    @media (--sm-breakpoint-down) {
+        margin-left: 1rem;
+        margin-right: 1rem;
+        max-width: calc(100vw - 2rem);
+    }
+
+    &:first-of-type {
+        margin-right: 0;
+        max-width: 32.5rem;
+        @media (--xs-breakpoint-down) {
+            margin-top: 0.75rem;
+        }
+    }
+    &:last-of-type {
+        @media (--xs-breakpoint-down) {
+            margin-top: 3rem;
+            margin-left: 0;
+            margin-right: 0;
+            margin-bottom: 0 !important;
+        }
+    }
 }
 
 .feature-list {
+    line-height: 1.6rem;
     margin: 2rem 0;
+    @media (--xs-breakpoint-down) {
+        margin-left: -1rem;
+    }
 }
 
 .companies-header {
@@ -98,25 +123,23 @@
     margin-bottom: 2rem;
 }
 
-.sign-up-wrapper,
-.sign-up-wrapper-invited-by {
-    position: absolute;
-    top: -7.5rem;
-    right: 0;
+.customer-logos {
+    @media (--xs-breakpoint-down) {
+        width: 100%;
+    }
+}
+
+.sign-up-wrapper {
     width: 27.5rem;
     background-color: var(--code-bg);
     box-shadow: 0 2px 10px rgba(0, 27, 76, 0.16);
     border-radius: 0.5rem;
     padding: 3.5rem;
 
-    @media (--sm-breakpoint-down) {
-        position: static;
-        margin-top: 2rem;
+    @media (--xs-breakpoint-down) {
+        width: 100%;
+        border-radius: 0;
     }
-}
-
-.sign-up-wrapper-invited-by {
-    top: -3.5rem;
 }
 
 .sign-up-button {
@@ -174,23 +197,12 @@
 .avatar {
     width: 3rem !important;
     height: 3rem !important;
-}
-
-.subtitle {
-    margin-bottom: 2rem;
-    border-bottom: 1px solid var(--border-color-2);
-}
-
-.page-heading {
-    font-size: 1rem;
-    font-weight: bold;
-    margin-top: 0;
-    margin-bottom: 1rem;
+    flex-shrink: 0;
 }
 
 .icon-cirlce {
     border-radius: 100%;
-    background-color: var(--theme-bg-selection);
+    background-color: #f0f0f0;
     width: 3rem;
     height: 3rem;
     padding: 0.25rem;

--- a/client/web/src/auth/VsCodeSignUpPage.module.scss
+++ b/client/web/src/auth/VsCodeSignUpPage.module.scss
@@ -94,8 +94,8 @@
     }
 
     &:first-of-type {
-        margin-right: 0;
-        max-width: 32.5rem;
+        margin-right: 1rem;
+        max-width: 31.5rem;
         @media (--xs-breakpoint-down) {
             margin-top: 0.75rem;
         }

--- a/client/web/src/auth/VsCodeSignUpPage.tsx
+++ b/client/web/src/auth/VsCodeSignUpPage.tsx
@@ -1,0 +1,178 @@
+import classNames from 'classnames'
+import ChevronLeftIcon from 'mdi-react/ChevronLeftIcon'
+import React from 'react'
+import { Link, useLocation } from 'react-router-dom'
+
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { ThemeProps } from '@sourcegraph/shared/src/theme'
+
+import { BrandLogo } from '../components/branding/BrandLogo'
+import { FeatureFlagProps } from '../featureFlags/featureFlags'
+import { AuthProvider, SourcegraphContext } from '../jscontext'
+
+import { ExternalsAuth } from './ExternalsAuth'
+import { SignUpArguments, SignUpForm } from './SignUpForm'
+import styles from './VsCodeSignUpPage.module.scss'
+
+export const ShowEmailFormQueryParameter = 'showEmail'
+interface Props extends ThemeProps, TelemetryProps, FeatureFlagProps {
+    source: string | null
+    showEmailForm: boolean
+    /** Called to perform the signup on the server. */
+    onSignUp: (args: SignUpArguments) => Promise<void>
+    context: Pick<SourcegraphContext, 'authProviders' | 'experimentalFeatures'>
+}
+
+const VSCodeIcon: React.FunctionComponent<{}> = () => (
+    <svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path
+            d="M22.0834 21.3325V8.46915L13.5834 14.9008L22.0834 21.3325ZM1.14506 11.0192C0.939444 10.7993 0.822721 10.511 0.817486 10.21C0.812252 9.90905 0.918879 9.61685 1.11672 9.38999L2.81672 7.81749C3.10006 7.56249 3.79422 7.44915 4.30422 7.81749L9.14922 11.515L20.3834 1.24415C20.8367 0.79082 21.6159 0.606653 22.5084 1.07415L28.1751 3.77999C28.6851 4.07749 29.1667 4.54499 29.1667 5.40915V24.5342C29.1667 25.1008 28.7559 25.71 28.3167 25.9508L22.0834 28.9258C21.6301 29.11 20.7801 28.94 20.4826 28.6425L9.12089 18.3008L4.30422 21.9842C3.76589 22.3525 3.10006 22.2533 2.81672 21.9842L1.11672 20.4258C0.663389 19.9583 0.720056 19.1933 1.18756 18.7258L5.43756 14.9008"
+            fill="#339AF0"
+        />
+    </svg>
+)
+
+/**
+ * Sign up page specifically from users via our VS Code integration
+ */
+export const VsCodeSignUpPage: React.FunctionComponent<Props> = ({
+    isLightTheme,
+    showEmailForm,
+    onSignUp,
+    context,
+    telemetryService,
+    featureFlags,
+}) => {
+    const location = useLocation()
+
+    const queryWithUseEmailToggled = new URLSearchParams(location.search)
+    if (showEmailForm) {
+        queryWithUseEmailToggled.delete(ShowEmailFormQueryParameter)
+    } else {
+        queryWithUseEmailToggled.append(ShowEmailFormQueryParameter, 'true')
+    }
+
+    const assetsRoot = window.context?.assetsRoot || ''
+
+    const logEvent = (type: AuthProvider['serviceType']): void => {
+        const eventType = type === 'builtin' ? 'form' : type
+        telemetryService.log(
+            'SignupInitiated',
+            { type: eventType, source: 'vs-code' },
+            { type: eventType, source: 'vs-code' }
+        )
+    }
+
+    const signUpForm = (
+        <SignUpForm
+            featureFlags={featureFlags}
+            onSignUp={args => {
+                logEvent('builtin')
+                return onSignUp(args)
+            }}
+            context={{ authProviders: [], sourcegraphDotComMode: true }}
+            buttonLabel="Sign up"
+            experimental={true}
+            className="my-3"
+        />
+    )
+
+    const renderCodeHostAuth = (): JSX.Element => (
+        <>
+            <ExternalsAuth
+                context={context}
+                githubLabel="Continue with GitHub"
+                gitlabLabel="Continue with GitLab"
+                onClick={logEvent}
+            />
+
+            <div className="mb-4">
+                Or, <Link to={`${location.pathname}?${queryWithUseEmailToggled.toString()}`}>continue with email</Link>
+            </div>
+        </>
+    )
+
+    const renderEmailAuthForm = (): JSX.Element => (
+        <>
+            <small className="d-block mt-3">
+                <Link
+                    className="d-flex align-items-center"
+                    to={`${location.pathname}?${queryWithUseEmailToggled.toString()}`}
+                >
+                    <ChevronLeftIcon className={classNames('icon-inline', styles.backIcon)} />
+                    Go back
+                </Link>
+            </small>
+
+            {signUpForm}
+        </>
+    )
+
+    const renderAuthMethod = (): JSX.Element => (showEmailForm ? renderEmailAuthForm() : renderCodeHostAuth())
+
+    return (
+        <div className={styles.page}>
+            <header>
+                <div className="position-relative">
+                    <div className={styles.headerBackground1} />
+                    <div className={styles.headerBackground2} />
+                    <div className={styles.headerBackground3} />
+
+                    <div className={styles.limitWidth}>
+                        <BrandLogo isLightTheme={isLightTheme} variant="logo" className={styles.logo} />
+                    </div>
+                </div>
+            </header>
+
+            <div className={classNames(styles.contents, styles.limitWidth)}>
+                <div className={classNames(styles.contentsLeft, styles.subtitle)}>
+                    <h2 className={classNames('d-flex', 'align-items-center', styles.pageHeading)}>
+                        <div className={classNames(styles.iconCirlce, 'mr-3')}>
+                            <VSCodeIcon />
+                        </div>{' '}
+                        Unlock the full potential of the Sourcegraph extension
+                    </h2>
+                </div>
+
+                <div className={styles.contentsLeft}>
+                    With a Sourcegraph account, you can:
+                    <ul className={styles.featureList}>
+                        <li>Search all of your code from your code host, even without downloading it locally</li>
+                        <li>Reference and re-use code from all your projects without leaving VS Code</li>
+                        <li>Create code monitors to alert you to changes in code</li>
+                    </ul>
+                    <div className={styles.companiesHeader}>
+                        Trusted by developers at the world's most innovative companies:
+                    </div>
+                    <img
+                        src={`${assetsRoot}/img/customer-logos-${isLightTheme ? 'light' : 'dark'}.svg`}
+                        alt="Cloudflare, Uber, SoFi, Dropbox, Plaid, Toast"
+                    />
+                </div>
+
+                <div className={styles.signUpWrapper}>
+                    <h2>Create a free account</h2>
+                    {renderAuthMethod()}
+
+                    <small className="text-muted">
+                        By registering, you agree to our{' '}
+                        <a href="https://about.sourcegraph.com/terms" target="_blank" rel="noopener">
+                            Terms of Service
+                        </a>{' '}
+                        and{' '}
+                        <a href="https://about.sourcegraph.com/privacy" target="_blank" rel="noopener">
+                            Privacy Policy
+                        </a>
+                        .
+                    </small>
+
+                    <hr className={styles.separator} />
+
+                    <div>
+                        Already have an account? <Link to={`/sign-in${location.search}`}>Log in</Link>
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/client/web/src/auth/VsCodeSignUpPage.tsx
+++ b/client/web/src/auth/VsCodeSignUpPage.tsx
@@ -112,29 +112,20 @@ export const VsCodeSignUpPage: React.FunctionComponent<Props> = ({
 
     return (
         <div className={styles.page}>
-            <header>
-                <div className="position-relative">
-                    <div className={styles.headerBackground1} />
-                    <div className={styles.headerBackground2} />
-                    <div className={styles.headerBackground3} />
-
-                    <div className={styles.limitWidth}>
-                        <BrandLogo isLightTheme={isLightTheme} variant="logo" className={styles.logo} />
-                    </div>
-                </div>
+            <header className="position-relative">
+                <div className={styles.headerBackground1} />
+                <div className={styles.headerBackground2} />
             </header>
 
-            <div className={classNames(styles.contents, styles.limitWidth)}>
-                <div className={classNames(styles.contentsLeft, styles.subtitle)}>
-                    <h2 className={classNames('d-flex', 'align-items-center', styles.pageHeading)}>
+            <div className={classNames('d-flex', 'justify-content-center', 'mb-5', styles.leftOrRightContainer)}>
+                <div className={styles.leftOrRight}>
+                    <BrandLogo isLightTheme={isLightTheme} variant="logo" className={styles.logo} />
+                    <h2 className={classNames('d-flex', 'align-items-center', 'mb-3', 'mt-1', styles.pageHeading)}>
                         <div className={classNames(styles.iconCirlce, 'mr-3')}>
                             <VSCodeIcon />
                         </div>{' '}
-                        Unlock the full potential of the Sourcegraph extension
+                        <strong className="mr-1">Unlock the full potential of the Sourcegraph extension</strong>
                     </h2>
-                </div>
-
-                <div className={styles.contentsLeft}>
                     With a Sourcegraph account, you can:
                     <ul className={styles.featureList}>
                         <li>Search all of your code from your code host, even without downloading it locally</li>
@@ -147,13 +138,13 @@ export const VsCodeSignUpPage: React.FunctionComponent<Props> = ({
                     <img
                         src={`${assetsRoot}/img/customer-logos-${isLightTheme ? 'light' : 'dark'}.svg`}
                         alt="Cloudflare, Uber, SoFi, Dropbox, Plaid, Toast"
+                        className={styles.customerLogos}
                     />
                 </div>
-
-                <div className={styles.signUpWrapper}>
+                <div className={classNames(styles.leftOrRight, styles.signUpWrapper)}>
+                    {' '}
                     <h2>Create a free account</h2>
                     {renderAuthMethod()}
-
                     <small className="text-muted">
                         By registering, you agree to our{' '}
                         <a href="https://about.sourcegraph.com/terms" target="_blank" rel="noopener">
@@ -165,9 +156,7 @@ export const VsCodeSignUpPage: React.FunctionComponent<Props> = ({
                         </a>
                         .
                     </small>
-
                     <hr className={styles.separator} />
-
                     <div>
                         Already have an account? <Link to={`/sign-in${location.search}`}>Log in</Link>
                     </div>


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/29703

__**🚨 This is a preview PR until we have a final copy**__

The idea here is that for users coming via the VS Code extension, we likely want a custom copy. 

Right now, we are already a couple of different versions of the sign-up flow:

- A regular cloud signup flow
- A regular on-prem signup flow (which does not contain marketing copy)
- ~~A `signup-optimized` flow that is currently being tested.~~ We can disregard this [as it's going away soon](https://github.com/sourcegraph/sourcegraph/pull/29728/files)
- An `?invitedBy=username` that is being worked on by @slimsag 

For the VS Code sign-up copy I decided to make a cleaned up fork of the regular cloud signup flow. I decided to remove the invited by logic because when users get an invite link, it should take precedence over their VS Code referrer. I also ignored the on-prem signup since it currently does not have any marketing text so an adjustment for VS Code won't make sense.

![Screenshot 2022-01-18 at 16 25 42](https://user-images.githubusercontent.com/458591/149966768-6814520f-62cc-4b58-839d-6c47e3d66eb1.png)


The new page can be opted into by including `vs-code` in the query search params, e.g.:

```
https://sourcegraph.test:3443/sign-up?vs-code=1&showEmail=true
```

## Outstanding Issues

- I need access to the Figma account so that I can extract the proper VS Code icon.
- The subtitle breaks to two lines with the font that we use on the signup page. Should we change something there?