### PR TITLE
search-blitz: add ability to change sampling duration for metrics on dashboard

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -927,27 +927,27 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: mean_successful_sentinel_duration_1h30m
+## frontend: mean_successful_sentinel_duration
 
-<p class="subtitle">mean successful sentinel search duration over 1h30m</p>
+<p class="subtitle">mean successful sentinel search duration</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 5s+ mean successful sentinel search duration over 1h30m for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 8s+ mean successful sentinel search duration over 1h30m for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 5s+ mean successful sentinel search duration for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 8s+ mean successful sentinel search duration for 30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-mean-successful-sentinel-duration-1h30m).
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-mean-successful-sentinel-duration).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_mean_successful_sentinel_duration_1h30m",
-  "critical_frontend_mean_successful_sentinel_duration_1h30m"
+  "warning_frontend_mean_successful_sentinel_duration",
+  "critical_frontend_mean_successful_sentinel_duration"
 ]
 ```
 
@@ -955,27 +955,27 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: mean_sentinel_stream_latency_1h30m
+## frontend: mean_sentinel_stream_latency
 
-<p class="subtitle">mean successful sentinel stream latency over 1h30m</p>
+<p class="subtitle">mean successful sentinel stream latency</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 2s+ mean successful sentinel stream latency over 1h30m for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 3s+ mean successful sentinel stream latency over 1h30m for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 2s+ mean successful sentinel stream latency for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 3s+ mean successful sentinel stream latency for 30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-mean-sentinel-stream-latency-1h30m).
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-mean-sentinel-stream-latency).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_mean_sentinel_stream_latency_1h30m",
-  "critical_frontend_mean_sentinel_stream_latency_1h30m"
+  "warning_frontend_mean_sentinel_stream_latency",
+  "critical_frontend_mean_sentinel_stream_latency"
 ]
 ```
 
@@ -983,27 +983,27 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: 90th_percentile_successful_sentinel_duration_1h30m
+## frontend: 90th_percentile_successful_sentinel_duration
 
-<p class="subtitle">90th percentile successful sentinel search duration over 1h30m</p>
+<p class="subtitle">90th percentile successful sentinel search duration</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 5s+ 90th percentile successful sentinel search duration over 1h30m for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 10s+ 90th percentile successful sentinel search duration over 1h30m for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 5s+ 90th percentile successful sentinel search duration for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 10s+ 90th percentile successful sentinel search duration for 30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-90th-percentile-successful-sentinel-duration-1h30m).
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-90th-percentile-successful-sentinel-duration).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_90th_percentile_successful_sentinel_duration_1h30m",
-  "critical_frontend_90th_percentile_successful_sentinel_duration_1h30m"
+  "warning_frontend_90th_percentile_successful_sentinel_duration",
+  "critical_frontend_90th_percentile_successful_sentinel_duration"
 ]
 ```
 
@@ -1011,27 +1011,27 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: 90th_percentile_sentinel_stream_latency_1h30m
+## frontend: 90th_percentile_sentinel_stream_latency
 
-<p class="subtitle">90th percentile successful sentinel stream latency over 1h30m</p>
+<p class="subtitle">90th percentile successful sentinel stream latency</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 4s+ 90th percentile successful sentinel stream latency over 1h30m for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 6s+ 90th percentile successful sentinel stream latency over 1h30m for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 4s+ 90th percentile successful sentinel stream latency for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 6s+ 90th percentile successful sentinel stream latency for 30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-90th-percentile-sentinel-stream-latency-1h30m).
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-90th-percentile-sentinel-stream-latency).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_90th_percentile_sentinel_stream_latency_1h30m",
-  "critical_frontend_90th_percentile_sentinel_stream_latency_1h30m"
+  "warning_frontend_90th_percentile_sentinel_stream_latency",
+  "critical_frontend_90th_percentile_sentinel_stream_latency"
 ]
 ```
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -2778,13 +2778,13 @@ Query: `sum by(app) (up{app=~".*(frontend|sourcegraph-frontend)"}) / count by (a
 
 ### Frontend: Sentinel queries (only on sourcegraph.com)
 
-#### frontend: mean_successful_sentinel_duration_1h30m
+#### frontend: mean_successful_sentinel_duration
 
-<p class="subtitle">Mean successful sentinel search duration over 1h30m</p>
+<p class="subtitle">Mean successful sentinel search duration</p>
 
 Mean search duration for all successful sentinel queries
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-successful-sentinel-duration-1h30m) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-successful-sentinel-duration) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102300` on your Sourcegraph instance.
 
@@ -2793,19 +2793,19 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102300`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[1h30m])) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[1h30m]))`
+Query: `sum(rate(src_search_response_latency_seconds_sum{source=~`searchblitz.*`, status=`success`}[$sentinel_sampling_duration])) / sum(rate(src_search_response_latency_seconds_count{source=~`searchblitz.*`, status=`success`}[$sentinel_sampling_duration]))`
 
 </details>
 
 <br />
 
-#### frontend: mean_sentinel_stream_latency_1h30m
+#### frontend: mean_sentinel_stream_latency
 
-<p class="subtitle">Mean successful sentinel stream latency over 1h30m</p>
+<p class="subtitle">Mean successful sentinel stream latency</p>
 
 Mean time to first result for all successful streaming sentinel queries
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-sentinel-stream-latency-1h30m) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-sentinel-stream-latency) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102301` on your Sourcegraph instance.
 
@@ -2814,19 +2814,19 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102301`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[1h30m])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[1h30m]))`
+Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[$sentinel_sampling_duration])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[$sentinel_sampling_duration]))`
 
 </details>
 
 <br />
 
-#### frontend: 90th_percentile_successful_sentinel_duration_1h30m
+#### frontend: 90th_percentile_successful_sentinel_duration
 
-<p class="subtitle">90th percentile successful sentinel search duration over 1h30m</p>
+<p class="subtitle">90th percentile successful sentinel search duration</p>
 
 90th percentile search duration for all successful sentinel queries
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-successful-sentinel-duration-1h30m) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-successful-sentinel-duration) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102310` on your Sourcegraph instance.
 
@@ -2835,19 +2835,19 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102310`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m]), "source", "$1", "source", "searchblitz_(.*)")))`
+Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration]), "source", "$1", "source", "searchblitz_(.*)")))`
 
 </details>
 
 <br />
 
-#### frontend: 90th_percentile_sentinel_stream_latency_1h30m
+#### frontend: 90th_percentile_sentinel_stream_latency
 
-<p class="subtitle">90th percentile successful sentinel stream latency over 1h30m</p>
+<p class="subtitle">90th percentile successful sentinel stream latency</p>
 
 90th percentile time to first result for all successful streaming sentinel queries
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-sentinel-stream-latency-1h30m) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-sentinel-stream-latency) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102311` on your Sourcegraph instance.
 
@@ -2856,15 +2856,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102311`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m]), "source", "$1", "source", "searchblitz_(.*)")))`
+Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[$sentinel_sampling_duration]), "source", "$1", "source", "searchblitz_(.*)")))`
 
 </details>
 
 <br />
 
-#### frontend: mean_successful_sentinel_duration_by_query_1h30m
+#### frontend: mean_successful_sentinel_duration_by_query
 
-<p class="subtitle">Mean successful sentinel search duration by query over 1h30m</p>
+<p class="subtitle">Mean successful sentinel search duration by query</p>
 
 Mean search duration for successful sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -2877,15 +2877,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102320`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[1h30m])) by (source) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[1h30m])) by (source)`
+Query: `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (source) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (source)`
 
 </details>
 
 <br />
 
-#### frontend: mean_sentinel_stream_latency_by_query_1h30m
+#### frontend: mean_sentinel_stream_latency_by_query
 
-<p class="subtitle">Mean successful sentinel stream latency by query over 1h30m</p>
+<p class="subtitle">Mean successful sentinel stream latency by query</p>
 
 Mean time to first result for successful streaming sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -2898,15 +2898,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102321`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[1h30m])) by (source) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[1h30m])) by (source)`
+Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (source) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (source)`
 
 </details>
 
 <br />
 
-#### frontend: 90th_percentile_successful_sentinel_duration_by_query_1h30m
+#### frontend: 90th_percentile_successful_sentinel_duration_by_query
 
-<p class="subtitle">90th percentile successful sentinel search duration by query over 1h30m</p>
+<p class="subtitle">90th percentile successful sentinel search duration by query</p>
 
 90th percentile search duration for successful sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -2919,15 +2919,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102330`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m])) by (le, source))`
+Query: `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (le, source))`
 
 </details>
 
 <br />
 
-#### frontend: 90th_percentile_successful_stream_latency_by_query_1h30m
+#### frontend: 90th_percentile_successful_stream_latency_by_query
 
-<p class="subtitle">90th percentile successful sentinel stream latency by query over 1h30m</p>
+<p class="subtitle">90th percentile successful sentinel stream latency by query</p>
 
 90th percentile time to first result for successful streaming sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -2940,15 +2940,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102331`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m])) by (le, source))`
+Query: `histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (le, source))`
 
 </details>
 
 <br />
 
-#### frontend: 90th_percentile_unsuccessful_duration_by_query_1h30m
+#### frontend: 90th_percentile_unsuccessful_duration_by_query
 
-<p class="subtitle">90th percentile unsuccessful sentinel search duration by query over 1h30m</p>
+<p class="subtitle">90th percentile unsuccessful sentinel search duration by query</p>
 
 90th percentile search duration of _unsuccessful_ sentinel queries (by error or timeout), broken down by query. Useful for debugging how the performance of failed requests affect UX.
 
@@ -2961,15 +2961,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102340`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[1h30m])) by (le, source))`
+Query: `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[$sentinel_sampling_duration])) by (le, source))`
 
 </details>
 
 <br />
 
-#### frontend: 75th_percentile_successful_sentinel_duration_by_query_1h30m
+#### frontend: 75th_percentile_successful_sentinel_duration_by_query
 
-<p class="subtitle">75th percentile successful sentinel search duration by query over 1h30m</p>
+<p class="subtitle">75th percentile successful sentinel search duration by query</p>
 
 75th percentile search duration of successful sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -2982,15 +2982,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102350`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m])) by (le, source))`
+Query: `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (le, source))`
 
 </details>
 
 <br />
 
-#### frontend: 75th_percentile_successful_stream_latency_by_query_1h30m
+#### frontend: 75th_percentile_successful_stream_latency_by_query
 
-<p class="subtitle">75th percentile successful sentinel stream latency by query over 1h30m</p>
+<p class="subtitle">75th percentile successful sentinel stream latency by query</p>
 
 75th percentile time to first result for successful streaming sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -3003,15 +3003,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102351`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m])) by (le, source))`
+Query: `histogram_quantile(0.75, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (le, source))`
 
 </details>
 
 <br />
 
-#### frontend: 75th_percentile_unsuccessful_duration_by_query_1h30m
+#### frontend: 75th_percentile_unsuccessful_duration_by_query
 
-<p class="subtitle">75th percentile unsuccessful sentinel search duration by query over 1h30m</p>
+<p class="subtitle">75th percentile unsuccessful sentinel search duration by query</p>
 
 75th percentile search duration of _unsuccessful_ sentinel queries (by error or timeout), broken down by query. Useful for debugging how the performance of failed requests affect UX.
 
@@ -3024,15 +3024,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102360`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[1h30m])) by (le, source))`
+Query: `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[$sentinel_sampling_duration])) by (le, source))`
 
 </details>
 
 <br />
 
-#### frontend: unsuccessful_status_rate_1h30m
+#### frontend: unsuccessful_status_rate
 
-<p class="subtitle">Unsuccessful status rate per 1h30m</p>
+<p class="subtitle">Unsuccessful status rate</p>
 
 The rate of unsuccessful sentinel queries, broken down by failure type.
 
@@ -3045,7 +3045,7 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102370`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_graphql_search_response{source=~"searchblitz.*", status!="success"}[1h30m])) by (status)`
+Query: `sum(rate(src_graphql_search_response{source=~"searchblitz.*", status!="success"}[$sentinel_sampling_duration])) by (status)`
 
 </details>
 

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -1,20 +1,55 @@
 package definitions
 
 import (
+	"strings"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/monitoring/definitions/shared"
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
+
+	"github.com/grafana-tools/sdk"
 )
 
 func Frontend() *monitoring.Container {
 	// frontend is sometimes called sourcegraph-frontend in various contexts
 	const containerName = "(frontend|sourcegraph-frontend)"
 
+	var sentinelSamplingIntervals []string
+	for _, d := range []time.Duration{
+		1 * time.Minute,
+		5 * time.Minute,
+		10 * time.Minute,
+		30 * time.Minute,
+		1 * time.Hour,
+		90 * time.Minute,
+		3 * time.Hour,
+	} {
+		sentinelSamplingIntervals = append(sentinelSamplingIntervals, d.Round(time.Second).String())
+	}
+
+	defaultSamplingInterval := (90 * time.Minute).Round(time.Second)
+
 	return &monitoring.Container{
 		Name:        "frontend",
 		Title:       "Frontend",
 		Description: "Serves all end-user browser and API requests.",
+		RawVariables: []sdk.TemplateVar{
+			{
+				Type:  "interval",
+				Name:  "sentinel_sampling_duration",
+				Label: "Sentinel query sampling duration",
+				Query: strings.Join(sentinelSamplingIntervals, ","),
+				Current: sdk.Current{
+					Text: &sdk.StringSliceString{
+						Value: []string{defaultSamplingInterval.String()}, Valid: true},
+					Value: defaultSamplingInterval.String(),
+				},
+				Refresh: sdk.BoolInt{
+					Flag:  true,
+					Value: monitoring.Int64Ptr(2),
+				},
+			},
+		},
 		Groups: []monitoring.Group{
 			{
 				Title: "Search at a glance",
@@ -582,11 +617,11 @@ func Frontend() *monitoring.Container {
 				Rows: []monitoring.Row{
 					{
 						{
-							Name:        "mean_successful_sentinel_duration_1h30m",
-							Description: "mean successful sentinel search duration over 1h30m",
+							Name:        "mean_successful_sentinel_duration",
+							Description: "mean successful sentinel search duration",
 							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
 							// since these panels relate to metrics that don't exist on a customer instance.
-							Query:          `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[1h30m])) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[1h30m]))`,
+							Query:          "sum(rate(src_search_response_latency_seconds_sum{source=~`searchblitz.*`, status=`success`}[$sentinel_sampling_duration])) / sum(rate(src_search_response_latency_seconds_count{source=~`searchblitz.*`, status=`success`}[$sentinel_sampling_duration]))",
 							Warning:        monitoring.Alert().GreaterOrEqual(5, nil).For(15 * time.Minute),
 							Critical:       monitoring.Alert().GreaterOrEqual(8, nil).For(30 * time.Minute),
 							Panel:          monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(monitoring.PanelOptions.NoLegend()),
@@ -599,11 +634,11 @@ func Frontend() *monitoring.Container {
 							`,
 						},
 						{
-							Name:        "mean_sentinel_stream_latency_1h30m",
-							Description: "mean successful sentinel stream latency over 1h30m",
+							Name:        "mean_sentinel_stream_latency",
+							Description: "mean successful sentinel stream latency",
 							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
 							// since these panels relate to metrics that don't exist on a customer instance.
-							Query:    `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[1h30m])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[1h30m]))`,
+							Query:    `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[$sentinel_sampling_duration])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[$sentinel_sampling_duration]))`,
 							Warning:  monitoring.Alert().GreaterOrEqual(2, nil).For(15 * time.Minute),
 							Critical: monitoring.Alert().GreaterOrEqual(3, nil).For(30 * time.Minute),
 							Panel: monitoring.Panel().LegendFormat("latency").Unit(monitoring.Seconds).With(
@@ -621,11 +656,11 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:        "90th_percentile_successful_sentinel_duration_1h30m",
-							Description: "90th percentile successful sentinel search duration over 1h30m",
+							Name:        "90th_percentile_successful_sentinel_duration",
+							Description: "90th percentile successful sentinel search duration",
 							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
 							// since these panels relate to metrics that don't exist on a customer instance.
-							Query:          `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m]), "source", "$1", "source", "searchblitz_(.*)")))`,
+							Query:          `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration]), "source", "$1", "source", "searchblitz_(.*)")))`,
 							Warning:        monitoring.Alert().GreaterOrEqual(5, nil).For(15 * time.Minute),
 							Critical:       monitoring.Alert().GreaterOrEqual(10, nil).For(30 * time.Minute),
 							Panel:          monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(monitoring.PanelOptions.NoLegend()),
@@ -638,11 +673,11 @@ func Frontend() *monitoring.Container {
 							`,
 						},
 						{
-							Name:        "90th_percentile_sentinel_stream_latency_1h30m",
-							Description: "90th percentile successful sentinel stream latency over 1h30m",
+							Name:        "90th_percentile_sentinel_stream_latency",
+							Description: "90th percentile successful sentinel stream latency",
 							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
 							// since these panels relate to metrics that don't exist on a customer instance.
-							Query:    `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m]), "source", "$1", "source", "searchblitz_(.*)")))`,
+							Query:    `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[$sentinel_sampling_duration]), "source", "$1", "source", "searchblitz_(.*)")))`,
 							Warning:  monitoring.Alert().GreaterOrEqual(4, nil).For(15 * time.Minute),
 							Critical: monitoring.Alert().GreaterOrEqual(6, nil).For(30 * time.Minute),
 							Panel: monitoring.Panel().LegendFormat("latency").Unit(monitoring.Seconds).With(
@@ -660,9 +695,9 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:        "mean_successful_sentinel_duration_by_query_1h30m",
-							Description: "mean successful sentinel search duration by query over 1h30m",
-							Query:       `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[1h30m])) by (source) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[1h30m])) by (source)`,
+							Name:        "mean_successful_sentinel_duration_by_query",
+							Description: "mean successful sentinel search duration by query",
+							Query:       `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (source) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (source)`,
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.LegendOnRight(),
@@ -674,9 +709,9 @@ func Frontend() *monitoring.Container {
 							Interpretation: `Mean search duration for successful sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.`,
 						},
 						{
-							Name:        "mean_sentinel_stream_latency_by_query_1h30m",
-							Description: "mean successful sentinel stream latency by query over 1h30m",
-							Query:       `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[1h30m])) by (source) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[1h30m])) by (source)`,
+							Name:        "mean_sentinel_stream_latency_by_query",
+							Description: "mean successful sentinel stream latency by query",
+							Query:       `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (source) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (source)`,
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.LegendOnRight(),
@@ -690,9 +725,9 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:        "90th_percentile_successful_sentinel_duration_by_query_1h30m",
-							Description: "90th percentile successful sentinel search duration by query over 1h30m",
-							Query:       `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m])) by (le, source))`,
+							Name:        "90th_percentile_successful_sentinel_duration_by_query",
+							Description: "90th percentile successful sentinel search duration by query",
+							Query:       `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (le, source))`,
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.LegendOnRight(),
@@ -704,9 +739,9 @@ func Frontend() *monitoring.Container {
 							Interpretation: `90th percentile search duration for successful sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.`,
 						},
 						{
-							Name:        "90th_percentile_successful_stream_latency_by_query_1h30m",
-							Description: "90th percentile successful sentinel stream latency by query over 1h30m",
-							Query:       `histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m])) by (le, source))`,
+							Name:        "90th_percentile_successful_stream_latency_by_query",
+							Description: "90th percentile successful sentinel stream latency by query",
+							Query:       `histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (le, source))`,
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.LegendOnRight(),
@@ -720,9 +755,9 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:        "90th_percentile_unsuccessful_duration_by_query_1h30m",
-							Description: "90th percentile unsuccessful sentinel search duration by query over 1h30m",
-							Query:       "histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[1h30m])) by (le, source))",
+							Name:        "90th_percentile_unsuccessful_duration_by_query",
+							Description: "90th percentile unsuccessful sentinel search duration by query",
+							Query:       "histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[$sentinel_sampling_duration])) by (le, source))",
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{source}}").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.LegendOnRight(),
@@ -736,9 +771,9 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:        "75th_percentile_successful_sentinel_duration_by_query_1h30m",
-							Description: "75th percentile successful sentinel search duration by query over 1h30m",
-							Query:       `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m])) by (le, source))`,
+							Name:        "75th_percentile_successful_sentinel_duration_by_query",
+							Description: "75th percentile successful sentinel search duration by query",
+							Query:       `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (le, source))`,
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.LegendOnRight(),
@@ -750,9 +785,9 @@ func Frontend() *monitoring.Container {
 							Interpretation: `75th percentile search duration of successful sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.`,
 						},
 						{
-							Name:        "75th_percentile_successful_stream_latency_by_query_1h30m",
-							Description: "75th percentile successful sentinel stream latency by query over 1h30m",
-							Query:       `histogram_quantile(0.75, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m])) by (le, source))`,
+							Name:        "75th_percentile_successful_stream_latency_by_query",
+							Description: "75th percentile successful sentinel stream latency by query",
+							Query:       `histogram_quantile(0.75, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (le, source))`,
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.LegendOnRight(),
@@ -766,9 +801,9 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:        "75th_percentile_unsuccessful_duration_by_query_1h30m",
-							Description: "75th percentile unsuccessful sentinel search duration by query over 1h30m",
-							Query:       "histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[1h30m])) by (le, source))",
+							Name:        "75th_percentile_unsuccessful_duration_by_query",
+							Description: "75th percentile unsuccessful sentinel search duration by query",
+							Query:       "histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[$sentinel_sampling_duration])) by (le, source))",
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{source}}").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.LegendOnRight(),
@@ -782,9 +817,9 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:           "unsuccessful_status_rate_1h30m",
-							Description:    "unsuccessful status rate per 1h30m",
-							Query:          `sum(rate(src_graphql_search_response{source=~"searchblitz.*", status!="success"}[1h30m])) by (status)`,
+							Name:           "unsuccessful_status_rate",
+							Description:    "unsuccessful status rate",
+							Query:          `sum(rate(src_graphql_search_response{source=~"searchblitz.*", status!="success"}[$sentinel_sampling_duration])) by (status)`,
 							NoAlert:        true,
 							Panel:          monitoring.Panel().LegendFormat("{{status}}"),
 							Owner:          monitoring.ObservableOwnerSearch,

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -31,6 +31,11 @@ type Container struct {
 	// container, such as instances or shards.
 	Variables []ContainerVariable
 
+	// RawVariables exposes the underlying Grafana API to define
+	// variables that can be applied to the dashboard for this container,
+	// such as instances or shards.
+	RawVariables []sdk.TemplateVar
+
 	// Groups of observable information about the container.
 	Groups []Group
 
@@ -87,6 +92,7 @@ func (c *Container) renderDashboard() *sdk.Board {
 	for _, variable := range c.Variables {
 		board.Templating.List = append(board.Templating.List, variable.toGrafanaTemplateVar())
 	}
+	board.Templating.List = append(board.Templating.List, c.RawVariables...)
 	board.Annotations.List = []sdk.Annotation{{
 		Name:       "Alert events",
 		Datasource: StringPtr("Prometheus"),


### PR DESCRIPTION
Closes #29713

<img width="1480" alt="Screen Shot 2022-01-14 at 7 35 58 AM" src="https://user-images.githubusercontent.com/9022011/149542141-80d96712-0609-4fda-a059-5c33c964dd92.png">

Successor to #29713 which works around issues by directly exposing the Grafana API under the `RawVariables[]` label. 