### PR TITLE
search: scaffolding for or-expression to regexp transformer

### DIFF
--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -436,6 +436,55 @@ func TestExpandOr(t *testing.T) {
 	}
 }
 
+func Test_convertOrToRegexp(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: "foo or bar",
+			want:  `"foo|bar"`,
+		},
+		{
+			input: "(foo or (bar or baz))",
+			want:  `"foo|bar|baz"`,
+		},
+		{
+			input: "repo:foobar foo or (bar or baz)",
+			want:  `(or "bar|baz" (and "repo:foobar" "foo"))`,
+		},
+		{
+			input: "(foo or (bar or baz)) and foobar",
+			want:  `(and "foo|bar|baz" "foobar")`,
+		},
+		{
+			input: "(foo or (bar and baz))",
+			want:  `(or "foo" (and "bar" "baz"))`,
+		},
+		{
+			input: "foo or (bar and baz) or foobar",
+			want:  `(or "foo|foobar" (and "bar" "baz"))`,
+		},
+		{
+			input: "repo:foo or repo:bar",
+			want:  `(or "" "repo:foo" "repo:bar")`, // Needs fix: check should handle not adding empty node
+		},
+		{
+			input: "repo:a b or repo:c d",         // Filters are unsupported, function only deals with pure patterns.
+			want:  `(or "repo:a" "repo:c" "b|d")`, // WRONG
+		},
+	}
+	for _, c := range cases {
+		t.Run("Map query", func(t *testing.T) {
+			query, _ := ParseRegexp(c.input)
+			got := toString(convertOrToRegexp(query))
+			if diff := cmp.Diff(c.want, got); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
 func TestMap(t *testing.T) {
 	cases := []struct {
 		input string


### PR DESCRIPTION
Dug up an ancient branch where I started implementing a or-expression to regexp converter since @tsenart has appetite for this. See test cases for example. I got as far as converting pattern expressions (no filters like `repo` or `rev`), so this is some good scaffolding. I think we should use it as a discussion point, I think it doesn't handle enough to be useful yet, and I think Tomas is specifically interested in `repo`/`rev`/`file` filters for query-based contexts, and if we can assume we're _only_ interested in those to start, it will greatly simplify the transformation pass.


Once the pass works, it can be added as a step in a query [`Pipeline`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@214c3eb4f6a635dc6014f404a5606b64ed6e300c/-/blob/internal/search/query/query.go?L121&subtree=true) from specific callers, or we can add it for every query in the [`For` step](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@214c3eb4f6a635dc6014f404a5606b64ed6e300c/-/blob/internal/search/query/query.go?L43-55&subtree=true)