### PR TITLE
Wildcard: Add tether position calculation sub package for future popover component

### DIFF
--- a/client/wildcard/src/components/Popover/tether/index.ts
+++ b/client/wildcard/src/components/Popover/tether/index.ts
@@ -1,0 +1,10 @@
+// Tether primitive models and structures
+export * from './models/tether-models'
+export * from './models/geometry/point'
+export * from './models/geometry/rectangle'
+
+// The main entry point of tooltip positioning engine
+export { createTether } from './services/tether-registry'
+
+// Shared type interfaces
+export type { Tether } from './services/types'

--- a/client/wildcard/src/components/Popover/tether/models/geometry/point.ts
+++ b/client/wildcard/src/components/Popover/tether/models/geometry/point.ts
@@ -1,0 +1,12 @@
+export interface Point {
+    x: number
+    y: number
+}
+
+export const createPoint = (xCoord: number, yCoord: number): Point => ({ x: xCoord, y: yCoord })
+
+/**
+ * Compare two points, returns true if points have the same coordinates value.
+ */
+export const isPointsEqual = (point1: Point | undefined | null, point2: Point | undefined | null): boolean =>
+    !!point1 && !!point2 && point1.x === point2.x && point1.y === point2.y

--- a/client/wildcard/src/components/Popover/tether/models/geometry/point.ts
+++ b/client/wildcard/src/components/Popover/tether/models/geometry/point.ts
@@ -4,9 +4,3 @@ export interface Point {
 }
 
 export const createPoint = (xCoord: number, yCoord: number): Point => ({ x: xCoord, y: yCoord })
-
-/**
- * Compare two points, returns true if points have the same coordinates value.
- */
-export const isPointsEqual = (point1: Point | undefined | null, point2: Point | undefined | null): boolean =>
-    !!point1 && !!point2 && point1.x === point2.x && point1.y === point2.y

--- a/client/wildcard/src/components/Popover/tether/models/geometry/rectangle.spec.ts
+++ b/client/wildcard/src/components/Popover/tether/models/geometry/rectangle.spec.ts
@@ -1,12 +1,13 @@
-import { createRectangle, intersection } from './rectangle'
+import { createRectangle, getIntersection } from './rectangle'
 
 describe('rectangle should calculate intersection', () => {
     const intersectionCases = [
         [createRectangle(500, 500, 200, 200), createRectangle(0, 0, 600, 600), createRectangle(500, 500, 100, 100)],
         [createRectangle(0, 0, 200, 200), createRectangle(10, 10, 600, 600), createRectangle(10, 10, 190, 190)],
+        [createRectangle(0, 0, 200, 200), createRectangle(210, 210, 600, 600), createRectangle(0, 0, 0, 0)],
     ]
 
     test.each(intersectionCases)('with %s and %s rectangles', (a, b, expected) => {
-        expect(intersection(a, b)).toStrictEqual(expected)
+        expect(getIntersection(a, b)).toStrictEqual(expected)
     })
 })

--- a/client/wildcard/src/components/Popover/tether/models/geometry/rectangle.spec.ts
+++ b/client/wildcard/src/components/Popover/tether/models/geometry/rectangle.spec.ts
@@ -1,0 +1,12 @@
+import { createRectangle, intersection } from './rectangle'
+
+describe('rectangle should calculate intersection', () => {
+    const intersectionCases = [
+        [createRectangle(500, 500, 200, 200), createRectangle(0, 0, 600, 600), createRectangle(500, 500, 100, 100)],
+        [createRectangle(0, 0, 200, 200), createRectangle(10, 10, 600, 600), createRectangle(10, 10, 190, 190)],
+    ]
+
+    test.each(intersectionCases)('with %s and %s rectangles', (a, b, expected) => {
+        expect(intersection(a, b)).toStrictEqual(expected)
+    })
+})

--- a/client/wildcard/src/components/Popover/tether/models/geometry/rectangle.ts
+++ b/client/wildcard/src/components/Popover/tether/models/geometry/rectangle.ts
@@ -44,7 +44,7 @@ export const createRectangleFromPoints = (a: Point, b: Point): Rectangle => {
  * Returns intersection of two rectangles. Returns empty rectangle in case
  * if input rectangles don't have any intersection area.
  */
-export function intersection(a: Rectangle, b: Rectangle): Rectangle {
+export function getIntersection(a: Rectangle, b: Rectangle): Rectangle {
     const xStart = Math.max(a.left, b.left)
     const xEnd = Math.min(a.left + a.width, b.left + b.width)
 

--- a/client/wildcard/src/components/Popover/tether/models/geometry/rectangle.ts
+++ b/client/wildcard/src/components/Popover/tether/models/geometry/rectangle.ts
@@ -1,0 +1,85 @@
+import { Point } from './point'
+
+export interface Rectangle {
+    left: number
+    top: number
+    right: number
+    bottom: number
+    width: number
+    height: number
+}
+
+export const createRectangle = (left: number, top: number, rawWidth: number, rawHeight: number): Rectangle => {
+    // Inlined clamp to zero logic.
+    const width = rawWidth < 0 ? 0 : rawWidth
+    const height = rawHeight < 0 ? 0 : rawHeight
+
+    return {
+        left,
+        top,
+        width,
+        height,
+
+        // Additional calculated properties
+        right: left + width,
+        bottom: top + height,
+    }
+}
+
+export const EMPTY_RECTANGLE = createRectangle(0, 0, 0, 0)
+
+/**
+ * Create rectangle from two points by subtracting one point from other.
+ */
+export const createRectangleFromPoints = (a: Point, b: Point): Rectangle => {
+    const left = Math.min(a.x, b.x)
+    const top = Math.min(a.y, b.y)
+    const width = Math.max(a.x, b.x) - left
+    const height = Math.max(a.y, b.y) - top
+
+    return createRectangle(left, top, width, height)
+}
+
+/**
+ * Returns intersection of two rectangles. Returns empty rectangle in case
+ * if input rectangles don't have any intersection area.
+ */
+export function intersection(a: Rectangle, b: Rectangle): Rectangle {
+    const xStart = Math.max(a.left, b.left)
+    const xEnd = Math.min(a.left + a.width, b.left + b.width)
+
+    if (xStart <= xEnd) {
+        const yStart = Math.max(a.top, b.top)
+        const yEnd = Math.min(a.top + a.height, b.top + b.height)
+
+        if (yStart <= yEnd) {
+            return createRectangle(xStart, yStart, xEnd - xStart, yEnd - yStart)
+        }
+    }
+
+    return createRectangle(0, 0, 0, 0)
+}
+
+/**
+ * Tests that two rectangles do or don't have overlapping between each other.
+ */
+export function intersects(a: Rectangle, b: Rectangle): boolean {
+    return (
+        a.left <= b.left + b.width &&
+        b.left <= a.left + a.width &&
+        a.top <= b.top + b.height &&
+        b.top <= a.top + a.height
+    )
+}
+
+/**
+ * Tests does the first rectangle contain the second one.
+ */
+export function containsRectangle(a: Rectangle, b: Rectangle): boolean {
+    return (
+        a.left <= b.left &&
+        a.left + a.width >= b.left + b.width &&
+        a.top <= b.top &&
+        a.top + a.height >= b.top + b.height
+    )
+}

--- a/client/wildcard/src/components/Popover/tether/models/tether-models.ts
+++ b/client/wildcard/src/components/Popover/tether/models/tether-models.ts
@@ -1,0 +1,76 @@
+import { Rectangle } from './geometry/rectangle'
+
+/**
+ * Describes padding (offset) of tooltip element and target element.
+ */
+export interface Padding {
+    top: number
+    left: number
+    right: number
+    bottom: number
+}
+
+/**
+ * Describes boundary element for the tooltip position calculation.
+ */
+export interface Constraint {
+    element: Rectangle
+    padding: Rectangle
+}
+
+/**
+ * Describes position strategy if tooltip doesn't have enough place to render
+ */
+export enum Overlapping {
+    /**
+     * Overlap all space of target element.
+     */
+    all = 'all',
+
+    /**
+     * Turns off position overlapping for any elements even if elements don't
+     * have enough space.
+     */
+    none = 'none',
+}
+
+/**
+ * Describes options for changing position when tooltip element doesn't have
+ * enough space for rendering.
+ */
+export enum Flipping {
+    /**
+     * Whenever tooltip doesn't have enough space then pick any other position
+     * based on initial position that tooltip has.
+     *
+     * Example: left → right → bottom → top
+     */
+    all = 'all',
+
+    /**
+     * Whenever tooltip doesn't have enough space then pick only opposite position
+     * of whatever initial position tooltip got.
+     *
+     * Example: left → right only
+     * Example: top → bottom only
+     */
+    opposite = 'opposite',
+}
+
+/**
+ * Describes all possible initial values for tooltip position.
+ */
+export enum Position {
+    topStart = 'topStart',
+    top = 'top',
+    topEnd = 'topEnd',
+    leftStart = 'leftStart',
+    left = 'left',
+    leftEnd = 'leftEnd',
+    rightStart = 'rightStart',
+    right = 'right',
+    rightEnd = 'rightEnd',
+    bottomStart = 'bottomStart',
+    bottom = 'bottom',
+    bottomEnd = 'bottomEnd',
+}

--- a/client/wildcard/src/components/Popover/tether/services/geometry/actions/get-constrained-element.spec.ts
+++ b/client/wildcard/src/components/Popover/tether/services/geometry/actions/get-constrained-element.spec.ts
@@ -1,0 +1,14 @@
+import { createRectangle } from '../../../models/geometry/rectangle'
+
+import { getConstrainedElement } from './get-constrained-element'
+
+describe('getConstrainedElement', () => {
+    const testCases = [
+        [createRectangle(500, 500, 200, 200), createRectangle(0, 0, 600, 600), createRectangle(400, 400, 200, 200)],
+        [createRectangle(0, 0, 200, 200), createRectangle(10, 10, 600, 600), createRectangle(10, 10, 200, 200)],
+    ]
+
+    test.each(testCases)('should return correct result with overflowed content', (a, b, expected) => {
+        expect(getConstrainedElement(a, b)).toStrictEqual(expected)
+    })
+})

--- a/client/wildcard/src/components/Popover/tether/services/geometry/actions/get-constrained-element.ts
+++ b/client/wildcard/src/components/Popover/tether/services/geometry/actions/get-constrained-element.ts
@@ -1,0 +1,28 @@
+import { createPoint } from '../../../models/geometry/point'
+import { createRectangleFromPoints, Rectangle } from '../../../models/geometry/rectangle'
+
+/**
+ * Moves element rectangle in a way to fit the element rectangle to the constraint element.
+ * If moving isn't possible cuts off some parts of overflowed tooltip element rectangle.
+ *
+ * ```
+ *         ┏━━━━━━━━┓      New position
+ * ┌───────╋░░░░░░░░┃     ┌───┳━━━━━━━━┓
+ * │       ┃░░░░░░░░┃────┐│   ┃░░░░░░░░┃
+ * │       ┗━━━━╋━━━┛    └┼──▶┃░░░░░░░░┃
+ * │            │         │   ┗━━━━━━━━┫
+ * │            │         │            │
+ * └────────────┘         └────────────┘
+ * ```
+ *
+ * @param element - Tooltip rectangle element
+ * @param constraint - Constraint rectangle.
+ */
+export function getConstrainedElement(element: Rectangle, constraint: Rectangle): Rectangle {
+    const xStart = Math.max(Math.min(element.left, constraint.right - element.width), constraint.left)
+    const yStart = Math.max(Math.min(element.top, constraint.bottom - element.height), constraint.top)
+    const xEnd = Math.min(Math.max(element.right, constraint.left + element.width), constraint.right)
+    const yEnd = Math.min(Math.max(element.bottom, constraint.top + element.height), constraint.bottom)
+
+    return createRectangleFromPoints(createPoint(xStart, yStart), createPoint(xEnd, yEnd))
+}

--- a/client/wildcard/src/components/Popover/tether/services/geometry/actions/get-element-constraints.ts
+++ b/client/wildcard/src/components/Popover/tether/services/geometry/actions/get-element-constraints.ts
@@ -1,0 +1,65 @@
+import { createPoint } from '../../../models/geometry/point'
+import { createRectangleFromPoints, Rectangle } from '../../../models/geometry/rectangle'
+import { Overlapping, Position } from '../../../models/tether-models'
+import { POSITION_VARIANTS } from '../constants'
+
+/**
+ * Returns constraint rectangle according to target element position
+ * tooltip element position and overlapping setting.
+ *
+ * Example: Pattern area for right, left, bottom or bottom tooltip positioned
+ * constraint. If overlap all just returns original constraint.
+ * ```
+ * ┌────────┳━━━━━━━━━┓ ┏━━━━━━━━━┳────────┐
+ * │        ┃░░░░░░░░░┃ ┃░░░░░░░░░┃        │
+ * │┌──────┐┃░░░░░░░░░┃ ┃░░░░░░░░░┃┌──────┐│
+ * ││Target│┃░░░░░░░░░┃ ┃░░░░░░░░░┃│Target││
+ * │└──────┘┃░░░░░░░░░┃ ┃░░░░░░░░░┃└──────┘│
+ * │        ┃░░░░░░░░░┃ ┃░░░░░░░░░┃        │
+ * └────────┻━━━━━━━━━┛ ┗━━━━━━━━━┻────────┘
+ * ┏━━━━━━━━━━━━━━━━━━┓ ┌──────────────────┐
+ * ┃░░░░░░░░░░░░░░░░░░┃ │     ┌──────┐     │
+ * ┃░░░░░░░░░░░░░░░░░░┃ │     │Target│     │
+ * ┣━━━━━━━━━━━━━━━━━━┫ │     └──────┘     │
+ * │     ┌──────┐     │ ┣━━━━━━━━━━━━━━━━━━┫
+ * │     │Target│     │ ┃░░░░░░░░░░░░░░░░░░┃
+ * │     └──────┘     │ ┃░░░░░░░░░░░░░░░░░░┃
+ * └──────────────────┘ ┗━━━━━━━━━━━━━━━━━━┛
+ * ```
+ *
+ * @param target - Target rectangle element
+ * @param constraint - Original constraint rectangle element
+ * @param position - Desirable tooltip position
+ * @param overlapping - Overlapping strategy (all, none)
+ */
+export function getElementConstraint(
+    target: Rectangle,
+    constraint: Rectangle,
+    position: Position,
+    overlapping: Overlapping
+): Rectangle {
+    const side = POSITION_VARIANTS[position].positionSides
+
+    let xStart = constraint.left
+    let xEnd = constraint.right
+    let yStart = constraint.top
+    let yEnd = constraint.bottom
+
+    if (overlapping === Overlapping.none) {
+        if (side === Position.top) {
+            yStart = Math.min(target.top, constraint.top)
+            yEnd = Math.min(target.top, constraint.bottom)
+        } else if (side === Position.right) {
+            xStart = Math.max(target.right, constraint.left)
+            xEnd = Math.max(target.right, constraint.right)
+        } else if (side === Position.bottom) {
+            yStart = Math.max(target.bottom, constraint.top)
+            yEnd = Math.max(target.bottom, constraint.bottom)
+        } else {
+            xStart = Math.min(target.left, constraint.left)
+            xEnd = Math.min(target.left, constraint.right)
+        }
+    }
+
+    return createRectangleFromPoints(createPoint(xStart, yStart), createPoint(xEnd, yEnd))
+}

--- a/client/wildcard/src/components/Popover/tether/services/geometry/actions/get-elements-intersection.ts
+++ b/client/wildcard/src/components/Popover/tether/services/geometry/actions/get-elements-intersection.ts
@@ -1,5 +1,10 @@
 import { createPoint } from '../../../models/geometry/point'
-import { createRectangle, createRectangleFromPoints, intersection, Rectangle } from '../../../models/geometry/rectangle'
+import {
+    createRectangle,
+    createRectangleFromPoints,
+    getIntersection,
+    Rectangle,
+} from '../../../models/geometry/rectangle'
 import { Constraint, Padding } from '../../../models/tether-models'
 
 import { getRoundedElement } from './rectangle-position-helpers'
@@ -25,7 +30,7 @@ export function getElementsIntersection(constraints: Constraint[]): Rectangle {
         const content = getContentElement(element, constraint.padding)
 
         constrainedArea = constrainedArea ?? content
-        constrainedArea = intersection(constrainedArea, content)
+        constrainedArea = getIntersection(constrainedArea, content)
     }
 
     return constrainedArea ?? createRectangle(0, 0, 0, 0)

--- a/client/wildcard/src/components/Popover/tether/services/geometry/actions/get-elements-intersection.ts
+++ b/client/wildcard/src/components/Popover/tether/services/geometry/actions/get-elements-intersection.ts
@@ -1,0 +1,44 @@
+import { createPoint } from '../../../models/geometry/point'
+import { createRectangle, createRectangleFromPoints, intersection, Rectangle } from '../../../models/geometry/rectangle'
+import { Constraint, Padding } from '../../../models/tether-models'
+
+import { getRoundedElement } from './rectangle-position-helpers'
+
+/**
+ * Applies constrains rectangles and returns intersection of all contained element.
+ *
+ * Example: Intersected rectangle based on two overlapped area.
+ * ```
+ *   ┌─────────────────┐
+ * ┌─╋━━━━━━━━━━━━━━━━━╋─┐
+ * │ ┃░░░░░░░░░░░░░░░░░┃ │
+ * │ ┃░░░░░░░░░░░░░░░░░┃ │
+ * └─╋━━━━━━━━━━━━━━━━━╋─┘
+ *   └─────────────────┘
+ * ```
+ */
+export function getElementsIntersection(constraints: Constraint[]): Rectangle {
+    let constrainedArea: Rectangle | null = null
+
+    for (const constraint of constraints) {
+        const element = getRoundedElement(constraint.element)
+        const content = getContentElement(element, constraint.padding)
+
+        constrainedArea = constrainedArea ?? content
+        constrainedArea = intersection(constrainedArea, content)
+    }
+
+    return constrainedArea ?? createRectangle(0, 0, 0, 0)
+}
+
+/**
+ * Returns extended by padding rectangle.
+ */
+function getContentElement(element: Rectangle, padding: Padding): Rectangle {
+    const xStart = element.left + padding.left
+    const yStart = element.top + padding.top
+    const xEnd = element.right - padding.right
+    const yEnd = element.bottom - padding.bottom
+
+    return createRectangleFromPoints(createPoint(xStart, yStart), createPoint(xEnd, yEnd))
+}

--- a/client/wildcard/src/components/Popover/tether/services/geometry/actions/get-joined-element.ts
+++ b/client/wildcard/src/components/Popover/tether/services/geometry/actions/get-joined-element.ts
@@ -1,0 +1,44 @@
+import { createRectangle, Rectangle } from '../../../models/geometry/rectangle'
+import { Position } from '../../../models/tether-models'
+import { POSITION_VARIANTS } from '../constants'
+
+/**
+ * Returns joined tooltip element rectangle based on the target element position.
+ *
+ * Example: Return moved tooltip rectangle based on desirable tooltip position
+ * and target position.
+ *
+ * ```
+ * Top Left                         Right Top
+ * ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─  ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
+ *   ┌───────────┐                │   ┌───────────┐                │
+ * │ │░░░░░░░░░░░│   New position   │ │░░░░░░░░░░░├─Shift
+ *   │░░░░░░░░░░░│  ┌───────────┐ │   │░░░░░░░░░░░│  │             │
+ * │ └─────┬─────┘  │░░░░░░░░░░░│   │ └───────────┘  │New position
+ *         Shift───▶│░░░░░░░░░░░│ │          ┌──────┬▼──────────┐  │
+ * │                ├──────┬────┘   │        │Target│░░░░░░░░░░░│
+ *                  │Target│      │          └──────┤░░░░░░░░░░░│  │
+ * │                └──────┘        │               └───────────┘
+ *  ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘  ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘
+ *```
+ * @param element - Tooltip element rectangle
+ * @param target - Target element rectangle
+ * @param position - Desirable tooltip position
+ */
+export function getJoinedElement(element: Rectangle, target: Rectangle, position: Position): Rectangle {
+    const elementA = POSITION_VARIANTS[position].elementAttachments
+    const elementX = element.left + element.width * elementA.x
+    const elementY = element.top + element.height * elementA.y
+
+    const targetA = POSITION_VARIANTS[position].targetAttachments
+    const targetX = target.left + target.width * targetA.x
+    const targetY = target.top + target.height * targetA.y
+
+    const shiftX = Math.floor(targetX - elementX)
+    const shiftY = Math.floor(targetY - elementY)
+
+    const pointX = element.left + shiftX
+    const pointY = element.top + shiftY
+
+    return createRectangle(pointX, pointY, element.width, element.height)
+}

--- a/client/wildcard/src/components/Popover/tether/services/geometry/actions/get-target-element.ts
+++ b/client/wildcard/src/components/Popover/tether/services/geometry/actions/get-target-element.ts
@@ -1,0 +1,38 @@
+import { createPoint } from '../../../models/geometry/point'
+import { createRectangleFromPoints, Rectangle } from '../../../models/geometry/rectangle'
+import { Position } from '../../../models/tether-models'
+import { POSITION_VARIANTS } from '../constants'
+
+/**
+ * Returns an extended target element rectangle by the marker rectangle size.
+ *
+ * Example: Extended target rect by marker size based on horizontal or
+ * vertical tooltip position. Where x - marker width, y - marker height.
+ * ```
+ *                        ┌ ─ ─ ─ ───▲──
+ *                         ░░░░░░░░│ │ y
+ *               │  x │   ┣━━━━━━━━┳─▼──
+ *               ◀────▶   ┃ Target ┃
+ * ┌─ ──┏━━━━━━━━┫── ─┤   ┣━━━━━━━━┛
+ *  ░░░░┃ Target ┃░░░░     ░░░░░░░░│
+ * └─ ──┗━━━━━━━━┛── ─┘   └ ─ ─ ─ ─
+ *```
+ *
+ * @param target - Original target rectangle.
+ * @param marker - Marker (tail) rectangle.
+ * @param position - Tooltip position relative to target element.
+ */
+export function getTargetElement(target: Rectangle, marker: Rectangle, position: Position): Rectangle {
+    const offset = POSITION_VARIANTS[position].targetOffset
+
+    const targetX = marker.width * offset.x
+    const targetY = marker.height * offset.y
+
+    // Extend width and height of tooltip element by marker rectangle
+    const targetX1 = target.left - targetX
+    const targetY1 = target.top - targetY
+    const targetX2 = target.right + targetX
+    const targetY2 = target.bottom + targetY
+
+    return createRectangleFromPoints(createPoint(targetX1, targetY1), createPoint(targetX2, targetY2))
+}

--- a/client/wildcard/src/components/Popover/tether/services/geometry/actions/rectangle-position-helpers.ts
+++ b/client/wildcard/src/components/Popover/tether/services/geometry/actions/rectangle-position-helpers.ts
@@ -1,0 +1,45 @@
+import { createRectangle, Rectangle } from '../../../models/geometry/rectangle'
+import { Flipping, Position } from '../../../models/tether-models'
+import { POSITION_VARIANTS } from '../constants'
+
+/**
+ * Returns all possible positions (top, top-left, left, right, ..etc) based on
+ * initial position and flipping settings.
+ */
+export function getPositions(position: Position, flipping: Flipping): Position[] {
+    const positions = [position, POSITION_VARIANTS[position].opposite]
+
+    if (flipping === Flipping.all) {
+        positions.push(Position.topStart, Position.rightStart, Position.bottomStart, Position.leftStart)
+    }
+
+    return positions
+}
+
+export function getRoundedElement(element: Rectangle): Rectangle {
+    return createRectangle(
+        Math.floor(element.left),
+        Math.floor(element.top),
+        Math.floor(element.width),
+        Math.floor(element.height)
+    )
+}
+
+/**
+ * Returned bounded (constrained element) element. Returns null in case if element hasn't been
+ * constrained during position calculations.
+ *
+ * @param element - constrained tooltip element
+ * @param originalElement - original sized tooltip element
+ */
+export function getElementBounds(element: Rectangle, originalElement: Rectangle): Rectangle | null {
+    if (element.width < originalElement.width || element.height < originalElement.height) {
+        return element
+    }
+
+    return null
+}
+
+export function isElementVisible(element: Rectangle): boolean {
+    return element.width * element.height >= 1
+}

--- a/client/wildcard/src/components/Popover/tether/services/geometry/actions/tooltip-marker-utils.ts
+++ b/client/wildcard/src/components/Popover/tether/services/geometry/actions/tooltip-marker-utils.ts
@@ -1,0 +1,80 @@
+import { createPoint, Point } from '../../../models/geometry/point'
+import { createRectangle, createRectangleFromPoints, Rectangle } from '../../../models/geometry/rectangle'
+import { Position } from '../../../models/tether-models'
+import { POSITION_VARIANTS } from '../constants'
+
+/**
+ * Returns rectangle (constraint) that marker should always be within.
+ *
+ * @param element - constrained tooltip element rectangle
+ * @param marker - rotated marker
+ * @param position - another tooltip position
+ */
+export function getMarkerConstraint(element: Rectangle, marker: Rectangle, position: Position): Rectangle {
+    const side = POSITION_VARIANTS[position].positionSides
+
+    let xStart = element.right
+    let xEnd = element.left
+    let yStart = element.bottom
+    let yEnd = element.top
+
+    const deltaX = Math.floor(Math.min(marker.width, Math.floor((element.width - marker.width) / 2)))
+    const deltaY = Math.floor(Math.min(marker.height, Math.floor((element.height - marker.height) / 2)))
+
+    if (side === Position.top) {
+        xStart = element.left + deltaX
+        xEnd = element.right - deltaX
+        yEnd = element.bottom + marker.height
+    } else if (side === Position.right) {
+        xStart = element.left - marker.width
+        yStart = element.top + deltaY
+        yEnd = element.bottom - deltaY
+    } else if (side === Position.bottom) {
+        xStart = element.left + deltaX
+        xEnd = element.right - deltaX
+        yStart = element.top - marker.height
+    } else {
+        xEnd = element.right + marker.width
+        yStart = element.top + deltaY
+        yEnd = element.bottom - deltaY
+    }
+
+    return createRectangleFromPoints(createPoint(xStart, yStart), createPoint(xEnd, yEnd))
+}
+
+export function getMarkerOffset(origin: Point, marker: Rectangle): Point {
+    return createPoint(marker.left + origin.x, marker.top + origin.y)
+}
+
+interface MarkerRotation {
+    markerOrigin: Point
+    markerAngle: number
+    rotatedMarker: Rectangle
+}
+
+/**
+ * Returns marker element position information. Shifted center of marker element for
+ * correct rotation, marker rectangle itself and rotation angle.
+ */
+export function getMarkerRotation(marker: Rectangle, position: Position): MarkerRotation {
+    const markerAngle = POSITION_VARIANTS[position].rotationAngle
+
+    if (markerAngle % 180 !== 0) {
+        const delta = Math.floor((marker.width - marker.height) / 2)
+        const markerOrigin = createPoint(-delta, delta)
+
+        // Swap marker height and width and therefore rotate.
+        const rotatedMarker = createRectangle(marker.left, marker.top, marker.height, marker.width)
+
+        return {
+            rotatedMarker,
+            markerOrigin,
+            markerAngle,
+        }
+    }
+    return {
+        markerOrigin: createPoint(0, 0),
+        rotatedMarker: marker,
+        markerAngle,
+    }
+}

--- a/client/wildcard/src/components/Popover/tether/services/geometry/constants.ts
+++ b/client/wildcard/src/components/Popover/tether/services/geometry/constants.ts
@@ -101,4 +101,4 @@ export const POSITION_VARIANTS = {
         targetAttachments: createPoint(0, 1),
         targetOffset: createPoint(1, 0),
     },
-}
+} as const

--- a/client/wildcard/src/components/Popover/tether/services/geometry/constants.ts
+++ b/client/wildcard/src/components/Popover/tether/services/geometry/constants.ts
@@ -1,0 +1,104 @@
+import { createPoint } from '../../models/geometry/point'
+import { Position } from '../../models/tether-models'
+
+/**
+ * Static position preferences settings for each possible pre-defined position.
+ */
+export const POSITION_VARIANTS = {
+    [Position.topStart]: {
+        positionSides: Position.top,
+        rotationAngle: 0,
+        opposite: Position.bottomStart,
+        elementAttachments: createPoint(0, 1),
+        targetAttachments: createPoint(0, 0),
+        targetOffset: createPoint(0, 1),
+    },
+    [Position.top]: {
+        positionSides: Position.top,
+        rotationAngle: 0,
+        opposite: Position.bottom,
+        elementAttachments: createPoint(0.5, 1),
+        targetAttachments: createPoint(0.5, 0),
+        targetOffset: createPoint(0, 1),
+    },
+    [Position.topEnd]: {
+        positionSides: Position.top,
+        rotationAngle: 0,
+        opposite: Position.bottomEnd,
+        elementAttachments: createPoint(1, 1),
+        targetAttachments: createPoint(1, 0),
+        targetOffset: createPoint(0, 1),
+    },
+    [Position.rightStart]: {
+        positionSides: Position.right,
+        rotationAngle: 90,
+        opposite: Position.leftStart,
+        elementAttachments: createPoint(0, 0),
+        targetAttachments: createPoint(1, 0),
+        targetOffset: createPoint(1, 0),
+    },
+    [Position.right]: {
+        positionSides: Position.right,
+        rotationAngle: 90,
+        opposite: Position.left,
+        elementAttachments: createPoint(0, 0.5),
+        targetAttachments: createPoint(1, 0.5),
+        targetOffset: createPoint(1, 0),
+    },
+    [Position.rightEnd]: {
+        positionSides: Position.right,
+        rotationAngle: 90,
+        opposite: Position.leftEnd,
+        elementAttachments: createPoint(0, 1),
+        targetAttachments: createPoint(1, 1),
+        targetOffset: createPoint(1, 0),
+    },
+    [Position.bottomStart]: {
+        positionSides: Position.bottom,
+        rotationAngle: 180,
+        opposite: Position.topStart,
+        elementAttachments: createPoint(0, 0),
+        targetAttachments: createPoint(0, 1),
+        targetOffset: createPoint(0, 1),
+    },
+    [Position.bottom]: {
+        positionSides: Position.bottom,
+        rotationAngle: 180,
+        opposite: Position.top,
+        elementAttachments: createPoint(0.5, 0),
+        targetAttachments: createPoint(0.5, 1),
+        targetOffset: createPoint(0, 1),
+    },
+    [Position.bottomEnd]: {
+        positionSides: Position.bottom,
+        rotationAngle: 180,
+        opposite: Position.topEnd,
+        elementAttachments: createPoint(1, 0),
+        targetAttachments: createPoint(1, 1),
+        targetOffset: createPoint(0, 1),
+    },
+    [Position.leftStart]: {
+        positionSides: Position.left,
+        rotationAngle: 270,
+        opposite: Position.rightStart,
+        elementAttachments: createPoint(1, 0),
+        targetAttachments: createPoint(0, 0),
+        targetOffset: createPoint(1, 0),
+    },
+    [Position.left]: {
+        positionSides: Position.left,
+        rotationAngle: 270,
+        opposite: Position.right,
+        elementAttachments: createPoint(1, 0.5),
+        targetAttachments: createPoint(0, 0.5),
+        targetOffset: createPoint(1, 0),
+    },
+    [Position.leftEnd]: {
+        positionSides: Position.left,
+        rotationAngle: 270,
+        opposite: Position.rightEnd,
+        elementAttachments: createPoint(1, 1),
+        targetAttachments: createPoint(0, 1),
+        targetOffset: createPoint(1, 0),
+    },
+}

--- a/client/wildcard/src/components/Popover/tether/services/geometry/index.ts
+++ b/client/wildcard/src/components/Popover/tether/services/geometry/index.ts
@@ -1,0 +1,7 @@
+export * from './actions/get-constrained-element'
+export * from './actions/get-element-constraints'
+export * from './actions/get-elements-intersection'
+export * from './actions/get-joined-element'
+export * from './actions/get-target-element'
+export * from './actions/rectangle-position-helpers'
+export * from './actions/tooltip-marker-utils'

--- a/client/wildcard/src/components/Popover/tether/services/tether-browser.ts
+++ b/client/wildcard/src/components/Popover/tether/services/tether-browser.ts
@@ -25,8 +25,6 @@ export function getScrollPositions(element: Element): ScrollPositions {
 
 /**
  * Returns list of all parent elements that have scroll.
- *
- * @param element
  */
 export function getScrollParents(element: Element): HTMLElement[] {
     const containers: HTMLElement[] = []
@@ -63,14 +61,14 @@ export function setScrollPositions(positions: ScrollPositions): void {
  * visible.
  */
 export function isVisible(element: HTMLElement | null): boolean {
-    if (element === null) {
-        return true
-    }
-    if (element.hidden !== null && element.hidden) {
-        return false
-    }
-    if (element.parentElement !== null) {
-        return isVisible(element.parentElement)
+    let current = element
+
+    while (current) {
+        if (current.hidden !== null && current.hidden) {
+            return false
+        }
+
+        current = current.parentElement
     }
     return true
 }

--- a/client/wildcard/src/components/Popover/tether/services/tether-browser.ts
+++ b/client/wildcard/src/components/Popover/tether/services/tether-browser.ts
@@ -1,0 +1,128 @@
+import { createPoint, Point } from '../models/geometry/point'
+import { Rectangle } from '../models/geometry/rectangle'
+
+interface ScrollPositions {
+    points: WeakMap<Element, Point>
+    elements: Element[]
+}
+
+/**
+ * Collect elements with scroll overflow (with scrollbar) and returns
+ * their scroll position coordinates (scrollX, scrollY)
+ *
+ * @param element - the root element for getting scroll information
+ */
+export function getScrollPositions(element: Element): ScrollPositions {
+    const store = new WeakMap<Element, Point>()
+    const scrollElements = getScrollChildren(element)
+
+    for (const element of scrollElements) {
+        store.set(element, createPoint(element.scrollLeft, element.scrollTop))
+    }
+
+    return { elements: scrollElements, points: store }
+}
+
+/**
+ * Returns list of all parent elements that have scroll.
+ *
+ * @param element
+ */
+export function getScrollParents(element: Element): HTMLElement[] {
+    const containers: HTMLElement[] = []
+
+    if (element.parentElement !== null) {
+        if (isScrollContainer(element.parentElement)) {
+            containers.push(element.parentElement)
+        }
+
+        containers.push(...getScrollParents(element.parentElement))
+    }
+
+    return containers
+}
+
+/**
+ * Iterates over elements and restore they scroll positions by information
+ * that was collected by @link getScrollPositions function.
+ *
+ * @param positions - scroll positions information.
+ */
+export function setScrollPositions(positions: ScrollPositions): void {
+    for (const container of positions.elements) {
+        const position = positions.points.get(container)
+
+        container.scrollLeft = position?.x ?? 0
+        container.scrollTop = position?.y ?? 0
+    }
+}
+
+/**
+ * Walks DOM from the element to top-level HTML-elements (body, html) and
+ * checks visibility properties in order to be sure that the element is visually
+ * visible.
+ */
+export function isVisible(element: HTMLElement | null): boolean {
+    if (element === null) {
+        return true
+    }
+    if (element.hidden !== null && element.hidden) {
+        return false
+    }
+    if (element.parentElement !== null) {
+        return isVisible(element.parentElement)
+    }
+    return true
+}
+
+export function setTransform(element: HTMLElement | null, angle: number, offset: Point): void {
+    setStyle(element, 'transform', `translate(${offset.x}px, ${offset.y}px) rotate(${angle}deg)`)
+}
+
+export function setMaxSize(element: HTMLElement, bounds: Rectangle | null): void {
+    setStyle(element, 'max-width', bounds !== null ? `${bounds.width}px` : '')
+    setStyle(element, 'max-height', bounds !== null ? `${bounds.height}px` : '')
+}
+
+export function setVisibility(element: HTMLElement | null, isVisible: boolean): void {
+    if (element !== null && element.hidden !== !isVisible) {
+        element.hidden = !isVisible
+    }
+}
+
+// ------------- Private API methods ---------------
+
+function setStyle(element: HTMLElement | null, key: string, value: string): void {
+    if (element !== null && element.style.getPropertyValue(key) !== value) {
+        element.style.setProperty(key, value)
+    }
+}
+
+/**
+ * Collect all elements by the root element and below that have scroll.
+ */
+function getScrollChildren(element: Element): Element[] {
+    const containers: Element[] = []
+
+    if (isScrollContainer(element)) {
+        containers.push(element)
+    }
+
+    for (const child of [...element.children]) {
+        containers.push(...getScrollChildren(child))
+    }
+
+    return containers
+}
+
+function isScrollContainer(element: Element): boolean {
+    if (element.scrollWidth > element.clientWidth || element.scrollHeight > element.clientHeight) {
+        const style = getComputedStyle(element)
+        const keywords = new Set(['auto', 'scroll', 'overlay'])
+        const properties = [style.overflow, style.overflowX, style.overflowY]
+
+        return properties.some(property => keywords.has(property))
+    }
+
+    return false
+}

--- a/client/wildcard/src/components/Popover/tether/services/tether-layout.ts
+++ b/client/wildcard/src/components/Popover/tether/services/tether-layout.ts
@@ -4,6 +4,10 @@ import { Constraint, Flipping, Overlapping, Position } from '../models/tether-mo
 import { getScrollParents } from './tether-browser'
 import { Tether, TetherLayout } from './types'
 
+/**
+ * Collects all information about current layout (tether and popover elements rectangle),
+ * constrains rectangles (viewport and scrollable parent elements).
+ */
 export function getLayout(tether: Tether): TetherLayout {
     const {
         position = Position.top,

--- a/client/wildcard/src/components/Popover/tether/services/tether-layout.ts
+++ b/client/wildcard/src/components/Popover/tether/services/tether-layout.ts
@@ -1,0 +1,102 @@
+import { createRectangle, createRectangleFromPoints, EMPTY_RECTANGLE, Rectangle } from '../models/geometry/rectangle'
+import { Constraint, Flipping, Overlapping, Position } from '../models/tether-models'
+
+import { getScrollParents } from './tether-browser'
+import { Tether, TetherLayout } from './types'
+
+export function getLayout(tether: Tether): TetherLayout {
+    const {
+        position = Position.top,
+        flipping = Flipping.opposite,
+        overlapping = Overlapping.none,
+        windowPadding = EMPTY_RECTANGLE,
+        constraintPadding = EMPTY_RECTANGLE,
+        overflowToScrollParents = true,
+        constrainToScrollParents,
+    } = tether
+
+    const target = tether.pin
+        ? createRectangleFromPoints(tether.pin, { x: tether.pin.x + 1, y: tether.pin.y + 1 })
+        : tether.target
+        ? tether.target.getBoundingClientRect()
+        : EMPTY_RECTANGLE
+
+    const element = tether.element.getBoundingClientRect()
+    const marker = getMarkerSize(tether.marker)
+
+    const overflows: Constraint[] = []
+    const constraints: Constraint[] = []
+
+    overflows.push({
+        element: createRectangle(
+            document.documentElement.clientLeft,
+            document.documentElement.clientTop,
+            document.documentElement.clientWidth,
+            document.documentElement.clientHeight
+        ),
+        padding: windowPadding,
+    })
+
+    constraints.push({
+        element: createRectangle(
+            document.documentElement.clientLeft,
+            document.documentElement.clientTop,
+            document.documentElement.clientWidth,
+            document.documentElement.clientHeight
+        ),
+        padding: windowPadding,
+    })
+
+    if (tether.constraint) {
+        constraints.push({
+            element: tether.constraint.getBoundingClientRect(),
+            padding: constraintPadding,
+        })
+    }
+
+    if (tether.target !== null && constrainToScrollParents) {
+        const containers = getScrollParents(tether.target)
+
+        const scrollConstraints = containers.map(container => ({
+            element: container.getBoundingClientRect(),
+            padding: constraintPadding,
+        }))
+
+        constraints.push(...scrollConstraints)
+    }
+
+    if (tether.target !== null && overflowToScrollParents) {
+        const containers = getScrollParents(tether.target)
+
+        const overflowConstraints = containers.map(container => ({
+            element: container.getBoundingClientRect(),
+            padding: EMPTY_RECTANGLE,
+        }))
+
+        overflows.push(...overflowConstraints)
+    }
+
+    return {
+        element,
+        target,
+        marker,
+        position,
+        flipping,
+        overlapping,
+        overflows,
+        constraints,
+    }
+}
+
+function getMarkerSize(element?: HTMLElement | null): Rectangle {
+    if (!element) {
+        return createRectangle(0, 0, 0, 0)
+    }
+
+    // Reset transform rotation properties
+    element.style.transform = ''
+
+    // Measure element without rotation transformations
+    // since transform rotation may affect element sizing
+    return element.getBoundingClientRect()
+}

--- a/client/wildcard/src/components/Popover/tether/services/tether-position.ts
+++ b/client/wildcard/src/components/Popover/tether/services/tether-position.ts
@@ -1,5 +1,5 @@
 import { createPoint, Point } from '../models/geometry/point'
-import { intersection, intersects, Rectangle } from '../models/geometry/rectangle'
+import { getIntersection, intersects, Rectangle } from '../models/geometry/rectangle'
 import { Position } from '../models/tether-models'
 
 import {
@@ -49,7 +49,7 @@ export function getPositionState(layout: TetherLayout, position: Position): Teth
     const { markerAngle, markerOrigin, rotatedMarker } = getMarkerRotation(marker, position)
 
     // Apply overflow constraints to target element
-    const overflowedTarget = intersection(target, overflow)
+    const overflowedTarget = getIntersection(target, overflow)
 
     // Force tooltip layout hide in case if target is outside of overflow constraint.
     if (!isElementVisible(overflowedTarget)) {

--- a/client/wildcard/src/components/Popover/tether/services/tether-position.ts
+++ b/client/wildcard/src/components/Popover/tether/services/tether-position.ts
@@ -1,0 +1,127 @@
+import { createPoint, Point } from '../models/geometry/point'
+import { intersection, intersects, Rectangle } from '../models/geometry/rectangle'
+import { Position } from '../models/tether-models'
+
+import {
+    getConstrainedElement,
+    getElementBounds,
+    getElementConstraint,
+    getElementsIntersection,
+    getJoinedElement,
+    getMarkerConstraint,
+    getMarkerOffset,
+    getMarkerRotation,
+    getRoundedElement,
+    getTargetElement,
+    isElementVisible,
+} from './geometry'
+import { TetherLayout } from './types'
+
+export interface TetherState {
+    /** Area of the element in pixels */
+    elementArea: number
+
+    /** Y and X coordinates of tooltip element */
+    elementOffset: Point
+
+    /** Constrained tooltip element due to constraints */
+    elementBounds: Rectangle | null
+
+    /** Tooltip tail angle based on tooltip element position */
+    markerAngle: number
+
+    /** Y and X coordinates of marker element */
+    markerOffset: Point
+}
+
+/**
+ * Calculates position for the tooltip element based on layout settings and current position value
+ * of the tooltip element. In case if there is no visual way to fit tooltip element in the constraints
+ * then returns null.
+ *
+ * @param layout - Document layout information (overflows, constrains, paddings, etc)
+ * @param position - Another position value to fit tooltip element
+ */
+export function getPositionState(layout: TetherLayout, position: Position): TetherState | null {
+    const { overlapping } = layout
+    const { element, target, marker, overflow, constraint } = getNormalizedLayout(layout)
+
+    const { markerAngle, markerOrigin, rotatedMarker } = getMarkerRotation(marker, position)
+
+    // Apply overflow constraints to target element
+    const overflowedTarget = intersection(target, overflow)
+
+    // Force tooltip layout hide in case if target is outside of overflow constraint.
+    if (!isElementVisible(overflowedTarget)) {
+        return null
+    }
+
+    // Extend the target element by marker size element  for correctness of calculations below
+    const extendedTarget = getTargetElement(overflowedTarget, marker, position)
+
+    // Change element tooltip coordinates to put this element right next extended target element
+    const joinedElement = getJoinedElement(element, extendedTarget, position)
+
+    // Calculate constraint rectangle by target position and default constraint
+    const elementConstraint = getElementConstraint(extendedTarget, constraint, position, overlapping)
+
+    // Change tooltip element rectangle by element constraint
+    const constrainedElement = getConstrainedElement(joinedElement, elementConstraint)
+
+    // Calculate element metric of the tooltip element after all constraint calculations
+    const elementArea = constrainedElement.width * constrainedElement.height
+    const elementOffset = createPoint(constrainedElement.left, constrainedElement.top)
+    const elementBounds = getElementBounds(constrainedElement, element)
+
+    // Change element tooltip coordinates to put the element right next target element
+    const joinedMarker = getJoinedElement(rotatedMarker, overflowedTarget, position)
+
+    // Calculate constraint rectangle for marker element (always within tooltip element rectangle)
+    const markerConstraint = getMarkerConstraint(constrainedElement, joinedMarker, position)
+
+    // Apply marker constraint (shift marker element if it's needed)
+    const constrainedMarker = getConstrainedElement(joinedMarker, markerConstraint)
+    const markerOffset = getMarkerOffset(markerOrigin, constrainedMarker)
+
+    // Check visibility and join geometry
+    const isTooltipVisible = isElementVisible(constrainedElement)
+    const isTooltipJoined = intersects(extendedTarget, constrainedElement)
+    const isMarkerJoined = intersects(extendedTarget, constrainedMarker)
+
+    if (!isTooltipVisible || (!isTooltipJoined && !isMarkerJoined)) {
+        return null
+    }
+
+    return {
+        elementArea,
+        elementOffset,
+        elementBounds,
+        markerAngle,
+        markerOffset,
+    }
+}
+
+// ------------ Private methods --------------
+
+interface NormalizedTetherLayout {
+    element: Rectangle
+    target: Rectangle
+    marker: Rectangle
+    overflow: Rectangle
+    constraint: Rectangle
+}
+
+/**
+ * Returns normalized (rounded and amplified) layout input.
+ */
+function getNormalizedLayout(layout: TetherLayout): NormalizedTetherLayout {
+    const { element, target, marker, overflows, constraints } = layout
+
+    return {
+        element: getRoundedElement(element),
+        target: getRoundedElement(target),
+        marker: getRoundedElement(marker),
+        overflow: getElementsIntersection(overflows),
+        constraint: getElementsIntersection(constraints),
+    }
+}

--- a/client/wildcard/src/components/Popover/tether/services/tether-registry.ts
+++ b/client/wildcard/src/components/Popover/tether/services/tether-registry.ts
@@ -1,0 +1,43 @@
+import { render } from './tether-render'
+import { Tether } from './types'
+
+interface TetherInstanceAPI {
+    unsubscribe: () => void
+    forceUpdate: () => void
+}
+
+/**
+ * Main entry point of all tether logic. Creates tether API instance
+ * and initializes the main tooltip position logic.
+ */
+export function createTether(tether: Tether): TetherInstanceAPI {
+    function eventHandler(event: Event): void {
+        // Run everything in the next frame to be able to get actual value
+        // of size and element position.
+        requestAnimationFrame(() => {
+            const target = event.target as HTMLElement
+
+            render(tether, target)
+        })
+    }
+
+    window.addEventListener('resize', eventHandler, true)
+    document.addEventListener('scroll', eventHandler, true)
+    document.addEventListener('click', eventHandler, true)
+    document.addEventListener('keyDown', eventHandler, true)
+    document.addEventListener('input', eventHandler, true)
+
+    // Synthetic run without target
+    render(tether, null)
+
+    return {
+        unsubscribe: () => {
+            window.removeEventListener('resize', eventHandler, true)
+            document.removeEventListener('scroll', eventHandler, true)
+            document.removeEventListener('click', eventHandler, true)
+            document.removeEventListener('keyDown', eventHandler, true)
+            document.removeEventListener('input', eventHandler, true)
+        },
+        forceUpdate: () => requestAnimationFrame(() => render(tether, null)),
+    }
+}

--- a/client/wildcard/src/components/Popover/tether/services/tether-registry.ts
+++ b/client/wildcard/src/components/Popover/tether/services/tether-registry.ts
@@ -27,7 +27,7 @@ export function createTether(tether: Tether): TetherInstanceAPI {
     document.addEventListener('keyDown', eventHandler, true)
     document.addEventListener('input', eventHandler, true)
 
-    // Synthetic run without target
+    // Synthetic run without target for the initial tooltip positioning render
     render(tether, null)
 
     return {

--- a/client/wildcard/src/components/Popover/tether/services/tether-render.ts
+++ b/client/wildcard/src/components/Popover/tether/services/tether-render.ts
@@ -1,0 +1,49 @@
+import {
+    getScrollPositions,
+    isVisible,
+    setMaxSize,
+    setScrollPositions,
+    setTransform,
+    setVisibility,
+} from './tether-browser'
+import { getLayout } from './tether-layout'
+import { getState } from './tether-state'
+import { Tether } from './types'
+
+/**
+ * Main entry point for tooltip element position calculations. It mutates tooltip
+ * DOM element (set visibility, width, height, top, left) properties.
+ *
+ * @param tether - settings tooltip information.
+ * @param eventTarget - event target element event of which has triggered tooltip
+ * position update.
+ */
+export function render(tether: Tether, eventTarget: HTMLElement | null): void {
+    const positions = getScrollPositions(tether.element)
+
+    if (!positions.points.has(<Element>eventTarget)) {
+        setMaxSize(tether.element, null)
+    }
+
+    // Restore visibility for correct measure in layout service
+    setVisibility(tether.element, true)
+    setVisibility(tether.marker ?? null, true)
+
+    const layout = getLayout(tether)
+    const state = getState(layout)
+
+    if (state === null || !isVisible(tether.target)) {
+        setVisibility(tether.element, false)
+        setVisibility(tether.marker ?? null, false)
+
+        return
+    }
+
+    setTransform(tether.element, 0, state.elementOffset)
+    setTransform(tether.marker ?? null, state.markerAngle, state.markerOffset)
+
+    if (!positions.points.has(<Element>eventTarget)) {
+        setMaxSize(tether.element, state.elementBounds)
+        setScrollPositions(positions)
+    }
+}

--- a/client/wildcard/src/components/Popover/tether/services/tether-render.ts
+++ b/client/wildcard/src/components/Popover/tether/services/tether-render.ts
@@ -21,7 +21,7 @@ import { Tether } from './types'
 export function render(tether: Tether, eventTarget: HTMLElement | null): void {
     const positions = getScrollPositions(tether.element)
 
-    if (!positions.points.has(<Element>eventTarget)) {
+    if (!positions.points.has(eventTarget as Element)) {
         setMaxSize(tether.element, null)
     }
 
@@ -42,7 +42,7 @@ export function render(tether: Tether, eventTarget: HTMLElement | null): void {
     setTransform(tether.element, 0, state.elementOffset)
     setTransform(tether.marker ?? null, state.markerAngle, state.markerOffset)
 
-    if (!positions.points.has(<Element>eventTarget)) {
+    if (!positions.points.has(eventTarget as Element)) {
         setMaxSize(tether.element, state.elementBounds)
         setScrollPositions(positions)
     }

--- a/client/wildcard/src/components/Popover/tether/services/tether-state.ts
+++ b/client/wildcard/src/components/Popover/tether/services/tether-state.ts
@@ -1,0 +1,35 @@
+import { getPositions } from './geometry'
+import { TetherState, getPositionState } from './tether-position'
+import { TetherLayout } from './types'
+
+/**
+ * Calculates and returns the most suitable position and tooltip element
+ * size value based on layout settings.
+ *
+ * @param layout
+ */
+export function getState(layout: TetherLayout): TetherState | null {
+    let state: TetherState | null = null
+
+    for (const position of getPositions(layout.position, layout.flipping)) {
+        const current = getPositionState(layout, position)
+        state ??= current
+
+        if (current === null) {
+            continue
+        }
+
+        if (state !== null && current.elementArea > state.elementArea) {
+            state = current
+        }
+
+        // If element bounds equals to null that means that non of constraints were applied
+        // therefore we have enough space to render all content inside tooltip without any
+        // visual restriction. Pick current state and stop further calculations
+        if (current.elementBounds === null) {
+            break
+        }
+    }
+
+    return state
+}

--- a/client/wildcard/src/components/Popover/tether/services/types.ts
+++ b/client/wildcard/src/components/Popover/tether/services/types.ts
@@ -1,0 +1,73 @@
+import { Point } from '../models/geometry/point'
+import { Rectangle } from '../models/geometry/rectangle'
+import { Constraint, Flipping, Overlapping, Position } from '../models/tether-models'
+
+export interface Tether {
+    /** Reference on target HTML element in the DOM. */
+    target: HTMLElement | null
+
+    /** Reference on tooltip HTML element in the DOM. */
+    element: HTMLElement
+
+    /** Reference on tooltip tail (marker) HTML element in the DOM. */
+    marker?: HTMLElement | null
+
+    /**
+     * In case if consumer wants to position not by target but
+     * just a point on the page. It could be mouse cursor or
+     * some coordinate on a canvas chart.
+     */
+    pin?: Point | null
+
+    /**
+     * Initial tooltip position. It can be changed by tooltip position calculator
+     * during position calculation that takes into account layout data (constraints,
+     * viewport space, paddings, etc)
+     */
+    position?: Position
+
+    /**
+     * Position flipping strategy. With active flipping tooltip tries to find other
+     * position on opposite side of target element if current doesn't have enough
+     * space.
+     */
+    flipping?: Flipping
+
+    /**
+     * Position strategy settings, allows tooltip to overlap target element if it's
+     * needed (not enough space with current position)
+     */
+    overlapping?: Overlapping
+
+    /** A custom constrain element for the tooltip element position. */
+    constraint?: HTMLElement
+
+    windowPadding?: Rectangle
+    constraintPadding?: Rectangle
+
+    overflowToScrollParents?: boolean
+    constrainToScrollParents?: boolean
+}
+
+export interface TetherLayout {
+    /** Tooltip target element */
+    target: Rectangle
+
+    /** Tooltip HTML element itself */
+    element: Rectangle
+
+    /** Marker HTML element (for tooltip tail/arrow rendering) */
+    marker: Rectangle
+
+    /** Tooltip position relative to target */
+    position: Position
+
+    /** Position flipping strategy */
+    flipping: Flipping
+
+    /** Overlapping position strategy */
+    overlapping: Overlapping
+
+    overflows: Constraint[]
+    constraints: Constraint[]
+}


### PR DESCRIPTION
## PRs map 

1. **This PR** (Add tether sub package PR)
2. [Adding `Popover` component](https://github.com/sourcegraph/sourcegraph/pull/29791)
3. _PRs from the third phase could be merged in parallel and reviewed independently_ 
   3.1 [Use `Popover` component in `Menu button` instead of built-in reach UI popover](https://github.com/sourcegraph/sourcegraph/pull/29792)
  3.2 [Migrate Code Insights to new wildcard `Popover` component](https://github.com/sourcegraph/sourcegraph/pull/29794)
   
## Context
This PR is the first PR of the series of changes of implementation `Popover` component. Previous these changes were in [one big PR here ](https://github.com/sourcegraph/sourcegraph/pull/29518)

1. **This PR** - tether package 
2. [Popover components implementation](https://github.com/sourcegraph/sourcegraph/pull/29791)

This PR adds a custom solution for tooltip, popover, or floating panel positioning. This PR is only about position logic and doesn't add anything else (like popover components, adoption of this solution, or even demo) All of these will be added in separate PRs.

## Sidenote about @floating-ui

It's a fair question why do we need to use something custom for this problem, does some OSS lib solve this problem better? Well, the most popular solution in the OSS market now is [floating-ui](https://floating-ui.com) (previously [popperJS](https://popper.js.org))

I tried to use them in some code insights specific use cases where we use the `Popover` component. Here are the problems that I've got in the code insights drill-down popover with `floating-ui` implementation.

- Determine available space and set this as a max-size max-height to popup element. Here we need to point out that @floating-ui has a special setting/plugin for it but this doesn't work really well if we need a floating panel with auto-placement and sizing at the same time.
- Flipping isn't perfect as well. TLDR; with size, shift, flip plugins at least in code insights popovers this logic picks non-optimal sizes/sides of popover elements.

If you're curious here is a draft PR where you can check the implementation in action https://github.com/sourcegraph/sourcegraph/pull/29488

