### PR TITLE
Eslint rule to enforce the <Link /> Wildcard component

### DIFF
--- a/client/eslint-plugin-wildcard/lib/index.js
+++ b/client/eslint-plugin-wildcard/lib/index.js
@@ -27,6 +27,10 @@ module.exports = {
                 element: 'textarea',
                 message: 'Use the <TextArea /> component from @sourcegraph/wildcard instead.',
               },
+              {
+                element: 'link',
+                message: 'Use the <Link /> component from @sourcegraph/wildcard instead.',
+              },
             ],
           },
         ],


### PR DESCRIPTION
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->

## Description
Eslint rule to enforce the <Link /> Wildcard component

## Refs
[SourceGraph Issue](https://github.com/sourcegraph/sourcegraph/issues/27662)
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-27662)

## Acceptance Criteria

- [x]  Eslint rule is added to enforce usage

- [x]  Eslint rule is implemented in the Sourcegraph repository