### PR TITLE
Upgrade Zustand to get access to better typed middleware

### DIFF
--- a/client/web/src/stores/themeState.ts
+++ b/client/web/src/stores/themeState.ts
@@ -1,5 +1,5 @@
-import create from 'zustand'
-import { persist } from 'zustand/middleware'
+import create, { GetState, SetState } from 'zustand'
+import { persist, StoreApiWithPersist } from 'zustand/middleware'
 
 /**
  * The user preference for the theme.
@@ -34,15 +34,14 @@ export interface ThemeState {
 }
 
 export const useThemeState = create<ThemeState>(
-    persist<ThemeState>(
-        set => ({
+    persist<ThemeState, SetState<ThemeState>, GetState<ThemeState>, StoreApiWithPersist<ThemeState>>(
+        (set): ThemeState => ({
             theme: readStoredThemePreference(),
             setTheme: theme => set({ theme }),
         }),
         {
             name: LIGHT_THEME_LOCAL_STORAGE_KEY,
-            whitelist: ['theme'],
-            serialize: state => state.state.theme,
+            serialize: state => state.state.theme ?? ThemePreference.System,
             deserialize: string => ({ state: { theme: readStoredThemePreference(string) } }),
         }
     )

--- a/package.json
+++ b/package.json
@@ -425,7 +425,7 @@
     "webext-domain-permission-toggle": "^1.0.1",
     "webextension-polyfill": "^0.6.0",
     "yaml-ast-parser": "^0.0.43",
-    "zustand": "^3.5.10"
+    "zustand": "^3.6.9"
   },
   "resolutions": {
     "history": "4.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24574,10 +24574,10 @@ zip-stream@^4.0.0:
     compress-commons "^4.1.0"
     readable-stream "^3.6.0"
 
-zustand@^3.5.10:
-  version "3.5.10"
-  resolved "https://registry.npmjs.org/zustand/-/zustand-3.5.10.tgz#d2622efd64530ffda285ee5b13ff645b68ab0faf"
-  integrity sha512-upluvSRWrlCiExu2UbkuMIPJ9AigyjRFoO7O9eUossIj7rPPq7pcJ0NKk6t2P7KF80tg/UdPX6/pNKOSbs9DEg==
+zustand@^3.6.9:
+  version "3.6.9"
+  resolved "https://registry.npmjs.org/zustand/-/zustand-3.6.9.tgz#f61a756ddea9f95c7ee7cfd3af2f88c10078afbc"
+  integrity sha512-OvDNu/jEWpRnEC7k8xh8GKjqYog7td6FZrLMuHs/IeI8WhrCwV+FngVuwMIFhp5kysZXr6emaeReMqjLGaldAQ==
 
 zwitch@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
See https://github.com/pmndrs/zustand/releases/tag/v3.6.0 some more details. I basically want to use the subscribe-with-selector functionality in the future and I thought why not just update as well.