### PR TITLE
Enable the fuzzy finder by default

### DIFF
--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -87,9 +87,12 @@ export const SearchNavbarItem: React.FunctionComponent<Props> = (props: Props) =
         }
     }, [isSearchPage, isFuzzyFinderVisible])
 
-    const { fuzzyFinder, fuzzyFinderCaseInsensitiveFileCountThreshold } = getExperimentalFeatures(
-        props.settingsCascade.final
-    )
+    let { fuzzyFinder } = getExperimentalFeatures(props.settingsCascade.final)
+    if (fuzzyFinder === undefined) {
+        // Happens even when `"default": true` is defined in
+        // settings.schema.json.
+        fuzzyFinder = true
+    }
 
     return (
         <Form
@@ -125,7 +128,6 @@ export const SearchNavbarItem: React.FunctionComponent<Props> = (props: Props) =
             />
             {props.isRepositoryRelatedPage && retainFuzzyFinderCache && fuzzyFinder && (
                 <FuzzyFinder
-                    caseInsensitiveFileCountThreshold={fuzzyFinderCaseInsensitiveFileCountThreshold}
                     setIsVisible={bool => setIsFuzzyFinderVisible(bool)}
                     isVisible={isFuzzyFinderVisible}
                     telemetryService={props.telemetryService}

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -177,7 +177,6 @@
         "fuzzyFinder": {
           "description": "Enables fuzzy finder with keyboard shortcut `t`.",
           "type": "boolean",
-          "default": true,
           "!go": {
             "pointer": true
           }


### PR DESCRIPTION
Also removes an unused `fuzzyFinderCaseInsensitiveFileCountThreshold` setting.
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
