### PR TITLE
dev/ci: do not remove containers by default, set unique container name

### DIFF
--- a/dev/ci/integration/run-integration.sh
+++ b/dev/ci/integration/run-integration.sh
@@ -15,8 +15,10 @@ fi
 
 URL="http://localhost:7080"
 
-# In CI, provide a directory unique to this job
-export DATA="/tmp/sourcegraph-data-${BUILDKITE_JOB_ID:-$(openssl rand -hex 12)}"
+# In CI, provide a directory and container name unique to this job
+IDENT=${BUILDKITE_JOB_ID:-$(openssl rand -hex 12)}
+export DATA="/tmp/sourcegraph-data-${IDENT}"
+export CONTAINER="sourcegraph-${IDENT}"
 
 function docker_cleanup() {
   echo "--- docker cleanup"
@@ -63,8 +65,7 @@ function cleanup() {
 trap cleanup EXIT
 
 echo "--- Running a daemonized $IMAGE as the test subject..."
-CONTAINER="sourcegraph"
-CLEAN="true" "${root_dir}"/dev/run-server-image.sh -d --name $CONTAINER
+CLEAN="true" "${root_dir}"/dev/run-server-image.sh -d --name "$CONTAINER"
 
 echo "--- Waiting for $URL to be up"
 set +e

--- a/dev/run-server-image.sh
+++ b/dev/run-server-image.sh
@@ -34,7 +34,6 @@ fi
 echo "--- Starting server ${IMAGE}"
 docker run "$@" \
   --publish 7080:7080 \
-  --rm \
   -e SRC_LOG_LEVEL=dbug \
   -e DEBUG=t \
   --volume "$DATA/config:/etc/sourcegraph" \


### PR DESCRIPTION
Right now, because test containers are started with `--rm`, if they fail to start we are unable to get any debug information from it. This changes containers to start _without_ `--rm` by default, and ensures integration tests provide a unique container name.

Each step ends with a broader image cleanup as well so we should not run into any state issues.