### PR TITLE
Revert "search-blitz: add ability to change sampling duration for metrics on dashboard"

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -927,27 +927,27 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: mean_successful_sentinel_duration
+## frontend: mean_successful_sentinel_duration_1h30m
 
-<p class="subtitle">mean successful sentinel search duration</p>
+<p class="subtitle">mean successful sentinel search duration over 1h30m</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 5s+ mean successful sentinel search duration for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 8s+ mean successful sentinel search duration for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 5s+ mean successful sentinel search duration over 1h30m for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 8s+ mean successful sentinel search duration over 1h30m for 30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-mean-successful-sentinel-duration).
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-mean-successful-sentinel-duration-1h30m).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_mean_successful_sentinel_duration",
-  "critical_frontend_mean_successful_sentinel_duration"
+  "warning_frontend_mean_successful_sentinel_duration_1h30m",
+  "critical_frontend_mean_successful_sentinel_duration_1h30m"
 ]
 ```
 
@@ -955,27 +955,27 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: mean_sentinel_stream_latency
+## frontend: mean_sentinel_stream_latency_1h30m
 
-<p class="subtitle">mean successful sentinel stream latency</p>
+<p class="subtitle">mean successful sentinel stream latency over 1h30m</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 2s+ mean successful sentinel stream latency for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 3s+ mean successful sentinel stream latency for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 2s+ mean successful sentinel stream latency over 1h30m for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 3s+ mean successful sentinel stream latency over 1h30m for 30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-mean-sentinel-stream-latency).
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-mean-sentinel-stream-latency-1h30m).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_mean_sentinel_stream_latency",
-  "critical_frontend_mean_sentinel_stream_latency"
+  "warning_frontend_mean_sentinel_stream_latency_1h30m",
+  "critical_frontend_mean_sentinel_stream_latency_1h30m"
 ]
 ```
 
@@ -983,27 +983,27 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: 90th_percentile_successful_sentinel_duration
+## frontend: 90th_percentile_successful_sentinel_duration_1h30m
 
-<p class="subtitle">90th percentile successful sentinel search duration</p>
+<p class="subtitle">90th percentile successful sentinel search duration over 1h30m</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 5s+ 90th percentile successful sentinel search duration for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 10s+ 90th percentile successful sentinel search duration for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 5s+ 90th percentile successful sentinel search duration over 1h30m for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 10s+ 90th percentile successful sentinel search duration over 1h30m for 30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-90th-percentile-successful-sentinel-duration).
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-90th-percentile-successful-sentinel-duration-1h30m).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_90th_percentile_successful_sentinel_duration",
-  "critical_frontend_90th_percentile_successful_sentinel_duration"
+  "warning_frontend_90th_percentile_successful_sentinel_duration_1h30m",
+  "critical_frontend_90th_percentile_successful_sentinel_duration_1h30m"
 ]
 ```
 
@@ -1011,27 +1011,27 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: 90th_percentile_sentinel_stream_latency
+## frontend: 90th_percentile_sentinel_stream_latency_1h30m
 
-<p class="subtitle">90th percentile successful sentinel stream latency</p>
+<p class="subtitle">90th percentile successful sentinel stream latency over 1h30m</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 4s+ 90th percentile successful sentinel stream latency for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 6s+ 90th percentile successful sentinel stream latency for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 4s+ 90th percentile successful sentinel stream latency over 1h30m for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 6s+ 90th percentile successful sentinel stream latency over 1h30m for 30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-90th-percentile-sentinel-stream-latency).
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-90th-percentile-sentinel-stream-latency-1h30m).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_90th_percentile_sentinel_stream_latency",
-  "critical_frontend_90th_percentile_sentinel_stream_latency"
+  "warning_frontend_90th_percentile_sentinel_stream_latency_1h30m",
+  "critical_frontend_90th_percentile_sentinel_stream_latency_1h30m"
 ]
 ```
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -2843,13 +2843,13 @@ Query: `sum by(app) (up{app=~".*(frontend|sourcegraph-frontend)"}) / count by (a
 
 ### Frontend: Sentinel queries (only on sourcegraph.com)
 
-#### frontend: mean_successful_sentinel_duration
+#### frontend: mean_successful_sentinel_duration_1h30m
 
-<p class="subtitle">Mean successful sentinel search duration</p>
+<p class="subtitle">Mean successful sentinel search duration over 1h30m</p>
 
 Mean search duration for all successful sentinel queries
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-successful-sentinel-duration) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-successful-sentinel-duration-1h30m) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102400` on your Sourcegraph instance.
 
@@ -2858,19 +2858,19 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102400`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_search_response_latency_seconds_sum{source=~`searchblitz.*`, status=`success`}[$sentinel_sampling_duration])) / sum(rate(src_search_response_latency_seconds_count{source=~`searchblitz.*`, status=`success`}[$sentinel_sampling_duration]))`
+Query: `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[1h30m])) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[1h30m]))`
 
 </details>
 
 <br />
 
-#### frontend: mean_sentinel_stream_latency
+#### frontend: mean_sentinel_stream_latency_1h30m
 
-<p class="subtitle">Mean successful sentinel stream latency</p>
+<p class="subtitle">Mean successful sentinel stream latency over 1h30m</p>
 
 Mean time to first result for all successful streaming sentinel queries
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-sentinel-stream-latency) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-sentinel-stream-latency-1h30m) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102401` on your Sourcegraph instance.
 
@@ -2879,19 +2879,19 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102401`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[$sentinel_sampling_duration])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[$sentinel_sampling_duration]))`
+Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[1h30m])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[1h30m]))`
 
 </details>
 
 <br />
 
-#### frontend: 90th_percentile_successful_sentinel_duration
+#### frontend: 90th_percentile_successful_sentinel_duration_1h30m
 
-<p class="subtitle">90th percentile successful sentinel search duration</p>
+<p class="subtitle">90th percentile successful sentinel search duration over 1h30m</p>
 
 90th percentile search duration for all successful sentinel queries
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-successful-sentinel-duration) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-successful-sentinel-duration-1h30m) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102410` on your Sourcegraph instance.
 
@@ -2900,19 +2900,19 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102410`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration]), "source", "$1", "source", "searchblitz_(.*)")))`
+Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m]), "source", "$1", "source", "searchblitz_(.*)")))`
 
 </details>
 
 <br />
 
-#### frontend: 90th_percentile_sentinel_stream_latency
+#### frontend: 90th_percentile_sentinel_stream_latency_1h30m
 
-<p class="subtitle">90th percentile successful sentinel stream latency</p>
+<p class="subtitle">90th percentile successful sentinel stream latency over 1h30m</p>
 
 90th percentile time to first result for all successful streaming sentinel queries
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-sentinel-stream-latency) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-sentinel-stream-latency-1h30m) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102411` on your Sourcegraph instance.
 
@@ -2921,15 +2921,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102411`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[$sentinel_sampling_duration]), "source", "$1", "source", "searchblitz_(.*)")))`
+Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m]), "source", "$1", "source", "searchblitz_(.*)")))`
 
 </details>
 
 <br />
 
-#### frontend: mean_successful_sentinel_duration_by_query
+#### frontend: mean_successful_sentinel_duration_by_query_1h30m
 
-<p class="subtitle">Mean successful sentinel search duration by query</p>
+<p class="subtitle">Mean successful sentinel search duration by query over 1h30m</p>
 
 Mean search duration for successful sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -2942,15 +2942,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102420`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (source) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (source)`
+Query: `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[1h30m])) by (source) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[1h30m])) by (source)`
 
 </details>
 
 <br />
 
-#### frontend: mean_sentinel_stream_latency_by_query
+#### frontend: mean_sentinel_stream_latency_by_query_1h30m
 
-<p class="subtitle">Mean successful sentinel stream latency by query</p>
+<p class="subtitle">Mean successful sentinel stream latency by query over 1h30m</p>
 
 Mean time to first result for successful streaming sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -2963,15 +2963,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102421`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (source) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (source)`
+Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[1h30m])) by (source) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[1h30m])) by (source)`
 
 </details>
 
 <br />
 
-#### frontend: 90th_percentile_successful_sentinel_duration_by_query
+#### frontend: 90th_percentile_successful_sentinel_duration_by_query_1h30m
 
-<p class="subtitle">90th percentile successful sentinel search duration by query</p>
+<p class="subtitle">90th percentile successful sentinel search duration by query over 1h30m</p>
 
 90th percentile search duration for successful sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -2984,15 +2984,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102430`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (le, source))`
+Query: `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m])) by (le, source))`
 
 </details>
 
 <br />
 
-#### frontend: 90th_percentile_successful_stream_latency_by_query
+#### frontend: 90th_percentile_successful_stream_latency_by_query_1h30m
 
-<p class="subtitle">90th percentile successful sentinel stream latency by query</p>
+<p class="subtitle">90th percentile successful sentinel stream latency by query over 1h30m</p>
 
 90th percentile time to first result for successful streaming sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -3005,15 +3005,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102431`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (le, source))`
+Query: `histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m])) by (le, source))`
 
 </details>
 
 <br />
 
-#### frontend: 90th_percentile_unsuccessful_duration_by_query
+#### frontend: 90th_percentile_unsuccessful_duration_by_query_1h30m
 
-<p class="subtitle">90th percentile unsuccessful sentinel search duration by query</p>
+<p class="subtitle">90th percentile unsuccessful sentinel search duration by query over 1h30m</p>
 
 90th percentile search duration of _unsuccessful_ sentinel queries (by error or timeout), broken down by query. Useful for debugging how the performance of failed requests affect UX.
 
@@ -3026,15 +3026,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102440`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[$sentinel_sampling_duration])) by (le, source))`
+Query: `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[1h30m])) by (le, source))`
 
 </details>
 
 <br />
 
-#### frontend: 75th_percentile_successful_sentinel_duration_by_query
+#### frontend: 75th_percentile_successful_sentinel_duration_by_query_1h30m
 
-<p class="subtitle">75th percentile successful sentinel search duration by query</p>
+<p class="subtitle">75th percentile successful sentinel search duration by query over 1h30m</p>
 
 75th percentile search duration of successful sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -3047,15 +3047,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102450`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (le, source))`
+Query: `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m])) by (le, source))`
 
 </details>
 
 <br />
 
-#### frontend: 75th_percentile_successful_stream_latency_by_query
+#### frontend: 75th_percentile_successful_stream_latency_by_query_1h30m
 
-<p class="subtitle">75th percentile successful sentinel stream latency by query</p>
+<p class="subtitle">75th percentile successful sentinel stream latency by query over 1h30m</p>
 
 75th percentile time to first result for successful streaming sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -3068,15 +3068,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102451`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (le, source))`
+Query: `histogram_quantile(0.75, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m])) by (le, source))`
 
 </details>
 
 <br />
 
-#### frontend: 75th_percentile_unsuccessful_duration_by_query
+#### frontend: 75th_percentile_unsuccessful_duration_by_query_1h30m
 
-<p class="subtitle">75th percentile unsuccessful sentinel search duration by query</p>
+<p class="subtitle">75th percentile unsuccessful sentinel search duration by query over 1h30m</p>
 
 75th percentile search duration of _unsuccessful_ sentinel queries (by error or timeout), broken down by query. Useful for debugging how the performance of failed requests affect UX.
 
@@ -3089,15 +3089,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102460`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[$sentinel_sampling_duration])) by (le, source))`
+Query: `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[1h30m])) by (le, source))`
 
 </details>
 
 <br />
 
-#### frontend: unsuccessful_status_rate
+#### frontend: unsuccessful_status_rate_1h30m
 
-<p class="subtitle">Unsuccessful status rate</p>
+<p class="subtitle">Unsuccessful status rate per 1h30m</p>
 
 The rate of unsuccessful sentinel queries, broken down by failure type.
 
@@ -3110,7 +3110,7 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102470`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_graphql_search_response{source=~"searchblitz.*", status!="success"}[$sentinel_sampling_duration])) by (status)`
+Query: `sum(rate(src_graphql_search_response{source=~"searchblitz.*", status!="success"}[1h30m])) by (status)`
 
 </details>
 

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -31,11 +31,6 @@ type Container struct {
 	// container, such as instances or shards.
 	Variables []ContainerVariable
 
-	// RawVariables exposes the underlying Grafana API to define
-	// variables that can be applied to the dashboard for this container,
-	// such as instances or shards.
-	RawVariables []sdk.TemplateVar
-
 	// Groups of observable information about the container.
 	Groups []Group
 
@@ -92,7 +87,6 @@ func (c *Container) renderDashboard() *sdk.Board {
 	for _, variable := range c.Variables {
 		board.Templating.List = append(board.Templating.List, variable.toGrafanaTemplateVar())
 	}
-	board.Templating.List = append(board.Templating.List, c.RawVariables...)
 	board.Annotations.List = []sdk.Annotation{{
 		Name:       "Alert events",
 		Datasource: StringPtr("Prometheus"),


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#29753

I suspect this is causing CI failures, where prometheus is failing to start: https://buildkite.com/sourcegraph/sourcegraph/builds/125820

```
2022-01-17T17:25:24.588070560Z [0;33m17:25:24                prometheus | [0mTerminating prometheus
2022-01-17T17:25:24.588082780Z prometheus died. Shutting down...
```

It is the first build that failed this morning: https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1642432851057700

Not clear why, but giving this a try

Main-dry-run: https://buildkite.com/sourcegraph/sourcegraph/builds/125854