### PR TITLE
Clean up CommitMatch string types

### DIFF
--- a/cmd/frontend/graphqlbackend/commit_search_result.go
+++ b/cmd/frontend/graphqlbackend/commit_search_result.go
@@ -56,14 +56,14 @@ func (r *CommitSearchResultResolver) MessagePreview() *highlightedStringResolver
 	if r.CommitMatch.MessagePreview == nil {
 		return nil
 	}
-	return &highlightedStringResolver{(*r.CommitMatch.MessagePreview).ToHighlightedString()}
+	return &highlightedStringResolver{r.CommitMatch.MessagePreview.ToHighlightedString()}
 }
 
 func (r *CommitSearchResultResolver) DiffPreview() *highlightedStringResolver {
 	if r.CommitMatch.DiffPreview == nil {
 		return nil
 	}
-	return &highlightedStringResolver{(*r.CommitMatch.DiffPreview).ToHighlightedString()}
+	return &highlightedStringResolver{r.CommitMatch.DiffPreview.ToHighlightedString()}
 }
 
 func (r *CommitSearchResultResolver) Label() Markdown {

--- a/cmd/frontend/graphqlbackend/commit_search_result.go
+++ b/cmd/frontend/graphqlbackend/commit_search_result.go
@@ -56,14 +56,14 @@ func (r *CommitSearchResultResolver) MessagePreview() *highlightedStringResolver
 	if r.CommitMatch.MessagePreview == nil {
 		return nil
 	}
-	return &highlightedStringResolver{*r.CommitMatch.MessagePreview}
+	return &highlightedStringResolver{(*r.CommitMatch.MessagePreview).ToHighlightedString()}
 }
 
 func (r *CommitSearchResultResolver) DiffPreview() *highlightedStringResolver {
 	if r.CommitMatch.DiffPreview == nil {
 		return nil
 	}
-	return &highlightedStringResolver{*r.CommitMatch.DiffPreview}
+	return &highlightedStringResolver{(*r.CommitMatch.DiffPreview).ToHighlightedString()}
 }
 
 func (r *CommitSearchResultResolver) Label() Markdown {
@@ -79,9 +79,10 @@ func (r *CommitSearchResultResolver) Detail() Markdown {
 }
 
 func (r *CommitSearchResultResolver) Matches() []*searchResultMatchResolver {
+	hls := r.CommitMatch.Body.ToHighlightedString()
 	match := &searchResultMatchResolver{
-		body:       r.CommitMatch.Body.Value,
-		highlights: r.CommitMatch.Body.Highlights,
+		body:       hls.Value,
+		highlights: hls.Highlights,
 		url:        r.Commit().URL(),
 	}
 	matches := []*searchResultMatchResolver{match}

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -553,11 +553,9 @@ func fromRepository(rm *result.RepoMatch, repoCache map[api.RepoID]*types.Search
 }
 
 func fromCommit(commit *result.CommitMatch, repoCache map[api.RepoID]*types.SearchedRepo) *streamhttp.EventCommitMatch {
-	content := commit.Body.Value
-
-	highlights := commit.Body.Highlights
-	ranges := make([][3]int32, len(highlights))
-	for i, h := range highlights {
+	hls := commit.Body.ToHighlightedString()
+	ranges := make([][3]int32, len(hls.Highlights))
+	for i, h := range hls.Highlights {
 		ranges[i] = [3]int32{h.Line, h.Character, h.Length}
 	}
 
@@ -567,7 +565,7 @@ func fromCommit(commit *result.CommitMatch, repoCache map[api.RepoID]*types.Sear
 		URL:        commit.URL().String(),
 		Detail:     commit.Detail(),
 		Repository: string(commit.Repo.Name),
-		Content:    content,
+		Content:    hls.Value,
 		Ranges:     ranges,
 	}
 

--- a/internal/compute/output_command.go
+++ b/internal/compute/output_command.go
@@ -65,7 +65,7 @@ func resultContent(ctx context.Context, r result.Match) (string, bool, error) {
 	case *result.CommitMatch:
 		var content string
 		if m.DiffPreview != nil {
-			content = m.DiffPreview.Value
+			content = m.DiffPreview.Content
 		} else {
 			content = string(m.Commit.Message)
 		}

--- a/internal/search/commit/commit_new.go
+++ b/internal/search/commit/commit_new.go
@@ -303,20 +303,18 @@ func queryParameterToPredicate(parameter query.Parameter, caseSensitive, diff bo
 func protocolMatchToCommitMatch(repo types.MinimalRepo, diff bool, in protocol.CommitMatch) *result.CommitMatch {
 	var (
 		markdown       result.MatchedString
-		diffPreview    *result.HighlightedString
-		messagePreview *result.HighlightedString
+		diffPreview    *result.MatchedString
+		messagePreview *result.MatchedString
 	)
 
 	if diff {
-		hls := in.Diff.ToHighlightedString()
-		diffPreview = &hls
+		diffPreview = &in.Diff
 		markdown = result.MatchedString{
 			Content:       "```diff\n" + in.Diff.Content + "\n```",
 			MatchedRanges: in.Diff.MatchedRanges.Add(result.Location{Line: 1, Offset: len("```diff\n")}),
 		}
 	} else {
-		hls := in.Message.ToHighlightedString()
-		messagePreview = &hls
+		messagePreview = &in.Message
 		markdown = result.MatchedString{
 			Content:       "```COMMIT_EDITMSG\n" + in.Message.Content + "\n```",
 			MatchedRanges: in.Message.MatchedRanges.Add(result.Location{Line: 1, Offset: len("```COMMIT_EDITMSG\n")}),
@@ -342,7 +340,7 @@ func protocolMatchToCommitMatch(repo types.MinimalRepo, diff bool, in protocol.C
 		Repo:           repo,
 		MessagePreview: messagePreview,
 		DiffPreview:    diffPreview,
-		Body:           markdown.ToHighlightedString(),
+		Body:           markdown,
 	}
 }
 

--- a/internal/search/commit/commit_new.go
+++ b/internal/search/commit/commit_new.go
@@ -303,22 +303,27 @@ func queryParameterToPredicate(parameter query.Parameter, caseSensitive, diff bo
 
 func protocolMatchToCommitMatch(repo types.MinimalRepo, diff bool, in protocol.CommitMatch) *result.CommitMatch {
 	var (
-		matchBody       string
-		matchHighlights []result.HighlightedRange
-		diffPreview     *result.HighlightedString
-		messagePreview  *result.HighlightedString
+		matchBody      result.HighlightedString
+		diffPreview    *result.HighlightedString
+		messagePreview *result.HighlightedString
 	)
 
 	if diff {
-		matchBody = "```diff\n" + in.Diff.Content + "\n```"
-		matchHighlights = searchRangesToHighlights(matchBody, in.Diff.MatchedRanges.Add(result.Location{Line: 1, Offset: len("```diff\n")}))
+		matchBodyValue := "```diff\n" + in.Diff.Content + "\n```"
+		matchBody = result.HighlightedString{
+			Value:      matchBodyValue,
+			Highlights: searchRangesToHighlights(matchBodyValue, in.Diff.MatchedRanges.Add(result.Location{Line: 1, Offset: len("```diff\n")})),
+		}
 		diffPreview = &result.HighlightedString{
 			Value:      in.Diff.Content,
 			Highlights: searchRangesToHighlights(in.Diff.Content, in.Diff.MatchedRanges),
 		}
 	} else {
-		matchBody = "```COMMIT_EDITMSG\n" + in.Message.Content + "\n```"
-		matchHighlights = searchRangesToHighlights(matchBody, in.Message.MatchedRanges.Add(result.Location{Line: 1, Offset: len("```COMMIT_EDITMSG\n")}))
+		matchBodyValue := "```COMMIT_EDITMSG\n" + in.Message.Content + "\n```"
+		matchBody = result.HighlightedString{
+			Value:      matchBodyValue,
+			Highlights: searchRangesToHighlights(matchBodyValue, in.Message.MatchedRanges.Add(result.Location{Line: 1, Offset: len("```COMMIT_EDITMSG\n")})),
+		}
 		messagePreview = &result.HighlightedString{
 			Value:      in.Message.Content,
 			Highlights: searchRangesToHighlights(in.Message.Content, in.Message.MatchedRanges),
@@ -344,10 +349,7 @@ func protocolMatchToCommitMatch(repo types.MinimalRepo, diff bool, in protocol.C
 		Repo:           repo,
 		MessagePreview: messagePreview,
 		DiffPreview:    diffPreview,
-		Body: result.HighlightedString{
-			Value:      matchBody,
-			Highlights: matchHighlights,
-		},
+		Body:           matchBody,
 	}
 }
 

--- a/internal/search/commit/commit_test.go
+++ b/internal/search/commit/commit_test.go
@@ -10,8 +10,8 @@ import (
 func TestCommitSearchResult_Limit(t *testing.T) {
 	f := func(nHighlights []int, limitInput uint32) bool {
 		cr := &result.CommitMatch{
-			Body: result.HighlightedString{
-				Highlights: make([]result.HighlightedRange, len(nHighlights)),
+			Body: result.MatchedString{
+				MatchedRanges: make([]result.MatchedRange, len(nHighlights)),
 			},
 		}
 

--- a/internal/search/commit/commit_test.go
+++ b/internal/search/commit/commit_test.go
@@ -11,7 +11,7 @@ func TestCommitSearchResult_Limit(t *testing.T) {
 	f := func(nHighlights []int, limitInput uint32) bool {
 		cr := &result.CommitMatch{
 			Body: result.MatchedString{
-				MatchedRanges: make([]result.MatchedRange, len(nHighlights)),
+				MatchedRanges: make([]result.Range, len(nHighlights)),
 			},
 		}
 

--- a/internal/search/commit/commit_test.go
+++ b/internal/search/commit/commit_test.go
@@ -1,11 +1,8 @@
 package commit
 
 import (
-	"strconv"
 	"testing"
 	"testing/quick"
-
-	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
@@ -43,71 +40,5 @@ func TestCommitSearchResult_Limit(t *testing.T) {
 				t.Error("small exhaustive check failed")
 			}
 		}
-	}
-}
-
-func Test_searchRangeToHighlights(t *testing.T) {
-	type testCase struct {
-		input      string
-		inputRange result.Range
-		output     []result.HighlightedRange
-	}
-
-	cases := []testCase{
-		{
-			input: "abc",
-			inputRange: result.Range{
-				Start: result.Location{Offset: 1, Line: 0, Column: 1},
-				End:   result.Location{Offset: 2, Line: 0, Column: 2},
-			},
-			output: []result.HighlightedRange{{
-				Line:      0,
-				Character: 1,
-				Length:    1,
-			}},
-		},
-		{
-			input: "abc\ndef\n",
-			inputRange: result.Range{
-				Start: result.Location{Offset: 2, Line: 0, Column: 2},
-				End:   result.Location{Offset: 5, Line: 1, Column: 1},
-			},
-			output: []result.HighlightedRange{{
-				Line:      0,
-				Character: 2,
-				Length:    1,
-			}, {
-				Line:      1,
-				Character: 0,
-				Length:    1,
-			}},
-		},
-		{
-			input: "abc\ndef\nghi\n",
-			inputRange: result.Range{
-				Start: result.Location{Offset: 0, Line: 0, Column: 0},
-				End:   result.Location{Offset: 11, Line: 2, Column: 3},
-			},
-			output: []result.HighlightedRange{{
-				Line:      0,
-				Character: 0,
-				Length:    3,
-			}, {
-				Line:      1,
-				Character: 0,
-				Length:    3,
-			}, {
-				Line:      2,
-				Character: 0,
-				Length:    3,
-			}},
-		},
-	}
-
-	for i, tc := range cases {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			res := searchRangeToHighlights(tc.input, tc.inputRange)
-			require.Equal(t, tc.output, res)
-		})
 	}
 }

--- a/internal/search/result/deduper_test.go
+++ b/internal/search/result/deduper_test.go
@@ -30,7 +30,7 @@ func TestDeduper(t *testing.T) {
 			Commit: gitdomain.Commit{
 				ID: api.CommitID(id),
 			},
-			DiffPreview: &HighlightedString{},
+			DiffPreview: &MatchedString{},
 		}
 	}
 

--- a/internal/search/result/merge_test.go
+++ b/internal/search/result/merge_test.go
@@ -23,7 +23,7 @@ func commitResult(repo, commit string) *CommitMatch {
 
 func diffResult(repo, commit string) *CommitMatch {
 	return &CommitMatch{
-		DiffPreview: &HighlightedString{},
+		DiffPreview: &MatchedString{},
 		Repo:        types.MinimalRepo{Name: api.RepoName(repo)},
 		Commit: gitdomain.Commit{
 			ID: api.CommitID(commit),

--- a/internal/search/result/range_test.go
+++ b/internal/search/result/range_test.go
@@ -1,0 +1,74 @@
+package result
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_searchRangeToHighlights(t *testing.T) {
+	type testCase struct {
+		input      string
+		inputRange Range
+		output     []HighlightedRange
+	}
+
+	cases := []testCase{
+		{
+			input: "abc",
+			inputRange: Range{
+				Start: Location{Offset: 1, Line: 0, Column: 1},
+				End:   Location{Offset: 2, Line: 0, Column: 2},
+			},
+			output: []HighlightedRange{{
+				Line:      0,
+				Character: 1,
+				Length:    1,
+			}},
+		},
+		{
+			input: "abc\ndef\n",
+			inputRange: Range{
+				Start: Location{Offset: 2, Line: 0, Column: 2},
+				End:   Location{Offset: 5, Line: 1, Column: 1},
+			},
+			output: []HighlightedRange{{
+				Line:      0,
+				Character: 2,
+				Length:    1,
+			}, {
+				Line:      1,
+				Character: 0,
+				Length:    1,
+			}},
+		},
+		{
+			input: "abc\ndef\nghi\n",
+			inputRange: Range{
+				Start: Location{Offset: 0, Line: 0, Column: 0},
+				End:   Location{Offset: 11, Line: 2, Column: 3},
+			},
+			output: []HighlightedRange{{
+				Line:      0,
+				Character: 0,
+				Length:    3,
+			}, {
+				Line:      1,
+				Character: 0,
+				Length:    3,
+			}, {
+				Line:      2,
+				Character: 0,
+				Length:    3,
+			}},
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			res := rangeToHighlights(tc.input, tc.inputRange)
+			require.Equal(t, tc.output, res)
+		})
+	}
+}

--- a/internal/search/streaming/search_filters_test.go
+++ b/internal/search/streaming/search_filters_test.go
@@ -26,10 +26,10 @@ func TestSearchFiltersUpdate(t *testing.T) {
 					Results: []result.Match{
 						&result.CommitMatch{
 							Repo: repo,
-							Body: result.HighlightedString{Highlights: make([]result.HighlightedRange, 2)}},
+							Body: result.MatchedString{MatchedRanges: make([]result.Range, 2)}},
 						&result.CommitMatch{
 							Repo: repo,
-							Body: result.HighlightedString{Highlights: make([]result.HighlightedRange, 1)}},
+							Body: result.MatchedString{MatchedRanges: make([]result.Range, 1)}},
 					},
 				}},
 			wantFilterName:  "repo:^foo$",


### PR DESCRIPTION
This pushes the `MatchedString` type up the stack so that `CommitMatch` uses `MatchedString` instead of `HighlightedString`. This is useful because `MatchedString` retains multiline information. Additionally, this moves the conversion code from `MatchedString` to `HighlightedString` into the `internal/search/result` package, which makes sense because both of those types are defined there. 

There should be no change in behavior here. It just pushes the conversion to a `HighlightedString` up to the GraphQL layer, since that's where the "highlights are only one line" constraint actually exists. The change is split up into three smaller commits. 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
