### PR TITLE
search: factor out static validation in downstream repo search logic

### DIFF
--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -34,32 +34,6 @@ func (s *RepoSearch) Run(ctx context.Context, stream streaming.Sender, repos sea
 		tr.Finish()
 	}()
 
-	fieldAllowlist := map[string]struct{}{
-		query.FieldRepo:               {},
-		query.FieldContext:            {},
-		query.FieldType:               {},
-		query.FieldDefault:            {},
-		query.FieldIndex:              {},
-		query.FieldCount:              {},
-		query.FieldTimeout:            {},
-		query.FieldFork:               {},
-		query.FieldArchived:           {},
-		query.FieldVisibility:         {},
-		query.FieldCase:               {},
-		query.FieldRepoHasFile:        {},
-		query.FieldRepoHasCommitAfter: {},
-		query.FieldPatternType:        {},
-		query.FieldSelect:             {},
-	}
-	// Don't return repo results if the search contains fields that aren't on the allowlist.
-	// Matching repositories based whether they contain files at a certain path (etc.) is not yet implemented.
-	for field := range s.Args.Query.Fields() {
-		if _, ok := fieldAllowlist[field]; !ok {
-			tr.LazyPrintf("contains dissallowed field: %s", field)
-			return nil
-		}
-	}
-
 	tr.LogFields(
 		otlog.String("pattern", s.Args.PatternInfo.Pattern),
 		otlog.Int("limit", s.Limit))


### PR DESCRIPTION
The `RepoSearch` job is the last job to fully depend on `Args *search.TextParameters`, and it doesn't need access to 90% of the state stored there. If I can remove the dependency on this type for this job, I can start to remove `search.TextParameters` type, which means I can eventually move job creation out of `search_results` and part of the query pipeline.

The `RepoSearch` job currently depends on `search.TextParameters` for a couple of reasons, one is static validation that we should do up front (this PR)