### PR TITLE
Update readiness/liveness probes for postgres containers to use local socket

### DIFF
--- a/docker-images/postgres-12.6-alpine/rootfs/ready.sh
+++ b/docker-images/postgres-12.6-alpine/rootfs/ready.sh
@@ -13,8 +13,6 @@ if [ -n "$POSTGRES_PASSWORD" ]; then
   export PGPASSWORD="$POSTGRES_PASSWORD"
 fi
 
-PGHOST="$(hostname)"
-export PGHOST
 export PGUSER="$POSTGRES_USER"
 export PGDATABASE="$POSTGRES_DB"
 export PGCONNECT_TIMEOUT=10


### PR DESCRIPTION
Using `hostname` in the psql command involves a DNS lookup and traffic exiting the container. This is outside the scope of a readiness probe and introduces new dependencies that are unrelated to the postgres container. DNS lookup failures should not cause Postgres to restart.

Another potential improvement here is to replace the `psql` command on L24 with `pg_isready`([docs](https://www.postgresql.org/docs/12/app-pg-isready.html)). I don't have enough context on why we chose to use psql, so I wanted to err on the side of minimal change first.

[Related conversation](https://sourcegraph.slack.com/archives/C02E4HE42BX/p1642015522059800)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
