### PR TITLE
search: move static repo option logic to job creation

### DIFF
--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -3,8 +3,6 @@ package run
 import (
 	"context"
 	"math"
-	"regexp"
-	"strings"
 
 	"github.com/cockroachdb/errors"
 	otlog "github.com/opentracing/opentracing-go/log"
@@ -39,18 +37,6 @@ func (s *RepoSearch) Run(ctx context.Context, stream streaming.Sender, repos sea
 		otlog.Int("limit", s.Limit))
 
 	opts := s.Args.RepoOptions // copy
-
-	if s.Args.PatternInfo.Pattern != "" {
-		opts.RepoFilters = append(make([]string, 0, len(opts.RepoFilters)), opts.RepoFilters...)
-		opts.CaseSensitiveRepoFilters = s.Args.Query.IsCaseSensitive()
-
-		p, ok := validRepoPattern(s.Args.PatternInfo.Pattern)
-		if !ok {
-			// skip running a repo search for this pattern
-			return nil
-		}
-		opts.RepoFilters = append(opts.RepoFilters, p)
-	}
 
 	ctx, stream, cleanup := streaming.WithLimit(ctx, stream, s.Limit)
 	defer cleanup()
@@ -87,41 +73,6 @@ func (*RepoSearch) Name() string {
 
 func (s *RepoSearch) Required() bool {
 	return s.IsRequired
-}
-
-// validRepoPattern returns true if the pattern part of a query can be used to
-// search repos. A problematic case we check for is when the pattern contains `@`,
-// which may confuse downstream logic to interpret it as part of `repo@rev` syntax.
-func validRepoPattern(pattern string) (string, bool) {
-	patternPrefix := strings.SplitN(pattern, "@", 2)
-	if len(patternPrefix) == 1 {
-		// No "@" in pattern? We're good.
-		return pattern, true
-	}
-
-	if patternPrefix[0] != "" {
-		// Extend the repo search using the pattern value, but
-		// since the pattern contains @, only search the part
-		// prefixed by the first @. This because downstream
-		// logic will get confused by the presence of @ and try
-		// to resolve repo revisions. See #27816.
-		if _, err := regexp.Compile(patternPrefix[0]); err != nil {
-			// Prefix is not valid regexp, so just reject it. This can happen for patterns where we've automatically added `(...).*?(...)`
-			// such as `foo @bar` which becomes `(foo).*?(@bar)`, which when stripped becomes `(foo).*?(` which is unbalanced and invalid.
-			// Why is this a mess? Because validation for everything, including repo values, should be done up front so far possible, not downtsream
-			// after possible modifications. By the time we reach this code, the pattern should already have been considered valid to continue with
-			// a search. But fixing the order of concerns for repo code is not something @rvantonder is doing today.
-			return "", false
-		}
-		return patternPrefix[0], true
-	}
-
-	// This pattern starts with @, of the form "@thing". We can't
-	// consistently handle search repos of this form, because
-	// downstream logic will attempt to interpret "thing" as a repo
-	// revision, may fail, and cause us to raise an alert for any
-	// non `type:repo` search. Better to not attempt a repo search.
-	return "", false
 }
 
 func repoRevsToRepoMatches(ctx context.Context, repos []*search.RepositoryRevisions) []result.Match {

--- a/internal/search/run/repository_test.go
+++ b/internal/search/run/repository_test.go
@@ -3,7 +3,6 @@ package run
 import (
 	"context"
 	"os"
-	"strconv"
 	"testing"
 
 	"github.com/google/zoekt"
@@ -13,8 +12,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/search/unindexed"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-
-	"github.com/hexops/autogold"
 )
 
 func TestRepoShouldBeAdded(t *testing.T) {
@@ -145,15 +142,4 @@ func repoShouldBeAdded(ctx context.Context, zoekt zoekt.Streamer, repo *search.R
 		return false, err
 	}
 	return len(rsta) == 1, nil
-}
-
-func Test_validRepoPattern(t *testing.T) {
-	test := func(input string) string {
-		_, ok := validRepoPattern(input)
-		return strconv.FormatBool(ok)
-	}
-	autogold.Want("normal pattern", "true").Equal(t, test("ok ok"))
-	autogold.Want("normal pattern with space", "true").Equal(t, test("ok @thing"))
-	autogold.Want("unsupported prefix", "false").Equal(t, test("@nope"))
-	autogold.Want("unsupported regexp", "false").Equal(t, test("(nope).*?(@(thing))"))
 }


### PR DESCRIPTION
Just moving stuff up to job creation where I can deal with it better. Point is to get to this very simple place where repo search jobs only rely on `RepoOptions`: https://github.com/sourcegraph/sourcegraph/pull/29843/files