### PR TITLE
remove deadline from searcher

### DIFF
--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -45,10 +45,6 @@ type Request struct {
 	// the fetch will still happen in the background so future requests don't have to wait.
 	FetchTimeout string
 
-	// The deadline for the search request.
-	// It is parsed with time.Time.UnmarshalText.
-	Deadline string
-
 	// Endpoint(s) for reaching Zoekt. See description in
 	// endpoint.go:Static(...)
 	IndexerEndpoints []string

--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -64,16 +64,6 @@ func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if p.Deadline != "" {
-		var deadline time.Time
-		if err := deadline.UnmarshalText([]byte(p.Deadline)); err != nil {
-			http.Error(w, "invalid deadline: "+err.Error(), http.StatusBadRequest)
-			return
-		}
-		dctx, cancel := context.WithDeadline(ctx, deadline)
-		defer cancel()
-		ctx = dctx
-	}
 	if !p.PatternMatchesContent && !p.PatternMatchesPath {
 		// BACKCOMPAT: Old frontends send neither of these fields, but we still want to
 		// search file content in that case.
@@ -112,10 +102,9 @@ func (s *Service) streamSearch(ctx context.Context, w http.ResponseWriter, p pro
 	ctx, cancel, stream := newLimitedStream(ctx, p.Limit, onMatches)
 	defer cancel()
 
-	deadlineHit, err := s.search(ctx, &p, stream)
+	err = s.search(ctx, &p, stream)
 	doneEvent := searcher.EventDone{
-		DeadlineHit: deadlineHit,
-		LimitHit:    stream.LimitHit(),
+		LimitHit: stream.LimitHit(),
 	}
 	if err != nil {
 		doneEvent.Error = err.Error()
@@ -130,7 +119,7 @@ func (s *Service) streamSearch(ctx context.Context, w http.ResponseWriter, p pro
 	}
 }
 
-func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchSender) (deadlineHit bool, err error) {
+func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchSender) (err error) {
 	tr := nettrace.New("search", fmt.Sprintf("%s@%s", p.Repo, p.Commit))
 	tr.LazyPrintf("%s", p.Pattern)
 
@@ -150,7 +139,6 @@ func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchS
 	span.SetTag("limit", p.Limit)
 	span.SetTag("patternMatchesContent", p.PatternMatchesContent)
 	span.SetTag("patternMatchesPath", p.PatternMatchesPath)
-	span.SetTag("deadline", p.Deadline)
 	span.SetTag("indexerEndpoints", p.IndexerEndpoints)
 	span.SetTag("select", p.Select)
 	defer func(start time.Time) {
@@ -160,11 +148,6 @@ func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchS
 		if ctx.Err() == context.Canceled {
 			code = "canceled"
 			span.SetTag("err", err)
-		} else if ctx.Err() == context.DeadlineExceeded {
-			code = "timedout"
-			span.SetTag("err", err)
-			deadlineHit = true
-			err = nil // error is fully described by deadlineHit=true return value
 		} else if err != nil {
 			tr.LazyPrintf("error: %v", err)
 			tr.SetError()
@@ -178,12 +161,11 @@ func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchS
 				code = "500"
 			}
 		}
-		tr.LazyPrintf("code=%s matches=%d limitHit=%v deadlineHit=%v", code, sender.SentCount(), sender.LimitHit(), deadlineHit)
+		tr.LazyPrintf("code=%s matches=%d limitHit=%v", code, sender.SentCount(), sender.LimitHit())
 		tr.Finish()
 		requestTotal.WithLabelValues(code).Inc()
 		span.LogFields(otlog.Int("matches.len", sender.SentCount()))
 		span.SetTag("limitHit", sender.LimitHit())
-		span.SetTag("deadlineHit", deadlineHit)
 		span.Finish()
 		if s.Log != nil {
 			s.Log.Debug("search request", "repo", p.Repo, "commit", p.Commit, "pattern", p.Pattern, "isRegExp", p.IsRegExp, "isStructuralPat", p.IsStructuralPat, "languages", p.Languages, "isWordMatch", p.IsWordMatch, "isCaseSensitive", p.IsCaseSensitive, "patternMatchesContent", p.PatternMatchesContent, "patternMatchesPath", p.PatternMatchesPath, "matches", sender.SentCount(), "code", code, "duration", time.Since(start), "indexerEndpoints", p.IndexerEndpoints, "err", err)
@@ -201,7 +183,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchS
 	if !p.IsStructuralPat {
 		rg, err = compile(&p.PatternInfo)
 		if err != nil {
-			return false, badRequestError{err.Error()}
+			return badRequestError{err.Error()}
 		}
 	}
 
@@ -210,7 +192,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchS
 	}
 	fetchTimeout, err := time.ParseDuration(p.FetchTimeout)
 	if err != nil {
-		return false, err
+		return err
 	}
 	prepareCtx, cancel := context.WithTimeout(ctx, fetchTimeout)
 	defer cancel()
@@ -226,7 +208,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchS
 
 	zipPath, zf, err := store.GetZipFileWithRetry(getZf)
 	if err != nil {
-		return false, errors.Wrap(err, "failed to get archive")
+		return errors.Wrap(err, "failed to get archive")
 	}
 	defer zf.Close()
 
@@ -240,9 +222,9 @@ func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchS
 	archiveSize.Observe(float64(bytes))
 
 	if p.IsStructuralPat {
-		return false, filteredStructuralSearch(ctx, zipPath, zf, &p.PatternInfo, p.Repo, sender)
+		return filteredStructuralSearch(ctx, zipPath, zf, &p.PatternInfo, p.Repo, sender)
 	} else {
-		return false, regexSearch(ctx, rg, zf, p.Limit, p.PatternMatchesContent, p.PatternMatchesPath, p.IsNegated, sender)
+		return regexSearch(ctx, rg, zf, p.Limit, p.PatternMatchesContent, p.PatternMatchesPath, p.IsNegated, sender)
 	}
 }
 

--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -279,7 +279,7 @@ func structuralSearch(ctx context.Context, zipPath string, paths filePatterns, e
 	return nil
 }
 
-func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request, sender matchSender) (deadlineHit bool, err error) {
+func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request, sender matchSender) (err error) {
 	patternInfo := &search.TextPatternInfo{
 		Pattern:                      p.Pattern,
 		IsNegated:                    p.IsNegated,
@@ -304,22 +304,22 @@ func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request, sender 
 	useFullDeadline := false
 	zoektMatches, _, _, err := zoektSearch(ctx, patternInfo, branchRepos, time.Since, p.IndexerEndpoints, useFullDeadline, nil)
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	if len(zoektMatches) == 0 {
-		return false, nil
+		return nil
 	}
 
 	zipFile, err := os.CreateTemp("", "*.zip")
 	if err != nil {
-		return false, err
+		return err
 	}
 	defer zipFile.Close()
 	defer os.Remove(zipFile.Name())
 
 	if err = writeZip(ctx, zipFile, zoektMatches); err != nil {
-		return false, err
+		return err
 	}
 
 	var extensionHint string
@@ -328,7 +328,7 @@ func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request, sender 
 		extensionHint = filepath.Ext(filename)
 	}
 
-	return false, structuralSearch(ctx, zipFile.Name(), All, extensionHint, p.Pattern, p.CombyRule, p.Languages, p.Repo, sender)
+	return structuralSearch(ctx, zipFile.Name(), All, extensionHint, p.Pattern, p.CombyRule, p.Languages, p.Repo, sender)
 }
 
 var requestTotalStructuralSearch = promauto.NewCounterVec(prometheus.CounterOpts{

--- a/cmd/searcher/search/search_test.go
+++ b/cmd/searcher/search/search_test.go
@@ -460,9 +460,6 @@ func doSearch(u string, p *protocol.Request) ([]protocol.FileMatch, error) {
 	if ed.Error != "" {
 		return nil, errors.New(ed.Error)
 	}
-	if ed.DeadlineHit {
-		err = context.DeadlineExceeded
-	}
 	return matches, err
 }
 

--- a/internal/search/searcher/client.go
+++ b/internal/search/searcher/client.go
@@ -81,13 +81,6 @@ func Search(
 		IndexerEndpoints: indexerEndpoints,
 	}
 
-	if deadline, ok := ctx.Deadline(); ok {
-		t, err := deadline.MarshalText()
-		if err != nil {
-			return false, err
-		}
-		r.Deadline = string(t)
-	}
 	body, err := json.Marshal(r)
 	if err != nil {
 		return false, err
@@ -182,9 +175,6 @@ func textSearchStream(ctx context.Context, url string, body []byte, cb func([]*p
 	}
 	if ed.Error != "" {
 		return false, errors.New(ed.Error)
-	}
-	if ed.DeadlineHit {
-		err = context.DeadlineExceeded
 	}
 	return ed.LimitHit, err
 }

--- a/internal/search/searcher/stream.go
+++ b/internal/search/searcher/stream.go
@@ -52,7 +52,6 @@ func (rr StreamDecoder) ReadAll(r io.Reader) error {
 }
 
 type EventDone struct {
-	LimitHit    bool   `json:"limit_hit"`
-	DeadlineHit bool   `json:"deadline_hit"`
-	Error       string `json:"error"`
+	LimitHit bool   `json:"limit_hit"`
+	Error    string `json:"error"`
 }


### PR DESCRIPTION
This removes the deadline parameter from search requests sent to
searcher because it is no longer necessary now that searcher streams its
results.

When making a request to searcher, we examine the context passed to the
requesting code and pull off a deadline from that context if it is set.
Then, we explicitly marshal and send that deadline as part of the search
request. This is a historical artifact of searcher being batch-only.
This made it possible for searcher to stop its search early if it knew
its context was going to be canceled soon, and send the results back to
the caller before the caller gave up on a response.

However, now that searcher streams results as it finds them, it's fine
to just stop sending results when the context is canceled.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
