### PR TITLE
Add sg doctor check for git version.

### DIFF
--- a/cmd/gitserver/server/sg_maintenance.sh
+++ b/cmd/gitserver/server/sg_maintenance.sh
@@ -50,6 +50,7 @@ git reflog expire --all
 # proportional to the number of new objects. Inspired by
 # https://github.blog/2021-04-29-scaling-monorepo-maintenance/
 # --write-midx reqiures git>=2.34.1.
+# [NOTE: git-version-min-requirement]
 git repack --write-midx --write-bitmap-index -d --geometric=2
 
 # Usually run by git gc. Prune all unreachable objects form the object database.

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -33,6 +33,7 @@ LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
 RUN apk add --no-cache --verbose \
+    # [NOTE: git-version-min-requirement]
     # We require git 2.34.1 because we use git-repack with flag --write-midx.
     'git>=2.34.1' \
     git-p4 \

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -726,6 +726,27 @@ checks:
     cmd: (command -v psql && psql -c 'SELECT 1;') || docker-compose -f dev/redis-postgres.yml exec -T postgresql psql -U ${PGUSER} -c 'select 1;'
     failMessage: 'Failed to connect to Postgres database. Make sure environment variables are setup correctly so that psql can connect.'
 
+  git-version:
+    cmd: |
+      git_version="$(git --version | cut -d' ' -f 3)"
+      git_major_version="$(echo $git_version | cut -d'.' -f 1)"
+      git_minor_version="$(echo $git_version | cut -d'.' -f 2)"
+      git_patch_version="$(echo $git_version | cut -d'.' -f 3)"
+      # See [NOTE: git-version-min-requirement]
+      ERR_MSG="Need git version 2.34.1 or higher but found $git_version."
+      if [[ "$git_major_version" -eq 2 ]]; then
+        if [[ "$git_minor_version" -eq 34 ]]; then
+          if [[ "$git_patch_version" -lt 1 ]]; then
+            echo $ERR_MSG && exit 1
+          fi
+        elif [[ "$git_minor_version" -lt 34 ]]; then
+          echo $ERR_MSG && exit 1
+        fi
+      elif [[ "$git_major_version" -lt 2 ]]; then
+        echo $ERR_MSG && exit 1
+      fi
+    failMessage: 'Incorrect git version'
+
 defaultCommandset: enterprise
 commandsets:
   oss:


### PR DESCRIPTION
It's easy to run into a mysterious gitserver failure when running `sg start` because of an outdated Git. Example: https://sourcegraph.slack.com/archives/C07KZF47K/p1642491532171300

On macOS, Xcode CommandLineTools include Git 2.30.1 whereas we need 2.34.1 or newer.
