### PR TITLE
extensions: Ensure extensions that no longer match the action events are deactivated

### DIFF
--- a/client/shared/src/api/extension/activation.ts
+++ b/client/shared/src/api/extension/activation.ts
@@ -33,10 +33,9 @@ export function observeActiveExtensions(
     ]).pipe(
         tap(([activeLanguages, enabledExtensions]) => {
             const activeExtensions = extensionsWithMatchedActivationEvent(enabledExtensions, activeLanguages)
+            activatedExtensionIDs.clear()
             for (const extension of activeExtensions) {
-                if (!activatedExtensionIDs.has(extension.id)) {
-                    activatedExtensionIDs.add(extension.id)
-                }
+                activatedExtensionIDs.add(extension.id)
             }
         }),
         map(([, extensions]) =>

--- a/client/shared/src/api/extension/activation.ts
+++ b/client/shared/src/api/extension/activation.ts
@@ -36,8 +36,12 @@ export function observeActiveExtensions(
         tap(([activeLanguages, enabledExtensions]) => {
             const activeExtensions = extensionsWithMatchedActivationEvent(enabledExtensions, activeLanguages)
 
-            // We disable previously activated events that no longer match the
-            // activation condition when the set of active languages changes.
+            // We deactivate extensions that no longer match the activation conditions when thre viewed language change.
+            //
+            // When no file is open (e.g. a user is navigating), activeLanguages might temporary be an empty set. We
+            // don't need to deactive the extensions in this case, since no new language-activated extensions will be
+            // added.
+            //
             // c.f. https://github.com/sourcegraph/sourcegraph/pull/29853
             if (!isEqual(previousActiveLanguages, activeLanguages) && activeLanguages.size !== 0) {
                 activatedExtensionIDs.clear()

--- a/client/shared/src/api/extension/activation.ts
+++ b/client/shared/src/api/extension/activation.ts
@@ -25,21 +25,13 @@ export function observeActiveExtensions(
 } {
     const activeLanguages = new BehaviorSubject<ReadonlySet<string>>(new Set())
     const enabledExtensions = wrapRemoteObservable(mainAPI.getEnabledExtensions())
-    const activatedExtensionIDs = new Set<string>()
 
     const activeExtensions: Observable<(ConfiguredExtension | ExecutableExtension)[]> = combineLatest([
         activeLanguages,
         enabledExtensions,
     ]).pipe(
-        tap(([activeLanguages, enabledExtensions]) => {
-            const activeExtensions = extensionsWithMatchedActivationEvent(enabledExtensions, activeLanguages)
-            activatedExtensionIDs.clear()
-            for (const extension of activeExtensions) {
-                activatedExtensionIDs.add(extension.id)
-            }
-        }),
-        map(([, extensions]) =>
-            extensions ? extensions.filter(extension => activatedExtensionIDs.has(extension.id)) : []
+        map(([activeLanguages, enabledExtensions]) =>
+            extensionsWithMatchedActivationEvent(enabledExtensions, activeLanguages)
         ),
         distinctUntilChanged((a, b) => areExtensionsSame(a, b))
     )


### PR DESCRIPTION
Fixes #28973

Right now, when different language-triggered extensions are activated, they stay active as long as the browser session is open. This means that a hover action exported in an extension that activates `onLanguage:x` will still be active even though we might no longer be on a document with language `x`. This is causes some actions to be omitted multiple times, c.f. #28973:

![Screenshot 2022-01-18 at 12 16 28](https://user-images.githubusercontent.com/458591/149927456-40a64ba7-40c9-40f4-95da-443bb3b95586.png)


There are several ideas I have to fix this. For example we could make sure that all exported actions also undergo the `onLanguage:` check if they are exported from an extension that activates on a specific language. A simpler solution is to disable extensions that no longer match, which is what I am doing in this PR.

## Regression Test

Switching from a Rust to a Go file now only shows one Find implementation button:

https://user-images.githubusercontent.com/458591/149927478-20ca5d10-6f8d-4297-b4b1-faf80da38a67.mov


## Open Questions

- Are there any memory/perf implications of this? I imagine a user that often switches between two languages might be running into issues. How do I verify this? 
- Are there any side effects of activating the same extension multiple times? A quick check by jumping from Go -> Rust -> Go indicates that everything works fine. 
- How do I properly test these changes? `action.test.ts` looks pretty confusing with all the mocking but even when I add telemetry (so I can spy on it) and try to call `activateExtensions` again with no active extensions, I won't observe a deactivation. If you think this approach makes sense I am happy to investigate further.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
