### PR TITLE
Revert "Enable Zoekt ranking by default (#29691)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ All notable changes to Sourcegraph are documented in this file.
 - The endpoint `/search/stream` will be retired in favor of `/.api/search/stream`. This requires no action unless you have developed custom code against `/search/stream`. We will support both endpoints for a short period of time before removing `/search/stream`. Please refer to the [documentation](https://docs.sourcegraph.com/api/stream_api) for more information.
 - When displaying the content of symbolic links in the repository tree view, we will show the relative path to the link's target instead of the target's content. This behavior is consistent with how we display symbolic links in search results. [#29687](https://github.com/sourcegraph/sourcegraph/pull/29687)
 - A new janitor job, "sg maintenance" was added to gitserver. The new job replaces "garbage collect" with the goal to optimize the performance of git operations for large repositories. You can choose to enable "garbage collect" again by setting the environment variables "SRC_ENABLE_GC_AUTO" to "true" and "SRC_ENABLE_SG_MAINTENANCE" to "false" for gitserver. Note that you must not enable both options at the same time. [#28224](https://github.com/sourcegraph/sourcegraph/pull/28224).
-- Search results within the same file are now ordered by relevance instead of line number. To order by line number, update the setting `experimentalFeatures.clientSearchResultRanking: "by-line-number"`. [#29046](https://github.com/sourcegraph/sourcegraph/pull/29046)
 
 ### Fixed
 

--- a/client/shared/src/components/FileMatch.tsx
+++ b/client/shared/src/components/FileMatch.tsx
@@ -65,20 +65,16 @@ interface Props extends SettingsCascadeProps, TelemetryProps {
 
 const sumHighlightRanges = (count: number, item: MatchItem): number => count + item.highlightRanges.length
 
-const BY_LINE_RANKING = 'by-line-number'
+const ByZoektRanking = 'by-zoekt-ranking'
 const DEFAULT_CONTEXT = 1
 
 export const FileMatch: React.FunctionComponent<Props> = props => {
     const result = props.result
     const repoAtRevisionURL = getRepositoryUrl(result.repository, result.branches)
     const revisionDisplayName = getRevision(result.branches, result.commit)
-    const settings = props.settingsCascade.final
-    const ranking = useMemo(() => {
-        if (!isErrorLike(settings) && settings?.experimentalFeatures?.clientSearchResultRanking === BY_LINE_RANKING) {
-            return new LineRanking()
-        }
-        return new ZoektRanking()
-    }, [settings])
+    const isZoektRanking: boolean =
+        !isErrorLike(props.settingsCascade.final) &&
+        props.settingsCascade?.final?.experimentalFeatures?.clientSearchResultRanking === ByZoektRanking
     const renderTitle = (): JSX.Element => (
         <>
             <RepoIcon repoName={result.repository} className="icon-inline text-muted" />
@@ -148,6 +144,8 @@ export const FileMatch: React.FunctionComponent<Props> = props => {
         ) : undefined
 
     let containerProps: ResultContainerProps
+
+    const ranking = useMemo(() => (isZoektRanking ? new ZoektRanking() : new LineRanking()), [isZoektRanking])
 
     const expandedMatchGroups = useMemo(() => ranking.expandedResults(items, context), [items, context, ranking])
     const collapsedMatchGroups = useMemo(() => ranking.collapsedResults(items, context), [items, context, ranking])


### PR DESCRIPTION
This reverts commit 5f7db99b68c430d9f879e12b48ad9b3dfe66e6b6.

This broke main on https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1642515627065300
