### PR TITLE
[SG-29637] - Show OS specific keys in keyboard shortcuts

### DIFF
--- a/client/web/src/keyboardShortcuts/KeyboardShortcutsHelp.tsx
+++ b/client/web/src/keyboardShortcuts/KeyboardShortcutsHelp.tsx
@@ -1,4 +1,4 @@
-import { Shortcut } from '@slimsag/react-shortcuts'
+import { Shortcut, ModifierKey, Key } from '@slimsag/react-shortcuts'
 import CloseIcon from 'mdi-react/CloseIcon'
 import React, { useCallback, useState } from 'react'
 
@@ -24,6 +24,11 @@ const LEGACY_KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
         keybindings: [{ ordered: ['y'] }],
     },
 ]
+
+const KEY_TO_NAMES: { [P in Key | ModifierKey]?: string } = {
+    Meta: 'Cmd',
+    Control: 'Ctrl',
+}
 
 const MODAL_LABEL_ID = 'keyboard-shortcuts-help-modal-title'
 
@@ -68,7 +73,7 @@ export const KeyboardShortcutsHelp: React.FunctionComponent<Props> = ({
                                                 {index !== 0 && ' or '}
                                                 {[...(keybinding.held || []), ...keybinding.ordered].map(
                                                     (key, index) => (
-                                                        <kbd key={index}>{key}</kbd>
+                                                        <kbd key={index}>{KEY_TO_NAMES[key] ?? key}</kbd>
                                                     )
                                                 )}
                                             </span>


### PR DESCRIPTION
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->

### Problem statement
1. Go to https://sourcegraph.com/search
2. Using Shift + ? to open keyboard shortcuts.
3. See that the Meta key is used in keyboard shortcuts.

<img width="515" alt="149175899-6ac6acd6-2a35-40a5-9757-430f4c5e1565" src="https://user-images.githubusercontent.com/54555805/149461805-ec40363a-17db-4f95-9706-238a7ce5f7b0.png">

### Refs
[Sourcegraph issue](https://github.com/sourcegraph/sourcegraph/issues/29637)
[Gitstart ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-29637)

### Success Criteria
Keyboard shortcuts on Windows should never use the Meta/Windows key as this is only for global OS shortcuts. We should use Cmd `(⌘)` on Mac and Ctrl on Windows and Linux and show that appropriately based on the OS.

### Screenshots
#### Windows / Linux
![Screenshot from 2022-01-20 10-48-39](https://user-images.githubusercontent.com/89894075/150316666-23d7c946-608e-4c6d-88d9-2907f57cfbfb.png)
#### Mac Os
<img width="514" alt="Screenshot 2022-01-20 at 11 00 15" src="https://user-images.githubusercontent.com/54555805/150317426-6d63757d-deda-4dd2-8ddc-4a65a06832bd.png">

