### PR TITLE
gitserver: Allow absolute git command

### DIFF
--- a/cmd/gitserver/server/customfetch_test.go
+++ b/cmd/gitserver/server/customfetch_test.go
@@ -36,6 +36,10 @@ func TestCustomGitFetch(t *testing.T) {
 			DomainPath: "github.com/foo/faulty",
 			Fetch:      "",
 		},
+		{
+			DomainPath: "github.com/foo/absolute",
+			Fetch:      "/foo/bar/git fetch things",
+		},
 	}
 
 	tests := []struct {
@@ -55,6 +59,10 @@ func TestCustomGitFetch(t *testing.T) {
 		},
 		{
 			url: "https://8cd1419f4d5c1e0527f2893c9422f1a2a435116dgit@github.com/bar/notthere",
+		},
+		{
+			url:          "https://8cd1419f4d5c1e0527f2893c9422f1a2a435116d@github.com/foo/absolute",
+			expectedArgs: []string{"/foo/bar/git", "fetch", "things"},
 		},
 	}
 

--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -178,6 +178,8 @@ func runWith(ctx context.Context, cmd *exec.Cmd, configRemoteOpts bool, progress
 }
 
 func configureRemoteGitCommand(cmd *exec.Cmd, tlsConf *tlsConfig) {
+	// We split here in case the first command is an absolute path to the executable
+	// which allows us to safely match lower down
 	_, executable := path.Split(cmd.Args[0])
 	// As a special case we also support the experimental p4-fusion client which is
 	// not run as a subcommand of git.

--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -177,10 +178,11 @@ func runWith(ctx context.Context, cmd *exec.Cmd, configRemoteOpts bool, progress
 }
 
 func configureRemoteGitCommand(cmd *exec.Cmd, tlsConf *tlsConfig) {
+	_, executable := path.Split(cmd.Args[0])
 	// As a special case we also support the experimental p4-fusion client which is
 	// not run as a subcommand of git.
-	if cmd.Args[0] != "git" && cmd.Args[0] != "p4-fusion" {
-		panic("Only git or p4-fusion commands are supported")
+	if executable != "git" && executable != "p4-fusion" {
+		panic(fmt.Sprintf("Only git or p4-fusion commands are supported, got %q", executable))
 	}
 
 	cmd.Env = append(cmd.Env, "GIT_ASKPASS=true") // disable password prompt

--- a/cmd/gitserver/server/serverutil_test.go
+++ b/cmd/gitserver/server/serverutil_test.go
@@ -60,6 +60,15 @@ func TestConfigureRemoteGitCommand(t *testing.T) {
 			expectedEnv:  append(expectedEnv, "GIT_SSL_CAINFO=/tmp/foo.certs"),
 			expectedArgs: []string{"git", "-c", "credential.helper=", "ls-remote"},
 		},
+		// Allow absolute git commands
+		{
+			input: exec.Command("/foo/bar/git", "ls-remote"),
+			tlsConfig: &tlsConfig{
+				SSLCAInfo: "/tmp/foo.certs",
+			},
+			expectedEnv:  append(expectedEnv, "GIT_SSL_CAINFO=/tmp/foo.certs"),
+			expectedArgs: []string{"/foo/bar/git", "-c", "credential.helper=", "ls-remote"},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Instead of only allowing the exact strings `git` or `p4-fusion` we
should also allow absolute paths to those executables.

Part of https://github.com/sourcegraph/customer/issues/637