### PR TITLE
Revert "Revert "search-blitz: add ability to change sampling duration""

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -927,27 +927,27 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: mean_successful_sentinel_duration_1h30m
+## frontend: mean_successful_sentinel_duration
 
-<p class="subtitle">mean successful sentinel search duration over 1h30m</p>
+<p class="subtitle">mean successful sentinel search duration</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 5s+ mean successful sentinel search duration over 1h30m for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 8s+ mean successful sentinel search duration over 1h30m for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 5s+ mean successful sentinel search duration for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 8s+ mean successful sentinel search duration for 30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-mean-successful-sentinel-duration-1h30m).
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-mean-successful-sentinel-duration).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_mean_successful_sentinel_duration_1h30m",
-  "critical_frontend_mean_successful_sentinel_duration_1h30m"
+  "warning_frontend_mean_successful_sentinel_duration",
+  "critical_frontend_mean_successful_sentinel_duration"
 ]
 ```
 
@@ -955,27 +955,27 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: mean_sentinel_stream_latency_1h30m
+## frontend: mean_sentinel_stream_latency
 
-<p class="subtitle">mean successful sentinel stream latency over 1h30m</p>
+<p class="subtitle">mean successful sentinel stream latency</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 2s+ mean successful sentinel stream latency over 1h30m for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 3s+ mean successful sentinel stream latency over 1h30m for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 2s+ mean successful sentinel stream latency for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 3s+ mean successful sentinel stream latency for 30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-mean-sentinel-stream-latency-1h30m).
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-mean-sentinel-stream-latency).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_mean_sentinel_stream_latency_1h30m",
-  "critical_frontend_mean_sentinel_stream_latency_1h30m"
+  "warning_frontend_mean_sentinel_stream_latency",
+  "critical_frontend_mean_sentinel_stream_latency"
 ]
 ```
 
@@ -983,27 +983,27 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: 90th_percentile_successful_sentinel_duration_1h30m
+## frontend: 90th_percentile_successful_sentinel_duration
 
-<p class="subtitle">90th percentile successful sentinel search duration over 1h30m</p>
+<p class="subtitle">90th percentile successful sentinel search duration</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 5s+ 90th percentile successful sentinel search duration over 1h30m for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 10s+ 90th percentile successful sentinel search duration over 1h30m for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 5s+ 90th percentile successful sentinel search duration for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 10s+ 90th percentile successful sentinel search duration for 30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-90th-percentile-successful-sentinel-duration-1h30m).
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-90th-percentile-successful-sentinel-duration).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_90th_percentile_successful_sentinel_duration_1h30m",
-  "critical_frontend_90th_percentile_successful_sentinel_duration_1h30m"
+  "warning_frontend_90th_percentile_successful_sentinel_duration",
+  "critical_frontend_90th_percentile_successful_sentinel_duration"
 ]
 ```
 
@@ -1011,27 +1011,27 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: 90th_percentile_sentinel_stream_latency_1h30m
+## frontend: 90th_percentile_sentinel_stream_latency
 
-<p class="subtitle">90th percentile successful sentinel stream latency over 1h30m</p>
+<p class="subtitle">90th percentile successful sentinel stream latency</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 4s+ 90th percentile successful sentinel stream latency over 1h30m for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 6s+ 90th percentile successful sentinel stream latency over 1h30m for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 4s+ 90th percentile successful sentinel stream latency for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 6s+ 90th percentile successful sentinel stream latency for 30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-90th-percentile-sentinel-stream-latency-1h30m).
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-90th-percentile-sentinel-stream-latency).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_90th_percentile_sentinel_stream_latency_1h30m",
-  "critical_frontend_90th_percentile_sentinel_stream_latency_1h30m"
+  "warning_frontend_90th_percentile_sentinel_stream_latency",
+  "critical_frontend_90th_percentile_sentinel_stream_latency"
 ]
 ```
 

--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -927,27 +927,27 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: mean_successful_sentinel_duration
+## frontend: mean_successful_sentinel_duration_over_1h30m
 
-<p class="subtitle">mean successful sentinel search duration</p>
+<p class="subtitle">mean successful sentinel search duration over 1h30m</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 5s+ mean successful sentinel search duration for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 8s+ mean successful sentinel search duration for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 5s+ mean successful sentinel search duration over 1h30m for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 8s+ mean successful sentinel search duration over 1h30m for 30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-mean-successful-sentinel-duration).
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-mean-successful-sentinel-duration-over-1h30m).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_mean_successful_sentinel_duration",
-  "critical_frontend_mean_successful_sentinel_duration"
+  "warning_frontend_mean_successful_sentinel_duration_over_1h30m",
+  "critical_frontend_mean_successful_sentinel_duration_over_1h30m"
 ]
 ```
 
@@ -955,27 +955,27 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: mean_sentinel_stream_latency
+## frontend: mean_sentinel_stream_latency_over_1h30m
 
-<p class="subtitle">mean successful sentinel stream latency</p>
+<p class="subtitle">mean successful sentinel stream latency over 1h30m</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 2s+ mean successful sentinel stream latency for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 3s+ mean successful sentinel stream latency for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 2s+ mean successful sentinel stream latency over 1h30m for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 3s+ mean successful sentinel stream latency over 1h30m for 30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-mean-sentinel-stream-latency).
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-mean-sentinel-stream-latency-over-1h30m).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_mean_sentinel_stream_latency",
-  "critical_frontend_mean_sentinel_stream_latency"
+  "warning_frontend_mean_sentinel_stream_latency_over_1h30m",
+  "critical_frontend_mean_sentinel_stream_latency_over_1h30m"
 ]
 ```
 
@@ -983,27 +983,27 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: 90th_percentile_successful_sentinel_duration
+## frontend: 90th_percentile_successful_sentinel_duration_over_1h30m
 
-<p class="subtitle">90th percentile successful sentinel search duration</p>
+<p class="subtitle">90th percentile successful sentinel search duration over 1h30m</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 5s+ 90th percentile successful sentinel search duration for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 10s+ 90th percentile successful sentinel search duration for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 5s+ 90th percentile successful sentinel search duration over 1h30m for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 10s+ 90th percentile successful sentinel search duration over 1h30m for 30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-90th-percentile-successful-sentinel-duration).
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-90th-percentile-successful-sentinel-duration-over-1h30m).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_90th_percentile_successful_sentinel_duration",
-  "critical_frontend_90th_percentile_successful_sentinel_duration"
+  "warning_frontend_90th_percentile_successful_sentinel_duration_over_1h30m",
+  "critical_frontend_90th_percentile_successful_sentinel_duration_over_1h30m"
 ]
 ```
 
@@ -1011,27 +1011,27 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: 90th_percentile_sentinel_stream_latency
+## frontend: 90th_percentile_sentinel_stream_latency_over_1h30m
 
-<p class="subtitle">90th percentile successful sentinel stream latency</p>
+<p class="subtitle">90th percentile successful sentinel stream latency over 1h30m</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 4s+ 90th percentile successful sentinel stream latency for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 6s+ 90th percentile successful sentinel stream latency for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 4s+ 90th percentile successful sentinel stream latency over 1h30m for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 6s+ 90th percentile successful sentinel stream latency over 1h30m for 30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-90th-percentile-sentinel-stream-latency).
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-90th-percentile-sentinel-stream-latency-over-1h30m).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_90th_percentile_sentinel_stream_latency",
-  "critical_frontend_90th_percentile_sentinel_stream_latency"
+  "warning_frontend_90th_percentile_sentinel_stream_latency_over_1h30m",
+  "critical_frontend_90th_percentile_sentinel_stream_latency_over_1h30m"
 ]
 ```
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -2843,13 +2843,13 @@ Query: `sum by(app) (up{app=~".*(frontend|sourcegraph-frontend)"}) / count by (a
 
 ### Frontend: Sentinel queries (only on sourcegraph.com)
 
-#### frontend: mean_successful_sentinel_duration_1h30m
+#### frontend: mean_successful_sentinel_duration
 
-<p class="subtitle">Mean successful sentinel search duration over 1h30m</p>
+<p class="subtitle">Mean successful sentinel search duration</p>
 
 Mean search duration for all successful sentinel queries
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-successful-sentinel-duration-1h30m) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-successful-sentinel-duration) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102400` on your Sourcegraph instance.
 
@@ -2858,19 +2858,19 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102400`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[1h30m])) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[1h30m]))`
+Query: `sum(rate(src_search_response_latency_seconds_sum{source=~`searchblitz.*`, status=`success`}[$sentinel_sampling_duration])) / sum(rate(src_search_response_latency_seconds_count{source=~`searchblitz.*`, status=`success`}[$sentinel_sampling_duration]))`
 
 </details>
 
 <br />
 
-#### frontend: mean_sentinel_stream_latency_1h30m
+#### frontend: mean_sentinel_stream_latency
 
-<p class="subtitle">Mean successful sentinel stream latency over 1h30m</p>
+<p class="subtitle">Mean successful sentinel stream latency</p>
 
 Mean time to first result for all successful streaming sentinel queries
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-sentinel-stream-latency-1h30m) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-sentinel-stream-latency) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102401` on your Sourcegraph instance.
 
@@ -2879,19 +2879,19 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102401`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[1h30m])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[1h30m]))`
+Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[$sentinel_sampling_duration])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[$sentinel_sampling_duration]))`
 
 </details>
 
 <br />
 
-#### frontend: 90th_percentile_successful_sentinel_duration_1h30m
+#### frontend: 90th_percentile_successful_sentinel_duration
 
-<p class="subtitle">90th percentile successful sentinel search duration over 1h30m</p>
+<p class="subtitle">90th percentile successful sentinel search duration</p>
 
 90th percentile search duration for all successful sentinel queries
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-successful-sentinel-duration-1h30m) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-successful-sentinel-duration) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102410` on your Sourcegraph instance.
 
@@ -2900,19 +2900,19 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102410`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m]), "source", "$1", "source", "searchblitz_(.*)")))`
+Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration]), "source", "$1", "source", "searchblitz_(.*)")))`
 
 </details>
 
 <br />
 
-#### frontend: 90th_percentile_sentinel_stream_latency_1h30m
+#### frontend: 90th_percentile_sentinel_stream_latency
 
-<p class="subtitle">90th percentile successful sentinel stream latency over 1h30m</p>
+<p class="subtitle">90th percentile successful sentinel stream latency</p>
 
 90th percentile time to first result for all successful streaming sentinel queries
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-sentinel-stream-latency-1h30m) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-sentinel-stream-latency) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102411` on your Sourcegraph instance.
 
@@ -2921,15 +2921,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102411`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m]), "source", "$1", "source", "searchblitz_(.*)")))`
+Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[$sentinel_sampling_duration]), "source", "$1", "source", "searchblitz_(.*)")))`
 
 </details>
 
 <br />
 
-#### frontend: mean_successful_sentinel_duration_by_query_1h30m
+#### frontend: mean_successful_sentinel_duration_by_query
 
-<p class="subtitle">Mean successful sentinel search duration by query over 1h30m</p>
+<p class="subtitle">Mean successful sentinel search duration by query</p>
 
 Mean search duration for successful sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -2942,15 +2942,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102420`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[1h30m])) by (source) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[1h30m])) by (source)`
+Query: `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (source) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (source)`
 
 </details>
 
 <br />
 
-#### frontend: mean_sentinel_stream_latency_by_query_1h30m
+#### frontend: mean_sentinel_stream_latency_by_query
 
-<p class="subtitle">Mean successful sentinel stream latency by query over 1h30m</p>
+<p class="subtitle">Mean successful sentinel stream latency by query</p>
 
 Mean time to first result for successful streaming sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -2963,15 +2963,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102421`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[1h30m])) by (source) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[1h30m])) by (source)`
+Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (source) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (source)`
 
 </details>
 
 <br />
 
-#### frontend: 90th_percentile_successful_sentinel_duration_by_query_1h30m
+#### frontend: 90th_percentile_successful_sentinel_duration_by_query
 
-<p class="subtitle">90th percentile successful sentinel search duration by query over 1h30m</p>
+<p class="subtitle">90th percentile successful sentinel search duration by query</p>
 
 90th percentile search duration for successful sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -2984,15 +2984,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102430`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m])) by (le, source))`
+Query: `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (le, source))`
 
 </details>
 
 <br />
 
-#### frontend: 90th_percentile_successful_stream_latency_by_query_1h30m
+#### frontend: 90th_percentile_successful_stream_latency_by_query
 
-<p class="subtitle">90th percentile successful sentinel stream latency by query over 1h30m</p>
+<p class="subtitle">90th percentile successful sentinel stream latency by query</p>
 
 90th percentile time to first result for successful streaming sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -3005,15 +3005,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102431`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m])) by (le, source))`
+Query: `histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (le, source))`
 
 </details>
 
 <br />
 
-#### frontend: 90th_percentile_unsuccessful_duration_by_query_1h30m
+#### frontend: 90th_percentile_unsuccessful_duration_by_query
 
-<p class="subtitle">90th percentile unsuccessful sentinel search duration by query over 1h30m</p>
+<p class="subtitle">90th percentile unsuccessful sentinel search duration by query</p>
 
 90th percentile search duration of _unsuccessful_ sentinel queries (by error or timeout), broken down by query. Useful for debugging how the performance of failed requests affect UX.
 
@@ -3026,15 +3026,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102440`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[1h30m])) by (le, source))`
+Query: `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[$sentinel_sampling_duration])) by (le, source))`
 
 </details>
 
 <br />
 
-#### frontend: 75th_percentile_successful_sentinel_duration_by_query_1h30m
+#### frontend: 75th_percentile_successful_sentinel_duration_by_query
 
-<p class="subtitle">75th percentile successful sentinel search duration by query over 1h30m</p>
+<p class="subtitle">75th percentile successful sentinel search duration by query</p>
 
 75th percentile search duration of successful sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -3047,15 +3047,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102450`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m])) by (le, source))`
+Query: `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (le, source))`
 
 </details>
 
 <br />
 
-#### frontend: 75th_percentile_successful_stream_latency_by_query_1h30m
+#### frontend: 75th_percentile_successful_stream_latency_by_query
 
-<p class="subtitle">75th percentile successful sentinel stream latency by query over 1h30m</p>
+<p class="subtitle">75th percentile successful sentinel stream latency by query</p>
 
 75th percentile time to first result for successful streaming sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
@@ -3068,15 +3068,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102451`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m])) by (le, source))`
+Query: `histogram_quantile(0.75, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (le, source))`
 
 </details>
 
 <br />
 
-#### frontend: 75th_percentile_unsuccessful_duration_by_query_1h30m
+#### frontend: 75th_percentile_unsuccessful_duration_by_query
 
-<p class="subtitle">75th percentile unsuccessful sentinel search duration by query over 1h30m</p>
+<p class="subtitle">75th percentile unsuccessful sentinel search duration by query</p>
 
 75th percentile search duration of _unsuccessful_ sentinel queries (by error or timeout), broken down by query. Useful for debugging how the performance of failed requests affect UX.
 
@@ -3089,15 +3089,15 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102460`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[1h30m])) by (le, source))`
+Query: `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[$sentinel_sampling_duration])) by (le, source))`
 
 </details>
 
 <br />
 
-#### frontend: unsuccessful_status_rate_1h30m
+#### frontend: unsuccessful_status_rate
 
-<p class="subtitle">Unsuccessful status rate per 1h30m</p>
+<p class="subtitle">Unsuccessful status rate</p>
 
 The rate of unsuccessful sentinel queries, broken down by failure type.
 
@@ -3110,7 +3110,7 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102470`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_graphql_search_response{source=~"searchblitz.*", status!="success"}[1h30m])) by (status)`
+Query: `sum(rate(src_graphql_search_response{source=~"searchblitz.*", status!="success"}[$sentinel_sampling_duration])) by (status)`
 
 </details>
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -2843,13 +2843,13 @@ Query: `sum by(app) (up{app=~".*(frontend|sourcegraph-frontend)"}) / count by (a
 
 ### Frontend: Sentinel queries (only on sourcegraph.com)
 
-#### frontend: mean_successful_sentinel_duration
+#### frontend: mean_successful_sentinel_duration_over_1h30m
 
-<p class="subtitle">Mean successful sentinel search duration</p>
+<p class="subtitle">Mean successful sentinel search duration over 1h30m</p>
 
 Mean search duration for all successful sentinel queries
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-successful-sentinel-duration) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-successful-sentinel-duration-over-1h30m) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102400` on your Sourcegraph instance.
 
@@ -2858,19 +2858,19 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102400`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_search_response_latency_seconds_sum{source=~`searchblitz.*`, status=`success`}[$sentinel_sampling_duration])) / sum(rate(src_search_response_latency_seconds_count{source=~`searchblitz.*`, status=`success`}[$sentinel_sampling_duration]))`
+Query: `sum(rate(src_search_response_latency_seconds_sum{source=~`searchblitz.*`, status=`success`}[1h30m])) / sum(rate(src_search_response_latency_seconds_count{source=~`searchblitz.*`, status=`success`}[1h30m]))`
 
 </details>
 
 <br />
 
-#### frontend: mean_sentinel_stream_latency
+#### frontend: mean_sentinel_stream_latency_over_1h30m
 
-<p class="subtitle">Mean successful sentinel stream latency</p>
+<p class="subtitle">Mean successful sentinel stream latency over 1h30m</p>
 
 Mean time to first result for all successful streaming sentinel queries
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-sentinel-stream-latency) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-sentinel-stream-latency-over-1h30m) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102401` on your Sourcegraph instance.
 
@@ -2879,19 +2879,19 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102401`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[$sentinel_sampling_duration])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[$sentinel_sampling_duration]))`
+Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[1h30m])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[1h30m]))`
 
 </details>
 
 <br />
 
-#### frontend: 90th_percentile_successful_sentinel_duration
+#### frontend: 90th_percentile_successful_sentinel_duration_over_1h30m
 
-<p class="subtitle">90th percentile successful sentinel search duration</p>
+<p class="subtitle">90th percentile successful sentinel search duration over 1h30m</p>
 
 90th percentile search duration for all successful sentinel queries
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-successful-sentinel-duration) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-successful-sentinel-duration-over-1h30m) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102410` on your Sourcegraph instance.
 
@@ -2900,19 +2900,19 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102410`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration]), "source", "$1", "source", "searchblitz_(.*)")))`
+Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m]), "source", "$1", "source", "searchblitz_(.*)")))`
 
 </details>
 
 <br />
 
-#### frontend: 90th_percentile_sentinel_stream_latency
+#### frontend: 90th_percentile_sentinel_stream_latency_over_1h30m
 
-<p class="subtitle">90th percentile successful sentinel stream latency</p>
+<p class="subtitle">90th percentile successful sentinel stream latency over 1h30m</p>
 
 90th percentile time to first result for all successful streaming sentinel queries
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-sentinel-stream-latency) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-sentinel-stream-latency-over-1h30m) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102411` on your Sourcegraph instance.
 
@@ -2921,7 +2921,7 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102411`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[$sentinel_sampling_duration]), "source", "$1", "source", "searchblitz_(.*)")))`
+Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m]), "source", "$1", "source", "searchblitz_(.*)")))`
 
 </details>
 

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -1,20 +1,55 @@
 package definitions
 
 import (
+	"strings"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/monitoring/definitions/shared"
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
+
+	"github.com/grafana-tools/sdk"
 )
 
 func Frontend() *monitoring.Container {
 	// frontend is sometimes called sourcegraph-frontend in various contexts
 	const containerName = "(frontend|sourcegraph-frontend)"
 
+	var sentinelSamplingIntervals []string
+	for _, d := range []time.Duration{
+		1 * time.Minute,
+		5 * time.Minute,
+		10 * time.Minute,
+		30 * time.Minute,
+		1 * time.Hour,
+		90 * time.Minute,
+		3 * time.Hour,
+	} {
+		sentinelSamplingIntervals = append(sentinelSamplingIntervals, d.Round(time.Second).String())
+	}
+
+	defaultSamplingInterval := (90 * time.Minute).Round(time.Second)
+
 	return &monitoring.Container{
 		Name:        "frontend",
 		Title:       "Frontend",
 		Description: "Serves all end-user browser and API requests.",
+		RawVariables: []sdk.TemplateVar{
+			{
+				Type:  "interval",
+				Name:  "sentinel_sampling_duration",
+				Label: "Sentinel query sampling duration",
+				Query: strings.Join(sentinelSamplingIntervals, ","),
+				Current: sdk.Current{
+					Text: &sdk.StringSliceString{
+						Value: []string{defaultSamplingInterval.String()}, Valid: true},
+					Value: defaultSamplingInterval.String(),
+				},
+				Refresh: sdk.BoolInt{
+					Flag:  true,
+					Value: monitoring.Int64Ptr(2),
+				},
+			},
+		},
 		Groups: []monitoring.Group{
 			{
 				Title: "Search at a glance",
@@ -616,11 +651,11 @@ func Frontend() *monitoring.Container {
 				Rows: []monitoring.Row{
 					{
 						{
-							Name:        "mean_successful_sentinel_duration_1h30m",
-							Description: "mean successful sentinel search duration over 1h30m",
+							Name:        "mean_successful_sentinel_duration",
+							Description: "mean successful sentinel search duration",
 							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
 							// since these panels relate to metrics that don't exist on a customer instance.
-							Query:          `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[1h30m])) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[1h30m]))`,
+							Query:          "sum(rate(src_search_response_latency_seconds_sum{source=~`searchblitz.*`, status=`success`}[$sentinel_sampling_duration])) / sum(rate(src_search_response_latency_seconds_count{source=~`searchblitz.*`, status=`success`}[$sentinel_sampling_duration]))",
 							Warning:        monitoring.Alert().GreaterOrEqual(5, nil).For(15 * time.Minute),
 							Critical:       monitoring.Alert().GreaterOrEqual(8, nil).For(30 * time.Minute),
 							Panel:          monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(monitoring.PanelOptions.NoLegend()),
@@ -633,11 +668,11 @@ func Frontend() *monitoring.Container {
 							`,
 						},
 						{
-							Name:        "mean_sentinel_stream_latency_1h30m",
-							Description: "mean successful sentinel stream latency over 1h30m",
+							Name:        "mean_sentinel_stream_latency",
+							Description: "mean successful sentinel stream latency",
 							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
 							// since these panels relate to metrics that don't exist on a customer instance.
-							Query:    `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[1h30m])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[1h30m]))`,
+							Query:    `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[$sentinel_sampling_duration])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[$sentinel_sampling_duration]))`,
 							Warning:  monitoring.Alert().GreaterOrEqual(2, nil).For(15 * time.Minute),
 							Critical: monitoring.Alert().GreaterOrEqual(3, nil).For(30 * time.Minute),
 							Panel: monitoring.Panel().LegendFormat("latency").Unit(monitoring.Seconds).With(
@@ -655,11 +690,11 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:        "90th_percentile_successful_sentinel_duration_1h30m",
-							Description: "90th percentile successful sentinel search duration over 1h30m",
+							Name:        "90th_percentile_successful_sentinel_duration",
+							Description: "90th percentile successful sentinel search duration",
 							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
 							// since these panels relate to metrics that don't exist on a customer instance.
-							Query:          `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m]), "source", "$1", "source", "searchblitz_(.*)")))`,
+							Query:          `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration]), "source", "$1", "source", "searchblitz_(.*)")))`,
 							Warning:        monitoring.Alert().GreaterOrEqual(5, nil).For(15 * time.Minute),
 							Critical:       monitoring.Alert().GreaterOrEqual(10, nil).For(30 * time.Minute),
 							Panel:          monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(monitoring.PanelOptions.NoLegend()),
@@ -672,11 +707,11 @@ func Frontend() *monitoring.Container {
 							`,
 						},
 						{
-							Name:        "90th_percentile_sentinel_stream_latency_1h30m",
-							Description: "90th percentile successful sentinel stream latency over 1h30m",
+							Name:        "90th_percentile_sentinel_stream_latency",
+							Description: "90th percentile successful sentinel stream latency",
 							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
 							// since these panels relate to metrics that don't exist on a customer instance.
-							Query:    `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m]), "source", "$1", "source", "searchblitz_(.*)")))`,
+							Query:    `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[$sentinel_sampling_duration]), "source", "$1", "source", "searchblitz_(.*)")))`,
 							Warning:  monitoring.Alert().GreaterOrEqual(4, nil).For(15 * time.Minute),
 							Critical: monitoring.Alert().GreaterOrEqual(6, nil).For(30 * time.Minute),
 							Panel: monitoring.Panel().LegendFormat("latency").Unit(monitoring.Seconds).With(
@@ -694,9 +729,9 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:        "mean_successful_sentinel_duration_by_query_1h30m",
-							Description: "mean successful sentinel search duration by query over 1h30m",
-							Query:       `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[1h30m])) by (source) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[1h30m])) by (source)`,
+							Name:        "mean_successful_sentinel_duration_by_query",
+							Description: "mean successful sentinel search duration by query",
+							Query:       `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (source) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (source)`,
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.LegendOnRight(),
@@ -708,9 +743,9 @@ func Frontend() *monitoring.Container {
 							Interpretation: `Mean search duration for successful sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.`,
 						},
 						{
-							Name:        "mean_sentinel_stream_latency_by_query_1h30m",
-							Description: "mean successful sentinel stream latency by query over 1h30m",
-							Query:       `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[1h30m])) by (source) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[1h30m])) by (source)`,
+							Name:        "mean_sentinel_stream_latency_by_query",
+							Description: "mean successful sentinel stream latency by query",
+							Query:       `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (source) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (source)`,
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.LegendOnRight(),
@@ -724,9 +759,9 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:        "90th_percentile_successful_sentinel_duration_by_query_1h30m",
-							Description: "90th percentile successful sentinel search duration by query over 1h30m",
-							Query:       `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m])) by (le, source))`,
+							Name:        "90th_percentile_successful_sentinel_duration_by_query",
+							Description: "90th percentile successful sentinel search duration by query",
+							Query:       `histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (le, source))`,
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.LegendOnRight(),
@@ -738,9 +773,9 @@ func Frontend() *monitoring.Container {
 							Interpretation: `90th percentile search duration for successful sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.`,
 						},
 						{
-							Name:        "90th_percentile_successful_stream_latency_by_query_1h30m",
-							Description: "90th percentile successful sentinel stream latency by query over 1h30m",
-							Query:       `histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m])) by (le, source))`,
+							Name:        "90th_percentile_successful_stream_latency_by_query",
+							Description: "90th percentile successful sentinel stream latency by query",
+							Query:       `histogram_quantile(0.90, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (le, source))`,
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.LegendOnRight(),
@@ -754,9 +789,9 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:        "90th_percentile_unsuccessful_duration_by_query_1h30m",
-							Description: "90th percentile unsuccessful sentinel search duration by query over 1h30m",
-							Query:       "histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[1h30m])) by (le, source))",
+							Name:        "90th_percentile_unsuccessful_duration_by_query",
+							Description: "90th percentile unsuccessful sentinel search duration by query",
+							Query:       "histogram_quantile(0.90, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[$sentinel_sampling_duration])) by (le, source))",
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{source}}").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.LegendOnRight(),
@@ -770,9 +805,9 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:        "75th_percentile_successful_sentinel_duration_by_query_1h30m",
-							Description: "75th percentile successful sentinel search duration by query over 1h30m",
-							Query:       `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m])) by (le, source))`,
+							Name:        "75th_percentile_successful_sentinel_duration_by_query",
+							Description: "75th percentile successful sentinel search duration by query",
+							Query:       `histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration])) by (le, source))`,
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.LegendOnRight(),
@@ -784,9 +819,9 @@ func Frontend() *monitoring.Container {
 							Interpretation: `75th percentile search duration of successful sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.`,
 						},
 						{
-							Name:        "75th_percentile_successful_stream_latency_by_query_1h30m",
-							Description: "75th percentile successful sentinel stream latency by query over 1h30m",
-							Query:       `histogram_quantile(0.75, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m])) by (le, source))`,
+							Name:        "75th_percentile_successful_stream_latency_by_query",
+							Description: "75th percentile successful sentinel stream latency by query",
+							Query:       `histogram_quantile(0.75, sum(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[$sentinel_sampling_duration])) by (le, source))`,
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.LegendOnRight(),
@@ -800,9 +835,9 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:        "75th_percentile_unsuccessful_duration_by_query_1h30m",
-							Description: "75th percentile unsuccessful sentinel search duration by query over 1h30m",
-							Query:       "histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[1h30m])) by (le, source))",
+							Name:        "75th_percentile_unsuccessful_duration_by_query",
+							Description: "75th percentile unsuccessful sentinel search duration by query",
+							Query:       "histogram_quantile(0.75, sum(rate(src_search_response_latency_seconds_bucket{source=~`searchblitz.*`, status!=`success`}[$sentinel_sampling_duration])) by (le, source))",
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{source}}").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.LegendOnRight(),
@@ -816,9 +851,9 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:           "unsuccessful_status_rate_1h30m",
-							Description:    "unsuccessful status rate per 1h30m",
-							Query:          `sum(rate(src_graphql_search_response{source=~"searchblitz.*", status!="success"}[1h30m])) by (status)`,
+							Name:           "unsuccessful_status_rate",
+							Description:    "unsuccessful status rate",
+							Query:          `sum(rate(src_graphql_search_response{source=~"searchblitz.*", status!="success"}[$sentinel_sampling_duration])) by (status)`,
 							NoAlert:        true,
 							Panel:          monitoring.Panel().LegendFormat("{{status}}"),
 							Owner:          monitoring.ObservableOwnerSearch,

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -651,11 +651,11 @@ func Frontend() *monitoring.Container {
 				Rows: []monitoring.Row{
 					{
 						{
-							Name:        "mean_successful_sentinel_duration",
-							Description: "mean successful sentinel search duration",
+							Name:        "mean_successful_sentinel_duration_over_1h30m",
+							Description: "mean successful sentinel search duration over 1h30m",
 							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
 							// since these panels relate to metrics that don't exist on a customer instance.
-							Query:          "sum(rate(src_search_response_latency_seconds_sum{source=~`searchblitz.*`, status=`success`}[$sentinel_sampling_duration])) / sum(rate(src_search_response_latency_seconds_count{source=~`searchblitz.*`, status=`success`}[$sentinel_sampling_duration]))",
+							Query:          "sum(rate(src_search_response_latency_seconds_sum{source=~`searchblitz.*`, status=`success`}[1h30m])) / sum(rate(src_search_response_latency_seconds_count{source=~`searchblitz.*`, status=`success`}[1h30m]))",
 							Warning:        monitoring.Alert().GreaterOrEqual(5, nil).For(15 * time.Minute),
 							Critical:       monitoring.Alert().GreaterOrEqual(8, nil).For(30 * time.Minute),
 							Panel:          monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(monitoring.PanelOptions.NoLegend()),
@@ -668,11 +668,11 @@ func Frontend() *monitoring.Container {
 							`,
 						},
 						{
-							Name:        "mean_sentinel_stream_latency",
-							Description: "mean successful sentinel stream latency",
+							Name:        "mean_sentinel_stream_latency_over_1h30m",
+							Description: "mean successful sentinel stream latency over 1h30m",
 							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
 							// since these panels relate to metrics that don't exist on a customer instance.
-							Query:    `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[$sentinel_sampling_duration])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[$sentinel_sampling_duration]))`,
+							Query:    `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[1h30m])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[1h30m]))`,
 							Warning:  monitoring.Alert().GreaterOrEqual(2, nil).For(15 * time.Minute),
 							Critical: monitoring.Alert().GreaterOrEqual(3, nil).For(30 * time.Minute),
 							Panel: monitoring.Panel().LegendFormat("latency").Unit(monitoring.Seconds).With(
@@ -690,11 +690,11 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:        "90th_percentile_successful_sentinel_duration",
-							Description: "90th percentile successful sentinel search duration",
+							Name:        "90th_percentile_successful_sentinel_duration_over_1h30m",
+							Description: "90th percentile successful sentinel search duration over 1h30m",
 							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
 							// since these panels relate to metrics that don't exist on a customer instance.
-							Query:          `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[$sentinel_sampling_duration]), "source", "$1", "source", "searchblitz_(.*)")))`,
+							Query:          `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m]), "source", "$1", "source", "searchblitz_(.*)")))`,
 							Warning:        monitoring.Alert().GreaterOrEqual(5, nil).For(15 * time.Minute),
 							Critical:       monitoring.Alert().GreaterOrEqual(10, nil).For(30 * time.Minute),
 							Panel:          monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(monitoring.PanelOptions.NoLegend()),
@@ -707,11 +707,11 @@ func Frontend() *monitoring.Container {
 							`,
 						},
 						{
-							Name:        "90th_percentile_sentinel_stream_latency",
-							Description: "90th percentile successful sentinel stream latency",
+							Name:        "90th_percentile_sentinel_stream_latency_over_1h30m",
+							Description: "90th percentile successful sentinel stream latency over 1h30m",
 							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
 							// since these panels relate to metrics that don't exist on a customer instance.
-							Query:    `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[$sentinel_sampling_duration]), "source", "$1", "source", "searchblitz_(.*)")))`,
+							Query:    `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m]), "source", "$1", "source", "searchblitz_(.*)")))`,
 							Warning:  monitoring.Alert().GreaterOrEqual(4, nil).For(15 * time.Minute),
 							Critical: monitoring.Alert().GreaterOrEqual(6, nil).For(30 * time.Minute),
 							Panel: monitoring.Panel().LegendFormat("latency").Unit(monitoring.Seconds).With(

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -31,6 +31,11 @@ type Container struct {
 	// container, such as instances or shards.
 	Variables []ContainerVariable
 
+	// RawVariables exposes the underlying Grafana API to define
+	// variables that can be applied to the dashboard for this container,
+	// such as instances or shards.
+	RawVariables []sdk.TemplateVar
+
 	// Groups of observable information about the container.
 	Groups []Group
 
@@ -87,6 +92,7 @@ func (c *Container) renderDashboard() *sdk.Board {
 	for _, variable := range c.Variables {
 		board.Templating.List = append(board.Templating.List, variable.toGrafanaTemplateVar())
 	}
+	board.Templating.List = append(board.Templating.List, c.RawVariables...)
 	board.Annotations.List = []sdk.Annotation{{
 		Name:       "Alert events",
 		Datasource: StringPtr("Prometheus"),


### PR DESCRIPTION
This PR re-adds the search-blitz dashboards changes that were reverted in https://github.com/sourcegraph/sourcegraph/pull/29813 with one new bit. 

---

Prometheus' Alertmanager doesn't like sampling durations that come from the interpolated strings (`$...`) that Grafana will fill in:

```
ts=2022-01-18T16:22:30.432Z caller=manager.go:968 level=error component="rule manager" msg="loading groups failed" err="/sg_config_prometheus/frontend_alert_rules.yml: 1203:11: group \"frontend\", rule 99, \"critical_frontend_90th_percentile_successful_sentinel_duration\": could not parse expression: 1:148: parse error: missing unit character in duration"
```

This error was (silently) causing the `sourcegraph/server` docker image failures that we were seeing in CI.

I worked around this by simply hard-coding the duration (`1h30m`) for the 4 dashboards that we have that generate alerts. As a result, the dashboard now looks like this:
![screencapture-localhost-3370-debug-grafana-d-frontend-frontend-2022-01-18-09_13_40](https://user-images.githubusercontent.com/9022011/149985903-fdf1594b-720e-4a41-a77f-4d3ecc6cc5dc.png)

---
passing main-dry-run buildkite build (to prove that the CI failures are fixed): https://buildkite.com/sourcegraph/sourcegraph/builds/126002