### PR TITLE
search: Fix type:path match counting

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -967,7 +967,6 @@ func testSearchClient(t *testing.T, client searchClient) {
 	})
 
 	t.Run("And/Or search expression queries", func(t *testing.T) {
-		t.Skip("Flakey test https://github.com/sourcegraph/sourcegraph/issues/29828")
 
 		tests := []struct {
 			name            string

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -143,14 +143,19 @@ func (fm *FileMatch) Limit(limit int) int {
 
 func (fm *FileMatch) Key() Key {
 	k := Key{
-		TypeRank: rankFileMatch,
-		Repo:     fm.Repo.Name,
-		Commit:   fm.CommitID,
-		Path:     fm.Path,
+		Repo:   fm.Repo.Name,
+		Commit: fm.CommitID,
+		Path:   fm.Path,
 	}
 
 	if fm.InputRev != nil {
 		k.Rev = *fm.InputRev
+	}
+
+	if len(fm.Symbols) > 0 || len(fm.LineMatches) > 0 {
+		k.TypeRank = rankFileMatch
+	} else {
+		k.TypeRank = rankFilePathMatch
 	}
 
 	return k

--- a/internal/search/result/match.go
+++ b/internal/search/result/match.go
@@ -32,10 +32,11 @@ var (
 // Match types with lower ranks will be sorted before match types
 // with higher ranks.
 const (
-	rankFileMatch   = 0
-	rankCommitMatch = 1
-	rankDiffMatch   = 2
-	rankRepoMatch   = 3
+	rankFileMatch     = 0
+	rankCommitMatch   = 1
+	rankDiffMatch     = 2
+	rankRepoMatch     = 3
+	rankFilePathMatch = 4
 )
 
 // Key is a sorting or deduplicating key for a Match.

--- a/internal/search/unindexed/unindexed_test.go
+++ b/internal/search/unindexed/unindexed_test.go
@@ -319,10 +319,10 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 	sort.Slice(matchKeys, func(i, j int) bool { return matchKeys[i].Less(matchKeys[j]) })
 
 	wantResultKeys := []result.Key{
-		{Repo: "foo", Commit: "branch3", Path: "main.go"},
-		{Repo: "foo", Commit: "branch4", Path: "main.go"},
-		{Repo: "foo", Commit: "master", Path: "main.go"},
-		{Repo: "foo", Commit: "mybranch", Path: "main.go"},
+		{Repo: "foo", Commit: "branch3", Path: "main.go", TypeRank: 4},
+		{Repo: "foo", Commit: "branch4", Path: "main.go", TypeRank: 4},
+		{Repo: "foo", Commit: "master", Path: "main.go", TypeRank: 4},
+		{Repo: "foo", Commit: "mybranch", Path: "main.go", TypeRank: 4},
 	}
 	if !reflect.DeepEqual(matchKeys, wantResultKeys) {
 		t.Errorf("got %v, want %v", matchKeys, wantResultKeys)

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -192,9 +192,9 @@ func TestIndexedSearch(t *testing.T) {
 			},
 			wantMatchCount: 3,
 			wantMatchKeys: []result.Key{
-				{Repo: "foo/bar", Rev: "HEAD", Commit: "1", Path: "baz.go"},
-				{Repo: "foo/bar", Rev: "dev", Commit: "1", Path: "baz.go"},
-				{Repo: "foo/bar", Rev: "dev", Commit: "2", Path: "bam.go"},
+				{Repo: "foo/bar", Rev: "HEAD", Commit: "1", Path: "baz.go", TypeRank: 4},
+				{Repo: "foo/bar", Rev: "dev", Commit: "1", Path: "baz.go", TypeRank: 4},
+				{Repo: "foo/bar", Rev: "dev", Commit: "2", Path: "bam.go", TypeRank: 4},
 			},
 			wantMatchInputRevs: []string{
 				"HEAD",
@@ -225,7 +225,7 @@ func TestIndexedSearch(t *testing.T) {
 			},
 			wantUnindexed: makeRepositoryRevisions("foo/bar@unindexed"),
 			wantMatchKeys: []result.Key{
-				{Repo: "foo/bar", Rev: "HEAD", Commit: "1", Path: "baz.go"},
+				{Repo: "foo/bar", Rev: "HEAD", Commit: "1", Path: "baz.go", TypeRank: 4},
 			},
 			wantMatchCount:     1,
 			wantMatchInputRevs: []string{"HEAD"},


### PR DESCRIPTION
This commit fixes type:path match counting by ensuring they are separate
from type:file results, and hence, don't get merged into a single match,
where the count of the type:path results gets lost.

Thanks @keegancsmith for point out the problem here: https://github.com/sourcegraph/sourcegraph/pull/29540/files#r786672991



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
