### PR TITLE
batches: prevent overflow spill with margin again

### DIFF
--- a/client/web/src/enterprise/batches/global/GlobalBatchChangesArea.tsx
+++ b/client/web/src/enterprise/batches/global/GlobalBatchChangesArea.tsx
@@ -68,12 +68,11 @@ interface Props
 /**
  * The global batch changes area.
  */
-export const GlobalBatchChangesArea: React.FunctionComponent<Props> = props => {
-    if (props.isSourcegraphDotCom) {
-        return <DotcomGettingStartedPage />
-    }
-    return <AuthenticatedBatchChangesArea {...props} />
-}
+export const GlobalBatchChangesArea: React.FunctionComponent<Props> = props => (
+    <div className="w-100">
+        {props.isSourcegraphDotCom ? <DotcomGettingStartedPage /> : <AuthenticatedBatchChangesArea {...props} />}
+    </div>
+)
 
 const NotFoundPage: React.FunctionComponent = () => <HeroPage icon={MapSearchIcon} title="404: Not Found" />
 
@@ -82,34 +81,30 @@ interface AuthenticatedProps extends Props {
 }
 
 export const AuthenticatedBatchChangesArea = withAuthenticatedUser<AuthenticatedProps>(({ match, ...outerProps }) => (
-    <div className="w-100">
-        <Switch>
-            <Route
-                render={props => (
-                    <BatchChangeListPage headingElement="h1" canCreate={true} {...outerProps} {...props} />
-                )}
-                path={match.url}
-                exact={true}
-            />
-            <Route
-                path={`${match.url}/create`}
-                render={props => <CreateBatchChangePage headingElement="h1" {...outerProps} {...props} />}
-                exact={true}
-            />
-            <Route
-                path={`${match.url}/executions/:batchSpecID`}
-                render={({ match, ...props }: RouteComponentProps<{ batchSpecID: string }>) => (
-                    <BatchSpecExecutionDetailsPage
-                        {...outerProps}
-                        {...props}
-                        match={match}
-                        batchSpecID={match.params.batchSpecID}
-                    />
-                )}
-            />
-            <Route component={NotFoundPage} key="hardcoded-key" />
-        </Switch>
-    </div>
+    <Switch>
+        <Route
+            render={props => <BatchChangeListPage headingElement="h1" canCreate={true} {...outerProps} {...props} />}
+            path={match.url}
+            exact={true}
+        />
+        <Route
+            path={`${match.url}/create`}
+            render={props => <CreateBatchChangePage headingElement="h1" {...outerProps} {...props} />}
+            exact={true}
+        />
+        <Route
+            path={`${match.url}/executions/:batchSpecID`}
+            render={({ match, ...props }: RouteComponentProps<{ batchSpecID: string }>) => (
+                <BatchSpecExecutionDetailsPage
+                    {...outerProps}
+                    {...props}
+                    match={match}
+                    batchSpecID={match.params.batchSpecID}
+                />
+            )}
+        />
+        <Route component={NotFoundPage} key="hardcoded-key" />
+    </Switch>
 ))
 
 export interface NamespaceBatchChangesAreaProps extends Props {


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/26812 but better.

The important thing here is just having that `<div>` (or any `display: block` container) wrap the component with `Page` (which introduces the consistent vertical padding). This was explored in the previous PR: since the next nearest parent is a `display: flex` container, it otherwise eats the bottom margin. The `<div>` wrapper wasn't included on `DotcomGettingStartedPage`, hence the regression. This ensures all pages in the global area have that wrapper.