### PR TITLE
buildchecker: attach more context to announcement messages

### DIFF
--- a/dev/buildchecker/checker_test.go
+++ b/dev/buildchecker/checker_test.go
@@ -238,14 +238,15 @@ func TestCheckConsecutiveFailures(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotCommits, gotThresholdExceeded, _ := checkConsecutiveFailures(tt.args.builds, tt.args.threshold, tt.args.timeout, false, false)
+			gotCommits, gotThresholdExceeded, _ := checkConsecutiveFailures(tt.args.builds, tt.args.threshold, tt.args.timeout, false)
 			assert.Equal(t, tt.wantThresholdExceeded, gotThresholdExceeded, "thresholdExceeded")
 
-			wantCommits := []CommitInfo{}
-			for _, c := range tt.wantCommits {
-				wantCommits = append(wantCommits, CommitInfo{Commit: c})
+			got := []string{}
+			for _, c := range gotCommits {
+				assert.NotZero(t, c.BuildNumber)
+				got = append(got, c.Commit)
 			}
-			assert.Equal(t, wantCommits, gotCommits, "commits")
+			assert.Equal(t, tt.wantCommits, got, "commits")
 		})
 	}
 }

--- a/dev/buildchecker/history_test.go
+++ b/dev/buildchecker/history_test.go
@@ -128,7 +128,6 @@ func TestGenerateHistory(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			println("--- " + t.Name())
 			_, gotFlakes, gotConsecutiveFailures := generateHistory(tt.builds, day.Add(2*time.Hour), CheckOptions{
 				FailuresThreshold: 3,
 				BuildTimeout:      0, // disable timeout check

--- a/dev/buildchecker/main.go
+++ b/dev/buildchecker/main.go
@@ -122,7 +122,7 @@ func cmdCheck(ctx context.Context, flags *Flags, checkFlags *cmdCheckFlags) {
 	// Only post an update if the lock has been modified
 	lockModified := results.Action != nil
 	if lockModified {
-		summary := slackSummary(results.LockBranch, results.FailedCommits)
+		summary := slackSummary(results.LockBranch, flags.Branch, results.FailedCommits)
 		announceWebhooks := strings.Split(checkFlags.slackAnnounceWebhooks, ",")
 
 		// Post update first to avoid invisible changes

--- a/dev/buildchecker/slack.go
+++ b/dev/buildchecker/slack.go
@@ -15,23 +15,27 @@ func slackMention(slackUserID string) string {
 	return fmt.Sprintf("<@%s>", slackUserID)
 }
 
-func slackSummary(locked bool, failedCommits []CommitInfo) string {
+func slackSummary(locked bool, branch string, failedCommits []CommitInfo) string {
+	branchStr := fmt.Sprintf("`%s`", branch)
 	if !locked {
-		return ":white_check_mark: Pipeline healthy - branch unlocked!"
+		return fmt.Sprintf(":white_check_mark: Pipeline healthy - %s unlocked!", branchStr)
 	}
-	message := `:alert: *Consecutive build failures detected - branch has been locked.* :alert:
+	message := fmt.Sprintf(`:alert: *Consecutive build failures detected - the %s branch has been locked.* :alert:
 The authors of the following failed commits who are Sourcegraph teammates have been granted merge access to investigate and resolve the issue:
-`
+`, branchStr)
 
 	for _, commit := range failedCommits {
 		var mention string
 		if commit.AuthorSlackID != "" {
 			mention = slackMention(commit.AuthorSlackID)
-		} else {
+		} else if commit.Author != "" {
 			mention = commit.Author
+		} else {
+			mention = "unable to infer author"
 		}
-		message += fmt.Sprintf("\n- <https://github.com/sourcegraph/sourcegraph/commit/%s|%.7s>: %s",
-			commit.Commit, commit.Commit, mention)
+
+		message += fmt.Sprintf("\n- <https://github.com/sourcegraph/sourcegraph/commit/%s|%.7s> (<%s|build %d>): %s",
+			commit.Commit, commit.Commit, commit.BuildURL, commit.BuildNumber, mention)
 	}
 	message += `
 
@@ -79,12 +83,12 @@ func postSlackUpdate(webhooks []string, summary string) (bool, error) {
 	// Attempt to send a message out to each
 	var errs error
 	var oneSucceeded bool
-	for _, webhook := range webhooks {
+	for i, webhook := range webhooks {
 		if len(webhook) == 0 {
 			return false, nil
 		}
 
-		log.Println("posting to ", webhook)
+		log.Println("posting to webhook ", i)
 
 		req, err := http.NewRequest(http.MethodPost, webhook, bytes.NewBuffer(body))
 		if err != nil {

--- a/dev/buildchecker/slack.go
+++ b/dev/buildchecker/slack.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"sort"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -23,6 +24,9 @@ func slackSummary(locked bool, branch string, failedCommits []CommitInfo) string
 	message := fmt.Sprintf(`:alert: *Consecutive build failures detected - the %s branch has been locked.* :alert:
 The authors of the following failed commits who are Sourcegraph teammates have been granted merge access to investigate and resolve the issue:
 `, branchStr)
+
+	// Reverse order of commits so that the oldest are listed first
+	sort.Slice(failedCommits, func(i, j int) bool { return failedCommits[i].BuildCreated.After(failedCommits[j].BuildCreated) })
 
 	for _, commit := range failedCommits {
 		var mention string

--- a/dev/buildchecker/slack_test.go
+++ b/dev/buildchecker/slack_test.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
+// See rendered output with:
+// 	go test -timeout 30s -run ^TestSlackSummary$ github.com/sourcegraph/sourcegraph/dev/buildchecker -v
 func TestSlackSummary(t *testing.T) {
 	t.Run("unlocked", func(t *testing.T) {
 		s := slackSummary(false, "main", []CommitInfo{})
@@ -16,11 +19,12 @@ func TestSlackSummary(t *testing.T) {
 
 	t.Run("locked", func(t *testing.T) {
 		s := slackSummary(true, "main", []CommitInfo{
-			{Commit: "a", Author: "bob", AuthorSlackID: "123", BuildNumber: 1, BuildURL: "https://sourcegraph.com"},
-			{Commit: "b", Author: "alice", AuthorSlackID: "124", BuildNumber: 1, BuildURL: "https://sourcegraph.com"},
-			{Commit: "c", Author: "no_slack", AuthorSlackID: "", BuildNumber: 1, BuildURL: "https://sourcegraph.com"},
+			{Commit: "a", Author: "bob", AuthorSlackID: "123", BuildNumber: 3, BuildURL: "https://sourcegraph.com", BuildCreated: time.Now()},
+			{Commit: "b", Author: "alice", AuthorSlackID: "124", BuildNumber: 2, BuildURL: "https://sourcegraph.com", BuildCreated: time.Now().Add(-1)},
+			{Commit: "c", Author: "no_slack", AuthorSlackID: "", BuildNumber: 1, BuildURL: "https://sourcegraph.com", BuildCreated: time.Now().Add(-2)},
 		})
 		t.Log(s)
+
 		assert.Contains(t, s, "locked")
 		assert.Contains(t, s, "main")
 		// If Slack user is available, mention only the Slack user
@@ -30,6 +34,8 @@ func TestSlackSummary(t *testing.T) {
 		assert.Contains(t, s, "no_slack")
 		// Includes build number and URL
 		assert.Contains(t, s, "build 1")
+		assert.Contains(t, s, "build 2")
+		assert.Contains(t, s, "build 3")
 		assert.Contains(t, s, "https://sourcegraph.com")
 	})
 }

--- a/dev/buildchecker/slack_test.go
+++ b/dev/buildchecker/slack_test.go
@@ -8,23 +8,28 @@ import (
 
 func TestSlackSummary(t *testing.T) {
 	t.Run("unlocked", func(t *testing.T) {
-		s := slackSummary(false, []CommitInfo{})
+		s := slackSummary(false, "main", []CommitInfo{})
 		t.Log(s)
 		assert.Contains(t, s, "unlocked")
+		assert.Contains(t, s, "main")
 	})
 
 	t.Run("locked", func(t *testing.T) {
-		s := slackSummary(true, []CommitInfo{
-			{Commit: "a", Author: "bob", AuthorSlackID: "123"},
-			{Commit: "b", Author: "alice", AuthorSlackID: "124"},
-			{Commit: "c", Author: "no_slack", AuthorSlackID: ""},
+		s := slackSummary(true, "main", []CommitInfo{
+			{Commit: "a", Author: "bob", AuthorSlackID: "123", BuildNumber: 1, BuildURL: "https://sourcegraph.com"},
+			{Commit: "b", Author: "alice", AuthorSlackID: "124", BuildNumber: 1, BuildURL: "https://sourcegraph.com"},
+			{Commit: "c", Author: "no_slack", AuthorSlackID: "", BuildNumber: 1, BuildURL: "https://sourcegraph.com"},
 		})
 		t.Log(s)
 		assert.Contains(t, s, "locked")
+		assert.Contains(t, s, "main")
 		// If Slack user is available, mention only the Slack user
 		assert.Contains(t, s, "<@123>")
 		assert.Contains(t, s, "<@124>")
 		// If no Slack user is available, note the author (user not found is implicit)
 		assert.Contains(t, s, "no_slack")
+		// Includes build number and URL
+		assert.Contains(t, s, "build 1")
+		assert.Contains(t, s, "https://sourcegraph.com")
 	})
 }


### PR DESCRIPTION
I will be adding `#dev-chat` as a target for announcements as well. Before doing so, and hopefully to help folks respond to incidents, I'm making a round of minor tweaks to the announcement messages:

- specify branch being locked
- include link to exact build that failed
- avoid [empty author](https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1642439338059300) with a vague error message
- list oldest builds first in announcement