### PR TITLE
search: Fix type:path results counting (v2)

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -967,7 +967,6 @@ func testSearchClient(t *testing.T, client searchClient) {
 	})
 
 	t.Run("And/Or search expression queries", func(t *testing.T) {
-		t.Skip("Flakey test https://github.com/sourcegraph/sourcegraph/issues/29828")
 
 		tests := []struct {
 			name            string

--- a/internal/search/result/merge.go
+++ b/internal/search/result/merge.go
@@ -3,7 +3,7 @@ package result
 // Union performs a merge of results, merging line matches when they occur in
 // the same file.
 func Union(left, right []Match) []Match {
-	dedup := NewDeduper()
+	dedup := NewDeduper(0)
 	// Add results to maps for deduping
 	for _, result := range left {
 		dedup.Add(result)

--- a/internal/search/result/postprocess.go
+++ b/internal/search/result/postprocess.go
@@ -12,7 +12,7 @@ func Select(results []Match, q query.Basic) []Match {
 	}
 	sp, _ := filter.SelectPathFromString(v) // Invariant: select already validated
 
-	dedup := NewDeduper()
+	dedup := NewDeduper(0)
 	for _, result := range results {
 		current := result.Select(sp)
 		if current == nil {

--- a/internal/search/streaming/stream.go
+++ b/internal/search/streaming/stream.go
@@ -74,7 +74,7 @@ func WithLimit(ctx context.Context, parent Sender, limit int) (context.Context, 
 // on each event, deduplicating where possible.
 func WithSelect(parent Sender, s filter.SelectPath) Sender {
 	var mux sync.Mutex
-	dedup := result.NewDeduper()
+	dedup := result.NewDeduper(0)
 
 	return StreamFunc(func(e SearchEvent) {
 		if parent == nil {


### PR DESCRIPTION
This is an alternative to #29873 that keeps the merging of type:path
and type:file results, which is necessary to keep `not` queries working,
since they only return `type:path` results.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
