### PR TITLE
add tests for CommitMatch.Select()

### DIFF
--- a/internal/search/result/commit.go
+++ b/internal/search/result/commit.go
@@ -148,17 +148,17 @@ func displayRepoName(repoPath string) string {
 
 // selectModifiedLines extracts the highlight ranges that correspond to lines
 // that have a `+` or `-` prefix (corresponding to additions resp. removals).
-func selectModifiedLines(lines []string, highlights []Range, prefix string, offset int) []Range {
+func selectModifiedLines(lines []string, highlights []Range, prefix string) []Range {
 	if len(lines) == 0 {
 		return highlights
 	}
 	include := make([]Range, 0, len(highlights))
 	for _, h := range highlights {
-		if h.Start.Line-offset < 0 {
+		if h.Start.Line < 0 {
 			// Skip negative line numbers. See: https://github.com/sourcegraph/sourcegraph/issues/20286.
 			continue
 		}
-		if strings.HasPrefix(lines[h.Start.Line-offset], prefix) {
+		if strings.HasPrefix(lines[h.Start.Line], prefix) {
 			include = append(include, h)
 		}
 	}
@@ -207,8 +207,8 @@ func selectCommitDiffKind(c *CommitMatch, field string) Match {
 	// We have two data structures storing highlight information for diff
 	// results. We must keep these in sync. Additionally the diff highlights
 	// line number is offset by 1.
-	bodyHighlights := selectModifiedLines(strings.Split(c.Body.Content, "\n"), c.Body.MatchedRanges, prefix, 0)
-	diffHighlights := selectModifiedLines(strings.Split(diff.Content, "\n"), diff.MatchedRanges, prefix, 1)
+	bodyHighlights := selectModifiedLines(strings.Split(c.Body.Content, "\n"), c.Body.MatchedRanges, prefix)
+	diffHighlights := selectModifiedLines(strings.Split(diff.Content, "\n"), diff.MatchedRanges, prefix)
 	if len(bodyHighlights) > 0 {
 		// Only rely on bodyHighlights since the header in diff.Value
 		// will create bogus highlights due to `+++` or `---`.

--- a/internal/search/result/match_test.go
+++ b/internal/search/result/match_test.go
@@ -5,28 +5,159 @@ import (
 	"testing"
 
 	"github.com/hexops/autogold"
+	"github.com/stretchr/testify/require"
+
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 func TestSelect(t *testing.T) {
-	data := &FileMatch{
-		Symbols: []*SymbolMatch{
-			{Symbol: Symbol{Name: "a()", Kind: "func"}},
-			{Symbol: Symbol{Name: "b()", Kind: "function"}},
-			{Symbol: Symbol{Name: "var c", Kind: "variable"}},
-		},
-	}
-
-	test := func(input string) string {
-		selectPath, _ := filter.SelectPathFromString(input)
-		symbols := data.Select(selectPath).(*FileMatch).Symbols
-		var values []string
-		for _, s := range symbols {
-			values = append(values, s.Symbol.Name+":"+s.Symbol.Kind)
+	t.Run("FileMatch", func(t *testing.T) {
+		data := &FileMatch{
+			Symbols: []*SymbolMatch{
+				{Symbol: Symbol{Name: "a()", Kind: "func"}},
+				{Symbol: Symbol{Name: "b()", Kind: "function"}},
+				{Symbol: Symbol{Name: "var c", Kind: "variable"}},
+			},
 		}
-		return strings.Join(values, ", ")
-	}
 
-	autogold.Want("filter any symbol", "a():func, b():function, var c:variable").Equal(t, test("symbol"))
-	autogold.Want("filter symbol kind variable", "var c:variable").Equal(t, test("symbol.variable"))
+		test := func(input string) string {
+			selectPath, _ := filter.SelectPathFromString(input)
+			symbols := data.Select(selectPath).(*FileMatch).Symbols
+			var values []string
+			for _, s := range symbols {
+				values = append(values, s.Symbol.Name+":"+s.Symbol.Kind)
+			}
+			return strings.Join(values, ", ")
+		}
+
+		autogold.Want("filter any symbol", "a():func, b():function, var c:variable").Equal(t, test("symbol"))
+		autogold.Want("filter symbol kind variable", "var c:variable").Equal(t, test("symbol.variable"))
+	})
+
+	t.Run("CommitMatch", func(t *testing.T) {
+		type commitMatchTestCase struct {
+			input      CommitMatch
+			selectPath filter.SelectPath
+			output     Match
+		}
+
+		t.Run("Message", func(t *testing.T) {
+			testMessageMatch := CommitMatch{
+				Repo:           types.MinimalRepo{Name: "testrepo"},
+				Body:           MatchedString{Content: "```COMMIT_EDITMSG\ntest\n```"},
+				MessagePreview: &MatchedString{Content: "test"},
+			}
+
+			cases := []commitMatchTestCase{{
+				input:      testMessageMatch,
+				selectPath: []string{filter.Commit},
+				output:     &testMessageMatch,
+			}, {
+				input:      testMessageMatch,
+				selectPath: []string{filter.Repository},
+				output:     &RepoMatch{Name: "testrepo"},
+			}, {
+				input:      testMessageMatch,
+				selectPath: []string{filter.File},
+				output:     nil,
+			}, {
+				input:      testMessageMatch,
+				selectPath: []string{filter.Commit, "diff", "added"},
+				output:     nil,
+			}, {
+				input:      testMessageMatch,
+				selectPath: []string{filter.Symbol},
+				output:     nil,
+			}, {
+				input:      testMessageMatch,
+				selectPath: []string{filter.Content},
+				output:     nil,
+			}}
+
+			for _, tc := range cases {
+				t.Run(tc.selectPath.String(), func(t *testing.T) {
+					result := tc.input.Select(tc.selectPath)
+					require.Equal(t, tc.output, result)
+				})
+			}
+		})
+
+		t.Run("Diff", func(t *testing.T) {
+			diffContent := "file1 file2\n@@ -969,3 +969,2 @@ functioncontext\ncontextbefore\n-removed\n+added\ncontextafter\n"
+			removedRange := Range{Start: Location{Offset: 63, Line: 3, Column: 1}, End: Location{Offset: 67, Line: 3, Column: 5}}
+			addedRange := Range{Start: Location{Offset: 73, Line: 4, Column: 2}, End: Location{Offset: 77, Line: 4, Column: 6}}
+
+			testDiffMatch := func() CommitMatch {
+				return CommitMatch{
+					Repo: types.MinimalRepo{Name: "testrepo"},
+					Body: MatchedString{
+						Content:       "```diff\n" + diffContent + "\n```",
+						MatchedRanges: Ranges{addedRange, removedRange}.Add(Location{Line: 1, Offset: len("```diff\n")}),
+					},
+					DiffPreview: &MatchedString{
+						Content:       diffContent,
+						MatchedRanges: Ranges{addedRange, removedRange},
+					},
+				}
+			}
+
+			cases := []commitMatchTestCase{{
+				input:      testDiffMatch(),
+				selectPath: []string{filter.Commit},
+				output:     func() *CommitMatch { c := testDiffMatch(); return &c }(),
+			}, {
+				input:      testDiffMatch(),
+				selectPath: []string{filter.Repository},
+				output:     &RepoMatch{Name: "testrepo"},
+			}, {
+				input:      testDiffMatch(),
+				selectPath: []string{filter.File},
+				output:     nil,
+			}, {
+				input:      testDiffMatch(),
+				selectPath: []string{filter.Symbol},
+				output:     nil,
+			}, {
+				input:      testDiffMatch(),
+				selectPath: []string{filter.Content},
+				output:     nil,
+			}, {
+				input:      testDiffMatch(),
+				selectPath: []string{filter.Commit, "diff", "added"},
+				output: &CommitMatch{
+					Repo: types.MinimalRepo{Name: "testrepo"},
+					Body: MatchedString{
+						Content:       "```diff\n" + diffContent + "\n```",
+						MatchedRanges: Ranges{addedRange}.Add(Location{Line: 1, Offset: len("```diff\n")}),
+					},
+					DiffPreview: &MatchedString{
+						Content:       diffContent,
+						MatchedRanges: Ranges{addedRange},
+					},
+				},
+			}, {
+				input:      testDiffMatch(),
+				selectPath: []string{filter.Commit, "diff", "removed"},
+				output: &CommitMatch{
+					Repo: types.MinimalRepo{Name: "testrepo"},
+					Body: MatchedString{
+						Content:       "```diff\n" + diffContent + "\n```",
+						MatchedRanges: Ranges{removedRange}.Add(Location{Line: 1, Offset: len("```diff\n")}),
+					},
+					DiffPreview: &MatchedString{
+						Content:       diffContent,
+						MatchedRanges: Ranges{removedRange},
+					},
+				},
+			}}
+
+			for _, tc := range cases {
+				t.Run(tc.selectPath.String(), func(t *testing.T) {
+					result := tc.input.Select(tc.selectPath)
+					require.Equal(t, tc.output, result)
+				})
+			}
+		})
+	})
 }


### PR DESCRIPTION
I'm going to attempt to make the CommitMatch type better represent our
domain, but I couldn't find any good tests for calling Select() on
CommitMatch, so I added these to lock in expected behavior as I make
some changes that affect this.

Note that there seemed to be a few incorrect assumptions about the
format of DiffPreview in `selectCommitDiffKind`, but since we don't
really ever use DiffPreview right now (it's redundant with Body), we
weren't seeing the issues. Specifically, there is no need to adjust
the offset because the highlight ranges are adjusted to match added line
from wrapping the diff in a markdown code block.

I tested this locally, and there are no visible changes to highlights when using
`select:commit.diff.added/removed`.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
