### PR TITLE
executors: Pass auth via header instead of basic auth

### DIFF
--- a/enterprise/cmd/executor/config.go
+++ b/enterprise/cmd/executor/config.go
@@ -17,28 +17,28 @@ import (
 type Config struct {
 	env.BaseConfig
 
-	FrontendURL          string
-	FrontendPassword     string
-	QueueName            string
-	QueuePollInterval    time.Duration
-	MaximumNumJobs       int
-	FirecrackerImage     string
-	VMStartupScriptPath  string
-	VMPrefix             string
-	UseFirecracker       bool
-	FirecrackerNumCPUs   int
-	FirecrackerMemory    string
-	FirecrackerDiskSpace string
-	MaximumRuntimePerJob time.Duration
-	CleanupTaskInterval  time.Duration
-	NumTotalJobs         int
-	MaxActiveTime        time.Duration
-	WorkerHostname       string
+	FrontendURL                string
+	FrontendAuthorizationToken string
+	QueueName                  string
+	QueuePollInterval          time.Duration
+	MaximumNumJobs             int
+	FirecrackerImage           string
+	VMStartupScriptPath        string
+	VMPrefix                   string
+	UseFirecracker             bool
+	FirecrackerNumCPUs         int
+	FirecrackerMemory          string
+	FirecrackerDiskSpace       string
+	MaximumRuntimePerJob       time.Duration
+	CleanupTaskInterval        time.Duration
+	NumTotalJobs               int
+	MaxActiveTime              time.Duration
+	WorkerHostname             string
 }
 
 func (c *Config) Load() {
 	c.FrontendURL = c.Get("EXECUTOR_FRONTEND_URL", "", "The external URL of the sourcegraph instance.")
-	c.FrontendPassword = c.Get("EXECUTOR_FRONTEND_PASSWORD", "", "The password supplied to the frontend.")
+	c.FrontendAuthorizationToken = c.Get("EXECUTOR_FRONTEND_PASSWORD", "", "The authorization token supplied to the frontend.")
 	c.QueueName = c.Get("EXECUTOR_QUEUE_NAME", "", "The name of the queue to listen to.")
 	c.QueuePollInterval = c.GetInterval("EXECUTOR_QUEUE_POLL_INTERVAL", "1s", "Interval between dequeue requests.")
 	c.MaximumNumJobs = c.GetInt("EXECUTOR_MAXIMUM_NUM_JOBS", "1", "Number of virtual machines or containers that can be running at once.")
@@ -81,7 +81,7 @@ func (c *Config) APIWorkerOptions(telemetryOptions apiclient.TelemetryOptions) a
 		RedactedValues: map[string]string{
 			// 🚨 SECURITY: Catch uses of the shared frontend token used to clone
 			// git repositories that make it into commands or stdout/stderr streams.
-			c.FrontendPassword: "PASSWORD_REMOVED",
+			c.FrontendAuthorizationToken: "SECRET_REMOVED",
 		},
 	}
 }
@@ -131,7 +131,7 @@ func (c *Config) BaseClientOptions() apiclient.BaseClientOptions {
 
 func (c *Config) EndpointOptions() apiclient.EndpointOptions {
 	return apiclient.EndpointOptions{
-		URL:      c.FrontendURL,
-		Password: c.FrontendPassword,
+		URL:   c.FrontendURL,
+		Token: c.FrontendAuthorizationToken,
 	}
 }

--- a/enterprise/cmd/executor/internal/apiclient/client.go
+++ b/enterprise/cmd/executor/internal/apiclient/client.go
@@ -44,8 +44,8 @@ type EndpointOptions struct {
 	// URL is the target request URL.
 	URL string
 
-	// Password is the basic-auth password to include with all requests.
-	Password string
+	// Token is the authorization token to include with all requests (via Authorization header).
+	Token string
 }
 
 func New(options Options, observationContext *observation.Context) *Client {
@@ -242,7 +242,7 @@ func (c *Client) makeRequest(method, path string, payload interface{}) (*http.Re
 		return nil, err
 	}
 
-	r.Header.Add("Authorization", fmt.Sprintf("%s %s", SchemeExecutorToken, c.options.EndpointOptions.Password))
+	r.Header.Add("Authorization", fmt.Sprintf("%s %s", SchemeExecutorToken, c.options.EndpointOptions.Token))
 	return r, nil
 }
 

--- a/enterprise/cmd/executor/internal/apiclient/client.go
+++ b/enterprise/cmd/executor/internal/apiclient/client.go
@@ -245,6 +245,7 @@ func makeURL(base, password string, path ...string) (*url.URL, error) {
 		return nil, err
 	}
 
+	// TODO
 	u.User = url.UserPassword("sourcegraph", password)
 	return u, nil
 }

--- a/enterprise/cmd/executor/internal/apiclient/client_test.go
+++ b/enterprise/cmd/executor/internal/apiclient/client_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -21,7 +22,7 @@ func TestDequeue(t *testing.T) {
 		expectedMethod:   "POST",
 		expectedPath:     "/.executors/queue/test_queue/dequeue",
 		expectedUsername: "test",
-		expectedPassword: "hunter2",
+		expectedToken:    "hunter2",
 		expectedPayload:  `{"executorName": "deadbeef"}`,
 		responseStatus:   http.StatusOK,
 		responsePayload:  `{"id": 42}`,
@@ -47,7 +48,7 @@ func TestDequeueNoRecord(t *testing.T) {
 		expectedMethod:   "POST",
 		expectedPath:     "/.executors/queue/test_queue/dequeue",
 		expectedUsername: "test",
-		expectedPassword: "hunter2",
+		expectedToken:    "hunter2",
 		expectedPayload:  `{"executorName": "deadbeef"}`,
 		responseStatus:   http.StatusNoContent,
 		responsePayload:  ``,
@@ -69,7 +70,7 @@ func TestDequeueBadResponse(t *testing.T) {
 		expectedMethod:   "POST",
 		expectedPath:     "/.executors/queue/test_queue/dequeue",
 		expectedUsername: "test",
-		expectedPassword: "hunter2",
+		expectedToken:    "hunter2",
 		expectedPayload:  `{"executorName": "deadbeef"}`,
 		responseStatus:   http.StatusInternalServerError,
 		responsePayload:  ``,
@@ -96,7 +97,7 @@ func TestAddExecutionLogEntry(t *testing.T) {
 		expectedMethod:   "POST",
 		expectedPath:     "/.executors/queue/test_queue/addExecutionLogEntry",
 		expectedUsername: "test",
-		expectedPassword: "hunter2",
+		expectedToken:    "hunter2",
 		expectedPayload: `{
 			"executorName": "deadbeef",
 			"jobId": 42,
@@ -136,7 +137,7 @@ func TestAddExecutionLogEntryBadResponse(t *testing.T) {
 		expectedMethod:   "POST",
 		expectedPath:     "/.executors/queue/test_queue/addExecutionLogEntry",
 		expectedUsername: "test",
-		expectedPassword: "hunter2",
+		expectedToken:    "hunter2",
 		expectedPayload: `{
 			"executorName": "deadbeef",
 			"jobId": 42,
@@ -172,7 +173,7 @@ func TestUpdateExecutionLogEntry(t *testing.T) {
 		expectedMethod:   "POST",
 		expectedPath:     "/.executors/queue/test_queue/updateExecutionLogEntry",
 		expectedUsername: "test",
-		expectedPassword: "hunter2",
+		expectedToken:    "hunter2",
 		expectedPayload: `{
 			"executorName": "deadbeef",
 			"jobId": 42,
@@ -209,7 +210,7 @@ func TestUpdateExecutionLogEntryBadResponse(t *testing.T) {
 		expectedMethod:   "POST",
 		expectedPath:     "/.executors/queue/test_queue/updateExecutionLogEntry",
 		expectedUsername: "test",
-		expectedPassword: "hunter2",
+		expectedToken:    "hunter2",
 		expectedPayload: `{
 			"executorName": "deadbeef",
 			"jobId": 42,
@@ -237,7 +238,7 @@ func TestMarkComplete(t *testing.T) {
 		expectedMethod:   "POST",
 		expectedPath:     "/.executors/queue/test_queue/markComplete",
 		expectedUsername: "test",
-		expectedPassword: "hunter2",
+		expectedToken:    "hunter2",
 		expectedPayload:  `{"executorName": "deadbeef", "jobId": 42}`,
 		responseStatus:   http.StatusNoContent,
 		responsePayload:  ``,
@@ -255,7 +256,7 @@ func TestMarkCompleteBadResponse(t *testing.T) {
 		expectedMethod:   "POST",
 		expectedPath:     "/.executors/queue/test_queue/markComplete",
 		expectedUsername: "test",
-		expectedPassword: "hunter2",
+		expectedToken:    "hunter2",
 		expectedPayload:  `{"executorName": "deadbeef", "jobId": 42}`,
 		responseStatus:   http.StatusInternalServerError,
 		responsePayload:  ``,
@@ -273,7 +274,7 @@ func TestMarkErrored(t *testing.T) {
 		expectedMethod:   "POST",
 		expectedPath:     "/.executors/queue/test_queue/markErrored",
 		expectedUsername: "test",
-		expectedPassword: "hunter2",
+		expectedToken:    "hunter2",
 		expectedPayload:  `{"executorName": "deadbeef", "jobId": 42, "errorMessage": "OH NO"}`,
 		responseStatus:   http.StatusNoContent,
 		responsePayload:  ``,
@@ -291,7 +292,7 @@ func TestMarkErroredBadResponse(t *testing.T) {
 		expectedMethod:   "POST",
 		expectedPath:     "/.executors/queue/test_queue/markErrored",
 		expectedUsername: "test",
-		expectedPassword: "hunter2",
+		expectedToken:    "hunter2",
 		expectedPayload:  `{"executorName": "deadbeef", "jobId": 42, "errorMessage": "OH NO"}`,
 		responseStatus:   http.StatusInternalServerError,
 		responsePayload:  ``,
@@ -309,7 +310,7 @@ func TestMarkFailed(t *testing.T) {
 		expectedMethod:   "POST",
 		expectedPath:     "/.executors/queue/test_queue/markFailed",
 		expectedUsername: "test",
-		expectedPassword: "hunter2",
+		expectedToken:    "hunter2",
 		expectedPayload:  `{"executorName": "deadbeef", "jobId": 42, "errorMessage": "OH NO"}`,
 		responseStatus:   http.StatusNoContent,
 		responsePayload:  ``,
@@ -327,7 +328,7 @@ func TestCanceled(t *testing.T) {
 		expectedMethod:   "POST",
 		expectedPath:     "/.executors/queue/test_queue/canceled",
 		expectedUsername: "test",
-		expectedPassword: "hunter2",
+		expectedToken:    "hunter2",
 		expectedPayload:  `{"executorName": "deadbeef"}`,
 		responseStatus:   http.StatusOK,
 		responsePayload:  `[1]`,
@@ -347,7 +348,7 @@ func TestHeartbeat(t *testing.T) {
 		expectedMethod:   "POST",
 		expectedPath:     "/.executors/queue/test_queue/heartbeat",
 		expectedUsername: "test",
-		expectedPassword: "hunter2",
+		expectedToken:    "hunter2",
 		expectedPayload: `{
 			"executorName": "deadbeef",
 			"jobIds": [1,2,3],
@@ -381,7 +382,7 @@ func TestHeartbeatBadResponse(t *testing.T) {
 		expectedMethod:   "POST",
 		expectedPath:     "/.executors/queue/test_queue/heartbeat",
 		expectedUsername: "test",
-		expectedPassword: "hunter2",
+		expectedToken:    "hunter2",
 		expectedPayload: `{
 			"executorName": "deadbeef",
 			"jobIds": [1,2,3],
@@ -409,7 +410,7 @@ type routeSpec struct {
 	expectedMethod   string
 	expectedPath     string
 	expectedUsername string
-	expectedPassword string
+	expectedToken    string
 	expectedPayload  string
 	responseStatus   int
 	responsePayload  string
@@ -423,8 +424,8 @@ func testRoute(t *testing.T, spec routeSpec, f func(client *Client)) {
 		ExecutorName: "deadbeef",
 		PathPrefix:   "/.executors/queue",
 		EndpointOptions: EndpointOptions{
-			URL:      ts.URL,
-			Password: "hunter2",
+			URL:   ts.URL,
+			Token: "hunter2",
 		},
 		TelemetryOptions: TelemetryOptions{
 			OS:              "test-os",
@@ -449,9 +450,11 @@ func testServer(t *testing.T, spec routeSpec) *httptest.Server {
 			t.Errorf("unexpected method. want=%s have=%s", spec.expectedPath, r.URL.Path)
 		}
 
-		_, password, _ := r.BasicAuth()
-		if password != spec.expectedPassword {
-			t.Errorf("unexpected password. want=%s have=%s", spec.expectedPassword, password)
+		parts := strings.Split(r.Header.Get("Authorization"), " ")
+		if len(parts) != 2 || parts[0] != "token-executor" {
+			if parts[1] != spec.expectedToken {
+				t.Errorf("unexpected token`. want=%s have=%s", spec.expectedToken, parts[1])
+			}
 		}
 
 		content, err := io.ReadAll(r.Body)

--- a/enterprise/cmd/executor/internal/worker/workspace.go
+++ b/enterprise/cmd/executor/internal/worker/workspace.go
@@ -40,7 +40,7 @@ func (h *handler) prepareWorkspace(ctx context.Context, commandRunner command.Ru
 		}
 
 		authorizationOption := fmt.Sprintf(
-			"http.extraheader='Authorization: %s %s'",
+			"http.extraHeader=Authorization: %s %s",
 			SchemeExecutorToken,
 			h.options.ClientOptions.EndpointOptions.Password,
 		)
@@ -71,7 +71,14 @@ func makeRelativeURL(base string, path ...string) (*url.URL, error) {
 		return nil, err
 	}
 
-	return baseURL.ResolveReference(&url.URL{Path: filepath.Join(path...)}), nil
+	urlx, err := baseURL.ResolveReference(&url.URL{Path: filepath.Join(path...)}), nil
+	if err != nil {
+		return nil, err
+	}
+
+	// HOLY SHIT
+	urlx.User = url.User("executor") // TODO - identify self?
+	return urlx, nil
 }
 
 // makeTempDir defaults to makeTemporaryDirectory and can be replaced for testing

--- a/enterprise/cmd/executor/internal/worker/workspace.go
+++ b/enterprise/cmd/executor/internal/worker/workspace.go
@@ -12,6 +12,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/command"
 )
 
+const SchemeExecutorToken = "token-executor"
+
 // prepareWorkspace creates and returns a temporary director in which acts the workspace
 // while processing a single job. It is up to the caller to ensure that this directory is
 // removed after the job has finished processing. If a repository name is supplied, then
@@ -28,9 +30,8 @@ func (h *handler) prepareWorkspace(ctx context.Context, commandRunner command.Ru
 	}()
 
 	if repositoryName != "" {
-		cloneURL, err := makeURL(
+		cloneURL, err := makeRelativeURL(
 			h.options.ClientOptions.EndpointOptions.URL,
-			h.options.ClientOptions.EndpointOptions.Password,
 			h.options.GitServicePath,
 			repositoryName,
 		)
@@ -38,9 +39,15 @@ func (h *handler) prepareWorkspace(ctx context.Context, commandRunner command.Ru
 			return "", err
 		}
 
+		authorizationOption := fmt.Sprintf(
+			"http.extraheader='Authorization: %s %s'",
+			SchemeExecutorToken,
+			h.options.ClientOptions.EndpointOptions.Password,
+		)
+
 		gitCommands := []command.CommandSpec{
 			{Key: "setup.git.init", Command: []string{"git", "-C", tempDir, "init"}, Operation: h.operations.SetupGitInit},
-			{Key: "setup.git.fetch", Command: []string{"git", "-C", tempDir, "-c", "protocol.version=2", "fetch", cloneURL.String(), "-t", commit}, Operation: h.operations.SetupGitFetch},
+			{Key: "setup.git.fetch", Command: []string{"git", "-C", tempDir, "-c", "protocol.version=2", "-c", authorizationOption, "fetch", cloneURL.String(), "-t", commit}, Operation: h.operations.SetupGitFetch},
 			{Key: "setup.git.add-remote", Command: []string{"git", "-C", tempDir, "remote", "add", "origin", repositoryName}, Operation: h.operations.SetupAddRemote},
 			{Key: "setup.git.checkout", Command: []string{"git", "-C", tempDir, "checkout", commit}, Operation: h.operations.SetupGitCheckout},
 		}
@@ -56,16 +63,6 @@ func (h *handler) prepareWorkspace(ctx context.Context, commandRunner command.Ru
 	}
 
 	return tempDir, nil
-}
-
-func makeURL(base, password string, path ...string) (*url.URL, error) {
-	u, err := makeRelativeURL(base, path...)
-	if err != nil {
-		return nil, err
-	}
-
-	u.User = url.UserPassword("sourcegraph", password)
-	return u, nil
 }
 
 func makeRelativeURL(base string, path ...string) (*url.URL, error) {

--- a/enterprise/cmd/executor/internal/worker/workspace.go
+++ b/enterprise/cmd/executor/internal/worker/workspace.go
@@ -76,8 +76,7 @@ func makeRelativeURL(base string, path ...string) (*url.URL, error) {
 		return nil, err
 	}
 
-	// HOLY SHIT
-	urlx.User = url.User("executor") // TODO - identify self?
+	urlx.User = url.User("executor")
 	return urlx, nil
 }
 

--- a/enterprise/cmd/executor/internal/worker/workspace.go
+++ b/enterprise/cmd/executor/internal/worker/workspace.go
@@ -42,7 +42,7 @@ func (h *handler) prepareWorkspace(ctx context.Context, commandRunner command.Ru
 		authorizationOption := fmt.Sprintf(
 			"http.extraHeader=Authorization: %s %s",
 			SchemeExecutorToken,
-			h.options.ClientOptions.EndpointOptions.Password,
+			h.options.ClientOptions.EndpointOptions.Token,
 		)
 
 		gitCommands := []command.CommandSpec{

--- a/enterprise/cmd/executor/internal/worker/workspace_test.go
+++ b/enterprise/cmd/executor/internal/worker/workspace_test.go
@@ -16,8 +16,8 @@ func TestPrepareWorkspace(t *testing.T) {
 	options := Options{
 		ClientOptions: apiclient.Options{
 			EndpointOptions: apiclient.EndpointOptions{
-				URL:      "https://test.io",
-				Password: "hunter2",
+				URL:   "https://test.io",
+				Token: "hunter2",
 			},
 		},
 		GitServicePath: "/internal/git",
@@ -45,7 +45,7 @@ func TestPrepareWorkspace(t *testing.T) {
 
 	expectedCommands := [][]string{
 		{"git", "-C", dir, "init"},
-		{"git", "-C", dir, "-c", "protocol.version=2", "fetch", "https://sourcegraph:hunter2@test.io/internal/git/torvalds/linux", "-t", "deadbeef"},
+		{"git", "-C", dir, "-c", "protocol.version=2", "-c", "http.extraHeader=Authorization: token-executor hunter2", "fetch", "https://executor@test.io/internal/git/torvalds/linux", "-t", "deadbeef"},
 		{"git", "-C", dir, "remote", "add", "origin", "torvalds/linux"},
 		{"git", "-C", dir, "checkout", "deadbeef"},
 	}

--- a/enterprise/cmd/frontend/internal/executorqueue/queuehandler.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queuehandler.go
@@ -51,6 +51,7 @@ func newExecutorQueueHandler(executorStore executor.Store, queueOptions []handle
 // in which a shared key exchange can be done so safely.
 func basicAuthMiddleware(accessToken func() string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// TODO
 		// We don't care about the username. Only the password matters here.
 		_, password, ok := r.BasicAuth()
 		if !ok {


### PR DESCRIPTION
This PR stops passing auth via BasicAuth/the URL when the executor interfaces with the frontend (via HTTP requests as well as git commands for fetch/clone) and sends the same shared token (previously the password) via the Authorization header instead.

This PR remove support for reading the old auth type. This should not affect any configuration, but executors + application code must be deployed concurrently for existing instances (dogfood, Cloud) to prevent a bad auth scheme failing jobs.

Fixes sourcegraph/security-issues/issues/205.