### PR TITLE
Generate commit match body on demand

### DIFF
--- a/cmd/frontend/graphqlbackend/commit_search_result.go
+++ b/cmd/frontend/graphqlbackend/commit_search_result.go
@@ -79,7 +79,7 @@ func (r *CommitSearchResultResolver) Detail() Markdown {
 }
 
 func (r *CommitSearchResultResolver) Matches() []*searchResultMatchResolver {
-	hls := r.CommitMatch.Body.ToHighlightedString()
+	hls := r.CommitMatch.Body().ToHighlightedString()
 	match := &searchResultMatchResolver{
 		body:       hls.Value,
 		highlights: hls.Highlights,

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -553,7 +553,7 @@ func fromRepository(rm *result.RepoMatch, repoCache map[api.RepoID]*types.Search
 }
 
 func fromCommit(commit *result.CommitMatch, repoCache map[api.RepoID]*types.SearchedRepo) *streamhttp.EventCommitMatch {
-	hls := commit.Body.ToHighlightedString()
+	hls := commit.Body().ToHighlightedString()
 	ranges := make([][3]int32, len(hls.Highlights))
 	for i, h := range hls.Highlights {
 		ranges[i] = [3]int32{h.Line, h.Character, h.Length}

--- a/internal/search/commit/commit_new.go
+++ b/internal/search/commit/commit_new.go
@@ -301,7 +301,14 @@ func queryParameterToPredicate(parameter query.Parameter, caseSensitive, diff bo
 }
 
 func protocolMatchToCommitMatch(repo types.MinimalRepo, diff bool, in protocol.CommitMatch) *result.CommitMatch {
-	cm := result.CommitMatch{
+	var diffPreview, messagePreview *result.MatchedString
+	if diff {
+		diffPreview = &in.Diff
+	} else {
+		messagePreview = &in.Message
+	}
+
+	return &result.CommitMatch{
 		Commit: gitdomain.Commit{
 			ID: in.Oid,
 			Author: gitdomain.Signature{
@@ -317,16 +324,10 @@ func protocolMatchToCommitMatch(repo types.MinimalRepo, diff bool, in protocol.C
 			Message: gitdomain.Message(in.Message.Content),
 			Parents: in.Parents,
 		},
-		Repo: repo,
+		Repo:           repo,
+		DiffPreview:    diffPreview,
+		MessagePreview: messagePreview,
 	}
-
-	if diff {
-		cm.DiffPreview = &in.Diff
-	} else {
-		cm.MessagePreview = &in.Message
-	}
-
-	return &cm
 }
 
 func newReposLimitError(limit int, hasTimeFilter bool, resultType string) error {

--- a/internal/search/commit/commit_test.go
+++ b/internal/search/commit/commit_test.go
@@ -10,7 +10,7 @@ import (
 func TestCommitSearchResult_Limit(t *testing.T) {
 	f := func(nHighlights []int, limitInput uint32) bool {
 		cr := &result.CommitMatch{
-			Body: result.MatchedString{
+			MessagePreview: &result.MatchedString{
 				MatchedRanges: make([]result.Range, len(nHighlights)),
 			},
 		}

--- a/internal/search/result/commit.go
+++ b/internal/search/result/commit.go
@@ -31,11 +31,20 @@ type CommitMatch struct {
 	// MessagePreview and DiffPreview are mutually exclusive. Only one should be set
 	MessagePreview *MatchedString
 	DiffPreview    *MatchedString
+}
 
-	// Body is a markdown-formatteed code block that contains the content of either
-	// the commit message if this match is to a commit, or the matching diff hunks
-	// if this is a diff result.
-	Body MatchedString
+func (c *CommitMatch) Body() MatchedString {
+	if c.DiffPreview != nil {
+		return MatchedString{
+			Content:       "```diff\n" + c.DiffPreview.Content + "\n```",
+			MatchedRanges: c.DiffPreview.MatchedRanges.Add(Location{Line: 1, Offset: len("```diff\n")}),
+		}
+	}
+
+	return MatchedString{
+		Content:       "```COMMIT_EDITMSG\n" + c.MessagePreview.Content + "\n```",
+		MatchedRanges: c.MessagePreview.MatchedRanges.Add(Location{Line: 1, Offset: len("```COMMIT_EDITMSG\n")}),
+	}
 }
 
 // ResultCount for CommitSearchResult returns the number of highlights if there
@@ -44,8 +53,15 @@ type CommitMatch struct {
 // compatibility for our GraphQL API. The GraphQL API calls ResultCount on the
 // resolver, while streaming calls ResultCount on CommitSearchResult.
 func (r *CommitMatch) ResultCount() int {
-	if n := len(r.Body.MatchedRanges); n > 0 {
-		return n
+	matchCount := 0
+	switch {
+	case r.DiffPreview != nil:
+		matchCount = len(r.DiffPreview.MatchedRanges)
+	case r.MessagePreview != nil:
+		matchCount = len(r.MessagePreview.MatchedRanges)
+	}
+	if matchCount > 0 {
+		return matchCount
 	}
 	// Queries such as type:commit after:"1 week ago" don't have highlights. We count
 	// those results as 1.
@@ -57,13 +73,24 @@ func (r *CommitMatch) RepoName() types.MinimalRepo {
 }
 
 func (r *CommitMatch) Limit(limit int) int {
-	if len(r.Body.MatchedRanges) == 0 {
-		return limit - 1 // just counting the commit
-	} else if len(r.Body.MatchedRanges) > limit {
-		r.Body.MatchedRanges = r.Body.MatchedRanges[:limit]
-		return 0
+	limitMatchedString := func(ms *MatchedString) int {
+		if len(ms.MatchedRanges) == 0 {
+			return limit - 1
+		} else if len(ms.MatchedRanges) > limit {
+			ms.MatchedRanges = ms.MatchedRanges[:limit]
+			return 0
+		}
+		return limit - len(ms.MatchedRanges)
 	}
-	return limit - len(r.Body.MatchedRanges)
+
+	switch {
+	case r.DiffPreview != nil:
+		return limitMatchedString(r.DiffPreview)
+	case r.MessagePreview != nil:
+		return limitMatchedString(r.MessagePreview)
+	default:
+		panic("exactly one of DiffPreview or Message must be set")
+	}
 }
 
 func (r *CommitMatch) Select(path filter.SelectPath) Match {
@@ -99,7 +126,6 @@ func (r *CommitMatch) Select(path filter.SelectPath) Match {
 func (r *CommitMatch) AppendMatches(src *CommitMatch) {
 	if r.MessagePreview != nil && src.MessagePreview != nil {
 		r.MessagePreview.MatchedRanges = append(r.MessagePreview.MatchedRanges, src.MessagePreview.MatchedRanges...)
-		r.Body.MatchedRanges = append(r.Body.MatchedRanges, src.Body.MatchedRanges...)
 	}
 }
 
@@ -195,24 +221,14 @@ func selectCommitDiffKind(c *CommitMatch, field string) Match {
 	if len(diff.MatchedRanges) == 0 {
 		// No highlights, implying no pattern was specified. Filter by
 		// whether there exists lines corresponding to additions or
-		// removals. Inspect c.Body, which is the diff markdown in the
-		// format ```diff <...>``` and which doesn't contain a unified
-		// diff header with +++ or --- in diff.Value, which would would
-		// otherwise confuse this check.
-		if modifiedLinesExist(strings.Split(c.Body.Content, "\n"), prefix) {
+		// removals.
+		if modifiedLinesExist(strings.Split(diff.Content, "\n"), prefix) {
 			return c
 		}
 		return nil
 	}
-	// We have two data structures storing highlight information for diff
-	// results. We must keep these in sync. Additionally the diff highlights
-	// line number is offset by 1.
-	bodyHighlights := selectModifiedLines(strings.Split(c.Body.Content, "\n"), c.Body.MatchedRanges, prefix)
 	diffHighlights := selectModifiedLines(strings.Split(diff.Content, "\n"), diff.MatchedRanges, prefix)
-	if len(bodyHighlights) > 0 {
-		// Only rely on bodyHighlights since the header in diff.Value
-		// will create bogus highlights due to `+++` or `---`.
-		c.Body.MatchedRanges = bodyHighlights
+	if len(diffHighlights) > 0 {
 		c.DiffPreview.MatchedRanges = diffHighlights
 		return c
 	}

--- a/internal/search/result/match_test.go
+++ b/internal/search/result/match_test.go
@@ -45,7 +45,6 @@ func TestSelect(t *testing.T) {
 		t.Run("Message", func(t *testing.T) {
 			testMessageMatch := CommitMatch{
 				Repo:           types.MinimalRepo{Name: "testrepo"},
-				Body:           MatchedString{Content: "```COMMIT_EDITMSG\ntest\n```"},
 				MessagePreview: &MatchedString{Content: "test"},
 			}
 
@@ -91,10 +90,6 @@ func TestSelect(t *testing.T) {
 			testDiffMatch := func() CommitMatch {
 				return CommitMatch{
 					Repo: types.MinimalRepo{Name: "testrepo"},
-					Body: MatchedString{
-						Content:       "```diff\n" + diffContent + "\n```",
-						MatchedRanges: Ranges{addedRange, removedRange}.Add(Location{Line: 1, Offset: len("```diff\n")}),
-					},
 					DiffPreview: &MatchedString{
 						Content:       diffContent,
 						MatchedRanges: Ranges{addedRange, removedRange},
@@ -127,10 +122,6 @@ func TestSelect(t *testing.T) {
 				selectPath: []string{filter.Commit, "diff", "added"},
 				output: &CommitMatch{
 					Repo: types.MinimalRepo{Name: "testrepo"},
-					Body: MatchedString{
-						Content:       "```diff\n" + diffContent + "\n```",
-						MatchedRanges: Ranges{addedRange}.Add(Location{Line: 1, Offset: len("```diff\n")}),
-					},
 					DiffPreview: &MatchedString{
 						Content:       diffContent,
 						MatchedRanges: Ranges{addedRange},
@@ -141,10 +132,6 @@ func TestSelect(t *testing.T) {
 				selectPath: []string{filter.Commit, "diff", "removed"},
 				output: &CommitMatch{
 					Repo: types.MinimalRepo{Name: "testrepo"},
-					Body: MatchedString{
-						Content:       "```diff\n" + diffContent + "\n```",
-						MatchedRanges: Ranges{removedRange}.Add(Location{Line: 1, Offset: len("```diff\n")}),
-					},
 					DiffPreview: &MatchedString{
 						Content:       diffContent,
 						MatchedRanges: Ranges{removedRange},

--- a/internal/search/streaming/search_filters_test.go
+++ b/internal/search/streaming/search_filters_test.go
@@ -25,11 +25,11 @@ func TestSearchFiltersUpdate(t *testing.T) {
 				{
 					Results: []result.Match{
 						&result.CommitMatch{
-							Repo: repo,
-							Body: result.MatchedString{MatchedRanges: make([]result.Range, 2)}},
+							Repo:           repo,
+							MessagePreview: &result.MatchedString{MatchedRanges: make([]result.Range, 2)}},
 						&result.CommitMatch{
-							Repo: repo,
-							Body: result.MatchedString{MatchedRanges: make([]result.Range, 1)}},
+							Repo:           repo,
+							MessagePreview: &result.MatchedString{MatchedRanges: make([]result.Range, 1)}},
 					},
 				}},
 			wantFilterName:  "repo:^foo$",


### PR DESCRIPTION
Currently, we store the matched content and ranges for commit matches in
two places: in Body, and in either MessagePreview or DiffPreview. This
is problematic because any changes require keeping the two places in
sync. Additionally, it makes it harder to split the CommitMatch type
into the more appropriate CommitMessageMatch and CommitDiffMatch (or
whatever we end up calling them).

This moves the construction of the markdown-formatted body into a method
on the CommitMatch type rather than being pre-computed. This makes it
more clear that it is not a source of truth, and it makes it easier to
rip out for when I eventually get to updating the APIs to return more
general information to the clients (as opposed to pre-formatted markdown
strings).



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
