### PR TITLE
user invites: web: cleanup cloud signup page & fix mobile/small display

### DIFF
--- a/client/web/src/auth/CloudSignUpPage.module.scss
+++ b/client/web/src/auth/CloudSignUpPage.module.scss
@@ -5,19 +5,20 @@
     isolation: isolate;
 }
 
-.header-background-1 {
+.header-background-1,
+.header-background-2,
+.header-background-3 {
+    height: 9.375rem;
+    width: 100%;
     position: absolute;
-    width: 100vw;
     top: 0;
-    bottom: 0;
+
+    @media (--xs-breakpoint-down) {
+        height: 4rem;
+    }
 }
 
-.header-background-2 {
-    position: absolute;
-    width: 100vw;
-    top: 0;
-    bottom: 0;
-
+.header-background-1 {
     :global(.theme-light) & {
         background: radial-gradient(
             72.88% 750.51% at 102.36% 110.93%,
@@ -30,12 +31,7 @@
     mix-blend-mode: multiply;
 }
 
-.header-background-3 {
-    position: absolute;
-    width: 100vw;
-    top: 0;
-    bottom: 0;
-
+.header-background-2 {
     :global(.theme-light) & {
         background: linear-gradient(
             82.41deg,
@@ -48,18 +44,9 @@
     mix-blend-mode: multiply;
 }
 
-.limit-width {
-    max-width: 64rem;
-    margin-left: auto;
-    margin-right: auto;
-    padding-left: 2rem;
-    padding-right: 2rem;
-}
-
 .logo {
     width: 14.0625rem;
     height: 2.375rem;
-    margin-top: 6rem;
     margin-bottom: 1rem;
     position: relative;
 }
@@ -69,6 +56,12 @@
     margin: 0;
     padding-top: 1.5rem;
     padding-bottom: 1rem;
+    white-space: nowrap;
+
+    @media (--xs-breakpoint-down) {
+        display: flex;
+        flex-direction: column;
+    }
 }
 
 .page-heading-invited-by {
@@ -79,18 +72,51 @@
     margin-top: -1.5rem;
 }
 
-.contents {
-    font-size: 1rem;
-    padding-top: 1.75rem;
-    position: relative;
+.left-or-right-container {
+    @media (--md-breakpoint-down) {
+        flex-direction: column;
+        align-items: center;
+    }
+    @media (--xs-breakpoint-down) {
+        margin-bottom: 0 !important;
+    }
 }
 
-.contents-left {
+.left-or-right {
+    height: 100%;
+    margin-top: 6rem;
+    margin-left: 2.5rem;
+    margin-right: 2.5rem;
     max-width: 30rem;
+    font-size: 1rem;
+    z-index: 1;
+
+    @media (--sm-breakpoint-down) {
+        margin-left: 1rem;
+        margin-right: 1rem;
+        max-width: 100%;
+    }
+
+    &:first-of-type {
+        @media (--xs-breakpoint-down) {
+            margin-top: 0.75rem;
+        }
+    }
+    &:last-of-type {
+        @media (--xs-breakpoint-down) {
+            margin-top: 3rem;
+            margin-left: 0;
+            margin-right: 0;
+            margin-bottom: 0 !important;
+        }
+    }
 }
 
 .feature-list {
     margin: 2rem 0;
+    @media (--xs-breakpoint-down) {
+        margin-left: -1rem;
+    }
 }
 
 .companies-header {
@@ -98,25 +124,23 @@
     margin-bottom: 2rem;
 }
 
-.sign-up-wrapper,
-.sign-up-wrapper-invited-by {
-    position: absolute;
-    top: -7.5rem;
-    right: 0;
+.customer-logos {
+    @media (--xs-breakpoint-down) {
+        width: 100%;
+    }
+}
+
+.sign-up-wrapper {
     width: 27.5rem;
     background-color: var(--code-bg);
     box-shadow: 0 2px 10px rgba(0, 27, 76, 0.16);
     border-radius: 0.5rem;
     padding: 3.5rem;
 
-    @media (--sm-breakpoint-down) {
-        position: static;
-        margin-top: 2rem;
+    @media (--xs-breakpoint-down) {
+        width: 100%;
+        border-radius: 0;
     }
-}
-
-.sign-up-wrapper-invited-by {
-    top: -3.5rem;
 }
 
 .sign-up-button {
@@ -174,4 +198,5 @@
 .avatar {
     width: 3rem !important;
     height: 3rem !important;
+    flex-shrink: 0;
 }

--- a/client/web/src/auth/CloudSignUpPage.tsx
+++ b/client/web/src/auth/CloudSignUpPage.tsx
@@ -144,7 +144,7 @@ export const CloudSignUpPage: React.FunctionComponent<Props> = ({
                             invitedBy ? styles.pageHeadingInvitedBy : styles.pageHeading
                         )}
                     >
-                        {invitedBy ? (
+                        {invitedByUser ? (
                             <>
                                 <UserAvatar
                                     className={classNames('icon-inline', 'mr-3', styles.avatar)}

--- a/client/web/src/auth/CloudSignUpPage.tsx
+++ b/client/web/src/auth/CloudSignUpPage.tsx
@@ -128,53 +128,25 @@ export const CloudSignUpPage: React.FunctionComponent<Props> = ({
 
     return (
         <div className={styles.page}>
-            <header>
-                <div className="position-relative">
-                    <div className={styles.headerBackground1} />
-                    <div className={styles.headerBackground2} />
-                    <div className={styles.headerBackground3} />
-
-                    <div className={styles.limitWidth}>
-                        <BrandLogo isLightTheme={isLightTheme} variant="logo" className={styles.logo} />
-                    </div>
-                </div>
-
-                {!invitedBy && (
-                    <div className={styles.limitWidth}>
-                        <h2 className={classNames('d-flex', 'align-items-center', styles.pageHeading)}>{title}</h2>
-                    </div>
-                )}
+            <header className="position-relative">
+                <div className={styles.headerBackground1} />
+                <div className={styles.headerBackground2} />
             </header>
+            <div className={classNames('d-flex', 'justify-content-center', 'mb-5', styles.leftOrRightContainer)}>
+                <div className={styles.leftOrRight}>
+                    <BrandLogo isLightTheme={isLightTheme} variant="logo" className={styles.logo} />
+                    <h2 className={classNames('d-flex', 'align-items-center', 'mb-4', 'mt-1', invitedBy ? styles.pageHeadingInvitedBy : styles.pageHeading)}>
+                        {invitedBy ? <>
+                            <UserAvatar
+                                    className={classNames('icon-inline', 'mr-3', styles.avatar)}
+                                    user={invitedByUser}
+                                />
+                                <strong className="mr-1">{invitedBy}</strong> has invited you to join
+                                Sourcegraph
+                        </> : title }
+                    </h2>
 
-            <div className={classNames(styles.contents, styles.limitWidth)}>
-                <div className={styles.contentsLeft}>
-                    {invitedByUser ? (
-                        <>
-                            <h2
-                                className={classNames(
-                                    'd-flex',
-                                    'align-items-center',
-                                    invitedByUser ? styles.pageHeadingInvitedBy : styles.pageHeading
-                                )}
-                            >
-                                {invitedByUser ? (
-                                    <>
-                                        <UserAvatar
-                                            className={classNames('icon-inline', 'mr-3', styles.avatar)}
-                                            user={invitedByUser}
-                                        />
-                                        <strong className="mr-1">{invitedBy}</strong> has invited you to join
-                                        Sourcegraph
-                                    </>
-                                ) : (
-                                    title
-                                )}
-                            </h2>
-                            With a Sourcegraph account, you can:
-                        </>
-                    ) : (
-                        'With a Sourcegraph account, you can also:'
-                    )}
+                    {invitedBy ? 'With a Sourcegraph account, you can:' : 'With a Sourcegraph account, you can also:'}
                     <ul className={styles.featureList}>
                         <li>
                             <div className="d-flex align-items-center">
@@ -192,10 +164,11 @@ export const CloudSignUpPage: React.FunctionComponent<Props> = ({
                     <img
                         src={`${assetsRoot}/img/customer-logos-${isLightTheme ? 'light' : 'dark'}.svg`}
                         alt="Cloudflare, Uber, SoFi, Dropbox, Plaid, Toast"
+                        className={styles.customerLogos}
                     />
                 </div>
 
-                <div className={invitedBy ? styles.signUpWrapperInvitedBy : styles.signUpWrapper}>
+                <div className={classNames(styles.leftOrRight, styles.signUpWrapper)}>
                     <h2>Create a free account</h2>
                     {renderAuthMethod()}
 

--- a/client/web/src/auth/CloudSignUpPage.tsx
+++ b/client/web/src/auth/CloudSignUpPage.tsx
@@ -135,15 +135,26 @@ export const CloudSignUpPage: React.FunctionComponent<Props> = ({
             <div className={classNames('d-flex', 'justify-content-center', 'mb-5', styles.leftOrRightContainer)}>
                 <div className={styles.leftOrRight}>
                     <BrandLogo isLightTheme={isLightTheme} variant="logo" className={styles.logo} />
-                    <h2 className={classNames('d-flex', 'align-items-center', 'mb-4', 'mt-1', invitedBy ? styles.pageHeadingInvitedBy : styles.pageHeading)}>
-                        {invitedBy ? <>
-                            <UserAvatar
+                    <h2
+                        className={classNames(
+                            'd-flex',
+                            'align-items-center',
+                            'mb-4',
+                            'mt-1',
+                            invitedBy ? styles.pageHeadingInvitedBy : styles.pageHeading
+                        )}
+                    >
+                        {invitedBy ? (
+                            <>
+                                <UserAvatar
                                     className={classNames('icon-inline', 'mr-3', styles.avatar)}
                                     user={invitedByUser}
                                 />
-                                <strong className="mr-1">{invitedBy}</strong> has invited you to join
-                                Sourcegraph
-                        </> : title }
+                                <strong className="mr-1">{invitedBy}</strong> has invited you to join Sourcegraph
+                            </>
+                        ) : (
+                            title
+                        )}
                     </h2>
 
                     {invitedBy ? 'With a Sourcegraph account, you can:' : 'With a Sourcegraph account, you can also:'}

--- a/client/web/src/auth/__snapshots__/SignUpPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignUpPage.test.tsx.snap
@@ -7,45 +7,32 @@ exports[`SignUpPage renders sign up page (cloud) 1`] = `
   <div
     class="page"
   >
-    <header>
+    <header
+      class="position-relative"
+    >
       <div
-        class="position-relative"
-      >
-        <div
-          class="headerBackground1"
-        />
-        <div
-          class="headerBackground2"
-        />
-        <div
-          class="headerBackground3"
-        />
-        <div
-          class="limitWidth"
-        >
-          <img
-            alt="Sourcegraph logo"
-            class="logo"
-            src="/img/sourcegraph-logo-light.svg"
-          />
-        </div>
-      </div>
+        class="headerBackground1"
+      />
       <div
-        class="limitWidth"
+        class="headerBackground2"
+      />
+    </header>
+    <div
+      class="d-flex justify-content-center mb-5 leftOrRightContainer"
+    >
+      <div
+        class="leftOrRight"
       >
+        <img
+          alt="Sourcegraph logo"
+          class="logo"
+          src="/img/sourcegraph-logo-light.svg"
+        />
         <h2
-          class="d-flex align-items-center pageHeading"
+          class="d-flex align-items-center mb-4 mt-1 pageHeading"
         >
           Easily search the code you care about.
         </h2>
-      </div>
-    </header>
-    <div
-      class="contents limitWidth"
-    >
-      <div
-        class="contentsLeft"
-      >
         With a Sourcegraph account, you can also:
         <ul
           class="featureList"
@@ -80,11 +67,12 @@ exports[`SignUpPage renders sign up page (cloud) 1`] = `
         </div>
         <img
           alt="Cloudflare, Uber, SoFi, Dropbox, Plaid, Toast"
+          class="customerLogos"
           src="/img/customer-logos-light.svg"
         />
       </div>
       <div
-        class="signUpWrapper"
+        class="leftOrRight signUpWrapper"
       >
         <h2>
           Create a free account


### PR DESCRIPTION
This change does 3 things:

1. Cleans up the negative messy HTML/CSS previously used on this page (useless divs, negative margins, fixed positioning, etc.)
2. Fixes mobile displays
3. Fixes small/medium displays

No effective change on regular/laptop display sizes.

## Fixes mobile displays

iPhone 11 pro, before:

<img src="https://user-images.githubusercontent.com/3173176/150040097-c0977898-08f6-4459-913e-855356a3af87.png" width="300px">

after:

<img src="https://user-images.githubusercontent.com/3173176/150040175-ec552616-e72e-4fa0-8745-8979a31ab139.png" width="300px">

Bottom of page [before](https://user-images.githubusercontent.com/3173176/150040137-302b88c3-8c39-4073-91de-c78be46abb9e.png) | [after](https://user-images.githubusercontent.com/3173176/150040216-d9768576-4211-4b75-b2a3-dbfec0ae8712.png)

## Fixes small/medium displays

Before:

<img width="788" alt="image" src="https://user-images.githubusercontent.com/3173176/150042374-321b2d2f-eedb-4d92-b2d5-1dee2c2f05a1.png">

After:

<img width="788" alt="image" src="https://user-images.githubusercontent.com/3173176/150042354-d20b0973-8145-434b-b342-bc048a2e6d0c.png">

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
