### PR TITLE
search: preserve annotation data when substituting context

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -179,11 +179,12 @@ func overrideSearchType(input string, searchType query.SearchType) query.SearchT
 
 func substituteSearchContexts(ctx context.Context, db database.DB, plan query.Plan) (query.Plan, error) {
 	errs := new(multierror.Error)
-	dnf := query.Dnf(query.MapParameter(plan.ToParseTree(), func(field, value string, negated bool, a query.Annotation) query.Node {
+	dnf := query.Dnf(query.MapParameter(plan.ToParseTree(), func(field, value string, negated bool, ann query.Annotation) query.Node {
 		p := query.Parameter{
-			Value:   value,
-			Field:   field,
-			Negated: negated,
+			Value:      value,
+			Field:      field,
+			Negated:    negated,
+			Annotation: ann,
 		}
 
 		if field != query.FieldContext {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/29897

Since this is a fix for an experimental feature, that would have been caught by integration tests were it not experimental, and since there is no existing test for this substitution function, I am punting.