### PR TITLE
search: track type and index of selected search results

### DIFF
--- a/client/branded/src/components/panel/views/FileLocations.tsx
+++ b/client/branded/src/components/panel/views/FileLocations.tsx
@@ -154,7 +154,7 @@ export class FileLocations extends React.PureComponent<Props, State> {
                     items={orderedURIs}
                     renderItem={(
                         item: OrderedURI,
-                        _index: number,
+                        index: number,
                         additionalProps: { locationsByURI: Map<string, Location[]> }
                     ) => this.renderFileMatch(item, additionalProps)}
                     itemProps={{ locationsByURI }}

--- a/client/branded/src/components/panel/views/FileLocations.tsx
+++ b/client/branded/src/components/panel/views/FileLocations.tsx
@@ -152,7 +152,11 @@ export class FileLocations extends React.PureComponent<Props, State> {
                     itemsToShow={this.state.itemsToShow}
                     onShowMoreItems={this.onShowMoreItems}
                     items={orderedURIs}
-                    renderItem={this.renderFileMatch}
+                    renderItem={(
+                        item: OrderedURI,
+                        _index: number,
+                        additionalProps: { locationsByURI: Map<string, Location[]> }
+                    ) => this.renderFileMatch(item, additionalProps)}
                     itemProps={{ locationsByURI }}
                     itemKey={this.itemKey}
                 />

--- a/client/search-ui/src/components/SearchResult.tsx
+++ b/client/search-ui/src/components/SearchResult.tsx
@@ -21,9 +21,10 @@ interface Props extends PlatformContextProps<'requestGraphQL'> {
     result: CommitMatch | RepositoryMatch
     repoName: string
     icon: React.ComponentType<{ className?: string }>
+    onSelect: () => void
 }
 
-export const SearchResult: React.FunctionComponent<Props> = ({ result, icon, repoName, platformContext }) => {
+export const SearchResult: React.FunctionComponent<Props> = ({ result, icon, repoName, platformContext, onSelect }) => {
     const renderTitle = (): JSX.Element => {
         const formattedRepositoryStarCount = formatRepositoryStarCount(result.repoStars)
         return (
@@ -127,6 +128,7 @@ export const SearchResult: React.FunctionComponent<Props> = ({ result, icon, rep
             defaultExpanded={true}
             title={renderTitle()}
             resultType={result.type}
+            onResultClicked={onSelect}
             expandedChildren={renderBody()}
         />
     )

--- a/client/search-ui/src/results/StreamingSearchResultsList.tsx
+++ b/client/search-ui/src/results/StreamingSearchResultsList.tsx
@@ -71,10 +71,18 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
     const resultsNumber = results?.results.length || 0
     const { itemsToShow, handleBottomHit } = useItemsToShow(location.search, resultsNumber)
 
-    const logSearchResultClicked = useCallback(() => telemetryService.log('SearchResultClicked'), [telemetryService])
+    const logSearchResultClicked = useCallback(
+        (index: number, type: string) => {
+            telemetryService.log('SearchResultClicked')
+
+            // This data ends up in Prometheus and is not part of the ping payload.
+            telemetryService.log('search.ranking.result-clicked', { index, type })
+        },
+        [telemetryService]
+    )
 
     const renderResult = useCallback(
-        (result: SearchMatch): JSX.Element => {
+        (result: SearchMatch, index: number): JSX.Element => {
             switch (result.type) {
                 case 'content':
                 case 'path':
@@ -85,7 +93,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
                             telemetryService={telemetryService}
                             icon={getFileMatchIcon(result)}
                             result={result}
-                            onSelect={logSearchResultClicked}
+                            onSelect={() => logSearchResultClicked(index, 'fileMatch')}
                             expanded={false}
                             showAllMatches={false}
                             allExpanded={allExpanded}
@@ -101,6 +109,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
                             result={result}
                             repoName={result.repository}
                             platformContext={platformContext}
+                            onSelect={() => logSearchResultClicked(index, 'commit')}
                         />
                     )
                 case 'repo':
@@ -110,6 +119,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
                             result={result}
                             repoName={result.repository}
                             platformContext={platformContext}
+                            onSelect={() => logSearchResultClicked(index, 'repo')}
                         />
                     )
             }

--- a/client/shared/src/components/VirtualList.tsx
+++ b/client/shared/src/components/VirtualList.tsx
@@ -8,7 +8,7 @@ interface Props<TItem, TExtraItemProps> {
     /* Additional props passed to the render function. */
     itemProps: TExtraItemProps
     /* Function to render an item once it becomes visible. */
-    renderItem: (item: TItem, additionalProps: TExtraItemProps) => JSX.Element
+    renderItem: (item: TItem, index: number, additionalProps: TExtraItemProps) => JSX.Element
     /* Determines the list key of an item. Needed for stable react array rendering. */
     itemKey: (item: TItem) => string
 
@@ -60,7 +60,7 @@ export class VirtualList<TItem, TExtraItemProps = undefined> extends React.PureC
                         containment={this.props.containment}
                         partialVisibility={true}
                     >
-                        {this.props.renderItem(item, this.props.itemProps)}
+                        {this.props.renderItem(item, index, this.props.itemProps)}
                     </VisibilitySensor>
                 ))}
             </div>


### PR DESCRIPTION
The goal of this PR is to track the quality of our ranking over time.

We send the type and index of the selected search result to Prometheus. The data is not persisted in Postgres and is not part of the ping data. This is a very basic measure to get us started. In a follow-up PR we will add a Grafana dashboard to visualize the average position of a selected search result as well as the distribution of search result types.

Note: We only track clicks on top-level items (file match, diff/commit, repo) for now and not individual line matches.  

The commits are split in frontend and backend changes and can be reviewed separately.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
