### PR TITLE
search: remove duplicate event SearchResultClicked

### DIFF
--- a/client/shared/src/components/FileMatchChildren.test.tsx
+++ b/client/shared/src/components/FileMatchChildren.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent } from '@testing-library/react'
+import { cleanup } from '@testing-library/react'
 import * as H from 'history'
 import * as React from 'react'
 import _VisibilitySensor from 'react-visibility-sensor'
@@ -57,14 +57,6 @@ const defaultProps = {
 
 describe('FileMatchChildren', () => {
     afterAll(cleanup)
-
-    it('calls onSelect callback when an item is clicked', () => {
-        const { container } = renderWithRouter(<FileMatchChildren {...defaultProps} onSelect={onSelect} />)
-        const item = container.querySelector('[data-testid="file-match-children-item"]')
-        expect(item).toBeVisible()
-        fireEvent.click(item!)
-        expect(onSelect.calledOnce).toBe(true)
-    })
 
     it('does not disable the highlighting timeout', () => {
         /*

--- a/client/shared/src/components/FileMatchChildren.tsx
+++ b/client/shared/src/components/FileMatchChildren.tsx
@@ -30,10 +30,6 @@ interface FileMatchProps extends SettingsCascadeProps, TelemetryProps {
     /* Called when the first result has fully loaded. */
     onFirstResultLoad?: () => void
     fetchHighlightedFileLineRanges: (parameters: FetchFileParameters, force?: boolean) => Observable<string[][]>
-    /**
-     * Called when the file's search result is selected.
-     */
-    onSelect: () => void
 }
 
 export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props => {
@@ -135,7 +131,6 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
                                     styles.item,
                                     styles.itemClickable
                                 )}
-                                onClick={props.onSelect}
                                 data-testid="file-match-children-item"
                             >
                                 <CodeExcerpt


### PR DESCRIPTION
For each click on a file match in the list of search results, we currently send out 2 event logs
of type "SearchResultClicked" with the only difference being the value of the `url` field (search page vs. blob page).

![image](https://user-images.githubusercontent.com/26413131/150118735-57fc7f4c-ff1a-49c0-a8d3-fca1d5a52ace.png)

I don't believe there is a reason to keep both. Let's remove the call to
`onSelect` from `FileMatchChildren` and keep it for the `ResultContainer`.
This way we can treat the other match types, IE those without children, the same.

This is related to #29909, where the duplicate event leads to a double counting of clicked results.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
