### PR TITLE
web: Add tracking to batch changes cloud landing page

### DIFF
--- a/client/web/src/enterprise/batches/global/DotcomGettingStartedPage.tsx
+++ b/client/web/src/enterprise/batches/global/DotcomGettingStartedPage.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import React from 'react'
+import React, { useEffect } from 'react'
 
 import { PageHeader } from '@sourcegraph/wildcard'
 
@@ -7,6 +7,7 @@ import { BatchChangesIcon } from '../../../batches/icons'
 import { CtaBanner } from '../../../components/CtaBanner'
 import { Page } from '../../../components/Page'
 import { PageTitle } from '../../../components/PageTitle'
+import { eventLogger } from '../../../tracking/eventLogger'
 import { GettingStarted } from '../list/GettingStarted'
 
 import styles from './DotcomGettingStartedPage.module.scss'
@@ -15,17 +16,21 @@ export interface DotcomGettingStartedPageProps {
     // Nothing for now.
 }
 
-export const DotcomGettingStartedPage: React.FunctionComponent<DotcomGettingStartedPageProps> = () => (
-    <Page>
-        <PageTitle title="Batch Changes" />
-        <PageHeader
-            path={[{ icon: BatchChangesIcon, text: 'Batch Changes' }]}
-            description="Run custom code over hundreds of repositories and manage the resulting changesets."
-            className="mb-3"
-        />
-        <GettingStarted footer={<DotcomGettingStartedPageFooter />} />
-    </Page>
-)
+export const DotcomGettingStartedPage: React.FunctionComponent<DotcomGettingStartedPageProps> = () => {
+    useEffect(() => eventLogger.logViewEvent('BatchChangesCloudLandingPage'), [])
+
+    return (
+        <Page>
+            <PageTitle title="Batch Changes" />
+            <PageHeader
+                path={[{ icon: BatchChangesIcon, text: 'Batch Changes' }]}
+                description="Run custom code over hundreds of repositories and manage the resulting changesets."
+                className="mb-3"
+            />
+            <GettingStarted footer={<DotcomGettingStartedPageFooter />} />
+        </Page>
+    )
+}
 
 const DotcomGettingStartedPageFooter: React.FunctionComponent<{}> = () => (
     <div className="d-flex justify-content-between">
@@ -45,9 +50,10 @@ const DotcomGettingStartedPageFooter: React.FunctionComponent<{}> = () => (
             bodyText="Batch Changes requires a local Sourcegraph installation. You can check it out for free by installing with a single line of code."
             title="Install locally to get started"
             linkText="Install local instance"
-            href="https://docs.sourcegraph.com/admin/install"
+            href="https://docs.sourcegraph.com/admin/install?utm_medium=inproduct&utm_source=inproduct-batch-changes&utm_campaign=inproduct-batch-changes&term="
             icon={<DownloadSourcegraphIcon />}
             className="ml-3"
+            onClick={() => eventLogger.log('BatchChangesInstallFromCloudClicked')}
         />
     </div>
 )


### PR DESCRIPTION
Fixes #29860

- Added a view event for the batch changes cloud landing page (`ViewBatchChangesCloudLandingPage` to be consistent with the other pages)
- Added a new event when the CTA button is clicked `BatchChangesInstallFromCloudClicked`
- Added the UTM campaign to the CTA button (as described in #29860)

You can see all changes on this screenshot:

![Screenshot 2022-01-19 at 16 29 39](https://user-images.githubusercontent.com/458591/150163423-272997a7-df70-456c-b48b-69140b0498bc.png)