### PR TITLE
git: Apply sub-repo permissions to git.ArchiveReader

### DIFF
--- a/cmd/frontend/internal/app/ui/raw.go
+++ b/cmd/frontend/internal/app/ui/raw.go
@@ -182,7 +182,7 @@ func serveRaw(db database.DB) handlerFunc {
 			// caching locally is not useful. Additionally we transfer the output over the
 			// internet, so we use default compression levels on zips (instead of no
 			// compression).
-			f, err := git.ArchiveReader(r.Context(), common.Repo.Name, format, common.CommitID, relativePath)
+			f, err := git.ArchiveReader(r.Context(), authz.DefaultSubRepoPermsChecker, common.Repo.Name, format, common.CommitID, relativePath)
 			if err != nil {
 				return err
 			}

--- a/internal/vcs/git/archive.go
+++ b/internal/vcs/git/archive.go
@@ -33,7 +33,7 @@ func ArchiveReader(
 	relativePath string,
 ) (io.ReadCloser, error) {
 	a := actor.FromContext(ctx)
-	if checker != nil && checker.Enabled() && a.IsAuthenticated() {
+	if authz.SubRepoEnabled(checker) && a.IsAuthenticated() {
 		return nil, errors.New("ArchiveReader invoked by user on a repo with sub-repo permissions")
 	}
 	cmd := gitserver.DefaultClient.Command("git", "archive", "--format="+string(format), string(commit), relativePath)

--- a/internal/vcs/git/archive.go
+++ b/internal/vcs/git/archive.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"io"
 
+	"github.com/cockroachdb/errors"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 )
 
@@ -20,7 +24,18 @@ const (
 )
 
 // ArchiveReader streams back the file contents of an archived git repo.
-func ArchiveReader(ctx context.Context, repo api.RepoName, format ArchiveFormat, commit api.CommitID, relativePath string) (io.ReadCloser, error) {
+func ArchiveReader(
+	ctx context.Context,
+	checker authz.SubRepoPermissionChecker,
+	repo api.RepoName,
+	format ArchiveFormat,
+	commit api.CommitID,
+	relativePath string,
+) (io.ReadCloser, error) {
+	a := actor.FromContext(ctx)
+	if checker != nil && checker.Enabled() && a.IsAuthenticated() {
+		return nil, errors.New("ArchiveReader invoked by user on a repo with sub-repo permissions")
+	}
 	cmd := gitserver.DefaultClient.Command("git", "archive", "--format="+string(format), string(commit), relativePath)
 	cmd.Repo = repo
 	return gitserver.StdoutReader(ctx, cmd)

--- a/internal/vcs/git/archive_test.go
+++ b/internal/vcs/git/archive_test.go
@@ -1,0 +1,60 @@
+package git
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
+)
+
+func TestArchiveReader(t *testing.T) {
+	repo := MakeGitRepository(t,
+		"echo abcd > file1",
+		"git add file1",
+		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit -m commit1 --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
+	)
+	const commitID = "3d689662de70f9e252d4f6f1d75284e23587d670"
+
+	checker := authz.NewMockSubRepoPermissionChecker()
+	checker.EnabledFunc.SetDefaultHook(func() bool {
+		return true
+	})
+	checker.PermissionsFunc.SetDefaultHook(func(ctx context.Context, i int32, content authz.RepoContent) (authz.Perms, error) {
+		return authz.None, nil
+	})
+
+	ctx := actor.WithActor(context.Background(), &actor.Actor{
+		UID: 1,
+	})
+
+	if _, err := ArchiveReader(ctx, checker, repo, ArchiveFormatZip, commitID, "."); err == nil {
+		t.Error("Error should be thrown because ArchiveReader invoked by user on a repo with sub-repo permissions")
+	}
+}
+
+func TestArchiveReaderNotUserRequest(t *testing.T) {
+	repo := MakeGitRepository(t,
+		"echo abcd > file1",
+		"git add file1",
+		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit -m commit1 --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
+	)
+	const commitID = "3d689662de70f9e252d4f6f1d75284e23587d670"
+
+	checker := authz.NewMockSubRepoPermissionChecker()
+	checker.EnabledFunc.SetDefaultHook(func() bool {
+		return true
+	})
+	checker.PermissionsFunc.SetDefaultHook(func(ctx context.Context, i int32, content authz.RepoContent) (authz.Perms, error) {
+		return authz.None, nil
+	})
+
+	readCloser, err := ArchiveReader(context.Background(), checker, repo, ArchiveFormatZip, commitID, ".")
+	if err != nil {
+		t.Error("Error should be thrown because ArchiveReader invoked by user on a repo with sub-repo permissions")
+	}
+	err = readCloser.Close()
+	if err != nil {
+		t.Error("Error during closing a reader")
+	}
+}


### PR DESCRIPTION
Since we don't have a valid use case for an end-user to request an entire archive of a repo, sub-repo permissions check returns an error if the context indicates this is a user request.

Closes https://github.com/sourcegraph/sourcegraph/issues/27332

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
