### PR TITLE
auth: Update executor auth tests

### DIFF
--- a/dev/authtest/code_intel_test.go
+++ b/dev/authtest/code_intel_test.go
@@ -145,6 +145,8 @@ func TestCodeIntelEndpoints(t *testing.T) {
 		cleanup := setExecutorAccessToken(t, "hunter2hunter2hunter2")
 		defer cleanup()
 
+		time.Sleep(time.Second * 10)
+
 		resp, err := userClient.Get(*baseURL + "/.executors/")
 		if err != nil {
 			t.Fatal(err)

--- a/dev/authtest/code_intel_test.go
+++ b/dev/authtest/code_intel_test.go
@@ -121,7 +121,8 @@ func TestCodeIntelEndpoints(t *testing.T) {
 		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode/100 != 4 {
-			t.Fatalf(`Want status code 4xx error but got %d`, resp.StatusCode)
+			payload, _ := io.ReadAll(resp.Body)
+			t.Fatalf(`Want status code 4xx error but got %d (%v)`, resp.StatusCode, payload)
 		}
 	})
 }

--- a/dev/authtest/code_intel_test.go
+++ b/dev/authtest/code_intel_test.go
@@ -134,7 +134,7 @@ func TestCodeIntelEndpoints(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		expectedText := "executors.accessToken not configured in site config"
+		expectedText := "Executors are not configured on this instance"
 		if !strings.Contains(string(response), expectedText) {
 			t.Fatalf(`Expected different failure. want=%q got=%q`, expectedText, string(response))
 		}

--- a/dev/authtest/code_intel_test.go
+++ b/dev/authtest/code_intel_test.go
@@ -127,7 +127,10 @@ func TestCodeIntelEndpoints(t *testing.T) {
 		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode/100 != 4 {
-			payload, _ := io.ReadAll(resp.Body)
+			payload, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
 			t.Fatalf(`Want status code 4xx error but got %d (%v)`, resp.StatusCode, payload)
 		}
 	})

--- a/dev/authtest/code_intel_test.go
+++ b/dev/authtest/code_intel_test.go
@@ -115,9 +115,10 @@ func TestCodeIntelEndpoints(t *testing.T) {
 		}
 	})
 
-	t.Run("executor endpoints (no access not configured configured)", func(t *testing.T) {
+	t.Run("executor endpoints (access token not configured)", func(t *testing.T) {
 		// Update site configuration to remove any executor access token.
-		defer setExecutorAccessToken(t, "")()
+		cleanup := setExecutorAccessToken(t, "")
+		defer cleanup()
 
 		resp, err := userClient.Get(*baseURL + "/.executors/")
 		if err != nil {
@@ -141,7 +142,8 @@ func TestCodeIntelEndpoints(t *testing.T) {
 
 	t.Run("executor endpoints (access token configured but not supplied)", func(t *testing.T) {
 		// Update site configuration to set the executor access token.
-		defer setExecutorAccessToken(t, "hunter2hunter2hunter2")()
+		cleanup := setExecutorAccessToken(t, "hunter2hunter2hunter2")
+		defer cleanup()
 
 		resp, err := userClient.Get(*baseURL + "/.executors/")
 		if err != nil {

--- a/dev/authtest/code_intel_test.go
+++ b/dev/authtest/code_intel_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestCodeIntelEndpoints(t *testing.T) {
-
 	// Create a test user (authtest-user-code-intel) which is not a site admin, the
 	// user should receive access denied for LSIF endpoints of repositories the user
 	// does not have access to.

--- a/dev/authtest/code_intel_test.go
+++ b/dev/authtest/code_intel_test.go
@@ -3,6 +3,7 @@ package authtest
 import (
 	"bytes"
 	"io"
+	"net/http"
 	"testing"
 	"time"
 
@@ -114,7 +115,12 @@ func TestCodeIntelEndpoints(t *testing.T) {
 	})
 
 	t.Run("executor endpoints", func(t *testing.T) {
-		resp, err := userClient.Get(*baseURL + "/.executors/")
+		req, err := http.NewRequest("GET", *baseURL+"/.executors/", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/enterprise/cmd/frontend/internal/executorqueue/queuehandler.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queuehandler.go
@@ -63,7 +63,7 @@ const SchemeExecutorToken = "token-executor"
 func validateExecutorToken(w http.ResponseWriter, r *http.Request, expectedAccessToken string) bool {
 	if expectedAccessToken == "" {
 		log15.Error("executors.accessToken not configured in site config")
-		w.WriteHeader(http.StatusInternalServerError)
+		http.Error(w, "Executors are not configured on this instance", http.StatusInternalServerError)
 		return false
 	}
 


### PR DESCRIPTION
c43eb41b9973128477def452910a9b9ecdd2b09b changed the way auth is accepted in the executors. This change in code revealed a test that never set a valid token for executors to begin with.