### PR TITLE
buildchecker: require explicit 'check', add discussion channel

### DIFF
--- a/.github/workflows/buildchecker.yml
+++ b/.github/workflows/buildchecker.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-go@v2
         with: { go-version: '1.17' }
 
-      - run: ./dev/buildchecker/run.sh
+      - run: ./dev/buildchecker/run-check.sh
         env:
           GITHUB_TOKEN: ${{ secrets.AUTOBUILDSHERRIF_GITHUB_TOKEN }}
           BUILDKITE_TOKEN: ${{ secrets.AUTOBUILDSHERRIF_BUILDKITE_TOKEN }}

--- a/dev/buildchecker/README.md
+++ b/dev/buildchecker/README.md
@@ -7,20 +7,31 @@ More documentation for Sourcegraph teammates is available in the[CI incidents pl
 
 ## Usage
 
+Available commands:
+
+- [`buildchecker check`](#check)
+- [`buildchecker history`](#history)
+
+### Check
+
+Checks for a series of build failures that exceed the configured threshold, locks the target branch, and posts various updates to Slack.
+
 ```sh
-go run ./dev/buildchecker/ # directly
-./dev/buildchecker/run.sh  # using wrapper script
+go run ./dev/buildchecker/ check # directly
+./dev/buildchecker/run-check.sh  # using wrapper script
 ```
 
-Also see the [`buildchecker` GitHub Action workflow](../../.github/workflows/buildchecker.yml) where this program is run on an automated basis.
+Also see the [`buildchecker` GitHub Action workflow](../../.github/workflows/buildchecker.yml) where `buildchecker check` is run on an automated basis.
 
 ### History
+
+Writes aggregated historical data, including the builds it finds, to a few files.
 
 ```sh
 go run ./dev/buildchecker -buildkite.token=$BUILDKITE_TOKEN -failures.timeout=999 -created.from="2021-08-01" history
 ```
 
-Writes aggregated data, including the builds it finds, to a few files. To load builds from a file instead of fetching from Buildkite, use `-load-from="$FILE"`.
+To load builds from a file instead of fetching from Buildkite, use `-load-from="$FILE"`.
 
 ## Development
 

--- a/dev/buildchecker/run-check.sh
+++ b/dev/buildchecker/run-check.sh
@@ -5,10 +5,11 @@ cd "$(dirname "${BASH_SOURCE[0]}")"/../..
 
 set -eu
 
-echo "--- Running buildchecker"
+echo "--- Running 'buildchecker check'"
 go run ./dev/buildchecker/ \
   -buildkite.token="$BUILDKITE_TOKEN" \
   -github.token="$GITHUB_TOKEN" \
   -slack.announce-webhook="$SLACK_ANNOUNCE_WEBHOOK" \
   -slack.debug-webhook="$SLACK_DEBUG_WEBHOOK" \
-  -slack.token="$SLACK_TOKEN"
+  -slack.token="$SLACK_TOKEN" \
+  check

--- a/dev/buildchecker/slack.go
+++ b/dev/buildchecker/slack.go
@@ -16,7 +16,7 @@ func slackMention(slackUserID string) string {
 	return fmt.Sprintf("<@%s>", slackUserID)
 }
 
-func slackSummary(locked bool, branch string, failedCommits []CommitInfo) string {
+func slackSummary(locked bool, branch string, discussionChannel string, failedCommits []CommitInfo) string {
 	branchStr := fmt.Sprintf("`%s`", branch)
 	if !locked {
 		return fmt.Sprintf(":white_check_mark: Pipeline healthy - %s unlocked!", branchStr)
@@ -41,13 +41,15 @@ The authors of the following failed commits who are Sourcegraph teammates have b
 		message += fmt.Sprintf("\n- <https://github.com/sourcegraph/sourcegraph/commit/%s|%.7s> (<%s|build %d>): %s",
 			commit.Commit, commit.Commit, commit.BuildURL, commit.BuildNumber, mention)
 	}
-	message += `
+	message += fmt.Sprintf(`
 
-The branch will automatically be unlocked once a green build is run.
+The branch will automatically be unlocked once a green build has run on %s.
+Please head over to %s for relevant discussion about this branch lock.
 Refer to the <https://handbook.sourcegraph.com/departments/product-engineering/engineering/process/incidents/playbooks/ci|CI incident playbook> for help.
+
 If unable to resolve the issue, please start an incident with the '/incident' Slack command.
 
-cc: @dev-experience-support`
+cc: @dev-experience-support`, branchStr, discussionChannel)
 	return message
 }
 

--- a/dev/buildchecker/slack_test.go
+++ b/dev/buildchecker/slack_test.go
@@ -11,14 +11,14 @@ import (
 // 	go test -timeout 30s -run ^TestSlackSummary$ github.com/sourcegraph/sourcegraph/dev/buildchecker -v
 func TestSlackSummary(t *testing.T) {
 	t.Run("unlocked", func(t *testing.T) {
-		s := slackSummary(false, "main", []CommitInfo{})
+		s := slackSummary(false, "main", "#buildkite-main", []CommitInfo{})
 		t.Log(s)
 		assert.Contains(t, s, "unlocked")
 		assert.Contains(t, s, "main")
 	})
 
 	t.Run("locked", func(t *testing.T) {
-		s := slackSummary(true, "main", []CommitInfo{
+		s := slackSummary(true, "main", "#buildkite-main", []CommitInfo{
 			{Commit: "a", Author: "bob", AuthorSlackID: "123", BuildNumber: 3, BuildURL: "https://sourcegraph.com", BuildCreated: time.Now()},
 			{Commit: "b", Author: "alice", AuthorSlackID: "124", BuildNumber: 2, BuildURL: "https://sourcegraph.com", BuildCreated: time.Now().Add(-1)},
 			{Commit: "c", Author: "no_slack", AuthorSlackID: "", BuildNumber: 1, BuildURL: "https://sourcegraph.com", BuildCreated: time.Now().Add(-2)},
@@ -37,5 +37,7 @@ func TestSlackSummary(t *testing.T) {
 		assert.Contains(t, s, "build 2")
 		assert.Contains(t, s, "build 3")
 		assert.Contains(t, s, "https://sourcegraph.com")
+		// Mention the slack channel for discussion
+		assert.Contains(t, s, "#buildkite-main")
 	})
 }


### PR DESCRIPTION
- require the `check` argument when running the buildchecker
- ask everyone to go to #buildkite-main for discussion

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
