### PR TITLE
gqltest: Lower timeout for settings to be available

### DIFF
--- a/dev/authtest/code_intel_test.go
+++ b/dev/authtest/code_intel_test.go
@@ -145,7 +145,8 @@ func TestCodeIntelEndpoints(t *testing.T) {
 		cleanup := setExecutorAccessToken(t, "hunter2hunter2hunter2")
 		defer cleanup()
 
-		time.Sleep(time.Second * 10)
+		// sleep 5s to wait for site configuration to be restored from gqltest
+		time.Sleep(5 * time.Second)
 
 		resp, err := userClient.Get(*baseURL + "/.executors/")
 		if err != nil {


### PR DESCRIPTION
I just decreased our build time by FIVE SECONDS. This timeout better matches what's there in the bash script for the same reason.