### PR TITLE
search: reenable and/or integration tests

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -967,8 +967,6 @@ func testSearchClient(t *testing.T, client searchClient) {
 	})
 
 	t.Run("And/Or search expression queries", func(t *testing.T) {
-		t.Skip("Flakey test https://github.com/sourcegraph/sourcegraph/issues/29828")
-
 		tests := []struct {
 			name            string
 			query           string
@@ -1013,16 +1011,26 @@ func testSearchClient(t *testing.T, client searchClient) {
 				query: `(repo:^github\.com/sgtest/sourcegraph-typescript$ or repo:^github\.com/sgtest/go-diff$) package diff provides`,
 			},
 			{
-				name:            `Or distributive property on commits deduplicates and merges`,
-				query:           `repo:^github\.com/sgtest/go-diff$ type:commit (message:add or message:file)`,
-				exactMatchCount: 30,
-				skip:            skipStream,
+				name:  `Or distributive property on commits deduplicates and merges`,
+				query: `repo:^github\.com/sgtest/go-diff$ type:commit (message:add or message:file)`,
+				skip:  skipStream,
 			},
 			{
-				name:            `Exact default count is respected in OR queries`,
-				query:           `foo OR bar OR (type:repo diff)`,
-				exactMatchCount: 30,
+				name:  `Exact default count is respected in OR queries`,
+				query: `foo OR bar OR (type:repo diff)`,
 			},
+			// Flakey test for exactMatchCount due to bug https://github.com/sourcegraph/sourcegraph/issues/29828
+			// {
+			//	name:            `Or distributive property on commits deduplicates and merges`,
+			//	query:           `repo:^github\.com/sgtest/go-diff$ type:commit (message:add or message:file)`,
+			//	exactMatchCount: 30,
+			//	skip:            skipStream,
+			// },
+			// {
+			//	name:            `Exact default count is respected in OR queries`,
+			//	query:           `foo OR bar OR (type:repo diff)`,
+			//	exactMatchCount: 30,
+			// },
 		}
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Let's not disable all the tests because of https://github.com/sourcegraph/sourcegraph/issues/29828. Also the issue is with "exactMatchCount", which wasn't something we tested before recent changes.