### PR TITLE
batches: fix exclude repo from workspaces when query is quoted

### DIFF
--- a/client/web/src/enterprise/batches/create/useBatchSpecCode.ts
+++ b/client/web/src/enterprise/batches/create/useBatchSpecCode.ts
@@ -168,7 +168,7 @@ export const useBatchSpecCode = (initialCode: string, name: string): UseBatchSpe
                 setCode(result.spec)
             } else {
                 setUpdateError(
-                    'Unable to update batch spec. Double-check to make sure there are no syntax errors, then try again.' +
+                    'Unable to update batch spec. Double-check to make sure there are no syntax errors, then try again. ' +
                         result.error
                 )
             }

--- a/client/web/src/enterprise/batches/create/yaml-util.test.ts
+++ b/client/web/src/enterprise/batches/create/yaml-util.test.ts
@@ -128,9 +128,9 @@ on:
         expected: 0,
     },
 
-    // Spec with "repositoriesMatchingQuery" => append "-repo:"
+    // Spec with "repositoriesMatchingQuery" => append "-repo:" with escaped dot
     {
-        repo: 'repo1',
+        repo: 'github.com/repo1',
         branch: 'doesnt-matter',
         original: `name: hello-world
 on:
@@ -138,8 +138,23 @@ on:
 `,
         expected: `name: hello-world
 on:
-    - repositoriesMatchingQuery: file:README.md -repo:repo1
+    - repositoriesMatchingQuery: file:README.md -repo:github\\.com/repo1
 `,
+    },
+
+    // Spec with "repositoriesMatchingQuery" with the query captured in quotes => append
+    // "-repo:" without any escaping
+    {
+        repo: 'github.com/repo1',
+        branch: 'doesnt-matter',
+        original: `name: hello-world
+on:
+    - repositoriesMatchingQuery: "file:README.md"
+        `,
+        expected: `name: hello-world
+on:
+    - repositoriesMatchingQuery: "file:README.md -repo:github.com/repo1"
+        `,
     },
 
     // Spec with "repositoriesMatchingQuery" and multiple "repository" directives but repo


### PR DESCRIPTION
The SSBC editor currently throws an error if you try to use the "exclude repo" button from the workspaces preview if your repo query value is quoted. For example, in the following batch spec:

```yaml
name: test-1234
description: Add Hello World to READMEs
on:
  - repositoriesMatchingQuery: "file:README.md count:10"
...
```

Trying to exclude a single repo would throw this error:

> Unable to update batch spec. Double-check to make sure there are no syntax errors, then try again.Could not parse spec after updating "repositoriesMatchingQuery"

This was due to the interpretation of the escape character sequence, which we were applying to the value regardless of whether or not it was quoted. So it would try to add, for example:

![Screen Shot 2022-01-19 at 1 35 23 PM](https://user-images.githubusercontent.com/8942601/150217562-ed2974e0-fd95-45c1-9d05-f87db4ad18e1.png)

which would produce a syntax error.

This PR updates it to only escapes the "-repo:" qualifier if the query value is not quoted, and adds another test.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
