### PR TITLE
Add new PathMatch type

### DIFF
--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -2,9 +2,8 @@ package result
 
 import (
 	"net/url"
-	"strings"
-
 	"path"
+	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"

--- a/internal/search/result/match.go
+++ b/internal/search/result/match.go
@@ -24,6 +24,7 @@ type Match interface {
 // Guard to ensure all match types implement the interface
 var (
 	_ Match = (*FileMatch)(nil)
+	_ Match = (*PathMatch)(nil)
 	_ Match = (*RepoMatch)(nil)
 	_ Match = (*CommitMatch)(nil)
 )
@@ -36,6 +37,7 @@ const (
 	rankCommitMatch = 1
 	rankDiffMatch   = 2
 	rankRepoMatch   = 3
+	rankPathMatch   = 4
 )
 
 // Key is a sorting or deduplicating key for a Match.

--- a/internal/search/result/path.go
+++ b/internal/search/result/path.go
@@ -1,0 +1,59 @@
+package result
+
+import (
+	"github.com/sourcegraph/sourcegraph/internal/search/filter"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+// PathMatch represents a match of the file itself, rather than
+// a match on the content of the file.
+type PathMatch struct {
+	File
+
+	// MatchedPathRanges is a set of ranges of the embedded File.Path
+	// that matched the query.
+	MatchedPathRanges Ranges
+}
+
+func (p *PathMatch) ResultCount() int {
+	return 1
+}
+
+// Limit will mutate p such that it only has limit results. limit is a number
+// greater than 0.
+func (p *PathMatch) Limit(limit int) int {
+	return limit - 1
+}
+
+func (p *PathMatch) Key() Key {
+	k := Key{
+		TypeRank: rankPathMatch,
+		Repo:     p.Repo.Name,
+		Commit:   p.CommitID,
+		Path:     p.Path,
+	}
+	if p.InputRev != nil {
+		k.Rev = *p.InputRev
+	}
+	return k
+}
+
+func (p *PathMatch) Select(selectPath filter.SelectPath) Match {
+	switch selectPath.Root() {
+	case filter.Repository:
+		return &RepoMatch{
+			Name: p.Repo.Name,
+			ID:   p.Repo.ID,
+		}
+	case filter.File:
+		return p
+	default:
+		return nil
+	}
+}
+
+func (p *PathMatch) RepoName() types.MinimalRepo {
+	return p.Repo
+}
+
+func (p *PathMatch) searchResultMarker() {}


### PR DESCRIPTION
This adds a new PathMatch type. It is not used anywhere yet. The next
step will be adding the code at our API boundaries to handle matches of
type PathMatch.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
