### PR TITLE
search: factor out query mapping for search contexts

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/google/zoekt"
-	"github.com/hashicorp/go-multierror"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -73,21 +72,26 @@ func NewSearchImplementer(ctx context.Context, db database.DB, args *SearchArgs)
 		return nil, errors.New("Structural search is disabled in the site configuration.")
 	}
 
+	// Experimental: create a step to replace each context in the query with its repository query if any.
+	searchContextsQueryEnabled := settings.ExperimentalFeatures != nil && getBoolPtr(settings.ExperimentalFeatures.SearchContextsQuery, false)
+	substituteContextsStep := query.SubstituteSearchContexts(func(context string) (string, error) {
+		sc, err := searchcontexts.ResolveSearchContextSpec(ctx, db, context)
+		if err != nil {
+			return "", err
+		}
+		tr.LazyPrintf("substitute query %s for context %s", sc.Query, context)
+		return sc.Query, nil
+	})
+
 	var plan query.Plan
-	plan, err = query.Pipeline(query.Init(args.Query, searchType))
+	plan, err = query.Pipeline(
+		query.Init(args.Query, searchType),
+		query.With(searchContextsQueryEnabled, substituteContextsStep),
+	)
 	if err != nil {
 		return alertForQuery(args.Query, err).wrapSearchImplementer(db), nil
 	}
 	tr.LazyPrintf("parsing done")
-
-	if settings.ExperimentalFeatures != nil && getBoolPtr(settings.ExperimentalFeatures.SearchContextsQuery, false) {
-		// Replace each context in the query with its repository query if any.
-		plan, err = substituteSearchContexts(ctx, db, plan)
-		if err != nil {
-			return alertForQuery(args.Query, err).wrapSearchImplementer(db), nil
-		}
-		tr.LazyPrintf("context substitution done")
-	}
 
 	defaultLimit := defaultMaxSearchResults
 	if args.Stream != nil {
@@ -173,42 +177,6 @@ func overrideSearchType(input string, searchType query.SearchType) query.SearchT
 		}
 	})
 	return searchType
-}
-
-func substituteSearchContexts(ctx context.Context, db database.DB, plan query.Plan) (query.Plan, error) {
-	errs := new(multierror.Error)
-	dnf := query.Dnf(query.MapField(plan.ToParseTree(), query.FieldContext, func(value string, negated bool, ann query.Annotation) query.Node {
-		p := query.Parameter{
-			Value:      value,
-			Field:      query.FieldContext,
-			Negated:    negated,
-			Annotation: ann,
-		}
-
-		sc, err := searchcontexts.ResolveSearchContextSpec(ctx, db, value)
-		if err != nil {
-			errs = multierror.Append(errs, err)
-			return p
-		}
-
-		if sc.Query == "" {
-			return p
-		}
-
-		contextQuery, err := query.Pipeline(query.InitRegexp(sc.Query))
-		if err != nil {
-			errs = multierror.Append(errs, err)
-			return p
-		}
-
-		return contextQuery.ToParseTree()[0]
-	}))
-
-	if err := errs.ErrorOrNil(); err != nil {
-		return nil, err
-	}
-
-	return query.ToPlan(dnf)
 }
 
 func getBoolPtr(b *bool, def bool) bool {

--- a/internal/search/query/query_test.go
+++ b/internal/search/query/query_test.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -49,4 +50,83 @@ func TestPipeline(t *testing.T) {
 	}
 
 	autogold.Want("contains(...) spans newlines", `"repo:contains.file(\nfoo\n)"`).Equal(t, test("repo:contains.file(\nfoo\n)"))
+}
+
+func jsonFormatted(nodes []Node) string {
+	var jsons []interface{}
+	for _, node := range nodes {
+		jsons = append(jsons, toJSON(node))
+	}
+	json, err := json.MarshalIndent(jsons, "", "  ")
+	if err != nil {
+		return ""
+	}
+	return string(json)
+}
+
+func TestSubstituteSearchContexts(t *testing.T) {
+	test := func(input string, verbose bool) string {
+		lookup := func(string) (string, error) {
+			return "repo:primary or repo:secondary", nil
+		}
+		plan, err := Pipeline(InitLiteral(input), SubstituteSearchContexts(lookup))
+		if err != nil {
+			return err.Error()
+		}
+
+		if verbose {
+			return jsonFormatted(plan.ToParseTree())
+		}
+		return plan.ToParseTree().String()
+	}
+
+	autogold.Want("basic", `(or (and "repo:primary" "scamaz") (and "repo:secondary" "scamaz"))`).Equal(t, test("context:gordo scamaz", false))
+
+	autogold.Want("preserve predicate label", `[
+  {
+    "or": [
+      {
+        "and": [
+          {
+            "field": "repo",
+            "value": "primary",
+            "negated": false,
+            "labels": [
+              "None"
+            ]
+          },
+          {
+            "field": "repo",
+            "value": "contains.file(gordo)",
+            "negated": false,
+            "labels": [
+              "IsPredicate"
+            ]
+          }
+        ]
+      },
+      {
+        "and": [
+          {
+            "field": "repo",
+            "value": "secondary",
+            "negated": false,
+            "labels": [
+              "None"
+            ]
+          },
+          {
+            "field": "repo",
+            "value": "contains.file(gordo)",
+            "negated": false,
+            "labels": [
+              "IsPredicate"
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]`).
+		Equal(t, test("context:gordo repo:contains.file(gordo)", true))
 }


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/29951

This factors out the core query transformation parts of `substituteSearchContexts` previously in `search.go`. At the cost of passing a callback, we can embed the substitution in the query plan pipeline. This grants:

- easier to test the core substitution because it abstracts away `ctx`/`db` deps
- easier to promote this query step to the default pipeline once we're ready to turn off the feature flag
- avoids redoing work by taking the existing plan, unrolling it, and rebuilding it with a bunch of function calls to `plan`/`DNF`

It was a bit difficult to spot the possibility of this simplification when I reviewed the original PR, so I couldn't recommend it at the time, sorry about that. The heavy dependence on `query.` functions and the fact that we did a lot of work post-query-pipeline had me thinking there had to be some way like this to achieve something more separable.