### PR TITLE
buildchecker: correctly get build URL

### DIFF
--- a/dev/buildchecker/failures.go
+++ b/dev/buildchecker/failures.go
@@ -45,7 +45,7 @@ func findConsecutiveFailures(
 		}
 		if build.Number != nil {
 			commit.BuildNumber = *build.Number
-			commit.BuildURL = maybeString(build.URL)
+			commit.BuildURL = maybeString(build.WebURL)
 		}
 		if build.CreatedAt != nil {
 			commit.BuildCreated = build.CreatedAt.Time


### PR DESCRIPTION
🤦‍♂️ `build.URL` is a link to the Buildkite API, what we need is `build.WebURL`. Serves me right [for not using code search to check what everyone else is doing](https://sourcegraph.com/search?q=context:%40sourcegraph+/v3/buildkite+AND+%28.WebURL+OR+.URL%29+lang:go&patternType=literal)