### PR TITLE
ssbc: Implement filters and search on workspaces list and preview

### DIFF
--- a/client/web/src/enterprise/batches/ChangesetFilter.tsx
+++ b/client/web/src/enterprise/batches/ChangesetFilter.tsx
@@ -26,11 +26,7 @@ export const ChangesetFilter = <T extends string>({
 
     return (
         <>
-            <select
-                className={classNames('form-control changeset-filter__dropdown', className)}
-                value={selected}
-                onChange={innerOnChange}
-            >
+            <select className={classNames('form-control', className)} value={selected} onChange={innerOnChange}>
                 <option value="">{label}</option>
                 {values.map(state => (
                     <option value={state} key={state}>

--- a/client/web/src/enterprise/batches/create/backend.ts
+++ b/client/web/src/enterprise/batches/create/backend.ts
@@ -94,13 +94,13 @@ export const WORKSPACE_RESOLUTION_STATUS = gql`
 `
 
 export const WORKSPACES = gql`
-    query BatchSpecWorkspacesPreview($batchSpec: ID!, $first: Int, $after: String) {
+    query BatchSpecWorkspacesPreview($batchSpec: ID!, $first: Int, $after: String, $search: String) {
         node(id: $batchSpec) {
             __typename
             ... on BatchSpec {
                 workspaceResolution {
                     __typename
-                    workspaces(first: $first, after: $after) {
+                    workspaces(first: $first, after: $after, search: $search) {
                         __typename
                         totalCount
                         pageInfo {

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.tsx
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.tsx
@@ -88,7 +88,7 @@ export const WorkspacesPreview: React.FunctionComponent<WorkspacesPreviewProps> 
             {showPreviewPrompt && (
                 <PreviewPrompt disabled={previewDisabled} preview={clearErrorAndPreview} form={previewPromptForm} />
             )}
-            {hasPreviewed && !isResolvingPreview && (
+            {hasPreviewed && !isResolvingPreview && !resolutionError && (
                 <div className="d-flex flex-column align-items-center overflow-auto w-100">
                     <WorkspacesPreviewList
                         batchSpecID={batchSpec.id}

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewList.tsx
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewList.tsx
@@ -172,7 +172,7 @@ export const WorkspacePreviewFilterRow: React.FunctionComponent<WorkspacePreview
     return (
         <div className="row no-gutters mr-1">
             <div className="m-0 col">
-                <Form className="form-inline d-flex mb-2" onSubmit={onSubmit}>
+                <Form className="d-flex mb-2" onSubmit={onSubmit}>
                     <Input
                         className="flex-grow-1"
                         type="search"

--- a/client/web/src/enterprise/batches/execution/WorkspacesList.tsx
+++ b/client/web/src/enterprise/batches/execution/WorkspacesList.tsx
@@ -1,6 +1,9 @@
 import classNames from 'classnames'
-import React from 'react'
+import { lowerCase, upperFirst } from 'lodash'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { useHistory } from 'react-router'
 
+import { Form } from '@sourcegraph/branded/src/components/Form'
 import { Link } from '@sourcegraph/wildcard'
 
 import { DiffStat } from '../../../components/diff/DiffStat'
@@ -13,7 +16,7 @@ import {
     ShowMoreButton,
     SummaryContainer,
 } from '../../../components/FilteredConnection/ui'
-import { BatchSpecWorkspaceListFields, Scalars } from '../../../graphql-operations'
+import { BatchSpecWorkspaceListFields, BatchSpecWorkspaceState, Scalars } from '../../../graphql-operations'
 import { Branch } from '../Branch'
 
 import { useWorkspacesListConnection } from './backend'
@@ -27,11 +30,17 @@ export interface WorkspacesListProps {
 }
 
 export const WorkspacesList: React.FunctionComponent<WorkspacesListProps> = ({ batchSpecID, selectedNode }) => {
-    const { loading, hasNextPage, fetchMore, connection, error } = useWorkspacesListConnection(batchSpecID)
+    const [filters, setFilters] = useState<WorkspaceFilters>()
+    const { loading, hasNextPage, fetchMore, connection, error } = useWorkspacesListConnection(
+        batchSpecID,
+        filters?.search ?? null,
+        filters?.state ?? null
+    )
 
     return (
         <ConnectionContainer>
             {error && <ConnectionError errors={[error.message]} />}
+            <WorkspaceFilterRow onFiltersChange={setFilters} />
             <ConnectionList as="ul" className="list-group list-group-flush">
                 {connection?.nodes?.map(node => (
                     <WorkspaceNode key={node.id} node={node} selectedNode={selectedNode} />
@@ -79,3 +88,126 @@ const WorkspaceNode: React.FunctionComponent<WorkspaceNodeProps> = ({ node, sele
         </Link>
     </li>
 )
+
+export interface WorkspaceFilters {
+    state: BatchSpecWorkspaceState | null
+    search: string | null
+}
+
+export interface WorkspaceFilterRowProps {
+    onFiltersChange: (newFilters: WorkspaceFilters) => void
+}
+
+export const WorkspaceFilterRow: React.FunctionComponent<WorkspaceFilterRowProps> = ({ onFiltersChange }) => {
+    const history = useHistory()
+    const searchElement = useRef<HTMLInputElement | null>(null)
+    const searchParameters = new URLSearchParams(history.location.search)
+    const [state, setState] = useState<BatchSpecWorkspaceState | undefined>(() => {
+        const value = searchParameters.get('state')
+        return value && isValidBatchSpecWorkspaceState(value) ? value : undefined
+    })
+    const [search, setSearch] = useState<string | undefined>(() => searchParameters.get('search') ?? undefined)
+    useEffect(() => {
+        const searchParameters = new URLSearchParams(history.location.search)
+        if (state) {
+            searchParameters.set('state', state)
+        } else {
+            searchParameters.delete('state')
+        }
+        if (search) {
+            searchParameters.set('search', search)
+        } else {
+            searchParameters.delete('search')
+        }
+        if (history.location.search !== searchParameters.toString()) {
+            history.replace({ ...history.location, search: searchParameters.toString() })
+        }
+        // Update the filters in the parent component.
+        onFiltersChange({
+            state: state || null,
+            search: search || null,
+        })
+        // We cannot depend on the history, since it's modified by this hook and that would cause an infinite render loop.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [state, search])
+
+    const onSubmit = useCallback(
+        (event?: React.FormEvent<HTMLFormElement>): void => {
+            event?.preventDefault()
+            setSearch(searchElement.current?.value)
+        },
+        [setSearch, searchElement]
+    )
+
+    return (
+        <>
+            <div className="row no-gutters mr-1">
+                <div className="m-0 col">
+                    <Form className="form-inline d-flex mb-2" onSubmit={onSubmit}>
+                        <input
+                            className="form-control flex-grow-1"
+                            type="search"
+                            ref={searchElement}
+                            defaultValue={search}
+                            placeholder="Search repository name"
+                        />
+                    </Form>
+                </div>
+                <div className="w-100 d-block d-md-none" />
+                <div className="m-0 col col-md-auto">
+                    <div className="row no-gutters">
+                        <div className="col mb-2 ml-0 ml-md-2">
+                            <WorkspaceFilter<BatchSpecWorkspaceState>
+                                values={Object.values(BatchSpecWorkspaceState)}
+                                label="State"
+                                selected={state}
+                                onChange={setState}
+                                className="w-100"
+                            />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </>
+    )
+}
+
+export interface WorkspaceFilterProps<T extends string> {
+    label: string
+    values: T[]
+    selected: T | undefined
+    onChange: (value: T | undefined) => void
+    className?: string
+}
+
+export const WorkspaceFilter = <T extends string>({
+    label,
+    values,
+    selected,
+    onChange,
+    className,
+}: WorkspaceFilterProps<T>): React.ReactElement<WorkspaceFilterProps<T>> => {
+    const innerOnChange = useCallback<React.ChangeEventHandler<HTMLSelectElement>>(
+        event => {
+            onChange((event.target.value ?? undefined) as T | undefined)
+        },
+        [onChange]
+    )
+
+    return (
+        <>
+            <select className={classNames('form-control', className)} value={selected} onChange={innerOnChange}>
+                <option value="">{label}</option>
+                {values.map(state => (
+                    <option value={state} key={state}>
+                        {upperFirst(lowerCase(state))}
+                    </option>
+                ))}
+            </select>
+        </>
+    )
+}
+
+function isValidBatchSpecWorkspaceState(state: string): state is BatchSpecWorkspaceState {
+    return Object.values(BatchSpecWorkspaceState).some(value => value === state)
+}

--- a/client/web/src/enterprise/batches/execution/WorkspacesList.tsx
+++ b/client/web/src/enterprise/batches/execution/WorkspacesList.tsx
@@ -143,9 +143,9 @@ export const WorkspaceFilterRow: React.FunctionComponent<WorkspaceFilterRowProps
     return (
         <div className="row no-gutters mr-1">
             <div className="m-0 col">
-                <Form className="form-inline d-flex mb-2" onSubmit={onSubmit}>
+                <Form className="d-flex mb-2" onSubmit={onSubmit}>
                     <Input
-                        className="form-control flex-grow-1"
+                        className="flex-grow-1"
                         type="search"
                         ref={searchElement}
                         defaultValue={search}

--- a/client/web/src/enterprise/batches/execution/backend.ts
+++ b/client/web/src/enterprise/batches/execution/backend.ts
@@ -26,6 +26,7 @@ import {
     RetryBatchSpecExecutionResult,
     RetryBatchSpecExecutionVariables,
     BatchSpecWorkspaceListFields,
+    BatchSpecWorkspaceState,
 } from '../../../graphql-operations'
 
 const batchSpecWorkspaceFieldsFragment = gql`
@@ -327,13 +328,19 @@ export const queryBatchSpecWorkspaceStepFileDiffs = ({
     )
 
 const BATCH_SPEC_WORKSPACES = gql`
-    query BatchSpecWorkspaces($node: ID!, $first: Int, $after: String) {
+    query BatchSpecWorkspaces(
+        $node: ID!
+        $first: Int
+        $after: String
+        $search: String
+        $state: BatchSpecWorkspaceState
+    ) {
         node(id: $node) {
             __typename
             ... on BatchSpec {
                 id
                 workspaceResolution {
-                    workspaces(first: $first, after: $after) {
+                    workspaces(first: $first, after: $after, search: $search, state: $state) {
                         ...BatchSpecWorkspacesConnectionFields
                     }
                 }
@@ -376,7 +383,9 @@ const BATCH_SPEC_WORKSPACES = gql`
 `
 
 export const useWorkspacesListConnection = (
-    batchSpecID: Scalars['ID']
+    batchSpecID: Scalars['ID'],
+    search: string | null,
+    state: BatchSpecWorkspaceState | null
 ): UseConnectionResult<BatchSpecWorkspaceListFields> =>
     useConnection<BatchSpecWorkspacesResult, BatchSpecWorkspacesVariables, BatchSpecWorkspaceListFields>({
         query: BATCH_SPEC_WORKSPACES,
@@ -384,6 +393,8 @@ export const useWorkspacesListConnection = (
             node: batchSpecID,
             after: null,
             first: 20,
+            search,
+            state,
         },
         options: {
             useURL: true,

--- a/client/web/src/enterprise/batches/execution/util.ts
+++ b/client/web/src/enterprise/batches/execution/util.ts
@@ -1,0 +1,5 @@
+import { BatchSpecWorkspaceState } from '../../../graphql-operations'
+
+export function isValidBatchSpecWorkspaceState(state: string): state is BatchSpecWorkspaceState {
+    return Object.values(BatchSpecWorkspaceState).some(value => value === state)
+}

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -575,6 +575,7 @@ type ListWorkspacesArgs struct {
 	After   *string
 	OrderBy *string
 	Search  *string
+	State   *string
 }
 
 type ListRecentlyCompletedWorkspacesArgs struct {

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -1831,8 +1831,20 @@ type BatchSpecWorkspaceResolution {
     workspaces(
         first: Int = 50
         after: String
+        """
+        Not implemented.
+        """
         orderBy: WorkspacesSortOrder
+        """
+        Search for workspaces matching this query. Queries may include quoted substrings
+        to match phrases, and words may be preceded by - to negate them.
+        Currently, this supports searching repository names only.
+        """
         search: String
+        """
+        Filter workspaces by given state.
+        """
+        state: BatchSpecWorkspaceState
     ): BatchSpecWorkspaceConnection!
 
     """

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_resolution_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_resolution_test.go
@@ -1,0 +1,91 @@
+package resolvers
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/search"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+)
+
+func TestWorkspacesListArgsToDBOpts(t *testing.T) {
+	tcs := []struct {
+		name string
+		args *graphqlbackend.ListWorkspacesArgs
+		want store.ListBatchSpecWorkspacesOpts
+	}{
+		{
+			name: "empty",
+			args: &graphqlbackend.ListWorkspacesArgs{},
+		},
+		{
+			name: "first set",
+			args: &graphqlbackend.ListWorkspacesArgs{
+				First: 1,
+			},
+			want: store.ListBatchSpecWorkspacesOpts{
+				LimitOpts: store.LimitOpts{Limit: 1},
+			},
+		},
+		{
+			name: "after set",
+			args: &graphqlbackend.ListWorkspacesArgs{
+				After: strPtr("10"),
+			},
+			want: store.ListBatchSpecWorkspacesOpts{
+				Cursor: 10,
+			},
+		},
+		{
+			name: "search set",
+			args: &graphqlbackend.ListWorkspacesArgs{
+				Search: strPtr("sourcegraph"),
+			},
+			want: store.ListBatchSpecWorkspacesOpts{
+				TextSearch: []search.TextSearchTerm{{Term: "sourcegraph"}},
+			},
+		},
+		{
+			name: "state completed",
+			args: &graphqlbackend.ListWorkspacesArgs{
+				State: strPtr("COMPLETED"),
+			},
+			want: store.ListBatchSpecWorkspacesOpts{
+				OnlyCachedOrCompleted: true,
+			},
+		},
+		{
+			name: "state pending",
+			args: &graphqlbackend.ListWorkspacesArgs{
+				State: strPtr("PENDING"),
+			},
+			want: store.ListBatchSpecWorkspacesOpts{
+				OnlyWithoutExecution: true,
+			},
+		},
+		{
+			name: "state queued",
+			args: &graphqlbackend.ListWorkspacesArgs{
+				State: strPtr("QUEUED"),
+			},
+			want: store.ListBatchSpecWorkspacesOpts{
+				State: types.BatchSpecWorkspaceExecutionJobStateQueued,
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			have, err := workspacesListArgsToDBOpts(tc.args)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(have, tc.want); diff != "" {
+				t.Fatal("invalid args returned" + diff)
+			}
+		})
+	}
+}

--- a/enterprise/internal/batches/store/batch_spec_workspaces.go
+++ b/enterprise/internal/batches/store/batch_spec_workspaces.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lib/pq"
 	"github.com/opentracing/opentracing-go/log"
 
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/search"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/batch"
@@ -218,12 +219,18 @@ type ListBatchSpecWorkspacesOpts struct {
 	Cursor      int64
 	BatchSpecID int64
 	IDs         []int64
+
+	State                 btypes.BatchSpecWorkspaceExecutionJobState
+	OnlyWithoutExecution  bool
+	OnlyCachedOrCompleted bool
+	TextSearch            []search.TextSearchTerm
 }
 
-func (opts ListBatchSpecWorkspacesOpts) SQLConds(forCount bool) *sqlf.Query {
+func (opts ListBatchSpecWorkspacesOpts) SQLConds(forCount bool) (where *sqlf.Query, joinStatements *sqlf.Query) {
 	preds := []*sqlf.Query{
 		sqlf.Sprintf("repo.deleted_at IS NULL"),
 	}
+	joins := []*sqlf.Query{}
 
 	if len(opts.IDs) != 0 {
 		preds = append(preds, sqlf.Sprintf("batch_spec_workspaces.id = ANY(%s)", pq.Array(opts.IDs)))
@@ -237,7 +244,41 @@ func (opts ListBatchSpecWorkspacesOpts) SQLConds(forCount bool) *sqlf.Query {
 		preds = append(preds, sqlf.Sprintf("batch_spec_workspaces.id >= %s", opts.Cursor))
 	}
 
-	return sqlf.Join(preds, "\n AND ")
+	joinedExecution := false
+	ensureJoinExecution := func() {
+		if joinedExecution {
+			return
+		}
+		joins = append(joins, sqlf.Sprintf("LEFT JOIN batch_spec_workspace_execution_jobs ON batch_spec_workspace_execution_jobs.batch_spec_workspace_id = batch_spec_workspaces.id"))
+		joinedExecution = true
+	}
+
+	if opts.State != "" {
+		ensureJoinExecution()
+		preds = append(preds, sqlf.Sprintf("batch_spec_workspace_execution_jobs.state = %s", opts.State))
+	}
+
+	if opts.OnlyWithoutExecution {
+		ensureJoinExecution()
+		preds = append(preds, sqlf.Sprintf("batch_spec_workspace_execution_jobs.id IS NULL"))
+	}
+
+	if opts.OnlyCachedOrCompleted {
+		ensureJoinExecution()
+		preds = append(preds, sqlf.Sprintf("(batch_spec_workspaces.cached_result_found OR batch_spec_workspace_execution_jobs.state = %s)", btypes.BatchSpecWorkspaceExecutionJobStateCompleted))
+	}
+
+	if len(opts.TextSearch) != 0 {
+		for _, term := range opts.TextSearch {
+			preds = append(preds, textSearchTermToClause(
+				term,
+				// TODO: Add more terms here later.
+				sqlf.Sprintf("repo.name"),
+			))
+		}
+	}
+
+	return sqlf.Join(preds, "\n AND "), sqlf.Join(joins, "\n")
 }
 
 // ListBatchSpecWorkspaces lists batch spec workspaces with the given filters.
@@ -269,15 +310,18 @@ var listBatchSpecWorkspacesQueryFmtstr = `
 -- source: enterprise/internal/batches/store/batch_spec_workspace_job.go:ListBatchSpecWorkspaces
 SELECT %s FROM batch_spec_workspaces
 INNER JOIN repo ON repo.id = batch_spec_workspaces.repo_id
+%s
 WHERE %s
 ORDER BY id ASC
 `
 
 func listBatchSpecWorkspacesQuery(opts ListBatchSpecWorkspacesOpts) *sqlf.Query {
+	where, joins := opts.SQLConds(false)
 	return sqlf.Sprintf(
 		listBatchSpecWorkspacesQueryFmtstr+opts.LimitOpts.ToDB(),
 		sqlf.Join(BatchSpecWorkspaceColums.ToSqlf(), ", "),
-		opts.SQLConds(false),
+		joins,
+		where,
 	)
 }
 
@@ -299,13 +343,16 @@ SELECT
 FROM
 	batch_spec_workspaces
 INNER JOIN repo ON repo.id = batch_spec_workspaces.repo_id
+%s
 WHERE %s
 `
 
 func countBatchSpecWorkspacesQuery(opts ListBatchSpecWorkspacesOpts) *sqlf.Query {
+	where, joins := opts.SQLConds(true)
 	return sqlf.Sprintf(
 		countBatchSpecWorkspacesQueryFmtstr+opts.LimitOpts.ToDB(),
-		opts.SQLConds(true),
+		joins,
+		where,
 	)
 }
 


### PR DESCRIPTION
Turns out to be not THAT big of a deal overall, so I've just thrown all the things together in one PR. This brings repo name search to the preview page and search plus state filtering to the execution page.