### PR TITLE
Allow files in SSBC

### DIFF
--- a/doc/batch_changes/explanations/server_side.md
+++ b/doc/batch_changes/explanations/server_side.md
@@ -23,7 +23,6 @@ This feature is experimental. In particular, it comes with the following limitat
 - Documentation is minimal and will change a lot before the GA release.
 - Batch change execution is not optimized.
 - Executors can only be deployed using Terraform (AWS or GCP) or using pre-built binaries (see [deploying executors](../../admin/deploy_executors.md)).
-- Steps cannot include [files](../references/batch_spec_yaml_reference.md#steps-files).
 
 Server-side Batch Changes has been tested to run a simple 20k changeset batch change. Actual performance and setup requirements depend on the complexity of the batch change.
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_test.go
@@ -159,7 +159,7 @@ func TestBatchChangeResolver_BatchSpecs(t *testing.T) {
 	}
 
 	// Non-created-from-raw, attached to batch change
-	batchSpec1, err := btypes.NewBatchSpecFromRaw(ct.TestRawBatchSpec, false)
+	batchSpec1, err := btypes.NewBatchSpecFromRaw(ct.TestRawBatchSpec)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -167,7 +167,7 @@ func TestBatchChangeResolver_BatchSpecs(t *testing.T) {
 	batchSpec1.NamespaceUserID = userID
 
 	// Non-created-from-raw, not attached to batch change
-	batchSpec2, err := btypes.NewBatchSpecFromRaw(ct.TestRawBatchSpec, false)
+	batchSpec2, err := btypes.NewBatchSpecFromRaw(ct.TestRawBatchSpec)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -175,7 +175,7 @@ func TestBatchChangeResolver_BatchSpecs(t *testing.T) {
 	batchSpec2.NamespaceUserID = userID
 
 	// created-from-raw, not attached to batch change
-	batchSpec3, err := btypes.NewBatchSpecFromRaw(ct.TestRawBatchSpec, false)
+	batchSpec3, err := btypes.NewBatchSpecFromRaw(ct.TestRawBatchSpec)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_test.go
@@ -51,7 +51,7 @@ func TestBatchSpecResolver(t *testing.T) {
 	adminID := ct.CreateTestUser(t, db, true).ID
 	orgID := ct.InsertTestOrg(t, db, orgname)
 
-	spec, err := btypes.NewBatchSpecFromRaw(ct.TestRawBatchSpec, true)
+	spec, err := btypes.NewBatchSpecFromRaw(ct.TestRawBatchSpec)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -166,7 +166,7 @@ func TestBatchSpecResolver(t *testing.T) {
 
 	// Now create an updated changeset spec and check that we get a superseding
 	// batch spec.
-	sup, err := btypes.NewBatchSpecFromRaw(ct.TestRawBatchSpec, true)
+	sup, err := btypes.NewBatchSpecFromRaw(ct.TestRawBatchSpec)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec_test.go
@@ -55,7 +55,7 @@ func TestChangesetSpecResolver(t *testing.T) {
 	testRev := api.CommitID("b69072d5f687b31b9f6ae3ceafdc24c259c4b9ec")
 	mockBackendCommits(t, testRev)
 
-	batchSpec, err := btypes.NewBatchSpecFromRaw(`name: awesome-test`, true)
+	batchSpec, err := btypes.NewBatchSpecFromRaw(`name: awesome-test`)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/batches/background/batch_spec_workspace_creator_test.go
+++ b/enterprise/internal/batches/background/batch_spec_workspace_creator_test.go
@@ -213,7 +213,7 @@ func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 	}
 
 	createBatchSpec := func(t *testing.T, noCache bool) *btypes.BatchSpec {
-		batchSpec, err := btypes.NewBatchSpecFromRaw(ct.TestRawBatchSpecYAML, false)
+		batchSpec, err := btypes.NewBatchSpecFromRaw(ct.TestRawBatchSpecYAML)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -242,7 +242,7 @@ func (s *Service) CreateBatchSpec(ctx context.Context, opts CreateBatchSpecOpts)
 	}})
 	defer endObservation(1, observation.Args{})
 
-	spec, err = btypes.NewBatchSpecFromRaw(opts.RawSpec, true)
+	spec, err = btypes.NewBatchSpecFromRaw(opts.RawSpec)
 	if err != nil {
 		return nil, err
 	}
@@ -331,7 +331,7 @@ func (s *Service) CreateBatchSpecFromRaw(ctx context.Context, opts CreateBatchSp
 	}})
 	defer endObservation(1, observation.Args{})
 
-	spec, err = btypes.NewBatchSpecFromRaw(opts.RawSpec, false)
+	spec, err = btypes.NewBatchSpecFromRaw(opts.RawSpec)
 	if err != nil {
 		return nil, err
 	}
@@ -544,7 +544,7 @@ func (s *Service) ReplaceBatchSpecInput(ctx context.Context, opts ReplaceBatchSp
 	defer endObservation(1, observation.Args{})
 
 	// Before we hit the database, validate the new spec.
-	newSpec, err := btypes.NewBatchSpecFromRaw(opts.RawSpec, false)
+	newSpec, err := btypes.NewBatchSpecFromRaw(opts.RawSpec)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/batches/types/batch_spec.go
+++ b/enterprise/internal/batches/types/batch_spec.go
@@ -9,7 +9,7 @@ import (
 
 // NewBatchSpecFromRaw parses and validates the given rawSpec, and returns a BatchSpec
 // containing the result.
-func NewBatchSpecFromRaw(rawSpec string, allowFiles bool) (_ *BatchSpec, err error) {
+func NewBatchSpecFromRaw(rawSpec string) (_ *BatchSpec, err error) {
 	c := &BatchSpec{RawSpec: rawSpec}
 
 	c.Spec, err = batcheslib.ParseBatchSpec([]byte(rawSpec), batcheslib.ParseBatchSpecOptions{
@@ -17,7 +17,6 @@ func NewBatchSpecFromRaw(rawSpec string, allowFiles bool) (_ *BatchSpec, err err
 		AllowArrayEnvironments: true,
 		AllowTransformChanges:  true,
 		AllowConditionalExec:   true,
-		AllowFiles:             allowFiles,
 	})
 
 	return c, err

--- a/lib/batches/batch_spec.go
+++ b/lib/batches/batch_spec.go
@@ -133,7 +133,6 @@ type ParseBatchSpecOptions struct {
 	AllowArrayEnvironments bool
 	AllowTransformChanges  bool
 	AllowConditionalExec   bool
-	AllowFiles             bool
 }
 
 func ParseBatchSpec(data []byte, opts ParseBatchSpecOptions) (*BatchSpec, error) {
@@ -189,17 +188,6 @@ func parseBatchSpec(schema string, data []byte, opts ParseBatchSpecOptions) (*Ba
 			if step.IfCondition() != "" {
 				errs = multierror.Append(errs, NewValidationError(fmt.Errorf(
 					"step %d in batch spec uses the 'if' attribute for conditional execution, which is not supported in this Sourcegraph version",
-					i+1,
-				)))
-			}
-		}
-	}
-
-	if !opts.AllowFiles {
-		for i, step := range spec.Steps {
-			if len(step.Files) != 0 {
-				errs = multierror.Append(errs, NewValidationError(fmt.Errorf(
-					"step %d in batch spec uses the 'files' attribute to create files in the step container, which is not supported in this Batch Changes version",
 					i+1,
 				)))
 			}

--- a/lib/batches/batch_spec_test.go
+++ b/lib/batches/batch_spec_test.go
@@ -208,41 +208,6 @@ changesetTemplate:
 			t.Fatalf("wrong error. want=%q, have=%q", wantErr, haveErr)
 		}
 	})
-	t.Run("uses unsupported files attribute", func(t *testing.T) {
-		const spec = `
-name: hello-world
-description: Add Hello World to READMEs
-on:
-  - repositoriesMatchingQuery: file:README.md
-steps:
-  - run: echo Hello World | tee -a $(find -name README.md)
-    container: alpine:3
-    files:
-      /tmp/horse.txt: yipeeee
-
-changesetTemplate:
-  title: Hello World
-  body: My first batch change!
-  branch: hello-world
-  commit:
-    message: Append Hello World to all README.md files
-  published: false
-`
-
-		_, err := ParseBatchSpec([]byte(spec), ParseBatchSpecOptions{AllowFiles: false})
-		if err == nil {
-			t.Fatal("no error returned")
-		}
-
-		wantErr := `1 error occurred:
-	* step 1 in batch spec uses the 'files' attribute to create files in the step container, which is not supported in this Batch Changes version
-
-`
-		haveErr := err.Error()
-		if haveErr != wantErr {
-			t.Fatalf("wrong error. want=%q, have=%q", wantErr, haveErr)
-		}
-	})
 }
 
 func TestOnQueryOrRepository_Branches(t *testing.T) {


### PR DESCRIPTION
There is no reason we can't allow this. Those files are not from the host, so we incorrectly made the assumption this is unsafe.
Will be followed by another src-cli PR and a src-cli version bump but due to the circular dependency that cannot be all in 1 PR 😄 🔫 