### PR TITLE
Bump src-cli version to latest

### DIFF
--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.36.0"
+const MinimumVersion = "3.36.1"


### PR DESCRIPTION
This is to support `files:` in SSBC.

Yet to be released, will include the changes from https://github.com/sourcegraph/src-cli/pull/682. 

Closes https://github.com/sourcegraph/sourcegraph/issues/29583