### PR TITLE
codeintel: make dependencies/dependents list collapsible

### DIFF
--- a/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadPage.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadPage.tsx
@@ -18,6 +18,7 @@ import { Button, Container, PageHeader, LoadingSpinner } from '@sourcegraph/wild
 
 import { AuthenticatedUser } from '../../../../auth'
 import { ErrorAlert } from '../../../../components/alerts'
+import { Collapsible } from '../../../../components/Collapsible'
 import { PageTitle } from '../../../../components/PageTitle'
 import { LsifUploadFields, LsifUploadConnectionFields } from '../../../../graphql-operations'
 import { CodeIntelStateBanner } from '../../shared/components/CodeIntelStateBanner'
@@ -212,10 +213,18 @@ export const CodeIntelUploadPage: FunctionComponent<CodeIntelUploadPageProps> = 
                     {(uploadOrError.state === LSIFUploadState.COMPLETED ||
                         uploadOrError.state === LSIFUploadState.DELETING) && (
                         <Container className="mt-2">
-                            <div className="mb-2">
+                            <Collapsible
+                                title={
+                                    dependencyGraphState === DependencyGraphState.ShowDependencies ? (
+                                        <h3 className="mb-0">Dependencies</h3>
+                                    ) : (
+                                        <h3 className="mb-0">Dependents</h3>
+                                    )
+                                }
+                                titleAtStart={true}
+                            >
                                 {dependencyGraphState === DependencyGraphState.ShowDependencies ? (
-                                    <h3>
-                                        Dependencies
+                                    <>
                                         <Button
                                             type="button"
                                             className="float-right p-0 mb-2"
@@ -224,10 +233,21 @@ export const CodeIntelUploadPage: FunctionComponent<CodeIntelUploadPageProps> = 
                                         >
                                             Show dependents
                                         </Button>
-                                    </h3>
+                                        <FilteredConnection
+                                            listComponent="div"
+                                            listClassName={classNames(styles.grid, 'mb-3')}
+                                            noun="dependency"
+                                            pluralNoun="dependencies"
+                                            nodeComponent={DependencyOrDependentNode}
+                                            queryConnection={queryDependencies}
+                                            history={history}
+                                            location={props.location}
+                                            cursorPaging={true}
+                                            emptyElement={<EmptyDependencies />}
+                                        />
+                                    </>
                                 ) : (
-                                    <h3>
-                                        Dependents
+                                    <>
                                         <Button
                                             type="button"
                                             className="float-right p-0 mb-2"
@@ -238,37 +258,21 @@ export const CodeIntelUploadPage: FunctionComponent<CodeIntelUploadPageProps> = 
                                         >
                                             Show dependencies
                                         </Button>
-                                    </h3>
+                                        <FilteredConnection
+                                            listComponent="div"
+                                            listClassName={classNames(styles.grid, 'mb-3')}
+                                            noun="dependent"
+                                            pluralNoun="dependents"
+                                            nodeComponent={DependencyOrDependentNode}
+                                            queryConnection={queryDependents}
+                                            history={history}
+                                            location={props.location}
+                                            cursorPaging={true}
+                                            emptyElement={<EmptyDependents />}
+                                        />
+                                    </>
                                 )}
-                            </div>
-
-                            {dependencyGraphState === DependencyGraphState.ShowDependencies ? (
-                                <FilteredConnection
-                                    listComponent="div"
-                                    listClassName={classNames(styles.grid, 'mb-3')}
-                                    noun="dependency"
-                                    pluralNoun="dependencies"
-                                    nodeComponent={DependencyOrDependentNode}
-                                    queryConnection={queryDependencies}
-                                    history={history}
-                                    location={props.location}
-                                    cursorPaging={true}
-                                    emptyElement={<EmptyDependencies />}
-                                />
-                            ) : (
-                                <FilteredConnection
-                                    listComponent="div"
-                                    listClassName={classNames(styles.grid, 'mb-3')}
-                                    noun="dependent"
-                                    pluralNoun="dependents"
-                                    nodeComponent={DependencyOrDependentNode}
-                                    queryConnection={queryDependents}
-                                    history={history}
-                                    location={props.location}
-                                    cursorPaging={true}
-                                    emptyElement={<EmptyDependents />}
-                                />
-                            )}
+                            </Collapsible>
                         </Container>
                     )}
                 </>


### PR DESCRIPTION
Hiding dependencies/dependents list behind a dropdown to reduce initial amount of visuals on an upload page. This will make it easier to see additional sections we may add to the upload page.

<h2>Before:</h2>

![image](https://user-images.githubusercontent.com/18282288/150357833-9a73123f-1aca-4162-9b2c-8d3452d5c3b8.png)

<h2>After:</h2>

![image](https://user-images.githubusercontent.com/18282288/150357688-77098d6a-3551-41a3-80c5-0fdb78834482.png)
