### PR TITLE
Instrument external service mutations

### DIFF
--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -3,7 +3,6 @@ package graphqlbackend
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"strconv"
 	"strings"
@@ -424,7 +423,6 @@ func (r *computedExternalServiceConnectionResolver) PageInfo(ctx context.Context
 
 func reportExternalServiceDuration(startTime time.Time, mutation ExternalServiceMutationType, err *error, userId, orgId int32) {
 	duration := time.Since(startTime)
-	log.Println("ReportingReportingReportingReportingReportingReportingReportingReportingReporting", mutation, duration.Seconds(), *err, "u:", userId, "o:", orgId)
 	ns := "global"
 	if userId != 0 {
 		ns = "user"

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -45,7 +45,7 @@ type addExternalServiceInput struct {
 func (r *schemaResolver) AddExternalService(ctx context.Context, args *addExternalServiceArgs) (*externalServiceResolver, error) {
 	start := time.Now()
 	// 🚨 SECURITY: Only site admins may add external services if user mode is disabled.
-	namespaceUserID, namespaceOrgID := int32(0), int32(0)
+	var namespaceUserID, namespaceOrgID int32
 	var err error
 	defer reportExternalServiceDuration(start, Add, &err, &namespaceUserID, &namespaceOrgID)
 	if os.Getenv("EXTSVC_CONFIG_FILE") != "" && !extsvcConfigAllowEdits {

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -123,7 +123,7 @@ type updateExternalServiceInput struct {
 func (r *schemaResolver) UpdateExternalService(ctx context.Context, args *updateExternalServiceArgs) (*externalServiceResolver, error) {
 	start := time.Now()
 	var err error
-	namespaceUserID, namespaceOrgID := int32(0), int32(0)
+	var namespaceUserID, namespaceOrgID int32
 	defer reportExternalServiceDuration(start, Update, &err, &namespaceUserID, &namespaceOrgID)
 	if os.Getenv("EXTSVC_CONFIG_FILE") != "" && !extsvcConfigAllowEdits {
 		return nil, errors.New("updating external service not allowed when using EXTSVC_CONFIG_FILE")
@@ -222,7 +222,7 @@ type deleteExternalServiceArgs struct {
 func (r *schemaResolver) DeleteExternalService(ctx context.Context, args *deleteExternalServiceArgs) (*EmptyResponse, error) {
 	start := time.Now()
 	var err error
-	namespaceUserID, namespaceOrgID := int32(0), int32(0)
+	var namespaceUserID, namespaceOrgID int32
 	defer reportExternalServiceDuration(start, Delete, &err, &namespaceUserID, &namespaceOrgID)
 	if os.Getenv("EXTSVC_CONFIG_FILE") != "" && !extsvcConfigAllowEdits {
 		return nil, errors.New("deleting external service not allowed when using EXTSVC_CONFIG_FILE")

--- a/cmd/frontend/graphqlbackend/set_external_service_repos.go
+++ b/cmd/frontend/graphqlbackend/set_external_service_repos.go
@@ -20,7 +20,7 @@ func (r *schemaResolver) SetExternalServiceRepos(ctx context.Context, args struc
 }) (*EmptyResponse, error) {
 	start := time.Now()
 	var err error
-	namespaceUserID, namespaceOrgID := int32(0), int32(0)
+	var namespaceUserID, namespaceOrgID int32
 	defer reportExternalServiceDuration(start, SetRepos, &err, &namespaceUserID, &namespaceOrgID)
 
 	id, err := UnmarshalExternalServiceID(args.ID)

--- a/cmd/frontend/graphqlbackend/set_external_service_repos.go
+++ b/cmd/frontend/graphqlbackend/set_external_service_repos.go
@@ -18,16 +18,21 @@ func (r *schemaResolver) SetExternalServiceRepos(ctx context.Context, args struc
 	Repos    *[]string
 	AllRepos bool
 }) (*EmptyResponse, error) {
+	start := time.Now()
 	id, err := UnmarshalExternalServiceID(args.ID)
 	if err != nil {
+		defer reportExternalServiceDuration(start, "set-repos", &err, nil, nil)
+
 		return nil, err
 	}
 
 	extsvcStore := r.db.ExternalServices()
 	es, err := extsvcStore.GetByID(ctx, id)
 	if err != nil {
+		defer reportExternalServiceDuration(start, "set-repos", &err, nil, nil)
 		return nil, err
 	}
+	defer reportExternalServiceDuration(start, "set-repos", &err, &es.NamespaceUserID, &es.NamespaceOrgID)
 
 	// 🚨 SECURITY: make sure the user has access to external service
 	if err := backend.CheckExternalServiceAccess(ctx, r.db, es.NamespaceUserID, es.NamespaceOrgID); err != nil {

--- a/cmd/frontend/graphqlbackend/set_external_service_repos.go
+++ b/cmd/frontend/graphqlbackend/set_external_service_repos.go
@@ -21,7 +21,7 @@ func (r *schemaResolver) SetExternalServiceRepos(ctx context.Context, args struc
 	start := time.Now()
 	id, err := UnmarshalExternalServiceID(args.ID)
 	if err != nil {
-		defer reportExternalServiceDuration(start, "set-repos", &err, nil, nil)
+		defer reportExternalServiceDuration(start, SetRepos, &err, 0, 0)
 
 		return nil, err
 	}
@@ -29,10 +29,10 @@ func (r *schemaResolver) SetExternalServiceRepos(ctx context.Context, args struc
 	extsvcStore := r.db.ExternalServices()
 	es, err := extsvcStore.GetByID(ctx, id)
 	if err != nil {
-		defer reportExternalServiceDuration(start, "set-repos", &err, nil, nil)
+		defer reportExternalServiceDuration(start, SetRepos, &err, 0, 0)
 		return nil, err
 	}
-	defer reportExternalServiceDuration(start, "set-repos", &err, &es.NamespaceUserID, &es.NamespaceOrgID)
+	defer reportExternalServiceDuration(start, SetRepos, &err, es.NamespaceUserID, es.NamespaceOrgID)
 
 	// 🚨 SECURITY: make sure the user has access to external service
 	if err := backend.CheckExternalServiceAccess(ctx, r.db, es.NamespaceUserID, es.NamespaceOrgID); err != nil {


### PR DESCRIPTION
Part of [CLOUD-175 ](https://sourcegraph.atlassian.net/browse/CLOUD-175)

This PR add instrumentation to external_services mutations to capture namespace information. We originally hoped to use GraphQL-level instrumentation instead, but information about namespace of a given request is not passed in a consistent way.
