### PR TITLE
Remove use of edge repos, pinned versions

### DIFF
--- a/docker-images/alpine-3.12/Dockerfile
+++ b/docker-images/alpine-3.12/Dockerfile
@@ -24,10 +24,9 @@ RUN addgroup -g 101 -S sourcegraph && adduser -u 100 -S -G sourcegraph -h /home/
 # Install other packages that are desirable in ALL Sourcegraph Docker images.
 RUN apk update && apk add --no-cache \
     bind-tools \
-    'busybox>=1.34.1' \
+    busybox \
     ca-certificates \
     curl \
     mailcap \
     tini \
-    # Required due to ssl_clent upgrade with busybox
-    'wget>=1.21.1'
+    wget

--- a/docker-images/alpine-3.12/Dockerfile
+++ b/docker-images/alpine-3.12/Dockerfile
@@ -24,11 +24,10 @@ RUN addgroup -g 101 -S sourcegraph && adduser -u 100 -S -G sourcegraph -h /home/
 # Install other packages that are desirable in ALL Sourcegraph Docker images.
 RUN apk update && apk add --no-cache \
     bind-tools \
-    # Requires the use of the edge repo for CVE-2021-28831 until a patched version is brought into the 3.12 mirror.
-    'busybox>=1.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    'busybox>=1.34.1' \
     ca-certificates \
     curl \
     mailcap \
     tini \
     # Required due to ssl_clent upgrade with busybox
-    'wget>=1.21.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main
+    'wget>=1.21.1'

--- a/docker-images/alpine-3.14/Dockerfile
+++ b/docker-images/alpine-3.14/Dockerfile
@@ -24,8 +24,7 @@ RUN addgroup -g 101 -S sourcegraph && adduser -u 100 -S -G sourcegraph -h /home/
 # Install other packages that are desirable in ALL Sourcegraph Docker images.
 RUN apk update && apk add --no-cache \
     bind-tools \
-    # Requires the use of the edge repo for CVE-2021-28831 until a patched version is brought into the 3.12 mirror.
-    'busybox>=1.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    'busybox>=1.34.1' \
     ca-certificates \
     curl \
     mailcap \

--- a/docker-images/alpine-3.14/Dockerfile
+++ b/docker-images/alpine-3.14/Dockerfile
@@ -24,10 +24,9 @@ RUN addgroup -g 101 -S sourcegraph && adduser -u 100 -S -G sourcegraph -h /home/
 # Install other packages that are desirable in ALL Sourcegraph Docker images.
 RUN apk update && apk add --no-cache \
     bind-tools \
-    'busybox>=1.34.1' \
+    busybox \
     ca-certificates \
     curl \
     mailcap \
     tini \
-    # Required due to ssl_clent upgrade with busybox
     wget

--- a/docker-images/cadvisor/Dockerfile
+++ b/docker-images/cadvisor/Dockerfile
@@ -13,10 +13,9 @@ LABEL org.opencontainers.image.source=https://github.com/sourcegraph/sourcegraph
 LABEL org.opencontainers.image.documentation=https://docs.sourcegraph.com/
 
 RUN apk add --upgrade --no-cache apk-tools=2.10.8-r0 krb5-libs=1.18.4-r0 \
-    # Requires the use of the edge repo for CVE-2021-28831 until a patched version is brought into the 3.12 mirror.
-    'busybox>=1.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    'busybox>=1.34.1'
     # Required due to ssl_clent upgrade with busybox
-    'wget>=1.21.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main
+    'wget>=1.21.1'
 
 # Reflects cAdvisor Dockerfile at https://github.com/google/cadvisor/blob/v0.39.2/deploy/Dockerfile
 # alongside additional Sourcegraph defaults.

--- a/docker-images/cadvisor/Dockerfile
+++ b/docker-images/cadvisor/Dockerfile
@@ -13,9 +13,8 @@ LABEL org.opencontainers.image.source=https://github.com/sourcegraph/sourcegraph
 LABEL org.opencontainers.image.documentation=https://docs.sourcegraph.com/
 
 RUN apk add --upgrade --no-cache apk-tools=2.10.8-r0 krb5-libs=1.18.4-r0 \
-    'busybox>=1.34.1'
-    # Required due to ssl_clent upgrade with busybox
-    'wget>=1.21.1'
+    busybox \
+    wget
 
 # Reflects cAdvisor Dockerfile at https://github.com/google/cadvisor/blob/v0.39.2/deploy/Dockerfile
 # alongside additional Sourcegraph defaults.

--- a/docker-images/codeinsights-db/Dockerfile
+++ b/docker-images/codeinsights-db/Dockerfile
@@ -2,8 +2,7 @@ FROM timescale/timescaledb:2.0.0-pg12-oss
 
 # hadolint ignore=DL3017
 RUN apk -U upgrade && apk add --no-cache \
-    # Requires the use of the edge repo for CVE-2021-28831 until a patched version is brought into the 3.12 mirror.
-    'busybox>=1.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    'busybox>=1.34.1'
     # Required due to ssl_clent upgrade with busybox
-    'wget>=1.21.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main
+    'wget>=1.21.1'
 

--- a/docker-images/codeinsights-db/Dockerfile
+++ b/docker-images/codeinsights-db/Dockerfile
@@ -2,7 +2,6 @@ FROM timescale/timescaledb:2.0.0-pg12-oss
 
 # hadolint ignore=DL3017
 RUN apk -U upgrade && apk add --no-cache \
-    'busybox>=1.34.1'
-    # Required due to ssl_clent upgrade with busybox
-    'wget>=1.21.1'
+    busybox \
+    wget
 


### PR DESCRIPTION
wget is currently broken in containers that use the edge repo to install it. When you try to invoke it, it errors with: `Error relocating /usr/bin/wget: reallocarray: symbol not found`. This breaks the cadvisor docker-compose healthcheck, which uses wget.

We started using the edge repo to get a bleeding-edge fix for some CVE's, but now that fix is incorporated into the normal repo so we can remove both the version pinning and repo specifications. No Trivy errors reported on the dry-run build [here](https://buildkite.com/sourcegraph/sourcegraph/builds/126473).

The failing wget was introduced in #29493 but I think it was just a matter of time before this bit us.