### PR TITLE
codeintel: add root to rust autoindex inferrence

### DIFF
--- a/lib/codeintel/autoindex/inference/rust.go
+++ b/lib/codeintel/autoindex/inference/rust.go
@@ -17,7 +17,7 @@ func InferRustIndexJobs(gitserver GitClient, paths []string) (indexes []config.I
 				Indexer:     "sourcegraph/lsif-rust",
 				IndexerArgs: []string{"lsif-rust", "index"},
 				Outfile:     "dump.lsif",
-				Root:        "",
+				Root:        dirWithoutDot(path),
 				Steps:       []config.DockerStep{},
 			})
 			break


### PR DESCRIPTION
Address issues found for [this auto-index job](https://sourcegraph.com/site-admin/code-intelligence/indexes/TFNJRkluZGV4OjEzNTEzMTc=). There is the "danger" that it only catches the demo projects, but this is a step in the right direction