### PR TITLE
Sub-repo filtering for git.HasCommitAfter, git.BranchesContaining, git.RefDescriptions, and git.CommitDate

### DIFF
--- a/enterprise/internal/codeintel/gitserver/client.go
+++ b/enterprise/internal/codeintel/gitserver/client.go
@@ -76,7 +76,7 @@ func (c *Client) CommitDate(ctx context.Context, repositoryID int, commit string
 		return "", time.Time{}, false, nil
 	}
 
-	rev, tm, ok, err := git.CommitDate(ctx, repo, api.CommitID(commit))
+	rev, tm, ok, err := git.CommitDate(ctx, repo, api.CommitID(commit), authz.DefaultSubRepoPermsChecker)
 	if err == nil {
 		return rev, tm, ok, nil
 	}

--- a/enterprise/internal/codeintel/gitserver/client.go
+++ b/enterprise/internal/codeintel/gitserver/client.go
@@ -161,7 +161,7 @@ func (c *Client) RefDescriptions(ctx context.Context, repositoryID int) (_ map[s
 		return nil, err
 	}
 
-	return git.RefDescriptions(ctx, repo)
+	return git.RefDescriptions(ctx, repo, authz.DefaultSubRepoPermsChecker)
 }
 
 // CommitsUniqueToBranch returns a map from commits that exist on a particular branch in the given repository to
@@ -191,7 +191,7 @@ func (c *Client) BranchesContaining(ctx context.Context, repositoryID int, commi
 	if err != nil {
 		return nil, err
 	}
-	return git.BranchesContaining(ctx, repo, api.CommitID(commit))
+	return git.BranchesContaining(ctx, repo, api.CommitID(commit), authz.DefaultSubRepoPermsChecker)
 }
 
 // DefaultBranchContains tells if the default branch contains the given commit ID.

--- a/enterprise/internal/codeintel/gitserver/client.go
+++ b/enterprise/internal/codeintel/gitserver/client.go
@@ -181,7 +181,7 @@ func (c *Client) CommitsUniqueToBranch(ctx context.Context, repositoryID int, br
 		return nil, err
 	}
 
-	return git.CommitsUniqueToBranch(ctx, repo, branchName, isDefaultBranch, maxAge)
+	return git.CommitsUniqueToBranch(ctx, repo, branchName, isDefaultBranch, maxAge, authz.DefaultSubRepoPermsChecker)
 }
 
 // BranchesContaining returns a map from branch names to branch tip hashes for each branch

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -625,10 +625,11 @@ func RefDescriptions(ctx context.Context, repo api.RepoName, checker authz.SubRe
 func filterRefDescriptions(ctx context.Context,
 	repo api.RepoName,
 	refDescriptions map[string][]gitdomain.RefDescription,
-	checker authz.SubRepoPermissionChecker) map[string][]gitdomain.RefDescription {
+	checker authz.SubRepoPermissionChecker,
+) map[string][]gitdomain.RefDescription {
 	filtered := make(map[string][]gitdomain.RefDescription, len(refDescriptions))
 	for commitID, descriptions := range refDescriptions {
-		if _, err := GetCommit(ctx, repo, api.CommitID(commitID), ResolveRevisionOptions{}, checker); !errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
+		if _, err := GetCommit(ctx, repo, api.CommitID(commitID), ResolveRevisionOptions{}, checker); !errors.Is(err, &gitdomain.RevisionNotFoundError{}) {
 			filtered[commitID] = descriptions
 		}
 	}

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -629,7 +629,7 @@ func filterRefDescriptions(ctx context.Context,
 ) map[string][]gitdomain.RefDescription {
 	filtered := make(map[string][]gitdomain.RefDescription, len(refDescriptions))
 	for commitID, descriptions := range refDescriptions {
-		if _, err := GetCommit(ctx, repo, api.CommitID(commitID), ResolveRevisionOptions{}, checker); !errors.Is(err, &gitdomain.RevisionNotFoundError{}) {
+		if _, err := GetCommit(ctx, repo, api.CommitID(commitID), ResolveRevisionOptions{}, checker); !errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
 			filtered[commitID] = descriptions
 		}
 	}

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -759,7 +759,6 @@ type CommitGraphOptions struct {
 // from a commit to its parents. If a commit is supplied, the returned graph will
 // be rooted at the given commit. If a non-zero limit is supplied, at most that
 // many commits will be returned.
-// TODO: sub-repo filtering
 func CommitGraph(ctx context.Context, repo api.RepoName, opts CommitGraphOptions) (_ *gitdomain.CommitGraph, err error) {
 	args := []string{"log", "--pretty=%H %P", "--topo-order"}
 	if opts.AllRefs {


### PR DESCRIPTION
- sub-repo permissions filtering for git.HasCommitAfter, git.BranchesContaining,  git.RefDescriptions, and git.CommitDate
- Made `git.CommitCount` private and reference `git.HasCommitAfter` instead

Part of https://github.com/sourcegraph/sourcegraph/issues/27498
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
