### PR TITLE
remove VS Code lsif-tsc-eslint job

### DIFF
--- a/.github/workflows/lsif-ts.yml
+++ b/.github/workflows/lsif-ts.yml
@@ -23,7 +23,6 @@ jobs:
           - client/shared
           - client/search
           - client/search-ui
-          - client/vscode
           - client/web
           - client/wildcard
           - client/common


### PR DESCRIPTION
This is currently [breaking the build](https://github.com/sourcegraph/sourcegraph/runs/4890167649?check_suite_focus=true). From a quick glance I'm not sure what the root cause of the failure is, but we can go without this step until the extension is in a working state.
