### PR TITLE
hubspotutil: separate request for firstsourceURL property

### DIFF
--- a/cmd/frontend/hubspot/contacts.go
+++ b/cmd/frontend/hubspot/contacts.go
@@ -21,6 +21,15 @@ func (c *Client) CreateOrUpdateContact(email string, params *ContactProperties) 
 	}
 	var resp ContactResponse
 	err := c.postJSON("CreateOrUpdateContact", c.baseContactURL(email), newAPIValues(params), &resp)
+	if err != nil {
+		return &resp, err
+	}
+	if resp.IsNew {
+		// First source URL should only be sent when a contact is new. Although the user's cookie value should
+		// not change, minimize risk of login via multiple browsers, clearing of cookies, etc. by not sending
+		// this value on subsequent logins.
+		err = c.postJSON("CreateOrUpdateContact", c.baseContactURL(email), firstSourceURLValue(params), &resp)
+	}
 	return &resp, err
 }
 
@@ -63,11 +72,16 @@ func newAPIValues(h *ContactProperties) *apiProperties {
 	apiProps.set("is_server_admin", h.IsServerAdmin)
 	apiProps.set("latest_ping", h.LatestPing)
 	apiProps.set("anonymous_user_id", h.AnonymousUserID)
-	apiProps.set("first_source_url", h.FirstSourceURL)
 	apiProps.set("last_source_url", h.LastSourceURL)
 	apiProps.set("database_id", h.DatabaseID)
 	apiProps.set("has_agreed_to_tos_and_pp", h.HasAgreedToToS)
 	return apiProps
+}
+
+func firstSourceURLValue(h *ContactProperties) *apiProperties {
+	firstSourceProp := &apiProperties{}
+	firstSourceProp.set("first_source_url", h.FirstSourceURL)
+	return firstSourceProp
 }
 
 // apiProperties represents a list of HubSpot API-compliant key-value pairs

--- a/enterprise/cmd/frontend/internal/auth/oauth/session.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/session.go
@@ -2,7 +2,6 @@ package oauth
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -97,7 +96,7 @@ func SessionIssuer(db database.DB, s SessionIssuerHelper, sessionKey string) htt
 			http.Error(w, safeErrMsg, http.StatusInternalServerError)
 			return
 		}
-		r.Context().
+
 		user, err := db.Users().GetByID(r.Context(), actr.UID)
 		if err != nil {
 			log15.Error("OAuth failed: error retrieving user from database.", "error", err)

--- a/enterprise/cmd/frontend/internal/auth/oauth/session.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/session.go
@@ -2,6 +2,7 @@ package oauth
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -89,7 +90,6 @@ func SessionIssuer(db database.DB, s SessionIssuerHelper, sessionKey string) htt
 			}
 			return c.Value
 		}
-
 		anonymousId, _ := cookie.AnonymousUID(r)
 		actr, safeErrMsg, err := s.GetOrCreateUser(ctx, token, anonymousId, getCookie("sourcegraphSourceUrl"), getCookie("sourcegraphRecentSourceUrl"))
 		if err != nil {
@@ -97,7 +97,7 @@ func SessionIssuer(db database.DB, s SessionIssuerHelper, sessionKey string) htt
 			http.Error(w, safeErrMsg, http.StatusInternalServerError)
 			return
 		}
-
+		r.Context().
 		user, err := db.Users().GetByID(r.Context(), actr.UID)
 		if err != nil {
 			log15.Error("OAuth failed: error retrieving user from database.", "error", err)


### PR DESCRIPTION
First source URL is a property that should only be set once and never changed. HubSpot unfortunately does not provide a setting that enforces this, so we have relied on the cookie being set to not expire to ensure the value doesn't get updated.

This PR adds a separate request that only fires when the user is a new contact in HubSpot, and if so, updates the first source URL for that contact. This further safe guards against the edge cases (browser cookies being cleared, logging in from a different computer, etc.) that may update the first source URL property unwantedly. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
