### PR TITLE
Keep URL hash when building new URLs in search results

### DIFF
--- a/client/shared/src/components/FileMatchChildren.tsx
+++ b/client/shared/src/components/FileMatchChildren.tsx
@@ -86,6 +86,7 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
 
     const createCodeExcerptLink = (group: MatchGroup): string => {
         const positionOrRangeQueryParameter = toPositionOrRangeQueryParameter({ position: group.position })
+
         return appendLineRangeQueryParameter(
             appendSubtreeQueryParameter(getFileMatchUrl(result)),
             positionOrRangeQueryParameter

--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -692,7 +692,7 @@ export const isExternalLink = (url: string): boolean =>
 export const appendSubtreeQueryParameter = (url: string): string => {
     const newUrl = new URL(url, window.location.href)
     newUrl.searchParams.set('subtree', 'true')
-    return newUrl.pathname + `?${formatSearchParameters(newUrl.searchParams)}` + newUrl.hash
+    return newUrl.pathname + `?${formatSearchParameters(newUrl.searchParams)}` + window.location.hash
 }
 
 /**
@@ -717,5 +717,5 @@ export const addLineRangeQueryParameter = (
 export const appendLineRangeQueryParameter = (url: string, range: string | undefined): string => {
     const newUrl = new URL(url, window.location.href)
     const searchQuery = formatSearchParameters(addLineRangeQueryParameter(newUrl.searchParams, range))
-    return newUrl.pathname + `?${searchQuery}` + newUrl.hash
+    return newUrl.pathname + `?${searchQuery}` + window.location.hash
 }


### PR DESCRIPTION
This makes sure that we don't lose `#tab=references` when navigating
through references.

###  Navigating within one file

https://user-images.githubusercontent.com/1185253/150501052-b418354e-9f55-474c-81b0-435198fe91bf.mp4

### Navigating between multiple files (or one large file)

https://user-images.githubusercontent.com/1185253/150501137-cc69af68-b9b9-4d30-bf98-1f6d2e12e254.mp4


