### PR TITLE
Fix broken 'src lsif upload' inside executor due to basic auth removal

### DIFF
--- a/enterprise/cmd/frontend/internal/executorqueue/queuehandler.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queuehandler.go
@@ -41,16 +41,17 @@ func newExecutorQueueHandler(executorStore executor.Store, queueOptions []handle
 		// Upload LSIF indexes without a sudo access token or github tokens.
 		base.Path("/lsif/upload").Methods("POST").Handler(uploadHandler)
 
-		return basicAuthMiddleware(accessToken, base)
+		return authMiddleware(accessToken, base)
 	}
 
 	return factory, nil
 }
 
-// basicAuthMiddleware rejects requests that do not have a basic auth username and password matching
-// the expected username and password. This should only be used for internal _services_, not users,
-// in which a shared key exchange can be done so safely.
-func basicAuthMiddleware(accessToken func() string, next http.Handler) http.Handler {
+// authMiddleware rejects requests that do not have a Authorization header set
+// with the correct "token-executor <token>" value. This should only be used
+// for internal _services_, not users, in which a shared key exchange can be
+// done so safely.
+func authMiddleware(accessToken func() string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if validateExecutorToken(w, r, accessToken()) {
 			next.ServeHTTP(w, r)

--- a/enterprise/cmd/frontend/internal/executorqueue/queuehandler_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queuehandler_test.go
@@ -11,7 +11,7 @@ import (
 func TestInternalProxyAuthTokenMiddleware(t *testing.T) {
 	accessToken := "hunter2"
 
-	ts := httptest.NewServer(basicAuthMiddleware(
+	ts := httptest.NewServer(authMiddleware(
 		func() string { return accessToken },
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusTeapot)

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform_test.go
@@ -68,12 +68,15 @@ func TestTransformRecord(t *testing.T) {
 					"-associated-index-id", "42",
 				},
 				Dir: "web",
-				Env: []string{"SRC_ENDPOINT=https://sourcegraph:hunter2@test.io"},
+				Env: []string{
+					"SRC_ENDPOINT=https://test.io",
+					"SRC_HEADER_AUTHORIZATION=token-executor hunter2",
+				},
 			},
 		},
 		RedactedValues: map[string]string{
-			"https://sourcegraph:hunter2@test.io": "https://sourcegraph:PASSWORD_REMOVED@test.io",
-			"hunter2":                             "PASSWORD_REMOVED",
+			"hunter2":                "PASSWORD_REMOVED",
+			"token-executor hunter2": "token-executor REDACTED",
 		},
 	}
 	if diff := cmp.Diff(expected, job); diff != "" {
@@ -143,12 +146,15 @@ func TestTransformRecordWithoutIndexer(t *testing.T) {
 					"-associated-index-id", "42",
 				},
 				Dir: "",
-				Env: []string{"SRC_ENDPOINT=https://sourcegraph:hunter2@test.io"},
+				Env: []string{
+					"SRC_ENDPOINT=https://test.io",
+					"SRC_HEADER_AUTHORIZATION=token-executor hunter2",
+				},
 			},
 		},
 		RedactedValues: map[string]string{
-			"https://sourcegraph:hunter2@test.io": "https://sourcegraph:PASSWORD_REMOVED@test.io",
-			"hunter2":                             "PASSWORD_REMOVED",
+			"hunter2":                "PASSWORD_REMOVED",
+			"token-executor hunter2": "token-executor REDACTED",
 		},
 	}
 	if diff := cmp.Diff(expected, job); diff != "" {


### PR DESCRIPTION
In #29885 we removed basic auth from the `executor` (and its counterpart
in Sourcegrap, the `executorqueue`).

We replaced it with `Authorization` header based authentication due to
customer feedback.

What we forgot: we also used basic auth for the internal LSIF upload
endpoint that's used by `src` inside `executor`.

On the `src` side:

1. We set username/password by modifying the `SRC_ENDPOINT`: https://github.com/sourcegraph/sourcegraph/blob/cdd762da77261e5d007ece56cfa51bef628aeb62/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform.go#L39-L42
1. We tell `src` to use the internal upload handler: https://github.com/sourcegraph/sourcegraph/blob/cdd762da77261e5d007ece56cfa51bef628aeb62/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform.go#L72

On the server side:

1. We protect the `/lsif/upload` route with the same auth middleware that we use for other `executor`<->`Sourcegraph` communication: https://github.com/sourcegraph/sourcegraph/blob/899643f29b1e88170e984c8946d322f6ca2c7bc1/enterprise/cmd/frontend/internal/executorqueue/queuehandler.go#L42-L44

The last point is what we forgot when we changed the middleware in #29885.

So, the fix here is to tell `src` to authenticate via the
`Authorization:` header too.