### PR TITLE
external-services: only sync for config change

### DIFF
--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -138,6 +138,7 @@ func (r *schemaResolver) UpdateExternalService(ctx context.Context, args *update
 	if err != nil {
 		return nil, err
 	}
+	oldConfig := es.Config
 	namespaceUserID, namespaceOrgID = es.NamespaceUserID, es.NamespaceOrgID
 
 	// 🚨 SECURITY: check access to external service
@@ -166,8 +167,12 @@ func (r *schemaResolver) UpdateExternalService(ctx context.Context, args *update
 	}
 
 	res := &externalServiceResolver{db: r.db, externalService: es}
-	if err = syncExternalService(ctx, es, syncExternalServiceTimeout, r.repoupdaterClient); err != nil {
-		res.warning = fmt.Sprintf("External service updated, but we encountered a problem while validating the external service: %s", err)
+
+	if oldConfig != es.Config {
+		err = syncExternalService(ctx, es, syncExternalServiceTimeout, r.repoupdaterClient)
+		if err != nil {
+			res.warning = fmt.Sprintf("External service updated, but we encountered a problem while validating the external service: %s", err)
+		}
 	}
 
 	return res, nil


### PR DESCRIPTION
With this change we won't trigger a sync if the config hasn't changed.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
