### PR TITLE
search: Make code in search results selectable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
--
+- Code in search results is now selectable (e.g. for copying). Just clicking on the code continues to open the corresponding file as it did before. [#30033](https://github.com/sourcegraph/sourcegraph/pull/30033)
 
 ### Changed
 

--- a/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
+++ b/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
@@ -91,15 +91,12 @@ exports[`<HierarchicalLocationsView /> displays a single location when complete 
                 <div
                   class="test-file-match-children-item-wrapper itemCodeWrapper"
                 >
-                  <a
-                    aria-label="Open file match"
-                    class=""
-                    href="/github.com/foo/bar/-/blob/?L2:1&subtree=true"
-                  />
                   <div
                     class="test-file-match-children-item item itemClickable"
+                    data-href="/github.com/foo/bar/-/blob/?L2:1&subtree=true"
                     data-testid="file-match-children-item"
-                    role="none"
+                    role="link"
+                    tabindex="0"
                   >
                     <code
                       class="codeExcerpt"
@@ -322,15 +319,12 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
                 <div
                   class="test-file-match-children-item-wrapper itemCodeWrapper"
                 >
-                  <a
-                    aria-label="Open file match"
-                    class=""
-                    href="/github.com/foo/bar/-/blob/file1.txt?L2:1&subtree=true"
-                  />
                   <div
                     class="test-file-match-children-item item itemClickable"
+                    data-href="/github.com/foo/bar/-/blob/file1.txt?L2:1&subtree=true"
                     data-testid="file-match-children-item"
-                    role="none"
+                    role="link"
+                    tabindex="0"
                   >
                     <code
                       class="codeExcerpt"
@@ -504,15 +498,12 @@ exports[`<HierarchicalLocationsView /> displays partial locations before complet
                 <div
                   class="test-file-match-children-item-wrapper itemCodeWrapper"
                 >
-                  <a
-                    aria-label="Open file match"
-                    class=""
-                    href="/github.com/foo/bar/-/blob/?L2:1&subtree=true"
-                  />
                   <div
                     class="test-file-match-children-item item itemClickable"
+                    data-href="/github.com/foo/bar/-/blob/?L2:1&subtree=true"
                     data-testid="file-match-children-item"
-                    role="none"
+                    role="link"
+                    tabindex="0"
                   >
                     <code
                       class="codeExcerpt"

--- a/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
+++ b/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
@@ -92,9 +92,14 @@ exports[`<HierarchicalLocationsView /> displays a single location when complete 
                   class="test-file-match-children-item-wrapper itemCodeWrapper"
                 >
                   <a
+                    aria-label="Open file match"
+                    class=""
+                    href="/github.com/foo/bar/-/blob/?L2:1&subtree=true"
+                  />
+                  <div
                     class="test-file-match-children-item item itemClickable"
                     data-testid="file-match-children-item"
-                    href="/github.com/foo/bar/-/blob/?L2:1&subtree=true"
+                    role="none"
                   >
                     <code
                       class="codeExcerpt"
@@ -141,7 +146,7 @@ exports[`<HierarchicalLocationsView /> displays a single location when complete 
                         </tbody>
                       </table>
                     </code>
-                  </a>
+                  </div>
                 </div>
               </div>
             </div>
@@ -318,9 +323,14 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
                   class="test-file-match-children-item-wrapper itemCodeWrapper"
                 >
                   <a
+                    aria-label="Open file match"
+                    class=""
+                    href="/github.com/foo/bar/-/blob/file1.txt?L2:1&subtree=true"
+                  />
+                  <div
                     class="test-file-match-children-item item itemClickable"
                     data-testid="file-match-children-item"
-                    href="/github.com/foo/bar/-/blob/file1.txt?L2:1&subtree=true"
+                    role="none"
                   >
                     <code
                       class="codeExcerpt"
@@ -391,7 +401,7 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
                         </tbody>
                       </table>
                     </code>
-                  </a>
+                  </div>
                 </div>
               </div>
             </div>
@@ -495,9 +505,14 @@ exports[`<HierarchicalLocationsView /> displays partial locations before complet
                   class="test-file-match-children-item-wrapper itemCodeWrapper"
                 >
                   <a
+                    aria-label="Open file match"
+                    class=""
+                    href="/github.com/foo/bar/-/blob/?L2:1&subtree=true"
+                  />
+                  <div
                     class="test-file-match-children-item item itemClickable"
                     data-testid="file-match-children-item"
-                    href="/github.com/foo/bar/-/blob/?L2:1&subtree=true"
+                    role="none"
                   >
                     <code
                       class="codeExcerpt"
@@ -544,7 +559,7 @@ exports[`<HierarchicalLocationsView /> displays partial locations before complet
                         </tbody>
                       </table>
                     </code>
-                  </a>
+                  </div>
                 </div>
               </div>
             </div>

--- a/client/shared/src/components/CodeExcerpt.module.scss
+++ b/client/shared/src/components/CodeExcerpt.module.scss
@@ -23,6 +23,10 @@
         padding-left: 1rem;
     }
 
+    :global(.hl-source) {
+        cursor: text;
+    }
+
     &-error {
         width: 100%;
     }

--- a/client/shared/src/components/FileMatchChildren.module.scss
+++ b/client/shared/src/components/FileMatchChildren.module.scss
@@ -7,23 +7,25 @@
 }
 
 .item {
-    text-decoration: none; /* don't use cascading link style */
     display: flex;
     align-items: center;
-    padding: 0.25rem 0.5rem;
+    /* A combination of padding and margin is used to make sure that the
+     * box-shadow used to mark the item as focused is visible.
+     */
+    padding: 0.125rem 0.375rem;
+    margin: 0.125rem;
     background-color: var(--code-bg);
+    /* Overflow has to be set here instead of the wrapper otherwise the focus
+     * box-shadow is off when the item is scrolled.
+     */
+    overflow-x: auto;
 
     &-clickable {
         cursor: pointer;
     }
 
-    &:hover {
-        text-decoration: none;
-    }
-
     &-code-wrapper {
         position: relative;
-        overflow-x: auto;
 
         &:not(:first-child) {
             border-top: 1px solid var(--border-color-2);

--- a/client/shared/src/components/FileMatchChildren.module.scss
+++ b/client/shared/src/components/FileMatchChildren.module.scss
@@ -9,13 +9,17 @@
 .item {
     display: flex;
     align-items: center;
-    /* A combination of padding and margin is used to make sure that the
+
+    /*
+     * A combination of padding and margin is used to make sure that the
      * box-shadow used to mark the item as focused is visible.
      */
     padding: 0.125rem 0.375rem;
     margin: 0.125rem;
     background-color: var(--code-bg);
-    /* Overflow has to be set here instead of the wrapper otherwise the focus
+
+    /*
+     * Overflow has to be set here instead of the wrapper otherwise the focus
      * box-shadow is off when the item is scrolled.
      */
     overflow-x: auto;

--- a/client/shared/src/components/FileMatchChildren.tsx
+++ b/client/shared/src/components/FileMatchChildren.tsx
@@ -152,10 +152,7 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
                             }`}
                             className={classNames('test-file-match-children-item-wrapper', styles.itemCodeWrapper)}
                         >
-                            <Link
-                                to={createCodeExcerptLink(group)}
-                                aria-label="Open file match"
-                            />
+                            <Link to={createCodeExcerptLink(group)} aria-label="Open file match" />
                             <div
                                 className={classNames(
                                     'test-file-match-children-item',

--- a/client/shared/src/components/FileMatchChildren.tsx
+++ b/client/shared/src/components/FileMatchChildren.tsx
@@ -66,7 +66,7 @@ function isTextSelectionEvent(event: MouseEvent<HTMLElement>): boolean {
         // CTRL+click would select the table cell. Since users don't know that we
         // use tables, the most likely wanted to open the search results in a new
         // tab instead though.
-        if (event.ctrlKey && selection.anchorNode?.nodeName === 'TR') {
+        if ((event.ctrlKey || event.metaKey) && selection.anchorNode?.nodeName === 'TR') {
             // Ugly side effect: We don't want the table cell to be highlighted.
             // The focus style that Firefox uses doesn't seem to be affected by
             // CSS so instead we clear the selection.


### PR DESCRIPTION
Solves #30002 

This makes selection possible by converting the `<Link>` element to a `<div>` and check inside the click event handler whether text is selected or not.

But I also kept the `<Link>` element around, without content, to preserve the previous behavior:

- Instead of handling ctrl/meta+clicks ourselves, I'm letting the browser do the right thing by "forwarding" the click event to a real link.
- The link is also tabbable, thus preserving keyboard navigation (e.g. navigating to the search results when pressing enter).
- Since we don't have visual indicators for tabbing through file matches, keeping the link around will show the the URL at the bottom of the page (at least Firefox does that).

I tested it in Chromium and Firefox and didn't find any issues. Somehow needs to test it in Safari.