### PR TITLE
Code Monitors: make the graphql response well-typed

### DIFF
--- a/enterprise/internal/codemonitors/background/graphql.go
+++ b/enterprise/internal/codemonitors/background/graphql.go
@@ -33,30 +33,16 @@ const gqlSearchQuery = `query CodeMonitorSearch(
 			timedout { name }
 			results {
 				__typename
-				... on FileMatch {
-					limitHit
-					lineMatches {
-						preview
-						lineNumber
-						offsetAndLengths
-					}
-				}
 				... on CommitSearchResult {
 					refs {
 						name
 						displayName
 						prefix
-						repository {
-							name
-						}
 					}
 					sourceRefs {
 						name
 						displayName
 						prefix
-						repository {
-							name
-						}
 					}
 					messagePreview {
 						value
@@ -79,11 +65,9 @@ const gqlSearchQuery = `query CodeMonitorSearch(
 							name
 						}
 						oid
-						abbreviatedOID
 						author {
 							person {
 								displayName
-								avatarURL
 							}
 							date
 						}

--- a/enterprise/internal/codemonitors/background/graphql.go
+++ b/enterprise/internal/codemonitors/background/graphql.go
@@ -225,12 +225,8 @@ func gqlURL(queryName string) (string, error) {
 }
 
 // extractTime extracts the time from the given search result.
-func extractTime(result commitSearchResult) (*time.Time, error) {
+func extractTime(result commitSearchResult) (time.Time, error) {
 	// This relies on the date format that our API returns. It was previously broken
 	// and should be checked first in case date extraction stops working.
-	t, err := time.Parse(time.RFC3339, result.Commit.Author.Date)
-	if err != nil {
-		return nil, err
-	}
-	return &t, nil
+	return time.Parse(time.RFC3339, result.Commit.Author.Date)
 }

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -387,7 +387,7 @@ func latestResultTime(previousLastResult *time.Time, v *gqlSearchResponse, searc
 		// Error already logged by extractTime.
 		return time.Now()
 	}
-	return *t
+	return t
 }
 
 func zeroOrVal(i *int) int {


### PR DESCRIPTION
This modifies the type we unmarshal the GraphQL response into so that it is more well-typed. Previously, we were using a bunch of interface types, which forced us to do a bunch of fragile type introspection whenever we wanted to get the data out of it. 

Additionally, this slims down the graphql query to better fit the domain. We don't need a `FileMatch` fragment for code monitor searches because there should only ever be `CommitSearchResult` in the results. This is enforced at JSON deserialization time. 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
