### PR TITLE
search: mint search routine type

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -38,12 +38,12 @@ func (srs *searchResultsStats) Languages(ctx context.Context) ([]*languageStatis
 
 func (srs *searchResultsStats) getResults(ctx context.Context) (*SearchResultsResolver, error) {
 	srs.once.Do(func() {
-		jobs, repoOptions, timeout, err := srs.sr.toSearchInputs(srs.sr.Query)
+		routine, err := srs.sr.toSearchRoutine(srs.sr.Query)
 		if err != nil {
 			srs.srsErr = err
 			return
 		}
-		results, err := srs.sr.doResults(ctx, jobs, repoOptions, timeout)
+		results, err := srs.sr.doResults(ctx, routine)
 		if err != nil {
 			srs.srsErr = err
 			return

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -899,9 +899,9 @@ func Test_toSearchInputs(t *testing.T) {
 				PatternType:  query.SearchTypeLiteral,
 			},
 		}
-		jobs, _, _, _ := resolver.toSearchInputs(q)
+		routine, _ := resolver.toSearchRoutine(q)
 		var jobNames []string
-		for _, j := range jobs {
+		for _, j := range routine.Jobs {
 			jobNames = append(jobNames, j.Name())
 		}
 		return strings.Join(jobNames, ",")

--- a/internal/search/run/run.go
+++ b/internal/search/run/run.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"context"
+	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/search"
@@ -24,12 +25,10 @@ type SearchInputs struct {
 	DefaultLimit int
 }
 
-// Job is an interface shared by all search backends. Calling Run on a job
-// object runs a search. The relation with SearchInputs and Jobs is that
-// SearchInputs are static values, parsed and validated, to produce Jobs. Jobs
-// express semantic behavior at runtime across different backends and system
-// architecture. The third argument accepts resolved repositories (which may or
-// may not be required, depending on the job. E.g., a global search job does not
+// Job is an interface shared by all individual search operations in the backend
+// (e.g., text vs commit vs symbol search are represented as different jobs).
+// Calling Run on a job object runs a search. The third argument accepts resolved repositories (which may or may
+// not be required, depending on the job. E.g., a global search job does not
 // require upfront repository resolution).
 type Job interface {
 	Run(context.Context, streaming.Sender, searchrepos.Pager) error
@@ -41,6 +40,20 @@ type Job interface {
 	// set of required and optional jobs concurrently, and cancel optional
 	// jobs once we've guaranteed some required results, or after a timeout.
 	Required() bool
+}
+
+// Routine represents all inputs to run multiple search operations (i.e.,
+// multiple Jobs) in a single search routine. In other words, it executes all
+// jobs that may be implemented by different search engines (Zoekt vs Searcher)
+// or return different result types (text vs. symbols). The relation with
+// SearchInputs and Routine is that SearchInputs are static values, parsed and
+// validated, to produce one or more Routines. Routines express the complete
+// information to execute the runtime semantics for particular search
+// operations.
+type Routine struct {
+	Jobs        []Job
+	RepoOptions search.RepoOptions
+	Timeout     time.Duration
 }
 
 // MaxResults computes the limit for the query.


### PR DESCRIPTION
This mints a `Routine` type to hold the 3-tuple values previously used to evaluate a toplevel search:

```go
type Routine struct {
	Jobs        []Job
	RepoOptions search.RepoOptions
	Timeout     time.Duration
}
```

After thinking about a name for this type and settling on `Routine`, and propagating it, I think it works well. See docstring for more details.


This is semantics-preserving. Comments and functions are updated to reflect this type. This structure is generally more comprehensible, but there's another motivation. Optional reading below if you want to understand why.


---

The main motivation is that I want to move from our current `evaluate*(...)` functions that operate on `query.Basic`, to instead evaluate on `run.Routine`. That is, a search query plan gets converted to a tree of `run.Routine`. This conversion phase is needed if we want to do optimizations (like Zoekt `and`) cleanly. Currently there's an issue with the order in which search jobs/routines are evaluated. If we implemented the Zoekt optimization now, we'd effectively have to go and find search routines containing zoekt jobs (where the work has already been split up) and replace it with the Zoekt-optimized job, OR, we'd have to add the Zoeekt-optimized job to a routine, and then pass some conditional so that subsequent `and` logic does not also add unoptimized Zoekt jobs. If this doesn't quite make sense, don't worry about it. The point is that the eval functions operate on a `query.Basic` type and impose a certain ordering of job/routine creation that makes it difficult to modify the output of that creation for optimized backend queries. The solution is to not operate on `query.Basic` during eval, but instead convert it before eval to a tree of routines. The intent has always been to not evaluate on `query.Basic` and I made a comment about this ages ago--we want to evaluate on our internal type (best represented by `Routine` now). 

There is no reason we can't turn a query into a tree of `Routines`, and, in fact, our `type Plan []query.Basic` is going to eventually be `type Plan <tree of routines>`. Actually that will probably happen pretty soon, because that representation is conducive to the optimization phase. Keegan has brought up the idea of an "IR" for our search code, and `type Plan <tree of routines>` is currently our best representation of that "IR". Notably that representation of a backend plan should not (and should never have had to) care directly about anything in the query string.