### PR TITLE
Search jobs: spike out some search combinator jobs

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -920,10 +920,10 @@ func (r *searchResolver) toSearchRoutine(q query.Q) (*run.Routine, error) {
 	}
 
 	return &run.Routine{
-		Job: &run.RequiredAndOptionalJob{
-			Required: &run.ParallelJob{Children: requiredJobs},
-			Optional: &run.ParallelJob{Children: optionalJobs},
-		},
+		Job: run.NewRequiredAndOptionalJob(
+			run.NewParallelJob(requiredJobs...),
+			run.NewParallelJob(optionalJobs...),
+		),
 		RepoOptions: repoOptions,
 		Timeout:     args.Timeout,
 	}, nil

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -920,7 +920,7 @@ func (r *searchResolver) toSearchRoutine(q query.Q) (*run.Routine, error) {
 	}
 
 	return &run.Routine{
-		Job: run.NewRequiredAndOptionalJob(
+		Job: run.NewJobWithOptional(
 			run.NewParallelJob(requiredJobs...),
 			run.NewParallelJob(optionalJobs...),
 		),

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -921,8 +921,8 @@ func (r *searchResolver) toSearchRoutine(q query.Q) (*run.Routine, error) {
 
 	return &run.Routine{
 		Job: &run.RequiredAndOptionalJob{
-			Required: &run.ParallelJob{Jobs: requiredJobs},
-			Optional: &run.ParallelJob{Jobs: optionalJobs},
+			Required: &run.ParallelJob{Children: requiredJobs},
+			Optional: &run.ParallelJob{Children: optionalJobs},
 		},
 		RepoOptions: repoOptions,
 		Timeout:     args.Timeout,

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -617,7 +617,15 @@ func (r *searchResolver) toSearchRoutine(q query.Q) (*run.Routine, error) {
 	// still relies on all of args. In time it should depend only on the bits it truly needs.
 	args.RepoOptions = repoOptions
 
-	var jobs []run.Job
+	var requiredJobs, optionalJobs []run.Job
+	addJob := func(required bool, job run.Job) {
+		if required {
+			requiredJobs = append(requiredJobs, job)
+		} else {
+			optionalJobs = append(optionalJobs, job)
+		}
+	}
+
 	{
 		// This code block creates search jobs under specific
 		// conditions, and depending on generic process of `args` above.
@@ -673,7 +681,7 @@ func (r *searchResolver) toSearchRoutine(q query.Q) (*run.Routine, error) {
 					Zoekt:          args.Zoekt,
 				}
 
-				jobs = append(jobs, &unindexed.RepoUniverseTextSearch{
+				addJob(true, &unindexed.RepoUniverseTextSearch{
 					GlobalZoektQuery: globalZoektQuery,
 					ZoektArgs:        zoektArgs,
 					FileMatchLimit:   args.PatternInfo.FileMatchLimit,
@@ -699,7 +707,7 @@ func (r *searchResolver) toSearchRoutine(q query.Q) (*run.Routine, error) {
 					Zoekt:          args.Zoekt,
 				}
 
-				jobs = append(jobs, &symbol.RepoUniverseSymbolSearch{
+				addJob(true, &symbol.RepoUniverseSymbolSearch{
 					GlobalZoektQuery: globalZoektQuery,
 					ZoektArgs:        zoektArgs,
 					PatternInfo:      args.PatternInfo,
@@ -735,7 +743,7 @@ func (r *searchResolver) toSearchRoutine(q query.Q) (*run.Routine, error) {
 					UseFullDeadline: args.UseFullDeadline,
 				}
 
-				jobs = append(jobs, &unindexed.RepoSubsetTextSearch{
+				addJob(true, &unindexed.RepoSubsetTextSearch{
 					ZoektArgs:         zoektArgs,
 					SearcherArgs:      searcherArgs,
 					FileMatchLimit:    args.PatternInfo.FileMatchLimit,
@@ -762,7 +770,8 @@ func (r *searchResolver) toSearchRoutine(q query.Q) (*run.Routine, error) {
 					Zoekt:          args.Zoekt,
 				}
 
-				jobs = append(jobs, &symbol.RepoSubsetSymbolSearch{
+				required := args.UseFullDeadline || args.ResultTypes.Without(result.TypeSymbol) == 0
+				addJob(required, &symbol.RepoSubsetSymbolSearch{
 					ZoektArgs:         zoektArgs,
 					PatternInfo:       args.PatternInfo,
 					Limit:             r.MaxResults(),
@@ -776,7 +785,15 @@ func (r *searchResolver) toSearchRoutine(q query.Q) (*run.Routine, error) {
 
 		if args.ResultTypes.Has(result.TypeCommit) || args.ResultTypes.Has(result.TypeDiff) {
 			diff := args.ResultTypes.Has(result.TypeDiff)
-			jobs = append(jobs, &commit.CommitSearch{
+			var required bool
+			if args.UseFullDeadline {
+				required = true
+			} else if diff {
+				required = args.ResultTypes.Without(result.TypeDiff) == 0
+			} else {
+				required = args.ResultTypes.Without(result.TypeCommit) == 0
+			}
+			addJob(required, &commit.CommitSearch{
 				Query:         commit.QueryToGitQuery(args.Query, diff),
 				RepoOpts:      repoOptions,
 				Diff:          diff,
@@ -806,7 +823,7 @@ func (r *searchResolver) toSearchRoutine(q query.Q) (*run.Routine, error) {
 				UseFullDeadline: args.UseFullDeadline,
 			}
 
-			jobs = append(jobs, &unindexed.StructuralSearch{
+			addJob(true, &unindexed.StructuralSearch{
 				ZoektArgs:    zoektArgs,
 				SearcherArgs: searcherArgs,
 
@@ -893,7 +910,7 @@ func (r *searchResolver) toSearchRoutine(q query.Q) (*run.Routine, error) {
 			if valid() {
 				if repoOptions, ok := addPatternAsRepoFilter(args.PatternInfo.Pattern, repoOptions); ok {
 					args.RepoOptions = repoOptions
-					jobs = append(jobs, &run.RepoSearch{
+					addJob(true, &run.RepoSearch{
 						Args:  &args,
 						Limit: r.MaxResults(),
 					})
@@ -902,42 +919,14 @@ func (r *searchResolver) toSearchRoutine(q query.Q) (*run.Routine, error) {
 		}
 	}
 
-	for _, job := range jobs {
-		switch j := job.(type) {
-		case *commit.CommitSearch:
-			if args.UseFullDeadline {
-				j.IsRequired = true
-				continue
-			}
-
-			if job.Name() == "Diff" {
-				j.IsRequired = (args.ResultTypes.Without(result.TypeDiff) == 0)
-			} else {
-				j.IsRequired = (args.ResultTypes.Without(result.TypeCommit) == 0)
-			}
-		case *symbol.RepoSubsetSymbolSearch:
-			if args.UseFullDeadline {
-				j.IsRequired = true
-				continue
-			}
-
-			j.IsRequired = (args.ResultTypes.Without(result.TypeSymbol) == 0)
-		case *symbol.RepoUniverseSymbolSearch:
-			j.IsRequired = true
-		case *run.RepoSearch:
-			j.IsRequired = true
-		case *unindexed.RepoSubsetTextSearch:
-			j.IsRequired = true
-		case *unindexed.RepoUniverseTextSearch:
-			j.IsRequired = true
-		case *unindexed.StructuralSearch:
-			j.IsRequired = true
-
-		default:
-			panic(fmt.Sprintf("unknown job type: %q", j))
-		}
-	}
-	return &run.Routine{Jobs: jobs, RepoOptions: repoOptions, Timeout: args.Timeout}, nil
+	return &run.Routine{
+		Job: &run.RequiredAndOptionalJob{
+			Required: &run.ParallelJob{Jobs: requiredJobs},
+			Optional: &run.ParallelJob{Jobs: optionalJobs},
+		},
+		RepoOptions: repoOptions,
+		Timeout:     args.Timeout,
+	}, nil
 }
 
 // intersect returns the intersection of two sets of search result content
@@ -1808,23 +1797,10 @@ func (r *searchResolver) doResults(ctx context.Context, routine *run.Routine) (r
 		tr.Finish()
 	}()
 
-	start := time.Now()
-
 	ctx, cancel := context.WithTimeout(ctx, routine.Timeout)
 	defer cancel()
 
 	limit := r.MaxResults()
-	var (
-		requiredWg sync.WaitGroup
-		optionalWg sync.WaitGroup
-	)
-
-	waitGroup := func(required bool) *sync.WaitGroup {
-		if required {
-			return &requiredWg
-		}
-		return &optionalWg
-	}
 
 	// For streaming search we want to limit based on all results, not just
 	// per backend. This works better than batch based since we have higher
@@ -1839,22 +1815,9 @@ func (r *searchResolver) doResults(ctx context.Context, routine *run.Routine) (r
 
 	agg := run.NewAggregator(stream)
 
-	// This ensures we properly cleanup in the case of an early return. In
-	// particular we want to cancel global searches before returning early.
-	hasStartedAllBackends := false
-	defer func() {
-		if hasStartedAllBackends {
-			return
-		}
-		cancel()
-		requiredWg.Wait()
-		optionalWg.Wait()
-		_, _, _, _ = agg.Get()
-	}()
-
 	repoOptionsCopy := routine.RepoOptions
+	var wg sync.WaitGroup
 	{
-		wg := waitGroup(true)
 		wg.Add(1)
 		goroutine.Go(func() {
 			defer wg.Done()
@@ -1882,32 +1845,7 @@ func (r *searchResolver) doResults(ctx context.Context, routine *run.Routine) (r
 		DB:   r.db,
 	}
 
-	// Start all specific search jobs, if any.
-	for _, job := range routine.Jobs {
-		job := job
-		wg := waitGroup(job.Required())
-		wg.Add(1)
-		goroutine.Go(func() {
-			defer wg.Done()
-			_ = agg.DoSearch(ctx, job, repos)
-		})
-	}
-
-	hasStartedAllBackends = true
-
-	// Wait for required searches.
-	requiredWg.Wait()
-
-	// Give optional searches some minimum budget in case required searches return quickly.
-	// Cancel all remaining searches after this minimum budget.
-	budget := 100 * time.Millisecond
-	elapsed := time.Since(start)
-	timer := time.AfterFunc(budget-elapsed, cancel)
-
-	// Wait for remaining optional searches to finish or get cancelled.
-	optionalWg.Wait()
-
-	timer.Stop()
+	_ = agg.DoSearch(ctx, routine.Job, repos)
 
 	return r.toSearchResults(ctx, agg)
 }

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -906,15 +906,15 @@ func Test_toSearchInputs(t *testing.T) {
 	// Job generation for global vs non-global search
 	autogold.Want("user search context", "RequiredAndOptionalJob{Required: ParallelJob{RepoSubsetText, Repo}, Optional: ParallelJob{}}").Equal(t, test(`foo context:@userA`, query.ParseLiteral))
 	autogold.Want("universal (AKA global) search context", "RequiredAndOptionalJob{Required: ParallelJob{RepoUniverseText, Repo}, Optional: ParallelJob{}}").Equal(t, test(`foo context:global`, query.ParseLiteral))
-	autogold.Want("universal (AKA global) search", "RepoUniverseText,Repo").Equal(t, test(`foo`, query.ParseLiteral))
-	autogold.Want("nonglobal repo", "RepoSubsetText,Repo").Equal(t, test(`foo repo:sourcegraph/sourcegraph`, query.ParseLiteral))
-	autogold.Want("nonglobal repo contains", "RepoSubsetText,Repo").Equal(t, test(`foo repo:contains(bar)`, query.ParseLiteral))
+	autogold.Want("universal (AKA global) search", "RequiredAndOptionalJob{Required: ParallelJob{RepoUniverseText, Repo}, Optional: ParallelJob{}}").Equal(t, test(`foo`, query.ParseLiteral))
+	autogold.Want("nonglobal repo", "RequiredAndOptionalJob{Required: ParallelJob{RepoSubsetText, Repo}, Optional: ParallelJob{}}").Equal(t, test(`foo repo:sourcegraph/sourcegraph`, query.ParseLiteral))
+	autogold.Want("nonglobal repo contains", "RequiredAndOptionalJob{Required: ParallelJob{RepoSubsetText, Repo}, Optional: ParallelJob{}}").Equal(t, test(`foo repo:contains(bar)`, query.ParseLiteral))
 
 	// Job generation support for implied `type:repo` queries.
-	autogold.Want("supported Repo job", "RepoUniverseText,Repo").Equal(t, test("ok ok", query.ParseRegexp))
-	autogold.Want("supportedRepo job literal", "RepoUniverseText,Repo").Equal(t, test("ok @thing", query.ParseLiteral))
-	autogold.Want("unsupported Repo job prefix", "RepoUniverseText").Equal(t, test("@nope", query.ParseRegexp))
-	autogold.Want("unsupported Repo job regexp", "RepoUniverseText").Equal(t, test("foo @bar", query.ParseRegexp))
+	autogold.Want("supported Repo job", "RequiredAndOptionalJob{Required: ParallelJob{RepoUniverseText, Repo}, Optional: ParallelJob{}}").Equal(t, test("ok ok", query.ParseRegexp))
+	autogold.Want("supportedRepo job literal", "RequiredAndOptionalJob{Required: ParallelJob{RepoUniverseText, Repo}, Optional: ParallelJob{}}").Equal(t, test("ok @thing", query.ParseLiteral))
+	autogold.Want("unsupported Repo job prefix", "RequiredAndOptionalJob{Required: ParallelJob{RepoUniverseText}, Optional: ParallelJob{}}").Equal(t, test("@nope", query.ParseRegexp))
+	autogold.Want("unsupported Repo job regexp", "RequiredAndOptionalJob{Required: ParallelJob{RepoUniverseText}, Optional: ParallelJob{}}").Equal(t, test("foo @bar", query.ParseRegexp))
 }
 
 func TestZeroElapsedMilliseconds(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -921,6 +921,7 @@ func Test_toSearchInputs(t *testing.T) {
 	autogold.Want("commit", "Commit").Equal(t, test("type:commit test", query.ParseRegexp))
 	autogold.Want("diff", "Diff").Equal(t, test("type:diff test", query.ParseRegexp))
 	autogold.Want("file or commit", "JobWithOptional{Required: RepoUniverseText, Optional: Commit}").Equal(t, test("type:file type:commit test", query.ParseRegexp))
+	autogold.Want("many types", "JobWithOptional{Required: ParallelJob{RepoSubsetText, Repo}, Optional: ParallelJob{RepoSubsetSymbol, Commit}}").Equal(t, test("type:file type:path type:repo type:commit type:symbol repo:test test", query.ParseRegexp))
 }
 
 func TestZeroElapsedMilliseconds(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -915,6 +915,12 @@ func Test_toSearchInputs(t *testing.T) {
 	autogold.Want("supportedRepo job literal", "ParallelJob{RepoUniverseText, Repo}").Equal(t, test("ok @thing", query.ParseLiteral))
 	autogold.Want("unsupported Repo job prefix", "RepoUniverseText").Equal(t, test("@nope", query.ParseRegexp))
 	autogold.Want("unsupported Repo job regexp", "RepoUniverseText").Equal(t, test("foo @bar", query.ParseRegexp))
+
+	// Job generation for other types of search
+	autogold.Want("symbol", "RepoUniverseSymbol").Equal(t, test("type:symbol test", query.ParseRegexp))
+	autogold.Want("commit", "Commit").Equal(t, test("type:commit test", query.ParseRegexp))
+	autogold.Want("diff", "Diff").Equal(t, test("type:diff test", query.ParseRegexp))
+	autogold.Want("file or commit", "RequiredAndOptionalJob{Required: RepoUniverseText, Optional: Commit}").Equal(t, test("type:file type:commit test", query.ParseRegexp))
 }
 
 func TestZeroElapsedMilliseconds(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -904,8 +904,8 @@ func Test_toSearchInputs(t *testing.T) {
 	}
 
 	// Job generation for global vs non-global search
-	autogold.Want("user search context", "RepoSubsetText,Repo").Equal(t, test(`foo context:@userA`, query.ParseLiteral))
-	autogold.Want("universal (AKA global) search context", "RepoUniverseText,Repo").Equal(t, test(`foo context:global`, query.ParseLiteral))
+	autogold.Want("user search context", "RequiredAndOptionalJob{Required: ParallelJob{RepoSubsetText, Repo}, Optional: ParallelJob{}}").Equal(t, test(`foo context:@userA`, query.ParseLiteral))
+	autogold.Want("universal (AKA global) search context", "RequiredAndOptionalJob{Required: ParallelJob{RepoUniverseText, Repo}, Optional: ParallelJob{}}").Equal(t, test(`foo context:global`, query.ParseLiteral))
 	autogold.Want("universal (AKA global) search", "RepoUniverseText,Repo").Equal(t, test(`foo`, query.ParseLiteral))
 	autogold.Want("nonglobal repo", "RepoSubsetText,Repo").Equal(t, test(`foo repo:sourcegraph/sourcegraph`, query.ParseLiteral))
 	autogold.Want("nonglobal repo contains", "RepoSubsetText,Repo").Equal(t, test(`foo repo:contains(bar)`, query.ParseLiteral))

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -920,7 +920,7 @@ func Test_toSearchInputs(t *testing.T) {
 	autogold.Want("symbol", "RepoUniverseSymbol").Equal(t, test("type:symbol test", query.ParseRegexp))
 	autogold.Want("commit", "Commit").Equal(t, test("type:commit test", query.ParseRegexp))
 	autogold.Want("diff", "Diff").Equal(t, test("type:diff test", query.ParseRegexp))
-	autogold.Want("file or commit", "RequiredAndOptionalJob{Required: RepoUniverseText, Optional: Commit}").Equal(t, test("type:file type:commit test", query.ParseRegexp))
+	autogold.Want("file or commit", "JobWithOptional{Required: RepoUniverseText, Optional: Commit}").Equal(t, test("type:file type:commit test", query.ParseRegexp))
 }
 
 func TestZeroElapsedMilliseconds(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -904,17 +904,17 @@ func Test_toSearchInputs(t *testing.T) {
 	}
 
 	// Job generation for global vs non-global search
-	autogold.Want("user search context", "RequiredAndOptionalJob{Required: ParallelJob{RepoSubsetText, Repo}, Optional: ParallelJob{}}").Equal(t, test(`foo context:@userA`, query.ParseLiteral))
-	autogold.Want("universal (AKA global) search context", "RequiredAndOptionalJob{Required: ParallelJob{RepoUniverseText, Repo}, Optional: ParallelJob{}}").Equal(t, test(`foo context:global`, query.ParseLiteral))
-	autogold.Want("universal (AKA global) search", "RequiredAndOptionalJob{Required: ParallelJob{RepoUniverseText, Repo}, Optional: ParallelJob{}}").Equal(t, test(`foo`, query.ParseLiteral))
-	autogold.Want("nonglobal repo", "RequiredAndOptionalJob{Required: ParallelJob{RepoSubsetText, Repo}, Optional: ParallelJob{}}").Equal(t, test(`foo repo:sourcegraph/sourcegraph`, query.ParseLiteral))
-	autogold.Want("nonglobal repo contains", "RequiredAndOptionalJob{Required: ParallelJob{RepoSubsetText, Repo}, Optional: ParallelJob{}}").Equal(t, test(`foo repo:contains(bar)`, query.ParseLiteral))
+	autogold.Want("user search context", "ParallelJob{RepoSubsetText, Repo}").Equal(t, test(`foo context:@userA`, query.ParseLiteral))
+	autogold.Want("universal (AKA global) search context", "ParallelJob{RepoUniverseText, Repo}").Equal(t, test(`foo context:global`, query.ParseLiteral))
+	autogold.Want("universal (AKA global) search", "ParallelJob{RepoUniverseText, Repo}").Equal(t, test(`foo`, query.ParseLiteral))
+	autogold.Want("nonglobal repo", "ParallelJob{RepoSubsetText, Repo}").Equal(t, test(`foo repo:sourcegraph/sourcegraph`, query.ParseLiteral))
+	autogold.Want("nonglobal repo contains", "ParallelJob{RepoSubsetText, Repo}").Equal(t, test(`foo repo:contains(bar)`, query.ParseLiteral))
 
 	// Job generation support for implied `type:repo` queries.
-	autogold.Want("supported Repo job", "RequiredAndOptionalJob{Required: ParallelJob{RepoUniverseText, Repo}, Optional: ParallelJob{}}").Equal(t, test("ok ok", query.ParseRegexp))
-	autogold.Want("supportedRepo job literal", "RequiredAndOptionalJob{Required: ParallelJob{RepoUniverseText, Repo}, Optional: ParallelJob{}}").Equal(t, test("ok @thing", query.ParseLiteral))
-	autogold.Want("unsupported Repo job prefix", "RequiredAndOptionalJob{Required: ParallelJob{RepoUniverseText}, Optional: ParallelJob{}}").Equal(t, test("@nope", query.ParseRegexp))
-	autogold.Want("unsupported Repo job regexp", "RequiredAndOptionalJob{Required: ParallelJob{RepoUniverseText}, Optional: ParallelJob{}}").Equal(t, test("foo @bar", query.ParseRegexp))
+	autogold.Want("supported Repo job", "ParallelJob{RepoUniverseText, Repo}").Equal(t, test("ok ok", query.ParseRegexp))
+	autogold.Want("supportedRepo job literal", "ParallelJob{RepoUniverseText, Repo}").Equal(t, test("ok @thing", query.ParseLiteral))
+	autogold.Want("unsupported Repo job prefix", "RepoUniverseText").Equal(t, test("@nope", query.ParseRegexp))
+	autogold.Want("unsupported Repo job regexp", "RepoUniverseText").Equal(t, test("foo @bar", query.ParseRegexp))
 }
 
 func TestZeroElapsedMilliseconds(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -900,11 +900,7 @@ func Test_toSearchInputs(t *testing.T) {
 			},
 		}
 		routine, _ := resolver.toSearchRoutine(q)
-		var jobNames []string
-		for _, j := range routine.Jobs {
-			jobNames = append(jobNames, j.Name())
-		}
-		return strings.Join(jobNames, ",")
+		return routine.Job.Name()
 	}
 
 	// Job generation for global vs non-global search

--- a/internal/search/commit/commit_new.go
+++ b/internal/search/commit/commit_new.go
@@ -30,8 +30,6 @@ type CommitSearch struct {
 	Limit         int
 
 	Db database.DB
-
-	IsRequired bool
 }
 
 func (j *CommitSearch) Run(ctx context.Context, stream streaming.Sender, repos searchrepos.Pager) error {
@@ -107,10 +105,6 @@ func (j CommitSearch) Name() string {
 		return "Diff"
 	}
 	return "Commit"
-}
-
-func (j CommitSearch) Required() bool {
-	return j.IsRequired
 }
 
 func (j *CommitSearch) ExpandUsernames(ctx context.Context, db database.DB) (err error) {

--- a/internal/search/run/combinators.go
+++ b/internal/search/run/combinators.go
@@ -28,7 +28,7 @@ type JobWithOptional struct {
 }
 
 func (r *JobWithOptional) Name() string {
-	return fmt.Sprintf("RequiredAndOptionalJob{Required: %s, Optional: %s}", r.required.Name(), r.optional.Name())
+	return fmt.Sprintf("JobWithOptional{Required: %s, Optional: %s}", r.required.Name(), r.optional.Name())
 }
 
 func (r *JobWithOptional) Run(ctx context.Context, s streaming.Sender, pager searchrepos.Pager) error {
@@ -93,7 +93,7 @@ func (p *ParallelJob) Run(ctx context.Context, s streaming.Sender, pager searchr
 			return job.Run(ctx, s, pager)
 		})
 	}
-	return g.Wait()
+	return g.Wait().ErrorOrNil()
 }
 
 type emptyJob struct{}

--- a/internal/search/run/meta_jobs.go
+++ b/internal/search/run/meta_jobs.go
@@ -1,0 +1,74 @@
+package run
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+
+	searchrepos "github.com/sourcegraph/sourcegraph/internal/search/repos"
+	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+)
+
+type RequiredAndOptionalJob struct {
+	Required Job
+	Optional Job
+}
+
+func (r *RequiredAndOptionalJob) Name() string {
+	return fmt.Sprintf("RequiredAndOptionalJob{Required: %s, Optional: %s}", r.Required.Name(), r.Optional.Name())
+}
+
+func (r *RequiredAndOptionalJob) Run(ctx context.Context, s streaming.Sender, pager searchrepos.Pager) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var optionalGroup, requiredGroup multierror.Group
+	requiredGroup.Go(func() error {
+		return r.Required.Run(ctx, s, pager)
+	})
+	optionalGroup.Go(func() error {
+		return r.Optional.Run(ctx, s, pager)
+	})
+
+	var errs *multierror.Error
+	if err := requiredGroup.Wait(); err != nil {
+		errs = multierror.Append(errs, err)
+	}
+
+	// Give optional searches some minimum budget in case required searches return quickly.
+	// Cancel all remaining searches after this minimum budget.
+	budget := 100 * time.Millisecond
+	time.AfterFunc(budget, cancel)
+
+	if err := optionalGroup.Wait(); err != nil {
+		errs = multierror.Append(errs, err)
+	}
+
+	return errs.ErrorOrNil()
+}
+
+type ParallelJob struct {
+	Jobs []Job
+}
+
+func (p *ParallelJob) Name() string {
+	var childNames []string
+	for _, job := range p.Jobs {
+		childNames = append(childNames, job.Name())
+	}
+	return fmt.Sprintf("ParallelJob{%s}", strings.Join(childNames, ", "))
+}
+
+func (p *ParallelJob) Run(ctx context.Context, s streaming.Sender, pager searchrepos.Pager) error {
+	var g multierror.Group
+	for _, job := range p.Jobs {
+		job := job
+		g.Go(func() error {
+			return job.Run(ctx, s, pager)
+		})
+	}
+	return g.Wait()
+}

--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -21,8 +21,6 @@ import (
 type RepoSearch struct {
 	Args  *search.TextParameters
 	Limit int
-
-	IsRequired bool
 }
 
 func (s *RepoSearch) Run(ctx context.Context, stream streaming.Sender, repos searchrepos.Pager) (err error) {
@@ -69,10 +67,6 @@ func (s *RepoSearch) Run(ctx context.Context, stream streaming.Sender, repos sea
 
 func (*RepoSearch) Name() string {
 	return "Repo"
-}
-
-func (s *RepoSearch) Required() bool {
-	return s.IsRequired
 }
 
 func repoRevsToRepoMatches(ctx context.Context, repos []*search.RepositoryRevisions) []result.Match {

--- a/internal/search/run/run.go
+++ b/internal/search/run/run.go
@@ -33,13 +33,6 @@ type SearchInputs struct {
 type Job interface {
 	Run(context.Context, streaming.Sender, searchrepos.Pager) error
 	Name() string
-
-	// Required sets whether the results of this job are required. If true,
-	// we must wait for its routines to complete. If false, the job is
-	// optional, expressing that we may cancel the job. We typically run a
-	// set of required and optional jobs concurrently, and cancel optional
-	// jobs once we've guaranteed some required results, or after a timeout.
-	Required() bool
 }
 
 // Routine represents all inputs to run multiple search operations (i.e.,
@@ -51,7 +44,7 @@ type Job interface {
 // information to execute the runtime semantics for particular search
 // operations.
 type Routine struct {
-	Jobs        []Job
+	Job         Job
 	RepoOptions search.RepoOptions
 	Timeout     time.Duration
 }

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -417,8 +417,6 @@ type RepoSubsetSymbolSearch struct {
 	UseIndex          query.YesNoOnly
 	ContainsRefGlobs  bool
 	OnMissingRepoRevs zoektutil.OnMissingRepoRevs
-
-	IsRequired bool
 }
 
 func (s *RepoSubsetSymbolSearch) Run(ctx context.Context, stream streaming.Sender, repos searchrepos.Pager) error {
@@ -446,10 +444,6 @@ func (*RepoSubsetSymbolSearch) Name() string {
 	return "RepoSubsetSymbol"
 }
 
-func (s *RepoSubsetSymbolSearch) Required() bool {
-	return s.IsRequired
-}
-
 type RepoUniverseSymbolSearch struct {
 	GlobalZoektQuery *zoektutil.GlobalZoektQuery
 	ZoektArgs        *search.ZoektParameters
@@ -458,8 +452,6 @@ type RepoUniverseSymbolSearch struct {
 
 	RepoOptions search.RepoOptions
 	Db          database.DB
-
-	IsRequired bool
 }
 
 func (s *RepoUniverseSymbolSearch) Run(ctx context.Context, stream streaming.Sender, _ searchrepos.Pager) error {
@@ -486,8 +478,4 @@ func (s *RepoUniverseSymbolSearch) Run(ctx context.Context, stream streaming.Sen
 
 func (*RepoUniverseSymbolSearch) Name() string {
 	return "RepoUniverseSymbol"
-}
-
-func (s *RepoUniverseSymbolSearch) Required() bool {
-	return s.IsRequired
 }

--- a/internal/search/unindexed/structural.go
+++ b/internal/search/unindexed/structural.go
@@ -156,8 +156,6 @@ type StructuralSearch struct {
 	UseIndex          query.YesNoOnly
 	ContainsRefGlobs  bool
 	OnMissingRepoRevs zoektutil.OnMissingRepoRevs
-
-	IsRequired bool
 }
 
 func (s *StructuralSearch) Run(ctx context.Context, stream streaming.Sender, repos searchrepos.Pager) error {
@@ -184,8 +182,4 @@ func (s *StructuralSearch) Run(ctx context.Context, stream streaming.Sender, rep
 
 func (*StructuralSearch) Name() string {
 	return "Structural"
-}
-
-func (s *StructuralSearch) Required() bool {
-	return s.IsRequired
 }

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -315,8 +315,6 @@ type RepoSubsetTextSearch struct {
 	UseIndex          query.YesNoOnly
 	ContainsRefGlobs  bool
 	OnMissingRepoRevs zoektutil.OnMissingRepoRevs
-
-	IsRequired bool
 }
 
 func (t *RepoSubsetTextSearch) Run(ctx context.Context, stream streaming.Sender, repos searchrepos.Pager) error {
@@ -344,10 +342,6 @@ func (*RepoSubsetTextSearch) Name() string {
 	return "RepoSubsetText"
 }
 
-func (t *RepoSubsetTextSearch) Required() bool {
-	return t.IsRequired
-}
-
 type RepoUniverseTextSearch struct {
 	GlobalZoektQuery *zoektutil.GlobalZoektQuery
 	ZoektArgs        *search.ZoektParameters
@@ -356,8 +350,6 @@ type RepoUniverseTextSearch struct {
 	RepoOptions search.RepoOptions
 	Db          database.DB
 	UserID      int32
-
-	IsRequired bool
 }
 
 func (t *RepoUniverseTextSearch) Run(ctx context.Context, stream streaming.Sender, _ searchrepos.Pager) error {
@@ -385,8 +377,4 @@ func (t *RepoUniverseTextSearch) Run(ctx context.Context, stream streaming.Sende
 
 func (*RepoUniverseTextSearch) Name() string {
 	return "RepoUniverseText"
-}
-
-func (t *RepoUniverseTextSearch) Required() bool {
-	return t.IsRequired
 }


### PR DESCRIPTION
Now that jobs are statically defined within the scope of a basic query, we can make combinator jobs that control the runtime behavior of a set of jobs. 

This creates two new combinator jobs; `JobWithOptional` and `ParallelJob`. 

`JobWithOptional` now encapsulates our logic for optional and required searches, allowing us to remove the `Required` method from the `Job` interface. 

`ParallelJob` encapsulates the process of running a set of jobs in parallel.