### PR TITLE
batches: move batch spec errors below editor

### DIFF
--- a/client/branded/src/components/alerts.tsx
+++ b/client/branded/src/components/alerts.tsx
@@ -12,8 +12,8 @@ export const renderError = (error: unknown): string =>
         .replace(/^<p>/, '')
         .replace(/<\/p>$/, '')
 
-export const ErrorMessage: React.FunctionComponent<{ error: unknown }> = ({ error }) => (
-    <Markdown wrapper="span" dangerousInnerHTML={renderError(error)} />
+export const ErrorMessage: React.FunctionComponent<{ className?: string; error: unknown }> = ({ className, error }) => (
+    <Markdown className={className} wrapper="span" dangerousInnerHTML={renderError(error)} />
 )
 
 export type ErrorAlertProps = {

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -1,6 +1,6 @@
 import { ApolloQueryResult } from '@apollo/client'
 import classNames from 'classnames'
-import { noop } from 'lodash'
+import { compact, noop } from 'lodash'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import React, { useCallback, useMemo, useState } from 'react'
 import { useHistory } from 'react-router'
@@ -33,6 +33,7 @@ import { BatchSpecDownloadLink } from '../BatchSpec'
 
 import { GET_BATCH_CHANGE_TO_EDIT, CREATE_EMPTY_BATCH_CHANGE } from './backend'
 import styles from './CreateOrEditBatchChangePage.module.scss'
+import { EditorFeedbackPanel } from './editor/EditorFeedbackPanel'
 import { MonacoBatchSpecEditor } from './editor/MonacoBatchSpecEditor'
 import { LibraryPane } from './library/LibraryPane'
 import { NamespaceSelector } from './NamespaceSelector'
@@ -176,6 +177,8 @@ const CreatePage: React.FunctionComponent<CreatePageProps> = ({ namespaceID, set
     )
 }
 
+const INVALID_BATCH_SPEC_TOOLTIP = "There's a problem with your batch spec code."
+
 interface EditPageProps extends ThemeProps, SettingsCascadeProps<Settings> {
     batchChange: EditBatchChangeFields
     refetchBatchChange: () => Promise<ApolloQueryResult<GetBatchChangeToEditResult>>
@@ -263,7 +266,10 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({
 
     // Disable the preview button if the batch spec code is invalid or the on: statement
     // is missing, or if we're already processing a preview.
-    const previewDisabled = useMemo(() => isValid !== true || isLoadingPreview, [isValid, isLoadingPreview])
+    const previewDisabled = useMemo(() => (isValid !== true ? INVALID_BATCH_SPEC_TOOLTIP : isLoadingPreview), [
+        isValid,
+        isLoadingPreview,
+    ])
 
     const workspacesPreviewResolution = useBatchSpecWorkspaceResolution(batchSpec, { fetchPolicy: 'cache-first' })
 
@@ -290,7 +296,7 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({
         // The execution tooltip only shows if the execute button is disabled, and explains why.
         const executionTooltip =
             isValid === false || previewError
-                ? "There's a problem with your batch spec."
+                ? INVALID_BATCH_SPEC_TOOLTIP
                 : !hasPreviewed
                 ? 'Preview workspaces first before you run.'
                 : batchSpecStale
@@ -309,16 +315,6 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({
         batchSpecStale,
         workspacesPreviewResolution?.state,
     ])
-
-    const errors =
-        codeErrors.update || codeErrors.validation || previewError || executeError ? (
-            <div className="w-100">
-                {codeErrors.update && <ErrorAlert error={codeErrors.update} />}
-                {codeErrors.validation && <ErrorAlert error={codeErrors.validation} />}
-                {previewError && <ErrorAlert error={previewError} />}
-                {executeError && <ErrorAlert error={executeError} />}
-            </div>
-        ) : null
 
     const buttons = (
         <>
@@ -353,13 +349,15 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({
             <div className={classNames(styles.editorLayoutContainer, 'd-flex flex-1')}>
                 <LibraryPane name={batchChange.name} onReplaceItem={clearErrorsAndHandleCodeChange} />
                 <div className={styles.editorContainer}>
-                    <h4>Batch spec</h4>
                     <MonacoBatchSpecEditor
                         batchChangeName={batchChange.name}
                         className={styles.editor}
                         isLightTheme={isLightTheme}
                         value={code}
                         onChange={clearErrorsAndHandleCodeChange}
+                    />
+                    <EditorFeedbackPanel
+                        errors={compact([codeErrors.update, codeErrors.validation, previewError, executeError])}
                     />
                 </div>
                 <div
@@ -368,7 +366,6 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({
                         'd-flex flex-column align-items-center pl-4'
                     )}
                 >
-                    {errors}
                     <WorkspacesPreview
                         batchSpec={batchSpec}
                         hasPreviewed={hasPreviewed}

--- a/client/web/src/enterprise/batches/create/editor/EditorFeedbackPanel.module.scss
+++ b/client/web/src/enterprise/batches/create/editor/EditorFeedbackPanel.module.scss
@@ -1,0 +1,4 @@
+.panel {
+    max-height: 15%;
+    overflow-y: auto;
+}

--- a/client/web/src/enterprise/batches/create/editor/EditorFeedbackPanel.tsx
+++ b/client/web/src/enterprise/batches/create/editor/EditorFeedbackPanel.tsx
@@ -1,0 +1,24 @@
+import classNames from 'classnames'
+import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
+import React from 'react'
+
+import { ErrorMessage } from '@sourcegraph/branded/src/components/alerts'
+
+import styles from './EditorFeedbackPanel.module.scss'
+
+export const EditorFeedbackPanel: React.FunctionComponent<{ errors: (string | Error)[] }> = ({ errors }) => {
+    if (errors.length === 0) {
+        return null
+    }
+
+    return (
+        <div className={classNames(styles.panel, 'rounded border bg-1 p-2 w-100 mt-2')}>
+            <h4 className="text-danger text-uppercase">
+                <AlertCircleIcon className="text-danger icon-inline" /> Validation Errors
+            </h4>
+            {errors.map(error => (
+                <ErrorMessage className="text-monospace" error={error} key={String(error)} />
+            ))}
+        </div>
+    )
+}

--- a/client/web/src/enterprise/batches/create/editor/MonacoBatchSpecEditor.tsx
+++ b/client/web/src/enterprise/batches/create/editor/MonacoBatchSpecEditor.tsx
@@ -79,13 +79,12 @@ export class MonacoBatchSpecEditor extends React.PureComponent<Props, State> {
             <MonacoEditor
                 className={classNames(styles.editor, this.props.className)}
                 language="yaml"
-                height="100%"
+                height="auto"
                 isLightTheme={this.props.isLightTheme}
                 value={this.props.value}
                 editorWillMount={this.editorWillMount}
                 options={{
                     lineNumbers: 'on',
-                    automaticLayout: true,
                     minimap: { enabled: false },
                     formatOnType: true,
                     formatOnPaste: true,

--- a/client/web/src/enterprise/batches/create/workspaces-preview/PreviewPrompt.tsx
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/PreviewPrompt.tsx
@@ -2,7 +2,8 @@ import SearchIcon from 'mdi-react/SearchIcon'
 import React from 'react'
 
 import { CodeSnippet } from '@sourcegraph/branded/src/components/CodeSnippet'
-import { Button } from '@sourcegraph/wildcard'
+
+import { ButtonTooltip } from '../../../../components/ButtonTooltip'
 
 import styles from './PreviewPrompt.module.scss'
 import { PreviewPromptIcon } from './PreviewPromptIcon'
@@ -23,8 +24,17 @@ const ON_STATEMENT = `on:
 export type PreviewPromptForm = 'Initial' | 'Error' | 'Update'
 
 interface PreviewPromptProps {
+    /**
+     * Function to submit the current input batch spec YAML to trigger a workspaces
+     * preview request.
+     */
     preview: () => void
-    disabled: boolean
+    /**
+     * Whether or not the preview button should be disabled due to their being a problem
+     * with the input batch spec YAML, or a preview request is already happening. An
+     * optional tooltip string to display may be provided in place of `true`.
+     */
+    disabled: boolean | string
     form: PreviewPromptForm
 }
 
@@ -34,10 +44,16 @@ interface PreviewPromptProps {
  */
 export const PreviewPrompt: React.FunctionComponent<PreviewPromptProps> = ({ preview, disabled, form }) => {
     const previewButton = (
-        <Button variant="success" disabled={disabled} onClick={preview}>
+        <ButtonTooltip
+            type="button"
+            className="btn btn-success mb-2"
+            disabled={!!disabled}
+            tooltip={typeof disabled === 'string' ? disabled : undefined}
+            onClick={preview}
+        >
             <SearchIcon className="icon-inline mr-1" />
             Preview workspaces
-        </Button>
+        </ButtonTooltip>
     )
 
     switch (form) {

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.tsx
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.tsx
@@ -25,9 +25,10 @@ interface WorkspacesPreviewProps {
     hasPreviewed: boolean
     /**
      * Whether or not the preview button should be disabled due to their being a problem
-     * with the input batch spec YAML, or a preview request is already happening.
+     * with the input batch spec YAML, or a preview request is already happening. An
+     * optional tooltip string to display may be provided in place of `true`.
      */
-    previewDisabled: boolean
+    previewDisabled: boolean | string
     /**
      * Function to submit the current input batch spec YAML to trigger a workspaces
      * preview request.


### PR DESCRIPTION
Moves the batch spec validation errors section to beneath the editor and brings them up-to-date with EM3 designs.

![Screen Shot 2022-01-21 at 2 49 52 PM](https://user-images.githubusercontent.com/8942601/150610382-1a89fbba-0b9f-47ed-9758-5b27b72f2269.png)


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
