### PR TITLE
Search jobs: convert repo exclusion to job

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -861,24 +861,24 @@ func Test_toSearchInputs(t *testing.T) {
 	}
 
 	// Job generation for global vs non-global search
-	autogold.Want("user search context", "ParallelJob{RepoSubsetText, Repo}").Equal(t, test(`foo context:@userA`, query.ParseLiteral))
-	autogold.Want("universal (AKA global) search context", "ParallelJob{RepoUniverseText, Repo}").Equal(t, test(`foo context:global`, query.ParseLiteral))
-	autogold.Want("universal (AKA global) search", "ParallelJob{RepoUniverseText, Repo}").Equal(t, test(`foo`, query.ParseLiteral))
-	autogold.Want("nonglobal repo", "ParallelJob{RepoSubsetText, Repo}").Equal(t, test(`foo repo:sourcegraph/sourcegraph`, query.ParseLiteral))
-	autogold.Want("nonglobal repo contains", "ParallelJob{RepoSubsetText, Repo}").Equal(t, test(`foo repo:contains(bar)`, query.ParseLiteral))
+	autogold.Want("user search context", "ParallelJob{RepoSubsetText, Repo, ComputeExcludedRepos}").Equal(t, test(`foo context:@userA`, query.ParseLiteral))
+	autogold.Want("universal (AKA global) search context", "ParallelJob{RepoUniverseText, Repo, ComputeExcludedRepos}").Equal(t, test(`foo context:global`, query.ParseLiteral))
+	autogold.Want("universal (AKA global) search", "ParallelJob{RepoUniverseText, Repo, ComputeExcludedRepos}").Equal(t, test(`foo`, query.ParseLiteral))
+	autogold.Want("nonglobal repo", "ParallelJob{RepoSubsetText, Repo, ComputeExcludedRepos}").Equal(t, test(`foo repo:sourcegraph/sourcegraph`, query.ParseLiteral))
+	autogold.Want("nonglobal repo contains", "ParallelJob{RepoSubsetText, Repo, ComputeExcludedRepos}").Equal(t, test(`foo repo:contains(bar)`, query.ParseLiteral))
 
 	// Job generation support for implied `type:repo` queries.
-	autogold.Want("supported Repo job", "ParallelJob{RepoUniverseText, Repo}").Equal(t, test("ok ok", query.ParseRegexp))
-	autogold.Want("supportedRepo job literal", "ParallelJob{RepoUniverseText, Repo}").Equal(t, test("ok @thing", query.ParseLiteral))
-	autogold.Want("unsupported Repo job prefix", "RepoUniverseText").Equal(t, test("@nope", query.ParseRegexp))
-	autogold.Want("unsupported Repo job regexp", "RepoUniverseText").Equal(t, test("foo @bar", query.ParseRegexp))
+	autogold.Want("supported Repo job", "ParallelJob{RepoUniverseText, Repo, ComputeExcludedRepos}").Equal(t, test("ok ok", query.ParseRegexp))
+	autogold.Want("supportedRepo job literal", "ParallelJob{RepoUniverseText, Repo, ComputeExcludedRepos}").Equal(t, test("ok @thing", query.ParseLiteral))
+	autogold.Want("unsupported Repo job prefix", "ParallelJob{RepoUniverseText, ComputeExcludedRepos}").Equal(t, test("@nope", query.ParseRegexp))
+	autogold.Want("unsupported Repo job regexp", "ParallelJob{RepoUniverseText, ComputeExcludedRepos}").Equal(t, test("foo @bar", query.ParseRegexp))
 
 	// Job generation for other types of search
-	autogold.Want("symbol", "RepoUniverseSymbol").Equal(t, test("type:symbol test", query.ParseRegexp))
-	autogold.Want("commit", "Commit").Equal(t, test("type:commit test", query.ParseRegexp))
-	autogold.Want("diff", "Diff").Equal(t, test("type:diff test", query.ParseRegexp))
-	autogold.Want("file or commit", "JobWithOptional{Required: RepoUniverseText, Optional: Commit}").Equal(t, test("type:file type:commit test", query.ParseRegexp))
-	autogold.Want("many types", "JobWithOptional{Required: ParallelJob{RepoSubsetText, Repo}, Optional: ParallelJob{RepoSubsetSymbol, Commit}}").Equal(t, test("type:file type:path type:repo type:commit type:symbol repo:test test", query.ParseRegexp))
+	autogold.Want("symbol", "ParallelJob{RepoUniverseSymbol, ComputeExcludedRepos}").Equal(t, test("type:symbol test", query.ParseRegexp))
+	autogold.Want("commit", "ParallelJob{Commit, ComputeExcludedRepos}").Equal(t, test("type:commit test", query.ParseRegexp))
+	autogold.Want("diff", "ParallelJob{Diff, ComputeExcludedRepos}").Equal(t, test("type:diff test", query.ParseRegexp))
+	autogold.Want("file or commit", "JobWithOptional{Required: ParallelJob{RepoUniverseText, ComputeExcludedRepos}, Optional: Commit}").Equal(t, test("type:file type:commit test", query.ParseRegexp))
+	autogold.Want("many types", "JobWithOptional{Required: ParallelJob{RepoSubsetText, Repo, ComputeExcludedRepos}, Optional: ParallelJob{RepoSubsetSymbol, Commit}}").Equal(t, test("type:file type:path type:repo type:commit type:symbol repo:test test", query.ParseRegexp))
 }
 
 func TestZeroElapsedMilliseconds(t *testing.T) {

--- a/internal/search/repos/excluded_job.go
+++ b/internal/search/repos/excluded_job.go
@@ -1,0 +1,35 @@
+package repos
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+)
+
+type ComputeExcludedRepos struct {
+	DB      database.DB
+	Options search.RepoOptions
+}
+
+func (c *ComputeExcludedRepos) Run(ctx context.Context, s streaming.Sender, _ Pager) (err error) {
+	repositoryResolver := Resolver{DB: c.DB}
+	excluded, err := repositoryResolver.Excluded(ctx, c.Options)
+	if err != nil {
+		return err
+	}
+
+	s.Send(streaming.SearchEvent{
+		Stats: streaming.Stats{
+			ExcludedArchived: excluded.Archived,
+			ExcludedForks:    excluded.Forks,
+		},
+	})
+
+	return nil
+}
+
+func (c *ComputeExcludedRepos) Name() string {
+	return "ComputeExcludedRepos"
+}


### PR DESCRIPTION
This converts repo exclusion to a job. This pulls the execution out of
`doResults`, and adds it to the list of jobs to be executed in
`toSearchRoutine`. This allows us to slim down `doResults` and to
describe the operation in our routine tree like we do our other jobs.


Stacked on #30063 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
