### PR TITLE
Search jobs: add TimeoutJob

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -924,11 +924,13 @@ func (r *searchResolver) toSearchRoutine(q query.Q) (*run.Routine, error) {
 	})
 
 	return &run.Routine{
-		Job: run.NewJobWithOptional(
-			run.NewParallelJob(requiredJobs...),
-			run.NewParallelJob(optionalJobs...),
+		Job: run.NewTimeoutJob(
+			args.Timeout,
+			run.NewJobWithOptional(
+				run.NewParallelJob(requiredJobs...),
+				run.NewParallelJob(optionalJobs...),
+			),
 		),
-		Timeout: args.Timeout,
 	}, nil
 }
 
@@ -1799,9 +1801,6 @@ func (r *searchResolver) doResults(ctx context.Context, routine *run.Routine) (r
 		}
 		tr.Finish()
 	}()
-
-	ctx, cancel := context.WithTimeout(ctx, routine.Timeout)
-	defer cancel()
 
 	limit := r.MaxResults()
 

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -861,24 +861,24 @@ func Test_toSearchInputs(t *testing.T) {
 	}
 
 	// Job generation for global vs non-global search
-	autogold.Want("user search context", "ParallelJob{RepoSubsetText, Repo, ComputeExcludedRepos}").Equal(t, test(`foo context:@userA`, query.ParseLiteral))
-	autogold.Want("universal (AKA global) search context", "ParallelJob{RepoUniverseText, Repo, ComputeExcludedRepos}").Equal(t, test(`foo context:global`, query.ParseLiteral))
-	autogold.Want("universal (AKA global) search", "ParallelJob{RepoUniverseText, Repo, ComputeExcludedRepos}").Equal(t, test(`foo`, query.ParseLiteral))
-	autogold.Want("nonglobal repo", "ParallelJob{RepoSubsetText, Repo, ComputeExcludedRepos}").Equal(t, test(`foo repo:sourcegraph/sourcegraph`, query.ParseLiteral))
-	autogold.Want("nonglobal repo contains", "ParallelJob{RepoSubsetText, Repo, ComputeExcludedRepos}").Equal(t, test(`foo repo:contains(bar)`, query.ParseLiteral))
+	autogold.Want("user search context", "TimeoutJob{ParallelJob{RepoSubsetText, Repo, ComputeExcludedRepos}}").Equal(t, test(`foo context:@userA`, query.ParseLiteral))
+	autogold.Want("universal (AKA global) search context", "TimeoutJob{ParallelJob{RepoUniverseText, Repo, ComputeExcludedRepos}}").Equal(t, test(`foo context:global`, query.ParseLiteral))
+	autogold.Want("universal (AKA global) search", "TimeoutJob{ParallelJob{RepoUniverseText, Repo, ComputeExcludedRepos}}").Equal(t, test(`foo`, query.ParseLiteral))
+	autogold.Want("nonglobal repo", "TimeoutJob{ParallelJob{RepoSubsetText, Repo, ComputeExcludedRepos}}").Equal(t, test(`foo repo:sourcegraph/sourcegraph`, query.ParseLiteral))
+	autogold.Want("nonglobal repo contains", "TimeoutJob{ParallelJob{RepoSubsetText, Repo, ComputeExcludedRepos}}").Equal(t, test(`foo repo:contains(bar)`, query.ParseLiteral))
 
 	// Job generation support for implied `type:repo` queries.
-	autogold.Want("supported Repo job", "ParallelJob{RepoUniverseText, Repo, ComputeExcludedRepos}").Equal(t, test("ok ok", query.ParseRegexp))
-	autogold.Want("supportedRepo job literal", "ParallelJob{RepoUniverseText, Repo, ComputeExcludedRepos}").Equal(t, test("ok @thing", query.ParseLiteral))
-	autogold.Want("unsupported Repo job prefix", "ParallelJob{RepoUniverseText, ComputeExcludedRepos}").Equal(t, test("@nope", query.ParseRegexp))
-	autogold.Want("unsupported Repo job regexp", "ParallelJob{RepoUniverseText, ComputeExcludedRepos}").Equal(t, test("foo @bar", query.ParseRegexp))
+	autogold.Want("supported Repo job", "TimeoutJob{ParallelJob{RepoUniverseText, Repo, ComputeExcludedRepos}}").Equal(t, test("ok ok", query.ParseRegexp))
+	autogold.Want("supportedRepo job literal", "TimeoutJob{ParallelJob{RepoUniverseText, Repo, ComputeExcludedRepos}}").Equal(t, test("ok @thing", query.ParseLiteral))
+	autogold.Want("unsupported Repo job prefix", "TimeoutJob{ParallelJob{RepoUniverseText, ComputeExcludedRepos}}").Equal(t, test("@nope", query.ParseRegexp))
+	autogold.Want("unsupported Repo job regexp", "TimeoutJob{ParallelJob{RepoUniverseText, ComputeExcludedRepos}}").Equal(t, test("foo @bar", query.ParseRegexp))
 
 	// Job generation for other types of search
-	autogold.Want("symbol", "ParallelJob{RepoUniverseSymbol, ComputeExcludedRepos}").Equal(t, test("type:symbol test", query.ParseRegexp))
-	autogold.Want("commit", "ParallelJob{Commit, ComputeExcludedRepos}").Equal(t, test("type:commit test", query.ParseRegexp))
-	autogold.Want("diff", "ParallelJob{Diff, ComputeExcludedRepos}").Equal(t, test("type:diff test", query.ParseRegexp))
-	autogold.Want("file or commit", "JobWithOptional{Required: ParallelJob{RepoUniverseText, ComputeExcludedRepos}, Optional: Commit}").Equal(t, test("type:file type:commit test", query.ParseRegexp))
-	autogold.Want("many types", "JobWithOptional{Required: ParallelJob{RepoSubsetText, Repo, ComputeExcludedRepos}, Optional: ParallelJob{RepoSubsetSymbol, Commit}}").Equal(t, test("type:file type:path type:repo type:commit type:symbol repo:test test", query.ParseRegexp))
+	autogold.Want("symbol", "TimeoutJob{ParallelJob{RepoUniverseSymbol, ComputeExcludedRepos}}").Equal(t, test("type:symbol test", query.ParseRegexp))
+	autogold.Want("commit", "TimeoutJob{ParallelJob{Commit, ComputeExcludedRepos}}").Equal(t, test("type:commit test", query.ParseRegexp))
+	autogold.Want("diff", "TimeoutJob{ParallelJob{Diff, ComputeExcludedRepos}}").Equal(t, test("type:diff test", query.ParseRegexp))
+	autogold.Want("file or commit", "TimeoutJob{JobWithOptional{Required: ParallelJob{RepoUniverseText, ComputeExcludedRepos}, Optional: Commit}}").Equal(t, test("type:file type:commit test", query.ParseRegexp))
+	autogold.Want("many types", "TimeoutJob{JobWithOptional{Required: ParallelJob{RepoSubsetText, Repo, ComputeExcludedRepos}, Optional: ParallelJob{RepoSubsetSymbol, Commit}}}").Equal(t, test("type:file type:path type:repo type:commit type:symbol repo:test test", query.ParseRegexp))
 }
 
 func TestZeroElapsedMilliseconds(t *testing.T) {

--- a/internal/search/run/run.go
+++ b/internal/search/run/run.go
@@ -2,7 +2,6 @@ package run
 
 import (
 	"context"
-	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
@@ -44,8 +43,7 @@ type Job interface {
 // information to execute the runtime semantics for particular search
 // operations.
 type Routine struct {
-	Job     Job
-	Timeout time.Duration
+	Job Job
 }
 
 // MaxResults computes the limit for the query.


### PR DESCRIPTION
This adds a new `TimeoutJob`, which represents a job that is
time-limited.

Stacked on #30068 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
