### PR TITLE
Search jobs: replace run.Routine with run.Job

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -38,12 +38,12 @@ func (srs *searchResultsStats) Languages(ctx context.Context) ([]*languageStatis
 
 func (srs *searchResultsStats) getResults(ctx context.Context) (*SearchResultsResolver, error) {
 	srs.once.Do(func() {
-		routine, err := srs.sr.toSearchRoutine(srs.sr.Query)
+		job, err := srs.sr.toSearchJob(srs.sr.Query)
 		if err != nil {
 			srs.srsErr = err
 			return
 		}
-		results, err := srs.sr.doResults(ctx, routine)
+		results, err := srs.sr.doResults(ctx, job)
 		if err != nil {
 			srs.srsErr = err
 			return

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -856,8 +856,8 @@ func Test_toSearchInputs(t *testing.T) {
 				PatternType:  query.SearchTypeLiteral,
 			},
 		}
-		routine, _ := resolver.toSearchRoutine(q)
-		return routine.Job.Name()
+		job, _ := resolver.toSearchJob(q)
+		return job.Name()
 	}
 
 	// Job generation for global vs non-global search

--- a/internal/search/run/run.go
+++ b/internal/search/run/run.go
@@ -24,28 +24,6 @@ type SearchInputs struct {
 	DefaultLimit int
 }
 
-// Job is an interface shared by all individual search operations in the backend
-// (e.g., text vs commit vs symbol search are represented as different jobs).
-// Calling Run on a job object runs a search. The third argument accepts resolved repositories (which may or may
-// not be required, depending on the job. E.g., a global search job does not
-// require upfront repository resolution).
-type Job interface {
-	Run(context.Context, database.DB, streaming.Sender) error
-	Name() string
-}
-
-// Routine represents all inputs to run multiple search operations (i.e.,
-// multiple Jobs) in a single search routine. In other words, it executes all
-// jobs that may be implemented by different search engines (Zoekt vs Searcher)
-// or return different result types (text vs. symbols). The relation with
-// SearchInputs and Routine is that SearchInputs are static values, parsed and
-// validated, to produce one or more Routines. Routines express the complete
-// information to execute the runtime semantics for particular search
-// operations.
-type Routine struct {
-	Job Job
-}
-
 // MaxResults computes the limit for the query.
 func (inputs SearchInputs) MaxResults() int {
 	if inputs.Query == nil {
@@ -61,4 +39,13 @@ func (inputs SearchInputs) MaxResults() int {
 	}
 
 	return search.DefaultMaxSearchResults
+}
+
+// Job is an interface shared by all individual search operations in the
+// backend (e.g., text vs commit vs symbol search are represented as different
+// jobs) as well as combinations over those searches (run a set in parallel,
+// timeout). Calling Run on a job object runs a search.
+type Job interface {
+	Run(context.Context, database.DB, streaming.Sender) error
+	Name() string
 }


### PR DESCRIPTION
With timeout as a simple job wrapper, `run.Routine` can be fully
represented as a job. This makes `run.Routine` unnecessary, and we can
get rid of it.

Stacked on #30074 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
