### PR TITLE
Wildcard [Popover]: Support absolute strategy `tether` calculations

### DIFF
--- a/client/wildcard/src/components/Popover/Popover.tsx
+++ b/client/wildcard/src/components/Popover/Popover.tsx
@@ -6,8 +6,8 @@ import React, {
     MutableRefObject,
     useCallback,
     useContext,
+    useEffect,
     useMemo,
-    useRef,
     useState,
 } from 'react'
 import FocusLock from 'react-focus-lock'
@@ -119,6 +119,7 @@ export const PopoverTrigger = forwardRef((props, reference) => {
 interface PopoverContentProps extends Omit<FloatingPanelProps, 'target' | 'marker'> {
     isOpen?: boolean
     focusLocked?: boolean
+    autoFocus?: boolean
 }
 
 export const PopoverContent = forwardRef((props, reference) => {
@@ -126,6 +127,7 @@ export const PopoverContent = forwardRef((props, reference) => {
         isOpen,
         children,
         focusLocked = true,
+        autoFocus = true,
         as: Component = 'div',
         role = 'dialog',
         'aria-modal': ariaModel = true,
@@ -133,9 +135,11 @@ export const PopoverContent = forwardRef((props, reference) => {
     } = props
 
     const { isOpen: isOpenContext, targetElement, anchor, setOpen } = useContext(PopoverContext)
+    const [focusLock, setFocusLock] = useState(false)
 
-    const localReference = useRef<HTMLDivElement>(null)
-    const mergeReference = useMergeRefs([localReference, reference])
+    const [tooltipElement, setTooltipElement] = useState<HTMLDivElement | null>(null)
+    const tooltipReferenceCallback = useCallbackRef<HTMLDivElement>(null, setTooltipElement)
+    const mergeReference = useMergeRefs([tooltipReferenceCallback, reference])
 
     // Catch any outside click of popover element
     useOnClickOutside(mergeReference, event => {
@@ -148,6 +152,22 @@ export const PopoverContent = forwardRef((props, reference) => {
 
     // Close popover on escape
     useKeyboard({ detectKeys: ['Escape'] }, () => setOpen({ isOpen: false, reason: PopoverOpenEventReason.Esc }))
+
+    // Native behavior of browsers about focus elements says - if element that gets focus
+    // is in outside of the visible area than browser should scroll to this element automatically.
+    // This logic breaks popover behavior by loosing scroll positions of the scroll container with
+    // target element. In order to preserve scroll we should adjust order of actions
+    // Render popover element in the DOM → Calculate and apply the right position for the popover →
+    // Enable focus lock (therefore autofocus first scrollable element within the popover content)
+    useEffect(() => {
+        if (tooltipElement && autoFocus && focusLocked) {
+            setFocusLock(true)
+        }
+
+        return () => {
+            setFocusLock(false)
+        }
+    }, [autoFocus, focusLocked, tooltipElement])
 
     if (!isOpenContext && !isOpen) {
         return null
@@ -163,7 +183,13 @@ export const PopoverContent = forwardRef((props, reference) => {
             aria-modal={ariaModel}
             className={classNames('dropdown-menu', otherProps.className)}
         >
-            {focusLocked ? <FocusLock returnFocus={true}>{children}</FocusLock> : children}
+            {focusLocked ? (
+                <FocusLock disabled={!focusLock} returnFocus={true}>
+                    {children}
+                </FocusLock>
+            ) : (
+                children
+            )}
         </FloatingPanel>
     )
 }) as ForwardReferenceComponent<'div', PopoverContentProps>

--- a/client/wildcard/src/components/Popover/Popover.tsx
+++ b/client/wildcard/src/components/Popover/Popover.tsx
@@ -161,7 +161,9 @@ export const PopoverContent = forwardRef((props, reference) => {
     // Enable focus lock (therefore autofocus first scrollable element within the popover content)
     useEffect(() => {
         if (tooltipElement && autoFocus && focusLocked) {
-            setFocusLock(true)
+            requestAnimationFrame(() => {
+                setFocusLock(true)
+            })
         }
 
         return () => {

--- a/client/wildcard/src/components/Popover/README.md
+++ b/client/wildcard/src/components/Popover/README.md
@@ -207,3 +207,20 @@ enum Flipping {
   needed (not enough space with current position)
 - **_overflowToScrollParents_** (optional) - If it's true then it hides tooltip when target isn't visible due scroll containers
 - **_constrainToScrollParents_** (optional) - If it's true then it fits popover element' position and sizes into target scroll containers.
+- **_strategy_** (optional) - Setups position strategy (Fixed or Absolute) to render the popover element.
+
+```ts
+enum Strategy {
+  /**
+   * Fixed strategy renders popover element outside of DOM hierarchy in the designated
+   * container in the body element
+   */
+  Fixed,
+
+  /**
+   * Absolute strategy renders popover element next to the target element and
+   * calculate its position based on the nearest container with position relative.
+   */
+  Absolute,
+}
+```

--- a/client/wildcard/src/components/Popover/floating-panel/FloatingPanel.module.scss
+++ b/client/wildcard/src/components/Popover/floating-panel/FloatingPanel.module.scss
@@ -10,6 +10,10 @@
     left: 0;
     z-index: 1;
     overflow: auto;
+
+    &-absolute {
+        position: absolute;
+    }
 }
 
 .tail {

--- a/client/wildcard/src/components/Popover/story/Popover.story.module.scss
+++ b/client/wildcard/src/components/Popover/story/Popover.story.module.scss
@@ -4,13 +4,14 @@
     flex-direction: column;
     height: 100%;
     overflow: auto;
+    position: relative;
 }
 
 .container {
     background: var(--gray-03);
     height: 100%;
     overflow: auto;
-    position: relative;
+    //position: relative;
     border: 1px solid #000000;
 
     &--as-sub-root {
@@ -57,6 +58,7 @@
 
     &--tooltip-like {
         min-width: auto;
+        max-width: 30rem;
         padding: 0.5rem;
     }
 

--- a/client/wildcard/src/components/Popover/story/Popover.story.module.scss
+++ b/client/wildcard/src/components/Popover/story/Popover.story.module.scss
@@ -11,7 +11,6 @@
     background: var(--gray-03);
     height: 100%;
     overflow: auto;
-    //position: relative;
     border: 1px solid #000000;
 
     &--as-sub-root {

--- a/client/wildcard/src/components/Popover/story/Popover.story.tsx
+++ b/client/wildcard/src/components/Popover/story/Popover.story.tsx
@@ -1,4 +1,5 @@
-import { Meta } from '@storybook/react'
+import { boolean } from '@storybook/addon-knobs'
+import { Meta, Story } from '@storybook/react'
 import classNames from 'classnames'
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { noop } from 'rxjs'
@@ -175,7 +176,7 @@ export const AbsoluteStrategyExample = () => (
                     Hello
                 </PopoverTrigger>
 
-                <PopoverContent focusLocked={false} position={Position.rightStart} strategy={Strategy.Absolute} className={styles.floating}>
+                <PopoverContent position={Position.rightStart} strategy={Strategy.Absolute} className={styles.floating}>
                     Limonov was born in the Soviet Union, in Dzerzhinsk, an industrial town in the Gorky Oblast (now
                     Nizhny Novgorod Oblast). Limonov's father—then in the military service – was in a state security
                     career and his mother was a homemaker.[6] In the early years of his life his family moved to Kharkiv
@@ -341,38 +342,46 @@ export const WithControlledState = () => {
     )
 }
 
-export const WithNestedScrollParents = () => (
-    <ScrollCenterBox title="Root scroll block" className={styles.root}>
-        <div className={styles.spreadContentBlock}>
-            <ScrollCenterBox
-                title="Sub scroll block"
-                className={classNames(styles.container, styles.containerAsSubRoot)}
-            >
-                <div className={styles.content}>
-                    <Popover>
-                        <div className={styles.triggerAnchor}>
-                            <PopoverTrigger as={Button} variant="secondary" className={styles.target}>
-                                Hello
-                            </PopoverTrigger>
-                        </div>
+export const WithNestedScrollParents: Story = () => {
+    const constrainToScrollParents = boolean('constrainToScrollParents', true)
 
-                        <PopoverContent position={Position.rightStart} className={styles.floating}>
-                            Limonov was born in the Soviet Union, in Dzerzhinsk, an industrial town in the Gorky Oblast
-                            (now Nizhny Novgorod Oblast). Limonov's father—then in the military service – was in a state
-                            security career and his mother was a homemaker.[6] In the early years of his life his family
-                            moved to Kharkiv in the Ukrainian SSR, where Limonov grew up. He studied at the H.S.
-                            Skovoroda Kharkiv National Pedagogical University.
-                            <div className="mt-2 d-flex" style={{ gap: 10 }}>
-                                <Button variant="secondary">Action 1</Button>
-                                <Button variant="secondary">Action 2</Button>
+    return (
+        <ScrollCenterBox title="Root scroll block" className={styles.root}>
+            <div className={styles.spreadContentBlock}>
+                <ScrollCenterBox
+                    title="Sub scroll block (see knobs panel for rendering tooltip outside of the scroll container"
+                    className={classNames(styles.container, styles.containerAsSubRoot)}
+                >
+                    <div className={styles.content}>
+                        <Popover>
+                            <div className={styles.triggerAnchor}>
+                                <PopoverTrigger as={Button} variant="secondary" className={styles.target}>
+                                    Hello
+                                </PopoverTrigger>
                             </div>
-                        </PopoverContent>
-                    </Popover>
-                </div>
-            </ScrollCenterBox>
-        </div>
-    </ScrollCenterBox>
-)
+
+                            <PopoverContent
+                                constrainToScrollParents={constrainToScrollParents}
+                                position={Position.rightStart}
+                                className={styles.floating}
+                            >
+                                Limonov was born in the Soviet Union, in Dzerzhinsk, an industrial town in the Gorky
+                                Oblast (now Nizhny Novgorod Oblast). Limonov's father—then in the military service – was
+                                in a state security career and his mother was a homemaker.[6] In the early years of his
+                                life his family moved to Kharkiv in the Ukrainian SSR, where Limonov grew up. He studied
+                                at the H.S. Skovoroda Kharkiv National Pedagogical University.
+                                <div className="mt-2 d-flex" style={{ gap: 10 }}>
+                                    <Button variant="secondary">Action 1</Button>
+                                    <Button variant="secondary">Action 2</Button>
+                                </div>
+                            </PopoverContent>
+                        </Popover>
+                    </div>
+                </ScrollCenterBox>
+            </div>
+        </ScrollCenterBox>
+    )
+}
 
 export const WithVirtualTarget = () => {
     const [virtualElement, setVirtualElement] = useState<Point | null>(null)

--- a/client/wildcard/src/components/Popover/story/Popover.story.tsx
+++ b/client/wildcard/src/components/Popover/story/Popover.story.tsx
@@ -8,7 +8,7 @@ import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
 import { Button, Position } from '@sourcegraph/wildcard'
 
 import { Popover, PopoverContent, PopoverOpenEvent, PopoverTrigger } from '../Popover'
-import { Point } from '../tether'
+import { Point, Strategy } from '../tether'
 
 import styles from './Popover.story.module.scss'
 
@@ -152,6 +152,30 @@ export const StandardExample = () => (
                 </PopoverTrigger>
 
                 <PopoverContent position={Position.rightStart} className={styles.floating}>
+                    Limonov was born in the Soviet Union, in Dzerzhinsk, an industrial town in the Gorky Oblast (now
+                    Nizhny Novgorod Oblast). Limonov's father—then in the military service – was in a state security
+                    career and his mother was a homemaker.[6] In the early years of his life his family moved to Kharkiv
+                    in the Ukrainian SSR, where Limonov grew up. He studied at the H.S. Skovoroda Kharkiv National
+                    Pedagogical University.
+                    <div className="mt-2 d-flex" style={{ gap: 10 }}>
+                        <Button variant="secondary">Action 1</Button>
+                        <Button variant="secondary">Action 2</Button>
+                    </div>
+                </PopoverContent>
+            </Popover>
+        </div>
+    </ScrollCenterBox>
+)
+
+export const AbsoluteStrategyExample = () => (
+    <ScrollCenterBox title="Root scroll block" className={styles.container}>
+        <div className={styles.content}>
+            <Popover>
+                <PopoverTrigger as={Button} variant="secondary" className={styles.target}>
+                    Hello
+                </PopoverTrigger>
+
+                <PopoverContent focusLocked={false} position={Position.rightStart} strategy={Strategy.Absolute} className={styles.floating}>
                     Limonov was born in the Soviet Union, in Dzerzhinsk, an industrial town in the Gorky Oblast (now
                     Nizhny Novgorod Oblast). Limonov's father—then in the military service – was in a state security
                     career and his mother was a homemaker.[6] In the early years of his life his family moved to Kharkiv

--- a/client/wildcard/src/components/Popover/tether/models/tether-models.ts
+++ b/client/wildcard/src/components/Popover/tether/models/tether-models.ts
@@ -77,5 +77,5 @@ export enum Position {
 
 export enum Strategy {
     Fixed = 'fixed',
-    Absolute = 'absolute'
+    Absolute = 'absolute',
 }

--- a/client/wildcard/src/components/Popover/tether/models/tether-models.ts
+++ b/client/wildcard/src/components/Popover/tether/models/tether-models.ts
@@ -74,3 +74,8 @@ export enum Position {
     bottom = 'bottom',
     bottomEnd = 'bottomEnd',
 }
+
+export enum Strategy {
+    Fixed = 'fixed',
+    Absolute = 'absolute'
+}

--- a/client/wildcard/src/components/Popover/tether/models/tether-models.ts
+++ b/client/wildcard/src/components/Popover/tether/models/tether-models.ts
@@ -76,6 +76,15 @@ export enum Position {
 }
 
 export enum Strategy {
+    /**
+     * This strategy renders the element outside of DOM hierarchy in the designated
+     * container in the body element and calculate position for fixed element.
+     */
     Fixed = 'fixed',
+
+    /**
+     * Absolute strategy renders element right next to the target element and calculate
+     * position based on the nearest container with position relative.
+     */
     Absolute = 'absolute',
 }

--- a/client/wildcard/src/components/Popover/tether/services/geometry/actions/get-extended-constraint.ts
+++ b/client/wildcard/src/components/Popover/tether/services/geometry/actions/get-extended-constraint.ts
@@ -1,0 +1,25 @@
+import { createPoint } from '../../../models/geometry/point'
+import { createRectangleFromPoints, Rectangle } from '../../../models/geometry/rectangle'
+
+/**
+ * Extends constraint rectangle by target rectangle position.
+ *
+ * ```
+ *          ┏━━━━━━━━┓      ┌ ── ── ┳━━━━━━━━┓
+ *          ┃ Target ┃      │░░░░░░░┃ Target ┃
+ *  ┌───────┫        ┃       ░░░░░░░┃        ┃
+ *  │░░░░░░░┗━━━━┳━━━┛      │░░░░░░░┗━━━━━━━━┫
+ *  │░░░░░░░░░░░░│ ───────▶ │░░░░░░░░░░░░░░░░│
+ *  │░░░░░░░░░░░░│           ░░░░░░░░░░░░░░░░
+ *  │░░░░░░░░░░░░│          │░░░░░░░░░░░░░░░░│
+ *  └Constraint──┘          └Constraint── ── ┘
+ * ```
+ */
+export function getExtendedConstraint(target: Rectangle, constraint: Rectangle): Rectangle {
+    const xStart = Math.min(constraint.left, Math.max(target.left, target.right))
+    const yStart = Math.min(constraint.top, Math.max(target.top, target.bottom))
+    const xEnd = Math.max(constraint.right, Math.min(target.left, target.right))
+    const yEnd = Math.max(constraint.bottom, Math.min(target.top, target.bottom))
+
+    return createRectangleFromPoints(createPoint(xStart, yStart), createPoint(xEnd, yEnd))
+}

--- a/client/wildcard/src/components/Popover/tether/services/geometry/actions/rectangle-position-helpers.ts
+++ b/client/wildcard/src/components/Popover/tether/services/geometry/actions/rectangle-position-helpers.ts
@@ -18,10 +18,10 @@ export function getPositions(position: Position, flipping: Flipping): Position[]
 
 export function getRoundedElement(element: Rectangle): Rectangle {
     return createRectangle(
-        Math.floor(element.left),
-        Math.floor(element.top),
-        Math.floor(element.width),
-        Math.floor(element.height)
+        Math.ceil(element.left),
+        Math.ceil(element.top),
+        Math.ceil(element.width),
+        Math.ceil(element.height)
     )
 }
 

--- a/client/wildcard/src/components/Popover/tether/services/tether-browser.ts
+++ b/client/wildcard/src/components/Popover/tether/services/tether-browser.ts
@@ -70,7 +70,29 @@ export function isVisible(element: HTMLElement | null): boolean {
 
         current = current.parentElement
     }
+
     return true
+}
+
+export function getAbsoluteAnchorOffset(element: HTMLElement): Point {
+    let current = element.parentElement
+
+    while (current) {
+        const styles = getComputedStyle(current)
+
+        if (styles.position !== 'static') {
+            const rectangle = current.getBoundingClientRect()
+
+            return createPoint(
+                current.scrollLeft - rectangle.left ,
+                current.scrollTop - rectangle.top,
+            )
+        }
+
+        current = current.parentElement
+    }
+
+    return createPoint(0, 0)
 }
 
 export function setTransform(element: HTMLElement | null, angle: number, offset: Point): void {

--- a/client/wildcard/src/components/Popover/tether/services/tether-browser.ts
+++ b/client/wildcard/src/components/Popover/tether/services/tether-browser.ts
@@ -83,10 +83,7 @@ export function getAbsoluteAnchorOffset(element: HTMLElement): Point {
         if (styles.position !== 'static') {
             const rectangle = current.getBoundingClientRect()
 
-            return createPoint(
-                current.scrollLeft - rectangle.left ,
-                current.scrollTop - rectangle.top,
-            )
+            return createPoint(current.scrollLeft - rectangle.left, current.scrollTop - rectangle.top)
         }
 
         current = current.parentElement

--- a/client/wildcard/src/components/Popover/tether/services/tether-browser.ts
+++ b/client/wildcard/src/components/Popover/tether/services/tether-browser.ts
@@ -74,6 +74,25 @@ export function isVisible(element: HTMLElement | null): boolean {
     return true
 }
 
+/**
+ * Returns offset of the element that is parent of the target element and at the same time
+ * creates another stacking context.
+ *
+ * ```
+ *   ┌────▲────────────────────────┐
+ *   │    │y                       │
+ *   ◀────╋━━stacking context━━━┓  │
+ *   │ x  ┃  ┌── ─── ─── ──┐    ┃  │
+ *   │    ┃   ┌ ─ ─ ─ ─ ─ ┐     ┃  │
+ *   │    ┃  │  ┌──────┐   │    ┃  │
+ *   │    ┃  ││ │Target│  ││    ┃  │
+ *   │    ┃  │  └──────┘   │    ┃  │
+ *   │    ┃   └ ─ ─ ─ ─ ─ ┘     ┃  │
+ *   │    ┃  └── ─── ─── ──┘    ┃  │
+ *   │    ┗━━━━━━━━━━━━━━━━━━━━━┛  │
+ *   └─────────────────────────────┘
+ * ```
+ */
 export function getAbsoluteAnchorOffset(element: HTMLElement): Point {
     let current = element.parentElement
 

--- a/client/wildcard/src/components/Popover/tether/services/tether-layout.ts
+++ b/client/wildcard/src/components/Popover/tether/services/tether-layout.ts
@@ -1,4 +1,4 @@
-import { createPoint, Point } from '../models/geometry/point';
+import { createPoint, Point } from '../models/geometry/point'
 import { createRectangle, createRectangleFromPoints, EMPTY_RECTANGLE, Rectangle } from '../models/geometry/rectangle'
 import { Constraint, Flipping, Overlapping, Position, Strategy } from '../models/tether-models'
 
@@ -18,7 +18,7 @@ export function getLayout(tether: Tether): TetherLayout {
         constraintPadding = EMPTY_RECTANGLE,
         overflowToScrollParents = true,
         strategy = Strategy.Fixed,
-        constrainToScrollParents
+        constrainToScrollParents,
     } = tether
 
     const target = tether.pin
@@ -34,27 +34,25 @@ export function getLayout(tether: Tether): TetherLayout {
     const overflows: Constraint[] = []
     const constraints: Constraint[] = []
 
-    if (strategy === Strategy.Fixed) {
-        overflows.push({
-            element: createRectangle(
-                document.documentElement.clientLeft,
-                document.documentElement.clientTop,
-                document.documentElement.clientWidth,
-                document.documentElement.clientHeight
-            ),
-            padding: windowPadding,
-        })
+    overflows.push({
+        element: createRectangle(
+            document.documentElement.clientLeft,
+            document.documentElement.clientTop,
+            document.documentElement.clientWidth,
+            document.documentElement.clientHeight
+        ),
+        padding: windowPadding,
+    })
 
-        constraints.push({
-            element: createRectangle(
-                document.documentElement.clientLeft,
-                document.documentElement.clientTop,
-                document.documentElement.clientWidth,
-                document.documentElement.clientHeight
-            ),
-            padding: windowPadding,
-        })
-    }
+    constraints.push({
+        element: createRectangle(
+            document.documentElement.clientLeft,
+            document.documentElement.clientTop,
+            document.documentElement.clientWidth,
+            document.documentElement.clientHeight
+        ),
+        padding: windowPadding,
+    })
 
     if (tether.constraint) {
         constraints.push({

--- a/client/wildcard/src/components/Popover/tether/services/tether-position.ts
+++ b/client/wildcard/src/components/Popover/tether/services/tether-position.ts
@@ -15,6 +15,7 @@ import {
     getTargetElement,
     isElementVisible,
 } from './geometry'
+import { getExtendedConstraint } from './geometry/actions/get-extended-constraint'
 import { TetherLayout } from './types'
 
 export interface TetherState {
@@ -49,12 +50,10 @@ export function getPositionState(layout: TetherLayout, position: Position): Teth
     const { markerAngle, markerOrigin, rotatedMarker } = getMarkerRotation(marker, position)
 
     // Apply overflow constraints to target element
-    const overflowedTarget = strategy === Strategy.Fixed
-        ? getIntersection(target, overflow)
-        : target
+    const overflowedTarget = strategy === Strategy.Fixed ? getIntersection(target, overflow) : target
 
     // Force tooltip layout hide in case if target is outside of overflow constraint.
-    if (!isElementVisible(overflowedTarget) ) {
+    if (!isElementVisible(overflowedTarget)) {
         return null
     }
 
@@ -64,8 +63,11 @@ export function getPositionState(layout: TetherLayout, position: Position): Teth
     // Change element tooltip coordinates to put this element right next extended target element
     const joinedElement = getJoinedElement(element, extendedTarget, position)
 
+    const extendedConstraint =
+        strategy === Strategy.Absolute ? getExtendedConstraint(extendedTarget, constraint) : constraint
+
     // Calculate constraint rectangle by target position and default constraint
-    const elementConstraint = getElementConstraint(extendedTarget, constraint, position, overlapping)
+    const elementConstraint = getElementConstraint(extendedTarget, extendedConstraint, position, overlapping)
 
     // Change tooltip element rectangle by element constraint
     const constrainedElement = getConstrainedElement(joinedElement, elementConstraint)
@@ -86,8 +88,8 @@ export function getPositionState(layout: TetherLayout, position: Position): Teth
     const markerOffset = getMarkerOffset(markerOrigin, constrainedMarker)
 
     // Check visibility and join geometry
-    const isTooltipVisible = strategy === Strategy.Fixed ? isElementVisible(constrainedElement) : true
-    const isTooltipJoined = strategy === Strategy.Fixed ? intersects(extendedTarget, constrainedElement) : true
+    const isTooltipVisible = isElementVisible(constrainedElement)
+    const isTooltipJoined = intersects(extendedTarget, constrainedElement)
     const isMarkerJoined = intersects(extendedTarget, constrainedMarker)
 
     if (!isTooltipVisible || (!isTooltipJoined && !isMarkerJoined)) {

--- a/client/wildcard/src/components/Popover/tether/services/tether-registry.ts
+++ b/client/wildcard/src/components/Popover/tether/services/tether-registry.ts
@@ -27,7 +27,7 @@ export function createTether(tether: Tether): TetherInstanceAPI {
     document.addEventListener('keyDown', eventHandler, true)
     document.addEventListener('input', eventHandler, true)
 
-    // Synthetic run without target for the initial tooltip positioning render
+    // Synthetic runs without target for the initial tooltip positioning render
     requestAnimationFrame(() => {
         render(tether, null)
     })

--- a/client/wildcard/src/components/Popover/tether/services/types.ts
+++ b/client/wildcard/src/components/Popover/tether/services/types.ts
@@ -44,6 +44,15 @@ export interface Tether {
      */
     constraint?: HTMLElement
 
+    /**
+     * Setups position strategy (Fixed or Absolute) to render the popover element.
+     *
+     * Fixed strategy renders element outside of DOM hierarchy in the designated
+     * container in the body element
+     *
+     * Absolute strategy renders element right next to the target element and
+     * calculate position based on the nearest container with position relative.
+     */
     strategy?: Strategy
 
     windowPadding?: Rectangle

--- a/client/wildcard/src/components/Popover/tether/services/types.ts
+++ b/client/wildcard/src/components/Popover/tether/services/types.ts
@@ -1,6 +1,6 @@
 import { Point } from '../models/geometry/point'
 import { Rectangle } from '../models/geometry/rectangle'
-import { Constraint, Flipping, Overlapping, Position } from '../models/tether-models'
+import { Constraint, Flipping, Overlapping, Position, Strategy } from '../models/tether-models'
 
 export interface Tether {
     /** Reference on target HTML element in the DOM. */
@@ -44,6 +44,8 @@ export interface Tether {
      */
     constraint?: HTMLElement
 
+    strategy?: Strategy
+
     windowPadding?: Rectangle
     constraintPadding?: Rectangle
 
@@ -72,4 +74,7 @@ export interface TetherLayout {
 
     overflows: Constraint[]
     constraints: Constraint[]
+
+    strategy: Strategy
+    anchorOffset: Point
 }

--- a/client/wildcard/src/components/Popover/tether/services/types.ts
+++ b/client/wildcard/src/components/Popover/tether/services/types.ts
@@ -46,12 +46,6 @@ export interface Tether {
 
     /**
      * Setups position strategy (Fixed or Absolute) to render the popover element.
-     *
-     * Fixed strategy renders element outside of DOM hierarchy in the designated
-     * container in the body element
-     *
-     * Absolute strategy renders element right next to the target element and
-     * calculate position based on the nearest container with position relative.
      */
     strategy?: Strategy
 


### PR DESCRIPTION

## Context

Prior to this PR the `<Popover />` component always rendered its content outside of DOM hierarchy and set a `positions: fixed` position layout to it. This strategy is called `fixed` and it usually covers 80% of all usage of `<Popover />` like components.

But sometimes we want to render the Popover element right next to the target and set the` position: absolute` strategy in order to make popover content that it hides behind the borders of constraints (visible viewport or any scroll parents on the way to the top of DOM tree).


<table>


<tr><th>Fixed</th><th>Absolute</th></tr>
<tr><th>

![](https://user-images.githubusercontent.com/18492575/150721863-16a53048-513f-4903-b256-c0397d01b043.mov)

</th><th>

![](https://user-images.githubusercontent.com/18492575/150722193-f9f0bda4-aca8-4e84-8b10-8462081823d8.mov)

</th></tr>
</table>