### PR TITLE
Update auto-inference to work with NPM packages

### DIFF
--- a/lib/codeintel/autoindex/inference/typescript.go
+++ b/lib/codeintel/autoindex/inference/typescript.go
@@ -3,6 +3,7 @@ package inference
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"regexp"
 
@@ -28,10 +29,33 @@ var tscSegmentBlockList = append([]string{"node_modules"}, segmentBlockList...)
 
 func InferTypeScriptIndexJobs(gitclient GitClient, paths []string) (indexes []config.IndexJob) {
 	pathMap := newPathMap(paths)
+	createTSConfigCommand := map[string][]string{}
 
 	tsConfigPaths := pathMap.pathsFor("tsconfig.json")
+
+	// TypeScript packages on NPM are commonly distributed without a
+	// tsconfig.json file. Instead of skipping indexing altogether,
+	// synthesize some permissive tsconfig.json files, as a treat.
 	if len(tsConfigPaths) == 0 {
-		return indexes
+		packageJSONPaths := pathMap.pathsFor("package.json")
+		if len(packageJSONPaths) == 0 {
+			return indexes
+		}
+		for _, packageJSONPath := range packageJSONPaths {
+			if !containsNoSegments(packageJSONPath, tscSegmentBlockList...) {
+				continue
+			}
+			dir := filepath.Dir(packageJSONPath)
+			tsConfigPath := filepath.Join(dir, "tsconfig.json")
+			createTSConfigCommand[tsConfigPath] = []string{
+				fmt.Sprintf("echo '{\"compilerOptions\":{\"allowJs\":true}}' > %s", tsConfigPath),
+			}
+			pathMap.insert(dir, "tsconfig.json")
+		}
+		if len(createTSConfigCommand) == 0 {
+			return indexes
+		}
+		tsConfigPaths = pathMap.pathsFor("tsconfig.json")
 	}
 
 	for _, tsConfigPath := range tsConfigPaths {
@@ -46,10 +70,30 @@ func InferTypeScriptIndexJobs(gitclient GitClient, paths []string) (indexes []co
 			}
 
 			var commands []string
+			if cmds, ok := createTSConfigCommand[tsConfigPath]; ok {
+				commands = make([]string, len(cmds))
+				copy(commands, cmds)
+			}
+
 			if isYarn || pathMap.contains(dir, "yarn.lock") {
 				commands = append(commands, "yarn --ignore-engines")
 			} else {
-				commands = append(commands, "npm install")
+				// [QUESTION] Should we make --ignore-scripts conditional for
+				// packages? For source repos, the TypeScript source should be
+				// present elsewhere...
+				//
+				// TypeScript code sometimes deletes the 'dist' directory as
+				// part of a pre-build step, as it is used for the generated
+				// JavaScript code and type definitions.
+				// https://sourcegraph.com/search?q=context:global+%22build%22:+%22%28rm+-rf%7Cdel-cli%29+dist+file:package.json+count:all&patternType=regexp
+				//
+				// This delete step is a problem when dealing with the
+				// corresponding NPM package, since the original TypeScript
+				// code may not be part of the package tarball. If we just
+				// run `npm install` after extracting the tarball, we may get
+				// rid of the available source code, and emit an empty index.
+				// Avoid that with `--ignore-scripts`.
+				commands = append(commands, "npm install --ignore-scripts")
 			}
 
 			dockerSteps = append(dockerSteps, config.DockerStep{

--- a/lib/codeintel/autoindex/inference/typescript_test.go
+++ b/lib/codeintel/autoindex/inference/typescript_test.go
@@ -91,7 +91,7 @@ func TestInferTypeScriptIndexJobsInstallSteps(t *testing.T) {
 				{
 					Root:     "",
 					Image:    lsifTscImage,
-					Commands: []string{"npm install"},
+					Commands: []string{"npm install --ignore-scripts"},
 				},
 			},
 			Root:        "",
@@ -104,7 +104,7 @@ func TestInferTypeScriptIndexJobsInstallSteps(t *testing.T) {
 				{
 					Root:     "",
 					Image:    lsifTscImage,
-					Commands: []string{"npm install"},
+					Commands: []string{"npm install --ignore-scripts"},
 				},
 			},
 			Root:        "foo/baz",
@@ -117,7 +117,7 @@ func TestInferTypeScriptIndexJobsInstallSteps(t *testing.T) {
 				{
 					Root:     "",
 					Image:    lsifTscImage,
-					Commands: []string{"npm install"},
+					Commands: []string{"npm install --ignore-scripts"},
 				},
 				{
 					Root:     "foo/bar",
@@ -135,7 +135,7 @@ func TestInferTypeScriptIndexJobsInstallSteps(t *testing.T) {
 				{
 					Root:     "",
 					Image:    lsifTscImage,
-					Commands: []string{"npm install"},
+					Commands: []string{"npm install --ignore-scripts"},
 				},
 				{
 					Root:     "foo/bar",
@@ -145,7 +145,7 @@ func TestInferTypeScriptIndexJobsInstallSteps(t *testing.T) {
 				{
 					Root:     "foo/bar/bonk",
 					Image:    lsifTscImage,
-					Commands: []string{"npm install"},
+					Commands: []string{"npm install --ignore-scripts"},
 				},
 			},
 			Root:        "foo/bar/bonk",
@@ -223,7 +223,7 @@ func TestInferTypeScriptIndexJobsTscLernaConfig(t *testing.T) {
 					{
 						Root:     "",
 						Image:    lsifTscImage,
-						Commands: []string{"npm install"},
+						Commands: []string{"npm install --ignore-scripts"},
 					},
 				},
 				LocalSteps:  nil,
@@ -239,7 +239,7 @@ func TestInferTypeScriptIndexJobsTscLernaConfig(t *testing.T) {
 					{
 						Root:     "",
 						Image:    lsifTscImage,
-						Commands: []string{"npm install"},
+						Commands: []string{"npm install --ignore-scripts"},
 					},
 				},
 				LocalSteps:  nil,
@@ -305,7 +305,7 @@ func TestInferTypeScriptIndexJobsNodeVersionInferrence(t *testing.T) {
 					{
 						Root:     "",
 						Image:    lsifTscImage,
-						Commands: []string{nMuslCommand, "npm install"},
+						Commands: []string{nMuslCommand, "npm install --ignore-scripts"},
 					},
 				},
 				LocalSteps: []string{
@@ -323,7 +323,7 @@ func TestInferTypeScriptIndexJobsNodeVersionInferrence(t *testing.T) {
 					{
 						Root:     "",
 						Image:    lsifTscImage,
-						Commands: []string{nMuslCommand, "npm install"},
+						Commands: []string{nMuslCommand, "npm install --ignore-scripts"},
 					},
 				},
 				LocalSteps: []string{

--- a/lib/codeintel/autoindex/inference/util.go
+++ b/lib/codeintel/autoindex/inference/util.go
@@ -12,31 +12,64 @@ type pathMapValue struct {
 	baseDirs map[string]struct{}
 }
 
-type pathMap map[string]*pathMapValue
+type pathMap struct {
+	// impl stores the directory mappings for each file name.
+	// Use pathMap.contains or pathMap.pathsFor instead of accessing this field.
+	impl map[string]*pathMapValue
+	// uniquePaths represents a subset of the original list of paths.
+	// Use pathMap.pathsFor instead of accessing this field directly.
+	uniquePaths []string
+}
 
-func newPathMap(paths []string) (p pathMap) {
-	p = map[string]*pathMapValue{}
-	for i, path := range paths {
+func newPathMap(paths []string) (p *pathMap) {
+	p = &pathMap{}
+	p.uniquePaths = []string{}
+	p.impl = map[string]*pathMapValue{}
+	for _, path := range paths {
 		dir, baseName := filepath.Split(path)
-		dir = filepath.Clean(dir)
-		if entry, ok := p[baseName]; ok {
-			if _, dirPresent := entry.baseDirs[dir]; !dirPresent {
-				entry.indexes = append(entry.indexes, i)
-				entry.baseDirs[dir] = struct{}{}
-			} // dirPresent ==> paths must have duplicates; ignore them
-		} else {
-			p[baseName] = &pathMapValue{[]int{i}, map[string]struct{}{dir: {}}}
-		}
+		p.insert(dir, baseName)
 	}
 	return p
 }
 
-func (p pathMap) contains(dir string, baseName string) bool {
+func (p *pathMap) contains(dir string, baseName string) bool {
 	dir = filepath.Clean(dir)
-	if entry, ok := p[baseName]; ok {
+	if entry, ok := p.impl[baseName]; ok {
 		if _, ok := entry.baseDirs[dir]; ok {
 			return true
 		}
 	}
 	return false
+}
+
+func (p *pathMap) insert(dir string, baseName string) {
+	dir = filepath.Clean(dir)
+	i := len(p.uniquePaths)
+	inserted := true
+	if entry, ok := p.impl[baseName]; ok {
+		if _, dirPresent := entry.baseDirs[dir]; !dirPresent {
+			entry.indexes = append(entry.indexes, i)
+			entry.baseDirs[dir] = struct{}{}
+		} else { // dirPresent ==> paths must have duplicates; ignore them
+			inserted = false
+		}
+	} else {
+		p.impl[baseName] = &pathMapValue{[]int{i}, map[string]struct{}{dir: {}}}
+	}
+	if inserted {
+		p.uniquePaths = append(p.uniquePaths, filepath.Join(dir, baseName))
+	}
+}
+
+// pathsFor returns the list of paths have the same baseName.
+//
+// The returned slice may be empty.
+func (p *pathMap) pathsFor(baseName string) []string {
+	out := []string{}
+	if entry, ok := p.impl[baseName]; ok {
+		for _, index := range entry.indexes {
+			out = append(out, p.uniquePaths[index])
+		}
+	}
+	return out
 }

--- a/lib/codeintel/autoindex/inference/util_test.go
+++ b/lib/codeintel/autoindex/inference/util_test.go
@@ -53,3 +53,22 @@ func TestPathMapContains(t *testing.T) {
 		}
 	}
 }
+
+func TestPathMapInsert(t *testing.T) {
+	pathMap := newPathMap([]string{})
+
+	pathMap.insert("a/", "b.txt")
+	require.True(t, pathMap.contains("a/", "b.txt"))
+
+	pathMap.insert("c/", "b.txt")
+	require.True(t, pathMap.contains("a/", "b.txt"))
+	require.True(t, pathMap.contains("c", "b.txt"))
+
+	pathMap.insert("a/", "d.txt")
+	require.True(t, pathMap.contains("a/", "b.txt"))
+	require.True(t, pathMap.contains("a/", "d.txt"))
+	require.False(t, pathMap.contains("c", "d.txt"))
+
+	pathMap.insert("e/", "a")
+	require.False(t, pathMap.contains("e/a", "b.txt"))
+}


### PR DESCRIPTION
- First commit is a no semantic change commit that introduces a helper method `pathMap.insert` that's useful in the second commit.
- Second commit implements the main change where I tweak auto-inference to work with NPM packages.

Main questions:
- [ ] I've changed the invocation `npm install` to `npm install --ignore-scripts`, because the latter seems to be more applicable to TypeScript packages on NPM. Should we only do that in certain cases? (e.g. When we know we're trying to infer steps for an NPM package? When we see that one of the build steps involves deleting the `dist` directory?) What could go wrong by using `--ignore-scripts`?
- [ ] Should I add more tests? If so, what kind of tests?