### PR TITLE
Add missing .gitattributes files for various generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 cmd/repo-updater/repos/testdata/** linguist-generated=true
 **/__fixtures__/** linguist-generated=true
 **/bindata.go linguist-generated=true
+**/*.pb.go linguist-generated=true
 CHANGELOG.md merge=union

--- a/doc/admin/observability/.gitattributes
+++ b/doc/admin/observability/.gitattributes
@@ -1,0 +1,2 @@
+dashboards.md linguist-generated=true
+alert_solutions.md linguist-generated=true

--- a/doc/code_intelligence/references/.gitattributes
+++ b/doc/code_intelligence/references/.gitattributes
@@ -1,0 +1,2 @@
+lsif.md linguist-generated=true
+lsif.sprig linguish-generated=true

--- a/lib/codeintel/lsif_typed/.gitattributes
+++ b/lib/codeintel/lsif_typed/.gitattributes
@@ -1,0 +1,1 @@
+lsif.ts linguist-generated=true

--- a/monitoring/.gitattributes
+++ b/monitoring/.gitattributes
@@ -1,0 +1,1 @@
+monitoring/documentation.go linguist-generated=true


### PR DESCRIPTION
With PR review, I've noticed myself making the mistake multiple times where I end up reading a bunch of generated code when I should be focusing on the original code from which it was generated. Part of the issue here is that GitHub doesn't show the file header, which usually carries a "DO NOT EDIT, this was generated by blah." [This problem can be mitigated by using `.gitattributes` files](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github).

> Use a .gitattributes file to mark files that match a given "pattern" with the specified attributes.
>
> Use the linguist-generated attribute to mark or unmark paths that you would like to be ignored for the repository's language statistics and hidden by default in diffs

We already have one at the project root, but that doesn't catch everything. The current patch adds directory-local files, which should be allowed according the [Git docs](https://git-scm.com/docs/gitattributes):

> When deciding what attributes are assigned to a path, Git consults $GIT_DIR/info/attributes file (which has the highest precedence), **.gitattributes file in the same directory as the path in question** (emphasis added), and its parent directories up to the toplevel of the work tree (the further the directory that contains .gitattributes is from the path in question, the lower its precedence). Finally global and system-wide files are considered (they have the lowest precedence).

The official GitHub docs recommend:

> Unless the .gitattributes file already exists, create a .gitattributes file in the root of the repository.

I'm not 100% sure if directory-local `.gitattributes` work or not on GitHub. If this patch doesn't work, I guess we can combine all the `.gitattributes` into one jumbo `.gitattributes` at the root of the repo.