### PR TITLE
Code Insight [spike]: Re-implement grid layout in order to support persistent order and size

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.story.tsx
@@ -44,6 +44,36 @@ const insights: Insight[] = [
         step: { weeks: 2 },
         filters: { excludeRepoRegexp: '', includeRepoRegexp: '' },
     },
+    {
+        id: 'searchInsights.insight.Backend_3',
+        type: InsightExecutionType.Backend,
+        viewType: InsightType.SearchBased,
+        title: 'Backend insight #3',
+        series: [],
+        visibility: 'personal',
+        step: { weeks: 2 },
+        filters: { excludeRepoRegexp: '', includeRepoRegexp: '' },
+    },
+    {
+        id: 'searchInsights.insight.Backend_4',
+        type: InsightExecutionType.Backend,
+        viewType: InsightType.SearchBased,
+        title: 'Backend insight #4',
+        series: [],
+        visibility: 'personal',
+        step: { weeks: 2 },
+        filters: { excludeRepoRegexp: '', includeRepoRegexp: '' },
+    },
+    {
+        id: 'searchInsights.insight.Backend_5',
+        type: InsightExecutionType.Backend,
+        viewType: InsightType.SearchBased,
+        title: 'Backend insight #5',
+        series: [],
+        visibility: 'personal',
+        step: { weeks: 2 },
+        filters: { excludeRepoRegexp: '', includeRepoRegexp: '' },
+    },
 ]
 
 class CodeInsightsStoryBackend extends CodeInsightsSettingsCascadeBackend {

--- a/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.tsx
@@ -8,7 +8,11 @@ import { ViewGrid } from '../../../../views'
 import { Insight } from '../../core/types'
 
 import { SmartInsight } from './components/smart-insight/SmartInsight'
-import { insightLayoutGenerator, recalculateGridLayout } from './utils/grid-layout-generator'
+import {
+    insightLayoutGenerator,
+    recalculateGridLayout,
+    recalculateGridLayoutOnResize
+} from './utils/grid-layout-generator'
 
 interface SmartInsightsViewGridProps extends TelemetryProps {
     /**
@@ -72,9 +76,14 @@ export const SmartInsightsViewGrid: React.FunctionComponent<SmartInsightsViewGri
         [insights]
     )
 
+    const handleLayoutResize = useCallback((currentLayout: Layout[]) => {
+        recalculateGridLayoutOnResize(currentLayout)
+    }, [])
+
     return (
         <ViewGrid
             layouts={layouts}
+            onResize={handleLayoutResize}
             onResizeStart={handleResizeStart}
             onResizeStop={handleResizeStop}
             onDragStart={trackUICustomization}

--- a/client/web/src/views/components/view-grid/ViewGrid.tsx
+++ b/client/web/src/views/components/view-grid/ViewGrid.tsx
@@ -18,15 +18,15 @@ import styles from './ViewGrid.module.scss'
 // (WidthProvider only listens to window resize events)
 const ResponsiveGridLayout = WidthProvider(Responsive)
 
-export const BREAKPOINTS_NAMES = ['xs', 'sm', 'md', 'lg'] as const
+export const BREAKPOINTS_NAMES = ['xs', 'lg'] as const
 
 export type BreakpointName = typeof BREAKPOINTS_NAMES[number]
 
 /** Minimum size in px after which a breakpoint is active. */
-export const BREAKPOINTS: Record<BreakpointName, number> = { xs: 0, sm: 576, md: 768, lg: 992 } // no xl because TreePage's max-width is the xl breakpoint.
-export const COLUMNS: Record<BreakpointName, number> = { xs: 1, sm: 6, md: 8, lg: 12 }
-export const DEFAULT_ITEMS_PER_ROW: Record<BreakpointName, number> = { xs: 1, sm: 2, md: 2, lg: 3 }
-export const MIN_WIDTHS: Record<BreakpointName, number> = { xs: 1, sm: 2, md: 3, lg: 3 }
+export const BREAKPOINTS: Record<BreakpointName, number> = { xs: 0, lg: 512 } // no xl because TreePage's max-width is the xl breakpoint.
+export const COLUMNS: Record<BreakpointName, number> = { xs: 1, lg: 12 }
+export const DEFAULT_ITEMS_PER_ROW: Record<BreakpointName, number> = { xs: 1, lg: 3 }
+export const MIN_WIDTHS: Record<BreakpointName, number> = { xs: 1, lg: 3 }
 export const DEFAULT_HEIGHT = 3.25
 
 const DEFAULT_VIEWS_LAYOUT_GENERATOR = (viewIds: string[]): ReactGridLayouts =>
@@ -75,6 +75,7 @@ interface ViewGridCommonProps {
     className?: string
 
     onLayoutChange?: (currentLayout: Layout[], allLayouts: Layouts) => void
+    onResize?: (currentLayout: Layout[]) => void
     onResizeStart?: (newItem: Layout) => void
     onResizeStop?: (newItem: Layout) => void
     onDragStart?: (newItem: Layout) => void
@@ -90,6 +91,7 @@ export const ViewGrid: React.FunctionComponent<PropsWithChildren<ViewGridProps &
         children,
         className,
         onLayoutChange,
+        onResize = noop,
         onResizeStart = noop,
         onResizeStop = noop,
         onDragStart = noop,
@@ -130,8 +132,11 @@ export const ViewGrid: React.FunctionComponent<PropsWithChildren<ViewGridProps &
                 rowHeight={6 * 16}
                 containerPadding={[0, 0]}
                 useCSSTransforms={useCSSTransforms}
+                compactType={null}
+                verticalCompact={false}
                 margin={[12, 12]}
                 onResizeStart={handleResizeStart}
+                onResize={onResize}
                 onResizeStop={handleResizeStop}
                 onLayoutChange={onLayoutChange}
                 onDragStart={handleDragStart}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/29536

## Context 

More details on persistent order/size and its problems [here in the designated GH discussion ](https://github.com/sourcegraph/sourcegraph/discussions/29840)

## The order problem with resizing 
[Link to the discussion thread](https://github.com/sourcegraph/sourcegraph/discussions/29840#discussioncomment-1986554)

In this PR we've managed to tweak the `react-grid-layout` lib in a way to achieve row item wrapping that supports persistent order of the grid cards. In the nutshell, we support horizontal compact layer 

<img width="599" alt="Screenshot 2022-01-24 at 12 35 27" src="https://user-images.githubusercontent.com/18492575/150757849-fa14f08e-ea3d-4e79-959b-7ff2bc7834c9.png">

Compare the following two grid layouts 

**The first one** is the current one. We compact grid items by Y-axis. In this case, if we don't have enough space in a row for items this item will be shifted down in the grid. This is bad because in this case, we're losing order. 

https://user-images.githubusercontent.com/18492575/150759145-68be5363-5ba5-4c25-9fff-61c0cdfa78a0.mov

**The second one** is this PR improved grid layout. Note how we wrap elements in the next row if we don't have enough space. We persist the order according to the horizontal order of the masonry grid layout

https://user-images.githubusercontent.com/18492575/150759064-f8d5f7de-532a-40f8-916e-9664a48972d6.mov

## Persistent order

For now, it looks like an algorithm for determining order from the grid ([as described here](https://github.com/sourcegraph/sourcegraph/discussions/29840#discussioncomment-1988687)) is a good fit for our system. 

## Persistent cards sizes

Based on eng team sync and discussion about having only two modes for the grid layout (mobile and desktop) as [described here](https://github.com/sourcegraph/sourcegraph/discussions/29840#discussioncomment-1992687) allows us to have universal card size columns/rows size values for the cards. This simplifies mutation and query for storing those sizes in our GQL API. ([related GH discussion thread](https://github.com/sourcegraph/sourcegraph/discussions/29840#discussioncomment-1989158))

```graphql
type InsightsDashboard implements Node {
 
    id: ID!
    title: String!
    views(first: Int, after: ID): InsightViewConnection
    grants: InsightsPermissionGrants!
    
    """
    The dashboard visual settings
    """
    visualSettings: InsightVisualSettings[]
}

type InsightVisualSettings {
 id: ID!
 width: number!
 height: number!
}
```


