### PR TITLE
ci: avoid spawning a subshell when tracing cmds

### DIFF
--- a/enterprise/dev/ci/scripts/trace-command.sh
+++ b/enterprise/dev/ci/scripts/trace-command.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-(
-  BUILDEVENT_APIKEY="$CI_BUILDEVENT_API_KEY"
-  BUILDEVENT_DATASET="$CI_BUILDEVENT_DATASET"
-  export BUILDEVENT_APIKEY
-  export BUILDEVENT_DATASET
-  args=$*
+BUILDEVENT_APIKEY="$CI_BUILDEVENT_API_KEY"
+BUILDEVENT_DATASET="$CI_BUILDEVENT_DATASET"
+export BUILDEVENT_APIKEY
+export BUILDEVENT_DATASET
+args=$*
 
-  tracedCommand=$(printf 'buildevents cmd %s %s '"'"'%s'"'" "$BUILDKITE_BUILD_ID" "$BUILDKITE_STEP_ID" "$args")
-  eval "$tracedCommand -- $args"
-)
+tracedCommand=$(printf 'buildevents cmd %s %s '"'"'%s'"'" "$BUILDKITE_BUILD_ID" "$BUILDKITE_STEP_ID" "$args")
+eval "$tracedCommand -- $args"
+
+unset BUILDEVENT_APIKEY
+unset BUILDEVENT_DATASET


### PR DESCRIPTION
Running the commands within `( ... )` has the side-effect of negating directory changes from `pushd/popd` which broke the e2e nightly test suite. 
