### PR TITLE
github: Explicit check for org admin in getRepoAffiliatedGroups

### DIFF
--- a/enterprise/internal/authz/github/client.go
+++ b/enterprise/internal/authz/github/client.go
@@ -9,18 +9,20 @@ import (
 
 // 🚨 SECURITY: Call sites should take care to provide this valid values and use the return
 // value appropriately to ensure org repo access are only provided to valid users.
-func canViewOrgRepos(org *github.OrgDetailsAndMembership) bool {
-	if org == nil {
+func canViewOrgRepos(odm *github.OrgDetailsAndMembership) bool {
+	if odm == nil {
 		return false
 	}
-	// If user is active org admin, they can see all org repos
-	if org.OrgMembership != nil && org.OrgMembership.State == "active" && org.OrgMembership.Role == "admin" {
+
+	// If user is active org admin, they can see all org repos.
+	if odm.IsAdmin() {
 		return true
 	}
+
 	// https://github.com/organizations/$ORG/settings/member_privileges -> "Base permissions"
-	return org.OrgDetails != nil && (org.DefaultRepositoryPermission == "read" ||
-		org.DefaultRepositoryPermission == "write" ||
-		org.DefaultRepositoryPermission == "admin")
+	return odm.OrgDetails != nil && (odm.DefaultRepositoryPermission == "read" ||
+		odm.DefaultRepositoryPermission == "write" ||
+		odm.DefaultRepositoryPermission == "admin")
 }
 
 // client defines the set of GitHub API client methods used by the authz provider.

--- a/enterprise/internal/authz/github/github.go
+++ b/enterprise/internal/authz/github/github.go
@@ -539,12 +539,13 @@ func (p *Provider) getRepoAffiliatedGroups(ctx context.Context, owner, name stri
 		groups = append(groups, repoAffiliatedGroup{cachedGroup: group, adminsOnly: adminsOnly})
 	}
 
-	allOrgMembersCanRead := canViewOrgRepos(&github.OrgDetailsAndMembership{OrgDetails: org})
+	odm := github.OrgDetailsAndMembership{OrgDetails: org}
+	allOrgMembersCanRead := canViewOrgRepos(&odm)
 	if allOrgMembersCanRead {
 		// 🚨 SECURITY: Iff all members of this org can view this repo, indicate that all members should
 		// be sync'd.
 		syncGroup(owner, "", false)
-	} else {
+	} else if odm.IsAdmin() {
 		// 🚨 SECURITY: Sync *only admins* of this org
 		syncGroup(owner, "", true)
 

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -330,6 +330,18 @@ type OrgDetailsAndMembership struct {
 	*OrgMembership
 }
 
+// IsAdmin will return true if the membership details for the given OrgDetailsAndMembership has an
+// "active" state and the role is set to "admin". Otherwise it will return false.
+func (o *OrgDetailsAndMembership) IsAdmin() bool {
+	if o.OrgMembership != nil &&
+		o.OrgMembership.State == "active" &&
+		o.OrgMembership.Role == "admin" {
+		return true
+	}
+
+	return false
+}
+
 // GetAuthenticatedUserOrgsDetailsAndMembership returns the organizations associated with the currently
 // authenticated user as well as additional information about each org by making API
 // requests for each org (see `OrgDetails` and `OrgMembership` docs for more details).


### PR DESCRIPTION
I stumbled upon this while writing a test case for #29325. 

If `canViewOrgRepos` returns `false` we implicitly assume that the org
membership details belong to an admin. This is not necessarily true in
all cases. For example, if the user is not an admin and the
OrgDetailsAndMembership.DefaultRepositoryPermissions is set to
`none`[1], the function call to `canViewOrgRepos` will return false
and we will continue to call `syncGroup` assuming this is an
admin. Which is not the correct behaviour.

[1]: https://docs.github.com/en/rest/reference/orgs#update-an-organization--parameters



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
