### PR TITLE
Fix browser extension after-install page

### DIFF
--- a/client/browser/src/browser-extension/scripts/afterInstallPage.main.tsx
+++ b/client/browser/src/browser-extension/scripts/afterInstallPage.main.tsx
@@ -18,4 +18,4 @@ const AfterInstallPage: React.FunctionComponent = () => (
     </ThemeWrapper>
 )
 
-document.addEventListener('DOMContentLoaded', () => render(<AfterInstallPage />, document.querySelector('#root')))
+render(<AfterInstallPage />, document.querySelector('#root'))

--- a/client/browser/src/browser-extension/scripts/afterInstallPage.main.tsx
+++ b/client/browser/src/browser-extension/scripts/afterInstallPage.main.tsx
@@ -10,8 +10,12 @@ import { ThemeWrapper } from '../ThemeWrapper'
 
 const AfterInstallPage: React.FunctionComponent = () => (
     <ThemeWrapper>
-        <WildcardThemeProvider>{AfterInstallPageContent}</WildcardThemeProvider>
+        {({ isLightTheme }) => (
+            <WildcardThemeProvider>
+                <AfterInstallPageContent isLightTheme={isLightTheme} />
+            </WildcardThemeProvider>
+        )}
     </ThemeWrapper>
 )
 
-render(<AfterInstallPage />, document.querySelector('#root'))
+document.addEventListener('DOMContentLoaded', () => render(<AfterInstallPage />, document.querySelector('#root')))


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/30101.

#### Description

This PR:
- Fixes the browser extension after-install page, which was broken in https://github.com/sourcegraph/sourcegraph/pull/28837

#### How to test
- `sg run bext`
- Reinstall the browser extension locally and check that the after-install page is rendered properly.
