### PR TITLE
sg: warn the user if running start outside repo

### DIFF
--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -78,6 +78,8 @@ Use this to start your Sourcegraph environment!
 		}
 		sort.Strings(names)
 		fmt.Fprint(&out, strings.Join(names, "\n"))
+	} else {
+		fmt.Fprintf(&out, "\n%sNo commandsets found! Please change your current directory the the Sourcegraph repository.%s", output.StyleOrange, output.StyleReset)
 	}
 
 	return out.String()

--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -79,7 +79,7 @@ Use this to start your Sourcegraph environment!
 		sort.Strings(names)
 		fmt.Fprint(&out, strings.Join(names, "\n"))
 	} else {
-		fmt.Fprintf(&out, "\n%sNo commandsets found! Please change your current directory the the Sourcegraph repository.%s", output.StyleOrange, output.StyleReset)
+		fmt.Fprintf(&out, "\n%sNo commandsets found! Please change your current directory to the Sourcegraph repository.%s", output.StyleOrange, output.StyleReset)
 	}
 
 	return out.String()


### PR DESCRIPTION
Context on [Slack](https://sourcegraph.slack.com/archives/C01CSS3TC75/p1643026864118600?thread_ts=1642753971.104500&cid=C01CSS3TC75): users are confused by the output of `sg start -h` because if its run outside the main repo, it lists not commandsets. 

![image](https://user-images.githubusercontent.com/10151/150786438-83e6aa3e-308d-46b7-a8a3-94f48b435ebb.png)

Fixed the typo in the screenshot in the second commit.
