### PR TITLE
internal/repos: Add debug log to investigate update queue growth rate

### DIFF
--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -864,6 +864,8 @@ func (s *schedule) reset() {
 		s.timer.Stop()
 		s.timer = nil
 	}
+
+	log15.Debug("schedKnownRepos reset")
 	schedKnownRepos.Set(0)
 }
 


### PR DESCRIPTION
We've seen this alert get triggered over the last few days even though
the metrics seem to indicate otherwise. Adding a log to understand
when we are resetting the update queue.


Screenshot of the metric and the alert event. Clearly indicates that the growth rate is not zero even thought [the alert](https://sourcegraph.app.opsgenie.com/alert/detail/70e102c6-39fe-410a-872a-e564ff278738-1643028323021/details) suggests otherwise. 
![image](https://user-images.githubusercontent.com/2682729/150789887-ba31e61d-ae05-40e8-9a67-45f72ba2cc8c.png)




<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
