### PR TITLE
Customize colors for JSON syntax highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
--
+- Syntax highlighting for JSON now uses a distinct color for strings in object key positions. [#30105](https://github.com/sourcegraph/sourcegraph/pull/30105)
 
 ### Fixed
 

--- a/client/branded/src/global-styles/highlight.scss
+++ b/client/branded/src/global-styles/highlight.scss
@@ -458,6 +458,14 @@
         }
     }
 
+    .hl-json {
+        .hl-key {
+            .hl-string {
+                color: var(--hl-orange);
+            }
+        }
+    }
+
     .hl-ts {
         .hl-keyword.hl-control {
             color: var(--hl-orange);
@@ -756,6 +764,14 @@
         .hl-markup.hl-inserted {
             color: var(--hl-white);
             background: var(--diff-add-bg);
+        }
+    }
+
+    .hl-json {
+        .hl-key {
+            .hl-string {
+                color: var(--hl-green-2);
+            }
         }
     }
 }


### PR DESCRIPTION
Previously, we used the same syntax highlighting color for JSON keys and
values. This commit overrides the color for keys so that it's easier to
distinguish them from values.

**Before (current behavior on Cloud)**
![CleanShot 2022-01-24 at 15 20 44](https://user-images.githubusercontent.com/1408093/150800080-d9fb3e7c-581c-49ed-a0df-4158b3e48ceb.png)

**After (this PR)**
![CleanShot 2022-01-24 at 15 20 58](https://user-images.githubusercontent.com/1408093/150800132-318d13a3-516c-4950-ad32-b3eecbef9cc8.png)
![CleanShot 2022-01-24 at 15 20 54](https://user-images.githubusercontent.com/1408093/150800144-a06ae4f7-6442-42dd-886e-b8855eed1b2d.png)



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
