### PR TITLE
Add helpers to the `Matches` type

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -144,7 +144,7 @@ type SearchResultsResolver struct {
 }
 
 type SearchResults struct {
-	Matches []result.Match
+	Matches result.Matches
 	Stats   streaming.Stats
 	Alert   *searchAlert
 }
@@ -198,11 +198,7 @@ func matchesToResolvers(db database.DB, matches []result.Match) []SearchResultRe
 }
 
 func (sr *SearchResultsResolver) MatchCount() int32 {
-	var totalResults int
-	for _, result := range sr.Matches {
-		totalResults += result.ResultCount()
-	}
-	return int32(totalResults)
+	return int32(sr.Matches.ResultCount())
 }
 
 // Deprecated. Prefer MatchCount.

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -144,14 +144,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		filters.Update(event)
 
 		// Truncate the event to the match limit before fetching repo metadata
-		for i, match := range event.Results {
-			if display <= 0 {
-				event.Results = event.Results[:i]
-				break
-			}
-
-			display = match.Limit(display)
-		}
+		display = event.Results.Limit(display)
 
 		repoMetadata, err := getEventRepoMetadata(ctx, h.db, event)
 		if err != nil {

--- a/internal/search/result/commit.go
+++ b/internal/search/result/commit.go
@@ -72,6 +72,7 @@ func (r *CommitMatch) RepoName() types.MinimalRepo {
 	return r.Repo
 }
 
+// Limit implements Match.Limit()
 func (r *CommitMatch) Limit(limit int) int {
 	limitMatchedString := func(ms *MatchedString) int {
 		if len(ms.MatchedRanges) == 0 {

--- a/internal/search/result/match.go
+++ b/internal/search/result/match.go
@@ -10,7 +10,12 @@ import (
 // to ensure only those types implement Match.
 type Match interface {
 	ResultCount() int
+
+	// Limit truncates the match such that, after limiting,
+	// `Match.ResultCount() == limit`. It should never be called with
+	// `limit <= 0`, since a single match cannot be truncated to zero results.
 	Limit(int) int
+
 	Select(filter.SelectPath) Match
 	RepoName() types.MinimalRepo
 
@@ -87,6 +92,7 @@ func (m Matches) Len() int           { return len(m) }
 func (m Matches) Less(i, j int) bool { return m[i].Key().Less(m[j].Key()) }
 func (m Matches) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
 
+// Limit truncates the slice of matches such that, after limiting, `m.ResultCount() == limit`
 func (m *Matches) Limit(limit int) int {
 	for i, match := range *m {
 		if limit <= 0 {
@@ -98,6 +104,7 @@ func (m *Matches) Limit(limit int) int {
 	return limit
 }
 
+// ResultCount returns the sum of the result counts of each match in the slice
 func (m Matches) ResultCount() int {
 	count := 0
 	for _, match := range m {

--- a/internal/search/result/match.go
+++ b/internal/search/result/match.go
@@ -86,3 +86,14 @@ type Matches []Match
 func (m Matches) Len() int           { return len(m) }
 func (m Matches) Less(i, j int) bool { return m[i].Key().Less(m[j].Key()) }
 func (m Matches) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
+
+func (m *Matches) Limit(limit int) int {
+	for i, match := range *m {
+		if limit <= 0 {
+			*m = (*m)[:i]
+			return 0
+		}
+		limit = match.Limit(limit)
+	}
+	return limit
+}

--- a/internal/search/result/match.go
+++ b/internal/search/result/match.go
@@ -97,3 +97,11 @@ func (m *Matches) Limit(limit int) int {
 	}
 	return limit
 }
+
+func (m Matches) ResultCount() int {
+	count := 0
+	for _, match := range m {
+		count += match.ResultCount()
+	}
+	return count
+}

--- a/internal/search/result/repo.go
+++ b/internal/search/result/repo.go
@@ -23,6 +23,7 @@ func (r RepoMatch) RepoName() types.MinimalRepo {
 	}
 }
 
+// Limit implements Match.Limit()
 func (r RepoMatch) Limit(limit int) int {
 	// Always represents one result and limit > 0 so we just return limit - 1.
 	return limit - 1

--- a/internal/search/streaming/stream.go
+++ b/internal/search/streaming/stream.go
@@ -28,18 +28,14 @@ type LimitStream struct {
 func (s *LimitStream) Send(event SearchEvent) {
 	s.s.Send(event)
 
-	var count int64
-	for _, r := range event.Results {
-		count += int64(r.ResultCount())
-	}
-
 	// Avoid limit checks if no change to result count.
+	count := event.Results.ResultCount()
 	if count == 0 {
 		return
 	}
 
 	old := s.remaining.Load()
-	s.remaining.Sub(count)
+	s.remaining.Sub(int64(count))
 
 	// Only send IsLimitHit once. Can race with other sends and be sent
 	// multiple times, but this is fine. Want to avoid lots of noop events

--- a/internal/search/streaming/stream.go
+++ b/internal/search/streaming/stream.go
@@ -11,7 +11,7 @@ import (
 )
 
 type SearchEvent struct {
-	Results []result.Match
+	Results result.Matches
 	Stats   Stats
 }
 


### PR DESCRIPTION
We have a type for a collection of matches, and we have a few spots that contain inline logic for things that can be operations on this slice type. This adds `Matches.Limit()` and `Matches.ResultCount()` which better encapsulates the logic and simplifies the callsites. 