### PR TITLE
vcs: fix RefDescriptions output for tag refs to print commit objname rather than tag objname

### DIFF
--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -486,7 +486,8 @@ func parseCommitFromLog(data []byte, partsPerCommit int) (commit *wrappedCommit,
 			Committer: &gitdomain.Signature{Name: string(parts[5]), Email: string(parts[6]), Date: time.Unix(committerTime, 0).UTC()},
 			Message:   gitdomain.Message(strings.TrimSuffix(string(parts[8]), "\n")),
 			Parents:   parents,
-		}, files: fileNames}
+		}, files: fileNames,
+	}
 
 	if len(parts) == partsPerCommit+1 {
 		rest = parts[partsPerCommit]
@@ -555,7 +556,7 @@ func parseBranchesContaining(lines []string) []string {
 // RefDescriptions returns a map from commits to descriptions of the tip of each
 // branch and tag of the given repository.
 func RefDescriptions(ctx context.Context, repo api.RepoName) (_ map[string][]gitdomain.RefDescription, err error) {
-	args := []string{"for-each-ref", "--format=%(objectname):%(refname):%(HEAD):%(creatordate:iso8601-strict)"}
+	args := []string{"for-each-ref", "--format=%(*objectname):%(refname):%(HEAD):%(creatordate:iso8601-strict)"}
 	for prefix := range refPrefixes {
 		args = append(args, prefix)
 	}


### PR DESCRIPTION
From [git: for-each-ref](https://git-scm.com/docs/git-for-each-ref#Documentation/git-for-each-ref.txt---formatltformatgt): "If `fieldname` is prefixed with an asterisk (`*`) and the ref points at a tag object, use the value for the field in the object which the tag object refers to (instead of the field in the tag object)."

Example: 
[v3.36.1](https://github.com/sourcegraph/sourcegraph/releases/tag/v3.36.1) is tagged at the commit `a702958ce54aeb141b820662e0f0167011e9a610`. 
- Running `git for-each-ref --format='%(objectname):%(refname):%(HEAD):%(creatordate:iso8601-strict)' 'refs/heads/' 'refs/tags/' | grep a702958ce54aeb141b820662e0f0167011e9a610` returns no results. 
- Running `git for-each-ref --format='%(objectname):%(refname):%(HEAD):%(creatordate:iso8601-strict)' 'refs/heads/' 'refs/tags/' | grep '3.36.1:'` returns one result, `95eb0e56f6390f12d88292fdd32da32756bc1af1:refs/tags/v3.36.1: :2022-01-21T13:07:22-05:00`. Notice thats a different hash than the commit hash the tag supposedly points to.
- Running `git for-each-ref --format='%(*objectname):%(refname):%(HEAD):%(creatordate:iso8601-strict)' 'refs/heads/' 'refs/tags/' | grep '3.36.1:'` returns one result, `a702958ce54aeb141b820662e0f0167011e9a610:refs/tags/v3.36.1: :2022-01-21T13:07:22-05:00`. This is the expected output, with the commit hash the tag points to.

This probably adversely affected the tag policy matcher, probably making it not effective has the [commit map insert](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@nsc/refdescriptions-tag-fix/-/blob/enterprise/internal/codeintel/policies/matcher.go#L139:7) would insert the tag object hash while the [commit map lookup](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@nsc/refdescriptions-tag-fix/-/blob/enterprise/cmd/worker/internal/codeintel/janitor/upload_expirer.go#L264:42) wouldn't return any tag policy matches as theyd be under a different key
