### PR TITLE
Fix browser extension dropdown to start suggesting after 1st URL change instead of 2nd

### DIFF
--- a/client/browser/src/browser-extension/scripts/optionsPage.main.tsx
+++ b/client/browser/src/browser-extension/scripts/optionsPage.main.tsx
@@ -105,7 +105,7 @@ const validateSourcegraphUrl = (url: string): Observable<string | undefined> =>
     )
 
 const observingIsActivated = observeStorageKey('sync', 'disableExtension').pipe(map(isDisabled => !isDisabled))
-const observingPreviouslyUsedUrls = observeStorageKey('sync', 'previouslyUsedURLs').pipe(distinctUntilChanged())
+const observingPreviouslyUsedUrls = observeStorageKey('sync', 'previouslyUsedURLs')
 const observingSourcegraphUrl = observeSourcegraphURL(true).pipe(distinctUntilChanged())
 const observingOptionFlagsWithValues = observeOptionFlagsWithValues(IS_EXTENSION)
 const observingSendTelemetry = observeSendTelemetry(IS_EXTENSION)

--- a/client/browser/src/browser-extension/scripts/optionsPage.main.tsx
+++ b/client/browser/src/browser-extension/scripts/optionsPage.main.tsx
@@ -105,7 +105,7 @@ const validateSourcegraphUrl = (url: string): Observable<string | undefined> =>
     )
 
 const observingIsActivated = observeStorageKey('sync', 'disableExtension').pipe(map(isDisabled => !isDisabled))
-const observingPreviouslyUsedUrls = observeStorageKey('sync', 'previouslyUsedURLs')
+const observingPreviouslyUsedUrls = observeStorageKey('sync', 'previouslyUsedURLs').pipe(distinctUntilChanged())
 const observingSourcegraphUrl = observeSourcegraphURL(true).pipe(distinctUntilChanged())
 const observingOptionFlagsWithValues = observeOptionFlagsWithValues(IS_EXTENSION)
 const observingSendTelemetry = observeSendTelemetry(IS_EXTENSION)
@@ -183,7 +183,12 @@ const Options: React.FunctionComponent = () => {
                 return
             }
             storage.sync
-                .set({ sourcegraphURL: url, previouslyUsedURLs: uniq([...(previouslyUsedUrls || []), url]) })
+                .set({
+                    sourcegraphURL: url,
+                    previouslyUsedURLs: uniq([...(previouslyUsedUrls || []), url, sourcegraphUrl]).filter(
+                        value => !!value
+                    ) as string[],
+                })
                 .catch(console.error)
         },
         [previouslyUsedUrls, sourcegraphUrl]


### PR DESCRIPTION
Follow-up https://github.com/sourcegraph/sourcegraph/pull/29471.

#### Description

Currently, browser extension starts suggesting after the initial 2 URL changes. 

P.S: I missed it because I have bext installed always and storage was always there. Only noticed when doing full regression test before a new release.

#### How to test

- `sg run bext`
- Reinstall browser extension
- Update URL
- Check that there appear a dropdown with suggestions
