### PR TITLE
Make LimitStream stop sending results when the limit is hit

### DIFF
--- a/internal/search/streaming/stream.go
+++ b/internal/search/streaming/stream.go
@@ -38,7 +38,7 @@ func (s *LimitStream) Send(event SearchEvent) {
 	after := s.remaining.Sub(count)
 	before := after + count
 
-	// Check if the event needs truncated before being sent
+	// Check if the event needs truncating before being sent
 	if after < 0 {
 		limit := before
 		if before < 0 {

--- a/internal/search/streaming/stream.go
+++ b/internal/search/streaming/stream.go
@@ -26,21 +26,36 @@ type LimitStream struct {
 }
 
 func (s *LimitStream) Send(event SearchEvent) {
-	s.s.Send(event)
+	count := int64(event.Results.ResultCount())
 
 	// Avoid limit checks if no change to result count.
-	count := event.Results.ResultCount()
 	if count == 0 {
+		s.s.Send(event)
 		return
 	}
 
-	old := s.remaining.Load()
-	s.remaining.Sub(int64(count))
+	// Get the remaining count before and after sending this event
+	after := s.remaining.Sub(count)
+	before := after + count
 
-	// Only send IsLimitHit once. Can race with other sends and be sent
-	// multiple times, but this is fine. Want to avoid lots of noop events
-	// after the first IsLimitHit.
-	if old >= 0 && s.remaining.Load() < 0 {
+	// Check if the event needs truncated before being sent
+	if after < 0 {
+		limit := before
+		if before < 0 {
+			limit = 0
+		}
+		event.Results.Limit(int(limit))
+	}
+
+	// Send the maybe-truncated event. We want to always send the event
+	// even if we truncate it to zero results in case it has stats on it
+	// that we care about it.
+	s.s.Send(event)
+
+	// Send the IsLimitHit event and call cancel exactly once. This will
+	// only trigger when the result count of an event causes us to cross
+	// the zero-remaining threshold.
+	if after <= 0 && before > 0 {
 		s.s.Send(SearchEvent{Stats: Stats{IsLimitHit: true}})
 		s.cancel()
 	}


### PR DESCRIPTION
Previously, when the limit was hit, we would cancel any jobs depending
on the context returned when creating the LimitStream, but we would
still send any events that those jobs sent after the context was
cancelled. This meant that, even though we were "limiting" the stream,
it was only a soft limit.

This makes it difficult to make guarantees for upstream consumers of a
limited stream. For example, with AND searches, we want strictly no more
than n results, but limit stream might return an unboundedly large
number of results. This causes errors when I try to depend on
LimitStream for AND searches.

Stacked on #30118 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
