### PR TITLE
ci: caching mechanism for stateless agents 

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -29,7 +29,7 @@ aws configure set aws_secret_access_key "$BUILDKITE_HMAC_SECRET" --profile build
 # TODO remove this when making job the default queue
 # Skip on normal queues because standard agents do not have fresh asdf installs
 if [ "$BUILDKITE_AGENT_META_DATA_QUEUE" = "standard,default" ]; then 
-  exit 0
+    exit 0
 fi
 
 asdf_checksum=$(sha1sum .tool-versions | awk '{print $1}')
@@ -37,21 +37,21 @@ cache_file="cache-asdf-$asdf_checksum.tar.gz"
 cache_key="$BUILDKITE_ORGANIZATION_SLUG/$BUILDKITE_PIPELINE_NAME/$cache_file"
 
 if aws s3api head-object --bucket "sourcegraph_buildkite_cache" --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "us-central1" --key "$cache_key"; then
-  set -e
-  echo -e "ASDF 🔥 Cache hit: $cache_key"
-  aws s3 cp --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "us-central1" "s3://sourcegraph_buildkite_cache/$cache_key" "$HOME/"
-  pushd "$HOME"
-  tar xzf "$cache_file"
-  popd
+    set -e
+    echo -e "ASDF 🔥 Cache hit: $cache_key"
+    aws s3 cp --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "us-central1" "s3://sourcegraph_buildkite_cache/$cache_key" "$HOME/"
+    pushd "$HOME"
+    tar xzf "$cache_file"
+    popd
 else
-  set -e
-  echo "--- installing all asdf tool versions"
-  asdf install
-  echo "--- caching asdf installation"
-  pushd "$HOME"
-  tar cfz "$cache_file" .asdf
-  popd
-  aws s3 cp --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "us-central1" "$HOME/$cache_file" "s3://sourcegraph_buildkite_cache/$cache_key" 
+    set -e
+    echo "--- installing all asdf tool versions"
+    asdf install
+    echo "--- caching asdf installation"
+    pushd "$HOME"
+    tar cfz "$cache_file" .asdf
+    popd
+    aws s3 cp --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "us-central1" "$HOME/$cache_file" "s3://sourcegraph_buildkite_cache/$cache_key" 
 fi
 
 unset AWS_SHARED_CREDENTIALS_FILE

--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -28,6 +28,11 @@ aws configure set aws_secret_access_key "$BUILDKITE_HMAC_SECRET" --profile build
 unset AWS_SHARED_CREDENTIALS_FILE
 unset AWS_CONFIG_FILE
 
+# Skip on normal queues because standard agents do not have fresh asdf installs
+if [ "$BUILDKITE_AGENT_META_DATA_QUEUE" = "standard,default" ]; then 
+  exit 0
+fi
+
 asdf_checksum=$(sha1sum .tool-versions | awk '{print $1}')
 cache_file="cache-asdf-$asdf_checksum.tar.gz"
 cache_key="$BUILDKITE_ORGANIZATION_SLUG/$BUILDKITE_PIPELINE_NAME/$cache_file"

--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -25,9 +25,8 @@ AWS_SHARED_CREDENTIALS_FILE="/buildkite/.aws/credentials"
 export AWS_SHARED_CREDENTIALS_FILE
 aws configure set aws_access_key_id "$BUILDKITE_HMAC_KEY" --profile buildkite
 aws configure set aws_secret_access_key "$BUILDKITE_HMAC_SECRET" --profile buildkite
-unset AWS_SHARED_CREDENTIALS_FILE
-unset AWS_CONFIG_FILE
 
+# TODO remove this when making job the default queue
 # Skip on normal queues because standard agents do not have fresh asdf installs
 if [ "$BUILDKITE_AGENT_META_DATA_QUEUE" = "standard,default" ]; then 
   exit 0
@@ -37,21 +36,23 @@ asdf_checksum=$(sha1sum .tool-versions | awk '{print $1}')
 cache_file="cache-asdf-$asdf_checksum.tar.gz"
 cache_key="$BUILDKITE_ORGANIZATION_SLUG/$BUILDKITE_PIPELINE_NAME/$cache_file"
 
-if aws s3api head-object --bucket "sourcegraph_buildkite_cache" --profile buildkite --endpoint-url 'https://storage.googleapis.com' --key "$cache_key"; then
+if aws s3api head-object --bucket "sourcegraph_buildkite_cache" --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "us-central1" --key "$cache_key"; then
   set -e
   echo -e "ASDF 🔥 Cache hit: $cache_key"
-  aws s3 cp --bucket "sourcegraph_buildkite_cache" --profile buildkite --endpoint-url 'https://storage.googleapis.com' "s3://$cache_key" .
-  tar xzf "$cache_file" -C "$HOME/"
+  aws s3 cp --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "us-central1" "s3://sourcegraph_buildkite_cache/$cache_key" "$HOME/"
+  pushd "$HOME"
+  tar xzf "$cache_file"
+  popd
 else
   set -e
   echo "--- installing all asdf tool versions"
   asdf install
-  # Take note of awscli version that we installed, before switching to the home folder
-  awscli_version=$(asdf list awscli | head -n 1)
   echo "--- caching asdf installation"
   pushd "$HOME"
-  tar chfz "$cache_file" .asdf
-  # Because we're in the home folder, we don't know which version to use, so we need to fix that.
-  asdf global awscli "$awscli_version"
-  aws s3 cp --bucket "sourcegraph_buildkite_cache" --profile buildkite --endpoint-url 'https://storage.googleapis.com' "$cache_file" "s3://$cache_key" 
+  tar cfz "$cache_file" .asdf
+  popd
+  aws s3 cp --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "us-central1" "$HOME/$cache_file" "s3://sourcegraph_buildkite_cache/$cache_key" 
 fi
+
+unset AWS_SHARED_CREDENTIALS_FILE
+unset AWS_CONFIG_FILE

--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -28,6 +28,21 @@ aws configure set aws_secret_access_key "$BUILDKITE_HMAC_SECRET" --profile build
 unset AWS_SHARED_CREDENTIALS_FILE
 unset AWS_CONFIG_FILE
 
-# handle caching absolute paths
-mkdir -p .buildkite-cache
-ln -s ~/.asdf .buildkite-cache/asdf
+asdf_checksum=$(sha1sum .tool-versions | awk '{print $1}')
+cache_file="cache-asdf-$asdf_checksum.tar.gz"
+cache_key="$BUILDKITE_ORGANIZATION_SLUG/$BUILDKITE_PIPELINE_NAME/$cache_file"
+
+if aws s3api head-object --bucket "sourcegraph_buildkite_cache" --profile buildkite --endpoint-url 'https://storage.googleapis.com' --key "$cache_key"; then
+  set -e
+  echo -e "ASDF 🔥 Cache hit: $cache_key"
+  aws s3 cp --bucket "sourcegraph_buildkite_cache" --profile buildkite --endpoint-url 'https://storage.googleapis.com' "s3://$cache_key" .
+  tar xzf "$cache_file" -C "$HOME/"
+else
+  set -e
+  echo "--- installing all asdf tool versions"
+  asdf install
+  echo "--- caching asdf installation"
+  pushd "$HOME"
+  tar chfz "$cache_file" .asdf
+  aws s3 cp --bucket "sourcegraph_buildkite_cache" --profile buildkite --endpoint-url 'https://storage.googleapis.com' "$cache_file" "s3://$cache_key" 
+fi

--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -46,8 +46,12 @@ else
   set -e
   echo "--- installing all asdf tool versions"
   asdf install
+  # Take note of awscli version that we installed, before switching to the home folder
+  awscli_version=$(asdf list awscli | head -n 1)
   echo "--- caching asdf installation"
   pushd "$HOME"
   tar chfz "$cache_file" .asdf
+  # Because we're in the home folder, we don't know which version to use, so we need to fix that.
+  asdf global awscli "$awscli_version"
   aws s3 cp --bucket "sourcegraph_buildkite_cache" --profile buildkite --endpoint-url 'https://storage.googleapis.com' "$cache_file" "s3://$cache_key" 
 fi

--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -9,9 +9,25 @@ echo "Running git fetch..."
 git fetch
 echo "Running git fetch... done"
 
-echo "install asdf plugins"
-asdf install
+echo "install asdf awscli"
+asdf install awscli
 echo "done installing"
 
 # Link the trace-script so we can have pretty steps in the buildkite ui
 ln -s "$(pwd)/enterprise/dev/ci/scripts/trace-command.sh" tr 2>/dev/null || true
+
+# set the buildkite cache access keys
+AWS_CONFIG_DIR_PATH="/buildkite/.aws"
+mkdir -p "$AWS_CONFIG_DIR_PATH"
+AWS_CONFIG_FILE="$AWS_CONFIG_DIR_PATH/config"
+export AWS_CONFIG_FILE
+AWS_SHARED_CREDENTIALS_FILE="/buildkite/.aws/credentials"
+export AWS_SHARED_CREDENTIALS_FILE
+aws configure set aws_access_key_id "$BUILDKITE_HMAC_KEY" --profile buildkite
+aws configure set aws_secret_access_key "$BUILDKITE_HMAC_SECRET" --profile buildkite
+unset AWS_SHARED_CREDENTIALS_FILE
+unset AWS_CONFIG_FILE
+
+# handle caching absolute paths
+mkdir -p .buildkite-cache
+ln -s ~/.asdf .buildkite-cache/asdf

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -3,29 +3,6 @@
 set -eu
 pushd "$(dirname "${BASH_SOURCE[0]}")"/../..
 
-ORPHAN_ASDF=()
-mapfile ORPHAN_ASDF < <(find "$HOME/.asdf/installs/" -maxdepth 2 -empty)
-
-for dir in "${ORPHAN_ASDF[@]}"; do
-    echo "Removing orphaned .asdf directory: ${dir}"
-    rm -rf "${dir}"
-done
-
-TOOL_VERSION_FILES=()
-mapfile -d $'\0' TOOL_VERSION_FILES < <(fd .tool-versions --hidden --absolute-path --print0)
-
-for file in "${TOOL_VERSION_FILES[@]}"; do
-    echo "Installing asdf dependencies as defined in ${file}:"
-    parent=$(dirname "${file}")
-    pushd "${parent}"
-
-    asdf install
-
-    popd
-done
-
-popd
-
 # HoneyComb's buildevent plumbing.
 # -------------------------------
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -28,3 +28,4 @@ GH2SG.bookmarklet.js
 docker-images/grafana/config/provisioning/dashboards/sourcegraph/
 storybook-static/
 browser/code-intel-extensions/
+.buildkite-cache/

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 golang 1.17.5
-yarn 1.22.4
+yarn 1.22.17
 fd 7.4.0
 shfmt 3.2.0
 shellcheck 0.7.1

--- a/doc/dev/background-information/continuous_integration.md
+++ b/doc/dev/background-information/continuous_integration.md
@@ -114,6 +114,8 @@ For most basic PR checks, see [Creating PR checks](#creating-pr-checks) for how 
 
 For more advanced usage for specific run types, see [Run types](#run-types).
 
+For caching artefacts to speed up builds, see [How to cache CI artefacts](../how-to/cache_ci_artefacts.md).
+
 #### Creating PR checks
 
 To create a new check that can run on pull requests on relevant files, check the [`changed.Files`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/enterprise/dev/ci/internal/ci/changed/changed.go) type to see if a relevant `affectsXyz` check already exists.

--- a/doc/dev/how-to/cache_ci_artefacts.md
+++ b/doc/dev/how-to/cache_ci_artefacts.md
@@ -1,0 +1,76 @@
+# How to cache CI artefacts
+
+This guide documents how to cache build artefacts in order to speed up build times on Buildkite. 
+
+## Understanding how agents are working
+
+Our continuous integration system is composed of two parts, a central server controled by Buildkite and agents that are operated by Sourcegraph within our own infrastructure.
+In order to provide strong isolation across builds, to prevent a previous build to create any effect on the next one, our agents are stateless jobs. 
+
+When a build is dispatched by Buildkite, each individual job will be assigned to an agent in a pristine state. Each agent will execute its assigned job, automatically report back to Buildkite and finally shuts itself down. A fresh agent will then be created and will stand in line for the next job.  
+
+This means that our agents are totally **stateless**, exactly like the runners used in GitHub actions. 
+
+## The need for caching 
+
+Because the agents starts with a blank slate means that all dependencies and binaries have to rebuild on each job. This is the price to pay for complete isolation from one job to the other.
+
+A common strategy to address this problem of having to rebuild everything is to store objects that are commonly reused accross jobs and to download them again rather than rebuilding everything from scratch. 
+
+## What and when to cache?
+
+In order to determine what we can cache and when to do it, we need to make sure to cover the following questions:
+
+1. Will it be faster to download a cached version rather than building it?
+1. Can we come up with an identifier that represents accurately what version of the cache is needed, before building anything? 
+  - Ex: the checksum of `yarn.lock` accurately tells us which version of the dependencies cache needs to be downloaded if it exists. 
+1. Is what is being cached, not the end result of that test? 
+  - If it were the case, it means we would be caching the result of the test, which is defeating the purpose of a continuous integration process. 
+
+## How to write a step that caches an artefact?
+
+In the [CI pipeline generator](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/enterprise/dev/ci), when defining a step you can use the `buildkite.Cache()` function to define what needs to be cached and under which key to store it. 
+
+For example: we want to cache the `node_modules` folder to avoid dowloading again all dependencies for the front-end. 
+
+```
+// Browser extension unit tests
+pipeline.AddStep(":jest::chrome: Test browser extension",
+  bk.Cache(&buildkite.CacheOptions{
+		ID:          "node_modules",
+		Key:         "cache-node_modules-{{ checksum 'yarn.lock' }}",
+		RestoreKeys: []string{"cache-node_modules-{{ checksum 'yarn.lock' }}"},
+		Paths:       []string{"node_modules", "client/extension-api/node_modules", "client/eslint-plugin-sourcegraph/node_modules"},
+	})
+  bk.Cmd("dev/ci/yarn-test.sh client/browser"),
+  bk.Cmd("dev/ci/codecov.sh -c -F typescript -F unit"))
+```
+
+The important part here are: 
+
+- The `Key` which defines how the cached version is named, so we can find it again on ulterior builds. 
+  - It includes a `{{ checkusm 'yarn.lock' }}` segment in its name, which means that any changes in the `yarn.lock` will be reflected in the key name. 
+  - It means that if the `yarn.lock` checksum would change because dependencies have changed, it should use a different version of the cached dependencies. If those were to not be present on the cache, it will simply rebuild them and upload the result to the cache. 
+- The `RestoreKeys` lists the keys we can use to know if there is a cached version or not available. 99% of the time, that's the same exact thing as the `Key`.
+- The `Paths` lists the path to the files that needs to be cached. They **must be within the repository**, not outside.
+
+Please note that from the perspective of the commands ran in that step, it's not possible to know if the cache was hit or missed. So the code using what has been cached must be able to understand it on its own (example, checking for the presence of folders defined in the `Paths` keys). Most build systems will handle that on their own, but if you were to cache test data you'll probably have to handle that yourself. 
+
+## How to make sure that caching is faster?
+
+When a build is finished and successful, you will find an annotation with a link to the trace of that build on HoneyComb. You can compare the timings of your build before and after adding the cache (with a cache hit of course, otherwise you would compare no cache with a cache miss, which will often be longer because there is time spent uploading the cache result). 
+
+## How to purge the cache from a given key?
+
+If you accidently cached incorrect results, the simplest way to purge it is to use `gsutil`:
+
+```
+# List everything
+gsutil ls -al gs://sourcegraph_buildkite_cache/sourcegraph/sourcegraph/
+# Purge the key you want to delete
+gsutil rm gs://sourcegraph_buildkite_cache/sourcegraph/sourcegraph/[MY-KEY].tar.gz
+```
+
+## When is the cache purged?
+
+The cached is purged every TODO

--- a/enterprise/dev/ci/internal/buildkite/buildkite.go
+++ b/enterprise/dev/ci/internal/buildkite/buildkite.go
@@ -136,7 +136,7 @@ func (p *Pipeline) AddStep(label string, opts ...StepOpt) {
 
 	// Set a default agent queue to assign this job to
 	if len(step.Agents) == 0 {
-		step.Agents["queue"] = "standard"
+		step.Agents["queue"] = "job"
 	}
 
 	p.Steps = append(p.Steps, step)

--- a/enterprise/dev/ci/internal/buildkite/cache.go
+++ b/enterprise/dev/ci/internal/buildkite/cache.go
@@ -1,0 +1,52 @@
+package buildkite
+
+// const cachePluginName = "gencer/cache#v2.4.10"
+
+const cachePluginName = "jhchabran/cache#a006be99a6d5bfbab177ddbf8c988bdce3bd2a0e"
+
+// CacheConfig represents the configuration data for https://github.com/gencer/cache-buildkite-plugin
+type CacheConfigPayload struct {
+	ID          string   `json:"id"`
+	Backend     string   `json:"backend"`
+	Key         string   `json:"key"`
+	RestoreKeys []string `json:"restore_keys"`
+	Compress    bool     `json:"compress,omitempty"`
+	TarBall     struct {
+		Path string `json:"path,omitempty"`
+		Max  int    `json:"max,omitempty"`
+	} `json:"tarball,omitempty"`
+	Paths []string             `json:"paths"`
+	S3    CacheConfigS3Payload `json:"s3"`
+}
+
+type CacheConfigS3Payload struct {
+	Profile  string `json:"profile,omitempty"`
+	Bucket   string `json:"bucket"`
+	Class    string `json:"class,omitempty"`
+	Args     string `json:"args,omitempty"`
+	Endpoint string `json:"endpoint,omitempty"`
+	Region   string `json:"region,omitempty"`
+}
+
+type CacheOptions struct {
+	ID          string
+	Key         string
+	RestoreKeys []string
+	Paths       []string
+}
+
+func Cache(opts *CacheOptions) StepOpt {
+	return Plugin(cachePluginName, CacheConfigPayload{
+		ID:          opts.ID,
+		Key:         opts.Key,
+		RestoreKeys: opts.RestoreKeys,
+		Paths:       opts.Paths,
+		Backend:     "s3",
+		S3: CacheConfigS3Payload{
+			Bucket:   "sourcegraph_buildkite_cache",
+			Profile:  "buildkite",
+			Endpoint: "https://storage.googleapis.com",
+			Region:   "us-central1",
+		},
+	})
+}

--- a/enterprise/dev/ci/internal/buildkite/cache.go
+++ b/enterprise/dev/ci/internal/buildkite/cache.go
@@ -33,6 +33,7 @@ type CacheOptions struct {
 	Key         string
 	RestoreKeys []string
 	Paths       []string
+	Compress    bool
 }
 
 func Cache(opts *CacheOptions) StepOpt {
@@ -46,8 +47,8 @@ func Cache(opts *CacheOptions) StepOpt {
 			Key:         opts.Key,
 			RestoreKeys: opts.RestoreKeys,
 			Paths:       opts.Paths,
+			Compress:    opts.Compress,
 			Backend:     "s3",
-			Compress:    true,
 			S3: CacheConfigS3Payload{
 				Bucket:   "sourcegraph_buildkite_cache",
 				Profile:  "buildkite",

--- a/enterprise/dev/ci/internal/ci/asdf_operation.go
+++ b/enterprise/dev/ci/internal/ci/asdf_operation.go
@@ -1,0 +1,23 @@
+package ci
+
+import (
+	"github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/buildkite"
+	bk "github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/buildkite"
+)
+
+func ASDFInstall() []bk.StepOpt {
+	return []bk.StepOpt{
+		// buildkite.Env("AWS_CONFIG_FILE", "/buildkite/.aws/config"),
+		// buildkite.Env("AWS_SHARED_CREDENTIALS_FILE", "/buildkite/.aws/credentials"),
+		// buildkite.Cache(&buildkite.CacheOptions{
+		// 	ID:          "asdf",
+		// 	Key:         "cache-asdf-{{ checksum '.tool-versions' }}",
+		// 	RestoreKeys: []string{"cache-asdf-{{ checksum '.tool-versions' }}"},
+		// 	Paths:       []string{".buildkite-cache/asdf/downloads"},
+		// }),
+		// buildkite.Cmd("ls ~/.asdf/downloads/"),
+		// buildkite.Cmd("ls .buildkite-cache/asdf/downloads/"),
+		// buildkite.Cmd("asdf list"),
+		buildkite.Cmd("asdf install"),
+	}
+}

--- a/enterprise/dev/ci/internal/ci/cache_helpers.go
+++ b/enterprise/dev/ci/internal/ci/cache_helpers.go
@@ -8,5 +8,7 @@ func cacheYarn() buildkite.StepOpt {
 		Key:         "cache-node_modules-{{ checksum 'yarn.lock' }}",
 		RestoreKeys: []string{"cache-node_modules-{{ checksum 'yarn.lock' }}"},
 		Paths:       []string{"node_modules", "client/extension-api/node_modules", "client/eslint-plugin-sourcegraph/node_modules"},
+		// TODO: @jhchabran, check the numbers, but in my last run it seemed to be clear that compression is really slow (+3/4m IIRC)
+		Compress: false,
 	})
 }

--- a/enterprise/dev/ci/internal/ci/cache_helpers.go
+++ b/enterprise/dev/ci/internal/ci/cache_helpers.go
@@ -1,0 +1,12 @@
+package ci
+
+import "github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/buildkite"
+
+func cacheYarn() buildkite.StepOpt {
+	return buildkite.Cache(&buildkite.CacheOptions{
+		ID:          "node_modules",
+		Key:         "cache-node_modules-{{ checksum 'yarn.lock' }}",
+		RestoreKeys: []string{"cache-node_modules-{{ checksum 'yarn.lock' }}"},
+		Paths:       []string{"node_modules", "client/extension-api/node_modules", "client/eslint-plugin-sourcegraph/node_modules"},
+	})
+}

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -196,7 +196,10 @@ func addBrowserExt(pipeline *bk.Pipeline) {
 func clientIntegrationTests(pipeline *bk.Pipeline) {
 	chunkSize := 2
 	prepStepKey := "puppeteer:prep"
-	skipGitCloneStep := bk.Plugin("uber-workflow/run-without-clone", "")
+	// TODO check with Valery about this. Because we're running stateless agents,
+	// this runs on a fresh instance and the hooks are not present at all, which
+	// breaks the step.
+	// skipGitCloneStep := bk.Plugin("uber-workflow/run-without-clone", "")
 
 	// Build web application used for integration tests to share it between multiple parallel steps.
 	pipeline.AddStep(":puppeteer::electric_plug: Puppeteer tests prep",
@@ -236,7 +239,7 @@ func clientIntegrationTests(pipeline *bk.Pipeline) {
 		// just retry a few times.
 		bk.AutomaticRetry(3),
 		// Finalize just uses a remote package.
-		skipGitCloneStep,
+		// skipGitCloneStep,
 		bk.Cmd("npx @percy/cli build:finalize"),
 	}
 

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -114,16 +114,13 @@ func addCheck(pipeline *bk.Pipeline) {
 // yarn ~41s + ~30s
 func addPrettier(pipeline *bk.Pipeline) {
 	pipeline.AddStep(":lipstick: Prettier",
-		bk.Env("AWS_CONFIG_FILE", "/buildkite/.aws/config"),
-		bk.Env("AWS_SHARED_CREDENTIALS_FILE", "/buildkite/.aws/credentials"),
-		bk.Env("BUILDKITE_PLUGIN_CACHE_DEBUG", "true"),
 		bk.Cache(&buildkite.CacheOptions{
 			ID:          "node_modules",
 			Key:         "cache-node_modules-{{ checksum 'yarn.lock' }}",
 			RestoreKeys: []string{"cache-node_modules-{{ checksum 'yarn.lock' }}"},
 			Paths:       []string{"node_modules", "client/extension-api/node_modules", "client/eslint-plugin-sourcegraph/node_modules"},
 		}),
-		bk.Cmd("yarn install --prefer-offline --frozen-lockfile"))
+		bk.Cmd("dev/ci/yarn-run.sh prettier-check"))
 }
 
 // yarn ~41s + ~1s

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images"
+	"github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/buildkite"
 	bk "github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/buildkite"
 	"github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/ci/changed"
 	"github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/ci/operations"
@@ -113,7 +114,16 @@ func addCheck(pipeline *bk.Pipeline) {
 // yarn ~41s + ~30s
 func addPrettier(pipeline *bk.Pipeline) {
 	pipeline.AddStep(":lipstick: Prettier",
-		bk.Cmd("dev/ci/yarn-run.sh prettier-check"))
+		bk.Env("AWS_CONFIG_FILE", "/buildkite/.aws/config"),
+		bk.Env("AWS_SHARED_CREDENTIALS_FILE", "/buildkite/.aws/credentials"),
+		bk.Env("BUILDKITE_PLUGIN_CACHE_DEBUG", "true"),
+		bk.Cache(&buildkite.CacheOptions{
+			ID:          "node_modules",
+			Key:         "cache-node_modules-{{ checksum 'yarn.lock' }}",
+			RestoreKeys: []string{"cache-node_modules-{{ checksum 'yarn.lock' }}"},
+			Paths:       []string{"node_modules", "client/extension-api/node_modules", "client/eslint-plugin-sourcegraph/node_modules"},
+		}),
+		bk.Cmd("yarn install --prefer-offline --frozen-lockfile"))
 }
 
 // yarn ~41s + ~1s

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -65,6 +65,10 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		Env:     env,
 	}
 
+	// Every step first requires an ASDF installation of the tools defined in the
+	// repository .tools-version.
+	bk.BeforeEveryStepOpts = append(bk.BeforeEveryStepOpts, ASDFInstall()...)
+
 	// Make all command steps timeout after 60 minutes in case a buildkite agent
 	// got stuck / died.
 	bk.AfterEveryStepOpts = append(bk.AfterEveryStepOpts, func(s *bk.Step) {

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -67,7 +67,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 
 	// Every step first requires an ASDF installation of the tools defined in the
 	// repository .tools-version.
-	bk.BeforeEveryStepOpts = append(bk.BeforeEveryStepOpts, ASDFInstall()...)
+	// bk.BeforeEveryStepOpts = append(bk.BeforeEveryStepOpts, ASDFInstall()...)
 
 	// Make all command steps timeout after 60 minutes in case a buildkite agent
 	// got stuck / died.

--- a/enterprise/dev/ci/scripts/trace-command.sh
+++ b/enterprise/dev/ci/scripts/trace-command.sh
@@ -8,6 +8,9 @@ args=$*
 
 tracedCommand=$(printf 'buildevents cmd %s %s '"'"'%s'"'" "$BUILDKITE_BUILD_ID" "$BUILDKITE_STEP_ID" "$args")
 eval "$tracedCommand -- $args"
+exit_code="$?"
 
 unset BUILDEVENT_APIKEY
 unset BUILDEVENT_DATASET
+
+exit "$exit_code"


### PR DESCRIPTION
This PR is a draft exploring how caching helps to improve build times on caching agents. Without it, the build times are so high that it challenges the whole idea of going stateless.

I'll make another pass on the numbers tomorrow to provide more precise insights.

It caches the biggest drags of moving to stateless agents (Docker excluded) 

- [x] Node modules
  - about 200s saved on every build involving node
  - that can be taken further by working with yarn specifics, but it requires investing more time. 
- [x] `asdf` installations 
  - about 20s saved on every builds 
  - less external HTTP calls
- [ ] ~Go modules Cache~ will fix later
  - Need to enable the cache plugins to deal with absolute paths, postponed for the moment, should just be a matter of patching the plugin for those specific cases. 

Other changes:

- Fixed the `Plugin` function that allowed to use of only a single plugin 
- Added docs enabling everyone to make use of the cache. 
- Removed the `post-command` hook that installed asdf tool versions on every command in favour of a `post-checkout` one. 

See https://github.com/sourcegraph/sourcegraph/issues/21130

TODO @jhchabran 

- [x] It seems there is a bug that made the misc linters pass even if there was an error. 
