### PR TITLE
Fix trace command that swallowed errors

### DIFF
--- a/enterprise/dev/ci/scripts/trace-command.sh
+++ b/enterprise/dev/ci/scripts/trace-command.sh
@@ -8,6 +8,9 @@ args=$*
 
 tracedCommand=$(printf 'buildevents cmd %s %s '"'"'%s'"'" "$BUILDKITE_BUILD_ID" "$BUILDKITE_STEP_ID" "$args")
 eval "$tracedCommand -- $args"
+exit_code="$?"
 
 unset BUILDEVENT_APIKEY
 unset BUILDEVENT_DATASET
+
+exit "$exit_code"


### PR DESCRIPTION
I accidentally introduce earlier a very dangerous bug that caused any command trace to exit 0 regardless of the original exit code. This PR fixes it. 
