### PR TITLE
dev/ci: always upload build logs

### DIFF
--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -7,24 +7,23 @@
 set -e # Not -u because $SOFT_FAIL_EXIT_CODES may not be bound
 
 if [[ "$BUILDKITE_PIPELINE_NAME" != "sourcegraph" ]]; then
-    exit 0
+  exit 0
 fi
 
 if [ "$BUILDKITE_BRANCH" == "main" ]; then
-    if [ "$BUILDKITE_COMMAND_EXIT_STATUS" -eq 0 ]; then
-        # If the job exit code is either 0 or a soft failt exit code defined by that step, do nothing.
-        exit 0
+  # Turn the string of exit codes "1 2 3 4" into an array of strings
+  IFS=' ' read -ra codes <<<"$SOFT_FAIL_EXIT_CODES"
+  for code in "${codes[@]}"; do
+    if [ "$code" == "$BUILDKITE_COMMAND_EXIT_STATUS" ]; then
+      # Buildkite exit code is a soft fail
+      OVERWRITE_STATE="soft-failed" ./enterprise/dev/ci/scripts/upload-build-logs.sh
     fi
+  done
 
-    # Turn the string of exit codes "1 2 3 4" into an array of strings
-    IFS=' ' read -ra codes <<<"$SOFT_FAIL_EXIT_CODES"
-    for code in "${codes[@]}"; do
-        if [ "$code" == "$BUILDKITE_COMMAND_EXIT_STATUS" ]; then
-            # If the Buildkite exit code is a soft fail, do nothing either.
-            exit 0
-        fi
-    done
-
-    # Non-zero exit code and not a soft fail: upload the logs.
-    ./enterprise/dev/upload-build-logs.sh
+  # Non-zero exit code and not a soft fail: upload the logs.
+  if [ "$BUILDKITE_COMMAND_EXIT_STATUS" -eq 0 ]; then
+    OVERWRITE_STATE="passed" ./enterprise/dev/ci/scripts/upload-build-logs.sh
+  else
+    OVERWRITE_STATE="failed" ./enterprise/dev/ci/scripts/upload-build-logs.sh
+  fi
 fi

--- a/enterprise/dev/ci/scripts/upload-build-logs.sh
+++ b/enterprise/dev/ci/scripts/upload-build-logs.sh
@@ -10,6 +10,7 @@ Requires:
 - \$BUILDKITE_BUILD_NUMBER
 - \$BUILDKITE_JOB_ID
 - \$BUILD_LOGS_LOKI_URL
+- \$OVERWRITE_STATE
 EOF
 }
 
@@ -37,4 +38,4 @@ echo "--- :file_cabinet: Uploading logs"
 # Because we are running this script in the buildkite post-exit hook, the state of the job is still "running".
 # Passing --state="" just overrides the default. It's not set to any specific state because this script caller
 # is responsible of making sure the job has failed.
-./dev/ci/sentry-capture.sh ./sg ci logs --out="$BUILD_LOGS_LOKI_URL" --state="" --overwrite-state="failed" --build="$BUILDKITE_BUILD_NUMBER" --job="$BUILDKITE_JOB_ID"
+./dev/ci/sentry-capture.sh ./sg ci logs --out="$BUILD_LOGS_LOKI_URL" --state="" --overwrite-state="$OVERWRITE_STATE" --build="$BUILDKITE_BUILD_NUMBER" --job="$BUILDKITE_JOB_ID"


### PR DESCRIPTION
This could help us debug incidents like today's, where it would have been handy to be able to search more build logs.

This _might_ make our Grafana cloud costs skyrocket though (https://github.com/sourcegraph/sourcegraph/issues/30115#issuecomment-1020354456), so we might not want to do this - I'll leave this up for now, will revisit later

Alternatives/for augment: https://github.com/sourcegraph/sourcegraph/issues/26101