### PR TITLE
tool-versions: add nodejs

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,5 @@
 golang 1.17.5
+nodejs 16.7.0
 yarn 1.22.4
 fd 7.4.0
 shfmt 3.2.0


### PR DESCRIPTION
Part of https://github.com/sourcegraph/infrastructure/pull/3019 - the support legacy configuration is still enabled, but I did run into a slight hiccup with that in test runs (https://github.com/sourcegraph/sourcegraph/pull/30082), so just in case (and also because we should) I'm adding `nodejs` to `.tool-versions`. For now we can manually keep this in sync with `.nvmrc`, and communicate a deprecation timeline for the latter before removing it