### PR TITLE
release: generate GitHub release on release:close

### DIFF
--- a/dev/release/src/util.ts
+++ b/dev/release/src/util.ts
@@ -75,3 +75,8 @@ function hubSpotFeedbackFormURL(version: string): string {
 export async function ensureDocker(): Promise<execa.ExecaReturnValue<string>> {
     return execa('docker', ['version'], { stdout: 'ignore' })
 }
+
+export function changelogURL(version: string): string {
+    const versionAnchor = version.replace(/\./g, '-')
+    return `https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/CHANGELOG.md#${versionAnchor}`
+}


### PR DESCRIPTION
Updates the release tool to generate a proper GitHub release on the `release:close` step, which allows folks to use the "watch releases" feature on GitHub to be notified of releases.

The release includes a link to the changelog, update guide, and release post. The generated release gets linked to from the final tracking issue update and Slack announcements.

Closes https://github.com/sourcegraph/sourcegraph/issues/13598 (see issue for more details!)
