### PR TITLE
Search jobs: Remove limiters on child jobs

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -915,8 +915,7 @@ func (r *searchResolver) toSearchJob(q query.Q) (run.Job, error) {
 				if repoOptions, ok := addPatternAsRepoFilter(args.PatternInfo.Pattern, repoOptions); ok {
 					args.RepoOptions = repoOptions
 					addJob(true, &run.RepoSearch{
-						Args:  &args,
-						Limit: maxResults,
+						Args: &args,
 					})
 				}
 			}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -690,7 +690,6 @@ func (r *searchResolver) toSearchJob(q query.Q) (run.Job, error) {
 				addJob(true, &unindexed.RepoUniverseTextSearch{
 					GlobalZoektQuery: globalZoektQuery,
 					ZoektArgs:        zoektArgs,
-					FileMatchLimit:   args.PatternInfo.FileMatchLimit,
 
 					RepoOptions: repoOptions,
 				})
@@ -750,7 +749,6 @@ func (r *searchResolver) toSearchJob(q query.Q) (run.Job, error) {
 				addJob(true, &unindexed.RepoSubsetTextSearch{
 					ZoektArgs:         zoektArgs,
 					SearcherArgs:      searcherArgs,
-					FileMatchLimit:    args.PatternInfo.FileMatchLimit,
 					NotSearcherOnly:   !searcherOnly,
 					UseIndex:          args.PatternInfo.Index,
 					ContainsRefGlobs:  query.ContainsRefGlobs(q),

--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -35,10 +35,15 @@ func (s *RepoSearch) Run(ctx context.Context, db database.DB, stream streaming.S
 		otlog.String("pattern", s.Args.PatternInfo.Pattern),
 		otlog.Int("limit", s.Limit))
 
-	ctx, stream, cleanup := streaming.WithLimit(ctx, stream, s.Limit)
-	defer cleanup()
-
 	repos := &searchrepos.Resolver{DB: db, Opts: s.Args.RepoOptions}
+
+	// By default, RepoOptions on TextParameters doesn't have a limit set because we want to find
+	// results for all repos that match. However, for repo search, we want to limit the number of
+	// results returned. The top-level stream limiter will keep us from returning too many results,
+	// but we want to keep load on the DB to a minimum. We request one more than the limit in order
+	// to know whether the limit was hit.
+	repos.Opts.Limit = s.Limit + 1
+
 	err = repos.Paginate(ctx, nil, func(page *searchrepos.Resolved) error {
 		tr.LogFields(otlog.Int("resolved.len", len(page.RepoRevs)))
 

--- a/internal/search/unindexed/structural.go
+++ b/internal/search/unindexed/structural.go
@@ -78,9 +78,6 @@ func runJobs(ctx context.Context, jobs []*searchRepos) error {
 
 // streamStructuralSearch runs structural search jobs and streams the results.
 func streamStructuralSearch(ctx context.Context, args *search.SearcherParameters, repos []repoData, stream streaming.Sender) (err error) {
-	ctx, stream, cleanup := streaming.WithLimit(ctx, stream, int(args.PatternInfo.FileMatchLimit))
-	defer cleanup()
-
 	jobs := []*searchRepos{}
 	for _, repoSet := range repos {
 		searcherArgs := &search.SearcherParameters{


### PR DESCRIPTION
Now that we have a top-level limiter, there is no reason for each of the
child jobs to have their own limiters since they all use the same
context.

Stacked on #30122 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
