### PR TITLE
compute: fix search pattern modification for case insensitivity

### DIFF
--- a/internal/compute/match_only_command.go
+++ b/internal/compute/match_only_command.go
@@ -11,10 +11,20 @@ import (
 
 type MatchOnly struct {
 	MatchPattern MatchPattern
+
+	// ComputePattern is the valid, semantically-equivalent representation
+	// of MatchPattern that mirrors implicit Sourcegraph search behavior
+	// (e.g., default case insensitivity), but which may differ
+	// syntactically (e.g., by wrapping a pattern in (?i:<MatchPattern>).
+	ComputePattern MatchPattern
 }
 
 func (c *MatchOnly) String() string {
-	return fmt.Sprintf("Match only: %s", c.MatchPattern.String())
+	return fmt.Sprintf(
+		"Match only search pattern: %s, compute pattern: %s",
+		c.MatchPattern.String(),
+		c.ComputePattern.String(),
+	)
 }
 
 func fromRegexpMatches(submatches []int, namedGroups []string, lineValue string, lineNumber int) Match {
@@ -66,7 +76,7 @@ func matchOnly(fm *result.FileMatch, r *regexp.Regexp) *MatchContext {
 func (c *MatchOnly) Run(_ context.Context, r result.Match) (Result, error) {
 	switch m := r.(type) {
 	case *result.FileMatch:
-		return matchOnly(m, c.MatchPattern.(*Regexp).Value), nil
+		return matchOnly(m, c.ComputePattern.(*Regexp).Value), nil
 	}
 	return nil, nil
 }

--- a/internal/compute/query.go
+++ b/internal/compute/query.go
@@ -211,16 +211,20 @@ func parseMatchOnly(q *query.Basic) (Command, bool, error) {
 		return nil, false, err
 	}
 
-	if !q.IsCaseSensitive() {
-		pattern.Value = "(?i:" + pattern.Value + ")"
-	}
-
-	rp, err := toRegexpPattern(pattern.Value)
+	sp, err := toRegexpPattern(pattern.Value)
 	if err != nil {
 		return nil, false, err
 	}
 
-	return &MatchOnly{MatchPattern: rp}, true, nil
+	cp := sp
+	if !q.IsCaseSensitive() {
+		cp, err = toRegexpPattern("(?i:" + pattern.Value + ")")
+		if err != nil {
+			return nil, false, err
+		}
+	}
+
+	return &MatchOnly{MatchPattern: sp, ComputePattern: cp}, true, nil
 }
 
 type commandParser func(pattern *query.Basic) (Command, bool, error)

--- a/internal/compute/query_test.go
+++ b/internal/compute/query_test.go
@@ -20,11 +20,11 @@ func TestParse(t *testing.T) {
 		Equal(t, test("not a(foo)"))
 
 	autogold.Want("`content` normalized",
-		"Command: `Match only: (?i:foo)`").
+		"Command: `Match only search pattern: foo, compute pattern: (?i:foo)`").
 		Equal(t, test("content:'foo'"))
 
 	autogold.Want("`case:yes` honored for `Match only` command",
-		"Command: `Match only: milk`, Parameters: `\"case:yes\"`").
+		"Command: `Match only search pattern: milk, compute pattern: milk`, Parameters: `\"case:yes\"`").
 		Equal(t, test("milk case:yes"))
 
 	autogold.Want("no pattern",
@@ -63,7 +63,7 @@ func TestToSearchQuery(t *testing.T) {
 	}
 
 	autogold.Want("convert match-only to search query",
-		"repo:foo file:bar (?i:carolado)").
+		"repo:foo file:bar carolado").
 		Equal(t, test("repo:foo file:bar carolado"))
 
 	autogold.Want("convert replace-in-place to search query",


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/30140.

Since Sourcegraph search queries implicitly make the search pattern case-insensitive, this needs to be mirrored in the compute world with `(?i<pattern>)`. Previously the compute world ensured the pattern was case insensitive with `(?i<pattern>)` and then searched this pattern directly. This isn't valid--Sourcegraph search will do its own implicit tack-on of `(?i<pattern)`. 

This PR fixes it so that the compute world mirrors the behavior implicitly as well, at the point when it's ready to process results.