### PR TITLE
Disable test that is flaking with off-by-one

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -475,11 +475,12 @@ func testSearchClient(t *testing.T, client searchClient) {
 				name:  "error count:1000",
 				query: "error count:1000",
 			},
-			{
-				name:          "something with more than 1000 results and use count:1000",
-				query:         ". count:1000",
-				minMatchCount: 1000,
-			},
+			// Flakey test for exactMatchCount due to bug https://github.com/sourcegraph/sourcegraph/issues/29828
+			// {
+			// 	name:          "something with more than 1000 results and use count:1000",
+			// 	query:         ". count:1000",
+			// 	minMatchCount: 1000,
+			// },
 			{
 				name:          "default limit streaming",
 				query:         ".",


### PR DESCRIPTION
This disables another test that is flaking, seemingly related to https://github.com/sourcegraph/sourcegraph/issues/29828, so I will just disable it and add it to that isuse. 