### PR TITLE
Filter paths passed to auto-index inference functions.

### DIFF
--- a/enterprise/internal/codeintel/autoindex/enqueuer/enqueuer.go
+++ b/enterprise/internal/codeintel/autoindex/enqueuer/enqueuer.go
@@ -187,7 +187,16 @@ func (s *IndexEnqueuer) inferIndexJobsFromRepositoryStructure(ctx context.Contex
 
 	var indexes []config.IndexJob
 	for _, recognizer := range inference.Recognizers {
-		indexes = append(indexes, recognizer.InferIndexJobs(gitclient, paths)...)
+		recognizedPaths := []string{}
+		pattern := inference.OrPattern(recognizer.Patterns())
+		for _, path := range paths {
+			if pattern.MatchString(path) {
+				recognizedPaths = append(recognizedPaths, path)
+			}
+		}
+		if len(recognizedPaths) > 0 {
+			indexes = append(indexes, recognizer.InferIndexJobs(gitclient, recognizedPaths)...)
+		}
 	}
 
 	if len(indexes) > s.config.MaximumIndexJobsPerInferredConfiguration {

--- a/lib/codeintel/autoindex/inference/patterns.go
+++ b/lib/codeintel/autoindex/inference/patterns.go
@@ -45,3 +45,12 @@ func extensionPattern(pattern *regexp.Regexp) *regexp.Regexp {
 func pathPattern(pattern *regexp.Regexp) *regexp.Regexp {
 	return suffixPattern(regexp.MustCompile("(^|/)" + pattern.String()))
 }
+
+// OrPattern [r1, r2, r3, ...] is equivalent to r1|r2|r3|... .
+func OrPattern(patterns []*regexp.Regexp) *regexp.Regexp {
+	var patternStrings []string
+	for _, pattern := range patterns {
+		patternStrings = append(patternStrings, pattern.String())
+	}
+	return regexp.MustCompile(strings.Join(patternStrings, "|"))
+}

--- a/lib/codeintel/autoindex/inference/patterns.go
+++ b/lib/codeintel/autoindex/inference/patterns.go
@@ -8,14 +8,11 @@ import (
 // Patterns is a regular expression that matches any input that would also match
 // any registered recognizer pattern.
 var Patterns = func() *regexp.Regexp {
-	var patterns []string
+	var patterns []*regexp.Regexp
 	for _, recognizer := range Recognizers {
-		for _, pattern := range recognizer.Patterns() {
-			patterns = append(patterns, pattern.String())
-		}
+		patterns = append(patterns, recognizer.Patterns()...)
 	}
-
-	return regexp.MustCompile(strings.Join(patterns, "|"))
+	return OrPattern(patterns)
 }()
 
 // rawPattern creates a regular expression matching the given string literal.


### PR DESCRIPTION
Passing only relevant indexing paths makes debugging easier,
and reduces the amount of work when we are auto-indexing projects
which do not contain all languages.