### PR TITLE
web: usage of the conditional Wildcard component generic

### DIFF
--- a/client/web/src/enterprise/code-monitoring/components/actions/ActionEditor.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/ActionEditor.tsx
@@ -80,6 +80,9 @@ export const ActionEditor: React.FunctionComponent<ActionEditorProps> = ({
         [onDelete]
     )
 
+    const divOrButton = completed ? 'div' : Button
+    type DivOrButton = typeof divOrButton
+
     return (
         <>
             {expanded && (
@@ -140,12 +143,12 @@ export const ActionEditor: React.FunctionComponent<ActionEditorProps> = ({
                 </Card>
             )}
             {!expanded && (
-                <Card
+                <Card<DivOrButton, React.ComponentProps<DivOrButton>>
                     data-testid={`form-action-toggle-${idName}`}
                     className={classNames(styles.cardButton, disabled && 'disabled', `test-action-button-${idName}`)}
                     aria-label={`Edit action: ${label}`}
                     onClick={toggleExpanded}
-                    as={completed ? 'div' : Button}
+                    as={divOrButton}
                     disabled={disabled}
                 >
                     <div className="d-flex justify-content-between align-items-center w-100">

--- a/client/wildcard/src/types.ts
+++ b/client/wildcard/src/types.ts
@@ -17,18 +17,21 @@ export interface ForwardReferenceComponent<
     /**
      * When `as` prop is passed, use this overload.
      * Merges original own props (without DOM props) and the inferred props
-     * from `as` element with the own props taking precendence.
+     * from `as` element with the own props taking precedence.
+     *
+     * The exception is made for the `ref` prop that changes based on the `as` prop value.
+     * Inferred `ref` props overwrites the original `ref` type.
      *
      * We explicitly avoid `React.ElementType` and manually narrow the prop types
      * so that events are typed when using JSX.IntrinsicElements.
      */
-    <As = IntrinsicElementString>(
+    <As = IntrinsicElementString, OwnPropsOverwrite = OwnProps>(
         props: As extends ''
             ? { as: keyof JSX.IntrinsicElements }
             : As extends React.ComponentType<infer P>
-            ? Merge<P, OwnProps & { as: As }>
+            ? Merge<P, Omit<OwnPropsOverwrite, 'ref'> & { as: As }>
             : As extends keyof JSX.IntrinsicElements
-            ? Merge<JSX.IntrinsicElements[As], OwnProps & { as: As }>
+            ? Merge<JSX.IntrinsicElements[As], Omit<OwnPropsOverwrite, 'ref'> & { as: As }>
             : never
     ): React.ReactElement | null
 }


### PR DESCRIPTION
## Context 

[Reported issue in Slack](https://sourcegraph.slack.com/archives/C01C3NCGD40/p1643041809067900):

> I can't use conditional as in Card component (using as={Button} or as="div" works fine). This is the error I get:
```
The expected type comes from property 'as' which is declared here on type 'IntrinsicAttributes & Omit<Pick<DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "key" | keyof HTMLAttributes<HTMLDivElement>> & { ref?: ((instance: HTMLDivElement | null) => void) | RefObject<HTMLDivElement> | null | undefined; }, "as"> & CardProps & { as?: "div" | undefined; }'
```

## Changes

1. The `ForwardReferenceComponent` helper is changed to allow passing generic props that would be used instead of the component own prop types. It's a copy-paste from this PR: https://github.com/sourcegraph/sourcegraph/pull/30096.
2. The conditional `as` value is extracted into a variable for reusability:
```ts
const divOrButton = completed ? 'div' : Button
type DivOrButton = typeof divOrButton
```
3. Then it's used to pass the right generic type to the `Card` component: 
```tsx
<Card<DivOrButton, React.ComponentProps<DivOrButton>>
  as={divOrButton}
>
  <div />
</Card>
```