### PR TITLE
web: remove duplicate `as` props in Wildcard

### DIFF
--- a/client/wildcard/src/components/Alert/Alert.tsx
+++ b/client/wildcard/src/components/Alert/Alert.tsx
@@ -9,7 +9,6 @@ import { getAlertStyle } from './utils'
 
 export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
     variant?: typeof ALERT_VARIANTS[number]
-    as?: React.ElementType
 }
 
 export const Alert = React.forwardRef(

--- a/client/wildcard/src/components/Button/Button.tsx
+++ b/client/wildcard/src/components/Button/Button.tsx
@@ -21,13 +21,6 @@ export interface ButtonProps
      * Modifies the button style to have a transparent/light background and a more pronounced outline.
      */
     outline?: boolean
-    /**
-     * Used to change the element that is rendered.
-     * Useful if needing to style a link as a button, or in certain cases where a different element is required.
-     * Always be mindful of potentially accessibiliy pitfalls when using this!
-     * Note: This component assumes `HTMLButtonElement` types, providing a different component here will change the potential types that can be passed to this component.
-     */
-    as?: React.ElementType
 }
 
 /**

--- a/client/wildcard/src/components/Button/story/ButtonVariants.tsx
+++ b/client/wildcard/src/components/Button/story/ButtonVariants.tsx
@@ -7,7 +7,7 @@ import { BUTTON_VARIANTS } from '../constants'
 
 import styles from './ButtonVariants.module.scss'
 
-interface ButtonVariantsProps extends Pick<ButtonProps, 'size' | 'outline' | 'as'> {
+interface ButtonVariantsProps extends Pick<ButtonProps, 'size' | 'outline'> {
     variants: readonly typeof BUTTON_VARIANTS[number][]
     icon?: React.ComponentType<{ className?: string }>
 }

--- a/client/wildcard/src/components/Card/components/CardBody.tsx
+++ b/client/wildcard/src/components/Card/components/CardBody.tsx
@@ -5,12 +5,7 @@ import { ForwardReferenceComponent } from '../../..'
 
 import styles from './CardBody.module.scss'
 
-interface CardBodyProps {
-    /**
-     * Used to change the element that is rendered.
-     */
-    as?: React.ElementType
-}
+interface CardBodyProps {}
 
 export const CardBody = React.forwardRef(({ as: Component = 'div', children, className, ...attributes }, reference) => (
     <Component ref={reference} className={classNames(styles.cardBody, className)} {...attributes}>

--- a/client/wildcard/src/components/Card/components/CardHeader.tsx
+++ b/client/wildcard/src/components/Card/components/CardHeader.tsx
@@ -5,12 +5,7 @@ import { ForwardReferenceComponent } from '../../..'
 
 import styles from './CardHeader.module.scss'
 
-interface CardHeaderProps {
-    /**
-     * Used to change the element that is rendered.
-     */
-    as?: React.ElementType
-}
+interface CardHeaderProps {}
 
 export const CardHeader = React.forwardRef(
     ({ as: Component = 'div', children, className, ...attributes }, reference) => (

--- a/client/wildcard/src/components/Card/components/CardList.tsx
+++ b/client/wildcard/src/components/Card/components/CardList.tsx
@@ -5,12 +5,7 @@ import { ForwardReferenceComponent } from '../../..'
 
 import styles from './CardList.module.scss'
 
-interface CardListProps {
-    /**
-     * Used to change the element that is rendered.
-     */
-    as?: React.ElementType
-}
+interface CardListProps {}
 
 export const CardList = React.forwardRef(({ as: Component = 'div', children, className, ...attributes }, reference) => (
     <Component ref={reference} className={classNames(styles.listGroup, className)} {...attributes}>

--- a/client/wildcard/src/components/Card/components/CardSubtitle.tsx
+++ b/client/wildcard/src/components/Card/components/CardSubtitle.tsx
@@ -5,12 +5,7 @@ import { ForwardReferenceComponent } from '../../..'
 
 import styles from './CardSubtitle.module.scss'
 
-interface CardSubtitleProps {
-    /**
-     * Used to change the element that is rendered.
-     */
-    as?: React.ElementType
-}
+interface CardSubtitleProps {}
 
 export const CardSubtitle = React.forwardRef(
     ({ as: Component = 'div', children, className, ...attributes }, reference) => (

--- a/client/wildcard/src/components/Card/components/CardText.tsx
+++ b/client/wildcard/src/components/Card/components/CardText.tsx
@@ -5,12 +5,7 @@ import { ForwardReferenceComponent } from '../../..'
 
 import styles from './CardText.module.scss'
 
-interface CardTextProps {
-    /**
-     * Used to change the element that is rendered.
-     */
-    as?: React.ElementType
-}
+interface CardTextProps {}
 
 export const CardText = React.forwardRef(({ as: Component = 'p', children, className, ...attributes }, reference) => (
     <Component ref={reference} className={classNames(styles.cardText, className)} {...attributes}>

--- a/client/wildcard/src/components/Card/components/CardTitle.tsx
+++ b/client/wildcard/src/components/Card/components/CardTitle.tsx
@@ -5,12 +5,7 @@ import { ForwardReferenceComponent } from '../../..'
 
 import styles from './CardTitle.module.scss'
 
-interface CardTitleProps {
-    /**
-     * Used to change the element that is rendered.
-     */
-    as?: React.ElementType
-}
+interface CardTitleProps {}
 
 export const CardTitle = React.forwardRef(({ as: Component = 'h3', children, className, ...attributes }, reference) => (
     <Component ref={reference} className={classNames(styles.cardTitle, className)} {...attributes}>


### PR DESCRIPTION
`ForwardReferenceComponent` already defines `as`. We duplicate it in some cases which can lead to type errors like:

> The expected type comes from property 'as' which is declared here on type 'IntrinsicAttributes & Omit<Pick<DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "key" | keyof HTMLAttributes<HTMLDivElement>> & { ref?: ((instance: HTMLDivElement | null) => void) | RefObject<HTMLDivElement> | null | undefined; }, "as"> & CardProps & { as?: "div" | undefined; }'
