### PR TITLE
ci: add a unit test for the trace command

### DIFF
--- a/enterprise/dev/ci/internal/buildkite/buildkite.go
+++ b/enterprise/dev/ci/internal/buildkite/buildkite.go
@@ -197,6 +197,15 @@ func (p *Pipeline) WriteYAMLTo(w io.Writer) (int64, error) {
 
 type StepOpt func(step *Step)
 
+// RawCmd adds a command step without any instrumentation. This is useful to
+// test the instrumentation itself.
+func RawCmd(command string) StepOpt {
+	return func(step *Step) {
+		step.Command = append(step.Command, command)
+	}
+}
+
+// Cmd adds a command step with added instrumentation for testing purposes.
 func Cmd(command string) StepOpt {
 	return func(step *Step) {
 		// ./tr is a symbolic link created by the .buildkite/hooks/post-checkout hook.

--- a/enterprise/dev/ci/internal/ci/changed/changed.go
+++ b/enterprise/dev/ci/internal/ci/changed/changed.go
@@ -10,6 +10,17 @@ import (
 // Helper functions on Files should all be in the format `AffectsXYZ`.
 type Files []string
 
+// AffectsPathsPrefixedBy returns whether the chanegs affects files
+// whose path are prefixed with the given string.
+func (f Files) AffectsPathsPrefixedBy(prefix string) bool {
+	for _, p := range f {
+		if strings.HasPrefix(p, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 // AffectsDocs returns whether the changes affects documentation.
 func (f Files) AffectsDocs() bool {
 	for _, p := range f {

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -118,7 +118,7 @@ func addCIScriptsTests(pipeline *bk.Pipeline) {
 		}
 	}
 
-	pipeline.AddStep(":bash: CI Scripts",
+	pipeline.AddStep(":bash: Test CI Scripts",
 		stepOpts...,
 	)
 }

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -2,7 +2,6 @@ package ci
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -107,7 +106,7 @@ func CoreTestOperations(changedFiles changed.Files, opts CoreTestOperationsOptio
 
 // Run enterprise/dev/ci/scripts tests
 func addCIScriptsTests(pipeline *bk.Pipeline) {
-	files, err := ioutil.ReadDir("./enterprise/dev/ci/scripts/tests")
+	files, err := os.ReadDir("./enterprise/dev/ci/scripts/tests")
 	if err != nil {
 		log.Fatalf("Failed to list CI scripts tests scripts: %s", err)
 	}
@@ -115,7 +114,7 @@ func addCIScriptsTests(pipeline *bk.Pipeline) {
 	var stepOpts []bk.StepOpt
 	for _, f := range files {
 		if filepath.Ext(f.Name()) == ".sh" {
-			stepOpts = append(stepOpts, bk.Cmd(fmt.Sprintf("./enterprise/dev/ci/scripts/tests/%s", f.Name())))
+			stepOpts = append(stepOpts, bk.RawCmd(fmt.Sprintf("./enterprise/dev/ci/scripts/tests/%s", f.Name())))
 		}
 	}
 

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -45,8 +45,13 @@ func CoreTestOperations(changedFiles changed.Files, opts CoreTestOperationsOptio
 		// these on all PRs
 		addPrettier,
 		addCheck,
-		addCIScriptsTests,
 	})
+
+	if runAll || changedFiles.AffectsPathsPrefixedBy("enterprise/dev/ci/scripts") {
+		ops.Append(
+			addCIScriptsTests,
+		)
+	}
 
 	if runAll || changedFiles.AffectsClient() || changedFiles.AffectsGraphQL() {
 		// If there are any Graphql changes, they are impacting the client as well.

--- a/enterprise/dev/ci/scripts/tests/test-trace-command.sh
+++ b/enterprise/dev/ci/scripts/tests/test-trace-command.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Making local changes in subshells on purpose.
+# shellcheck disable=SC2030,SC2031
 cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." || exit 1 # cd to enterprise/
 
 function printRed {
@@ -16,7 +18,6 @@ function TestExitCodeNOK {
   (
     # Mock the buildevents command to test just the script
     # Locally adjust the path for the purpose of this test.
-    # shellcheck disable=SC2030,SC2031
     PATH="$(pwd)/dev/ci/scripts/tests/testdata/:$PATH"
     BUILDKITE_BUILD_ID=${BUILDKITE_BUILD_ID:-fake_build_id}
     BUILDKITE_STEP_ID=${BUILDKITE_STEP_ID:-fake_step_id}

--- a/enterprise/dev/ci/scripts/tests/test-trace-command.sh
+++ b/enterprise/dev/ci/scripts/tests/test-trace-command.sh
@@ -45,7 +45,6 @@ function TestExitCodeOK {
   (
     # Mock the buildevents command to test just the script
     # Locally adjust the path for the purpose of this test.
-    # shellcheck disable=SC2030,SC2031
     PATH="$(pwd)/dev/ci/scripts/tests/testdata/:$PATH"
     BUILDKITE_BUILD_ID=${BUILDKITE_BUILD_ID:-fake_build_id}
     BUILDKITE_STEP_ID=${BUILDKITE_STEP_ID:-fake_step_id}

--- a/enterprise/dev/ci/scripts/tests/test-trace-command.sh
+++ b/enterprise/dev/ci/scripts/tests/test-trace-command.sh
@@ -2,22 +2,22 @@
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." || exit 1 # cd to enterprise/
 
-function printRed { 
+function printRed {
   echo -e "\033[0;31m$1\033[0m"
 }
 
-function printGreen { 
+function printGreen {
   echo -e "\033[0;32m$1\033[0m"
 }
 
 function TestExitCodeNOK {
   local got
   local want
-  
+
   (
     # Mock the buildevents command to test just the script
     # Locally adjust the path for the purpose of this test.
-    # shellsheck disable=SC2030
+    # shellcheck disable=SC2030
     PATH="$(pwd)/dev/ci/scripts/tests/testdata/:$PATH"
 
     dev/ci/scripts/trace-command.sh exit 10
@@ -37,10 +37,12 @@ function TestExitCodeNOK {
 function TestExitCodeOK {
   local got
   local want
-  
+
   (
     # Mock the buildevents command to test just the script
-    PATH="`pwd`/dev/ci/scripts/tests/testdata/:$PATH"
+    # Locally adjust the path for the purpose of this test.
+    # shellcheck disable=SC2030
+    PATH="$(pwd)/dev/ci/scripts/tests/testdata/:$PATH"
 
     dev/ci/scripts/trace-command.sh exit 0
     got="$?"
@@ -69,6 +71,6 @@ if ! TestExitCodeOK; then
   failed=1
 fi
 
-if [ "$failed" != "0" ]; then 
+if [ "$failed" != "0" ]; then
   exit 1
 fi

--- a/enterprise/dev/ci/scripts/tests/test-trace-command.sh
+++ b/enterprise/dev/ci/scripts/tests/test-trace-command.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." # cd to enterprise/
+
+function printRed { 
+  echo -e "\033[0;31m$1\033[0m"
+}
+
+function printGreen { 
+  echo -e "\033[0;32m$1\033[0m"
+}
+
+function TestExitCodeNOK {
+  local got
+  local want
+  
+  (
+    # Mock the buildevents command to test just the script
+    PATH="`pwd`/dev/ci/scripts/tests/testdata/:$PATH"
+
+    dev/ci/scripts/trace-command.sh exit 10
+    got="$?"
+    want="10"
+
+    if [ "$got" != "$want" ]; then
+      printRed "    FAIL: got exit code $got but want $want instead."
+      return 1
+    else
+      printGreen "    PASS"
+      return 0
+    fi
+  )
+}
+
+function TestExitCodeOK {
+  local got
+  local want
+  
+  (
+    # Mock the buildevents command to test just the script
+    PATH="`pwd`/dev/ci/scripts/tests/testdata/:$PATH"
+
+    dev/ci/scripts/trace-command.sh exit 0
+    got="$?"
+    want="0"
+
+    if [ "$got" != "$want" ]; then
+      printRed "    FAIL: got exit code $got but want $want instead."
+      return 1
+    else
+      printGreen "    PASS"
+      return 0
+    fi
+  )
+}
+
+local failed=0
+
+echo "--- Test: trace-command.sh"
+echo -e "  - Exit code should not be zero if the command fails"
+if ! TestExitCodeNOK; then
+  failed = 1
+fi
+echo -e "  - Exit code should be zero if the command succeeds"
+if ! TestExitCodeOK; then
+  failed = 1
+fi
+
+if [ failed != 0 ]; then 
+  exit 1
+fi

--- a/enterprise/dev/ci/scripts/tests/test-trace-command.sh
+++ b/enterprise/dev/ci/scripts/tests/test-trace-command.sh
@@ -25,7 +25,7 @@ function TestExitCodeNOK {
 
     dev/ci/scripts/trace-command.sh exit 10
     got="$?"
-    want="10"
+    want="100"
 
     if [ "$got" != "$want" ]; then
       printRed "    FAIL: got exit code $got but want $want instead."

--- a/enterprise/dev/ci/scripts/tests/test-trace-command.sh
+++ b/enterprise/dev/ci/scripts/tests/test-trace-command.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -x
 cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." || exit 1 # cd to enterprise/
 
 function printRed {
@@ -19,6 +18,10 @@ function TestExitCodeNOK {
     # Locally adjust the path for the purpose of this test.
     # shellcheck disable=SC2030,SC2031
     PATH="$(pwd)/dev/ci/scripts/tests/testdata/:$PATH"
+    BUILDKITE_BUILD_ID=${BUILDKITE_BUILD_ID:-fake_build_id}
+    BUILDKITE_STEP_ID=${BUILDKITE_STEP_ID:-fake_step_id}
+    export BUILDKITE_BUILD_ID
+    export BUILDKITE_STEP_ID
 
     dev/ci/scripts/trace-command.sh exit 10
     got="$?"
@@ -43,6 +46,10 @@ function TestExitCodeOK {
     # Locally adjust the path for the purpose of this test.
     # shellcheck disable=SC2030,SC2031
     PATH="$(pwd)/dev/ci/scripts/tests/testdata/:$PATH"
+    BUILDKITE_BUILD_ID=${BUILDKITE_BUILD_ID:-fake_build_id}
+    BUILDKITE_STEP_ID=${BUILDKITE_STEP_ID:-fake_step_id}
+    export BUILDKITE_BUILD_ID
+    export BUILDKITE_STEP_ID
 
     dev/ci/scripts/trace-command.sh exit 0
     got="$?"

--- a/enterprise/dev/ci/scripts/tests/test-trace-command.sh
+++ b/enterprise/dev/ci/scripts/tests/test-trace-command.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+set -x
 cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." || exit 1 # cd to enterprise/
 
 function printRed {

--- a/enterprise/dev/ci/scripts/tests/test-trace-command.sh
+++ b/enterprise/dev/ci/scripts/tests/test-trace-command.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." # cd to enterprise/
+cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." || exit 1 # cd to enterprise/
 
 function printRed { 
   echo -e "\033[0;31m$1\033[0m"
@@ -16,7 +16,9 @@ function TestExitCodeNOK {
   
   (
     # Mock the buildevents command to test just the script
-    PATH="`pwd`/dev/ci/scripts/tests/testdata/:$PATH"
+    # Locally adjust the path for the purpose of this test.
+    # shellsheck disable=SC2030
+    PATH="$(pwd)/dev/ci/scripts/tests/testdata/:$PATH"
 
     dev/ci/scripts/trace-command.sh exit 10
     got="$?"
@@ -54,18 +56,19 @@ function TestExitCodeOK {
   )
 }
 
-local failed=0
+# Account for intermediary failures
+failed=0
 
 echo "--- Test: trace-command.sh"
 echo -e "  - Exit code should not be zero if the command fails"
 if ! TestExitCodeNOK; then
-  failed = 1
+  failed=1
 fi
 echo -e "  - Exit code should be zero if the command succeeds"
 if ! TestExitCodeOK; then
-  failed = 1
+  failed=1
 fi
 
-if [ failed != 0 ]; then 
+if [ "$failed" != "0" ]; then 
   exit 1
 fi

--- a/enterprise/dev/ci/scripts/tests/test-trace-command.sh
+++ b/enterprise/dev/ci/scripts/tests/test-trace-command.sh
@@ -17,7 +17,7 @@ function TestExitCodeNOK {
   (
     # Mock the buildevents command to test just the script
     # Locally adjust the path for the purpose of this test.
-    # shellcheck disable=SC2030
+    # shellcheck disable=SC2030,SC2031
     PATH="$(pwd)/dev/ci/scripts/tests/testdata/:$PATH"
 
     dev/ci/scripts/trace-command.sh exit 10
@@ -41,7 +41,7 @@ function TestExitCodeOK {
   (
     # Mock the buildevents command to test just the script
     # Locally adjust the path for the purpose of this test.
-    # shellcheck disable=SC2030
+    # shellcheck disable=SC2030,SC2031
     PATH="$(pwd)/dev/ci/scripts/tests/testdata/:$PATH"
 
     dev/ci/scripts/trace-command.sh exit 0

--- a/enterprise/dev/ci/scripts/tests/test-trace-command.sh
+++ b/enterprise/dev/ci/scripts/tests/test-trace-command.sh
@@ -25,7 +25,7 @@ function TestExitCodeNOK {
 
     dev/ci/scripts/trace-command.sh exit 10
     got="$?"
-    want="100"
+    want="10"
 
     if [ "$got" != "$want" ]; then
       printRed "    FAIL: got exit code $got but want $want instead."

--- a/enterprise/dev/ci/scripts/tests/testdata/buildevents
+++ b/enterprise/dev/ci/scripts/tests/testdata/buildevents
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
-# buildevents cmd [command-name] [label..]
-# Imitate what buildevents does
-bash -c "$2"
+args="$*"
+# buildevents cmd [command-name] [label..] -- -> CMD <- what we want to run
+cmd=$(echo $args | sed 's/.*-- //') # only keep what's after the "--"
+bash -c "$cmd"

--- a/enterprise/dev/ci/scripts/tests/testdata/buildevents
+++ b/enterprise/dev/ci/scripts/tests/testdata/buildevents
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# buildevents cmd [command-name] [label..]
+# Imitate what buildevents does
+bash -c "$2"

--- a/enterprise/dev/ci/scripts/tests/testdata/buildevents
+++ b/enterprise/dev/ci/scripts/tests/testdata/buildevents
@@ -4,5 +4,5 @@ args="$*"
 # buildevents cmd [command-name] [label..] -- -> CMD <- what we want to run
 
 # shellcheck disable=SC2001
-cmd="$(echo $args | sed 's/.*-- //')" # only keep what's after the "--"
+cmd="$(echo "$args" | sed 's/.*-- //')" # only keep what's after the "--"
 bash -c "$cmd"

--- a/enterprise/dev/ci/scripts/tests/testdata/buildevents
+++ b/enterprise/dev/ci/scripts/tests/testdata/buildevents
@@ -2,5 +2,7 @@
 
 args="$*"
 # buildevents cmd [command-name] [label..] -- -> CMD <- what we want to run
-cmd=$(echo $args | sed 's/.*-- //') # only keep what's after the "--"
+
+# shellcheck disable=SC2001
+cmd="$(echo $args | sed 's/.*-- //')" # only keep what's after the "--"
 bash -c "$cmd"


### PR DESCRIPTION
Having recently broken the trace command script that wraps every test command in the pipeline generator, the necessity to make sure this script is working has become very obvious. 

This PR adds: 

- a very basic test runner for such scripts
  - I have considered looking at https://github.com/sstephenson/bats but it's not maintained anymore and incorporating it properly in our repository felt a bit heavy-handed for now.
- a testing step for those scripts that will list every `.sh` in `./enterprise/dev/ci/scripts/` and will run them on every PR. 
  - Due to the nature of those scripts and how they impact **every** command we're running, as well as their very low duration, it seems logical to have them being run on every change. 
- a fake `buildevents` replacement to solely test the script itself and not have any side effects. 

Example outputs: 

Failed pipeline generation if we can't list those tests:
```
~/work/sourcegraph US devx/test-trace-command $ go run ./enterprise/dev/ci/gen-pipeline.go
2022/01/25 11:24:22 Failed to list CI scripts tests scripts: open ./enterprise/dev/ci/scripts/testsf: no such file or directory
exit status 1
``` 

Failed test: 

<img width="1177" alt="image" src="https://user-images.githubusercontent.com/10151/150968798-acd5905a-1c0c-44f3-86d7-8619340c1596.png">

