### PR TITLE
Tether: Set max width/height only when it's needed

### DIFF
--- a/client/wildcard/src/components/Popover/tether/services/geometry/actions/rectangle-position-helpers.ts
+++ b/client/wildcard/src/components/Popover/tether/services/geometry/actions/rectangle-position-helpers.ts
@@ -32,13 +32,9 @@ export function getRoundedElement(element: Rectangle): Rectangle {
  * @param element - constrained tooltip element
  * @param originalElement - original sized tooltip element
  */
-export function getElementBounds(
-    element: Rectangle,
-    originalElement: Rectangle,
-    elementConstraint: Rectangle
-): Rectangle | null {
+export function getElementBounds(element: Rectangle, originalElement: Rectangle): Rectangle | null {
     if (element.width < originalElement.width || element.height < originalElement.height) {
-        return elementConstraint
+        return element
     }
 
     return null

--- a/client/wildcard/src/components/Popover/tether/services/tether-position.ts
+++ b/client/wildcard/src/components/Popover/tether/services/tether-position.ts
@@ -27,8 +27,6 @@ export interface TetherState {
     /** Constrained tooltip element due to constraints */
     elementBounds: Rectangle | null
 
-    constrainedElement: Rectangle
-
     /** Tooltip tail angle based on tooltip element position */
     markerAngle: number
 
@@ -73,7 +71,7 @@ export function getPositionState(layout: TetherLayout, position: Position): Teth
     // Calculate element metric of the tooltip element after all constraint calculations
     const elementArea = constrainedElement.width * constrainedElement.height
     const elementOffset = createPoint(constrainedElement.left, constrainedElement.top)
-    const elementBounds = getElementBounds(constrainedElement, element, elementConstraint)
+    const elementBounds = getElementBounds(constrainedElement, element)
 
     // Change element tooltip coordinates to put the element right next target element
     const joinedMarker = getJoinedElement(rotatedMarker, overflowedTarget, position)
@@ -100,7 +98,6 @@ export function getPositionState(layout: TetherLayout, position: Position): Teth
         elementBounds,
         markerAngle,
         markerOffset,
-        constrainedElement,
     }
 }
 

--- a/client/wildcard/src/components/Popover/tether/services/tether-render.ts
+++ b/client/wildcard/src/components/Popover/tether/services/tether-render.ts
@@ -46,23 +46,22 @@ export function render(tether: Tether, eventTarget: HTMLElement | null, preserve
     setTransform(tether.marker ?? null, state.markerAngle, state.markerOffset)
 
     if (!positions.points.has(eventTarget as Element)) {
-        const bounds = state.elementBounds ?? state.constrainedElement
-        const elementMaxWidth = Math.min(bounds.width, state.constrainedElement.width)
+        if (state.elementBounds) {
+            const { width, height } = state.elementBounds
 
-        // Bound width of the floating element
-        setStyle(tether.element, 'max-width', `${elementMaxWidth}px`)
+            // Bound width of the floating element
+            setStyle(tether.element, 'max-width', `${width}px`)
 
-        const nextElement = tether.element.getBoundingClientRect()
+            const nextElement = tether.element.getBoundingClientRect()
 
-        // If height has been changed by bounding max-width it might change the whole
-        // position calculation. In this case we need to run render algorithm again
-        // to take into account a new width of the floating element.
-        if (layout.element.height !== nextElement.height) {
-            render(tether, eventTarget, true)
-        } else {
-            const elementMaxHeight = Math.min(bounds.height, state.constrainedElement.height)
-
-            setStyle(tether.element, 'max-height', `${elementMaxHeight}px`)
+            // If height has been changed by bounding max-width it might change the whole
+            // position calculation. In this case we need to run render algorithm again
+            // to take into account a new width of the floating element.
+            if (layout.element.height !== nextElement.height) {
+                render(tether, eventTarget, true)
+            } else {
+                setStyle(tether.element, 'max-height', `${height}px`)
+            }
         }
 
         // Restore containers scroll positions


### PR DESCRIPTION

## Context

Prior to this PR tether package always set max sizes to the floating element. This led to problems with overflow content in some corner cases in firefox and chrome. I suspect that for some reason (I'm still not sure why it happens) `getBoundingClientRect` returns not fully corrected values. This PR tweaks logic around setting max sizes in a way that if the floating element wasn't constrained tether logic doesn't set max values.    

https://user-images.githubusercontent.com/18492575/150978250-e101f8b1-271e-4c5e-8b68-b8ff20a3de66.mov

 