### PR TITLE
Move entries from local .gitattributes files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,12 @@ cmd/repo-updater/repos/testdata/** linguist-generated=true
 **/bindata.go linguist-generated=true
 **/*.pb.go linguist-generated=true
 CHANGELOG.md merge=union
+
+# GitHub doesn't seem to support directory specific .gitattributes
+# files, unlike Git itself, so we add these paths here.
+doc/admin/observability/dashboards.md linguist-generated=true
+doc/admin/observability/alert_solutions.md linguist-generated=true
+
+doc/code_intelligence/references/lsif.md linguist-generated=true
+doc/code_intelligence/references/lsif.sprig linguist-generated=true
+lib/codeintel/lsif_typed/lsif.ts linguist-generated=true

--- a/doc/admin/observability/.gitattributes
+++ b/doc/admin/observability/.gitattributes
@@ -1,2 +1,0 @@
-dashboards.md linguist-generated=true
-alert_solutions.md linguist-generated=true

--- a/doc/code_intelligence/references/.gitattributes
+++ b/doc/code_intelligence/references/.gitattributes
@@ -1,2 +1,0 @@
-lsif.md linguist-generated=true
-lsif.sprig linguish-generated=true

--- a/lib/codeintel/lsif_typed/.gitattributes
+++ b/lib/codeintel/lsif_typed/.gitattributes
@@ -1,1 +1,0 @@
-lsif.ts linguist-generated=true

--- a/monitoring/.gitattributes
+++ b/monitoring/.gitattributes
@@ -1,1 +1,0 @@
-monitoring/documentation.go linguist-generated=true


### PR DESCRIPTION
One entry is removed; it was incorrectly added earlier due to a
regex finding a match for 'DO NOT EDIT' inside a string, instead
of in a comment.

In my earlier PR (https://github.com/sourcegraph/sourcegraph/pull/30092), I noted that:

> The current patch adds directory-local files, which should be allowed according the Git docs:
>
> [...]
>
> The official GitHub docs recommend:
>
>    Unless the .gitattributes file already exists, create a .gitattributes file in the root of the repository.
>
> I'm not 100% sure if directory-local .gitattributes work or not on GitHub. If this patch doesn't work, I guess we can combine all the .gitattributes into one jumbo .gitattributes at the root of the repo.

Well, turns out, it didn't quite work. For example, if I go to
https://github.com/sourcegraph/sourcegraph/pull/29929/files, I see
`lsif.pb.go` being hidden (its rule is in the project-wide `.gitattributes`)
but `lsif.ts` still shows up (its rule is in the directory-local `.gitattributes`).

Fix this by moving the few special cases into the top level `.gitattributes`.