### PR TITLE
Use pink instead of orange for JSON keys in light theme

### DIFF
--- a/client/branded/src/global-styles/highlight.scss
+++ b/client/branded/src/global-styles/highlight.scss
@@ -461,7 +461,7 @@
     .hl-json {
         .hl-key {
             .hl-string {
-                color: var(--hl-orange);
+                color: var(--hl-pink);
             }
         }
     }


### PR DESCRIPTION
The pink color is more distinct from the yellow-ish color that's used for boolean literals. I tried several different colors and pink was the one that I liked the most.

**Before**
![CleanShot 2022-01-25 at 17 23 59](https://user-images.githubusercontent.com/1408093/151017238-7292320c-09f4-47bf-97c6-33d75eb66594.png)

**After**
![CleanShot 2022-01-25 at 17 23 40](https://user-images.githubusercontent.com/1408093/151017277-2fe9f088-30aa-4b49-a1d6-16701bda3ff8.png)



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
