### PR TITLE
analytics: Add new EventSource type

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -854,6 +854,7 @@ enum EventSource {
     WEB
     CODEHOSTINTEGRATION
     BACKEND
+    STATICWEB
 }
 
 """


### PR DESCRIPTION
Once upon a time, I had to run `./dev/generate.sh` to get GQL schema changes propagated to the webapp, extensions, etc., but now it doesn't seem like that's required anymore (when I run it, nothing else changes?). Is there a new process?