### PR TITLE
search: limit MEM for sg maintenance

### DIFF
--- a/cmd/gitserver/server/sg_maintenance.sh
+++ b/cmd/gitserver/server/sg_maintenance.sh
@@ -51,7 +51,7 @@ git reflog expire --all
 # https://github.blog/2021-04-29-scaling-monorepo-maintenance/
 # --write-midx reqiures git>=2.34.1.
 # [NOTE: git-version-min-requirement]
-git repack --write-midx --write-bitmap-index -d --geometric=2
+git -c pack.windowMemory=100m repack --write-midx --write-bitmap-index -d --geometric=2
 
 # Usually run by git gc. Prune all unreachable objects form the object database.
 git prune --expire 2.weeks.ago


### PR DESCRIPTION
Relates to #29497

We limit the memory git pack (called by repack) can use. This is motivated by spikes in MEM
we see during deployments of gitserver.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
