### PR TITLE
insights: fix panic when insight series definition does not exist for…

### DIFF
--- a/enterprise/internal/insights/background/queryrunner/testdata/TestGetSeries/series_definition_does_exist.golden
+++ b/enterprise/internal/insights/background/queryrunner/testdata/TestGetSeries/series_definition_does_exist.golden
@@ -1,0 +1,16 @@
+&types.InsightSeries{
+	ID: 1, SeriesID: "arealseries",
+	Query: "query1",
+	CreatedAt: time.Time{
+		ext: 63773913600,
+	},
+	OldestHistoricalAt:  time.Time{ext: 63773913600},
+	LastRecordedAt:      time.Time{ext: 63773913600},
+	NextRecordingAfter:  time.Time{ext: 63773913600},
+	LastSnapshotAt:      time.Time{ext: 63773913600},
+	NextSnapshotAfter:   time.Time{ext: 63773913600},
+	Enabled:             true,
+	SampleIntervalUnit:  "MONTH",
+	SampleIntervalValue: 1,
+	GenerationMethod:    types.GenerationMethod("search"),
+}

--- a/enterprise/internal/insights/background/queryrunner/work_handler.go
+++ b/enterprise/internal/insights/background/queryrunner/work_handler.go
@@ -59,6 +59,8 @@ func (r *workHandler) getSeries(ctx context.Context, seriesID string) (*types.In
 		series, err := r.fetchSeries(ctx, seriesID)
 		if err != nil {
 			return nil, err
+		} else if series == nil {
+			return nil, errors.Newf("workHandler.getSeries: insight definition not found for series_id: %s", seriesID)
 		}
 
 		r.mu.Lock()

--- a/enterprise/internal/insights/background/queryrunner/work_handler_test.go
+++ b/enterprise/internal/insights/background/queryrunner/work_handler_test.go
@@ -9,6 +9,9 @@ import (
 	"testing"
 	"time"
 
+	insightsdbtesting "github.com/sourcegraph/sourcegraph/enterprise/internal/insights/dbtesting"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -295,4 +298,59 @@ func mockComputeSearch(results []computeSearch) func(context.Context, string) ([
 	return func(ctx context.Context, s string) ([]query.ComputeResult, error) {
 		return mock, nil
 	}
+}
+
+func TestGetSeries(t *testing.T) {
+	timescale, cleanup := insightsdbtesting.TimescaleDB(t)
+	defer cleanup()
+	now := time.Date(2021, 12, 1, 0, 0, 0, 0, time.UTC).Truncate(time.Microsecond).Round(0)
+	metadataStore := store.NewInsightStore(timescale)
+	metadataStore.Now = func() time.Time {
+		return now
+	}
+	ctx := context.Background()
+
+	workHandler := workHandler{
+		metadadataStore: metadataStore,
+		mu:              sync.RWMutex{},
+		seriesCache:     make(map[string]*types.InsightSeries),
+	}
+
+	t.Run("series definition does not exist", func(t *testing.T) {
+		_, err := workHandler.getSeries(ctx, "seriesshouldnotexist")
+		if err == nil {
+			t.Fatal("expected error from getSeries")
+		}
+		autogold.Want("series definition does not exist", "workHandler.getSeries: insight definition not found for series_id: seriesshouldnotexist").Equal(t, err.Error())
+	})
+
+	t.Run("series definition does exist", func(t *testing.T) {
+		series, err := metadataStore.CreateSeries(ctx, types.InsightSeries{
+			SeriesID:                   "arealseries",
+			Query:                      "query1",
+			CreatedAt:                  now,
+			OldestHistoricalAt:         now,
+			LastRecordedAt:             now,
+			NextRecordingAfter:         now,
+			LastSnapshotAt:             now,
+			NextSnapshotAfter:          now,
+			BackfillQueuedAt:           now,
+			Enabled:                    true,
+			Repositories:               nil,
+			SampleIntervalUnit:         string(types.Month),
+			SampleIntervalValue:        1,
+			GeneratedFromCaptureGroups: false,
+			JustInTime:                 false,
+			GenerationMethod:           types.Search,
+		})
+		if err != nil {
+			t.Error(err)
+		}
+		got, err := workHandler.getSeries(ctx, series.SeriesID)
+		if err != nil {
+			t.Fatal("unexpected error from getseries")
+		}
+		autogold.Equal(t, got, autogold.ExportedOnly())
+	})
+
 }


### PR DESCRIPTION
Fixes #29502

Fix a panic caused when a record with a `series_id` is dequeued without a corresponding definition in the `insight_series` table.