### PR TITLE
chore: add .graphqlconfig to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # JetBrains/IntelliJ
 .idea
+.graphqlconfig
 
 # Emacs
 *~


### PR DESCRIPTION
Adding `.graphqlconfig` file (used by Jetbrains plugin) to the `.gitignore`.