### PR TITLE
buildchecker: bump timeout threshold to 1hr

### DIFF
--- a/dev/buildchecker/main.go
+++ b/dev/buildchecker/main.go
@@ -34,7 +34,7 @@ func (f *Flags) Parse() {
 	flag.StringVar(&f.Pipeline, "pipeline", "sourcegraph", "name of the pipeline to inspect")
 	flag.StringVar(&f.Branch, "branch", "main", "name of the branch to inspect")
 	flag.IntVar(&f.FailuresThreshold, "failures.threshold", 3, "failures required to trigger an incident")
-	flag.IntVar(&f.FailuresTimeoutMins, "failures.timeout", 40, "duration of a run required to be considered a failure (minutes)")
+	flag.IntVar(&f.FailuresTimeoutMins, "failures.timeout", 60, "duration of a run required to be considered a failure (minutes)")
 	flag.Parse()
 }
 


### PR DESCRIPTION
See https://github.com/sourcegraph/sourcegraph/issues/30150#issuecomment-1021493691 - the current 40m might be a bit too sensitive, and more indicative of "something is _really_ slow" than "something is totally bust"