### PR TITLE
insights: Add referenceCount to InsightViews returned via the API

### DIFF
--- a/cmd/frontend/graphqlbackend/insights.go
+++ b/cmd/frontend/graphqlbackend/insights.go
@@ -173,6 +173,7 @@ type InsightViewResolver interface {
 	DataSeries(ctx context.Context) ([]InsightSeriesResolver, error)
 	Presentation(ctx context.Context) (InsightPresentation, error)
 	DataSeriesDefinitions(ctx context.Context) ([]InsightDataSeriesDefinition, error)
+	ReferenceCount(ctx context.Context) (int32, error)
 }
 
 type InsightDataSeriesDefinition interface {

--- a/cmd/frontend/graphqlbackend/insights.graphql
+++ b/cmd/frontend/graphqlbackend/insights.graphql
@@ -795,6 +795,11 @@ type InsightView implements Node {
     Information on how each data series was generated
     """
     dataSeriesDefinitions: [InsightDataSeriesDefinition!]!
+
+    """
+    The total number of dashboards on which this insight is referenced. The count is global and disregards permissions.
+    """
+    referenceCount: Int!
 }
 
 """

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -261,6 +261,14 @@ func (i *insightViewResolver) DataSeriesDefinitions(ctx context.Context) ([]grap
 	return resolvers, nil
 }
 
+func (i *insightViewResolver) ReferenceCount(ctx context.Context) (int32, error) {
+	referenceCount, err := i.insightStore.GetReferenceCount(ctx, i.view.ViewID)
+	if err != nil {
+		return 0, err
+	}
+	return int32(referenceCount), nil
+}
+
 type searchInsightDataSeriesDefinitionResolver struct {
 	series *types.InsightViewSeries
 }

--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -746,6 +746,14 @@ func (s *InsightStore) UpdateFrontendSeries(ctx context.Context, args UpdateFron
 	return s.Exec(ctx, sqlf.Sprintf(updateFrontendSeriesSql, args.Query, pq.Array(args.Repositories), args.StepIntervalUnit, args.StepIntervalValue, args.SeriesID))
 }
 
+func (s *InsightStore) GetReferenceCount(ctx context.Context, id int) (int, error) {
+	count, _, err := basestore.ScanFirstInt(s.Query(ctx, sqlf.Sprintf(getReferenceCount, id)))
+	if err != nil {
+		return 0, nil
+	}
+	return count, nil
+}
+
 const setSeriesStatusSql = `
 -- source: enterprise/internal/insights/store/insight_store.go:SetSeriesStatus
 UPDATE insight_series
@@ -890,4 +898,10 @@ const updateFrontendSeriesSql = `
 UPDATE insight_series
 SET query = %s, repositories = %s, sample_interval_unit = %s, sample_interval_value = %s
 WHERE series_id = %s
+`
+
+const getReferenceCount = `
+-- source: enterprise/internal/insights/store/insight_store.go:GetReferenceCount
+SELECT COUNT(*) from dashboard_insight_view
+WHERE insight_view_id = %s
 `

--- a/enterprise/internal/insights/store/insight_store_test.go
+++ b/enterprise/internal/insights/store/insight_store_test.go
@@ -1664,3 +1664,61 @@ func TestUpdateFrontendSeries(t *testing.T) {
 		}}).Equal(t, gotAfterUpdate)
 	})
 }
+
+func TestGetReferenceCount(t *testing.T) {
+	timescale, cleanup := insightsdbtesting.TimescaleDB(t)
+	defer cleanup()
+	now := time.Now().Truncate(time.Microsecond).Round(0)
+
+	store := NewInsightStore(timescale)
+	store.Now = func() time.Time {
+		return now
+	}
+
+	_, err := timescale.Exec(`INSERT INTO insight_view (id, title, description, unique_id)
+									VALUES (1, 'test title', 'test description', 'unique-1'),
+									       (2, 'test title 2', 'test description 2', 'unique-2'),
+										   (3, 'test title 3', 'test description 3', 'unique-3')`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = timescale.Exec(`INSERT INTO dashboard (id, title)
+		VALUES (1, 'dashboard 1'), (2, 'dashboard 2'), (3, 'dashboard 3');`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = timescale.Exec(`INSERT INTO dashboard_insight_view (dashboard_id, insight_view_id)
+									VALUES  (1, 1),
+											(1, 2),
+											(1, 3),
+											(2, 2);`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	t.Run("finds a single reference", func(t *testing.T) {
+		referenceCount, err := store.GetReferenceCount(ctx, 2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		autogold.Want("ReferenceCount", referenceCount).Equal(t, 1)
+	})
+	t.Run("finds 3 references", func(t *testing.T) {
+		referenceCount, err := store.GetReferenceCount(ctx, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		autogold.Want("ReferenceCount", referenceCount).Equal(t, 3)
+	})
+	t.Run("finds no references", func(t *testing.T) {
+		referenceCount, err := store.GetReferenceCount(ctx, 3)
+		if err != nil {
+			t.Fatal(err)
+		}
+		autogold.Want("ReferenceCount", referenceCount).Equal(t, 0)
+	})
+}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/30031

## Description
We want to be able to display the total number of dashboards an insight is on, (regardless of permissions.) This PR adds a `referenceCount` to the `InsightView` object in GraphQL.

## Testing Steps
Query for insight views and check that the `referenceCount` value is what you expect. You can add/remove insights from dashboards to test that it goes up and down as well!
```
query { insightViews {
    pageInfo {
        hasNextPage,
    endCursor
  },
  nodes {
	id,
        referenceCount,
        presentation {
        ... on LineChartInsightViewPresentation {
            title,
        },
        ... on PieChartInsightViewPresentation {
            title,
        }
     }
  }
}
}
```
