### PR TITLE
compute: add ToSearchPattern for commands

### DIFF
--- a/internal/compute/command.go
+++ b/internal/compute/command.go
@@ -9,6 +9,7 @@ import (
 type Command interface {
 	command()
 	Run(context.Context, result.Match) (Result, error)
+	ToSearchPattern() string
 	String() string
 }
 

--- a/internal/compute/match_only_command.go
+++ b/internal/compute/match_only_command.go
@@ -10,7 +10,7 @@ import (
 )
 
 type MatchOnly struct {
-	MatchPattern MatchPattern
+	SearchPattern MatchPattern
 
 	// ComputePattern is the valid, semantically-equivalent representation
 	// of MatchPattern that mirrors implicit Sourcegraph search behavior
@@ -19,10 +19,14 @@ type MatchOnly struct {
 	ComputePattern MatchPattern
 }
 
+func (c *MatchOnly) ToSearchPattern() string {
+	return c.SearchPattern.String()
+}
+
 func (c *MatchOnly) String() string {
 	return fmt.Sprintf(
 		"Match only search pattern: %s, compute pattern: %s",
-		c.MatchPattern.String(),
+		c.SearchPattern.String(),
 		c.ComputePattern.String(),
 	)
 }

--- a/internal/compute/output_command.go
+++ b/internal/compute/output_command.go
@@ -13,13 +13,17 @@ import (
 )
 
 type Output struct {
-	MatchPattern  MatchPattern
+	SearchPattern MatchPattern
 	OutputPattern string
 	Separator     string
 }
 
+func (c *Output) ToSearchPattern() string {
+	return c.SearchPattern.String()
+}
+
 func (c *Output) String() string {
-	return fmt.Sprintf("Output with separator: (%s) -> (%s) separator: %s", c.MatchPattern.String(), c.OutputPattern, c.Separator)
+	return fmt.Sprintf("Output with separator: (%s) -> (%s) separator: %s", c.SearchPattern.String(), c.OutputPattern, c.Separator)
 }
 
 func substituteRegexp(content string, match *regexp.Regexp, replacePattern, separator string) string {
@@ -88,5 +92,5 @@ func (c *Output) Run(ctx context.Context, r result.Match) (Result, error) {
 	if err != nil {
 		return nil, err
 	}
-	return output(ctx, content, c.MatchPattern, outputPattern, c.Separator)
+	return output(ctx, content, c.SearchPattern, outputPattern, c.Separator)
 }

--- a/internal/compute/output_command_test.go
+++ b/internal/compute/output_command_test.go
@@ -17,7 +17,7 @@ import (
 
 func Test_output(t *testing.T) {
 	test := func(input string, cmd *Output) string {
-		result, err := output(context.Background(), input, cmd.MatchPattern, cmd.OutputPattern, cmd.Separator)
+		result, err := output(context.Background(), input, cmd.SearchPattern, cmd.OutputPattern, cmd.Separator)
 		if err != nil {
 			return err.Error()
 		}
@@ -28,7 +28,7 @@ func Test_output(t *testing.T) {
 		"regexp search outputs only digits",
 		"(1)~(2)~(3)~").
 		Equal(t, test("a 1 b 2 c 3", &Output{
-			MatchPattern:  &Regexp{Value: regexp.MustCompile(`(\d)`)},
+			SearchPattern: &Regexp{Value: regexp.MustCompile(`(\d)`)},
 			OutputPattern: "($1)",
 			Separator:     "~",
 		}))
@@ -43,7 +43,7 @@ func Test_output(t *testing.T) {
 		`train(regional, intercity)
 train(commuter, lightrail)`).
 		Equal(t, test("Im a train. train(intercity, regional). choo choo. train(lightrail, commuter)", &Output{
-			MatchPattern:  &Comby{Value: `train(:[x], :[y])`},
+			SearchPattern: &Comby{Value: `train(:[x], :[y])`},
 			OutputPattern: "train(:[y], :[x])",
 		}))
 }

--- a/internal/compute/query.go
+++ b/internal/compute/query.go
@@ -24,20 +24,10 @@ func (q Query) String() string {
 }
 
 func (q Query) ToSearchQuery() (string, error) {
-	var searchPattern string
-	switch c := q.Command.(type) {
-	case *MatchOnly:
-		searchPattern = c.MatchPattern.String()
-	case *Replace:
-		searchPattern = c.MatchPattern.String()
-	case *Output:
-		searchPattern = c.MatchPattern.String()
-	default:
-		return "", errors.Errorf("unsupported query conversion for compute command %T", c)
-	}
+	pattern := q.Command.ToSearchPattern()
 	basic := query.Basic{
 		Parameters: q.Parameters,
-		Pattern:    query.Pattern{Value: searchPattern},
+		Pattern:    query.Pattern{Value: pattern},
 	}
 	return basic.StringHuman(), nil
 }
@@ -167,7 +157,7 @@ func parseReplace(q *query.Basic) (Command, bool, error) {
 		return nil, false, nil
 	}
 
-	return &Replace{MatchPattern: matchPattern, ReplacePattern: right}, true, nil
+	return &Replace{SearchPattern: matchPattern, ReplacePattern: right}, true, nil
 }
 
 func parseOutput(q *query.Basic) (Command, bool, error) {
@@ -202,7 +192,7 @@ func parseOutput(q *query.Basic) (Command, bool, error) {
 	}
 
 	// The default separator is newline and cannot be changed currently.
-	return &Output{MatchPattern: matchPattern, OutputPattern: right, Separator: "\n"}, true, nil
+	return &Output{SearchPattern: matchPattern, OutputPattern: right, Separator: "\n"}, true, nil
 }
 
 func parseMatchOnly(q *query.Basic) (Command, bool, error) {
@@ -224,7 +214,7 @@ func parseMatchOnly(q *query.Basic) (Command, bool, error) {
 		}
 	}
 
-	return &MatchOnly{MatchPattern: sp, ComputePattern: cp}, true, nil
+	return &MatchOnly{SearchPattern: sp, ComputePattern: cp}, true, nil
 }
 
 type commandParser func(pattern *query.Basic) (Command, bool, error)

--- a/internal/compute/replace_command.go
+++ b/internal/compute/replace_command.go
@@ -13,12 +13,16 @@ import (
 )
 
 type Replace struct {
-	MatchPattern   MatchPattern
+	SearchPattern  MatchPattern
 	ReplacePattern string
 }
 
+func (c *Replace) ToSearchPattern() string {
+	return c.SearchPattern.String()
+}
+
 func (c *Replace) String() string {
-	return fmt.Sprintf("Replace in place: (%s) -> (%s)", c.MatchPattern.String(), c.ReplacePattern)
+	return fmt.Sprintf("Replace in place: (%s) -> (%s)", c.SearchPattern.String(), c.ReplacePattern)
 }
 
 func replace(ctx context.Context, content []byte, matchPattern MatchPattern, replacePattern string) (*Text, error) {
@@ -53,7 +57,7 @@ func (c *Replace) Run(ctx context.Context, r result.Match) (Result, error) {
 		if err != nil {
 			return nil, err
 		}
-		return replace(ctx, content, c.MatchPattern, c.ReplacePattern)
+		return replace(ctx, content, c.SearchPattern, c.ReplacePattern)
 	}
 	return nil, nil
 }

--- a/internal/compute/replace_command_test.go
+++ b/internal/compute/replace_command_test.go
@@ -12,7 +12,7 @@ import (
 
 func Test_replace(t *testing.T) {
 	test := func(input string, cmd *Replace) string {
-		result, err := replace(context.Background(), []byte(input), cmd.MatchPattern, cmd.ReplacePattern)
+		result, err := replace(context.Background(), []byte(input), cmd.SearchPattern, cmd.ReplacePattern)
 		if err != nil {
 			return err.Error()
 		}
@@ -23,7 +23,7 @@ func Test_replace(t *testing.T) {
 		"regexp search replace",
 		"needs a bit more queryrunner").
 		Equal(t, test("needs more queryrunner", &Replace{
-			MatchPattern:   &Regexp{Value: regexp.MustCompile(`more (\w+)`)},
+			SearchPattern:  &Regexp{Value: regexp.MustCompile(`more (\w+)`)},
 			ReplacePattern: "a bit more $1",
 		}))
 
@@ -36,7 +36,7 @@ func Test_replace(t *testing.T) {
 		"structural search replace",
 		"foo(baz, bar)").
 		Equal(t, test("foo(bar, baz)", &Replace{
-			MatchPattern:   &Comby{Value: `foo(:[x], :[y])`},
+			SearchPattern:  &Comby{Value: `foo(:[x], :[y])`},
 			ReplacePattern: "foo(:[y], :[x])",
 		}))
 }


### PR DESCRIPTION
Follow up of PR to just reflect better distinction of the pattern used for running a (Sourcegraph) search.