### PR TITLE
docs: add code monitoring slack tutorial

### DIFF
--- a/doc/code_monitoring/explanations/index.md
+++ b/doc/code_monitoring/explanations/index.md
@@ -1,4 +1,4 @@
-## Explanations
+# Explanations
 
 * [Core concepts](core_concepts.md)
-* [Best_practices](best_practices.md)
+* [Best practices](best_practices.md)

--- a/doc/code_monitoring/how-tos/index.md
+++ b/doc/code_monitoring/how-tos/index.md
@@ -1,4 +1,4 @@
-
-## How-tos
+# How-tos
 
 * [Starting points](starting_points.md)
+* <span class="badge badge-experimental">Experimental</span> [Setting up Slack notifications](slack.md)

--- a/doc/code_monitoring/how-tos/slack.md
+++ b/doc/code_monitoring/how-tos/slack.md
@@ -1,0 +1,43 @@
+# Setting up Slack notifications
+
+<aside class="experimental">
+<p>
+<span class="badge badge-experimental">Experimental</span> This feature is experimental and might change or be removed in the future. We've released it as an experimental feature to provide a preview of functionality we're working on.
+</p>
+
+<p><b>We're very much looking for input and feedback on this feature.</b> You can either <a href="https://about.sourcegraph.com/contact">contact us directly</a>, <a href="https://github.com/sourcegraph/sourcegraph">file an issue</a>, or <a href="https://twitter.com/sourcegraph">tweet at us</a>.</p>
+</aside>
+
+Slack notifications are supported via webhooks. Webhooks are special URLs that Sourcegraph's Code Monitoring 
+can call in order to send a message to a Slack channel when there are new search results for a query. 
+In order to use Slack notifications, you must first create a Slack application in your organization's Slack workspace, 
+add a webhook for a Slack channel within that application, and then configure a code monitor in Sourcegraph to
+use that webhook's URL.
+
+## Prerequisites
+
+- You must have the experimental feature flag `experimentalFeatures.codeMonitoringWebHooks` set to `true` in your Sourcegraph settings
+- You must have permission to create apps inside of your organization's Slack workspace
+
+## Creating a Slack webhook
+
+1. Navigate to https://api.slack.com/apps and sign in to your Slack account if necessary.
+1. Click on the "Create an app" button.
+1. Create your app "From scratch".
+1. Give your app a name and select the workplace you want notifications sent to.
+ <video src="https://storage.googleapis.com/sourcegraph-assets/search/code-monitoring/slack-tutorial/1-create-app.mp4" controls />
+1. Once your app is created, click on the "Incoming Webhooks" in the sidebar, under "Features".
+1. Click the toggle button to activate incoming webhooks.
+1. Scroll to the bottom of the page and click on "Add New Webhook to Workspace".
+1. Select the channel you want notifications sent to, then click on the "Allow" button.
+1. Your webhook URL is now created! Click the copy button to copy it to your clipboard.
+ <video src="https://storage.googleapis.com/sourcegraph-assets/search/code-monitoring/slack-tutorial/2-create-webhook.mp4" controls />
+
+## Configuring a code monitor to send Slack notifications
+
+1. In Sourcegraph, click on the "Code Monitoring" nav item at the top of the page.
+1. Create a new code monitor or edit an existing monitor by clicking on the "Edit" button next to it.
+1. Go through the standard configuration steps for a code monitor and select action "Send Slack message to channel".
+1. Paste your webhook URL into the "Webhook URL" field.
+1. Click on the "Continue" button, and then the "Save" button.
+ <video src="https://storage.googleapis.com/sourcegraph-assets/search/code-monitoring/slack-tutorial/3-create-monitor.mp4" controls>

--- a/doc/code_monitoring/index.md
+++ b/doc/code_monitoring/index.md
@@ -56,11 +56,14 @@ Watch your code with code monitors and trigger actions to run automatically in r
   </a>
 </div>
 
-## Explanations
+## [Explanations](explanations/index.md)
 
 - [Core concepts](explanations/core_concepts.md)
 - [Best practices](explanations/best_practices.md)
+
+## [How-tos](how-tos/index.md)
 - [Starting points and ideas](how-tos/starting_points.md)
+- <span class="badge badge-experimental">Experimental</span> [Setting up Slack notifications](how-tos/slack.md)
 
 ## Questions & Feedback
 

--- a/doc/code_search/index.md
+++ b/doc/code_search/index.md
@@ -49,7 +49,7 @@ Sourcegraph code search helps developers perform these tasks more quickly and ef
   - Define saved [search scopes](explanations/features.md#search-scopes) for easier searching.
   - Use [search contexts](explanations/features.md#search-contexts) to search across a set of repositories at specific revisions.
   - Curate [saved searches](explanations/features.md#saved-searches) for yourself or your org.
-  - Set up notifications for code changes that match a query.
+  - Use [Code Monitoring](../code_monitoring/index.md) to set up notifications for code changes that match a query.
   - View [language statistics](explanations/features.md#statistics) for search results.
 - [Search details](explanations/search_details.md)
 - [Sourcegraph Cloud](explanations/sourcegraph_cloud.md)

--- a/doc/code_search/index.md
+++ b/doc/code_search/index.md
@@ -49,7 +49,7 @@ Sourcegraph code search helps developers perform these tasks more quickly and ef
   - Define saved [search scopes](explanations/features.md#search-scopes) for easier searching.
   - Use [search contexts](explanations/features.md#search-contexts) to search across a set of repositories at specific revisions.
   - Curate [saved searches](explanations/features.md#saved-searches) for yourself or your org.
-  - Use [Code Monitoring](../code_monitoring/index.md) to set up notifications for code changes that match a query.
+  - Use [Code monitoring](../code_monitoring/index.md) to set up notifications for code changes that match a query.
   - View [language statistics](explanations/features.md#statistics) for search results.
 - [Search details](explanations/search_details.md)
 - [Sourcegraph Cloud](explanations/sourcegraph_cloud.md)


### PR DESCRIPTION
Fixes #27161

Also fixes some links in the docs related to code monitoring

The markdown files have videos but the GitHub PR preview doesn't show them. Here are the videos:

https://storage.googleapis.com/sourcegraph-assets/search/code-monitoring/slack-tutorial/1-create-app.mp4
https://storage.googleapis.com/sourcegraph-assets/search/code-monitoring/slack-tutorial/2-create-webhook.mp4
https://storage.googleapis.com/sourcegraph-assets/search/code-monitoring/slack-tutorial/3-create-monitor.mp4