### PR TITLE
eventlogger/auth: update cookie policy to Lax to allow sending on redirects

### DIFF
--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -30,7 +30,7 @@ export class EventLogger implements TelemetryService {
         // Enforce HTTPS
         secure: true,
         // We only read the cookie with JS so we don't need to send it cross-site nor on initial page requests.
-        sameSite: 'Strict',
+        sameSite: 'Lax',
         // Specify the Domain attribute to ensure subdomains (about.sourcegraph.com) can receive this cookie.
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent
         domain: location.hostname,

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -30,6 +30,8 @@ export class EventLogger implements TelemetryService {
         // Enforce HTTPS
         secure: true,
         // We only read the cookie with JS so we don't need to send it cross-site nor on initial page requests.
+        // However, we do need it on page redirects when users sign up via OAuth, hence using the Lax policy.
+        // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
         sameSite: 'Lax',
         // Specify the Domain attribute to ensure subdomains (about.sourcegraph.com) can receive this cookie.
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent

--- a/enterprise/cmd/frontend/internal/auth/oauth/session.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/session.go
@@ -2,7 +2,6 @@ package oauth
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -92,9 +91,6 @@ func SessionIssuer(db database.DB, s SessionIssuerHelper, sessionKey string) htt
 		}
 
 		anonymousId, _ := cookie.AnonymousUID(r)
-		fmt.Println("!!!!!!!!!!!!!!!!!! anon id", anonymousId)
-		fmt.Println("!!!!!!!!!!!!!!!!!! sourceurl", getCookie("sourcegraphSourceUrl"))
-		fmt.Println("!!!!!!!!!!!!!!!!!! sourceurl", getCookie("sourcegraphRecentSourceUrl"))
 		actr, safeErrMsg, err := s.GetOrCreateUser(ctx, token, anonymousId, getCookie("sourcegraphSourceUrl"), getCookie("sourcegraphRecentSourceUrl"))
 		if err != nil {
 			log15.Error("OAuth failed: error looking up or creating user from OAuth token.", "error", err, "userErr", safeErrMsg)

--- a/enterprise/cmd/frontend/internal/auth/oauth/session.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/session.go
@@ -2,6 +2,7 @@ package oauth
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -91,6 +92,9 @@ func SessionIssuer(db database.DB, s SessionIssuerHelper, sessionKey string) htt
 		}
 
 		anonymousId, _ := cookie.AnonymousUID(r)
+		fmt.Println("!!!!!!!!!!!!!!!!!! anon id", anonymousId)
+		fmt.Println("!!!!!!!!!!!!!!!!!! sourceurl", getCookie("sourcegraphSourceUrl"))
+		fmt.Println("!!!!!!!!!!!!!!!!!! sourceurl", getCookie("sourcegraphRecentSourceUrl"))
 		actr, safeErrMsg, err := s.GetOrCreateUser(ctx, token, anonymousId, getCookie("sourcegraphSourceUrl"), getCookie("sourcegraphRecentSourceUrl"))
 		if err != nil {
 			log15.Error("OAuth failed: error looking up or creating user from OAuth token.", "error", err, "userErr", safeErrMsg)


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/30020.

Our attribution cookies were not getting sent when users signed up via GitHub and GitLab auth because the sameSite policy was set to `Strict`. This means that on redirects or following links to Sourcegraph, we would not send these cookies in the request. However, when a user signs up via GitHub auth, we redirect them to the site after approving access.

This PR changes the sameSite policy to Lax, so that these cookies are sent on redirects as well. @david-sandy can you confirm that this is safe? We believe this isn't a security risk, but want to check.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
