### PR TITLE
git-combine: handle force pushes

### DIFF
--- a/internal/cmd/git-combine/Dockerfile
+++ b/internal/cmd/git-combine/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.3-alpine AS builder
+FROM golang:1.17.6-alpine AS builder
 
 WORKDIR /go/src/app
 


### PR DESCRIPTION
Previously we import all commits from a remote until we found the commit which matches what we currently have stored in HEAD. However, in the case of a force push this condition is never met since what we have in HEAD has disappeared. This commit updates this logic to instead of checking for one commit, we check the last 1000 commits. We don't check all commits for performance and memory reasons.

Tested manually:

``` shellsession
$ CGO_ENABLED=0 go build ./internal/cmd/git-combine/
$ kubectl -n default cp git-combine git-combine-0:/data/
$ kubectl -n default exec -it git-combine-0 -- /bin/sh -il
$ cd /data/monorepo.git
$ echo "keegan testing new git-combine" > PAUSE

# In case it fails, keep the old HEAD to undo changes.
$ git rev-parse HEAD
68bfbe3140570a851405e843a43c0513e2106c64

# Now simulate a force push.
$ git rev-parse sourcegraph/main sourcegraph/main^1
8ce14d012087d334e09c59c500462d1cf179fd76
a625615e6a6feea60a8d128c1ff033d0afa0f74a
$ git update-ref refs/remotes/sourcegraph/main sourcegraph/main^1
$ git rev-parse sourcegraph/main
a625615e6a6feea60a8d128c1ff033d0afa0f74a

# This should be a noop, old version would import full history.
$ ../git-combine

# success, lets see if normal operations work.
$ git fetch --all
...snip
$ ../git-combine
2022/01/26 08:42:10 1/6 created f0f468c42f333 ...snip

$ rm PAUSE
```
