### PR TITLE
Add support for NPM credentials.

### DIFF
--- a/cmd/gitserver/server/vcs_syncer_npm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages.go
@@ -52,7 +52,7 @@ func NewNPMPackagesSyncer(
 ) *NPMPackagesSyncer {
 	var client = customClient
 	if client == nil {
-		client = npm.NewHTTPClient(connection.Registry, connection.RateLimit)
+		client = npm.NewHTTPClient(connection.Registry, connection.RateLimit, connection.Credentials)
 	}
 	return &NPMPackagesSyncer{connection, dbStore, client}
 }

--- a/internal/extsvc/npm/npm_test.go
+++ b/internal/extsvc/npm/npm_test.go
@@ -5,11 +5,15 @@ import (
 	"compress/gzip"
 	"context"
 	"flag"
+	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"sort"
 	"testing"
 
+	"github.com/cockroachdb/errors"
 	"github.com/inconshreveable/log15"
 	"github.com/stretchr/testify/require"
 
@@ -32,11 +36,73 @@ func newTestHTTPClient(t *testing.T) (client *HTTPClient, stop func()) {
 	t.Helper()
 	recorderFactory, stop := httptestutil.NewRecorderFactory(t, *updateRecordings, t.Name())
 	rateLimit := schema.NPMRateLimit{true, 1000}
-	client = NewHTTPClient("https://registry.npmjs.org", &rateLimit)
+	client = NewHTTPClient("https://registry.npmjs.org", &rateLimit, "")
 	doer, err := recorderFactory.Doer()
 	require.Nil(t, err)
 	client.doer = doer
 	return client, stop
+}
+
+func mockNPMServer(credentials string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if key, ok := req.Header["Authorization"]; ok && key[0] != fmt.Sprintf("Bearer %s", credentials) {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"error": "incorrect credentials"}`))
+			return
+		}
+		routes := map[string]struct {
+			status int
+			body   string
+		}{
+			"/left-pad/1.3.1": {
+				status: http.StatusNotFound,
+				body:   `"version not found: 1.3.1"`,
+			},
+			"/left-pad/1.3.0": {
+				status: http.StatusOK,
+				body:   `{"name":"left-pad","dist": {"tarball": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz"}}`,
+			},
+		}
+		resp, found := routes[req.URL.Path]
+		if !found {
+			panic(fmt.Sprintf("unexpected request to %s", req.URL.Path))
+		}
+		w.WriteHeader(resp.status)
+		w.Write([]byte(resp.body))
+	}))
+}
+
+func TestCredentials(t *testing.T) {
+	credentials := "top secret access token"
+	server := mockNPMServer(credentials)
+	defer server.Close()
+
+	ctx := context.Background()
+	rateLimit := schema.NPMRateLimit{true, 1000}
+	client := NewHTTPClient(server.URL, &rateLimit, credentials)
+
+	presentDep, err := reposource.ParseNPMDependency("left-pad@1.3.0")
+	require.Nil(t, err)
+	absentDep, err := reposource.ParseNPMDependency("left-pad@1.3.1")
+	require.Nil(t, err)
+
+	exists, err := client.DoesDependencyExist(ctx, *presentDep)
+	require.Nil(t, err)
+	require.True(t, exists)
+
+	exists, _ = client.DoesDependencyExist(ctx, *absentDep)
+	require.False(t, exists)
+
+	// Check that using the wrong credentials doesn't work
+	client.credentials = "incorrect_credentials"
+
+	_, err = client.DoesDependencyExist(ctx, *presentDep)
+	var npmErr1 npmError
+	require.True(t, errors.As(err, &npmErr1) && npmErr1.statusCode == http.StatusUnauthorized)
+
+	_, err = client.DoesDependencyExist(ctx, *absentDep)
+	var npmErr2 npmError
+	require.True(t, errors.As(err, &npmErr2) && npmErr2.statusCode == http.StatusUnauthorized)
 }
 
 func TestAvailablePackageVersions(t *testing.T) {
@@ -102,4 +168,15 @@ func TestFetchSources(t *testing.T) {
 		"package/test/fixtures.json",
 		"package/test/index.js",
 	})
+}
+
+func TestNoPanicOnNonexistentRegistry(t *testing.T) {
+	ctx := context.Background()
+	client, stop := newTestHTTPClient(t)
+	defer stop()
+	client.registryURL = "http://not-an-npm-registry.sourcegraph.com"
+	dep, err := reposource.ParseNPMDependency("left-pad@1.3.0")
+	require.Nil(t, err)
+	_, err = client.DoesDependencyExist(ctx, *dep)
+	require.NotNil(t, err)
 }

--- a/internal/repos/npm_packages.go
+++ b/internal/repos/npm_packages.go
@@ -38,7 +38,12 @@ func NewNPMPackagesSource(svc *types.ExternalService) (*NPMPackagesSource, error
 	if err := jsonc.Unmarshal(svc.Config, &c); err != nil {
 		return nil, errors.Errorf("external service id=%d config error: %s", svc.ID, err)
 	}
-	return &NPMPackagesSource{svc: svc, connection: c /*dbStore initialized in SetDB */, client: npm.NewHTTPClient(c.Registry, c.RateLimit)}, nil
+	return &NPMPackagesSource{
+		svc:        svc,
+		connection: c,
+		/*dbStore initialized in SetDB */
+		client: npm.NewHTTPClient(c.Registry, c.RateLimit, c.Credentials),
+	}, nil
 }
 
 var _ Source = &NPMPackagesSource{}

--- a/internal/types/secret.go
+++ b/internal/types/secret.go
@@ -109,8 +109,7 @@ func redactionInfo(cfg interface{}) ([]jsonStringField, error) {
 		}
 		return []jsonStringField{}, nil
 	case *schema.NPMPackagesConnection:
-		// TODO: [npm-package-support-credentials] Redact credentials here.
-		return []jsonStringField{}, nil
+		return []jsonStringField{{[]string{"credentials"}, &cfg.Credentials}}, nil
 	case *schema.OtherExternalServiceConnection:
 		return []jsonStringField{{[]string{"url"}, &cfg.Url}}, nil
 	default:

--- a/internal/types/secret_test.go
+++ b/internal/types/secret_test.go
@@ -71,7 +71,7 @@ func TestRoundTripRedactExternalServiceConfig(t *testing.T) {
 		Url: "https://src.fedoraproject.org",
 	}
 	npmPackagesConfig := schema.NPMPackagesConnection{
-		// TODO: [npm-package-support-credentials] Add a credential field here
+		Credentials:  "npm credentials!",
 		Dependencies: []string{"placeholder"},
 	}
 	otherConfig := schema.OtherExternalServiceConnection{

--- a/schema/npm-packages.schema.json
+++ b/schema/npm-packages.schema.json
@@ -2,12 +2,18 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "npm-packages.schema.json#",
   "title": "NPMPackagesConnection",
-  "description": "Configuration for a connection to an NPM packages repository.\nTODO: [npm-package-support-credentials] Add a credential field to NPMConfig.",
+  "description": "Configuration for a connection to an NPM packages repository.",
   "allowComments": true,
   "type": "object",
   "additionalProperties": false,
   "required": ["registry"],
   "properties": {
+    "credentials": {
+      "description": "Access token for logging into the NPM registry.",
+      "type": "string",
+      "default": "",
+      "examples": ["CRs5VaTVbR7pBPcVpaxwQeafrYOId7IdVUiZCkFCqnw="]
+    },
     "registry": {
       "description": "The URL at which the NPM registry can be found.",
       "type": "string",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1021,8 +1021,9 @@ type MountedEncryptionKey struct {
 }
 
 // NPMPackagesConnection description: Configuration for a connection to an NPM packages repository.
-// TODO: [npm-package-support-credentials] Add a credential field to NPMConfig.
 type NPMPackagesConnection struct {
+	// Credentials description: Access token for logging into the NPM registry.
+	Credentials string `json:"credentials,omitempty"`
 	// Dependencies description: An array of "(@scope/)?packageName@version" strings specifying which NPM packages to mirror on Sourcegraph.
 	Dependencies []string `json:"dependencies,omitempty"`
 	// RateLimit description: Rate limit applied when making background API requests to the NPM registry.


### PR DESCRIPTION
The largest part of the change is the testing setup. I'm using [Verdaccio](https://github.com/verdaccio/verdaccio) to spin up a proxy for the NPM registry, and testing authorization against that.

Questions and TODOs:
- [X] Should I include any documentation about Verdaccio so that people can change/understand the code better? - Resolution: Removed the usage of Verdaccio altogether.
- [X] Is there a better/simpler way to test this same behavior? - Resolution: Using a mock server which uses a hard-coded JSON response.
- [x] I've left a TODO for adding a test case for an error code path I hit, I will fix that.