### PR TITLE
notebook papercuts: reset md block max width and auto-focus block inputs

### DIFF
--- a/client/web/src/integration/notebook.test.ts
+++ b/client/web/src/integration/notebook.test.ts
@@ -211,7 +211,6 @@ describe('Search Notebook', () => {
 
         // Edit and run new markdown block
         await driver.page.click(newMarkdownBlockSelector)
-        await driver.page.click('[data-testid="Edit"]')
         await driver.replaceText({
             selector: `${newMarkdownBlockSelector} .monaco-editor`,
             newText: 'Replaced text',

--- a/client/web/src/search/notebook/SearchNotebookAddBlockButtons.tsx
+++ b/client/web/src/search/notebook/SearchNotebookAddBlockButtons.tsx
@@ -38,7 +38,7 @@ export const SearchNotebookAddBlockButtons: React.FunctionComponent<SearchNotebo
             </Button>
             <Button
                 className={classNames('ml-2', styles.addBlockButton)}
-                onClick={() => onAddBlock(index, { type: 'md', input: '*Enter markdown*' })}
+                onClick={() => onAddBlock(index, { type: 'md', input: '' })}
                 data-testid="add-md-button"
                 outline={true}
                 variant="secondary"

--- a/client/web/src/search/notebook/SearchNotebookMarkdownBlock.module.scss
+++ b/client/web/src/search/notebook/SearchNotebookMarkdownBlock.module.scss
@@ -9,7 +9,6 @@
 
 .output {
     padding: 0.5rem 1rem;
-    max-width: 640px;
 }
 
 .markdown {

--- a/client/web/src/search/notebook/SearchNotebookMarkdownBlock.tsx
+++ b/client/web/src/search/notebook/SearchNotebookMarkdownBlock.tsx
@@ -35,7 +35,7 @@ export const SearchNotebookMarkdownBlock: React.FunctionComponent<SearchNotebook
     onSelectBlock,
     ...props
 }) => {
-    const [isEditing, setIsEditing] = useState(false)
+    const [isEditing, setIsEditing] = useState(input.length === 0)
     const [editor, setEditor] = useState<Monaco.editor.IStandaloneCodeEditor>()
     const blockElement = useRef<HTMLDivElement>(null)
 

--- a/client/web/src/search/notebook/SearchNotebookQueryBlock.tsx
+++ b/client/web/src/search/notebook/SearchNotebookQueryBlock.tsx
@@ -3,7 +3,7 @@ import { noop } from 'lodash'
 import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
 import PlayCircleOutlineIcon from 'mdi-react/PlayCircleOutlineIcon'
 import * as Monaco from 'monaco-editor'
-import React, { useState, useCallback, useRef, useMemo } from 'react'
+import React, { useState, useCallback, useRef, useMemo, useEffect } from 'react'
 import { useLocation } from 'react-router'
 import { Observable, of } from 'rxjs'
 
@@ -128,6 +128,15 @@ export const SearchNotebookQueryBlock: React.FunctionComponent<SearchNotebookQue
     )
 
     useQueryDiagnostics(editor, { patternType: SearchPatternType.literal, interpretComments: true })
+
+    // Focus the query input when a new query block is added (the input is empty).
+    useEffect(() => {
+        if (editor && input.length === 0) {
+            editor.focus()
+        }
+        // Only run this hook for the initial input.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [editor])
 
     return (
         <div className={classNames('block-wrapper', blockStyles.blockWrapper)} data-block-id={id}>

--- a/client/web/src/search/notebook/fileBlock/SearchNotebookFileBlockInput.story.tsx
+++ b/client/web/src/search/notebook/fileBlock/SearchNotebookFileBlockInput.story.tsx
@@ -38,7 +38,7 @@ add('default with suggestions', () => (
                 onBlur={noop}
                 isMacPlatform={false}
                 suggestions={['client/web/file1.tsx', 'client/web/file2.tsx', 'client/web/file3.tsx']}
-                testTriggerSuggestions={true}
+                focusInput={true}
             />
         )}
     </WebStory>

--- a/client/web/src/search/notebook/fileBlock/SearchNotebookFileBlockInput.tsx
+++ b/client/web/src/search/notebook/fileBlock/SearchNotebookFileBlockInput.tsx
@@ -27,8 +27,8 @@ interface SearchNotebookFileBlockInputProps {
     suggestionsIcon?: JSX.Element
     isValid?: boolean
     isMacPlatform: boolean
+    focusInput?: boolean
     dataTestId?: string
-    testTriggerSuggestions?: boolean
 }
 
 export const SearchNotebookFileBlockInput: React.FunctionComponent<SearchNotebookFileBlockInputProps> = ({
@@ -44,8 +44,8 @@ export const SearchNotebookFileBlockInput: React.FunctionComponent<SearchNoteboo
     suggestionsIcon,
     isValid,
     isMacPlatform,
+    focusInput,
     dataTestId,
-    testTriggerSuggestions,
 }) => {
     const [inputValue, setInputValue] = useState(value)
     const debouncedOnChange = useMemo(() => debounce(onChange, 300), [onChange])
@@ -59,10 +59,12 @@ export const SearchNotebookFileBlockInput: React.FunctionComponent<SearchNoteboo
 
     const inputReference = useRef<HTMLInputElement>(null)
     useEffect(() => {
-        if (testTriggerSuggestions) {
+        if (focusInput) {
             inputReference.current?.focus()
         }
-    }, [inputReference, testTriggerSuggestions])
+        // Only focus input on the initial render.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [inputReference])
 
     const popoverReference = useRef<HTMLDivElement>(null)
     const onKeyDown = (event: React.KeyboardEvent): void => {

--- a/client/web/src/search/notebook/fileBlock/SearchNotebookFileBlockInputs.tsx
+++ b/client/web/src/search/notebook/fileBlock/SearchNotebookFileBlockInputs.tsx
@@ -127,6 +127,7 @@ export const SearchNotebookFileBlockInputs: React.FunctionComponent<SearchNotebo
                     suggestionsIcon={<SourceRepositoryIcon className="mr-1" size="1rem" />}
                     isValid={isRepositoryNameValid}
                     isMacPlatform={isMacPlatform}
+                    focusInput={repositoryName.length === 0}
                     dataTestId="file-block-repository-name-input"
                 />
                 <div className={styles.separator} />


### PR DESCRIPTION
Markdown blocks before:
<img width="1171" alt="Screenshot 2022-01-26 at 13 27 29" src="https://user-images.githubusercontent.com/6417322/151163042-51e0ba38-fb24-4272-8803-bed4c1df1452.png">

Markdown blocks now:
<img width="1197" alt="Screenshot 2022-01-26 at 13 25 57" src="https://user-images.githubusercontent.com/6417322/151163024-a200cbff-2f5a-45e1-bff9-f8b74fc24ecc.png">

Additionally, we auto-focus the block input when a new block is created (for the file block we focus the repository input).