### PR TITLE
perf: do not load rich HTML file content when highlighting line ranges

### DIFF
--- a/client/web/src/repo/backend.ts
+++ b/client/web/src/repo/backend.ts
@@ -190,7 +190,6 @@ export const fetchHighlightedFileLineRanges = memoizeObservable(
                         commit(rev: $commitID) {
                             file(path: $filePath) {
                                 isDirectory
-                                richHTML
                                 highlight(disableTimeout: $disableTimeout) {
                                     aborted
                                     lineRanges(ranges: $ranges)


### PR DESCRIPTION
Turns out that we don't use the result of that, which means that we
always loaded the complete file in rich HTML when highlighting file
ranges (in references, for example).



