### PR TITLE
migrations: Expose transactional store behavior in `Store` interface

### DIFF
--- a/cmd/migrator/main.go
+++ b/cmd/migrator/main.go
@@ -64,7 +64,7 @@ func newRunFunc() cliutil.RunFunc {
 		}
 
 		storeFactory := func(db *sql.DB, migrationsTable string) connections.Store {
-			return store.NewWithDB(db, migrationsTable, operations)
+			return connections.NewStoreShim(store.NewWithDB(db, migrationsTable, operations))
 		}
 
 		return connections.RunnerFromDSNs(dsns, appName, storeFactory).Run(ctx, options)

--- a/dev/sg/sg_db.go
+++ b/dev/sg/sg_db.go
@@ -196,7 +196,7 @@ func dbResetPGExec(ctx context.Context, args []string) error {
 	}
 
 	storeFactory := func(db *sql.DB, migrationsTable string) connections.Store {
-		return store.NewWithDB(db, migrationsTable, store.NewOperations(&observation.TestContext))
+		return connections.NewStoreShim(store.NewWithDB(db, migrationsTable, store.NewOperations(&observation.TestContext)))
 	}
 
 	options := runner.Options{

--- a/dev/sg/sg_migration.go
+++ b/dev/sg/sg_migration.go
@@ -69,7 +69,7 @@ var (
 
 func runMigration(ctx context.Context, options runner.Options) error {
 	storeFactory := func(db *sql.DB, migrationsTable string) connections.Store {
-		return store.NewWithDB(db, migrationsTable, store.NewOperations(&observation.TestContext))
+		return connections.NewStoreShim(store.NewWithDB(db, migrationsTable, store.NewOperations(&observation.TestContext)))
 	}
 
 	return connections.RunnerFromDSNs(postgresdsn.RawDSNsBySchema(schemas.SchemaNames), "sg", storeFactory).Run(ctx, options)

--- a/internal/database/connections/test/store.go
+++ b/internal/database/connections/test/store.go
@@ -25,6 +25,14 @@ func newMemoryStore(db *sql.DB) runner.Store {
 	}
 }
 
+func (s *memoryStore) Transact(ctx context.Context) (runner.Store, error) {
+	return s, nil
+}
+
+func (s *memoryStore) Done(err error) error {
+	return err
+}
+
 func (s *memoryStore) Version(ctx context.Context) (int, bool, bool, error) {
 	return s.version, s.dirty, s.versionSet, nil
 }

--- a/internal/database/migration/runner/helpers_test.go
+++ b/internal/database/migration/runner/helpers_test.go
@@ -50,6 +50,8 @@ func testStoreWithVersion(version int, dirty bool) *MockStore {
 	}
 
 	store := NewMockStore()
+	store.TransactFunc.SetDefaultReturn(store, nil)
+	store.DoneFunc.SetDefaultHook(func(err error) error { return err })
 	store.LockFunc.SetDefaultReturn(true, func(err error) error { return err }, nil)
 	store.TryLockFunc.SetDefaultReturn(true, func(err error) error { return err }, nil)
 	store.UpFunc.SetDefaultHook(migrationHook)

--- a/internal/database/migration/runner/iface.go
+++ b/internal/database/migration/runner/iface.go
@@ -7,6 +7,9 @@ import (
 )
 
 type Store interface {
+	Transact(ctx context.Context) (Store, error)
+	Done(err error) error
+
 	Version(ctx context.Context) (int, bool, bool, error)
 	Lock(ctx context.Context) (bool, func(err error) error, error)
 	TryLock(ctx context.Context) (bool, func(err error) error, error)


### PR DESCRIPTION
Pulled from #29831.