### PR TITLE
web: display author commit time on hover of commit node

### DIFF
--- a/client/web/src/repo/RevisionsPopover/RevisionsPopoverCommits.tsx
+++ b/client/web/src/repo/RevisionsPopover/RevisionsPopoverCommits.tsx
@@ -91,7 +91,7 @@ const GitCommitNode: React.FunctionComponent<GitCommitNodeProps> = ({
                 <Badge title={node.oid} as="code">
                     {node.abbreviatedOID}
                 </Badge>
-                <small className={styles.message}>{node.subject.slice(0, 200)}</small>
+                <small title={node.author.date} className={styles.message}>{node.subject.slice(0, 200)}</small>
             </ConnectionPopoverNodeLink>
         </ConnectionPopoverNode>
     )


### PR DESCRIPTION
I was trying to use the commit drop down to do some debugging on a repo that had few commits (over a long time) and found it irritating that I couldn't see _when_ the commits were from. This is a super simple change that mimics the behavior of the badge on the left, to display the commit (author) time on hover of the description.

### Before
![CleanShot 2022-01-26 at 15 20 14](https://user-images.githubusercontent.com/5090588/151257050-b221f912-8234-4088-ab55-e1490a0a7148.gif)

### After
![CleanShot 2022-01-26 at 15 20 42](https://user-images.githubusercontent.com/5090588/151257058-7878dc98-a9e6-4292-aa4a-8b03784567dd.gif)

