### PR TITLE
search: mint internal alert query proposal type

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -93,9 +93,11 @@ func alertForTimeout(usedTime time.Duration, suggestTime time.Duration, r *searc
 		description:    fmt.Sprintf("We weren't able to find any results in %s.", usedTime.Round(time.Second)),
 		proposedQueries: []*searchQueryDescription{
 			{
-				description: "query with longer timeout",
-				query:       fmt.Sprintf("timeout:%v %s", suggestTime, query.OmitField(q, query.FieldTimeout)),
-				patternType: r.PatternType,
+				search.NewProposedQuery(
+					"query with longer timeout",
+					fmt.Sprintf("timeout:%v %s", suggestTime, query.OmitField(q, query.FieldTimeout)),
+					r.PatternType,
+				),
 			},
 		},
 	}
@@ -133,11 +135,15 @@ func (o *alertObserver) alertForNoResolvedRepos(ctx context.Context, q query.Q) 
 	}
 	if len(contextFilters) == 1 && !searchcontexts.IsGlobalSearchContextSpec(contextFilters[0]) && len(repoFilters) > 0 {
 		withoutContextFilter := query.OmitField(q, query.FieldContext)
-		proposedQueries := []*searchQueryDescription{{
-			description: "search in the global context",
-			query:       fmt.Sprintf("context:%s %s", searchcontexts.GlobalSearchContextName, withoutContextFilter),
-			patternType: o.PatternType,
-		}}
+		proposedQueries := []*searchQueryDescription{
+			{
+				search.NewProposedQuery(
+					"search in the global context",
+					fmt.Sprintf("context:%s %s", searchcontexts.GlobalSearchContextName, withoutContextFilter),
+					o.PatternType,
+				),
+			},
+		}
 
 		return &searchAlert{
 			prometheusType:  "no_resolved_repos__context_none_in_common",
@@ -172,9 +178,11 @@ func (o *alertObserver) alertForNoResolvedRepos(ctx context.Context, q query.Q) 
 		}
 		if o.reposExist(ctx, tryIncludeForks) {
 			proposedQueries = append(proposedQueries, &searchQueryDescription{
-				description: "include forked repositories in your query.",
-				query:       o.OriginalQuery + " fork:yes",
-				patternType: o.PatternType,
+				search.NewProposedQuery(
+					"include forked repositories in your query.",
+					o.OriginalQuery+" fork:yes",
+					o.PatternType,
+				),
 			})
 		}
 	}
@@ -189,9 +197,11 @@ func (o *alertObserver) alertForNoResolvedRepos(ctx context.Context, q query.Q) 
 		}
 		if o.reposExist(ctx, tryIncludeArchived) {
 			proposedQueries = append(proposedQueries, &searchQueryDescription{
-				description: "include archived repositories in your query.",
-				query:       o.OriginalQuery + " archived:yes",
-				patternType: o.PatternType,
+				search.NewProposedQuery(
+					"include archived repositories in your query.",
+					o.OriginalQuery+" archived:yes",
+					o.PatternType,
+				),
 			})
 		}
 	}
@@ -226,11 +236,15 @@ func alertForStructuralSearchNotSet(queryString string) *searchAlert {
 		prometheusType: "structural_search_not_set",
 		title:          "No results",
 		description:    "It looks like you may have meant to run a structural search, but it is not toggled.",
-		proposedQueries: []*searchQueryDescription{{
-			description: "Activate structural search",
-			query:       queryString,
-			patternType: query.SearchTypeStructural,
-		}},
+		proposedQueries: []*searchQueryDescription{
+			{
+				search.NewProposedQuery(
+					"Activate structural search",
+					queryString,
+					query.SearchTypeStructural,
+				),
+			},
+		},
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/commit"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/run"
@@ -31,9 +32,11 @@ func TestSearchPatternForSuggestion(t *testing.T) {
 				description: "An alert for regex",
 				proposedQueries: []*searchQueryDescription{
 					{
-						description: "Some query description",
-						query:       "repo:github.com/sourcegraph/sourcegraph",
-						patternType: query.SearchTypeRegex,
+						search.NewProposedQuery(
+							"Some query description",
+							"repo:github.com/sourcegraph/sourcegraph",
+							query.SearchTypeRegex,
+						),
 					},
 				},
 			},
@@ -46,9 +49,11 @@ func TestSearchPatternForSuggestion(t *testing.T) {
 				description: "An alert for structural",
 				proposedQueries: []*searchQueryDescription{
 					{
-						description: "Some query description",
-						query:       "repo:github.com/sourcegraph/sourcegraph",
-						patternType: query.SearchTypeStructural,
+						search.NewProposedQuery(
+							"Some query description",
+							"repo:github.com/sourcegraph/sourcegraph",
+							query.SearchTypeStructural,
+						),
 					},
 				},
 			},
@@ -60,7 +65,7 @@ func TestSearchPatternForSuggestion(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			got := tt.Alert.ProposedQueries()
 			if !reflect.DeepEqual((*got)[0].Query(), tt.Want) {
-				t.Errorf("got: %s, want: %s", (*got)[0].query, tt.Want)
+				t.Errorf("got: %s, want: %s", (*got)[0].Query(), tt.Want)
 			}
 		})
 	}
@@ -249,9 +254,11 @@ func TestAlertForNoResolvedReposWithNonGlobalSearchContext(t *testing.T) {
 		prometheusType: "no_resolved_repos__context_none_in_common",
 		title:          "No repositories found for your query within the context @user",
 		proposedQueries: []*searchQueryDescription{{
-			description: "search in the global context",
-			query:       "context:global repo:r1 foo",
-			patternType: query.SearchTypeRegex,
+			search.NewProposedQuery(
+				"search in the global context",
+				"context:global repo:r1 foo",
+				query.SearchTypeRegex,
+			),
 		}},
 	}
 

--- a/cmd/frontend/graphqlbackend/search_query_description.go
+++ b/cmd/frontend/graphqlbackend/search_query_description.go
@@ -1,35 +1,19 @@
 package graphqlbackend
 
-import "github.com/sourcegraph/sourcegraph/internal/search/query"
+import "github.com/sourcegraph/sourcegraph/internal/search"
 
 // searchQueryDescription is a type for the SearchQueryDescription resolver used
-// by SearchAlert.
+// by SearchAlert. This name is a bit of a misnomer but cannot be changed: It
+// must be this way to work with the GQL definition and compatibility. We use
+// our internal, resolver-agnostic alert type to do real work.
 type searchQueryDescription struct {
-	description string
-	query       string
-	patternType query.SearchType
+	query *search.ProposedQuery
 }
 
 func (q searchQueryDescription) Query() string {
-	if q.description != "Remove quotes" {
-		switch q.patternType {
-		case query.SearchTypeRegex:
-			return q.query + " patternType:regexp"
-		case query.SearchTypeLiteral:
-			return q.query + " patternType:literal"
-		case query.SearchTypeStructural:
-			return q.query + " patternType:structural"
-		default:
-			panic("unreachable")
-		}
-	}
-	return q.query
+	return q.query.QueryString()
 }
 
 func (q searchQueryDescription) Description() *string {
-	if q.description == "" {
-		return nil
-	}
-
-	return &q.description
+	return q.query.Description()
 }

--- a/internal/search/alert.go
+++ b/internal/search/alert.go
@@ -1,0 +1,37 @@
+package search
+
+import "github.com/sourcegraph/sourcegraph/internal/search/query"
+
+type ProposedQuery struct {
+	description string
+	query       string
+	patternType query.SearchType
+}
+
+func NewProposedQuery(description, query string, patternType query.SearchType) *ProposedQuery {
+	return &ProposedQuery{description: description, query: query, patternType: patternType}
+}
+
+func (q *ProposedQuery) QueryString() string {
+	if q.description != "Remove quotes" {
+		switch q.patternType {
+		case query.SearchTypeRegex:
+			return q.query + " patternType:regexp"
+		case query.SearchTypeLiteral:
+			return q.query + " patternType:literal"
+		case query.SearchTypeStructural:
+			return q.query + " patternType:structural"
+		default:
+			panic("unreachable")
+		}
+	}
+	return q.query
+}
+
+func (q *ProposedQuery) Description() *string {
+	if q.description == "" {
+		return nil
+	}
+
+	return &q.description
+}


### PR DESCRIPTION
As per title. I want us to represent alerts in `internal/search`, and need to start with the proposal type to break up this work. I started hacking on this because alert code stuff is blocking me from moving forward with job tree (long story, but basically because it's still not decoupled from GQL resolver).