### PR TITLE
migrations: Make definition-by-id lookup constant-time

### DIFF
--- a/internal/database/migration/definition/definition.go
+++ b/internal/database/migration/definition/definition.go
@@ -21,7 +21,20 @@ type Metadata struct {
 }
 
 type Definitions struct {
-	definitions []Definition
+	definitions    []Definition
+	definitionsMap map[int]Definition
+}
+
+func newDefinitions(migrationDefinitions []Definition) *Definitions {
+	definitionsMap := make(map[int]Definition, len(migrationDefinitions))
+	for _, migrationDefinition := range migrationDefinitions {
+		definitionsMap[migrationDefinition.ID] = migrationDefinition
+	}
+
+	return &Definitions{
+		definitions:    migrationDefinitions,
+		definitionsMap: definitionsMap,
+	}
 }
 
 func (ds *Definitions) Count() int {
@@ -33,13 +46,8 @@ func (ds *Definitions) First() int {
 }
 
 func (ds *Definitions) GetByID(id int) (Definition, bool) {
-	for _, definition := range ds.definitions {
-		if definition.ID == id {
-			return definition, true
-		}
-	}
-
-	return Definition{}, false
+	definition, ok := ds.definitionsMap[id]
+	return definition, ok
 }
 
 func (ds *Definitions) UpTo(id, target int) ([]Definition, error) {

--- a/internal/database/migration/definition/definition_test.go
+++ b/internal/database/migration/definition/definition_test.go
@@ -7,13 +7,13 @@ import (
 )
 
 func TestDefinitionGetByID(t *testing.T) {
-	definitions := &Definitions{definitions: []Definition{
+	definitions := newDefinitions([]Definition{
 		{ID: 1, UpFilename: "1.up.sql"},
 		{ID: 2, UpFilename: "2.up.sql"},
 		{ID: 3, UpFilename: "3.up.sql"},
 		{ID: 4, UpFilename: "4.up.sql"},
 		{ID: 5, UpFilename: "5.up.sql"},
-	}}
+	})
 
 	definition, ok := definitions.GetByID(3)
 	if !ok {
@@ -26,13 +26,13 @@ func TestDefinitionGetByID(t *testing.T) {
 }
 
 func TestUpTo(t *testing.T) {
-	definitions := &Definitions{definitions: []Definition{
+	definitions := newDefinitions([]Definition{
 		{ID: 11, UpFilename: "11.up.sql"},
 		{ID: 12, UpFilename: "12.up.sql"},
 		{ID: 13, UpFilename: "13.up.sql"},
 		{ID: 14, UpFilename: "14.up.sql"},
 		{ID: 15, UpFilename: "15.up.sql"},
-	}}
+	})
 
 	t.Run("zero", func(t *testing.T) {
 		// middle of sequence
@@ -85,13 +85,13 @@ func TestUpTo(t *testing.T) {
 }
 
 func TestUpFrom(t *testing.T) {
-	definitions := &Definitions{definitions: []Definition{
+	definitions := newDefinitions([]Definition{
 		{ID: 11, UpFilename: "11.up.sql"},
 		{ID: 12, UpFilename: "12.up.sql"},
 		{ID: 13, UpFilename: "13.up.sql"},
 		{ID: 14, UpFilename: "14.up.sql"},
 		{ID: 15, UpFilename: "15.up.sql"},
-	}}
+	})
 
 	t.Run("no limit", func(t *testing.T) {
 		// middle of sequence
@@ -149,13 +149,13 @@ func TestUpFrom(t *testing.T) {
 }
 
 func TestDownTo(t *testing.T) {
-	definitions := &Definitions{definitions: []Definition{
+	definitions := newDefinitions([]Definition{
 		{ID: 11, UpFilename: "11.up.sql"},
 		{ID: 12, UpFilename: "12.up.sql"},
 		{ID: 13, UpFilename: "13.up.sql"},
 		{ID: 14, UpFilename: "14.up.sql"},
 		{ID: 15, UpFilename: "15.up.sql"},
-	}}
+	})
 
 	t.Run("zero", func(t *testing.T) {
 		if _, err := definitions.DownTo(14, 0); err == nil {
@@ -196,13 +196,13 @@ func TestDownTo(t *testing.T) {
 }
 
 func TestDownFrom(t *testing.T) {
-	definitions := &Definitions{definitions: []Definition{
+	definitions := newDefinitions([]Definition{
 		{ID: 11, UpFilename: "11.up.sql"},
 		{ID: 12, UpFilename: "12.up.sql"},
 		{ID: 13, UpFilename: "13.up.sql"},
 		{ID: 14, UpFilename: "14.up.sql"},
 		{ID: 15, UpFilename: "15.up.sql"},
-	}}
+	})
 
 	t.Run("zero", func(t *testing.T) {
 		// middle of sequence

--- a/internal/database/migration/definition/read.go
+++ b/internal/database/migration/definition/read.go
@@ -40,9 +40,7 @@ func ReadDefinitions(fs fs.FS) (*Definitions, error) {
 		return nil, err
 	}
 
-	return &Definitions{
-		definitions: migrationDefinitions,
-	}, nil
+	return newDefinitions(migrationDefinitions), nil
 }
 
 func readSQLFilenames(fs fs.FS) ([]string, error) {


### PR DESCRIPTION
Pulled from #29831. 