### PR TITLE
migrations: Simplify tests comparing definition instances

### DIFF
--- a/internal/database/migration/definition/read_test.go
+++ b/internal/database/migration/definition/read_test.go
@@ -12,6 +12,16 @@ import (
 )
 
 func TestReadDefinitions(t *testing.T) {
+	queryComparer := cmp.Comparer(func(a, b *sqlf.Query) bool {
+		if a == nil {
+			return b == nil
+		}
+		if b == nil {
+			return false
+		}
+		return strings.TrimSpace(a.Query(sqlf.PostgresBindVar)) == strings.TrimSpace(b.Query(sqlf.PostgresBindVar))
+	})
+
 	t.Run("well-formed", func(t *testing.T) {
 		fs, err := fs.Sub(testdata.Content, "well-formed")
 		if err != nil {
@@ -23,33 +33,14 @@ func TestReadDefinitions(t *testing.T) {
 			t.Fatalf("unexpected error: %s", err)
 		}
 
-		type comparableDefinition struct {
-			ID           int
-			UpFilename   string
-			UpQuery      string
-			DownFilename string
-			DownQuery    string
+		expectedDefinitions := []Definition{
+			{ID: 10001, UpFilename: "10001_first.up.sql", DownFilename: "10001_first.down.sql", UpQuery: sqlf.Sprintf("10001 UP"), DownQuery: sqlf.Sprintf("10001 DOWN")},
+			{ID: 10002, UpFilename: "10002_second.up.sql", DownFilename: "10002_second.down.sql", UpQuery: sqlf.Sprintf("10002 UP"), DownQuery: sqlf.Sprintf("10002 DOWN"), Metadata: Metadata{Parent: 10001}},
+			{ID: 10003, UpFilename: "10003_third.up.sql", DownFilename: "10003_third.down.sql", UpQuery: sqlf.Sprintf("10003 UP"), DownQuery: sqlf.Sprintf("10003 DOWN"), Metadata: Metadata{Parent: 10002}},
+			{ID: 10004, UpFilename: "10004_fourth.up.sql", DownFilename: "10004_fourth.down.sql", UpQuery: sqlf.Sprintf("10004 UP"), DownQuery: sqlf.Sprintf("10004 DOWN"), Metadata: Metadata{Parent: 10003}},
+			{ID: 10005, UpFilename: "10005_fifth.up.sql", DownFilename: "10005_fifth.down.sql", UpQuery: sqlf.Sprintf("10005 UP"), DownQuery: sqlf.Sprintf("10005 DOWN"), Metadata: Metadata{Parent: 10004}},
 		}
-
-		comparableDefinitions := make([]comparableDefinition, 0, len(definitions.definitions))
-		for _, definition := range definitions.definitions {
-			comparableDefinitions = append(comparableDefinitions, comparableDefinition{
-				ID:           definition.ID,
-				UpFilename:   definition.UpFilename,
-				UpQuery:      strings.TrimSpace(definition.UpQuery.Query(sqlf.PostgresBindVar)),
-				DownFilename: definition.DownFilename,
-				DownQuery:    strings.TrimSpace(definition.DownQuery.Query(sqlf.PostgresBindVar)),
-			})
-		}
-
-		expectedDefinitions := []comparableDefinition{
-			{ID: 10001, UpFilename: "10001_first.up.sql", DownFilename: "10001_first.down.sql", UpQuery: "10001 UP", DownQuery: "10001 DOWN"},
-			{ID: 10002, UpFilename: "10002_second.up.sql", DownFilename: "10002_second.down.sql", UpQuery: "10002 UP", DownQuery: "10002 DOWN"},
-			{ID: 10003, UpFilename: "10003_third.up.sql", DownFilename: "10003_third.down.sql", UpQuery: "10003 UP", DownQuery: "10003 DOWN"},
-			{ID: 10004, UpFilename: "10004_fourth.up.sql", DownFilename: "10004_fourth.down.sql", UpQuery: "10004 UP", DownQuery: "10004 DOWN"},
-			{ID: 10005, UpFilename: "10005_fifth.up.sql", DownFilename: "10005_fifth.down.sql", UpQuery: "10005 UP", DownQuery: "10005 DOWN"},
-		}
-		if diff := cmp.Diff(expectedDefinitions, comparableDefinitions); diff != "" {
+		if diff := cmp.Diff(expectedDefinitions, definitions.definitions, queryComparer); diff != "" {
 			t.Fatalf("unexpected definitions (-want +got):\n%s", diff)
 		}
 	})


### PR DESCRIPTION
Pulled from #29831.