### PR TITLE
Removing unversioned docs links from the enterprise folder 

### DIFF
--- a/client/web/src/enterprise/batches/create/OldCreateBatchChangeContent.tsx
+++ b/client/web/src/enterprise/batches/create/OldCreateBatchChangeContent.tsx
@@ -59,7 +59,7 @@ export const OldBatchChangePageContent: React.FunctionComponent<{}> = () => {
                 <p className="mb-0">
                     The batch spec (
                     <Link
-                        to="https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference"
+                        to="/help/batch_changes/references/batch_spec_yaml_reference"
                         rel="noopener noreferrer"
                         target="_blank"
                     >

--- a/client/web/src/enterprise/batches/global/DotcomGettingStartedPage.tsx
+++ b/client/web/src/enterprise/batches/global/DotcomGettingStartedPage.tsx
@@ -50,7 +50,7 @@ const DotcomGettingStartedPageFooter: React.FunctionComponent<{}> = () => (
             bodyText="Batch Changes requires a local Sourcegraph installation. You can check it out for free by installing with a single line of code."
             title="Install locally to get started"
             linkText="Install local instance"
-            href="https://docs.sourcegraph.com/admin/install?utm_medium=inproduct&utm_source=inproduct-batch-changes&utm_campaign=inproduct-batch-changes&term="
+            href="/help/admin/install?utm_medium=inproduct&utm_source=inproduct-batch-changes&utm_campaign=inproduct-batch-changes&term="
             icon={<DownloadSourcegraphIcon />}
             className="ml-3"
             onClick={() => eventLogger.log('BatchChangesInstallFromCloudClicked')}

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -36,8 +36,8 @@ import { NewBatchChangeButton } from './NewBatchChangeButton'
 
 export interface BatchChangeListPageProps
     extends TelemetryProps,
-        Pick<RouteComponentProps, 'location'>,
-        SettingsCascadeProps<Settings> {
+    Pick<RouteComponentProps, 'location'>,
+    SettingsCascadeProps<Settings> {
     canCreate: boolean
     headingElement: 'h1' | 'h2'
     displayNamespace?: boolean
@@ -224,7 +224,7 @@ export const NamespaceBatchChangeListPage: React.FunctionComponent<NamespaceBatc
     )
 }
 
-interface BatchChangeListEmptyElementProps extends Pick<BatchChangeListPageProps, 'location' | 'canCreate'> {}
+interface BatchChangeListEmptyElementProps extends Pick<BatchChangeListPageProps, 'location' | 'canCreate'> { }
 
 const BatchChangeListEmptyElement: React.FunctionComponent<BatchChangeListEmptyElementProps> = ({
     canCreate,
@@ -298,7 +298,7 @@ const GettingStartedFooter: React.FunctionComponent<{}> = () => (
                 <CardBody className="text-center">
                     <p>Create your first batch change</p>
                     <h2 className="mb-0">
-                        <Link to="https://docs.sourcegraph.com/batch_changes/quickstart" target="_blank" rel="noopener">
+                        <Link to="/help/batch_changes/quickstart" target="_blank" rel="noopener">
                             Batch Changes quickstart
                         </Link>
                     </h2>

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -36,8 +36,8 @@ import { NewBatchChangeButton } from './NewBatchChangeButton'
 
 export interface BatchChangeListPageProps
     extends TelemetryProps,
-    Pick<RouteComponentProps, 'location'>,
-    SettingsCascadeProps<Settings> {
+        Pick<RouteComponentProps, 'location'>,
+        SettingsCascadeProps<Settings> {
     canCreate: boolean
     headingElement: 'h1' | 'h2'
     displayNamespace?: boolean

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -224,7 +224,7 @@ export const NamespaceBatchChangeListPage: React.FunctionComponent<NamespaceBatc
     )
 }
 
-interface BatchChangeListEmptyElementProps extends Pick<BatchChangeListPageProps, 'location' | 'canCreate'> { }
+interface BatchChangeListEmptyElementProps extends Pick<BatchChangeListPageProps, 'location' | 'canCreate'> {}
 
 const BatchChangeListEmptyElement: React.FunctionComponent<BatchChangeListEmptyElementProps> = ({
     canCreate,

--- a/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
@@ -17,7 +17,7 @@ export const BatchChangesChangelogAlert: React.FunctionComponent = () => (
                 <ul className="mb-0 pl-3">
                     <li>
                         <Link
-                            to="https://docs.sourcegraph.com/admin/config/batch_changes#forks"
+                            to="/help/admin/config/batch_changes#forks"
                             rel="noopener"
                             target="_blank"
                         >

--- a/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
@@ -17,10 +17,7 @@ export const BatchChangesChangelogAlert: React.FunctionComponent = () => (
                 <ul className="mb-0 pl-3">
                     <li>
                         <Link
-                            to="/help/admin/config/batch_changes#forks"
-                            rel="noopener"
-                            target="_blank"
-                        >
+                            to="/help/admin/config/batch_changes#forks" rel="noopener" target="_blank">
                             Batch Changes now supports pushing changesets to forked repositories.
                         </Link>
                     </li>

--- a/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
@@ -16,8 +16,7 @@ export const BatchChangesChangelogAlert: React.FunctionComponent = () => (
                 <h4>Batch Changes updates in version 3.36</h4>
                 <ul className="mb-0 pl-3">
                     <li>
-                        <Link
-                            to="/help/admin/config/batch_changes#forks" rel="noopener" target="_blank">
+                        <Link to="/help/admin/config/batch_changes#forks" rel="noopener" target="_blank">
                             Batch Changes now supports pushing changesets to forked repositories.
                         </Link>
                     </li>

--- a/client/web/src/enterprise/batches/list/GettingStarted.tsx
+++ b/client/web/src/enterprise/batches/list/GettingStarted.tsx
@@ -62,7 +62,7 @@ export const GettingStarted: React.FunctionComponent<GettingStartedProps> = ({ f
                         <div>
                             <h4>
                                 <Link
-                                    to="https://docs.sourcegraph.com/batch_changes/tutorials/search_and_replace_specific_terms"
+                                    to="/help/batch_changes/tutorials/search_and_replace_specific_terms"
                                     rel="noopener"
                                 >
                                     Finding and replacing exclusionary terms
@@ -83,7 +83,7 @@ export const GettingStarted: React.FunctionComponent<GettingStartedProps> = ({ f
                         <div>
                             <h4>
                                 <Link
-                                    to="https://docs.sourcegraph.com/batch_changes/tutorials/updating_go_import_statements"
+                                    to="/help/batch_changes/tutorials/updating_go_import_statements"
                                     rel="noopener"
                                 >
                                     Refactoring with language aware search
@@ -103,7 +103,7 @@ export const GettingStarted: React.FunctionComponent<GettingStartedProps> = ({ f
             </div>
             <div className="col-12 mb-4 text-right">
                 <p>
-                    <Link to="https://docs.sourcegraph.com/batch_changes/tutorials" rel="noopener">
+                    <Link to="/help/batch_changes/tutorials" rel="noopener">
                         More tutorials
                     </Link>
                 </p>
@@ -116,7 +116,7 @@ export const GettingStarted: React.FunctionComponent<GettingStartedProps> = ({ f
                     <strong>Quickstart</strong>
                 </p>
                 <p>Create your first Sourcegraph batch change in 10 minutes or less.</p>
-                <Link to="https://docs.sourcegraph.com/batch_changes/quickstart" rel="noopener">
+                <Link to="/help/batch_changes/quickstart" rel="noopener">
                     Batch Changes quickstart
                 </Link>
             </div>
@@ -127,24 +127,24 @@ export const GettingStarted: React.FunctionComponent<GettingStartedProps> = ({ f
                 <p>
                     Learn about the batch spec{' '}
                     <Link
-                        to="https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference"
+                        to="/help/batch_changes/references/batch_spec_yaml_reference"
                         rel="noopener"
                     >
                         YAML reference
                     </Link>
                     , its powerful{' '}
-                    <Link to="https://docs.sourcegraph.com/batch_changes/references/batch_spec_templating">
+                    <Link to="/help/batch_changes/references/batch_spec_templating">
                         templating language
                     </Link>
                     ,{' '}
                     <Link
-                        to="https://docs.sourcegraph.com/batch_changes/explanations/permissions_in_batch_changes"
+                        to="/help/batch_changes/explanations/permissions_in_batch_changes"
                         rel="noopener"
                     >
                         permissions
                     </Link>{' '}
                     and more in the{' '}
-                    <Link to="https://docs.sourcegraph.com/batch_changes" rel="noopener">
+                    <Link to="/help/batch_changes" rel="noopener">
                         Batch Changes documentation
                     </Link>
                     .

--- a/client/web/src/enterprise/batches/list/GettingStarted.tsx
+++ b/client/web/src/enterprise/batches/list/GettingStarted.tsx
@@ -82,8 +82,7 @@ export const GettingStarted: React.FunctionComponent<GettingStartedProps> = ({ f
                         <RefactorCombyIcon className="mr-3" />
                         <div>
                             <h4>
-                                <Link
-                                    to="/help/batch_changes/tutorials/updating_go_import_statements" rel="noopener">
+                                <Link to="/help/batch_changes/tutorials/updating_go_import_statements" rel="noopener">
                                     Refactoring with language aware search
                                 </Link>
                             </h4>
@@ -124,14 +123,12 @@ export const GettingStarted: React.FunctionComponent<GettingStartedProps> = ({ f
                 </p>
                 <p>
                     Learn about the batch spec{' '}
-                    <Link
-                        to="/help/batch_changes/references/batch_spec_yaml_reference" rel="noopener">
+                    <Link to="/help/batch_changes/references/batch_spec_yaml_reference" rel="noopener">
                         YAML reference
                     </Link>
                     , its powerful{' '}
                     <Link to="/help/batch_changes/references/batch_spec_templating">templating language</Link>,{' '}
-                    <Link
-                        to="/help/batch_changes/explanations/permissions_in_batch_changes" rel="noopener">
+                    <Link to="/help/batch_changes/explanations/permissions_in_batch_changes" rel="noopener">
                         permissions
                     </Link>{' '}
                     and more in the{' '}

--- a/client/web/src/enterprise/batches/list/GettingStarted.tsx
+++ b/client/web/src/enterprise/batches/list/GettingStarted.tsx
@@ -83,9 +83,7 @@ export const GettingStarted: React.FunctionComponent<GettingStartedProps> = ({ f
                         <div>
                             <h4>
                                 <Link
-                                    to="/help/batch_changes/tutorials/updating_go_import_statements"
-                                    rel="noopener"
-                                >
+                                    to="/help/batch_changes/tutorials/updating_go_import_statements" rel="noopener">
                                     Refactoring with language aware search
                                 </Link>
                             </h4>
@@ -127,20 +125,13 @@ export const GettingStarted: React.FunctionComponent<GettingStartedProps> = ({ f
                 <p>
                     Learn about the batch spec{' '}
                     <Link
-                        to="/help/batch_changes/references/batch_spec_yaml_reference"
-                        rel="noopener"
-                    >
+                        to="/help/batch_changes/references/batch_spec_yaml_reference" rel="noopener">
                         YAML reference
                     </Link>
                     , its powerful{' '}
-                    <Link to="/help/batch_changes/references/batch_spec_templating">
-                        templating language
-                    </Link>
-                    ,{' '}
+                    <Link to="/help/batch_changes/references/batch_spec_templating">templating language</Link>,{' '}
                     <Link
-                        to="/help/batch_changes/explanations/permissions_in_batch_changes"
-                        rel="noopener"
-                    >
+                        to="/help/batch_changes/explanations/permissions_in_batch_changes" rel="noopener">
                         permissions
                     </Link>{' '}
                     and more in the{' '}

--- a/client/web/src/enterprise/batches/settings/CodeHostConnections.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnections.tsx
@@ -46,9 +46,9 @@ export const CodeHostConnections: React.FunctionComponent<CodeHostConnectionsPro
                       after: args.after ?? null,
                   })
                 : queryGlobalBatchChangesCodeHosts({
-                    first: args.first ?? null,
-                    after: args.after ?? null,
-                }),
+                      first: args.first ?? null,
+                      after: args.after ?? null,
+                  }),
         [queryUserBatchChangesCodeHosts, queryGlobalBatchChangesCodeHosts, userID]
     )
     return (

--- a/client/web/src/enterprise/batches/settings/CodeHostConnections.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnections.tsx
@@ -41,14 +41,14 @@ export const CodeHostConnections: React.FunctionComponent<CodeHostConnectionsPro
         args =>
             userID
                 ? queryUserBatchChangesCodeHosts({
-                      user: userID,
-                      first: args.first ?? null,
-                      after: args.after ?? null,
-                  })
+                    user: userID,
+                    first: args.first ?? null,
+                    after: args.after ?? null,
+                })
                 : queryGlobalBatchChangesCodeHosts({
-                      first: args.first ?? null,
-                      after: args.after ?? null,
-                  }),
+                    first: args.first ?? null,
+                    after: args.after ?? null,
+                }),
         [queryUserBatchChangesCodeHosts, queryGlobalBatchChangesCodeHosts, userID]
     )
     return (
@@ -75,7 +75,7 @@ export const CodeHostConnections: React.FunctionComponent<CodeHostConnectionsPro
             <p className="mb-0">
                 Code host not present? Site admins can add a code host in{' '}
                 <Link
-                    to="https://docs.sourcegraph.com/admin/external_service"
+                    to="/help/admin/external_service"
                     target="_blank"
                     rel="noopener noreferrer"
                 >

--- a/client/web/src/enterprise/batches/settings/CodeHostConnections.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnections.tsx
@@ -41,10 +41,10 @@ export const CodeHostConnections: React.FunctionComponent<CodeHostConnectionsPro
         args =>
             userID
                 ? queryUserBatchChangesCodeHosts({
-                    user: userID,
-                    first: args.first ?? null,
-                    after: args.after ?? null,
-                })
+                      user: userID,
+                      first: args.first ?? null,
+                      after: args.after ?? null,
+                  })
                 : queryGlobalBatchChangesCodeHosts({
                     first: args.first ?? null,
                     after: args.after ?? null,

--- a/client/web/src/enterprise/batches/settings/CodeHostConnections.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnections.tsx
@@ -74,11 +74,7 @@ export const CodeHostConnections: React.FunctionComponent<CodeHostConnectionsPro
             />
             <p className="mb-0">
                 Code host not present? Site admins can add a code host in{' '}
-                <Link
-                    to="/help/admin/external_service"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                >
+                <Link to="/help/admin/external_service" target="_blank" rel="noopener noreferrer">
                     the manage repositories settings
                 </Link>
                 .

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
@@ -137,8 +137,7 @@ export const CodeMonitoringGettingStarted: React.FunctionComponent<CodeMonitorin
                                 Find specific examples of useful code monitors to keep on top of security and
                                 consistency concerns.
                             </p>
-                            <Link
-                                to="/help/code_monitoring/how-tos/starting_points" className="link">
+                            <Link to="/help/code_monitoring/how-tos/starting_points" className="link">
                                 Explore starting points
                             </Link>
                         </div>

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
@@ -125,7 +125,7 @@ export const CodeMonitoringGettingStarted: React.FunctionComponent<CodeMonitorin
                                 Craft searches that will monitor your code and trigger actions such as email
                                 notifications.
                             </p>
-                            <Link to="https://docs.sourcegraph.com/code_monitoring" className="link">
+                            <Link to="/help/code_monitoring" className="link">
                                 Code monitoring documentation
                             </Link>
                         </div>
@@ -138,7 +138,7 @@ export const CodeMonitoringGettingStarted: React.FunctionComponent<CodeMonitorin
                                 consistency concerns.
                             </p>
                             <Link
-                                to="https://docs.sourcegraph.com/code_monitoring/how-tos/starting_points"
+                                to="/help/code_monitoring/how-tos/starting_points"
                                 className="link"
                             >
                                 Explore starting points

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
@@ -138,9 +138,7 @@ export const CodeMonitoringGettingStarted: React.FunctionComponent<CodeMonitorin
                                 consistency concerns.
                             </p>
                             <Link
-                                to="/help/code_monitoring/how-tos/starting_points"
-                                className="link"
-                            >
+                                to="/help/code_monitoring/how-tos/starting_points" className="link">
                                 Explore starting points
                             </Link>
                         </div>

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
@@ -71,8 +71,7 @@ const AuthenticatedCreateCodeMonitorPage: React.FunctionComponent<CreateCodeMoni
                 description={
                     <>
                         Code monitors watch your code for specific triggers and run actions in response.{' '}
-                        <Link
-                            to="/help/code_monitoring/how-tos/starting_points" target="_blank" rel="noopener">
+                        <Link to="/help/code_monitoring/how-tos/starting_points" target="_blank" rel="noopener">
                             Learn more
                         </Link>
                     </>

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
@@ -72,7 +72,7 @@ const AuthenticatedCreateCodeMonitorPage: React.FunctionComponent<CreateCodeMoni
                     <>
                         Code monitors watch your code for specific triggers and run actions in response.{' '}
                         <Link
-                            to="https://docs.sourcegraph.com/code_monitoring/how-tos/starting_points"
+                            to="/help/code_monitoring/how-tos/starting_points"
                             target="_blank"
                             rel="noopener"
                         >

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
@@ -72,10 +72,7 @@ const AuthenticatedCreateCodeMonitorPage: React.FunctionComponent<CreateCodeMoni
                     <>
                         Code monitors watch your code for specific triggers and run actions in response.{' '}
                         <Link
-                            to="/help/code_monitoring/how-tos/starting_points"
-                            target="_blank"
-                            rel="noopener"
-                        >
+                            to="/help/code_monitoring/how-tos/starting_points" target="_blank" rel="noopener">
                             Learn more
                         </Link>
                     </>

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
@@ -95,7 +95,7 @@ const AuthenticatedManageCodeMonitorPage: React.FunctionComponent<ManageCodeMoni
                 description={
                     <>
                         Code monitors watch your code for specific triggers and run actions in response.{' '}
-                        <Link to="https://docs.sourcegraph.com/code_monitoring" target="_blank" rel="noopener">
+                        <Link to="/help/code_monitoring" target="_blank" rel="noopener">
                             Learn more
                         </Link>
                     </>

--- a/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.tsx
@@ -169,7 +169,7 @@ export const CodeMonitorForm: React.FunctionComponent<CodeMonitorFormProps> = ({
                             Give it a short, descriptive name to reference events on Sourcegraph and in notifications.
                             Do not include{' '}
                             <Link
-                                to="https://docs.sourcegraph.com/code_monitoring/explanations/best_practices#do-not-include-confidential-information-in-monitor-names"
+                                to="/help/code_monitoring/explanations/best_practices#do-not-include-confidential-information-in-monitor-names"
                                 target="_blank"
                                 rel="noopener"
                             >

--- a/client/web/src/enterprise/codeintel/configuration/components/EmptyPoliciesList.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/EmptyPoliciesList.tsx
@@ -9,7 +9,7 @@ export const EmptyPoliciesList: React.FunctionComponent = () => (
         <br />
         {'No policies have been defined.  Enable precise code intelligence by '}
         <Link
-            to="https://docs.sourcegraph.com/code_intelligence/how-to/configure_data_retention"
+            to="/help/code_intelligence/how-to/configure_data_retention"
             target="_blank"
             rel="noreferrer noopener"
         >

--- a/client/web/src/enterprise/codeintel/configuration/components/EmptyPoliciesList.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/EmptyPoliciesList.tsx
@@ -8,8 +8,7 @@ export const EmptyPoliciesList: React.FunctionComponent = () => (
         <MapSearchIcon className="mb-2" />
         <br />
         {'No policies have been defined.  Enable precise code intelligence by '}
-        <Link
-            to="/help/code_intelligence/how-to/configure_data_retention" target="_blank" rel="noreferrer noopener">
+        <Link to="/help/code_intelligence/how-to/configure_data_retention" target="_blank" rel="noreferrer noopener">
             configuring data retention policies
         </Link>
         .

--- a/client/web/src/enterprise/codeintel/configuration/components/EmptyPoliciesList.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/EmptyPoliciesList.tsx
@@ -9,10 +9,7 @@ export const EmptyPoliciesList: React.FunctionComponent = () => (
         <br />
         {'No policies have been defined.  Enable precise code intelligence by '}
         <Link
-            to="/help/code_intelligence/how-to/configure_data_retention"
-            target="_blank"
-            rel="noreferrer noopener"
-        >
+            to="/help/code_intelligence/how-to/configure_data_retention" target="_blank" rel="noreferrer noopener">
             configuring data retention policies
         </Link>
         .

--- a/client/web/src/enterprise/codeintel/indexes/components/EmptyAutoIndex.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/components/EmptyAutoIndex.tsx
@@ -9,7 +9,7 @@ export const EmptyAutoIndex: React.FunctionComponent = () => (
         <br />
         {'No indexes yet.  Enable precise code intelligence by '}
         <Link
-            to="https://docs.sourcegraph.com/code_intelligence/how-to/index_a_go_repository"
+            to="/help/code_intelligence/how-to/index_a_go_repository"
             target="_blank"
             rel="noreferrer noopener"
         >

--- a/client/web/src/enterprise/codeintel/indexes/components/EmptyAutoIndex.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/components/EmptyAutoIndex.tsx
@@ -9,10 +9,7 @@ export const EmptyAutoIndex: React.FunctionComponent = () => (
         <br />
         {'No indexes yet.  Enable precise code intelligence by '}
         <Link
-            to="/help/code_intelligence/how-to/index_a_go_repository"
-            target="_blank"
-            rel="noreferrer noopener"
-        >
+            to="/help/code_intelligence/how-to/index_a_go_repository" target="_blank" rel="noreferrer noopener">
             auto-indexing LSIF data
         </Link>
         .

--- a/client/web/src/enterprise/codeintel/indexes/components/EmptyAutoIndex.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/components/EmptyAutoIndex.tsx
@@ -8,8 +8,7 @@ export const EmptyAutoIndex: React.FunctionComponent = () => (
         <MapSearchIcon className="mb-2" />
         <br />
         {'No indexes yet.  Enable precise code intelligence by '}
-        <Link
-            to="/help/code_intelligence/how-to/index_a_go_repository" target="_blank" rel="noreferrer noopener">
+        <Link to="/help/code_intelligence/how-to/index_a_go_repository" target="_blank" rel="noreferrer noopener">
             auto-indexing LSIF data
         </Link>
         .

--- a/client/web/src/enterprise/codeintel/uploads/components/EmptyUploads.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/EmptyUploads.tsx
@@ -9,7 +9,7 @@ export const EmptyUploads: React.FunctionComponent = () => (
         <br />
         No uploads yet. Enable precise code intelligence by{' '}
         <Link
-            to="https://docs.sourcegraph.com/code_intelligence/explanations/precise_code_intelligence"
+            to="/help/code_intelligence/explanations/precise_code_intelligence"
             target="_blank"
             rel="noreferrer noopener"
         >

--- a/client/web/src/enterprise/executors/ExecutorsListPage.tsx
+++ b/client/web/src/enterprise/executors/ExecutorsListPage.tsx
@@ -80,15 +80,15 @@ export const ExecutorsListPage: FunctionComponent<ExecutorsListPageProps> = ({
                 <h3>Setting up executors</h3>
                 <p className="mb-0">
                     Executors enable{' '}
-                    <Link to="https://docs.sourcegraph.com/code_intelligence/explanations/auto_indexing" rel="noopener">
+                    <Link to="/help/code_intelligence/explanations/auto_indexing" rel="noopener">
                         auto-indexing for Code Intelligence
                     </Link>{' '}
                     and{' '}
-                    <Link to="https://docs.sourcegraph.com/batch_changes/explanations/server_side" rel="noopener">
+                    <Link to="/help/batch_changes/explanations/server_side" rel="noopener">
                         server-side Batch Changes
                     </Link>
                     . In order to use those features,{' '}
-                    <Link to="https://docs.sourcegraph.com/admin/deploy_executors" rel="noopener">
+                    <Link to="/help/admin/deploy_executors" rel="noopener">
                         set them up
                     </Link>
                     .

--- a/client/web/src/enterprise/extensions/registry/RegistryNewExtensionPage.tsx
+++ b/client/web/src/enterprise/extensions/registry/RegistryNewExtensionPage.tsx
@@ -168,11 +168,11 @@ export const RegistryNewExtensionPage = withAuthenticatedUser(
                             <PuzzleIcon className="icon-inline" /> New extension
                         </h2>
                         <div className="mb-3">
-                            <Link target="_blank" rel="noopener" to="https://docs.sourcegraph.com/extensions/authoring">
+                            <Link target="_blank" rel="noopener" to="/help/extensions/authoring">
                                 Learn more
                             </Link>{' '}
                             about authoring Sourcegraph extensions{' '}
-                            <Link target="_blank" rel="noopener" to="https://docs.sourcegraph.com/extensions/authoring">
+                            <Link target="_blank" rel="noopener" to="/help/extensions/authoring">
                                 <HelpCircleOutline className="icon-inline" />
                             </Link>
                         </div>

--- a/client/web/src/enterprise/insights/components/beta-feedback-panel/BetaFeedbackPanel.tsx
+++ b/client/web/src/enterprise/insights/components/beta-feedback-panel/BetaFeedbackPanel.tsx
@@ -11,7 +11,7 @@ export const BetaFeedbackPanel: React.FunctionComponent = () => {
 
     return (
         <div className="d-flex align-items-center">
-            <Link to="https://docs.sourcegraph.com/code_insights#code-insights-beta" target="_blank" rel="noopener">
+            <Link to="/help/code_insights#code-insights-beta" target="_blank" rel="noopener">
                 <ProductStatusBadge status="beta" className="text-uppercase" />
             </Link>
 

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/components/drill-down-filters-form/DrillDownFiltersForm.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/components/drill-down-filters-form/DrillDownFiltersForm.tsx
@@ -166,8 +166,8 @@ export const DrillDownFiltersForm: React.FunctionComponent<DrillDownFiltersFormP
                                 ? 'Updating'
                                 : 'Saving'
                             : hasAppliedFilters
-                                ? 'Update default filters'
-                                : 'Save default filters'
+                            ? 'Update default filters'
+                            : 'Save default filters'
                     }
                     type="submit"
                     disabled={formAPI.submitting || !hasFiltersChanged}

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/components/drill-down-filters-form/DrillDownFiltersForm.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/components/drill-down-filters-form/DrillDownFiltersForm.tsx
@@ -102,7 +102,7 @@ export const DrillDownFiltersForm: React.FunctionComponent<DrillDownFiltersFormP
                     <small className="ml-auto">
                         <span className="text-muted">Default filters applied</span>{' '}
                         <Link
-                            to="https://docs.sourcegraph.com/code_insights/explanations/code_insights_filters"
+                            to="/help/code_insights/explanations/code_insights_filters"
                             target="_blank"
                             rel="noopener"
                             className="small"
@@ -166,8 +166,8 @@ export const DrillDownFiltersForm: React.FunctionComponent<DrillDownFiltersFormP
                                 ? 'Updating'
                                 : 'Saving'
                             : hasAppliedFilters
-                            ? 'Update default filters'
-                            : 'Save default filters'
+                                ? 'Update default filters'
+                                : 'Save default filters'
                     }
                     type="submit"
                     disabled={formAPI.submitting || !hasFiltersChanged}

--- a/client/web/src/enterprise/insights/modals/BetaConfirmationModal.tsx
+++ b/client/web/src/enterprise/insights/modals/BetaConfirmationModal.tsx
@@ -72,7 +72,7 @@ export const BetaConfirmationModalContent: React.FunctionComponent<BetaConfirmat
                 <p>
                     We're still polishing Code Insights and you might find bugs while we’re in beta. Please{' '}
                     <Link
-                        to="https://docs.sourcegraph.com/code_insights#code-insights-beta"
+                        to="/help/code_insights#code-insights-beta"
                         target="_blank"
                         rel="noopener"
                     >

--- a/client/web/src/enterprise/insights/modals/BetaConfirmationModal.tsx
+++ b/client/web/src/enterprise/insights/modals/BetaConfirmationModal.tsx
@@ -71,8 +71,7 @@ export const BetaConfirmationModalContent: React.FunctionComponent<BetaConfirmat
 
                 <p>
                     We're still polishing Code Insights and you might find bugs while we’re in beta. Please{' '}
-                    <Link
-                        to="/help/code_insights#code-insights-beta" target="_blank" rel="noopener">
+                    <Link to="/help/code_insights#code-insights-beta" target="_blank" rel="noopener">
                         share any bugs 🐛 or feedback
                     </Link>{' '}
                     to help us make Code Insights better.

--- a/client/web/src/enterprise/insights/modals/BetaConfirmationModal.tsx
+++ b/client/web/src/enterprise/insights/modals/BetaConfirmationModal.tsx
@@ -72,10 +72,7 @@ export const BetaConfirmationModalContent: React.FunctionComponent<BetaConfirmat
                 <p>
                     We're still polishing Code Insights and you might find bugs while we’re in beta. Please{' '}
                     <Link
-                        to="/help/code_insights#code-insights-beta"
-                        target="_blank"
-                        rel="noopener"
-                    >
+                        to="/help/code_insights#code-insights-beta" target="_blank" rel="noopener">
                         share any bugs 🐛 or feedback
                     </Link>{' '}
                     to help us make Code Insights better.

--- a/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
@@ -19,7 +19,7 @@ import {
 } from './components/insights-dashboard-creation-content/InsightsDashboardCreationContent'
 import styles from './InsightsDashboardCreationPage.module.scss'
 
-interface InsightsDashboardCreationPageProps extends TelemetryProps { }
+interface InsightsDashboardCreationPageProps extends TelemetryProps {}
 
 export const InsightsDashboardCreationPage: React.FunctionComponent<InsightsDashboardCreationPageProps> = props => {
     const { telemetryService } = props

--- a/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
@@ -19,7 +19,7 @@ import {
 } from './components/insights-dashboard-creation-content/InsightsDashboardCreationContent'
 import styles from './InsightsDashboardCreationPage.module.scss'
 
-interface InsightsDashboardCreationPageProps extends TelemetryProps {}
+interface InsightsDashboardCreationPageProps extends TelemetryProps { }
 
 export const InsightsDashboardCreationPage: React.FunctionComponent<InsightsDashboardCreationPageProps> = props => {
     const { telemetryService } = props
@@ -60,7 +60,7 @@ export const InsightsDashboardCreationPage: React.FunctionComponent<InsightsDash
             <span className="text-muted d-block mt-2">
                 Dashboards group your insights and let you share them with others.{' '}
                 <Link
-                    to="https://docs.sourcegraph.com/code_insights/explanations/viewing_code_insights"
+                    to="/help/code_insights/explanations/viewing_code_insights"
                     target="_blank"
                     rel="noopener"
                 >

--- a/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
@@ -60,10 +60,7 @@ export const InsightsDashboardCreationPage: React.FunctionComponent<InsightsDash
             <span className="text-muted d-block mt-2">
                 Dashboards group your insights and let you share them with others.{' '}
                 <Link
-                    to="/help/code_insights/explanations/viewing_code_insights"
-                    target="_blank"
-                    rel="noopener"
-                >
+                    to="/help/code_insights/explanations/viewing_code_insights" target="_blank" rel="noopener">
                     Learn more.
                 </Link>
             </span>

--- a/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
@@ -59,8 +59,7 @@ export const InsightsDashboardCreationPage: React.FunctionComponent<InsightsDash
 
             <span className="text-muted d-block mt-2">
                 Dashboards group your insights and let you share them with others.{' '}
-                <Link
-                    to="/help/code_insights/explanations/viewing_code_insights" target="_blank" rel="noopener">
+                <Link to="/help/code_insights/explanations/viewing_code_insights" target="_blank" rel="noopener">
                     Learn more.
                 </Link>
             </span>

--- a/client/web/src/enterprise/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
@@ -109,10 +109,7 @@ export const EditDashboardPage: React.FunctionComponent<EditDashboardPageProps> 
             <span className="text-muted d-block mt-2">
                 Dashboards group your insights and let you share them with others.{' '}
                 <Link
-                    to="/help/code_insights/explanations/viewing_code_insights"
-                    target="_blank"
-                    rel="noopener"
-                >
+                    to="/help/code_insights/explanations/viewing_code_insights" target="_blank" rel="noopener">
                     Learn more.
                 </Link>
             </span>

--- a/client/web/src/enterprise/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
@@ -108,8 +108,7 @@ export const EditDashboardPage: React.FunctionComponent<EditDashboardPageProps> 
 
             <span className="text-muted d-block mt-2">
                 Dashboards group your insights and let you share them with others.{' '}
-                <Link
-                    to="/help/code_insights/explanations/viewing_code_insights" target="_blank" rel="noopener">
+                <Link to="/help/code_insights/explanations/viewing_code_insights" target="_blank" rel="noopener">
                     Learn more.
                 </Link>
             </span>

--- a/client/web/src/enterprise/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
@@ -109,7 +109,7 @@ export const EditDashboardPage: React.FunctionComponent<EditDashboardPageProps> 
             <span className="text-muted d-block mt-2">
                 Dashboards group your insights and let you share them with others.{' '}
                 <Link
-                    to="https://docs.sourcegraph.com/code_insights/explanations/viewing_code_insights"
+                    to="/help/code_insights/explanations/viewing_code_insights"
                     target="_blank"
                     rel="noopener"
                 >

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/CaptureGroupCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/CaptureGroupCreationPage.tsx
@@ -65,7 +65,7 @@ export const CaptureGroupCreationPage: React.FunctionComponent<CaptureGroupCreat
 
                 <p className="text-muted">
                     Search-based code insights analyze your code based on any search query.{' '}
-                    <Link to="https://docs.sourcegraph.com/code_insights" target="_blank" rel="noopener">
+                    <Link to="/help/code_insights" target="_blank" rel="noopener">
                         Learn more.
                     </Link>
                 </p>

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/CaptureGoupCreationForm.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/CaptureGoupCreationForm.tsx
@@ -92,7 +92,7 @@ export const CaptureGroupCreationForm: React.FunctionComponent<CaptureGroupCreat
                     <small className="w-100 mt-2 text-muted">
                         This feature is actively in development. Read about the{' '}
                         <Link
-                            to="https://docs.sourcegraph.com/code_insights/explanations/current_limitations_of_code_insights"
+                            to="/help/code_insights/explanations/current_limitations_of_code_insights"
                             target="_blank"
                             rel="noopener noreferrer"
                         >
@@ -111,7 +111,7 @@ export const CaptureGroupCreationForm: React.FunctionComponent<CaptureGroupCreat
                     <>
                         Generated dynamically for each unique value from the regular expression capture group.{' '}
                         <Link
-                            to="https://docs.sourcegraph.com/code_insights/explanations/automatically_generated_data_series"
+                            to="/help/code_insights/explanations/automatically_generated_data_series"
                             target="_blank"
                             rel="noopener"
                         >
@@ -144,7 +144,7 @@ export const CaptureGroupCreationForm: React.FunctionComponent<CaptureGroupCreat
                     <small className="mt-3">
                         Explore{' '}
                         <Link
-                            to="https://docs.sourcegraph.com/code_insights/references/common_use_cases#automatic-version-and-pattern-tracking"
+                            to="/help/code_insights/references/common_use_cases#automatic-version-and-pattern-tracking"
                             target="_blank"
                             rel="noopener noreferrer"
                         >
@@ -152,7 +152,7 @@ export const CaptureGroupCreationForm: React.FunctionComponent<CaptureGroupCreat
                         </Link>{' '}
                         and learn more about{' '}
                         <Link
-                            to="https://docs.sourcegraph.com/code_insights/explanations/automatically_generated_data_series"
+                            to="/help/code_insights/explanations/automatically_generated_data_series"
                             target="_blank"
                             rel="noopener noreferrer"
                         >
@@ -225,7 +225,7 @@ const QueryFieldSubtitle: React.FunctionComponent<{ className?: string }> = prop
     <small className={classNames(props.className, 'text-muted', 'd-block', 'font-weight-normal')}>
         Search query must contain a properly formatted regular expression with at least one{' '}
         <Link
-            to="https://docs.sourcegraph.com/code_insights/explanations/automatically_generated_data_series#regular-expression-capture-group-resources"
+            to="/help/code_insights/explanations/automatically_generated_data_series#regular-expression-capture-group-resources"
             target="_blank"
             rel="noopener"
         >

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
@@ -20,7 +20,7 @@ import {
 } from './cards/InsightCards'
 import styles from './IntroCreationPage.module.scss'
 
-interface IntroCreationPageProps extends TelemetryProps {}
+interface IntroCreationPageProps extends TelemetryProps { }
 
 /** Displays intro page for insights creation UI. */
 export const IntroCreationPage: React.FunctionComponent<IntroCreationPageProps> = props => {
@@ -64,7 +64,7 @@ export const IntroCreationPage: React.FunctionComponent<IntroCreationPageProps> 
                 description={
                     <>
                         Insights analyze your code based on any search query.{' '}
-                        <Link to="https://docs.sourcegraph.com/code_insights" target="_blank" rel="noopener">
+                        <Link to="/help/code_insights" target="_blank" rel="noopener">
                             Learn more
                         </Link>
                     </>
@@ -90,7 +90,7 @@ export const IntroCreationPage: React.FunctionComponent<IntroCreationPageProps> 
                 <div className={styles.info}>
                     Not sure which insight type to choose? Learn more about the{' '}
                     <Link
-                        to="https://docs.sourcegraph.com/code_insights/references/common_use_cases"
+                        to="/help/code_insights/references/common_use_cases"
                         target="_blank"
                         rel="noopener"
                     >

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
@@ -90,10 +90,7 @@ export const IntroCreationPage: React.FunctionComponent<IntroCreationPageProps> 
                 <div className={styles.info}>
                     Not sure which insight type to choose? Learn more about the{' '}
                     <Link
-                        to="/help/code_insights/references/common_use_cases"
-                        target="_blank"
-                        rel="noopener"
-                    >
+                        to="/help/code_insights/references/common_use_cases" target="_blank" rel="noopener">
                         use cases.
                     </Link>
                 </div>

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
@@ -89,8 +89,7 @@ export const IntroCreationPage: React.FunctionComponent<IntroCreationPageProps> 
 
                 <div className={styles.info}>
                     Not sure which insight type to choose? Learn more about the{' '}
-                    <Link
-                        to="/help/code_insights/references/common_use_cases" target="_blank" rel="noopener">
+                    <Link to="/help/code_insights/references/common_use_cases" target="_blank" rel="noopener">
                         use cases.
                     </Link>
                 </div>

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
@@ -20,7 +20,7 @@ import {
 } from './cards/InsightCards'
 import styles from './IntroCreationPage.module.scss'
 
-interface IntroCreationPageProps extends TelemetryProps { }
+interface IntroCreationPageProps extends TelemetryProps {}
 
 /** Displays intro page for insights creation UI. */
 export const IntroCreationPage: React.FunctionComponent<IntroCreationPageProps> = props => {

--- a/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.tsx
@@ -116,7 +116,7 @@ export const LangStatsInsightCreationPage: React.FunctionComponent<LangStatsInsi
 
                 <p className="text-muted">
                     Shows language usage in your repository based on number of lines of code.{' '}
-                    <Link to="https://docs.sourcegraph.com/code_insights" target="_blank" rel="noopener">
+                    <Link to="/help/code_insights" target="_blank" rel="noopener">
                         Learn more.
                     </Link>
                 </p>

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/SearchInsightCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/SearchInsightCreationPage.tsx
@@ -126,7 +126,7 @@ export const SearchInsightCreationPage: React.FunctionComponent<SearchInsightCre
 
                             <p className="text-muted">
                                 Search-based code insights analyze your code based on any search query.{' '}
-                                <Link to="https://docs.sourcegraph.com/code_insights" target="_blank" rel="noopener">
+                                <Link to="/help/code_insights" target="_blank" rel="noopener">
                                     Learn more.
                                 </Link>
                             </p>

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
@@ -190,7 +190,7 @@ const QueryFieldDescription: React.FunctionComponent<{ isSearchQueryDisabled: bo
                 We don't yet allow editing queries for insights over all repos. To change the query, make a new insight.
                 This is a known{' '}
                 <Link
-                    to="https://docs.sourcegraph.com/code_insights/explanations/current_limitations_of_code_insights"
+                    to="/help/code_insights/explanations/current_limitations_of_code_insights"
                     target="_blank"
                     rel="noopener noreferrer"
                 >

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
@@ -136,7 +136,7 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
                     <small className="w-100 mt-2 text-muted">
                         This feature is actively in development. Read about the{' '}
                         <Link
-                            to="https://docs.sourcegraph.com/code_insights/explanations/current_limitations_of_code_insights"
+                            to="/help/code_insights/explanations/current_limitations_of_code_insights"
                             target="_blank"
                             rel="noopener noreferrer"
                         >

--- a/client/web/src/enterprise/insights/pages/insights/edit-insight/EditInsightPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/edit-insight/EditInsightPage.tsx
@@ -67,7 +67,7 @@ export const EditInsightPage: React.FunctionComponent<EditInsightPageProps> = pr
 
                 <p className="text-muted">
                     Insights analyze your code based on any search query.{' '}
-                    <Link to="https://docs.sourcegraph.com/code_insights" target="_blank" rel="noopener">
+                    <Link to="/help/code_insights" target="_blank" rel="noopener">
                         Learn more.
                     </Link>
                 </p>

--- a/client/web/src/enterprise/searchContexts/CreateSearchContextPage.tsx
+++ b/client/web/src/enterprise/searchContexts/CreateSearchContextPage.tsx
@@ -25,10 +25,10 @@ import { SearchContextForm } from './SearchContextForm'
 
 export interface CreateSearchContextPageProps
     extends RouteComponentProps,
-        ThemeProps,
-        TelemetryProps,
-        Pick<SearchContextProps, 'createSearchContext' | 'deleteSearchContext'>,
-        PlatformContextProps<'requestGraphQL'> {
+    ThemeProps,
+    TelemetryProps,
+    Pick<SearchContextProps, 'createSearchContext' | 'deleteSearchContext'>,
+    PlatformContextProps<'requestGraphQL'> {
     authenticatedUser: AuthenticatedUser
     isSourcegraphDotCom: boolean
 }
@@ -73,7 +73,7 @@ export const AuthenticatedCreateSearchContextPage: React.FunctionComponent<Creat
                                 A search context represents a group of repositories at specified branches or revisions
                                 that will be targeted by search queries.{' '}
                                 <Link
-                                    to="https://docs.sourcegraph.com/code_search/explanations/features#search-contexts"
+                                    to="/help/code_search/explanations/features#search-contexts"
                                     target="_blank"
                                     rel="noopener noreferrer"
                                 >

--- a/client/web/src/enterprise/searchContexts/CreateSearchContextPage.tsx
+++ b/client/web/src/enterprise/searchContexts/CreateSearchContextPage.tsx
@@ -25,10 +25,10 @@ import { SearchContextForm } from './SearchContextForm'
 
 export interface CreateSearchContextPageProps
     extends RouteComponentProps,
-    ThemeProps,
-    TelemetryProps,
-    Pick<SearchContextProps, 'createSearchContext' | 'deleteSearchContext'>,
-    PlatformContextProps<'requestGraphQL'> {
+        ThemeProps,
+        TelemetryProps,
+        Pick<SearchContextProps, 'createSearchContext' | 'deleteSearchContext'>,
+        PlatformContextProps<'requestGraphQL'> {
     authenticatedUser: AuthenticatedUser
     isSourcegraphDotCom: boolean
 }

--- a/client/web/src/enterprise/searchContexts/SearchContextsListPage.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextsListPage.tsx
@@ -15,10 +15,10 @@ import { SearchContextsListTab } from './SearchContextsListTab'
 
 export interface SearchContextsListPageProps
     extends Pick<
-    SearchContextProps,
-    'fetchSearchContexts' | 'fetchAutoDefinedSearchContexts' | 'getUserSearchContextNamespaces'
-    >,
-    PlatformContextProps<'requestGraphQL'> {
+             SearchContextProps,
+             'fetchSearchContexts' | 'fetchAutoDefinedSearchContexts' | 'getUserSearchContextNamespaces'
+        >,
+        PlatformContextProps<'requestGraphQL'> {
     location: H.Location
     history: H.History
     isSourcegraphDotCom: boolean

--- a/client/web/src/enterprise/searchContexts/SearchContextsListPage.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextsListPage.tsx
@@ -15,8 +15,8 @@ import { SearchContextsListTab } from './SearchContextsListTab'
 
 export interface SearchContextsListPageProps
     extends Pick<
-             SearchContextProps,
-             'fetchSearchContexts' | 'fetchAutoDefinedSearchContexts' | 'getUserSearchContextNamespaces'
+            SearchContextProps,
+            'fetchSearchContexts' | 'fetchAutoDefinedSearchContexts' | 'getUserSearchContextNamespaces'
         >,
         PlatformContextProps<'requestGraphQL'> {
     location: H.Location

--- a/client/web/src/enterprise/searchContexts/SearchContextsListPage.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextsListPage.tsx
@@ -15,10 +15,10 @@ import { SearchContextsListTab } from './SearchContextsListTab'
 
 export interface SearchContextsListPageProps
     extends Pick<
-            SearchContextProps,
-            'fetchSearchContexts' | 'fetchAutoDefinedSearchContexts' | 'getUserSearchContextNamespaces'
-        >,
-        PlatformContextProps<'requestGraphQL'> {
+    SearchContextProps,
+    'fetchSearchContexts' | 'fetchAutoDefinedSearchContexts' | 'getUserSearchContextNamespaces'
+    >,
+    PlatformContextProps<'requestGraphQL'> {
     location: H.Location
     history: H.History
     isSourcegraphDotCom: boolean
@@ -86,7 +86,7 @@ export const SearchContextsListPage: React.FunctionComponent<SearchContextsListP
                         <span className="text-muted">
                             Search code you care about with search contexts.{' '}
                             <Link
-                                to="https://docs.sourcegraph.com/code_search/explanations/features#search-contexts"
+                                to="/help/code_search/explanations/features#search-contexts"
                                 target="_blank"
                                 rel="noopener noreferrer"
                             >

--- a/client/web/src/enterprise/site-admin/SiteAdminAuthenticationProvidersPage.tsx
+++ b/client/web/src/enterprise/site-admin/SiteAdminAuthenticationProvidersPage.tsx
@@ -82,8 +82,8 @@ export class SiteAdminAuthenticationProvidersPage extends React.Component<Props>
                 <h2>Authentication providers</h2>
                 <p>
                     Authentication providers allow users to sign into Sourcegraph. See{' '}
-                    <Link to="/help/admin/auth">authentication documentation</Link> about
-                    configuring single-sign-on (SSO) via SAML and OpenID Connect. Configure authentication providers in
+                    <Link to="/help/admin/auth">authentication documentation</Link> about configuring single-sign-on (SSO)
+                    via SAML and OpenID Connect. Configure authentication providers in
                     the <Link to="/help/admin/config/site_config">site configuration</Link>.
                 </p>
                 <FilteredAuthProviderConnection

--- a/client/web/src/enterprise/site-admin/SiteAdminAuthenticationProvidersPage.tsx
+++ b/client/web/src/enterprise/site-admin/SiteAdminAuthenticationProvidersPage.tsx
@@ -63,9 +63,9 @@ const authProviderFragment = gql`
     }
 `
 
-interface Props extends RouteComponentProps<{}> {}
+interface Props extends RouteComponentProps<{}> { }
 
-class FilteredAuthProviderConnection extends FilteredConnection<GQL.IAuthProvider> {}
+class FilteredAuthProviderConnection extends FilteredConnection<GQL.IAuthProvider> { }
 
 /**
  * A page displaying the auth providers in site configuration.
@@ -82,9 +82,9 @@ export class SiteAdminAuthenticationProvidersPage extends React.Component<Props>
                 <h2>Authentication providers</h2>
                 <p>
                     Authentication providers allow users to sign into Sourcegraph. See{' '}
-                    <Link to="https://docs.sourcegraph.com/admin/auth">authentication documentation</Link> about
+                    <Link to="/help/admin/auth">authentication documentation</Link> about
                     configuring single-sign-on (SSO) via SAML and OpenID Connect. Configure authentication providers in
-                    the <Link to="https://docs.sourcegraph.com/admin/config/site_config">site configuration</Link>.
+                    the <Link to="/help/admin/config/site_config">site configuration</Link>.
                 </p>
                 <FilteredAuthProviderConnection
                     className="list-group list-group-flush mt-3"

--- a/client/web/src/enterprise/site-admin/SiteAdminAuthenticationProvidersPage.tsx
+++ b/client/web/src/enterprise/site-admin/SiteAdminAuthenticationProvidersPage.tsx
@@ -63,9 +63,9 @@ const authProviderFragment = gql`
     }
 `
 
-interface Props extends RouteComponentProps<{}> { }
+interface Props extends RouteComponentProps<{}> {}
 
-class FilteredAuthProviderConnection extends FilteredConnection<GQL.IAuthProvider> { }
+class FilteredAuthProviderConnection extends FilteredConnection<GQL.IAuthProvider> {}
 
 /**
  * A page displaying the auth providers in site configuration.

--- a/client/web/src/enterprise/site-admin/SiteAdminAuthenticationProvidersPage.tsx
+++ b/client/web/src/enterprise/site-admin/SiteAdminAuthenticationProvidersPage.tsx
@@ -82,9 +82,9 @@ export class SiteAdminAuthenticationProvidersPage extends React.Component<Props>
                 <h2>Authentication providers</h2>
                 <p>
                     Authentication providers allow users to sign into Sourcegraph. See{' '}
-                    <Link to="/help/admin/auth">authentication documentation</Link> about configuring single-sign-on (SSO)
-                    via SAML and OpenID Connect. Configure authentication providers in
-                    the <Link to="/help/admin/config/site_config">site configuration</Link>.
+                    <Link to="/help/admin/auth">authentication documentation</Link> about configuring single-sign-on
+                    (SSO) via SAML and OpenID Connect. Configure authentication providers in the{' '}
+                    <Link to="/help/admin/config/site_config">site configuration</Link>.
                 </p>
                 <FilteredAuthProviderConnection
                     className="list-group list-group-flush mt-3"


### PR DESCRIPTION
Pulling them out of /enterprise first. [Context here](https://sourcegraph.slack.com/archives/C0C324C91/p1641855680027300) .

Will have a followup PR for links outside the enterprise folder. 
