### PR TITLE
bext: add "https://" URL input placeholder

### DIFF
--- a/client/browser/CHANGELOG.md
+++ b/client/browser/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to Sourcegraph [Browser Extensions](./README.md) are documen
 
 ## Unreleased
 
+- Add "https://" URL input placeholder [#pull/30282](https://github.com/sourcegraph/sourcegraph/pull/30282), [#issues/14723](https://github.com/sourcegraph/sourcegraph/issues/14723)
+
 ## Chrome & Firefox v22.1.25.1535, Safari v1.10
 
 - Add extra field to log browser extension version [#issues/27845](https://github.com/sourcegraph/sourcegraph/issues/27845), [pull/27902](https://github.com/sourcegraph/sourcegraph/pull/27902)

--- a/client/browser/src/browser-extension/options-menu/OptionsPage.tsx
+++ b/client/browser/src/browser-extension/options-menu/OptionsPage.tsx
@@ -284,7 +284,7 @@ export const SourcegraphURLForm: React.FunctionComponent<SourcegraphURLFormProps
     const handleInputChange = useCallback(
         (event: React.ChangeEvent<HTMLInputElement>) => {
             if (!event.target.value.startsWith('https://')) {
-                event.target.value = 'https://'
+                event.target.value = `https://${event.target.value}`
             }
             nextUrlFieldChange(event)
         },

--- a/client/browser/src/browser-extension/options-menu/OptionsPage.tsx
+++ b/client/browser/src/browser-extension/options-menu/OptionsPage.tsx
@@ -281,6 +281,16 @@ export const SourcegraphURLForm: React.FunctionComponent<SourcegraphURLFormProps
         }
     }, [onChange, urlState])
 
+    const handleInputChange = useCallback(
+        (event: React.ChangeEvent<HTMLInputElement>) => {
+            if (!event.target.value.startsWith('https://')) {
+                event.target.value = 'https://'
+            }
+            nextUrlFieldChange(event)
+        },
+        [nextUrlFieldChange]
+    )
+
     return (
         // eslint-disable-next-line react/forbid-elements
         <form onSubmit={preventDefault} noValidate={true}>
@@ -298,7 +308,7 @@ export const SourcegraphURLForm: React.FunctionComponent<SourcegraphURLFormProps
                         id="sourcegraph-url"
                         ref={urlInputElements}
                         value={urlState.value}
-                        onChange={nextUrlFieldChange}
+                        onChange={handleInputChange}
                         className={classNames('form-control', 'test-sourcegraph-url', deriveInputClassName(urlState))}
                     />
                 </LoaderInput>

--- a/client/browser/src/browser-extension/options-menu/OptionsPage.tsx
+++ b/client/browser/src/browser-extension/options-menu/OptionsPage.tsx
@@ -281,17 +281,6 @@ export const SourcegraphURLForm: React.FunctionComponent<SourcegraphURLFormProps
         }
     }, [onChange, urlState])
 
-    const handleInputChange = useCallback(
-        (event: React.ChangeEvent<HTMLInputElement>) => {
-            if (!event.target.value.startsWith('https://')) {
-                // TODO: handle pasting URLs starting with 'http://'
-                event.target.value = `https://${event.target.value}`
-            }
-            nextUrlFieldChange(event)
-        },
-        [nextUrlFieldChange]
-    )
-
     return (
         // eslint-disable-next-line react/forbid-elements
         <form onSubmit={preventDefault} noValidate={true}>
@@ -305,11 +294,12 @@ export const SourcegraphURLForm: React.FunctionComponent<SourcegraphURLFormProps
                         autoComplete="off"
                         autocomplete={false}
                         pattern="^https://.*"
+                        placeholder="https://"
                         onFocus={onFocus}
                         id="sourcegraph-url"
                         ref={urlInputElements}
                         value={urlState.value}
-                        onChange={handleInputChange}
+                        onChange={nextUrlFieldChange}
                         className={classNames('form-control', 'test-sourcegraph-url', deriveInputClassName(urlState))}
                     />
                 </LoaderInput>

--- a/client/browser/src/browser-extension/options-menu/OptionsPage.tsx
+++ b/client/browser/src/browser-extension/options-menu/OptionsPage.tsx
@@ -284,6 +284,7 @@ export const SourcegraphURLForm: React.FunctionComponent<SourcegraphURLFormProps
     const handleInputChange = useCallback(
         (event: React.ChangeEvent<HTMLInputElement>) => {
             if (!event.target.value.startsWith('https://')) {
+                // TODO: handle pasting URLs starting with 'http://'
                 event.target.value = `https://${event.target.value}`
             }
             nextUrlFieldChange(event)


### PR DESCRIPTION
Closes [#14723](https://github.com/sourcegraph/sourcegraph/issues/14723)

**Description**

Currently user can delete `'https://'` prefix in the browser extension URL input which [is not expected behavior](https://github.com/sourcegraph/sourcegraph/issues/14723#issue-721549364).

## Screenshots

| Before  | After |
| --: | :-- |
| ![image](https://user-images.githubusercontent.com/6717049/152516297-685e0def-4005-4188-8a77-491182d84b61.png) | ![image](https://user-images.githubusercontent.com/6717049/152516158-20d691c5-40e0-4896-b663-a32a95d60fe2.png)|

**How to test**
- `sg run bext`
- Remove bext URL and check that there is a placholder