### PR TITLE
web: Fix onboarding tour language picker capitalization

### DIFF
--- a/client/web/src/stores/onboardingTourState.ts
+++ b/client/web/src/stores/onboardingTourState.ts
@@ -7,10 +7,10 @@ export enum OnboardingTourLanguage {
     C = 'C',
     Go = 'Go',
     Java = 'Java',
-    Javascript = 'Javascript',
-    Php = 'Php',
+    Javascript = 'JavaScript',
+    Php = 'PHP',
     Python = 'Python',
-    Typescript = 'Typescript',
+    Typescript = 'TypeScript',
 }
 
 export interface OnboardingTourState {


### PR DESCRIPTION
I noticed that the programming languages displayed in the onboarding tour have incorrect capitalization. I’m not sure if these strings are used elsewhere but we should fix the user-facing aspect of it.

![Screenshot 2022-01-27 at 14 14 46](https://user-images.githubusercontent.com/458591/151366471-f05ad7cb-af32-496f-a388-d4b6dee57ba8.png)


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
