### PR TITLE
[cloud] Add migration to support email & expiring invitations

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1635,6 +1635,8 @@ Referenced by:
  response_type     | boolean                  |           |          | 
  revoked_at        | timestamp with time zone |           |          | 
  deleted_at        | timestamp with time zone |           |          | 
+ recipient_email   | citext                   |           |          | 
+ expires_at        | timestamp with time zone |           |          | 
 Indexes:
     "org_invitations_pkey" PRIMARY KEY, btree (id)
     "org_invitations_singleflight" UNIQUE, btree (org_id, recipient_user_id) WHERE responded_at IS NULL AND revoked_at IS NULL AND deleted_at IS NULL

--- a/migrations/frontend/1528395969_add_org_invitation_fields.down.sql
+++ b/migrations/frontend/1528395969_add_org_invitation_fields.down.sql
@@ -1,0 +1,7 @@
+BEGIN; 
+
+ALTER TABLE IF EXISTS org_invitations
+  DROP COLUMN IF EXISTS recipient_email,
+  DROP COLUMN IF EXISTS expires_at;
+
+COMMIT;

--- a/migrations/frontend/1528395969_add_org_invitation_fields.up.sql
+++ b/migrations/frontend/1528395969_add_org_invitation_fields.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE IF EXISTS org_invitations 
+  ADD COLUMN recipient_email CITEXT,
+  ADD COLUMN expires_at timestamp with time zone;
+
+COMMIT;

--- a/migrations/frontend/1528395969_add_org_invitation_fields.up.sql
+++ b/migrations/frontend/1528395969_add_org_invitation_fields.up.sql
@@ -1,3 +1,7 @@
+-- +++
+-- parent: 1528395968
+-- +++
+
 BEGIN;
 
 ALTER TABLE IF EXISTS org_invitations 

--- a/migrations/frontend/1528395969_add_org_invitation_fields.up.sql
+++ b/migrations/frontend/1528395969_add_org_invitation_fields.up.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
 ALTER TABLE IF EXISTS org_invitations 
-  ADD COLUMN recipient_email CITEXT,
-  ADD COLUMN expires_at timestamp with time zone;
+  ADD COLUMN IF NOT EXISTS recipient_email CITEXT,
+  ADD COLUMN IF NOT EXISTS expires_at timestamp with time zone;
 
 COMMIT;


### PR DESCRIPTION
Adding 2 columns to the `org_invitations` table:
`recipient_email` - the email of the recipient of the invitation
`expires_at` - the date when the invitation is considered to be expired
