### PR TITLE
ssbc: Prettify create batch change page

### DIFF
--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.module.scss
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.module.scss
@@ -26,23 +26,3 @@
     width: 30%;
     max-width: 700px;
 }
-
-.name-input {
-    max-width: 300px;
-}
-
-.settings-container {
-    align-self: center;
-    display: flex;
-    flex-direction: column;
-    width: 60%;
-    max-width: 1000px;
-    margin-top: 1rem;
-}
-
-.header {
-    align-self: flex-start;
-    width: 100%;
-    padding-bottom: 0.5rem;
-    border-bottom: 1px solid var(--border-color);
-}

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.module.scss
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.module.scss
@@ -26,3 +26,10 @@
     width: 30%;
     max-width: 700px;
 }
+
+.header {
+    align-self: flex-start;
+    width: 100%;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--border-color);
+}

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -134,11 +134,11 @@ const CreatePage: React.FunctionComponent<CreatePageProps> = ({ namespaceID, set
     )
 
     const [nameInput, setNameInput] = useState('')
-    const [nameValid, setNameValid] = useState<boolean>()
+    const [isNameValid, setIsNameValid] = useState<boolean>()
 
     const onNameChange = useCallback<React.ChangeEventHandler<HTMLInputElement>>(event => {
         setNameInput(event.target.value)
-        setNameValid(NAME_PATTERN.test(event.target.value))
+        setIsNameValid(NAME_PATTERN.test(event.target.value))
     }, [])
 
     const history = useHistory()
@@ -178,12 +178,12 @@ const CreatePage: React.FunctionComponent<CreatePageProps> = ({ namespaceID, set
                             onChange={onNameChange}
                             pattern={String(NAME_PATTERN)}
                             required={true}
-                            status={nameValid === undefined ? undefined : nameValid ? 'valid' : 'error'}
+                            status={isNameValid === undefined ? undefined : isNameValid ? 'valid' : 'error'}
                         />
                         <small className="text-muted">
                             Give it a short, descriptive name to reference the batch change on Sourcegraph. Do not
                             include confidential information.{' '}
-                            <span className={classNames(nameValid === false && 'text-danger')}>
+                            <span className={classNames(isNameValid === false && 'text-danger')}>
                                 Only regular characters, _ and - are allowed.
                             </span>
                         </small>
@@ -191,7 +191,7 @@ const CreatePage: React.FunctionComponent<CreatePageProps> = ({ namespaceID, set
                         <h3 className="text-muted">
                             Visibility <InfoCircleOutlineIcon className="icon-inline" data-tooltip="Coming soon" />
                         </h3>
-                        <div className="form-group text-muted mb-1">
+                        <div className="form-group mb-1">
                             <RadioButton
                                 name="visibility"
                                 value="public"
@@ -202,7 +202,7 @@ const CreatePage: React.FunctionComponent<CreatePageProps> = ({ namespaceID, set
                                 aria-label="Public"
                             />
                         </div>
-                        <div className="form-group text-muted mb-0">
+                        <div className="form-group mb-0">
                             <RadioButton
                                 name="visibility"
                                 value="private"
@@ -222,7 +222,7 @@ const CreatePage: React.FunctionComponent<CreatePageProps> = ({ namespaceID, set
                             variant="primary"
                             type="submit"
                             onClick={handleCreate}
-                            disabled={loading || nameInput === '' || !nameValid}
+                            disabled={loading || nameInput === '' || !isNameValid}
                             className="mr-2"
                         >
                             Create batch change
@@ -501,5 +501,5 @@ const BatchChangePage: React.FunctionComponent<BatchChangePageProps> = ({
         {children}
     </div>
 )
-
+/* Regex pattern for a valid batch change name. Needs to match what's defined in the BatchSpec JSON schema. */
 const NAME_PATTERN = /^[\w.-]+$/

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -210,7 +210,7 @@ const CreatePage: React.FunctionComponent<CreatePageProps> = ({ namespaceID, set
                                 disabled={true}
                                 label={
                                     <>
-                                        Private <LockIcon className="text-warning icon-inline" />
+                                        Private <LockIcon className="text-warning icon-inline" aria-hidden={true} />
                                     </>
                                 }
                                 aria-label="Private"

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -18,7 +18,7 @@ import {
 } from '@sourcegraph/shared/src/settings/settings'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { HeroPage } from '@sourcegraph/web/src/components/HeroPage'
-import { PageHeader, Button, Container, Input, LoadingSpinner, FeedbackBadge } from '@sourcegraph/wildcard'
+import { PageHeader, Button, Container, Input, LoadingSpinner, FeedbackBadge, RadioButton } from '@sourcegraph/wildcard'
 
 import { BatchChangesIcon } from '../../../batches/icons'
 import { PageTitle } from '../../../components/PageTitle'
@@ -138,7 +138,7 @@ const CreatePage: React.FunctionComponent<CreatePageProps> = ({ namespaceID, set
 
     const onNameChange = useCallback<React.ChangeEventHandler<HTMLInputElement>>(event => {
         setNameInput(event.target.value)
-        setNameValid(/^[\w.-]+$/.test(event.target.value))
+        setNameValid(NAME_PATTERN.test(event.target.value))
     }, [])
 
     const history = useHistory()
@@ -171,13 +171,12 @@ const CreatePage: React.FunctionComponent<CreatePageProps> = ({ namespaceID, set
                             namespaces={namespaces}
                             selectedNamespace={selectedNamespace.id}
                             onSelect={setSelectedNamespace}
-                            disabled={!!namespaceID}
                         />
                         <Input
                             label="Batch change name"
                             value={nameInput}
                             onChange={onNameChange}
-                            pattern="^[\\w.-]+$"
+                            pattern={String(NAME_PATTERN)}
                             required={true}
                             status={nameValid === undefined ? undefined : nameValid ? 'valid' : 'error'}
                         />
@@ -190,32 +189,32 @@ const CreatePage: React.FunctionComponent<CreatePageProps> = ({ namespaceID, set
                         </small>
                         <hr className="my-3" />
                         <h3 className="text-muted">
-                            Visibility <InfoCircleOutlineIcon className="icon-inline" data-tooltip="Upcoming feature" />
+                            Visibility <InfoCircleOutlineIcon className="icon-inline" data-tooltip="Coming soon" />
                         </h3>
                         <div className="form-group text-muted mb-1">
-                            <label>
-                                <input
-                                    type="radio"
-                                    name="visibility"
-                                    value="public"
-                                    className="mr-2"
-                                    checked={true}
-                                    disabled={true}
-                                />
-                                Public
-                            </label>
+                            <RadioButton
+                                name="visibility"
+                                value="public"
+                                className="mr-2"
+                                checked={true}
+                                disabled={true}
+                                label="Public"
+                                aria-label="Public"
+                            />
                         </div>
                         <div className="form-group text-muted mb-0">
-                            <label className="mb-0">
-                                <input
-                                    type="radio"
-                                    name="visibility"
-                                    value="private"
-                                    className="mr-2"
-                                    disabled={true}
-                                />
-                                Private <LockIcon className="text-warning icon-inline" />
-                            </label>
+                            <RadioButton
+                                name="visibility"
+                                value="private"
+                                className="mr-2 mb-0"
+                                disabled={true}
+                                label={
+                                    <>
+                                        Private <LockIcon className="text-warning icon-inline" />
+                                    </>
+                                }
+                                aria-label="Private"
+                            />
                         </div>
                     </Container>
                     <div>
@@ -502,3 +501,5 @@ const BatchChangePage: React.FunctionComponent<BatchChangePageProps> = ({
         {children}
     </div>
 )
+
+const NAME_PATTERN = /^[\w.-]+$/

--- a/client/web/src/enterprise/batches/create/NamespaceSelector.module.scss
+++ b/client/web/src/enterprise/batches/create/NamespaceSelector.module.scss
@@ -1,3 +1,0 @@
-.namespace-selector {
-    max-width: 180px;
-}

--- a/client/web/src/enterprise/batches/create/NamespaceSelector.tsx
+++ b/client/web/src/enterprise/batches/create/NamespaceSelector.tsx
@@ -1,9 +1,6 @@
-import classNames from 'classnames'
 import React, { useCallback } from 'react'
 
 import { SettingsOrgSubject, SettingsUserSubject } from '@sourcegraph/shared/src/settings/settings'
-
-import styles from './NamespaceSelector.module.scss'
 
 const getNamespaceDisplayName = (namespace: SettingsUserSubject | SettingsOrgSubject): string => {
     switch (namespace.__typename) {
@@ -19,11 +16,13 @@ const NAMESPACE_SELECTOR_ID = 'batch-spec-execution-namespace-selector'
 interface NamespaceSelectorProps {
     namespaces: (SettingsUserSubject | SettingsOrgSubject)[]
     selectedNamespace: string
+    disabled?: boolean
     onSelect: (namespace: SettingsUserSubject | SettingsOrgSubject) => void
 }
 
 export const NamespaceSelector: React.FunctionComponent<NamespaceSelectorProps> = ({
     namespaces,
+    disabled,
     selectedNamespace,
     onSelect,
 }) => {
@@ -41,13 +40,14 @@ export const NamespaceSelector: React.FunctionComponent<NamespaceSelectorProps> 
     return (
         <div className="form-group">
             <label className="text-nowrap mb-2" htmlFor={NAMESPACE_SELECTOR_ID}>
-                <strong>Namespace:</strong>
+                <strong>Namespace</strong>
             </label>
             <select
-                className={classNames(styles.namespaceSelector, 'form-control')}
+                className="form-control"
                 id={NAMESPACE_SELECTOR_ID}
                 value={selectedNamespace}
                 onChange={onSelectNamespace}
+                disabled={disabled}
             >
                 {namespaces.map(namespace => (
                     <option key={namespace.id} value={namespace.id}>

--- a/client/web/src/enterprise/batches/create/backend.ts
+++ b/client/web/src/enterprise/batches/create/backend.ts
@@ -13,7 +13,18 @@ export const GET_BATCH_CHANGE_TO_EDIT = gql`
         url
         name
         namespace {
+            __typename
             id
+            ... on User {
+                username
+                displayName
+                viewerCanAdminister
+            }
+            ... on Org {
+                name
+                displayName
+                viewerCanAdminister
+            }
         }
         description
 


### PR DESCRIPTION
Not meant to be pixel perfect but some start towards a more "wow" effect when getting started with SSBC the first time. The visibility toggle is muted and disabled, but it makes it visually more appealing.

Also fixes a bug where the namespace on the editor page would not match the namespace of the batch change being edited.

![image](https://user-images.githubusercontent.com/19534377/151389269-51724987-c1ce-4231-9944-f03b3c8c2fb2.png)

Closes #31165