### PR TITLE
Revert "enterprise: Special case handling of internal repo in FetchRepoPerms"

### DIFF
--- a/enterprise/internal/authz/github/client.go
+++ b/enterprise/internal/authz/github/client.go
@@ -38,7 +38,6 @@ type client interface {
 	GetAuthenticatedUserOrgsDetailsAndMembership(ctx context.Context, page int) (orgs []github.OrgDetailsAndMembership, hasNextPage bool, rateLimitCost int, err error)
 	GetAuthenticatedUserTeams(ctx context.Context, page int) (teams []*github.Team, hasNextPage bool, rateLimitCost int, err error)
 	GetOrganization(ctx context.Context, login string) (org *github.OrgDetails, err error)
-	GetRepository(ctx context.Context, owner, name string) (*github.Repository, error)
 
 	GetAuthenticatedOAuthScopes(ctx context.Context) ([]string, error)
 	WithToken(token string) client
@@ -70,10 +69,8 @@ type mockClient struct {
 	MockGetAuthenticatedUserOrgsDetailsAndMembership func(ctx context.Context, page int) (orgs []github.OrgDetailsAndMembership, hasNextPage bool, rateLimitCost int, err error)
 	MockGetAuthenticatedUserTeams                    func(ctx context.Context, page int) (teams []*github.Team, hasNextPage bool, rateLimitCost int, err error)
 	MockGetOrganization                              func(ctx context.Context, login string) (org *github.OrgDetails, err error)
-	MockGetRepository                                func(ctx context.Context, owner, repo string) (*github.Repository, error)
-
-	MockGetAuthenticatedOAuthScopes func(ctx context.Context) ([]string, error)
-	MockWithToken                   func(token string) client
+	MockGetAuthenticatedOAuthScopes                  func(ctx context.Context) ([]string, error)
+	MockWithToken                                    func(token string) client
 }
 
 func (m *mockClient) ListAffiliatedRepositories(ctx context.Context, visibility github.Visibility, page int, affiliations ...github.RepositoryAffiliation) ([]*github.Repository, bool, int, error) {
@@ -114,10 +111,6 @@ func (m *mockClient) GetAuthenticatedUserTeams(ctx context.Context, page int) (t
 
 func (m *mockClient) GetOrganization(ctx context.Context, login string) (org *github.OrgDetails, err error) {
 	return m.MockGetOrganization(ctx, login)
-}
-
-func (m *mockClient) GetRepository(ctx context.Context, owner, name string) (*github.Repository, error) {
-	return m.MockGetRepository(ctx, owner, name)
 }
 
 func (m *mockClient) GetAuthenticatedOAuthScopes(ctx context.Context) ([]string, error) {

--- a/enterprise/internal/authz/github/github.go
+++ b/enterprise/internal/authz/github/github.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cockroachdb/errors"
 
 	"github.com/sourcegraph/sourcegraph/internal/authz"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
@@ -538,23 +537,6 @@ func (p *Provider) getRepoAffiliatedGroups(ctx context.Context, owner, name stri
 			p.groupsCache.invalidateGroup(&group)
 		}
 		groups = append(groups, repoAffiliatedGroup{cachedGroup: group, adminsOnly: adminsOnly})
-	}
-
-	// The visibility field on a repo is only returned if this feature flag is set. As a result
-	// there's no point in making an extra API call if this feature flag is not set explicitly.
-	if conf.ExperimentalFeatures().EnableGithubInternalRepoVisibility {
-		var r *github.Repository
-		r, err = p.client.GetRepository(ctx, owner, name)
-		if err != nil {
-			// Maybe the repo doesn't belong to this org? Or Another error occurred in trying to get the
-			// repo. Either way, we are not going to syncGroup for this repo.
-			return
-		}
-
-		if org != nil && r.Visibility == github.VisibilityInternal {
-			syncGroup(owner, "", false)
-			return
-		}
 	}
 
 	allOrgMembersCanRead := canViewOrgRepos(&github.OrgDetailsAndMembership{OrgDetails: org})


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#29325

```
❯ sg ci logs | grep FAIL
          {"node":{"__typename":"BatchSpec","id":"QmF0Y2hTcGVjOiI2djFKTndLd0tydCI=","originalInput":"\nname: my-unique-name\ndescription: My description\n'on':\n- repositoriesMatchingQuery: lang:go func main\n- repository: github.com/sourcegraph/src-cli\nsteps:\n- run: echo 'foobar'\n  container: alpine\n  env:\n    PATH: \"/work/foobar:$PATH\"\nchangesetTemplate:\n  title: Hello World\n  body: My first batch change!\n  branch: hello-world\n  commit:\n    message: Append Hello World to all README.md files\n  published: false\n","parsedInput":{"name":"my-unique-name","description":"My description","on":[{"repositoriesMatchingQuery":"lang:go func main"},{"repository":"github.com/sourcegraph/src-cli"}],"steps":[{"run":"echo 'foobar'","container":"alpine","env":{"PATH":"/work/foobar:$PATH"}}],"changesetTemplate":{"title":"Hello World","body":"My first batch change!","branch":"hello-world","commit":{"message":"Append Hello World to all README.md files"},"published":false}},"creator":{"id":"VXNlcjox","databaseID":1,"siteAdmin":false},"namespace":{"id":"VXNlcjox","databaseID":1,"siteAdmin":false},"applyURL":"/users/testuser-11/batch-changes/apply/QmF0Y2hTcGVjOiI2djFKTndLd0tydCI=","viewerCanAdminister":true,"createdAt":"2022-01-27T13:25:33Z","expiresAt":"2022-02-03T13:25:33Z","diffStat":{"added":0,"deleted":0,"changed":0},"appliesToBatchChange":null,"supersedingBatchSpec":null,"allCodeHosts":{"totalCount":0,"nodes":[]},"onlyWithoutCredential":{"totalCount":0,"nodes":[]},"changesetSpecs":{"totalCount":0,"nodes":[]},"state":"FAILED","workspaceResolution":{"state":"COMPLETED"},"startedAt":"2022-01-27T11:46:33Z","finishedAt":"2022-01-27T13:16:33Z","failureMessage":"Failures:\n\n* failure message\n","viewerCanRetry":true}}
          {"node":{"__typename":"BatchSpec","id":"QmF0Y2hTcGVjOiI2djFKTndLd0tydCI=","originalInput":"\nname: my-unique-name\ndescription: My description\n'on':\n- repositoriesMatchingQuery: lang:go func main\n- repository: github.com/sourcegraph/src-cli\nsteps:\n- run: echo 'foobar'\n  container: alpine\n  env:\n    PATH: \"/work/foobar:$PATH\"\nchangesetTemplate:\n  title: Hello World\n  body: My first batch change!\n  branch: hello-world\n  commit:\n    message: Append Hello World to all README.md files\n  published: false\n","parsedInput":{"name":"my-unique-name","description":"My description","on":[{"repositoriesMatchingQuery":"lang:go func main"},{"repository":"github.com/sourcegraph/src-cli"}],"steps":[{"run":"echo 'foobar'","container":"alpine","env":{"PATH":"/work/foobar:$PATH"}}],"changesetTemplate":{"title":"Hello World","body":"My first batch change!","branch":"hello-world","commit":{"message":"Append Hello World to all README.md files"},"published":false}},"creator":{"id":"VXNlcjox","databaseID":1,"siteAdmin":false},"namespace":{"id":"VXNlcjox","databaseID":1,"siteAdmin":false},"applyURL":null,"viewerCanAdminister":true,"createdAt":"2022-01-27T13:25:33Z","expiresAt":"2022-02-03T13:25:33Z","diffStat":{"added":20,"deleted":4,"changed":10},"appliesToBatchChange":null,"supersedingBatchSpec":null,"allCodeHosts":{"totalCount":1,"nodes":[{"externalServiceKind":"GITHUB","externalServiceURL":"https://github.com/"}]},"onlyWithoutCredential":{"totalCount":1,"nodes":[{"externalServiceKind":"GITHUB","externalServiceURL":"https://github.com/"}]},"changesetSpecs":{"totalCount":2,"nodes":[{"__typename":"VisibleChangesetSpec","type":"BRANCH","id":"Q2hhbmdlc2V0U3BlYzoiQW1lQkE5SVNrc08i","description":{"baseRepository":{"id":"UmVwb3NpdG9yeTox","name":"repo-1-1"}}},{"__typename":"VisibleChangesetSpec","type":"BRANCH","id":"Q2hhbmdlc2V0U3BlYzoiRlJGNG9FR3FQaCI=","description":{"baseRepository":{"id":"UmVwb3NpdG9yeTox","name":"repo-1-1"}}}]},"state":"FAILED","workspaceResolution":{"state":"COMPLETED"},"startedAt":"2022-01-27T11:46:33Z","finishedAt":"2022-01-27T13:16:33Z","failureMessage":"Validating changeset specs resulted in an error:\n* 2 changeset specs in repo-1-1 use the same branch: refs/heads/conflicting-head-ref\n","viewerCanRetry":true}}
  --- FAIL: TestProvider_FetchRepoPerms (0.01s)
      --- FAIL: TestProvider_FetchRepoPerms/cache_enabled (0.01s)
          --- FAIL: TestProvider_FetchRepoPerms/cache_enabled/internal_repo_in_org (0.00s)
              --- FAIL: TestProvider_FetchRepoPerms/cache_enabled/internal_repo_in_org/feature_flag_disabled (0.00s)
  FAIL  github.com/sourcegraph/sourcegraph/enterprise/internal/authz/github     0.062s
  FAIL
```

This happened in https://buildkite.com/sourcegraph/sourcegraph/builds/127466#047937cb-7e14-4272-83cd-3f381d2d8e3e but [excess log lines](https://github.com/sourcegraph/sourcegraph/issues/30115#issuecomment-1020354456) obfuscated the issue it seems

![image](https://user-images.githubusercontent.com/23356519/151390874-2896d1d7-04c7-4157-b36e-35bfc3289eff.png)
