### PR TITLE
insights: always look up revisions from execution plan, and adds debu…

### DIFF
--- a/enterprise/internal/insights/compression/worker.go
+++ b/enterprise/internal/insights/compression/worker.go
@@ -3,6 +3,7 @@ package compression
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -160,7 +161,7 @@ func (i *CommitIndexer) index(name string, id api.RepoID) (err error) {
 	}
 
 	log15.Debug("indexing commits", "repo_id", repoId, "count", len(commits))
-	err = i.commitStore.InsertCommits(ctx, repoId, commits)
+	err = i.commitStore.InsertCommits(ctx, repoId, commits, fmt.Sprintf("|repoName:%s|repoId:%d", repoName, repoId))
 	if err != nil {
 		return errors.Wrapf(err, "unable to update commit index repo_id: %v", repoId)
 	}

--- a/migrations/codeinsights/1000000026_commit_indexer_debug_fields.down.sql
+++ b/migrations/codeinsights/1000000026_commit_indexer_debug_fields.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+-- Undo the changes made in the up migration
+
+COMMIT;

--- a/migrations/codeinsights/1000000026_commit_indexer_debug_fields.down.sql
+++ b/migrations/codeinsights/1000000026_commit_indexer_debug_fields.down.sql
@@ -1,5 +1,7 @@
 BEGIN;
 
--- Undo the changes made in the up migration
+ALTER TABLE IF EXISTS commit_index
+    DROP COLUMN IF EXISTS indexed_at,
+    DROP COLUMN IF EXISTS debug_field;
 
 COMMIT;

--- a/migrations/codeinsights/1000000026_commit_indexer_debug_fields.up.sql
+++ b/migrations/codeinsights/1000000026_commit_indexer_debug_fields.up.sql
@@ -1,0 +1,16 @@
+-- +++
+-- parent: 1000000025
+-- +++
+
+BEGIN;
+
+-- Perform migration here.
+--
+-- See /migrations/README.md. Highlights:
+--  * Make migrations idempotent (use IF EXISTS)
+--  * Make migrations backwards-compatible (old readers/writers must continue to work)
+--  * Wrap your changes in a transaction. Note that CREATE INDEX CONCURRENTLY is an exception
+--    and cannot be performed in a transaction. For such migrations, ensure that only one
+--    statement is defined per migration to prevent query transactions from starting implicitly.
+
+COMMIT;

--- a/migrations/codeinsights/1000000026_commit_indexer_debug_fields.up.sql
+++ b/migrations/codeinsights/1000000026_commit_indexer_debug_fields.up.sql
@@ -4,13 +4,8 @@
 
 BEGIN;
 
--- Perform migration here.
---
--- See /migrations/README.md. Highlights:
---  * Make migrations idempotent (use IF EXISTS)
---  * Make migrations backwards-compatible (old readers/writers must continue to work)
---  * Wrap your changes in a transaction. Note that CREATE INDEX CONCURRENTLY is an exception
---    and cannot be performed in a transaction. For such migrations, ensure that only one
---    statement is defined per migration to prevent query transactions from starting implicitly.
+ALTER TABLE IF EXISTS commit_index
+    ADD COLUMN IF NOT EXISTS indexed_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    ADD COLUMN IF NOT EXISTS debug_field TEXT;
 
 COMMIT;


### PR DESCRIPTION
This PR does 2 things:
1. Always look up the revision from a compressed execution plan. This is a partial mitigation to the problem where we are seeing invalid revisions appear in the commit index. This doesn't fully solve the problem, because the compression algorithm is still taking these bad revisions into account, but at least the search queries will not fail in this case.
2. Introduce some new temporary debug fields in the commit index - this should help us have a bit more context about what the commits are when they do show up.
