### PR TITLE
Add user-select: none to line numbers

### DIFF
--- a/client/shared/src/components/CodeExcerpt.module.scss
+++ b/client/shared/src/components/CodeExcerpt.module.scss
@@ -10,6 +10,7 @@
     :global(.line) {
         min-width: 1.5rem;
         text-align: right;
+        user-select: none;
 
         &::before {
             /* draw line number with css so it cannot be copied to clipboard */


### PR DESCRIPTION
Currently, even though the line numbers in search results aren't copied
selected, they are causing hte addition of newlines between lines of
code. This adds the `user-select: none` style to the line numbers, which
makes the search reuslts copy as expected.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
