### PR TITLE
Code Monitors: use committer date for after filter

### DIFF
--- a/enterprise/internal/codemonitors/background/graphql.go
+++ b/enterprise/internal/codemonitors/background/graphql.go
@@ -92,6 +92,12 @@ const gqlSearchQuery = `query CodeMonitorSearch(
 							}
 							date
 						}
+						committer {
+							person {
+								displayName
+							}
+							date
+						}
 						message
 					}
 				}
@@ -163,5 +169,5 @@ func gqlURL(queryName string) (string, error) {
 func extractTime(result cmtypes.CommitSearchResult) (time.Time, error) {
 	// This relies on the date format that our API returns. It was previously broken
 	// and should be checked first in case date extraction stops working.
-	return time.Parse(time.RFC3339, result.Commit.Author.Date)
+	return time.Parse(time.RFC3339, result.Commit.Committer.Date)
 }

--- a/enterprise/internal/codemonitors/types/graphql.go
+++ b/enterprise/internal/codemonitors/types/graphql.go
@@ -87,12 +87,15 @@ type Commit struct {
 	Repository struct {
 		Name string `json:"name"`
 	} `json:"repository"`
-	Oid     string `json:"oid"`
-	Message string `json:"message"`
-	Author  struct {
-		Person struct {
-			DisplayName string `json:"displayName"`
-		} `json:"person"`
-		Date string `json:"date"`
-	} `json:"author"`
+	Oid       string    `json:"oid"`
+	Message   string    `json:"message"`
+	Author    Signature `json:"author"`
+	Committer Signature `json:"committer"`
+}
+
+type Signature struct {
+	Person struct {
+		DisplayName string `json:"displayName"`
+	} `json:"person"`
+	Date string `json:"date"`
 }


### PR DESCRIPTION
Previously, we were using the author date to populate the after filter,
but our search filters use the committer date. This meant we could make
a commit with different committer and author dates such that we would
repeatedly return the same result for the generated code monitor
queries. This fixes the issue by populating the after filter with
committer date rather than author date.

This problem only exists because we limit our searches by date rather
than by commit hash. The problem will no longer be possible after
repo-aware code monitors are active.


~Stacked on #30056~
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
