### PR TITLE
fix expected typename on json unmarshaller

### DIFF
--- a/enterprise/internal/codemonitors/types/graphql.go
+++ b/enterprise/internal/codemonitors/types/graphql.go
@@ -25,7 +25,7 @@ func (c *CommitSearchResults) UnmarshalJSON(b []byte) error {
 		}
 
 		switch t.Typename {
-		case "CommitSearchResults", "":
+		case "CommitSearchResult", "":
 		default:
 			return errors.Errorf("expected result type %q, got %q", "CommitSearchResult", t.Typename)
 		}


### PR DESCRIPTION
Somehow this slipped through and the typename is incorrect in the unmarshaller, causing failures
when trying to unmarshal the graphql results. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
