### PR TITLE
migrations: Add `WithMigrationLog`

### DIFF
--- a/internal/database/connections/test/store.go
+++ b/internal/database/connections/test/store.go
@@ -53,6 +53,10 @@ func (s *memoryStore) Down(ctx context.Context, migration definition.Definition)
 	return s.exec(ctx, migration, migration.DownQuery)
 }
 
+func (s *memoryStore) WithMigrationLog(_ context.Context, _ definition.Definition, _ bool, f func() error) error {
+	return f()
+}
+
 func (s *memoryStore) exec(ctx context.Context, migration definition.Definition, query *sqlf.Query) error {
 	_, err := s.db.ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
 	s.version, s.dirty, s.versionSet = migration.ID, s.dirty || err != nil, true

--- a/internal/database/migration/runner/helpers_test.go
+++ b/internal/database/migration/runner/helpers_test.go
@@ -52,13 +52,12 @@ func testStoreWithVersion(version int, dirty bool) *MockStore {
 	store := NewMockStore()
 	store.TransactFunc.SetDefaultReturn(store, nil)
 	store.DoneFunc.SetDefaultHook(func(err error) error { return err })
+	store.VersionFunc.SetDefaultHook(func(ctx context.Context) (int, bool, bool, error) { return version, dirty, true, nil })
 	store.LockFunc.SetDefaultReturn(true, func(err error) error { return err }, nil)
 	store.TryLockFunc.SetDefaultReturn(true, func(err error) error { return err }, nil)
 	store.UpFunc.SetDefaultHook(migrationHook)
 	store.DownFunc.SetDefaultHook(migrationHook)
-	store.VersionFunc.SetDefaultHook(func(ctx context.Context) (int, bool, bool, error) {
-		return version, dirty, true, nil
-	})
+	store.WithMigrationLogFunc.SetDefaultHook(func(_ context.Context, _ definition.Definition, _ bool, f func() error) error { return f() })
 
 	return store
 }

--- a/internal/database/migration/runner/iface.go
+++ b/internal/database/migration/runner/iface.go
@@ -15,4 +15,5 @@ type Store interface {
 	TryLock(ctx context.Context) (bool, func(err error) error, error)
 	Up(ctx context.Context, migration definition.Definition) error
 	Down(ctx context.Context, migration definition.Definition) error
+	WithMigrationLog(ctx context.Context, definition definition.Definition, up bool, f func() error) error
 }

--- a/internal/database/migration/store/observability.go
+++ b/internal/database/migration/store/observability.go
@@ -15,6 +15,7 @@ type Operations struct {
 	tryLock           *observation.Operation
 	up                *observation.Operation
 	version           *observation.Operation
+	withMigrationLog  *observation.Operation
 }
 
 func NewOperations(observationContext *observation.Context) *Operations {
@@ -41,5 +42,6 @@ func NewOperations(observationContext *observation.Context) *Operations {
 		tryLock:           op("TryLock"),
 		up:                op("Up"),
 		version:           op("Version"),
+		withMigrationLog:  op("WithMigrationLog"),
 	}
 }

--- a/internal/database/migration/store/store.go
+++ b/internal/database/migration/store/store.go
@@ -268,10 +268,7 @@ func (s *Store) WithMigrationLog(ctx context.Context, definition definition.Defi
 	ctx, endObservation := s.operations.withMigrationLog.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	return s.runMigrationQuery(ctx, definition.ID, up, f)
-}
-
-func (s *Store) runMigrationQuery(ctx context.Context, definitionVersion int, up bool, f func() error) (err error) {
+	definitionVersion := definition.ID
 	targetVersion := definitionVersion
 	expectedCurrentVersion := definitionVersion - 1
 	if !up {

--- a/internal/database/migration/store/store.go
+++ b/internal/database/migration/store/store.go
@@ -215,26 +215,20 @@ func (s *Store) lockKey() int32 {
 	return locker.StringKey(fmt.Sprintf("%s:migrations", s.migrationsTable))
 }
 
+// Up runs the given definition's up query.
 func (s *Store) Up(ctx context.Context, definition definition.Definition) (err error) {
 	ctx, endObservation := s.operations.up.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	if err := s.runMigrationQuery(ctx, definition.ID, true, definition.UpQuery); err != nil {
-		return err
-	}
-
-	return nil
+	return s.Exec(ctx, definition.UpQuery)
 }
 
+// Down runs the given definition's down query.
 func (s *Store) Down(ctx context.Context, definition definition.Definition) (err error) {
 	ctx, endObservation := s.operations.down.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	if err := s.runMigrationQuery(ctx, definition.ID, false, definition.DownQuery); err != nil {
-		return err
-	}
-
-	return nil
+	return s.Exec(ctx, definition.DownQuery)
 }
 
 // IndexStatus returns an object describing the current validity status and creation progress of the
@@ -267,7 +261,17 @@ WHERE
 	ai.indexrelname = %s
 `
 
-func (s *Store) runMigrationQuery(ctx context.Context, definitionVersion int, up bool, query *sqlf.Query) (err error) {
+// WithMigrationLog runs the given function while writing its progress to a migration log associated
+// with the given definition. All users are assumed to run either `s.Up` or `s.Down` as part of the
+// given function, among any other behaviors that are necessary to perform in the _critical section_.
+func (s *Store) WithMigrationLog(ctx context.Context, definition definition.Definition, up bool, f func() error) (err error) {
+	ctx, endObservation := s.operations.withMigrationLog.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	return s.runMigrationQuery(ctx, definition.ID, up, f)
+}
+
+func (s *Store) runMigrationQuery(ctx context.Context, definitionVersion int, up bool, f func() error) (err error) {
 	targetVersion := definitionVersion
 	expectedCurrentVersion := definitionVersion - 1
 	if !up {
@@ -291,7 +295,7 @@ func (s *Store) runMigrationQuery(ctx context.Context, definitionVersion int, up
 		}
 	}()
 
-	if err := s.Exec(ctx, query); err != nil {
+	if err := f(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Pulled from #29831. This PR splits the *attempt* of a migration and its *bookkeeping*. This will be necessary for the full effort to later be able to add migration logs for other automatic repair actions (e.g. dropping an invalid index before re-running the migration).