### PR TITLE
migrations: Add `Versions` to store

### DIFF
--- a/internal/database/migration/store/observability.go
+++ b/internal/database/migration/store/observability.go
@@ -15,6 +15,7 @@ type Operations struct {
 	tryLock           *observation.Operation
 	up                *observation.Operation
 	version           *observation.Operation
+	versions          *observation.Operation
 	withMigrationLog  *observation.Operation
 }
 
@@ -42,6 +43,7 @@ func NewOperations(observationContext *observation.Context) *Operations {
 		tryLock:           op("TryLock"),
 		up:                op("Up"),
 		version:           op("Version"),
+		versions:          op("Versions"),
 		withMigrationLog:  op("WithMigrationLog"),
 	}
 }

--- a/internal/database/migration/store/store.go
+++ b/internal/database/migration/store/store.go
@@ -148,6 +148,56 @@ func (s *Store) Version(ctx context.Context) (version int, dirty bool, ok bool, 
 	return 0, false, false, nil
 }
 
+// Versions returns three sets of versions that completely describes the current. The sets
+// describe, respectively, all applied, pending, and failed migrations.
+//
+// A failed migration requires administrator attention. A pending migration may currently be
+// in-progress, or may indicate that a migration was attempted but failed part way through.
+func (s *Store) Versions(ctx context.Context) (appliedVersions, pendingVersions, failedVersions []int, err error) {
+	ctx, endObservation := s.operations.versions.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	migrationLogs, err := scanMigrationLogs(s.Query(ctx, sqlf.Sprintf(versionsQuery, s.schemaName)))
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	for _, migrationLog := range migrationLogs {
+		if migrationLog.Success == nil {
+			pendingVersions = append(pendingVersions, migrationLog.Version)
+			continue
+		}
+		if !*migrationLog.Success {
+			failedVersions = append(failedVersions, migrationLog.Version)
+			continue
+		}
+		if migrationLog.Up {
+			appliedVersions = append(appliedVersions, migrationLog.Version)
+		}
+	}
+
+	return appliedVersions, pendingVersions, failedVersions, nil
+}
+
+const versionsQuery = `
+-- source: internal/database/migration/store/store.go:Versions
+WITH ranked_migration_logs AS (
+	SELECT
+		migration_logs.*,
+		ROW_NUMBER() OVER (PARTITION BY version ORDER BY finished_at DESC) AS row_number
+	FROM migration_logs
+	WHERE schema = %s
+)
+SELECT
+	schema,
+	version,
+	up,
+	success
+FROM ranked_migration_logs
+WHERE row_number = 1
+ORDER BY version
+`
+
 // Lock creates and holds an advisory lock. This method returns a function that should be called
 // once the lock should be released. This method accepts the current function's error output and
 // wraps any additional errors that occur on close.

--- a/internal/database/migration/store/store.go
+++ b/internal/database/migration/store/store.go
@@ -148,8 +148,9 @@ func (s *Store) Version(ctx context.Context) (version int, dirty bool, ok bool, 
 	return 0, false, false, nil
 }
 
-// Versions returns three sets of versions that completely describes the current. The sets
-// describe, respectively, all applied, pending, and failed migrations.
+// Versions returns three sets of migration versions that, together, describe the current schema
+// state. These states describe, respectively, the identifieers of all applied, pending, and failed
+// migrations.
 //
 // A failed migration requires administrator attention. A pending migration may currently be
 // in-progress, or may indicate that a migration was attempted but failed part way through.

--- a/internal/database/migration/store/store_test.go
+++ b/internal/database/migration/store/store_test.go
@@ -96,6 +96,83 @@ func TestVersion(t *testing.T) {
 	}
 }
 
+func TestVersions(t *testing.T) {
+	db := dbtest.NewDB(t)
+	store := testStore(db)
+	ctx := context.Background()
+	if err := store.EnsureSchemaTable(ctx); err != nil {
+		t.Fatalf("unexpected error ensuring schema table exists: %s", err)
+	}
+
+	t.Run("empty", func(*testing.T) {
+		if appliedVersions, pendingVersions, failedVersions, err := store.Versions(ctx); err != nil {
+			t.Fatalf("unexpected error querying versions: %s", err)
+		} else if len(appliedVersions)+len(pendingVersions)+len(failedVersions) > 0 {
+			t.Fatalf("unexpected no versions, got applied=%v pending=%v failed=%v", appliedVersions, pendingVersions, failedVersions)
+		}
+	})
+
+	type testCase struct {
+		version      int
+		up           bool
+		success      *bool
+		errorMessage *string
+	}
+	makeCase := func(version int, up bool, failed *bool) testCase {
+		if failed == nil {
+			return testCase{version, up, nil, nil}
+		}
+		if *failed {
+			return testCase{version, up, boolPtr(false), strPtr("uh-oh")}
+		}
+		return testCase{version, up, boolPtr(true), nil}
+	}
+
+	for _, migrationLog := range []testCase{
+		// Historic attempts
+		makeCase(1003, true, boolPtr(true)), makeCase(1003, false, boolPtr(true)), // 1003: successful up, successful down
+		makeCase(1004, true, boolPtr(true)),                                       // 1004: successful up
+		makeCase(1006, true, boolPtr(false)), makeCase(1006, true, boolPtr(true)), // 1006: failed up, successful up
+
+		// Last attempts
+		makeCase(1001, true, boolPtr(false)),  // successful up
+		makeCase(1002, false, boolPtr(false)), // successful down
+		makeCase(1003, true, nil),             // pending up
+		makeCase(1004, false, nil),            // pending down
+		makeCase(1005, true, boolPtr(true)),   // failed up
+		makeCase(1006, false, boolPtr(true)),  // failed down
+	} {
+		if err := store.Exec(ctx, sqlf.Sprintf(`INSERT INTO migration_logs (
+				migration_logs_schema_version,
+				schema,
+				version,
+				up,
+				started_at,
+				success,
+				finished_at,
+				error_message
+			) VALUES (%s, %s, %s, %s, NOW(), %s, NOW(), %s)`,
+			currentMigrationLogSchemaVersion,
+			"test_migrations_table",
+			migrationLog.version,
+			migrationLog.up,
+			migrationLog.success,
+			migrationLog.errorMessage,
+		)); err != nil {
+			t.Fatalf("unexpected error inserting data: %s", err)
+		}
+	}
+
+	assertVersions(
+		t,
+		ctx,
+		store,
+		[]int{1001},       // expectedAppliedVersions
+		[]int{1003, 1004}, // expectedPendingVersions
+		[]int{1005, 1006}, // expectedFailedVersions
+	)
+}
+
 func TestLock(t *testing.T) {
 	db := dbtest.NewDB(t)
 	store := testStore(db)
@@ -216,6 +293,7 @@ func TestWrappedUp(t *testing.T) {
 				Success: boolPtr(true),
 			},
 		})
+		assertVersions(t, ctx, store, []int{16}, nil, nil)
 		truncateLogs(t, ctx, store)
 	})
 
@@ -278,6 +356,7 @@ func TestWrappedUp(t *testing.T) {
 				Success: boolPtr(false),
 			},
 		})
+		assertVersions(t, ctx, store, nil, nil, []int{17})
 		truncateLogs(t, ctx, store)
 	})
 
@@ -375,6 +454,7 @@ func TestWrappedDown(t *testing.T) {
 				Success: boolPtr(true),
 			},
 		})
+		assertVersions(t, ctx, store, nil, nil, nil)
 		truncateLogs(t, ctx, store)
 	})
 
@@ -432,6 +512,7 @@ func TestWrappedDown(t *testing.T) {
 				Success: boolPtr(false),
 			},
 		})
+		assertVersions(t, ctx, store, nil, nil, []int{13})
 		truncateLogs(t, ctx, store)
 	})
 
@@ -617,6 +698,10 @@ func testStore(db dbutil.DB) *Store {
 	return NewWithDB(db, "test_migrations_table", NewOperations(&observation.TestContext))
 }
 
+func strPtr(v string) *string {
+	return &v
+}
+
 func boolPtr(value bool) *bool {
 	return &value
 }
@@ -639,5 +724,24 @@ func assertLogs(t *testing.T, ctx context.Context, store *Store, expectedLogs []
 
 	if diff := cmp.Diff(expectedLogs, logs); diff != "" {
 		t.Errorf("unexpected migration logs (-want +got):\n%s", diff)
+	}
+}
+
+func assertVersions(t *testing.T, ctx context.Context, store *Store, expectedAppliedVersions, expectedPendingVersions, expectedFailedVersions []int) {
+	t.Helper()
+
+	appliedVersions, pendingVersions, failedVersions, err := store.Versions(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error querying version: %s", err)
+	}
+
+	if diff := cmp.Diff(expectedAppliedVersions, appliedVersions); diff != "" {
+		t.Errorf("unexpected applied migration logs (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(expectedPendingVersions, pendingVersions); diff != "" {
+		t.Errorf("unexpected pending migration logs (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(expectedFailedVersions, failedVersions); diff != "" {
+		t.Errorf("unexpected failed migration logs (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
Pulled from #29831. This PR adds the `Versions` method to the migration store. This gives more fidelity of information than the `Version` method, which only returns the highest applied migration number.