### PR TITLE
migrations: Store migration parents as a slice

### DIFF
--- a/internal/database/migration/definition/definition.go
+++ b/internal/database/migration/definition/definition.go
@@ -13,11 +13,7 @@ type Definition struct {
 	UpQuery      *sqlf.Query
 	DownFilename string
 	DownQuery    *sqlf.Query
-	Metadata     Metadata
-}
-
-type Metadata struct {
-	Parent int `yaml:"parent"`
+	Parents      []int
 }
 
 type IndexMetadata struct {

--- a/internal/database/migration/definition/read.go
+++ b/internal/database/migration/definition/read.go
@@ -175,17 +175,26 @@ func hydrateDefinitions(fs fs.FS, definitions []Definition) (err error) {
 			}
 		}
 
+		var parents []int
+		if metadata.Parent != 0 {
+			parents = append(parents, metadata.Parent)
+		}
+
 		definitions[i] = Definition{
 			ID:           definition.ID,
-			Metadata:     metadata,
 			UpFilename:   definition.UpFilename,
 			UpQuery:      upQuery,
 			DownFilename: definition.DownFilename,
 			DownQuery:    downQuery,
+			Parents:      parents,
 		}
 	}
 
 	return nil
+}
+
+type Metadata struct {
+	Parent int
 }
 
 // readQueryFromFile returns the parsed query and extracted metadata read from
@@ -382,7 +391,7 @@ func findDefinitionOrder(migrationDefinitions []Definition) ([]int, error) {
 func root(migrationDefinitions []Definition) (int, error) {
 	roots := make([]int, 0, 1)
 	for _, migrationDefinition := range migrationDefinitions {
-		if migrationDefinition.Metadata.Parent == 0 {
+		if len(migrationDefinition.Parents) == 0 {
 			roots = append(roots, migrationDefinition.ID)
 		}
 	}
@@ -401,7 +410,7 @@ func root(migrationDefinitions []Definition) (int, error) {
 func children(migrationDefinitions []Definition) map[int][]int {
 	children := make(map[int][]int, len(migrationDefinitions))
 	for _, migrationDefinition := range migrationDefinitions {
-		if parent := migrationDefinition.Metadata.Parent; parent != 0 {
+		for _, parent := range migrationDefinition.Parents {
 			children[parent] = append(children[parent], migrationDefinition.ID)
 		}
 	}
@@ -421,12 +430,12 @@ func validateLinearizedGraph(migrationDefinitions []Definition) error {
 		return nil
 	}
 
-	if migrationDefinitions[0].Metadata.Parent != 0 {
+	if len(migrationDefinitions[0].Parents) != 0 {
 		return fmt.Errorf("unexpected parent for root definition")
 	}
 
 	for _, definition := range migrationDefinitions[1:] {
-		if definition.Metadata.Parent != definition.ID-1 {
+		if len(definition.Parents) != 1 || definition.Parents[0] != definition.ID-1 {
 			return fmt.Errorf("unexpected parent declared in definition %d", definition.ID)
 		}
 	}

--- a/internal/database/migration/definition/read_test.go
+++ b/internal/database/migration/definition/read_test.go
@@ -35,10 +35,10 @@ func TestReadDefinitions(t *testing.T) {
 
 		expectedDefinitions := []Definition{
 			{ID: 10001, UpFilename: "10001_first.up.sql", DownFilename: "10001_first.down.sql", UpQuery: sqlf.Sprintf("10001 UP"), DownQuery: sqlf.Sprintf("10001 DOWN")},
-			{ID: 10002, UpFilename: "10002_second.up.sql", DownFilename: "10002_second.down.sql", UpQuery: sqlf.Sprintf("10002 UP"), DownQuery: sqlf.Sprintf("10002 DOWN"), Metadata: Metadata{Parent: 10001}},
-			{ID: 10003, UpFilename: "10003_third.up.sql", DownFilename: "10003_third.down.sql", UpQuery: sqlf.Sprintf("10003 UP"), DownQuery: sqlf.Sprintf("10003 DOWN"), Metadata: Metadata{Parent: 10002}},
-			{ID: 10004, UpFilename: "10004_fourth.up.sql", DownFilename: "10004_fourth.down.sql", UpQuery: sqlf.Sprintf("10004 UP"), DownQuery: sqlf.Sprintf("10004 DOWN"), Metadata: Metadata{Parent: 10003}},
-			{ID: 10005, UpFilename: "10005_fifth.up.sql", DownFilename: "10005_fifth.down.sql", UpQuery: sqlf.Sprintf("10005 UP"), DownQuery: sqlf.Sprintf("10005 DOWN"), Metadata: Metadata{Parent: 10004}},
+			{ID: 10002, UpFilename: "10002_second.up.sql", DownFilename: "10002_second.down.sql", UpQuery: sqlf.Sprintf("10002 UP"), DownQuery: sqlf.Sprintf("10002 DOWN"), Parents: []int{10001}},
+			{ID: 10003, UpFilename: "10003_third.up.sql", DownFilename: "10003_third.down.sql", UpQuery: sqlf.Sprintf("10003 UP"), DownQuery: sqlf.Sprintf("10003 DOWN"), Parents: []int{10002}},
+			{ID: 10004, UpFilename: "10004_fourth.up.sql", DownFilename: "10004_fourth.down.sql", UpQuery: sqlf.Sprintf("10004 UP"), DownQuery: sqlf.Sprintf("10004 DOWN"), Parents: []int{10003}},
+			{ID: 10005, UpFilename: "10005_fifth.up.sql", DownFilename: "10005_fifth.down.sql", UpQuery: sqlf.Sprintf("10005 UP"), DownQuery: sqlf.Sprintf("10005 DOWN"), Parents: []int{10004}},
 		}
 		if diff := cmp.Diff(expectedDefinitions, definitions.definitions, queryComparer); diff != "" {
 			t.Fatalf("unexpected definitions (-want +got):\n%s", diff)


### PR DESCRIPTION
Pulled from #29831. This PR expands the migration `Definition` struct to carry a _slice_ of parent migration identifiers instead of a single integer representing a parent (or no parent if zero). Note that because we haven't updated any of the code that reads migration definitions from disk, so we still maintain migrations as a single chain of definitions (therefore this PR should be behavior-preserving from any existing codepath).