### PR TITLE
user invites: add backend to query invitable users

### DIFF
--- a/cmd/frontend/graphqlbackend/external_service_collaborators.go
+++ b/cmd/frontend/graphqlbackend/external_service_collaborators.go
@@ -119,6 +119,8 @@ type invitableCollaboratorResolver struct {
 	date      time.Time
 }
 
-func (i *invitableCollaboratorResolver) Email() string     { return i.email }
-func (i *invitableCollaboratorResolver) Name() string      { return i.name }
-func (i *invitableCollaboratorResolver) AvatarURL() string { return i.avatarURL }
+func (i *invitableCollaboratorResolver) Name() string        { return i.name }
+func (i *invitableCollaboratorResolver) Email() string       { return i.email }
+func (i *invitableCollaboratorResolver) DisplayName() string { return i.name }
+func (i *invitableCollaboratorResolver) AvatarURL() *string  { return &i.avatarURL }
+func (i *invitableCollaboratorResolver) User() *UserResolver { return nil }

--- a/cmd/frontend/graphqlbackend/external_service_collaborators.go
+++ b/cmd/frontend/graphqlbackend/external_service_collaborators.go
@@ -1,0 +1,124 @@
+package graphqlbackend
+
+import (
+	"context"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+// See schema.graphql for an explanation of how this is intended to be used. This is particularly
+// for listing collaborators to *some* of the repositories associated with this external service
+// *before* they are cloned onto Sourcegraph.
+func (r *externalServiceResolver) InvitableCollaborators(ctx context.Context) ([]*invitableCollaboratorResolver, error) {
+	cfg, err := r.externalService.Configuration()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse external service config")
+	}
+	githubCfg, ok := cfg.(*schema.GitHubConnection)
+	if !ok {
+		return nil, errors.Wrap(err, "contributors API only supported with GitHub")
+	}
+	githubUrl, err := url.Parse(githubCfg.Url)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse external service URL")
+	}
+	client := github.NewV4Client(githubUrl, &auth.OAuthBearerToken{Token: githubCfg.Token}, nil)
+
+	// We'll only look in 20 repos. We limit ourselves here to prevent having our github token run
+	// into rate limits (which could affect repo discovery / cloning / other API operations we need
+	// to perform for the user elsewhere.)
+	const maxReposToScan = 20
+	fewRepos := githubCfg.Repos
+	if len(fewRepos) > maxReposToScan {
+		fewRepos = fewRepos[:maxReposToScan]
+	}
+
+	// In parallel collect all recent committers info for the few repos we're going to scan.
+	var (
+		wg                  sync.WaitGroup
+		mu                  sync.Mutex
+		allRecentCommitters []*invitableCollaboratorResolver
+	)
+	for _, repoName := range fewRepos {
+		owner, name, err := github.SplitRepositoryNameWithOwner(repoName)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to split repository name")
+		}
+		wg.Add(1)
+		goroutine.Go(func() {
+			defer wg.Done()
+			recentCommits, err := client.RecentCommitters(ctx, &github.RecentCommittersParams{
+				Name:  name,
+				Owner: owner,
+				First: 100,
+			})
+			if err != nil {
+				log15.Error("InvitableCollaborators: failed to get recent committers", "err", err)
+				return
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			for _, commit := range recentCommits.Nodes {
+				for _, author := range commit.Authors.Nodes {
+					parsedTime, _ := time.Parse(time.RFC3339, author.Date)
+					allRecentCommitters = append(allRecentCommitters, &invitableCollaboratorResolver{
+						email:     author.Email,
+						name:      author.Name,
+						avatarURL: author.AvatarURL,
+						date:      parsedTime,
+					})
+				}
+			}
+		})
+	}
+	wg.Wait()
+
+	// Sort committers by most-recent-first. This ensures that the top of the list of people you can
+	// invite are people who recently committed to code, which means they're more active and more
+	// likely the person you want to invite (compared to e.g. if we hit a very old repo and the
+	// committer is say no longer working at that organization.)
+	sort.Slice(allRecentCommitters, func(i, j int) bool {
+		a := allRecentCommitters[i].date
+		b := allRecentCommitters[j].date
+		return a.After(b)
+	})
+
+	// Eliminate committers who are duplicates, don't have an email, or have a noreply@github.com
+	// email (which happens when you make edits via the web UI.)
+	var (
+		invitable   []*invitableCollaboratorResolver
+		deduplicate = map[string]struct{}{}
+	)
+	for _, recentCommitter := range allRecentCommitters {
+		if recentCommitter.email == "" || strings.Contains(recentCommitter.email, "noreply") {
+			continue
+		}
+		if _, duplicate := deduplicate[recentCommitter.email]; duplicate {
+			continue
+		}
+		deduplicate[recentCommitter.email] = struct{}{}
+		invitable = append(invitable, recentCommitter)
+	}
+	return invitable, nil
+}
+
+type invitableCollaboratorResolver struct {
+	email     string
+	name      string
+	avatarURL string
+	date      time.Time
+}
+
+func (i *invitableCollaboratorResolver) Email() string     { return i.email }
+func (i *invitableCollaboratorResolver) Name() string      { return i.name }
+func (i *invitableCollaboratorResolver) AvatarURL() string { return i.avatarURL }

--- a/cmd/frontend/graphqlbackend/external_service_collaborators.go
+++ b/cmd/frontend/graphqlbackend/external_service_collaborators.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
@@ -28,10 +29,12 @@ func (r *externalServiceResolver) InvitableCollaborators(ctx context.Context) ([
 	if !ok {
 		return nil, errors.Wrap(err, "contributors API only supported with GitHub")
 	}
-	githubUrl, err := url.Parse(githubCfg.Url)
+	baseURL, err := url.Parse(githubCfg.Url)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse external service URL")
 	}
+	baseURL = extsvc.NormalizeBaseURL(baseURL)
+	githubUrl, _ := github.APIRoot(baseURL)
 	client := github.NewV4Client(githubUrl, &auth.OAuthBearerToken{Token: githubCfg.Token}, nil)
 
 	// We'll only look in 20 repos. We limit ourselves here to prevent having our github token run

--- a/cmd/frontend/graphqlbackend/external_service_collaborators.go
+++ b/cmd/frontend/graphqlbackend/external_service_collaborators.go
@@ -21,6 +21,11 @@ import (
 // for listing collaborators to *some* of the repositories associated with this external service
 // *before* they are cloned onto Sourcegraph.
 func (r *externalServiceResolver) InvitableCollaborators(ctx context.Context) ([]*invitableCollaboratorResolver, error) {
+	// SECURITY: This API should only be exposed for user-added external services, not for example by
+	// site-wide (CloudDefault) external services (the API also makes zero sense in that context.)
+	if r.externalService.IsSiteOwned() {
+		return nil, errors.New("InvitableCollaborators may only be used on user-added external services.")
+	}
 	cfg, err := r.externalService.Configuration()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse external service config")

--- a/cmd/frontend/graphqlbackend/external_service_collaborators.go
+++ b/cmd/frontend/graphqlbackend/external_service_collaborators.go
@@ -23,6 +23,10 @@ import (
 func (r *externalServiceResolver) InvitableCollaborators(ctx context.Context) ([]*invitableCollaboratorResolver, error) {
 	// SECURITY: This API should only be exposed for user-added external services, not for example by
 	// site-wide (CloudDefault) external services (the API also makes zero sense in that context.)
+	//
+	// IMPORTANT: This API is allowed for org external services. You may not have access to every repo
+	// within an org external service, and so if we expose too much information here it could be an
+	// ACL vulnerability. Since we only expose name+email+avatar URL, this is fine to do.
 	if r.externalService.IsSiteOwned() {
 		return nil, errors.New("InvitableCollaborators may only be used on user-added external services.")
 	}

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2330,25 +2330,7 @@ type ExternalService implements Node {
     In general, this API should NOT be used once repositories are cloned on to Sourcegraph as it
     reaches out to the code host directly which is wasteful if repositories are already cloned.
     """
-    invitableCollaborators: [InvitableCollaborator!]!
-}
-
-"""
-A collaborator that can be invited to Sourcegraph.
-"""
-type InvitableCollaborator {
-    """
-    The collaborator's email address
-    """
-    email: String!
-    """
-    The collaborator's name (not username)
-    """
-    name: String!
-    """
-    The collaborator's avatar URL (per their code host)
-    """
-    avatarURL: String!
+    invitableCollaborators: [Person!]!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2326,6 +2326,9 @@ type ExternalService implements Node {
 
     Importantly, this API works when repositories are not cloned on Sourcegraph yet so as to allow
     inviting collaborators while repositories are cloning.
+
+    In general, this API should NOT be used once repositories are cloned on to Sourcegraph as it
+    reaches out to the code host directly which is wasteful if repositories are already cloned.
     """
     invitableCollaborators: [InvitableCollaborator!]!
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2317,6 +2317,35 @@ type ExternalService implements Node {
         """
         until: DateTime
     ): WebhookLogConnection!
+
+    """
+    EXPERIMENTAL: Collaborators who can be invited to Sourcegraph. This typically comes from a few
+    repositories included by this external service, and is derived from commit history (because that
+    for example gives more accurate collaborator work email addresses than the contributors API which
+    often returns personal emails.
+
+    Importantly, this API works when repositories are not cloned on Sourcegraph yet so as to allow
+    inviting collaborators while repositories are cloning.
+    """
+    invitableCollaborators: [InvitableCollaborator!]!
+}
+
+"""
+A collaborator that can be invited to Sourcegraph.
+"""
+type InvitableCollaborator {
+    """
+    The collaborator's email address
+    """
+    email: String!
+    """
+    The collaborator's name (not username)
+    """
+    name: String!
+    """
+    The collaborator's avatar URL (per their code host)
+    """
+    avatarURL: String!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/status_messages.go
+++ b/cmd/frontend/graphqlbackend/status_messages.go
@@ -81,6 +81,8 @@ func (r *statusMessageResolver) ExternalService(ctx context.Context) (*externalS
 	if err != nil {
 		return nil, err
 	}
-
+	if err := backend.CheckExternalServiceAccess(ctx, r.db, externalService.NamespaceUserID, externalService.NamespaceOrgID); err != nil {
+		return nil, err
+	}
 	return &externalServiceResolver{db: r.db, externalService: externalService}, nil
 }

--- a/internal/extsvc/github/testdata/golden/RecentCommitters
+++ b/internal/extsvc/github/testdata/golden/RecentCommitters
@@ -1,0 +1,1208 @@
+{
+  "Nodes": [
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2021-05-12T18:17:49-05:00",
+       "Email": "eric@eric-fritz.com",
+       "Name": "Eric Fritz",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/103087?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2021-05-12T17:42:19-05:00",
+       "Email": "eric@eric-fritz.com",
+       "Name": "Eric Fritz",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/103087?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2021-05-12T17:38:55-05:00",
+       "Email": "eric@eric-fritz.com",
+       "Name": "Eric Fritz",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/103087?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2021-03-11T14:25:14+01:00",
+       "Email": "mrnugget@gmail.com",
+       "Name": "Thorsten Ball",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/1185253?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2021-03-11T14:24:26+01:00",
+       "Email": "mrnugget@gmail.com",
+       "Name": "Thorsten Ball",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/1185253?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-05-04T23:26:22-07:00",
+       "Email": "xiangli.cs@gmail.com",
+       "Name": "Xiang Li",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/4479947?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-05-04T17:43:08-07:00",
+       "Email": "yuzhihong@gmail.com",
+       "Name": "Zhihong Yu",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/235188?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-05-04T15:46:36-07:00",
+       "Email": "yuzhihong@gmail.com",
+       "Name": "Zhihong Yu",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/235188?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-05-04T13:37:55-04:00",
+       "Email": "spzala@us.ibm.com",
+       "Name": "Sahdev Zala",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6462877?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-05-04T12:40:34-04:00",
+       "Email": "spzala@us.ibm.com",
+       "Name": "Sahdev P. Zala",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6462877?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-05-03T23:32:25+09:00",
+       "Email": "h.mitake@gmail.com",
+       "Name": "Hitoshi Mitake",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/1173955?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-05-03T17:17:30+09:00",
+       "Email": "h.mitake@gmail.com",
+       "Name": "Hitoshi Mitake",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/1173955?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-30T11:08:33-04:00",
+       "Email": "spzala@us.ibm.com",
+       "Name": "Sahdev Zala",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6462877?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-30T13:59:17+02:00",
+       "Email": "krzysztof.t.kruk@gmail.com",
+       "Name": "Krzysztof Kruk",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/40073114?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-29T05:35:06-07:00",
+       "Email": "brandon@ifup.org",
+       "Name": "Brandon Philips",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/33544?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-28T23:27:08-07:00",
+       "Email": "leegyuho@amazon.com",
+       "Name": "Gyuho Lee",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6799218?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-28T20:54:13-07:00",
+       "Email": "leegyuho@amazon.com",
+       "Name": "Gyuho Lee",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6799218?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-28T20:33:40-07:00",
+       "Email": "yuzhihong@gmail.com",
+       "Name": "Ted Yu",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/235188?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-28T16:11:26-07:00",
+       "Email": "brandon@ifup.org",
+       "Name": "Brandon Philips",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/33544?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-28T15:24:29-07:00",
+       "Email": "brandon@ifup.org",
+       "Name": "Brandon Philips",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/33544?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-28T15:12:50-07:00",
+       "Email": "brandon@ifup.org",
+       "Name": "Brandon Philips",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/33544?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-28T22:02:19Z",
+       "Email": "brandon@ifup.org",
+       "Name": "Brandon Philips",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/33544?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-26T11:16:25-04:00",
+       "Email": "gaurav1086@gmail.com",
+       "Name": "Gaurav Singh",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/1029926?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-25T22:48:04-04:00",
+       "Email": "gaurav1086@gmail.com",
+       "Name": "Gaurav Singh",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/1029926?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-27T14:54:34Z",
+       "Email": "brandon@ifup.org",
+       "Name": "Brandon Philips",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/33544?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-27T15:41:00Z",
+       "Email": "brandon@ifup.org",
+       "Name": "Brandon Philips",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/33544?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-27T06:09:09Z",
+       "Email": "brandon@ifup.org",
+       "Name": "Brandon Philips",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/33544?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-27T00:49:18Z",
+       "Email": "brandon@ifup.org",
+       "Name": "Brandon Philips",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/33544?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-26T21:24:35Z",
+       "Email": "brandon@ifup.org",
+       "Name": "Brandon Philips",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/33544?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-26T22:28:02Z",
+       "Email": "brandon@ifup.org",
+       "Name": "Brandon Philips",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/33544?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-26T21:03:37Z",
+       "Email": "brandon@ifup.org",
+       "Name": "Brandon Philips",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/33544?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-25T11:08:39-07:00",
+       "Email": "yuzhihong@gmail.com",
+       "Name": "Ted Yu",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/235188?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-25T12:54:23-04:00",
+       "Email": "spzala@us.ibm.com",
+       "Name": "Sahdev Zala",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6462877?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-25T09:14:30-07:00",
+       "Email": "yuzhihong@gmail.com",
+       "Name": "Ted Yu",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/235188?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-23T14:55:11-07:00",
+       "Email": "leegyuho@amazon.com",
+       "Name": "Gyuho Lee",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6799218?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-23T15:53:05-04:00",
+       "Email": "spzala@us.ibm.com",
+       "Name": "Sahdev P. Zala",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6462877?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-23T11:02:27-07:00",
+       "Email": "bphilips@redhat.com",
+       "Name": "Brandon Philips",
+       "AvatarURL": "https://camo.githubusercontent.com/da245587335a1436fc7e82d42652b52832174bc55aa1357bf2a846a036b912f0/68747470733a2f2f312e67726176617461722e636f6d2f6176617461722f62633635396638626163643433363930343233366537323134613165303939353f643d68747470732533412532462532466769746875622e6769746875626173736574732e636f6d253246696d6167657325324667726176617461727325324667726176617461722d757365722d3432302e706e6726723d67"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-23T10:47:02-07:00",
+       "Email": "brandon@ifup.org",
+       "Name": "Brandon Philips",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/33544?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-23T11:24:42-04:00",
+       "Email": "spzala@us.ibm.com",
+       "Name": "Sahdev Zala",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6462877?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-16T13:31:19-07:00",
+       "Email": "leegyuho@amazon.com",
+       "Name": "Gyuho Lee",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6799218?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-23T07:50:29+09:00",
+       "Email": "h.mitake@gmail.com",
+       "Name": "Hitoshi Mitake",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/1173955?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-22T11:38:58-04:00",
+       "Email": "spzala@us.ibm.com",
+       "Name": "Sahdev Zala",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6462877?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-22T11:26:07-04:00",
+       "Email": "spzala@us.ibm.com",
+       "Name": "Sahdev Zala",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6462877?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-20T01:11:52+09:00",
+       "Email": "h.mitake@gmail.com",
+       "Name": "Hitoshi Mitake",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/1173955?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-21T22:58:48-04:00",
+       "Email": "spzala@us.ibm.com",
+       "Name": "Sahdev Zala",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6462877?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-08T13:50:12-04:00",
+       "Email": "sbatsche@redhat.com",
+       "Name": "Sam Batschelet",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/1249749?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-20T11:31:17-04:00",
+       "Email": "spzala@us.ibm.com",
+       "Name": "Sahdev Zala",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6462877?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-16T15:00:58+08:00",
+       "Email": "malinbupt@gmail.com",
+       "Name": "mlmhl",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/7688266?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-18T12:20:03+08:00",
+       "Email": "malinbupt@gmail.com",
+       "Name": "mlmhl",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/7688266?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-17T15:29:10-07:00",
+       "Email": "leegyuho@amazon.com",
+       "Name": "Gyuho Lee",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6799218?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-16T19:34:51-07:00",
+       "Email": "leegyuho@amazon.com",
+       "Name": "Gyuho Lee",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6799218?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-17T09:30:22+08:00",
+       "Email": "tangcong506@gmail.com",
+       "Name": "tangcong",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/2403673?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-12T00:35:12+08:00",
+       "Email": "tangcong506@gmail.com",
+       "Name": "tangcong",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/2403673?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-12T00:09:17+08:00",
+       "Email": "tangcong506@gmail.com",
+       "Name": "tangcong",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/2403673?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-16T12:01:33-07:00",
+       "Email": "yoyinzyc@gmail.com",
+       "Name": "yoyinzyc",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/11894762?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-15T19:13:19-04:00",
+       "Email": "spzala@us.ibm.com",
+       "Name": "Sahdev Zala",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6462877?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-15T18:16:36-04:00",
+       "Email": "spzala@us.ibm.com",
+       "Name": "Sahdev Zala",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6462877?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-13T14:53:18Z",
+       "Email": "narang@us.ibm.com",
+       "Name": "Nirman Narang",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/8256882?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-12T22:44:37-04:00",
+       "Email": "andrei@cockroachlabs.com",
+       "Name": "Andrei Matei",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/377201?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-10T10:14:15-07:00",
+       "Email": "leegyuho@amazon.com",
+       "Name": "Gyuho Lee",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6799218?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-10T23:38:36+08:00",
+       "Email": "tangcong506@gmail.com",
+       "Name": "tangcong",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/2403673?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-10T23:24:46+08:00",
+       "Email": "jingyih@google.com",
+       "Name": "Jingyi Hu",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/23108879?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-10T19:30:32+08:00",
+       "Email": "tangcong506@gmail.com",
+       "Name": "tangcong",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/2403673?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-10T00:09:46+08:00",
+       "Email": "tangcong506@gmail.com",
+       "Name": "tangcong",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/2403673?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-09T23:50:17+08:00",
+       "Email": "tangcong506@gmail.com",
+       "Name": "tangcong",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/2403673?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-07T18:15:02+02:00",
+       "Email": "fbranczyk@gmail.com",
+       "Name": "Frederic Branczyk",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/4546722?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-07T18:14:23+02:00",
+       "Email": "fbranczyk@gmail.com",
+       "Name": "Frederic Branczyk",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/4546722?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-07T18:13:41+02:00",
+       "Email": "fbranczyk@gmail.com",
+       "Name": "Frederic Branczyk",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/4546722?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-07T11:27:46+08:00",
+       "Email": "fullstop1005@gmail.com",
+       "Name": "Fullstop000",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/12471960?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-06T16:56:45-04:00",
+       "Email": "spzala@us.ibm.com",
+       "Name": "Sahdev Zala",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6462877?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-06T12:07:59-07:00",
+       "Email": "xiangli.cs@gmail.com",
+       "Name": "Xiang Li",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/4479947?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-06T10:49:49-07:00",
+       "Email": "bphilips@redhat.com",
+       "Name": "Brandon Philips",
+       "AvatarURL": "https://camo.githubusercontent.com/da245587335a1436fc7e82d42652b52832174bc55aa1357bf2a846a036b912f0/68747470733a2f2f312e67726176617461722e636f6d2f6176617461722f62633635396638626163643433363930343233366537323134613165303939353f643d68747470732533412532462532466769746875622e6769746875626173736574732e636f6d253246696d6167657325324667726176617461727325324667726176617461722d757365722d3432302e706e6726723d67"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-07T01:16:47+08:00",
+       "Email": "tangcong506@gmail.com",
+       "Name": "tangcong",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/2403673?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-06T21:56:05+08:00",
+       "Email": "jingyih@google.com",
+       "Name": "Jingyi Hu",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/23108879?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-06T22:46:14+09:00",
+       "Email": "h.mitake@gmail.com",
+       "Name": "Hitoshi Mitake",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/1173955?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-06T22:45:55+09:00",
+       "Email": "h.mitake@gmail.com",
+       "Name": "Hitoshi Mitake",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/1173955?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-06T16:55:55+08:00",
+       "Email": "malinbupt@gmail.com",
+       "Name": "mlmhl",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/7688266?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-06T13:43:37+08:00",
+       "Email": "mcx_221@foxmail.com",
+       "Name": "Changxin Miao",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/2657334?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-05T19:27:13+08:00",
+       "Email": "tangcong506@gmail.com",
+       "Name": "tangcong",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/2403673?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-04T14:46:03-07:00",
+       "Email": "yczhou@google.com",
+       "Name": "Yuchen Zhou",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/11894762?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-05T05:41:19+08:00",
+       "Email": "zhanw15@gmail.com",
+       "Name": "zhanwang",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/33194527?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-04T14:38:14-07:00",
+       "Email": "lars.lehtonen@gmail.com",
+       "Name": "Lars Lehtonen",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/28523?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-02T21:42:48+08:00",
+       "Email": "jingyih@google.com",
+       "Name": "Jingyi Hu",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/23108879?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-02T10:57:13+08:00",
+       "Email": "malinbupt@gmail.com",
+       "Name": "mlmhl",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/7688266?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-02T10:04:35+08:00",
+       "Email": "zhangbitao01@gmail.com",
+       "Name": "zhangbitao",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/3415872?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-01T12:05:00-07:00",
+       "Email": "leegyuho@amazon.com",
+       "Name": "Gyuho Lee",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6799218?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-01T10:55:48-07:00",
+       "Email": "leegyuho@amazon.com",
+       "Name": "Gyuho Lee",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6799218?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-01T09:08:10-07:00",
+       "Email": "leegyuho@amazon.com",
+       "Name": "Gyuho Lee",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6799218?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-04-01T23:24:35+08:00",
+       "Email": "jingyih@google.com",
+       "Name": "Jingyi Hu",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/23108879?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-03-31T20:34:16-07:00",
+       "Email": "leegyuho@amazon.com",
+       "Name": "Gyuho Lee",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6799218?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-03-31T20:31:32-07:00",
+       "Email": "leegyuho@amazon.com",
+       "Name": "Gyuho Lee",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6799218?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-03-31T20:31:24-07:00",
+       "Email": "leegyuho@amazon.com",
+       "Name": "Gyuho Lee",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6799218?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-03-30T17:21:40+08:00",
+       "Email": "shawwang@tencent.com",
+       "Name": "shawwang",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/7612790?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-03-29T12:43:18-07:00",
+       "Email": "leegyuho@amazon.com",
+       "Name": "Gyuho Lee",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6799218?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-03-29T12:38:04-07:00",
+       "Email": "leegyuho@amazon.com",
+       "Name": "Gyuho Lee",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6799218?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-03-29T12:30:49-07:00",
+       "Email": "leegyuho@amazon.com",
+       "Name": "Gyuho Lee",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6799218?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-03-29T08:09:46+08:00",
+       "Email": "tangcong506@gmail.com",
+       "Name": "tangcong",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/2403673?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-03-27T11:13:58-04:00",
+       "Email": "spzala@us.ibm.com",
+       "Name": "Sahdev Zala",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6462877?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-02-18T23:36:55-08:00",
+       "Email": "jingyih@google.com",
+       "Name": "jingyih",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/23108879?v=4"
+      }
+     ]
+    }
+   },
+   {
+    "Authors": {
+     "Nodes": [
+      {
+       "Date": "2020-03-25T18:07:44-07:00",
+       "Email": "leegyuho@amazon.com",
+       "Name": "Gyuho Lee",
+       "AvatarURL": "https://avatars.githubusercontent.com/u/6799218?v=4"
+      }
+     ]
+    }
+   }
+  ],
+  "PageInfo": {
+   "HasNextPage": true,
+   "EndCursor": "461eb90e5e85791f08332657dfdfa1a60677edf5 99"
+  }
+ }

--- a/internal/extsvc/github/testdata/vcr/RecentCommitters.yaml
+++ b/internal/extsvc/github/testdata/vcr/RecentCommitters.yaml
@@ -1,0 +1,151 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"query":"\n\t  query($name: String!, $owner: String!, $after: String,
+      $first: Int!) {\n\t\trepository(name: $name, owner: $owner) {\n\t\t  defaultBranchRef
+      {\n\t\t\ttarget {\n\t\t\t  ... on Commit {\n\t\t\t\thistory(after: $after, first:
+      $first) {\n\t\t\t\t  pageInfo { hasNextPage, endCursor }\n\t\t\t\t  nodes {\n\t\t\t\t\tauthors(first:
+      50) {\n\t\t\t\t\t  nodes {\n\t\t\t\t\t\temail\n\t\t\t\t\t\tname\n\t\t\t\t\t\tavatarUrl\n\t\t\t\t\t\tdate\n\t\t\t\t\t  }\n\t\t\t\t\t}\n\t\t\t\t  }\n\t\t\t\t}\n\t\t\t  }\n\t\t\t}\n\t\t  }\n\t\t}\n\t  }\n\t","variables":{"first":100,"name":"etcd","owner":"sourcegraph-testing"}}'
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.antiope-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/graphql
+    method: POST
+  response:
+    body: '{"data":{"repository":{"defaultBranchRef":{"target":{"history":{"pageInfo":{"hasNextPage":true,"endCursor":"461eb90e5e85791f08332657dfdfa1a60677edf5
+      99"},"nodes":[{"authors":{"nodes":[{"email":"eric@eric-fritz.com","name":"Eric
+      Fritz","avatarUrl":"https://avatars.githubusercontent.com/u/103087?v=4","date":"2021-05-12T18:17:49-05:00"}]}},{"authors":{"nodes":[{"email":"eric@eric-fritz.com","name":"Eric
+      Fritz","avatarUrl":"https://avatars.githubusercontent.com/u/103087?v=4","date":"2021-05-12T17:42:19-05:00"}]}},{"authors":{"nodes":[{"email":"eric@eric-fritz.com","name":"Eric
+      Fritz","avatarUrl":"https://avatars.githubusercontent.com/u/103087?v=4","date":"2021-05-12T17:38:55-05:00"}]}},{"authors":{"nodes":[{"email":"mrnugget@gmail.com","name":"Thorsten
+      Ball","avatarUrl":"https://avatars.githubusercontent.com/u/1185253?v=4","date":"2021-03-11T14:25:14+01:00"}]}},{"authors":{"nodes":[{"email":"mrnugget@gmail.com","name":"Thorsten
+      Ball","avatarUrl":"https://avatars.githubusercontent.com/u/1185253?v=4","date":"2021-03-11T14:24:26+01:00"}]}},{"authors":{"nodes":[{"email":"xiangli.cs@gmail.com","name":"Xiang
+      Li","avatarUrl":"https://avatars.githubusercontent.com/u/4479947?v=4","date":"2020-05-04T23:26:22-07:00"}]}},{"authors":{"nodes":[{"email":"yuzhihong@gmail.com","name":"Zhihong
+      Yu","avatarUrl":"https://avatars.githubusercontent.com/u/235188?v=4","date":"2020-05-04T17:43:08-07:00"}]}},{"authors":{"nodes":[{"email":"yuzhihong@gmail.com","name":"Zhihong
+      Yu","avatarUrl":"https://avatars.githubusercontent.com/u/235188?v=4","date":"2020-05-04T15:46:36-07:00"}]}},{"authors":{"nodes":[{"email":"spzala@us.ibm.com","name":"Sahdev
+      Zala","avatarUrl":"https://avatars.githubusercontent.com/u/6462877?v=4","date":"2020-05-04T13:37:55-04:00"}]}},{"authors":{"nodes":[{"email":"spzala@us.ibm.com","name":"Sahdev
+      P. Zala","avatarUrl":"https://avatars.githubusercontent.com/u/6462877?v=4","date":"2020-05-04T12:40:34-04:00"}]}},{"authors":{"nodes":[{"email":"h.mitake@gmail.com","name":"Hitoshi
+      Mitake","avatarUrl":"https://avatars.githubusercontent.com/u/1173955?v=4","date":"2020-05-03T23:32:25+09:00"}]}},{"authors":{"nodes":[{"email":"h.mitake@gmail.com","name":"Hitoshi
+      Mitake","avatarUrl":"https://avatars.githubusercontent.com/u/1173955?v=4","date":"2020-05-03T17:17:30+09:00"}]}},{"authors":{"nodes":[{"email":"spzala@us.ibm.com","name":"Sahdev
+      Zala","avatarUrl":"https://avatars.githubusercontent.com/u/6462877?v=4","date":"2020-04-30T11:08:33-04:00"}]}},{"authors":{"nodes":[{"email":"krzysztof.t.kruk@gmail.com","name":"Krzysztof
+      Kruk","avatarUrl":"https://avatars.githubusercontent.com/u/40073114?v=4","date":"2020-04-30T13:59:17+02:00"}]}},{"authors":{"nodes":[{"email":"brandon@ifup.org","name":"Brandon
+      Philips","avatarUrl":"https://avatars.githubusercontent.com/u/33544?v=4","date":"2020-04-29T05:35:06-07:00"}]}},{"authors":{"nodes":[{"email":"leegyuho@amazon.com","name":"Gyuho
+      Lee","avatarUrl":"https://avatars.githubusercontent.com/u/6799218?v=4","date":"2020-04-28T23:27:08-07:00"}]}},{"authors":{"nodes":[{"email":"leegyuho@amazon.com","name":"Gyuho
+      Lee","avatarUrl":"https://avatars.githubusercontent.com/u/6799218?v=4","date":"2020-04-28T20:54:13-07:00"}]}},{"authors":{"nodes":[{"email":"yuzhihong@gmail.com","name":"Ted
+      Yu","avatarUrl":"https://avatars.githubusercontent.com/u/235188?v=4","date":"2020-04-28T20:33:40-07:00"}]}},{"authors":{"nodes":[{"email":"brandon@ifup.org","name":"Brandon
+      Philips","avatarUrl":"https://avatars.githubusercontent.com/u/33544?v=4","date":"2020-04-28T16:11:26-07:00"}]}},{"authors":{"nodes":[{"email":"brandon@ifup.org","name":"Brandon
+      Philips","avatarUrl":"https://avatars.githubusercontent.com/u/33544?v=4","date":"2020-04-28T15:24:29-07:00"}]}},{"authors":{"nodes":[{"email":"brandon@ifup.org","name":"Brandon
+      Philips","avatarUrl":"https://avatars.githubusercontent.com/u/33544?v=4","date":"2020-04-28T15:12:50-07:00"}]}},{"authors":{"nodes":[{"email":"brandon@ifup.org","name":"Brandon
+      Philips","avatarUrl":"https://avatars.githubusercontent.com/u/33544?v=4","date":"2020-04-28T22:02:19Z"}]}},{"authors":{"nodes":[{"email":"gaurav1086@gmail.com","name":"Gaurav
+      Singh","avatarUrl":"https://avatars.githubusercontent.com/u/1029926?v=4","date":"2020-04-26T11:16:25-04:00"}]}},{"authors":{"nodes":[{"email":"gaurav1086@gmail.com","name":"Gaurav
+      Singh","avatarUrl":"https://avatars.githubusercontent.com/u/1029926?v=4","date":"2020-04-25T22:48:04-04:00"}]}},{"authors":{"nodes":[{"email":"brandon@ifup.org","name":"Brandon
+      Philips","avatarUrl":"https://avatars.githubusercontent.com/u/33544?v=4","date":"2020-04-27T14:54:34Z"}]}},{"authors":{"nodes":[{"email":"brandon@ifup.org","name":"Brandon
+      Philips","avatarUrl":"https://avatars.githubusercontent.com/u/33544?v=4","date":"2020-04-27T15:41:00Z"}]}},{"authors":{"nodes":[{"email":"brandon@ifup.org","name":"Brandon
+      Philips","avatarUrl":"https://avatars.githubusercontent.com/u/33544?v=4","date":"2020-04-27T06:09:09Z"}]}},{"authors":{"nodes":[{"email":"brandon@ifup.org","name":"Brandon
+      Philips","avatarUrl":"https://avatars.githubusercontent.com/u/33544?v=4","date":"2020-04-27T00:49:18Z"}]}},{"authors":{"nodes":[{"email":"brandon@ifup.org","name":"Brandon
+      Philips","avatarUrl":"https://avatars.githubusercontent.com/u/33544?v=4","date":"2020-04-26T21:24:35Z"}]}},{"authors":{"nodes":[{"email":"brandon@ifup.org","name":"Brandon
+      Philips","avatarUrl":"https://avatars.githubusercontent.com/u/33544?v=4","date":"2020-04-26T22:28:02Z"}]}},{"authors":{"nodes":[{"email":"brandon@ifup.org","name":"Brandon
+      Philips","avatarUrl":"https://avatars.githubusercontent.com/u/33544?v=4","date":"2020-04-26T21:03:37Z"}]}},{"authors":{"nodes":[{"email":"yuzhihong@gmail.com","name":"Ted
+      Yu","avatarUrl":"https://avatars.githubusercontent.com/u/235188?v=4","date":"2020-04-25T11:08:39-07:00"}]}},{"authors":{"nodes":[{"email":"spzala@us.ibm.com","name":"Sahdev
+      Zala","avatarUrl":"https://avatars.githubusercontent.com/u/6462877?v=4","date":"2020-04-25T12:54:23-04:00"}]}},{"authors":{"nodes":[{"email":"yuzhihong@gmail.com","name":"Ted
+      Yu","avatarUrl":"https://avatars.githubusercontent.com/u/235188?v=4","date":"2020-04-25T09:14:30-07:00"}]}},{"authors":{"nodes":[{"email":"leegyuho@amazon.com","name":"Gyuho
+      Lee","avatarUrl":"https://avatars.githubusercontent.com/u/6799218?v=4","date":"2020-04-23T14:55:11-07:00"}]}},{"authors":{"nodes":[{"email":"spzala@us.ibm.com","name":"Sahdev
+      P. Zala","avatarUrl":"https://avatars.githubusercontent.com/u/6462877?v=4","date":"2020-04-23T15:53:05-04:00"}]}},{"authors":{"nodes":[{"email":"bphilips@redhat.com","name":"Brandon
+      Philips","avatarUrl":"https://camo.githubusercontent.com/da245587335a1436fc7e82d42652b52832174bc55aa1357bf2a846a036b912f0/68747470733a2f2f312e67726176617461722e636f6d2f6176617461722f62633635396638626163643433363930343233366537323134613165303939353f643d68747470732533412532462532466769746875622e6769746875626173736574732e636f6d253246696d6167657325324667726176617461727325324667726176617461722d757365722d3432302e706e6726723d67","date":"2020-04-23T11:02:27-07:00"}]}},{"authors":{"nodes":[{"email":"brandon@ifup.org","name":"Brandon
+      Philips","avatarUrl":"https://avatars.githubusercontent.com/u/33544?v=4","date":"2020-04-23T10:47:02-07:00"}]}},{"authors":{"nodes":[{"email":"spzala@us.ibm.com","name":"Sahdev
+      Zala","avatarUrl":"https://avatars.githubusercontent.com/u/6462877?v=4","date":"2020-04-23T11:24:42-04:00"}]}},{"authors":{"nodes":[{"email":"leegyuho@amazon.com","name":"Gyuho
+      Lee","avatarUrl":"https://avatars.githubusercontent.com/u/6799218?v=4","date":"2020-04-16T13:31:19-07:00"}]}},{"authors":{"nodes":[{"email":"h.mitake@gmail.com","name":"Hitoshi
+      Mitake","avatarUrl":"https://avatars.githubusercontent.com/u/1173955?v=4","date":"2020-04-23T07:50:29+09:00"}]}},{"authors":{"nodes":[{"email":"spzala@us.ibm.com","name":"Sahdev
+      Zala","avatarUrl":"https://avatars.githubusercontent.com/u/6462877?v=4","date":"2020-04-22T11:38:58-04:00"}]}},{"authors":{"nodes":[{"email":"spzala@us.ibm.com","name":"Sahdev
+      Zala","avatarUrl":"https://avatars.githubusercontent.com/u/6462877?v=4","date":"2020-04-22T11:26:07-04:00"}]}},{"authors":{"nodes":[{"email":"h.mitake@gmail.com","name":"Hitoshi
+      Mitake","avatarUrl":"https://avatars.githubusercontent.com/u/1173955?v=4","date":"2020-04-20T01:11:52+09:00"}]}},{"authors":{"nodes":[{"email":"spzala@us.ibm.com","name":"Sahdev
+      Zala","avatarUrl":"https://avatars.githubusercontent.com/u/6462877?v=4","date":"2020-04-21T22:58:48-04:00"}]}},{"authors":{"nodes":[{"email":"sbatsche@redhat.com","name":"Sam
+      Batschelet","avatarUrl":"https://avatars.githubusercontent.com/u/1249749?v=4","date":"2020-04-08T13:50:12-04:00"}]}},{"authors":{"nodes":[{"email":"spzala@us.ibm.com","name":"Sahdev
+      Zala","avatarUrl":"https://avatars.githubusercontent.com/u/6462877?v=4","date":"2020-04-20T11:31:17-04:00"}]}},{"authors":{"nodes":[{"email":"malinbupt@gmail.com","name":"mlmhl","avatarUrl":"https://avatars.githubusercontent.com/u/7688266?v=4","date":"2020-04-16T15:00:58+08:00"}]}},{"authors":{"nodes":[{"email":"malinbupt@gmail.com","name":"mlmhl","avatarUrl":"https://avatars.githubusercontent.com/u/7688266?v=4","date":"2020-04-18T12:20:03+08:00"}]}},{"authors":{"nodes":[{"email":"leegyuho@amazon.com","name":"Gyuho
+      Lee","avatarUrl":"https://avatars.githubusercontent.com/u/6799218?v=4","date":"2020-04-17T15:29:10-07:00"}]}},{"authors":{"nodes":[{"email":"leegyuho@amazon.com","name":"Gyuho
+      Lee","avatarUrl":"https://avatars.githubusercontent.com/u/6799218?v=4","date":"2020-04-16T19:34:51-07:00"}]}},{"authors":{"nodes":[{"email":"tangcong506@gmail.com","name":"tangcong","avatarUrl":"https://avatars.githubusercontent.com/u/2403673?v=4","date":"2020-04-17T09:30:22+08:00"}]}},{"authors":{"nodes":[{"email":"tangcong506@gmail.com","name":"tangcong","avatarUrl":"https://avatars.githubusercontent.com/u/2403673?v=4","date":"2020-04-12T00:35:12+08:00"}]}},{"authors":{"nodes":[{"email":"tangcong506@gmail.com","name":"tangcong","avatarUrl":"https://avatars.githubusercontent.com/u/2403673?v=4","date":"2020-04-12T00:09:17+08:00"}]}},{"authors":{"nodes":[{"email":"yoyinzyc@gmail.com","name":"yoyinzyc","avatarUrl":"https://avatars.githubusercontent.com/u/11894762?v=4","date":"2020-04-16T12:01:33-07:00"}]}},{"authors":{"nodes":[{"email":"spzala@us.ibm.com","name":"Sahdev
+      Zala","avatarUrl":"https://avatars.githubusercontent.com/u/6462877?v=4","date":"2020-04-15T19:13:19-04:00"}]}},{"authors":{"nodes":[{"email":"spzala@us.ibm.com","name":"Sahdev
+      Zala","avatarUrl":"https://avatars.githubusercontent.com/u/6462877?v=4","date":"2020-04-15T18:16:36-04:00"}]}},{"authors":{"nodes":[{"email":"narang@us.ibm.com","name":"Nirman
+      Narang","avatarUrl":"https://avatars.githubusercontent.com/u/8256882?v=4","date":"2020-04-13T14:53:18Z"}]}},{"authors":{"nodes":[{"email":"andrei@cockroachlabs.com","name":"Andrei
+      Matei","avatarUrl":"https://avatars.githubusercontent.com/u/377201?v=4","date":"2020-04-12T22:44:37-04:00"}]}},{"authors":{"nodes":[{"email":"leegyuho@amazon.com","name":"Gyuho
+      Lee","avatarUrl":"https://avatars.githubusercontent.com/u/6799218?v=4","date":"2020-04-10T10:14:15-07:00"}]}},{"authors":{"nodes":[{"email":"tangcong506@gmail.com","name":"tangcong","avatarUrl":"https://avatars.githubusercontent.com/u/2403673?v=4","date":"2020-04-10T23:38:36+08:00"}]}},{"authors":{"nodes":[{"email":"jingyih@google.com","name":"Jingyi
+      Hu","avatarUrl":"https://avatars.githubusercontent.com/u/23108879?v=4","date":"2020-04-10T23:24:46+08:00"}]}},{"authors":{"nodes":[{"email":"tangcong506@gmail.com","name":"tangcong","avatarUrl":"https://avatars.githubusercontent.com/u/2403673?v=4","date":"2020-04-10T19:30:32+08:00"}]}},{"authors":{"nodes":[{"email":"tangcong506@gmail.com","name":"tangcong","avatarUrl":"https://avatars.githubusercontent.com/u/2403673?v=4","date":"2020-04-10T00:09:46+08:00"}]}},{"authors":{"nodes":[{"email":"tangcong506@gmail.com","name":"tangcong","avatarUrl":"https://avatars.githubusercontent.com/u/2403673?v=4","date":"2020-04-09T23:50:17+08:00"}]}},{"authors":{"nodes":[{"email":"fbranczyk@gmail.com","name":"Frederic
+      Branczyk","avatarUrl":"https://avatars.githubusercontent.com/u/4546722?v=4","date":"2020-04-07T18:15:02+02:00"}]}},{"authors":{"nodes":[{"email":"fbranczyk@gmail.com","name":"Frederic
+      Branczyk","avatarUrl":"https://avatars.githubusercontent.com/u/4546722?v=4","date":"2020-04-07T18:14:23+02:00"}]}},{"authors":{"nodes":[{"email":"fbranczyk@gmail.com","name":"Frederic
+      Branczyk","avatarUrl":"https://avatars.githubusercontent.com/u/4546722?v=4","date":"2020-04-07T18:13:41+02:00"}]}},{"authors":{"nodes":[{"email":"fullstop1005@gmail.com","name":"Fullstop000","avatarUrl":"https://avatars.githubusercontent.com/u/12471960?v=4","date":"2020-04-07T11:27:46+08:00"}]}},{"authors":{"nodes":[{"email":"spzala@us.ibm.com","name":"Sahdev
+      Zala","avatarUrl":"https://avatars.githubusercontent.com/u/6462877?v=4","date":"2020-04-06T16:56:45-04:00"}]}},{"authors":{"nodes":[{"email":"xiangli.cs@gmail.com","name":"Xiang
+      Li","avatarUrl":"https://avatars.githubusercontent.com/u/4479947?v=4","date":"2020-04-06T12:07:59-07:00"}]}},{"authors":{"nodes":[{"email":"bphilips@redhat.com","name":"Brandon
+      Philips","avatarUrl":"https://camo.githubusercontent.com/da245587335a1436fc7e82d42652b52832174bc55aa1357bf2a846a036b912f0/68747470733a2f2f312e67726176617461722e636f6d2f6176617461722f62633635396638626163643433363930343233366537323134613165303939353f643d68747470732533412532462532466769746875622e6769746875626173736574732e636f6d253246696d6167657325324667726176617461727325324667726176617461722d757365722d3432302e706e6726723d67","date":"2020-04-06T10:49:49-07:00"}]}},{"authors":{"nodes":[{"email":"tangcong506@gmail.com","name":"tangcong","avatarUrl":"https://avatars.githubusercontent.com/u/2403673?v=4","date":"2020-04-07T01:16:47+08:00"}]}},{"authors":{"nodes":[{"email":"jingyih@google.com","name":"Jingyi
+      Hu","avatarUrl":"https://avatars.githubusercontent.com/u/23108879?v=4","date":"2020-04-06T21:56:05+08:00"}]}},{"authors":{"nodes":[{"email":"h.mitake@gmail.com","name":"Hitoshi
+      Mitake","avatarUrl":"https://avatars.githubusercontent.com/u/1173955?v=4","date":"2020-04-06T22:46:14+09:00"}]}},{"authors":{"nodes":[{"email":"h.mitake@gmail.com","name":"Hitoshi
+      Mitake","avatarUrl":"https://avatars.githubusercontent.com/u/1173955?v=4","date":"2020-04-06T22:45:55+09:00"}]}},{"authors":{"nodes":[{"email":"malinbupt@gmail.com","name":"mlmhl","avatarUrl":"https://avatars.githubusercontent.com/u/7688266?v=4","date":"2020-04-06T16:55:55+08:00"}]}},{"authors":{"nodes":[{"email":"mcx_221@foxmail.com","name":"Changxin
+      Miao","avatarUrl":"https://avatars.githubusercontent.com/u/2657334?v=4","date":"2020-04-06T13:43:37+08:00"}]}},{"authors":{"nodes":[{"email":"tangcong506@gmail.com","name":"tangcong","avatarUrl":"https://avatars.githubusercontent.com/u/2403673?v=4","date":"2020-04-05T19:27:13+08:00"}]}},{"authors":{"nodes":[{"email":"yczhou@google.com","name":"Yuchen
+      Zhou","avatarUrl":"https://avatars.githubusercontent.com/u/11894762?v=4","date":"2020-04-04T14:46:03-07:00"}]}},{"authors":{"nodes":[{"email":"zhanw15@gmail.com","name":"zhanwang","avatarUrl":"https://avatars.githubusercontent.com/u/33194527?v=4","date":"2020-04-05T05:41:19+08:00"}]}},{"authors":{"nodes":[{"email":"lars.lehtonen@gmail.com","name":"Lars
+      Lehtonen","avatarUrl":"https://avatars.githubusercontent.com/u/28523?v=4","date":"2020-04-04T14:38:14-07:00"}]}},{"authors":{"nodes":[{"email":"jingyih@google.com","name":"Jingyi
+      Hu","avatarUrl":"https://avatars.githubusercontent.com/u/23108879?v=4","date":"2020-04-02T21:42:48+08:00"}]}},{"authors":{"nodes":[{"email":"malinbupt@gmail.com","name":"mlmhl","avatarUrl":"https://avatars.githubusercontent.com/u/7688266?v=4","date":"2020-04-02T10:57:13+08:00"}]}},{"authors":{"nodes":[{"email":"zhangbitao01@gmail.com","name":"zhangbitao","avatarUrl":"https://avatars.githubusercontent.com/u/3415872?v=4","date":"2020-04-02T10:04:35+08:00"}]}},{"authors":{"nodes":[{"email":"leegyuho@amazon.com","name":"Gyuho
+      Lee","avatarUrl":"https://avatars.githubusercontent.com/u/6799218?v=4","date":"2020-04-01T12:05:00-07:00"}]}},{"authors":{"nodes":[{"email":"leegyuho@amazon.com","name":"Gyuho
+      Lee","avatarUrl":"https://avatars.githubusercontent.com/u/6799218?v=4","date":"2020-04-01T10:55:48-07:00"}]}},{"authors":{"nodes":[{"email":"leegyuho@amazon.com","name":"Gyuho
+      Lee","avatarUrl":"https://avatars.githubusercontent.com/u/6799218?v=4","date":"2020-04-01T09:08:10-07:00"}]}},{"authors":{"nodes":[{"email":"jingyih@google.com","name":"Jingyi
+      Hu","avatarUrl":"https://avatars.githubusercontent.com/u/23108879?v=4","date":"2020-04-01T23:24:35+08:00"}]}},{"authors":{"nodes":[{"email":"leegyuho@amazon.com","name":"Gyuho
+      Lee","avatarUrl":"https://avatars.githubusercontent.com/u/6799218?v=4","date":"2020-03-31T20:34:16-07:00"}]}},{"authors":{"nodes":[{"email":"leegyuho@amazon.com","name":"Gyuho
+      Lee","avatarUrl":"https://avatars.githubusercontent.com/u/6799218?v=4","date":"2020-03-31T20:31:32-07:00"}]}},{"authors":{"nodes":[{"email":"leegyuho@amazon.com","name":"Gyuho
+      Lee","avatarUrl":"https://avatars.githubusercontent.com/u/6799218?v=4","date":"2020-03-31T20:31:24-07:00"}]}},{"authors":{"nodes":[{"email":"shawwang@tencent.com","name":"shawwang","avatarUrl":"https://avatars.githubusercontent.com/u/7612790?v=4","date":"2020-03-30T17:21:40+08:00"}]}},{"authors":{"nodes":[{"email":"leegyuho@amazon.com","name":"Gyuho
+      Lee","avatarUrl":"https://avatars.githubusercontent.com/u/6799218?v=4","date":"2020-03-29T12:43:18-07:00"}]}},{"authors":{"nodes":[{"email":"leegyuho@amazon.com","name":"Gyuho
+      Lee","avatarUrl":"https://avatars.githubusercontent.com/u/6799218?v=4","date":"2020-03-29T12:38:04-07:00"}]}},{"authors":{"nodes":[{"email":"leegyuho@amazon.com","name":"Gyuho
+      Lee","avatarUrl":"https://avatars.githubusercontent.com/u/6799218?v=4","date":"2020-03-29T12:30:49-07:00"}]}},{"authors":{"nodes":[{"email":"tangcong506@gmail.com","name":"tangcong","avatarUrl":"https://avatars.githubusercontent.com/u/2403673?v=4","date":"2020-03-29T08:09:46+08:00"}]}},{"authors":{"nodes":[{"email":"spzala@us.ibm.com","name":"Sahdev
+      Zala","avatarUrl":"https://avatars.githubusercontent.com/u/6462877?v=4","date":"2020-03-27T11:13:58-04:00"}]}},{"authors":{"nodes":[{"email":"jingyih@google.com","name":"jingyih","avatarUrl":"https://avatars.githubusercontent.com/u/23108879?v=4","date":"2020-02-18T23:36:55-08:00"}]}},{"authors":{"nodes":[{"email":"leegyuho@amazon.com","name":"Gyuho
+      Lee","avatarUrl":"https://avatars.githubusercontent.com/u/6799218?v=4","date":"2020-03-25T18:07:44-07:00"}]}}]}}}}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 28 Jan 2022 02:02:09 GMT
+      Github-Authentication-Token-Expiration:
+      - 2022-02-27 01:54:25 UTC
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v4; param=antiope-preview; format=json
+      X-Github-Request-Id:
+      - F380:67F3:171F06:4103C3:61F34EA0
+      X-Oauth-Scopes:
+      - repo
+      X-Ratelimit-Limit:
+      - "5000"
+      X-Ratelimit-Remaining:
+      - "4990"
+      X-Ratelimit-Reset:
+      - "1643338478"
+      X-Ratelimit-Resource:
+      - graphql
+      X-Ratelimit-Used:
+      - "10"
+      X-Xss-Protection:
+      - "0"
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -673,7 +673,7 @@ func (c *V4Client) RecentCommitters(ctx context.Context, params *RecentCommitter
 		if errors.As(err, &e) {
 			for _, err2 := range e {
 				if err2.Type == graphqlErrTypeNotFound {
-					log15.Warn("GitHub repository not found", "error", err2)
+					log15.Warn("RecentCommitters: GitHub repository not found", "error", err2)
 					continue
 				}
 				return nil, err

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -588,3 +588,95 @@ func (c *V4Client) Fork(ctx context.Context, owner, repo string, org *string) (*
 	// December 2021, so we have to fall back to the REST API.
 	return NewV3Client(c.apiURL, c.auth, c.httpClient).Fork(ctx, owner, repo, org)
 }
+
+type RecentCommittersParams struct {
+	// Repository name
+	Name string
+	// Repository owner
+	Owner string
+	// After is the cursor to paginate from.
+	After Cursor
+	// First is the page size. Default to 100 if left zero.
+	First int
+}
+
+type RecentCommittersResults struct {
+	Nodes []struct {
+		Authors struct {
+			Nodes []struct {
+				Date      string
+				Email     string
+				Name      string
+				AvatarURL string
+			}
+		}
+	}
+	PageInfo struct {
+		HasNextPage bool
+		EndCursor   Cursor
+	}
+}
+
+// Lists recent committers for a repository.
+func (c *V4Client) RecentCommitters(ctx context.Context, params *RecentCommittersParams) (*RecentCommittersResults, error) {
+	query := `
+	  query($name: String!, $owner: String!, $after: String, $first: Int!) {
+		repository(name: $name, owner: $owner) {
+		  defaultBranchRef {
+			target {
+			  ... on Commit {
+				history(after: $after, first: $first) {
+				  pageInfo { hasNextPage, endCursor }
+				  nodes {
+					authors(first: 50) {
+					  nodes {
+						email
+						name
+						avatarUrl
+						date
+					  }
+					}
+				  }
+				}
+			  }
+			}
+		  }
+		}
+	  }
+	`
+
+	vars := map[string]interface{}{
+		"name":  params.Name,
+		"owner": params.Owner,
+		"first": params.First,
+	}
+	if params.After != "" {
+		vars["after"] = params.After
+	}
+
+	var result struct {
+		Repository struct {
+			DefaultBranchRef struct {
+				Target struct {
+					History RecentCommittersResults
+				}
+			}
+		}
+	}
+	err := c.requestGraphQL(ctx, query, vars, &result)
+	if err != nil {
+		var e graphqlErrors
+		if errors.As(err, &e) {
+			for _, err2 := range e {
+				if err2.Type == graphqlErrTypeNotFound {
+					log15.Warn("GitHub repository not found", "error", err2)
+					continue
+				}
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
+	}
+	return &result.Repository.DefaultBranchRef.Target.History, nil
+}

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -619,6 +619,10 @@ type RecentCommittersResults struct {
 
 // Lists recent committers for a repository.
 func (c *V4Client) RecentCommitters(ctx context.Context, params *RecentCommittersParams) (*RecentCommittersResults, error) {
+	if params.First == 0 {
+		params.First = 100
+	}
+
 	query := `
 	  query($name: String!, $owner: String!, $after: String, $first: Int!) {
 		repository(name: $name, owner: $owner) {

--- a/internal/extsvc/github/v4_test.go
+++ b/internal/extsvc/github/v4_test.go
@@ -645,6 +645,25 @@ query{
 	}
 }
 
+func TestRecentCommitters(t *testing.T) {
+	cli, save := newV4Client(t, "RecentCommitters")
+	t.Cleanup(save)
+
+	recentCommitters, err := cli.RecentCommitters(context.Background(), &RecentCommittersParams{
+		Owner: "sourcegraph-testing",
+		Name:  "etcd",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testutil.AssertGolden(t,
+		"testdata/golden/RecentCommitters",
+		update("SearchRepos-Enterprise"),
+		recentCommitters,
+	)
+}
+
 func TestV4Client_SearchRepos_Enterprise(t *testing.T) {
 	cli, save := newEnterpriseV4Client(t, "SearchRepos-Enterprise")
 	t.Cleanup(save)


### PR DESCRIPTION
I am working on a feature that will let you invite collaborators to your repositories while you wait for repositories to clone on Sourcegraph:

---

<img width="1145" alt="image" src="https://user-images.githubusercontent.com/3173176/151461348-333f8cdd-2b72-441a-98e7-4d519250a0f7.png">

---

In order to identify collaborators we can invite, we need to use GitHub's API (we can't use our own, because the repositories are not yet cloned.) I've added this to our GitHub v4 GraphQL client, and exposed the data over GraphQL via a new `ExternalService.invitableCollaborators` field.

I chose to use the GitHub API for enumerating committers (not the repository collaborator API) because:

1. The collaborator API return's users public emails listed on their GitHub profile, which often aren't the ones e.g. your coworker would use at work and not the one you'd want to invite them via.
2. It gives us "relevance": we can order by most-recent-committer with the idea being that those who commit code frequently are more likely to be the ones you'd want to invite (than, say, someone who committed code last year and left the org.)

To avoid imposing any additional load on our rate limits with the user's GitHub access token, we only query GitHub for 20 repositories out of those that you've chosen to add to Sourcegraph.