### PR TITLE
migrations: Add additional graph utils

### DIFF
--- a/internal/database/migration/definition/definition.go
+++ b/internal/database/migration/definition/definition.go
@@ -58,6 +58,25 @@ func (ds *Definitions) GetByID(id int) (Definition, bool) {
 	return definition, ok
 }
 
+// Root returns the definition with no parents.
+func (ds *Definitions) Root() Definition {
+	return ds.definitions[0]
+}
+
+// Leaves returns the definitions with no children.
+func (ds *Definitions) Leaves() []Definition {
+	childrenMap := children(ds.definitions)
+
+	leaves := make([]Definition, 0, 4)
+	for _, definition := range ds.definitions {
+		if len(childrenMap[definition.ID]) == 0 {
+			leaves = append(leaves, definition)
+		}
+	}
+
+	return leaves
+}
+
 func (ds *Definitions) UpTo(id, target int) ([]Definition, error) {
 	if target == 0 {
 		return ds.UpFrom(id, 0)

--- a/internal/database/migration/definition/definition.go
+++ b/internal/database/migration/definition/definition.go
@@ -40,9 +40,11 @@ func newDefinitions(migrationDefinitions []Definition) *Definitions {
 }
 
 // All returns the set of all definitions ordered such that each migration occurs
-// only after all of its parents. The returned slice is not a copy, so it is not
-// meant to be mutated.
+// only after all of its parents. The returned slice is a copy of the underlying
+// data and can be safely mutated.
 func (ds *Definitions) All() []Definition {
+	definitions := make([]Definition, len(ds.definitions))
+	copy(definitions, ds.definitions)
 	return ds.definitions
 }
 

--- a/internal/database/migration/definition/definition.go
+++ b/internal/database/migration/definition/definition.go
@@ -38,6 +38,13 @@ func newDefinitions(migrationDefinitions []Definition) *Definitions {
 	}
 }
 
+// All returns the set of all definitions ordered such that each migration occurs
+// only after all of its parents. The returned slice is not a copy, so it is not
+// meant to be mutated.
+func (ds *Definitions) All() []Definition {
+	return ds.definitions
+}
+
 func (ds *Definitions) Count() int {
 	return len(ds.definitions)
 }

--- a/internal/database/migration/definition/definition_test.go
+++ b/internal/database/migration/definition/definition_test.go
@@ -4,24 +4,25 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/keegancsmith/sqlf"
 )
 
 func TestDefinitionGetByID(t *testing.T) {
-	definitions := newDefinitions([]Definition{
-		{ID: 1, UpFilename: "1.up.sql"},
-		{ID: 2, UpFilename: "2.up.sql"},
-		{ID: 3, UpFilename: "3.up.sql"},
-		{ID: 4, UpFilename: "4.up.sql"},
-		{ID: 5, UpFilename: "5.up.sql"},
-	})
+	definitions := []Definition{
+		{ID: 1, UpQuery: sqlf.Sprintf(`SELECT 1;`)},
+		{ID: 2, UpQuery: sqlf.Sprintf(`SELECT 2;`), Parents: []int{1}},
+		{ID: 3, UpQuery: sqlf.Sprintf(`SELECT 3;`), Parents: []int{2}},
+		{ID: 4, UpQuery: sqlf.Sprintf(`SELECT 4;`), Parents: []int{3}},
+		{ID: 5, UpQuery: sqlf.Sprintf(`SELECT 5;`), Parents: []int{4}},
+	}
 
-	definition, ok := definitions.GetByID(3)
+	definition, ok := newDefinitions(definitions).GetByID(3)
 	if !ok {
 		t.Fatalf("expected definition")
 	}
 
-	if definition.UpFilename != "3.up.sql" {
-		t.Fatalf("unexpected up filename. want=%q have=%q", "3.up.sql", definition.UpFilename)
+	if diff := cmp.Diff(definitions[2], definition, queryComparer); diff != "" {
+		t.Errorf("unexpected definition (-want, +got):\n%s", diff)
 	}
 }
 

--- a/internal/database/migration/definition/definition_test.go
+++ b/internal/database/migration/definition/definition_test.go
@@ -26,6 +26,28 @@ func TestDefinitionGetByID(t *testing.T) {
 	}
 }
 
+func TestLeaves(t *testing.T) {
+	definitions := []Definition{
+		{ID: 1, UpQuery: sqlf.Sprintf(`SELECT 1;`)},
+		{ID: 2, UpQuery: sqlf.Sprintf(`SELECT 2;`), Parents: []int{1}},
+		{ID: 3, UpQuery: sqlf.Sprintf(`SELECT 3;`), Parents: []int{2}},
+		{ID: 4, UpQuery: sqlf.Sprintf(`SELECT 4;`), Parents: []int{2}},
+		{ID: 5, UpQuery: sqlf.Sprintf(`SELECT 5;`), Parents: []int{3, 4}},
+		{ID: 6, UpQuery: sqlf.Sprintf(`SELECT 6;`), Parents: []int{5}},
+		{ID: 7, UpQuery: sqlf.Sprintf(`SELECT 7;`), Parents: []int{5}},
+		{ID: 8, UpQuery: sqlf.Sprintf(`SELECT 8;`), Parents: []int{5, 6}},
+		{ID: 9, UpQuery: sqlf.Sprintf(`SELECT 9;`), Parents: []int{5, 8}},
+	}
+
+	expectedLeaves := []Definition{
+		definitions[6],
+		definitions[8],
+	}
+	if diff := cmp.Diff(expectedLeaves, newDefinitions(definitions).Leaves(), queryComparer); diff != "" {
+		t.Errorf("unexpected leaves (-want, +got):\n%s", diff)
+	}
+}
+
 func TestUpTo(t *testing.T) {
 	definitions := newDefinitions([]Definition{
 		{ID: 11, UpFilename: "11.up.sql"},

--- a/internal/database/migration/definition/helpers_test.go
+++ b/internal/database/migration/definition/helpers_test.go
@@ -1,0 +1,18 @@
+package definition
+
+import (
+	"strings"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/keegancsmith/sqlf"
+)
+
+var queryComparer = cmp.Comparer(func(a, b *sqlf.Query) bool {
+	if a == nil {
+		return b == nil
+	}
+	if b == nil {
+		return false
+	}
+	return strings.TrimSpace(a.Query(sqlf.PostgresBindVar)) == strings.TrimSpace(b.Query(sqlf.PostgresBindVar))
+})

--- a/internal/database/migration/definition/read_test.go
+++ b/internal/database/migration/definition/read_test.go
@@ -12,16 +12,6 @@ import (
 )
 
 func TestReadDefinitions(t *testing.T) {
-	queryComparer := cmp.Comparer(func(a, b *sqlf.Query) bool {
-		if a == nil {
-			return b == nil
-		}
-		if b == nil {
-			return false
-		}
-		return strings.TrimSpace(a.Query(sqlf.PostgresBindVar)) == strings.TrimSpace(b.Query(sqlf.PostgresBindVar))
-	})
-
 	t.Run("well-formed", func(t *testing.T) {
 		fs, err := fs.Sub(testdata.Content, "well-formed")
 		if err != nil {


### PR DESCRIPTION
Pulled from #29831. This PR adds additional methods onto `Definitions`, which is a topologically ordered sequence of migrations. Currently, we only construct linear chains of migrations.

These new methods are preparing for a world where we construct something _cooler_:

- `All` returns all migrations.
- `Root` returns the migration with no defined _parent_.
- `Leaves` returns migrations with no defined _children_. These are the migrations that should be the parents of newly defined migrations. These are also the set of migration targets we can plug into `Up` (see below) to build the set of migrations which need to be applied on upgrade.
- `Filter` induces a migration subgraph to what it looked like in for a historic commit. This will be useful for squashing old migrations. See `LeafDominator`, which is also related to squashing.
- `LeafDominator` returns the most specific common dominator of the leaves. When squashing, we need to select an old commit that we *know* has been applied on all upgrade paths, and we also need to make sure that the migrations we squash form a single-entry, single-exit graph. This dominator gives exactly these properties.
- `Up` and `Down` returns some filtered subset of definitions that are descendants or ancestors (respectively) of the the target commit on migration operations. This will be used in place of `{Up,Down}{To,From}` methods that compose our current CLI tooling.

**Reviewers**: Each new method (and test) is added in separate commits for cohesion.