### PR TITLE
search: simplify internal alert constructors

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -38,7 +38,7 @@ func (a searchAlert) ProposedQueries() *[]*searchQueryDescription {
 	}
 	var proposedQueries []*searchQueryDescription
 	for _, q := range a.alert.ProposedQueries {
-		proposedQueries = append(proposedQueries, &searchQueryDescription{query: q})
+		proposedQueries = append(proposedQueries, &searchQueryDescription{q})
 	}
 	return &proposedQueries
 }

--- a/cmd/frontend/graphqlbackend/search_query_description.go
+++ b/cmd/frontend/graphqlbackend/search_query_description.go
@@ -11,9 +11,14 @@ type searchQueryDescription struct {
 }
 
 func (q searchQueryDescription) Query() string {
+	// Do not add logic here that manipulates the query string. Do it in the QueryString() method.
 	return q.query.QueryString()
 }
 
 func (q searchQueryDescription) Description() *string {
-	return q.query.Description()
+	if q.query.Description == "" {
+		return nil
+	}
+
+	return &q.query.Description
 }

--- a/internal/search/alert.go
+++ b/internal/search/alert.go
@@ -21,37 +21,25 @@ type Alert struct {
 }
 
 type ProposedQuery struct {
-	description string
-	query       string
-	patternType query.SearchType
-}
-
-func NewProposedQuery(description, query string, patternType query.SearchType) *ProposedQuery {
-	return &ProposedQuery{description: description, query: query, patternType: patternType}
+	Description string
+	Query       string
+	PatternType query.SearchType
 }
 
 func (q *ProposedQuery) QueryString() string {
-	if q.description != "Remove quotes" {
-		switch q.patternType {
+	if q.Description != "Remove quotes" {
+		switch q.PatternType {
 		case query.SearchTypeRegex:
-			return q.query + " patternType:regexp"
+			return q.Query + " patternType:regexp"
 		case query.SearchTypeLiteral:
-			return q.query + " patternType:literal"
+			return q.Query + " patternType:literal"
 		case query.SearchTypeStructural:
-			return q.query + " patternType:structural"
+			return q.Query + " patternType:structural"
 		default:
 			panic("unreachable")
 		}
 	}
-	return q.query
-}
-
-func (q *ProposedQuery) Description() *string {
-	if q.description == "" {
-		return nil
-	}
-
-	return &q.description
+	return q.Query
 }
 
 func AlertForCappedAndExpression() *Alert {
@@ -93,11 +81,11 @@ func AlertForTimeout(usedTime time.Duration, suggestTime time.Duration, queryStr
 		Title:          "Timed out while searching",
 		Description:    fmt.Sprintf("We weren't able to find any results in %s.", usedTime.Round(time.Second)),
 		ProposedQueries: []*ProposedQuery{
-			NewProposedQuery(
-				"query with longer timeout",
-				fmt.Sprintf("timeout:%v %s", suggestTime, query.OmitField(q, query.FieldTimeout)),
-				patternType,
-			),
+			{
+				Description: "query with longer timeout",
+				Query:       fmt.Sprintf("timeout:%v %s", suggestTime, query.OmitField(q, query.FieldTimeout)),
+				PatternType: patternType,
+			},
 		},
 	}
 }
@@ -129,11 +117,11 @@ func AlertForStructuralSearchNotSet(queryString string) *Alert {
 		Title:          "No results",
 		Description:    "It looks like you may have meant to run a structural search, but it is not toggled.",
 		ProposedQueries: []*ProposedQuery{
-			NewProposedQuery(
-				"Activate structural search",
-				queryString,
-				query.SearchTypeStructural,
-			),
+			{
+				Description: "Activate structural search",
+				Query:       queryString,
+				PatternType: query.SearchTypeStructural,
+			},
 		},
 	}
 }

--- a/internal/search/alert/observer.go
+++ b/internal/search/alert/observer.go
@@ -73,11 +73,11 @@ func (o *Observer) alertForNoResolvedRepos(ctx context.Context, q query.Q) *sear
 	if len(contextFilters) == 1 && !searchcontexts.IsGlobalSearchContextSpec(contextFilters[0]) && len(repoFilters) > 0 {
 		withoutContextFilter := query.OmitField(q, query.FieldContext)
 		proposedQueries := []*search.ProposedQuery{
-			search.NewProposedQuery(
-				"search in the global context",
-				fmt.Sprintf("context:%s %s", searchcontexts.GlobalSearchContextName, withoutContextFilter),
-				o.PatternType,
-			),
+			{
+				Description: "search in the global context",
+				Query:       fmt.Sprintf("context:%s %s", searchcontexts.GlobalSearchContextName, withoutContextFilter),
+				PatternType: o.PatternType,
+			},
 		}
 
 		return &search.Alert{
@@ -114,11 +114,11 @@ func (o *Observer) alertForNoResolvedRepos(ctx context.Context, q query.Q) *sear
 		}
 		if o.reposExist(ctx, tryIncludeForks) {
 			proposedQueries = append(proposedQueries,
-				search.NewProposedQuery(
-					"include forked repositories in your query.",
-					o.OriginalQuery+" fork:yes",
-					o.PatternType,
-				),
+				&search.ProposedQuery{
+					Description: "include forked repositories in your query.",
+					Query:       o.OriginalQuery + " fork:yes",
+					PatternType: o.PatternType,
+				},
 			)
 		}
 	}
@@ -133,11 +133,11 @@ func (o *Observer) alertForNoResolvedRepos(ctx context.Context, q query.Q) *sear
 		}
 		if o.reposExist(ctx, tryIncludeArchived) {
 			proposedQueries = append(proposedQueries,
-				search.NewProposedQuery(
-					"include archived repositories in your query.",
-					o.OriginalQuery+" archived:yes",
-					o.PatternType,
-				),
+				&search.ProposedQuery{
+					Description: "include archived repositories in your query.",
+					Query:       o.OriginalQuery + " archived:yes",
+					PatternType: o.PatternType,
+				},
 			)
 		}
 	}

--- a/internal/search/alert/observer_test.go
+++ b/internal/search/alert/observer_test.go
@@ -92,11 +92,12 @@ func TestAlertForNoResolvedReposWithNonGlobalSearchContext(t *testing.T) {
 		PrometheusType: "no_resolved_repos__context_none_in_common",
 		Title:          "No repositories found for your query within the context @user",
 		ProposedQueries: []*search.ProposedQuery{
-			search.NewProposedQuery(
-				"search in the global context",
-				"context:global repo:r1 foo",
-				query.SearchTypeRegex,
-			),
+			{
+
+				Description: "search in the global context",
+				Query:       "context:global repo:r1 foo",
+				PatternType: query.SearchTypeRegex,
+			},
 		},
 	}
 

--- a/internal/search/alert_test.go
+++ b/internal/search/alert_test.go
@@ -21,11 +21,11 @@ func TestSearchPatternForSuggestion(t *testing.T) {
 				Title:       "An alert for regex",
 				Description: "An alert for regex",
 				ProposedQueries: []*ProposedQuery{
-					NewProposedQuery(
-						"Some query description",
-						"repo:github.com/sourcegraph/sourcegraph",
-						query.SearchTypeRegex,
-					),
+					{
+						Description: "Some query description",
+						Query:       "repo:github.com/sourcegraph/sourcegraph",
+						PatternType: query.SearchTypeRegex,
+					},
 				},
 			},
 			Want: "repo:github.com/sourcegraph/sourcegraph patternType:regexp",
@@ -36,11 +36,11 @@ func TestSearchPatternForSuggestion(t *testing.T) {
 				Title:       "An alert for structural",
 				Description: "An alert for structural",
 				ProposedQueries: []*ProposedQuery{
-					NewProposedQuery(
-						"Some query description",
-						"repo:github.com/sourcegraph/sourcegraph",
-						query.SearchTypeStructural,
-					),
+					{
+						Description: "Some query description",
+						Query:       "repo:github.com/sourcegraph/sourcegraph",
+						PatternType: query.SearchTypeStructural,
+					},
 				},
 			},
 			Want: "repo:github.com/sourcegraph/sourcegraph patternType:structural",


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/30311.

This restores exposing the fields for query proposal brought up in https://github.com/sourcegraph/sourcegraph/pull/30264#discussion_r793333463.