### PR TITLE
enterprise: Special case handling of internal repo in FetchRepoPerms

### DIFF
--- a/enterprise/internal/authz/github/authz.go
+++ b/enterprise/internal/authz/github/authz.go
@@ -20,6 +20,7 @@ import (
 func NewAuthzProviders(
 	conns []*types.GitHubConnection,
 	authProviders []schema.AuthProviders,
+	enableGithubInternalRepoVisibility bool,
 ) (ps []authz.Provider, problems []string, warnings []string) {
 	// Auth providers (i.e. login mechanisms)
 	githubAuthProviders := make(map[string]*schema.GitHubAuthProvider)
@@ -47,6 +48,11 @@ func NewAuthzProviders(
 		} else if p == nil {
 			continue
 		}
+
+		// We want to make the feature flag available to the GitHub provider, but at the same time
+		// also not use the global conf.SiteConfig which is discouraged and could cause race
+		// conditions. As a result, we use a temporary hack by setting this on the provider for now.
+		p.enableGithubInternalRepoVisibility = enableGithubInternalRepoVisibility
 
 		// Permissions require a corresponding GitHub OAuth provider. Without one, repos
 		// with restricted permissions will not be visible to non-admins.

--- a/enterprise/internal/authz/github/authz_test.go
+++ b/enterprise/internal/authz/github/authz_test.go
@@ -19,7 +19,9 @@ func TestNewAuthzProviders(t *testing.T) {
 					Authorization: nil,
 				},
 			}},
-			[]schema.AuthProviders{})
+			[]schema.AuthProviders{},
+			false,
+		)
 		if len(providers) != 0 {
 			t.Fatalf("unexpected providers: %+v", providers)
 		}
@@ -43,7 +45,9 @@ func TestNewAuthzProviders(t *testing.T) {
 				Github: &schema.GitHubAuthProvider{
 					Url: "https://github.com",
 				},
-			}})
+			}},
+			false,
+		)
 		if len(providers) != 1 || providers[0] == nil {
 			t.Fatal("expected a provider")
 		}
@@ -67,7 +71,9 @@ func TestNewAuthzProviders(t *testing.T) {
 				[]schema.AuthProviders{{
 					// falls back to schema.DefaultGitHubURL
 					Github: &schema.GitHubAuthProvider{},
-				}})
+				}},
+				false,
+			)
 			if len(providers) != 1 || providers[0] == nil {
 				t.Fatal("expected a provider")
 			}
@@ -94,7 +100,9 @@ func TestNewAuthzProviders(t *testing.T) {
 						Url:                        "https://github.com",
 						AllowGroupsPermissionsSync: false,
 					},
-				}})
+				}},
+				false,
+			)
 			if len(providers) != 1 || providers[0] == nil {
 				t.Fatal("expected a provider")
 			}
@@ -128,7 +136,9 @@ func TestNewAuthzProviders(t *testing.T) {
 						Url:                        "https://github.com",
 						AllowGroupsPermissionsSync: true,
 					},
-				}})
+				}},
+				false,
+			)
 			if len(providers) != 1 || providers[0] == nil {
 				t.Fatal("expected a provider")
 			}

--- a/enterprise/internal/authz/github/client.go
+++ b/enterprise/internal/authz/github/client.go
@@ -38,6 +38,7 @@ type client interface {
 	GetAuthenticatedUserOrgsDetailsAndMembership(ctx context.Context, page int) (orgs []github.OrgDetailsAndMembership, hasNextPage bool, rateLimitCost int, err error)
 	GetAuthenticatedUserTeams(ctx context.Context, page int) (teams []*github.Team, hasNextPage bool, rateLimitCost int, err error)
 	GetOrganization(ctx context.Context, login string) (org *github.OrgDetails, err error)
+	GetRepository(ctx context.Context, owner, name string) (*github.Repository, error)
 
 	GetAuthenticatedOAuthScopes(ctx context.Context) ([]string, error)
 	WithToken(token string) client
@@ -69,8 +70,10 @@ type mockClient struct {
 	MockGetAuthenticatedUserOrgsDetailsAndMembership func(ctx context.Context, page int) (orgs []github.OrgDetailsAndMembership, hasNextPage bool, rateLimitCost int, err error)
 	MockGetAuthenticatedUserTeams                    func(ctx context.Context, page int) (teams []*github.Team, hasNextPage bool, rateLimitCost int, err error)
 	MockGetOrganization                              func(ctx context.Context, login string) (org *github.OrgDetails, err error)
-	MockGetAuthenticatedOAuthScopes                  func(ctx context.Context) ([]string, error)
-	MockWithToken                                    func(token string) client
+	MockGetRepository                                func(ctx context.Context, owner, repo string) (*github.Repository, error)
+
+	MockGetAuthenticatedOAuthScopes func(ctx context.Context) ([]string, error)
+	MockWithToken                   func(token string) client
 }
 
 func (m *mockClient) ListAffiliatedRepositories(ctx context.Context, visibility github.Visibility, page int, affiliations ...github.RepositoryAffiliation) ([]*github.Repository, bool, int, error) {
@@ -111,6 +114,10 @@ func (m *mockClient) GetAuthenticatedUserTeams(ctx context.Context, page int) (t
 
 func (m *mockClient) GetOrganization(ctx context.Context, login string) (org *github.OrgDetails, err error) {
 	return m.MockGetOrganization(ctx, login)
+}
+
+func (m *mockClient) GetRepository(ctx context.Context, owner, name string) (*github.Repository, error) {
+	return m.MockGetRepository(ctx, owner, name)
 }
 
 func (m *mockClient) GetAuthenticatedOAuthScopes(ctx context.Context) ([]string, error) {

--- a/enterprise/internal/authz/github/github.go
+++ b/enterprise/internal/authz/github/github.go
@@ -25,6 +25,14 @@ type Provider struct {
 	codeHost *extsvc.CodeHost
 	// groupsCache may be nil if group caching is disabled (negative TTL)
 	groupsCache *cachedGroups
+
+	// enableGithubInternalRepoVisibility is a feature flag to optionally impelement a fix for
+	// internal repos on GithHub Enterprise. At the moment we do not handle internal repos
+	// explicitly and allow all org members to read it irrespective of repo permissions. We have
+	// this as a temporary feature flag here to guard against any regressions. This will go away as
+	// soon as we have verified our approach works and is reliable, at which point the fix will
+	// become the default behaviour.
+	enableGithubInternalRepoVisibility bool
 }
 
 type ProviderOptions struct {
@@ -539,7 +547,27 @@ func (p *Provider) getRepoAffiliatedGroups(ctx context.Context, owner, name stri
 		groups = append(groups, repoAffiliatedGroup{cachedGroup: group, adminsOnly: adminsOnly})
 	}
 
-	allOrgMembersCanRead := canViewOrgRepos(&github.OrgDetailsAndMembership{OrgDetails: org})
+	// If this repo is an internal repo, we want to allow everyone in the org to read this repo
+	// (provided the temporary feature flag is set) irrespective of the user being an admin or not.
+	isRepoInternallyVisible := false
+
+	// The visibility field on a repo is only returned if this feature flag is set. As a result
+	// there's no point in making an extra API call if this feature flag is not set explicitly.
+	if p.enableGithubInternalRepoVisibility {
+		var r *github.Repository
+		r, err = p.client.GetRepository(ctx, owner, name)
+		if err != nil {
+			// Maybe the repo doesn't belong to this org? Or Another error occurred in trying to get the
+			// repo. Either way, we are not going to syncGroup for this repo.
+			return
+		}
+
+		if org != nil && r.Visibility == github.VisibilityInternal {
+			isRepoInternallyVisible = true
+		}
+	}
+
+	allOrgMembersCanRead := isRepoInternallyVisible || canViewOrgRepos(&github.OrgDetailsAndMembership{OrgDetails: org})
 	if allOrgMembersCanRead {
 		// 🚨 SECURITY: Iff all members of this org can view this repo, indicate that all members should
 		// be sync'd.

--- a/enterprise/internal/authz/github/github.go
+++ b/enterprise/internal/authz/github/github.go
@@ -26,7 +26,7 @@ type Provider struct {
 	// groupsCache may be nil if group caching is disabled (negative TTL)
 	groupsCache *cachedGroups
 
-	// enableGithubInternalRepoVisibility is a feature flag to optionally impelement a fix for
+	// enableGithubInternalRepoVisibility is a feature flag to optionally enable a fix for
 	// internal repos on GithHub Enterprise. At the moment we do not handle internal repos
 	// explicitly and allow all org members to read it irrespective of repo permissions. We have
 	// this as a temporary feature flag here to guard against any regressions. This will go away as


### PR DESCRIPTION
One more try as we had to revert #29325. 

Reverts sourcegraph/sourcegraph#30296.

Progress on #25904. 