### PR TITLE
git-combine: limit flag for a target commit history size

### DIFF
--- a/internal/cmd/git-combine/git-combine.go
+++ b/internal/cmd/git-combine/git-combine.go
@@ -26,6 +26,10 @@ import (
 
 // Options are configurables for Combine.
 type Options struct {
+	// Limit is the maximum number of commits we import in total. Limit is
+	// useful to specify when creating a new combined repo.
+	Limit int
+
 	// LimitRemote is the maximum number of commits we import from each remote. The
 	// memory usage of Combine is based on the number of unseen commits per
 	// remote. LimitRemote is useful to specify when importing a large new upstream.
@@ -35,8 +39,12 @@ type Options struct {
 }
 
 func (o *Options) SetDefaults() {
+	if o.Limit == 0 {
+		o.Limit = math.MaxInt
+	}
+
 	if o.LimitRemote == 0 {
-		o.LimitRemote = math.MaxInt
+		o.LimitRemote = o.Limit
 	}
 
 	if o.Logger == nil {
@@ -138,6 +146,17 @@ func Combine(path string, opt Options) error {
 	sort.Slice(commits, func(i, j int) bool {
 		return commits[i].Committer.When.Before(commits[j].Committer.When)
 	})
+
+	if len(commits) > opt.Limit {
+		// We only take the last Limit commits. But we want to ensure we are
+		// using the latest treehash for each dir, so we need to walk over the
+		// commits we are cutting out first.
+		cut := len(commits) - opt.Limit
+		for _, commit := range commits[:cut] {
+			rootTree[commit.dir] = commit.TreeHash
+		}
+		commits = commits[cut:]
+	}
 
 	for i, commit := range commits {
 		// This is the important line, "/dir" will now be the code (tree) for
@@ -442,10 +461,12 @@ func doDaemon(dir string, ticker <-chan time.Time, done <-chan struct{}, opt Opt
 func main() {
 	daemon := flag.Bool("daemon", false, "run in daemon mode. This mode loops on fetch, combine, push.")
 	limitRemote := flag.Int("limit-remote", 0, "limits the number of commits imported from each remote. If 0 there is no limit. Used to reduce memory usage when importing new large remotes.")
+	limit := flag.Int("limit", 0, "limits the number of commits imported in total. If 0 there is no limit. Used to reduce memory usage when importing new large remotes.")
 
 	flag.Parse()
 
 	opt := Options{
+		Limit:       *limit,
 		LimitRemote: *limitRemote,
 	}
 

--- a/internal/cmd/git-combine/git-combine.go
+++ b/internal/cmd/git-combine/git-combine.go
@@ -26,17 +26,17 @@ import (
 
 // Options are configurables for Combine.
 type Options struct {
-	// Limit is the maximum number of commits we import from each remote. The
+	// LimitRemote is the maximum number of commits we import from each remote. The
 	// memory usage of Combine is based on the number of unseen commits per
-	// remote. Limit is useful to specify when importing a large new upstream.
-	Limit int
+	// remote. LimitRemote is useful to specify when importing a large new upstream.
+	LimitRemote int
 
 	Logger *log.Logger
 }
 
 func (o *Options) SetDefaults() {
-	if o.Limit == 0 {
-		o.Limit = math.MaxInt
+	if o.LimitRemote == 0 {
+		o.LimitRemote = math.MaxInt
 	}
 
 	if o.Logger == nil {
@@ -115,7 +115,7 @@ func Combine(path string, opt Options) error {
 
 		seen := recentRootTrees[remote]
 
-		for i := 0; i < opt.Limit; i++ {
+		for i := 0; i < opt.LimitRemote; i++ {
 			commit, err := iter.Next()
 			if err == io.EOF {
 				break
@@ -441,12 +441,12 @@ func doDaemon(dir string, ticker <-chan time.Time, done <-chan struct{}, opt Opt
 
 func main() {
 	daemon := flag.Bool("daemon", false, "run in daemon mode. This mode loops on fetch, combine, push.")
-	limit := flag.Int("limit", 0, "limits the number of commits imported from each remote. If 0 there is no limit. Used to reduce memory usage when importing new large remotes.")
+	limitRemote := flag.Int("limit-remote", 0, "limits the number of commits imported from each remote. If 0 there is no limit. Used to reduce memory usage when importing new large remotes.")
 
 	flag.Parse()
 
 	opt := Options{
-		Limit: *limit,
+		LimitRemote: *limitRemote,
 	}
 
 	gitDir, err := getGitDir()

--- a/internal/cmd/git-combine/git-combine_test.go
+++ b/internal/cmd/git-combine/git-combine_test.go
@@ -43,8 +43,8 @@ git fetch --depth 100 sourcegraph
 	}
 
 	opt := Options{
-		Limit:  100,
-		Logger: log.New(io.Discard, "", 0),
+		LimitRemote: 100,
+		Logger:      log.New(io.Discard, "", 0),
 	}
 	if testing.Verbose() {
 		opt.Logger = log.Default()


### PR DESCRIPTION
For the gigarepo we want to ensure we start off with a size of around 1.1million commits. We will use this flag to target that size.

Note we already had a `limit` flag, but that was used to prevent storing too much information in memory from each remote. This flag still exists and is useful, but has been renamed to `limit-remote`.