### PR TITLE
git-combine: skip push if origin is missing

### DIFF
--- a/internal/cmd/git-combine/git-combine.go
+++ b/internal/cmd/git-combine/git-combine.go
@@ -365,6 +365,21 @@ func commitTitle(commit *object.Commit) string {
 	return strings.TrimSpace(title)
 }
 
+func hasRemote(path, remote string) (bool, error) {
+	r, err := git.PlainOpen(path)
+	if err != nil {
+		return false, err
+	}
+
+	conf, err := r.Config()
+	if err != nil {
+		return false, err
+	}
+
+	_, ok := conf.Remotes[remote]
+	return ok, nil
+}
+
 func getGitDir() (string, error) {
 	dir := os.Getenv("GIT_DIR")
 	if dir == "" {
@@ -427,7 +442,11 @@ func doDaemon(dir string, ticker <-chan time.Time, done <-chan struct{}, opt Opt
 			return nil
 		}
 
-		if err := runGit(dir, "push", "origin"); err != nil {
+		if hasOrigin, err := hasRemote(dir, "origin"); err != nil {
+			return err
+		} else if !hasOrigin {
+			opt.Logger.Printf("skipping push since remote origin is missing")
+		} else if err := runGit(dir, "push", "origin"); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
In the case of the gigarepo we won't be pushing it to github since it will be too large. As such we just do a warning log if the origin is missing in daemon mode.
