### PR TITLE
monitoring: add panel for repos we stopped tracking

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -13416,7 +13416,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100021` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `increase(index_num_stopped_tracking_total{instance=~`${instance:regex}`}[5m])`
+Query: `sum by (instance) (increase(index_num_stopped_tracking_total{instance=~`${instance:regex}`}[5m]))`
 
 </details>
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -13380,13 +13380,55 @@ Query: `sum by (le, state) (increase(index_repo_seconds_bucket{state="fail"}[$__
 
 <br />
 
+#### zoekt: repos_stopped_tracking_total_aggregate
+
+<p class="subtitle">The number of repositories we stopped tracking over 5m (aggregate)</p>
+
+Repositories we stop tracking are soft-deleted during the next cleanup job.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100020` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(increase(index_num_stopped_tracking_total[5m]))`
+
+</details>
+
+<br />
+
+#### zoekt: repos_stopped_tracking_total_per_instance
+
+<p class="subtitle">The number of repositories we stopped tracking over 5m (per instance)</p>
+
+Repositories we stop tracking are soft-deleted during the next cleanup job.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100021` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `increase(index_num_stopped_tracking_total{instance=~`${instance:regex}`}[5m])`
+
+</details>
+
+<br />
+
 #### zoekt: average_resolve_revision_duration
 
 <p class="subtitle">Average resolve revision duration over 5m</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-average-resolve-revision-duration) for 2 alerts related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100020` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100030` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -13413,7 +13455,7 @@ this indicates repositories will not get updated indexes.
 
 Refer to the [alert solutions reference](./alert_solutions.md#zoekt-get-index-options-error-increase) for 2 alerts related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100021` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100031` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 

--- a/monitoring/definitions/zoekt.go
+++ b/monitoring/definitions/zoekt.go
@@ -126,6 +126,30 @@ func Zoekt() *monitoring.Container {
 					},
 					{
 						{
+							Name:        "repos_stopped_tracking_total_aggregate",
+							Description: "the number of repositories we stopped tracking over 5m (aggregate)",
+							Query:       `sum(increase(index_num_stopped_tracking_total[5m]))`,
+							NoAlert:     true,
+							Panel: monitoring.Panel().LegendFormat("dropped").Unit(monitoring.Number).With(func(observable monitoring.Observable, panel *sdk.Panel) {
+								panel.GraphPanel.Legend.RightSide = true
+							}),
+							Owner:          monitoring.ObservableOwnerSearchCore,
+							Interpretation: "Repositories we stop tracking are soft-deleted during the next cleanup job.",
+						},
+						{
+							Name:        "repos_stopped_tracking_total_per_instance",
+							Description: "the number of repositories we stopped tracking over 5m (per instance)",
+							Query:       "increase(index_num_stopped_tracking_total{instance=~`${instance:regex}`}[5m])",
+							NoAlert:     true,
+							Panel: monitoring.Panel().LegendFormat("{{instance}}").Unit(monitoring.Number).With(func(observable monitoring.Observable, panel *sdk.Panel) {
+								panel.GraphPanel.Legend.RightSide = true
+							}),
+							Owner:          monitoring.ObservableOwnerSearchCore,
+							Interpretation: "Repositories we stop tracking are soft-deleted during the next cleanup job.",
+						},
+					},
+					{
+						{
 							Name:              "average_resolve_revision_duration",
 							Description:       "average resolve revision duration over 5m",
 							Query:             `sum(rate(resolve_revision_seconds_sum[5m])) / sum(rate(resolve_revision_seconds_count[5m]))`,

--- a/monitoring/definitions/zoekt.go
+++ b/monitoring/definitions/zoekt.go
@@ -139,7 +139,7 @@ func Zoekt() *monitoring.Container {
 						{
 							Name:        "repos_stopped_tracking_total_per_instance",
 							Description: "the number of repositories we stopped tracking over 5m (per instance)",
-							Query:       "increase(index_num_stopped_tracking_total{instance=~`${instance:regex}`}[5m])",
+							Query:       "sum by (instance) (increase(index_num_stopped_tracking_total{instance=~`${instance:regex}`}[5m]))",
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").Unit(monitoring.Number).With(func(observable monitoring.Observable, panel *sdk.Panel) {
 								panel.GraphPanel.Legend.RightSide = true


### PR DESCRIPTION
This adds 2 new panels to the Zoekt dashboard. During incidents, the new
panels will help us figure out more quickly if/why Zoekt deletes shards.
 
I tried to include the data in the top panel "total number of repos". However, even on log scale, the numbers were just too different and the little gap between tracked and indexed became invisible on log scale. Hence the separate panels.

<img width="2481" alt="Screenshot 2022-01-28 at 12 10 34" src="https://user-images.githubusercontent.com/26413131/151537848-d437abed-c557-4d85-96cc-ac3e917011eb.png">

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
