### PR TITLE
[CLOUD-209] Redirect users to connect code host connections through GitHub App

### DIFF
--- a/client/web/dev/utils/create-js-context.ts
+++ b/client/web/dev/utils/create-js-context.ts
@@ -50,6 +50,7 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
         siteID: 'TestSiteID',
         siteGQLID: 'TestGQLSiteID',
         sourcegraphDotComMode: true,
+        githubAppCloudSlug: 'TestApp',
         userAgentIsBot: false,
         version: '0.0.0',
         xhrHeaders: {},

--- a/client/web/src/integration/jscontext.ts
+++ b/client/web/src/integration/jscontext.ts
@@ -40,6 +40,7 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
     siteID,
     siteGQLID,
     sourcegraphDotComMode: false,
+    githubAppCloudSlug: 'test-app',
     userAgentIsBot: false,
     version: '0.0.0',
     xhrHeaders: {},

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -39,6 +39,8 @@ export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'e
 
     sourcegraphDotComMode: boolean
 
+    githubAppCloudSlug: string
+
     /**
      * siteID is the identifier of the Sourcegraph site.
      */

--- a/client/web/src/org/backend.ts
+++ b/client/web/src/org/backend.ts
@@ -125,3 +125,5 @@ export const GET_ORG_FEATURE_FLAG_VALUE = gql`
     }
 `
 export const ORG_CODE_FEATURE_FLAG_NAME = 'org-code'
+
+export const GITHUB_APP_FEATURE_FLAG_NAME = 'github-app-cloud'

--- a/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
+++ b/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
@@ -53,10 +53,9 @@ export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
     useGitHubApp,
 }) => {
     const [isAddConnectionModalOpen, setIsAddConnectionModalOpen] = useState(false)
-    const toggleAddConnectionModal = useCallback(
-        () => setIsAddConnectionModalOpen(!isAddConnectionModalOpen),
-        [isAddConnectionModalOpen]
-    )
+    const toggleAddConnectionModal = useCallback(() => setIsAddConnectionModalOpen(!isAddConnectionModalOpen), [
+        isAddConnectionModalOpen,
+    ])
 
     const [isRemoveConnectionModalOpen, setIsRemoveConnectionModalOpen] = useState(false)
     const toggleRemoveConnectionModal = useCallback(

--- a/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
+++ b/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
@@ -33,7 +33,7 @@ interface CodeHostItemProps {
     onDidAdd?: (service: ListExternalServiceFields) => void
     onDidRemove: () => void
     onDidError: (error: ErrorLike) => void
-    useGitHubApp: boolean
+    useGitHubApp?: boolean
 }
 
 export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
@@ -50,7 +50,7 @@ export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
     isUpdateModalOpen,
     toggleUpdateModal,
     onDidUpsert,
-    useGitHubApp,
+    useGitHubApp = false,
 }) => {
     const [isAddConnectionModalOpen, setIsAddConnectionModalOpen] = useState(false)
     const toggleAddConnectionModal = useCallback(() => setIsAddConnectionModalOpen(!isAddConnectionModalOpen), [
@@ -82,7 +82,7 @@ export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
     }
 
     const isUserOwner = owner.type === 'user'
-    const connectAction = useGitHubApp ? toGitHubApp : isUserOwner ? toAuthProvider : toggleAddConnectionModal
+    const connectAction = isUserOwner ? toAuthProvider : toggleAddConnectionModal
     const updateAction = isUserOwner ? toAuthProvider : toggleUpdateModal
 
     return (
@@ -148,7 +148,7 @@ export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
                             variant="primary"
                         />
                     ) : (
-                        <Button onClick={connectAction} variant="primary">
+                        <Button onClick={useGitHubApp ? toGitHubApp : connectAction} variant="primary">
                             Connect
                         </Button>
                     )

--- a/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
+++ b/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
@@ -33,6 +33,7 @@ interface CodeHostItemProps {
     onDidAdd?: (service: ListExternalServiceFields) => void
     onDidRemove: () => void
     onDidError: (error: ErrorLike) => void
+    loading?: boolean
     useGitHubApp?: boolean
 }
 
@@ -50,6 +51,7 @@ export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
     isUpdateModalOpen,
     toggleUpdateModal,
     onDidUpsert,
+    loading = false,
     useGitHubApp = false,
 }) => {
     const [isAddConnectionModalOpen, setIsAddConnectionModalOpen] = useState(false)
@@ -146,6 +148,14 @@ export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
                             label="Connecting..."
                             alwaysShowLabel={true}
                             variant="primary"
+                        />
+                    ) : loading ? (
+                        <LoaderButton
+                            type="button"
+                            className="btn btn-primary"
+                            loading={true}
+                            disabled={true}
+                            alwaysShowLabel={false}
                         />
                     ) : (
                         <Button onClick={useGitHubApp ? toGitHubApp : connectAction} variant="primary">

--- a/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
+++ b/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
@@ -74,7 +74,7 @@ export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
     }, [kind, navigateToAuthProvider])
 
     const toGitHubApp = function (): void {
-        window.location.assign(`https://github.com/apps/<your GitHub app slug>/installations/new?state=${encodeURIComponent(owner.id)}`)
+        window.location.assign(`https://github.com/apps/${window.context.githubAppCloudSlug}/installations/new?state=${encodeURIComponent(owner.id)}`)
     }
 
     const isUserOwner = owner.type === 'user'

--- a/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
+++ b/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
@@ -33,6 +33,7 @@ interface CodeHostItemProps {
     onDidAdd?: (service: ListExternalServiceFields) => void
     onDidRemove: () => void
     onDidError: (error: ErrorLike) => void
+    useGitHubApp: boolean
 }
 
 export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
@@ -49,6 +50,7 @@ export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
     isUpdateModalOpen,
     toggleUpdateModal,
     onDidUpsert,
+    useGitHubApp,
 }) => {
     const [isAddConnectionModalOpen, setIsAddConnectionModalOpen] = useState(false)
     const toggleAddConnectionModal = useCallback(() => setIsAddConnectionModalOpen(!isAddConnectionModalOpen), [
@@ -71,8 +73,12 @@ export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
         navigateToAuthProvider(kind)
     }, [kind, navigateToAuthProvider])
 
+    const toGitHubApp = function (): void {
+        window.location.assign(`https://github.com/apps/<your GitHub app slug>/installations/new?state=${encodeURIComponent(owner.id)}`)
+    }
+
     const isUserOwner = owner.type === 'user'
-    const connectAction = isUserOwner ? toAuthProvider : toggleAddConnectionModal
+    const connectAction = useGitHubApp ? toGitHubApp : (isUserOwner ? toAuthProvider : toggleAddConnectionModal)
     const updateAction = isUserOwner ? toAuthProvider : toggleUpdateModal
 
     return (

--- a/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
+++ b/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
@@ -53,9 +53,10 @@ export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
     useGitHubApp,
 }) => {
     const [isAddConnectionModalOpen, setIsAddConnectionModalOpen] = useState(false)
-    const toggleAddConnectionModal = useCallback(() => setIsAddConnectionModalOpen(!isAddConnectionModalOpen), [
-        isAddConnectionModalOpen,
-    ])
+    const toggleAddConnectionModal = useCallback(
+        () => setIsAddConnectionModalOpen(!isAddConnectionModalOpen),
+        [isAddConnectionModalOpen]
+    )
 
     const [isRemoveConnectionModalOpen, setIsRemoveConnectionModalOpen] = useState(false)
     const toggleRemoveConnectionModal = useCallback(
@@ -74,11 +75,15 @@ export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
     }, [kind, navigateToAuthProvider])
 
     const toGitHubApp = function (): void {
-        window.location.assign(`https://github.com/apps/${window.context.githubAppCloudSlug}/installations/new?state=${encodeURIComponent(owner.id)}`)
+        window.location.assign(
+            `https://github.com/apps/${window.context.githubAppCloudSlug}/installations/new?state=${encodeURIComponent(
+                owner.id
+            )}`
+        )
     }
 
     const isUserOwner = owner.type === 'user'
-    const connectAction = useGitHubApp ? toGitHubApp : (isUserOwner ? toAuthProvider : toggleAddConnectionModal)
+    const connectAction = useGitHubApp ? toGitHubApp : isUserOwner ? toAuthProvider : toggleAddConnectionModal
     const updateAction = isUserOwner ? toAuthProvider : toggleUpdateModal
 
     return (

--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -288,13 +288,16 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
         [authProvidersByKind]
     )
 
-    const { data } = useQuery<OrgFeatureFlagValueResult, OrgFeatureFlagValueVariables>(GET_ORG_FEATURE_FLAG_VALUE, {
-        variables: { orgID: owner.id, flagName: GITHUB_APP_FEATURE_FLAG_NAME },
-        // Cache this data but always re-request it in the background when we revisit
-        // this page to pick up newer changes.
-        fetchPolicy: 'cache-and-network',
-        skip: !(owner.type === 'org'),
-    })
+    const { data, loading } = useQuery<OrgFeatureFlagValueResult, OrgFeatureFlagValueVariables>(
+        GET_ORG_FEATURE_FLAG_VALUE,
+        {
+            variables: { orgID: owner.id, flagName: GITHUB_APP_FEATURE_FLAG_NAME },
+            // Cache this data but always re-request it in the background when we revisit
+            // this page to pick up newer changes.
+            fetchPolicy: 'cache-and-network',
+            skip: !(owner.type === 'org'),
+        }
+    )
 
     const useGitHubApp = data?.organizationFeatureFlagValue || false
 
@@ -330,22 +333,26 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
                         {Object.entries(codeHostExternalServices).map(([id, { kind, defaultDisplayName, icon }]) =>
                             authProvidersByKind[kind] ? (
                                 <CodeHostListItem key={id}>
-                                    <CodeHostItem
-                                        owner={owner}
-                                        service={isServicesByKind(statusOrError) ? statusOrError[kind] : undefined}
-                                        kind={kind}
-                                        name={defaultDisplayName}
-                                        isTokenUpdateRequired={isTokenUpdateRequired[kind]}
-                                        navigateToAuthProvider={navigateToAuthProvider}
-                                        icon={icon}
-                                        isUpdateModalOpen={isUpdateModalOpen}
-                                        toggleUpdateModal={toggleUpdateModal}
-                                        onDidUpsert={handleServiceUpsert}
-                                        onDidAdd={addNewService}
-                                        onDidRemove={removeService(kind)}
-                                        onDidError={handleError}
-                                        useGitHubApp={useGitHubApp && kind === ExternalServiceKind.GITHUB}
-                                    />
+                                    {kind === ExternalServiceKind.GITHUB && loading ? (
+                                        <LoadingSpinner />
+                                    ) : (
+                                        <CodeHostItem
+                                            owner={owner}
+                                            service={isServicesByKind(statusOrError) ? statusOrError[kind] : undefined}
+                                            kind={kind}
+                                            name={defaultDisplayName}
+                                            isTokenUpdateRequired={isTokenUpdateRequired[kind]}
+                                            navigateToAuthProvider={navigateToAuthProvider}
+                                            icon={icon}
+                                            isUpdateModalOpen={isUpdateModalOpen}
+                                            toggleUpdateModal={toggleUpdateModal}
+                                            onDidUpsert={handleServiceUpsert}
+                                            onDidAdd={addNewService}
+                                            onDidRemove={removeService(kind)}
+                                            onDidError={handleError}
+                                            useGitHubApp={kind === ExternalServiceKind.GITHUB && useGitHubApp}
+                                        />
+                                    )}
                                 </CodeHostListItem>
                             ) : null
                         )}

--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -333,26 +333,23 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
                         {Object.entries(codeHostExternalServices).map(([id, { kind, defaultDisplayName, icon }]) =>
                             authProvidersByKind[kind] ? (
                                 <CodeHostListItem key={id}>
-                                    {kind === ExternalServiceKind.GITHUB && loading ? (
-                                        <LoadingSpinner />
-                                    ) : (
-                                        <CodeHostItem
-                                            owner={owner}
-                                            service={isServicesByKind(statusOrError) ? statusOrError[kind] : undefined}
-                                            kind={kind}
-                                            name={defaultDisplayName}
-                                            isTokenUpdateRequired={isTokenUpdateRequired[kind]}
-                                            navigateToAuthProvider={navigateToAuthProvider}
-                                            icon={icon}
-                                            isUpdateModalOpen={isUpdateModalOpen}
-                                            toggleUpdateModal={toggleUpdateModal}
-                                            onDidUpsert={handleServiceUpsert}
-                                            onDidAdd={addNewService}
-                                            onDidRemove={removeService(kind)}
-                                            onDidError={handleError}
-                                            useGitHubApp={kind === ExternalServiceKind.GITHUB && useGitHubApp}
-                                        />
-                                    )}
+                                    <CodeHostItem
+                                        owner={owner}
+                                        service={isServicesByKind(statusOrError) ? statusOrError[kind] : undefined}
+                                        kind={kind}
+                                        name={defaultDisplayName}
+                                        isTokenUpdateRequired={isTokenUpdateRequired[kind]}
+                                        navigateToAuthProvider={navigateToAuthProvider}
+                                        icon={icon}
+                                        isUpdateModalOpen={isUpdateModalOpen}
+                                        toggleUpdateModal={toggleUpdateModal}
+                                        onDidUpsert={handleServiceUpsert}
+                                        onDidAdd={addNewService}
+                                        onDidRemove={removeService(kind)}
+                                        onDidError={handleError}
+                                        loading={kind === ExternalServiceKind.GITHUB && loading}
+                                        useGitHubApp={kind === ExternalServiceKind.GITHUB && useGitHubApp}
+                                    />
                                 </CodeHostListItem>
                             ) : null
                         )}

--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -11,7 +11,12 @@ import { Button, Container, PageHeader, LoadingSpinner, Link, Alert } from '@sou
 import { queryExternalServices } from '../../../components/externalServices/backend'
 import { AddExternalServiceOptions } from '../../../components/externalServices/externalServices'
 import { PageTitle } from '../../../components/PageTitle'
-import { ExternalServiceKind, ListExternalServiceFields , OrgFeatureFlagValueResult, OrgFeatureFlagValueVariables } from '../../../graphql-operations'
+import {
+    ExternalServiceKind,
+    ListExternalServiceFields,
+    OrgFeatureFlagValueResult,
+    OrgFeatureFlagValueVariables,
+} from '../../../graphql-operations'
 import { AuthProvider, SourcegraphContext } from '../../../jscontext'
 import { GET_ORG_FEATURE_FLAG_VALUE, GITHUB_APP_FEATURE_FLAG_NAME } from '../../../org/backend'
 import { useCodeHostScopeContext } from '../../../site/CodeHostScopeAlerts/CodeHostScopeProvider'
@@ -283,16 +288,13 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
         [authProvidersByKind]
     )
 
-    const { data } = useQuery<OrgFeatureFlagValueResult, OrgFeatureFlagValueVariables>(
-        GET_ORG_FEATURE_FLAG_VALUE,
-        {
-            variables: { orgID: owner.id, flagName: GITHUB_APP_FEATURE_FLAG_NAME },
-            // Cache this data but always re-request it in the background when we revisit
-            // this page to pick up newer changes.
-            fetchPolicy: 'cache-and-network',
-            skip: !(owner.type === 'org'),
-        }
-    )
+    const { data } = useQuery<OrgFeatureFlagValueResult, OrgFeatureFlagValueVariables>(GET_ORG_FEATURE_FLAG_VALUE, {
+        variables: { orgID: owner.id, flagName: GITHUB_APP_FEATURE_FLAG_NAME },
+        // Cache this data but always re-request it in the background when we revisit
+        // this page to pick up newer changes.
+        fetchPolicy: 'cache-and-network',
+        skip: !(owner.type === 'org'),
+    })
 
     const useGitHubApp = data?.organizationFeatureFlagValue || false
 

--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -283,7 +283,7 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
         [authProvidersByKind]
     )
 
-    const { data, loading } = useQuery<OrgFeatureFlagValueResult, OrgFeatureFlagValueVariables>(
+    const { data } = useQuery<OrgFeatureFlagValueResult, OrgFeatureFlagValueVariables>(
         GET_ORG_FEATURE_FLAG_VALUE,
         {
             variables: { orgID: owner.id, flagName: GITHUB_APP_FEATURE_FLAG_NAME },

--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState, useEffect } from 'react'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { asError, ErrorLike, isErrorLike, isDefined } from '@sourcegraph/common'
+import { useQuery } from '@sourcegraph/http-client'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { keyExistsIn } from '@sourcegraph/shared/src/util/types'
 import { SelfHostedCta } from '@sourcegraph/web/src/components/SelfHostedCta'
@@ -10,8 +11,9 @@ import { Button, Container, PageHeader, LoadingSpinner, Link, Alert } from '@sou
 import { queryExternalServices } from '../../../components/externalServices/backend'
 import { AddExternalServiceOptions } from '../../../components/externalServices/externalServices'
 import { PageTitle } from '../../../components/PageTitle'
-import { ExternalServiceKind, ListExternalServiceFields } from '../../../graphql-operations'
+import { ExternalServiceKind, ListExternalServiceFields , OrgFeatureFlagValueResult, OrgFeatureFlagValueVariables } from '../../../graphql-operations'
 import { AuthProvider, SourcegraphContext } from '../../../jscontext'
+import { GET_ORG_FEATURE_FLAG_VALUE, GITHUB_APP_FEATURE_FLAG_NAME } from '../../../org/backend'
 import { useCodeHostScopeContext } from '../../../site/CodeHostScopeAlerts/CodeHostScopeProvider'
 import { eventLogger } from '../../../tracking/eventLogger'
 import { UserExternalServicesOrRepositoriesUpdateProps } from '../../../util'
@@ -281,6 +283,19 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
         [authProvidersByKind]
     )
 
+    const { data, loading } = useQuery<OrgFeatureFlagValueResult, OrgFeatureFlagValueVariables>(
+        GET_ORG_FEATURE_FLAG_VALUE,
+        {
+            variables: { orgID: owner.id, flagName: GITHUB_APP_FEATURE_FLAG_NAME },
+            // Cache this data but always re-request it in the background when we revisit
+            // this page to pick up newer changes.
+            fetchPolicy: 'cache-and-network',
+            skip: !(owner.type === 'org'),
+        }
+    )
+
+    const useGitHubApp = data?.organizationFeatureFlagValue || false
+
     return (
         <div className="user-code-hosts-page">
             <PageTitle title="Code host connections" />
@@ -327,6 +342,7 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
                                         onDidAdd={addNewService}
                                         onDidRemove={removeService(kind)}
                                         onDidError={handleError}
+                                        useGitHubApp={useGitHubApp}
                                     />
                                 </CodeHostListItem>
                             ) : null

--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -342,7 +342,7 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
                                         onDidAdd={addNewService}
                                         onDidRemove={removeService(kind)}
                                         onDidError={handleError}
-                                        useGitHubApp={useGitHubApp}
+                                        useGitHubApp={useGitHubApp && kind === ExternalServiceKind.GITHUB}
                                     />
                                 </CodeHostListItem>
                             ) : null

--- a/client/web/src/user/settings/codeHosts/UserCodeHosts.tsx
+++ b/client/web/src/user/settings/codeHosts/UserCodeHosts.tsx
@@ -104,6 +104,7 @@ export const UserCodeHosts: React.FunctionComponent<UserCodeHosts> = ({
                                 icon={icon}
                                 onDidRemove={removeService(kind)}
                                 onDidError={onDidError}
+                                useGitHubApp={false}
                             />
                         </CodeHostListItem>
                     ) : null

--- a/client/web/src/user/settings/codeHosts/UserCodeHosts.tsx
+++ b/client/web/src/user/settings/codeHosts/UserCodeHosts.tsx
@@ -104,7 +104,6 @@ export const UserCodeHosts: React.FunctionComponent<UserCodeHosts> = ({
                                 icon={icon}
                                 onDidRemove={removeService(kind)}
                                 onDidError={onDidError}
-                                useGitHubApp={false}
                             />
                         </CodeHostListItem>
                     ) : null


### PR DESCRIPTION


https://user-images.githubusercontent.com/6427795/151542519-f53e83b8-c8fa-40ce-9ae7-8cd7790de332.mp4


If GitHub App feature is enabled for an Org the Connect button should direct the user to GitHub App.
