### PR TITLE
search: Make code in search results selectable (take 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
--
+- Code in search results is now selectable (e.g. for copying). Just clicking on the code continues to open the corresponding file as it did before. [#30033](https://github.com/sourcegraph/sourcegraph/pull/30033)
 
 ### Changed
 

--- a/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
+++ b/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
@@ -91,10 +91,12 @@ exports[`<HierarchicalLocationsView /> displays a single location when complete 
                 <div
                   class="test-file-match-children-item-wrapper itemCodeWrapper"
                 >
-                  <a
+                  <div
                     class="test-file-match-children-item item itemClickable"
+                    data-href="/github.com/foo/bar/-/blob/?L2:1&subtree=true"
                     data-testid="file-match-children-item"
-                    href="/github.com/foo/bar/-/blob/?L2:1&subtree=true"
+                    role="link"
+                    tabindex="0"
                   >
                     <code
                       class="codeExcerpt"
@@ -141,7 +143,7 @@ exports[`<HierarchicalLocationsView /> displays a single location when complete 
                         </tbody>
                       </table>
                     </code>
-                  </a>
+                  </div>
                 </div>
               </div>
             </div>
@@ -317,10 +319,12 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
                 <div
                   class="test-file-match-children-item-wrapper itemCodeWrapper"
                 >
-                  <a
+                  <div
                     class="test-file-match-children-item item itemClickable"
+                    data-href="/github.com/foo/bar/-/blob/file1.txt?L2:1&subtree=true"
                     data-testid="file-match-children-item"
-                    href="/github.com/foo/bar/-/blob/file1.txt?L2:1&subtree=true"
+                    role="link"
+                    tabindex="0"
                   >
                     <code
                       class="codeExcerpt"
@@ -391,7 +395,7 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
                         </tbody>
                       </table>
                     </code>
-                  </a>
+                  </div>
                 </div>
               </div>
             </div>
@@ -494,10 +498,12 @@ exports[`<HierarchicalLocationsView /> displays partial locations before complet
                 <div
                   class="test-file-match-children-item-wrapper itemCodeWrapper"
                 >
-                  <a
+                  <div
                     class="test-file-match-children-item item itemClickable"
+                    data-href="/github.com/foo/bar/-/blob/?L2:1&subtree=true"
                     data-testid="file-match-children-item"
-                    href="/github.com/foo/bar/-/blob/?L2:1&subtree=true"
+                    role="link"
+                    tabindex="0"
                   >
                     <code
                       class="codeExcerpt"
@@ -544,7 +550,7 @@ exports[`<HierarchicalLocationsView /> displays partial locations before complet
                         </tbody>
                       </table>
                     </code>
-                  </a>
+                  </div>
                 </div>
               </div>
             </div>

--- a/client/shared/src/components/CodeExcerpt.module.scss
+++ b/client/shared/src/components/CodeExcerpt.module.scss
@@ -23,6 +23,10 @@
         padding-left: 1rem;
     }
 
+    :global(.hl-source) {
+        cursor: text;
+    }
+
     &-error {
         width: 100%;
     }

--- a/client/shared/src/components/FileMatchChildren.module.scss
+++ b/client/shared/src/components/FileMatchChildren.module.scss
@@ -7,23 +7,29 @@
 }
 
 .item {
-    text-decoration: none; /* don't use cascading link style */
     display: flex;
     align-items: center;
-    padding: 0.25rem 0.5rem;
+
+    /*
+     * A combination of padding and margin is used to make sure that the
+     * box-shadow used to mark the item as focused is visible.
+     */
+    padding: 0.125rem 0.375rem;
+    margin: 0.125rem;
     background-color: var(--code-bg);
+
+    /*
+     * Overflow has to be set here instead of the wrapper otherwise the focus
+     * box-shadow is off when the item is scrolled.
+     */
+    overflow-x: auto;
 
     &-clickable {
         cursor: pointer;
     }
 
-    &:hover {
-        text-decoration: none;
-    }
-
     &-code-wrapper {
         position: relative;
-        overflow-x: auto;
 
         &:not(:first-child) {
             border-top: 1px solid var(--border-color-2);

--- a/client/shared/src/components/FileMatchChildren.tsx
+++ b/client/shared/src/components/FileMatchChildren.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames'
 import * as H from 'history'
-import React from 'react'
+import React, { MouseEvent, KeyboardEvent, useCallback } from 'react'
+import { useHistory } from 'react-router'
 import { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
 
@@ -32,6 +33,53 @@ interface FileMatchProps extends SettingsCascadeProps, TelemetryProps {
     fetchHighlightedFileLineRanges: (parameters: FetchFileParameters, force?: boolean) => Observable<string[][]>
 }
 
+/**
+ * This helper function determines whether a mouse/click event was triggered as
+ * a result of selecting text in search results.
+ * There are at least to ways to do this:
+ *
+ * - Tracking `mouseup`, `mousemove` and `mousedown` events. The occurrence of
+ * a `mousemove` event would indicate a text selection. However, users
+ * might slightly move the mouse while clicking, and solutions that would
+ * take this into account seem fragile.
+ * - (implemented here) Inspect the Selection object returned by
+ * `window.getSelection()`.
+ *
+ * CAVEAT: Chromium and Firefox (and maybe other browsers) behave
+ * differently when a search result is clicked *after* text selection was
+ * made:
+ *
+ * - Firefox will clear the selection before executing the click event
+ * handler, i.e. the search result will be opened.
+ * - Chrome will only clear the selection if the click happens *outside*
+ * of the selected text (in which case the search result will be
+ * opened). If the click happens inside the selected text the selection
+ * will be cleared only *after* executing the click event handler.
+ */
+function isTextSelectionEvent(event: MouseEvent<HTMLElement>): boolean {
+    const selection = window.getSelection()
+
+    // Text selections are always ranges. Should the type not be set, verify
+    // that the selection is not empty.
+    if (selection && (selection.type === 'Range' || selection.toString() !== '')) {
+        // Firefox specific: Because our code excerpts are implemented as tables,
+        // CTRL+click would select the table cell. Since users don't know that we
+        // use tables, the most likely wanted to open the search results in a new
+        // tab instead though.
+        if ((event.ctrlKey || event.metaKey) && selection.anchorNode?.nodeName === 'TR') {
+            // Ugly side effect: We don't want the table cell to be highlighted.
+            // The focus style that Firefox uses doesn't seem to be affected by
+            // CSS so instead we clear the selection.
+            selection.empty()
+            return false
+        }
+
+        return true
+    }
+
+    return false
+}
+
 export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props => {
     // If optimizeHighlighting is enabled, compile a list of the highlighted file ranges we want to
     // fetch (instead of the entire file.)
@@ -42,6 +90,7 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
         props.settingsCascade.final.experimentalFeatures.enableFastResultLoading
 
     const { result, grouped, fetchHighlightedFileLineRanges, telemetryService, onFirstResultLoad } = props
+    const history = useHistory()
     const fetchHighlightedFileRangeLines = React.useCallback(
         (isFirst, startLine, endLine) => {
             const startTime = Date.now()
@@ -88,6 +137,45 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
         )
     }
 
+    /**
+     * This handler implements the logic to simulate the click/keyboard
+     * activation behavior of links, while also allowing the selection of text
+     * inside the element.
+     * Because a click event is dispatched in both cases (clicking the search
+     * result to open it as well as selecting text within it), we have to be
+     * able to distinguish between those two actions.
+     * If we detect a text selection action, we don't have to do anything.
+     *
+     * CAVEATS:
+     * - In Firefox, Shift+click will open the URL in a new tab instead of
+     * a window (unlike Chromium which seems to show the same behavior as with
+     * native links).
+     * - Firefox will insert \t\n in between table rows, causing the copied
+     * text to be different from what is in the file/search result.
+     */
+    const navigateToFile = useCallback(
+        (event: KeyboardEvent<HTMLElement> | MouseEvent<HTMLElement>): void => {
+            // Testing for text selection is only necessary for mouse/click
+            // events.
+            if (
+                (event.type === 'click' && !isTextSelectionEvent(event as MouseEvent<HTMLElement>)) ||
+                (event as KeyboardEvent<HTMLElement>).key === 'Enter'
+            ) {
+                const href = event.currentTarget.getAttribute('data-href')
+
+                if (!event.defaultPrevented && href) {
+                    event.preventDefault()
+                    if (event.ctrlKey || event.metaKey || event.shiftKey) {
+                        window.open(href, '_blank')
+                    } else {
+                        history.push(href)
+                    }
+                }
+            }
+        },
+        [history]
+    )
+
     return (
         <div className={styles.fileMatchChildren} data-testid="file-match-children">
             {result.repoLastFetched && <LastSyncedIcon lastSyncedTime={result.repoLastFetched} />}
@@ -124,14 +212,18 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
                             }`}
                             className={classNames('test-file-match-children-item-wrapper', styles.itemCodeWrapper)}
                         >
-                            <Link
-                                to={createCodeExcerptLink(group)}
+                            <div
+                                data-href={createCodeExcerptLink(group)}
                                 className={classNames(
                                     'test-file-match-children-item',
                                     styles.item,
                                     styles.itemClickable
                                 )}
+                                onClick={navigateToFile}
+                                onKeyDown={navigateToFile}
                                 data-testid="file-match-children-item"
+                                tabIndex={0}
+                                role="link"
                             >
                                 <CodeExcerpt
                                     repoName={result.repository}
@@ -144,7 +236,7 @@ export const FileMatchChildren: React.FunctionComponent<FileMatchProps> = props 
                                     isFirst={index === 0}
                                     blobLines={group.blobLines}
                                 />
-                            </Link>
+                            </div>
                         </div>
                     ))}
                 </div>

--- a/client/web/src/regression/codeintel.test.ts
+++ b/client/web/src/regression/codeintel.test.ts
@@ -338,7 +338,7 @@ async function getPanelTabTitles(driver: Driver): Promise<string[]> {
 function collectVisibleLinks(driver: Driver): Promise<string[]> {
     return driver.page.evaluate(() =>
         [...document.querySelectorAll<HTMLElement>('.test-file-match-children-item-wrapper')].map(
-            a => a.querySelector('.test-file-match-children-item')?.getAttribute('href') || ''
+            a => a.querySelector('.test-file-match-children-item')?.getAttribute('data-href') || ''
         )
     )
 }


### PR DESCRIPTION
This is restoring commit 2f77f4581a9a0c86355d7ae09986bd54f13a149f, from PR #30304 (reverts e4b1567). See that PR for more information.

I think I fixed the failing codeintel regression test. Unfortunately I wasn't able to get those test to run locally, but I searched for all reference to the class `test-file-match-children-item` and this was the only one that references the `href` property.