### PR TITLE
Add AB testing of "search onboarding" tour vs "getting started tour"

### DIFF
--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -20,7 +20,7 @@ class ProxyMap<K extends string, V extends boolean> extends Map<K, V> {
 
 // A union of all feature flags we currently have.
 // If there are no feature flags at the moment, this should be `never`.
-export type FeatureFlagName = 'search-notebook-onboarding' | 'getting-started-tour' | 'disable-search-onboarding-tour'
+export type FeatureFlagName = 'search-notebook-onboarding' | 'getting-started-tour'
 
 export type FlagSet = ProxyMap<FeatureFlagName, boolean>
 

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -62,10 +62,10 @@ export const SearchPage: React.FunctionComponent<SearchPageProps> = props => {
         features => features.showOnboardingTour ?? false
     )
     const hasSearchQuery = useNavbarQueryState(state => state.searchQueryFromURL !== '')
-    const isSearchOnboardingFeatureDisabled = props.featureFlags.get('disable-search-onboarding-tour')
+    const isGettingStartedTourEnabled = props.featureFlags.get('getting-started-tour')
     const showOnboardingTour = useMemo(
-        () => isExperimentalOnboardingTourEnabled && !hasSearchQuery && !isSearchOnboardingFeatureDisabled,
-        [hasSearchQuery, isSearchOnboardingFeatureDisabled, isExperimentalOnboardingTourEnabled]
+        () => isExperimentalOnboardingTourEnabled && !hasSearchQuery && !isGettingStartedTourEnabled,
+        [hasSearchQuery, isGettingStartedTourEnabled, isExperimentalOnboardingTourEnabled]
     )
 
     useEffect(() => props.telemetryService.logViewEvent('Home'), [props.telemetryService])


### PR DESCRIPTION
Follow-up on https://github.com/sourcegraph/sourcegraph/issues/29890.

## Description
This PR:
- Splits AB testing traffic between old search onboarding tour and new getting started tour

## Screenshots
| `getting-started-tour` disabled | `getting-started-tour` enabled | 
| --: | :-- |
| ![image](https://user-images.githubusercontent.com/6717049/151580115-656a82c7-9d5d-4765-b366-0754c321683f.png) | ![image](https://user-images.githubusercontent.com/6717049/151580418-7ae27125-d64a-4aa8-b926-a97c064667c8.png) |
