### PR TITLE
sg: record previously installed version on bootstrap, install

### DIFF
--- a/dev/sg/bootstrap.sh
+++ b/dev/sg/bootstrap.sh
@@ -60,6 +60,9 @@ main() {
 
   printf '%s\n' 'running sg install' 1>&2
   "$_file" install </dev/tty
+
+  printf '%s\n' 'recording sg version' 1>&2
+  "$_file" version -record
 }
 
 get_architecture() {

--- a/dev/sg/install.sh
+++ b/dev/sg/install.sh
@@ -3,6 +3,11 @@
 set -euf -o pipefail
 pushd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null
 
+# Silently try to record previous version if easily available
+if command -v "sg" &>/dev/null; then
+  sg version -record 2>/dev/null || true
+fi
+
 # The BUILD_COMMIT is baked into the binary (see `go install` below) and
 # contains the latest commit in the `dev/sg` folder. If the directory is
 # "dirty", though, we mark the build as a dev build.

--- a/dev/sg/sg_version.go
+++ b/dev/sg/sg_version.go
@@ -3,24 +3,73 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
+	"github.com/sourcegraph/sourcegraph/dev/sg/root"
 )
 
 var (
-	versionFlagSet = flag.NewFlagSet("sg version", flag.ExitOnError)
+	versionFlagSet  = flag.NewFlagSet("sg version", flag.ExitOnError)
+	versionRecord   = versionFlagSet.Bool("record", false, "Record the currently installed sg version")
+	versionRecorded = versionFlagSet.Bool("recorded", false, "Print the currently recorded sg version")
+)
+
+var (
 	versionCommand = &ffcli.Command{
-		Name:       "version",
-		ShortUsage: "sg version",
-		ShortHelp:  "Prints the sg version",
-		FlagSet:    versionFlagSet,
-		Exec:       versionExec,
+		Name:        "version",
+		ShortUsage:  "sg version",
+		ShortHelp:   "Prints the sg version",
+		FlagSet:     versionFlagSet,
+		Exec:        versionExec,
+		Subcommands: []*ffcli.Command{},
 	}
 )
 
 func versionExec(ctx context.Context, args []string) error {
-	stdout.Out.Write(BuildCommit)
+	if !*versionRecorded && !*versionRecord {
+		stdout.Out.Write(BuildCommit)
+		return nil
+	}
+
+	versionPath, err := getRecordedVersionPath()
+	if err != nil {
+		return fmt.Errorf("getRecordedVersionPath: %w", err)
+	}
+	if *versionRecorded {
+		recordedVersion, err := os.ReadFile(versionPath)
+		if err != nil {
+			return fmt.Errorf("os.ReadFile: %w", err)
+		}
+		stdout.Out.Write(strings.TrimSpace(string(recordedVersion)))
+	}
+	if *versionRecord {
+		if BuildCommit == "dev" {
+			return fmt.Errorf("Refusing to record dev version without embedded commit")
+		}
+
+		versionFile, err := os.Create(versionPath)
+		if err != nil {
+			return fmt.Errorf("os.Create: %w", err)
+		}
+		realBuildCommit := strings.TrimPrefix(BuildCommit, "dev-")
+		if _, err := versionFile.WriteString(realBuildCommit); err != nil {
+			return fmt.Errorf("versionFile.WriteString: %w", err)
+		}
+		writeSuccessLinef("Currently installed version %q has been recorded to %s", realBuildCommit, versionPath)
+	}
 	return nil
+}
+
+func getRecordedVersionPath() (string, error) {
+	homepath, err := root.GetSGHomePath()
+	if err != nil {
+		return "", fmt.Errorf("GetSGHomePath: %w", err)
+	}
+	return filepath.Join(homepath, "PREVIOUS_SG_VERSION"), nil
 }


### PR DESCRIPTION
Adds:

```sh
sg version -record   # record currently installed commit
sg version -recorded # show currently recorded commit
```

This is automatically added on `bootstrap.sh` and `install.sh`. This will help us build changelog functionality into `sg`, which I'm envisioning as `sg version changelog`