### PR TITLE
for symbols: wrap handler in actor.HTTPMiddleware

### DIFF
--- a/cmd/symbols/main.go
+++ b/cmd/symbols/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/symbols/internal/fetcher"
 	"github.com/sourcegraph/sourcegraph/cmd/symbols/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/cmd/symbols/internal/parser"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/diskcache"
@@ -116,7 +117,7 @@ func main() {
 	server := httpserver.NewFromAddr(addr, &http.Server{
 		ReadTimeout:  75 * time.Second,
 		WriteTimeout: 10 * time.Minute,
-		Handler:      ot.HTTPMiddleware(trace.HTTPMiddleware(apiHandler, conf.DefaultClient())),
+		Handler:      actor.HTTPMiddleware(ot.HTTPMiddleware(trace.HTTPMiddleware(apiHandler, conf.DefaultClient()))),
 	})
 
 	evictionInterval := time.Second * 10

--- a/internal/actor/http.go
+++ b/internal/actor/http.go
@@ -136,6 +136,8 @@ func HTTPMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+// getCondensedURLPath truncates known high-cardinality paths to be used as metric labels in order to reduce the
+// label cardinality. This can and should be expanded to include other paths as necessary.
 func getCondensedURLPath(urlPath string) string {
 	if strings.HasPrefix(urlPath, "/.internal/git/") {
 		return "/.internal/git/..."


### PR DESCRIPTION
In tracking down missing actors for requests from `symbols` I saw that we didn't have the middleware wrapping the handler. I _think_ we want to add that here @bobheadxi lmk if this makes sense

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
