### PR TITLE
Implement allowSignup flag for OIDC authentication provider

### DIFF
--- a/enterprise/cmd/frontend/internal/auth/openidconnect/user.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/user.go
@@ -71,7 +71,7 @@ func getOrCreateUser(ctx context.Context, db database.DB, p *provider, idToken *
 			AccountID:   idToken.Subject,
 		},
 		ExternalAccountData: data,
-		CreateIfNotExist:    true,
+		CreateIfNotExist:    p.config.AllowSignup == nil || *p.config.AllowSignup,
 	})
 	if err != nil {
 		return nil, safeErrMsg, err

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/user_test.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/user_test.go
@@ -35,7 +35,7 @@ func TestAllowSignup(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			auth.MockGetAndSaveUser = func(ctx context.Context, op auth.GetAndSaveUserOp) (userID int32, safeErrMsg string, err error) {
 				if test.shouldAllowSignup != op.CreateIfNotExist {
-					t.Fatalf("Expected %v to equal %v", op.CreateIfNotExist, test.shouldAllowSignup)
+					t.Fatalf("op.CreateIfNotExist: want %v got %v\n", test.shouldAllowSignup, op.CreateIfNotExist)
 				}
 				return 0, "", nil
 			}
@@ -47,7 +47,7 @@ func TestAllowSignup(t *testing.T) {
 			}, oidc: &oidcProvider{}}
 			_, _, err := getOrCreateUser(context.Background(), database.NewStrictMockDB(), p, &oidc.IDToken{}, &oidc.UserInfo{Email: "foo@bar.com", EmailVerified: true}, &userClaims{})
 			if err != nil {
-				t.Fatal(err)
+				t.Errorf("err: expected nil, got %v\n", err)
 			}
 		})
 	}

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/user_test.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/user_test.go
@@ -1,0 +1,54 @@
+package openidconnect
+
+import (
+	"context"
+	"testing"
+
+	"github.com/coreos/go-oidc"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func TestAllowSignup(t *testing.T) {
+	allow := true
+	disallow := false
+	tests := map[string]struct {
+		allowSignup       *bool
+		shouldAllowSignup bool
+	}{
+		"nil": {
+			allowSignup:       nil,
+			shouldAllowSignup: true,
+		},
+		"true": {
+			allowSignup:       &allow,
+			shouldAllowSignup: true,
+		},
+		"false": {
+			allowSignup:       &disallow,
+			shouldAllowSignup: false,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			auth.MockGetAndSaveUser = func(ctx context.Context, op auth.GetAndSaveUserOp) (userID int32, safeErrMsg string, err error) {
+				if test.shouldAllowSignup != op.CreateIfNotExist {
+					t.Fatalf("Expected %v to equal %v", op.CreateIfNotExist, test.shouldAllowSignup)
+				}
+				return 0, "", nil
+			}
+			p := &provider{config: schema.OpenIDConnectAuthProvider{
+				ClientID:           testClientID,
+				ClientSecret:       "aaaaaaaaaaaaaaaaaaaaaaaaa",
+				RequireEmailDomain: "example.com",
+				AllowSignup:        test.allowSignup,
+			}, oidc: &oidcProvider{}}
+			_, _, err := getOrCreateUser(context.Background(), database.NewStrictMockDB(), p, &oidc.IDToken{}, &oidc.UserInfo{Email: "foo@bar.com", EmailVerified: true}, &userClaims{})
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1190,7 +1190,7 @@ type OnRepository struct {
 
 // OpenIDConnectAuthProvider description: Configures the OpenID Connect authentication provider for SSO.
 type OpenIDConnectAuthProvider struct {
-	// AllowSignup description: Allows new visitors to sign up for accounts via SAML authentication. If false, users signing in via SAML must have an existing Sourcegraph account, which will be linked to their SAML identity after sign-in.
+	// AllowSignup description: Allows new visitors to sign up for accounts via OpenID Connect authentication. If false, users signing in via OpenID Connect must have an existing Sourcegraph account, which will be linked to their OpenID Connect identity after sign-in.
 	AllowSignup *bool `json:"allowSignup,omitempty"`
 	// ClientID description: The client ID for the OpenID Connect client for this site.
 	//

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1190,6 +1190,8 @@ type OnRepository struct {
 
 // OpenIDConnectAuthProvider description: Configures the OpenID Connect authentication provider for SSO.
 type OpenIDConnectAuthProvider struct {
+	// AllowSignup description: Allows new visitors to sign up for accounts via SAML authentication. If false, users signing in via SAML must have an existing Sourcegraph account, which will be linked to their SAML identity after sign-in.
+	AllowSignup *bool `json:"allowSignup,omitempty"`
 	// ClientID description: The client ID for the OpenID Connect client for this site.
 	//
 	// For Google Apps: obtain this value from the API console (https://console.developers.google.com), as described at https://developers.google.com/identity/protocols/OpenIDConnect#getcredentials

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1375,7 +1375,7 @@
           "pattern": "^[^<@]"
         },
         "allowSignup": {
-          "description": "Allows new visitors to sign up for accounts via SAML authentication. If false, users signing in via SAML must have an existing Sourcegraph account, which will be linked to their SAML identity after sign-in.",
+          "description": "Allows new visitors to sign up for accounts via OpenID Connect authentication. If false, users signing in via OpenID Connect must have an existing Sourcegraph account, which will be linked to their OpenID Connect identity after sign-in.",
           "type": "boolean",
           "!go": { "pointer": true }
         }

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1373,6 +1373,11 @@
           "description": "Only allow users to authenticate if their email domain is equal to this value (example: mycompany.com). Do not include a leading \"@\". If not set, all users on this OpenID Connect provider can authenticate to Sourcegraph.",
           "type": "string",
           "pattern": "^[^<@]"
+        },
+        "allowSignup": {
+          "description": "Allows new visitors to sign up for accounts via SAML authentication. If false, users signing in via SAML must have an existing Sourcegraph account, which will be linked to their SAML identity after sign-in.",
+          "type": "boolean",
+          "!go": { "pointer": true }
         }
       }
     },


### PR DESCRIPTION
This adds a allowSignup flag to OpenIDConnect auth provider - [context](https://sourcegraph.slack.com/archives/C02MH5Z8MCP/p1643333880345989), [rfc](https://www.google.com/url?sa=t&rct=j&esrc=s&source=appssearch&uact=8&cd=0&cad=rja&q&sig2=L6Je_UY52EzIJr1vOR9b2g&ved=0ahUKEwimw6uR9_L1AhUErFAKHU3tBo04ABABKAAwAA&url=https://drive.google.com/a/sourcegraph.com/open?id%3D1Op6jum_SQJSU5KeJlJJEED1QYFdXOO30botb3BgEO6U%26usp%3Dchrome_omnibox&usg=AOvVaw2LgsnXwUR-nVtva45AX6C8).

This is enough to block new signups through OIDC (while still allowing existing accounts to log-in).

**Testing:**

Added basic unit tests.
 
On local instance with Sourcegraph GSuite OIDC provider verified - [Loom](https://www.loom.com/share/41de3a2e30d047d6b96d9f941c09aff6)

- [x] with allowSignup: false I cannot create a new account
- [x] with allowSignup: false I can use OIDC to authenticate to an existing account
- [x] with allowSignup: true I can create a new account