### PR TITLE
search: rename searchAlert -> searchAlertResolver in GQL package

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -8,31 +8,31 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/run"
 )
 
-type searchAlert struct {
+type searchAlertResolver struct {
 	alert *search.Alert
 }
 
-func NewSearchAlertResolver(alert *search.Alert) *searchAlert {
+func NewSearchAlertResolver(alert *search.Alert) *searchAlertResolver {
 	if alert == nil {
 		return nil
 	}
-	return &searchAlert{alert: alert}
+	return &searchAlertResolver{alert: alert}
 }
 
-func (a searchAlert) Title() string { return a.alert.Title }
+func (a searchAlertResolver) Title() string { return a.alert.Title }
 
-func (a searchAlert) Description() *string {
+func (a searchAlertResolver) Description() *string {
 	if a.alert.Description == "" {
 		return nil
 	}
 	return &a.alert.Description
 }
 
-func (a searchAlert) PrometheusType() string {
+func (a searchAlertResolver) PrometheusType() string {
 	return a.alert.PrometheusType
 }
 
-func (a searchAlert) ProposedQueries() *[]*searchQueryDescription {
+func (a searchAlertResolver) ProposedQueries() *[]*searchQueryDescription {
 	if len(a.alert.ProposedQueries) == 0 {
 		return nil
 	}
@@ -43,11 +43,11 @@ func (a searchAlert) ProposedQueries() *[]*searchQueryDescription {
 	return &proposedQueries
 }
 
-func (a searchAlert) wrapResults() *SearchResults {
+func (a searchAlertResolver) wrapResults() *SearchResults {
 	return &SearchResults{Alert: &a}
 }
 
-func (a searchAlert) wrapSearchImplementer(db database.DB) *alertSearchImplementer {
+func (a searchAlertResolver) wrapSearchImplementer(db database.DB) *alertSearchImplementer {
 	return &alertSearchImplementer{
 		db:    db,
 		alert: a,
@@ -58,7 +58,7 @@ func (a searchAlert) wrapSearchImplementer(db database.DB) *alertSearchImplement
 // SearchImplementer. This helps avoid needing to have a db on the searchAlert type
 type alertSearchImplementer struct {
 	db    database.DB
-	alert searchAlert
+	alert searchAlertResolver
 }
 
 func (a alertSearchImplementer) Results(context.Context) (*SearchResultsResolver, error) {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -147,7 +147,7 @@ type SearchResultsResolver struct {
 type SearchResults struct {
 	Matches result.Matches
 	Stats   streaming.Stats
-	Alert   *searchAlert
+	Alert   *searchAlertResolver
 }
 
 // Results are the results found by the search. It respects the limits set. To
@@ -213,7 +213,7 @@ func (sr *SearchResultsResolver) ApproximateResultCount() string {
 	return strconv.Itoa(int(count))
 }
 
-func (sr *SearchResultsResolver) Alert() *searchAlert { return sr.SearchResults.Alert }
+func (sr *SearchResultsResolver) Alert() *searchAlertResolver { return sr.SearchResults.Alert }
 
 func (sr *SearchResultsResolver) ElapsedMilliseconds() int32 {
 	return int32(sr.elapsed.Milliseconds())
@@ -1071,7 +1071,7 @@ func (r *searchResolver) evaluateOr(ctx context.Context, q query.Basic) (*Search
 	var (
 		mu     sync.Mutex
 		stats  streaming.Stats
-		alerts []*searchAlert
+		alerts []*searchAlertResolver
 		dedup  = result.NewDeduper()
 		// NOTE(tsenart): In the future, when we have the need for more intelligent rate limiting,
 		// this concurrency limit should probably be informed by a user's rate limit quota
@@ -1126,7 +1126,7 @@ func (r *searchResolver) evaluateOr(ctx context.Context, q query.Basic) (*Search
 		return nil, err
 	}
 
-	var alert *searchAlert
+	var alert *searchAlertResolver
 	if len(alerts) > 0 {
 		sort.Slice(alerts, func(i, j int) bool {
 			return alerts[i].alert.Priority > alerts[j].alert.Priority
@@ -1331,7 +1331,7 @@ func (r *searchResolver) resultsRecursive(ctx context.Context, plan query.Plan) 
 	var (
 		mu     sync.Mutex
 		stats  streaming.Stats
-		alerts []*searchAlert
+		alerts []*searchAlertResolver
 		dedup  = result.NewDeduper()
 		// NOTE(tsenart): In the future, when we have the need for more intelligent rate limiting,
 		// this concurrency limit should probably be informed by a user's rate limit quota
@@ -1439,7 +1439,7 @@ func (r *searchResolver) resultsRecursive(ctx context.Context, plan query.Plan) 
 		sortResults(matches)
 	}
 
-	var alert *searchAlert
+	var alert *searchAlertResolver
 	if len(alerts) > 0 {
 		sort.Slice(alerts, func(i, j int) bool {
 			return alerts[i].alert.Priority > alerts[j].alert.Priority

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -473,7 +473,7 @@ func TestSearchResultsResolver_ApproximateResultCount(t *testing.T) {
 	type fields struct {
 		results             []result.Match
 		searchResultsCommon streaming.Stats
-		alert               *searchAlert
+		alert               *searchAlertResolver
 	}
 	tests := []struct {
 		name   string


### PR DESCRIPTION
Just a rename. With this it's easier to see the resolver type and where it's in the "wrong" places so I can fix it.