### PR TITLE
search: break searchResolver dependency in doResults

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1527,7 +1527,7 @@ func (r *searchResolver) evaluateJob(ctx context.Context, job run.Job) (_ *Searc
 	}()
 
 	start := time.Now()
-	rr, err := r.doResults(ctx, job)
+	rr, err := doResults(ctx, r.SearchInputs, r.db, r.stream, job)
 
 	// We have an alert for context timeouts and we have a progress
 	// notification for timeouts. We don't want to show both, so we only show
@@ -1712,7 +1712,7 @@ func (r *searchResolver) Stats(ctx context.Context) (stats *searchResultsStats, 
 		if err != nil {
 			return nil, err
 		}
-		results, err := r.doResults(ctx, job)
+		results, err := doResults(ctx, r.SearchInputs, r.db, r.stream, job)
 		if err != nil {
 			return nil, err // do not cache errors.
 		}
@@ -1799,8 +1799,8 @@ func withResultTypes(args search.TextParameters, forceTypes result.Types) search
 
 // doResults returns the results of running a search job.
 // Partial results AND an error may be returned.
-func (r *searchResolver) doResults(ctx context.Context, job run.Job) (res *SearchResults, err error) {
-	tr, ctx := trace.New(ctx, "doResults", r.rawQuery())
+func doResults(ctx context.Context, searchInputs *run.SearchInputs, db database.DB, stream streaming.Sender, job run.Job) (res *SearchResults, err error) {
+	tr, ctx := trace.New(ctx, "doResults", searchInputs.OriginalQuery)
 	defer func() {
 		tr.SetError(err)
 		if res != nil {
@@ -1809,8 +1809,8 @@ func (r *searchResolver) doResults(ctx context.Context, job run.Job) (res *Searc
 		tr.Finish()
 	}()
 
-	agg := run.NewAggregator(r.stream)
-	_ = agg.DoSearch(ctx, r.db, job)
+	agg := run.NewAggregator(stream)
+	_ = agg.DoSearch(ctx, db, job)
 	matches, common, matchCount, aggErrs := agg.Get()
 
 	if aggErrs == nil {
@@ -1818,8 +1818,8 @@ func (r *searchResolver) doResults(ctx context.Context, job run.Job) (res *Searc
 	}
 
 	ao := alert.Observer{
-		Db:           r.db,
-		SearchInputs: r.SearchInputs,
+		Db:           db,
+		SearchInputs: searchInputs,
 		HasResults:   matchCount > 0,
 	}
 	for _, err := range aggErrs.Errors {

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -43,7 +43,7 @@ func (srs *searchResultsStats) getResults(ctx context.Context) (*SearchResultsRe
 			srs.srsErr = err
 			return
 		}
-		results, err := srs.sr.doResults(ctx, job)
+		results, err := doResults(ctx, srs.sr.SearchInputs, srs.sr.db, srs.sr.stream, job)
 		if err != nil {
 			srs.srsErr = err
 			return


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/30376.

As in description. This unlocks a major simplification: after this change the signature of `doResults` is:


`doResults(ctx context.Context, searchInputs *run.SearchInputs, db database.DB, stream streaming.Sender, job run.Job) (res *SearchResults, err error)`

You'll see this _almost_ satisfies the job `Run` interface! Which is exactly what I'd like next: to turn this into a job. Conceptually, it would be:

```go
type Job struct {
  SearchInputs
}
```

```go
func (Job) Run(ctx, db, stream) error {
...
}
```

Amazing! Just one snag: the return type to satisfy is `error`. This "job" generates the exact `SearchResults` we need to do further processing, and we need to extract these `SearchResults` especially because of alert messages that get sent out over the stream. 

**Open Question**:

- What do you think the best way is to get this value out of a job? My first idea: can we just use a channel sent into the Job struct? Or: I think we can even change the interface to be `(SearchResults, error)` for all jobs since this will be our terminal/"leaf" job?  @camdencheek halp!

Once we have this represented as a job, and we can extract `SearchResults`, we don't _just_ represent jobs as a tree, as a thing that we pass to `doResults`. Instead, we would be able to create the tree, and then just  Run from the root node directly! The only thing it seems we need to figure out is extracting / propagating `SearchResults` out of a job. 

- Minor: What do we call this kind of job? It's the one that aggregates stream results and also produces alert info.