### PR TITLE
search: move SearchResults type out of GQL package

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -43,8 +43,8 @@ func (a searchAlertResolver) ProposedQueries() *[]*searchQueryDescription {
 	return &proposedQueries
 }
 
-func alertToSearchResults(alert *search.Alert) *SearchResults {
-	return &SearchResults{Alert: alert}
+func alertToSearchResults(alert *search.Alert) *run.SearchResults {
+	return &run.SearchResults{Alert: alert}
 }
 
 func (a searchAlertResolver) wrapSearchImplementer(db database.DB) *alertSearchImplementer {

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -332,7 +332,7 @@ func TestSearchResolver_DynamicFilters(t *testing.T) {
 		t.Run(test.descr, func(t *testing.T) {
 			for _, globbing := range []bool{true, false} {
 				mockDecodedViewerFinalSettings.SearchGlobbing = &globbing
-				actualDynamicFilters := (&SearchResultsResolver{db: database.NewMockDB(), SearchResults: &SearchResults{Matches: test.searchResults}}).DynamicFilters(context.Background())
+				actualDynamicFilters := (&SearchResultsResolver{db: database.NewMockDB(), SearchResults: &run.SearchResults{Matches: test.searchResults}}).DynamicFilters(context.Background())
 				actualDynamicFilterStrs := make(map[string]int)
 
 				for _, filter := range actualDynamicFilters {
@@ -542,7 +542,7 @@ func TestSearchResultsResolver_ApproximateResultCount(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			sr := &SearchResultsResolver{
 				db: database.NewMockDB(),
-				SearchResults: &SearchResults{
+				SearchResults: &run.SearchResults{
 					Stats:   tt.fields.searchResultsCommon,
 					Matches: tt.fields.results,
 					Alert:   tt.fields.alert,

--- a/internal/search/run/run.go
+++ b/internal/search/run/run.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -39,6 +40,12 @@ func (inputs SearchInputs) MaxResults() int {
 	}
 
 	return search.DefaultMaxSearchResults
+}
+
+type SearchResults struct {
+	Matches result.Matches
+	Stats   streaming.Stats
+	Alert   *search.Alert
 }
 
 // Job is an interface shared by all individual search operations in the


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/30377

moves the `type SearchResults` definition into `package run` so we can change the `job.Run` signature to return this. The many `run.SearchResults` references created by this change, in the `graphqlbackend` package, is indicative of logic that we should, and will, move out over time.