### PR TITLE
Search jobs: inline `Aggregator.DoSearch`

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1818,19 +1818,15 @@ func doResults(ctx context.Context, searchInputs *run.SearchInputs, db database.
 	}()
 
 	agg := run.NewAggregator(stream)
-	_ = agg.DoSearch(ctx, db, job)
-	matches, common, matchCount, aggErrs := agg.Get()
-
-	if aggErrs == nil {
-		return nil, errors.New("aggErrs should never be nil")
-	}
+	err = job.Run(ctx, db, agg)
+	matches, common, matchCount := agg.Get()
 
 	ao := alert.Observer{
 		Db:           db,
 		SearchInputs: searchInputs,
 		HasResults:   matchCount > 0,
 	}
-	for _, err := range aggErrs.Errors {
+	if err != nil {
 		ao.Error(ctx, err)
 	}
 	alert, err := ao.Done(&common)

--- a/internal/search/run/aggregator.go
+++ b/internal/search/run/aggregator.go
@@ -1,24 +1,16 @@
 package run
 
 import (
-	"context"
 	"sync"
 
-	"github.com/cockroachdb/errors"
-	"github.com/hashicorp/go-multierror"
-	"github.com/inconshreveable/log15"
-
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
-	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
 func NewAggregator(stream streaming.Sender) *Aggregator {
 	return &Aggregator{
 		parentStream: stream,
-		errors:       &multierror.Error{},
 	}
 }
 
@@ -28,17 +20,16 @@ type Aggregator struct {
 	mu         sync.Mutex
 	results    []result.Match
 	stats      streaming.Stats
-	errors     *multierror.Error
 	matchCount int
 }
 
 // Get finalises aggregation over the stream and returns the aggregated
 // result. It should only be called once each do* function is finished
 // running.
-func (a *Aggregator) Get() ([]result.Match, streaming.Stats, int, *multierror.Error) {
+func (a *Aggregator) Get() ([]result.Match, streaming.Stats, int) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	return a.results, a.stats, a.matchCount, a.errors
+	return a.results, a.stats, a.matchCount
 }
 
 // Send propagates the given event to the Aggregator's parent stream, or
@@ -71,25 +62,4 @@ func (a *Aggregator) Send(event streaming.SearchEvent) {
 
 	a.matchCount += len(event.Results)
 	a.stats.Update(&event.Stats)
-}
-
-func (a *Aggregator) Error(err error) {
-	a.mu.Lock()
-	a.errors = multierror.Append(a.errors, err)
-	a.mu.Unlock()
-	if err != nil {
-		log15.Debug("aggregated search error", "error", err)
-	}
-}
-
-func (a *Aggregator) DoSearch(ctx context.Context, db database.DB, job Job) (err error) {
-	tr, ctx := trace.New(ctx, "DoSearch", job.Name())
-	defer func() {
-		a.Error(err)
-		tr.SetErrorIfNotContext(err)
-		tr.Finish()
-	}()
-
-	err = job.Run(ctx, db, a)
-	return errors.Wrap(err, job.Name()+" search failed")
 }


### PR DESCRIPTION
The only thing this method was doing was wrapping the job with a trace
(which was already happening in DoResults) and aggregating the error,
which is useless since it is only ever possible for a single error to be
aggregated. This means we can get rid of `Aggregator.Error()` entirely.

My goal here is just to pull some threads to see how far I can get this
to unravel.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
