### PR TITLE
remove unused `IsIndexAvailable`

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1949,6 +1949,7 @@ type SearchResults {
     """
     timedout: [Repository!]!
     """
+    DEPRECATED: This field is not used in known clients, and will always return `false`.
     True if indexed search is enabled but was not available during this search.
     """
     indexUnavailable: Boolean!

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -125,7 +125,9 @@ func (c *SearchResultsResolver) Timedout(ctx context.Context) ([]*RepositoryReso
 }
 
 func (c *SearchResultsResolver) IndexUnavailable() bool {
-	return c.Stats.IsIndexUnavailable
+	// This used to return c.Stats.IsIndexUnavailable, but it was never set,
+	// so would always return false
+	return false
 }
 
 // SearchResultsResolver is a resolver for the GraphQL type `SearchResults`

--- a/internal/search/streaming/progress.go
+++ b/internal/search/streaming/progress.go
@@ -28,9 +28,6 @@ type Stats struct {
 	// ExcludedArchived is the count of excluded archived repos because the
 	// search query doesn't apply to them, but that we want to know about.
 	ExcludedArchived int
-
-	// IsIndexUnavailable is true if indexed search was unavailable.
-	IsIndexUnavailable bool
 }
 
 // Update updates c with the other data, deduping as necessary. It modifies c but
@@ -41,7 +38,6 @@ func (c *Stats) Update(other *Stats) {
 	}
 
 	c.IsLimitHit = c.IsLimitHit || other.IsLimitHit
-	c.IsIndexUnavailable = c.IsIndexUnavailable || other.IsIndexUnavailable
 
 	if c.Repos == nil && len(other.Repos) > 0 {
 		c.Repos = make(map[api.RepoID]struct{}, len(other.Repos))
@@ -69,8 +65,7 @@ func (c *Stats) Zero() bool {
 		len(c.Repos) > 0 ||
 		c.Status.Len() > 0 ||
 		c.ExcludedForks > 0 ||
-		c.ExcludedArchived > 0 ||
-		c.IsIndexUnavailable)
+		c.ExcludedArchived > 0)
 }
 
 func (c *Stats) String() string {
@@ -96,9 +91,6 @@ func (c *Stats) String() string {
 	}
 	if c.IsLimitHit {
 		parts = append(parts, "limitHit")
-	}
-	if c.IsIndexUnavailable {
-		parts = append(parts, "indexUnavailable")
 	}
 
 	return "Stats{" + strings.Join(parts, " ") + "}"


### PR DESCRIPTION
`IsIndexAvailable` was never set, and I'm not sure what it was for, so this removes it. If it _should_ be used, I'll close this and open an issue for it. 