### PR TITLE
Fix long lines wrap in split diff mode

### DIFF
--- a/client/web/src/components/diff/Lines.module.scss
+++ b/client/web/src/components/diff/Lines.module.scss
@@ -6,6 +6,9 @@
             display: inline;
         }
     }
+    &--force-wrap {
+        overflow-wrap: anywhere;
+    }
     &--active {
         background-color: var(--code-line-highlight-color) !important;
     }

--- a/client/web/src/components/diff/Lines.tsx
+++ b/client/web/src/components/diff/Lines.tsx
@@ -102,7 +102,7 @@ export const Line: React.FunctionComponent<Line> = ({
             >
                 <div className={classNames('d-inline', styles.lineCode)}>
                     <div
-                        className="d-inline-block"
+                        className={classNames('d-inline-block', styles.lineForceWrap)}
                         dangerouslySetInnerHTML={{ __html: html }}
                         data-diff-marker={diffHunkTypeIndicators[kind]}
                     />


### PR DESCRIPTION
## Issue
This PR addresses https://github.com/sourcegraph/sourcegraph/issues/29888
Long lines of code weren't wrapped properly and caused text from the left column to overlap the right one.

Repro link: https://sourcegraph.com/github.com/angular/angular/-/commit/f593552cfe44ced74a3ec7e95a9ae847094fb632?visible=27

## The fix
We could've applied some sort of horizontal scrolling, which isn't ideal in my opinion - because it would lead to harder to perceive UI, or force long lines to be split in a few. I chose the latter.

### Before
<img width="1204" alt="Screenshot 2022-01-31 at 13 26 04" src="https://user-images.githubusercontent.com/2196347/151777340-3047db14-fbdf-46d5-839d-b42eec1ca3d6.png">

### After
<img width="1203" alt="Screenshot 2022-01-31 at 13 26 21" src="https://user-images.githubusercontent.com/2196347/151777366-6d328d2e-abb2-4128-a97c-963f7976ff2d.png">
