### PR TITLE
code intel: Enable snapshots for one variant per story

### DIFF
--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.story.tsx
@@ -297,3 +297,7 @@ Policies.args = {
         tosAccepted: true,
     },
 }
+
+Policies.parameters = {
+    chromatic: { disableSnapshots: false },
+}

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.story.tsx
@@ -169,3 +169,7 @@ RepositoryPage.args = {
     ...defaults,
     repo: { id: '42' },
 }
+RepositoryPage.parameters = {
+    // Keep snapshots for one variant
+    chromatic: { disableSnapshots: false },
+}

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelRepositoryIndexConfigurationPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelRepositoryIndexConfigurationPage.story.tsx
@@ -32,3 +32,7 @@ RepositoryPage.args = {
     ...defaults,
     repo: { id: '42' },
 }
+RepositoryPage.parameters = {
+    // Keep snapshots for one variant
+    chromatic: { disableSnapshots: false },
+}

--- a/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelIndexPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelIndexPage.story.tsx
@@ -453,6 +453,11 @@ Completed.args = {
         }),
 }
 
+Completed.parameters = {
+    // Keep snapshots for one variant
+    chromatic: { disableSnapshots: false },
+}
+
 export const Errored = Template.bind({})
 Errored.args = {
     ...defaults,

--- a/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelIndexesPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelIndexesPage.story.tsx
@@ -148,3 +148,7 @@ RepositoryPage.args = {
     queryLsifIndexListByRepository: () => of(makeResponse(testIndexes)),
     queryLsifIndexList: () => of(makeResponse(testIndexes)),
 }
+RepositoryPage.parameters = {
+    // Keep snapshots for one variant
+    chromatic: { disableSnapshots: false },
+}

--- a/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadPage.story.tsx
@@ -187,6 +187,10 @@ Completed.args = {
             finishedAt: '2020-06-14T12:30:30+00:00',
         }),
 }
+Completed.parameters = {
+    // Keep snapshots for one variant
+    chromatic: { disableSnapshots: false },
+}
 
 export const Errored = Template.bind({})
 Errored.args = {

--- a/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadsPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadsPage.story.tsx
@@ -150,3 +150,7 @@ RepositoryPage.args = {
     repo: { id: 'sourcegraph' },
     queryLsifUploadsByRepository: () => of(makeResponse(testUploads)),
 }
+RepositoryPage.parameters = {
+    // Keep snapshots for one variant
+    chromatic: { disableSnapshots: false },
+}


### PR DESCRIPTION
This  fixes https://github.com/sourcegraph/sourcegraph/issues/30335 by enabling snapshots for one variant of all code intel stories I could find.
