### PR TITLE
Revert 'Add AB testing of "search onboarding" tour vs "getting started tour" (#30359)'

### DIFF
--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -20,7 +20,7 @@ class ProxyMap<K extends string, V extends boolean> extends Map<K, V> {
 
 // A union of all feature flags we currently have.
 // If there are no feature flags at the moment, this should be `never`.
-export type FeatureFlagName = 'search-notebook-onboarding' | 'getting-started-tour'
+export type FeatureFlagName = 'search-notebook-onboarding' | 'getting-started-tour' | 'disable-search-onboarding-tour'
 
 export type FlagSet = ProxyMap<FeatureFlagName, boolean>
 

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -62,10 +62,10 @@ export const SearchPage: React.FunctionComponent<SearchPageProps> = props => {
         features => features.showOnboardingTour ?? false
     )
     const hasSearchQuery = useNavbarQueryState(state => state.searchQueryFromURL !== '')
-    const isGettingStartedTourEnabled = props.featureFlags.get('getting-started-tour')
+    const isSearchOnboardingFeatureDisabled = props.featureFlags.get('disable-search-onboarding-tour')
     const showOnboardingTour = useMemo(
-        () => isExperimentalOnboardingTourEnabled && !hasSearchQuery && !isGettingStartedTourEnabled,
-        [hasSearchQuery, isGettingStartedTourEnabled, isExperimentalOnboardingTourEnabled]
+        () => isExperimentalOnboardingTourEnabled && !hasSearchQuery && !isSearchOnboardingFeatureDisabled,
+        [hasSearchQuery, isSearchOnboardingFeatureDisabled, isExperimentalOnboardingTourEnabled]
     )
 
     useEffect(() => props.telemetryService.logViewEvent('Home'), [props.telemetryService])


### PR DESCRIPTION
This reverts commit 9bbbbacc3e9aa459390db1bc9a781ef8a5606b17, due to spurious failures showing up in Chromatic.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
