### PR TITLE
migrations: Enrich migration operation direction

### DIFF
--- a/dev/sg/sg_db.go
+++ b/dev/sg/sg_db.go
@@ -203,7 +203,7 @@ func dbResetPGExec(ctx context.Context, args []string) error {
 	for _, schemaName := range schemaNames {
 		operations = append(operations, runner.MigrationOperation{
 			SchemaName: schemaName,
-			Up:         true,
+			Type:       runner.MigrationOperationTypeUpgrade,
 		})
 	}
 

--- a/internal/database/connections/live/connect.go
+++ b/internal/database/connections/live/connect.go
@@ -82,7 +82,7 @@ func validateSchema(db *sql.DB, schema *schemas.Schema, validateOnly bool, obser
 			Operations: []runner.MigrationOperation{
 				{
 					SchemaName: schema.Name,
-					Up:         true,
+					Type:       runner.MigrationOperationTypeUpgrade,
 				},
 			},
 		})

--- a/internal/database/connections/live/migration_test.go
+++ b/internal/database/connections/live/migration_test.go
@@ -50,7 +50,7 @@ func testMigrations(t *testing.T, name string, schema *schemas.Schema) {
 		Operations: []runner.MigrationOperation{
 			{
 				SchemaName: name,
-				Up:         true,
+				Type:       runner.MigrationOperationTypeUpgrade,
 			},
 		},
 	}
@@ -58,11 +58,11 @@ func testMigrations(t *testing.T, name string, schema *schemas.Schema) {
 		Operations: []runner.MigrationOperation{
 			{
 				SchemaName: name,
-				Up:         false,
+				Type:       runner.MigrationOperationTypeTargetedDown,
 				// Run down to the root "squashed commits" migration. We don't go
 				// any farther than that because it would require a fresh database,
 				// and that doesn't adequately test upgrade idempotency.
-				TargetMigration: schema.Definitions.First(),
+				TargetVersion: schema.Definitions.First(),
 			},
 		},
 	}

--- a/internal/database/connections/test/connect.go
+++ b/internal/database/connections/test/connect.go
@@ -31,7 +31,7 @@ func NewTestDB(dsn string, schemas ...*schemas.Schema) (_ *sql.DB, err error) {
 	for _, schemaName := range schemaNames {
 		operations = append(operations, runner.MigrationOperation{
 			SchemaName: schemaName,
-			Up:         true,
+			Type:       runner.MigrationOperationTypeUpgrade,
 		})
 	}
 

--- a/internal/database/migration/cliutil/down.go
+++ b/internal/database/migration/cliutil/down.go
@@ -32,9 +32,9 @@ func Down(commandName string, run RunFunc, out *output.Output) *ffcli.Command {
 		return run(ctx, runner.Options{
 			Operations: []runner.MigrationOperation{
 				{
-					SchemaName:      *downDatabaseNameFlag,
-					Up:              false,
-					TargetMigration: *downTargetFlag,
+					SchemaName:    *downDatabaseNameFlag,
+					Type:          runner.MigrationOperationTypeTargetedDown,
+					TargetVersion: *downTargetFlag,
 				},
 			},
 		})

--- a/internal/database/migration/cliutil/up.go
+++ b/internal/database/migration/cliutil/up.go
@@ -40,9 +40,9 @@ func Up(commandName string, run RunFunc, out *output.Output) *ffcli.Command {
 		operations := []runner.MigrationOperation{}
 		for _, databaseName := range databaseNames {
 			operations = append(operations, runner.MigrationOperation{
-				SchemaName:      databaseName,
-				Up:              true,
-				TargetMigration: *upTargetFlag,
+				SchemaName:    databaseName,
+				Type:          runner.MigrationOperationTypeTargetedUp,
+				TargetVersion: *upTargetFlag,
 			})
 		}
 

--- a/internal/database/migration/runner/options.go
+++ b/internal/database/migration/runner/options.go
@@ -1,5 +1,11 @@
 package runner
 
+import (
+	"fmt"
+
+	"github.com/inconshreveable/log15"
+)
+
 type Options struct {
 	Operations []MigrationOperation
 
@@ -11,7 +17,84 @@ type Options struct {
 }
 
 type MigrationOperation struct {
-	SchemaName      string
-	Up              bool
-	TargetMigration int
+	SchemaName    string
+	Type          MigrationOperationType
+	TargetVersion int
+}
+
+type MigrationOperationType int
+
+const (
+	MigrationOperationTypeTargetedUp MigrationOperationType = iota
+	MigrationOperationTypeTargetedDown
+	MigrationOperationTypeUpgrade
+	MigrationOperationTypeRevert
+)
+
+func desugarOperation(schemaContext schemaContext, operation MigrationOperation) (MigrationOperation, error) {
+	switch operation.Type {
+	case MigrationOperationTypeUpgrade:
+		return desugarUpgrade(schemaContext, operation)
+	case MigrationOperationTypeRevert:
+		return desugarRevert(schemaContext, operation)
+	}
+
+	return operation, nil
+}
+
+// desugarUpgrade converts an "upgrade" operation into a targeted "upto" operation. We only need to
+// identify the leaves of the current schema definition to run everything defined.
+func desugarUpgrade(schemaContext schemaContext, operation MigrationOperation) (MigrationOperation, error) {
+	leafVersions := extractIDs(schemaContext.schema.Definitions.Leaves())
+	if len(leafVersions) != 1 {
+		return MigrationOperation{}, fmt.Errorf("nothing to upgrade")
+	}
+
+	log15.Info(
+		"Desugaring `upgrade` to `targeted up` operation",
+		"schema", operation.SchemaName,
+		"leafVersions", leafVersions,
+	)
+
+	return MigrationOperation{
+		SchemaName:    operation.SchemaName,
+		Type:          MigrationOperationTypeTargetedUp,
+		TargetVersion: leafVersions[0],
+	}, nil
+}
+
+// desugarRevert converts a "revert" operation into a targeted "down" operation. A revert operation
+// is primarily meant to support "undo" capability in local development when testing a single migration
+// (or linear chain of migrations).
+//
+// This function selects to undo the migration that has no applied children. Repeated application of the
+// revert operation should "pop" off the last migration applied. This function will give up if the revert
+// is ambiguous, which can happen once a migration with multiple parents has been reverted. More complex
+// down migrations can be run with an explicit "down" operation.
+func desugarRevert(schemaContext schemaContext, operation MigrationOperation) (MigrationOperation, error) {
+	definitions := schemaContext.schema.Definitions
+	leafVersions := []int{schemaContext.schemaVersion.version}
+
+	log15.Info(
+		"Desugaring `revert` to `targeted down` operation",
+		"schema", operation.SchemaName,
+		"appliedLeafVersions", leafVersions,
+	)
+
+	// We want to revert leafVersions[0], so we need to migrate "down" its parents.
+	// That operation will undo any applied proper descendants of this parent set, which
+	// should consist of exactly this target version.
+	definition, ok := definitions.GetByID(leafVersions[0])
+	if !ok {
+		return MigrationOperation{}, fmt.Errorf("unknown version %d", leafVersions[0])
+	}
+	if len(definition.Parents) != 1 {
+		return MigrationOperation{}, fmt.Errorf("expected one parent")
+	}
+
+	return MigrationOperation{
+		SchemaName:    operation.SchemaName,
+		Type:          MigrationOperationTypeTargetedDown,
+		TargetVersion: definition.Parents[0],
+	}, nil
 }

--- a/internal/database/migration/runner/run_test.go
+++ b/internal/database/migration/runner/run_test.go
@@ -19,9 +19,9 @@ func TestRunnerRun(t *testing.T) {
 		if err := makeTestRunner(t, store).Run(ctx, Options{
 			Operations: []MigrationOperation{
 				{
-					SchemaName:      "well-formed",
-					Up:              true,
-					TargetMigration: 10000 + 2,
+					SchemaName:    "well-formed",
+					Type:          MigrationOperationTypeTargetedUp,
+					TargetVersion: 10000 + 2,
 				},
 			},
 		}); err != nil {
@@ -38,9 +38,9 @@ func TestRunnerRun(t *testing.T) {
 		if err := makeTestRunner(t, store).Run(ctx, Options{
 			Operations: []MigrationOperation{
 				{
-					SchemaName:      "well-formed",
-					Up:              false,
-					TargetMigration: 10003 - 2,
+					SchemaName:    "well-formed",
+					Type:          MigrationOperationTypeTargetedDown,
+					TargetVersion: 10003 - 2,
 				},
 			},
 		}); err != nil {
@@ -58,9 +58,9 @@ func TestRunnerRun(t *testing.T) {
 		if err := makeTestRunner(t, store).Run(ctx, Options{
 			Operations: []MigrationOperation{
 				{
-					SchemaName:      "query-error",
-					Up:              true,
-					TargetMigration: 10000 + 1,
+					SchemaName:    "query-error",
+					Type:          MigrationOperationTypeTargetedUp,
+					TargetVersion: 10000 + 1,
 				},
 			},
 		}); err == nil || !strings.Contains(err.Error(), "uh-oh") {
@@ -78,9 +78,9 @@ func TestRunnerRun(t *testing.T) {
 		if err := makeTestRunner(t, store).Run(ctx, Options{
 			Operations: []MigrationOperation{
 				{
-					SchemaName:      "query-error",
-					Up:              false,
-					TargetMigration: 10001 - 1,
+					SchemaName:    "query-error",
+					Type:          MigrationOperationTypeTargetedDown,
+					TargetVersion: 10001 - 1,
 				},
 			},
 		}); err == nil || !strings.Contains(err.Error(), "uh-oh") {
@@ -95,9 +95,9 @@ func TestRunnerRun(t *testing.T) {
 		if err := makeTestRunner(t, testStoreWithVersion(10000, false)).Run(ctx, Options{
 			Operations: []MigrationOperation{
 				{
-					SchemaName:      "unknown",
-					Up:              true,
-					TargetMigration: 10000 + 1,
+					SchemaName:    "unknown",
+					Type:          MigrationOperationTypeTargetedUp,
+					TargetVersion: 10000 + 1,
 				},
 			},
 		}); err == nil || !strings.Contains(err.Error(), "unknown schema") {
@@ -111,9 +111,9 @@ func TestRunnerRun(t *testing.T) {
 		if err := makeTestRunner(t, store).Run(ctx, Options{
 			Operations: []MigrationOperation{
 				{
-					SchemaName:      "well-formed",
-					Up:              true,
-					TargetMigration: 10000 + 1,
+					SchemaName:    "well-formed",
+					Type:          MigrationOperationTypeTargetedUp,
+					TargetVersion: 10000 + 1,
 				},
 			},
 		}); err == nil || !strings.Contains(err.Error(), "dirty database") {
@@ -128,9 +128,9 @@ func TestRunnerRun(t *testing.T) {
 		if err := makeTestRunner(t, store).Run(ctx, Options{
 			Operations: []MigrationOperation{
 				{
-					SchemaName:      "well-formed",
-					Up:              true,
-					TargetMigration: 10002 + 0,
+					SchemaName:    "well-formed",
+					Type:          MigrationOperationTypeTargetedUp,
+					TargetVersion: 10002 + 0,
 				},
 			},
 		}); err == nil || !strings.Contains(err.Error(), "dirty database") {
@@ -146,9 +146,9 @@ func TestRunnerRun(t *testing.T) {
 		if err := makeTestRunner(t, store).Run(ctx, Options{
 			Operations: []MigrationOperation{
 				{
-					SchemaName:      "well-formed",
-					Up:              true,
-					TargetMigration: 10000 + 1,
+					SchemaName:    "well-formed",
+					Type:          MigrationOperationTypeTargetedUp,
+					TargetVersion: 10000 + 1,
 				},
 			},
 		}); err == nil || !strings.Contains(err.Error(), "contention") {
@@ -163,9 +163,9 @@ func TestRunnerRun(t *testing.T) {
 		if err := makeTestRunner(t, store).Run(ctx, Options{
 			Operations: []MigrationOperation{
 				{
-					SchemaName:      "well-formed",
-					Up:              true,
-					TargetMigration: 10002 + 1,
+					SchemaName:    "well-formed",
+					Type:          MigrationOperationTypeTargetedUp,
+					TargetVersion: 10002 + 1,
 				},
 			},
 		}); err == nil || !strings.Contains(err.Error(), "contention") {

--- a/internal/database/migration/runner/util.go
+++ b/internal/database/migration/runner/util.go
@@ -1,0 +1,12 @@
+package runner
+
+import "github.com/sourcegraph/sourcegraph/internal/database/migration/definition"
+
+func extractIDs(definitions []definition.Definition) []int {
+	ids := make([]int, 0, len(definitions))
+	for _, definition := range definitions {
+		ids = append(ids, definition.ID)
+	}
+
+	return ids
+}


### PR DESCRIPTION
Pulled from #29831. This PR replaces the boolean `Up` field on migration operations with an enum type that will (eventually) support four operations:

- (targeted) up: apply everything necessary to get your database up to this version
- (targeted) down: unapply everything necessary to revert your database to this version
- upgrade: apply everything necessary to get your database up to the latest version
- revert: unapply whatever the tip version of your database is (undo for local development)

This PR only adds the infra for the last two; we still only expose "up" and "down" in the migrator/sg migration command. A subsequent PR will add the next two commands.