### PR TITLE
migrations: Allow idempotent unlock in `TryLock`

### DIFF
--- a/internal/database/migration/store/store.go
+++ b/internal/database/migration/store/store.go
@@ -254,6 +254,9 @@ func (s *Store) TryLock(ctx context.Context) (_ bool, _ func(err error) error, e
 			if unlockErr := s.Exec(ctx, sqlf.Sprintf(`SELECT pg_advisory_unlock(%s, %s)`, key, 0)); unlockErr != nil {
 				err = multierror.Append(err, unlockErr)
 			}
+
+			// No-op if called more than once
+			locked = false
 		}
 
 		return err


### PR DESCRIPTION
Pulled from #29831. This PR adds a flag to prevent the replay of a SQL query which can be called explicitly or on defer. We should allow it to be called multiple times to ensure at-least-once semantics on the way out of a function.