### PR TITLE
sg migration squash: Fix removal of squashed files

### DIFF
--- a/dev/sg/internal/migration/squash.go
+++ b/dev/sg/internal/migration/squash.go
@@ -306,7 +306,7 @@ func removeMigrationFilesUpToIndex(database db.Database, targetIndex int) ([]str
 	}
 
 	for _, name := range filtered {
-		if err := os.Remove(filepath.Join(baseDir, name)); err != nil {
+		if err := os.RemoveAll(filepath.Join(baseDir, name)); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Pulled from #29831. This PR fixes the removal of migration _directories_ instead of single files.