### PR TITLE
sg migration squash: Exclude `migration_logs`

### DIFF
--- a/dev/sg/internal/migration/squash.go
+++ b/dev/sg/internal/migration/squash.go
@@ -221,7 +221,21 @@ func generateSquashedUpMigration(database db.Database, postgresDSN string) (_ st
 		return run.InRoot(cmd)
 	}
 
-	pgDumpOutput, err := pgDump("--schema-only", "--no-owner", "--exclude-table", "*schema_migrations")
+	excludeTables := []string{
+		"*schema_migrations",
+		"migration_logs",
+		"migration_logs_id_seq",
+	}
+
+	args := []string{
+		"--schema-only",
+		"--no-owner",
+	}
+	for _, tableName := range excludeTables {
+		args = append(args, "--exclude-table", tableName)
+	}
+
+	pgDumpOutput, err := pgDump(args...)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Pulled from #29831. Exclude `migration_logs` and its sequence from squashed migrations. This table is created on-demand by the migration store.