### PR TITLE
Code Insights: Add template section to the getting started page

### DIFF
--- a/client/web/src/enterprise/insights/pages/getting-started/CodeInsightsGettingStartedPage.tsx
+++ b/client/web/src/enterprise/insights/pages/getting-started/CodeInsightsGettingStartedPage.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
 
 import { CodeInsightsExamples } from './components/code-insights-examples/CodeInsightsExamples'
+import { CodeInsightsTemplates } from './components/code-insights-temlates/CodeInsightsTemplates'
 
 export const CodeInsightsGettingStartedPage: React.FunctionComponent = () => (
-    <div>
-        <CodeInsightsExamples />
+    <div className="pb-5">
+        <CodeInsightsExamples className="mt-5" />
+        <CodeInsightsTemplates className="mt-5" />
     </div>
 )

--- a/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-examples/CodeInsightsExamples.tsx
+++ b/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-examples/CodeInsightsExamples.tsx
@@ -17,10 +17,20 @@ import { DATA_SERIES_COLORS, encodeSearchInsightUrl } from '../../../insights/cr
 
 import styles from './CodeInsightsExamples.module.scss'
 
-export const CodeInsightsExamples: React.FunctionComponent = () => (
-    <section className={styles.section}>
-        <CodeInsightSearchExample className={styles.card} />
-        <CodeInsightCaptureExample className={styles.card} />
+export interface CodeInsightsExamples extends React.HTMLAttributes<HTMLElement> {}
+
+export const CodeInsightsExamples: React.FunctionComponent<CodeInsightsExamples> = props => (
+    <section {...props}>
+        <h2>Example insights</h2>
+        <p className="text-muted">
+            We've created a few common simple insights to show you what the tool can do.{' '}
+            <a href="/help">Explore more use cases.</a>
+        </p>
+
+        <div className={styles.section}>
+            <CodeInsightSearchExample className={styles.card} />
+            <CodeInsightCaptureExample className={styles.card} />
+        </div>
     </section>
 )
 

--- a/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-examples/CodeInsightsExamples.tsx
+++ b/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-examples/CodeInsightsExamples.tsx
@@ -24,7 +24,9 @@ export const CodeInsightsExamples: React.FunctionComponent<CodeInsightsExamples>
         <h2>Example insights</h2>
         <p className="text-muted">
             We've created a few common simple insights to show you what the tool can do.{' '}
-            <a href="/help">Explore more use cases.</a>
+            <a href="/help/code_insights/references/common_use_cases" rel="noopener noreferrer" target="_blank">
+                Explore more use cases.
+            </a>
         </p>
 
         <div className={styles.section}>

--- a/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-temlates/CodeInsightsTemplates.module.scss
+++ b/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-temlates/CodeInsightsTemplates.module.scss
@@ -1,0 +1,25 @@
+.cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(25rem, 1fr));
+    row-gap: 0.5rem;
+    column-gap: 0.5rem;
+    padding-top: 1rem;
+}
+
+.card {
+    display: flex;
+    text-decoration: none;
+    flex-direction: column;
+
+    &:hover {
+        text-decoration: none;
+    }
+}
+
+.cards-footer-button {
+    margin-left: auto;
+    margin-right: auto;
+    grid-column-start: 1;
+    grid-column-end: -1;
+    margin-top: 1rem;
+}

--- a/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-temlates/CodeInsightsTemplates.tsx
+++ b/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-temlates/CodeInsightsTemplates.tsx
@@ -1,0 +1,97 @@
+import React, { useState } from 'react'
+import { Link, LinkProps } from 'react-router-dom'
+
+import {
+    Button,
+    Card,
+    CardBody,
+    CardText,
+    CardTitle,
+    Tab,
+    TabList,
+    TabPanel,
+    TabPanels,
+    Tabs,
+} from '@sourcegraph/wildcard'
+
+import { InsightType } from '../../../../core/types'
+import { encodeCaptureInsightURL } from '../../../insights/creation/capture-group'
+import { encodeSearchInsightUrl } from '../../../insights/creation/search-insight'
+
+import styles from './CodeInsightsTemplates.module.scss'
+import { Template, TEMPLATE_SECTIONS } from './constants'
+
+function getTemplateURL(template: Template): string {
+    switch (template.type) {
+        case InsightType.CaptureGroup:
+            return `/insights/create/capture-group?${encodeCaptureInsightURL(template.templateValues)}`
+        case InsightType.SearchBased:
+            return `/insights/create/search?${encodeSearchInsightUrl(template.templateValues)}`
+    }
+}
+
+export const CodeInsightsTemplates: React.FunctionComponent<React.HTMLAttributes<HTMLElement>> = props => (
+    <section {...props}>
+        <h2>Templates</h2>
+        <p className="text-muted">
+            Some of the most popular <a href="/help/">use cases</a>, collected from our beta customers.
+        </p>
+
+        <Tabs size="medium" className="mt-3">
+            <TabList>
+                {TEMPLATE_SECTIONS.map(section => (
+                    <Tab key={section.title}>{section.title}</Tab>
+                ))}
+            </TabList>
+            <TabPanels>
+                {TEMPLATE_SECTIONS.map(section => (
+                    <TemplatesPanel key={section.title} templates={section.templates} />
+                ))}
+            </TabPanels>
+        </Tabs>
+    </section>
+)
+
+interface TemplatesPanelProps {
+    templates: Template[]
+}
+
+const TemplatesPanel: React.FunctionComponent<TemplatesPanelProps> = props => {
+    const { templates } = props
+    const [allVisible, setAllVisible] = useState(false)
+
+    const maxNumberOfCards = allVisible ? templates.length : 4
+
+    const hasMoreLessButton = templates.length > 4
+
+    return (
+        <TabPanel className={styles.cards}>
+            {templates.slice(0, maxNumberOfCards).map(template => (
+                <Card key={template.title} as={TemplateCardBody} to={getTemplateURL(template)} className={styles.card}>
+                    <CardTitle>{template.title}</CardTitle>
+                    <CardText className="flex-grow-1">{template.description}</CardText>
+                    <Button variant="secondary" outline={true} className="mr-auto">
+                        Use this template
+                    </Button>
+                </Card>
+            ))}
+
+            {hasMoreLessButton && (
+                <Button
+                    variant="secondary"
+                    outline={true}
+                    className={styles.cardsFooterButton}
+                    onClick={() => setAllVisible(!allVisible)}
+                >
+                    {allVisible ? 'Show less' : 'Show all'}
+                </Button>
+            )}
+        </TabPanel>
+    )
+}
+
+interface TemplateCardBodyProps extends LinkProps {}
+
+export const TemplateCardBody: React.FunctionComponent<TemplateCardBodyProps> = props => (
+    <CardBody as={Link} {...props} />
+)

--- a/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-temlates/CodeInsightsTemplates.tsx
+++ b/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-temlates/CodeInsightsTemplates.tsx
@@ -34,7 +34,11 @@ export const CodeInsightsTemplates: React.FunctionComponent<React.HTMLAttributes
     <section {...props}>
         <h2>Templates</h2>
         <p className="text-muted">
-            Some of the most popular <a href="/help/">use cases</a>, collected from our beta customers.
+            Some of the most popular{' '}
+            <a href="/help/code_insights/references/common_use_cases" rel="noopener noreferrer" target="_blank">
+                use cases
+            </a>
+            , collected from our beta customers.
         </p>
 
         <Tabs size="medium" className="mt-3">
@@ -61,7 +65,6 @@ const TemplatesPanel: React.FunctionComponent<TemplatesPanelProps> = props => {
     const [allVisible, setAllVisible] = useState(false)
 
     const maxNumberOfCards = allVisible ? templates.length : 4
-
     const hasMoreLessButton = templates.length > 4
 
     return (

--- a/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-temlates/constants.ts
+++ b/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-temlates/constants.ts
@@ -1,0 +1,149 @@
+import { InsightType } from '../../../../core/types'
+import { CaptureInsightUrlValues } from '../../../insights/creation/capture-group'
+import { DATA_SERIES_COLORS, SearchInsightURLValues } from '../../../insights/creation/search-insight'
+
+export interface TemplateSection {
+    title: string
+    templates: Template[]
+}
+
+export type Template = SearchTemplate | CaptureGroupTemplate
+
+interface SearchTemplate {
+    type: InsightType.SearchBased
+    title: string
+    description: string
+    templateValues: Partial<SearchInsightURLValues>
+}
+
+interface CaptureGroupTemplate {
+    type: InsightType.CaptureGroup
+    title: string
+    description: string
+    templateValues: Partial<CaptureInsightUrlValues>
+}
+
+export const TEMPLATE_SECTIONS: TemplateSection[] = [
+    {
+        title: 'Popular',
+        templates: [
+            {
+                type: InsightType.CaptureGroup,
+                title: 'Java versions',
+                description: 'Detect and track which Java versions are present or most popular in your code base.',
+                templateValues: {
+                    title: 'Java versions',
+                    groupSearchQuery: 'file:pom\\.xml$ <java\\.version>(.*)</java\\.version> archived:no fork:no',
+                },
+            },
+            {
+                type: InsightType.CaptureGroup,
+                title: 'Terraform versions',
+                description: 'Detect and track which Terraform versions are present or most popular in your code base.',
+                templateValues: {
+                    title: 'Terraform versions',
+                    groupSearchQuery:
+                        'repoapp.terraform.io/(.*)\\n version =(.*)([0-9].[0-9].[0-9]) lang:Terraform archived:no fork:no',
+                },
+            },
+            {
+                type: InsightType.SearchBased,
+                title: 'Yarn adoption',
+                description: 'Are more groups or teams using yarn? Track yarn adoption.',
+                templateValues: {
+                    title: 'Yarn adoption',
+                    allRepos: true,
+                    series: [
+                        {
+                            name: 'Yarn',
+                            query: 'select:repo file:yarn.lock archived:no fork:no',
+                            stroke: DATA_SERIES_COLORS.BLUE,
+                        },
+                    ],
+                },
+            },
+            {
+                type: InsightType.SearchBased,
+                title: 'Linter override rules',
+                description: 'Code hygiene and health: How many linter override rules exist',
+                templateValues: {
+                    title: 'Rule overrides',
+                    allRepos: true,
+                    series: [
+                        {
+                            name: 'Rule overrides',
+                            query: 'file:^\\.eslintignore .\\n patternType:regexp archived:no fork:no',
+                            stroke: DATA_SERIES_COLORS.ORANGE,
+                        },
+                    ],
+                },
+            },
+        ],
+    },
+    {
+        title: 'Migration',
+        templates: [
+            {
+                type: InsightType.SearchBased,
+                title: 'React function component migration',
+                description: 'Track your migration from class based component to function based',
+                templateValues: {
+                    title: 'React function component migration',
+                    series: [
+                        {
+                            name: 'Function components',
+                            query: 'patternType:regexp const\\s\\w+:\\s(React\\.)?FunctionComponent',
+                            stroke: DATA_SERIES_COLORS.ORANGE,
+                        },
+                        {
+                            name: 'Class components',
+                            query: 'patternType:regexp extends\\s(React\\.)?(Pure)?Component',
+                            stroke: DATA_SERIES_COLORS.BLUE,
+                        },
+                    ],
+                },
+            },
+            {
+                type: InsightType.SearchBased,
+                title: 'CSS module migration',
+                description: 'Track how many CSS modules files you have compared to global CSS files',
+                templateValues: {
+                    title: 'CSS module migration',
+                    series: [
+                        {
+                            name: 'Global CSS',
+                            query:
+                                'context:global type:file lang:scss -file:module.scss -file:global-styles patterntype:regexp',
+                            stroke: DATA_SERIES_COLORS.RED,
+                        },
+                        {
+                            name: 'CSS Modules',
+                            query: 'context:global type:file lang:scss file:module.scss patterntype:regexp',
+                            stroke: DATA_SERIES_COLORS.GREEN,
+                        },
+                    ],
+                },
+            },
+            {
+                type: InsightType.SearchBased,
+                title: 'Migration to new GraphQL TS types Diff Search',
+                description: 'Track migration from global gql types to GQL generated types',
+                templateValues: {
+                    title: 'Migration to new GraphQL TS types Diff Search',
+                    series: [
+                        {
+                            name: 'Imports of old GQL.* types',
+                            query: 'patternType:regex case:yes \\*\\sas\\sGQL type:diff',
+                            stroke: DATA_SERIES_COLORS.RED,
+                        },
+                        {
+                            name: 'Imports of new graphql-operations types',
+                            query: "patternType:regexp case:yes /graphql-operations' type:diff",
+                            stroke: DATA_SERIES_COLORS.GREEN,
+                        },
+                    ],
+                },
+            },
+        ],
+    },
+]

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/index.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/index.ts
@@ -1,3 +1,5 @@
 export { CaptureGroupCreationPage } from './CaptureGroupCreationPage'
 export { encodeCaptureInsightURL } from './utils/capture-insigh-url-parsers/capture-insight-url-parsers'
 export { CaptureGroupFormFields } from './types'
+
+export type { CaptureInsightUrlValues } from './utils/capture-insigh-url-parsers/capture-insight-url-parsers'

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/capture-insigh-url-parsers/capture-insight-url-parsers.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/capture-insigh-url-parsers/capture-insight-url-parsers.ts
@@ -1,6 +1,6 @@
 import { CaptureGroupFormFields } from '../../types'
 
-type CaptureInsightUrlValues = Omit<CaptureGroupFormFields, 'step' | 'stepValue'>
+export type CaptureInsightUrlValues = Omit<CaptureGroupFormFields, 'step' | 'stepValue'>
 
 export function encodeCaptureInsightURL(values: Partial<CaptureInsightUrlValues>): string {
     const parameters = new URLSearchParams()

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/index.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/index.ts
@@ -3,3 +3,5 @@ export { encodeSearchInsightUrl } from './utils/search-insight-url-parsers/searc
 export { CreateInsightFormFields, EditableDataSeries, InsightStep } from './types'
 
 export { DATA_SERIES_COLORS, DEFAULT_DATA_SERIES_COLOR } from './constants'
+
+export type { SearchInsightURLValues } from './utils/search-insight-url-parsers/search-insight-url-parsers'

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/utils/search-insight-url-parsers/search-insight-url-parsers.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/utils/search-insight-url-parsers/search-insight-url-parsers.ts
@@ -32,7 +32,7 @@ export function decodeSearchInsightUrl(queryParameters: string): CreateInsightFo
 
 type UnsupportedValues = 'series' | 'step' | 'visibility' | 'stepValue'
 
-interface SearchInsightURLValues extends Omit<CreateInsightFormFields, UnsupportedValues> {
+export interface SearchInsightURLValues extends Omit<CreateInsightFormFields, UnsupportedValues> {
     series: (Omit<SearchBasedInsightSeries, 'id'> & { id?: string })[]
 }
 

--- a/client/wildcard/src/components/Tabs/Tabs.tsx
+++ b/client/wildcard/src/components/Tabs/Tabs.tsx
@@ -51,7 +51,7 @@ export interface TabListProps extends ReachTabListProps {
 
 export interface TabProps extends ReachTabProps {}
 export interface TabPanelsProps extends ReachTabPanelsProps {}
-export interface TabPanelProps extends ReachTabPanelProps {}
+export interface TabPanelProps extends ReachTabPanelProps, React.HTMLAttributes<HTMLDivElement> {}
 
 /**
  *
@@ -102,7 +102,12 @@ export const TabPanels: React.FunctionComponent<TabPanelsProps> = ({ children })
     </ReachTabPanels>
 )
 
-export const TabPanel: React.FunctionComponent = ({ children }) => {
+export const TabPanel: React.FunctionComponent<TabPanelProps> = ({ children, ...otherProps }) => {
     const shouldRender = useShouldPanelRender(children)
-    return <ReachTabPanel data-testid="wildcard-tab-panel">{shouldRender ? children : null}</ReachTabPanel>
+
+    return shouldRender ? (
+        <ReachTabPanel data-testid="wildcard-tab-panel" {...otherProps}>
+            {children}
+        </ReachTabPanel>
+    ) : null
 }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/30158

## Context
[Designs](https://www.figma.com/file/EFgTP7gpdpQSEo1n4FUfsW/In-product-landing-page-WIP?node-id=1128%3A9814)

This PR just adds the template section component to the getting started page. Also in these PR changes, you can find a static non UI file where all templates for code insights and this section are stored. If you want to add/delete/edit a template for this section this is your file to edit. 

<img width="913" alt="Screenshot 2022-01-31 at 18 43 50" src="https://user-images.githubusercontent.com/18492575/151825234-34c2f296-96d3-443e-bf61-3c3c736bd397.png">

## For reviewers 

@oleggromov I had to slightly extend the `<Tab />` component in the wildcard in order to add custom styles. 