### PR TITLE
fix race from leaked goroutine

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -387,7 +387,7 @@ var (
 // function may only be called after a search result is performed, because it
 // relies on the invariant that query and pattern error checking has already
 // been performed.
-func LogSearchLatency(ctx context.Context, db database.DB, si *run.SearchInputs, durationMs int32) {
+func LogSearchLatency(ctx context.Context, db database.DB, wg *sync.WaitGroup, si *run.SearchInputs, durationMs int32) {
 	tr, ctx := trace.New(ctx, "LogSearchLatency", "")
 	defer tr.Finish()
 	var types []string
@@ -455,7 +455,9 @@ func LogSearchLatency(ctx context.Context, db database.DB, si *run.SearchInputs,
 			value := fmt.Sprintf(`{"durationMs": %d}`, durationMs)
 			eventName := fmt.Sprintf("search.latencies.%s", types[0])
 			featureFlags := featureflag.FromContext(ctx)
+			wg.Add(1)
 			go func() {
+				defer wg.Done()
 				err := usagestats.LogBackendEvent(db, a.UID, deviceid.FromContext(ctx), eventName, json.RawMessage(value), json.RawMessage(value), featureFlags, nil)
 				if err != nil {
 					log15.Warn("Could not log search latency", "err", err)
@@ -1220,7 +1222,9 @@ func (r *searchResolver) logBatch(ctx context.Context, srr *SearchResultsResolve
 	elapsed := time.Since(start)
 	if srr != nil {
 		srr.elapsed = elapsed
-		LogSearchLatency(ctx, r.db, r.SearchInputs, srr.ElapsedMilliseconds())
+		var wg sync.WaitGroup
+		LogSearchLatency(ctx, r.db, &wg, r.SearchInputs, srr.ElapsedMilliseconds())
+		defer wg.Wait()
 	}
 
 	var status, alertType string


### PR DESCRIPTION
We were leaking a goroutine in an optimization to move logging latency
out of the critical path of streaming search, so this collects that
goroutine while still allowing it to run concurrently. I added the
waitgroup as part of the function signature to make it harder to misuse
(as opposed to a return value that could be ignored).

Fixes https://github.com/sourcegraph/sourcegraph/issues/30426

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
