### PR TITLE
replace streaming.CollectStream with aggregatingStream

### DIFF
--- a/internal/search/unindexed/structural.go
+++ b/internal/search/unindexed/structural.go
@@ -111,28 +111,28 @@ func runStructuralSearch(ctx context.Context, args *search.SearcherParameters, r
 	}
 
 	// For structural search with default limits we retry if we get no results.
-	fileMatches, stats, err := streaming.CollectStream(func(stream streaming.Sender) error {
-		return streamStructuralSearch(ctx, args, repos, stream)
-	})
+	agg := streaming.NewAggregatingStream()
+	err := streamStructuralSearch(ctx, args, repos, stream)
 
-	if len(fileMatches) == 0 && err == nil {
+	event := agg.Get()
+	if len(event.Results) == 0 && err == nil {
 		// retry structural search with a higher limit.
-		fileMatches, stats, err = streaming.CollectStream(func(stream streaming.Sender) error {
-			return retryStructuralSearch(ctx, args, repos, stream)
-		})
+		agg := streaming.NewAggregatingStream()
+		err := retryStructuralSearch(ctx, args, repos, agg)
 		if err != nil {
 			return err
 		}
 
-		if len(fileMatches) == 0 {
+		event = agg.Get()
+		if len(event.Results) == 0 {
 			// Still no results? Give up.
 			log15.Warn("Structural search gives up after more exhaustive attempt. Results may have been missed.")
-			stats.IsLimitHit = false // Ensure we don't display "Show more".
+			event.Stats.IsLimitHit = false // Ensure we don't display "Show more".
 		}
 	}
 
-	matches := make([]result.Match, 0, len(fileMatches))
-	for _, fm := range fileMatches {
+	matches := make([]result.Match, 0, len(event.Results))
+	for _, fm := range event.Results {
 		if _, ok := fm.(*result.FileMatch); !ok {
 			return errors.Errorf("StructuralSearch failed to convert results")
 		}
@@ -141,7 +141,7 @@ func runStructuralSearch(ctx context.Context, args *search.SearcherParameters, r
 
 	stream.Send(streaming.SearchEvent{
 		Results: matches,
-		Stats:   stats,
+		Stats:   event.Stats,
 	})
 	return err
 }

--- a/internal/search/unindexed/structural.go
+++ b/internal/search/unindexed/structural.go
@@ -112,7 +112,7 @@ func runStructuralSearch(ctx context.Context, args *search.SearcherParameters, r
 
 	// For structural search with default limits we retry if we get no results.
 	agg := streaming.NewAggregatingStream()
-	err := streamStructuralSearch(ctx, args, repos, stream)
+	err := streamStructuralSearch(ctx, args, repos, agg)
 
 	event := agg.Get()
 	if len(event.Results) == 0 && err == nil {

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -69,15 +69,15 @@ func SearchFilesInRepos(ctx context.Context, zoektArgs zoektutil.IndexedSearchRe
 // SearchFilesInRepoBatch is a convenience function around searchFilesInRepos
 // which collects the results from the stream.
 func SearchFilesInReposBatch(ctx context.Context, zoektArgs zoektutil.IndexedSearchRequest, searcherArgs *search.SearcherParameters, searcherOnly bool) ([]*result.FileMatch, streaming.Stats, error) {
-	matches, stats, err := streaming.CollectStream(func(stream streaming.Sender) error {
-		return SearchFilesInRepos(ctx, zoektArgs, searcherArgs, searcherOnly, stream)
-	})
+	agg := streaming.NewAggregatingStream()
+	err := SearchFilesInRepos(ctx, zoektArgs, searcherArgs, searcherOnly, agg)
+	event := agg.Get()
 
-	fms, fmErr := matchesToFileMatches(matches)
+	fms, fmErr := matchesToFileMatches(event.Results)
 	if fmErr != nil && err == nil {
 		err = errors.Wrap(fmErr, "searchFilesInReposBatch failed to convert results")
 	}
-	return fms, stats, err
+	return fms, event.Stats, err
 }
 
 var mockSearchFilesInRepo func(ctx context.Context, repo types.MinimalRepo, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration, stream streaming.Sender) (limitHit bool, err error)

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -319,20 +319,20 @@ func TestIndexedSearch(t *testing.T) {
 			// This is a quick fix which will break once we enable the zoekt client for true streaming.
 			// Once we return more than one event we have to account for the proper order of results
 			// in the tests.
-			gotMatches, gotCommon, err := streaming.CollectStream(func(stream streaming.Sender) error {
-				return indexed.Search(tt.args.ctx, stream)
-			})
+			agg := streaming.NewAggregatingStream()
+			err = indexed.Search(tt.args.ctx, agg)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("zoektSearchHEAD() error = %v, wantErr = %v", err, tt.wantErr)
 				return
 			}
+			got := agg.Get()
 
-			gotFm, err := matchesToFileMatches(gotMatches)
+			gotFm, err := matchesToFileMatches(got.Results)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if diff := cmp.Diff(&tt.wantCommon, &gotCommon, cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(&tt.wantCommon, &got.Stats, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("common mismatch (-want +got):\n%s", diff)
 			}
 


### PR DESCRIPTION
This replaces the weird callback method I made to collect a stream with
a more idiomatic stream type that collects events as they come through.
I find this easier to understand than the callback method, and it better
matches what we do elsewhere with custom stream types.

I've wanted this type elsewhere to clean up some things, so I figured I'd
convert the places we were using `CollectStream` first. 



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
