### PR TITLE
ci: Disable go-backcompat tests

### DIFF
--- a/dev/ci/go-backcompat/test.sh
+++ b/dev/ci/go-backcompat/test.sh
@@ -69,6 +69,10 @@ if git diff --quiet "${latest_minor_release_tag}".."${current_head}" migrations;
   exit 0
 fi
 
+# TODO(efritz) - re-enable
+echo "SKIPPING BACKCOMPAT TEST"
+exit 0
+
 echo "--- Running backwards compatibility tests"
 echo "current_head                = ${current_head}"
 echo "latest_minor_release_tag    = ${latest_minor_release_tag}"


### PR DESCRIPTION
This unblocks main while I fix the test scripts.