### PR TITLE
logging: Print iTerm link to the log's source file:line in VS Code

### DIFF
--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -30,6 +30,7 @@ var (
 	MyName, envVarName = findName()
 	LogLevel           = Get("SRC_LOG_LEVEL", "warn", "upper log level to restrict log output to (dbug, info, warn, error, crit)")
 	LogFormat          = Get("SRC_LOG_FORMAT", "logfmt", "log format (logfmt, condensed, json)")
+	LogSourceLink, _   = strconv.ParseBool(Get("SRC_LOG_SOURCE_LINK", "false", "Print an iTerm link to the file:line in VS Code"))
 	InsecureDev, _     = strconv.ParseBool(Get("INSECURE_DEV", "false", "Running in insecure dev (local laptop) mode"))
 )
 

--- a/internal/logging/main.go
+++ b/internal/logging/main.go
@@ -33,11 +33,20 @@ func condensedFormat(r *log15.Record) []byte {
 	colorAttr := logColors[r.Lvl]
 	text := logLabels[r.Lvl]
 	var msg bytes.Buffer
-	if colorAttr != 0 {
-		fmt.Fprint(&msg, color.New(colorAttr).Sprint(text)+" "+r.Msg)
-	} else {
-		fmt.Fprint(&msg, r.Msg)
+	if env.LogSourceLink {
+		// Link to open the file:line in VS Code.
+		url := "vscode://file/" + fmt.Sprintf("%#v", r.Call)
+
+		// Constructs an escape sequence that iTerm recognizes as a link.
+		// See https://iterm2.com/documentation-escape-codes.html
+		link := fmt.Sprintf("\x1B]8;;%s\x07%s\x1B]8;;\x07", url, "src")
+
+		fmt.Fprint(&msg, color.New(color.Faint).Sprint(link)+" ")
 	}
+	if colorAttr != 0 {
+		fmt.Fprint(&msg, color.New(colorAttr).Sprint(text)+" ")
+	}
+	fmt.Fprint(&msg, r.Msg)
 	if len(r.Ctx) > 0 {
 		for i := 0; i < len(r.Ctx); i += 2 {
 			// not as smart about printing things as log15's internal magic

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -10,6 +10,8 @@ env:
   SRC_REPOS_DIR: $HOME/.sourcegraph/repos
   SRC_LOG_LEVEL: info
   SRC_LOG_FORMAT: condensed
+  # Set this to true to show an iTerm link to the file:line where the log message came from
+  SRC_LOG_SOURCE_LINK: false
   SRC_GIT_SERVER_1: 127.0.0.1:3178
   SRC_GIT_SERVERS: 127.0.0.1:3178
 


### PR DESCRIPTION
This prints a little iTerm link to the log statement's source file:line in VS Code.

Enable it by setting `SRC_LOG_SOURCE_LINK=true`.

More terminal+editor combinations could be supported in the future.

https://user-images.githubusercontent.com/1387653/151882112-7e3b06e7-d0ba-42a8-9cd1-960f8640be82.mp4