### PR TITLE
insights: fix FirstEverCommit returning wrong commit

### DIFF
--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -417,14 +417,20 @@ func FirstEverCommit(ctx context.Context, repo api.RepoName, checker authz.SubRe
 	span, ctx := ot.StartSpanFromContext(ctx, "Git: FirstEverCommit")
 	defer span.Finish()
 
-	args := []string{"rev-list", "--max-count=1", "--max-parents=0", "HEAD"}
+	args := []string{"rev-list", "--reverse", "--date-order", "--max-parents=0", "HEAD"}
 	cmd := gitserver.DefaultClient.Command("git", args...)
 	cmd.Repo = repo
 	out, err := cmd.Output(ctx)
 	if err != nil {
 		return nil, errors.WithMessage(err, fmt.Sprintf("git command %v failed (output: %q)", args, out))
 	}
-	id := api.CommitID(bytes.TrimSpace(out))
+	lines := string(bytes.TrimSpace(out))
+	tokens := strings.Split(lines, "\n")
+	if len(tokens) == 0 {
+		return nil, errors.New("FirstEverCommit returned no revisions")
+	}
+	first := tokens[0]
+	id := api.CommitID(bytes.TrimSpace([]byte(first)))
 	return GetCommit(ctx, repo, id, ResolveRevisionOptions{NoEnsureRevision: true}, checker)
 }
 

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -424,13 +424,13 @@ func FirstEverCommit(ctx context.Context, repo api.RepoName, checker authz.SubRe
 	if err != nil {
 		return nil, errors.WithMessage(err, fmt.Sprintf("git command %v failed (output: %q)", args, out))
 	}
-	lines := string(bytes.TrimSpace(out))
-	tokens := strings.Split(lines, "\n")
+	lines := bytes.TrimSpace(out)
+	tokens := bytes.Split(lines, []byte("\n"))
 	if len(tokens) == 0 {
 		return nil, errors.New("FirstEverCommit returned no revisions")
 	}
 	first := tokens[0]
-	id := api.CommitID(bytes.TrimSpace([]byte(first)))
+	id := api.CommitID(bytes.TrimSpace(first))
 	return GetCommit(ctx, repo, id, ResolveRevisionOptions{NoEnsureRevision: true}, checker)
 }
 


### PR DESCRIPTION
Fixes #30433

The behavior of `FirstEverCommit` would return the wrong commit if there were multiple parent-less commits. This modifies the behavior to always return the `oldest` commit. Note: we can't use `--max-count=1` in combination with `--reverse`, since git performs the reverse after the count filter.

To test this I created a fake repository locally, served it with `src-cli`, and did the following:
1. Created an initial commit
2. Created an orphan branch, and committed a different file (to simulate divergent histories)
3. Merged the branches together

The result in logs (over a backfill) is:
```
[enterprise-worker] INFO FirstEverCommit, lines: 521a8294b0f1ec5ebd8ba9b5922d83a556ac4a09
[enterprise-worker] 40c237ff816691e28a26202854c99bd0e023c14b, first: 521a8294b0f1ec5ebd8ba9b5922d83a556ac4a09

```
And you can see from the history page that this is indeed the oldest commit.

<img width="1158" alt="CleanShot 2022-01-31 at 15 46 46@2x" src="https://user-images.githubusercontent.com/5090588/151886080-2b8cb152-00cb-4e31-a84f-b2bcd28f3802.png">