### PR TITLE
Add missing required field `descending` for `ListSearchContexts` API

### DIFF
--- a/doc/api/graphql/managing-search-contexts-with-api.md
+++ b/doc/api/graphql/managing-search-contexts-with-api.md
@@ -129,6 +129,7 @@ global contexts (`null`), `organization1` contexts (`organization1-id`), and `us
   "first": 50,
   "namespaces": [null, "organization1-id", "user1-id"],
   "orderBy": "SEARCH_CONTEXT_UPDATED_AT",
+  "descending": false
 }
 ```
 


### PR DESCRIPTION
without the default value there, we see this error:
`graphql: got null for non-null`



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
