### PR TITLE
batches: add upsert mutation for SSBC

### DIFF
--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -95,6 +95,8 @@ type ReplaceBatchSpecInputArgs struct {
 	NoCache          bool
 }
 
+type UpsertBatchSpecInputArgs = CreateBatchSpecFromRawArgs
+
 type DeleteBatchSpecArgs struct {
 	BatchSpec graphql.ID
 }
@@ -244,6 +246,7 @@ type BatchChangesResolver interface {
 	CreateEmptyBatchChange(ctx context.Context, args *CreateEmptyBatchChangeArgs) (BatchChangeResolver, error)
 	CreateBatchSpecFromRaw(ctx context.Context, args *CreateBatchSpecFromRawArgs) (BatchSpecResolver, error)
 	ReplaceBatchSpecInput(ctx context.Context, args *ReplaceBatchSpecInputArgs) (BatchSpecResolver, error)
+	UpsertBatchSpecInput(ctx context.Context, args *UpsertBatchSpecInputArgs) (BatchSpecResolver, error)
 	DeleteBatchSpec(ctx context.Context, args *DeleteBatchSpecArgs) (*EmptyResponse, error)
 	ExecuteBatchSpec(ctx context.Context, args *ExecuteBatchSpecArgs) (BatchSpecResolver, error)
 	CancelBatchSpecExecution(ctx context.Context, args *CancelBatchSpecExecutionArgs) (BatchSpecResolver, error)

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -1471,6 +1471,54 @@ extend type Mutation {
     ): BatchSpec!
 
     """
+    Creates or updates a batch spec based on the given namespace and name, then
+    triggers a job to evaluate the workspaces.
+
+    This is essentially a wrapper for `createBatchSpecFromRaw` and
+    `replaceBatchSpecInput` to facilitate src-cli, and should not be used
+    otherwise.
+    """
+    upsertBatchSpecInput(
+        """
+        The raw batch spec as YAML (or the equivalent JSON). See
+        https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/schema/batch_spec.schema.json
+        for the JSON Schema that describes the structure of this input.
+        """
+        batchSpec: String!
+
+        """
+        If true, repos with a .batchignore file will still be included.
+        """
+        allowIgnored: Boolean = false
+
+        """
+        If true, repos on unsupported codehosts will be included. Resulting changesets in these repos cannot
+        be published.
+        """
+        allowUnsupported: Boolean = false
+
+        """
+        Right away set the execute flag.
+
+        TODO: Not implemented yet.
+        """
+        execute: Boolean = false
+
+        """
+        Don't use cache entries.
+
+        TODO: Not implemented yet.
+        """
+        noCache: Boolean = false
+
+        """
+        The namespace (either a user or organization). A batch spec can only be applied to (or
+        used to create) batch changes in this namespace.
+        """
+        namespace: ID!
+    ): BatchSpec!
+
+    """
     Deletes the batch spec. All associated jobs will be canceled, if still running.
     This is called by the client, whenever a new run is triggered, to support
     faster cleanups. We will also purge these in the background, but this'll be

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -1689,6 +1689,45 @@ func (r *Resolver) ReplaceBatchSpecInput(ctx context.Context, args *graphqlbacke
 	return &batchSpecResolver{store: r.store, batchSpec: batchSpec}, nil
 }
 
+func (r *Resolver) UpsertBatchSpecInput(ctx context.Context, args *graphqlbackend.UpsertBatchSpecInputArgs) (_ graphqlbackend.BatchSpecResolver, err error) {
+	tr, ctx := trace.New(ctx, "Resolver.UpsertBatchSpecInput", fmt.Sprintf("BatchSpec: %+v", args.BatchSpec))
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
+
+	if err := batchChangesCreateAccess(ctx, r.store.DatabaseDB()); err != nil {
+		return nil, err
+	}
+
+	svc := service.New(r.store)
+
+	var uid, oid int32
+	if err := graphqlbackend.UnmarshalNamespaceID(args.Namespace, &uid, &oid); err != nil {
+		return nil, err
+	}
+
+	// 🚨 SECURITY: UpsertBatchSpecInput checks whether current user is
+	// authorised and has access to the namespace.
+	//
+	// Right now we also only allow creating batch specs in a user namespace, so
+	// the check makes sure the current user is the creator of the batch spec or
+	// an admin.
+	batchSpec, err := svc.UpsertBatchSpecInput(ctx, service.UpsertBatchSpecInputOpts{
+		NamespaceUserID:  uid,
+		NamespaceOrgID:   oid,
+		RawSpec:          args.BatchSpec,
+		AllowIgnored:     args.AllowIgnored,
+		AllowUnsupported: args.AllowUnsupported,
+		NoCache:          args.NoCache,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &batchSpecResolver{store: r.store, batchSpec: batchSpec}, nil
+}
+
 func (r *Resolver) CancelBatchSpecWorkspaceExecution(ctx context.Context, args *graphqlbackend.CancelBatchSpecWorkspaceExecutionArgs) (*graphqlbackend.EmptyResponse, error) {
 	// TODO(ssbc): currently admin only.
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.store.DatabaseDB()); err != nil {

--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
@@ -159,6 +160,14 @@ func TestServicePermissionLevels(t *testing.T) {
 				_, err := svc.ReplaceBatchSpecInput(currentUserCtx, ReplaceBatchSpecInputOpts{
 					BatchSpecRandID: batchSpec.RandID,
 					RawSpec:         ct.TestRawBatchSpecYAML,
+				})
+				tc.assertFunc(t, err)
+			})
+
+			t.Run("UpsertBatchSpecInput", func(t *testing.T) {
+				_, err := svc.UpsertBatchSpecInput(currentUserCtx, UpsertBatchSpecInputOpts{
+					RawSpec:         ct.TestRawBatchSpecYAML,
+					NamespaceUserID: tc.batchChangeAuthor,
 				})
 				tc.assertFunc(t, err)
 			})
@@ -1539,6 +1548,48 @@ func TestService(t *testing.T) {
 			if !strings.Contains(err.Error(), "Invalid type. Expected: string, given: boolean") {
 				t.Fatalf("wrong error message: %s", err)
 			}
+		})
+	})
+
+	t.Run("UpsertBatchSpecInput", func(t *testing.T) {
+		t.Run("new spec", func(t *testing.T) {
+			newSpec, err := svc.UpsertBatchSpecInput(ctx, UpsertBatchSpecInputOpts{
+				RawSpec:         ct.TestRawBatchSpecYAML,
+				NamespaceUserID: admin.ID,
+			})
+			assert.Nil(t, err)
+			assert.True(t, newSpec.CreatedFromRaw)
+
+			resolutionJob, err := s.GetBatchSpecResolutionJob(ctx, store.GetBatchSpecResolutionJobOpts{
+				BatchSpecID: newSpec.ID,
+			})
+			assert.Nil(t, err)
+			assert.Equal(t, btypes.BatchSpecResolutionJobStateQueued, resolutionJob.State)
+		})
+
+		t.Run("replaced spec", func(t *testing.T) {
+			oldSpec, err := svc.UpsertBatchSpecInput(adminCtx, UpsertBatchSpecInputOpts{
+				RawSpec:         ct.TestRawBatchSpecYAML,
+				NamespaceUserID: admin.ID,
+			})
+			assert.Nil(t, err)
+			assert.True(t, oldSpec.CreatedFromRaw)
+
+			newSpec, err := svc.UpsertBatchSpecInput(adminCtx, UpsertBatchSpecInputOpts{
+				RawSpec:         ct.TestRawBatchSpecYAML,
+				NamespaceUserID: admin.ID,
+			})
+			assert.Nil(t, err)
+			assert.True(t, newSpec.CreatedFromRaw)
+			assert.Equal(t, oldSpec.RandID, newSpec.RandID)
+			assert.Equal(t, oldSpec.NamespaceUserID, newSpec.NamespaceUserID)
+			assert.Equal(t, oldSpec.NamespaceOrgID, newSpec.NamespaceOrgID)
+
+			// Check that the replaced batch spec was really deleted.
+			_, err = s.GetBatchSpec(ctx, store.GetBatchSpecOpts{
+				ID: oldSpec.ID,
+			})
+			assert.Equal(t, store.ErrNoResults, err)
 		})
 	})
 


### PR DESCRIPTION
This PR adds an upsert batch spec from raw mutation, which both speeds up and simplifies the logic in https://github.com/sourcegraph/src-cli/pull/671.

Logic is basically pulled from the existing create and replace mutations: the checks and behaviour should be identical to doing:

```python
spec = getBatchSpecFor(namespace, raw.name)
if spec:
    replaceBatchSpecInput(spec, raw)
else:
    createBatchSpecFromRaw(raw)
```

Related to #26503.