### PR TITLE
dev: improve patch release instruction

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -352,16 +352,6 @@ These steps must be completed before this PR can be merged, unless otherwise sta
 
 ${actionItems.map(item => `- [ ] ${item}`).join('\n')}
 
-${
-    notPatchRelease
-        ? ''
-        : `### :information_source: How to update CHANGELOG
-- [ ] I understood the convention of our changelog format. Learn more from our [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md).
-- [ ] Create a new H2 title named \`${release.version}\` after the \`Unreleased\` section if it doesn't already exist
-- [ ] Copy all changelog entries of the commits belong to this patch release into the new H2 title \`## ${release.version}\`, grouped into the types they were originally in (e.g. \`### Added\`, \`### Changed\`).
-`
-}
-
 cc @${config.captainGitHubUsername}
 `,
                 }
@@ -430,7 +420,7 @@ cc @${config.captainGitHubUsername}
                                     items.push('Update the upgrade guides in `doc/admin/updates`')
                                 } else {
                                     items.push(
-                                        'Update the [CHANGELOG](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) to include all the changes included in this patch',
+                                        'Update the [CHANGELOG](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) to include all the changes included in this patch. Learn more about [how to update CHANGELOG.md](departments/product-engineering/engineering/process/releases#changelogmd).',
                                         'If any specific upgrade steps are required, update the upgrade guides in `doc/admin/updates`'
                                     )
                                 }

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -437,7 +437,7 @@ cc @${config.captainGitHubUsername}
                                 items.push(
                                     'Ensure all other pull requests in the batch change have been merged',
                                     'Run `yarn run release release:finalize` to generate the tags required. **Note** CI will not pass until this command is run.',
-                                    'Re-run Buildkite on this branch, and ensure the build passes before merging this pull request'
+                                    'Re-run the build on this branch (using either `sg ci build --wait` or the Buildkite UI) and merge when the build passes.'
                                 )
                                 return items
                             })()

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -436,7 +436,7 @@ cc @${config.captainGitHubUsername}
                                 }
                                 items.push(
                                     'Ensure all other pull requests in the batch change have been merged',
-                                    'Run `yarn run release release:finalize` to generate the tags required. **Note** CI will not pass until this command is run.',
+                                    'Run `yarn run release release:finalize` to generate the tags required. CI will not pass until this command is run.',
                                     'Re-run the build on this branch (using either `sg ci build --wait` or the Buildkite UI) and merge when the build passes.'
                                 )
                                 return items

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -356,7 +356,7 @@ ${
     notPatchRelease
         ? ''
         : `### :information_source: How to update CHANGELOG
-- [ ] I understood the convention of our changelog format. [learn more](https://keepachangelog.com/en/1.0.0/)
+- [ ] I understood the convention of our changelog format. Learn more from our [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md).
 - [ ] Create a new H2 title named \`${release.version}\` after the \`Unreleased\` section if it doesn't already exist
 - [ ] Copy all changelog entries of the commits belong to this patch release into the new H2 title \`## ${release.version}\`, grouped into the types they were originally in (e.g. \`### Added\`, \`### Changed\`).
 `

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -352,6 +352,16 @@ These steps must be completed before this PR can be merged, unless otherwise sta
 
 ${actionItems.map(item => `- [ ] ${item}`).join('\n')}
 
+${
+    notPatchRelease
+        ? ''
+        : `### :information_source: How to update CHANGELOG
+- [ ] I understood the convention of our changelog format. [learn more](https://keepachangelog.com/en/1.0.0/)
+- [ ] I created a new H2 title named \`${release.version}\` after the \`Unreleases\` section if it doesn't already exist
+- [ ] I copied all changelogs of the commits belong to this patch release into the new H2 title \`## ${release.version}\` and they are grouped by type (e.g. \`### Added\`, \`### Changed\`).
+`
+}
+
 cc @${config.captainGitHubUsername}
 `,
                 }
@@ -425,7 +435,9 @@ cc @${config.captainGitHubUsername}
                                     )
                                 }
                                 items.push(
-                                    'Ensure all other pull requests in the batch change have been merged - then run `yarn run release release:finalize` to generate the tags required, re-run Buildkite on this branch, and ensure the build passes before merging this pull request'
+                                    'Ensure all other pull requests in the batch change have been merged',
+                                    'Run `yarn run release release:finalize` to generate the tags required. **Note** CI will not pass until this command is run.',
+                                    'Re-run Buildkite on this branch, and ensure the build passes before merging this pull request'
                                 )
                                 return items
                             })()

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -357,8 +357,8 @@ ${
         ? ''
         : `### :information_source: How to update CHANGELOG
 - [ ] I understood the convention of our changelog format. [learn more](https://keepachangelog.com/en/1.0.0/)
-- [ ] I created a new H2 title named \`${release.version}\` after the \`Unreleases\` section if it doesn't already exist
-- [ ] I copied all changelogs of the commits belong to this patch release into the new H2 title \`## ${release.version}\` and they are grouped by type (e.g. \`### Added\`, \`### Changed\`).
+- [ ] Create a new H2 title named \`${release.version}\` after the \`Unreleased\` section if it doesn't already exist
+- [ ] Copy all changelog entries of the commits belong to this patch release into the new H2 title \`## ${release.version}\`, grouped into the types they were originally in (e.g. \`### Added\`, \`### Changed\`).
 `
 }
 


### PR DESCRIPTION
We caught a few problems when @caugustus-sourcegraph walked me through the release process.

In the changeset against the main sourcegraph repo, e.g., #30206, it says update changelog without explicitly explaining how to update it.

Breakdown the manual steps even further to make sure the Release Captain knows they should merge the changeset against the sourcegraph at last. Also, Crystal mentions CI pipeline will always fail before the `yarn release:finalize` command is run is confusing people as well.

Fix https://github.com/sourcegraph/sourcegraph/issues/30420
Related https://github.com/sourcegraph/handbook/pull/2114