### PR TITLE
Search backend: chop out `doResults`

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1704,9 +1704,10 @@ type searchResultsStats struct {
 
 	sr *searchResolver
 
-	once              sync.Once
-	getResultsMatches result.Matches
-	getResultsErr     error
+	// These items are lazily populated by getResults
+	once    sync.Once
+	results result.Matches
+	err     error
 }
 
 func (srs *searchResultsStats) ApproximateResultCount() string { return srs.JApproximateResultCount }

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1735,11 +1735,15 @@ func (r *searchResolver) Stats(ctx context.Context) (stats *searchResultsStats, 
 		if err != nil {
 			return nil, err
 		}
-		results, err := doResults(ctx, r.SearchInputs, r.db, r.stream, job)
+		agg := streaming.NewAggregatingStream()
+		_, err = doResults(ctx, r.SearchInputs, r.db, agg, job)
 		if err != nil {
 			return nil, err // do not cache errors.
 		}
-		v = r.resultsToResolver(results)
+		v = r.resultsToResolver(&SearchResults{
+			Matches: agg.Get().Results,
+			Stats:   agg.Get().Stats,
+		})
 		if v.MatchCount() > 0 {
 			break
 		}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1736,7 +1736,7 @@ func (r *searchResolver) Stats(ctx context.Context) (stats *searchResultsStats, 
 			return nil, err
 		}
 		agg := streaming.NewAggregatingStream()
-		_, err = doResults(ctx, r.SearchInputs, r.db, agg, job)
+		err = job.Run(ctx, r.db, agg)
 		if err != nil {
 			return nil, err // do not cache errors.
 		}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1684,9 +1684,9 @@ type searchResultsStats struct {
 
 	sr *searchResolver
 
-	once   sync.Once
-	srs    *SearchResultsResolver
-	srsErr error
+	once              sync.Once
+	getResultsMatches result.Matches
+	getResultsErr     error
 }
 
 func (srs *searchResultsStats) ApproximateResultCount() string { return srs.JApproximateResultCount }

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1844,7 +1844,7 @@ func doResults(ctx context.Context, searchInputs *run.SearchInputs, db database.
 	if err != nil {
 		ao.Error(ctx, err)
 	}
-	alert, err := ao.Done(&common)
+	alert, err := ao.Done()
 
 	sort.Sort(matches)
 

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -41,18 +41,18 @@ func (srs *searchResultsStats) getResults(ctx context.Context) (result.Matches, 
 	srs.once.Do(func() {
 		job, err := srs.sr.toSearchJob(srs.sr.Query)
 		if err != nil {
-			srs.getResultsErr = err
+			srs.err = err
 			return
 		}
 		agg := streaming.NewAggregatingStream()
 		err = job.Run(ctx, srs.sr.db, agg)
 		if err != nil {
-			srs.getResultsErr = err
+			srs.err = err
 			return
 		}
-		srs.getResultsMatches = agg.Get().Results
+		srs.results = agg.Get().Results
 	})
-	return srs.getResultsMatches, srs.getResultsErr
+	return srs.results, srs.err
 }
 
 func searchResultsStatsLanguages(ctx context.Context, db database.DB, matches []result.Match) ([]inventory.Lang, error) {

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -14,17 +14,18 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/inventory"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
 func (srs *searchResultsStats) Languages(ctx context.Context) ([]*languageStatisticsResolver, error) {
-	srr, err := srs.getResults(ctx)
+	matches, err := srs.getResults(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	langs, err := searchResultsStatsLanguages(ctx, srs.sr.db, srr.Matches)
+	langs, err := searchResultsStatsLanguages(ctx, srs.sr.db, matches)
 	if err != nil {
 		return nil, err
 	}
@@ -36,21 +37,22 @@ func (srs *searchResultsStats) Languages(ctx context.Context) ([]*languageStatis
 	return wrapped, nil
 }
 
-func (srs *searchResultsStats) getResults(ctx context.Context) (*SearchResultsResolver, error) {
+func (srs *searchResultsStats) getResults(ctx context.Context) (result.Matches, error) {
 	srs.once.Do(func() {
 		job, err := srs.sr.toSearchJob(srs.sr.Query)
 		if err != nil {
-			srs.srsErr = err
+			srs.getResultsErr = err
 			return
 		}
-		results, err := doResults(ctx, srs.sr.SearchInputs, srs.sr.db, srs.sr.stream, job)
+		agg := streaming.NewAggregatingStream()
+		_, err = doResults(ctx, srs.sr.SearchInputs, srs.sr.db, agg, job)
 		if err != nil {
-			srs.srsErr = err
+			srs.getResultsErr = err
 			return
 		}
-		srs.srs = srs.sr.resultsToResolver(results)
+		srs.getResultsMatches = agg.Get().Results
 	})
-	return srs.srs, srs.srsErr
+	return srs.getResultsMatches, srs.getResultsErr
 }
 
 func searchResultsStatsLanguages(ctx context.Context, db database.DB, matches []result.Match) ([]inventory.Lang, error) {

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -45,7 +45,7 @@ func (srs *searchResultsStats) getResults(ctx context.Context) (result.Matches, 
 			return
 		}
 		agg := streaming.NewAggregatingStream()
-		_, err = doResults(ctx, srs.sr.SearchInputs, srs.sr.db, agg, job)
+		err = job.Run(ctx, srs.sr.db, agg)
 		if err != nil {
 			srs.getResultsErr = err
 			return

--- a/internal/search/alert/observer.go
+++ b/internal/search/alert/observer.go
@@ -22,7 +22,6 @@ import (
 	searchrepos "github.com/sourcegraph/sourcegraph/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/search/run"
 	"github.com/sourcegraph/sourcegraph/internal/search/searchcontexts"
-	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 )
 
 type Observer struct {
@@ -202,7 +201,7 @@ func (o *Observer) update(alert *search.Alert) {
 
 // Done returns the highest priority alert and a multierror.Error containing
 // all errors that could not be converted to alerts.
-func (o *Observer) Done(stats *streaming.Stats) (*search.Alert, error) {
+func (o *Observer) Done() (*search.Alert, error) {
 	if !o.HasResults && o.PatternType != query.SearchTypeStructural && comby.MatchHoleRegexp.MatchString(o.OriginalQuery) {
 		o.update(search.AlertForStructuralSearchNotSet(o.OriginalQuery))
 	}


### PR DESCRIPTION
This removes all but the single dependency on `doResults` then inlines it.

Please review commit-by-commit since each commit has a message describing how I convinced myself that the change is behavior-preserving. 

~Stacked on #30451~