### PR TITLE
migrations: Remove `Definitions.First` in favor of `Root`

### DIFF
--- a/internal/database/connections/live/migration_test.go
+++ b/internal/database/connections/live/migration_test.go
@@ -62,7 +62,7 @@ func testMigrations(t *testing.T, name string, schema *schemas.Schema) {
 				// Run down to the root "squashed commits" migration. We don't go
 				// any farther than that because it would require a fresh database,
 				// and that doesn't adequately test upgrade idempotency.
-				TargetVersion: schema.Definitions.First(),
+				TargetVersion: schema.Definitions.Root().ID,
 			},
 		},
 	}

--- a/internal/database/migration/definition/definition.go
+++ b/internal/database/migration/definition/definition.go
@@ -52,10 +52,6 @@ func (ds *Definitions) Count() int {
 	return len(ds.definitions)
 }
 
-func (ds *Definitions) First() int {
-	return ds.definitions[0].ID
-}
-
 func (ds *Definitions) GetByID(id int) (Definition, bool) {
 	definition, ok := ds.definitionsMap[id]
 	return definition, ok


### PR DESCRIPTION
Pulled from #29831. 