### PR TITLE
migrations: Keep user-facing naming consistent

### DIFF
--- a/dev/sg/sg_migration.go
+++ b/dev/sg/sg_migration.go
@@ -104,9 +104,9 @@ func migrationAddExec(ctx context.Context, args []string) error {
 	}
 
 	block := stdout.Out.Block(output.Linef("", output.StyleBold, "Migration files created"))
-	block.Writef("Up migration: %s", upFile)
-	block.Writef("Down migration: %s", downFile)
-	block.Writef("Metadata: %s", metadataFile)
+	block.Writef("Up query file: %s", upFile)
+	block.Writef("Down query file: %s", downFile)
+	block.Writef("Metadata file: %s", metadataFile)
 	block.Close()
 
 	return nil

--- a/internal/database/migration/cliutil/downto.go
+++ b/internal/database/migration/cliutil/downto.go
@@ -54,7 +54,7 @@ func DownTo(commandName string, run RunFunc, out *output.Output) *ffcli.Command 
 	return &ffcli.Command{
 		Name:       "downto",
 		ShortUsage: fmt.Sprintf("%s downto -db=<schema> -target=<target>,<target>,...", commandName),
-		ShortHelp:  `Revert any applied migrations that are children of the given targets - this effectively "resets" the database to the target migration`,
+		ShortHelp:  `Revert any applied migrations that are children of the given targets - this effectively "resets" the schmea to the target version`,
 		FlagSet:    flagSet,
 		Exec:       exec,
 		LongHelp:   ConstructLongHelp(),

--- a/internal/database/migration/cliutil/flags.go
+++ b/internal/database/migration/cliutil/flags.go
@@ -19,7 +19,7 @@ func Flags(commandName string, run RunFunc, out *output.Output) *ffcli.Command {
 	return &ffcli.Command{
 		Name:       commandName,
 		ShortUsage: fmt.Sprintf("%s <command>", commandName),
-		ShortHelp:  "Modifies and runs database migrations",
+		ShortHelp:  "Modifies and runs schema migrations",
 		FlagSet:    rootFlagSet,
 		Exec: func(ctx context.Context, args []string) error {
 			return flag.ErrHelp


### PR DESCRIPTION
Pulled from #29831. 