### PR TITLE
migrations: Remove unused `Count` method

### DIFF
--- a/internal/database/migration/definition/definition.go
+++ b/internal/database/migration/definition/definition.go
@@ -48,10 +48,6 @@ func (ds *Definitions) All() []Definition {
 	return ds.definitions
 }
 
-func (ds *Definitions) Count() int {
-	return len(ds.definitions)
-}
-
 func (ds *Definitions) First() int {
 	return ds.definitions[0].ID
 }

--- a/internal/database/migration/definition/definition.go
+++ b/internal/database/migration/definition/definition.go
@@ -48,10 +48,6 @@ func (ds *Definitions) All() []Definition {
 	return ds.definitions
 }
 
-func (ds *Definitions) First() int {
-	return ds.definitions[0].ID
-}
-
 func (ds *Definitions) GetByID(id int) (Definition, bool) {
 	definition, ok := ds.definitionsMap[id]
 	return definition, ok


### PR DESCRIPTION
Pulled from #29831.