### PR TITLE
Search backend: use sort interface of `result.Matches`

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"path"
 	"regexp"
 	"sort"
 	"strconv"

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1452,7 +1452,7 @@ func (r *searchResolver) resultsRecursive(ctx context.Context, plan query.Plan) 
 
 	matches := dedup.Results()
 	if len(matches) > 0 {
-		sort.Sort(result.Matches(matches))
+		sort.Sort(matches)
 	}
 
 	var alert *search.Alert
@@ -1837,7 +1837,7 @@ func doResults(ctx context.Context, searchInputs *run.SearchInputs, db database.
 	}
 	alert, err := ao.Done(&common)
 
-	sort.Sort(result.Matches(matches))
+	sort.Sort(matches)
 
 	return &SearchResults{
 		Matches: matches,

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -608,7 +608,7 @@ func TestCompareSearchResults(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run("test", func(t *testing.T) {
-			if got := compareSearchResults(tt.a, tt.b); got != tt.aIsLess {
+			if got := tt.a.Key().Less(tt.b.Key()); got != tt.aIsLess {
 				t.Errorf("compareSearchResults() = %v, aIsLess %v", got, tt.aIsLess)
 			}
 		})

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -564,121 +564,51 @@ func TestCompareSearchResults(t *testing.T) {
 	}
 
 	tests := []struct {
-		name              string
-		a                 *result.FileMatch
-		b                 *result.FileMatch
-		exactFilePatterns map[string]struct{}
-		aIsLess           bool
+		name    string
+		a       *result.FileMatch
+		b       *result.FileMatch
+		aIsLess bool
 	}{
 		{
-			name:              "prefer exact match",
-			a:                 makeResult("arepo", "afile"),
-			b:                 makeResult("arepo", "file"),
-			exactFilePatterns: map[string]struct{}{"file": {}},
-			aIsLess:           false,
+			name:    "alphabetical order",
+			a:       makeResult("arepo", "afile"),
+			b:       makeResult("arepo", "bfile"),
+			aIsLess: true,
 		},
 		{
-			name:              "reverse a and b",
-			a:                 makeResult("arepo", "file"),
-			b:                 makeResult("arepo", "afile"),
-			exactFilePatterns: map[string]struct{}{"file": {}},
-			aIsLess:           true,
+			name:    "same length, different files",
+			a:       makeResult("arepo", "bfile"),
+			b:       makeResult("arepo", "afile"),
+			aIsLess: false,
 		},
 		{
-			name:              "alphabetical order if exactFilePatterns is empty",
-			a:                 makeResult("arepo", "afile"),
-			b:                 makeResult("arepo", "file"),
-			exactFilePatterns: map[string]struct{}{},
-			aIsLess:           true,
+			name:    "different repo, no exact patterns",
+			a:       makeResult("arepo", "file"),
+			b:       makeResult("brepo", "afile"),
+			aIsLess: true,
 		},
 		{
-			name:              "alphabetical order if exactFilePatterns is nil",
-			a:                 makeResult("arepo", "afile"),
-			b:                 makeResult("arepo", "bfile"),
-			exactFilePatterns: nil,
-			aIsLess:           true,
+			name:    "repo matches only",
+			a:       makeResult("arepo", ""),
+			b:       makeResult("brepo", ""),
+			aIsLess: true,
 		},
 		{
-			name:              "same length, different files",
-			a:                 makeResult("arepo", "bfile"),
-			b:                 makeResult("arepo", "afile"),
-			exactFilePatterns: nil,
-			aIsLess:           false,
+			name:    "repo match and file match, same repo",
+			a:       makeResult("arepo", "file"),
+			b:       makeResult("arepo", ""),
+			aIsLess: false,
 		},
 		{
-			name:              "exact matches with different length",
-			a:                 makeResult("arepo", "adir1/file"),
-			b:                 makeResult("arepo", "dir1/file"),
-			exactFilePatterns: map[string]struct{}{"file": {}},
-			aIsLess:           false,
-		},
-		{
-			name:              "exact matches with same length",
-			a:                 makeResult("arepo", "dir2/file"),
-			b:                 makeResult("arepo", "dir1/file"),
-			exactFilePatterns: map[string]struct{}{"file": {}},
-			aIsLess:           false,
-		},
-		{
-			name:              "no match",
-			a:                 makeResult("arepo", "afile"),
-			b:                 makeResult("arepo", "bfile"),
-			exactFilePatterns: map[string]struct{}{"file": {}},
-			aIsLess:           true,
-		},
-		{
-			name:              "different repo, 1 exact match",
-			a:                 makeResult("arepo", "file"),
-			b:                 makeResult("brepo", "afile"),
-			exactFilePatterns: map[string]struct{}{"file": {}},
-			aIsLess:           true,
-		},
-		{
-			name:              "different repo, no exact patterns",
-			a:                 makeResult("arepo", "file"),
-			b:                 makeResult("brepo", "afile"),
-			exactFilePatterns: nil,
-			aIsLess:           true,
-		},
-		{
-			name:              "different repo, 2 exact matches",
-			a:                 makeResult("arepo", "file"),
-			b:                 makeResult("brepo", "file"),
-			exactFilePatterns: map[string]struct{}{"file": {}},
-			aIsLess:           true,
-		},
-		{
-			name:              "repo matches only",
-			a:                 makeResult("arepo", ""),
-			b:                 makeResult("brepo", ""),
-			exactFilePatterns: nil,
-			aIsLess:           true,
-		},
-		{
-			name:              "repo match and file match, same repo",
-			a:                 makeResult("arepo", "file"),
-			b:                 makeResult("arepo", ""),
-			exactFilePatterns: nil,
-			aIsLess:           false,
-		},
-		{
-			name:              "repo match and file match, different repos",
-			a:                 makeResult("arepo", ""),
-			b:                 makeResult("brepo", "file"),
-			exactFilePatterns: nil,
-			aIsLess:           true,
-		},
-		{
-			name:              "prefer repo matches",
-			a:                 makeResult("arepo", ""),
-			b:                 makeResult("brepo", "file"),
-			exactFilePatterns: map[string]struct{}{"file": {}},
-			aIsLess:           true,
+			name:    "repo match and file match, different repos",
+			a:       makeResult("arepo", ""),
+			b:       makeResult("brepo", "file"),
+			aIsLess: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run("test", func(t *testing.T) {
-			if got := compareSearchResults(tt.a, tt.b, tt.exactFilePatterns); got != tt.aIsLess {
+			if got := compareSearchResults(tt.a, tt.b); got != tt.aIsLess {
 				t.Errorf("compareSearchResults() = %v, aIsLess %v", got, tt.aIsLess)
 			}
 		})

--- a/internal/search/result/commit.go
+++ b/internal/search/result/commit.go
@@ -136,9 +136,10 @@ func (r *CommitMatch) Key() Key {
 		typeRank = rankDiffMatch
 	}
 	return Key{
-		TypeRank: typeRank,
-		Repo:     r.Repo.Name,
-		Commit:   r.Commit.ID,
+		TypeRank:   typeRank,
+		Repo:       r.Repo.Name,
+		AuthorDate: &r.Commit.Author.Date,
+		Commit:     r.Commit.ID,
 	}
 }
 

--- a/internal/search/result/deduper.go
+++ b/internal/search/result/deduper.go
@@ -3,7 +3,7 @@ package result
 // deduper deduplicates matches added to it with Add(). Matches are deduplicated by their key,
 // and the return value of Results() is ordered in the same order results are added with Add().
 type deduper struct {
-	results []Match
+	results Matches
 	seen    map[Key]Match
 }
 
@@ -36,6 +36,6 @@ func (d *deduper) Seen(m Match) bool {
 	return ok
 }
 
-func (d *deduper) Results() []Match {
+func (d *deduper) Results() Matches {
 	return d.results
 }

--- a/internal/search/result/deduper_test.go
+++ b/internal/search/result/deduper_test.go
@@ -62,8 +62,8 @@ func TestDeduper(t *testing.T) {
 
 	cases := []struct {
 		name     string
-		input    []Match
-		expected []Match
+		input    Matches
+		expected Matches
 	}{
 		{
 			name: "no dups",

--- a/internal/search/result/match.go
+++ b/internal/search/result/match.go
@@ -57,7 +57,7 @@ type Key struct {
 	// AuthorDate is the date a commit was authored if this key is for
 	// a commit match.
 	//
-	// TODO(@camdencheek): this should probably use committer date,
+	// NOTE(@camdencheek): this should probably use committer date,
 	// but the CommitterField on our CommitMatch type is possibly null,
 	// so using AuthorDate here preserves previous sorting behavior.
 	AuthorDate *time.Time

--- a/internal/search/result/match.go
+++ b/internal/search/result/match.go
@@ -1,6 +1,8 @@
 package result
 
 import (
+	"time"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -52,6 +54,14 @@ type Key struct {
 	// Rev is the revision associated with the repo if it exists
 	Rev string
 
+	// AuthorDate is the date a commit was authored if this key is for
+	// a commit match.
+	//
+	// TODO(@camdencheek): this should probably use committer date,
+	// but the CommitterField on our CommitMatch type is possibly null,
+	// so using AuthorDate here preserves previous sorting behavior.
+	AuthorDate *time.Time
+
 	// Commit is the commit hash of the commit the match belongs to.
 	// Empty if there is no commit associated with the match (e.g. RepoMatch)
 	Commit api.CommitID
@@ -72,6 +82,14 @@ func (k Key) Less(other Key) bool {
 
 	if k.Rev != other.Rev {
 		return k.Rev < other.Rev
+	}
+
+	if k.AuthorDate != nil && other.AuthorDate != nil {
+		return k.AuthorDate.Before(*other.AuthorDate)
+	} else if k.AuthorDate != nil {
+		return true
+	} else if other.AuthorDate != nil {
+		return false
 	}
 
 	if k.Commit != other.Commit {

--- a/internal/search/run/aggregator.go
+++ b/internal/search/run/aggregator.go
@@ -18,7 +18,7 @@ type Aggregator struct {
 	parentStream streaming.Sender
 
 	mu         sync.Mutex
-	results    []result.Match
+	results    result.Matches
 	stats      streaming.Stats
 	matchCount int
 }
@@ -26,7 +26,7 @@ type Aggregator struct {
 // Get finalises aggregation over the stream and returns the aggregated
 // result. It should only be called once each do* function is finished
 // running.
-func (a *Aggregator) Get() ([]result.Match, streaming.Stats, int) {
+func (a *Aggregator) Get() (result.Matches, streaming.Stats, int) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	return a.results, a.stats, a.matchCount

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -177,7 +177,7 @@ func searchInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, pat
 	}
 
 	// Create file matches from partitioned symbols
-	matches := make([]result.Match, 0, len(symbolsByPath))
+	matches := make(result.Matches, 0, len(symbolsByPath))
 	for path, symbols := range symbolsByPath {
 		file := result.File{
 			Path:     path,
@@ -201,7 +201,7 @@ func searchInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, pat
 	}
 
 	// Make the results deterministic
-	sort.Sort(result.Matches(matches))
+	sort.Sort(matches)
 	return matches, err
 }
 


### PR DESCRIPTION
We have a built-in sorting mechanism for the `result.Matches` type, and it was almost equivalent to that of `sortResults`. This brings the two into agreement and removes `sortResults` in favor of the sorting interface implemented by `result.Matches`. 

To do this, I needed to:
- Remove `exactFilePatterns` logic. This was already unused since `exactFilePatterns` was always being passed as `nil`.
- Add `AuthorDate` to the `Key` type and modified the `Less()` method to use it for sorting. Previously, we were sorting by `CommitID`, but this is not a very useful sort for commit results. 
- Convert a few uses of `[]result.Match` to `result.Matches` so we can use the sort interface it implements
