### PR TITLE
notebooks: log additional events and enable stories snapshotting

### DIFF
--- a/client/web/src/search/notebook/CreateNotebookPage.tsx
+++ b/client/web/src/search/notebook/CreateNotebookPage.tsx
@@ -4,6 +4,7 @@ import { catchError, startWith } from 'rxjs/operators'
 import * as uuid from 'uuid'
 
 import { asError, isErrorLike } from '@sourcegraph/common'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, useObservable, Alert } from '@sourcegraph/wildcard'
 
 import { Page } from '../../components/Page'
@@ -26,7 +27,7 @@ function deserializeBlocks(serializedBlocks: string): CreateNotebookBlockInput[]
     })
 }
 
-export const CreateNotebookPage: React.FunctionComponent = () => {
+export const CreateNotebookPage: React.FunctionComponent<TelemetryProps> = ({ telemetryService }) => {
     const notebookOrError = useObservable(
         useMemo(() => {
             const serializedBlocks = location.hash.trim().slice(1)
@@ -39,6 +40,7 @@ export const CreateNotebookPage: React.FunctionComponent = () => {
     )
 
     if (notebookOrError && !isErrorLike(notebookOrError) && notebookOrError !== LOADING) {
+        telemetryService.log('SearchNotebookCreated')
         return <Redirect to={PageRoutes.Notebook.replace(':id', notebookOrError.id)} />
     }
 

--- a/client/web/src/search/notebook/NotebookTitle.tsx
+++ b/client/web/src/search/notebook/NotebookTitle.tsx
@@ -2,11 +2,12 @@ import classNames from 'classnames'
 import PencilOutlineIcon from 'mdi-react/PencilOutlineIcon'
 import React, { useEffect, useRef, useState } from 'react'
 
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useOnClickOutside } from '@sourcegraph/wildcard'
 
 import styles from './NotebookTitle.module.scss'
 
-export interface NotebookTitleProps {
+export interface NotebookTitleProps extends TelemetryProps {
     title: string
     viewerCanManage: boolean
     onUpdateTitle: (title: string) => void
@@ -16,6 +17,7 @@ export const NotebookTitle: React.FunctionComponent<NotebookTitleProps> = ({
     title: initialTitle,
     viewerCanManage,
     onUpdateTitle,
+    telemetryService,
 }) => {
     const [isEditing, setIsEditing] = useState(false)
     const [title, setTitle] = useState(initialTitle)
@@ -28,6 +30,7 @@ export const NotebookTitle: React.FunctionComponent<NotebookTitleProps> = ({
     }
 
     const updateTitle = (): void => {
+        telemetryService.log('SearchNotebookTitleUpdated')
         setIsEditing(false)
         onUpdateTitle(title)
     }

--- a/client/web/src/search/notebook/SearchNotebook.story.tsx
+++ b/client/web/src/search/notebook/SearchNotebook.story.tsx
@@ -17,9 +17,9 @@ import { SearchNotebook } from './SearchNotebook'
 
 import { BlockInit } from '.'
 
-const { add } = storiesOf('web/search/notebook/SearchNotebook', module).addDecorator(story => (
-    <div className="p-3 container">{story()}</div>
-))
+const { add } = storiesOf('web/search/notebook/SearchNotebook', module)
+    .addDecorator(story => <div className="p-3 container">{story()}</div>)
+    .addParameters({ chromatic: { disableSnapshots: false } })
 
 const blocks: BlockInit[] = [
     { id: '1', type: 'md', input: '# Markdown' },

--- a/client/web/src/search/notebook/SearchNotebook.tsx
+++ b/client/web/src/search/notebook/SearchNotebook.tsx
@@ -25,7 +25,7 @@ import { SearchNotebookMarkdownBlock } from './SearchNotebookMarkdownBlock'
 import { SearchNotebookQueryBlock } from './SearchNotebookQueryBlock'
 import { isMonacoEditorDescendant } from './useBlockSelection'
 
-import { Block, BlockDirection, BlockInit, BlockInput, Notebook } from '.'
+import { Block, BlockDirection, BlockInit, BlockInput, BlockType, Notebook } from '.'
 
 export interface SearchNotebookProps
     extends SearchStreamingProps,
@@ -43,6 +43,16 @@ export interface SearchNotebookProps
 }
 
 const LOADING = 'LOADING' as const
+
+type BlockCounts = { [blockType in BlockType]: number }
+
+function countBlockTypes(blocks: Block[]): BlockCounts {
+    return blocks.reduce((aggregate, block) => ({ ...aggregate, [block.type]: aggregate[block.type] + 1 }), {
+        md: 0,
+        file: 0,
+        query: 0,
+    })
+}
 
 export const SearchNotebook: React.FunctionComponent<SearchNotebookProps> = ({
     onSerializeBlocks,
@@ -69,8 +79,14 @@ export const SearchNotebook: React.FunctionComponent<SearchNotebookProps> = ({
             if (serialize) {
                 onSerializeBlocks(blocks)
             }
+            const blockCountsPerType = countBlockTypes(blocks)
+            props.telemetryService.log(
+                'SearchNotebookBlocksUpdated',
+                { blocksCount: blocks.length, blockCountsPerType },
+                { blocksCount: blocks.length, blockCountsPerType }
+            )
         },
-        [notebook, setBlocks, onSerializeBlocks]
+        [notebook, setBlocks, onSerializeBlocks, props.telemetryService]
     )
 
     // Update the blocks if the notebook instance changes (when new initializer blocks are provided)

--- a/client/web/src/search/notebook/SearchNotebookPage.tsx
+++ b/client/web/src/search/notebook/SearchNotebookPage.tsx
@@ -187,6 +187,7 @@ export const SearchNotebookPage: React.FunctionComponent<SearchNotebookPageProps
                                             title={notebookOrError.title}
                                             viewerCanManage={notebookOrError.viewerCanManage}
                                             onUpdateTitle={onUpdateTitle}
+                                            telemetryService={props.telemetryService}
                                         />
                                     ),
                                 },
@@ -203,6 +204,7 @@ export const SearchNotebookPage: React.FunctionComponent<SearchNotebookPageProps
                                     viewerHasStarred={notebookOrError.viewerHasStarred}
                                     createNotebookStar={createNotebookStar}
                                     deleteNotebookStar={deleteNotebookStar}
+                                    telemetryService={props.telemetryService}
                                 />
                             }
                         />

--- a/client/web/src/search/notebook/listPage/SearchNotebooksList.tsx
+++ b/client/web/src/search/notebook/listPage/SearchNotebooksList.tsx
@@ -1,5 +1,7 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useEffect } from 'react'
 import { useHistory, useLocation } from 'react-router'
+
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { FilteredConnection, FilteredConnectionFilter } from '../../../components/FilteredConnection'
 import {
@@ -13,7 +15,8 @@ import { fetchNotebooks as _fetchNotebooks } from '../backend'
 import { NotebookNode, NotebookNodeProps } from './NotebookNode'
 import styles from './SearchNotebooksList.module.scss'
 
-interface SearchNotebooksListProps {
+interface SearchNotebooksListProps extends TelemetryProps {
+    logEventName: string
     filters: FilteredConnectionFilter[]
     creatorUserID?: string
     starredByUserID?: string
@@ -21,11 +24,18 @@ interface SearchNotebooksListProps {
 }
 
 export const SearchNotebooksList: React.FunctionComponent<SearchNotebooksListProps> = ({
+    logEventName,
     filters,
     creatorUserID,
     starredByUserID,
     fetchNotebooks,
+    telemetryService,
 }) => {
+    useEffect(() => telemetryService.logViewEvent(`SearchNotebooksList${logEventName}`), [
+        logEventName,
+        telemetryService,
+    ])
+
     const queryConnection = useCallback(
         (args: Partial<ListNotebooksVariables>) => {
             const { orderBy, descending } = args as {

--- a/client/web/src/search/notebook/listPage/SearchNotebooksListPage.story.tsx
+++ b/client/web/src/search/notebook/listPage/SearchNotebooksListPage.story.tsx
@@ -10,9 +10,9 @@ import { ListNotebooksResult } from '../../../graphql-operations'
 
 import { SearchNotebooksListPage } from './SearchNotebooksListPage'
 
-const { add } = storiesOf('web/search/notebook/SearchNotebooksListPage', module).addDecorator(story => (
-    <div className="p-3 container">{story()}</div>
-))
+const { add } = storiesOf('web/search/notebook/SearchNotebooksListPage', module)
+    .addDecorator(story => <div className="p-3 container">{story()}</div>)
+    .addParameters({ chromatic: { disableSnapshots: false } })
 
 const now = new Date()
 

--- a/client/web/src/search/notebook/listPage/SearchNotebooksListPage.tsx
+++ b/client/web/src/search/notebook/listPage/SearchNotebooksListPage.tsx
@@ -185,7 +185,7 @@ export const SearchNotebooksListPage: React.FunctionComponent<SearchNotebooksLis
                                 role="button"
                                 onClick={event => {
                                     event.preventDefault()
-                                    onSelectTab('starred', 'SearchNotebooksExploreNotebooksTabClick')
+                                    onSelectTab('starred', 'SearchNotebooksStarredNotebooksTabClick')
                                 }}
                                 className={classNames('nav-link', selectedTab === 'starred' && 'active')}
                             >
@@ -214,16 +214,20 @@ export const SearchNotebooksListPage: React.FunctionComponent<SearchNotebooksLis
                 </div>
                 {selectedTab === 'my' && authenticatedUser && (
                     <SearchNotebooksList
+                        logEventName="MyNotebooks"
                         fetchNotebooks={fetchNotebooks}
                         filters={filters}
                         creatorUserID={authenticatedUser.id}
+                        telemetryService={telemetryService}
                     />
                 )}
                 {selectedTab === 'starred' && authenticatedUser && (
                     <SearchNotebooksList
+                        logEventName="StarredNotebooks"
                         fetchNotebooks={fetchNotebooks}
                         starredByUserID={authenticatedUser.id}
                         filters={filters}
+                        telemetryService={telemetryService}
                     />
                 )}
                 {(selectedTab === 'my' || selectedTab === 'starred') && !authenticatedUser && (
@@ -235,7 +239,14 @@ export const SearchNotebooksListPage: React.FunctionComponent<SearchNotebooksLis
                         }
                     />
                 )}
-                {selectedTab === 'explore' && <SearchNotebooksList fetchNotebooks={fetchNotebooks} filters={filters} />}
+                {selectedTab === 'explore' && (
+                    <SearchNotebooksList
+                        logEventName="ExploreNotebooks"
+                        fetchNotebooks={fetchNotebooks}
+                        filters={filters}
+                        telemetryService={telemetryService}
+                    />
+                )}
             </Page>
         </div>
     )


### PR DESCRIPTION
Adds the majority of events listed in https://github.com/sourcegraph/sourcegraph/issues/30087.

Also enables snapshotting for two notebook stories.