### PR TITLE
internal: Add comments for generated metric names

### DIFF
--- a/internal/extsvc/bitbucketcloud/client.go
+++ b/internal/extsvc/bitbucketcloud/client.go
@@ -22,7 +22,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
 
-var requestCounter = metrics.NewRequestMeter("bitbucket_cloud_requests_count", "Total number of requests sent to the Bitbucket Cloud API.")
+// The metric generated here will be named as "src_bitbucket_cloud_requests_total".
+var requestCounter = metrics.NewRequestMeter("bitbucket_cloud", "Total number of requests sent to the Bitbucket Cloud API.")
 
 // These fields define the self-imposed Bitbucket rate limit (since Bitbucket Cloud does
 // not have a concept of rate limiting in HTTP response headers).

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -33,6 +33,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
+// The metric generated here will be named as "src_bitbucket_requests_total".
 var requestCounter = metrics.NewRequestMeter("bitbucket", "Total number of requests sent to the Bitbucket API.")
 
 // These fields define the self-imposed Bitbucket rate limit (since Bitbucket Server does

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -1480,6 +1480,7 @@ var (
 		return url
 	}()
 
+	// The metric generated here will be named as "src_github_requests_total".
 	requestCounter = metrics.NewRequestMeter("github", "Total number of requests sent to the GitHub API.")
 )
 

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -27,6 +27,7 @@ import (
 )
 
 var (
+	// The metric generated here will be named as "src_gitlab_requests_total".
 	requestCounter = metrics.NewRequestMeter("gitlab", "Total number of requests sent to the GitLab API.")
 
 	// Whether debug logging is turned on

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -347,6 +347,11 @@ func TracedTransportOpt(cli *http.Client) error {
 // MeteredTransportOpt returns an opt that wraps an existing http.Transport of a http.Client with
 // metrics collection.
 func MeteredTransportOpt(subsystem string) Opt {
+	// This will generate a metric of the following format:
+	// src_$subsystem_requests_total
+	//
+	// For example, if the subsystem is set to "internal", the metric being generated will be named
+	// src_internal_requests_total
 	meter := metrics.NewRequestMeter(
 		subsystem,
 		"Total number of requests sent to "+subsystem,

--- a/internal/search/backend/zoekt.go
+++ b/internal/search/backend/zoekt.go
@@ -20,6 +20,7 @@ var zoektHTTPClient, _ = httpcli.NewFactory(
 		httpcli.ContextErrorMiddleware,
 	),
 	httpcli.NewMaxIdleConnsPerHostOpt(500),
+	// This will also generate a metric named "src_zoekt_webserver_requests_total".
 	httpcli.MeteredTransportOpt("zoekt_webserver"),
 	httpcli.TracedTransportOpt,
 ).Client()


### PR DESCRIPTION
When debugging an issue related to these metrics, we tend to do a
string search for the metric name but will fail to find a match since
these metrics are generated. As a result, adding a comment will help
with such scenarios.

Also, in this commit a metric for bitbucket cloud is renamed to remove
a redundant string from the name.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
