### PR TITLE
executor: quote env vars if passed as args & contain whitespace

### DIFF
--- a/enterprise/cmd/executor/internal/command/docker.go
+++ b/enterprise/cmd/executor/internal/command/docker.go
@@ -33,7 +33,8 @@ func formatRawOrDockerCommand(spec CommandSpec, dir string, options Options) com
 			dockerResourceFlags(options.ResourceOptions),
 			dockerVolumeFlags(dir, spec.ScriptPath),
 			dockerWorkingdirectoryFlags(spec.Dir),
-			dockerEnvFlags(spec.Env),
+			// If the env vars will be part of the command line args, we need to quote them
+			dockerEnvFlags(quoteEnv(spec.Env)),
 			dockerEntrypointFlags(),
 			spec.Image,
 			filepath.Join("/data", ScriptsPath, spec.ScriptPath),

--- a/enterprise/cmd/executor/internal/command/docker_test.go
+++ b/enterprise/cmd/executor/internal/command/docker_test.go
@@ -9,9 +9,12 @@ import (
 func TestFormatRawOrDockerCommandRaw(t *testing.T) {
 	actual := formatRawOrDockerCommand(
 		CommandSpec{
-			Command:   []string{"ls", "-a"},
-			Dir:       "subdir",
-			Env:       []string{"TEST=true"},
+			Command: []string{"ls", "-a"},
+			Dir:     "subdir",
+			Env: []string{
+				`TEST=true`,
+				`CONTAINS_WHITESPACE=yes it does`,
+			},
 			Operation: makeTestOperation(),
 		},
 		"/proj/src",
@@ -21,7 +24,7 @@ func TestFormatRawOrDockerCommandRaw(t *testing.T) {
 	expected := command{
 		Command: []string{"ls", "-a"},
 		Dir:     "/proj/src/subdir",
-		Env:     []string{"TEST=true"},
+		Env:     []string{"TEST=true", "CONTAINS_WHITESPACE=yes it does"},
 	}
 	if diff := cmp.Diff(expected, actual, commandComparer); diff != "" {
 		t.Errorf("unexpected command (-want +got):\n%s", diff)
@@ -34,8 +37,11 @@ func TestFormatRawOrDockerCommandDockerScript(t *testing.T) {
 			Image:      "alpine:latest",
 			ScriptPath: "myscript.sh",
 			Dir:        "subdir",
-			Env:        []string{"TEST=true"},
-			Operation:  makeTestOperation(),
+			Env: []string{
+				`TEST=true`,
+				`CONTAINS_WHITESPACE=yes it does`,
+			},
+			Operation: makeTestOperation(),
 		},
 		"/proj/src",
 		Options{
@@ -54,34 +60,12 @@ func TestFormatRawOrDockerCommandDockerScript(t *testing.T) {
 			"-v", "/proj/src:/data",
 			"-w", "/data/subdir",
 			"-e", "TEST=true",
+			"-e", `CONTAINS_WHITESPACE="yes it does"`,
 			"--entrypoint",
 			"/bin/sh",
 			"alpine:latest",
 			"/data/.sourcegraph-executor/myscript.sh",
 		},
-	}
-	if diff := cmp.Diff(expected, actual, commandComparer); diff != "" {
-		t.Errorf("unexpected command (-want +got):\n%s", diff)
-	}
-}
-
-func TestFormatRawOrDockerCommandDockerCommand(t *testing.T) {
-	actual := formatRawOrDockerCommand(
-		CommandSpec{
-			Command: []string{"ls", "-a"},
-			Dir:     "subdir",
-			Env:     []string{"TEST=true"},
-		},
-		"/proj/src",
-		Options{},
-	)
-
-	expected := command{
-		Command: []string{
-			"ls", "-a",
-		},
-		Env: []string{"TEST=true"},
-		Dir: "/proj/src/subdir",
 	}
 	if diff := cmp.Diff(expected, actual, commandComparer); diff != "" {
 		t.Errorf("unexpected command (-want +got):\n%s", diff)

--- a/enterprise/cmd/executor/internal/command/firecracker.go
+++ b/enterprise/cmd/executor/internal/command/firecracker.go
@@ -35,7 +35,9 @@ func formatFirecrackerCommand(spec CommandSpec, name, repoDir string, options Op
 
 	innerCommand := strings.Join(rawOrDockerCommand.Command, " ")
 	if len(rawOrDockerCommand.Env) > 0 {
-		innerCommand = fmt.Sprintf("%s %s", strings.Join(rawOrDockerCommand.Env, " "), innerCommand)
+		// If we have env vars that are arguments to the command we need to escape them
+		quotedEnv := quoteEnv(rawOrDockerCommand.Env)
+		innerCommand = fmt.Sprintf("%s %s", strings.Join(quotedEnv, " "), innerCommand)
 	}
 	if rawOrDockerCommand.Dir != "" {
 		innerCommand = fmt.Sprintf("cd %s && %s", rawOrDockerCommand.Dir, innerCommand)

--- a/enterprise/cmd/executor/internal/command/firecracker_test.go
+++ b/enterprise/cmd/executor/internal/command/firecracker_test.go
@@ -14,9 +14,12 @@ import (
 func TestFormatFirecrackerCommandRaw(t *testing.T) {
 	actual := formatFirecrackerCommand(
 		CommandSpec{
-			Command:   []string{"ls", "-a"},
-			Dir:       "subdir",
-			Env:       []string{"TEST=true"},
+			Command: []string{"ls", "-a"},
+			Dir:     "subdir",
+			Env: []string{
+				`TEST=true`,
+				`CONTAINS_WHITESPACE=yes it does`,
+			},
 			Operation: makeTestOperation(),
 		},
 		"deadbeef",
@@ -27,7 +30,7 @@ func TestFormatFirecrackerCommandRaw(t *testing.T) {
 	expected := command{
 		Command: []string{
 			"ignite", "exec", "deadbeef", "--",
-			"cd /work/subdir && TEST=true ls -a",
+			`cd /work/subdir && TEST=true CONTAINS_WHITESPACE="yes it does" ls -a`,
 		},
 	}
 	if diff := cmp.Diff(expected, actual, commandComparer); diff != "" {
@@ -41,8 +44,11 @@ func TestFormatFirecrackerCommandDockerScript(t *testing.T) {
 			Image:      "alpine:latest",
 			ScriptPath: "myscript.sh",
 			Dir:        "subdir",
-			Env:        []string{"TEST=true"},
-			Operation:  makeTestOperation(),
+			Env: []string{
+				`TEST=true`,
+				`CONTAINS_WHITESPACE=yes it does`,
+			},
+			Operation: makeTestOperation(),
 		},
 		"deadbeef",
 		"/proj/src",
@@ -64,6 +70,7 @@ func TestFormatFirecrackerCommandDockerScript(t *testing.T) {
 				"-v", "/work:/data",
 				"-w", "/data/subdir",
 				"-e", "TEST=true",
+				"-e", `CONTAINS_WHITESPACE="yes it does"`,
 				"--entrypoint /bin/sh",
 				"alpine:latest",
 				"/data/.sourcegraph-executor/myscript.sh",
@@ -71,34 +78,6 @@ func TestFormatFirecrackerCommandDockerScript(t *testing.T) {
 		},
 	}
 	if diff := cmp.Diff(expected, actual, commandComparer); diff != "" {
-		t.Errorf("unexpected command (-want +got):\n%s", diff)
-	}
-}
-
-func TestFormatFirecrackerCommandDockerCommand(t *testing.T) {
-	actual := formatFirecrackerCommand(
-		CommandSpec{
-			Command: []string{"ls", "-a"},
-			Dir:     "subdir",
-			Env:     []string{"TEST=true"},
-		},
-		"deadbeef",
-		"/proj/src",
-		Options{
-			ResourceOptions: ResourceOptions{
-				NumCPUs: 4,
-				Memory:  "20G",
-			},
-		},
-	)
-
-	expected := command{
-		Command: []string{
-			"ignite", "exec", "deadbeef", "--",
-			"cd /work/subdir && TEST=true ls -a",
-		},
-	}
-	if diff := cmp.Diff(expected, actual); diff != "" {
 		t.Errorf("unexpected command (-want +got):\n%s", diff)
 	}
 }

--- a/enterprise/cmd/executor/internal/command/util.go
+++ b/enterprise/cmd/executor/internal/command/util.go
@@ -38,7 +38,7 @@ func quoteEnv(env []string) []string {
 	for i, e := range env {
 		if strings.Contains(e, " ") {
 			elems := strings.SplitN(e, "=", 2)
-			quotedEnv[i] = fmt.Sprintf(`%s="%s"`, elems[0], elems[1])
+			quotedEnv[i] = fmt.Sprintf(`%s=%q`, elems[0], elems[1])
 		} else {
 			quotedEnv[i] = e
 		}

--- a/enterprise/cmd/executor/internal/command/util.go
+++ b/enterprise/cmd/executor/internal/command/util.go
@@ -1,5 +1,10 @@
 package command
 
+import (
+	"fmt"
+	"strings"
+)
+
 // flatten combines string values and (non-recursive) string slice values
 // into a single string slice.
 func flatten(values ...interface{}) []string {
@@ -24,4 +29,20 @@ func intersperse(flag string, values []string) []string {
 	}
 
 	return interspersed
+}
+
+// quoteEnv returns a slice of env vars in which env vars that contain a whitespace have been quoted
+func quoteEnv(env []string) []string {
+	quotedEnv := make([]string, len(env))
+
+	for i, e := range env {
+		if strings.Contains(e, " ") {
+			elems := strings.SplitN(e, "=", 2)
+			quotedEnv[i] = fmt.Sprintf(`%s="%s"`, elems[0], elems[1])
+		} else {
+			quotedEnv[i] = e
+		}
+	}
+
+	return quotedEnv
 }

--- a/enterprise/cmd/executor/internal/command/util_test.go
+++ b/enterprise/cmd/executor/internal/command/util_test.go
@@ -39,3 +39,44 @@ func TestIntersperse(t *testing.T) {
 		t.Errorf("unexpected slice (-want +got):\n%s", diff)
 	}
 }
+
+func TestQuoteEnv(t *testing.T) {
+	tests := []struct {
+		in   []string
+		want []string
+	}{
+		{
+			in:   []string{"FOO=bar"},
+			want: []string{"FOO=bar"},
+		},
+		{
+			in:   []string{"FOO=bar foo bar"},
+			want: []string{`FOO="bar foo bar"`},
+		},
+
+		{
+			in:   []string{"HOME=computer", "FOO=bar"},
+			want: []string{"HOME=computer", "FOO=bar"},
+		},
+		{
+			in:   []string{"HOME=compute r", "FOO=bar foo bar"},
+			want: []string{`HOME="compute r"`, `FOO="bar foo bar"`},
+		},
+		{
+			in:   []string{"FOO=bar -e 31337=H4XX0R"},
+			want: []string{`FOO="bar -e 31337=H4XX0R"`},
+		},
+		{
+			in:   []string{`FOO=bar -e "shell-h4xx0r"`},
+			want: []string{`FOO="bar -e \"shell-h4xx0r\""`},
+		},
+	}
+
+	for _, tt := range tests {
+		got := quoteEnv(tt.in)
+
+		if diff := cmp.Diff(tt.want, got); diff != "" {
+			t.Errorf("unexpected slice (-want +got):\n%s", diff)
+		}
+	}
+}


### PR DESCRIPTION
This fixes auto-indexing on executors that use ignite/firecracker under
the hood.

It was broken since #30023 (and due to #29885 for a different reason),
because in #30023 we added an env var to the auto-index jobs whose value
contains whitespace.

We didn't detect that this is a problem when testing locally, because on
macOS we don't use ignite and all the commands are executed on the host.
In that case the env vars are set as env vars on Go's `exec.Cmd`
structure and that takes care of the whitespace for us.

But when the jobs are run via ignite in firecracker VMs the env vars are
passed to the VM as args of the `ignite` command.

That lead to a command like this being executed:

    ignite exec $VM-NAME -- \
      SRC_HEADER_AUTHORIZATION=token-executor SECRET-TOKEN src lsif upload [...]

    (details omitted)

That failed with:

    bash: SECRET-TOKEN: command not found

Because we didn't put the env var value in quotes.

Now we come to this PR.

This quotes env vars, but only under two circumstances:

1. if the env vars are passed as part of the command line
2. if they contain whitespace

The important bit is (1), because we need to make sure that when we set
a `cmd.Env` field we *don't* quote the env vars, because Go will then
use the quotes as part of the value.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
