### PR TITLE
Code Insights: Adjust dashboard page header layout

### DIFF
--- a/client/web/src/components/AppRouterContainer/AppRouterContainer.tsx
+++ b/client/web/src/components/AppRouterContainer/AppRouterContainer.tsx
@@ -12,7 +12,7 @@ export const AppRouterContainer: React.FunctionComponent<AppRouterContainerProps
     ...rest
 }) => (
     <ElementScroller scrollKey="app-router-container">
-        <div className={classNames(styles.appRouterContainer, className)} {...rest}>
+        <div data-layout={true} className={classNames(styles.appRouterContainer, className)} {...rest}>
             {children}
         </div>
     </ElementScroller>

--- a/client/web/src/components/AppRouterContainer/AppRouterContainer.tsx
+++ b/client/web/src/components/AppRouterContainer/AppRouterContainer.tsx
@@ -12,6 +12,10 @@ export const AppRouterContainer: React.FunctionComponent<AppRouterContainerProps
     ...rest
 }) => (
     <ElementScroller scrollKey="app-router-container">
+        {/*
+            Data Layout data attribute is used to get access to the main layout scroll element (the div element below).
+            from child levels in order to handle or react on this container scroll or other important events.
+         */}
         <div data-layout={true} className={classNames(styles.appRouterContainer, className)} {...rest}>
             {children}
         </div>

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardPage.test.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardPage.test.tsx
@@ -7,6 +7,8 @@ import { Router, Route } from 'react-router-dom'
 import { of } from 'rxjs'
 import sinon from 'sinon'
 
+import { MockIntersectionObserver } from '@sourcegraph/shared/src/testing/MockIntersectionObserver'
+
 import { CodeInsightsBackend } from '../../../core/backend/code-insights-backend'
 import {
     CodeInsightsBackendContext,
@@ -64,6 +66,10 @@ const renderWithRouter = (
 })
 
 describe('DashboardsPage', () => {
+    beforeAll(() => {
+        window.IntersectionObserver = MockIntersectionObserver
+    })
+
     it('should redirect to "All insights" page if no dashboardId is provided', () => {
         const { history } = renderWithRouter(<DashboardsPage telemetryService={mockTelemetryService} />)
 

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.tsx
@@ -9,7 +9,7 @@ import { Button } from '@sourcegraph/wildcard'
 import { positionBottomRight } from '../../../../../components/context-menu/utils'
 import { InsightDashboard } from '../../../../../core/types'
 import { SupportedInsightSubject } from '../../../../../core/types/subjects'
-import { getTooltipMessage, useDashboardPermissions } from '../../hooks/use-dashboard-permissions'
+import { getTooltipMessage, getDashboardPermissions } from '../../utils/get-dashboard-permissions'
 
 import styles from './DashboardMenu.module.scss'
 
@@ -26,13 +26,14 @@ export interface DashboardMenuProps {
     dashboard?: InsightDashboard
     onSelect?: (action: DashboardMenuAction) => void
     tooltipText?: string
+    className?: string
 }
 
 export const DashboardMenu: React.FunctionComponent<DashboardMenuProps> = props => {
-    const { innerRef, dashboard, subjects, onSelect = () => {}, tooltipText } = props
+    const { innerRef, dashboard, subjects, onSelect = () => {}, tooltipText, className } = props
 
     const hasDashboard = dashboard !== undefined
-    const permissions = useDashboardPermissions(dashboard, subjects)
+    const permissions = getDashboardPermissions(dashboard, subjects)
 
     return (
         <Menu>
@@ -41,7 +42,7 @@ export const DashboardMenu: React.FunctionComponent<DashboardMenuProps> = props 
                 ref={innerRef}
                 data-tooltip={tooltipText}
                 data-placement="right"
-                className={classNames(styles.triggerButton, 'btn-icon')}
+                className={classNames(className, styles.triggerButton, 'btn-icon')}
             >
                 <VisuallyHidden>Dashboard options</VisuallyHidden>
                 <DotsVerticalIcon size={16} />
@@ -49,18 +50,6 @@ export const DashboardMenu: React.FunctionComponent<DashboardMenuProps> = props 
 
             <MenuPopover portal={true} position={positionBottomRight}>
                 <MenuItems className={classNames(styles.menuList, 'dropdown-menu')}>
-                    <MenuItem
-                        as={Button}
-                        disabled={!permissions.isConfigurable}
-                        data-tooltip={getTooltipMessage(dashboard, permissions)}
-                        data-placement="right"
-                        className={styles.menuItem}
-                        onSelect={() => onSelect(DashboardMenuAction.AddRemoveInsights)}
-                        outline={true}
-                    >
-                        Add or remove insights
-                    </MenuItem>
-
                     <MenuItem
                         as={Button}
                         disabled={!permissions.isConfigurable}

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.module.scss
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.module.scss
@@ -8,6 +8,5 @@
 
 .dashboard-select-label {
     font-weight: 500;
-    margin-bottom: 0.5rem;
-    width: 100%;
+    margin-right: 1rem;
 }

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.test.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.test.tsx
@@ -1,11 +1,12 @@
 import { useApolloClient } from '@apollo/client'
 import { MockedResponse } from '@apollo/client/testing'
-import { waitFor } from '@testing-library/react'
+import { fireEvent, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 import sinon from 'sinon'
 
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
+import { MockIntersectionObserver } from '@sourcegraph/shared/src/testing/MockIntersectionObserver'
 import { renderWithRouter, RenderWithRouterResult } from '@sourcegraph/shared/src/testing/render-with-router'
 
 import { AuthenticatedUser } from '../../../../../../../auth'
@@ -158,6 +159,7 @@ const triggerDashboardMenuItem = async (screen: RenderWithRouterResult & { user:
 
 beforeEach(() => {
     jest.clearAllMocks()
+    window.IntersectionObserver = MockIntersectionObserver
 })
 
 describe('DashboardsContent', () => {
@@ -204,8 +206,9 @@ describe('DashboardsContent', () => {
 
     it('opens add insight modal', async () => {
         const screen = renderDashboardsContent()
+        const addInsightsButton = await waitFor(() => screen.getByRole('button', { name: /Add insights/ }))
 
-        await triggerDashboardMenuItem(screen, /Add or remove insights/)
+        fireEvent.click(addInsightsButton)
 
         const addInsightHeader = await waitFor(() =>
             screen.getByRole('heading', { name: /Add insight to Global Dashboard/ })

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.test.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.test.tsx
@@ -1,6 +1,6 @@
 import { useApolloClient } from '@apollo/client'
 import { MockedResponse } from '@apollo/client/testing'
-import { fireEvent, waitFor } from '@testing-library/react'
+import { waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 import sinon from 'sinon'
@@ -208,7 +208,7 @@ describe('DashboardsContent', () => {
         const screen = renderDashboardsContent()
         const addInsightsButton = await waitFor(() => screen.getByRole('button', { name: /Add insights/ }))
 
-        fireEvent.click(addInsightsButton)
+        userEvent.click(addInsightsButton)
 
         const addInsightHeader = await waitFor(() =>
             screen.getByRole('heading', { name: /Add insight to Global Dashboard/ })

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
@@ -5,17 +5,19 @@ import { useHistory } from 'react-router-dom'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { authenticatedUser } from '@sourcegraph/web/src/auth'
-import { LoadingSpinner, useObservable } from '@sourcegraph/wildcard'
+import { Button, LoadingSpinner, useObservable } from '@sourcegraph/wildcard'
 
 import { HeroPage } from '../../../../../../../components/HeroPage'
 import { CodeInsightsBackendContext } from '../../../../../core/backend/code-insights-backend-context'
 import { isVirtualDashboard } from '../../../../../core/types'
 import { isCustomInsightDashboard } from '../../../../../core/types/dashboard/real-dashboard'
+import { getTooltipMessage, getDashboardPermissions } from '../../utils/get-dashboard-permissions'
 import { AddInsightModal } from '../add-insight-modal/AddInsightModal'
 import { DashboardMenu, DashboardMenuAction } from '../dashboard-menu/DashboardMenu'
 import { DashboardSelect } from '../dashboard-select/DashboardSelect'
 import { DeleteDashboardModal } from '../delete-dashboard-modal/DeleteDashboardModal'
 
+import { DashboardHeader } from './components/dashboard-header/DashboardHeader'
 import { DashboardInsights } from './components/dashboard-inisghts/DashboardInsights'
 import styles from './DashboardsContent.module.scss'
 import { useCopyURLHandler } from './hooks/use-copy-url-handler'
@@ -61,6 +63,7 @@ export const DashboardsContent: React.FunctionComponent<DashboardsContentProps> 
     }
 
     const currentDashboard = findDashboardByUrlId(dashboards, dashboardID)
+    const permissions = getDashboardPermissions(currentDashboard, subjects)
 
     const handleSelect = (action: DashboardMenuAction): void => {
         switch (action) {
@@ -105,8 +108,8 @@ export const DashboardsContent: React.FunctionComponent<DashboardsContentProps> 
 
     return (
         <div>
-            <section className="d-flex flex-wrap align-items-center">
-                <span className={styles.dashboardSelectLabel}>Dashboard</span>
+            <DashboardHeader className="d-flex flex-wrap align-items-center mb-3">
+                <span className={styles.dashboardSelectLabel}>Dashboard:</span>
 
                 <DashboardSelect
                     value={currentDashboard?.id}
@@ -122,10 +125,20 @@ export const DashboardsContent: React.FunctionComponent<DashboardsContentProps> 
                     tooltipText={isCopied ? 'Copied!' : undefined}
                     dashboard={currentDashboard}
                     onSelect={handleSelect}
+                    className="mr-auto"
                 />
-            </section>
 
-            <hr className="mt-2 mb-3" />
+                <Button
+                    outline={true}
+                    variant="secondary"
+                    disabled={!permissions.isConfigurable}
+                    data-tooltip={getTooltipMessage(currentDashboard, permissions)}
+                    data-placement="bottom"
+                    onClick={() => handleSelect(DashboardMenuAction.AddRemoveInsights)}
+                >
+                    Add insights
+                </Button>
+            </DashboardHeader>
 
             {currentDashboard ? (
                 <DashboardInsights

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-header/DashboardHeader.module.scss
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-header/DashboardHeader.module.scss
@@ -15,8 +15,10 @@
             bottom: 0;
             left: 0;
             right: 0;
-            margin-left: -100vw;
-            margin-right: -100vw;
+
+            // For stretching the bottom border across the entire screen
+            // stylelint-disable-next-line declaration-property-unit-allowed-list
+            margin: 0 -100vw;
             border-bottom: 1px solid var(--border-color-2);
         }
     }

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-header/DashboardHeader.module.scss
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-header/DashboardHeader.module.scss
@@ -1,5 +1,3 @@
-
-
 .header {
     top: 0;
     position: sticky;
@@ -12,7 +10,7 @@
 
         &::after {
             display: block;
-            content: "";
+            content: '';
             position: absolute;
             bottom: 0;
             left: 0;

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-header/DashboardHeader.module.scss
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-header/DashboardHeader.module.scss
@@ -1,0 +1,25 @@
+
+
+.header {
+    top: 0;
+    position: sticky;
+    padding: 0.5rem 0;
+    z-index: 1;
+    background-color: var(--body-bg);
+
+    &--sticked {
+        background-color: var(--color-bg-1);
+
+        &::after {
+            display: block;
+            content: "";
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            margin-left: -100vw;
+            margin-right: -100vw;
+            border-bottom: 1px solid var(--border-color-2);
+        }
+    }
+}

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-header/DashboardHeader.module.scss
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-header/DashboardHeader.module.scss
@@ -5,7 +5,7 @@
     z-index: 1;
     background-color: var(--body-bg);
 
-    &--sticked {
+    &--stuck {
         background-color: var(--color-bg-1);
 
         &::after {

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-header/DashboardHeader.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-header/DashboardHeader.tsx
@@ -3,7 +3,9 @@ import React, { useEffect, useRef } from 'react'
 
 import styles from './DashboardHeader.module.scss'
 
-export const DashboardHeader: React.FunctionComponent<React.HTMLAttributes<HTMLElement>> = props => {
+interface DashboardHeaderProps extends React.HTMLAttributes<HTMLElement> {}
+
+export const DashboardHeader: React.FunctionComponent<DashboardHeaderProps> = props => {
     const { children } = props
     const reference = useRef(null)
 
@@ -22,7 +24,7 @@ export const DashboardHeader: React.FunctionComponent<React.HTMLAttributes<HTMLE
         // Based on the solution from the following stackoverflow thread
         // https://stackoverflow.com/questions/16302483/event-to-detect-when-positionsticky-is-triggered
         const observer = new IntersectionObserver(
-            ([entry]) => entry.target.classList.toggle(styles.headerSticked, entry.intersectionRatio < 1),
+            ([entry]) => entry.target.classList.toggle(styles.headerStuck, entry.intersectionRatio < 1),
             { root, rootMargin: '-1px 0px 0px 0px', threshold: [1] }
         )
 

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-header/DashboardHeader.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-header/DashboardHeader.tsx
@@ -1,0 +1,40 @@
+import classNames from 'classnames';
+import React, { useEffect, useRef } from 'react'
+
+import styles from './DashboardHeader.module.scss'
+
+export const DashboardHeader: React.FunctionComponent<React.HTMLAttributes<HTMLElement>> = props => {
+    const { children } = props
+    const reference = useRef(null)
+
+    useEffect(() => {
+        const element = reference.current
+
+        if (!element) {
+            return
+        }
+
+        // Here we trying to get closest scroll layout element
+        // In our case it should be AppRouterContainer div element.
+        // TODO: Put AppRouterContainer element in the global state to avoid bad querySelector calls
+        const root = document.querySelector('[data-layout]')
+
+        // Based on the solution from the following stackoverflow thread
+        // https://stackoverflow.com/questions/16302483/event-to-detect-when-positionsticky-is-triggered
+        const observer = new IntersectionObserver(
+            ([entry]) =>
+                        entry.target.classList.toggle(styles.headerSticked, entry.intersectionRatio < 1),
+            { root, rootMargin: '-1px 0px 0px 0px', threshold: [1] }
+        );
+
+        observer.observe(element)
+
+        return () => observer.disconnect()
+    }, [])
+
+    return (
+        <header ref={reference} {...props} className={classNames(props.className, styles.header)}>
+            { children }
+        </header>
+    )
+}

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-header/DashboardHeader.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-header/DashboardHeader.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import classNames from 'classnames'
 import React, { useEffect, useRef } from 'react'
 
 import styles from './DashboardHeader.module.scss'
@@ -22,10 +22,9 @@ export const DashboardHeader: React.FunctionComponent<React.HTMLAttributes<HTMLE
         // Based on the solution from the following stackoverflow thread
         // https://stackoverflow.com/questions/16302483/event-to-detect-when-positionsticky-is-triggered
         const observer = new IntersectionObserver(
-            ([entry]) =>
-                        entry.target.classList.toggle(styles.headerSticked, entry.intersectionRatio < 1),
+            ([entry]) => entry.target.classList.toggle(styles.headerSticked, entry.intersectionRatio < 1),
             { root, rootMargin: '-1px 0px 0px 0px', threshold: [1] }
-        );
+        )
 
         observer.observe(element)
 
@@ -34,7 +33,7 @@ export const DashboardHeader: React.FunctionComponent<React.HTMLAttributes<HTMLE
 
     return (
         <header ref={reference} {...props} className={classNames(props.className, styles.header)}>
-            { children }
+            {children}
         </header>
     )
 }

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.tsx
@@ -5,7 +5,7 @@ import { Button, Link, Card } from '@sourcegraph/wildcard'
 
 import { InsightDashboard } from '../../../../../../../core/types'
 import { SupportedInsightSubject } from '../../../../../../../core/types/subjects'
-import { getTooltipMessage, useDashboardPermissions } from '../../../../hooks/use-dashboard-permissions'
+import { getTooltipMessage, getDashboardPermissions } from '../../../../utils/get-dashboard-permissions'
 import { isDashboardConfigurable } from '../../utils/is-dashboard-configurable'
 
 import styles from './EmptyInsightDashboard.module.scss'
@@ -51,7 +51,7 @@ export const EmptyBuiltInDashboard: React.FunctionComponent<{ dashboard: Insight
  */
 export const EmptySettingsBasedDashboard: React.FunctionComponent<EmptyInsightDashboardProps> = props => {
     const { onAddInsight, dashboard, subjects } = props
-    const permissions = useDashboardPermissions(dashboard, subjects)
+    const permissions = getDashboardPermissions(dashboard, subjects)
 
     return (
         <section className={styles.emptySection}>

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/utils/get-dashboard-permissions.ts
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/utils/get-dashboard-permissions.ts
@@ -23,7 +23,7 @@ const DEFAULT_DASHBOARD_PERMISSIONS: DashboardPermissions = {
     reason: DashboardReasonDenied.UnknownDashboard,
 }
 
-export function useDashboardPermissions(
+export function getDashboardPermissions(
     dashboard: InsightDashboard | undefined,
     supportedSubjects?: SupportedInsightSubject[]
 ): DashboardPermissions {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/30160

## Context 

This PR adjusts the dashboard header layout according to our [latest designs for this page](https://www.figma.com/file/EFgTP7gpdpQSEo1n4FUfsW/In-product-landing-page-WIP?node-id=1130%3A8493)

https://user-images.githubusercontent.com/18492575/151987179-05613ba2-79d3-40b7-af2b-1b09b9e8d959.mov

## For reviewers 

I left a few comments about the dashboard sticky header solution. I think I'm going to resolve the `querySelector`  problem in the separate follow up PR