### PR TITLE
revert back to system python

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -10,4 +10,3 @@ packer 1.6.6
 trivy 0.20.0
 kustomize 4.0.5
 awscli 2.4.7
-python 3.10.0


### PR DESCRIPTION
stop using asdf isntall python due to bloat and CI run time