### PR TITLE
Insights/fix commits before index

### DIFF
--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -332,8 +332,8 @@ func (h *historicalEnqueuer) buildFrames(ctx context.Context, uniqueSeries map[s
 	var multi error
 
 	hardErr := h.allReposIterator(ctx, h.buildForRepo(ctx, uniqueSeries, sortedSeriesIDs, multi))
-	if hardErr != nil {
-		log15.Error("historical_enqueuer.buildFrames - multierror", "err", hardErr)
+	if multi != nil {
+		log15.Error("historical_enqueuer.buildFrames - multierror", "err", multi)
 	}
 	return hardErr
 }

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -332,7 +332,9 @@ func (h *historicalEnqueuer) buildFrames(ctx context.Context, uniqueSeries map[s
 	var multi error
 
 	hardErr := h.allReposIterator(ctx, h.buildForRepo(ctx, uniqueSeries, sortedSeriesIDs, multi))
-	log15.Error("historical_enqueuer.buildFrames - multierror", "err", multi)
+	if hardErr != nil {
+		log15.Error("historical_enqueuer.buildFrames - multierror", "err", hardErr)
+	}
 	return hardErr
 }
 

--- a/enterprise/internal/insights/compression/commits.go
+++ b/enterprise/internal/insights/compression/commits.go
@@ -126,9 +126,10 @@ type CommitStamp struct {
 }
 
 type CommitIndexMetadata struct {
-	RepoId        int
-	Enabled       bool
-	LastIndexedAt time.Time
+	RepoId          int
+	Enabled         bool
+	LastIndexedAt   time.Time
+	OldestIndexedAt *time.Time
 }
 
 const getCommitsInRangeStr = `
@@ -143,7 +144,8 @@ INSERT INTO commit_index(repo_id, commit_bytea, committed_at, debug_field) VALUE
 
 const getCommitIndexMetadataStr = `
 -- source: enterprise/internal/insights/compression/commits.go:GetMetadata
-SELECT repo_id, enabled, last_indexed_at FROM commit_index_metadata WHERE repo_id = %s;
+SELECT repo_id, enabled, last_indexed_at FROM commit_index_metadata, (select min(committed_at) from commit_index where repo_id = %1) as oldest_indexed_at
+WHERE repo_id = $1;
 `
 
 const upsertCommitIndexMetadataStampStr = `

--- a/enterprise/internal/insights/compression/commits.go
+++ b/enterprise/internal/insights/compression/commits.go
@@ -97,10 +97,10 @@ func (c *DBCommitStore) Get(ctx context.Context, id api.RepoID, start time.Time,
 
 // GetMetadata Returns commit index metadata for a given repository
 func (c *DBCommitStore) GetMetadata(ctx context.Context, id api.RepoID) (CommitIndexMetadata, error) {
-	row := c.QueryRow(ctx, sqlf.Sprintf(getCommitIndexMetadataStr, id))
+	row := c.QueryRow(ctx, sqlf.Sprintf(getCommitIndexMetadataStr, id, id))
 
 	var metadata CommitIndexMetadata
-	if err := row.Scan(&metadata.RepoId, &metadata.Enabled, &metadata.LastIndexedAt); err != nil {
+	if err := row.Scan(&metadata.RepoId, &metadata.Enabled, &metadata.LastIndexedAt, &metadata.OldestIndexedAt); err != nil {
 		return CommitIndexMetadata{}, err
 	}
 
@@ -144,8 +144,9 @@ INSERT INTO commit_index(repo_id, commit_bytea, committed_at, debug_field) VALUE
 
 const getCommitIndexMetadataStr = `
 -- source: enterprise/internal/insights/compression/commits.go:GetMetadata
-SELECT repo_id, enabled, last_indexed_at FROM commit_index_metadata, (select min(committed_at) from commit_index where repo_id = %1) as oldest_indexed_at
-WHERE repo_id = $1;
+SELECT repo_id, enabled, last_indexed_at, (select min(committed_at) from commit_index where repo_id = %s) oldest_indexed_at
+FROM commit_index_metadata
+WHERE repo_id = %s;
 `
 
 const upsertCommitIndexMetadataStampStr = `

--- a/enterprise/internal/insights/compression/compression.go
+++ b/enterprise/internal/insights/compression/compression.go
@@ -97,6 +97,12 @@ func (c *CommitFilter) FilterFrames(ctx context.Context, frames []types.Frame, i
 		log15.Error("unable to retrieve commit index metadata", "repo_id", id, "error", err)
 		return uncompressedPlan(frames)
 	}
+	if metadata.OldestIndexedAt == nil {
+		// The index has no commits for this repository. Therefore, we cannot apply any compression, and will need to
+		// query for each data point.
+		log15.Debug("skipping insights compression due to empty index", "repo_id", id)
+		return uncompressedPlan(frames)
+	}
 
 	// The first frame will always be included to establish a baseline measurement. This is important because
 	// it is possible that the commit index will report zero commits because they may have happened beyond the
@@ -108,6 +114,7 @@ func (c *CommitFilter) FilterFrames(ctx context.Context, frames []types.Frame, i
 		if metadata.LastIndexedAt.Before(frame.To) || metadata.OldestIndexedAt.After(frame.From) {
 			// The commit indexer is not up to date enough to understand if this frame can be dropped,
 			// or the index doesn't contain enough history to be able to compress this frame
+			log15.Debug("cannot compress frame - missing history", "from", frame.From, "to", frame.To, "repo_id", id)
 			addToPlan(frame, "")
 			continue
 		}

--- a/enterprise/internal/insights/compression/compression.go
+++ b/enterprise/internal/insights/compression/compression.go
@@ -105,8 +105,9 @@ func (c *CommitFilter) FilterFrames(ctx context.Context, frames []types.Frame, i
 	for i := 1; i < len(frames); i++ {
 		previous := frames[i-1]
 		frame := frames[i]
-		if metadata.LastIndexedAt.Before(frame.To) {
-			// The commit indexer is not up to date enough to understand if this frame can be dropped
+		if metadata.LastIndexedAt.Before(frame.To) || metadata.OldestIndexedAt.After(frame.From) {
+			// The commit indexer is not up to date enough to understand if this frame can be dropped,
+			// or the index doesn't contain enough history to be able to compress this frame
 			addToPlan(frame, "")
 			continue
 		}

--- a/enterprise/internal/insights/compression/testdata/TestFilterFrames/test_no_commits_two_frames.golden
+++ b/enterprise/internal/insights/compression/testdata/TestFilterFrames/test_no_commits_two_frames.golden
@@ -1,9 +1,11 @@
 compression.BackfillPlan{
 	Executions: []*compression.QueryExecution{
-		{RecordingTime: time.Time{
-			ext: 63713433600,
-		}},
-		{RecordingTime: time.Time{ext: 63713434100}},
+		{
+			RecordingTime: time.Time{
+				ext: 63713433600,
+			},
+			SharedRecordings: []time.Time{{ext: 63713434100}},
+		},
 	},
 	RecordCount: 2,
 }


### PR DESCRIPTION
Fixes #30434

In our compression logic we assumed that the index would always include enough history to evaluate each commit from oldest to youngest. In 3.35 we enabled editable series intervals for all repos series, which allows them to extend beyond the horizon of the index history. This PR adds some logic to ensure that we are only compressing commits within the range of the index.