### PR TITLE
add a minimal amount of tracing to search jobs

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1536,11 +1536,12 @@ func searchResultsToFileNodes(matches []result.Match) ([]query.Node, error) {
 // is exceeded, returns a search alert with a did-you-mean link for the same
 // query with a longer timeout.
 func (r *searchResolver) evaluateJob(ctx context.Context, job run.Job) (_ *SearchResults, err error) {
-	tr, ctx := trace.New(ctx, "evaluateRoutine", "")
+	tr, ctx := trace.New(ctx, "evaluateJob", "")
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
 	}()
+	tr.LazyPrintf("job name: %s", job.Name())
 
 	start := time.Now()
 	rr, err := doResults(ctx, r.SearchInputs, r.db, r.stream, job)

--- a/internal/search/commit/commit_new.go
+++ b/internal/search/commit/commit_new.go
@@ -19,6 +19,7 @@ import (
 	searchrepos "github.com/sourcegraph/sourcegraph/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -32,7 +33,13 @@ type CommitSearch struct {
 	IncludeModifiedFiles bool
 }
 
-func (j *CommitSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) error {
+func (j *CommitSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (err error) {
+	tr, ctx := trace.New(ctx, "CommitSearch", "")
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
+
 	if err := j.ExpandUsernames(ctx, db); err != nil {
 		return err
 	}
@@ -49,7 +56,7 @@ func (j *CommitSearch) Run(ctx context.Context, db database.DB, stream streaming
 
 	var repoRevs []*search.RepositoryRevisions
 	repos := searchrepos.Resolver{DB: db, Opts: j.RepoOpts}
-	err := repos.Paginate(ctx, &opts, func(page *searchrepos.Resolved) error {
+	err = repos.Paginate(ctx, &opts, func(page *searchrepos.Resolved) error {
 		if repoRevs = page.RepoRevs; page.Next != nil {
 			return newReposLimitError(opts.Limit, j.HasTimeFilter, resultType)
 		}

--- a/internal/search/repos/excluded_job.go
+++ b/internal/search/repos/excluded_job.go
@@ -14,7 +14,7 @@ type ComputeExcludedRepos struct {
 }
 
 func (c *ComputeExcludedRepos) Run(ctx context.Context, db database.DB, s streaming.Sender) (err error) {
-	tr, ctx := trace.New(ctx, "RepoUniverseTextSearch", "")
+	tr, ctx := trace.New(ctx, "ComputeExcludedRepos", "")
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()

--- a/internal/search/repos/excluded_job.go
+++ b/internal/search/repos/excluded_job.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
 type ComputeExcludedRepos struct {
@@ -13,6 +14,12 @@ type ComputeExcludedRepos struct {
 }
 
 func (c *ComputeExcludedRepos) Run(ctx context.Context, db database.DB, s streaming.Sender) (err error) {
+	tr, ctx := trace.New(ctx, "RepoUniverseTextSearch", "")
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
+
 	repositoryResolver := Resolver{DB: db}
 	excluded, err := repositoryResolver.Excluded(ctx, c.Options)
 	if err != nil {

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -419,7 +419,13 @@ type RepoSubsetSymbolSearch struct {
 	RepoOpts          search.RepoOptions
 }
 
-func (s *RepoSubsetSymbolSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) error {
+func (s *RepoSubsetSymbolSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (err error) {
+	tr, ctx := trace.New(ctx, "RepoSubsetSymbolSearch", "")
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
+
 	repos := searchrepos.Resolver{DB: db, Opts: s.RepoOpts}
 	return repos.Paginate(ctx, nil, func(page *searchrepos.Resolved) error {
 		request, ok, err := zoektutil.OnlyUnindexed(page.RepoRevs, s.ZoektArgs.Zoekt, s.UseIndex, s.ContainsRefGlobs, s.OnMissingRepoRevs)
@@ -451,7 +457,13 @@ type RepoUniverseSymbolSearch struct {
 	RepoOptions search.RepoOptions
 }
 
-func (s *RepoUniverseSymbolSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) error {
+func (s *RepoUniverseSymbolSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (err error) {
+	tr, ctx := trace.New(ctx, "RepoUniverseSymbolSearch", "")
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
+
 	userID := int32(0)
 
 	if envvar.SourcegraphDotComMode() {

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -317,7 +317,13 @@ type RepoSubsetTextSearch struct {
 	RepoOpts search.RepoOptions
 }
 
-func (t *RepoSubsetTextSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) error {
+func (t *RepoSubsetTextSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (err error) {
+	tr, ctx := trace.New(ctx, "RepoSubsetTextSearch", "")
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
+
 	repos := &searchrepos.Resolver{DB: db, Opts: t.RepoOpts}
 	return repos.Paginate(ctx, nil, func(page *searchrepos.Resolved) error {
 		request, ok, err := zoektutil.OnlyUnindexed(page.RepoRevs, t.ZoektArgs.Zoekt, t.UseIndex, t.ContainsRefGlobs, t.OnMissingRepoRevs)
@@ -348,7 +354,13 @@ type RepoUniverseTextSearch struct {
 	UserID      int32
 }
 
-func (t *RepoUniverseTextSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) error {
+func (t *RepoUniverseTextSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (err error) {
+	tr, ctx := trace.New(ctx, "RepoUniverseTextSearch", "")
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
+
 	userID := int32(0)
 
 	if envvar.SourcegraphDotComMode() {


### PR DESCRIPTION
Search jobs are the best representation of our structure we have at this
point, but they are not represented in the traces. This adds some
minimal tracing to the top of each of the search jobs so they show up in
traces in the same structure they are defined. Also will be useful to
help debug a weird issue we're seeing in the k8s deployment.


Now our traces are much more tree-like:
<img width="480" alt="Screen Shot 2022-02-01 at 11 46 53" src="https://user-images.githubusercontent.com/12631702/152031385-04bd3a13-7386-4db9-b048-ac3e9c201cca.png">

I would not consider this fully instrumented, but it is good enough to help debug for the moment.