### PR TITLE
add code-insights to the license tags

### DIFF
--- a/enterprise/internal/licensing/data.go
+++ b/enterprise/internal/licensing/data.go
@@ -54,6 +54,9 @@ const (
 	// FeatureBackupAndRestore is whether builtin backup and restore on this Sourcegraph instance
 	// has been purchased.
 	FeatureBackupAndRestore Feature = "backup-and-restore"
+
+	// FeatureCodeInsights is whether Code Insights on this Sourcegraph instance has been purchased.
+	FeatureCodeInsights Feature = "code-insights"
 )
 
 // planFeatures defines the features that are enabled for each plan.
@@ -68,6 +71,7 @@ var planFeatures = map[Plan][]Feature{
 		FeatureBatchChanges,
 		FeatureMonitoring,
 		FeatureBackupAndRestore,
+		FeatureCodeInsights,
 	},
 	team:       {},
 	enterprise: {},

--- a/enterprise/internal/licensing/features_test.go
+++ b/enterprise/internal/licensing/features_test.go
@@ -87,9 +87,27 @@ func TestCheckFeature(t *testing.T) {
 			check(t, feature, license(plan(enterprise), string(feature)), true)
 		}
 	}
+
 	// FeatureCampaigns is deprecated but should behave like BatchChanges.
 	t.Run(string(FeatureCampaigns), testBatchChanges(FeatureCampaigns))
 	t.Run(string(FeatureBatchChanges), testBatchChanges(FeatureBatchChanges))
+
+	testCodeInsights := func(feature Feature) func(*testing.T) {
+		return func(t *testing.T) {
+			check(t, feature, nil, false)
+
+			check(t, feature, license("starter"), false)
+			check(t, feature, license(plan(oldEnterpriseStarter)), false)
+			check(t, feature, license(plan(oldEnterprise)), true)
+			check(t, feature, license(), true)
+
+			check(t, feature, license(plan(team)), false)
+			check(t, feature, license(plan(enterprise)), false)
+			check(t, feature, license(plan(enterprise), string(feature)), true)
+		}
+	}
+	// Code Insights
+	t.Run(string(FeatureCodeInsights), testCodeInsights(FeatureCodeInsights))
 
 	t.Run(string(FeatureMonitoring), func(t *testing.T) {
 		check(t, FeatureMonitoring, nil, false)


### PR DESCRIPTION
Closes #30417

Adding the `code-insights` license tag to the backend.

Tested locally by running in dot-com mode, and generating a license:
<img width="911" alt="CleanShot 2022-02-01 at 13 49 52@2x" src="https://user-images.githubusercontent.com/5090588/152051099-b11d7866-b1ba-4290-afcd-3d53b8db6265.png">

