### PR TITLE
migrations: Extract `IndexStatus` into `storetypes` package

### DIFF
--- a/internal/database/migration/store/store_test.go
+++ b/internal/database/migration/store/store_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/definition"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/storetypes"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
@@ -636,8 +637,8 @@ func TestIndexStatus(t *testing.T) {
 	// sessions holding advisory locks. We may happen to hit one of the earlier phases
 	// if we're quick enough, so we'll keep polling progress until we hit the target.
 	blockingPhase := "waiting for old snapshots"
-	nonblockingPhasePrefixes := make([]string, 0, len(CreateIndexConcurrentlyPhases))
-	for _, prefix := range CreateIndexConcurrentlyPhases {
+	nonblockingPhasePrefixes := make([]string, 0, len(storetypes.CreateIndexConcurrentlyPhases))
+	for _, prefix := range storetypes.CreateIndexConcurrentlyPhases {
 		if prefix == blockingPhase {
 			break
 		}

--- a/internal/database/migration/storetypes/index_progress.go
+++ b/internal/database/migration/storetypes/index_progress.go
@@ -1,0 +1,40 @@
+package storetypes
+
+// IndexStatus describes the state of an index. Is{Valid,Ready,Live} is taken
+// from the `pg_index` system table. If the index is currently being created,
+// then the remaining reference fields will be populated describing the index
+// creation progress.
+type IndexStatus struct {
+	IsValid      bool
+	IsReady      bool
+	IsLive       bool
+	Phase        *string
+	LockersDone  *int
+	LockersTotal *int
+	BlocksDone   *int
+	BlocksTotal  *int
+	TuplesDone   *int
+	TuplesTotal  *int
+}
+
+// CreateIndexConcurrentlyPhases is an ordered list of phases that occur during
+// a CREATE INDEX CONCURRENTLY operation. The phase of an ongoing operation can
+// found in the system view `view pg_stat_progress_create_index` (since PG 12).
+//
+// If the phase value found in the system view may not match these values exactly
+// and may only indicate a prefix. The phase may have more specific information
+// following the initial phase description. Do not compare phase values exactly.
+//
+// See https://www.postgresql.org/docs/12/progress-reporting.html#CREATE-INDEX-PROGRESS-REPORTING.
+var CreateIndexConcurrentlyPhases = []string{
+	"initializing",
+	"waiting for writers before build",
+	"building index",
+	"waiting for writers before validation",
+	"index validation: scanning index",
+	"index validation: sorting tuples",
+	"index validation: scanning table",
+	"waiting for old snapshots",
+	"waiting for readers before marking dead",
+	"waiting for readers before dropping",
+}


### PR DESCRIPTION
Pulled from #29831. This PR moves `IndexStatus` into a common package to be importable by `runner`. We can't import `store` from `runner` without cycles.