### PR TITLE
migrations: Backfill `migration_logs` content on startup if empty

### DIFF
--- a/internal/database/migration/store/store.go
+++ b/internal/database/migration/store/store.go
@@ -119,7 +119,7 @@ func (s *Store) EnsureSchemaTable(ctx context.Context) (err error) {
 		"schema_migrations":              1528395834,
 		"codeintel_schema_migrations":    1000000015,
 		"codeinsights_schema_migrations": 1000000000,
-		"test_migrations_table2":         1000000000, // TODO - do better
+		"test_migrations_table_backfill": 1000000000, // used in tests
 	}
 	if minMigrationVersion, ok := minMigrationVersions[s.schemaName]; ok {
 		queries = append(queries, sqlf.Sprintf(`

--- a/internal/database/migration/store/store.go
+++ b/internal/database/migration/store/store.go
@@ -95,7 +95,7 @@ const currentMigrationLogSchemaVersion = 1
 
 // EnsureSchemaTable creates the bookeeping tables required to track this schema
 // if they do not already exist. If old versions of the tables exist, this method
-// will attempt to update them in a backwards-compataible manner.
+// will attempt to update them in a backward-compatible manner.
 func (s *Store) EnsureSchemaTable(ctx context.Context) (err error) {
 	ctx, endObservation := s.operations.ensureSchemaTable.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})

--- a/internal/database/migration/store/store_test.go
+++ b/internal/database/migration/store/store_test.go
@@ -23,29 +23,122 @@ func TestEnsureSchemaTable(t *testing.T) {
 	store := testStore(db)
 	ctx := context.Background()
 
-	if err := store.Exec(ctx, sqlf.Sprintf("SELECT * FROM test_migrations_table")); err == nil {
-		t.Fatalf("expected query to fail due to missing schema table")
+	tableNames := []string{
+		"migration_logs",
+		"test_migrations_table",
 	}
 
-	if err := store.Exec(ctx, sqlf.Sprintf("SELECT * FROM migration_logs")); err == nil {
-		t.Fatalf("expected query to fail due to missing logs table")
+	// Test initially missing tables
+	for _, tableName := range tableNames {
+		if err := store.Exec(ctx, sqlf.Sprintf("SELECT * FROM %s", quote(tableName))); err == nil {
+			t.Fatalf("expected query to fail due to missing table %q", tableName)
+		}
 	}
 
 	if err := store.EnsureSchemaTable(ctx); err != nil {
 		t.Fatalf("unexpected error ensuring schema table exists: %s", err)
 	}
 
-	if err := store.Exec(ctx, sqlf.Sprintf("SELECT * FROM test_migrations_table")); err != nil {
-		t.Fatalf("unexpected error querying version table: %s", err)
+	// Test tables were created
+	for _, tableName := range tableNames {
+		if err := store.Exec(ctx, sqlf.Sprintf("SELECT * FROM %s", quote(tableName))); err != nil {
+			t.Fatalf("unexpected error querying %q: %s", tableName, err)
+		}
 	}
 
-	if err := store.Exec(ctx, sqlf.Sprintf("SELECT * FROM migration_logs")); err != nil {
-		t.Fatalf("unexpected error querying logs table: %s", err)
-	}
-
+	// Test idempotency
 	if err := store.EnsureSchemaTable(ctx); err != nil {
 		t.Fatalf("expected method to be idempotent, got error: %s", err)
 	}
+}
+
+func TestEnsureTableBackfills(t *testing.T) {
+	t.Run("fresh database", func(t *testing.T) {
+		db := dbtest.NewDB(t)
+		store := testStore(db)
+		ctx := context.Background()
+
+		if err := store.EnsureSchemaTable(ctx); err != nil {
+			t.Fatalf("unexpected error ensuring schema table exists: %s", err)
+		}
+
+		assertLogs(t, ctx, store, nil)
+	})
+
+	k := 5
+	n := k * 5
+	expectedLogs := make([]migrationLog, 0, n)
+	for i := 0; i <= n; i++ {
+		s := true
+		expectedLogs = append(expectedLogs, migrationLog{Schema: "test_migrations_table2", Version: 1000000000 + i, Up: true, Success: &s})
+	}
+
+	runTest := func(k int) func(t *testing.T) {
+		return func(t *testing.T) {
+			db := dbtest.NewDB(t)
+			store := NewWithDB(db, "test_migrations_table2", NewOperations(&observation.TestContext))
+			ctx := context.Background()
+
+			if err := store.Exec(ctx, sqlf.Sprintf(`CREATE TABLE test_migrations_table2(version bigint NOT NULL PRIMARY KEY, dirty boolean NOT NULL)`)); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if err := store.Exec(ctx, sqlf.Sprintf(`INSERT INTO test_migrations_table2 VALUES (%s, false)`, 1000000000+n)); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if err := store.Exec(ctx, sqlf.Sprintf(`
+				CREATE TABLE migration_logs(
+					id SERIAL PRIMARY KEY,
+					migration_logs_schema_version integer NOT NULL,
+					schema text NOT NULL,
+					version integer NOT NULL,
+					up bool NOT NULL,
+					started_at timestamptz NOT NULL,
+					finished_at timestamptz,
+					success boolean,
+					error_message text
+				)
+			`)); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			for i := 0; i < k; i++ {
+				if err := store.Exec(ctx, sqlf.Sprintf(`
+				INSERT INTO migration_logs(
+					migration_logs_schema_version,
+					schema,
+					version,
+					up,
+					started_at,
+					finished_at,
+					success
+				) VALUES (
+					1,
+					%s,
+					%s,
+					true,
+					NOW(),
+					NOW(),
+					true
+				)`,
+					"test_migrations_table2",
+					1000000000+n-i,
+				)); err != nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+			}
+
+			if err := store.EnsureSchemaTable(ctx); err != nil {
+				t.Fatalf("unexpected error ensuring schema table exists: %s", err)
+			}
+
+			assertLogs(t, ctx, store, expectedLogs)
+		}
+	}
+
+	t.Run("full insert", runTest(0))       // no migration logs
+	t.Run("partial insert", runTest(k))    // k migration logs
+	t.Run("nothing to insert", runTest(n)) // n migration logs
 }
 
 func TestVersion(t *testing.T) {
@@ -717,7 +810,7 @@ func truncateLogs(t *testing.T, ctx context.Context, store *Store) {
 func assertLogs(t *testing.T, ctx context.Context, store *Store, expectedLogs []migrationLog) {
 	t.Helper()
 
-	logs, err := scanMigrationLogs(store.Query(ctx, sqlf.Sprintf(`SELECT schema, version, up, success FROM migration_logs ORDER BY started_at`)))
+	logs, err := scanMigrationLogs(store.Query(ctx, sqlf.Sprintf(`SELECT schema, version, up, success FROM migration_logs ORDER BY version`)))
 	if err != nil {
 		t.Fatalf("unexpected error scanning logs: %s", err)
 	}


### PR DESCRIPTION
Pulled from #29831. This PR adds an attempt to create an initial `migration_logs` content from a `*schema_migrations` table on startup.