### PR TITLE
migrations: Update memoryStore methods (for tests)

### DIFF
--- a/internal/database/connections/test/store.go
+++ b/internal/database/connections/test/store.go
@@ -10,13 +10,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/runner"
 )
 
-// memoryStore implements runner.Store but writes to migration metadata to any
-// underlying persistence layer.
+// memoryStore implements runner.Store but writes to migration metadata are
+// not passed to any underlying persistence layer.
 type memoryStore struct {
-	db         *sql.DB
-	version    int
-	versionSet bool
-	dirty      bool
+	db              *sql.DB
+	appliedVersions []int
+	pendingVersions []int
+	failedVersions  []int
 }
 
 func newMemoryStore(db *sql.DB) runner.Store {
@@ -34,7 +34,15 @@ func (s *memoryStore) Done(err error) error {
 }
 
 func (s *memoryStore) Version(ctx context.Context) (int, bool, bool, error) {
-	return s.version, s.dirty, s.versionSet, nil
+	if n := len(s.appliedVersions); n > 0 {
+		return s.pendingVersions[n-1], len(s.pendingVersions)+len(s.failedVersions) > 0, true, nil
+	}
+
+	return 0, false, false, nil
+}
+
+func (s *memoryStore) Versions(ctx context.Context) (appliedVersions, pendingVersions, failedVersions []int, _ error) {
+	return s.appliedVersions, s.pendingVersions, s.failedVersions, nil
 }
 
 func (s *memoryStore) Lock(ctx context.Context) (bool, func(err error) error, error) {
@@ -59,6 +67,11 @@ func (s *memoryStore) WithMigrationLog(_ context.Context, _ definition.Definitio
 
 func (s *memoryStore) exec(ctx context.Context, migration definition.Definition, query *sqlf.Query) error {
 	_, err := s.db.ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
-	s.version, s.dirty, s.versionSet = migration.ID, s.dirty || err != nil, true
-	return err
+	if err != nil {
+		s.failedVersions = append(s.failedVersions, migration.ID)
+		return err
+	}
+
+	s.appliedVersions = append(s.appliedVersions, migration.ID)
+	return nil
 }

--- a/internal/database/connections/test/store.go
+++ b/internal/database/connections/test/store.go
@@ -35,7 +35,7 @@ func (s *memoryStore) Done(err error) error {
 
 func (s *memoryStore) Version(ctx context.Context) (int, bool, bool, error) {
 	if n := len(s.appliedVersions); n > 0 {
-		return s.pendingVersions[n-1], len(s.pendingVersions)+len(s.failedVersions) > 0, true, nil
+		return s.appliedVersions[n-1], len(s.pendingVersions)+len(s.failedVersions) > 0, true, nil
 	}
 
 	return 0, false, false, nil


### PR DESCRIPTION
Pulled from #29831. This PR updates the memoryStore used in tests touching the database to more accurately reflect the migration `Store` interface.