### PR TITLE
migrations: Remove validation from store on migration application

### DIFF
--- a/internal/database/migration/store/store.go
+++ b/internal/database/migration/store/store.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/cockroachdb/errors"
 	"github.com/hashicorp/go-multierror"
 	"github.com/keegancsmith/sqlf"
 	"github.com/opentracing/opentracing-go/log"
@@ -322,15 +321,7 @@ func (s *Store) WithMigrationLog(ctx context.Context, definition definition.Defi
 	ctx, endObservation := s.operations.withMigrationLog.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	definitionVersion := definition.ID
-	targetVersion := definitionVersion
-	expectedCurrentVersion := definitionVersion - 1
-	if !up {
-		targetVersion = definitionVersion - 1
-		expectedCurrentVersion = definitionVersion
-	}
-
-	logID, err := s.createMigrationLog(ctx, up, expectedCurrentVersion, targetVersion, definitionVersion)
+	logID, err := s.createMigrationLog(ctx, definition.ID, up)
 	if err != nil {
 		return err
 	}
@@ -358,32 +349,17 @@ func (s *Store) WithMigrationLog(ctx context.Context, definition definition.Defi
 	return nil
 }
 
-func (s *Store) createMigrationLog(ctx context.Context, up bool, expectedCurrentVersion, targetVersion, sourceVersion int) (_ int, err error) {
+func (s *Store) createMigrationLog(ctx context.Context, definitionVersion int, up bool) (_ int, err error) {
 	tx, err := s.Transact(ctx)
 	if err != nil {
 		return 0, err
 	}
 	defer func() { err = tx.Done(err) }()
 
-	assertionFailure := func(description string, args ...interface{}) error {
-		cta := "This condition should not be reachable by normal use of the migration store via the runner and indicates a bug. Please report this issue."
-		return errors.Errorf(description+"\n\n"+cta+"\n", args...)
-	}
-	if currentVersion, dirty, ok, err := tx.Version(ctx); err != nil {
+	if err := tx.Exec(ctx, sqlf.Sprintf(`DELETE FROM %s`, quote(s.schemaName))); err != nil {
 		return 0, err
-	} else if dirty {
-		return 0, assertionFailure("dirty database")
-	} else if ok {
-		if currentVersion != expectedCurrentVersion {
-			return 0, assertionFailure("expected schema to have version %d, but has version %d\n", expectedCurrentVersion, currentVersion)
-		}
-
-		if err := tx.Exec(ctx, sqlf.Sprintf(`DELETE FROM %s`, quote(s.schemaName))); err != nil {
-			return 0, err
-		}
 	}
-
-	if err := tx.Exec(ctx, sqlf.Sprintf(`INSERT INTO %s (version, dirty) VALUES (%s, true)`, quote(s.schemaName), targetVersion)); err != nil {
+	if err := tx.Exec(ctx, sqlf.Sprintf(`INSERT INTO %s (version, dirty) VALUES (%s, true)`, quote(s.schemaName), definitionVersion)); err != nil {
 		return 0, err
 	}
 
@@ -400,7 +376,7 @@ func (s *Store) createMigrationLog(ctx context.Context, up bool, expectedCurrent
 		`,
 		currentMigrationLogSchemaVersion,
 		s.schemaName,
-		sourceVersion,
+		definitionVersion,
 		up,
 	)))
 	if err != nil {

--- a/internal/database/migration/store/store_test.go
+++ b/internal/database/migration/store/store_test.go
@@ -250,6 +250,40 @@ func TestWrappedUp(t *testing.T) {
 		t.Fatalf("unexpected error setting initial version: %s", err)
 	}
 
+	// Seed a few migrations
+	for _, id := range []int{13, 14, 15} {
+		definition := definition.Definition{
+			ID:      id,
+			UpQuery: sqlf.Sprintf(`-- No-op`),
+		}
+		f := func() error {
+			return store.Up(ctx, definition)
+		}
+		if err := store.WithMigrationLog(ctx, definition, true, f); err != nil {
+			t.Fatalf("unexpected error running migration: %s", err)
+		}
+	}
+
+	logs := []migrationLog{
+		{
+			Schema:  "test_migrations_table",
+			Version: 13,
+			Up:      true,
+			Success: boolPtr(true),
+		},
+		{
+			Schema:  "test_migrations_table",
+			Version: 14,
+			Up:      true,
+			Success: boolPtr(true),
+		}, {
+			Schema:  "test_migrations_table",
+			Version: 15,
+			Up:      true,
+			Success: boolPtr(true),
+		},
+	}
+
 	t.Run("success", func(t *testing.T) {
 		definition := definition.Definition{
 			ID: 16,
@@ -260,7 +294,6 @@ func TestWrappedUp(t *testing.T) {
 					seed_type text,
 					bark_type text
 				);
-
 				INSERT INTO test_trees VALUES
 					('oak', 'broad', 'regular', 'strong'),
 					('birch', 'narrow', 'regular', 'flaky'),
@@ -280,21 +313,14 @@ func TestWrappedUp(t *testing.T) {
 			t.Fatalf("migration query did not succeed; unexpected bark type. want=%s have=%s", "flaky", barkType)
 		}
 
-		// Version set to migration ID; not dirty
-		if version, dirty, ok, err := store.Version(ctx); err != nil || !ok || dirty || version != 16 {
-			t.Fatalf("unexpected version. want=(version=%d, dirty=%v), have=(version=%d, dirty=%v, ok=%v, error=%q)", 16, false, version, dirty, ok, err)
-		}
-
-		assertLogs(t, ctx, store, []migrationLog{
-			{
-				Schema:  "test_migrations_table",
-				Version: 16,
-				Up:      true,
-				Success: boolPtr(true),
-			},
+		logs = append(logs, migrationLog{
+			Schema:  "test_migrations_table",
+			Version: 16,
+			Up:      true,
+			Success: boolPtr(true),
 		})
-		assertVersions(t, ctx, store, []int{16}, nil, nil)
-		truncateLogs(t, ctx, store)
+		assertLogs(t, ctx, store, logs)
+		assertVersions(t, ctx, store, []int{13, 14, 15, 16}, nil, nil)
 	})
 
 	t.Run("query failure", func(t *testing.T) {
@@ -315,25 +341,18 @@ func TestWrappedUp(t *testing.T) {
 		f := func() error {
 			return store.Up(ctx, definition)
 		}
-		if err := store.WithMigrationLog(ctx, definition, true, f); err == nil || !strings.HasPrefix(err.Error(), expectedErrorMessage) {
+		if err := store.WithMigrationLog(ctx, definition, true, f); err == nil || !strings.Contains(err.Error(), expectedErrorMessage) {
 			t.Fatalf("unexpected error want=%q have=%q", expectedErrorMessage, err)
 		}
 
-		// Version set to migration ID; dirty
-		if version, dirty, ok, err := store.Version(ctx); err != nil || !ok || !dirty || version != 17 {
-			t.Fatalf("unexpected version. want=(version=%d, dirty=%v), have=(version=%d, dirty=%v, ok=%v, error=%q)", 17, true, version, dirty, ok, err)
-		}
-
-		assertLogs(t, ctx, store, []migrationLog{
-			{
-				Schema:  "test_migrations_table",
-				Version: 17,
-				Up:      true,
-				Success: boolPtr(false),
-			},
+		logs = append(logs, migrationLog{
+			Schema:  "test_migrations_table",
+			Version: 17,
+			Up:      true,
+			Success: boolPtr(false),
 		})
-		assertVersions(t, ctx, store, nil, nil, []int{17})
-		truncateLogs(t, ctx, store)
+		assertLogs(t, ctx, store, logs)
+		assertVersions(t, ctx, store, []int{13, 14, 15, 16}, nil, []int{17})
 	})
 }
 
@@ -374,6 +393,41 @@ func TestWrappedDown(t *testing.T) {
 		t.Fatalf("unexpected error inserting into test table: %s", err)
 	}
 
+	// Seed a few migrations
+	for _, id := range []int{12, 13, 14} {
+		definition := definition.Definition{
+			ID:      id,
+			UpQuery: sqlf.Sprintf(`-- No-op`),
+		}
+		f := func() error {
+			return store.Up(ctx, definition)
+		}
+		if err := store.WithMigrationLog(ctx, definition, true, f); err != nil {
+			t.Fatalf("unexpected error running migration: %s", err)
+		}
+	}
+
+	logs := []migrationLog{
+		{
+			Schema:  "test_migrations_table",
+			Version: 12,
+			Up:      true,
+			Success: boolPtr(true),
+		},
+		{
+			Schema:  "test_migrations_table",
+			Version: 13,
+			Up:      true,
+			Success: boolPtr(true),
+		},
+		{
+			Schema:  "test_migrations_table",
+			Version: 14,
+			Up:      true,
+			Success: boolPtr(true),
+		},
+	}
+
 	t.Run("success", func(t *testing.T) {
 		definition := definition.Definition{
 			ID: 14,
@@ -389,25 +443,18 @@ func TestWrappedDown(t *testing.T) {
 		}
 
 		// note: this query succeeded twice earlier
-		if err := store.Exec(ctx, testQuery); err == nil || !strings.HasPrefix(err.Error(), "SQL Error") {
+		if err := store.Exec(ctx, testQuery); err == nil || !strings.Contains(err.Error(), "SQL Error") {
 			t.Fatalf("migration query did not succeed; expected missing table. want=%q have=%q", "SQL Error", err)
 		}
 
-		// Version set to migration ID; not dirty
-		if version, dirty, ok, err := store.Version(ctx); err != nil || !ok || dirty || version != 13 {
-			t.Fatalf("unexpected version. want=(version=%d, dirty=%v), have=(version=%d, dirty=%v, ok=%v, error=%q)", 13, false, version, dirty, ok, err)
-		}
-
-		assertLogs(t, ctx, store, []migrationLog{
-			{
-				Schema:  "test_migrations_table",
-				Version: 14,
-				Up:      false,
-				Success: boolPtr(true),
-			},
+		logs = append(logs, migrationLog{
+			Schema:  "test_migrations_table",
+			Version: 14,
+			Up:      false,
+			Success: boolPtr(true),
 		})
-		assertVersions(t, ctx, store, nil, nil, nil)
-		truncateLogs(t, ctx, store)
+		assertLogs(t, ctx, store, logs)
+		assertVersions(t, ctx, store, []int{12, 13}, nil, nil)
 	})
 
 	t.Run("query failure", func(t *testing.T) {
@@ -423,25 +470,18 @@ func TestWrappedDown(t *testing.T) {
 		f := func() error {
 			return store.Down(ctx, definition)
 		}
-		if err := store.WithMigrationLog(ctx, definition, false, f); err == nil || !strings.HasPrefix(err.Error(), expectedErrorMessage) {
+		if err := store.WithMigrationLog(ctx, definition, false, f); err == nil || !strings.Contains(err.Error(), expectedErrorMessage) {
 			t.Fatalf("unexpected error want=%q have=%q", expectedErrorMessage, err)
 		}
 
-		// Version set to migration ID; dirty
-		if version, dirty, ok, err := store.Version(ctx); err != nil || !ok || !dirty || version != 12 {
-			t.Fatalf("unexpected version. want=(version=%d, dirty=%v), have=(version=%d, dirty=%v, ok=%v, error=%q)", 12, true, version, dirty, ok, err)
-		}
-
-		assertLogs(t, ctx, store, []migrationLog{
-			{
-				Schema:  "test_migrations_table",
-				Version: 13,
-				Up:      false,
-				Success: boolPtr(false),
-			},
+		logs = append(logs, migrationLog{
+			Schema:  "test_migrations_table",
+			Version: 13,
+			Up:      false,
+			Success: boolPtr(false),
 		})
-		assertVersions(t, ctx, store, nil, nil, []int{13})
-		truncateLogs(t, ctx, store)
+		assertLogs(t, ctx, store, logs)
+		assertVersions(t, ctx, store, []int{12}, nil, []int{13})
 	})
 }
 

--- a/internal/database/migration/store/store_test.go
+++ b/internal/database/migration/store/store_test.go
@@ -297,30 +297,6 @@ func TestWrappedUp(t *testing.T) {
 		truncateLogs(t, ctx, store)
 	})
 
-	t.Run("unexpected version", func(t *testing.T) {
-		expectedErrorMessage := "expected schema to have version 17, but has version 16"
-
-		definition := definition.Definition{
-			ID: 18,
-			UpQuery: sqlf.Sprintf(`
-				-- Does not actually run
-			`),
-		}
-		f := func() error {
-			return store.Up(ctx, definition)
-		}
-		if err := store.WithMigrationLog(ctx, definition, true, f); err == nil || !strings.HasPrefix(err.Error(), expectedErrorMessage) {
-			t.Fatalf("unexpected error want=%q have=%q", expectedErrorMessage, err)
-		}
-
-		// Version, dirty status unchanged
-		if version, dirty, ok, err := store.Version(ctx); err != nil || !ok || dirty || version != 16 {
-			t.Fatalf("unexpected version. want=(version=%d, dirty=%v), have=(version=%d, dirty=%v, ok=%v, error=%q)", 16, false, version, dirty, ok, err)
-		}
-
-		assertLogs(t, ctx, store, nil)
-	})
-
 	t.Run("query failure", func(t *testing.T) {
 		expectedErrorMessage := "SQL Error"
 
@@ -358,30 +334,6 @@ func TestWrappedUp(t *testing.T) {
 		})
 		assertVersions(t, ctx, store, nil, nil, []int{17})
 		truncateLogs(t, ctx, store)
-	})
-
-	t.Run("dirty", func(t *testing.T) {
-		expectedErrorMessage := "dirty database"
-
-		definition := definition.Definition{
-			ID: 17,
-			UpQuery: sqlf.Sprintf(`
-				-- Does not actually run
-			`),
-		}
-		f := func() error {
-			return store.Up(ctx, definition)
-		}
-		if err := store.WithMigrationLog(ctx, definition, true, f); err == nil || !strings.HasPrefix(err.Error(), expectedErrorMessage) {
-			t.Fatalf("unexpected error want=%q have=%q", expectedErrorMessage, err)
-		}
-
-		// Version, dirty status unchanged
-		if version, dirty, ok, err := store.Version(ctx); err != nil || !ok || !dirty || version != 17 {
-			t.Fatalf("unexpected version. want=(version=%d, dirty=%v), have=(version=%d, dirty=%v, ok=%v, error=%q)", 17, true, version, dirty, ok, err)
-		}
-
-		assertLogs(t, ctx, store, nil)
 	})
 }
 
@@ -458,30 +410,6 @@ func TestWrappedDown(t *testing.T) {
 		truncateLogs(t, ctx, store)
 	})
 
-	t.Run("unexpected version", func(t *testing.T) {
-		expectedErrorMessage := "expected schema to have version 12, but has version 13"
-
-		definition := definition.Definition{
-			ID: 12,
-			DownQuery: sqlf.Sprintf(`
-				-- Does not actually run
-			`),
-		}
-		f := func() error {
-			return store.Down(ctx, definition)
-		}
-		if err := store.WithMigrationLog(ctx, definition, false, f); err == nil || !strings.HasPrefix(err.Error(), expectedErrorMessage) {
-			t.Fatalf("unexpected error want=%q have=%q", expectedErrorMessage, err)
-		}
-
-		// Version, dirty status unchanged
-		if version, dirty, ok, err := store.Version(ctx); err != nil || !ok || dirty || version != 13 {
-			t.Fatalf("unexpected version. want=(version=%d, dirty=%v), have=(version=%d, dirty=%v, ok=%v, error=%q)", 13, false, version, dirty, ok, err)
-		}
-
-		assertLogs(t, ctx, store, nil)
-	})
-
 	t.Run("query failure", func(t *testing.T) {
 		expectedErrorMessage := "SQL Error"
 
@@ -514,30 +442,6 @@ func TestWrappedDown(t *testing.T) {
 		})
 		assertVersions(t, ctx, store, nil, nil, []int{13})
 		truncateLogs(t, ctx, store)
-	})
-
-	t.Run("dirty", func(t *testing.T) {
-		expectedErrorMessage := "dirty database"
-
-		definition := definition.Definition{
-			ID: 12,
-			DownQuery: sqlf.Sprintf(`
-				-- Does not actually run
-			`),
-		}
-		f := func() error {
-			return store.Down(ctx, definition)
-		}
-		if err := store.WithMigrationLog(ctx, definition, false, f); err == nil || !strings.HasPrefix(err.Error(), expectedErrorMessage) {
-			t.Fatalf("unexpected error want=%q have=%q", expectedErrorMessage, err)
-		}
-
-		// Version, dirty status unchanged
-		if version, dirty, ok, err := store.Version(ctx); err != nil || !ok || !dirty || version != 12 {
-			t.Fatalf("unexpected version. want=(version=%d, dirty=%v), have=(version=%d, dirty=%v, ok=%v, error=%q)", 12, true, version, dirty, ok, err)
-		}
-
-		assertLogs(t, ctx, store, nil)
 	})
 }
 


### PR DESCRIPTION
Pulled from #29831. This PR removes the validation from the migration store that ensures we are applying the _correct_ next migration. Once we have multiple parents, there is no _next_ migration derivable from the previous version. This PR also updates the tests associated with up/down migration application behavior.