### PR TITLE
Tracing: fix span tagging and add LazyFields

### DIFF
--- a/internal/trace/traceutil.go
+++ b/internal/trace/traceutil.go
@@ -145,8 +145,9 @@ func (t *Trace) LogFields(fields ...log.Field) {
 // TagFields adds fields to the opentracing.Span as tags
 // as well as as logs to the nettrace.Trace.
 func (t *Trace) TagFields(fields ...log.Field) {
+	enc := spanTagEncoder{Span: t.span}
 	for _, field := range fields {
-		t.span.SetTag(field.Key(), field.Value())
+		field.Marshal(&enc)
 	}
 	t.trace.LazyLog(fieldsStringer(fields), false)
 }
@@ -225,6 +226,16 @@ func Printf(key, f string, args ...interface{}) log.Field {
 func Stringer(key string, v fmt.Stringer) log.Field {
 	return log.Lazy(func(fv log.Encoder) {
 		fv.EmitString(key, v.String())
+	})
+}
+
+// LazyFields is an opentracing log.Field that will only call the field-generating
+// function if the trace is collected.
+func LazyFields(lazyFields func() []log.Field) log.Field {
+	return log.Lazy(func(fv log.Encoder) {
+		for _, field := range lazyFields() {
+			field.Marshal(fv)
+		}
 	})
 }
 
@@ -309,5 +320,58 @@ func (e *encoder) EmitObject(key string, value interface{}) {
 }
 
 func (e *encoder) EmitLazyLogger(value log.LazyLogger) {
+	value(e)
+}
+
+// spanTagEncoder wraps the opentracing.Span.SetTags to write values
+// of type log.Field to span tags. The doc string of SetTags notes
+// that it only accepts strings, numeric types, and bools, so these
+// encoder methods convert to those types before writing the tag.
+type spanTagEncoder struct {
+	opentracing.Span
+}
+
+func (e *spanTagEncoder) EmitString(key, value string) {
+	e.SetTag(key, value)
+}
+
+func (e *spanTagEncoder) EmitBool(key string, value bool) {
+	e.SetTag(key, value)
+}
+
+func (e *spanTagEncoder) EmitInt(key string, value int) {
+	e.SetTag(key, value)
+}
+
+func (e *spanTagEncoder) EmitInt32(key string, value int32) {
+	e.SetTag(key, value)
+}
+
+func (e *spanTagEncoder) EmitInt64(key string, value int64) {
+	e.SetTag(key, value)
+}
+
+func (e *spanTagEncoder) EmitUint32(key string, value uint32) {
+	e.SetTag(key, value)
+}
+
+func (e *spanTagEncoder) EmitUint64(key string, value uint64) {
+	e.SetTag(key, value)
+}
+
+func (e *spanTagEncoder) EmitFloat32(key string, value float32) {
+	e.SetTag(key, value)
+}
+
+func (e *spanTagEncoder) EmitFloat64(key string, value float64) {
+	e.SetTag(key, value)
+}
+
+func (e *spanTagEncoder) EmitObject(key string, value interface{}) {
+	s := fmt.Sprintf("%#+v", value)
+	e.EmitString(key, s)
+}
+
+func (e *spanTagEncoder) EmitLazyLogger(value log.LazyLogger) {
 	value(e)
 }


### PR DESCRIPTION
This adds a couple things to our `trace` package to fix some issues I
was running into when trying to expand our instrumentation coverage in
the search package.
    
First, it adds a `LazyFields` function, which is like `log.Lazy` except
it takes a function that generates a set of fields to log. This is
convenient when you have a set of potentially-expensive-to-generate
fields that you want to log, or also if you have self-describing objects
(such as the example `CommitSearch.Tags()` method).
    
Second, it adds `spanTagEncoder`. This is a bug fix.
`opentracing.Span.SetTags` only accepts numeric types, strings, and
bools, so when we would try to set a tag to an object type or a lazy
field, it would just set a tag with the memory address of that object.

Proof that it works:
<img width="370" alt="Screen Shot 2022-02-01 at 15 52 30" src="https://user-images.githubusercontent.com/12631702/152065327-7a7de2af-b5ba-42dd-95a5-a4ae327af4ca.png">


Super not sure who to tag on this, so 👋 backend devs!
