### PR TITLE
executors: Add `X-Sourcegraph-Actor-UID: internal` to git fetch command

### DIFF
--- a/enterprise/cmd/executor/internal/worker/workspace.go
+++ b/enterprise/cmd/executor/internal/worker/workspace.go
@@ -47,7 +47,7 @@ func (h *handler) prepareWorkspace(ctx context.Context, commandRunner command.Ru
 
 		gitCommands := []command.CommandSpec{
 			{Key: "setup.git.init", Command: []string{"git", "-C", tempDir, "init"}, Operation: h.operations.SetupGitInit},
-			{Key: "setup.git.fetch", Command: []string{"git", "-C", tempDir, "-c", "protocol.version=2", "-c", authorizationOption, "fetch", cloneURL.String(), "-t", commit}, Operation: h.operations.SetupGitFetch},
+			{Key: "setup.git.fetch", Command: []string{"git", "-C", tempDir, "-c", "protocol.version=2", "-c", authorizationOption, "-c", "http.extraHeader=X-Sourcegraph-Actor-UID: internal", "fetch", cloneURL.String(), "-t", commit}, Operation: h.operations.SetupGitFetch},
 			{Key: "setup.git.add-remote", Command: []string{"git", "-C", tempDir, "remote", "add", "origin", repositoryName}, Operation: h.operations.SetupAddRemote},
 			{Key: "setup.git.checkout", Command: []string{"git", "-C", tempDir, "checkout", commit}, Operation: h.operations.SetupGitCheckout},
 		}

--- a/enterprise/cmd/executor/internal/worker/workspace_test.go
+++ b/enterprise/cmd/executor/internal/worker/workspace_test.go
@@ -45,7 +45,7 @@ func TestPrepareWorkspace(t *testing.T) {
 
 	expectedCommands := [][]string{
 		{"git", "-C", dir, "init"},
-		{"git", "-C", dir, "-c", "protocol.version=2", "-c", "http.extraHeader=Authorization: token-executor hunter2", "fetch", "https://executor@test.io/internal/git/torvalds/linux", "-t", "deadbeef"},
+		{"git", "-C", dir, "-c", "protocol.version=2", "-c", "http.extraHeader=Authorization: token-executor hunter2", "-c", "http.extraHeader=X-Sourcegraph-Actor-UID: internal", "fetch", "https://executor@test.io/internal/git/torvalds/linux", "-t", "deadbeef"},
 		{"git", "-C", dir, "remote", "add", "origin", "torvalds/linux"},
 		{"git", "-C", dir, "checkout", "deadbeef"},
 	}


### PR DESCRIPTION
This PR adds an extra header to fetch that eventually hit an internal `gitserver` so that repo clones won't be empty once sub-repo permissions are enforced on this endpoint. See https://github.com/sourcegraph/sourcegraph/pull/30508 for additional context.