### PR TITLE
dev/ci: rewrite computeRunType to use structured RunTypeMatchers

### DIFF
--- a/enterprise/dev/ci/internal/ci/config.go
+++ b/enterprise/dev/ci/internal/ci/config.go
@@ -62,7 +62,9 @@ func NewConfig(now time.Time) Config {
 		branch = os.Getenv("BUILDKITE_BRANCH")
 		tag    = os.Getenv("BUILDKITE_TAG")
 		// evaluates what type of pipeline run this is
-		runType = computeRunType(tag, branch)
+		runType = computeRunType(tag, branch, map[string]string{
+			"BEXT_NIGHTLY": os.Getenv("BEXT_NIGHTLY"),
+		})
 		// defaults to 0
 		buildNumber, _ = strconv.Atoi(os.Getenv("BUILDKITE_BUILD_NUMBER"))
 	)

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -28,9 +28,8 @@ type CoreTestOperationsOptions struct {
 // notably, this is what is used to define operations that run on PRs. Please read the
 // following notes:
 //
-// - changedFiles can be nil to run all tests.
-// - opts should be used ONLY to adjust the behaviour of specific steps, e.g. by adding flags,
-// and not as a condition for adding steps or commands.
+// - opts should be used ONLY to adjust the behaviour of specific steps, e.g. by adding,
+//	flags and not as a condition for adding steps or commands.
 // - be careful not to add duplicate steps.
 //
 // If the conditions for the addition of an operation cannot be expressed using the above

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -28,8 +28,8 @@ type CoreTestOperationsOptions struct {
 // notably, this is what is used to define operations that run on PRs. Please read the
 // following notes:
 //
-// - opts should be used ONLY to adjust the behaviour of specific steps, e.g. by adding,
-//	flags and not as a condition for adding steps or commands.
+// - opts should be used ONLY to adjust the behaviour of specific steps, e.g. by adding
+//   flags and not as a condition for adding steps or commands.
 // - be careful not to add duplicate steps.
 //
 // If the conditions for the addition of an operation cannot be expressed using the above

--- a/enterprise/dev/ci/internal/ci/runtype.go
+++ b/enterprise/dev/ci/internal/ci/runtype.go
@@ -44,10 +44,9 @@ const (
 )
 
 func computeRunType(tag, branch string, env map[string]string) RunType {
-	for rt := PullRequest + 1; rt < None; rt += 1 {
-		reqs := rt.Matcher()
-		if reqs.Matches(tag, branch, env) {
-			return rt
+	for runType := PullRequest + 1; runType < None; runType += 1 {
+		if runType.Matcher().Matches(tag, branch, env) {
+			return runType
 		}
 	}
 	// RunType is PullRequest by default

--- a/enterprise/dev/ci/internal/ci/runtype.go
+++ b/enterprise/dev/ci/internal/ci/runtype.go
@@ -9,19 +9,20 @@ import (
 // RunType indicates the type of this run. Each CI pipeline can only be a single run type.
 type RunType int
 
-// RunTypes should be defined by order of precedence.
 const (
+	// RunTypes should be defined by order of precedence.
+
 	PullRequest RunType = iota // pull request build
 
-	// Browser extensions - must be first because they take precedence
+	// Nightly builds - must be first because they take precedence
 
+	BextNightly // browser extension nightly build
+
+	// Release branches
+
+	TaggedRelease     // semver-tagged release
+	ReleaseBranch     // release branch build
 	BextReleaseBranch // browser extension release build
-	BextNightly       // browser extension nightly build
-
-	// Releases
-
-	TaggedRelease // semver-tagged release
-	ReleaseBranch // release branch build
 
 	// Main branches
 
@@ -66,11 +67,6 @@ func (t RunType) Is(oneOfTypes ...RunType) bool {
 // Matcher returns the requirements for a build to be considered of this RunType.
 func (t RunType) Matcher() *RunTypeMatcher {
 	switch t {
-	case BextReleaseBranch:
-		return &RunTypeMatcher{
-			Branch:      "bext/release",
-			BranchExact: true,
-		}
 	case BextNightly:
 		return &RunTypeMatcher{
 			EnvIncludes: map[string]string{
@@ -86,6 +82,11 @@ func (t RunType) Matcher() *RunTypeMatcher {
 		return &RunTypeMatcher{
 			Branch:       `^[0-9]+\.[0-9]+$`,
 			BranchRegexp: true,
+		}
+	case BextReleaseBranch:
+		return &RunTypeMatcher{
+			Branch:      "bext/release",
+			BranchExact: true,
 		}
 
 	case MainBranch:
@@ -127,27 +128,32 @@ func (t RunType) Matcher() *RunTypeMatcher {
 func (t RunType) String() string {
 	switch t {
 	case PullRequest:
-		return "PullRequest"
-	case MainBranch:
-		return "MainBranch"
-	case MainDryRun:
-		return "MainDryRun"
-	case TaggedRelease:
-		return "TaggedRelease"
-	case ReleaseBranch:
-		return "ReleaseBranch"
-	case BextReleaseBranch:
-		return "Browser Extension Release Build"
+		return "Pull request"
+
 	case BextNightly:
-		return "Browser Extension Nightly Release Build"
+		return "Browser extension nightly release build"
+
+	case TaggedRelease:
+		return "Tagged release"
+	case ReleaseBranch:
+		return "Release branch"
+	case BextReleaseBranch:
+		return "Browser extension release build"
+
+	case MainBranch:
+		return "Main branch"
+	case MainDryRun:
+		return "Main dry run"
+
 	case ImagePatch:
-		return "Patched Image"
+		return "Patch image"
 	case ImagePatchNoTest:
-		return "Patched image without testing"
+		return "Patch image without testing"
 	case CandidatesNoTest:
 		return "Build all candidates without testing"
 	case ExecutorPatchNoTest:
-		return "Build executor without test"
+		return "Build executor without testing"
+
 	case BackendIntegrationTests:
 		return "Backend integration tests"
 	}

--- a/enterprise/dev/ci/internal/ci/runtype.go
+++ b/enterprise/dev/ci/internal/ci/runtype.go
@@ -1,7 +1,6 @@
 package ci
 
 import (
-	"os"
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
@@ -10,21 +9,24 @@ import (
 // RunType indicates the type of this run. Each CI pipeline can only be a single run type.
 type RunType int
 
+// RunTypes should be defined by order of precedence.
 const (
 	PullRequest RunType = iota // pull request build
 
-	MainBranch // main branch build
-	MainDryRun // run everything main does, except for deploy-related steps
+	// Browser extensions - must be first because they take precedence
+
+	BextReleaseBranch // browser extension release build
+	BextNightly       // browser extension nightly build
 
 	// Releases
 
 	TaggedRelease // semver-tagged release
 	ReleaseBranch // release branch build
 
-	// Browser extensions
+	// Main branches
 
-	BextReleaseBranch // browser extension release build
-	BextNightly       // browser extension nightly build
+	MainBranch // main branch build
+	MainDryRun // run everything main does, except for deploy-related steps
 
 	// Patches (NOT patch releases)
 
@@ -41,43 +43,18 @@ const (
 	None
 )
 
-func computeRunType(tag, branch string) RunType {
-	switch {
-	case branch == "bext/release":
-		return BextReleaseBranch
-	case os.Getenv("BEXT_NIGHTLY") == "true":
-		return BextNightly
-
-	case branch == "main":
-		return MainBranch
-	case strings.HasPrefix(branch, "main-dry-run/"):
-		return MainDryRun
-
-	case strings.HasPrefix(tag, "v"):
-		return TaggedRelease
-	case lazyregexp.New(`^[0-9]+\.[0-9]+$`).MatchString(branch):
-		return ReleaseBranch
-
-	case strings.HasPrefix(branch, "docker-images-patch/"):
-		return ImagePatch
-	case strings.HasPrefix(branch, "docker-images-patch-notest/"):
-		return ImagePatchNoTest
-	case branch == "docker-images-candidates-notest":
-		return CandidatesNoTest
-	case branch == "executor-patch-notest",
-		strings.HasPrefix(branch, "executor-patch-notest/"):
-		return ExecutorPatchNoTest
-
-	case strings.HasPrefix(branch, "backend-integration/"):
-		return BackendIntegrationTests
-
-	default:
-		// If no specific run type is matched, assumed to be a PR
-		return PullRequest
+func computeRunType(tag, branch string, env map[string]string) RunType {
+	for rt := PullRequest + 1; rt < None; rt += 1 {
+		reqs := rt.Matcher()
+		if reqs.Matches(tag, branch, env) {
+			return rt
+		}
 	}
+	// RunType is PullRequest by default
+	return PullRequest
 }
 
-// Is returns true if this run type Is one of the given RunTypes
+// Is returns true if this run type is one of the given RunTypes
 func (t RunType) Is(oneOfTypes ...RunType) bool {
 	for _, rt := range oneOfTypes {
 		if t == rt {
@@ -85,6 +62,67 @@ func (t RunType) Is(oneOfTypes ...RunType) bool {
 		}
 	}
 	return false
+}
+
+// Matcher returns the requirements for a build to be considered of this RunType.
+func (t RunType) Matcher() *RunTypeMatcher {
+	switch t {
+	case BextReleaseBranch:
+		return &RunTypeMatcher{
+			Branch:      "bext/release",
+			BranchExact: true,
+		}
+	case BextNightly:
+		return &RunTypeMatcher{
+			EnvIncludes: map[string]string{
+				"BEXT_NIGHTLY": "true",
+			},
+		}
+
+	case TaggedRelease:
+		return &RunTypeMatcher{
+			TagPrefix: "v",
+		}
+	case ReleaseBranch:
+		return &RunTypeMatcher{
+			Branch:       `^[0-9]+\.[0-9]+$`,
+			BranchRegexp: true,
+		}
+
+	case MainBranch:
+		return &RunTypeMatcher{
+			Branch:      "main",
+			BranchExact: true,
+		}
+	case MainDryRun:
+		return &RunTypeMatcher{
+			Branch: "main-dry-run/",
+		}
+
+	case ImagePatch:
+		return &RunTypeMatcher{
+			Branch: "docker-images-patch/",
+		}
+	case ImagePatchNoTest:
+		return &RunTypeMatcher{
+			Branch: "docker-images-patch-notest/",
+		}
+	case CandidatesNoTest:
+		return &RunTypeMatcher{
+			Branch: "docker-images-candidates-notest/",
+		}
+	case ExecutorPatchNoTest:
+		return &RunTypeMatcher{
+			Branch: "executor-patch-notest/",
+		}
+
+	case BackendIntegrationTests:
+		return &RunTypeMatcher{
+			Branch: "backend-integration/",
+		}
+	}
+
+	return nil
 }
 
 func (t RunType) String() string {
@@ -115,4 +153,50 @@ func (t RunType) String() string {
 		return "Backend integration tests"
 	}
 	return ""
+}
+
+// RunTypeMatcher defines the requirements for any given build to be considered a build of
+// this RunType.
+type RunTypeMatcher struct {
+	// Branch loosely matches branches that begin with this value, unless a different type
+	// of match is indicated (e.g. BranchExact, BranchRegexp)
+	Branch       string
+	BranchExact  bool
+	BranchRegexp bool
+
+	// TagPrefix matches tags that begin with this value.
+	TagPrefix string
+
+	// EnvIncludes validates if these key-value pairs are configured in environment.
+	EnvIncludes map[string]string
+}
+
+// Matches returns true if the given properties and environment match this RunType.
+func (m *RunTypeMatcher) Matches(tag, branch string, env map[string]string) bool {
+	if m.Branch != "" {
+		switch {
+		case m.BranchExact:
+			return m.Branch == branch
+		case m.BranchRegexp:
+			return lazyregexp.New(m.Branch).MatchString(branch)
+		default:
+			return strings.HasPrefix(branch, m.Branch)
+		}
+	}
+
+	if m.TagPrefix != "" {
+		return strings.HasPrefix(tag, m.TagPrefix)
+	}
+
+	if len(m.EnvIncludes) > 0 && len(env) > 0 {
+		for wantK, wantV := range m.EnvIncludes {
+			gotV, exists := env[wantK]
+			if !exists || (wantV != gotV) {
+				return false
+			}
+		}
+		return true
+	}
+
+	return false
 }

--- a/enterprise/dev/ci/internal/ci/runtype.go
+++ b/enterprise/dev/ci/internal/ci/runtype.go
@@ -1,7 +1,6 @@
 package ci
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -37,6 +36,9 @@ const (
 	// Special test branches
 
 	BackendIntegrationTests // run backend tests that are used on main
+
+	// None is a no-op, add all run types above this type.
+	None
 )
 
 func computeRunType(tag, branch string) RunType {
@@ -92,7 +94,7 @@ func (t RunType) String() string {
 	case MainBranch:
 		return "MainBranch"
 	case MainDryRun:
-		return "Main dry run"
+		return "MainDryRun"
 	case TaggedRelease:
 		return "TaggedRelease"
 	case ReleaseBranch:
@@ -100,15 +102,17 @@ func (t RunType) String() string {
 	case BextReleaseBranch:
 		return "Browser Extension Release Build"
 	case BextNightly:
-		return "Browser Extension Release Build"
+		return "Browser Extension Nightly Release Build"
 	case ImagePatch:
 		return "Patched Image"
 	case ImagePatchNoTest:
-		return "Patched Image without testing"
+		return "Patched image without testing"
 	case CandidatesNoTest:
-		return "Build All candidates without testing"
+		return "Build all candidates without testing"
+	case ExecutorPatchNoTest:
+		return "Build executor without test"
 	case BackendIntegrationTests:
 		return "Backend integration tests"
 	}
-	panic(fmt.Sprintf("Run type %d does not have a full name defined", t))
+	return ""
 }

--- a/enterprise/dev/ci/internal/ci/runtype_test.go
+++ b/enterprise/dev/ci/internal/ci/runtype_test.go
@@ -18,6 +18,12 @@ func TestComputeRunType(t *testing.T) {
 		args args
 		want RunType
 	}{{
+		name: "pull request by default",
+		args: args{
+			branch: "some-random-feature-branch",
+		},
+		want: PullRequest,
+	}, {
 		name: "main",
 		args: args{
 			branch: "main",

--- a/enterprise/dev/ci/internal/ci/runtype_test.go
+++ b/enterprise/dev/ci/internal/ci/runtype_test.go
@@ -6,9 +6,135 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestComputeRunType should be used for high-level testing of critical run types.
+func TestComputeRunType(t *testing.T) {
+	type args struct {
+		tag    string
+		branch string
+		env    map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want RunType
+	}{{
+		name: "main",
+		args: args{
+			branch: "main",
+		},
+		want: MainBranch,
+	}, {
+		name: "tagged release",
+		args: args{
+			branch: "1.3",
+			tag:    "v1.2.3",
+		},
+		want: TaggedRelease,
+	}, {
+		name: "bext release",
+		args: args{
+			branch: "bext/release",
+		},
+		want: BextReleaseBranch,
+	}, {
+		name: "bext nightly",
+		args: args{
+			branch: "main",
+			env: map[string]string{
+				"BEXT_NIGHTLY": "true",
+			},
+		},
+		want: BextNightly,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := computeRunType(tt.args.tag, tt.args.branch, tt.args.env)
+			assert.Equal(t, tt.want.String(), got.String())
+		})
+	}
+}
+
 func TestRunTypeString(t *testing.T) {
 	// Check all individual types have a name defined at least
 	for rt := PullRequest; rt < None; rt += 1 {
-		assert.NotEmpty(t, rt.String(), "RunType: %d", rt)
+		assert.NotEmpty(t, rt.String(), "RunType: %d with matcher %+v", rt, rt.Matcher())
+	}
+}
+
+func TestRunTypeMatcher(t *testing.T) {
+	// Check all individual types have a matcher defined at least
+	// Start a PullRequest+1 because PullRequest is the default RunType, and does not have
+	// a matcher.
+	for rt := PullRequest + 1; rt < None; rt += 1 {
+		assert.NotNil(t, rt.Matcher(), "RunType: %d with name %q", rt, rt.String())
+	}
+}
+
+func TestRunTypeMatcherMatches(t *testing.T) {
+	type args struct {
+		tag    string
+		branch string
+	}
+	tests := []struct {
+		name    string
+		matcher RunTypeMatcher
+		args    args
+		want    bool
+	}{{
+		name: "branch prefix",
+		matcher: RunTypeMatcher{
+			Branch: "main-dry-run/",
+		},
+		args: args{branch: "main-dry-run/asdf"},
+		want: true,
+	}, {
+		name: "branch regexp",
+		matcher: RunTypeMatcher{
+			Branch:       `^[0-9]+\.[0-9]+$`,
+			BranchRegexp: true,
+		},
+		args: args{branch: "1.2"},
+		want: true,
+	}, {
+		name: "branch exact",
+		matcher: RunTypeMatcher{
+			Branch:      "main",
+			BranchExact: true,
+		},
+		args: args{branch: "main"},
+		want: true,
+	}, {
+		name: "tag prefix",
+		matcher: RunTypeMatcher{
+			TagPrefix: "v",
+		},
+		args: args{branch: "main", tag: "v1.2.3"},
+		want: true,
+	}, {
+		name: "env includes",
+		matcher: RunTypeMatcher{
+			EnvIncludes: map[string]string{
+				"KEY": "VALUE",
+			},
+		},
+		args: args{branch: "main"},
+		want: true,
+	}, {
+		name: "env not includes",
+		matcher: RunTypeMatcher{
+			EnvIncludes: map[string]string{
+				"KEY": "NOT_VALUE",
+			},
+		},
+		args: args{branch: "main"},
+		want: false,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.matcher.Matches(tt.args.tag, tt.args.branch, map[string]string{
+				"KEY": "VALUE",
+			})
+			assert.Equal(t, tt.want, got)
+		})
 	}
 }

--- a/enterprise/dev/ci/internal/ci/runtype_test.go
+++ b/enterprise/dev/ci/internal/ci/runtype_test.go
@@ -56,18 +56,24 @@ func TestComputeRunType(t *testing.T) {
 
 func TestRunTypeString(t *testing.T) {
 	// Check all individual types have a name defined at least
+	var tested int
 	for rt := PullRequest; rt < None; rt += 1 {
+		tested += 1
 		assert.NotEmpty(t, rt.String(), "RunType: %d with matcher %+v", rt, rt.Matcher())
 	}
+	assert.Equal(t, int(None), tested)
 }
 
 func TestRunTypeMatcher(t *testing.T) {
 	// Check all individual types have a matcher defined at least
 	// Start a PullRequest+1 because PullRequest is the default RunType, and does not have
 	// a matcher.
+	var tested int
 	for rt := PullRequest + 1; rt < None; rt += 1 {
+		tested += 1
 		assert.NotNil(t, rt.Matcher(), "RunType: %d with name %q", rt, rt.String())
 	}
+	assert.Equal(t, int(None)-1, tested)
 }
 
 func TestRunTypeMatcherMatches(t *testing.T) {

--- a/enterprise/dev/ci/internal/ci/runtype_test.go
+++ b/enterprise/dev/ci/internal/ci/runtype_test.go
@@ -1,0 +1,14 @@
+package ci
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunTypeString(t *testing.T) {
+	// Check all individual types have a name defined at least
+	for rt := PullRequest; rt < None; rt += 1 {
+		assert.NotEmpty(t, rt.String(), "RunType: %d", rt)
+	}
+}


### PR DESCRIPTION
Rewrite computeRunType to use structured RunTypeMatchers provided by each RunType to allow us to understand how a RunType is determined after the fact. See this in action in https://github.com/sourcegraph/sourcegraph/pull/30532. Demonstrative example:

https://github.com/sourcegraph/sourcegraph/blob/e562df81b1473c9f3b9b08a5cb16268e3bc21243/enterprise/dev/ci/internal/ci/runtype.go#L46-L54

Also introduces testing that iterates over RunTypes and ensures each has relevant properties defined, as well as tests covering some of the new and old functionality.