### PR TITLE
ci: extract frontend specific checks into steps

### DIFF
--- a/dev/check/all.sh
+++ b/dev/check/all.sh
@@ -11,7 +11,6 @@ go version
 go env
 
 CHECKS=(
-  ./yarn-deduplicate.sh
   ./gofmt.sh
   ./template-inlines.sh
   ./go-enterprise-import.sh
@@ -24,7 +23,6 @@ CHECKS=(
   ./shfmt.sh
   ./shellcheck.sh
   ./ts-enterprise-import.sh
-  ./svgo.sh
 )
 
 echo "--- 🚨 Buildkite's timing information is misleading! Only consider the job timing that's printed after 'done'"

--- a/enterprise/dev/ci/internal/ci/changed/changed.go
+++ b/enterprise/dev/ci/internal/ci/changed/changed.go
@@ -51,6 +51,17 @@ func (c Files) AffectsTerraformFiles() bool {
 	return false
 }
 
+// AffectsFilesWithExt returns whether the changes affects files with the given extension.
+// Extension must be passed with the dot, eg: ".svg"
+func (c Files) AffectsFilesWithExt(ext string) bool {
+	for _, p := range c {
+		if strings.HasSuffix(p, ext) {
+			return true
+		}
+	}
+	return false
+}
+
 // AffectsGo returns whether the changes affects go files.
 func (c Files) AffectsGo() bool {
 	for _, p := range c {

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -51,6 +51,12 @@ func CoreTestOperations(changedFiles changed.Files, opts CoreTestOperationsOptio
 	if runAll || changedFiles.AffectsGraphQL() {
 		linterOps.Append(addGraphQLLint)
 	}
+	if runAll || changedFiles.AffectsFilesWithExt(".svg") {
+		linterOps.Append(addSVGLint)
+	}
+	if runAll || changedFiles.AffectsClient() {
+		linterOps.Append(addYarnDeduplicateLint)
+	}
 	if runAll || changedFiles.AffectsDockerfiles() {
 		linterOps.Append(addDockerfileLint)
 	}
@@ -143,6 +149,16 @@ func addPrettier(pipeline *bk.Pipeline) {
 func addGraphQLLint(pipeline *bk.Pipeline) {
 	pipeline.AddStep(":lipstick: :graphql: GraphQL lint",
 		bk.Cmd("dev/ci/yarn-run.sh graphql-lint"))
+}
+
+func addSVGLint(pipeline *bk.Pipeline) {
+	pipeline.AddStep(":lipstick: :compression: SVG lint",
+		bk.Cmd("dev/check/svgo.sh"))
+}
+
+func addYarnDeduplicateLint(pipeline *bk.Pipeline) {
+	pipeline.AddStep(":lipstick: :yarn: SVG lint",
+		bk.Cmd("dev/check/yarn-deduplicate.sh"))
 }
 
 // Adds Typescript linting. (2x ~41s) + ~60s + ~137s + 7s

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -157,7 +157,7 @@ func addSVGLint(pipeline *bk.Pipeline) {
 }
 
 func addYarnDeduplicateLint(pipeline *bk.Pipeline) {
-	pipeline.AddStep(":lipstick: :yarn: SVG lint",
+	pipeline.AddStep(":lipstick: :yarn: Yarn deduplicate lint",
 		bk.Cmd("dev/check/yarn-deduplicate.sh"))
 }
 


### PR DESCRIPTION
Extracting those steps from the `check/all.sh` script will isolate the issues we've been observing with `svgo` (I suspect a race condition with the `parallel` binary). 

QA: 
<img width="1208" alt="image" src="https://user-images.githubusercontent.com/10151/152145130-c8ac9ee7-d265-4bc4-919a-a073493c9044.png">
