### PR TITLE
codemonitors: Remove dead parameter

### DIFF
--- a/enterprise/internal/codemonitors/background/graphql.go
+++ b/enterprise/internal/codemonitors/background/graphql.go
@@ -120,7 +120,7 @@ const gqlSearchQuery = `query CodeMonitorSearch(
 	}
 }`
 
-func search(ctx context.Context, query string, userID int32, monitorID *int64) (_ *searchResults, err error) {
+func search(ctx context.Context, query string, monitorID *int64) (_ *searchResults, err error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "CodeMonitorSearch")
 	defer func() {
 		span.LogFields(log.Error(err))

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -177,10 +177,10 @@ func (r *queryRunner) Handle(ctx context.Context, record workerutil.Record) (err
 	)
 	if hasRepoAware {
 		newQuery = q.QueryString
-		results, err = search(ctx, newQuery, m.UserID, &m.ID)
+		results, err = search(ctx, newQuery, &m.ID)
 	} else {
 		newQuery = newQueryWithAfterFilter(q)
-		results, err = search(ctx, newQuery, m.UserID, nil)
+		results, err = search(ctx, newQuery, nil)
 	}
 	if err != nil {
 		return errors.Wrap(err, "run search")


### PR DESCRIPTION
The user information is now stored in the context.
