### PR TITLE
migrations: Read all applied versions when populating `schemaVersion`

### DIFF
--- a/internal/database/migration/runner/iface.go
+++ b/internal/database/migration/runner/iface.go
@@ -11,6 +11,7 @@ type Store interface {
 	Done(err error) error
 
 	Version(ctx context.Context) (int, bool, bool, error)
+	Versions(ctx context.Context) (appliedVersions, pendingVersions, failedVersions []int, _ error)
 	Lock(ctx context.Context) (bool, func(err error) error, error)
 	TryLock(ctx context.Context) (bool, func(err error) error, error)
 	Up(ctx context.Context, migration definition.Definition) error

--- a/internal/database/migration/runner/runner.go
+++ b/internal/database/migration/runner/runner.go
@@ -29,8 +29,11 @@ type schemaContext struct {
 }
 
 type schemaVersion struct {
-	version int
-	dirty   bool
+	version         int
+	dirty           bool
+	appliedVersions []int
+	pendingVersions []int
+	failedVersions  []int
 }
 
 type visitFunc func(ctx context.Context, schemaContext schemaContext) error
@@ -150,16 +153,26 @@ func (r *Runner) fetchVersion(ctx context.Context, schemaName string, store Stor
 	if err != nil {
 		return schemaVersion{}, err
 	}
+	appliedVersions, pendingVersions, failedVersions, err := store.Versions(ctx)
+	if err != nil {
+		return schemaVersion{}, err
+	}
 
 	logger.Info(
 		"Checked current version",
 		"schema", schemaName,
 		"version", version,
 		"dirty", dirty,
+		"appliedVersions", appliedVersions,
+		"pendingVersions", pendingVersions,
+		"failedVersions", failedVersions,
 	)
 
 	return schemaVersion{
 		version,
 		dirty,
+		appliedVersions,
+		pendingVersions,
+		failedVersions,
 	}, nil
 }


### PR DESCRIPTION
Pulled from #29831. This PR calls `Versions` as well as `Version` from the runner process. We'll eventually phase out `Version` completely.