### PR TITLE
migrations: Refactor `runSchema{Up,Down}` in runner

### DIFF
--- a/internal/database/migration/runner/run.go
+++ b/internal/database/migration/runner/run.go
@@ -110,10 +110,19 @@ func (r *Runner) runSchema(ctx context.Context, operation MigrationOperation, sc
 		return errDirtyDatabase
 	}
 
-	if operation.Type == MigrationOperationTypeTargetedUp {
-		return r.runSchemaUp(ctx, operation, schemaContext)
+	targetVersion := operation.TargetVersion
+	gatherDefinitions := schemaContext.schema.Definitions.UpTo
+	if operation.Type != MigrationOperationTypeTargetedUp {
+		gatherDefinitions = schemaContext.schema.Definitions.DownTo
 	}
-	return r.runSchemaDown(ctx, operation, schemaContext)
+
+	// Get the set of migrations that need to be applied or unapplied, depending on the migration direction.
+	definitions, err := gatherDefinitions(schemaContext.initialSchemaVersion.version, targetVersion)
+	if err != nil {
+		return err
+	}
+
+	return r.applyMigrations(ctx, operation, schemaContext, definitions)
 }
 
 func (r *Runner) applyMigrations(ctx context.Context, operation MigrationOperation, schemaContext schemaContext, definitions []definition.Definition) error {
@@ -131,32 +140,6 @@ func (r *Runner) applyMigrations(ctx context.Context, operation MigrationOperati
 	}
 
 	return nil
-}
-
-func (r *Runner) runSchemaUp(ctx context.Context, operation MigrationOperation, schemaContext schemaContext) (err error) {
-	logger.Info("Upgrading schema", "schema", schemaContext.schema.Name)
-
-	definitions, err := schemaContext.schema.Definitions.UpTo(schemaContext.initialSchemaVersion.version, operation.TargetVersion)
-	if err != nil {
-		return err
-	}
-
-	return r.applyMigrations(ctx, operation, schemaContext, definitions)
-}
-
-func (r *Runner) runSchemaDown(ctx context.Context, operation MigrationOperation, schemaContext schemaContext) error {
-	logger.Info("Downgrading schema", "schema", schemaContext.schema.Name)
-
-	if operation.TargetVersion == 0 {
-		operation.TargetVersion = schemaContext.initialSchemaVersion.version - 1
-	}
-
-	definitions, err := schemaContext.schema.Definitions.DownTo(schemaContext.initialSchemaVersion.version, operation.TargetVersion)
-	if err != nil {
-		return err
-	}
-
-	return r.applyMigrations(ctx, operation, schemaContext, definitions)
 }
 
 // applyMigration applies the given migration in the direction indicated by the given operation.


### PR DESCRIPTION
Pulled from #29831. This PR replaces the `runSchemaUp` and `runSchemaDown` methods. This only removes redundant logging.