### PR TITLE
migrations: Add `withLockedSchemaState` to runner

### DIFF
--- a/internal/database/migration/runner/run.go
+++ b/internal/database/migration/runner/run.go
@@ -81,22 +81,22 @@ func (r *Runner) runSchema(ctx context.Context, operation MigrationOperation, sc
 
 			return errDirtyDatabase
 		}
-  }
+	}
 
 	callback := func(schemaVersion schemaVersion) error {
 		targetVersion := operation.TargetVersion
-  	gatherDefinitions := schemaContext.schema.Definitions.UpTo
-  	if operation.Type != MigrationOperationTypeTargetedUp {
-  		gatherDefinitions = schemaContext.schema.Definitions.DownTo
-	  }
+		gatherDefinitions := schemaContext.schema.Definitions.UpTo
+		if operation.Type != MigrationOperationTypeTargetedUp {
+			gatherDefinitions = schemaContext.schema.Definitions.DownTo
+		}
 
-	  // Get the set of migrations that need to be applied or unapplied, depending on the migration direction.
-  	definitions, err := gatherDefinitions(schemaContext.initialSchemaVersion.version, targetVersion)
-  	if err != nil {
-  		return err
-  	}
+		// Get the set of migrations that need to be applied or unapplied, depending on the migration direction.
+		definitions, err := gatherDefinitions(schemaContext.initialSchemaVersion.version, targetVersion)
+		if err != nil {
+			return err
+		}
 
-    return r.applyMigrations(ctx, operation, schemaContext, definitions)
+		return r.applyMigrations(ctx, operation, schemaContext, definitions)
 	}
 
 	return r.withLockedSchemaState(ctx, schemaContext, callback)

--- a/internal/database/migration/runner/run.go
+++ b/internal/database/migration/runner/run.go
@@ -84,6 +84,21 @@ func (r *Runner) runSchema(ctx context.Context, operation MigrationOperation, sc
 	}
 
 	callback := func(schemaVersion schemaVersion) error {
+		if !upgradingToLatest {
+			// Check if another instance changed the schema version before we acquired the
+			// lock. If we're not migrating to the latest schema, concurrent migrations may
+			// have unexpected behavior. We'll early exit here.
+			if schemaVersion.version != schemaContext.initialSchemaVersion.version {
+				return errMigrationContention
+			}
+		}
+		if schemaVersion.dirty {
+			// The store layer will refuse to alter a dirty database. We'll return an error
+			// here instead of from the store as we can provide a bit instruction to the user
+			// at this point.
+			return errDirtyDatabase
+		}
+
 		targetVersion := operation.TargetVersion
 		gatherDefinitions := schemaContext.schema.Definitions.UpTo
 		if operation.Type != MigrationOperationTypeTargetedUp {


### PR DESCRIPTION
Pulled from #29831. This PR bundles the `Lock`/`fetchVersion` calls together in a method.