### PR TITLE
simplify aggregatingStream access

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1751,8 +1751,8 @@ func (r *searchResolver) Stats(ctx context.Context) (stats *searchResultsStats, 
 			return nil, err // do not cache errors.
 		}
 		v = r.resultsToResolver(&SearchResults{
-			Matches: agg.Get().Results,
-			Stats:   agg.Get().Stats,
+			Matches: agg.Results,
+			Stats:   agg.Stats,
 		})
 		if v.MatchCount() > 0 {
 			break

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -50,7 +50,7 @@ func (srs *searchResultsStats) getResults(ctx context.Context) (result.Matches, 
 			srs.err = err
 			return
 		}
-		srs.results = agg.Get().Results
+		srs.results = agg.Results
 	})
 	return srs.results, srs.err
 }

--- a/internal/search/streaming/stream.go
+++ b/internal/search/streaming/stream.go
@@ -132,18 +132,14 @@ func NewAggregatingStream() *aggregatingStream {
 
 type aggregatingStream struct {
 	sync.Mutex
-	event SearchEvent
+	SearchEvent
 }
 
 func (c *aggregatingStream) Send(event SearchEvent) {
 	c.Lock()
-	c.event.Results = append(c.event.Results, event.Results...)
-	c.event.Stats.Update(&event.Stats)
+	c.Results = append(c.Results, event.Results...)
+	c.Stats.Update(&event.Stats)
 	c.Unlock()
-}
-
-func (c *aggregatingStream) Get() SearchEvent {
-	return c.event
 }
 
 func NewNullStream() Sender {

--- a/internal/search/unindexed/structural.go
+++ b/internal/search/unindexed/structural.go
@@ -115,7 +115,7 @@ func runStructuralSearch(ctx context.Context, args *search.SearcherParameters, r
 	agg := streaming.NewAggregatingStream()
 	err := streamStructuralSearch(ctx, args, repos, agg)
 
-	event := agg.Get()
+	event := agg.SearchEvent
 	if len(event.Results) == 0 && err == nil {
 		// retry structural search with a higher limit.
 		agg := streaming.NewAggregatingStream()
@@ -124,7 +124,7 @@ func runStructuralSearch(ctx context.Context, args *search.SearcherParameters, r
 			return err
 		}
 
-		event = agg.Get()
+		event = agg.SearchEvent
 		if len(event.Results) == 0 {
 			// Still no results? Give up.
 			log15.Warn("Structural search gives up after more exhaustive attempt. Results may have been missed.")

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -71,13 +71,12 @@ func SearchFilesInRepos(ctx context.Context, zoektArgs zoektutil.IndexedSearchRe
 func SearchFilesInReposBatch(ctx context.Context, zoektArgs zoektutil.IndexedSearchRequest, searcherArgs *search.SearcherParameters, searcherOnly bool) ([]*result.FileMatch, streaming.Stats, error) {
 	agg := streaming.NewAggregatingStream()
 	err := SearchFilesInRepos(ctx, zoektArgs, searcherArgs, searcherOnly, agg)
-	event := agg.Get()
 
-	fms, fmErr := matchesToFileMatches(event.Results)
+	fms, fmErr := matchesToFileMatches(agg.Results)
 	if fmErr != nil && err == nil {
 		err = errors.Wrap(fmErr, "searchFilesInReposBatch failed to convert results")
 	}
-	return fms, event.Stats, err
+	return fms, agg.Stats, err
 }
 
 var mockSearchFilesInRepo func(ctx context.Context, repo types.MinimalRepo, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration, stream streaming.Sender) (limitHit bool, err error)

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -325,14 +325,12 @@ func TestIndexedSearch(t *testing.T) {
 				t.Errorf("zoektSearchHEAD() error = %v, wantErr = %v", err, tt.wantErr)
 				return
 			}
-			got := agg.Get()
-
-			gotFm, err := matchesToFileMatches(got.Results)
+			gotFm, err := matchesToFileMatches(agg.Results)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if diff := cmp.Diff(&tt.wantCommon, &got.Stats, cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(&tt.wantCommon, &agg.Stats, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("common mismatch (-want +got):\n%s", diff)
 			}
 


### PR DESCRIPTION
After a few days of using the new aggregating stream type, this is just
a refinement to the API to make it less awkward to use. Essentially, it
just embeds the aggregated event into the aggregatingStream so either
the event or its fields are directly accessible.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
