### PR TITLE
dev/team: include link to team.yml to add GitHub handle

### DIFF
--- a/dev/team/team.go
+++ b/dev/team/team.go
@@ -28,6 +28,7 @@ type TeammateResolver interface {
 }
 
 const teamDataURL = "https://raw.githubusercontent.com/sourcegraph/handbook/main/data/team.yml"
+const teamDataGitHubURL = "https://github.com/sourcegraph/handbook/blob/main/data/team.yml"
 
 type Teammate struct {
 	// Key is the key for this teammate in team.yml
@@ -95,7 +96,8 @@ func (r *teammateResolver) ResolveByGitHubHandle(ctx context.Context, handle str
 		}
 	}
 	if teammate == nil {
-		return nil, fmt.Errorf("no teammate with GitHub handle %q", handle)
+		return nil, fmt.Errorf("no teammate with GitHub handle %q - if this is you, ensure the `github` field is set in your profile in %s",
+			handle, teamDataGitHubURL)
 	}
 	return teammate, nil
 }


### PR DESCRIPTION
Right now we propagate this error for per-build notifications, which gives us a good opportunity to let people know how to fix the `team` library being unable to identify them by GitHub handle by including this information in the error message.