### PR TITLE
Search backend: simplify aggregator

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1564,7 +1564,7 @@ func (r *searchResolver) evaluateJob(ctx context.Context, stream streaming.Sende
 	start := time.Now()
 	agg := run.NewAggregator(stream)
 	err = job.Run(ctx, r.db, agg)
-	matches, common, matchCount := agg.Get()
+	common, matchCount := agg.Get()
 
 	ao := alert.Observer{
 		Db:           r.db,
@@ -1576,10 +1576,8 @@ func (r *searchResolver) evaluateJob(ctx context.Context, stream streaming.Sende
 	}
 	alert, err := ao.Done()
 
-	sort.Sort(matches)
-
 	rr := &SearchResults{
-		Matches: matches,
+		Matches: nil, // matches are always sent up the stream, which is always non-nil
 		Stats:   common,
 		Alert:   alert,
 	}


### PR DESCRIPTION
Now that we know stream will always be non-nil, we can simplify the
aggregator to assume that that can always send results to the parent
stream.

Stacked on #30576 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
