### PR TITLE
compute: enterprise compute streaming HTTP endpoint scaffolding

### DIFF
--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -22,6 +22,7 @@ type Services struct {
 	NewCodeIntelUploadHandler     NewCodeIntelUploadHandler
 	NewExecutorProxyHandler       NewExecutorProxyHandler
 	NewGitHubAppCloudSetupHandler NewGitHubAppCloudSetupHandler
+	NewComputeStreamHandler       NewComputeStreamHandler
 	AuthzResolver                 graphqlbackend.AuthzResolver
 	BatchChangesResolver          graphqlbackend.BatchChangesResolver
 	CodeIntelResolver             graphqlbackend.CodeIntelResolver
@@ -48,6 +49,9 @@ type NewExecutorProxyHandler func() http.Handler
 // GitHub App setup URL endpoint.
 type NewGitHubAppCloudSetupHandler func() http.Handler
 
+// NewComputeStreamHandler creates a new handler for the Sourcegraph Compute streaming endpoint.
+type NewComputeStreamHandler func() http.Handler
+
 // DefaultServices creates a new Services value that has default implementations for all services.
 func DefaultServices() Services {
 	return Services{
@@ -57,6 +61,7 @@ func DefaultServices() Services {
 		NewCodeIntelUploadHandler:     func(_ bool) http.Handler { return makeNotFoundHandler("code intel upload") },
 		NewExecutorProxyHandler:       func() http.Handler { return makeNotFoundHandler("executor proxy") },
 		NewGitHubAppCloudSetupHandler: func() http.Handler { return makeNotFoundHandler("Sourcegraph Cloud GitHub App setup") },
+		NewComputeStreamHandler:       func() http.Handler { return makeNotFoundHandler("compute streaming endpoint") },
 	}
 }
 

--- a/enterprise/cmd/frontend/internal/compute/init.go
+++ b/enterprise/cmd/frontend/internal/compute/init.go
@@ -2,6 +2,7 @@ package compute
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/compute/resolvers"
@@ -12,5 +13,15 @@ import (
 
 func Init(ctx context.Context, db database.DB, _ conftypes.UnifiedWatchable, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
 	enterpriseServices.ComputeResolver = resolvers.NewResolver(db)
+	enterpriseServices.NewComputeStreamHandler = newComputeStreamHandler
 	return nil
+}
+
+// newComputeStreamHandler implements the HTTP endpoint for the Compute stream.
+// TODO(rvantonder): #30527
+func newComputeStreamHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotImplemented)
+		_, _ = w.Write([]byte("compute stream endpoint unimplemented"))
+	})
 }


### PR DESCRIPTION
Chopping up the task of compute streaming. This adds a dummy HTTP handler to the enterprise side of compute service. Next I'll hook this handler up to a route.

Part of #30527