### PR TITLE
dev/ci: add RunType for nightly release branch healthchecks

### DIFF
--- a/enterprise/dev/ci/internal/ci/config.go
+++ b/enterprise/dev/ci/internal/ci/config.go
@@ -63,7 +63,8 @@ func NewConfig(now time.Time) Config {
 		tag    = os.Getenv("BUILDKITE_TAG")
 		// evaluates what type of pipeline run this is
 		runType = computeRunType(tag, branch, map[string]string{
-			"BEXT_NIGHTLY": os.Getenv("BEXT_NIGHTLY"),
+			"BEXT_NIGHTLY":    os.Getenv("BEXT_NIGHTLY"),
+			"RELEASE_NIGHTLY": os.Getenv("RELEASE_NIGHTLY"),
 		})
 		// defaults to 0
 		buildNumber, _ = strconv.Atoi(os.Getenv("BUILDKITE_BUILD_NUMBER"))

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -7,6 +7,9 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
+
+	"github.com/Masterminds/semver"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images"
 	bk "github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/buildkite"
@@ -445,6 +448,27 @@ func triggerAsync(buildOptions bk.BuildOptions) operations.Operation {
 			bk.Async(true),
 			bk.Build(buildOptions),
 		)
+	}
+}
+
+func triggerReleaseBranchHealthchecks(minimumUpgradeableVersion string) operations.Operation {
+	return func(pipeline *bk.Pipeline) {
+		version := semver.MustParse(minimumUpgradeableVersion)
+		for _, branch := range []string{
+			// Most recent major.minor
+			fmt.Sprintf("%d.%d", version.Major(), version.Minor()),
+			// The previous major.minor-1
+			fmt.Sprintf("%d.%d", version.Major(), version.Minor()-1),
+		} {
+			pipeline.AddTrigger(fmt.Sprintf(":stethoscope: Trigger %s release branch healthcheck build", branch),
+				bk.Trigger("sourcegraph"),
+				bk.Async(false),
+				bk.Build(bk.BuildOptions{
+					Branch:  branch,
+					Message: time.Now().Format(time.RFC1123) + " healthcheck build",
+				}),
+			)
+		}
 	}
 }
 

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -121,6 +121,9 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		}
 		ops.Merge(CoreTestOperations(c.Diff, CoreTestOperationsOptions{MinimumUpgradeableVersion: minimumUpgradeableVersion}))
 
+	case ReleaseNightly:
+		ops.Append(triggerReleaseBranchHealthchecks(minimumUpgradeableVersion))
+
 	case BackendIntegrationTests:
 		ops.Append(
 			buildCandidateDockerImage("server", c.Version, c.candidateImageTag()),

--- a/enterprise/dev/ci/internal/ci/runtype.go
+++ b/enterprise/dev/ci/internal/ci/runtype.go
@@ -16,7 +16,8 @@ const (
 
 	// Nightly builds - must be first because they take precedence
 
-	BextNightly // browser extension nightly build
+	ReleaseNightly // release branch nightly healthcheck builds
+	BextNightly    // browser extension nightly build
 
 	// Release branches
 
@@ -67,6 +68,12 @@ func (t RunType) Is(oneOfTypes ...RunType) bool {
 // Matcher returns the requirements for a build to be considered of this RunType.
 func (t RunType) Matcher() *RunTypeMatcher {
 	switch t {
+	case ReleaseNightly:
+		return &RunTypeMatcher{
+			EnvIncludes: map[string]string{
+				"RELEASE_NIGHTLY": "true",
+			},
+		}
 	case BextNightly:
 		return &RunTypeMatcher{
 			EnvIncludes: map[string]string{
@@ -130,6 +137,8 @@ func (t RunType) String() string {
 	case PullRequest:
 		return "Pull request"
 
+	case ReleaseNightly:
+		return "Release branch nightly healthcheck build"
 	case BextNightly:
 		return "Browser extension nightly release build"
 

--- a/enterprise/dev/ci/internal/ci/runtype_test.go
+++ b/enterprise/dev/ci/internal/ci/runtype_test.go
@@ -51,6 +51,15 @@ func TestComputeRunType(t *testing.T) {
 			},
 		},
 		want: BextNightly,
+	}, {
+		name: "release nightly",
+		args: args{
+			branch: "main",
+			env: map[string]string{
+				"RELEASE_NIGHTLY": "true",
+			},
+		},
+		want: ReleaseNightly,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Introduces a RunType that will trigger builds on the `$major.$minor` and `$major.$minor-1` branches corresponding to the minimum upgradeable version.
The goal of this is to allow the Delivery and DevX team to keep tabs on the releasability of recent release branches to enable patches to be shipped faster - due to CI changes, patch releases seem to frequently run into blocking issues due to failed builds on outdated branches, for example: https://github.com/sourcegraph/sourcegraph/issues/30567, [Slack discussion](https://sourcegraph.slack.com/archives/C01N83PS4TU/p1643826301903359?thread_ts=1643824826.104819&cid=C01N83PS4TU).

This RunType will be set up to be triggered via Buildkite scheduled builds once a day. Based on how it behaves, we can set up relevant alerting on it for #buildkite-main as well, though for now I suggest we manually monitor it.

This change is stacked on top of some pending refactors that improve the way RunTypes are implemented: https://github.com/sourcegraph/sourcegraph/pull/30581#issuecomment-1028371187

### Example

![image](https://user-images.githubusercontent.com/23356519/152242881-795f2ae7-2898-45af-b30f-b8de97057c26.png)

- https://buildkite.com/sourcegraph/sourcegraph/builds/128766
- https://buildkite.com/sourcegraph/sourcegraph/builds/128767