### PR TITLE
compute: add .api/compute/stream route

### DIFF
--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -42,6 +42,7 @@ func newExternalHTTPHandler(
 	newCodeIntelUploadHandler enterprise.NewCodeIntelUploadHandler,
 	newExecutorProxyHandler enterprise.NewExecutorProxyHandler,
 	newGitHubAppCloudSetupHandler enterprise.NewGitHubAppCloudSetupHandler,
+	newComputeStreamHandler enterprise.NewComputeStreamHandler,
 	rateLimitWatcher graphqlbackend.LimitWatcher,
 ) (http.Handler, error) {
 	// Each auth middleware determines on a per-request basis whether it should be enabled (if not, it
@@ -50,7 +51,7 @@ func newExternalHTTPHandler(
 
 	// HTTP API handler, the call order of middleware is LIFO.
 	r := router.New(mux.NewRouter().PathPrefix("/.api/").Subrouter())
-	apiHandler := internalhttpapi.NewHandler(db, r, schema, gitHubWebhook, gitLabWebhook, bitbucketServerWebhook, newCodeIntelUploadHandler, rateLimitWatcher)
+	apiHandler := internalhttpapi.NewHandler(db, r, schema, gitHubWebhook, gitLabWebhook, bitbucketServerWebhook, newCodeIntelUploadHandler, newComputeStreamHandler, rateLimitWatcher)
 	if hooks.PostAuthMiddleware != nil {
 		// 🚨 SECURITY: These all run after the auth handler so the client is authenticated.
 		apiHandler = hooks.PostAuthMiddleware(apiHandler)

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -317,6 +317,7 @@ func makeExternalAPI(db database.DB, schema *graphql.Schema, enterprise enterpri
 		enterprise.NewCodeIntelUploadHandler,
 		enterprise.NewExecutorProxyHandler,
 		enterprise.NewGitHubAppCloudSetupHandler,
+		enterprise.NewComputeStreamHandler,
 		rateLimiter,
 	)
 	if err != nil {

--- a/cmd/frontend/internal/httpapi/api_test.go
+++ b/cmd/frontend/internal/httpapi/api_test.go
@@ -28,6 +28,7 @@ func newTest() *httptestutil.Client {
 		enterpriseServices.GitLabWebhook,
 		enterpriseServices.BitbucketServerWebhook,
 		enterpriseServices.NewCodeIntelUploadHandler,
+		enterpriseServices.NewComputeStreamHandler,
 		rateLimiter,
 	))
 }

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -43,7 +43,17 @@ import (
 //
 // 🚨 SECURITY: The caller MUST wrap the returned handler in middleware that checks authentication
 // and sets the actor in the request context.
-func NewHandler(db database.DB, m *mux.Router, schema *graphql.Schema, githubWebhook webhooks.Registerer, gitlabWebhook, bitbucketServerWebhook http.Handler, newCodeIntelUploadHandler enterprise.NewCodeIntelUploadHandler, rateLimiter graphqlbackend.LimitWatcher) http.Handler {
+func NewHandler(
+	db database.DB,
+	m *mux.Router,
+	schema *graphql.Schema,
+	githubWebhook webhooks.Registerer,
+	gitlabWebhook,
+	bitbucketServerWebhook http.Handler,
+	newCodeIntelUploadHandler enterprise.NewCodeIntelUploadHandler,
+	newComputeStreamHandler enterprise.NewComputeStreamHandler,
+	rateLimiter graphqlbackend.LimitWatcher,
+) http.Handler {
 	if m == nil {
 		m = apirouter.New(nil)
 	}
@@ -76,6 +86,7 @@ func NewHandler(db database.DB, m *mux.Router, schema *graphql.Schema, githubWeb
 	m.Get(apirouter.GitLabWebhooks).Handler(trace.Route(webhookMiddleware.Logger(gitlabWebhook)))
 	m.Get(apirouter.BitbucketServerWebhooks).Handler(trace.Route(webhookMiddleware.Logger(bitbucketServerWebhook)))
 	m.Get(apirouter.LSIFUpload).Handler(trace.Route(newCodeIntelUploadHandler(false)))
+	m.Get(apirouter.ComputeStream).Handler(trace.Route(newComputeStreamHandler()))
 
 	if envvar.SourcegraphDotComMode() {
 		m.Path("/updates").Methods("GET", "POST").Name("updatecheck").Handler(trace.Route(http.HandlerFunc(updatecheck.Handler)))

--- a/cmd/frontend/internal/httpapi/router/router.go
+++ b/cmd/frontend/internal/httpapi/router/router.go
@@ -11,7 +11,8 @@ const (
 	LSIFUpload = "lsif.upload"
 	GraphQL    = "graphql"
 
-	SearchStream = "search.stream"
+	SearchStream  = "search.stream"
+	ComputeStream = "compute.stream"
 
 	SrcCliVersion  = "src-cli.version"
 	SrcCliDownload = "src-cli.download"
@@ -69,6 +70,7 @@ func New(base *mux.Router) *mux.Router {
 	base.Path("/bitbucket-server-webhooks").Methods("POST").Name(BitbucketServerWebhooks)
 	base.Path("/lsif/upload").Methods("POST").Name(LSIFUpload)
 	base.Path("/search/stream").Methods("GET").Name(SearchStream)
+	base.Path("/compute/stream").Methods("GET").Name(ComputeStream)
 	base.Path("/src-cli/version").Methods("GET").Name(SrcCliVersion)
 	base.Path("/src-cli/{rest:.*}").Methods("GET").Name(SrcCliDownload)
 


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/30580. This adds `.api/compute/stream` and served by the compute handler in `enterprise`:


<img width="476" alt="Screen Shot 2022-02-02 at 1 47 37 PM" src="https://user-images.githubusercontent.com/888624/152242976-1b33e5a1-c234-42a7-83a2-303d1c0198a3.png">

Note that unlike `stream/search` this is _not_ added to the UI routing. May have to deal with https://github.com/sourcegraph/sourcegraph/issues/29399#issuecomment-1006562412 once I start adding web things but yeah.

Part of https://github.com/sourcegraph/sourcegraph/issues/30527