### PR TITLE
user invites: components: add flex option to CopyableText

### DIFF
--- a/client/web/src/components/CopyableText.tsx
+++ b/client/web/src/components/CopyableText.tsx
@@ -14,6 +14,9 @@ interface Props {
     /** An optional class name. */
     className?: string
 
+    /** Whether or not the input should take up all horizontal space (flex:1) */
+    flex?: boolean
+
     /** The size of the input element. */
     size?: number
 
@@ -37,7 +40,7 @@ export class CopyableText extends React.PureComponent<Props, State> {
     public render(): JSX.Element | null {
         return (
             <div className={classNames('form-inline', this.props.className)}>
-                <div className="input-group">
+                <div className={classNames('input-group', this.props.flex && 'flex-1')}>
                     <input
                         type={this.props.password ? 'password' : 'text'}
                         className={classNames('form-control', styles.input)}


### PR DESCRIPTION
I need a way to make `CopyableText` have a `flex: 1` layout to consume the horizontal width. For example right now this text box does not consume all horizontal width in the container:

<img width="649" alt="image" src="https://user-images.githubusercontent.com/3173176/152246017-f23c3357-0071-4522-941b-50357bc64d03.png">

I need a way to enable it to, and so adding this option.

Part of #27101

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>