### PR TITLE
web: useExternalServices: add option to fetch collaborators

### DIFF
--- a/client/web/src/auth/useExternalServices.ts
+++ b/client/web/src/auth/useExternalServices.ts
@@ -1,7 +1,10 @@
 import { ApolloError, ApolloQueryResult } from '@apollo/client'
 
 import { useQuery } from '@sourcegraph/http-client'
-import { EXTERNAL_SERVICES } from '@sourcegraph/web/src/components/externalServices/backend'
+import {
+    EXTERNAL_SERVICES_WITH_COLLABORATORS,
+    EXTERNAL_SERVICES,
+} from '@sourcegraph/web/src/components/externalServices/backend'
 
 import {
     Exact,
@@ -28,9 +31,12 @@ interface UseExternalServicesResult {
     ) => Promise<ApolloQueryResult<ExternalServicesResult>>
 }
 
-export const useExternalServices = (userId: string | null): UseExternalServicesResult => {
+export const useExternalServices = (
+    userId: string | null,
+    fetchCollaborators: boolean = false
+): UseExternalServicesResult => {
     const { data, loading, error, refetch } = useQuery<ExternalServicesResult, ExternalServicesVariables>(
-        EXTERNAL_SERVICES,
+        fetchCollaborators ? EXTERNAL_SERVICES_WITH_COLLABORATORS : EXTERNAL_SERVICES,
         {
             variables: {
                 namespace: userId,

--- a/client/web/src/auth/useExternalServicesWithCollaborators.ts
+++ b/client/web/src/auth/useExternalServicesWithCollaborators.ts
@@ -1,17 +1,17 @@
 import { ApolloError, ApolloQueryResult } from '@apollo/client'
 
 import { useQuery } from '@sourcegraph/http-client'
-import { EXTERNAL_SERVICES } from '@sourcegraph/web/src/components/externalServices/backend'
+import { EXTERNAL_SERVICES_WITH_COLLABORATORS } from '@sourcegraph/web/src/components/externalServices/backend'
 
 import {
     Exact,
-    ExternalServicesResult,
-    ExternalServicesVariables,
+    ExternalServicesWithCollaboratorsResult,
+    ExternalServicesWithCollaboratorsVariables,
     ListExternalServiceFields,
     Maybe,
 } from '../graphql-operations'
 
-interface UseExternalServicesResult {
+interface UseExternalServicesWithCollaboratorsResult {
     externalServices: ListExternalServiceFields[] | undefined
     loadingServices: boolean
     errorServices: ApolloError | undefined
@@ -25,20 +25,20 @@ interface UseExternalServicesResult {
                   }>
               >
             | undefined
-    ) => Promise<ApolloQueryResult<ExternalServicesResult>>
+    ) => Promise<ApolloQueryResult<ExternalServicesWithCollaboratorsResult>>
 }
 
-export const useExternalServices = (userId: string | null): UseExternalServicesResult => {
-    const { data, loading, error, refetch } = useQuery<ExternalServicesResult, ExternalServicesVariables>(
-        EXTERNAL_SERVICES,
-        {
-            variables: {
-                namespace: userId,
-                first: null,
-                after: null,
-            },
-        }
-    )
+export const useExternalServicesWithCollaborators = (userId: string | null): UseExternalServicesWithCollaboratorsResult => {
+    const { data, loading, error, refetch } = useQuery<
+        ExternalServicesWithCollaboratorsResult,
+        ExternalServicesWithCollaboratorsVariables
+    >(EXTERNAL_SERVICES_WITH_COLLABORATORS, {
+        variables: {
+            namespace: userId,
+            first: null,
+            after: null,
+        },
+    })
 
     return {
         externalServices: data?.externalServices.nodes,

--- a/client/web/src/auth/useExternalServicesWithCollaborators.ts
+++ b/client/web/src/auth/useExternalServicesWithCollaborators.ts
@@ -28,7 +28,9 @@ interface UseExternalServicesWithCollaboratorsResult {
     ) => Promise<ApolloQueryResult<ExternalServicesWithCollaboratorsResult>>
 }
 
-export const useExternalServicesWithCollaborators = (userId: string | null): UseExternalServicesWithCollaboratorsResult => {
+export const useExternalServicesWithCollaborators = (
+    userId: string | null
+): UseExternalServicesWithCollaboratorsResult => {
     const { data, loading, error, refetch } = useQuery<
         ExternalServicesWithCollaboratorsResult,
         ExternalServicesWithCollaboratorsVariables

--- a/client/web/src/components/externalServices/backend.ts
+++ b/client/web/src/components/externalServices/backend.ts
@@ -208,6 +208,29 @@ export const listExternalServiceFragment = gql`
     }
 `
 
+export const EXTERNAL_SERVICES_WITH_COLLABORATORS = gql`
+    query ExternalServicesWithCollaborators($first: Int, $after: String, $namespace: ID) {
+        externalServices(first: $first, after: $after, namespace: $namespace) {
+            nodes {
+                ...ListExternalServiceFields
+                invitableCollaborators {
+                    email
+                    displayName
+                    name
+                    avatarURL
+                }
+            }
+            totalCount
+            pageInfo {
+                endCursor
+                hasNextPage
+            }
+        }
+    }
+
+    ${listExternalServiceFragment}
+`
+
 export const EXTERNAL_SERVICES = gql`
     query ExternalServices($first: Int, $after: String, $namespace: ID) {
         externalServices(first: $first, after: $after, namespace: $namespace) {


### PR DESCRIPTION
This adds an option to `useExternalServices` which causes it to additionally fetch `invitableCollaborators`

Part of #27101

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>