### PR TITLE
gitserver: put paths for git archive in the HTTP body

### DIFF
--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -303,7 +303,7 @@ func serveGitTar(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	opts := gitserver.ArchiveOptions{
+	opts := gitserver.ArchiveUrlOptions{
 		Treeish: string(commit),
 		Format:  "tar",
 	}

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -865,8 +865,15 @@ func (s *Server) handleArchive(w http.ResponseWriter, r *http.Request) {
 		treeish = q.Get("treeish")
 		repo    = q.Get("repo")
 		format  = q.Get("format")
-		paths   = q["path"]
 	)
+
+	var paths []string
+	var archiveBody protocol.ArchiveBody
+	if err := json.NewDecoder(r.Body).Decode(&archiveBody); err == nil {
+		if paths == nil && archiveBody.Paths != nil {
+			paths = archiveBody.Paths
+		}
+	}
 
 	if err := checkSpecArgSafety(treeish); err != nil {
 		w.WriteHeader(http.StatusBadRequest)

--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -70,7 +70,8 @@ func main() {
 	service := &search.Service{
 		Store: &store.Store{
 			FetchTar: func(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
-				return gitserver.DefaultClient.Archive(ctx, repo, gitserver.ArchiveOptions{Treeish: string(commit), Format: "tar"})
+				urlOptions := gitserver.ArchiveUrlOptions{Treeish: string(commit), Format: "tar"}
+				return gitserver.DefaultClient.Archive(ctx, repo, gitserver.ArchiveOptions{ArchiveUrlOptions: urlOptions})
 			},
 			FilterTar:         search.NewFilter,
 			Path:              filepath.Join(cacheDir, "searcher-archives"),

--- a/cmd/symbols/internal/gitserver/client.go
+++ b/cmd/symbols/internal/gitserver/client.go
@@ -53,9 +53,11 @@ func (c *gitserverClient) FetchTar(ctx context.Context, repo api.RepoName, commi
 	defer endObservation(1, observation.Args{})
 
 	opts := gitserver.ArchiveOptions{
-		Treeish: string(commit),
-		Format:  "tar",
-		Paths:   paths,
+		ArchiveUrlOptions: gitserver.ArchiveUrlOptions{
+			Treeish: string(commit),
+			Format:  "tar",
+		},
+		Paths: paths,
 	}
 
 	return gitserver.DefaultClient.Archive(ctx, repo, opts)

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -145,7 +145,7 @@ func TestClient_Archive(t *testing.T) {
 				}
 			}
 
-			rc, err := cli.Archive(ctx, name, gitserver.ArchiveOptions{Treeish: "HEAD", Format: "zip"})
+			rc, err := cli.Archive(ctx, name, gitserver.ArchiveOptions{ArchiveUrlOptions: gitserver.ArchiveUrlOptions{Treeish: "HEAD", Format: "zip"}})
 			if have, want := fmt.Sprint(err), fmt.Sprint(test.err); have != want {
 				t.Errorf("archive: have err %v, want %v", have, want)
 			}

--- a/internal/gitserver/mock_client.go
+++ b/internal/gitserver/mock_client.go
@@ -106,7 +106,7 @@ func NewMockClient() *MockClient {
 			},
 		},
 		ArchiveURLFunc: &ClientArchiveURLFunc{
-			defaultHook: func(api.RepoName, ArchiveOptions) *url.URL {
+			defaultHook: func(api.RepoName, ArchiveUrlOptions) *url.URL {
 				return nil
 			},
 		},
@@ -218,7 +218,7 @@ func NewStrictMockClient() *MockClient {
 			},
 		},
 		ArchiveURLFunc: &ClientArchiveURLFunc{
-			defaultHook: func(api.RepoName, ArchiveOptions) *url.URL {
+			defaultHook: func(api.RepoName, ArchiveUrlOptions) *url.URL {
 				panic("unexpected invocation of MockClient.ArchiveURL")
 			},
 		},
@@ -695,15 +695,15 @@ func (c ClientArchiveFuncCall) Results() []interface{} {
 // ClientArchiveURLFunc describes the behavior when the ArchiveURL method of
 // the parent MockClient instance is invoked.
 type ClientArchiveURLFunc struct {
-	defaultHook func(api.RepoName, ArchiveOptions) *url.URL
-	hooks       []func(api.RepoName, ArchiveOptions) *url.URL
+	defaultHook func(api.RepoName, ArchiveUrlOptions) *url.URL
+	hooks       []func(api.RepoName, ArchiveUrlOptions) *url.URL
 	history     []ClientArchiveURLFuncCall
 	mutex       sync.Mutex
 }
 
 // ArchiveURL delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockClient) ArchiveURL(v0 api.RepoName, v1 ArchiveOptions) *url.URL {
+func (m *MockClient) ArchiveURL(v0 api.RepoName, v1 ArchiveUrlOptions) *url.URL {
 	r0 := m.ArchiveURLFunc.nextHook()(v0, v1)
 	m.ArchiveURLFunc.appendCall(ClientArchiveURLFuncCall{v0, v1, r0})
 	return r0
@@ -711,7 +711,7 @@ func (m *MockClient) ArchiveURL(v0 api.RepoName, v1 ArchiveOptions) *url.URL {
 
 // SetDefaultHook sets function that is called when the ArchiveURL method of
 // the parent MockClient instance is invoked and the hook queue is empty.
-func (f *ClientArchiveURLFunc) SetDefaultHook(hook func(api.RepoName, ArchiveOptions) *url.URL) {
+func (f *ClientArchiveURLFunc) SetDefaultHook(hook func(api.RepoName, ArchiveUrlOptions) *url.URL) {
 	f.defaultHook = hook
 }
 
@@ -719,7 +719,7 @@ func (f *ClientArchiveURLFunc) SetDefaultHook(hook func(api.RepoName, ArchiveOpt
 // ArchiveURL method of the parent MockClient instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *ClientArchiveURLFunc) PushHook(hook func(api.RepoName, ArchiveOptions) *url.URL) {
+func (f *ClientArchiveURLFunc) PushHook(hook func(api.RepoName, ArchiveUrlOptions) *url.URL) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -728,7 +728,7 @@ func (f *ClientArchiveURLFunc) PushHook(hook func(api.RepoName, ArchiveOptions) 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *ClientArchiveURLFunc) SetDefaultReturn(r0 *url.URL) {
-	f.SetDefaultHook(func(api.RepoName, ArchiveOptions) *url.URL {
+	f.SetDefaultHook(func(api.RepoName, ArchiveUrlOptions) *url.URL {
 		return r0
 	})
 }
@@ -736,12 +736,12 @@ func (f *ClientArchiveURLFunc) SetDefaultReturn(r0 *url.URL) {
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *ClientArchiveURLFunc) PushReturn(r0 *url.URL) {
-	f.PushHook(func(api.RepoName, ArchiveOptions) *url.URL {
+	f.PushHook(func(api.RepoName, ArchiveUrlOptions) *url.URL {
 		return r0
 	})
 }
 
-func (f *ClientArchiveURLFunc) nextHook() func(api.RepoName, ArchiveOptions) *url.URL {
+func (f *ClientArchiveURLFunc) nextHook() func(api.RepoName, ArchiveUrlOptions) *url.URL {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -779,7 +779,7 @@ type ClientArchiveURLFuncCall struct {
 	Arg0 api.RepoName
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 ArchiveOptions
+	Arg1 ArchiveUrlOptions
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 *url.URL

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -98,6 +98,12 @@ type ExecRequest struct {
 	Opt            *RemoteOpts `json:"opt"`
 }
 
+// ArchiveBody specifies paths for `git archive`. Paths are put in the body because there's a limit to
+// how big a URL query can get. The other arguments are put in the URL query.
+type ArchiveBody struct {
+	Paths []string `json:"paths"`
+}
+
 // P4ExecRequest is a request to execute a p4 command with given arguments.
 //
 // Note that this request is deserialized by both gitserver and the frontend's


### PR DESCRIPTION
Prior to this change, the paths were put in the URL query, which had limited size.

After this change, paths will be put in the HTTP body.