### PR TITLE
migrations: Poll for advisory locks in the runner

### DIFF
--- a/internal/database/connections/test/store.go
+++ b/internal/database/connections/test/store.go
@@ -45,10 +45,6 @@ func (s *memoryStore) Versions(ctx context.Context) (appliedVersions, pendingVer
 	return s.appliedVersions, s.pendingVersions, s.failedVersions, nil
 }
 
-func (s *memoryStore) Lock(ctx context.Context) (bool, func(err error) error, error) {
-	return true, func(err error) error { return err }, nil
-}
-
 func (s *memoryStore) TryLock(ctx context.Context) (bool, func(err error) error, error) {
 	return true, func(err error) error { return err }, nil
 }

--- a/internal/database/migration/runner/helpers_test.go
+++ b/internal/database/migration/runner/helpers_test.go
@@ -53,7 +53,6 @@ func testStoreWithVersion(version int, dirty bool) *MockStore {
 	store.TransactFunc.SetDefaultReturn(store, nil)
 	store.DoneFunc.SetDefaultHook(func(err error) error { return err })
 	store.VersionFunc.SetDefaultHook(func(ctx context.Context) (int, bool, bool, error) { return version, dirty, true, nil })
-	store.LockFunc.SetDefaultReturn(true, func(err error) error { return err }, nil)
 	store.TryLockFunc.SetDefaultReturn(true, func(err error) error { return err }, nil)
 	store.UpFunc.SetDefaultHook(migrationHook)
 	store.DownFunc.SetDefaultHook(migrationHook)

--- a/internal/database/migration/runner/iface.go
+++ b/internal/database/migration/runner/iface.go
@@ -12,7 +12,6 @@ type Store interface {
 
 	Version(ctx context.Context) (int, bool, bool, error)
 	Versions(ctx context.Context) (appliedVersions, pendingVersions, failedVersions []int, _ error)
-	Lock(ctx context.Context) (bool, func(err error) error, error)
 	TryLock(ctx context.Context) (bool, func(err error) error, error)
 	Up(ctx context.Context, migration definition.Definition) error
 	Down(ctx context.Context, migration definition.Definition) error

--- a/internal/database/migration/runner/mock_iface_test.go
+++ b/internal/database/migration/runner/mock_iface_test.go
@@ -20,9 +20,6 @@ type MockStore struct {
 	// DownFunc is an instance of a mock function object controlling the
 	// behavior of the method Down.
 	DownFunc *StoreDownFunc
-	// LockFunc is an instance of a mock function object controlling the
-	// behavior of the method Lock.
-	LockFunc *StoreLockFunc
 	// TransactFunc is an instance of a mock function object controlling the
 	// behavior of the method Transact.
 	TransactFunc *StoreTransactFunc
@@ -55,11 +52,6 @@ func NewMockStore() *MockStore {
 		DownFunc: &StoreDownFunc{
 			defaultHook: func(context.Context, definition.Definition) error {
 				return nil
-			},
-		},
-		LockFunc: &StoreLockFunc{
-			defaultHook: func(context.Context) (bool, func(err error) error, error) {
-				return false, nil, nil
 			},
 		},
 		TransactFunc: &StoreTransactFunc{
@@ -109,11 +101,6 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.Down")
 			},
 		},
-		LockFunc: &StoreLockFunc{
-			defaultHook: func(context.Context) (bool, func(err error) error, error) {
-				panic("unexpected invocation of MockStore.Lock")
-			},
-		},
 		TransactFunc: &StoreTransactFunc{
 			defaultHook: func(context.Context) (Store, error) {
 				panic("unexpected invocation of MockStore.Transact")
@@ -156,9 +143,6 @@ func NewMockStoreFrom(i Store) *MockStore {
 		},
 		DownFunc: &StoreDownFunc{
 			defaultHook: i.Down,
-		},
-		LockFunc: &StoreLockFunc{
-			defaultHook: i.Lock,
 		},
 		TransactFunc: &StoreTransactFunc{
 			defaultHook: i.Transact,
@@ -386,114 +370,6 @@ func (c StoreDownFuncCall) Args() []interface{} {
 // invocation.
 func (c StoreDownFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
-}
-
-// StoreLockFunc describes the behavior when the Lock method of the parent
-// MockStore instance is invoked.
-type StoreLockFunc struct {
-	defaultHook func(context.Context) (bool, func(err error) error, error)
-	hooks       []func(context.Context) (bool, func(err error) error, error)
-	history     []StoreLockFuncCall
-	mutex       sync.Mutex
-}
-
-// Lock delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockStore) Lock(v0 context.Context) (bool, func(err error) error, error) {
-	r0, r1, r2 := m.LockFunc.nextHook()(v0)
-	m.LockFunc.appendCall(StoreLockFuncCall{v0, r0, r1, r2})
-	return r0, r1, r2
-}
-
-// SetDefaultHook sets function that is called when the Lock method of the
-// parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreLockFunc) SetDefaultHook(hook func(context.Context) (bool, func(err error) error, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// Lock method of the parent MockStore instance invokes the hook at the
-// front of the queue and discards it. After the queue is empty, the default
-// hook function is invoked for any future action.
-func (f *StoreLockFunc) PushHook(hook func(context.Context) (bool, func(err error) error, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
-// the given values.
-func (f *StoreLockFunc) SetDefaultReturn(r0 bool, r1 func(err error) error, r2 error) {
-	f.SetDefaultHook(func(context.Context) (bool, func(err error) error, error) {
-		return r0, r1, r2
-	})
-}
-
-// PushReturn calls PushDefaultHook with a function that returns the given
-// values.
-func (f *StoreLockFunc) PushReturn(r0 bool, r1 func(err error) error, r2 error) {
-	f.PushHook(func(context.Context) (bool, func(err error) error, error) {
-		return r0, r1, r2
-	})
-}
-
-func (f *StoreLockFunc) nextHook() func(context.Context) (bool, func(err error) error, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreLockFunc) appendCall(r0 StoreLockFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of StoreLockFuncCall objects describing the
-// invocations of this function.
-func (f *StoreLockFunc) History() []StoreLockFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreLockFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreLockFuncCall is an object that describes an invocation of method
-// Lock on an instance of MockStore.
-type StoreLockFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 bool
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 func(err error) error
-	// Result2 is the value of the 3rd result returned from this method
-	// invocation.
-	Result2 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreLockFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreLockFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
 // StoreTransactFunc describes the behavior when the Transact method of the

--- a/internal/database/migration/runner/runner.go
+++ b/internal/database/migration/runner/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 
@@ -177,6 +178,28 @@ func (r *Runner) fetchVersion(ctx context.Context, schemaName string, store Stor
 	}, nil
 }
 
+const lockPollInterval = time.Second
+
+// pollLock will attempt to acquire a session-level advisory lock while the given context has not
+// been canceled. The caller must eventually invoke the unlock function on successful acquisition
+// of the lock.
+func (r *Runner) pollLock(ctx context.Context, store Store) (unlock func(err error) error, _ error) {
+	for {
+		if acquired, unlock, err := store.TryLock(ctx); err != nil {
+			return nil, err
+		} else if acquired {
+			return unlock, nil
+		}
+
+		select {
+		case <-time.After(lockPollInterval):
+			continue
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}
+
 type lockedVersionCallback func(
 	schemaVersion schemaVersion,
 ) error
@@ -184,11 +207,14 @@ type lockedVersionCallback func(
 // withLockedSchemaState attempts to take an advisory lock, then re-checks the version of the
 // database. The resulting schema state is passed to the given function. The advisory lock
 // will be released on function exit.
-func (r *Runner) withLockedSchemaState(ctx context.Context, schemaContext schemaContext, callback lockedVersionCallback) (err error) {
-	if acquired, unlock, err := schemaContext.store.Lock(ctx); err != nil {
+func (r *Runner) withLockedSchemaState(
+	ctx context.Context,
+	schemaContext schemaContext,
+	callback lockedVersionCallback,
+) (err error) {
+	unlock, err := r.pollLock(ctx, schemaContext.store)
+	if err != nil {
 		return err
-	} else if !acquired {
-		return fmt.Errorf("failed to acquire migration lock")
 	} else {
 		defer func() { err = unlock(err) }()
 	}

--- a/internal/database/migration/runner/validate.go
+++ b/internal/database/migration/runner/validate.go
@@ -2,7 +2,6 @@ package runner
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/definition"
 )
@@ -108,10 +107,8 @@ func (r *Runner) waitForMigration(ctx context.Context, schemaName string, schema
 }
 
 func (r *Runner) lockedVersion(ctx context.Context, schemaContext schemaContext) (_ schemaVersion, err error) {
-	if locked, unlock, err := schemaContext.store.Lock(ctx); err != nil {
+	if unlock, err := r.pollLock(ctx, schemaContext.store); err != nil {
 		return schemaVersion{}, err
-	} else if !locked {
-		return schemaVersion{}, fmt.Errorf("failed to acquire migration lock")
 	} else {
 		defer func() { err = unlock(err) }()
 	}

--- a/internal/database/migration/store/store_test.go
+++ b/internal/database/migration/store/store_test.go
@@ -174,26 +174,6 @@ func TestVersions(t *testing.T) {
 	)
 }
 
-func TestLock(t *testing.T) {
-	db := dbtest.NewDB(t)
-	store := testStore(db)
-	ctx := context.Background()
-
-	t.Run("sanity test", func(t *testing.T) {
-		acquired, close, err := store.Lock(ctx)
-		if err != nil {
-			t.Fatalf("unexpected error acquiring lock: %s", err)
-		}
-		if !acquired {
-			t.Fatalf("expected lock to be acquired")
-		}
-
-		if err := close(nil); err != nil {
-			t.Fatalf("unexpected error releasing lock: %s", err)
-		}
-	})
-}
-
 func TestTryLock(t *testing.T) {
 	db := dbtest.NewDB(t)
 	store := testStore(db)


### PR DESCRIPTION
Pulled from #29831. In this PR, we remove the `Lock` method from the flow of the migration runner and rely only on the `TryLock` method. Where `Lock` was used before, we replace with a polling loop that tries to acquire the lock.

This change will prevent a class of errors in which concurrent index creation live/dead-locks with the migration advisory locks (depending on the number of concurrent migrators, the previous code live-locks AND dead-locks). By refreshing the transaction ID on every attempt of the lock, we ensure that we don't starve out concurrent index creation by holding open long transactions while waiting for migrations to finish.