### PR TITLE
Search backend: add alert as a return value to the job interface

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -45,7 +45,7 @@ func (srs *searchResultsStats) getResults(ctx context.Context) (result.Matches, 
 			return
 		}
 		agg := streaming.NewAggregatingStream()
-		err = job.Run(ctx, srs.sr.db, agg)
+		_, err = job.Run(ctx, srs.sr.db, agg)
 		if err != nil {
 			srs.err = err
 			return

--- a/internal/search/alert.go
+++ b/internal/search/alert.go
@@ -3,6 +3,7 @@ package search
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 
@@ -18,6 +19,31 @@ type Alert struct {
 	ProposedQueries []*ProposedQuery
 	// The higher the priority the more important is the alert.
 	Priority int
+}
+
+func MaxPriorityAlert(alerts ...*Alert) (max *Alert) {
+	for _, alert := range alerts {
+		if alert == nil {
+			continue
+		}
+		if max == nil || alert.Priority > max.Priority {
+			max = alert
+		}
+	}
+	return max
+}
+
+// MaxAlerter is a simple struct that provides a thread-safe way
+// to aggregate a set of alerts, leaving the highest priority alert
+type MaxAlerter struct {
+	sync.Mutex
+	*Alert
+}
+
+func (m *MaxAlerter) Add(a *Alert) {
+	m.Lock()
+	m.Alert = MaxPriorityAlert(m.Alert, a)
+	m.Unlock()
 }
 
 type ProposedQuery struct {

--- a/internal/search/alert_test.go
+++ b/internal/search/alert_test.go
@@ -6,8 +6,47 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 )
+
+func TestMaxPriorityAlert(t *testing.T) {
+	t.Run("no alerts", func(t *testing.T) {
+		require.Equal(t, (*Alert)(nil), MaxPriorityAlert())
+	})
+
+	t.Run("nil alert", func(t *testing.T) {
+		require.Equal(t, (*Alert)(nil), MaxPriorityAlert(nil))
+	})
+
+	t.Run("one alert", func(t *testing.T) {
+		a1 := Alert{Title: "test1"}
+		require.Equal(t, &a1, MaxPriorityAlert(&a1))
+	})
+
+	t.Run("equal priority alerts", func(t *testing.T) {
+		a1 := Alert{Title: "test1"}
+		a2 := Alert{Title: "test2"}
+		require.Equal(t, &a1, MaxPriorityAlert(&a1, &a2))
+	})
+
+	t.Run("higher priority alerts", func(t *testing.T) {
+		a1 := Alert{Title: "test1"}
+		a2 := Alert{Title: "test2", Priority: 2}
+		require.Equal(t, &a2, MaxPriorityAlert(&a1, &a2))
+	})
+
+	t.Run("nil and non-nil", func(t *testing.T) {
+		a1 := Alert{Title: "test1"}
+		require.Equal(t, &a1, MaxPriorityAlert(nil, &a1))
+	})
+
+	t.Run("non-nil and nil", func(t *testing.T) {
+		a1 := Alert{Title: "test1"}
+		require.Equal(t, &a1, MaxPriorityAlert(&a1, nil))
+	})
+}
 
 func TestSearchPatternForSuggestion(t *testing.T) {
 	cases := []struct {

--- a/internal/search/commit/commit_new.go
+++ b/internal/search/commit/commit_new.go
@@ -35,7 +35,7 @@ type CommitSearch struct {
 	IncludeModifiedFiles bool
 }
 
-func (j *CommitSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (err error) {
+func (j *CommitSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (_ *search.Alert, err error) {
 	tr, ctx := trace.New(ctx, "CommitSearch", "")
 	defer func() {
 		tr.SetError(err)
@@ -44,7 +44,7 @@ func (j *CommitSearch) Run(ctx context.Context, db database.DB, stream streaming
 	tr.TagFields(trace.LazyFields(j.Tags))
 
 	if err := j.ExpandUsernames(ctx, db); err != nil {
-		return err
+		return nil, err
 	}
 
 	opts := j.RepoOpts
@@ -66,7 +66,7 @@ func (j *CommitSearch) Run(ctx context.Context, db database.DB, stream streaming
 		return nil
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	bounded := goroutine.NewBounded(8)
@@ -109,7 +109,7 @@ func (j *CommitSearch) Run(ctx context.Context, db database.DB, stream streaming
 		})
 	}
 
-	return bounded.Wait()
+	return nil, bounded.Wait()
 }
 
 func (j CommitSearch) Name() string {

--- a/internal/search/repos/excluded_job.go
+++ b/internal/search/repos/excluded_job.go
@@ -13,7 +13,7 @@ type ComputeExcludedRepos struct {
 	Options search.RepoOptions
 }
 
-func (c *ComputeExcludedRepos) Run(ctx context.Context, db database.DB, s streaming.Sender) (err error) {
+func (c *ComputeExcludedRepos) Run(ctx context.Context, db database.DB, s streaming.Sender) (_ *search.Alert, err error) {
 	tr, ctx := trace.New(ctx, "ComputeExcludedRepos", "")
 	defer func() {
 		tr.SetError(err)
@@ -23,7 +23,7 @@ func (c *ComputeExcludedRepos) Run(ctx context.Context, db database.DB, s stream
 	repositoryResolver := Resolver{DB: db}
 	excluded, err := repositoryResolver.Excluded(ctx, c.Options)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	s.Send(streaming.SearchEvent{
@@ -33,7 +33,7 @@ func (c *ComputeExcludedRepos) Run(ctx context.Context, db database.DB, s stream
 		},
 	})
 
-	return nil
+	return nil, nil
 }
 
 func (c *ComputeExcludedRepos) Name() string {

--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -23,7 +23,7 @@ type RepoSearch struct {
 	Args *search.TextParameters
 }
 
-func (s *RepoSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (err error) {
+func (s *RepoSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (_ *search.Alert, err error) {
 	tr, ctx := trace.New(ctx, "RepoSearch", "")
 	defer func() {
 		tr.SetError(err)
@@ -56,7 +56,7 @@ func (s *RepoSearch) Run(ctx context.Context, db database.DB, stream streaming.S
 		err = nil
 	}
 
-	return err
+	return nil, err
 }
 
 func (*RepoSearch) Name() string {

--- a/internal/search/run/run.go
+++ b/internal/search/run/run.go
@@ -48,6 +48,6 @@ func (inputs SearchInputs) MaxResults() int {
 // timeout). Calling Run on a job object runs a search.
 //go:generate ../../../dev/mockgen.sh github.com/sourcegraph/sourcegraph/internal/search/run -i Job -o job_mock_test.go
 type Job interface {
-	Run(context.Context, database.DB, streaming.Sender) error
+	Run(context.Context, database.DB, streaming.Sender) (*search.Alert, error)
 	Name() string
 }

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -418,7 +418,7 @@ type RepoSubsetSymbolSearch struct {
 	RepoOpts         search.RepoOptions
 }
 
-func (s *RepoSubsetSymbolSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (err error) {
+func (s *RepoSubsetSymbolSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (_ *search.Alert, err error) {
 	tr, ctx := trace.New(ctx, "RepoSubsetSymbolSearch", "")
 	defer func() {
 		tr.SetError(err)
@@ -426,7 +426,7 @@ func (s *RepoSubsetSymbolSearch) Run(ctx context.Context, db database.DB, stream
 	}()
 
 	repos := searchrepos.Resolver{DB: db, Opts: s.RepoOpts}
-	return repos.Paginate(ctx, nil, func(page *searchrepos.Resolved) error {
+	return nil, repos.Paginate(ctx, nil, func(page *searchrepos.Resolved) error {
 		request, ok, err := zoektutil.OnlyUnindexed(page.RepoRevs, s.ZoektArgs.Zoekt, s.UseIndex, s.ContainsRefGlobs, zoektutil.MissingRepoRevStatus(stream))
 		if err != nil {
 			return err
@@ -456,7 +456,7 @@ type RepoUniverseSymbolSearch struct {
 	RepoOptions search.RepoOptions
 }
 
-func (s *RepoUniverseSymbolSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (err error) {
+func (s *RepoUniverseSymbolSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (_ *search.Alert, err error) {
 	tr, ctx := trace.New(ctx, "RepoUniverseSymbolSearch", "")
 	defer func() {
 		tr.SetError(err)
@@ -478,7 +478,7 @@ func (s *RepoUniverseSymbolSearch) Run(ctx context.Context, db database.DB, stre
 	// TODO(rvantonder): The `true` argument corresponds to notSearcherOnly,
 	// implied by global search. Separate the concerns in the symbol search
 	// function so that we don't need to pass this value.
-	return symbolSearchInRepos(ctx, request, s.PatternInfo, true, s.Limit, stream)
+	return nil, symbolSearchInRepos(ctx, request, s.PatternInfo, true, s.Limit, stream)
 }
 
 func (*RepoUniverseSymbolSearch) Name() string {

--- a/internal/search/unindexed/structural.go
+++ b/internal/search/unindexed/structural.go
@@ -158,7 +158,7 @@ type StructuralSearch struct {
 	RepoOpts search.RepoOptions
 }
 
-func (s *StructuralSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (err error) {
+func (s *StructuralSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (_ *search.Alert, err error) {
 	tr, ctx := trace.New(ctx, "StructuralSearch", "")
 	defer func() {
 		tr.SetError(err)
@@ -166,7 +166,7 @@ func (s *StructuralSearch) Run(ctx context.Context, db database.DB, stream strea
 	}()
 
 	repos := &searchrepos.Resolver{DB: db, Opts: s.RepoOpts}
-	return repos.Paginate(ctx, nil, func(page *searchrepos.Resolved) error {
+	return nil, repos.Paginate(ctx, nil, func(page *searchrepos.Resolved) error {
 		request, ok, err := zoektutil.OnlyUnindexed(page.RepoRevs, s.ZoektArgs.Zoekt, s.UseIndex, s.ContainsRefGlobs, zoektutil.MissingRepoRevStatus(stream))
 		if err != nil {
 			return err

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -315,7 +315,7 @@ type RepoSubsetTextSearch struct {
 	RepoOpts search.RepoOptions
 }
 
-func (t *RepoSubsetTextSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (err error) {
+func (t *RepoSubsetTextSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (_ *search.Alert, err error) {
 	tr, ctx := trace.New(ctx, "RepoSubsetTextSearch", "")
 	defer func() {
 		tr.SetError(err)
@@ -323,7 +323,7 @@ func (t *RepoSubsetTextSearch) Run(ctx context.Context, db database.DB, stream s
 	}()
 
 	repos := &searchrepos.Resolver{DB: db, Opts: t.RepoOpts}
-	return repos.Paginate(ctx, nil, func(page *searchrepos.Resolved) error {
+	return nil, repos.Paginate(ctx, nil, func(page *searchrepos.Resolved) error {
 		request, ok, err := zoektutil.OnlyUnindexed(page.RepoRevs, t.ZoektArgs.Zoekt, t.UseIndex, t.ContainsRefGlobs, zoektutil.MissingRepoRevStatus(stream))
 		if err != nil {
 			return err
@@ -352,7 +352,7 @@ type RepoUniverseTextSearch struct {
 	UserID      int32
 }
 
-func (t *RepoUniverseTextSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (err error) {
+func (t *RepoUniverseTextSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (_ *search.Alert, err error) {
 	tr, ctx := trace.New(ctx, "RepoUniverseTextSearch", "")
 	defer func() {
 		tr.SetError(err)
@@ -375,7 +375,7 @@ func (t *RepoUniverseTextSearch) Run(ctx context.Context, db database.DB, stream
 	g.Go(func() error {
 		return zoektutil.DoZoektSearchGlobal(ctx, t.ZoektArgs, stream)
 	})
-	return g.Wait()
+	return nil, g.Wait()
 }
 
 func (*RepoUniverseTextSearch) Name() string {


### PR DESCRIPTION
With alerts being such a general bear to work with, I think expanding the job interface to return an alert is going to be the fastest way to keep converting search code to jobs. 

That said, I don't love it. Alerts are intended to be user-facing, and building a user-facing thing into our backend interface is a bad split of responsibilities. 

I think the ideal situation here would be to have a richer set of error types that are convertible to alerts outside of the job execution tree. However, this will take a great deal of work to get there, and we'll get more immediate value out of expanding jobs, so this is debt I'm willing to take on in return for the freedom it gives us to pay down other debt. 

