### PR TITLE
gitserver: No sources for a JVM dependency is non fatal

### DIFF
--- a/cmd/gitserver/server/vcs_syncer_jvm_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages_test.go
@@ -258,3 +258,14 @@ type simpleJVMPackageDBStoreMock struct{}
 func (m *simpleJVMPackageDBStoreMock) GetJVMDependencyRepos(ctx context.Context, filter dbstore.GetJVMDependencyReposOpts) ([]dbstore.JVMDependencyRepo, error) {
 	return []dbstore.JVMDependencyRepo{}, nil
 }
+
+// Sanity check errors.Is
+func TestIsError(t *testing.T) {
+	err := coursier.ErrNoSources{Dependency: reposource.MavenDependency{}}
+	if !errors.Is(err, coursier.ErrNoSources{}) {
+		t.Fatal("should be true")
+	}
+	if errors.Is(nil, coursier.ErrNoSources{}) {
+		t.Fatal("should be false")
+	}
+}

--- a/internal/extsvc/jvmpackages/coursier/coursier.go
+++ b/internal/extsvc/jvmpackages/coursier/coursier.go
@@ -98,12 +98,21 @@ func FetchSources(ctx context.Context, config *schema.JVMPackagesConnection, dep
 		return "", err
 	}
 	if len(paths) == 0 || (len(paths) == 1 && paths[0] == "") {
-		return "", errors.Errorf("no sources for dependency %s", dependency)
+		return "", ErrNoSources{Dependency: dependency}
 	}
 	if len(paths) > 1 {
 		return "", errors.Errorf("expected single JAR path but found multiple: %v", paths)
 	}
 	return paths[0], nil
+}
+
+// ErrNoSources indicates that a dependency has no sources
+type ErrNoSources struct {
+	Dependency reposource.MavenDependency
+}
+
+func (e ErrNoSources) Error() string {
+	return fmt.Sprintf("no sources for dependency %s", e.Dependency)
 }
 
 func FetchByteCode(ctx context.Context, config *schema.JVMPackagesConnection, dependency reposource.MavenDependency) (byteCodeJarPath string, err error) {


### PR DESCRIPTION
A JVM dependency with missing sources should not be fatal and was
leading to a large increase in error rates during scheduling repos for
update in repo-updater.

We still consider it a fatal error if ALL dependencies are missing
sources.
