### PR TITLE
Add onCopy callback to CopyableText

### DIFF
--- a/client/web/src/components/CopyableText.tsx
+++ b/client/web/src/components/CopyableText.tsx
@@ -22,6 +22,9 @@ interface Props {
 
     /** Whether or not the text to be copied is a password. */
     password?: boolean
+
+    /** Callback for when the content is copied  */
+    onCopy?: () => void
 }
 
 interface State {
@@ -72,5 +75,9 @@ export class CopyableText extends React.PureComponent<Props, State> {
         this.setState({ copied: true })
 
         setTimeout(() => this.setState({ copied: false }), 1000)
+
+        if (typeof this.props.onCopy === 'function') {
+            this.props.onCopy()
+        }
     }
 }

--- a/client/web/src/components/CopyableText.tsx
+++ b/client/web/src/components/CopyableText.tsx
@@ -14,6 +14,9 @@ interface Props {
     /** An optional class name. */
     className?: string
 
+    /** Whether or not the input should take up all horizontal space (flex:1) */
+    flex?: boolean
+
     /** The size of the input element. */
     size?: number
 
@@ -37,7 +40,7 @@ export class CopyableText extends React.PureComponent<Props, State> {
     public render(): JSX.Element | null {
         return (
             <div className={classNames('form-inline', this.props.className)}>
-                <div className="input-group">
+                <div className={classNames('input-group', this.props.flex && 'flex-1')}>
                     <input
                         type={this.props.password ? 'password' : 'text'}
                         className={classNames('form-control', styles.input)}


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/27101

This PR is based on top of https://github.com/sourcegraph/sourcegraph/pull/30591 to avoid merge conflicts (we'll land them together anyway).

In order to log events around when invite links are copied, we need a callback from the `<CopyableText />` component. Notice that there are two paths to copying text: Either by clicking the button or by focusing the text. This `onCopy` callback is emitted on both paths.

I tested the changes by adding an `onClick={() => console.log("onCopy called")}` prop to the caller in `StartSearching.tsx` and it worked as expected:

![Screenshot 2022-02-03 at 13 03 22](https://user-images.githubusercontent.com/458591/152339331-316e3fbc-004c-4abe-8e97-23ba091244a5.png)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
