### PR TITLE
web: add missing `.btn:hover` styles

### DIFF
--- a/client/wildcard/src/components/Button/Button.module.scss
+++ b/client/wildcard/src/components/Button/Button.module.scss
@@ -34,6 +34,11 @@
     &:disabled {
         cursor: not-allowed;
     }
+
+    &:hover {
+        color: var(--body-color);
+        text-decoration: none;
+    }
 }
 
 .btn-link {


### PR DESCRIPTION
## Context

We forgot to include hover state during [the migration of `Button` styles to CSS modules](https://github.com/sourcegraph/sourcegraph/pull/29347) styles provided by Bootstrap.
[Slack report](https://sourcegraph.slack.com/archives/C01LTKUHRL3/p1643892212625109).

| Before | After |
| -- | -- |
| <img width="190" alt="CleanShot 2022-02-03 at 13 42 31@2x" src="https://user-images.githubusercontent.com/3846380/152347272-87c34935-d63b-4640-9fab-7018b31c891e.png"> | <img width="190" alt="Screen Shot 2022-02-03 at 15 58 15" src="https://user-images.githubusercontent.com/3846380/152347407-b385ab42-8828-4465-908b-810b64e6485e.png"> |