### PR TITLE
internal/extsvc/github: Cache oauth scopes in redis with 5s TTL

### DIFF
--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -1753,7 +1753,7 @@ func (c *V3Client) getAuthenticatedOAuthScopesFromCache(ctx context.Context, key
 		return ""
 	}
 
-	return string(b[:])
+	return string(b)
 }
 
 var reposGitHubCacheCounter = promauto.NewCounterVec(prometheus.CounterOpts{

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -1747,6 +1747,15 @@ func (c *V3Client) cachedGetRepository(ctx context.Context, key string, getRepos
 	return repo, nil
 }
 
+func (c *V3Client) getAuthenticatedOAuthScopesFromCache(ctx context.Context, key string) string {
+	b, ok := c.oauthScopesCache.Get(strings.ToLower(key))
+	if !ok {
+		return ""
+	}
+
+	return string(b[:])
+}
+
 var reposGitHubCacheCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 	Name: "src_repos_github_cache_hit",
 	Help: "Counts cache hits and misses for GitHub repo metadata.",

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -419,7 +419,8 @@ func (c *V3Client) GetAuthenticatedOAuthScopes(ctx context.Context) ([]string, e
 		return MockGetAuthenticatedOAuthScopes(ctx)
 	}
 
-	if scope := c.getAuthenticatedOAuthScopesFromCache(ctx, c.auth.Hash()); scope != "" {
+	key := c.auth.Hash()
+	if scope := c.getAuthenticatedOAuthScopesFromCache(ctx, key); scope != "" {
 		return strings.Split(scope, ", "), nil
 	}
 
@@ -434,6 +435,10 @@ func (c *V3Client) GetAuthenticatedOAuthScopes(ctx context.Context) ([]string, e
 	if scope == "" {
 		return []string{}, nil
 	}
+
+	// Set the scope in the cache.
+	c.oauthScopesCache.Set(key, []byte(scope))
+
 	return strings.Split(scope, ", "), nil
 }
 


### PR DESCRIPTION
In POC stage. Looking for some early feedback.

Maybe helps reduce the high volume of GitHub API requests observed in https://github.com/sourcegraph/customer/issues/658. 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
