### PR TITLE
Remove asdf python 3.10 installation

### DIFF
--- a/dev/ci/go-backcompat/test.sh
+++ b/dev/ci/go-backcompat/test.sh
@@ -126,15 +126,6 @@ for schema in frontend codeintel codeinsights; do
   mv "${MIGRATION_STAGING}/${MIGRATION_FORMAT}/${schema}" "./migrations/${schema}"
 done
 
-# go-test.sh requires python 3.10.0 to calculate the api key value for
-# BUILDKITE_ANALYTICS_BACKEND_TEST_SUITE_API_KEY, but not all versions
-# we check out are guaranteed to have this dependency.
-#
-# Add it by force here.
-#
-# TODO: Remove this once no longer relevant (post-3.37 branch cut)
-grep -qxF 'python 3.10.0' ./.tool-versions || echo 'python 3.10.0' >>./.tool-versions
-
 # If migration files have been renamed or deleted between these commits
 # (which historically we've done in response to reverted migrations), we
 # might end up with a combination of files from both commits that ruin


### PR DESCRIPTION
In https://github.com/sourcegraph/sourcegraph/issues/30355, we switched everything to using system python. Using asdf to install python causes problems for other builds that are trying to rely on system python (https://github.com/sourcegraph/sourcegraph/issues/30626), because we don't currently have ephemeral agents.

Python 3.10 is already installed on the agents (https://k8s.sgdev.org/github.com/sourcegraph/infrastructure/-/blob/docker-images/buildkite-agent/Dockerfile?L103), so this hardcoding isn't necessary.

Note that this test will probably fail until we roll out new Buildkite agents.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
