### PR TITLE
[cloud][CLOUD-226] Add email to `inviteUserToOrganization` mutation

### DIFF
--- a/client/web/src/org/settings/members/InviteForm.tsx
+++ b/client/web/src/org/settings/members/InviteForm.tsx
@@ -192,8 +192,8 @@ function inviteUserToOrganization(
 ): Promise<InviteUserToOrganizationResult['inviteUserToOrganization']> {
     return requestGraphQL<InviteUserToOrganizationResult, InviteUserToOrganizationVariables>(
         gql`
-            mutation InviteUserToOrganization($organization: ID!, $username: String!) {
-                inviteUserToOrganization(organization: $organization, username: $username) {
+            mutation InviteUserToOrganization($organization: ID!, $username: String, $email: String) {
+                inviteUserToOrganization(organization: $organization, username: $username, email: $email) {
                     ...InviteUserToOrganizationFields
                 }
             }
@@ -206,6 +206,7 @@ function inviteUserToOrganization(
         {
             username,
             organization,
+            email: null,
         }
     )
         .pipe(

--- a/cmd/frontend/graphqlbackend/org_invitations.go
+++ b/cmd/frontend/graphqlbackend/org_invitations.go
@@ -59,8 +59,12 @@ func (r *inviteUserToOrganizationResult) InvitationURL() string     { return r.i
 
 func (r *schemaResolver) InviteUserToOrganization(ctx context.Context, args *struct {
 	Organization graphql.ID
-	Username     string
+	Username     *string
+	Email        *string
 }) (*inviteUserToOrganizationResult, error) {
+	if (args.Email != nil && *args.Email != "") || args.Username == nil {
+		return nil, errors.New("inviting by email is not implemented yet")
+	}
 	var orgID int32
 	if err := relay.UnmarshalSpec(args.Organization, &orgID); err != nil {
 		return nil, err
@@ -80,7 +84,7 @@ func (r *schemaResolver) InviteUserToOrganization(ctx context.Context, args *str
 	if err != nil {
 		return nil, err
 	}
-	recipient, recipientEmail, err := getUserToInviteToOrganization(ctx, r.db, args.Username, orgID)
+	recipient, recipientEmail, err := getUserToInviteToOrganization(ctx, r.db, *args.Username, orgID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -258,7 +258,7 @@ type Mutation {
 
     Only site admins and any organization member may perform this mutation.
     """
-    inviteUserToOrganization(organization: ID!, username: String!): InviteUserToOrganizationResult!
+    inviteUserToOrganization(organization: ID!, username: String, email: String): InviteUserToOrganizationResult!
     """
     Accept or reject an existing organization invitation.
 

--- a/dev/authtest/organization_test.go
+++ b/dev/authtest/organization_test.go
@@ -86,7 +86,7 @@ func TestOrganization(t *testing.T) {
 		{
 			name: "invite user to organization",
 			run: func() error {
-				_, err := userClient.InviteUserToOrganization(orgID, testUsername)
+				_, err := userClient.InviteUserToOrganization(orgID, testUsername, "")
 				return err
 			},
 			wantErr: "current user is not an org member",

--- a/internal/gqltestutil/organization.go
+++ b/internal/gqltestutil/organization.go
@@ -85,10 +85,10 @@ type InviteUserToOrganizationResult struct {
 }
 
 // InviteUserToOrganization invites a user to the given organization.
-func (c *Client) InviteUserToOrganization(orgID, username string) (*InviteUserToOrganizationResult, error) {
+func (c *Client) InviteUserToOrganization(orgID, username string, email string) (*InviteUserToOrganizationResult, error) {
 	const query = `
-mutation InviteUserToOrganization($organization: ID!, $username: String!) {
-	inviteUserToOrganization(organization: $organization, username: $username) {
+mutation InviteUserToOrganization($organization: ID!, $username: String, $email String) {
+	inviteUserToOrganization(organization: $organization, username: $username, email $email) {
 		... on InviteUserToOrganizationResult {
 			sentInvitationEmail
 			invitationURL
@@ -99,6 +99,7 @@ mutation InviteUserToOrganization($organization: ID!, $username: String!) {
 	variables := map[string]interface{}{
 		"organization": orgID,
 		"username":     username,
+		"email":        email,
 	}
 	var resp struct {
 		Data struct {
@@ -112,7 +113,7 @@ mutation InviteUserToOrganization($organization: ID!, $username: String!) {
 	return resp.Data.InviteUserToOrganizationResult, nil
 }
 
-// InviteUserToOrganization invites a user to the given organization.
+// AddUserToOrganization invites a user to the given organization.
 func (c *Client) AddUserToOrganization(orgID, username string) error {
 	const query = `
 	mutation AddUserToOrganization($organization: ID!, $username: String!) {


### PR DESCRIPTION
# Description

This PR is meant to unblock work on the UI for email invitations.

This will add `email` parameter to the `inviteUserToOrganization` mutation. The parameter is optional. If provided, the mutation will return an error, since it's not implemented.
