### PR TITLE
diskcache: Construct correct paths

### DIFF
--- a/internal/diskcache/cache.go
+++ b/internal/diskcache/cache.go
@@ -304,13 +304,17 @@ func (s *store) Evict(maxCacheSizeBytes int64) (stats EvictStats, err error) {
 		return strings.HasSuffix(fi.Name(), ".zip")
 	}
 
-	list := []fs.FileInfo{}
+	type relpathPrefixedFileInfo struct {
+		path string
+		info fs.FileInfo
+	}
+	entries := []relpathPrefixedFileInfo{}
 	err = filepath.Walk(s.dir,
 		func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				return err
 			}
-			list = append(list, info)
+			entries = append(entries, relpathPrefixedFileInfo{path, info})
 			return nil
 		})
 	if err != nil {
@@ -322,9 +326,9 @@ func (s *store) Evict(maxCacheSizeBytes int64) (stats EvictStats, err error) {
 
 	// Sum up the total size of all zips
 	var size int64
-	for _, fi := range list {
-		if isZip(fi) {
-			size += fi.Size()
+	for _, entry := range entries {
+		if isZip(entry.info) {
+			size += entry.info.Size()
 		}
 	}
 	stats.CacheSize = size
@@ -336,17 +340,17 @@ func (s *store) Evict(maxCacheSizeBytes int64) (stats EvictStats, err error) {
 
 	// Keep removing files until we are under the cache size. Remove the
 	// oldest first.
-	sort.Slice(list, func(i, j int) bool {
-		return list[i].ModTime().Before(list[j].ModTime())
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].info.ModTime().Before(entries[j].info.ModTime())
 	})
-	for _, fi := range list {
+	for _, entry := range entries {
 		if size <= maxCacheSizeBytes {
 			break
 		}
-		if !isZip(fi) {
+		if !isZip(entry.info) {
 			continue
 		}
-		path := filepath.Join(s.dir, fi.Name())
+		path := filepath.Join(s.dir, entry.path, entry.info.Name())
 		if s.beforeEvict != nil {
 			s.beforeEvict(path, trace)
 		}
@@ -357,7 +361,7 @@ func (s *store) Evict(maxCacheSizeBytes int64) (stats EvictStats, err error) {
 			continue
 		}
 		stats.Evicted++
-		size -= fi.Size()
+		size -= entry.info.Size()
 	}
 
 	trace.Tag(

--- a/internal/diskcache/cache.go
+++ b/internal/diskcache/cache.go
@@ -304,17 +304,17 @@ func (s *store) Evict(maxCacheSizeBytes int64) (stats EvictStats, err error) {
 		return strings.HasSuffix(fi.Name(), ".zip")
 	}
 
-	type relpathPrefixedFileInfo struct {
-		path string
-		info fs.FileInfo
+	type absFileInfo struct {
+		absPath string
+		info    fs.FileInfo
 	}
-	entries := []relpathPrefixedFileInfo{}
+	entries := []absFileInfo{}
 	err = filepath.Walk(s.dir,
 		func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				return err
 			}
-			entries = append(entries, relpathPrefixedFileInfo{path, info})
+			entries = append(entries, absFileInfo{absPath: path, info: info})
 			return nil
 		})
 	if err != nil {
@@ -350,7 +350,7 @@ func (s *store) Evict(maxCacheSizeBytes int64) (stats EvictStats, err error) {
 		if !isZip(entry.info) {
 			continue
 		}
-		path := filepath.Join(s.dir, entry.path, entry.info.Name())
+		path := entry.absPath
 		if s.beforeEvict != nil {
 			s.beforeEvict(path, trace)
 		}


### PR DESCRIPTION
A bug was introduced in incremental processing of symbols data https://github.com/sourcegraph/sourcegraph/pull/27932/files?w=1#diff-8b3a8c5193ef74d96d16a575971641affe279db976cc0926d4dda179fc4d305dR251 which added a directory component to the cache, but cleanup wasn't updated.