### PR TITLE
logging: Truncate long slow log messages

### DIFF
--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -2,6 +2,7 @@ package trace
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"os"
 	"strconv"
@@ -217,7 +218,7 @@ func HTTPMiddleware(next http.Handler, siteConfig conftypes.SiteConfigQuerier) h
 			kvs := make([]interface{}, 0, 20)
 			kvs = append(kvs,
 				"method", r.Method,
-				"url", r.URL.String(),
+				"url", truncate(r.URL.String(), 100),
 				"code", m.Code,
 				"duration", m.Duration,
 			)
@@ -272,6 +273,13 @@ func HTTPMiddleware(next http.Handler, siteConfig conftypes.SiteConfigQuerier) h
 			})
 		}
 	}))
+}
+
+func truncate(s string, n int) string {
+	if len(s) > n {
+		return fmt.Sprintf("%s...(%d more)", s[:n], len(s)-n)
+	}
+	return s
 }
 
 func Route(next http.Handler) http.Handler {


### PR DESCRIPTION
The archive endpoint can get really long when many paths are specified:

`/archive?path=foo&bar&baz&...` 

Combined with a buffering issue in `sg`, this was causing gitserver to hang when logging messages https://github.com/sourcegraph/sourcegraph/issues/30529#issuecomment-1029363414

After this change, long URLs will get truncated to something like `/archive?path=foo&ba...(214398 more)` for logging.