### PR TITLE
Add more services to list that depend on Redis

### DIFF
--- a/doc/admin/external_services/redis.md
+++ b/doc/admin/external_services/redis.md
@@ -18,4 +18,5 @@ or follow the [IANA specification for Redis URLs](https://www.iana.org/assignmen
 
 If using Docker for Desktop, `host.docker.internal` will resolve to the host IP address.
 
-
+## Kubernetes Redis
+See our documentation for Kubernetes [here](../install/kubernetes/configure.md#configure-custom-redis)

--- a/doc/admin/install/kubernetes/configure.md
+++ b/doc/admin/install/kubernetes/configure.md
@@ -704,8 +704,14 @@ Sourcegraph supports specifying a custom Redis server for:
 
 If you want to specify a custom Redis server, you'll need specify the corresponding environment variable for each of the following deployments:
 
+<!-- Use ./dev/depgraph/depgraph summary internal/redispool to generate this -->
+
 - `sourcegraph-frontend`
 - `repo-updater`
+- `worker`
+- `precise-code-intel-worker`
+- `searcher`
+- `symbols`
 
 ## Connect to an external Jaeger instance
 

--- a/doc/admin/install/kubernetes/configure.md
+++ b/doc/admin/install/kubernetes/configure.md
@@ -702,16 +702,37 @@ Sourcegraph supports specifying a custom Redis server for:
 - caching information (specified via the `REDIS_CACHE_ENDPOINT` environment variable)
 - storing information (session data and job queues) (specified via the `REDIS_STORE_ENDPOINT` environment variable)
 
+If these are not set, they will [default](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24++REDIS_CACHE_ENDPOINT+AND+REDIS_STORE_ENDPOINT+-file:doc+file:internal&patternType=literal) to `redis-cache:6379` & `redis-store:6379` 
+
 If you want to specify a custom Redis server, you'll need specify the corresponding environment variable for each of the following deployments:
 
 <!-- Use ./dev/depgraph/depgraph summary internal/redispool to generate this -->
 
 - `sourcegraph-frontend`
 - `repo-updater`
-- `worker`
-- `precise-code-intel-worker`
+- `gitserver`
 - `searcher`
 - `symbols`
+- `worker`
+
+_Kubernetes yaml example_
+
+```
+apiVersion: apps/v1
+kind: <Deployment/StatefulSet>
+spec:
+  template:
+    spec:
+      containers:
+        - name: <frontend>
+        - image: <frontend_image>/<TAG>
+        - env:
+          - name: REDIS_CACHE_ENDPOINT
+            value: "<REDIS_CACHE_DSN>"
+          - name: REDIS_STORE_ENDPOINT
+            value: "<REDIS_STORE_DSN>"
+    
+```
 
 ## Connect to an external Jaeger instance
 


### PR DESCRIPTION
Due to the way we import our internal Redis package, we need to declare these env vars for most services.

Fixes https://github.com/sourcegraph/customer/issues/675

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
