### PR TITLE
compute: stream results

### DIFF
--- a/enterprise/cmd/frontend/internal/compute/init.go
+++ b/enterprise/cmd/frontend/internal/compute/init.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/compute/resolvers"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/compute/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -13,15 +14,6 @@ import (
 
 func Init(ctx context.Context, db database.DB, _ conftypes.UnifiedWatchable, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
 	enterpriseServices.ComputeResolver = resolvers.NewResolver(db)
-	enterpriseServices.NewComputeStreamHandler = newComputeStreamHandler
+	enterpriseServices.NewComputeStreamHandler = func() http.Handler { return streaming.NewComputeStreamHandler(db) }
 	return nil
-}
-
-// newComputeStreamHandler implements the HTTP endpoint for the Compute stream.
-// TODO(rvantonder): #30527
-func newComputeStreamHandler() http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotImplemented)
-		_, _ = w.Write([]byte("compute stream endpoint unimplemented"))
-	})
 }

--- a/enterprise/cmd/frontend/internal/compute/streaming/compute.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/compute.go
@@ -1,0 +1,74 @@
+package streaming
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/compute"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+)
+
+func toComputeResultStream(ctx context.Context, cmd compute.Command, matches []result.Match, f func(compute.Result)) error {
+	for _, m := range matches {
+		result, err := cmd.Run(ctx, m)
+		if err != nil {
+			return err
+		}
+		f(result)
+	}
+	return nil
+}
+
+func NewComputeStream(ctx context.Context, db database.DB, query string) (<-chan Event, func() error) {
+	computeQuery, err := compute.Parse(query)
+	if err != nil {
+		return nil, func() error { return err }
+	}
+
+	searchQuery, err := computeQuery.ToSearchQuery()
+	if err != nil {
+		return nil, func() error { return err }
+	}
+
+	eventsC := make(chan Event)
+	stream := streaming.StreamFunc(func(event streaming.SearchEvent) {
+		if len(event.Results) > 0 {
+			callback := func(result compute.Result) {
+				eventsC <- Event{Results: []compute.Result{result}}
+			}
+			_ = toComputeResultStream(ctx, computeQuery.Command, event.Results, callback)
+			// TODO(rvantonder): compute err is currently ignored. Process it and send alerts/errors as needed.
+		}
+	})
+
+	patternType := "regexp"
+	searchArgs := &graphqlbackend.SearchArgs{
+		Query:       searchQuery,
+		PatternType: &patternType,
+		Stream:      stream,
+	}
+	job, err := graphqlbackend.NewSearchImplementer(ctx, db, searchArgs)
+	if err != nil {
+		close(eventsC)
+		return eventsC, func() error { return err }
+	}
+
+	type finalResult struct {
+		err error
+	}
+	final := make(chan finalResult, 1)
+	go func() {
+		defer close(final)
+		defer close(eventsC)
+
+		_, err := job.Results(ctx)
+		final <- finalResult{err: err}
+	}()
+
+	return eventsC, func() error {
+		f := <-final
+		return f.err
+	}
+}

--- a/enterprise/cmd/frontend/internal/compute/streaming/event.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/event.go
@@ -1,0 +1,7 @@
+package streaming
+
+import "github.com/sourcegraph/sourcegraph/enterprise/internal/compute"
+
+type Event struct {
+	Results []compute.Result // TODO(rvantonder): hydrate repo information in this Event type.
+}

--- a/enterprise/cmd/frontend/internal/compute/streaming/stream.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/stream.go
@@ -1,0 +1,205 @@
+package streaming
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	otlog "github.com/opentracing/opentracing-go/log"
+
+	"github.com/cockroachdb/errors"
+	"github.com/inconshreveable/log15"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	streamhttp "github.com/sourcegraph/sourcegraph/internal/search/streaming/http"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+)
+
+// NewComputeStreamHandler is an http handler which streams back compute results.
+func NewComputeStreamHandler(db database.DB) http.Handler {
+	return &streamHandler{
+		db:                  db,
+		flushTickerInternal: 100 * time.Millisecond,
+	}
+}
+
+type streamHandler struct {
+	db                  database.DB
+	flushTickerInternal time.Duration
+}
+
+func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	args, err := parseURLQuery(r.URL.Query())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	tr, ctx := trace.New(ctx, "compute.ServeStream", args.Query)
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
+
+	eventWriter, err := streamhttp.NewWriter(w)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Always send a final done event so clients know the stream is shutting
+	// down.
+	defer eventWriter.Event("done", map[string]interface{}{})
+
+	// Log events to trace
+	eventWriter.StatHook = eventStreamOTHook(tr.LogFields)
+
+	events, getErr := NewComputeStream(ctx, h.db, args.Query)
+	events = batchEvents(events, 50*time.Millisecond)
+
+	// Store marshalled matches and flush periodically or when we go over
+	// 32kb. 32kb chosen to be smaller than bufio.MaxTokenSize. Note: we can
+	// still write more than that.
+	matchesBuf := streamhttp.NewJSONArrayBuf(32*1024, func(data []byte) error {
+		return eventWriter.EventBytes("results", data)
+	})
+	matchesFlush := func() {
+		if err := matchesBuf.Flush(); err != nil {
+			// EOF
+			return
+		}
+	}
+	flushTicker := time.NewTicker(h.flushTickerInternal)
+	defer flushTicker.Stop()
+
+	first := true
+	handleEvent := func(event Event) {
+		for _, result := range event.Results {
+			_ = matchesBuf.Append(result)
+		}
+
+		// Instantly send results if we have not sent any yet.
+		if first && matchesBuf.Len() > 0 {
+			log15.Info("flushing first now")
+			first = false
+			matchesFlush()
+		}
+
+	}
+
+LOOP:
+	for {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				break LOOP
+			}
+			handleEvent(event)
+		case <-flushTicker.C:
+			matchesFlush()
+		}
+	}
+
+	matchesFlush()
+
+	if err = getErr(); err != nil {
+		_ = eventWriter.Event("error", streamhttp.EventError{Message: err.Error()})
+		return
+	}
+}
+
+type args struct {
+	Query   string
+	Display int
+}
+
+func parseURLQuery(q url.Values) (*args, error) {
+	get := func(k, def string) string {
+		v := q.Get(k)
+		if v == "" {
+			return def
+		}
+		return v
+	}
+
+	a := args{
+		Query: get("q", ""),
+	}
+
+	if a.Query == "" {
+		return nil, errors.New("no query found")
+	}
+
+	display := get("display", "-1") // TODO(rvantonder): Currently unused; implement a limit for compute results.
+	var err error
+	if a.Display, err = strconv.Atoi(display); err != nil {
+		return nil, errors.Errorf("display must be an integer, got %q: %w", display, err)
+	}
+
+	return &a, nil
+}
+
+// batchEvents takes an event stream and merges events that come through close in time into a single event.
+// This makes downstream database and network operations more efficient by enabling batch reads.
+func batchEvents(source <-chan Event, delay time.Duration) <-chan Event {
+	results := make(chan Event)
+	go func() {
+		defer close(results)
+
+		// Send the first event without a delay
+		firstEvent, ok := <-source
+		if !ok {
+			return
+		}
+		results <- firstEvent
+
+	OUTER:
+		for {
+			// Wait for a first event
+			event, ok := <-source
+			if !ok {
+				return
+			}
+
+			// Wait up to the delay for more events to come through,
+			// and merge any that do into the first event
+			timer := time.After(delay)
+			for {
+				select {
+				case newEvent, ok := <-source:
+					if !ok {
+						// Flush the buffered event and exit
+						results <- event
+						return
+					}
+					event.Results = append(event.Results, newEvent.Results...)
+				case <-timer:
+					results <- event
+					continue OUTER
+				}
+			}
+		}
+
+	}()
+	return results
+}
+
+// eventStreamOTHook returns a StatHook which logs to log.
+func eventStreamOTHook(log func(...otlog.Field)) func(streamhttp.WriterStat) {
+	return func(stat streamhttp.WriterStat) {
+		fields := []otlog.Field{
+			otlog.String("streamhttp.Event", stat.Event),
+			otlog.Int("bytes", stat.Bytes),
+			otlog.Int64("duration_ms", stat.Duration.Milliseconds()),
+		}
+		if stat.Error != nil {
+			fields = append(fields, otlog.Error(stat.Error))
+		}
+		log(fields...)
+	}
+}


### PR DESCRIPTION
Implements `.api/compute/stream` with the basic functionality.

<img width="1071" alt="Screen Shot 2022-02-03 at 4 54 14 PM" src="https://user-images.githubusercontent.com/888624/152454393-ad15a7ae-d733-4366-90da-b05b319bcad2.png">

Part of https://github.com/sourcegraph/sourcegraph/issues/30527

Not used by anything right now (integration tests will follow later), and there are follow up items to address in subsequent PRs, see inline comments. I thought about feature flagging the endpoint, but since it's unused/undocumented that can also be a follow up if needed.