### PR TITLE
insights: Add docs around permissions

### DIFF
--- a/doc/code_insights/explanations/administration_and_security_of_code_insights.md
+++ b/doc/code_insights/explanations/administration_and_security_of_code_insights.md
@@ -29,7 +29,7 @@ A user can view an insight if at least one of the following is true:
 1. The user created the insight.
 2. The user has permission to view a dashboard that the insight is on.
 
-In most cases, permissions can be thought of as belonging to a dashboard. Dashboards have 3 permission levels:
+Except for the singular, non-transferable creator's permission noted in case 1 above, permissions can be thought of as belonging to a dashboard. Dashboards have 3 permission levels:
 
 - User: only this specific user can view this dashboard.
 - Organization: only users within this organization can view this dashboard.
@@ -38,3 +38,5 @@ In most cases, permissions can be thought of as belonging to a dashboard. Dashbo
 ### Changing permission levels
 
 Because there are no separate read/write permissions and no dashboard owners, any user who can view a dashboard can change its permission level or add/remove insights from the dashboard. The only way to guarantee continued access to an insight that you did not create is to add it to a private dashboard.
+
+If a user gets deleted, any insights they created will still be visible to other users via the dashboards they appear on. However, if one of these insights is removed from all dashboards, it will no longer be accessible.

--- a/doc/code_insights/explanations/administration_and_security_of_code_insights.md
+++ b/doc/code_insights/explanations/administration_and_security_of_code_insights.md
@@ -2,7 +2,9 @@
 
 ## Code Insights enforce user permissions 
 
-Users can only create code insights that include repositories they have access to. Moreover, when creating code insights, the repository field will *not* validate nor show users repositories they would not have access to otherwise. 
+Users can only create code insights that include repositories they have access to. Moreover, when creating code insights, the repository field will *not* validate nor show users repositories they would not have access to otherwise.
+
+When a user is viewing an insight, any repositories they do not have access to will not be included in the total counts.
 
 ## Security of native Sourcegraph Code Insights (Search-based and Language Insights)
 
@@ -16,4 +18,23 @@ If you are concerned about the security of extension-provided insights, then you
 
 ## Disable Sourcegraph extension-provided Code Insights 
 
-If you want to disable Sourcegraph-extension-provided code insights, you can do so the same way you would disable any other extension. Refer to [Disabling remote extensions](../../admin/extensions.md#use-extensions-from-sourcegraph-com-or-disable-remote-extensions) and [Allow only specific extensions](../../admin/extensions.md#use-extensions-from-sourcegraph-com-or-disable-remote-extensions). 
+If you want to disable Sourcegraph-extension-provided code insights, you can do so the same way you would disable any other extension. Refer to [Disabling remote extensions](../../admin/extensions.md#use-extensions-from-sourcegraph-com-or-disable-remote-extensions) and [Allow only specific extensions](../../admin/extensions.md#use-extensions-from-sourcegraph-com-or-disable-remote-extensions).
+
+## Insight and Dashboard permissions
+
+Note: there are no separate read/write permissions. If a user can view an insight or dashboard, they can also edit it.
+
+A user can view an insight if at least one of the following is true:
+
+1. The user created the insight.
+2. The user has permission to view a dashboard that the insight is on.
+
+In most cases, permissions can be thought of as belonging to a dashboard. Dashboards have 3 permission levels:
+
+- User: only this specific user can view this dashboard.
+- Organization: only users within this organization can view this dashboard.
+- Global: any user on the Sourcegraph instance can view this dashboard.
+
+### Changing permission levels
+
+Because there are no separate read/write permissions and no dashboard owners, any user who can view a dashboard can change its permission level or add/remove insights from the dashboard. The only way to guarantee continued access to an insight that you did not create is to add it to a private dashboard.


### PR DESCRIPTION
Closes: https://github.com/sourcegraph/sourcegraph/issues/29530

## Description

Docs only change. This adds some information to our docs that is intended to be useful to the security team to answer questions about how code insights permissions work.

I'm fairly unsure that I addressed the right issues here, so please let me know if I missed important details that we need to share!