### PR TITLE
symbols: Split calls to git archive

### DIFF
--- a/cmd/symbols/config.go
+++ b/cmd/symbols/config.go
@@ -23,6 +23,16 @@ type Config struct {
 	numCtagsProcesses int
 	requestBufferSize int
 	processingTimeout time.Duration
+
+	// The maximum sum of lengths of all paths in a single call to git archive. Without this limit, we
+	// could hit the error "argument list too long" by exceeding the limit on the number of arguments to
+	// a command enforced by the OS.
+	//
+	// Mac  : getconf ARG_MAX returns 1,048,576
+	// Linux: getconf ARG_MAX returns 2,097,152
+	//
+	// We want to remain well under that limit, so defaulting to 100,000 seems safe.
+	maxTotalPathsLength int
 }
 
 var config = &Config{}
@@ -40,4 +50,5 @@ func (c *Config) Load() {
 	c.numCtagsProcesses = c.GetInt("CTAGS_PROCESSES", strconv.Itoa(runtime.GOMAXPROCS(0)), "number of concurrent parser processes to run")
 	c.requestBufferSize = c.GetInt("REQUEST_BUFFER_SIZE", "8192", "maximum size of buffered parser request channel")
 	c.processingTimeout = c.GetInterval("PROCESSING_TIMEOUT", "2h", "maximum time to spend processing a repository")
+	c.maxTotalPathsLength = c.GetInt("MAX_TOTAL_PATHS_LENGTH", "100000", "maximum sum of lengths of all paths in a single call to git archive")
 }

--- a/cmd/symbols/config.go
+++ b/cmd/symbols/config.go
@@ -31,7 +31,8 @@ type Config struct {
 	// Mac  : getconf ARG_MAX returns 1,048,576
 	// Linux: getconf ARG_MAX returns 2,097,152
 	//
-	// We want to remain well under that limit, so defaulting to 100,000 seems safe.
+	// We want to remain well under that limit, so defaulting to 100,000 seems safe (see the
+	// MAX_TOTAL_PATHS_LENGTH environment variable below).
 	maxTotalPathsLength int
 }
 

--- a/cmd/symbols/internal/api/handler_test.go
+++ b/cmd/symbols/internal/api/handler_test.go
@@ -50,7 +50,7 @@ func TestHandler(t *testing.T) {
 	gitserverClient := NewMockGitserverClient()
 	gitserverClient.FetchTarFunc.SetDefaultHook(gitserver.CreateTestFetchTarFunc(files))
 
-	parser := parser.NewParser(parserPool, fetcher.NewRepositoryFetcher(gitserverClient, 15, &observation.TestContext), 0, 10, &observation.TestContext)
+	parser := parser.NewParser(parserPool, fetcher.NewRepositoryFetcher(gitserverClient, 15, 1000, &observation.TestContext), 0, 10, &observation.TestContext)
 	databaseWriter := writer.NewDatabaseWriter(tmpDir, gitserverClient, parser)
 	cachedDatabaseWriter := writer.NewCachedDatabaseWriter(databaseWriter, cache)
 	handler := NewHandler(cachedDatabaseWriter, &observation.TestContext)

--- a/cmd/symbols/internal/fetcher/repository_fetcher.go
+++ b/cmd/symbols/internal/fetcher/repository_fetcher.go
@@ -21,9 +21,10 @@ type RepositoryFetcher interface {
 }
 
 type repositoryFetcher struct {
-	gitserverClient gitserver.GitserverClient
-	fetchSem        chan int
-	operations      *operations
+	gitserverClient     gitserver.GitserverClient
+	fetchSem            chan int
+	operations          *operations
+	maxTotalPathsLength int
 }
 
 type ParseRequest struct {
@@ -36,11 +37,12 @@ type parseRequestOrError struct {
 	Err          error
 }
 
-func NewRepositoryFetcher(gitserverClient gitserver.GitserverClient, maximumConcurrentFetches int, observationContext *observation.Context) RepositoryFetcher {
+func NewRepositoryFetcher(gitserverClient gitserver.GitserverClient, maximumConcurrentFetches int, maxTotalPathsLength int, observationContext *observation.Context) RepositoryFetcher {
 	return &repositoryFetcher{
-		gitserverClient: gitserverClient,
-		fetchSem:        make(chan int, maximumConcurrentFetches),
-		operations:      newOperations(observationContext),
+		gitserverClient:     gitserverClient,
+		fetchSem:            make(chan int, maximumConcurrentFetches),
+		operations:          newOperations(observationContext),
+		maxTotalPathsLength: maxTotalPathsLength,
 	}
 }
 
@@ -79,13 +81,44 @@ func (f *repositoryFetcher) fetchRepositoryArchive(ctx context.Context, args typ
 	f.operations.fetching.Inc()
 	defer f.operations.fetching.Dec()
 
-	rc, err := f.gitserverClient.FetchTar(ctx, args.Repo, args.CommitID, paths)
-	if err != nil {
-		return errors.Wrap(err, "gitserverClient.FetchTar")
-	}
-	defer rc.Close()
+	for _, pathBatch := range batchByTotalLength(paths, f.maxTotalPathsLength) {
+		rc, err := f.gitserverClient.FetchTar(ctx, args.Repo, args.CommitID, pathBatch)
+		if err != nil {
+			return errors.Wrap(err, "gitserverClient.FetchTar")
+		}
 
-	return readTar(ctx, tar.NewReader(rc), callback, trace)
+		err = readTar(ctx, tar.NewReader(rc), callback, trace)
+		rc.Close()
+		if err != nil {
+			return errors.Wrap(err, "readTar")
+		}
+	}
+
+	return nil
+}
+
+// batchByTotalLength returns batches of paths where each batch contains at most maxTotalLength
+// characters, except when a single path exceeds the soft max, in which case that long path will be put
+// into its own batch.
+func batchByTotalLength(paths []string, maxTotalLength int) [][]string {
+	batches := [][]string{}
+	currentBatch := []string{}
+	currentLength := 0
+
+	for _, path := range paths {
+		if len(currentBatch) > 0 && currentLength+len(path) > maxTotalLength {
+			batches = append(batches, currentBatch)
+			currentBatch = []string{}
+			currentLength = 0
+		}
+
+		currentBatch = append(currentBatch, path)
+		currentLength += len(path)
+	}
+
+	batches = append(batches, currentBatch)
+
+	return batches
 }
 
 func (f *repositoryFetcher) limitConcurrentFetches(ctx context.Context) (func(), error) {

--- a/cmd/symbols/main.go
+++ b/cmd/symbols/main.go
@@ -108,7 +108,7 @@ func main() {
 	}
 
 	gitserverClient := gitserver.NewClient(observationContext)
-	repositoryFetcher := fetcher.NewRepositoryFetcher(gitserverClient, 15, observationContext)
+	repositoryFetcher := fetcher.NewRepositoryFetcher(gitserverClient, 15, config.maxTotalPathsLength, observationContext)
 	parser := parser.NewParser(parserPool, repositoryFetcher, config.requestBufferSize, config.numCtagsProcesses, observationContext)
 	databaseWriter := writer.NewDatabaseWriter(config.cacheDir, gitserverClient, parser)
 	cachedDatabaseWriter := writer.NewCachedDatabaseWriter(databaseWriter, cache)


### PR DESCRIPTION
Prior to this change, the `symbols` service would fall back to a full `git archive` when the paths were too long.

After this change, it will split a big list of paths into batches and call `git archive` on each batch. This is more efficient than falling back to a full `git archive`.

On `sourcegraph/sourcegraph`:

- `git archive` **without** paths (meaning a full archive) takes 549ms
- `git archive` with **all** of the paths takes 652ms
- `git archive` with **half** of the paths takes 363ms