### PR TITLE
Search backend: create batchingStream

### DIFF
--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -86,7 +86,6 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	eventWriter.StatHook = eventStreamOTHook(tr.LogFields)
 
 	events, inputs, results := h.startSearch(ctx, args)
-	events = batchEvents(events, 50*time.Millisecond)
 
 	// Display is the number of results we send down. If display is < 0 we
 	// want to send everything we find before hitting a limit. Otherwise we
@@ -281,15 +280,16 @@ LOOP:
 // will return the results resolver and error.
 func (h *streamHandler) startSearch(ctx context.Context, a *args) (events <-chan streaming.SearchEvent, inputs run.SearchInputs, results func() (*graphqlbackend.SearchResultsResolver, error)) {
 	eventsC := make(chan streaming.SearchEvent)
+	stream := streaming.StreamFunc(func(event streaming.SearchEvent) {
+		eventsC <- event
+	})
+	batchedStream := streaming.NewBatchingStream(50*time.Millisecond, stream)
 
 	search, err := h.newSearchResolver(ctx, h.db, &graphqlbackend.SearchArgs{
 		Query:       a.Query,
 		Version:     a.Version,
 		PatternType: strPtr(a.PatternType),
-
-		Stream: streaming.StreamFunc(func(event streaming.SearchEvent) {
-			eventsC <- event
-		}),
+		Stream:      batchedStream,
 	})
 	if err != nil {
 		close(eventsC)
@@ -306,6 +306,7 @@ func (h *streamHandler) startSearch(ctx context.Context, a *args) (events <-chan
 	go func() {
 		defer close(final)
 		defer close(eventsC)
+		defer batchedStream.Done()
 
 		r, err := search.Results(ctx)
 		final <- finalResult{resultsResolver: r, err: err}
@@ -620,51 +621,6 @@ func GuessSource(r *http.Request) trace.SourceType {
 	}
 
 	return trace.SourceOther
-}
-
-// batchEvents takes an event stream and merges events that come through close in time into a single event.
-// This makes downstream database and network operations more efficient by enabling batch reads.
-func batchEvents(source <-chan streaming.SearchEvent, delay time.Duration) <-chan streaming.SearchEvent {
-	results := make(chan streaming.SearchEvent)
-	go func() {
-		defer close(results)
-
-		// Send the first event without a delay
-		firstEvent, ok := <-source
-		if !ok {
-			return
-		}
-		results <- firstEvent
-
-	OUTER:
-		for {
-			// Wait for a first event
-			event, ok := <-source
-			if !ok {
-				return
-			}
-
-			// Wait up to the delay for more events to come through,
-			// and merge any that do into the first event
-			timer := time.After(delay)
-			for {
-				select {
-				case newEvent, ok := <-source:
-					if !ok {
-						// Flush the buffered event and exit
-						results <- event
-						return
-					}
-					event.Results = append(event.Results, newEvent.Results...)
-					event.Stats.Update(&newEvent.Stats)
-				case <-timer:
-					results <- event
-					continue OUTER
-				}
-			}
-		}
-	}()
-	return results
 }
 
 func repoIDs(results []result.Match) []api.RepoID {

--- a/internal/search/streaming/stream.go
+++ b/internal/search/streaming/stream.go
@@ -259,6 +259,8 @@ func (s *batchingStream) Done() {
 	s.mu.Unlock()
 }
 
+// flush sends the currently batched events to the parent stream. The caller must hold
+// a lock on the batching stream.
 func (s *batchingStream) flush() {
 	if s.dirty {
 		s.parent.Send(s.batch)

--- a/internal/search/streaming/stream.go
+++ b/internal/search/streaming/stream.go
@@ -3,6 +3,7 @@ package streaming
 import (
 	"context"
 	"sync"
+	"time"
 
 	"go.uber.org/atomic"
 
@@ -184,4 +185,83 @@ func (c *resultCountingStream) Send(event SearchEvent) {
 
 func (c *resultCountingStream) Count() int {
 	return int(c.count.Load())
+}
+
+// NewBatchingStream returns a stream that batches results sent to it, holding
+// delaying their forwarding by a max time of maxDelay, then sending the batched
+// event to the parent stream. The first event is passed through without delay.
+func NewBatchingStream(maxDelay time.Duration, parent Sender) *batchingStream {
+	return &batchingStream{
+		parent:   parent,
+		maxDelay: maxDelay,
+	}
+}
+
+type batchingStream struct {
+	parent   Sender
+	maxDelay time.Duration
+
+	mu             sync.Mutex
+	sentFirstEvent bool
+	dirty          bool
+	batch          SearchEvent
+	timer          *time.Timer
+	flushScheduled bool
+}
+
+func (s *batchingStream) Send(event SearchEvent) {
+	s.mu.Lock()
+
+	// Send the first event without delay
+	if !s.sentFirstEvent {
+		s.sentFirstEvent = true
+		s.mu.Unlock()
+		s.parent.Send(event)
+		return
+	}
+
+	// Update the batch
+	s.batch.Results = append(s.batch.Results, event.Results...)
+	s.batch.Stats.Update(&event.Stats)
+	s.dirty = true
+
+	if s.timer == nil {
+		// Create a timer and schedule a flush
+		s.timer = time.AfterFunc(s.maxDelay, func() {
+			s.mu.Lock()
+			s.flush()
+			s.flushScheduled = false
+			s.mu.Unlock()
+		})
+		s.flushScheduled = true
+	} else if !s.flushScheduled {
+		// Reuse the timer, scheduling a new flush
+		s.timer.Reset(s.maxDelay)
+	}
+	// If neither of those conditions is true,
+	// a flush has already been scheduled and
+	// we're good to go.
+	s.mu.Unlock()
+}
+
+// Done should be called when no more events will be sent down
+// the stream. It flushes any events that are currently batched
+// and cancels any scheduled flush.
+func (s *batchingStream) Done() {
+	s.mu.Lock()
+	// Cancel any scheduled flush
+	if s.timer != nil {
+		s.timer.Stop()
+	}
+
+	s.flush()
+	s.mu.Unlock()
+}
+
+func (s *batchingStream) flush() {
+	if s.dirty {
+		s.parent.Send(s.batch)
+		s.batch = SearchEvent{}
+		s.dirty = false
+	}
 }

--- a/internal/search/streaming/stream.go
+++ b/internal/search/streaming/stream.go
@@ -213,7 +213,7 @@ func (s *batchingStream) Send(event SearchEvent) {
 	s.mu.Lock()
 
 	// Send the first event without delay
-	if !s.sentFirstEvent {
+	if !s.sentFirstEvent && len(event.Results) > 0 {
 		s.sentFirstEvent = true
 		s.mu.Unlock()
 		s.parent.Send(event)
@@ -237,6 +237,7 @@ func (s *batchingStream) Send(event SearchEvent) {
 	} else if !s.flushScheduled {
 		// Reuse the timer, scheduling a new flush
 		s.timer.Reset(s.maxDelay)
+		s.flushScheduled = true
 	}
 	// If neither of those conditions is true,
 	// a flush has already been scheduled and

--- a/internal/search/streaming/stream.go
+++ b/internal/search/streaming/stream.go
@@ -190,6 +190,8 @@ func (c *resultCountingStream) Count() int {
 // NewBatchingStream returns a stream that batches results sent to it, holding
 // delaying their forwarding by a max time of maxDelay, then sending the batched
 // event to the parent stream. The first event is passed through without delay.
+// When there will be no more events sent on the batching stream, Done() must be
+// called to flush the remaining batched events.
 func NewBatchingStream(maxDelay time.Duration, parent Sender) *batchingStream {
 	return &batchingStream{
 		parent:   parent,

--- a/internal/search/streaming/stream_test.go
+++ b/internal/search/streaming/stream_test.go
@@ -1,0 +1,84 @@
+package streaming
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
+)
+
+func BenchmarkBatchingStream(b *testing.B) {
+	s := NewBatchingStream(10*time.Millisecond, StreamFunc(func(SearchEvent) {}))
+	res := make(result.Matches, 1)
+	for i := 0; i < b.N; i++ {
+		s.Send(SearchEvent{
+			Results: res,
+		})
+	}
+	s.Done()
+}
+
+func TestBatchingStream(t *testing.T) {
+	t.Run("basic walkthrough", func(t *testing.T) {
+		var mu sync.Mutex
+		var matches result.Matches
+		s := NewBatchingStream(100*time.Millisecond, StreamFunc(func(event SearchEvent) {
+			mu.Lock()
+			matches = append(matches, event.Results...)
+			mu.Unlock()
+		}))
+
+		for i := 0; i < 10; i++ {
+			s.Send(SearchEvent{Results: make(result.Matches, 1)})
+		}
+
+		// The first event should be sent without delay, but the
+		// remaining events should have been batched but unsent
+		mu.Lock()
+		require.Len(t, matches, 1)
+		mu.Unlock()
+
+		// After 150 milliseconds, the batch should have been flushed
+		time.Sleep(150 * time.Millisecond)
+		mu.Lock()
+		require.Len(t, matches, 10)
+		mu.Unlock()
+
+		// Sending another event shouldn't go through immediately
+		s.Send(SearchEvent{Results: make(result.Matches, 1)})
+		mu.Lock()
+		require.Len(t, matches, 10)
+		mu.Unlock()
+
+		// But if tell the stream we're done, it should
+		s.Done()
+		require.Len(t, matches, 11)
+	})
+
+	t.Run("super parallel", func(t *testing.T) {
+		var matches result.Matches
+		s := NewBatchingStream(100*time.Millisecond, StreamFunc(func(event SearchEvent) {
+			matches = append(matches, event.Results...)
+		}))
+
+		var wg sync.WaitGroup
+		wg.Add(1000)
+		for i := 0; i < 1000; i++ {
+			go func() {
+				s.Send(SearchEvent{Results: make(result.Matches, 1)})
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+
+		// One should be sent immediately
+		require.Len(t, matches, 1)
+
+		// The rest should be sent after flushing
+		s.Done()
+		require.Len(t, matches, 1000)
+	})
+}

--- a/internal/search/streaming/stream_test.go
+++ b/internal/search/streaming/stream_test.go
@@ -58,6 +58,55 @@ func TestBatchingStream(t *testing.T) {
 		require.Len(t, matches, 11)
 	})
 
+	t.Run("send event before timer", func(t *testing.T) {
+		var mu sync.Mutex
+		var matches result.Matches
+		s := NewBatchingStream(100*time.Millisecond, StreamFunc(func(event SearchEvent) {
+			mu.Lock()
+			matches = append(matches, event.Results...)
+			mu.Unlock()
+		}))
+
+		for i := 0; i < 10; i++ {
+			s.Send(SearchEvent{Results: make(result.Matches, 1)})
+		}
+
+		// The first event should be sent without delay, but the
+		// remaining events should have been batched but unsent
+		mu.Lock()
+		require.Len(t, matches, 1)
+		mu.Unlock()
+
+		// After 150 milliseconds, all events should be sent
+		time.Sleep(150 * time.Millisecond)
+		mu.Lock()
+		require.Len(t, matches, 10)
+		mu.Unlock()
+
+		// Sending an event should not make it through immediately
+		s.Send(SearchEvent{Results: make(result.Matches, 1)})
+		mu.Lock()
+		require.Len(t, matches, 10)
+		mu.Unlock()
+
+		// Sending another event should be added to the batch, but still be sent
+		// with the previous event because it triggered a new timer
+		time.Sleep(50 * time.Millisecond)
+		s.Send(SearchEvent{Results: make(result.Matches, 1)})
+		mu.Lock()
+		require.Len(t, matches, 10)
+		mu.Unlock()
+
+		// After 75 milliseconds, the timer from 2 events ago should have triggered
+		time.Sleep(75 * time.Millisecond)
+		mu.Lock()
+		require.Len(t, matches, 12)
+		mu.Unlock()
+
+		s.Done()
+		require.Len(t, matches, 12)
+	})
+
 	t.Run("super parallel", func(t *testing.T) {
 		var matches result.Matches
 		s := NewBatchingStream(100*time.Millisecond, StreamFunc(func(event SearchEvent) {


### PR DESCRIPTION
This creates a new stream type: batchingStream. This is a stream type
that batches events up to a maximum delay, then sends them to its parent
stream. What's the point? Well, right now, we have a "batchEvents"
function that batches events sent down a channel, but it doesn't conform
to our standard streaming.Sender interface, so it can only be used at
the streaming search API layer. As a bonus, this is faster than using
goroutines and channels. Approximately 3-5x faster based on my
benchmarks. And that's not taking into account that for streaming, we're
sending events down an unbuffered channel, which will slow that down
even more.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
