### PR TITLE
devx: add OWNERS files

### DIFF
--- a/dev/bkstats/OWNERS
+++ b/dev/bkstats/OWNERS
@@ -1,0 +1,3 @@
+# See https://github.com/sourcegraph/codenotify for documentation.
+
+**/* @sourcegraph/dev-experience

--- a/dev/buildchecker/ONWERS
+++ b/dev/buildchecker/ONWERS
@@ -1,0 +1,3 @@
+# See https://github.com/sourcegraph/codenotify for documentation.
+
+**/* @sourcegraph/dev-experience

--- a/dev/ci/OWNERS
+++ b/dev/ci/OWNERS
@@ -1,0 +1,6 @@
+# See https://github.com/sourcegraph/codenotify for documentation.
+
+annotate.sh @sourcegraph/dev-experience
+go-build.sh @sourcegraph/dev-experience
+go-test.sh @sourcegraph/dev-experience
+sentry-capture.sh @sourcegraph/dev-experience

--- a/dev/sg/OWNERS
+++ b/dev/sg/OWNERS
@@ -1,0 +1,3 @@
+# See https://github.com/sourcegraph/codenotify for documentation.
+
+**/* @mrnugget @sourcegraph/dev-experience

--- a/enterprise/dev/ci/OWNERS
+++ b/enterprise/dev/ci/OWNERS
@@ -1,0 +1,3 @@
+# See https://github.com/sourcegraph/codenotify for documentation.
+
+**/* @sourcegraph/dev-experience


### PR DESCRIPTION
Following up on [RFC-551](https://docs.google.com/document/d/1TleM8nX7kJA9QySYj7IwVojzBf4A0KwzkKbQ8-dwnjQ/edit#heading=h.trqab8y0kufp), this PRs addes a few OWNERS files on our stuff. 
