### PR TITLE
bext: filter dropdown duplicated URLs

### DIFF
--- a/client/browser/src/browser-extension/scripts/optionsPage.main.tsx
+++ b/client/browser/src/browser-extension/scripts/optionsPage.main.tsx
@@ -1,7 +1,7 @@
 // We want to polyfill first.
 import '../../shared/polyfills'
 
-import { uniq } from 'lodash'
+import { trimEnd, uniq } from 'lodash'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { render } from 'react-dom'
 import { from, noop, Observable } from 'rxjs'
@@ -143,6 +143,12 @@ function useTelemetryService(sourcegraphUrl: string | undefined): TelemetryServi
     return telemetryService
 }
 
+/**
+ * Returns unique URLs
+ */
+const uniqURLs = (urls: (string | undefined)[]): string[] =>
+    uniq(urls.filter(value => !!value).map(value => trimEnd(value, '/')))
+
 const Options: React.FunctionComponent = () => {
     const sourcegraphUrl = useObservable(observingSourcegraphUrl)
     const [previousSourcegraphUrl, setPreviousSourcegraphUrl] = useState(sourcegraphUrl)
@@ -185,9 +191,7 @@ const Options: React.FunctionComponent = () => {
             storage.sync
                 .set({
                     sourcegraphURL: url,
-                    previouslyUsedURLs: uniq([...(previouslyUsedUrls || []), url, sourcegraphUrl]).filter(
-                        value => !!value
-                    ) as string[],
+                    previouslyUsedURLs: uniqURLs([...(previouslyUsedUrls || []), url, sourcegraphUrl]),
                 })
                 .catch(console.error)
         },
@@ -215,7 +219,7 @@ const Options: React.FunctionComponent = () => {
                 <OptionsPage
                     isFullPage={isFullPage}
                     sourcegraphUrl={sourcegraphUrl || ''}
-                    suggestedSourcegraphUrls={previouslyUsedUrls || []}
+                    suggestedSourcegraphUrls={uniqURLs(previouslyUsedUrls || [])}
                     onChangeSourcegraphUrl={handleChangeSourcegraphUrl}
                     version={version}
                     validateSourcegraphUrl={validateSourcegraphUrl}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/30673.

## How to test

`sg run bext`
- Add different URLs with and without trailing `/`
- Check that dropdown correctly suggests URLs

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
