### PR TITLE
Fix invalid GraphQL query in integration tests

### DIFF
--- a/internal/gqltestutil/organization.go
+++ b/internal/gqltestutil/organization.go
@@ -87,8 +87,8 @@ type InviteUserToOrganizationResult struct {
 // InviteUserToOrganization invites a user to the given organization.
 func (c *Client) InviteUserToOrganization(orgID, username string, email string) (*InviteUserToOrganizationResult, error) {
 	const query = `
-mutation InviteUserToOrganization($organization: ID!, $username: String, $email String) {
-	inviteUserToOrganization(organization: $organization, username: $username, email $email) {
+mutation InviteUserToOrganization($organization: ID!, $username: String, $email: String) {
+	inviteUserToOrganization(organization: $organization, username: $username, email: $email) {
 		... on InviteUserToOrganizationResult {
 			sentInvitationEmail
 			invitationURL


### PR DESCRIPTION
This was introduced in e29d8182dbf652e12fab3888c95e9717e3ba2227 and
broke integration tests on main.
