### PR TITLE
monitoring: Increase alert timing threshold

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -3169,7 +3169,7 @@ with your code hosts connections or networking issues affecting communication wi
 
 **Descriptions**
 
-- <span class="badge badge-critical">critical</span> repo-updater: 1+ repositories schedule error rate for 15m0s
+- <span class="badge badge-critical">critical</span> repo-updater: 1+ repositories schedule error rate for 25m0s
 
 **Possible solutions**
 

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -207,7 +207,7 @@ func RepoUpdater() *monitoring.Container {
 							Name:              "sched_error",
 							Description:       "repositories schedule error rate",
 							Query:             `max(rate(src_repoupdater_sched_error[1m]))`,
-							Critical:          monitoring.Alert().GreaterOrEqual(1, nil).For(15 * time.Minute),
+							Critical:          monitoring.Alert().GreaterOrEqual(1, nil).For(25 * time.Minute),
 							Panel:             monitoring.Panel().Unit(monitoring.Number),
 							Owner:             monitoring.ObservableOwnerCoreApplication,
 							PossibleSolutions: "Check repo-updater logs for errors",


### PR DESCRIPTION
This metric spikes during gitserver deployments which can take longer
than 15 minutes so we want to avoid this alert going off during every
deployment.
