### PR TITLE
search: Fix icon alignment in search stack entries

### DIFF
--- a/client/web/src/search/SearchStack.tsx
+++ b/client/web/src/search/SearchStack.tsx
@@ -138,8 +138,12 @@ function renderSearchEntry(entry: SearchStackEntry): React.ReactChild {
                     }}
                     className={styles.entry}
                 >
-                    <SearchIcon className="icon-inline text-muted mr-1" />
-                    <SyntaxHighlightedSearchQuery query={entry.query} />
+                    <div className="d-flex">
+                        <span className="flex-shrink-0">
+                            <SearchIcon className="icon-inline text-muted mr-1" />
+                        </span>
+                        <SyntaxHighlightedSearchQuery query={entry.query} />
+                    </div>
                 </Link>
             )
         case 'file':
@@ -154,8 +158,10 @@ function renderSearchEntry(entry: SearchStackEntry): React.ReactChild {
                     }}
                     className={styles.entry}
                 >
-                    <div>
-                        <FileDocumentIcon className="icon-inline text-muted mr-1" />
+                    <div className="d-flex">
+                        <span className="flex-shrink-0">
+                            <FileDocumentIcon className="icon-inline text-muted mr-1" />
+                        </span>
                         <span title={entry.path}>{shortenFilePath(entry.path)}</span>
                     </div>
                     <small className="text-muted">


### PR DESCRIPTION
Closes #30009

This fixes the icon alignment by using flex box and wrapping the icon in an inline element so that it still properly aligns with the first line of the text.

<img width="222" alt="2022-02-04_14-53" src="https://user-images.githubusercontent.com/179026/152542145-faa8f2c9-4014-4fa0-ba25-8c171205850e.png">
