### PR TITLE
Allow site-admin to remove themselves from an Org CLOUD-262

### DIFF
--- a/client/web/src/org/settings/members/OrgSettingsMembersPage.tsx
+++ b/client/web/src/org/settings/members/OrgSettingsMembersPage.tsx
@@ -36,7 +36,7 @@ interface UserNodeProps {
 
     /** Called when the user is updated by an action in this list item. */
     onDidUpdate?: (didRemoveSelf: boolean) => void
-    onRemoveOnlyMember?: () => void
+    blockRemoveOnlyMember?: () => boolean
     history: H.History
 }
 
@@ -69,10 +69,11 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
                 .pipe(
                     filter(() => {
                         if (this.props.org.hasOneMember) {
-                            if (this.props.onRemoveOnlyMember) {
-                                this.props.onRemoveOnlyMember()
+                            if (this.props.blockRemoveOnlyMember) {
+                                if (this.props.blockRemoveOnlyMember()) {
+                                    return false
+                                }
                             }
-                            return false
                         }
                         return window.confirm(
                             this.isSelf ? 'Leave the organization?' : `Remove the user ${this.props.node.username}?`
@@ -214,7 +215,13 @@ export class OrgSettingsMembersPage extends React.PureComponent<Props, State> {
             },
             authenticatedUser: this.props.authenticatedUser,
             onDidUpdate: this.onDidUpdateUser,
-            onRemoveOnlyMember: () => this.setState({ onlyMemberRemovalAttempted: true }),
+            blockRemoveOnlyMember: () => {
+                if (!this.props.authenticatedUser.siteAdmin) {
+                    this.setState({ onlyMemberRemovalAttempted: true })
+                    return true
+                }
+                return false
+            },
 
             history: this.props.history,
         }

--- a/client/web/src/org/settings/members/OrgSettingsMembersPage.tsx
+++ b/client/web/src/org/settings/members/OrgSettingsMembersPage.tsx
@@ -68,12 +68,8 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
             this.removes
                 .pipe(
                     filter(() => {
-                        if (this.props.org.hasOneMember) {
-                            if (this.props.blockRemoveOnlyMember) {
-                                if (this.props.blockRemoveOnlyMember()) {
-                                    return false
-                                }
-                            }
+                        if (this.props.org.hasOneMember && this.props.blockRemoveOnlyMember?.()) {
+                            return false
                         }
                         return window.confirm(
                             this.isSelf ? 'Leave the organization?' : `Remove the user ${this.props.node.username}?`

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -290,7 +290,7 @@ func (r *schemaResolver) RemoveUserFromOrganization(ctx context.Context, args *s
 	if err != nil {
 		return nil, err
 	}
-	if memberCount == 1 {
+	if memberCount == 1 && !r.siteAdminSelfRemoving(ctx, userID) {
 		return nil, errors.New("you can’t remove the only member of an organization")
 	}
 	log15.Info("removing user from org", "user", userID, "org", orgID)
@@ -306,6 +306,16 @@ func (r *schemaResolver) RemoveUserFromOrganization(ctx context.Context, args *s
 		)
 	}
 	return nil, nil
+}
+
+func (r *schemaResolver) siteAdminSelfRemoving(ctx context.Context, userID int32) bool {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
+		return false
+	}
+	if err := backend.CheckSameUser(ctx, userID); err != nil {
+		return false
+	}
+	return true
 }
 
 func (r *schemaResolver) AddUserToOrganization(ctx context.Context, args *struct {


### PR DESCRIPTION
Allow site-admin to remove themselves even if they are the last member of an Org - [CLOUD-262](https://sourcegraph.atlassian.net/browse/CLOUD-262).

Tested:

- site admin can remove themselves (in UI and API)
- site admin cannot remove last user if they are not a member of an Org (through API)
- regular user cannot remove themselves if they are the last member (through API)
