### PR TITLE
permissions: Instrument sub-repo perms sync timings

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -1239,6 +1239,8 @@ func (s *PermsSyncer) collectMetrics(ctx context.Context) {
 		metricsPermsGap.WithLabelValues("user").Set(m.UsersPermsGapSeconds)
 		metricsStalePerms.WithLabelValues("repo").Set(float64(m.ReposWithStalePerms))
 		metricsPermsGap.WithLabelValues("repo").Set(m.ReposPermsGapSeconds)
+		metricsStalePerms.WithLabelValues("sub-repo").Set(float64(m.SubReposWithStalePerms))
+		metricsPermsGap.WithLabelValues("sub-repo").Set(m.SubReposPermsGapSeconds)
 
 		s.queue.mu.RLock()
 		metricsQueueSize.Set(float64(s.queue.Len()))


### PR DESCRIPTION
Tracks the number of stale permissions and the gape between oldest and
newest synced users. This is the same information we currently expose
for normal user and repo perms.
