### PR TITLE
SSBC: Skipped steps migration

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -166,19 +166,15 @@ Foreign-key constraints:
  path                 | text                     |           | not null | 
  file_matches         | text[]                   |           | not null | 
  only_fetch_workspace | boolean                  |           | not null | false
- steps                | jsonb                    |           |          | '[]'::jsonb
  created_at           | timestamp with time zone |           | not null | now()
  updated_at           | timestamp with time zone |           | not null | now()
  ignored              | boolean                  |           | not null | false
  unsupported          | boolean                  |           | not null | false
  skipped              | boolean                  |           | not null | false
  cached_result_found  | boolean                  |           | not null | false
- skipped_steps        | integer[]                |           | not null | '{}'::integer[]
  step_cache_results   | jsonb                    |           | not null | '{}'::jsonb
 Indexes:
     "batch_spec_workspaces_pkey" PRIMARY KEY, btree (id)
-Check constraints:
-    "batch_spec_workspaces_steps_check" CHECK (jsonb_typeof(steps) = 'array'::text)
 Foreign-key constraints:
     "batch_spec_workspaces_batch_spec_id_fkey" FOREIGN KEY (batch_spec_id) REFERENCES batch_specs(id) ON DELETE CASCADE DEFERRABLE
     "batch_spec_workspaces_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) DEFERRABLE

--- a/migrations/frontend/1528395972/down.sql
+++ b/migrations/frontend/1528395972/down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE batch_spec_workspaces ADD COLUMN IF NOT EXISTS steps JSONB DEFAULT '[]'::JSONB CHECK (jsonb_typeof(steps) = 'array'::TEXT);
+ALTER TABLE batch_spec_workspaces ADD COLUMN IF NOT EXISTS skipped_steps INTEGER[] NOT NULL DEFAULT '{}'::INTEGER[];
+
+COMMIT;

--- a/migrations/frontend/1528395972/metadata.yaml
+++ b/migrations/frontend/1528395972/metadata.yaml
@@ -1,0 +1,2 @@
+name: no steps persisted
+parent: 1528395971

--- a/migrations/frontend/1528395972/up.sql
+++ b/migrations/frontend/1528395972/up.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE batch_spec_workspaces DROP COLUMN IF EXISTS steps;
+ALTER TABLE batch_spec_workspaces DROP COLUMN IF EXISTS skipped_steps;
+
+COMMIT;


### PR DESCRIPTION
After not storing these fields in the database anymore, we also don't need the columns anymore.
