### PR TITLE
dev/sg: introduce 'sg version changelog'

### DIFF
--- a/dev/sg/install.sh
+++ b/dev/sg/install.sh
@@ -105,3 +105,5 @@ fi
 
 echo "                                                  "
 echo "                  Happy hacking!"
+echo
+echo "  Run 'sg version changelog' to see what has changed."

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -118,10 +118,11 @@ func checkSgVersion() {
 	}
 
 	out = strings.TrimSpace(out)
-	if out != "" {
-		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "--------------------------------------------------------------------------"))
-		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "HEY! New version of sg available. Run `./dev/sg/install.sh` to install it."))
-		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "--------------------------------------------------------------------------"))
+	if out != "" || true {
+		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "------------------------------------------------------------------------------"))
+		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "  HEY! New version of sg available. Run './dev/sg/install.sh' to install it.  "))
+		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "             To see what's new, run 'sg version changelog -next'.             "))
+		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "------------------------------------------------------------------------------"))
 	}
 }
 

--- a/dev/sg/sg_version.go
+++ b/dev/sg/sg_version.go
@@ -3,24 +3,83 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/run"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
+	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
 var (
 	versionFlagSet = flag.NewFlagSet("sg version", flag.ExitOnError)
+
+	versionChangelogFlagSet = flag.NewFlagSet("sg version changelog", flag.ExitOnError)
+	versionChangelogNext    = versionChangelogFlagSet.Bool("next", false, "Show changelog for changes you would get if you upgrade.")
+	versionChangelogEntries = versionChangelogFlagSet.Int("limit", 20, "Number of changelog entries to show.")
+
 	versionCommand = &ffcli.Command{
 		Name:       "version",
 		ShortUsage: "sg version",
 		ShortHelp:  "Prints the sg version",
 		FlagSet:    versionFlagSet,
 		Exec:       versionExec,
+		Subcommands: []*ffcli.Command{
+			{
+				Name:      "changelog",
+				ShortHelp: "See what's changed in or since this version of sg",
+				FlagSet:   versionChangelogFlagSet,
+				Exec:      changelogExec,
+			},
+		},
 	}
 )
 
 func versionExec(ctx context.Context, args []string) error {
 	stdout.Out.Write(BuildCommit)
+	return nil
+}
+
+func changelogExec(ctx context.Context, args []string) error {
+	logArgs := []string{
+		"log", "--pretty=%C(reset)%s %C(dim)%h by %an, %ar",
+		"--color=always",
+		fmt.Sprintf("--max-count=%d", *versionChangelogEntries),
+	}
+	var title string
+	if BuildCommit != "dev" {
+		current := strings.TrimLeft(BuildCommit, "dev-")
+		if *versionChangelogNext {
+			logArgs = append(logArgs, current+"..")
+			title = fmt.Sprintf("Changes since sg release %s", BuildCommit)
+		} else {
+			logArgs = append(logArgs, current)
+			title = fmt.Sprintf("Changes in sg release %s", BuildCommit)
+		}
+	} else {
+		writeWarningLinef("Dev version detected - just showing recent changes.")
+		title = "Recent sg changes"
+	}
+
+	gitLog := exec.Command("git", append(logArgs, "--", "./dev/sg")...)
+	gitLog.Env = os.Environ()
+	out, err := run.InRoot(gitLog)
+	if err != nil {
+		return err
+	}
+
+	block := stdout.Out.Block(output.Linef("", output.StyleSearchQuery, title))
+	if len(out) == 0 {
+		block.Write("No changes found.")
+	} else {
+		block.Write(out + "...")
+	}
+	block.Close()
+
+	stdout.Out.WriteLine(output.Linef("", output.StyleSuggestion, "Only showing %d entries - configure with 'sg version changelog -limit=50'", *versionChangelogEntries))
 	return nil
 }


### PR DESCRIPTION
Adds a simple `sg version changelog` with `-next` and `-limit` flags, as well as prompts to use it.

![image](https://user-images.githubusercontent.com/23356519/152575939-07efec1e-3c2e-45a0-8860-f7e1eca1b97f.png)

![image](https://user-images.githubusercontent.com/23356519/152576264-b17b8e0c-def1-45ea-be81-43f167ca8d57.png)
