### PR TITLE
use smaller number of parallel senders

### DIFF
--- a/internal/search/streaming/stream_test.go
+++ b/internal/search/streaming/stream_test.go
@@ -115,8 +115,8 @@ func TestBatchingStream(t *testing.T) {
 		}))
 
 		var wg sync.WaitGroup
-		wg.Add(1000)
-		for i := 0; i < 1000; i++ {
+		wg.Add(10)
+		for i := 0; i < 10; i++ {
 			go func() {
 				s.Send(SearchEvent{Results: make(result.Matches, 1)})
 				wg.Done()
@@ -129,6 +129,6 @@ func TestBatchingStream(t *testing.T) {
 
 		// The rest should be sent after flushing
 		s.Done()
-		require.Equal(t, count.Load(), int64(1000))
+		require.Equal(t, count.Load(), int64(10))
 	})
 }


### PR DESCRIPTION
I think this is causing failures in CI because we can't send 1000
messages in 100 milliseconds on CI. I expect this is just because CI is
more CPU-loaded than my local machine. I seem to remember other issues
about atomics being slow on CI as well. 

This just runs it with a smaller number of parallel workers
so that it will hopefully fit in the batch time-window in a stable
manner.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
