### PR TITLE
compute: support multiline matches for regexp capture groups

### DIFF
--- a/enterprise/cmd/frontend/internal/compute/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/compute/resolvers/resolvers_test.go
@@ -7,25 +7,25 @@ import (
 
 	"github.com/hexops/autogold"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/compute"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
 func TestToResultResolverList(t *testing.T) {
-	matches := []result.Match{
-		&result.FileMatch{
-			LineMatches: []*result.LineMatch{
-				{Preview: "a"},
-				{Preview: "b"},
-			},
-		},
+	content := "ab"
+
+	git.Mocks.ReadFile = func(_ api.CommitID, _ string) ([]byte, error) {
+		return []byte(content), nil
 	}
+
 	test := func(input string) string {
 		computeQuery, _ := compute.Parse(input)
 		resolvers, _ := toResultResolverList(
 			context.Background(),
 			computeQuery.Command,
-			matches,
+			[]result.Match{&result.FileMatch{}},
 			database.NewMockDB(),
 		)
 		results := make([]string, 0, len(resolvers))

--- a/enterprise/internal/compute/match_context_result.go
+++ b/enterprise/internal/compute/match_context_result.go
@@ -46,9 +46,16 @@ func newLocation(line, column, offset int) Location {
 	}
 }
 
-func newRange(startLine, endLine, startColumn, endColumn int) Range {
+func NewRange(startLine, endLine, startColumn, endColumn int) Range {
 	return Range{
 		Start: newLocation(startLine, startColumn, -1),
 		End:   newLocation(endLine, endColumn, -1),
+	}
+}
+
+func newOffsetRange(start, end int) Range {
+	return Range{
+		Start: newLocation(-1, -1, start),
+		End:   newLocation(-1, -1, end),
 	}
 }


### PR DESCRIPTION
As in title

Slack context: https://sourcegraph.slack.com/archives/C02QG5A2N31/p1643934724602509