### PR TITLE
dev/release: do not create GitHub release if release is old

### DIFF
--- a/dev/release/src/github.ts
+++ b/dev/release/src/github.ts
@@ -648,7 +648,8 @@ export async function createLatestRelease(
         owner,
         repo,
     })
-    if (release.compare(latest.data.tag_name) === -1) {
+    const latestTag = latest.data.tag_name
+    if (release.compare(latestTag.startsWith('v') ? latestTag.slice(1) : latestTag) === -1) {
         // if latest is greater than release, do not generate a release
         return ''
     }

--- a/dev/release/src/github.ts
+++ b/dev/release/src/github.ts
@@ -651,6 +651,7 @@ export async function createLatestRelease(
     const latestTag = latest.data.tag_name
     if (release.compare(latestTag.startsWith('v') ? latestTag.slice(1) : latestTag) === -1) {
         // if latest is greater than release, do not generate a release
+        console.log(`Latest release ${latestTag} is more recent than ${release.version}, skipping GitHub release`)
         return ''
     }
 

--- a/dev/release/src/github.ts
+++ b/dev/release/src/github.ts
@@ -649,7 +649,7 @@ export async function createLatestRelease(
         repo,
     })
     const latestTag = latest.data.tag_name
-    if (release.compare(latestTag.startsWith('v') ? latestTag.slice(1) : latestTag) === -1) {
+    if (semver.gt(latestTag.startsWith('v') ? latestTag.slice(1) : latestTag, release)) {
         // if latest is greater than release, do not generate a release
         console.log(`Latest release ${latestTag} is more recent than ${release.version}, skipping GitHub release`)
         return ''

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -19,7 +19,7 @@ import {
     commentOnIssue,
     queryIssues,
     IssueLabel,
-    createRelease,
+    createLatestRelease,
 } from './github'
 import { ensureEvent, getClient, EventOptions, calendarTime } from './google-calendar'
 import { postMessage, slackURL } from './slack'
@@ -600,7 +600,7 @@ Batch change: ${batchChangeURL}`,
             // Create final GitHub release
             let githubRelease = ''
             try {
-                githubRelease = await createRelease(
+                githubRelease = await createLatestRelease(
                     githubClient,
                     {
                         owner: 'sourcegraph',
@@ -621,7 +621,7 @@ Batch change: ${batchChangeURL}`,
             const releaseMessage = `*Sourcegraph ${release.version} has been published*
 
 * Changelog: ${changelogURL(release.format())}
-* GitHub release: ${githubRelease || 'Failed to generate release'}
+* GitHub release: ${githubRelease || 'No release generated'}
 * Release batch change: ${batchChangeURL}`
 
             // Slack


### PR DESCRIPTION
The recent 3.35.2 patch release shows up as the latest release, as reported by @eseliger : 

![image](https://user-images.githubusercontent.com/23356519/152614724-51ceb6ae-6f95-4895-8178-55171568854e.png)


So apparently GitHub just treats whatever release was published most recently as `latest`, which is kind of right but also doesn't feel like the way it should work but oh well 😅 https://github.community/t/latest-release-isnt-the-real-latest/2244/6 

This change adds an additional check to see if the latest release is newer than the release being published and if it is, we don't publish a GitHub release for it. I think this is fine because folks watching the repo are likely watching for the latest and greatest, not a patch fix to an older release. I think?