### PR TITLE
insight docs: update capture group limitations

### DIFF
--- a/doc/code_insights/explanations/automatically_generated_data_series.md
+++ b/doc/code_insights/explanations/automatically_generated_data_series.md
@@ -28,10 +28,6 @@ For the above example, this means that if `<java.version>1.9</java.version>` was
 
 Code Insights is in Beta and this feature has some yet-released limitations. In rough order, with limitations listed first likely to be removed soonest, they are: 
 
-### Must specify repository list 
-
-Code Insights using capture groups only run over an explicit list of repositories (max 50-70) rather than running over all connected repositories. 
-
 ### Limited to 20 matches
 
 Capture groups will only display 20 returned match values to prevent extremely large result sets from being rendered. If there are more than 20 matches, **a non-deterministic 20 series will be rendered on every reload**. Until we add controls to make this deterministic and configurable, for now we strongly recommend you refine your regular expression so that there are no more than 20 different values returned. 
@@ -39,6 +35,10 @@ Capture groups will only display 20 returned match values to prevent extremely l
 ### No capture groups in filter strings 
 
 This type of Code Insight only supports capture groups in the main query string. You cannot use a capture group in a filter keywork, like a `repo:` or `file:` filter. 
+
+### No multiline matches
+
+You can only use a single-line regular expression. This means that `^` and `$` characters are still valid but needing to match on a `\n` is not. As a potential workaround to get more granularity, you can still use `file:contains()` and other [search predicates](https://docs.sourcegraph.com/code_search/reference/language#built-in-file-predicate). 
 
 ### No combinations of capture groups 
 


### PR DESCRIPTION
Related to #30713 and as a result of a discussion in slack. This attempts to capture [the new understanding](https://sourcegraph.slack.com/archives/C02QG5A2N31/p1643934724602509), pun intended. 

Am actually not certain about the predicate allowance and the use of `^` `$` characters so if anyone is more certain, please do check me on that. Will go and test them. 