### PR TITLE
Fix <ButtonLink> and disallow href props

### DIFF
--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -311,7 +311,7 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
                                     >
                                         Log in
                                     </Button>
-                                    <ButtonLink className={styles.signUp} href={buildGetStartedURL('nav')} size="sm">
+                                    <ButtonLink className={styles.signUp} to={buildGetStartedURL('nav')} size="sm">
                                         Get started
                                     </ButtonLink>
                                 </div>

--- a/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
@@ -231,7 +231,6 @@ exports[`GlobalNavbar default 1`] = `
           <a
             class="btn btnSm signUp"
             href="https://about.sourcegraph.com/get-started?utm_medium=inproduct&utm_source=nav&utm_campaign=inproduct-cta"
-            role="button"
             tabindex="0"
           >
             Get started
@@ -495,7 +494,6 @@ exports[`GlobalNavbar low-profile 1`] = `
           <a
             class="btn btnSm signUp"
             href="https://about.sourcegraph.com/get-started?utm_medium=inproduct&utm_source=nav&utm_campaign=inproduct-cta"
-            role="button"
             tabindex="0"
           >
             Get started

--- a/client/wildcard/src/components/ButtonLink/ButtonLink.tsx
+++ b/client/wildcard/src/components/ButtonLink/ButtonLink.tsx
@@ -14,7 +14,7 @@ const isSelectKeyPress = (event: React.KeyboardEvent): boolean =>
     event.key === Key.Enter && !event.ctrlKey && !event.shiftKey && !event.metaKey && !event.altKey
 
 export type ButtonLinkProps = Omit<ButtonProps, 'as'> &
-    AnchorHTMLAttributes<HTMLAnchorElement> & {
+    Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> & {
         /** The link destination URL. */
         to?: H.LocationDescriptor
 

--- a/client/wildcard/src/components/ButtonLink/ButtonLink.tsx
+++ b/client/wildcard/src/components/ButtonLink/ButtonLink.tsx
@@ -14,7 +14,7 @@ const isSelectKeyPress = (event: React.KeyboardEvent): boolean =>
     event.key === Key.Enter && !event.ctrlKey && !event.shiftKey && !event.metaKey && !event.altKey
 
 export type ButtonLinkProps = Omit<ButtonProps, 'as'> &
-    Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> & {
+    AnchorHTMLAttributes<HTMLAnchorElement> & {
         /** The link destination URL. */
         to?: H.LocationDescriptor
 


### PR DESCRIPTION
After [changing some of the items on the nav bar to use `<ButtonLink>`](https://github.com/sourcegraph/sourcegraph/pull/30534), the Get Started button no longer works. It seems that the problem is that it sets an `href` on the `<ButtonLink />` where it should set `to`. This works because the typing extends `AnchorHTMLAttributes` without omitting the href. 

--

Whoever looks at this: feel free to merge on my behalf!

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
