### PR TITLE
dev/sg: render 'sg ci preview' with nice markdown

### DIFF
--- a/dev/sg/printing.go
+++ b/dev/sg/printing.go
@@ -37,6 +37,7 @@ func writePrettyMarkdown(str string) error {
 		glamour.WithAutoStyle(),
 		// wrap output at specific width
 		glamour.WithWordWrap(120),
+		glamour.WithEmoji(),
 	)
 	if err != nil {
 		return err

--- a/dev/sg/sg_ci.go
+++ b/dev/sg/sg_ci.go
@@ -99,8 +99,7 @@ Note that Sourcegraph's CI pipelines are under our enterprise license: https://g
 				if err != nil {
 					return err
 				}
-				stdout.Out.Write(out)
-				return nil
+				return writePrettyMarkdown(out)
 			},
 		}, {
 			Name:      "status",

--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -66,15 +66,15 @@ func main() {
 }
 
 func previewPipeline(w io.Writer, c ci.Config, pipeline *buildkite.Pipeline) {
-	fmt.Fprintf(w, "Detected run type:\n\t%s\n", c.RunType.String())
-	fmt.Fprintf(w, "Detected diffs:\n\t%s\n", c.Diff.String())
-	fmt.Fprintf(w, "Computed build steps:\n")
+	fmt.Fprintf(w, "- **Detected run type:** %s\n", c.RunType.String())
+	fmt.Fprintf(w, "- **Detected diffs:** %s\n", c.Diff.String())
+	fmt.Fprintf(w, "- **Computed build steps:**\n")
 	printPipeline(w, "", pipeline)
 }
 
 func printPipeline(w io.Writer, prefix string, pipeline *buildkite.Pipeline) {
 	if pipeline.Group.Group != "" {
-		fmt.Fprintf(w, "%s%s\n", prefix, pipeline.Group.Group)
+		fmt.Fprintf(w, "%s- **%s**\n", prefix, pipeline.Group.Group)
 	}
 	for _, raw := range pipeline.Steps {
 		switch v := raw.(type) {
@@ -87,13 +87,14 @@ func printPipeline(w io.Writer, prefix string, pipeline *buildkite.Pipeline) {
 }
 
 func printStep(w io.Writer, prefix string, step *buildkite.Step) {
-	fmt.Fprintf(w, "%s\t%s\n", prefix, step.Label)
+	fmt.Fprintf(w, "%s\t- %s", prefix, step.Label)
 	switch {
 	case len(step.DependsOn) > 5:
-		fmt.Fprintf(w, "%s\t\t→ depends on %s, ... (%d more steps)\n", prefix, strings.Join(step.DependsOn[0:5], ", "), len(step.DependsOn)-5)
+		fmt.Fprintf(w, " → _depends on %s, ... (%d more steps)_", strings.Join(step.DependsOn[0:5], ", "), len(step.DependsOn)-5)
 	case len(step.DependsOn) > 0:
-		fmt.Fprintf(w, "%s\t\t→ depends on %s\n", prefix, strings.Join(step.DependsOn, " "))
+		fmt.Fprintf(w, " → _depends on %s_", strings.Join(step.DependsOn, " "))
 	}
+	fmt.Fprintln(w)
 }
 
 var emojiRegexp = regexp.MustCompile(`:(\S*):`)


### PR DESCRIPTION
`gen-pipeline.go` currently only renders very bare-bones output since it is a separate tool. Perhaps we could roll it into `sg` proper one day, but for now it seems the simplest way to get nicer output is to render Markdown and use the pretty Markdown printer introduced in https://github.com/sourcegraph/sourcegraph/pull/30532 to get some formatted results.

Also supports some emoji through glamour's built-in emoji renderer option

![image](https://user-images.githubusercontent.com/23356519/152655880-59fd3794-7df1-4354-aa0d-a9e42b06bdb9.png)
