### PR TITLE
repo-updater: Remove feature flag to enable / disable repo update jitter

### DIFF
--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -789,12 +789,10 @@ func (s *schedule) updateInterval(repo configuredRepo, interval time.Duration) {
 			update.Interval = interval
 		}
 
-		if conf.ExperimentalFeatures().EnableRepoUpdateIntervalJitter {
-			// Add a jitter of 5% on either side of the interval to avoid
-			// repos getting updated at the same time.
-			delta := int64(update.Interval) / 20
-			update.Interval = update.Interval + time.Duration(s.randGenerator.Int63n(2*delta)-delta)
-		}
+		// Add a jitter of 5% on either side of the interval to avoid
+		// repos getting updated at the same time.
+		delta := int64(update.Interval) / 20
+		update.Interval = update.Interval + time.Duration(s.randGenerator.Int63n(2*delta)-delta)
 
 		update.Due = timeNow().Add(update.Interval)
 		log15.Debug("updated repo", "repo", repo.Name, "due", update.Due.Sub(timeNow()))

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -575,8 +575,6 @@ type ExperimentalFeatures struct {
 	EnablePermissionsWebhooks bool `json:"enablePermissionsWebhooks,omitempty"`
 	// EnablePostSignupFlow description: Enables post sign-up user flow to add code hosts and sync code
 	EnablePostSignupFlow bool `json:"enablePostSignupFlow,omitempty"`
-	// EnableRepoUpdateIntervalJitter description: Enable a jitter of 5% in the update interval of a repo in the schedule
-	EnableRepoUpdateIntervalJitter bool `json:"enableRepoUpdateIntervalJitter,omitempty"`
 	// EventLogging description: Enables user event logging inside of the Sourcegraph instance. This will allow admins to have greater visibility of user activity, such as frequently viewed pages, frequent searches, and more. These event logs (and any specific user actions) are only stored locally, and never leave this Sourcegraph instance.
 	EventLogging string `json:"eventLogging,omitempty"`
 	// JvmPackages description: Allow adding JVM packages code host connections

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -370,11 +370,6 @@
           "description": "Enable support for visilibity of internal Github repositories",
           "type": "boolean",
           "default": false
-        },
-        "enableRepoUpdateIntervalJitter": {
-          "description": "Enable a jitter of 5% in the update interval of a repo in the schedule",
-          "type": "boolean",
-          "default": false
         }
       },
       "examples": [


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#30154

Part of investigation of #30110.

We had set the feature flag to verify if the jitter was the root cause of the alert `0+ rate of growth of update queue length over 5 minutes` to get triggered but after ~2 weeks in production with jitter disabled, it seems like this is unrelated. Here's the graph for the related metric since the time we disabled the jitter feature. 

![image](https://user-images.githubusercontent.com/2682729/152772429-46bc7f88-dd12-4f73-8875-5493d6bbfdd8.png)

[Link](https://sourcegraph.com/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100051&orgId=1&from=now-30d&to=now) to the dashboard.


