### PR TITLE
search: Show last added item on top of search stack

### DIFF
--- a/client/web/src/search/SearchStack.story.tsx
+++ b/client/web/src/search/SearchStack.story.tsx
@@ -31,9 +31,10 @@ export default {
 } as ComponentMeta<typeof SearchStack>
 
 const mockEntries: SearchStackEntry[] = [
-    { type: 'search', query: 'TODO', caseSensitive: false, patternType: SearchPatternType.literal },
-    { type: 'file', path: 'path/to/file1', repo: 'my/repo', revision: 'master', lineRange: null },
+    { id: 0, type: 'search', query: 'TODO', caseSensitive: false, patternType: SearchPatternType.literal },
+    { id: 1, type: 'file', path: 'path/to/file1', repo: 'my/repo', revision: 'master', lineRange: null },
     {
+        id: 2,
         type: 'file',
         path: 'path/to/a/really/deeply/nested/file/that/should/be/abbreviated/somehow',
         repo: 'github.com/sourcegraph/sourcegraph',
@@ -41,6 +42,7 @@ const mockEntries: SearchStackEntry[] = [
         lineRange: { startLine: 10, endLine: 11 },
     },
     {
+        id: 3,
         type: 'search',
         query: 'file:ts$ a really long search query that should wrap',
         caseSensitive: false,
@@ -85,6 +87,7 @@ SearchStackEmptyWithoutRestore.args = {
 export const SearchStackManyEntries = Template.bind({})
 SearchStackManyEntries.args = {
     entries: Array.from({ length: 50 }, (_element, index) => ({
+        id: index,
         type: 'search',
         query: `TODO${index}`,
         caseSensitive: false,

--- a/client/web/src/search/SearchStack.test.tsx
+++ b/client/web/src/search/SearchStack.test.tsx
@@ -17,8 +17,8 @@ describe('Search Stack', () => {
     afterEach(cleanup)
 
     const mockEntries: SearchStackEntry[] = [
-        { type: 'search', query: 'TODO', caseSensitive: false, patternType: SearchPatternType.literal },
-        { type: 'file', path: 'path/to/file', repo: 'test', revision: 'master', lineRange: null },
+        { id: 0, type: 'search', query: 'TODO', caseSensitive: false, patternType: SearchPatternType.literal },
+        { id: 1, type: 'file', path: 'path/to/file', repo: 'test', revision: 'master', lineRange: null },
     ]
 
     describe('inital state', () => {
@@ -60,8 +60,14 @@ describe('Search Stack', () => {
             useExperimentalFeatures.setState({ enableSearchStack: true })
             useSearchStackState.setState({
                 entries: [
-                    { type: 'search', query: 'TODO', caseSensitive: false, patternType: SearchPatternType.literal },
-                    { type: 'file', path: 'path/to/file', repo: 'test', revision: 'master', lineRange: null },
+                    {
+                        id: 0,
+                        type: 'search',
+                        query: 'TODO',
+                        caseSensitive: false,
+                        patternType: SearchPatternType.literal,
+                    },
+                    { id: 1, type: 'file', path: 'path/to/file', repo: 'test', revision: 'master', lineRange: null },
                 ],
             })
         })
@@ -83,8 +89,9 @@ describe('Search Stack', () => {
 
             const entryLinks = screen.queryAllByRole('link')
 
-            expect(entryLinks[0]).toHaveAttribute('href', '/search?q=TODO&patternType=literal')
-            expect(entryLinks[1]).toHaveAttribute('href', '/test@master/-/blob/path/to/file')
+            // Entries are in reverse order
+            expect(entryLinks[0]).toHaveAttribute('href', '/test@master/-/blob/path/to/file')
+            expect(entryLinks[1]).toHaveAttribute('href', '/search?q=TODO&patternType=literal')
         })
 
         it('creates notebooks', () => {

--- a/client/web/src/search/SearchStack.tsx
+++ b/client/web/src/search/SearchStack.tsx
@@ -6,7 +6,7 @@ import SearchStackIcon from 'mdi-react/LayersSearchIcon'
 import NotebookPlusIcon from 'mdi-react/NotebookPlusIcon'
 import SearchIcon from 'mdi-react/SearchIcon'
 import TrashIcon from 'mdi-react/TrashCanIcon'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useState, useMemo } from 'react'
 import { useHistory } from 'react-router-dom'
 
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
@@ -40,6 +40,8 @@ export const SearchStack: React.FunctionComponent<{ initialOpen?: boolean }> = (
     const entries = useSearchStackState(state => state.entries)
     const canRestore = useSearchStackState(state => state.canRestoreSession)
     const enableSearchStack = useExperimentalFeatures(features => features.enableSearchStack)
+
+    const reversedEntries = useMemo(() => [...entries].reverse(), [entries])
 
     const createNotebook = useCallback(() => {
         const location = {
@@ -97,8 +99,8 @@ export const SearchStack: React.FunctionComponent<{ initialOpen?: boolean }> = (
             {open && (
                 <>
                     <ul>
-                        {entries.map((entry, index) => (
-                            <li key={index}>{renderSearchEntry(entry)}</li>
+                        {reversedEntries.map(entry => (
+                            <li key={entry.id}>{renderSearchEntry(entry)}</li>
                         ))}
                     </ul>
                     {confirmRemoveAll && (

--- a/client/web/src/stores/searchStack.test.ts
+++ b/client/web/src/stores/searchStack.test.ts
@@ -20,6 +20,7 @@ describe('search stack store', () => {
     })
 
     const exampleEntry: SearchStackEntry = {
+        id: 0,
         type: 'search',
         query: 'test',
         patternType: SearchPatternType.literal,
@@ -49,6 +50,7 @@ describe('search stack store', () => {
 
         it('updates an existing file entry', () => {
             const entry: SearchStackEntry = {
+                id: 0,
                 type: 'file',
                 path: 'path/to/file',
                 repo: 'test',

--- a/client/web/src/stores/searchStack.ts
+++ b/client/web/src/stores/searchStack.ts
@@ -11,6 +11,10 @@ import { useExperimentalFeatures } from './experimentalFeatures'
 
 export interface SearchEntry {
     type: 'search'
+    /**
+     * The ID is primarily used to let the UI uniquily identifiy each entry.
+     */
+    id: number
     query: string
     caseSensitive: boolean
     searchContext?: string
@@ -19,6 +23,10 @@ export interface SearchEntry {
 
 export interface FileEntry {
     type: 'file'
+    /**
+     * The ID is primarily used to let the UI uniquily identifiy each entry.
+     */
+    id: number
     path: string
     repo: string
     revision: string
@@ -26,14 +34,19 @@ export interface FileEntry {
 }
 
 export type SearchStackEntry = SearchEntry | FileEntry
-
-const SEARCH_STACK_SESSION_KEY = 'search:search-stack:session'
+export type SearchStackEntryInput = Omit<SearchEntry, 'id'> | Omit<FileEntry, 'id'>
 
 export interface SearchStackStore {
     entries: SearchStackEntry[]
     previousEntries: SearchStackEntry[]
     canRestoreSession: boolean
 }
+
+const SEARCH_STACK_SESSION_KEY = 'search:search-stack:session'
+/**
+ * Uniquly identifies each entry.
+ */
+let nextEntryID = 0
 
 /**
  * Hook to get the search stack's current state. Used by the SearchStack
@@ -64,7 +77,7 @@ export const useSearchStackState = create<SearchStackStore>(() => {
  * - A file entry is considered the same if the repo and the path are the same
  * (revison and line range are updated)
  */
-export function useSearchStack(newEntry: SearchStackEntry | null): void {
+export function useSearchStack(newEntry: SearchStackEntryInput | null): void {
     const enableSearchStack = useExperimentalFeatures(features => features.enableSearchStack)
     useEffect(() => {
         if (enableSearchStack && newEntry) {
@@ -98,7 +111,7 @@ export function useSearchStack(newEntry: SearchStackEntry | null): void {
     }, [newEntry, enableSearchStack])
 }
 
-function addSearchStackEntry(entry: SearchStackEntry, update?: (entry: SearchStackEntry) => boolean): void {
+function addSearchStackEntry(entry: SearchStackEntryInput, update?: (entry: SearchStackEntry) => boolean): void {
     useSearchStackState.setState(state => {
         if (update) {
             const existingEntry = state.entries.find(update)
@@ -112,7 +125,7 @@ function addSearchStackEntry(entry: SearchStackEntry, update?: (entry: SearchSta
             }
         }
         const newState = {
-            entries: [...state.entries, entry],
+            entries: [...state.entries, { ...entry, id: nextEntryID++ }],
             canRestoreSession: state.entries.length === 0,
         }
 
@@ -145,7 +158,12 @@ export function removeAllSearchStackEntries(): void {
 }
 
 function restoreSession(storage: Storage): SearchStackEntry[] {
-    return JSON.parse(storage.getItem(SEARCH_STACK_SESSION_KEY) ?? '[]')
+    return (
+        JSON.parse(storage.getItem(SEARCH_STACK_SESSION_KEY) ?? '[]')
+            // We always "re-id" restored entries. This makes things easier (no need
+            // to track which IDs have already been used)
+            .map((entry: SearchStackEntry) => ({ ...entry, id: nextEntryID++ }))
+    )
 }
 
 function persistSession(entries: SearchStackEntry[]): void {


### PR DESCRIPTION
This reverses the order in which search stack items are rendered so that
the most recent item is rendered on top. This only affects the UI. The
items are still stored in order so Notebook creation still works as
before.

Instead of introducing the `id` property I could have used the same
logic that is used to identify "duplicate" entries (for updating them),
but I think that this logic is going away anyway once entries are added
manually instead of automatically (in which case the action is
deliberate, so no duplicate detection is necessary).
