### PR TITLE
migrations: Add (rudimentary) docs for rollback

### DIFF
--- a/doc/admin/how-to/index.md
+++ b/doc/admin/how-to/index.md
@@ -4,6 +4,7 @@
   - Commands: [up](manual_database_migrations.md#up), [upto](manual_database_migrations.md#upto), [downto](manual_database_migrations.md#downto), [validate](manual_database_migrations.md#validate)
   - Environments: [Kubernetes](manual_database_migrations.md#kubernetes), [Docker compose](manual_database_migrations.md#docker-compose), [Local development](manual_database_migrations.md#local-development)
 - [How to troubleshoot a dirty database](dirty_database.md)
+- [How to rollback the Postgres database](rollback_database.md)
 - [How to troubleshoot an unfinished migration](unfinished_migration.md)
 - [How to enable or disable an experimental feature](enable-experimental-feature.md)
 - [How to diagnose an `Unknown Error` during login to your Sourcegraph instance](unknown-error-login.md)

--- a/doc/admin/how-to/rollback_database.md
+++ b/doc/admin/how-to/rollback_database.md
@@ -31,4 +31,4 @@ Leaf migrations for "codeinsights" defined at commit "v3.36.0"
 - `downto -db=codeintel -target=1000000030`
 - `downto -db=codeinsights -target=1000000025`
 
-The log output of the `migrator` should include `INFO`-level logs and successfully terminate with `migrator exited with code 0`. If you see an error message or any of the databases have been flagged as "dirty", please follow ["How to troubleshoot a dirty database"](dirty_database.md). A dirty database at this stage requires manual intervention. Please contact support at <mailto:support@sourcegraph.com> for further assistance.
+The log output of the `migrator` should include `INFO`-level logs and successfully terminate with `migrator exited with code 0`. If you see an error message or any of the databases have been flagged as "dirty", please follow ["How to troubleshoot a dirty database"](dirty_database.md). A dirty database at this stage requires manual intervention. Please contact support at <mailto:support@sourcegraph.com> or via your enterprise support channel for further assistance.

--- a/doc/admin/how-to/rollback_database.md
+++ b/doc/admin/how-to/rollback_database.md
@@ -1,0 +1,34 @@
+## Rolling back a Postgres database
+
+> WARNING: **Rolling back the database may result in data loss.** Rolling back the database schema may remove tables or columns that were not present in previous versions of Sourcegraph.
+
+If a customer downgrades their instance to a previous version, they need to downgrade their database schema in two circumstances:
+
+1. Developer created **backwards-incompatible** migration: if a migration added in the successor version that was not backwards-compatible, the code of the previous version may struggle operating with the new schema. This may be an emergency situation in which the previous schema must be restored to bring the instance back to a stable state.
+1. The customer is **downgrading multiple versions**: if a customer has downgraded their instance once, they will need to downgrade their database schema before downgrading their instance a subsequent time. This is because an instance two (or more) versions ago has no guarantee to run properly against the current database schema. Multiple instance downgrades therefore need to be performed in an alternating fashion with database downgrades.
+
+> NOTE: This feature is only available in versions `3.37` and later
+
+> NOTE: A customer rollback is considered an **emergency operation**. Please contact support at <mailto:support@sourcegraph.com> for guidance on this operation.
+
+1. To roll back the database to a specific version, we need to determine the set of _leaf_ migrations defined at that version. This can be done via the [`sg`](https://docs.sourcegraph.com/dev/background-information/sg) development tool. This should be ran by a supporting Sourcegraph engineer _in an up-to-date clone of the [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph) repository_. For example, if we are downgrading from 3.37.0 to 3.36.0:
+
+```bash
+$ sg migration leaves v3.36.0
+Leaf migrations for "frontend" defined at commit "v3.36.0"
+ 1528395968: (track fork namespace on spec)
+
+Leaf migrations for "codeintel" defined at commit "v3.36.0"
+ 1000000030: (lsif data implementations)
+
+Leaf migrations for "codeinsights" defined at commit "v3.36.0"
+ 1000000025: (captured values series points)
+```
+
+2. Once we have discovered our target leaf versions, we need to unappaly all migrations applied _after_ those migrations. For the following, consult the [Kubernetes](./manual_database_migrations.md#kubernetes) or [Docker-compose](./manual_database_migrations.md#docker-compose) instructions on manually run database migrations. The specific migrator commands to run will be unique to each schema that needs to be downgraded. For the example above, we'll need to issue three `downto` commands:
+
+- `downto -db=frontend -target=1528395968`
+- `downto -db=codeintel -target=1000000030`
+- `downto -db=codeinsights -target=1000000025`
+
+The log output of the `migrator` should include `INFO`-level logs and successfully terminate with `migrator exited with code 0`. If you see an error message or any of the databases have been flagged as "dirty", please follow ["How to troubleshoot a dirty database"](dirty_database.md). A dirty database at this stage requires manual intervention. Please contact support at <mailto:support@sourcegraph.com> for further assistance.


### PR DESCRIPTION
This PR adds:

- a `validate` command to both `sg migration` and the `migrator` service, which simply runs the validation routine that the applications do on startup, and exits with a status of zero if the database is clean and up to date and one otherwise.
- a `leaves` command to `sg migration` which takes a commit and returns the last migrations defined at that time.
- documentation on how to roll back a postgres database with these two new tools

**Reviewers**: Please give special attention to the doc page and suggest where I can steal copy from other migrations work we've been doing lately.

**Edit**: Non-docs work was pulled out into #30860.