### PR TITLE
Revert adding auth check for external service in status messages resolver

### DIFF
--- a/cmd/frontend/graphqlbackend/status_messages.go
+++ b/cmd/frontend/graphqlbackend/status_messages.go
@@ -80,8 +80,6 @@ func (r *statusMessageResolver) ExternalService(ctx context.Context) (*externalS
 	if err != nil {
 		return nil, err
 	}
-	if err := backend.CheckExternalServiceAccess(ctx, r.db, externalService.NamespaceUserID, externalService.NamespaceOrgID); err != nil {
-		return nil, err
-	}
+
 	return &externalServiceResolver{db: r.db, externalService: externalService}, nil
 }


### PR DESCRIPTION
This caused site-admins on cloud to not be able to view the code host sync status panel anymore.
Reported here: https://sourcegraph.slack.com/archives/C02EDAQAJQZ/p1644275222837499
