### PR TITLE
gitserver: Add option to disable the command timeout

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1141,8 +1141,13 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 		defer fw.Close()
 	}
 
-	ctx, cancel := context.WithTimeout(r.Context(), shortGitCommandTimeout(req.Args))
-	defer cancel()
+	ctx := r.Context()
+
+	if req.Timeout == nil || *req.Timeout {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(r.Context(), shortGitCommandTimeout(req.Args))
+		defer cancel()
+	}
 
 	start := time.Now()
 	var cmdStart time.Time // set once we have ensured commit

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1145,7 +1145,7 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 
 	if req.Timeout == nil || *req.Timeout {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(r.Context(), shortGitCommandTimeout(req.Args))
+		ctx, cancel = context.WithTimeout(ctx, shortGitCommandTimeout(req.Args))
 		defer cancel()
 	}
 

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1143,7 +1143,7 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 
 	ctx := r.Context()
 
-	if req.Timeout == nil || *req.Timeout {
+	if !req.NoTimeout {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, shortGitCommandTimeout(req.Args))
 		defer cancel()

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -391,6 +391,7 @@ func (c *Cmd) sendExec(ctx context.Context) (_ io.ReadCloser, _ http.Header, err
 		Repo:           repoName,
 		EnsureRevision: c.EnsureRevision,
 		Args:           c.Args[1:],
+		Timeout:        c.Timeout,
 	}
 	resp, err := c.client.httpPost(ctx, repoName, "exec", req)
 	if err != nil {
@@ -528,6 +529,7 @@ type Cmd struct {
 	Repo           api.RepoName // the repository to execute the command in
 	EnsureRevision string
 	ExitStatus     int
+	Timeout        *bool
 }
 
 func (c *ClientImplementor) Command(name string, arg ...string) *Cmd {
@@ -582,6 +584,11 @@ func (c *Cmd) Output(ctx context.Context) ([]byte, error) {
 func (c *Cmd) CombinedOutput(ctx context.Context) ([]byte, error) {
 	stdout, stderr, err := c.DividedOutput(ctx)
 	return append(stdout, stderr...), err
+}
+
+func (c *Cmd) DisableTimeout() {
+	noTimeout := false
+	c.Timeout = &noTimeout
 }
 
 func (c *Cmd) String() string { return fmt.Sprintf("%q", c.Args) }

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -391,7 +391,7 @@ func (c *Cmd) sendExec(ctx context.Context) (_ io.ReadCloser, _ http.Header, err
 		Repo:           repoName,
 		EnsureRevision: c.EnsureRevision,
 		Args:           c.Args[1:],
-		Timeout:        c.Timeout,
+		NoTimeout:      c.NoTimeout,
 	}
 	resp, err := c.client.httpPost(ctx, repoName, "exec", req)
 	if err != nil {
@@ -529,7 +529,7 @@ type Cmd struct {
 	Repo           api.RepoName // the repository to execute the command in
 	EnsureRevision string
 	ExitStatus     int
-	Timeout        *bool
+	NoTimeout      bool
 }
 
 func (c *ClientImplementor) Command(name string, arg ...string) *Cmd {
@@ -587,8 +587,7 @@ func (c *Cmd) CombinedOutput(ctx context.Context) ([]byte, error) {
 }
 
 func (c *Cmd) DisableTimeout() {
-	noTimeout := false
-	c.Timeout = &noTimeout
+	c.NoTimeout = true
 }
 
 func (c *Cmd) String() string { return fmt.Sprintf("%q", c.Args) }

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -95,6 +95,7 @@ type ExecRequest struct {
 	EnsureRevision string      `json:"ensureRevision"`
 	Args           []string    `json:"args"`
 	Opt            *RemoteOpts `json:"opt"`
+	Timeout        *bool       `json:"timeout"`
 }
 
 // P4ExecRequest is a request to execute a p4 command with given arguments.

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -95,7 +95,7 @@ type ExecRequest struct {
 	EnsureRevision string      `json:"ensureRevision"`
 	Args           []string    `json:"args"`
 	Opt            *RemoteOpts `json:"opt"`
-	Timeout        *bool       `json:"timeout"`
+	NoTimeout      bool        `json:"noTimeout"`
 }
 
 // P4ExecRequest is a request to execute a p4 command with given arguments.


### PR DESCRIPTION
[Rockskip](https://github.com/sourcegraph/sourcegraph/pull/28719) currently relies on the ability to execute long-running commands:

- `git log` to process commits one-by-one. It takes ~5 minutes on sourcegraph/sourcegraph, and hours on the megarepo.
- `git archive` to run ctags on files. It takes a few minutes on big commits.

This PR adds the option to disable gitserver's default command timeout for these long-running commands. The command is still bound by the HTTP context, so the command will not get orphaned by a dropped connection.

Alternatively, Rockskip could retry calls to `git log`, but `git archive` would be much more difficult to solve (Rockskip would have to keep track of paths that it had processed within a commit, keep track of more locking/transaction states, etc.).