### PR TITLE
Trigger auth flow through GitHub App

### DIFF
--- a/client/web/dev/utils/create-js-context.ts
+++ b/client/web/dev/utils/create-js-context.ts
@@ -51,6 +51,7 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
         siteGQLID: 'TestGQLSiteID',
         sourcegraphDotComMode: true,
         githubAppCloudSlug: 'TestApp',
+        githubAppClientID: 'TestClientID',
         userAgentIsBot: false,
         version: '0.0.0',
         xhrHeaders: {},

--- a/client/web/src/integration/jscontext.ts
+++ b/client/web/src/integration/jscontext.ts
@@ -41,6 +41,7 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
     siteGQLID,
     sourcegraphDotComMode: false,
     githubAppCloudSlug: 'test-app',
+    githubAppClientID: 'client-id',
     userAgentIsBot: false,
     version: '0.0.0',
     xhrHeaders: {},

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -41,6 +41,8 @@ export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'e
 
     githubAppCloudSlug: string
 
+    githubAppClientID: string
+
     /**
      * siteID is the identifier of the Sourcegraph site.
      */

--- a/client/web/src/user/settings/auth/ExternalAccountsSignIn.tsx
+++ b/client/web/src/user/settings/auth/ExternalAccountsSignIn.tsx
@@ -43,6 +43,7 @@ interface Props {
     authProviders: AuthProvidersByType
     onDidRemove: (id: string, name: string) => void
     onDidError: (error: ErrorLike) => void
+    isGitHubAppEnabled?: boolean
 }
 
 const getNormalizedAccount = (accounts: ExternalAccountsByType, kind: ExternalServiceKind): NormalizedMinAccount => {
@@ -105,6 +106,7 @@ export const ExternalAccountsSignIn: React.FunctionComponent<Props> = ({
     authProviders,
     onDidRemove,
     onDidError,
+    isGitHubAppEnabled = false,
 }) => (
     <>
         {accounts && (
@@ -116,6 +118,12 @@ export const ExternalAccountsSignIn: React.FunctionComponent<Props> = ({
                     // if auth provider for this account doesn't exist -
                     // don't display the account as an option
                     if (authProvider) {
+                        if (kind === ExternalServiceKind.GITHUB && isGitHubAppEnabled) {
+                            authProvider.authenticationURL = `https://github.com/login/oauth/authorize?client_id=${
+                                window.context.githubAppClientID
+                            }&redirect_uri=${encodeURIComponent(`${window.context.externalURL}/.auth/github/callback`)}`
+                        }
+
                         const account = getNormalizedAccount(accounts, kind)
 
                         return (

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -70,6 +70,8 @@ type JSContext struct {
 
 	SourcegraphDotComMode bool   `json:"sourcegraphDotComMode"`
 	GitHubAppCloudSlug    string `json:"githubAppCloudSlug"`
+	GitHubAppClientID     string `json:"githubAppClientID"`
+	GitHubAppClientSecret string `json:"githubAppClientSecret"`
 
 	BillingPublishableKey string `json:"billingPublishableKey,omitempty"`
 
@@ -143,8 +145,10 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 	}
 
 	var githubAppCloudSlug string
+	var githubAppClientID string
 	if envvar.SourcegraphDotComMode() && siteConfig.Dotcom != nil && siteConfig.Dotcom.GithubAppCloud != nil {
 		githubAppCloudSlug = siteConfig.Dotcom.GithubAppCloud.Slug
+		githubAppClientID = siteConfig.Dotcom.GithubAppCloud.ClientID
 	}
 
 	// 🚨 SECURITY: This struct is sent to all users regardless of whether or
@@ -174,6 +178,8 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 
 		SourcegraphDotComMode: envvar.SourcegraphDotComMode(),
 		GitHubAppCloudSlug:    githubAppCloudSlug,
+		GitHubAppClientID:     githubAppClientID,
+		GitHubAppClientSecret: githubAppClientSecret,
 
 		BillingPublishableKey: BillingPublishableKey,
 

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -179,7 +179,6 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 		SourcegraphDotComMode: envvar.SourcegraphDotComMode(),
 		GitHubAppCloudSlug:    githubAppCloudSlug,
 		GitHubAppClientID:     githubAppClientID,
-		GitHubAppClientSecret: githubAppClientSecret,
 
 		BillingPublishableKey: BillingPublishableKey,
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -866,6 +866,10 @@ type GitLabWebhook struct {
 type GithubAppCloud struct {
 	// AppID description: The app ID of the GitHub App for Sourcegraph Cloud.
 	AppID string `json:"appID,omitempty"`
+	// ClientID description: The Client ID of the GitHub App, accessible from https://github.com/settings/apps .
+	ClientID string `json:"clientID,omitempty"`
+	// ClientSecret description: The Client Secret of the GitHub App, accessible from https://github.com/settings/apps .
+	ClientSecret string `json:"clientSecret,omitempty"`
 	// PrivateKey description: The base64-encoded private key of the GitHub App for Sourcegraph Cloud.
 	PrivateKey string `json:"privateKey,omitempty"`
 	// Slug description: The slug of the GitHub App for Sourcegraph Cloud.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1103,6 +1103,14 @@
             "privateKey": {
               "description": "The base64-encoded private key of the GitHub App for Sourcegraph Cloud.",
               "type": "string"
+            },
+            "clientID": {
+              "type": "string",
+              "description": "The Client ID of the GitHub App, accessible from https://github.com/settings/apps ."
+            },
+            "clientSecret": {
+              "type": "string",
+              "description": "The Client Secret of the GitHub App, accessible from https://github.com/settings/apps ."
             }
           }
         }


### PR DESCRIPTION
This PR implements CLOUD-205.

If a user belongs to an organization that has the GitHub App feature flag enabled, the GitHub App authorization flow is used to create the user's connection to GitHub.

As stated in CLOUD-205, what isn't handled is the functioning of the callback URL (this is future work). This is why there is an Auth error once the app navigates back to Sourcegraph.


https://user-images.githubusercontent.com/6427795/152921270-917f251a-e7e3-4691-944a-8a56504bf15b.mp4


