### PR TITLE
Notebook: embed route bundle debug

### DIFF
--- a/client/web/src/enterprise/embed/EmbeddedWebApp.tsx
+++ b/client/web/src/enterprise/embed/EmbeddedWebApp.tsx
@@ -6,7 +6,7 @@ import { createController as createExtensionsController } from '@sourcegraph/sha
 import { aggregateStreamingSearch } from '@sourcegraph/shared/src/search/stream'
 import { EMPTY_SETTINGS_CASCADE } from '@sourcegraph/shared/src/settings/settings'
 import { isMacPlatform } from '@sourcegraph/shared/src/util/browserDetection'
-import { AnchorLink, setLinkComponent } from '@sourcegraph/wildcard'
+import { Alert, AnchorLink, setLinkComponent, WildcardTheme, WildcardThemeContext } from '@sourcegraph/wildcard'
 
 import { createPlatformContext } from '../../platform/context'
 import { fetchHighlightedFileLineRanges, fetchRepository, resolveRevision } from '../../repo/backend'
@@ -16,40 +16,53 @@ import { eventLogger } from '../../tracking/eventLogger'
 
 setLinkComponent(AnchorLink)
 
+const WILDCARD_THEME: WildcardTheme = {
+    isBranded: true,
+}
+
 export const EmbeddedWebApp: React.FunctionComponent = () => {
     const platformContext = useMemo(() => createPlatformContext(), [])
     const extensionsController = useMemo(() => createExtensionsController(platformContext), [platformContext])
+    // We only support light theme for now, but this can be made dynamic through a URL param in the embedding link.
     const isLightTheme = true
 
     return (
         <BrowserRouter>
-            <div className={classNames(isLightTheme ? 'theme-light' : 'theme-dark', 'p-3')}>
-                <Switch>
-                    <Route
-                        path="/embed/notebooks/:notebookId"
-                        render={(props: RouteComponentProps<{ notebookId: string }>) => (
-                            <EmbeddedNotebookPage
-                                notebookId={props.match.params.notebookId}
-                                searchContextsEnabled={false}
-                                showSearchContext={false}
-                                isSourcegraphDotCom={window.context.sourcegraphDotComMode}
-                                authenticatedUser={null}
-                                fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
-                                isLightTheme={isLightTheme}
-                                telemetryService={eventLogger}
-                                globbing={true}
-                                isMacPlatform={isMacPlatform}
-                                resolveRevision={resolveRevision}
-                                fetchRepository={fetchRepository}
-                                streamSearch={aggregateStreamingSearch}
-                                platformContext={platformContext}
-                                extensionsController={extensionsController}
-                                settingsCascade={EMPTY_SETTINGS_CASCADE}
-                            />
-                        )}
-                    />
-                </Switch>
-            </div>
+            <WildcardThemeContext.Provider value={WILDCARD_THEME}>
+                <div className={classNames(isLightTheme ? 'theme-light' : 'theme-dark', 'p-3')}>
+                    <Switch>
+                        <Route
+                            path="/embed/notebooks/:notebookId"
+                            render={(props: RouteComponentProps<{ notebookId: string }>) => (
+                                <EmbeddedNotebookPage
+                                    notebookId={props.match.params.notebookId}
+                                    searchContextsEnabled={false}
+                                    showSearchContext={false}
+                                    isSourcegraphDotCom={window.context.sourcegraphDotComMode}
+                                    authenticatedUser={null}
+                                    fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
+                                    isLightTheme={isLightTheme}
+                                    telemetryService={eventLogger}
+                                    globbing={true}
+                                    isMacPlatform={isMacPlatform}
+                                    resolveRevision={resolveRevision}
+                                    fetchRepository={fetchRepository}
+                                    streamSearch={aggregateStreamingSearch}
+                                    platformContext={platformContext}
+                                    extensionsController={extensionsController}
+                                    settingsCascade={EMPTY_SETTINGS_CASCADE}
+                                />
+                            )}
+                        />
+                        <Route
+                            path="*"
+                            render={() => (
+                                <Alert variant="danger">Invalid embedding route, please check the embedding URL.</Alert>
+                            )}
+                        />
+                    </Switch>
+                </div>
+            </WildcardThemeContext.Provider>
         </BrowserRouter>
     )
 }

--- a/client/web/src/enterprise/embed/EmbeddedWebApp.tsx
+++ b/client/web/src/enterprise/embed/EmbeddedWebApp.tsx
@@ -1,0 +1,55 @@
+import classNames from 'classnames'
+import React, { useMemo } from 'react'
+import { BrowserRouter, Route, RouteComponentProps, Switch } from 'react-router-dom'
+
+import { createController as createExtensionsController } from '@sourcegraph/shared/src/extensions/controller'
+import { aggregateStreamingSearch } from '@sourcegraph/shared/src/search/stream'
+import { EMPTY_SETTINGS_CASCADE } from '@sourcegraph/shared/src/settings/settings'
+import { isMacPlatform } from '@sourcegraph/shared/src/util/browserDetection'
+import { AnchorLink, setLinkComponent } from '@sourcegraph/wildcard'
+
+import { createPlatformContext } from '../../platform/context'
+import { fetchHighlightedFileLineRanges, fetchRepository, resolveRevision } from '../../repo/backend'
+import '../../SourcegraphWebApp.scss'
+import { EmbeddedNotebookPage } from '../../search/notebook/EmbeddedNotebookPage'
+import { eventLogger } from '../../tracking/eventLogger'
+
+setLinkComponent(AnchorLink)
+
+export const EmbeddedWebApp: React.FunctionComponent = () => {
+    const platformContext = useMemo(() => createPlatformContext(), [])
+    const extensionsController = useMemo(() => createExtensionsController(platformContext), [platformContext])
+    const isLightTheme = true
+
+    return (
+        <BrowserRouter>
+            <div className={classNames(isLightTheme ? 'theme-light' : 'theme-dark', 'p-3')}>
+                <Switch>
+                    <Route
+                        path="/embed/notebooks/:notebookId"
+                        render={(props: RouteComponentProps<{ notebookId: string }>) => (
+                            <EmbeddedNotebookPage
+                                notebookId={props.match.params.notebookId}
+                                searchContextsEnabled={false}
+                                showSearchContext={false}
+                                isSourcegraphDotCom={window.context.sourcegraphDotComMode}
+                                authenticatedUser={null}
+                                fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
+                                isLightTheme={isLightTheme}
+                                telemetryService={eventLogger}
+                                globbing={true}
+                                isMacPlatform={isMacPlatform}
+                                resolveRevision={resolveRevision}
+                                fetchRepository={fetchRepository}
+                                streamSearch={aggregateStreamingSearch}
+                                platformContext={platformContext}
+                                extensionsController={extensionsController}
+                                settingsCascade={EMPTY_SETTINGS_CASCADE}
+                            />
+                        )}
+                    />
+                </Switch>
+            </div>
+        </BrowserRouter>
+    )
+}

--- a/client/web/src/enterprise/embed/EmbeddedWebApp.tsx
+++ b/client/web/src/enterprise/embed/EmbeddedWebApp.tsx
@@ -1,10 +1,8 @@
 import classNames from 'classnames'
-import React, { Suspense, useMemo } from 'react'
+import React, { Suspense } from 'react'
 import { BrowserRouter, Route, RouteComponentProps, Switch } from 'react-router-dom'
 
-import { createController as createExtensionsController } from '@sourcegraph/shared/src/extensions/controller'
-import { aggregateStreamingSearch } from '@sourcegraph/shared/src/search/stream'
-import { EMPTY_SETTINGS_CASCADE } from '@sourcegraph/shared/src/settings/settings'
+import {SettingsCascade} from '@sourcegraph/shared/src/settings/settings';
 import { isMacPlatform } from '@sourcegraph/shared/src/util/browserDetection'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import {
@@ -16,10 +14,7 @@ import {
     WildcardThemeContext,
 } from '@sourcegraph/wildcard'
 
-import { createPlatformContext } from '../../platform/context'
-import { fetchHighlightedFileLineRanges, fetchRepository, resolveRevision } from '../../repo/backend'
 import '../../SourcegraphWebApp.scss'
-import { eventLogger } from '../../tracking/eventLogger'
 
 setLinkComponent(AnchorLink)
 
@@ -32,9 +27,9 @@ const EmbeddedNotebookPage = lazyComponent(
     'EmbeddedNotebookPage'
 )
 
+export const EMPTY_SETTINGS_CASCADE: SettingsCascade = { final: {}, subjects: [] }
+
 export const EmbeddedWebApp: React.FunctionComponent = () => {
-    const platformContext = useMemo(() => createPlatformContext(), [])
-    const extensionsController = useMemo(() => createExtensionsController(platformContext), [platformContext])
     // We only support light theme for now, but this can be made dynamic through a URL param in the embedding link.
     const isLightTheme = true
 
@@ -59,16 +54,9 @@ export const EmbeddedWebApp: React.FunctionComponent = () => {
                                         showSearchContext={false}
                                         isSourcegraphDotCom={window.context.sourcegraphDotComMode}
                                         authenticatedUser={null}
-                                        fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
                                         isLightTheme={isLightTheme}
-                                        telemetryService={eventLogger}
                                         globbing={true}
                                         isMacPlatform={isMacPlatform}
-                                        resolveRevision={resolveRevision}
-                                        fetchRepository={fetchRepository}
-                                        streamSearch={aggregateStreamingSearch}
-                                        platformContext={platformContext}
-                                        extensionsController={extensionsController}
                                         settingsCascade={EMPTY_SETTINGS_CASCADE}
                                     />
                                 )}

--- a/client/web/src/enterprise/embed/main.tsx
+++ b/client/web/src/enterprise/embed/main.tsx
@@ -1,0 +1,12 @@
+import '@sourcegraph/shared/src/polyfills'
+
+import React from 'react'
+import { render } from 'react-dom'
+
+import { EmbeddedWebApp } from './EmbeddedWebApp'
+
+// It's important to have a root component in a separate file to create a react-refresh boundary and avoid page reload.
+// https://github.com/pmmmwh/react-refresh-webpack-plugin/blob/main/docs/TROUBLESHOOTING.md#edits-always-lead-to-full-reload
+window.addEventListener('DOMContentLoaded', () => {
+    render(<EmbeddedWebApp />, document.querySelector('#root'))
+})

--- a/client/web/src/search/notebook/EmbeddedNotebookPage.tsx
+++ b/client/web/src/search/notebook/EmbeddedNotebookPage.tsx
@@ -1,0 +1,62 @@
+import { noop } from 'lodash'
+import React, { useEffect, useMemo } from 'react'
+import { useLocation } from 'react-router-dom'
+import { catchError, startWith } from 'rxjs/operators'
+
+import { asError, isErrorLike } from '@sourcegraph/common'
+import { Alert, LoadingSpinner, useObservable } from '@sourcegraph/wildcard'
+
+import { fetchNotebook as _fetchNotebook } from './backend'
+import { NotebookContent, NotebookContentProps } from './NotebookContent'
+
+interface EmbeddedNotebookPageProps
+    extends Omit<NotebookContentProps, 'blocks' | 'onUpdateBlocks' | 'location' | 'viewerCanManage'> {
+    notebookId: string
+    fetchNotebook?: typeof _fetchNotebook
+}
+
+const LOADING = 'loading' as const
+
+export const EmbeddedNotebookPage: React.FunctionComponent<EmbeddedNotebookPageProps> = ({
+    notebookId,
+    fetchNotebook = _fetchNotebook,
+    ...props
+}) => {
+    useEffect(() => props.telemetryService.logViewEvent('EmbeddedNotebookPage'), [props.telemetryService])
+
+    const notebookOrError = useObservable(
+        useMemo(
+            () =>
+                fetchNotebook(notebookId).pipe(
+                    startWith(LOADING),
+                    catchError(error => [asError(error)])
+                ),
+            [fetchNotebook, notebookId]
+        )
+    )
+
+    const location = useLocation()
+    return (
+        <div className="p-3">
+            {notebookOrError === LOADING && (
+                <div className="d-flex justify-content-center">
+                    <LoadingSpinner />
+                </div>
+            )}
+            {isErrorLike(notebookOrError) && (
+                <Alert variant="danger">
+                    Error while loading the notebook: <strong>{notebookOrError.message}</strong>
+                </Alert>
+            )}
+            {notebookOrError && notebookOrError !== LOADING && !isErrorLike(notebookOrError) && (
+                <NotebookContent
+                    {...props}
+                    location={location}
+                    blocks={notebookOrError.blocks}
+                    onUpdateBlocks={noop}
+                    viewerCanManage={false}
+                />
+            )}
+        </div>
+    )
+}

--- a/client/web/src/search/notebook/NotebookContent.tsx
+++ b/client/web/src/search/notebook/NotebookContent.tsx
@@ -14,7 +14,7 @@ import { SearchNotebook } from './SearchNotebook'
 
 import { Block, BlockInit } from '.'
 
-interface NotebookContentProps
+export interface NotebookContentProps
     extends SearchStreamingProps,
         ThemeProps,
         TelemetryProps,

--- a/client/web/src/search/notebook/SearchNotebookBlock.module.scss
+++ b/client/web/src/search/notebook/SearchNotebookBlock.module.scss
@@ -29,4 +29,12 @@
             box-shadow: none;
         }
     }
+
+    :global(.monaco-mouse-cursor-text) {
+        /* Hack: remove focus ring around Monaco editor cursor */
+        &:focus-within,
+        &:focus-visible {
+            box-shadow: none;
+        }
+    }
 }

--- a/client/web/src/search/notebook/SearchNotebookBlockMenu.tsx
+++ b/client/web/src/search/notebook/SearchNotebookBlockMenu.tsx
@@ -34,7 +34,7 @@ export type BlockMenuActionComponentProps = {
     Pick<ButtonProps, 'variant'>
 
 const BlockMenuActionComponent: React.FunctionComponent<BlockMenuActionComponentProps> = props => {
-    const { className, label, type, id, isDisabled, icon, iconClassName } = props
+    const { className, label, type, id, isDisabled, icon, iconClassName, variant } = props
 
     const element = type === 'button' ? 'button' : 'a'
     const elementSpecificProps =
@@ -51,6 +51,7 @@ const BlockMenuActionComponent: React.FunctionComponent<BlockMenuActionComponent
             role="menuitem"
             data-testid={label}
             size="sm"
+            variant={variant}
             {...elementSpecificProps}
         >
             <div className={iconClassName}>{icon}</div>

--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -109,6 +109,9 @@ const config = {
     // Enterprise vs. OSS builds use different entrypoints. The enterprise entrypoint imports a
     // strict superset of the OSS entrypoint.
     app: isEnterpriseBuild ? path.join(enterpriseDirectory, 'main.tsx') : path.join(__dirname, 'src', 'main.tsx'),
+    // Embedding entrypoint. It uses a small subset of the main webapp intended to be embedded into
+    // iframes on 3rd party sites.
+    embed: path.join(enterpriseDirectory, 'embed', 'main.tsx')
   },
   output: {
     path: path.join(ROOT_PATH, 'ui', 'assets'),
@@ -138,41 +141,41 @@ const config = {
     }),
     getMonacoWebpackPlugin(),
     !shouldServeIndexHTML &&
-      new WebpackManifestPlugin({
-        writeToFileEmit: true,
-        fileName: 'webpack.manifest.json',
-        // Only output files that are required to run the application
-        filter: ({ isInitial }) => isInitial,
-      }),
+    new WebpackManifestPlugin({
+      writeToFileEmit: true,
+      fileName: 'webpack.manifest.json',
+      // Only output files that are required to run the application
+      filter: ({ isInitial }) => isInitial,
+    }),
     ...(shouldServeIndexHTML ? getHTMLWebpackPlugins() : []),
     shouldAnalyze && new BundleAnalyzerPlugin(),
     isHotReloadEnabled && new webpack.HotModuleReplacementPlugin(),
     isHotReloadEnabled && new ReactRefreshWebpackPlugin({ overlay: false }),
     isProduction &&
-      new CompressionPlugin({
-        filename: '[path][base].gz',
-        algorithm: 'gzip',
-        test: /\.(js|css|svg)$/,
-        compressionOptions: {
-          /** Maximum compression level for Gzip */
-          level: 9,
-        },
-      }),
+    new CompressionPlugin({
+      filename: '[path][base].gz',
+      algorithm: 'gzip',
+      test: /\.(js|css|svg)$/,
+      compressionOptions: {
+        /** Maximum compression level for Gzip */
+        level: 9,
+      },
+    }),
     isProduction &&
-      new CompressionPlugin({
-        filename: '[path][base].br',
-        algorithm: 'brotliCompress',
-        test: /\.(js|css|svg)$/,
-        compressionOptions: {
-          /** Maximum compression level for Brotli */
-          level: 11,
-        },
-        /**
-         * We get little/no benefits from compressing files that are already under this size.
-         * We can fall back to dynamic gzip for these.
-         */
-        threshold: 10240,
-      }),
+    new CompressionPlugin({
+      filename: '[path][base].br',
+      algorithm: 'brotliCompress',
+      test: /\.(js|css|svg)$/,
+      compressionOptions: {
+        /** Maximum compression level for Brotli */
+        level: 11,
+      },
+      /**
+       * We get little/no benefits from compressing files that are already under this size.
+       * We can fall back to dynamic gzip for these.
+       */
+      threshold: 10240,
+    }),
   ].filter(Boolean),
   resolve: {
     extensions: ['.mjs', '.ts', '.tsx', '.js', '.json'],

--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -176,7 +176,7 @@ const config = {
          */
         threshold: 10240,
       }),
-    ].filter(Boolean),
+  ].filter(Boolean),
   resolve: {
     extensions: ['.mjs', '.ts', '.tsx', '.js', '.json'],
     mainFields: ['es2015', 'module', 'browser', 'main'],

--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -141,42 +141,42 @@ const config = {
     }),
     getMonacoWebpackPlugin(),
     !shouldServeIndexHTML &&
-    new WebpackManifestPlugin({
-      writeToFileEmit: true,
-      fileName: 'webpack.manifest.json',
-      // Only output files that are required to run the application
-      filter: ({ isInitial }) => isInitial,
-    }),
+      new WebpackManifestPlugin({
+        writeToFileEmit: true,
+        fileName: 'webpack.manifest.json',
+        // Only output files that are required to run the application
+        filter: ({ isInitial }) => isInitial,
+      }),
     ...(shouldServeIndexHTML ? getHTMLWebpackPlugins() : []),
     shouldAnalyze && new BundleAnalyzerPlugin(),
     isHotReloadEnabled && new webpack.HotModuleReplacementPlugin(),
     isHotReloadEnabled && new ReactRefreshWebpackPlugin({ overlay: false }),
     isProduction &&
-    new CompressionPlugin({
-      filename: '[path][base].gz',
-      algorithm: 'gzip',
-      test: /\.(js|css|svg)$/,
-      compressionOptions: {
-        /** Maximum compression level for Gzip */
-        level: 9,
-      },
-    }),
+      new CompressionPlugin({
+        filename: '[path][base].gz',
+        algorithm: 'gzip',
+        test: /\.(js|css|svg)$/,
+        compressionOptions: {
+          /** Maximum compression level for Gzip */
+          level: 9,
+        },
+      }),
     isProduction &&
-    new CompressionPlugin({
-      filename: '[path][base].br',
-      algorithm: 'brotliCompress',
-      test: /\.(js|css|svg)$/,
-      compressionOptions: {
-        /** Maximum compression level for Brotli */
-        level: 11,
-      },
-      /**
-       * We get little/no benefits from compressing files that are already under this size.
-       * We can fall back to dynamic gzip for these.
-       */
-      threshold: 10240,
-    }),
-  ].filter(Boolean),
+      new CompressionPlugin({
+        filename: '[path][base].br',
+        algorithm: 'brotliCompress',
+        test: /\.(js|css|svg)$/,
+        compressionOptions: {
+          /** Maximum compression level for Brotli */
+          level: 11,
+        },
+        /**
+         * We get little/no benefits from compressing files that are already under this size.
+         * We can fall back to dynamic gzip for these.
+         */
+        threshold: 10240,
+      }),
+    ].filter(Boolean),
   resolve: {
     extensions: ['.mjs', '.ts', '.tsx', '.js', '.json'],
     mainFields: ['es2015', 'module', 'browser', 'main'],

--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 const path = require('path')
-
+const StatoscopeWebpackPlugin = require('@statoscope/webpack-plugin').default;
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin')
 const CompressionPlugin = require('compression-webpack-plugin')
 const CssMinimizerWebpackPlugin = require('css-minimizer-webpack-plugin')
@@ -86,6 +86,7 @@ const config = {
   cache: isCacheEnabled && getCacheConfig({ invalidateCacheFiles: [path.resolve(__dirname, 'babel.config.js')] }),
   optimization: {
     minimize: isProduction,
+    mergeDuplicateChunks: true,
     minimizer: [getTerserPlugin(), new CssMinimizerWebpackPlugin()],
     splitChunks: {
       cacheGroups: {
@@ -148,7 +149,7 @@ const config = {
         filter: ({ isInitial }) => isInitial,
       }),
     ...(shouldServeIndexHTML ? getHTMLWebpackPlugins() : []),
-    shouldAnalyze && new BundleAnalyzerPlugin(),
+    shouldAnalyze && new StatoscopeWebpackPlugin({ watchMode: true }),
     isHotReloadEnabled && new webpack.HotModuleReplacementPlugin(),
     isHotReloadEnabled && new ReactRefreshWebpackPlugin({ overlay: false }),
     isProduction &&

--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -111,7 +111,7 @@ const config = {
     app: isEnterpriseBuild ? path.join(enterpriseDirectory, 'main.tsx') : path.join(__dirname, 'src', 'main.tsx'),
     // Embedding entrypoint. It uses a small subset of the main webapp intended to be embedded into
     // iframes on 3rd party sites.
-    embed: path.join(enterpriseDirectory, 'embed', 'main.tsx')
+    embed: path.join(enterpriseDirectory, 'embed', 'main.tsx'),
   },
   output: {
     path: path.join(ROOT_PATH, 'ui', 'assets'),

--- a/cmd/frontend/internal/app/ui/embed.html
+++ b/cmd/frontend/internal/app/ui/embed.html
@@ -16,8 +16,8 @@
         {{end}}
         <!-- TODO: Google Tag Manager? -->
         <script ignore-csp>
-            window.context = {{ .Context }}
-            window.pageError = {{ .Error }}
+            window.context = {{.Context}}
+            window.pageError = {{.Error}}
         </script>
         {{.Injected.HeadBottom}}
     </head>

--- a/cmd/frontend/internal/app/ui/embed.html
+++ b/cmd/frontend/internal/app/ui/embed.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en" class="base">
+    <head>
+        {{.Injected.HeadTop}}
+        <meta charset="utf-8" />
+        <meta http-equiv="x-ua-compatible" content="ie=edge" />
+        <meta name="google" content="notranslate" />
+        <meta http-equiv="Content-Language" content="en" />
+        <meta name="viewport" content="width=device-width, viewport-fit=cover" />
+        <meta name="referrer" content="origin-when-cross-origin" />
+        <meta name="color-scheme" content="light dark" />
+
+        <title>{{.Title}}</title>
+        {{if .Manifest.EmbedCSSBundlePath}}
+        <link rel="stylesheet" href="{{.Manifest.EmbedCSSBundlePath}}" />
+        {{end}}
+        <!-- TODO: Google Tag Manager? -->
+        <script ignore-csp>
+            window.context = {{ .Context }}
+            window.pageError = {{ .Error }}
+        </script>
+        {{.Injected.HeadBottom}}
+    </head>
+
+    <body>
+        {{.Injected.BodyTop}}
+        <div id="root"></div>
+        <noscript>
+            <p>
+                Sourcegraph is a web-based code search and navigation tool for dev teams. Search, navigate, and review
+                code. Find answers.
+            </p>
+
+            <br />
+            <br />
+            <br />
+            You need to enable JavaScript to run this app.
+        </noscript>
+        {{if .Manifest.AppJSRuntimeBundlePath}}
+        <script src="{{.Manifest.AppJSRuntimeBundlePath}}"></script>
+        {{end}}
+        <script src="{{.Manifest.ReactJSBundlePath}}" {{if .Manifest.IsModule}}type="module" {{end}}></script>
+        <script src="{{.Manifest.EmbedJSBundlePath}}" {{if .Manifest.IsModule}}type="module" {{end}}></script>
+        {{.Injected.BodyBottom}}
+    </body>
+</html>

--- a/cmd/frontend/internal/app/ui/embed.html
+++ b/cmd/frontend/internal/app/ui/embed.html
@@ -14,11 +14,12 @@
         {{if .Manifest.EmbedCSSBundlePath}}
         <link rel="stylesheet" href="{{.Manifest.EmbedCSSBundlePath}}" />
         {{end}}
-        <!-- TODO: Google Tag Manager? -->
+
         <script ignore-csp>
             window.context = {{.Context}}
             window.pageError = {{.Error}}
         </script>
+
         {{.Injected.HeadBottom}}
     </head>
 

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -329,6 +329,23 @@ func serveSignIn(db database.DB) handlerFunc {
 	}
 }
 
+func serveEmbed(db database.DB) handlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		// Allow embedding in an iframe
+		w.Header().Del("X-Frame-Options")
+
+		common, err := newCommon(w, r, db, "", index, serveError)
+		if err != nil {
+			return err
+		}
+		if common == nil {
+			return nil // request was handled
+		}
+
+		return renderTemplate(w, "embed.html", common)
+	}
+}
+
 // redirectTreeOrBlob redirects a blob page to a tree page if the file is actually a directory,
 // or a tree page to a blob page if the directory is actually a file.
 func redirectTreeOrBlob(routeName, path string, common *Common, w http.ResponseWriter, r *http.Request, db database.DB) (requestHandled bool, err error) {

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -77,6 +77,7 @@ const (
 	routeStats                   = "stats"
 	routeViews                   = "views"
 	routeDevToolTime             = "devtooltime"
+	routeEmbed                   = "embed"
 
 	routeSearchStream  = "search.stream"
 	routeSearchConsole = "search.console"
@@ -164,6 +165,10 @@ func newRouter() *mux.Router {
 	r.PathPrefix("/views").Methods("GET").Name(routeViews)
 	r.PathPrefix("/devtooltime").Methods("GET").Name(routeDevToolTime)
 	r.Path("/ping-from-self-hosted").Methods("GET", "OPTIONS").Name(uirouter.RoutePingFromSelfHosted)
+
+	if envvar.SourcegraphDotComMode() {
+		r.PathPrefix("/embed").Methods("GET").Name(routeEmbed)
+	}
 
 	// Community search contexts pages. Must mirror client/web/src/communitySearchContexts/routes.tsx
 	if envvar.SourcegraphDotComMode() {
@@ -264,6 +269,10 @@ func initRouter(db database.DB, router *mux.Router, codeIntelResolver graphqlbac
 	router.Get(routeStats).Handler(brandedNoIndex("Stats"))
 	router.Get(routeViews).Handler(brandedNoIndex("View"))
 	router.Get(uirouter.RoutePingFromSelfHosted).Handler(handler(db, servePingFromSelfHosted))
+
+	if envvar.SourcegraphDotComMode() {
+		router.Get(routeEmbed).Handler(handler(db, serveEmbed(db)))
+	}
 
 	router.Get(routeUserSettings).Handler(brandedNoIndex("User settings"))
 	router.Get(routeUserRedirect).Handler(brandedNoIndex("User"))

--- a/cmd/frontend/internal/app/ui/tmpl.go
+++ b/cmd/frontend/internal/app/ui/tmpl.go
@@ -20,6 +20,9 @@ import (
 //go:embed app.html
 var appHTML string
 
+//go:embed embed.html
+var embedHTML string
+
 //go:embed error.html
 var errorHTML string
 
@@ -102,6 +105,8 @@ func doLoadTemplate(path string) (*template.Template, error) {
 	switch path {
 	case "app.html":
 		data = appHTML
+	case "embed.html":
+		data = embedHTML
 	case "error.html":
 		data = errorHTML
 	default:

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "@sourcegraph/prettierrc": "^3.0.3",
     "@sourcegraph/stylelint-config": "^1.4.0",
     "@sourcegraph/tsconfig": "^4.0.1",
+    "@statoscope/webpack-plugin": "^5.20.1",
     "@storybook/addon-a11y": "^6.3.12",
     "@storybook/addon-actions": "^6.3.12",
     "@storybook/addon-console": "^1.2.3",

--- a/ui/assets/manifest.go
+++ b/ui/assets/manifest.go
@@ -8,6 +8,10 @@ type WebpackManifest struct {
 	// Webpack bundle that serves as the entrypoint
 	// for the webapp code.
 	AppJSBundlePath string `json:"app.js"`
+	// EmbedJSBundlePath contains the file name of the
+	// Webpack bundle that serves as the entrypoint
+	// for the embeddable webapp code.
+	EmbedJSBundlePath string `json:"embed.js"`
 	// AppJSRuntimeBundlePath contains the file name of the
 	// JS runtime bundle which is served only in development environment
 	// to kick off the main application code.
@@ -16,4 +20,6 @@ type WebpackManifest struct {
 	IsModule bool `json:"isModule"`
 	// Main CSS bundle, only present in production.
 	AppCSSBundlePath *string `json:"app.css"`
+	// Embed CSS bundle, only present in production.
+	EmbedCSSBundlePath *string `json:"embed.css"`
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1529,6 +1529,11 @@
   resolved "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.5.tgz#9283c9ce5b289a3c4f61c12757469e59377f81f3"
   integrity sha512-6nFkfkmSeV/rqSaS4oWHgmpnYw194f6hmWF5is6b0J1naJZoiD0NTc9AiUwPHvWsowkjuHErCZT1wa0jg+BLIA==
 
+"@discoveryjs/json-ext@^0.5.5":
+  version "0.5.6"
+  resolved "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz#d5e0706cf8c6acd8c6032f8d54070af261bbbb2f"
+  integrity sha512-ws57AidsDvREKrZKYffXddNkyaF14iHNHm8VQnZH6t99E8gczjNN0GpvcGny0imC80yQ0tHz1xVUKk/KFQSUyA==
+
 "@dsherret/to-absolute-glob@^2.0.2":
   version "2.0.2"
   resolved "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz#1f6475dc8bd974cea07a2daf3864b317b1dd332c"
@@ -3539,6 +3544,135 @@
   resolved "https://registry.npmjs.org/@sqs/jsonc-parser/-/jsonc-parser-1.0.3.tgz#178538e4cb32cad15b47a739cabd77408ba18021"
   integrity sha512-dW/2OZ1z5r2rhYPcISh8GwRz7lUzVh4S4+Dgw8wg4WDdTL8yqXjQX8Ysd8cUGhzKE9/UbbrLdlj7sEwzI8Bbqw==
 
+"@statoscope/extensions@5.14.1":
+  version "5.14.1"
+  resolved "https://registry.npmjs.org/@statoscope/extensions/-/extensions-5.14.1.tgz#b7c32b39de447da76b9fa2daada61b2f699754e6"
+  integrity sha512-5O31566+bOkkdYFH81mGGBTh0YcU0zoYurTrsK5uZfpNY87ZCPpptrszX8npTRHNsxbjBBNt7vAwImJyYdhzLw==
+
+"@statoscope/helpers@5.19.0":
+  version "5.19.0"
+  resolved "https://registry.npmjs.org/@statoscope/helpers/-/helpers-5.19.0.tgz#02f8101643a0fd9b706eb59eafac4448c7d97db9"
+  integrity sha512-EFD7XqZZxtZJZlaWznAYIOrqECYHqobXxa0EADtn/mIToUrsL9g/bnkBMl28KX6zy07QcDt9gLmp5s+5GDJCoQ==
+  dependencies:
+    "@types/archy" "^0.0.32"
+    "@types/semver" "^7.3.6"
+    archy "~1.0.0"
+    jora "^1.0.0-beta.5"
+    semver "^7.3.5"
+
+"@statoscope/report-writer@5.20.0":
+  version "5.20.0"
+  resolved "https://registry.npmjs.org/@statoscope/report-writer/-/report-writer-5.20.0.tgz#18329ca8b194660087cdd2cbd996883a845be5d4"
+  integrity sha512-/QwHWzRoOCpcJkZYoTb1kuMaLoDxJpo/VteSNbhOOyCwK/74oAPAsSgbGz52T6bHAn6zkMqrSEJFJMVbYeWAJw==
+  dependencies:
+    "@discoveryjs/json-ext" "^0.5.5"
+
+"@statoscope/stats-extension-compressed@5.19.0":
+  version "5.19.0"
+  resolved "https://registry.npmjs.org/@statoscope/stats-extension-compressed/-/stats-extension-compressed-5.19.0.tgz#1a5b22416db344b9e7f5cc2ddbb08ec2c57436e8"
+  integrity sha512-CVV6dDi0vo5wDzXOuTmwydeHyjE/i56TUfA+S3llVLsxasMc6udtkLBKUfCQkbAUTJlYJcY8yUR6fH7SfiqOZw==
+  dependencies:
+    "@statoscope/helpers" "5.19.0"
+    gzip-size "^6.0.0"
+
+"@statoscope/stats-extension-custom-reports@5.19.0":
+  version "5.19.0"
+  resolved "https://registry.npmjs.org/@statoscope/stats-extension-custom-reports/-/stats-extension-custom-reports-5.19.0.tgz#6d7be7000f8c50a84c75044d466ac21aba0f3cce"
+  integrity sha512-RoOyVPZSYsk1MF/yvryuD0mNlc88OCSyr32EXTpqxlK1w0w/7SxxLtDHpSbKoMxdMrYHxvi32apjoNh03BsD+Q==
+  dependencies:
+    "@statoscope/extensions" "5.14.1"
+    "@statoscope/helpers" "5.19.0"
+    "@statoscope/stats" "5.14.1"
+    "@statoscope/types" "5.14.1"
+
+"@statoscope/stats-extension-package-info@5.19.3":
+  version "5.19.3"
+  resolved "https://registry.npmjs.org/@statoscope/stats-extension-package-info/-/stats-extension-package-info-5.19.3.tgz#9ec60dc8e36ac6f23a0a9a9e0fbc813d6354f07f"
+  integrity sha512-KUvzAkNiw1vNUY2i5IoSVnf6pIyiK3BWHOkmw94SCPWA+BXizwGbGIn6qyW/A4BI1icZvnuE4Gcrtyg0zML0KA==
+  dependencies:
+    "@statoscope/helpers" "5.19.0"
+
+"@statoscope/stats-extension-stats-validation-result@5.19.0":
+  version "5.19.0"
+  resolved "https://registry.npmjs.org/@statoscope/stats-extension-stats-validation-result/-/stats-extension-stats-validation-result-5.19.0.tgz#ab430fe1c64272f3a7fed3585c7d404bac5fb0de"
+  integrity sha512-9pNmSooDvhUNF5OJyOrmiKjEo+WaCKZhjmZX592uX653JeKr1xTwDxjSWgWyPKkkeyvMHw2T2CjB+WM8Rd/FmA==
+  dependencies:
+    "@statoscope/extensions" "5.14.1"
+    "@statoscope/helpers" "5.19.0"
+    "@statoscope/stats" "5.14.1"
+    "@statoscope/types" "5.14.1"
+
+"@statoscope/stats@5.14.1":
+  version "5.14.1"
+  resolved "https://registry.npmjs.org/@statoscope/stats/-/stats-5.14.1.tgz#728656629bc06aa4bf5634398662ac05287793d5"
+  integrity sha512-Kz7kCKuT6DXaqAPfyTwp27xHMDUna9o6UlRSQXXBZ8Yyk7eYYvTNw+5ffRyqivL9IOzD7FQYDQ6VUBHh0UfyDw==
+
+"@statoscope/types@5.14.1":
+  version "5.14.1"
+  resolved "https://registry.npmjs.org/@statoscope/types/-/types-5.14.1.tgz#4cc3da44f6a63d4318c50a75efe89f97d512ac8b"
+  integrity sha512-vIo7aq2E71AC3y3mdnZqA5aupYUaEIHuPD2gUG0bAA8zTXH7YICk7nRkuxx7xnCBhTZTXAgvtF8hgQ35K4N8oQ==
+  dependencies:
+    "@statoscope/stats" "5.14.1"
+
+"@statoscope/webpack-model@5.20.1":
+  version "5.20.1"
+  resolved "https://registry.npmjs.org/@statoscope/webpack-model/-/webpack-model-5.20.1.tgz#b749d75ab179cdd0933e9022a426766e1070659c"
+  integrity sha512-3I8fccxQiikQqoLq9K0A/qLedNehGwifpcJtXGC8YuIXJVAGU1BVudjBSveqgaVyiSdw3RKJB9TU6lsf6BGoQw==
+  dependencies:
+    "@statoscope/extensions" "5.14.1"
+    "@statoscope/helpers" "5.19.0"
+    "@statoscope/stats" "5.14.1"
+    "@statoscope/stats-extension-compressed" "5.19.0"
+    "@statoscope/stats-extension-custom-reports" "5.19.0"
+    "@statoscope/stats-extension-package-info" "5.19.3"
+    "@statoscope/stats-extension-stats-validation-result" "5.19.0"
+    "@statoscope/types" "5.14.1"
+    ajv "^8.6.3"
+    md5 "^2.3.0"
+
+"@statoscope/webpack-plugin@^5.20.1":
+  version "5.20.1"
+  resolved "https://registry.npmjs.org/@statoscope/webpack-plugin/-/webpack-plugin-5.20.1.tgz#4e967087265b1db08c5b5e93364930cf83a464c5"
+  integrity sha512-H4RsRnsEPnbKtC3/OuvhFzAolw8TwKOw0RVso8brlh2a5WLddWikFGUl1/KRQqKB45R3q1e4rnTPe+MVAVwAVA==
+  dependencies:
+    "@discoveryjs/json-ext" "^0.5.5"
+    "@statoscope/report-writer" "5.20.0"
+    "@statoscope/stats" "5.14.1"
+    "@statoscope/stats-extension-compressed" "5.19.0"
+    "@statoscope/stats-extension-custom-reports" "5.19.0"
+    "@statoscope/types" "5.14.1"
+    "@statoscope/webpack-model" "5.20.1"
+    "@statoscope/webpack-stats-extension-compressed" "5.20.1"
+    "@statoscope/webpack-stats-extension-package-info" "5.20.1"
+    "@statoscope/webpack-ui" "5.20.1"
+    open "^8.2.1"
+
+"@statoscope/webpack-stats-extension-compressed@5.20.1":
+  version "5.20.1"
+  resolved "https://registry.npmjs.org/@statoscope/webpack-stats-extension-compressed/-/webpack-stats-extension-compressed-5.20.1.tgz#e5929e1ebf1687baff15957d4dd0154c578b5017"
+  integrity sha512-UpvC2sKzFDBgetoyF4D8EyUqoPNHwIlUSewRwyqA0pdUYgNPNv8jGdNeLSLBDP7DORXaWDu1cFAf2Feal+d4OQ==
+  dependencies:
+    "@statoscope/stats" "5.14.1"
+    "@statoscope/stats-extension-compressed" "5.19.0"
+    "@statoscope/webpack-model" "5.20.1"
+
+"@statoscope/webpack-stats-extension-package-info@5.20.1":
+  version "5.20.1"
+  resolved "https://registry.npmjs.org/@statoscope/webpack-stats-extension-package-info/-/webpack-stats-extension-package-info-5.20.1.tgz#6f69f21328994b23437b5d76f082fc246daeb385"
+  integrity sha512-pHGEe1vgyaOk5U9QRpHyRLgV+Ju8SnvPxHGl1BSsle1YJv7ksW6gkatEN95ySaPFcVGp+YOMacjAf1mHQ+0I/g==
+  dependencies:
+    "@statoscope/stats" "5.14.1"
+    "@statoscope/stats-extension-package-info" "5.19.3"
+    "@statoscope/webpack-model" "5.20.1"
+
+"@statoscope/webpack-ui@5.20.1":
+  version "5.20.1"
+  resolved "https://registry.npmjs.org/@statoscope/webpack-ui/-/webpack-ui-5.20.1.tgz#b8e596a6725c826a1be86e3af2d029611fb68284"
+  integrity sha512-C/6yOuYYdaHEe3BWUavkJAu8BoXLiRzRxq01z1FolT6V3btr2ILnCHdhNOtkIJt5wbTFnmtxCbMsx4RK49gq2g==
+  dependencies:
+    "@statoscope/types" "5.14.1"
+    highcharts "^9.2.2"
+
 "@storybook/addon-a11y@^6.3.12":
   version "6.3.12"
   resolved "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-6.3.12.tgz#2f930fc84fc275a4ed43a716fc09cc12caf4e110"
@@ -4428,6 +4562,11 @@
   dependencies:
     anymatch "*"
 
+"@types/archy@^0.0.32":
+  version "0.0.32"
+  resolved "https://registry.npmjs.org/@types/archy/-/archy-0.0.32.tgz#8b572741dad9172dfbf289397af1bb41296d3e40"
+  integrity sha512-5ZZ5+YGmUE01yejiXsKnTcvhakMZ2UllZlMsQni53Doc1JWhe21ia8VntRoRD6fAEWw08JBh/z9qQHJ+//MrIg==
+
 "@types/aria-query@^4.2.0":
   version "4.2.1"
   resolved "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.1.tgz#78b5433344e2f92e8b306c06a5622c50c245bf6b"
@@ -5303,6 +5442,11 @@
   integrity sha512-ooD/FJ8EuwlDKOI6D9HWxgIgJjMg2cuziXm/42npDC8y4NjxplBUn9loewZiBNCt44450lHAU0OSb51/UqXeag==
   dependencies:
     "@types/node" "*"
+
+"@types/semver@^7.3.6":
+  version "7.3.9"
+  resolved "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz#152c6c20a7688c30b967ec1841d31ace569863fc"
+  integrity sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==
 
 "@types/serve-index@*":
   version "1.9.1"
@@ -6504,7 +6648,7 @@ archiver@~5.0.2:
     tar-stream "^2.1.4"
     zip-stream "^4.0.0"
 
-archy@^1.0.0:
+archy@^1.0.0, archy@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
   integrity sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
@@ -13421,6 +13565,11 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
+highcharts@^9.2.2:
+  version "9.3.3"
+  resolved "https://registry.npmjs.org/highcharts/-/highcharts-9.3.3.tgz#ae62178de788fd7934431aa26b8e250b8073c541"
+  integrity sha512-QeOvm6cifeZYYdTLm4IxZsXcOE9c4xqfs0z0OJJ0z7hhA9WG0rmcVAyuIp5HBl/znjA/ayYHmpYjBYD/9PG4Fg==
+
 highlight.js@^10.0.0, highlight.js@^10.1.1, highlight.js@^10.5.0:
   version "10.7.3"
   resolved "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
@@ -15306,6 +15455,11 @@ jetpack-id@1.0.0:
   resolved "https://registry.npmjs.org/jetpack-id/-/jetpack-id-1.0.0.tgz#2cf9fbae46d8074fc16b7de0071c8efebca473a6"
   integrity sha1-LPn7rkbYB0/Ba33gBxyO/rykc6Y=
 
+jora@^1.0.0-beta.5:
+  version "1.0.0-beta.5"
+  resolved "https://registry.npmjs.org/jora/-/jora-1.0.0-beta.5.tgz#55b2c4d86078af1bc74da401e88b67be42b0bddd"
+  integrity sha512-hPJKQyF0eiCqQOwfgIuQa+8wIn+WcEcjjyeOchuiXEUnt6zbV0tHKsUqRRwJY47ZtBiGcJQNr/BGuYW1Sfwbvg==
+
 jpeg-js@^0.4.1:
   version "0.4.3"
   resolved "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.3.tgz#6158e09f1983ad773813704be80680550eff977b"
@@ -16469,7 +16623,7 @@ mathml-tag-names@^2.1.3:
   resolved "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz#4ddadd67308e780cf16a47685878ee27b736a0a3"
   integrity sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==
 
-md5@^2.2.1:
+md5@^2.2.1, md5@^2.3.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz#c3da9a6aae3a30b46b7b0c349b87b110dc3bda4f"
   integrity sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==
@@ -17653,6 +17807,15 @@ open@^8.0.9:
   version "8.2.1"
   resolved "https://registry.npmjs.org/open/-/open-8.2.1.tgz#82de42da0ccbf429bc12d099dad2e0975e14e8af"
   integrity sha512-rXILpcQlkF/QuFez2BJDf3GsqpjGKbkUUToAIGo9A0Q6ZkoSGogZJulrUdwRkrAsoQvoZsrjCYt8+zblOk7JQQ==
+  dependencies:
+    define-lazy-prop "^2.0.0"
+    is-docker "^2.1.1"
+    is-wsl "^2.2.0"
+
+open@^8.2.1:
+  version "8.4.0"
+  resolved "https://registry.npmjs.org/open/-/open-8.4.0.tgz#345321ae18f8138f82565a910fdc6b39e8c244f8"
+  integrity sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==
   dependencies:
     define-lazy-prop "^2.0.0"
     is-docker "^2.1.1"


### PR DESCRIPTION
Based on https://github.com/sourcegraph/sourcegraph/pull/30669
### Experimental PR: Do not merge this one anywhere 

Basically this PR just moves all notebook deps from the main route (bundle) to the lazy-loaded notebook route where all those deps were used. 

<table>
<tr>Original PR bundle<th></th><th>This PR bundle size</th></tr>
<tr>
<td>
<img width="444" alt="Screenshot 2022-02-08 at 13 08 07" src="https://user-images.githubusercontent.com/18492575/152967222-c45f05dc-71ca-45e2-826d-63072f94d539.png">

</td>
<td>
<img width="456" alt="Screenshot 2022-02-08 at 13 08 15" src="https://user-images.githubusercontent.com/18492575/152967243-58f55581-4391-415c-9237-6464011b7af0.png">

</td>
</tr>
</table>

But still, this embed bundle looks strange. It seems like it has some part from the main App bundle for example - 'react-grid-layout' lib

<img width="799" alt="Screenshot 2022-02-08 at 13 07 36" src="https://user-images.githubusercontent.com/18492575/152967413-673bdfed-b667-4c98-bb38-5643c2c3319a.png">
The screenshot above statoscope shows that the embed bundle has this package included in its bundle. But we know that only Code Insights (which is not in the embed bundle) has this dependency. 

My guess is that [we use global css styles imports for the react-grid in the SourcegraphWebApp.scss file and this might be a culprit here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@vk/embed-route-bundle-debug/-/blob/client/web/src/SourcegraphWebApp.scss?L7%3A15=&utm_product_name=WebStorm&utm_product_version=WebStorm)


It seems like our cache group settings don't work properly if we have more than one bundle entry point (which is the case now when we have `embed` entry point together with the main app entry point in the webpack config)

