### PR TITLE
symbols: improvements to ctags build script

### DIFF
--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -104,6 +104,14 @@ ADD https://github.com/jtilander/p4d/raw/4600d741720f85d77852dcca7c182e96ad61335
 RUN tar zxf /lib-x64.tgz --directory /
 
 # p4-fusion installation
+RUN apk add --no-cache \
+    --virtual p4-build-deps \
+    g++ \
+    gcc \
+    perl \
+    cmake \
+    make
+
 # Fetching p4 sources archive
 RUN wget https://github.com/salesforce/p4-fusion/archive/refs/tags/v1.5.tar.gz && \
     mv v1.5.tar.gz /usr/local/bin && \
@@ -134,6 +142,8 @@ WORKDIR /usr/local/bin
 RUN mv /usr/local/bin/p4-fusion-src/build/p4-fusion/p4-fusion /usr/local/bin && \
     rm -rf /usr/local/bin/p4-fusion-src && \
     rm /usr/local/bin/v1.5.tar.gz
+
+RUN apk --no-cache --purge del p4-build-deps
 # p4-fusion installation completed here
 
 # hadolint ignore=DL3022

--- a/cmd/symbols/ctags-install-alpine.sh
+++ b/cmd/symbols/ctags-install-alpine.sh
@@ -6,6 +6,7 @@
 CTAGS_VERSION=7c4df9d38c4fe4bb494e5f3b2279034d7d8bd7b7
 
 cleanup() {
+  apk --no-cache --purge del build-deps || true
   cd /
   rm -rf /tmp/ctags-$CTAGS_VERSION
 }
@@ -15,6 +16,7 @@ trap cleanup EXIT
 set -eux
 
 apk --no-cache add \
+  --virtual build-deps \
   autoconf \
   automake \
   binutils \
@@ -22,9 +24,11 @@ apk --no-cache add \
   g++ \
   gcc \
   jansson-dev \
-  jansson \
   make \
   pkgconfig
+
+# ctags is dynamically linked against jansson
+apk --no-cache add jansson
 
 NUMCPUS=$(grep -c '^processor' /proc/cpuinfo)
 

--- a/cmd/symbols/ctags-install-alpine.sh
+++ b/cmd/symbols/ctags-install-alpine.sh
@@ -22,10 +22,7 @@ apk --no-cache add \
   g++ \
   gcc \
   jansson-dev \
-  libseccomp-dev \
   jansson \
-  libseccomp \
-  linux-headers \
   make \
   pkgconfig
 
@@ -35,6 +32,6 @@ NUMCPUS=$(grep -c '^processor' /proc/cpuinfo)
 curl "https://codeload.github.com/universal-ctags/ctags/tar.gz/$CTAGS_VERSION" | tar xz -C /tmp
 cd /tmp/ctags-$CTAGS_VERSION
 ./autogen.sh
-./configure --program-prefix=universal- --enable-json --enable-seccomp
+./configure --program-prefix=universal- --enable-json
 make -j"$NUMCPUS" --load-average="$NUMCPUS"
 make install

--- a/cmd/symbols/ctags-install-alpine.sh
+++ b/cmd/symbols/ctags-install-alpine.sh
@@ -2,10 +2,17 @@
 
 # This script installs ctags within an alpine container.
 
-set -eux
-
 # Commit hash of github.com/universal-ctags/ctags
 CTAGS_VERSION=7c4df9d38c4fe4bb494e5f3b2279034d7d8bd7b7
+
+cleanup() {
+  cd /
+  rm -rf /tmp/ctags-$CTAGS_VERSION
+}
+
+trap cleanup EXIT
+
+set -eux
 
 apk --no-cache add \
   autoconf \
@@ -29,7 +36,3 @@ cd /tmp/ctags-$CTAGS_VERSION
 ./configure --program-prefix=universal- --enable-json --enable-seccomp
 make -j8
 make install
-
-# Cleanup
-cd /
-rm -rf /tmp/ctags-$CTAGS_VERSION

--- a/cmd/symbols/ctags-install-alpine.sh
+++ b/cmd/symbols/ctags-install-alpine.sh
@@ -6,7 +6,7 @@
 CTAGS_VERSION=7c4df9d38c4fe4bb494e5f3b2279034d7d8bd7b7
 
 cleanup() {
-  apk --no-cache --purge del build-deps || true
+  apk --no-cache --purge del ctags-build-deps || true
   cd /
   rm -rf /tmp/ctags-$CTAGS_VERSION
 }
@@ -16,7 +16,7 @@ trap cleanup EXIT
 set -eux
 
 apk --no-cache add \
-  --virtual build-deps \
+  --virtual ctags-build-deps \
   autoconf \
   automake \
   binutils \

--- a/cmd/symbols/ctags-install-alpine.sh
+++ b/cmd/symbols/ctags-install-alpine.sh
@@ -29,10 +29,12 @@ apk --no-cache add \
   make \
   pkgconfig
 
+NUMCPUS=$(grep -c '^processor' /proc/cpuinfo)
+
 # Installation
 curl "https://codeload.github.com/universal-ctags/ctags/tar.gz/$CTAGS_VERSION" | tar xz -C /tmp
 cd /tmp/ctags-$CTAGS_VERSION
 ./autogen.sh
 ./configure --program-prefix=universal- --enable-json --enable-seccomp
-make -j8
+make -j"$NUMCPUS" --load-average="$NUMCPUS"
 make install


### PR DESCRIPTION
The main improvement is we no longer ship the ctags build dependencies in the symbols docker image. Otherwise this can be reviewed commit by commit:

- remove seccomp support in ctags
- use all your cores to build ctags
- cleanup via trap for ctags-install-alpine

The cleanup of this script was motivated in wanting to share it with how we build ctags in zoekt.

Test Plan: built and ran the docker image locally. Verified that `universal-ctags --help` didn't fail. Pushed this branch to backend integration.