### PR TITLE
gitserver: Only allow acceptable commands and POST method in /exec

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1152,9 +1152,13 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 	// See https://github.com/sourcegraph/security-issues/issues/213.
 	if !gitdomain.IsAllowedGitCmd(req.Args) {
 		log15.Warn("exec: bad command", "RemoteAddr", r.RemoteAddr, "req.Args", req.Args)
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte("invalid command"))
-		return
+
+		// Temporary feature flag to disable this feature in case their are any regressions.
+		if conf.ExperimentalFeatures().EnableGitServerCommandExecFilter {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("invalid command"))
+			return
+		}
 	}
 
 	ctx := r.Context()

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1151,7 +1151,7 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 	// 🚨 SECURITY: Ensure that only commands in the allowed list are executed.
 	// See https://github.com/sourcegraph/security-issues/issues/213.
 	if !gitdomain.IsAllowedGitCmd(req.Args) {
-		log15.Warn(fmt.Sprintf("Server.exec: bad command %q", req.Args))
+		log15.Warn("exec: bad command", "RemoteAddr", r.RemoteAddr, "req.Args", req.Args)
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte("invalid command"))
 		return

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -44,6 +44,13 @@ type Test struct {
 func TestRequest(t *testing.T) {
 	tests := []Test{
 		{
+			Name:         "HTTP GET",
+			Request:      httptest.NewRequest("GET", "/exec", strings.NewReader("{}")),
+			ExpectedCode: http.StatusMethodNotAllowed,
+			ExpectedBody: "",
+		},
+
+		{
 			Name:         "Command",
 			Request:      httptest.NewRequest("POST", "/exec", strings.NewReader(`{"repo": "github.com/gorilla/mux", "args": ["testcommand"]}`)),
 			ExpectedCode: http.StatusOK,
@@ -108,8 +115,8 @@ func TestRequest(t *testing.T) {
 		{
 			Name:         "EmptyInput",
 			Request:      httptest.NewRequest("POST", "/exec", strings.NewReader("{}")),
-			ExpectedCode: http.StatusNotFound,
-			ExpectedBody: `{"cloneInProgress":false}`,
+			ExpectedCode: http.StatusBadRequest,
+			ExpectedBody: `invalid command`,
 		},
 	}
 

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/mutablelimiter"
@@ -31,14 +32,16 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 type Test struct {
-	Name             string
-	Request          *http.Request
-	ExpectedCode     int
-	ExpectedBody     string
-	ExpectedTrailers http.Header
+	Name                             string
+	Request                          *http.Request
+	ExpectedCode                     int
+	ExpectedBody                     string
+	ExpectedTrailers                 http.Header
+	EnableGitServerCommandExecFilter bool
 }
 
 func TestRequest(t *testing.T) {
@@ -115,14 +118,28 @@ func TestRequest(t *testing.T) {
 		{
 			Name:         "EmptyInput",
 			Request:      httptest.NewRequest("POST", "/exec", strings.NewReader("{}")),
-			ExpectedCode: http.StatusBadRequest,
-			ExpectedBody: "invalid command",
+			ExpectedCode: http.StatusNotFound,
+			ExpectedBody: `{"cloneInProgress":false}`,
+		},
+		{
+			Name:                             "EmptyInput/EnableGitServerCommandExecFilter",
+			Request:                          httptest.NewRequest("POST", "/exec", strings.NewReader("{}")),
+			ExpectedCode:                     http.StatusBadRequest,
+			ExpectedBody:                     "invalid command",
+			EnableGitServerCommandExecFilter: true,
 		},
 		{
 			Name:         "BadCommand",
 			Request:      httptest.NewRequest("POST", "/exec", strings.NewReader(`{"repo":"github.com/sourcegraph/sourcegraph", "args": ["invalid-command"]}`)),
-			ExpectedCode: http.StatusBadRequest,
-			ExpectedBody: "invalid command",
+			ExpectedCode: http.StatusNotFound,
+			ExpectedBody: `{"cloneInProgress":false}`,
+		},
+		{
+			Name:                             "BadCommand/EnableGitServerCommandExecFilter",
+			Request:                          httptest.NewRequest("POST", "/exec", strings.NewReader(`{"repo":"github.com/sourcegraph/sourcegraph", "args": ["invalid-command"]}`)),
+			ExpectedCode:                     http.StatusBadRequest,
+			ExpectedBody:                     "invalid command",
+			EnableGitServerCommandExecFilter: true,
 		},
 	}
 
@@ -167,6 +184,14 @@ func TestRequest(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
+			conf.Mock(&conf.Unified{
+				SiteConfiguration: schema.SiteConfiguration{
+					ExperimentalFeatures: &schema.ExperimentalFeatures{
+						EnableGitServerCommandExecFilter: test.EnableGitServerCommandExecFilter,
+					},
+				},
+			})
+
 			w := httptest.ResponseRecorder{Body: new(bytes.Buffer)}
 			h.ServeHTTP(&w, test.Request)
 

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -116,7 +116,13 @@ func TestRequest(t *testing.T) {
 			Name:         "EmptyInput",
 			Request:      httptest.NewRequest("POST", "/exec", strings.NewReader("{}")),
 			ExpectedCode: http.StatusBadRequest,
-			ExpectedBody: `invalid command`,
+			ExpectedBody: "invalid command",
+		},
+		{
+			Name:         "BadCommand",
+			Request:      httptest.NewRequest("POST", "/exec", strings.NewReader(`{"repo":"github.com/sourcegraph/sourcegraph", "args": ["invalid-command"]}`)),
+			ExpectedCode: http.StatusBadRequest,
+			ExpectedBody: "invalid command",
 		},
 	}
 

--- a/internal/gitserver/gitdomain/exec.go
+++ b/internal/gitserver/gitdomain/exec.go
@@ -1,0 +1,82 @@
+package gitdomain
+
+import "strings"
+
+var (
+	// gitCmdAllowlist are commands and arguments that are allowed to execute when calling execSafe.
+	gitCmdAllowlist = map[string][]string{
+		"log":    append([]string{}, gitCommonAllowlist...),
+		"show":   append([]string{}, gitCommonAllowlist...),
+		"remote": {"-v"},
+		"diff":   append([]string{}, gitCommonAllowlist...),
+		"blame":  {"--root", "--incremental", "-w", "-p", "--porcelain", "--"},
+		"branch": {"-r", "-a", "--contains"},
+
+		"rev-parse":    {"--abbrev-ref", "--symbolic-full-name"},
+		"rev-list":     {"--max-parents", "--reverse", "--max-count"},
+		"ls-remote":    {"--get-url"},
+		"symbolic-ref": {"--short"},
+
+		// Used in tests to simulate errors with runCommand in handleExec of gitserver.
+		"testcommand": {},
+		"testerror":   {},
+	}
+
+	// `git log`, `git show`, `git diff`, etc., share a large common set of allowed args.
+	gitCommonAllowlist = []string{
+		"--name-status", "--full-history", "-M", "--date", "--format", "-i", "-n1", "-m", "--", "-n200", "-n2", "--follow", "--author", "--grep", "--date-order", "--decorate", "--skip", "--max-count", "--numstat", "--pretty", "--parents", "--topo-order", "--raw", "--follow", "--all", "--before", "--no-merges",
+		"--patch", "--unified", "-S", "-G", "--pickaxe-all", "--pickaxe-regex", "--function-context", "--branches", "--source", "--src-prefix", "--dst-prefix", "--no-prefix",
+		"--regexp-ignore-case", "--glob", "--cherry", "-z",
+		"--until", "--since", "--author", "--committer",
+		"--all-match", "--invert-grep", "--extended-regexp",
+		"--no-color", "--decorate", "--no-patch", "--exclude",
+		"--no-merges",
+		"--full-index",
+		"--find-copies",
+		"--find-renames",
+		"--inter-hunk-context",
+	}
+)
+
+// isAllowedGitArg checks if the arg is allowed.
+func isAllowedGitArg(allowedArgs []string, arg string) bool {
+	// Split the arg at the first equal sign and check the LHS against the allowlist args.
+	splitArg := strings.Split(arg, "=")[0]
+	for _, allowedArg := range allowedArgs {
+		if splitArg == allowedArg {
+			return true
+		}
+	}
+	return false
+}
+
+// IsAllowedGitCmd checks if the cmd and arguments are allowed.
+func IsAllowedGitCmd(args []string) bool {
+	if len(args) == 0 || len(gitCmdAllowlist) == 0 {
+		return false
+	}
+
+	cmd := args[0]
+	allowedArgs, ok := gitCmdAllowlist[cmd]
+	if !ok {
+		// Command not allowed
+		return false
+	}
+	for _, arg := range args[1:] {
+		if strings.HasPrefix(arg, "-") {
+			// Special-case `git log -S` and `git log -G`, which interpret any characters
+			// after their 'S' or 'G' as part of the query. There is no long form of this
+			// flags (such as --something=query), so if we did not special-case these, there
+			// would be no way to safely express a query that began with a '-' character.
+			// (Same for `git show`, where the flag has the same meaning.)
+			if (cmd == "log" || cmd == "show") && (strings.HasPrefix(arg, "-S") || strings.HasPrefix(arg, "-G")) {
+				continue // this arg is OK
+			}
+
+			if !isAllowedGitArg(allowedArgs, arg) {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/internal/gitserver/gitdomain/exec.go
+++ b/internal/gitserver/gitdomain/exec.go
@@ -1,6 +1,10 @@
 package gitdomain
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/inconshreveable/log15"
+)
 
 var (
 	// gitCmdAllowlist are commands and arguments that are allowed to execute when calling execSafe.
@@ -10,14 +14,19 @@ var (
 		"remote": {"-v"},
 		"diff":   append([]string{}, gitCommonAllowlist...),
 		"blame":  {"--root", "--incremental", "-w", "-p", "--porcelain", "--"},
-		"branch": {"-r", "-a", "--contains"},
+		"branch": {"-r", "-a", "--contains", "--merged"},
 
 		"rev-parse":    {"--abbrev-ref", "--symbolic-full-name"},
-		"rev-list":     {"--max-parents", "--reverse", "--max-count"},
+		"rev-list":     {"--max-parents", "--reverse", "--max-count", "--count", "--after", "--before", "--", "-n", "--date-order", "--skip", "--left-right"},
 		"ls-remote":    {"--get-url"},
 		"symbolic-ref": {"--short"},
-
-		"archive": {"--worktree-attributes", "--format", "-0", "HEAD", "--"},
+		"archive":      {"--worktree-attributes", "--format", "-0", "HEAD", "--"},
+		"ls-tree":      {"--name-only", "HEAD", "--long", "--full-name", "--", "-z", "-r"},
+		"ls-files":     {"--with-tree", "-z"},
+		"for-each-ref": {"--format"},
+		"tag":          {"--list", "--sort", "-creatordate", "--format"},
+		"merge-base":   {"--"},
+		"show-ref":     {"--heads"},
 
 		// Used in tests to simulate errors with runCommand in handleExec of gitserver.
 		"testcommand": {},
@@ -26,7 +35,7 @@ var (
 
 	// `git log`, `git show`, `git diff`, etc., share a large common set of allowed args.
 	gitCommonAllowlist = []string{
-		"--name-status", "--full-history", "-M", "--date", "--format", "-i", "-n1", "-m", "--", "-n200", "-n2", "--follow", "--author", "--grep", "--date-order", "--decorate", "--skip", "--max-count", "--numstat", "--pretty", "--parents", "--topo-order", "--raw", "--follow", "--all", "--before", "--no-merges",
+		"--name-only", "--name-status", "--full-history", "-M", "--date", "--format", "-i", "-n", "-n1", "-m", "--", "-n200", "-n2", "--follow", "--author", "--grep", "--date-order", "--decorate", "--skip", "--max-count", "--numstat", "--pretty", "--parents", "--topo-order", "--raw", "--follow", "--all", "--before", "--no-merges",
 		"--patch", "--unified", "-S", "-G", "--pickaxe-all", "--pickaxe-regex", "--function-context", "--branches", "--source", "--src-prefix", "--dst-prefix", "--no-prefix",
 		"--regexp-ignore-case", "--glob", "--cherry", "-z",
 		"--until", "--since", "--author", "--committer",
@@ -37,6 +46,9 @@ var (
 		"--find-copies",
 		"--find-renames",
 		"--inter-hunk-context",
+		"--after",
+		"--date.order",
+		"-s",
 	}
 )
 
@@ -62,6 +74,7 @@ func IsAllowedGitCmd(args []string) bool {
 	allowedArgs, ok := gitCmdAllowlist[cmd]
 	if !ok {
 		// Command not allowed
+		log15.Warn("IsAllowedGitCmd: command not allowed", "cmd", cmd)
 		return false
 	}
 	for _, arg := range args[1:] {
@@ -76,6 +89,7 @@ func IsAllowedGitCmd(args []string) bool {
 			}
 
 			if !isAllowedGitArg(allowedArgs, arg) {
+				log15.Warn("IsAllowedGitCmd.isAllowedGitArgcmd", "cmd", cmd, "arg", arg)
 				return false
 			}
 		}

--- a/internal/gitserver/gitdomain/exec.go
+++ b/internal/gitserver/gitdomain/exec.go
@@ -17,6 +17,8 @@ var (
 		"ls-remote":    {"--get-url"},
 		"symbolic-ref": {"--short"},
 
+		"archive": {"--worktree-attributes", "--format", "-0", "HEAD", "--"},
+
 		// Used in tests to simulate errors with runCommand in handleExec of gitserver.
 		"testcommand": {},
 		"testerror":   {},

--- a/internal/vcs/git/exec.go
+++ b/internal/vcs/git/exec.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -32,7 +33,7 @@ func execSafe(ctx context.Context, repo api.RepoName, params []string) (stdout, 
 		return nil, nil, 0, errors.New("at least one argument required")
 	}
 
-	if !IsAllowedGitCmd(params) {
+	if !gitdomain.IsAllowedGitCmd(params) {
 		return nil, nil, 0, errors.Errorf("command failed: %q is not a allowed git command", params)
 	}
 
@@ -60,91 +61,12 @@ func execReader(ctx context.Context, repo api.RepoName, args []string) (io.ReadC
 	span.SetTag("args", args)
 	defer span.Finish()
 
-	if !IsAllowedGitCmd(args) {
+	if !gitdomain.IsAllowedGitCmd(args) {
 		return nil, errors.Errorf("command failed: %v is not a allowed git command", args)
 	}
 	cmd := gitserver.DefaultClient.Command("git", args...)
 	cmd.Repo = repo
 	return gitserver.StdoutReader(ctx, cmd)
-}
-
-var (
-	// gitCmdAllowlist are commands and arguments that are allowed to execute when calling execSafe.
-	gitCmdAllowlist = map[string][]string{
-		"log":    append([]string{}, gitCommonAllowlist...),
-		"show":   append([]string{}, gitCommonAllowlist...),
-		"remote": {"-v"},
-		"diff":   append([]string{}, gitCommonAllowlist...),
-		"blame":  {"--root", "--incremental", "-w", "-p", "--porcelain", "--"},
-		"branch": {"-r", "-a", "--contains"},
-
-		"rev-parse":    {"--abbrev-ref", "--symbolic-full-name"},
-		"rev-list":     {"--max-parents", "--reverse", "--max-count"},
-		"ls-remote":    {"--get-url"},
-		"symbolic-ref": {"--short"},
-
-		// Used in tests to simulate errors with runCommand in handleExec of gitserver.
-		"testcommand": {},
-		"testerror":   {},
-	}
-
-	// `git log`, `git show`, `git diff`, etc., share a large common set of allowed args.
-	gitCommonAllowlist = []string{
-		"--name-status", "--full-history", "-M", "--date", "--format", "-i", "-n1", "-m", "--", "-n200", "-n2", "--follow", "--author", "--grep", "--date-order", "--decorate", "--skip", "--max-count", "--numstat", "--pretty", "--parents", "--topo-order", "--raw", "--follow", "--all", "--before", "--no-merges",
-		"--patch", "--unified", "-S", "-G", "--pickaxe-all", "--pickaxe-regex", "--function-context", "--branches", "--source", "--src-prefix", "--dst-prefix", "--no-prefix",
-		"--regexp-ignore-case", "--glob", "--cherry", "-z",
-		"--until", "--since", "--author", "--committer",
-		"--all-match", "--invert-grep", "--extended-regexp",
-		"--no-color", "--decorate", "--no-patch", "--exclude",
-		"--no-merges",
-		"--full-index",
-		"--find-copies",
-		"--find-renames",
-		"--inter-hunk-context",
-	}
-)
-
-// isAllowedGitArg checks if the arg is allowed.
-func isAllowedGitArg(allowedArgs []string, arg string) bool {
-	// Split the arg at the first equal sign and check the LHS against the allowlist args.
-	splitArg := strings.Split(arg, "=")[0]
-	for _, allowedArg := range allowedArgs {
-		if splitArg == allowedArg {
-			return true
-		}
-	}
-	return false
-}
-
-// IsAllowedGitCmd checks if the cmd and arguments are allowed.
-func IsAllowedGitCmd(args []string) bool {
-	if len(args) == 0 || len(gitCmdAllowlist) == 0 {
-		return false
-	}
-
-	cmd := args[0]
-	allowedArgs, ok := gitCmdAllowlist[cmd]
-	if !ok {
-		// Command not allowed
-		return false
-	}
-	for _, arg := range args[1:] {
-		if strings.HasPrefix(arg, "-") {
-			// Special-case `git log -S` and `git log -G`, which interpret any characters
-			// after their 'S' or 'G' as part of the query. There is no long form of this
-			// flags (such as --something=query), so if we did not special-case these, there
-			// would be no way to safely express a query that began with a '-' character.
-			// (Same for `git show`, where the flag has the same meaning.)
-			if (cmd == "log" || cmd == "show") && (strings.HasPrefix(arg, "-S") || strings.HasPrefix(arg, "-G")) {
-				continue // this arg is OK
-			}
-
-			if !isAllowedGitArg(allowedArgs, arg) {
-				return false
-			}
-		}
-	}
-	return true
 }
 
 // checkSpecArgSafety returns a non-nil err if spec begins with a "-", which

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -569,6 +569,8 @@ type ExperimentalFeatures struct {
 	CustomGitFetch []*CustomGitFetchMapping `json:"customGitFetch,omitempty"`
 	// DebugLog description: Turns on debug logging for specific debugging scenarios.
 	DebugLog *DebugLog `json:"debug.log,omitempty"`
+	// EnableGitServerCommandExecFilter description: Enable filtering of all exec commands on gitserver based on a pre-defined allowlist
+	EnableGitServerCommandExecFilter bool `json:"enableGitServerCommandExecFilter,omitempty"`
 	// EnableGithubInternalRepoVisibility description: Enable support for visilibity of internal Github repositories
 	EnableGithubInternalRepoVisibility bool `json:"enableGithubInternalRepoVisibility,omitempty"`
 	// EnablePermissionsWebhooks description: Enables webhook consumers to sync permissions from external services faster than the defaults schedule

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -370,6 +370,11 @@
           "description": "Enable support for visilibity of internal Github repositories",
           "type": "boolean",
           "default": false
+        },
+        "enableGitServerCommandExecFilter": {
+          "description": "Enable filtering of all exec commands on gitserver based on a pre-defined allowlist",
+          "type": "boolean",
+          "default": false
         }
       },
       "examples": [


### PR DESCRIPTION
Patch for https://github.com/sourcegraph/security-issues/issues/213.

## Note to reviewers

This PR also fixes an edge case with the `isAllowedGitCmd` function. So it's suggested to look at the commits one after the other during review as this function and related functions and variables have also been moved from `internal/vcs/git` to `internal/gitserver/gitdomain`.

Without this move, `golangci-lint` caught a cyclic dependency between `cmd/gitserver/server` and `internal/vcs/git`:

1. `internal/vcs/git/main_test.go` already imports `cmd/gitserver/server`
2. `cmd/gitserver/server/server.go` would now be importing `internal/vcs/git` if we didn't move `IsAllowedGitCmd` to `internal/gitserver/gitdomain` package.

## Regression concerns

On scanning the PR commit by commit, reviewers should also notice the addition of multiple new commands to the allow list. This does not introduce new behavior, but adds the existing set of commands which are already in use in the `/exec` endpoint. With the check for the allow list in in `func (s *Server) exec`, existing tests were failing unless these commands and in some cases extra args were added to the allow list. My concern here is that if we have existing commands in use for which test cases do not exist, this PR could lead to a severe regression. 

My thoughts at this point are to keep the code around the allow list checking guarded behind a feature flag while at the same time doing a dry run check and logging any commands that fail the check for the next few days. Observing the logs in production should give us a concrete list of commands that are not present in the allow list at the moment. I'd appreciate any thoughts or suggestions on the best path to take forward.

### Update

The PR now does the following in order to avoid regressions:

1. Increment the prometheus metric `src_gitserver_exec_blocked_command_received` if a blocked command is received by gitserver's `/exec` endpoint
1. Always log blocked commands as a warning
1. If the feature flag `experimentalFeatures.enableGitServerCommandExecFilter` is set to `true`, block the command from being executed or else default to current behavior of letting the command be executed

Note: By default the feature flag is disabled and merging this PR **WILL NOT** fix the linked issue.

## Test Plan

1. Merge the PR and deploy to cloud
1. Monitor the new metric `src_gitserver_exec_blocked_command_received` for 2-3 days
1. If the metric has a non-zero value after this initial monitoring period, inspect logs to identify commands that are logged as blocked commands
1. Depending on the command update the allow list
1. GOTO 1 until the metric's value is `0` (Note: Use `rate` or `increase` as this is a monotonically increasing counter)

Tagging @sourcegraph/security for suggestions on testing plan and timeline with respect to SLA.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
