### PR TITLE
web: add react chunk to the production Webpack manifest

### DIFF
--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -141,8 +141,8 @@ const config = {
       new WebpackManifestPlugin({
         writeToFileEmit: true,
         fileName: 'webpack.manifest.json',
-        // Only output files that are required to run the application
-        filter: ({ isInitial }) => isInitial,
+        // Only output files that are required to run the application.
+        filter: ({ isInitial, name }) => isInitial || name?.includes('react'),
       }),
     ...(shouldServeIndexHTML ? getHTMLWebpackPlugins() : []),
     shouldAnalyze && new BundleAnalyzerPlugin(),


### PR DESCRIPTION
## Context 

It seems that React chunk was included in `webpack.manifest.js` by chance. Now we explicitly add it.