### PR TITLE
Fixing old Organization invite form: invite url not appearing anymore

### DIFF
--- a/client/web/src/org/area/OrgArea.tsx
+++ b/client/web/src/org/area/OrgArea.tsx
@@ -213,7 +213,11 @@ export class OrgArea extends React.Component<Props> {
                                 : of(false)
                         return flagObservable.pipe(
                             catchError((): [boolean] => [false]), // set flag to false in case of error reading it
-                            map(newMembersInviteEnabled => ({ orgOrError: state.orgOrError, newMembersInviteEnabled }))
+                            map(newMembersInviteEnabled =>
+                                !state.orgOrError
+                                    ? { newMembersInviteEnabled }
+                                    : { orgOrError: state.orgOrError, newMembersInviteEnabled }
+                            )
                         )
                     })
                 )


### PR DESCRIPTION
A change to client/web/src/org/area/OrgArea.tsx to load feature flags after organization data, was causing the components to unmount on refresh. This caused a 
``` Can't perform a React state update on an unmounted component.```
