### PR TITLE
database: reorder where conditions so that existing compound index is used, add user_id index

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -2214,6 +2214,7 @@ Foreign-key constraints:
  updated_at    | timestamp with time zone |           | not null | now()
 Indexes:
     "sub_repo_permissions_repo_id_user_id_version_uindex" UNIQUE, btree (repo_id, user_id, version)
+    "sub_repo_perms_user_id" btree (user_id)
 Foreign-key constraints:
     "sub_repo_permissions_repo_id_fk" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
     "sub_repo_permissions_users_id_fk" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE

--- a/internal/database/sub_repo_perms_store.go
+++ b/internal/database/sub_repo_perms_store.go
@@ -118,8 +118,8 @@ func (s *subRepoPermsStore) Get(ctx context.Context, userID int32, repoID api.Re
 	q := sqlf.Sprintf(`
 SELECT path_includes, path_excludes
 FROM sub_repo_permissions
-WHERE user_id = %s
-  AND repo_id = %s
+WHERE repo_id = %s
+  AND user_id = %s
   AND version = %s
 `, userID, repoID, SubRepoPermsVersion)
 

--- a/migrations/frontend/1528395973/down.sql
+++ b/migrations/frontend/1528395973/down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+DROP INDEX IF EXISTS sub_repo_perms_user_id;
+COMMIT;

--- a/migrations/frontend/1528395973/metadata.yaml
+++ b/migrations/frontend/1528395973/metadata.yaml
@@ -1,0 +1,3 @@
+name: return user_id index to sub_repo_permissions table
+parent: 1528395972
+createIndexConcurrently: true

--- a/migrations/frontend/1528395973/up.sql
+++ b/migrations/frontend/1528395973/up.sql
@@ -1,0 +1,4 @@
+-- +++
+-- parent: 1528395972
+-- +++
+CREATE INDEX CONCURRENTLY IF NOT EXISTS sub_repo_perms_user_id ON sub_repo_permissions (user_id);

--- a/migrations/frontend/1528395973/up.sql
+++ b/migrations/frontend/1528395973/up.sql
@@ -1,4 +1,1 @@
--- +++
--- parent: 1528395972
--- +++
 CREATE INDEX CONCURRENTLY IF NOT EXISTS sub_repo_perms_user_id ON sub_repo_permissions (user_id);


### PR DESCRIPTION
First I noticed that [this query](https://github.com/sourcegraph/sourcegraph/blob/2ad9c35b82723bcda62e883e7ee82b8dfdaef17e/internal/database/sub_repo_perms_store.go#L119-L124) will not use the index. Reordering the predicates will fix it.

Then I recognised that [another query](https://github.com/sourcegraph/sourcegraph/blob/2ad9c35b82723bcda62e883e7ee82b8dfdaef17e/internal/database/sub_repo_perms_store.go#L152-L157) will also full scan the table because `user_id` index was deleted some time ago, but it should not be deleted as existing compound index `"sub_repo_permissions_repo_id_user_id_version_uindex" UNIQUE, btree (repo_id, user_id, version)` is inefficient for `user_id` or `version` queries. That's why I returned the `user_id` column index.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
