### PR TITLE
ci: fix honeycomb tracing 

### DIFF
--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 echo "STEP_START=$STEP_START"
+echo "BUILD_START_TIME=$BUILD_START_TIME"
 
 (
     echo "--- Sending stuff to HoneyComb"

--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+echo "STEP_START=$STEP_START"
+
 (
     echo "--- Sending stuff to HoneyComb"
     echo "build_id=$BUILDKITE_BUILD_ID step_id=$BUILDKITE_STEP_ID step_start=$STEP_START step_key=$BUILDKITE_STEP_KEY"

--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 
 (
-    echo "--- Sending stuff to HoneyComb"
-    echo "build_id=$BUILDKITE_BUILD_ID step_id=$BUILDKITE_STEP_ID step_start=$STEP_START step_key=$BUILDKITE_STEP_KEY"
-
     exit_code="$BUILDKITE_COMMAND_EXIT_STATUS"
     BUILDEVENT_APIKEY=$CI_BUILDEVENT_API_KEY
     BUILDEVENT_DATASET="$CI_BUILDEVENT_DATASET"

--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-echo "STEP_START=$STEP_START"
-echo "BUILD_START_TIME=$BUILD_START_TIME"
-
 (
     echo "--- Sending stuff to HoneyComb"
     echo "build_id=$BUILDKITE_BUILD_ID step_id=$BUILDKITE_STEP_ID step_start=$STEP_START step_key=$BUILDKITE_STEP_KEY"

--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
 (
+    echo "--- Sending stuff to HoneyComb"
+    echo "build_id=$BUILDKITE_BUILD_ID step_id=$BUILDKITE_STEP_ID step_start=$STEP_START step_key=$BUILDKITE_STEP_KEY"
+
     exit_code="$BUILDKITE_COMMAND_EXIT_STATUS"
     BUILDEVENT_APIKEY=$CI_BUILDEVENT_API_KEY
     BUILDEVENT_DATASET="$CI_BUILDEVENT_DATASET"

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -31,45 +31,45 @@ if [[ ! "$BUILDKITE_AGENT_META_DATA_QUEUE" =~ .*job.* ]]; then
     echo "install asdf plugins"
     asdf install
     echo "done installing"
-    exit 0
-fi
-
-# We need awscli to use asdf cache
-echo "install asdf awscli"
-asdf install awscli
-echo "done installing"
-
-# set the buildkite cache access keys
-AWS_CONFIG_DIR_PATH="/buildkite/.aws"
-mkdir -p "$AWS_CONFIG_DIR_PATH"
-AWS_CONFIG_FILE="$AWS_CONFIG_DIR_PATH/config"
-export AWS_CONFIG_FILE
-AWS_SHARED_CREDENTIALS_FILE="/buildkite/.aws/credentials"
-export AWS_SHARED_CREDENTIALS_FILE
-aws configure set aws_access_key_id "$BUILDKITE_HMAC_KEY" --profile buildkite
-aws configure set aws_secret_access_key "$BUILDKITE_HMAC_SECRET" --profile buildkite
-
-asdf_checksum=$(sha1sum .tool-versions | awk '{print $1}')
-cache_file="cache-asdf-$asdf_checksum.tar.gz"
-cache_key="$BUILDKITE_ORGANIZATION_SLUG/$BUILDKITE_PIPELINE_NAME/$cache_file"
-
-echo -e "ASDF 🔍 Locating cache: $cache_key"
-if aws s3api head-object --bucket "sourcegraph_buildkite_cache" --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "us-central1" --key "$cache_key"; then
-    echo -e "ASDF 🔥 Cache hit: $cache_key"
-    aws s3 cp --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "us-central1" "s3://sourcegraph_buildkite_cache/$cache_key" "$HOME/"
-    pushd "$HOME"
-    tar xzf "$cache_file"
-    popd
+    # We can't use exit 0 here, it would prevent the variables to be exported.
 else
-    echo -e "ASDF 🚨 Cache miss: $cache_key"
-    echo "--- installing all asdf tool versions"
-    asdf install
-    echo "--- caching asdf installation"
-    pushd "$HOME"
-    tar cfz "$cache_file" .asdf
-    popd
-    aws s3 cp --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "us-central1" "$HOME/$cache_file" "s3://sourcegraph_buildkite_cache/$cache_key"
-fi
+    # We need awscli to use asdf cache
+    echo "install asdf awscli"
+    asdf install awscli
+    echo "done installing"
 
-unset AWS_SHARED_CREDENTIALS_FILE
-unset AWS_CONFIG_FILE
+    # set the buildkite cache access keys
+    AWS_CONFIG_DIR_PATH="/buildkite/.aws"
+    mkdir -p "$AWS_CONFIG_DIR_PATH"
+    AWS_CONFIG_FILE="$AWS_CONFIG_DIR_PATH/config"
+    export AWS_CONFIG_FILE
+    AWS_SHARED_CREDENTIALS_FILE="/buildkite/.aws/credentials"
+    export AWS_SHARED_CREDENTIALS_FILE
+    aws configure set aws_access_key_id "$BUILDKITE_HMAC_KEY" --profile buildkite
+    aws configure set aws_secret_access_key "$BUILDKITE_HMAC_SECRET" --profile buildkite
+
+    asdf_checksum=$(sha1sum .tool-versions | awk '{print $1}')
+    cache_file="cache-asdf-$asdf_checksum.tar.gz"
+    cache_key="$BUILDKITE_ORGANIZATION_SLUG/$BUILDKITE_PIPELINE_NAME/$cache_file"
+
+    echo -e "ASDF 🔍 Locating cache: $cache_key"
+    if aws s3api head-object --bucket "sourcegraph_buildkite_cache" --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "us-central1" --key "$cache_key"; then
+        echo -e "ASDF 🔥 Cache hit: $cache_key"
+        aws s3 cp --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "us-central1" "s3://sourcegraph_buildkite_cache/$cache_key" "$HOME/"
+        pushd "$HOME"
+        tar xzf "$cache_file"
+        popd
+    else
+        echo -e "ASDF 🚨 Cache miss: $cache_key"
+        echo "--- installing all asdf tool versions"
+        asdf install
+        echo "--- caching asdf installation"
+        pushd "$HOME"
+        tar cfz "$cache_file" .asdf
+        popd
+        aws s3 cp --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "us-central1" "$HOME/$cache_file" "s3://sourcegraph_buildkite_cache/$cache_key"
+    fi
+
+    unset AWS_SHARED_CREDENTIALS_FILE
+    unset AWS_CONFIG_FILE
+fi

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -5,12 +5,16 @@ set -eu
 # HoneyComb's buildevent plumbing.
 # -------------------------------
 
+echo "--- Setting up HoneyComb tracing for the build"
+
 # Record start time if we need to exit
 BUILD_START_TIME=$(curl -H "Authorization: Bearer $BUILDKITE_API_TOKEN" "https://api.buildkite.com/v2/organizations/$BUILDKITE_ORGANIZATION_SLUG/pipelines/$BUILDKITE_PIPELINE_SLUG/builds/$BUILDKITE_BUILD_NUMBER/" | jq -r .started_at)
 
 # Convert to UTC & Epoch
 BUILD_START_TIME=$(TZ=UTC date -d "$BUILD_START_TIME" +'%s')
 export BUILD_START_TIME
+
+echo "BUILD_START_TIME=$BUILD_START_TIME"
 
 # Init the step
 STEP_START=$(date +'%s')

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -27,7 +27,7 @@ if [[ ! "$BUILDKITE_AGENT_META_DATA_QUEUE" =~ .*job.* ]]; then
     echo "install asdf plugins"
     asdf install
     echo "done installing"
-    # We can't use exit 0 here, it would prevent the variables to be exported.
+    # We can't use exit 0 here, it would prevent the variables to be exported (that's a particular buildkite hook peculiarity).
 else
     # We need awscli to use asdf cache
     echo "install asdf awscli"

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -14,13 +14,9 @@ BUILD_START_TIME=$(curl -H "Authorization: Bearer $BUILDKITE_API_TOKEN" "https:/
 BUILD_START_TIME=$(TZ=UTC date -d "$BUILD_START_TIME" +'%s')
 export BUILD_START_TIME
 
-echo "BUILD_START_TIME=$BUILD_START_TIME"
-
 # Init the step
 STEP_START=$(date +'%s')
 export STEP_START
-
-echo "STEP_START=$STEP_START"
 
 # ASDF setup
 # ----------

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -20,6 +20,8 @@ echo "BUILD_START_TIME=$BUILD_START_TIME"
 STEP_START=$(date +'%s')
 export STEP_START
 
+echo "STEP_START=$STEP_START"
+
 # ASDF setup
 # ----------
 


### PR DESCRIPTION
When we merged the stateless agents PR, it came with a conditional that exited early with `exit 0`. That somehow triggered something that caused the env variables for HoneyComb to not be exported and caused a later failure in the late post-command hook. 