### PR TITLE
authz: rename Validate to ValidateConnection, remove from constructors

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/init.go
+++ b/enterprise/cmd/frontend/internal/authz/init.go
@@ -47,7 +47,7 @@ func Init(ctx context.Context, db database.DB, _ conftypes.UnifiedWatchable, ent
 	// Report any authz provider problems in external configs.
 	conf.ContributeWarning(func(cfg conftypes.SiteConfigQuerier) (problems conf.Problems) {
 		_, providers, seriousProblems, warnings :=
-			eiauthz.ProvidersFromConfig(context.Background(), cfg, extsvcStore)
+			eiauthz.ProvidersFromConfig(ctx, cfg, extsvcStore)
 		problems = append(problems, conf.NewExternalServiceProblems(seriousProblems...)...)
 
 		// Add connection validation issue
@@ -72,7 +72,7 @@ func Init(ctx context.Context, db database.DB, _ conftypes.UnifiedWatchable, ent
 		}
 
 		// We can ignore problems returned here because they would have been surfaced in other places.
-		_, providers, _, _ := eiauthz.ProvidersFromConfig(context.Background(), conf.Get(), extsvcStore)
+		_, providers, _, _ := eiauthz.ProvidersFromConfig(ctx, conf.Get(), extsvcStore)
 		if len(providers) == 0 {
 			return nil
 		}

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
@@ -82,7 +82,8 @@ func (*mockProvider) FetchAccount(context.Context, *types.User, []*extsvc.Accoun
 func (p *mockProvider) ServiceType() string { return p.serviceType }
 func (p *mockProvider) ServiceID() string   { return p.serviceID }
 func (p *mockProvider) URN() string         { return extsvc.URN(p.serviceType, p.id) }
-func (*mockProvider) Validate() []string    { return nil }
+
+func (*mockProvider) ValidateConnection(context.Context) []string { return nil }
 
 func (p *mockProvider) FetchUserPerms(ctx context.Context, acct *extsvc.Account, opts authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
 	return p.fetchUserPerms(ctx, acct)

--- a/enterprise/internal/authz/authz.go
+++ b/enterprise/internal/authz/authz.go
@@ -32,9 +32,9 @@ type ExternalServicesStore interface {
 // and "warnings". "Serious problems" are those that should make Sourcegraph set authz.allowAccessByDefault
 // to false. "Warnings" are all other validation problems.
 //
-// This constructor does not and should not directly check connectivity to code hosts - if desired,
-// callers should use `(*Provider).ValidateConnection` directly to get warnings related to connection
-// issues with the code host.
+// This constructor does not and should not directly check connectivity to external services - if
+// desired, callers should use `(*Provider).ValidateConnection` directly to get warnings related
+// to connection issues.
 func ProvidersFromConfig(
 	ctx context.Context,
 	cfg conftypes.SiteConfigQuerier,
@@ -187,9 +187,9 @@ var MockProviderFromExternalService func(siteConfig schema.SiteConfiguration, sv
 //
 // It returns `(nil, nil)` if no authz.Provider can be derived and no error had occurred.
 //
-// This constructor does not and should not directly check connectivity to code hosts - if desired,
-// callers should use `(*Provider).ValidateConnection` directly to get warnings related to connection
-// issues with the code host.
+// This constructor does not and should not directly check connectivity to external services - if
+// desired, callers should use `(*Provider).ValidateConnection` directly to get warnings related
+// to connection issues.
 func ProviderFromExternalService(siteConfig schema.SiteConfiguration, svc *types.ExternalService) (authz.Provider, error) {
 	if MockProviderFromExternalService != nil {
 		return MockProviderFromExternalService(siteConfig, svc)

--- a/enterprise/internal/authz/authz.go
+++ b/enterprise/internal/authz/authz.go
@@ -25,10 +25,16 @@ type ExternalServicesStore interface {
 	List(context.Context, database.ExternalServicesListOptions) ([]*types.ExternalService, error)
 }
 
-// ProvidersFromConfig returns the set of permission-related providers derived from the site config.
-// It also returns any validation problems with the config, separating these into "serious problems"
+// ProvidersFromConfig returns the set of permission-related providers derived from the site config
+// based on `NewAuthzProviders` constructors provided by each provider type's package.
+//
+// It also returns any simple validation problems with the config, separating these into "serious problems"
 // and "warnings". "Serious problems" are those that should make Sourcegraph set authz.allowAccessByDefault
 // to false. "Warnings" are all other validation problems.
+//
+// This constructor does not and should not directly check connectivity to code hosts - if desired,
+// callers should use `(*Provider).ValidateConnection` directly to get warnings related to connection
+// issues with the code host.
 func ProvidersFromConfig(
 	ctx context.Context,
 	cfg conftypes.SiteConfigQuerier,
@@ -175,11 +181,15 @@ func ProvidersFromConfig(
 
 var MockProviderFromExternalService func(siteConfig schema.SiteConfiguration, svc *types.ExternalService) (authz.Provider, error)
 
-// ProviderFromExternalService returns the parsed authz.Provider derived from
-// the site config and the given external service.
+// ProviderFromExternalService returns the parsed authz.Provider derived from the site config
+// and the given external service based on `NewAuthzProviders` constructors provided by each
+// provider type's package.
 //
-// It returns `(nil, nil)` if no authz.Provider can be derived and no error had
-// occurred.
+// It returns `(nil, nil)` if no authz.Provider can be derived and no error had occurred.
+//
+// This constructor does not and should not directly check connectivity to code hosts - if desired,
+// callers should use `(*Provider).ValidateConnection` directly to get warnings related to connection
+// issues with the code host.
 func ProviderFromExternalService(siteConfig schema.SiteConfiguration, svc *types.ExternalService) (authz.Provider, error) {
 	if MockProviderFromExternalService != nil {
 		return MockProviderFromExternalService(siteConfig, svc)

--- a/enterprise/internal/authz/authz_test.go
+++ b/enterprise/internal/authz/authz_test.go
@@ -46,7 +46,7 @@ func (m gitlabAuthzProviderParams) URN() string {
 	panic("should never be called")
 }
 
-func (m gitlabAuthzProviderParams) Validate() []string { return nil }
+func (m gitlabAuthzProviderParams) ValidateConnection(context.Context) []string { return nil }
 
 func (m gitlabAuthzProviderParams) FetchUserPerms(context.Context, *extsvc.Account, authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
 	panic("should never be called")

--- a/enterprise/internal/authz/bitbucketserver/authz.go
+++ b/enterprise/internal/authz/bitbucketserver/authz.go
@@ -1,8 +1,6 @@
 package bitbucketserver
 
 import (
-	"fmt"
-
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
@@ -26,12 +24,6 @@ func NewAuthzProviders(
 			problems = append(problems, err.Error())
 		} else if p != nil {
 			ps = append(ps, p)
-		}
-	}
-
-	for _, p := range ps {
-		for _, problem := range p.Validate() {
-			warnings = append(warnings, fmt.Sprintf("BitbucketServer config for %s was invalid: %s", p.ServiceID(), problem))
 		}
 	}
 

--- a/enterprise/internal/authz/bitbucketserver/authz.go
+++ b/enterprise/internal/authz/bitbucketserver/authz.go
@@ -15,9 +15,9 @@ import (
 // and "warnings". "Serious problems" are those that should make Sourcegraph set authz.allowAccessByDefault
 // to false. "Warnings" are all other validation problems.
 //
-// This constructor does not and should not directly check connectivity to code hosts - if desired,
-// callers should use `(*Provider).ValidateConnection` directly to get warnings related to connection
-// issues with the code host.
+// This constructor does not and should not directly check connectivity to external services - if
+// desired, callers should use `(*Provider).ValidateConnection` directly to get warnings related
+// to connection issues.
 func NewAuthzProviders(
 	conns []*types.BitbucketServerConnection,
 ) (ps []authz.Provider, problems []string, warnings []string) {

--- a/enterprise/internal/authz/bitbucketserver/authz.go
+++ b/enterprise/internal/authz/bitbucketserver/authz.go
@@ -10,9 +10,14 @@ import (
 )
 
 // NewAuthzProviders returns the set of Bitbucket Server authz providers derived from the connections.
-// It also returns any validation problems with the config, separating these into "serious problems" and
-// "warnings". "Serious problems" are those that should make Sourcegraph set authz.allowAccessByDefault
+//
+// It also returns any simple validation problems with the config, separating these into "serious problems"
+// and "warnings". "Serious problems" are those that should make Sourcegraph set authz.allowAccessByDefault
 // to false. "Warnings" are all other validation problems.
+//
+// This constructor does not and should not directly check connectivity to code hosts - if desired,
+// callers should use `(*Provider).ValidateConnection` directly to get warnings related to connection
+// issues with the code host.
 func NewAuthzProviders(
 	conns []*types.BitbucketServerConnection,
 ) (ps []authz.Provider, problems []string, warnings []string) {

--- a/enterprise/internal/authz/bitbucketserver/provider.go
+++ b/enterprise/internal/authz/bitbucketserver/provider.go
@@ -49,8 +49,8 @@ func NewProvider(cli *bitbucketserver.Client, urn string, pluginPerm bool) *Prov
 
 // Validate validates that the Provider has access to the Bitbucket Server API
 // with the OAuth credentials it was configured with.
-func (p *Provider) Validate() []string {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+func (p *Provider) ValidateConnection(ctx context.Context) []string {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	username, err := p.client.Username()

--- a/enterprise/internal/authz/bitbucketserver/provider_test.go
+++ b/enterprise/internal/authz/bitbucketserver/provider_test.go
@@ -24,7 +24,7 @@ import (
 
 var update = flag.Bool("update", false, "update testdata")
 
-func TestProvider_Validate(t *testing.T) {
+func TestProvider_ValidateConnection(t *testing.T) {
 	instanceURL := os.Getenv("BITBUCKET_SERVER_URL")
 	if instanceURL == "" {
 		instanceURL = "https://bitbucket.sgdev.org"
@@ -60,7 +60,7 @@ func TestProvider_Validate(t *testing.T) {
 				tc.problems[i] = strings.ReplaceAll(tc.problems[i], "${INSTANCEURL}", instanceURL)
 			}
 
-			problems := p.Validate()
+			problems := p.ValidateConnection(context.Background())
 			if have, want := problems, tc.problems; !reflect.DeepEqual(have, want) {
 				t.Error(cmp.Diff(have, want))
 			}

--- a/enterprise/internal/authz/github/authz.go
+++ b/enterprise/internal/authz/github/authz.go
@@ -74,11 +74,6 @@ func NewAuthzProviders(
 			p.groupsCache = nil
 		}
 
-		// Check for other validation issues.
-		for _, problem := range p.Validate() {
-			warnings = append(warnings, fmt.Sprintf("GitHub config for %s was invalid: %s", p.ServiceID(), problem))
-		}
-
 		// Register this provider.
 		ps = append(ps, p)
 	}

--- a/enterprise/internal/authz/github/authz.go
+++ b/enterprise/internal/authz/github/authz.go
@@ -18,9 +18,9 @@ import (
 // and "warnings". "Serious problems" are those that should make Sourcegraph set authz.allowAccessByDefault
 // to false. "Warnings" are all other validation problems.
 //
-// This constructor does not and should not directly check connectivity to code hosts - if desired,
-// callers should use `(*Provider).ValidateConnection` directly to get warnings related to connection
-// issues with the code host.
+// This constructor does not and should not directly check connectivity to external services - if
+// desired, callers should use `(*Provider).ValidateConnection` directly to get warnings related
+// to connection issues.
 func NewAuthzProviders(
 	conns []*types.GitHubConnection,
 	authProviders []schema.AuthProviders,

--- a/enterprise/internal/authz/github/authz.go
+++ b/enterprise/internal/authz/github/authz.go
@@ -13,9 +13,14 @@ import (
 )
 
 // NewAuthzProviders returns the set of GitHub authz providers derived from the connections.
-// It also returns any validation problems with the config, separating these into "serious problems" and
-// "warnings". "Serious problems" are those that should make Sourcegraph set authz.allowAccessByDefault
+//
+// It also returns any simple validation problems with the config, separating these into "serious problems"
+// and "warnings". "Serious problems" are those that should make Sourcegraph set authz.allowAccessByDefault
 // to false. "Warnings" are all other validation problems.
+//
+// This constructor does not and should not directly check connectivity to code hosts - if desired,
+// callers should use `(*Provider).ValidateConnection` directly to get warnings related to connection
+// issues with the code host.
 func NewAuthzProviders(
 	conns []*types.GitHubConnection,
 	authProviders []schema.AuthProviders,

--- a/enterprise/internal/authz/github/github.go
+++ b/enterprise/internal/authz/github/github.go
@@ -88,13 +88,13 @@ func (p *Provider) ServiceType() string {
 	return p.codeHost.ServiceType
 }
 
-func (p *Provider) Validate() []string {
+func (p *Provider) ValidateConnection(ctx context.Context) []string {
 	required := p.requiredAuthScopes()
 	if len(required) == 0 {
 		return []string{}
 	}
 
-	scopes, err := p.client.GetAuthenticatedOAuthScopes(context.Background())
+	scopes, err := p.client.GetAuthenticatedOAuthScopes(ctx)
 	if err != nil {
 		return []string{
 			fmt.Sprintf("Additional OAuth scopes are required, but failed to get available scopes: %+v", err),

--- a/enterprise/internal/authz/github/github_test.go
+++ b/enterprise/internal/authz/github/github_test.go
@@ -1102,13 +1102,13 @@ func TestProvider_FetchRepoPerms(t *testing.T) {
 	})
 }
 
-func TestProvider_Validate(t *testing.T) {
+func TestProvider_ValidateConnection(t *testing.T) {
 	t.Run("cache disabled: scopes ok", func(t *testing.T) {
 		p := NewProvider("", ProviderOptions{
 			GitHubURL:      mustURL(t, "https://github.com"),
 			GroupsCacheTTL: -1,
 		})
-		problems := p.Validate()
+		problems := p.ValidateConnection(context.Background())
 		if len(problems) > 0 {
 			t.Fatal("expected validate to pass")
 		}
@@ -1126,7 +1126,7 @@ func TestProvider_Validate(t *testing.T) {
 					return nil, errors.New("scopes error")
 				},
 			}
-			problems := p.Validate()
+			problems := p.ValidateConnection(context.Background())
 			if len(problems) != 1 {
 				t.Fatal("expected 1 problem")
 			}
@@ -1141,7 +1141,7 @@ func TestProvider_Validate(t *testing.T) {
 					return []string{}, nil
 				},
 			}
-			problems := p.Validate()
+			problems := p.ValidateConnection(context.Background())
 			if len(problems) != 1 {
 				t.Fatal("expected 1 problem")
 			}
@@ -1161,7 +1161,7 @@ func TestProvider_Validate(t *testing.T) {
 						return testCase, nil
 					},
 				}
-				problems := p.Validate()
+				problems := p.ValidateConnection(context.Background())
 				if len(problems) != 0 {
 					t.Fatalf("expected validate to pass for scopes=%+v", testCase)
 				}

--- a/enterprise/internal/authz/gitlab/authz.go
+++ b/enterprise/internal/authz/gitlab/authz.go
@@ -17,9 +17,9 @@ import (
 // and "warnings". "Serious problems" are those that should make Sourcegraph set authz.allowAccessByDefault
 // to false. "Warnings" are all other validation problems.
 //
-// This constructor does not and should not directly check connectivity to code hosts - if desired,
-// callers should use `(*Provider).ValidateConnection` directly to get warnings related to connection
-// issues with the code host.
+// This constructor does not and should not directly check connectivity to external services - if
+// desired, callers should use `(*Provider).ValidateConnection` directly to get warnings related
+// to connection issues.
 func NewAuthzProviders(
 	cfg schema.SiteConfiguration,
 	conns []*types.GitLabConnection,

--- a/enterprise/internal/authz/gitlab/authz.go
+++ b/enterprise/internal/authz/gitlab/authz.go
@@ -12,9 +12,14 @@ import (
 )
 
 // NewAuthzProviders returns the set of GitLab authz providers derived from the connections.
-// It also returns any validation problems with the config, separating these into "serious problems" and
-// "warnings". "Serious problems" are those that should make Sourcegraph set authz.allowAccessByDefault
+//
+// It also returns any simple validation problems with the config, separating these into "serious problems"
+// and "warnings". "Serious problems" are those that should make Sourcegraph set authz.allowAccessByDefault
 // to false. "Warnings" are all other validation problems.
+//
+// This constructor does not and should not directly check connectivity to code hosts - if desired,
+// callers should use `(*Provider).ValidateConnection` directly to get warnings related to connection
+// issues with the code host.
 func NewAuthzProviders(
 	cfg schema.SiteConfiguration,
 	conns []*types.GitLabConnection,

--- a/enterprise/internal/authz/gitlab/gitlab.go
+++ b/enterprise/internal/authz/gitlab/gitlab.go
@@ -1,7 +1,6 @@
 package gitlab
 
 import (
-	"fmt"
 	"net/url"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
@@ -27,11 +26,6 @@ func NewAuthzProviders(
 			problems = append(problems, err.Error())
 		} else if p != nil {
 			ps = append(ps, p)
-		}
-	}
-	for _, p := range ps {
-		for _, problem := range p.Validate() {
-			warnings = append(warnings, fmt.Sprintf("GitLab config for %s was invalid: %s", p.ServiceID(), problem))
 		}
 	}
 

--- a/enterprise/internal/authz/gitlab/oauth.go
+++ b/enterprise/internal/authz/gitlab/oauth.go
@@ -54,7 +54,7 @@ func newOAuthProvider(op OAuthProviderOp, cli httpcli.Doer) *OAuthProvider {
 	}
 }
 
-func (p *OAuthProvider) Validate() (problems []string) {
+func (p *OAuthProvider) ValidateConnection(context.Context) (problems []string) {
 	return nil
 }
 

--- a/enterprise/internal/authz/gitlab/sudo.go
+++ b/enterprise/internal/authz/gitlab/sudo.go
@@ -75,8 +75,8 @@ func newSudoProvider(op SudoProviderOp, cli httpcli.Doer) *SudoProvider {
 	}
 }
 
-func (p *SudoProvider) Validate() (problems []string) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+func (p *SudoProvider) ValidateConnection(ctx context.Context) (problems []string) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	if _, _, err := p.clientProvider.GetPATClient(p.sudoToken, "1").ListProjects(ctx, "projects"); err != nil {
 		if err == ctx.Err() {

--- a/enterprise/internal/authz/perforce/authz.go
+++ b/enterprise/internal/authz/perforce/authz.go
@@ -15,9 +15,9 @@ import (
 // and "warnings". "Serious problems" are those that should make Sourcegraph set authz.allowAccessByDefault
 // to false. "Warnings" are all other validation problems.
 //
-// This constructor does not and should not directly check connectivity to code hosts - if desired,
-// callers should use `(*Provider).ValidateConnection` directly to get warnings related to connection
-// issues with the code host.
+// This constructor does not and should not directly check connectivity to external services - if
+// desired, callers should use `(*Provider).ValidateConnection` directly to get warnings related
+// to connection issues.
 func NewAuthzProviders(conns []*types.PerforceConnection) (ps []authz.Provider, problems []string, warnings []string) {
 	for _, c := range conns {
 		p, err := newAuthzProvider(c.URN, c.Authorization, c.P4Port, c.P4User, c.P4Passwd, c.Depots)

--- a/enterprise/internal/authz/perforce/authz.go
+++ b/enterprise/internal/authz/perforce/authz.go
@@ -9,11 +9,15 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-// NewAuthzProviders returns the set of Perforce authz providers derived from
-// the connections. It also returns any validation problems with the config,
-// separating these into "serious problems" and "warnings". "Serious problems"
-// are those that should make Sourcegraph set authz.allowAccessByDefault to
-// false. "Warnings" are all other validation problems.
+// NewAuthzProviders returns the set of Perforce authz providers derived from the connections.
+//
+// It also returns any simple validation problems with the config, separating these into "serious problems"
+// and "warnings". "Serious problems" are those that should make Sourcegraph set authz.allowAccessByDefault
+// to false. "Warnings" are all other validation problems.
+//
+// This constructor does not and should not directly check connectivity to code hosts - if desired,
+// callers should use `(*Provider).ValidateConnection` directly to get warnings related to connection
+// issues with the code host.
 func NewAuthzProviders(conns []*types.PerforceConnection) (ps []authz.Provider, problems []string, warnings []string) {
 	for _, c := range conns {
 		p, err := newAuthzProvider(c.URN, c.Authorization, c.P4Port, c.P4User, c.P4Passwd, c.Depots)

--- a/enterprise/internal/authz/perforce/authz.go
+++ b/enterprise/internal/authz/perforce/authz.go
@@ -1,7 +1,6 @@
 package perforce
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/authz"
@@ -22,12 +21,6 @@ func NewAuthzProviders(conns []*types.PerforceConnection) (ps []authz.Provider, 
 			problems = append(problems, err.Error())
 		} else if p != nil {
 			ps = append(ps, p)
-		}
-	}
-
-	for _, p := range ps {
-		for _, problem := range p.Validate() {
-			warnings = append(warnings, fmt.Sprintf("Perforce config for %s was invalid: %s", p.ServiceID(), problem))
 		}
 	}
 

--- a/enterprise/internal/authz/perforce/perforce.go
+++ b/enterprise/internal/authz/perforce/perforce.go
@@ -331,7 +331,7 @@ func (p *Provider) URN() string {
 	return p.urn
 }
 
-func (p *Provider) Validate() (problems []string) {
+func (p *Provider) ValidateConnection(ctx context.Context) (problems []string) {
 	// Validate the user has "super" access with "-u" option, see https://www.perforce.com/perforce/r12.1/manuals/cmdref/protects.html
 	rc, _, err := p.p4Execer.P4Exec(context.Background(), p.host, p.user, p.password, "protects", "-u", p.user)
 	if err == nil {

--- a/internal/authz/iface.go
+++ b/internal/authz/iface.go
@@ -133,9 +133,10 @@ type Provider interface {
 	// is defined.
 	URN() string
 
-	// ValidateConnection checks the configuration and credentials of the authz provider and returns any
-	// problems.
-	ValidateConnection(ctx context.Context) (problems []string)
+	// ValidateConnection checks that the configuration and credentials of the authz provider
+	// can establish a valid connection with the provider, and returns warnings based on any
+	// issues it finds.
+	ValidateConnection(ctx context.Context) (warnings []string)
 }
 
 // ErrUnauthenticated indicates an unauthenticated request.

--- a/internal/authz/iface.go
+++ b/internal/authz/iface.go
@@ -133,9 +133,9 @@ type Provider interface {
 	// is defined.
 	URN() string
 
-	// Validate checks the configuration and credentials of the authz provider and returns any
+	// ValidateConnection checks the configuration and credentials of the authz provider and returns any
 	// problems.
-	Validate() (problems []string)
+	ValidateConnection(ctx context.Context) (problems []string)
 }
 
 // ErrUnauthenticated indicates an unauthenticated request.

--- a/internal/database/repos_perm_test.go
+++ b/internal/database/repos_perm_test.go
@@ -32,10 +32,11 @@ func (p *fakeProvider) FetchAccount(context.Context, *types.User, []*extsvc.Acco
 	return p.extAcct, nil
 }
 
-func (p *fakeProvider) ServiceType() string           { return p.codeHost.ServiceType }
-func (p *fakeProvider) ServiceID() string             { return p.codeHost.ServiceID }
-func (p *fakeProvider) URN() string                   { return extsvc.URN(p.codeHost.ServiceType, 0) }
-func (p *fakeProvider) Validate() (problems []string) { return nil }
+func (p *fakeProvider) ServiceType() string { return p.codeHost.ServiceType }
+func (p *fakeProvider) ServiceID() string   { return p.codeHost.ServiceID }
+func (p *fakeProvider) URN() string         { return extsvc.URN(p.codeHost.ServiceType, 0) }
+
+func (p *fakeProvider) ValidateConnection(context.Context) (problems []string) { return nil }
 
 func (p *fakeProvider) FetchUserPerms(context.Context, *extsvc.Account, authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
 	return nil, nil


### PR DESCRIPTION
- Rename `Validate` to `ValidateConnection(context.Context)`
	- See https://github.com/sourcegraph/sourcegraph/pull/30617#issuecomment-1032058894 - tl;dr [all `Valdiate` implementations today make network requests _and nothing else_](https://sourcegraph.com/search?q=context:%40sourcegraph/all+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24%400355eeb0c+file:%5Eenterprise/internal/authz+func+%28...%29+Validate%28%29+...+%7B+...+%7D+count:all&patternType=structural), so this change makes it clearer what is going on and allows the check to accept a context for cancellation etc.
- Remove validation from default constructors
	- Only a single call to `ProvidersFromConfig` [actually uses the warnings returned](https://sourcegraph.com/search?q=context:%40sourcegraph/all+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24%400355eeb0c++ProvidersFromConfig%28...%29+count:all+-f:test&patternType=structural), making all these calls to `Validate` unnecessary. 
	   - In the single callsite that actually uses the returned warnings, I've added calls to `ValidateConnection`
	- `ProviderFromExternalService` is the other primary user of the various authz provider constructors e.g. `github.NewAuthzProviders`, but it discards `warnings`, and validation problems are always appended to `warnings` (see the removed calls in the PR diff)

For https://github.com/sourcegraph/customer/issues/658 , closes https://github.com/sourcegraph/sourcegraph/pull/30617

Remaining TODOs:

- [x] Main-dry-run passes: https://buildkite.com/sourcegraph/sourcegraph/builds/129954
- [x] Update docstrings on authz provider constructors to indicate only simple validation occurs on the constructors