### PR TITLE
sg setup: Fix yarn check

### DIFF
--- a/dev/sg/sg_setup.go
+++ b/dev/sg/sg_setup.go
@@ -296,7 +296,7 @@ asdf install golang
 			},
 			{
 				name:  "yarn",
-				check: combineChecks(checkInPath("yarn"), checkCommandOutputContains("yarn version", "yarn version")),
+				check: combineChecks(checkInPath("yarn"), checkCommandExitCode("yarn --version", 0)),
 				instructionsComment: `` +
 					`Souregraph requires Yarn to be installed.
 


### PR DESCRIPTION
`yarn version`, not to be confused with `yarn --version` cuts a new version of the current package, which leaves behind a new commit on the main branch after running through sg setup. This switches to yarn --version to avoid that.