### PR TITLE
Code Monitors: return full results from ActionJobMetadata

### DIFF
--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -264,7 +264,7 @@ func (r *actionRunner) handleEmail(ctx context.Context, j *edb.ActionJob) error 
 		return errors.Wrap(err, "ListRecipients")
 	}
 
-	data, err := NewTemplateDataForNewSearchResults(ctx, m.Description, m.Query, e, zeroOrVal(m.NumResults))
+	data, err := NewTemplateDataForNewSearchResults(ctx, m.Description, m.Query, e, len(m.Results))
 	if err != nil {
 		return errors.Wrap(err, "NewTemplateDataForNewSearchResults")
 	}
@@ -317,7 +317,7 @@ func (r *actionRunner) handleWebhook(ctx context.Context, j *edb.ActionJob) erro
 		MonitorURL:         codeMonitorURL,
 		Query:              m.Query,
 		QueryURL:           searchURL,
-		NumResults:         zeroOrVal(m.NumResults),
+		NumResults:         len(m.Results),
 	}
 
 	return sendWebhookNotification(ctx, w.URL, args)
@@ -356,7 +356,7 @@ func (r *actionRunner) handleSlackWebhook(ctx context.Context, j *edb.ActionJob)
 		MonitorURL:         codeMonitorURL,
 		Query:              m.Query,
 		QueryURL:           searchURL,
-		NumResults:         zeroOrVal(m.NumResults),
+		NumResults:         len(m.Results),
 	}
 
 	return sendSlackNotification(ctx, w.URL, args)

--- a/enterprise/internal/database/code_monitor_action_jobs.go
+++ b/enterprise/internal/database/code_monitor_action_jobs.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/keegancsmith/sqlf"
 
+	cmtypes "github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors/types"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
@@ -36,7 +37,7 @@ func (a *ActionJob) RecordID() int {
 type ActionJobMetadata struct {
 	Description string
 	MonitorID   int64
-	NumResults  *int
+	Results     cmtypes.CommitSearchResults
 
 	// The query with after: filter.
 	Query string
@@ -225,7 +226,7 @@ SELECT
 	cm.description,
 	ctj.query_string,
 	cm.id AS monitorID,
-	jsonb_array_length(ctj.search_results)
+	ctj.search_results
 FROM cm_action_jobs caj
 INNER JOIN cm_trigger_jobs ctj on caj.trigger_event = ctj.id
 INNER JOIN cm_queries cq on cq.id = ctj.query
@@ -233,10 +234,11 @@ INNER JOIN cm_monitors cm on cm.id = cq.monitor
 WHERE caj.id = %s
 `
 
+// GetActionJobMetada returns the set of fields needed to execute all action jobs
 func (s *codeMonitorStore) GetActionJobMetadata(ctx context.Context, jobID int32) (*ActionJobMetadata, error) {
 	row := s.Store.QueryRow(ctx, sqlf.Sprintf(getActionJobMetadataFmtStr, jobID))
 	m := &ActionJobMetadata{}
-	return m, row.Scan(&m.Description, &m.Query, &m.MonitorID, &m.NumResults)
+	return m, row.Scan(&m.Description, &m.Query, &m.MonitorID, &m.Results)
 }
 
 const actionJobForIDFmtStr = `

--- a/enterprise/internal/database/code_monitor_action_jobs_test.go
+++ b/enterprise/internal/database/code_monitor_action_jobs_test.go
@@ -52,10 +52,10 @@ func TestGetActionJobMetadata(t *testing.T) {
 	triggerJobID := triggerJobs[0].ID
 
 	var (
-		wantNumResults = 42
-		wantQuery      = testQuery + " after:\"" + s.Now().UTC().Format(time.RFC3339) + "\""
+		wantResults = make(cmtypes.CommitSearchResults, wantNumResults)
+		wantQuery   = testQuery + " after:\"" + s.Now().UTC().Format(time.RFC3339) + "\""
 	)
-	err = s.UpdateTriggerJobWithResults(ctx, triggerJobID, wantQuery, make(cmtypes.CommitSearchResults, wantNumResults))
+	err = s.UpdateTriggerJobWithResults(ctx, triggerJobID, wantQuery, wantResults)
 	require.NoError(t, err)
 
 	actionJobs, err := s.EnqueueActionJobsForMonitor(ctx, fixtures.monitor.ID, triggerJobID)
@@ -68,7 +68,7 @@ func TestGetActionJobMetadata(t *testing.T) {
 	want := &ActionJobMetadata{
 		Description: testDescription,
 		Query:       wantQuery,
-		NumResults:  &wantNumResults,
+		Results:     wantResults,
 		MonitorID:   fixtures.monitor.ID,
 	}
 	require.Equal(t, want, got)


### PR DESCRIPTION
This returns the actual results with ActionJobMetadata so they can be
used to populate outbound messages with the result contents.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @delivery if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
