### PR TITLE
codeintel: surface per-upload retention reasons

### DIFF
--- a/client/web/src/enterprise/codeintel/uploads/components/EmptyUploadRetentionStatusNode.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/EmptyUploadRetentionStatusNode.tsx
@@ -1,0 +1,10 @@
+import MapSearchIcon from 'mdi-react/MapSearchIcon'
+import React from 'react'
+
+export const EmptyUploadRetentionMatchStatus: React.FunctionComponent = () => (
+    <p className="text-muted text-center w-100 mb-0 mt-1">
+        <MapSearchIcon className="mb-2" />
+        <br />
+        No retention policies matched.
+    </p>
+)

--- a/client/web/src/enterprise/codeintel/uploads/components/UploadRetentionStatusNode.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/UploadRetentionStatusNode.tsx
@@ -1,0 +1,81 @@
+import classNames from 'classnames'
+import InformationOutlineIcon from 'mdi-react/InformationOutlineIcon'
+import React, { FunctionComponent } from 'react'
+
+import { pluralize } from '@sourcegraph/shared/src/util/strings'
+import { Link } from '@sourcegraph/wildcard/src/components/Link'
+
+import { NormalizedUploadRetentionMatch } from '../hooks/queryUploadRetentionMatches'
+
+import styles from './DependencyOrDependentNode.module.scss'
+
+export interface RetentionMatchNodeProps {
+    node: NormalizedUploadRetentionMatch
+}
+
+export const retentionByUploadTitle = 'Retention by reference'
+
+export const RetentionMatchNode: FunctionComponent<RetentionMatchNodeProps> = ({ node }) => {
+    if (node.matchType === 'RetentionPolicy') {
+        const joinedRevhashes =
+            node.protectingCommits.length !== 0 ? (
+                <>
+                    , by visible {pluralize('commit', node.protectingCommits.length, 'commits')}{' '}
+                    {node.protectingCommits.map(hash => hash.slice(0, 9)).join(', ')}
+                    <InformationOutlineIcon
+                        className="ml-1 icon-inline"
+                        data-tooltip="This upload is retained to service code-intel queries for commit(s) with applicable retention policies."
+                    />
+                </>
+            ) : (
+                <></>
+            )
+        return (
+            <>
+                <span className={styles.separator} />
+
+                <div className={classNames(styles.information, 'd-flex flex-column')}>
+                    <div className="m-0">
+                        <Link to={`../configuration/${node.configurationPolicy.id}`} className="p-0">
+                            <h3 className="m-0 d-block d-md-inline">{node.configurationPolicy.name}</h3>
+                        </Link>
+                        <div className="mr-2 d-block d-mdinline-block">
+                            Matched: {node.matches ? 'yes' : 'no'}
+                            {joinedRevhashes}
+                        </div>
+                    </div>
+                </div>
+            </>
+        )
+    }
+    if (node.matchType === 'UploadReference') {
+        return (
+            <>
+                <span className={styles.separator} />
+
+                <div className={classNames(styles.information, 'd-flex flex-column')}>
+                    <div className="m-0">
+                        <h3 className="m-0 d-block d-md-inline">{retentionByUploadTitle}</h3>
+                        <div className="mr-2 d-block d-mdinline-block">
+                            Referenced by {node.total} {pluralize('upload', node.total, 'uploads')}, including{' '}
+                            {node.uploadSlice
+                                .slice(0, 3)
+                                .map<React.ReactNode>(upload => (
+                                    <Link key={upload.id} to={`/site-admin/code-intelligence/uploads/${upload.id}`}>
+                                        {upload.projectRoot?.repository.name ?? 'unknown'}
+                                    </Link>
+                                ))
+                                .reduce((previous, current) => [previous, ', ', current])}
+                            <InformationOutlineIcon
+                                className='ml-1 icon-inline'
+                                data-tooltip="Uploads that are dependencies of other upload(s) are retained to service cross-repository code-intel queries."
+                            />
+                        </div>
+                    </div>
+                </div>
+            </>
+        )
+    }
+
+    throw new Error(`invalid node type ${JSON.stringify(node as object)}`)
+}

--- a/client/web/src/enterprise/codeintel/uploads/hooks/queryUploadRetentionMatches.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/hooks/queryUploadRetentionMatches.tsx
@@ -1,0 +1,182 @@
+import { ApolloClient } from '@apollo/client'
+import { from, Observable } from 'rxjs'
+import { map } from 'rxjs/operators'
+
+import { getDocumentNode, gql } from '@sourcegraph/http-client'
+import { IRetentionPolicyOverviewOnLSIFUploadArguments } from '@sourcegraph/shared/src/schema'
+
+import { Connection } from '../../../../components/FilteredConnection'
+import {
+    GitObjectType,
+    LsifUploadRetentionPolicyMatchesResult as LsifUploadRetentionMatchesResult,
+    LsifUploadRetentionPolicyMatchesVariables as LsifUploadRetentionMatchesVariables,
+} from '../../../../graphql-operations'
+import { retentionByUploadTitle } from '../components/UploadRetentionStatusNode'
+
+interface UploadRetentionMatchesResult {
+    node: {
+        retentionPolicyOverview: {
+            nodes: {
+                matches: boolean
+                protectingCommits: string[] | null
+                configurationPolicy: {
+                    id: string
+                    name: string
+                    type: GitObjectType
+                    retentionDurationHours: number | null
+                }
+            }[]
+            totalCount: number | null
+            pageInfo: { endCursor: string | null; hasNextPage: boolean }
+        }
+    }
+    lsifUploads: {
+        nodes: {
+            id: string
+            inputCommit: string
+            inputRoot: string
+            projectRoot: {
+                repository: { id: string; name: string }
+            } | null
+        }[]
+        totalCount: number | null
+    }
+}
+
+export type NormalizedUploadRetentionMatch =
+    | {
+          matchType: 'RetentionPolicy'
+          matches: boolean
+          protectingCommits: string[]
+          configurationPolicy: {
+              id: string
+              name: string
+              type: GitObjectType
+              retentionDurationHours: number | null
+          }
+      }
+    | {
+          matchType: 'UploadReference'
+          uploadSlice: {
+              id: string
+              inputCommit: string
+              inputRoot: string
+              projectRoot: {
+                  repository: { id: string; name: string }
+              } | null
+          }[]
+          total: number
+      }
+
+const UPLOAD_RETENTIONS_QUERY = gql`
+    query LsifUploadRetentionMatches(
+        $id: ID!
+        $matchesOnly: Boolean!
+        $after: String
+        $first: Int
+        $query: String
+    ) {
+        node(id: $id) {
+            __typename
+            ... on LSIFUpload {
+                retentionPolicyOverview(matchesOnly: $matchesOnly, query: $query, after: $after, first: $first) {
+                    __typename
+                    nodes {
+                        __typename
+                        # id
+                        configurationPolicy {
+                            __typename
+                            id
+                            name
+                            type
+                            retentionDurationHours
+                        }
+                        matches
+                        protectingCommits
+                    }
+                    totalCount
+                    pageInfo {
+                        endCursor
+                        hasNextPage
+                    }
+                }
+            }
+        }
+
+        lsifUploads(dependentOf: $id) {
+            __typename
+            totalCount
+            nodes {
+                id
+                inputCommit
+                inputRoot
+                projectRoot {
+                    repository {
+                        name
+                        id
+                    }
+                }
+            }
+        }
+    }
+`
+export const queryUploadRetentionMatches = (
+    client: ApolloClient<object>,
+    id: string,
+    { matchesOnly, after, first, query }: IRetentionPolicyOverviewOnLSIFUploadArguments
+): Observable<Connection<NormalizedUploadRetentionMatch>> => {
+    const vars: LsifUploadRetentionMatchesVariables = {
+        id,
+        matchesOnly,
+        query: query ?? null,
+        first: first ?? null,
+        after: after ?? null,
+    }
+
+    return from(
+        client.query<LsifUploadRetentionMatchesResult, LsifUploadRetentionMatchesVariables>({
+            query: getDocumentNode(UPLOAD_RETENTIONS_QUERY),
+            variables: { ...vars },
+        })
+    ).pipe(
+        map(({ data }) => {
+            const { node, ...rest } = data
+            if (!node || node.__typename !== 'LSIFUpload') {
+                throw new Error('No such LSIFUpload')
+            }
+
+            const matchesResult: UploadRetentionMatchesResult = { node, ...rest }
+            return matchesResult
+        }),
+        map(({ node, lsifUploads }) => {
+            const conn: Connection<NormalizedUploadRetentionMatch> = {
+                totalCount: (node.retentionPolicyOverview.totalCount ?? 0) + (lsifUploads.totalCount ?? 0) > 0 ? 1 : 0,
+                nodes: [],
+            }
+
+            if ((lsifUploads.totalCount ?? 0) > 0 && retentionByUploadTitle.toLowerCase().includes(query ?? '')) {
+                conn.nodes.push({
+                    matchType: 'UploadReference',
+                    uploadSlice: lsifUploads.nodes,
+                    total: lsifUploads.totalCount ?? 0,
+                })
+            }
+
+            conn.nodes.push(
+                ...node.retentionPolicyOverview.nodes.map(
+                    (node): NormalizedUploadRetentionMatch => ({
+                        matchType: 'RetentionPolicy',
+                        ...node,
+                        protectingCommits: node.protectingCommits ?? [],
+                    })
+                )
+            )
+
+            console.log(JSON.stringify(conn.nodes, null, 4))
+
+            conn.pageInfo = node.retentionPolicyOverview.pageInfo
+
+            return conn
+        })
+    )
+}

--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -56,6 +56,13 @@ type LSIFRepositoryUploadsQueryArgs struct {
 	RepositoryID graphql.ID
 }
 
+type LSIFUploadRetentionPolicyMatchesArgs struct {
+	MatchesOnly bool
+	First       *int32
+	After       *string
+	Query       *string
+}
+
 type LSIFUploadResolver interface {
 	ID() graphql.ID
 	InputCommit() string
@@ -70,6 +77,7 @@ type LSIFUploadResolver interface {
 	PlaceInQueue() *int32
 	AssociatedIndex(ctx context.Context) (LSIFIndexResolver, error)
 	ProjectRoot(ctx context.Context) (*GitTreeEntryResolver, error)
+	RetentionPolicyOverview(ctx context.Context, args *LSIFUploadRetentionPolicyMatchesArgs) (CodeIntelligenceRetentionPolicyMatchesConnectionResolver, error)
 }
 
 type LSIFUploadConnectionResolver interface {
@@ -337,4 +345,16 @@ type CodeIntelligenceConfigurationPolicyResolver interface {
 	IndexingEnabled() bool
 	IndexCommitMaxAgeHours() *int32
 	IndexIntermediateCommits() bool
+}
+
+type CodeIntelligenceRetentionPolicyMatchesConnectionResolver interface {
+	Nodes(ctx context.Context) ([]CodeIntelligenceRetentionPolicyMatchResolver, error)
+	TotalCount(ctx context.Context) (*int32, error)
+	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
+}
+
+type CodeIntelligenceRetentionPolicyMatchResolver interface {
+	ConfigurationPolicy() CodeIntelligenceConfigurationPolicyResolver
+	Matches() bool
+	ProtectingCommits() *[]string
 }

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -370,6 +370,39 @@ type CodeIntelligenceConfigurationPolicy implements Node {
     indexIntermediateCommits: Boolean!
 }
 
+type CodeIntelligenceRetentionPolicyMatch {
+    configurationPolicy: CodeIntelligenceConfigurationPolicy!
+
+    matches: Boolean!
+
+    protectingCommits: [String!]
+}
+
+type CodeIntelligenceRetentionByReference {
+    referencingUploads: [LSIFUpload!]!
+
+    total: Int!
+}
+
+union CodeIntelligenceRetentionReasons = CodeIntelligenceRetentionPolicyMatch | CodeIntelligenceRetentionByReference
+
+type CodeIntelligenceRetentionPolicyMatchesConnection {
+    """
+    A list of code intelligence retention policies matches.
+    """
+    nodes: [CodeIntelligenceRetentionPolicyMatch!]!
+
+    """
+    The total number of policies in this result set.
+    """
+    totalCount: Int
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
 extend type Repository {
     """
     Gets the indexing configuration associated with the repository.
@@ -1090,6 +1123,30 @@ type LSIFUpload implements Node {
     The LSIF indexing job that created this upload record.
     """
     associatedIndex: LSIFIndex
+
+    retentionPolicyOverview(
+        matchesOnly: Boolean!
+
+        """
+        An (optional) search query that searches over the name property.
+        """
+        query: String
+
+        """
+        When specified, indicates that this request should be paginated and
+        to fetch results starting at this cursor.
+        A future request can be made for more results by passing in the
+        'LocationConnection.pageInfo.endCursor' that is returned.
+        """
+        after: String
+
+        """
+        When specified, indicates that this request should be paginated and
+        the first N results (relative to the cursor) should be returned. i.e.
+        how many results to return per page.
+        """
+        first: Int
+    ): CodeIntelligenceRetentionPolicyMatchesConnection!
 }
 
 """

--- a/doc/cli/references/validate.md
+++ b/doc/cli/references/validate.md
@@ -42,6 +42,10 @@ Usage:
 or
     cat src-validate.yml | src validate [options]
 
+if user is authenticated, user can also run default checks
+
+	src validate [options]
+
 Please visit https://docs.sourcegraph.com/admin/validation for documentation of the validate command.
 
 

--- a/enterprise/cmd/frontend/internal/codeintel/init.go
+++ b/enterprise/cmd/frontend/internal/codeintel/init.go
@@ -67,7 +67,7 @@ func newResolver(ctx context.Context, db database.DB, observationContext *observ
 		db,
 	)
 
-	return codeintelgqlresolvers.NewResolver(db, innerResolver, &observation.Context{Sentry: observationContext.Sentry}), nil
+	return codeintelgqlresolvers.NewResolver(services.dbStore, services.gitserverClient, innerResolver, &observation.Context{Sentry: observationContext.Sentry}), nil
 }
 
 func newUploadHandler(services *Services) func(internal bool) http.Handler {

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index.go
@@ -9,6 +9,7 @@ import (
 
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -16,7 +17,8 @@ import (
 )
 
 type IndexResolver struct {
-	db               database.DB
+	db               *store.Store
+	gitserver        policies.GitserverClient
 	resolver         resolvers.Resolver
 	index            store.Index
 	prefetcher       *Prefetcher
@@ -24,7 +26,7 @@ type IndexResolver struct {
 	traceErrs        *observation.ErrCollector
 }
 
-func NewIndexResolver(db database.DB, resolver resolvers.Resolver, index store.Index, prefetcher *Prefetcher, locationResolver *CachedLocationResolver, errTrace *observation.ErrCollector) gql.LSIFIndexResolver {
+func NewIndexResolver(db *store.Store, gitserver policies.GitserverClient, resolver resolvers.Resolver, index store.Index, prefetcher *Prefetcher, locationResolver *CachedLocationResolver, errTrace *observation.ErrCollector) gql.LSIFIndexResolver {
 	if index.AssociatedUploadID != nil {
 		// Request the next batch of upload fetches to contain the record's associated
 		// upload id, if one exists it exists. This allows the prefetcher.GetUploadByID
@@ -35,6 +37,7 @@ func NewIndexResolver(db database.DB, resolver resolvers.Resolver, index store.I
 
 	return &IndexResolver{
 		db:               db,
+		gitserver:        gitserver,
 		resolver:         resolver,
 		index:            index,
 		prefetcher:       prefetcher,
@@ -52,7 +55,7 @@ func (r *IndexResolver) Failure() *string          { return r.index.FailureMessa
 func (r *IndexResolver) StartedAt() *gql.DateTime  { return gql.DateTimeOrNil(r.index.StartedAt) }
 func (r *IndexResolver) FinishedAt() *gql.DateTime { return gql.DateTimeOrNil(r.index.FinishedAt) }
 func (r *IndexResolver) Steps() gql.IndexStepsResolver {
-	return &indexStepsResolver{db: r.db, index: r.index}
+	return &indexStepsResolver{db: database.NewDBWith(r.db), index: r.index}
 }
 func (r *IndexResolver) PlaceInQueue() *int32 { return toInt32(r.index.Rank) }
 
@@ -80,7 +83,7 @@ func (r *IndexResolver) AssociatedUpload(ctx context.Context) (_ gql.LSIFUploadR
 		return nil, err
 	}
 
-	return NewUploadResolver(r.db, r.resolver, upload, r.prefetcher, r.locationResolver, r.traceErrs), nil
+	return NewUploadResolver(r.db, r.gitserver, r.resolver, upload, r.prefetcher, r.locationResolver, r.traceErrs), nil
 }
 
 func (r *IndexResolver) ProjectRoot(ctx context.Context) (_ *gql.GitTreeEntryResolver, err error) {

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index_connection.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index_connection.go
@@ -8,12 +8,14 @@ import (
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers"
-	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 type IndexConnectionResolver struct {
-	db               database.DB
+	db               *dbstore.Store
+	gitserver        policies.GitserverClient
 	resolver         resolvers.Resolver
 	indexesResolver  *resolvers.IndexesResolver
 	prefetcher       *Prefetcher
@@ -21,7 +23,7 @@ type IndexConnectionResolver struct {
 	errTracer        *observation.ErrCollector
 }
 
-func NewIndexConnectionResolver(db database.DB, resolver resolvers.Resolver, indexesResolver *resolvers.IndexesResolver, prefetcher *Prefetcher, locationResolver *CachedLocationResolver, errTracer *observation.ErrCollector) gql.LSIFIndexConnectionResolver {
+func NewIndexConnectionResolver(db *dbstore.Store, gitserver policies.GitserverClient, resolver resolvers.Resolver, indexesResolver *resolvers.IndexesResolver, prefetcher *Prefetcher, locationResolver *CachedLocationResolver, errTracer *observation.ErrCollector) gql.LSIFIndexConnectionResolver {
 	return &IndexConnectionResolver{
 		db:               db,
 		resolver:         resolver,
@@ -38,7 +40,7 @@ func (r *IndexConnectionResolver) Nodes(ctx context.Context) ([]gql.LSIFIndexRes
 
 	resolvers := make([]gql.LSIFIndexResolver, 0, len(r.indexesResolver.Indexes))
 	for i := range r.indexesResolver.Indexes {
-		resolvers = append(resolvers, NewIndexResolver(r.db, r.resolver, r.indexesResolver.Indexes[i], r.prefetcher, r.locationResolver, r.errTracer))
+		resolvers = append(resolvers, NewIndexResolver(r.db, r.gitserver, r.resolver, r.indexesResolver.Indexes[i], r.prefetcher, r.locationResolver, r.errTracer))
 	}
 	return resolvers, nil
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
@@ -14,6 +14,8 @@ import (
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -27,6 +29,7 @@ const (
 	DefaultIndexPageSize                   = 50
 	DefaultConfigurationPolicyPageSize     = 50
 	DefaultRepositoryFilterPreviewPageSize = 50
+	DefaultRetentionPolicyMatchesPageSize  = 50
 )
 
 var errAutoIndexingNotEnabled = errors.New("precise code intelligence auto-indexing is not enabled")
@@ -36,18 +39,22 @@ var errAutoIndexingNotEnabled = errors.New("precise code intelligence auto-index
 // All code intel-specific behavior is delegated to the underlying resolver instance, which is defined
 // in the parent package.
 type Resolver struct {
+	dbStore            *dbstore.Store
 	db                 database.DB
+	gitserver          policies.GitserverClient
 	resolver           resolvers.Resolver
 	locationResolver   *CachedLocationResolver
 	observationContext *operations
 }
 
 // NewResolver creates a new Resolver with the given resolver that defines all code intel-specific behavior.
-func NewResolver(db database.DB, resolver resolvers.Resolver, observationContext *observation.Context) gql.CodeIntelResolver {
+func NewResolver(dbStore *dbstore.Store, gitserver policies.GitserverClient, resolver resolvers.Resolver, observationContext *observation.Context) gql.CodeIntelResolver {
 	return &Resolver{
-		db:                 db,
+		dbStore:            dbStore,
+		db:                 database.NewDB(dbStore.Handle().DB()),
+		gitserver:          gitserver,
 		resolver:           resolver,
-		locationResolver:   NewCachedLocationResolver(db),
+		locationResolver:   NewCachedLocationResolver(database.NewDB(dbStore.Handle().DB())),
 		observationContext: newOperations(observationContext),
 	}
 }
@@ -91,7 +98,7 @@ func (r *Resolver) LSIFUploadByID(ctx context.Context, id graphql.ID) (_ gql.LSI
 		return nil, err
 	}
 
-	return NewUploadResolver(r.db, r.resolver, upload, prefetcher, r.locationResolver, traceErrs), nil
+	return NewUploadResolver(r.dbStore, r.gitserver, r.resolver, upload, prefetcher, r.locationResolver, traceErrs), nil
 }
 
 // 🚨 SECURITY: dbstore layer handles authz for GetUploads
@@ -119,7 +126,7 @@ func (r *Resolver) LSIFUploadsByRepo(ctx context.Context, args *gql.LSIFReposito
 	// the same graphQL request, not across different request.
 	prefetcher := NewPrefetcher(r.resolver)
 
-	return NewUploadConnectionResolver(r.db, r.resolver, r.resolver.UploadConnectionResolver(opts), prefetcher, r.locationResolver, traceErrs), nil
+	return NewUploadConnectionResolver(r.dbStore, r.gitserver, r.resolver, r.resolver.UploadConnectionResolver(opts), prefetcher, r.locationResolver, traceErrs), nil
 }
 
 // 🚨 SECURITY: Only site admins may modify code intelligence upload data
@@ -172,7 +179,7 @@ func (r *Resolver) LSIFIndexByID(ctx context.Context, id graphql.ID) (_ gql.LSIF
 		return nil, err
 	}
 
-	return NewIndexResolver(r.db, r.resolver, index, prefetcher, r.locationResolver, traceErrs), nil
+	return NewIndexResolver(r.dbStore, r.gitserver, r.resolver, index, prefetcher, r.locationResolver, traceErrs), nil
 }
 
 // 🚨 SECURITY: dbstore layer handles authz for GetIndexes
@@ -208,7 +215,7 @@ func (r *Resolver) LSIFIndexesByRepo(ctx context.Context, args *gql.LSIFReposito
 	// the same graphQL request, not across different request.
 	prefetcher := NewPrefetcher(r.resolver)
 
-	return NewIndexConnectionResolver(r.db, r.resolver, r.resolver.IndexConnectionResolver(opts), prefetcher, r.locationResolver, traceErrs), nil
+	return NewIndexConnectionResolver(r.dbStore, r.gitserver, r.resolver, r.resolver.IndexConnectionResolver(opts), prefetcher, r.locationResolver, traceErrs), nil
 }
 
 // 🚨 SECURITY: Only site admins may modify code intelligence index data
@@ -292,7 +299,7 @@ func (r *Resolver) QueueAutoIndexJobsForRepo(ctx context.Context, args *gql.Queu
 
 	resolvers := make([]gql.LSIFIndexResolver, 0, len(indexes))
 	for i := range indexes {
-		resolvers = append(resolvers, NewIndexResolver(r.db, r.resolver, indexes[i], prefetcher, r.locationResolver, traceErrs))
+		resolvers = append(resolvers, NewIndexResolver(r.dbStore, r.gitserver, r.resolver, indexes[i], prefetcher, r.locationResolver, traceErrs))
 	}
 	return resolvers, nil
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver_test.go
@@ -12,6 +12,7 @@ import (
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	resolvermocks "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -28,11 +29,12 @@ func TestDeleteLSIFUpload(t *testing.T) {
 
 	db := database.NewStrictMockDB()
 	db.UsersFunc.SetDefaultReturn(users)
+	dbStore := dbstore.NewWithDB(db, &observation.TestContext)
 
 	id := graphql.ID(base64.StdEncoding.EncodeToString([]byte("LSIFUpload:42")))
 	mockResolver := resolvermocks.NewMockResolver()
 
-	if _, err := NewResolver(db, mockResolver, &observation.TestContext).DeleteLSIFUpload(context.Background(), &struct{ ID graphql.ID }{id}); err != nil {
+	if _, err := NewResolver(dbStore, nil, mockResolver, &observation.TestContext).DeleteLSIFUpload(context.Background(), &struct{ ID graphql.ID }{id}); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -46,11 +48,12 @@ func TestDeleteLSIFUpload(t *testing.T) {
 
 func TestDeleteLSIFUploadUnauthenticated(t *testing.T) {
 	db := database.NewDB(nil)
+	dbStore := dbstore.NewWithDB(db, &observation.TestContext)
 
 	id := graphql.ID(base64.StdEncoding.EncodeToString([]byte("LSIFUpload:42")))
 	mockResolver := resolvermocks.NewMockResolver()
 
-	if _, err := NewResolver(db, mockResolver, &observation.TestContext).DeleteLSIFUpload(context.Background(), &struct{ ID graphql.ID }{id}); err != backend.ErrNotAuthenticated {
+	if _, err := NewResolver(dbStore, nil, mockResolver, &observation.TestContext).DeleteLSIFUpload(context.Background(), &struct{ ID graphql.ID }{id}); err != backend.ErrNotAuthenticated {
 		t.Errorf("unexpected error. want=%q have=%q", backend.ErrNotAuthenticated, err)
 	}
 }
@@ -61,11 +64,12 @@ func TestDeleteLSIFIndex(t *testing.T) {
 
 	db := database.NewStrictMockDB()
 	db.UsersFunc.SetDefaultReturn(users)
+	dbStore := dbstore.NewWithDB(db, &observation.TestContext)
 
 	id := graphql.ID(base64.StdEncoding.EncodeToString([]byte("LSIFIndex:42")))
 	mockResolver := resolvermocks.NewMockResolver()
 
-	if _, err := NewResolver(db, mockResolver, &observation.TestContext).DeleteLSIFIndex(context.Background(), &struct{ ID graphql.ID }{id}); err != nil {
+	if _, err := NewResolver(dbStore, nil, mockResolver, &observation.TestContext).DeleteLSIFIndex(context.Background(), &struct{ ID graphql.ID }{id}); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -79,11 +83,12 @@ func TestDeleteLSIFIndex(t *testing.T) {
 
 func TestDeleteLSIFIndexUnauthenticated(t *testing.T) {
 	db := database.NewDB(nil)
+	dbStore := dbstore.NewWithDB(db, &observation.TestContext)
 
 	id := graphql.ID(base64.StdEncoding.EncodeToString([]byte("LSIFIndex:42")))
 	mockResolver := resolvermocks.NewMockResolver()
 
-	if _, err := NewResolver(db, mockResolver, &observation.TestContext).DeleteLSIFIndex(context.Background(), &struct{ ID graphql.ID }{id}); err != backend.ErrNotAuthenticated {
+	if _, err := NewResolver(dbStore, nil, mockResolver, &observation.TestContext).DeleteLSIFIndex(context.Background(), &struct{ ID graphql.ID }{id}); err != backend.ErrNotAuthenticated {
 		t.Errorf("unexpected error. want=%q have=%q", backend.ErrNotAuthenticated, err)
 	}
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/retention_policy_matcher_connection.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/retention_policy_matcher_connection.go
@@ -1,0 +1,47 @@
+package graphql
+
+import (
+	"context"
+
+	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+type codeIntelligenceRetentionPolicyMatcherConnectionResolver struct {
+	db         database.DB
+	resolver   resolvers.Resolver
+	policies   []retentionPolicyMatchCandidate
+	totalCount int
+	errTracer  *observation.ErrCollector
+}
+
+func NewCodeIntelligenceRetentionPolicyMatcherConnectionResolver(db database.DB, resolver resolvers.Resolver, policies []retentionPolicyMatchCandidate, totalCount int, errTracer *observation.ErrCollector) *codeIntelligenceRetentionPolicyMatcherConnectionResolver {
+	return &codeIntelligenceRetentionPolicyMatcherConnectionResolver{
+		db:         db,
+		resolver:   resolver,
+		policies:   policies,
+		totalCount: totalCount,
+		errTracer:  errTracer,
+	}
+}
+
+func (r *codeIntelligenceRetentionPolicyMatcherConnectionResolver) Nodes(ctx context.Context) ([]gql.CodeIntelligenceRetentionPolicyMatchResolver, error) {
+	resolvers := make([]gql.CodeIntelligenceRetentionPolicyMatchResolver, 0, len(r.policies))
+	for _, policy := range r.policies {
+		resolvers = append(resolvers, NewRetentionPolicyMatcherResolver(r.db, policy))
+	}
+
+	return resolvers, nil
+}
+
+func (r *codeIntelligenceRetentionPolicyMatcherConnectionResolver) TotalCount(ctx context.Context) (*int32, error) {
+	v := int32(r.totalCount)
+	return &v, nil
+}
+
+func (r *codeIntelligenceRetentionPolicyMatcherConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	return graphqlutil.HasNextPage(len(r.policies) < r.totalCount), nil
+}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/retention_policy_matches.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/retention_policy_matches.go
@@ -1,0 +1,36 @@
+package graphql
+
+import (
+	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+type RetentionPolicyMatcherResolver struct {
+	db           database.DB
+	policy       retentionPolicyMatchCandidate
+	errCollector *observation.ErrCollector
+}
+
+type retentionPolicyMatchCandidate struct {
+	dbstore.ConfigurationPolicy
+	matched           bool
+	protectingCommits []string
+}
+
+func NewRetentionPolicyMatcherResolver(db database.DB, policy retentionPolicyMatchCandidate) *RetentionPolicyMatcherResolver {
+	return &RetentionPolicyMatcherResolver{db: db, policy: policy}
+}
+
+func (r *RetentionPolicyMatcherResolver) ConfigurationPolicy() gql.CodeIntelligenceConfigurationPolicyResolver {
+	return NewConfigurationPolicyResolver(r.db, r.policy.ConfigurationPolicy, r.errCollector)
+}
+
+func (r *RetentionPolicyMatcherResolver) Matches() bool {
+	return r.policy.matched
+}
+
+func (r *RetentionPolicyMatcherResolver) ProtectingCommits() *[]string {
+	return &r.policy.protectingCommits
+}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/upload.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/upload.go
@@ -2,29 +2,34 @@ package graphql
 
 import (
 	"context"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/opentracing/opentracing-go/log"
+	"github.com/pkg/errors"
 
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers"
-	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 type UploadResolver struct {
-	db               database.DB
+	db               *dbstore.Store
+	gitserver        policies.GitserverClient
 	resolver         resolvers.Resolver
-	upload           store.Upload
+	upload           dbstore.Upload
 	prefetcher       *Prefetcher
 	locationResolver *CachedLocationResolver
 	traceErrs        *observation.ErrCollector
 }
 
-func NewUploadResolver(db database.DB, resolver resolvers.Resolver, upload store.Upload, prefetcher *Prefetcher, locationResolver *CachedLocationResolver, traceErrs *observation.ErrCollector) gql.LSIFUploadResolver {
+func NewUploadResolver(db *dbstore.Store, gitserver policies.GitserverClient, resolver resolvers.Resolver, upload dbstore.Upload, prefetcher *Prefetcher, locationResolver *CachedLocationResolver, traceErrs *observation.ErrCollector) gql.LSIFUploadResolver {
 	if upload.AssociatedIndexID != nil {
 		// Request the next batch of index fetches to contain the record's associated
 		// index id, if one exists it exists. This allows the prefetcher.GetIndexByID
@@ -35,6 +40,7 @@ func NewUploadResolver(db database.DB, resolver resolvers.Resolver, upload store
 
 	return &UploadResolver{
 		db:               db,
+		gitserver:        gitserver,
 		resolver:         resolver,
 		upload:           upload,
 		prefetcher:       prefetcher,
@@ -79,9 +85,149 @@ func (r *UploadResolver) AssociatedIndex(ctx context.Context) (_ gql.LSIFIndexRe
 		return nil, err
 	}
 
-	return NewIndexResolver(r.db, r.resolver, index, r.prefetcher, r.locationResolver, r.traceErrs), nil
+	return NewIndexResolver(r.db, r.gitserver, r.resolver, index, r.prefetcher, r.locationResolver, r.traceErrs), nil
 }
 
 func (r *UploadResolver) ProjectRoot(ctx context.Context) (*gql.GitTreeEntryResolver, error) {
 	return r.locationResolver.Path(ctx, api.RepoID(r.upload.RepositoryID), r.upload.Commit, r.upload.Root)
+}
+
+func (r *UploadResolver) RetentionPolicyOverview(ctx context.Context, args *gql.LSIFUploadRetentionPolicyMatchesArgs) (_ gql.CodeIntelligenceRetentionPolicyMatchesConnectionResolver, err error) {
+	var afterID int64
+	if args.After != nil {
+		afterID, err = unmarshalConfigurationPolicyGQLID(graphql.ID(*args.After))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	pageSize := DefaultRetentionPolicyMatchesPageSize
+	if args.First != nil {
+		pageSize = int(*args.First)
+	}
+
+	policyMatcher := policies.NewMatcher(r.gitserver, policies.RetentionExtractor, false, false)
+
+	var term string
+	if args.Query != nil {
+		term = *args.Query
+	}
+
+	policies, _, err := r.resolver.GetConfigurationPolicies(ctx, dbstore.GetConfigurationPoliciesOptions{
+		RepositoryID:     r.upload.RepositoryID,
+		Term:             term,
+		ForDataRetention: true,
+		Limit:            pageSize,
+		Offset:           int(afterID),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	visibileCommits, err := r.commitsVisibleToUpload(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	matchingPolicies, err := policyMatcher.CommitsDescribedByPolicy(ctx, r.upload.RepositoryID, policies, time.Now(), visibileCommits...)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		now                    = time.Now()
+		potentialMatchIndexSet map[int]int // map of polciy ID to array index
+		potentialMatches       []retentionPolicyMatchCandidate
+	)
+
+	if args.MatchesOnly {
+		potentialMatches, _ = r.populateMatchingCommits(visibileCommits, matchingPolicies, policies, now)
+	} else {
+		potentialMatches, potentialMatchIndexSet = r.populateMatchingCommits(visibileCommits, matchingPolicies, policies, now)
+
+		// populate with remaining unmatched policies
+		for _, policy := range policies {
+			if _, ok := potentialMatchIndexSet[policy.ID]; !ok {
+				potentialMatches = append(potentialMatches, retentionPolicyMatchCandidate{
+					ConfigurationPolicy: policy,
+					matched:             false,
+				})
+			}
+		}
+	}
+
+	sort.Slice(potentialMatches, func(i, j int) bool {
+		return potentialMatches[i].ID < potentialMatches[j].ID
+	})
+
+	return NewCodeIntelligenceRetentionPolicyMatcherConnectionResolver(database.NewDBWith(r.db), r.resolver, potentialMatches, len(potentialMatches), r.traceErrs), nil
+}
+
+func (r *UploadResolver) commitsVisibleToUpload(ctx context.Context) (commits []string, err error) {
+	var token *string
+	for first := true; first || token != nil; first = false {
+		cs, nextToken, err := r.db.CommitsVisibleToUpload(ctx, r.upload.ID, 50, token)
+		if err != nil {
+			return nil, errors.Wrap(err, "dbstore.CommitsVisibleToUpload")
+		}
+		token = nextToken
+
+		commits = append(commits, cs...)
+	}
+
+	return
+}
+
+func (r *UploadResolver) populateMatchingCommits(visibileCommits []string, matchingPolicies map[string][]policies.PolicyMatch, policies []dbstore.ConfigurationPolicy, now time.Time) ([]retentionPolicyMatchCandidate, map[int]int) {
+	var (
+		potentialMatches       = make([]retentionPolicyMatchCandidate, 0, len(policies))
+		potentialMatchIndexSet = make(map[int]int, len(policies))
+	)
+
+	// First add all matches for the commit of this upload. We do this to ensure that if a policy matches both the upload's commit
+	// and a visible commit, we ensure an entry for that policy is only added for the upload's commit. This makes the logic in checking
+	// the visible commits a bit simpler, as we don't have to check if policy X has already been added for a visible commit in the case
+	// that the upload's commit is not first in the list.
+	if policyMatches, ok := matchingPolicies[r.upload.Commit]; ok {
+		for _, policyMatch := range policyMatches {
+			potentialMatches = append(potentialMatches, retentionPolicyMatchCandidate{
+				ConfigurationPolicy: *policyByID(policies, *policyMatch.PolicyID),
+				matched:             true,
+			})
+			potentialMatchIndexSet[*policyMatch.PolicyID] = len(potentialMatches)
+		}
+	}
+
+	for _, commit := range visibileCommits {
+		if commit == r.upload.Commit {
+			continue
+		}
+		if policyMatches, ok := matchingPolicies[commit]; ok {
+			for _, policyMatch := range policyMatches {
+				if policyMatch.PolicyDuration == nil || now.Sub(r.upload.UploadedAt) < *policyMatch.PolicyDuration {
+					if index, ok := potentialMatchIndexSet[*policyMatch.PolicyID]; ok && potentialMatches[index].protectingCommits != nil {
+						potentialMatches[index].protectingCommits = append(potentialMatches[index].protectingCommits, commit)
+					} else {
+						potentialMatches = append(potentialMatches, retentionPolicyMatchCandidate{
+							ConfigurationPolicy: *policyByID(policies, *policyMatch.PolicyID),
+							matched:             true,
+							protectingCommits:   []string{commit},
+						})
+						potentialMatchIndexSet[*policyMatch.PolicyID] = len(potentialMatches)
+					}
+				}
+			}
+		}
+	}
+
+	return potentialMatches, potentialMatchIndexSet
+}
+
+func policyByID(policies []dbstore.ConfigurationPolicy, id int) *dbstore.ConfigurationPolicy {
+	for _, policy := range policies {
+		if policy.ID == id {
+			return &policy
+		}
+	}
+	return nil
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/upload_connection.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/upload_connection.go
@@ -8,12 +8,14 @@ import (
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers"
-	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 type UploadConnectionResolver struct {
-	db               database.DB
+	db               *dbstore.Store
+	gitserver        policies.GitserverClient
 	resolver         resolvers.Resolver
 	uploadsResolver  *resolvers.UploadsResolver
 	prefetcher       *Prefetcher
@@ -21,9 +23,11 @@ type UploadConnectionResolver struct {
 	errTracer        *observation.ErrCollector
 }
 
-func NewUploadConnectionResolver(db database.DB, resolver resolvers.Resolver, uploadsResolver *resolvers.UploadsResolver, prefetcher *Prefetcher, locationResolver *CachedLocationResolver, errTracer *observation.ErrCollector) gql.LSIFUploadConnectionResolver {
+func NewUploadConnectionResolver(db *dbstore.Store, gitserver policies.GitserverClient, resolver resolvers.Resolver, uploadsResolver *resolvers.UploadsResolver, prefetcher *Prefetcher, locationResolver *CachedLocationResolver, errTracer *observation.ErrCollector) gql.LSIFUploadConnectionResolver {
 	return &UploadConnectionResolver{
 		resolver:         resolver,
+		db:               db,
+		gitserver:        gitserver,
 		uploadsResolver:  uploadsResolver,
 		prefetcher:       prefetcher,
 		locationResolver: locationResolver,
@@ -38,7 +42,7 @@ func (r *UploadConnectionResolver) Nodes(ctx context.Context) ([]gql.LSIFUploadR
 
 	resolvers := make([]gql.LSIFUploadResolver, 0, len(r.uploadsResolver.Uploads))
 	for i := range r.uploadsResolver.Uploads {
-		resolvers = append(resolvers, NewUploadResolver(r.db, r.resolver, r.uploadsResolver.Uploads[i], r.prefetcher, r.locationResolver, r.errTracer))
+		resolvers = append(resolvers, NewUploadResolver(r.db, r.gitserver, r.resolver, r.uploadsResolver.Uploads[i], r.prefetcher, r.locationResolver, r.errTracer))
 	}
 	return resolvers, nil
 }

--- a/enterprise/cmd/worker/internal/codeintel/commitgraph/iface.go
+++ b/enterprise/cmd/worker/internal/codeintel/commitgraph/iface.go
@@ -28,6 +28,6 @@ type Locker interface {
 }
 
 type GitserverClient interface {
-	RefDescriptions(ctx context.Context, repositoryID int) (map[string][]gitdomain.RefDescription, error)
+	RefDescriptions(ctx context.Context, repositoryID int, gitOjbs ...string) (map[string][]gitdomain.RefDescription, error)
 	CommitGraph(ctx context.Context, repositoryID int, options git.CommitGraphOptions) (*gitdomain.CommitGraph, error)
 }

--- a/enterprise/cmd/worker/internal/codeintel/commitgraph/mock_iface_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/commitgraph/mock_iface_test.go
@@ -456,7 +456,7 @@ func NewMockGitserverClient() *MockGitserverClient {
 			},
 		},
 		RefDescriptionsFunc: &GitserverClientRefDescriptionsFunc{
-			defaultHook: func(context.Context, int) (map[string][]gitdomain.RefDescription, error) {
+			defaultHook: func(context.Context, int, ...string) (map[string][]gitdomain.RefDescription, error) {
 				return nil, nil
 			},
 		},
@@ -473,7 +473,7 @@ func NewStrictMockGitserverClient() *MockGitserverClient {
 			},
 		},
 		RefDescriptionsFunc: &GitserverClientRefDescriptionsFunc{
-			defaultHook: func(context.Context, int) (map[string][]gitdomain.RefDescription, error) {
+			defaultHook: func(context.Context, int, ...string) (map[string][]gitdomain.RefDescription, error) {
 				panic("unexpected invocation of MockGitserverClient.RefDescriptions")
 			},
 		},
@@ -610,24 +610,24 @@ func (c GitserverClientCommitGraphFuncCall) Results() []interface{} {
 // RefDescriptions method of the parent MockGitserverClient instance is
 // invoked.
 type GitserverClientRefDescriptionsFunc struct {
-	defaultHook func(context.Context, int) (map[string][]gitdomain.RefDescription, error)
-	hooks       []func(context.Context, int) (map[string][]gitdomain.RefDescription, error)
+	defaultHook func(context.Context, int, ...string) (map[string][]gitdomain.RefDescription, error)
+	hooks       []func(context.Context, int, ...string) (map[string][]gitdomain.RefDescription, error)
 	history     []GitserverClientRefDescriptionsFuncCall
 	mutex       sync.Mutex
 }
 
 // RefDescriptions delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockGitserverClient) RefDescriptions(v0 context.Context, v1 int) (map[string][]gitdomain.RefDescription, error) {
-	r0, r1 := m.RefDescriptionsFunc.nextHook()(v0, v1)
-	m.RefDescriptionsFunc.appendCall(GitserverClientRefDescriptionsFuncCall{v0, v1, r0, r1})
+func (m *MockGitserverClient) RefDescriptions(v0 context.Context, v1 int, v2 ...string) (map[string][]gitdomain.RefDescription, error) {
+	r0, r1 := m.RefDescriptionsFunc.nextHook()(v0, v1, v2...)
+	m.RefDescriptionsFunc.appendCall(GitserverClientRefDescriptionsFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the RefDescriptions
 // method of the parent MockGitserverClient instance is invoked and the hook
 // queue is empty.
-func (f *GitserverClientRefDescriptionsFunc) SetDefaultHook(hook func(context.Context, int) (map[string][]gitdomain.RefDescription, error)) {
+func (f *GitserverClientRefDescriptionsFunc) SetDefaultHook(hook func(context.Context, int, ...string) (map[string][]gitdomain.RefDescription, error)) {
 	f.defaultHook = hook
 }
 
@@ -635,7 +635,7 @@ func (f *GitserverClientRefDescriptionsFunc) SetDefaultHook(hook func(context.Co
 // RefDescriptions method of the parent MockGitserverClient instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *GitserverClientRefDescriptionsFunc) PushHook(hook func(context.Context, int) (map[string][]gitdomain.RefDescription, error)) {
+func (f *GitserverClientRefDescriptionsFunc) PushHook(hook func(context.Context, int, ...string) (map[string][]gitdomain.RefDescription, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -644,7 +644,7 @@ func (f *GitserverClientRefDescriptionsFunc) PushHook(hook func(context.Context,
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *GitserverClientRefDescriptionsFunc) SetDefaultReturn(r0 map[string][]gitdomain.RefDescription, r1 error) {
-	f.SetDefaultHook(func(context.Context, int) (map[string][]gitdomain.RefDescription, error) {
+	f.SetDefaultHook(func(context.Context, int, ...string) (map[string][]gitdomain.RefDescription, error) {
 		return r0, r1
 	})
 }
@@ -652,12 +652,12 @@ func (f *GitserverClientRefDescriptionsFunc) SetDefaultReturn(r0 map[string][]gi
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *GitserverClientRefDescriptionsFunc) PushReturn(r0 map[string][]gitdomain.RefDescription, r1 error) {
-	f.PushHook(func(context.Context, int) (map[string][]gitdomain.RefDescription, error) {
+	f.PushHook(func(context.Context, int, ...string) (map[string][]gitdomain.RefDescription, error) {
 		return r0, r1
 	})
 }
 
-func (f *GitserverClientRefDescriptionsFunc) nextHook() func(context.Context, int) (map[string][]gitdomain.RefDescription, error) {
+func (f *GitserverClientRefDescriptionsFunc) nextHook() func(context.Context, int, ...string) (map[string][]gitdomain.RefDescription, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -697,6 +697,9 @@ type GitserverClientRefDescriptionsFuncCall struct {
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
 	Arg1 int
+	// Arg2 is a slice containing the values of the variadic arguments
+	// passed to this method invocation.
+	Arg2 []string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 map[string][]gitdomain.RefDescription
@@ -706,9 +709,16 @@ type GitserverClientRefDescriptionsFuncCall struct {
 }
 
 // Args returns an interface slice containing the arguments of this
-// invocation.
+// invocation. The variadic slice argument is flattened in this array such
+// that one positional argument and three variadic arguments would result in
+// a slice of four, not two.
 func (c GitserverClientRefDescriptionsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+	trailing := []interface{}{}
+	for _, val := range c.Arg2 {
+		trailing = append(trailing, val)
+	}
+
+	return append([]interface{}{c.Arg0, c.Arg1}, trailing...)
 }
 
 // Results returns an interface slice containing the results of this

--- a/enterprise/cmd/worker/internal/codeintel/indexing/iface.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/iface.go
@@ -69,5 +69,5 @@ type IndexEnqueuer interface {
 }
 
 type PolicyMatcher interface {
-	CommitsDescribedByPolicy(ctx context.Context, repositoryID int, policies []dbstore.ConfigurationPolicy, now time.Time) (map[string][]policies.PolicyMatch, error)
+	CommitsDescribedByPolicy(ctx context.Context, repositoryID int, policies []dbstore.ConfigurationPolicy, now time.Time, filterCommits ...string) (map[string][]policies.PolicyMatch, error)
 }

--- a/enterprise/cmd/worker/internal/codeintel/indexing/index_scheduler_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/index_scheduler_test.go
@@ -84,7 +84,6 @@ func TestIndexScheduler(t *testing.T) {
 	if len(enqueueCalls) != 8 {
 		t.Fatalf("unexpected number of calls to QueueIndexes. want=%d have=%d", 8, len(indexEnqueuer.QueueIndexesFunc.History()))
 	}
-
 }
 
 func testIndexSchedulerMockDBStore() *MockDBStore {
@@ -161,7 +160,7 @@ func testIndexSchedulerMockPolicyMatcher(now time.Time) *MockPolicyMatcher {
 		},
 	}
 
-	commitsDescribedByPolicy := func(ctx context.Context, repositoryID int, policies []dbstore.ConfigurationPolicy, now time.Time) (map[string][]policies.PolicyMatch, error) {
+	commitsDescribedByPolicy := func(ctx context.Context, repositoryID int, policies []dbstore.ConfigurationPolicy, now time.Time, _ ...string) (map[string][]policies.PolicyMatch, error) {
 		return policyMatches[repositoryID], nil
 	}
 

--- a/enterprise/cmd/worker/internal/codeintel/indexing/mock_iface_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/mock_iface_test.go
@@ -2929,7 +2929,7 @@ type MockPolicyMatcher struct {
 func NewMockPolicyMatcher() *MockPolicyMatcher {
 	return &MockPolicyMatcher{
 		CommitsDescribedByPolicyFunc: &PolicyMatcherCommitsDescribedByPolicyFunc{
-			defaultHook: func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time) (map[string][]policies.PolicyMatch, error) {
+			defaultHook: func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time, ...string) (map[string][]policies.PolicyMatch, error) {
 				return nil, nil
 			},
 		},
@@ -2941,7 +2941,7 @@ func NewMockPolicyMatcher() *MockPolicyMatcher {
 func NewStrictMockPolicyMatcher() *MockPolicyMatcher {
 	return &MockPolicyMatcher{
 		CommitsDescribedByPolicyFunc: &PolicyMatcherCommitsDescribedByPolicyFunc{
-			defaultHook: func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time) (map[string][]policies.PolicyMatch, error) {
+			defaultHook: func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time, ...string) (map[string][]policies.PolicyMatch, error) {
 				panic("unexpected invocation of MockPolicyMatcher.CommitsDescribedByPolicy")
 			},
 		},
@@ -2963,24 +2963,24 @@ func NewMockPolicyMatcherFrom(i PolicyMatcher) *MockPolicyMatcher {
 // CommitsDescribedByPolicy method of the parent MockPolicyMatcher instance
 // is invoked.
 type PolicyMatcherCommitsDescribedByPolicyFunc struct {
-	defaultHook func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time) (map[string][]policies.PolicyMatch, error)
-	hooks       []func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time) (map[string][]policies.PolicyMatch, error)
+	defaultHook func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time, ...string) (map[string][]policies.PolicyMatch, error)
+	hooks       []func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time, ...string) (map[string][]policies.PolicyMatch, error)
 	history     []PolicyMatcherCommitsDescribedByPolicyFuncCall
 	mutex       sync.Mutex
 }
 
 // CommitsDescribedByPolicy delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockPolicyMatcher) CommitsDescribedByPolicy(v0 context.Context, v1 int, v2 []dbstore.ConfigurationPolicy, v3 time.Time) (map[string][]policies.PolicyMatch, error) {
-	r0, r1 := m.CommitsDescribedByPolicyFunc.nextHook()(v0, v1, v2, v3)
-	m.CommitsDescribedByPolicyFunc.appendCall(PolicyMatcherCommitsDescribedByPolicyFuncCall{v0, v1, v2, v3, r0, r1})
+func (m *MockPolicyMatcher) CommitsDescribedByPolicy(v0 context.Context, v1 int, v2 []dbstore.ConfigurationPolicy, v3 time.Time, v4 ...string) (map[string][]policies.PolicyMatch, error) {
+	r0, r1 := m.CommitsDescribedByPolicyFunc.nextHook()(v0, v1, v2, v3, v4...)
+	m.CommitsDescribedByPolicyFunc.appendCall(PolicyMatcherCommitsDescribedByPolicyFuncCall{v0, v1, v2, v3, v4, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
 // CommitsDescribedByPolicy method of the parent MockPolicyMatcher instance
 // is invoked and the hook queue is empty.
-func (f *PolicyMatcherCommitsDescribedByPolicyFunc) SetDefaultHook(hook func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time) (map[string][]policies.PolicyMatch, error)) {
+func (f *PolicyMatcherCommitsDescribedByPolicyFunc) SetDefaultHook(hook func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time, ...string) (map[string][]policies.PolicyMatch, error)) {
 	f.defaultHook = hook
 }
 
@@ -2989,7 +2989,7 @@ func (f *PolicyMatcherCommitsDescribedByPolicyFunc) SetDefaultHook(hook func(con
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *PolicyMatcherCommitsDescribedByPolicyFunc) PushHook(hook func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time) (map[string][]policies.PolicyMatch, error)) {
+func (f *PolicyMatcherCommitsDescribedByPolicyFunc) PushHook(hook func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time, ...string) (map[string][]policies.PolicyMatch, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2998,7 +2998,7 @@ func (f *PolicyMatcherCommitsDescribedByPolicyFunc) PushHook(hook func(context.C
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *PolicyMatcherCommitsDescribedByPolicyFunc) SetDefaultReturn(r0 map[string][]policies.PolicyMatch, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time) (map[string][]policies.PolicyMatch, error) {
+	f.SetDefaultHook(func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time, ...string) (map[string][]policies.PolicyMatch, error) {
 		return r0, r1
 	})
 }
@@ -3006,12 +3006,12 @@ func (f *PolicyMatcherCommitsDescribedByPolicyFunc) SetDefaultReturn(r0 map[stri
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *PolicyMatcherCommitsDescribedByPolicyFunc) PushReturn(r0 map[string][]policies.PolicyMatch, r1 error) {
-	f.PushHook(func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time) (map[string][]policies.PolicyMatch, error) {
+	f.PushHook(func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time, ...string) (map[string][]policies.PolicyMatch, error) {
 		return r0, r1
 	})
 }
 
-func (f *PolicyMatcherCommitsDescribedByPolicyFunc) nextHook() func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time) (map[string][]policies.PolicyMatch, error) {
+func (f *PolicyMatcherCommitsDescribedByPolicyFunc) nextHook() func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time, ...string) (map[string][]policies.PolicyMatch, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3058,6 +3058,9 @@ type PolicyMatcherCommitsDescribedByPolicyFuncCall struct {
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
 	Arg3 time.Time
+	// Arg4 is a slice containing the values of the variadic arguments
+	// passed to this method invocation.
+	Arg4 []string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 map[string][]policies.PolicyMatch
@@ -3067,9 +3070,16 @@ type PolicyMatcherCommitsDescribedByPolicyFuncCall struct {
 }
 
 // Args returns an interface slice containing the arguments of this
-// invocation.
+// invocation. The variadic slice argument is flattened in this array such
+// that one positional argument and three variadic arguments would result in
+// a slice of four, not two.
 func (c PolicyMatcherCommitsDescribedByPolicyFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+	trailing := []interface{}{}
+	for _, val := range c.Arg4 {
+		trailing = append(trailing, val)
+	}
+
+	return append([]interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}, trailing...)
 }
 
 // Results returns an interface slice containing the results of this

--- a/enterprise/cmd/worker/internal/codeintel/janitor/iface.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/iface.go
@@ -71,5 +71,5 @@ func (s *LSIFStoreShim) Transact(ctx context.Context) (LSIFStore, error) {
 }
 
 type PolicyMatcher interface {
-	CommitsDescribedByPolicy(ctx context.Context, repositoryID int, policies []dbstore.ConfigurationPolicy, now time.Time) (map[string][]policies.PolicyMatch, error)
+	CommitsDescribedByPolicy(ctx context.Context, repositoryID int, policies []dbstore.ConfigurationPolicy, now time.Time, filterCommits ...string) (map[string][]policies.PolicyMatch, error)
 }

--- a/enterprise/cmd/worker/internal/codeintel/janitor/mock_iface_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/mock_iface_test.go
@@ -3160,7 +3160,7 @@ type MockPolicyMatcher struct {
 func NewMockPolicyMatcher() *MockPolicyMatcher {
 	return &MockPolicyMatcher{
 		CommitsDescribedByPolicyFunc: &PolicyMatcherCommitsDescribedByPolicyFunc{
-			defaultHook: func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time) (map[string][]policies.PolicyMatch, error) {
+			defaultHook: func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time, ...string) (map[string][]policies.PolicyMatch, error) {
 				return nil, nil
 			},
 		},
@@ -3172,7 +3172,7 @@ func NewMockPolicyMatcher() *MockPolicyMatcher {
 func NewStrictMockPolicyMatcher() *MockPolicyMatcher {
 	return &MockPolicyMatcher{
 		CommitsDescribedByPolicyFunc: &PolicyMatcherCommitsDescribedByPolicyFunc{
-			defaultHook: func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time) (map[string][]policies.PolicyMatch, error) {
+			defaultHook: func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time, ...string) (map[string][]policies.PolicyMatch, error) {
 				panic("unexpected invocation of MockPolicyMatcher.CommitsDescribedByPolicy")
 			},
 		},
@@ -3194,24 +3194,24 @@ func NewMockPolicyMatcherFrom(i PolicyMatcher) *MockPolicyMatcher {
 // CommitsDescribedByPolicy method of the parent MockPolicyMatcher instance
 // is invoked.
 type PolicyMatcherCommitsDescribedByPolicyFunc struct {
-	defaultHook func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time) (map[string][]policies.PolicyMatch, error)
-	hooks       []func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time) (map[string][]policies.PolicyMatch, error)
+	defaultHook func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time, ...string) (map[string][]policies.PolicyMatch, error)
+	hooks       []func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time, ...string) (map[string][]policies.PolicyMatch, error)
 	history     []PolicyMatcherCommitsDescribedByPolicyFuncCall
 	mutex       sync.Mutex
 }
 
 // CommitsDescribedByPolicy delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockPolicyMatcher) CommitsDescribedByPolicy(v0 context.Context, v1 int, v2 []dbstore.ConfigurationPolicy, v3 time.Time) (map[string][]policies.PolicyMatch, error) {
-	r0, r1 := m.CommitsDescribedByPolicyFunc.nextHook()(v0, v1, v2, v3)
-	m.CommitsDescribedByPolicyFunc.appendCall(PolicyMatcherCommitsDescribedByPolicyFuncCall{v0, v1, v2, v3, r0, r1})
+func (m *MockPolicyMatcher) CommitsDescribedByPolicy(v0 context.Context, v1 int, v2 []dbstore.ConfigurationPolicy, v3 time.Time, v4 ...string) (map[string][]policies.PolicyMatch, error) {
+	r0, r1 := m.CommitsDescribedByPolicyFunc.nextHook()(v0, v1, v2, v3, v4...)
+	m.CommitsDescribedByPolicyFunc.appendCall(PolicyMatcherCommitsDescribedByPolicyFuncCall{v0, v1, v2, v3, v4, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
 // CommitsDescribedByPolicy method of the parent MockPolicyMatcher instance
 // is invoked and the hook queue is empty.
-func (f *PolicyMatcherCommitsDescribedByPolicyFunc) SetDefaultHook(hook func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time) (map[string][]policies.PolicyMatch, error)) {
+func (f *PolicyMatcherCommitsDescribedByPolicyFunc) SetDefaultHook(hook func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time, ...string) (map[string][]policies.PolicyMatch, error)) {
 	f.defaultHook = hook
 }
 
@@ -3220,7 +3220,7 @@ func (f *PolicyMatcherCommitsDescribedByPolicyFunc) SetDefaultHook(hook func(con
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *PolicyMatcherCommitsDescribedByPolicyFunc) PushHook(hook func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time) (map[string][]policies.PolicyMatch, error)) {
+func (f *PolicyMatcherCommitsDescribedByPolicyFunc) PushHook(hook func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time, ...string) (map[string][]policies.PolicyMatch, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3229,7 +3229,7 @@ func (f *PolicyMatcherCommitsDescribedByPolicyFunc) PushHook(hook func(context.C
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *PolicyMatcherCommitsDescribedByPolicyFunc) SetDefaultReturn(r0 map[string][]policies.PolicyMatch, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time) (map[string][]policies.PolicyMatch, error) {
+	f.SetDefaultHook(func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time, ...string) (map[string][]policies.PolicyMatch, error) {
 		return r0, r1
 	})
 }
@@ -3237,12 +3237,12 @@ func (f *PolicyMatcherCommitsDescribedByPolicyFunc) SetDefaultReturn(r0 map[stri
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *PolicyMatcherCommitsDescribedByPolicyFunc) PushReturn(r0 map[string][]policies.PolicyMatch, r1 error) {
-	f.PushHook(func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time) (map[string][]policies.PolicyMatch, error) {
+	f.PushHook(func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time, ...string) (map[string][]policies.PolicyMatch, error) {
 		return r0, r1
 	})
 }
 
-func (f *PolicyMatcherCommitsDescribedByPolicyFunc) nextHook() func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time) (map[string][]policies.PolicyMatch, error) {
+func (f *PolicyMatcherCommitsDescribedByPolicyFunc) nextHook() func(context.Context, int, []dbstore.ConfigurationPolicy, time.Time, ...string) (map[string][]policies.PolicyMatch, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3289,6 +3289,9 @@ type PolicyMatcherCommitsDescribedByPolicyFuncCall struct {
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
 	Arg3 time.Time
+	// Arg4 is a slice containing the values of the variadic arguments
+	// passed to this method invocation.
+	Arg4 []string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 map[string][]policies.PolicyMatch
@@ -3298,9 +3301,16 @@ type PolicyMatcherCommitsDescribedByPolicyFuncCall struct {
 }
 
 // Args returns an interface slice containing the arguments of this
-// invocation.
+// invocation. The variadic slice argument is flattened in this array such
+// that one positional argument and three variadic arguments would result in
+// a slice of four, not two.
 func (c PolicyMatcherCommitsDescribedByPolicyFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+	trailing := []interface{}{}
+	for _, val := range c.Arg4 {
+		trailing = append(trailing, val)
+	}
+
+	return append([]interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}, trailing...)
 }
 
 // Results returns an interface slice containing the results of this

--- a/enterprise/cmd/worker/internal/codeintel/janitor/upload_expirer.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/upload_expirer.go
@@ -27,8 +27,10 @@ type uploadExpirer struct {
 	branchesCacheMaxKeys   int
 }
 
-var _ goroutine.Handler = &uploadExpirer{}
-var _ goroutine.ErrorHandler = &uploadExpirer{}
+var (
+	_ goroutine.Handler      = &uploadExpirer{}
+	_ goroutine.ErrorHandler = &uploadExpirer{}
+)
 
 // NewUploadExpirer returns a background routine that periodically compares the age of upload records
 // against the age of uploads protected by global and repository specific data retention policies.
@@ -190,8 +192,10 @@ func (e *uploadExpirer) handleUploads(
 	now time.Time,
 ) (err error) {
 	// Categorize each upload as protected or expired
-	protectedUploadIDs := make([]int, 0, len(uploads))
-	expiredUploadIDs := make([]int, 0, len(uploads))
+	var (
+		protectedUploadIDs = make([]int, 0, len(uploads))
+		expiredUploadIDs   = make([]int, 0, len(uploads))
+	)
 
 	for _, upload := range uploads {
 		protected, checkErr := e.isUploadProtectedByPolicy(ctx, commitMap, upload, now)

--- a/enterprise/cmd/worker/internal/codeintel/janitor/upload_expirer_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/upload_expirer_test.go
@@ -235,7 +235,7 @@ func testUploadExpirerMockPolicyMatcher(now time.Time) *MockPolicyMatcher {
 		},
 	}
 
-	commitsDescribedByPolicy := func(ctx context.Context, repositoryID int, policies []dbstore.ConfigurationPolicy, now time.Time) (map[string][]policies.PolicyMatch, error) {
+	commitsDescribedByPolicy := func(ctx context.Context, repositoryID int, policies []dbstore.ConfigurationPolicy, now time.Time, _ ...string) (map[string][]policies.PolicyMatch, error) {
 		return policyMatches[repositoryID], nil
 	}
 

--- a/enterprise/internal/codeintel/gitserver/client.go
+++ b/enterprise/internal/codeintel/gitserver/client.go
@@ -149,8 +149,9 @@ func (c *Client) CommitGraph(ctx context.Context, repositoryID int, opts git.Com
 }
 
 // RefDescriptions returns a map from commits to descriptions of the tip of each
-// branch and tag of the given repository.
-func (c *Client) RefDescriptions(ctx context.Context, repositoryID int) (_ map[string][]gitdomain.RefDescription, err error) {
+// branch and tag of the given repository. If any git objects are provided, it will
+// only populate entries for descriptions pointing at the given git objects.
+func (c *Client) RefDescriptions(ctx context.Context, repositoryID int, pointedAt ...string) (_ map[string][]gitdomain.RefDescription, err error) {
 	ctx, endObservation := c.operations.refDescriptions.With(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("repositoryID", repositoryID),
 	}})
@@ -161,7 +162,7 @@ func (c *Client) RefDescriptions(ctx context.Context, repositoryID int) (_ map[s
 		return nil, err
 	}
 
-	return git.RefDescriptions(ctx, repo, authz.DefaultSubRepoPermsChecker)
+	return git.RefDescriptions(ctx, repo, authz.DefaultSubRepoPermsChecker, pointedAt...)
 }
 
 // CommitsUniqueToBranch returns a map from commits that exist on a particular branch in the given repository to

--- a/enterprise/internal/codeintel/policies/iface.go
+++ b/enterprise/internal/codeintel/policies/iface.go
@@ -11,6 +11,6 @@ import (
 type GitserverClient interface {
 	ResolveRevision(ctx context.Context, repositoryID int, versionString string) (api.CommitID, error)
 	CommitDate(ctx context.Context, repositoryID int, commit string) (string, time.Time, bool, error)
-	RefDescriptions(ctx context.Context, repositoryID int) (map[string][]gitdomain.RefDescription, error)
+	RefDescriptions(ctx context.Context, repositoryID int, gitOjbs ...string) (map[string][]gitdomain.RefDescription, error)
 	CommitsUniqueToBranch(ctx context.Context, repositoryID int, branchName string, isDefaultBranch bool, maxAge *time.Time) (map[string]time.Time, error)
 }

--- a/enterprise/internal/codeintel/policies/matcher.go
+++ b/enterprise/internal/codeintel/policies/matcher.go
@@ -53,7 +53,9 @@ func NewMatcher(
 // filtered out. If false, policy duration is not considered. This is set to true for auto-indexing, but false
 // for data retention as we need to compare the policy duration against the associated upload date, not the
 // commit date.
-func (m *Matcher) CommitsDescribedByPolicy(ctx context.Context, repositoryID int, policies []dbstore.ConfigurationPolicy, now time.Time) (map[string][]PolicyMatch, error) {
+//
+// A subset of all commits can be returned by passing in any number of commit revhash strings.
+func (m *Matcher) CommitsDescribedByPolicy(ctx context.Context, repositoryID int, policies []dbstore.ConfigurationPolicy, now time.Time, filterCommits ...string) (map[string][]PolicyMatch, error) {
 	if len(policies) == 0 && !m.includeTipOfDefaultBranch {
 		return nil, nil
 	}
@@ -72,7 +74,7 @@ func (m *Matcher) CommitsDescribedByPolicy(ctx context.Context, repositoryID int
 		branchRequests: map[string]branchRequestMeta{},
 	}
 
-	refDescriptions, err := m.gitserverClient.RefDescriptions(ctx, repositoryID)
+	refDescriptions, err := m.gitserverClient.RefDescriptions(ctx, repositoryID, filterCommits...)
 	if err != nil {
 		return nil, errors.Wrap(err, "gitserver.RefDescriptions")
 	}

--- a/enterprise/internal/codeintel/policies/matcher_common_test.go
+++ b/enterprise/internal/codeintel/policies/matcher_common_test.go
@@ -16,7 +16,7 @@ func testUploadExpirerMockGitserverClient(defaultBranchName string, now time.Tim
 	//   \                        \               \               \         \                   \
 	//    xy/feature-y            xy/feature-x    zw/feature-z     v1.2.2    v1.2.3              develop
 
-	var branchHeads = map[string]string{
+	branchHeads := map[string]string{
 		"develop":      "deadbeef01",
 		"feat/blank":   "deadbeef02",
 		"xy/feature-x": "deadbeef07",
@@ -24,13 +24,13 @@ func testUploadExpirerMockGitserverClient(defaultBranchName string, now time.Tim
 		"xy/feature-y": "deadbeef09",
 	}
 
-	var tagHeads = map[string]string{
+	tagHeads := map[string]string{
 		"v1.2.3": "deadbeef04",
 		"v1.2.2": "deadbeef05",
 		"v2.2.2": "deadbeef06",
 	}
 
-	var branchMembers = map[string][]string{
+	branchMembers := map[string][]string{
 		"develop":      {"deadbeef01", "deadbeef03", "deadbeef04", "deadbeef05"},
 		"feat/blank":   {"deadbeef02"},
 		"xy/feature-x": {"deadbeef07", "deadbeef08"},
@@ -38,7 +38,7 @@ func testUploadExpirerMockGitserverClient(defaultBranchName string, now time.Tim
 		"zw/feature-z": {"deadbeef06"},
 	}
 
-	var createdAt = map[string]time.Time{
+	createdAt := map[string]time.Time{
 		"deadbeef01": now.Add(-time.Hour * 5),
 		"deadbeef02": now.Add(-time.Hour * 5),
 		"deadbeef03": now.Add(-time.Hour * 5),
@@ -55,7 +55,7 @@ func testUploadExpirerMockGitserverClient(defaultBranchName string, now time.Tim
 		return commit, commitDate, ok, nil
 	}
 
-	refDescriptions := func(ctx context.Context, repositoryID int) (map[string][]gitdomain.RefDescription, error) {
+	refDescriptions := func(ctx context.Context, repositoryID int, _ ...string) (map[string][]gitdomain.RefDescription, error) {
 		refDescriptions := map[string][]gitdomain.RefDescription{}
 		for branch, commit := range branchHeads {
 			refDescriptions[commit] = append(refDescriptions[commit], gitdomain.RefDescription{

--- a/enterprise/internal/codeintel/policies/mock_iface_test.go
+++ b/enterprise/internal/codeintel/policies/mock_iface_test.go
@@ -46,7 +46,7 @@ func NewMockGitserverClient() *MockGitserverClient {
 			},
 		},
 		RefDescriptionsFunc: &GitserverClientRefDescriptionsFunc{
-			defaultHook: func(context.Context, int) (map[string][]gitdomain.RefDescription, error) {
+			defaultHook: func(context.Context, int, ...string) (map[string][]gitdomain.RefDescription, error) {
 				return nil, nil
 			},
 		},
@@ -73,7 +73,7 @@ func NewStrictMockGitserverClient() *MockGitserverClient {
 			},
 		},
 		RefDescriptionsFunc: &GitserverClientRefDescriptionsFunc{
-			defaultHook: func(context.Context, int) (map[string][]gitdomain.RefDescription, error) {
+			defaultHook: func(context.Context, int, ...string) (map[string][]gitdomain.RefDescription, error) {
 				panic("unexpected invocation of MockGitserverClient.RefDescriptions")
 			},
 		},
@@ -349,24 +349,24 @@ func (c GitserverClientCommitsUniqueToBranchFuncCall) Results() []interface{} {
 // RefDescriptions method of the parent MockGitserverClient instance is
 // invoked.
 type GitserverClientRefDescriptionsFunc struct {
-	defaultHook func(context.Context, int) (map[string][]gitdomain.RefDescription, error)
-	hooks       []func(context.Context, int) (map[string][]gitdomain.RefDescription, error)
+	defaultHook func(context.Context, int, ...string) (map[string][]gitdomain.RefDescription, error)
+	hooks       []func(context.Context, int, ...string) (map[string][]gitdomain.RefDescription, error)
 	history     []GitserverClientRefDescriptionsFuncCall
 	mutex       sync.Mutex
 }
 
 // RefDescriptions delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockGitserverClient) RefDescriptions(v0 context.Context, v1 int) (map[string][]gitdomain.RefDescription, error) {
-	r0, r1 := m.RefDescriptionsFunc.nextHook()(v0, v1)
-	m.RefDescriptionsFunc.appendCall(GitserverClientRefDescriptionsFuncCall{v0, v1, r0, r1})
+func (m *MockGitserverClient) RefDescriptions(v0 context.Context, v1 int, v2 ...string) (map[string][]gitdomain.RefDescription, error) {
+	r0, r1 := m.RefDescriptionsFunc.nextHook()(v0, v1, v2...)
+	m.RefDescriptionsFunc.appendCall(GitserverClientRefDescriptionsFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the RefDescriptions
 // method of the parent MockGitserverClient instance is invoked and the hook
 // queue is empty.
-func (f *GitserverClientRefDescriptionsFunc) SetDefaultHook(hook func(context.Context, int) (map[string][]gitdomain.RefDescription, error)) {
+func (f *GitserverClientRefDescriptionsFunc) SetDefaultHook(hook func(context.Context, int, ...string) (map[string][]gitdomain.RefDescription, error)) {
 	f.defaultHook = hook
 }
 
@@ -374,7 +374,7 @@ func (f *GitserverClientRefDescriptionsFunc) SetDefaultHook(hook func(context.Co
 // RefDescriptions method of the parent MockGitserverClient instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *GitserverClientRefDescriptionsFunc) PushHook(hook func(context.Context, int) (map[string][]gitdomain.RefDescription, error)) {
+func (f *GitserverClientRefDescriptionsFunc) PushHook(hook func(context.Context, int, ...string) (map[string][]gitdomain.RefDescription, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -383,7 +383,7 @@ func (f *GitserverClientRefDescriptionsFunc) PushHook(hook func(context.Context,
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *GitserverClientRefDescriptionsFunc) SetDefaultReturn(r0 map[string][]gitdomain.RefDescription, r1 error) {
-	f.SetDefaultHook(func(context.Context, int) (map[string][]gitdomain.RefDescription, error) {
+	f.SetDefaultHook(func(context.Context, int, ...string) (map[string][]gitdomain.RefDescription, error) {
 		return r0, r1
 	})
 }
@@ -391,12 +391,12 @@ func (f *GitserverClientRefDescriptionsFunc) SetDefaultReturn(r0 map[string][]gi
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *GitserverClientRefDescriptionsFunc) PushReturn(r0 map[string][]gitdomain.RefDescription, r1 error) {
-	f.PushHook(func(context.Context, int) (map[string][]gitdomain.RefDescription, error) {
+	f.PushHook(func(context.Context, int, ...string) (map[string][]gitdomain.RefDescription, error) {
 		return r0, r1
 	})
 }
 
-func (f *GitserverClientRefDescriptionsFunc) nextHook() func(context.Context, int) (map[string][]gitdomain.RefDescription, error) {
+func (f *GitserverClientRefDescriptionsFunc) nextHook() func(context.Context, int, ...string) (map[string][]gitdomain.RefDescription, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -436,6 +436,9 @@ type GitserverClientRefDescriptionsFuncCall struct {
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
 	Arg1 int
+	// Arg2 is a slice containing the values of the variadic arguments
+	// passed to this method invocation.
+	Arg2 []string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 map[string][]gitdomain.RefDescription
@@ -445,9 +448,16 @@ type GitserverClientRefDescriptionsFuncCall struct {
 }
 
 // Args returns an interface slice containing the arguments of this
-// invocation.
+// invocation. The variadic slice argument is flattened in this array such
+// that one positional argument and three variadic arguments would result in
+// a slice of four, not two.
 func (c GitserverClientRefDescriptionsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+	trailing := []interface{}{}
+	for _, val := range c.Arg2 {
+		trailing = append(trailing, val)
+	}
+
+	return append([]interface{}{c.Arg0, c.Arg1}, trailing...)
 }
 
 // Results returns an interface slice containing the results of this


### PR DESCRIPTION
Previously, it was not always easily viewable in the UI whether or why an LSIF upload is retained or not. The git object preview list only showed up to a certain number of revhashes and only for a single policy at a time. This PR surfaces the list of matching retention policies, and referencing uploads, on the LSIF upload page.

<details>
<summary>Retention policy matches (and not) list with tooltip</summary>

![image](https://user-images.githubusercontent.com/18282288/153083404-b8663e93-0c57-4582-8822-bed5319d6202.png)

</details>

<details>
<summary>Retention by upload reference</summary>

![image](https://user-images.githubusercontent.com/18282288/153090608-f68964f8-dfa0-40d7-9b28-3af6af9d2e3d.png)

</details>

<details>
<summary>Retention by upload reference tooltip</summary>


![image](https://user-images.githubusercontent.com/18282288/153090585-1ca454ec-fa98-449b-a4f0-748fb80dff44.png)

</details>

TODO: 
- [ ] correct links for repository local vs global configuration policies
- [ ] investigate testing possibilities
- [ ] more?