### PR TITLE
search: mint internal/search/structural

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -43,6 +43,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/run"
 	"github.com/sourcegraph/sourcegraph/internal/search/searchcontexts"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+	"github.com/sourcegraph/sourcegraph/internal/search/structural"
 	"github.com/sourcegraph/sourcegraph/internal/search/subrepoperms"
 	"github.com/sourcegraph/sourcegraph/internal/search/symbol"
 	"github.com/sourcegraph/sourcegraph/internal/search/unindexed"
@@ -840,7 +841,7 @@ func (r *searchResolver) toSearchJob(q query.Q) (run.Job, error) {
 				UseFullDeadline: args.UseFullDeadline,
 			}
 
-			addJob(true, &unindexed.StructuralSearch{
+			addJob(true, &structural.StructuralSearch{
 				ZoektArgs:    zoektArgs,
 				SearcherArgs: searcherArgs,
 

--- a/internal/search/structural/structural.go
+++ b/internal/search/structural/structural.go
@@ -1,4 +1,4 @@
-package unindexed
+package structural
 
 import (
 	"context"
@@ -13,6 +13,7 @@ import (
 	searchrepos "github.com/sourcegraph/sourcegraph/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+	"github.com/sourcegraph/sourcegraph/internal/search/unindexed"
 	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -66,7 +67,7 @@ func PartitionRepos(request zoektutil.IndexedSearchRequest, notSearcherOnly bool
 // getJob returns a function parameterized by ctx to search over repos.
 func (s *searchRepos) getJob(ctx context.Context) func() error {
 	return func() error {
-		return callSearcherOverRepos(ctx, s.args, s.stream, s.repoSet.AsList(), s.repoSet.IsIndexed())
+		return unindexed.CallSearcherOverRepos(ctx, s.args, s.stream, s.repoSet.AsList(), s.repoSet.IsIndexed())
 	}
 }
 

--- a/internal/search/unindexed/unindexed.go
+++ b/internal/search/unindexed/unindexed.go
@@ -55,7 +55,7 @@ func SearchFilesInRepos(ctx context.Context, zoektArgs zoektutil.IndexedSearchRe
 
 	// Concurrently run searcher for all unindexed repos regardless whether text or regexp.
 	g.Go(func() error {
-		return callSearcherOverRepos(ctx, searcherArgs, stream, zoektArgs.UnindexedRepos(), false)
+		return CallSearcherOverRepos(ctx, searcherArgs, stream, zoektArgs.UnindexedRepos(), false)
 	})
 
 	return g.Wait()
@@ -207,8 +207,8 @@ func matchesToFileMatches(matches []result.Match) ([]*result.FileMatch, error) {
 	return fms, nil
 }
 
-// callSearcherOverRepos calls searcher on searcherRepos.
-func callSearcherOverRepos(
+// CallSearcherOverRepos calls searcher on searcherRepos.
+func CallSearcherOverRepos(
 	ctx context.Context,
 	args *search.SearcherParameters,
 	stream streaming.Sender,


### PR DESCRIPTION
Want to improve the `unindexed` package situation (follow up of https://github.com/sourcegraph/sourcegraph/pull/30784#pullrequestreview-875519621). First moving `structural.go` out of that package.



## Test plan
Covered by go unit tests. semantics preserving change.


