### PR TITLE
Search backend: fix key equality for type CommitMatch

### DIFF
--- a/internal/search/result/commit.go
+++ b/internal/search/result/commit.go
@@ -142,7 +142,7 @@ func (r *CommitMatch) Key() Key {
 	return Key{
 		TypeRank:   typeRank,
 		Repo:       r.Repo.Name,
-		AuthorDate: &r.Commit.Author.Date,
+		AuthorDate: r.Commit.Author.Date,
 		Commit:     r.Commit.ID,
 	}
 }


### PR DESCRIPTION
In a recent change, I added AuthorDate to the Key type so that we could
sort commit matches by date. However, the pointer type is not traversed
when comparing structs with struct equality, so equivalent commits from
two different sources were not being evaluated as the same commit. This
broke deduplication for and/or queries.



## Test plan

I added a test for this specific regression, and plan to expand these tests
as part of my continued work search backend health. 
