### PR TITLE
WIP: VSCE to work on Web

### DIFF
--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -31,6 +31,7 @@
     "onWebviewPanel:sourcegraphSearch"
   ],
   "main": "./dist/node/extension.js",
+  "browser": "./dist/webworker/extension.js",
   "contributes": {
     "commands": [
       {
@@ -198,6 +199,7 @@
   },
   "dependencies": {
     "https-browserify": "^1.0.0",
+    "stream-browserify": "^3.0.0",
     "stream-http": "^3.2.0"
   }
 }

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "sourcegraph",
   "displayName": "Sourcegraph",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Sourcegraph for VS Code",
   "publisher": "sourcegraph",
   "sideEffects": false,
@@ -195,5 +195,9 @@
     "build:web": "TARGET_TYPE=webworker yarn task:gulp webpack",
     "watch:node": "NODE_ENV=development TARGET_TYPE=node yarn task:gulp watchWebpack",
     "watch:web": "NODE_ENV=development TARGET_TYPE=webworker yarn task:gulp watchWebpack"
+  },
+  "dependencies": {
+    "https-browserify": "^1.0.0",
+    "stream-http": "^3.2.0"
   }
 }

--- a/client/vscode/src/polyfills/eventSource.js
+++ b/client/vscode/src/polyfills/eventSource.js
@@ -46,10 +46,10 @@ function hasBom(buf) {
 /**
  * Creates a new EventSource object
  *
- * @param {string} url the URL to which to connect
- * @param {Object} [eventSourceInitDict] extra init params. See README for details.
+ * @param url the URL to which to connect
+ * @param [eventSourceInitDict] extra init params. See README for details.
  * @api public
- **/
+ */
 function EventSource(url, eventSourceInitDict) {
   let readyState = EventSource.CONNECTING
   Object.defineProperty(this, 'readyState', {
@@ -104,11 +104,11 @@ function EventSource(url, eventSourceInitDict) {
   var reconnectUrl = null
 
   function connect() {
-    const options = parse(url)
+    const streamApi = url.replace('search/stream?q=', '.api/search/stream?q=')
+    const options = parse(streamApi)
+
     let isSecure = options.protocol === 'https:'
     options.headers = {
-      'Cache-Control': 'no-cache',
-      Accept: 'text/event-stream',
       ...fixedHeaders,
     }
     if (lastEventId) {
@@ -139,7 +139,7 @@ function EventSource(url, eventSourceInitDict) {
       isSecure = proxy.protocol === 'https:'
 
       options.protocol = isSecure ? 'https:' : 'http:'
-      options.path = url
+      options.path = streamApi
       options.headers.Host = options.host
       options.hostname = proxy.hostname
       options.host = proxy.host
@@ -164,7 +164,6 @@ function EventSource(url, eventSourceInitDict) {
     if (eventSourceInitDict && eventSourceInitDict.withCredentials !== undefined) {
       options.withCredentials = eventSourceInitDict.withCredentials
     }
-
     request = (isSecure ? https : http).request(options, res => {
       self.connectionInProgress = false
       // Handle HTTP errors
@@ -361,7 +360,7 @@ EventSource.prototype.constructor = EventSource // make stacktraces readable
     /**
      * Returns the current listener
      *
-     * @returns {Mixed} the set function or undefined
+     * @returns the set function or undefined
      * @api private
      */
     get: function get() {
@@ -372,8 +371,8 @@ EventSource.prototype.constructor = EventSource // make stacktraces readable
     /**
      * Start listening for events
      *
-     * @param {Function} listener the listener
-     * @returns {Mixed} the set function or undefined
+     * @param listener the listener
+     * @returns the set function or undefined
      * @api private
      */
     set: function set(listener) {
@@ -407,8 +406,8 @@ EventSource.prototype.close = function () {
 /**
  * Emulates the W3C Browser based WebSocket interface using addEventListener.
  *
- * @param {string} type A string representing the event type to listen out for
- * @param {Function} listener callback
+ * @param type A string representing the event type to listen out for
+ * @param listener callback
  * @see https://developer.mozilla.org/en/DOM/element.addEventListener
  * @see http://dev.w3.org/html5/websockets/#the-websocket-interface
  * @api public
@@ -424,7 +423,7 @@ EventSource.prototype.addEventListener = function addEventListener(type, listene
 /**
  * Emulates the W3C Browser based WebSocket interface using dispatchEvent.
  *
- * @param {Event} event An event to be dispatched
+ * @param event An event to be dispatched
  * @see https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/dispatchEvent
  * @api public
  */
@@ -440,8 +439,8 @@ EventSource.prototype.dispatchEvent = function dispatchEvent(event) {
 /**
  * Emulates the W3C Browser based WebSocket interface using removeEventListener.
  *
- * @param {string} type A string representing the event type to remove
- * @param {Function} listener callback
+ * @param type A string representing the event type to remove
+ * @param listener callback
  * @see https://developer.mozilla.org/en/DOM/element.removeEventListener
  * @see http://dev.w3.org/html5/websockets/#the-websocket-interface
  * @api public

--- a/client/vscode/src/webview/initialize.ts
+++ b/client/vscode/src/webview/initialize.ts
@@ -138,9 +138,11 @@ export function initializeSearchSidebarWebview({
                 src: url(${codiconFontSource.toString()})
             }
         </style>
-        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src vscode-resource: vscode-webview: data: https:; script-src blob: vscode-webview: https:; style-src 'unsafe-inline' vscode-resource: ${
+        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; child-src data: ${
             webviewView.webview.cspSource
-        } http: https: data:; connect-src 'self' http: https:; font-src vscode-resource: vscode-webview: https:;">
+        }; img-src data: https:; script-src blob: https:; style-src 'unsafe-inline' ${
+        webviewView.webview.cspSource
+    } http: https: data:; connect-src 'self' http: https:; font-src vscode-resource: vscode-webview: https:;">
         <title>Sourcegraph Search</title>
         <link rel="stylesheet" href="${styleSource.toString()}" />
         <link rel="stylesheet" href="${cssModuleSource.toString()}" />

--- a/client/vscode/webpack.config.js
+++ b/client/vscode/webpack.config.js
@@ -63,6 +63,8 @@ function getExtensionCoreConfiguration(targetType) {
               path: require.resolve('path-browserify'),
               assert: require.resolve('assert'),
               util: require.resolve('util'),
+              http: require.resolve('stream-http'),
+              https: require.resolve('https-browserify')
             }
           : {},
     },
@@ -126,6 +128,8 @@ const webviewConfig = {
     fallback: {
       path: require.resolve('path-browserify'),
       process: require.resolve('process/browser'),
+      http: require.resolve('stream-http'),
+      https: require.resolve('https-browserify')
     },
   },
   module: {

--- a/client/vscode/webpack.config.js
+++ b/client/vscode/webpack.config.js
@@ -4,6 +4,7 @@
 const path = require('path')
 
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
+const webpack = require('webpack')
 
 const {
   getMonacoWebpackPlugin,
@@ -63,8 +64,9 @@ function getExtensionCoreConfiguration(targetType) {
               path: require.resolve('path-browserify'),
               assert: require.resolve('assert'),
               util: require.resolve('util'),
+              stream: require.resolve('stream-browserify'),
               http: require.resolve('stream-http'),
-              https: require.resolve('https-browserify')
+              https: require.resolve('https-browserify'),
             }
           : {},
     },
@@ -82,6 +84,12 @@ function getExtensionCoreConfiguration(targetType) {
         },
       ],
     },
+    plugins: [
+      new webpack.ProvidePlugin({
+        Buffer: ['buffer', 'Buffer'],
+        process: 'process/browser', // provide a shim for the global `process` variable
+      }),
+    ],
   }
 }
 
@@ -114,7 +122,14 @@ const webviewConfig = {
     path: path.resolve(__dirname, 'dist/webview'),
     filename: '[name].js',
   },
-  plugins: [new MiniCssExtractPlugin(), getMonacoWebpackPlugin()],
+  plugins: [
+    new MiniCssExtractPlugin(),
+    getMonacoWebpackPlugin(),
+    new webpack.ProvidePlugin({
+      Buffer: ['buffer', 'Buffer'],
+      process: 'process/browser', // provide a shim for the global `process` variable
+    }),
+  ],
   externals: {
     // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
     vscode: 'commonjs vscode',
@@ -129,7 +144,8 @@ const webviewConfig = {
       path: require.resolve('path-browserify'),
       process: require.resolve('process/browser'),
       http: require.resolve('stream-http'),
-      https: require.resolve('https-browserify')
+      https: require.resolve('https-browserify'),
+      stream: require.resolve('stream-browserify'),
     },
   },
   module: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7654,6 +7654,11 @@ buffer@^5.2.1, buffer@^5.5.0, buffer@^5.7.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
+builtin-status-codes@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
+  integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
+
 bundlesize2@^0.0.31:
   version "0.0.31"
   resolved "https://registry.npmjs.org/bundlesize2/-/bundlesize2-0.0.31.tgz#cef6830dbbe5360e27fce07593ec0f4e3e5355d9"
@@ -13770,6 +13775,11 @@ http2-wrapper@^1.0.0-beta.5.0:
     quick-lru "^5.1.1"
     resolve-alpn "^1.0.0"
 
+https-browserify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
+  integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
+
 https-proxy-agent@5.0.0, https-proxy-agent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
@@ -13980,7 +13990,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.0, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.0, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -20022,7 +20032,7 @@ readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.0.6, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
+readable-stream@^3.0.6, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.5.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -21694,10 +21704,28 @@ storybook-dark-mode@^1.0.8:
     fast-deep-equal "^3.0.0"
     memoizerific "^1.11.3"
 
+stream-browserify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz#22b0a2850cdf6503e73085da1fc7b7d0c2122f2f"
+  integrity sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==
+  dependencies:
+    inherits "~2.0.4"
+    readable-stream "^3.5.0"
+
 stream-exhaust@^1.0.1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz#acdac8da59ef2bc1e17a2c0ccf6c320d120e555d"
   integrity sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==
+
+stream-http@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/stream-http/-/stream-http-3.2.0.tgz#1872dfcf24cb15752677e40e5c3f9cc1926028b5"
+  integrity sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==
+  dependencies:
+    builtin-status-codes "^3.0.0"
+    inherits "^2.0.4"
+    readable-stream "^3.6.0"
+    xtend "^4.0.2"
 
 stream-parser@~0.3.1:
   version "0.3.1"
@@ -24398,7 +24426,7 @@ xmlhttprequest-ssl@~1.5.4:
   resolved "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz#c2876b06168aadc40e57d97e81191ac8f4398b3e"
   integrity sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=
 
-xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0, xtend@~4.0.1:
+xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==


### PR DESCRIPTION
Before this PR, VSCE is using the stream search endpoint which is not supported in Webview, as the polyfill for https does not support CORS.

Switching to the stream search API allows stream search to run on both web and node. 
Note: The http polyfill requires a dependency called stream-readable that requires additional polyfill for process and buffer for the extension to run the stream search API.

![image](https://user-images.githubusercontent.com/68532117/153111336-b432d5d9-bf24-408a-8b83-fa50c93bac4f.png)

Currently not working correctly in Firefox. 

