### PR TITLE
CodeInsights: Fix query count filter checker (support count:all)

### DIFF
--- a/client/web/src/enterprise/insights/core/backend/core/api/get-search-insight-content/query-has-count-filter.ts
+++ b/client/web/src/enterprise/insights/core/backend/core/api/get-search-insight-content/query-has-count-filter.ts
@@ -2,5 +2,5 @@
  * Returns whether the query specifies a count. Search queries break when count is specified twice.
  */
 export function queryHasCountFilter(query: string): boolean {
-    return /\bcount:\d+\b/gi.test(query)
+    return /\bcount:(\d+|all)\b/gi.test(query)
 }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/30873

By default, all queries for the just-in-time type of insights have a `count:99999` filter. But we also want to allow users to input their count filter. The query with two count values is an invalid query so we should detect appearance users count filters in a query and add or not add a default `count:99999`. This PR just simply fixes count appearance checker in a way that the checker supports the` count: all` filter.