### PR TITLE
gitserver: Rename NoTimeout to EnableTimeout

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1143,7 +1143,7 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 
 	ctx := r.Context()
 
-	if !req.NoTimeout {
+	if req.EnableTimeout {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, shortGitCommandTimeout(req.Args))
 		defer cancel()

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -391,7 +391,7 @@ func (c *Cmd) sendExec(ctx context.Context) (_ io.ReadCloser, _ http.Header, err
 		Repo:           repoName,
 		EnsureRevision: c.EnsureRevision,
 		Args:           c.Args[1:],
-		NoTimeout:      c.NoTimeout,
+		EnableTimeout:  c.EnableTimeout,
 	}
 	resp, err := c.client.httpPost(ctx, repoName, "exec", req)
 	if err != nil {
@@ -529,7 +529,7 @@ type Cmd struct {
 	Repo           api.RepoName // the repository to execute the command in
 	EnsureRevision string
 	ExitStatus     int
-	NoTimeout      bool
+	EnableTimeout  bool
 }
 
 func (c *ClientImplementor) Command(name string, arg ...string) *Cmd {
@@ -584,10 +584,6 @@ func (c *Cmd) Output(ctx context.Context) ([]byte, error) {
 func (c *Cmd) CombinedOutput(ctx context.Context) ([]byte, error) {
 	stdout, stderr, err := c.DividedOutput(ctx)
 	return append(stdout, stderr...), err
-}
-
-func (c *Cmd) DisableTimeout() {
-	c.NoTimeout = true
 }
 
 func (c *Cmd) String() string { return fmt.Sprintf("%q", c.Args) }

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -95,7 +95,7 @@ type ExecRequest struct {
 	EnsureRevision string      `json:"ensureRevision"`
 	Args           []string    `json:"args"`
 	Opt            *RemoteOpts `json:"opt"`
-	NoTimeout      bool        `json:"noTimeout"`
+	EnableTimeout  bool        `json:"enableTimeout"`
 }
 
 // P4ExecRequest is a request to execute a p4 command with given arguments.


### PR DESCRIPTION
Rationale for this change:

When using a flag with a negative word, NOT conditions become a double
negative. For example:

```
if !NoTimeout {}
```

This makes the reader work harder to first flip the NOT condition and
then flip the flag in their head again based on the name. Dropping the
negative from the name would simplify the condition:

```
if Timeout {}
```

However, using `Timeout` would be confusing in this case for a boolean
flag as it usually implies an integer value to indicate a timeout in
seconds.

As a result, `EnableTimeout` makes for a better fit:

```
if EnableTimeout {}
```

All the three conditions imply the same while the last name makes it
the easiest and fastest to derive the correct meaning when reading the
code.

Finally, this commit also removes what apears to be dead code on the
gitserver.Cmd struct.



## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


