### PR TITLE
authz/github: Check against group.Org for org related functions

### DIFF
--- a/enterprise/internal/authz/github/github.go
+++ b/enterprise/internal/authz/github/github.go
@@ -434,7 +434,7 @@ func (p *Provider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository, 
 		hasNextPage := true
 		for page := 1; hasNextPage; page++ {
 			var members []*github.Collaborator
-			if group.Team == "" {
+			if group.Org != "" {
 				members, hasNextPage, err = p.client.ListOrganizationMembers(ctx, owner, page, group.adminsOnly)
 			} else {
 				members, hasNextPage, err = p.client.ListTeamMembers(ctx, owner, group.Team, page)


### PR DESCRIPTION
Minor nit that makes reading the code of this function slightly
intuitive.

Rationale:

If we are making Org related actions, we should check for a non-empty
Org string.



## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


