### PR TITLE
search: Manually add items to search stack

### DIFF
--- a/client/web/src/search/SearchStack.tsx
+++ b/client/web/src/search/SearchStack.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames'
 import { LocationDescriptor } from 'history'
 import CloseIcon from 'mdi-react/CloseIcon'
+import CodeBracketsIcon from 'mdi-react/CodeBracketsIcon'
 import FileDocumentIcon from 'mdi-react/FileDocumentIcon'
 import SearchStackIcon from 'mdi-react/LayersSearchIcon'
 import NotebookPlusIcon from 'mdi-react/NotebookPlusIcon'
@@ -12,6 +13,7 @@ import { useHistory } from 'react-router-dom'
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
 import { RepoIcon } from '@sourcegraph/shared/src/components/RepoIcon'
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
+import { IHighlightLineRange } from '@sourcegraph/shared/src/schema'
 import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
 import { appendContextFilter, updateFilter } from '@sourcegraph/shared/src/search/query/transformer'
 import { buildSearchURLQuery, toPrettyBlobURL } from '@sourcegraph/shared/src/util/url'
@@ -26,6 +28,8 @@ import {
     SearchStackEntry,
     removeSearchStackEntry,
     removeAllSearchStackEntries,
+    SearchStackEntryInput,
+    addSearchStackEntry,
 } from '../stores/searchStack'
 
 import { BlockInput } from './notebook'
@@ -37,6 +41,7 @@ export const SearchStack: React.FunctionComponent<{ initialOpen?: boolean }> = (
 
     const [open, setOpen] = useState(initialOpen)
     const [confirmRemoveAll, setConfirmRemoveAll] = useState(false)
+    const addableEntry = useSearchStackState(state => state.addableEntry)
     const entries = useSearchStackState(state => state.entries)
     const canRestore = useSearchStackState(state => state.canRestoreSession)
     const enableSearchStack = useExperimentalFeatures(features => features.enableSearchStack)
@@ -98,6 +103,7 @@ export const SearchStack: React.FunctionComponent<{ initialOpen?: boolean }> = (
             </div>
             {open && (
                 <>
+                    {addableEntry && <AddEntryButton entry={addableEntry} />}
                     <ul>
                         {reversedEntries.map(entry => (
                             <li key={entry.id}>{renderSearchEntry(entry)}</li>
@@ -161,6 +167,47 @@ export const SearchStack: React.FunctionComponent<{ initialOpen?: boolean }> = (
     )
 }
 
+interface AddEntryButtonProps {
+    entry: SearchStackEntryInput
+}
+
+const AddEntryButton: React.FunctionComponent<AddEntryButtonProps> = ({ entry }) => {
+    switch (entry.type) {
+        case 'search':
+            return (
+                <Button variant="primary" size="sm" title="Add search" className="m-3" onClick={addSearchStackEntry}>
+                    + <SearchIcon className="icon-inline" /> Search
+                </Button>
+            )
+        case 'file':
+            return (
+                <span className="d-flex m-2">
+                    <Button
+                        variant="primary"
+                        size="sm"
+                        title="Add file"
+                        className="flex-1 m-1"
+                        onClick={addSearchStackEntry}
+                    >
+                        + <FileDocumentIcon className="icon-inline" /> File
+                    </Button>
+                    {entry.lineRange && (
+                        <Button
+                            variant="primary"
+                            size="sm"
+                            title="Add line range"
+                            className="flex-1 m-1"
+                            onClick={addSearchStackEntry}
+                        >
+                            + <CodeBracketsIcon className="icon-inline" /> Range (
+                            {entry.lineRange.endLine - entry.lineRange.startLine})
+                        </Button>
+                    )}
+                </span>
+            )
+    }
+}
+
 interface SearchStackEntryComponentProps {
     entry: SearchStackEntry
     icon: React.ReactElement
@@ -221,8 +268,19 @@ function renderSearchEntry(entry: SearchStackEntry): React.ReactChild {
             return (
                 <SearchStackEntryComponent
                     entry={entry}
-                    icon={<FileDocumentIcon className="icon-inline" />}
-                    title={<span title={entry.path}>{shortenFilePath(entry.path)}</span>}
+                    icon={
+                        entry.lineRange ? (
+                            <CodeBracketsIcon className="icon-inline" />
+                        ) : (
+                            <FileDocumentIcon className="icon-inline" />
+                        )
+                    }
+                    title={
+                        <span title={entry.path}>
+                            {fileName(entry.path)}
+                            {entry.lineRange ? ` ${formatLineRange(entry.lineRange)}` : ''}
+                        </span>
+                    }
                     location={{
                         pathname: toPrettyBlobURL({
                             repoName: entry.repo,
@@ -254,22 +312,14 @@ function toSearchQuery(entry: SearchEntry): string {
     return query
 }
 
-/**
- * This function takes a file path and shortens any path segment to the first
- * character, except for the first and last segment and any segment that
- * contains less than five characters.
- *
- * Example: path/to/deeply/nested/file => path/to/d/n/file
- */
-function shortenFilePath(path: string): string {
+function fileName(path: string): string {
     const parts = path.split('/')
-    if (parts.length === 1) {
-        return path
+    return parts[parts.length - 1]
+}
+
+function formatLineRange(lineRange: IHighlightLineRange): string {
+    if (lineRange.startLine === lineRange.endLine - 1) {
+        return `L${lineRange.startLine}`
     }
-    return [parts[0]]
-        .concat(
-            parts.slice(1, -1).map(part => (part.length < 5 ? part : part[0])),
-            parts[parts.length - 1]
-        )
-        .join('/')
+    return `L${lineRange.startLine}:${lineRange.endLine}`
 }

--- a/client/web/src/search/SearchStack.tsx
+++ b/client/web/src/search/SearchStack.tsx
@@ -175,7 +175,13 @@ const AddEntryButton: React.FunctionComponent<AddEntryButtonProps> = ({ entry })
     switch (entry.type) {
         case 'search':
             return (
-                <Button variant="primary" size="sm" title="Add search" className="m-3" onClick={addSearchStackEntry}>
+                <Button
+                    variant="primary"
+                    size="sm"
+                    title="Add search"
+                    className="m-3"
+                    onClick={() => addSearchStackEntry(entry)}
+                >
                     + <SearchIcon className="icon-inline" /> Search
                 </Button>
             )
@@ -187,7 +193,7 @@ const AddEntryButton: React.FunctionComponent<AddEntryButtonProps> = ({ entry })
                         size="sm"
                         title="Add file"
                         className="flex-1 m-1"
-                        onClick={addSearchStackEntry}
+                        onClick={() => addSearchStackEntry(entry, 'file')}
                     >
                         + <FileDocumentIcon className="icon-inline" /> File
                     </Button>
@@ -197,7 +203,7 @@ const AddEntryButton: React.FunctionComponent<AddEntryButtonProps> = ({ entry })
                             size="sm"
                             title="Add line range"
                             className="flex-1 m-1"
-                            onClick={addSearchStackEntry}
+                            onClick={() => addSearchStackEntry(entry, 'range')}
                         >
                             + <CodeBracketsIcon className="icon-inline" /> Range (
                             {entry.lineRange.endLine - entry.lineRange.startLine})

--- a/client/web/src/stores/searchStack.test.ts
+++ b/client/web/src/stores/searchStack.test.ts
@@ -40,8 +40,24 @@ describe('search stack store', () => {
 
         it('adds a new entry', () => {
             renderHook(() => useSearchStack(exampleEntry))
-            addSearchStackEntry()
+            addSearchStackEntry(exampleEntry)
             expect(useSearchStackState.getState().entries).toEqual([exampleEntry])
+        })
+
+        it('adds a new entry as file', () => {
+            addSearchStackEntry(
+                { type: 'file', path: 'path/', lineRange: { startLine: 0, endLine: 1 }, repo: 'repo', revision: 'rev' },
+                'file'
+            )
+            expect(useSearchStackState.getState().entries[0]).toHaveProperty('lineRange', null)
+        })
+
+        it('adds a new entry as line range', () => {
+            addSearchStackEntry(
+                { type: 'file', path: 'path/', lineRange: { startLine: 0, endLine: 1 }, repo: 'repo', revision: 'rev' },
+                'range'
+            )
+            expect(useSearchStackState.getState().entries[0]).toHaveProperty('lineRange', { startLine: 0, endLine: 1 })
         })
     })
 

--- a/client/web/src/stores/searchStack.test.ts
+++ b/client/web/src/stores/searchStack.test.ts
@@ -6,10 +6,12 @@ import { setAct } from '../__mocks__/zustand'
 
 import { useExperimentalFeatures } from './experimentalFeatures'
 import {
+    addSearchStackEntry,
     removeAllSearchStackEntries,
     removeSearchStackEntry,
     restorePreviousSession,
     SearchStackEntry,
+    SearchStackEntryInput,
     useSearchStack,
     useSearchStackState,
 } from './searchStack'
@@ -19,12 +21,16 @@ describe('search stack store', () => {
         setAct(act)
     })
 
-    const exampleEntry: SearchStackEntry = {
-        id: 0,
+    const exampleEntryInput: SearchStackEntryInput = {
         type: 'search',
         query: 'test',
         patternType: SearchPatternType.literal,
         caseSensitive: false,
+    }
+
+    const exampleEntry: SearchStackEntry = {
+        ...exampleEntryInput,
+        id: 0,
     }
 
     describe('adding entries (via useSearchStack)', () => {
@@ -34,35 +40,8 @@ describe('search stack store', () => {
 
         it('adds a new entry', () => {
             renderHook(() => useSearchStack(exampleEntry))
+            addSearchStackEntry()
             expect(useSearchStackState.getState().entries).toEqual([exampleEntry])
-        })
-
-        it('updates an existing query entry', () => {
-            const { rerender } = renderHook(({ entry }: { entry: SearchStackEntry }) => useSearchStack(entry), {
-                initialProps: { entry: exampleEntry },
-            })
-            rerender({ entry: { ...exampleEntry, caseSensitive: true } })
-
-            const { entries } = useSearchStackState.getState()
-            expect(entries).toHaveLength(1)
-            expect(entries[0]).toHaveProperty('caseSensitive', true)
-        })
-
-        it('updates an existing file entry', () => {
-            const entry: SearchStackEntry = {
-                id: 0,
-                type: 'file',
-                path: 'path/to/file',
-                repo: 'test',
-                revision: 'master',
-                lineRange: null,
-            }
-            const { rerender } = renderHook(({ entry }: { entry: SearchStackEntry }) => useSearchStack(entry), {
-                initialProps: { entry },
-            })
-            rerender({ entry: { ...entry, lineRange: { startLine: 10, endLine: 11 } } })
-
-            expect(useSearchStackState.getState().entries).toHaveLength(1)
         })
     })
 

--- a/client/web/src/stores/searchStack.ts
+++ b/client/web/src/stores/searchStack.ts
@@ -37,6 +37,11 @@ export type SearchStackEntry = SearchEntry | FileEntry
 export type SearchStackEntryInput = Omit<SearchEntry, 'id'> | Omit<FileEntry, 'id'>
 
 export interface SearchStackStore {
+    /**
+     * If a page/component has information that can be added to the search
+     * stack, it should set this value.
+     */
+    addableEntry: SearchStackEntryInput | null
     entries: SearchStackEntry[]
     previousEntries: SearchStackEntry[]
     canRestoreSession: boolean
@@ -62,6 +67,7 @@ export const useSearchStackState = create<SearchStackStore>(() => {
     const entriesFromPreviousSession = restoreSession(localStorage)
 
     return {
+        addableEntry: null,
         entries: entriesFromSession,
         previousEntries: entriesFromPreviousSession,
         canRestoreSession: entriesFromSession.length === 0 && entriesFromPreviousSession.length > 0,
@@ -81,58 +87,48 @@ export function useSearchStack(newEntry: SearchStackEntryInput | null): void {
     const enableSearchStack = useExperimentalFeatures(features => features.enableSearchStack)
     useEffect(() => {
         if (enableSearchStack && newEntry) {
-            switch (newEntry.type) {
-                case 'file':
-                    addSearchStackEntry(
-                        newEntry,
-                        existingEntry =>
-                            existingEntry.type === 'file' &&
-                            existingEntry.repo === newEntry.repo &&
-                            existingEntry.path === newEntry.path
-                    )
-                    break
+            let entry: SearchStackEntryInput = newEntry
+
+            switch (entry.type) {
                 case 'search': {
                     // `query` most likely contains a 'context' filter that we don't
                     // want to show (this information is kept separately in
                     // `searchContext`).
-                    let processedQuery = newEntry.query
-                    const contextFilter = findFilter(newEntry.query, FilterType.context, FilterKind.Global)
+                    let processedQuery = entry.query
+                    const contextFilter = findFilter(entry.query, FilterType.context, FilterKind.Global)
                     if (contextFilter) {
-                        processedQuery = omitFilter(newEntry.query, contextFilter)
+                        processedQuery = omitFilter(entry.query, contextFilter)
                     }
-                    addSearchStackEntry(
-                        { ...newEntry, query: processedQuery },
-                        existingEntry => existingEntry.type === 'search' && existingEntry.query === processedQuery
-                    )
+                    entry = { ...entry, query: processedQuery }
                     break
                 }
             }
+            useSearchStackState.setState({ addableEntry: entry })
+
+            // We have to "remove" the entry if the component unmounts.
+            return () => {
+                const currentState = useSearchStackState.getState()
+                if (currentState.addableEntry === newEntry) {
+                    useSearchStackState.setState({ addableEntry: null })
+                }
+            }
         }
+        return // without this typescript complains
     }, [newEntry, enableSearchStack])
 }
 
-function addSearchStackEntry(entry: SearchStackEntryInput, update?: (entry: SearchStackEntry) => boolean): void {
-    useSearchStackState.setState(state => {
-        if (update) {
-            const existingEntry = state.entries.find(update)
-            if (existingEntry) {
-                const entriesCopy = [...state.entries]
-                const index = entriesCopy.indexOf(existingEntry)
-                entriesCopy[index] = { ...existingEntry, ...entry }
-                // If the list contains more than one entry we disable restoring from
-                // the previous session
-                return { entries: entriesCopy, canRestoreSession: entriesCopy.length <= 1 }
-            }
-        }
+export function addSearchStackEntry(): void {
+    const { addableEntry, entries } = useSearchStackState.getState()
+    if (addableEntry) {
         const newState = {
-            entries: [...state.entries, { ...entry, id: nextEntryID++ }],
-            canRestoreSession: state.entries.length === 0,
+            addableEntry: null,
+            entries: [...entries, { ...addableEntry, id: nextEntryID++ }],
+            canRestoreSession: entries.length === 0,
         }
 
         persistSession(newState.entries)
-
-        return newState
-    })
+        useSearchStackState.setState(newState)
+    }
 }
 
 export function restorePreviousSession(): void {

--- a/client/web/src/stores/searchStack.ts
+++ b/client/web/src/stores/searchStack.ts
@@ -117,18 +117,28 @@ export function useSearchStack(newEntry: SearchStackEntryInput | null): void {
     }, [newEntry, enableSearchStack])
 }
 
-export function addSearchStackEntry(): void {
+/**
+ * Adds the current value of addableEntry to the list of items.
+ * If that value is a file entry, then a hint can be provided to control whether
+ * the whole file or the line range should be added.
+ */
+export function addSearchStackEntry(newEntry: SearchStackEntryInput, hint?: 'file' | 'range'): void {
     const { addableEntry, entries } = useSearchStackState.getState()
-    if (addableEntry) {
-        const newState = {
-            addableEntry: null,
-            entries: [...entries, { ...addableEntry, id: nextEntryID++ }],
-            canRestoreSession: entries.length === 0,
-        }
 
-        persistSession(newState.entries)
-        useSearchStackState.setState(newState)
+    let entry = newEntry
+    if (entry.type === 'file' && entry.lineRange && hint === 'file') {
+        entry = { ...entry, lineRange: null }
     }
+
+    const newState = {
+        // Clear addableEntry if that's the entry we are adding
+        addableEntry: addableEntry === newEntry ? null : addableEntry,
+        entries: [...entries, { ...entry, id: nextEntryID++ }],
+        canRestoreSession: entries.length === 0,
+    }
+
+    persistSession(newState.entries)
+    useSearchStackState.setState(newState)
 }
 
 export function restorePreviousSession(): void {


### PR DESCRIPTION
This commit changes the behavior of the search stack to allow items
being added manually instead of automatically.

As a consequence this change also removes the detection of duplicate
items (the same file/search could be added multiple times if desired).
Whether or not this is desirable (or whether an item should be
highlighted somehow when it matches the current query/file) needs to be
discussed.

Instead of having the search stack component automatically detect
whether it's opened on a page that can be added to the stack, I'm
keeping the existing API (the pages "push" to the stack).
I decided against having the component detect the page because the only
way I could see that working is via inspect and parsing the URLs, and
that appeared too fragile to me (and also the URLs might not contain all
the information we want).
But if URL parsing is considered to be good enough then this could be
considered in the future.

Clicking any of the "add" buttons will make the button disappear but we could also consider to keep it visible.


https://user-images.githubusercontent.com/179026/153200857-1cc4efaf-d710-4ddb-8b9b-eb2caa6ae0f1.mp4




## Test plan

- Go to https://sourcegraph.com/search and submit a search
- On the search result page, open the search stack widget.
  - A button for adding the current search should be shown.
  - Clicking the button should add a search entry to the stack
- Click on the file link of one of the search results
  - This should open the file.
  - A button for adding the current file should be shown.
  - Clicking the button should add a search entry to the stack
- Go back to the search results and click on one of the search results
  - This should open file and the matched line should be highlighed.
  - Open the search stack widget if necessary.
  - It should show two buttons, one for adding a file and one for adding a line range
  - Click on the "add file" button, a new file entry should be added.
  - Refresh the page.
  - Open the search stack widget.
  - Click on the "add range" button, a new line range entry should be added.