### PR TITLE
search contexts: add the dynamic query option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - Syntax highlighting for JSON now uses a distinct color for strings in object key positions. [#30105](https://github.com/sourcegraph/sourcegraph/pull/30105)
-- [Query based search contexts](https://docs.sourcegraph.com/code_search/how-to/search_contexts#beta-query-based-search-contexts) are now enabled by default. [#30888](https://github.com/sourcegraph/sourcegraph/pull/30888)
+- [Query based search contexts](https://docs.sourcegraph.com/code_search/how-to/search_contexts#beta-query-based-search-contexts) are now enabled by default as a [beta feature](https://docs.sourcegraph.com/admin/beta_and_experimental_features). [#30888](https://github.com/sourcegraph/sourcegraph/pull/30888)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - Syntax highlighting for JSON now uses a distinct color for strings in object key positions. [#30105](https://github.com/sourcegraph/sourcegraph/pull/30105)
+- [Query based search contexts](https://docs.sourcegraph.com/code_search/how-to/search_contexts#beta-query-based-search-contexts) are now enabled by default. [#30888](https://github.com/sourcegraph/sourcegraph/pull/30888)
 
 ### Fixed
 

--- a/client/web/src/enterprise/searchContexts/SearchContextForm.module.scss
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.module.scss
@@ -28,7 +28,7 @@
         }
     }
 
-    &__visibility-radio {
+    &__radio {
         margin-top: 0.2rem;
         width: 0.875rem;
         height: 0.875rem;
@@ -36,12 +36,6 @@
 
     &__visibility-title {
         cursor: pointer;
-    }
-
-    &__type-radio {
-        margin-top: 0.2rem;
-        width: 0.875rem;
-        height: 0.875rem;
     }
 
     &__query {

--- a/client/web/src/enterprise/searchContexts/SearchContextForm.module.scss
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.module.scss
@@ -38,10 +38,28 @@
         cursor: pointer;
     }
 
+    &__type-radio {
+        margin-top: 0.2rem;
+        width: 0.875rem;
+        height: 0.875rem;
+    }
+
     &__query {
+        margin-top: 0.75rem;
+        margin-left: 1.25rem;
         border-radius: 0.25rem;
         padding: 0.5rem;
         background-color: var(--color-bg-1);
         border: 1px solid var(--border-color-2);
+    }
+
+    &__query-label {
+        margin-top: 0.25rem;
+        margin-left: 1.25rem;
+    }
+
+    &__static-config {
+        margin-top: 0.75rem;
+        margin-left: 1.25rem;
     }
 }

--- a/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
@@ -382,7 +382,7 @@ export const SearchContextForm: React.FunctionComponent<SearchContextFormProps> 
                         <RadioButton
                             key={radio.visibility}
                             id={`visibility_${index}`}
-                            className={styles.searchContextFormVisibilityRadio}
+                            className={styles.searchContextFormRadio}
                             name="visibility"
                             value={radio.visibility}
                             checked={visibility === radio.visibility}
@@ -416,7 +416,7 @@ export const SearchContextForm: React.FunctionComponent<SearchContextFormProps> 
                     <div>
                         <RadioButton
                             id="search_context_type_dynamic"
-                            className={styles.searchContextFormTypeRadio}
+                            className={styles.searchContextFormRadio}
                             name="search_context_type"
                             value="dynamic"
                             checked={contextType === 'dynamic'}
@@ -443,13 +443,13 @@ export const SearchContextForm: React.FunctionComponent<SearchContextFormProps> 
                         </div>
                         <div className={classNames(styles.searchContextFormQueryLabel, 'text-muted')}>
                             <small>
-                                Valid filters: <SyntaxHighlightedSearchQuery query="repo" />,{' '}
-                                <SyntaxHighlightedSearchQuery query="rev" />,{' '}
-                                <SyntaxHighlightedSearchQuery query="file" /> ,{' '}
-                                <SyntaxHighlightedSearchQuery query="lang" />,{' '}
-                                <SyntaxHighlightedSearchQuery query="case" />,{' '}
-                                <SyntaxHighlightedSearchQuery query="fork" />, and{' '}
-                                <SyntaxHighlightedSearchQuery query="visibility" />.{' '}
+                                Valid filters: <SyntaxHighlightedSearchQuery query="repo:" />,{' '}
+                                <SyntaxHighlightedSearchQuery query="rev:" />,{' '}
+                                <SyntaxHighlightedSearchQuery query="file:" /> ,{' '}
+                                <SyntaxHighlightedSearchQuery query="lang:" />,{' '}
+                                <SyntaxHighlightedSearchQuery query="case:" />,{' '}
+                                <SyntaxHighlightedSearchQuery query="fork:" />, and{' '}
+                                <SyntaxHighlightedSearchQuery query="visibility:" />.{' '}
                                 <SyntaxHighlightedSearchQuery query="OR" /> and{' '}
                                 <SyntaxHighlightedSearchQuery query="AND" /> expressions are also allowed.
                             </small>
@@ -458,7 +458,7 @@ export const SearchContextForm: React.FunctionComponent<SearchContextFormProps> 
                     <div className="mt-3">
                         <RadioButton
                             id="search_context_type_static"
-                            className={styles.searchContextFormTypeRadio}
+                            className={styles.searchContextFormRadio}
                             name="search_context_type"
                             value="static"
                             checked={contextType === 'static'}

--- a/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
@@ -411,7 +411,7 @@ export const SearchContextForm: React.FunctionComponent<SearchContextFormProps> 
                         >
                             search query
                         </Link>
-                        . For a static set, use JSON configuration.
+                        . For a static set, use the JSON configuration.
                     </div>
                     <div>
                         <RadioButton

--- a/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
@@ -417,7 +417,7 @@ export const SearchContextForm: React.FunctionComponent<SearchContextFormProps> 
                         >
                             search query
                         </Link>
-                        . For a static set, use tjhe JSON configuration.
+                        . For a static set, use the JSON configuration.
                     </div>
                     <div>
                         <RadioButton

--- a/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
@@ -449,13 +449,13 @@ export const SearchContextForm: React.FunctionComponent<SearchContextFormProps> 
                         </div>
                         <div className={classNames(styles.searchContextFormQueryLabel, 'text-muted')}>
                             <small>
-                                Valid filters: <SyntaxHighlightedSearchQuery query="repo:" />,{' '}
-                                <SyntaxHighlightedSearchQuery query="rev:" />,{' '}
-                                <SyntaxHighlightedSearchQuery query="file:" /> ,{' '}
-                                <SyntaxHighlightedSearchQuery query="lang:" />,{' '}
-                                <SyntaxHighlightedSearchQuery query="case:" />,{' '}
-                                <SyntaxHighlightedSearchQuery query="fork:" />, and{' '}
-                                <SyntaxHighlightedSearchQuery query="visibility:" />.{' '}
+                                Valid filters: <SyntaxHighlightedSearchQuery query="repo" />,{' '}
+                                <SyntaxHighlightedSearchQuery query="rev" />,{' '}
+                                <SyntaxHighlightedSearchQuery query="file" /> ,{' '}
+                                <SyntaxHighlightedSearchQuery query="lang" />,{' '}
+                                <SyntaxHighlightedSearchQuery query="case" />,{' '}
+                                <SyntaxHighlightedSearchQuery query="fork" />, and{' '}
+                                <SyntaxHighlightedSearchQuery query="visibility" />.{' '}
                                 <SyntaxHighlightedSearchQuery query="OR" /> and{' '}
                                 <SyntaxHighlightedSearchQuery query="AND" /> expressions are also allowed.
                             </small>

--- a/client/web/src/integration/search-contexts.test.ts
+++ b/client/web/src/integration/search-contexts.test.ts
@@ -168,7 +168,7 @@ describe('Search contexts', () => {
         await clearLocalStorage()
     })
 
-    test('Create search context', async () => {
+    test('Create static search context', async () => {
         testContext.overrideGraphQL({
             ...testContextForSearchContexts,
             RepositoriesByNames: ({ names }) => ({
@@ -186,7 +186,7 @@ describe('Search contexts', () => {
                     autoDefined: false,
                     updatedAt: '',
                     viewerCanManage: true,
-                    query: '',
+                    query: searchContext.query,
                     repositories: repositories.map(repository => ({
                         __typename: 'SearchContextRepositoryRevisions',
                         revisions: repository.revisions,
@@ -217,6 +217,9 @@ describe('Search contexts', () => {
             enterTextMethod: 'type',
         })
 
+        // Select JSON config option
+        await driver.page.click('#search-context-type-static')
+
         // Enter repositories
         const repositoriesConfig =
             '[{ "repository": "github.com/example/example", "revisions": ["main", "pr/feature1"] }]'
@@ -235,7 +238,75 @@ describe('Search contexts', () => {
         )
 
         // Take Snapshot
-        await percySnapshotWithVariants(driver.page, 'Create search context page')
+        await percySnapshotWithVariants(driver.page, 'Create static search context page')
+
+        // Click create
+        await driver.page.click('[data-testid="search-context-submit-button"]')
+
+        // Wait for submit request to finish and redirect to list page
+        await driver.page.waitForSelector('[data-testid="search-contexts-list-page"]')
+    })
+
+    test('Create dynamic query search context', async () => {
+        testContext.overrideGraphQL({
+            ...testContextForSearchContexts,
+            CreateSearchContext: ({ searchContext, repositories }) => ({
+                createSearchContext: {
+                    __typename: 'SearchContext',
+                    id: 'id1',
+                    spec: searchContext.name,
+                    name: searchContext.name,
+                    namespace: null,
+                    description: searchContext.description,
+                    public: searchContext.public,
+                    autoDefined: false,
+                    updatedAt: '',
+                    viewerCanManage: true,
+                    query: searchContext.query,
+                    repositories: repositories.map(repository => ({
+                        __typename: 'SearchContextRepositoryRevisions',
+                        revisions: repository.revisions,
+                        repository: { name: repository.repositoryID },
+                    })),
+                },
+            }),
+        })
+
+        await driver.page.goto(driver.sourcegraphBaseUrl + '/contexts/new')
+
+        await driver.replaceText({
+            selector: '[data-testid="search-context-name-input"]',
+            newText: 'new-context',
+            enterTextMethod: 'type',
+        })
+
+        // Assert spec preview
+        const specPreview = await driver.page.evaluate(
+            () => document.querySelector('[data-testid="search-context-preview"]')?.textContent
+        )
+        expect(specPreview).toBe('context:@test/new-context')
+
+        // Enter description
+        await driver.replaceText({
+            selector: '[data-testid="search-context-description-input"]',
+            newText: 'Search context description',
+            enterTextMethod: 'type',
+        })
+
+        // Select query option
+        await driver.page.click('#search-context-type-dynamic')
+
+        // Enter query
+        await driver.page.waitForSelector('[data-testid="search-context-dynamic-query"] .monaco-editor')
+        await driver.replaceText({
+            selector: '[data-testid="search-context-dynamic-query"] .monaco-editor',
+            newText: 'repo:abc',
+            selectMethod: 'keyboard',
+            enterTextMethod: 'paste',
+        })
+
+        // Take Snapshot
+        await percySnapshotWithVariants(driver.page, 'Create dynamic query search context page')
 
         // Click create
         await driver.page.click('[data-testid="search-context-submit-button"]')
@@ -329,7 +400,7 @@ describe('Search contexts', () => {
 
         // Enter repositories
         const repositoriesConfig =
-            '[{ "repository": "github.com/example/example", "revisions": ["main", "pr/feature1"] }]'
+            '[{ "repository": "github.com/example/example", "revisions": ["main", "pr/feature1"] }]'
         await driver.page.waitForSelector('[data-testid="repositories-config-area"] .monaco-editor')
         await driver.replaceText({
             selector: '[data-testid="repositories-config-area"] .monaco-editor',
@@ -500,7 +571,7 @@ describe('Search contexts', () => {
         })
 
         // Wait for correct number of total elements to load
-        await driver.page.waitFor(
+        await driver.page.waitForFunction(
             (searchContextsCount: number) =>
                 document.querySelectorAll('[data-testid="search-context-menu-item-name"]').length ===
                 searchContextsCount,

--- a/client/web/src/search/results/components/CreateSearchContextButton.tsx
+++ b/client/web/src/search/results/components/CreateSearchContextButton.tsx
@@ -7,7 +7,6 @@ import { omitFilter } from '@sourcegraph/shared/src/search/query/transformer'
 import { ButtonLink } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../../auth'
-import { getExperimentalFeatures } from '../../../stores'
 
 interface CreateSearchContextButtonProps {
     /** Search query string. */
@@ -18,8 +17,7 @@ interface CreateSearchContextButtonProps {
 }
 
 export const CreateSearchContextButton: React.FunctionComponent<CreateSearchContextButtonProps> = props => {
-    const experimentalFeatures = getExperimentalFeatures()
-    if (!experimentalFeatures.searchContextsQuery || !props.query || !props.authenticatedUser) {
+    if (!props.query || !props.authenticatedUser) {
         return null
     }
 

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -198,13 +198,6 @@ func overrideSearchType(input string, searchType query.SearchType) query.SearchT
 	return searchType
 }
 
-func getBoolPtr(b *bool, def bool) bool {
-	if b == nil {
-		return def
-	}
-	return *b
-}
-
 // searchResolver is a resolver for the GraphQL type `Search`
 type searchResolver struct {
 	*run.SearchInputs

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -82,8 +82,7 @@ func NewSearchImplementer(ctx context.Context, db database.DB, args *SearchArgs)
 		return nil, errors.New("Structural search is disabled in the site configuration.")
 	}
 
-	// Experimental: create a step to replace each context in the query with its repository query if any.
-	searchContextsQueryEnabled := settings.ExperimentalFeatures != nil && getBoolPtr(settings.ExperimentalFeatures.SearchContextsQuery, false)
+	// Beta: create a step to replace each context in the query with its repository query if any.
 	substituteContextsStep := query.SubstituteSearchContexts(func(context string) (string, error) {
 		sc, err := searchcontexts.ResolveSearchContextSpec(ctx, db, context)
 		if err != nil {
@@ -96,7 +95,7 @@ func NewSearchImplementer(ctx context.Context, db database.DB, args *SearchArgs)
 	var plan query.Plan
 	plan, err = query.Pipeline(
 		query.Init(args.Query, searchType),
-		query.With(searchContextsQueryEnabled, substituteContextsStep),
+		query.With(true, substituteContextsStep),
 	)
 	if err != nil {
 		return NewSearchAlertResolver(search.AlertForQuery(args.Query, err)).wrapSearchImplementer(db), nil

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -285,18 +285,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 	})
 
 	t.Run("context: search query", func(t *testing.T) {
-		err := client.OverwriteSettings(client.AuthenticatedUserID(), `{"experimentalFeatures":{"searchContextsQuery": true}}`)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer func() {
-			err := client.OverwriteSettings(client.AuthenticatedUserID(), `{}`)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
-
-		_, err = client.Repository("github.com/sgtest/java-langserver")
+		_, err := client.Repository("github.com/sgtest/java-langserver")
 		require.NoError(t, err)
 		_, err = client.Repository("github.com/sgtest/jsonrpc2")
 		require.NoError(t, err)

--- a/internal/database/search_contexts.go
+++ b/internal/database/search_contexts.go
@@ -373,10 +373,6 @@ func (s *searchContextsStore) UpdateSearchContextWithRepositoryRevisions(ctx con
 }
 
 func (s *searchContextsStore) SetSearchContextRepositoryRevisions(ctx context.Context, searchContextID int64, repositoryRevisions []*types.SearchContextRepositoryRevisions) (err error) {
-	if len(repositoryRevisions) == 0 {
-		return nil
-	}
-
 	tx, err := s.Transact(ctx)
 	if err != nil {
 		return err
@@ -386,6 +382,10 @@ func (s *searchContextsStore) SetSearchContextRepositoryRevisions(ctx context.Co
 	err = tx.Exec(ctx, sqlf.Sprintf("DELETE FROM search_context_repos WHERE search_context_id = %d", searchContextID))
 	if err != nil {
 		return err
+	}
+
+	if len(repositoryRevisions) == 0 {
+		return nil
 	}
 
 	values := []*sqlf.Query{}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1587,7 +1587,7 @@ type SettingsExperimentalFeatures struct {
 	FuzzyFinder *bool `json:"fuzzyFinder,omitempty"`
 	// FuzzyFinderCaseInsensitiveFileCountThreshold description: The maximum number of files a repo can have to use case-insensitive fuzzy finding
 	FuzzyFinderCaseInsensitiveFileCountThreshold *float64 `json:"fuzzyFinderCaseInsensitiveFileCountThreshold,omitempty"`
-	// SearchContextsQuery description: Enables query based search contexts
+	// SearchContextsQuery description: DEPRECATED: This feature is now permanently enabled. Enables query based search contexts
 	SearchContextsQuery *bool `json:"searchContextsQuery,omitempty"`
 	// SearchStats description: Enables a button on the search results page that shows language statistics about the results for a search query.
 	SearchStats *bool `json:"searchStats,omitempty"`

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -71,7 +71,7 @@
           }
         },
         "searchContextsQuery": {
-          "description": "Enables query based search contexts",
+          "description": "DEPRECATED: This feature is now permanently enabled. Enables query based search contexts",
           "type": "boolean",
           "default": false,
           "!go": {


### PR DESCRIPTION
Paired with @tsenart to fully enable the dynamic query for search contexts. The feature is now designated as beta and enabled by default.

Screenshot:

<img width="709" alt="Screenshot 2022-02-09 at 14 20 01" src="https://user-images.githubusercontent.com/6417322/153209376-b6d20be4-348d-4eb6-9954-a18f27542093.png">

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Tested the creation and editing of search contexts with the new query option. Verified at each step that only one of the options (either JSON config or query) is being saved and displayed.

* Create a new search context with the JSON config
* Save & confirm it works in search
* Edit the same context to now use the dynamic query
* Save & confirm it works in search
* Edit the same context to use the JSON config
* Save & confirm it works in search
