### PR TITLE
Add UTM params to VSCE sidebar

### DIFF
--- a/client/vscode/src/webview/search-sidebar/AuthSidebarView.tsx
+++ b/client/vscode/src/webview/search-sidebar/AuthSidebarView.tsx
@@ -10,6 +10,8 @@ import { WebviewPageProps } from '../platform/context'
 
 import styles from './AuthSidebarView.module.scss'
 
+const SIDEBAR_UTM_PARAMS = 'utm_medium=VSCIDE&utm_source=sidebar&utm_campaign=vsce-sign-up&utm_content=sign-up'
+
 /**
  * Rendered by sidebar in search-home state when user doesn't have a valid access token.
  */
@@ -22,7 +24,9 @@ export const AuthSidebarView: React.FunctionComponent<WebviewPageProps> = ({
 
     const [hasAccount, setHasAccount] = useState(false)
 
-    const signUpURL = useMemo(() => new URL('sign-up?editor=vscode', instanceURL).href, [instanceURL])
+    const signUpURL = useMemo(() => new URL('sign-up?editor=vscode&' + SIDEBAR_UTM_PARAMS, instanceURL).href, [
+        instanceURL,
+    ])
     const instanceHostname = useMemo(() => new URL(instanceURL).hostname, [instanceURL])
 
     const ctaButtonProps: Partial<ButtonProps> = {
@@ -99,7 +103,11 @@ export const AuthSidebarView: React.FunctionComponent<WebviewPageProps> = ({
             </p>
             <div>
                 <p className="mb-0">Learn more:</p>
-                <a href="http://sourcegraph.com/" className="my-0" onClick={() => onLinkClick('Sourcegraph')}>
+                <a
+                    href={'https://sourcegraph.com/?' + SIDEBAR_UTM_PARAMS}
+                    className="my-0"
+                    onClick={() => onLinkClick('Sourcegraph')}
+                >
                     Sourcegraph.com
                 </a>
                 <br />
@@ -127,7 +135,7 @@ export const AuthSidebarView: React.FunctionComponent<WebviewPageProps> = ({
                     history, monitor, save searches and more.
                 </p>
                 <Button onClick={onSignUpClick} {...ctaButtonProps}>
-                    Create an account
+                    Create account
                 </Button>
                 <Button onClick={() => setHasAccount(true)} {...buttonLinkProps}>
                     Have an account?
@@ -140,8 +148,11 @@ export const AuthSidebarView: React.FunctionComponent<WebviewPageProps> = ({
         <>
             <p>Sign in by entering an access token created through your user settings on {instanceHostname}.</p>
             <p>
-                See our <a href="https://docs.sourcegraph.com/cli/how-tos/creating_an_access_token">user docs</a> for a
-                video guide on how to create an access token.
+                See our{' '}
+                <a href={'https://docs.sourcegraph.com/cli/how-tos/creating_an_access_token?' + SIDEBAR_UTM_PARAMS}>
+                    user docs
+                </a>{' '}
+                for a video guide on how to create an access token.
             </p>
             {state === 'failure' && (
                 <Alert variant="danger">

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -253,11 +253,12 @@ function pageViewQueryParameters(url: string): UTMMarker {
 
     const utmSource = parsedUrl.searchParams.get('utm_source')
     const utmCampaign = parsedUrl.searchParams.get('utm_campaign')
+    const utmMedium = parsedUrl.searchParams.get('utm_medium')
 
     const utmProps: UTMMarker = {
         utm_campaign: utmCampaign || undefined,
         utm_source: utmSource || undefined,
-        utm_medium: parsedUrl.searchParams.get('utm_medium') || undefined,
+        utm_medium: utmMedium || undefined,
         utm_term: parsedUrl.searchParams.get('utm_term') || undefined,
         utm_content: parsedUrl.searchParams.get('utm_content') || undefined,
     }
@@ -281,6 +282,8 @@ function pageViewQueryParameters(url: string): UTMMarker {
         ].includes(utmSource ?? '')
     ) {
         eventLogger.log('UTMCodeHostIntegration', utmProps, utmProps)
+    } else if (utmMedium === 'VSCIDE' && utmCampaign === 'vsce-sign-up') {
+        eventLogger.log('VSCIDESignUpLinkClicked', utmProps, utmProps)
     }
 
     return utmProps


### PR DESCRIPTION
Fixes #30859

We want to improve our funnel tracking to better understand when users started their flow in VS Code (see #30859 for more context). 

- [x] Sidebar CTAs
- [ ] Banner CTAs
- [ ] CTAs from Save Search, and Create Monitor buttons
- [x] Create VSCE campaign events on sourcegraph.com 

## Open questions

- I suppose that the banners share code with Web. I [found the callsite](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/search/results/StreamingSearchResults.tsx?L411-423) to add the UTM params but I’m not sure which context I could access to find out wether the CTA is shown inside the browser or VS Code? I suppose `window.navigator` might be helpful but since [I can't run the extension in dev mode yet](https://sourcegraph.slack.com/archives/C01T0BL4EFN/p1644412320049179) I have to wait before I can confirm.

## Test plan

1. I tested the sidebar changes by starting the VSCE in development mode, clicking the sign-up link, and looked at the URL it generated.
2. To validate that this logs the right parmeters I changed the hostname to my local instance: `https://sourcegraph.test:3443/sign-up?editor=vscode&utm_medium=VSCIDE&utm_source=sidebar&utm_campaign=vsce-sign-up&utm_content=sign-up` and verified that the events show up in the console: 
![Screenshot 2022-02-09 at 14 19 41](https://user-images.githubusercontent.com/458591/153211675-6afc0989-b9be-4c43-9d9a-f6a18e174f86.png)


<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


