### PR TITLE
Search Jobs: expand acceptable timing windows for job tests

### DIFF
--- a/internal/search/run/combinators_test.go
+++ b/internal/search/run/combinators_test.go
@@ -112,10 +112,8 @@ func TestTimeoutJob(t *testing.T) {
 			return nil, ctx.Err()
 		})
 		timeoutJob := NewTimeoutJob(10*time.Millisecond, timeoutWaiter)
-		start := time.Now()
 		_, err := timeoutJob.Run(context.Background(), nil, nil)
 		require.ErrorIs(t, err, context.DeadlineExceeded)
-		require.WithinDuration(t, time.Now(), start.Add(10*time.Millisecond), 5*time.Millisecond)
 	})
 
 	t.Run("early return returns early", func(t *testing.T) {
@@ -128,7 +126,7 @@ func TestTimeoutJob(t *testing.T) {
 				return nil, ctx.Err()
 			}
 		})
-		timeoutJob := NewTimeoutJob(20*time.Millisecond, timeoutWaiter)
+		timeoutJob := NewTimeoutJob(time.Second, timeoutWaiter)
 		start := time.Now()
 		_, err := timeoutJob.Run(context.Background(), nil, nil)
 		require.NoError(t, err)
@@ -152,7 +150,7 @@ func TestParallelJob(t *testing.T) {
 		start := time.Now()
 		_, err := parallelJob.Run(context.Background(), nil, nil)
 		require.NoError(t, err)
-		require.WithinDuration(t, time.Now(), start.Add(10*time.Millisecond), 5*time.Millisecond)
+		require.WithinDuration(t, time.Now(), start.Add(20*time.Millisecond), 10*time.Millisecond)
 	})
 
 	t.Run("errors are aggregated", func(t *testing.T) {
@@ -210,7 +208,7 @@ func TestPriorityJob(t *testing.T) {
 		job := NewPriorityJob(required, optional)
 		_, err := job.Run(context.Background(), nil, nil)
 		require.ErrorIs(t, err, context.Canceled)
-		require.WithinDuration(t, time.Now(), start.Add(100*time.Millisecond), 10*time.Millisecond)
+		require.WithinDuration(t, time.Now(), start.Add(100*time.Millisecond), 40*time.Millisecond)
 	})
 
 	t.Run("optional job has some time to complete", func(t *testing.T) {
@@ -229,7 +227,7 @@ func TestPriorityJob(t *testing.T) {
 		job := NewPriorityJob(required, optional)
 		_, err := job.Run(context.Background(), nil, nil)
 		require.NoError(t, err, context.Canceled)
-		require.WithinDuration(t, time.Now(), start.Add(50*time.Millisecond), 10*time.Millisecond)
+		require.WithinDuration(t, time.Now(), start.Add(50*time.Millisecond), 30*time.Millisecond)
 	})
 
 	t.Run("NewPriorityJob", func(t *testing.T) {

--- a/internal/search/run/expression_job_test.go
+++ b/internal/search/run/expression_job_test.go
@@ -57,11 +57,8 @@ func TestAndJob(t *testing.T) {
 				_, err := j.Run(context.Background(), nil, s)
 				require.NoError(t, err)
 
-				// we should wait ~10ms for all parallel subexpressions to complete
-				require.WithinDuration(t, start.Add(10*time.Millisecond), time.Now(), 3*time.Millisecond)
-
-				// event should be streamed ~immediately
-				require.Less(t, eventTime.Sub(start), time.Millisecond)
+				// event should be streamed ~immediately (definitely before the jobs exit)
+				require.Less(t, eventTime.Sub(start), 5*time.Millisecond)
 			})
 		}
 	})
@@ -109,7 +106,7 @@ func TestOrJob(t *testing.T) {
 				})
 				_, err := j.Run(context.Background(), nil, s)
 				require.NoError(t, err)
-				require.Less(t, eventTime.Sub(start), time.Millisecond)
+				require.Less(t, eventTime.Sub(start), 5*time.Millisecond)
 			})
 		}
 	})


### PR DESCRIPTION
This should help stabilize these tests in CI. 
Timing-based tests on CI are much less consistent than locally. This
expands the range of acceptable time ranges to hopefully make them more
stable. In the ideal world, these tests would not depend on timings at all. However,
they currently cover the "is my and/or job actually streaming" question, which 
is a valuable thing to test. If these continue to be problematic, (and probably
eventually anyways), I'll move testing to the more deterministic `merger`
type. 



## Test plan

This PR only updates tests. 


