### PR TITLE
Fix bext options page > advanced settings

### DIFF
--- a/client/browser/src/browser-extension/scripts/afterInstallPage.main.tsx
+++ b/client/browser/src/browser-extension/scripts/afterInstallPage.main.tsx
@@ -11,7 +11,7 @@ import { ThemeWrapper } from '../ThemeWrapper'
 const AfterInstallPage: React.FunctionComponent = () => (
     <ThemeWrapper>
         {({ isLightTheme }) => (
-            <WildcardThemeProvider>
+            <WildcardThemeProvider isBranded={true}>
                 <AfterInstallPageContent isLightTheme={isLightTheme} />
             </WildcardThemeProvider>
         )}

--- a/client/browser/src/browser-extension/scripts/optionsPage.main.tsx
+++ b/client/browser/src/browser-extension/scripts/optionsPage.main.tsx
@@ -215,7 +215,7 @@ const Options: React.FunctionComponent = () => {
 
     return (
         <ThemeWrapper>
-            <WildcardThemeProvider>
+            <WildcardThemeProvider isBranded={true}>
                 <OptionsPage
                     isFullPage={isFullPage}
                     sourcegraphUrl={sourcegraphUrl || ''}

--- a/client/browser/src/shared/code-hosts/shared/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/shared/codeHost.tsx
@@ -1543,7 +1543,7 @@ export function injectCodeIntelligenceToCodeHost(
     const hideActions = codeHost.type === 'gerrit'
 
     const renderWithThemeProvider = (element: React.ReactNode, container: Element | null): void =>
-        reactDOMRender(<WildcardThemeProvider>{element}</WildcardThemeProvider>, container)
+        reactDOMRender(<WildcardThemeProvider isBranded={false}>{element}</WildcardThemeProvider>, container)
 
     subscriptions.add(
         // eslint-disable-next-line rxjs/no-async-subscribe, @typescript-eslint/no-misused-promises

--- a/client/browser/src/shared/components/WildcardThemeProvider.tsx
+++ b/client/browser/src/shared/components/WildcardThemeProvider.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
-import { WildcardThemeContext } from '@sourcegraph/wildcard'
+import { WildcardTheme, WildcardThemeContext } from '@sourcegraph/wildcard'
 
-export const WildcardThemeProvider: React.FunctionComponent = ({ children }) => (
-    <WildcardThemeContext.Provider value={{ isBranded: false }}>{children}</WildcardThemeContext.Provider>
+export const WildcardThemeProvider: React.FunctionComponent<WildcardTheme> = ({ children, ...props }) => (
+    <WildcardThemeContext.Provider value={props}>{children}</WildcardThemeContext.Provider>
 )


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/30897.

## Description
After https://github.com/sourcegraph/sourcegraph/pull/30621 browser extension > advanced settings button/link styles were broken.

## Screenshots (TODO: if applicable)
| Before | After |
| -: | :- |
| ![image](https://user-images.githubusercontent.com/6717049/153234435-688164b1-22a0-40c4-9d26-fb754e3d73b0.png)| ![image](https://user-images.githubusercontent.com/6717049/153234591-166c08a2-780e-4670-b228-b23701a567a7.png)|

## Before merging

- [ ] Test on different code hosts (if applicable)
    - [ ] GitHub
    - [ ] Gitlab
    - [ ] GitHub Enterprise
    - [ ] Refined GitHub
    - [ ] Phabricator
    - [ ] Phabricator integration
    - [ ] Bitbucket
    - [ ] Bitbucket integration

- [ ] Test on different browsers (if applicable)
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
- [ ] Add change log message to [client/browser/CHANGELOG.md](./client/browser/CHANGELOG.md), under "Unreleased" section. (if applicable)

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


