### PR TITLE
Use proper form ID for the post-sign-up teams beta step

### DIFF
--- a/client/web/src/auth/welcome/TeamsBeta.tsx
+++ b/client/web/src/auth/welcome/TeamsBeta.tsx
@@ -12,7 +12,7 @@ import styles from './TeamsBeta.module.scss'
 import { useHubSpotForm } from './useHubSpotForm'
 
 const PORTAL_ID = '2762526'
-const FORM_ID = 'e0e43746-83e9-4133-97bd-9954a60c7af8'
+const FORM_ID = 'b65cc7a2-75ad-4114-be4c-cd9637e7c068'
 
 interface TeamsBeta {
     onFinish: FinishWelcomeFlow


### PR DESCRIPTION
It seems that I made a mistake on the last iteration of https://github.com/sourcegraph/sourcegraph/pull/30413 and we were showing the wrong HubSpot form for the post-sign-up step.

This means that any new leads up until now where added to the old table rather than the new. 😞 


## Test plan

You can see the hidden value of the new field using the inspect DOM feature. This now properly shows `post-signup`.

![Screenshot 2022-02-09 at 18 09 26](https://user-images.githubusercontent.com/458591/153253147-8f6416bb-9cd3-40d4-a114-726f8a1c022b.png)


<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


