### PR TITLE
update docsite and remove insights from the docs pages

### DIFF
--- a/dev/docsite.sh
+++ b/dev/docsite.sh
@@ -5,7 +5,7 @@ set -euf -o pipefail
 pushd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null
 
 # Update DOCSITE_VERSION everywhere in all places (including outside this repo)
-version=v1.8.5
+version=v1.8.6
 suffix="${version}_$(go env GOOS)_$(go env GOARCH)"
 url="https://github.com/sourcegraph/docsite/releases/download/${version}/docsite_${suffix}"
 

--- a/doc/docsite.json
+++ b/doc/docsite.json
@@ -8,5 +8,6 @@
   "assetsBaseURLPath": "/assets/",
   "check": {
     "ignoreURLPattern": "(^https?://)|(^#)|(^mailto:(hi|support|security|feedback)@sourcegraph\\.com(\\?|$))|(^chrome://)|(^/@)"
-  }
+  },
+  "search": {"skipIndexURLPattern": ".*insights.*"}
 }

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -338,7 +338,7 @@ commands:
         -o .bin/docsite_${DOCSITE_VERSION} && chmod +x .bin/docsite_${DOCSITE_VERSION}
       fi
     env:
-      DOCSITE_VERSION: v1.8.5 # Update DOCSITE_VERSION in all places (including outside this repo)
+      DOCSITE_VERSION: v1.8.6 # Update DOCSITE_VERSION in all places (including outside this repo)
 
   syntax-highlighter:
     ignoreStdout: true
@@ -992,4 +992,4 @@ tests:
   docsite:
     cmd: .bin/docsite_${DOCSITE_VERSION} check ./doc
     env:
-      DOCSITE_VERSION: v1.8.5 # Update DOCSITE_VERSION everywhere in all places (including outside this repo)
+      DOCSITE_VERSION: v1.8.6 # Update DOCSITE_VERSION everywhere in all places (including outside this repo)


### PR DESCRIPTION
Updates docsite to 1.8.6 in the dev tools, and updates the dev tool docsite config to match prod: https://github.com/sourcegraph/deploy-sourcegraph-cloud/pull/15530

## Test plan

Before:
<img width="747" alt="image" src="https://user-images.githubusercontent.com/5090588/153264611-a2242b4c-7aa7-4afe-81f9-2fb5a8fbbe4e.png">

After
<img width="1504" alt="CleanShot 2022-02-09 at 11 00 35@2x" src="https://user-images.githubusercontent.com/5090588/153263164-81e9c17b-67a0-4d29-bfca-a9c3b99018f8.png">



<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


