### PR TITLE
ci: fix bug with script cwd

### DIFF
--- a/enterprise/dev/ci/scripts/annotate.sh
+++ b/enterprise/dev/ci/scripts/annotate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd "$(dirname "${BASH_SOURCE[0]}")/../../"
+cd "$(dirname "${BASH_SOURCE[0]}")/../../../.."
 set -e
 
 if [[ -z "$BUILDKITE" ]]; then

--- a/enterprise/dev/ci/scripts/upload-build-logs.sh
+++ b/enterprise/dev/ci/scripts/upload-build-logs.sh
@@ -22,7 +22,7 @@ source /root/.profile
 
 set -euo pipefail
 
-cd "$(dirname "${BASH_SOURCE[0]}")"/../..
+cd "$(dirname "${BASH_SOURCE[0]}")"/../../../..
 
 echo "--- :go: Building sg"
 (


### PR DESCRIPTION
This fixes a bug with the moved script, the CWD code wasn't updated. 

## Test plan

Tested the path locally (`set -e` was disabled to allow running the command up to the faulty dir change)

Before: 

```
~/work/sourcegraph U devx/fix-logs-uploading $ ./enterprise/dev/ci/scripts/upload-build-logs.sh
./enterprise/dev/ci/scripts/upload-build-logs.sh: line 21: /root/.profile: No such file or directory
--- :go: Building sg
+ pushd dev/sg
./enterprise/dev/ci/scripts/upload-build-logs.sh: line 30: pushd: dev/sg: No such file or directory
+ go build -o ../../sg -ldflags '-X main.BuildCommit=' -mod=mod .
no Go files in /Users/tech/work/sourcegraph/enterprise/dev
+ popd
./enterprise/dev/ci/scripts/upload-build-logs.sh: line 32: popd: directory stack empty
--- :file_cabinet: Uploading logs
```

After:

```
~/work/sourcegraph U devx/fix-logs-uploading $ ./enterprise/dev/ci/scripts/upload-build-logs.sh
./enterprise/dev/ci/scripts/upload-build-logs.sh: line 21: /root/.profile: No such file or directory
--- :go: Building sg
+ pushd dev/sg
~/work/sourcegraph/dev/sg ~/work/sourcegraph
+ go build -o ../../sg -ldflags '-X main.BuildCommit=' -mod=mod .
+ popd
~/work/sourcegraph
```

It's building `sg` properly, so the path is correct. 