### PR TITLE
Aa/unify headers

### DIFF
--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.module.scss
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.module.scss
@@ -39,3 +39,10 @@
     max-width: 1000px;
     margin-top: 1rem;
 }
+
+.header {
+    align-self: flex-start;
+    width: 100%;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--border-color);
+}

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -355,7 +355,7 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({
                     {/* <animated.h4 className=“overflow-hidden” style={headerStyle}>
                         Library
                     </animated.h4>                    */}
-                    <h4>Batch Specification</h4>
+                    <h4 className={styles.header}>Batch specification</h4>
                     <MonacoBatchSpecEditor
                         batchChangeName={batchChange.name}
                         className={styles.editor}

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -191,6 +191,9 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({
     isLightTheme,
     settingsCascade,
 }) => {
+    ;<animated.h4 className="overflow-hidden" style={headerStyle}>
+        Library
+    </animated.h4>
     // Get the latest batch spec for the batch change.
     const { batchSpec, isApplied: isLatestBatchSpecApplied, initialCode: initialBatchSpecCode } = useInitialBatchSpec(
         batchChange

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -191,9 +191,6 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({
     isLightTheme,
     settingsCascade,
 }) => {
-    ;<animated.h4 className="overflow-hidden" style={headerStyle}>
-        Library
-    </animated.h4>
     // Get the latest batch spec for the batch change.
     const { batchSpec, isApplied: isLatestBatchSpecApplied, initialCode: initialBatchSpecCode } = useInitialBatchSpec(
         batchChange
@@ -355,6 +352,10 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({
             <div className={classNames(styles.editorLayoutContainer, 'd-flex flex-1')}>
                 <LibraryPane name={batchChange.name} onReplaceItem={clearErrorsAndHandleCodeChange} />
                 <div className={styles.editorContainer}>
+                    {/* <animated.h4 className=“overflow-hidden” style={headerStyle}>
+                        Library
+                    </animated.h4>                    */}
+                    <h4>Batch Specification</h4>
                     <MonacoBatchSpecEditor
                         batchChangeName={batchChange.name}
                         className={styles.editor}

--- a/client/web/src/enterprise/batches/create/library/LibraryPane.module.scss
+++ b/client/web/src/enterprise/batches/create/library/LibraryPane.module.scss
@@ -22,3 +22,11 @@
     border: none;
     padding: 0;
 }
+
+.header {
+    align-self: flex-start;
+    width: 100%;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--border-color);
+    overflow: hidden;
+}

--- a/client/web/src/enterprise/batches/create/library/LibraryPane.tsx
+++ b/client/web/src/enterprise/batches/create/library/LibraryPane.tsx
@@ -103,9 +103,9 @@ export const LibraryPane: React.FunctionComponent<LibraryPaneProps> = ({ name, o
             ) : null}
             <animated.div style={containerStyle} className="d-flex flex-column mr-1">
                 <div className="d-flex align-items-center justify-content-center pb-1">
-                    <animated.h5 className="overflow-hidden" style={headerStyle}>
+                    <animated.h4 className="overflow-hidden" style={headerStyle}>
                         Library
-                    </animated.h5>
+                    </animated.h4>
                     <div className={styles.collapseButton}>
                         <Button
                             className="p-0"

--- a/client/web/src/enterprise/batches/create/library/LibraryPane.tsx
+++ b/client/web/src/enterprise/batches/create/library/LibraryPane.tsx
@@ -51,10 +51,12 @@ export const LibraryPane: React.FunctionComponent<LibraryPaneProps> = ({ name, o
     const [containerStyle, animateContainer] = useSpring(() => ({
         width: collapsed ? BUTTON_WIDTH : CONTENT_WIDTH,
     }))
+
     const [headerStyle, animateHeader] = useSpring(() => ({
         opacity: collapsed ? 0 : 1,
         width: collapsed ? '0rem' : CONTENT_WIDTH,
     }))
+
     const [contentStyle, animateContent] = useSpring(() => ({
         display: collapsed ? 'none' : 'block',
         opacity: collapsed ? 0 : 1,
@@ -103,7 +105,7 @@ export const LibraryPane: React.FunctionComponent<LibraryPaneProps> = ({ name, o
             ) : null}
             <animated.div style={containerStyle} className="d-flex flex-column mr-1">
                 <div className="d-flex align-items-center justify-content-center pb-1">
-                    <animated.h4 className="overflow-hidden" style={headerStyle}>
+                    <animated.h4 className={styles.header} style={headerStyle}>
                         Library
                     </animated.h4>
                     <div className={styles.collapseButton}>

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.tsx
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.tsx
@@ -166,7 +166,7 @@ export const WorkspacesPreview: React.FunctionComponent<WorkspacesPreviewProps> 
 
     return (
         <div className="d-flex flex-column align-items-center w-100 h-100">
-            <h3 className={styles.header}>
+            <h4 className={styles.header}>
                 Workspaces preview{' '}
                 {(batchSpecStale || !hasPreviewed) && shouldShowConnection && (
                     <WarningIcon
@@ -174,7 +174,7 @@ export const WorkspacesPreview: React.FunctionComponent<WorkspacesPreviewProps> 
                         data-tooltip="The workspaces previewed below may not be up-to-date."
                     />
                 )}
-            </h3>
+            </h4>
             {/* We wrap this section in its own div to prevent margin collapsing within the flex column */}
             <div className="d-flex flex-column align-items-center w-100 mb-3">
                 {error && <ErrorAlert error={error} className="w-100 mb-0" />}


### PR DESCRIPTION
Closes issue #30464

**Minor UI improvements to address Kelli & Rob's feedback of:**
- Library header should be h4 and not capitalized
- Editor should have batch spec header
- Workspaces preview header should be h4
- All three should have single underline

**Result**
<img width="1772" alt="Screen Shot 2022-02-09 at 2 07 47 PM" src="https://user-images.githubusercontent.com/67931373/153272319-e8e3e5dc-09f5-40af-aa0b-629afae3de83.png">

**Questions**
Looking at my photo preview, you can see the underline under the Library and Batch specification headers are in line but that is not true for the Workspaces preview header, which is slightly pushed down. Workspaces preview has the following class:
`<h4 className={styles.header}>Workspaces preview</h4>
`

Which is loaded from this file:

<img width="583" alt="Screen Shot 2022-02-09 at 2 12 40 PM" src="https://user-images.githubusercontent.com/67931373/153273049-a6d6b928-ae91-4eb0-be71-e4b3cb37bc2e.png">

I'm not very familiar on how to go about finding and editing these styles. Can someone tell me how I can fix the padding?
 
Alsooooo.. i'm not clear why stuff from my last pull request on a different branch that was already merged is showing up in this PR? :( 

