### PR TITLE
sg ci logs: add -out=json and -out=simple, rename -out=stdout to -out=terminal

### DIFF
--- a/dev/sg/internal/bk/logs.go
+++ b/dev/sg/internal/bk/logs.go
@@ -1,0 +1,18 @@
+package bk
+
+import (
+	"regexp"
+	"strings"
+)
+
+// CleanANSI cleans up Buildkite log output markup.
+func CleanANSI(s string) string {
+	// https://github.com/acarl005/stripansi/blob/master/stripansi.go
+	ansi := regexp.MustCompile("[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))")
+	s = ansi.ReplaceAllString(s, "")
+	// Other weird markers not caught be above regex
+	s = strings.ReplaceAll(s, "\x1BE", "")
+	s = strings.ReplaceAll(s, "\x1b", "")
+	s = strings.ReplaceAll(s, "\a", "")
+	return s
+}

--- a/dev/sg/internal/loki/loki.go
+++ b/dev/sg/internal/loki/loki.go
@@ -54,18 +54,6 @@ type StreamLabels struct {
 	Branch string `json:"branch"`
 }
 
-// Logs come out with a ton yikes
-func cleanAnsi(s string) string {
-	// https://github.com/acarl005/stripansi/blob/master/stripansi.go
-	ansi := regexp.MustCompile("[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))")
-	s = ansi.ReplaceAllString(s, "")
-	// Other weird markers not caught be above regex
-	s = strings.ReplaceAll(s, "\x1BE", "")
-	s = strings.ReplaceAll(s, "\x1b", "")
-	s = strings.ReplaceAll(s, "\a", "")
-	return s
-}
-
 // NewStreamFromJobLogs cleans the given log data, splits it into log entries, merges
 // entries with the same timestamp, and returns a Stream that can be pushed to Loki.
 func NewStreamFromJobLogs(log *bk.JobLogs) (*Stream, error) {
@@ -74,7 +62,7 @@ func NewStreamFromJobLogs(log *bk.JobLogs) (*Stream, error) {
 		App:       "buildkite",
 		Component: "build-logs",
 	}
-	cleanedContent := cleanAnsi(*log.Content)
+	cleanedContent := bk.CleanANSI(*log.Content)
 
 	// seems to be some kind of buildkite line separator, followed by a timestamp
 	const bkTimestampSeparator = "_bk;"


### PR DESCRIPTION
Checking if https://github.com/sourcegraph/sourcegraph/pull/30915 's hiding of verbose logs is done through markup, and whether stripping markup might reveal content. Unfortunately not :(

However this seems potentially useful to have handy:

- `-out=simple` if you don't want colours
- `-out=json` if you want to manipulate logs yourself or something, or debug the Loki logs adapter
- `-out=terminal` is more specific than `-out=stdout`

## Test plan

```sh
go run ./dev/sg ci logs -branch=devx/ci-improve-go-output # same as before
go run ./dev/sg ci logs -branch=devx/ci-improve-go-output -out=simple # no colors!
go run ./dev/sg ci logs -branch=devx/ci-improve-go-output -out=json # json format
```

