### PR TITLE
doc/dev: adjustments to testing guidelines

### DIFF
--- a/doc/dev/background-information/testing_principles.md
+++ b/doc/dev/background-information/testing_principles.md
@@ -2,9 +2,7 @@
 
 <span class="badge badge-note">SOC2/GN-105</span>
 
-This file documents how we test code at Sourcegraph.
-
-Related pages: [How to write and run tests](../how-to/testing.md) | [Testing Go code](languages/testing_go_code.md) | [Testing web code](testing_web_code.md) | [Continuous integration](continuous_integration.md)
+This page documents how we test code at Sourcegraph.
 
 ## Policy
 
@@ -15,7 +13,13 @@ Any addition or change to our codebase should be covered by an appropriate amoun
 1. Our product and code works as intended when we ship it to customers.
 1. Our product and code doesn't accidentally break as we make changes over time.
 
-Engineers should budget an appropriate amount of time for ensuring test plans are made for all changes when making iteration plans. **All pull requests must provide test plans** that indicate what has been done to test the changes being introduced. This can be done with a "Test plan" section within a pull request's description. Also see [Exceptions](#exceptions).
+Engineers should budget an appropriate amount of time for ensuring [test plans](#test-plans) are made for all changes when making iteration plans.
+
+### Test plans
+
+**All pull requests must provide test plans** that indicate what has been done to test the changes being introduced. This can be done with a "Test plan" section within a pull request's description.
+
+Some pull requests may not require a rigorous test plan - see [Exceptions](#exceptions).
 
 ## Types of tests
 
@@ -32,9 +36,11 @@ A good automated test suite increases the velocity of our team because it allows
 The testing pyramid is a helpful way to determine the most appropriate type of test when deciding how to test a change:
 
 ![Testing pyramid](testing-pyramid.svg)
-The closer a test is to the bottom, the larger the scope of that test is. It means that failures will be harder to link to the actual cause. Tests at the bottom are notoriously slower than at the top. 
 
-It's important to take into account this trade-off when deciding at which level to implement a test. Please refer to each testing level below for more details.
+The closer a test is to the bottom, the larger the scope of that test is. It means that failures will be harder to link to the actual cause. Tests at the bottom are notoriously slower than at the top.
+
+It's important to take these trade-offs into account when deciding at which level to implement a test. Please refer to each testing level below for more details.
+
 #### Unit tests
 
 Unit tests test individual functions in our codebase and are the most desirable kind of test to write.
@@ -99,12 +105,29 @@ We use [Percy](https://percy.io/) to detect visual changes in Sourcegraph featur
 
 - Targeted [code reviews](pull_request_reviews.md) can help ensure changes are appropriately tested.
   - If a change contains changes pertaining to the processing or storing of credentials or tokens, authorization, and authentication methods, the `security` label should be added and a review should be requested from members of the [Sourcegraph Security team](https://handbook.sourcegraph.com/departments/product-engineering/engineering/cloud/security)
-  - If a change requires changes to self-managed, managed, or Sourcegraph Cloud deployment methods, reviews from members of the relevant [DevOps teams](https://handbook.sourcegraph.com/departments/product-engineering/engineering/cloud/devops) should be requested
+  - If a change requires changes to self-managed, managed, or Sourcegraph Cloud deployment methods, reviews from members of the relevant [Sourcegraph DevOps teams](https://handbook.sourcegraph.com/departments/product-engineering/engineering/cloud/devops) should be requested
   - Performance-sensitive changes should undergo reviews from other engineers to assess potential performance implications.
 - Deployment considerations can help test things live, detect when things have gone wrong, and limit the scope of risks.
-  - For high-risk changes, consider using feature flags, such as by rolling a change out to just Sourcegraph teammates and/or to a subset of production customers before rolling it out to all customers in Sourcegraph Cloud or a full release.
+  - For high-risk changes, consider using [feature flags](../how-to/use_feature_flags.md), such as by rolling a change out to just Sourcegraph teammates and/or to a subset of production customers before rolling it out to all customers in Sourcegraph Cloud or a full release.
   - Introduce adequate [observability measures](observability/index.md) so that issues can easily be detected and monitored.
 - Documentation can help ensure that changes are easy to understand if anything goes wrong, and should be added to [sources of truth](https://handbook.sourcegraph.com/company-info-and-process/communication#sources-of-truth).
+  - If the documentation will be published to docs.sourcegraph.com, it can be tested by running `sg run docsite` and navigating to the corrected page.
+- Some changes are easy to test manually - test plans can include what was done to perform this manual testing.
+
+## Exceptions
+
+If for a situational reason, a pull request needs to be exempted from the testing guidelines, skipping reviews or not providing a [test plan](#test-plans) will trigger an automated process that create and link an issue requesting that the author document a reason for the exception within [sourcegraph/sec-pr-audit-trail](https://github.com/sourcegraph/sec-pr-audit-trail).
+
+Explanations for exceptions can also simply be provided within a pull request's [test plan](#test-plans).
+
+### Fixed exceptions
+
+The list below designates source code exempt from the testing guidelines because they do not directly impact the behaviour of the application in any way.
+
+- [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph)
+  - `dev/*`: internal tools, scripts for the local environment and continuous integration.
+  - `enterprise/dev/*`: internal tools, scripts for the local environment and continuous integration that fall under the [Sourcegraph Enterprise license](https://github.com/sourcegraph/sourcegraph/blob/main/LICENSE.enterprise).
+  - Dev environment configuration (e.g. `.editorconfig`, `shell.nix`, etc.)
 
 ## Test health
 
@@ -120,20 +143,16 @@ Why are flaky tests undesirable? Because these tests stop being an informative s
 
 Other kinds of flakes include [flaky steps](continuous_integration.md#flaky-steps) and [flaky infrastructure](continuous_integration.md#laky-infrastructure)
 
-## Exceptions
-
-If for a situational reason, a pull request needs to be exempted from the testing guidelines, skipping reviews or not providing a test plan will trigger an automated process that create and link an issue requesting that the author document a reason for the exception within [sourcegraph/sec-pr-audit-trail](https://github.com/sourcegraph/sec-pr-audit-trail).
-
-### Fixed exceptions
-
-The list below designates source code exempt from the testing guidelines because they do not directly impact the behaviour of the application in any way.
-
-- [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph)
-  - `dev/*`: internal tools, scripts for the local environment and continuous integration.
-  - `enterprise/dev/*`: internal tools, scripts for the local environment and continuous integration that fall under the [Sourcegraph Enterprise license](https://github.com/sourcegraph/sourcegraph/blob/main/LICENSE.enterprise).
-
 ## Ownership
 
-- [DevX Team](https://handbook.sourcegraph.com/engineering/enablement/dev-experience) owns build and test infrastructure.
+- [DevX Team](https://handbook.sourcegraph.com/engineering/enablement/dev-experience) owns build and test infrastructure (also see [build pipeline support](https://handbook.sourcegraph.com/departments/product-engineering/engineering/enablement/dev-experience#build-pipeline-support)).
 - [Frontend Platform Team](https://handbook.sourcegraph.com/engineering/enablement/frontend-platform) owns any tests that are driven through the browser.
-- All other tests are owned by the teams responsible for the domain being tested. 
+- All other tests and tools used in tests are owned by the teams responsible for the domain being tested.
+
+## Reference
+
+- [Continuous integration](continuous_integration.md)
+- [How to write and run tests](../how-to/testing.md)
+- [Testing Go code](languages/testing_go_code.md)
+- [Testing web code](testing_web_code.md)
+- [Pull request reviews](pull_request_reviews.md)


### PR DESCRIPTION
Wording tweaks, formatting fixes, explicit "exception explanation can be in test plan"

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

```
sg run docsite
```

navigate to http://localhost:5080/dev/background-information/testing_principles

