### PR TITLE
Adding link to single docker container db query

### DIFF
--- a/doc/admin/migration/3_31.md
+++ b/doc/admin/migration/3_31.md
@@ -19,7 +19,7 @@ If your indexes are corrupted, then there is also a possibility that there is ba
 1. `pgsql`
 2. `codeintel-db`
 
-*For more information about how to access a database container and run queries via `psql` see our admin documentation for [kubernetes](https://docs.sourcegraph.com/admin/install/kubernetes/operations#access-the-database) or [docker-compose](https://docs.sourcegraph.com/admin/install/docker-compose/operations#access-the-database)*
+*For more information about how to access a database container and run queries via `psql` see our admin documentation for [kubernetes](https://docs.sourcegraph.com/admin/install/kubernetes/operations#access-the-database), [docker-compose](https://docs.sourcegraph.com/admin/install/docker-compose/operations#access-the-database) or [single-container docker](https://docs.sourcegraph.com/admin/install/docker/operations#access-the-database)*
 
 ```sql
 create extension amcheck;


### PR DESCRIPTION
## Why this edit

Customer was running through upgrades steps and is on single-docker. The links on the page only point to kubernetes or docker compose. Adding a link to the relevant section for single-docker.

## Test plan

The query was tested and shown to be working. No code changes here, just linking a file.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


