### PR TITLE
docs/dev: add generated pipeline reference

### DIFF
--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -1,0 +1,218 @@
+<!-- DO NOT EDIT: generated via: go generate ./enterprise/dev/ci -->
+
+# Pipeline types reference
+
+This is a reference outlining what CI pipelines we generate under different conditions.
+
+To preview the pipeline for your branch, use `sg ci preview`.
+
+For a higher-level overview, please refer to the [continuous integration docs](https://docs.sourcegraph.com/dev/background-information/continuous_integration).
+
+## Run types
+
+### Pull request
+
+The default run type.
+
+- Pipeline for `Go` changes:
+  - **Linters and static analysis**: Prettier, Misc Linters
+  - **Go checks**: Test (all), Test (enterprise/internal/codeintel/stores/dbstore), Test (enterprise/internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
+  - Upload build trace
+
+- Pipeline for `Client` changes:
+  - **Pipeline setup**: Trigger async
+  - **Linters and static analysis**: Prettier, Misc Linters, Yarn deduplicate lint
+  - **Client checks**: Puppeteer tests prep, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests finalize, Upload Storybook to Chromatic, Test shared client code, Test wildcard client code, Build, Enterprise build, Test, Puppeteer tests for chrome extension, Test browser extension, Test branded client code, Typescript eslint, Stylelint
+  - Upload build trace
+
+- Pipeline for `GraphQL` changes:
+  - **Linters and static analysis**: Prettier, Misc Linters, GraphQL lint
+  - **Client checks**: Puppeteer tests prep, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests finalize, Upload Storybook to Chromatic, Test shared client code, Test wildcard client code, Build, Enterprise build, Test, Puppeteer tests for chrome extension, Test browser extension, Test branded client code, Typescript eslint, Stylelint
+  - **Go checks**: Test (all), Test (enterprise/internal/codeintel/stores/dbstore), Test (enterprise/internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
+  - Upload build trace
+
+- Pipeline for `DatabaseSchema` changes:
+  - **Linters and static analysis**: Prettier, Misc Linters
+  - **DB backcompat tests**: Backcompat test (all), Backcompat test (enterprise/internal/codeintel/stores/dbstore), Backcompat test (enterprise/internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
+  - Upload build trace
+
+- Pipeline for `Docs` changes:
+  - **Linters and static analysis**: Prettier, Misc Linters, Check and build docsite
+  - Upload build trace
+
+- Pipeline for `Dockerfiles` changes:
+  - **Linters and static analysis**: Prettier, Misc Linters, Lint
+  - Upload build trace
+
+- Pipeline for `ExecutorDockerRegistryMirror` changes:
+  - **Linters and static analysis**: Prettier, Misc Linters
+  - Upload build trace
+
+- Pipeline for `CIScripts` changes:
+  - **Linters and static analysis**: Prettier, Misc Linters
+  - **CI script tests**: test-trace-command.sh
+  - Upload build trace
+
+- Pipeline for `Terraform` changes:
+  - **Linters and static analysis**: Prettier, Misc Linters, security - checkov
+  - Upload build trace
+
+- Pipeline for `SVG` changes:
+  - **Linters and static analysis**: Prettier, Misc Linters, SVG lint
+  - Upload build trace
+
+### Release branch nightly healthcheck build
+
+The run type for environment including `{"RELEASE_NIGHTLY":"true"}`.
+
+- Default pipeline:
+  - **Pipeline setup**: Trigger async
+  - **Linters and static analysis**: Prettier, Misc Linters, GraphQL lint, SVG lint, Yarn deduplicate lint, Lint, security - checkov, Check and build docsite
+  - **Client checks**: Puppeteer tests prep, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests finalize, Upload Storybook to Chromatic, Test shared client code, Test wildcard client code, Build, Enterprise build, Test, Puppeteer tests for chrome extension, Test browser extension, Test branded client code, Typescript eslint, Stylelint
+  - **Go checks**: Test (all), Test (enterprise/internal/codeintel/stores/dbstore), Test (enterprise/internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
+  - **DB backcompat tests**: Backcompat test (all), Backcompat test (enterprise/internal/codeintel/stores/dbstore), Backcompat test (enterprise/internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
+  - **CI script tests**: test-trace-command.sh
+  - Upload build trace
+
+### Browser extension nightly release build
+
+The run type for environment including `{"BEXT_NIGHTLY":"true"}`.
+
+- Default pipeline:
+  - **Pipeline setup**: Trigger async
+  - **Linters and static analysis**: Prettier, Misc Linters, GraphQL lint, SVG lint, Yarn deduplicate lint, Lint, security - checkov, Check and build docsite
+  - **Client checks**: Puppeteer tests prep, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests finalize, Upload Storybook to Chromatic, Test shared client code, Test wildcard client code, Build, Enterprise build, Test, Puppeteer tests for chrome extension, Test browser extension, Test branded client code, Typescript eslint, Stylelint
+  - **Go checks**: Test (all), Test (enterprise/internal/codeintel/stores/dbstore), Test (enterprise/internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
+  - **DB backcompat tests**: Backcompat test (all), Backcompat test (enterprise/internal/codeintel/stores/dbstore), Backcompat test (enterprise/internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
+  - **CI script tests**: test-trace-command.sh
+  - Upload build trace
+
+### Tagged release
+
+The run type for tags starting with `v`.
+
+- Default pipeline:
+  - **Pipeline setup**: Trigger async
+  - **Linters and static analysis**: Prettier, Misc Linters, GraphQL lint, SVG lint, Yarn deduplicate lint, Lint, security - checkov, Check and build docsite
+  - **Client checks**: Puppeteer tests prep, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests finalize, Upload Storybook to Chromatic, Test shared client code, Test wildcard client code, Build, Enterprise build, Test, Puppeteer tests for chrome extension, Test browser extension, Test branded client code, Typescript eslint, Stylelint
+  - **Go checks**: Test (all), Test (enterprise/internal/codeintel/stores/dbstore), Test (enterprise/internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
+  - **DB backcompat tests**: Backcompat test (all), Backcompat test (enterprise/internal/codeintel/stores/dbstore), Backcompat test (enterprise/internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
+  - **CI script tests**: test-trace-command.sh
+  - Upload build trace
+
+### Release branch
+
+The run type for branches matching `^[0-9]+\.[0-9]+$` (regexp).
+
+- Default pipeline:
+  - **Pipeline setup**: Trigger async
+  - **Linters and static analysis**: Prettier, Misc Linters, GraphQL lint, SVG lint, Yarn deduplicate lint, Lint, security - checkov, Check and build docsite
+  - **Client checks**: Puppeteer tests prep, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests finalize, Upload Storybook to Chromatic, Test shared client code, Test wildcard client code, Build, Enterprise build, Test, Puppeteer tests for chrome extension, Test browser extension, Test branded client code, Typescript eslint, Stylelint
+  - **Go checks**: Test (all), Test (enterprise/internal/codeintel/stores/dbstore), Test (enterprise/internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
+  - **DB backcompat tests**: Backcompat test (all), Backcompat test (enterprise/internal/codeintel/stores/dbstore), Backcompat test (enterprise/internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
+  - **CI script tests**: test-trace-command.sh
+  - Upload build trace
+
+### Browser extension release build
+
+The run type for branches matching `bext/release` (exact).
+
+- Default pipeline:
+  - **Pipeline setup**: Trigger async
+  - **Linters and static analysis**: Prettier, Misc Linters, GraphQL lint, SVG lint, Yarn deduplicate lint, Lint, security - checkov, Check and build docsite
+  - **Client checks**: Puppeteer tests prep, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests finalize, Upload Storybook to Chromatic, Test shared client code, Test wildcard client code, Build, Enterprise build, Test, Puppeteer tests for chrome extension, Test browser extension, Test branded client code, Typescript eslint, Stylelint
+  - **Go checks**: Test (all), Test (enterprise/internal/codeintel/stores/dbstore), Test (enterprise/internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
+  - **DB backcompat tests**: Backcompat test (all), Backcompat test (enterprise/internal/codeintel/stores/dbstore), Backcompat test (enterprise/internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
+  - **CI script tests**: test-trace-command.sh
+  - Upload build trace
+
+### Main branch
+
+The run type for branches matching `main` (exact).
+
+- Default pipeline:
+  - **Pipeline setup**: Trigger async
+  - **Linters and static analysis**: Prettier, Misc Linters, GraphQL lint, SVG lint, Yarn deduplicate lint, Lint, security - checkov, Check and build docsite
+  - **Client checks**: Puppeteer tests prep, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests finalize, Upload Storybook to Chromatic, Test shared client code, Test wildcard client code, Build, Enterprise build, Test, Puppeteer tests for chrome extension, Test browser extension, Test branded client code, Typescript eslint, Stylelint
+  - **Go checks**: Test (all), Test (enterprise/internal/codeintel/stores/dbstore), Test (enterprise/internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
+  - **DB backcompat tests**: Backcompat test (all), Backcompat test (enterprise/internal/codeintel/stores/dbstore), Backcompat test (enterprise/internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
+  - **CI script tests**: test-trace-command.sh
+  - Upload build trace
+
+### Main dry run
+
+The run type for branches matching `main-dry-run/`.
+
+- Default pipeline:
+  - **Pipeline setup**: Trigger async
+  - **Linters and static analysis**: Prettier, Misc Linters, GraphQL lint, SVG lint, Yarn deduplicate lint, Lint, security - checkov, Check and build docsite
+  - **Client checks**: Puppeteer tests prep, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests finalize, Upload Storybook to Chromatic, Test shared client code, Test wildcard client code, Build, Enterprise build, Test, Puppeteer tests for chrome extension, Test browser extension, Test branded client code, Typescript eslint, Stylelint
+  - **Go checks**: Test (all), Test (enterprise/internal/codeintel/stores/dbstore), Test (enterprise/internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
+  - **DB backcompat tests**: Backcompat test (all), Backcompat test (enterprise/internal/codeintel/stores/dbstore), Backcompat test (enterprise/internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
+  - **CI script tests**: test-trace-command.sh
+  - Upload build trace
+
+### Patch image
+
+The run type for branches matching `docker-images-patch/`.
+
+- Default pipeline:
+  - **Pipeline setup**: Trigger async
+  - **Linters and static analysis**: Prettier, Misc Linters, GraphQL lint, SVG lint, Yarn deduplicate lint, Lint, security - checkov, Check and build docsite
+  - **Client checks**: Puppeteer tests prep, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests finalize, Upload Storybook to Chromatic, Test shared client code, Test wildcard client code, Build, Enterprise build, Test, Puppeteer tests for chrome extension, Test browser extension, Test branded client code, Typescript eslint, Stylelint
+  - **Go checks**: Test (all), Test (enterprise/internal/codeintel/stores/dbstore), Test (enterprise/internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
+  - **DB backcompat tests**: Backcompat test (all), Backcompat test (enterprise/internal/codeintel/stores/dbstore), Backcompat test (enterprise/internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
+  - **CI script tests**: test-trace-command.sh
+  - Upload build trace
+
+### Patch image without testing
+
+The run type for branches matching `docker-images-patch-notest/`.
+
+- Default pipeline:
+  - **Pipeline setup**: Trigger async
+  - **Linters and static analysis**: Prettier, Misc Linters, GraphQL lint, SVG lint, Yarn deduplicate lint, Lint, security - checkov, Check and build docsite
+  - **Client checks**: Puppeteer tests prep, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests finalize, Upload Storybook to Chromatic, Test shared client code, Test wildcard client code, Build, Enterprise build, Test, Puppeteer tests for chrome extension, Test browser extension, Test branded client code, Typescript eslint, Stylelint
+  - **Go checks**: Test (all), Test (enterprise/internal/codeintel/stores/dbstore), Test (enterprise/internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
+  - **DB backcompat tests**: Backcompat test (all), Backcompat test (enterprise/internal/codeintel/stores/dbstore), Backcompat test (enterprise/internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
+  - **CI script tests**: test-trace-command.sh
+  - Upload build trace
+
+### Build all candidates without testing
+
+The run type for branches matching `docker-images-candidates-notest/`.
+
+- Default pipeline:
+  - **Pipeline setup**: Trigger async
+  - **Linters and static analysis**: Prettier, Misc Linters, GraphQL lint, SVG lint, Yarn deduplicate lint, Lint, security - checkov, Check and build docsite
+  - **Client checks**: Puppeteer tests prep, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests finalize, Upload Storybook to Chromatic, Test shared client code, Test wildcard client code, Build, Enterprise build, Test, Puppeteer tests for chrome extension, Test browser extension, Test branded client code, Typescript eslint, Stylelint
+  - **Go checks**: Test (all), Test (enterprise/internal/codeintel/stores/dbstore), Test (enterprise/internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
+  - **DB backcompat tests**: Backcompat test (all), Backcompat test (enterprise/internal/codeintel/stores/dbstore), Backcompat test (enterprise/internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
+  - **CI script tests**: test-trace-command.sh
+  - Upload build trace
+
+### Build executor without testing
+
+The run type for branches matching `executor-patch-notest/`.
+
+- Default pipeline:
+  - **Pipeline setup**: Trigger async
+  - **Linters and static analysis**: Prettier, Misc Linters, GraphQL lint, SVG lint, Yarn deduplicate lint, Lint, security - checkov, Check and build docsite
+  - **Client checks**: Puppeteer tests prep, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests finalize, Upload Storybook to Chromatic, Test shared client code, Test wildcard client code, Build, Enterprise build, Test, Puppeteer tests for chrome extension, Test browser extension, Test branded client code, Typescript eslint, Stylelint
+  - **Go checks**: Test (all), Test (enterprise/internal/codeintel/stores/dbstore), Test (enterprise/internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
+  - **DB backcompat tests**: Backcompat test (all), Backcompat test (enterprise/internal/codeintel/stores/dbstore), Backcompat test (enterprise/internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
+  - **CI script tests**: test-trace-command.sh
+  - Upload build trace
+
+### Backend integration tests
+
+The run type for branches matching `backend-integration/`.
+
+- Default pipeline:
+  - **Pipeline setup**: Trigger async
+  - **Linters and static analysis**: Prettier, Misc Linters, GraphQL lint, SVG lint, Yarn deduplicate lint, Lint, security - checkov, Check and build docsite
+  - **Client checks**: Puppeteer tests prep, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests finalize, Upload Storybook to Chromatic, Test shared client code, Test wildcard client code, Build, Enterprise build, Test, Puppeteer tests for chrome extension, Test browser extension, Test branded client code, Typescript eslint, Stylelint
+  - **Go checks**: Test (all), Test (enterprise/internal/codeintel/stores/dbstore), Test (enterprise/internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
+  - **DB backcompat tests**: Backcompat test (all), Backcompat test (enterprise/internal/codeintel/stores/dbstore), Backcompat test (enterprise/internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
+  - **CI script tests**: test-trace-command.sh
+  - Upload build trace

--- a/doc/dev/background-information/continuous_integration.md
+++ b/doc/dev/background-information/continuous_integration.md
@@ -19,9 +19,10 @@ sg ci preview
 
 To learn about making changes to our Buildkite pipelines, see [Pipeline development](#pipeline-development).
 
-### Pipeline steps
+### Pipeline types
 
-A complete reference of all available pipeline steps is not yet available ([#30203](https://github.com/sourcegraph/sourcegraph/issues/30203)). This section contains a high-level documentation about what runs in our pipeline.
+A complete reference of all available pipeline types and steps is available in the generated [Pipeline reference](ci/reference.md).
+You can also see these docs locally with `sg ci docs`.
 
 #### Soft failures
 

--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -28,6 +28,8 @@ func init() {
 	flag.BoolVar(&docs, "docs", false, "Render generated documentation")
 }
 
+//go:generate sh -c "cd ../../../ && echo '<!-- DO NOT EDIT: generated via: go generate ./enterprise/dev/ci -->\n' > doc/dev/background-information/ci/reference.md"
+//go:generate sh -c "cd ../../../ && go run ./enterprise/dev/ci/gen-pipeline.go -docs >> doc/dev/background-information/ci/reference.md"
 func main() {
 	flag.Parse()
 
@@ -104,10 +106,14 @@ func trimEmoji(s string) string {
 }
 
 func renderPipelineDocs(w io.Writer) {
-	fmt.Fprintln(w, "# Pipeline reference")
+	fmt.Fprintln(w, "# Pipeline types reference")
+	fmt.Fprintln(w, "\nThis is a reference outlining what CI pipelines we generate under different conditions.")
+	fmt.Fprintln(w, "\nTo preview the pipeline for your branch, use `sg ci preview`.")
+	fmt.Fprintln(w, "\nFor a higher-level overview, please refer to the [continuous integration docs](https://docs.sourcegraph.com/dev/background-information/continuous_integration).")
+
 	fmt.Fprintln(w, "\n## Run types")
 
-	// Introduce pull request builds first
+	// Introduce pull request pipelines first
 	fmt.Fprintf(w, "\n### %s\n\n", ci.PullRequest.String())
 	fmt.Fprintln(w, "The default run type.")
 	changed.ForEachDiffType(func(diff changed.Diff) {
@@ -150,6 +156,7 @@ func renderPipelineDocs(w io.Writer) {
 			}
 			fmt.Fprintf(w, "The run type for %s.\n", strings.Join(conditions, ", "))
 
+			// Generate a sample pipeline with all changes
 			pipeline, err := ci.GeneratePipeline(ci.Config{
 				RunType: ci.PullRequest,
 				Diff:    changed.All,


### PR DESCRIPTION
Commits the generated reference introduced in https://github.com/sourcegraph/sourcegraph/pull/30532 into the docsite.

Closes https://github.com/sourcegraph/sourcegraph/issues/30203

I am placing this under `dev/background-information/ci` - I hope to consolidate CI docs in here some day, but that will require some redirects and link updates so I'll just let this be the only file for now.

We can expand this in the future with https://github.com/sourcegraph/sourcegraph/issues/28286 , for example

## Test plan

```sh
go generate ./enterprise/dev/ci
sg ci docs # see adjusted intro output
sg run docsite
```

Visit http://localhost:5080/dev/background-information/ci/reference
