### PR TITLE
try go tests without hiding 'any' output"

### DIFF
--- a/.ci-richstyle.yml
+++ b/.ci-richstyle.yml
@@ -1,4 +1,2 @@
 startStyle:
   hide: true
-anyStyle:
-  hide: true

--- a/.ci-richstyle.yml
+++ b/.ci-richstyle.yml
@@ -1,4 +1,2 @@
-startStyle:
-  hide: true
 passStyle:
   hide: true

--- a/.ci-richstyle.yml
+++ b/.ci-richstyle.yml
@@ -1,2 +1,4 @@
 startStyle:
   hide: true
+passStyle:
+  hide: true

--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -108,6 +108,9 @@ echo "--- comby install"
 export CODEINSIGHTS_PGDATASOURCE=postgres://postgres:password@127.0.0.1:5435/postgres
 export DB_STARTUP_TIMEOUT=360s # codeinsights-db needs more time to start in some instances.
 
+# Disable GraphQL logs which are wildly noisy
+export NO_GRAPHQL_LOG=true
+
 # Install richgo for better output
 # We are using this fork for now, until I open a PR to merge it upstream
 go install github.com/jhchabran/richgo@installable


### PR DESCRIPTION
Trying to see if just hiding `START` is sufficiently reducing log lines, it is not :( ~10k lines vs ~11k lines in main

https://buildkite.com/sourcegraph/sourcegraph/builds/130348#2784e46a-77db-47bb-93d8-04112e2188ff