### PR TITLE
sg db: add short help text

### DIFF
--- a/dev/sg/sg_db.go
+++ b/dev/sg/sg_db.go
@@ -33,9 +33,8 @@ var (
 	dbAddUserPasswordFlag = dbAddUserFlagSet.String("password", "sourcegraphsourcegraph", "User password")
 
 	dbCommand = &ffcli.Command{
-		Name:       "db",
-		ShortUsage: "",
-		LongHelp:   "",
+		Name:      "db",
+		ShortHelp: "Interact with Sourcegraph databases for development.",
 		Exec: func(ctx context.Context, args []string) error {
 			return flag.ErrHelp
 		},


### PR DESCRIPTION
Blank line was bothering me 😬 

<img width="442" alt="image" src="https://user-images.githubusercontent.com/23356519/153301421-32606d5f-c0c6-47b9-acc6-45a9b2fb09e3.png">


## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

```
go run ./dev/sg -h
```

see the void now filled:

<img width="507" alt="image" src="https://user-images.githubusercontent.com/23356519/153301768-fb1794fa-3b79-4b15-8efd-28cffbfc35fc.png">

