### PR TITLE
Add errors.Ignore()

### DIFF
--- a/internal/search/run/expression_job.go
+++ b/internal/search/run/expression_job.go
@@ -161,7 +161,7 @@ func (j *OrJob) Run(ctx context.Context, db database.DB, stream streaming.Sender
 		})
 	}
 
-	err := g.Wait().ErrorOrNil()
+	err = g.Wait().ErrorOrNil()
 	if err = errors.Ignore(err, errors.IsContextCanceled); err != nil {
 		return maxAlerter.Alert, err
 	}

--- a/internal/search/run/expression_job.go
+++ b/internal/search/run/expression_job.go
@@ -161,14 +161,8 @@ func (j *OrJob) Run(ctx context.Context, db database.DB, stream streaming.Sender
 		})
 	}
 
-	// TODO(@camdencheek): errors.Is isn't good enough here since a single
-	// backend that returns a context.Canceled error will make the multierror
-	// return true for errors.Is(err, context.Canceled). Ideally, we have some
-	// sort of multi-error filter that can filter out any context.Canceled and
-	// leave us with whatever errors are left. Note that this is true of anywhere
-	// we check the type of an aggregated error. This is neither a new nor a
-	// unique problem.
-	if err := g.Wait(); err != nil && !errors.Is(err, context.Canceled) {
+	err := g.Wait().ErrorOrNil()
+	if err = errors.Ignore(err, errors.IsContextCanceled); err != nil {
 		return maxAlerter.Alert, err
 	}
 

--- a/lib/errors/filter.go
+++ b/lib/errors/filter.go
@@ -4,6 +4,10 @@ import (
 	"context"
 )
 
+// Ignore filters out any errors that match pred. This applies
+// recursively to MultiErrors, filtering out any child errors
+// that match `pred`, or returning `nil` if all of the child
+// errors match `pred`.
 func Ignore(err error, pred ErrorPredicate) error {
 	// If the error (or any wrapped error) is a multierror,
 	// filter its children.

--- a/lib/errors/filter.go
+++ b/lib/errors/filter.go
@@ -1,0 +1,35 @@
+package errors
+
+import (
+	"context"
+)
+
+func Ignore(err error, pred ErrorPredicate) error {
+	// If the error (or any wrapped error) is a multierror,
+	// filter its children.
+	var multi *MultiError
+	if As(err, &multi) {
+		filtered := multi.Errors[:0]
+		for _, childErr := range multi.Errors {
+			if ignored := Ignore(childErr, pred); ignored != nil {
+				filtered = append(filtered, ignored)
+			}
+		}
+		if len(filtered) == 0 {
+			return nil
+		}
+		multi.Errors = filtered
+		return err
+	}
+
+	if pred(err) {
+		return nil
+	}
+	return err
+}
+
+type ErrorPredicate func(error) bool
+
+func IsContextCanceled(err error) bool {
+	return Is(err, context.Canceled)
+}

--- a/lib/errors/filter_test.go
+++ b/lib/errors/filter_test.go
@@ -1,0 +1,88 @@
+package errors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIgnore(t *testing.T) {
+	testError1 := New("test1")
+	testError2 := New("test2")
+
+	cases := []struct {
+		input error
+		pred  func(error) bool
+		check func(*testing.T, error)
+	}{{
+		input: testError1,
+		pred:  func(err error) bool { return Is(err, testError2) },
+		check: func(t *testing.T, err error) {
+			require.ErrorIs(t, err, testError1)
+		},
+	}, {
+		input: testError1,
+		pred:  func(err error) bool { return Is(err, testError1) },
+		check: func(t *testing.T, err error) {
+			require.NoError(t, err)
+		},
+	}, {
+		input: Append(testError1, testError2),
+		pred:  func(err error) bool { return Is(err, testError1) },
+		check: func(t *testing.T, err error) {
+			require.ErrorIs(t, err, testError2)
+			require.NotErrorIs(t, err, testError1)
+		},
+	}, {
+		input: Append(testError1, testError2, testError1),
+		pred:  func(err error) bool { return Is(err, testError1) },
+		check: func(t *testing.T, err error) {
+			require.ErrorIs(t, err, testError2)
+			require.NotErrorIs(t, err, testError1)
+		},
+	}, {
+		input: Append(testError1, testError1),
+		pred:  func(err error) bool { return Is(err, testError1) },
+		check: func(t *testing.T, err error) {
+			require.NoError(t, err)
+		},
+	}, {
+		input: Wrap(Append(testError1, testError2), "wrapped"),
+		pred:  func(err error) bool { return Is(err, testError1) },
+		check: func(t *testing.T, err error) {
+			require.ErrorIs(t, err, testError2)
+			require.NotErrorIs(t, err, testError1)
+			require.Contains(t, err.Error(), "wrapped")
+		},
+	}, {
+		input: Wrap(testError1, "wrapped"),
+		pred:  func(err error) bool { return Is(err, testError1) },
+		check: func(t *testing.T, err error) {
+			require.NoError(t, err)
+		},
+	}, {
+		input: Wrapf(testError1, "wrapped %s", "interpolated"),
+		pred:  func(err error) bool { return false },
+		check: func(t *testing.T, err error) {
+			require.ErrorIs(t, err, testError1)
+			require.Contains(t, err.Error(), "interpolated")
+		},
+	}, {
+		input: Append(
+			Wrap(Append(testError1, testError2), "wrapped1"),
+			Wrap(Append(testError1, testError2), "wrapped2"),
+		),
+		pred: func(err error) bool { return Is(err, testError1) },
+		check: func(t *testing.T, err error) {
+			require.ErrorIs(t, err, testError2)
+			require.NotErrorIs(t, err, testError1)
+		},
+	}}
+
+	for _, tc := range cases {
+		t.Run("", func(t *testing.T) {
+			got := Ignore(tc.input, tc.pred)
+			tc.check(t, got)
+		})
+	}
+}


### PR DESCRIPTION
This adds the new helper function `Ignore` to our `errors` package. This
allows us to ignore errors based on a given predicate function in a way
that takes into account aggregated errors in MultiError. It recursively
unwraps to multierrors an filters out all child errors that match the
predicate.



## Test plan

Solid unit tests were added as part of this PR. 
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


