### PR TITLE
Sg/dry run

### DIFF
--- a/doc/dev/background-information/sg/index.md
+++ b/doc/dev/background-information/sg/index.md
@@ -235,6 +235,9 @@ sg ci logs --build 123456
 sg ci build 
 # Manually trigger a build on the CI on the current branch, but with a specific commit
 sg ci build --commit my-commit
+
+# Create and push a main-dry-run branch from the HEAD of the current branch.
+sg ci dry-run
 ```
 
 ### `sg teammate` - Get current time or open their handbook page


### PR DESCRIPTION
Adds a simple command `sg ci dry-run` to create a dry-run branch from the current branch. This may seem trivial, but I think it should help with discoverability (I didn't really know about this special branch).

## Test plan

I ran this locally on this branch to create a main-dry-run branch:
<img width="724" alt="CleanShot 2022-02-09 at 17 04 44@2x" src="https://user-images.githubusercontent.com/5090588/153311438-3da2077a-55f8-47b3-939b-5ab73cfccd30.png">

Resulting branch: https://github.com/sourcegraph/sourcegraph/tree/main-dry-run/sg/dry-run
Resulting CI build: https://buildkite.com/sourcegraph/sourcegraph/builds?branch=main-dry-run%2Fsg%2Fdry-run

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


