### PR TITLE
batches: clean up text styles on editor screen

### DIFF
--- a/client/web/src/enterprise/batches/create/library/LibraryPane.module.scss
+++ b/client/web/src/enterprise/batches/create/library/LibraryPane.module.scss
@@ -21,6 +21,8 @@
     background: none;
     border: none;
     padding: 0;
+    // color: #dbe2f0;
+    color: var(--body-color);
 }
 
 .header {

--- a/client/web/src/enterprise/batches/create/library/LibraryPane.module.scss
+++ b/client/web/src/enterprise/batches/create/library/LibraryPane.module.scss
@@ -21,7 +21,6 @@
     background: none;
     border: none;
     padding: 0;
-    // color: #dbe2f0;
     color: var(--body-color);
 }
 

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewListItem.module.scss
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewListItem.module.scss
@@ -11,13 +11,7 @@
     overflow-wrap: anywhere;
 }
 
-.link {
-    display: block;
-    font-size: 1rem;
-    padding-bottom: 0.125rem;
-}
-
-.link-stale {
+.stale {
     color: var(--text-disabled);
 }
 

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewListItem.tsx
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewListItem.tsx
@@ -5,7 +5,7 @@ import DeleteIcon from 'mdi-react/DeleteIcon'
 import SourceBranchIcon from 'mdi-react/SourceBranchIcon'
 import React, { useCallback, useState } from 'react'
 
-import { Button, Link } from '@sourcegraph/wildcard'
+import { Button } from '@sourcegraph/wildcard'
 
 import { PreviewBatchSpecWorkspaceFields } from '../../../../graphql-operations'
 
@@ -47,12 +47,9 @@ export const WorkspacesPreviewListItem: React.FunctionComponent<WorkspacesPrevie
                 <StatusIcon status={toBeExcluded ? 'to-exclude' : item.cachedResultFound ? 'cached' : 'none'} />
             </div>
             <div className="flex-1">
-                <Link
-                    className={classNames(styles.link, styles.overflow, (toBeExcluded || isStale) && styles.linkStale)}
-                    to={item.branch.url}
-                >
+                <h4 className={classNames(styles.overflow, (toBeExcluded || isStale) && styles.linkStale)}>
                     {item.repository.name}
-                </Link>
+                </h4>
                 {item.path !== '' && item.path !== '/' ? (
                     <span className={classNames(styles.overflow, 'd-block text-muted')}>{item.path}</span>
                 ) : null}

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewListItem.tsx
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewListItem.tsx
@@ -47,7 +47,7 @@ export const WorkspacesPreviewListItem: React.FunctionComponent<WorkspacesPrevie
                 <StatusIcon status={toBeExcluded ? 'to-exclude' : item.cachedResultFound ? 'cached' : 'none'} />
             </div>
             <div className="flex-1">
-                <h4 className={classNames(styles.overflow, (toBeExcluded || isStale) && styles.linkStale)}>
+                <h4 className={classNames(styles.overflow, (toBeExcluded || isStale) && styles.stale)}>
                     {item.repository.name}
                 </h4>
                 {item.path !== '' && item.path !== '/' ? (


### PR DESCRIPTION
Closes #30466

**Changes**
- Library links are now body-color in light mode
- workspace preview items are no longer links and are `<h4>`. Should they be `<h4>`? Also,  Im guessing I can remove the `styles.linkStale` class

<img width="587" alt="Screen Shot 2022-02-09 at 6 54 02 PM" src="https://user-images.githubusercontent.com/67931373/153310455-7041e652-d808-42f9-81ae-f056ce73f362.png">

**Image**
<img width="457" alt="Screen Shot 2022-02-09 at 7 14 51 PM" src="https://user-images.githubusercontent.com/67931373/153312416-0875125e-a719-414e-b73a-b765a9d9ece0.png">

Thanks to Erik's comment I think I know why old changes are showing up here but I started this work before I saw that comment sooo, should be fixed next time

