### PR TITLE
Set total current count of errored repos as metric

### DIFF
--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -25,6 +25,7 @@ type GitserverRepoStore interface {
 	SetLastError(ctx context.Context, name api.RepoName, error, shardID string) error
 	SetLastFetched(ctx context.Context, name api.RepoName, data GitserverFetchData) error
 	IterateWithNonemptyLastError(ctx context.Context, repoFn func(repo types.RepoGitserverStatus) error) error
+	TotalErroredRepos(ctx context.Context) (int, error)
 }
 
 var _ GitserverRepoStore = (*gitserverRepoStore)(nil)
@@ -82,6 +83,35 @@ INSERT INTO
 
 	return errors.Wrap(err, "creating GitserverRepo")
 }
+
+// TotalErroredRepos returns the total number of repos which have a non-empty last_error field. Note that this is only
+// counting repos with an associated cloud_default external service.
+func (s *gitserverRepoStore) TotalErroredRepos(ctx context.Context) (int, error) {
+	rows, err := s.Query(ctx, sqlf.Sprintf(totalErroredQuery))
+	if err != nil {
+		return 0, errors.Wrap(err, "fetching count of total errored repos")
+	}
+	var total int
+	for rows.Next() {
+		if err := rows.Scan(
+			&total,
+		); err != nil {
+			return 0, errors.Wrap(err, "scanning row")
+		}
+	}
+	return total, nil
+}
+
+const totalErroredQuery = `
+-- source: internal/database/gitserver_repos.go:gitserverRepoStore.TotalErroredRepos
+SELECT
+	count(repo.name)
+FROM repo
+	LEFT JOIN gitserver_repos gr ON repo.id = gr.repo_id
+	INNER JOIN external_service_repos esr ON repo.id = esr.repo_id
+	INNER JOIN external_services es on esr.external_service_id = es.id
+WHERE gr.last_error != '' AND repo.deleted_at is NULL AND es.cloud_default IS True
+`
 
 // IterateWithNonemptyLastError iterates over repos w/ non-empty last_error field and calls the repoFn for these repos.
 // note that this currently filters out any repos which do not have an associated external service where cloud_default = true.

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -217,6 +217,14 @@ func TestIterateWithNonemptyLastError(t *testing.T) {
 					t.Fatalf("expected repo %s got %s instead", fr.Name, tc.expectedReposFound[i])
 				}
 			}
+
+			total, err := GitserverRepos(db).TotalErroredRepos(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if total != len(tc.expectedReposFound) {
+				t.Fatalf("expected %d total errored repos, got %d instead", len(tc.expectedReposFound), total)
+			}
 		})
 	}
 }

--- a/internal/repos/sync_errored.go
+++ b/internal/repos/sync_errored.go
@@ -20,6 +20,11 @@ var erroredRepoGauge = promauto.NewGauge(prometheus.GaugeOpts{
 	Help: "Counts number of repos with non empty_last errors which have been synced.",
 })
 
+var totalErroredRepos = promauto.NewGauge(prometheus.GaugeOpts{
+	Name: "src_repoupdater_syncer_total_errored_repos",
+	Help: "Total number of repos with last error currently.",
+})
+
 func (s *Syncer) RunSyncReposWithLastErrorsWorker(ctx context.Context, rateLimiter *rate.Limiter) {
 	for {
 		log15.Info("running worker for SyncReposWithLastErrors", "time", time.Now())
@@ -39,6 +44,7 @@ func (s *Syncer) RunSyncReposWithLastErrorsWorker(ctx context.Context, rateLimit
 // Dot com mode.
 func (s *Syncer) SyncReposWithLastErrors(ctx context.Context, rateLimiter *rate.Limiter) error {
 	erroredRepoGauge.Set(0)
+	s.setTotalErroredRepos(ctx)
 	err := s.Store.GitserverReposStore.IterateWithNonemptyLastError(ctx, func(repo types.RepoGitserverStatus) error {
 		err := rateLimiter.Wait(ctx)
 		if err != nil {
@@ -52,4 +58,13 @@ func (s *Syncer) SyncReposWithLastErrors(ctx context.Context, rateLimiter *rate.
 		return nil
 	})
 	return err
+}
+
+func (s *Syncer) setTotalErroredRepos(ctx context.Context) {
+	totalErrored, err := s.Store.GitserverReposStore.TotalErroredRepos(ctx)
+	if err != nil {
+		log15.Error("error fetching count of total errored repos", "err", err)
+		return
+	}
+	totalErroredRepos.Set(float64(totalErrored))
 }


### PR DESCRIPTION
I've realized that due to the rate limiting and such it's tough to tell from the current metric what is the exact number of repos with non-empty last_error. I'm adding this metric so we know this without having to go run a db query manually to find the count.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


