### PR TITLE
made the all filter the default filter and reordered radio buttons

### DIFF
--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -82,7 +82,7 @@ const getFilters = (withDrafts = false): FilteredConnectionFilter[] => [
         id: 'status',
         label: 'Status',
         type: 'radio',
-        values: [OPEN_FILTER, ...(withDrafts ? [DRAFT_FILTER] : []), CLOSED_FILTER, ALL_FILTER],
+        values: [ALL_FILTER, OPEN_FILTER, ...(withDrafts ? [DRAFT_FILTER] : []), CLOSED_FILTER],
     },
 ]
 


### PR DESCRIPTION
closes #30461

defaulted to 'All' instead of 'open' and switched the order 