### PR TITLE
symbols: bump ctags to latest commit

### DIFF
--- a/cmd/symbols/ctags-install-alpine.sh
+++ b/cmd/symbols/ctags-install-alpine.sh
@@ -2,8 +2,9 @@
 
 # This script installs ctags within an alpine container.
 
-# Commit hash of github.com/universal-ctags/ctags
-CTAGS_VERSION=7c4df9d38c4fe4bb494e5f3b2279034d7d8bd7b7
+# Commit hash of github.com/universal-ctags/ctags.
+# Last bumped 2022-02-10
+CTAGS_VERSION=40603a68c1f3b14dc1db4671111096733f6d2485
 
 cleanup() {
   apk --no-cache --purge del ctags-build-deps || true

--- a/go.mod
+++ b/go.mod
@@ -130,7 +130,7 @@ require (
 	github.com/slack-go/slack v0.10.1
 	github.com/snabb/sitemap v1.0.0
 	github.com/sourcegraph/ctxvfs v0.0.0-20180418081416-2b65f1b1ea81
-	github.com/sourcegraph/go-ctags v0.0.0-20210923201916-00b9c039141c
+	github.com/sourcegraph/go-ctags v0.0.0-20220210084826-96f4236f0a78
 	github.com/sourcegraph/go-diff v0.6.1
 	github.com/sourcegraph/go-jsonschema v0.0.0-20211011105148-2e30f7bacbe1
 	github.com/sourcegraph/go-langserver v2.0.1-0.20181108233942-4a51fa2e1238+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1462,6 +1462,8 @@ github.com/sourcegraph/ctxvfs v0.0.0-20180418081416-2b65f1b1ea81 h1:v4/JVxZSPWif
 github.com/sourcegraph/ctxvfs v0.0.0-20180418081416-2b65f1b1ea81/go.mod h1:xIvvI5FiHLxhv8prbzVpaMHaaGPFPFQSuTcxC91ryOo=
 github.com/sourcegraph/go-ctags v0.0.0-20210923201916-00b9c039141c h1:yE3O0BjqgifSyuyhnvvOuonOHZa8m58IJgqFEB07dR0=
 github.com/sourcegraph/go-ctags v0.0.0-20210923201916-00b9c039141c/go.mod h1:ZYjpRXoJrRlxjU9ZfpaUKJkk62AjhJPffN3rlw2aqxM=
+github.com/sourcegraph/go-ctags v0.0.0-20220210084826-96f4236f0a78 h1:DY/m+6+PnBz49fMU7rE+DfPf09QYgO1RLPDeJ/1BY9w=
+github.com/sourcegraph/go-ctags v0.0.0-20220210084826-96f4236f0a78/go.mod h1:ZYjpRXoJrRlxjU9ZfpaUKJkk62AjhJPffN3rlw2aqxM=
 github.com/sourcegraph/go-diff v0.5.1/go.mod h1:j2dHj3m8aZgQO8lMTcTnBcXkRRRqi34cd2MNlA9u1mE=
 github.com/sourcegraph/go-diff v0.6.1 h1:hmA1LzxW0n1c3Q4YbrFgg4P99GSnebYa3x8gr0HZqLQ=
 github.com/sourcegraph/go-diff v0.6.1/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=


### PR DESCRIPTION
We also needed to update go-ctags to not specify our custom Thrift support. ctags now natively supports thrift files.

Test Plan: build the ctags docker image and ran the tests in go-ctags and symbols against it.