### PR TITLE
Turn off client/web LSIF uploads for all instances.

### DIFF
--- a/.github/workflows/lsif-ts.yml
+++ b/.github/workflows/lsif-ts.yml
@@ -23,7 +23,9 @@ jobs:
           - client/shared
           - client/search
           - client/search-ui
-          - client/web
+          # Temporarily disable client/web uploads because of long queues
+          # https://github.com/sourcegraph/sourcegraph/issues/30493#issuecomment-1030090306
+          # - client/web
           - client/wildcard
           - client/common
           - client/http-client
@@ -53,9 +55,6 @@ jobs:
           SRC_ENDPOINT: https://sourcegraph.com/
       - name: Upload lsif-tsc dump to Dogfood
         working-directory: ${{ matrix.root }}
-        # Temporarily disable client/web uploads to Dogfood because of long queues
-        # https://github.com/sourcegraph/sourcegraph/issues/30493#issuecomment-1030090306
-        if: matrix.root != 'client/web'
         run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
         env:
           SRC_ENDPOINT: https://k8s.sgdev.org/


### PR DESCRIPTION
Follow up to #30717.

## Test plan

N/A as this doesn't affect the application code that is running in production.