### PR TITLE
Add "page" argument to CTAs for logging

### DIFF
--- a/client/web/src/repo/actions/BrowserExtensionAlert.story.tsx
+++ b/client/web/src/repo/actions/BrowserExtensionAlert.story.tsx
@@ -19,6 +19,6 @@ const config: Meta = {
 export default config
 
 export const BrowserExtensionAlertDefault: Story = () => (
-    <BrowserExtensionAlert onAlertDismissed={action('onAlertDismissed')} />
+    <BrowserExtensionAlert page="search" onAlertDismissed={action('onAlertDismissed')} />
 )
 BrowserExtensionAlertDefault.storyName = 'BrowserExtensionAlert'

--- a/client/web/src/repo/actions/BrowserExtensionAlert.tsx
+++ b/client/web/src/repo/actions/BrowserExtensionAlert.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useCallback, useEffect, useMemo } from 'react'
 
 import { CtaAlert } from '@sourcegraph/shared/src/components/CtaAlert'
 
@@ -12,9 +12,14 @@ interface Props {
 }
 
 export const BrowserExtensionAlert: React.FunctionComponent<Props> = ({ className, page, onAlertDismissed }) => {
+    const args = useMemo(() => ({ page }), [page])
     useEffect(() => {
-        eventLogger.log('InstallBrowserExtensionCTAShown', undefined, { page })
-    }, [page])
+        eventLogger.log('InstallBrowserExtensionCTAShown', args, args)
+    }, [args])
+
+    const onBrowserExtensionClick = useCallback((): void => {
+        eventLogger.log('InstallBrowserExtensionCTAClicked', args, args)
+    }, [args])
 
     return (
         <CtaAlert
@@ -24,15 +29,11 @@ export const BrowserExtensionAlert: React.FunctionComponent<Props> = ({ classNam
                 label: 'Learn more about the extension',
                 href:
                     'https://docs.sourcegraph.com/integration/browser_extension?utm_campaign=inproduct-cta&utm_medium=direct_traffic&utm_source=search-results-cta&utm_term=null&utm_content=install-browser-exten',
-                onClick: () => onBrowserExtensionClick(page),
+                onClick: onBrowserExtensionClick,
             }}
             icon={<ExtensionRadialGradientIcon />}
             className={className}
             onClose={onAlertDismissed}
         />
     )
-}
-
-const onBrowserExtensionClick = (page: 'search' | 'file'): void => {
-    eventLogger.log('InstallBrowserExtensionCTAClicked', undefined, { page })
 }

--- a/client/web/src/repo/actions/BrowserExtensionAlert.tsx
+++ b/client/web/src/repo/actions/BrowserExtensionAlert.tsx
@@ -7,13 +7,14 @@ import { eventLogger } from '../../tracking/eventLogger'
 
 interface Props {
     className?: string
+    page: 'search' | 'file'
     onAlertDismissed: () => void
 }
 
-export const BrowserExtensionAlert: React.FunctionComponent<Props> = ({ className, onAlertDismissed }) => {
+export const BrowserExtensionAlert: React.FunctionComponent<Props> = ({ className, page, onAlertDismissed }) => {
     useEffect(() => {
-        eventLogger.log('InstallBrowserExtensionCTAShown')
-    }, [])
+        eventLogger.log('InstallBrowserExtensionCTAShown', undefined, { page })
+    }, [page])
 
     return (
         <CtaAlert
@@ -23,7 +24,7 @@ export const BrowserExtensionAlert: React.FunctionComponent<Props> = ({ classNam
                 label: 'Learn more about the extension',
                 href:
                     'https://docs.sourcegraph.com/integration/browser_extension?utm_campaign=inproduct-cta&utm_medium=direct_traffic&utm_source=search-results-cta&utm_term=null&utm_content=install-browser-exten',
-                onClick: onBrowserExtensionClick,
+                onClick: () => onBrowserExtensionClick(page),
             }}
             icon={<ExtensionRadialGradientIcon />}
             className={className}
@@ -32,6 +33,6 @@ export const BrowserExtensionAlert: React.FunctionComponent<Props> = ({ classNam
     )
 }
 
-const onBrowserExtensionClick = (): void => {
-    eventLogger.log('InstallBrowserExtensionCTAClicked')
+const onBrowserExtensionClick = (page: 'search' | 'file'): void => {
+    eventLogger.log('InstallBrowserExtensionCTAClicked', undefined, { page })
 }

--- a/client/web/src/repo/actions/IdeExtensionAlert.story.tsx
+++ b/client/web/src/repo/actions/IdeExtensionAlert.story.tsx
@@ -18,5 +18,7 @@ const config: Meta = {
 
 export default config
 
-export const IDEExtensionAlertDefault: Story = () => <IDEExtensionAlert onAlertDismissed={action('onAlertDismissed')} />
+export const IDEExtensionAlertDefault: Story = () => (
+    <IDEExtensionAlert page="search" onAlertDismissed={action('onAlertDismissed')} />
+)
 IDEExtensionAlertDefault.storyName = 'IDEExtensionAlert'

--- a/client/web/src/repo/actions/IdeExtensionAlert.tsx
+++ b/client/web/src/repo/actions/IdeExtensionAlert.tsx
@@ -9,13 +9,14 @@ import styles from './IdeExtensionAlert.module.scss'
 
 interface Props {
     className?: string
+    page: 'search' | 'file'
     onAlertDismissed: () => void
 }
 
-export const IDEExtensionAlert: React.FunctionComponent<Props> = ({ className, onAlertDismissed }) => {
+export const IDEExtensionAlert: React.FunctionComponent<Props> = ({ className, page, onAlertDismissed }) => {
     useEffect(() => {
-        eventLogger.log('InstallIDEExtensionCTAShown')
-    }, [])
+        eventLogger.log('InstallIDEExtensionCTAShown', undefined, { page })
+    }, [page])
 
     return (
         <CtaAlert
@@ -25,7 +26,7 @@ export const IDEExtensionAlert: React.FunctionComponent<Props> = ({ className, o
                 label: 'Learn more about IDE extensions',
                 href:
                     'https://docs.sourcegraph.com/integration/editor?utm_medium=inproduct&utm_source=search-results&utm_campaign=inproduct-cta&utm_term=null',
-                onClick: onIDEExtensionClick,
+                onClick: () => onIDEExtensionClick(page),
             }}
             icon={
                 <div className={`d-flex flex-row ${styles.icons}`}>
@@ -41,6 +42,6 @@ export const IDEExtensionAlert: React.FunctionComponent<Props> = ({ className, o
     )
 }
 
-const onIDEExtensionClick = (): void => {
-    eventLogger.log('InstallIDEExtensionCTAClicked')
+const onIDEExtensionClick = (page: 'search' | 'file'): void => {
+    eventLogger.log('InstallIDEExtensionCTAClicked', undefined, { page })
 }

--- a/client/web/src/repo/actions/IdeExtensionAlert.tsx
+++ b/client/web/src/repo/actions/IdeExtensionAlert.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useMemo, useCallback } from 'react'
 
 import { CtaAlert } from '@sourcegraph/shared/src/components/CtaAlert'
 
@@ -14,10 +14,14 @@ interface Props {
 }
 
 export const IDEExtensionAlert: React.FunctionComponent<Props> = ({ className, page, onAlertDismissed }) => {
+    const args = useMemo(() => ({ page }), [page])
     useEffect(() => {
-        eventLogger.log('InstallIDEExtensionCTAShown', undefined, { page })
-    }, [page])
+        eventLogger.log('InstallIDEExtensionCTAShown', args, args)
+    }, [args])
 
+    const onIDEExtensionClick = useCallback((): void => {
+        eventLogger.log('InstallIDEExtensionCTAClicked', args, args)
+    }, [args])
     return (
         <CtaAlert
             title="The power of Sourcegraph in your IDE"
@@ -26,7 +30,7 @@ export const IDEExtensionAlert: React.FunctionComponent<Props> = ({ className, p
                 label: 'Learn more about IDE extensions',
                 href:
                     'https://docs.sourcegraph.com/integration/editor?utm_medium=inproduct&utm_source=search-results&utm_campaign=inproduct-cta&utm_term=null',
-                onClick: () => onIDEExtensionClick(page),
+                onClick: onIDEExtensionClick,
             }}
             icon={
                 <div className={`d-flex flex-row ${styles.icons}`}>
@@ -40,8 +44,4 @@ export const IDEExtensionAlert: React.FunctionComponent<Props> = ({ className, p
             onClose={onAlertDismissed}
         />
     )
-}
-
-const onIDEExtensionClick = (page: 'search' | 'file'): void => {
-    eventLogger.log('InstallIDEExtensionCTAClicked', undefined, { page })
 }

--- a/client/web/src/repo/actions/InstallIntegrationsAlert.tsx
+++ b/client/web/src/repo/actions/InstallIntegrationsAlert.tsx
@@ -15,7 +15,7 @@ export interface ExtensionAlertProps {
 }
 
 interface InstallIntegrationsAlertProps
-    extends Pick<NativeIntegrationAlertProps, 'externalURLs' | 'className'>,
+    extends Pick<NativeIntegrationAlertProps, 'externalURLs' | 'className' | 'page'>,
         ExtensionAlertProps {
     codeHostIntegrationMessaging: 'native-integration' | 'browser-extension'
 }
@@ -32,6 +32,7 @@ export const InstallIntegrationsAlert: React.FunctionComponent<InstallIntegratio
     codeHostIntegrationMessaging,
     externalURLs,
     className,
+    page,
     onExtensionAlertDismissed,
 }) => {
     const displayBrowserExtensionCTABasedOnCadence = usePersistentCadence(CADENCE_KEY, DISPLAY_CADENCE)
@@ -103,17 +104,18 @@ export const InstallIntegrationsAlert: React.FunctionComponent<InstallIntegratio
             return (
                 <NativeIntegrationAlert
                     className={className}
+                    page={page}
                     onAlertDismissed={onAlertDismissed}
                     externalURLs={externalURLs}
                 />
             )
         }
 
-        return <BrowserExtensionAlert className={className} onAlertDismissed={onAlertDismissed} />
+        return <BrowserExtensionAlert className={className} page={page} onAlertDismissed={onAlertDismissed} />
     }
 
     if (ctaToDisplay === 'ide') {
-        return <IDEExtensionAlert className={className} onAlertDismissed={onAlertDismissed} />
+        return <IDEExtensionAlert className={className} page={page} onAlertDismissed={onAlertDismissed} />
     }
 
     return null

--- a/client/web/src/repo/actions/NativeIntegrationAlert.story.tsx
+++ b/client/web/src/repo/actions/NativeIntegrationAlert.story.tsx
@@ -31,6 +31,7 @@ const NativeIntegrationAlertWrapper: React.FunctionComponent<{ serviceKind: Exte
 }) => (
     <NativeIntegrationAlert
         onAlertDismissed={onAlertDismissed}
+        page="search"
         externalURLs={[
             {
                 url: '',

--- a/client/web/src/repo/actions/NativeIntegrationAlert.tsx
+++ b/client/web/src/repo/actions/NativeIntegrationAlert.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useCallback, useMemo } from 'react'
 
 import { CtaAlert } from '@sourcegraph/shared/src/components/CtaAlert'
 import { AlertLink } from '@sourcegraph/wildcard'
@@ -30,9 +30,14 @@ export const NativeIntegrationAlert: React.FunctionComponent<NativeIntegrationAl
     onAlertDismissed,
     externalURLs,
 }) => {
+    const args = useMemo(() => ({ page }), [page])
     useEffect(() => {
-        eventLogger.log('NativeIntegrationInstallShown', undefined, { page })
-    }, [page])
+        eventLogger.log('NativeIntegrationInstallShown', args, args)
+    }, [args])
+
+    const installLinkClickHandler = useCallback((): void => {
+        eventLogger.log('NativeIntegrationInstallClicked', args, args)
+    }, [args])
 
     const externalLink = externalURLs.find(link => link.serviceKind && supportedServiceTypes.has(link.serviceKind))
     if (!externalLink) {
@@ -57,14 +62,10 @@ export const NativeIntegrationAlert: React.FunctionComponent<NativeIntegrationAl
                     </AlertLink>
                 </>
             }
-            cta={{ label: 'Try it out', href: externalLink.url, onClick: () => installLinkClickHandler(page) }}
+            cta={{ label: 'Try it out', href: externalLink.url, onClick: installLinkClickHandler }}
             icon={<ExtensionRadialGradientIcon />}
             className={className}
             onClose={onAlertDismissed}
         />
     )
-}
-
-const installLinkClickHandler = (page: 'search' | 'file'): void => {
-    eventLogger.log('NativeIntegrationInstallClicked', undefined, { page })
 }

--- a/client/web/src/repo/actions/NativeIntegrationAlert.tsx
+++ b/client/web/src/repo/actions/NativeIntegrationAlert.tsx
@@ -11,6 +11,7 @@ import { serviceKindDisplayNameAndIcon } from './GoToCodeHostAction'
 
 export interface NativeIntegrationAlertProps {
     className?: string
+    page: 'search' | 'file'
     onAlertDismissed: () => void
     externalURLs: ExternalLinkFields[]
 }
@@ -25,12 +26,13 @@ const supportedServiceTypes = new Set<string>([
 
 export const NativeIntegrationAlert: React.FunctionComponent<NativeIntegrationAlertProps> = ({
     className,
+    page,
     onAlertDismissed,
     externalURLs,
 }) => {
     useEffect(() => {
-        eventLogger.log('NativeIntegrationInstallShown')
-    }, [])
+        eventLogger.log('NativeIntegrationInstallShown', undefined, { page })
+    }, [page])
 
     const externalLink = externalURLs.find(link => link.serviceKind && supportedServiceTypes.has(link.serviceKind))
     if (!externalLink) {
@@ -55,7 +57,7 @@ export const NativeIntegrationAlert: React.FunctionComponent<NativeIntegrationAl
                     </AlertLink>
                 </>
             }
-            cta={{ label: 'Try it out', href: externalLink.url, onClick: installLinkClickHandler }}
+            cta={{ label: 'Try it out', href: externalLink.url, onClick: () => installLinkClickHandler(page) }}
             icon={<ExtensionRadialGradientIcon />}
             className={className}
             onClose={onAlertDismissed}
@@ -63,6 +65,6 @@ export const NativeIntegrationAlert: React.FunctionComponent<NativeIntegrationAl
     )
 }
 
-const installLinkClickHandler = (): void => {
-    eventLogger.log('NativeIntegrationInstallClicked')
+const installLinkClickHandler = (page: 'search' | 'file'): void => {
+    eventLogger.log('NativeIntegrationInstallClicked', undefined, { page })
 }

--- a/client/web/src/repo/routes.tsx
+++ b/client/web/src/repo/routes.tsx
@@ -211,6 +211,7 @@ export const repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[] 
                                     <>
                                         <InstallIntegrationsAlert
                                             codeHostIntegrationMessaging={codeHostIntegrationMessaging}
+                                            page="file"
                                             externalURLs={repo.externalURLs}
                                             onExtensionAlertDismissed={onExtensionAlertDismissed}
                                         />

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -318,9 +318,10 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
     )
     const [showSidebar, setShowSidebar] = useState(false)
 
-    const onSignUpClick = (): void => {
-        telemetryService.log('SignUpPLGSearchCTA_1_Search', undefined, { page: 'search' })
-    }
+    const onSignUpClick = useCallback((): void => {
+        const args = { page: 'search' }
+        telemetryService.log('SignUpPLGSearchCTA_1_Search', args, args)
+    }, [telemetryService])
 
     const resultsFound = useMemo<boolean>(() => (results ? results.results.length > 0 : false), [results])
     const showOnboardingTour =

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -319,7 +319,7 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
     const [showSidebar, setShowSidebar] = useState(false)
 
     const onSignUpClick = (): void => {
-        telemetryService.log('SignUpPLGSearchCTA_1_Search')
+        telemetryService.log('SignUpPLGSearchCTA_1_Search', undefined, { page: 'search' })
     }
 
     const resultsFound = useMemo<boolean>(() => (results ? results.results.length > 0 : false), [results])
@@ -423,10 +423,10 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
                     />
                 )}
                 {ctaToDisplay === 'browser' && (
-                    <BrowserExtensionAlert className="mr-3" onAlertDismissed={onCtaAlertDismissed} />
+                    <BrowserExtensionAlert className="mr-3" onAlertDismissed={onCtaAlertDismissed} page="search" />
                 )}
                 {ctaToDisplay === 'ide' && (
-                    <IDEExtensionAlert className="mr-3" onAlertDismissed={onCtaAlertDismissed} />
+                    <IDEExtensionAlert className="mr-3" onAlertDismissed={onCtaAlertDismissed} page="search" />
                 )}
                 <StreamingSearchResultsList
                     {...props}


### PR DESCRIPTION
It was missing from analytics. It was defined in the [figma](https://sourcegraph.com/search?q=context:global+InstallBrowserExtensionCTAShown&patternType=literal) that we wanted the page name sent in the logs.

## Test plan

- Set `eventLogDebug` to `true` in the localStorage, and see if the "page" attributes get logged as CTAs are displayed, in case of IDE and BExt CTAs
- Check out storybook to see if all CTAs still render well. If `eventLogDebug` is `true` then probably the log items will be there even in storybook, and with this, even `NativeIntegrationAlert` can be tested.

