### PR TITLE
sg: ignore pipe-closed errors when piping output

### DIFF
--- a/lib/process/pipe.go
+++ b/lib/process/pipe.go
@@ -3,8 +3,10 @@ package process
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os/exec"
 	"sync"
 )
@@ -28,8 +30,9 @@ func PipeOutput(ctx context.Context, c *exec.Cmd, stdoutWriter, stderrWriter io.
 func PipeOutputUnbuffered(ctx context.Context, c *exec.Cmd, stdoutWriter, stderrWriter io.Writer) (*sync.WaitGroup, error) {
 	return pipeOutputWithCopy(ctx, c, stdoutWriter, stderrWriter, func(w io.Writer, r io.Reader) {
 		_, err := io.Copy(w, r)
-		if err != nil {
-			panic(fmt.Sprintf("failed to pipe output: %s", err))
+		// We can ignore ErrClosed because we get that if a process crashes
+		if err != nil && !errors.Is(err, fs.ErrClosed) {
+			panic(err)
 		}
 	})
 }


### PR DESCRIPTION
This fixes #30882.

## Test plan

In one terminal: `go run . run docsite`
In another terminal: `go run . start`


