### PR TITLE
Add GraphQL query that fetches all Org flag overrides

### DIFF
--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -66,13 +66,13 @@ export function fetchFeatureFlags(): Observable<FlagSet> {
 }
 
 export type OrgFlagOverride = {
-    namespace: string
+    orgID: string
     flagName: string
     value: boolean
 }
 
 /**
- * Fetches all organization feature flag overrides for the current user
+ * Fetches all feature flag overrides for organizations that the current user is a member of
  */
 export function fetchOrgOverrides(): { data: OrgFlagOverride[]; loading: boolean } {
     const { data, loading } = useQuery<OrgFeatureFlagOverridesResult, OrgFeatureFlagOverridesVariables>(
@@ -104,7 +104,7 @@ export function fetchOrgOverrides(): { data: OrgFlagOverride[]; loading: boolean
     return {
         data: data?.organizationFeatureFlagOverrides.map(value => {
             return {
-                namespace: atob(value.namespace.id),
+                orgID: atob(value.namespace.id).split(':')[1],
                 flagName: value.targetFlag.name,
                 value: value.value,
             }

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -65,7 +65,7 @@ export function fetchFeatureFlags(): Observable<FlagSet> {
     )
 }
 
-export type OrgFlagOverride = {
+export interface OrgFlagOverride {
     orgID: string
     flagName: string
     value: boolean
@@ -102,13 +102,11 @@ export function useFlagsOverrides(): { data: OrgFlagOverride[]; loading: boolean
     }
 
     return {
-        data: data?.organizationFeatureFlagOverrides.map(value => {
-            return {
-                orgID: value.namespace.id,
-                flagName: value.targetFlag.name,
-                value: value.value,
-            }
-        }),
+        data: data?.organizationFeatureFlagOverrides.map(value => ({
+            orgID: value.namespace.id,
+            flagName: value.targetFlag.name,
+            value: value.value,
+        })),
         loading,
     }
 }

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -74,7 +74,7 @@ export type OrgFlagOverride = {
 /**
  * Fetches all feature flag overrides for organizations that the current user is a member of
  */
-export function fetchOrgOverrides(): { data: OrgFlagOverride[]; loading: boolean } {
+export function useFlagsOverrides(): { data: OrgFlagOverride[]; loading: boolean } {
     const { data, loading } = useQuery<OrgFeatureFlagOverridesResult, OrgFeatureFlagOverridesVariables>(
         gql`
             query OrgFeatureFlagOverrides {
@@ -104,7 +104,7 @@ export function fetchOrgOverrides(): { data: OrgFlagOverride[]; loading: boolean
     return {
         data: data?.organizationFeatureFlagOverrides.map(value => {
             return {
-                orgID: atob(value.namespace.id).split(':')[1],
+                orgID: value.namespace.id,
                 flagName: value.targetFlag.name,
                 value: value.value,
             }

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -4,7 +4,11 @@ import { map } from 'rxjs/operators'
 import { dataOrThrowErrors, gql, useQuery } from '@sourcegraph/http-client'
 
 import { requestGraphQL } from '../backend/graphql'
-import { FetchFeatureFlagsResult, OrgFeatureFlagOverridesResult, OrgFeatureFlagOverridesVariables } from '../graphql-operations'
+import {
+    FetchFeatureFlagsResult,
+    OrgFeatureFlagOverridesResult,
+    OrgFeatureFlagOverridesVariables,
+} from '../graphql-operations'
 
 import { getOverrideKey } from './lib/getOverrideKey'
 
@@ -70,35 +74,43 @@ export type OrgFlagOverride = {
 /**
  * Fetches all organization feature flag overrides for the current user
  */
-export function fetchOrgOverrides(): {data: OrgFlagOverride[], loading: boolean} {
+export function fetchOrgOverrides(): { data: OrgFlagOverride[]; loading: boolean } {
     const { data, loading } = useQuery<OrgFeatureFlagOverridesResult, OrgFeatureFlagOverridesVariables>(
-        gql`query OrgFeatureFlagOverrides {
-            organizationFeatureFlagOverrides {
-                namespace { id },
-                targetFlag {
-                    ... on FeatureFlagBoolean {
-                        name
+        gql`
+            query OrgFeatureFlagOverrides {
+                organizationFeatureFlagOverrides {
+                    namespace {
+                        id
                     }
-                    ... on FeatureFlagRollout {
-                        name
+                    targetFlag {
+                        ... on FeatureFlagBoolean {
+                            name
+                        }
+                        ... on FeatureFlagRollout {
+                            name
+                        }
                     }
-                },
-                value
+                    value
+                }
             }
-        }`, {fetchPolicy: 'cache-and-network'}
+        `,
+        { fetchPolicy: 'cache-and-network' }
     )
 
     if (!data) {
-        return {data: [], loading}
+        return { data: [], loading }
     }
 
-    return {data: data?.organizationFeatureFlagOverrides.map(value => {
-        return {
-            namespace: atob(value.namespace.id),
-            flagName: value.targetFlag.name,
-            value: value.value
-        }
-    }), loading}
+    return {
+        data: data?.organizationFeatureFlagOverrides.map(value => {
+            return {
+                namespace: atob(value.namespace.id),
+                flagName: value.targetFlag.name,
+                value: value.value,
+            }
+        }),
+        loading,
+    }
 }
 
 export interface FeatureFlagProps {

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -1,9 +1,6 @@
 import { from, Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
 
-import { QueryResult } from '@apollo/client'
-
-
 import { dataOrThrowErrors, gql, useQuery } from '@sourcegraph/http-client'
 
 import { requestGraphQL } from '../backend/graphql'

--- a/client/web/src/integration/graphQlResults.ts
+++ b/client/web/src/integration/graphQlResults.ts
@@ -229,6 +229,9 @@ export const commonWebGraphQlResults: Partial<
     OrgFeatureFlagValue: () => ({
         organizationFeatureFlagValue: false,
     }),
+    OrgFeatureFlagOverrides: () => ({
+        organizationFeatureFlagOverrides: [],
+    }),
     GetTemporarySettings: () => ({
         temporarySettings: {
             __typename: 'TemporarySettings',

--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -25,6 +25,7 @@ import { githubRepoScopeRequired, gitlabAPIScopeRequired, Owner } from '../cloud
 
 import { CodeHostItem } from './CodeHostItem'
 import { CodeHostListItem } from './CodeHostListItem'
+import { useFlagsOverrides } from '../../../featureFlags/featureFlags'
 
 type AuthProvidersByKind = Partial<Record<ExternalServiceKind, AuthProvider>>
 
@@ -326,6 +327,7 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
             {isErrorLike(statusOrError) && (
                 <ErrorAlert error={statusOrError} prefix="Code host action error" icon={false} />
             )}
+            {console.log(useFlagsOverrides())}
             {codeHostExternalServices && isServicesByKind(statusOrError) ? (
                 <Container>
                     <ul className="list-group">

--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -25,7 +25,6 @@ import { githubRepoScopeRequired, gitlabAPIScopeRequired, Owner } from '../cloud
 
 import { CodeHostItem } from './CodeHostItem'
 import { CodeHostListItem } from './CodeHostListItem'
-import { useFlagsOverrides } from '../../../featureFlags/featureFlags'
 
 type AuthProvidersByKind = Partial<Record<ExternalServiceKind, AuthProvider>>
 
@@ -327,7 +326,6 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
             {isErrorLike(statusOrError) && (
                 <ErrorAlert error={statusOrError} prefix="Code host action error" icon={false} />
             )}
-            {console.log(useFlagsOverrides())}
             {codeHostExternalServices && isServicesByKind(statusOrError) ? (
                 <Container>
                     <ul className="list-group">

--- a/cmd/frontend/graphqlbackend/feature_flags.go
+++ b/cmd/frontend/graphqlbackend/feature_flags.go
@@ -159,6 +159,20 @@ func (r *schemaResolver) OrganizationFeatureFlagValue(ctx context.Context, args 
 	return result, nil
 }
 
+func (r *schemaResolver) OrganizationFeatureFlagOverrides(ctx context.Context) ([]*FeatureFlagOverrideResolver, error) {
+	user, err := backend.CurrentUser(ctx, r.db)
+	if err != nil {
+		return nil, err
+	}
+
+	flags, err := database.FeatureFlags(r.db).GetOrgOverridesForUser(ctx, user.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	return overridesToResolvers(r.db, flags), nil
+}
+
 func (r *schemaResolver) FeatureFlags(ctx context.Context) ([]*FeatureFlagResolver, error) {
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err

--- a/cmd/frontend/graphqlbackend/feature_flags.go
+++ b/cmd/frontend/graphqlbackend/feature_flags.go
@@ -78,7 +78,7 @@ type FeatureFlagOverrideResolver struct {
 }
 
 func (f *FeatureFlagOverrideResolver) TargetFlag(ctx context.Context) (*FeatureFlagResolver, error) {
-	res, err := database.FeatureFlags(f.db).GetFeatureFlag(ctx, f.inner.FlagName)
+	res, err := f.db.FeatureFlags().GetFeatureFlag(ctx, f.inner.FlagName)
 	return &FeatureFlagResolver{f.db, res}, err
 }
 func (f *FeatureFlagOverrideResolver) Value() bool { return f.inner.Value }
@@ -153,7 +153,7 @@ func (r *schemaResolver) OrganizationFeatureFlagValue(ctx context.Context, args 
 		return false, nil
 	}
 
-	result, err := database.FeatureFlags(r.db).GetOrgFeatureFlag(ctx, org, args.FlagName)
+	result, err := r.db.FeatureFlags().GetOrgFeatureFlag(ctx, org, args.FlagName)
 	if err != nil {
 		return false, err
 	}
@@ -179,7 +179,7 @@ func (r *schemaResolver) FeatureFlags(ctx context.Context) ([]*FeatureFlagResolv
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
-	flags, err := database.FeatureFlags(r.db).GetFeatureFlags(ctx)
+	flags, err := r.db.FeatureFlags().GetFeatureFlags(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/feature_flags_test.go
+++ b/cmd/frontend/graphqlbackend/feature_flags_test.go
@@ -1,0 +1,101 @@
+package graphqlbackend
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func TestOrganizationFeatureFlagOverrides(t *testing.T) {
+	users := database.NewMockUserStore()
+	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 1}, nil)
+
+	ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
+
+	orgs := database.NewMockOrgStore()
+	mockedOrg := types.Org{ID: 1, Name: "acme"}
+	orgs.GetByNameFunc.SetDefaultReturn(&mockedOrg, nil)
+	orgs.GetByIDFunc.SetDefaultReturn(&mockedOrg, nil)
+
+	flags := database.NewMockFeatureFlagStore()
+	mockedFlag := featureflag.Override{UserID: nil, OrgID: &mockedOrg.ID, FlagName: "test-flag", Value: true}
+	flagOverrides := []*featureflag.Override{&mockedFlag}
+
+	flags.GetOrgOverridesForUserFunc.SetDefaultHook(func(ctx context.Context, userID int32) ([]*featureflag.Override, error) {
+		assert.Equal(t, int32(1), userID)
+		return flagOverrides, nil
+	})
+
+	db := database.NewMockDB()
+	db.OrgsFunc.SetDefaultReturn(orgs)
+	db.UsersFunc.SetDefaultReturn(users)
+	db.FeatureFlagsFunc.SetDefaultReturn(flags)
+
+	result, err := newSchemaResolver(db).OrganizationFeatureFlagOverrides(ctx)
+
+	if err != nil {
+		t.Errorf("expected error to be nil")
+	}
+
+	got := []*featureflag.Override{}
+
+	for _, f := range result {
+		got = append(got, f.inner)
+	}
+
+	if !reflect.DeepEqual(got, flagOverrides) {
+		t.Errorf("expected %v got %v", flagOverrides, got)
+	}
+
+	t.Run("return org override for user", func(t *testing.T) {
+		RunTests(t, []*Test{
+			{
+				Context: ctx,
+				Schema:  mustParseGraphQLSchema(t, db),
+				Query: `
+				{
+					organizationFeatureFlagOverrides {
+						namespace {
+							id
+						},
+						targetFlag {
+							... on FeatureFlagBoolean {
+								name
+							},
+							... on FeatureFlagRollout {
+								name
+							}
+						},
+						value
+					}
+				}
+				`,
+				ExpectedResult: `
+					{
+						"organizationFeatureFlagOverrides": {
+							"nodes": [
+								{
+									"namespace": {
+										"id": "1"
+									},
+									"targetFlag": {
+										"name": "test-flag"
+									},
+									"value": true
+								}
+							]
+						}
+					}
+				`,
+			},
+		})
+	})
+
+}

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1415,6 +1415,11 @@ type Query {
     organizationFeatureFlagValue(orgID: ID!, flagName: String!): Boolean!
 
     """
+    Retrieve all organization feature flag overrides for the current user
+    """
+    organizationFeatureFlagOverrides: [FeatureFlagOverride!]!
+
+    """
     Retrieves the temporary settings for the current user.
     """
     temporarySettings: TemporarySettings!


### PR DESCRIPTION
This PR adds a GraphQL query that fetches all organization flag overrides for the current user. The database query for this already existed as part of another query, this simply uses that database query and hooks it up to the GraphQL API.

This allows the frontend to react differently if a user belongs to different organizations where the feature flag means different behaviour depending on the organization.

## Test plan

TODO

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


