### PR TITLE
Add UTM params to VSCE links

### DIFF
--- a/client/vscode/src/webview/search-panel/components/ButtonDropdownCta.tsx
+++ b/client/vscode/src/webview/search-panel/components/ButtonDropdownCta.tsx
@@ -54,7 +54,12 @@ export const ButtonDropdownCta: React.FunctionComponent<ButtonDropdownCtaProps> 
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isDropdownOpen])
 
-    const signUpURL = new URL(`/sign-up?src=${source}&returnTo=${encodeURIComponent(returnTo)}`, instanceURL)
+    const signUpURL = new URL(
+        `/sign-up?src=${source}&returnTo=${encodeURIComponent(
+            returnTo
+        )}&utm_medium=VSCIDE&utm_source=sidebar&utm_campaign=vsce-sign-up&utm_content=sign-up`,
+        instanceURL
+    )
 
     return (
         <ButtonDropdown className="menu-nav-item" direction="down" isOpen={isDropdownOpen} toggle={toggleDropdownOpen}>

--- a/client/vscode/src/webview/search-panel/components/SearchCta.tsx
+++ b/client/vscode/src/webview/search-panel/components/SearchCta.tsx
@@ -30,7 +30,7 @@ export const SearchPageCta: React.FunctionComponent<SearchPageCtaProps> = ({
         </div>
         <a
             className={classNames('btn', styles.btn)}
-            href="https://sourcegraph.com/sign-up?editor=vscode"
+            href="https://sourcegraph.com/sign-up?editor=vscode&utm_medium=VSCIDE&utm_source=sidebar&utm_campaign=vsce-sign-up&utm_content=sign-up"
             onClick={onClickAction}
         >
             <span className={styles.text}>{buttonText}</span>

--- a/client/vscode/src/webview/search-sidebar/AuthSidebarView.tsx
+++ b/client/vscode/src/webview/search-sidebar/AuthSidebarView.tsx
@@ -11,6 +11,8 @@ import { WebviewPageProps } from '../platform/context'
 
 import styles from './AuthSidebarView.module.scss'
 
+const SIDEBAR_UTM_PARAMS = 'utm_medium=VSCIDE&utm_source=sidebar&utm_campaign=vsce-sign-up&utm_content=sign-up'
+
 interface AuthSidebarViewProps extends WebviewPageProps {
     stateStatus: string
 }
@@ -28,7 +30,9 @@ export const AuthSidebarView: React.FunctionComponent<AuthSidebarViewProps> = ({
 
     const [hasAccount, setHasAccount] = useState(false)
 
-    const signUpURL = useMemo(() => new URL('sign-up?editor=vscode', instanceURL).href, [instanceURL])
+    const signUpURL = useMemo(() => new URL('sign-up?editor=vscode&' + SIDEBAR_UTM_PARAMS, instanceURL).href, [
+        instanceURL,
+    ])
     const instanceHostname = useMemo(() => new URL(instanceURL).hostname, [instanceURL])
 
     const validateAccessToken: React.FormEventHandler<HTMLFormElement> = (event): void => {
@@ -98,7 +102,11 @@ export const AuthSidebarView: React.FunctionComponent<AuthSidebarViewProps> = ({
                     </p>
                     <div className={classNames(styles.ctaParagraph)}>
                         <p className="mb-0">Learn more:</p>
-                        <a href="http://sourcegraph.com/" className="my-0" onClick={() => onLinkClick('Sourcegraph')}>
+                        <a
+                            href={'https://sourcegraph.com/?' + SIDEBAR_UTM_PARAMS}
+                            className="my-0"
+                            onClick={() => onLinkClick('Sourcegraph')}
+                        >
                             Sourcegraph.com
                         </a>
                         <br />
@@ -148,7 +156,7 @@ export const AuthSidebarView: React.FunctionComponent<AuthSidebarViewProps> = ({
             <p className={classNames(styles.ctaParagraph)}>
                 See our{' '}
                 <a
-                    href="https://docs.sourcegraph.com/cli/how-tos/creating_an_access_token"
+                    href={`https://docs.sourcegraph.com/cli/how-tos/creating_an_access_token?${SIDEBAR_UTM_PARAMS}`}
                     onClick={() => platformContext.telemetryService.log('VSCESidebarCreateToken')}
                 >
                     user docs

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -256,11 +256,12 @@ function pageViewQueryParameters(url: string): EventQueryParameters {
 
     const utmSource = parsedUrl.searchParams.get('utm_source')
     const utmCampaign = parsedUrl.searchParams.get('utm_campaign')
+    const utmMedium = parsedUrl.searchParams.get('utm_medium')
 
     const utmProps = {
         utm_campaign: utmCampaign || undefined,
         utm_source: utmSource || undefined,
-        utm_medium: parsedUrl.searchParams.get('utm_medium') || undefined,
+        utm_medium: utmMedium || undefined,
         utm_term: parsedUrl.searchParams.get('utm_term') || undefined,
         utm_content: parsedUrl.searchParams.get('utm_content') || undefined,
     }
@@ -273,6 +274,8 @@ function pageViewQueryParameters(url: string): EventQueryParameters {
         eventLogger.log('CodeMonitorEmailLinkClicked')
     } else if (utmSource === 'hubspot' && utmCampaign?.match(/^cloud-onboarding-email(.*)$/)) {
         eventLogger.log('UTMCampaignLinkClicked', utmProps, utmProps)
+    } else if (utmMedium === 'VSCIDE' && utmCampaign === 'vsce-sign-up') {
+        eventLogger.log('VSCIDESignUpLinkClicked', utmProps, utmProps)
     }
 
     return utmProps


### PR DESCRIPTION
Fixes #30859

We want to improve our funnel tracking to better understand when users started their flow in VS Code (see #30859 for more context). 

- [x] Sidebar CTAs
- [x] Banner CTAs
- [x] CTAs from Save Search, and Create Monitor buttons
- [x] Create VSCE campaign events on sourcegraph.com 

## Test plan

1. To validate that this logs the right parmeters I changed the hostname to my local instance: `https://sourcegraph.test:3443/sign-up?editor=vscode&utm_medium=VSCIDE&utm_source=sidebar&utm_campaign=vsce-sign-up&utm_content=sign-up` and verified that the events show up in the console: 
![Screenshot 2022-02-09 at 14 19 41](https://user-images.githubusercontent.com/458591/153211675-6afc0989-b9be-4c43-9d9a-f6a18e174f86.png)
3. With the help of @abeatrix and @tjkandala I was able to build the extension locally and verify that all buttons indeed contain the UTM parameters in the links they open. 

__Note: This is a new version of a previous PR (https://github.com/sourcegraph/sourcegraph/pull/30890) since we have not merged all of the VSCE code into main yet. Merging this into main _will_ have a merge conflict in `client/web/src/tracking/eventLogger.ts`__ 

