### PR TITLE
gitserver: Don't return JVM source errors

### DIFF
--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -72,22 +72,16 @@ func (s *JVMPackagesSyncer) IsCloneable(ctx context.Context, remoteURL *vcs.URL)
 		return err
 	}
 
-	noDepsCounter := 0
 	for _, dependency := range dependencies {
 		_, err := coursier.FetchSources(ctx, s.Config, dependency)
 		if err != nil {
 			// Temporary: We shouldn't need both these checks but we're continuing to see the
 			// error in production logs which implies `Is` is not matching.
 			if errors.Is(err, coursier.ErrNoSources{}) || strings.Contains(err.Error(), "no sources for dependency") {
-				// Non fatal
-				noDepsCounter++
 				continue
 			}
 			return err
 		}
-	}
-	if noDepsCounter == len(dependencies) {
-		return errors.Errorf("all dependencies are missing sources")
 	}
 
 	return nil


### PR DESCRIPTION
We can't do anything and it's leading to increases in our src_repoupdater_sched_error
alert firing more often.
