### PR TITLE
ci: disable graphql logs in CI tests

### DIFF
--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -108,6 +108,9 @@ echo "--- comby install"
 export CODEINSIGHTS_PGDATASOURCE=postgres://postgres:password@127.0.0.1:5435/postgres
 export DB_STARTUP_TIMEOUT=360s # codeinsights-db needs more time to start in some instances.
 
+# Disable GraphQL logs which are wildly noisy
+export NO_GRAPHQL_LOG=true
+
 # Install richgo for better output
 go install github.com/kyoh86/richgo@latest
 asdf reshim golang


### PR DESCRIPTION

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Observe absence of overly verbose logs on the build. 
