### PR TITLE
add helper predicates for HasType and Is

### DIFF
--- a/lib/errors/filter.go
+++ b/lib/errors/filter.go
@@ -32,8 +32,21 @@ func Ignore(err error, pred ErrorPredicate) error {
 	return err
 }
 
+// ErrorPredicate is a function type that returns whether an error matches a given condition
 type ErrorPredicate func(error) bool
 
-func IsContextCanceled(err error) bool {
-	return Is(err, context.Canceled)
+// HasTypePred returns an ErrorPredicatehat returns true for errors that unwrap to an error with the same type as target
+func HasTypePred(target error) ErrorPredicate {
+	return func(err error) bool {
+		return HasType(err, target)
+	}
 }
+
+// IsPred returns an ErrorPredicate that returns true for errors that uwrap to the target error
+func IsPred(target error) ErrorPredicate {
+	return func(err error) bool {
+		return Is(err, target)
+	}
+}
+
+var IsContextCanceled = IsPred(context.Canceled)


### PR DESCRIPTION
This adds a couple of small helpers to make working with errors.Ignore a
little easier. Now, if you just want to ignore a certain error type,
instead of creating a function for it, you can just do something like
```go
err = errors.Ignore(err, errors.IsPred(context.Canceled))
```



## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


