### PR TITLE
codeintel: Try to improve performance of `canonicalizeDocuments`

### DIFF
--- a/lib/codeintel/lsif/conversion/canonicalize.go
+++ b/lib/codeintel/lsif/conversion/canonicalize.go
@@ -45,20 +45,18 @@ func canonicalizeDocuments(state *State) {
 	}
 
 	for documentID, canonicalID := range canonicalIDs {
-		// Move ranges and diagnostics into the canonical document
-		state.Contains.SetUnion(canonicalID, state.Contains.Get(documentID))
-		state.Diagnostics.SetUnion(canonicalID, state.Diagnostics.Get(documentID))
-	}
-
-	for documentID, canonicalID := range canonicalIDs {
 		// Replace references to each document with the canonical reference
 		canonicalizeDocumentsInDefinitionReferences(state, state.DefinitionData, documentID, canonicalID)
 		canonicalizeDocumentsInDefinitionReferences(state, state.ReferenceData, documentID, canonicalID)
 		canonicalizeDocumentsInDefinitionReferences(state, state.ImplementationData, documentID, canonicalID)
 	}
 
-	for documentID := range canonicalIDs {
-		// Remove non-canonical document
+	for documentID, canonicalID := range canonicalIDs {
+		// Move ranges and diagnostics into the canonical document
+		state.Contains.SetUnion(canonicalID, state.Contains.Get(documentID))
+		state.Diagnostics.SetUnion(canonicalID, state.Diagnostics.Get(documentID))
+
+		// Remove non-canonical documents
 		delete(state.DocumentData, documentID)
 		state.Contains.Delete(documentID)
 		state.Diagnostics.Delete(documentID)

--- a/lib/codeintel/lsif/conversion/canonicalize.go
+++ b/lib/codeintel/lsif/conversion/canonicalize.go
@@ -45,29 +45,23 @@ func canonicalizeDocuments(state *State) {
 	}
 
 	for documentID, canonicalID := range canonicalIDs {
-		if true {
-			// Move ranges and diagnostics into the canonical document
-			state.Contains.SetUnion(canonicalID, state.Contains.Get(documentID))
-			state.Diagnostics.SetUnion(canonicalID, state.Diagnostics.Get(documentID))
-		}
+		// Move ranges and diagnostics into the canonical document
+		state.Contains.SetUnion(canonicalID, state.Contains.Get(documentID))
+		state.Diagnostics.SetUnion(canonicalID, state.Diagnostics.Get(documentID))
 	}
 
 	for documentID, canonicalID := range canonicalIDs {
-		if true {
-			// Replace references to each document with the canonical reference
-			canonicalizeDocumentsInDefinitionReferences(state, state.DefinitionData, documentID, canonicalID)
-			canonicalizeDocumentsInDefinitionReferences(state, state.ReferenceData, documentID, canonicalID)
-			canonicalizeDocumentsInDefinitionReferences(state, state.ImplementationData, documentID, canonicalID)
-		}
+		// Replace references to each document with the canonical reference
+		canonicalizeDocumentsInDefinitionReferences(state, state.DefinitionData, documentID, canonicalID)
+		canonicalizeDocumentsInDefinitionReferences(state, state.ReferenceData, documentID, canonicalID)
+		canonicalizeDocumentsInDefinitionReferences(state, state.ImplementationData, documentID, canonicalID)
 	}
 
 	for documentID := range canonicalIDs {
-		if true {
-			// Remove non-canonical document
-			delete(state.DocumentData, documentID)
-			state.Contains.Delete(documentID)
-			state.Diagnostics.Delete(documentID)
-		}
+		// Remove non-canonical document
+		delete(state.DocumentData, documentID)
+		state.Contains.Delete(documentID)
+		state.Diagnostics.Delete(documentID)
 	}
 }
 

--- a/lib/codeintel/lsif/conversion/canonicalize.go
+++ b/lib/codeintel/lsif/conversion/canonicalize.go
@@ -67,12 +67,10 @@ func canonicalizeDocuments(state *State) {
 func canonicalizeDocumentsInDefinitionReferences(state *State, definitionReferenceData map[int]*datastructures.DefaultIDSetMap, canonicalIDs map[int]int) {
 	for _, documentRanges := range definitionReferenceData {
 		for documentID, canonicalID := range canonicalIDs {
-			if rangeIDs := documentRanges.Get(documentID); rangeIDs != nil {
-				// Move definition/reference data into the canonical document
+			// Remove references to non-canonical document...
+			if rangeIDs := documentRanges.Pop(documentID); rangeIDs != nil {
+				// ...and move existing definition/reference data into the canonical document
 				documentRanges.SetUnion(canonicalID, rangeIDs)
-
-				// Remove references to non-canonical document
-				documentRanges.Delete(documentID)
 			}
 		}
 	}

--- a/lib/codeintel/lsif/conversion/canonicalize.go
+++ b/lib/codeintel/lsif/conversion/canonicalize.go
@@ -36,17 +36,33 @@ func canonicalizeDocuments(state *State) {
 		sort.Ints(v)
 	}
 
+	canonicalIDs := make(map[int]int, len(state.DocumentData))
 	for documentID, uri := range state.DocumentData {
 		// Choose canonical document alphabetically
 		if canonicalID := documentIDs[uri][0]; documentID != canonicalID {
+			canonicalIDs[documentID] = canonicalID
+		}
+	}
+
+	for documentID, canonicalID := range canonicalIDs {
+		if true {
 			// Move ranges and diagnostics into the canonical document
 			state.Contains.SetUnion(canonicalID, state.Contains.Get(documentID))
 			state.Diagnostics.SetUnion(canonicalID, state.Diagnostics.Get(documentID))
+		}
+	}
 
+	for documentID, canonicalID := range canonicalIDs {
+		if true {
+			// Replace references to each document with the canonical reference
 			canonicalizeDocumentsInDefinitionReferences(state, state.DefinitionData, documentID, canonicalID)
 			canonicalizeDocumentsInDefinitionReferences(state, state.ReferenceData, documentID, canonicalID)
 			canonicalizeDocumentsInDefinitionReferences(state, state.ImplementationData, documentID, canonicalID)
+		}
+	}
 
+	for documentID := range canonicalIDs {
+		if true {
 			// Remove non-canonical document
 			delete(state.DocumentData, documentID)
 			state.Contains.Delete(documentID)

--- a/lib/codeintel/lsif/conversion/canonicalize.go
+++ b/lib/codeintel/lsif/conversion/canonicalize.go
@@ -65,8 +65,8 @@ func canonicalizeDocuments(state *State) {
 // data from a document to its canonical document (if they differ) and removes all references to the
 // non-canonical document.
 func canonicalizeDocumentsInDefinitionReferences(state *State, definitionReferenceData map[int]*datastructures.DefaultIDSetMap, canonicalIDs map[int]int) {
-	for documentID, canonicalID := range canonicalIDs {
-		for _, documentRanges := range definitionReferenceData {
+	for _, documentRanges := range definitionReferenceData {
+		for documentID, canonicalID := range canonicalIDs {
 			if rangeIDs := documentRanges.Get(documentID); rangeIDs != nil {
 				// Move definition/reference data into the canonical document
 				documentRanges.SetUnion(canonicalID, rangeIDs)

--- a/lib/codeintel/lsif/conversion/datastructures/default_idset_map.go
+++ b/lib/codeintel/lsif/conversion/datastructures/default_idset_map.go
@@ -43,6 +43,25 @@ func (sm *DefaultIDSetMap) Get(key int) *IDSet {
 	return nil
 }
 
+// Pop returns the identifier set at the given key or nil if it does not exist and
+// removes the key from the map.
+func (sm *DefaultIDSetMap) Pop(key int) *IDSet {
+	if sm.key == key {
+		v := sm.value
+		sm.key = 0
+		sm.value = nil
+		return v
+	}
+	if sm.m != nil {
+		v, ok := sm.m[key]
+		if ok {
+			delete(sm.m, key)
+		}
+		return v
+	}
+	return nil
+}
+
 // Delete removes the identifier set at the given key if it exists.
 func (sm *DefaultIDSetMap) Delete(key int) {
 	if sm.key == key {


### PR DESCRIPTION
This PR changes the iteration order of work done in the LSIF upload conversion routine `canonicalizeDocuments`. Improvements should be a more cache-friendly iteration order of documents while trying to identify and reduce duplicates.

## Test plan

- Run the [codeintel-QA pipeline](https://buildkite.com/sourcegraph/sourcegraph/builds/130639)
- @varungandhi-src will identify if this is a likely fix to the recent Cloud slowdown