### PR TITLE
repo-updater: Touch permissions schedule for unimplemented providers

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -750,7 +750,7 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 			// We should still touch the repo perms so that we don't keep scheduling the repo
 			// for permissions syncs on a tight interval.
 			if err = s.permsStore.TouchRepoPermissions(ctx, int32(repoID)); err != nil {
-				log15.Warn("Error touching permissions for UnImplemented authz provider", "err", err)
+				log15.Warn("Error touching permissions for unimplemented authz provider", "err", err)
 			}
 
 			return nil

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -746,6 +746,13 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 		// Skip repo if unimplemented
 		if errors.Is(err, &authz.ErrUnimplemented{}) {
 			log15.Debug("PermsSyncer.syncRepoPerms.unimplemented", "repoID", repo.ID, "err", err)
+
+			// We should still touch the repo perms so that we don't keep scheduling the repo
+			// for permissions syncs on a tight interval.
+			if err = s.permsStore.TouchRepoPermissions(ctx, int32(repoID)); err != nil {
+				log15.Warn("Error touching permissions for UnImplemented authz provider", "err", err)
+			}
+
 			return nil
 		}
 


### PR DESCRIPTION
If we don't, the repos appears to have never been synced and then the
repos keep getting scheduled based on our logic that schedules oldest
repos first.

This was spotted by observing unexpected gaps between most and least
recent synced repos [here](https://k8s.sgdev.org/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100100&orgId=1)
