### PR TITLE
doc: replace reference to acme with example

### DIFF
--- a/doc/admin/deploy_executors.md
+++ b/doc/admin/deploy_executors.md
@@ -207,7 +207,7 @@ tfenv use 0.13.7
 2. Install [`gcloud`](https://cloud.google.com/sdk/docs/install)
 3. Run `gcloud auth application-default login`
 4. Open your Sourcegraph instance in your browser, click your profile in the top right, click **Site admin**, expand **Configuration**, click **Site configuration**, and set:
-  - `"externalURL": "<URL>"` to a URL that is accessible from the GCP VM that will be created later (e.g. a public URL such as `https://sourcegraph.acme.com`)
+  - `"externalURL": "<URL>"` to a URL that is accessible from the GCP VM that will be created later (e.g. a public URL such as `https://sourcegraph.example.com`)
   - `"executors.accessToken": "<new long secret>"` to a new long secret (e.g. `cat /dev/random | base64 | head -c 20`)
   - `"codeIntelAutoIndexing.enabled": true`
 5. Download the [example files](https://github.com/sourcegraph/terraform-google-executors/blob/master/examples/single-executor) and change these:

--- a/doc/admin/organizations.md
+++ b/doc/admin/organizations.md
@@ -12,9 +12,9 @@ To automatically join all users on your instance to a specific organization, cre
 {
   // ...
   "auth.userOrgMap": {
-    // All users ("*") will be automatically joined to the "acme-corp" org.
+    // All users ("*") will be automatically joined to the "example-corp" org.
     // Currently "*" (all users) is the only supported key.
-    "*": ["acme-corp"] // The array values refer to org names you've already created.
+    "*": ["example-corp"] // The array values refer to org names you've already created.
   }
   // ...
 }

--- a/doc/admin/repo/perforce.md
+++ b/doc/admin/repo/perforce.md
@@ -210,7 +210,7 @@ The instructions below will help you get Perforce depots on Sourcegraph quickly 
 We intend to improve Sourcegraph's Perforce support in the future. Please [file an issue](https://github.com/sourcegraph/sourcegraph/issues) to help us prioritize any specific improvements you'd like to see.
 
 - Sourcegraph was initially built for Git repositories only, so it exposes Git concepts that are meaningless for converted Perforce depots, such as the commit SHA, branches, and tags.
-- The commit messages for a Perforce depot converted to a Git repository have an extra line at the end with Perforce information, such as `[git-p4: depot-paths = "//guest/acme_org/myproject/": change = 12345]`.
+- The commit messages for a Perforce depot converted to a Git repository have an extra line at the end with Perforce information, such as `[git-p4: depot-paths = "//guest/example_org/myproject/": change = 12345]`.
 - [Permissions](#repository-permissions)
   - [File-level permissions](#file-level-permissions) are not supported when syncing permissions via the [code host integration](#add-a-perforce-code-host).
   - The [host field](https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_protect.html#Form_Fields_..361) in protections are not supported.

--- a/doc/getting-started/personalization/quick_links.md
+++ b/doc/getting-started/personalization/quick_links.md
@@ -21,12 +21,12 @@ For example, this JSON will create two quick links:
   // ...
   "quicklinks": [
     {
-      "name": "ACMECorp main repo",
-      "url": "/github.com/acmecorp/main-repository"
+      "name": "ExampleCorp main repo",
+      "url": "/github.com/ExampleCorp/main-repository"
     },
     {
-      "name": "ACMECorp Sourcegraph docs",
-      "url": "https://dev.acme.com/docs/sourcegraph"
+      "name": "ExampleCorp Sourcegraph docs",
+      "url": "https://dev.example.com/docs/sourcegraph"
     }
   ]
   // ...


### PR DESCRIPTION
Replace references to `acme` with `example`. I tried to find all references to `acme` and change them all for consistency but I was mostly concerned with references to the `acme.com` which appears to be a valid website.