### PR TITLE
monitoring: fix ContainerVariable validate, tweak remote prometheus docs

### DIFF
--- a/doc/dev/how-to/monitoring_local_dev.md
+++ b/doc/dev/how-to/monitoring_local_dev.md
@@ -33,9 +33,12 @@ For Kubernetes deployments, you can accomplish this by creating a [sg.config.ove
 
 ```yaml
 # sg.config.overwrite.yaml
-
 commands:
   prometheus:
+    # install can just be set up gcloud credentials for a cluster
+    # e.g. https://handbook.sourcegraph.com/departments/product-engineering/engineering/process/deployments/instances
+    install: |
+      gcloud container clusters get-credentials ...
     cmd: |
       kubectl port-forward svc/prometheus 9090:30090
 ```

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -378,6 +378,9 @@ func (c *ContainerVariable) validate() error {
 		return errors.New("ContainerVariable.Label is required")
 	}
 	if c.OptionsQuery == "" && len(c.Options) == 0 {
+		return errors.New("one of ContainerVariable.Query and ContainerVariable.Options must be set")
+	}
+	if c.OptionsQuery != "" && len(c.Options) > 0 {
 		return errors.New("ContainerVariable.Query and ContainerVariable.Options cannot both be set")
 	}
 	return nil


### PR DESCRIPTION
Some adjustments I noticed as I skimmed through this code again as part of https://github.com/sourcegraph/sourcegraph/pull/30997

- [monitoring: fix ContainerVariable validation](https://github.com/sourcegraph/sourcegraph/commit/3c836ae692d5f9406b9c7c968d480c7c99f2368e). We were previously not validating that only one of `OptionsQuery` and `Options` is set
- [doc/dev: tweak sg overwrite advice for remote prometheus](https://github.com/sourcegraph/sourcegraph/commit/8845d25c66a8a08a539c32380de92b65232ee9f1). Skips the lengthy Prometheus build in favour of authenticating against a cluster

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


```
sg run monitoring-generator
```