### PR TITLE
Align NewExtensionPage with CreateCodeMonitorPage

### DIFF
--- a/client/web/src/enterprise/extensions/extension/RegistryExtensionForm.tsx
+++ b/client/web/src/enterprise/extensions/extension/RegistryExtensionForm.tsx
@@ -1,9 +1,9 @@
-import classNames from 'classnames'
 import * as React from 'react'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { ErrorLike, isErrorLike } from '@sourcegraph/common'
 import { Scalars } from '@sourcegraph/shared/src/graphql-operations'
+import { Input, Select } from '@sourcegraph/wildcard'
 
 import {
     EXTENSION_NAME_MAX_LENGTH,
@@ -13,8 +13,6 @@ import {
 } from '../../../extensions/extension/extension'
 
 export const RegistryPublisherFormGroup: React.FunctionComponent<{
-    className?: string
-
     /** The current publisher value. */
     value?: Scalars['ID']
 
@@ -23,19 +21,19 @@ export const RegistryPublisherFormGroup: React.FunctionComponent<{
 
     disabled?: boolean
     onChange?: React.FormEventHandler<HTMLSelectElement>
-}> = ({ className = '', value, publishersOrError, disabled, onChange }) => (
-    <div className={classNames('form-group', className)}>
-        <label htmlFor="extension-registry-create-extension-page__publisher">Publisher</label>
+}> = ({ value, publishersOrError, disabled, onChange }) => (
+    <>
         {isErrorLike(publishersOrError) ? (
             <ErrorAlert error={publishersOrError} />
         ) : (
-            <select
-                id="extension-registry-create-extension-page__publisher"
-                className="form-control"
+            <Select
+                label="Publisher"
                 onChange={onChange}
                 required={true}
                 disabled={disabled || publishersOrError === 'loading'}
                 value={value}
+                aria-label="Publisher"
+                message="The owner of this extension. This can't be changed after creation."
             >
                 {publishersOrError === 'loading' ? (
                     <option disabled={true}>Loading...</option>
@@ -46,39 +44,31 @@ export const RegistryPublisherFormGroup: React.FunctionComponent<{
                         </option>
                     ))
                 )}
-            </select>
+            </Select>
         )}
-        <small className="form-help text-muted">
-            The owner of this extension. This can't be changed after creation.
-        </small>
-    </div>
+    </>
 )
 
 export const RegistryExtensionNameFormGroup: React.FunctionComponent<{
-    className?: string
     value: string
     disabled?: boolean
     onChange: React.FormEventHandler<HTMLInputElement>
-}> = ({ className = '', value, disabled, onChange }) => (
-    <div className={classNames('form-group', className)}>
-        <label htmlFor="extension-registry-form__name">Name</label>
-        <input
-            type="text"
-            name="extension-name"
-            className="form-control"
-            id="extension-registry-form__name"
-            onChange={onChange}
-            required={true}
-            autoFocus={true}
-            spellCheck={false}
-            autoCapitalize="off"
-            autoCorrect="off"
-            autoComplete="off"
-            value={value}
-            pattern={EXTENSION_NAME_VALID_PATTERN}
-            maxLength={EXTENSION_NAME_MAX_LENGTH}
-            disabled={disabled}
-        />
-        <small className="form-help text-muted">The name for this extension.</small>
-    </div>
+}> = ({ value, disabled, onChange }) => (
+    <Input
+        label="Name"
+        type="text"
+        name="extension-name"
+        onChange={onChange}
+        required={true}
+        autoFocus={true}
+        spellCheck={false}
+        autoCapitalize="off"
+        autoCorrect="off"
+        autoComplete="off"
+        value={value}
+        pattern={EXTENSION_NAME_VALID_PATTERN}
+        maxLength={EXTENSION_NAME_MAX_LENGTH}
+        disabled={disabled}
+        message="The name for this extension."
+    />
 )

--- a/client/web/src/enterprise/extensions/extension/RegistryExtensionForm.tsx
+++ b/client/web/src/enterprise/extensions/extension/RegistryExtensionForm.tsx
@@ -74,6 +74,6 @@ export const RegistryExtensionNameFormGroup: React.FunctionComponent<{
         maxLength={EXTENSION_NAME_MAX_LENGTH}
         disabled={disabled}
         message="The name for this extension."
-        className={className}
+        inputClassName={className}
     />
 )

--- a/client/web/src/enterprise/extensions/extension/RegistryExtensionForm.tsx
+++ b/client/web/src/enterprise/extensions/extension/RegistryExtensionForm.tsx
@@ -21,7 +21,9 @@ export const RegistryPublisherFormGroup: React.FunctionComponent<{
 
     disabled?: boolean
     onChange?: React.FormEventHandler<HTMLSelectElement>
-}> = ({ value, publishersOrError, disabled, onChange }) => (
+
+    className?: string
+}> = ({ value, publishersOrError, disabled, onChange, className }) => (
     <>
         {isErrorLike(publishersOrError) ? (
             <ErrorAlert error={publishersOrError} />
@@ -34,6 +36,7 @@ export const RegistryPublisherFormGroup: React.FunctionComponent<{
                 value={value}
                 aria-label="Publisher"
                 message="The owner of this extension. This can't be changed after creation."
+                className={className}
             >
                 {publishersOrError === 'loading' ? (
                     <option disabled={true}>Loading...</option>
@@ -53,7 +56,8 @@ export const RegistryExtensionNameFormGroup: React.FunctionComponent<{
     value: string
     disabled?: boolean
     onChange: React.FormEventHandler<HTMLInputElement>
-}> = ({ value, disabled, onChange }) => (
+    className?: string
+}> = ({ value, disabled, onChange, className }) => (
     <Input
         label="Name"
         type="text"
@@ -70,5 +74,6 @@ export const RegistryExtensionNameFormGroup: React.FunctionComponent<{
         maxLength={EXTENSION_NAME_MAX_LENGTH}
         disabled={disabled}
         message="The name for this extension."
+        className={className}
     />
 )

--- a/client/web/src/enterprise/extensions/registry/RegistryNewExtensionPage.tsx
+++ b/client/web/src/enterprise/extensions/registry/RegistryNewExtensionPage.tsx
@@ -1,6 +1,5 @@
 import classNames from 'classnames'
 import * as H from 'history'
-import AddIcon from 'mdi-react/AddIcon'
 import HelpCircleOutline from 'mdi-react/HelpCircleOutlineIcon'
 import PuzzleOutlineIcon from 'mdi-react/PuzzleOutlineIcon'
 import * as React from 'react'
@@ -178,16 +177,21 @@ export const RegistryNewExtensionPage = withAuthenticatedUser(
                             disabled={
                                 isErrorLike(this.state.publishersOrError) ||
                                 this.state.publishersOrError === 'loading' ||
-                                this.state.creationOrError === 'loading'
+                                this.state.creationOrError === 'loading' ||
+                                !this.state.name
                             }
                             variant="primary"
+                            className="mr-2"
                         >
-                            {this.state.creationOrError === 'loading' ? (
-                                <LoadingSpinner />
-                            ) : (
-                                <AddIcon className="icon-inline" />
-                            )}{' '}
+                            {this.state.creationOrError === 'loading' && (
+                                <>
+                                    <LoadingSpinner />{' '}
+                                </>
+                            )}
                             Create extension
+                        </Button>
+                        <Button type="button" variant="secondary" as={Link} to="..">
+                            Cancel
                         </Button>
                     </Form>
                 </div>

--- a/client/web/src/enterprise/extensions/registry/backend.ts
+++ b/client/web/src/enterprise/extensions/registry/backend.ts
@@ -5,7 +5,7 @@ import { createAggregateError } from '@sourcegraph/common'
 import { gql } from '@sourcegraph/http-client'
 import * as GQL from '@sourcegraph/shared/src/schema'
 
-import { queryGraphQL, requestGraphQL } from '../../../backend/graphql'
+import { mutateGraphQL, queryGraphQL, requestGraphQL } from '../../../backend/graphql'
 import { DeleteRegistryExtensionResult, DeleteRegistryExtensionVariables, Scalars } from '../../../graphql-operations'
 
 export function deleteRegistryExtensionWithConfirmation(extension: Scalars['ID']): Observable<boolean> {
@@ -64,6 +64,40 @@ export function queryViewerRegistryPublishers(): Observable<GQL.RegistryPublishe
                 ...publisher,
                 extensionIDPrefix: data.extensionRegistry.localExtensionIDPrefix || undefined,
             }))
+        })
+    )
+}
+
+export function createExtension(
+    publisher: Scalars['ID'],
+    name: string
+): Observable<GQL.IExtensionRegistryCreateExtensionResult> {
+    return mutateGraphQL(
+        gql`
+            mutation CreateRegistryExtension($publisher: ID!, $name: String!) {
+                extensionRegistry {
+                    createExtension(publisher: $publisher, name: $name) {
+                        extension {
+                            id
+                            extensionID
+                            url
+                        }
+                    }
+                }
+            }
+        `,
+        { publisher, name }
+    ).pipe(
+        map(({ data, errors }) => {
+            if (
+                !data ||
+                !data.extensionRegistry ||
+                !data.extensionRegistry.createExtension ||
+                (errors && errors.length > 0)
+            ) {
+                throw createAggregateError(errors)
+            }
+            return data.extensionRegistry.createExtension
         })
     )
 }

--- a/client/web/src/extensions/extension/ExtensionAreaHeader.tsx
+++ b/client/web/src/extensions/extension/ExtensionAreaHeader.tsx
@@ -209,9 +209,11 @@ export const ExtensionAreaHeader: React.FunctionComponent<ExtensionAreaHeaderPro
                                                     activeClassName="active"
                                                     exact={exact}
                                                 >
-                                                    {Icon && <Icon className="icon-inline" />}{' '}
-                                                    <span className="text-content" data-tab-content={label}>
-                                                        {label}
+                                                    <span>
+                                                        {Icon && <Icon className="icon-inline" />}{' '}
+                                                        <span className="text-content" data-tab-content={label}>
+                                                            {label}
+                                                        </span>
                                                     </span>
                                                 </NavLink>
                                             </li>


### PR DESCRIPTION
Rob and I talked about how unaligned our create forms are, so I took a stab here at making the `NewExtensionPage` align with the design of the `CreateCodeMonitorPage`. In a separate PR, I will align the `CreateBatchChangePage` with this general layout as well.

| **Old** | **New** |
| --- | --- |
| <img width="1504" alt="image" src="https://user-images.githubusercontent.com/19534377/153892179-0444442c-f2f4-411b-8c12-3ec7a83aba10.png"> | <img width="1506" alt="image" src="https://user-images.githubusercontent.com/19534377/153891904-89a71b29-c91f-4e94-91a8-9f54d4bf514f.png"> |

## Test plan

Tested manually in the browser, this is just some visual changes and functionality seems to be preserved.