### PR TITLE
remove hypertable ref from old migration

### DIFF
--- a/migrations/codeinsights/1000000001/up.sql
+++ b/migrations/codeinsights/1000000001/up.sql
@@ -96,10 +96,6 @@ CREATE TABLE series_points (
     FOREIGN KEY (original_repo_name_id) REFERENCES repo_names(id) ON DELETE CASCADE DEFERRABLE
 );
 
--- Create hypertable, partitioning events by time.
--- See https://docs.timescale.com/latest/using-timescaledb/hypertables
-SELECT create_hypertable('series_points', 'time');
-
 -- Create btree indexes for repository filtering.
 CREATE INDEX series_points_repo_id_btree ON series_points USING btree (repo_id);
 CREATE INDEX series_points_repo_name_id_btree ON series_points USING btree (repo_name_id);


### PR DESCRIPTION
This hypertable statement got missed in https://github.com/sourcegraph/sourcegraph/pull/30781, so removing it here.

## Test plan

N/A


