### PR TITLE
batches: tweak wording of superseding batch spec banner

### DIFF
--- a/client/web/src/enterprise/batches/detail/SupersedingBatchSpecAlert.tsx
+++ b/client/web/src/enterprise/batches/detail/SupersedingBatchSpecAlert.tsx
@@ -26,8 +26,8 @@ export const SupersedingBatchSpecAlert: React.FunctionComponent<SupersedingBatch
         <DismissibleAlert variant="info" partialStorageKey={`superseding-spec-${parseISO(spec.createdAt).getTime()}`}>
             <div className="d-flex align-items-center">
                 <div className="flex-grow-1">
-                    A <Link to={applyURL}>modified batch spec</Link> is ready but not applied since{' '}
-                    <Timestamp date={createdAt} noAbout={true} />.
+                    A <Link to={applyURL}>modified batch spec</Link> was uploaded{' '}
+                    <Timestamp date={createdAt} noAbout={true} />, but has not been applied.
                 </div>
             </div>
         </DismissibleAlert>


### PR DESCRIPTION
Dealing with the big issues today. The wording of this message doesn't quite work for me, since it ends up like:

> A [modified batch spec](https://sourcegraph.test:3443/users/LawnGnome/batch-changes/apply/QmF0Y2hTcGVjOiJRbWdOSFVFTVA3Ig==) was uploaded 24 days ago, but has not been applied.

I think this reads better.

## Test plan

Verified with a Mark I eyeball. (I suspect we've disabled the snapshot that would have included this, but we'll see what CI does.)