### PR TITLE
[CLOUD-270] Sync private repositories through GitHub App

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/hostname"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -113,85 +114,7 @@ func main() {
 		ReposDir:           reposDir,
 		DesiredPercentFree: wantPctFree2,
 		GetRemoteURLFunc: func(ctx context.Context, repo api.RepoName) (string, error) {
-			r, err := repoStore.GetByName(ctx, repo)
-			if err != nil {
-				return "", err
-			}
-
-			for _, info := range r.Sources {
-				// build the clone url using the external service config instead of using
-				// the source CloneURL field
-				svc, err := externalServiceStore.GetByID(ctx, info.ExternalServiceID())
-				if err != nil {
-					return "", err
-				}
-
-				dotcomConfig := conf.SiteConfig().Dotcom
-				if envvar.SourcegraphDotComMode() &&
-					repos.IsGitHubAppCloudEnabled(dotcomConfig) &&
-					svc.Kind == extsvc.KindGitHub {
-					parsed, err := extsvc.ParseConfig(svc.Kind, svc.Config)
-					if err != nil {
-						return "", errors.Wrap(err, "parse config")
-					}
-
-					c, ok := parsed.(*schema.GitHubConnection)
-					if !ok {
-						return "", errors.Errorf("expect *schema.GitHubConnection but got %T", parsed)
-					}
-					if c.GithubAppInstallationID != "" {
-						baseURL, err := url.Parse(c.Url)
-						if err != nil {
-							return "", errors.Wrap(err, "parse base URL")
-						}
-
-						apiURL, githubDotCom := github.APIRoot(baseURL)
-						if !githubDotCom {
-							return "", errors.Errorf("only GitHub App on GitHub.com is supported, but got %q", baseURL)
-						}
-
-						pkey, err := base64.StdEncoding.DecodeString(dotcomConfig.GithubAppCloud.PrivateKey)
-						if err != nil {
-							return "", errors.Wrap(err, "decode private key")
-						}
-
-						auther, err := auth.NewOAuthBearerTokenWithGitHubApp(dotcomConfig.GithubAppCloud.AppID, pkey)
-						if err != nil {
-							return "", errors.Wrap(err, "new authenticator with GitHub App")
-						}
-
-						client := github.NewV3Client(apiURL, auther, nil)
-
-						installationID, err := strconv.ParseInt(c.GithubAppInstallationID, 10, 64)
-						if err != nil {
-							return "", errors.Wrap(err, "parse installation ID")
-						}
-
-						ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-						defer cancel()
-
-						// TODO(cloud-saas): Cache the installation access token until it expires, see
-						// https://sourcegraph.atlassian.net/browse/CLOUD-255
-						token, err := client.CreateAppInstallationAccessToken(ctx, installationID)
-						if err != nil {
-							return "", errors.Wrap(err, "create app installation access token")
-						}
-						if token.Token == nil {
-							return "", errors.New("empty token returned")
-						}
-
-						c.Token = *token.Token
-						config, err := json.Marshal(c)
-						if err != nil {
-							return "", errors.Wrap(err, "marshal config")
-						}
-						svc.Config = string(config)
-					}
-				}
-
-				return repos.CloneURL(svc.Kind, svc.Config, r)
-			}
-			return "", errors.Errorf("no sources for %q", repo)
+			return getRemoteURLFunc(ctx, externalServiceStore, repoStore, nil, repo)
 		},
 		GetVCSSyncer: func(ctx context.Context, repo api.RepoName) (server.VCSSyncer, error) {
 			return getVCSSyncer(ctx, externalServiceStore, repoStore, codeintelDB, repo)
@@ -352,6 +275,94 @@ func getDB() (*sql.DB, error) {
 		sqlDB, err = connections.EnsureNewFrontendDB(dsn, "gitserver", &observation.TestContext)
 	}
 	return sqlDB, err
+}
+
+func getRemoteURLFunc(
+	ctx context.Context,
+	externalServiceStore database.ExternalServiceStore,
+	repoStore database.RepoStore,
+	cli httpcli.Doer,
+	repo api.RepoName,
+) (string, error) {
+	r, err := repoStore.GetByName(ctx, repo)
+	if err != nil {
+		return "", err
+	}
+
+	for _, info := range r.Sources {
+		// build the clone url using the external service config instead of using
+		// the source CloneURL field
+		svc, err := externalServiceStore.GetByID(ctx, info.ExternalServiceID())
+		if err != nil {
+			return "", err
+		}
+
+		dotcomConfig := conf.SiteConfig().Dotcom
+		if envvar.SourcegraphDotComMode() &&
+			repos.IsGitHubAppCloudEnabled(dotcomConfig) &&
+			svc.Kind == extsvc.KindGitHub {
+			parsed, err := extsvc.ParseConfig(svc.Kind, svc.Config)
+			if err != nil {
+				return "", errors.Wrap(err, "parse config")
+			}
+
+			c, ok := parsed.(*schema.GitHubConnection)
+			if !ok {
+				return "", errors.Errorf("expect *schema.GitHubConnection but got %T", parsed)
+			}
+			if c.GithubAppInstallationID != "" {
+				baseURL, err := url.Parse(c.Url)
+				if err != nil {
+					return "", errors.Wrap(err, "parse base URL")
+				}
+
+				apiURL, githubDotCom := github.APIRoot(baseURL)
+				if !githubDotCom {
+					return "", errors.Errorf("only GitHub App on GitHub.com is supported, but got %q", baseURL)
+				}
+
+				pkey, err := base64.StdEncoding.DecodeString(dotcomConfig.GithubAppCloud.PrivateKey)
+				if err != nil {
+					return "", errors.Wrap(err, "decode private key")
+				}
+
+				auther, err := auth.NewOAuthBearerTokenWithGitHubApp(dotcomConfig.GithubAppCloud.AppID, pkey)
+				if err != nil {
+					return "", errors.Wrap(err, "new authenticator with GitHub App")
+				}
+
+				client := github.NewV3Client(apiURL, auther, cli)
+
+				installationID, err := strconv.ParseInt(c.GithubAppInstallationID, 10, 64)
+				if err != nil {
+					return "", errors.Wrap(err, "parse installation ID")
+				}
+
+				ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+				defer cancel()
+
+				// TODO(cloud-saas): Cache the installation access token until it expires, see
+				// https://sourcegraph.atlassian.net/browse/CLOUD-255
+				token, err := client.CreateAppInstallationAccessToken(ctx, installationID)
+				if err != nil {
+					return "", errors.Wrap(err, "create app installation access token")
+				}
+				if token.Token == nil {
+					return "", errors.New("empty token returned")
+				}
+
+				c.Token = *token.Token
+				config, err := json.Marshal(c)
+				if err != nil {
+					return "", errors.Wrap(err, "marshal config")
+				}
+				svc.Config = string(config)
+			}
+		}
+
+		return repos.CloneURL(svc.Kind, svc.Config, r)
+	}
+	return "", errors.Errorf("no sources for %q", repo)
 }
 
 func getVCSSyncer(ctx context.Context, externalServiceStore database.ExternalServiceStore, repoStore database.RepoStore,

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -126,7 +126,10 @@ func main() {
 					return "", err
 				}
 
-				if envvar.SourcegraphDotComMode() && svc.Kind == extsvc.KindGitHub {
+				dotcomConfig := conf.SiteConfig().Dotcom
+				if envvar.SourcegraphDotComMode() &&
+					repos.IsGitHubAppCloudEnabled(dotcomConfig) &&
+					svc.Kind == extsvc.KindGitHub {
 					parsed, err := extsvc.ParseConfig(svc.Kind, svc.Config)
 					if err != nil {
 						return "", errors.Wrap(err, "parse config")
@@ -145,11 +148,6 @@ func main() {
 						apiURL, githubDotCom := github.APIRoot(baseURL)
 						if !githubDotCom {
 							return "", errors.Errorf("only GitHub App on GitHub.com is supported, but got %q", baseURL)
-						}
-
-						dotcomConfig := conf.SiteConfig().Dotcom
-						if !repos.IsGitHubAppCloudEnabled(dotcomConfig) {
-							return "", errors.Errorf("connection contains an GitHub App installation ID while GitHub App for Sourcegraph Cloud is not enabled")
 						}
 
 						pkey, err := base64.StdEncoding.DecodeString(dotcomConfig.GithubAppCloud.PrivateKey)

--- a/cmd/gitserver/main_test.go
+++ b/cmd/gitserver/main_test.go
@@ -2,16 +2,38 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"flag"
+	"io"
+	"net/http"
+	"os"
 	"testing"
 
+	"github.com/inconshreveable/log15"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	codeinteldbstore "github.com/sourcegraph/sourcegraph/internal/codeintel/stores/dbstore"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if !testing.Verbose() {
+		log15.Root().SetHandler(log15.DiscardHandler())
+	}
+	os.Exit(m.Run())
+}
 
 func TestParsePercent(t *testing.T) {
 	tests := []struct {
@@ -38,6 +60,89 @@ func TestParsePercent(t *testing.T) {
 			}
 		})
 	}
+}
+
+type mockDoer struct {
+	do func(*http.Request) (*http.Response, error)
+}
+
+func (c *mockDoer) Do(r *http.Request) (*http.Response, error) {
+	return c.do(r)
+}
+
+func TestGetRemoteURLFunc_GitHubAppCloud(t *testing.T) {
+	externalServiceStore := database.NewMockExternalServiceStore()
+	externalServiceStore.GetByIDFunc.SetDefaultReturn(
+		&types.ExternalService{
+			ID:   1,
+			Kind: extsvc.KindGitHub,
+			Config: `
+{
+  "url": "https://github.com",
+  "githubAppInstallationID": "21994992",
+  "repos": []
+}`,
+		},
+		nil,
+	)
+
+	repoStore := database.NewMockRepoStore()
+	repoStore.GetByNameFunc.SetDefaultReturn(
+		&types.Repo{
+			ID:   1,
+			Name: "test-repo-1",
+			Sources: map[string]*types.SourceInfo{
+				"extsvc:github:1": {
+					ID:       "extsvc:github:1",
+					CloneURL: "https://github.com/sgtest/test-repo-1",
+				},
+			},
+			Metadata: &github.Repository{
+				URL: "https://github.com/sgtest/test-repo-1",
+			},
+		},
+		nil,
+	)
+
+	doer := &mockDoer{
+		do: func(r *http.Request) (*http.Response, error) {
+			want := "http://github-proxy/app/installations/21994992/access_tokens"
+			if r.URL.String() != want {
+				return nil, errors.Errorf("URL: want %q but got %q", want, r.URL)
+			}
+
+			body := `{"token": "mock-installtion-access-token"}`
+			return &http.Response{
+				Status:     http.StatusText(http.StatusOK),
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader([]byte(body))),
+			}, nil
+		},
+	}
+
+	orig := envvar.SourcegraphDotComMode()
+	envvar.MockSourcegraphDotComMode(true)
+	defer envvar.MockSourcegraphDotComMode(orig)
+
+	const bogusKey = `LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlCUEFJQkFBSkJBUEpIaWprdG1UMUlLYUd0YTVFZXAzQVo5Q2VPZUw4alBESUZUN3dRZ0tabXQzRUZxRGhCCk93bitRVUhKdUs5Zm92UkROSmVWTDJvWTVCT0l6NHJ3L0cwQ0F3RUFBUUpCQU1BK0o5Mks0d2NQVllsbWMrM28KcHU5NmlKTkNwMmp5Nm5hK1pEQlQzK0VvSUo1VFJGdnN3R2kvTHUzZThYUWwxTDNTM21ub0xPSlZNcTF0bUxOMgpIY0VDSVFEK3daeS83RlYxUEFtdmlXeWlYVklETzJnNWJOaUJlbmdKQ3hFa3Nia1VtUUloQVBOMlZaczN6UFFwCk1EVG9vTlJXcnl0RW1URERkamdiOFpzTldYL1JPRGIxQWlCZWNKblNVQ05TQllLMXJ5VTFmNURTbitoQU9ZaDkKWDFBMlVnTDE3bWhsS1FJaEFPK2JMNmRDWktpTGZORWxmVnRkTUtxQnFjNlBIK01heFU2VzlkVlFvR1dkQWlFQQptdGZ5cE9zYTFiS2hFTDg0blovaXZFYkJyaVJHalAya3lERHYzUlg0V0JrPQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=`
+	conf.Mock(&conf.Unified{
+		SiteConfiguration: schema.SiteConfiguration{
+			Dotcom: &schema.Dotcom{
+				GithubAppCloud: &schema.GithubAppCloud{
+					AppID:      "404",
+					PrivateKey: bogusKey,
+					Slug:       "test-app",
+				},
+			},
+		},
+	})
+	defer conf.Mock(nil)
+
+	got, err := getRemoteURLFunc(context.Background(), externalServiceStore, repoStore, doer, "test-repo-1")
+	require.NoError(t, err)
+
+	want := "https://x-access-token:mock-installtion-access-token@github.com/sgtest/test-repo-1"
+	assert.Equal(t, want, got)
 }
 
 func TestGetVCSSyncer(t *testing.T) {

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -670,7 +670,6 @@ func (s *Server) getRemoteURL(ctx context.Context, name api.RepoName) (*vcs.URL,
 	if err != nil {
 		return nil, errors.Wrap(err, "GetRemoteURLFunc")
 	}
-	fmt.Println("remoteURL", remoteURL)
 
 	return vcs.ParseURL(remoteURL)
 }

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -670,6 +670,7 @@ func (s *Server) getRemoteURL(ctx context.Context, name api.RepoName) (*vcs.URL,
 	if err != nil {
 		return nil, errors.Wrap(err, "GetRemoteURLFunc")
 	}
+	fmt.Println("remoteURL", remoteURL)
 
 	return vcs.ParseURL(remoteURL)
 }

--- a/internal/repos/clone_url.go
+++ b/internal/repos/clone_url.go
@@ -175,7 +175,12 @@ func githubCloneURL(repo *github.Repository, cfg *schema.GitHubConnection) (stri
 		log15.Warn("Error adding authentication to GitHub repository Git remote URL.", "url", repo.URL, "error", err)
 		return repo.URL, nil
 	}
-	u.User = url.User(cfg.Token)
+
+	if cfg.GithubAppInstallationID != "" {
+		u.User = url.UserPassword("x-access-token", cfg.Token)
+	} else {
+		u.User = url.User(cfg.Token)
+	}
 	return u.String(), nil
 }
 


### PR DESCRIPTION
Due to the fact that the code host connection created by the GitHub App does not currently store the access token in the config itself (which will be addressed separately with more care in CLOUD-255), we need to exchange an installation access token for our GitHub App in order to compose the repository clone URLs for repositories that are synced through GitHub App, at the time of cloning and updating.

Notes:

1. I extracted the previously embedded function body of `GetRemoteURLFunc` to its own function (`getRemoteURLFunc`) in order to write tests for it.
2. I am aware of [similar boilerplates in other places already](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+:%3D+auth.NewOAuthBearerTokenWithGitHubApp%28&patternType=literal), but I choose to leave it for CLOUD-255 because I think it is currently unclear how to best utilize the code reusability within the scope of this PR.

## Test plan

1. Use our [GitHub App local testing guide](https://docs.google.com/document/d/1FYTIPLsT4CAT0jPHoCbTb7JcS8dySX4am_rmQZlVJVE/edit) to set up the organization code host connection, allow access to at least one public and one private repositories for the installation.
2. Pick at least one public and one private repositories to be synced into Sourcegraph.
3. All selected repositories should be available for search once the initial cloning is done.


