### PR TITLE
fixing a broken link

### DIFF
--- a/doc/admin/http_https_configuration.md
+++ b/doc/admin/http_https_configuration.md
@@ -167,7 +167,7 @@ Usage instructions are provided via [the `caddy` service's inline comments insid
 
 ### HTTPS with Custom Certificates in Docker Compose
 
-In https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml:
+In https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml
     
 1. In the Environment section of the compose file uncomment & update this line with your Sourcegraph Site Address:
 


### PR DESCRIPTION
this link originally had the `:` character on the end of it, which caused the link to 404.  We probably don't need that colon as it stands, so I just removed it.

