### PR TITLE
gomod: update zoekt

### DIFF
--- a/dev/zoekt/update
+++ b/dev/zoekt/update
@@ -19,7 +19,7 @@ newsha="$(echo "$module" | grep -o '[a-f0-9]*$')"
 
 echo "https://github.com/sourcegraph/zoekt/compare/$oldsha...$newsha"
 echo "git log --pretty=format:'- https://github.com/sourcegraph/zoekt/commit/%h %s' $oldsha...$newsha | sed 's/ (#[0-9]*)//g'"
-echo "git log --pretty=format:'- %h %s' $oldsha...$newsha"
+echo "git log --pretty=format:'- %h %s' $oldsha...$newsha | sed 's/ (#[0-9]*)//g'"
 
 go mod edit "-replace=${upstream}=${module}"
 go mod download ${upstream}

--- a/go.mod
+++ b/go.mod
@@ -392,7 +392,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20220120135924-650214d5a4ea
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20220210200412-9d1b56e6180f
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20211110092431-863f5b1ee51b

--- a/go.sum
+++ b/go.sum
@@ -1460,8 +1460,6 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d h1:yKm7XZV6j9
 github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:UdhH50NIW0fCiwBSr0co2m7BnFLdv4fQTgdqdJTHFeE=
 github.com/sourcegraph/ctxvfs v0.0.0-20180418081416-2b65f1b1ea81 h1:v4/JVxZSPWifxmICRqgXK7khThjw03RfdGhyeA2S4EQ=
 github.com/sourcegraph/ctxvfs v0.0.0-20180418081416-2b65f1b1ea81/go.mod h1:xIvvI5FiHLxhv8prbzVpaMHaaGPFPFQSuTcxC91ryOo=
-github.com/sourcegraph/go-ctags v0.0.0-20210923201916-00b9c039141c h1:yE3O0BjqgifSyuyhnvvOuonOHZa8m58IJgqFEB07dR0=
-github.com/sourcegraph/go-ctags v0.0.0-20210923201916-00b9c039141c/go.mod h1:ZYjpRXoJrRlxjU9ZfpaUKJkk62AjhJPffN3rlw2aqxM=
 github.com/sourcegraph/go-ctags v0.0.0-20220210084826-96f4236f0a78 h1:DY/m+6+PnBz49fMU7rE+DfPf09QYgO1RLPDeJ/1BY9w=
 github.com/sourcegraph/go-ctags v0.0.0-20220210084826-96f4236f0a78/go.mod h1:ZYjpRXoJrRlxjU9ZfpaUKJkk62AjhJPffN3rlw2aqxM=
 github.com/sourcegraph/go-diff v0.5.1/go.mod h1:j2dHj3m8aZgQO8lMTcTnBcXkRRRqi34cd2MNlA9u1mE=
@@ -1491,8 +1489,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20220120135924-650214d5a4ea h1:ok7yfBtNYtkBP2EzsQnJEB7m+9V0AtNQn4CMiMkZZKw=
-github.com/sourcegraph/zoekt v0.0.0-20220120135924-650214d5a4ea/go.mod h1:Sx/PuFfor3D2/B5yTV9TqhTW48+85dR5o2tWD8VsASk=
+github.com/sourcegraph/zoekt v0.0.0-20220210200412-9d1b56e6180f h1:jBnIBqQsyTfPJ0ahWXQbRdGcSllkuhqbzCfw86AuD6Y=
+github.com/sourcegraph/zoekt v0.0.0-20220210200412-9d1b56e6180f/go.mod h1:Dx/yL46cfqqppDnXA6XwNlWi/++l+WIGs8AkJIo9cDI=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
Includes the following commits. In particular we are interested to see
if our commit which removes python from the image removes a CVE related
to expat.

- https://github.com/sourcegraph/zoekt/commit/9d1b56e change findShard implementation to match on IDs, not names
- https://github.com/sourcegraph/zoekt/commit/f6ba702 ctags: bump version to latest
- https://github.com/sourcegraph/zoekt/commit/840d5e4 docs: document JSON API
- https://github.com/sourcegraph/zoekt/commit/5f70fa0 fix: sourcegraphFake only checks SG_PRIVATE
- https://github.com/sourcegraph/zoekt/commit/abedc19 introduce BLOCK_PROFILE_RATE environment variable to control the sampling rate of Go's block profiler
- https://github.com/sourcegraph/zoekt/commit/acb6f19 use the ctags build script from sourcegraph
- https://github.com/sourcegraph/zoekt/commit/9e4c394 indexserver: track number of repository options we fetch
- https://github.com/sourcegraph/zoekt/commit/6b1df4f build ctags on alpine 3.11
- https://github.com/sourcegraph/zoekt/commit/65df08f specify docker tag versions
- https://github.com/sourcegraph/zoekt/commit/b87be87 debug: add more facilities for debugging
- https://github.com/sourcegraph/zoekt/commit/d19dfcd remove zoekt-merge-small.py
- https://github.com/sourcegraph/zoekt/commit/27e54f1 Add support for JSON responses in the webserver
- https://github.com/sourcegraph/zoekt/commit/574b805 indexserver: return uint from MaybeRemoveMissing
- https://github.com/sourcegraph/zoekt/commit/512672d indexserver: track num of repos we stop tracking
- https://github.com/sourcegraph/zoekt/commit/5bbbd4e merging: run vacuum every 24h instead of every hour
- https://github.com/sourcegraph/zoekt/commit/d11a068 merging: remove obsolete maxSize
- https://github.com/sourcegraph/zoekt/commit/8ec61a4 merging: support unsetting tombstones during cleanup

Test Plan: main dry run for integration tests and to inspect the trivy report to see if expat CVE is gone.
