### PR TITLE
docker-images: upgrade prometheus to 2.33.1

### DIFF
--- a/docker-images/prometheus/Dockerfile
+++ b/docker-images/prometheus/Dockerfile
@@ -8,7 +8,7 @@ RUN PROMETHEUS_DIR='/generated/prometheus' GRAFANA_DIR='' DOCS_DIR='' NO_PRUNE=t
 RUN ls '/generated/prometheus'
 
 # To upgrade Prometheus or Alertmanager, see https://docs.sourcegraph.com/dev/background-information/observability/prometheus#upgrading-prometheus-or-alertmanager
-FROM prom/prometheus:v2.31.1@sha256:a8779cfe553e0331e9046268e26c539fa39ecf90d59836d828163e65e8f4fa35 AS prom_upstream
+FROM prom/prometheus:v2.33.1@sha256:3a75763d209af6ef82aca8fb202a76092a690d25f24d2def7f4eff64e79b7ed9 AS prom_upstream
 FROM prom/alertmanager:v0.23.0@sha256:9ab73a421b65b80be072f96a88df756fc5b52a1bc8d983537b8ec5be8b624c5a AS am_upstream
 
 # Prepare final image
@@ -16,7 +16,7 @@ FROM prom/alertmanager:v0.23.0@sha256:9ab73a421b65b80be072f96a88df756fc5b52a1bc8
 FROM quay.io/prometheus/busybox-linux-amd64:latest
 
 # Should reflect versions above
-LABEL com.sourcegraph.prometheus.version=v2.31.1
+LABEL com.sourcegraph.prometheus.version=v2.33.1
 LABEL com.sourcegraph.alertmanager.version=v0.23.0
 
 ARG COMMIT_SHA="unknown"


### PR DESCRIPTION
We hope to resolve the trivy reports around containerd. Prometheus's dockerfile had not changes since 2.32.1 so we only needed to bump the versions.

Test Plan: CI main dry run.
