### PR TITLE
bext: fix after-install page

### DIFF
--- a/client/browser/src/browser-extension/scripts/afterInstallPage.main.tsx
+++ b/client/browser/src/browser-extension/scripts/afterInstallPage.main.tsx
@@ -4,9 +4,13 @@ import '../../shared/polyfills'
 import React from 'react'
 import { render } from 'react-dom'
 
+import { AnchorLink, setLinkComponent } from '@sourcegraph/wildcard'
+
 import { WildcardThemeProvider } from '../../shared/components/WildcardThemeProvider'
 import { AfterInstallPageContent } from '../after-install-page/AfterInstallPageContent'
 import { ThemeWrapper } from '../ThemeWrapper'
+
+setLinkComponent(AnchorLink)
 
 const AfterInstallPage: React.FunctionComponent = () => (
     <ThemeWrapper>


### PR DESCRIPTION


## Description

Seems like, after https://github.com/sourcegraph/sourcegraph/pull/30534, the browser extension after-install page was broken due to the Link is not set for it.

As long terms plan https://github.com/sourcegraph/sourcegraph/issues/31046, we will be rewriting browser extension storybook stories to replicate production configuration because currently it is wrapped into BrandedStory and other components that set the environment. 

## How to test
- `sg run bext`
- Reinstall browser extension locally and make sure that after install page is rendered.

## Before merging

- [ ] Test on different code hosts (if applicable)
    - [ ] GitHub
    - [ ] Gitlab
    - [ ] GitHub Enterprise
    - [ ] Refined GitHub
    - [ ] Phabricator
    - [ ] Phabricator integration
    - [ ] Bitbucket
    - [ ] Bitbucket integration

- [ ] Test on different browsers (if applicable)
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
- [ ] Add change log message to [client/browser/CHANGELOG.md](./client/browser/CHANGELOG.md), under "Unreleased" section. (if applicable)

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


