### PR TITLE
insights: add sub-repo permissions checker to code-insights worker

### DIFF
--- a/enterprise/internal/insights/background/queryrunner/work_handler.go
+++ b/enterprise/internal/insights/background/queryrunner/work_handler.go
@@ -166,7 +166,7 @@ func (r *workHandler) searchHandler(ctx context.Context, job *Job, series *types
 		if authz.SubRepoEnabled(checker) {
 			enabled, checkErr := checkSubRepoPermissions(ctx, checker, decoded.RepoID(), err)
 			if checkErr != nil {
-				err = errors.Append(err, checkErr)
+				log15.Error(fmt.Sprintf("Error during sub-repo permissions check for repoID=%s", decoded.RepoID()))
 				continue
 			}
 			if enabled {

--- a/enterprise/internal/insights/background/queryrunner/work_handler.go
+++ b/enterprise/internal/insights/background/queryrunner/work_handler.go
@@ -88,13 +88,15 @@ func (r *workHandler) generateComputeRecordings(ctx context.Context, job *Job, r
 			continue
 		}
 		// sub-repo permissions filtering. If the repo supports it, then it should be excluded from search results
-		enabled, checkErr := checkSubRepoPermissionsForRepoId(ctx, checker, repoId, err)
-		if checkErr != nil {
-			err = errors.Append(err, checkErr)
-			continue
-		}
-		if enabled {
-			continue
+		if authz.SubRepoEnabled(checker) {
+			enabled, checkErr := checkSubRepoPermissionsForRepoId(ctx, checker, repoId, err)
+			if checkErr != nil {
+				err = errors.Append(err, checkErr)
+				continue
+			}
+			if enabled {
+				continue
+			}
 		}
 		for _, group := range groupedByCapture {
 			capture := group.Value

--- a/enterprise/internal/insights/background/queryrunner/work_handler_test.go
+++ b/enterprise/internal/insights/background/queryrunner/work_handler_test.go
@@ -142,7 +142,73 @@ func TestGenerateComputeRecordings(t *testing.T) {
 			t.Error(err)
 		}
 		if len(recordings) != 0 {
-			t.Error("No recording should be returned as given repo has sub-repo permissions")
+			t.Error("No records should be returned as given repo has sub-repo permissions")
+		}
+
+		// Resetting DefaultSubRepoPermsChecker, so it won't affect further tests
+		authz.DefaultSubRepoPermsChecker = nil
+	})
+
+	t.Run("compute job with sub-repo permissions resulted in error", func(t *testing.T) {
+		date := time.Date(2021, 12, 1, 0, 0, 0, 0, time.UTC)
+		job := Job{
+			SeriesID:        "testseries1",
+			SearchQuery:     "searchit",
+			RecordTime:      &date,
+			PersistMode:     "record",
+			DependentFrames: nil,
+			ID:              1,
+			State:           "queued",
+		}
+
+		mocked := mockComputeSearch([]computeSearch{
+			{
+				repoName: "github.com/sourcegraph/sourcegraph",
+				repoId:   11,
+				values: []computeValue{
+					{
+						value:   "1.15",
+						count:   3,
+						path:    "package1/go.mod",
+						revhash: "asdfsadf1234qwrar234",
+					},
+					{
+						value:   "1.14",
+						count:   1,
+						path:    "package1/go.mod",
+						revhash: "asdfsadf1234qwrar234",
+					},
+				},
+			},
+		})
+
+		handler := workHandler{
+			baseWorkerStore: nil,
+			insightsStore:   nil,
+			metadadataStore: nil,
+			limiter:         nil,
+			mu:              sync.RWMutex{},
+			seriesCache:     nil,
+			computeSearch:   mocked,
+		}
+
+		checker := authz.NewMockSubRepoPermissionChecker()
+		checker.EnabledFunc.SetDefaultHook(func() bool {
+			return true
+		})
+		checker.EnabledForRepoIdFunc.SetDefaultHook(func(ctx context.Context, id api.RepoID) (bool, error) {
+			return false, errors.New("Oops")
+		})
+
+		// sub-repo permissions are enabled
+		authz.DefaultSubRepoPermsChecker = checker
+
+		recordings, err := handler.generateComputeRecordings(ctx, &job, date)
+		if err != nil {
+			t.Error(err)
+		}
+		if len(recordings) != 0 {
+			t.Error("No records should be returned as given repo has an error during sub-repo permissions check")
 		}
 
 		// Resetting DefaultSubRepoPermsChecker, so it won't affect further tests

--- a/enterprise/internal/insights/background/queryrunner/work_handler_test.go
+++ b/enterprise/internal/insights/background/queryrunner/work_handler_test.go
@@ -10,9 +10,10 @@ import (
 	"time"
 
 	insightsdbtesting "github.com/sourcegraph/sourcegraph/enterprise/internal/insights/dbtesting"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
-
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 
@@ -76,6 +77,73 @@ func TestGenerateComputeRecordings(t *testing.T) {
 			"github.com/sourcegraph/sourcegraph 11 2021-12-01 00:00:00 +0000 UTC 1.14 1.000000",
 			"github.com/sourcegraph/sourcegraph 11 2021-12-01 00:00:00 +0000 UTC 1.15 3.000000",
 		}).Equal(t, stringified)
+	})
+
+	t.Run("compute job with sub-repo permissions", func(t *testing.T) {
+		date := time.Date(2021, 12, 1, 0, 0, 0, 0, time.UTC)
+		job := Job{
+			SeriesID:        "testseries1",
+			SearchQuery:     "searchit",
+			RecordTime:      &date,
+			PersistMode:     "record",
+			DependentFrames: nil,
+			ID:              1,
+			State:           "queued",
+		}
+
+		mocked := mockComputeSearch([]computeSearch{
+			{
+				repoName: "github.com/sourcegraph/sourcegraph",
+				repoId:   11,
+				values: []computeValue{
+					{
+						value:   "1.15",
+						count:   3,
+						path:    "package1/go.mod",
+						revhash: "asdfsadf1234qwrar234",
+					},
+					{
+						value:   "1.14",
+						count:   1,
+						path:    "package1/go.mod",
+						revhash: "asdfsadf1234qwrar234",
+					},
+				},
+			},
+		})
+
+		handler := workHandler{
+			baseWorkerStore: nil,
+			insightsStore:   nil,
+			metadadataStore: nil,
+			limiter:         nil,
+			mu:              sync.RWMutex{},
+			seriesCache:     nil,
+			computeSearch:   mocked,
+		}
+
+		checker := authz.NewMockSubRepoPermissionChecker()
+		checker.EnabledFunc.SetDefaultHook(func() bool {
+			return true
+		})
+		checker.EnabledForRepoIdFunc.SetDefaultHook(func(ctx context.Context, id api.RepoID) (bool, error) {
+			if id == 11 {
+				return true, nil
+			} else {
+				return false, errors.New("Wrong repoID, try again")
+			}
+		})
+
+		// sub-repo permissions are enabled
+		authz.DefaultSubRepoPermsChecker = checker
+
+		recordings, err := handler.generateComputeRecordings(ctx, &job, date)
+		if err != nil {
+			t.Error(err)
+		}
+		if len(recordings) != 0 {
+			t.Error("No recording should be returned as given repo has sub-repo permissions")
+		}
 	})
 
 	t.Run("compute job with no dependencies multirepo", func(t *testing.T) {

--- a/enterprise/internal/insights/background/queryrunner/work_handler_test.go
+++ b/enterprise/internal/insights/background/queryrunner/work_handler_test.go
@@ -144,6 +144,9 @@ func TestGenerateComputeRecordings(t *testing.T) {
 		if len(recordings) != 0 {
 			t.Error("No recording should be returned as given repo has sub-repo permissions")
 		}
+
+		// Resetting DefaultSubRepoPermsChecker, so it won't affect further tests
+		authz.DefaultSubRepoPermsChecker = nil
 	})
 
 	t.Run("compute job with no dependencies multirepo", func(t *testing.T) {

--- a/internal/authz/mock_sub_repo_perms_checker.go
+++ b/internal/authz/mock_sub_repo_perms_checker.go
@@ -5,6 +5,8 @@ package authz
 import (
 	"context"
 	"sync"
+
+	api "github.com/sourcegraph/sourcegraph/internal/api"
 )
 
 // MockSubRepoPermissionChecker is a mock implementation of the
@@ -14,6 +16,9 @@ type MockSubRepoPermissionChecker struct {
 	// EnabledFunc is an instance of a mock function object controlling the
 	// behavior of the method Enabled.
 	EnabledFunc *SubRepoPermissionCheckerEnabledFunc
+	// EnabledForRepoIdFunc is an instance of a mock function object
+	// controlling the behavior of the method EnabledForRepoId.
+	EnabledForRepoIdFunc *SubRepoPermissionCheckerEnabledForRepoIdFunc
 	// PermissionsFunc is an instance of a mock function object controlling
 	// the behavior of the method Permissions.
 	PermissionsFunc *SubRepoPermissionCheckerPermissionsFunc
@@ -27,6 +32,11 @@ func NewMockSubRepoPermissionChecker() *MockSubRepoPermissionChecker {
 		EnabledFunc: &SubRepoPermissionCheckerEnabledFunc{
 			defaultHook: func() bool {
 				return false
+			},
+		},
+		EnabledForRepoIdFunc: &SubRepoPermissionCheckerEnabledForRepoIdFunc{
+			defaultHook: func(context.Context, api.RepoID) (bool, error) {
+				return false, nil
 			},
 		},
 		PermissionsFunc: &SubRepoPermissionCheckerPermissionsFunc{
@@ -47,6 +57,11 @@ func NewStrictMockSubRepoPermissionChecker() *MockSubRepoPermissionChecker {
 				panic("unexpected invocation of MockSubRepoPermissionChecker.Enabled")
 			},
 		},
+		EnabledForRepoIdFunc: &SubRepoPermissionCheckerEnabledForRepoIdFunc{
+			defaultHook: func(context.Context, api.RepoID) (bool, error) {
+				panic("unexpected invocation of MockSubRepoPermissionChecker.EnabledForRepoId")
+			},
+		},
 		PermissionsFunc: &SubRepoPermissionCheckerPermissionsFunc{
 			defaultHook: func(context.Context, int32, RepoContent) (Perms, error) {
 				panic("unexpected invocation of MockSubRepoPermissionChecker.Permissions")
@@ -62,6 +77,9 @@ func NewMockSubRepoPermissionCheckerFrom(i SubRepoPermissionChecker) *MockSubRep
 	return &MockSubRepoPermissionChecker{
 		EnabledFunc: &SubRepoPermissionCheckerEnabledFunc{
 			defaultHook: i.Enabled,
+		},
+		EnabledForRepoIdFunc: &SubRepoPermissionCheckerEnabledForRepoIdFunc{
+			defaultHook: i.EnabledForRepoId,
 		},
 		PermissionsFunc: &SubRepoPermissionCheckerPermissionsFunc{
 			defaultHook: i.Permissions,
@@ -170,6 +188,119 @@ func (c SubRepoPermissionCheckerEnabledFuncCall) Args() []interface{} {
 // invocation.
 func (c SubRepoPermissionCheckerEnabledFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
+}
+
+// SubRepoPermissionCheckerEnabledForRepoIdFunc describes the behavior when
+// the EnabledForRepoId method of the parent MockSubRepoPermissionChecker
+// instance is invoked.
+type SubRepoPermissionCheckerEnabledForRepoIdFunc struct {
+	defaultHook func(context.Context, api.RepoID) (bool, error)
+	hooks       []func(context.Context, api.RepoID) (bool, error)
+	history     []SubRepoPermissionCheckerEnabledForRepoIdFuncCall
+	mutex       sync.Mutex
+}
+
+// EnabledForRepoId delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockSubRepoPermissionChecker) EnabledForRepoId(v0 context.Context, v1 api.RepoID) (bool, error) {
+	r0, r1 := m.EnabledForRepoIdFunc.nextHook()(v0, v1)
+	m.EnabledForRepoIdFunc.appendCall(SubRepoPermissionCheckerEnabledForRepoIdFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the EnabledForRepoId
+// method of the parent MockSubRepoPermissionChecker instance is invoked and
+// the hook queue is empty.
+func (f *SubRepoPermissionCheckerEnabledForRepoIdFunc) SetDefaultHook(hook func(context.Context, api.RepoID) (bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// EnabledForRepoId method of the parent MockSubRepoPermissionChecker
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *SubRepoPermissionCheckerEnabledForRepoIdFunc) PushHook(hook func(context.Context, api.RepoID) (bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *SubRepoPermissionCheckerEnabledForRepoIdFunc) SetDefaultReturn(r0 bool, r1 error) {
+	f.SetDefaultHook(func(context.Context, api.RepoID) (bool, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *SubRepoPermissionCheckerEnabledForRepoIdFunc) PushReturn(r0 bool, r1 error) {
+	f.PushHook(func(context.Context, api.RepoID) (bool, error) {
+		return r0, r1
+	})
+}
+
+func (f *SubRepoPermissionCheckerEnabledForRepoIdFunc) nextHook() func(context.Context, api.RepoID) (bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *SubRepoPermissionCheckerEnabledForRepoIdFunc) appendCall(r0 SubRepoPermissionCheckerEnabledForRepoIdFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// SubRepoPermissionCheckerEnabledForRepoIdFuncCall objects describing the
+// invocations of this function.
+func (f *SubRepoPermissionCheckerEnabledForRepoIdFunc) History() []SubRepoPermissionCheckerEnabledForRepoIdFuncCall {
+	f.mutex.Lock()
+	history := make([]SubRepoPermissionCheckerEnabledForRepoIdFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// SubRepoPermissionCheckerEnabledForRepoIdFuncCall is an object that
+// describes an invocation of method EnabledForRepoId on an instance of
+// MockSubRepoPermissionChecker.
+type SubRepoPermissionCheckerEnabledForRepoIdFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 api.RepoID
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 bool
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c SubRepoPermissionCheckerEnabledForRepoIdFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c SubRepoPermissionCheckerEnabledForRepoIdFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // SubRepoPermissionCheckerPermissionsFunc describes the behavior when the

--- a/internal/authz/mock_sub_repo_perms_getter.go
+++ b/internal/authz/mock_sub_repo_perms_getter.go
@@ -16,6 +16,9 @@ type MockSubRepoPermissionsGetter struct {
 	// GetByUserFunc is an instance of a mock function object controlling
 	// the behavior of the method GetByUser.
 	GetByUserFunc *SubRepoPermissionsGetterGetByUserFunc
+	// RepoIdSupportedFunc is an instance of a mock function object
+	// controlling the behavior of the method RepoIdSupported.
+	RepoIdSupportedFunc *SubRepoPermissionsGetterRepoIdSupportedFunc
 }
 
 // NewMockSubRepoPermissionsGetter creates a new mock of the
@@ -26,6 +29,11 @@ func NewMockSubRepoPermissionsGetter() *MockSubRepoPermissionsGetter {
 		GetByUserFunc: &SubRepoPermissionsGetterGetByUserFunc{
 			defaultHook: func(context.Context, int32) (map[api.RepoName]SubRepoPermissions, error) {
 				return nil, nil
+			},
+		},
+		RepoIdSupportedFunc: &SubRepoPermissionsGetterRepoIdSupportedFunc{
+			defaultHook: func(context.Context, api.RepoID) (bool, error) {
+				return false, nil
 			},
 		},
 	}
@@ -41,6 +49,11 @@ func NewStrictMockSubRepoPermissionsGetter() *MockSubRepoPermissionsGetter {
 				panic("unexpected invocation of MockSubRepoPermissionsGetter.GetByUser")
 			},
 		},
+		RepoIdSupportedFunc: &SubRepoPermissionsGetterRepoIdSupportedFunc{
+			defaultHook: func(context.Context, api.RepoID) (bool, error) {
+				panic("unexpected invocation of MockSubRepoPermissionsGetter.RepoIdSupported")
+			},
+		},
 	}
 }
 
@@ -51,6 +64,9 @@ func NewMockSubRepoPermissionsGetterFrom(i SubRepoPermissionsGetter) *MockSubRep
 	return &MockSubRepoPermissionsGetter{
 		GetByUserFunc: &SubRepoPermissionsGetterGetByUserFunc{
 			defaultHook: i.GetByUser,
+		},
+		RepoIdSupportedFunc: &SubRepoPermissionsGetterRepoIdSupportedFunc{
+			defaultHook: i.RepoIdSupported,
 		},
 	}
 }
@@ -164,5 +180,118 @@ func (c SubRepoPermissionsGetterGetByUserFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c SubRepoPermissionsGetterGetByUserFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// SubRepoPermissionsGetterRepoIdSupportedFunc describes the behavior when
+// the RepoIdSupported method of the parent MockSubRepoPermissionsGetter
+// instance is invoked.
+type SubRepoPermissionsGetterRepoIdSupportedFunc struct {
+	defaultHook func(context.Context, api.RepoID) (bool, error)
+	hooks       []func(context.Context, api.RepoID) (bool, error)
+	history     []SubRepoPermissionsGetterRepoIdSupportedFuncCall
+	mutex       sync.Mutex
+}
+
+// RepoIdSupported delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockSubRepoPermissionsGetter) RepoIdSupported(v0 context.Context, v1 api.RepoID) (bool, error) {
+	r0, r1 := m.RepoIdSupportedFunc.nextHook()(v0, v1)
+	m.RepoIdSupportedFunc.appendCall(SubRepoPermissionsGetterRepoIdSupportedFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the RepoIdSupported
+// method of the parent MockSubRepoPermissionsGetter instance is invoked and
+// the hook queue is empty.
+func (f *SubRepoPermissionsGetterRepoIdSupportedFunc) SetDefaultHook(hook func(context.Context, api.RepoID) (bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// RepoIdSupported method of the parent MockSubRepoPermissionsGetter
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *SubRepoPermissionsGetterRepoIdSupportedFunc) PushHook(hook func(context.Context, api.RepoID) (bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *SubRepoPermissionsGetterRepoIdSupportedFunc) SetDefaultReturn(r0 bool, r1 error) {
+	f.SetDefaultHook(func(context.Context, api.RepoID) (bool, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *SubRepoPermissionsGetterRepoIdSupportedFunc) PushReturn(r0 bool, r1 error) {
+	f.PushHook(func(context.Context, api.RepoID) (bool, error) {
+		return r0, r1
+	})
+}
+
+func (f *SubRepoPermissionsGetterRepoIdSupportedFunc) nextHook() func(context.Context, api.RepoID) (bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *SubRepoPermissionsGetterRepoIdSupportedFunc) appendCall(r0 SubRepoPermissionsGetterRepoIdSupportedFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// SubRepoPermissionsGetterRepoIdSupportedFuncCall objects describing the
+// invocations of this function.
+func (f *SubRepoPermissionsGetterRepoIdSupportedFunc) History() []SubRepoPermissionsGetterRepoIdSupportedFuncCall {
+	f.mutex.Lock()
+	history := make([]SubRepoPermissionsGetterRepoIdSupportedFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// SubRepoPermissionsGetterRepoIdSupportedFuncCall is an object that
+// describes an invocation of method RepoIdSupported on an instance of
+// MockSubRepoPermissionsGetter.
+type SubRepoPermissionsGetterRepoIdSupportedFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 api.RepoID
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 bool
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c SubRepoPermissionsGetterRepoIdSupportedFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c SubRepoPermissionsGetterRepoIdSupportedFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }

--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -323,13 +323,13 @@ func SubRepoEnabled(checker SubRepoPermissionChecker) bool {
 	return checker != nil && checker.Enabled()
 }
 
-// SubRepoEnabledForRepoId takes a SubRepoPermissionChecker and repoID and returns true if sub-repo
+// SubRepoEnabledForRepoID takes a SubRepoPermissionChecker and repoID and returns true if sub-repo
 // permissions are enabled for a repo with given repoID
-func SubRepoEnabledForRepoId(ctx context.Context, checker SubRepoPermissionChecker, repoId api.RepoID) (bool, error) {
+func SubRepoEnabledForRepoID(ctx context.Context, checker SubRepoPermissionChecker, repoID api.RepoID) (bool, error) {
 	if !SubRepoEnabled(checker) {
 		return false, nil
 	}
-	return checker.EnabledForRepoId(ctx, repoId)
+	return checker.EnabledForRepoId(ctx, repoID)
 }
 
 // CanReadAllPaths returns true if the actor can read all paths.

--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -39,6 +39,9 @@ type SubRepoPermissionChecker interface {
 
 	// Enabled indicates whether sub-repo permissions are enabled.
 	Enabled() bool
+
+	// EnabledForRepoId indicates whether sub-repo permissions are enabled for the given repoID
+	EnabledForRepoId(ctx context.Context, repoId api.RepoID) (bool, error)
 }
 
 // DefaultSubRepoPermsChecker allows us to use a single instance with a shared
@@ -57,6 +60,10 @@ func (*noopPermsChecker) Enabled() bool {
 	return false
 }
 
+func (*noopPermsChecker) EnabledForRepoId(ctx context.Context, repoId api.RepoID) (bool, error) {
+	return false, nil
+}
+
 var _ SubRepoPermissionChecker = &SubRepoPermsClient{}
 
 // SubRepoPermissionsGetter allows getting sub repository permissions.
@@ -65,6 +72,9 @@ var _ SubRepoPermissionChecker = &SubRepoPermsClient{}
 type SubRepoPermissionsGetter interface {
 	// GetByUser returns the known sub repository permissions rules known for a user.
 	GetByUser(ctx context.Context, userID int32) (map[api.RepoName]SubRepoPermissions, error)
+
+	// RepoIdSupported returns true if repo with the given ID has sub-repo permissions
+	RepoIdSupported(ctx context.Context, repoId api.RepoID) (bool, error)
 }
 
 // SubRepoPermsClient is a concrete implementation of SubRepoPermissionChecker.
@@ -279,6 +289,10 @@ func (s *SubRepoPermsClient) Enabled() bool {
 	return false
 }
 
+func (s *SubRepoPermsClient) EnabledForRepoId(ctx context.Context, id api.RepoID) (bool, error) {
+	return s.permissionsGetter.RepoIdSupported(ctx, id)
+}
+
 // ActorPermissions returns the level of access the given actor has for the requested
 // content.
 //
@@ -307,6 +321,15 @@ func ActorPermissions(ctx context.Context, s SubRepoPermissionChecker, a *actor.
 // SubRepoEnabled takes a SubRepoPermissionChecker and returns true if the checker is not nil and is enabled
 func SubRepoEnabled(checker SubRepoPermissionChecker) bool {
 	return checker != nil && checker.Enabled()
+}
+
+// SubRepoEnabledForRepoId takes a SubRepoPermissionChecker and repoID and returns true if sub-repo
+// permissions are enabled for a repo with given repoID
+func SubRepoEnabledForRepoId(ctx context.Context, checker SubRepoPermissionChecker, repoId api.RepoID) (bool, error) {
+	if !SubRepoEnabled(checker) {
+		return false, nil
+	}
+	return checker.EnabledForRepoId(ctx, repoId)
 }
 
 // CanReadAllPaths returns true if the actor can read all paths.

--- a/internal/database/mocks.go
+++ b/internal/database/mocks.go
@@ -28975,6 +28975,9 @@ type MockSubRepoPermsStore struct {
 	// GetByUserFunc is an instance of a mock function object controlling
 	// the behavior of the method GetByUser.
 	GetByUserFunc *SubRepoPermsStoreGetByUserFunc
+	// RepoIdSupportedFunc is an instance of a mock function object
+	// controlling the behavior of the method RepoIdSupported.
+	RepoIdSupportedFunc *SubRepoPermsStoreRepoIdSupportedFunc
 	// TransactFunc is an instance of a mock function object controlling the
 	// behavior of the method Transact.
 	TransactFunc *SubRepoPermsStoreTransactFunc
@@ -29007,6 +29010,11 @@ func NewMockSubRepoPermsStore() *MockSubRepoPermsStore {
 		GetByUserFunc: &SubRepoPermsStoreGetByUserFunc{
 			defaultHook: func(context.Context, int32) (map[api.RepoName]authz.SubRepoPermissions, error) {
 				return nil, nil
+			},
+		},
+		RepoIdSupportedFunc: &SubRepoPermsStoreRepoIdSupportedFunc{
+			defaultHook: func(context.Context, api.RepoID) (bool, error) {
+				return false, nil
 			},
 		},
 		TransactFunc: &SubRepoPermsStoreTransactFunc{
@@ -29052,6 +29060,11 @@ func NewStrictMockSubRepoPermsStore() *MockSubRepoPermsStore {
 				panic("unexpected invocation of MockSubRepoPermsStore.GetByUser")
 			},
 		},
+		RepoIdSupportedFunc: &SubRepoPermsStoreRepoIdSupportedFunc{
+			defaultHook: func(context.Context, api.RepoID) (bool, error) {
+				panic("unexpected invocation of MockSubRepoPermsStore.RepoIdSupported")
+			},
+		},
 		TransactFunc: &SubRepoPermsStoreTransactFunc{
 			defaultHook: func(context.Context) (SubRepoPermsStore, error) {
 				panic("unexpected invocation of MockSubRepoPermsStore.Transact")
@@ -29088,6 +29101,9 @@ func NewMockSubRepoPermsStoreFrom(i SubRepoPermsStore) *MockSubRepoPermsStore {
 		},
 		GetByUserFunc: &SubRepoPermsStoreGetByUserFunc{
 			defaultHook: i.GetByUser,
+		},
+		RepoIdSupportedFunc: &SubRepoPermsStoreRepoIdSupportedFunc{
+			defaultHook: i.RepoIdSupported,
 		},
 		TransactFunc: &SubRepoPermsStoreTransactFunc{
 			defaultHook: i.Transact,
@@ -29425,6 +29441,118 @@ func (c SubRepoPermsStoreGetByUserFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c SubRepoPermsStoreGetByUserFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// SubRepoPermsStoreRepoIdSupportedFunc describes the behavior when the
+// RepoIdSupported method of the parent MockSubRepoPermsStore instance is
+// invoked.
+type SubRepoPermsStoreRepoIdSupportedFunc struct {
+	defaultHook func(context.Context, api.RepoID) (bool, error)
+	hooks       []func(context.Context, api.RepoID) (bool, error)
+	history     []SubRepoPermsStoreRepoIdSupportedFuncCall
+	mutex       sync.Mutex
+}
+
+// RepoIdSupported delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockSubRepoPermsStore) RepoIdSupported(v0 context.Context, v1 api.RepoID) (bool, error) {
+	r0, r1 := m.RepoIdSupportedFunc.nextHook()(v0, v1)
+	m.RepoIdSupportedFunc.appendCall(SubRepoPermsStoreRepoIdSupportedFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the RepoIdSupported
+// method of the parent MockSubRepoPermsStore instance is invoked and the
+// hook queue is empty.
+func (f *SubRepoPermsStoreRepoIdSupportedFunc) SetDefaultHook(hook func(context.Context, api.RepoID) (bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// RepoIdSupported method of the parent MockSubRepoPermsStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *SubRepoPermsStoreRepoIdSupportedFunc) PushHook(hook func(context.Context, api.RepoID) (bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *SubRepoPermsStoreRepoIdSupportedFunc) SetDefaultReturn(r0 bool, r1 error) {
+	f.SetDefaultHook(func(context.Context, api.RepoID) (bool, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *SubRepoPermsStoreRepoIdSupportedFunc) PushReturn(r0 bool, r1 error) {
+	f.PushHook(func(context.Context, api.RepoID) (bool, error) {
+		return r0, r1
+	})
+}
+
+func (f *SubRepoPermsStoreRepoIdSupportedFunc) nextHook() func(context.Context, api.RepoID) (bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *SubRepoPermsStoreRepoIdSupportedFunc) appendCall(r0 SubRepoPermsStoreRepoIdSupportedFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of SubRepoPermsStoreRepoIdSupportedFuncCall
+// objects describing the invocations of this function.
+func (f *SubRepoPermsStoreRepoIdSupportedFunc) History() []SubRepoPermsStoreRepoIdSupportedFuncCall {
+	f.mutex.Lock()
+	history := make([]SubRepoPermsStoreRepoIdSupportedFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// SubRepoPermsStoreRepoIdSupportedFuncCall is an object that describes an
+// invocation of method RepoIdSupported on an instance of
+// MockSubRepoPermsStore.
+type SubRepoPermsStoreRepoIdSupportedFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 api.RepoID
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 bool
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c SubRepoPermsStoreRepoIdSupportedFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c SubRepoPermsStoreRepoIdSupportedFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/database/sub_repo_perms_store_test.go
+++ b/internal/database/sub_repo_perms_store_test.go
@@ -212,6 +212,13 @@ func TestSubRepoPermsSupportedForRepoId(t *testing.T) {
 		t.Fatal("Repo is private, therefore sub-repo perms are supported")
 	}
 
+	exists, err = s.RepoIdSupported(ctx, api.RepoID(5))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Fatal("Repo is not perforce, therefore sub-repo perms are not supported")
+	}
 }
 
 func prepareSubRepoTestData(ctx context.Context, t *testing.T, db dbutil.DB) {
@@ -228,6 +235,7 @@ func prepareSubRepoTestData(ctx context.Context, t *testing.T, db dbutil.DB) {
 		`INSERT INTO repo(id, name, external_id, external_service_type, external_service_id) VALUES(2, 'github.com/foo/baz', 'MDEwOlJlcG9zaXRvcnk0MTI4ODcwOB==', 'github', 'https://github.com/')`,
 		`INSERT INTO repo(id, name, external_id, external_service_type, external_service_id) VALUES(3, 'perforce1', 'MDEwOlJlcG9zaXRvcnk0MTI4ODcwOB==', 'perforce', 'https://perforce.com/')`,
 		`INSERT INTO repo(id, name, external_id, external_service_type, external_service_id, private) VALUES(4, 'perforce2', 'MDEwOlJlcG9zaXRvcnk0MTI4ODcwOB==', 'perforce', 'https://perforce.com/2', 'true')`,
+		`INSERT INTO repo(id, name, external_id, external_service_type, external_service_id, private) VALUES(5, 'github.com/foo/qux', 'MDEwOlJlcG9zaXRvcnk0MTI4ODcwOC==', 'github', 'https://github.com/', 'true')`,
 
 		`INSERT INTO external_service_repos(repo_id, external_service_id, clone_url) VALUES(1, 1, 'cloneURL')`,
 		`INSERT INTO external_service_repos(repo_id, external_service_id, clone_url) VALUES(2, 1, 'cloneURL')`,

--- a/internal/database/sub_repo_perms_store_test.go
+++ b/internal/database/sub_repo_perms_store_test.go
@@ -184,6 +184,36 @@ func TestSubRepoPermsGetByUser(t *testing.T) {
 	}
 }
 
+func TestSubRepoPermsSupportedForRepoId(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
+	db := dbtest.NewDB(t)
+
+	ctx := context.Background()
+	s := SubRepoPerms(db)
+	prepareSubRepoTestData(ctx, t, db)
+
+	exists, err := s.RepoIdSupported(ctx, api.RepoID(3))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Fatal("Repo is not private, therefore sub-repo perms are not supported")
+	}
+
+	exists, err = s.RepoIdSupported(ctx, api.RepoID(4))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Fatal("Repo is private, therefore sub-repo perms are supported")
+	}
+
+}
+
 func prepareSubRepoTestData(ctx context.Context, t *testing.T, db dbutil.DB) {
 	t.Helper()
 
@@ -197,6 +227,7 @@ func prepareSubRepoTestData(ctx context.Context, t *testing.T, db dbutil.DB) {
 		`INSERT INTO repo(id, name, external_id, external_service_type, external_service_id) VALUES(1, 'github.com/foo/bar', 'MDEwOlJlcG9zaXRvcnk0MTI4ODcwOA==', 'github', 'https://github.com/')`,
 		`INSERT INTO repo(id, name, external_id, external_service_type, external_service_id) VALUES(2, 'github.com/foo/baz', 'MDEwOlJlcG9zaXRvcnk0MTI4ODcwOB==', 'github', 'https://github.com/')`,
 		`INSERT INTO repo(id, name, external_id, external_service_type, external_service_id) VALUES(3, 'perforce1', 'MDEwOlJlcG9zaXRvcnk0MTI4ODcwOB==', 'perforce', 'https://perforce.com/')`,
+		`INSERT INTO repo(id, name, external_id, external_service_type, external_service_id, private) VALUES(4, 'perforce2', 'MDEwOlJlcG9zaXRvcnk0MTI4ODcwOB==', 'perforce', 'https://perforce.com/2', 'true')`,
 
 		`INSERT INTO external_service_repos(repo_id, external_service_id, clone_url) VALUES(1, 1, 'cloneURL')`,
 		`INSERT INTO external_service_repos(repo_id, external_service_id, clone_url) VALUES(2, 1, 'cloneURL')`,


### PR DESCRIPTION
As an initial implementation, sub-repo permissions are checked for every repo in search results of code insights search query. No caching (per repoID) is happening currently.

If repo supports sub-repo permissions, then search result related to this repo is excluded and the data point of this repo is dropped

Closes https://github.com/sourcegraph/sourcegraph/issues/27490

## Test plan
I wrote unit tests for code-insights worker layer and database layer.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


