### PR TITLE
Сode Insights: Fix GQL insight create mutations

### DIFF
--- a/client/web/src/enterprise/insights/core/backend/gql-api/methods/create-insight/create-insight.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-api/methods/create-insight/create-insight.ts
@@ -153,6 +153,7 @@ function searchInsightCreationOptimisticUpdate(
     const cachedInsight = cache.readFragment<InsightViewNode>({
         id: createdInsightId,
         fragment: INSIGHT_VIEW_FRAGMENT,
+        fragmentName: 'InsightViewNode',
     })
 
     if (dashboard && !isVirtualDashboard(dashboard)) {

--- a/client/web/src/enterprise/insights/core/types/insight/capture-group-insight.ts
+++ b/client/web/src/enterprise/insights/core/types/insight/capture-group-insight.ts
@@ -21,5 +21,5 @@ export interface CaptureGroupInsight extends SyntheticInsightFields {
      */
     repositories: string[]
     step: Duration
-    filters: InsightFilters
+    filters?: InsightFilters
 }

--- a/client/web/src/enterprise/insights/core/types/insight/search-insight.ts
+++ b/client/web/src/enterprise/insights/core/types/insight/search-insight.ts
@@ -40,7 +40,6 @@ export interface SearchBackendBasedInsight extends SearchBasedBackendInsightSett
     viewType: InsightType.SearchBased
     series: SearchBasedInsightSeries[]
     step: Duration
-    filters: SearchBasedBackendFilters
 }
 
 /**

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/utils/insight-sanitizer.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/utils/insight-sanitizer.ts
@@ -42,15 +42,14 @@ export function getSanitizedSearchInsight(rawInsight: CreateInsightFormFields): 
             series: getSanitizedSeries(rawInsight.series),
             visibility: rawInsight.visibility,
             step: { [rawInsight.step]: +rawInsight.stepValue },
-            filters: { includeRepoRegexp: '', excludeRepoRegexp: '' },
             dashboardReferenceCount: rawInsight.dashboardReferenceCount,
         }
     }
 
     return {
-        id: `${InsightTypePrefix.search}.${camelCase(rawInsight.title)}`,
         // ID generated according to our naming insight convention
         // <Type of insight>.insight.<name of insight>
+        id: `${InsightTypePrefix.search}.${camelCase(rawInsight.title)}`,
         type: InsightExecutionType.Runtime,
         viewType: InsightType.SearchBased,
         visibility: rawInsight.visibility,


### PR DESCRIPTION

## Context 

Because for the creation UI we're using optimistic update logic where we call `readFragment` method. When a fragment has another nested fragment we have to specify the main fragment name (the root one) for the Apollo cache. Otherwise Apollo throughs an error about this problem. 

![](https://files.slack.com/files-pri/T02FSM7DL-F032KAXS92R/image.png)

Also in this PR, I changed main insight interfaces and mark filters as optional because in the creation UI we don't deal with filters and we don't have it. But prior to this PR insight interfaces always required filters object. Which led to the complex insight creation flow. At the moment our GQL creation mutation doesn't support filters input and in case we need to create insight with pre-defined filters (like creation insight through the drill-down panel) we have to make two network requests (1. create insight mutation, 2. update filters in the newly created insight)

[Relate codebase link](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/blob/client/web/src/enterprise/insights/core/backend/gql-api/methods/create-insight/create-insight.ts?L73&utm_product_name=WebStorm&utm_product_version=WebStorm&utm_source=JetBrains-v1.2.2)

Well because interfaces always required these filters we used complex flow for the just insight creation. In this PR since filters isn't a required field anymore we could run just create insight mutation and don't care about filters flow anymore (we still care about this for the drill-down creation flow)