### PR TITLE
Overhaul DefaultIDSetMap's implementation and API

### DIFF
--- a/lib/codeintel/lsif/conversion/canonicalize.go
+++ b/lib/codeintel/lsif/conversion/canonicalize.go
@@ -99,7 +99,7 @@ func canonicalizeReferenceResults(state *State) {
 
 			// Copy data from the referenced to the referencing set
 			state.ReferenceData[nextID].Each(func(documentID int, rangeIDs *datastructures.IDSet) {
-				state.ReferenceData[id].SetUnion(documentID, rangeIDs)
+				state.ReferenceData[id].UnionIDSet(documentID, rangeIDs)
 			})
 		}
 	}
@@ -118,7 +118,7 @@ func canonicalizeResultSets(state *State) {
 	}
 
 	for resultSetID := range state.ResultSetData {
-		state.Monikers.SetUnion(resultSetID, gatherMonikers(state, state.Monikers.Get(resultSetID)))
+		state.Monikers.UnionIDSet(resultSetID, gatherMonikers(state, state.Monikers.Get(resultSetID)))
 	}
 }
 
@@ -138,7 +138,7 @@ func canonicalizeRanges(state *State) {
 		}
 
 		state.RangeData[rangeID] = rangeData
-		state.Monikers.SetUnion(rangeID, gatherMonikers(state, state.Monikers.Get(rangeID)))
+		state.Monikers.UnionIDSet(rangeID, gatherMonikers(state, state.Monikers.Get(rangeID)))
 	}
 }
 
@@ -179,7 +179,7 @@ func mergeNextResultSetData(state *State, itemID int, item ResultSet, nextID int
 		item = item.SetDocumentationResultID(nextItem.DocumentationResultID)
 	}
 
-	state.Monikers.SetUnion(itemID, state.Monikers.Get(nextID))
+	state.Monikers.UnionIDSet(itemID, state.Monikers.Get(nextID))
 	return item
 }
 
@@ -203,7 +203,7 @@ func mergeNextRangeData(state *State, itemID int, item Range, nextID int, nextIt
 		item = item.SetDocumentationResultID(nextItem.DocumentationResultID)
 	}
 
-	state.Monikers.SetUnion(itemID, state.Monikers.Get(nextID))
+	state.Monikers.UnionIDSet(itemID, state.Monikers.Get(nextID))
 	return item
 }
 

--- a/lib/codeintel/lsif/conversion/canonicalize.go
+++ b/lib/codeintel/lsif/conversion/canonicalize.go
@@ -51,8 +51,8 @@ func canonicalizeDocuments(state *State) {
 
 	for documentID, canonicalID := range canonicalIDs {
 		// Move ranges and diagnostics into the canonical document
-		state.Contains.SetUnion(canonicalID, state.Contains.Get(documentID))
-		state.Diagnostics.SetUnion(canonicalID, state.Diagnostics.Get(documentID))
+		state.Contains.UnionIDSet(canonicalID, state.Contains.Get(documentID))
+		state.Diagnostics.UnionIDSet(canonicalID, state.Diagnostics.Get(documentID))
 
 		// Remove non-canonical documents
 		delete(state.DocumentData, documentID)
@@ -70,7 +70,7 @@ func canonicalizeDocumentsInDefinitionReferences(state *State, definitionReferen
 			// Remove references to non-canonical document...
 			if rangeIDs := documentRanges.Pop(documentID); rangeIDs != nil {
 				// ...and move existing definition/reference data into the canonical document
-				documentRanges.SetUnion(canonicalID, rangeIDs)
+				documentRanges.UnionIDSet(canonicalID, rangeIDs)
 			}
 		}
 	}

--- a/lib/codeintel/lsif/conversion/correlate.go
+++ b/lib/codeintel/lsif/conversion/correlate.go
@@ -374,7 +374,7 @@ func correlateContainsEdge(state *wrappedState, id int, edge Edge) error {
 		if _, ok := state.RangeData[inV]; !ok {
 			return malformedDump(id, inV, "range")
 		}
-		state.Contains.SetAdd(edge.OutV, inV)
+		state.Contains.AddID(edge.OutV, inV)
 	}
 	return nil
 }
@@ -406,7 +406,7 @@ func correlateItemEdge(state *wrappedState, id int, edge Edge) error {
 			}
 
 			// Link definition data to defining range
-			documentMap.SetAdd(edge.Document, inV)
+			documentMap.AddID(edge.Document, inV)
 		}
 
 		return nil
@@ -423,7 +423,7 @@ func correlateItemEdge(state *wrappedState, id int, edge Edge) error {
 				}
 
 				// Link reference data to a reference range
-				documentMap.SetAdd(edge.Document, inV)
+				documentMap.AddID(edge.Document, inV)
 			}
 		}
 
@@ -437,7 +437,7 @@ func correlateItemEdge(state *wrappedState, id int, edge Edge) error {
 			}
 
 			// Link definition data to defining range
-			documentMap.SetAdd(edge.Document, inV)
+			documentMap.AddID(edge.Document, inV)
 		}
 
 		return nil
@@ -517,9 +517,9 @@ func correlateMonikerEdge(state *wrappedState, id int, edge Edge) error {
 	}
 
 	if _, ok := state.RangeData[edge.OutV]; ok {
-		state.Monikers.SetAdd(edge.OutV, edge.InV)
+		state.Monikers.AddID(edge.OutV, edge.InV)
 	} else if _, ok := state.ResultSetData[edge.OutV]; ok {
-		state.Monikers.SetAdd(edge.OutV, edge.InV)
+		state.Monikers.AddID(edge.OutV, edge.InV)
 	} else {
 		return malformedDump(id, edge.OutV, "range", "resultSet")
 	}
@@ -573,6 +573,6 @@ func correlateDiagnosticEdge(state *wrappedState, id int, edge Edge) error {
 		return malformedDump(id, edge.InV, "diagnosticResult")
 	}
 
-	state.Diagnostics.SetAdd(edge.OutV, edge.InV)
+	state.Diagnostics.AddID(edge.OutV, edge.InV)
 	return nil
 }

--- a/lib/codeintel/lsif/conversion/datastructures/default_idset_map.go
+++ b/lib/codeintel/lsif/conversion/datastructures/default_idset_map.go
@@ -1,25 +1,33 @@
 package datastructures
 
-// DefaultIDSetMap is a space-efficient map from integer keys to identifier sets. This
-// map adds convenience operations that will operate on the set at a specific key, and
-// create it if it does not yet exist in the map.
+const (
+	// random sentinel key to identify runtime errors
+	uninit_sentinel_key = -0xc0c0
+)
+
+// DefaultIDSetMap is a small-size-optimized map from integer keys to identifier sets.
+// It adds convenience operations that operate on the set for a specific key.
 //
 // The correlation process creates many such maps (e.g. result set and contains relations),
-// the majority of which contain only a single element. This structure optimizes for the
-// case where only a single key is present in the map.
+// the majority of which contain only a single element. Since Go maps have high overhead
+// (see https://golang.org/src/runtime/map.go#L115), we optimize for the common case.
 //
 // For concrete numbers, processing an index for aws-sdk-go produces 1.5 million singleton
 // maps, and only 25k non-singleton maps.
 //
-// Each map starts out empty. Insertion of the first element sets a key and value field
-// directly in the map struct. Insertion of a second element will promote the struct into
-// a non-singleton map and heap-allocate a builtin map to hold additional keys. Maps have
-// large overhead (see https://golang.org/src/runtime/map.go#L115), so we only want to pay
-// this cost when we need to.
+// The map is conceptually in one of three states:
+// - Empty: This is the initial state.
+// - Inline: This contains an inline element.
+// - Heap: This contains key-value pairs in a Go map.
+//
+// The state of the map may change:
+// - On additions: Empty → Inline or Inline → Heap.
+// - On deletions: Inline → Empty or Heap → Inline.
 type DefaultIDSetMap struct {
-	key   int            // singleton map key
-	value *IDSet         // singleton map value
-	m     map[int]*IDSet // non-singleton map
+	len         int            // number of keys
+	inlineKey   int            // key for the Inline state
+	inlineValue *IDSet         // value for the Inline state
+	m           map[int]*IDSet // storage for 2 or more key-value pairs
 }
 
 // NewDefaultIDSetMap creates a new empty default identifier set map.
@@ -28,19 +36,46 @@ func NewDefaultIDSetMap() *DefaultIDSetMap {
 }
 
 // DefaultIDSetMapWith creates a default identifier set map with the given contents.
+//
+// The supplied map is not used directly if it has length 0 or 1.
 func DefaultIDSetMapWith(m map[int]*IDSet) *DefaultIDSetMap {
-	return &DefaultIDSetMap{m: m}
+	switch len(m) {
+	case 0:
+		return NewDefaultIDSetMap()
+	case 1:
+		tmp := NewDefaultIDSetMap()
+		for k, v := range m {
+			tmp.inlineKey = k
+			tmp.inlineValue = v
+		}
+		tmp.len = 1
+		return tmp
+	default:
+		return &DefaultIDSetMap{len: len(m), m: m}
+	}
+}
+
+// Len returns the number of keys.
+func (sm *DefaultIDSetMap) Len() int {
+	if sm == nil {
+		return 0
+	}
+	return sm.len
 }
 
 // Get returns the identifier set at the given key or nil if it does not exist.
 func (sm *DefaultIDSetMap) Get(key int) *IDSet {
-	if sm.key == key {
-		return sm.value
-	}
-	if sm.m != nil {
+	switch sm.Len() {
+	case 0:
+		return nil
+	case 1:
+		if sm.inlineKey == key {
+			return sm.inlineValue
+		}
+		return nil
+	default:
 		return sm.m[key]
 	}
-	return nil
 }
 
 // Pop returns the identifier set at the given key or nil if it does not exist and
@@ -64,75 +99,103 @@ func (sm *DefaultIDSetMap) Pop(key int) *IDSet {
 
 // Delete removes the identifier set at the given key if it exists.
 func (sm *DefaultIDSetMap) Delete(key int) {
-	if sm.key == key {
-		sm.key = 0
-		sm.value = nil
-	}
-	if sm.m != nil {
+	switch sm.Len() {
+	case 0:
+		return
+	case 1:
+		if sm.inlineKey == key {
+			sm.inlineKey = uninit_sentinel_key
+			sm.inlineValue = nil
+			sm.len = 0
+		}
+	default:
+		if _, ok := sm.m[key]; ok {
+			sm.len--
+		}
 		delete(sm.m, key)
+		if sm.len == 1 {
+			for k, v := range sm.m {
+				sm.inlineKey = k
+				sm.inlineValue = v
+			}
+			sm.m = nil
+		}
 	}
 }
 
 // Each invokes the given function with each key and identifier set in the map.
+//
+// The order of iteration is not guaranteed to be deterministic.
 func (sm *DefaultIDSetMap) Each(f func(key int, value *IDSet)) {
-	if sm.key != 0 {
-		f(sm.key, sm.value)
-	}
-	if sm.m != nil {
+	switch sm.len {
+	case 0:
+		return
+	case 1:
+		f(sm.inlineKey, sm.inlineValue)
+	default:
 		for k, v := range sm.m {
 			f(k, v)
 		}
 	}
 }
 
-// SetLen returns the number of identifiers in the identifier set at the given key.
-func (sm *DefaultIDSetMap) SetLen(key int) int {
-	if sm.key == key {
-		return sm.value.Len()
-	}
-	if sm.m != nil {
+// NumIDsForKey returns the number of identifiers in the identifier set at the given key.
+func (sm *DefaultIDSetMap) NumIDsForKey(key int) int {
+	switch sm.len {
+	case 0:
+		return 0
+	case 1:
+		if sm.inlineKey == key {
+			return sm.inlineValue.Len()
+		}
+	default:
 		if s, ok := sm.m[key]; ok {
 			return s.Len()
 		}
 	}
-
 	return 0
 }
 
-// SetContains determines if the given identifier belongs to the set at the given key.
-func (sm *DefaultIDSetMap) SetContains(key, id int) bool {
-	if sm.key == key {
-		return sm.value.Contains(id)
-	}
-	if sm.m != nil {
+// Contains determines if the given identifier belongs to the set at the given key.
+func (sm *DefaultIDSetMap) Contains(key, id int) bool {
+	switch sm.len {
+	case 0:
+		return false
+	case 1:
+		return sm.inlineKey == key && sm.inlineValue.Contains(id)
+	default:
 		if s, ok := sm.m[key]; ok {
 			return s.Contains(id)
 		}
 	}
-
 	return false
 }
 
-// SetEach invokes the given function with each identifier in the set at the given key.
-func (sm *DefaultIDSetMap) SetEach(key int, f func(id int)) {
-	if sm.key == key {
-		sm.value.Each(f)
+// EachID invokes the given function with each identifier in the set at the given key.
+//
+// The order of iteration is not guaranteed to be deterministic.
+func (sm *DefaultIDSetMap) EachID(key int, f func(id int)) {
+	switch sm.len {
+	case 0:
 		return
-	}
-	if sm.m != nil {
+	case 1:
+		if sm.inlineKey == key {
+			sm.inlineValue.Each(f)
+		}
+	default:
 		if s, ok := sm.m[key]; ok {
 			s.Each(f)
 		}
 	}
 }
 
-// SetAdd inserts an identifier into the set at the given key.
-func (sm *DefaultIDSetMap) SetAdd(key, id int) {
+// AddID inserts an identifier into the set at the given key.
+func (sm *DefaultIDSetMap) AddID(key, id int) {
 	sm.getOrCreate(key).Add(id)
 }
 
-// SetUnion inserts all the identifiers of other into the set a the given key.
-func (sm *DefaultIDSetMap) SetUnion(key int, other *IDSet) {
+// UnionIDSet inserts all the identifiers of other into the set a the given key.
+func (sm *DefaultIDSetMap) UnionIDSet(key int, other *IDSet) {
 	if other == nil || other.Len() == 0 {
 		return
 	}
@@ -140,41 +203,35 @@ func (sm *DefaultIDSetMap) SetUnion(key int, other *IDSet) {
 	sm.getOrCreate(key).Union(other)
 }
 
-// GetOrCreate will return the set at the given key, or create an empty set if it does not exist.
+// getOrCreate will return the set at the given inlineKey, or create an empty set if it does not exist.
+//
+// The return value is never nil.
 func (sm *DefaultIDSetMap) getOrCreate(key int) *IDSet {
-	if sm.key == key {
-		return sm.value
-	}
-	if sm.m != nil {
+	switch sm.len {
+	case 0:
+		sm.inlineKey = key
+		sm.inlineValue = NewIDSet()
+		sm.len = 1
+		return sm.inlineValue
+	case 1:
+		if sm.inlineKey == key {
+			return sm.inlineValue
+		}
+		newValue := NewIDSet()
+		sm.m = map[int]*IDSet{sm.inlineKey: sm.inlineValue, key: newValue}
+		sm.len = 2
+		sm.inlineValue = nil
+		sm.inlineKey = uninit_sentinel_key
+		return newValue
+	default:
 		if s, ok := sm.m[key]; ok {
 			return s
 		}
+		newValue := NewIDSet()
+		sm.m[key] = newValue
+		sm.len++
+		return newValue
 	}
-
-	if sm.m != nil {
-		// Already a map, just add a new key
-		s := NewIDSet()
-		sm.m[key] = s
-		return s
-	}
-
-	if sm.key == 0 {
-		// Populating a singleton set
-		s := NewIDSet()
-		sm.key = key
-		sm.value = s
-		return s
-	}
-
-	// Adding to a singleton set. Create a new map and add the
-	// new value along with the old singleton value to the it
-	s := NewIDSet()
-	sm.m = make(map[int]*IDSet, 2)
-	sm.m[key] = s
-	sm.m[sm.key] = sm.value
-	sm.key = 0
-	sm.value = nil
-	return s
 }
 
 // compareDefaultIDSetMaps returns true if the given identifier default identifier set maps
@@ -184,16 +241,12 @@ func compareDefaultIDSetMaps(x, y *DefaultIDSetMap) bool {
 		return true
 	}
 
-	if x == nil || y == nil {
+	if x.len != y.len {
 		return false
 	}
 
 	m1 := toMap(x)
 	m2 := toMap(y)
-
-	if len(m1) != len(m2) {
-		return false
-	}
 
 	for k, v := range m1 {
 		if !compareIDSets(v, m2[k]) {
@@ -207,19 +260,16 @@ func compareDefaultIDSetMaps(x, y *DefaultIDSetMap) bool {
 // toMap returns a copy of the map backing the default identifier set map. This is called from
 // compareDefaultIDSetMaps for testing and should not be used in the hot path.
 func toMap(s *DefaultIDSetMap) map[int]*IDSet {
-	if s.key != 0 {
-		return map[int]*IDSet{
-			s.key: s.value,
-		}
-	}
-
-	if s.m != nil {
+	switch s.len {
+	case 0:
+		return nil
+	case 1:
+		return map[int]*IDSet{s.inlineKey: s.inlineValue}
+	default:
 		m := map[int]*IDSet{}
 		for k, v := range s.m {
 			m[k] = v
 		}
 		return m
 	}
-
-	return nil
 }

--- a/lib/codeintel/lsif/conversion/datastructures/default_idset_map.go
+++ b/lib/codeintel/lsif/conversion/datastructures/default_idset_map.go
@@ -1,7 +1,9 @@
 package datastructures
 
+type mapState int
+
 const (
-	mapStateEmpty = iota
+	mapStateEmpty mapState = iota
 	mapStateInline
 	mapStateHeap
 	ILLEGAL_MAPSTATE = "invariant violation: illegal map state!"
@@ -38,7 +40,7 @@ func NewDefaultIDSetMap() *DefaultIDSetMap {
 	return &DefaultIDSetMap{}
 }
 
-func (sm *DefaultIDSetMap) state() uint8 {
+func (sm *DefaultIDSetMap) state() mapState {
 	if sm.inlineValue == nil {
 		if sm.m == nil {
 			return mapStateEmpty

--- a/lib/codeintel/lsif/conversion/datastructures/default_idset_map_test.go
+++ b/lib/codeintel/lsif/conversion/datastructures/default_idset_map_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TODO: Add some fuzz tests when we move to Go 1.18.
+
 func TestDefaultIDSetMapAdd(t *testing.T) {
 	for _, numUnrelatedKeys := range []int{0, 1, 16} {
 		for _, max := range []int{SmallSetThreshold / 2, SmallSetThreshold, SmallSetThreshold * 16} {
@@ -16,21 +18,21 @@ func TestDefaultIDSetMapAdd(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				m := NewDefaultIDSetMap()
 				for i := 0; i < numUnrelatedKeys; i++ {
-					m.SetAdd(1000+i, 42)
+					m.AddID(1000+i, 42)
 				}
 
 				for i := 1; i <= max; i++ {
-					m.SetAdd(50, i)
+					m.AddID(50, i)
 				}
 
-				if m.SetLen(50) != max {
-					t.Errorf("unexpected length. want=%d have=%d", max, m.SetLen(50))
+				if m.NumIDsForKey(50) != max {
+					t.Errorf("unexpected length. want=%d have=%d", max, m.NumIDsForKey(50))
 					return
 				}
 
 				for i := 1; i <= max; i++ {
-					if !m.SetContains(50, i) {
-						t.Errorf("unexpected contains. want=%v have=%v", true, m.SetContains(50, i))
+					if !m.Contains(50, i) {
+						t.Errorf("unexpected contains. want=%v have=%v", true, m.Contains(50, i))
 					}
 				}
 			})
@@ -46,29 +48,29 @@ func TestDefaultIDSetMapUnion(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				m := NewDefaultIDSetMap()
 				for i := 0; i < numUnrelatedKeys; i++ {
-					m.SetAdd(1000+i, 42)
+					m.AddID(1000+i, 42)
 				}
 
 				for i := 1; i <= max; i++ {
 					if i%2 == 0 {
-						m.SetAdd(50, i)
+						m.AddID(50, i)
 					}
 					if i%3 == 0 {
-						m.SetAdd(51, i)
+						m.AddID(51, i)
 					}
 				}
 
-				m.SetUnion(50, m.Get(51))
+				m.UnionIDSet(50, m.Get(51))
 
-				if m.SetLen(50) != (max/2)+(max/3)-(max/6) {
-					t.Errorf("unexpected length. want=%d have=%d", (max/2)+(max/3)-(max/6), m.SetLen(50))
+				if m.NumIDsForKey(50) != (max/2)+(max/3)-(max/6) {
+					t.Errorf("unexpected length. want=%d have=%d", (max/2)+(max/3)-(max/6), m.NumIDsForKey(50))
 				}
 
 				for i := 1; i <= max/2; i++ {
 					expected := (i%2 == 0) || (i%3 == 0)
 
-					if m.SetContains(50, i) != expected {
-						t.Errorf("unexpected contains. want=%v have=%v", expected, m.SetContains(50, i))
+					if m.Contains(50, i) != expected {
+						t.Errorf("unexpected contains. want=%v have=%v", expected, m.Contains(50, i))
 					}
 				}
 			})
@@ -80,10 +82,10 @@ func TestDefaultIDSetMapDelete(t *testing.T) {
 	for _, unrelatedKey := range []int{0, 1, 16} {
 		m := NewDefaultIDSetMap()
 		for i := 0; i < unrelatedKey; i++ {
-			m.SetAdd(1000+i, 42)
+			m.AddID(1000+i, 42)
 		}
 
-		m.SetAdd(50, 51)
+		m.AddID(50, 51)
 		m.Delete(50)
 
 		if v := m.Get(50); v != nil {
@@ -94,11 +96,11 @@ func TestDefaultIDSetMapDelete(t *testing.T) {
 
 func TestDefaultIDSetMapMultipleValues(t *testing.T) {
 	m := NewDefaultIDSetMap()
-	m.SetAdd(50, 51)
-	m.SetAdd(50, 52)
-	m.SetAdd(51, 53)
-	m.SetAdd(51, 54)
-	m.SetAdd(52, 55)
+	m.AddID(50, 51)
+	m.AddID(50, 52)
+	m.AddID(51, 53)
+	m.AddID(51, 54)
+	m.AddID(52, 55)
 
 	for value, expectedSet := range map[int]*IDSet{
 		50: IDSetWith(51, 52),
@@ -120,7 +122,7 @@ func TestDefaultIDSetMapMultipleValues(t *testing.T) {
 
 func TestDefaultIDSetMap_Each(t *testing.T) {
 	sm := NewDefaultIDSetMap()
-	sm.SetAdd(0, 1)
+	sm.AddID(0, 1)
 	counter := 0
 	sm.Each(func(_ int, _ *IDSet) {
 		counter++
@@ -128,42 +130,42 @@ func TestDefaultIDSetMap_Each(t *testing.T) {
 	require.Equal(t, counter, 1)
 }
 
-func TestDefaultIDSetMap_SetLen(t *testing.T) {
+func TestDefaultIDSetMap_NumValuesForKey(t *testing.T) {
 	sm := NewDefaultIDSetMap()
 	require.NotPanics(t, func() {
-		sm.SetLen(0)
+		sm.NumIDsForKey(0)
 	})
 }
 
-func TestDefaultIDSetMap_SetContains(t *testing.T) {
+func TestDefaultIDSetMap_Contains(t *testing.T) {
 	sm := NewDefaultIDSetMap()
 	require.NotPanics(t, func() {
-		_ = sm.SetContains(0, 1)
+		_ = sm.Contains(0, 1)
 	})
 }
 
-func TestDefaultIDSetMap_SetEach(t *testing.T) {
+func TestDefaultIDSetMap_EachID(t *testing.T) {
 	sm := NewDefaultIDSetMap()
 	num := 30
 	require.NotPanics(t,
-		func() { sm.SetEach(0, func(_ int) { num++ }) },
+		func() { sm.EachID(0, func(_ int) { num++ }) },
 	)
 	require.Equal(t, 30, num)
 }
 
-func TestDefaultIDSetMap_SetAdd(t *testing.T) {
+func TestDefaultIDSetMap_AddID(t *testing.T) {
 	sm := NewDefaultIDSetMap()
 	require.NotPanics(t, func() {
-		sm.SetAdd(0, 22)
+		sm.AddID(0, 22)
 	})
 }
 
-func TestDefaultIDSetMap_SetUnion(t *testing.T) {
+func TestDefaultIDSetMap_UnionIDSet(t *testing.T) {
 	sm := NewDefaultIDSetMap()
 	idSet := NewIDSet()
 	idSet.Add(3)
 	require.NotPanics(t, func() {
-		sm.SetUnion(0, idSet)
+		sm.UnionIDSet(0, idSet)
 	})
 }
 

--- a/lib/codeintel/lsif/conversion/datastructures/default_idset_map_test.go
+++ b/lib/codeintel/lsif/conversion/datastructures/default_idset_map_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDefaultIDSetMapAdd(t *testing.T) {
@@ -113,4 +114,60 @@ func TestDefaultIDSetMapMultipleValues(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Regression tests
+
+func TestDefaultIDSetMap_Each(t *testing.T) {
+	sm := NewDefaultIDSetMap()
+	sm.SetAdd(0, 1)
+	counter := 0
+	sm.Each(func(_ int, _ *IDSet) {
+		counter++
+	})
+	require.Equal(t, counter, 1)
+}
+
+func TestDefaultIDSetMap_SetLen(t *testing.T) {
+	sm := NewDefaultIDSetMap()
+	require.NotPanics(t, func() {
+		sm.SetLen(0)
+	})
+}
+
+func TestDefaultIDSetMap_SetContains(t *testing.T) {
+	sm := NewDefaultIDSetMap()
+	require.NotPanics(t, func() {
+		_ = sm.SetContains(0, 1)
+	})
+}
+
+func TestDefaultIDSetMap_SetEach(t *testing.T) {
+	sm := NewDefaultIDSetMap()
+	num := 30
+	require.NotPanics(t,
+		func() { sm.SetEach(0, func(_ int) { num++ }) },
+	)
+	require.Equal(t, 30, num)
+}
+
+func TestDefaultIDSetMap_SetAdd(t *testing.T) {
+	sm := NewDefaultIDSetMap()
+	require.NotPanics(t, func() {
+		sm.SetAdd(0, 22)
+	})
+}
+
+func TestDefaultIDSetMap_SetUnion(t *testing.T) {
+	sm := NewDefaultIDSetMap()
+	idSet := NewIDSet()
+	idSet.Add(3)
+	require.NotPanics(t, func() {
+		sm.SetUnion(0, idSet)
+	})
+}
+
+func TestDefaultIDSetMap_getOrCreate(t *testing.T) {
+	sm := NewDefaultIDSetMap()
+	require.NotNil(t, sm.getOrCreate(0))
 }

--- a/lib/codeintel/lsif/conversion/datastructures/disjoint_idset.go
+++ b/lib/codeintel/lsif/conversion/datastructures/disjoint_idset.go
@@ -26,8 +26,8 @@ func DisjointIDSetWith(pairs ...int) *DisjointIDSet {
 // Link composes the connected components containing the given identifiers. If one or
 // the other value is already in the set, then the sets of the two values will merge.
 func (sm *DisjointIDSet) Link(id1, id2 int) {
-	sm.SetAdd(id1, id2)
-	sm.SetAdd(id2, id1)
+	sm.AddID(id1, id2)
+	sm.AddID(id2, id1)
 }
 
 // ExtractSet returns a set of all values reachable from the given source value. The

--- a/lib/codeintel/lsif/conversion/group.go
+++ b/lib/codeintel/lsif/conversion/group.go
@@ -83,18 +83,18 @@ func serializeBundleDocuments(ctx context.Context, state *State) chan precise.Ke
 
 func serializeDocument(state *State, documentID int) precise.DocumentData {
 	document := precise.DocumentData{
-		Ranges:             make(map[precise.ID]precise.RangeData, state.Contains.SetLen(documentID)),
+		Ranges:             make(map[precise.ID]precise.RangeData, state.Contains.NumIDsForKey(documentID)),
 		HoverResults:       map[precise.ID]string{},
 		Monikers:           map[precise.ID]precise.MonikerData{},
 		PackageInformation: map[precise.ID]precise.PackageInformationData{},
-		Diagnostics:        make([]precise.DiagnosticData, 0, state.Diagnostics.SetLen(documentID)),
+		Diagnostics:        make([]precise.DiagnosticData, 0, state.Diagnostics.NumIDsForKey(documentID)),
 	}
 
-	state.Contains.SetEach(documentID, func(rangeID int) {
+	state.Contains.EachID(documentID, func(rangeID int) {
 		rangeData := state.RangeData[rangeID]
 
-		monikerIDs := make([]precise.ID, 0, state.Monikers.SetLen(rangeID))
-		state.Monikers.SetEach(rangeID, func(monikerID int) {
+		monikerIDs := make([]precise.ID, 0, state.Monikers.NumIDsForKey(rangeID))
+		state.Monikers.EachID(rangeID, func(monikerID int) {
 			moniker := state.MonikerData[monikerID]
 			monikerIDs = append(monikerIDs, toID(monikerID))
 
@@ -133,7 +133,7 @@ func serializeDocument(state *State, documentID int) precise.DocumentData {
 		}
 	})
 
-	state.Diagnostics.SetEach(documentID, func(diagnosticID int) {
+	state.Diagnostics.EachID(documentID, func(diagnosticID int) {
 		for _, diagnostic := range state.DiagnosticResults[diagnosticID] {
 			document.Diagnostics = append(document.Diagnostics, precise.DiagnosticData{
 				Severity:       diagnostic.Severity,
@@ -265,7 +265,7 @@ func gatherMonikersLocations(ctx context.Context, state *State, data map[int]*da
 	monikers := datastructures.NewDefaultIDSetMap()
 	for rangeID, r := range state.RangeData {
 		if resultID := getResultID(r); resultID != 0 {
-			monikers.SetUnion(resultID, state.Monikers.Get(rangeID))
+			monikers.UnionIDSet(resultID, state.Monikers.Get(rangeID))
 		}
 	}
 


### PR DESCRIPTION
Related GitHub discussion: https://github.com/sourcegraph/sourcegraph/pull/30978#issuecomment-1035950484
Slack discussion: https://sourcegraph.slack.com/archives/CHXHX7XAS/p1644561669822999

Specifically, when implementing Chris's suggestion on top of [Eric's PR](https://github.com/sourcegraph/sourcegraph/pull/30978): (see patch) and uploading the LSIF dump for the `client/web` directory, I get a crash in `SetUnion`: it ends up calling `getOrCreate(0)` which returns `nil` (this happens for an empty `DefaultIDSetMap`), which crashes on the call to `Union` inside `SetUnion` (since `Union` expects a non-nil receiver).

I've changed the method names as well because I found the `Set` prefix quite confusing; it's hard to not read it as the verb "set", since method names often follow the verb + noun pattern.  So `SetLen` reads like a setter for `Len` (which is not what it actually means).

## Test plan

- Added regression tests for the various edge cases.

## Patch

<details>

```
diff --git a/lib/codeintel/lsif/conversion/canonicalize.go b/lib/codeintel/lsif/conversion/canonicalize.go
index 362ae9e618..303f4a6455 100644
--- a/lib/codeintel/lsif/conversion/canonicalize.go
+++ b/lib/codeintel/lsif/conversion/canonicalize.go
@@ -68,6 +68,16 @@ func canonicalizeDocumentsInDefinitionReferences(state *State, definitionReferen
 	for _, documentRanges := range definitionReferenceData {
-		for documentID, canonicalID := range canonicalIDs {
-			// Remove references to non-canonical document...
-			if rangeIDs := documentRanges.Pop(documentID); rangeIDs != nil {
-				// ...and move existing definition/reference data into the canonical document
+		if documentRanges.ApproxLen() >= len(canonicalIDs) {
+			for documentID, canonicalID := range canonicalIDs {
+				// Remove references to non-canonical document...
+				if rangeIDs := documentRanges.Pop(documentID); rangeIDs != nil {
+					// ...and move existing definition/reference data into the canonical document
+					documentRanges.SetUnion(canonicalID, rangeIDs)
+				}
+			}
+		} else {
+			// Copy out keys first to avoid iterator invalidation
+			var documentIDs = documentRanges.UnorderedKeys()
+			for _, documentID := range documentIDs {
+				canonicalID := canonicalIDs[documentID]
+				rangeIDs := documentRanges.Pop(documentID)
 				documentRanges.SetUnion(canonicalID, rangeIDs)
diff --git a/lib/codeintel/lsif/conversion/datastructures/default_idset_map.go b/lib/codeintel/lsif/conversion/datastructures/default_idset_map.go
index 07b6bfcf4e..99ceadefa7 100644
--- a/lib/codeintel/lsif/conversion/datastructures/default_idset_map.go
+++ b/lib/codeintel/lsif/conversion/datastructures/default_idset_map.go
@@ -87,2 +87,20 @@ func (sm *DefaultIDSetMap) Each(f func(key int, value *IDSet)) {
 
+func (sm *DefaultIDSetMap) ApproxLen() int {
+	if sm.key != 0 {
+		return len(sm.m) + 1
+	}
+	return len(sm.m)
+}
+
+func (sm *DefaultIDSetMap) UnorderedKeys() []int {
+	var out = make([]int, sm.ApproxLen())
+	if sm.key != 0 {
+		out = append(out, sm.key)
+	}
+	for k := range sm.m {
+		out = append(out, k)
+	}
+	return out
+}
+
 // SetLen returns the number of identifiers in the identifier set at the given key.
```

</details>