### PR TITLE
notebooks: fix embedded notebooks background color

### DIFF
--- a/client/web/src/enterprise/embed/EmbeddedWebApp.module.scss
+++ b/client/web/src/enterprise/embed/EmbeddedWebApp.module.scss
@@ -1,0 +1,5 @@
+.body {
+    background: var(--color-bg-1);
+    width: 100%;
+    height: 100%;
+}

--- a/client/web/src/enterprise/embed/EmbeddedWebApp.tsx
+++ b/client/web/src/enterprise/embed/EmbeddedWebApp.tsx
@@ -14,6 +14,8 @@ import {
 
 import '../../SourcegraphWebApp.scss'
 
+import styles from './EmbeddedWebApp.module.scss'
+
 setLinkComponent(AnchorLink)
 
 const WILDCARD_THEME: WildcardTheme = {
@@ -40,7 +42,7 @@ export const EmbeddedWebApp: React.FunctionComponent = () => {
     return (
         <BrowserRouter>
             <WildcardThemeContext.Provider value={WILDCARD_THEME}>
-                <div className={classNames(isLightTheme ? 'theme-light' : 'theme-dark', 'p-3')}>
+                <div className={classNames(isLightTheme ? 'theme-light' : 'theme-dark', styles.body)}>
                     <Suspense
                         fallback={
                             <div className="d-flex justify-content-center">


### PR DESCRIPTION
Fixes the issue with embedded notebooks if the system theme is set to dark.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

* Set system default theme to dark
* Navigate to sourcegraph.test:3443/embed/notebooks/:id
* Verify that the background color is light and not dark
