### PR TITLE
sg: redesign checks functionality

### DIFF
--- a/dev/sg/checks.go
+++ b/dev/sg/checks.go
@@ -96,7 +96,6 @@ func runChecks(ctx context.Context, checks map[string]check.CheckFunc) error {
 
 	if len(failed) == 0 {
 		return nil
-
 	}
 
 	stdout.Out.Write("")

--- a/dev/sg/checks.go
+++ b/dev/sg/checks.go
@@ -1,0 +1,321 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/gomodule/redigo/redis"
+	"github.com/jackc/pgx/v4"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/check"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/usershell"
+	"github.com/sourcegraph/sourcegraph/dev/sg/root"
+	"github.com/sourcegraph/sourcegraph/internal/database/postgresdsn"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/output"
+)
+
+// NOTE: These checkFuncs are also used by `sg setup`, so make sure that when
+// you change something here `sg setup` still works as expected.
+var checks = map[string]check.CheckFunc{
+	"sourcegraph-database":  checkSourcegraphDatabase,
+	"postgres":              check.Any(checkSourcegraphDatabase, checkPostgresConnection),
+	"redis":                 check.Retry(checkRedisConnection, 5, 500*time.Millisecond),
+	"psql":                  check.InPath("psql"),
+	"sourcegraph-test-host": check.FileContains("/etc/hosts", "sourcegraph.test"),
+	"caddy-trusted":         checkCaddyTrusted,
+	"asdf":                  check.CommandOutputContains("asdf", "version"),
+	"git":                   check.Combine(check.InPath("git"), checkGitVersion(">= 2.34.1")),
+	"yarn":                  check.Combine(check.InPath("yarn"), checkYarnVersion("~> 1.22.4")),
+	"go":                    check.Combine(check.InPath("go"), checkGoVersion("1.17.5")),
+	"node":                  check.Combine(check.InPath("node"), check.CommandOutputContains(`node -e "console.log(\"foobar\")"`, "foobar")),
+	"docker-installed":      check.WrapErrMessage(check.InPath("docker"), "if Docker is installed and the check fails, you might need to start Docker.app and restart terminal and 'sg setup'"),
+	"docker": check.WrapErrMessage(
+		check.Combine(check.InPath("docker"), check.CommandExitCode("docker info", 0)),
+		"Docker needs to be running",
+	),
+}
+
+func getCheck(name string) check.CheckFunc {
+	return func(ctx context.Context) error {
+		fn, ok := checks[name]
+		if !ok {
+			return errors.Newf("check %q not found", name)
+		}
+		return fn(ctx)
+	}
+}
+
+func runChecksWithName(ctx context.Context, names []string) error {
+	funcs := make(map[string]check.CheckFunc, len(names))
+	for _, name := range names {
+		if check, ok := checks[name]; ok {
+			funcs[name] = check
+		} else {
+			return errors.Newf("check %q not found", name)
+		}
+	}
+
+	return runChecks(ctx, funcs)
+}
+
+func runChecks(ctx context.Context, checks map[string]check.CheckFunc) error {
+	if len(checks) == 0 {
+		return nil
+	}
+
+	stdout.Out.WriteLine(output.Linef(output.EmojiLightbulb, output.StyleBold, "Running %d checks...", len(checks)))
+
+	ctx, err := usershell.Context(ctx)
+	if err != nil {
+		return err
+	}
+
+	var failed []string
+
+	for name, check := range checks {
+		p := stdout.Out.Pending(output.Linef(output.EmojiLightbulb, output.StylePending, "Running check %q...", name))
+
+		if err := check(ctx); err != nil {
+			p.Complete(output.Linef(output.EmojiFailure, output.StyleWarning, "Check %q failed with the following errors:", name))
+
+			stdout.Out.WriteLine(output.Linef("", output.StyleWarning, "%s", err))
+
+			failed = append(failed, name)
+		} else {
+			p.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Check %q success!", name))
+		}
+	}
+
+	if len(failed) == 0 {
+		return nil
+
+	}
+
+	stdout.Out.Write("")
+	stdout.Out.WriteLine(output.Linef(output.EmojiWarningSign, output.StyleBold, "The following checks failed:"))
+	for _, name := range failed {
+		stdout.Out.Writef("- %s", name)
+	}
+
+	stdout.Out.Write("")
+	writeFingerPointingLinef("Run 'sg setup' to make sure your system is setup correctly")
+	stdout.Out.Write("")
+
+	return errors.Newf("%d failed checks", len(failed))
+}
+
+func checkInMainRepoOrRepoInDirectory(context.Context) error {
+	_, err := root.RepositoryRoot()
+	if err != nil {
+		ok, err := pathExists("sourcegraph")
+		if !ok || err != nil {
+			return errors.New("'sg setup' is not run in sourcegraph and repository is also not found in current directory")
+		}
+		return nil
+	}
+	return nil
+}
+
+func checkDevPrivateInParentOrInCurrentDirectory(context.Context) error {
+	ok, err := pathExists("dev-private")
+	if ok && err == nil {
+		return nil
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return errors.Wrap(err, "failed to check for dev-private repository")
+	}
+
+	p := filepath.Join(wd, "..", "dev-private")
+	ok, err = pathExists(p)
+	if ok && err == nil {
+		return nil
+	}
+	return errors.New("could not find dev-private repository either in current directory or one above")
+}
+
+// checkPostgresConnection succeeds connecting to the default user database works, regardless
+// of if it's running locally or with docker.
+func checkPostgresConnection(ctx context.Context) error {
+	dsns, err := dsnCandidates()
+	if err != nil {
+		return err
+	}
+	var errs []error
+	for _, dsn := range dsns {
+		conn, err := pgx.Connect(ctx, dsn)
+		if err != nil {
+			errs = append(errs, errors.Wrapf(err, "failed to connect to Postgresql Database at %s", dsn))
+			continue
+		}
+		defer conn.Close(ctx)
+		err = conn.Ping(ctx)
+		if err == nil {
+			// if ping passed
+			return nil
+		}
+		errs = append(errs, errors.Wrapf(err, "failed to connect to Postgresql Database at %s", dsn))
+	}
+
+	messages := []string{"failed all attempts to connect to Postgresql database"}
+	for _, e := range errs {
+		messages = append(messages, "\t"+e.Error())
+	}
+	return errors.New(strings.Join(messages, "\n"))
+}
+
+func dsnCandidates() ([]string, error) {
+	env := func(key string) string { val, _ := os.LookupEnv(key); return val }
+
+	// best case scenario
+	datasource := env("PGDATASOURCE")
+	// most classic dsn
+	baseURL := url.URL{Scheme: "postgres", Host: "127.0.0.1:5432"}
+	// classic docker dsn
+	dockerURL := baseURL
+	dockerURL.User = url.UserPassword("postgres", "postgres")
+	// other classic docker dsn
+	dockerURL2 := baseURL
+	dockerURL2.User = url.UserPassword("postgres", "password")
+	// env based dsn
+	envURL := baseURL
+	username, ok := os.LookupEnv("PGUSER")
+	if !ok {
+		uinfo, err := user.Current()
+		if err != nil {
+			return nil, err
+		}
+		username = uinfo.Name
+	}
+	envURL.User = url.UserPassword(username, env("PGPASSWORD"))
+	if host, ok := os.LookupEnv("PGHOST"); ok {
+		if port, ok := os.LookupEnv("PGPORT"); ok {
+			envURL.Host = fmt.Sprintf("%s:%s", host, port)
+		}
+		envURL.Host = fmt.Sprintf("%s:%s", host, "5432")
+	}
+	if sslmode := env("PGSSLMODE"); sslmode != "" {
+		qry := envURL.Query()
+		qry.Set("sslmode", sslmode)
+		envURL.RawQuery = qry.Encode()
+	}
+	return []string{
+		datasource,
+		envURL.String(),
+		baseURL.String(),
+		dockerURL.String(),
+		dockerURL2.String(),
+	}, nil
+}
+
+func checkSourcegraphDatabase(ctx context.Context) error {
+	// This check runs only in the `sourcegraph/sourcegraph` repository, so
+	// we try to parse the globalConf and use its `Env` to configure the
+	// Postgres connection.
+	ok, _ := parseConf(*configFlag, *overwriteConfigFlag)
+	if !ok {
+		return errors.New("failed to read sg.config.yaml. This step of `sg setup` needs to be run in the `sourcegraph` repository")
+	}
+
+	getEnv := func(key string) string {
+		// First look into process env, emulating the logic in makeEnv used
+		// in internal/run/run.go
+		val, ok := os.LookupEnv(key)
+		if ok {
+			return val
+		}
+		// Otherwise check in globalConf.Env
+		return globalConf.Env[key]
+	}
+
+	dsn := postgresdsn.New("", "", getEnv)
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		return errors.Wrapf(err, "failed to connect to Soucegraph Postgres database at %s. Please check the settings in sg.config.yml (see https://docs.sourcegraph.com/dev/background-information/sg#changing-database-configuration)", dsn)
+	}
+	defer conn.Close(ctx)
+	return conn.Ping(ctx)
+}
+
+func checkRedisConnection(context.Context) error {
+	conn, err := redis.Dial("tcp", ":6379", redis.DialConnectTimeout(5*time.Second))
+	if err != nil {
+		return errors.Wrap(err, "failed to connect to Redis at 127.0.0.1:6379")
+	}
+
+	if _, err := conn.Do("SET", "sg-setup", "was-here"); err != nil {
+		return errors.Wrap(err, "failed to write to Redis at 127.0.0.1:6379")
+	}
+
+	retval, err := redis.String(conn.Do("GET", "sg-setup"))
+	if err != nil {
+		return errors.Wrap(err, "failed to read from Redis at 127.0.0.1:6379")
+	}
+
+	if retval != "was-here" {
+		return errors.New("failed to test write in Redis")
+	}
+	return nil
+}
+
+func checkGitVersion(versionConstraint string) func(context.Context) error {
+	return func(ctx context.Context) error {
+		out, err := usershell.CombinedExec(ctx, "git version")
+		if err != nil {
+			return errors.Wrapf(err, "failed to run 'git version'")
+		}
+
+		elems := strings.Split(string(out), " ")
+		if len(elems) != 3 {
+			return errors.Newf("unexpected output from git server: %s", out)
+		}
+
+		trimmed := strings.TrimSpace(elems[2])
+		return check.Version("git", trimmed, versionConstraint)
+	}
+}
+
+func checkGoVersion(versionConstraint string) func(context.Context) error {
+	return func(ctx context.Context) error {
+		cmd := "go version"
+		out, err := usershell.CombinedExec(ctx, "go version")
+		if err != nil {
+			return errors.Wrapf(err, "failed to run %q", cmd)
+		}
+
+		elems := strings.Split(string(out), " ")
+		if len(elems) != 4 {
+			return errors.Newf("unexpected output from %q: %s", out)
+		}
+
+		haveVersion := strings.TrimLeft(elems[2], "go")
+
+		return check.Version("go", haveVersion, versionConstraint)
+	}
+}
+
+func checkYarnVersion(versionConstraint string) func(context.Context) error {
+	return func(ctx context.Context) error {
+		cmd := "yarn --version"
+		out, err := usershell.CombinedExec(ctx, cmd)
+		if err != nil {
+			return errors.Wrapf(err, "failed to run %q", cmd)
+		}
+
+		elems := strings.Split(string(out), "\n")
+		if len(elems) == 0 {
+			return errors.Newf("no output from %q", cmd)
+		}
+
+		trimmed := strings.TrimSpace(elems[0])
+		return check.Version("yarn", trimmed, versionConstraint)
+	}
+}

--- a/dev/sg/config.go
+++ b/dev/sg/config.go
@@ -46,11 +46,6 @@ func ParseConfig(data []byte) (*Config, error) {
 		conf.Tests[name] = cmd
 	}
 
-	for name, check := range conf.Checks {
-		check.Name = name
-		conf.Checks[name] = check
-	}
-
 	return &conf, nil
 }
 
@@ -109,21 +104,12 @@ func (c *Commandset) Merge(other *Commandset) *Commandset {
 	return merged
 }
 
-type check struct {
-	Name        string `yaml:"-"`
-	Cmd         string `yaml:"cmd"`
-	FailMessage string `yaml:"failMessage"`
-
-	CheckFunc string `yaml:"checkFunc"`
-}
-
 type Config struct {
 	Env               map[string]string      `yaml:"env"`
 	Commands          map[string]run.Command `yaml:"commands"`
 	Commandsets       map[string]*Commandset `yaml:"commandsets"`
 	DefaultCommandset string                 `yaml:"defaultCommandset"`
 	Tests             map[string]run.Command `yaml:"tests"`
-	Checks            map[string]check       `yaml:"checks"`
 }
 
 // Merges merges the top-level entries of two Config objects, with the receiver

--- a/dev/sg/config_test.go
+++ b/dev/sg/config_test.go
@@ -68,13 +68,6 @@ commandsets:
 				Checks:   []string{"docker"},
 			},
 		},
-		Checks: map[string]check{
-			"docker": {
-				Name:        "docker",
-				Cmd:         "docker version",
-				FailMessage: "Failed to run 'docker version'. Please make sure Docker is running.",
-			},
-		},
 	}
 
 	if diff := cmp.Diff(want, have); diff != "" {

--- a/dev/sg/internal/check/check.go
+++ b/dev/sg/internal/check/check.go
@@ -1,0 +1,94 @@
+package check
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/Masterminds/semver"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/usershell"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type CheckFunc func(context.Context) error
+
+func InPath(cmd string) func(context.Context) error {
+	return func(ctx context.Context) error {
+		hashCmd := fmt.Sprintf("hash %s 2>/dev/null", cmd)
+		_, err := usershell.CombinedExec(ctx, hashCmd)
+		if err != nil {
+			return errors.Newf("executable %q not found in $PATH", cmd)
+		}
+		return nil
+	}
+}
+
+func CommandExitCode(cmd string, exitCode int) func(context.Context) error {
+	return func(ctx context.Context) error {
+		cmd := usershell.Cmd(ctx, cmd)
+		err := cmd.Run()
+		var execErr *exec.ExitError
+		if err != nil {
+			if errors.As(err, &execErr) && execErr.ExitCode() != exitCode {
+				return errors.Newf("command %q has wrong exit code, wanted %d but got %d", cmd, exitCode, execErr.ExitCode())
+			}
+			return err
+		}
+		return nil
+	}
+}
+
+func Version(cmdName, haveVersion, versionConstraint string) error {
+	c, err := semver.NewConstraint(versionConstraint)
+	if err != nil {
+		return err
+	}
+
+	version, err := semver.NewVersion(haveVersion)
+	if err != nil {
+		return errors.Newf("cannot decode version in %q: %w", haveVersion, err)
+	}
+
+	if !c.Check(version) {
+		return errors.Newf("version %q from %q does not match constraint %q", haveVersion, cmdName, versionConstraint)
+	}
+	return nil
+}
+
+func CommandOutputContains(cmd, contains string) func(context.Context) error {
+	return func(ctx context.Context) error {
+		out, _ := usershell.CombinedExec(ctx, cmd)
+		if !strings.Contains(string(out), contains) {
+			return errors.Newf("command output of %q doesn't contain %q", cmd, contains)
+		}
+		return nil
+	}
+}
+
+func FileContains(fileName, content string) func(context.Context) error {
+	return func(context.Context) error {
+		file, err := os.Open(fileName)
+		if err != nil {
+			return errors.Wrapf(err, "failed to check that %q contains %q", fileName, content)
+		}
+		defer file.Close()
+
+		scanner := bufio.NewScanner(file)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.Contains(line, content) {
+				return nil
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			return err
+		}
+
+		return errors.Newf("file %q did not contain %q", fileName, content)
+	}
+}

--- a/dev/sg/internal/check/check_test.go
+++ b/dev/sg/internal/check/check_test.go
@@ -1,4 +1,4 @@
-package main
+package check
 
 import (
 	"testing"
@@ -19,7 +19,7 @@ func TestCheckVersion(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		err := checkVersion(tt.cmd, tt.haveVersion, tt.constraint)
+		err := Version(tt.cmd, tt.haveVersion, tt.constraint)
 
 		if tt.wantErr != "" {
 			if err != nil {

--- a/dev/sg/internal/check/helpers.go
+++ b/dev/sg/internal/check/helpers.go
@@ -1,0 +1,55 @@
+package check
+
+import (
+	"context"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func Any(checks ...CheckFunc) CheckFunc {
+	return func(ctx context.Context) (err error) {
+		for _, chk := range checks {
+			err = chk(ctx)
+			if err == nil {
+				return nil
+			}
+		}
+		return err
+	}
+}
+
+func Combine(checks ...CheckFunc) CheckFunc {
+	return func(ctx context.Context) (err error) {
+		for _, chk := range checks {
+			err = chk(ctx)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func Retry(check CheckFunc, retries int, sleep time.Duration) CheckFunc {
+	return func(ctx context.Context) (err error) {
+		for i := 0; i < retries; i++ {
+			err = check(ctx)
+			if err == nil {
+				return nil
+			}
+			time.Sleep(sleep)
+		}
+		return err
+	}
+}
+
+func WrapErrMessage(check CheckFunc, message string) CheckFunc {
+	return func(ctx context.Context) error {
+		err := check(ctx)
+		if err != nil {
+			return errors.Wrap(err, message)
+		}
+		return nil
+	}
+}

--- a/dev/sg/internal/run/check.go
+++ b/dev/sg/internal/run/check.go
@@ -1,7 +1,0 @@
-package run
-
-type Check struct {
-	Name        string `yaml:"-"`
-	Cmd         string `yaml:"cmd"`
-	FailMessage string `yaml:"failMessage"`
-}

--- a/dev/sg/internal/run/run.go
+++ b/dev/sg/internal/run/run.go
@@ -631,39 +631,3 @@ func Test(ctx context.Context, cmd Command, args []string, globalEnv map[string]
 
 	return c.Run()
 }
-
-func Checks(ctx context.Context, globalEnv map[string]string, checks ...Check) (bool, error) {
-	success := true
-
-	for _, check := range checks {
-		commandCtx, cancel := context.WithCancel(ctx)
-		defer cancel()
-
-		c := exec.CommandContext(commandCtx, "bash", "-c", check.Cmd)
-		c.Env = makeEnv(globalEnv)
-
-		p := stdout.Out.Pending(output.Linef(output.EmojiLightbulb, output.StylePending, "Running check %q...", check.Name))
-
-		if cmdOut, err := InRoot(c); err != nil {
-			success = false
-
-			p.Complete(output.Linef(output.EmojiFailure, output.StyleWarning, "Check %q failed: %s", check.Name, err))
-
-			stdout.Out.WriteLine(output.Linef("", output.StyleWarning, "%s", check.FailMessage))
-			if len(cmdOut) != 0 {
-				stdout.Out.WriteLine(output.Linef("", output.StyleWarning, "Check produced the following output:"))
-				separator := strings.Repeat("-", 80)
-				line := output.Linef(
-					"", output.StyleWarning,
-					"%s\n%s%s%s%s%s",
-					separator, output.StyleReset, cmdOut, output.StyleWarning, separator, output.StyleReset,
-				)
-				stdout.Out.WriteLine(line)
-			}
-		} else {
-			p.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Check %q success!", check.Name))
-		}
-	}
-
-	return success, nil
-}

--- a/dev/sg/internal/usershell/usershell.go
+++ b/dev/sg/internal/usershell/usershell.go
@@ -3,7 +3,9 @@ package usershell
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -63,4 +65,18 @@ func Context(ctx context.Context) (context.Context, error) {
 		shellConfigPath: shellConfigPath,
 	}
 	return context.WithValue(ctx, key{}, userCtx), nil
+}
+
+// Cmd returns a command wrapped in a new shell process, enabling
+// changes added by various checks to be run. This negates the new to ask the
+// user to restart sg for many checks.
+func Cmd(ctx context.Context, cmd string) *exec.Cmd {
+	command := fmt.Sprintf("source %s || true; %s", ShellConfigPath(ctx), cmd)
+	return exec.CommandContext(ctx, ShellPath(ctx), "-c", command)
+}
+
+// CombinedExec runs a command in a fresh shell environment, and returns
+// stderr and stdout combined, along with an error.
+func CombinedExec(ctx context.Context, cmd string) ([]byte, error) {
+	return Cmd(ctx, cmd).CombinedOutput()
 }

--- a/dev/sg/sg.config.example.yaml
+++ b/dev/sg/sg.config.example.yaml
@@ -91,15 +91,6 @@ commands:
       NODE_ENV: development
       NODE_OPTIONS: "--max_old_space_size=8192"
 
-checks:
-  docker:
-    cmd: docker version
-    failMessage: "Failed to run 'docker version'. Please make sure Docker is running."
-
-  redis:
-    cmd: redis-cli -p 6379 PING
-    failMessage: 'Failed to connect to Redis on port 6379. Please make sure Redis is running.'
-
 commandsets:
   minimal:
     - frontend

--- a/dev/sg/sg_doctor.go
+++ b/dev/sg/sg_doctor.go
@@ -3,17 +3,8 @@ package main
 import (
 	"context"
 	"flag"
-	"os"
-	"strings"
-	"time"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
-
-	"github.com/sourcegraph/sourcegraph/dev/sg/internal/run"
-	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
-	"github.com/sourcegraph/sourcegraph/dev/sg/internal/usershell"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
-	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
 var (
@@ -21,92 +12,12 @@ var (
 	doctorCommand = &ffcli.Command{
 		Name:       "doctor",
 		ShortUsage: "sg doctor",
-		ShortHelp:  "Run the checks defined in the sg config file.",
-		LongHelp: `Run the checks defined in the sg config file to make sure your system is healthy.
-
-See the "checks:" in the configuration file.`,
-		FlagSet: doctorFlagSet,
-		Exec:    doctorExec,
+		ShortHelp:  "Runs checks to test whether system is in correct state to run Sourcegraph.",
+		FlagSet:    doctorFlagSet,
+		Exec:       doctorExec,
 	}
 )
 
-// NOTE: These checkFuncs are also used by `sg doctor`, so make sure that when
-// you change something here `sg setup` still works as expected.
-var checkFuncs = map[string]dependencyCheck{
-	"postgres": anyChecks(checkSourcegraphDatabase, checkPostgresConnection),
-	"redis":    retryCheck(checkRedisConnection, 5, 500*time.Millisecond),
-	"psql":     checkInPath("psql"),
-	// TODO: get these versions from .tool-versions
-	"git":    combineChecks(checkInPath("git"), checkGitVersion(">= 2.34.1")),
-	"yarn":   combineChecks(checkInPath("yarn"), checkYarnVersion("~> 1.22.4")),
-	"go":     combineChecks(checkInPath("go"), checkGoVersion("1.17.5")),
-	"docker": wrapCheckErr(checkInPath("docker"), "if Docker is installed and the check fails, you might need to start Docker.app and restart terminal and 'sg setup'"),
-}
-
-type builtinCheck struct {
-	Name        string
-	Func        dependencyCheck
-	FailMessage string
-}
-
 func doctorExec(ctx context.Context, args []string) error {
-	ok, errLine := parseConf(*configFlag, *overwriteConfigFlag)
-	if !ok {
-		stdout.Out.WriteLine(errLine)
-		os.Exit(1)
-	}
-
-	var funcs []builtinCheck
-	var checks []run.Check
-	for _, c := range globalConf.Checks {
-		if c.Cmd != "" {
-			checks = append(checks, run.Check{
-				Name:        c.Name,
-				Cmd:         c.Cmd,
-				FailMessage: c.FailMessage,
-			})
-		} else if fn, ok := checkFuncs[c.CheckFunc]; ok {
-			funcs = append(funcs, builtinCheck{
-				Name:        c.CheckFunc,
-				Func:        fn,
-				FailMessage: c.FailMessage,
-			})
-		}
-	}
-
-	_, err := run.Checks(ctx, globalConf.Env, checks...)
-	if err != nil {
-		return err
-	}
-
-	// No funcs, early exit
-	if len(funcs) == 0 {
-		return nil
-	}
-
-	ctx, err = usershell.Context(ctx)
-	if err != nil {
-		return err
-	}
-
-	var failedchecks []string
-	for _, check := range funcs {
-		// TODO: Formatting here is duplicated from run.Checks
-		p := stdout.Out.Pending(output.Linef(output.EmojiLightbulb, output.StylePending, "Running check %q...", check.Name))
-
-		if err := check.Func(ctx); err != nil {
-			p.Complete(output.Linef(output.EmojiFailure, output.StyleWarning, "Check %q failed: %s", check.Name, err))
-
-			stdout.Out.WriteLine(output.Linef("", output.StyleWarning, "%s", check.FailMessage))
-
-			failedchecks = append(failedchecks, check.Name)
-		} else {
-			p.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Check %q success!", check.Name))
-		}
-	}
-
-	if len(failedchecks) != 0 {
-		return errors.Newf("failed checks: %s", strings.Join(failedchecks, ", "))
-	}
-	return nil
+	return runChecks(ctx, checks)
 }

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -700,31 +700,6 @@ commands:
     cmd: yarn --cwd client/browser dev
     install: yarn
 
-checks:
-  docker:
-    checkFunc: docker
-    failMessage: "Failed to run 'docker version'. Please make sure Docker is running."
-
-  docker-compose:
-    cmd: docker-compose version
-    failMessage: "Failed to run 'docker-compose version'. Please make sure Docker is running."
-
-  go:
-    checkFunc: go
-    failMessage: 'Failed to get correct Go version. Run "sg setup" to make sure you have the right version.'
-
-  redis:
-    checkFunc: redis
-    failMessage: 'Failed to connect to Redis on port 6379. Please make sure Redis is running.'
-
-  postgres:
-    checkFunc: postgres
-    failMessage: 'Failed to connect to Postgres database. Make sure environment variables are setup correctly so that psql can connect.'
-
-  git-version:
-    checkFunc: git
-    failMessage: 'Failed to get correct git version. Run "sg setup" to make sure you have the right version.'
-
 defaultCommandset: enterprise
 commandsets:
   oss:


### PR DESCRIPTION
This does multiple things to fix https://github.com/sourcegraph/sourcegraph/issues/31043

- Move Sourcegraph-independent check functionality into `internal/check` (including helpers like `check.Version`, `check.Any`, etc.)
- Remove the previous `run.Check` and removes the distinction between built-in and config checks
- Remove all checks from `sg.config.yaml`. Old `sg` versions will run into "WARNING: check not found" messages, so it's kinda backwards-compatible
- Moves all Sourcegraph and sg-related check code into a single file, `checks.go`
- Adds a helper to safely get a check by name
- Fixes #31039 by checking that Docker is running, but _only_ in `sg doctor`, not in `setup`.
- Changes output of `sg doctor` to be more readable
- Move some functionality into `usershell` so the code is in a leaf package

## Test plan

- Run `go run . doctor` locally with Redis/Postgres/Docker on and off
- Run `go run . setup` locally with Redis/Postgres/Docker on and off
