### PR TITLE
Revert "gitserver: Rename NoTimeout to EnableTimeout"

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1170,7 +1170,7 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 
 	ctx := r.Context()
 
-	if req.EnableTimeout {
+	if !req.NoTimeout {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, shortGitCommandTimeout(req.Args))
 		defer cancel()

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -391,7 +391,7 @@ func (c *Cmd) sendExec(ctx context.Context) (_ io.ReadCloser, _ http.Header, err
 		Repo:           repoName,
 		EnsureRevision: c.EnsureRevision,
 		Args:           c.Args[1:],
-		EnableTimeout:  c.EnableTimeout,
+		NoTimeout:      c.NoTimeout,
 	}
 	resp, err := c.client.httpPost(ctx, repoName, "exec", req)
 	if err != nil {
@@ -529,7 +529,7 @@ type Cmd struct {
 	Repo           api.RepoName // the repository to execute the command in
 	EnsureRevision string
 	ExitStatus     int
-	EnableTimeout  bool
+	NoTimeout      bool
 }
 
 func (c *ClientImplementor) Command(name string, arg ...string) *Cmd {
@@ -584,6 +584,10 @@ func (c *Cmd) Output(ctx context.Context) ([]byte, error) {
 func (c *Cmd) CombinedOutput(ctx context.Context) ([]byte, error) {
 	stdout, stderr, err := c.DividedOutput(ctx)
 	return append(stdout, stderr...), err
+}
+
+func (c *Cmd) DisableTimeout() {
+	c.NoTimeout = true
 }
 
 func (c *Cmd) String() string { return fmt.Sprintf("%q", c.Args) }

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -95,7 +95,7 @@ type ExecRequest struct {
 	EnsureRevision string      `json:"ensureRevision"`
 	Args           []string    `json:"args"`
 	Opt            *RemoteOpts `json:"opt"`
-	EnableTimeout  bool        `json:"enableTimeout"`
+	NoTimeout      bool        `json:"noTimeout"`
 }
 
 // P4ExecRequest is a request to execute a p4 command with given arguments.


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#30884

Reverting because [this](https://github.com/sourcegraph/sourcegraph/pull/30884#issuecomment-1035932721) comment by @keegancsmith makes sense:

> The purpose of double negative is the default value in go is false. This makes it much easier to rollout changes when adding a field/etc. Also I think it's nice when you structure your fields such that the go zero values are the defaults.
>
> @indradhanush Reading this PR it looks like we now never set EnableTimeout. Doesn't this imlpy now that we never have a timeout set which is breaking existing behaviour? IE before chris's PR every git exec command had a timeout. Now we don't have that...

Closes #31036. 