### PR TITLE
Fix styling of actions in panel

### DIFF
--- a/client/branded/src/components/panel/Panel.tsx
+++ b/client/branded/src/components/panel/Panel.tsx
@@ -264,29 +264,27 @@ export const Panel = React.memo<Props>(props => {
                 <TabList
                     wrapperClassName={styles.header}
                     actions={
-                        <>
-                            <small>
-                                {activeTab && (
-                                    <ActionsNavItems
-                                        {...props}
-                                        // TODO remove references to Bootstrap from shared, get class name from prop
-                                        // This is okay for now because the Panel is currently only used in the webapp
-                                        listClass="d-flex justify-content-end list-unstyled m-0 align-items-center"
-                                        listItemClass="px-2 mx-2"
-                                        actionItemClass="font-weight-medium"
-                                        actionItemIconClass="icon-inline"
-                                        menu={ContributableMenu.PanelToolbar}
-                                        scope={{
-                                            type: 'panelView',
-                                            id: activeTab.id,
-                                            hasLocations: Boolean(activeTab.hasLocations),
-                                        }}
-                                        wrapInList={true}
-                                        location={location}
-                                        transformContributions={transformPanelContributions}
-                                    />
-                                )}
-                            </small>
+                        <div className="align-items-center d-flex">
+                            {activeTab && (
+                                <ActionsNavItems
+                                    {...props}
+                                    // TODO remove references to Bootstrap from shared, get class name from prop
+                                    // This is okay for now because the Panel is currently only used in the webapp
+                                    listClass="d-flex justify-content-end list-unstyled m-0 align-items-center"
+                                    listItemClass="px-2 mx-2"
+                                    actionItemClass="font-weight-medium"
+                                    actionItemIconClass="icon-inline"
+                                    menu={ContributableMenu.PanelToolbar}
+                                    scope={{
+                                        type: 'panelView',
+                                        id: activeTab.id,
+                                        hasLocations: Boolean(activeTab.hasLocations),
+                                    }}
+                                    wrapInList={true}
+                                    location={location}
+                                    transformContributions={transformPanelContributions}
+                                />
+                            )}
                             <Button
                                 onClick={handlePanelClose}
                                 variant="icon"
@@ -297,7 +295,7 @@ export const Panel = React.memo<Props>(props => {
                             >
                                 <CloseIcon className="icon-inline" />
                             </Button>
-                        </>
+                        </div>
                     }
                 >
                     {items.map(({ label, id, trackTabClick }) => (


### PR DESCRIPTION
This fixes #30993.

The changes in #30954 produced a regression here that resulted in the
actions not being aligned correctly.

Now it looks like this again: 

<img width="1410" alt="screenshot_2022-02-11_13 29 07@2x" src="https://user-images.githubusercontent.com/1185253/153591604-c393a37f-f638-4a8d-ab8a-318f5d828ea1.png">

