### PR TITLE
gitserver: build p4-fusion as a seperate stage

### DIFF
--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -11,6 +11,11 @@ RUN wget http://cdist2.perforce.com/perforce/r20.1/bin.linux26x86_64/p4 && \
     mv p4 /usr/local/bin/p4 && \
     chmod +x /usr/local/bin/p4
 
+FROM sourcegraph/alpine-3.12:120059_2021-12-09_b34c7b2@sha256:9a1fde12f56fea02027cf4caeebdddfedb7b73bf8db6c16f7907a6e04a29134c AS p4-fusion
+
+COPY p4-fusion-install-alpine.sh /p4-fusion-install-alpine.sh
+RUN /p4-fusion-install-alpine.sh
+
 FROM sourcegraph/alpine-3.12:120059_2021-12-09_b34c7b2@sha256:9a1fde12f56fea02027cf4caeebdddfedb7b73bf8db6c16f7907a6e04a29134c AS coursier
 
 # TODO(code-intel): replace with official streams when musl builds are upstreamed
@@ -37,17 +42,15 @@ RUN apk add --no-cache \
     git-p4 \
     && apk add --no-cache  \
     openssh-client \
-    # We require g++, gcc, perl and make to install openssl and p4-fusion
-    g++ \
-    gcc \
-    perl \
-    cmake \
-    make \
+    # We require libstdc++ for p4-fusion
+    libstdc++ \
     python2 \
     python3 \
     bash
 
 COPY --from=p4cli /usr/local/bin/p4 /usr/local/bin/p4
+
+COPY --from=p4-fusion /usr/local/bin/p4-fusion /usr/local/bin/p4-fusion
 
 COPY --from=coursier /usr/local/bin/coursier /usr/local/bin/coursier
 
@@ -55,39 +58,6 @@ COPY --from=coursier /usr/local/bin/coursier /usr/local/bin/coursier
 # please refer to https://blog.tilander.org/docker-perforce/
 ADD https://github.com/jtilander/p4d/raw/4600d741720f85d77852dcca7c182e96ad613358/lib/lib-x64.tgz /
 RUN tar zxf /lib-x64.tgz --directory /
-
-# p4-fusion installation
-# Fetching p4 sources archive
-RUN wget https://github.com/salesforce/p4-fusion/archive/refs/tags/v1.5.tar.gz && \
-    mv v1.5.tar.gz /usr/local/bin && \
-    mkdir -p /usr/local/bin/p4-fusion-src && \
-    tar -C /usr/local/bin/p4-fusion-src -xzvf /usr/local/bin/v1.5.tar.gz --strip 1
-
-# We need a specific version of OpenSSL
-RUN wget https://www.openssl.org/source/openssl-1.0.2t.tar.gz && tar -xzvf openssl-1.0.2t.tar.gz
-
-WORKDIR /openssl-1.0.2t
-
-RUN ./config && make && make install
-
-# We also need Helix Core C++ API to build p4-fusion
-RUN wget https://www.perforce.com/downloads/perforce/r21.1/bin.linux26x86_64/p4api.tgz && \
-    mkdir -p /usr/local/bin/p4-fusion-src/vendor/helix-core-api/linux && \
-    mv p4api.tgz /usr/local/bin/p4-fusion-src/vendor/helix-core-api/linux && \
-    tar -C /usr/local/bin/p4-fusion-src/vendor/helix-core-api/linux -xzvf /usr/local/bin/p4-fusion-src/vendor/helix-core-api/linux/p4api.tgz --strip 1
-
-WORKDIR /usr/local/bin/p4-fusion-src
-
-# Build p4-fusion
-RUN ./generate_cache.sh Release
-RUN ./build.sh
-
-WORKDIR /usr/local/bin
-# Move exe file to /usr/local/bin where other executables are located; delete src directory and archive
-RUN mv /usr/local/bin/p4-fusion-src/build/p4-fusion/p4-fusion /usr/local/bin && \
-    rm -rf /usr/local/bin/p4-fusion-src && \
-    rm /usr/local/bin/v1.5.tar.gz
-# p4-fusion installation completed here
 
 RUN mkdir -p /data/repos && chown -R sourcegraph:sourcegraph /data/repos
 USER sourcegraph

--- a/cmd/gitserver/build.sh
+++ b/cmd/gitserver/build.sh
@@ -10,6 +10,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
+cp -a ./cmd/gitserver/p4-fusion-install-alpine.sh "$OUTPUT"
+
 # Environment for building linux binaries
 export GO111MODULE=on
 export GOARCH=amd64

--- a/cmd/gitserver/p4-fusion-install-alpine.sh
+++ b/cmd/gitserver/p4-fusion-install-alpine.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+# This script installs p4-fusion within an alpine container.
+
+cleanup() {
+  apk --no-cache --purge del p4-build-deps || true
+  cd /
+  rm -rf /usr/local/bin/p4-fusion-src || true
+  rm -rf /usr/local/bin/v1.5.tar.gz || true
+}
+
+trap cleanup EXIT
+
+cd /
+
+set -eux
+
+# Runtime dependencies
+apk add --no-cache libstdc++
+
+# Build dependencies
+apk add --no-cache \
+    --virtual p4-build-deps \
+    wget \
+    g++ \
+    gcc \
+    perl \
+    bash \
+    cmake \
+    make
+
+# Fetching p4 sources archive
+wget https://github.com/salesforce/p4-fusion/archive/refs/tags/v1.5.tar.gz
+mv v1.5.tar.gz /usr/local/bin
+mkdir -p /usr/local/bin/p4-fusion-src
+tar -C /usr/local/bin/p4-fusion-src -xzvf /usr/local/bin/v1.5.tar.gz --strip 1
+
+# We need a specific version of OpenSSL
+wget https://www.openssl.org/source/openssl-1.0.2t.tar.gz
+tar -xzvf openssl-1.0.2t.tar.gz
+cd /openssl-1.0.2t
+
+./config && make && make install
+
+# We also need Helix Core C++ API to build p4-fusion
+wget https://www.perforce.com/downloads/perforce/r21.1/bin.linux26x86_64/p4api.tgz
+mkdir -p /usr/local/bin/p4-fusion-src/vendor/helix-core-api/linux
+mv p4api.tgz /usr/local/bin/p4-fusion-src/vendor/helix-core-api/linux
+tar -C /usr/local/bin/p4-fusion-src/vendor/helix-core-api/linux -xzvf /usr/local/bin/p4-fusion-src/vendor/helix-core-api/linux/p4api.tgz --strip 1
+
+cd /usr/local/bin/p4-fusion-src
+
+# Build p4-fusion
+./generate_cache.sh Release
+./build.sh
+
+# Move exe file to /usr/local/bin where other executables are located
+mv /usr/local/bin/p4-fusion-src/build/p4-fusion/p4-fusion /usr/local/bin

--- a/cmd/gitserver/p4-fusion-install-alpine.sh
+++ b/cmd/gitserver/p4-fusion-install-alpine.sh
@@ -20,14 +20,14 @@ apk add --no-cache libstdc++
 
 # Build dependencies
 apk add --no-cache \
-    --virtual p4-build-deps \
-    wget \
-    g++ \
-    gcc \
-    perl \
-    bash \
-    cmake \
-    make
+  --virtual p4-build-deps \
+  wget \
+  g++ \
+  gcc \
+  perl \
+  bash \
+  cmake \
+  make
 
 # Fetching p4 sources archive
 wget https://github.com/salesforce/p4-fusion/archive/refs/tags/v1.5.tar.gz


### PR DESCRIPTION
When we introduced p4-fusion to our docker images it added a significant amount of build time. In the case of server it doubled the build time. This is a first step to improving that but only targetted at gitserver. Next up we can do the same change to server, but I wanted to keep this focussed.

The meat of this change is extracting the docker steps for p4-fusion into a build script. This is in preparation for using it in server image builds.

The main benefit is it is now a seperate change. Previously we ran into linking issues but this was easy to resolve. You just need to install libstdc++.

Note: I noticed some flaws in our build script. This commit doesn't fix those it just does manual refactoring. Follow-up commits can improve the process. The only real functional change it does is use a shell script trap for cleanup.

Test Plan: A lot of docker building. Running the gitserver image and checking that p4-fusion runs and "ldd p4-fusion" is happy.
