### PR TITLE
gitdomain: Special case handling for git blame

### DIFF
--- a/internal/gitserver/gitdomain/exec.go
+++ b/internal/gitserver/gitdomain/exec.go
@@ -90,6 +90,11 @@ func IsAllowedGitCmd(args []string) bool {
 				continue // this arg is OK
 			}
 
+			// Special case handling of commands like `git blame -L15,60`.
+			if cmd == "blame" && strings.HasPrefix(arg, "-L") {
+				continue // this arg is OK
+			}
+
 			if !isAllowedGitArg(allowedArgs, arg) {
 				log15.Warn("IsAllowedGitCmd.isAllowedGitArgcmd", "cmd", cmd, "arg", arg)
 				return false


### PR DESCRIPTION
This looks like one last edge case based on the [logs](https://sourcegraph.grafana.net/explore?orgId=1&left=%7B%22datasource%22:%22grafanacloud-sourcegraph-logs%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bapp%3D%5C%22gitserver%5C%22,%20namespace%3D%5C%22prod%5C%22%7D%20%7C%3D%20%5C%22IsAllowedGitCmd%5C%22%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D). 

Follow up on #30833 and #30987.

## Test plan

Monitor the logs over the weekend.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


