### PR TITLE
ci: ignore benign CVE-2021-43816 in prometheus

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,4 +1,8 @@
 # github.com/containerd/containerd use in prometheus does not allow
 # explotation of the CVE. Prometheus has an open PR to update the dependency:
 # https://github.com/prometheus/prometheus/pull/10282
+# Documentation for false-positive report
+# https://github.com/sourcegraph/security-issues/issues/218
 CVE-2021-43816
+
+

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,4 @@
+# github.com/containerd/containerd use in prometheus does not allow
+# explotation of the CVE. Prometheus has an open PR to update the dependency:
+# https://github.com/prometheus/prometheus/pull/10282
+CVE-2021-43816


### PR DESCRIPTION
This is not exploitable due to how prometheus uses containerd. So we can
remove the trivy reports for it.

Test Plan: main dry run to see if report goes away.