### PR TITLE
git: apply sub-repo permissions for git.ArchiveReader command

### DIFF
--- a/cmd/frontend/internal/app/ui/raw.go
+++ b/cmd/frontend/internal/app/ui/raw.go
@@ -182,7 +182,7 @@ func serveRaw(db database.DB) handlerFunc {
 			// caching locally is not useful. Additionally we transfer the output over the
 			// internet, so we use default compression levels on zips (instead of no
 			// compression).
-			f, err := git.ArchiveReader(r.Context(), common.Repo.Name, format, common.CommitID, relativePath)
+			f, err := git.ArchiveReader(r.Context(), authz.DefaultSubRepoPermsChecker, common.Repo, format, common.CommitID, relativePath)
 			if err != nil {
 				return err
 			}

--- a/internal/vcs/git/archive.go
+++ b/internal/vcs/git/archive.go
@@ -5,7 +5,10 @@ import (
 	"io"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // ArchiveFormat represents an archive format (zip, tar, etc).
@@ -20,8 +23,24 @@ const (
 )
 
 // ArchiveReader streams back the file contents of an archived git repo.
-func ArchiveReader(ctx context.Context, repo api.RepoName, format ArchiveFormat, commit api.CommitID, relativePath string) (io.ReadCloser, error) {
+func ArchiveReader(
+	ctx context.Context,
+	checker authz.SubRepoPermissionChecker,
+	repo *types.Repo,
+	format ArchiveFormat,
+	commit api.CommitID,
+	relativePath string,
+) (io.ReadCloser, error) {
+	if authz.SubRepoEnabled(checker) {
+		enabled, err := authz.SubRepoEnabledForRepoID(ctx, checker, repo.ID)
+		if err != nil {
+			return nil, errors.Wrap(err, "Sub-repo permissions check:")
+		}
+		if enabled {
+			return nil, errors.New("ArchiveReader invoked for a repo with sub-repo permissions")
+		}
+	}
 	cmd := gitserver.DefaultClient.Command("git", "archive", "--format="+string(format), string(commit), relativePath)
-	cmd.Repo = repo
+	cmd.Repo = repo.Name
 	return gitserver.StdoutReader(ctx, cmd)
 }

--- a/internal/vcs/git/archive.go
+++ b/internal/vcs/git/archive.go
@@ -34,10 +34,10 @@ func ArchiveReader(
 	if authz.SubRepoEnabled(checker) {
 		enabled, err := authz.SubRepoEnabledForRepoID(ctx, checker, repo.ID)
 		if err != nil {
-			return nil, errors.Wrap(err, "Sub-repo permissions check:")
+			return nil, errors.Wrap(err, "sub-repo permissions check:")
 		}
 		if enabled {
-			return nil, errors.New("ArchiveReader invoked for a repo with sub-repo permissions")
+			return nil, errors.New("archiveReader invoked for a repo with sub-repo permissions")
 		}
 	}
 	cmd := gitserver.DefaultClient.Command("git", "archive", "--format="+string(format), string(commit), relativePath)

--- a/internal/vcs/git/archive_test.go
+++ b/internal/vcs/git/archive_test.go
@@ -1,0 +1,63 @@
+package git
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func TestArchiveReaderForRepoWithSubRepoPermissions(t *testing.T) {
+	repoName := MakeGitRepository(t,
+		"echo abcd > file1",
+		"git add file1",
+		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit -m commit1 --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
+	)
+	const commitID = "3d689662de70f9e252d4f6f1d75284e23587d670"
+
+	checker := authz.NewMockSubRepoPermissionChecker()
+	checker.EnabledFunc.SetDefaultHook(func() bool {
+		return true
+	})
+	checker.EnabledForRepoIdFunc.SetDefaultHook(func(ctx context.Context, id api.RepoID) (bool, error) {
+		// sub-repo permissions are enabled only for repo with repoID = 1
+		return id == 1, nil
+	})
+
+	repo := &types.Repo{Name: repoName, ID: 1}
+
+	if _, err := ArchiveReader(context.Background(), checker, repo, ArchiveFormatZip, commitID, "."); err == nil {
+		t.Error("Error should not be null because ArchiveReader is invoked for a repo with sub-repo permissions")
+	}
+}
+
+func TestArchiveReaderForRepoWithoutSubRepoPermissions(t *testing.T) {
+	repoName := MakeGitRepository(t,
+		"echo abcd > file1",
+		"git add file1",
+		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit -m commit1 --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
+	)
+	const commitID = "3d689662de70f9e252d4f6f1d75284e23587d670"
+
+	checker := authz.NewMockSubRepoPermissionChecker()
+	checker.EnabledFunc.SetDefaultHook(func() bool {
+		return true
+	})
+	checker.EnabledForRepoIdFunc.SetDefaultHook(func(ctx context.Context, id api.RepoID) (bool, error) {
+		// sub-repo permissions are not present for repo with repoID = 1
+		return id != 1, nil
+	})
+
+	repo := &types.Repo{Name: repoName, ID: 1}
+
+	readCloser, err := ArchiveReader(context.Background(), checker, repo, ArchiveFormatZip, commitID, ".")
+	if err != nil {
+		t.Error("Error should not be thrown because ArchiveReader is invoked for a repo without sub-repo permissions")
+	}
+	err = readCloser.Close()
+	if err != nil {
+		t.Error("Error during closing a reader")
+	}
+}


### PR DESCRIPTION
Second attempt on applying sub-repo permissions for git.ArchiveReader command.

Now it considers the repo for which an archive is downloaded. Download is forbidden only for repos with enabled sub-repo permissions.

Should be merged after https://github.com/sourcegraph/sourcegraph/pull/31049 because it reuses code from that PR

Closes https://github.com/sourcegraph/sourcegraph/issues/27332

## Test plan
Unit tests for git.ArchiveReader command
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


