### PR TITLE
sg: refactor process output piping to use errgroups

### DIFF
--- a/dev/sg/internal/run/logger.go
+++ b/dev/sg/internal/run/logger.go
@@ -20,11 +20,10 @@ func newCmdLogger(ctx context.Context, name string, out *output.Output) *process
 	color := nameToColor(name)
 
 	sink := func(data string) {
-		// TODO: This always adds a newline, which is not always what we want. When
+		// NOTE: This always adds a newline, which is not always what we want. When
 		// we flush partial lines, we don't want to add a newline character. What
 		// we need to do: extend the `*output.Output` type to have a
 		// `WritefNoNewline` (yes, bad name) method.
-		//
 		out.Writef("%s%s[%s]%s %s", output.StyleBold, color, name, output.StyleReset, data)
 	}
 

--- a/lib/go.mod
+++ b/lib/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27
 	golang.org/x/tools v0.1.9 // indirect
 	google.golang.org/protobuf v1.27.1

--- a/lib/go.sum
+++ b/lib/go.sum
@@ -343,6 +343,7 @@ golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
This confirms that #30529 is fixed and makes it a bit less error prone.

## Test plan

- [x] Change `cmd/github-proxy/github_proxy.go` to print 10M characters with `log15.Warn`, run `cd dev/sg && go run . run github-proxy`
- [x] Change `cmd/github-proxy/github_proxy.go` to print single characters without newlines, run `cd dev/sg && go run . run github-proxy`


