### PR TITLE
Search jobs: make new search jobs default and remove evaluate* methods

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -962,132 +962,6 @@ func (r *searchResolver) toSearchJob(q query.Q) (run.Job, error) {
 	return job, nil
 }
 
-// intersect returns the intersection of two sets of search result content
-// matches, based on whether a single file path contains content matches in both sets.
-func intersect(left, right *SearchResults) *SearchResults {
-	if left == nil || right == nil {
-		return nil
-	}
-	left.Matches = result.Intersect(left.Matches, right.Matches)
-	left.Stats.Update(&right.Stats)
-	return left
-}
-
-// evaluateAnd performs set intersection on result sets. It collects results for
-// all expressions that are ANDed together by searching for each subexpression
-// and then intersects those results that are in the same repo/file path. To
-// collect N results for count:N, we need to opportunistically ask for more than
-// N results for each subexpression (since intersect can never yield more than N,
-// and likely yields fewer than N results). If the intersection does not yield N
-// results, and is not exhaustive for every expression, we rerun the search by
-// doubling count again.
-func (r *searchResolver) evaluateAnd(ctx context.Context, stream streaming.Sender, q query.Basic) (*search.Alert, error) {
-	start := time.Now()
-
-	// Invariant: this function is only reachable from callers that
-	// guarantee a root node with one or more operands.
-	operands := q.Pattern.(query.Operator).Operands
-
-	var (
-		result     *SearchResults
-		termResult *SearchResults
-	)
-
-	// The number of results we want. Note that for intersect, this number
-	// corresponds to documents, not line matches. By default, we ask for at
-	// least 5 documents to fill the result page.
-	want := 5
-	// The fraction of file matches two terms share on average
-	averageIntersection := 0.05
-	// When we retry, cap the max search results we request for each expression
-	// if search continues to not be exhaustive. Alert if exceeded.
-	maxTryCount := 40000
-
-	// Set an overall timeout in addition to the timeouts that are set for leaf-requests.
-	ctx, cancel := context.WithTimeout(ctx, search.TimeoutDuration(q))
-	defer cancel()
-
-	if count := q.GetCount(); count != "" {
-		want, _ = strconv.Atoi(count) // Invariant: count is validated.
-	} else {
-		q = q.AddCount(want)
-	}
-
-	// tryCount starts small but grows exponentially with the number of operands. It is capped at maxTryCount.
-	tryCount := int(math.Floor(float64(want) / math.Pow(averageIntersection, float64(len(operands)-1))))
-	if tryCount > maxTryCount {
-		tryCount = maxTryCount
-	}
-
-	var exhausted bool
-	for {
-		q = q.MapCount(tryCount)
-		agg := streaming.NewAggregatingStream()
-		alert, err := r.evaluatePatternExpression(ctx, agg, q.MapPattern(operands[0]))
-		if err != nil {
-			return nil, err
-		}
-		result = &SearchResults{
-			Matches: agg.Results,
-			Stats:   agg.Stats,
-			Alert:   alert,
-		}
-
-		if len(result.Matches) == 0 {
-			// result might contain an alert.
-			return result.Alert, nil
-		}
-		exhausted = !result.Stats.IsLimitHit
-		for _, term := range operands[1:] {
-			// check if we exceed the overall time limit before running the next query.
-			select {
-			case <-ctx.Done():
-				usedTime := time.Since(start)
-				suggestTime := longer(2, usedTime)
-				return search.AlertForTimeout(usedTime, suggestTime, r.rawQuery(), r.PatternType), nil
-			default:
-			}
-
-			termAgg := streaming.NewAggregatingStream()
-			termAlert, err := r.evaluatePatternExpression(ctx, termAgg, q.MapPattern(term))
-			if err != nil {
-				return nil, err
-			}
-			termResult = &SearchResults{
-				Matches: termAgg.Results,
-				Stats:   termAgg.Stats,
-				Alert:   termAlert,
-			}
-
-			if len(termResult.Matches) == 0 {
-				// termResult might contain an alert.
-				return termResult.Alert, nil
-			}
-			exhausted = exhausted && !termResult.Stats.IsLimitHit
-			result = intersect(result, termResult)
-		}
-		if exhausted {
-			break
-		}
-		if len(result.Matches) >= want {
-			break
-		}
-		// If the result size set is not big enough, and we haven't
-		// exhausted search on all expressions, double the tryCount and search more.
-		tryCount *= 2
-		if tryCount > maxTryCount {
-			// We've capped out what we're willing to do, throw alert.
-			return search.AlertForCappedAndExpression(), nil
-		}
-	}
-	result.Stats.IsLimitHit = !exhausted
-	stream.Send(streaming.SearchEvent{
-		Results: result.Matches,
-		Stats:   result.Stats,
-	})
-	return result.Alert, nil
-}
-
 // toAndJob creates a new job from a basic query whose pattern is an And operator at the root.
 func (r *searchResolver) toAndJob(q query.Basic) (run.Job, error) {
 	// Invariant: this function is only reachable from callers that
@@ -1131,99 +1005,6 @@ func (r *searchResolver) toOrJob(q query.Basic) (run.Job, error) {
 	return run.NewOrJob(operands...), nil
 }
 
-// evaluateOr performs set union on result sets. It collects results for all
-// expressions that are ORed together by searching for each subexpression. If
-// the maximum number of results are reached after evaluating a subexpression,
-// we shortcircuit and return results immediately.
-func (r *searchResolver) evaluateOr(ctx context.Context, stream streaming.Sender, q query.Basic) (*search.Alert, error) {
-	// Invariant: this function is only reachable from callers that
-	// guarantee a root node with one or more operands.
-	operands := q.Pattern.(query.Operator).Operands
-
-	wantCount := defaultMaxSearchResults
-	if count := q.GetCount(); count != "" {
-		wantCount, _ = strconv.Atoi(count) // Invariant: count is already validated
-	}
-
-	var (
-		mu     sync.Mutex
-		stats  streaming.Stats
-		alerts []*search.Alert
-		dedup  = result.NewDeduper()
-		// NOTE(tsenart): In the future, when we have the need for more intelligent rate limiting,
-		// this concurrency limit should probably be informed by a user's rate limit quota
-		// at any given time.
-		sem = semaphore.NewWeighted(16)
-	)
-
-	g, ctx := errgroup.WithContext(ctx)
-	for _, term := range operands {
-		term := term
-		g.Go(func() error {
-			if err := sem.Acquire(ctx, 1); err != nil {
-				return err
-			}
-
-			defer sem.Release(1)
-
-			agg := streaming.NewAggregatingStream()
-			alert, err := r.evaluatePatternExpression(ctx, agg, q.MapPattern(term))
-			if err != nil {
-				return err
-			}
-			new := &SearchResults{
-				Matches: agg.Results,
-				Stats:   agg.Stats,
-				Alert:   alert,
-			}
-
-			mu.Lock()
-			defer mu.Unlock()
-
-			if new.Alert != nil {
-				alerts = append(alerts, new.Alert)
-			}
-
-			// Check if another go-routine has already produced enough results.
-			if wantCount <= 0 {
-				return context.Canceled
-			}
-
-			// BUG: When we find enough results we stop adding them to dedupper,
-			// but don't adjust the stats accordingly. This bug was here
-			// before, and remains after making OR query evaluation concurrent.
-			stats.Update(&new.Stats)
-
-			for _, m := range new.Matches {
-				wantCount = m.Limit(wantCount)
-				if dedup.Add(m); wantCount <= 0 {
-					return context.Canceled
-				}
-			}
-
-			return nil
-		})
-	}
-
-	if err := g.Wait(); err != nil && err != context.Canceled {
-		return nil, err
-	}
-
-	var alert *search.Alert
-	if len(alerts) > 0 {
-		sort.Slice(alerts, func(i, j int) bool {
-			return alerts[i].Priority > alerts[j].Priority
-		})
-		alert = alerts[0]
-	}
-
-	stream.Send(streaming.SearchEvent{
-		Results: dedup.Results(),
-		Stats:   stats,
-	})
-	return alert, nil
-}
-
 func (r *searchResolver) toPatternExpressionJob(q query.Basic) (run.Job, error) {
 	switch term := q.Pattern.(type) {
 	case query.Operator:
@@ -1249,40 +1030,6 @@ func (r *searchResolver) toPatternExpressionJob(q query.Basic) (run.Job, error) 
 	return nil, errors.Errorf("unrecognized type %T in evaluatePatternExpression", q.Pattern)
 }
 
-// evaluatePatternExpression evaluates a search pattern containing and/or expressions.
-func (r *searchResolver) evaluatePatternExpression(ctx context.Context, stream streaming.Sender, q query.Basic) (*search.Alert, error) {
-	switch term := q.Pattern.(type) {
-	case query.Operator:
-		if len(term.Operands) == 0 {
-			return nil, nil
-		}
-
-		switch term.Kind {
-		case query.And:
-			return r.evaluateAnd(ctx, stream, q)
-		case query.Or:
-			return r.evaluateOr(ctx, stream, q)
-		case query.Concat:
-			job, err := r.toSearchJob(q.ToParseTree())
-			if err != nil {
-				return nil, err
-			}
-			return r.evaluateJob(ctx, stream, job)
-		}
-	case query.Pattern:
-		job, err := r.toSearchJob(q.ToParseTree())
-		if err != nil {
-			return nil, err
-		}
-		return r.evaluateJob(ctx, stream, job)
-	case query.Parameter:
-		// evaluatePatternExpression does not process Parameter nodes.
-		return nil, nil
-	}
-	// Unreachable.
-	return nil, errors.Errorf("unrecognized type %T in evaluatePatternExpression", q.Pattern)
-}
-
 func (r *searchResolver) toEvaluateJob(q query.Basic) (run.Job, error) {
 	maxResults := r.MaxResults()
 	timeout := search.TimeoutDuration(q)
@@ -1297,22 +1044,11 @@ func (r *searchResolver) toEvaluateJob(q query.Basic) (run.Job, error) {
 
 // evaluate evaluates all expressions of a search query. The value of stream must be non-nil
 func (r *searchResolver) evaluate(ctx context.Context, stream streaming.Sender, q query.Basic) (*search.Alert, error) {
-	enableAndOrJobs := r.SearchInputs.Features.GetBoolOr("cc-and-or-jobs", false)
-	if enableAndOrJobs {
-		j, err := r.toEvaluateJob(q)
-		if err != nil {
-			return nil, err
-		}
-		return j.Run(ctx, r.db, stream)
+	j, err := r.toEvaluateJob(q)
+	if err != nil {
+		return nil, err
 	}
-	if q.Pattern == nil {
-		job, err := r.toSearchJob(query.ToNodes(q.Parameters))
-		if err != nil {
-			return nil, err
-		}
-		return r.evaluateJob(ctx, stream, job)
-	}
-	return r.evaluatePatternExpression(ctx, stream, q)
+	return r.evaluateJob(ctx, stream, j)
 }
 
 func logPrometheusBatch(status, alertType, requestSource, requestName string, elapsed time.Duration) {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -945,15 +945,6 @@ func (r *searchResolver) toSearchJob(q query.Q) (run.Job, error) {
 		run.NewParallelJob(optionalJobs...),
 	)
 
-	// If and/or jobs are not enabled, set limit and timeout here.
-	// If the feature is enabled, this will be set in toEvaluateJob.
-	if !r.SearchInputs.Features.GetBoolOr("cc-and-or-jobs", false) {
-		job = run.NewLimitJob(
-			maxResults,
-			run.NewTimeoutJob(args.Timeout, job),
-		)
-	}
-
 	checker := authz.DefaultSubRepoPermsChecker
 	if authz.SubRepoEnabled(checker) {
 		job = subrepoperms.NewFilterJob(job)

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -635,7 +635,7 @@ func TestEvaluateAnd(t *testing.T) {
 		{
 			name:         "zoekt does not return enough matches, not exhausted",
 			query:        "foo and bar index:only count:50",
-			zoektMatches: 10,
+			zoektMatches: 0,
 			filesSkipped: 1,
 			wantAlert:    true,
 		},

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -785,24 +785,24 @@ func Test_toSearchInputs(t *testing.T) {
 	}
 
 	// Job generation for global vs non-global search
-	autogold.Want("user search context", "LimitJob{TimeoutJob{ParallelJob{RepoSubsetText, Repo, ComputeExcludedRepos}}}").Equal(t, test(`foo context:@userA`, query.ParseLiteral))
-	autogold.Want("universal (AKA global) search context", "LimitJob{TimeoutJob{ParallelJob{RepoUniverseText, Repo, ComputeExcludedRepos}}}").Equal(t, test(`foo context:global`, query.ParseLiteral))
-	autogold.Want("universal (AKA global) search", "LimitJob{TimeoutJob{ParallelJob{RepoUniverseText, Repo, ComputeExcludedRepos}}}").Equal(t, test(`foo`, query.ParseLiteral))
-	autogold.Want("nonglobal repo", "LimitJob{TimeoutJob{ParallelJob{RepoSubsetText, Repo, ComputeExcludedRepos}}}").Equal(t, test(`foo repo:sourcegraph/sourcegraph`, query.ParseLiteral))
-	autogold.Want("nonglobal repo contains", "LimitJob{TimeoutJob{ParallelJob{RepoSubsetText, Repo, ComputeExcludedRepos}}}").Equal(t, test(`foo repo:contains(bar)`, query.ParseLiteral))
+	autogold.Want("user search context", "ParallelJob{RepoSubsetText, Repo, ComputeExcludedRepos}").Equal(t, test(`foo context:@userA`, query.ParseLiteral))
+	autogold.Want("universal (AKA global) search context", "ParallelJob{RepoUniverseText, Repo, ComputeExcludedRepos}").Equal(t, test(`foo context:global`, query.ParseLiteral))
+	autogold.Want("universal (AKA global) search", "ParallelJob{RepoUniverseText, Repo, ComputeExcludedRepos}").Equal(t, test(`foo`, query.ParseLiteral))
+	autogold.Want("nonglobal repo", "ParallelJob{RepoSubsetText, Repo, ComputeExcludedRepos}").Equal(t, test(`foo repo:sourcegraph/sourcegraph`, query.ParseLiteral))
+	autogold.Want("nonglobal repo contains", "ParallelJob{RepoSubsetText, Repo, ComputeExcludedRepos}").Equal(t, test(`foo repo:contains(bar)`, query.ParseLiteral))
 
 	// Job generation support for implied `type:repo` queries.
-	autogold.Want("supported Repo job", "LimitJob{TimeoutJob{ParallelJob{RepoUniverseText, Repo, ComputeExcludedRepos}}}").Equal(t, test("ok ok", query.ParseRegexp))
-	autogold.Want("supportedRepo job literal", "LimitJob{TimeoutJob{ParallelJob{RepoUniverseText, Repo, ComputeExcludedRepos}}}").Equal(t, test("ok @thing", query.ParseLiteral))
-	autogold.Want("unsupported Repo job prefix", "LimitJob{TimeoutJob{ParallelJob{RepoUniverseText, ComputeExcludedRepos}}}").Equal(t, test("@nope", query.ParseRegexp))
-	autogold.Want("unsupported Repo job regexp", "LimitJob{TimeoutJob{ParallelJob{RepoUniverseText, ComputeExcludedRepos}}}").Equal(t, test("foo @bar", query.ParseRegexp))
+	autogold.Want("supported Repo job", "ParallelJob{RepoUniverseText, Repo, ComputeExcludedRepos}").Equal(t, test("ok ok", query.ParseRegexp))
+	autogold.Want("supportedRepo job literal", "ParallelJob{RepoUniverseText, Repo, ComputeExcludedRepos}").Equal(t, test("ok @thing", query.ParseLiteral))
+	autogold.Want("unsupported Repo job prefix", "ParallelJob{RepoUniverseText, ComputeExcludedRepos}").Equal(t, test("@nope", query.ParseRegexp))
+	autogold.Want("unsupported Repo job regexp", "ParallelJob{RepoUniverseText, ComputeExcludedRepos}").Equal(t, test("foo @bar", query.ParseRegexp))
 
 	// Job generation for other types of search
-	autogold.Want("symbol", "LimitJob{TimeoutJob{ParallelJob{RepoUniverseSymbol, ComputeExcludedRepos}}}").Equal(t, test("type:symbol test", query.ParseRegexp))
-	autogold.Want("commit", "LimitJob{TimeoutJob{ParallelJob{Commit, ComputeExcludedRepos}}}").Equal(t, test("type:commit test", query.ParseRegexp))
-	autogold.Want("diff", "LimitJob{TimeoutJob{ParallelJob{Diff, ComputeExcludedRepos}}}").Equal(t, test("type:diff test", query.ParseRegexp))
-	autogold.Want("file or commit", "LimitJob{TimeoutJob{JobWithOptional{Required: ParallelJob{RepoUniverseText, ComputeExcludedRepos}, Optional: Commit}}}").Equal(t, test("type:file type:commit test", query.ParseRegexp))
-	autogold.Want("many types", "LimitJob{TimeoutJob{JobWithOptional{Required: ParallelJob{RepoSubsetText, Repo, ComputeExcludedRepos}, Optional: ParallelJob{RepoSubsetSymbol, Commit}}}}").Equal(t, test("type:file type:path type:repo type:commit type:symbol repo:test test", query.ParseRegexp))
+	autogold.Want("symbol", "ParallelJob{RepoUniverseSymbol, ComputeExcludedRepos}").Equal(t, test("type:symbol test", query.ParseRegexp))
+	autogold.Want("commit", "ParallelJob{Commit, ComputeExcludedRepos}").Equal(t, test("type:commit test", query.ParseRegexp))
+	autogold.Want("diff", "ParallelJob{Diff, ComputeExcludedRepos}").Equal(t, test("type:diff test", query.ParseRegexp))
+	autogold.Want("file or commit", "JobWithOptional{Required: ParallelJob{RepoUniverseText, ComputeExcludedRepos}, Optional: Commit}").Equal(t, test("type:file type:commit test", query.ParseRegexp))
+	autogold.Want("many types", "JobWithOptional{Required: ParallelJob{RepoSubsetText, Repo, ComputeExcludedRepos}, Optional: ParallelJob{RepoSubsetSymbol, Commit}}").Equal(t, test("type:file type:path type:repo type:commit type:symbol repo:test test", query.ParseRegexp))
 }
 
 func TestZeroElapsedMilliseconds(t *testing.T) {


### PR DESCRIPTION
The new jobs for AND/OR searches have been live for a week now on
sourcegraph.com with no apparent issues. This deletes the evaluate*
methods that they replace and makes the previously-feature-flagged
code path the default.



## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


