### PR TITLE
Create VSCE campaign events on sourcegraph.com

### DIFF
--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -253,11 +253,12 @@ function pageViewQueryParameters(url: string): UTMMarker {
 
     const utmSource = parsedUrl.searchParams.get('utm_source')
     const utmCampaign = parsedUrl.searchParams.get('utm_campaign')
+    const utmMedium = parsedUrl.searchParams.get('utm_medium')
 
     const utmProps: UTMMarker = {
         utm_campaign: utmCampaign || undefined,
         utm_source: utmSource || undefined,
-        utm_medium: parsedUrl.searchParams.get('utm_medium') || undefined,
+        utm_medium: utmMedium || undefined,
         utm_term: parsedUrl.searchParams.get('utm_term') || undefined,
         utm_content: parsedUrl.searchParams.get('utm_content') || undefined,
     }
@@ -281,6 +282,8 @@ function pageViewQueryParameters(url: string): UTMMarker {
         ].includes(utmSource ?? '')
     ) {
         eventLogger.log('UTMCodeHostIntegration', utmProps, utmProps)
+    } else if (utmMedium === 'VSCIDE' && utmCampaign === 'vsce-sign-up') {
+        eventLogger.log('VSCIDESignUpLinkClicked', utmProps, utmProps)
     }
 
     return utmProps


### PR DESCRIPTION
This is a cherry-picked commit from https://github.com/sourcegraph/sourcegraph/pull/30963 to enable the tracking of the new VSCE related UTM campaigns on sourcegraph.com.

We need to land this in a separate PR as the VSCE currently lives in a diverged branch but that branch does not deploy onto sourcegraph.com.

## Test plan

To validate that this logs the right parmeters I changed the hostname to my local instance: `https://sourcegraph.test:3443/sign-up?editor=vscode&utm_medium=VSCIDE&utm_source=sidebar&utm_campaign=vsce-sign-up&utm_content=sign-up` and verified that the events show up in the console: 
![Screenshot 2022-02-09 at 14 19 41](https://user-images.githubusercontent.com/458591/153211675-6afc0989-b9be-4c43-9d9a-f6a18e174f86.png)

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


