### PR TITLE
sg: Use filesystem (not go-embed) contents for `sg migration ...` commands

### DIFF
--- a/cmd/migrator/main.go
+++ b/cmd/migrator/main.go
@@ -80,11 +80,14 @@ func newRunnerFactory() func(ctx context.Context, schemaNames []string) (cliutil
 		if err != nil {
 			return nil, err
 		}
-
 		storeFactory := func(db *sql.DB, migrationsTable string) connections.Store {
 			return connections.NewStoreShim(store.NewWithDB(db, migrationsTable, operations))
 		}
+		r, err := connections.RunnerFromDSNs(dsns, appName, storeFactory)
+		if err != nil {
+			return nil, err
+		}
 
-		return cliutil.NewShim(connections.RunnerFromDSNs(dsns, appName, storeFactory)), nil
+		return cliutil.NewShim(r), nil
 	}
 }

--- a/internal/database/migration/runner/runner.go
+++ b/internal/database/migration/runner/runner.go
@@ -12,13 +12,19 @@ import (
 
 type Runner struct {
 	storeFactories map[string]StoreFactory
+	schemas        []*schemas.Schema
 }
 
 type StoreFactory func(ctx context.Context) (Store, error)
 
 func NewRunner(storeFactories map[string]StoreFactory) *Runner {
+	return NewRunnerWithSchemas(storeFactories, schemas.Schemas)
+}
+
+func NewRunnerWithSchemas(storeFactories map[string]StoreFactory, schemas []*schemas.Schema) *Runner {
 	return &Runner{
 		storeFactories: storeFactories,
+		schemas:        schemas,
 	}
 }
 
@@ -103,7 +109,7 @@ func (r *Runner) prepareSchemas(schemaNames []string) (map[string]*schemas.Schem
 	schemaMap := make(map[string]*schemas.Schema, len(schemaNames))
 
 	for _, targetSchemaName := range schemaNames {
-		for _, schema := range schemas.Schemas {
+		for _, schema := range r.schemas {
 			if schema.Name == targetSchemaName {
 				schemaMap[schema.Name] = schema
 				break

--- a/internal/database/migration/schemas/schemas.go
+++ b/internal/database/migration/schemas/schemas.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/definition"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/migrations"
 )
 
@@ -27,9 +28,18 @@ func mustResolveSchema(name string) *Schema {
 		panic(fmt.Sprintf("malformed migration definitions %q: %s", name, err))
 	}
 
+	schema, err := ResolveSchema(fs, name)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	return schema
+}
+
+func ResolveSchema(fs fs.FS, name string) (*Schema, error) {
 	definitions, err := definition.ReadDefinitions(fs)
 	if err != nil {
-		panic(fmt.Sprintf("malformed migration definitions %q: %s", name, err))
+		return nil, errors.Newf("malformed migration definitions %q: %s", name, err)
 	}
 
 	return &Schema{
@@ -37,5 +47,5 @@ func mustResolveSchema(name string) *Schema {
 		MigrationsTableName: strings.TrimPrefix(fmt.Sprintf("%s_schema_migrations", name), "frontend_"),
 		FS:                  fs,
 		Definitions:         definitions,
-	}
+	}, nil
 }


### PR DESCRIPTION
Fixes #30205.

## Test plan

- Installed sg from main
- Added migration
- Ran validate and see that it wasn't in the list (unintuitive)
- Cleared repo state
- Installed sg from branch
- Added migration
- Ran validate and it detected an out-of-date database (Intuitive)
