### PR TITLE
doc/dev: generate sg ci build instructions for supported run types

### DIFF
--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -142,6 +142,11 @@ The run type for branches matching `main` (exact).
 ### Main dry run
 
 The run type for branches matching `main-dry-run/`.
+You can create a build of this run type for your changes using:
+
+```sh
+sg ci build main-dry-run
+```
 
 - Default pipeline:
   - **Pipeline setup**: Trigger async
@@ -155,6 +160,11 @@ The run type for branches matching `main-dry-run/`.
 ### Patch image
 
 The run type for branches matching `docker-images-patch/`.
+You can create a build of this run type for your changes using:
+
+```sh
+sg ci build docker-images-patch
+```
 
 - Default pipeline:
   - **Pipeline setup**: Trigger async
@@ -168,6 +178,11 @@ The run type for branches matching `docker-images-patch/`.
 ### Patch image without testing
 
 The run type for branches matching `docker-images-patch-notest/`.
+You can create a build of this run type for your changes using:
+
+```sh
+sg ci build docker-images-patch-notest
+```
 
 - Default pipeline:
   - **Pipeline setup**: Trigger async
@@ -181,6 +196,11 @@ The run type for branches matching `docker-images-patch-notest/`.
 ### Build all candidates without testing
 
 The run type for branches matching `docker-images-candidates-notest/`.
+You can create a build of this run type for your changes using:
+
+```sh
+sg ci build docker-images-candidates-notest
+```
 
 - Default pipeline:
   - **Pipeline setup**: Trigger async
@@ -194,6 +214,11 @@ The run type for branches matching `docker-images-candidates-notest/`.
 ### Build executor without testing
 
 The run type for branches matching `executor-patch-notest/`.
+You can create a build of this run type for your changes using:
+
+```sh
+sg ci build executor-patch-notest
+```
 
 - Default pipeline:
   - **Pipeline setup**: Trigger async
@@ -207,6 +232,11 @@ The run type for branches matching `executor-patch-notest/`.
 ### Backend integration tests
 
 The run type for branches matching `backend-integration/`.
+You can create a build of this run type for your changes using:
+
+```sh
+sg ci build backend-integration
+```
 
 - Default pipeline:
   - **Pipeline setup**: Trigger async

--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -157,6 +157,11 @@ func renderPipelineDocs(w io.Writer) {
 			}
 			fmt.Fprintf(w, "The run type for %s.\n", strings.Join(conditions, ", "))
 
+			if m.IsPrefixMatcher() {
+				fmt.Fprintf(w, "You can create a build of this run type for your changes using:\n\n```sh\nsg ci build %s\n```\n",
+					strings.TrimRight(m.Branch, "/"))
+			}
+
 			// Generate a sample pipeline with all changes
 			pipeline, err := ci.GeneratePipeline(ci.Config{
 				RunType: runtype.PullRequest,


### PR DESCRIPTION
Generates documentation for `sg ci build [runtype]` (https://github.com/sourcegraph/sourcegraph/pull/30932) in the pipeline types reference.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

```
sg ci docs
sg run docsite
```

http://localhost:5080/dev/background-information/ci/reference#main-dry-run