### PR TITLE
cli: update for 3.36.4

### DIFF
--- a/doc/cli/references/batch/exec.md
+++ b/doc/cli/references/batch/exec.md
@@ -5,14 +5,18 @@
 
 | Name | Description | Default Value |
 |------|-------------|---------------|
+| `-allow-unsupported` | Allow unsupported code hosts. | `false` |
 | `-cache` | Directory for caching results and repository archives. | `~/.cache/sourcegraph/batch` |
 | `-clean-archives` | If true, deletes downloaded repository archives after executing batch spec steps. | `true` |
 | `-clear-cache` | If true, clears the execution cache and executes all steps anew. | `false` |
 | `-dump-requests` | Log GraphQL requests and responses to stdout | `false` |
 | `-f` | The batch spec file to read, or - to read from standard input. |  |
+| `-force-override-ignore` | Do not ignore repositories that have a .batchignore file. | `false` |
 | `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false` |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false` |
 | `-j` | The maximum number of parallel jobs. Default is GOMAXPROCS. | `8` |
+| `-n` | Alias for -namespace. |  |
+| `-namespace` | The user or organization namespace to place the batch change within. Default is the currently authenticated user. |  |
 | `-skip-errors` | If true, errors encountered while executing steps in a repository won't stop the execution of the batch spec but only cause that repository to be skipped. | `false` |
 | `-timeout` | The maximum duration a single batch spec step can take. | `1h0m0s` |
 | `-tmp` | Directory for storing temporary data, such as log files. Default is /tmp. Can also be set with environment variable SRC_BATCH_TMP_DIR; if both are set, this flag will be used and not the environment variable. | `/tmp` |
@@ -26,6 +30,8 @@
 
 ```
 Usage of 'src batch exec':
+  -allow-unsupported
+    	Allow unsupported code hosts.
   -cache string
     	Directory for caching results and repository archives. (default "~/.cache/sourcegraph/batch")
   -clean-archives
@@ -36,12 +42,18 @@ Usage of 'src batch exec':
     	Log GraphQL requests and responses to stdout
   -f string
     	The batch spec file to read, or - to read from standard input.
+  -force-override-ignore
+    	Do not ignore repositories that have a .batchignore file.
   -get-curl
     	Print the curl command for executing this query and exit (WARNING: includes printing your access token!)
   -insecure-skip-verify
     	Skip validation of TLS certificates against trusted chains
   -j int
     	The maximum number of parallel jobs. Default is GOMAXPROCS. (default 8)
+  -n string
+    	Alias for -namespace.
+  -namespace string
+    	The user or organization namespace to place the batch change within. Default is the currently authenticated user.
   -skip-errors
     	If true, errors encountered while executing steps in a repository won't stop the execution of the batch spec but only cause that repository to be skipped.
   -timeout duration

--- a/doc/cli/references/batch/index.md
+++ b/doc/cli/references/batch/index.md
@@ -7,6 +7,7 @@
 * [`exec`](exec.md)
 * [`new`](new.md)
 * [`preview`](preview.md)
+* [`remote`](remote.md)
 * [`repositories`](repositories.md)
 * [`validate`](validate.md)
 	

--- a/doc/cli/references/batch/remote.md
+++ b/doc/cli/references/batch/remote.md
@@ -21,7 +21,7 @@
 ## Usage
 
 ```
-Usage of 'src batch remote remote':
+Usage of 'src batch remote':
   -allow-unsupported
     	Allow unsupported code hosts.
   -clear-cache

--- a/doc/cli/references/batch/remote.md
+++ b/doc/cli/references/batch/remote.md
@@ -1,0 +1,61 @@
+# `src batch remote`
+
+
+## Flags
+
+| Name | Description | Default Value |
+|------|-------------|---------------|
+| `-allow-unsupported` | Allow unsupported code hosts. | `false` |
+| `-clear-cache` | If true, clears the execution cache and executes all steps anew. | `false` |
+| `-dump-requests` | Log GraphQL requests and responses to stdout | `false` |
+| `-f` | The name of the batch spec file to run. |  |
+| `-force-override-ignore` | Do not ignore repositories that have a .batchignore file. | `false` |
+| `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false` |
+| `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false` |
+| `-n` | Alias for -namespace. |  |
+| `-namespace` | The user or organization namespace to place the batch change within. Default is the currently authenticated user. |  |
+| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
+| `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true` |
+
+
+## Usage
+
+```
+Usage of 'src batch remote remote':
+  -allow-unsupported
+    	Allow unsupported code hosts.
+  -clear-cache
+    	If true, clears the execution cache and executes all steps anew.
+  -dump-requests
+    	Log GraphQL requests and responses to stdout
+  -f string
+    	The name of the batch spec file to run.
+  -force-override-ignore
+    	Do not ignore repositories that have a .batchignore file.
+  -get-curl
+    	Print the curl command for executing this query and exit (WARNING: includes printing your access token!)
+  -insecure-skip-verify
+    	Skip validation of TLS certificates against trusted chains
+  -n string
+    	Alias for -namespace.
+  -namespace string
+    	The user or organization namespace to place the batch change within. Default is the currently authenticated user.
+  -trace
+    	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+  -user-agent-telemetry
+    	Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
+'src batch remote' runs a batch spec on the Sourcegraph instance.
+
+Usage:
+
+    src batch remote [-f FILE]
+    src batch remote FILE
+
+Examples:
+
+    $ src batch remote -f batch.spec.yaml
+
+
+
+```
+	

--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.36.3"
+const MinimumVersion = "3.36.4"


### PR DESCRIPTION
The most notable aspect is that we have a new command to be documented. (The `src batch exec` changes are correct, but less important for end users.)

## Test plan

N/A

