### PR TITLE
doc/dev: actually generate sample pipelines for runtypes

### DIFF
--- a/dev/sg/sg_ci.go
+++ b/dev/sg/sg_ci.go
@@ -466,6 +466,7 @@ From there, you can start exploring logs with the Grafana explore panel.
 		}, {
 			Name:      "docs",
 			ShortHelp: "Render reference documentation for build pipeline types.",
+			LongHelp:  "Render reference documentation for build pipeline types. An online version of this is also available in https://docs.sourcegraph.com/dev/background-information/ci/reference.",
 			Exec: func(ctx context.Context, args []string) error {
 				cmd := exec.Command("go", "run", "./enterprise/dev/ci/gen-pipeline.go", "-docs")
 				out, err := run.InRoot(cmd)

--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -15,50 +15,50 @@ For a higher-level overview, please refer to the [continuous integration docs](h
 The default run type.
 
 - Pipeline for `Go` changes:
-  - **Linters and static analysis**: Prettier, Misc Linters
+  - **Linters and static analysis**: Prettier, Misc linters
   - **Go checks**: Test (all), Test (enterprise/internal/codeintel/stores/dbstore), Test (enterprise/internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
   - Upload build trace
 
 - Pipeline for `Client` changes:
   - **Pipeline setup**: Trigger async
-  - **Linters and static analysis**: Prettier, Misc Linters, Yarn deduplicate lint
+  - **Linters and static analysis**: Prettier, Misc linters, Yarn deduplicate lint
   - **Client checks**: Puppeteer tests prep, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests finalize, Upload Storybook to Chromatic, Test shared client code, Test wildcard client code, Build, Enterprise build, Test, Puppeteer tests for chrome extension, Test browser extension, Test branded client code, Typescript eslint, Stylelint
   - Upload build trace
 
 - Pipeline for `GraphQL` changes:
-  - **Linters and static analysis**: Prettier, Misc Linters, GraphQL lint
+  - **Linters and static analysis**: Prettier, Misc linters, GraphQL lint
   - **Client checks**: Puppeteer tests prep, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests finalize, Upload Storybook to Chromatic, Test shared client code, Test wildcard client code, Build, Enterprise build, Test, Puppeteer tests for chrome extension, Test browser extension, Test branded client code, Typescript eslint, Stylelint
   - **Go checks**: Test (all), Test (enterprise/internal/codeintel/stores/dbstore), Test (enterprise/internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
   - Upload build trace
 
 - Pipeline for `DatabaseSchema` changes:
-  - **Linters and static analysis**: Prettier, Misc Linters
+  - **Linters and static analysis**: Prettier, Misc linters
   - **DB backcompat tests**: Backcompat test (all), Backcompat test (enterprise/internal/codeintel/stores/dbstore), Backcompat test (enterprise/internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
   - Upload build trace
 
 - Pipeline for `Docs` changes:
-  - **Linters and static analysis**: Prettier, Misc Linters, Check and build docsite
+  - **Linters and static analysis**: Prettier, Misc linters, Check and build docsite
   - Upload build trace
 
 - Pipeline for `Dockerfiles` changes:
-  - **Linters and static analysis**: Prettier, Misc Linters, Lint
+  - **Linters and static analysis**: Prettier, Misc linters, Lint
   - Upload build trace
 
 - Pipeline for `ExecutorDockerRegistryMirror` changes:
-  - **Linters and static analysis**: Prettier, Misc Linters
+  - **Linters and static analysis**: Prettier, Misc linters
   - Upload build trace
 
 - Pipeline for `CIScripts` changes:
-  - **Linters and static analysis**: Prettier, Misc Linters
+  - **Linters and static analysis**: Prettier, Misc linters
   - **CI script tests**: test-trace-command.sh
   - Upload build trace
 
 - Pipeline for `Terraform` changes:
-  - **Linters and static analysis**: Prettier, Misc Linters, security - checkov
+  - **Linters and static analysis**: Prettier, Misc linters, Checkov Terraform scanning
   - Upload build trace
 
 - Pipeline for `SVG` changes:
-  - **Linters and static analysis**: Prettier, Misc Linters, SVG lint
+  - **Linters and static analysis**: Prettier, Misc linters, SVG lint
   - Upload build trace
 
 ### Release branch nightly healthcheck build
@@ -67,13 +67,9 @@ The run type for environment including `{"RELEASE_NIGHTLY":"true"}`.
 
 Default pipeline:
 
-- **Pipeline setup**: Trigger async
-- **Linters and static analysis**: Prettier, Misc Linters, GraphQL lint, SVG lint, Yarn deduplicate lint, Lint, security - checkov, Check and build docsite
-- **Client checks**: Puppeteer tests prep, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests finalize, Upload Storybook to Chromatic, Test shared client code, Test wildcard client code, Build, Enterprise build, Test, Puppeteer tests for chrome extension, Test browser extension, Test branded client code, Typescript eslint, Stylelint
-- **Go checks**: Test (all), Test (enterprise/internal/codeintel/stores/dbstore), Test (enterprise/internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
-- **DB backcompat tests**: Backcompat test (all), Backcompat test (enterprise/internal/codeintel/stores/dbstore), Backcompat test (enterprise/internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
-- **CI script tests**: test-trace-command.sh
-  - Upload build trace
+- Trigger 3.36 release branch healthcheck build
+- Trigger 3.35 release branch healthcheck build
+- Upload build trace
 
 ### Browser extension nightly release build
 
@@ -81,13 +77,14 @@ The run type for environment including `{"BEXT_NIGHTLY":"true"}`.
 
 Default pipeline:
 
-- **Pipeline setup**: Trigger async
-- **Linters and static analysis**: Prettier, Misc Linters, GraphQL lint, SVG lint, Yarn deduplicate lint, Lint, security - checkov, Check and build docsite
-- **Client checks**: Puppeteer tests prep, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests finalize, Upload Storybook to Chromatic, Test shared client code, Test wildcard client code, Build, Enterprise build, Test, Puppeteer tests for chrome extension, Test browser extension, Test branded client code, Typescript eslint, Stylelint
-- **Go checks**: Test (all), Test (enterprise/internal/codeintel/stores/dbstore), Test (enterprise/internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
-- **DB backcompat tests**: Backcompat test (all), Backcompat test (enterprise/internal/codeintel/stores/dbstore), Backcompat test (enterprise/internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
-- **CI script tests**: test-trace-command.sh
-  - Upload build trace
+- Typescript eslint
+- Stylelint
+- Puppeteer tests for chrome extension
+- Test browser extension
+- Test shared client code
+- Test wildcard client code
+- E2E for chrome extension
+- Upload build trace
 
 ### Tagged release
 
@@ -96,12 +93,17 @@ The run type for tags starting with `v`.
 Default pipeline:
 
 - **Pipeline setup**: Trigger async
-- **Linters and static analysis**: Prettier, Misc Linters, GraphQL lint, SVG lint, Yarn deduplicate lint, Lint, security - checkov, Check and build docsite
+- **Image builds**: Build alpine-3.12, Build alpine-3.14, Build cadvisor, Build codeinsights-db, Build codeintel-db, Build frontend, Build github-proxy, Build gitserver, Build grafana, Build indexed-searcher, Build jaeger-agent, Build jaeger-all-in-one, Build minio, Build postgres-12.6-alpine, Build postgres_exporter, Build precise-code-intel-worker, Build prometheus, Build redis-cache, Build redis-store, Build redis_exporter, Build repo-updater, Build search-indexer, Build searcher, Build symbols, Build syntax-highlighter, Build worker, Build migrator, Build server
+- **Image security scans**: Scan alpine-3.12, Scan alpine-3.14, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan jaeger-agent, Scan jaeger-all-in-one, Scan minio, Scan postgres-12.6-alpine, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan symbols, Scan syntax-highlighter, Scan worker, Scan migrator, Scan server
+- **Linters and static analysis**: Prettier, Misc linters, GraphQL lint, SVG lint, Yarn deduplicate lint, Lint, Checkov Terraform scanning, Check and build docsite
 - **Client checks**: Puppeteer tests prep, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests finalize, Upload Storybook to Chromatic, Test shared client code, Test wildcard client code, Build, Enterprise build, Test, Puppeteer tests for chrome extension, Test browser extension, Test branded client code, Typescript eslint, Stylelint
 - **Go checks**: Test (all), Test (enterprise/internal/codeintel/stores/dbstore), Test (enterprise/internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
 - **DB backcompat tests**: Backcompat test (all), Backcompat test (enterprise/internal/codeintel/stores/dbstore), Backcompat test (enterprise/internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
 - **CI script tests**: test-trace-command.sh
-  - Upload build trace
+- **Integration tests**: Backend integration tests, Code Intel QA
+- **End-to-end tests**: Sourcegraph E2E, Sourcegraph QA, Sourcegraph Upgrade
+- **Publish images**: alpine-3.12, alpine-3.14, cadvisor, codeinsights-db, codeintel-db, frontend, github-proxy, gitserver, grafana, indexed-searcher, jaeger-agent, jaeger-all-in-one, minio, postgres-12.6-alpine, postgres_exporter, precise-code-intel-worker, prometheus, redis-cache, redis-store, redis_exporter, repo-updater, search-indexer, searcher, symbols, syntax-highlighter, worker, migrator, server
+- Upload build trace
 
 ### Release branch
 
@@ -110,12 +112,17 @@ The run type for branches matching `^[0-9]+\.[0-9]+$` (regexp match).
 Default pipeline:
 
 - **Pipeline setup**: Trigger async
-- **Linters and static analysis**: Prettier, Misc Linters, GraphQL lint, SVG lint, Yarn deduplicate lint, Lint, security - checkov, Check and build docsite
+- **Image builds**: Build alpine-3.12, Build alpine-3.14, Build cadvisor, Build codeinsights-db, Build codeintel-db, Build frontend, Build github-proxy, Build gitserver, Build grafana, Build indexed-searcher, Build jaeger-agent, Build jaeger-all-in-one, Build minio, Build postgres-12.6-alpine, Build postgres_exporter, Build precise-code-intel-worker, Build prometheus, Build redis-cache, Build redis-store, Build redis_exporter, Build repo-updater, Build search-indexer, Build searcher, Build symbols, Build syntax-highlighter, Build worker, Build migrator, Build server, Build executor image, Build docker registry mirror image
+- **Image security scans**: Scan alpine-3.12, Scan alpine-3.14, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan jaeger-agent, Scan jaeger-all-in-one, Scan minio, Scan postgres-12.6-alpine, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan symbols, Scan syntax-highlighter, Scan worker, Scan migrator, Scan server
+- **Linters and static analysis**: Prettier, Misc linters, GraphQL lint, SVG lint, Yarn deduplicate lint, Lint, Checkov Terraform scanning, Check and build docsite
 - **Client checks**: Puppeteer tests prep, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests finalize, Upload Storybook to Chromatic, Test shared client code, Test wildcard client code, Build, Enterprise build, Test, Puppeteer tests for chrome extension, Test browser extension, Test branded client code, Typescript eslint, Stylelint
 - **Go checks**: Test (all), Test (enterprise/internal/codeintel/stores/dbstore), Test (enterprise/internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
 - **DB backcompat tests**: Backcompat test (all), Backcompat test (enterprise/internal/codeintel/stores/dbstore), Backcompat test (enterprise/internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
 - **CI script tests**: test-trace-command.sh
-  - Upload build trace
+- **Integration tests**: Backend integration tests, Code Intel QA
+- **End-to-end tests**: Sourcegraph E2E, Sourcegraph QA, Sourcegraph Upgrade
+- **Publish images**: alpine-3.12, alpine-3.14, cadvisor, codeinsights-db, codeintel-db, frontend, github-proxy, gitserver, grafana, indexed-searcher, jaeger-agent, jaeger-all-in-one, minio, postgres-12.6-alpine, postgres_exporter, precise-code-intel-worker, prometheus, redis-cache, redis-store, redis_exporter, repo-updater, search-indexer, searcher, symbols, syntax-highlighter, worker, migrator, server, Publish executor image, Publish docker registry mirror image
+- Upload build trace
 
 ### Browser extension release build
 
@@ -123,13 +130,17 @@ The run type for branches matching `bext/release` (exact match).
 
 Default pipeline:
 
-- **Pipeline setup**: Trigger async
-- **Linters and static analysis**: Prettier, Misc Linters, GraphQL lint, SVG lint, Yarn deduplicate lint, Lint, security - checkov, Check and build docsite
-- **Client checks**: Puppeteer tests prep, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests finalize, Upload Storybook to Chromatic, Test shared client code, Test wildcard client code, Build, Enterprise build, Test, Puppeteer tests for chrome extension, Test browser extension, Test branded client code, Typescript eslint, Stylelint
-- **Go checks**: Test (all), Test (enterprise/internal/codeintel/stores/dbstore), Test (enterprise/internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
-- **DB backcompat tests**: Backcompat test (all), Backcompat test (enterprise/internal/codeintel/stores/dbstore), Backcompat test (enterprise/internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
-- **CI script tests**: test-trace-command.sh
-  - Upload build trace
+- Typescript eslint
+- Stylelint
+- Puppeteer tests for chrome extension
+- Test browser extension
+- Test shared client code
+- Test wildcard client code
+- E2E for chrome extension
+- Extension release
+- Extension release
+- NPM Release
+- Upload build trace
 
 ### Main branch
 
@@ -138,12 +149,17 @@ The run type for branches matching `main` (exact match).
 Default pipeline:
 
 - **Pipeline setup**: Trigger async
-- **Linters and static analysis**: Prettier, Misc Linters, GraphQL lint, SVG lint, Yarn deduplicate lint, Lint, security - checkov, Check and build docsite
+- **Image builds**: Build alpine-3.12, Build alpine-3.14, Build cadvisor, Build codeinsights-db, Build codeintel-db, Build frontend, Build github-proxy, Build gitserver, Build grafana, Build indexed-searcher, Build jaeger-agent, Build jaeger-all-in-one, Build minio, Build postgres-12.6-alpine, Build postgres_exporter, Build precise-code-intel-worker, Build prometheus, Build redis-cache, Build redis-store, Build redis_exporter, Build repo-updater, Build search-indexer, Build searcher, Build symbols, Build syntax-highlighter, Build worker, Build migrator, Build server, Build executor image, Build docker registry mirror image
+- **Image security scans**: Scan alpine-3.12, Scan alpine-3.14, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan jaeger-agent, Scan jaeger-all-in-one, Scan minio, Scan postgres-12.6-alpine, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan symbols, Scan syntax-highlighter, Scan worker, Scan migrator, Scan server
+- **Linters and static analysis**: Prettier, Misc linters, GraphQL lint, SVG lint, Yarn deduplicate lint, Lint, Checkov Terraform scanning, Check and build docsite
 - **Client checks**: Puppeteer tests prep, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests finalize, Upload Storybook to Chromatic, Test shared client code, Test wildcard client code, Build, Enterprise build, Test, Puppeteer tests for chrome extension, Test browser extension, Test branded client code, Typescript eslint, Stylelint
 - **Go checks**: Test (all), Test (enterprise/internal/codeintel/stores/dbstore), Test (enterprise/internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
 - **DB backcompat tests**: Backcompat test (all), Backcompat test (enterprise/internal/codeintel/stores/dbstore), Backcompat test (enterprise/internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
 - **CI script tests**: test-trace-command.sh
-  - Upload build trace
+- **Integration tests**: Backend integration tests, Code Intel QA
+- **End-to-end tests**: Sourcegraph E2E, Sourcegraph QA, Sourcegraph Upgrade
+- **Publish images**: alpine-3.12, alpine-3.14, cadvisor, codeinsights-db, codeintel-db, frontend, github-proxy, gitserver, grafana, indexed-searcher, jaeger-agent, jaeger-all-in-one, minio, postgres-12.6-alpine, postgres_exporter, precise-code-intel-worker, prometheus, redis-cache, redis-store, redis_exporter, repo-updater, search-indexer, searcher, symbols, syntax-highlighter, worker, migrator, server, Publish executor image, Publish docker registry mirror image
+- Upload build trace
 
 ### Main dry run
 
@@ -157,12 +173,17 @@ sg ci build main-dry-run
 Default pipeline:
 
 - **Pipeline setup**: Trigger async
-- **Linters and static analysis**: Prettier, Misc Linters, GraphQL lint, SVG lint, Yarn deduplicate lint, Lint, security - checkov, Check and build docsite
+- **Image builds**: Build alpine-3.12, Build alpine-3.14, Build cadvisor, Build codeinsights-db, Build codeintel-db, Build frontend, Build github-proxy, Build gitserver, Build grafana, Build indexed-searcher, Build jaeger-agent, Build jaeger-all-in-one, Build minio, Build postgres-12.6-alpine, Build postgres_exporter, Build precise-code-intel-worker, Build prometheus, Build redis-cache, Build redis-store, Build redis_exporter, Build repo-updater, Build search-indexer, Build searcher, Build symbols, Build syntax-highlighter, Build worker, Build migrator, Build server, Build executor image, Build docker registry mirror image
+- **Image security scans**: Scan alpine-3.12, Scan alpine-3.14, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan jaeger-agent, Scan jaeger-all-in-one, Scan minio, Scan postgres-12.6-alpine, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan symbols, Scan syntax-highlighter, Scan worker, Scan migrator, Scan server
+- **Linters and static analysis**: Prettier, Misc linters, GraphQL lint, SVG lint, Yarn deduplicate lint, Lint, Checkov Terraform scanning, Check and build docsite
 - **Client checks**: Puppeteer tests prep, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests finalize, Upload Storybook to Chromatic, Test shared client code, Test wildcard client code, Build, Enterprise build, Test, Puppeteer tests for chrome extension, Test browser extension, Test branded client code, Typescript eslint, Stylelint
 - **Go checks**: Test (all), Test (enterprise/internal/codeintel/stores/dbstore), Test (enterprise/internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
 - **DB backcompat tests**: Backcompat test (all), Backcompat test (enterprise/internal/codeintel/stores/dbstore), Backcompat test (enterprise/internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
 - **CI script tests**: test-trace-command.sh
-  - Upload build trace
+- **Integration tests**: Backend integration tests, Code Intel QA
+- **End-to-end tests**: Sourcegraph E2E, Sourcegraph QA, Sourcegraph Upgrade
+- **Publish images**: alpine-3.12, alpine-3.14, cadvisor, codeinsights-db, codeintel-db, frontend, github-proxy, gitserver, grafana, indexed-searcher, jaeger-agent, jaeger-all-in-one, minio, postgres-12.6-alpine, postgres_exporter, precise-code-intel-worker, prometheus, redis-cache, redis-store, redis_exporter, repo-updater, search-indexer, searcher, symbols, syntax-highlighter, worker, migrator, server
+- Upload build trace
 
 ### Patch image
 
@@ -173,15 +194,9 @@ You can create a build of this run type for your changes using:
 sg ci build docker-images-patch
 ```
 
-Default pipeline:
-
-- **Pipeline setup**: Trigger async
-- **Linters and static analysis**: Prettier, Misc Linters, GraphQL lint, SVG lint, Yarn deduplicate lint, Lint, security - checkov, Check and build docsite
-- **Client checks**: Puppeteer tests prep, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests finalize, Upload Storybook to Chromatic, Test shared client code, Test wildcard client code, Build, Enterprise build, Test, Puppeteer tests for chrome extension, Test browser extension, Test branded client code, Typescript eslint, Stylelint
-- **Go checks**: Test (all), Test (enterprise/internal/codeintel/stores/dbstore), Test (enterprise/internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
-- **DB backcompat tests**: Backcompat test (all), Backcompat test (enterprise/internal/codeintel/stores/dbstore), Backcompat test (enterprise/internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
-- **CI script tests**: test-trace-command.sh
-  - Upload build trace
+<!--
+no image "" found
+-->
 
 ### Patch image without testing
 
@@ -192,15 +207,9 @@ You can create a build of this run type for your changes using:
 sg ci build docker-images-patch-notest
 ```
 
-Default pipeline:
-
-- **Pipeline setup**: Trigger async
-- **Linters and static analysis**: Prettier, Misc Linters, GraphQL lint, SVG lint, Yarn deduplicate lint, Lint, security - checkov, Check and build docsite
-- **Client checks**: Puppeteer tests prep, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests finalize, Upload Storybook to Chromatic, Test shared client code, Test wildcard client code, Build, Enterprise build, Test, Puppeteer tests for chrome extension, Test browser extension, Test branded client code, Typescript eslint, Stylelint
-- **Go checks**: Test (all), Test (enterprise/internal/codeintel/stores/dbstore), Test (enterprise/internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
-- **DB backcompat tests**: Backcompat test (all), Backcompat test (enterprise/internal/codeintel/stores/dbstore), Backcompat test (enterprise/internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
-- **CI script tests**: test-trace-command.sh
-  - Upload build trace
+<!--
+no image "" found
+-->
 
 ### Build all candidates without testing
 
@@ -213,13 +222,35 @@ sg ci build docker-images-candidates-notest
 
 Default pipeline:
 
-- **Pipeline setup**: Trigger async
-- **Linters and static analysis**: Prettier, Misc Linters, GraphQL lint, SVG lint, Yarn deduplicate lint, Lint, security - checkov, Check and build docsite
-- **Client checks**: Puppeteer tests prep, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests finalize, Upload Storybook to Chromatic, Test shared client code, Test wildcard client code, Build, Enterprise build, Test, Puppeteer tests for chrome extension, Test browser extension, Test branded client code, Typescript eslint, Stylelint
-- **Go checks**: Test (all), Test (enterprise/internal/codeintel/stores/dbstore), Test (enterprise/internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
-- **DB backcompat tests**: Backcompat test (all), Backcompat test (enterprise/internal/codeintel/stores/dbstore), Backcompat test (enterprise/internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
-- **CI script tests**: test-trace-command.sh
-  - Upload build trace
+- Build alpine-3.12
+- Build alpine-3.14
+- Build cadvisor
+- Build codeinsights-db
+- Build codeintel-db
+- Build frontend
+- Build github-proxy
+- Build gitserver
+- Build grafana
+- Build indexed-searcher
+- Build jaeger-agent
+- Build jaeger-all-in-one
+- Build minio
+- Build postgres-12.6-alpine
+- Build postgres_exporter
+- Build precise-code-intel-worker
+- Build prometheus
+- Build redis-cache
+- Build redis-store
+- Build redis_exporter
+- Build repo-updater
+- Build search-indexer
+- Build searcher
+- Build symbols
+- Build syntax-highlighter
+- Build worker
+- Build migrator
+- Build server
+- Upload build trace
 
 ### Build executor without testing
 
@@ -232,13 +263,11 @@ sg ci build executor-patch-notest
 
 Default pipeline:
 
-- **Pipeline setup**: Trigger async
-- **Linters and static analysis**: Prettier, Misc Linters, GraphQL lint, SVG lint, Yarn deduplicate lint, Lint, security - checkov, Check and build docsite
-- **Client checks**: Puppeteer tests prep, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests finalize, Upload Storybook to Chromatic, Test shared client code, Test wildcard client code, Build, Enterprise build, Test, Puppeteer tests for chrome extension, Test browser extension, Test branded client code, Typescript eslint, Stylelint
-- **Go checks**: Test (all), Test (enterprise/internal/codeintel/stores/dbstore), Test (enterprise/internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
-- **DB backcompat tests**: Backcompat test (all), Backcompat test (enterprise/internal/codeintel/stores/dbstore), Backcompat test (enterprise/internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
-- **CI script tests**: test-trace-command.sh
-  - Upload build trace
+- Build executor image
+- Publish executor image
+- Build docker registry mirror image
+- Publish docker registry mirror image
+- Upload build trace
 
 ### Backend integration tests
 
@@ -251,10 +280,11 @@ sg ci build backend-integration
 
 Default pipeline:
 
-- **Pipeline setup**: Trigger async
-- **Linters and static analysis**: Prettier, Misc Linters, GraphQL lint, SVG lint, Yarn deduplicate lint, Lint, security - checkov, Check and build docsite
+- Build server
+- Backend integration tests
+- **Linters and static analysis**: Prettier, Misc linters, GraphQL lint, SVG lint, Yarn deduplicate lint, Lint, Checkov Terraform scanning, Check and build docsite
 - **Client checks**: Puppeteer tests prep, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests finalize, Upload Storybook to Chromatic, Test shared client code, Test wildcard client code, Build, Enterprise build, Test, Puppeteer tests for chrome extension, Test browser extension, Test branded client code, Typescript eslint, Stylelint
 - **Go checks**: Test (all), Test (enterprise/internal/codeintel/stores/dbstore), Test (enterprise/internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
 - **DB backcompat tests**: Backcompat test (all), Backcompat test (enterprise/internal/codeintel/stores/dbstore), Backcompat test (enterprise/internal/codeintel/stores/lsifstore), Backcompat test (enterprise/internal/insights), Backcompat test (internal/database), Backcompat test (internal/repos), Backcompat test (enterprise/internal/batches), Backcompat test (cmd/frontend), Backcompat test (enterprise/internal/database), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers)
 - **CI script tests**: test-trace-command.sh
-  - Upload build trace
+- Upload build trace

--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -162,19 +162,29 @@ func renderPipelineDocs(w io.Writer) {
 					strings.TrimRight(m.Branch, "/"))
 			}
 
-			// Generate a sample pipeline with all changes
-			pipeline, err := ci.GeneratePipeline(ci.Config{
-				RunType: runtype.PullRequest,
-				Diff:    changed.All,
-				Branch:  m.Branch,
-			})
-			if err != nil {
-				log.Fatalf("Generating pipeline for RunType %q: %s", rt.String(), err)
-			}
-			fmt.Fprint(w, "\nDefault pipeline:\n\n")
-			for _, raw := range pipeline.Steps {
-				printStepSummary(w, "", raw)
-			}
+			// Generate a sample pipeline with all changes. If it panics just don't bother
+			// generating a sample for now - it's usually because a special branch name
+			// parameter is needed.
+			func() {
+				defer func() {
+					if err := recover(); err != nil {
+						fmt.Fprintf(w, "\n<!--\n%+v\n-->\n", err)
+					}
+				}()
+
+				pipeline, err := ci.GeneratePipeline(ci.Config{
+					RunType: rt,
+					Diff:    changed.All,
+					Branch:  m.Branch,
+				})
+				if err != nil {
+					log.Fatalf("Generating pipeline for RunType %q: %s", rt.String(), err)
+				}
+				fmt.Fprint(w, "\nDefault pipeline:\n\n")
+				for _, raw := range pipeline.Steps {
+					printStepSummary(w, "", raw)
+				}
+			}()
 		}
 	}
 }
@@ -182,7 +192,7 @@ func renderPipelineDocs(w io.Writer) {
 func printStepSummary(w io.Writer, indent string, rawStep interface{}) {
 	switch v := rawStep.(type) {
 	case *buildkite.Step:
-		fmt.Fprintf(w, "  - %s\n", trimEmoji(v.Label))
+		fmt.Fprintf(w, "%s- %s\n", indent, trimEmoji(v.Label))
 	case *buildkite.Pipeline:
 		var steps []string
 		for _, step := range v.Steps {

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -61,7 +61,7 @@ func CoreTestOperations(diff changed.Diff, opts CoreTestOperationsOptions) *oper
 		linterOps.Append(addDockerfileLint)
 	}
 	if diff.Has(changed.Terraform) {
-		linterOps.Append(addTerraformLint)
+		linterOps.Append(addTerraformScan)
 	}
 	if diff.Has(changed.Docs) {
 		linterOps.Append(addDocs)
@@ -127,15 +127,15 @@ func addDocs(pipeline *bk.Pipeline) {
 }
 
 // Adds the terraform scanner step.  This executes very quickly ~6s
-func addTerraformLint(pipeline *bk.Pipeline) {
-	pipeline.AddStep(":lock: security - checkov",
+func addTerraformScan(pipeline *bk.Pipeline) {
+	pipeline.AddStep(":lock: Checkov Terraform scanning",
 		bk.Cmd("dev/ci/ci-checkov.sh"),
 		bk.SoftFail(222))
 }
 
 // Adds the static check test step.
 func addCheck(pipeline *bk.Pipeline) {
-	pipeline.AddStep(":clipboard: Misc Linters",
+	pipeline.AddStep(":clipboard: Misc linters",
 		withYarnCache(),
 		bk.AnnotatedCmd("./dev/check/all.sh", bk.AnnotatedCmdOpts{
 			IncludeNames: true,
@@ -644,7 +644,7 @@ func buildCandidateDockerImage(app, version, tag string) operations.Operation {
 			bk.Cmd(fmt.Sprintf("docker push %s", devImage)),
 		)
 
-		pipeline.AddStep(fmt.Sprintf(":docker: :construction: %s", app), cmds...)
+		pipeline.AddStep(fmt.Sprintf(":docker: :construction: Build %s", app), cmds...)
 	}
 }
 
@@ -659,7 +659,7 @@ func trivyScanCandidateImage(app, tag string) operations.Operation {
 	vulnerabilityExitCode := 27
 
 	return func(pipeline *bk.Pipeline) {
-		pipeline.AddStep(fmt.Sprintf(":trivy: :docker: :mag: %s", app),
+		pipeline.AddStep(fmt.Sprintf(":trivy: :docker: :mag: Scan %s", app),
 			bk.DependsOn(candidateImageStepKey(app)),
 
 			bk.Cmd(fmt.Sprintf("docker pull %s", image)),
@@ -746,7 +746,7 @@ func buildExecutor(version string, skipHashCompare bool) operations.Operation {
 		stepOpts = append(stepOpts,
 			bk.Cmd("./enterprise/cmd/executor/build.sh"))
 
-		pipeline.AddStep(":packer: :construction: executor image", stepOpts...)
+		pipeline.AddStep(":packer: :construction: Build executor image", stepOpts...)
 	}
 }
 
@@ -768,7 +768,7 @@ func publishExecutor(version string, skipHashCompare bool) operations.Operation 
 		stepOpts = append(stepOpts,
 			bk.Cmd("./enterprise/cmd/executor/release.sh"))
 
-		pipeline.AddStep(":packer: :white_check_mark: executor image", stepOpts...)
+		pipeline.AddStep(":packer: :white_check_mark: Publish executor image", stepOpts...)
 	}
 }
 
@@ -782,7 +782,7 @@ func buildExecutorDockerMirror(version string) operations.Operation {
 		stepOpts = append(stepOpts,
 			bk.Cmd("./enterprise/cmd/executor/docker-mirror/build.sh"))
 
-		pipeline.AddStep(":packer: :construction: docker registry mirror image", stepOpts...)
+		pipeline.AddStep(":packer: :construction: Build docker registry mirror image", stepOpts...)
 	}
 }
 
@@ -796,7 +796,7 @@ func publishExecutorDockerMirror(version string) operations.Operation {
 		stepOpts = append(stepOpts,
 			bk.Cmd("./enterprise/cmd/executor/docker-mirror/release.sh"))
 
-		pipeline.AddStep(":packer: :white_check_mark: docker registry mirror image", stepOpts...)
+		pipeline.AddStep(":packer: :white_check_mark: Publish docker registry mirror image", stepOpts...)
 	}
 }
 

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -174,11 +174,14 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 
 	case runtype.ImagePatchNoTest:
 		// If this is a no-test branch, then run only the Docker build. No tests are run.
-		app := c.Branch[27:]
+		patchImage := c.Branch[27:]
+		if !contains(images.SourcegraphDockerImages, patchImage) {
+			panic(fmt.Sprintf("no image %q found", patchImage))
+		}
 		ops = operations.NewSet(
-			buildCandidateDockerImage(app, c.Version, c.candidateImageTag()),
+			buildCandidateDockerImage(patchImage, c.Version, c.candidateImageTag()),
 			wait,
-			publishFinalDockerImage(c, app))
+			publishFinalDockerImage(c, patchImage))
 
 	case runtype.CandidatesNoTest:
 		for _, dockerImage := range images.SourcegraphDockerImages {


### PR DESCRIPTION
I noticed this while working on https://github.com/sourcegraph/sourcegraph/pull/31096 🤦 The reference docs weren't actually generating pipelines for the special run types, it was hardcoded to `PullRequest`. This PR fixes that and makes some minor adjustments:

- Rename some steps for readability
- Prefix `Build` and `Publish` to relevant steps for readability
- Recover from panic on runtype reference generation, because some require an argument. Going to leave rendering those docs as a follow-up.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

```
sg ci docs
sg run docsite
```

http://localhost:5080/dev/background-information/ci/reference

<img width="898" alt="image" src="https://user-images.githubusercontent.com/23356519/153667495-5e659110-f52c-4d9c-8ca5-e9a35bbfdcc2.png">

