### PR TITLE
dev/ci: generate notifications for release nightly builds

### DIFF
--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -22,11 +22,14 @@ import (
 var preview bool
 var wantYaml bool
 var docs bool
+var overrideRunType int
 
 func init() {
 	flag.BoolVar(&preview, "preview", false, "Preview the pipeline steps")
 	flag.BoolVar(&wantYaml, "yaml", false, "Use YAML instead of JSON")
 	flag.BoolVar(&docs, "docs", false, "Render generated documentation")
+	// For testing purposes
+	flag.IntVar(&overrideRunType, "overrideRunType", -1, "Override inferred run type")
 }
 
 //go:generate sh -c "cd ../../../ && echo '<!-- DO NOT EDIT: generated via: go generate ./enterprise/dev/ci -->\n' > doc/dev/background-information/ci/reference.md"
@@ -46,6 +49,9 @@ func main() {
 	if buildkite.FeatureFlags.StatelessBuild {
 		// We do not want to trigger any deployment.
 		config.RunType = runtype.MainDryRun
+	}
+	if overrideRunType > -1 {
+		config.RunType = runtype.RunType(overrideRunType)
 	}
 
 	pipeline, err := ci.GeneratePipeline(config)

--- a/enterprise/dev/ci/internal/buildkite/buildkite.go
+++ b/enterprise/dev/ci/internal/buildkite/buildkite.go
@@ -203,8 +203,9 @@ func (p *Pipeline) AddFailureSlackNotify(channel string, mentionUserID string, e
 
 	if mentionUserID != "" {
 		n.Message = fmt.Sprintf("cc <@%s>", mentionUserID)
-	} else if err != nil {
-		n.Message = err.Error()
+	}
+	if err != nil {
+		n.Message = strings.Join([]string{n.Message, err.Error()}, " ")
 	}
 	p.Notify = append(p.Notify, slackNotifier{
 		Slack: n,

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -21,7 +21,6 @@ import (
 	bk "github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/buildkite"
 	"github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/ci/changed"
 	"github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/ci/operations"
-	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -280,19 +279,18 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 }
 
 func addNotifyBlocks(ctx context.Context, pipeline *bk.Pipeline, c Config) {
-	// Slack client for retriving Slack profile data, not for making the request - for
-	// more details, see the config.Notify docstring.
-	slc := slack.New(c.Notify.SlackToken)
-
-	// For now, we use an unauthenticated GitHub client because `sourcegraph/sourcegraph`
-	// is a public repository.
-	ghc := github.NewClient(http.DefaultClient)
-
-	// Get teammate based on GitHub author of commit
-	teammates := team.NewTeammateResolver(ghc, slc)
-
-	// Add a notify block
 	if c.RunType.Is(runtype.MainBranch) {
+		// Slack client for retriving Slack profile data, not for making the request - for
+		// more details, see the config.Notify docstring.
+		slc := slack.New(c.Notify.SlackToken)
+
+		// For now, we use an unauthenticated GitHub client because `sourcegraph/sourcegraph`
+		// is a public repository.
+		ghc := github.NewClient(http.DefaultClient)
+
+		// Get teammate based on GitHub author of commit
+		teammates := team.NewTeammateResolver(ghc, slc)
+
 		tm, err := teammates.ResolveByCommitAuthor(ctx, "sourcegraph", "sourcegraph", c.Commit)
 		if err != nil {
 			pipeline.AddFailureSlackNotify(c.Notify.Channel, "", errors.Newf("failed to get Slack user: %w", err))
@@ -300,25 +298,8 @@ func addNotifyBlocks(ctx context.Context, pipeline *bk.Pipeline, c Config) {
 			pipeline.AddFailureSlackNotify(c.Notify.Channel, tm.SlackID, nil)
 		}
 	}
-
 	if c.RunType.Is(runtype.ReleaseNightly) {
-		releaseConfigData, err := os.ReadFile("./dev/release/release-config.jsonc")
-		if err == nil {
-			var releaseConfig struct {
-				CaptainGitHubUsername string `json:"captainGitHubUsername"`
-			}
-			if err = jsonc.Unmarshal(string(releaseConfigData), &releaseConfig); err == nil {
-				var tm *team.Teammate
-				tm, err = teammates.ResolveByGitHubHandle(ctx, releaseConfig.CaptainGitHubUsername)
-				if err == nil {
-					pipeline.AddFailureSlackNotify(c.Notify.Channel, tm.SlackID, nil)
-				}
-			}
-		}
-
-		if err != nil {
-			pipeline.AddFailureSlackNotify(c.Notify.Channel, "dev-experience-support", err)
-		}
+		pipeline.AddFailureSlackNotify(c.Notify.Channel, "release-guild", nil)
 	}
 }
 


### PR DESCRIPTION
Release nightly healthchecks, if failed, will now try to tag either a Slack user based on `captainGitHubUsername`  or the dev experience support handle. I noticed this request in [RFC 590](https://docs.google.com/document/d/1C--cw5ZC-OUsQT7sbe3GboDxOGHs16KB0jM_F0BAWVI/edit#)

We cannot use Slack usernames for tagging because doing so is not supported by Buildkite/Slack.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

```sh
export SLACK_INTEGRATION_TOKEN=...
go run enterprise/dev/ci/gen-pipeline.go -overrideRunType=1 -yaml
```

You get:

```yaml
notify:
- if: build.state == "failed"
  slack:
    channels:
    - '#buildkite-main'
    message: cc <@U02UJSAEQP9>
```

The above is @michaellzc , current release captain