### PR TITLE
symbols: Fix "too many SQL variables"

### DIFF
--- a/cmd/symbols/internal/database/store/symbols.go
+++ b/cmd/symbols/internal/database/store/symbols.go
@@ -49,16 +49,14 @@ func (s *store) CreateSymbolIndexes(ctx context.Context) error {
 }
 
 func (s *store) DeletePaths(ctx context.Context, paths []string) error {
-	if len(paths) == 0 {
-		return nil
-	}
-
-	pathQueries := make([]*sqlf.Query, 0, len(paths))
 	for _, path := range paths {
-		pathQueries = append(pathQueries, sqlf.Sprintf("%s", path))
+		err := s.Exec(ctx, sqlf.Sprintf(`DELETE FROM symbols WHERE path = %s`, path))
+		if err != nil {
+			return err
+		}
 	}
 
-	return s.Exec(ctx, sqlf.Sprintf(`DELETE FROM symbols WHERE path IN (%s)`, sqlf.Join(pathQueries, ",")))
+	return nil
 }
 
 func (s *store) WriteSymbols(ctx context.Context, symbolOrErrors <-chan parser.SymbolOrError) (err error) {

--- a/cmd/symbols/internal/database/store/symbols.go
+++ b/cmd/symbols/internal/database/store/symbols.go
@@ -49,7 +49,7 @@ func (s *store) CreateSymbolIndexes(ctx context.Context) error {
 }
 
 func (s *store) DeletePaths(ctx context.Context, paths []string) error {
-	for _, chunkOfPaths := range chunksOf(1000, paths) {
+	for _, chunkOfPaths := range chunksOf1000(paths) {
 		pathQueries := []*sqlf.Query{}
 		for _, path := range chunkOfPaths {
 			pathQueries = append(pathQueries, sqlf.Sprintf("%s", path))
@@ -64,11 +64,15 @@ func (s *store) DeletePaths(ctx context.Context, paths []string) error {
 	return nil
 }
 
-func chunksOf(n int, strings []string) [][]string {
-	var chunks [][]string
+func chunksOf1000(strings []string) [][]string {
+	if strings == nil {
+		return nil
+	}
 
-	for i := 0; i < len(strings); i += n {
-		end := i + n
+	chunks := [][]string{}
+
+	for i := 0; i < len(strings); i += 1000 {
+		end := i + 1000
 
 		if end > len(strings) {
 			end = len(strings)

--- a/cmd/symbols/internal/database/store/symbols_test.go
+++ b/cmd/symbols/internal/database/store/symbols_test.go
@@ -1,0 +1,36 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestChunksOf(t *testing.T) {
+	if chunksOf1000(nil) != nil {
+		t.Fatalf("got %v, want nil", chunksOf1000(nil))
+	}
+
+	if diff := cmp.Diff([][]string{}, chunksOf1000([]string{})); diff != "" {
+		t.Fatalf("unexpected chunks (-want +got):\n%s", diff)
+	}
+
+	if diff := cmp.Diff([][]string{{"foo"}}, chunksOf1000([]string{"foo"})); diff != "" {
+		t.Fatalf("unexpected chunks (-want +got):\n%s", diff)
+	}
+
+	strings := []string{}
+	for i := 0; i < 1001; i++ {
+		strings = append(strings, "foo")
+	}
+	chunks := chunksOf1000(strings)
+	if len(chunks) != 2 {
+		t.Fatalf("got %v, want 2", len(chunks))
+	}
+	if len(chunks[0]) != 1000 {
+		t.Fatalf("got %v, want 1000", len(chunks[0]))
+	}
+	if len(chunks[1]) != 1 {
+		t.Fatalf("got %v, want 1", len(chunks[1]))
+	}
+}


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/27986 switched from deleting one path at a time to deleting all paths in one SQL query. The number of paths is unbounded, and we hit the limit on Sourcegraph.com:

`t=2022-02-11T22:56:12+0000 lvl=eror msg="diskcache.Cached Fetch" error="failed to fetch missing archive cache item: databaseWriter.WriteDBFile: store.DeletePaths: too many SQL variables" count=1.000 elapsed=5.384 component=symbols`

This reverts the behavior back to deleting one path at a time. Deleting 3287 paths took 197ms before this change and 204ms after.

This problem could be causing https://github.com/sourcegraph/sourcegraph/issues/28457

## Test plan

Saved a SQLite DB that had paths deleted by running `sqlite3 file.zip .dump` from before and after this change, sorted, and compared them with `diff`. No difference.