### PR TITLE
v2.0.8: Add utm, eventName for saveSearchForm, fix link issue for web

### DIFF
--- a/client/search-ui/src/input/SearchHelpDropdownButton.tsx
+++ b/client/search-ui/src/input/SearchHelpDropdownButton.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useState } from 'react'
 import { DropdownItem, DropdownMenu, DropdownToggle, ButtonDropdown } from 'reactstrap'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { Link } from '@sourcegraph/wildcard'
 
 interface SearchHelpDropdownButtonProps extends TelemetryProps {
     isSourcegraphDotCom?: boolean
@@ -114,15 +115,15 @@ export const SearchHelpDropdownButton: React.FunctionComponent<SearchHelpDropdow
                     </li>
                 </ul>
                 <DropdownItem divider={true} className="mb-0" />
-                <a
+                <Link
                     target="_blank"
                     rel="noopener"
-                    href={`${documentationUrlPrefix}/code_search/reference/queries`}
                     className="dropdown-item"
                     onClick={onQueryDocumentationLinkClicked}
+                    to={`${documentationUrlPrefix}/code_search/reference/queries`}
                 >
                     <ExternalLinkIcon className="icon-inline small" /> All search keywords
-                </a>
+                </Link>
                 {isSourcegraphDotCom && (
                     <div className="alert alert-info small rounded-0 mb-0 mt-1">
                         On Sourcegraph.com, use a <code>repo:</code> filter to narrow your search to &le;500

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "sourcegraph",
   "displayName": "Sourcegraph",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Sourcegraph for VS Code",
   "publisher": "sourcegraph",
   "sideEffects": false,

--- a/client/vscode/src/link-commands/initialize.ts
+++ b/client/vscode/src/link-commands/initialize.ts
@@ -47,9 +47,12 @@ export function generateSourcegraphBlobLink(
     endLine: number,
     endChar: number
 ): string {
+    const instanceUrl = vscode.workspace.getConfiguration('sourcegraph').get<string>('url') || 'https://sourcegraph.com'
     // Using SourcegraphUri.parse to properly decode repo revision
     const decodedUri = SourcegraphUri.parse(uri.toString()).uri
-    return `${decodedUri.replace(uri.scheme, 'https')}?L${encodeURIComponent(String(startLine))}:${encodeURIComponent(
-        String(startChar)
-    )}-${encodeURIComponent(String(endLine))}:${encodeURIComponent(String(endChar))}${vsceUtms}`
+    return `${decodedUri.replace(uri.scheme, instanceUrl.startsWith('https') ? 'https' : 'http')}?L${encodeURIComponent(
+        String(startLine)
+    )}:${encodeURIComponent(String(startChar))}-${encodeURIComponent(String(endLine))}:${encodeURIComponent(
+        String(endChar)
+    )}${vsceUtms}`
 }

--- a/client/vscode/src/webview/search-panel/alias/Link.tsx
+++ b/client/vscode/src/webview/search-panel/alias/Link.tsx
@@ -1,0 +1,133 @@
+import classNames from 'classnames'
+import * as H from 'history'
+import isAbsoluteUrl from 'is-absolute-url'
+import React from 'react'
+
+import styles from '@sourcegraph/wildcard/src/components/Link/AnchorLink/AnchorLink.module.scss'
+import { useWildcardTheme } from '@sourcegraph/wildcard/src/hooks/useWildcardTheme'
+
+export interface LinkProps
+    extends Pick<
+        React.AnchorHTMLAttributes<HTMLAnchorElement>,
+        Exclude<keyof React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>
+    > {
+    to: string | H.LocationDescriptor<any>
+    ref?: React.Ref<HTMLAnchorElement>
+}
+
+/**
+ * The component used to render a link. All shared code must use this component for links—not <a>, <Link>, etc.
+ *
+ * Different platforms (web app vs. browser extension) require the use of different link components:
+ *
+ * The web app uses <RouterLinkOrAnchor>, which uses react-router-dom's <Link> for relative URLs (for page
+ * navigation using the HTML history API) and <a> for absolute URLs. The react-router-dom <Link> component only
+ * works inside a react-router <BrowserRouter> context, so it wouldn't work in the browser extension.
+ *
+ * The browser extension uses <a> for everything (because code hosts don't generally use react-router). A
+ * react-router-dom <Link> wouldn't work in the browser extension, because there is no <BrowserRouter>.
+ *
+ * This variable must be set at initialization time by calling {@link setLinkComponent}.
+ *
+ * The `to` property holds the destination URL (do not use `href`). If <a> is used, the `to` property value is
+ * given as the `href` property value on the <a> element.
+ *
+ * @see setLinkComponent
+ */
+export let Link: React.FunctionComponent<LinkProps> = ({ to, children, ...props }) => (
+    <a
+        href={checkLink(to && typeof to !== 'string' ? H.createPath(to) : to)}
+        id={to && typeof to !== 'string' ? H.createPath(to) : to}
+        {...props}
+    >
+        {children}
+    </a>
+)
+
+if (process.env.NODE_ENV !== 'production') {
+    // Fail with helpful message if setLinkComponent has not been called when the <Link> component is used.
+    Link = () => {
+        throw new Error('No Link component set. You must call setLinkComponent to set the Link component to use.')
+    }
+}
+
+/**
+ * Sets (globally) the component to use for links. This must be set at initialization time.
+ *
+ * @see Link
+ * @see AnchorLink
+ */
+export function setLinkComponent(component: typeof Link): void {
+    Link = component
+}
+
+export type AnchorLinkProps = LinkProps & {
+    as?: LinkComponent
+}
+
+export type LinkComponent = React.FunctionComponent<LinkProps>
+
+export const AnchorLink: React.FunctionComponent<AnchorLinkProps> = React.forwardRef(
+    ({ to, as: Component, children, className, ...rest }: AnchorLinkProps, reference) => {
+        const { isBranded } = useWildcardTheme()
+
+        const commonProps = {
+            ref: reference,
+            className: classNames(isBranded && styles.anchorLink, className),
+        }
+
+        if (!Component) {
+            return (
+                <a href={checkLink(to && typeof to !== 'string' ? H.createPath(to) : to)} {...rest} {...commonProps}>
+                    {children}
+                </a>
+            )
+        }
+
+        return (
+            <Component to={to} {...rest} {...commonProps}>
+                {children}
+            </Component>
+        )
+    }
+)
+
+/**
+ * Uses react-router-dom's <Link> for relative URLs, <a> for absolute URLs. This is useful because passing an
+ * absolute URL to <Link> will create an (almost certainly invalid) URL where the absolute URL is resolved to the
+ * current URL, such as https://example.com/a/b/https://example.com/c/d.
+ */
+export const RouterLink: React.FunctionComponent<AnchorLinkProps> = React.forwardRef(
+    ({ to, children, ...rest }: AnchorLinkProps, reference) => (
+        <AnchorLink
+            to={checkLink(to && typeof to !== 'string' ? H.createPath(to) : to)}
+            as={typeof to === 'string' && isAbsoluteUrl(to) ? undefined : Link}
+            {...rest}
+            ref={reference}
+        >
+            {children}
+        </AnchorLink>
+    )
+)
+
+/**
+ * Check if link is valid
+ * Set invalid links to '#' because VS Code Web opens invalid links in new tabs
+ * Invalid links includes links that start with 'sourcegraph://'
+ */
+function checkLink(uri: string): string {
+    // Private instance user are required to provide access token
+    // This is for users who has not provide an access token and is using dotcom by default
+    if (
+        uri.startsWith('/sign-up') ||
+        uri.startsWith('/contexts') ||
+        uri.startsWith('/code_search/reference/queries') ||
+        uri.startsWith('/help')
+    ) {
+        return `https://sourcegraph.com${uri}?editor=vscode&utm_medium=VSCIDE&utm_source=sidebar&utm_campaign=vsce-sign-up&utm_content=sign-up`
+    }
+    if (uri.startsWith('https://')) {
+        return uri
+    }
+    return '#'
+}

--- a/client/vscode/src/webview/search-panel/components/ButtonDropdownCta.tsx
+++ b/client/vscode/src/webview/search-panel/components/ButtonDropdownCta.tsx
@@ -54,12 +54,12 @@ export const ButtonDropdownCta: React.FunctionComponent<ButtonDropdownCtaProps> 
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isDropdownOpen])
 
-    const signUpURL = new URL(
-        `/sign-up?src=${source}&returnTo=${encodeURIComponent(
-            returnTo
-        )}&utm_medium=VSCIDE&utm_source=sidebar&utm_campaign=vsce-sign-up&utm_content=sign-up`,
-        instanceURL
-    )
+    // Use cloud url instead of instance url
+    // This will only display for non private uers
+    // Because private users are required use with token = signed up
+    const signUpURL = `https://sourcegraph.com/sign-up?src=${source}&returnTo=${encodeURIComponent(
+        returnTo
+    )}&utm_medium=VSCIDE&utm_source=sidebar&utm_campaign=vsce-sign-up&utm_content=sign-up`
 
     return (
         <ButtonDropdown className="menu-nav-item" direction="down" isOpen={isDropdownOpen} toggle={toggleDropdownOpen}>
@@ -86,7 +86,7 @@ export const ButtonDropdownCta: React.FunctionComponent<ButtonDropdownCtaProps> 
                         <div className={classNames('text-muted', styles.copyText)}>{copyText}</div>
                     </div>
                 </div>
-                <Button to={signUpURL.href} onClick={onClick} variant="primary" as={Link}>
+                <Button to={signUpURL} onClick={onClick} variant="primary" as={Link}>
                     Sign up for Sourcegraph
                 </Button>
             </DropdownMenu>

--- a/client/vscode/src/webview/search-panel/components/SavedSearchForm.tsx
+++ b/client/vscode/src/webview/search-panel/components/SavedSearchForm.tsx
@@ -7,7 +7,7 @@ import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { Form } from '@sourcegraph/branded/src/components/Form'
 import { dataOrThrowErrors, gql } from '@sourcegraph/http-client'
 import { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
-import { Container, Link, PageHeader, ProductStatusBadge } from '@sourcegraph/wildcard'
+import { Container, PageHeader } from '@sourcegraph/wildcard'
 
 import { CreateSavedSearchResult, CreateSavedSearchVariables, SavedSearchFields } from '../../../graphql-operations'
 import { WebviewPageProps } from '../../platform/context'
@@ -79,7 +79,7 @@ export const SavedSearchCreateForm: React.FunctionComponent<SavedSearchCreateFor
     const onSubmit: SavedSearchFormProps['onSubmit'] = fields => {
         if (!loading) {
             setLoading(true)
-
+            props.platformContext.telemetryService.log('VSCESaveSearchSubmited')
             props.platformContext
                 .requestGraphQL<CreateSavedSearchResult, CreateSavedSearchVariables>({
                     request: createSavedSearchQuery,
@@ -155,13 +155,6 @@ const SavedSearchForm: React.FunctionComponent<SavedSearchFormProps> = props => 
         return notifying && !values.query.includes('type:diff') && !values.query.includes('type:commit')
     }, [values])
 
-    const codeMonitoringUrl = useMemo(() => {
-        const searchParameters = new URLSearchParams()
-        searchParameters.set('trigger-query', values.query)
-        searchParameters.set('description', values.description)
-        return `/code-monitoring/new?${searchParameters.toString()}`
-    }, [values.query, values.description])
-
     const { query, description, notify, notifySlack, slackWebhookURL } = values
 
     return (
@@ -224,16 +217,6 @@ const SavedSearchForm: React.FunctionComponent<SavedSearchFormProps> = props => 
                                     <span>Send email notifications to my email</span>
                                 </label>
                             </div>
-
-                            <div className={classNames(styles.codeMonitoringAlert, 'alert alert-primary p-3 mb-0')}>
-                                <div className="mb-2">
-                                    <strong>New:</strong> Watch your code for changes with code monitoring to get
-                                    notifications.
-                                </div>
-                                <Link to={codeMonitoringUrl} className="btn btn-primary">
-                                    Go to code monitoring →
-                                </Link>
-                            </div>
                         </div>
                     )}
 
@@ -278,18 +261,6 @@ const SavedSearchForm: React.FunctionComponent<SavedSearchFormProps> = props => 
                 </button>
 
                 {props.error && !props.loading && <ErrorAlert className="mb-3" error={props.error} />}
-
-                {!props.defaultValues?.notify && (
-                    <Container className="d-flex p-3 align-items-start">
-                        <ProductStatusBadge status="new" className="mr-3">
-                            New
-                        </ProductStatusBadge>
-                        <span>
-                            Watch for changes to your code and trigger email notifications, webhooks, and more with{' '}
-                            <Link to={`${props.instanceURL}/code-monitoring`}>code monitoring →</Link>
-                        </span>
-                    </Container>
-                )}
             </Form>
         </div>
     )

--- a/client/vscode/src/webview/search-sidebar/AuthSidebarView.tsx
+++ b/client/vscode/src/webview/search-sidebar/AuthSidebarView.tsx
@@ -30,9 +30,8 @@ export const AuthSidebarView: React.FunctionComponent<AuthSidebarViewProps> = ({
 
     const [hasAccount, setHasAccount] = useState(false)
 
-    const signUpURL = useMemo(() => new URL('sign-up?editor=vscode&' + SIDEBAR_UTM_PARAMS, instanceURL).href, [
-        instanceURL,
-    ])
+    const signUpURL = `https://sourcegraph.com/sign-up?editor=vscode&${SIDEBAR_UTM_PARAMS}`
+
     const instanceHostname = useMemo(() => new URL(instanceURL).hostname, [instanceURL])
 
     const validateAccessToken: React.FormEventHandler<HTMLFormElement> = (event): void => {

--- a/client/vscode/webpack.config.js
+++ b/client/vscode/webpack.config.js
@@ -120,6 +120,7 @@ const webviewConfig = {
   resolve: {
     alias: {
       path: require.resolve('path-browserify'),
+      './Link': path.resolve(__dirname, 'src', 'webview', 'search-panel', 'alias', 'Link'),
     },
     // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader
     extensions: ['.ts', '.tsx', '.js', '.jsx'],


### PR DESCRIPTION
This PR is used to build v2.0.8:

1. Created Link component for VSCE purpose as VSCE Web would open empty file links
2. Removed Code Monitor CTA from Save Seach Form
3. Fixed All Search Keyword link issue: https://github.com/sourcegraph/sourcegraph/issues/31023
4. Fixed issue where[ files link will only be opened ](https://github.com/sourcegraph/sourcegraph/blob/a5fd0cb9b6a6734153372e195e8e8e94a13469bb/client/vscode/src/link-commands/initialize.ts)with `https` https://github.com/sourcegraph/sourcegraph/issues/31095