### PR TITLE
search: add job mapper

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -44,7 +44,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/searchcontexts"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/search/structural"
-	"github.com/sourcegraph/sourcegraph/internal/search/subrepoperms"
 	"github.com/sourcegraph/sourcegraph/internal/search/symbol"
 	"github.com/sourcegraph/sourcegraph/internal/search/textsearch"
 	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
@@ -956,7 +955,7 @@ func (r *searchResolver) toSearchJob(q query.Q) (run.Job, error) {
 
 	checker := authz.DefaultSubRepoPermsChecker
 	if authz.SubRepoEnabled(checker) {
-		job = subrepoperms.NewFilterJob(job)
+		job = run.NewFilterJob(job)
 	}
 
 	return job, nil

--- a/internal/search/run/run.go
+++ b/internal/search/run/run.go
@@ -2,12 +2,18 @@ package run
 
 import (
 	"context"
+	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/commit"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	"github.com/sourcegraph/sourcegraph/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+	"github.com/sourcegraph/sourcegraph/internal/search/structural"
+	"github.com/sourcegraph/sourcegraph/internal/search/symbol"
+	"github.com/sourcegraph/sourcegraph/internal/search/textsearch"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -50,4 +56,154 @@ func (inputs SearchInputs) MaxResults() int {
 type Job interface {
 	Run(context.Context, database.DB, streaming.Sender) (*search.Alert, error)
 	Name() string
+}
+
+type Mapper struct {
+	MapJob func(job Job) Job
+
+	// Search Jobs (leaf nodes)
+	MapRepoSearchJob               func(*RepoSearch) *RepoSearch
+	MapRepoSubsetTextSearchJob     func(*textsearch.RepoSubsetTextSearch) *textsearch.RepoSubsetTextSearch
+	MapRepoUniverseTextSearchJob   func(*textsearch.RepoUniverseTextSearch) *textsearch.RepoUniverseTextSearch
+	MapStructuralSearchJob         func(*structural.StructuralSearch) *structural.StructuralSearch
+	MapCommitSearchJob             func(*commit.CommitSearch) *commit.CommitSearch
+	MapRepoSubsetSymbolSearchJob   func(*symbol.RepoSubsetSymbolSearch) *symbol.RepoSubsetSymbolSearch
+	MapRepoUniverseSymbolSearchJob func(*symbol.RepoUniverseSymbolSearch) *symbol.RepoUniverseSymbolSearch
+	MapComputeExcludedReposJob     func(*repos.ComputeExcludedRepos) *repos.ComputeExcludedRepos
+
+	// Expression Jobs
+	MapAndJob func(children []Job) []Job
+	MapOrJob  func(children []Job) []Job
+
+	// Combinator Jobs
+	MapParallelJob func(children []Job) []Job
+	MapPriorityJob func(required, optional Job) (Job, Job)
+	MapTimeoutJob  func(timeout time.Duration, child Job) (time.Duration, Job)
+	MapLimitJob    func(limit int, child Job) (int, Job)
+
+	// Filter Jobs
+	MapSubRepoPermsFilterJob func(child Job) Job
+}
+
+func (m *Mapper) Map(job Job) Job {
+	if m.MapJob != nil {
+		job = m.MapJob(job)
+	}
+
+	switch j := job.(type) {
+	case *RepoSearch:
+		if m.MapRepoSearchJob != nil {
+			j = m.MapRepoSearchJob(j)
+		}
+		return j
+
+	case *textsearch.RepoSubsetTextSearch:
+		if m.MapRepoSubsetTextSearchJob != nil {
+			j = m.MapRepoSubsetTextSearchJob(j)
+		}
+		return j
+
+	case *textsearch.RepoUniverseTextSearch:
+		if m.MapRepoUniverseTextSearchJob != nil {
+			j = m.MapRepoUniverseTextSearchJob(j)
+		}
+		return j
+
+	case *structural.StructuralSearch:
+		if m.MapStructuralSearchJob != nil {
+			j = m.MapStructuralSearchJob(j)
+		}
+		return j
+
+	case *commit.CommitSearch:
+		if m.MapCommitSearchJob != nil {
+			j = m.MapCommitSearchJob(j)
+		}
+		return j
+
+	case *symbol.RepoSubsetSymbolSearch:
+		if m.MapRepoSubsetSymbolSearchJob != nil {
+			j = m.MapRepoSubsetSymbolSearchJob(j)
+		}
+		return j
+
+	case *symbol.RepoUniverseSymbolSearch:
+		if m.MapRepoUniverseSymbolSearchJob != nil {
+			j = m.MapRepoUniverseSymbolSearchJob(j)
+		}
+		return j
+
+	case *repos.ComputeExcludedRepos:
+		if m.MapComputeExcludedReposJob != nil {
+			j = m.MapComputeExcludedReposJob(j)
+		}
+		return j
+
+	case *AndJob:
+		children := make([]Job, 0, len(j.children))
+		for _, child := range j.children {
+			children = append(children, m.Map(child))
+		}
+		if m.MapAndJob != nil {
+			children = m.MapAndJob(children)
+		}
+		return NewAndJob(children...)
+
+	case *OrJob:
+		children := make([]Job, 0, len(j.children))
+		for _, child := range j.children {
+			children = append(children, m.Map(child))
+		}
+		if m.MapOrJob != nil {
+			children = m.MapOrJob(children)
+		}
+		return NewOrJob(children...)
+
+	case *ParallelJob:
+		children := make([]Job, 0, len(*j))
+		for _, child := range *j {
+			children = append(children, m.Map(child))
+		}
+		if m.MapParallelJob != nil {
+			children = m.MapParallelJob(children)
+		}
+		return NewParallelJob(children...)
+
+	case *PriorityJob:
+		required := m.Map(j.required)
+		optional := m.Map(j.optional)
+		if m.MapPriorityJob != nil {
+			required, optional = m.MapPriorityJob(required, optional)
+		}
+		return NewPriorityJob(required, optional)
+
+	case *TimeoutJob:
+		child := m.Map(j.child)
+		timeout := j.timeout
+		if m.MapTimeoutJob != nil {
+			timeout, child = m.MapTimeoutJob(timeout, child)
+		}
+		return NewTimeoutJob(timeout, child)
+
+	case *LimitJob:
+		child := m.Map(j.child)
+		limit := j.limit
+		if m.MapLimitJob != nil {
+			limit, child = m.MapLimitJob(limit, child)
+		}
+		return NewLimitJob(limit, child)
+
+	case *subRepoPermsFilterJob:
+		child := m.Map(j.child)
+		if m.MapSubRepoPermsFilterJob != nil {
+			child = m.MapSubRepoPermsFilterJob(child)
+		}
+		return NewFilterJob(child)
+
+	case *noopJob:
+		return j
+
+	}
+	// Unreachable
+	return job
 }

--- a/internal/search/run/run_test.go
+++ b/internal/search/run/run_test.go
@@ -1,0 +1,65 @@
+package run
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hexops/autogold"
+
+	"github.com/sourcegraph/sourcegraph/internal/search/commit"
+	"github.com/sourcegraph/sourcegraph/internal/search/repos"
+	"github.com/sourcegraph/sourcegraph/internal/search/structural"
+	"github.com/sourcegraph/sourcegraph/internal/search/symbol"
+	"github.com/sourcegraph/sourcegraph/internal/search/textsearch"
+)
+
+func prettyPrint(job Job) string {
+	switch j := job.(type) {
+	case
+		*RepoSearch,
+		*textsearch.RepoSubsetTextSearch,
+		*textsearch.RepoUniverseTextSearch,
+		*structural.StructuralSearch,
+		*commit.CommitSearch,
+		*symbol.RepoSubsetSymbolSearch,
+		*symbol.RepoUniverseSymbolSearch,
+		*repos.ComputeExcludedRepos:
+		return j.Name()
+	case *AndJob:
+		var jobs []string
+		for _, child := range j.children {
+			jobs = append(jobs, prettyPrint(child))
+		}
+		return "and(" + strings.Join(jobs, ",") + ")"
+	case *OrJob:
+		var jobs []string
+		for _, child := range j.children {
+			jobs = append(jobs, prettyPrint(child))
+		}
+		return "or(" + strings.Join(jobs, ",") + ")"
+	case
+		*PriorityJob,
+		*ParallelJob,
+		*TimeoutJob,
+		*LimitJob,
+		*subRepoPermsFilterJob:
+		return j.Name()
+	case *noopJob:
+		return "NoOp"
+	}
+	// Unreachable.
+	return ""
+}
+
+func TestMap(t *testing.T) {
+	test := func(job Job, mapper Mapper) string {
+		return prettyPrint(mapper.Map(job))
+	}
+
+	andMapper := Mapper{
+		MapAndJob: func(children []Job) []Job {
+			return append(children, NewOrJob(NewNoopJob(), NewNoopJob()))
+		},
+	}
+	autogold.Want("basic and-job mapper", "and(NoOp,NoOp,or(NoOp,NoOp))").Equal(t, test(NewAndJob(NewNoopJob(), NewNoopJob()), andMapper))
+}

--- a/internal/search/run/sub_repo_perms_job.go
+++ b/internal/search/run/sub_repo_perms_job.go
@@ -1,4 +1,4 @@
-package subrepoperms
+package run
 
 import (
 	"context"
@@ -12,19 +12,18 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
-	"github.com/sourcegraph/sourcegraph/internal/search/run"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // NewFilterJob creates a job that filters the streamed results
 // of its child job using the default authz.DefaultSubRepoPermsChecker.
-func NewFilterJob(child run.Job) run.Job {
+func NewFilterJob(child Job) Job {
 	return &subRepoPermsFilterJob{child: child}
 }
 
 type subRepoPermsFilterJob struct {
-	child run.Job
+	child Job
 }
 
 func (s *subRepoPermsFilterJob) Run(ctx context.Context, db database.DB, stream streaming.Sender) (*search.Alert, error) {

--- a/internal/search/run/sub_repo_perms_job_test.go
+++ b/internal/search/run/sub_repo_perms_job_test.go
@@ -1,4 +1,4 @@
-package subrepoperms
+package run
 
 import (
 	"context"


### PR DESCRIPTION
This adds a `Mapper` to map jobs. It's going to be very useful to restrict optimization to, e.g., modifying Zoekt or commit queries. 

I had to move `subrepoperms` into `package run` to avoid a circular dependency (it was the only `Job` that had this issue). We can try break this later if we have a dedicated job package. Right now the tradeoff is very much worth it, since we can operate/map over all jobs exhaustively this way.

By the way @camdencheek using a mapper is going to help cut down messier changes that I thought would be needed!

## Test plan
Basic unit test. This functionality isn't used by any logic yet.


