### PR TITLE
get first repo with todos

### DIFF
--- a/client/web/src/enterprise/insights/core/backend/code-insights-backend-context.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-backend-context.ts
@@ -50,6 +50,7 @@ export class FakeDefaultCodeInsightsBackend implements CodeInsightsBackend {
         errorMockMethod('getRepositorySuggestions')().toPromise()
     public getResolvedSearchRepositories = (): Promise<string[]> =>
         errorMockMethod('getResolvedSearchRepositories')().toPromise()
+    public getFirstExampleRepository = errorMockMethod('getFirstExampleRepository')
 }
 
 export const CodeInsightsBackendContext = React.createContext<CodeInsightsBackend>(new FakeDefaultCodeInsightsBackend())

--- a/client/web/src/enterprise/insights/core/backend/code-insights-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-backend.ts
@@ -138,4 +138,14 @@ export interface CodeInsightsBackend {
      * @param query - search page query value
      */
     getResolvedSearchRepositories: (query: string) => Promise<string[]>
+
+    /**
+     * Used for the dynamic insight example on the insights landing page.
+     * Attempts to return a repoository that contains the string "TODO"
+     * If a repository is not found it then returns the first repository it finds.
+     *
+     * Under the hood this is calling the search API with "select:repo TODO count:1"
+     * or "select:repo count:1" if no repository is found with the string "TODO"
+     */
+    getFirstExampleRepository: () => Observable<string>
 }

--- a/client/web/src/enterprise/insights/core/backend/gql-api/code-insights-gql-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-api/code-insights-gql-backend.ts
@@ -1,4 +1,4 @@
-import { ApolloCache, ApolloClient, gql } from '@apollo/client'
+import { ApolloCache, ApolloClient, ApolloQueryResult, gql } from '@apollo/client'
 import { from, Observable, of } from 'rxjs'
 import { map, mapTo, switchMap } from 'rxjs/operators'
 import { LineChartContent, PieChartContent } from 'sourcegraph'
@@ -7,6 +7,8 @@ import {
     CreateDashboardResult,
     CreateInsightsDashboardInput,
     DeleteDashboardResult,
+    ExampleFirstRepositoryResult,
+    ExampleTodoRepositoryResult,
     GetDashboardInsightsResult,
     GetInsightsResult,
     HasAvailableCodeInsightResult,
@@ -47,6 +49,7 @@ import { parseDashboardScope } from '../utils/parse-dashboard-scope'
 
 import { createInsightView } from './deserialization/create-insight-view'
 import { GET_DASHBOARD_INSIGHTS_GQL } from './gql/GetDashboardInsights'
+import { GET_EXAMPLE_FIRST_REPOSITORY_GQL, GET_EXAMPLE_TODO_REPOSITORY_GQL } from './gql/GetExampleRepository'
 import { GET_INSIGHTS_GQL } from './gql/GetInsights'
 import { GET_INSIGHTS_DASHBOARDS_GQL } from './gql/GetInsightsDashboards'
 import { GET_INSIGHTS_SUBJECTS_GQL } from './gql/GetInsightSubjects'
@@ -453,4 +456,28 @@ export class CodeInsightsGqlBackend implements CodeInsightsBackend {
             )
         )
     }
+
+    public getFirstExampleRepository = (): Observable<string> => {
+        const firstRepository = (): Observable<string> =>
+            fromObservableQuery(
+                this.apolloClient.watchQuery<ExampleFirstRepositoryResult>({
+                    query: GET_EXAMPLE_FIRST_REPOSITORY_GQL,
+                })
+            ).pipe(map(getRepositoryName))
+
+        const todoRepository = (): Observable<string> =>
+            fromObservableQuery(
+                this.apolloClient.watchQuery<ExampleTodoRepositoryResult>({
+                    query: GET_EXAMPLE_TODO_REPOSITORY_GQL,
+                })
+            ).pipe(map(getRepositoryName))
+
+        return todoRepository().pipe(
+            switchMap(todoRepository => (todoRepository ? of(todoRepository) : firstRepository()))
+        )
+    }
 }
+
+const getRepositoryName = (
+    result: ApolloQueryResult<ExampleTodoRepositoryResult | ExampleFirstRepositoryResult>
+): string => result.data.search?.results.repositories[0].name || ''

--- a/client/web/src/enterprise/insights/core/backend/gql-api/gql/GetExampleRepository.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-api/gql/GetExampleRepository.ts
@@ -1,0 +1,25 @@
+import { gql } from '@apollo/client'
+
+export const GET_EXAMPLE_TODO_REPOSITORY_GQL = gql`
+    query ExampleTodoRepository {
+        search(patternType: literal, version: V2, query: "select:repo TODO count:1") {
+            results {
+                repositories {
+                    name
+                }
+            }
+        }
+    }
+`
+
+export const GET_EXAMPLE_FIRST_REPOSITORY_GQL = gql`
+    query ExampleFirstRepository {
+        search(patternType: literal, version: V2, query: "select:repo count:1") {
+            results {
+                repositories {
+                    name
+                }
+            }
+        }
+    }
+`

--- a/client/web/src/enterprise/insights/core/backend/setting-based-api/code-insights-setting-cascade-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/setting-based-api/code-insights-setting-cascade-backend.ts
@@ -276,4 +276,5 @@ export class CodeInsightsSettingsCascadeBackend implements CodeInsightsBackend {
     // Repositories API
     public getRepositorySuggestions = getRepositorySuggestions
     public getResolvedSearchRepositories = getResolvedSearchRepositories
+    public getFirstExampleRepository = (): Observable<string> => of('')
 }

--- a/client/web/src/enterprise/insights/pages/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
+++ b/client/web/src/enterprise/insights/pages/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
@@ -1,15 +1,16 @@
 import classNames from 'classnames'
 import PlusIcon from 'mdi-react/PlusIcon'
-import React from 'react'
+import React, { useContext, useMemo } from 'react'
 import { noop } from 'rxjs'
 
-import { Button, Card, Link } from '@sourcegraph/wildcard'
+import { Button, Card, Link, useObservable } from '@sourcegraph/wildcard'
 
 import { FormInput } from '../../../../components/form/form-input/FormInput'
 import { useField } from '../../../../components/form/hooks/useField'
 import { useForm } from '../../../../components/form/hooks/useForm'
 import { InsightQueryInput } from '../../../../components/form/query-input/InsightQueryInput'
 import { RepositoriesField } from '../../../../components/form/repositories-field/RepositoriesField'
+import { CodeInsightsBackendContext } from '../../../../core/backend/code-insights-backend-context'
 import { DATA_SERIES_COLORS, EditableDataSeries } from '../../../insights/creation/search-insight'
 import { getQueryPatternTypeFilter } from '../../../insights/creation/search-insight/components/form-series-input/get-pattern-type-filter'
 import { SearchInsightLivePreview } from '../../../insights/creation/search-insight/components/live-preview-chart/SearchInsightLivePreview'
@@ -44,6 +45,8 @@ const createExampleDataSeries = (query: string): EditableDataSeries[] => [
 interface DynamicCodeInsightExampleProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export const DynamicCodeInsightExample: React.FunctionComponent<DynamicCodeInsightExampleProps> = props => {
+    const { getFirstExampleRepository } = useContext(CodeInsightsBackendContext)
+
     const form = useForm<CodeInsightExampleFormValues>({
         initialValues: INITIAL_INSIGHT_VALUES,
         touched: true,
@@ -65,6 +68,12 @@ export const DynamicCodeInsightExample: React.FunctionComponent<DynamicCodeInsig
     })
 
     const hasValidLivePreview = repositories.meta.validState === 'VALID' && query.meta.validState === 'VALID'
+    const repository = useObservable(useMemo(() => getFirstExampleRepository(), [getFirstExampleRepository]))
+
+    // This is to prevent resetting the name in an endless loop
+    if (repository && repositories.input.value !== repository) {
+        repositories.meta.setState(state => ({ ...state, value: repository }))
+    }
 
     return (
         <Card {...props} className={classNames(styles.wrapper, props.className)}>


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/30745

Updates the dynamic example to check for an actual repo with TODOs. If no repo is found containing "TODO" then the first repo is used.

Note: We are assuming that all customers will have at least 1 repo. In the unlikely event that no repo is found then an empty string will be returned.

![PixelSnap 2022-02-15 at 22 49 50](https://user-images.githubusercontent.com/1855233/154198260-7dafb11d-f480-4585-bf03-1ff4e714a526.png)
