### PR TITLE
Fix duplicate key warning

### DIFF
--- a/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-examples/CodeInsightsExamples.tsx
+++ b/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-examples/CodeInsightsExamples.tsx
@@ -171,7 +171,7 @@ const CAPTURE_INSIGHT_EXAMPLES_DATA: LineChartContent<any, string> = {
             stroke: DATA_SERIES_COLORS.CYAN,
         },
         {
-            dataKey: 'e',
+            dataKey: 'f',
             name: '17.0.1',
             stroke: DATA_SERIES_COLORS.GRAPE,
         },


### PR DESCRIPTION
Sample data had a duplicate key that was blowing up the logs. This just updates one of the keys.