### PR TITLE
Code Insights: Fix sticky dashboard header layout

### DIFF
--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-header/DashboardHeader.module.scss
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-header/DashboardHeader.module.scss
@@ -6,7 +6,7 @@
     background-color: var(--body-bg);
 
     &--stuck {
-        background-color: var(--color-bg-1);
+        background-color: var(--body-bg);
 
         &::after {
             display: block;
@@ -18,7 +18,7 @@
 
             // For stretching the bottom border across the entire screen
             // stylelint-disable-next-line declaration-property-unit-allowed-list
-            margin: 0 -100vw;
+            margin: 0 calc((100% - 100vw) / 2);
             border-bottom: 1px solid var(--border-color-2);
         }
     }


### PR DESCRIPTION
<table>
<tr><th>Before</th><th>After</th></tr>

<tr>
<td>
<img width="1188" alt="Screenshot 2022-02-12 at 17 44 53" src="https://user-images.githubusercontent.com/18492575/153716580-622e8b09-183e-41cf-9e3b-efddee3789ca.png">


</td>
<td>
<img width="1106" alt="Screenshot 2022-02-12 at 17 43 45" src="https://user-images.githubusercontent.com/18492575/153716583-f0012a70-4251-43ec-a31c-2791ee98f44e.png">


</td>
</tr>
</table>