### PR TITLE
ci: explore --cache-from and leverage multi-stage builds to speed up builds

### DIFF
--- a/cmd/frontend/build.sh
+++ b/cmd/frontend/build.sh
@@ -20,8 +20,15 @@ echo "--- go build"
 pkg="github.com/sourcegraph/sourcegraph/cmd/frontend"
 go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION  -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"
 
+# Enable image build caching via CACHE=true
+BUILD_CACHE="--no-cache"
+if [[ "$CACHE" == "true" ]]; then
+  BUILD_CACHE=""
+fi
+
 echo "--- docker build $IMAGE"
-docker build -f cmd/frontend/Dockerfile -t "$IMAGE" "$OUTPUT" \
+docker pull us.gcr.io/sourcegraph-dev/frontend:insiders || true
+docker build --cache-from us.gcr.io/sourcegraph-dev/frotend:insiders -f cmd/frontend/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \
   --build-arg COMMIT_SHA \
   --build-arg DATE \

--- a/cmd/frontend/build.sh
+++ b/cmd/frontend/build.sh
@@ -28,7 +28,9 @@ fi
 
 echo "--- docker build $IMAGE"
 docker pull us.gcr.io/sourcegraph-dev/frontend:insiders || true
-docker build --cache-from us.gcr.io/sourcegraph-dev/frotend:insiders ${BUILD_CACHE} -f cmd/frontend/Dockerfile -t "$IMAGE" "$OUTPUT" \
+docker build --build-arg BUILDKIT_INLINE_CACHE=1 \
+  --cache-from us.gcr.io/sourcegraph-dev/frotend:insiders ${BUILD_CACHE} \
+  -f cmd/frontend/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \
   --build-arg COMMIT_SHA \
   --build-arg DATE \

--- a/cmd/frontend/build.sh
+++ b/cmd/frontend/build.sh
@@ -28,7 +28,7 @@ fi
 
 echo "--- docker build $IMAGE"
 docker pull us.gcr.io/sourcegraph-dev/frontend:insiders || true
-docker build --cache-from us.gcr.io/sourcegraph-dev/frotend:insiders -f cmd/frontend/Dockerfile -t "$IMAGE" "$OUTPUT" \
+docker build --cache-from us.gcr.io/sourcegraph-dev/frotend:insiders ${BUILD_CACHE} -f cmd/frontend/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \
   --build-arg COMMIT_SHA \
   --build-arg DATE \

--- a/cmd/frontend/build.sh
+++ b/cmd/frontend/build.sh
@@ -20,17 +20,11 @@ echo "--- go build"
 pkg="github.com/sourcegraph/sourcegraph/cmd/frontend"
 go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION  -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"
 
-# Enable image build caching via CACHE=true
-BUILD_CACHE="--no-cache"
-if [[ "$CACHE" == "true" ]]; then
-  BUILD_CACHE=""
-fi
-
 echo "--- docker build $IMAGE"
-docker pull us.gcr.io/sourcegraph-dev/frontend:insiders || true
+docker pull sourcegraph/frontend:insiders || true
 docker build \
   --build-arg BUILDKIT_INLINE_CACHE=1 \
-  --cache-from us.gcr.io/sourcegraph-dev/frontend:insiders "${BUILD_CACHE}" \
+  --cache-from sourcegraph/frontend:insiders \
   -f cmd/frontend/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \
   --build-arg COMMIT_SHA \

--- a/cmd/frontend/build.sh
+++ b/cmd/frontend/build.sh
@@ -28,8 +28,9 @@ fi
 
 echo "--- docker build $IMAGE"
 docker pull us.gcr.io/sourcegraph-dev/frontend:insiders || true
-docker build --build-arg BUILDKIT_INLINE_CACHE=1 \
-  --cache-from us.gcr.io/sourcegraph-dev/frotend:insiders ${BUILD_CACHE} \
+docker build \
+  --build-arg BUILDKIT_INLINE_CACHE=1 \
+  --cache-from us.gcr.io/sourcegraph-dev/frontend:insiders "${BUILD_CACHE}" \
   -f cmd/frontend/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \
   --build-arg COMMIT_SHA \

--- a/cmd/gitserver/build.sh
+++ b/cmd/gitserver/build.sh
@@ -21,6 +21,8 @@ export CGO_ENABLED=0
 pkg="github.com/sourcegraph/sourcegraph/cmd/gitserver"
 go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION  -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"
 
+docker pull us.gcr.io/sourcegraph-dev/gitserver:insiders || true
+
 docker build -f cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \
   --build-arg COMMIT_SHA \

--- a/cmd/gitserver/build.sh
+++ b/cmd/gitserver/build.sh
@@ -33,7 +33,7 @@ docker pull $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-coursier || true
 docker build \
   --target p4cli \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
-  -t sourcegraph-dev/gitserver:p4cli \
+  -t $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
   -f cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \
   --build-arg COMMIT_SHA \
@@ -44,7 +44,7 @@ docker build \
   --target p4-fusion \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion \
-  -t sourcegraph-dev/gitserver:p4-fusion \
+  -t $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion \
   -f cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \
   --build-arg COMMIT_SHA \
@@ -56,7 +56,7 @@ docker build \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:coursier \
-  -t sourcegraph-dev/gitserver:coursier \
+  -t $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:coursier \
   -f cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \
   --build-arg COMMIT_SHA \

--- a/cmd/gitserver/build.sh
+++ b/cmd/gitserver/build.sh
@@ -21,7 +21,9 @@ export CGO_ENABLED=0
 pkg="github.com/sourcegraph/sourcegraph/cmd/gitserver"
 go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION  -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"
 
-PRIVATE_REGISTRY="private-docker-registry:5000"
+# Can't use it because it's not yet https
+# PRIVATE_REGISTRY="private-docker-registry:5000"
+PRIVATE_REGISTRY="us.gcr.io"
 
 docker pull us.gcr.io/sourcegraph-dev/gitserver:insiders || true
 docker pull $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli || true

--- a/cmd/gitserver/build.sh
+++ b/cmd/gitserver/build.sh
@@ -32,6 +32,7 @@ docker pull $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:coursier || true
 
 docker build \
   --target p4cli \
+  --build-arg BUILDKIT_INLINE_CACHE=1 \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
   -t $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
   -f cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \
@@ -42,6 +43,7 @@ docker build \
 
 docker build \
   --target p4-fusion \
+  --build-arg BUILDKIT_INLINE_CACHE=1 \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion \
   -t $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion \
@@ -53,6 +55,7 @@ docker build \
 
 docker build \
   --target coursier \
+  --build-arg BUILDKIT_INLINE_CACHE=1 \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:coursier \
@@ -68,6 +71,7 @@ docker push $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion
 docker push $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:coursier
 
 docker build \
+  --build-arg BUILDKIT_INLINE_CACHE=1 \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:fusion \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:coursier \

--- a/cmd/gitserver/build.sh
+++ b/cmd/gitserver/build.sh
@@ -33,7 +33,7 @@ docker pull $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-coursier || true
 docker build \
   --target p4cli \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
-  -t $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
+  -t sourcegraph-dev/gitserver:p4cli \
   -f cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \
   --build-arg COMMIT_SHA \
@@ -44,7 +44,7 @@ docker build \
   --target p4-fusion \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion \
-  -t $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion \
+  -t sourcegraph-dev/gitserver:p4-fusion \
   -f cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \
   --build-arg COMMIT_SHA \
@@ -56,7 +56,7 @@ docker build \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:coursier \
-  -t $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:coursier \
+  -t sourcegraph-dev/gitserver:coursier \
   -f cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \
   --build-arg COMMIT_SHA \

--- a/cmd/gitserver/build.sh
+++ b/cmd/gitserver/build.sh
@@ -31,7 +31,7 @@ docker pull $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion || true
 docker pull $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-coursier || true
 
 docker build \
-  --target p4cli
+  --target p4cli \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
   -f cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \
@@ -40,7 +40,7 @@ docker build \
   --build-arg VERSION
 
 docker build \
-  --target p4-fusion
+  --target p4-fusion \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion \
   -f cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \
@@ -50,7 +50,7 @@ docker build \
   --build-arg VERSION
 
 docker build \
-  --target coursier
+  --target coursier \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:coursier \
@@ -65,6 +65,9 @@ docker push $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion
 docker push $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-coursier
 
 docker build \
+  --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
+  --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion \
+  --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:coursier \
   --cache-from us.gcr.io/sourcegraph-dev/server:insiders \
   -f cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \

--- a/cmd/gitserver/build.sh
+++ b/cmd/gitserver/build.sh
@@ -23,7 +23,16 @@ go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/vers
 
 docker pull us.gcr.io/sourcegraph-dev/gitserver:insiders || true
 
-docker build -f cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \
+# docker build \ 
+#   --target p4cli
+#   -f cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \
+#   --progress=plain \
+#   --build-arg COMMIT_SHA \
+#   --build-arg DATE \
+#   --build-arg VERSION
+
+docker build --cache-from us.gcr.io/sourcegraph-dev/server:insiders \
+  -f cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \
   --build-arg COMMIT_SHA \
   --build-arg DATE \

--- a/cmd/gitserver/build.sh
+++ b/cmd/gitserver/build.sh
@@ -21,17 +21,49 @@ export CGO_ENABLED=0
 pkg="github.com/sourcegraph/sourcegraph/cmd/gitserver"
 go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION  -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"
 
+PRIVATE_REGISTRY="private-docker-registry:5000"
+
 docker pull us.gcr.io/sourcegraph-dev/gitserver:insiders || true
+docker pull $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli || true
+docker pull $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion || true
+docker pull $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-coursier || true
 
-# docker build \ 
-#   --target p4cli
-#   -f cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \
-#   --progress=plain \
-#   --build-arg COMMIT_SHA \
-#   --build-arg DATE \
-#   --build-arg VERSION
+docker build \
+  --target p4cli
+  --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
+  -f cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \
+  --progress=plain \
+  --build-arg COMMIT_SHA \
+  --build-arg DATE \
+  --build-arg VERSION
 
-docker build --cache-from us.gcr.io/sourcegraph-dev/server:insiders \
+docker build \
+  --target p4-fusion
+  --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
+  --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion \
+  -f cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \
+  --progress=plain \
+  --build-arg COMMIT_SHA \
+  --build-arg DATE \
+  --build-arg VERSION
+
+docker build \
+  --target coursier
+  --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
+  --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion \
+  --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:coursier \
+  -f cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \
+  --progress=plain \
+  --build-arg COMMIT_SHA \
+  --build-arg DATE \
+  --build-arg VERSION
+
+docker push $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli
+docker push $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion
+docker push $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-coursier
+
+docker build \
+  --cache-from us.gcr.io/sourcegraph-dev/server:insiders \
   -f cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \
   --build-arg COMMIT_SHA \

--- a/cmd/gitserver/build.sh
+++ b/cmd/gitserver/build.sh
@@ -33,6 +33,7 @@ docker pull $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-coursier || true
 docker build \
   --target p4cli \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
+  -t $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
   -f cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \
   --build-arg COMMIT_SHA \
@@ -43,6 +44,7 @@ docker build \
   --target p4-fusion \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion \
+  -t $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion \
   -f cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \
   --build-arg COMMIT_SHA \
@@ -54,6 +56,7 @@ docker build \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:coursier \
+  -t $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-coursier \
   -f cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \
   --build-arg COMMIT_SHA \

--- a/cmd/gitserver/build.sh
+++ b/cmd/gitserver/build.sh
@@ -28,7 +28,7 @@ PRIVATE_REGISTRY="us.gcr.io"
 docker pull us.gcr.io/sourcegraph-dev/gitserver:insiders || true
 docker pull $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli || true
 docker pull $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion || true
-docker pull $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-coursier || true
+docker pull $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:coursier || true
 
 docker build \
   --target p4cli \
@@ -65,11 +65,11 @@ docker build \
 
 docker push $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli
 docker push $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion
-docker push $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-coursier
+docker push $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:coursier
 
 docker build \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
-  --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion \
+  --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:fusion \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:coursier \
   --cache-from us.gcr.io/sourcegraph-dev/server:insiders \
   -f cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \

--- a/cmd/gitserver/build.sh
+++ b/cmd/gitserver/build.sh
@@ -56,7 +56,7 @@ docker build \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion \
   --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:coursier \
-  -t $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-coursier \
+  -t $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:coursier \
   -f cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \
   --build-arg COMMIT_SHA \

--- a/cmd/gitserver/build.sh
+++ b/cmd/gitserver/build.sh
@@ -23,18 +23,18 @@ go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/vers
 
 # Can't use it because it's not yet https
 # PRIVATE_REGISTRY="private-docker-registry:5000"
-PRIVATE_REGISTRY="us.gcr.io"
+# PRIVATE_REGISTRY="us.gcr.io"
 
-docker pull us.gcr.io/sourcegraph-dev/gitserver:insiders || true
-docker pull $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli || true
-docker pull $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion || true
-docker pull $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:coursier || true
+docker pull index.docker.io/sourcegraph/gitserver:insiders || true
+docker pull index.docker.io/sourcegraph/gitserver:p4cli || true
+docker pull index.docker.io/sourcegraph/gitserver:p4-fusion || true
+docker pull index.docker.io/sourcegraph/gitserver:coursier || true
 
 docker build \
   --target p4cli \
   --build-arg BUILDKIT_INLINE_CACHE=1 \
-  --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
-  -t $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
+  --cache-from index.docker.io/sourcegraph/gitserver:p4cli \
+  -t index.docker.io/sourcegraph/gitserver:p4cli \
   -f cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \
   --build-arg COMMIT_SHA \
@@ -44,9 +44,9 @@ docker build \
 docker build \
   --target p4-fusion \
   --build-arg BUILDKIT_INLINE_CACHE=1 \
-  --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
-  --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion \
-  -t $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion \
+  --cache-from index.docker.io/sourcegraph/gitserver:p4cli \
+  --cache-from index.docker.io/sourcegraph/gitserver:p4-fusion \
+  -t index.docker.io/sourcegraph/gitserver:p4-fusion \
   -f cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \
   --build-arg COMMIT_SHA \
@@ -56,25 +56,25 @@ docker build \
 docker build \
   --target coursier \
   --build-arg BUILDKIT_INLINE_CACHE=1 \
-  --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
-  --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion \
-  --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:coursier \
-  -t $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:coursier \
+  --cache-from index.docker.io/sourcegraph/gitserver:p4cli \
+  --cache-from index.docker.io/sourcegraph/gitserver:p4-fusion \
+  --cache-from index.docker.io/sourcegraph/gitserver:coursier \
+  -t index.docker.io/sourcegraph/gitserver:coursier \
   -f cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \
   --build-arg COMMIT_SHA \
   --build-arg DATE \
   --build-arg VERSION
 
-docker push $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli
-docker push $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4-fusion
-docker push $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:coursier
+docker push index.docker.io/sourcegraph/gitserver:p4cli
+docker push index.docker.io/sourcegraph/gitserver:p4-fusion
+docker push index.docker.io/sourcegraph/gitserver:coursier
 
 docker build \
   --build-arg BUILDKIT_INLINE_CACHE=1 \
-  --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:p4cli \
-  --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:fusion \
-  --cache-from $PRIVATE_REGISTRY/sourcegraph-dev/gitserver:coursier \
+  --cache-from index.docker.io/sourcegraph/gitserver:p4cli \
+  --cache-from index.docker.io/sourcegraph/gitserver:fusion \
+  --cache-from index.docker.io/sourcegraph/gitserver:coursier \
   --cache-from us.gcr.io/sourcegraph-dev/server:insiders \
   -f cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \

--- a/cmd/server/build.sh
+++ b/cmd/server/build.sh
@@ -106,9 +106,9 @@ cmd/server/jaeger.sh
 echo "--- docker build"
 docker pull us.gcr.io/sourcegraph-dev/server:insiders || true
 
-docker build -f cmd/server/Dockerfile -t "$IMAGE" "$OUTPUT" \
+docker build --cache-from us.gcr.io/sourcegraph-dev/server:insiders \
+  -f cmd/server/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \
   --build-arg COMMIT_SHA \
   --build-arg DATE \
-  --build-arg VERSION \
-  --cache-from us.gcr.io/sourcegraph-dev/server:insiders
+  --build-arg VERSION

--- a/cmd/server/build.sh
+++ b/cmd/server/build.sh
@@ -104,8 +104,11 @@ echo "--- jaeger-all-in-one binary"
 cmd/server/jaeger.sh
 
 echo "--- docker build"
+docker pull us.gcr.io/sourcegraph-dev/server:insiders || true
+
 docker build -f cmd/server/Dockerfile -t "$IMAGE" "$OUTPUT" \
   --progress=plain \
   --build-arg COMMIT_SHA \
   --build-arg DATE \
-  --build-arg VERSION
+  --build-arg VERSION \
+  --cache-from us.gcr.io/sourcegraph-dev/server:insiders

--- a/cmd/server/build.sh
+++ b/cmd/server/build.sh
@@ -76,7 +76,7 @@ parallel_run go_build {} ::: "${PACKAGES[@]}"
 
 echo "--- build scripts"
 cp -a ./cmd/symbols/ctags-install-alpine.sh "$OUTPUT"
-cp -a ./cmd/server/p4-fusion-install-alpine.sh "$OUTPUT"
+cp -a ./cmd/gitserver/p4-fusion-install-alpine.sh "$OUTPUT"
 
 echo "--- monitoring generation"
 # For code generation we need to match the local machine so we can run the generator

--- a/docker-images/grafana/build.sh
+++ b/docker-images/grafana/build.sh
@@ -36,12 +36,12 @@ fi
 
 # shellcheck disable=SC2086
 docker pull us.gcr.io/sourcegraph-dev/grafana:insiders || true
-docker build ${BUILD_CACHE} -t "${IMAGE:-sourcegraph/grafana}" . \
+docker build --cache-from us.gcr.io/sourcegraph-dev/grafana:insiders \
+  ${BUILD_CACHE} -t "${IMAGE:-sourcegraph/grafana}" . \
   --progress=plain \
   --build-arg COMMIT_SHA \
   --build-arg DATE \
-  --build-arg VERSION \
-  --cache-from us.gcr.io/sourcegraph-dev/grafana:insiders
+  --build-arg VERSION 
 
 # cd out of $BUILDDIR for cleanup
 popd

--- a/docker-images/grafana/build.sh
+++ b/docker-images/grafana/build.sh
@@ -35,11 +35,13 @@ if [[ "$CACHE" == "true" ]]; then
 fi
 
 # shellcheck disable=SC2086
+docker pull us.gcr.io/sourcegraph-dev/grafana:insiders || true
 docker build ${BUILD_CACHE} -t "${IMAGE:-sourcegraph/grafana}" . \
   --progress=plain \
   --build-arg COMMIT_SHA \
   --build-arg DATE \
-  --build-arg VERSION
+  --build-arg VERSION \
+  --cache-from us.gcr.io/sourcegraph-dev/grafana:insiders
 
 # cd out of $BUILDDIR for cleanup
 popd

--- a/docker-images/grafana/build.sh
+++ b/docker-images/grafana/build.sh
@@ -34,8 +34,8 @@ if [[ "$CACHE" == "true" ]]; then
   BUILD_CACHE=""
 fi
 
-# shellcheck disable=SC2086
 docker pull us.gcr.io/sourcegraph-dev/grafana:insiders || true
+# shellcheck disable=SC2086
 docker build \
   --build-arg BUILDKIT_INLINE_CACHE=1 \
   --cache-from us.gcr.io/sourcegraph-dev/grafana:insiders \

--- a/docker-images/grafana/build.sh
+++ b/docker-images/grafana/build.sh
@@ -36,7 +36,9 @@ fi
 
 # shellcheck disable=SC2086
 docker pull us.gcr.io/sourcegraph-dev/grafana:insiders || true
-docker build --cache-from us.gcr.io/sourcegraph-dev/grafana:insiders \
+docker build \
+  --build-arg BUILDKIT_INLINE_CACHE=1 \
+  --cache-from us.gcr.io/sourcegraph-dev/grafana:insiders \
   ${BUILD_CACHE} -t "${IMAGE:-sourcegraph/grafana}" . \
   --progress=plain \
   --build-arg COMMIT_SHA \

--- a/docker-images/grafana/build.sh
+++ b/docker-images/grafana/build.sh
@@ -43,7 +43,7 @@ docker build \
   --progress=plain \
   --build-arg COMMIT_SHA \
   --build-arg DATE \
-  --build-arg VERSION 
+  --build-arg VERSION
 
 # cd out of $BUILDDIR for cleanup
 popd

--- a/docker-images/postgres_exporter/build.sh
+++ b/docker-images/postgres_exporter/build.sh
@@ -42,9 +42,9 @@ echo "${CODEINTEL_OUTPUT_FILE}"
 
 docker pull us.gcr.io/sourcegraph-dev/postgres_exporter:insiders || true
 
-docker build -f ./Dockerfile -t "${IMAGE:-sourcegraph/postgres_exporter}" "${OUTPUT}" \
+docker build --cache-from docker us.gcr.io/sourcegraph-dev/postgres_exporter:insiders \
+  -f ./Dockerfile -t "${IMAGE:-sourcegraph/postgres_exporter}" "${OUTPUT}" \
   --progress=plain \
   --build-arg COMMIT_SHA \
   --build-arg DATE \
-  --build-arg VERSION \
-  --cache-from docker us.gcr.io/sourcegraph-dev/postgres_exporter:insiders
+  --build-arg VERSION 

--- a/docker-images/postgres_exporter/build.sh
+++ b/docker-images/postgres_exporter/build.sh
@@ -40,8 +40,11 @@ done
 echo "${OUTPUT_FILE}"
 echo "${CODEINTEL_OUTPUT_FILE}"
 
+docker pull us.gcr.io/sourcegraph-dev/postgres_exporter:insiders || true
+
 docker build -f ./Dockerfile -t "${IMAGE:-sourcegraph/postgres_exporter}" "${OUTPUT}" \
   --progress=plain \
   --build-arg COMMIT_SHA \
   --build-arg DATE \
-  --build-arg VERSION
+  --build-arg VERSION \
+  --cache-from docker us.gcr.io/sourcegraph-dev/postgres_exporter:insiders

--- a/docker-images/postgres_exporter/build.sh
+++ b/docker-images/postgres_exporter/build.sh
@@ -42,7 +42,7 @@ echo "${CODEINTEL_OUTPUT_FILE}"
 
 docker pull us.gcr.io/sourcegraph-dev/postgres_exporter:insiders || true
 
-docker build --cache-from docker us.gcr.io/sourcegraph-dev/postgres_exporter:insiders \
+docker build --cache-from us.gcr.io/sourcegraph-dev/postgres_exporter:insiders \
   -f ./Dockerfile -t "${IMAGE:-sourcegraph/postgres_exporter}" "${OUTPUT}" \
   --progress=plain \
   --build-arg COMMIT_SHA \

--- a/docker-images/postgres_exporter/build.sh
+++ b/docker-images/postgres_exporter/build.sh
@@ -42,11 +42,11 @@ echo "${CODEINTEL_OUTPUT_FILE}"
 
 docker pull us.gcr.io/sourcegraph-dev/postgres_exporter:insiders || true
 
-docker build \ 
+docker build \
   --build-arg BUILDKIT_INLINE_CACHE=1 \
   --cache-from us.gcr.io/sourcegraph-dev/postgres_exporter:insiders \
   -f ./Dockerfile -t "${IMAGE:-sourcegraph/postgres_exporter}" "${OUTPUT}" \
   --progress=plain \
   --build-arg COMMIT_SHA \
   --build-arg DATE \
-  --build-arg VERSION 
+  --build-arg VERSION

--- a/docker-images/postgres_exporter/build.sh
+++ b/docker-images/postgres_exporter/build.sh
@@ -42,7 +42,9 @@ echo "${CODEINTEL_OUTPUT_FILE}"
 
 docker pull us.gcr.io/sourcegraph-dev/postgres_exporter:insiders || true
 
-docker build --cache-from us.gcr.io/sourcegraph-dev/postgres_exporter:insiders \
+docker build \ 
+  --build-arg BUILDKIT_INLINE_CACHE=1 \
+  --cache-from us.gcr.io/sourcegraph-dev/postgres_exporter:insiders \
   -f ./Dockerfile -t "${IMAGE:-sourcegraph/postgres_exporter}" "${OUTPUT}" \
   --progress=plain \
   --build-arg COMMIT_SHA \

--- a/docker-images/prometheus/build.sh
+++ b/docker-images/prometheus/build.sh
@@ -49,11 +49,13 @@ if [[ "$CACHE" == "true" ]]; then
 fi
 
 # shellcheck disable=SC2086
+docker pull us.gcr.io/sourcegraph-dev/prometheus:insiders
 docker build ${BUILD_CACHE} -t "${IMAGE:-sourcegraph/prometheus}" . \
   --progress=plain \
   --build-arg COMMIT_SHA \
   --build-arg DATE \
-  --build-arg VERSION
+  --build-arg VERSION \
+  --cache-from us.gcr.io/sourcegraph-dev/prometheus:insiders
 
 # cd out of $BUILDDIR for cleanup
 popd

--- a/docker-images/prometheus/build.sh
+++ b/docker-images/prometheus/build.sh
@@ -50,12 +50,12 @@ fi
 
 # shellcheck disable=SC2086
 docker pull us.gcr.io/sourcegraph-dev/prometheus:insiders
-docker build ${BUILD_CACHE} -t "${IMAGE:-sourcegraph/prometheus}" . \
+docker build --cache-from us.gcr.io/sourcegraph-dev/prometheus:insiders \
+  ${BUILD_CACHE} -t "${IMAGE:-sourcegraph/prometheus}" . \
   --progress=plain \
   --build-arg COMMIT_SHA \
   --build-arg DATE \
-  --build-arg VERSION \
-  --cache-from us.gcr.io/sourcegraph-dev/prometheus:insiders
+  --build-arg VERSION
 
 # cd out of $BUILDDIR for cleanup
 popd

--- a/docker-images/prometheus/build.sh
+++ b/docker-images/prometheus/build.sh
@@ -48,8 +48,8 @@ if [[ "$CACHE" == "true" ]]; then
   BUILD_CACHE=""
 fi
 
-# shellcheck disable=SC2086
 docker pull us.gcr.io/sourcegraph-dev/prometheus:insiders
+# shellcheck disable=SC2086
 docker build \
   --build-arg BUILDKIT_INLINE_CACHE=1 \
   --cache-from us.gcr.io/sourcegraph-dev/prometheus:insiders \

--- a/docker-images/prometheus/build.sh
+++ b/docker-images/prometheus/build.sh
@@ -50,7 +50,9 @@ fi
 
 # shellcheck disable=SC2086
 docker pull us.gcr.io/sourcegraph-dev/prometheus:insiders
-docker build --cache-from us.gcr.io/sourcegraph-dev/prometheus:insiders \
+docker build \
+  --build-arg BUILDKIT_INLINE_CACHE=1 \
+  --cache-from us.gcr.io/sourcegraph-dev/prometheus:insiders \
   ${BUILD_CACHE} -t "${IMAGE:-sourcegraph/prometheus}" . \
   --progress=plain \
   --build-arg COMMIT_SHA \

--- a/enterprise/dev/ci/internal/buildkite/buildkite.go
+++ b/enterprise/dev/ci/internal/buildkite/buildkite.go
@@ -164,7 +164,7 @@ func (p *Pipeline) AddStep(label string, opts ...StepOpt) {
 		if FeatureFlags.StatelessBuild {
 			step.Agents["queue"] = "job"
 		} else {
-			step.Agents["queue"] = "standard"
+			step.Agents["queue"] = "job"
 		}
 	}
 

--- a/enterprise/dev/ci/internal/ci/cache_helpers.go
+++ b/enterprise/dev/ci/internal/ci/cache_helpers.go
@@ -3,9 +3,10 @@ package ci
 import "github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/buildkite"
 
 func withYarnCache() buildkite.StepOpt {
-	if !buildkite.FeatureFlags.StatelessBuild {
-		return buildkite.RawCmd(`echo "skipping yarn cache, not a stateless agent"`)
-	}
+	// TODO do not merge with this
+	// if !buildkite.FeatureFlags.StatelessBuild {
+	// 	return buildkite.RawCmd(`echo "skipping yarn cache, not a stateless agent"`)
+	// }
 
 	return buildkite.Cache(&buildkite.CacheOptions{
 		ID:          "node_modules",

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -609,13 +609,17 @@ func buildCandidateDockerImage(app, version, tag string) operations.Operation {
 		image := strings.ReplaceAll(app, "/", "-")
 		localImage := "sourcegraph/" + image + ":" + version
 
-		cmds := []bk.StepOpt{
+		var cmds []bk.StepOpt
+		if bk.FeatureFlags.StatelessBuild && app == "server" {
+			cmds = append(cmds, withYarnCache())
+		}
+		cmds = append(cmds,
 			bk.Key(candidateImageStepKey(app)),
 			bk.Cmd(fmt.Sprintf(`echo "Building candidate %s image..."`, app)),
 			bk.Env("DOCKER_BUILDKIT", "1"),
 			bk.Env("IMAGE", localImage),
 			bk.Env("VERSION", version),
-		}
+		)
 
 		if _, err := os.Stat(filepath.Join("docker-images", app)); err == nil {
 			// Building Docker image located under $REPO_ROOT/docker-images/

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -621,6 +621,10 @@ func buildCandidateDockerImage(app, version, tag string) operations.Operation {
 			bk.Env("VERSION", version),
 		)
 
+		if app == "server" || app == "frontend" {
+			cmds = append([]bk.StepOpt{withYarnCache()}, cmds...)
+		}
+
 		if _, err := os.Stat(filepath.Join("docker-images", app)); err == nil {
 			// Building Docker image located under $REPO_ROOT/docker-images/
 			cmds = append(cmds, bk.Cmd(filepath.Join("docker-images", app, "build.sh")))


### PR DESCRIPTION
Follow up on https://github.com/sourcegraph/sourcegraph/pull/31066 that leverage explicit caching with `--cache-from` and pushes individual stages to avoid rebuilding them later. 

Please note that this PR does not make use of our internal docker registry because we need to either add the missing certificates to enable `https` or configure the `dind` container to make an exception and use our internal registry to pull things with insecure settings. 

Apparently, it's totally fine when using it as a pull-through, but not when pushing onto it explicitly. 

As a result, we went from 6m30 for a `gitserver` build on the stateless agents down to 2m30 (30s are just for cloning the repo). It's going to be marginally faster by using our own registry rather than pushing on gcr, but I don't think that's going to shave a ton either. 

The process to handle the caching explicitly is rather repetitive, especially if with multi-stage builds, but that could be addressed through scripting. 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


