### PR TITLE
search: mint limits package

### DIFF
--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -17,6 +17,7 @@ import (
 	gitprotocol "github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/limits"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	searchrepos "github.com/sourcegraph/sourcegraph/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
@@ -362,11 +363,11 @@ func newReposLimitError(limit int, hasTimeFilter bool, resultType string) error 
 }
 
 func reposLimit(hasTimeFilter bool) int {
-	limits := search.SearchLimits(conf.Get())
+	searchLimits := limits.SearchLimits(conf.Get())
 	if hasTimeFilter {
-		return limits.CommitDiffWithTimeFilterMaxRepos
+		return searchLimits.CommitDiffWithTimeFilterMaxRepos
 	}
-	return limits.CommitDiffMaxRepos
+	return searchLimits.CommitDiffMaxRepos
 }
 
 type DiffCommitError struct {

--- a/internal/search/limits/limits.go
+++ b/internal/search/limits/limits.go
@@ -1,4 +1,4 @@
-package search
+package limits
 
 import (
 	"math"

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/grafana/regexp"
+
+	"github.com/sourcegraph/sourcegraph/internal/search/limits"
 )
 
 type ExpectedOperand struct {
@@ -340,6 +342,22 @@ func (q Q) Repositories() (repos []string, negatedRepos []string) {
 		repos = append(repos, value)
 	})
 	return repos, negatedRepos
+}
+
+func (q Q) MaxResults(defaultLimit int) int {
+	if q == nil {
+		return 0
+	}
+
+	if count := q.Count(); count != nil {
+		return *count
+	}
+
+	if defaultLimit != 0 {
+		return defaultLimit
+	}
+
+	return limits.DefaultMaxSearchResults
 }
 
 func parseRegexpOrPanic(field, value string) *regexp.Regexp {

--- a/internal/search/query_converter.go
+++ b/internal/search/query_converter.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
+	"github.com/sourcegraph/sourcegraph/internal/search/limits"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 
 	zoekt "github.com/google/zoekt/query"
@@ -92,14 +93,14 @@ func count(q query.Basic, p Protocol) int {
 	}
 
 	if q.IsStructural() {
-		return DefaultMaxSearchResults
+		return limits.DefaultMaxSearchResults
 	}
 
 	switch p {
 	case Batch:
-		return DefaultMaxSearchResults
+		return limits.DefaultMaxSearchResults
 	case Streaming:
-		return DefaultMaxSearchResultsStreaming
+		return limits.DefaultMaxSearchResultsStreaming
 	}
 	panic("unreachable")
 }
@@ -176,8 +177,8 @@ func ToTextPatternInfo(q query.Basic, p Protocol, transform query.BasicPass) *Te
 }
 
 func TimeoutDuration(b query.Basic) time.Duration {
-	d := DefaultTimeout
-	maxTimeout := time.Duration(SearchLimits(conf.Get()).MaxTimeoutSeconds) * time.Second
+	d := limits.DefaultTimeout
+	maxTimeout := time.Duration(limits.SearchLimits(conf.Get()).MaxTimeoutSeconds) * time.Second
 	timeout := b.GetTimeout()
 	if timeout != nil {
 		d = *timeout

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/limits"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/searchcontexts"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
@@ -123,7 +124,7 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 
 	limit := op.Limit
 	if limit == 0 {
-		limit = search.SearchLimits(conf.Get()).MaxRepos
+		limit = limits.SearchLimits(conf.Get()).MaxRepos
 	}
 
 	// note that this mutates the strings in includePatterns, stripping their
@@ -405,7 +406,7 @@ func (r *Resolver) Excluded(ctx context.Context, op search.RepoOptions) (ex Excl
 
 	limit := op.Limit
 	if limit == 0 {
-		limit = search.SearchLimits(conf.Get()).MaxRepos
+		limit = limits.SearchLimits(conf.Get()).MaxRepos
 	}
 
 	// note that this mutates the strings in includePatterns, stripping their
@@ -700,7 +701,7 @@ func PrivateReposForActor(ctx context.Context, db database.DB, repoOptions searc
 	userPrivateRepos, err := db.Repos().ListMinimalRepos(ctx, database.ReposListOptions{
 		UserID:         userID, // Zero valued when not in sourcegraph.com mode
 		OnlyPrivate:    true,
-		LimitOffset:    &database.LimitOffset{Limit: search.SearchLimits(conf.Get()).MaxRepos + 1},
+		LimitOffset:    &database.LimitOffset{Limit: limits.SearchLimits(conf.Get()).MaxRepos + 1},
 		OnlyForks:      repoOptions.OnlyForks,
 		NoForks:        repoOptions.NoForks,
 		OnlyArchived:   repoOptions.OnlyArchived,

--- a/internal/search/run/run.go
+++ b/internal/search/run/run.go
@@ -33,19 +33,7 @@ type SearchInputs struct {
 
 // MaxResults computes the limit for the query.
 func (inputs SearchInputs) MaxResults() int {
-	if inputs.Query == nil {
-		return 0
-	}
-
-	if count := inputs.Query.Count(); count != nil {
-		return *count
-	}
-
-	if inputs.DefaultLimit != 0 {
-		return inputs.DefaultLimit
-	}
-
-	return search.DefaultMaxSearchResults
+	return inputs.Query.MaxResults(inputs.DefaultLimit)
 }
 
 // Job is an interface shared by all individual search operations in the

--- a/internal/search/structural/structural.go
+++ b/internal/search/structural/structural.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/limits"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	searchrepos "github.com/sourcegraph/sourcegraph/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
@@ -106,7 +107,7 @@ func retryStructuralSearch(ctx context.Context, args *search.SearcherParameters,
 }
 
 func runStructuralSearch(ctx context.Context, args *search.SearcherParameters, repos []repoData, stream streaming.Sender) error {
-	if args.PatternInfo.FileMatchLimit != search.DefaultMaxSearchResults {
+	if args.PatternInfo.FileMatchLimit != limits.DefaultMaxSearchResults {
 		// streamStructuralSearch performs a streaming search when the user sets a value
 		// for `count`. The first return parameter indicates whether the request was
 		// serviced with streaming.

--- a/internal/search/textsearch/textsearch_test.go
+++ b/internal/search/textsearch/textsearch_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
+	"github.com/sourcegraph/sourcegraph/internal/search/limits"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/searcher"
@@ -89,7 +90,7 @@ func TestSearchFilesInRepos(t *testing.T) {
 	repoRevs := makeRepositoryRevisions("foo/one", "foo/two", "foo/empty", "foo/cloning", "foo/missing", "foo/missing-database", "foo/timedout", "foo/no-rev")
 	args := &search.TextParameters{
 		PatternInfo: &search.TextPatternInfo{
-			FileMatchLimit: search.DefaultMaxSearchResults,
+			FileMatchLimit: limits.DefaultMaxSearchResults,
 			Pattern:        "foo",
 		},
 		Repos:        repoRevs,
@@ -130,7 +131,7 @@ func TestSearchFilesInRepos(t *testing.T) {
 	// that should be checked earlier.
 	args = &search.TextParameters{
 		PatternInfo: &search.TextPatternInfo{
-			FileMatchLimit: search.DefaultMaxSearchResults,
+			FileMatchLimit: limits.DefaultMaxSearchResults,
 			Pattern:        "foo",
 		},
 		Repos:        makeRepositoryRevisions("foo/no-rev@dev"),
@@ -206,7 +207,7 @@ func TestSearchFilesInReposStream(t *testing.T) {
 	}
 	args := &search.TextParameters{
 		PatternInfo: &search.TextPatternInfo{
-			FileMatchLimit: search.DefaultMaxSearchResults,
+			FileMatchLimit: limits.DefaultMaxSearchResults,
 			Pattern:        "foo",
 		},
 		Repos:        makeRepositoryRevisions("foo/one", "foo/two", "foo/three"),
@@ -285,7 +286,7 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 	}
 	args := &search.TextParameters{
 		PatternInfo: &search.TextPatternInfo{
-			FileMatchLimit: search.DefaultMaxSearchResults,
+			FileMatchLimit: limits.DefaultMaxSearchResults,
 			Pattern:        "foo",
 		},
 		Repos:        makeRepositoryRevisions("foo@master:mybranch:*refs/heads/"),
@@ -345,7 +346,7 @@ func TestRepoShouldBeSearched(t *testing.T) {
 	}
 	defer func() { searcher.MockSearch = nil }()
 	info := &search.TextPatternInfo{
-		FileMatchLimit:               search.DefaultMaxSearchResults,
+		FileMatchLimit:               limits.DefaultMaxSearchResults,
 		Pattern:                      "foo",
 		FilePatternsReposMustInclude: []string{"main"},
 	}

--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -9,9 +9,9 @@ import (
 	zoektquery "github.com/google/zoekt/query"
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go"
-	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 
-	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/filter"
+	"github.com/sourcegraph/sourcegraph/internal/search/limits"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -77,8 +77,8 @@ func SearchOpts(ctx context.Context, k int, fileMatchLimit int32, selector filte
 		MaxWallTime: defaultTimeout,
 	}
 
-	if userProbablyWantsToWaitLonger := fileMatchLimit > search.DefaultMaxSearchResults; userProbablyWantsToWaitLonger {
-		searchOpts.MaxWallTime *= time.Duration(3 * float64(fileMatchLimit) / float64(search.DefaultMaxSearchResults))
+	if userProbablyWantsToWaitLonger := fileMatchLimit > limits.DefaultMaxSearchResults; userProbablyWantsToWaitLonger {
+		searchOpts.MaxWallTime *= time.Duration(3 * float64(fileMatchLimit) / float64(limits.DefaultMaxSearchResults))
 	}
 
 	if selector.Root() == filter.Repository {
@@ -121,8 +121,8 @@ func ResultCountFactor(numRepos int, fileMatchLimit int32, globalSearch bool) (k
 			k = 1
 		}
 	}
-	if fileMatchLimit > search.DefaultMaxSearchResults {
-		k = int(float64(k) * 3 * float64(fileMatchLimit) / float64(search.DefaultMaxSearchResults))
+	if fileMatchLimit > limits.DefaultMaxSearchResults {
+		k = int(float64(k) * 3 * float64(fileMatchLimit) / float64(limits.DefaultMaxSearchResults))
 	}
 	return k
 }


### PR DESCRIPTION
This mints a `limits` package so it can be referenced from `query` to compute `MaxResults` without relying on search input state. This is setup for other changes to break resolver dependencies.

## Test plan
Semantics-preserving, covered by tests.


