### PR TITLE
search: move job logic out of gqlbackend

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -7,11 +7,9 @@ import (
 	"math"
 	"sort"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
-	"github.com/google/zoekt"
 	"github.com/grafana/regexp"
 	"github.com/inconshreveable/log15"
 	"github.com/neelance/parallel"
@@ -29,7 +27,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/deviceid"
-	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/honey"
@@ -37,18 +34,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/alert"
-	"github.com/sourcegraph/sourcegraph/internal/search/commit"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
+	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
-	searchrepos "github.com/sourcegraph/sourcegraph/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/run"
-	"github.com/sourcegraph/sourcegraph/internal/search/searchcontexts"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
-	"github.com/sourcegraph/sourcegraph/internal/search/structural"
-	"github.com/sourcegraph/sourcegraph/internal/search/symbol"
-	"github.com/sourcegraph/sourcegraph/internal/search/textsearch"
-	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -469,586 +460,21 @@ func LogSearchLatency(ctx context.Context, db database.DB, wg *sync.WaitGroup, s
 	}
 }
 
-func toRepoOptions(q query.Q, userSettings *schema.Settings) search.RepoOptions {
-	repoFilters, minusRepoFilters := q.Repositories()
-
-	var settingForks, settingArchived bool
-	if v := userSettings.SearchIncludeForks; v != nil {
-		settingForks = *v
-	}
-	if v := userSettings.SearchIncludeArchived; v != nil {
-		settingArchived = *v
-	}
-
-	fork := query.No
-	if searchrepos.ExactlyOneRepo(repoFilters) || settingForks {
-		// fork defaults to No unless either of:
-		// (1) exactly one repo is being searched, or
-		// (2) user/org/global setting includes forks
-		fork = query.Yes
-	}
-	if setFork := q.Fork(); setFork != nil {
-		fork = *setFork
-	}
-
-	archived := query.No
-	if searchrepos.ExactlyOneRepo(repoFilters) || settingArchived {
-		// archived defaults to No unless either of:
-		// (1) exactly one repo is being searched, or
-		// (2) user/org/global setting includes archives in all searches
-		archived = query.Yes
-	}
-	if setArchived := q.Archived(); setArchived != nil {
-		archived = *setArchived
-	}
-
-	visibilityStr, _ := q.StringValue(query.FieldVisibility)
-	visibility := query.ParseVisibility(visibilityStr)
-
-	commitAfter, _ := q.StringValue(query.FieldRepoHasCommitAfter)
-	searchContextSpec, _ := q.StringValue(query.FieldContext)
-
-	return search.RepoOptions{
-		RepoFilters:       repoFilters,
-		MinusRepoFilters:  minusRepoFilters,
-		SearchContextSpec: searchContextSpec,
-		UserSettings:      userSettings,
-		OnlyForks:         fork == query.Only,
-		NoForks:           fork == query.No,
-		OnlyArchived:      archived == query.Only,
-		NoArchived:        archived == query.No,
-		Visibility:        visibility,
-		CommitAfter:       commitAfter,
-		Query:             q,
-	}
-}
-
-func withMode(args search.TextParameters, st query.SearchType) search.TextParameters {
-	isGlobalSearch := func() bool {
-		if st == query.SearchTypeStructural {
-			return false
-		}
-
-		return query.ForAll(args.Query, func(node query.Node) bool {
-			n, ok := node.(query.Parameter)
-			if !ok {
-				return true
-			}
-			switch n.Field {
-			case query.FieldContext:
-				return searchcontexts.IsGlobalSearchContextSpec(n.Value)
-			case query.FieldRepo:
-				// We allow -repo: in global search.
-				return n.Negated
-			case
-				query.FieldRepoHasFile:
-				return false
-			default:
-				return true
-			}
-		})
-	}
-
-	hasGlobalSearchResultType := args.ResultTypes.Has(result.TypeFile | result.TypePath | result.TypeSymbol)
-	isIndexedSearch := args.PatternInfo.Index != query.No
-	isEmpty := args.PatternInfo.Pattern == "" && args.PatternInfo.ExcludePattern == "" && len(args.PatternInfo.IncludePatterns) == 0
-	if isGlobalSearch() && isIndexedSearch && hasGlobalSearchResultType && !isEmpty {
-		args.Mode = search.ZoektGlobalSearch
-	}
-	if isEmpty {
-		args.Mode = search.SkipUnindexed
-	}
-	return args
-}
-
-func toFeatures(flags featureflag.FlagSet) search.Features {
-	if flags == nil {
-		flags = featureflag.FlagSet{}
-		metricFeatureFlagUnavailable.Inc()
-		log15.Warn("search feature flags are not available")
-	}
-
-	return search.Features{
-		ContentBasedLangFilters: flags.GetBoolOr("search-content-based-lang-detection", false),
-	}
-}
-
-type JobArgs struct {
-	SearchInputs *run.SearchInputs
-	Protocol     search.Protocol
-	PatternType  query.SearchType
-	Zoekt        zoekt.Streamer
-	SearcherURLs *endpoint.Map
-}
-
 // JobArgs converts the parts of search resolver state to values needed to create search jobs.
-func (r *searchResolver) JobArgs() *JobArgs {
-	return &JobArgs{
-		SearchInputs: r.SearchInputs,
-		Protocol:     r.protocol(),
-		PatternType:  r.PatternType,
-		Zoekt:        r.zoekt,
-		SearcherURLs: r.searcherURLs,
+func (r *searchResolver) JobArgs() *job.Args {
+	return &job.Args{
+		SearchInputs:        r.SearchInputs,
+		OnSourcegraphDotCom: envvar.SourcegraphDotComMode(),
+		Protocol:            r.protocol(),
+		PatternType:         r.PatternType,
+		Zoekt:               r.zoekt,
+		SearcherURLs:        r.searcherURLs,
 	}
-}
-
-// toSearchJob converts a query parse tree to the _internal_ representation
-// needed to run a search routine. To understand why this conversion matters, think
-// about the fact that the query parse tree doesn't know anything about our
-// backends or architecture. It doesn't decide certain defaults, like whether we
-// should return multiple result types (pattern matches content, or a file name,
-// or a repo name). If we want to optimize a Sourcegraph query parse tree for a
-// particular backend (e.g., skip repository resolution and just run a Zoekt
-// query on all indexed repositories) then we need to convert our tree to
-// Zoekt's internal inputs and representation. These concerns are all handled by
-// toSearchJob.
-func toSearchJob(jargs *JobArgs, q query.Q) (run.Job, error) {
-	maxResults := q.MaxResults(jargs.SearchInputs.DefaultLimit)
-
-	b, err := query.ToBasicQuery(q)
-	if err != nil {
-		return nil, err
-	}
-
-	p := search.ToTextPatternInfo(b, jargs.Protocol, query.Identity)
-
-	forceResultTypes := result.TypeEmpty
-	if jargs.PatternType == query.SearchTypeStructural {
-		if p.Pattern == "" {
-			// Fallback to literal search for searching repos and files if
-			// the structural search pattern is empty.
-			jargs.PatternType = query.SearchTypeLiteral
-			p.IsStructuralPat = false
-			forceResultTypes = result.Types(0)
-		} else {
-			forceResultTypes = result.TypeStructural
-		}
-	}
-
-	args := search.TextParameters{
-		PatternInfo: p,
-		Query:       q,
-		Features:    toFeatures(jargs.SearchInputs.Features),
-		Timeout:     search.TimeoutDuration(b),
-
-		// UseFullDeadline if timeout: set or we are streaming.
-		UseFullDeadline: q.Timeout() != nil || q.Count() != nil || jargs.Protocol == search.Streaming,
-
-		Zoekt:        jargs.Zoekt,
-		SearcherURLs: jargs.SearcherURLs,
-	}
-	args = withResultTypes(args, forceResultTypes)
-	args = withMode(args, jargs.PatternType)
-	repoOptions := toRepoOptions(args.Query, jargs.SearchInputs.UserSettings)
-	// explicitly populate RepoOptions field in args, because the repo search job
-	// still relies on all of args. In time it should depend only on the bits it truly needs.
-	args.RepoOptions = repoOptions
-
-	var requiredJobs, optionalJobs []run.Job
-	addJob := func(required bool, job run.Job) {
-		// Filter out any jobs that aren't commit jobs as they are added
-		if jargs.SearchInputs.CodeMonitorID != nil {
-			if _, ok := job.(*commit.CommitSearch); !ok {
-				return
-			}
-		}
-
-		if required {
-			requiredJobs = append(requiredJobs, job)
-		} else {
-			optionalJobs = append(optionalJobs, job)
-		}
-	}
-
-	{
-		// This code block creates search jobs under specific
-		// conditions, and depending on generic process of `args` above.
-		// It which specializes search logic in doResults. In time, all
-		// of the above logic should be used to create search jobs
-		// across all of Sourcegraph.
-
-		globalSearch := args.Mode == search.ZoektGlobalSearch
-		// skipUnindexed is a value that controls whether to run
-		// unindexed search in a specific scenario of queries that
-		// contain no repo-affecting filters (global mode). When on
-		// sourcegraph.com, we resolve only a subset of all indexed
-		// repos to search. This control flow implies len(searcherRepos)
-		// is always 0, meaning that we should not create jobs to run
-		// unindexed searcher.
-		skipUnindexed := args.Mode == search.SkipUnindexed || (globalSearch && envvar.SourcegraphDotComMode())
-		// searcherOnly is a value that controls whether to run
-		// unindexed search in one of two scenarios. The first scenario
-		// depends on if index:no is set (value true). The second
-		// scenario happens if queries contain no repo-affecting filters
-		// (global mode). When NOT on sourcegraph.com the we _may_
-		// resolve some subset of nonindexed repos to search, so wemay
-		// generate jobs that run searcher, but it is conditional on
-		// whether global zoekt search will run (value true).
-		searcherOnly := args.Mode == search.SearcherOnly || (globalSearch && !envvar.SourcegraphDotComMode())
-
-		if globalSearch {
-			defaultScope, err := zoektutil.DefaultGlobalQueryScope(repoOptions)
-			if err != nil {
-				return nil, err
-			}
-			includePrivate := repoOptions.Visibility == query.Private || repoOptions.Visibility == query.Any
-
-			if args.ResultTypes.Has(result.TypeFile | result.TypePath) {
-				typ := search.TextRequest
-				zoektQuery, err := search.QueryToZoektQuery(args.PatternInfo, &args.Features, typ)
-				if err != nil {
-					return nil, err
-				}
-
-				globalZoektQuery := zoektutil.NewGlobalZoektQuery(zoektQuery, defaultScope, includePrivate)
-
-				zoektArgs := &search.ZoektParameters{
-					// TODO(rvantonder): the Query value is set when the global zoekt query is
-					// enriched with private repository data in the search job's Run method, and
-					// is therefore set to `nil` below.
-					// Ideally, The ZoektParameters type should not expose this field for Universe text
-					// searches at all, and will be removed once jobs are fully migrated.
-					Query:          nil,
-					Typ:            typ,
-					FileMatchLimit: args.PatternInfo.FileMatchLimit,
-					Select:         args.PatternInfo.Select,
-					Zoekt:          args.Zoekt,
-				}
-
-				addJob(true, &textsearch.RepoUniverseTextSearch{
-					GlobalZoektQuery: globalZoektQuery,
-					ZoektArgs:        zoektArgs,
-
-					RepoOptions: repoOptions,
-				})
-			}
-
-			if args.ResultTypes.Has(result.TypeSymbol) {
-				typ := search.SymbolRequest
-				zoektQuery, err := search.QueryToZoektQuery(args.PatternInfo, &args.Features, typ)
-				if err != nil {
-					return nil, err
-				}
-				globalZoektQuery := zoektutil.NewGlobalZoektQuery(zoektQuery, defaultScope, includePrivate)
-
-				zoektArgs := &search.ZoektParameters{
-					Query:          nil,
-					Typ:            typ,
-					FileMatchLimit: args.PatternInfo.FileMatchLimit,
-					Select:         args.PatternInfo.Select,
-					Zoekt:          args.Zoekt,
-				}
-
-				addJob(true, &symbol.RepoUniverseSymbolSearch{
-					GlobalZoektQuery: globalZoektQuery,
-					ZoektArgs:        zoektArgs,
-					PatternInfo:      args.PatternInfo,
-					Limit:            maxResults,
-
-					RepoOptions: repoOptions,
-				})
-			}
-		}
-
-		if args.ResultTypes.Has(result.TypeFile | result.TypePath) {
-			if !skipUnindexed {
-				typ := search.TextRequest
-				// TODO(rvantonder): we don't always have to run
-				// this converter. It depends on whether we run
-				// a zoekt search at all.
-				zoektQuery, err := search.QueryToZoektQuery(args.PatternInfo, &args.Features, typ)
-				if err != nil {
-					return nil, err
-				}
-				zoektArgs := &search.ZoektParameters{
-					Query:          zoektQuery,
-					Typ:            typ,
-					FileMatchLimit: args.PatternInfo.FileMatchLimit,
-					Select:         args.PatternInfo.Select,
-					Zoekt:          args.Zoekt,
-				}
-
-				searcherArgs := &search.SearcherParameters{
-					SearcherURLs:    args.SearcherURLs,
-					PatternInfo:     args.PatternInfo,
-					UseFullDeadline: args.UseFullDeadline,
-				}
-
-				addJob(true, &textsearch.RepoSubsetTextSearch{
-					ZoektArgs:        zoektArgs,
-					SearcherArgs:     searcherArgs,
-					NotSearcherOnly:  !searcherOnly,
-					UseIndex:         args.PatternInfo.Index,
-					ContainsRefGlobs: query.ContainsRefGlobs(q),
-					RepoOpts:         repoOptions,
-				})
-			}
-		}
-
-		if args.ResultTypes.Has(result.TypeSymbol) && args.PatternInfo.Pattern != "" {
-			if !skipUnindexed {
-				typ := search.SymbolRequest
-				zoektQuery, err := search.QueryToZoektQuery(args.PatternInfo, &args.Features, typ)
-				if err != nil {
-					return nil, err
-				}
-				zoektArgs := &search.ZoektParameters{
-					Query:          zoektQuery,
-					Typ:            typ,
-					FileMatchLimit: args.PatternInfo.FileMatchLimit,
-					Select:         args.PatternInfo.Select,
-					Zoekt:          args.Zoekt,
-				}
-
-				required := args.UseFullDeadline || args.ResultTypes.Without(result.TypeSymbol) == 0
-				addJob(required, &symbol.RepoSubsetSymbolSearch{
-					ZoektArgs:        zoektArgs,
-					PatternInfo:      args.PatternInfo,
-					Limit:            maxResults,
-					NotSearcherOnly:  !searcherOnly,
-					UseIndex:         args.PatternInfo.Index,
-					ContainsRefGlobs: query.ContainsRefGlobs(q),
-					RepoOpts:         repoOptions,
-				})
-			}
-		}
-
-		if args.ResultTypes.Has(result.TypeCommit) || args.ResultTypes.Has(result.TypeDiff) {
-			diff := args.ResultTypes.Has(result.TypeDiff)
-			var required bool
-			if args.UseFullDeadline {
-				required = true
-			} else if diff {
-				required = args.ResultTypes.Without(result.TypeDiff) == 0
-			} else {
-				required = args.ResultTypes.Without(result.TypeCommit) == 0
-			}
-			addJob(required, &commit.CommitSearch{
-				Query:                commit.QueryToGitQuery(args.Query, diff),
-				RepoOpts:             repoOptions,
-				Diff:                 diff,
-				HasTimeFilter:        commit.HasTimeFilter(args.Query),
-				Limit:                int(args.PatternInfo.FileMatchLimit),
-				CodeMonitorID:        jargs.SearchInputs.CodeMonitorID,
-				IncludeModifiedFiles: authz.SubRepoEnabled(authz.DefaultSubRepoPermsChecker),
-			})
-		}
-
-		if jargs.PatternType == query.SearchTypeStructural && p.Pattern != "" {
-			typ := search.TextRequest
-			zoektQuery, err := search.QueryToZoektQuery(args.PatternInfo, &args.Features, typ)
-			if err != nil {
-				return nil, err
-			}
-			zoektArgs := &search.ZoektParameters{
-				Query:          zoektQuery,
-				Typ:            typ,
-				FileMatchLimit: args.PatternInfo.FileMatchLimit,
-				Select:         args.PatternInfo.Select,
-				Zoekt:          args.Zoekt,
-			}
-
-			searcherArgs := &search.SearcherParameters{
-				SearcherURLs:    args.SearcherURLs,
-				PatternInfo:     args.PatternInfo,
-				UseFullDeadline: args.UseFullDeadline,
-			}
-
-			addJob(true, &structural.StructuralSearch{
-				ZoektArgs:    zoektArgs,
-				SearcherArgs: searcherArgs,
-
-				NotSearcherOnly:  !searcherOnly,
-				UseIndex:         args.PatternInfo.Index,
-				ContainsRefGlobs: query.ContainsRefGlobs(q),
-				RepoOpts:         repoOptions,
-			})
-		}
-
-		if args.ResultTypes.Has(result.TypeRepo) {
-			valid := func() bool {
-				fieldAllowlist := map[string]struct{}{
-					query.FieldRepo:               {},
-					query.FieldContext:            {},
-					query.FieldType:               {},
-					query.FieldDefault:            {},
-					query.FieldIndex:              {},
-					query.FieldCount:              {},
-					query.FieldTimeout:            {},
-					query.FieldFork:               {},
-					query.FieldArchived:           {},
-					query.FieldVisibility:         {},
-					query.FieldCase:               {},
-					query.FieldRepoHasFile:        {},
-					query.FieldRepoHasCommitAfter: {},
-					query.FieldPatternType:        {},
-					query.FieldSelect:             {},
-				}
-
-				// Don't run a repo search if the search contains fields that aren't on the allowlist.
-				for field := range args.Query.Fields() {
-					if _, ok := fieldAllowlist[field]; !ok {
-						return false
-					}
-				}
-				return true
-			}
-
-			// returns an updated RepoOptions if the pattern part of a query can be used to
-			// search repos. A problematic case we check for is when the pattern contains `@`,
-			// which may confuse downstream logic to interpret it as part of `repo@rev` syntax.
-			addPatternAsRepoFilter := func(pattern string, opts search.RepoOptions) (search.RepoOptions, bool) {
-				if pattern == "" {
-					return opts, true
-				}
-
-				opts.RepoFilters = append(make([]string, 0, len(opts.RepoFilters)), opts.RepoFilters...)
-				opts.CaseSensitiveRepoFilters = args.Query.IsCaseSensitive()
-
-				patternPrefix := strings.SplitN(pattern, "@", 2)
-				if len(patternPrefix) == 1 {
-					// No "@" in pattern? We're good.
-					opts.RepoFilters = append(opts.RepoFilters, pattern)
-					return opts, true
-				}
-
-				if patternPrefix[0] != "" {
-					// Extend the repo search using the pattern value, but
-					// since the pattern contains @, only search the part
-					// prefixed by the first @. This because downstream
-					// logic will get confused by the presence of @ and try
-					// to resolve repo revisions. See #27816.
-					if _, err := regexp.Compile(patternPrefix[0]); err != nil {
-						// Prefix is not valid regexp, so just reject it. This can happen for patterns where we've automatically added `(...).*?(...)`
-						// such as `foo @bar` which becomes `(foo).*?(@bar)`, which when stripped becomes `(foo).*?(` which is unbalanced and invalid.
-						// Why is this a mess? Because validation for everything, including repo values, should be done up front so far possible, not downtsream
-						// after possible modifications. By the time we reach this code, the pattern should already have been considered valid to continue with
-						// a search. But fixing the order of concerns for repo code is not something @rvantonder is doing today.
-						return search.RepoOptions{}, false
-					}
-					opts.RepoFilters = append(opts.RepoFilters, patternPrefix[0])
-					return opts, true
-				}
-
-				// This pattern starts with @, of the form "@thing". We can't
-				// consistently handle search repos of this form, because
-				// downstream logic will attempt to interpret "thing" as a repo
-				// revision, may fail, and cause us to raise an alert for any
-				// non `type:repo` search. Better to not attempt a repo search.
-				return search.RepoOptions{}, false
-			}
-
-			if valid() {
-				if repoOptions, ok := addPatternAsRepoFilter(args.PatternInfo.Pattern, repoOptions); ok {
-					args.RepoOptions = repoOptions
-					addJob(true, &run.RepoSearch{
-						Args: &args,
-					})
-				}
-			}
-		}
-	}
-
-	addJob(true, &searchrepos.ComputeExcludedRepos{
-		Options: repoOptions,
-	})
-
-	job := run.NewPriorityJob(
-		run.NewParallelJob(requiredJobs...),
-		run.NewParallelJob(optionalJobs...),
-	)
-
-	checker := authz.DefaultSubRepoPermsChecker
-	if authz.SubRepoEnabled(checker) {
-		job = run.NewFilterJob(job)
-	}
-
-	return job, nil
-}
-
-// toAndJob creates a new job from a basic query whose pattern is an And operator at the root.
-func toAndJob(args *JobArgs, q query.Basic) (run.Job, error) {
-	// Invariant: this function is only reachable from callers that
-	// guarantee a root node with one or more queryOperands.
-	queryOperands := q.Pattern.(query.Operator).Operands
-
-	// Limit the number of results from each child to avoid a huge amount of memory bloat.
-	// With streaming, we should re-evaluate this number.
-	//
-	// NOTE: It may be possible to page over repos so that each intersection is only over
-	// a small set of repos, limiting massive number of results that would need to be
-	// kept in memory otherwise.
-	maxTryCount := 40000
-
-	operands := make([]run.Job, 0, len(queryOperands))
-	for _, queryOperand := range queryOperands {
-		operand, err := toPatternExpressionJob(args, q.MapPattern(queryOperand))
-		if err != nil {
-			return nil, err
-		}
-		operands = append(operands, run.NewLimitJob(maxTryCount, operand))
-	}
-
-	return run.NewAndJob(operands...), nil
-}
-
-// toOrJob creates a new job from a basic query whose pattern is an Or operator at the top level
-func toOrJob(args *JobArgs, q query.Basic) (run.Job, error) {
-	// Invariant: this function is only reachable from callers that
-	// guarantee a root node with one or more queryOperands.
-	queryOperands := q.Pattern.(query.Operator).Operands
-
-	operands := make([]run.Job, 0, len(queryOperands))
-	for _, term := range queryOperands {
-		operand, err := toPatternExpressionJob(args, q.MapPattern(term))
-		if err != nil {
-			return nil, err
-		}
-		operands = append(operands, operand)
-	}
-	return run.NewOrJob(operands...), nil
-}
-
-func toPatternExpressionJob(args *JobArgs, q query.Basic) (run.Job, error) {
-	switch term := q.Pattern.(type) {
-	case query.Operator:
-		if len(term.Operands) == 0 {
-			return run.NewNoopJob(), nil
-		}
-
-		switch term.Kind {
-		case query.And:
-			return toAndJob(args, q)
-		case query.Or:
-			return toOrJob(args, q)
-		case query.Concat:
-			return toSearchJob(args, q.ToParseTree())
-		}
-	case query.Pattern:
-		return toSearchJob(args, q.ToParseTree())
-	case query.Parameter:
-		// evaluatePatternExpression does not process Parameter nodes.
-		return run.NewNoopJob(), nil
-	}
-	// Unreachable.
-	return nil, errors.Errorf("unrecognized type %T in evaluatePatternExpression", q.Pattern)
-}
-
-func toEvaluateJob(args *JobArgs, q query.Basic) (run.Job, error) {
-	maxResults := q.ToParseTree().MaxResults(args.SearchInputs.DefaultLimit)
-	timeout := search.TimeoutDuration(q)
-
-	if q.Pattern == nil {
-		job, err := toSearchJob(args, query.ToNodes(q.Parameters))
-		return run.NewTimeoutJob(timeout, run.NewLimitJob(maxResults, job)), err
-	}
-	job, err := toPatternExpressionJob(args, q)
-	return run.NewTimeoutJob(timeout, run.NewLimitJob(maxResults, job)), err
 }
 
 // evaluate evaluates all expressions of a search query. The value of stream must be non-nil
-func (r *searchResolver) evaluate(ctx context.Context, stream streaming.Sender, args *JobArgs, q query.Basic) (*search.Alert, error) {
-	j, err := toEvaluateJob(args, q)
+func (r *searchResolver) evaluate(ctx context.Context, stream streaming.Sender, args *job.Args, q query.Basic) (*search.Alert, error) {
+	j, err := job.ToEvaluateJob(args, q)
 	if err != nil {
 		return nil, err
 	}
@@ -1598,12 +1024,12 @@ func (r *searchResolver) Stats(ctx context.Context) (stats *searchResultsStats, 
 	for {
 		// Query search results.
 		var err error
-		job, err := toSearchJob(args, r.Query)
+		j, err := job.ToSearchJob(args, r.Query)
 		if err != nil {
 			return nil, err
 		}
 		agg := streaming.NewAggregatingStream()
-		_, err = job.Run(ctx, r.db, agg)
+		_, err = j.Run(ctx, r.db, agg)
 		if err != nil {
 			return nil, err // do not cache errors.
 		}
@@ -1663,34 +1089,6 @@ func (r *searchResolver) Stats(ctx context.Context) (stats *searchResultsStats, 
 	return stats, nil
 }
 
-// withResultTypes populates the ResultTypes field of args, which drives the kind
-// of search to run (e.g., text search, symbol search).
-func withResultTypes(args search.TextParameters, forceTypes result.Types) search.TextParameters {
-	var rts result.Types
-	if forceTypes != 0 {
-		rts = forceTypes
-	} else {
-		stringTypes, _ := args.Query.StringValues(query.FieldType)
-		if len(stringTypes) == 0 {
-			rts = result.TypeFile | result.TypePath | result.TypeRepo
-		} else {
-			for _, stringType := range stringTypes {
-				rts = rts.With(result.TypeFromString[stringType])
-			}
-		}
-	}
-
-	if rts.Has(result.TypeFile) {
-		args.PatternInfo.PatternMatchesContent = true
-	}
-
-	if rts.Has(result.TypePath) {
-		args.PatternInfo.PatternMatchesPath = true
-	}
-	args.ResultTypes = rts
-	return args
-}
-
 // isContextError returns true if ctx.Err() is not nil or if err
 // is an error caused by context cancelation or timeout.
 func isContextError(ctx context.Context, err error) bool {
@@ -1713,8 +1111,3 @@ type SearchResultResolver interface {
 
 	ResultCount() int32
 }
-
-var metricFeatureFlagUnavailable = promauto.NewCounter(prometheus.CounterOpts{
-	Name: "src_search_featureflag_unavailable",
-	Help: "temporary counter to check if we have feature flag available in practice.",
-})

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/inventory"
+	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -40,13 +41,13 @@ func (srs *searchResultsStats) Languages(ctx context.Context) ([]*languageStatis
 func (srs *searchResultsStats) getResults(ctx context.Context) (result.Matches, error) {
 	args := srs.sr.JobArgs()
 	srs.once.Do(func() {
-		job, err := toSearchJob(args, srs.sr.Query)
+		j, err := job.ToSearchJob(args, srs.sr.Query)
 		if err != nil {
 			srs.err = err
 			return
 		}
 		agg := streaming.NewAggregatingStream()
-		_, err = job.Run(ctx, srs.sr.db, agg)
+		_, err = j.Run(ctx, srs.sr.db, agg)
 		if err != nil {
 			srs.err = err
 			return

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -12,7 +12,6 @@ import (
 	mockrequire "github.com/derision-test/go-mockgen/testutil/require"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/zoekt"
-	"github.com/hexops/autogold"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 
@@ -764,47 +763,6 @@ func TestSearchContext(t *testing.T) {
 			}
 		})
 	}
-}
-
-func Test_toSearchInputs(t *testing.T) {
-	orig := envvar.SourcegraphDotComMode()
-	envvar.MockSourcegraphDotComMode(true)
-	defer envvar.MockSourcegraphDotComMode(orig)
-
-	test := func(input string, parser func(string) (query.Q, error)) string {
-		q, _ := parser(input)
-		resolver := searchResolver{
-			SearchInputs: &run.SearchInputs{
-				Query:        q,
-				UserSettings: &schema.Settings{},
-				PatternType:  query.SearchTypeLiteral,
-			},
-		}
-
-		args := resolver.JobArgs()
-		job, _ := toSearchJob(args, q)
-		return job.Name()
-	}
-
-	// Job generation for global vs non-global search
-	autogold.Want("user search context", "ParallelJob{RepoSubsetText, Repo, ComputeExcludedRepos}").Equal(t, test(`foo context:@userA`, query.ParseLiteral))
-	autogold.Want("universal (AKA global) search context", "ParallelJob{RepoUniverseText, Repo, ComputeExcludedRepos}").Equal(t, test(`foo context:global`, query.ParseLiteral))
-	autogold.Want("universal (AKA global) search", "ParallelJob{RepoUniverseText, Repo, ComputeExcludedRepos}").Equal(t, test(`foo`, query.ParseLiteral))
-	autogold.Want("nonglobal repo", "ParallelJob{RepoSubsetText, Repo, ComputeExcludedRepos}").Equal(t, test(`foo repo:sourcegraph/sourcegraph`, query.ParseLiteral))
-	autogold.Want("nonglobal repo contains", "ParallelJob{RepoSubsetText, Repo, ComputeExcludedRepos}").Equal(t, test(`foo repo:contains(bar)`, query.ParseLiteral))
-
-	// Job generation support for implied `type:repo` queries.
-	autogold.Want("supported Repo job", "ParallelJob{RepoUniverseText, Repo, ComputeExcludedRepos}").Equal(t, test("ok ok", query.ParseRegexp))
-	autogold.Want("supportedRepo job literal", "ParallelJob{RepoUniverseText, Repo, ComputeExcludedRepos}").Equal(t, test("ok @thing", query.ParseLiteral))
-	autogold.Want("unsupported Repo job prefix", "ParallelJob{RepoUniverseText, ComputeExcludedRepos}").Equal(t, test("@nope", query.ParseRegexp))
-	autogold.Want("unsupported Repo job regexp", "ParallelJob{RepoUniverseText, ComputeExcludedRepos}").Equal(t, test("foo @bar", query.ParseRegexp))
-
-	// Job generation for other types of search
-	autogold.Want("symbol", "ParallelJob{RepoUniverseSymbol, ComputeExcludedRepos}").Equal(t, test("type:symbol test", query.ParseRegexp))
-	autogold.Want("commit", "ParallelJob{Commit, ComputeExcludedRepos}").Equal(t, test("type:commit test", query.ParseRegexp))
-	autogold.Want("diff", "ParallelJob{Diff, ComputeExcludedRepos}").Equal(t, test("type:diff test", query.ParseRegexp))
-	autogold.Want("file or commit", "JobWithOptional{Required: ParallelJob{RepoUniverseText, ComputeExcludedRepos}, Optional: Commit}").Equal(t, test("type:file type:commit test", query.ParseRegexp))
-	autogold.Want("many types", "JobWithOptional{Required: ParallelJob{RepoSubsetText, Repo, ComputeExcludedRepos}, Optional: ParallelJob{RepoSubsetSymbol, Commit}}").Equal(t, test("type:file type:path type:repo type:commit type:symbol repo:test test", query.ParseRegexp))
 }
 
 func TestZeroElapsedMilliseconds(t *testing.T) {

--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -1,0 +1,628 @@
+package job
+
+import (
+	"strings"
+
+	"github.com/google/zoekt"
+	"github.com/grafana/regexp"
+	"github.com/inconshreveable/log15"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/endpoint"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/commit"
+	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	searchrepos "github.com/sourcegraph/sourcegraph/internal/search/repos"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/internal/search/run"
+	"github.com/sourcegraph/sourcegraph/internal/search/searchcontexts"
+	"github.com/sourcegraph/sourcegraph/internal/search/structural"
+	"github.com/sourcegraph/sourcegraph/internal/search/symbol"
+	"github.com/sourcegraph/sourcegraph/internal/search/textsearch"
+	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+type Args struct {
+	SearchInputs        *run.SearchInputs
+	OnSourcegraphDotCom bool
+	Protocol            search.Protocol
+	PatternType         query.SearchType
+	Zoekt               zoekt.Streamer
+	SearcherURLs        *endpoint.Map
+}
+
+// ToSearchJob converts a query parse tree to the _internal_ representation
+// needed to run a search routine. To understand why this conversion matters, think
+// about the fact that the query parse tree doesn't know anything about our
+// backends or architecture. It doesn't decide certain defaults, like whether we
+// should return multiple result types (pattern matches content, or a file name,
+// or a repo name). If we want to optimize a Sourcegraph query parse tree for a
+// particular backend (e.g., skip repository resolution and just run a Zoekt
+// query on all indexed repositories) then we need to convert our tree to
+// Zoekt's internal inputs and representation. These concerns are all handled by
+// toSearchJob.
+func ToSearchJob(jargs *Args, q query.Q) (run.Job, error) {
+	maxResults := q.MaxResults(jargs.SearchInputs.DefaultLimit)
+
+	b, err := query.ToBasicQuery(q)
+	if err != nil {
+		return nil, err
+	}
+
+	p := search.ToTextPatternInfo(b, jargs.Protocol, query.Identity)
+
+	forceResultTypes := result.TypeEmpty
+	if jargs.PatternType == query.SearchTypeStructural {
+		if p.Pattern == "" {
+			// Fallback to literal search for searching repos and files if
+			// the structural search pattern is empty.
+			jargs.PatternType = query.SearchTypeLiteral
+			p.IsStructuralPat = false
+			forceResultTypes = result.Types(0)
+		} else {
+			forceResultTypes = result.TypeStructural
+		}
+	}
+
+	args := search.TextParameters{
+		PatternInfo: p,
+		Query:       q,
+		Features:    toFeatures(jargs.SearchInputs.Features),
+		Timeout:     search.TimeoutDuration(b),
+
+		// UseFullDeadline if timeout: set or we are streaming.
+		UseFullDeadline: q.Timeout() != nil || q.Count() != nil || jargs.Protocol == search.Streaming,
+
+		Zoekt:        jargs.Zoekt,
+		SearcherURLs: jargs.SearcherURLs,
+	}
+	args = withResultTypes(args, forceResultTypes)
+	args = withMode(args, jargs.PatternType)
+	repoOptions := toRepoOptions(args.Query, jargs.SearchInputs.UserSettings)
+	// explicitly populate RepoOptions field in args, because the repo search job
+	// still relies on all of args. In time it should depend only on the bits it truly needs.
+	args.RepoOptions = repoOptions
+
+	var requiredJobs, optionalJobs []run.Job
+	addJob := func(required bool, job run.Job) {
+		// Filter out any jobs that aren't commit jobs as they are added
+		if jargs.SearchInputs.CodeMonitorID != nil {
+			if _, ok := job.(*commit.CommitSearch); !ok {
+				return
+			}
+		}
+
+		if required {
+			requiredJobs = append(requiredJobs, job)
+		} else {
+			optionalJobs = append(optionalJobs, job)
+		}
+	}
+
+	{
+		// This code block creates search jobs under specific
+		// conditions, and depending on generic process of `args` above.
+		// It which specializes search logic in doResults. In time, all
+		// of the above logic should be used to create search jobs
+		// across all of Sourcegraph.
+
+		globalSearch := args.Mode == search.ZoektGlobalSearch
+		// skipUnindexed is a value that controls whether to run
+		// unindexed search in a specific scenario of queries that
+		// contain no repo-affecting filters (global mode). When on
+		// sourcegraph.com, we resolve only a subset of all indexed
+		// repos to search. This control flow implies len(searcherRepos)
+		// is always 0, meaning that we should not create jobs to run
+		// unindexed searcher.
+		skipUnindexed := args.Mode == search.SkipUnindexed || (globalSearch && jargs.OnSourcegraphDotCom)
+		// searcherOnly is a value that controls whether to run
+		// unindexed search in one of two scenarios. The first scenario
+		// depends on if index:no is set (value true). The second
+		// scenario happens if queries contain no repo-affecting filters
+		// (global mode). When NOT on sourcegraph.com the we _may_
+		// resolve some subset of nonindexed repos to search, so wemay
+		// generate jobs that run searcher, but it is conditional on
+		// whether global zoekt search will run (value true).
+		searcherOnly := args.Mode == search.SearcherOnly || (globalSearch && !jargs.OnSourcegraphDotCom)
+
+		if globalSearch {
+			defaultScope, err := zoektutil.DefaultGlobalQueryScope(repoOptions)
+			if err != nil {
+				return nil, err
+			}
+			includePrivate := repoOptions.Visibility == query.Private || repoOptions.Visibility == query.Any
+
+			if args.ResultTypes.Has(result.TypeFile | result.TypePath) {
+				typ := search.TextRequest
+				zoektQuery, err := search.QueryToZoektQuery(args.PatternInfo, &args.Features, typ)
+				if err != nil {
+					return nil, err
+				}
+
+				globalZoektQuery := zoektutil.NewGlobalZoektQuery(zoektQuery, defaultScope, includePrivate)
+
+				zoektArgs := &search.ZoektParameters{
+					// TODO(rvantonder): the Query value is set when the global zoekt query is
+					// enriched with private repository data in the search job's Run method, and
+					// is therefore set to `nil` below.
+					// Ideally, The ZoektParameters type should not expose this field for Universe text
+					// searches at all, and will be removed once jobs are fully migrated.
+					Query:          nil,
+					Typ:            typ,
+					FileMatchLimit: args.PatternInfo.FileMatchLimit,
+					Select:         args.PatternInfo.Select,
+					Zoekt:          args.Zoekt,
+				}
+
+				addJob(true, &textsearch.RepoUniverseTextSearch{
+					GlobalZoektQuery: globalZoektQuery,
+					ZoektArgs:        zoektArgs,
+
+					RepoOptions: repoOptions,
+				})
+			}
+
+			if args.ResultTypes.Has(result.TypeSymbol) {
+				typ := search.SymbolRequest
+				zoektQuery, err := search.QueryToZoektQuery(args.PatternInfo, &args.Features, typ)
+				if err != nil {
+					return nil, err
+				}
+				globalZoektQuery := zoektutil.NewGlobalZoektQuery(zoektQuery, defaultScope, includePrivate)
+
+				zoektArgs := &search.ZoektParameters{
+					Query:          nil,
+					Typ:            typ,
+					FileMatchLimit: args.PatternInfo.FileMatchLimit,
+					Select:         args.PatternInfo.Select,
+					Zoekt:          args.Zoekt,
+				}
+
+				addJob(true, &symbol.RepoUniverseSymbolSearch{
+					GlobalZoektQuery: globalZoektQuery,
+					ZoektArgs:        zoektArgs,
+					PatternInfo:      args.PatternInfo,
+					Limit:            maxResults,
+
+					RepoOptions: repoOptions,
+				})
+			}
+		}
+
+		if args.ResultTypes.Has(result.TypeFile | result.TypePath) {
+			if !skipUnindexed {
+				typ := search.TextRequest
+				// TODO(rvantonder): we don't always have to run
+				// this converter. It depends on whether we run
+				// a zoekt search at all.
+				zoektQuery, err := search.QueryToZoektQuery(args.PatternInfo, &args.Features, typ)
+				if err != nil {
+					return nil, err
+				}
+				zoektArgs := &search.ZoektParameters{
+					Query:          zoektQuery,
+					Typ:            typ,
+					FileMatchLimit: args.PatternInfo.FileMatchLimit,
+					Select:         args.PatternInfo.Select,
+					Zoekt:          args.Zoekt,
+				}
+
+				searcherArgs := &search.SearcherParameters{
+					SearcherURLs:    args.SearcherURLs,
+					PatternInfo:     args.PatternInfo,
+					UseFullDeadline: args.UseFullDeadline,
+				}
+
+				addJob(true, &textsearch.RepoSubsetTextSearch{
+					ZoektArgs:        zoektArgs,
+					SearcherArgs:     searcherArgs,
+					NotSearcherOnly:  !searcherOnly,
+					UseIndex:         args.PatternInfo.Index,
+					ContainsRefGlobs: query.ContainsRefGlobs(q),
+					RepoOpts:         repoOptions,
+				})
+			}
+		}
+
+		if args.ResultTypes.Has(result.TypeSymbol) && args.PatternInfo.Pattern != "" {
+			if !skipUnindexed {
+				typ := search.SymbolRequest
+				zoektQuery, err := search.QueryToZoektQuery(args.PatternInfo, &args.Features, typ)
+				if err != nil {
+					return nil, err
+				}
+				zoektArgs := &search.ZoektParameters{
+					Query:          zoektQuery,
+					Typ:            typ,
+					FileMatchLimit: args.PatternInfo.FileMatchLimit,
+					Select:         args.PatternInfo.Select,
+					Zoekt:          args.Zoekt,
+				}
+
+				required := args.UseFullDeadline || args.ResultTypes.Without(result.TypeSymbol) == 0
+				addJob(required, &symbol.RepoSubsetSymbolSearch{
+					ZoektArgs:        zoektArgs,
+					PatternInfo:      args.PatternInfo,
+					Limit:            maxResults,
+					NotSearcherOnly:  !searcherOnly,
+					UseIndex:         args.PatternInfo.Index,
+					ContainsRefGlobs: query.ContainsRefGlobs(q),
+					RepoOpts:         repoOptions,
+				})
+			}
+		}
+
+		if args.ResultTypes.Has(result.TypeCommit) || args.ResultTypes.Has(result.TypeDiff) {
+			diff := args.ResultTypes.Has(result.TypeDiff)
+			var required bool
+			if args.UseFullDeadline {
+				required = true
+			} else if diff {
+				required = args.ResultTypes.Without(result.TypeDiff) == 0
+			} else {
+				required = args.ResultTypes.Without(result.TypeCommit) == 0
+			}
+			addJob(required, &commit.CommitSearch{
+				Query:                commit.QueryToGitQuery(args.Query, diff),
+				RepoOpts:             repoOptions,
+				Diff:                 diff,
+				HasTimeFilter:        commit.HasTimeFilter(args.Query),
+				Limit:                int(args.PatternInfo.FileMatchLimit),
+				CodeMonitorID:        jargs.SearchInputs.CodeMonitorID,
+				IncludeModifiedFiles: authz.SubRepoEnabled(authz.DefaultSubRepoPermsChecker),
+			})
+		}
+
+		if jargs.PatternType == query.SearchTypeStructural && p.Pattern != "" {
+			typ := search.TextRequest
+			zoektQuery, err := search.QueryToZoektQuery(args.PatternInfo, &args.Features, typ)
+			if err != nil {
+				return nil, err
+			}
+			zoektArgs := &search.ZoektParameters{
+				Query:          zoektQuery,
+				Typ:            typ,
+				FileMatchLimit: args.PatternInfo.FileMatchLimit,
+				Select:         args.PatternInfo.Select,
+				Zoekt:          args.Zoekt,
+			}
+
+			searcherArgs := &search.SearcherParameters{
+				SearcherURLs:    args.SearcherURLs,
+				PatternInfo:     args.PatternInfo,
+				UseFullDeadline: args.UseFullDeadline,
+			}
+
+			addJob(true, &structural.StructuralSearch{
+				ZoektArgs:    zoektArgs,
+				SearcherArgs: searcherArgs,
+
+				NotSearcherOnly:  !searcherOnly,
+				UseIndex:         args.PatternInfo.Index,
+				ContainsRefGlobs: query.ContainsRefGlobs(q),
+				RepoOpts:         repoOptions,
+			})
+		}
+
+		if args.ResultTypes.Has(result.TypeRepo) {
+			valid := func() bool {
+				fieldAllowlist := map[string]struct{}{
+					query.FieldRepo:               {},
+					query.FieldContext:            {},
+					query.FieldType:               {},
+					query.FieldDefault:            {},
+					query.FieldIndex:              {},
+					query.FieldCount:              {},
+					query.FieldTimeout:            {},
+					query.FieldFork:               {},
+					query.FieldArchived:           {},
+					query.FieldVisibility:         {},
+					query.FieldCase:               {},
+					query.FieldRepoHasFile:        {},
+					query.FieldRepoHasCommitAfter: {},
+					query.FieldPatternType:        {},
+					query.FieldSelect:             {},
+				}
+
+				// Don't run a repo search if the search contains fields that aren't on the allowlist.
+				for field := range args.Query.Fields() {
+					if _, ok := fieldAllowlist[field]; !ok {
+						return false
+					}
+				}
+				return true
+			}
+
+			// returns an updated RepoOptions if the pattern part of a query can be used to
+			// search repos. A problematic case we check for is when the pattern contains `@`,
+			// which may confuse downstream logic to interpret it as part of `repo@rev` syntax.
+			addPatternAsRepoFilter := func(pattern string, opts search.RepoOptions) (search.RepoOptions, bool) {
+				if pattern == "" {
+					return opts, true
+				}
+
+				opts.RepoFilters = append(make([]string, 0, len(opts.RepoFilters)), opts.RepoFilters...)
+				opts.CaseSensitiveRepoFilters = args.Query.IsCaseSensitive()
+
+				patternPrefix := strings.SplitN(pattern, "@", 2)
+				if len(patternPrefix) == 1 {
+					// No "@" in pattern? We're good.
+					opts.RepoFilters = append(opts.RepoFilters, pattern)
+					return opts, true
+				}
+
+				if patternPrefix[0] != "" {
+					// Extend the repo search using the pattern value, but
+					// since the pattern contains @, only search the part
+					// prefixed by the first @. This because downstream
+					// logic will get confused by the presence of @ and try
+					// to resolve repo revisions. See #27816.
+					if _, err := regexp.Compile(patternPrefix[0]); err != nil {
+						// Prefix is not valid regexp, so just reject it. This can happen for patterns where we've automatically added `(...).*?(...)`
+						// such as `foo @bar` which becomes `(foo).*?(@bar)`, which when stripped becomes `(foo).*?(` which is unbalanced and invalid.
+						// Why is this a mess? Because validation for everything, including repo values, should be done up front so far possible, not downtsream
+						// after possible modifications. By the time we reach this code, the pattern should already have been considered valid to continue with
+						// a search. But fixing the order of concerns for repo code is not something @rvantonder is doing today.
+						return search.RepoOptions{}, false
+					}
+					opts.RepoFilters = append(opts.RepoFilters, patternPrefix[0])
+					return opts, true
+				}
+
+				// This pattern starts with @, of the form "@thing". We can't
+				// consistently handle search repos of this form, because
+				// downstream logic will attempt to interpret "thing" as a repo
+				// revision, may fail, and cause us to raise an alert for any
+				// non `type:repo` search. Better to not attempt a repo search.
+				return search.RepoOptions{}, false
+			}
+
+			if valid() {
+				if repoOptions, ok := addPatternAsRepoFilter(args.PatternInfo.Pattern, repoOptions); ok {
+					args.RepoOptions = repoOptions
+					addJob(true, &run.RepoSearch{
+						Args: &args,
+					})
+				}
+			}
+		}
+	}
+
+	addJob(true, &searchrepos.ComputeExcludedRepos{
+		Options: repoOptions,
+	})
+
+	job := run.NewPriorityJob(
+		run.NewParallelJob(requiredJobs...),
+		run.NewParallelJob(optionalJobs...),
+	)
+
+	checker := authz.DefaultSubRepoPermsChecker
+	if authz.SubRepoEnabled(checker) {
+		job = run.NewFilterJob(job)
+	}
+
+	return job, nil
+}
+
+func toRepoOptions(q query.Q, userSettings *schema.Settings) search.RepoOptions {
+	repoFilters, minusRepoFilters := q.Repositories()
+
+	var settingForks, settingArchived bool
+	if v := userSettings.SearchIncludeForks; v != nil {
+		settingForks = *v
+	}
+	if v := userSettings.SearchIncludeArchived; v != nil {
+		settingArchived = *v
+	}
+
+	fork := query.No
+	if searchrepos.ExactlyOneRepo(repoFilters) || settingForks {
+		// fork defaults to No unless either of:
+		// (1) exactly one repo is being searched, or
+		// (2) user/org/global setting includes forks
+		fork = query.Yes
+	}
+	if setFork := q.Fork(); setFork != nil {
+		fork = *setFork
+	}
+
+	archived := query.No
+	if searchrepos.ExactlyOneRepo(repoFilters) || settingArchived {
+		// archived defaults to No unless either of:
+		// (1) exactly one repo is being searched, or
+		// (2) user/org/global setting includes archives in all searches
+		archived = query.Yes
+	}
+	if setArchived := q.Archived(); setArchived != nil {
+		archived = *setArchived
+	}
+
+	visibilityStr, _ := q.StringValue(query.FieldVisibility)
+	visibility := query.ParseVisibility(visibilityStr)
+
+	commitAfter, _ := q.StringValue(query.FieldRepoHasCommitAfter)
+	searchContextSpec, _ := q.StringValue(query.FieldContext)
+
+	return search.RepoOptions{
+		RepoFilters:       repoFilters,
+		MinusRepoFilters:  minusRepoFilters,
+		SearchContextSpec: searchContextSpec,
+		UserSettings:      userSettings,
+		OnlyForks:         fork == query.Only,
+		NoForks:           fork == query.No,
+		OnlyArchived:      archived == query.Only,
+		NoArchived:        archived == query.No,
+		Visibility:        visibility,
+		CommitAfter:       commitAfter,
+		Query:             q,
+	}
+}
+
+func withMode(args search.TextParameters, st query.SearchType) search.TextParameters {
+	isGlobalSearch := func() bool {
+		if st == query.SearchTypeStructural {
+			return false
+		}
+
+		return query.ForAll(args.Query, func(node query.Node) bool {
+			n, ok := node.(query.Parameter)
+			if !ok {
+				return true
+			}
+			switch n.Field {
+			case query.FieldContext:
+				return searchcontexts.IsGlobalSearchContextSpec(n.Value)
+			case query.FieldRepo:
+				// We allow -repo: in global search.
+				return n.Negated
+			case
+				query.FieldRepoHasFile:
+				return false
+			default:
+				return true
+			}
+		})
+	}
+
+	hasGlobalSearchResultType := args.ResultTypes.Has(result.TypeFile | result.TypePath | result.TypeSymbol)
+	isIndexedSearch := args.PatternInfo.Index != query.No
+	isEmpty := args.PatternInfo.Pattern == "" && args.PatternInfo.ExcludePattern == "" && len(args.PatternInfo.IncludePatterns) == 0
+	if isGlobalSearch() && isIndexedSearch && hasGlobalSearchResultType && !isEmpty {
+		args.Mode = search.ZoektGlobalSearch
+	}
+	if isEmpty {
+		args.Mode = search.SkipUnindexed
+	}
+	return args
+}
+
+func toFeatures(flags featureflag.FlagSet) search.Features {
+	if flags == nil {
+		flags = featureflag.FlagSet{}
+		metricFeatureFlagUnavailable.Inc()
+		log15.Warn("search feature flags are not available")
+	}
+
+	return search.Features{
+		ContentBasedLangFilters: flags.GetBoolOr("search-content-based-lang-detection", false),
+	}
+}
+
+// withResultTypes populates the ResultTypes field of args, which drives the kind
+// of search to run (e.g., text search, symbol search).
+func withResultTypes(args search.TextParameters, forceTypes result.Types) search.TextParameters {
+	var rts result.Types
+	if forceTypes != 0 {
+		rts = forceTypes
+	} else {
+		stringTypes, _ := args.Query.StringValues(query.FieldType)
+		if len(stringTypes) == 0 {
+			rts = result.TypeFile | result.TypePath | result.TypeRepo
+		} else {
+			for _, stringType := range stringTypes {
+				rts = rts.With(result.TypeFromString[stringType])
+			}
+		}
+	}
+
+	if rts.Has(result.TypeFile) {
+		args.PatternInfo.PatternMatchesContent = true
+	}
+
+	if rts.Has(result.TypePath) {
+		args.PatternInfo.PatternMatchesPath = true
+	}
+	args.ResultTypes = rts
+	return args
+}
+
+// toAndJob creates a new job from a basic query whose pattern is an And operator at the root.
+func toAndJob(args *Args, q query.Basic) (run.Job, error) {
+	// Invariant: this function is only reachable from callers that
+	// guarantee a root node with one or more queryOperands.
+	queryOperands := q.Pattern.(query.Operator).Operands
+
+	// Limit the number of results from each child to avoid a huge amount of memory bloat.
+	// With streaming, we should re-evaluate this number.
+	//
+	// NOTE: It may be possible to page over repos so that each intersection is only over
+	// a small set of repos, limiting massive number of results that would need to be
+	// kept in memory otherwise.
+	maxTryCount := 40000
+
+	operands := make([]run.Job, 0, len(queryOperands))
+	for _, queryOperand := range queryOperands {
+		operand, err := toPatternExpressionJob(args, q.MapPattern(queryOperand))
+		if err != nil {
+			return nil, err
+		}
+		operands = append(operands, run.NewLimitJob(maxTryCount, operand))
+	}
+
+	return run.NewAndJob(operands...), nil
+}
+
+// toOrJob creates a new job from a basic query whose pattern is an Or operator at the top level
+func toOrJob(args *Args, q query.Basic) (run.Job, error) {
+	// Invariant: this function is only reachable from callers that
+	// guarantee a root node with one or more queryOperands.
+	queryOperands := q.Pattern.(query.Operator).Operands
+
+	operands := make([]run.Job, 0, len(queryOperands))
+	for _, term := range queryOperands {
+		operand, err := toPatternExpressionJob(args, q.MapPattern(term))
+		if err != nil {
+			return nil, err
+		}
+		operands = append(operands, operand)
+	}
+	return run.NewOrJob(operands...), nil
+}
+
+func toPatternExpressionJob(args *Args, q query.Basic) (run.Job, error) {
+	switch term := q.Pattern.(type) {
+	case query.Operator:
+		if len(term.Operands) == 0 {
+			return run.NewNoopJob(), nil
+		}
+
+		switch term.Kind {
+		case query.And:
+			return toAndJob(args, q)
+		case query.Or:
+			return toOrJob(args, q)
+		case query.Concat:
+			return ToSearchJob(args, q.ToParseTree())
+		}
+	case query.Pattern:
+		return ToSearchJob(args, q.ToParseTree())
+	case query.Parameter:
+		// evaluatePatternExpression does not process Parameter nodes.
+		return run.NewNoopJob(), nil
+	}
+	// Unreachable.
+	return nil, errors.Errorf("unrecognized type %T in evaluatePatternExpression", q.Pattern)
+}
+
+func ToEvaluateJob(args *Args, q query.Basic) (run.Job, error) {
+	maxResults := q.ToParseTree().MaxResults(args.SearchInputs.DefaultLimit)
+	timeout := search.TimeoutDuration(q)
+
+	if q.Pattern == nil {
+		job, err := ToSearchJob(args, query.ToNodes(q.Parameters))
+		return run.NewTimeoutJob(timeout, run.NewLimitJob(maxResults, job)), err
+	}
+	job, err := toPatternExpressionJob(args, q)
+	return run.NewTimeoutJob(timeout, run.NewLimitJob(maxResults, job)), err
+}
+
+var metricFeatureFlagUnavailable = promauto.NewCounter(prometheus.CounterOpts{
+	Name: "src_search_featureflag_unavailable",
+	Help: "temporary counter to check if we have feature flag available in practice.",
+})

--- a/internal/search/job/job_test.go
+++ b/internal/search/job/job_test.go
@@ -1,0 +1,51 @@
+package job
+
+import (
+	"testing"
+
+	"github.com/hexops/autogold"
+
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	"github.com/sourcegraph/sourcegraph/internal/search/run"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func TestToSearchInputs(t *testing.T) {
+	test := func(input string, parser func(string) (query.Q, error)) string {
+		q, _ := parser(input)
+		args := &Args{
+			SearchInputs: &run.SearchInputs{
+				Query:        q,
+				UserSettings: &schema.Settings{},
+				PatternType:  query.SearchTypeLiteral,
+			},
+			OnSourcegraphDotCom: true,
+			PatternType:         query.SearchTypeLiteral,
+			Protocol:            search.Batch,
+		}
+
+		j, _ := ToSearchJob(args, q)
+		return j.Name()
+	}
+
+	// Job generation for global vs non-global search
+	autogold.Want("user search context", "ParallelJob{RepoSubsetText, Repo, ComputeExcludedRepos}").Equal(t, test(`foo context:@userA`, query.ParseLiteral))
+	autogold.Want("universal (AKA global) search context", "ParallelJob{RepoUniverseText, Repo, ComputeExcludedRepos}").Equal(t, test(`foo context:global`, query.ParseLiteral))
+	autogold.Want("universal (AKA global) search", "ParallelJob{RepoUniverseText, Repo, ComputeExcludedRepos}").Equal(t, test(`foo`, query.ParseLiteral))
+	autogold.Want("nonglobal repo", "ParallelJob{RepoSubsetText, Repo, ComputeExcludedRepos}").Equal(t, test(`foo repo:sourcegraph/sourcegraph`, query.ParseLiteral))
+	autogold.Want("nonglobal repo contains", "ParallelJob{RepoSubsetText, Repo, ComputeExcludedRepos}").Equal(t, test(`foo repo:contains(bar)`, query.ParseLiteral))
+
+	// Job generation support for implied `type:repo` queries.
+	autogold.Want("supported Repo job", "ParallelJob{RepoUniverseText, Repo, ComputeExcludedRepos}").Equal(t, test("ok ok", query.ParseRegexp))
+	autogold.Want("supportedRepo job literal", "ParallelJob{RepoUniverseText, Repo, ComputeExcludedRepos}").Equal(t, test("ok @thing", query.ParseLiteral))
+	autogold.Want("unsupported Repo job prefix", "ParallelJob{RepoUniverseText, ComputeExcludedRepos}").Equal(t, test("@nope", query.ParseRegexp))
+	autogold.Want("unsupported Repo job regexp", "ParallelJob{RepoUniverseText, ComputeExcludedRepos}").Equal(t, test("foo @bar", query.ParseRegexp))
+
+	// Job generation for other types of search
+	autogold.Want("symbol", "ParallelJob{RepoUniverseSymbol, ComputeExcludedRepos}").Equal(t, test("type:symbol test", query.ParseRegexp))
+	autogold.Want("commit", "ParallelJob{Commit, ComputeExcludedRepos}").Equal(t, test("type:commit test", query.ParseRegexp))
+	autogold.Want("diff", "ParallelJob{Diff, ComputeExcludedRepos}").Equal(t, test("type:diff test", query.ParseRegexp))
+	autogold.Want("file or commit", "JobWithOptional{Required: ParallelJob{RepoUniverseText, ComputeExcludedRepos}, Optional: Commit}").Equal(t, test("type:file type:commit test", query.ParseRegexp))
+	autogold.Want("many types", "JobWithOptional{Required: ParallelJob{RepoSubsetText, Repo, ComputeExcludedRepos}, Optional: ParallelJob{RepoSubsetSymbol, Commit}}").Equal(t, test("type:file type:path type:repo type:commit type:symbol repo:test test", query.ParseRegexp))
+}


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/31129.

This moves the search job stuff out of `search_results.go`. See some inline notes.

Next I'll move job-specific logic out of `package run` and into `package job`

## Test plan
Semantics-preserving, covered by tests.

