### PR TITLE
Fix broken server image build after new alpine RC of postgresql

### DIFF
--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -48,7 +48,7 @@ RUN apk add --no-cache --verbose \
     python2 \
     python3 \
     'nginx>=1.18.0' openssh-client pcre sqlite-libs su-exec 'nodejs-current>=14.5.0' \
-    postgresql=12.9-r0 \
+    postgresql=12.10-r0 \
     postgresql-contrib \
     cmake
 


### PR DESCRIPTION
`main` is broken because the server image is not being built: https://buildkite.com/sourcegraph/sourcegraph/builds/131141#208eb229-e2f5-4a4e-b48c-4813a2ad738b

cc @sourcegraph/dev-experience I had to built the image locally to see the Alpine "no package matching" error message that was previously easy to see in Buildkite. I wonder whether something in how we parse the output changed that leads to us dropping the message? If nothing changed, feel free to ignore this message.

## Test plan

Built the server image locally with

```
export GO111MODULE="on"
export IMAGE="sourcegraph/server:131141_2022-02-13_4a84d8350301"
export NODE_OPTIONS="--max_old_space_size=8192"
export VERSION="131141_2022-02-13_4a84d8350301"
./cmd/server/build.sh
```


