### PR TITLE
web: fix `WebCommandList` link styling

### DIFF
--- a/client/web/src/components/WebCommandListPopoverButton.module.scss
+++ b/client/web/src/components/WebCommandListPopoverButton.module.scss
@@ -1,8 +1,0 @@
-.button {
-    color: var(--icon-color);
-
-    &:hover {
-        // Required to overwrite .btn:hover styles with greater specificity.
-        color: var(--body-color) !important;
-    }
-}

--- a/client/web/src/components/WebCommandListPopoverButton/WebCommandListPopoverButton.module.scss
+++ b/client/web/src/components/WebCommandListPopoverButton/WebCommandListPopoverButton.module.scss
@@ -1,0 +1,19 @@
+.button {
+    color: var(--icon-color);
+
+    &:hover {
+        // Required to overwrite .btn:hover styles with greater specificity.
+        color: var(--body-color) !important;
+    }
+}
+
+.action-item {
+    --link-color: var(--body-color);
+    --link-hover-color: var(--body-color);
+
+    display: block;
+    text-align: left;
+
+    /* Overwrite `ButtonLink` style */
+    text-decoration: none !important;
+}

--- a/client/web/src/components/WebCommandListPopoverButton/WebCommandListPopoverButton.tsx
+++ b/client/web/src/components/WebCommandListPopoverButton/WebCommandListPopoverButton.tsx
@@ -1,0 +1,27 @@
+import classNames from 'classnames'
+import React from 'react'
+
+import {
+    CommandListPopoverButton,
+    CommandListPopoverButtonProps,
+} from '@sourcegraph/shared/src/commandPalette/CommandList'
+
+import styles from './WebCommandListPopoverButton.module.scss'
+
+export const WebCommandListPopoverButton: React.FunctionComponent<CommandListPopoverButtonProps> = props => (
+    <CommandListPopoverButton
+        {...props}
+        variant="link"
+        buttonClassName={classNames('m-0 p-0', styles.button)}
+        popoverClassName="popover border-0"
+        popoverInnerClassName="rounded overflow-hidden"
+        formClassName="form p-2 bg-1 border-bottom"
+        inputClassName="form-control px-2 py-1"
+        listClassName="list-group list-group-flush list-unstyled pt-1"
+        actionItemClassName={classNames('list-group-item list-group-item-action p-2 border-0', styles.actionItem)}
+        selectedActionItemClassName="active border-primary"
+        noResultsClassName="list-group-item text-muted"
+    />
+)
+
+WebCommandListPopoverButton.displayName = 'WebCommandListPopoverButton'

--- a/client/web/src/components/WebCommandListPopoverButton/index.ts
+++ b/client/web/src/components/WebCommandListPopoverButton/index.ts
@@ -1,0 +1,1 @@
+export * from './WebCommandListPopoverButton'

--- a/client/web/src/components/shared.tsx
+++ b/client/web/src/components/shared.tsx
@@ -1,30 +1,3 @@
-import classNames from 'classnames'
-import React from 'react'
-
-import {
-    CommandListPopoverButton,
-    CommandListPopoverButtonProps,
-} from '@sourcegraph/shared/src/commandPalette/CommandList'
-
-import styles from './WebCommandListPopoverButton.module.scss'
-
 // Components from shared with web-styling class names applied
 export { WebHoverOverlay } from './WebHoverOverlay'
-
-export const WebCommandListPopoverButton: React.FunctionComponent<CommandListPopoverButtonProps> = props => (
-    <CommandListPopoverButton
-        {...props}
-        variant="link"
-        buttonClassName={classNames('m-0 p-0', styles.button)}
-        popoverClassName="popover border-0"
-        popoverInnerClassName="rounded overflow-hidden"
-        formClassName="form p-2 bg-1 border-bottom"
-        inputClassName="form-control px-2 py-1"
-        listClassName="list-group list-group-flush list-unstyled pt-1"
-        actionItemClassName="list-group-item list-group-item-action p-2 border-0"
-        selectedActionItemClassName="active border-primary"
-        noResultsClassName="list-group-item text-muted"
-    />
-)
-
-WebCommandListPopoverButton.displayName = 'WebCommandListPopoverButton'
+export { WebCommandListPopoverButton } from './WebCommandListPopoverButton'


### PR DESCRIPTION
## Context

Styling issue caused by [the `ButtonLink` migration](https://github.com/sourcegraph/sourcegraph/issues/30303).

<img width="1294" alt="Screenshot 2022-02-11 at 22 33 15" src="https://user-images.githubusercontent.com/3846380/153759806-8fe0c441-3181-4dd5-bced-84459fe55304.png">


## Test plan

Ensure that command list items styling is fixed.

<img width="1034" alt="Screen Shot 2022-02-13 at 18 16 28" src="https://user-images.githubusercontent.com/3846380/153759893-264ac1c4-17ce-47e5-a06c-a44e96d9ab14.png">



