### PR TITLE
refactor(dev): extract img str parser

### DIFF
--- a/dev/sg/internal/images/images_test.go
+++ b/dev/sg/internal/images/images_test.go
@@ -74,3 +74,41 @@ func Test_findLatestTag(t *testing.T) {
 		})
 	}
 }
+
+func TestParseRawImgString(t *testing.T) {
+	stdout.Out.SetVerbose()
+
+	tests := []struct {
+		name string
+		tag  string
+		want *ImageReference
+	}{
+		{
+			"base",
+			"index.docker.io/sourcegraph/server:3.36.2@sha256:07d7407fdc656d7513aa54cdffeeecb33aa4e284eea2fd82e27342411430e5f2",
+			&ImageReference{
+				Registry: "docker.io",
+				Name:     "sourcegraph/server",
+				Tag:      "3.36.2",
+				Digest:   "sha256:07d7407fdc656d7513aa54cdffeeecb33aa4e284eea2fd82e27342411430e5f2",
+			},
+		},
+		{
+			"base",
+			"index.docker.io/sourcegraph/server:3.36.2",
+			&ImageReference{
+				Registry: "docker.io",
+				Name:     "sourcegraph/server",
+				Tag:      "3.36.2",
+				Digest:   "",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, _ := parseImgString(tt.tag); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseImgString() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Extract the logic to parse raw img string from `updateImage` method to make it reusable.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

See added unit test. We shouldn't need any extensive testing for this method, it's just a wrapper on top of some other well-tested (hopefully) image name parser.


