### PR TITLE
dev: support update images in helm values

### DIFF
--- a/dev/sg/sg_ops.go
+++ b/dev/sg/sg_ops.go
@@ -29,6 +29,7 @@ var (
 		Subcommands: []*ffcli.Command{opsUpdateImagesCommand},
 	}
 	opsUpdateImagesFlagSet                       = flag.NewFlagSet("sg ops update-images", flag.ExitOnError)
+	opsUpdateImagesDeploymentKindFlag            = opsUpdateImagesFlagSet.String("kind", string(images.DeploymentTypeK8S), "The kind of deployment (one of 'k8s', 'helm')")
 	opsUpdateImagesContainerRegistryUsernameFlag = opsUpdateImagesFlagSet.String("cr-username", "", "Username for the container registry")
 	opsUpdateImagesContainerRegistryPasswordFlag = opsUpdateImagesFlagSet.String("cr-password", "", "Password or access token for the container registry")
 	opsUpdateImagesCommand                       = &ffcli.Command{
@@ -74,11 +75,13 @@ func opsUpdateImage(ctx context.Context, args []string) error {
 			// We do not want any error handling here, just fallback to anonymous requests
 			writeWarningLinef("Registry credentials are not provided and could not be retrieved from docker config.")
 			writeWarningLinef("You will be using anonymous requests and may be subject to rate limiting by Docker Hub.")
+			dockerCredentials = &credentials.Credentials{ServerURL: "https://index.docker.io/v1/", Username: "", Secret: ""}
 		} else {
 			writeFingerPointingLinef("Using credentials from docker credentials store (learn more https://docs.docker.com/engine/reference/commandline/login/#credentials-store)")
 			opsUpdateImagesContainerRegistryUsernameFlag = &dockerCredentials.Username
 			opsUpdateImagesContainerRegistryPasswordFlag = &dockerCredentials.Secret
 		}
 	}
-	return images.Parse(args[0], *dockerCredentials)
+
+	return images.Parse(args[0], *dockerCredentials, images.DeploymentType(*opsUpdateImagesDeploymentKindFlag))
 }

--- a/go.mod
+++ b/go.mod
@@ -358,7 +358,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20220124234850-424119656bbf // indirect
 	k8s.io/utils v0.0.0-20220127004650-9b3446523e65 // indirect
 	mvdan.cc/gofumpt v0.2.1 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (


### PR DESCRIPTION
The goal is to replace https://github.com/sourcegraph/delivery-scratch/blob/main/2022/helm-updates/update-tags.sh with a more proper implementation. Also, we can fetch image digest from the registry instead of relying on parsing published docker-compose.yaml from `deploy-*` repo.

This PR introduced a new flag `kind` flag to `sg ops update-images` command to automate update of image tags in helm charts `values.yaml` file. See test plan for usage

> Should I rename `plain` to something like `kustomize`? idk...

`-kind` is expecting one of `plain`, `helm`. `plain` is the default for backward compatibility (not that we're actually using `update-images` somewhere anyway)

## Test plan

clone helm chart repo somewhere

```bash
git clone https://github.com/sourcegraph/deploy-sourcegraph-helm ~/Code/sourcegraph/deploy-sourcegraph-helm
```

Switch to `sg` directory
```bash
cd dev/sg
```

```bash
go run . ops update-images -kind helm ~/Code/sourcegraph/deploy-sourcegraph-helm/charts/sourcegraph/.
```

Inspect the content of `~/Code/sourcegraph/deploy-sourcegraph-helm/charts/sourcegraph/values.yaml`, all `defaultTag` should be replaced with the latest image tag+digest.

You can also try manually pulling the images to verify they indeed exist on the registry

```tmpl
docker pull sourcegraph/{{ .Values.alpine.image.name }}:{{ .Values.alpine.image.defaultTag }}
```

Sample diff of `values.yaml`

```diff
diff --git a/charts/sourcegraph/values.yaml b/charts/sourcegraph/values.yaml
index 2dd9291..b5d4a65 100644
--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -74,7 +74,7 @@ sourcegraph:
 
 alpine: # Used in init containers
   image:
-    defaultTag: 3.36.2@sha256:a8daf8c1c95117cf32a49eac1179dcc785a9004f309e238d7742d72ad4b59aaf
+    defaultTag: 131149_2022-02-13_25b5aca6ca76@sha256:142345b2458b7160295b5f407df21ebc2a5d03935e99dd0cdf19193c4af15bfa
     name: "alpine-3.12"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -92,7 +92,7 @@ alpine: # Used in init containers
 cadvisor:
   enabled: true
   image:
-    defaultTag: 3.36.2@sha256:a359efa6b02d956866dbdbc36b9a81e39fe8ae0228230b38625333a46930f0c4
+    defaultTag: 131149_2022-02-13_25b5aca6ca76@sha256:965e7b54cd4dc116396c4dac79a10b3506c198dd0ccef6158b10843b7ccea9ca
     name: "cadvisor"
   podSecurityPolicy:
     enabled: false
@@ -114,7 +114,7 @@ codeInsightsDB:
       value: password
   existingConfig: "" # Name of an existing configmap
   image:
-    defaultTag: 3.36.2@sha256:e5771058bcb2793e9262762d521194910352dca6d0ffe739dd29e917cf1bf539
+    defaultTag: 131149_2022-02-13_25b5aca6ca76@sha256:e360be444476b9bc9caa247afe64484ceb8298ebed8c3a48b4c072072078fe2f
     name: "codeinsights-db"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -139,7 +139,7 @@ codeIntelDB:
   enabled: true
   existingConfig: "" # Name of an existing configmap
   image:
-    defaultTag: 3.36.2@sha256:4e7acd14edd67c0cd9b866981ce6cb78b824bc992c99e055c1ce2aa0b01aa817
+    defaultTag: 131149_2022-02-13_25b5aca6ca76@sha256:bc9ded38528fd5e832b18195eeaf91b121a0cb499b82f4ec4f80e9d2652d3a18
     name: "codeintel-db"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -191,7 +191,7 @@ frontend:
     PROMETHEUS_URL:
       value: http://prometheus:30090
   image:
-    defaultTag: 3.36.2@sha256:0e2a4759b0874d58a11e6fba62baee527fa6d899d70aed83691f93a2738ab349
+    defaultTag: 131149_2022-02-13_25b5aca6ca76@sha256:77b5db2b9cba51d5a91260ca73a18eab3bc5a1ad899f63936a23852fe1f6b5d4
     name: "frontend"
   ingress:
     annotations:
@@ -223,7 +223,7 @@ frontend:
 
 githubProxy:
   image:
-    defaultTag: 3.36.2@sha256:a7680aedbd50b9a91de80cb8cbb2d105d427880bfe843e8c77b48ff64ee7a283
+    defaultTag: 131149_2022-02-13_25b5aca6ca76@sha256:1aed0b494a30ac88edbee899c18a99d32f1e76364ff3ec7b9ffc0a2b85b83111
     name: "github-proxy"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -241,7 +241,7 @@ githubProxy:
 
 gitserver:
   image:
-    defaultTag: 3.36.2@sha256:c8bb244bc17f4d509219ec9bf3d6aa09487ce7c13567314dbebd879298747955
+    defaultTag: 131149_2022-02-13_25b5aca6ca76@sha256:755045832d85dc1bc6e1f015ed9ca16830b42fdeb58953f2a3f0daa48a44ca4f
     name: "gitserver"
   labels: {}
   podSecurityContext:
@@ -268,7 +268,7 @@ grafana:
   enabled: true
   existingConfig: "" # Name of an existing configmap
   image:
-    defaultTag: 3.36.2@sha256:bacc783ee4ccc99cda09d97590caec6ebd675ec1065fd6ee4ef166c40cae37d5
+    defaultTag: 131149_2022-02-13_25b5aca6ca76@sha256:9a09c16565d2c13a954d0118eaa42b6abfb5c54ef8cc28be662c1414c198c18b
     name: "grafana"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -294,7 +294,7 @@ grafana:
 
 indexedSearch:
   image:
-    defaultTag: 3.36.2@sha256:1399fbff116c249d4aec55c2c1e70c23e4617bf3a17921cfdede53893e97b533
+    defaultTag: 131149_2022-02-13_25b5aca6ca76@sha256:907715ff9430fd8c0be4781df104a164218e04ff3dcd10de88c98cd598982913
     name: "indexed-searcher"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -318,7 +318,7 @@ indexedSearch:
 
 indexedSearchIndexer:
   image:
-    defaultTag: 3.36.2@sha256:a9a72e81cacdb644b0530229bd6b5c54dcd84d2d15d11976f28b59f970b85471
+    defaultTag: 131149_2022-02-13_25b5aca6ca76@sha256:0b85220d0a3e8539c43a61c42d31cca238976b8edb1dcffed06dce0f2935c643
     name: "search-indexer"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -343,7 +343,7 @@ minio:
     MINIO_SECRET_KEY:
       value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
   image:
-    defaultTag: 3.36.2@sha256:66925bab722ed11584e1135687b5c1e00a13c550e38d954a56048c90f17edc53
+    defaultTag: 131149_2022-02-13_25b5aca6ca76@sha256:66925bab722ed11584e1135687b5c1e00a13c550e38d954a56048c90f17edc53
     name: "minio"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -368,7 +368,7 @@ pgsql:
   enabled: true
   existingConfig: "" # Name of an existing configmap
   image:
-    defaultTag: 3.36.2@sha256:3a5ce53dbf0951b8bc653d5d544ba0970f54774f840aa4162e86b05566fad7a8
+    defaultTag: 131149_2022-02-13_25b5aca6ca76@sha256:41b3f5e176c03c9ba5b7bb3e50428e58fc0dcc8eb97a104bc76f6181bd93b362
     name: "postgres-12.6-alpine"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -397,7 +397,7 @@ pgsql:
 
 postgresExporter:
   image:
-    defaultTag: 3.36.2@sha256:c42d2720ff5288bb2a1e430c6b77445bb81fde77252748a723b42db81b5b0945
+    defaultTag: 131149_2022-02-13_25b5aca6ca76@sha256:5ba6c04bb01899e9e7d0d20d0985776dea9b567f7a22f62fef5e14e09dc1496e
     name: "postgres_exporter"
   resources:
     limits:
@@ -412,7 +412,7 @@ preciseCodeIntel:
     NUM_WORKERS:
       value: "4"
   image:
-    defaultTag: 3.36.2@sha256:07d7407fdc656d7513aa54cdffeeecb33aa4e284eea2fd82e27342411430e5f2
+    defaultTag: 131149_2022-02-13_25b5aca6ca76@sha256:32dd839c9b8379b89a80fb9a2028ff2ac6f8afb6fbdb3148d524ac2935bd4485
     name: "precise-code-intel-worker"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -432,7 +432,7 @@ prometheus:
   enabled: true
   existingConfig: "" # Name of an existing configmap
   image:
-    defaultTag: 3.36.2@sha256:1bfd0e0087ae34d343fd4be93077de6c62d48b789d5ba056a108203a38c2a646
+    defaultTag: 131149_2022-02-13_25b5aca6ca76@sha256:42b15f810009a9ef1e2aa1db9844ba35a65103327f9d9a203269c96e03248c3b
     name: "prometheus"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -465,7 +465,7 @@ prometheus:
 redisCache:
   enabled: true
   image:
-    defaultTag: 3.36.2@sha256:768fb88b8d331363e4df554f0cccb44556300eecfaa1de6369f49ae5e0d37e56
+    defaultTag: 131149_2022-02-13_25b5aca6ca76@sha256:bf5c4149a66285ec05631e0622244273bd07c2f503fbd286f1e2d5912cd88fa0
     name: "redis-cache"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -487,7 +487,7 @@ redisCache:
 
 redisExporter:
   image:
-    defaultTag: 84464_2021-01-15_c2e4c28@sha256:f3f51453e4261734f08579fe9c812c66ee443626690091401674be4fb724da70
+    defaultTag: 131149_2022-02-13_25b5aca6ca76@sha256:f3f51453e4261734f08579fe9c812c66ee443626690091401674be4fb724da70
     name: "redis_exporter"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -505,7 +505,7 @@ redisExporter:
 redisStore:
   enabled: true
   image:
-    defaultTag: 3.36.2@sha256:208b53b11479d9461fa58de37c9157e8e8eebffda274d503969ab4df57cc78e8
+    defaultTag: 131149_2022-02-13_25b5aca6ca76@sha256:bdf1b058c32404eb4f5d214369bded70ce525a200b4eaafcae8b6f3bb0421e29
     name: "redis-store"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -527,7 +527,7 @@ redisStore:
 
 repoUpdater:
   image:
-    defaultTag: 3.36.2@sha256:cedb6af8a1e7b97257e38afc0131cd8e5660fc2531c61482ce39abd1e34e418f
+    defaultTag: 131149_2022-02-13_25b5aca6ca76@sha256:ec545b66fb4935440cf0a74fca54c480e14f3b3fa30c04d4112e0b2e378bd458
     name: "repo-updater"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -545,7 +545,7 @@ repoUpdater:
 
 searcher:
   image:
-    defaultTag: 3.36.2@sha256:a616bab2528f495c142c825a8c11cf5ee704acbed89e5cdde966994107a8ccf4
+    defaultTag: 131149_2022-02-13_25b5aca6ca76@sha256:4ceebd8de65171576e002ce06ac26a3b3dd81662c51cf6291c9d05c9220fe53f
     name: "searcher"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -571,7 +571,7 @@ storageClass:
 
 symbols:
   image:
-    defaultTag: 3.36.2@sha256:f4a983ef6bd321699cf321c6d1f2be7f025774cf4bce7a610ec3ec2476128d72
+    defaultTag: 131149_2022-02-13_25b5aca6ca76@sha256:ca13d6acca53983aa5f54bbe6ad81b2f394658b4baa1f77f2ebc383ba8feeb6b
     name: "symbols"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -591,7 +591,7 @@ symbols:
 
 syntectServer:
   image:
-    defaultTag: 3.36.2@sha256:d90d5821146c192939ab72e624a5f7ca2800328fae894698db61ad30aa68231d
+    defaultTag: 131149_2022-02-13_25b5aca6ca76@sha256:6321a2453f36b1cd421158cefa351112d11123353ad32b57afcb37bfd425e151
     name: "syntax-highlighter"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -611,7 +611,7 @@ tracing:
   collector: {}
   enabled: true
   image:
-    defaultTag: 3.36.2@sha256:e2c0c17dd38a2661b29c29599d151d3c1f75d5ed7e687344821ecff8cf62e17d
+    defaultTag: 131149_2022-02-13_25b5aca6ca76@sha256:576b5826b6ea79af922f3426f61b00a71ce5521e6bfd65f131754de7dd0fda2f
     name: "jaeger-all-in-one"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -631,7 +631,7 @@ tracing:
 tracingAgent:
   enabled: true
   image:
-    defaultTag: 3.36.2@sha256:51433dad65ce11c5492d8e87c7c4eb8155a42bc9d06092ad6204a3d6f6128bac
+    defaultTag: 131149_2022-02-13_25b5aca6ca76@sha256:c2f07439484205c8708218e6faf50c9a5d3c92560eef2f4e4e7a40431577a38a
     name: "jaeger-agent"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -648,7 +648,7 @@ tracingAgent:
 
 worker:
   image:
-    defaultTag: 3.36.2@sha256:4263b4b79fba3a6a8d5f1edf9b7154ea1119ddbf7dd3e544aad47e8fef017eda
+    defaultTag: 131149_2022-02-13_25b5aca6ca76@sha256:2ad6f987d7e76372247e3da0ed25b4d1813a9d011a42694a21ffefc931eb4db1
     name: "worker"
   podSecurityContext:
     allowPrivilegeEscalation: false
```

## TODO

- [ ] refactor `updateImage` method to support fetching images of a specific release (e.g., `3.36.2`) instead of `latest`.