### PR TITLE
Charts: Add stacked support in line chart

### DIFF
--- a/client/web/src/charts/components/line-chart/LineChart.story.tsx
+++ b/client/web/src/charts/components/line-chart/LineChart.story.tsx
@@ -70,6 +70,57 @@ export const PlainChart = () => {
     return <LineChart width={400} height={400} data={DATA} series={SERIES} xAxisKey="x" />
 }
 
+export const PlainStackedChart = () => {
+    const DATA: StandardDatum[] = [
+        { x: 1588965700286 - 4 * 24 * 60 * 60 * 1000, c: 5000, a: 4000, b: 15000 },
+        { x: 1588965700286 - 3 * 24 * 60 * 60 * 1000, c: 5000, a: 4000, b: 26000 },
+        { x: 1588965700286 - 2 * 24 * 60 * 60 * 1000, c: 5000, a: 5600, b: 20000 },
+        { x: 1588965700286 - 1 * 24 * 60 * 60 * 1000, c: 5000, a: 9800, b: 19000 },
+        { x: 1588965700286, c: 5000, a: 6000, b: 17000 },
+    ]
+
+    const SERIES: LineChartSeries<StandardDatum>[] = [
+        {
+            dataKey: 'a',
+            name: 'A metric',
+            color: 'var(--blue)',
+            linkURLs: [
+                'https://google.com/search',
+                'https://google.com/search',
+                'https://google.com/search',
+                'https://google.com/search',
+                'https://google.com/search',
+            ],
+        },
+        {
+            dataKey: 'b',
+            name: 'B metric',
+            color: 'var(--warning)',
+            linkURLs: [
+                'https://yandex.com/search',
+                'https://yandex.com/search',
+                'https://yandex.com/search',
+                'https://yandex.com/search',
+                'https://yandex.com/search',
+            ],
+        },
+        {
+            dataKey: 'c',
+            name: 'C metric',
+            color: 'var(--green)',
+            linkURLs: [
+                'https://twitter.com/search',
+                'https://twitter.com/search',
+                'https://twitter.com/search',
+                'https://twitter.com/search',
+                'https://twitter.com/search',
+            ],
+        },
+    ]
+
+    return <LineChart width={400} height={400} data={DATA} series={SERIES} xAxisKey="x" stacked={true} />
+}
+
 export const WithLegendExample = () => {
     const DATA: StandardDatum[] = [
         { x: 1588965700286 - 4 * 24 * 60 * 60 * 1000, c: 5000, a: 4000, b: 15000 },
@@ -296,18 +347,19 @@ export const WithDataSteps = () => {
 interface DatumWithMissingData {
     a: number | null
     b: number | null
+    c: number | null
     x: number
 }
 
 export const WithDataMissingValues = () => {
     const DATA_WITH_STEP: DatumWithMissingData[] = [
-        { x: 1588965700286 - 4 * 24 * 60 * 60 * 1000, a: null, b: null },
-        { x: 1588965700286 - 3 * 24 * 60 * 60 * 1000, a: null, b: null },
-        { x: 1588965700286 - 2 * 24 * 60 * 60 * 1000, a: 94, b: 200 },
-        { x: 1588965700286 - 1.5 * 24 * 60 * 60 * 1000, a: 134, b: null },
-        { x: 1588965700286 - 1.3 * 24 * 60 * 60 * 1000, a: null, b: 150 },
-        { x: 1588965700286 - 1 * 24 * 60 * 60 * 1000, a: 134, b: 190 },
-        { x: 1588965700286, a: 123, b: 170 },
+        { x: 1588965700286 - 4 * 24 * 60 * 60 * 1000, a: null, b: null, c: null },
+        { x: 1588965700286 - 3 * 24 * 60 * 60 * 1000, a: null, b: null, c: null },
+        { x: 1588965700286 - 2 * 24 * 60 * 60 * 1000, a: 94, b: 200, c: 200 },
+        { x: 1588965700286 - 1.5 * 24 * 60 * 60 * 1000, a: 134, b: null, c: 134 },
+        { x: 1588965700286 - 1.3 * 24 * 60 * 60 * 1000, a: null, b: 150, c: null },
+        { x: 1588965700286 - 1 * 24 * 60 * 60 * 1000, a: 134, b: 190, c: 134 },
+        { x: 1588965700286, a: 123, b: 170, c: 123 },
     ]
 
     const SERIES: LineChartSeries<DatumWithMissingData>[] = [
@@ -333,6 +385,53 @@ export const WithDataMissingValues = () => {
                         data={DATA_WITH_STEP}
                         series={SERIES}
                         xAxisKey="x"
+                    />
+                )}
+            </ParentSize>
+        </div>
+    )
+}
+
+export const StackedWithDataMissingValues = () => {
+    const DATA_WITH_STEP: DatumWithMissingData[] = [
+        { x: 1588965700286 - 4 * 24 * 60 * 60 * 1000, a: null, b: null, c: null },
+        { x: 1588965700286 - 3 * 24 * 60 * 60 * 1000, a: null, b: null, c: null },
+        { x: 1588965700286 - 2 * 24 * 60 * 60 * 1000, a: 94, b: null, c: null },
+        { x: 1588965700286 - 1.5 * 24 * 60 * 60 * 1000, a: 134, b: null, c: 200 },
+        { x: 1588965700286 - 1.3 * 24 * 60 * 60 * 1000, a: null, b: 150, c: 150 },
+        { x: 1588965700286 - 1 * 24 * 60 * 60 * 1000, a: 134, b: 190, c: 190 },
+        { x: 1588965700286, a: 123, b: 170, c: 170 },
+    ]
+
+    const SERIES: LineChartSeries<DatumWithMissingData>[] = [
+        {
+            dataKey: 'a',
+            name: 'A metric',
+            color: 'var(--blue)',
+        },
+        {
+            dataKey: 'b',
+            name: 'B metric',
+            color: 'var(--warning)',
+        },
+        {
+            dataKey: 'c',
+            name: 'C metric',
+            color: 'var(--purple)',
+        },
+    ]
+
+    return (
+        <div style={{ width: 400, height: 400 }}>
+            <ParentSize>
+                {({ width, height }) => (
+                    <LineChart<DatumWithMissingData>
+                        width={width}
+                        height={height}
+                        data={DATA_WITH_STEP}
+                        series={SERIES}
+                        xAxisKey="x"
+                        stacked={true}
                     />
                 )}
             </ParentSize>

--- a/client/web/src/charts/components/line-chart/LineChart.tsx
+++ b/client/web/src/charts/components/line-chart/LineChart.tsx
@@ -38,7 +38,7 @@ export interface LineChartContentProps<D> {
     xAxisKey: keyof D
 
     /**
-     * Whenever a chart component should stack data based on x value for each series
+     * Whether a chart component should stack data based on x value for each series
      */
     stacked?: boolean
 

--- a/client/web/src/charts/components/line-chart/LineChart.tsx
+++ b/client/web/src/charts/components/line-chart/LineChart.tsx
@@ -19,8 +19,9 @@ import { getSeriesWithData } from './utils/data-series-processing'
 import { generatePointsField } from './utils/generate-points-field'
 import { getChartContentSizes } from './utils/get-chart-content-sizes'
 import { getMinMaxBoundaries } from './utils/get-min-max-boundary'
+import { getStackedAreaPaths } from './utils/get-stacked-area-paths'
 
-export interface LineChartContentProps<D extends object> {
+export interface LineChartContentProps<D> {
     width: number
     height: number
 
@@ -37,6 +38,11 @@ export interface LineChartContentProps<D extends object> {
     xAxisKey: keyof D
 
     /**
+     * Whenever a chart component should stack data based on x value for each series
+     */
+    stacked?: boolean
+
+    /**
      * Callback runs whenever a point-zone (zone around point) and point itself
      * on the chart is clicked.
      */
@@ -47,10 +53,18 @@ export interface LineChartContentProps<D extends object> {
  * Visual component that renders svg line chart with pre-defined sizes, tooltip,
  * voronoi area distribution.
  */
-export function LineChart<D extends object>(props: LineChartContentProps<D>): ReactElement | null {
-    const { width: outerWidth, height: outerHeight, data, series, xAxisKey, onDatumClick = noop } = props
+export function LineChart<D>(props: LineChartContentProps<D>): ReactElement | null {
+    const {
+        width: outerWidth,
+        height: outerHeight,
+        data,
+        series,
+        xAxisKey,
+        stacked = false,
+        onDatumClick = noop,
+    } = props
 
-    const [activePoint, setActivePoint] = useState<Point & { element?: Element }>()
+    const [activePoint, setActivePoint] = useState<Point<D> & { element?: Element }>()
     const yAxisReference = useRef<SVGGElement>(null)
     const xAxisReference = useRef<SVGGElement>(null)
 
@@ -69,9 +83,15 @@ export function LineChart<D extends object>(props: LineChartContentProps<D>): Re
         [outerWidth, outerHeight, yAxisReference]
     )
 
-    const { minX, maxX, minY, maxY } = useMemo(() => getMinMaxBoundaries({ data, series, xAxisKey }), [
+    const dataSeries = useMemo(() => getSeriesWithData({ data, series, stacked, xAxisKey }), [
         data,
         series,
+        stacked,
+        xAxisKey,
+    ])
+
+    const { minX, maxX, minY, maxY } = useMemo(() => getMinMaxBoundaries({ dataSeries, xAxisKey }), [
+        dataSeries,
         xAxisKey,
     ])
 
@@ -81,6 +101,7 @@ export function LineChart<D extends object>(props: LineChartContentProps<D>): Re
                 domain: [minX, maxX],
                 range: [margin.left, width],
                 nice: true,
+                clamp: true,
             }),
         [minX, maxX, margin.left, width]
     )
@@ -95,19 +116,16 @@ export function LineChart<D extends object>(props: LineChartContentProps<D>): Re
         [minY, maxY, margin.top, height]
     )
 
-    const points = useMemo(() => generatePointsField({ data, series, xAxisKey, yScale, xScale }), [
-        data,
-        series,
+    const points = useMemo(() => generatePointsField({ dataSeries, xAxisKey, yScale, xScale }), [
+        dataSeries,
         xAxisKey,
         yScale,
         xScale,
     ])
 
-    const dataSeries = useMemo(() => getSeriesWithData({ data, series }), [data, series])
-
     const voronoiLayout = useMemo(
         () =>
-            voronoi<Point>({
+            voronoi<Point<D>>({
                 x: point => point.x,
                 y: point => point.y,
                 width,
@@ -163,6 +181,20 @@ export function LineChart<D extends object>(props: LineChartContentProps<D>): Re
             />
 
             <Group top={margin.top}>
+                {stacked && (
+                    <Group>
+                        {getStackedAreaPaths({ data, dataSeries, xScale, yScale, xKey: xAxisKey }).map(line => (
+                            <path
+                                key={`stack-${line.dataKey as string}`}
+                                d={line.path}
+                                stroke="transparent"
+                                opacity={0.5}
+                                fill={line.color}
+                            />
+                        ))}
+                    </Group>
+                )}
+
                 {dataSeries.map(line => (
                     <LinePath
                         key={line.dataKey as string}
@@ -194,7 +226,7 @@ export function LineChart<D extends object>(props: LineChartContentProps<D>): Re
 
             {activePoint && (
                 <Tooltip reference={activePoint.element}>
-                    <TooltipContent data={data} series={series} xAxisKey={xAxisKey} activePoint={activePoint} />
+                    <TooltipContent series={series} xAxisKey={xAxisKey} activePoint={activePoint} />
                 </Tooltip>
             )}
         </svg>

--- a/client/web/src/charts/components/line-chart/components/NonActiveBackground.tsx
+++ b/client/web/src/charts/components/line-chart/components/NonActiveBackground.tsx
@@ -7,7 +7,7 @@ import { isValidNumber } from '../utils/data-guards'
 
 const PATTERN_ID = 'xy-chart-pattern'
 
-export interface NonActiveBackgroundProps<Datum extends object> {
+export interface NonActiveBackgroundProps<Datum> {
     data: Datum[]
     series: LineChartSeries<Datum>[]
     xAxisKey: keyof Datum
@@ -36,7 +36,7 @@ export interface NonActiveBackgroundProps<Datum extends object> {
  * └──────────────────────────────────┘
  * Where ` is a non-active background
  */
-export function NonActiveBackground<Datum extends object>(props: NonActiveBackgroundProps<Datum>): ReactElement | null {
+export function NonActiveBackground<Datum>(props: NonActiveBackgroundProps<Datum>): ReactElement | null {
     const { data, series, xAxisKey, xScale, top, left, width, height } = props
 
     const backgroundWidth = useMemo(() => {

--- a/client/web/src/charts/components/line-chart/components/tooltip/Tooltip.tsx
+++ b/client/web/src/charts/components/line-chart/components/tooltip/Tooltip.tsx
@@ -122,8 +122,10 @@ export function TooltipContent<Datum>(props: TooltipContentProps<Datum>): ReactE
             <ul className={styles.tooltipList}>
                 {lines.leftRemaining > 0 && <li className={styles.item}>... and {lines.leftRemaining} more</li>}
                 {lines.window.map(line => {
+                    // In stacked mode each line and datum has its original selfValue
+                    // and stacked value which is sum of all data items of lines below
                     const selfValue = formatYTick(line.selfValue)
-                    const value = formatYTick(line.value)
+                    const stackedValue = formatYTick(line.value)
                     const datumKey = activePoint.seriesKey
                     const backgroundColor = datumKey === line.dataKey ? 'var(--secondary-2)' : ''
 
@@ -135,16 +137,14 @@ export function TooltipContent<Datum>(props: TooltipContentProps<Datum>): ReactE
                             <span className={styles.legendText}>{line?.name ?? 'unknown series'}</span>
 
                             <span className={styles.legendValue}>
-                                {selfValue !== value ? (
+                                {selfValue !== stackedValue ? (
                                     selfValue === null || Number.isNaN(selfValue) ? (
                                         '–'
                                     ) : (
                                         <span className="font-weight-bold">{selfValue}</span>
                                     )
-                                ) : (
-                                    false
-                                )}{' '}
-                                {value === null || Number.isNaN(value) ? '–' : value}
+                                ) : null}{' '}
+                                {stackedValue === null || Number.isNaN(stackedValue) ? '–' : stackedValue}
                             </span>
                         </li>
                     )

--- a/client/web/src/charts/components/line-chart/components/tooltip/Tooltip.tsx
+++ b/client/web/src/charts/components/line-chart/components/tooltip/Tooltip.tsx
@@ -15,8 +15,9 @@ import { getListWindow } from './utils/get-list-window'
  */
 export const DEFAULT_LINE_STROKE = 'var(--gray-07)'
 
-export const getLineStroke = <Datum extends object>(line: LineChartSeries<Datum>): string =>
-    line?.color ?? DEFAULT_LINE_STROKE
+export function getLineStroke<Datum>(line: LineChartSeries<Datum>): string {
+    return line?.color ?? DEFAULT_LINE_STROKE
+}
 
 interface TooltipProps {
     reference?: Target
@@ -70,10 +71,9 @@ export const Tooltip: React.FunctionComponent<TooltipProps> = props => {
 
 const MAX_ITEMS_IN_TOOLTIP = 10
 
-export interface TooltipContentProps<Datum extends object> {
+export interface TooltipContentProps<Datum> {
     series: LineChartSeries<Datum>[]
-    data: Datum[]
-    activePoint: Point
+    activePoint: Point<Datum>
     xAxisKey: keyof Datum
 }
 
@@ -81,25 +81,25 @@ export interface TooltipContentProps<Datum extends object> {
  * Display tooltip content for XYChart.
  * It consists of title - datetime for current x point and list of all nearest y points.
  */
-export function TooltipContent<Datum extends object>(props: TooltipContentProps<Datum>): ReactElement | null {
-    const { data, activePoint, series, xAxisKey } = props
+export function TooltipContent<Datum>(props: TooltipContentProps<Datum>): ReactElement | null {
+    const { activePoint, series, xAxisKey } = props
+    const { datum, originalDatum } = activePoint
 
     const lines = useMemo(() => {
         if (!activePoint) {
             return { window: [], leftRemaining: 0, rightRemaining: 0 }
         }
 
-        const currentDatum = data[activePoint.index]
-
         const sortedSeries = [...series]
             .map(line => {
-                const value = currentDatum[line.dataKey]
+                const value = datum[line.dataKey]
+                const selfValue = originalDatum[line.dataKey]
 
-                if (!isValidNumber(value)) {
+                if (!isValidNumber(value) || !isValidNumber(selfValue)) {
                     return
                 }
 
-                return { ...line, value }
+                return { ...line, value, selfValue }
             })
             .filter(isDefined)
             .sort((lineA, lineB) => lineB.value - lineA.value)
@@ -111,9 +111,9 @@ export function TooltipContent<Datum extends object>(props: TooltipContentProps<
         const centerIndex = hoveredSeriesIndex !== -1 ? hoveredSeriesIndex : Math.floor(sortedSeries.length / 2)
 
         return getListWindow(sortedSeries, centerIndex, MAX_ITEMS_IN_TOOLTIP)
-    }, [series, activePoint, data])
+    }, [activePoint, series, datum, originalDatum])
 
-    const dateString = new Date(+data[activePoint.index][xAxisKey]).toDateString()
+    const dateString = new Date(+datum[xAxisKey]).toDateString()
 
     return (
         <>
@@ -122,6 +122,7 @@ export function TooltipContent<Datum extends object>(props: TooltipContentProps<
             <ul className={styles.tooltipList}>
                 {lines.leftRemaining > 0 && <li className={styles.item}>... and {lines.leftRemaining} more</li>}
                 {lines.window.map(line => {
+                    const selfValue = formatYTick(line.selfValue)
                     const value = formatYTick(line.value)
                     const datumKey = activePoint.seriesKey
                     const backgroundColor = datumKey === line.dataKey ? 'var(--secondary-2)' : ''
@@ -134,8 +135,16 @@ export function TooltipContent<Datum extends object>(props: TooltipContentProps<
                             <span className={styles.legendText}>{line?.name ?? 'unknown series'}</span>
 
                             <span className={styles.legendValue}>
-                                {' '}
-                                {value === null || Number.isNaN(value) ? '–' : value}{' '}
+                                {selfValue !== value ? (
+                                    selfValue === null || Number.isNaN(selfValue) ? (
+                                        '–'
+                                    ) : (
+                                        <span className="font-weight-bold">{selfValue}</span>
+                                    )
+                                ) : (
+                                    false
+                                )}{' '}
+                                {value === null || Number.isNaN(value) ? '–' : value}
                             </span>
                         </li>
                     )

--- a/client/web/src/charts/components/line-chart/types.ts
+++ b/client/web/src/charts/components/line-chart/types.ts
@@ -19,13 +19,14 @@ export interface LineChartSeries<D> {
     color?: string
 }
 
-export interface Point {
+export interface Point<D> {
     id: string
     seriesKey: string
-    index: number
     value: number
     color: string
     x: number
     y: number
+    datum: D
+    originalDatum: D
     linkUrl?: string
 }

--- a/client/web/src/charts/components/line-chart/utils/data-series-processing.ts
+++ b/client/web/src/charts/components/line-chart/utils/data-series-processing.ts
@@ -63,6 +63,9 @@ export function getSeriesWithData<Datum>(input: SeriesWithDataInput<Datum>): Lin
 
     for (const stackedSeries of stackedSeriesData) {
         for (const point of stackedSeries) {
+            // D3-stack api feature. The stacked data has array shape where 0 indexed element
+            // is a lower border for the stacked datum and 1 indexed element is a upper boundary
+            // for the stacked line.
             const newStackedValue = point['1']
             const date = (point.data[xAxisKey] as unknown) as string
 

--- a/client/web/src/charts/components/line-chart/utils/data-series-processing.ts
+++ b/client/web/src/charts/components/line-chart/utils/data-series-processing.ts
@@ -1,14 +1,21 @@
+import { stack } from '@visx/shape'
+import { Series } from 'd3-shape'
+
 import { LineChartSeries } from '../types'
 
 import { isValidNumber } from './data-guards'
 
 export interface LineChartSeriesWithData<Datum> extends LineChartSeries<Datum> {
     data: Datum[]
+    originalData: Datum[]
+    stackedSeries: Series<Datum, keyof Datum> | null
 }
 
-interface SeriesWithDataInput<Datum extends object> {
+interface SeriesWithDataInput<Datum> {
     data: Datum[]
     series: LineChartSeries<Datum>[]
+    stacked: boolean
+    xAxisKey: keyof Datum
 }
 
 /**
@@ -27,18 +34,60 @@ interface SeriesWithDataInput<Datum extends object> {
  *   ]
  * ```
  */
-export function getSeriesWithData<Datum extends object>(
-    input: SeriesWithDataInput<Datum>
-): LineChartSeriesWithData<Datum>[] {
-    const { data, series } = input
+export function getSeriesWithData<Datum>(input: SeriesWithDataInput<Datum>): LineChartSeriesWithData<Datum>[] {
+    const { data, series, stacked, xAxisKey } = input
+
+    if (!stacked) {
+        return (
+            series
+                // Separate datum object by series lines
+                .map<LineChartSeriesWithData<Datum>>(line => {
+                    const filteredData = getFilteredSeriesData(data, datum => datum[line.dataKey])
+
+                    return {
+                        ...line,
+                        // Filter select series data from the datum object and process this points array
+                        data: filteredData,
+                        originalData: filteredData,
+                        stackedSeries: null,
+                    }
+                })
+        )
+    }
+
+    const stackedDataMap: Record<string, Datum> = {}
+    const stackedSeriesData = stack<Datum, keyof Datum>({
+        keys: series.map(line => line.dataKey),
+        order: 'ascending',
+    })(data)
+
+    for (const stackedSeries of stackedSeriesData) {
+        for (const point of stackedSeries) {
+            const newStackedValue = point['1']
+            const date = (point.data[xAxisKey] as unknown) as string
+
+            if (!stackedDataMap[date]) {
+                stackedDataMap[date] = { ...point.data }
+            }
+
+            stackedDataMap[date] = {
+                ...stackedDataMap[date],
+                [stackedSeries.key]: isValidNumber(point.data[stackedSeries.key]) ? newStackedValue : null,
+            }
+        }
+    }
+
+    const stackedDataList = [...Object.values(stackedDataMap)]
 
     return (
         series
             // Separate datum object by series lines
-            .map<LineChartSeriesWithData<Datum>>(line => ({
+            .map<LineChartSeriesWithData<Datum>>((line, index) => ({
                 ...line,
                 // Filter select series data from the datum object and process this points array
-                data: getFilteredSeriesData(data, datum => datum[line.dataKey]),
+                data: getFilteredSeriesData(stackedDataList, datum => datum[line.dataKey]),
+                originalData: getFilteredSeriesData(data, datum => datum[line.dataKey]),
+                stackedSeries: stackedSeriesData[index] ?? null,
             }))
     )
 }

--- a/client/web/src/charts/components/line-chart/utils/generate-points-field.ts
+++ b/client/web/src/charts/components/line-chart/utils/generate-points-field.ts
@@ -1,32 +1,39 @@
 import { ScaleLinear, ScaleTime } from 'd3-scale'
 
-import { LineChartSeries, Point } from '../types'
+import { isDefined } from '@sourcegraph/common'
+
+import { Point } from '../types'
 
 import { isValidNumber } from './data-guards'
+import { LineChartSeriesWithData } from './data-series-processing'
 
-interface PointsFieldInput<Datum extends object> {
-    data: Datum[]
-    series: LineChartSeries<Datum>[]
+interface PointsFieldInput<Datum> {
+    dataSeries: LineChartSeriesWithData<Datum>[]
     xScale: ScaleTime<number, number>
     yScale: ScaleLinear<number, number>
     xAxisKey: keyof Datum
 }
 
-export function generatePointsField<Datum extends object>(input: PointsFieldInput<Datum>): Point[] {
-    const { data, series, xScale, yScale, xAxisKey } = input
+export function generatePointsField<Datum>(input: PointsFieldInput<Datum>): Point<Datum>[] {
+    const { dataSeries, xScale, yScale, xAxisKey } = input
 
-    return data.flatMap((datum, index) =>
-        series
-            .filter(line => isValidNumber(datum[line.dataKey]))
-            .map<Point>(line => ({
-                id: `${line.dataKey as string}-${index}`,
-                seriesKey: line.dataKey as string,
-                value: +datum[line.dataKey],
-                x: xScale(+datum[xAxisKey]),
-                y: yScale(+datum[line.dataKey]),
-                color: line.color ?? 'green',
-                linkUrl: line.linkURLs?.[index],
-                index,
-            }))
+    return dataSeries.flatMap(series =>
+        series.data
+            .map((datum, index) =>
+                isValidNumber(datum[series.dataKey])
+                    ? {
+                          id: `${series.dataKey as string}-${index}`,
+                          seriesKey: series.dataKey as string,
+                          value: +datum[series.dataKey],
+                          x: xScale(+datum[xAxisKey]),
+                          y: yScale(+datum[series.dataKey]),
+                          color: series.color ?? 'green',
+                          linkUrl: series.linkURLs?.[index],
+                          originalDatum: series.originalData[index],
+                          datum,
+                      }
+                    : null
+            )
+            .filter(isDefined)
     )
 }

--- a/client/web/src/charts/components/line-chart/utils/get-min-max-boundary.ts
+++ b/client/web/src/charts/components/line-chart/utils/get-min-max-boundary.ts
@@ -1,8 +1,7 @@
-import { LineChartSeries } from '../types'
+import { LineChartSeriesWithData } from './data-series-processing'
 
-interface MinMaxBoundariesInput<D extends object> {
-    data: D[]
-    series: LineChartSeries<D>[]
+interface MinMaxBoundariesInput<D> {
+    dataSeries: LineChartSeriesWithData<D>[]
     xAxisKey: keyof D
 }
 
@@ -17,24 +16,21 @@ interface Boundaries {
  * Calculates min/max ranges for Y (across all available data series) and X axis
  * (time interval) global for all lines on the chart.
  */
-export function getMinMaxBoundaries<D extends object>(props: MinMaxBoundariesInput<D>): Boundaries {
-    const { data, series, xAxisKey } = props
+export function getMinMaxBoundaries<D>(props: MinMaxBoundariesInput<D>): Boundaries {
+    const { dataSeries, xAxisKey } = props
 
     let minX
     let maxX
     let minY
     let maxY
 
-    for (const datum of data) {
-        minX = Math.min(+datum[xAxisKey], minX ?? +datum[xAxisKey])
-        maxX = Math.max(+datum[xAxisKey], maxX ?? +datum[xAxisKey])
+    for (const line of dataSeries) {
+        for (const datum of line.data) {
+            minX = Math.min(+datum[xAxisKey], minX ?? +datum[xAxisKey])
+            maxX = Math.max(+datum[xAxisKey], maxX ?? +datum[xAxisKey])
 
-        for (const line of series) {
-            minY ??= +datum[line.dataKey]
-            maxY ??= +datum[line.dataKey]
-
-            minY = Math.min(+datum[line.dataKey], minY)
-            maxY = Math.max(+datum[line.dataKey], maxY)
+            minY = Math.min(+datum[line.dataKey], minY ?? +datum[line.dataKey])
+            maxY = Math.max(+datum[line.dataKey], maxY ?? +datum[line.dataKey])
         }
     }
 

--- a/client/web/src/charts/components/line-chart/utils/get-stacked-area-paths.ts
+++ b/client/web/src/charts/components/line-chart/utils/get-stacked-area-paths.ts
@@ -1,0 +1,47 @@
+import { area } from '@visx/shape'
+import { ScaleLinear, ScaleTime } from 'd3-scale'
+import { SeriesPoint } from 'd3-shape'
+
+import { LineChartSeries } from '../types'
+
+import { isValidNumber } from './data-guards'
+import { LineChartSeriesWithData } from './data-series-processing'
+
+interface Props<Datum> {
+    data: Datum[]
+    dataSeries: LineChartSeriesWithData<Datum>[]
+    xKey: keyof Datum
+    yScale: ScaleLinear<number, number>
+    xScale: ScaleTime<number, number>
+}
+
+interface SeriesPath<Datum> extends LineChartSeries<Datum> {
+    path: string
+}
+
+export function getStackedAreaPaths<Datum>(props: Props<Datum>): SeriesPath<Datum>[] {
+    const { dataSeries, xKey, yScale, xScale } = props
+
+    const paths: SeriesPath<Datum>[] = []
+
+    for (const series of dataSeries) {
+        const { stackedSeries } = series
+
+        if (!stackedSeries) {
+            continue
+        }
+
+        const path = area<SeriesPoint<Datum>>({
+            x: seriesDatum => xScale(+seriesDatum.data[xKey]) ?? 0,
+            y0: seriesDatum => yScale(seriesDatum[0]) ?? 0,
+            y1: seriesDatum => yScale(seriesDatum[1]) ?? 0,
+        })
+
+        paths.push({
+            ...series,
+            path: path(stackedSeries.filter(series => isValidNumber(series.data[stackedSeries.key]))) ?? '',
+        })
+    }
+
+    return paths
+}


### PR DESCRIPTION
## Context
This PR adds support stacked data in the line chart. Note that this PR change nothing about main charts. So it could be safely merged into the main. 

<img width="543" alt="Screenshot 2022-02-14 at 02 55 39" src="https://user-images.githubusercontent.com/18492575/153781058-0f960bec-cf09-492f-bbfe-1af2d9465a89.png">

## Changes
- Now `LineCharts` has `stacked` prop for data stacked mode
- In stacked mode chart's tooltip shows self and absolute item's value
- Add storybook examples for stacked mode


## Test plan 
Check new chart storybook stories. Make sure that the main functionality hasn't been affected by stacked chart mode changes.