### PR TITLE
codeintel: Speed up document canonicalization by 100x~300x

### DIFF
--- a/lib/codeintel/lsif/conversion/canonicalize.go
+++ b/lib/codeintel/lsif/conversion/canonicalize.go
@@ -66,12 +66,22 @@ func canonicalizeDocuments(state *State) {
 // non-canonical document.
 func canonicalizeDocumentsInDefinitionReferences(state *State, definitionReferenceData map[int]*datastructures.DefaultIDSetMap, canonicalIDs map[int]int) {
 	for _, documentRanges := range definitionReferenceData {
-		for documentID, canonicalID := range canonicalIDs {
-			// Remove references to non-canonical document...
-			if rangeIDs := documentRanges.Pop(documentID); rangeIDs != nil {
-				// ...and move existing definition/reference data into the canonical document
-				documentRanges.UnionIDSet(canonicalID, rangeIDs)
+		// The length of documentRanges will always be less than or equal to
+		// the length of canonicalIDs, since canonicalIDs will have one entry
+		// for each document. So iterate over documentRanges instead of
+		// iterating over canonicalIDs.
+
+		// Copy out keys first instead of (incorrectly) iterating over documentRanges while modifying it
+		var documentIDs = documentRanges.UnorderedKeys()
+		for _, documentID := range documentIDs {
+			canonicalID, ok := canonicalIDs[documentID]
+			if !ok {
+				continue
 			}
+			// Remove def/ref data from non-canonical document...
+			rangeIDs := documentRanges.Pop(documentID)
+			// ...and merge it with the data for the canonical document.
+			documentRanges.UnionIDSet(canonicalID, rangeIDs)
 		}
 	}
 }

--- a/lib/codeintel/lsif/conversion/datastructures/default_idset_map.go
+++ b/lib/codeintel/lsif/conversion/datastructures/default_idset_map.go
@@ -79,6 +79,24 @@ func (sm *DefaultIDSetMap) Len() int {
 	}
 }
 
+// UnorderedKeys returns a slice with a copy of all keys in an unspecified order.
+func (sm *DefaultIDSetMap) UnorderedKeys() []int {
+	switch sm.state() {
+	case mapStateEmpty:
+		return []int{}
+	case mapStateInline:
+		return []int{sm.inlineKey}
+	case mapStateHeap:
+		var out = make([]int, 0, sm.Len())
+		for k := range sm.m {
+			out = append(out, k)
+		}
+		return out
+	default:
+		panic(ILLEGAL_MAPSTATE)
+	}
+}
+
 // Get returns the identifier set at the given key or nil if it does not exist.
 func (sm *DefaultIDSetMap) Get(key int) *IDSet {
 	switch sm.state() {

--- a/lib/codeintel/lsif/conversion/datastructures/default_idset_map_test.go
+++ b/lib/codeintel/lsif/conversion/datastructures/default_idset_map_test.go
@@ -2,6 +2,7 @@ package datastructures
 
 import (
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -172,4 +173,18 @@ func TestDefaultIDSetMap_UnionIDSet(t *testing.T) {
 func TestDefaultIDSetMap_getOrCreate(t *testing.T) {
 	sm := NewDefaultIDSetMap()
 	require.NotNil(t, sm.getOrCreate(0))
+}
+
+func TestDefaultIDSetMap_UnorderedKeys(t *testing.T) {
+	sm := NewDefaultIDSetMap()
+	require.Equal(t, 0, len(sm.UnorderedKeys()))
+	sm.AddID(0, 1)
+	sm.AddID(0, 2)
+	require.Equal(t, []int{0}, sm.UnorderedKeys())
+	sm.AddID(1, 2)
+	sortedKeys := sm.UnorderedKeys()
+	sort.Ints(sortedKeys)
+	require.Equal(t, []int{0, 1}, sortedKeys)
+	sm.Delete(1)
+	require.Equal(t, []int{0}, sm.UnorderedKeys())
 }


### PR DESCRIPTION
Implement Chris's suggestion for faster intersection. This speeds up `canonicalizeDocuments` quite a bit (because `documentRanges` is quite small, whereas `canonicalIDs` is roughly proportional to number of documents), so the slowest part of canonicalization is now `canonicalizeRanges`. This patch is essentially the same as the one I mentioned in https://github.com/sourcegraph/sourcegraph/pull/31053#issue-1132430354

```
60M patch with max ~46 dupes
- before:
  canonicalizeDocuments         duration=35.962733208s
 - after
  canonicalizeDocuments         duration=357.644125ms
other pieces:
  canonicalizeReferenceResults  duration=42.093958ms
  canonicalizeResultSets        duration=398.065625ms
  canonicalizeRanges            duration=1.450452084s
 
large patch (120M) with max ~145 dupes
- before:
  canonicalizeDocuments         duration=3m8.622550417s
- after
  canonicalizeDocuments         duration=569.585209ms
other pieces:
  canonicalizeReferenceResults  duration=71.916292ms
  canonicalizeResultSets        duration=959.010791ms
  canonicalizeRanges            duration=2.775382167s
```

I don't fully understand why I didn't see this large speedup when I tried this earlier in https://github.com/sourcegraph/sourcegraph/pull/30978#issuecomment-1035950484. (One difference is I made the earlier measurements with a locally running Sourcegraph instance, whereas these measurements are made locally with a small helper script that just plumbs through the LSIF dump.)

## Test plan

- Added some tests for the new method `UnorderedKeys`
