### PR TITLE
search-blitz: renable mono_rev_symbol_small

### DIFF
--- a/internal/cmd/search-blitz/queries.txt
+++ b/internal/cmd/search-blitz/queries.txt
@@ -72,12 +72,8 @@ repo:^github\.com/sgtest/megarepo$ patterntype:structural strings.ToUpper(...) r
 # mono_symbol_small
 repo:^github\.com/sgtest/megarepo$ type:symbol IndexFormatVersion
 
-## This query has been disabled due to it causing the symbols service to
-## degrade. We want to enable it again, tracked at
-## https://github.com/sourcegraph/sourcegraph/issues/28457
-##
-## # mono_rev_symbol_small
-## repo:^github\.com/sgtest/megarepo$ type:symbol IndexFormatVersion rev:main
+# mono_rev_symbol_small
+repo:^github\.com/sgtest/megarepo$ type:symbol IndexFormatVersion rev:main
 
 # mono_diff_small
 repo:^github\.com/sgtest/megarepo$ type:diff   author:camden before:"february 1 2021"


### PR DESCRIPTION
This reverts commit 5929cb6887733af4df3161223899e46447837c8c. We disabled this since it was causing the symbols service to be unresponsive.

Test Plan: once landed we will deploy a new version and monitor the impact. We expect after 15min that the query will start to succeed (cold start time).

Fixes https://github.com/sourcegraph/sourcegraph/issues/28457
