### PR TITLE
Fix implementation of Pop() function for DefaultIDSetMap.

### DIFF
--- a/lib/codeintel/lsif/conversion/canonicalize_test.go
+++ b/lib/codeintel/lsif/conversion/canonicalize_test.go
@@ -138,6 +138,34 @@ func TestCanonicalizeReferenceResults(t *testing.T) {
 	}
 }
 
+func TestCanonicalizeDocumentsInDefinitionReferences(t *testing.T) {
+	actualMap := map[int]*datastructures.DefaultIDSetMap{
+		1: newIDSetMap(map[int]*idSet{
+			11: newIDSet(101, 102),
+			12: newIDSet(101, 103),
+		}),
+		2: newIDSetMap(map[int]*idSet{
+			12: newIDSet(104),
+		}),
+	}
+	canonicalizeDocumentsInDefinitionReferences(actualMap, map[int]int{
+		12: 11,
+	})
+
+	expectedMap := map[int]*datastructures.DefaultIDSetMap{
+		1: newIDSetMap(map[int]*idSet{
+			11: newIDSet(101, 102, 103),
+		}),
+		2: newIDSetMap(map[int]*idSet{
+			11: newIDSet(104),
+		}),
+	}
+
+	if diff := cmp.Diff(expectedMap, actualMap, datastructures.Comparers...); diff != "" {
+		t.Errorf("unexpected state (-want +got):\n%s", diff)
+	}
+}
+
 func TestCanonicalizeResultSets(t *testing.T) {
 	linkedMonikers := datastructures.NewDisjointIDSet()
 	linkedMonikers.Link(4002, 4005)

--- a/lib/codeintel/lsif/conversion/datastructures/default_idset_map.go
+++ b/lib/codeintel/lsif/conversion/datastructures/default_idset_map.go
@@ -131,7 +131,7 @@ func (sm *DefaultIDSetMap) Pop(key int) *IDSet {
 	case mapStateHeap:
 		v, ok := sm.m[key]
 		if ok {
-			delete(sm.m, key)
+			sm.deleteFromMap(key)
 		}
 		return v
 	default:
@@ -150,16 +150,20 @@ func (sm *DefaultIDSetMap) Delete(key int) {
 			sm.inlineValue = nil
 		}
 	case mapStateHeap:
-		delete(sm.m, key)
-		if len(sm.m) == 1 {
-			for k, v := range sm.m {
-				sm.inlineKey = k
-				sm.inlineValue = v
-			}
-			sm.m = nil
-		}
+		sm.deleteFromMap(key)
 	default:
 		panic(ILLEGAL_MAPSTATE)
+	}
+}
+
+func (sm *DefaultIDSetMap) deleteFromMap(key int) {
+	delete(sm.m, key)
+	if len(sm.m) == 1 {
+		for k, v := range sm.m {
+			sm.inlineKey = k
+			sm.inlineValue = v
+		}
+		sm.m = nil
 	}
 }
 

--- a/lib/codeintel/lsif/conversion/datastructures/default_idset_map_test.go
+++ b/lib/codeintel/lsif/conversion/datastructures/default_idset_map_test.go
@@ -175,6 +175,36 @@ func TestDefaultIDSetMap_getOrCreate(t *testing.T) {
 	require.NotNil(t, sm.getOrCreate(0))
 }
 
+func TestDefaultIDSetMap_Pop(t *testing.T) {
+	sm := NewDefaultIDSetMap()
+	sm.AddID(0, 1)
+	sm.AddID(1, 1)
+
+	sm.Pop(2)
+	require.Equal(t, mapStateHeap, sm.state())
+	expect := DefaultIDSetMapWith(map[int]*IDSet{
+		0: IDSetWith(1),
+		1: IDSetWith(1),
+	})
+	if diff := cmp.Diff(expect, sm, Comparers...); diff != "" {
+		t.Errorf("unexpected state (-want +got):\n%s", diff)
+	}
+
+	sm.Pop(0)
+	require.Equal(t, mapStateInline, sm.state())
+	expect = DefaultIDSetMapWith(map[int]*IDSet{1: IDSetWith(1)})
+	if diff := cmp.Diff(expect, sm, Comparers...); diff != "" {
+		t.Errorf("unexpected state (-want +got):\n%s", diff)
+	}
+
+	sm.Pop(1)
+	require.Equal(t, mapStateEmpty, sm.state())
+	expect = DefaultIDSetMapWith(map[int]*IDSet{})
+	if diff := cmp.Diff(expect, sm, Comparers...); diff != "" {
+		t.Errorf("unexpected state (-want +got):\n%s", diff)
+	}
+}
+
 func TestDefaultIDSetMap_UnorderedKeys(t *testing.T) {
 	sm := NewDefaultIDSetMap()
 	require.Equal(t, 0, len(sm.UnorderedKeys()))


### PR DESCRIPTION
1 commit stacked on top of #31144 

Context: When removing elements, the map should transition from the Heap state to the Inline state. However, there was a code path in `Pop()` where this was not followed. This doesn't affect correctness in the way we use the map, but it does affect writing test cases, because adding a key followed by deleting the key is not an identity operation without this fix.

## Test plan

- Added test cases for `Pop()` as well as higher level code using it.