### PR TITLE
notebooks: auto-save on input change, not block run

### DIFF
--- a/client/web/src/search/notebook/SearchNotebook.tsx
+++ b/client/web/src/search/notebook/SearchNotebook.tsx
@@ -95,7 +95,7 @@ export const SearchNotebook: React.FunctionComponent<SearchNotebookProps> = ({
     const onRunBlock = useCallback(
         (id: string) => {
             notebook.runBlockById(id)
-            updateBlocks()
+            updateBlocks(false)
 
             props.telemetryService.log(
                 'SearchNotebookRunBlock',
@@ -112,7 +112,7 @@ export const SearchNotebook: React.FunctionComponent<SearchNotebookProps> = ({
                 click.pipe(
                     switchMap(() => notebook.runAllBlocks().pipe(startWith(LOADING))),
                     tap(() => {
-                        updateBlocks()
+                        updateBlocks(false)
                         props.telemetryService.log('SearchNotebookRunAllBlocks')
                     })
                 ),
@@ -123,7 +123,7 @@ export const SearchNotebook: React.FunctionComponent<SearchNotebookProps> = ({
     const onBlockInputChange = useCallback(
         (id: string, blockInput: BlockInput) => {
             notebook.setBlockInputById(id, blockInput)
-            updateBlocks(false)
+            updateBlocks()
         },
         [notebook, updateBlocks]
     )

--- a/client/web/src/search/notebook/SearchNotebookMarkdownBlock.tsx
+++ b/client/web/src/search/notebook/SearchNotebookMarkdownBlock.tsx
@@ -35,7 +35,7 @@ export const SearchNotebookMarkdownBlock: React.FunctionComponent<SearchNotebook
     onSelectBlock,
     ...props
 }) => {
-    const [isEditing, setIsEditing] = useState(input.length === 0)
+    const [isEditing, setIsEditing] = useState(!isReadOnly && input.length === 0)
     const [editor, setEditor] = useState<Monaco.editor.IStandaloneCodeEditor>()
     const blockElement = useRef<HTMLDivElement>(null)
 

--- a/client/web/src/search/notebook/fileBlock/SearchNotebookFileBlock.tsx
+++ b/client/web/src/search/notebook/fileBlock/SearchNotebookFileBlock.tsx
@@ -210,11 +210,11 @@ export const SearchNotebookFileBlock: React.FunctionComponent<SearchNotebookFile
 
     // Automatically fetch the highlighted file on each input change, if all inputs are valid
     useEffect(() => {
-        if (!areInputsValid) {
+        if (!showInputs || !areInputsValid) {
             return
         }
         onRunBlock(id)
-    }, [id, input, areInputsValid, onRunBlock])
+    }, [id, input, showInputs, areInputsValid, onRunBlock])
 
     const onFileURLPaste = useCallback(
         (event: ClipboardEvent) => {

--- a/client/web/src/search/notebook/index.ts
+++ b/client/web/src/search/notebook/index.ts
@@ -86,13 +86,9 @@ export class Notebook {
         this.blocks = new Map(blocks.map(block => [block.id, block]))
         this.blockOrder = blocks.map(block => block.id)
 
-        this.renderMarkdownBlocks()
-    }
-
-    private renderMarkdownBlocks(): void {
-        const blocks = this.blocks.values()
+        // Pre-run the markdown and file blocks, for a better user experience.
         for (const block of blocks) {
-            if (block.type === 'md') {
+            if (block.type === 'md' || block.type === 'file') {
                 this.runBlockById(block.id)
             }
         }


### PR DESCRIPTION
Fixes #31117

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

* Create a notebook with a file block
* Refresh the page
* Auto-save should not be triggered
* Click "Run all blocks" button
* Auto-save should not be triggered
* Change a block input
* Auto-save should be triggered
