### PR TITLE
bext: Include file path into view repo on Sourcegraph link

### DIFF
--- a/client/browser/src/shared/code-hosts/github/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/github/codeHost.tsx
@@ -676,10 +676,12 @@ export const githubCodeHost: GithubCodeHost = {
     nativeTooltipResolvers: [nativeTooltipResolver],
     getContext: async () => {
         const { repoName, rawRepoName, pageType } = parseURL()
+        const { revision, filePath } = resolveFileInfo().blob
 
         return {
             rawRepoName,
-            revision: pageType === 'blob' || pageType === 'tree' ? resolveFileInfo().blob.revision : undefined,
+            revision: pageType === 'blob' || pageType === 'tree' ? revision : undefined,
+            filePath: pageType === 'blob' || pageType === 'tree' ? `${pageType}/${filePath}` : undefined,
             privateRepository: await isPrivateRepository(repoName),
         }
     },

--- a/client/browser/src/shared/code-hosts/github/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/github/codeHost.tsx
@@ -39,7 +39,7 @@ import { diffDomFunctions, searchCodeSnippetDOMFunctions, singleFileDOMFunctions
 import { getCommandPaletteMount } from './extensions'
 import { resolveDiffFileInfo, resolveFileInfo, resolveSnippetFileInfo } from './fileInfo'
 import { setElementTooltip } from './tooltip'
-import { getFileContainers, getFilePath, parseURL } from './util'
+import { getFileContainers, getPermalinkHref, parseURL } from './util'
 
 /**
  * Creates the mount element for the CodeViewToolbar on code views containing
@@ -693,7 +693,7 @@ export const githubCodeHost: GithubCodeHost = {
     getContext,
     getReactiveContext: mutations =>
         ['blob', 'tree'].includes(parseURL().pageType)
-            ? mutations.pipe(map(getFilePath), filter(Boolean), distinctUntilChanged(), mergeMap(getContext))
+            ? mutations.pipe(map(getPermalinkHref), filter(Boolean), distinctUntilChanged(), mergeMap(getContext))
             : from(getContext()),
     isLightTheme: defer(() => {
         const mode = document.documentElement.dataset.colorMode as 'auto' | 'light' | 'dark' | undefined

--- a/client/browser/src/shared/code-hosts/github/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/github/codeHost.tsx
@@ -414,6 +414,11 @@ export const isPrivateRepository = (
 
 export interface GithubCodeHost extends CodeHost {
     /**
+     * Observable used to trigger context updates
+     */
+    contextUpdater: (mutations: Observable<MutationRecordLike[]>) => Observable<unknown>
+
+    /**
      * Configuration for built-in search input enhancement
      */
     searchEnhancement: {
@@ -685,6 +690,12 @@ export const githubCodeHost: GithubCodeHost = {
             privateRepository: await isPrivateRepository(repoName),
         }
     },
+    contextUpdater: mutations =>
+        mutations.pipe(
+            map(() => document.querySelector<HTMLAnchorElement>('a.js-permalink-shortcut')?.href),
+            filter(Boolean),
+            distinctUntilChanged()
+        ),
     isLightTheme: defer(() => {
         const mode = document.documentElement.dataset.colorMode as 'auto' | 'light' | 'dark' | undefined
         if (mode === 'auto') {

--- a/client/browser/src/shared/code-hosts/github/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/github/codeHost.tsx
@@ -4,7 +4,7 @@ import { trimStart } from 'lodash'
 import React from 'react'
 import { render } from 'react-dom'
 import { defer, Observable, of, Subscription } from 'rxjs'
-import { distinctUntilChanged, filter, map } from 'rxjs/operators'
+import { distinctUntilChanged, filter, map, mergeMap } from 'rxjs/operators'
 import { Omit } from 'utility-types'
 
 import { AdjustmentDirection, PositionAdjuster } from '@sourcegraph/codeintellify'
@@ -39,7 +39,7 @@ import { diffDomFunctions, searchCodeSnippetDOMFunctions, singleFileDOMFunctions
 import { getCommandPaletteMount } from './extensions'
 import { resolveDiffFileInfo, resolveFileInfo, resolveSnippetFileInfo } from './fileInfo'
 import { setElementTooltip } from './tooltip'
-import { getFileContainers, parseURL } from './util'
+import { getFileContainers, getFilePath, parseURL } from './util'
 
 /**
  * Creates the mount element for the CodeViewToolbar on code views containing
@@ -687,8 +687,8 @@ export const githubCodeHost: GithubCodeHost = {
     contentViewResolvers: [markdownBodyViewResolver],
     nativeTooltipResolvers: [nativeTooltipResolver],
     getContext,
-    // getReactiveContext: mutations =>
-    //     mutations.pipe(map(getFilePath), filter(Boolean), distinctUntilChanged(), mergeMap(getContext)),
+    getReactiveContext: mutations =>
+        mutations.pipe(map(getFilePath), filter(Boolean), distinctUntilChanged(), mergeMap(getContext)),
     isLightTheme: defer(() => {
         const mode = document.documentElement.dataset.colorMode as 'auto' | 'light' | 'dark' | undefined
         if (mode === 'auto') {

--- a/client/browser/src/shared/code-hosts/github/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/github/codeHost.tsx
@@ -3,8 +3,8 @@ import classNames from 'classnames'
 import { trimStart } from 'lodash'
 import React from 'react'
 import { render } from 'react-dom'
-import { defer, Observable, of, Subscription } from 'rxjs'
-import { catchError, distinctUntilChanged, filter, map, mergeMap } from 'rxjs/operators'
+import { defer, from, Observable, of, Subscription } from 'rxjs'
+import { distinctUntilChanged, filter, map, mergeMap } from 'rxjs/operators'
 import { Omit } from 'utility-types'
 
 import { AdjustmentDirection, PositionAdjuster } from '@sourcegraph/codeintellify'
@@ -692,13 +692,9 @@ export const githubCodeHost: GithubCodeHost = {
     nativeTooltipResolvers: [nativeTooltipResolver],
     getContext,
     getReactiveContext: mutations =>
-        mutations.pipe(
-            map(getFilePath),
-            catchError(() => of('')),
-            filter(Boolean),
-            distinctUntilChanged(),
-            mergeMap(getContext)
-        ),
+        ['blob', 'tree'].includes(parseURL().pageType)
+            ? mutations.pipe(map(getFilePath), filter(Boolean), distinctUntilChanged(), mergeMap(getContext))
+            : from(getContext()),
     isLightTheme: defer(() => {
         const mode = document.documentElement.dataset.colorMode as 'auto' | 'light' | 'dark' | undefined
         if (mode === 'auto') {

--- a/client/browser/src/shared/code-hosts/github/util.tsx
+++ b/client/browser/src/shared/code-hosts/github/util.tsx
@@ -190,6 +190,14 @@ function getDiffResolvedRevisionFromPageSource(
     }
 }
 
+export function getPermalinkHref(): string {
+    const permalink = document.querySelector<HTMLAnchorElement>('a.js-permalink-shortcut')
+    if (!permalink) {
+        throw new Error('Unable to determine the file path because no a.js-permalink-shortcut element was found.')
+    }
+    return permalink.href
+}
+
 /**
  * Returns the file path for the current page. Must be on a blob or tree page.
  *
@@ -207,11 +215,7 @@ function getDiffResolvedRevisionFromPageSource(
  * TODO ideally, this should only scrape the code view itself.
  */
 export function getFilePath(): string {
-    const permalink = document.querySelector<HTMLAnchorElement>('a.js-permalink-shortcut')
-    if (!permalink) {
-        throw new Error('Unable to determine the file path because no a.js-permalink-shortcut element was found.')
-    }
-    const url = new URL(permalink.href)
+    const url = new URL(getPermalinkHref())
     // <empty>/<user>/<repo>/(blob|tree)/<commitID>/<path/to/file>
     // eslint-disable-next-line unicorn/no-unreadable-array-destructuring
     const [, , , pageType, , ...path] = url.pathname.split('/')

--- a/client/browser/src/shared/code-hosts/shared/ViewOnSourcegraphButton.tsx
+++ b/client/browser/src/shared/code-hosts/shared/ViewOnSourcegraphButton.tsx
@@ -146,8 +146,6 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphB
         return null
     }
 
-    console.log({ url, context })
-
     // Render a "View on Sourcegraph" button
     return (
         <SourcegraphIconButton

--- a/client/browser/src/shared/code-hosts/shared/ViewOnSourcegraphButton.tsx
+++ b/client/browser/src/shared/code-hosts/shared/ViewOnSourcegraphButton.tsx
@@ -56,7 +56,7 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphB
         iconClassName,
     }
 
-    const { rawRepoName, revision, privateRepository } = context
+    const { rawRepoName, revision, filePath, privateRepository } = context
 
     const isPrivateCloudError =
         isDefaultSourcegraphUrl(sourcegraphURL) && repoExistsOrError === false && privateRepository
@@ -74,10 +74,13 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphB
         return null
     }
 
-    const url = createURLWithUTM(new URL(`/${rawRepoName}${revision ? `@${revision}` : ''}`, sourcegraphURL), {
-        utm_source: getPlatformName(),
-        utm_campaign: 'view-on-sourcegraph',
-    }).href
+    const url = createURLWithUTM(
+        new URL(`/${rawRepoName}${revision ? `@${revision}` : ''}${filePath ? `/-/${filePath}` : ''}`, sourcegraphURL),
+        {
+            utm_source: getPlatformName(),
+            utm_campaign: 'view-on-sourcegraph',
+        }
+    ).href
 
     if (isErrorLike(repoExistsOrError)) {
         // If the problem is the user is not signed in, show a sign in CTA (if not shown elsewhere)
@@ -142,6 +145,8 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphB
     if (minimalUI) {
         return null
     }
+
+    console.log({ url, context })
 
     // Render a "View on Sourcegraph" button
     return (

--- a/client/browser/src/shared/code-hosts/shared/ViewOnSourcegraphButton.tsx
+++ b/client/browser/src/shared/code-hosts/shared/ViewOnSourcegraphButton.tsx
@@ -76,10 +76,7 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphB
 
     const url = createURLWithUTM(
         new URL(`/${rawRepoName}${revision ? `@${revision}` : ''}${filePath ? `/-/${filePath}` : ''}`, sourcegraphURL),
-        {
-            utm_source: getPlatformName(),
-            utm_campaign: 'view-on-sourcegraph',
-        }
+        { utm_source: getPlatformName(), utm_campaign: 'view-on-sourcegraph' }
     ).href
 
     if (isErrorLike(repoExistsOrError)) {

--- a/client/browser/src/shared/code-hosts/shared/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/shared/codeHost.tsx
@@ -160,7 +160,7 @@ export type MountGetter = (container: HTMLElement) => HTMLElement | null
 /**
  * The context the code host is in on the current page.
  */
-export type CodeHostContext = RawRepoSpec & Partial<RevisionSpec> & { privateRepository: boolean }
+export type CodeHostContext = RawRepoSpec & Partial<RevisionSpec> & Partial<FileSpec> & { privateRepository: boolean }
 
 export type CodeHostType = 'github' | 'phabricator' | 'bitbucket-server' | 'bitbucket-cloud' | 'gitlab' | 'gerrit'
 

--- a/client/browser/src/shared/code-hosts/shared/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/shared/codeHost.tsx
@@ -945,10 +945,10 @@ export async function handleCodeHost({
     const codeViewCount = new BehaviorSubject<number>(0)
 
     // Render view on Sourcegraph button
-    if (codeHost.getViewContextOnSourcegraphMount && codeHost.getContext) {
+    if (codeHost.getViewContextOnSourcegraphMount && (codeHost.getContext || codeHost.getReactiveContext)) {
         const { getContext, getReactiveContext, viewOnSourcegraphButtonClassProps } = codeHost
 
-        const context = getReactiveContext ? getReactiveContext(mutations) : from(getContext())
+        const context = getReactiveContext ? getReactiveContext(mutations) : from(getContext!())
 
         /** Whether or not the repo exists on the configured Sourcegraph instance. */
         const repoExistsOrErrors = combineLatest([signInCloses.pipe(startWith(null)), context]).pipe(


### PR DESCRIPTION
Closes [#12551](https://github.com/sourcegraph/sourcegraph/issues/12551)

**View repository on Sourcegraph** button now navigates to the corresponding folder/file on Sourcegraph.
Button functionality in other than repo navigation modes remains unchanged.

### Test Plan
- `sg run bext`
- select repo, browse its code and click on Sourcegraph icon button
- ensure that the same file/folder and revision were opened on Sourcegraph search page

https://user-images.githubusercontent.com/25318659/154055293-dc373297-9929-481a-bbb5-4b691d19a60f.mp4


