### PR TITLE
codeintel: Fix repository inference for NPM packages.

### DIFF
--- a/enterprise/cmd/worker/internal/codeintel/indexing/dependency_indexing_scheduler.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/dependency_indexing_scheduler.go
@@ -134,12 +134,12 @@ func (h *dependencyIndexingSchedulerHandler) Handle(ctx context.Context, record 
 			Version: packageReference.Package.Version,
 		}
 
-		name, _, ok := enqueuer.InferRepositoryAndRevision(pkg)
+		repoName, _, ok := enqueuer.InferRepositoryAndRevision(pkg)
 		if !ok {
 			continue
 		}
-		repoToPackages[api.RepoName(name)] = append(repoToPackages[api.RepoName(name)], pkg)
-		repoNames = append(repoNames, api.RepoName(name))
+		repoToPackages[repoName] = append(repoToPackages[repoName], pkg)
+		repoNames = append(repoNames, repoName)
 	}
 
 	// if this job is not associated with an external service kind that was just synced, then we need to guarantee

--- a/enterprise/internal/codeintel/autoindex/enqueuer/enqueuer.go
+++ b/enterprise/internal/codeintel/autoindex/enqueuer/enqueuer.go
@@ -8,7 +8,6 @@ import (
 	"golang.org/x/time/rate"
 
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/autoindex/config"
@@ -115,14 +114,14 @@ func (s *IndexEnqueuer) QueueIndexesForPackage(ctx context.Context, pkg precise.
 	if !ok {
 		return nil
 	}
-	trace.Log(log.String("repoName", repoName))
+	trace.Log(log.String("repoName", string(repoName)))
 	trace.Log(log.String("revision", revision))
 
 	if err := s.repoUpdaterLimiter.Wait(ctx); err != nil {
 		return err
 	}
 
-	resp, err := s.repoUpdater.EnqueueRepoUpdate(ctx, api.RepoName(repoName))
+	resp, err := s.repoUpdater.EnqueueRepoUpdate(ctx, repoName)
 	if err != nil {
 		if errcode.IsNotFound(err) {
 			return nil

--- a/enterprise/internal/codeintel/autoindex/enqueuer/infer.go
+++ b/enterprise/internal/codeintel/autoindex/enqueuer/infer.go
@@ -3,13 +3,15 @@ package enqueuer
 import (
 	"strings"
 
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores/dbstore"
+	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 )
 
-func InferRepositoryAndRevision(pkg precise.Package) (repoName, gitTagOrCommit string, ok bool) {
-	for _, fn := range []func(pkg precise.Package) (string, string, bool){
+func InferRepositoryAndRevision(pkg precise.Package) (repoName api.RepoName, gitTagOrCommit string, ok bool) {
+	for _, fn := range []func(pkg precise.Package) (api.RepoName, string, bool){
 		inferGoRepositoryAndRevision,
 		inferJVMRepositoryAndRevision,
 		inferNPMRepositoryAndRevision,
@@ -26,7 +28,7 @@ const GitHubScheme = "https://"
 
 var goVersionPattern = lazyregexp.New(`^v?[\d\.]+-([a-f0-9]+)`)
 
-func inferGoRepositoryAndRevision(pkg precise.Package) (string, string, bool) {
+func inferGoRepositoryAndRevision(pkg precise.Package) (api.RepoName, string, bool) {
 	if pkg.Scheme != "gomod" || !strings.HasPrefix(pkg.Name, GitHubScheme+"github.com/") {
 		return "", "", false
 	}
@@ -41,19 +43,22 @@ func inferGoRepositoryAndRevision(pkg precise.Package) (string, string, bool) {
 		version = match[0][1]
 	}
 
-	return strings.Join(repoParts, "/"), version, true
+	return api.RepoName(strings.Join(repoParts, "/")), version, true
 }
 
-func inferJVMRepositoryAndRevision(pkg precise.Package) (string, string, bool) {
+func inferJVMRepositoryAndRevision(pkg precise.Package) (api.RepoName, string, bool) {
 	if pkg.Scheme != dbstore.JVMPackagesScheme {
 		return "", "", false
 	}
-	return pkg.Name, "v" + pkg.Version, true
+	// TODO: [Varun] Is this correct, or do we need extra steps like for NPM?
+	return api.RepoName(pkg.Name), "v" + pkg.Version, true
 }
 
-func inferNPMRepositoryAndRevision(pkg precise.Package) (string, string, bool) {
+func inferNPMRepositoryAndRevision(pkg precise.Package) (api.RepoName, string, bool) {
 	if pkg.Scheme != dbstore.NPMPackagesScheme {
 		return "", "", false
 	}
-	return pkg.Name, "v" + pkg.Version, true
+	// TODO: [Varun] What should we do about the error here?
+	npmPkg, _ := reposource.ParseNPMPackageFromPackageSyntax(pkg.Name)
+	return npmPkg.RepoName(), "v" + pkg.Version, true
 }

--- a/enterprise/internal/codeintel/autoindex/enqueuer/infer_test.go
+++ b/enterprise/internal/codeintel/autoindex/enqueuer/infer_test.go
@@ -40,6 +40,24 @@ func TestInferRepositoryAndRevision(t *testing.T) {
 				repoName: "github.com/sourcegraph/sourcegraph",
 				revision: "de0123456789",
 			},
+			{
+				pkg: precise.Package{
+					Scheme:  "npm",
+					Name:    "mypackage",
+					Version: "1.0.0",
+				},
+				repoName: "npm/mypackage",
+				revision: "v1.0.0",
+			},
+			{
+				pkg: precise.Package{
+					Scheme:  "npm",
+					Name:    "@myscope/mypackage",
+					Version: "1.0.0",
+				},
+				repoName: "npm/myscope/mypackage",
+				revision: "v1.0.0",
+			},
 		}
 
 		for _, testCase := range testCases {
@@ -48,8 +66,8 @@ func TestInferRepositoryAndRevision(t *testing.T) {
 				t.Fatalf("expected repository to be inferred")
 			}
 
-			if repoName != testCase.repoName {
-				t.Errorf("unexpected repo name. want=%q have=%q", testCase.repoName, repoName)
+			if string(repoName) != testCase.repoName {
+				t.Errorf("unexpected repo name. want=%q have=%q", testCase.repoName, string(repoName))
 			}
 			if revision != testCase.revision {
 				t.Errorf("unexpected revision. want=%q have=%q", testCase.revision, revision)


### PR DESCRIPTION
Later code in gitserver.RepoInfo uses the repo name to infer a path
where the repo contents are cloned. NPM package have their contents
cloned under an npm/ subdirectory (similar to github.com/) under
.sourcegraph/repos. However, this code was just passing in the package
name instead of using the proper repo name which has an npm/ prefix,
and removes an @ from the scope (if a scope is present).

Questions: 
1. Should we add an integration test or broadly some larger test here? The failure mode seems particularly unfortunate, what ends up happening is that the call to `RepoInfo` returns entries with `IsCloned` set to false, because it ends up looking at the wrong directory (under `~/.sourcegraph/repos/<package>` rather than under `~/.sourcegraph/repos/npm/<package>`. So no jobs are scheduled under `QueueIndexesForPackage`. 🤦 
2. Does this same problem apply to Maven packages? I've left a TODO in that spot in the code.
3. I'm currently dropping an error for the situation where we accidentally put the name in an incorrect format in the database (so parsing the package will fail). Should that error be bubbled up instead?

## Test plan

- I've add some tests for the main function that was fixed.