### PR TITLE
[cloud][CLOUD-185] Store expiry time for organization invitations

### DIFF
--- a/cmd/frontend/graphqlbackend/org_invitation.go
+++ b/cmd/frontend/graphqlbackend/org_invitation.go
@@ -20,7 +20,7 @@ func NewOrganizationInvitationResolver(db database.DB, v *database.OrgInvitation
 }
 
 func orgInvitationByID(ctx context.Context, db database.DB, id graphql.ID) (*organizationInvitationResolver, error) {
-	orgInvitationID, err := unmarshalOrgInvitationID(id)
+	orgInvitationID, err := UnmarshalOrgInvitationID(id)
 	if err != nil {
 		return nil, err
 	}
@@ -36,12 +36,12 @@ func orgInvitationByIDInt64(ctx context.Context, db database.DB, id int64) (*org
 }
 
 func (r *organizationInvitationResolver) ID() graphql.ID {
-	return marshalOrgInvitationID(r.v.ID)
+	return MarshalOrgInvitationID(r.v.ID)
 }
 
-func marshalOrgInvitationID(id int64) graphql.ID { return relay.MarshalID("OrgInvitation", id) }
+func MarshalOrgInvitationID(id int64) graphql.ID { return relay.MarshalID("OrgInvitation", id) }
 
-func unmarshalOrgInvitationID(id graphql.ID) (orgInvitationID int64, err error) {
+func UnmarshalOrgInvitationID(id graphql.ID) (orgInvitationID int64, err error) {
 	err = relay.UnmarshalSpec(id, &orgInvitationID)
 	return
 }
@@ -90,7 +90,7 @@ func (r *organizationInvitationResolver) RespondURL(ctx context.Context) (*strin
 		var url string
 		var err error
 		if orgInvitationConfigDefined() {
-			url, err = orgInvitationURL(r.v.OrgID, r.v.ID, r.v.SenderUserID, r.v.RecipientUserID, "", true)
+			url, err = orgInvitationURL(*r.v, true)
 		} else { // TODO: remove this fallback once signing key is enforced for on-prem instances
 			org, err := database.Orgs(r.db).GetByID(ctx, r.v.OrgID)
 			if err != nil {
@@ -108,6 +108,10 @@ func (r *organizationInvitationResolver) RespondURL(ctx context.Context) (*strin
 
 func (r *organizationInvitationResolver) RevokedAt() *DateTime {
 	return DateTimeOrNil(r.v.RevokedAt)
+}
+
+func (r *organizationInvitationResolver) ExpiresAt() *DateTime {
+	return DateTimeOrNil(r.v.ExpiresAt)
 }
 
 func (r *organizationInvitationResolver) IsVerifiedEmail() *bool {

--- a/cmd/frontend/graphqlbackend/org_invitations.go
+++ b/cmd/frontend/graphqlbackend/org_invitations.go
@@ -29,6 +29,7 @@ import (
 
 var EMAIL_INVITES_FF = "org-email-invites"
 var SIGNING_KEY_MESSAGE = "signing key not provided, cannot create JWT for invitation URL. Please add organizationInvitations signingKey to site configuration."
+var DEFAULT_EXPIRY_TIME = 48 * time.Hour
 
 func getUserToInviteToOrganization(ctx context.Context, db database.DB, username string, orgID int32) (userToInvite *types.User, userEmailAddress string, err error) {
 	userToInvite, err = db.Users().GetByUsername(ctx, username)
@@ -205,7 +206,12 @@ func (r *schemaResolver) InviteUserToOrganization(ctx context.Context, args *str
 		recipientEmail = *args.Email
 	}
 
-	invitation, err := r.db.OrgInvitations().Create(ctx, orgID, sender.ID, recipientID, recipientEmail)
+	var expiryDuration = DEFAULT_EXPIRY_TIME
+	if hasConfig && conf.SiteConfig().OrganizationInvitations.ExpiryTime > 0 {
+		expiryDuration = time.Duration(conf.SiteConfig().OrganizationInvitations.ExpiryTime) * time.Hour
+	}
+	expiryTime := timeNow().Add(expiryDuration)
+	invitation, err := r.db.OrgInvitations().Create(ctx, orgID, sender.ID, recipientID, recipientEmail, expiryTime)
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +219,7 @@ func (r *schemaResolver) InviteUserToOrganization(ctx context.Context, args *str
 	// create invitation URL
 	var invitationURL string
 	if args.Email != nil || hasConfig {
-		invitationURL, err = orgInvitationURL(org.ID, invitation.ID, sender.ID, recipientID, recipientEmail, false)
+		invitationURL, err = orgInvitationURL(*invitation, false)
 	} else { // TODO: remove this fallback once signing key is enforced for on-prem instances
 		invitationURL = orgInvitationURLLegacy(org, false)
 	}
@@ -245,7 +251,7 @@ func (r *schemaResolver) RespondToOrganizationInvitation(ctx context.Context, ar
 		return nil, errors.New("no current user")
 	}
 
-	id, err := unmarshalOrgInvitationID(args.OrganizationInvitation)
+	id, err := UnmarshalOrgInvitationID(args.OrganizationInvitation)
 	if err != nil {
 		return nil, err
 	}
@@ -309,30 +315,40 @@ func (r *schemaResolver) RespondToOrganizationInvitation(ctx context.Context, ar
 func (r *schemaResolver) ResendOrganizationInvitationNotification(ctx context.Context, args *struct {
 	OrganizationInvitation graphql.ID
 }) (*EmptyResponse, error) {
-	orgInvitation, err := orgInvitationByID(ctx, r.db, args.OrganizationInvitation)
+	id, err := UnmarshalOrgInvitationID(args.OrganizationInvitation)
+	if err != nil {
+		return nil, err
+	}
+
+	orgInvitation, err := r.db.OrgInvitations().GetPendingByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 
 	// 🚨 SECURITY: Check that the current user is a member of the org that the invite is for.
-	if err := backend.CheckOrgAccessOrSiteAdmin(ctx, r.db, orgInvitation.v.OrgID); err != nil {
+	if err := backend.CheckOrgAccessOrSiteAdmin(ctx, r.db, orgInvitation.OrgID); err != nil {
 		return nil, err
 	}
 
 	// Prevent reuse. This just prevents annoyance (abuse is prevented by the quota check in the
 	// call to sendOrgInvitationNotification).
-	if orgInvitation.v.RevokedAt != nil {
-		return nil, errors.New("refusing to send notification for revoked invitation")
-	}
-	if orgInvitation.v.RespondedAt != nil {
-		return nil, errors.New("refusing to send notification for invitation that was already responded to")
+	if !orgInvitation.Pending() {
+		if orgInvitation.RevokedAt != nil {
+			return nil, errors.New("refusing to send notification for revoked invitation")
+		}
+		if orgInvitation.RespondedAt != nil {
+			return nil, errors.New("refusing to send notification for invitation that was already responded to")
+		}
+		if orgInvitation.Expired() {
+			return nil, errors.New("refusing to send notification for expired invitation")
+		}
 	}
 
 	if !conf.CanSendEmail() {
 		return nil, errors.New("unable to send notification for invitation because sending emails is not enabled")
 	}
 
-	org, err := r.db.Orgs().GetByID(ctx, orgInvitation.v.OrgID)
+	org, err := r.db.Orgs().GetByID(ctx, orgInvitation.OrgID)
 	if err != nil {
 		return nil, err
 	}
@@ -340,7 +356,7 @@ func (r *schemaResolver) ResendOrganizationInvitationNotification(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	recipientEmail, recipientEmailVerified, err := r.db.UserEmails().GetPrimaryEmail(ctx, orgInvitation.v.RecipientUserID)
+	recipientEmail, recipientEmailVerified, err := r.db.UserEmails().GetPrimaryEmail(ctx, orgInvitation.RecipientUserID)
 	if err != nil {
 		return nil, err
 	}
@@ -349,7 +365,7 @@ func (r *schemaResolver) ResendOrganizationInvitationNotification(ctx context.Co
 	}
 	var invitationURL string
 	if orgInvitationConfigDefined() {
-		invitationURL, err = orgInvitationURL(org.ID, orgInvitation.v.ID, sender.ID, orgInvitation.v.RecipientUserID, recipientEmail, false)
+		invitationURL, err = orgInvitationURL(*orgInvitation, false)
 	} else { // TODO: remove this fallback once signing key is enforced for on-prem instances
 		invitationURL = orgInvitationURLLegacy(org, false)
 	}
@@ -365,17 +381,21 @@ func (r *schemaResolver) ResendOrganizationInvitationNotification(ctx context.Co
 func (r *schemaResolver) RevokeOrganizationInvitation(ctx context.Context, args *struct {
 	OrganizationInvitation graphql.ID
 }) (*EmptyResponse, error) {
-	orgInvitation, err := orgInvitationByID(ctx, r.db, args.OrganizationInvitation)
+	id, err := UnmarshalOrgInvitationID(args.OrganizationInvitation)
+	if err != nil {
+		return nil, err
+	}
+	orgInvitation, err := r.db.OrgInvitations().GetPendingByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 
 	// 🚨 SECURITY: Check that the current user is a member of the org that the invite is for.
-	if err := backend.CheckOrgAccessOrSiteAdmin(ctx, r.db, orgInvitation.v.OrgID); err != nil {
+	if err := backend.CheckOrgAccessOrSiteAdmin(ctx, r.db, orgInvitation.OrgID); err != nil {
 		return nil, err
 	}
 
-	if err := r.db.OrgInvitations().Revoke(ctx, orgInvitation.v.ID); err != nil {
+	if err := r.db.OrgInvitations().Revoke(ctx, orgInvitation.ID); err != nil {
 		return nil, err
 	}
 	return &EmptyResponse{}, nil
@@ -393,8 +413,8 @@ func orgInvitationURLLegacy(org *types.Org, relative bool) string {
 	return globals.ExternalURL().ResolveReference(&url.URL{Path: path}).String()
 }
 
-func orgInvitationURL(orgID int32, invitationID int64, senderID int32, recipientID int32, recipientEmail string, relative bool) (string, error) {
-	token, err := createInvitationJWT(orgID, invitationID, senderID)
+func orgInvitationURL(invitation database.OrgInvitation, relative bool) (string, error) {
+	token, err := createInvitationJWT(invitation.OrgID, invitation.ID, invitation.SenderUserID, *invitation.ExpiresAt)
 	if err != nil {
 		return "", err
 	}
@@ -405,21 +425,16 @@ func orgInvitationURL(orgID int32, invitationID int64, senderID int32, recipient
 	return globals.ExternalURL().ResolveReference(&url.URL{Path: path}).String(), nil
 }
 
-func createInvitationJWT(orgID int32, invitationID int64, senderID int32) (string, error) {
+func createInvitationJWT(orgID int32, invitationID int64, senderID int32, expiryTime time.Time) (string, error) {
 	if !orgInvitationConfigDefined() {
 		return "", errors.New(SIGNING_KEY_MESSAGE)
 	}
 	config := conf.SiteConfig().OrganizationInvitations
 
-	expiryTime := time.Duration(config.ExpiryTime)
-	if expiryTime == 0 {
-		expiryTime = 48 // default expiry time is 2 days
-	}
-
 	token := jwt.NewWithClaims(jwt.SigningMethodHS512, &orgInvitationClaims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    globals.ExternalURL().String(),
-			ExpiresAt: jwt.NewNumericDate(timeNow().Add(expiryTime * time.Hour)), // TODO: store expiry in DB
+			ExpiresAt: jwt.NewNumericDate(expiryTime),
 			Subject:   strconv.FormatInt(int64(orgID), 10),
 		},
 		InvitationID: invitationID,
@@ -477,7 +492,10 @@ func sendOrgInvitationNotification(ctx context.Context, db database.DB, org *typ
 		orgName = org.Name
 	}
 
-	var expiry = 2
+	var expiry = DEFAULT_EXPIRY_TIME
+	if orgInvitationConfigDefined() && conf.SiteConfig().OrganizationInvitations.ExpiryTime > 0 {
+		expiry = time.Duration(conf.SiteConfig().OrganizationInvitations.ExpiryTime) * time.Hour
+	}
 
 	return txemail.Send(ctx, txemail.Message{
 		To:       []string{recipientEmail},
@@ -495,7 +513,7 @@ func sendOrgInvitationNotification(ctx context.Context, db database.DB, org *typ
 			FromUserName:    sender.Username,
 			OrgName:         orgName,
 			InvitationUrl:   invitationURL,
-			ExpiryDays:      expiry,
+			ExpiryDays:      int(expiry.Hours() / 24), // golang does not have `duration.Days` :(
 		},
 	})
 }

--- a/cmd/frontend/graphqlbackend/org_invitations.go
+++ b/cmd/frontend/graphqlbackend/org_invitations.go
@@ -414,6 +414,9 @@ func orgInvitationURLLegacy(org *types.Org, relative bool) string {
 }
 
 func orgInvitationURL(invitation database.OrgInvitation, relative bool) (string, error) {
+	if invitation.ExpiresAt == nil {
+		return "", errors.New("invitation does not have expiry time defined")
+	}
 	token, err := createInvitationJWT(invitation.OrgID, invitation.ID, invitation.SenderUserID, *invitation.ExpiresAt)
 	if err != nil {
 		return "", err

--- a/cmd/frontend/graphqlbackend/org_invitations_test.go
+++ b/cmd/frontend/graphqlbackend/org_invitations_test.go
@@ -44,7 +44,7 @@ func mockDefaultSiteConfig() {
 
 func TestCreateJWT(t *testing.T) {
 	t.Run("Fails when signingKey is not configured in site config", func(t *testing.T) {
-		_, err := createInvitationJWT(1, 1, 1)
+		_, err := createInvitationJWT(1, 1, 1, *invitation.ExpiresAt)
 
 		expectedError := "signing key not provided, cannot create JWT for invitation URL. Please add organizationInvitations signingKey to site configuration."
 		if err == nil || err.Error() != expectedError {
@@ -55,7 +55,7 @@ func TestCreateJWT(t *testing.T) {
 		signingKey := mockSiteConfigSigningKey()
 		defer mockDefaultSiteConfig()
 
-		token, err := createInvitationJWT(1, 2, 3)
+		token, err := createInvitationJWT(1, 2, 3, *invitation.ExpiresAt)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -88,7 +88,7 @@ func TestCreateJWT(t *testing.T) {
 
 func TestOrgInvitationURL(t *testing.T) {
 	t.Run("Fails if site config is not defined", func(t *testing.T) {
-		_, err := orgInvitationURL(1, 1, 1, 1, "foo@bar.baz", true)
+		_, err := orgInvitationURL(invitation, true)
 
 		expectedError := "signing key not provided, cannot create JWT for invitation URL. Please add organizationInvitations signingKey to site configuration."
 		if err == nil || err.Error() != expectedError {
@@ -100,7 +100,7 @@ func TestOrgInvitationURL(t *testing.T) {
 		signingKey := mockSiteConfigSigningKey()
 		defer mockDefaultSiteConfig()
 
-		url, err := orgInvitationURL(1, 2, 3, 0, "foo@bar.baz", true)
+		url, err := orgInvitationURL(invitation, true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -359,7 +359,7 @@ func TestInvitationByToken(t *testing.T) {
 	t.Run("Returns invitation URL in the response", func(t *testing.T) {
 		mockSiteConfigSigningKey()
 		defer mockDefaultSiteConfig()
-		token, err := createInvitationJWT(1, 1, 1)
+		token, err := createInvitationJWT(1, 1, 1, *invitation.ExpiresAt)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -444,7 +444,7 @@ func TestRespondToOrganizationInvitation(t *testing.T) {
 				}
 				`,
 				Variables: map[string]interface{}{
-					"id":       string(marshalOrgInvitationID(invitationID)),
+					"id":       string(MarshalOrgInvitationID(invitationID)),
 					"response": "REJECT",
 				},
 				ExpectedResult: `{
@@ -483,7 +483,7 @@ func TestRespondToOrganizationInvitation(t *testing.T) {
 				}
 				`,
 				Variables: map[string]interface{}{
-					"id":       string(marshalOrgInvitationID(invitationID)),
+					"id":       string(MarshalOrgInvitationID(invitationID)),
 					"response": "ACCEPT",
 				},
 				ExpectedResult: `{
@@ -528,7 +528,7 @@ func TestRespondToOrganizationInvitation(t *testing.T) {
 				}
 				`,
 				Variables: map[string]interface{}{
-					"id":       string(marshalOrgInvitationID(invitationID)),
+					"id":       string(MarshalOrgInvitationID(invitationID)),
 					"response": "ACCEPT",
 				},
 				ExpectedResult: `{
@@ -573,7 +573,7 @@ func TestRespondToOrganizationInvitation(t *testing.T) {
 				}
 				`,
 				Variables: map[string]interface{}{
-					"id":       string(marshalOrgInvitationID(invitationID)),
+					"id":       string(MarshalOrgInvitationID(invitationID)),
 					"response": "ACCEPT",
 				},
 				ExpectedResult: "null",

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -5105,6 +5105,10 @@ type OrganizationInvitation implements Node {
     """
     revokedAt: DateTime
     """
+    The date when this invitation is going to expire.
+    """
+    expiresAt: DateTime
+    """
     Boolean flag which returns true if the email on the invite matches a verified email of the user
     """
     isVerifiedEmail: Boolean

--- a/internal/database/mocks.go
+++ b/internal/database/mocks.go
@@ -16934,7 +16934,7 @@ func NewMockOrgInvitationStore() *MockOrgInvitationStore {
 			},
 		},
 		CreateFunc: &OrgInvitationStoreCreateFunc{
-			defaultHook: func(context.Context, int32, int32, int32, string) (*OrgInvitation, error) {
+			defaultHook: func(context.Context, int32, int32, int32, string, time.Time) (*OrgInvitation, error) {
 				return nil, nil
 			},
 		},
@@ -17002,7 +17002,7 @@ func NewStrictMockOrgInvitationStore() *MockOrgInvitationStore {
 			},
 		},
 		CreateFunc: &OrgInvitationStoreCreateFunc{
-			defaultHook: func(context.Context, int32, int32, int32, string) (*OrgInvitation, error) {
+			defaultHook: func(context.Context, int32, int32, int32, string, time.Time) (*OrgInvitation, error) {
 				panic("unexpected invocation of MockOrgInvitationStore.Create")
 			},
 		},
@@ -17215,24 +17215,24 @@ func (c OrgInvitationStoreCountFuncCall) Results() []interface{} {
 // OrgInvitationStoreCreateFunc describes the behavior when the Create
 // method of the parent MockOrgInvitationStore instance is invoked.
 type OrgInvitationStoreCreateFunc struct {
-	defaultHook func(context.Context, int32, int32, int32, string) (*OrgInvitation, error)
-	hooks       []func(context.Context, int32, int32, int32, string) (*OrgInvitation, error)
+	defaultHook func(context.Context, int32, int32, int32, string, time.Time) (*OrgInvitation, error)
+	hooks       []func(context.Context, int32, int32, int32, string, time.Time) (*OrgInvitation, error)
 	history     []OrgInvitationStoreCreateFuncCall
 	mutex       sync.Mutex
 }
 
 // Create delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockOrgInvitationStore) Create(v0 context.Context, v1 int32, v2 int32, v3 int32, v4 string) (*OrgInvitation, error) {
-	r0, r1 := m.CreateFunc.nextHook()(v0, v1, v2, v3, v4)
-	m.CreateFunc.appendCall(OrgInvitationStoreCreateFuncCall{v0, v1, v2, v3, v4, r0, r1})
+func (m *MockOrgInvitationStore) Create(v0 context.Context, v1 int32, v2 int32, v3 int32, v4 string, v5 time.Time) (*OrgInvitation, error) {
+	r0, r1 := m.CreateFunc.nextHook()(v0, v1, v2, v3, v4, v5)
+	m.CreateFunc.appendCall(OrgInvitationStoreCreateFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the Create method of the
 // parent MockOrgInvitationStore instance is invoked and the hook queue is
 // empty.
-func (f *OrgInvitationStoreCreateFunc) SetDefaultHook(hook func(context.Context, int32, int32, int32, string) (*OrgInvitation, error)) {
+func (f *OrgInvitationStoreCreateFunc) SetDefaultHook(hook func(context.Context, int32, int32, int32, string, time.Time) (*OrgInvitation, error)) {
 	f.defaultHook = hook
 }
 
@@ -17240,7 +17240,7 @@ func (f *OrgInvitationStoreCreateFunc) SetDefaultHook(hook func(context.Context,
 // Create method of the parent MockOrgInvitationStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *OrgInvitationStoreCreateFunc) PushHook(hook func(context.Context, int32, int32, int32, string) (*OrgInvitation, error)) {
+func (f *OrgInvitationStoreCreateFunc) PushHook(hook func(context.Context, int32, int32, int32, string, time.Time) (*OrgInvitation, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -17249,7 +17249,7 @@ func (f *OrgInvitationStoreCreateFunc) PushHook(hook func(context.Context, int32
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *OrgInvitationStoreCreateFunc) SetDefaultReturn(r0 *OrgInvitation, r1 error) {
-	f.SetDefaultHook(func(context.Context, int32, int32, int32, string) (*OrgInvitation, error) {
+	f.SetDefaultHook(func(context.Context, int32, int32, int32, string, time.Time) (*OrgInvitation, error) {
 		return r0, r1
 	})
 }
@@ -17257,12 +17257,12 @@ func (f *OrgInvitationStoreCreateFunc) SetDefaultReturn(r0 *OrgInvitation, r1 er
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *OrgInvitationStoreCreateFunc) PushReturn(r0 *OrgInvitation, r1 error) {
-	f.PushHook(func(context.Context, int32, int32, int32, string) (*OrgInvitation, error) {
+	f.PushHook(func(context.Context, int32, int32, int32, string, time.Time) (*OrgInvitation, error) {
 		return r0, r1
 	})
 }
 
-func (f *OrgInvitationStoreCreateFunc) nextHook() func(context.Context, int32, int32, int32, string) (*OrgInvitation, error) {
+func (f *OrgInvitationStoreCreateFunc) nextHook() func(context.Context, int32, int32, int32, string, time.Time) (*OrgInvitation, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -17310,6 +17310,9 @@ type OrgInvitationStoreCreateFuncCall struct {
 	// Arg4 is the value of the 5th argument passed to this method
 	// invocation.
 	Arg4 string
+	// Arg5 is the value of the 6th argument passed to this method
+	// invocation.
+	Arg5 time.Time
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 *OrgInvitation
@@ -17321,7 +17324,7 @@ type OrgInvitationStoreCreateFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c OrgInvitationStoreCreateFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/database/org_invitations.go
+++ b/internal/database/org_invitations.go
@@ -15,6 +15,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
+var timeNow = time.Now
+
 // An OrgInvitation is an invitation for a user to join an organization as a member.
 type OrgInvitation struct {
 	ID              int64
@@ -27,20 +29,27 @@ type OrgInvitation struct {
 	RespondedAt     *time.Time
 	ResponseType    *bool // accepted (true), rejected (false), no response (nil)
 	RevokedAt       *time.Time
+	ExpiresAt       *time.Time
 	IsVerifiedEmail bool // returns true if the current user has verified email that matches the invite
 }
 
 // Pending reports whether the invitation is pending (i.e., can be responded to by the recipient
 // because it has not been revoked or responded to yet).
 func (oi *OrgInvitation) Pending() bool {
-	return oi.RespondedAt == nil && oi.RevokedAt == nil
+	return oi.RespondedAt == nil && oi.RevokedAt == nil && !oi.Expired()
+}
+
+// Expired reports whether the invitation is expired (i.e., can be responded to by the recipient
+// because it has not been expired yet).
+func (oi *OrgInvitation) Expired() bool {
+	return oi.ExpiresAt != nil && timeNow().After(*oi.ExpiresAt)
 }
 
 type OrgInvitationStore interface {
 	basestore.ShareableStore
 	With(basestore.ShareableStore) OrgInvitationStore
 	Transact(context.Context) (OrgInvitationStore, error)
-	Create(ctx context.Context, orgID, senderUserID, recipientUserID int32, email string) (*OrgInvitation, error)
+	Create(ctx context.Context, orgID, senderUserID, recipientUserID int32, email string, expiryTime time.Time) (*OrgInvitation, error)
 	GetByID(context.Context, int64) (*OrgInvitation, error)
 	GetPending(ctx context.Context, orgID, recipientUserID int32) (*OrgInvitation, error)
 	GetPendingByID(ctx context.Context, id int64) (*OrgInvitation, error)
@@ -90,12 +99,13 @@ func (err OrgInvitationNotFoundError) Error() string {
 	return fmt.Sprintf("org invitation not found: %v", err.args)
 }
 
-func (s *orgInvitationStore) Create(ctx context.Context, orgID, senderUserID, recipientUserID int32, email string) (*OrgInvitation, error) {
+func (s *orgInvitationStore) Create(ctx context.Context, orgID, senderUserID, recipientUserID int32, email string, expiryTime time.Time) (*OrgInvitation, error) {
 	t := &OrgInvitation{
 		OrgID:           orgID,
 		SenderUserID:    senderUserID,
 		RecipientUserID: recipientUserID,
 		RecipientEmail:  email,
+		ExpiresAt:       &expiryTime,
 	}
 
 	var column, value string
@@ -110,8 +120,8 @@ func (s *orgInvitationStore) Create(ctx context.Context, orgID, senderUserID, re
 
 	if err := s.Handle().DB().QueryRowContext(
 		ctx,
-		fmt.Sprintf("INSERT INTO org_invitations(org_id, sender_user_id, %s) VALUES($1, $2, $3) RETURNING id, created_at", column),
-		orgID, senderUserID, value,
+		fmt.Sprintf("INSERT INTO org_invitations(org_id, sender_user_id, %s, expires_at) VALUES($1, $2, $3, $4) RETURNING id, created_at", column),
+		orgID, senderUserID, value, expiryTime,
 	).Scan(&t.ID, &t.CreatedAt); err != nil {
 		var e *pgconn.PgError
 		if errors.As(err, &e) && e.ConstraintName == "org_invitations_singleflight" {
@@ -150,6 +160,9 @@ func (s *orgInvitationStore) GetPending(ctx context.Context, orgID, recipientUse
 	if len(results) == 0 {
 		return nil, OrgInvitationNotFoundError{[]interface{}{fmt.Sprintf("pending for org %d recipient %d", orgID, recipientUserID)}}
 	}
+	if results[0].Expired() {
+		return nil, errors.New("invitation is expired")
+	}
 	return results[0], nil
 }
 
@@ -165,6 +178,9 @@ func (s *orgInvitationStore) GetPendingByID(ctx context.Context, id int64) (*Org
 	}
 	if len(results) == 0 {
 		return nil, NewOrgInvitationNotFoundError(id)
+	}
+	if results[0].Expired() {
+		return nil, errors.New("invitation is expired")
 	}
 	return results[0], nil
 }
@@ -200,7 +216,7 @@ func (s *orgInvitationStore) List(ctx context.Context, opt OrgInvitationsListOpt
 
 func (s *orgInvitationStore) list(ctx context.Context, conds []*sqlf.Query, limitOffset *LimitOffset) ([]*OrgInvitation, error) {
 	q := sqlf.Sprintf(`
-SELECT id, org_id, sender_user_id, recipient_user_id, recipient_email, created_at, notified_at, responded_at, response_type, revoked_at FROM org_invitations
+SELECT id, org_id, sender_user_id, recipient_user_id, recipient_email, created_at, notified_at, responded_at, response_type, revoked_at, expires_at FROM org_invitations
 WHERE (%s) AND deleted_at IS NULL
 ORDER BY id ASC
 %s`,
@@ -217,7 +233,7 @@ ORDER BY id ASC
 	var results []*OrgInvitation
 	for rows.Next() {
 		var t OrgInvitation
-		if err := rows.Scan(&t.ID, &t.OrgID, &t.SenderUserID, &dbutil.NullInt32{N: &t.RecipientUserID}, &dbutil.NullString{S: &t.RecipientEmail}, &t.CreatedAt, &t.NotifiedAt, &t.RespondedAt, &t.ResponseType, &t.RevokedAt); err != nil {
+		if err := rows.Scan(&t.ID, &t.OrgID, &t.SenderUserID, &dbutil.NullInt32{N: &t.RecipientUserID}, &dbutil.NullString{S: &t.RecipientEmail}, &t.CreatedAt, &t.NotifiedAt, &t.RespondedAt, &t.ResponseType, &t.RevokedAt, &t.ExpiresAt); err != nil {
 			return nil, err
 		}
 		results = append(results, &t)
@@ -240,7 +256,7 @@ func (s *orgInvitationStore) Count(ctx context.Context, opt OrgInvitationsListOp
 // UpdateEmailSentTimestamp updates the email-sent timestam[ for the org invitation to the current
 // time.
 func (s *orgInvitationStore) UpdateEmailSentTimestamp(ctx context.Context, id int64) error {
-	res, err := s.Handle().DB().ExecContext(ctx, "UPDATE org_invitations SET notified_at=now() WHERE id=$1 AND revoked_at IS NULL AND deleted_at IS NULL", id)
+	res, err := s.Handle().DB().ExecContext(ctx, "UPDATE org_invitations SET notified_at=now() WHERE id=$1 AND revoked_at IS NULL AND deleted_at IS NULL AND expires_at > now()", id)
 	if err != nil {
 		return err
 	}
@@ -258,7 +274,7 @@ func (s *orgInvitationStore) UpdateEmailSentTimestamp(ctx context.Context, id in
 // which the recipient was invited. If the recipient user ID given is incorrect, an
 // OrgInvitationNotFoundError error is returned.
 func (s *orgInvitationStore) Respond(ctx context.Context, id int64, recipientUserID int32, accept bool) (orgID int32, err error) {
-	if err := s.Handle().DB().QueryRowContext(ctx, "UPDATE org_invitations SET responded_at=now(), response_type=$2 WHERE id=$1 AND responded_at IS NULL AND revoked_at IS NULL AND deleted_at IS NULL RETURNING org_id", id, accept).Scan(&orgID); err == sql.ErrNoRows {
+	if err := s.Handle().DB().QueryRowContext(ctx, "UPDATE org_invitations SET responded_at=now(), response_type=$2 WHERE id=$1 AND responded_at IS NULL AND revoked_at IS NULL AND deleted_at IS NULL AND expires_at > now() RETURNING org_id", id, accept).Scan(&orgID); err == sql.ErrNoRows {
 		return 0, OrgInvitationNotFoundError{[]interface{}{fmt.Sprintf("id %d recipient %d", id, recipientUserID)}}
 	} else if err != nil {
 		return 0, err
@@ -269,7 +285,7 @@ func (s *orgInvitationStore) Respond(ctx context.Context, id int64, recipientUse
 // Revoke marks an org invitation as revoked. The recipient is forbidden from responding to it after
 // it has been revoked.
 func (s *orgInvitationStore) Revoke(ctx context.Context, id int64) error {
-	res, err := s.Handle().DB().ExecContext(ctx, "UPDATE org_invitations SET revoked_at=now() WHERE id=$1 AND revoked_at IS NULL AND deleted_at IS NULL", id)
+	res, err := s.Handle().DB().ExecContext(ctx, "UPDATE org_invitations SET revoked_at=now() WHERE id=$1 AND revoked_at IS NULL AND deleted_at IS NULL AND expires_at > now()", id)
 	if err != nil {
 		return err
 	}

--- a/migrations/frontend/1644583379/down.sql
+++ b/migrations/frontend/1644583379/down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+-- Undo the changes made in the up migration
+UPDATE org_invitations SET expires_at = NULL WHERE expires_at IS NOT NULL;
+
+COMMIT;

--- a/migrations/frontend/1644583379/metadata.yaml
+++ b/migrations/frontend/1644583379/metadata.yaml
@@ -1,0 +1,2 @@
+name: set_expiry_date_for_existing_invitations
+parents: [1644515056]

--- a/migrations/frontend/1644583379/up.sql
+++ b/migrations/frontend/1644583379/up.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+-- If we have invitations that are not deleted, not revoked, not responded to and with no expiry time
+-- set the default expiry time to 7 days from now
+UPDATE
+    org_invitations
+SET
+    expires_at = now() + interval '7 days'
+WHERE
+    deleted_at IS NULL
+    AND revoked_at IS NULL
+    AND responded_at IS NULL
+    AND expires_at IS NULL;
+    
+COMMIT;


### PR DESCRIPTION
# Description

Return consistent URL for the invitation because expiry time on the
JWT is now the same as in the DB.

We also force an expiry of 7 days to all existing pending invitations
with a DB migration. This way, we will never have long-lasting invitations
anymore, that can be potentially misused years from now to implant
organization members by a potential attacker.

# Related issue
https://sourcegraph.atlassian.net/browse/CLOUD-185

## Test plan
Tested with unit tests and manually


