### PR TITLE
embedded notebooks: implement light & dark mode support

### DIFF
--- a/client/web/src/enterprise/embed/EmbeddedWebApp.module.scss
+++ b/client/web/src/enterprise/embed/EmbeddedWebApp.module.scss
@@ -1,5 +1,5 @@
+:global(#root),
 .body {
-    background: var(--color-bg-1);
+    background-color: var(--color-bg-1);
     width: 100%;
-    height: 100%;
 }

--- a/client/web/src/search/notebook/SearchNotebook.module.scss
+++ b/client/web/src/search/notebook/SearchNotebook.module.scss
@@ -7,7 +7,4 @@
     @media (--md-breakpoint-down) {
         padding-right: 2.5rem;
     }
-    // Allows scrolling past last blocks in the notebook
-    // for easier editing.
-    margin-bottom: 30rem;
 }

--- a/client/web/src/search/notebook/SearchNotebookPage.module.scss
+++ b/client/web/src/search/notebook/SearchNotebookPage.module.scss
@@ -3,6 +3,12 @@
     overflow: auto;
 }
 
+.spacer {
+    // Allows scrolling past last blocks in the notebook
+    // for easier editing.
+    height: 30rem;
+}
+
 .auto-save-indicator {
     font-size: 1rem !important;
     width: 1rem !important;

--- a/client/web/src/search/notebook/SearchNotebookPage.tsx
+++ b/client/web/src/search/notebook/SearchNotebookPage.tsx
@@ -257,6 +257,7 @@ export const SearchNotebookPage: React.FunctionComponent<SearchNotebookPageProps
                             fetchRepository={fetchRepository}
                             resolveRevision={resolveRevision}
                         />
+                        <div className={styles.spacer} />
                     </>
                 )}
             </Page>


### PR DESCRIPTION
Embedded web app now reads the theme from URL params, or uses the default system theme. PR also moves notebook end spacing to the SearchNotebookPage.

To force an embedded web app theme, a `theme` URL parameter has to be appended to the iframe URL. For example: `?theme=light` for light mode, `?theme=dark` for dark mode. If there isn't a theme parameter present, we will use the system theme.


## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

* Create a notebook
* Get embedding url, append `?theme=light` and embed it inside an iframe
* Verify that the notebook renders in light mode
* Do the same for dark mode and `?theme=dark`
* Verify that notebook renders in default system theme if no `theme` parameter is present
