### PR TITLE
gitdomain: Allow shortlog and more args in allowlist

### DIFF
--- a/internal/gitserver/gitdomain/exec.go
+++ b/internal/gitserver/gitdomain/exec.go
@@ -27,6 +27,7 @@ var (
 		"tag":          {"--list", "--sort", "-creatordate", "--format"},
 		"merge-base":   {"--"},
 		"show-ref":     {"--heads"},
+		"shortlog":     {"-s", "-n", "-e", "--no-merges"},
 
 		// Used in tests to simulate errors with runCommand in handleExec of gitserver.
 		"testcommand": {},
@@ -35,7 +36,7 @@ var (
 
 	// `git log`, `git show`, `git diff`, etc., share a large common set of allowed args.
 	gitCommonAllowlist = []string{
-		"--name-only", "--name-status", "--full-history", "-M", "--date", "--format", "-i", "-n", "-n1", "-m", "--", "-n200", "-n2", "--follow", "--author", "--grep", "--date-order", "--decorate", "--skip", "--max-count", "--numstat", "--pretty", "--parents", "--topo-order", "--raw", "--follow", "--all", "--before", "--no-merges",
+		"--name-only", "--name-status", "--full-history", "-M", "--date", "--format", "-i", "-n", "-n1", "-m", "--", "-n200", "-n2", "--follow", "--author", "--grep", "--date-order", "--decorate", "--skip", "--max-count", "--numstat", "--pretty", "--parents", "--topo-order", "--raw", "--follow", "--all", "--before", "--no-merges", "--fixed-strings",
 		"--patch", "--unified", "-S", "-G", "--pickaxe-all", "--pickaxe-regex", "--function-context", "--branches", "--source", "--src-prefix", "--dst-prefix", "--no-prefix",
 		"--regexp-ignore-case", "--glob", "--cherry", "-z",
 		"--until", "--since", "--author", "--committer",

--- a/internal/vcs/git/shortlog.go
+++ b/internal/vcs/git/shortlog.go
@@ -45,7 +45,8 @@ func ShortLog(ctx context.Context, repo api.RepoName, opt ShortLogOptions) ([]*P
 		return nil, err
 	}
 
-	args := []string{"shortlog", "-sne", "--no-merges"}
+	// We split the individual args for the shortlog command instead of -sne for easier arg checking in the allowlist.
+	args := []string{"shortlog", "-s", "-n", "-e", "--no-merges"}
 	if opt.After != "" {
 		args = append(args, "--after="+opt.After)
 	}
@@ -57,7 +58,7 @@ func ShortLog(ctx context.Context, repo api.RepoName, opt ShortLogOptions) ([]*P
 	cmd.Repo = repo
 	out, err := cmd.Output(ctx)
 	if err != nil {
-		return nil, errors.Errorf("exec `git shortlog -sne` failed: %v", err)
+		return nil, errors.Errorf("exec `git shortlog -s -n -e` failed: %v", err)
 	}
 	return parseShortLog(out)
 }


### PR DESCRIPTION
This is a follow up to #30833. 

Logs that identified the missing arg and command in gitserver are [here](https://sourcegraph.grafana.net/explore?orgId=1&left=%7B%22datasource%22:%22grafanacloud-sourcegraph-logs%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bapp%3D%5C%22gitserver%5C%22,%20namespace%3D%5C%22prod%5C%22%7D%20%7C%3D%20%5C%22IsAllowedGitCmd%5C%22%22%7D%5D,%22range%22:%7B%22from%22:%22now-2d%22,%22to%22:%22now%22%7D%7D). 

## Test plan

We're adding new commands to the allowlist that need to be allowed for us to turn on the feature flag added in #30833. No additional testing required at this point.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


