### PR TITLE
web: Improve empty collaborators error message

### DIFF
--- a/client/web/src/auth/welcome/InviteCollaborators/InviteCollaborators.module.scss
+++ b/client/web/src/auth/welcome/InviteCollaborators/InviteCollaborators.module.scss
@@ -19,8 +19,25 @@
 .invitable-collaborators {
     height: 15.5rem;
     overflow: auto;
+    display: flex;
+    flex-direction: column;
 }
 
 .invite-button {
     height: 1.875rem;
+}
+
+.no-collaborators {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    max-width: 28rem;
+    margin: auto;
+    text-align: center;
+}
+
+.invite-all-container {
+    height: 3.2rem;
 }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/31011

As per https://github.com/sourcegraph/sourcegraph/issues/31011 this PR fixes the wording around various null states with the new invites feature.

More specifically we are now separating between two different null states:

- No collaborators found across any of the linked repos
- Custom search filter yields no results.

Below are two screenshots of the new null states.

## Test plan

### No collaborators found across any of the linked repos 

![Screenshot 2022-02-14 at 15 27 41](https://user-images.githubusercontent.com/458591/153883091-b3c0fc17-57a6-4ffd-887d-bed11e5d1d7d.png)

### Custom search filter yields no results

![Screenshot 2022-02-14 at 15 28 03](https://user-images.githubusercontent.com/458591/153883133-6f7c50b4-6254-4c94-bbc1-1c2fa2294545.png)



<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


