### PR TITLE
gitserver: faster and cleaner p4-fusion build script

### DIFF
--- a/cmd/gitserver/p4-fusion-install-alpine.sh
+++ b/cmd/gitserver/p4-fusion-install-alpine.sh
@@ -40,7 +40,14 @@ wget https://www.openssl.org/source/openssl-1.0.2t.tar.gz
 tar -xzvf openssl-1.0.2t.tar.gz
 cd /openssl-1.0.2t
 
-./config && make && make install
+./config
+# We only need libcrypto and libssl, which "build_libs" covers. We use
+# unbounded concurrency. Experiments on a 32-core machine showed a multiple of
+# 32 didn't help.
+make -j build_libs
+# TODO "install" includes "all". Can we avoid extra work?
+make install
+cd ..
 
 # We also need Helix Core C++ API to build p4-fusion
 wget https://www.perforce.com/downloads/perforce/r21.1/bin.linux26x86_64/p4api.tgz

--- a/cmd/gitserver/p4-fusion-install-alpine.sh
+++ b/cmd/gitserver/p4-fusion-install-alpine.sh
@@ -77,3 +77,8 @@ cd ..
 # Move exe file to /usr/local/bin where other executables are located
 echo "--- p4-fusion install"
 mv p4-fusion-src/build/p4-fusion/p4-fusion /usr/local/bin
+
+# Test that p4-fusion runs and is on the path
+echo "--- p4-fusion test"
+ldd "$(which p4-fusion)"
+p4-fusion > /dev/null

--- a/cmd/gitserver/p4-fusion-install-alpine.sh
+++ b/cmd/gitserver/p4-fusion-install-alpine.sh
@@ -66,7 +66,6 @@ mkdir -p p4-fusion-src/vendor/helix-core-api/linux
 wget https://www.perforce.com/downloads/perforce/r21.1/bin.linux26x86_64/p4api.tgz
 tar -C p4-fusion-src/vendor/helix-core-api/linux -xzf p4api.tgz --strip 1
 
-
 # Build p4-fusion
 echo "--- p4-fusion build"
 cd p4-fusion-src
@@ -81,4 +80,4 @@ mv p4-fusion-src/build/p4-fusion/p4-fusion /usr/local/bin
 # Test that p4-fusion runs and is on the path
 echo "--- p4-fusion test"
 ldd "$(which p4-fusion)"
-p4-fusion > /dev/null
+p4-fusion >/dev/null

--- a/cmd/gitserver/p4-fusion-install-alpine.sh
+++ b/cmd/gitserver/p4-fusion-install-alpine.sh
@@ -7,6 +7,7 @@ set -eu
 tmpdir=$(mktemp -d)
 
 cleanup() {
+  echo "--- cleanup"
   apk --no-cache --purge del p4-build-deps || true
   cd /
   rm -rf "$tmpdir" || true
@@ -17,9 +18,11 @@ trap cleanup EXIT
 set -x
 
 # Runtime dependencies
+echo "--- p4-fusion apk runtime-deps"
 apk add --no-cache libstdc++
 
 # Build dependencies
+echo "--- p4-fusion apk build-deps"
 apk add --no-cache \
   --virtual p4-build-deps \
   wget \
@@ -33,36 +36,44 @@ apk add --no-cache \
 cd "$tmpdir"
 
 # Fetching p4 sources archive
+echo "--- p4-fusion fetch"
 mkdir p4-fusion-src
 wget https://github.com/salesforce/p4-fusion/archive/refs/tags/v1.5.tar.gz
 tar -C p4-fusion-src -xzf v1.5.tar.gz --strip 1
 
 # We need a specific version of OpenSSL
+echo "--- p4-fusion openssl fetch"
 mkdir openssl-src
 wget https://www.openssl.org/source/openssl-1.0.2t.tar.gz
 tar -C openssl-src -xzf openssl-1.0.2t.tar.gz --strip 1
 
+echo "--- p4-fusion openssl build"
 cd openssl-src
 ./config
 # We only need libcrypto and libssl, which "build_libs" covers. We use
 # unbounded concurrency. Experiments on a 32-core machine showed a multiple of
 # 32 didn't help.
 make -j build_libs
+
+echo "--- p4-fusion openssl install"
 # TODO "install" includes "all". Can we avoid extra work?
 make install
 cd ..
 
 # We also need Helix Core C++ API to build p4-fusion
+echo "--- p4-fusion helix-core fetch"
 mkdir -p p4-fusion-src/vendor/helix-core-api/linux
 wget https://www.perforce.com/downloads/perforce/r21.1/bin.linux26x86_64/p4api.tgz
 tar -C p4-fusion-src/vendor/helix-core-api/linux -xzf p4api.tgz --strip 1
 
 
 # Build p4-fusion
+echo "--- p4-fusion build"
 cd p4-fusion-src
 ./generate_cache.sh Release
 ./build.sh
 cd ..
 
 # Move exe file to /usr/local/bin where other executables are located
+echo "--- p4-fusion install"
 mv p4-fusion-src/build/p4-fusion/p4-fusion /usr/local/bin


### PR DESCRIPTION
Observing builds for p4-fusion on my machine, it seems the time is dominated by building OpenSSL. This commit speed that up by using concurrency and doing less work. Additionally we add justification for why we need a specific OpenSSL.

We make cleanup more robust by doing all work inside of a temporary directory.

We add buildkite sections to make reading the logs clearer.

We also add a mini test that p4-fusion runs correctly. Note in practice we copy this into another docker file so the test is not that robust. However, it is better than nothing.

Test Plan: Run build and test p4-fusion in the image.

```shell
docker build -t p4-fusion --target=p4-fusion .
docker run --rm=true -it p4-fusion /bin/sh -il
ldd `which p4-fusion`
p4-fusion --help
```
