### PR TITLE
search: make job creation not depend on resolver

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -38,8 +38,9 @@ func (srs *searchResultsStats) Languages(ctx context.Context) ([]*languageStatis
 }
 
 func (srs *searchResultsStats) getResults(ctx context.Context) (result.Matches, error) {
+	args := srs.sr.JobArgs()
 	srs.once.Do(func() {
-		job, err := srs.sr.toSearchJob(srs.sr.Query)
+		job, err := toSearchJob(args, srs.sr.Query)
 		if err != nil {
 			srs.err = err
 			return

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -780,7 +780,9 @@ func Test_toSearchInputs(t *testing.T) {
 				PatternType:  query.SearchTypeLiteral,
 			},
 		}
-		job, _ := resolver.toSearchJob(q)
+
+		args := resolver.JobArgs()
+		job, _ := toSearchJob(args, q)
 		return job.Name()
 	}
 


### PR DESCRIPTION
Redo of https://github.com/sourcegraph/sourcegraph/pull/31129, GH autoclosed after I accidentally pushed empty branch.

Stacked on https://github.com/sourcegraph/sourcegraph/pull/31128.

As in title. Will move this out of `graphqlbackend` next

## Test plan
Semantics-preserving, covered by tests

