### PR TITLE
[cloud][CLOUD-192] Make resend invitation work for email invites

### DIFF
--- a/cmd/frontend/graphqlbackend/org_invitations.go
+++ b/cmd/frontend/graphqlbackend/org_invitations.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"math"
 	"net/url"
 	"strconv"
 	"time"
@@ -27,9 +28,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-var EMAIL_INVITES_FF = "org-email-invites"
-var SIGNING_KEY_MESSAGE = "signing key not provided, cannot create JWT for invitation URL. Please add organizationInvitations signingKey to site configuration."
-var DEFAULT_EXPIRY_TIME = 48 * time.Hour
+var EmailInvitesFeatureFlag = "org-email-invites"
+var SigningKeyMessage = "signing key not provided, cannot create JWT for invitation URL. Please add organizationInvitations signingKey to site configuration."
+var DefaultExpiryDuration = 48 * time.Hour
 
 func getUserToInviteToOrganization(ctx context.Context, db database.DB, username string, orgID int32) (userToInvite *types.User, userEmailAddress string, err error) {
 	userToInvite, err = db.Users().GetByUsername(ctx, username)
@@ -110,6 +111,18 @@ func checkEmail(ctx context.Context, db database.DB, inviteEmail string) (bool, 
 	return false, nil
 }
 
+func newExpiryDuration() time.Duration {
+	expiryDuration := DefaultExpiryDuration
+	if orgInvitationConfigDefined() && conf.SiteConfig().OrganizationInvitations.ExpiryTime > 0 {
+		expiryDuration = time.Duration(conf.SiteConfig().OrganizationInvitations.ExpiryTime) * time.Hour
+	}
+	return expiryDuration
+}
+
+func newExpiryTime() time.Time {
+	return timeNow().Add(newExpiryDuration())
+}
+
 func (r *schemaResolver) InvitationByToken(ctx context.Context, args *struct {
 	Token string
 }) (*organizationInvitationResolver, error) {
@@ -170,7 +183,7 @@ func (r *schemaResolver) InviteUserToOrganization(ctx context.Context, args *str
 		return nil, err
 	}
 	// check org has feature flag for email invites enabled, we can ignore errors here as flag value would be false
-	enabled, _ := r.db.FeatureFlags().GetOrgFeatureFlag(ctx, orgID, EMAIL_INVITES_FF)
+	enabled, _ := r.db.FeatureFlags().GetOrgFeatureFlag(ctx, orgID, EmailInvitesFeatureFlag)
 	// return error if feature flag is not enabled and we got an email as an argument
 	if ((args.Email != nil && *args.Email != "") || args.Username == nil) && !enabled {
 		return nil, errors.New("inviting by email is not supported for this organization")
@@ -201,16 +214,12 @@ func (r *schemaResolver) InviteUserToOrganization(ctx context.Context, args *str
 	if args.Email != nil {
 		// we only support new URL schema for email invitations
 		if !hasConfig {
-			return nil, errors.New(SIGNING_KEY_MESSAGE)
+			return nil, errors.New(SigningKeyMessage)
 		}
 		recipientEmail = *args.Email
 	}
 
-	var expiryDuration = DEFAULT_EXPIRY_TIME
-	if hasConfig && conf.SiteConfig().OrganizationInvitations.ExpiryTime > 0 {
-		expiryDuration = time.Duration(conf.SiteConfig().OrganizationInvitations.ExpiryTime) * time.Hour
-	}
-	expiryTime := timeNow().Add(expiryDuration)
+	expiryTime := newExpiryTime()
 	invitation, err := r.db.OrgInvitations().Create(ctx, orgID, sender.ID, recipientID, recipientEmail, expiryTime)
 	if err != nil {
 		return nil, err
@@ -234,7 +243,7 @@ func (r *schemaResolver) InviteUserToOrganization(ctx context.Context, args *str
 	// Send a notification to the recipient. If disabled, the frontend will still show the
 	// invitation link.
 	if conf.CanSendEmail() && recipientEmail != "" {
-		if err := sendOrgInvitationNotification(ctx, r.db, org, sender, recipientEmail, invitationURL); err != nil {
+		if err := sendOrgInvitationNotification(ctx, r.db, org, sender, recipientEmail, invitationURL, *invitation.ExpiresAt); err != nil {
 			return nil, errors.WithMessage(err, "sending notification to invitation recipient")
 		}
 		result.sentInvitationEmail = true
@@ -330,18 +339,9 @@ func (r *schemaResolver) ResendOrganizationInvitationNotification(ctx context.Co
 		return nil, err
 	}
 
-	// Prevent reuse. This just prevents annoyance (abuse is prevented by the quota check in the
-	// call to sendOrgInvitationNotification).
-	if !orgInvitation.Pending() {
-		if orgInvitation.RevokedAt != nil {
-			return nil, errors.New("refusing to send notification for revoked invitation")
-		}
-		if orgInvitation.RespondedAt != nil {
-			return nil, errors.New("refusing to send notification for invitation that was already responded to")
-		}
-		if orgInvitation.Expired() {
-			return nil, errors.New("refusing to send notification for expired invitation")
-		}
+	// Do not allow to resend for expired invitation
+	if orgInvitation.Expired() {
+		return nil, errors.New("invitation is expired")
 	}
 
 	if !conf.CanSendEmail() {
@@ -356,13 +356,26 @@ func (r *schemaResolver) ResendOrganizationInvitationNotification(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	recipientEmail, recipientEmailVerified, err := r.db.UserEmails().GetPrimaryEmail(ctx, orgInvitation.RecipientUserID)
-	if err != nil {
+	var recipientEmail string
+	if orgInvitation.RecipientEmail != "" {
+		recipientEmail = orgInvitation.RecipientEmail
+	} else {
+		recipientEmailVerified := false
+		recipientEmail, recipientEmailVerified, err = r.db.UserEmails().GetPrimaryEmail(ctx, orgInvitation.RecipientUserID)
+		if err != nil {
+			return nil, err
+		}
+		if !recipientEmailVerified {
+			return nil, errors.New("refusing to send notification because recipient has no verified email address")
+		}
+	}
+
+	expiryTime := newExpiryTime()
+	orgInvitation.ExpiresAt = &expiryTime
+	if err := r.db.OrgInvitations().UpdateExpiryTime(ctx, orgInvitation.ID, expiryTime); err != nil {
 		return nil, err
 	}
-	if !recipientEmailVerified {
-		return nil, errors.New("refusing to send notification because recipient has no verified email address")
-	}
+
 	var invitationURL string
 	if orgInvitationConfigDefined() {
 		invitationURL, err = orgInvitationURL(*orgInvitation, false)
@@ -372,7 +385,7 @@ func (r *schemaResolver) ResendOrganizationInvitationNotification(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	if err := sendOrgInvitationNotification(ctx, r.db, org, sender, recipientEmail, invitationURL); err != nil {
+	if err := sendOrgInvitationNotification(ctx, r.db, org, sender, recipientEmail, invitationURL, *orgInvitation.ExpiresAt); err != nil {
 		return nil, err
 	}
 	return &EmptyResponse{}, nil
@@ -430,7 +443,7 @@ func orgInvitationURL(invitation database.OrgInvitation, relative bool) (string,
 
 func createInvitationJWT(orgID int32, invitationID int64, senderID int32, expiryTime time.Time) (string, error) {
 	if !orgInvitationConfigDefined() {
-		return "", errors.New(SIGNING_KEY_MESSAGE)
+		return "", errors.New(SigningKeyMessage)
 	}
 	config := conf.SiteConfig().OrganizationInvitations
 
@@ -459,7 +472,7 @@ func createInvitationJWT(orgID int32, invitationID int64, senderID int32, expiry
 // sendOrgInvitationNotification sends an email to the recipient of an org invitation with a link to
 // respond to the invitation. Callers should check conf.CanSendEmail() if they want to return a nice
 // error if sending email is not enabled.
-func sendOrgInvitationNotification(ctx context.Context, db database.DB, org *types.Org, sender *types.User, recipientEmail string, invitationURL string) error {
+func sendOrgInvitationNotification(ctx context.Context, db database.DB, org *types.Org, sender *types.User, recipientEmail string, invitationURL string, expiryTime time.Time) error {
 	if envvar.SourcegraphDotComMode() {
 		// Basic abuse prevention for Sourcegraph.com.
 
@@ -495,11 +508,6 @@ func sendOrgInvitationNotification(ctx context.Context, db database.DB, org *typ
 		orgName = org.Name
 	}
 
-	var expiry = DEFAULT_EXPIRY_TIME
-	if orgInvitationConfigDefined() && conf.SiteConfig().OrganizationInvitations.ExpiryTime > 0 {
-		expiry = time.Duration(conf.SiteConfig().OrganizationInvitations.ExpiryTime) * time.Hour
-	}
-
 	return txemail.Send(ctx, txemail.Message{
 		To:       []string{recipientEmail},
 		Template: emailTemplates,
@@ -516,7 +524,7 @@ func sendOrgInvitationNotification(ctx context.Context, db database.DB, org *typ
 			FromUserName:    sender.Username,
 			OrgName:         orgName,
 			InvitationUrl:   invitationURL,
-			ExpiryDays:      int(expiry.Hours() / 24), // golang does not have `duration.Days` :(
+			ExpiryDays:      int(math.Round(expiryTime.Sub(timeNow()).Hours() / 24)), // golang does not have `duration.Days` :(
 		},
 	})
 }

--- a/cmd/frontend/graphqlbackend/org_invitations_test.go
+++ b/cmd/frontend/graphqlbackend/org_invitations_test.go
@@ -3,6 +3,8 @@ package graphqlbackend
 import (
 	"context"
 	"encoding/base64"
+	"github.com/sourcegraph/sourcegraph/internal/txemail"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -25,14 +27,20 @@ func mockTimeNow() {
 	}
 }
 
-func mockSiteConfigSigningKey() string {
+func mockSiteConfigSigningKey(withEmails *bool) string {
 	signingKey := "Zm9v"
-	conf.Mock(&conf.Unified{
-		SiteConfiguration: schema.SiteConfiguration{
-			OrganizationInvitations: &schema.OrganizationInvitations{
-				SigningKey: signingKey,
-			},
+
+	siteConfig := schema.SiteConfiguration{
+		OrganizationInvitations: &schema.OrganizationInvitations{
+			SigningKey: signingKey,
 		},
+	}
+	if withEmails != nil && *withEmails {
+		siteConfig.EmailSmtp = &schema.SMTPServerConfig{}
+	}
+
+	conf.Mock(&conf.Unified{
+		SiteConfiguration: siteConfig,
 	})
 
 	return signingKey
@@ -43,7 +51,7 @@ func mockDefaultSiteConfig() {
 }
 
 func TestCreateJWT(t *testing.T) {
-	expiryTime := timeNow().Add(DEFAULT_EXPIRY_TIME)
+	expiryTime := timeNow().Add(DefaultExpiryDuration)
 
 	t.Run("Fails when signingKey is not configured in site config", func(t *testing.T) {
 		_, err := createInvitationJWT(1, 1, 1, expiryTime)
@@ -54,7 +62,7 @@ func TestCreateJWT(t *testing.T) {
 		}
 	})
 	t.Run("Returns JWT with encoded parameters", func(t *testing.T) {
-		signingKey := mockSiteConfigSigningKey()
+		signingKey := mockSiteConfigSigningKey(nil)
 		defer mockDefaultSiteConfig()
 
 		token, err := createInvitationJWT(1, 2, 3, expiryTime)
@@ -89,12 +97,11 @@ func TestCreateJWT(t *testing.T) {
 }
 
 func TestOrgInvitationURL(t *testing.T) {
-	//invitation.OrgID, invitation.ID, invitation.SenderUserID, *invitation.ExpiresAt
 	invitation := database.OrgInvitation{
 		OrgID:        1,
 		ID:           2,
 		SenderUserID: 3,
-		ExpiresAt:    timePtr(timeNow().Add(DEFAULT_EXPIRY_TIME)),
+		ExpiresAt:    timePtr(timeNow().Add(DefaultExpiryDuration)),
 	}
 
 	t.Run("Fails if site config is not defined", func(t *testing.T) {
@@ -107,7 +114,7 @@ func TestOrgInvitationURL(t *testing.T) {
 	})
 
 	t.Run("Returns invitation URL with JWT", func(t *testing.T) {
-		signingKey := mockSiteConfigSigningKey()
+		signingKey := mockSiteConfigSigningKey(nil)
 		defer mockDefaultSiteConfig()
 
 		url, err := orgInvitationURL(invitation, true)
@@ -171,7 +178,7 @@ func TestInviteUserToOrganization(t *testing.T) {
 	orgs.GetByIDFunc.SetDefaultReturn(&mockedOrg, nil)
 
 	orgInvitations := database.NewMockOrgInvitationStore()
-	orgInvitations.CreateFunc.SetDefaultReturn(&database.OrgInvitation{ID: 1, ExpiresAt: timePtr(timeNow().Add(DEFAULT_EXPIRY_TIME))}, nil)
+	orgInvitations.CreateFunc.SetDefaultReturn(&database.OrgInvitation{ID: 1, ExpiresAt: timePtr(timeNow().Add(DefaultExpiryDuration))}, nil)
 
 	featureFlags := database.NewMockFeatureFlagStore()
 	featureFlags.GetOrgFeatureFlagFunc.SetDefaultReturn(false, nil)
@@ -212,7 +219,7 @@ func TestInviteUserToOrganization(t *testing.T) {
 	})
 
 	t.Run("Returns invitation URL in the response for username invitation", func(t *testing.T) {
-		mockSiteConfigSigningKey()
+		mockSiteConfigSigningKey(nil)
 		defer mockDefaultSiteConfig()
 		RunTests(t, []*Test{
 			{
@@ -242,7 +249,7 @@ func TestInviteUserToOrganization(t *testing.T) {
 	})
 
 	t.Run("Fails for email invitation if feature flag is not enabled", func(t *testing.T) {
-		mockSiteConfigSigningKey()
+		mockSiteConfigSigningKey(nil)
 		defer mockDefaultSiteConfig()
 		RunTests(t, []*Test{
 			{
@@ -271,7 +278,7 @@ func TestInviteUserToOrganization(t *testing.T) {
 	})
 
 	t.Run("Returns invitation URL in the response for email invitation", func(t *testing.T) {
-		mockSiteConfigSigningKey()
+		mockSiteConfigSigningKey(nil)
 		defer mockDefaultSiteConfig()
 
 		featureFlags.GetOrgFeatureFlagFunc.SetDefaultReturn(true, nil)
@@ -367,9 +374,9 @@ func TestInvitationByToken(t *testing.T) {
 	})
 
 	t.Run("Returns invitation URL in the response", func(t *testing.T) {
-		mockSiteConfigSigningKey()
+		mockSiteConfigSigningKey(nil)
 		defer mockDefaultSiteConfig()
-		token, err := createInvitationJWT(1, 1, 1, timeNow().Add(DEFAULT_EXPIRY_TIME))
+		token, err := createInvitationJWT(1, 1, 1, timeNow().Add(DefaultExpiryDuration))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -591,6 +598,201 @@ func TestRespondToOrganizationInvitation(t *testing.T) {
 					{
 						Message: "your email addresses [something@else.invalid] do not match the email address on the invitation.",
 						Path:    []interface{}{"respondToOrganizationInvitation"},
+					},
+				},
+			},
+		})
+	})
+}
+
+func TestResendOrganizationInvitationNotification(t *testing.T) {
+	users := database.NewMockUserStore()
+	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 1}, nil)
+	users.GetByUsernameFunc.SetDefaultReturn(&types.User{ID: 2, Username: "foo"}, nil)
+
+	userEmails := database.NewMockUserEmailsStore()
+	userEmails.GetPrimaryEmailFunc.SetDefaultReturn("foo@bar.baz", true, nil)
+
+	orgMembers := database.NewMockOrgMemberStore()
+	orgMembers.GetByOrgIDAndUserIDFunc.SetDefaultHook(func(_ context.Context, orgID int32, userID int32) (*types.OrgMembership, error) {
+		if userID == 1 {
+			return &types.OrgMembership{}, nil
+		}
+
+		return nil, &database.ErrOrgMemberNotFound{}
+	})
+
+	orgs := database.NewMockOrgStore()
+	orgName := "acme"
+	mockedOrg := types.Org{ID: 1, Name: orgName}
+	orgs.GetByNameFunc.SetDefaultReturn(&mockedOrg, nil)
+	orgs.GetByIDFunc.SetDefaultReturn(&mockedOrg, nil)
+
+	orgInvitations := database.NewMockOrgInvitationStore()
+	orgInvitations.GetPendingByIDFunc.SetDefaultReturn(&database.OrgInvitation{ID: 1, OrgID: 1, RecipientUserID: 2}, nil)
+	orgInvitations.RespondFunc.SetDefaultHook(func(ctx context.Context, id int64, userID int32, accept bool) (int32, error) {
+		return int32(id), nil
+	})
+
+	db := database.NewMockDB()
+	db.OrgsFunc.SetDefaultReturn(orgs)
+	db.UsersFunc.SetDefaultReturn(users)
+	db.UserEmailsFunc.SetDefaultReturn(userEmails)
+	db.OrgMembersFunc.SetDefaultReturn(orgMembers)
+	db.OrgInvitationsFunc.SetDefaultReturn(orgInvitations)
+
+	ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 2})
+
+	expiryTime := newExpiryTime()
+
+	trueVal := true
+	mockSiteConfigSigningKey(&trueVal)
+
+	t.Run("Can resend a user invitation", func(t *testing.T) {
+		invitationID := int64(2)
+		orgID := int32(2)
+		orgInvitations.GetPendingByIDFunc.SetDefaultReturn(&database.OrgInvitation{ID: invitationID, OrgID: orgID, RecipientUserID: 2, ExpiresAt: &expiryTime}, nil)
+		emailSent := false
+		txemail.MockSend = func(ctx context.Context, msg txemail.Message) error {
+			emailSent = true
+			return nil
+		}
+
+		RunTests(t, []*Test{
+			{
+				Schema:  mustParseGraphQLSchema(t, db),
+				Context: ctx,
+				Query: `
+				mutation ResendOrganizationInvitation($id: ID!) {
+					resendOrganizationInvitationNotification(organizationInvitation:$id) {
+						alwaysNil
+					}
+				}
+				`,
+				Variables: map[string]interface{}{
+					"id": string(MarshalOrgInvitationID(invitationID)),
+				},
+				ExpectedResult: `{
+					"resendOrganizationInvitationNotification": {
+						"alwaysNil": null
+					}
+				}`,
+			},
+		})
+
+		updateExpiryCalls := orgInvitations.UpdateExpiryTimeFunc.History()
+		lastUpdateExpiryCall := updateExpiryCalls[len(updateExpiryCalls)-1]
+		if lastUpdateExpiryCall.Arg1 != invitationID || math.Round(lastUpdateExpiryCall.Arg2.Sub(timeNow()).Hours()) != math.Round(DefaultExpiryDuration.Hours()) {
+			t.Fatalf("db.OrgInvitations.ResendOrganizationInvitationNotification was not called with right args: %v", lastUpdateExpiryCall.Args())
+		}
+
+		if !emailSent {
+			t.Fatalf("email not sent")
+		}
+	})
+
+	t.Run("Can resend an email invitation", func(t *testing.T) {
+		invitationID := int64(3)
+		orgID := int32(3)
+		email := "foo@bar.baz"
+		orgInvitations.GetPendingByIDFunc.SetDefaultReturn(&database.OrgInvitation{ID: invitationID, OrgID: orgID, RecipientEmail: email, ExpiresAt: &expiryTime}, nil)
+		emailSent := false
+		txemail.MockSend = func(ctx context.Context, msg txemail.Message) error {
+			emailSent = true
+			return nil
+		}
+
+		RunTests(t, []*Test{
+			{
+				Schema:  mustParseGraphQLSchema(t, db),
+				Context: ctx,
+				Query: `
+				mutation ResendOrganizationInvitation($id: ID!) {
+					resendOrganizationInvitationNotification(organizationInvitation:$id) {
+						alwaysNil
+					}
+				}
+				`,
+				Variables: map[string]interface{}{
+					"id": string(MarshalOrgInvitationID(invitationID)),
+				},
+				ExpectedResult: `{
+					"resendOrganizationInvitationNotification": {
+						"alwaysNil": null
+					}
+				}`,
+			},
+		})
+
+		updateExpiryCalls := orgInvitations.UpdateExpiryTimeFunc.History()
+		lastUpdateExpiryCall := updateExpiryCalls[len(updateExpiryCalls)-1]
+		if lastUpdateExpiryCall.Arg1 != invitationID || math.Round(lastUpdateExpiryCall.Arg2.Sub(timeNow()).Hours()) != math.Round(DefaultExpiryDuration.Hours()) {
+			t.Fatalf("db.OrgInvitations.ResendOrganizationInvitationNotification was not called with right args: %v", lastUpdateExpiryCall.Args())
+		}
+
+		if !emailSent {
+			t.Fatalf("email not sent")
+		}
+	})
+
+	t.Run("Fails if invitation is expired", func(t *testing.T) {
+		invitationID := int64(3)
+		orgID := int32(3)
+		email := "foo@bar.baz"
+		yesterday := timeNow().Add(-24 * time.Hour)
+		orgInvitations.GetPendingByIDFunc.SetDefaultReturn(&database.OrgInvitation{ID: invitationID, OrgID: orgID, RecipientEmail: email, ExpiresAt: &yesterday}, nil)
+
+		RunTests(t, []*Test{
+			{
+				Schema:  mustParseGraphQLSchema(t, db),
+				Context: ctx,
+				Query: `
+				mutation ResendOrganizationInvitation($id: ID!) {
+					resendOrganizationInvitationNotification(organizationInvitation:$id) {
+						alwaysNil
+					}
+				}
+				`,
+				Variables: map[string]interface{}{
+					"id": string(MarshalOrgInvitationID(invitationID)),
+				},
+				ExpectedResult: "null",
+				ExpectedErrors: []*errors.QueryError{
+					{
+						Message: "invitation is expired",
+						Path:    []interface{}{"resendOrganizationInvitationNotification"},
+					},
+				},
+			},
+		})
+	})
+
+	t.Run("Fails if user invitation email is not verified", func(t *testing.T) {
+		invitationID := int64(4)
+		orgID := int32(4)
+		email := "foo@bar.baz"
+		orgInvitations.GetPendingByIDFunc.SetDefaultReturn(&database.OrgInvitation{ID: invitationID, OrgID: orgID, RecipientUserID: 2, ExpiresAt: &expiryTime}, nil)
+		userEmails.GetPrimaryEmailFunc.SetDefaultReturn(email, false, nil)
+
+		RunTests(t, []*Test{
+			{
+				Schema:  mustParseGraphQLSchema(t, db),
+				Context: ctx,
+				Query: `
+				mutation ResendOrganizationInvitation($id: ID!) {
+					resendOrganizationInvitationNotification(organizationInvitation:$id) {
+						alwaysNil
+					}
+				}
+				`,
+				Variables: map[string]interface{}{
+					"id": string(MarshalOrgInvitationID(invitationID)),
+				},
+				ExpectedResult: "null",
+				ExpectedErrors: []*errors.QueryError{
+					{
+						Message: "refusing to send notification because recipient has no verified email address",
+						Path:    []interface{}{"resendOrganizationInvitationNotification"},
 					},
 				},
 			},

--- a/cmd/frontend/graphqlbackend/org_invitations_test.go
+++ b/cmd/frontend/graphqlbackend/org_invitations_test.go
@@ -3,7 +3,6 @@ package graphqlbackend
 import (
 	"context"
 	"encoding/base64"
-	"github.com/sourcegraph/sourcegraph/internal/txemail"
 	"math"
 	"strings"
 	"testing"
@@ -15,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/txemail"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	stderrors "github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"

--- a/internal/database/mocks.go
+++ b/internal/database/mocks.go
@@ -16918,6 +16918,9 @@ type MockOrgInvitationStore struct {
 	// UpdateEmailSentTimestampFunc is an instance of a mock function object
 	// controlling the behavior of the method UpdateEmailSentTimestamp.
 	UpdateEmailSentTimestampFunc *OrgInvitationStoreUpdateEmailSentTimestampFunc
+	// UpdateExpiryTimeFunc is an instance of a mock function object
+	// controlling the behavior of the method UpdateExpiryTime.
+	UpdateExpiryTimeFunc *OrgInvitationStoreUpdateExpiryTimeFunc
 	// WithFunc is an instance of a mock function object controlling the
 	// behavior of the method With.
 	WithFunc *OrgInvitationStoreWithFunc
@@ -16980,6 +16983,11 @@ func NewMockOrgInvitationStore() *MockOrgInvitationStore {
 		},
 		UpdateEmailSentTimestampFunc: &OrgInvitationStoreUpdateEmailSentTimestampFunc{
 			defaultHook: func(context.Context, int64) error {
+				return nil
+			},
+		},
+		UpdateExpiryTimeFunc: &OrgInvitationStoreUpdateExpiryTimeFunc{
+			defaultHook: func(context.Context, int64, time.Time) error {
 				return nil
 			},
 		},
@@ -17051,6 +17059,11 @@ func NewStrictMockOrgInvitationStore() *MockOrgInvitationStore {
 				panic("unexpected invocation of MockOrgInvitationStore.UpdateEmailSentTimestamp")
 			},
 		},
+		UpdateExpiryTimeFunc: &OrgInvitationStoreUpdateExpiryTimeFunc{
+			defaultHook: func(context.Context, int64, time.Time) error {
+				panic("unexpected invocation of MockOrgInvitationStore.UpdateExpiryTime")
+			},
+		},
 		WithFunc: &OrgInvitationStoreWithFunc{
 			defaultHook: func(basestore.ShareableStore) OrgInvitationStore {
 				panic("unexpected invocation of MockOrgInvitationStore.With")
@@ -17096,6 +17109,9 @@ func NewMockOrgInvitationStoreFrom(i OrgInvitationStore) *MockOrgInvitationStore
 		},
 		UpdateEmailSentTimestampFunc: &OrgInvitationStoreUpdateEmailSentTimestampFunc{
 			defaultHook: i.UpdateEmailSentTimestamp,
+		},
+		UpdateExpiryTimeFunc: &OrgInvitationStoreUpdateExpiryTimeFunc{
+			defaultHook: i.UpdateExpiryTime,
 		},
 		WithFunc: &OrgInvitationStoreWithFunc{
 			defaultHook: i.With,
@@ -18310,6 +18326,118 @@ func (c OrgInvitationStoreUpdateEmailSentTimestampFuncCall) Args() []interface{}
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c OrgInvitationStoreUpdateEmailSentTimestampFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// OrgInvitationStoreUpdateExpiryTimeFunc describes the behavior when the
+// UpdateExpiryTime method of the parent MockOrgInvitationStore instance is
+// invoked.
+type OrgInvitationStoreUpdateExpiryTimeFunc struct {
+	defaultHook func(context.Context, int64, time.Time) error
+	hooks       []func(context.Context, int64, time.Time) error
+	history     []OrgInvitationStoreUpdateExpiryTimeFuncCall
+	mutex       sync.Mutex
+}
+
+// UpdateExpiryTime delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockOrgInvitationStore) UpdateExpiryTime(v0 context.Context, v1 int64, v2 time.Time) error {
+	r0 := m.UpdateExpiryTimeFunc.nextHook()(v0, v1, v2)
+	m.UpdateExpiryTimeFunc.appendCall(OrgInvitationStoreUpdateExpiryTimeFuncCall{v0, v1, v2, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the UpdateExpiryTime
+// method of the parent MockOrgInvitationStore instance is invoked and the
+// hook queue is empty.
+func (f *OrgInvitationStoreUpdateExpiryTimeFunc) SetDefaultHook(hook func(context.Context, int64, time.Time) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// UpdateExpiryTime method of the parent MockOrgInvitationStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *OrgInvitationStoreUpdateExpiryTimeFunc) PushHook(hook func(context.Context, int64, time.Time) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *OrgInvitationStoreUpdateExpiryTimeFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, int64, time.Time) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *OrgInvitationStoreUpdateExpiryTimeFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, int64, time.Time) error {
+		return r0
+	})
+}
+
+func (f *OrgInvitationStoreUpdateExpiryTimeFunc) nextHook() func(context.Context, int64, time.Time) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *OrgInvitationStoreUpdateExpiryTimeFunc) appendCall(r0 OrgInvitationStoreUpdateExpiryTimeFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of OrgInvitationStoreUpdateExpiryTimeFuncCall
+// objects describing the invocations of this function.
+func (f *OrgInvitationStoreUpdateExpiryTimeFunc) History() []OrgInvitationStoreUpdateExpiryTimeFuncCall {
+	f.mutex.Lock()
+	history := make([]OrgInvitationStoreUpdateExpiryTimeFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// OrgInvitationStoreUpdateExpiryTimeFuncCall is an object that describes an
+// invocation of method UpdateExpiryTime on an instance of
+// MockOrgInvitationStore.
+type OrgInvitationStoreUpdateExpiryTimeFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int64
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 time.Time
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c OrgInvitationStoreUpdateExpiryTimeFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c OrgInvitationStoreUpdateExpiryTimeFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/org_invitations_test.go
+++ b/internal/database/org_invitations_test.go
@@ -319,11 +319,11 @@ func TestOrgInvitations(t *testing.T) {
 	})
 
 	t.Run("UpdateExpiryTime", func(t *testing.T) {
-		org3, err := db.Orgs().Create(ctx, "o3", nil)
+		org4, err := db.Orgs().Create(ctx, "o4", nil)
 		if err != nil {
 			t.Fatal(err)
 		}
-		toUpdateInvite, err := OrgInvitations(db).Create(ctx, org3.ID, sender.ID, recipient.ID, "", timeNow().Add(time.Hour))
+		toUpdateInvite, err := OrgInvitations(db).Create(ctx, org4.ID, sender.ID, recipient.ID, "", timeNow().Add(time.Hour))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/database/org_invitations_test.go
+++ b/internal/database/org_invitations_test.go
@@ -335,6 +335,9 @@ func TestOrgInvitations(t *testing.T) {
 
 		// After updating, the new expiry time on invite should be the same as we expect
 		updatedInvite, err := OrgInvitations(db).GetByID(ctx, toUpdateInvite.ID)
+		if err != nil {
+			t.Fatalf("cannot get invite by id %d", toUpdateInvite.ID)
+		}
 		if updatedInvite.ExpiresAt == nil && *updatedInvite.ExpiresAt != newExpiry {
 			t.Fatalf("expiry time differs, expected %v, got %v", newExpiry, updatedInvite.ExpiresAt)
 		}


### PR DESCRIPTION
# Description

Make resend invitation work for email invites
Also make sure, that when resending the invitation, we extend
the expiry time as if we created a new invitation.

## Related Jira issue
https://sourcegraph.atlassian.net/browse/CLOUD-192

## Test plan
unit tested, manually tested by running a graphql query

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


