### PR TITLE
dev/ci: make branches that require arguments explicit

### DIFF
--- a/dev/ci/runtype/runtype_test.go
+++ b/dev/ci/runtype/runtype_test.go
@@ -159,3 +159,45 @@ func TestRunTypeMatcherMatches(t *testing.T) {
 		})
 	}
 }
+
+func TestRunTypeMatcherExtractBranchArgument(t *testing.T) {
+	tests := []struct {
+		name            string
+		matcher         *RunTypeMatcher
+		branch          string
+		want            string
+		wantErrContains string
+	}{{
+		name:    "gets 1 segment argument",
+		matcher: &RunTypeMatcher{Branch: "prefix/"},
+		branch:  "prefix/argument",
+		want:    "argument",
+	}, {
+		name:    "gets 2 segment argument",
+		matcher: &RunTypeMatcher{Branch: "prefix/"},
+		branch:  "prefix/argument/name",
+		want:    "argument",
+	}, {
+		name:    "missing unrequired argument",
+		matcher: &RunTypeMatcher{Branch: "prefix/"},
+		branch:  "prefix/",
+	}, {
+		name: "missing required argument",
+		matcher: &RunTypeMatcher{
+			Branch:                 "prefix/",
+			BranchArgumentRequired: true,
+		},
+		branch:          "prefix/",
+		wantErrContains: "branch argument expected",
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.matcher.ExtractBranchArgument(tt.branch)
+			if tt.wantErrContains != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrContains)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -187,29 +187,21 @@ Default pipeline:
 
 ### Patch image
 
-The run type for branches matching `docker-images-patch/`.
+The run type for branches matching `docker-images-patch/`, requires a branch argument in the second branch path segment.
 You can create a build of this run type for your changes using:
 
 ```sh
 sg ci build docker-images-patch
 ```
 
-<!--
-no image "" found
--->
-
 ### Patch image without testing
 
-The run type for branches matching `docker-images-patch-notest/`.
+The run type for branches matching `docker-images-patch-notest/`, requires a branch argument in the second branch path segment.
 You can create a build of this run type for your changes using:
 
 ```sh
 sg ci build docker-images-patch-notest
 ```
-
-<!--
-no image "" found
--->
 
 ### Build all candidates without testing
 


### PR DESCRIPTION
Adds a new matcher option, `BranchArgumentRequired`, that indicates the run type requires an argument within the branch name - namely `docker-images-patch` and `docker-images-patch-notest`. This removes the need for magic numbers as pointed out in https://github.com/sourcegraph/sourcegraph/pull/31100#discussion_r805828674

This also allows `sg ci build` to identify branches that requires special arguments and prompt for one:

<img width="884" alt="Screen Shot 2022-02-14 at 11 27 24 AM" src="https://user-images.githubusercontent.com/23356519/153933687-110f3657-543b-4d95-b01b-21b6b9e28514.png">

This can also be provided directly:

```
sg ci build docker-images-patch cadvisor
```

`gen-pipeline -docs` now also more intelligently skips over branches that requires arguments, though it retains the panic recovery introduced in https://github.com/sourcegraph/sourcegraph/pull/31100 with a note that we should introduce better testing on that front instead of relying on `-docs` to error out.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Unit tests for the argument extraction. Also manual testing, indicated above, e.g. https://buildkite.com/sourcegraph/sourcegraph/builds/131387 which generates the expected pipeline.

Documentation: https://github.com/sourcegraph/handbook/pull/2336