### PR TITLE
Add unique constraint on batch changes table

### DIFF
--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_connection_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_connection_test.go
@@ -205,7 +205,6 @@ func TestBatchChangesListing(t *testing.T) {
 	createBatchChange := func(t *testing.T, c *btypes.BatchChange) {
 		t.Helper()
 
-		c.Name = "n"
 		if err := store.CreateBatchChange(ctx, c); err != nil {
 			t.Fatal(err)
 		}
@@ -216,6 +215,7 @@ func TestBatchChangesListing(t *testing.T) {
 		createBatchSpec(t, spec)
 
 		batchChange := &btypes.BatchChange{
+			Name:            "batch-change-1",
 			NamespaceUserID: userID,
 			BatchSpecID:     spec.ID,
 			CreatorID:       userID,
@@ -249,6 +249,7 @@ func TestBatchChangesListing(t *testing.T) {
 
 		// This batch change has never been applied -- it is a draft.
 		batchChange2 := &btypes.BatchChange{
+			Name:            "batch-change-2",
 			NamespaceUserID: userID,
 			BatchSpecID:     spec2.ID,
 		}
@@ -298,6 +299,7 @@ func TestBatchChangesListing(t *testing.T) {
 		createBatchSpec(t, spec)
 
 		batchChange := &btypes.BatchChange{
+			Name:           "batch-change-1",
 			NamespaceOrgID: orgID,
 			BatchSpecID:    spec.ID,
 			CreatorID:      userID,
@@ -331,6 +333,7 @@ func TestBatchChangesListing(t *testing.T) {
 
 		// This batch change has never been applied -- it is a draft.
 		batchChange2 := &btypes.BatchChange{
+			Name:           "batch-change-2",
 			NamespaceOrgID: orgID,
 			BatchSpecID:    spec2.ID,
 		}

--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -706,7 +706,7 @@ func TestService(t *testing.T) {
 		})
 
 		t.Run("new org namespace", func(t *testing.T) {
-			batchChange := createBatchChange(t, "old-name", admin.ID, admin.ID, 0)
+			batchChange := createBatchChange(t, "old-name-1", admin.ID, admin.ID, 0)
 
 			orgID := ct.InsertTestOrg(t, db, "org")
 
@@ -726,7 +726,7 @@ func TestService(t *testing.T) {
 		})
 
 		t.Run("new org namespace but current user is missing access", func(t *testing.T) {
-			batchChange := createBatchChange(t, "old-name", user.ID, user.ID, 0)
+			batchChange := createBatchChange(t, "old-name-2", user.ID, user.ID, 0)
 
 			orgID := ct.InsertTestOrg(t, db, "org-no-access")
 
@@ -2254,7 +2254,7 @@ func assertChangesetSpecsNotDeleted(t *testing.T, s *store.Store, specs []*btype
 
 func testBatchChange(user int32, spec *btypes.BatchSpec) *btypes.BatchChange {
 	c := &btypes.BatchChange{
-		Name:            "test-batch-change",
+		Name:            fmt.Sprintf("test-batch-change-%d", time.Now().UnixMicro()),
 		CreatorID:       user,
 		NamespaceUserID: user,
 		BatchSpecID:     spec.ID,

--- a/enterprise/internal/batches/store/batch_specs_test.go
+++ b/enterprise/internal/batches/store/batch_specs_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -389,7 +390,7 @@ func testStoreBatchSpecs(t *testing.T, ctx context.Context, s *Store, clock ct.C
 			{hasBatchChange: true, hasChangesetSpecs: true, createdAt: overTTL, wantDeleted: false},
 		}
 
-		for _, tc := range tests {
+		for i, tc := range tests {
 			batchSpec := &btypes.BatchSpec{
 				UserID:          1,
 				NamespaceUserID: 1,
@@ -402,7 +403,7 @@ func testStoreBatchSpecs(t *testing.T, ctx context.Context, s *Store, clock ct.C
 
 			if tc.hasBatchChange {
 				batchChange := &btypes.BatchChange{
-					Name:            "not-blank",
+					Name:            fmt.Sprintf("not-blank-%d", i),
 					CreatorID:       1,
 					NamespaceUserID: 1,
 					BatchSpecID:     batchSpec.ID,

--- a/enterprise/internal/batches/store/changesets_test.go
+++ b/enterprise/internal/batches/store/changesets_test.go
@@ -1529,9 +1529,9 @@ func testStoreListChangesetSyncData(t *testing.T, ctx context.Context, s *Store,
 	}
 
 	// We need batch changes attached to each changeset
-	for _, cs := range changesets {
+	for i, cs := range changesets {
 		c := &btypes.BatchChange{
-			Name:           "ListChangesetSyncData test",
+			Name:           fmt.Sprintf("ListChangesetSyncData-test-%d", i),
 			NamespaceOrgID: 23,
 			LastApplierID:  1,
 			LastAppliedAt:  time.Now(),

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -42,6 +42,8 @@ Referenced by:
  last_applied_at   | timestamp with time zone |           |          | 
 Indexes:
     "batch_changes_pkey" PRIMARY KEY, btree (id)
+    "batch_changes_unique_org_id" UNIQUE, btree (name, namespace_org_id) WHERE namespace_org_id IS NOT NULL
+    "batch_changes_unique_user_id" UNIQUE, btree (name, namespace_user_id) WHERE namespace_user_id IS NOT NULL
     "batch_changes_namespace_org_id" btree (namespace_org_id)
     "batch_changes_namespace_user_id" btree (namespace_user_id)
 Check constraints:

--- a/migrations/frontend/1644868458/down.sql
+++ b/migrations/frontend/1644868458/down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+DROP INDEX IF EXISTS batch_changes_unique_user_id;
+DROP INDEX IF EXISTS batch_changes_unique_org_id;
+
+COMMIT;

--- a/migrations/frontend/1644868458/metadata.yaml
+++ b/migrations/frontend/1644868458/metadata.yaml
@@ -1,0 +1,2 @@
+name: unqiue batch changes
+parents: [1644471839, 1644583379]

--- a/migrations/frontend/1644868458/up.sql
+++ b/migrations/frontend/1644868458/up.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+CREATE UNIQUE INDEX IF NOT EXISTS batch_changes_unique_user_id ON batch_changes (name, namespace_user_id) WHERE namespace_user_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS batch_changes_unique_org_id ON batch_changes (name, namespace_org_id) WHERE namespace_org_id IS NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
Now that there are multiple entry points to creating a batch change, we figured it'd be safer to have a unique constraint in place here. There are certainly some race conditions that can cause duplicates to happen and we currently handle those very poorly.

Closes https://github.com/sourcegraph/sourcegraph/issues/29164

## Test plan

We have a big test suite around all the mutations that could be affected by this, and I did some manual test runs both on the DB layer and from the app to verify this doesn't break anything. To be clear, this already had proper error handling in place, this is just guarding the application layer checks for race conditions.