### PR TITLE
search: add panic for unsupported job case in printer

### DIFF
--- a/internal/search/job/printers.go
+++ b/internal/search/job/printers.go
@@ -2,6 +2,7 @@ package job
 
 import (
 	"bytes"
+	"fmt"
 	"strconv"
 
 	"github.com/sourcegraph/sourcegraph/internal/search/commit"
@@ -117,6 +118,8 @@ func SexpFormat(job Job, sep, indent string) string {
 			writeSexp(j.child)
 			b.WriteString(")")
 			depth--
+		default:
+			panic(fmt.Sprintf("unsupported job %T for SexpFormat printer", job))
 		}
 	}
 	writeSexp(job)


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/31205

Follow up of https://github.com/sourcegraph/sourcegraph/pull/31199#discussion_r806230157 where I was too eager to merge 😞 

## Test plan
Semantics-preserving, just makes things fail hard instead of silently for debugging.


