### PR TITLE
lint: fix regexp lib

### DIFF
--- a/dev/pr-auditor/check.go
+++ b/dev/pr-auditor/check.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"context"
-	"regexp"
 	"strings"
 
 	"github.com/google/go-github/v41/github"
+	"github.com/grafana/regexp"
 )
 
 type checkResult struct {


### PR DESCRIPTION
looks like https://github.com/sourcegraph/sourcegraph/pull/30278 was merged without rebase and is causing a lint error

One of my PRs off main is failing, https://buildkite.com/sourcegraph/sourcegraph/builds/131463
## Test plan
it's a lint
