### PR TITLE
codeintel: fix hover positioning with CSS specificity

### DIFF
--- a/client/shared/src/hover/HoverOverlay.module.scss
+++ b/client/shared/src/hover/HoverOverlay.module.scss
@@ -1,4 +1,5 @@
-.hover-overlay {
+.hover-overlay,
+.card.hover-overlay {
     --hover-overlay-vertical-padding: 0.25rem;
     --hover-overlay-horizontal-padding: 1rem;
     --hover-overlay-contents-right-padding: 1rem;

--- a/client/shared/src/hover/HoverOverlay.tsx
+++ b/client/shared/src/hover/HoverOverlay.tsx
@@ -112,7 +112,7 @@ export const HoverOverlay: React.FunctionComponent<HoverOverlayProps> = props =>
             data-testid="hover-overlay"
             // eslint-disable-next-line react/forbid-dom-props
             style={getOverlayStyle(overlayPosition)}
-            className={classNames(hoverOverlayStyle.hoverOverlay, className)}
+            className={classNames(hoverOverlayStyle.card, hoverOverlayStyle.hoverOverlay, className)}
             ref={hoverRef}
         >
             <div

--- a/client/shared/src/hover/__snapshots__/HoverOverlay.test.tsx.snap
+++ b/client/shared/src/hover/__snapshots__/HoverOverlay.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`HoverOverlay actions and hover empty 1`] = `
 <DocumentFragment>
   <div
-    class="hoverOverlay"
+    class="card hoverOverlay"
     data-testid="hover-overlay"
     style="opacity: 1; visibility: visible; left: 0px; top: 0px;"
   >
@@ -24,7 +24,7 @@ exports[`HoverOverlay actions and hover empty 1`] = `
 exports[`HoverOverlay actions and hover error 1`] = `
 <DocumentFragment>
   <div
-    class="hoverOverlay"
+    class="card hoverOverlay"
     data-testid="hover-overlay"
     style="opacity: 1; visibility: visible; left: 0px; top: 0px;"
   >
@@ -45,7 +45,7 @@ exports[`HoverOverlay actions and hover error 1`] = `
 exports[`HoverOverlay actions and hover loading 1`] = `
 <DocumentFragment>
   <div
-    class="hoverOverlay"
+    class="card hoverOverlay"
     data-testid="hover-overlay"
     style="opacity: 1; visibility: visible; left: 0px; top: 0px;"
   >
@@ -68,7 +68,7 @@ exports[`HoverOverlay actions and hover loading 1`] = `
 exports[`HoverOverlay actions and hover present 1`] = `
 <DocumentFragment>
   <div
-    class="hoverOverlay"
+    class="card hoverOverlay"
     data-testid="hover-overlay"
     style="opacity: 1; visibility: visible; left: 0px; top: 0px;"
   >
@@ -112,7 +112,7 @@ exports[`HoverOverlay actions and hover undefined 1`] = `<DocumentFragment />`;
 exports[`HoverOverlay actions empty 1`] = `
 <DocumentFragment>
   <div
-    class="hoverOverlay"
+    class="card hoverOverlay"
     data-testid="hover-overlay"
     style="opacity: 1; visibility: visible; left: 0px; top: 0px;"
   >
@@ -129,7 +129,7 @@ exports[`HoverOverlay actions error 1`] = `<DocumentFragment />`;
 exports[`HoverOverlay actions error, hover present 1`] = `
 <DocumentFragment>
   <div
-    class="hoverOverlay"
+    class="card hoverOverlay"
     data-testid="hover-overlay"
     style="opacity: 1; visibility: visible; left: 0px; top: 0px;"
   >
@@ -155,7 +155,7 @@ exports[`HoverOverlay actions error, hover present 1`] = `
 exports[`HoverOverlay actions loading 1`] = `
 <DocumentFragment>
   <div
-    class="hoverOverlay"
+    class="card hoverOverlay"
     data-testid="hover-overlay"
     style="opacity: 1; visibility: visible; left: 0px; top: 0px;"
   >
@@ -170,7 +170,7 @@ exports[`HoverOverlay actions loading 1`] = `
 exports[`HoverOverlay actions present 1`] = `
 <DocumentFragment>
   <div
-    class="hoverOverlay"
+    class="card hoverOverlay"
     data-testid="hover-overlay"
     style="opacity: 1; visibility: visible; left: 0px; top: 0px;"
   >
@@ -201,7 +201,7 @@ exports[`HoverOverlay actions present 1`] = `
 exports[`HoverOverlay actions present, hover loading 1`] = `
 <DocumentFragment>
   <div
-    class="hoverOverlay"
+    class="card hoverOverlay"
     data-testid="hover-overlay"
     style="opacity: 1; visibility: visible; left: 0px; top: 0px;"
   >
@@ -240,7 +240,7 @@ exports[`HoverOverlay actions present, hover loading 1`] = `
 exports[`HoverOverlay actions, hover and alert present 1`] = `
 <DocumentFragment>
   <div
-    class="hoverOverlay"
+    class="card hoverOverlay"
     data-testid="hover-overlay"
     style="opacity: 1; visibility: visible; left: 0px; top: 0px;"
   >
@@ -319,7 +319,7 @@ exports[`HoverOverlay hover empty 1`] = `<DocumentFragment />`;
 exports[`HoverOverlay hover error 1`] = `
 <DocumentFragment>
   <div
-    class="hoverOverlay"
+    class="card hoverOverlay"
     data-testid="hover-overlay"
     style="opacity: 1; visibility: visible; left: 0px; top: 0px;"
   >
@@ -340,7 +340,7 @@ exports[`HoverOverlay hover error 1`] = `
 exports[`HoverOverlay hover error, actions present 1`] = `
 <DocumentFragment>
   <div
-    class="hoverOverlay"
+    class="card hoverOverlay"
     data-testid="hover-overlay"
     style="opacity: 1; visibility: visible; left: 0px; top: 0px;"
   >
@@ -377,7 +377,7 @@ exports[`HoverOverlay hover error, actions present 1`] = `
 exports[`HoverOverlay hover loading 1`] = `
 <DocumentFragment>
   <div
-    class="hoverOverlay"
+    class="card hoverOverlay"
     data-testid="hover-overlay"
     style="opacity: 1; visibility: visible; left: 0px; top: 0px;"
   >
@@ -400,7 +400,7 @@ exports[`HoverOverlay hover loading 1`] = `
 exports[`HoverOverlay hover present 1`] = `
 <DocumentFragment>
   <div
-    class="hoverOverlay"
+    class="card hoverOverlay"
     data-testid="hover-overlay"
     style="opacity: 1; visibility: visible; left: 0px; top: 0px;"
   >
@@ -426,7 +426,7 @@ exports[`HoverOverlay hover present 1`] = `
 exports[`HoverOverlay hover present, actions loading 1`] = `
 <DocumentFragment>
   <div
-    class="hoverOverlay"
+    class="card hoverOverlay"
     data-testid="hover-overlay"
     style="opacity: 1; visibility: visible; left: 0px; top: 0px;"
   >
@@ -452,7 +452,7 @@ exports[`HoverOverlay hover present, actions loading 1`] = `
 exports[`HoverOverlay multiple hovers present 1`] = `
 <DocumentFragment>
   <div
-    class="hoverOverlay"
+    class="card hoverOverlay"
     data-testid="hover-overlay"
     style="opacity: 1; visibility: visible; left: 0px; top: 0px;"
   >


### PR DESCRIPTION
Prior to this change, the hover popover was getting positioned incorrectly:

<img width="791" alt="CleanShot 2022-02-14 at 15 03 49@2x" src="https://user-images.githubusercontent.com/1387653/153954167-8f1364bd-79a5-40e8-a88a-8428b3f02706.png">

The hover overlay had [`class="card hover-overlay"`](https://github.com/sourcegraph/sourcegraph/blame/0fca89e7d98e5db2aad9091cdacabe4f1afe1dca/client/shared/src/hover/HoverOverlay.tsx#L115)

* `hover-overlay` sets [`position: absolute`](https://github.com/sourcegraph/sourcegraph/blob/0fca89e7d98e5db2aad9091cdacabe4f1afe1dca/client/shared/src/hover/HoverOverlay.module.scss#L12)
* `card` sets [`position: relative`](https://github.com/sourcegraph/sourcegraph/blob/0fca89e7d98e5db2aad9091cdacabe4f1afe1dca/client/wildcard/src/components/Card/Card.module.scss#L11)

Both have the same [specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity#directly_targeted_elements_vs._inherited_styles), so source order dictates which one's property is applied. I'm guessing the source order is not very stable and is different between my local env and cloud.

After this change, the hover popover will have a higher specificity than card, so the hover's CSS will be applied.

More info: [incident in Slack](https://sourcegraph.slack.com/archives/C0331CGA4P4).

## Test plan

Inspect element, see that 2 classes match now instead of 1, which means the hover overlay CSS is more specific and will be applied with higher priority than the card CSS.