### PR TITLE
Wildcard V2: Add label hover style to `BaseControlInput`

### DIFF
--- a/client/web/src/enterprise/dotcom/productPlans/__snapshots__/ProductPlanFormControl.test.tsx.snap
+++ b/client/web/src/enterprise/dotcom/productPlans/__snapshots__/ProductPlanFormControl.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`ProductPlanFormControl new subscription 1`] = `
               value="p0"
             />
             <label
-              class="form-check-label"
+              class="form-check-label label"
               for="product-plan-form-control__plan0"
             >
               <div>
@@ -63,7 +63,7 @@ exports[`ProductPlanFormControl new subscription 1`] = `
               value="p1"
             />
             <label
-              class="form-check-label"
+              class="form-check-label label"
               for="product-plan-form-control__plan1"
             >
               <div>

--- a/client/wildcard/src/components/Form/internal/BaseControlInput.module.scss
+++ b/client/wildcard/src/components/Form/internal/BaseControlInput.module.scss
@@ -1,0 +1,3 @@
+.label:hover {
+    color: var(--gray-12);
+}

--- a/client/wildcard/src/components/Form/internal/BaseControlInput.tsx
+++ b/client/wildcard/src/components/Form/internal/BaseControlInput.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames'
 import React from 'react'
 
 import { AccessibleFieldProps } from './AccessibleFieldType'
+import styles from './BaseControlInput.module.scss'
 import { FormFieldLabel } from './FormFieldLabel'
 import { FormFieldMessage } from './FormFieldMessage'
 import { getValidStyle } from './utils'
@@ -26,7 +27,7 @@ export const BaseControlInput: React.FunctionComponent<ControlInputProps> = Reac
                 {...props}
             />
             {'label' in props && (
-                <FormFieldLabel htmlFor={props.id} className="form-check-label">
+                <FormFieldLabel htmlFor={props.id} className={classNames('form-check-label', styles.label)}>
                     {props.label}
                 </FormFieldLabel>
             )}

--- a/client/wildcard/src/components/Form/internal/__snapshots__/BaseControlInput.test.tsx.snap
+++ b/client/wildcard/src/components/Form/internal/__snapshots__/BaseControlInput.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`BaseControlInput checkbox input renders correctly 1`] = `
     type="checkbox"
   />
   <label
-    class="form-check-label"
+    class="form-check-label label"
     for="test"
   >
     Hello world
@@ -30,7 +30,7 @@ exports[`BaseControlInput checkbox input renders with correct styles when invali
     type="checkbox"
   />
   <label
-    class="form-check-label"
+    class="form-check-label label"
     for="test"
   >
     Hello world
@@ -54,7 +54,7 @@ exports[`BaseControlInput checkbox input renders with correct styles when valid 
     type="checkbox"
   />
   <label
-    class="form-check-label"
+    class="form-check-label label"
     for="test"
   >
     Hello world
@@ -78,7 +78,7 @@ exports[`BaseControlInput checkbox input renders with message correctly 1`] = `
     type="checkbox"
   />
   <label
-    class="form-check-label"
+    class="form-check-label label"
     for="test"
   >
     Hello world
@@ -102,7 +102,7 @@ exports[`BaseControlInput radio input renders correctly 1`] = `
     type="radio"
   />
   <label
-    class="form-check-label"
+    class="form-check-label label"
     for="test"
   >
     Hello world
@@ -121,7 +121,7 @@ exports[`BaseControlInput radio input renders with correct styles when invalid 1
     type="radio"
   />
   <label
-    class="form-check-label"
+    class="form-check-label label"
     for="test"
   >
     Hello world
@@ -145,7 +145,7 @@ exports[`BaseControlInput radio input renders with correct styles when valid 1`]
     type="radio"
   />
   <label
-    class="form-check-label"
+    class="form-check-label label"
     for="test"
   >
     Hello world
@@ -169,7 +169,7 @@ exports[`BaseControlInput radio input renders with message correctly 1`] = `
     type="radio"
   />
   <label
-    class="form-check-label"
+    class="form-check-label label"
     for="test"
   >
     Hello world


### PR DESCRIPTION
Adds the missing hover style that darkens the text to `$gray-12` to the label for `BaseControlInput` as featured in the [Wildcard design files](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/Wildcard-Design-System?node-id=908%3A1437), which controls radio buttons and checkboxes:

https://user-images.githubusercontent.com/8942601/153955776-0de79914-2a92-4522-9cd5-ec41a8b35a80.mov

It's subtle but it's something. 🙂

"Valid" coloration (green for valid, red for invalid) overwrites this hover style.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Verified visually in Storybook for both the checkbox and radio button components.

