### PR TITLE
dev/ci: annotate sg check commands in CI

### DIFF
--- a/dev/sg/sg_check.go
+++ b/dev/sg/sg_check.go
@@ -21,7 +21,8 @@ import (
 )
 
 var (
-	checkFlagSet = flag.NewFlagSet("sg check", flag.ExitOnError)
+	checkFlagSet             = flag.NewFlagSet("sg check", flag.ExitOnError)
+	checkGenerateAnnotations = checkFlagSet.Bool("annotations", false, "Write helpful output to annotations directory")
 
 	checkShellFlagSet   = flag.NewFlagSet("sg check shell", flag.ExitOnError)
 	checkURLsFlagSet    = flag.NewFlagSet("sg check urls", flag.ExitOnError)
@@ -185,6 +186,17 @@ func printCheckReport(pending output.Pending, report *checkReport) {
 	if report.err != nil {
 		pending.VerboseLine(output.Linef(output.EmojiFailure, output.StyleWarning, msg))
 		pending.Verbose(report.output)
+		if *checkGenerateAnnotations {
+			repoRoot, err := root.RepositoryRoot()
+			if err != nil {
+				return // do nothing
+			}
+			annotationPath := filepath.Join(repoRoot, "annotations")
+			os.MkdirAll(annotationPath, os.ModePerm)
+			if err := os.WriteFile(filepath.Join(annotationPath, report.header), []byte(report.output+"\n"), os.ModePerm); err != nil {
+				return // do nothing
+			}
+		}
 		return
 	}
 	pending.VerboseLine(output.Linef(output.EmojiSuccess, output.StyleSuccess, msg))

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -399,7 +399,9 @@ func addGoBuild(pipeline *bk.Pipeline) {
 // Lints the Dockerfiles.
 func addDockerfileLint(pipeline *bk.Pipeline) {
 	pipeline.AddStep(":docker: Docker checks",
-		bk.Cmd("go run ./dev/sg check docker"))
+		bk.AnnotatedCmd("go run ./dev/sg check -annotations docker", bk.AnnotatedCmdOpts{
+			IncludeNames: true,
+		}))
 }
 
 // Adds backend integration tests step.


### PR DESCRIPTION
Add a `-annotate` flag for `sg check` that can be used on any `sg check` command run in CI to automatically be compatible with `bk.AnnotatedCmd`. It simply writes the result output to a file, which gets picked up by the pipeline generator.

Example with https://github.com/sourcegraph/sourcegraph/pull/31217 , which demonstrates `sg check docker` being annotated in CI:

<img width="1175" alt="image" src="https://user-images.githubusercontent.com/23356519/153966926-121b665e-52ce-4943-9516-20719ab46792.png">


## Test plan

Example build: https://buildkite.com/sourcegraph/sourcegraph/builds/131508

Run locally and examine output in `./annotations`: `go run ./dev/sg check docker`

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


