### PR TITLE
search: add mermaid printer for search job

### DIFF
--- a/internal/search/job/printers_test.go
+++ b/internal/search/job/printers_test.go
@@ -54,3 +54,75 @@ func TestSexp(t *testing.T) {
 							NewNoopJob(),
 							NewNoopJob()))))))))
 }
+
+func TestPrettyMermaid(t *testing.T) {
+	autogold.Want("simple mermaid", `
+flowchart TB
+0([AND])
+  0---1
+  1([NoopJob])
+  0---2
+  2([NoopJob])
+  `).Equal(t, fmt.Sprintf("\n%s", PrettyMermaid(
+		NewAndJob(
+			NewNoopJob(),
+			NewNoopJob()))))
+
+	autogold.Want("big mermaid", `
+flowchart TB
+0([FILTER])
+  0---1
+  1[SubRepoPermissions]
+  0---2
+  2([LIMIT])
+    2---3
+    3[100]
+    2---4
+    4([TIMEOUT])
+      4---5
+      5[50ms]
+      4---6
+      6([PARALLEL])
+        6---7
+        7([PRIORITY])
+          7---8
+          8([REQUIRED])
+          8---9
+          9([AND])
+            9---10
+            10([NoopJob])
+            9---11
+            11([NoopJob])
+            7---12
+          12([OPTIONAL])
+          12---13
+          13([OR])
+            13---14
+            14([NoopJob])
+            13---15
+            15([NoopJob])
+            6---16
+        16([AND])
+          16---17
+          17([NoopJob])
+          16---18
+          18([NoopJob])
+          `).Equal(t, fmt.Sprintf("\n%s", PrettyMermaid(
+		NewFilterJob(
+			NewLimitJob(
+				100,
+				NewTimeoutJob(
+					50*1_000_000,
+					NewParallelJob(
+						NewPriorityJob(
+							NewAndJob(
+								NewNoopJob(),
+								NewNoopJob()),
+							NewOrJob(
+								NewNoopJob(),
+								NewNoopJob()),
+						),
+						NewAndJob(
+							NewNoopJob(),
+							NewNoopJob()))))))))
+}


### PR DESCRIPTION
Figured I'd support `mermaid` while I was at it. I prefer `DOT` for configuring layouts, and will add that later. The fun thing about `mermaid` is that it renders natively in GH issues/PRs: https://github.blog/2022-02-14-include-diagrams-markdown-files-mermaid/

The plan is also to expose much more info about the query internals (e.g., which backends we hit, various filters, etc.), right now this is just the job nodes without their internal state. I will probably work on exposing internal state tomorrow.


```mermaid
flowchart TB
0([FILTER])
  0---1
  1[SubRepoPermissions]
  0---2
  2([LIMIT])
    2---3
    3[100]
    2---4
    4([TIMEOUT])
      4---5
      5[50ms]
      4---6
      6([PARALLEL])
        6---7
        7([PRIORITY])
          7---8
          8([REQUIRED])
          8---9
          9([AND])
            9---10
            10([NoopJob])
            9---11
            11([NoopJob])
            7---12
          12([OPTIONAL])
          12---13
          13([OR])
            13---14
            14([NoopJob])
            13---15
            15([NoopJob])
            6---16
        16([AND])
          16---17
          17([NoopJob])
          16---18
          18([NoopJob])
```




## Test plan
Unit tests

