### PR TITLE
gitdomain: Allow -- in args list for any command

### DIFF
--- a/internal/gitserver/gitdomain/exec.go
+++ b/internal/gitserver/gitdomain/exec.go
@@ -60,7 +60,9 @@ func isAllowedGitArg(allowedArgs []string, arg string) bool {
 	// Split the arg at the first equal sign and check the LHS against the allowlist args.
 	splitArg := strings.Split(arg, "=")[0]
 	for _, allowedArg := range allowedArgs {
-		if splitArg == allowedArg {
+		// We use -- to specify the end of command options.
+		// See: https://unix.stackexchange.com/a/11382/214756.
+		if splitArg == allowedArg || splitArg == "--" {
 			return true
 		}
 	}


### PR DESCRIPTION
Added the `--` arg for any command instead of adding explicitly for each command that needs it. Will be happy to change it back to hardcoded args list for the command that needs it if reviewers feel that's a better approach.

## Test plan

Modification to allow list to suppress warning.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


