### PR TITLE
Card: Use raw values instead of CSS var

### DIFF
--- a/client/wildcard/src/components/Card/Card.module.scss
+++ b/client/wildcard/src/components/Card/Card.module.scss
@@ -5,8 +5,6 @@
 
     // Added inset box shadow to prevent interactive card jump on hover and focus
     --hover-box-shadow: 0 0 0 1px var(--primary) inset;
-    --card-spacer-y: 0.5rem;
-    --card-spacer-x: 0.5rem;
 
     position: relative;
     display: flex;

--- a/client/wildcard/src/components/Card/components/CardBody.module.scss
+++ b/client/wildcard/src/components/Card/components/CardBody.module.scss
@@ -1,11 +1,10 @@
 .card-body {
-    --card-spacer-x: 1rem;
     // Enable `flex-grow: 1` for decks and groups so that card blocks take up
     // as much space as possible, ensuring footers are aligned to the bottom.
     flex: 1 1 auto;
     // Workaround for the image size bug in IE
     // See: https://github.com/twbs/bootstrap/pull/28855
     min-height: 1px;
-    padding: var(--card-spacer-x);
+    padding: 1rem;
     color: var(--body-color);
 }

--- a/client/wildcard/src/components/Card/components/CardFooter.module.scss
+++ b/client/wildcard/src/components/Card/components/CardFooter.module.scss
@@ -1,5 +1,5 @@
 .card-footer {
-    padding: var(--card-spacer-y) var(--card-spacer-x);
+    padding: 0.5rem;
     background-color: var(--color-bg-2);
     border-bottom: 1px solid var(--card-border-color);
 

--- a/client/wildcard/src/components/Card/components/CardHeader.module.scss
+++ b/client/wildcard/src/components/Card/components/CardHeader.module.scss
@@ -1,5 +1,5 @@
 .card-header {
-    padding: var(--card-spacer-y) var(--card-spacer-x);
+    padding: 0.5rem;
     background-color: var(--color-bg-2);
     border-bottom: 1px solid var(--card-border-color);
 

--- a/client/wildcard/src/components/Card/components/CardTitle.module.scss
+++ b/client/wildcard/src/components/Card/components/CardTitle.module.scss
@@ -1,4 +1,4 @@
 .card-title {
-    margin-bottom: var(--card-spacer-y);
+    margin-bottom: 0.5rem;
     font-size: 0.875rem;
 }


### PR DESCRIPTION
## Description

Our `CardX` components relied on the `card-spacer` variable. This might work fine, but we don't consistently render our `CardX` components within a `Card` wrapper. This can create strange styling bugs where the `spacer` variables do not exist, or only exist in certain circumstances.

## Test plan
1. Render a `CardHeader` outside of a `Card` component
2. Notice that `CardHeader` now has the correct padding
