### PR TITLE
ci: add new "targeted" runtype, to only build a specific step and its dependencies

### DIFF
--- a/dev/ci/runtype/runtype.go
+++ b/dev/ci/runtype/runtype.go
@@ -96,8 +96,9 @@ func (t RunType) Matcher() *RunTypeMatcher {
 
 	case Targeted:
 		return &RunTypeMatcher{
-			Branch:       `^targeted/[^/]+/.+$`,
-			BranchRegexp: true,
+			Branch:                 `^targeted/([^/]+)/.+$`,
+			BranchRegexp:           true,
+			BranchArgumentRequired: true,
 		}
 
 	case TaggedRelease:

--- a/dev/ci/runtype/runtype.go
+++ b/dev/ci/runtype/runtype.go
@@ -96,9 +96,9 @@ func (t RunType) Matcher() *RunTypeMatcher {
 
 	case Targeted:
 		return &RunTypeMatcher{
-			Branch:                 `^targeted/([^/]+)/.+$`,
-			BranchRegexp:           true,
-			BranchArgumentRequired: true,
+			Branch:                    "targeted/",
+			BranchArgumentRequired:    true,
+			BranchArgumentDescription: `A substring of a valid step label, with space replaced by dashes: "backend integration" will match ":chains: Backend integration tests"`,
 		}
 
 	case TaggedRelease:
@@ -205,6 +205,8 @@ type RunTypeMatcher struct {
 	// BranchArgumentRequired indicates the path segment following the branch prefix match is
 	// expected to be an argument (does not work in conjunction with BranchExact)
 	BranchArgumentRequired bool
+	// BranchArgumentDescription indicates what kind of argument must be given.
+	BranchArgumentDescription string
 
 	// TagPrefix matches tags that begin with this value.
 	TagPrefix string

--- a/dev/ci/runtype/runtype.go
+++ b/dev/ci/runtype/runtype.go
@@ -15,6 +15,8 @@ const (
 
 	PullRequest RunType = iota // pull request build
 
+	Targeted
+
 	// Nightly builds - must be first because they take precedence
 
 	ReleaseNightly // release branch nightly healthcheck builds
@@ -92,6 +94,12 @@ func (t RunType) Matcher() *RunTypeMatcher {
 			},
 		}
 
+	case Targeted:
+		return &RunTypeMatcher{
+			Branch:       `^targeted/[^/]+/.+$`,
+			BranchRegexp: true,
+		}
+
 	case TaggedRelease:
 		return &RunTypeMatcher{
 			TagPrefix: "v",
@@ -149,6 +157,9 @@ func (t RunType) String() string {
 	switch t {
 	case PullRequest:
 		return "Pull request"
+
+	case Targeted:
+		return "Targeted"
 
 	case ReleaseNightly:
 		return "Release branch nightly healthcheck build"

--- a/dev/sg/sg_ci.go
+++ b/dev/sg/sg_ci.go
@@ -281,6 +281,9 @@ Learn more about pipeline run types in https://docs.sourcegraph.com/dev/backgrou
 							branchArg = args[1]
 						} else {
 							stdout.Out.Write("This run type requires a branch path argument.")
+							if m.BranchArgumentDescription != "" {
+								stdout.Out.Writef("Argument: %s", m.BranchArgumentDescription)
+							}
 							branchArg, err = open.Prompt("Enter your argument input:")
 							if err != nil {
 								return err

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -304,7 +304,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 	}
 
 	if c.RunType.Is(runtype.Targeted) {
-		r := regexp.MustCompile(`^targeted/([^/]+)/.+$`)
+		r := regexp.MustCompile(runtype.Targeted.Matcher().Branch)
 		matches := r.FindStringSubmatch(c.Branch)
 		if len(matches) != 2 {
 			return nil, fmt.Errorf("targeted RunType: invalid branch name")

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -304,7 +304,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 	}
 
 	if c.RunType.Is(runtype.Targeted) {
-		r := regexp.MustCompile(runtype.Targeted.Matcher().Branch)
+		r := regexp.MustCompile(fmt.Sprintf(`^%s/([^/]+)/.+$`, runtype.Targeted.Matcher().Branch))
 		matches := r.FindStringSubmatch(c.Branch)
 		if len(matches) != 2 {
 			return nil, fmt.Errorf("targeted RunType: invalid branch name")

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -304,7 +304,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 	}
 
 	if c.RunType.Is(runtype.Targeted) {
-		r := regexp.MustCompile(fmt.Sprintf(`^%s/([^/]+)/.+$`, runtype.Targeted.Matcher().Branch))
+		r := regexp.MustCompile(fmt.Sprintf(`^%s([^/]+)/.+$`, runtype.Targeted.Matcher().Branch))
 		matches := r.FindStringSubmatch(c.Branch)
 		if len(matches) != 2 {
 			return nil, fmt.Errorf("targeted RunType: invalid branch name")

--- a/enterprise/dev/ci/internal/ci/pipeline_test.go
+++ b/enterprise/dev/ci/internal/ci/pipeline_test.go
@@ -1,0 +1,117 @@
+package ci_test
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/dev/ci/runtype"
+	"github.com/sourcegraph/sourcegraph/dev/sg/root"
+	bk "github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/buildkite"
+	"github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/ci"
+)
+
+func chdirToRoot(t *testing.T) {
+	path, err := root.RepositoryRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.Chdir(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGeneratePipeline(t *testing.T) {
+	// The pipeline is very cwd dependent, so we position ourselves at the repository root.
+	path, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	chdirToRoot(t)
+	// Restore the cwd this test.
+	defer func() { _ = os.Chdir(path) }()
+
+	t.Run("TargetedRunType", func(t *testing.T) {
+		tests := []struct {
+			branch    string
+			wantSteps []string
+			wantErr   bool
+		}{
+			{
+				branch:  "targeted/nothing-existing/test",
+				wantErr: true,
+			},
+			{
+				branch:  "targeted/puppeteer/test", // ambiguous
+				wantErr: true,
+			},
+			{
+				branch:  "targeted/backend-integration/test",
+				wantErr: false,
+				wantSteps: []string{
+					":chains: Backend integration tests",
+					":docker: :construction: Build server",
+				},
+			},
+			{
+				branch:  "targeted/build-server/test",
+				wantErr: false,
+				wantSteps: []string{
+					":docker: :construction: Build server",
+				},
+			},
+			{
+				branch:  "targeted/puppeteer-tests-finalize/test",
+				wantErr: false,
+				wantSteps: []string{
+					":puppeteer::electric_plug: Puppeteer tests prep",
+					":puppeteer::electric_plug: Puppeteer tests chunk #1",
+					":puppeteer::electric_plug: Puppeteer tests chunk #2",
+					":puppeteer::electric_plug: Puppeteer tests chunk #3",
+					":puppeteer::electric_plug: Puppeteer tests chunk #4",
+					":puppeteer::electric_plug: Puppeteer tests chunk #5",
+					":puppeteer::electric_plug: Puppeteer tests chunk #6",
+					":puppeteer::electric_plug: Puppeteer tests chunk #7",
+					":puppeteer::electric_plug: Puppeteer tests chunk #8",
+					":puppeteer::electric_plug: Puppeteer tests chunk #9",
+					":puppeteer::electric_plug: Puppeteer tests finalize",
+				},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.branch, func(t *testing.T) {
+				c := ci.NewConfig(time.Now())
+				c.Branch = test.branch
+				c.RunType = runtype.Targeted
+
+				p, err := ci.GeneratePipeline(c)
+				if !test.wantErr {
+					if err != nil {
+						t.Fatalf("want err to be nil, but got %q", err)
+					}
+				} else {
+					if err == nil {
+						t.Fatalf("want err to not be nil but got nil")
+					}
+					return
+				}
+
+				var found int
+				for _, s := range p.Steps {
+					if step, ok := s.(*bk.Step); ok {
+						for _, wantStep := range test.wantSteps {
+							if step.Label == wantStep {
+								found++
+							}
+						}
+					}
+				}
+				if found != len(test.wantSteps) {
+					t.Fatalf("want %d steps, but found %d matches", len(test.wantSteps), found)
+				}
+			})
+		}
+	})
+}


### PR DESCRIPTION
I had this at the back of mind for a while, I quickly hacked it in between things. 

---

It's rather inconvenient when debugging a specific step to generate irrelevant steps which are consuming jobs for nothing.

This PR adds a new run type, `targeted` which generates a full pipeline then peels off any step that isn't a dependency (direct or indirect) of the targeted step. 

The targeting works by seeking a substring match in the step labels, with dashes replacing spaces. Any ambiguity will be refused by the pipeline generator and will lead to an error. 

I have also added an optional argument description to the matcher, to make it clearer for the users how to use the targeted builds. 

❓ The prefix `targeted` may not be the most useful one, don't hesitate to suggest a better one. 


## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

1. Local runs
1. Unit tests
3. Triggered builds: 
    - [sg ci build targeted: `build server`](https://buildkite.com/sourcegraph/sourcegraph/builds/131612#96a94dd8-0d33-42c2-8474-508f661f75c9)
    - [sg ci build targeted `puppeteer-tests-finalize`](https://buildkite.com/sourcegraph/sourcegraph/builds/131623)
    - [sg ci build targeted `puppeteer`](https://buildkite.com/sourcegraph/sourcegraph/builds/131617) ambiguous, expected to fail. 
