### PR TITLE
insights: Add Total Insights to critical telemetry

### DIFF
--- a/client/web/src/site-admin/SiteAdminPingsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminPingsPage.tsx
@@ -98,6 +98,7 @@ export const SiteAdminPingsPage: React.FunctionComponent<Props> = props => {
                 <li>License key associated with your Sourcegraph subscription</li>
                 <li>Aggregate count of current monthly users</li>
                 <li>Total count of existing user accounts</li>
+                <li>Code Insights: total count of insights</li>
             </ul>
             <h3>Other telemetry</h3>
             <p>

--- a/cmd/frontend/internal/app/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/updatecheck/handler.go
@@ -199,6 +199,7 @@ type pingRequest struct {
 	HasRepos            bool            `json:"repos"`
 	EverSearched        bool            `json:"searched"`
 	EverFindRefs        bool            `json:"refs"`
+	TotalInsights       int32           `json:"totalInsights"`
 }
 
 type dependencyVersions struct {

--- a/doc/admin/pings.md
+++ b/doc/admin/pings.md
@@ -17,6 +17,7 @@ Critical telemetry includes only the high-level data below required for billing,
 - Aggregated repository statistics
   - Total size of git repositories stored in bytes
   - Total number of lines of code stored in text search index
+- Code Insights: total count of insights
 
 ## Other telemetry
 


### PR DESCRIPTION
Closes: https://github.com/sourcegraph/sourcegraph/issues/31078

## Description

This adds a new field into critical telemetry for `totalInsights`.

The way I did this was to use the existing entry that we write into `event_logs` and calculate the information based on the stats we are already reporting on. Namely, summing over totals in: `CodeInsightsUsageStatistics.InsightTotalCounts.ViewCounts`. This seemed like a lightweight solution.

The other way I could have done this would be to write a separate entry into `event_logs` with just this total, and read from there. That might be more straight-forward, but would be more code and db calls and it didn't seem worth it in this case.

Let me know what you think!

## Test plan

I tested this locally by disabling non-critical telemetry and verifying that `totalInsights` showed up with the correct count. I then re-enabled non-critical telemetry and verified that the new `totalInsights` count showed up along with the rest of the non-critical insight telemetry data. 