### PR TITLE
tracking-issue: update roadmap docs, remove availability

### DIFF
--- a/.github/ISSUE_TEMPLATE/tracking_issue.md
+++ b/.github/ISSUE_TEMPLATE/tracking_issue.md
@@ -16,10 +16,6 @@ Summarize what the team wants to achieve this iteration.
 - How do we plan to solve those problems or gather that information?
 -->
 
-### Availability
-
-If you have planned unavailability this iteration (e.g., vacation), you can note that here.
-
 ### Tracked issues
 
 <!-- BEGIN WORK -->
@@ -31,7 +27,7 @@ If you have planned unavailability this iteration (e.g., vacation), you can note
 - 🐛 Bug
 - 🧶 Technical debt
 - 🎩 Quality of life
-- 🛠️ [Roadmap](https://docs.google.com/document/d/1cBsE9801DcBF9chZyMnxRdolqM_1c2pPyGQz15QAvYI/edit#heading=h.5nwl5fv52ess)
+- 🛠️ [Roadmap](https://handbook.sourcegraph.com/departments/product-engineering/process/planning-process#roadmap)
 - 🕵️ [Spike](https://en.wikipedia.org/wiki/Spike_(software_development))
 - 🔒 Security issue
 - 🙆 Stretch goal


### PR DESCRIPTION
I noticed that the tracking issue treats roadmap items with an emoji:

<img width="539" alt="image" src="https://user-images.githubusercontent.com/23356519/154125234-de5cac7a-fc34-48c1-9007-fef414b1f694.png">

This updates the link in the legend to point to what seems to be the latest and greatest docs (the existing link links to a deprecated document), and also removes `Availability` because anecdotally iteration tracking isn't done with the tracking issue nowadays. It can still be added manually by teams that want it

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

n/a just docs

