### PR TITLE
search: add JSON job printer

### DIFF
--- a/internal/search/job/printers_test.go
+++ b/internal/search/job/printers_test.go
@@ -5,6 +5,10 @@ import (
 	"testing"
 
 	"github.com/hexops/autogold"
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	"github.com/sourcegraph/sourcegraph/internal/search/run"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestSexp(t *testing.T) {
@@ -125,4 +129,329 @@ flowchart TB
 						NewAndJob(
 							NewNoopJob(),
 							NewNoopJob()))))))))
+}
+
+func TestPrettyJSON(t *testing.T) {
+	autogold.Want("big JSON summary", `
+{
+  "FILTER": {
+    "LIMIT": {
+      "TIMEOUT": {
+        "PARALLEL": [
+          {
+            "PRIORITY": {
+              "REQUIRED": {
+                "AND": [
+                  "NoopJob",
+                  "NoopJob"
+                ]
+              },
+              "OPTIONAL": {
+                "OR": [
+                  "NoopJob",
+                  "NoopJob"
+                ]
+              }
+            }
+          },
+          {
+            "AND": [
+              "NoopJob",
+              "NoopJob"
+            ]
+          }
+        ]
+      },
+      "value": "50ms"
+    },
+    "value": 100
+  },
+  "value": "SubRepoPermissions"
+}`).Equal(t, fmt.Sprintf("\n%s", PrettyJSON(
+		NewFilterJob(
+			NewLimitJob(
+				100,
+				NewTimeoutJob(
+					50*1_000_000,
+					NewParallelJob(
+						NewPriorityJob(
+							NewAndJob(
+								NewNoopJob(),
+								NewNoopJob()),
+							NewOrJob(
+								NewNoopJob(),
+								NewNoopJob()),
+						),
+						NewAndJob(
+							NewNoopJob(),
+							NewNoopJob()))))))))
+	test := func(input string) string {
+		q, _ := query.ParseLiteral(input)
+		args := &Args{
+			SearchInputs: &run.SearchInputs{
+				UserSettings: &schema.Settings{},
+			},
+			Protocol: search.Streaming,
+		}
+		j, _ := ToSearchJob(args, q)
+		return PrettyJSONVerbose(j)
+	}
+
+	autogold.Want("full fidelity JSON output", `
+{
+  "PARALLEL": [
+    {
+      "RepoSubsetText": {
+        "ZoektArgs": {
+          "Query": {
+            "Pattern": "bar",
+            "CaseSensitive": false,
+            "FileName": false,
+            "Content": false
+          },
+          "Typ": "text",
+          "FileMatchLimit": 500,
+          "Select": [],
+          "Zoekt": null
+        },
+        "SearcherArgs": {
+          "SearcherURLs": null,
+          "PatternInfo": {
+            "Pattern": "bar",
+            "IsNegated": false,
+            "IsRegExp": true,
+            "IsStructuralPat": false,
+            "CombyRule": "",
+            "IsWordMatch": false,
+            "IsCaseSensitive": false,
+            "FileMatchLimit": 500,
+            "Index": "yes",
+            "Select": [],
+            "IncludePatterns": null,
+            "ExcludePattern": "",
+            "FilePatternsReposMustInclude": null,
+            "FilePatternsReposMustExclude": null,
+            "PathPatternsAreCaseSensitive": false,
+            "PatternMatchesContent": true,
+            "PatternMatchesPath": true,
+            "Languages": null
+          },
+          "UseFullDeadline": true
+        },
+        "NotSearcherOnly": true,
+        "UseIndex": "yes",
+        "ContainsRefGlobs": false,
+        "RepoOpts": {
+          "RepoFilters": [
+            "foo"
+          ],
+          "MinusRepoFilters": null,
+          "CaseSensitiveRepoFilters": false,
+          "SearchContextSpec": "",
+          "UserSettings": {},
+          "NoForks": true,
+          "OnlyForks": false,
+          "NoArchived": true,
+          "OnlyArchived": false,
+          "CommitAfter": "",
+          "Visibility": "Any",
+          "Limit": 0,
+          "Cursors": null,
+          "Query": [
+            {
+              "Kind": 1,
+              "Operands": [
+                {
+                  "field": "repo",
+                  "value": "foo",
+                  "negated": false
+                },
+                {
+                  "value": "bar",
+                  "negated": false
+                }
+              ],
+              "Annotation": {
+                "labels": 0,
+                "range": {
+                  "start": {
+                    "line": 0,
+                    "column": 0
+                  },
+                  "end": {
+                    "line": 0,
+                    "column": 0
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "Repo": {
+        "Args": {
+          "PatternInfo": {
+            "Pattern": "bar",
+            "IsNegated": false,
+            "IsRegExp": true,
+            "IsStructuralPat": false,
+            "CombyRule": "",
+            "IsWordMatch": false,
+            "IsCaseSensitive": false,
+            "FileMatchLimit": 500,
+            "Index": "yes",
+            "Select": [],
+            "IncludePatterns": null,
+            "ExcludePattern": "",
+            "FilePatternsReposMustInclude": null,
+            "FilePatternsReposMustExclude": null,
+            "PathPatternsAreCaseSensitive": false,
+            "PatternMatchesContent": true,
+            "PatternMatchesPath": true,
+            "Languages": null
+          },
+          "RepoOptions": {
+            "RepoFilters": [
+              "foo",
+              "bar"
+            ],
+            "MinusRepoFilters": null,
+            "CaseSensitiveRepoFilters": false,
+            "SearchContextSpec": "",
+            "UserSettings": {},
+            "NoForks": true,
+            "OnlyForks": false,
+            "NoArchived": true,
+            "OnlyArchived": false,
+            "CommitAfter": "",
+            "Visibility": "Any",
+            "Limit": 0,
+            "Cursors": null,
+            "Query": [
+              {
+                "Kind": 1,
+                "Operands": [
+                  {
+                    "field": "repo",
+                    "value": "foo",
+                    "negated": false
+                  },
+                  {
+                    "value": "bar",
+                    "negated": false
+                  }
+                ],
+                "Annotation": {
+                  "labels": 0,
+                  "range": {
+                    "start": {
+                      "line": 0,
+                      "column": 0
+                    },
+                    "end": {
+                      "line": 0,
+                      "column": 0
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "Features": {
+            "ContentBasedLangFilters": false
+          },
+          "ResultTypes": 13,
+          "Timeout": 20000000000,
+          "Repos": null,
+          "UserPrivateRepos": null,
+          "Mode": 0,
+          "Query": [
+            {
+              "Kind": 1,
+              "Operands": [
+                {
+                  "field": "repo",
+                  "value": "foo",
+                  "negated": false
+                },
+                {
+                  "value": "bar",
+                  "negated": false
+                }
+              ],
+              "Annotation": {
+                "labels": 0,
+                "range": {
+                  "start": {
+                    "line": 0,
+                    "column": 0
+                  },
+                  "end": {
+                    "line": 0,
+                    "column": 0
+                  }
+                }
+              }
+            }
+          ],
+          "UseFullDeadline": true,
+          "Zoekt": null,
+          "SearcherURLs": null
+        }
+      }
+    },
+    {
+      "ComputeExcludedRepos": {
+        "Options": {
+          "RepoFilters": [
+            "foo"
+          ],
+          "MinusRepoFilters": null,
+          "CaseSensitiveRepoFilters": false,
+          "SearchContextSpec": "",
+          "UserSettings": {},
+          "NoForks": true,
+          "OnlyForks": false,
+          "NoArchived": true,
+          "OnlyArchived": false,
+          "CommitAfter": "",
+          "Visibility": "Any",
+          "Limit": 0,
+          "Cursors": null,
+          "Query": [
+            {
+              "Kind": 1,
+              "Operands": [
+                {
+                  "field": "repo",
+                  "value": "foo",
+                  "negated": false
+                },
+                {
+                  "value": "bar",
+                  "negated": false
+                }
+              ],
+              "Annotation": {
+                "labels": 0,
+                "range": {
+                  "start": {
+                    "line": 0,
+                    "column": 0
+                  },
+                  "end": {
+                    "line": 0,
+                    "column": 0
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}`).Equal(t, fmt.Sprintf("\n%s", test("repo:foo bar")))
 }


### PR DESCRIPTION
Adds a JSON job printer to capture full fidelity of values.

I will probably tweak the output of leaf values a bit and hook it up to graph output. As a last step I'll expose this to the GQL [`parseSearchQuery`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/graphqlbackend/schema.graphql?L1335&subtree=true) endpoint so it's easy to generate client side.

## Test plan
Unit tests

