### PR TITLE
Code Insights: Add new tag for the code insights nav bar item

### DIFF
--- a/client/shared/src/settings/temporary/TemporarySettings.ts
+++ b/client/shared/src/settings/temporary/TemporarySettings.ts
@@ -12,6 +12,7 @@ export interface TemporarySettingsSchema {
     'search.onboarding.tourCancelled': boolean
     'search.contexts.ctaDismissed': boolean
     'insights.freeGaAccepted': boolean
+    'insights.wasMainPageOpen': boolean
     'npsSurvey.hasTemporarilyDismissed': boolean
     'npsSurvey.hasPermanentlyDismissed': boolean
     'user.lastDayActive': string | null

--- a/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
+++ b/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
@@ -1,8 +1,9 @@
 import PlusIcon from 'mdi-react/PlusIcon'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { matchPath, useHistory } from 'react-router'
 import { useLocation } from 'react-router-dom'
 
+import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { Button, Link, PageHeader, Tabs, TabList, Tab } from '@sourcegraph/wildcard'
@@ -48,6 +49,14 @@ export const CodeInsightsRootPage: React.FunctionComponent<CodeInsightsRootPageP
         matchPath<{ dashboardId?: string }>(location.pathname, {
             path: `/insights${CodeInsightsRootPageURLPaths.CodeInsights}`,
         }) ?? {}
+
+    const [hasInsightPageBeenViewed, markMainPageAsViewed] = useTemporarySetting('insights.wasMainPageOpen', false)
+
+    useEffect(() => {
+        if (hasInsightPageBeenViewed === false) {
+            markMainPageAsViewed(true)
+        }
+    }, [hasInsightPageBeenViewed, markMainPageAsViewed])
 
     const dashboardId = params?.dashboardId ?? ALL_INSIGHTS_DASHBOARD_ID
     const queryParameterDashboardId = query.get('dashboardId') ?? ALL_INSIGHTS_DASHBOARD_ID

--- a/client/web/src/integration/insights/utils/override-insights-graphql.ts
+++ b/client/web/src/integration/insights/utils/override-insights-graphql.ts
@@ -58,6 +58,7 @@ export function overrideGraphQLExtensions(props: OverrideGraphQLExtensionsProps)
                     'user.lastDayActive': new Date().toDateString(),
                     'search.usedNonGlobalContext': true,
                     'insights.freeGaAccepted': true,
+                    'insights.wasMainPageOpen': true,
                 }),
             },
         }),

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -23,6 +23,7 @@ import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import { getGlobalSearchContextFilter } from '@sourcegraph/shared/src/search/query/query'
 import { omitFilter } from '@sourcegraph/shared/src/search/query/transformer'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { buildGetStartedURL } from '@sourcegraph/shared/src/util/url'
@@ -34,6 +35,7 @@ import {
     FeedbackPrompt,
     ButtonLink,
     PopoverTrigger,
+    Badge,
 } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'
@@ -188,6 +190,7 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
     // CodeInsightsEnabled props controls insights appearance over OSS and Enterprise version
     // isCodeInsightsEnabled selector controls appearance based on user settings flags
     const codeInsights = props.authenticatedUser && codeInsightsEnabled && isCodeInsightsEnabled(props.settingsCascade)
+    const [hasInsightPageBeenViewed] = useTemporarySetting('insights.wasMainPageOpen', false)
 
     const searchNavBar = (
         <SearchNavbarItem
@@ -246,7 +249,14 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
                     {(props.batchChangesEnabled || isSourcegraphDotCom) && <BatchChangesNavItem />}
                     {codeInsights && (
                         <NavItem icon={BarChartIcon}>
-                            <NavLink to="/insights">Insights</NavLink>
+                            <NavLink to="/insights">
+                                Insights{' '}
+                                {hasInsightPageBeenViewed === false && (
+                                    <Badge variant="info" className="ml-1">
+                                        New
+                                    </Badge>
+                                )}
+                            </NavLink>
                         </NavItem>
                     )}
                     <NavItem icon={PuzzleOutlineIcon}>


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/31213

## Test plan 

- Run source graph frontend (sg start web-standalone)
- See that on the main page you can see "New" right next to the Insight navbar item
- Visit some insight pages like creation UI (but not the main Insight page dashboard page) 
- See that you still have "New" tag
- Click on the Insight navbar item 
- See that "New" tag has dissapeared 
- Refresh the page, you shouldn't see "New" tag anymore