### PR TITLE
Code Insights: Support repositories in the live preview button

### DIFF
--- a/client/web/src/enterprise/insights/components/form/query-input/InsightQueryInput.tsx
+++ b/client/web/src/enterprise/insights/components/form/query-input/InsightQueryInput.tsx
@@ -7,19 +7,27 @@ import type { MonacoFieldProps } from '../monaco-field'
 import * as Monaco from '../monaco-field'
 
 import styles from './InsightQueryInput.module.scss'
+import { generateRepoFiltersQuery } from './utils/generate-repo-filters-query'
 
 export interface InsightQueryInputProps extends MonacoFieldProps {
     patternType: SearchPatternType
+    repositories?: string
 }
 
 export const InsightQueryInput = forwardRef<HTMLInputElement, InsightQueryInputProps>((props, reference) => {
-    const { children, patternType } = props
+    const { children, patternType, repositories = '', ...otherProps } = props
+    const previewQuery = `${generateRepoFiltersQuery(repositories)} ${props.value}`.trim()
 
     return (
         <div className={styles.root}>
             {children ? (
                 <Monaco.Root className={classNames(props.className, styles.inputWrapper)}>
-                    <Monaco.Field {...props} ref={reference} className={props.className} />
+                    <Monaco.Field
+                        {...otherProps}
+                        patternType={patternType}
+                        ref={reference}
+                        className={props.className}
+                    />
 
                     {children}
                 </Monaco.Root>
@@ -27,7 +35,7 @@ export const InsightQueryInput = forwardRef<HTMLInputElement, InsightQueryInputP
                 <Monaco.Field {...props} ref={reference} className={props.className} />
             )}
 
-            <Monaco.PreviewLink query={props.value} patternType={patternType} className={styles.previewButton} />
+            <Monaco.PreviewLink query={previewQuery} patternType={patternType} className={styles.previewButton} />
         </div>
     )
 })

--- a/client/web/src/enterprise/insights/components/form/query-input/utils/generate-repo-filters-query.ts
+++ b/client/web/src/enterprise/insights/components/form/query-input/utils/generate-repo-filters-query.ts
@@ -2,7 +2,7 @@ import escapeRegExp from 'lodash/escapeRegExp'
 
 import { getSanitizedRepositories } from '../../../creation-ui-kit'
 
-export const generateRepoFiltersQuery = (repositoriesString: string) => {
+export const generateRepoFiltersQuery = (repositoriesString: string): string => {
     const repositories = getSanitizedRepositories(repositoriesString)
 
     if (repositories.length > 0) {

--- a/client/web/src/enterprise/insights/components/form/query-input/utils/generate-repo-filters-query.ts
+++ b/client/web/src/enterprise/insights/components/form/query-input/utils/generate-repo-filters-query.ts
@@ -1,0 +1,13 @@
+import escapeRegExp from 'lodash/escapeRegExp'
+
+import { getSanitizedRepositories } from '../../../creation-ui-kit'
+
+export const generateRepoFiltersQuery = (repositoriesString: string) => {
+    const repositories = getSanitizedRepositories(repositoriesString)
+
+    if (repositories.length > 0) {
+        return `repo:^(${repositories.map(escapeRegExp).join('|')})$`
+    }
+
+    return ''
+}

--- a/client/web/src/enterprise/insights/pages/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
+++ b/client/web/src/enterprise/insights/pages/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
@@ -85,6 +85,7 @@ export const DynamicCodeInsightExample: React.FunctionComponent<DynamicCodeInsig
                     title="Data series search query"
                     required={true}
                     as={InsightQueryInput}
+                    repositories={repositories.input.value}
                     patternType={getQueryPatternTypeFilter(query.input.value)}
                     placeholder="Example: patternType:regexp const\s\w+:\s(React\.)?FunctionComponent"
                     valid={query.meta.touched && query.meta.validState === 'VALID'}

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/CaptureGoupCreationForm.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/CaptureGoupCreationForm.tsx
@@ -127,6 +127,7 @@ export const CaptureGroupCreationForm: React.FunctionComponent<CaptureGroupCreat
                         title="Search query"
                         required={true}
                         as={CaptureGroupQueryInput}
+                        repositories={repositories.input.value}
                         subtitle={<QueryFieldSubtitle className="mb-3" />}
                         placeholder="Example: file:\.pom$ <java\.version>(.*)</java\.version>"
                         valid={query.meta.touched && query.meta.validState === 'VALID'}

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/query-input/CaptureGroupQueryInput.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/query-input/CaptureGroupQueryInput.tsx
@@ -4,12 +4,16 @@ import React, { forwardRef } from 'react'
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { Button } from '@sourcegraph/wildcard'
 
-import type { MonacoFieldProps } from '../../../../../../components/form/monaco-field'
-import { InsightQueryInput } from '../../../../../../components/form/query-input/InsightQueryInput'
+import {
+    InsightQueryInput,
+    InsightQueryInputProps,
+} from '../../../../../../components/form/query-input/InsightQueryInput'
 
 import styles from './CaptureGroupQueryInput.module.scss'
 
-export const CaptureGroupQueryInput = forwardRef<HTMLInputElement, MonacoFieldProps>((props, reference) => (
+export interface CaptureGroupQueryInputProps extends Omit<InsightQueryInputProps, 'patternType'> {}
+
+export const CaptureGroupQueryInput = forwardRef<HTMLInputElement, CaptureGroupQueryInputProps>((props, reference) => (
     <InsightQueryInput {...props} ref={reference} patternType={SearchPatternType.regexp}>
         <Button variant="icon" className={styles.regexButton} disabled={true}>
             <RegexIcon

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
@@ -37,6 +37,9 @@ interface FormSeriesInputProps {
 
     series: EditableDataSeries
 
+    /** Code Insight repositories field string value - repo1, repo2, ... */
+    repositories: string
+
     /** Enable autofocus behavior of first input of form. */
     autofocus?: boolean
 
@@ -65,6 +68,7 @@ export const FormSeriesInput: React.FunctionComponent<FormSeriesInputProps> = pr
         className,
         cancel = false,
         autofocus = true,
+        repositories,
         onCancel = noop,
         onSubmit = noop,
         onChange = noop,
@@ -138,6 +142,7 @@ export const FormSeriesInput: React.FunctionComponent<FormSeriesInputProps> = pr
                 title="Search query"
                 required={true}
                 as={InsightQueryInput}
+                repositories={repositories}
                 patternType={getQueryPatternTypeFilter(queryField.input.value)}
                 placeholder="Example: patternType:regexp const\s\w+:\s(React\.)?FunctionComponent"
                 description={<QueryFieldDescription isSearchQueryDisabled={isSearchQueryDisabled} />}

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series/FormSeries.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series/FormSeries.tsx
@@ -29,6 +29,11 @@ export interface FormSeriesProps {
     series?: EditableDataSeries[]
 
     /**
+     * Code Insight repositories field string value - repo1, repo2, ...
+     */
+    repositories: string
+
+    /**
      * Live change series handler while user typing in active series form.
      * Used by consumers to get latest values from series inputs and pass
      * them tp live preview chart.
@@ -68,6 +73,7 @@ export const FormSeries: React.FunctionComponent<FormSeriesProps> = props => {
         series = [],
         isBackendInsightEdit,
         showValidationErrorsOnMount,
+        repositories,
         onEditSeriesRequest,
         onEditSeriesCommit,
         onEditSeriesCancel,
@@ -87,6 +93,7 @@ export const FormSeries: React.FunctionComponent<FormSeriesProps> = props => {
                         index={index + 1}
                         cancel={series.length > 1}
                         autofocus={series.length > 1}
+                        repositories={repositories}
                         onSubmit={onEditSeriesCommit}
                         onCancel={() => onEditSeriesCancel(line.id)}
                         className={classNames('p-3', styles.formSeriesItem)}

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
@@ -163,6 +163,7 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
             >
                 <FormSeries
                     series={series.input.value}
+                    repositories={repositories.input.value}
                     isBackendInsightEdit={isGqlBackend ? false : isEditMode && allReposMode.input.value}
                     showValidationErrorsOnMount={submitted}
                     onLiveChange={onSeriesLiveChange}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/30945

## Background
This PR simply adds serialized repositories query string for the live preview series button. 

## Test Plan 
- Visit search based creation UI 
- Fill out repositories, series name, series query fields
- Hit the live preview series button 
- Check that repositories from the repositories field are presented in the search query on the search page

