### PR TITLE
Gitlab project not found: return a ProjectNotFoundError 

### DIFF
--- a/internal/extsvc/gitlab/projects.go
+++ b/internal/extsvc/gitlab/projects.go
@@ -206,6 +206,9 @@ func (c *Client) getProjectFromAPI(ctx context.Context, id int, pathWithNamespac
 		return nil, err
 	}
 	_, _, err = c.do(ctx, req, &proj)
+	if IsNotFound(err) {
+		err = &ProjectNotFoundError{Name: pathWithNamespace}
+	}
 	return proj, err
 }
 
@@ -258,8 +261,7 @@ func (c *Client) ForkProject(ctx context.Context, project *Project, namespace *s
 	fork, err := c.getForkedProject(ctx, project, resolved)
 	if err != nil {
 		// An error that _isn't_ a not found error needs to be reported.
-		httpErr := HTTPError{}
-		if !(errors.As(err, &httpErr) && httpErr.Code() == http.StatusNotFound) {
+		if !IsNotFound(err) {
 			return nil, errors.Wrap(err, "checking for previously forked project")
 		}
 	} else if err == nil {

--- a/internal/extsvc/gitlab/projects_test.go
+++ b/internal/extsvc/gitlab/projects_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
 )
 
 // TestClient_GetProject tests the behavior of GetProject.
@@ -97,6 +99,9 @@ func TestClient_GetProject_nonexistent(t *testing.T) {
 	proj, err := c.GetProject(context.Background(), GetProjectOp{PathWithNamespace: "doesnt/exist"})
 	if !IsNotFound(err) {
 		t.Errorf("got err == %v, want IsNotFound(err) == true", err)
+	}
+	if !errcode.IsNotFound(err) {
+		t.Errorf("expected a not found error")
 	}
 	if proj != nil {
 		t.Error("proj != nil")

--- a/internal/repos/gitlab_test.go
+++ b/internal/repos/gitlab_test.go
@@ -77,7 +77,7 @@ func TestGitLabSource_GetRepo(t *testing.T) {
 		{
 			name:                 "not found",
 			projectWithNamespace: "foobarfoobarfoobar/please-let-this-not-exist",
-			err:                  `unexpected response from GitLab API (https://gitlab.com/api/v4/projects/foobarfoobarfoobar%2Fplease-let-this-not-exist): HTTP error status 404`,
+			err:                  "GitLab project \"foobarfoobarfoobar/please-let-this-not-exist\" not found",
 		},
 		{
 			name:                 "found",


### PR DESCRIPTION
Context: 
- We have a background task in Cloud that iterates over all repos associated w/ a cloud_default external service (i.e. only synced on demand) and a non-empty `last_error` field and calls `syncer.SyncRepo()` for each of these repos. That `SyncRepo` function checks [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/repos/syncer.go?L265) if the error returned is a particular type of error or not. Currently none of the errors returned from Gitlab match that type, so this code updates that code to return the correct error. 
- I personally prefer this method (returning the `ProjectNotFoundError` rather than an `HTTPError`) because it's what we do with Github and it seems way cleaner. If others are worried about making this change to the error being returned, there is the possibility of handling an http error returned by `RepoStore.GetByName` in the syncer instead. I just personally prefer to keep consistency across different sources.



## Test plan

Updated/added unit tests to reflect this behavior. Will also test once more in my local deployment before merging.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


