### PR TITLE
Insights/critical insights telemetry

### DIFF
--- a/client/web/src/site-admin/SiteAdminPingsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminPingsPage.tsx
@@ -98,6 +98,7 @@ export const SiteAdminPingsPage: React.FunctionComponent<Props> = props => {
                 <li>License key associated with your Sourcegraph subscription</li>
                 <li>Aggregate count of current monthly users</li>
                 <li>Total count of existing user accounts</li>
+                <li>Code Insights: total count of insights</li>
             </ul>
             <h3>Other telemetry</h3>
             <p>

--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -226,7 +226,7 @@ func getAndMarshalExtensionsUsageStatisticsJSON(ctx context.Context, db database
 	return json.Marshal(extensionsUsage)
 }
 
-func getAndMarshalCodeInsightsUsageJSON(ctx context.Context, db database.DB) (message json.RawMessage, err error) {
+func getAndMarshalCodeInsightsUsageJSON(ctx context.Context, db database.DB) (_ json.RawMessage, err error) {
 	defer recordOperation("getAndMarshalCodeInsightsUsageJSON")
 
 	codeInsightsUsage, err := usagestats.GetCodeInsightsUsageStatistics(ctx, db)
@@ -234,11 +234,10 @@ func getAndMarshalCodeInsightsUsageJSON(ctx context.Context, db database.DB) (me
 		return nil, err
 	}
 
-	message, err = json.Marshal(codeInsightsUsage)
-	return
+	return json.Marshal(codeInsightsUsage)
 }
 
-func getAndMarshalCodeInsightsCriticalTelemetryJSON(ctx context.Context, db database.DB) (message json.RawMessage, err error) {
+func getAndMarshalCodeInsightsCriticalTelemetryJSON(ctx context.Context, db database.DB) (_ json.RawMessage, err error) {
 	defer recordOperation("getAndMarshalCodeInsightsUsageJSON")
 
 	insightsCriticalTelemetry, err := usagestats.GetCodeInsightsCriticalTelemetry(ctx, db)
@@ -246,8 +245,7 @@ func getAndMarshalCodeInsightsCriticalTelemetryJSON(ctx context.Context, db data
 		return nil, err
 	}
 
-	message, err = json.Marshal(insightsCriticalTelemetry)
-	return
+	return json.Marshal(insightsCriticalTelemetry)
 }
 
 func getAndMarshalCodeMonitoringUsageJSON(ctx context.Context, db database.DB) (_ json.RawMessage, err error) {

--- a/cmd/frontend/internal/app/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/updatecheck/handler.go
@@ -179,26 +179,27 @@ type pingRequest struct {
 	Activity             json.RawMessage `json:"act"`
 	BatchChangesUsage    json.RawMessage `json:"batchChangesUsage"`
 	// AutomationUsage (campaigns) is deprecated, but here so we can receive pings from older instances
-	AutomationUsage     json.RawMessage `json:"automationUsage"`
-	GrowthStatistics    json.RawMessage `json:"growthStatistics"`
-	SavedSearches       json.RawMessage `json:"savedSearches"`
-	HomepagePanels      json.RawMessage `json:"homepagePanels"`
-	SearchOnboarding    json.RawMessage `json:"searchOnboarding"`
-	Repositories        json.RawMessage `json:"repositories"`
-	RetentionStatistics json.RawMessage `json:"retentionStatistics"`
-	CodeIntelUsage      json.RawMessage `json:"codeIntelUsage"`
-	NewCodeIntelUsage   json.RawMessage `json:"newCodeIntelUsage"`
-	SearchUsage         json.RawMessage `json:"searchUsage"`
-	ExtensionsUsage     json.RawMessage `json:"extensionsUsage"`
-	CodeInsightsUsage   json.RawMessage `json:"codeInsightsUsage"`
-	CodeMonitoringUsage json.RawMessage `json:"codeMonitoringUsage"`
-	CodeHostVersions    json.RawMessage `json:"codeHostVersions"`
-	InitialAdminEmail   string          `json:"initAdmin"`
-	TosAccepted         bool            `json:"tosAccepted"`
-	TotalUsers          int32           `json:"totalUsers"`
-	HasRepos            bool            `json:"repos"`
-	EverSearched        bool            `json:"searched"`
-	EverFindRefs        bool            `json:"refs"`
+	AutomationUsage               json.RawMessage `json:"automationUsage"`
+	GrowthStatistics              json.RawMessage `json:"growthStatistics"`
+	SavedSearches                 json.RawMessage `json:"savedSearches"`
+	HomepagePanels                json.RawMessage `json:"homepagePanels"`
+	SearchOnboarding              json.RawMessage `json:"searchOnboarding"`
+	Repositories                  json.RawMessage `json:"repositories"`
+	RetentionStatistics           json.RawMessage `json:"retentionStatistics"`
+	CodeIntelUsage                json.RawMessage `json:"codeIntelUsage"`
+	NewCodeIntelUsage             json.RawMessage `json:"newCodeIntelUsage"`
+	SearchUsage                   json.RawMessage `json:"searchUsage"`
+	ExtensionsUsage               json.RawMessage `json:"extensionsUsage"`
+	CodeInsightsUsage             json.RawMessage `json:"codeInsightsUsage"`
+	CodeInsightsCriticalTelemetry json.RawMessage `json:"codeInsightsCriticalTelemetry"`
+	CodeMonitoringUsage           json.RawMessage `json:"codeMonitoringUsage"`
+	CodeHostVersions              json.RawMessage `json:"codeHostVersions"`
+	InitialAdminEmail             string          `json:"initAdmin"`
+	TosAccepted                   bool            `json:"tosAccepted"`
+	TotalUsers                    int32           `json:"totalUsers"`
+	HasRepos                      bool            `json:"repos"`
+	EverSearched                  bool            `json:"searched"`
+	EverFindRefs                  bool            `json:"refs"`
 }
 
 type dependencyVersions struct {

--- a/cmd/frontend/internal/app/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/updatecheck/handler.go
@@ -199,6 +199,7 @@ type pingRequest struct {
 	HasRepos            bool            `json:"repos"`
 	EverSearched        bool            `json:"searched"`
 	EverFindRefs        bool            `json:"refs"`
+	TotalInsights       int32           `json:"totalInsights"`
 }
 
 type dependencyVersions struct {

--- a/cmd/frontend/internal/app/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/updatecheck/handler.go
@@ -199,7 +199,6 @@ type pingRequest struct {
 	HasRepos            bool            `json:"repos"`
 	EverSearched        bool            `json:"searched"`
 	EverFindRefs        bool            `json:"refs"`
-	TotalInsights       int32           `json:"totalInsights"`
 }
 
 type dependencyVersions struct {

--- a/doc/admin/pings.md
+++ b/doc/admin/pings.md
@@ -17,6 +17,7 @@ Critical telemetry includes only the high-level data below required for billing,
 - Aggregated repository statistics
   - Total size of git repositories stored in bytes
   - Total number of lines of code stored in text search index
+- Code Insights: total count of insights
 
 ## Other telemetry
 

--- a/doc/admin/pings.md
+++ b/doc/admin/pings.md
@@ -17,7 +17,7 @@ Critical telemetry includes only the high-level data below required for billing,
 - Aggregated repository statistics
   - Total size of git repositories stored in bytes
   - Total number of lines of code stored in text search index
-- Code Insights: total count of insights (considered critical telemetry for licensing enforcement)
+- Code Insights: total count of insights 
 
 ## Other telemetry
 

--- a/doc/admin/pings.md
+++ b/doc/admin/pings.md
@@ -17,7 +17,7 @@ Critical telemetry includes only the high-level data below required for billing,
 - Aggregated repository statistics
   - Total size of git repositories stored in bytes
   - Total number of lines of code stored in text search index
-- Code Insights: total count of insights
+- Code Insights: total count of insights (considered critical telemetry for licensing enforcement)
 
 ## Other telemetry
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1128,6 +1128,11 @@ type CodeInsightsUsageStatistics struct {
 	InsightTimeIntervals           []InsightTimeIntervalPing
 	InsightOrgVisible              []OrgVisibleInsightPing
 	InsightTotalCounts             InsightTotalCounts
+	CriticalTelemetry              *CodeInsightsCriticalTelemetry
+}
+
+type CodeInsightsCriticalTelemetry struct {
+	TotalInsights int32
 }
 
 // Usage statistics for a type of code insight

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1128,7 +1128,6 @@ type CodeInsightsUsageStatistics struct {
 	InsightTimeIntervals           []InsightTimeIntervalPing
 	InsightOrgVisible              []OrgVisibleInsightPing
 	InsightTotalCounts             InsightTotalCounts
-	CriticalTelemetry              *CodeInsightsCriticalTelemetry
 }
 
 type CodeInsightsCriticalTelemetry struct {

--- a/internal/usagestats/code_insights.go
+++ b/internal/usagestats/code_insights.go
@@ -14,19 +14,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func GetCodeInsightsUsageStatistics(ctx context.Context, db database.DB, criticalOnly bool) (*types.CodeInsightsUsageStatistics, error) {
+func GetCodeInsightsUsageStatistics(ctx context.Context, db database.DB) (*types.CodeInsightsUsageStatistics, error) {
 	stats := types.CodeInsightsUsageStatistics{}
-
-	// --------------------- No pings go above this line ---------------------------
-	got, err := GetCodeInsightsCriticalTelemetry(ctx, db)
-	if err != nil {
-		return nil, err
-	}
-	stats.CriticalTelemetry = got
-	if criticalOnly {
-		// we are returning early to avoid populating any other fields
-		return &stats, nil
-	}
 
 	const platformQuery = `
 	SELECT

--- a/internal/usagestats/code_insights.go
+++ b/internal/usagestats/code_insights.go
@@ -14,8 +14,19 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func GetCodeInsightsUsageStatistics(ctx context.Context, db database.DB) (*types.CodeInsightsUsageStatistics, error) {
+func GetCodeInsightsUsageStatistics(ctx context.Context, db database.DB, criticalOnly bool) (*types.CodeInsightsUsageStatistics, error) {
 	stats := types.CodeInsightsUsageStatistics{}
+
+	// --------------------- No pings go above this line ---------------------------
+	got, err := GetCodeInsightsCriticalTelemetry(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	stats.CriticalTelemetry = got
+	if criticalOnly {
+		// we are returning early to avoid populating any other fields
+		return &stats, nil
+	}
 
 	const platformQuery = `
 	SELECT

--- a/internal/usagestats/code_insights_critical.go
+++ b/internal/usagestats/code_insights_critical.go
@@ -1,0 +1,33 @@
+package usagestats
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func GetCodeInsightsCriticalTelemetry(ctx context.Context, db database.DB) (_ *types.CodeInsightsCriticalTelemetry, err error) {
+	critical := &types.CodeInsightsCriticalTelemetry{}
+
+	totalCount, err := totalCountCritical(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	critical.TotalInsights = totalCount
+
+	return critical, nil
+}
+
+func totalCountCritical(ctx context.Context, db database.DB) (int32, error) {
+	counts, err := GetTotalInsightCounts(ctx, db)
+	if err != nil {
+		return 0, err
+	}
+
+	sum := 0
+	for _, count := range counts.ViewCounts {
+		sum += count.TotalCount
+	}
+	return int32(sum), nil
+}

--- a/internal/usagestats/code_insights_critical.go
+++ b/internal/usagestats/code_insights_critical.go
@@ -3,20 +3,21 @@ package usagestats
 import (
 	"context"
 
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 func GetCodeInsightsCriticalTelemetry(ctx context.Context, db database.DB) (_ *types.CodeInsightsCriticalTelemetry, err error) {
-	critical := &types.CodeInsightsCriticalTelemetry{}
+	telemetry := &types.CodeInsightsCriticalTelemetry{}
 
 	totalCount, err := totalCountCritical(ctx, db)
 	if err != nil {
 		return nil, err
 	}
-	critical.TotalInsights = totalCount
+	telemetry.TotalInsights = totalCount
 
-	return critical, nil
+	return telemetry, nil
 }
 
 func totalCountCritical(ctx context.Context, db database.DB) (int32, error) {


### PR DESCRIPTION
Implements [RFC 584](https://docs.google.com/document/d/1J-fnZzRtvcZ_NWweCZQ5ipDMh4NdgQ8rlxXsa8vHWlQ/edit#) to add the totalCount for Code Insights to critical pings. This will be used for licensing enforcement. This separates into a new object `codeInsightsCriticalTelemetry` to avoid any name collisions and add support for future changes to this license enforcement strategy.

[Schema PR](https://github.com/sourcegraph/analytics/pull/353)

## Test plan

Example json from running locally with only critical pings enabled:
``` json
{
    "u": 0,
    "act": {
        "DAUs": [],
        "MAUs": [
            {
                "StartTime": "2022-02-01T00:00:00Z",
                "UserCount": 2,
                "AnonymousUserCount": 1,
                "RegisteredUserCount": 1,
                "IntegrationUserCount": 0
            }
        ],
        "WAUs": []
    },
    "auth": null,
    "refs": false,
    "site": "f30d99cf-b64a-463b-9b65-d1eb5f6d9f80",
    "repos": false,
    "signup": false,
    "extsvcs": null,
    "version": "0.0.0+dev",
    "searched": false,
    "hasExtURL": false,
    "initAdmin": "dev@dev.dev.com",
    "deployType": "dev",
    "totalUsers": 2,
    "searchUsage": {},
    "tosAccepted": true,
    "repositories": {
        "GitDirBytes": 11431429029,
        "NewLinesCount": 2624871,
        "DefaultBranchNewLinesCount": 2624871,
        "OtherBranchesNewLinesCount": 0
    },
    "savedSearches": {},
    "codeIntelUsage": {},
    "homepagePanels": {},
    "automationUsage": null,
    "extensionsUsage": {},
    "codeHostVersions": null,
    "growthStatistics": {},
    "searchOnboarding": {},
    "batchChangesUsage": {},
    "codeInsightsUsage": {},
    "newCodeIntelUsage": {},
    "dependencyVersions": {
        "postgresVersion": "13.5",
        "redisCacheVersion": "6.2.5",
        "redisStoreVersion": "6.2.5"
    },
    "codeMonitoringUsage": {},
    "retentionStatistics": {},
    "codeInsightsCriticalTelemetry": {
        "TotalInsights": 94
    }
}
```
