### PR TITLE
Code Insights: use default values for insight templates

### DIFF
--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/capture-insigh-url-parsers/capture-insight-url-parsers.test.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/capture-insigh-url-parsers/capture-insight-url-parsers.test.ts
@@ -22,9 +22,6 @@ describe('encodeSearchInsightUrl', () => {
             title: 'Insight title',
             allRepos: true,
             groupSearchQuery: 'file:go\\.mod$ go\\s*(\\d\\.\\d+) patterntype:regexp',
-            step: 'days',
-            stepValue: '8',
-            dashboardReferenceCount: 0,
         })
     })
 })

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/capture-insigh-url-parsers/capture-insight-url-parsers.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/capture-insigh-url-parsers/capture-insight-url-parsers.ts
@@ -23,7 +23,7 @@ export function encodeCaptureInsightURL(values: Partial<CaptureInsightUrlValues>
     return parameters.toString()
 }
 
-export function decodeCaptureInsightURL(queryParameters: string): CaptureGroupFormFields | null {
+export function decodeCaptureInsightURL(queryParameters: string): Partial<CaptureGroupFormFields> | null {
     try {
         const searchParameter = new URLSearchParams(decodeURIComponent(queryParameters))
 
@@ -38,9 +38,6 @@ export function decodeCaptureInsightURL(queryParameters: string): CaptureGroupFo
                 repositories: repositories ?? '',
                 allRepos: !!allRepos,
                 groupSearchQuery: groupSearchQuery ?? '',
-                step: 'days',
-                stepValue: '8',
-                dashboardReferenceCount: 0,
             }
         }
 

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/utils/search-insight-url-parsers/search-insight-url-parsers.test.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/utils/search-insight-url-parsers/search-insight-url-parsers.test.ts
@@ -27,13 +27,9 @@ describe('decodeSearchInsightUrl', () => {
             title: 'Insight title',
             allRepos: true,
             series: [
-                { id: 1, edit: false, valid: false, name: 'series 1', query: 'test1', stroke: 'red' },
-                { id: 2, edit: false, valid: false, name: 'series 2', query: 'test2', stroke: 'blue' },
+                { id: 1, edit: false, valid: true, name: 'series 1', query: 'test1', stroke: 'red' },
+                { id: 2, edit: false, valid: true, name: 'series 2', query: 'test2', stroke: 'blue' },
             ],
-            step: 'days',
-            stepValue: '8',
-            visibility: '',
-            dashboardReferenceCount: 0,
         })
     })
 })
@@ -55,13 +51,9 @@ describe('encodeSearchInsightUrl', () => {
             title: 'Insight title',
             allRepos: true,
             series: [
-                { id: '1', edit: false, valid: false, name: 'series 1', query: 'test1', stroke: 'red' },
-                { id: '2', edit: false, valid: false, name: 'series 2', query: 'test2', stroke: 'blue' },
+                { id: '1', edit: false, valid: true, name: 'series 1', query: 'test1', stroke: 'red' },
+                { id: '2', edit: false, valid: true, name: 'series 2', query: 'test2', stroke: 'blue' },
             ],
-            step: 'days',
-            stepValue: '8',
-            visibility: '',
-            dashboardReferenceCount: 0,
         })
     })
 })

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/utils/search-insight-url-parsers/search-insight-url-parsers.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/utils/search-insight-url-parsers/search-insight-url-parsers.ts
@@ -2,14 +2,14 @@ import { SearchBasedInsightSeries } from '../../../../../../core/types'
 import { createDefaultEditSeries } from '../../components/search-insight-creation-content/hooks/use-editable-series'
 import { CreateInsightFormFields } from '../../types'
 
-export function decodeSearchInsightUrl(queryParameters: string): CreateInsightFormFields | null {
+export function decodeSearchInsightUrl(queryParameters: string): Partial<CreateInsightFormFields> | null {
     try {
         const searchParameter = new URLSearchParams(decodeURIComponent(queryParameters))
 
         const repositories = searchParameter.get('repositories')
         const title = searchParameter.get('title')
         const rawSeries = JSON.parse(searchParameter.get('series') ?? '[]') as SearchBasedInsightSeries[]
-        const editableSeries = rawSeries.map(series => createDefaultEditSeries({ ...series, edit: false }))
+        const editableSeries = rawSeries.map(series => createDefaultEditSeries({ ...series, edit: false, valid: true }))
         const allRepos = searchParameter.get('allRepos')
 
         if (repositories || title || editableSeries.length > 0 || allRepos) {
@@ -18,10 +18,6 @@ export function decodeSearchInsightUrl(queryParameters: string): CreateInsightFo
                 repositories: repositories ?? '',
                 allRepos: !!allRepos,
                 series: editableSeries,
-                visibility: '',
-                step: 'days',
-                stepValue: '8',
-                dashboardReferenceCount: 0,
             }
         }
 


### PR DESCRIPTION
Closes: https://github.com/sourcegraph/sourcegraph/issues/30947

## Test plan 
- Go to the get started page
- Click on the "use as template" link in the Insight Examples section 
- See that in the creation UI you have a default value for the time step - 2 months
- Click on the "use as template" link in the Templates section 
- See that in the creation UI you have a default value for the time step - 2 months

Bonus line: click  "use as template" and fill out the repositories field. You should see the live preview. Prior to this PR, the live preview chart ignores the templates series. This PR fixes this.