### PR TITLE
pr-auditor: change token, improve diagnostics and filtering

### DIFF
--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -15,5 +15,5 @@ jobs:
       - run: ./dev/pr-auditor/check-pr.sh
         env:
           GITHUB_EVENT_PATH: ${{ env.GITHUB_EVENT_PATH }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
           GITHUB_RUN_URL: https://github.com/sourcegraph/sourcegraph/actions/runs/${{ github.run_id }}

--- a/dev/pr-auditor/main.go
+++ b/dev/pr-auditor/main.go
@@ -49,11 +49,19 @@ func main() {
 	if err := json.Unmarshal(payloadData, &payload); err != nil {
 		log.Fatal("Unmarshal: ", err)
 	}
-	log.Printf("got event for pull request %s, full payload: %+v\n", payload.PullRequest.URL, payload)
+	log.Printf("handling event for pull request %s, payload: %+v\n", payload.PullRequest.URL, payload.Dump())
 
 	// Discard unwanted events
 	if payload.PullRequest.Base.Ref != "main" {
 		log.Printf("unknown pull request base %q - discarding\n", payload.PullRequest.Base.Ref)
+		return
+	}
+	if payload.PullRequest.Draft {
+		log.Printf("skipping event on draft PR")
+		return
+	}
+	if payload.Action == "closed" && !payload.PullRequest.Merged {
+		log.Println("ignoring closure of un-merged pull request")
 		return
 	}
 	if payload.Action == "edited" && payload.PullRequest.Merged {

--- a/dev/pr-auditor/webhook.go
+++ b/dev/pr-auditor/webhook.go
@@ -1,6 +1,9 @@
 package main
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // EventPayload describes the payload of the pull_request event we subscribe to:
 // https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
@@ -10,10 +13,16 @@ type EventPayload struct {
 	Repository  RepositoryPayload  `json:"repository"`
 }
 
+func (p EventPayload) Dump() string {
+	return fmt.Sprintf(`Action: %s, PullRequest: { Merged: %v, MergedBy: %+v, Head: %+v }, Repository: %s`,
+		p.Action, p.PullRequest.Merged, p.PullRequest.MergedBy, p.PullRequest.Head, p.Repository.FullName)
+}
+
 type PullRequestPayload struct {
 	Number int    `json:"number"`
 	Title  string `json:"title"`
 	Body   string `json:"body"`
+	Draft  bool   `json:"draft"`
 
 	ReviewComments int `json:"review_comments"`
 


### PR DESCRIPTION
Looking through https://github.com/sourcegraph/sourcegraph/actions/workflows/pr-auditor.yml?query=is%3Afailure for an initial round of fixes:

- Switch to token that should have access to open issues in another repo
- Improve readability of logs
- Improve filtering of events to handle

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

n/a
