### PR TITLE
Search jobs: convert `select` to a job

### DIFF
--- a/internal/search/job/printers.go
+++ b/internal/search/job/printers.go
@@ -119,6 +119,15 @@ func SexpFormat(job Job, sep, indent string) string {
 			writeSexp(j.child)
 			b.WriteString(")")
 			depth--
+		case *selectJob:
+			b.WriteString("(SELECT")
+			depth++
+			writeSep(b, sep, indent, depth)
+			b.WriteString(j.path.String())
+			writeSep(b, sep, indent, depth)
+			writeSexp(j.child)
+			b.WriteString(")")
+			depth--
 		default:
 			panic(fmt.Sprintf("unsupported job %T for SexpFormat printer", job))
 		}
@@ -257,6 +266,15 @@ func PrettyMermaid(job Job) string {
 			writeEdge(b, depth, srcId, id)
 			writeMermaid(j.child)
 			depth--
+		case *selectPath:
+			srcId := id
+			depth++
+			writeNode(b, depth, RoundedStyle, &id, "SELECT")
+			writeEdge(b, depth, srcId, id)
+			writeNode(b, depth, DefaultStyle, &id, j.path.String())
+			writeEdge(b, depth, srcId, id)
+			writeMermaid(j.child)
+			depth--
 		default:
 			panic(fmt.Sprintf("unsupported job %T for PrettyMermaid printer", job))
 		}
@@ -360,6 +378,14 @@ func toJSON(job Job, verbose bool) interface{} {
 			}{
 				Filter: emitJSON(j.child),
 				Value:  "SubRepoPermissions",
+			}
+		case *selectJob:
+			return struct {
+				Select interface{} `json:"SELECT"`
+				Value  string      `json:"value"`
+			}{
+				Select: emitJSON(j.child),
+				Value:  j.path.String(),
 			}
 
 		default:

--- a/internal/search/job/printers.go
+++ b/internal/search/job/printers.go
@@ -266,7 +266,7 @@ func PrettyMermaid(job Job) string {
 			writeEdge(b, depth, srcId, id)
 			writeMermaid(j.child)
 			depth--
-		case *selectPath:
+		case *selectJob:
 			srcId := id
 			depth++
 			writeNode(b, depth, RoundedStyle, &id, "SELECT")

--- a/internal/search/job/select.go
+++ b/internal/search/job/select.go
@@ -1,0 +1,30 @@
+package job
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/filter"
+	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+)
+
+// NewSelectJob creates a job that transforms streamed results with
+// the given filter.SelectPath.
+func NewSelectJob(path filter.SelectPath, child Job) Job {
+	return &selectJob{path: path, child: child}
+}
+
+type selectJob struct {
+	path  filter.SelectPath
+	child Job
+}
+
+func (j *selectJob) Run(ctx context.Context, db database.DB, stream streaming.Sender) (*search.Alert, error) {
+	selectingStream := streaming.WithSelect(stream, j.path)
+	return j.child.Run(ctx, db, selectingStream)
+}
+
+func (j *selectJob) Name() string {
+	return "Select"
+}


### PR DESCRIPTION
This converts our the logic for our `select:` filter into a simple
wrapping job. One more step towards `resultsRecursive` becoming
a job.



## Test plan

Semantics-preserving change that is already covered by existing tests. Did some
light manual testing in addition. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


