### PR TITLE
search: remove unused return value in job printer

### DIFF
--- a/internal/search/job/printers.go
+++ b/internal/search/job/printers.go
@@ -172,8 +172,8 @@ func PrettyMermaid(job Job) string {
 	id := 0
 	b := new(bytes.Buffer)
 	b.WriteString("flowchart TB\n")
-	var writeMermaid func(Job) int
-	writeMermaid = func(job Job) int {
+	var writeMermaid func(Job)
+	writeMermaid = func(job Job) {
 		switch j := job.(type) {
 		case
 			*run.RepoSearch,
@@ -260,7 +260,6 @@ func PrettyMermaid(job Job) string {
 		default:
 			panic(fmt.Sprintf("unsupported job %T for PrettyMermaid printer", job))
 		}
-		return id
 	}
 	writeMermaid(job)
 	return b.String()


### PR DESCRIPTION
Spotted this while trying something.

## Test plan
Removes dead code, covered by tests
