### PR TITLE
search: assert required implementations for jobs

### DIFF
--- a/internal/search/job/printers.go
+++ b/internal/search/job/printers.go
@@ -34,6 +34,9 @@ func SexpFormat(job Job, sep, indent string) string {
 	depth := 0
 	var writeSexp func(Job)
 	writeSexp = func(job Job) {
+		if job == nil {
+			return
+		}
 		switch j := job.(type) {
 		case
 			*run.RepoSearch,
@@ -183,6 +186,9 @@ func PrettyMermaid(job Job) string {
 	b.WriteString("flowchart TB\n")
 	var writeMermaid func(Job)
 	writeMermaid = func(job Job) {
+		if job == nil {
+			return
+		}
 		switch j := job.(type) {
 		case
 			*run.RepoSearch,
@@ -289,6 +295,9 @@ func PrettyMermaid(job Job) string {
 func toJSON(job Job, verbose bool) interface{} {
 	var emitJSON func(Job) interface{}
 	emitJSON = func(job Job) interface{} {
+		if job == nil {
+			return struct{}{}
+		}
 		switch j := job.(type) {
 		case
 			*run.RepoSearch,

--- a/internal/search/job/types.go
+++ b/internal/search/job/types.go
@@ -5,7 +5,13 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/commit"
+	"github.com/sourcegraph/sourcegraph/internal/search/repos"
+	"github.com/sourcegraph/sourcegraph/internal/search/run"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+	"github.com/sourcegraph/sourcegraph/internal/search/structural"
+	"github.com/sourcegraph/sourcegraph/internal/search/symbol"
+	"github.com/sourcegraph/sourcegraph/internal/search/textsearch"
 )
 
 // Job is an interface shared by all individual search operations in the
@@ -16,4 +22,26 @@ import (
 type Job interface {
 	Run(context.Context, database.DB, streaming.Sender) (*search.Alert, error)
 	Name() string
+}
+
+var allJobs = []Job{
+	&run.RepoSearch{},
+	&textsearch.RepoSubsetTextSearch{},
+	&textsearch.RepoUniverseTextSearch{},
+	&structural.StructuralSearch{},
+	&commit.CommitSearch{},
+	&symbol.RepoSubsetSymbolSearch{},
+	&symbol.RepoUniverseSymbolSearch{},
+	&repos.ComputeExcludedRepos{},
+	&noopJob{},
+
+	&AndJob{},
+	&OrJob{},
+	&PriorityJob{},
+	&ParallelJob{},
+
+	&TimeoutJob{},
+	&LimitJob{},
+	&subRepoPermsFilterJob{},
+	&selectJob{},
 }

--- a/internal/search/job/types_test.go
+++ b/internal/search/job/types_test.go
@@ -1,0 +1,17 @@
+package job
+
+import "testing"
+
+func TestMembership(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Please add a case statement for your job (%v)", r)
+		}
+	}()
+
+	for _, j := range allJobs {
+		Sexp(j)
+		PrettyMermaid(j)
+		PrettyJSON(j)
+	}
+}


### PR DESCRIPTION
As long as we can keep the list of jobs up to date, we'll trigger something like:

> --- FAIL: TestMembership (0.00s)                                                                                                                                                                                                       
    types_test.go:8: Please add a case statement for your job (unsupported job *job.selectJob for SexpFormat printer)  

if an implementation is missing

## Test plan
I deleted a case and ran the test and it fails as expected.


