### PR TITLE
Search jobs: remove IsStreamingCompatible

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -542,18 +542,7 @@ func (r *searchResolver) resultsBatch(ctx context.Context) (*SearchResultsResolv
 }
 
 func (r *searchResolver) resultsStreaming(ctx context.Context) (*SearchResultsResolver, error) {
-	stream := r.stream
-	if !query.IsStreamingCompatible(r.Plan) {
-		srr, err := r.resultsBatch(ctx)
-		if srr != nil {
-			stream.Send(streaming.SearchEvent{
-				Results: srr.Matches,
-				Stats:   srr.Stats,
-			})
-		}
-		return srr, err
-	}
-	alert, err := r.results(ctx, stream, r.Plan)
+	alert, err := r.results(ctx, r.stream, r.Plan)
 	srr := r.resultsToResolver(&SearchResults{Alert: alert})
 	return srr, err
 }


### PR DESCRIPTION
Now that we _always_ pass a non-nil stream to `results`, we can remove the streaming compatibility check.

Stacked on #31291 

## Test plan

Covered by integration tests, semantics preserving. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


