### PR TITLE
Search jobs: move job creation for plan into `job` package

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -668,27 +668,12 @@ func (r *searchResolver) results(ctx context.Context, stream streaming.Sender, p
 		return nil, err
 	}
 
-	planJob, err := r.expandedPlanToJob(plan)
+	planJob, err := job.ExpandedPlanToJob(r.JobArgs(), plan)
 	if err != nil {
 		return nil, err
 	}
 
 	return r.evaluateJob(ctx, stream, planJob)
-}
-
-// expandedPlanToJob takes a query plan that has had all predicates expanded,
-// and converts it to a job.
-func (r *searchResolver) expandedPlanToJob(plan query.Plan) (job.Job, error) {
-	args := r.JobArgs()
-	children := make([]job.Job, 0, len(plan))
-	for _, q := range plan {
-		child, err := job.ToEvaluateJob(args, q)
-		if err != nil {
-			return nil, err
-		}
-		children = append(children, child)
-	}
-	return job.NewOrJob(children...), nil
 }
 
 // searchResultsToRepoNodes converts a set of search results into repository nodes

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -668,7 +668,7 @@ func (r *searchResolver) results(ctx context.Context, stream streaming.Sender, p
 		return nil, err
 	}
 
-	planJob, err := job.ExpandedPlanToJob(r.JobArgs(), plan)
+	planJob, err := job.FromExpandedPlan(r.JobArgs(), plan)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -635,6 +635,20 @@ func ToEvaluateJob(args *Args, q query.Basic) (Job, error) {
 	return NewTimeoutJob(timeout, NewLimitJob(maxResults, job)), err
 }
 
+// ExpandedPlanToJob takes a query plan that has had all predicates expanded,
+// and converts it to a job.
+func ExpandedPlanToJob(args *Args, plan query.Plan) (Job, error) {
+	children := make([]Job, 0, len(plan))
+	for _, q := range plan {
+		child, err := ToEvaluateJob(args, q)
+		if err != nil {
+			return nil, err
+		}
+		children = append(children, child)
+	}
+	return NewOrJob(children...), nil
+}
+
 var metricFeatureFlagUnavailable = promauto.NewCounter(prometheus.CounterOpts{
 	Name: "src_search_featureflag_unavailable",
 	Help: "temporary counter to check if we have feature flag available in practice.",

--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -635,9 +635,9 @@ func ToEvaluateJob(args *Args, q query.Basic) (Job, error) {
 	return NewTimeoutJob(timeout, NewLimitJob(maxResults, job)), err
 }
 
-// ExpandedPlanToJob takes a query plan that has had all predicates expanded,
+// FromExpandedPlan takes a query plan that has had all predicates expanded,
 // and converts it to a job.
-func ExpandedPlanToJob(args *Args, plan query.Plan) (Job, error) {
+func FromExpandedPlan(args *Args, plan query.Plan) (Job, error) {
 	children := make([]Job, 0, len(plan))
 	for _, q := range plan {
 		child, err := ToEvaluateJob(args, q)


### PR DESCRIPTION
This just moves the `query.Plan -> Job` conversion into its own function in the `job` package so that we can officially say that, after predicate evaluation, we generate a fully static job before evaluation. 

Stacked on #31292 


## Test plan

Semantics-preserving

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


