### PR TITLE
symbols: Optimize prefix queries

### DIFF
--- a/cmd/symbols/internal/database/store/search.go
+++ b/cmd/symbols/internal/database/store/search.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"strings"
 
 	"github.com/grafana/regexp/syntax"
@@ -94,6 +95,7 @@ func makeSearchCondition(column string, regex string, isCaseSensitive bool) *sql
 		return nil
 	}
 
+	// Exact match
 	if symbolName, isExact, err := isLiteralEquality(regex); err == nil && isExact {
 		if isCaseSensitive {
 			return sqlf.Sprintf(column+" = %s", symbolName)
@@ -102,6 +104,16 @@ func makeSearchCondition(column string, regex string, isCaseSensitive bool) *sql
 		}
 	}
 
+	// Prefix match
+	if symbolName, isExact, err := isLiteralPrefix(regex); err == nil && isExact {
+		if isCaseSensitive {
+			return sqlf.Sprintf(column+" GLOB %s", globEscape(symbolName)+"*")
+		} else {
+			return sqlf.Sprintf(column+"lowercase GLOB %s", strings.ToLower(globEscape(symbolName))+"*")
+		}
+	}
+
+	// Regex match
 	if !isCaseSensitive {
 		regex = "(?i:" + regex + ")"
 	}
@@ -134,10 +146,49 @@ func isLiteralEquality(expr string) (string, bool, error) {
 	return "", false, nil
 }
 
+// isLiteralPrefix returns true if the given regex matches literal strings by prefix.
+// If so, this function returns true along with the literal search query. If not, this
+// function returns false.
+func isLiteralPrefix(expr string) (string, bool, error) {
+	regexp, err := syntax.Parse(expr, syntax.Perl)
+	if err != nil {
+		return "", false, errors.Wrap(err, "regexp/syntax.Parse")
+	}
+
+	// want a concat of size 2 which is [begin, literal]
+	if regexp.Op == syntax.OpConcat && len(regexp.Sub) == 2 {
+		// starts with ^
+		if regexp.Sub[0].Op == syntax.OpBeginLine || regexp.Sub[0].Op == syntax.OpBeginText {
+			// is a literal
+			if regexp.Sub[1].Op == syntax.OpLiteral {
+				return string(regexp.Sub[1].Rune), true, nil
+			}
+		}
+	}
+
+	return "", false, nil
+}
+
 func negate(query *sqlf.Query) *sqlf.Query {
 	if query == nil {
 		return nil
 	}
 
 	return sqlf.Sprintf("NOT %s", query)
+}
+
+func globEscape(str string) string {
+	var result strings.Builder
+
+	specials := `[]*?`
+
+	for _, c := range str {
+		if strings.ContainsRune(specials, c) {
+			fmt.Fprintf(&result, "[%c]", c)
+		} else {
+			fmt.Fprintf(&result, "%c", c)
+		}
+	}
+
+	return result.String()
 }

--- a/cmd/symbols/internal/database/store/search_test.go
+++ b/cmd/symbols/internal/database/store/search_test.go
@@ -39,3 +39,65 @@ func TestIsLiteralEquality(t *testing.T) {
 		}
 	}
 }
+
+func TestIsLiteralPrefix(t *testing.T) {
+	for _, test := range []struct {
+		regex           string
+		noMatch         bool
+		expectedLiteral string
+	}{
+		{regex: `^foo`, expectedLiteral: "foo"},
+		{regex: `^[f]oo`, expectedLiteral: `foo`},
+		{regex: `^\\`, expectedLiteral: `\`},
+		{regex: `^\(`, expectedLiteral: `(`},
+		{regex: `\\`, noMatch: true},
+		{regex: `\$`, noMatch: true},
+		{regex: `\(`, noMatch: true},
+		{regex: `foo$`, noMatch: true},
+		{regex: `(^foo$|^bar$)`, noMatch: true},
+	} {
+		literal, ok, err := isLiteralPrefix(test.regex)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ok {
+			if !test.noMatch {
+				t.Errorf("exected a match")
+			}
+		} else if test.noMatch {
+			t.Errorf("did not expect a match")
+		} else if literal != test.expectedLiteral {
+			t.Errorf(
+				"unexpected literal for %q. want=%q have=%q",
+				test.regex,
+				test.expectedLiteral,
+				literal,
+			)
+		}
+	}
+}
+
+func TestEscapeGlob(t *testing.T) {
+	for _, test := range []struct {
+		str  string
+		want string
+	}{
+		{str: "", want: ""},
+		{str: "foo", want: "foo"},
+		{str: "*", want: "[*]"},
+		{str: "?", want: "[?]"},
+		{str: "[", want: "[[]"},
+		{str: "]", want: "[]]"},
+		{str: "**?foo]*[", want: "[*][*][?]foo[]][*][[]"},
+	} {
+		got := globEscape(test.str)
+		if got != test.want {
+			t.Errorf(
+				"unexpected result for escaping %q. want=%q got=%q",
+				test.str,
+				test.want,
+				got,
+			)
+		}
+	}
+}


### PR DESCRIPTION
SQLite is super fast when you give it a `GLOB` with a literal prefix like `foo*`.

This will make the `symbols` service snappy for sidebar directory queries, once the appropriate query is sent https://github.com/sourcegraph/sourcegraph/issues/31296

## Test plan

Added a test.