### PR TITLE
sg: Set add-to-macos-firewall to be true by default.

### DIFF
--- a/dev/sg/internal/run/run.go
+++ b/dev/sg/internal/run/run.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -94,7 +95,7 @@ func Commands(ctx context.Context, globalEnv map[string]string, addToMacOSFirewa
 }
 
 func newPostInstall(ctx context.Context, cmds []Command, addToMacOSFirewall bool) func() error {
-	if !addToMacOSFirewall {
+	if !addToMacOSFirewall || runtime.GOOS != "darwin" {
 		return func() error { return nil }
 	}
 

--- a/dev/sg/sg_run.go
+++ b/dev/sg/sg_run.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	runFlagSet              = flag.NewFlagSet("sg run", flag.ExitOnError)
-	runFlagAddToMacFirewall = runFlagSet.Bool("add-to-macos-firewall", false, "OSX only; Add required exceptions to the firewall")
+	runFlagAddToMacFirewall = runFlagSet.Bool("add-to-macos-firewall", true, "OSX only; Add required exceptions to the firewall")
 	runCommand              = &ffcli.Command{
 		Name:       "run",
 		ShortUsage: "sg run <command>...",

--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -21,7 +21,7 @@ import (
 var (
 	startFlagSet       = flag.NewFlagSet("sg start", flag.ExitOnError)
 	debugStartServices = startFlagSet.String("debug", "", "Comma separated list of services to set at debug log level.")
-	addToMacOSFirewall = startFlagSet.Bool("add-to-macos-firewall", false, "OSX only; Add required exceptions to the firewall")
+	addToMacOSFirewall = startFlagSet.Bool("add-to-macos-firewall", true, "OSX only; Add required exceptions to the firewall")
 	infoStartServices  = startFlagSet.String("info", "", "Comma separated list of services to set at info log level.")
 	warnStartServices  = startFlagSet.String("warn", "", "Comma separated list of services to set at warn log level.")
 	errorStartServices = startFlagSet.String("error", "", "Comma separated list of services to set at error log level.")


### PR DESCRIPTION
Having the flag be off by default is counter-intuitive,
because most developers will want to have those exceptions
in place for the development binaries.

Follow up to https://github.com/sourcegraph/sourcegraph/pull/30747 and https://github.com/sourcegraph/sourcegraph/issues/29908.

## Test plan

N/A