### PR TITLE
symbols: Prefix sidebar queries with ^path/to/dir

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebarSymbols.test.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarSymbols.test.tsx
@@ -36,7 +36,7 @@ const symbolsMock: MockedResponse<SymbolsResult> = {
             first: 100,
             repo: sidebarProps.repoID,
             revision: sidebarProps.revision,
-            includePatterns: [escapeRegExp(sidebarProps.activePath)],
+            includePatterns: ['^' + escapeRegExp(sidebarProps.activePath)],
         },
     },
     result: {

--- a/client/web/src/repo/RepoRevisionSidebarSymbols.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarSymbols.tsx
@@ -135,7 +135,7 @@ export const RepoRevisionSidebarSymbols: React.FunctionComponent<RepoRevisionSid
             repo: repoID,
             revision,
             // `includePatterns` expects regexes, so first escape the path.
-            includePatterns: [escapeRegExp(activePath)],
+            includePatterns: ['^' + escapeRegExp(activePath)],
         },
         getConnection: result => {
             const { node } = dataOrThrowErrors(result)


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/31296

Once https://github.com/sourcegraph/sourcegraph/pull/31298 is merged, this PR will make symbols sidebar searches WAY faster.

Resolves https://github.com/sourcegraph/sourcegraph/issues/31296

## Test plan

Open a dir before (notice the timeout error) and after (no error).