### PR TITLE
Add dashboard id param for the creation insight URL flow at the add i…

### DIFF
--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/add-insight-modal/AddInsightModal.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/add-insight-modal/AddInsightModal.tsx
@@ -91,6 +91,7 @@ export const AddInsightModal: React.FunctionComponent<AddInsightModalProps> = pr
                 <AddInsightModalContent
                     initialValues={initialValues}
                     insights={insights}
+                    dashboardID={dashboard.id}
                     onCancel={onClose}
                     onSubmit={handleSubmit}
                 />

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/add-insight-modal/components/add-insight-modal-content/AddInsightModalContent.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/add-insight-modal/components/add-insight-modal-content/AddInsightModalContent.tsx
@@ -19,6 +19,7 @@ import styles from './AddInsightModalContent.module.scss'
 interface AddInsightModalContentProps {
     insights: ReachableInsight[]
     initialValues: AddInsightFormValues
+    dashboardID: string
     onSubmit: (values: AddInsightFormValues) => SubmissionErrors | Promise<SubmissionErrors> | void
     onCancel: () => void
 }
@@ -29,7 +30,7 @@ export interface AddInsightFormValues {
 }
 
 export const AddInsightModalContent: React.FunctionComponent<AddInsightModalContentProps> = props => {
-    const { initialValues, insights, onSubmit, onCancel } = props
+    const { initialValues, insights, dashboardID, onSubmit, onCancel } = props
 
     const { formAPI, ref, handleSubmit } = useForm({
         initialValues,
@@ -50,14 +51,13 @@ export const AddInsightModalContent: React.FunctionComponent<AddInsightModalCont
     )
 
     return (
-        // eslint-disable-next-line react/forbid-elements
         <form ref={ref} onSubmit={handleSubmit}>
             <FormInput
                 autoFocus={true}
                 description={
                     <span className="">
                         Don't see an insight? Check the insight's visibility settings or{' '}
-                        <Link to="/insights/create">create a new insight</Link>
+                        <Link to={`/insights/create?dashboardId=${dashboardID}`}>create a new insight</Link>
                     </span>
                 }
                 placeholder="Search insights..."


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/31303

## Test plan

- Go to your private/org/global (any custom user-created dashboard actually)
- Click "Add Insights" button 
- Click on the "create insight" link below the search field in the "Add Insights" modal UI
- Create any type of insight 
- See that you have been redirected on the dashboard you came from 
- See that your newly created insight is presented on the current dashboard