### PR TITLE
Add code host connection with popup

### DIFF
--- a/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
+++ b/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
@@ -89,9 +89,13 @@ export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
                 reloadComponent()
             }
         }
-        const popup = browser.open(`https://github.com/apps/${window.context.githubAppCloudSlug}/installations/new?state=${encodeURIComponent(
-            owner.id
-        )}`, 'name', `dependent=${1}, alwaysOnTop=${1}, alwaysRaised=${1}, alwaysRaised=${1}, width=${600}, height=${900}`)
+        const popup = browser.open(
+            `https://github.com/apps/${window.context.githubAppCloudSlug}/installations/new?state=${encodeURIComponent(
+                owner.id
+            )}`,
+            'name',
+            `dependent=${1}, alwaysOnTop=${1}, alwaysRaised=${1}, alwaysRaised=${1}, width=${600}, height=${900}`
+        )
         const popupTick = setInterval(() => {
             if (popup.closed) {
                 setOauthInFlight(false)

--- a/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
+++ b/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
@@ -35,6 +35,11 @@ interface CodeHostItemProps {
     onDidError: (error: ErrorLike) => void
     loading?: boolean
     useGitHubApp?: boolean
+    reloadComponent?: () => void
+}
+
+export interface ParentWindow extends Window {
+    onSuccess?: () => void
 }
 
 export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
@@ -53,6 +58,7 @@ export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
     onDidUpsert,
     loading = false,
     useGitHubApp = false,
+    reloadComponent,
 }) => {
     const [isAddConnectionModalOpen, setIsAddConnectionModalOpen] = useState(false)
     const toggleAddConnectionModal = useCallback(() => setIsAddConnectionModalOpen(!isAddConnectionModalOpen), [
@@ -76,11 +82,22 @@ export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
     }, [kind, navigateToAuthProvider])
 
     const toGitHubApp = function (): void {
-        window.location.assign(
-            `https://github.com/apps/${window.context.githubAppCloudSlug}/installations/new?state=${encodeURIComponent(
-                owner.id
-            )}`
-        )
+        setOauthInFlight(true)
+        const browser: ParentWindow = window.self
+        if (reloadComponent) {
+            browser.onSuccess = () => {
+                reloadComponent()
+            }
+        }
+        const popup = browser.open(`https://github.com/apps/${window.context.githubAppCloudSlug}/installations/new?state=${encodeURIComponent(
+            owner.id
+        )}`, 'name', `dependent=${1}, alwaysOnTop=${1}, alwaysRaised=${1}, alwaysRaised=${1}, width=${600}, height=${900}`)
+        const popupTick = setInterval(() => {
+            if (popup.closed) {
+                setOauthInFlight(false)
+                clearInterval(popupTick)
+            }
+        }, 500)
     }
 
     const isUserOwner = owner.type === 'user'

--- a/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
+++ b/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
@@ -83,7 +83,7 @@ export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
 
     const toGitHubApp = function (): void {
         setOauthInFlight(true)
-        const browser: ParentWindow = window.self
+        const browser: ParentWindow = window.self as ParentWindow
         if (reloadComponent) {
             browser.onSuccess = () => {
                 reloadComponent()
@@ -97,7 +97,7 @@ export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
             `dependent=${1}, alwaysOnTop=${1}, alwaysRaised=${1}, alwaysRaised=${1}, width=${600}, height=${900}`
         )
         const popupTick = setInterval(() => {
-            if (popup.closed) {
+            if (popup?.closed) {
                 setOauthInFlight(false)
                 clearInterval(popupTick)
             }

--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -7,7 +7,6 @@ import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryServi
 import { SelfHostedCta } from '@sourcegraph/web/src/components/SelfHostedCta'
 import { Button, Container, PageHeader, LoadingSpinner, Link, Alert } from '@sourcegraph/wildcard'
 
-import { AuthenticatedUser } from '../../../auth'
 import { queryExternalServices } from '../../../components/externalServices/backend'
 import { AddExternalServiceOptions } from '../../../components/externalServices/externalServices'
 import { PageTitle } from '../../../components/PageTitle'
@@ -37,7 +36,6 @@ export interface UserAddCodeHostsPageProps
     codeHostExternalServices: Record<string, AddExternalServiceOptions>
     routingPrefix: string
     context: Pick<SourcegraphContext, 'authProviders'>
-    authenticatedUser?: AuthenticatedUser
 }
 
 type ServicesByKind = Partial<Record<ExternalServiceKind, ListExternalServiceFields>>
@@ -75,11 +73,12 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
     context,
     onUserExternalServicesOrRepositoriesUpdate,
     telemetryService,
-    authenticatedUser,
 }) => {
     if (window.opener) {
         const parentWindow: ParentWindow = window.opener as ParentWindow
-        parentWindow.onSuccess()
+        if (parentWindow.onSuccess) {
+            parentWindow.onSuccess()
+        }
         window.close()
     }
     const [statusOrError, setStatusOrError] = useState<Status>()

--- a/client/web/src/user/settings/routes.tsx
+++ b/client/web/src/user/settings/routes.tsx
@@ -128,7 +128,6 @@ export const userSettingsAreaRoutes: readonly UserSettingsAreaRoute[] = [
                 routingPrefix={props.user.url + '/settings'}
                 onUserExternalServicesOrRepositoriesUpdate={props.onUserExternalServicesOrRepositoriesUpdate}
                 telemetryService={props.telemetryService}
-                authenticatedUser={props.authenticatedUser}
             />
         ),
         exact: true,


### PR DESCRIPTION
Changes the code host connection to use a pop-up window (new tab if the browser is in full screen on Mac) which then closes on successful redirect and refreshes the React component. Provides a more seamless experience. See video for explanation.

https://www.loom.com/share/d7a25774f887488abea2d9fbb03eebd4


## Test plan

Tested in browser 🤷‍♂️ Not sure what the test plan for these kind of changes should be. Open to any suggestions.


