### PR TITLE
gqltest: Add initial sub-repo permissions tests

### DIFF
--- a/dev/gqltest/sub_repo_permissions_test.go
+++ b/dev/gqltest/sub_repo_permissions_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/sourcegraph/sourcegraph/internal/gqltestutil"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func TestSubRepoPermissionsPerforce(t *testing.T) {
+	checkPerforceEnvironment(t)
+	enableSubRepoPermissions(t)
+	createPerforceExternalService(t)
+
+	// We need to creat the `alice` user with a specific e-mail address. This user is
+	// configured on our dogfood perforce instance with limited access to the
+	// test-perms depot.
+	alicePassword := "alicessupersecurepassword"
+	t.Log("Creating Alice")
+	aliceClient, err := gqltestutil.SignUp(*baseURL, "alice@perforce.sgdev.org", "alice", alicePassword)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	aliceID := aliceClient.AuthenticatedUserID()
+	t.Cleanup(func() {
+		if err := client.DeleteUser(aliceID, true); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	const repoName = "perforce/test-perms"
+
+	// We have not enabled EnforceAuthzForSiteAdmin so they can see this repo
+	t.Logf("Waiting for %q as Admin", repoName)
+	err = client.WaitForReposToBeCloned(repoName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("Waiting for %q as Alice", repoName)
+	err = aliceClient.WaitForReposToBeCloned(repoName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blob, err := aliceClient.GitBlob(repoName, "master", "README.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantBlob := `This depot is used to test user and group permissions.
+`
+	if diff := cmp.Diff(wantBlob, blob); diff != "" {
+		t.Fatalf("Blob mismatch (-want +got):\n%s", diff)
+	}
+
+	// Should not be able to read hack.sh
+	blob, err = aliceClient.GitBlob(repoName, "master", "Security/hack.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantBlob = `This depot is used to test user and group permissions.
+`
+	if diff := cmp.Diff(wantBlob, blob); diff != "" {
+		t.Fatalf("Blob mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func enableSubRepoPermissions(t *testing.T) {
+	t.Helper()
+
+	siteConfig, err := client.SiteConfiguration()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldSiteConfig := new(schema.SiteConfiguration)
+	*oldSiteConfig = *siteConfig
+	t.Cleanup(func() {
+		err = client.UpdateSiteConfiguration(oldSiteConfig)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	siteConfig.ExperimentalFeatures = &schema.ExperimentalFeatures{
+		Perforce: "enabled",
+		SubRepoPermissions: &schema.SubRepoPermissions{
+			Enabled: true,
+		},
+	}
+	err = client.UpdateSiteConfiguration(siteConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func logCurrentSiteConfig(t *testing.T) {
+	t.Helper()
+
+	c, err := client.SiteConfiguration()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := json.Marshal(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf(string(data))
+}

--- a/dev/gqltest/sub_repo_permissions_test.go
+++ b/dev/gqltest/sub_repo_permissions_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -106,19 +105,4 @@ func enableSubRepoPermissions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-}
-
-func logCurrentSiteConfig(t *testing.T) {
-	t.Helper()
-
-	c, err := client.SiteConfiguration()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	data, err := json.Marshal(c)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Logf(string(data))
 }

--- a/dev/gqltest/sub_repo_permissions_test.go
+++ b/dev/gqltest/sub_repo_permissions_test.go
@@ -37,6 +37,8 @@ func TestSubRepoPermissionsPerforce(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		// This is the desired behaviour at the moment, see where we check for
+		// os.IsNotExist error in GitCommitResolver.Blob
 		wantBlob := ``
 
 		if diff := cmp.Diff(wantBlob, blob); diff != "" {

--- a/dev/gqltest/sub_repo_permissions_test.go
+++ b/dev/gqltest/sub_repo_permissions_test.go
@@ -32,6 +32,10 @@ func TestSubRepoPermissionsPerforce(t *testing.T) {
 		}
 	})
 
+	if err := client.SetUserEmailVerified(aliceID, "alice@perforce.sgdev.org", true); err != nil {
+		t.Fatal(err)
+	}
+
 	const repoName = "perforce/test-perms"
 
 	// We have not enabled EnforceAuthzForSiteAdmin so they can see this repo
@@ -64,8 +68,9 @@ func TestSubRepoPermissionsPerforce(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	wantBlob = `This depot is used to test user and group permissions.
-`
+	// TODO: We probably want an error, not an empty string here
+	wantBlob = ``
+
 	if diff := cmp.Diff(wantBlob, blob); diff != "" {
 		t.Fatalf("Blob mismatch (-want +got):\n%s", diff)
 	}

--- a/internal/gqltestutil/client.go
+++ b/internal/gqltestutil/client.go
@@ -210,6 +210,29 @@ func (c *Client) CurrentUserID(token string) (string, error) {
 	return resp.Data.CurrentUser.ID, nil
 }
 
+func (c *Client) IsCurrentUserSiteAdmin(token string) (bool, error) {
+	const query = `
+	query{
+      currentUser{
+        siteAdmin
+    }
+  }
+`
+	var resp struct {
+		Data struct {
+			CurrentUser struct {
+				SiteAdmin bool `json:"siteAdmin"`
+			} `json:"currentUser"`
+		} `json:"data"`
+	}
+	err := c.GraphQL(token, query, nil, &resp)
+	if err != nil {
+		return false, errors.Wrap(err, "request GraphQL")
+	}
+
+	return resp.Data.CurrentUser.SiteAdmin, nil
+}
+
 // AuthenticatedUserID returns the GraphQL node ID of current authenticated user.
 func (c *Client) AuthenticatedUserID() string {
 	return c.userID

--- a/internal/gqltestutil/user.go
+++ b/internal/gqltestutil/user.go
@@ -59,6 +59,34 @@ mutation DeleteUser($user: ID!, $hard: Boolean) {
 	return nil
 }
 
+// SetUserEmailVerified sets the given user's email address verification status.
+//
+// This method requires the authenticated user to be a site admin.
+func (c *Client) SetUserEmailVerified(user, email string, verified bool) error {
+	const query = `
+mutation setUserEmailVerified($user: ID!, $email: String!, $verified: Boolean!) {
+	setUserEmailVerified(user: $user, email: $email, verified: $verified) {
+      alwaysNil
+	}
+}
+`
+	variables := map[string]interface{}{
+		"user":     user,
+		"email":    email,
+		"verified": verified,
+	}
+	var resp struct {
+		Data struct {
+		} `json:"data"`
+	}
+	err := c.GraphQL("", query, variables, &resp)
+	if err != nil {
+		return errors.Wrap(err, "request GraphQL")
+	}
+
+	return nil
+}
+
 // UserOrganizations returns organizations name the given user belongs to.
 func (c *Client) UserOrganizations(username string) ([]string, error) {
 	const query = `


### PR DESCRIPTION
This just adds a simple file access test, but adds the test infrastructure we need to add
more test cases.

Part of https://github.com/sourcegraph/sourcegraph/issues/27448