### PR TITLE
gqltest: add tests for sub-repo permissions for indexed, unindexed and structural search

### DIFF
--- a/dev/gqltest/sub_repo_permissions_test.go
+++ b/dev/gqltest/sub_repo_permissions_test.go
@@ -9,6 +9,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
+const (
+	repoName   = "perforce/test-perms"
+	aliceEmail = "alice@perforce.sgdev.org"
+)
+
 func TestSubRepoPermissionsPerforce(t *testing.T) {
 	checkPerforceEnvironment(t)
 	enableSubRepoPermissions(t)
@@ -46,15 +51,99 @@ func TestSubRepoPermissionsPerforce(t *testing.T) {
 	})
 }
 
+func TestSubRepoPermissionsSearch(t *testing.T) {
+	checkPerforceEnvironment(t)
+	enableSubRepoPermissions(t)
+	createPerforceExternalService(t)
+	userClient, _ := createTestUserAndWaitForRepo(t)
+
+	err := client.WaitForReposToBeIndexed(repoName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name          string
+		query         string
+		zeroResult    bool
+		minMatchCount int64
+	}{
+		{
+			name:          "indexed search, nonzero result",
+			query:         `index:only This depot is used to test`,
+			minMatchCount: 1,
+		},
+		{
+			name:          "unindexed multiline search, nonzero result",
+			query:         `index:no This depot is used to test`,
+			minMatchCount: 1,
+		},
+		{
+			name:       "indexed search of restricted content",
+			query:      `index:only uploading your secrets`,
+			zeroResult: true,
+		},
+		{
+			name:       "unindexed search of restricted content",
+			query:      `index:no uploading your secrets`,
+			zeroResult: true,
+		},
+		{
+			name:       "structural, indexed search of restricted content",
+			query:      `echo "..." index:only patterntype:structural`,
+			zeroResult: true,
+		},
+		{
+			name:       "structural, unindexed search of restricted content",
+			query:      `echo "..." index:no patterntype:structural`,
+			zeroResult: true,
+		},
+		{
+			name:          "structural, indexed search, nonzero result",
+			query:         `println(...) index:only patterntype:structural`,
+			minMatchCount: 1,
+		},
+		{
+			name:          "structural, unindexed search, nonzero result",
+			query:         `println(...) index:no patterntype:structural`,
+			minMatchCount: 1,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			results, err := userClient.SearchFiles(test.query)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if test.zeroResult {
+				if len(results.Results) > 0 {
+					t.Fatalf("Want zero result but got %d", len(results.Results))
+				}
+			} else {
+				if len(results.Results) == 0 {
+					t.Fatal("Want non-zero results but got 0")
+				}
+			}
+
+			if results.MatchCount < test.minMatchCount {
+				t.Fatalf("Want at least %d match count but got %d", test.minMatchCount, results.MatchCount)
+			}
+		})
+	}
+}
+
 func createTestUserAndWaitForRepo(t *testing.T) (*gqltestutil.Client, string) {
 	t.Helper()
 
-	// We need to creat the `alice` user with a specific e-mail address. This user is
+	// We need to create the `alice` user with a specific e-mail address. This user is
 	// configured on our dogfood perforce instance with limited access to the
 	// test-perms depot.
+	// Alice has access to root, Backend and Frontend directories. (there are .md, .ts and .go files)
+	// Alice doesn't have access to Security directory. (there is a .sh file)
 	alicePassword := "alicessupersecurepassword"
 	t.Log("Creating Alice")
-	userClient, err := gqltestutil.SignUp(*baseURL, "alice@perforce.sgdev.org", "alice", alicePassword)
+	userClient, err := gqltestutil.SignUp(*baseURL, aliceEmail, "alice", alicePassword)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,12 +155,10 @@ func createTestUserAndWaitForRepo(t *testing.T) (*gqltestutil.Client, string) {
 		}
 	})
 
-	if err := client.SetUserEmailVerified(aliceID, "alice@perforce.sgdev.org", true); err != nil {
+	if err := client.SetUserEmailVerified(aliceID, aliceEmail, true); err != nil {
 		t.Fatal(err)
 	}
 
-	const repoName = "perforce/test-perms"
-	t.Logf("Waiting for %q as Alice", repoName)
 	err = userClient.WaitForReposToBeCloned(repoName)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/27448

## Test plan
That's what I am going to commit (tests)

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


