### PR TITLE
schema: Set enableGitServerCommandExecFilter to true by default

### DIFF
--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -374,7 +374,7 @@
         "enableGitServerCommandExecFilter": {
           "description": "Enable filtering of all exec commands on gitserver based on a pre-defined allowlist",
           "type": "boolean",
-          "default": false
+          "default": true
         }
       },
       "examples": [


### PR DESCRIPTION
We have not seen any warning logs that match "IsAllowedGitCmd" in
gitserver for the last 24 hours. As a result the security patch can be
safely enabled by default. In case of any regressions, this flag can
be set to false in the site configuration.

Logs [here](https://sourcegraph.grafana.net/explore?orgId=1&left=%7B%22datasource%22:%22grafanacloud-sourcegraph-logs%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bapp%3D%5C%22gitserver%5C%22,%20namespace%3D%5C%22prod%5C%22%7D%20%7C%3D%20%5C%22IsAllowedGitCmd%5C%22%22%7D%5D,%22range%22:%7B%22from%22:%22now-24h%22,%22to%22:%22now%22%7D%7D).

Should be the final PR to help complete https://github.com/sourcegraph/security-issues/issues/213. 


## Test plan

Setting the default value of a config. No additional test required.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


