### PR TITLE
Fix NavBar main button styles

### DIFF
--- a/client/web/src/nav/NavBar/NavItem.module.scss
+++ b/client/web/src/nav/NavBar/NavItem.module.scss
@@ -20,6 +20,10 @@
     align-items: center;
     justify-content: center;
     color: var(--body-color);
+    border: none;
+    border-radius: 0;
+    transition: none;
+
     &:hover {
         text-decoration: none;
     }

--- a/client/web/src/nav/NavBar/NavItem.module.scss
+++ b/client/web/src/nav/NavBar/NavItem.module.scss
@@ -23,6 +23,7 @@
     border: none;
     border-radius: 0;
     transition: none;
+    font-weight: 400;
 
     &:hover {
         text-decoration: none;


### PR DESCRIPTION
## Problem
We recently discovered a [regression](https://github.com/sourcegraph/sourcegraph/issues/31249) after migrating [from Dropdown to MenuItem](https://github.com/sourcegraph/sourcegraph/pull/29582).


https://user-images.githubusercontent.com/19534377/154088419-ce214fbc-e46f-472b-a21e-f7f4e2d4504a.mov


There're 2 issues with the current state:
1. Dropdown button styles are different - there's a transition, an unwanted border radius, and bolder font weight
2. Focus behavior is different too - it's shown on the entire panel instead of individual menu items

## Solution
We currently fix only the 1st issue because the 2nd one is deeply ingrained into the `MenuList -> Popover (PopoverContent) -> FloatingPanel` rendering tree, and it seems to be a sophisticated change with a questionable outcome. The current implementation is just a bit different, not wrong.

### Before
At the `dfd241cc5ddf0acc080565239ad674f81b8af427` commit:

https://user-images.githubusercontent.com/2196347/154300735-ddeac910-d9d0-4e7b-8b58-765b71507bc5.mov



### After

https://user-images.githubusercontent.com/2196347/154302587-27d51386-a405-4c72-8c1d-b6271b1f1655.mov



## Test Plan
1. Run Sourcegraph locally
2. check that the styles are fine
