### PR TITLE
[cloud][CLOUD-187] Add unit tests for new pendingInvitations graphql query

### DIFF
--- a/cmd/frontend/graphqlbackend/org_invitations.go
+++ b/cmd/frontend/graphqlbackend/org_invitations.go
@@ -120,13 +120,12 @@ func (r *schemaResolver) PendingInvitations(ctx context.Context, args *struct {
 		return nil, errors.New("no current user")
 	}
 
-	var orgID int32
-	if err := relay.UnmarshalSpec(args.Organization, &orgID); err != nil {
+	orgID, err := UnmarshalOrgID(args.Organization)
+	if err != nil {
 		return nil, err
 	}
 
-	// 🚨 SECURITY: Check that the current user is a member of the org that the user is being
-	// invited to.
+	// 🚨 SECURITY: Check that the current user is a member of the org that we get the invitations for
 	if err := backend.CheckOrgAccess(ctx, r.db, orgID); err != nil {
 		return nil, err
 	}

--- a/internal/database/org_invitations_test.go
+++ b/internal/database/org_invitations_test.go
@@ -197,6 +197,27 @@ func TestOrgInvitations(t *testing.T) {
 		testPendingByID(t, 12345, nil, fmt.Sprintf(errorMessageFormat, 12345))
 	})
 
+	testPendingByOrgID := func(t *testing.T, orgID int32, want []*OrgInvitation) {
+		t.Helper()
+		ois, err := db.OrgInvitations().GetPendingByOrgID(ctx, orgID)
+		if err != nil {
+			t.Fatal(err)
+			return
+		}
+		if len(want) == 0 && len(ois) != 0 {
+			t.Errorf("want empty list, got %v", ois)
+		} else if len(want) != 0 && !reflect.DeepEqual(ois, want) {
+			t.Errorf("got %+v, want %+v", ois, want)
+		}
+	}
+	t.Run("GetPendingByOrgID", func(t *testing.T) {
+		testPendingByOrgID(t, oi1.OrgID, []*OrgInvitation{oi1})
+		testPendingByOrgID(t, oi2.OrgID, []*OrgInvitation{oi2, emailInvite})
+
+		// returns empty list if nothing is found
+		testPendingByOrgID(t, 42, []*OrgInvitation{})
+	})
+
 	testListCount := func(t *testing.T, opt OrgInvitationsListOptions, want []*OrgInvitation) {
 		t.Helper()
 		if ois, err := db.OrgInvitations().List(ctx, opt); err != nil {


### PR DESCRIPTION
# Description
Add unit tests that we decided to create a follow up PR for.

## Related items
https://sourcegraph.atlassian.net/browse/CLOUD-187
#31245 

## Test plan
This change is just adding new unit tests. 
Tests were run locally in GoLand.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


