### PR TITLE
bext: add after install page integration test

### DIFF
--- a/client/browser/src/browser-extension/after-install-page/AfterInstallPageContent.tsx
+++ b/client/browser/src/browser-extension/after-install-page/AfterInstallPageContent.tsx
@@ -52,7 +52,7 @@ export const AfterInstallPageContent: React.FunctionComponent<ThemeProps> = prop
     const showSearchShortcut = !isSafari
 
     return (
-        <div className="after-install-page-content">
+        <div className="after-install-page-content" data-testid="after-install-page-content">
             <div className="d-flex w-100 p-3 justify-content-between align-items-center">
                 <Link to="https://sourcegraph.com/search" target="_blank" rel="noopener">
                     <SourcegraphLogo className={styles.sourcegraphLogo} />

--- a/client/browser/src/integration/after-install-page.test.ts
+++ b/client/browser/src/integration/after-install-page.test.ts
@@ -1,0 +1,42 @@
+import { createDriverForTest, Driver } from '@sourcegraph/shared/src/testing/driver'
+
+import { BrowserIntegrationTestContext, createBrowserIntegrationTestContext } from './context'
+import { closeInstallPageTab } from './shared'
+
+describe('After install page', () => {
+    let driver: Driver
+    before(async () => {
+        driver = await createDriverForTest({ loadExtension: true })
+        await closeInstallPageTab(driver.browser)
+        if (driver.sourcegraphBaseUrl !== 'https://sourcegraph.com') {
+            await driver.setExtensionSourcegraphUrl()
+        }
+    })
+    after(() => driver?.close())
+
+    let testContext: BrowserIntegrationTestContext
+    beforeEach(async function () {
+        testContext = await createBrowserIntegrationTestContext({
+            driver,
+            currentTest: this.currentTest!,
+            directory: __dirname,
+        })
+
+        // Requests to other origins that we need to ignore to prevent breaking tests.
+        testContext.server
+            .get('https://storage.googleapis.com/sourcegraph-assets/code-host-integration/*path')
+            .intercept((request, response) => {
+                response.sendStatus(200)
+            })
+
+        // Ensure that the same assets are requested in all environments.
+        await driver.page.emulateMediaFeatures([{ name: 'prefers-color-scheme', value: 'light' }])
+    })
+
+    afterEach(() => testContext?.dispose())
+
+    it('renders after install page content', async () => {
+        await driver.openBrowserExtensionPage('after_install')
+        await driver.page.$("[data-testid='after-install-page-content']")
+    })
+})

--- a/client/shared/src/testing/driver.ts
+++ b/client/shared/src/testing/driver.ts
@@ -252,10 +252,17 @@ export class Driver {
     }
 
     /**
+     * Navigates to the Sourcegraph browser extension page.
+     */
+    public async openBrowserExtensionPage(page: 'options' | 'after_install'): Promise<void> {
+        await this.page.goto(`chrome-extension://${BROWSER_EXTENSION_DEV_ID}/${page}.html`)
+    }
+
+    /**
      * Navigates to the Sourcegraph browser extension options page and sets the sourcegraph URL.
      */
     public async setExtensionSourcegraphUrl(): Promise<void> {
-        await this.page.goto(`chrome-extension://${BROWSER_EXTENSION_DEV_ID}/options.html`)
+        await this.openBrowserExtensionPage('options')
         await this.page.waitForSelector('.test-sourcegraph-url')
         await this.replaceText({ selector: '.test-sourcegraph-url', newText: this.sourcegraphBaseUrl })
         await this.page.keyboard.press(Key.Enter)
@@ -266,7 +273,7 @@ export class Driver {
      * Sets 'Enable click to go to definition' option flag value.
      */
     public async setClickGoToDefOptionFlag(isEnabled: boolean): Promise<void> {
-        await this.page.goto(`chrome-extension://${BROWSER_EXTENSION_DEV_ID}/options.html`)
+        await this.openBrowserExtensionPage('options')
         const toggleAdvancedSettingsButton = await this.page.waitForSelector('.test-toggle-advanced-settings-button')
         await toggleAdvancedSettingsButton?.click()
         const checkbox = await this.findElementWithText('Enable click to go to definition')


### PR DESCRIPTION
Closes [#31046](https://github.com/sourcegraph/sourcegraph/issues/31046)

## Test plan
- make after install page throwing error or returning `null`
- check if _client/browser/src/integration/after-install-page.test.ts_ fails


