### PR TITLE
dev/sg: do not load schemas immediately to prevent panics

### DIFF
--- a/dev/sg/sg_migration.go
+++ b/dev/sg/sg_migration.go
@@ -103,7 +103,11 @@ func makeRunner(ctx context.Context, schemaNames []string) (cliutil.Runner, erro
 	storeFactory := func(db *sql.DB, migrationsTable string) connections.Store {
 		return connections.NewStoreShim(store.NewWithDB(db, migrationsTable, store.NewOperations(&observation.TestContext)))
 	}
-	r, err := connections.RunnerFromDSNsWithSchemas(postgresdsn.RawDSNsBySchema(schemaNames), "sg", storeFactory, filesystemSchemas)
+	schemas, err := getFilesystemSchemas()
+	if err != nil {
+		return nil, err
+	}
+	r, err := connections.RunnerFromDSNsWithSchemas(postgresdsn.RawDSNsBySchema(schemaNames), "sg", storeFactory, schemas)
 	if err != nil {
 		return nil, err
 	}
@@ -111,28 +115,33 @@ func makeRunner(ctx context.Context, schemaNames []string) (cliutil.Runner, erro
 	return cliutil.NewShim(r), nil
 }
 
-var filesystemSchemas = []*schemas.Schema{
-	mustResolveSchema("frontend"),
-	mustResolveSchema("codeintel"),
-	mustResolveSchema("codeinsights"),
+func getFilesystemSchemas() (schemas []*schemas.Schema, errs error) {
+	for _, name := range []string{"frontend", "codeintel", "codeinsights"} {
+		schema, err := resolveSchema(name)
+		if err != nil {
+			errs = errors.Append(errs, errors.Newf("%s: %w", name, err))
+		} else {
+			schemas = append(schemas, schema)
+		}
+	}
+	return
 }
 
-func mustResolveSchema(name string) *schemas.Schema {
+func resolveSchema(name string) (*schemas.Schema, error) {
 	repositoryRoot, err := root.RepositoryRoot()
 	if err != nil {
 		if errors.Is(err, root.ErrNotInsideSourcegraph) {
-			panic(fmt.Sprintf("sg migration command use the migrations defined on the local filesystem: %s", err))
+			return nil, errors.Newf("sg migration command uses the migrations defined on the local filesystem: %w", err)
 		}
-
-		panic(err.Error())
+		return nil, err
 	}
 
 	schema, err := schemas.ResolveSchema(os.DirFS(filepath.Join(repositoryRoot, "migrations", name)), name)
 	if err != nil {
-		panic(fmt.Sprintf("malformed migration definitions %q: %s", name, err))
+		return nil, errors.Newf("malformed migration definitions: %s", err)
 	}
 
-	return schema
+	return schema, nil
 }
 
 func addExec(ctx context.Context, args []string) error {

--- a/dev/sg/sg_migration.go
+++ b/dev/sg/sg_migration.go
@@ -138,7 +138,7 @@ func resolveSchema(name string) (*schemas.Schema, error) {
 
 	schema, err := schemas.ResolveSchema(os.DirFS(filepath.Join(repositoryRoot, "migrations", name)), name)
 	if err != nil {
-		return nil, errors.Newf("malformed migration definitions: %s", err)
+		return nil, errors.Newf("malformed migration definitions: %w", err)
 	}
 
 	return schema, nil


### PR DESCRIPTION
Do not load database schemas immediately upon running `sg`, which causes `sg` to panic on all commands when run outside of the Sourcegraph repository directory.

I think this was introduced in https://github.com/sourcegraph/sourcegraph/pull/31086 , @caugustus-sourcegraph noticed this in https://github.com/sourcegraph/sourcegraph/pull/31141#issuecomment-1041896355

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

**Before**

```sh
❯ go build -o .bin/sg ./dev/sg                                                                        
❯ (cd .. && ./sourcegraph/.bin/sg version)                                                            
panic: sg migration command use the migrations defined on the local filesystem: not running inside sourcegraph/sourcegraph

goroutine 1 [running]:
main.mustResolveSchema({0x52e2def, 0x8})
        /Users/robertlin/Projects/sourcegraph/sourcegraph/dev/sg/sg_migration.go:124 +0x219
main.init()
        /Users/robertlin/Projects/sourcegraph/sourcegraph/dev/sg/sg_migration.go:115 +0x26b6
```

**After**

```sh
❯ go build -o .bin/sg ./dev/sg                       
❯ (cd .. && ./sourcegraph/.bin/sg version)           
dev
❯ (cd .. && ./sourcegraph/.bin/sg migration validate)
error: 3 errors occurred:
        * frontend: sg migration command uses the migrations defined on the local filesystem: not running inside sourcegraph/sourcegraph
        * codeintel: sg migration command uses the migrations defined on the local filesystem: not running inside sourcegraph/sourcegraph
        * codeinsights: sg migration command uses the migrations defined on the local filesystem: not running inside sourcegraph/sourcegraph
```