### PR TITLE
pr-auditor: drop 'pull request' prefix from issue titles, update docs

### DIFF
--- a/dev/buildchecker/README.md
+++ b/dev/buildchecker/README.md
@@ -1,4 +1,4 @@
-# buildchecker
+# buildchecker [![buildchecker](https://github.com/sourcegraph/sourcegraph/actions/workflows/buildchecker.yml/badge.svg)](https://github.com/sourcegraph/sourcegraph/actions/workflows/buildchecker.yml)
 
 `buildchecker` is designed to respond to periods of consecutive build failures on a Buildkite pipeline.
 Owned by the [DevX team](https://handbook.sourcegraph.com/departments/product-engineering/engineering/enablement/dev-experience).

--- a/dev/pr-auditor/README.md
+++ b/dev/pr-auditor/README.md
@@ -1,6 +1,23 @@
-# pr-auditor
+# pr-auditor [![pr-auditor](https://github.com/sourcegraph/sourcegraph/actions/workflows/pr-auditor.yml/badge.svg)](https://github.com/sourcegraph/sourcegraph/actions/workflows/pr-auditor.yml)
 
 `pr-auditor` is a tool designed to operate on some [GitHub Actions pull request events](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request) in order to check for SOC2 compliance.
 Owned by the [DevX team](https://handbook.sourcegraph.com/departments/product-engineering/engineering/enablement/dev-experience).
 
 Learn more: [Testing principles and guidelines](https://docs.sourcegraph.com/dev/background-information/testing_principles)
+
+## Usage
+
+This action is primarily designed to run on GitHub Actions, and leverages the [pull request event payloads](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request) extensively.
+
+```sh
+GITHUB_EVENT_PATH="/path/to/json/payload.json"
+GITHUB_TOKEN="personal-access-token"
+
+# run directly
+go run ./dev/pr-auditor/ check \
+  -github.payload-path="$GITHUB_EVENT_PATH" \
+  -github.token="$GITHUB_TOKEN"
+
+# run using wrapper script
+./dev/buildchecker/check-pr.sh
+```

--- a/dev/pr-auditor/issue.go
+++ b/dev/pr-auditor/issue.go
@@ -12,7 +12,7 @@ const (
 
 func generateExceptionIssue(payload *EventPayload, result *checkResult) *github.IssueRequest {
 	var (
-		issueTitle      = fmt.Sprintf("pull request %s#%d: %q", payload.Repository.FullName, payload.PullRequest.Number, payload.PullRequest.Title)
+		issueTitle      = fmt.Sprintf("%s#%d: %q", payload.Repository.FullName, payload.PullRequest.Number, payload.PullRequest.Title)
 		issueBody       string
 		exceptionLabels = []string{}
 		issueAssignees  = []string{}

--- a/doc/dev/background-information/continuous_integration.md
+++ b/doc/dev/background-information/continuous_integration.md
@@ -289,11 +289,23 @@ Enabling a feature flag on the CI pipeline is achieved by setting environment va
 
 ### `buildchecker`
 
+[![buildchecker](https://github.com/sourcegraph/sourcegraph/actions/workflows/buildchecker.yml/badge.svg)](https://github.com/sourcegraph/sourcegraph/actions/workflows/buildchecker.yml)
+
 [`buildchecker`](https://github.com/sourcegraph/sourcegraph/actions/workflows/buildchecker.yml), our [branch lock management tool](#branch-locks), runs in GitHub actions - see the [workflow specification](https://github.com/sourcegraph/sourcegraph/blob/main/.github/workflows/buildchecker.yml).
 
 To learn more about `buildchecker`, refer to the [`buildchecker` source code and documentation](https://github.com/sourcegraph/sourcegraph/tree/main/dev/buildchecker).
 
+### `pr-auditor`
+
+[![pr-auditor](https://github.com/sourcegraph/sourcegraph/actions/workflows/pr-auditor.yml/badge.svg)](https://github.com/sourcegraph/sourcegraph/actions/workflows/pr-auditor.yml)
+
+[`pr-auditor`](https://github.com/sourcegraph/sourcegraph/actions/workflows/pr-auditor.yml), our [PR audit tool](testing_principles.md#policy), runs in GitHub actions - see the [workflow specification](https://github.com/sourcegraph/sourcegraph/blob/main/.github/workflows/pr-auditor.yml).
+
+To learn more about `pr-auditor`, refer to the [`pr-auditor` source code and documentation](https://github.com/sourcegraph/sourcegraph/tree/main/dev/pr-auditor).
+
 ### Third-party licenses
+
+[![Licenses Update](https://github.com/sourcegraph/sourcegraph/actions/workflows/licenses-update.yml/badge.svg)](https://github.com/sourcegraph/sourcegraph/actions/workflows/licenses-update.yml) [![Licenses Check](https://github.com/sourcegraph/sourcegraph/actions/workflows/licenses-check.yml/badge.svg)](https://github.com/sourcegraph/sourcegraph/actions/workflows/licenses-check.yml)
 
 We use the [`license_finder`](https://github.com/pivotal/LicenseFinder) tool to check third-party dependencies for their licenses. It runs as a [GitHub Action on pull requests](https://github.com/sourcegraph/sourcegraph/actions?query=workflow%3A%22Licenses+Check%22), which will fail if one of the following occur:
 


### PR DESCRIPTION
- [pr-auditor: drop 'pull request' prefix from issue titles](https://github.com/sourcegraph/sourcegraph/commit/92e4f86240969650ee29edb06a828494263baad0): This should be self-explanatory, since the repo is sec-pr-audit-trail
- [dev: update documentation for pr-auditor and other github actions](https://github.com/sourcegraph/sourcegraph/commit/f10b0dbf547b91cf1175cc8c4ef3eeb67e0ef15b)

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

n/a
