### PR TITLE
executors: Fix log group used in docker mirror

### DIFF
--- a/enterprise/cmd/executor/docker-mirror/install.sh
+++ b/enterprise/cmd/executor/docker-mirror/install.sh
@@ -27,7 +27,7 @@ function install_cloudwatch_agent() {
         "collect_list": [
           {
             "file_path": "/var/log/syslog",
-            "log_group_name": "executors",
+            "log_group_name": "executors_docker_mirror",
             "timezone": "UTC"
           }
         ]


### PR DESCRIPTION
This was wrong, we create another log group for the docker mirror but then didn't end up using it properly.

## Test plan

Tested manually on a running machine.
