### PR TITLE
Search backend: move protocol to SearchInputs

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -121,6 +121,11 @@ func NewSearchImplementer(ctx context.Context, db database.DB, args *SearchArgs)
 		codeMonitorID = &i
 	}
 
+	protocol := search.Batch
+	if args.Stream != nil {
+		protocol = search.Streaming
+	}
+
 	inputs := &run.SearchInputs{
 		Plan:          plan,
 		Query:         plan.ToParseTree(),
@@ -130,6 +135,7 @@ func NewSearchImplementer(ctx context.Context, db database.DB, args *SearchArgs)
 		PatternType:   searchType,
 		DefaultLimit:  defaultLimit,
 		CodeMonitorID: codeMonitorID,
+		Protocol:      protocol,
 	}
 
 	tr.LazyPrintf("Parsed query: %s", inputs.Query)
@@ -225,15 +231,6 @@ func (r *searchResolver) Inputs() run.SearchInputs {
 // rawQuery returns the original query string input.
 func (r *searchResolver) rawQuery() string {
 	return r.OriginalQuery
-}
-
-// protocol returns what type of search we are doing (batch, stream,
-// paginated).
-func (r *searchResolver) protocol() search.Protocol {
-	if r.stream != nil {
-		return search.Streaming
-	}
-	return search.Batch
 }
 
 const (

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -463,7 +463,6 @@ func (r *searchResolver) JobArgs() *job.Args {
 	return &job.Args{
 		SearchInputs:        r.SearchInputs,
 		OnSourcegraphDotCom: envvar.SourcegraphDotComMode(),
-		Protocol:            r.protocol(),
 		Zoekt:               r.zoekt,
 		SearcherURLs:        r.searcherURLs,
 	}

--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -31,7 +31,6 @@ import (
 type Args struct {
 	SearchInputs        *run.SearchInputs
 	OnSourcegraphDotCom bool
-	Protocol            search.Protocol
 	Zoekt               zoekt.Streamer
 	SearcherURLs        *endpoint.Map
 }
@@ -54,7 +53,7 @@ func ToSearchJob(jargs *Args, q query.Q) (Job, error) {
 		return nil, err
 	}
 
-	p := search.ToTextPatternInfo(b, jargs.Protocol, query.Identity)
+	p := search.ToTextPatternInfo(b, jargs.SearchInputs.Protocol, query.Identity)
 
 	forceResultTypes := result.TypeEmpty
 	if jargs.SearchInputs.PatternType == query.SearchTypeStructural {
@@ -76,7 +75,7 @@ func ToSearchJob(jargs *Args, q query.Q) (Job, error) {
 		Timeout:     search.TimeoutDuration(b),
 
 		// UseFullDeadline if timeout: set or we are streaming.
-		UseFullDeadline: q.Timeout() != nil || q.Count() != nil || jargs.Protocol == search.Streaming,
+		UseFullDeadline: q.Timeout() != nil || q.Count() != nil || jargs.SearchInputs.Protocol == search.Streaming,
 
 		Zoekt:        jargs.Zoekt,
 		SearcherURLs: jargs.SearcherURLs,

--- a/internal/search/job/job_test.go
+++ b/internal/search/job/job_test.go
@@ -18,9 +18,9 @@ func TestToSearchInputs(t *testing.T) {
 			SearchInputs: &run.SearchInputs{
 				UserSettings: &schema.Settings{},
 				PatternType:  query.SearchTypeLiteral,
+				Protocol:     protocol,
 			},
 			OnSourcegraphDotCom: true,
-			Protocol:            protocol,
 		}
 
 		j, _ := ToSearchJob(args, q)

--- a/internal/search/job/printers_test.go
+++ b/internal/search/job/printers_test.go
@@ -190,8 +190,8 @@ func TestPrettyJSON(t *testing.T) {
 		args := &Args{
 			SearchInputs: &run.SearchInputs{
 				UserSettings: &schema.Settings{},
+				Protocol:     search.Streaming,
 			},
-			Protocol: search.Streaming,
 		}
 		j, _ := ToSearchJob(args, q)
 		return PrettyJSONVerbose(j)

--- a/internal/search/run/run.go
+++ b/internal/search/run/run.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
+	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -15,6 +16,7 @@ type SearchInputs struct {
 	UserSettings  *schema.Settings
 	Features      featureflag.FlagSet
 	CodeMonitorID *int64
+	Protocol      search.Protocol
 
 	// DefaultLimit is the default limit to use if not specified in query.
 	DefaultLimit int


### PR DESCRIPTION
This removes `r.protocol()` and moves the value to the SearchInputs type
so we can calculate it when we generate search inputs. This is split off
the large set of changes I'm workign on to cut ties between streaming search
and graphqlbackend.


## Test plan

Semantics-preserving and covered by unit tests. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


