### PR TITLE
Search backend: unembed SearchInputs from searchResolver

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -214,8 +214,8 @@ func getBoolPtr(b *bool, def bool) bool {
 
 // searchResolver is a resolver for the GraphQL type `Search`
 type searchResolver struct {
-	*run.SearchInputs
-	db database.DB
+	SearchInputs *run.SearchInputs
+	db           database.DB
 
 	// stream if non-nil will send all search events we receive down it.
 	stream streaming.Sender
@@ -230,7 +230,7 @@ func (r *searchResolver) Inputs() run.SearchInputs {
 
 // rawQuery returns the original query string input.
 func (r *searchResolver) rawQuery() string {
-	return r.OriginalQuery
+	return r.SearchInputs.OriginalQuery
 }
 
 const (

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -530,7 +530,7 @@ func (r *searchResolver) logBatch(ctx context.Context, srr *SearchResultsResolve
 func (r *searchResolver) resultsBatch(ctx context.Context) (*SearchResultsResolver, error) {
 	start := time.Now()
 	agg := streaming.NewAggregatingStream()
-	alert, err := r.results(ctx, agg, r.Plan)
+	alert, err := r.results(ctx, agg, r.SearchInputs.Plan)
 	srr := r.resultsToResolver(&SearchResults{
 		Matches: agg.Results,
 		Stats:   agg.Stats,
@@ -541,7 +541,7 @@ func (r *searchResolver) resultsBatch(ctx context.Context) (*SearchResultsResolv
 }
 
 func (r *searchResolver) resultsStreaming(ctx context.Context) (*SearchResultsResolver, error) {
-	alert, err := r.results(ctx, r.stream, r.Plan)
+	alert, err := r.results(ctx, r.stream, r.SearchInputs.Plan)
 	srr := r.resultsToResolver(&SearchResults{Alert: alert})
 	return srr, err
 }
@@ -552,9 +552,9 @@ func (r *searchResolver) resultsToResolver(results *SearchResults) *SearchResult
 	}
 	return &SearchResultsResolver{
 		SearchResults: results,
-		limit:         r.MaxResults(),
+		limit:         r.SearchInputs.MaxResults(),
 		db:            r.db,
-		UserSettings:  r.UserSettings,
+		UserSettings:  r.SearchInputs.UserSettings,
 	}
 }
 
@@ -770,7 +770,7 @@ func (r *searchResolver) evaluateJob(ctx context.Context, stream streaming.Sende
 		if !statsObserver.Status.Any(search.RepoStatusTimedout) {
 			usedTime := time.Since(start)
 			suggestTime := longer(2, usedTime)
-			return search.AlertForTimeout(usedTime, suggestTime, r.rawQuery(), r.PatternType), nil
+			return search.AlertForTimeout(usedTime, suggestTime, r.rawQuery(), r.SearchInputs.PatternType), nil
 		} else {
 			err = nil
 		}
@@ -943,7 +943,7 @@ func (r *searchResolver) Stats(ctx context.Context) (stats *searchResultsStats, 
 	for {
 		// Query search results.
 		var err error
-		j, err := job.ToSearchJob(args, r.Query)
+		j, err := job.ToSearchJob(args, r.SearchInputs.Query)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -41,7 +41,7 @@ func (srs *searchResultsStats) Languages(ctx context.Context) ([]*languageStatis
 func (srs *searchResultsStats) getResults(ctx context.Context) (result.Matches, error) {
 	args := srs.sr.JobArgs()
 	srs.once.Do(func() {
-		j, err := job.ToSearchJob(args, srs.sr.Query)
+		j, err := job.ToSearchJob(args, srs.sr.SearchInputs.Query)
 		if err != nil {
 			srs.err = err
 			return


### PR DESCRIPTION
Because SearchInputs is embedded in searchResolver, it is difficult to
tell exactly where it is being used since find references doesn't show
the places its fields are accessed through the `searchResolver` type.

This just makes it a named field rather than an embedded field. This
will make it easier to reason about some of the upcoming changes I'd
like to make.

Stacked on #31337 

## Test plan

Semantics preserving and covered by tests.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


