### PR TITLE
dev/ci: disable cluster QA again

### DIFF
--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -582,7 +582,7 @@ func clusterQA(candidateTag string) operations.Operation {
 	return func(p *bk.Pipeline) {
 		p.AddStep(":k8s: Sourcegraph Cluster (deploy-sourcegraph) QA",
 
-			bk.Skip("flakey"),
+			bk.Skip("flakey: https://github.com/sourcegraph/sourcegraph/issues/31342"),
 
 			bk.DependsOn(candidateImageStepKey("frontend")),
 			bk.Env("CANDIDATE_VERSION", candidateTag),

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -581,6 +581,9 @@ func testUpgrade(candidateTag, minimumUpgradeableVersion string) operations.Oper
 func clusterQA(candidateTag string) operations.Operation {
 	return func(p *bk.Pipeline) {
 		p.AddStep(":k8s: Sourcegraph Cluster (deploy-sourcegraph) QA",
+
+			bk.Skip("flakey"),
+
 			bk.DependsOn(candidateImageStepKey("frontend")),
 			bk.Env("CANDIDATE_VERSION", candidateTag),
 			bk.Env("DOCKER_CLUSTER_IMAGES_TXT", strings.Join(images.DeploySourcegraphDockerImages, "\n")),


### PR DESCRIPTION
This was re-enabled in https://github.com/sourcegraph/sourcegraph/pull/31258. Unfortunately, it looks like both the tests and the deployment are unstable:

https://sourcegraph.grafana.net/goto/oqXtXMfnz?orgId=1

<img width="856" alt="image" src="https://user-images.githubusercontent.com/23356519/154350568-0ba04f12-2e94-49fb-8e45-16094c70be6c.png"> 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

No cluster-qa in main dry run:

<img width="555" alt="image" src="https://user-images.githubusercontent.com/23356519/154350608-b796407c-355b-4136-acb0-995d52b386d4.png">