### PR TITLE
Search backend: remove rawQuery()

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -228,11 +228,6 @@ func (r *searchResolver) Inputs() run.SearchInputs {
 	return *r.SearchInputs
 }
 
-// rawQuery returns the original query string input.
-func (r *searchResolver) rawQuery() string {
-	return r.SearchInputs.OriginalQuery
-}
-
 const (
 	defaultMaxSearchResults          = 30
 	defaultMaxSearchResultsStreaming = 500

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -509,7 +509,7 @@ func (r *searchResolver) logBatch(ctx context.Context, srr *SearchResultsResolve
 			n = len(srr.Matches)
 		}
 		ev := searchhoney.SearchEvent(ctx, searchhoney.SearchEventArgs{
-			OriginalQuery: r.rawQuery(),
+			OriginalQuery: r.SearchInputs.OriginalQuery,
 			Typ:           requestName,
 			Source:        requestSource,
 			Status:        status,
@@ -770,7 +770,7 @@ func (r *searchResolver) evaluateJob(ctx context.Context, stream streaming.Sende
 		if !statsObserver.Status.Any(search.RepoStatusTimedout) {
 			usedTime := time.Since(start)
 			suggestTime := longer(2, usedTime)
-			return search.AlertForTimeout(usedTime, suggestTime, r.rawQuery(), r.SearchInputs.PatternType), nil
+			return search.AlertForTimeout(usedTime, suggestTime, r.SearchInputs.OriginalQuery, r.SearchInputs.PatternType), nil
 		} else {
 			err = nil
 		}
@@ -922,7 +922,7 @@ func (r *searchResolver) Stats(ctx context.Context) (stats *searchResultsStats, 
 	ctx = context.Background()
 	ctx = opentracing.ContextWithSpan(ctx, opentracing.SpanFromContext(originalCtx))
 
-	cacheKey := r.rawQuery()
+	cacheKey := r.SearchInputs.OriginalQuery
 	// Check if value is in the cache.
 	jsonRes, ok := searchResultsStatsCache.Get(cacheKey)
 	if ok {


### PR DESCRIPTION
This removes searchResolver.rawQuery() in favor of just accessing the
original query on the SearchInputs struct. The goal here is just to
reduce the footprint/reach of searchResolver for further
simplifications.

Stacked on #31338 


## Test plan

Semantics preserving.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


