### PR TITLE
Search backend: cut resolver dependency for DetermineStatusForLogs

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -494,7 +494,7 @@ func (r *searchResolver) logBatch(ctx context.Context, srr *SearchResultsResolve
 	}
 
 	var status, alertType string
-	status = DetermineStatusForLogs(srr, err)
+	status = DetermineStatusForLogs(srr.SearchResults.Alert, srr.SearchResults.Stats, err)
 	if srr != nil && srr.SearchResults.Alert != nil {
 		alertType = srr.SearchResults.Alert.PrometheusType
 	}
@@ -567,17 +567,17 @@ func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, e
 
 // DetermineStatusForLogs determines the final status of a search for logging
 // purposes.
-func DetermineStatusForLogs(srr *SearchResultsResolver, err error) string {
+func DetermineStatusForLogs(alert *search.Alert, stats streaming.Stats, err error) string {
 	switch {
 	case err == context.DeadlineExceeded:
 		return "timeout"
 	case err != nil:
 		return "error"
-	case srr.Stats.Status.All(search.RepoStatusTimedout) && srr.Stats.Status.Len() == len(srr.Stats.Repos):
+	case stats.Status.All(search.RepoStatusTimedout) && stats.Status.Len() == len(stats.Repos):
 		return "timeout"
-	case srr.Stats.Status.Any(search.RepoStatusTimedout):
+	case stats.Status.Any(search.RepoStatusTimedout):
 		return "partial_timeout"
-	case srr.SearchResults.Alert != nil:
+	case alert != nil:
 		return "alert"
 	default:
 		return "success"

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -486,16 +486,14 @@ func logPrometheusBatch(status, alertType, requestSource, requestName string, el
 
 func (r *searchResolver) logBatch(ctx context.Context, srr *SearchResultsResolver, start time.Time, err error) {
 	elapsed := time.Since(start)
-	if srr != nil {
-		srr.elapsed = elapsed
-		var wg sync.WaitGroup
-		LogSearchLatency(ctx, r.db, &wg, r.SearchInputs, srr.ElapsedMilliseconds())
-		defer wg.Wait()
-	}
+	srr.elapsed = elapsed
+	var wg sync.WaitGroup
+	LogSearchLatency(ctx, r.db, &wg, r.SearchInputs, srr.ElapsedMilliseconds())
+	defer wg.Wait()
 
 	var status, alertType string
 	status = DetermineStatusForLogs(srr.SearchResults.Alert, srr.SearchResults.Stats, err)
-	if srr != nil && srr.SearchResults.Alert != nil {
+	if srr.SearchResults.Alert != nil {
 		alertType = srr.SearchResults.Alert.PrometheusType
 	}
 	requestSource := string(trace.RequestSource(ctx))

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -247,7 +247,7 @@ LOOP:
 	_ = eventWriter.Event("progress", progress.Final())
 
 	var status, alertType string
-	status = graphqlbackend.DetermineStatusForLogs(resultsResolver, err)
+	status = graphqlbackend.DetermineStatusForLogs(resultsResolver.SearchResults.Alert, resultsResolver.SearchResults.Stats, err)
 	if alert != nil {
 		alertType = alert.PrometheusType()
 	}


### PR DESCRIPTION
This just passes the requisite alert and stats to DetermineStatusForLogs
so that we can cut its dependency on resolver types. This is used in the
streaming code, so it's keeping us from cutting out resolver types.



## Test plan

Semantics preserving.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


