### PR TITLE
dev: support pining image tags by release version

### DIFF
--- a/dev/sg/internal/images/images.go
+++ b/dev/sg/internal/images/images.go
@@ -31,16 +31,16 @@ const (
 	DeploymentTypeHelm DeploymentType = "helm"
 )
 
-func Parse(path string, creds credentials.Credentials, deploy DeploymentType) error {
+func Parse(path string, creds credentials.Credentials, deploy DeploymentType, pinTag string) error {
 	if deploy == DeploymentTypeK8S {
-		return ParseK8S(path, creds)
+		return ParseK8S(path, creds, pinTag)
 	} else if deploy == DeploymentTypeHelm {
-		return ParseHelm(path, creds)
+		return ParseHelm(path, creds, pinTag)
 	}
 	return errors.Newf("deployment kind %s is not supported", deploy)
 }
 
-func ParseK8S(path string, creds credentials.Credentials) error {
+func ParseK8S(path string, creds credentials.Credentials, pinTag string) error {
 	rw := &kio.LocalPackageReadWriter{
 		KeepReaderAnnotations: false,
 		PreserveSeqIndent:     true,
@@ -56,7 +56,7 @@ func ParseK8S(path string, creds credentials.Credentials) error {
 
 	err := kio.Pipeline{
 		Inputs:                []kio.Reader{rw},
-		Filters:               []kio.Filter{imageFilter{credentials: &creds}},
+		Filters:               []kio.Filter{imageFilter{credentials: &creds, pinTag: pinTag}},
 		Outputs:               []kio.Writer{rw},
 		ContinueOnEmptyResult: true,
 	}.Execute()
@@ -91,7 +91,7 @@ func extraImages(m interface{}, acc *[]string) {
 	}
 }
 
-func ParseHelm(path string, creds credentials.Credentials) error {
+func ParseHelm(path string, creds credentials.Credentials, pinTag string) error {
 	valuesFilePath := filepath.Join(path, "values.yaml")
 	valuesFile, err := os.ReadFile(valuesFilePath)
 	if err != nil {
@@ -113,7 +113,7 @@ func ParseHelm(path string, creds credentials.Credentials) error {
 	valuesFileString := string(valuesFile)
 	for _, img := range images {
 		var updatedImg string
-		updatedImg, err = updateImage(img, creds)
+		updatedImg, err = updateImage(img, creds, pinTag)
 		if err != nil {
 			return errors.Wrapf(err, "couldn't update image %s", img)
 		}
@@ -142,6 +142,7 @@ func ParseHelm(path string, creds credentials.Credentials) error {
 
 type imageFilter struct {
 	credentials *credentials.Credentials
+	pinTag      string
 }
 
 var _ kio.Filter = &imageFilter{}
@@ -150,7 +151,7 @@ var _ kio.Filter = &imageFilter{}
 // Analogous to http://www.linfo.org/filters.html
 func (filter imageFilter) Filter(in []*yaml.RNode) ([]*yaml.RNode, error) {
 	for _, r := range in {
-		if err := findImage(r, *filter.credentials); err != nil {
+		if err := findImage(r, *filter.credentials, filter.pinTag); err != nil {
 			if errors.As(err, &ErrNoImage{}) || errors.Is(err, ErrNoUpdateNeeded) {
 				stdout.Out.Verbosef("Encountered expected err: %v\n", err)
 				continue
@@ -166,7 +167,7 @@ var conventionalInitContainerPaths = [][]string{
 	{"spec", "template", "spec", "initContainers"},
 }
 
-func findImage(r *yaml.RNode, credential credentials.Credentials) error {
+func findImage(r *yaml.RNode, credential credentials.Credentials, pinTag string) error {
 	containers, err := r.Pipe(yaml.LookupFirstMatch(yaml.ConventionalContainerPaths))
 	if err != nil {
 		return errors.Newf("%v: %s", err, r.GetName())
@@ -192,7 +193,7 @@ func findImage(r *yaml.RNode, credential credentials.Credentials) error {
 		if err != nil {
 			return err
 		}
-		updatedImage, err := updateImage(s, credential)
+		updatedImage, err := updateImage(s, credential, pinTag)
 		if err != nil {
 			return err
 		}
@@ -260,7 +261,7 @@ func parseImgString(rawImg string) (*ImageReference, error) {
 	return imgRef, nil
 }
 
-func updateImage(rawImage string, credential credentials.Credentials) (string, error) {
+func updateImage(rawImage string, credential credentials.Credentials, pinTag string) (string, error) {
 	imgRef, err := parseImgString(rawImage)
 	if err != nil {
 		return "", err
@@ -279,7 +280,7 @@ func updateImage(rawImage string, credential credentials.Credentials) (string, e
 		return prevRepo.imageRef.String(), nil
 	}
 
-	repo, err := createAndFillImageRepository(imgRef)
+	repo, err := createAndFillImageRepository(imgRef, pinTag)
 	if err != nil {
 		if errors.Is(err, ErrNoUpdateNeeded) {
 			return imgRef.String(), ErrNoUpdateNeeded
@@ -351,7 +352,7 @@ func (i *imageRepository) fetchAuthToken(registryName string) (string, error) {
 	return result.AccessToken, nil
 }
 
-func createAndFillImageRepository(ref *ImageReference) (repo *imageRepository, err error) {
+func createAndFillImageRepository(ref *ImageReference, pinTag string) (repo *imageRepository, err error) {
 
 	repo = &imageRepository{name: ref.Name, imageRef: ref}
 	repo.authToken, err = repo.fetchAuthToken(ref.Registry)
@@ -370,7 +371,11 @@ func createAndFillImageRepository(ref *ImageReference) (repo *imageRepository, e
 		Tag:      ref.Tag,
 	}
 
-	latestTag := findLatestTag(tags)
+	latestTag := pinTag
+	if pinTag == "" {
+		latestTag = findLatestTag(tags)
+	}
+
 	if latestTag == ref.Tag || latestTag == "" {
 		return repo, ErrNoUpdateNeeded
 	}

--- a/dev/sg/sg_ops.go
+++ b/dev/sg/sg_ops.go
@@ -32,6 +32,7 @@ var (
 	opsUpdateImagesDeploymentKindFlag            = opsUpdateImagesFlagSet.String("kind", string(images.DeploymentTypeK8S), "The kind of deployment (one of 'k8s', 'helm')")
 	opsUpdateImagesContainerRegistryUsernameFlag = opsUpdateImagesFlagSet.String("cr-username", "", "Username for the container registry")
 	opsUpdateImagesContainerRegistryPasswordFlag = opsUpdateImagesFlagSet.String("cr-password", "", "Password or access token for the container registry")
+	opsUpdateImagesPinTagFlag                    = opsUpdateImagesFlagSet.String("pin-tag", "", "Pin all images to a specific sourcegraph tag (e.g. 3.36.2, insiders)")
 	opsUpdateImagesCommand                       = &ffcli.Command{
 		Name:        "update-images",
 		ShortUsage:  "sg ops update-images [flags] <dir>",
@@ -83,5 +84,10 @@ func opsUpdateImage(ctx context.Context, args []string) error {
 		}
 	}
 
-	return images.Parse(args[0], *dockerCredentials, images.DeploymentType(*opsUpdateImagesDeploymentKindFlag))
+	if *opsUpdateImagesPinTagFlag == "" {
+		writeWarningLinef("No pin tag is provided.")
+		writeWarningLinef("Falling back to the latest deveopment build available.")
+	}
+
+	return images.Parse(args[0], *dockerCredentials, images.DeploymentType(*opsUpdateImagesDeploymentKindFlag), *opsUpdateImagesPinTagFlag)
 }


### PR DESCRIPTION
Dependency of https://github.com/sourcegraph/sourcegraph/pull/31141, a new flag `-pin-tag` is added to specific the target sg release or arbitrary tag (e.g., `insiders`).

## Test plan

### Helm

clone helm chart repo somewhere

```bash
git clone https://github.com/sourcegraph/deploy-sourcegraph-helm ~/Code/sourcegraph/deploy-sourcegraph-helm
```

Switch to `sg` directory
```bash
cd dev/sg
```

```bash
go run . ops update-images -kind helm -pin-tag 3.36.3 ~/Code/sourcegraph/deploy-sourcegraph-helm/charts/sourcegraph/.
```

Inspect the content of ~/Code/sourcegraph/deploy-sourcegraph-helm/charts/sourcegraph/values.yaml, all defaultTag should be replaced with the latest image tag+digest.

### K8S (kustomize)

clone deploy-sourcegraph repo somewhere

```bash
git clone https://github.com/sourcegraph/deploy-sourcegraph ~/Code/sourcegraph/deploy-sourcegraph
```

Switch to `sg` directory
```bash
cd dev/sg
```

```bash
go run . ops update-images -kind k8s -pin-tag 3.36.3 ~/Code/sourcegraph/deploy-sourcegraph/base/.
```

All resources in `base/*` should have their images tags updated

