### PR TITLE
Search backend: calculate DefaultLimit on demand

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -103,15 +103,6 @@ func NewSearchImplementer(ctx context.Context, db database.DB, args *SearchArgs)
 	}
 	tr.LazyPrintf("parsing done")
 
-	defaultLimit := defaultMaxSearchResults
-	if args.Stream != nil {
-		defaultLimit = defaultMaxSearchResultsStreaming
-	}
-	if searchType == query.SearchTypeStructural {
-		// Set a lower max result count until structural search supports true streaming.
-		defaultLimit = defaultMaxSearchResults
-	}
-
 	var codeMonitorID *int64
 	if args.CodeMonitorID != nil {
 		var i int64
@@ -133,7 +124,6 @@ func NewSearchImplementer(ctx context.Context, db database.DB, args *SearchArgs)
 		UserSettings:  settings,
 		Features:      featureflag.FromContext(ctx),
 		PatternType:   searchType,
-		DefaultLimit:  defaultLimit,
 		CodeMonitorID: codeMonitorID,
 		Protocol:      protocol,
 	}
@@ -227,11 +217,6 @@ type searchResolver struct {
 func (r *searchResolver) Inputs() run.SearchInputs {
 	return *r.SearchInputs
 }
-
-const (
-	defaultMaxSearchResults          = 30
-	defaultMaxSearchResultsStreaming = 500
-)
 
 var mockDecodedViewerFinalSettings *schema.Settings
 

--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -46,7 +46,7 @@ type Args struct {
 // Zoekt's internal inputs and representation. These concerns are all handled by
 // toSearchJob.
 func ToSearchJob(jargs *Args, q query.Q) (Job, error) {
-	maxResults := q.MaxResults(jargs.SearchInputs.DefaultLimit)
+	maxResults := q.MaxResults(jargs.SearchInputs.DefaultLimit())
 
 	b, err := query.ToBasicQuery(q)
 	if err != nil {
@@ -610,7 +610,7 @@ func toPatternExpressionJob(args *Args, q query.Basic) (Job, error) {
 }
 
 func ToEvaluateJob(args *Args, q query.Basic) (Job, error) {
-	maxResults := q.ToParseTree().MaxResults(args.SearchInputs.DefaultLimit)
+	maxResults := q.ToParseTree().MaxResults(args.SearchInputs.DefaultLimit())
 	timeout := search.TimeoutDuration(q)
 
 	var (

--- a/internal/search/run/run.go
+++ b/internal/search/run/run.go
@@ -3,13 +3,9 @@ package run
 import (
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/limits"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/schema"
-)
-
-const (
-	defaultMaxSearchResults          = 30
-	defaultMaxSearchResultsStreaming = 500
 )
 
 // SearchInputs contains fields we set before kicking off search.
@@ -32,7 +28,7 @@ func (inputs SearchInputs) MaxResults() int {
 // DefaultLimit is the default limit to use if not specified in query.
 func (inputs SearchInputs) DefaultLimit() int {
 	if inputs.Protocol == search.Batch || inputs.PatternType == query.SearchTypeStructural {
-		return defaultMaxSearchResults
+		return limits.DefaultMaxSearchResults
 	}
-	return defaultMaxSearchResultsStreaming
+	return limits.DefaultMaxSearchResultsStreaming
 }

--- a/internal/search/run/run.go
+++ b/internal/search/run/run.go
@@ -7,6 +7,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
+const (
+	defaultMaxSearchResults          = 30
+	defaultMaxSearchResultsStreaming = 500
+)
+
 // SearchInputs contains fields we set before kicking off search.
 type SearchInputs struct {
 	Plan          query.Plan // the comprehensive query plan
@@ -17,12 +22,17 @@ type SearchInputs struct {
 	Features      featureflag.FlagSet
 	CodeMonitorID *int64
 	Protocol      search.Protocol
-
-	// DefaultLimit is the default limit to use if not specified in query.
-	DefaultLimit int
 }
 
 // MaxResults computes the limit for the query.
 func (inputs SearchInputs) MaxResults() int {
-	return inputs.Query.MaxResults(inputs.DefaultLimit)
+	return inputs.Query.MaxResults(inputs.DefaultLimit())
+}
+
+// DefaultLimit is the default limit to use if not specified in query.
+func (inputs SearchInputs) DefaultLimit() int {
+	if inputs.Protocol == search.Batch || inputs.PatternType == query.SearchTypeStructural {
+		return defaultMaxSearchResults
+	}
+	return defaultMaxSearchResultsStreaming
 }


### PR DESCRIPTION
Rather than pre-calculating DefaultLimit and setting it on SearchInputs,
it can now be calculated from other values of SearchInputs, so this
changes it to a method on the SearchInputs type. This reduces the
footprint of the NewSearchImplementer function.



## Test plan

Semantics-preserving.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


