### PR TITLE
compute: don't panic in resolver for a nil compute match

### DIFF
--- a/enterprise/cmd/frontend/internal/compute/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/compute/resolvers/resolvers.go
@@ -202,6 +202,12 @@ func toResultResolverList(ctx context.Context, cmd compute.Command, matches []re
 		if err != nil {
 			return nil, err
 		}
+
+		if computeResult == nil {
+			// We processed a match that compute doesn't generate a result for.
+			continue
+		}
+
 		repoResolver := getRepoResolver(m.RepoName(), "")
 		path, commit := pathAndCommitFromResult(m)
 		result := toComputeResultResolver(computeResult, repoResolver, path, commit)

--- a/enterprise/cmd/frontend/internal/compute/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/compute/resolvers/resolvers_test.go
@@ -12,15 +12,7 @@ import (
 )
 
 func TestToResultResolverList(t *testing.T) {
-	matches := []result.Match{
-		&result.FileMatch{
-			LineMatches: []*result.LineMatch{
-				{Preview: "a"},
-				{Preview: "b"},
-			},
-		},
-	}
-	test := func(input string) string {
+	test := func(input string, matches []result.Match) string {
 		computeQuery, _ := compute.Parse(input)
 		resolvers, _ := toResultResolverList(
 			context.Background(),
@@ -41,5 +33,16 @@ func TestToResultResolverList(t *testing.T) {
 		return string(v)
 	}
 
-	autogold.Want("resolver copies all match results", `["a","b"]`).Equal(t, test("a|b"))
+	nonNilMatches := []result.Match{
+		&result.FileMatch{
+			LineMatches: []*result.LineMatch{
+				{Preview: "a"},
+				{Preview: "b"},
+			},
+		},
+	}
+	autogold.Want("resolver copies all match results", `["a","b"]`).Equal(t, test("a|b", nonNilMatches))
+
+	producesNilResult := []result.Match{&result.CommitMatch{}}
+	autogold.Want("resolver ignores nil compute result", "[]").Equal(t, test("a|b", producesNilResult))
 }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/31195

@coury-clark : do you think it's appropriate to start documenting fixes for this in the changelog, since my understanding is customers now rely on this behavior for code insights (starting in beta?)

## Test plan
Adds a unit test.


