### PR TITLE
add no new line validator

### DIFF
--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/search-query-checks/SearchQueryChecks.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/search-query-checks/SearchQueryChecks.tsx
@@ -12,6 +12,7 @@ interface SearchQueryChecksProps {
         isValidPatternType: true | false | undefined
         isNotRepo: true | false | undefined
         isNotCommitOrDiff: true | false | undefined
+        isNoNewLines: true | false | undefined
     }
 }
 
@@ -46,9 +47,14 @@ export const SearchQueryChecks: React.FunctionComponent<SearchQueryChecksProps> 
     <div className={classNames(styles.checksWrapper)}>
         <ul className={classNames(styles.checks)}>
             <li>
+                <CheckListItem valid={checks.isNoNewLines}>
+                    Does not contain a match over more than a single line.
+                </CheckListItem>
+            </li>
+            <li>
                 <CheckListItem valid={checks.isValidOperator}>
-                    Does not contain boolean operator <code>AND</code> and <code>OR</code> (regular expression boolean
-                    operators can still be used)
+                    Does not contain boolean operators <code>AND</code>, <code>OR</code>, and <code>NOT</code> (regular
+                    expression boolean operators can still be used)
                 </CheckListItem>
             </li>
             <li>

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/search-query-validator.test.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/search-query-validator.test.ts
@@ -1,0 +1,46 @@
+import { searchQueryValidator } from './search-query-validator'
+
+// eslint-disable-next-line quotes
+const GOOD_QUERY = `patterntype:regexp required_version = \"(.*)\"  lang:Terraform archived:no fork:no`
+
+const PASSING_VALIDATION = {
+    isValidOperator: true,
+    isValidPatternType: true,
+    isNotRepo: true,
+    isNotCommitOrDiff: true,
+    isNoNewLines: true,
+}
+
+describe('searchQueryValidator', () => {
+    it('validates a known good string', () => {
+        expect(searchQueryValidator(GOOD_QUERY, true)).toEqual(PASSING_VALIDATION)
+    })
+
+    it.each(['and', 'or', 'not'])('validates not containing `%s`', (operator: string) => {
+        expect(searchQueryValidator(`${GOOD_QUERY} ${operator}`, true)).toEqual({
+            ...PASSING_VALIDATION,
+            isValidOperator: false,
+        })
+    })
+
+    it('validates not using `repo`', () => {
+        expect(searchQueryValidator(`${GOOD_QUERY} repo:any`, true)).toEqual({
+            ...PASSING_VALIDATION,
+            isNotRepo: false,
+        })
+    })
+
+    it.each(['type:commit', 'type:diff'])('validates not using `commit` or `diff`', (type: string) => {
+        expect(searchQueryValidator(`${GOOD_QUERY} ${type}`, true)).toEqual({
+            ...PASSING_VALIDATION,
+            isNotCommitOrDiff: false,
+        })
+    })
+
+    it('validates no new lines', () => {
+        expect(searchQueryValidator(`${GOOD_QUERY} \\n`, true)).toEqual({
+            ...PASSING_VALIDATION,
+            isNoNewLines: false,
+        })
+    })
+})

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/search-query-validator.test.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/search-query-validator.test.ts
@@ -1,7 +1,6 @@
 import { searchQueryValidator } from './search-query-validator'
 
-// eslint-disable-next-line quotes
-const GOOD_QUERY = `patterntype:regexp required_version = \"(.*)\"  lang:Terraform archived:no fork:no`
+const GOOD_QUERY = 'patterntype:regexp required_version = \\"(.*)\\"  lang:Terraform archived:no fork:no'
 
 const PASSING_VALIDATION = {
     isValidOperator: true,


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/30713

Adds "no new lines" check to capture group creation UI

![PixelSnap 2022-02-16 at 18 00 12](https://user-images.githubusercontent.com/1855233/154377928-e00aa050-7392-426f-af15-ac8b3f93205c.png)

## Test plan

- Go to insights and create new insight
- Select "Detect and track patterns"
- Add `\n` to the query. Should show error seen in image above.
