### PR TITLE
dev/buildchecker: add ability to export history to honeycomb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Temporary directory for whatever you want
+.tmp/
+
 # Vim
 *.swp
 

--- a/dev/buildchecker/README.md
+++ b/dev/buildchecker/README.md
@@ -28,10 +28,26 @@ Also see the [`buildchecker` GitHub Action workflow](../../.github/workflows/bui
 Writes aggregated historical data, including the builds it finds, to a few files.
 
 ```sh
-go run ./dev/buildchecker -buildkite.token=$BUILDKITE_TOKEN -failures.timeout=999 -created.from="2021-08-01" history
+go run ./dev/buildchecker \
+  -buildkite.token=$BUILDKITE_TOKEN \
+  -failures.timeout=999 \
+  -created.from="2021-08-01" \
+  history
 ```
 
-To load builds from a file instead of fetching from Buildkite, use `-load-from="$FILE"`.
+To load builds from a file instead of fetching from Buildkite, use `-builds.load-from="$FILE"`.
+
+You can also send metrics to Honeycomb with `-honeycomb.dataset` and `-honeycomb.token`:
+
+```sh
+go run ./dev/buildchecker \
+  -builds.load-from=".tmp/builds.json" \
+  -failures.timeout=999 \
+  -created.from="2021-08-01" \
+  -honeycomb.dataset="buildkite-history" \
+  -honeycomb.token=$HONEYCOMB_TOKEN \
+  history
+```
 
 ## Tokens
 

--- a/dev/buildchecker/history_test.go
+++ b/dev/buildchecker/history_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestGenerateHistory(t *testing.T) {
 	day := time.Date(2006, 01, 02, 0, 0, 0, 0, time.UTC)
-	dayString := day.Format("2006/01/02")
+	dayString := day.Format("2006-01-02")
 
 	tests := []struct {
 		name                    string
@@ -134,6 +134,49 @@ func TestGenerateHistory(t *testing.T) {
 			})
 			assert.Equal(t, gotFlakes, tt.wantFlakes, "flakes")
 			assert.Equal(t, gotConsecutiveFailures, tt.wantConsecutiveFailures, "consecutive failures")
+		})
+	}
+}
+
+func TestMapToRecords(t *testing.T) {
+	tests := []struct {
+		name        string
+		arg         map[string]int
+		wantRecords [][]string
+	}{{
+		name: "sorted",
+		arg: map[string]int{
+			"2022-01-02": 2,
+			"2022-01-01": 1,
+			"2022-01-03": 3,
+		},
+		wantRecords: [][]string{
+			{"2022-01-01", "1"},
+			{"2022-01-02", "2"},
+			{"2022-01-03", "3"},
+		},
+	}, {
+		name: "gaps filled in",
+		arg: map[string]int{
+			"2022-01-01": 1,
+			"2022-01-03": 3,
+			"2022-01-06": 6,
+			"2022-01-07": 7,
+		},
+		wantRecords: [][]string{
+			{"2022-01-01", "1"},
+			{"2022-01-02", "0"},
+			{"2022-01-03", "3"},
+			{"2022-01-04", "0"},
+			{"2022-01-05", "0"},
+			{"2022-01-06", "6"},
+			{"2022-01-07", "7"},
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotRecords := mapToRecords(tt.arg)
+			assert.Equal(t, tt.wantRecords, gotRecords)
 		})
 	}
 }


### PR DESCRIPTION
Adds the ability for `buildchecker history` to export data as Honeycomb events. Discussion: https://sourcegraph.slack.com/archives/C02MWRMAFR8/p1645055788009699

Closes https://github.com/sourcegraph/sourcegraph/issues/31260

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Test locally, create a dashboard