### PR TITLE
dev: add helm support to release cli

### DIFF
--- a/dev/release/src/chart.ts
+++ b/dev/release/src/chart.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'fs'
+
+import { load as loadYAML } from 'js-yaml'
+
+export interface Metadata {
+    apiVersion: string
+    name: string
+    description: string
+    type: string
+    version: string
+    appVersion: string
+}
+
+export function parseChartMetadata(chartYamlPath: string): Metadata {
+    const chartYamlContents = readFileSync(chartYamlPath, 'utf8').toString()
+    return loadYAML(chartYamlContents) as Metadata
+}


### PR DESCRIPTION
This PR semi-automates the releases of `sourcegraph/deploy-sourcegraph-helm`.

- Updates to `values.yaml` is fully automated, -> pin `images.defaultTag` to the current release
- Updates to `chart.yaml` is also fully automated
	- `appVersion` is pined to the sourcegraph release version number
	- `version` - bump minor for minor releases, bump patch for patch releases

## Assumption

- helm chart only supports the latest (`n`) version, so changes will always be made against the `main` branch, no long-live `release/x.y` branch

## Test plan

Reuse `3.36.0` patch release - https://github.com/sourcegraph/sourcegraph/issues/30562 is reopened for the sake of testing the workflow.

### Setup

Update `release-config.jsonc`

```json
{
    "previousRelease": "3.35.2",
    "upcomingRelease": "3.36.0",
    "dryRun": {
        "tags": true,
        "changesets": true,
        "trackingIssues": true,
        "calendar": true,
        "slack": true
    }
}
```

Comment out `ensureMainBranchUpToDate()` in `dev/release/src/main.ts:18` to bypass sanity check

### Run

> Notes, you may still get rate limited by docker hub if you run this command to often. Why? older `deploy-*` branches still use the outdated https://github.com/sourcegraph/update-docker-tags that doesn't support authenticated requests. You may comment out affected changeSets to workaround it.

```bash
yarn release release:stage
```

Inspect the diff, specifically the output for `deploy-sourcegraph-helm` repo

- You should see all references to our images getting pin to `3.36.0` along with the digest.
- `appVerion` is updated to `3.36.0`
- `version` minor is updated (I also tested it with a patch release, it works).

Sample output


```diff
Your branch is up to date with 'origin/main'.
+ sg ops update-images -kind helm -pin-tag 3.36.0 charts/sourcegraph/.
👉 Using credentials from docker credentials store (learn more https://docs.docker.com/engine/reference/commandline/login/#credentials-store)
+ gsed -i 's/appVersion:.*/appVersion: "3.36.0"/g' charts/sourcegraph/Chart.yaml
Dry run enabled - printing diff instead of publishing
+ git --no-pager diff
diff --git a/charts/sourcegraph/Chart.yaml b/charts/sourcegraph/Chart.yaml
index 17af686..ad27416 100644
--- a/charts/sourcegraph/Chart.yaml
+++ b/charts/sourcegraph/Chart.yaml
@@ -5,7 +5,7 @@ description: Chart for installing Sourcegraph
 type: application

 # Chart version, separate from Sourcegraph
-version: 0.2.1
+version: 0.3.0

 # Version of Sourcegraph release
-appVersion: "3.36.3"
+appVersion: "3.36.0"
diff --git a/charts/sourcegraph/values.yaml b/charts/sourcegraph/values.yaml
index 01cdd04..8cd8ace 100644
--- a/charts/sourcegraph/values.yaml
+++ b/charts/sourcegraph/values.yaml
@@ -74,7 +74,7 @@ sourcegraph:

 alpine: # Used in init containers
   image:
-    defaultTag: 3.36.3@sha256:98d8f68fe165fe9a665b6409955edc6d162ffc8a0fcdc02b574d938c8f87e18c
+    defaultTag: 3.36.0@sha256:83101c4d23fc0463d06a8629bff78795ade867369f8b9241c28dfcbc35425dc2
     name: "alpine-3.12"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -92,7 +92,7 @@ alpine: # Used in init containers
 cadvisor:
   enabled: true
   image:
-    defaultTag: 3.36.3@sha256:249c573262967979889a186344ba5cc4e8e9186ec4f26c759ce9f8527560da69
+    defaultTag: 3.36.0@sha256:bb2a4747e3b0698c281bd7abd2f0478f110f0d9772ccb1b42fd0020e6902ddf0
     name: "cadvisor"
   podSecurityPolicy:
     enabled: false
@@ -114,7 +114,7 @@ codeInsightsDB:
       value: password
   existingConfig: "" # Name of an existing configmap
   image:
-    defaultTag: 3.36.3@sha256:98133abeb1fc6d02ee9f0fca6cc3ab65e2a3a47a07db96a56aa0869389393fce
+    defaultTag: 3.36.0@sha256:96a46c9c54916651fb75301d600d20e9d44c47402dc0c4f846ef6bb687b656a4
     name: "codeinsights-db"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -139,7 +139,7 @@ codeIntelDB:
   enabled: true
   existingConfig: "" # Name of an existing configmap
   image:
-    defaultTag: 3.36.3@sha256:fe3e956733e6ad3599c79d8ca8754249281eb3918aab110e99189cc9b052e28a
+    defaultTag: 3.36.0@sha256:599fb3b16cd502455ed78a3a08728fd773749aa458cb3617ec8c836e82c53902
     name: "codeintel-db"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -191,7 +191,7 @@ frontend:
     PROMETHEUS_URL:
       value: http://prometheus:30090
   image:
-    defaultTag: 3.36.3@sha256:f446e633ea7b536bb1a634267dea2ad1220734e90b7649aa981e9240d39e7e0c
+    defaultTag: 3.36.0@sha256:ffda2c7314e1337f11ac05a6405aacd2d2b07ff14832848bd733611befc2e4fb
     name: "frontend"
   ingress:
     annotations:
@@ -223,7 +223,7 @@ frontend:

 githubProxy:
   image:
-    defaultTag: 3.36.3@sha256:0b8f2a3d5751bf2e438ce1784be5cac7da19bdca0a25623f03a64a652c8def0d
+    defaultTag: 3.36.0@sha256:9d9828bf452a8f15e6c63d8c5799c1fe7ee0c24fb616a0e76f81462476f43c39
     name: "github-proxy"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -241,7 +241,7 @@ githubProxy:

 gitserver:
   image:
-    defaultTag: 3.36.3@sha256:8830d2bd6a3ad1fefeb9b7e89471101fa8b3e342b5f0a80cb793985b9017f07b
+    defaultTag: 3.36.0@sha256:66c9ab0b6c246b58c71c848dce07a7b74a2d5aae18b2ee0c162c643261446705
     name: "gitserver"
   labels: {}
   podSecurityContext:
@@ -268,7 +268,7 @@ grafana:
   enabled: true
   existingConfig: "" # Name of an existing configmap
   image:
-    defaultTag: 3.36.3@sha256:064908bc5848234f2fa4d86f7289af38b707612f90d80008acabe805c27c8a15
+    defaultTag: 3.36.0@sha256:a15f979c66f59ef9c046d4bae5671ab51920f2e7222af7c336bba3381fc84155
     name: "grafana"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -294,7 +294,7 @@ grafana:

 indexedSearch:
   image:
-    defaultTag: 3.36.3@sha256:1399fbff116c249d4aec55c2c1e70c23e4617bf3a17921cfdede53893e97b533
+    defaultTag: 3.36.0@sha256:1399fbff116c249d4aec55c2c1e70c23e4617bf3a17921cfdede53893e97b533
     name: "indexed-searcher"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -318,7 +318,7 @@ indexedSearch:

 indexedSearchIndexer:
   image:
-    defaultTag: 3.36.3@sha256:a9a72e81cacdb644b0530229bd6b5c54dcd84d2d15d11976f28b59f970b85471
+    defaultTag: 3.36.0@sha256:a9a72e81cacdb644b0530229bd6b5c54dcd84d2d15d11976f28b59f970b85471
     name: "search-indexer"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -343,7 +343,7 @@ minio:
     MINIO_SECRET_KEY:
       value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
   image:
-    defaultTag: 3.36.3@sha256:66925bab722ed11584e1135687b5c1e00a13c550e38d954a56048c90f17edc53
+    defaultTag: 3.36.0@sha256:66925bab722ed11584e1135687b5c1e00a13c550e38d954a56048c90f17edc53
     name: "minio"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -368,7 +368,7 @@ pgsql:
   enabled: true
   existingConfig: "" # Name of an existing configmap
   image:
-    defaultTag: 3.36.3@sha256:8a07418646c33d74e749391da3470f37d5401edae588bb79655f8c7206257d49
+    defaultTag: 3.36.0@sha256:c1d6d4fe31efd05fca97ff5dd84285de0f6860be35cb20c971748b85350214a5
     name: "postgres-12.6-alpine"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -397,7 +397,7 @@ pgsql:

 postgresExporter:
   image:
-    defaultTag: 3.36.3@sha256:33163fc4ff3a4973f7ab02f11f13b2fb828a705e7576793319324858885f7996
+    defaultTag: 3.36.0@sha256:1bab3d6977e46dee1df4379c5eecb85ca0c4f5e55113c2e9e5a6fe98d06e35c1
     name: "postgres_exporter"
   resources:
     limits:
@@ -412,7 +412,7 @@ preciseCodeIntel:
     NUM_WORKERS:
       value: "4"
   image:
-    defaultTag: 3.36.3@sha256:a5c4622636404fd5d753d11c907cde27676839c46b294bd111c0fb3475a708d9
+    defaultTag: 3.36.0@sha256:8199c8543b2ff2a1afb00c4fd2cfb4eb48cde930e7c73f112ebc8969a25c08fd
     name: "precise-code-intel-worker"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -432,7 +432,7 @@ prometheus:
   enabled: true
   existingConfig: "" # Name of an existing configmap
   image:
-    defaultTag: 3.36.3@sha256:01e102854f9d5888cd961f3aa8af416c2d0336b8673eefd8b2c7a095246fc130
+    defaultTag: 3.36.0@sha256:22dc76d6c74a36fe75d7d3e0db59c789ade32a2643a14fe5bbc9c35c2d916341
     name: "prometheus"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -465,7 +465,7 @@ prometheus:
 redisCache:
   enabled: true
   image:
-    defaultTag: 3.36.3@sha256:4aa9d97e42ad44e035107c12af6605543afb27c5b3b8582721e8c12736129597
+    defaultTag: 3.36.0@sha256:5b0f1f588667e03dabd06a1d4a4dadaa0fd434ed1f01ae18cd8a5c22799ccd4c
     name: "redis-cache"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -487,7 +487,7 @@ redisCache:

 redisExporter:
   image:
-    defaultTag: 3.36.3@sha256:f3f51453e4261734f08579fe9c812c66ee443626690091401674be4fb724da70
+    defaultTag: 3.36.0@sha256:f3f51453e4261734f08579fe9c812c66ee443626690091401674be4fb724da70
     name: "redis_exporter"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -505,7 +505,7 @@ redisExporter:
 redisStore:
   enabled: true
   image:
-    defaultTag: 3.36.3@sha256:6f33f93d73b825c890f3eb22f9d1f760c92e21b19cc948a9f58921c8eb5bbfc0
+    defaultTag: 3.36.0@sha256:bfa4f8c9ce426d0531cd3e2797d55b575adde5c4525e94058ae2dbc1b2fbe77a
     name: "redis-store"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -527,7 +527,7 @@ redisStore:

 repoUpdater:
   image:
-    defaultTag: 3.36.3@sha256:e4c2c756a97c15da8c5e4e4b944ca3ed8b469ecb6f284e0bad598c6cbf0d8452
+    defaultTag: 3.36.0@sha256:8855a663c8ff5e6977417083ada43a1b275a7637f6bf20494d7191ffb191ba70
     name: "repo-updater"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -545,7 +545,7 @@ repoUpdater:

 searcher:
   image:
-    defaultTag: 3.36.3@sha256:c2ab00f8194fde6eec005bedb4296e86c1262f086e963577f669d480504df016
+    defaultTag: 3.36.0@sha256:9cbd7932b5647b43c387e34e33f3044af0aee45eb015b320cc169a9e66269c87
     name: "searcher"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -571,7 +571,7 @@ storageClass:

 symbols:
   image:
-    defaultTag: 3.36.3@sha256:6b75d298acdbad333ed33e077a815ffe12b45b7d7ee76438b9b81f61faf6b60b
+    defaultTag: 3.36.0@sha256:d7968c81dfa52906ccb2bea989710a08a533871dd8f32fea60e7f0ee435a8e9f
     name: "symbols"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -591,7 +591,7 @@ symbols:

 syntectServer:
   image:
-    defaultTag: 3.36.3@sha256:d1088ff81f2b700f5541d23a14910b850309ce9208058255816e771be9e1d49b
+    defaultTag: 3.36.0@sha256:b5814d6dd78b81d61c6477537c3f7839296e23344a7143486d48635ac6bb5ee5
     name: "syntax-highlighter"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -611,7 +611,7 @@ tracing:
   collector: {}
   enabled: true
   image:
-    defaultTag: 3.36.3@sha256:c95c0f563dfc946b06ff0ce8c7db6d66e62b09a937917d804828bc46503e517b
+    defaultTag: 3.36.0@sha256:a7b0f3fd2a36697a2557faacceadc1d0ccfe4cad9bf866ccce79c90498c337b8
     name: "jaeger-all-in-one"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -631,7 +631,7 @@ tracing:
 tracingAgent:
   enabled: true
   image:
-    defaultTag: 3.36.3@sha256:763056bd06bd0c16db2c9cad4c77999c8482d5a4dca40d4f6574e367ae2d62cd
+    defaultTag: 3.36.0@sha256:705dd340ef94853cf653d667e8487b788fa9643f8e2625a1b3d817354b1a282d
     name: "jaeger-agent"
   podSecurityContext:
     allowPrivilegeEscalation: false
@@ -648,7 +648,7 @@ tracingAgent:

 worker:
   image:
-    defaultTag: 3.36.3@sha256:b4e56f9f2b1dc6c603463b743aca7da9dfeff83677aa271ace5eacf9e70181b4
+    defaultTag: 3.36.0@sha256:d15dd16036e319561159cf043158449d41e76be8dc6f7abcef6ac7b5354f8689
     name: "worker"
   podSecurityContext:
     allowPrivilegeEscalation: false
sourcegraph/deploy-sourcegraph-helm: Preparing pull request for change from 'main' to 'publish-3.36.0':

Title: release: sourcegraph@3.36.0
Body: This pull request is part of the Sourcegraph 3.36.0 release.


* [Release batch change](https://k8s.sgdev.org/organizations/sourcegraph/batch-changes/release-sourcegraph-3.36.0)
* [Tracking issue](https://github.com/sourcegraph/sourcegraph/issues/29290)
sourcegraph/deploy-sourcegraph-helm (main): created pull request
✨  Done in 65.97s.
```