### PR TITLE
Wildcard V2: Unset reach-ui styles for selected `MenuItem`

### DIFF
--- a/client/web/src/enterprise/searchContexts/SearchContextOwnerDropdown.module.scss
+++ b/client/web/src/enterprise/searchContexts/SearchContextOwnerDropdown.module.scss
@@ -16,23 +16,7 @@
 }
 
 .menu-list {
-    [data-reach-menu-item] {
-        &[data-selected] {
-            --text-muted: var(--white);
-
-            &:hover {
-                :global(.theme-light) & {
-                    --text-muted: var(--gray-07);
-                }
-
-                :global(.theme-dark) & {
-                    --text-muted: var(--gray-06);
-                }
-
-                &:active {
-                    --text-muted: var(--white);
-                }
-            }
-        }
+    [data-reach-menu-item]:active {
+        --text-muted: var(--white);
     }
 }

--- a/client/wildcard/src/components/Menu/Menu.story.tsx
+++ b/client/wildcard/src/components/Menu/Menu.story.tsx
@@ -1,4 +1,5 @@
 import { Meta, Story } from '@storybook/react'
+import { noop } from 'lodash'
 import React from 'react'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
@@ -38,9 +39,15 @@ export const MenuExample: Story = () => (
             <MenuHeader>This is a menu</MenuHeader>
             <MenuItem onSelect={() => alert('Clicked!')}>Click me</MenuItem>
             <MenuItem onSelect={() => alert('Clicked!')}>Alternative action</MenuItem>
+            <MenuItem onSelect={noop} disabled={true}>
+                I'm disabled
+            </MenuItem>
             <MenuDivider />
             <MenuLink as={Link} to="https://www.example.com">
                 Go somewhere
+            </MenuLink>
+            <MenuLink disabled={true} as={Link} to="https://www.example.com">
+                Disabled link
             </MenuLink>
         </MenuList>
     </Menu>

--- a/client/wildcard/src/components/Menu/MenuItem.module.scss
+++ b/client/wildcard/src/components/Menu/MenuItem.module.scss
@@ -1,4 +1,9 @@
 .item[data-reach-menu-item] {
+    &[aria-disabled]:active,
+    &[aria-disabled]:hover {
+        background-color: unset;
+        color: unset;
+    }
     &[data-selected]:not(:active) {
         background-color: var(--dropdown-link-hover-bg);
         color: unset;

--- a/client/wildcard/src/components/Menu/MenuItem.module.scss
+++ b/client/wildcard/src/components/Menu/MenuItem.module.scss
@@ -1,0 +1,6 @@
+.item[data-reach-menu-item] {
+    &[data-selected]:not(:active) {
+        background-color: var(--dropdown-link-hover-bg);
+        color: unset;
+    }
+}

--- a/client/wildcard/src/components/Menu/MenuItem.tsx
+++ b/client/wildcard/src/components/Menu/MenuItem.tsx
@@ -4,6 +4,8 @@ import React from 'react'
 
 import { ForwardReferenceComponent } from '../../types'
 
+import styles from './MenuItem.module.scss'
+
 export type MenuItemProps = ReachMenuItemProps
 
 /**
@@ -14,7 +16,7 @@ export type MenuItemProps = ReachMenuItemProps
  * @see — Docs https://reach.tech/menu-button#menuitem
  */
 export const MenuItem = React.forwardRef(({ children, className, ...props }, reference) => (
-    <ReachMenuItem ref={reference} {...props} className={classNames('dropdown-item', className)}>
+    <ReachMenuItem ref={reference} {...props} className={classNames('dropdown-item', styles.item, className)}>
         {children}
     </ReachMenuItem>
 )) as ForwardReferenceComponent<'div', MenuItemProps>

--- a/client/wildcard/src/components/Menu/MenuLink.tsx
+++ b/client/wildcard/src/components/Menu/MenuLink.tsx
@@ -4,6 +4,8 @@ import React from 'react'
 
 import { ForwardReferenceComponent } from '../../types'
 
+import styles from './MenuItem.module.scss'
+
 export type MenuLinkProps = ReachMenuLinkProps
 
 /**
@@ -15,5 +17,5 @@ export type MenuLinkProps = ReachMenuLinkProps
  * @see — Docs https://reach.tech/menu-button#menulink
  */
 export const MenuLink = React.forwardRef(({ className, ...props }, reference) => (
-    <ReachMenuLink ref={reference} {...props} className={classNames('dropdown-item', className)} />
+    <ReachMenuLink ref={reference} {...props} className={classNames('dropdown-item', styles.item, className)} />
 )) as ForwardReferenceComponent<'a', MenuLinkProps>


### PR DESCRIPTION
One of the benefits of Reach UI's collection of `Menu` components is that they have baked-in accessibility affordances, like being able to use the arrow keys to navigate up and down the children `MenuLink`s and `MenuItem`s while keeping focus on the parent. However, it seems we weren't overriding Reach UI's default styles that are applied to an item selected in this way, which left us with an ugly dark gray-blue background color that doesn't match anything else in Sourcegraph. This PR unsets that background color, as well as the white font color, and aligns it to our brand's hover style instead.

Before | After
:------:|:------:
<video src="https://user-images.githubusercontent.com/8942601/154381362-6228aa48-54e0-452d-9475-a694b0c5141e.mov"> | <video src="https://user-images.githubusercontent.com/8942601/154382176-9c49a946-15b8-405e-9e2a-313645b59fce.mov">

Making this change also allows us to remove several custom stylesheets that were overwriting this in individual places. There may be more to be cleaned up there, but I only checked a couple instances.

We also had active/hover styles applying to disabled `MenuItem`s and `MenuLink`s, which made it confusing whether or not you could interact with them. These styles have also been unset, and elements have been added to the Storybook story to cover them.

Before | After
:------:|:------:
<video src="https://user-images.githubusercontent.com/8942601/154390479-ff85b60c-6083-4313-9abc-e4092af749c7.mov"> | <video src="https://user-images.githubusercontent.com/8942601/154390519-de7854a4-a297-4e92-ba16-a28c7889584e.mov">

## Test plan

Verified visually in Storybook, as well as verifying most instances of the component by hand:
- `ExtensionRegistrySidenav`
- `SearchContextOwnerDropdown`
- `MenuNavItem`
- `UserNavItem`
- `NavDropdown`
- `OrgMembersListPage` settings
- `OrgPendingInvites` settings 

No current instances of `Menu` currently had disabled items to test. Elements have been added to the Storybook story to cover this behavior.

I don't have code insights set up locally so I was unable to verify those instances but, inspecting the code, I expect it to be low risk.


