### PR TITLE
search: move repo status logic to search package

### DIFF
--- a/internal/search/repo_status.go
+++ b/internal/search/repo_status.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // RepoStatus is a bit flag encoding the status of a search on a repository. A
@@ -139,9 +142,9 @@ func (m *RepoStatusMap) String() string {
 	return fmt.Sprintf("RepoStatusMap{N=%d %s}", len(m.m), m.status)
 }
 
-// RepoStatusSingleton is a convenience function to contain a RepoStatusMap
+// repoStatusSingleton is a convenience function to contain a RepoStatusMap
 // with one entry.
-func RepoStatusSingleton(id api.RepoID, status RepoStatus) RepoStatusMap {
+func repoStatusSingleton(id api.RepoID, status RepoStatus) RepoStatusMap {
 	if status == 0 {
 		return RepoStatusMap{}
 	}
@@ -149,4 +152,37 @@ func RepoStatusSingleton(id api.RepoID, status RepoStatus) RepoStatusMap {
 		m:      map[api.RepoID]RepoStatus{id: status},
 		status: status,
 	}
+}
+
+// HandleRepoSearchResult returns information about repository status, whether
+// search limits are hit, and error promotion. If searchErr is a fatal error, it
+// returns a non-nil error; otherwise, if searchErr == nil or a non-fatal error,
+// it returns a nil error.
+func HandleRepoSearchResult(repoRev *RepositoryRevisions, limitHit, timedOut bool, searchErr error) (RepoStatusMap, bool, error) {
+	var fatalErr error
+	var status RepoStatus
+	if limitHit {
+		status |= RepoStatusLimitHit
+	}
+
+	if gitdomain.IsRepoNotExist(searchErr) {
+		if gitdomain.IsCloneInProgress(searchErr) {
+			status |= RepoStatusCloning
+		} else {
+			status |= RepoStatusMissing
+		}
+	} else if errors.HasType(searchErr, &gitdomain.RevisionNotFoundError{}) {
+		if len(repoRev.Revs) == 0 || len(repoRev.Revs) == 1 && repoRev.Revs[0].RevSpec == "" {
+			// If we didn't specify an input revision, then the repo is empty and can be ignored.
+		} else {
+			fatalErr = searchErr
+		}
+	} else if errcode.IsNotFound(searchErr) {
+		status |= RepoStatusMissing
+	} else if errcode.IsTimeout(searchErr) || errcode.IsTemporary(searchErr) || timedOut {
+		status |= RepoStatusTimedout
+	} else if searchErr != nil {
+		fatalErr = searchErr
+	}
+	return repoStatusSingleton(repoRev.Repo.ID, status), limitHit, fatalErr
 }

--- a/internal/search/repo_status_test.go
+++ b/internal/search/repo_status_test.go
@@ -141,7 +141,7 @@ func TestRepoStatusMap_nil(t *testing.T) {
 }
 
 func TestRepoStatusSingleton(t *testing.T) {
-	x := RepoStatusSingleton(123, RepoStatusTimedout|RepoStatusLimitHit)
+	x := repoStatusSingleton(123, RepoStatusTimedout|RepoStatusLimitHit)
 	want := mkStatusMap(map[api.RepoID]RepoStatus{
 		123: RepoStatusTimedout | RepoStatusLimitHit,
 	})

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -86,10 +86,12 @@ func symbolSearchInRepos(
 			defer run.Release()
 
 			matches, err := searchInRepo(ctx, repoRevs, patternInfo, limit)
-			stats, err := searchrepos.HandleRepoSearchResult(repoRevs, len(matches) > limit, false, err)
+			status, limitHit, err := search.HandleRepoSearchResult(repoRevs, len(matches) > limit, false, err)
 			stream.Send(streaming.SearchEvent{
-				Results: matches,
-				Stats:   stats,
+				Stats: streaming.Stats{
+					Status:     status,
+					IsLimitHit: limitHit,
+				},
 			})
 			if err != nil {
 				tr.LogFields(otlog.String("repo", string(repoRevs.Repo.Name)), otlog.Error(err))

--- a/internal/search/textsearch/textsearch.go
+++ b/internal/search/textsearch/textsearch.go
@@ -285,9 +285,12 @@ func CallSearcherOverRepos(
 						log15.Warn("searchFilesInRepo failed", "error", err, "repo", repoRev.Repo.Name)
 					}
 					// non-diff search reports timeout through err, so pass false for timedOut
-					stats, err := searchrepos.HandleRepoSearchResult(repoRev, repoLimitHit, false, err)
+					status, limitHit, err := search.HandleRepoSearchResult(repoRev, repoLimitHit, false, err)
 					stream.Send(streaming.SearchEvent{
-						Stats: stats,
+						Stats: streaming.Stats{
+							Status:     status,
+							IsLimitHit: limitHit,
+						},
 					})
 					return err
 				})


### PR DESCRIPTION
`HandleRepoSearchResult` lives in the `repos` package, and the package is not allowed to be called from `internal` because it uses `db`. On closer inspection, this function is only called from symbol and text searches, so it can plausibly live somewhere else: https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+searchrepos.HandleRepoSearchResult&patternType=literal

A better place is `search/repo_status.go`, given it's just doing status/limit checks on repo results. One side effect is that this function cannot import `streaming` (cyclic dependency) which is easily resolved by not depending on the `streaming.Stats` result type, and instead creating that in symbol/text search.'

Setup so I can merge https://github.com/sourcegraph/sourcegraph/pull/31290

## Test plan
Just moving things around, covered by tests.


