### PR TITLE
batches: clean up dropdown menu buttons

### DIFF
--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -140,6 +140,7 @@ $theme-colors: (
     --border-color: var(--gray-03);
     --border-color-2: var(--gray-04);
     --border-active-color: var(--primary);
+    --border-primary-color: #0f59aa; // = dark variant of primary-2
     --search-query-text-color: var(--gray-12);
     --search-filter-keyword-color: var(--primary);
     --search-filter-separator-color: var(--oc-gray-6);
@@ -198,6 +199,7 @@ $theme-colors: (
     --border-color: var(--gray-09);
     --border-color-2: var(--gray-08);
     --border-active-color: #4393e7;
+    --border-primary-color: #0f59aa; // = dark variant of primary-2
     --search-query-text-color: var(--gray-04);
     --search-filter-keyword-color: #4393e7;
     --search-filter-separator-color: var(--oc-gray-6);

--- a/client/web/src/enterprise/batches/DropdownButton.module.scss
+++ b/client/web/src/enterprise/batches/DropdownButton.module.scss
@@ -4,7 +4,7 @@
 }
 
 .menu-list {
-    width: 350px;
+    width: 22rem;
     // NOTE: The default provided by reach-ui is 'nowrap', which causes overflow scroll
     // behavior rather than wrapping.
     white-space: normal;

--- a/client/web/src/enterprise/batches/DropdownButton.module.scss
+++ b/client/web/src/enterprise/batches/DropdownButton.module.scss
@@ -1,8 +1,19 @@
 .dropdown-button {
-    // Added padding from .dropdown-toggle-split to overide default padding
-    padding: 0.375rem 0.5625rem;
+    border-left: 1px solid var(--border-primary-color);
+    padding: 0 0.25rem;
+}
 
-    &__item {
-        min-width: min(90vw, 350px);
+.menu-list {
+    width: 350px;
+    // NOTE: The default provided by reach-ui is 'nowrap', which causes overflow scroll
+    // behavior rather than wrapping.
+    white-space: normal;
+}
+
+.menu-list-item {
+    padding: 0.5rem 1rem;
+
+    &[data-reach-menu-item]:active {
+        --text-muted: var(--white);
     }
 }

--- a/client/web/src/enterprise/batches/DropdownButton.story.tsx
+++ b/client/web/src/enterprise/batches/DropdownButton.story.tsx
@@ -24,6 +24,7 @@ const action: Action = {
 const disabledAction: Action = {
     type: 'disabled-action-type',
     buttonLabel: 'Disabled action',
+    disabled: true,
     dropdownTitle: 'Disabled action',
     dropdownDescription: 'Perform an action, if only this were enabled',
     onTrigger,
@@ -66,7 +67,7 @@ add('Multiple actions with default', () => (
         {() => (
             <DropdownButton
                 actions={[action, disabledAction, experimentalAction]}
-                defaultAction={1}
+                defaultAction={0}
                 {...commonKnobs()}
             />
         )}

--- a/client/web/src/enterprise/batches/create/ExecutionOptions.module.scss
+++ b/client/web/src/enterprise/batches/create/ExecutionOptions.module.scss
@@ -1,10 +1,10 @@
 .execution-options-menu-button {
-    border-left: 1px solid var(--primary-3);
     &::after {
         // Overwrite left margin -- otherwise it applies a margin to the `VisuallyHidden`
         // and shifts too far left
         margin-left: 0;
     }
+    border-left: 1px solid var(--border-primary-color);
 }
 
 .execution-option:last-child {

--- a/client/web/src/enterprise/batches/create/ExecutionOptions.module.scss
+++ b/client/web/src/enterprise/batches/create/ExecutionOptions.module.scss
@@ -19,9 +19,6 @@
 
 .menu-list {
     width: 17rem;
-    // NOTE: The default provided by reach-ui is 'nowrap', which causes overflow scroll
-    // behavior rather than wrapping.
-    white-space: normal;
 }
 
 .expanded-info {

--- a/client/web/src/enterprise/batches/create/ExecutionOptions.module.scss
+++ b/client/web/src/enterprise/batches/create/ExecutionOptions.module.scss
@@ -1,14 +1,10 @@
 .execution-options-menu-button {
-    &::after {
-        // Overwrite left margin -- otherwise it applies a margin to the `VisuallyHidden`
-        // and shifts too far left
-        margin-left: 0;
-    }
     border-left: 1px solid var(--border-primary-color);
+    padding: 0 0.25rem;
 }
 
 .execution-option:last-child {
-    padding-bottom: 1rem;
+    margin-bottom: 1rem;
 }
 
 .execution-option-form {

--- a/client/web/src/enterprise/batches/create/ExecutionOptions.tsx
+++ b/client/web/src/enterprise/batches/create/ExecutionOptions.tsx
@@ -1,18 +1,18 @@
 import VisuallyHidden from '@reach/visually-hidden'
-import classNames from 'classnames'
+import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
 import InfoCircleOutlineIcon from 'mdi-react/InfoCircleOutlineIcon'
-import React from 'react'
+import React, { useState } from 'react'
 import { animated } from 'react-spring'
 
 import {
     Button,
-    Menu,
-    MenuButton,
     Checkbox,
     ButtonGroup,
-    MenuList,
     Position,
     useAccordion,
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
 } from '@sourcegraph/wildcard'
 
 import styles from './ExecutionOptions.module.scss'
@@ -35,74 +35,91 @@ export const ExecutionOptionsDropdown: React.FunctionComponent<ExecutionOptionsD
     executionTooltip,
     options,
     onChangeOptions,
-}) => (
-    <Menu>
-        <ButtonGroup className="mb-2">
-            <Button variant="primary" onClick={execute} disabled={isExecutionDisabled} data-tooltip={executionTooltip}>
-                Run batch spec
-            </Button>
-            <MenuButton variant="primary" className={classNames(styles.executionOptionsMenuButton, 'dropdown-toggle')}>
-                <VisuallyHidden>Options</VisuallyHidden>
-            </MenuButton>
-        </ButtonGroup>
-        <MenuList className={styles.menuList} position={Position.bottomEnd}>
-            <h3 className="pb-2 pt-3 pl-3 pr-3 m-0">Execution options</h3>
-            <ExecutionOption moreInfo="When this batch spec is executed, it will not use cached results from any previous execution.">
-                <Checkbox
-                    name="run-without-cache"
-                    id="run-without-cache"
-                    checked={options.runWithoutCache}
-                    onChange={() => onChangeOptions({ runWithoutCache: !options.runWithoutCache })}
-                    label="Run without cache"
-                />
-            </ExecutionOption>
-            <ExecutionOption disabled={true} disabledTooltip="Coming soon">
-                <Checkbox
-                    name="apply-when-complete"
-                    id="apply-when-complete"
-                    checked={false}
-                    disabled={true}
-                    label="Apply when complete"
-                />
-            </ExecutionOption>
-        </MenuList>
-    </Menu>
-)
+}) => {
+    const [isOpen, setIsOpen] = useState(false)
 
-interface ExecutionOptionProps {
-    disabled?: boolean
-    disabledTooltip?: string
-    moreInfo?: string
+    return (
+        // We need to use `Popover` instead of `Menu` because `MenuList` doesn't support
+        // native tab indexing through the children; the parent holds focus instead,
+        // similarly to a native dropdown selector.
+        <Popover isOpen={isOpen} onOpenChange={event => setIsOpen(event.isOpen)}>
+            <ButtonGroup className="mb-2">
+                <Button
+                    variant="primary"
+                    onClick={execute}
+                    disabled={isExecutionDisabled}
+                    data-tooltip={executionTooltip}
+                >
+                    Run batch spec
+                </Button>
+                <PopoverTrigger
+                    as={Button}
+                    variant="primary"
+                    type="button"
+                    className={styles.executionOptionsMenuButton}
+                >
+                    <ChevronDownIcon />
+                    <VisuallyHidden>Options</VisuallyHidden>
+                </PopoverTrigger>
+            </ButtonGroup>
+
+            <PopoverContent className={styles.menuList} position={Position.bottomEnd}>
+                <h3 className="pb-2 pt-3 pl-3 pr-3 m-0">Execution options</h3>
+                <ExecutionOption moreInfo="When this batch spec is executed, it will not use cached results from any previous execution.">
+                    <Checkbox
+                        name="run-without-cache"
+                        id="run-without-cache"
+                        checked={options.runWithoutCache}
+                        onChange={() => onChangeOptions({ runWithoutCache: !options.runWithoutCache })}
+                        label="Run without cache"
+                    />
+                </ExecutionOption>
+                <ExecutionOption disabled={true} disabledTooltip="Coming soon">
+                    <Checkbox
+                        name="apply-when-complete"
+                        id="apply-when-complete"
+                        checked={false}
+                        disabled={true}
+                        label="Apply when complete"
+                    />
+                </ExecutionOption>
+            </PopoverContent>
+        </Popover>
+    )
 }
 
-const ExecutionOption: React.FunctionComponent<ExecutionOptionProps> = ({
-    disabled = false,
-    disabledTooltip,
-    moreInfo,
-    children,
-}) => {
+type ExecutionOptionProps =
+    | {
+          disabled?: false
+          moreInfo?: string
+      }
+    | {
+          disabled: true
+          disabledTooltip: string
+      }
+
+const ExecutionOption: React.FunctionComponent<ExecutionOptionProps> = props => {
     const [infoReference, infoOpen, setInfoOpen, infoStyle] = useAccordion<HTMLParagraphElement>()
 
-    const info =
-        disabled && !!disabledTooltip ? (
-            <InfoCircleOutlineIcon className="icon-inline ml-2" data-tooltip="Coming soon" />
-        ) : moreInfo ? (
-            <Button className="m-0 ml-2 p-0 border-0" onClick={() => setInfoOpen(!infoOpen)}>
-                <InfoCircleOutlineIcon className="icon-inline" aria-hidden={true} />
-                <VisuallyHidden>More info</VisuallyHidden>
-            </Button>
-        ) : null
+    const info = props.disabled ? (
+        <InfoCircleOutlineIcon className="icon-inline ml-2" data-tooltip={props.disabledTooltip} tabIndex={0} />
+    ) : props.moreInfo ? (
+        <Button className="m-0 ml-2 p-0 border-0" onClick={() => setInfoOpen(!infoOpen)}>
+            <InfoCircleOutlineIcon className="icon-inline" aria-hidden={true} />
+            <VisuallyHidden>More info</VisuallyHidden>
+        </Button>
+    ) : null
 
     return (
         <div className={styles.executionOption}>
             <div className={styles.executionOptionForm}>
-                {children}
+                {props.children}
                 {info}
             </div>
-            {!disabled && moreInfo && (
+            {!props.disabled && props.moreInfo && (
                 <animated.div className={styles.expandedInfo} style={infoStyle}>
                     <p className="m-0 pb-2" ref={infoReference}>
-                        {moreInfo}
+                        {props.moreInfo}
                     </p>
                 </animated.div>
             )}

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
@@ -144,8 +144,6 @@ export interface ChangesetSelectRowProps {
 
     /** For testing only. */
     queryAllChangesetIDs?: typeof _queryAllChangesetIDs
-    /** For testing only. */
-    dropDownInitiallyOpen?: boolean
 }
 
 /**
@@ -157,7 +155,6 @@ export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps
     onSubmit,
     queryArguments,
     queryAllChangesetIDs = _queryAllChangesetIDs,
-    dropDownInitiallyOpen = false,
 }) => {
     const { areAllVisibleSelected, selected, selectAll } = useContext(MultiSelectContext)
 
@@ -214,11 +211,7 @@ export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps
                 <div className="m-0 col col-md-auto">
                     <div className="row no-gutters">
                         <div className="col ml-0 ml-sm-2">
-                            <DropdownButton
-                                actions={actions}
-                                initiallyOpen={dropDownInitiallyOpen}
-                                placeholder="Select action"
-                            />
+                            <DropdownButton actions={actions} placeholder="Select action" />
                         </div>
                     </div>
                 </div>

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
@@ -216,7 +216,6 @@ export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps
                         <div className="col ml-0 ml-sm-2">
                             <DropdownButton
                                 actions={actions}
-                                dropdownMenuPosition="right"
                                 initiallyOpen={dropDownInitiallyOpen}
                                 placeholder="Select action"
                             />

--- a/client/web/src/enterprise/batches/preview/list/PreviewSelectRow.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewSelectRow.tsx
@@ -53,8 +53,6 @@ const getPublicationStateFromAction = (action: Action): Scalars['PublishedValue'
 export interface PreviewSelectRowProps {
     queryArguments: BatchSpecApplyPreviewVariables
     /** For testing only. */
-    dropDownInitiallyOpen?: boolean
-    /** For testing only. */
     queryPublishableChangesetSpecIDs?: typeof _queryPublishableChangesetSpecIDs
 }
 
@@ -63,7 +61,6 @@ export interface PreviewSelectRowProps {
  * the X selected label. Provides select ALL functionality.
  */
 export const PreviewSelectRow: React.FunctionComponent<PreviewSelectRowProps> = ({
-    dropDownInitiallyOpen = false,
     queryPublishableChangesetSpecIDs = _queryPublishableChangesetSpecIDs,
     queryArguments,
 }) => {
@@ -122,11 +119,7 @@ export const PreviewSelectRow: React.FunctionComponent<PreviewSelectRowProps> = 
                 <div className="m-0 col col-md-auto">
                     <div className="row no-gutters">
                         <div className="col ml-0 ml-sm-2">
-                            <DropdownButton
-                                actions={actions}
-                                initiallyOpen={dropDownInitiallyOpen}
-                                placeholder="Select action on apply"
-                            />
+                            <DropdownButton actions={actions} placeholder="Select action on apply" />
                         </div>
                     </div>
                 </div>

--- a/client/web/src/enterprise/batches/preview/list/PreviewSelectRow.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewSelectRow.tsx
@@ -124,7 +124,6 @@ export const PreviewSelectRow: React.FunctionComponent<PreviewSelectRowProps> = 
                         <div className="col ml-0 ml-sm-2">
                             <DropdownButton
                                 actions={actions}
-                                dropdownMenuPosition="right"
                                 initiallyOpen={dropDownInitiallyOpen}
                                 placeholder="Select action on apply"
                             />

--- a/client/web/src/enterprise/searchContexts/SearchContextOwnerDropdown.module.scss
+++ b/client/web/src/enterprise/searchContexts/SearchContextOwnerDropdown.module.scss
@@ -16,23 +16,7 @@
 }
 
 .menu-list {
-    [data-reach-menu-item] {
-        &[data-selected] {
-            --text-muted: var(--white);
-
-            &:hover {
-                :global(.theme-light) & {
-                    --text-muted: var(--gray-07);
-                }
-
-                :global(.theme-dark) & {
-                    --text-muted: var(--gray-06);
-                }
-
-                &:active {
-                    --text-muted: var(--white);
-                }
-            }
-        }
+    [data-reach-menu-item]:active {
+        --text-muted: var(--white);
     }
 }

--- a/client/wildcard/src/components/Menu/Menu.story.tsx
+++ b/client/wildcard/src/components/Menu/Menu.story.tsx
@@ -1,4 +1,5 @@
 import { Meta, Story } from '@storybook/react'
+import { noop } from 'lodash'
 import React from 'react'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
@@ -38,9 +39,15 @@ export const MenuExample: Story = () => (
             <MenuHeader>This is a menu</MenuHeader>
             <MenuItem onSelect={() => alert('Clicked!')}>Click me</MenuItem>
             <MenuItem onSelect={() => alert('Clicked!')}>Alternative action</MenuItem>
+            <MenuItem onSelect={noop} disabled={true}>
+                I'm disabled
+            </MenuItem>
             <MenuDivider />
             <MenuLink as={Link} to="https://www.example.com">
                 Go somewhere
+            </MenuLink>
+            <MenuLink disabled={true} as={Link} to="https://www.example.com">
+                Disabled link
             </MenuLink>
         </MenuList>
     </Menu>

--- a/client/wildcard/src/components/Menu/MenuItem.module.scss
+++ b/client/wildcard/src/components/Menu/MenuItem.module.scss
@@ -1,4 +1,9 @@
 .item[data-reach-menu-item] {
+    &[aria-disabled]:active,
+    &[aria-disabled]:hover {
+        background-color: unset;
+        color: unset;
+    }
     &[data-selected]:not(:active) {
         background-color: var(--dropdown-link-hover-bg);
         color: unset;

--- a/client/wildcard/src/components/Menu/MenuItem.module.scss
+++ b/client/wildcard/src/components/Menu/MenuItem.module.scss
@@ -1,0 +1,6 @@
+.item[data-reach-menu-item] {
+    &[data-selected]:not(:active) {
+        background-color: var(--dropdown-link-hover-bg);
+        color: unset;
+    }
+}

--- a/client/wildcard/src/components/Menu/MenuItem.tsx
+++ b/client/wildcard/src/components/Menu/MenuItem.tsx
@@ -4,6 +4,8 @@ import React from 'react'
 
 import { ForwardReferenceComponent } from '../../types'
 
+import styles from './MenuItem.module.scss'
+
 export type MenuItemProps = ReachMenuItemProps
 
 /**
@@ -14,7 +16,7 @@ export type MenuItemProps = ReachMenuItemProps
  * @see — Docs https://reach.tech/menu-button#menuitem
  */
 export const MenuItem = React.forwardRef(({ children, className, ...props }, reference) => (
-    <ReachMenuItem ref={reference} {...props} className={classNames('dropdown-item', className)}>
+    <ReachMenuItem ref={reference} {...props} className={classNames('dropdown-item', styles.item, className)}>
         {children}
     </ReachMenuItem>
 )) as ForwardReferenceComponent<'div', MenuItemProps>

--- a/client/wildcard/src/components/Menu/MenuLink.tsx
+++ b/client/wildcard/src/components/Menu/MenuLink.tsx
@@ -4,6 +4,8 @@ import React from 'react'
 
 import { ForwardReferenceComponent } from '../../types'
 
+import styles from './MenuItem.module.scss'
+
 export type MenuLinkProps = ReachMenuLinkProps
 
 /**
@@ -15,5 +17,5 @@ export type MenuLinkProps = ReachMenuLinkProps
  * @see — Docs https://reach.tech/menu-button#menulink
  */
 export const MenuLink = React.forwardRef(({ className, ...props }, reference) => (
-    <ReachMenuLink ref={reference} {...props} className={classNames('dropdown-item', className)} />
+    <ReachMenuLink ref={reference} {...props} className={classNames('dropdown-item', styles.item, className)} />
 )) as ForwardReferenceComponent<'a', MenuLinkProps>


### PR DESCRIPTION
**Note:** This branch is temporarily based on `kr/unset-menu-select-styles`, which applies general style fixes to the underlying Reach UI components that power the set of `Menu` Wildcard components and thus impacts the areas of work for this PR.

A small collection of accessibility, consistency, and visual polish tweaks to our "dropdown button"-style components.
- Adds a custom CSS variable for the darker border color per Rob's request in Figma
- Replaces `Menu` usage with `Popover` for execution options dropdown to improve accessibility
  - `MenuList` doesn't allow you to tab to its children. It works more like a native dropdown selector where the parent holds focus so long as it's open and you have to use the arrow keys to navigate options and ultimately select one. That doesn't work so well when we have checkboxes rather than items to select. 
  - I was aware of this earlier but originally thought this was a bug in `MenuList`. Now I understand it's more like expected behavior.
  - Switching to `Popover` gives us the same floating menu effect, but without locking focus to the parent.
- Swaps `.dropdown-toggle` for `ChevronDownIcon` instead -- see [my reasoning](https://github.com/sourcegraph/sourcegraph/issues/27699#issuecomment-1042360044) (tldr; we're inconsistent with this everywhere, but this icon is the simplest in terms of implementation, matches Wildcard, and looks the best!!)
- Updates `DropdownButton` to use `MenuList` (ah, it's intended purpose!) and unifies style to match `ExecutionOptions`


https://user-images.githubusercontent.com/8942601/154394301-b77932cf-4129-4018-82f2-a02faf442a50.mov


https://user-images.githubusercontent.com/8942601/154394307-4bb019ce-1f91-4006-b29f-6a77df950b08.mov

Here's the [Storybook story](https://5f0f381c0e50750022dc6bf7-qlyelrppfd.chromatic.com/?path=/story/web-batches-dropdownbutton--multiple-actions-without-default) for this branch to play with the updated `DropdownButton`.


## Test plan

Verified visually in Storybook stories. Manually tested both instances of `DropdownButton` (bulk actions and publish-from-preview). Walked through flow with keyboard navigation and regular mouse usage for all components.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


