### PR TITLE
web: fix up command list rows

### DIFF
--- a/client/shared/src/commandPalette/CommandList.tsx
+++ b/client/shared/src/commandPalette/CommandList.tsx
@@ -234,6 +234,7 @@ export class CommandList extends React.PureComponent<CommandListProps, State> {
                             items.map((item, index) => (
                                 <li
                                     className={classNames(
+                                        'd-flex',
                                         this.props.listItemClassName,
                                         index === selectedIndex && this.props.selectedListItemClassName
                                     )}


### PR DESCRIPTION
Noticed a weird visual regression in the "command list" part of the nav menu:

![Screen Shot 2022-02-16 at 7 09 24 PM](https://user-images.githubusercontent.com/8942601/154398018-d5dd6e75-dfc5-4fa3-b0e6-c26cd1511785.png)

Fixed by setting `display: flex` on the `<li />` elements:

![Screen Shot 2022-02-16 at 7 15 55 PM](https://user-images.githubusercontent.com/8942601/154398134-77347266-1c2f-4a79-9d1b-8a280785f3ea.png)

## Test plan

Just verified locally with the `Codecov` extension enabled. I'm not very familiar with this area of the code, though, and would appreciate any other insights into how to test.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


