### PR TITLE
web: use regular styles instead of Bootstrap utilities to avoid need for !important

### DIFF
--- a/client/shared/src/actions/ActionItem.module.scss
+++ b/client/shared/src/actions/ActionItem.module.scss
@@ -3,6 +3,14 @@
     &--loading {
         position: relative;
     }
+
+    &--link {
+        padding: 0;
+        display: inline;
+        font-weight: 400;
+        border: 0;
+        vertical-align: baseline;
+    }
 }
 
 .loader {

--- a/client/shared/src/actions/ActionItem.tsx
+++ b/client/shared/src/actions/ActionItem.tsx
@@ -278,7 +278,7 @@ export class ActionItem extends React.PureComponent<ActionItemProps, State, type
                     this.props.className,
                     showLoadingSpinner && styles.actionItemLoading,
                     pressed && [this.props.pressedClassName],
-                    buttonLinkProps.variant === 'link' && 'p-0 font-weight-normal border-0 align-baseline d-inline'
+                    buttonLinkProps.variant === 'link' && styles.actionItemLink
                 )}
                 pressed={pressed}
                 onSelect={this.runAction}

--- a/client/shared/src/actions/__snapshots__/ActionItem.test.tsx.snap
+++ b/client/shared/src/actions/__snapshots__/ActionItem.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ActionItem "open" command renders as link 1`] = `
 <DocumentFragment>
   <a
-    class="anchorLink btn btnLink test-action-item p-0 font-weight-normal border-0 align-baseline d-inline"
+    class="anchorLink btn btnLink test-action-item actionItemLink"
     href="https://example.com/bar"
     tabindex="0"
   >
@@ -15,7 +15,7 @@ exports[`ActionItem "open" command renders as link 1`] = `
 exports[`ActionItem "open" command renders as link that opens in a new tab, but without icon for a different origin as the alt action and a primary action defined 1`] = `
 <DocumentFragment>
   <a
-    class="anchorLink btn btnLink test-action-item p-0 font-weight-normal border-0 align-baseline d-inline"
+    class="anchorLink btn btnLink test-action-item actionItemLink"
     href="https://other.com/foo"
     rel="noopener noreferrer"
     tabindex="0"
@@ -29,7 +29,7 @@ exports[`ActionItem "open" command renders as link that opens in a new tab, but 
 exports[`ActionItem "open" command renders as link with icon and opens a new tab for a different origin 1`] = `
 <DocumentFragment>
   <a
-    class="anchorLink btn btnLink test-action-item p-0 font-weight-normal border-0 align-baseline d-inline"
+    class="anchorLink btn btnLink test-action-item actionItemLink"
     href="https://other.com/foo"
     rel="noopener noreferrer"
     tabindex="0"


### PR DESCRIPTION
## Context

Follow-up for https://github.com/sourcegraph/sourcegraph/pull/31138 to address issue spotted [here](https://github.com/sourcegraph/sourcegraph/pull/31375).

## Test plan

Check out the styling of the command list on the home page.

<img width="1034" alt="Screen Shot 2022-02-13 at 18 16 28" src="https://user-images.githubusercontent.com/3846380/154419022-eb2366c7-fdaf-49c4-ace1-c4533c79aefc.png">
