### PR TITLE
change type: to select:

### DIFF
--- a/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-examples/CodeInsightsExamples.tsx
+++ b/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-examples/CodeInsightsExamples.tsx
@@ -24,7 +24,7 @@ export const CodeInsightsExamples: React.FunctionComponent<CodeInsightsExamples>
     <section {...props}>
         <h2>Example insights</h2>
         <p className="text-muted">
-            We've created a few common simple insights to show you what the tool can do.{' '}
+            Here are a few example insights to show you what the tool can do.{' '}
             <Link to="/help/code_insights/references/common_use_cases" rel="noopener noreferrer" target="_blank">
                 Explore more use cases.
             </Link>

--- a/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-examples/CodeInsightsExamples.tsx
+++ b/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-examples/CodeInsightsExamples.tsx
@@ -63,13 +63,13 @@ const SEARCH_INSIGHT_EXAMPLES_DATA: Content = {
             dataKey: 'a',
             name: 'CSS Modules',
             stroke: DATA_SERIES_COLORS.GREEN,
-            query: 'type:file lang:scss file:module.scss patterntype:regexp archived:no fork:no',
+            query: 'select:file lang:scss file:module.scss patterntype:regexp archived:no fork:no',
         },
         {
             dataKey: 'b',
             name: 'Global CSS',
             stroke: DATA_SERIES_COLORS.RED,
-            query: 'type:file lang:scss -file:module.scss patterntype:regexp archived:no fork:no',
+            query: 'select:file lang:scss -file:module.scss patterntype:regexp archived:no fork:no',
         },
     ],
     xAxis: {


### PR DESCRIPTION
Both `type:` and `select:` are functionally correct *in this specific example* but in effort to train our users overall to be better at using insights, generally they want to use `select:` because: 

1. `type:file` searches file types and only returns the count of matches as # of files if _there is no other search string, just search filters._ This means that if I want the count of files containing a component, I can't use `type:file` – it will just search files and return "normal" total counts. 
2. `select:file` runs my search and then counts the file matches. This is usually what people want when thinking about "selecting the count of files".  


## Test plan

I have tested these queries and they return the same results, see: 
![image](https://user-images.githubusercontent.com/11967660/154433047-451eee43-3384-48fa-bb69-3c4e614510cf.png)

![image](https://user-images.githubusercontent.com/11967660/154433153-7b3df91e-5a5f-4290-a810-8ffa0c0ddfeb.png)

and

![image](https://user-images.githubusercontent.com/11967660/154433237-367490be-af12-479f-867a-8ba9d4d75738.png)
![image](https://user-images.githubusercontent.com/11967660/154433273-63148dbe-55b0-4704-bfa1-23d01c9efa22.png)



Otherwise, this is a copy change. 

