### PR TITLE
insights: fix popular use case copy to be shorter and match figma

### DIFF
--- a/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-templates/CodeInsightsTemplates.tsx
+++ b/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-templates/CodeInsightsTemplates.tsx
@@ -43,7 +43,7 @@ export const CodeInsightsTemplates: React.FunctionComponent<React.HTMLAttributes
             <Link to="/help/code_insights/references/common_use_cases" rel="noopener noreferrer" target="_blank">
                 use cases
             </Link>
-            , collected from our beta customers.
+            .
         </p>
 
         <Tabs size="medium" className="mt-3">


### PR DESCRIPTION
For some reason this got missed – no worries, easy fix, we can retro; lots of balls in the air these two weeks so not a big deal. [Reflected in the figma](https://www.figma.com/file/EFgTP7gpdpQSEo1n4FUfsW/In-product-landing-page-WIP?node-id=1624%3A23488) – we don't want to imply these are directly from customers (they aren't). 

## Test plan

Will review when lands on k8s. 


