### PR TITLE
insights: shorten landing page header text and make POV consistently second person

### DIFF
--- a/client/web/src/enterprise/insights/pages/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
+++ b/client/web/src/enterprise/insights/pages/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
@@ -117,12 +117,12 @@ export const DynamicCodeInsightExample: React.FunctionComponent<DynamicCodeInsig
 
             <section>
                 <h2 className={classNames(styles.cardTitle)}>
-                    Draw insights from your codebase about how different initiatives are tracking over time
+                    Draw insights from your codebase about how different initiatives track over time
                 </h2>
 
                 <p>
-                    Create customizable, visual dashboards with meaningful codebase signals your team can use to answer
-                    questions about how their code is changing and what’s in their code - questions that were difficult
+                    Create visual dashboards with meaningful, customizable codebase signals your team can use to answer
+                    questions about how your code is changing and what’s in your code {'\u2014'} questions that were difficult
                     or impossible to answer before.
                 </p>
 

--- a/client/web/src/enterprise/insights/pages/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
+++ b/client/web/src/enterprise/insights/pages/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
@@ -122,8 +122,8 @@ export const DynamicCodeInsightExample: React.FunctionComponent<DynamicCodeInsig
 
                 <p>
                     Create visual dashboards with meaningful, customizable codebase signals your team can use to answer
-                    questions about how your code is changing and what’s in your code {'\u2014'} questions that were difficult
-                    or impossible to answer before.
+                    questions about how your code is changing and what’s in your code {'\u2014'} questions that were
+                    difficult or impossible to answer before.
                 </p>
 
                 <h3 className={classNames(styles.bulletTitle)}>Use Code Insights to...</h3>


### PR DESCRIPTION
cc @AlicjaSuska would like your signoff on this copy change. I wanted to make the title shorter and change the words, make it about "your" code, and emphasize "customizable" is about the metrics more than about the dashboards. 

I believe it will look like this: 
![image](https://user-images.githubusercontent.com/11967660/154435934-cc991949-4e7f-434f-94cc-af88e3a044ef.png)


cc @vovakulikov  or @justin my `\u2014` was an attempt at inserting an emdash. It should be an emdash, not a single `-`, which is too short and not the correct punctuation (minor, but while I was fixing anyway!) 

## Test plan

Not setup to deploy locally at the moment – can someone check the emdash? Otherwise can catch on k8s. 

