### PR TITLE
insights: fix copy to not say code monitoring

### DIFF
--- a/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-learn-more/CodeInsightsLearnMore.tsx
+++ b/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-learn-more/CodeInsightsLearnMore.tsx
@@ -30,7 +30,7 @@ export const CodeInsightsLearnMore: React.FunctionComponent<React.HTMLAttributes
                 <article>
                     <h3>Detect and track patterns</h3>
                     <p className="text-muted mb-2">
-                        Track versions of languages, packages, terraform, docker images, or anything else that can be
+                        Track versions of languages, packages, infrastructure, docker images, or anything else that can be
                         captured with a regular expression capture group.
                     </p>
                     <Link
@@ -45,7 +45,7 @@ export const CodeInsightsLearnMore: React.FunctionComponent<React.HTMLAttributes
                 <article>
                     <h3>Questions and feedback</h3>
                     <p className="text-muted mb-2">
-                        Have a question or idea about code monitoring? We want to hear your feedback!
+                        Have a question or idea about Code Insights? We want to hear your feedback!
                     </p>
 
                     <FeedbackPrompt onSubmit={handleSubmitFeedback}>

--- a/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-learn-more/CodeInsightsLearnMore.tsx
+++ b/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-learn-more/CodeInsightsLearnMore.tsx
@@ -30,8 +30,8 @@ export const CodeInsightsLearnMore: React.FunctionComponent<React.HTMLAttributes
                 <article>
                     <h3>Detect and track patterns</h3>
                     <p className="text-muted mb-2">
-                        Track versions of languages, packages, infrastructure, docker images, or anything else that can be
-                        captured with a regular expression capture group.
+                        Track versions of languages, packages, infrastructure, docker images, or anything else that can
+                        be captured with a regular expression capture group.
                     </p>
                     <Link
                         to="/help/code_insights/explanations/automatically_generated_data_series"


### PR DESCRIPTION
Looks like this got missed in copy-pasting, so fixing! While I was here, also removed mention of "terraform" for "infrastructure" because right now most tf cases aren't supported due to multiline matching, but some are (so "infrastructure" gets at it less obviously). 

## Test plan

Purely a copy change!


