### PR TITLE
CHANGELOG: Add note on enableGitServerCommandExecFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - Code in search results is now selectable (e.g. for copying). Just clicking on the code continues to open the corresponding file as it did before. [#30033](https://github.com/sourcegraph/sourcegraph/pull/30033)
+- Added `experimentalFeatures.enableGitServerCommandExecFilter` (defaults to `true`) to enable a patch for a security issue in gitserver. For more detail see our security advisor [#TBD](insert-link-to-advisory)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - Code in search results is now selectable (e.g. for copying). Just clicking on the code continues to open the corresponding file as it did before. [#30033](https://github.com/sourcegraph/sourcegraph/pull/30033)
-- Added `experimentalFeatures.enableGitServerCommandExecFilter` (defaults to `true`) to enable a patch for a security issue in gitserver. For more detail see our [security advisor](https://github.com/sourcegraph/sourcegraph/security/advisories/GHSA-qcmp-fx72-q8q9)
+- Added `experimentalFeatures.enableGitServerCommandExecFilter` (defaults to `true`) to enable a patch for a security issue in gitserver. For more detail see [CVE-2022-23642](https://github.com/sourcegraph/sourcegraph/security/advisories/GHSA-qcmp-fx72-q8q9)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - Code in search results is now selectable (e.g. for copying). Just clicking on the code continues to open the corresponding file as it did before. [#30033](https://github.com/sourcegraph/sourcegraph/pull/30033)
-- Added `experimentalFeatures.enableGitServerCommandExecFilter` (defaults to `true`) to enable a patch for a security issue in gitserver. For more detail see our security advisor [#TBD](insert-link-to-advisory)
+- Added `experimentalFeatures.enableGitServerCommandExecFilter` (defaults to `true`) to enable a patch for a security issue in gitserver. For more detail see our [security advisor](https://github.com/sourcegraph/sourcegraph/security/advisories/GHSA-qcmp-fx72-q8q9)
 
 ### Changed
 


### PR DESCRIPTION
Blocked by #31318. 

## Test plan

Not applicable. Contains changes to changelog. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


