### PR TITLE
owners: use `@sourcegraph/frontend-platform-devs` team

### DIFF
--- a/client/build-config/OWNERS
+++ b/client/build-config/OWNERS
@@ -1,3 +1,3 @@
 # See https://github.com/sourcegraph/codenotify for documentation.
 
-**/* @sourcegraph/frontend-platform
+**/* @sourcegraph/frontend-platform-devs

--- a/client/common/OWNERS
+++ b/client/common/OWNERS
@@ -1,3 +1,3 @@
 # See https://github.com/sourcegraph/codenotify for documentation.
 
-**/* @sourcegraph/frontend-platform
+**/* @sourcegraph/frontend-platform-devs

--- a/client/eslint-plugin-wildcard/OWNERS
+++ b/client/eslint-plugin-wildcard/OWNERS
@@ -1,3 +1,3 @@
 # See https://github.com/sourcegraph/codenotify for documentation.
 
-**/* @sourcegraph/frontend-platform
+**/* @sourcegraph/frontend-platform-devs

--- a/client/http-client/OWNERS
+++ b/client/http-client/OWNERS
@@ -1,3 +1,3 @@
 # See https://github.com/sourcegraph/codenotify for documentation.
 
-**/* @sourcegraph/frontend-platform
+**/* @sourcegraph/frontend-platform-devs

--- a/client/wildcard/OWNERS
+++ b/client/wildcard/OWNERS
@@ -1,3 +1,3 @@
 # See https://github.com/sourcegraph/codenotify for documentation.
 
-**/* @sourcegraph/frontend-platform
+**/* @sourcegraph/frontend-platform-devs

--- a/client/wildcard/src/components/Icon/Icon.tsx
+++ b/client/wildcard/src/components/Icon/Icon.tsx
@@ -13,7 +13,7 @@ interface IconProps {
     size?: typeof ICON_SIZES[number]
     /**
      * Used to change the element that is rendered.
-     * Always be mindful of potentially accessibiliy pitfalls when using this!
+     * Always be mindful of potentially accessibility pitfalls when using this!
      */
     as?: React.ElementType
 }


### PR DESCRIPTION
## Context

To limit the noise of GitHub notifications relevant only for engineers, we created a separate GitHub team @sourcegraph/frontend-platform-devs, which will be used in `OWNERS` files.

## Test plan

Create a PR that changes files in one of the packages with frontend-platform `OWNERS`. It should notify @sourcegraph/frontend-platform-devs instead of @sourcegraph/frontend-platform.


