### PR TITLE
monitoring: set min-y of zoekt panels to auto

### DIFF
--- a/monitoring/definitions/zoekt.go
+++ b/monitoring/definitions/zoekt.go
@@ -54,7 +54,7 @@ func Zoekt() *monitoring.Container {
 									LegendFormat: "tracked",
 								}}
 								p.GraphPanel.Tooltip.Shared = true
-							}),
+							}).MinAuto(),
 							Owner: monitoring.ObservableOwnerSearchCore,
 							Interpretation: `
 								Sudden changes can be caused by indexing configuration changes.
@@ -86,7 +86,7 @@ func Zoekt() *monitoring.Container {
 									LegendFormat: "{{instance}} tracked",
 								}}
 								p.GraphPanel.Tooltip.Shared = true
-							}),
+							}).MinAuto(),
 							Owner: monitoring.ObservableOwnerSearchCore,
 							Interpretation: `
 								Sudden changes can be caused by indexing configuration changes.


### PR DESCRIPTION
For the 2 panels (aggregate and per instance) showing the total number of indexed repos it makes more
sense to set the min of the y-axis to auto instead of 0.

## Test plan
I ran Grafana locally and proxied to the production instance of Prometheus. Here is the before and after

before
<img width="1265" alt="Screenshot 2022-02-17 at 14 55 08" src="https://user-images.githubusercontent.com/26413131/154496126-c05c9ef9-2844-401d-ba2f-f515ba6055b7.png">

after
<img width="1247" alt="Screenshot 2022-02-17 at 11 00 19" src="https://user-images.githubusercontent.com/26413131/154453397-290d4a4a-48dd-419d-bef4-32a1f0223736.png">




<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


