### PR TITLE
sg: Remove uses of sudo in add-macos-to-firewall.

### DIFF
--- a/dev/sg/internal/run/run.go
+++ b/dev/sg/internal/run/run.go
@@ -106,25 +106,14 @@ func newPostInstall(ctx context.Context, cmds []Command, addToMacOSFirewall bool
 		}
 
 		fwCmdPath := "/usr/libexec/ApplicationFirewall/socketfilterfw"
-		stdout.Out.WriteLine(output.Linef(output.EmojiWarningSign, output.StyleWarning, "You may be prompted to enter your password to add exceptions to the firewall."))
-		fcmd := exec.CommandContext(ctx, "sudo", fwCmdPath, "--setglobalstate", "off")
-		err = fcmd.Run()
-		if err != nil {
-			return err
-		}
 		for _, cmd := range cmds {
 			if strings.HasPrefix(cmd.Cmd, ".bin/") {
-				fcmd = exec.CommandContext(ctx, "sudo", fwCmdPath, "--add", filepath.Join(root, cmd.Cmd))
+				fcmd := exec.CommandContext(ctx, fwCmdPath, "--add", filepath.Join(root, cmd.Cmd))
 				err = fcmd.Run()
 				if err != nil {
 					return err
 				}
 			}
-		}
-		fcmd = exec.CommandContext(ctx, "sudo", fwCmdPath, "--setglobalstate", "on")
-		err = fcmd.Run()
-		if err != nil {
-			return err
 		}
 		return nil
 	}


### PR DESCRIPTION
Manual reproduction steps:
1. Install sg with this patch.
2. Start a new terminal session.
3. Check out a branch

It seems that this works fine without using `sudo` (which makes sense in a way, because the prompts without the call do not require putting in a password) or turning the firewall off then on back again.

## Test plan

N/A.