### PR TITLE
web: Fix `mocha` types polluting non-mocha test files

### DIFF
--- a/client/web/src/nav/GlobalNavbar.story.tsx
+++ b/client/web/src/nav/GlobalNavbar.story.tsx
@@ -1,6 +1,5 @@
 import { storiesOf } from '@storybook/react'
 import { createMemoryHistory } from 'history'
-import { SuiteFunction } from 'mocha'
 import React from 'react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -21,7 +20,7 @@ import { ThemePreference } from '../stores/themeState'
 import { GlobalNavbar } from './GlobalNavbar'
 
 if (!window.context) {
-    window.context = {} as SourcegraphContext & SuiteFunction
+    window.context = {} as SourcegraphContext & Mocha.SuiteFunction
 }
 
 const history = createMemoryHistory()

--- a/client/web/src/savedSearches/SavedSearchForm.story.tsx
+++ b/client/web/src/savedSearches/SavedSearchForm.story.tsx
@@ -1,5 +1,4 @@
 import { storiesOf } from '@storybook/react'
-import { SuiteFunction } from 'mocha'
 import React from 'react'
 
 import { WebStory } from '../components/WebStory'
@@ -12,7 +11,7 @@ const { add } = storiesOf('web/savedSearches/SavedSearchForm', module).addParame
 })
 
 if (!window.context) {
-    window.context = {} as SourcegraphContext & SuiteFunction
+    window.context = {} as SourcegraphContext & Mocha.SuiteFunction
 }
 window.context.emailEnabled = true
 


### PR DESCRIPTION
## Description

Avoids importing types from `Mocha` which conflict with the global test types that `Jest` provides.

This fixes the immediate problem, it still isn't clear why `window.context` expects Mocha usage

## Test plan
Before:
![image](https://user-images.githubusercontent.com/9516420/154474644-1eff9294-5123-420f-85af-5f45509b18ee.png)


After:
![image](https://user-images.githubusercontent.com/9516420/154474455-5dd7a802-b1e0-423f-81d5-eb6e84e98a92.png)



