### PR TITLE
ci: fix buildkite analytics for e2e

### DIFF
--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -60,14 +60,20 @@ function go_test() {
 EOF
   )
 
+  set +e
   echo "$data" | curl \
     --request POST \
     --url https://analytics-api.buildkite.com/v1/uploads \
     --header "Authorization: Token token=\"$BUILDKITE_ANALYTICS_BACKEND_TEST_SUITE_API_KEY\";" \
     --header 'Content-Type: application/json' \
     --data-binary @-
-
-  echo -e "\n--- :information_source: Succesfully uploaded test results to Buildkite analytics"
+  local curl_exit="$?"
+  if [ "$curl_exit" -eq 0 ]; then 
+    echo -e "\n:--- :information_source: Succesfully uploaded test results to Buildkite analytics"
+  else
+    echo -e "\n^^^ +++ :warning: Failed to upload test results to Buildkite analytics"
+  fi
+  set -e
 
   return "$test_exit_code"
 }

--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -68,7 +68,7 @@ EOF
     --header 'Content-Type: application/json' \
     --data-binary @-
   local curl_exit="$?"
-  if [ "$curl_exit" -eq 0 ]; then 
+  if [ "$curl_exit" -eq 0 ]; then
     echo -e "\n:--- :information_source: Succesfully uploaded test results to Buildkite analytics"
   else
     echo -e "\n^^^ +++ :warning: Failed to upload test results to Buildkite analytics"

--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -62,6 +62,7 @@ EOF
 
   set +e
   echo "$data" | curl \
+    --fail \
     --request POST \
     --url https://analytics-api.buildkite.com/v1/uploads \
     --header "Authorization: Token token=\"$BUILDKITE_ANALYTICS_BACKEND_TEST_SUITE_API_KEY\";" \

--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -71,7 +71,7 @@ EOF
     --data-binary @-
   local curl_exit="$?"
   if [ "$curl_exit" -eq 0 ]; then
-    echo -e "\n:--- :information_source: Succesfully uploaded test results to Buildkite analytics"
+    echo -e "\n--- :information_source: Succesfully uploaded test results to Buildkite analytics"
   else
     echo -e "\n^^^ +++ :warning: Failed to upload test results to Buildkite analytics"
   fi

--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -60,6 +60,7 @@ function go_test() {
 EOF
   )
 
+  echo -e "\n--- :information_source: Uploading test results to Buildkite analytics"
   set +e
   echo "$data" | curl \
     --fail \

--- a/dev/ci/integration/e2e/test.sh
+++ b/dev/ci/integration/e2e/test.sh
@@ -57,7 +57,7 @@ EOF
     --header 'Content-Type: application/json' \
     --data-binary @-
   local curl_exit="$?"
-  if [ "$curl_exit" -eq 0 ]; then 
+  if [ "$curl_exit" -eq 0 ]; then
     echo -e "\n--- :information_source: Succesfully uploaded test results to Buildkite analytics"
   else
     echo -e "\n^^^ +++ :warning: Failed to upload test results to Buildkite analytics"

--- a/dev/ci/integration/qa/test.sh
+++ b/dev/ci/integration/qa/test.sh
@@ -75,7 +75,7 @@ EOF
     --header 'Content-Type: application/json' \
     --data-binary @-
   local curl_exit="$?"
-  if [ "$curl_exit" -eq 0 ]; then 
+  if [ "$curl_exit" -eq 0 ]; then
     echo -e "\n:--- :information_source: Succesfully uploaded test results to Buildkite analytics"
   else
     echo -e "\n^^^ +++ :warning: Failed to upload test results to Buildkite analytics"

--- a/dev/ci/integration/qa/test.sh
+++ b/dev/ci/integration/qa/test.sh
@@ -69,6 +69,7 @@ EOF
 
   set +e
   echo "$data" | curl \
+    --fail \
     --request POST \
     --url https://analytics-api.buildkite.com/v1/uploads \
     --header "Authorization: Token token=\"$BUILDKITE_ANALYTICS_FRONTEND_E2E_TEST_SUITE_API_KEY\";" \

--- a/dev/ci/integration/qa/test.sh
+++ b/dev/ci/integration/qa/test.sh
@@ -78,7 +78,7 @@ EOF
     --data-binary @-
   local curl_exit="$?"
   if [ "$curl_exit" -eq 0 ]; then
-    echo -e "\n:--- :information_source: Succesfully uploaded test results to Buildkite analytics"
+    echo -e "\n--- :information_source: Succesfully uploaded test results to Buildkite analytics"
   else
     echo -e "\n^^^ +++ :warning: Failed to upload test results to Buildkite analytics"
   fi

--- a/dev/ci/integration/qa/test.sh
+++ b/dev/ci/integration/qa/test.sh
@@ -67,6 +67,7 @@ function qa_test() {
 EOF
   )
 
+  echo -e "\n--- :information_source: Uploading test results to Buildkite analytics"
   set +e
   echo "$data" | curl \
     --fail \


### PR DESCRIPTION
There was a bug in how the script was written for the E2E test, which prevented the API key to be properly assigned. 

There was also another bug that slipped in that messed the exit code handling code in the QA test suite. 

I have taken the opportunity of also improving the output, issuing a warning message when the test suite isn't working. 

It's probably a good candidate for sentry reporting as well, I'll add that in a lta

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

- CI Run and observing that: 
  - E2E test suite properly submits its report
  - QA test suite properly submits its report
  - Go test suite properly submits its report
