### PR TITLE
Experimental reference panel: add independent pagination for references/implementations

### DIFF
--- a/client/http-client/src/graphql/apollo/cache.ts
+++ b/client/http-client/src/graphql/apollo/cache.ts
@@ -20,6 +20,9 @@ const typePolicies: TypedTypePolicies = {
             return incoming
         },
     },
+    Location: {
+        keyFields: ['url'],
+    },
     Query: {
         fields: {
             node: {

--- a/client/http-client/src/graphql/apollo/cache.ts
+++ b/client/http-client/src/graphql/apollo/cache.ts
@@ -23,6 +23,9 @@ const typePolicies: TypedTypePolicies = {
     Location: {
         keyFields: ['url'],
     },
+    GitBlob: {
+        keyFields: ['url'],
+    },
     Query: {
         fields: {
             node: {

--- a/client/web/src/global/CoolCodeIntel.tsx
+++ b/client/web/src/global/CoolCodeIntel.tsx
@@ -313,7 +313,7 @@ export const SideReferences: React.FunctionComponent<ReferencesComponentProps> =
 }
 
 export const SideReferencesWithHook: React.FunctionComponent<ReferencesComponentProps> = props => {
-    const { lsifData, error, loading, hasNextPage, fetchMore } = usePreciseCodeIntel<
+    const { lsifData, error, loading, referencesHasNextPage, fetchMore } = usePreciseCodeIntel<
         GetPreciseCodeIntelResult,
         GetPreciseCodeIntelVariables,
         LocationFields
@@ -326,7 +326,7 @@ export const SideReferencesWithHook: React.FunctionComponent<ReferencesComponent
             // On the backend the line/character are 0-indexed, but what we
             // get from hoverifier is 1-indexed.
             line: props.clickedToken.line - 1,
-            first: 50,
+            first: 1,
             character: props.clickedToken.character - 1,
             after: null,
             filter: props.filter || null,
@@ -424,7 +424,7 @@ export const SideReferencesWithHook: React.FunctionComponent<ReferencesComponent
             </ol>
             <p>
                 {references.length} references.{' '}
-                {hasNextPage && !loading && (
+                {referencesHasNextPage && !loading && (
                     <Button
                         onClick={() => fetchMore()}
                         size="sm"
@@ -435,7 +435,7 @@ export const SideReferencesWithHook: React.FunctionComponent<ReferencesComponent
                         Load more
                     </Button>
                 )}
-                {hasNextPage && loading && <LoadingSpinner inline={true} />}
+                {referencesHasNextPage && loading && <LoadingSpinner inline={true} />}
             </p>
         </>
     )

--- a/client/web/src/global/CoolCodeIntel.tsx
+++ b/client/web/src/global/CoolCodeIntel.tsx
@@ -56,7 +56,6 @@ import {
     CoolCodeIntelReferencesResult,
     CoolCodeIntelReferencesVariables,
     GetPreciseCodeIntelResult,
-    GetPreciseCodeIntelVariables,
     HoverFields,
     LocationConnectionFields,
     LocationFields,
@@ -321,7 +320,7 @@ export const SideReferencesWithHook: React.FunctionComponent<ReferencesComponent
         implementationsHasNextPage,
         fetchMoreReferences,
         fetchMoreImplementations,
-    } = usePreciseCodeIntel<GetPreciseCodeIntelResult, GetPreciseCodeIntelVariables, LocationFields>({
+    } = usePreciseCodeIntel<GetPreciseCodeIntelResult>({
         query: USE_CODE_INTEL_QUERY,
         variables: {
             repository: props.clickedToken.repoName,

--- a/client/web/src/global/CoolCodeIntel.tsx
+++ b/client/web/src/global/CoolCodeIntel.tsx
@@ -21,7 +21,7 @@ import {
     toPositionOrRangeQueryParameter,
 } from '@sourcegraph/common'
 import { Range } from '@sourcegraph/extension-api-types'
-import { dataOrThrowErrors, useQuery } from '@sourcegraph/http-client'
+import { useQuery } from '@sourcegraph/http-client'
 import { Markdown } from '@sourcegraph/shared/src/components/Markdown'
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoFileLink'
 import { Resizable } from '@sourcegraph/shared/src/components/Resizable'
@@ -55,7 +55,6 @@ import {
     CoolCodeIntelHighlightedBlobVariables,
     CoolCodeIntelReferencesResult,
     CoolCodeIntelReferencesVariables,
-    GetPreciseCodeIntelResult,
     HoverFields,
     LocationConnectionFields,
     LocationFields,
@@ -66,8 +65,8 @@ import { Blob, BlobProps } from '../repo/blob/Blob'
 import { parseBrowserRepoURL } from '../util/url'
 
 import styles from './CoolCodeIntel.module.scss'
-import { usePreciseCodeIntel } from './CoolCodeIntelHook'
-import { FETCH_HIGHLIGHTED_BLOB, FETCH_REFERENCES_QUERY, USE_CODE_INTEL_QUERY } from './CoolCodeIntelQueries'
+import { FETCH_HIGHLIGHTED_BLOB, FETCH_REFERENCES_QUERY } from './CoolCodeIntelQueries'
+import { usePreciseCodeIntel } from './usePreciseCodeIntel'
 
 export interface GlobalCoolCodeIntelProps {
     coolCodeIntelEnabled: boolean
@@ -320,8 +319,7 @@ export const SideReferencesWithHook: React.FunctionComponent<ReferencesComponent
         implementationsHasNextPage,
         fetchMoreReferences,
         fetchMoreImplementations,
-    } = usePreciseCodeIntel<GetPreciseCodeIntelResult>({
-        query: USE_CODE_INTEL_QUERY,
+    } = usePreciseCodeIntel({
         variables: {
             repository: props.clickedToken.repoName,
             commit: props.clickedToken.commitID,
@@ -338,38 +336,6 @@ export const SideReferencesWithHook: React.FunctionComponent<ReferencesComponent
         },
         options: {
             fetchPolicy: 'cache-first',
-        },
-        getConnection: result => {
-            const data = dataOrThrowErrors(result)
-
-            // If there weren't any errors and we just didn't receive any data
-            if (!data || !data.repository?.commit?.blob?.lsif) {
-                return {
-                    hover: null,
-                    definitions: {
-                        nodes: [],
-                        pageInfo: {
-                            endCursor: null,
-                        },
-                    },
-                    references: {
-                        nodes: [],
-                        pageInfo: {
-                            endCursor: null,
-                        },
-                    },
-                    implementations: {
-                        nodes: [],
-                        pageInfo: {
-                            endCursor: null,
-                        },
-                    },
-                }
-            }
-
-            const lsif = data.repository?.commit?.blob?.lsif
-
-            return lsif
         },
     })
 

--- a/client/web/src/global/CoolCodeIntel.tsx
+++ b/client/web/src/global/CoolCodeIntel.tsx
@@ -326,6 +326,7 @@ export const SideReferencesWithHook: React.FunctionComponent<ReferencesComponent
             // On the backend the line/character are 0-indexed, but what we
             // get from hoverifier is 1-indexed.
             line: props.clickedToken.line - 1,
+            first: 50,
             character: props.clickedToken.character - 1,
             after: null,
             filter: props.filter || null,
@@ -339,6 +340,13 @@ export const SideReferencesWithHook: React.FunctionComponent<ReferencesComponent
             // If there weren't any errors and we just didn't receive any data
             if (!data || !data.repository?.commit?.blob?.lsif) {
                 return {
+                    hover: null,
+                    definitions: {
+                        nodes: [],
+                        pageInfo: {
+                            endCursor: null,
+                        },
+                    },
                     references: {
                         nodes: [],
                         pageInfo: {
@@ -382,9 +390,28 @@ export const SideReferencesWithHook: React.FunctionComponent<ReferencesComponent
     }
 
     const references = lsifData?.references.nodes
+    const definitions = lsifData?.definitions.nodes
+    const hover = lsifData?.hover
 
     return (
         <>
+            <h3>Hover</h3>
+            {hover && (
+                <Markdown
+                    className={classNames('mb-0 card-body text-small', styles.hoverMarkdown)}
+                    dangerousInnerHTML={renderMarkdown(hover.markdown.text)}
+                />
+            )}
+            <h3>Definitions</h3>
+            <ol>
+                {definitions.map(definition => (
+                    <li key={definition.url}>
+                        <Link to={definition.url}>
+                            <code>{definition.url}</code>
+                        </Link>
+                    </li>
+                ))}
+            </ol>
             <h3>References</h3>
             <ol>
                 {references.map(reference => (

--- a/client/web/src/global/CoolCodeIntel.tsx
+++ b/client/web/src/global/CoolCodeIntel.tsx
@@ -331,9 +331,9 @@ export const SideReferencesWithHook: React.FunctionComponent<ReferencesComponent
             line: props.clickedToken.line - 1,
             character: props.clickedToken.character - 1,
             filter: props.filter || null,
-            firstReferences: 1,
+            firstReferences: 100,
             afterReferences: null,
-            firstImplementations: 1,
+            firstImplementations: 100,
             afterImplementations: null,
         },
         options: {

--- a/client/web/src/global/CoolCodeIntel.tsx
+++ b/client/web/src/global/CoolCodeIntel.tsx
@@ -313,11 +313,15 @@ export const SideReferences: React.FunctionComponent<ReferencesComponentProps> =
 }
 
 export const SideReferencesWithHook: React.FunctionComponent<ReferencesComponentProps> = props => {
-    const { lsifData, error, loading, referencesHasNextPage, fetchMore } = usePreciseCodeIntel<
-        GetPreciseCodeIntelResult,
-        GetPreciseCodeIntelVariables,
-        LocationFields
-    >({
+    const {
+        lsifData,
+        error,
+        loading,
+        referencesHasNextPage,
+        implementationsHasNextPage,
+        fetchMoreReferences,
+        fetchMoreImplementations,
+    } = usePreciseCodeIntel<GetPreciseCodeIntelResult, GetPreciseCodeIntelVariables, LocationFields>({
         query: USE_CODE_INTEL_QUERY,
         variables: {
             repository: props.clickedToken.repoName,
@@ -326,10 +330,12 @@ export const SideReferencesWithHook: React.FunctionComponent<ReferencesComponent
             // On the backend the line/character are 0-indexed, but what we
             // get from hoverifier is 1-indexed.
             line: props.clickedToken.line - 1,
-            first: 1,
             character: props.clickedToken.character - 1,
-            after: null,
             filter: props.filter || null,
+            firstReferences: 1,
+            afterReferences: null,
+            firstImplementations: 1,
+            afterImplementations: null,
         },
         options: {
             fetchPolicy: 'cache-first',
@@ -348,6 +354,12 @@ export const SideReferencesWithHook: React.FunctionComponent<ReferencesComponent
                         },
                     },
                     references: {
+                        nodes: [],
+                        pageInfo: {
+                            endCursor: null,
+                        },
+                    },
+                    implementations: {
                         nodes: [],
                         pageInfo: {
                             endCursor: null,
@@ -391,6 +403,7 @@ export const SideReferencesWithHook: React.FunctionComponent<ReferencesComponent
 
     const references = lsifData?.references.nodes
     const definitions = lsifData?.definitions.nodes
+    const implementations = lsifData?.implementations.nodes
     const hover = lsifData?.hover
 
     return (
@@ -426,7 +439,7 @@ export const SideReferencesWithHook: React.FunctionComponent<ReferencesComponent
                 {references.length} references.{' '}
                 {referencesHasNextPage && !loading && (
                     <Button
-                        onClick={() => fetchMore()}
+                        onClick={() => fetchMoreReferences()}
                         size="sm"
                         display="inline"
                         variant="secondary"
@@ -436,6 +449,31 @@ export const SideReferencesWithHook: React.FunctionComponent<ReferencesComponent
                     </Button>
                 )}
                 {referencesHasNextPage && loading && <LoadingSpinner inline={true} />}
+            </p>
+            <h3>Implementations</h3>
+            <ol>
+                {implementations.map(implementation => (
+                    <li key={implementation.url}>
+                        <Link to={implementation.url}>
+                            <code>{implementation.url}</code>
+                        </Link>
+                    </li>
+                ))}
+            </ol>
+            <p>
+                {implementations.length} implementations.{' '}
+                {implementationsHasNextPage && !loading && (
+                    <Button
+                        onClick={() => fetchMoreImplementations()}
+                        size="sm"
+                        display="inline"
+                        variant="secondary"
+                        className="mx-auto"
+                    >
+                        Load more
+                    </Button>
+                )}
+                {implementationsHasNextPage && loading && <LoadingSpinner inline={true} />}
             </p>
         </>
     )

--- a/client/web/src/global/CoolCodeIntel.tsx
+++ b/client/web/src/global/CoolCodeIntel.tsx
@@ -391,6 +391,13 @@ const CollapsibleLocationList: React.FunctionComponent<{
         setDisable(false)
     }, [props.locations])
 
+    const fetchMore = (): void => {
+        if (props.fetchMore) {
+            setDisable(true)
+            props.fetchMore()
+        }
+    }
+
     return (
         <>
             <CardHeader className="p-0">
@@ -434,17 +441,7 @@ const CollapsibleLocationList: React.FunctionComponent<{
                                 </div>
                             ) : (
                                 <div className="text-center mb-1">
-                                    <Button
-                                        variant="secondary"
-                                        disabled={disable}
-                                        onClick={event => {
-                                            event.preventDefault()
-                                            setDisable(true)
-                                            if (props.fetchMore) {
-                                                props.fetchMore()
-                                            }
-                                        }}
-                                    >
+                                    <Button variant="secondary" disabled={disable} onClick={fetchMore}>
                                         Load more {props.name}
                                     </Button>
                                 </div>

--- a/client/web/src/global/CoolCodeIntel.tsx
+++ b/client/web/src/global/CoolCodeIntel.tsx
@@ -332,7 +332,7 @@ export const SideReferencesWithHook: React.FunctionComponent<ReferencesComponent
             filter: props.filter || null,
         },
         options: {
-            fetchPolicy: 'cache-and-network',
+            fetchPolicy: 'cache-first',
         },
         getConnection: result => {
             const data = dataOrThrowErrors(result)

--- a/client/web/src/global/CoolCodeIntel.tsx
+++ b/client/web/src/global/CoolCodeIntel.tsx
@@ -362,14 +362,14 @@ export const SideReferencesWithHook: React.FunctionComponent<ReferencesComponent
     }
 
     // If there weren't any errors and we just didn't receive any data
-    if (!lsifData || lsifData.references.nodes.length === 0) {
+    if (!lsifData) {
         return <>Nothing found</>
     }
 
-    const references = lsifData?.references.nodes
-    const definitions = lsifData?.definitions.nodes
-    const implementations = lsifData?.implementations.nodes
-    const hover = lsifData?.hover
+    const references = lsifData.references.nodes
+    const definitions = lsifData.definitions.nodes
+    const implementations = lsifData.implementations.nodes
+    const hover = lsifData.hover
 
     return (
         <>

--- a/client/web/src/global/CoolCodeIntel.tsx
+++ b/client/web/src/global/CoolCodeIntel.tsx
@@ -272,7 +272,6 @@ export const SideReferences: React.FunctionComponent<ReferencesComponentProps> =
         },
         options: {
             fetchPolicy: 'cache-first',
-            nextFetchPolicy: 'network-only',
         },
     })
 
@@ -387,6 +386,11 @@ const CollapsibleLocationList: React.FunctionComponent<{
     const [isOpen, setOpen] = useState<boolean>(true)
     const handleOpen = useCallback(() => setOpen(previousState => !previousState), [])
 
+    const [disable, setDisable] = useState(false)
+    useEffect(() => {
+        setDisable(false)
+    }, [props.locations])
+
     return (
         <>
             <CardHeader className="p-0">
@@ -421,22 +425,30 @@ const CollapsibleLocationList: React.FunctionComponent<{
                             setActiveLocation={props.setActiveLocation}
                             filter={props.filter}
                         />
-                        {props.hasMore && props.fetchMore !== undefined && (
-                            <p className="text-center">
-                                <Button
-                                    variant="secondary"
-                                    size="sm"
-                                    onClick={event => {
-                                        event.preventDefault()
-                                        if (props.fetchMore) {
-                                            props.fetchMore()
-                                        }
-                                    }}
-                                >
-                                    Load more {props.name}
-                                </Button>
-                            </p>
-                        )}
+                        {props.hasMore &&
+                            props.fetchMore !== undefined &&
+                            (disable ? (
+                                <div className="text-center mb-1">
+                                    <em>Loading more {props.name}...</em>
+                                    <LoadingSpinner inline={true} />
+                                </div>
+                            ) : (
+                                <div className="text-center mb-1">
+                                    <Button
+                                        variant="secondary"
+                                        disabled={disable}
+                                        onClick={event => {
+                                            event.preventDefault()
+                                            setDisable(true)
+                                            if (props.fetchMore) {
+                                                props.fetchMore()
+                                            }
+                                        }}
+                                    >
+                                        Load more {props.name}
+                                    </Button>
+                                </div>
+                            ))}
                     </>
                 ) : (
                     <p className="text-muted pl-2">

--- a/client/web/src/global/CoolCodeIntelHook.tsx
+++ b/client/web/src/global/CoolCodeIntelHook.tsx
@@ -14,7 +14,7 @@ export interface UsePreciseCodeIntelResult {
     fetchMore: () => void
     refetchAll: () => void
     loading: boolean
-    hasNextPage: boolean
+    referencesHasNextPage: boolean
     startPolling: (pollInterval: number) => void
     stopPolling: () => void
 }
@@ -159,7 +159,7 @@ export const usePreciseCodeIntel = <TResult, TVariables, TData>({
         error,
         fetchMore: fetchMoreData,
         refetchAll,
-        hasNextPage: lsifData ? lsifData.references.pageInfo.endCursor !== null : false,
+        referencesHasNextPage: lsifData ? lsifData.references.pageInfo.endCursor !== null : false,
         startPolling: startExecution,
         stopPolling: stopExecution,
     }

--- a/client/web/src/global/CoolCodeIntelHook.tsx
+++ b/client/web/src/global/CoolCodeIntelHook.tsx
@@ -6,10 +6,10 @@ import { asGraphQLResult, parseQueryInt } from '@sourcegraph/web/src/components/
 import { useSearchParameters, useInterval } from '@sourcegraph/wildcard'
 
 import { ConnectionQueryArguments } from '../components/FilteredConnection/ConnectionType'
-import { LsifDataFields } from '../graphql-operations'
+import { RefPanelLsifDataFields } from '../graphql-operations'
 
 export interface UsePreciseCodeIntelResult {
-    lsifData?: LsifDataFields
+    lsifData?: RefPanelLsifDataFields
     error?: ApolloError
     fetchMore: () => void
     refetchAll: () => void
@@ -31,7 +31,7 @@ interface UsePreciseCodeIntelConfig {
 interface UsePreciseCodeIntelParameters<TResult, TVariables> {
     query: string
     variables: TVariables & ConnectionQueryArguments
-    getConnection: (result: GraphQLResult<TResult>) => LsifDataFields
+    getConnection: (result: GraphQLResult<TResult>) => RefPanelLsifDataFields
     options?: UsePreciseCodeIntelConfig
 }
 
@@ -100,7 +100,7 @@ export const usePreciseCodeIntel = <TResult, TVariables, TData>({
      * Map over Apollo results to provide type-compatible `GraphQLResult`s for consumers.
      * This ensures good interoperability between `FilteredConnection` and `useConnection`.
      */
-    const getLsifData = ({ data, error }: Pick<QueryResult<TResult>, 'data' | 'error'>): LsifDataFields => {
+    const getLsifData = ({ data, error }: Pick<QueryResult<TResult>, 'data' | 'error'>): RefPanelLsifDataFields => {
         const result = asGraphQLResult({ data, errors: error?.graphQLErrors || [] })
         return getLsifDataFromGraphQLResult(result)
     }

--- a/client/web/src/global/CoolCodeIntelHook.tsx
+++ b/client/web/src/global/CoolCodeIntelHook.tsx
@@ -6,7 +6,7 @@ import { asGraphQLResult } from '@sourcegraph/web/src/components/FilteredConnect
 import { ConnectionQueryArguments } from '../components/FilteredConnection'
 import { GetPreciseCodeIntelVariables, RefPanelLsifDataFields } from '../graphql-operations'
 
-import { LOAD_ADDITIONAL_REFERENCES_QUERY } from './CoolCodeIntelQueries'
+import { LOAD_ADDITIONAL_IMPLEMENTATIONS_QUERY, LOAD_ADDITIONAL_REFERENCES_QUERY } from './CoolCodeIntelQueries'
 
 export interface UsePreciseCodeIntelResult {
     lsifData?: RefPanelLsifDataFields
@@ -75,16 +75,14 @@ export const usePreciseCodeIntel = <TResult,>({
                     return previousResult
                 }
 
-                if (cursor) {
-                    const previousData = getLsifData({ data: previousResult })
-                    const previousReferencesNodes = previousData.references.nodes
+                const previousData = getLsifData({ data: previousResult })
+                const previousReferencesNodes = previousData.references.nodes
 
-                    const fetchMoreData = getLsifData({ data: fetchMoreResult })
-                    fetchMoreData.implementations = previousData.implementations
-                    fetchMoreData.definitions = previousData.definitions
-                    fetchMoreData.hover = previousData.hover
-                    fetchMoreData.references.nodes.unshift(...previousReferencesNodes)
-                }
+                const fetchMoreData = getLsifData({ data: fetchMoreResult })
+                fetchMoreData.implementations = previousData.implementations
+                fetchMoreData.definitions = previousData.definitions
+                fetchMoreData.hover = previousData.hover
+                fetchMoreData.references.nodes.unshift(...previousReferencesNodes)
 
                 return fetchMoreResult
             },
@@ -95,9 +93,8 @@ export const usePreciseCodeIntel = <TResult,>({
         const cursor = lsifData?.implementations.pageInfo?.endCursor
 
         await fetchMore({
+            query: getDocumentNode(LOAD_ADDITIONAL_IMPLEMENTATIONS_QUERY),
             variables: {
-                // TODO: If I comment this in, then typechecker dies
-                // query: getDocumentNode(LOAD_ADDITIONAL_IMPLEMENTATIONS_QUERY),
                 ...variables,
                 ...{ afterImplementations: cursor },
             },
@@ -106,16 +103,14 @@ export const usePreciseCodeIntel = <TResult,>({
                     return previousResult
                 }
 
-                if (cursor) {
-                    const previousData = getLsifData({ data: previousResult })
-                    const previousImplementationNodes = previousData.implementations.nodes
+                const previousData = getLsifData({ data: previousResult })
+                const previousImplementationsNodes = previousData.implementations.nodes
 
-                    const fetchMoreData = getLsifData({ data: fetchMoreResult })
-                    fetchMoreData.references = previousData.references
-                    fetchMoreData.definitions = previousData.definitions
-                    fetchMoreData.hover = previousData.hover
-                    fetchMoreData.implementations.nodes.unshift(...previousImplementationNodes)
-                }
+                const fetchMoreData = getLsifData({ data: fetchMoreResult })
+                fetchMoreData.references = previousData.references
+                fetchMoreData.definitions = previousData.definitions
+                fetchMoreData.hover = previousData.hover
+                fetchMoreData.implementations.nodes.unshift(...previousImplementationsNodes)
 
                 return fetchMoreResult
             },

--- a/client/web/src/global/CoolCodeIntelHook.tsx
+++ b/client/web/src/global/CoolCodeIntelHook.tsx
@@ -75,15 +75,13 @@ export const usePreciseCodeIntel = <TResult, TVariables, TData>({
                     return previousResult
                 }
 
-                if (cursor) {
-                    const previousData = getLsifData({ data: previousResult })
-                    const previousImplementationNodes = previousData.implementations.nodes
-                    const previousReferencesNodes = previousData.references.nodes
+                const previousData = getLsifData({ data: previousResult })
+                const previousImplementationNodes = previousData.implementations.nodes
+                const previousReferencesNodes = previousData.references.nodes
 
-                    const fetchMoreData = getLsifData({ data: fetchMoreResult })
-                    fetchMoreData.implementations.nodes = previousImplementationNodes
-                    fetchMoreData.references.nodes.unshift(...previousReferencesNodes)
-                }
+                const fetchMoreData = getLsifData({ data: fetchMoreResult })
+                fetchMoreData.implementations.nodes = previousImplementationNodes
+                fetchMoreData.references.nodes.unshift(...previousReferencesNodes)
 
                 return fetchMoreResult
             },
@@ -103,15 +101,13 @@ export const usePreciseCodeIntel = <TResult, TVariables, TData>({
                     return previousResult
                 }
 
-                if (cursor) {
-                    const previousData = getLsifData({ data: previousResult })
-                    const previousImplementationNodes = previousData.implementations.nodes
-                    const previousReferencesNodes = previousData.references.nodes
+                const previousData = getLsifData({ data: previousResult })
+                const previousImplementationNodes = previousData.implementations.nodes
+                const previousReferencesNodes = previousData.references.nodes
 
-                    const fetchMoreData = getLsifData({ data: fetchMoreResult })
-                    fetchMoreData.implementations.nodes.unshift(...previousImplementationNodes)
-                    fetchMoreData.references.nodes = previousReferencesNodes
-                }
+                const fetchMoreData = getLsifData({ data: fetchMoreResult })
+                fetchMoreData.implementations.nodes.unshift(...previousImplementationNodes)
+                fetchMoreData.references.nodes = previousReferencesNodes
 
                 return fetchMoreResult
             },

--- a/client/web/src/global/CoolCodeIntelHook.tsx
+++ b/client/web/src/global/CoolCodeIntelHook.tsx
@@ -1,0 +1,166 @@
+import { ApolloError, QueryResult, WatchQueryFetchPolicy } from '@apollo/client'
+import { useCallback, useMemo, useRef } from 'react'
+
+import { GraphQLResult, useQuery } from '@sourcegraph/http-client'
+import { asGraphQLResult, parseQueryInt } from '@sourcegraph/web/src/components/FilteredConnection/utils'
+import { useSearchParameters, useInterval } from '@sourcegraph/wildcard'
+
+import { ConnectionQueryArguments } from '../components/FilteredConnection/ConnectionType'
+import { LsifDataFields } from '../graphql-operations'
+
+export interface UsePreciseCodeIntelResult {
+    lsifData?: LsifDataFields
+    error?: ApolloError
+    fetchMore: () => void
+    refetchAll: () => void
+    loading: boolean
+    hasNextPage: boolean
+    startPolling: (pollInterval: number) => void
+    stopPolling: () => void
+}
+
+interface UsePreciseCodeIntelConfig {
+    /** Set if query variables should be updated in and derived from the URL */
+    useURL?: boolean
+    /** Allows modifying how the query interacts with the Apollo cache */
+    fetchPolicy?: WatchQueryFetchPolicy
+    /** Set to enable polling of all the nodes currently loaded in the connection */
+    pollInterval?: number
+}
+
+interface UsePreciseCodeIntelParameters<TResult, TVariables> {
+    query: string
+    variables: TVariables & ConnectionQueryArguments
+    getConnection: (result: GraphQLResult<TResult>) => LsifDataFields
+    options?: UsePreciseCodeIntelConfig
+}
+
+const DEFAULT_AFTER: ConnectionQueryArguments['after'] = undefined
+const DEFAULT_FIRST: ConnectionQueryArguments['first'] = 20
+
+export const usePreciseCodeIntel = <TResult, TVariables, TData>({
+    query,
+    variables,
+    getConnection: getLsifDataFromGraphQLResult,
+    options,
+}: UsePreciseCodeIntelParameters<TResult, TVariables>): UsePreciseCodeIntelResult => {
+    const searchParameters = useSearchParameters()
+
+    const { first = DEFAULT_FIRST, after = DEFAULT_AFTER } = variables
+    const firstReference = useRef({
+        /**
+         * The number of results that we will typically want to load in the next request (unless `visible` is used).
+         * This value will typically be static for cursor-based pagination, but will be dynamic for batch-based pagination.
+         */
+        actual: (options?.useURL && parseQueryInt(searchParameters, 'first')) || first,
+        /**
+         * Primarily used to determine original request state for URL search parameter logic.
+         */
+        default: first,
+    })
+
+    const initialControls = useMemo(
+        () => ({
+            /**
+             * The `first` variable for our **initial** query.
+             * If this is our first query and we were supplied a value for `visible` load that many results.
+             * If we weren't given such a value or this is a subsequent request, only ask for one page of results.
+             *
+             * 'visible' is the number of results that were visible from previous requests. The initial request of
+             * a result set will load `visible` items, then will request `first` items on each subsequent
+             * request. This has the effect of loading the correct number of visible results when a URL
+             * is copied during pagination. This value is only useful with cursor-based paging for the initial request.
+             */
+            first: (options?.useURL && parseQueryInt(searchParameters, 'visible')) || firstReference.current.actual,
+            /**
+             * The `after` variable for our **initial** query.
+             * Subsequent requests through `fetchMore` will use a valid `cursor` value here, where possible.
+             */
+            after: (options?.useURL && searchParameters.get('after')) || after,
+        }),
+        // We only need these controls for the inital request. We do not care about dependency updates.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        []
+    )
+
+    /**
+     * Initial query of the hook.
+     * Subsequent requests (such as further pagination) will be handled through `fetchMore`
+     */
+    const { data, error, loading, fetchMore, refetch } = useQuery<TResult, TVariables>(query, {
+        variables: {
+            ...variables,
+            ...initialControls,
+        },
+        notifyOnNetworkStatusChange: true, // Ensures loading state is updated on `fetchMore`
+        fetchPolicy: options?.fetchPolicy,
+    })
+
+    /**
+     * Map over Apollo results to provide type-compatible `GraphQLResult`s for consumers.
+     * This ensures good interoperability between `FilteredConnection` and `useConnection`.
+     */
+    const getLsifData = ({ data, error }: Pick<QueryResult<TResult>, 'data' | 'error'>): LsifDataFields => {
+        const result = asGraphQLResult({ data, errors: error?.graphQLErrors || [] })
+        return getLsifDataFromGraphQLResult(result)
+    }
+
+    const lsifData = data ? getLsifData({ data, error }) : undefined
+
+    const fetchMoreData = async (): Promise<void> => {
+        const cursor = lsifData?.references.pageInfo?.endCursor
+
+        await fetchMore({
+            variables: {
+                ...variables,
+                // Use cursor paging if possible, otherwise fallback to multiplying `first`
+                ...(cursor ? { after: cursor } : { first: firstReference.current.actual * 2 }),
+            },
+            updateQuery: (previousResult, { fetchMoreResult }) => {
+                if (!fetchMoreResult) {
+                    return previousResult
+                }
+
+                if (cursor) {
+                    // Update resultant data in the cache by prepending the `previousResult`s to the
+                    // `fetchMoreResult`s. We must rely on the consumer-provided `getConnection` here in
+                    // order to access and modify the actual `nodes` in the connection response because we
+                    // don't know the exact response structure
+                    const previousNodes = getLsifData({ data: previousResult }).references.nodes
+                    getLsifData({ data: fetchMoreResult }).references.nodes.unshift(...previousNodes)
+                } else {
+                    // With batch-based pagination, we have all the results already in `fetchMoreResult`,
+                    // we just need to update `first` to fetch more results next time
+                    firstReference.current.actual *= 2
+                }
+
+                return fetchMoreResult
+            },
+        })
+    }
+
+    const refetchAll = useCallback(async (): Promise<void> => {
+        const first = lsifData?.references.nodes.length || firstReference.current.actual
+
+        await refetch({
+            ...variables,
+            first,
+        })
+    }, [lsifData?.references.nodes.length, refetch, variables])
+
+    // We use `refetchAll` to poll for all of the nodes currently loaded in the
+    // connection, vs. just providing a `pollInterval` to the underlying `useQuery`, which
+    // would only poll for the first page of results.
+    const { startExecution, stopExecution } = useInterval(refetchAll, options?.pollInterval || -1)
+
+    return {
+        lsifData,
+        loading,
+        error,
+        fetchMore: fetchMoreData,
+        refetchAll,
+        hasNextPage: lsifData ? lsifData.references.pageInfo.endCursor !== null : false,
+        startPolling: startExecution,
+        stopPolling: stopExecution,
+    }
+}

--- a/client/web/src/global/CoolCodeIntelQueries.tsx
+++ b/client/web/src/global/CoolCodeIntelQueries.tsx
@@ -96,10 +96,8 @@ export const USE_PRECISE_CODE_INTEL_FOR_POSITION_QUERY = gql`
         $filter: String
     ) {
         repository(name: $repository) {
-            __typename
             id
             commit(rev: $commit) {
-                __typename
                 id
                 blob(path: $path) {
                     url
@@ -128,10 +126,8 @@ export const LOAD_ADDITIONAL_REFERENCES_QUERY = gql`
         $filter: String
     ) {
         repository(name: $repository) {
-            __typename
             id
             commit(rev: $commit) {
-                __typename
                 id
                 blob(path: $path) {
                     url
@@ -166,10 +162,8 @@ export const LOAD_ADDITIONAL_IMPLEMENTATIONS_QUERY = gql`
         $filter: String
     ) {
         repository(name: $repository) {
-            __typename
             id
             commit(rev: $commit) {
-                __typename
                 id
                 blob(path: $path) {
                     url

--- a/client/web/src/global/CoolCodeIntelQueries.tsx
+++ b/client/web/src/global/CoolCodeIntelQueries.tsx
@@ -92,7 +92,7 @@ export const FETCH_REFERENCES_QUERY = gql`
 `
 
 const gitBlobLsifDataQueryFragment = gql`
-    fragment RefPanelLsifDataFields on GitBlobLSIFData {
+    fragment PreciseCodeIntelForLocationFields on GitBlobLSIFData {
         references(
             line: $line
             character: $character
@@ -120,8 +120,8 @@ const gitBlobLsifDataQueryFragment = gql`
     }
 `
 
-export const USE_CODE_INTEL_QUERY = gql`
-    query GetPreciseCodeIntel(
+export const USE_PRECISE_CODE_INTEL_FOR_POSITION_QUERY = gql`
+    query UsePreciseCodeIntelForPosition(
         $repository: String!
         $commit: String!
         $path: String!
@@ -141,7 +141,7 @@ export const USE_CODE_INTEL_QUERY = gql`
                 id
                 blob(path: $path) {
                     lsif {
-                        ...RefPanelLsifDataFields
+                        ...PreciseCodeIntelForLocationFields
                     }
                 }
             }

--- a/client/web/src/global/CoolCodeIntelQueries.tsx
+++ b/client/web/src/global/CoolCodeIntelQueries.tsx
@@ -93,7 +93,22 @@ export const FETCH_REFERENCES_QUERY = gql`
 
 const gitBlobLsifDataQueryFragment = gql`
     fragment RefPanelLsifDataFields on GitBlobLSIFData {
-        references(line: $line, character: $character, first: $first, after: $after, filter: $filter) {
+        references(
+            line: $line
+            character: $character
+            first: $firstReferences
+            after: $afterReferences
+            filter: $filter
+        ) {
+            ...LocationConnectionFields
+        }
+        implementations(
+            line: $line
+            character: $character
+            first: $firstImplementations
+            after: $afterImplementations
+            filter: $filter
+        ) {
             ...LocationConnectionFields
         }
         definitions(line: $line, character: $character, filter: $filter) {
@@ -112,12 +127,18 @@ export const USE_CODE_INTEL_QUERY = gql`
         $path: String!
         $line: Int!
         $character: Int!
-        $after: String
-        $first: Int
+        $afterReferences: String
+        $firstReferences: Int
+        $afterImplementations: String
+        $firstImplementations: Int
         $filter: String
     ) {
         repository(name: $repository) {
+            __typename
+            id
             commit(rev: $commit) {
+                __typename
+                id
                 blob(path: $path) {
                     lsif {
                         ...RefPanelLsifDataFields

--- a/client/web/src/global/CoolCodeIntelQueries.tsx
+++ b/client/web/src/global/CoolCodeIntelQueries.tsx
@@ -21,6 +21,7 @@ const codeIntelFragments = gql`
     }
 
     fragment GitBlobFields on GitBlob {
+        url
         path
         content
         repository {
@@ -101,6 +102,7 @@ export const USE_PRECISE_CODE_INTEL_FOR_POSITION_QUERY = gql`
                 __typename
                 id
                 blob(path: $path) {
+                    url
                     lsif {
                         ...PreciseCodeIntelForLocationFields
                     }
@@ -132,6 +134,7 @@ export const LOAD_ADDITIONAL_REFERENCES_QUERY = gql`
                 __typename
                 id
                 blob(path: $path) {
+                    url
                     lsif {
                         references(
                             line: $line
@@ -169,6 +172,7 @@ export const LOAD_ADDITIONAL_IMPLEMENTATIONS_QUERY = gql`
                 __typename
                 id
                 blob(path: $path) {
+                    url
                     lsif {
                         implementations(
                             line: $line
@@ -190,6 +194,7 @@ export const LOAD_ADDITIONAL_IMPLEMENTATIONS_QUERY = gql`
 
 export const FETCH_HIGHLIGHTED_BLOB = gql`
     fragment HighlightedGitBlobFields on GitBlob {
+        url
         highlight(disableTimeout: false) {
             aborted
             html
@@ -198,7 +203,9 @@ export const FETCH_HIGHLIGHTED_BLOB = gql`
 
     query CoolCodeIntelHighlightedBlob($repository: String!, $commit: String!, $path: String!) {
         repository(name: $repository) {
+            id
             commit(rev: $commit) {
+                id
                 blob(path: $path) {
                     ...HighlightedGitBlobFields
                 }

--- a/client/web/src/global/CoolCodeIntelQueries.tsx
+++ b/client/web/src/global/CoolCodeIntelQueries.tsx
@@ -153,6 +153,43 @@ export const USE_CODE_INTEL_QUERY = gql`
     ${gitBlobLsifDataQueryFragment}
 `
 
+export const LOAD_ADDITIONAL_REFERENCES_QUERY = gql`
+    query LoadAdditionalReferences(
+        $repository: String!
+        $commit: String!
+        $path: String!
+        $line: Int!
+        $character: Int!
+        $afterReferences: String
+        $firstReferences: Int
+        $filter: String
+    ) {
+        repository(name: $repository) {
+            __typename
+            id
+            commit(rev: $commit) {
+                __typename
+                id
+                blob(path: $path) {
+                    lsif {
+                        references(
+                            line: $line
+                            character: $character
+                            first: $firstReferences
+                            after: $afterReferences
+                            filter: $filter
+                        ) {
+                            ...LocationConnectionFields
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    ${codeIntelFragments}
+`
+
 export const FETCH_HIGHLIGHTED_BLOB = gql`
     fragment HighlightedGitBlobFields on GitBlob {
         highlight(disableTimeout: false) {

--- a/client/web/src/global/CoolCodeIntelQueries.tsx
+++ b/client/web/src/global/CoolCodeIntelQueries.tsx
@@ -62,7 +62,11 @@ export const FETCH_REFERENCES_QUERY = gql`
         $filter: String
     ) {
         repository(name: $repository) {
+            __typename
+            id
             commit(rev: $commit) {
+                __typename
+                id
                 blob(path: $path) {
                     lsif {
                         references(line: $line, character: $character, after: $after, filter: $filter) {
@@ -89,8 +93,14 @@ export const FETCH_REFERENCES_QUERY = gql`
 
 const gitBlobLsifDataQueryFragment = gql`
     fragment LsifDataFields on GitBlobLSIFData {
-        references(line: $line, character: $character, after: $after, filter: $filter) {
+        references(line: $line, character: $character, first: $first, after: $after, filter: $filter) {
             ...LocationConnectionFields
+        }
+        definitions(line: $line, character: $character, filter: $filter) {
+            ...LocationConnectionFields
+        }
+        hover(line: $line, character: $character) {
+            ...HoverFields
         }
     }
 `
@@ -103,6 +113,7 @@ export const USE_CODE_INTEL_QUERY = gql`
         $line: Int!
         $character: Int!
         $after: String
+        $first: Int
         $filter: String
     ) {
         repository(name: $repository) {
@@ -117,6 +128,7 @@ export const USE_CODE_INTEL_QUERY = gql`
     }
 
     ${codeIntelFragments}
+    ${hoverFragments}
     ${gitBlobLsifDataQueryFragment}
 `
 

--- a/client/web/src/global/CoolCodeIntelQueries.tsx
+++ b/client/web/src/global/CoolCodeIntelQueries.tsx
@@ -92,7 +92,7 @@ export const FETCH_REFERENCES_QUERY = gql`
 `
 
 const gitBlobLsifDataQueryFragment = gql`
-    fragment LsifDataFields on GitBlobLSIFData {
+    fragment RefPanelLsifDataFields on GitBlobLSIFData {
         references(line: $line, character: $character, first: $first, after: $after, filter: $filter) {
             ...LocationConnectionFields
         }
@@ -120,7 +120,7 @@ export const USE_CODE_INTEL_QUERY = gql`
             commit(rev: $commit) {
                 blob(path: $path) {
                     lsif {
-                        ...LsifDataFields
+                        ...RefPanelLsifDataFields
                     }
                 }
             }

--- a/client/web/src/global/CoolCodeIntelQueries.tsx
+++ b/client/web/src/global/CoolCodeIntelQueries.tsx
@@ -190,6 +190,43 @@ export const LOAD_ADDITIONAL_REFERENCES_QUERY = gql`
     ${codeIntelFragments}
 `
 
+export const LOAD_ADDITIONAL_IMPLEMENTATIONS_QUERY = gql`
+    query LoadAdditionalImplementations(
+        $repository: String!
+        $commit: String!
+        $path: String!
+        $line: Int!
+        $character: Int!
+        $afterImplementations: String
+        $firstImplementations: Int
+        $filter: String
+    ) {
+        repository(name: $repository) {
+            __typename
+            id
+            commit(rev: $commit) {
+                __typename
+                id
+                blob(path: $path) {
+                    lsif {
+                        implementations(
+                            line: $line
+                            character: $character
+                            first: $firstImplementations
+                            after: $afterImplementations
+                            filter: $filter
+                        ) {
+                            ...LocationConnectionFields
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    ${codeIntelFragments}
+`
+
 export const FETCH_HIGHLIGHTED_BLOB = gql`
     fragment HighlightedGitBlobFields on GitBlob {
         highlight(disableTimeout: false) {

--- a/client/web/src/global/CoolCodeIntelQueries.tsx
+++ b/client/web/src/global/CoolCodeIntelQueries.tsx
@@ -51,45 +51,6 @@ const hoverFragments = gql`
         }
     }
 `
-export const FETCH_REFERENCES_QUERY = gql`
-    query CoolCodeIntelReferences(
-        $repository: String!
-        $commit: String!
-        $path: String!
-        $line: Int!
-        $character: Int!
-        $after: String
-        $filter: String
-    ) {
-        repository(name: $repository) {
-            __typename
-            id
-            commit(rev: $commit) {
-                __typename
-                id
-                blob(path: $path) {
-                    lsif {
-                        references(line: $line, character: $character, after: $after, filter: $filter) {
-                            ...LocationConnectionFields
-                        }
-                        implementations(line: $line, character: $character, after: $after, filter: $filter) {
-                            ...LocationConnectionFields
-                        }
-                        definitions(line: $line, character: $character, filter: $filter) {
-                            ...LocationConnectionFields
-                        }
-                        hover(line: $line, character: $character) {
-                            ...HoverFields
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    ${codeIntelFragments}
-    ${hoverFragments}
-`
 
 const gitBlobLsifDataQueryFragment = gql`
     fragment PreciseCodeIntelForLocationFields on GitBlobLSIFData {

--- a/client/web/src/global/usePreciseCodeIntel.tsx
+++ b/client/web/src/global/usePreciseCodeIntel.tsx
@@ -50,7 +50,6 @@ export const usePreciseCodeIntel = ({
         variables,
         notifyOnNetworkStatusChange: true,
         fetchPolicy: options?.fetchPolicy,
-        nextFetchPolicy: options?.nextFetchPolicy,
     })
 
     const lsifData = data ? getLsifData({ data, error }) : undefined

--- a/client/web/src/global/usePreciseCodeIntel.tsx
+++ b/client/web/src/global/usePreciseCodeIntel.tsx
@@ -31,7 +31,6 @@ export interface UsePreciseCodeIntelResult {
 interface UsePreciseCodeIntelConfig {
     /** Allows modifying how the query interacts with the Apollo cache */
     fetchPolicy?: WatchQueryFetchPolicy
-    nextFetchPolicy?: WatchQueryFetchPolicy
 }
 
 interface UsePreciseCodeIntelParameters {

--- a/client/web/src/global/usePreciseCodeIntel.tsx
+++ b/client/web/src/global/usePreciseCodeIntel.tsx
@@ -48,6 +48,7 @@ export const usePreciseCodeIntel = ({
         UsePreciseCodeIntelForPositionVariables & ConnectionQueryArguments
     >(USE_PRECISE_CODE_INTEL_FOR_POSITION_QUERY, {
         variables,
+        notifyOnNetworkStatusChange: true,
         fetchPolicy: options?.fetchPolicy,
         nextFetchPolicy: options?.nextFetchPolicy,
     })

--- a/client/web/src/global/usePreciseCodeIntel.tsx
+++ b/client/web/src/global/usePreciseCodeIntel.tsx
@@ -6,7 +6,6 @@ import { asGraphQLResult } from '@sourcegraph/web/src/components/FilteredConnect
 import { ConnectionQueryArguments } from '../components/FilteredConnection'
 import {
     UsePreciseCodeIntelForPositionVariables,
-    RefPanelLsifDataFields,
     UsePreciseCodeIntelForPositionResult,
     PreciseCodeIntelForLocationFields,
 } from '../graphql-operations'
@@ -18,7 +17,7 @@ import {
 } from './CoolCodeIntelQueries'
 
 export interface UsePreciseCodeIntelResult {
-    lsifData?: RefPanelLsifDataFields
+    lsifData?: PreciseCodeIntelForLocationFields
     error?: ApolloError
     loading: boolean
 

--- a/client/web/src/global/usePreciseCodeIntel.tsx
+++ b/client/web/src/global/usePreciseCodeIntel.tsx
@@ -48,7 +48,6 @@ export const usePreciseCodeIntel = ({
         UsePreciseCodeIntelForPositionVariables & ConnectionQueryArguments
     >(USE_PRECISE_CODE_INTEL_FOR_POSITION_QUERY, {
         variables,
-        notifyOnNetworkStatusChange: true, // Ensures loading state is updated on `fetchMore`
         fetchPolicy: options?.fetchPolicy,
         nextFetchPolicy: options?.nextFetchPolicy,
     })

--- a/client/web/src/global/usePreciseCodeIntel.tsx
+++ b/client/web/src/global/usePreciseCodeIntel.tsx
@@ -31,6 +31,7 @@ export interface UsePreciseCodeIntelResult {
 interface UsePreciseCodeIntelConfig {
     /** Allows modifying how the query interacts with the Apollo cache */
     fetchPolicy?: WatchQueryFetchPolicy
+    nextFetchPolicy?: WatchQueryFetchPolicy
 }
 
 interface UsePreciseCodeIntelParameters {
@@ -49,6 +50,7 @@ export const usePreciseCodeIntel = ({
         variables,
         notifyOnNetworkStatusChange: true, // Ensures loading state is updated on `fetchMore`
         fetchPolicy: options?.fetchPolicy,
+        nextFetchPolicy: options?.nextFetchPolicy,
     })
 
     const lsifData = data ? getLsifData({ data, error }) : undefined


### PR DESCRIPTION
This fixes #30971 by adding pagination to "References" and "Implementations" in the experimental reference panel.

Both lists can be independently paginated without re-loading data that was already requested before. 


https://user-images.githubusercontent.com/1185253/154961635-44588361-3ee7-4d45-baf6-8a0eda6a627b.mp4



## Test plan

- Uploaded LSIF dump for `sourcegraph/sourcegraph` and opened reference panel on `ShareableStore`
- Tested this locally (see video above) with `firstReferences` and `firstImplementations` set to `10` to easily test the cases where there is
  - no more data
  - more data
  - more data being loaded
- Watched developer tools network tab for requests and inspected those


