### PR TITLE
add a more representative or query

### DIFF
--- a/internal/cmd/search-blitz/queries.txt
+++ b/internal/cmd/search-blitz/queries.txt
@@ -92,3 +92,6 @@ patterntype:regexp \beven\b and \bintelligence\b and \bdream\b and \bsimplest\b
 
 # or_regex
 patterntype:regexp \bdeadbeeeeef\b or \bdeadbeeeeeef\b or \bdeadBEEEEEF\b or \bdeadbeeeeef\b or \bdeadbeeeeeef\b or \bdeadBEEEEEF\b or \bdoResults\b
+
+# or_literal_small
+patterntype:literal readUInt16LE or readUInt8

--- a/internal/cmd/search-blitz/queries.txt
+++ b/internal/cmd/search-blitz/queries.txt
@@ -93,5 +93,5 @@ patterntype:regexp \beven\b and \bintelligence\b and \bdream\b and \bsimplest\b
 # or_regex
 patterntype:regexp \bdeadbeeeeef\b or \bdeadbeeeeeef\b or \bdeadBEEEEEF\b or \bdeadbeeeeef\b or \bdeadbeeeeeef\b or \bdeadBEEEEEF\b or \bdoResults\b
 
-# or_literal_small
+# or_literal_simple
 patterntype:literal readUInt16LE or readUInt8


### PR DESCRIPTION
Our current `or_regexp` query is pretty gnarly, and does not well
represent the smaller, saner `or` searches that most people actually do.
This just adds a small `or` search that exercises the operator in a way
that's more likely to look like how it's actually used.



## Test plan

Just adds test.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


