### PR TITLE
Bump src-cli to latest version

### DIFF
--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.36.4"
+const MinimumVersion = "3.37.0"


### PR DESCRIPTION
## Test plan

This is just a mechanical bump to recommend the latest available version of src-cli. 