### PR TITLE
doc/templates: fix page panic for not-found and version fallbacks

### DIFF
--- a/doc/_resources/templates/document.html
+++ b/doc/_resources/templates/document.html
@@ -58,7 +58,15 @@
 {{end}}
 
 {{define "head"}}
-	{{if (or (contains .Content.Path "insights") (or (not .Content) .ContentVersion))}}<meta name="robots" content="noindex">{{end}}
+    {{ if .Content }}
+        {{ if contains .Content.Path "insights" }}
+            <!-- don't index embargoed insights pages -->
+            <meta name="robots" content="noindex">
+        {{end}}
+    {{ else if .ContentVersion }}
+        <!-- don't index version pages -->
+        <meta name="robots" content="noindex">
+    {{ end }}
 {{end}}
 
 {{define "content"}}


### PR DESCRIPTION
[Version fallbacks from customers](https://sourcegraph.slack.com/archives/C02E4HE42BX/p1645113656732839) are panicking again. It seems a new `.Content` check that didn't check for non-nil was added, this PR fixes the check to avoid panics on fallbacks.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

<img width="958" alt="image" src="https://user-images.githubusercontent.com/23356519/154524791-b0fcc65a-7be9-4655-9de3-7e3e290fb5b2.png">

