### PR TITLE
gqltest: add tests for sub-repo permissions for filename and content search

### DIFF
--- a/dev/gqltest/sub_repo_permissions_test.go
+++ b/dev/gqltest/sub_repo_permissions_test.go
@@ -108,12 +108,12 @@ func TestSubRepoPermissionsSearch(t *testing.T) {
 		},
 		{
 			name:       "structural, indexed search of restricted content",
-			query:      `echo "..." index:only patterntype:structural`,
+			query:      `repo:^perforce/test-perms$ echo "..." index:only patterntype:structural`,
 			zeroResult: true,
 		},
 		{
 			name:       "structural, unindexed search of restricted content",
-			query:      `echo "..." index:no patterntype:structural`,
+			query:      `repo:^perforce/test-perms$ echo "..." index:no patterntype:structural`,
 			zeroResult: true,
 		},
 		{
@@ -125,6 +125,26 @@ func TestSubRepoPermissionsSearch(t *testing.T) {
 			name:          "structural, unindexed search, nonzero result",
 			query:         `println(...) index:no patterntype:structural`,
 			minMatchCount: 1,
+		},
+		{
+			name:          "filename search, nonzero result",
+			query:         `repo:^perforce/test-perms$ type:path app`,
+			minMatchCount: 1,
+		},
+		{
+			name:       "filename search of restricted content",
+			query:      `repo:^perforce/test-perms$ type:path hack`,
+			zeroResult: true,
+		},
+		{
+			name:          "content search, nonzero result",
+			query:         `repo:^perforce/test-perms$ type:file let`,
+			minMatchCount: 1,
+		},
+		{
+			name:       "content search of restricted content",
+			query:      `repo:^perforce/test-perms$ type:file echo`,
+			zeroResult: true,
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/27448

## Test plan
Writing integration tests

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


