### PR TITLE
Fix search context fetching issue on older version

### DIFF
--- a/client/vscode/CHANGELOG.md
+++ b/client/vscode/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## Next Release
+## Next Release - 2.0.9
 
 ### Changes
 
 - Add Changelog for version tracking purpose [issue/28300](https://github.com/sourcegraph/sourcegraph/issues/28300)
+
+### Fixes
+
+- Manage context display issue for instances under v3.36.0 [issues/31022](https://github.com/sourcegraph/sourcegraph/issues/31022)
 
 ## 2.0.8
 

--- a/client/vscode/README.md
+++ b/client/vscode/README.md
@@ -58,6 +58,7 @@ In addition to searching open source code, you can create a Sourcegraph Cloud ac
 4. Click `Manage repositories`. From here, you can add your repositories to be synced to Sourcegraph.
 
 ### Connecting Sourcegraph Cloud account
+
 Once you have repositories synced to Sourcegraph, you can generate an access token to connect your VS Code extension back to your Sourcegraph Cloud account.
 
 1. Back in Sourcegraph Cloud, in your account settings, navigate to `Access tokens`, then click `Generate new token`.
@@ -66,12 +67,12 @@ Once you have repositories synced to Sourcegraph, you can generate an access tok
 4. Alternatively, you can copy and paste the generated token from step 4 in this format: `“sourcegraph.accessToken": "e4234234123112312”` into your VS Code Setting by going to `Code` > `Preference` > `Settings` > Search for "Sourcegraph" > `Edit in settings.json`.
 5. The Editor will be reloaded automatically to use the newly added token.
 
-### Connecting to a private Sourcegraph instance 
-1.  In Sourcegraph, in your account settings, navigate to `Access tokens`, then click `Generate new token`.
-2. Once you have generated a token, navigate to your VS Code Settings, then navigate to "Extension settings".
-3. Navigate to `Code preferences`, then click `Settings`.
-4. Search for `Sourcegraph`, and enter the newly generated access token as well as your Sourcegraph instance URL. 
+### Connecting to a private Sourcegraph instance
 
+1.  In Sourcegraph, in your account settings, navigate to `Access tokens`, then click `Generate new token`.
+2.  Once you have generated a token, navigate to your VS Code Settings, then navigate to "Extension settings".
+3.  Navigate to `Code preferences`, then click `Settings`.
+4.  Search for `Sourcegraph`, and enter the newly generated access token as well as your Sourcegraph instance URL.
 
 ## Keyboard Shortcuts:
 

--- a/client/vscode/src/webview/search-panel/SearchHomeView.tsx
+++ b/client/vscode/src/webview/search-panel/SearchHomeView.tsx
@@ -5,9 +5,8 @@ import { useDeepCompareEffectNoCheck } from 'use-deep-compare-effect'
 
 import {
     SearchPatternType,
-    fetchAutoDefinedSearchContexts,
     getUserSearchContextNamespaces,
-    fetchSearchContexts,
+    fetchAutoDefinedSearchContexts,
     QueryState,
 } from '@sourcegraph/search'
 import { SearchBox } from '@sourcegraph/search-ui'
@@ -20,6 +19,7 @@ import { globbingEnabledFromSettings } from '@sourcegraph/shared/src/util/globbi
 import { SearchHomeState } from '../../state'
 import { WebviewPageProps } from '../platform/context'
 
+import { fetchSearchContexts } from './alias/fetchSearchContext'
 import { BrandHeader } from './components/BrandHeader'
 import { HomeFooter } from './components/HomeFooter'
 import styles from './index.module.scss'
@@ -177,7 +177,7 @@ export const SearchHomeView: React.FunctionComponent<SearchHomeViewProps> = ({
                         authenticatedUser={authenticatedUser}
                         searchContextsEnabled={true}
                         showSearchContext={true}
-                        showSearchContextManagement={true}
+                        showSearchContextManagement={false}
                         defaultSearchContextSpec="global"
                         setSelectedSearchContextSpec={setSelectedSearchContextSpec}
                         selectedSearchContextSpec={context.selectedSearchContextSpec}

--- a/client/vscode/src/webview/search-panel/SearchResultsView.tsx
+++ b/client/vscode/src/webview/search-panel/SearchResultsView.tsx
@@ -7,7 +7,6 @@ import {
     SearchPatternType,
     fetchAutoDefinedSearchContexts,
     getUserSearchContextNamespaces,
-    fetchSearchContexts,
     QueryState,
 } from '@sourcegraph/search'
 import { SearchBox, SearchBoxEditor, StreamingProgress, StreamingSearchResultsList } from '@sourcegraph/search-ui'
@@ -23,6 +22,7 @@ import { SourcegraphUri } from '../../file-system/SourcegraphUri'
 import { SearchResultsState } from '../../state'
 import { WebviewPageProps } from '../platform/context'
 
+import { fetchSearchContexts } from './alias/fetchSearchContext'
 import { ModalVideo } from './alias/ModalVideo'
 import { setFocusSearchBox } from './api'
 import { SearchBetaIcon } from './components/icons'

--- a/client/vscode/src/webview/search-panel/alias/fetchSearchContext.ts
+++ b/client/vscode/src/webview/search-panel/alias/fetchSearchContext.ts
@@ -1,0 +1,184 @@
+import { Observable } from 'rxjs'
+import { map } from 'rxjs/operators'
+
+import { gql, dataOrThrowErrors } from '@sourcegraph/http-client'
+import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
+import * as GQL from '@sourcegraph/shared/src/schema'
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] }
+export type Maybe<T> = T | null
+
+/** All built-in and custom scalars, mapped to their actual values */
+export interface Scalars {
+    ID: string
+    String: string
+    Boolean: boolean
+    Int: number
+    Float: number
+    /** A quadruple that represents all possible states of the published value: true, false, 'draft', or null. */
+    PublishedValue: boolean | 'draft'
+    /** A valid JSON value. */
+    JSONValue: unknown
+    /** A string that contains valid JSON, with additional support for //-style comments and trailing commas. */
+    JSONCString: string
+    /** A Git object ID (SHA-1 hash, 40 hexadecimal characters). */
+    GitObjectID: string
+    /** An arbitrarily large integer encoded as a decimal string. */
+    BigInt: string
+    /**
+     * An RFC 3339-encoded UTC date string, such as 1973-11-29T21:33:09Z. This value can be parsed into a
+     * JavaScript Date using Date.parse. To produce this value from a JavaScript Date instance, use
+     * Date#toISOString.
+     */
+    DateTime: string
+}
+
+/**
+ * This is a copy of the fetchSearchContexts function from @sourcegraph/search created for VSCE use
+ * We have removed `query` from SearchContext to support instances below v3.36.0
+ * as query does not exist in Search Context type in older instances
+ * More context in https://github.com/sourcegraph/sourcegraph/issues/31022
+ **/
+
+const searchContextFragment = gql`
+    fragment SearchContextFields on SearchContext {
+        __typename
+        id
+        name
+        namespace {
+            __typename
+            id
+            namespaceName
+        }
+        spec
+        description
+        public
+        autoDefined
+        updatedAt
+        viewerCanManage
+        repositories {
+            __typename
+            repository {
+                name
+            }
+            revisions
+        }
+    }
+`
+
+export function fetchSearchContexts({
+    first,
+    namespaces,
+    query,
+    after,
+    orderBy,
+    descending,
+    platformContext,
+}: {
+    first: number
+    query?: string
+    namespaces?: Maybe<Scalars['ID']>[]
+    after?: string
+    orderBy?: GQL.SearchContextsOrderBy
+    descending?: boolean
+    platformContext: Pick<PlatformContext, 'requestGraphQL'>
+}): Observable<ListSearchContextsResult['searchContexts']> {
+    return platformContext
+        .requestGraphQL<ListSearchContextsResult, ListSearchContextsVariables>({
+            request: gql`
+                query ListSearchContexts(
+                    $first: Int!
+                    $after: String
+                    $query: String
+                    $namespaces: [ID]
+                    $orderBy: SearchContextsOrderBy
+                    $descending: Boolean
+                ) {
+                    searchContexts(
+                        first: $first
+                        after: $after
+                        query: $query
+                        namespaces: $namespaces
+                        orderBy: $orderBy
+                        descending: $descending
+                    ) {
+                        nodes {
+                            ...SearchContextFields
+                        }
+                        pageInfo {
+                            hasNextPage
+                            endCursor
+                        }
+                        totalCount
+                    }
+                }
+                ${searchContextFragment}
+            `,
+            variables: {
+                first,
+                after: after ?? null,
+                query: query ?? null,
+                namespaces: namespaces ?? [],
+                orderBy: orderBy ?? GQL.SearchContextsOrderBy.SEARCH_CONTEXT_SPEC,
+                descending: descending ?? false,
+            },
+            mightContainPrivateInfo: true,
+        })
+        .pipe(
+            map(dataOrThrowErrors),
+            map(data => data.searchContexts)
+        )
+}
+
+export interface SearchContextFields {
+    __typename: 'SearchContext'
+    id: string
+    name: string
+    spec: string
+    description: string
+    public: boolean
+    autoDefined: boolean
+    updatedAt: string
+    viewerCanManage: boolean
+    query: string
+    namespace: Maybe<
+        | { __typename: 'User'; id: string; namespaceName: string }
+        | { __typename: 'Org'; id: string; namespaceName: string }
+    >
+    repositories: {
+        __typename: 'SearchContextRepositoryRevisions'
+        revisions: string[]
+        repository: { __typename?: 'Repository'; name: string }
+    }[]
+}
+
+export type AutoDefinedSearchContextsVariables = Exact<{ [key: string]: never }>
+
+export interface AutoDefinedSearchContextsResult {
+    __typename?: 'Query'
+    autoDefinedSearchContexts: ({ __typename?: 'SearchContext' } & SearchContextFields)[]
+}
+
+export type ListSearchContextsVariables = Exact<{
+    first: Scalars['Int']
+    after: Maybe<Scalars['String']>
+    query: Maybe<Scalars['String']>
+    namespaces: Maybe<Maybe<Scalars['ID']>[]>
+    orderBy: Maybe<SearchContextsOrderBy>
+    descending: Maybe<Scalars['Boolean']>
+}>
+
+export interface ListSearchContextsResult {
+    __typename?: 'Query'
+    searchContexts: {
+        __typename?: 'SearchContextConnection'
+        totalCount: number
+        nodes: ({ __typename?: 'SearchContext' } & SearchContextFields)[]
+        pageInfo: { __typename?: 'PageInfo'; hasNextPage: boolean; endCursor: Maybe<string> }
+    }
+}
+
+/** SearchContextsOrderBy enumerates the ways a search contexts list can be ordered. */
+export enum SearchContextsOrderBy {
+    SEARCH_CONTEXT_SPEC = 'SEARCH_CONTEXT_SPEC',
+    SEARCH_CONTEXT_UPDATED_AT = 'SEARCH_CONTEXT_UPDATED_AT',
+}


### PR DESCRIPTION
Co-authored-by: Giselle Northy <northyg@oregonstate.edu>


This PR is to fix the issue where connecting VSCE to older instances would result in the error below while loading search contexts in search box:
![image](https://user-images.githubusercontent.com/68532117/154572119-77e9ba90-972c-46ff-9abd-ba8b85953e0b.png)

Quoting @northyg from https://github.com/sourcegraph/sourcegraph/issues/31022:
> @abeatrix and I did some digging around and found that older versions of Sourcegraph are not compatible with the latest version of VSCE because there is a new field query that was not in the older versions.
In other words, when a user has an older Sourcegraph version and is using the latest VSCE, they see Error occurred while loading search contexts
In testing, we tried making the query: String! field optional by removing the ! [here:](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/graphqlbackend/search_contexts.graphql?L122)
Which makes the extension work in both newer and older versions of Sourcegraph, but looked liked we needed to change [the backend code as well.](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/blob/client/search/src/backend.ts?L51)
Unfortunately that caused this other error when creating a search context:
![image](https://user-images.githubusercontent.com/68532117/154572414-67b0a5ad-8326-40c8-a03d-1c5ec066e3a9.png)


Due to what Giselle has mentioned above, we have decided not to make direct changes in the shared code base (to remove `query` from the [search backend file](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/blob/client/search/src/backend.ts?L51)) and created a separate file for the `fetchSearchContexts` function for the search box component to use so that it could support displaying search contexts for instances running from version 3.30 to 3.36:
In Version 3.31.2
![image](https://user-images.githubusercontent.com/68532117/154565473-95370776-2681-4c3b-9187-344315c2d05a.png)
in Version 3.34.2 (even though it says 3.36.3 in the image)
![image](https://user-images.githubusercontent.com/68532117/154566039-e32fd816-2e12-480b-8ec4-46855b499b58.png)

For reference, `query` does not exist in type SearchContext for older instances and hence the `Error: Cannot query field "query" on type "SearchContext".` error
![image](https://user-images.githubusercontent.com/68532117/154570818-7acd90c8-0237-4b59-b261-680878ae9c81.png)


I have also set `showSearchContextManagement` to false as we currently do not support `manage contexts` in app