### PR TITLE
codeintel: expose code intel info for `GitBlob` 

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -25,7 +25,7 @@ type CodeIntelResolver interface {
 	CommitGraph(ctx context.Context, id graphql.ID) (CodeIntelligenceCommitGraphResolver, error)
 	QueueAutoIndexJobsForRepo(ctx context.Context, args *QueueAutoIndexJobsForRepoArgs) ([]LSIFIndexResolver, error)
 	GitBlobLSIFData(ctx context.Context, args *GitBlobLSIFDataArgs) (GitBlobLSIFDataResolver, error)
-	GitBlobCodeIntelInfo(ctx context.Context, args *GitBlobCodeIntelInfoArgs) (GitBlobCodeIntelInfoResolver, error)
+	GitBlobCodeIntelInfo(ctx context.Context, args *GitBlobCodeIntelInfoArgs) (CodeIntelSupportResolver, error)
 
 	CodeIntelligenceConfigurationPolicies(ctx context.Context, args *CodeIntelligenceConfigurationPoliciesArgs) (CodeIntelligenceConfigurationPolicyConnectionResolver, error)
 	CreateCodeIntelligenceConfigurationPolicy(ctx context.Context, args *CreateCodeIntelligenceConfigurationPolicyArgs) (CodeIntelligenceConfigurationPolicyResolver, error)

--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -25,6 +25,7 @@ type CodeIntelResolver interface {
 	CommitGraph(ctx context.Context, id graphql.ID) (CodeIntelligenceCommitGraphResolver, error)
 	QueueAutoIndexJobsForRepo(ctx context.Context, args *QueueAutoIndexJobsForRepoArgs) ([]LSIFIndexResolver, error)
 	GitBlobLSIFData(ctx context.Context, args *GitBlobLSIFDataArgs) (GitBlobLSIFDataResolver, error)
+	GitBlobCodeIntelInfo(ctx context.Context, args *GitBlobCodeIntelInfoArgs) (GitBlobCodeIntelInfoResolver, error)
 
 	CodeIntelligenceConfigurationPolicies(ctx context.Context, args *CodeIntelligenceConfigurationPoliciesArgs) (CodeIntelligenceConfigurationPolicyConnectionResolver, error)
 	CreateCodeIntelligenceConfigurationPolicy(ctx context.Context, args *CreateCodeIntelligenceConfigurationPolicyArgs) (CodeIntelligenceConfigurationPolicyResolver, error)
@@ -339,4 +340,34 @@ type CodeIntelligenceConfigurationPolicyResolver interface {
 	IndexingEnabled() bool
 	IndexCommitMaxAgeHours() *int32
 	IndexIntermediateCommits() bool
+}
+
+type GitBlobCodeIntelInfoArgs struct {
+	Repo api.RepoName
+	Path string
+}
+
+type GitBlobCodeIntelInfoResolver interface {
+	Support(context.Context) CodeIntelSupportResolver
+	LSIFUploads(context.Context) (LSIFUploadConnectionResolver, error)
+}
+
+type CodeIntelSupportResolver interface {
+	SearchBasedSupport(context.Context) (SearchBasedCodeIntelSupportResolver, error)
+	PreciseSupport(context.Context) (PreciseCodeIntelSupportResolver, error)
+}
+
+type PreciseCodeIntelSupportResolver interface {
+	SupportLevel() string
+	Indexers() *[]CodeIntelIndexerResolver
+}
+
+type CodeIntelIndexerResolver interface {
+	Name() string
+	URL() string
+}
+
+type SearchBasedCodeIntelSupportResolver interface {
+	SupportLevel() string
+	Language() *string
 }

--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -141,6 +141,7 @@ type QueueAutoIndexJobsForRepoArgs struct {
 }
 
 type GitTreeLSIFDataResolver interface {
+	LSIFUploads(ctx context.Context) ([]LSIFUploadResolver, error)
 	Diagnostics(ctx context.Context, args *LSIFDiagnosticsArgs) (DiagnosticConnectionResolver, error)
 	DocumentationPage(ctx context.Context, args *LSIFDocumentationPageArgs) (DocumentationPageResolver, error)
 	DocumentationPathInfo(ctx context.Context, args *LSIFDocumentationPathInfoArgs) (JSONValue, error)

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -506,6 +506,8 @@ extend type GitBlob {
         """
         toolName: String
     ): GitBlobLSIFData
+
+    codeIntelInfo: GitBlobCodeIntelInfo!
 }
 
 """
@@ -1331,4 +1333,42 @@ type IndexConfiguration {
     The raw JSON-encoded index configuration as inferred by the auto-indexer.
     """
     inferredConfiguration: String
+}
+
+type GitBlobCodeIntelInfo {
+    support: CodeIntelSupport!
+
+    lsifUploads: LSIFUploadConnection
+}
+
+type CodeIntelSupport {
+    searchBasedSupport: SearchBasedCodeIntelSupport
+
+    preciseSupport: PreciseCodeIntelSupport!
+}
+
+type PreciseCodeIntelSupport {
+    supportLevel: PreciseSupportLevel!
+    indexers: [CodeIntelIndexer!]
+}
+
+type CodeIntelIndexer {
+    name: String!
+    url: String!
+}
+
+enum PreciseSupportLevel {
+    UNKNOWN
+    NATIVE
+    THIRD_PARTY
+}
+
+type SearchBasedCodeIntelSupport {
+    supportLevel: SearchBasedSupportLevel!
+    language: String
+}
+
+enum SearchBasedSupportLevel {
+    UNSUPPORTED
+    BASIC
 }

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -507,6 +507,9 @@ extend type GitBlob {
         toolName: String
     ): GitBlobLSIFData
 
+    """
+    Provides info on the level of code-intel support.
+    """
     codeIntelInfo: CodeIntelSupport!
 }
 

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -507,7 +507,7 @@ extend type GitBlob {
         toolName: String
     ): GitBlobLSIFData
 
-    codeIntelInfo: GitBlobCodeIntelInfo!
+    codeIntelInfo: CodeIntelSupport!
 }
 
 """
@@ -1350,38 +1350,98 @@ type IndexConfiguration {
     inferredConfiguration: String
 }
 
-type GitBlobCodeIntelInfo {
-    support: CodeIntelSupport!
-}
-
+"""
+Details the types, tools and levels of code-intel support.
+"""
 type CodeIntelSupport {
-    searchBasedSupport: SearchBasedCodeIntelSupport
+    """
+    Search-based code-intel support overview.
+    """
+    searchBasedSupport: SearchBasedCodeIntelSupport!
 
+    """
+    Precise code-intel support overview.
+    """
     preciseSupport: PreciseCodeIntelSupport!
 }
 
+"""
+Details precise code-intel support overview.
+"""
 type PreciseCodeIntelSupport {
+    """
+    Level of support/ownership for the most complete/accurate precise code-intel indexer.
+    This may be THIRD_PARTY even where a by us indexer exists, where the third-party indexer is
+    more maintained/accurate/complete etc such as with the Dart indexer, where the Workiva one
+    should be used over our own.
+    """
     supportLevel: PreciseSupportLevel!
+    """
+    List of indexers in subjective order of recommendation, from most to least recommended
+    (not an indication of absolute quality, rather relative).
+    """
     indexers: [CodeIntelIndexer!]
 }
 
+"""
+Describes a precise code-intel indexer.
+"""
 type CodeIntelIndexer {
+    """
+    Name of the precise code-intel indexer.
+    """
     name: String!
+    """
+    URL to the source of the indexer e.g. https://github.com/sourcegraph/lsif-go
+    """
     url: String!
 }
 
+"""
+Ownership level of the recommended precise code-intel indexer.
+"""
 enum PreciseSupportLevel {
+    """
+    When there is no known indexer.
+    """
     UNKNOWN
+    """
+    When the recommended indexer is maintained by us.
+    """
     NATIVE
+    """
+    When the recommended indexer is maintained by a third-party
+    but is recommended over a native indexer, where one exists.
+    """
     THIRD_PARTY
 }
 
+"""
+Details search-based code-intel support overview.
+"""
 type SearchBasedCodeIntelSupport {
+    """
+    Level of support.
+    """
     supportLevel: SearchBasedSupportLevel!
+    """
+    The inferred language the underlying tool inferred when building an index for
+    search-based code-intel.
+    """
     language: String
 }
 
+"""
+Tiered list of types of search-based support for a language. This may be expanded as different
+indexing methods are introduced.
+"""
 enum SearchBasedSupportLevel {
+    """
+    The language has no configured search-based code-intel support.
+    """
     UNSUPPORTED
+    """
+    Universal-ctags is used for indexing this language.
+    """
     BASIC
 }

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -537,6 +537,11 @@ interface TreeEntryLSIFData {
     diagnostics(first: Int): DiagnosticConnection!
 
     """
+    The list of LSIF uploads that may be used to service code-intel requests for this TreeEntry.
+    """
+    lsifUploads: [LSIFUpload!]!
+
+    """
     Returns the documentation page corresponding to the given path ID, where the empty string "/"
     refers to the current tree entry and can be used to walk all documentation below this tree entry.
 
@@ -625,6 +630,11 @@ type GitTreeLSIFData implements TreeEntryLSIFData {
     Code diagnostics provided through LSIF.
     """
     diagnostics(first: Int): DiagnosticConnection!
+
+    """
+    The list of LSIF uploads that may be used to service code-intel requests for this TreeEntry.
+    """
+    lsifUploads: [LSIFUpload!]!
 
     """
     Returns the documentation page corresponding to the given path ID, where the empty string "/"
@@ -850,6 +860,11 @@ type GitBlobLSIFData implements TreeEntryLSIFData {
     Code diagnostics provided through LSIF.
     """
     diagnostics(first: Int): DiagnosticConnection!
+
+    """
+    The list of LSIF uploads that may be used to service code-intel requests for this GitBlob.
+    """
+    lsifUploads: [LSIFUpload!]!
 
     """
     Returns the documentation page corresponding to the given path ID, where the path ID "/"
@@ -1337,8 +1352,6 @@ type IndexConfiguration {
 
 type GitBlobCodeIntelInfo {
     support: CodeIntelSupport!
-
-    lsifUploads: LSIFUploadConnection
 }
 
 type CodeIntelSupport {

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io/fs"
 	"net/url"
-	neturl "net/url"
 	"os"
 	"path"
 	"strings"
@@ -28,11 +27,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-var metricLabels = []string{"origin"}
-var codeIntelRequests = promauto.NewCounterVec(prometheus.CounterOpts{
-	Name: "src_lsif_requests",
-	Help: "Counts LSIF requests.",
-}, metricLabels)
+var (
+	metricLabels      = []string{"origin"}
+	codeIntelRequests = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "src_lsif_requests",
+		Help: "Counts LSIF requests.",
+	}, metricLabels)
+)
 
 // GitTreeEntryResolver resolves an entry in a Git tree in a repository. The entry can be any Git
 // object type that is valid in a tree.
@@ -178,7 +179,7 @@ func (r *GitTreeEntryResolver) ExternalURLs(ctx context.Context) ([]*externallin
 }
 
 func (r *GitTreeEntryResolver) RawZipArchiveURL() string {
-	return globals.ExternalURL().ResolveReference(&neturl.URL{
+	return globals.ExternalURL().ResolveReference(&url.URL{
 		Path:     path.Join(r.Repository().URL(), "-/raw/", r.Path()),
 		RawQuery: "format=zip",
 	}).String()
@@ -249,6 +250,18 @@ func (r *GitTreeEntryResolver) LSIF(ctx context.Context, args *struct{ ToolName 
 		Path:      r.Path(),
 		ExactPath: !r.stat.IsDir(),
 		ToolName:  toolName,
+	})
+}
+
+func (r *GitTreeEntryResolver) CodeIntelInfo(ctx context.Context) (GitBlobCodeIntelInfoResolver, error) {
+	repo, err := r.commit.repoResolver.repo(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return EnterpriseResolvers.codeIntelResolver.GitBlobCodeIntelInfo(ctx, &GitBlobCodeIntelInfoArgs{
+		Repo: repo.Name,
+		Path: r.Path(),
 	})
 }
 

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -253,7 +253,7 @@ func (r *GitTreeEntryResolver) LSIF(ctx context.Context, args *struct{ ToolName 
 	})
 }
 
-func (r *GitTreeEntryResolver) CodeIntelInfo(ctx context.Context) (GitBlobCodeIntelInfoResolver, error) {
+func (r *GitTreeEntryResolver) CodeIntelInfo(ctx context.Context) (CodeIntelSupportResolver, error) {
 	repo, err := r.commit.repoResolver.repo(ctx)
 	if err != nil {
 		return nil, err

--- a/cmd/symbols/internal/api/handler_test.go
+++ b/cmd/symbols/internal/api/handler_test.go
@@ -53,7 +53,7 @@ func TestHandler(t *testing.T) {
 	parser := parser.NewParser(parserPool, fetcher.NewRepositoryFetcher(gitserverClient, 15, 1000, &observation.TestContext), 0, 10, &observation.TestContext)
 	databaseWriter := writer.NewDatabaseWriter(tmpDir, gitserverClient, parser)
 	cachedDatabaseWriter := writer.NewCachedDatabaseWriter(databaseWriter, cache)
-	handler := NewHandler(cachedDatabaseWriter, &observation.TestContext)
+	handler := NewHandler(cachedDatabaseWriter, "", &observation.TestContext)
 
 	server := httptest.NewServer(handler)
 	defer server.Close()

--- a/cmd/symbols/main.go
+++ b/cmd/symbols/main.go
@@ -104,7 +104,7 @@ func main() {
 
 	parserPool, err := parser.NewParserPool(ctagsParserFactory, config.numCtagsProcesses)
 	if err != nil {
-		log.Fatalf("Failed to parser pool: %s", err)
+		log.Fatalf("Failed to create parser pool: %s", err)
 	}
 
 	gitserverClient := gitserver.NewClient(observationContext)
@@ -112,7 +112,7 @@ func main() {
 	parser := parser.NewParser(parserPool, repositoryFetcher, config.requestBufferSize, config.numCtagsProcesses, observationContext)
 	databaseWriter := writer.NewDatabaseWriter(config.cacheDir, gitserverClient, parser)
 	cachedDatabaseWriter := writer.NewCachedDatabaseWriter(databaseWriter, cache)
-	apiHandler := api.NewHandler(cachedDatabaseWriter, observationContext)
+	apiHandler := api.NewHandler(cachedDatabaseWriter, config.ctagsCommand, observationContext)
 
 	server := httpserver.NewFromAddr(addr, &http.Server{
 		ReadTimeout:  75 * time.Second,

--- a/enterprise/cmd/frontend/internal/codeintel/init.go
+++ b/enterprise/cmd/frontend/internal/codeintel/init.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/honey"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/symbols"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -57,6 +58,7 @@ func newResolver(ctx context.Context, db database.DB, config *Config, observatio
 		policyMatcher,
 		services.indexEnqueuer,
 		hunkCache,
+		symbols.DefaultClient,
 		observationContext,
 		db,
 	)

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/exists_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/exists_test.go
@@ -37,7 +37,7 @@ func TestFindClosestDumps(t *testing.T) {
 		return commit != "c4", nil
 	})
 
-	resolver := newResolver(mockDBStore, mockLSIFStore, mockGitserverClient, nil, nil, nil, &observation.TestContext, nil)
+	resolver := newResolver(mockDBStore, mockLSIFStore, mockGitserverClient, nil, nil, nil, nil, &observation.TestContext, nil)
 	dumps, err := resolver.findClosestDumps(context.Background(), commitChecker, 42, "deadbeef", "s1/main.go", true, "idx")
 	if err != nil {
 		t.Fatalf("unexpected error finding closest dumps: %s", err)
@@ -92,7 +92,7 @@ func TestFindClosestDumpsInfersClosestUploads(t *testing.T) {
 		return false, nil
 	})
 
-	resolver := newResolver(mockDBStore, mockLSIFStore, mockGitserverClient, nil, nil, nil, &observation.TestContext, nil)
+	resolver := newResolver(mockDBStore, mockLSIFStore, mockGitserverClient, nil, nil, nil, nil, &observation.TestContext, nil)
 	dumps, err := resolver.findClosestDumps(context.Background(), commitChecker, 42, "deadbeef", "s1/main.go", true, "idx")
 	if err != nil {
 		t.Fatalf("unexpected error finding closest dumps: %s", err)
@@ -131,7 +131,7 @@ func TestFindClosestDumpsDoesNotInferClosestUploadForUnknownRepository(t *testin
 	mockGitserverClient := NewMockGitserverClient()
 	commitChecker := newCachedCommitChecker(mockGitserverClient)
 
-	resolver := newResolver(mockDBStore, mockLSIFStore, mockGitserverClient, nil, nil, nil, &observation.TestContext, nil)
+	resolver := newResolver(mockDBStore, mockLSIFStore, mockGitserverClient, nil, nil, nil, nil, &observation.TestContext, nil)
 	dumps, err := resolver.findClosestDumps(context.Background(), commitChecker, 42, "deadbeef", "s1/main.go", true, "idx")
 	if err != nil {
 		t.Fatalf("unexpected error finding closest dumps: %s", err)

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/codeintel_info_resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/codeintel_info_resolver.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/go-ctags"
 
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	indexerconsts "github.com/sourcegraph/sourcegraph/internal/codeintel/indexer-consts"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/symbols"
 )
@@ -27,101 +28,6 @@ const (
 	thirdParty preciseCodeIntelSupportType = "THIRD_PARTY"
 	unknown    preciseCodeIntelSupportType = "UNKNOWN"
 )
-
-var (
-	lsifNode = codeIntelIndexerResolver{
-		name: "lsif-tsc",
-		urn:  "github.com/sourcegraph/lsif-node",
-	}
-	msftNode = codeIntelIndexerResolver{
-		name: "msft/lsif-node",
-		urn:  "github.com/Microsoft/lsif-node",
-	}
-	lsifTypescript = codeIntelIndexerResolver{
-		name: "lsif-typescript",
-		urn:  "github.com/sourcegraph/lsif-typescript",
-	}
-	lsifJava = codeIntelIndexerResolver{
-		name: "lsif-java",
-		urn:  "github.com/sourcegraph/lsif-java",
-	}
-	msftJava = codeIntelIndexerResolver{
-		name: "msft/lsif-java",
-		urn:  "github.com/Microsoft/lsif-java",
-	}
-	lsifGo = codeIntelIndexerResolver{
-		name: "lsif-go",
-		urn:  "github.com/sourcegraph/lsif-go",
-	}
-	lsifClang = codeIntelIndexerResolver{
-		name: "lsif-clang",
-		urn:  "github.com/sourcegraph/lsif-clang",
-	}
-	lsifCpp = codeIntelIndexerResolver{
-		name: "lsif-cpp",
-		urn:  "github.com/sourcegraph/lsif-cpp",
-	}
-	lsifDart = codeIntelIndexerResolver{
-		name: "lsif-dart",
-		urn:  "github.com/sourcegraph/lsif-dart",
-	}
-	workivaDart = codeIntelIndexerResolver{
-		name: "lsif_indexer",
-		urn:  "github.com/Workiva/lsif_indexer",
-	}
-	hieLsif = codeIntelIndexerResolver{
-		name: "hie-lsif",
-		urn:  "github.com/mpickering/hie-lsif",
-	}
-	lsifJsonnet = codeIntelIndexerResolver{
-		name: "lsif-jsonnet",
-		urn:  "github.com/sourcegraph/lsif-jsonnet",
-	}
-	lsifOcaml = codeIntelIndexerResolver{
-		name: "lsif-ocaml",
-		urn:  "github.com/rvantonder/lsif-ocaml",
-	}
-	lsifPy = codeIntelIndexerResolver{
-		name: "lsif-py",
-		urn:  "github.com/sourcegraph/lsif-py",
-	}
-	rustAnalyzer = codeIntelIndexerResolver{
-		name: "rust-analyzer",
-		urn:  "github.com/rust-analyzer/rust-analyzer",
-	}
-	lsifPhp = codeIntelIndexerResolver{
-		name: "lsif-php",
-		urn:  "github.com/davidrjenni/lsif-php",
-	}
-	lsifTerraform = codeIntelIndexerResolver{
-		name: "lsif-terraform",
-		urn:  "github.com/juliosueiras/lsif-terraform",
-	}
-)
-
-var languageToIndexer = map[string][]gql.CodeIntelIndexerResolver{
-	".go":      {&lsifGo},
-	".java":    {&lsifJava, &msftJava},
-	".kt":      {&lsifJava},
-	".scala":   {&lsifJava},
-	".js":      {&lsifTypescript, &lsifNode, &msftNode},
-	".jsx":     {&lsifTypescript, &lsifNode, &msftNode},
-	".ts":      {&lsifTypescript, &lsifNode, &msftNode},
-	".tsx":     {&lsifTypescript, &lsifNode, &msftNode},
-	".dart":    {&workivaDart, &lsifDart},
-	".c":       {&lsifClang, &lsifCpp},
-	".cc":      {&lsifClang, &lsifCpp},
-	".cpp":     {&lsifClang, &lsifCpp},
-	".cxx":     {&lsifClang, &lsifCpp},
-	".h":       {&lsifClang, &lsifCpp},
-	".hs":      {&hieLsif},
-	".jsonnet": {&lsifJsonnet},
-	".py":      {&lsifPy},
-	".ml":      {&lsifOcaml},
-	".rs":      {&rustAnalyzer},
-	".php":     {&lsifPhp},
-	".tf":      {&lsifTerraform},
-}
 
 type gitBlobCodeIntelInfoResolver struct {
 	gitBlobMeta *gql.GitBlobCodeIntelInfoArgs
@@ -208,7 +114,7 @@ type preciseCodeIntelSupportResolver struct {
 
 func NewPreciseCodeIntelSupportResolver(filepath string) gql.PreciseCodeIntelSupportResolver {
 	return &preciseCodeIntelSupportResolver{
-		indexers: languageToIndexer[path.Ext(filepath)],
+		indexers: indexerconsts.LanguageToIndexer[path.Ext(filepath)],
 	}
 }
 
@@ -235,16 +141,4 @@ func (r *preciseCodeIntelSupportResolver) Indexers() *[]gql.CodeIntelIndexerReso
 		return nil
 	}
 	return &r.indexers
-}
-
-type codeIntelIndexerResolver struct {
-	name, urn string
-}
-
-func (r *codeIntelIndexerResolver) Name() string {
-	return r.name
-}
-
-func (r *codeIntelIndexerResolver) URL() string {
-	return "https://" + r.urn
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/codeintel_info_resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/codeintel_info_resolver.go
@@ -119,15 +119,11 @@ func NewPreciseCodeIntelSupportResolver(filepath string) gql.PreciseCodeIntelSup
 }
 
 func (r *preciseCodeIntelSupportResolver) SupportLevel() string {
-	var hasNative bool
-	for _, indexer := range r.indexers {
-		if strings.HasPrefix(indexer.URL(), "https://github.com/sourcegraph") {
-			hasNative = true
-			break
-		}
-	}
+	// if the first indexer in a list is from us, consider native support
+	nativeRecommendation := len(r.indexers) > 0 &&
+		strings.HasPrefix(r.indexers[0].URL(), "https://github.com/sourcegraph")
 
-	if hasNative {
+	if nativeRecommendation {
 		return string(native)
 	} else if len(r.indexers) > 0 {
 		return string(thirdParty)

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/codeintel_info_resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/codeintel_info_resolver.go
@@ -1,0 +1,252 @@
+package graphql
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/gobwas/glob"
+	"github.com/sourcegraph/go-ctags"
+
+	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/symbols"
+)
+
+type searchBasedCodeIntelSupportType string
+
+const (
+	unsupported searchBasedCodeIntelSupportType = "UNSUPPORTED"
+	basic       searchBasedCodeIntelSupportType = "BASIC"
+)
+
+type preciseCodeIntelSupportType string
+
+const (
+	native     preciseCodeIntelSupportType = "NATIVE"
+	thirdParty preciseCodeIntelSupportType = "THIRD_PARTY"
+	unknown    preciseCodeIntelSupportType = "UNKNOWN"
+)
+
+var (
+	lsifNode = codeIntelIndexerResolver{
+		name: "lsif-tsc",
+		urn:  "github.com/sourcegraph/lsif-node",
+	}
+	msftNode = codeIntelIndexerResolver{
+		name: "msft/lsif-node",
+		urn:  "github.com/Microsoft/lsif-node",
+	}
+	lsifTypescript = codeIntelIndexerResolver{
+		name: "lsif-typescript",
+		urn:  "github.com/sourcegraph/lsif-typescript",
+	}
+	lsifJava = codeIntelIndexerResolver{
+		name: "lsif-java",
+		urn:  "github.com/sourcegraph/lsif-java",
+	}
+	msftJava = codeIntelIndexerResolver{
+		name: "msft/lsif-java",
+		urn:  "github.com/Microsoft/lsif-java",
+	}
+	lsifGo = codeIntelIndexerResolver{
+		name: "lsif-go",
+		urn:  "github.com/sourcegraph/lsif-go",
+	}
+	lsifClang = codeIntelIndexerResolver{
+		name: "lsif-clang",
+		urn:  "github.com/sourcegraph/lsif-clang",
+	}
+	lsifCpp = codeIntelIndexerResolver{
+		name: "lsif-cpp",
+		urn:  "github.com/sourcegraph/lsif-cpp",
+	}
+	lsifDart = codeIntelIndexerResolver{
+		name: "lsif-dart",
+		urn:  "github.com/sourcegraph/lsif-dart",
+	}
+	workivaDart = codeIntelIndexerResolver{
+		name: "lsif_indexer",
+		urn:  "github.com/Workiva/lsif_indexer",
+	}
+	hieLsif = codeIntelIndexerResolver{
+		name: "hie-lsif",
+		urn:  "github.com/mpickering/hie-lsif",
+	}
+	lsifJsonnet = codeIntelIndexerResolver{
+		name: "lsif-jsonnet",
+		urn:  "github.com/sourcegraph/lsif-jsonnet",
+	}
+	lsifOcaml = codeIntelIndexerResolver{
+		name: "lsif-ocaml",
+		urn:  "github.com/rvantonder/lsif-ocaml",
+	}
+	lsifPy = codeIntelIndexerResolver{
+		name: "lsif-py",
+		urn:  "github.com/sourcegraph/lsif-py",
+	}
+	rustAnalyzer = codeIntelIndexerResolver{
+		name: "rust-analyzer",
+		urn:  "github.com/rust-analyzer/rust-analyzer",
+	}
+	lsifPhp = codeIntelIndexerResolver{
+		name: "lsif-php",
+		urn:  "github.com/davidrjenni/lsif-php",
+	}
+	lsifTerraform = codeIntelIndexerResolver{
+		name: "lsif-terraform",
+		urn:  "github.com/juliosueiras/lsif-terraform",
+	}
+)
+
+var languageToIndexer = map[string][]gql.CodeIntelIndexerResolver{
+	".go":      {&lsifGo},
+	".java":    {&lsifJava, &msftJava},
+	".kt":      {&lsifJava},
+	".scala":   {&lsifJava},
+	".js":      {&lsifTypescript, &lsifNode, &msftNode},
+	".jsx":     {&lsifTypescript, &lsifNode, &msftNode},
+	".ts":      {&lsifTypescript, &lsifNode, &msftNode},
+	".tsx":     {&lsifTypescript, &lsifNode, &msftNode},
+	".dart":    {&workivaDart, &lsifDart},
+	".c":       {&lsifClang, &lsifCpp},
+	".cc":      {&lsifClang, &lsifCpp},
+	".cpp":     {&lsifClang, &lsifCpp},
+	".cxx":     {&lsifClang, &lsifCpp},
+	".h":       {&lsifClang, &lsifCpp},
+	".hs":      {&hieLsif},
+	".jsonnet": {&lsifJsonnet},
+	".py":      {&lsifPy},
+	".ml":      {&lsifOcaml},
+	".rs":      {&rustAnalyzer},
+	".php":     {&lsifPhp},
+	".tf":      {&lsifTerraform},
+}
+
+type gitBlobCodeIntelInfoResolver struct {
+	gitBlobMeta *gql.GitBlobCodeIntelInfoArgs
+	errTracer   *observation.ErrCollector
+}
+
+func NewGitBlobCodeIntelInfoResolver(args *gql.GitBlobCodeIntelInfoArgs, errTracer *observation.ErrCollector) gql.GitBlobCodeIntelInfoResolver {
+	return &gitBlobCodeIntelInfoResolver{
+		gitBlobMeta: args,
+		errTracer:   errTracer,
+	}
+}
+
+func (r *gitBlobCodeIntelInfoResolver) Support(ctx context.Context) gql.CodeIntelSupportResolver {
+	return NewCodeIntelSupportResolver(r.gitBlobMeta, r.errTracer)
+}
+
+func (r *gitBlobCodeIntelInfoResolver) LSIFUploads(ctx context.Context) (gql.LSIFUploadConnectionResolver, error) {
+	return nil, nil
+}
+
+type codeIntelSupportResolver struct {
+	gitBlobMeta *gql.GitBlobCodeIntelInfoArgs
+	errTracer   *observation.ErrCollector
+}
+
+func NewCodeIntelSupportResolver(args *gql.GitBlobCodeIntelInfoArgs, errTracer *observation.ErrCollector) gql.CodeIntelSupportResolver {
+	return &codeIntelSupportResolver{
+		gitBlobMeta: args,
+		errTracer:   errTracer,
+	}
+}
+
+func (r *codeIntelSupportResolver) SearchBasedSupport(ctx context.Context) (_ gql.SearchBasedCodeIntelSupportResolver, err error) {
+	defer r.errTracer.Collect(&err)
+
+	mappings, err := symbols.DefaultClient.ListLanguageMappings(ctx, r.gitBlobMeta.Repo)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, allowedLanguage := range ctags.SupportedLanguages {
+		for _, pattern := range mappings[allowedLanguage] {
+			compiled, err := glob.Compile(pattern)
+			if err != nil {
+				return nil, err
+			}
+
+			if compiled.Match(path.Base(r.gitBlobMeta.Path)) {
+				return NewSearchBasedCodeIntelResolver(&allowedLanguage), nil
+			}
+		}
+	}
+
+	return NewSearchBasedCodeIntelResolver(nil), nil
+}
+
+func (r *codeIntelSupportResolver) PreciseSupport(ctx context.Context) (gql.PreciseCodeIntelSupportResolver, error) {
+	return NewPreciseCodeIntelSupportResolver(r.gitBlobMeta.Path), nil
+}
+
+type searchBasedSupportResolver struct {
+	language *string
+}
+
+func NewSearchBasedCodeIntelResolver(language *string) gql.SearchBasedCodeIntelSupportResolver {
+	return &searchBasedSupportResolver{language}
+}
+
+func (r *searchBasedSupportResolver) SupportLevel() string {
+	if r.language != nil && *r.language != "" {
+		return string(basic)
+	}
+	return string(unsupported)
+}
+
+func (r *searchBasedSupportResolver) Language() *string {
+	return r.language
+}
+
+type preciseCodeIntelSupportResolver struct {
+	indexers []gql.CodeIntelIndexerResolver
+}
+
+func NewPreciseCodeIntelSupportResolver(filepath string) gql.PreciseCodeIntelSupportResolver {
+	fmt.Println(path.Ext(filepath))
+	return &preciseCodeIntelSupportResolver{
+		indexers: languageToIndexer[path.Ext(filepath)],
+	}
+}
+
+func (r *preciseCodeIntelSupportResolver) SupportLevel() string {
+	var hasNative bool
+	for _, indexer := range r.indexers {
+		if strings.HasPrefix(indexer.URL(), "https://github.com/sourcegraph") {
+			hasNative = true
+			break
+		}
+	}
+
+	if hasNative {
+		return string(native)
+	} else if len(r.indexers) > 0 {
+		return string(thirdParty)
+	} else {
+		return string(unknown)
+	}
+}
+
+func (r *preciseCodeIntelSupportResolver) Indexers() *[]gql.CodeIntelIndexerResolver {
+	if len(r.indexers) == 0 {
+		return nil
+	}
+	return &r.indexers
+}
+
+type codeIntelIndexerResolver struct {
+	name, urn string
+}
+
+func (r *codeIntelIndexerResolver) Name() string {
+	return r.name
+}
+
+func (r *codeIntelIndexerResolver) URL() string {
+	return "https://" + r.urn
+}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/codeintel_info_resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/codeintel_info_resolver.go
@@ -2,7 +2,6 @@ package graphql
 
 import (
 	"context"
-	"fmt"
 	"path"
 	"strings"
 
@@ -208,7 +207,6 @@ type preciseCodeIntelSupportResolver struct {
 }
 
 func NewPreciseCodeIntelSupportResolver(filepath string) gql.PreciseCodeIntelSupportResolver {
-	fmt.Println(path.Ext(filepath))
 	return &preciseCodeIntelSupportResolver{
 		indexers: languageToIndexer[path.Ext(filepath)],
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/observability.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/observability.go
@@ -18,6 +18,7 @@ type operations struct {
 	commitGraph               *observation.Operation
 	queueAutoIndexJobsForRepo *observation.Operation
 	gitBlobLsifData           *observation.Operation
+	gitBlobCodeIntelInfo      *observation.Operation
 	configurationPolicyByID   *observation.Operation
 	configurationPolicies     *observation.Operation
 	createConfigurationPolicy *observation.Operation
@@ -54,6 +55,7 @@ func newOperations(observationContext *observation.Context) *operations {
 		commitGraph:               op("CommitGraph"),
 		queueAutoIndexJobsForRepo: op("QueueAutoIndexJobsForRepo"),
 		gitBlobLsifData:           op("GitBlobLSIFData"),
+		gitBlobCodeIntelInfo:      op("GitBlobCodeIntelInfo"),
 		configurationPolicyByID:   op("ConfigurationPolicyByID"),
 		configurationPolicies:     op("ConfigurationPolicies"),
 		createConfigurationPolicy: op("CreateConfigurationPolicy"),

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query_documentation.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query_documentation.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (r *QueryResolver) DocumentationPage(ctx context.Context, args *gql.LSIFDocumentationPageArgs) (gql.DocumentationPageResolver, error) {
-	page, err := r.resolver.DocumentationPage(ctx, args.PathID)
+	page, err := r.queryResolver.DocumentationPage(ctx, args.PathID)
 	if err != nil {
 		return nil, err
 	}
@@ -34,7 +34,7 @@ func (r *DocumentationPageResolver) Tree() gql.JSONValue {
 }
 
 func (r *QueryResolver) DocumentationPathInfo(ctx context.Context, args *gql.LSIFDocumentationPathInfoArgs) (gql.JSONValue, error) {
-	var maxDepth = 1
+	maxDepth := 1
 	if args.MaxDepth != nil {
 		maxDepth = int(*args.MaxDepth)
 		if maxDepth < 0 {
@@ -48,7 +48,7 @@ func (r *QueryResolver) DocumentationPathInfo(ctx context.Context, args *gql.LSI
 
 	var get func(pathID string, depth int) (*DocumentationPathInfoResult, error)
 	get = func(pathID string, depth int) (*DocumentationPathInfoResult, error) {
-		pathInfo, err := r.resolver.DocumentationPathInfo(ctx, pathID)
+		pathInfo, err := r.queryResolver.DocumentationPathInfo(ctx, pathID)
 		if err != nil {
 			return nil, err
 		}
@@ -107,7 +107,7 @@ type DocumentationPathInfoResult struct {
 }
 
 func (r *QueryResolver) DocumentationDefinitions(ctx context.Context, args *gql.LSIFQueryDocumentationArgs) (gql.LocationConnectionResolver, error) {
-	locations, err := r.resolver.DocumentationDefinitions(ctx, args.PathID)
+	locations, err := r.queryResolver.DocumentationDefinitions(ctx, args.PathID)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +125,7 @@ func (r *QueryResolver) DocumentationReferences(ctx context.Context, args *gql.L
 		return nil, err
 	}
 
-	locations, cursor, err := r.resolver.DocumentationReferences(ctx, args.PathID, limit, cursor)
+	locations, cursor, err := r.queryResolver.DocumentationReferences(ctx, args.PathID, limit, cursor)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query_test.go
@@ -223,7 +223,7 @@ func TestDiagnosticsDefaultIllegalLimit(t *testing.T) {
 
 	mockQueryResolver := resolvermocks.NewMockQueryResolver()
 	mockResolver := resolvermocks.NewMockResolver()
-	resolver := NewQueryResolver(mockQueryResolver, mockResolver, NewCachedLocationResolver(db), nil)
+	resolver := NewQueryResolver(mockQueryResolver, mockResolver, NewCachedLocationResolver(db), observation.NewErrorCollector())
 
 	offset := int32(-1)
 	args := &gql.LSIFDiagnosticsArgs{

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query_test.go
@@ -10,27 +10,27 @@ import (
 	resolvermocks "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 func TestRanges(t *testing.T) {
 	db := database.NewDB(nil)
 
-	mockResolver := resolvermocks.NewMockQueryResolver()
-	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), nil)
+	mockQueryResolver := resolvermocks.NewMockQueryResolver()
+	mockResolver := resolvermocks.NewMockResolver()
+	resolver := NewQueryResolver(mockQueryResolver, mockResolver, NewCachedLocationResolver(db), nil)
 
 	args := &gql.LSIFRangesArgs{StartLine: 10, EndLine: 20}
 	if _, err := resolver.Ranges(context.Background(), args); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if len(mockResolver.RangesFunc.History()) != 1 {
-		t.Fatalf("unexpected call count. want=%d have=%d", 1, len(mockResolver.RangesFunc.History()))
+	if len(mockQueryResolver.RangesFunc.History()) != 1 {
+		t.Fatalf("unexpected call count. want=%d have=%d", 1, len(mockQueryResolver.RangesFunc.History()))
 	}
-	if val := mockResolver.RangesFunc.History()[0].Arg1; val != 10 {
+	if val := mockQueryResolver.RangesFunc.History()[0].Arg1; val != 10 {
 		t.Fatalf("unexpected start line. want=%d have=%d", 10, val)
 	}
-	if val := mockResolver.RangesFunc.History()[0].Arg2; val != 20 {
+	if val := mockQueryResolver.RangesFunc.History()[0].Arg2; val != 20 {
 		t.Fatalf("unexpected end line. want=%d have=%d", 20, val)
 	}
 }
@@ -38,21 +38,22 @@ func TestRanges(t *testing.T) {
 func TestDefinitions(t *testing.T) {
 	db := database.NewDB(nil)
 
-	mockResolver := resolvermocks.NewMockQueryResolver()
-	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), nil)
+	mockQueryResolver := resolvermocks.NewMockQueryResolver()
+	mockResolver := resolvermocks.NewMockResolver()
+	resolver := NewQueryResolver(mockQueryResolver, mockResolver, NewCachedLocationResolver(db), nil)
 
 	args := &gql.LSIFQueryPositionArgs{Line: 10, Character: 15}
 	if _, err := resolver.Definitions(context.Background(), args); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if len(mockResolver.DefinitionsFunc.History()) != 1 {
-		t.Fatalf("unexpected call count. want=%d have=%d", 1, len(mockResolver.DefinitionsFunc.History()))
+	if len(mockQueryResolver.DefinitionsFunc.History()) != 1 {
+		t.Fatalf("unexpected call count. want=%d have=%d", 1, len(mockQueryResolver.DefinitionsFunc.History()))
 	}
-	if val := mockResolver.DefinitionsFunc.History()[0].Arg1; val != 10 {
+	if val := mockQueryResolver.DefinitionsFunc.History()[0].Arg1; val != 10 {
 		t.Fatalf("unexpected line. want=%d have=%d", 10, val)
 	}
-	if val := mockResolver.DefinitionsFunc.History()[0].Arg2; val != 15 {
+	if val := mockQueryResolver.DefinitionsFunc.History()[0].Arg2; val != 15 {
 		t.Fatalf("unexpected character. want=%d have=%d", 15, val)
 	}
 }
@@ -60,8 +61,9 @@ func TestDefinitions(t *testing.T) {
 func TestReferences(t *testing.T) {
 	db := database.NewDB(nil)
 
-	mockResolver := resolvermocks.NewMockQueryResolver()
-	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), nil)
+	mockQueryResolver := resolvermocks.NewMockQueryResolver()
+	mockResolver := resolvermocks.NewMockResolver()
+	resolver := NewQueryResolver(mockQueryResolver, mockResolver, NewCachedLocationResolver(db), nil)
 
 	offset := int32(25)
 	cursor := base64.StdEncoding.EncodeToString([]byte("test-cursor"))
@@ -79,19 +81,19 @@ func TestReferences(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if len(mockResolver.ReferencesFunc.History()) != 1 {
-		t.Fatalf("unexpected call count. want=%d have=%d", 1, len(mockResolver.ReferencesFunc.History()))
+	if len(mockQueryResolver.ReferencesFunc.History()) != 1 {
+		t.Fatalf("unexpected call count. want=%d have=%d", 1, len(mockQueryResolver.ReferencesFunc.History()))
 	}
-	if val := mockResolver.ReferencesFunc.History()[0].Arg1; val != 10 {
+	if val := mockQueryResolver.ReferencesFunc.History()[0].Arg1; val != 10 {
 		t.Fatalf("unexpected line. want=%d have=%d", 10, val)
 	}
-	if val := mockResolver.ReferencesFunc.History()[0].Arg2; val != 15 {
+	if val := mockQueryResolver.ReferencesFunc.History()[0].Arg2; val != 15 {
 		t.Fatalf("unexpected character. want=%d have=%d", 15, val)
 	}
-	if val := mockResolver.ReferencesFunc.History()[0].Arg3; val != 25 {
+	if val := mockQueryResolver.ReferencesFunc.History()[0].Arg3; val != 25 {
 		t.Fatalf("unexpected character. want=%d have=%d", 25, val)
 	}
-	if val := mockResolver.ReferencesFunc.History()[0].Arg4; val != "test-cursor" {
+	if val := mockQueryResolver.ReferencesFunc.History()[0].Arg4; val != "test-cursor" {
 		t.Fatalf("unexpected character. want=%s have=%s", "test-cursor", val)
 	}
 }
@@ -99,8 +101,9 @@ func TestReferences(t *testing.T) {
 func TestReferencesDefaultLimit(t *testing.T) {
 	db := database.NewDB(nil)
 
-	mockResolver := resolvermocks.NewMockQueryResolver()
-	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), nil)
+	mockQueryResolver := resolvermocks.NewMockQueryResolver()
+	mockResolver := resolvermocks.NewMockResolver()
+	resolver := NewQueryResolver(mockQueryResolver, mockResolver, NewCachedLocationResolver(db), nil)
 
 	args := &gql.LSIFPagedQueryPositionArgs{
 		LSIFQueryPositionArgs: gql.LSIFQueryPositionArgs{
@@ -114,10 +117,10 @@ func TestReferencesDefaultLimit(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if len(mockResolver.ReferencesFunc.History()) != 1 {
-		t.Fatalf("unexpected call count. want=%d have=%d", 1, len(mockResolver.DiagnosticsFunc.History()))
+	if len(mockQueryResolver.ReferencesFunc.History()) != 1 {
+		t.Fatalf("unexpected call count. want=%d have=%d", 1, len(mockQueryResolver.DiagnosticsFunc.History()))
 	}
-	if val := mockResolver.ReferencesFunc.History()[0].Arg3; val != DefaultReferencesPageSize {
+	if val := mockQueryResolver.ReferencesFunc.History()[0].Arg3; val != DefaultReferencesPageSize {
 		t.Fatalf("unexpected limit. want=%d have=%d", DefaultReferencesPageSize, val)
 	}
 }
@@ -125,8 +128,9 @@ func TestReferencesDefaultLimit(t *testing.T) {
 func TestReferencesDefaultIllegalLimit(t *testing.T) {
 	db := database.NewDB(nil)
 
-	mockResolver := resolvermocks.NewMockQueryResolver()
-	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), observation.NewErrorCollector())
+	mockQueryResolver := resolvermocks.NewMockQueryResolver()
+	mockResolver := resolvermocks.NewMockResolver()
+	resolver := NewQueryResolver(mockQueryResolver, mockResolver, NewCachedLocationResolver(db), nil)
 
 	offset := int32(-1)
 	args := &gql.LSIFPagedQueryPositionArgs{
@@ -145,22 +149,23 @@ func TestReferencesDefaultIllegalLimit(t *testing.T) {
 func TestHover(t *testing.T) {
 	db := database.NewDB(nil)
 
-	mockResolver := resolvermocks.NewMockQueryResolver()
-	mockResolver.HoverFunc.SetDefaultReturn("text", lsifstore.Range{}, true, nil)
-	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), nil)
+	mockQueryResolver := resolvermocks.NewMockQueryResolver()
+	mockQueryResolver.HoverFunc.SetDefaultReturn("text", lsifstore.Range{}, true, nil)
+	mockResolver := resolvermocks.NewMockResolver()
+	resolver := NewQueryResolver(mockQueryResolver, mockResolver, NewCachedLocationResolver(db), nil)
 
 	args := &gql.LSIFQueryPositionArgs{Line: 10, Character: 15}
 	if _, err := resolver.Hover(context.Background(), args); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if len(mockResolver.HoverFunc.History()) != 1 {
-		t.Fatalf("unexpected call count. want=%d have=%d", 1, len(mockResolver.HoverFunc.History()))
+	if len(mockQueryResolver.HoverFunc.History()) != 1 {
+		t.Fatalf("unexpected call count. want=%d have=%d", 1, len(mockQueryResolver.HoverFunc.History()))
 	}
-	if val := mockResolver.HoverFunc.History()[0].Arg1; val != 10 {
+	if val := mockQueryResolver.HoverFunc.History()[0].Arg1; val != 10 {
 		t.Fatalf("unexpected line. want=%d have=%d", 10, val)
 	}
-	if val := mockResolver.HoverFunc.History()[0].Arg2; val != 15 {
+	if val := mockQueryResolver.HoverFunc.History()[0].Arg2; val != 15 {
 		t.Fatalf("unexpected character. want=%d have=%d", 15, val)
 	}
 }
@@ -168,8 +173,9 @@ func TestHover(t *testing.T) {
 func TestDiagnostics(t *testing.T) {
 	db := database.NewDB(nil)
 
-	mockResolver := resolvermocks.NewMockQueryResolver()
-	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), nil)
+	mockQueryResolver := resolvermocks.NewMockQueryResolver()
+	mockResolver := resolvermocks.NewMockResolver()
+	resolver := NewQueryResolver(mockQueryResolver, mockResolver, NewCachedLocationResolver(db), nil)
 
 	offset := int32(25)
 	args := &gql.LSIFDiagnosticsArgs{
@@ -180,10 +186,10 @@ func TestDiagnostics(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if len(mockResolver.DiagnosticsFunc.History()) != 1 {
-		t.Fatalf("unexpected call count. want=%d have=%d", 1, len(mockResolver.DiagnosticsFunc.History()))
+	if len(mockQueryResolver.DiagnosticsFunc.History()) != 1 {
+		t.Fatalf("unexpected call count. want=%d have=%d", 1, len(mockQueryResolver.DiagnosticsFunc.History()))
 	}
-	if val := mockResolver.DiagnosticsFunc.History()[0].Arg1; val != 25 {
+	if val := mockQueryResolver.DiagnosticsFunc.History()[0].Arg1; val != 25 {
 		t.Fatalf("unexpected limit. want=%d have=%d", 25, val)
 	}
 }
@@ -191,8 +197,9 @@ func TestDiagnostics(t *testing.T) {
 func TestDiagnosticsDefaultLimit(t *testing.T) {
 	db := database.NewDB(nil)
 
-	mockResolver := resolvermocks.NewMockQueryResolver()
-	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), nil)
+	mockQueryResolver := resolvermocks.NewMockQueryResolver()
+	mockResolver := resolvermocks.NewMockResolver()
+	resolver := NewQueryResolver(mockQueryResolver, mockResolver, NewCachedLocationResolver(db), nil)
 
 	args := &gql.LSIFDiagnosticsArgs{
 		ConnectionArgs: graphqlutil.ConnectionArgs{},
@@ -202,10 +209,10 @@ func TestDiagnosticsDefaultLimit(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if len(mockResolver.DiagnosticsFunc.History()) != 1 {
-		t.Fatalf("unexpected call count. want=%d have=%d", 1, len(mockResolver.DiagnosticsFunc.History()))
+	if len(mockQueryResolver.DiagnosticsFunc.History()) != 1 {
+		t.Fatalf("unexpected call count. want=%d have=%d", 1, len(mockQueryResolver.DiagnosticsFunc.History()))
 	}
-	if val := mockResolver.DiagnosticsFunc.History()[0].Arg1; val != DefaultDiagnosticsPageSize {
+	if val := mockQueryResolver.DiagnosticsFunc.History()[0].Arg1; val != DefaultDiagnosticsPageSize {
 		t.Fatalf("unexpected limit. want=%d have=%d", DefaultDiagnosticsPageSize, val)
 	}
 }
@@ -213,8 +220,9 @@ func TestDiagnosticsDefaultLimit(t *testing.T) {
 func TestDiagnosticsDefaultIllegalLimit(t *testing.T) {
 	db := database.NewDB(nil)
 
-	mockResolver := resolvermocks.NewMockQueryResolver()
-	resolver := NewQueryResolver(mockResolver, NewCachedLocationResolver(db), observation.NewErrorCollector())
+	mockQueryResolver := resolvermocks.NewMockQueryResolver()
+	mockResolver := resolvermocks.NewMockResolver()
+	resolver := NewQueryResolver(mockQueryResolver, mockResolver, NewCachedLocationResolver(db), nil)
 
 	offset := int32(-1)
 	args := &gql.LSIFDiagnosticsArgs{

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query_test.go
@@ -10,6 +10,7 @@ import (
 	resolvermocks "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 func TestRanges(t *testing.T) {
@@ -130,7 +131,7 @@ func TestReferencesDefaultIllegalLimit(t *testing.T) {
 
 	mockQueryResolver := resolvermocks.NewMockQueryResolver()
 	mockResolver := resolvermocks.NewMockResolver()
-	resolver := NewQueryResolver(mockQueryResolver, mockResolver, NewCachedLocationResolver(db), nil)
+	resolver := NewQueryResolver(mockQueryResolver, mockResolver, NewCachedLocationResolver(db), observation.NewErrorCollector())
 
 	offset := int32(-1)
 	args := &gql.LSIFPagedQueryPositionArgs{

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
@@ -310,6 +310,10 @@ func (r *Resolver) GitBlobLSIFData(ctx context.Context, args *gql.GitBlobLSIFDat
 	return NewQueryResolver(resolver, r.locationResolver, errTracer), nil
 }
 
+func (r *Resolver) GitBlobCodeIntelInfo(ctx context.Context, args *gql.GitBlobCodeIntelInfoArgs) (_ gql.GitBlobCodeIntelInfoResolver, err error) {
+	return NewGitBlobCodeIntelInfoResolver(args, nil), nil
+}
+
 // 🚨 SECURITY: dbstore layer handles authz for GetConfigurationPolicyByID
 func (r *Resolver) ConfigurationPolicyByID(ctx context.Context, id graphql.ID) (_ gql.CodeIntelligenceConfigurationPolicyResolver, err error) {
 	ctx, traceErrs, endObservation := r.observationContext.configurationPolicyByID.WithErrors(ctx, &err, observation.Args{LogFields: []log.Field{

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
@@ -307,7 +307,7 @@ func (r *Resolver) GitBlobLSIFData(ctx context.Context, args *gql.GitBlobLSIFDat
 		return nil, err
 	}
 
-	return NewQueryResolver(resolver, r.locationResolver, errTracer), nil
+	return NewQueryResolver(resolver, r.resolver, r.locationResolver, errTracer), nil
 }
 
 func (r *Resolver) GitBlobCodeIntelInfo(ctx context.Context, args *gql.GitBlobCodeIntelInfoArgs) (_ gql.GitBlobCodeIntelInfoResolver, err error) {

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
@@ -310,8 +310,11 @@ func (r *Resolver) GitBlobLSIFData(ctx context.Context, args *gql.GitBlobLSIFDat
 	return NewQueryResolver(resolver, r.resolver, r.locationResolver, errTracer), nil
 }
 
-func (r *Resolver) GitBlobCodeIntelInfo(ctx context.Context, args *gql.GitBlobCodeIntelInfoArgs) (_ gql.GitBlobCodeIntelInfoResolver, err error) {
-	return NewGitBlobCodeIntelInfoResolver(args, nil), nil
+func (r *Resolver) GitBlobCodeIntelInfo(ctx context.Context, args *gql.GitBlobCodeIntelInfoArgs) (_ gql.CodeIntelSupportResolver, err error) {
+	ctx, errTracer, endObservation := r.observationContext.gitBlobCodeIntelInfo.WithErrors(ctx, &err, observation.Args{})
+	endObservation.OnCancel(ctx, 1, observation.Args{})
+
+	return NewCodeIntelSupportResolver(r.resolver, args, errTracer), nil
 }
 
 // 🚨 SECURITY: dbstore layer handles authz for GetConfigurationPolicyByID

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/upload_connection.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/upload_connection.go
@@ -31,7 +31,9 @@ func NewUploadConnectionResolver(db database.DB, resolver resolvers.Resolver, up
 	}
 }
 
-func (r *UploadConnectionResolver) Nodes(ctx context.Context) ([]gql.LSIFUploadResolver, error) {
+func (r *UploadConnectionResolver) Nodes(ctx context.Context) (_ []gql.LSIFUploadResolver, err error) {
+	defer r.errTracer.Collect(&err, log.String("uploadConnectionResolver.field", "nodes"))
+
 	if err := r.uploadsResolver.Resolve(ctx); err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query.go
@@ -51,6 +51,7 @@ func (a *AdjustedCodeIntelligenceRange) ToDocumentation() *Documentation {
 // specifics (auth, validation, marshaling, etc.). This resolver is wrapped by a symmetrics resolver
 // in this package's graphql subpackage, which is exposed directly by the API.
 type QueryResolver interface {
+	LSIFUploads(ctx context.Context) ([]store.Upload, error)
 	Stencil(ctx context.Context) ([]lsifstore.Range, error)
 	Ranges(ctx context.Context, startLine, endLine int) ([]AdjustedCodeIntelligenceRange, error)
 	Definitions(ctx context.Context, line, character int) ([]AdjustedLocation, error)

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_uploads.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_uploads.go
@@ -1,0 +1,21 @@
+package resolvers
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
+)
+
+// LSIFUploads returns the list of dbstore.Uploads for the store.Dumps determined to be applicable
+// for answering code-intel queries.
+func (r *queryResolver) LSIFUploads(ctx context.Context) (uploads []dbstore.Upload, err error) {
+	return r.dbStore.GetUploadsByIDs(ctx, r.closestDumpIDs()...)
+}
+
+func (r *queryResolver) closestDumpIDs() []int {
+	ids := make([]int, 0, len(r.uploads))
+	for _, dump := range r.uploads {
+		ids = append(ids, dump.ID)
+	}
+	return ids
+}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver_test.go
@@ -15,7 +15,7 @@ func TestQueryResolver(t *testing.T) {
 	mockLSIFStore := NewMockLSIFStore()
 	mockGitserverClient := NewMockGitserverClient()
 
-	resolver := NewResolver(mockDBStore, mockLSIFStore, mockGitserverClient, nil, nil, nil, &observation.TestContext, nil)
+	resolver := NewResolver(mockDBStore, mockLSIFStore, mockGitserverClient, nil, nil, nil, nil, &observation.TestContext, nil)
 	queryResolver, err := resolver.QueryResolver(context.Background(), &gql.GitBlobLSIFDataArgs{
 		Repo:      &types.Repo{ID: 50},
 		Commit:    api.CommitID("deadbeef"),

--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 	github.com/slack-go/slack v0.10.1
 	github.com/snabb/sitemap v1.0.0
 	github.com/sourcegraph/ctxvfs v0.0.0-20180418081416-2b65f1b1ea81
-	github.com/sourcegraph/go-ctags v0.0.0-20220210084826-96f4236f0a78
+	github.com/sourcegraph/go-ctags v0.0.0-20220221141751-78951a22ec08
 	github.com/sourcegraph/go-diff v0.6.1
 	github.com/sourcegraph/go-jsonschema v0.0.0-20211011105148-2e30f7bacbe1
 	github.com/sourcegraph/go-langserver v2.0.1-0.20181108233942-4a51fa2e1238+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1994,6 +1994,8 @@ github.com/sourcegraph/ctxvfs v0.0.0-20180418081416-2b65f1b1ea81 h1:v4/JVxZSPWif
 github.com/sourcegraph/ctxvfs v0.0.0-20180418081416-2b65f1b1ea81/go.mod h1:xIvvI5FiHLxhv8prbzVpaMHaaGPFPFQSuTcxC91ryOo=
 github.com/sourcegraph/go-ctags v0.0.0-20220210084826-96f4236f0a78 h1:DY/m+6+PnBz49fMU7rE+DfPf09QYgO1RLPDeJ/1BY9w=
 github.com/sourcegraph/go-ctags v0.0.0-20220210084826-96f4236f0a78/go.mod h1:ZYjpRXoJrRlxjU9ZfpaUKJkk62AjhJPffN3rlw2aqxM=
+github.com/sourcegraph/go-ctags v0.0.0-20220221141751-78951a22ec08 h1:cuI0tTyrf6sS2TXh2OJHEKLfpDM7K4V360X9bU+3l0k=
+github.com/sourcegraph/go-ctags v0.0.0-20220221141751-78951a22ec08/go.mod h1:ZYjpRXoJrRlxjU9ZfpaUKJkk62AjhJPffN3rlw2aqxM=
 github.com/sourcegraph/go-diff v0.5.1/go.mod h1:j2dHj3m8aZgQO8lMTcTnBcXkRRRqi34cd2MNlA9u1mE=
 github.com/sourcegraph/go-diff v0.5.3/go.mod h1:v9JDtjCE4HHHCZGId75rg8gkKKa98RVjBcBGsVmMmak=
 github.com/sourcegraph/go-diff v0.6.1 h1:hmA1LzxW0n1c3Q4YbrFgg4P99GSnebYa3x8gr0HZqLQ=

--- a/internal/codeintel/indexer-consts/lsifindexers.go
+++ b/internal/codeintel/indexer-consts/lsifindexers.go
@@ -1,0 +1,117 @@
+package indexerconsts
+
+import gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+
+type codeIntelIndexerResolver struct {
+	name, urn string
+}
+
+func (r *codeIntelIndexerResolver) Name() string {
+	return r.name
+}
+
+func (r *codeIntelIndexerResolver) URL() string {
+	return "https://" + r.urn
+}
+
+var (
+	LSIFNode = codeIntelIndexerResolver{
+		name: "lsif-tsc",
+		urn:  "github.com/sourcegraph/lsif-node",
+	}
+	MSFTNode = codeIntelIndexerResolver{
+		name: "msft/lsif-node",
+		urn:  "github.com/Microsoft/lsif-node",
+	}
+	LSIFTypescript = codeIntelIndexerResolver{
+		name: "lsif-typescript",
+		urn:  "github.com/sourcegraph/lsif-typescript",
+	}
+	LSIFJava = codeIntelIndexerResolver{
+		name: "lsif-java",
+		urn:  "github.com/sourcegraph/lsif-java",
+	}
+	MSFTJava = codeIntelIndexerResolver{
+		name: "msft/lsif-java",
+		urn:  "github.com/Microsoft/lsif-java",
+	}
+	LSIFGo = codeIntelIndexerResolver{
+		name: "lsif-go",
+		urn:  "github.com/sourcegraph/lsif-go",
+	}
+	LSIFClang = codeIntelIndexerResolver{
+		name: "lsif-clang",
+		urn:  "github.com/sourcegraph/lsif-clang",
+	}
+	LSIFCpp = codeIntelIndexerResolver{
+		name: "lsif-cpp",
+		urn:  "github.com/sourcegraph/lsif-cpp",
+	}
+	LSIFDart = codeIntelIndexerResolver{
+		name: "lsif-dart",
+		urn:  "github.com/sourcegraph/lsif-dart",
+	}
+	WorkivaDart = codeIntelIndexerResolver{
+		name: "lsif_indexer",
+		urn:  "github.com/Workiva/lsif_indexer",
+	}
+	HieLSIF = codeIntelIndexerResolver{
+		name: "hie-lsif",
+		urn:  "github.com/mpickering/hie-lsif",
+	}
+	LSIFJsonnet = codeIntelIndexerResolver{
+		name: "lsif-jsonnet",
+		urn:  "github.com/sourcegraph/lsif-jsonnet",
+	}
+	LSIFOcaml = codeIntelIndexerResolver{
+		name: "lsif-ocaml",
+		urn:  "github.com/rvantonder/lsif-ocaml",
+	}
+	LSIFPy = codeIntelIndexerResolver{
+		name: "lsif-py",
+		urn:  "github.com/sourcegraph/lsif-py",
+	}
+	RustAnalyzer = codeIntelIndexerResolver{
+		name: "rust-analyzer",
+		urn:  "github.com/rust-analyzer/rust-analyzer",
+	}
+	LSIFPhp = codeIntelIndexerResolver{
+		name: "lsif-php",
+		urn:  "github.com/davidrjenni/lsif-php",
+	}
+	LSIFTerraform = codeIntelIndexerResolver{
+		name: "lsif-terraform",
+		urn:  "github.com/juliosueiras/lsif-terraform",
+	}
+	LSIFDotnet = codeIntelIndexerResolver{
+		name: "lsif-dotnet",
+		urn:  "github.com/tcz717/LsifDotnet",
+	}
+)
+
+// A map of file extension to a list of indexers in order of recommendation
+// from most to least.
+var LanguageToIndexer = map[string][]gql.CodeIntelIndexerResolver{
+	".go":      {&LSIFGo},
+	".java":    {&LSIFJava, &MSFTJava},
+	".kt":      {&LSIFJava},
+	".scala":   {&LSIFJava},
+	".js":      {&LSIFTypescript, &LSIFNode, &MSFTNode},
+	".jsx":     {&LSIFTypescript, &LSIFNode, &MSFTNode},
+	".ts":      {&LSIFTypescript, &LSIFNode, &MSFTNode},
+	".tsx":     {&LSIFTypescript, &LSIFNode, &MSFTNode},
+	".dart":    {&WorkivaDart, &LSIFDart},
+	".c":       {&LSIFClang, &LSIFCpp},
+	".cc":      {&LSIFClang, &LSIFCpp},
+	".cpp":     {&LSIFClang, &LSIFCpp},
+	".cxx":     {&LSIFClang, &LSIFCpp},
+	".h":       {&LSIFClang, &LSIFCpp},
+	".hs":      {&HieLSIF},
+	".jsonnet": {&LSIFJsonnet},
+	".py":      {&LSIFPy},
+	".ml":      {&LSIFOcaml},
+	".rs":      {&RustAnalyzer},
+	".php":     {&LSIFPhp},
+	".tf":      {&LSIFTerraform},
+	".cs":      {&LSIFDotnet},
+}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/31073
Reliant on https://github.com/sourcegraph/go-ctags/pull/7

## Test plan

Tested by hand in the API console. The brunt of the work is done in symbols service/go-ctags, and we dont have a great way of testing symbols service interfacing yet, sot his has been mostly manually tested

