### PR TITLE
Search backend: Remove SearchResults type

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -43,10 +43,6 @@ func (a searchAlertResolver) ProposedQueries() *[]*searchQueryDescription {
 	return &proposedQueries
 }
 
-func alertToSearchResults(alert *search.Alert) *SearchResults {
-	return &SearchResults{Alert: alert}
-}
-
 func (a searchAlertResolver) wrapSearchImplementer(db database.DB) *alertSearchImplementer {
 	return &alertSearchImplementer{
 		db:    db,
@@ -62,7 +58,7 @@ type alertSearchImplementer struct {
 }
 
 func (a alertSearchImplementer) Results(context.Context) (*SearchResultsResolver, error) {
-	return &SearchResultsResolver{db: a.db, SearchResults: alertToSearchResults(a.alert.alert)}, nil
+	return &SearchResultsResolver{db: a.db, SearchAlert: a.alert.alert}, nil
 }
 
 func (alertSearchImplementer) Stats(context.Context) (dummySearchResultsStats, error) {

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -330,7 +330,7 @@ func TestSearchResolver_DynamicFilters(t *testing.T) {
 		t.Run(test.descr, func(t *testing.T) {
 			for _, globbing := range []bool{true, false} {
 				mockDecodedViewerFinalSettings.SearchGlobbing = &globbing
-				actualDynamicFilters := (&SearchResultsResolver{db: database.NewMockDB(), SearchResults: &SearchResults{Matches: test.searchResults}}).DynamicFilters(context.Background())
+				actualDynamicFilters := (&SearchResultsResolver{db: database.NewMockDB(), Matches: test.searchResults}).DynamicFilters(context.Background())
 				actualDynamicFilterStrs := make(map[string]int)
 
 				for _, filter := range actualDynamicFilters {
@@ -539,12 +539,10 @@ func TestSearchResultsResolver_ApproximateResultCount(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sr := &SearchResultsResolver{
-				db: database.NewMockDB(),
-				SearchResults: &SearchResults{
-					Stats:   tt.fields.searchResultsCommon,
-					Matches: tt.fields.results,
-					Alert:   tt.fields.alert,
-				},
+				db:          database.NewMockDB(),
+				Stats:       tt.fields.searchResultsCommon,
+				Matches:     tt.fields.results,
+				SearchAlert: tt.fields.alert,
 			}
 			if got := sr.ApproximateResultCount(); got != tt.want {
 				t.Errorf("searchResultsResolver.ApproximateResultCount() = %v, want %v", got, tt.want)
@@ -691,7 +689,7 @@ func TestEvaluateAnd(t *testing.T) {
 				t.Fatal("Results:", err)
 			}
 			if tt.wantAlert {
-				if results.SearchResults.Alert == nil {
+				if results.SearchAlert == nil {
 					t.Errorf("Expected alert")
 				}
 			} else if int(results.MatchCount()) != len(zoektFileMatches) {

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -247,7 +247,7 @@ LOOP:
 	_ = eventWriter.Event("progress", progress.Final())
 
 	var status, alertType string
-	status = graphqlbackend.DetermineStatusForLogs(resultsResolver.SearchResults.Alert, resultsResolver.SearchResults.Stats, err)
+	status = graphqlbackend.DetermineStatusForLogs(resultsResolver.SearchAlert, resultsResolver.Stats, err)
 	if alert != nil {
 		alertType = alert.PrometheusType()
 	}

--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -231,8 +231,7 @@ func (h *mockSearchResolver) Results(ctx context.Context) (*graphqlbackend.Searc
 		return nil, ctx.Err()
 	case <-h.done:
 		return &graphqlbackend.SearchResultsResolver{
-			UserSettings:  &schema.Settings{},
-			SearchResults: &graphqlbackend.SearchResults{},
+			UserSettings: &schema.Settings{},
 		}, nil
 	}
 }


### PR DESCRIPTION
With an almost-fully-streaming backend, this type is barely used, and
just ties up the shape of the return values. This inlines the type into
SearchResultsResolver and removes other uses of it so that we can split
streaming search off of the resolver types.

## Test plan

Semantics-preserving. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


