### PR TITLE
VSCE v2.1.0: Add VS Code Web Support and custom headers

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
       "args": [
         "--extensionDevelopmentPath=${workspaceRoot}/client/vscode",
         "--disable-extension=kandalatj.sourcegraph-preview",
-        "--disable-extension=sourcegraph.sourcegraph"
+        "--disable-extension=sourcegraph.sourcegraph",
       ],
       "stopOnEntry": false,
       "sourceMaps": true,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,6 +15,7 @@
       "args": [
         "--extensionDevelopmentPath=${workspaceRoot}/client/vscode",
         "--disable-extension=kandalatj.sourcegraph-preview",
+        "--disable-extension=sourcegraph.sourcegraph"
       ],
       "stopOnEntry": false,
       "sourceMaps": true,
@@ -28,6 +29,7 @@
       "args": [
         "--extensionDevelopmentPath=${workspaceRoot}/client/vscode",
         "--disable-extension=kandalatj.sourcegraph-preview",
+        "--disable-extension=sourcegraph.sourcegraph",
         "--extensionDevelopmentKind=web",
         "--disable-web-security",
       ],

--- a/client/vscode/CHANGELOG.md
+++ b/client/vscode/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Changes
 
 - Add web support for VS Code Web [issues/28403](https://github.com/sourcegraph/sourcegraph/issues/28403)
+- Use API endpoint for stream search [issues/30916](https://github.com/sourcegraph/sourcegraph/issues/30916)
+- Add configuration settings for custom headers [issues/30916](https://github.com/sourcegraph/sourcegraph/issues/30916)
 
 ## Next Release - 2.0.9
 

--- a/client/vscode/CHANGELOG.md
+++ b/client/vscode/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## Next Release
+## Pre-release - 2.1.0
+
+### Changes
+
+- Add web support for VS Code Web [issues/28403](https://github.com/sourcegraph/sourcegraph/issues/28403)
+
+## Next Release - 2.0.9
 
 ### Changes
 

--- a/client/vscode/README.md
+++ b/client/vscode/README.md
@@ -58,6 +58,7 @@ In addition to searching open source code, you can create a Sourcegraph Cloud ac
 4. Click `Manage repositories`. From here, you can add your repositories to be synced to Sourcegraph.
 
 ### Connecting Sourcegraph Cloud account
+
 Once you have repositories synced to Sourcegraph, you can generate an access token to connect your VS Code extension back to your Sourcegraph Cloud account.
 
 1. Back in Sourcegraph Cloud, in your account settings, navigate to `Access tokens`, then click `Generate new token`.
@@ -66,12 +67,12 @@ Once you have repositories synced to Sourcegraph, you can generate an access tok
 4. Alternatively, you can copy and paste the generated token from step 4 in this format: `“sourcegraph.accessToken": "e4234234123112312”` into your VS Code Setting by going to `Code` > `Preference` > `Settings` > Search for "Sourcegraph" > `Edit in settings.json`.
 5. The Editor will be reloaded automatically to use the newly added token.
 
-### Connecting to a private Sourcegraph instance 
-1.  In Sourcegraph, in your account settings, navigate to `Access tokens`, then click `Generate new token`.
-2. Once you have generated a token, navigate to your VS Code Settings, then navigate to "Extension settings".
-3. Navigate to `Code preferences`, then click `Settings`.
-4. Search for `Sourcegraph`, and enter the newly generated access token as well as your Sourcegraph instance URL. 
+### Connecting to a private Sourcegraph instance
 
+1.  In Sourcegraph, in your account settings, navigate to `Access tokens`, then click `Generate new token`.
+2.  Once you have generated a token, navigate to your VS Code Settings, then navigate to "Extension settings".
+3.  Navigate to `Code preferences`, then click `Settings`.
+4.  Search for `Sourcegraph`, and enter the newly generated access token as well as your Sourcegraph instance URL.
 
 ## Keyboard Shortcuts:
 

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "sourcegraph",
   "displayName": "Sourcegraph",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "description": "Sourcegraph for VS Code",
   "publisher": "sourcegraph",
   "sideEffects": false,
@@ -10,10 +10,14 @@
   "icon": "images/logo.png",
   "repository": {
     "type": "git",
-    "url": "https://github.com/sourcegraph/sourcegraph.git"
+    "url": "https://github.com/sourcegraph/sourcegraph.git",
+    "directory": "client/vscode"
+  },
+  "bugs": {
+    "url": "https://github.com/sourcegraph/sourcegraph-vscode/issues"
   },
   "engines": {
-    "vscode": "^1.61.0"
+    "vscode": "^1.63.2"
   },
   "categories": [
     "Other"
@@ -31,6 +35,7 @@
     "onWebviewPanel:sourcegraphSearch"
   ],
   "main": "./dist/node/extension.js",
+  "browser": "./dist/webworker/extension.js",
   "contributes": {
     "commands": [
       {
@@ -195,5 +200,9 @@
     "build:web": "TARGET_TYPE=webworker yarn task:gulp webpack",
     "watch:node": "NODE_ENV=development TARGET_TYPE=node yarn task:gulp watchWebpack",
     "watch:web": "NODE_ENV=development TARGET_TYPE=webworker yarn task:gulp watchWebpack"
+  },
+  "dependencies": {
+    "https-browserify": "^1.0.0",
+    "stream-http": "^3.2.0"
   }
 }

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -126,6 +126,7 @@
             "object"
           ],
           "default": {},
+          "examples": [{"github": "gitlab", "master": "main"}],
           "description": "For each item in this object, replace key with value in the remote url."
         },
         "sourcegraph.defaultBranch": {
@@ -133,7 +134,15 @@
             "string"
           ],
           "default": "",
-          "description": "Always open local files on Sourcegraph web at this default branch."
+          "description": "Always open local files on Sourcegraph Web at this default branch."
+        },
+        "sourcegraph.requestHeaders": {
+          "type": [
+            "object"
+          ],
+          "default": {},
+          "examples": [{"Cache-Control": "no-cache", "Access-Control-Allow-Origin": "*"}],
+          "description": "Each value pair will be added to the request headers made to your instance."
         }
       }
     },

--- a/client/vscode/src/backend/requestGraphQl.ts
+++ b/client/vscode/src/backend/requestGraphQl.ts
@@ -2,7 +2,7 @@ import { asError } from '@sourcegraph/common'
 import { checkOk, GraphQLResult, GRAPHQL_URI, isHTTPAuthError } from '@sourcegraph/http-client'
 
 import { accessTokenSetting, handleAccessTokenError } from '../settings/accessTokenSetting'
-import { endpointSetting } from '../settings/endpointSetting'
+import { endpointSetting, endpointRequestHeadersSetting } from '../settings/endpointSetting'
 
 let invalidated = false
 
@@ -26,8 +26,9 @@ export const requestGraphQLFromVSCode = async <R, V = object>(
 
     const nameMatch = request.match(/^\s*(?:query|mutation)\s+(\w+)/)
     const apiURL = `${GRAPHQL_URI}${nameMatch ? '?' + nameMatch[1] : ''}`
-
-    const headers: HeadersInit = []
+    const customHeaders = endpointRequestHeadersSetting()
+    // return empty array if no custom header is provided
+    const headers: HeadersInit = Object.entries(customHeaders)
     const sourcegraphURL = endpointSetting()
     const accessToken = accessTokenSetting()
 

--- a/client/vscode/src/extension.ts
+++ b/client/vscode/src/extension.ts
@@ -87,8 +87,8 @@ export function activate(context: vscode.ExtensionContext): void {
     const sidebarQueryStates = new ReplaySubject<VSCEQueryState>(1)
 
     const { fs } = initializeSourcegraphFileSystem({ context, initialInstanceURL })
-
-    const streamSearch = createStreamSearch({ context, stateMachine, sourcegraphURL: initialInstanceURL })
+    // Use api endpoint for stream search
+    const streamSearch = createStreamSearch({ context, stateMachine, sourcegraphURL: `${initialInstanceURL}/.api` })
 
     const extensionCoreAPI: ExtensionCoreAPI = {
         panelInitialized: panelId => initializedPanelIDs.next(panelId),

--- a/client/vscode/src/polyfills/eventSource.js
+++ b/client/vscode/src/polyfills/eventSource.js
@@ -107,8 +107,8 @@ function EventSource(url, eventSourceInitDict) {
     const options = parse(url)
     let isSecure = options.protocol === 'https:'
     options.headers = {
-      'Cache-Control': 'no-cache',
-      Accept: 'text/event-stream',
+      // 'Cache-Control': 'no-cache',
+      // Accept: 'text/event-stream',
       ...fixedHeaders,
     }
     if (lastEventId) {

--- a/client/vscode/src/polyfills/eventSource.js
+++ b/client/vscode/src/polyfills/eventSource.js
@@ -107,8 +107,6 @@ function EventSource(url, eventSourceInitDict) {
     const options = parse(url)
     let isSecure = options.protocol === 'https:'
     options.headers = {
-      // 'Cache-Control': 'no-cache',
-      // Accept: 'text/event-stream',
       ...fixedHeaders,
     }
     if (lastEventId) {

--- a/client/vscode/src/settings/endpointSetting.ts
+++ b/client/vscode/src/settings/endpointSetting.ts
@@ -25,3 +25,7 @@ export function endpointAccessTokenSetting(): boolean {
     }
     return false
 }
+
+export function endpointRequestHeadersSetting(): object {
+    return readConfiguration().get<object>('requestHeaders') || {}
+}

--- a/client/vscode/src/webview/initialize.ts
+++ b/client/vscode/src/webview/initialize.ts
@@ -138,9 +138,11 @@ export function initializeSearchSidebarWebview({
                 src: url(${codiconFontSource.toString()})
             }
         </style>
-        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src vscode-resource: vscode-webview: data: https:; script-src blob: vscode-webview: https:; style-src 'unsafe-inline' vscode-resource: ${
+        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; child-src data: ${
             webviewView.webview.cspSource
-        } http: https: data:; connect-src 'self' http: https:; font-src vscode-resource: vscode-webview: https:;">
+        }; img-src data: https:; script-src blob: https:; style-src 'unsafe-inline' ${
+        webviewView.webview.cspSource
+    } http: https: data:; connect-src 'self' http: https:; font-src vscode-resource: vscode-webview: https:;">
         <title>Sourcegraph Search</title>
         <link rel="stylesheet" href="${styleSource.toString()}" />
         <link rel="stylesheet" href="${cssModuleSource.toString()}" />

--- a/client/vscode/src/webview/initialize.ts
+++ b/client/vscode/src/webview/initialize.ts
@@ -72,7 +72,9 @@ export async function initializeSearchPanelWebview({
                 src: url(${codiconFontSource.toString()})
             }
         </style>
-        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src data: vscode-resource: vscode-webview: https:; script-src 'nonce-${nonce}' vscode-webview:; style-src data: ${
+        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; child-src data: ${
+            panel.webview.cspSource
+        }; img-src data: vscode-resource: vscode-webview: https:; script-src 'nonce-${nonce}' vscode-webview:; style-src data: ${
         panel.webview.cspSource
     } vscode-resource: vscode-webview: 'unsafe-inline' http: https: data:; connect-src 'self' vscode-webview: http: https:; frame-src https:; font-src ${
         panel.webview.cspSource

--- a/client/vscode/webpack.config.js
+++ b/client/vscode/webpack.config.js
@@ -2,7 +2,7 @@
 
 'use strict'
 const path = require('path')
-
+const webpack = require('webpack')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 
 const {
@@ -63,6 +63,8 @@ function getExtensionCoreConfiguration(targetType) {
               path: require.resolve('path-browserify'),
               assert: require.resolve('assert'),
               util: require.resolve('util'),
+              http: require.resolve('stream-http'),
+              https: require.resolve('https-browserify'),
             }
           : {},
     },
@@ -80,6 +82,12 @@ function getExtensionCoreConfiguration(targetType) {
         },
       ],
     },
+    plugins: [
+      new webpack.ProvidePlugin({
+        Buffer: ['buffer', 'Buffer'],
+        process: 'process/browser', // provide a shim for the global `process` variable
+      }),
+    ],
   }
 }
 
@@ -112,7 +120,14 @@ const webviewConfig = {
     path: path.resolve(__dirname, 'dist/webview'),
     filename: '[name].js',
   },
-  plugins: [new MiniCssExtractPlugin(), getMonacoWebpackPlugin()],
+  plugins: [
+    new MiniCssExtractPlugin(),
+    getMonacoWebpackPlugin(),
+    new webpack.ProvidePlugin({
+      Buffer: ['buffer', 'Buffer'],
+      process: 'process/browser', // provide a shim for the global `process` variable
+    }),
+  ],
   externals: {
     // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
     vscode: 'commonjs vscode',
@@ -127,6 +142,8 @@ const webviewConfig = {
     fallback: {
       path: require.resolve('path-browserify'),
       process: require.resolve('process/browser'),
+      http: require.resolve('stream-http'), // for stream search - event source polyfills
+      https: require.resolve('https-browserify'), // for stream search - event source polyfills
     },
   },
   module: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7654,6 +7654,11 @@ buffer@^5.2.1, buffer@^5.5.0, buffer@^5.7.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
+builtin-status-codes@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
+  integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
+
 bundlesize2@^0.0.31:
   version "0.0.31"
   resolved "https://registry.npmjs.org/bundlesize2/-/bundlesize2-0.0.31.tgz#cef6830dbbe5360e27fce07593ec0f4e3e5355d9"
@@ -13769,6 +13774,11 @@ http2-wrapper@^1.0.0-beta.5.0:
   dependencies:
     quick-lru "^5.1.1"
     resolve-alpn "^1.0.0"
+
+https-browserify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
+  integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
 https-proxy-agent@5.0.0, https-proxy-agent@^5.0.0:
   version "5.0.0"
@@ -21699,6 +21709,16 @@ stream-exhaust@^1.0.1:
   resolved "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz#acdac8da59ef2bc1e17a2c0ccf6c320d120e555d"
   integrity sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==
 
+stream-http@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/stream-http/-/stream-http-3.2.0.tgz#1872dfcf24cb15752677e40e5c3f9cc1926028b5"
+  integrity sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==
+  dependencies:
+    builtin-status-codes "^3.0.0"
+    inherits "^2.0.4"
+    readable-stream "^3.6.0"
+    xtend "^4.0.2"
+
 stream-parser@~0.3.1:
   version "0.3.1"
   resolved "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz#1618548694420021a1182ff0af1911c129761773"
@@ -24398,7 +24418,7 @@ xmlhttprequest-ssl@~1.5.4:
   resolved "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz#c2876b06168aadc40e57d97e81191ac8f4398b3e"
   integrity sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=
 
-xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0, xtend@~4.0.1:
+xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==


### PR DESCRIPTION
This PR adds support for VS Code Web (https://github.com/sourcegraph/sourcegraph/issues/28403), and allows users to add custom headers to their requests to resolve proxy issues (https://github.com/sourcegraph/sourcegraph/issues/30916). 

We will also replace the regular endpoint with the stream search api endpoint for the extension to run on Web.
I've also added examples for the configuration settings in our package.json for clarity. 