### PR TITLE
Search backend: stop passing stream through GraphQL args

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -43,7 +43,7 @@ func (a searchAlertResolver) ProposedQueries() *[]*searchQueryDescription {
 	return &proposedQueries
 }
 
-func (a searchAlertResolver) wrapSearchImplementer(db database.DB) *alertSearchImplementer {
+func (a searchAlertResolver) WrapSearchImplementer(db database.DB) *alertSearchImplementer {
 	return &alertSearchImplementer{
 		db:    db,
 		alert: a,

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -43,10 +43,6 @@ func (a searchAlertResolver) ProposedQueries() *[]*searchQueryDescription {
 	return &proposedQueries
 }
 
-func alertToSearchResults(alert *search.Alert) *SearchResults {
-	return &SearchResults{Alert: alert}
-}
-
 func (a searchAlertResolver) wrapSearchImplementer(db database.DB) *alertSearchImplementer {
 	return &alertSearchImplementer{
 		db:    db,
@@ -62,7 +58,7 @@ type alertSearchImplementer struct {
 }
 
 func (a alertSearchImplementer) Results(context.Context) (*SearchResultsResolver, error) {
-	return &SearchResultsResolver{db: a.db, SearchResults: alertToSearchResults(a.alert.alert)}, nil
+	return &SearchResultsResolver{db: a.db, SearchAlert: a.alert.alert}, nil
 }
 
 func (alertSearchImplementer) Stats(context.Context) (dummySearchResultsStats, error) {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -424,7 +424,7 @@ func (r *searchResolver) resultsToResolver(matches result.Matches, alert *search
 func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, error) {
 	start := time.Now()
 	agg := streaming.NewAggregatingStream()
-	alert, err := r.results(ctx, agg, r.SearchInputs.Plan)
+	alert, err := r.StreamResults(ctx, agg)
 	srr := r.resultsToResolver(agg.Results, alert, agg.Stats)
 	srr.elapsed = time.Since(start)
 	r.logBatch(ctx, srr, err)

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -330,7 +330,7 @@ func TestSearchResolver_DynamicFilters(t *testing.T) {
 		t.Run(test.descr, func(t *testing.T) {
 			for _, globbing := range []bool{true, false} {
 				mockDecodedViewerFinalSettings.SearchGlobbing = &globbing
-				actualDynamicFilters := (&SearchResultsResolver{db: database.NewMockDB(), SearchResults: &SearchResults{Matches: test.searchResults}}).DynamicFilters(context.Background())
+				actualDynamicFilters := (&SearchResultsResolver{db: database.NewMockDB(), Matches: test.searchResults}).DynamicFilters(context.Background())
 				actualDynamicFilterStrs := make(map[string]int)
 
 				for _, filter := range actualDynamicFilters {
@@ -539,12 +539,10 @@ func TestSearchResultsResolver_ApproximateResultCount(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sr := &SearchResultsResolver{
-				db: database.NewMockDB(),
-				SearchResults: &SearchResults{
-					Stats:   tt.fields.searchResultsCommon,
-					Matches: tt.fields.results,
-					Alert:   tt.fields.alert,
-				},
+				db:          database.NewMockDB(),
+				Stats:       tt.fields.searchResultsCommon,
+				Matches:     tt.fields.results,
+				SearchAlert: tt.fields.alert,
 			}
 			if got := sr.ApproximateResultCount(); got != tt.want {
 				t.Errorf("searchResultsResolver.ApproximateResultCount() = %v, want %v", got, tt.want)
@@ -691,7 +689,7 @@ func TestEvaluateAnd(t *testing.T) {
 				t.Fatal("Results:", err)
 			}
 			if tt.wantAlert {
-				if results.SearchResults.Alert == nil {
+				if results.SearchAlert == nil {
 					t.Errorf("Expected alert")
 				}
 			} else if int(results.MatchCount()) != len(zoektFileMatches) {

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -247,7 +247,7 @@ LOOP:
 	_ = eventWriter.Event("progress", progress.Final())
 
 	var status, alertType string
-	status = graphqlbackend.DetermineStatusForLogs(resultsResolver.SearchResults.Alert, resultsResolver.SearchResults.Stats, err)
+	status = graphqlbackend.DetermineStatusForLogs(resultsResolver.SearchAlert, resultsResolver.Stats, err)
 	if alert != nil {
 		alertType = alert.PrometheusType()
 	}

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -389,13 +389,6 @@ func strPtr(s string) *string {
 	return &s
 }
 
-func fromStrPtr(s *string) string {
-	if s == nil {
-		return ""
-	}
-	return *s
-}
-
 // withDecoration hydrates event match with decorated hunks for a corresponding file match.
 func withDecoration(ctx context.Context, eventMatch streamhttp.EventMatch, internalResult result.Match, kind string, contextLines int) streamhttp.EventMatch {
 	if _, ok := internalResult.(*result.FileMatch); !ok {

--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -143,7 +143,6 @@ func TestDisplayLimit(t *testing.T) {
 				flushTickerInternal: 1 * time.Millisecond,
 				pingTickerInterval:  1 * time.Millisecond,
 				newSearchResolver: func(_ context.Context, _ database.DB, args *graphqlbackend.SearchArgs) (searchResolver, *search.Alert, error) {
-					mock.c = args.Stream
 					q, err := query.Parse(c.queryString, query.Literal)
 					if err != nil {
 						t.Fatal(err)
@@ -226,14 +225,13 @@ type mockSearchResolver struct {
 	inputs *run.SearchInputs
 }
 
-func (h *mockSearchResolver) Results(ctx context.Context) (*graphqlbackend.SearchResultsResolver, error) {
+func (h *mockSearchResolver) StreamResults(ctx context.Context, stream streaming.Sender) (*search.Alert, error) {
+	h.c = stream
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	case <-h.done:
-		return &graphqlbackend.SearchResultsResolver{
-			UserSettings: &schema.Settings{},
-		}, nil
+		return nil, nil
 	}
 }
 

--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -231,8 +231,7 @@ func (h *mockSearchResolver) Results(ctx context.Context) (*graphqlbackend.Searc
 		return nil, ctx.Err()
 	case <-h.done:
 		return &graphqlbackend.SearchResultsResolver{
-			UserSettings:  &schema.Settings{},
-			SearchResults: &graphqlbackend.SearchResults{},
+			UserSettings: &schema.Settings{},
 		}, nil
 	}
 }

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors/background"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -387,7 +388,7 @@ func (r *Resolver) TriggerTestSlackWebhookAction(ctx context.Context, args *grap
 
 func (r *Resolver) CodeMonitorSearch(ctx context.Context, args *graphqlbackend.SearchArgs) (graphqlbackend.SearchImplementer, error) {
 	args.Version = "V2"
-	sr, alert, err := graphqlbackend.NewSearchImplementer(ctx, r.db, args)
+	sr, alert, err := graphqlbackend.NewSearchImplementer(ctx, r.db, search.Batch, args)
 	if err != nil {
 		return nil, err
 	} else if alert != nil {

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -387,7 +387,13 @@ func (r *Resolver) TriggerTestSlackWebhookAction(ctx context.Context, args *grap
 
 func (r *Resolver) CodeMonitorSearch(ctx context.Context, args *graphqlbackend.SearchArgs) (graphqlbackend.SearchImplementer, error) {
 	args.Version = "V2"
-	return graphqlbackend.NewSearchImplementer(ctx, r.db, args)
+	sr, alert, err := graphqlbackend.NewSearchImplementer(ctx, r.db, args)
+	if err != nil {
+		return nil, err
+	} else if alert != nil {
+		return graphqlbackend.NewSearchAlertResolver(alert).WrapSearchImplementer(r.db), nil
+	}
+	return sr, nil
 }
 
 func sendTestEmail(ctx context.Context, recipient graphql.ID, description string) error {

--- a/enterprise/cmd/frontend/internal/compute/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/compute/resolvers/resolvers.go
@@ -10,6 +10,7 @@ import (
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/compute"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -231,7 +232,7 @@ func NewComputeImplementer(ctx context.Context, db database.DB, args *gql.Comput
 	log15.Debug("compute", "search", searchQuery)
 
 	patternType := "regexp"
-	job, _, err := gql.NewSearchImplementer(ctx, db, &gql.SearchArgs{Query: searchQuery, PatternType: &patternType})
+	job, _, err := gql.NewSearchImplementer(ctx, db, search.Batch, &gql.SearchArgs{Query: searchQuery, PatternType: &patternType})
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/compute/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/compute/resolvers/resolvers.go
@@ -231,7 +231,7 @@ func NewComputeImplementer(ctx context.Context, db database.DB, args *gql.Comput
 	log15.Debug("compute", "search", searchQuery)
 
 	patternType := "regexp"
-	job, err := gql.NewSearchImplementer(ctx, db, &gql.SearchArgs{Query: searchQuery, PatternType: &patternType})
+	job, _, err := gql.NewSearchImplementer(ctx, db, &gql.SearchArgs{Query: searchQuery, PatternType: &patternType})
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/compute/streaming/compute.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/compute.go
@@ -49,7 +49,7 @@ func NewComputeStream(ctx context.Context, db database.DB, query string) (<-chan
 		PatternType: &patternType,
 		Stream:      stream,
 	}
-	job, err := graphqlbackend.NewSearchImplementer(ctx, db, searchArgs)
+	job, _, err := graphqlbackend.NewSearchImplementer(ctx, db, searchArgs)
 	if err != nil {
 		close(eventsC)
 		return eventsC, func() error { return err }


### PR DESCRIPTION
This is a fairly big step towards cleanly separating streaming code from graphql resolvers. 
It's also a fairly big PR that I tried many times to split up, but failed, so bear with me 🧸 

Walkthrough comments inline.

## Test plan

Covered by integration tests, and some manual testing as well. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


