### PR TITLE
set internal actor for historical enqueuer

### DIFF
--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+
 	"github.com/grafana/regexp"
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go/log"
@@ -261,6 +263,11 @@ type historicalEnqueuer struct {
 }
 
 func (h *historicalEnqueuer) Handler(ctx context.Context) error {
+	// 🚨 SECURITY: This background process uses the internal actor to interact with Sourcegraph services. This background process
+	// is responsible for calculating the work needed to backfill an insight series _without_ a user context. Repository permissions
+	// are filtered at view time of an insight.
+	ctx = actor.WithInternalActor(ctx)
+
 	h.statistics = make(statistics)
 	// Discover all insights on the instance.
 	log15.Debug("Fetching data series for historical")


### PR DESCRIPTION
The internal actor is supposed to be set for this background process that analyzes historical repositories for insights. Recently the sub-repo work that merged in and deployed this week (and got flag enabled) on dogfood brought to light that this was not set appropriately.

## Test plan

Before
<img width="774" alt="CleanShot 2022-02-17 at 17 49 09@2x" src="https://user-images.githubusercontent.com/5090588/154596394-e5811c1f-8f7a-439d-b863-5387482cf637.png">

After

<img width="775" alt="CleanShot 2022-02-17 at 17 49 18@2x" src="https://user-images.githubusercontent.com/5090588/154596401-e5dee690-31a1-4209-a591-29f65580e5bc.png">


