### PR TITLE
Revert "remove all backend code for stats"

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1839,7 +1839,9 @@ type Search {
     """
     results: SearchResults!
     """
-    DEPRECATED: removed in favor of compute
+    A subset of results (excluding actual search results) which are heavily
+    cached and thus quicker to query. Useful for e.g. querying sparkline
+    data.
     """
     stats: SearchResultsStats!
 }
@@ -1944,7 +1946,7 @@ type SearchResults {
     """
     limitHit: Boolean!
     """
-    DEPRECATED: removed in favor of compute. Will always return an empty result.
+    Integers representing the sparkline for the search results.
     """
     sparkline: [Int!]!
     """

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -50,7 +50,7 @@ type SearchArgs struct {
 type SearchImplementer interface {
 	Results(context.Context) (*SearchResultsResolver, error)
 	//lint:ignore U1000 is used by graphql via reflection
-	Stats(context.Context) (dummySearchResultsStats, error)
+	Stats(context.Context) (*searchResultsStats, error)
 
 	Inputs() run.SearchInputs
 }

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -65,9 +65,7 @@ func (a alertSearchImplementer) Results(context.Context) (*SearchResultsResolver
 	return &SearchResultsResolver{db: a.db, SearchResults: alertToSearchResults(a.alert.alert)}, nil
 }
 
-func (alertSearchImplementer) Stats(context.Context) (dummySearchResultsStats, error) {
-	return nil, nil
-}
+func (alertSearchImplementer) Stats(context.Context) (*searchResultsStats, error) { return nil, nil }
 func (alertSearchImplementer) Inputs() run.SearchInputs {
 	return run.SearchInputs{}
 }

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -1,0 +1,195 @@
+package graphqlbackend
+
+import (
+	"context"
+	"io/fs"
+	"sync"
+
+	"github.com/neelance/parallel"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/internal/inventory"
+	"github.com/sourcegraph/sourcegraph/internal/search/job"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func (srs *searchResultsStats) Languages(ctx context.Context) ([]*languageStatisticsResolver, error) {
+	matches, err := srs.getResults(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	langs, err := searchResultsStatsLanguages(ctx, srs.sr.db, matches)
+	if err != nil {
+		return nil, err
+	}
+
+	wrapped := make([]*languageStatisticsResolver, len(langs))
+	for i, lang := range langs {
+		wrapped[i] = &languageStatisticsResolver{lang}
+	}
+	return wrapped, nil
+}
+
+func (srs *searchResultsStats) getResults(ctx context.Context) (result.Matches, error) {
+	args := srs.sr.JobArgs()
+	srs.once.Do(func() {
+		j, err := job.ToSearchJob(args, srs.sr.SearchInputs.Query)
+		if err != nil {
+			srs.err = err
+			return
+		}
+		agg := streaming.NewAggregatingStream()
+		_, err = j.Run(ctx, srs.sr.db, agg)
+		if err != nil {
+			srs.err = err
+			return
+		}
+		srs.results = agg.Results
+	})
+	return srs.results, srs.err
+}
+
+func searchResultsStatsLanguages(ctx context.Context, db database.DB, matches []result.Match) ([]inventory.Lang, error) {
+	// Batch our operations by repo-commit.
+	type repoCommit struct {
+		repo     api.RepoID
+		commitID api.CommitID
+	}
+
+	// Records the work necessary for a batch (repoCommit).
+	type fileStatsWork struct {
+		fullEntries  []fs.FileInfo     // matched these full files
+		partialFiles map[string]uint64 // file with line matches (path) -> count of lines matching
+	}
+
+	var (
+		repos    = map[api.RepoID]types.MinimalRepo{}
+		filesMap = map[repoCommit]*fileStatsWork{}
+
+		run = parallel.NewRun(16)
+
+		allInventories   []inventory.Inventory
+		allInventoriesMu sync.Mutex
+	)
+
+	// Track the mapping of repo ID -> repo object as we iterate.
+	sawRepo := func(repo types.MinimalRepo) {
+		if _, ok := repos[repo.ID]; !ok {
+			repos[repo.ID] = repo
+		}
+	}
+
+	// Only count repo matches if all matches are repo matches. Otherwise, it would get confusing
+	// because we might have a match of a repo *and* a file in the repo. We would need to avoid
+	// double-counting. In this case, we will just count the matching files.
+	hasNonRepoMatches := false
+	for _, match := range matches {
+		if _, ok := match.(*result.RepoMatch); !ok {
+			hasNonRepoMatches = true
+		}
+	}
+
+	for _, res := range matches {
+		if fileMatch, ok := res.(*result.FileMatch); ok {
+			sawRepo(fileMatch.Repo)
+			key := repoCommit{repo: fileMatch.Repo.ID, commitID: fileMatch.CommitID}
+
+			if _, ok := filesMap[key]; !ok {
+				filesMap[key] = &fileStatsWork{}
+			}
+
+			if len(fileMatch.LineMatches) > 0 {
+				// Only count matching lines. TODO(sqs): bytes are not counted for these files
+				if filesMap[key].partialFiles == nil {
+					filesMap[key].partialFiles = map[string]uint64{}
+				}
+				filesMap[key].partialFiles[fileMatch.Path] += uint64(len(fileMatch.LineMatches))
+			} else {
+				// Count entire file.
+				filesMap[key].fullEntries = append(filesMap[key].fullEntries, &fileInfo{
+					path:  fileMatch.Path,
+					isDir: false,
+				})
+			}
+		} else if repoMatch, ok := res.(*result.RepoMatch); ok && !hasNonRepoMatches {
+			sawRepo(repoMatch.RepoName())
+			run.Acquire()
+			goroutine.Go(func() {
+				defer run.Release()
+
+				repoName := repoMatch.RepoName()
+				_, oid, err := git.GetDefaultBranch(ctx, repoName.Name)
+				if err != nil {
+					run.Error(err)
+					return
+				}
+				inv, err := backend.NewRepos(db.Repos()).GetInventory(ctx, repoName.ToRepo(), oid, true)
+				if err != nil {
+					run.Error(err)
+					return
+				}
+				allInventoriesMu.Lock()
+				allInventories = append(allInventories, *inv)
+				allInventoriesMu.Unlock()
+			})
+		} else if _, ok := res.(*result.CommitMatch); ok {
+			return nil, errors.New("language statistics do not support diff searches")
+		}
+	}
+
+	for key_, work_ := range filesMap {
+		key := key_
+		work := work_
+		run.Acquire()
+		goroutine.Go(func() {
+			defer run.Release()
+
+			invCtx, err := backend.InventoryContext(repos[key.repo].Name, key.commitID, true)
+			if err != nil {
+				run.Error(err)
+				return
+			}
+
+			// Inventory all full-entry (files and trees) matches together.
+			inv, err := invCtx.Entries(ctx, work.fullEntries...)
+			if err != nil {
+				run.Error(err)
+				return
+			}
+			allInventoriesMu.Lock()
+			allInventories = append(allInventories, inv)
+			allInventoriesMu.Unlock()
+
+			// Separately inventory each partial-file match because we only increment the language lines
+			// by the number of matched lines in the file.
+			for partialFile, lines := range work.partialFiles {
+				inv, err := invCtx.Entries(ctx,
+					fileInfo{path: partialFile, isDir: false},
+				)
+				if err != nil {
+					run.Error(err)
+					return
+				}
+				for i := range inv.Languages {
+					inv.Languages[i].TotalLines = lines
+				}
+				allInventoriesMu.Lock()
+				allInventories = append(allInventories, inv)
+				allInventoriesMu.Unlock()
+			}
+		})
+	}
+
+	if err := run.Wait(); err != nil {
+		return nil, err
+	}
+	return inventory.Sum(allInventories).Languages, nil
+}

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
@@ -1,0 +1,128 @@
+package graphqlbackend
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"io/fs"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
+	"github.com/sourcegraph/sourcegraph/internal/inventory"
+	"github.com/sourcegraph/sourcegraph/internal/rcache"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+)
+
+func TestSearchResultsStatsLanguages(t *testing.T) {
+	wantCommitID := api.CommitID(strings.Repeat("a", 40))
+	rcache.SetupForTest(t)
+
+	git.Mocks.NewFileReader = func(commit api.CommitID, name string) (io.ReadCloser, error) {
+		if commit != wantCommitID {
+			t.Errorf("got commit %q, want %q", commit, wantCommitID)
+		}
+		var data []byte
+		switch name {
+		case "two.go":
+			data = []byte("a\nb\n")
+		case "three.go":
+			data = []byte("a\nb\nc\n")
+		default:
+			panic("unhandled mock NewFileReader " + name)
+		}
+		return io.NopCloser(bytes.NewReader(data)), nil
+	}
+	const wantDefaultBranchRef = "refs/heads/foo"
+	git.Mocks.ExecSafe = func(params []string) (stdout, stderr []byte, exitCode int, err error) {
+		// Mock default branch lookup in (*RepositoryResolver).DefaultBranch.
+		return []byte(wantDefaultBranchRef), nil, 0, nil
+	}
+	git.Mocks.ResolveRevision = func(spec string, opt git.ResolveRevisionOptions) (api.CommitID, error) {
+		if want := "HEAD"; spec != want {
+			t.Errorf("got spec %q, want %q", spec, want)
+		}
+		return wantCommitID, nil
+	}
+	defer git.ResetMocks()
+
+	gitserver.ClientMocks.GetObject = func(repo api.RepoName, objectName string) (*gitdomain.GitObject, error) {
+		oid := gitdomain.OID{} // empty is OK for this test
+		copy(oid[:], bytes.Repeat([]byte{0xaa}, 40))
+		return &gitdomain.GitObject{
+			ID:   oid,
+			Type: gitdomain.ObjectTypeTree,
+		}, nil
+	}
+	defer gitserver.ResetClientMocks()
+
+	mkResult := func(path string, lineNumbers ...int32) *result.FileMatch {
+		rn := types.MinimalRepo{
+			Name: "r",
+		}
+		fm := mkFileMatch(rn, path, lineNumbers...)
+		fm.CommitID = wantCommitID
+		return fm
+	}
+
+	tests := map[string]struct {
+		results  []result.Match
+		getFiles []fs.FileInfo
+		want     []inventory.Lang // TotalBytes values are incorrect (known issue doc'd in GraphQL schema)
+	}{
+		"empty": {
+			results: nil,
+			want:    []inventory.Lang{},
+		},
+		"1 entire file": {
+			results: []result.Match{
+				mkResult("three.go"),
+			},
+			want: []inventory.Lang{{Name: "Go", TotalBytes: 6, TotalLines: 3}},
+		},
+		"line matches in 1 file": {
+			results: []result.Match{
+				mkResult("three.go", 1),
+			},
+			want: []inventory.Lang{{Name: "Go", TotalBytes: 6, TotalLines: 1}},
+		},
+		"line matches in 2 files": {
+			results: []result.Match{
+				mkResult("two.go", 1, 2),
+				mkResult("three.go", 1),
+			},
+			want: []inventory.Lang{{Name: "Go", TotalBytes: 10, TotalLines: 3}},
+		},
+		"1 entire repo": {
+			results: []result.Match{
+				&result.RepoMatch{Name: "r"},
+			},
+			getFiles: []fs.FileInfo{
+				fileInfo{path: "two.go"},
+				fileInfo{path: "three.go"},
+			},
+			want: []inventory.Lang{{Name: "Go", TotalBytes: 10, TotalLines: 5}},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			git.Mocks.ReadDir = func(commit api.CommitID, name string, recurse bool) ([]fs.FileInfo, error) {
+				return test.getFiles, nil
+			}
+
+			langs, err := searchResultsStatsLanguages(context.Background(), database.NewMockDB(), test.results)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(langs, test.want) {
+				t.Errorf("got %+v, want %+v", langs, test.want)
+			}
+		})
+	}
+}

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/symbol"
 	"github.com/sourcegraph/sourcegraph/internal/search/textsearch"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -768,6 +769,38 @@ func TestZeroElapsedMilliseconds(t *testing.T) {
 	r := &SearchResultsResolver{}
 	if got := r.ElapsedMilliseconds(); got != 0 {
 		t.Fatalf("got %d, want %d", got, 0)
+	}
+}
+
+func TestIsContextError(t *testing.T) {
+	cases := []struct {
+		err  error
+		want bool
+	}{
+		{
+			context.Canceled,
+			true,
+		},
+		{
+			context.DeadlineExceeded,
+			true,
+		},
+		{
+			errors.Wrap(context.Canceled, "wrapped"),
+			true,
+		},
+		{
+			errors.New("not a context error"),
+			false,
+		},
+	}
+	ctx := context.Background()
+	for _, c := range cases {
+		t.Run(c.err.Error(), func(t *testing.T) {
+			if got := isContextError(ctx, c.err); got != c.want {
+				t.Fatalf("wanted %t, got %t", c.want, got)
+			}
+		})
 	}
 }
 

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
@@ -84,6 +85,8 @@ func TestSearch(t *testing.T) {
 			Client: client,
 		})
 	})
+
+	testSearchOther(t)
 }
 
 // searchClient is an interface so we can swap out a streaming vs graphql
@@ -1334,6 +1337,47 @@ func testSearchClient(t *testing.T, client searchClient) {
 					t.Fatalf("mismatch (-want +got):\n%s", diff)
 				}
 			})
+		}
+	})
+}
+
+// testSearchOther other contains search tests for parts of the GraphQL API
+// which are not replicated in the streaming API (statistics and suggestions).
+func testSearchOther(t *testing.T) {
+	t.Run("search statistics", func(t *testing.T) {
+		err := client.OverwriteSettings(client.AuthenticatedUserID(), `{"experimentalFeatures":{"searchStats": true}}`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			err := client.OverwriteSettings(client.AuthenticatedUserID(), `{}`)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		var lastResult *gqltestutil.SearchStatsResult
+		// Retry because the configuration update endpoint is eventually consistent
+		err = gqltestutil.Retry(5*time.Second, func() error {
+			// This is a substring that appears in the sgtest/go-diff repository.
+			// It is OK if it starts to appear in other repositories, the test just
+			// checks that it is found in at least 1 Go file.
+			result, err := client.SearchStats("Incomplete-Lines")
+			if err != nil {
+				t.Fatal(err)
+			}
+			lastResult = result
+
+			for _, lang := range result.Languages {
+				if strings.EqualFold(lang.Name, "Go") {
+					return nil
+				}
+			}
+
+			return gqltestutil.ErrContinueRetry
+		})
+		if err != nil {
+			t.Fatal(err, "lastResult:", lastResult)
 		}
 	})
 }


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#31436

This broke Code Insights (language stats insights) 😬 