### PR TITLE
usagestats: redact info from URLs, send to BigQuery

### DIFF
--- a/internal/usagestats/event_handlers.go
+++ b/internal/usagestats/event_handlers.go
@@ -243,12 +243,12 @@ func redactSensitiveInfoFromCloudURL(rawURL string) (string, error) {
 	parsedURL.RawPath = "/redacted"
 	parsedURL.Path = "/redacted"
 
-	marketingQueryParameters := map[string]string{
-		"utm_source":   "",
-		"utm_campaign": "",
-		"utm_medium":   "",
-		"utm_term":     "",
-		"utm_content":  "",
+	marketingQueryParameters := map[string]struct{}{
+		"utm_source":   {},
+		"utm_campaign": {},
+		"utm_medium":   {},
+		"utm_term":     {},
+		"utm_content":  {},
 	}
 	urlQueryParams, err := url.ParseQuery(parsedURL.RawQuery)
 	if err != nil {

--- a/internal/usagestats/event_handlers.go
+++ b/internal/usagestats/event_handlers.go
@@ -156,7 +156,8 @@ func serializePublishSourcegraphDotComEvents(events []Event) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		url, err := redactSensitiveInfoFromCloudAppURL(event.URL)
+
+		url, err := redactSensitiveInfoFromCloudURL(event.URL)
 		if err != nil {
 			return nil, err
 		}
@@ -229,16 +230,14 @@ func serializeLocalEvents(events []Event) ([]*database.Event, error) {
 	return databaseEvents, nil
 }
 
-// redactSensitiveInfoFromCloudAppURL redacts portions of Sourcegraph Cloud URLs that
-// may contain sensitive info. We remove all paths, and only maintain query
-// parameters in a specified allowlist, which are essential for marketing analytics.
-func redactSensitiveInfoFromCloudAppURL(rawURL string) (string, error) {
+// redactSensitiveInfoFromCloudURL redacts portions of URLs that
+// may contain sensitive info on Sourcegraph Cloud. We replace all paths,
+// and only maintain query parameters in a specified allowlist,
+// which are known to be essential for marketing analytics on Sourcegraph Cloud.
+func redactSensitiveInfoFromCloudURL(rawURL string) (string, error) {
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {
 		return "", err
-	}
-	if parsedURL.Host != "sourcegraph.com" {
-		return rawURL, nil
 	}
 
 	parsedURL.RawPath = "/redacted"
@@ -255,7 +254,7 @@ func redactSensitiveInfoFromCloudAppURL(rawURL string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	for key, _ := range urlQueryParams {
+	for key := range urlQueryParams {
 		if _, ok := marketingQueryParameters[key]; !ok {
 			urlQueryParams[key] = []string{"redacted"}
 		}

--- a/internal/usagestats/event_handlers.go
+++ b/internal/usagestats/event_handlers.go
@@ -240,6 +240,10 @@ func redactSensitiveInfoFromCloudURL(rawURL string) (string, error) {
 		return "", err
 	}
 
+	if parsedURL.Host != "https://sourcegraph.com" {
+		return rawURL, nil
+	}
+
 	parsedURL.RawPath = "/redacted"
 	parsedURL.Path = "/redacted"
 

--- a/internal/usagestats/event_handlers.go
+++ b/internal/usagestats/event_handlers.go
@@ -240,7 +240,7 @@ func redactSensitiveInfoFromCloudURL(rawURL string) (string, error) {
 		return "", err
 	}
 
-	if parsedURL.Host != "https://sourcegraph.com" {
+	if parsedURL.Host != "sourcegraph.com" {
 		return rawURL, nil
 	}
 

--- a/internal/usagestats/event_handlers_test.go
+++ b/internal/usagestats/event_handlers_test.go
@@ -1,0 +1,39 @@
+package usagestats
+
+import "testing"
+
+func TestRedactSensitiveInfoFromCloudURL(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "path redacted",
+			url:  "https://sourcegraph.com/github.com/test/test",
+			want: "https://sourcegraph.com/redacted",
+		},
+		{
+			name: "path and non-approved query param redacted",
+			url:  "https://sourcegraph.com/search?q=abcd",
+			want: "https://sourcegraph.com/redacted?q=redacted",
+		},
+		{
+			name: "path and non-approved query param redacted, approved params retained",
+			url:  "https://sourcegraph.com/search?q=abcd&utm_source=test&utm_campaign=test&utm_medium=test",
+			want: "https://sourcegraph.com/redacted?q=redacted&utm_campaign=test&utm_medium=test&utm_source=test",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			have, err := redactSensitiveInfoFromCloudURL(c.url)
+			if err != nil {
+				t.Fatal("Error in redactSensitiveInfoFromCloudURL")
+			}
+			if c.want != have {
+				t.Fatalf("Failed to redact info from Cloud URL, got %s, want %s", have, c.want)
+			}
+		})
+	}
+}

--- a/internal/usagestats/event_handlers_test.go
+++ b/internal/usagestats/event_handlers_test.go
@@ -28,12 +28,8 @@ func TestRedactSensitiveInfoFromCloudURL(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			have, err := redactSensitiveInfoFromCloudURL(c.url)
-			if err != nil {
-				t.Fatal("Error in redactSensitiveInfoFromCloudURL")
-			}
-			if c.want != have {
-				t.Fatalf("Failed to redact info from Cloud URL, got %s, want %s", have, c.want)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, c.want, have)
 		})
 	}
 }

--- a/internal/usagestats/event_handlers_test.go
+++ b/internal/usagestats/event_handlers_test.go
@@ -1,6 +1,11 @@
 package usagestats
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
 
 func TestRedactSensitiveInfoFromCloudURL(t *testing.T) {
 	cases := []struct {

--- a/internal/usagestats/event_handlers_test.go
+++ b/internal/usagestats/event_handlers_test.go
@@ -20,8 +20,8 @@ func TestRedactSensitiveInfoFromCloudURL(t *testing.T) {
 		},
 		{
 			name: "path and non-approved query param redacted, approved params retained",
-			url:  "https://sourcegraph.com/search?q=abcd&utm_source=test&utm_campaign=test&utm_medium=test",
-			want: "https://sourcegraph.com/redacted?q=redacted&utm_campaign=test&utm_medium=test&utm_source=test",
+			url:  "https://sourcegraph.com/search?q=abcd&utm_source=test&utm_campaign=test&utm_medium=test&utm_content=test&utm_term=test",
+			want: "https://sourcegraph.com/redacted?q=redacted&utm_campaign=test&utm_content=test&utm_medium=test&utm_source=test&utm_term=test",
 		},
 	}
 


### PR DESCRIPTION
This PR re-adds URLs to event payloads sent to BigQuery, with redaction for URL paths and query parameters not explicitly specified for marketing usage. This is being added to ensure we can implement a marketing attribution solution and determine the effectiveness of our campaigns.

URLs were completely removed in the past to make sure we didn't leak any private info to our analytics systems from Sourcegraph Cloud. With redaction in place for everything except marketing UTMs / query params, we can send URLs without leaking any private data.

## Test plan

Added unit tests for the new function. Tested locally that events are properly sent to a mirror of the BQ data warehouse.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


