### PR TITLE
bext: automate refetching of code intel extensions

### DIFF
--- a/client/browser/scripts/build-inline-extensions.js
+++ b/client/browser/scripts/build-inline-extensions.js
@@ -1,20 +1,27 @@
+const fs = require('fs')
 const path = require('path')
 
 const shelljs = require('shelljs')
 const signale = require('signale')
 
-const extensionNames = require('../bundled-code-intel-extensions.json').extensions || []
+const config = require('../bundled-code-intel-extensions.json')
+const extensionNames = config.extensions || []
 
 const toDirectory = path.join(process.cwd(), 'build')
 const temporarySourceDirectory = path.join(process.cwd(), 'code-intel-extensions')
+const pathToRevisionFile = path.join(process.cwd(), 'code-intel-extensions', 'revision.txt')
 
 // Check if code-intel-extensions has already been fetched
 const codeIntelExtensionsDirectoryExists = shelljs.test('-d', temporarySourceDirectory)
-if (codeIntelExtensionsDirectoryExists) {
+if (codeIntelExtensionsDirectoryExists && fs.existsSync(pathToRevisionFile) && fs.readFileSync(pathToRevisionFile).toString() === config.revision) {
   console.log('Found existing code-intel-extensions.')
 } else {
   console.log('Did not find an existing code-intel-extensions. Running fetch-code-intel-extensions')
+  console.log(fs.existsSync(pathToRevisionFile) ? fs.readFileSync(pathToRevisionFile).toString() : 'not found', config.revision)
   shelljs.exec('yarn run fetch-code-intel-extensions')
+  // Save revision info
+  shelljs.exec(`touch ${pathToRevisionFile}`)
+  shelljs.exec(`echo ${config.revision} >> ${pathToRevisionFile}`)
 }
 
 // Install dependencies

--- a/client/browser/scripts/build-inline-extensions.js
+++ b/client/browser/scripts/build-inline-extensions.js
@@ -11,11 +11,7 @@ const temporarySourceDirectory = path.join(process.cwd(), 'code-intel-extensions
 const pathToRevisionFile = path.join(process.cwd(), 'code-intel-extensions', 'revision.txt')
 
 // Check if code-intel-extensions has already been fetched
-const codeIntelExtensionsDirectoryExists = shelljs.test('-d', temporarySourceDirectory)
-const codeIntelExtensionsRevisionFetched =
-  fs.existsSync(pathToRevisionFile) && fs.readFileSync(pathToRevisionFile).toString() === revision
-
-if (codeIntelExtensionsDirectoryExists && codeIntelExtensionsRevisionFetched) {
+if (fs.existsSync(pathToRevisionFile) && fs.readFileSync(pathToRevisionFile).toString() === revision) {
   console.log('Found existing code-intel-extensions.')
 } else {
   console.log('Did not find an existing code-intel-extensions. Running fetch-code-intel-extensions')

--- a/client/browser/scripts/build-inline-extensions.js
+++ b/client/browser/scripts/build-inline-extensions.js
@@ -4,8 +4,7 @@ const path = require('path')
 const shelljs = require('shelljs')
 const signale = require('signale')
 
-const config = require('../bundled-code-intel-extensions.json')
-const extensionNames = config.extensions || []
+const { extensions: extensionNames = [], revision } = require('../bundled-code-intel-extensions.json')
 
 const toDirectory = path.join(process.cwd(), 'build')
 const temporarySourceDirectory = path.join(process.cwd(), 'code-intel-extensions')
@@ -13,15 +12,15 @@ const pathToRevisionFile = path.join(process.cwd(), 'code-intel-extensions', 're
 
 // Check if code-intel-extensions has already been fetched
 const codeIntelExtensionsDirectoryExists = shelljs.test('-d', temporarySourceDirectory)
-if (codeIntelExtensionsDirectoryExists && fs.existsSync(pathToRevisionFile) && fs.readFileSync(pathToRevisionFile).toString() === config.revision) {
+const codeIntelExtensionsRevisionFetched =
+  fs.existsSync(pathToRevisionFile) && fs.readFileSync(pathToRevisionFile).toString() === revision
+
+if (codeIntelExtensionsDirectoryExists && codeIntelExtensionsRevisionFetched) {
   console.log('Found existing code-intel-extensions.')
 } else {
   console.log('Did not find an existing code-intel-extensions. Running fetch-code-intel-extensions')
-  console.log(fs.existsSync(pathToRevisionFile) ? fs.readFileSync(pathToRevisionFile).toString() : 'not found', config.revision)
   shelljs.exec('yarn run fetch-code-intel-extensions')
-  // Save revision info
-  shelljs.exec(`touch ${pathToRevisionFile}`)
-  shelljs.exec(`echo ${config.revision} >> ${pathToRevisionFile}`)
+  fs.writeFileSync(pathToRevisionFile, revision)
 }
 
 // Install dependencies


### PR DESCRIPTION
Closes [#18383](https://github.com/sourcegraph/sourcegraph/issues/18383)

## Test plan
- change revision in _client/browser/bundled-code-intel-extensions.json_
- run `yarn --cwd client/browser build-inline-extensions`
- ensure code intel extensions were fetched (message [like this](https://sourcegraph.com/gitlab.com/rluna-open-source/code-management/sourcegraph/sourcegraph-2020/-/blob/client/browser/scripts/build-inline-extensions.js?L16) was printed to console)
- run `yarn --cwd client/browser build-inline-extensions` again
- ensure code intel extensions were not refetched (message [like this](https://sourcegraph.com/gitlab.com/rluna-open-source/code-management/sourcegraph/sourcegraph-2020/-/blob/client/browser/scripts/build-inline-extensions.js?L14) was printed to console)


