### PR TITLE
gitserver: add metrics about failed clones

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -130,7 +130,7 @@ func main() {
 		DB:         db,
 		CloneQueue: server.NewCloneQueue(list.New()),
 	}
-	gitserver.RegisterMetrics()
+	gitserver.RegisterMetrics(db)
 
 	if tmpDir, err := gitserver.SetupAndClearTmp(); err != nil {
 		log.Fatalf("failed to setup temporary directory: %s", err)

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1697,9 +1697,13 @@ func (s *Server) cloneRepo(ctx context.Context, repo api.RepoName, opts *cloneOp
 	return "", nil
 }
 
-func (s *Server) doClone(ctx context.Context, repo api.RepoName, dir GitDir, syncer VCSSyncer, lock *RepositoryLock, remoteURL *vcs.URL, opts *cloneOptions) error {
+func (s *Server) doClone(ctx context.Context, repo api.RepoName, dir GitDir, syncer VCSSyncer, lock *RepositoryLock, remoteURL *vcs.URL, opts *cloneOptions) (err error) {
 	defer lock.Release()
-
+	defer func() {
+		if err != nil {
+			repoCloneFailedCounter.Inc()
+		}
+	}()
 	if err := s.rpsLimiter.Wait(ctx); err != nil {
 		return err
 	}
@@ -1959,6 +1963,10 @@ var (
 	repoClonedCounter = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "src_gitserver_repo_cloned",
 		Help: "number of successful git clones run",
+	})
+	repoCloneFailedCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "src_gitserver_repo_cloned_failed",
+		Help: "number of failed git clones",
 	})
 )
 

--- a/cmd/gitserver/server/servermetrics.go
+++ b/cmd/gitserver/server/servermetrics.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"os/exec"
 	"syscall"
 	"time"
@@ -8,10 +9,11 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 )
 
-func (s *Server) RegisterMetrics() {
+func (s *Server) RegisterMetrics(db dbutil.DB) {
 	// test the latency of exec, which may increase under certain memory
 	// conditions
 	echoDuration := prometheus.NewGauge(prometheus.GaugeOpts{
@@ -59,6 +61,27 @@ func (s *Server) RegisterMetrics() {
 		var stat syscall.Statfs_t
 		_ = syscall.Statfs(s.ReposDir, &stat)
 		return float64(stat.Blocks * uint64(stat.Bsize))
+	})
+	prometheus.MustRegister(c)
+
+	c = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "src_gitserver_repo_last_error_total",
+		Help: "Number of repositories whose last_error column is not empty.",
+	}, func() float64 {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		var count int64
+		err := db.QueryRowContext(ctx, `
+			SELECT COUNT(*) FROM gitserver_repos g
+			LEFT JOIN repo AS r ON g.repo_id = r.id
+			WHERE g.last_error IS NOT NULL AND r.deleted_at IS NULL
+		`).Scan(&count)
+		if err != nil {
+			log15.Error("failed to count repository errors", "err", err)
+			return 0
+		}
+		return float64(count)
 	})
 	prometheus.MustRegister(c)
 }

--- a/cmd/gitserver/server/servermetrics.go
+++ b/cmd/gitserver/server/servermetrics.go
@@ -73,8 +73,8 @@ func (s *Server) RegisterMetrics(db dbutil.DB) {
 
 		var count int64
 		err := db.QueryRowContext(ctx, `
-			SELECT COUNT(*) FROM gitserver_repos g
-			LEFT JOIN repo AS r ON g.repo_id = r.id
+			SELECT COUNT(*) FROM gitserver_repos AS g
+			INNER JOIN repo AS r ON g.repo_id = r.id
 			WHERE g.last_error IS NOT NULL AND r.deleted_at IS NULL
 		`).Scan(&count)
 		if err != nil {


### PR DESCRIPTION
This adds two metrics:

- One metric that counts the number of failed clones
- One metric that counts the number of repos whose "last_error" column in the database is not null

## Test plan

- [x] Verify the metric is available on grafana locally


