### PR TITLE
Code Insights: Final Insight design review for the 3.37 release 

### DIFF
--- a/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
+++ b/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
@@ -85,7 +85,7 @@ export const CodeInsightsRootPage: React.FunctionComponent<CodeInsightsRootPageP
                 actions={
                     <>
                         <Button as={Link} to="/insights/add-dashboard" variant="secondary" className="mr-2">
-                            <PlusIcon className="icon-inline" /> Create dashboard
+                            <PlusIcon className="icon-inline" /> Add dashboard
                         </Button>
                         <Button
                             as={Link}

--- a/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
@@ -82,7 +82,7 @@ export const InsightsDashboardCreationPage: React.FunctionComponent<InsightsDash
                                 alwaysShowLabel={true}
                                 data-testid="insight-save-button"
                                 loading={formAPI.submitting}
-                                label={formAPI.submitting ? 'Creating' : 'Create dashboard'}
+                                label={formAPI.submitting ? 'Adding' : 'Add dashboard'}
                                 type="submit"
                                 disabled={formAPI.submitting}
                                 className="ml-2 mb-2"

--- a/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-examples/CodeInsightsExamples.tsx
+++ b/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-examples/CodeInsightsExamples.tsx
@@ -1,7 +1,7 @@
 import { ParentSize } from '@visx/responsive'
 import classNames from 'classnames'
 import React from 'react'
-import { useLocation } from 'react-router';
+import { useLocation } from 'react-router'
 import { LineChartContent, LineChartContent as LineChartContentType, LineChartSeries } from 'sourcegraph'
 
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
@@ -32,9 +32,7 @@ export const CodeInsightsExamples: React.FunctionComponent<CodeInsightsExamplesP
             <h2>Example insights</h2>
             <p className="text-muted">
                 Here are a few example insights to show you what the tool can do.{' '}
-                <Link to={`${pathname}${search}#code-insights-templates`}>
-                    Explore more use cases.
-                </Link>
+                <Link to={`${pathname}${search}#code-insights-templates`}>Explore more use cases.</Link>
             </p>
 
             <div className={styles.section}>

--- a/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-examples/CodeInsightsExamples.tsx
+++ b/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-examples/CodeInsightsExamples.tsx
@@ -1,6 +1,7 @@
 import { ParentSize } from '@visx/responsive'
 import classNames from 'classnames'
 import React from 'react'
+import { useLocation } from 'react-router';
 import { LineChartContent, LineChartContent as LineChartContentType, LineChartSeries } from 'sourcegraph'
 
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
@@ -24,12 +25,14 @@ export interface CodeInsightsExamplesProps extends TelemetryProps, React.HTMLAtt
 
 export const CodeInsightsExamples: React.FunctionComponent<CodeInsightsExamplesProps> = props => {
     const { telemetryService, ...otherProps } = props
+    const { pathname, search } = useLocation()
+
     return (
         <section {...otherProps}>
             <h2>Example insights</h2>
             <p className="text-muted">
                 Here are a few example insights to show you what the tool can do.{' '}
-                <Link to="/help/code_insights/references/common_use_cases" rel="noopener noreferrer" target="_blank">
+                <Link to={`${pathname}${search}#code-insights-templates`}>
                     Explore more use cases.
                 </Link>
             </p>
@@ -106,7 +109,7 @@ const CodeInsightSearchExample: React.FunctionComponent<ExampleCardProps> = prop
             subtitle={
                 <CodeInsightsQueryBlock
                     as={SyntaxHighlightedSearchQuery}
-                    query="repo:github.com/awesomeOrg/examplerepo"
+                    query="repo:github.com/wildcard-org/wc-repo"
                     className="mt-1"
                 />
             }

--- a/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-templates/CodeInsightsTemplates.module.scss
+++ b/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-templates/CodeInsightsTemplates.module.scss
@@ -33,14 +33,14 @@
 }
 
 .query {
-    padding: 0.25rem 1rem 0.25rem 0.5rem;
+    padding: 0.375rem 1rem 0.375rem 0.5rem;
     position: relative;
 }
 
 .copy-button {
     position: absolute;
-    right: 0.25rem;
-    top: 0.25rem;
+    right: 0.375rem;
+    top: 0.375rem;
     color: var(--icon-color);
 
     &:hover {

--- a/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-templates/CodeInsightsTemplates.tsx
+++ b/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-templates/CodeInsightsTemplates.tsx
@@ -49,7 +49,7 @@ export const CodeInsightsTemplates: React.FunctionComponent<CodeInsightsTemplate
 
     return (
         <section {...otherProps}>
-            <h2>Templates</h2>
+            <h2 id='code-insights-templates'>Templates</h2>
             <p className="text-muted">
                 Some of the most popular{' '}
                 <Link to="/help/code_insights/references/common_use_cases" rel="noopener noreferrer" target="_blank">
@@ -109,7 +109,7 @@ const TemplatesPanel: React.FunctionComponent<TemplatesPanelProps> = props => {
                     className={styles.cardsFooterButton}
                     onClick={handleShowMoreButtonClick}
                 >
-                    {allVisible ? 'Show less' : 'Show all'}
+                    {allVisible ? 'Show less' : 'Show more'}
                 </Button>
             )}
         </TabPanel>
@@ -135,7 +135,7 @@ const TemplateCard: React.FunctionComponent<TemplateCardProps> = props => {
     return (
         <Card as={CardBody} className={styles.card}>
             <CardTitle>{template.title}</CardTitle>
-            <CardText>{template.description}</CardText>
+            <CardText>{template.description}.</CardText>
 
             <div className={styles.queries}>
                 {series.map(

--- a/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-templates/CodeInsightsTemplates.tsx
+++ b/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-templates/CodeInsightsTemplates.tsx
@@ -49,7 +49,7 @@ export const CodeInsightsTemplates: React.FunctionComponent<CodeInsightsTemplate
 
     return (
         <section {...otherProps}>
-            <h2 id='code-insights-templates'>Templates</h2>
+            <h2 id="code-insights-templates">Templates</h2>
             <p className="text-muted">
                 Some of the most popular{' '}
                 <Link to="/help/code_insights/references/common_use_cases" rel="noopener noreferrer" target="_blank">

--- a/client/web/src/enterprise/insights/pages/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
+++ b/client/web/src/enterprise/insights/pages/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
@@ -72,21 +72,24 @@ export const DynamicCodeInsightExample: React.FunctionComponent<DynamicCodeInsig
         formApi: form.formAPI,
     })
 
-    const hasValidLivePreview = repositories.meta.validState === 'VALID' && query.meta.validState === 'VALID'
-    const repository = useObservable(useMemo(() => getFirstExampleRepository(), [getFirstExampleRepository]))
+    const debouncedQuery = useDebounce(query.input.value, 1000)
+    const debouncedRepositories = useDebounce(repositories.input.value, 1000)
 
-    // This is to prevent resetting the name in an endless loop
-    if (repository && repositories.input.value !== repository) {
-        repositories.meta.setState(state => ({ ...state, value: repository }))
-    }
+    const derivedRepositoryURL = useObservable(useMemo(() => getFirstExampleRepository(), [getFirstExampleRepository]))
+
+    const { onChange: setRepositoryValue } = repositories.input
+
+    useEffect(() => {
+        // This is to prevent resetting the name in an endless loop
+        if (derivedRepositoryURL) {
+            setRepositoryValue(derivedRepositoryURL)
+        }
+    }, [setRepositoryValue, derivedRepositoryURL])
 
     const { trackMouseEnter, trackMouseLeave, trackDatumClicks } = useCodeInsightViewPings({
         telemetryService,
         insightType: CodeInsightTrackType.InProductLandingPageInsight,
     })
-
-    const debouncedQuery = useDebounce(query.input.value, 1000)
-    const debouncedRepositories = useDebounce(repositories.input.value, 1000)
 
     useEffect(() => {
         if (debouncedQuery !== INITIAL_INSIGHT_VALUES.query) {
@@ -103,6 +106,8 @@ export const DynamicCodeInsightExample: React.FunctionComponent<DynamicCodeInsig
     const handleGetStartedClick = (): void => {
         telemetryService.log('InsightsGetStartedPrimaryCTAClick')
     }
+
+    const hasValidLivePreview = repositories.meta.validState === 'VALID' && query.meta.validState === 'VALID'
 
     return (
         <Card {...otherProps} className={classNames(styles.wrapper, otherProps.className)}>


### PR DESCRIPTION

[Designs](https://www.figma.com/file/EFgTP7gpdpQSEo1n4FUfsW/In-product-landing-page-%5Bready-for-dev%5D?node-id=2024%3A29989) with @AlicjaSuska review comments 

## Test plan

- Make sure that you're able to edit the repositories field in the first section of the landing page
- Check that the CSS module migration example has a right repo value 
- Make sure that the link at the Code Insights example (explore more templates) leads to the template section 
- Check that copy of the add dashboard are right (Prior to this PR it was Create dashboard on the main and dashboard UI pages) now it's "Add dashboard"
- Label of the template expand button should say "Show more" (prior to this it was "show all")
- All template descriptions should have periods/dots at the end.

@AlicjaSuska a few things about the rest of the issues that you noted in the Figma file
- **No need for the ‘show less’ button** - I suspect that if you changed the tab and moved back to the previously expanded tab you should see the "show more" button again. It turned out there is no easy way to achieve this behavior with our existing tab component. So I left the "show less" button that it still should be possible to go back to the not expanded state.
- **copy icon should be 12px x 12px, it is 16px x 16px it should be centered in the grey box**. Our CSS variables say that all inline icons show has sizes 16px and not less. About the centered position I want to point out that when these icons always are placed in the same position (right top corner) it should be easier for users to hit this icon. Because it's always in a predictable place. If we center this icon by Y-axis it will be in different places depending on gray block height.
