### PR TITLE
Accessibility: Add WCAG accessibility issue automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility_issue.md
+++ b/.github/ISSUE_TEMPLATE/accessibility_issue.md
@@ -1,0 +1,32 @@
+---
+name: Accessibility issue
+about: Create an issue that is automatically attached to the WCAG 2.1 AA Tracking Issue
+title: '[Accessibility]: '
+labels: ['accessibility', 'wcag/2.1/fixing', 'estimate/3d']
+assignees: ''
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for your contribution to the accessibility of Sourcegraph! Please note that this issue has been automatically given an estimate of **3 days**. You can modify this estimate by changing the label from "estimate/3d" to "estimate/Xd" where X is the number of days.
+  - type: textarea
+    id: problem-description
+    attributes:
+      label: Problem description
+      description: Please describe the issue is as much detail as possible
+    validations:
+      required: true
+  - type: textarea
+    id: solution-description
+    attributes:
+      label: Expected behavior
+      description: Please describe the expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: additional-details
+    attributes:
+      label: Additional details
+      description: Notes and/or screenshot describing the problem, details how to replicate, etc
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/accessibility_issue.yaml
+++ b/.github/ISSUE_TEMPLATE/accessibility_issue.yaml
@@ -3,6 +3,7 @@ description: Create an issue that is automatically attached to the WCAG 2.1 AA T
 title: '[Accessibility]: '
 labels:
 - 'accessibility'
+- 'wcag/2.1'
 - 'wcag/2.1/fixing'
 - 'estimate/3d'
 body:

--- a/.github/ISSUE_TEMPLATE/accessibility_issue.yaml
+++ b/.github/ISSUE_TEMPLATE/accessibility_issue.yaml
@@ -1,4 +1,3 @@
----
 name: Accessibility issue
 about: Create an issue that is automatically attached to the WCAG 2.1 AA Tracking Issue
 title: '[Accessibility]: '

--- a/.github/ISSUE_TEMPLATE/accessibility_issue.yaml
+++ b/.github/ISSUE_TEMPLATE/accessibility_issue.yaml
@@ -1,13 +1,18 @@
 name: Accessibility issue
-about: Create an issue that is automatically attached to the WCAG 2.1 AA Tracking Issue
+description: Create an issue that is automatically attached to the WCAG 2.1 AA Tracking Issue
 title: '[Accessibility]: '
-labels: ['accessibility', 'wcag/2.1/fixing', 'estimate/3d']
-assignees: ''
+labels:
+- 'accessibility'
+- 'wcag/2.1/fixing'
+- 'estimate/3d'
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for your contribution to the accessibility of Sourcegraph! Please note that this issue has been automatically given an estimate of **3 days**. You can modify this estimate by changing the label from "estimate/3d" to "estimate/Xd" where X is the number of days.
+        Thanks for your contribution to the accessibility of Sourcegraph!
+
+        Please note that this issue has been automatically given an estimate of **3 days**.
+        You can modify this estimate by changing the label from *estimate/3d* to *estimate/Xd* where X is the correct number of days.
   - type: textarea
     id: problem-description
     attributes:

--- a/.github/workflows/label-move.yml
+++ b/.github/workflows/label-move.yml
@@ -198,3 +198,25 @@ jobs:
               }
             }
           }' -f project=$PROJECT_ID -f node_id=$NODE_ID
+  wcag-accessibility-board:
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_ID: PN_kwDOADy5QM4AAyDB # https://github.com/orgs/sourcegraph/projects/222
+      GITHUB_TOKEN: ${{ secrets.GH_PROJECTS_ACTION_TOKEN }}
+    steps:
+    - name: Get issue if relevant
+      if: ${{ contains(github.event.issue.labels.*.name, 'wcag/2.1') }}
+      env:
+        NODE_ID: ${{ github.event.issue.node_id }}
+      run: echo 'NODE_ID='$NODE_ID >> $GITHUB_ENV
+    - name: Add to Accessibility board
+      if: ${{ env.NODE_ID != '' }}
+      run: |
+        gh api graphql --header 'GraphQL-Features: projects_next_graphql' -f query='
+          mutation($project:ID!, $node_id:ID!) {
+            addProjectNextItem(input: {projectId: $project, contentId: $node_id}) {
+              projectNextItem {
+                id
+              }
+            }
+          }' -f project=$PROJECT_ID -f node_id=$NODE_ID

--- a/.github/workflows/label-move.yml
+++ b/.github/workflows/label-move.yml
@@ -201,7 +201,7 @@ jobs:
   wcag-accessibility-board:
     runs-on: ubuntu-latest
     env:
-      PROJECT_ID: PN_kwDOADy5QM4AAyDB # https://github.com/orgs/sourcegraph/projects/222
+      PROJECT_ID: PN_kwDOADy5QM4AAyDB # https://github.com/orgs/sourcegraph/projects/238
       GITHUB_TOKEN: ${{ secrets.GH_PROJECTS_ACTION_TOKEN }}
     steps:
     - name: Get issue if relevant


### PR DESCRIPTION
<img width="982" alt="image" src="https://user-images.githubusercontent.com/9516420/154673809-f23fd950-0f1b-45ce-be3e-c5c2d7607157.png">

## Description

This PR adds:
- An issue template to make it as straight forward as possible to create new accessibility issues that are attached to our tracking issues and GH boards
- Board automation to automatically add these GH issues to the [Accessibility GH board](https://github.com/orgs/sourcegraph/projects/238) for further tracking

### Flow
1. Developer notices an issue when following the [self-audit documentation](https://github.com/sourcegraph/sourcegraph/issues/31237). The documentation links them to the GitHub issue template
2. Issue is created with correct labels and base estimate
3. Issue automatically attached to tracking issue
4. Issue automatically added to GH board.

#### Tracking Issues

Each step of the WCAG effort has its own tracking issue: [Planning](https://github.com/sourcegraph/sourcegraph/issues/31235), [Auditing](https://github.com/sourcegraph/sourcegraph/issues/31475), [Fixing](https://github.com/sourcegraph/sourcegraph/issues/31476).

### GH Board

Board: https://github.com/orgs/sourcegraph/projects/238

Each step of the WCAG effort has its own view


## Test plan
Create an issue, expect it to be added with the correct labels and attached to the board

closes https://github.com/sourcegraph/sourcegraph/issues/31236