### PR TITLE
docs: link back to explanation of auto-indexing from how-tos

### DIFF
--- a/doc/code_intelligence/how-to/configure_auto_indexing.md
+++ b/doc/code_intelligence/how-to/configure_auto_indexing.md
@@ -19,7 +19,7 @@ img.screenshot {
 <p><b>We're very much looking for input and feedback on this feature.</b> You can either <a href="https://about.sourcegraph.com/contact">contact us directly</a>, <a href="https://github.com/sourcegraph/sourcegraph">file an issue</a>, or <a href="https://twitter.com/sourcegraph">tweet at us</a>.</p>
 </aside>
 
-Precise code intelligence auto-indexing jobs are scheduled based on two fronts of configuration.
+Precise code intelligence [auto-indexing](../explanations/auto_indexing.md) jobs are scheduled based on two fronts of configuration.
 
 The first front selects the set of repositories and commits within those repositories that are candidates for auto-indexing. These candidates are controlled by [configuring auto-indexing policies](#configure-auto-indexing-policies).
 

--- a/doc/code_intelligence/how-to/enable_auto_indexing.md
+++ b/doc/code_intelligence/how-to/enable_auto_indexing.md
@@ -8,6 +8,8 @@
 <p><b>We're very much looking for input and feedback on this feature.</b> You can either <a href="https://about.sourcegraph.com/contact">contact us directly</a>, <a href="https://github.com/sourcegraph/sourcegraph">file an issue</a>, or <a href="https://twitter.com/sourcegraph">tweet at us</a>.</p>
 </aside>
 
+This how-to explains how to turn on [auto-indexing](../explanations/auto_indexing.md) on your Sourcegraph instance to enable [precise code intelligence](../explanations/precise_code_intelligence.md).
+
 ## Deploy executors
 
 First, [deploy the executor service](../../../../admin/deploy_executors.md) targeting your Sourcegraph instance. This will provide the necessary compute resources that clone the target Git repository, securely analyze the code to produce a precise code intelligence index, then upload that index to your Sourcegraph instance for processing.


### PR DESCRIPTION
It's hard to find out what auto-indexing is if landing on a how-to page. So let's link back to the explanation.

## Test plan

- `sg check docsite` to check that all the links are correct


