### PR TITLE
Make Storybook sort stories alphabetically

### DIFF
--- a/client/storybook/src/preview.ts
+++ b/client/storybook/src/preview.ts
@@ -20,7 +20,7 @@ export const parameters = {
     options: {
         storySort: {
             order: ['wildcard', 'shared', 'branded', '*'],
-            method: 'alphabetical'
+            method: 'alphabetical',
         },
     },
     darkMode: {

--- a/client/storybook/src/preview.ts
+++ b/client/storybook/src/preview.ts
@@ -20,6 +20,7 @@ export const parameters = {
     options: {
         storySort: {
             order: ['wildcard', 'shared', 'branded', '*'],
+            method: 'alphabetical'
         },
     },
     darkMode: {


### PR DESCRIPTION
## Problem
This isn't really a problem but storybook wasn't sorting stories within categories alphabetically.

<img width="1132" alt="Screenshot 2022-02-18 at 16 03 31" src="https://user-images.githubusercontent.com/2196347/154687992-053d055a-da52-4a35-8c8b-1af711d620cf.png">

## Solution
Enable alphabetical sort

<img width="1255" alt="Screenshot 2022-02-18 at 16 04 29" src="https://user-images.githubusercontent.com/2196347/154688079-c6ed7015-7f95-4c00-8494-aca2867c00e9.png">

## Test plan
1. Open storybook
2. Make sure sorting is enabled

## App preview:

- [Link](https://sg-web-og-storybook-sorting-alphabetical.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

