### PR TITLE
[CLOUD-268] Repo-centric permission syncing with GitHub App

### DIFF
--- a/enterprise/internal/authz/github/app.go
+++ b/enterprise/internal/authz/github/app.go
@@ -1,0 +1,53 @@
+package github
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// todo
+func newAppProvider(urn string, baseURL *url.URL, appID, privateKey string, installationID int64) (*Provider, error) {
+	pkey, err := base64.StdEncoding.DecodeString(privateKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "decode private key")
+	}
+
+	auther, err := auth.NewOAuthBearerTokenWithGitHubApp(appID, pkey)
+	if err != nil {
+		return nil, errors.Wrap(err, "new authenticator with GitHub App")
+	}
+
+	apiURL, _ := github.APIRoot(baseURL)
+	appClient := github.NewV3Client(apiURL, auther, nil)
+	return &Provider{
+		urn:      urn,
+		codeHost: extsvc.NewCodeHost(baseURL, extsvc.TypeGitHub),
+		client: func() (client, error) {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+			defer cancel()
+
+			// TODO(cloud-saas): Cache the installation access token until it expires.
+			token, err := appClient.CreateAppInstallationAccessToken(ctx, installationID)
+			if err != nil {
+				return nil, errors.Wrap(err, "create app installation access token")
+			}
+			if token.Token == nil {
+				return nil, errors.New("empty token returned")
+			}
+
+			fmt.Println("new token:", *token.Token)
+			auther = &auth.OAuthBearerToken{Token: *token.Token}
+			return &ClientAdapter{
+				V3Client: github.NewV3Client(apiURL, auther, nil),
+			}, nil
+		},
+	}, nil
+}

--- a/enterprise/internal/authz/github/app.go
+++ b/enterprise/internal/authz/github/app.go
@@ -33,7 +33,8 @@ func newAppProvider(urn string, baseURL *url.URL, appID, privateKey string, inst
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel()
 
-			// TODO(cloud-saas): Cache the installation access token until it expires.
+			// // TODO(cloud-saas): Cache the installation access token until it expires, see
+			// https://sourcegraph.atlassian.net/browse/CLOUD-255
 			token, err := appClient.CreateAppInstallationAccessToken(ctx, installationID)
 			if err != nil {
 				return nil, errors.Wrap(err, "create app installation access token")

--- a/enterprise/internal/authz/github/app.go
+++ b/enterprise/internal/authz/github/app.go
@@ -3,7 +3,6 @@ package github
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
 	"net/url"
 	"time"
 
@@ -13,7 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// todo
+// newAppProvider creates a new GitHub Provider with a client that creates a new installation access token.
 func newAppProvider(urn string, baseURL *url.URL, appID, privateKey string, installationID int64) (*Provider, error) {
 	pkey, err := base64.StdEncoding.DecodeString(privateKey)
 	if err != nil {
@@ -43,7 +42,6 @@ func newAppProvider(urn string, baseURL *url.URL, appID, privateKey string, inst
 				return nil, errors.New("empty token returned")
 			}
 
-			fmt.Println("new token:", *token.Token)
 			auther = &auth.OAuthBearerToken{Token: *token.Token}
 			return &ClientAdapter{
 				V3Client: github.NewV3Client(apiURL, auther, nil),

--- a/enterprise/internal/authz/github/app.go
+++ b/enterprise/internal/authz/github/app.go
@@ -33,7 +33,7 @@ func newAppProvider(urn string, baseURL *url.URL, appID, privateKey string, inst
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel()
 
-			// // TODO(cloud-saas): Cache the installation access token until it expires, see
+			// TODO(cloud-saas): Cache the installation access token until it expires, see
 			// https://sourcegraph.atlassian.net/browse/CLOUD-255
 			token, err := appClient.CreateAppInstallationAccessToken(ctx, installationID)
 			if err != nil {

--- a/enterprise/internal/authz/github/app.go
+++ b/enterprise/internal/authz/github/app.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// newAppProvider creates a new GitHub Provider with a client that creates a new installation access token.
+// newAppProvider creates a new authz Provider for GitHub App.
 func newAppProvider(urn string, baseURL *url.URL, appID, privateKey string, installationID int64) (*Provider, error) {
 	pkey, err := base64.StdEncoding.DecodeString(privateKey)
 	if err != nil {

--- a/enterprise/internal/authz/github/app_test.go
+++ b/enterprise/internal/authz/github/app_test.go
@@ -1,0 +1,62 @@
+package github
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v31/github"
+
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func TestNewAppProvider(t *testing.T) {
+	t.Run("test new app provider client", func(t *testing.T) {
+		srvHit := false
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			tokenString := "1234"
+			tokenExpiry := time.Now()
+			token := github.InstallationToken{
+				Token:        &tokenString,
+				ExpiresAt:    &tokenExpiry,
+				Permissions:  &github.InstallationPermissions{},
+				Repositories: []*github.Repository{},
+			}
+
+			respJson, _ := json.Marshal(token)
+
+			srvHit = true
+
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(respJson)
+		}))
+
+		ghConnection := &types.GitHubConnection{
+			URN: "",
+			GitHubConnection: &schema.GitHubConnection{
+				Url: srv.URL,
+				Authorization: &schema.GitHubAuthorization{
+					GroupsCacheTTL: 72,
+				},
+				GithubAppInstallationID: "1234",
+			},
+		}
+
+		baseURL, _ := url.Parse(ghConnection.Url)
+
+		const bogusKey = `LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlCUEFJQkFBSkJBUEpIaWprdG1UMUlLYUd0YTVFZXAzQVo5Q2VPZUw4alBESUZUN3dRZ0tabXQzRUZxRGhCCk93bitRVUhKdUs5Zm92UkROSmVWTDJvWTVCT0l6NHJ3L0cwQ0F3RUFBUUpCQU1BK0o5Mks0d2NQVllsbWMrM28KcHU5NmlKTkNwMmp5Nm5hK1pEQlQzK0VvSUo1VFJGdnN3R2kvTHUzZThYUWwxTDNTM21ub0xPSlZNcTF0bUxOMgpIY0VDSVFEK3daeS83RlYxUEFtdmlXeWlYVklETzJnNWJOaUJlbmdKQ3hFa3Nia1VtUUloQVBOMlZaczN6UFFwCk1EVG9vTlJXcnl0RW1URERkamdiOFpzTldYL1JPRGIxQWlCZWNKblNVQ05TQllLMXJ5VTFmNURTbitoQU9ZaDkKWDFBMlVnTDE3bWhsS1FJaEFPK2JMNmRDWktpTGZORWxmVnRkTUtxQnFjNlBIK01heFU2VzlkVlFvR1dkQWlFQQptdGZ5cE9zYTFiS2hFTDg0blovaXZFYkJyaVJHalAya3lERHYzUlg0V0JrPQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=`
+
+		provider, _ := newAppProvider(ghConnection.URN, baseURL, "1234", bogusKey, 1234)
+
+		provider.client()
+
+		if !srvHit {
+			t.Fatal("request to server was never made to get client token")
+		}
+	})
+}

--- a/enterprise/internal/authz/github/authz_test.go
+++ b/enterprise/internal/authz/github/authz_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -151,6 +152,51 @@ func TestNewAuthzProviders(t *testing.T) {
 			// assert groups cache is available
 			if (providers[0]).(*Provider).groupsCache == nil {
 				t.Fatal("expected groups cache to be enabled")
+			}
+		})
+
+		t.Run("github app installation id available", func(t *testing.T) {
+			const bogusKey = `LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlCUEFJQkFBSkJBUEpIaWprdG1UMUlLYUd0YTVFZXAzQVo5Q2VPZUw4alBESUZUN3dRZ0tabXQzRUZxRGhCCk93bitRVUhKdUs5Zm92UkROSmVWTDJvWTVCT0l6NHJ3L0cwQ0F3RUFBUUpCQU1BK0o5Mks0d2NQVllsbWMrM28KcHU5NmlKTkNwMmp5Nm5hK1pEQlQzK0VvSUo1VFJGdnN3R2kvTHUzZThYUWwxTDNTM21ub0xPSlZNcTF0bUxOMgpIY0VDSVFEK3daeS83RlYxUEFtdmlXeWlYVklETzJnNWJOaUJlbmdKQ3hFa3Nia1VtUUloQVBOMlZaczN6UFFwCk1EVG9vTlJXcnl0RW1URERkamdiOFpzTldYL1JPRGIxQWlCZWNKblNVQ05TQllLMXJ5VTFmNURTbitoQU9ZaDkKWDFBMlVnTDE3bWhsS1FJaEFPK2JMNmRDWktpTGZORWxmVnRkTUtxQnFjNlBIK01heFU2VzlkVlFvR1dkQWlFQQptdGZ5cE9zYTFiS2hFTDg0blovaXZFYkJyaVJHalAya3lERHYzUlg0V0JrPQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=`
+
+			conf.Mock(&conf.Unified{
+				SiteConfiguration: schema.SiteConfiguration{
+					Dotcom: &schema.Dotcom{
+						GithubAppCloud: &schema.GithubAppCloud{
+							AppID:        "1234",
+							ClientID:     "1234",
+							ClientSecret: "1234",
+							Slug:         "test-app",
+							PrivateKey:   bogusKey,
+						},
+					},
+				},
+			})
+			defer conf.Mock(nil)
+
+			providers, problems, warnings := NewAuthzProviders(
+				[]*types.GitHubConnection{{
+					GitHubConnection: &schema.GitHubConnection{
+						Url: "https://github.com/",
+						Authorization: &schema.GitHubAuthorization{
+							GroupsCacheTTL: 72,
+						},
+						GithubAppInstallationID: "1234",
+					},
+				}},
+				[]schema.AuthProviders{{
+					// falls back to schema.DefaultGitHubURL
+					Github: &schema.GitHubAuthProvider{},
+				}},
+				false,
+			)
+			if len(providers) != 1 || providers[0] == nil {
+				t.Fatal("expected a provider")
+			}
+			if len(problems) != 0 {
+				t.Fatalf("unexpected problems: %+v", problems)
+			}
+			if len(warnings) != 0 {
+				t.Fatalf("unexpected warnings: %+v", warnings)
 			}
 		})
 	})

--- a/enterprise/internal/authz/github/authz_test.go
+++ b/enterprise/internal/authz/github/authz_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -23,15 +25,10 @@ func TestNewAuthzProviders(t *testing.T) {
 			[]schema.AuthProviders{},
 			false,
 		)
-		if len(providers) != 0 {
-			t.Fatalf("unexpected providers: %+v", providers)
-		}
-		if len(problems) != 0 {
-			t.Fatalf("unexpected problems: %+v", problems)
-		}
-		if len(warnings) != 0 {
-			t.Fatalf("unexpected warnings: %+v", warnings)
-		}
+
+		assert.True(t, len(providers) == 0, "unexpected a providers: %+v", providers)
+		assert.True(t, len(problems) == 0, "unexpected problems: %+v", problems)
+		assert.True(t, len(warnings) == 0, "unexpected warnings: %+v", warnings)
 	})
 
 	t.Run("no matching auth provider", func(t *testing.T) {
@@ -49,15 +46,10 @@ func TestNewAuthzProviders(t *testing.T) {
 			}},
 			false,
 		)
-		if len(providers) != 1 || providers[0] == nil {
-			t.Fatal("expected a provider")
-		}
-		if len(problems) != 0 {
-			t.Fatalf("unexpected problems: %+v", problems)
-		}
-		if len(warnings) != 1 || !strings.Contains(warnings[0], "no authentication provider") {
-			t.Fatalf("unexpected warnings: %+v", warnings)
-		}
+
+		assert.True(t, len(providers) == 1 && providers[0] != nil, "expected a provider")
+		assert.True(t, len(problems) == 0, "unexpected problems: %+v", problems)
+		assert.True(t, len(warnings) == 1 && strings.Contains(warnings[0], "no authentication provider"), "unexpected warnings: %+v", warnings)
 	})
 
 	t.Run("matching auth provider found", func(t *testing.T) {
@@ -75,15 +67,10 @@ func TestNewAuthzProviders(t *testing.T) {
 				}},
 				false,
 			)
-			if len(providers) != 1 || providers[0] == nil {
-				t.Fatal("expected a provider")
-			}
-			if len(problems) != 0 {
-				t.Fatalf("unexpected problems: %+v", problems)
-			}
-			if len(warnings) != 0 {
-				t.Fatalf("unexpected warnings: %+v", warnings)
-			}
+
+			assert.True(t, len(providers) == 1 && providers[0] != nil, "expected a provider")
+			assert.True(t, len(problems) == 0, "unexpected problems: %+v", problems)
+			assert.True(t, len(warnings) == 0, "unexpected warnings: %+v", warnings)
 		})
 
 		t.Run("groups cache enabled, but not allowGroupsPermissionsSync", func(t *testing.T) {
@@ -104,19 +91,11 @@ func TestNewAuthzProviders(t *testing.T) {
 				}},
 				false,
 			)
-			if len(providers) != 1 || providers[0] == nil {
-				t.Fatal("expected a provider")
-			}
-			if len(problems) != 0 {
-				t.Fatalf("unexpected problems: %+v", problems)
-			}
-			if len(warnings) != 1 || !strings.Contains(warnings[0], "`allowGroupsPermissionsSync`") {
-				t.Fatalf("unexpected warnings: %+v", warnings)
-			}
-			// assert groups cache is forcibly disabled
-			if (providers[0]).(*Provider).groupsCache != nil {
-				t.Fatal("expected groups cache to be disabled")
-			}
+
+			assert.True(t, len(providers) == 1 && providers[0] != nil, "expected a provider")
+			assert.True(t, len(problems) == 0, "unexpected problems: %+v", problems)
+			assert.True(t, len(warnings) == 1 && strings.Contains(warnings[0], "`allowGroupsPermissionsSync`"), "unexpected warnings: %+v", warnings)
+			assert.True(t, (providers[0]).(*Provider).groupsCache == nil, "expected groups cache to be enabled")
 		})
 
 		t.Run("groups cache and allowGroupsPermissionsSync enabled", func(t *testing.T) {
@@ -140,19 +119,10 @@ func TestNewAuthzProviders(t *testing.T) {
 				}},
 				false,
 			)
-			if len(providers) != 1 || providers[0] == nil {
-				t.Fatal("expected a provider")
-			}
-			if len(problems) != 0 {
-				t.Fatalf("unexpected problems: %+v", problems)
-			}
-			if len(warnings) != 0 {
-				t.Fatalf("unexpected warnings: %+v", warnings)
-			}
-			// assert groups cache is available
-			if (providers[0]).(*Provider).groupsCache == nil {
-				t.Fatal("expected groups cache to be enabled")
-			}
+			assert.True(t, len(providers) == 1 && providers[0] != nil, "expected a provider")
+			assert.True(t, len(problems) == 0, "unexpected problems: %+v", problems)
+			assert.True(t, len(warnings) == 0, "unexpected warnings: %+v", warnings)
+			assert.True(t, (providers[0]).(*Provider).groupsCache != nil, "expected groups cache to be enabled")
 		})
 
 		t.Run("github app installation id available", func(t *testing.T) {
@@ -189,15 +159,10 @@ func TestNewAuthzProviders(t *testing.T) {
 				}},
 				false,
 			)
-			if len(providers) != 1 || providers[0] == nil {
-				t.Fatal("expected a provider")
-			}
-			if len(problems) != 0 {
-				t.Fatalf("unexpected problems: %+v", problems)
-			}
-			if len(warnings) != 0 {
-				t.Fatalf("unexpected warnings: %+v", warnings)
-			}
+
+			assert.True(t, len(providers) == 1 && providers[0] != nil, "expected a provider")
+			assert.True(t, len(problems) == 0, "unexpected problems: %+v", problems)
+			assert.True(t, len(warnings) == 0, "unexpected warnings: %+v", warnings)
 		})
 	})
 }

--- a/enterprise/internal/authz/github/authz_test.go
+++ b/enterprise/internal/authz/github/authz_test.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,9 +25,11 @@ func TestNewAuthzProviders(t *testing.T) {
 			false,
 		)
 
-		assert.True(t, len(providers) == 0, "unexpected a providers: %+v", providers)
-		assert.True(t, len(problems) == 0, "unexpected problems: %+v", problems)
-		assert.True(t, len(warnings) == 0, "unexpected warnings: %+v", warnings)
+		assert := assert.New(t)
+
+		assert.Len(providers, 0, "unexpected a providers: %+v", providers)
+		assert.Len(problems, 0, "unexpected problems: %+v", problems)
+		assert.Len(warnings, 0, "unexpected warnings: %+v", warnings)
 	})
 
 	t.Run("no matching auth provider", func(t *testing.T) {
@@ -47,9 +48,15 @@ func TestNewAuthzProviders(t *testing.T) {
 			false,
 		)
 
-		assert.True(t, len(providers) == 1 && providers[0] != nil, "expected a provider")
-		assert.True(t, len(problems) == 0, "unexpected problems: %+v", problems)
-		assert.True(t, len(warnings) == 1 && strings.Contains(warnings[0], "no authentication provider"), "unexpected warnings: %+v", warnings)
+		assert := assert.New(t)
+
+		if assert.Len(providers, 1, "expected exactly one provider") {
+			assert.NotNil(providers[0], "expected provider to not be nil")
+		}
+		assert.Len(problems, 0, "unexpected problems: %+v", problems)
+		if assert.Len(warnings, 1, "expected one warning") {
+			assert.Contains(warnings[0], "no authentication provider", "unexpected warnings: %+v", warnings)
+		}
 	})
 
 	t.Run("matching auth provider found", func(t *testing.T) {
@@ -68,9 +75,13 @@ func TestNewAuthzProviders(t *testing.T) {
 				false,
 			)
 
-			assert.True(t, len(providers) == 1 && providers[0] != nil, "expected a provider")
-			assert.True(t, len(problems) == 0, "unexpected problems: %+v", problems)
-			assert.True(t, len(warnings) == 0, "unexpected warnings: %+v", warnings)
+			assert := assert.New(t)
+
+			if assert.Len(providers, 1, "expected exactly one provider") {
+				assert.NotNil(providers[0], "expected provider to not be nil")
+			}
+			assert.Len(problems, 0, "unexpected problems: %+v", problems)
+			assert.Len(warnings, 0, "unexpected warnings: %+v", warnings)
 		})
 
 		t.Run("groups cache enabled, but not allowGroupsPermissionsSync", func(t *testing.T) {
@@ -92,10 +103,18 @@ func TestNewAuthzProviders(t *testing.T) {
 				false,
 			)
 
-			assert.True(t, len(providers) == 1 && providers[0] != nil, "expected a provider")
-			assert.True(t, len(problems) == 0, "unexpected problems: %+v", problems)
-			assert.True(t, len(warnings) == 1 && strings.Contains(warnings[0], "`allowGroupsPermissionsSync`"), "unexpected warnings: %+v", warnings)
-			assert.True(t, (providers[0]).(*Provider).groupsCache == nil, "expected groups cache to be enabled")
+			assert := assert.New(t)
+
+			if assert.Len(providers, 1, "expected exactly one provider") {
+				if assert.NotNil(providers[0], "expected provider to not be nil") {
+					assert.Nil((providers[0].(*Provider).groupsCache), "expected groups cache to be disabled")
+				}
+
+			}
+			assert.Len(problems, 0, "unexpected problems: %+v", problems)
+			if assert.Len(warnings, 1, "expected one warning") {
+				assert.Contains(warnings[0], "`allowGroupsPermissionsSync`", "unexpected warnings: %+v", warnings)
+			}
 		})
 
 		t.Run("groups cache and allowGroupsPermissionsSync enabled", func(t *testing.T) {
@@ -119,10 +138,17 @@ func TestNewAuthzProviders(t *testing.T) {
 				}},
 				false,
 			)
-			assert.True(t, len(providers) == 1 && providers[0] != nil, "expected a provider")
-			assert.True(t, len(problems) == 0, "unexpected problems: %+v", problems)
-			assert.True(t, len(warnings) == 0, "unexpected warnings: %+v", warnings)
-			assert.True(t, (providers[0]).(*Provider).groupsCache != nil, "expected groups cache to be enabled")
+
+			assert := assert.New(t)
+
+			if assert.Len(providers, 1, "expected exactly one provider") {
+				if assert.NotNil(providers[0], "expected provider to not be nil") {
+					assert.NotNil((providers[0].(*Provider).groupsCache), "expected groups cache to be enabled")
+				}
+
+			}
+			assert.Len(problems, 0, "unexpected problems: %+v", problems)
+			assert.Len(warnings, 0, "unexpected warnings: %+v", warnings)
 		})
 
 		t.Run("github app installation id available", func(t *testing.T) {
@@ -160,9 +186,13 @@ func TestNewAuthzProviders(t *testing.T) {
 				false,
 			)
 
-			assert.True(t, len(providers) == 1 && providers[0] != nil, "expected a provider")
-			assert.True(t, len(problems) == 0, "unexpected problems: %+v", problems)
-			assert.True(t, len(warnings) == 0, "unexpected warnings: %+v", warnings)
+			assert := assert.New(t)
+
+			if assert.Len(providers, 1, "expected exactly one provider") {
+				assert.NotNil(providers[0], "expected provider to not be nil")
+			}
+			assert.Len(problems, 0, "unexpected problems: %+v", problems)
+			assert.Len(warnings, 0, "unexpected warnings: %+v", warnings)
 		})
 	})
 }

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -168,9 +168,9 @@ func newGithubSource(svc *types.ExternalService, c *schema.GitHubConnection, cf 
 			return nil, errors.Wrap(err, "new authenticator with GitHub App")
 		}
 
-		apiURL, err := url.Parse("https://github.com")
+		apiURL, err := url.Parse("https://api.github.com")
 		if err != nil {
-			return nil, errors.Wrap(err, "parse github.com")
+			return nil, errors.Wrap(err, "parse api.github.com")
 		}
 		client := github.NewV3Client(apiURL, auther, nil)
 


### PR DESCRIPTION
This PR allows repo-centric permission syncing to work with GitHub App. A new Installation Access Token is created for every sync.

## Test plan

Added and updated unit tests.

Manually tested in local environment to confirm permission sync is working.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


