### PR TITLE
insights: Group the tab click pings by tabName

### DIFF
--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1128,6 +1128,8 @@ type CodeInsightsUsageStatistics struct {
 	WeeklyInsightCreators                   *int32
 	WeeklyFirstTimeInsightCreators          *int32
 	WeeklyAggregatedUsage                   []AggregatedPingStats
+	WeeklyGetStartedTabClickByTab           []InsightGetStartedTabClickPing
+	WeeklyGetStartedTabMoreClickByTab       []InsightGetStartedTabClickPing
 	InsightTimeIntervals                    []InsightTimeIntervalPing
 	InsightOrgVisible                       []OrgVisibleInsightPing
 	InsightTotalCounts                      InsightTotalCounts
@@ -1181,6 +1183,11 @@ type InsightViewSeriesCountPing struct {
 	GenerationType string
 	ViewType       string
 	TotalCount     int
+}
+
+type InsightGetStartedTabClickPing struct {
+	TabName    string
+	TotalCount int
 }
 
 type InsightTotalCounts struct {

--- a/internal/usagestats/code_insights.go
+++ b/internal/usagestats/code_insights.go
@@ -140,7 +140,41 @@ func GetCodeInsightsUsageStatistics(ctx context.Context, db database.DB) (*types
 	}
 	stats.InsightTotalCounts = totalCounts
 
+	weeklyGetStartedTabClickByTab, err := GetWeeklyTabClicks(ctx, db, getStartedTabClickSql)
+	if err != nil {
+		return nil, errors.Wrap(err, "GetWeeklyTabClicks")
+	}
+	stats.WeeklyGetStartedTabClickByTab = weeklyGetStartedTabClickByTab
+
+	weeklyGetStartedTabMoreClickByTab, err := GetWeeklyTabClicks(ctx, db, getStartedTabMoreClickSql)
+	if err != nil {
+		return nil, errors.Wrap(err, "GetWeeklyTabClicks")
+	}
+	stats.WeeklyGetStartedTabMoreClickByTab = weeklyGetStartedTabMoreClickByTab
+
 	return &stats, nil
+}
+
+func GetWeeklyTabClicks(ctx context.Context, db database.DB, sql string) ([]types.InsightGetStartedTabClickPing, error) {
+	weeklyGetStartedTabClickByTab := []types.InsightGetStartedTabClickPing{}
+	rows, err := db.QueryContext(ctx, sql, timeNow())
+
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		weeklyGetStartedTabClick := types.InsightGetStartedTabClickPing{}
+		if err := rows.Scan(
+			&weeklyGetStartedTabClick.TotalCount,
+			&weeklyGetStartedTabClick.TabName,
+		); err != nil {
+			return nil, err
+		}
+		weeklyGetStartedTabClickByTab = append(weeklyGetStartedTabClickByTab, weeklyGetStartedTabClick)
+	}
+	return weeklyGetStartedTabClickByTab, nil
 }
 
 func GetTotalInsightCounts(ctx context.Context, db database.DB) (types.InsightTotalCounts, error) {
@@ -289,8 +323,6 @@ func creationPagesPingBuilder(timeSupplier func() time.Time) PingQueryBuilder {
 		"InsightsGetStartedBigTemplateClick",
 		"InsightGetStartedTemplateCopyClick",
 		"InsightGetStartedTemplateClick",
-		"InsightsGetStartedTabClick",
-		"InsightsGetStartedTabMoreClick",
 		"InsightsGetStartedDocsClicks",
 	}
 
@@ -327,6 +359,18 @@ FROM event_logs
 WHERE name = ANY($2)
 AND timestamp > DATE_TRUNC('%v', $1::TIMESTAMP)
 GROUP BY name;
+`
+
+const getStartedTabClickSql = `
+SELECT COUNT(*), argument FROM event_logs
+WHERE name = 'InsightsGetStartedTabClick' AND timestamp > DATE_TRUNC('week', $1::TIMESTAMP)
+GROUP BY argument;
+`
+
+const getStartedTabMoreClickSql = `
+SELECT COUNT(*), argument FROM event_logs
+WHERE name = 'InsightsGetStartedTabMoreClick' AND timestamp > DATE_TRUNC('week', $1::TIMESTAMP)
+GROUP BY argument;
 `
 
 const InsightsTotalCountPingName = `INSIGHT_TOTAL_COUNTS`

--- a/internal/usagestats/code_insights.go
+++ b/internal/usagestats/code_insights.go
@@ -148,7 +148,7 @@ func GetCodeInsightsUsageStatistics(ctx context.Context, db database.DB) (*types
 
 	weeklyGetStartedTabMoreClickByTab, err := GetWeeklyTabClicks(ctx, db, getStartedTabMoreClickSql)
 	if err != nil {
-		return nil, errors.Wrap(err, "GetWeeklyTabClicks")
+		return nil, errors.Wrap(err, "GetWeeklyTabMoreClicks")
 	}
 	stats.WeeklyGetStartedTabMoreClickByTab = weeklyGetStartedTabMoreClickByTab
 

--- a/internal/usagestats/code_insights.go
+++ b/internal/usagestats/code_insights.go
@@ -362,13 +362,13 @@ GROUP BY name;
 `
 
 const getStartedTabClickSql = `
-SELECT COUNT(*), argument FROM event_logs
+SELECT COUNT(*), argument::json->>'tabName' as argument FROM event_logs
 WHERE name = 'InsightsGetStartedTabClick' AND timestamp > DATE_TRUNC('week', $1::TIMESTAMP)
 GROUP BY argument;
 `
 
 const getStartedTabMoreClickSql = `
-SELECT COUNT(*), argument FROM event_logs
+SELECT COUNT(*), argument::json->>'tabName' as argument FROM event_logs
 WHERE name = 'InsightsGetStartedTabMoreClick' AND timestamp > DATE_TRUNC('week', $1::TIMESTAMP)
 GROUP BY argument;
 `

--- a/internal/usagestats/code_insights_test.go
+++ b/internal/usagestats/code_insights_test.go
@@ -93,6 +93,8 @@ func TestCodeInsightsUsageStatistics(t *testing.T) {
 		WeekStart:                               weekStart,
 		WeeklyInsightCreators:                   &twoInt,
 		WeeklyFirstTimeInsightCreators:          &oneInt,
+		WeeklyGetStartedTabClickByTab:           []types.InsightGetStartedTabClickPing{},
+		WeeklyGetStartedTabMoreClickByTab:       []types.InsightGetStartedTabClickPing{},
 	}
 
 	wantedWeeklyUsage := []types.AggregatedPingStats{


### PR DESCRIPTION
The landing page click pings for tabs and tabs "show more" were only emitting totals, and not grouped by tabName. This PR groups them by tabName.

## Test plan

I tested this locally by clicking the tabs and "show more" buttons on the landing page, and verifying that the click pings were showing up as grouped in `site-admin/pings` under `WeeklyGetStartedTabClickByTab` and `WeeklyGetStartedTabMoreClickByTab`.

``` json
"codeInsightsUsage": {
        "WeekStart": "2022-02-14T00:00:00Z",
        "InsightOrgVisible": [
            {
                "Type": "search",
                "TotalCount": 4
            }
        ],
        "InsightTotalCounts": {
            "ViewCounts": [
                {
                    "ViewType": "PIE",
                    "TotalCount": 6
                },
                {
                    "ViewType": "LINE",
                    "TotalCount": 89
                }
            ],
            "SeriesCounts": [
                {
                    "TotalCount": 29,
                    "GenerationType": "search::global::recorded"
                },
                {
                    "TotalCount": 5,
                    "GenerationType": "capture-groups::global::recorded"
                },
                {
                    "TotalCount": 5,
                    "GenerationType": "language-stats::scoped::jit"
                },
                {
                    "TotalCount": 44,
                    "GenerationType": "search::scoped::jit"
                },
                {
                    "TotalCount": 6,
                    "GenerationType": "capture-groups::scoped::jit"
                },
                {
                    "TotalCount": 1,
                    "GenerationType": "search-stream::global::recorded"
                }
            ],
            "ViewSeriesCounts": [
                {
                    "ViewType": "LINE",
                    "TotalCount": 1,
                    "GenerationType": "search-stream::global::recorded"
                },
                {
                    "ViewType": "LINE",
                    "TotalCount": 49,
                    "GenerationType": "search::global::recorded"
                },
                {
                    "ViewType": "LINE",
                    "TotalCount": 5,
                    "GenerationType": "capture-groups::global::recorded"
                },
                {
                    "ViewType": "LINE",
                    "TotalCount": 43,
                    "GenerationType": "search::scoped::jit"
                },
                {
                    "ViewType": "LINE",
                    "TotalCount": 6,
                    "GenerationType": "capture-groups::scoped::jit"
                },
                {
                    "ViewType": "PIE",
                    "TotalCount": 5,
                    "GenerationType": "language-stats::scoped::jit"
                },
                {
                    "ViewType": "PIE",
                    "TotalCount": 1,
                    "GenerationType": "search::scoped::jit"
                }
            ]
        },
        "InsightTimeIntervals": [
            {
                "TotalCount": 1,
                "IntervalDays": 180
            },
            {
                "TotalCount": 5,
                "IntervalDays": 14
            },
            {
                "TotalCount": 11,
                "IntervalDays": 60
            },
            {
                "TotalCount": 3,
                "IntervalDays": 3
            },
            {
                "TotalCount": 15,
                "IntervalDays": 21
            },
            {
                "TotalCount": 1,
                "IntervalDays": 4
            },
            {
                "TotalCount": 1,
                "IntervalDays": 42
            },
            {
                "TotalCount": 2,
                "IntervalDays": 7
            },
            {
                "TotalCount": 43,
                "IntervalDays": 30
            },
            {
                "TotalCount": 3,
                "IntervalDays": 0
            },
            {
                "TotalCount": 2,
                "IntervalDays": 90
            },
            {
                "TotalCount": 3,
                "IntervalDays": 35
            }
        ],
        "WeeklyAggregatedUsage": [
            {
                "Name": "CodeInsightsCreateSearchBasedInsightClick",
                "TotalCount": 1,
                "UniqueCount": 1
            },
            {
                "Name": "CodeInsightsSearchBasedCreationPageSubmitClick",
                "TotalCount": 1,
                "UniqueCount": 1
            },
            {
                "Name": "InsightsGetStartedPageQueryModification",
                "TotalCount": 1,
                "UniqueCount": 1
            },
            {
                "Name": "ViewCodeInsightsCreationPage",
                "TotalCount": 5,
                "UniqueCount": 2
            },
            {
                "Name": "ViewCodeInsightsSearchBasedCreationPage",
                "TotalCount": 1,
                "UniqueCount": 1
            }
        ],
        "WeeklyInsightCreators": 1,
        "WeeklyInsightsPageViews": 58,
        "WeeklyInsightAddMoreClick": 3,
        "WeeklyInsightConfigureClick": 0,
        "WeeklyGetStartedTabClickByTab": [
            {
                "TabName": "Adoption",
                "TotalCount": 4
            },
            {
                "TabName": "Code health",
                "TotalCount": 6
            },
            {
                "TabName": "Deprecation",
                "TotalCount": 6
            },
            {
                "TabName": "Migration",
                "TotalCount": 4
            },
            {
                "TabName": "Other",
                "TotalCount": 8
            },
            {
                "TabName": "Popular",
                "TotalCount": 1
            },
            {
                "TabName": "Security",
                "TotalCount": 7
            },
            {
                "TabName": "Versions and patterns",
                "TotalCount": 7
            }
        ],
        "WeeklyInsightsUniquePageViews": 3,
        "WeeklyFirstTimeInsightCreators": 0,
        "WeeklyUsageStatisticsByInsight": [
            {
                "Edits": 0,
                "Hovers": 6,
                "Removals": 0,
                "Additions": 0,
                "InsightType": "CaptureGroup",
                "DataPointClicks": 0,
                "UICustomizations": 0
            },
            {
                "Edits": 0,
                "Hovers": 0,
                "Removals": 0,
                "Additions": 1,
                "InsightType": "captureGroupInsights",
                "DataPointClicks": 0,
                "UICustomizations": 0
            },
            {
                "Edits": 0,
                "Hovers": 0,
                "Removals": 0,
                "Additions": 1,
                "InsightType": "searchInsights",
                "DataPointClicks": 0,
                "UICustomizations": 0
            },
            {
                "Edits": 0,
                "Hovers": 3,
                "Removals": 0,
                "Additions": 0,
                "InsightType": "SearchBased",
                "DataPointClicks": 0,
                "UICustomizations": 0
            },
            {
                "Edits": 0,
                "Hovers": 4,
                "Removals": 0,
                "Additions": 0,
                "InsightType": "InProductLandingPageInsight",
                "DataPointClicks": 0,
                "UICustomizations": 0
            }
        ],
        "WeeklyGetStartedTabMoreClickByTab": [
            {
                "TabName": "Adoption",
                "TotalCount": 2
            },
            {
                "TabName": "Code health",
                "TotalCount": 3
            },
            {
                "TabName": "Deprecation",
                "TotalCount": 10
            },
            {
                "TabName": "Migration",
                "TotalCount": 2
            },
            {
                "TabName": "Other",
                "TotalCount": 1
            },
            {
                "TabName": "Popular",
                "TotalCount": 2
            },
            {
                "TabName": "Security",
                "TotalCount": 1
            },
            {
                "TabName": "Versions and patterns",
                "TotalCount": 8
            }
        ],
        "WeeklyInsightsGetStartedPageViews": 5,
        "WeeklyInsightsGetStartedUniquePageViews": 1
    },
```
