### PR TITLE
Code Insights: Send FE InsightsGetStartedTabMoreClick only on show more button click

### DIFF
--- a/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-templates/CodeInsightsTemplates.tsx
+++ b/client/web/src/enterprise/insights/pages/getting-started/components/code-insights-templates/CodeInsightsTemplates.tsx
@@ -92,8 +92,11 @@ const TemplatesPanel: React.FunctionComponent<TemplatesPanelProps> = props => {
     const hasMoreLessButton = templates.length > 4
 
     const handleShowMoreButtonClick = (): void => {
+        if (!allVisible) {
+            telemetryService.log('InsightsGetStartedTabMoreClick', { tabName: sectionTitle }, { tabName: sectionTitle })
+        }
+
         setAllVisible(!allVisible)
-        telemetryService.log('InsightsGetStartedTabMoreClick', { tabName: sectionTitle }, { tabName: sectionTitle })
     }
 
     return (


### PR DESCRIPTION

## Test plan

- Click the "show more" button and check that FE produces a valid `InsightsGetStartedTabMoreClick` FE even ping
- Click on the "show less" button and check that this action doesn't send anything on the BE