### PR TITLE
search frontend: add decoration for dependencies predicate

### DIFF
--- a/client/shared/src/search/query/decoratedToken.test.ts
+++ b/client/shared/src/search/query/decoratedToken.test.ts
@@ -1484,4 +1484,41 @@ describe('getMonacoTokens()', () => {
             ]
         `)
     })
+
+    test('highlight repo:dependencies predicate', () => {
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:dependencies(.*)')))).toMatchInlineSnapshot(
+            `
+            [
+              {
+                "startIndex": 0,
+                "scopes": "field"
+              },
+              {
+                "startIndex": 4,
+                "scopes": "metaFilterSeparator"
+              },
+              {
+                "startIndex": 5,
+                "scopes": "metaPredicateNameAccess"
+              },
+              {
+                "startIndex": 17,
+                "scopes": "metaPredicateParenthesis"
+              },
+              {
+                "startIndex": 18,
+                "scopes": "metaRegexpCharacterSet"
+              },
+              {
+                "startIndex": 19,
+                "scopes": "metaRegexpRangeQuantifier"
+              },
+              {
+                "startIndex": 20,
+                "scopes": "metaPredicateParenthesis"
+              }
+            ]
+        `
+        )
+    })
 })

--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -944,6 +944,14 @@ const decoratePredicateBody = (path: string[], body: string, offset: number): De
                 value: body,
                 kind: PatternKind.Regexp,
             })
+        case 'dependencies':
+        case 'deps':
+            return mapRegexpMetaSucceed({
+                type: 'pattern',
+                range: { start: offset, end: body.length },
+                value: body,
+                kind: PatternKind.Regexp,
+            })
     }
     decorated.push({
         type: 'literal',

--- a/client/shared/src/search/query/hover.ts
+++ b/client/shared/src/search/query/hover.ts
@@ -155,7 +155,7 @@ const toSelectorHover = (token: MetaSelector): string => {
     }
 }
 
-const toContainsHover = (token: MetaPredicate): string => {
+const toPredicateHover = (token: MetaPredicate): string => {
     const parameters = token.value.parameters.slice(1, -1)
     switch (token.value.path.join('.')) {
         case 'contains':
@@ -166,6 +166,9 @@ const toContainsHover = (token: MetaPredicate): string => {
             return `**Built-in predicate**. Search only inside repositories that contain **file content** matching the regular expression \`${parameters}\`.`
         case 'contains.commit.after':
             return `**Built-in predicate**. Search only inside repositories that have been committed to since \`${parameters}\`.`
+        case 'dependencies':
+        case 'deps':
+            return '**Built-in predicate**. Search only repository dependencies of repositories matching the regular expression'
     }
     return ''
 }
@@ -187,7 +190,7 @@ const toHover = (token: DecoratedToken): string => {
         case 'metaStructural':
             return toStructuralHover(token)
         case 'metaPredicate': {
-            return toContainsHover(token)
+            return toPredicateHover(token)
         }
     }
     return ''

--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -26,6 +26,12 @@ export const PREDICATES: Access[] = [
                     },
                 ],
             },
+            {
+                name: 'dependencies',
+            },
+            {
+                name: 'deps',
+            },
         ],
     },
     {


### PR DESCRIPTION
Frontend changes for `repo:dependencies`.

<img width="575" alt="Screen Shot 2022-02-18 at 9 40 05 AM" src="https://user-images.githubusercontent.com/888624/154734656-319cf11f-8e0c-4f51-87d3-6d2e03924a48.png">

## Test plan
Added a test


