### PR TITLE
migration: Remove `*schema_migrations` tables

### DIFF
--- a/internal/database/schema.codeintel.md
+++ b/internal/database/schema.codeintel.md
@@ -1,14 +1,3 @@
-# Table "public.codeintel_schema_migrations"
-```
- Column  |  Type   | Collation | Nullable | Default 
----------+---------+-----------+----------+---------
- version | bigint  |           | not null | 
- dirty   | boolean |           | not null | 
-Indexes:
-    "codeintel_schema_migrations_pkey" PRIMARY KEY, btree (version)
-
-```
-
 # Table "public.lsif_data_apidocs_num_dumps"
 ```
  Column |  Type  | Collation | Nullable | Default 

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -2074,17 +2074,6 @@ Foreign-key constraints:
 
 ```
 
-# Table "public.schema_migrations"
-```
- Column  |  Type   | Collation | Nullable | Default 
----------+---------+-----------+----------+---------
- version | bigint  |           | not null | 
- dirty   | boolean |           | not null | 
-Indexes:
-    "schema_migrations_pkey" PRIMARY KEY, btree (version)
-
-```
-
 # Table "public.search_context_repos"
 ```
       Column       |  Type   | Collation | Nullable | Default 


### PR DESCRIPTION
Remove the old single-row table that holds schema versions.

## Test plan

Remaining unit tests cover active code.