### PR TITLE
errors: Remove additional cockroachdb uses

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -82,14 +82,6 @@ run:
     # of dependencies in the root module (which has access to the colocated lib)
     # like we did with sg. That seemed very successful!
 
-    # In ./dev/bkstats
-    - main.go
-    # In ./dev/depgraph
-    - internal/graph/graph.go
-    - internal/lints/lint.go
-    - summary.go
-    - trace_internal.go
-    - trace.go
     # In ./enterprise/dev/insight-data-gen
     - main.go
     # In ./internal/cmd/progress-bot

--- a/dev/bkstats/main.go
+++ b/dev/bkstats/main.go
@@ -10,7 +10,8 @@ import (
 	"time"
 
 	"github.com/buildkite/go-buildkite/v3/buildkite"
-	"github.com/cockroachdb/errors"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 var token string

--- a/dev/depgraph/internal/graph/graph.go
+++ b/dev/depgraph/internal/graph/graph.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/cockroachdb/errors"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // DependencyGraph encodes the import relationships between packages within

--- a/dev/depgraph/internal/lints/lint.go
+++ b/dev/depgraph/internal/lints/lint.go
@@ -5,9 +5,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/sourcegraph/sourcegraph/dev/depgraph/internal/graph"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type Lint func(graph *graph.DependencyGraph) []lintError

--- a/dev/depgraph/summary.go
+++ b/dev/depgraph/summary.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/cockroachdb/errors"
 	"github.com/peterbourgon/ff/v3/ffcli"
 
 	"github.com/sourcegraph/sourcegraph/dev/depgraph/internal/graph"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 var summaryFlagSet = flag.NewFlagSet("depgraph summary", flag.ExitOnError)

--- a/dev/depgraph/trace.go
+++ b/dev/depgraph/trace.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/cockroachdb/errors"
 	"github.com/peterbourgon/ff/v3/ffcli"
 
 	"github.com/sourcegraph/sourcegraph/dev/depgraph/internal/graph"
 	"github.com/sourcegraph/sourcegraph/dev/depgraph/internal/visualization"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 var traceFlagSet = flag.NewFlagSet("depgraph trace", flag.ExitOnError)

--- a/dev/depgraph/trace_internal.go
+++ b/dev/depgraph/trace_internal.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cockroachdb/errors"
 	"github.com/peterbourgon/ff/v3/ffcli"
 
 	"github.com/sourcegraph/sourcegraph/dev/depgraph/internal/graph"
 	"github.com/sourcegraph/sourcegraph/dev/depgraph/internal/visualization"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 var traceInternalFlagSet = flag.NewFlagSet("depgraph trace-internal", flag.ExitOnError)

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/cespare/xxhash v1.1.0
 	github.com/cespare/xxhash/v2 v2.1.2
 	github.com/charmbracelet/glamour v0.5.0
-	github.com/cockroachdb/errors v1.8.9
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/coreos/go-semver v0.3.0
 	github.com/crewjam/saml v0.4.6
@@ -186,6 +185,7 @@ require (
 	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/alecthomas/chroma v0.10.0 // indirect
+	github.com/cockroachdb/errors v1.8.9 // indirect
 	github.com/containerd/typeurl v1.0.2 // indirect
 	github.com/dlclark/regexp2 v1.4.0 // indirect
 	github.com/docker/docker v20.10.7+incompatible // indirect


### PR DESCRIPTION
- Remove go.mod from dev/depgraph
- Remove dev/depgraph and dev/bkstats uses of cockroachdb, opting for lib/errors instead.

## Test plan

CI should catch any incorrect usages here.
