### PR TITLE
buildchecker: enforce branch protections for admins as well

### DIFF
--- a/dev/buildchecker/branch.go
+++ b/dev/buildchecker/branch.go
@@ -80,6 +80,7 @@ func (b *repoBranchLocker) Lock(ctx context.Context, commits []CommitInfo, fallb
 			RequiredPullRequestReviews: &github.PullRequestReviewsEnforcementRequest{
 				RequiredApprovingReviewCount: 1,
 			},
+			EnforceAdmins: true, // do not allow admins to bypass checks
 		}); err != nil {
 			return errors.Newf("unlock: %w", err)
 		}


### PR DESCRIPTION
I made an accidental push to main because I am an admin on the repo 😬 I think this config was wiped by Buildchecker unintentionally, this PR makes sure we set protections to admins as well

Thankfully the pushed change was a minor refactor (https://github.com/sourcegraph/sourcegraph/commit/6c0ead544e4f3b21de91f7ca2e7e8c8d7f77a818) but will keep an eye on the CI build

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

n/a, unit tests still pass 
