### PR TITLE
monitoring: replace RawVariables with RawTransform

### DIFF
--- a/monitoring/definitions/executor.go
+++ b/monitoring/definitions/executor.go
@@ -17,9 +17,11 @@ func Executor() *monitoring.Container {
 		Description: `Executes jobs in an isolated environment.`,
 		Variables: []monitoring.ContainerVariable{
 			{
-				Label:   "Queue name",
-				Name:    "queue",
-				Options: []string{"batches", "codeintel"},
+				Label: "Queue name",
+				Name:  "queue",
+				Options: monitoring.ContainerVariableOptions{
+					Options: []string{"batches", "codeintel"},
+				},
 			},
 			{
 				Label:        "Compute instance",

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -45,18 +45,10 @@ func Frontend() *monitoring.Container {
 			Name:  "sentinel_sampling_duration",
 			Label: "Sentinel query sampling duration",
 			Options: monitoring.ContainerVariableOptions{
-				Options:     sentinelSamplingIntervals,
-				NoAllOption: true,
-			},
-			RawTransform: func(tv *sdk.TemplateVar) {
-				tv.Type = "interval"
-				tv.Current = sdk.Current{
-					Text: &sdk.StringSliceString{
-						Value: []string{defaultSamplingInterval.String()},
-						Valid: true,
-					},
-					Value: defaultSamplingInterval.String(),
-				}
+				Type:          "interval",
+				Options:       sentinelSamplingIntervals,
+				DefaultOption: defaultSamplingInterval.String(),
+				NoAllOption:   true,
 			},
 		}},
 		Groups: []monitoring.Group{

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -1,7 +1,6 @@
 package definitions
 
 import (
-	"strings"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/monitoring/definitions/shared"
@@ -42,23 +41,24 @@ func Frontend() *monitoring.Container {
 		Name:        "frontend",
 		Title:       "Frontend",
 		Description: "Serves all end-user browser and API requests.",
-		RawVariables: []sdk.TemplateVar{
-			{
-				Type:  "interval",
-				Name:  "sentinel_sampling_duration",
-				Label: "Sentinel query sampling duration",
-				Query: strings.Join(sentinelSamplingIntervals, ","),
-				Current: sdk.Current{
-					Text: &sdk.StringSliceString{
-						Value: []string{defaultSamplingInterval.String()}, Valid: true},
-					Value: defaultSamplingInterval.String(),
-				},
-				Refresh: sdk.BoolInt{
-					Flag:  true,
-					Value: monitoring.Int64Ptr(2),
-				},
+		Variables: []monitoring.ContainerVariable{{
+			Name:  "sentinel_sampling_duration",
+			Label: "Sentinel query sampling duration",
+			Options: monitoring.ContainerVariableOptions{
+				Options:     sentinelSamplingIntervals,
+				NoAllOption: true,
 			},
-		},
+			RawTransform: func(tv *sdk.TemplateVar) {
+				tv.Type = "interval"
+				tv.Current = sdk.Current{
+					Text: &sdk.StringSliceString{
+						Value: []string{defaultSamplingInterval.String()},
+						Valid: true,
+					},
+					Value: defaultSamplingInterval.String(),
+				}
+			},
+		}},
 		Groups: []monitoring.Group{
 			{
 				Title: "Search at a glance",

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -45,10 +45,9 @@ func Frontend() *monitoring.Container {
 			Name:  "sentinel_sampling_duration",
 			Label: "Sentinel query sampling duration",
 			Options: monitoring.ContainerVariableOptions{
-				Type:          "interval",
+				Type:          monitoring.OptionTypeInterval,
 				Options:       sentinelSamplingIntervals,
 				DefaultOption: defaultSamplingInterval.String(),
-				NoAllOption:   true,
 			},
 		}},
 		Groups: []monitoring.Group{

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -31,12 +31,6 @@ type Container struct {
 	// container, such as instances or shards.
 	Variables []ContainerVariable
 
-	// RawVariables is an alternative to Variables that exposes the underlying Grafana API
-	// to define variables that can be applied to the dashboard for this container.
-	//
-	// It is recommended to use or expand the standardized Variables field instead.
-	RawVariables []sdk.TemplateVar
-
 	// Groups of observable information about the container.
 	Groups []Group
 
@@ -85,15 +79,16 @@ func (c *Container) renderDashboard() *sdk.Board {
 	board.Editable = false
 	board.AddTags("builtin")
 	alertLevelVariable := ContainerVariable{
-		Label:   "Alert level",
-		Name:    "alert_level",
-		Options: []string{"critical", "warning"},
+		Label: "Alert level",
+		Name:  "alert_level",
+		Options: ContainerVariableOptions{
+			Options: []string{"critical", "warning"},
+		},
 	}
 	board.Templating.List = []sdk.TemplateVar{alertLevelVariable.toGrafanaTemplateVar()}
 	for _, variable := range c.Variables {
 		board.Templating.List = append(board.Templating.List, variable.toGrafanaTemplateVar())
 	}
-	board.Templating.List = append(board.Templating.List, c.RawVariables...)
 	board.Annotations.List = []sdk.Annotation{{
 		Name:       "Alert events",
 		Datasource: StringPtr("Prometheus"),
@@ -338,6 +333,12 @@ func (c *Container) renderRules() (*promRulesFile, error) {
 	}, nil
 }
 
+type ContainerVariableOptions struct {
+	Options []string
+	// NoAllOption disables the addition of an 'All' option to the options set.
+	NoAllOption bool
+}
+
 // ContainerVariable describes a template variable that can be applied container dashboard
 // for filtering purposes.
 type ContainerVariable struct {
@@ -352,7 +353,7 @@ type ContainerVariable struct {
 	OptionsQuery string
 	// Options are the pre-defined possible values for this variable. Cannot be used in
 	// conjunction with Query
-	Options []string
+	Options ContainerVariableOptions
 
 	// WildcardAllValue indicates to Grafana that is should NOT use Query or Options to
 	// generate a concatonated 'All' value for the variable, and use a '.*' wildcard
@@ -368,6 +369,13 @@ type ContainerVariable struct {
 
 	// Multi indicates whether or not to allow multi-selection for this variable filter
 	Multi bool
+
+	// RawTransform is can be used to extend ContainerVariable to modify underlying
+	// Grafana variables specification.
+	//
+	// It is recommended to use or extend the standardized ContainerVariable options
+	// instead.
+	RawTransform func(*sdk.TemplateVar)
 }
 
 func (c *ContainerVariable) validate() error {
@@ -377,10 +385,10 @@ func (c *ContainerVariable) validate() error {
 	if c.Label == "" {
 		return errors.New("ContainerVariable.Label is required")
 	}
-	if c.OptionsQuery == "" && len(c.Options) == 0 {
+	if c.OptionsQuery == "" && len(c.Options.Options) == 0 {
 		return errors.New("one of ContainerVariable.Query and ContainerVariable.Options must be set")
 	}
-	if c.OptionsQuery != "" && len(c.Options) > 0 {
+	if c.OptionsQuery != "" && len(c.Options.Options) > 0 {
 		return errors.New("ContainerVariable.Query and ContainerVariable.Options cannot both be set")
 	}
 	return nil
@@ -422,14 +430,20 @@ func (c *ContainerVariable) toGrafanaTemplateVar() sdk.TemplateVar {
 		}
 		variable.Sort = 3
 
-	case len(c.Options) > 0:
+	case len(c.Options.Options) > 0:
 		variable.Type = "custom"
-		variable.Query = strings.Join(c.Options, ",")
-		// Add the AllValue as a default
-		variable.Options = []sdk.Option{{Text: "all", Value: "$__all", Selected: true}}
-		for _, option := range c.Options {
+		variable.Query = strings.Join(c.Options.Options, ",")
+		if !c.Options.NoAllOption {
+			// Add the AllValue as a default
+			variable.Options = append(variable.Options, sdk.Option{Text: "all", Value: "$__all", Selected: true})
+		}
+		for _, option := range c.Options.Options {
 			variable.Options = append(variable.Options, sdk.Option{Text: option, Value: option})
 		}
+	}
+
+	if c.RawTransform != nil {
+		c.RawTransform(&variable)
 	}
 
 	return variable


### PR DESCRIPTION
Some cleanup for fun, writing a small personal blog thing about the generator for and noticed this potential streamlining 😁 

When it comes down to it, the single usage of `RawVariables` only had 2 custom fields, and disables `$all`. This replaces it with something more ergonomic and less hacky - variables can now provide `RawTransform` to manipulate the generated variable

Also extends `Options` so that you can disable the `all` option we generate, configure a custom `Type`, and set a default selected value, negating the need for the one usage of `RawTransform` for now. I think all this configuration makes sense to be standardized here. Details: [`863c4d4` (#31518)](https://github.com/sourcegraph/sourcegraph/pull/31518/commits/863c4d4a27c2bf83ea52ff67ff467f6a795411de)

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

With the config described in https://github.com/sourcegraph/sourcegraph/pull/31530 :

```
sg start monitoring
```

![Kapture 2022-02-18 at 15 01 56](https://user-images.githubusercontent.com/23356519/154772887-77db466c-2285-4639-9b35-92b54f9f0db3.gif)


Before, after:

<img width="396" alt="image" src="https://user-images.githubusercontent.com/23356519/154772686-ea14095f-a63a-46d0-86cd-bbcbb14448bb.png"> <img width="390" alt="image" src="https://user-images.githubusercontent.com/23356519/154772641-080936da-446a-469e-83e5-3cad99e06b77.png">

Since these are static options the refresh was unnecessary
