### PR TITLE
tests: Fix LSIF IDs in dump1

### DIFF
--- a/lib/codeintel/lsif/testdata/dump1.lsif
+++ b/lib/codeintel/lsif/testdata/dump1.lsif
@@ -39,7 +39,7 @@
 {"id": "37", "type": "edge", "label": "item", "outV": "14", "inVs": ["04"], "document": "02"}
 {"id": "38", "type": "edge", "label": "item", "outV": "14", "inVs": ["05"], "document": "02"}
 {"id": "39", "type": "edge", "label": "item", "outV": "14", "inVs": ["15"], "shard": "02"}
-{"id": "38", "type": "edge", "label": "item", "outV": "100", "inVs": ["05"], "document": "02"}
+{"id": "102", "type": "edge", "label": "item", "outV": "100", "inVs": ["05"], "document": "02"}
 {"id": "40", "type": "edge", "label": "moniker", "outV": "07", "inV": "18"}
 {"id": "41", "type": "edge", "label": "moniker", "outV": "09", "inV": "19"}
 {"id": "42", "type": "edge", "label": "moniker", "outV": "10", "inV": "20"}


### PR DESCRIPTION
I think I messed up the numbering in https://github.com/sourcegraph/sourcegraph/pull/24854

## Test plan

We have automated tests for this.