### PR TITLE
batches: implement new URL scheme changes

### DIFF
--- a/client/web/src/enterprise/batches/BatchSpecNode.tsx
+++ b/client/web/src/enterprise/batches/BatchSpecNode.tsx
@@ -64,7 +64,7 @@ export const BatchSpecNode: React.FunctionComponent<BatchSpecNodeProps> = ({
                         </>
                     )}
                     {currentSpecID && (
-                        <Link to={`/batch-changes/executions/${node.id}`}>
+                        <Link to={`${node.namespace.url}/batch-changes/${node.description.name}/executions/${node.id}`}>
                             Executed by <strong>{node.creator?.username}</strong>{' '}
                             <Timestamp date={node.createdAt} now={now} />
                         </Link>
@@ -75,7 +75,11 @@ export const BatchSpecNode: React.FunctionComponent<BatchSpecNodeProps> = ({
                                 {node.namespace.namespaceName}
                             </Link>
                             <span className="text-muted d-inline-block mx-1">/</span>
-                            <Link to={`/batch-changes/executions/${node.id}`}>{node.description.name || '-'}</Link>
+                            <Link
+                                to={`${node.namespace.url}/batch-changes/${node.description.name}/executions/${node.id}`}
+                            >
+                                {node.description.name || '-'}
+                            </Link>
                         </>
                     )}
                 </h3>

--- a/client/web/src/enterprise/batches/create/backend.ts
+++ b/client/web/src/enterprise/batches/create/backend.ts
@@ -50,6 +50,9 @@ export const EXECUTE_BATCH_SPEC = gql`
     mutation ExecuteBatchSpec($batchSpec: ID!) {
         executeBatchSpec(batchSpec: $batchSpec) {
             id
+            description {
+                name
+            }
             namespace {
                 url
             }

--- a/client/web/src/enterprise/batches/create/useExecuteBatchSpec.ts
+++ b/client/web/src/enterprise/batches/create/useExecuteBatchSpec.ts
@@ -38,7 +38,9 @@ export const useExecuteBatchSpec = (batchSpecID?: Scalars['ID']): UseExecuteBatc
         submitBatchSpec({ variables: { batchSpec: batchSpecID } })
             .then(({ data }) => {
                 if (data?.executeBatchSpec) {
-                    history.push(`/batch-changes/executions/${data.executeBatchSpec.id}`)
+                    history.push(
+                        `${data.executeBatchSpec.namespace.url}/batch-changes/${data.executeBatchSpec.description.name}/executions/${data.executeBatchSpec.id}`
+                    )
                 }
             })
             .catch(setExecutionError)

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsActionSection.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsActionSection.tsx
@@ -18,6 +18,7 @@ export interface BatchChangeDetailsActionSectionProps extends SettingsCascadePro
     batchChangeID: Scalars['ID']
     batchChangeClosed: boolean
     batchChangeNamespaceURL: string
+    batchChangeURL: string
     history: H.History
 
     /** For testing only. */
@@ -28,6 +29,7 @@ export const BatchChangeDetailsActionSection: React.FunctionComponent<BatchChang
     batchChangeID,
     batchChangeClosed,
     batchChangeNamespaceURL,
+    batchChangeURL,
     history,
     settingsCascade,
     deleteBatchChange = _deleteBatchChange,
@@ -65,12 +67,12 @@ export const BatchChangeDetailsActionSection: React.FunctionComponent<BatchChang
     return (
         <div className="d-flex">
             {showEditButton && (
-                <Button to={`${location.pathname}/edit`} className="mr-2" variant="secondary" as={Link}>
+                <Button to={`${batchChangeURL}/edit`} className="mr-2" variant="secondary" as={Link}>
                     <PencilIcon className="icon-inline" /> Edit
                 </Button>
             )}
             <Button
-                to={`${location.pathname}/close`}
+                to={`${batchChangeURL}/close`}
                 className="test-batches-close-btn"
                 data-tooltip="View a preview of all changes that will happen when you close this batch change."
                 variant="danger"

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
@@ -128,6 +128,7 @@ export const BatchChangeDetailsPage: React.FunctionComponent<BatchChangeDetailsP
                         batchChangeClosed={!!batchChange.closedAt}
                         deleteBatchChange={deleteBatchChange}
                         batchChangeNamespaceURL={batchChange.namespace.url}
+                        batchChangeURL={batchChange.url}
                         history={history}
                         settingsCascade={props.settingsCascade}
                     />

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
@@ -21,7 +21,7 @@ import { Description } from '../Description'
 
 import { deleteBatchChange as _deleteBatchChange, BATCH_CHANGE_BY_NAMESPACE } from './backend'
 import { BatchChangeDetailsActionSection } from './BatchChangeDetailsActionSection'
-import { BatchChangeDetailsProps, BatchChangeDetailsTabs } from './BatchChangeDetailsTabs'
+import { BatchChangeDetailsProps, BatchChangeDetailsTabs, TabName } from './BatchChangeDetailsTabs'
 import { BatchChangeInfoByline } from './BatchChangeInfoByline'
 import { BatchChangeStatsCard } from './BatchChangeStatsCard'
 import { BulkOperationsAlerts } from './BulkOperationsAlerts'
@@ -36,6 +36,8 @@ export interface BatchChangeDetailsPageProps extends BatchChangeDetailsProps, Se
     namespaceID: Scalars['ID']
     /** The batch change name. */
     batchChangeName: BatchChangeFields['name']
+    /** The name of the tab that should be initially open */
+    initialTab?: TabName
     /** For testing only. */
     deleteBatchChange?: typeof _deleteBatchChange
 }

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
@@ -38,7 +38,10 @@ import { BatchChangeChangesets } from './changesets/BatchChangeChangesets'
 export enum TabName {
     Changesets = 'changesets',
     Chart = 'chart',
+    // Non-SSBC
     Spec = 'spec',
+    // SSBC-only
+    Executions = 'executions',
     Archived = 'archived',
     BulkOperations = 'bulkoperations',
 }
@@ -51,6 +54,8 @@ export interface BatchChangeDetailsProps
         TelemetryProps {
     history: H.History
     location: H.Location
+    /** The name of the tab that should be initially open */
+    initialTab?: TabName
 
     /** For testing only. */
     queryExternalChangesetWithFileDiffs?: typeof _queryExternalChangesetWithFileDiffs
@@ -73,6 +78,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<BatchChangeDetailsT
     location,
     platformContext,
     settingsCascade,
+    initialTab = TabName.Changesets,
     queryChangesetCountsOverTime,
     queryExternalChangesetWithFileDiffs,
     queryAllChangesetIDs,
@@ -86,7 +92,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<BatchChangeDetailsT
         false
 
     return (
-        <BatchChangeTabs history={history} location={location}>
+        <BatchChangeTabs history={history} location={location} initialTab={initialTab}>
             <BatchChangeTabList>
                 <BatchChangeTab index={0} name={TabName.Changesets}>
                     <span>
@@ -118,11 +124,11 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<BatchChangeDetailsT
                     </BatchChangeTab>
                 )}
                 {executionEnabled && (
-                    <BatchChangeTab index={2} name={TabName.Spec}>
+                    <BatchChangeTab index={2} name={TabName.Executions} customPath="/executions">
                         <span>
                             <FileDocumentIcon className="icon-inline text-muted mr-1" />{' '}
-                            <span className="text-content" data-tab-content="Specs">
-                                Specs
+                            <span className="text-content" data-tab-content="Executions">
+                                Executions
                             </span>
                         </span>
                     </BatchChangeTab>

--- a/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
@@ -121,7 +121,7 @@ export const BatchSpecExecutionDetailsPage: React.FunctionComponent<BatchSpecExe
             <Switch>
                 <Route render={() => <Redirect to={`${match.url}/execution`} />} path={match.url} exact={true} />
                 <Route
-                    path={`${match.url}/edit`}
+                    path={`${match.url}/spec`}
                     render={() => (
                         <EditPage
                             name={batchSpec.description.name}
@@ -159,7 +159,7 @@ const TabBar: React.FunctionComponent<{ url: string; batchSpec: BatchSpecExecuti
     <div className="mb-3">
         <ul className="nav nav-tabs d-inline-flex d-sm-flex flex-nowrap text-nowrap">
             <li className="nav-item">
-                <RouterLink to={`${url}/edit`} role="button" activeClassName="active" className="nav-link">
+                <RouterLink to={`${url}/spec`} role="button" activeClassName="active" className="nav-link">
                     {/* TODO: Rename to edit once this IS an editor. */}
                     <span className="text-content" data-tab-content="1. Batch spec">
                         1. Batch spec

--- a/client/web/src/enterprise/batches/global/GlobalBatchChangesArea.tsx
+++ b/client/web/src/enterprise/batches/global/GlobalBatchChangesArea.tsx
@@ -16,6 +16,7 @@ import { HeroPage } from '../../../components/HeroPage'
 import type { BatchChangeClosePageProps } from '../close/BatchChangeClosePage'
 import type { CreateBatchChangePageProps } from '../create/CreateBatchChangePage'
 import type { BatchChangeDetailsPageProps } from '../detail/BatchChangeDetailsPage'
+import { TabName } from '../detail/BatchChangeDetailsTabs'
 import type { BatchSpecExecutionDetailsPageProps } from '../execution/BatchSpecExecutionDetailsPage'
 import type { BatchChangeListPageProps, NamespaceBatchChangeListPageProps } from '../list/BatchChangeListPage'
 import type { BatchChangePreviewPageProps } from '../preview/BatchChangePreviewPage'
@@ -54,8 +55,8 @@ const DotcomGettingStartedPage = lazyComponent<DotcomGettingStartedPageProps, 'D
     () => import('./DotcomGettingStartedPage'),
     'DotcomGettingStartedPage'
 )
-interface Props
-    extends RouteComponentProps<{}>,
+interface Props<RouteProps extends {} = {}>
+    extends RouteComponentProps<RouteProps>,
         ThemeProps,
         ExtensionsControllerProps,
         TelemetryProps,
@@ -92,22 +93,11 @@ export const AuthenticatedBatchChangesArea = withAuthenticatedUser<Authenticated
             render={props => <CreateBatchChangePage headingElement="h1" {...outerProps} {...props} />}
             exact={true}
         />
-        <Route
-            path={`${match.url}/executions/:batchSpecID`}
-            render={({ match, ...props }: RouteComponentProps<{ batchSpecID: string }>) => (
-                <BatchSpecExecutionDetailsPage
-                    {...outerProps}
-                    {...props}
-                    match={match}
-                    batchSpecID={match.params.batchSpecID}
-                />
-            )}
-        />
         <Route component={NotFoundPage} key="hardcoded-key" />
     </Switch>
 ))
 
-export interface NamespaceBatchChangesAreaProps extends Props {
+export interface NamespaceBatchChangesAreaProps<RouteProps = {}> extends Props<RouteProps> {
     namespaceID: Scalars['ID']
 }
 
@@ -171,3 +161,17 @@ export const NamespaceBatchChangesArea = withAuthenticatedUser<
         </Switch>
     </div>
 ))
+
+export interface ExecutionAreaProps extends NamespaceBatchChangesAreaProps<{ batchSpecID: string }> {}
+
+/**
+ * This is just a dumb hack to work around the namespaces header that is preserved on
+ * original, non-SSBC pages but omitted from newer, SSBC ones, which bring their own
+ * header. Eventually all BC pages should supply their own header, at which point this can
+ * be removed.
+ */
+export const ExecutionArea = withAuthenticatedUser<ExecutionAreaProps & { authenticatedUser: AuthenticatedUser }>(
+    ({ match, namespaceID, ...outerProps }) => (
+        <BatchSpecExecutionDetailsPage {...outerProps} match={match} batchSpecID={match.params.batchSpecID} />
+    )
+)

--- a/client/web/src/enterprise/batches/global/GlobalBatchChangesArea.tsx
+++ b/client/web/src/enterprise/batches/global/GlobalBatchChangesArea.tsx
@@ -134,6 +134,18 @@ export const NamespaceBatchChangesArea = withAuthenticatedUser<
                 )}
             />
             <Route
+                path={`${match.url}/:batchChangeName/executions`}
+                render={({ match, ...props }: RouteComponentProps<{ batchChangeName: string }>) => (
+                    <BatchChangeDetailsPage
+                        {...outerProps}
+                        {...props}
+                        namespaceID={namespaceID}
+                        batchChangeName={match.params.batchChangeName}
+                        initialTab={TabName.Executions}
+                    />
+                )}
+            />
+            <Route
                 path={`${match.url}/:batchChangeName`}
                 render={({ match, ...props }: RouteComponentProps<{ batchChangeName: string }>) => (
                     <BatchChangeDetailsPage

--- a/client/web/src/enterprise/organizations/routes.tsx
+++ b/client/web/src/enterprise/organizations/routes.tsx
@@ -7,12 +7,17 @@ import { OrgAreaPageProps, OrgAreaRoute } from '../../org/area/OrgArea'
 import { orgAreaRoutes } from '../../org/area/routes'
 import { CreateBatchChangePageProps } from '../batches/create/CreateBatchChangePage'
 import { CreateOrEditBatchChangePageProps } from '../batches/create/CreateOrEditBatchChangePage'
-import { NamespaceBatchChangesAreaProps } from '../batches/global/GlobalBatchChangesArea'
+import { NamespaceBatchChangesAreaProps, ExecutionAreaProps } from '../batches/global/GlobalBatchChangesArea'
 import { enterpriseNamespaceAreaRoutes } from '../namespaces/routes'
 
 const NamespaceBatchChangesArea = lazyComponent<NamespaceBatchChangesAreaProps, 'NamespaceBatchChangesArea'>(
     () => import('../batches/global/GlobalBatchChangesArea'),
     'NamespaceBatchChangesArea'
+)
+
+const ExecutionArea = lazyComponent<ExecutionAreaProps, 'ExecutionArea'>(
+    () => import('../batches/global/GlobalBatchChangesArea'),
+    'ExecutionArea'
 )
 
 const CreateOrEditBatchChangePage = lazyComponent<CreateOrEditBatchChangePageProps, 'CreateOrEditBatchChangePage'>(
@@ -42,6 +47,15 @@ export const enterpriseOrganizationAreaRoutes: readonly OrgAreaRoute[] = [
                 initialNamespaceID={props.org.id}
                 batchChangeName={match.params.batchChangeName}
             />
+        ),
+        condition: ({ batchChangesEnabled, batchChangesExecutionEnabled }) =>
+            batchChangesEnabled && batchChangesExecutionEnabled,
+        fullPage: true,
+    },
+    {
+        path: '/batch-changes/:batchChangeName/executions/:batchSpecID',
+        render: (props: OrgAreaPageProps & RouteComponentProps<{ batchSpecID: string }>) => (
+            <ExecutionArea {...props} namespaceID={props.org.id} />
         ),
         condition: ({ batchChangesEnabled, batchChangesExecutionEnabled }) =>
             batchChangesEnabled && batchChangesExecutionEnabled,

--- a/client/web/src/enterprise/user/routes.tsx
+++ b/client/web/src/enterprise/user/routes.tsx
@@ -7,13 +7,18 @@ import { userAreaRoutes } from '../../user/area/routes'
 import { UserAreaRoute, UserAreaRouteContext } from '../../user/area/UserArea'
 import { CreateBatchChangePageProps } from '../batches/create/CreateBatchChangePage'
 import { CreateOrEditBatchChangePageProps } from '../batches/create/CreateOrEditBatchChangePage'
-import { NamespaceBatchChangesAreaProps } from '../batches/global/GlobalBatchChangesArea'
+import { ExecutionAreaProps, NamespaceBatchChangesAreaProps } from '../batches/global/GlobalBatchChangesArea'
 import { SHOW_BUSINESS_FEATURES } from '../dotcom/productSubscriptions/features'
 import { enterpriseNamespaceAreaRoutes } from '../namespaces/routes'
 
 const NamespaceBatchChangesArea = lazyComponent<NamespaceBatchChangesAreaProps, 'NamespaceBatchChangesArea'>(
     () => import('../batches/global/GlobalBatchChangesArea'),
     'NamespaceBatchChangesArea'
+)
+
+const ExecutionArea = lazyComponent<ExecutionAreaProps, 'ExecutionArea'>(
+    () => import('../batches/global/GlobalBatchChangesArea'),
+    'ExecutionArea'
 )
 
 const CreateOrEditBatchChangePage = lazyComponent<CreateOrEditBatchChangePageProps, 'CreateOrEditBatchChangePage'>(
@@ -56,6 +61,15 @@ export const enterpriseUserAreaRoutes: readonly UserAreaRoute[] = [
                 initialNamespaceID={props.user.id}
                 batchChangeName={match.params.batchChangeName}
             />
+        ),
+        condition: ({ batchChangesEnabled, batchChangesExecutionEnabled }) =>
+            batchChangesEnabled && batchChangesExecutionEnabled,
+        fullPage: true,
+    },
+    {
+        path: '/batch-changes/:batchChangeName/executions/:batchSpecID',
+        render: (props: UserAreaRouteContext & RouteComponentProps<{ batchSpecID: string }>) => (
+            <ExecutionArea {...props} namespaceID={props.user.id} />
         ),
         condition: ({ batchChangesEnabled, batchChangesExecutionEnabled }) =>
             batchChangesEnabled && batchChangesExecutionEnabled,


### PR DESCRIPTION
Follows from https://github.com/sourcegraph/sourcegraph/issues/28939, closes https://github.com/sourcegraph/sourcegraph/issues/29688! 🎉

Most of our pages were already accessible at the right paths, so here are the changes:
- `/{user|orgs}/:ownerName/batch-changes/:name?tab=spec` ➡️ `/{users|orgs}/:ownerName/batch-changes/:name/executions`
  - This is the details page with the batch spec executions list tab open.
  - `?tab=executions` will also still work, but the idea is that this URL path would be more stable in the future even if the executions list view moves out of `<Tabs />`.
  - The legacy URL `?tab=spec` is now reserved for when server-side execution is disabled.
  - I decided to leave the other tab URLs (e.g. `?tab=burndown` ➡️ `/burndown`) alone for now because they'd be easier to change in the future and we would want to maintain backwards compatibility anyway.
- `/batch-changes/executions/:executionID` ➡️ `/{users|orgs}/:ownerName/batch-changes/:name/executions/:executionID`
  - This is the execution details page.
  - Because it now lives in the `Org|UserNamespaceArea`, I had to hack around that namespace header and narrow page layout again... 🙄 I'm looking forward to when we give every BC page the SSBC design treatment and have them bring their own page header. This should get significantly less complicated then.
- `/batch-changes/executions/:executionID/edit` ➡️ `/{users|orgs}/:ownerName/batch-changes/:name/executions/:executionID/spec`
  - This is the execution details page with the read-only spec focused.
  - In order to edit the spec, you would navigate back to `/{users|orgs}/:ownerName/batch-changes/:name/edit`. This workflow will become more obvious in EM3.5 once we incorporate the actual editor into this execution view.

## Test plan

These changes are experimental behind a feature flag and should not impact existing customers, so I only went as far as to verify the intended functionality locally myself.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


