### PR TITLE
batches: resolve batch specs connection with newest specs first

### DIFF
--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -1459,6 +1459,7 @@ func (r *Resolver) BatchSpecs(ctx context.Context, args *graphqlbackend.ListBatc
 		LimitOpts: store.LimitOpts{
 			Limit: int(args.First),
 		},
+		NewestFirst: true,
 	}
 
 	// 🚨 SECURITY: If the user is not an admin, we don't want to include

--- a/enterprise/internal/batches/store/batch_specs.go
+++ b/enterprise/internal/batches/store/batch_specs.go
@@ -440,6 +440,10 @@ ON
 		preds = append(preds, sqlf.Sprintf("batch_specs.id >= %s", opts.Cursor))
 	}
 
+	if len(preds) == 0 {
+		preds = append(preds, sqlf.Sprintf("TRUE"))
+	}
+
 	return sqlf.Sprintf(
 		listBatchSpecsQueryFmtstr+opts.LimitOpts.ToDB(),
 		sqlf.Join(batchSpecColumns, ", "),


### PR DESCRIPTION
Noticed we had missed the `NewestFirst` parameter on the batch specs connection resolver, which I think we definitely want in both places we ask for batch specs in the UI. 👀

It also broke with `NewestFirst: true` but no cursor, oops. 😬 So fixed that and added tests.

## Test plan

Teeessssstttsssss!!!

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


