### PR TITLE
batches: align editor header border

### DIFF
--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.module.scss
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.module.scss
@@ -19,7 +19,10 @@
 }
 
 .workspaces-preview-container {
-    padding-top: 0.25rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-left: 1rem;
     background: none;
     border: none;
     min-width: 300px;
@@ -27,9 +30,14 @@
     max-width: 700px;
 }
 
+// Should mostly match WorkspacesPreview header and LibraryPane header
 .header {
-    align-self: flex-start;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
     width: 100%;
     padding-bottom: 0.5rem;
+    margin-bottom: 0.5rem;
     border-bottom: 1px solid var(--border-color);
+    overflow: hidden;
 }

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -380,7 +380,7 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({ batchChange, refetch
             description={batchChange.description}
             actionButtons={actionButtons}
         >
-            <div className={classNames(styles.editorLayoutContainer, 'd-flex flex-1')}>
+            <div className={classNames(styles.editorLayoutContainer, 'd-flex flex-1 mt-2')}>
                 <LibraryPane name={batchChange.name} onReplaceItem={clearErrorsAndHandleCodeChange} />
                 <div className={styles.editorContainer}>
                     <h4 className={styles.header}>Batch spec</h4>
@@ -395,12 +395,7 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({ batchChange, refetch
                         errors={compact([codeErrors.update, codeErrors.validation, previewError, executeError])}
                     />
                 </div>
-                <div
-                    className={classNames(
-                        styles.workspacesPreviewContainer,
-                        'd-flex flex-column align-items-center pl-4'
-                    )}
-                >
+                <div className={styles.workspacesPreviewContainer}>
                     <WorkspacesPreview
                         previewDisabled={previewDisabled}
                         preview={() => previewBatchSpec(debouncedCode)}

--- a/client/web/src/enterprise/batches/create/library/LibraryPane.module.scss
+++ b/client/web/src/enterprise/batches/create/library/LibraryPane.module.scss
@@ -9,6 +9,10 @@
     // Match this to the value in JS
     width: 1.25rem;
     z-index: 1000;
+    display: flex;
+    align-items: center;
+    height: 1rem;
+    overflow: visible;
 }
 
 .library-item {
@@ -23,10 +27,14 @@
     padding: 0;
 }
 
+// Should mostly match WorkspacesPreview header and Editor header
 .header {
-    align-self: flex-start;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     width: 100%;
     padding-bottom: 0.5rem;
+    margin-bottom: 0.5rem;
     border-bottom: 1px solid var(--border-color);
     overflow: hidden;
 }

--- a/client/web/src/enterprise/batches/create/library/LibraryPane.tsx
+++ b/client/web/src/enterprise/batches/create/library/LibraryPane.tsx
@@ -103,9 +103,9 @@ export const LibraryPane: React.FunctionComponent<LibraryPaneProps> = ({ name, o
                     onConfirm={onConfirm}
                 />
             ) : null}
-            <animated.div style={containerStyle} className="d-flex flex-column mr-1">
-                <div className="d-flex align-items-center justify-content-center pb-1">
-                    <animated.h4 className={styles.header} style={headerStyle}>
+            <animated.div style={containerStyle} className="d-flex flex-column mr-3">
+                <div className={styles.header}>
+                    <animated.h4 className="m-0" style={headerStyle}>
                         Library
                     </animated.h4>
                     <div className={styles.collapseButton}>

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.module.scss
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.module.scss
@@ -1,8 +1,15 @@
+// Should mostly match LibraryPane header and Editor header
 .header {
     align-self: flex-start;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
     width: 100%;
     padding-bottom: 0.5rem;
+    margin-bottom: 0.5rem;
     border-bottom: 1px solid var(--border-color);
+    overflow: hidden;
 }
 
 .icon-container {

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.module.scss
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.module.scss
@@ -10,6 +10,13 @@
     margin-bottom: 0.5rem;
     border-bottom: 1px solid var(--border-color);
     overflow: hidden;
+
+    .warning-icon {
+        // The warning icon is very bottom-heavy visually, so we give it the slightest
+        // nudge above technical vertical center alignment so that it "appears" more
+        // centered.
+        margin-top: -0.125rem;
+    }
 }
 
 .icon-container {

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.tsx
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.tsx
@@ -209,7 +209,7 @@ export const WorkspacesPreview: React.FunctionComponent<WorkspacesPreviewProps> 
                 Workspaces preview{' '}
                 {(batchSpecStale || !hasPreviewed) && shouldShowConnection && !isWorkspacesPreviewInProgress && (
                     <WarningIcon
-                        className="icon-inline text-muted"
+                        className={classNames('icon-inline text-muted ml-1', styles.warningIcon)}
                         data-tooltip="The workspaces previewed below may not be up-to-date."
                     />
                 )}


### PR DESCRIPTION
Fixes the vertical alignment of the header borders across the SSBC editor columns, as well as the alignment of the `LibraryPane` button and the column spacing:

Before | After
:------:|:-----:
![Screen Shot 2022-02-18 at 3 42 18 PM](https://user-images.githubusercontent.com/8942601/154775681-026bc4a0-1671-4a56-9d0e-c9b6fb27e41a.png) | ![Screen Shot 2022-02-18 at 3 47 39 PM](https://user-images.githubusercontent.com/8942601/154775687-37210b33-29ac-48f0-945f-fec32faad984.png)


## Test plan

This feature is experimental and behind a flag so poses no risk to actual customers. I only verified the changes visually, as is captured in the screenshots above.


