### PR TITLE
search: construct Zoekt query from expression type

### DIFF
--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -143,7 +143,7 @@ func TestDisplayLimit(t *testing.T) {
 				pingTickerInterval:  1 * time.Millisecond,
 				newSearchResolver: func(_ context.Context, _ database.DB, args *graphqlbackend.SearchArgs) (searchResolver, error) {
 					mock.c = args.Stream
-					q, err := query.Parse(c.queryString, query.Literal)
+					q, err := query.Parse(c.queryString, query.SearchTypeLiteral)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/internal/search/query/labels.go
+++ b/internal/search/query/labels.go
@@ -7,7 +7,7 @@ type labels uint16
 
 const (
 	None    labels = 0
-	Literal        = 1 << iota
+	Literal labels = 1 << iota
 	Regexp
 	Quoted
 	HeuristicParensAsPatterns


### PR DESCRIPTION
See inline explanation

## Test plan
Semantics-preserving, covered by existing tests.


