### PR TITLE
dev: unable to update insiders tag

### DIFF
--- a/dev/sg/internal/images/images.go
+++ b/dev/sg/internal/images/images.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Masterminds/semver"
 	"github.com/distribution/distribution/v3/reference"
 	"github.com/docker/docker-credential-helpers/credentials"
 	"github.com/opencontainers/go-digest"
@@ -376,7 +377,7 @@ func createAndFillImageRepository(ref *ImageReference, pinTag string) (repo *ima
 		latestTag = findLatestTag(tags)
 	}
 
-	if latestTag == ref.Tag || latestTag == "" {
+	if _, err := semver.NewVersion(latestTag); err == nil && (latestTag == ref.Tag || latestTag == "") {
 		return repo, ErrNoUpdateNeeded
 	}
 	repo.imageRef.Tag = latestTag

--- a/dev/sg/internal/images/images.go
+++ b/dev/sg/internal/images/images.go
@@ -372,17 +372,26 @@ func createAndFillImageRepository(ref *ImageReference, pinTag string) (repo *ima
 		Tag:      ref.Tag,
 	}
 
-	latestTag := pinTag
-	if pinTag == "" {
-		latestTag = findLatestTag(tags)
+	var targetTag string
+	isDevTag := pinTag == ""
+	if isDevTag {
+		targetTag = findLatestTag(tags)
+	} else {
+		targetTag = pinTag
 	}
 
-	if _, err := semver.NewVersion(latestTag); err == nil && (latestTag == ref.Tag || latestTag == "") {
+	_, semverErr := semver.NewVersion(targetTag)
+	isReleaseTag := semverErr == nil
+	isAlreadyLatest := targetTag == ref.Tag
+	// for release build, we use semver tags and they are immutable, so no update is needed if the current tag is the same as target tag
+	// for dev builds, if the current tag is the same as the latest tag, also no update is needed
+	// for mutable tags (neither release nor dev tag, e.g. `insiders`), we always need to fetch the latest digest.
+	if (isReleaseTag || isDevTag) && isAlreadyLatest {
 		return repo, ErrNoUpdateNeeded
 	}
-	repo.imageRef.Tag = latestTag
+	repo.imageRef.Tag = targetTag
 
-	dig, err := repo.fetchDigest(latestTag)
+	dig, err := repo.fetchDigest(targetTag)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION

## Test plan

Create a `values.yaml` somewhere

```yaml
migrator:
  image:
    defaultTag: insiders@sha256:18fb43c040e91bce06d8123e0f859cdfb1eded897f5c0b3a138864d9a885c1eb
    name: "migrator"
```

```bash
go run ./dev/sg ops update-images -kind helm /path/to/directory/of/values/yaml/.
```

Before the change, the command will fail with no update is needed.

After the change, it will be able to fetch the latest digest of `insiders` tag.


