### PR TITLE
doc/dev: dont reload prometheus with sg override

### DIFF
--- a/doc/dev/how-to/monitoring_local_dev.md
+++ b/doc/dev/how-to/monitoring_local_dev.md
@@ -37,10 +37,13 @@ commands:
   prometheus:
     # install can just be set up gcloud credentials for a cluster
     # e.g. https://handbook.sourcegraph.com/departments/product-engineering/engineering/process/deployments/instances
-    install: |
-      gcloud container clusters get-credentials ...
-    cmd: |
-      kubectl port-forward svc/prometheus 9090:30090
+    install: gcloud container clusters get-credentials ...
+    # make remote prometheus accessible to local grafana
+    cmd: kubectl port-forward svc/prometheus 9090:30090
+  monitoring-generator:
+    env:
+      # don't reload your production Prometheus!
+      PROMETHEUS_DIR: ''
 ```
 
 Then, you can start up the local dev monitoring stack by using:


### PR DESCRIPTION
As I was hacking on https://github.com/sourcegraph/sourcegraph/pull/31518 I realized... the monitoring generator might have been reloading the remote prometheus instance I was connected to 😰  This updates the sg override config snippet to disable prometheus reload.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

With the provided config snippet:

```
sg start monitoring
```

Should no longer see Prometheus reload messages 😁 