### PR TITLE
dev/ci: set GOPROXY everywhere

### DIFF
--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -18,8 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/ci/operations"
 )
 
-var goAthensProxyURL = "http://athens-athens-proxy"
-
 // CoreTestOperationsOptions should be used ONLY to adjust the behaviour of specific steps,
 // e.g. by adding flags, and not as a condition for adding steps or commands.
 type CoreTestOperationsOptions struct {
@@ -340,7 +338,6 @@ func addGoTests(pipeline *bk.Pipeline) {
 	buildGoTests(func(description, testSuffix string) {
 		pipeline.AddStep(
 			fmt.Sprintf(":go: Test (%s)", description),
-			bk.Env("GOPROXY", goAthensProxyURL),
 			bk.Cmd("./dev/ci/go-test.sh "+testSuffix),
 			bk.Cmd("./dev/ci/codecov.sh -c -F go"),
 		)
@@ -352,10 +349,8 @@ func addGoTestsBackcompat(minimumUpgradeableVersion string) func(pipeline *bk.Pi
 	return func(pipeline *bk.Pipeline) {
 		buildGoTests(func(description, testSuffix string) {
 			pipeline.AddStep(
-				// TODO - set minimum upgradeable version
 				fmt.Sprintf(":go::postgres: Backcompat test (%s)", description),
 				bk.Env("MINIMUM_UPGRADEABLE_VERSION", minimumUpgradeableVersion),
-				bk.Env("GOPROXY", goAthensProxyURL),
 				bk.Cmd("./dev/ci/go-backcompat/test.sh "+testSuffix),
 			)
 		})
@@ -391,7 +386,6 @@ func buildGoTests(f func(description, testSuffix string)) {
 // Builds the OSS and Enterprise Go commands.
 func addGoBuild(pipeline *bk.Pipeline) {
 	pipeline.AddStep(":go: Build",
-		bk.Env("GOPROXY", goAthensProxyURL),
 		bk.Cmd("./dev/ci/go-build.sh"),
 	)
 }

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -41,6 +41,10 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		"DATE":                               c.Time.Format(time.RFC3339),
 		"VERSION":                            c.Version,
 
+		// Use athens proxy for go modules downloads
+		// https://github.com/sourcegraph/infrastructure/blob/main/buildkite/kubernetes/athens-proxy/athens-athens-proxy.Deployment.yaml
+		"GOPROXY": "http://athens-athens-proxy",
+
 		// Additional flags
 		"GO111MODULE": "on",
 		"FORCE_COLOR": "3",


### PR DESCRIPTION
Follow-up to https://github.com/sourcegraph/sourcegraph/pull/28900 - noticed that we can just set this for all steps, rather than manually provide it for specific ones. Also adds a link to the proxy deployment - this was provided in a PR comment but not in the actual code (https://github.com/sourcegraph/sourcegraph/pull/28900#discussion_r771394216)

Just for fun, writing reading through this stuff for a personal blog thing : )

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

`main-dry-run`: https://buildkite.com/sourcegraph/sourcegraph/builds/132991