### PR TITLE
dev: sg is more friendly with fish user

### DIFF
--- a/dev/sg/internal/usershell/usershell.go
+++ b/dev/sg/internal/usershell/usershell.go
@@ -80,3 +80,8 @@ func Cmd(ctx context.Context, cmd string) *exec.Cmd {
 func CombinedExec(ctx context.Context, cmd string) ([]byte, error) {
 	return Cmd(ctx, cmd).CombinedOutput()
 }
+
+func IsSupportedShell(ctx context.Context) bool {
+	shell := ShellPath(ctx)
+	return strings.Contains(shell, "bash") || strings.Contains(shell, "zsh")
+}

--- a/dev/sg/sg_setup.go
+++ b/dev/sg/sg_setup.go
@@ -52,6 +52,15 @@ func setupExec(ctx context.Context, args []string) error {
 		return err
 	}
 
+	if ok := usershell.IsSupportedShell(ctx); !ok {
+		writeFailureLinef("This command is only supported on `bash` and `zsh`.")
+		shellPath := usershell.ShellPath(ctx)
+		if strings.Contains(shellPath, "fish") {
+			writeFingerPointingLinef("Are you a %s shell user? You may run `SHELL=(which zsh) sg setup` or `SHELL=(which bash) sg setup`.", output.EmojiFish)
+		}
+		return errors.Newf("unsupported shell %s", shellPath)
+	}
+
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
 	go func() {

--- a/lib/output/emoji.go
+++ b/lib/output/emoji.go
@@ -14,4 +14,5 @@ const (
 	EmojiShrug            = "🤷"
 	EmojiOk               = "👌"
 	EmojiQuestionMark     = "❔"
+	EmojiFish             = "🐟"
 )


### PR DESCRIPTION

## Test plan

For 🐟 shell user, running `sg start` or `sg setup` no longer yields unexpected errors that are hard to debug

Before this change, whenever `fish` users run `sg setup` or `sg start`, they will never get pass the sanity check

```
❌ Check "git" failed with the following errors:
unexpected output from git server: source: '/Users/michael' is not a file
git version 2.35.1
```

```

https://github.com/sourcegraph/sourcegraph/blob/df97baa8fad061107fdd7d088d6edb40f5de38d4/dev/sg/internal/usershell/usershell.go#L73-L76

https://github.com/sourcegraph/sourcegraph/blob/df97baa8fad061107fdd7d088d6edb40f5de38d4/dev/sg/internal/usershell/usershell.go#L48-L53

I don't think we could support `fish` due to the fact their syntax is not quite compatible. 
