### PR TITLE
dev: support fish shell in sg

### DIFF
--- a/dev/sg/checks.go
+++ b/dev/sg/checks.go
@@ -78,6 +78,15 @@ func runChecks(ctx context.Context, checks map[string]check.CheckFunc) error {
 		return err
 	}
 
+	// Scripts used in various CheckFuncs are typically written with bash-compatible shells in mind.
+	// Because of this, we throw a warning in non-compatible shells and ask that
+	// users set up environments in both their shell and bash to avoid issues.
+	if !usershell.IsSupportedShell(ctx) {
+		shell := usershell.ShellType(ctx)
+		writeWarningLinef("You're running on unsupported shell '%s'.", shell)
+		writeWarningLinef("If you run into error, you may run 'SHELL=(which bash) sg setup' to setup your environment.")
+	}
+
 	var failed []string
 
 	for name, check := range checks {

--- a/dev/sg/internal/usershell/usershell.go
+++ b/dev/sg/internal/usershell/usershell.go
@@ -16,8 +16,17 @@ import (
 
 type key struct{}
 
+type Shell string
+
+const (
+	BashShell Shell = "bash"
+	ZshShell  Shell = "zsh"
+	FishShell Shell = "fish"
+)
+
 // userShell stores which shell and which configuration file a user is using.
 type userShell struct {
+	shell           Shell
 	shellPath       string
 	shellConfigPath string
 }
@@ -34,25 +43,32 @@ func ShellConfigPath(ctx context.Context) string {
 	return v.shellConfigPath
 }
 
+// Shell returns the current shell type used by the current unix user.
+func ShellType(ctx context.Context) Shell {
+	v := ctx.Value(key{}).(userShell)
+	return v.shell
+}
+
 // GuessUserShell inspect the current environment to infer the shell the current user is running
 // and which configuration file it depends on.
-func GuessUserShell() (string, string, error) {
+func GuessUserShell() (shellPath string, shellrc string, shell Shell, error error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 	// Look up which shell the user is using, because that's most likely the
 	// one that has all the environment correctly setup.
-	shell, ok := os.LookupEnv("SHELL")
-	var shellrc string
+	shellPath, ok := os.LookupEnv("SHELL")
 	if !ok {
 		// If we can't find the shell in the environment, we fall back to `bash`
-		shell = "bash"
+		shellPath = "bash"
+		shell = BashShell
 	}
 	switch {
-	case strings.Contains(shell, "bash"):
+	case strings.Contains(shellPath, "bash"):
 		shellrc = ".bashrc"
-	case strings.Contains(shell, "zsh"):
+		shell = BashShell
+	case strings.Contains(shellPath, "zsh"):
 		if _, err := os.Stat(path.Join(home, ".zshrc")); errors.Is(err, os.ErrNotExist) {
 			// A fresh mac installation with standard homebrew will tell the user to append
 			// the configuration in .zprofile, not .zshrc.
@@ -60,17 +76,22 @@ func GuessUserShell() (string, string, error) {
 		} else {
 			shellrc = ".zshrc"
 		}
+		shell = ZshShell
+	case strings.Contains(shellPath, "fish"):
+		shellrc = ".config/fish/config.fish"
+		shell = FishShell
 	}
-	return shell, filepath.Join(home, shellrc), nil
+	return shellPath, filepath.Join(home, shellrc), shell, nil
 }
 
 // Context extends ctx with the UserContext of the current user.
 func Context(ctx context.Context) (context.Context, error) {
-	shell, shellConfigPath, err := GuessUserShell()
+	shell, shellConfigPath, shellType, err := GuessUserShell()
 	if err != nil {
 		return nil, err
 	}
 	userCtx := userShell{
+		shell:           shellType,
 		shellPath:       shell,
 		shellConfigPath: shellConfigPath,
 	}
@@ -81,6 +102,10 @@ func Context(ctx context.Context) (context.Context, error) {
 // changes added by various checks to be run. This negates the new to ask the
 // user to restart sg for many checks.
 func Cmd(ctx context.Context, cmd string) *exec.Cmd {
+	if ShellType(ctx) == FishShell {
+		command := fmt.Sprintf("fish || true; %s", cmd)
+		return exec.CommandContext(ctx, ShellPath(ctx), "-c", command)
+	}
 	if runtime.GOOS == "linux" {
 		// The default Ubuntu bashrc comes with a caveat that prevents the bashrc to be
 		// reloaded unless the shell is interactive. Therefore, we need to request for an
@@ -107,4 +132,10 @@ func CombinedExec(ctx context.Context, cmd string) ([]byte, error) {
 		return nil, errors.Errorf("can't execute empty command")
 	}
 	return Cmd(ctx, cmd).CombinedOutput()
+}
+
+// IsSupportedShell returns true if the given shell is supported by sg-cli
+func IsSupportedShell(ctx context.Context) bool {
+	shell := ShellType(ctx)
+	return shell == BashShell || shell == ZshShell
 }


### PR DESCRIPTION
## The problem

For 🐟 shell user, running `sg start` or `sg setup` yields unexpected errors that are hard to understand

Whenever `fish` users run `sg setup` or `sg start`, they will never get past the sanity check because the cli will try to `source` a non-existing `ShellConfigPath` file.

```
❌ Check "git" failed with the following errors:
unexpected output from git server: source: '/Users/michael' is not a file
git version 2.35.1
```
```
⋊> ~/C/s/sourcegraph on main ◦ go run ./dev/sg start                                                             15:16:46
💡 Running 4 checks...
✅ Check "docker" success!
✅ Check "redis" success!
✅ Check "postgres" success!
❌ Check "git" failed with the following errors:
unexpected output from git server: source: '/Users/michael' is not a file
git version 2.35.1
```

https://github.com/sourcegraph/sourcegraph/blob/df97baa8fad061107fdd7d088d6edb40f5de38d4/dev/sg/internal/usershell/usershell.go#L73-L76

https://github.com/sourcegraph/sourcegraph/blob/df97baa8fad061107fdd7d088d6edb40f5de38d4/dev/sg/internal/usershell/usershell.go#L48-L53

I started trying to get `sg` to work with `fish`. With this commit

- `sg setup` should work nicely with `fish`
- `sg start` will no longer error out right away provided they have followed `sg setup` to install all dependencies

However,  they still may not be able to run Sourcegraph unless their `bash` environment is also configured properly. This can be verified by running  `SHELL=(which bash) go run ./dev/sg setup`.

When running `sg setup` or `sg start`, it first tries to verify dependencies based on the `$PATH` available in the `fish` shell. However, when it comes to invoking scripts or commands defined `sg.config.yaml`, these commands are always run in a fresh bash shell via `bash -c` (this is expected because some of the scripts such as `caddy` only work with bash-compatible shell). This is problematic when the user doesn't have things like asdf-shim setup properly under `bash` but only `fish`. `fish` users will end up seeing error complaining fail to meet `go` or `node` version constraint because `asdf` is not configured properly in `.bashrc` and `.tool-versions` is not picked up automatically.

The workaround for `fish` user is first setting up the `asdf` and other dependencies in `bash` by running `SHELL=(which bash) go run ./dev/sg setup`, then `fish` users will be able to just run `sg start`.

~Maybe we can add a warning message for `fish` shell users to run `sg setup` in `bash` to double-check they have the correct environment setup? An alternative is just don't support `fish`, and do this https://github.com/sourcegraph/sourcegraph/pull/31537~

## Implementation

I ended up adding a warning message during `checks` if user is running on unsupported shell (neither `bash` nor `zsh`) to let users know they're on an unsupported path and they should run `SHELL=(which bash) sg setup` to setup their environment in case of error.

## Test plan

On `fish` shell, assuming both `fish` and `bash` has all dependencies configured properly

This should just work

```sh
go run ./dev/sg start
```

You should see

```
⋊> ~/C/s/sourcegraph on 02-19-dev_add_fish_support_to_sg ⨯ go run ./dev/sg start                                                                                                                                                             12:17:54
💡 Running 4 checks...
⚠️ You're running on unsupported shell `fish`.
⚠️ If you run into error, you may run `SHELL=(which bash) sg setup` to setup your environment.
✅ Check "docker" success!
⠹  Running check "redis"...
```