### PR TITLE
batches: introduce SSBC execution status pills

### DIFF
--- a/client/web/src/enterprise/batches/BatchSpecNode.tsx
+++ b/client/web/src/enterprise/batches/BatchSpecNode.tsx
@@ -64,7 +64,7 @@ export const BatchSpecNode: React.FunctionComponent<BatchSpecNodeProps> = ({
                         </>
                     )}
                     {currentSpecID && (
-                        <Link to={`/batch-changes/executions/${node.id}`}>
+                        <Link to={`${node.namespace.url}/batch-changes/${node.description.name}/executions/${node.id}`}>
                             Executed by <strong>{node.creator?.username}</strong>{' '}
                             <Timestamp date={node.createdAt} now={now} />
                         </Link>
@@ -75,7 +75,11 @@ export const BatchSpecNode: React.FunctionComponent<BatchSpecNodeProps> = ({
                                 {node.namespace.namespaceName}
                             </Link>
                             <span className="text-muted d-inline-block mx-1">/</span>
-                            <Link to={`/batch-changes/executions/${node.id}`}>{node.description.name || '-'}</Link>
+                            <Link
+                                to={`${node.namespace.url}/batch-changes/${node.description.name}/executions/${node.id}`}
+                            >
+                                {node.description.name || '-'}
+                            </Link>
                         </>
                     )}
                 </h3>

--- a/client/web/src/enterprise/batches/create/backend.ts
+++ b/client/web/src/enterprise/batches/create/backend.ts
@@ -50,6 +50,9 @@ export const EXECUTE_BATCH_SPEC = gql`
     mutation ExecuteBatchSpec($batchSpec: ID!) {
         executeBatchSpec(batchSpec: $batchSpec) {
             id
+            description {
+                name
+            }
             namespace {
                 url
             }

--- a/client/web/src/enterprise/batches/create/useExecuteBatchSpec.ts
+++ b/client/web/src/enterprise/batches/create/useExecuteBatchSpec.ts
@@ -38,7 +38,9 @@ export const useExecuteBatchSpec = (batchSpecID?: Scalars['ID']): UseExecuteBatc
         submitBatchSpec({ variables: { batchSpec: batchSpecID } })
             .then(({ data }) => {
                 if (data?.executeBatchSpec) {
-                    history.push(`/batch-changes/executions/${data.executeBatchSpec.id}`)
+                    history.push(
+                        `${data.executeBatchSpec.namespace.url}/batch-changes/${data.executeBatchSpec.description.name}/executions/${data.executeBatchSpec.id}`
+                    )
                 }
             })
             .catch(setExecutionError)

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
@@ -21,7 +21,7 @@ import { Description } from '../Description'
 
 import { deleteBatchChange as _deleteBatchChange, BATCH_CHANGE_BY_NAMESPACE } from './backend'
 import { BatchChangeDetailsActionSection } from './BatchChangeDetailsActionSection'
-import { BatchChangeDetailsProps, BatchChangeDetailsTabs } from './BatchChangeDetailsTabs'
+import { BatchChangeDetailsProps, BatchChangeDetailsTabs, TabName } from './BatchChangeDetailsTabs'
 import { BatchChangeInfoByline } from './BatchChangeInfoByline'
 import { BatchChangeStatsCard } from './BatchChangeStatsCard'
 import { BulkOperationsAlerts } from './BulkOperationsAlerts'
@@ -36,6 +36,8 @@ export interface BatchChangeDetailsPageProps extends BatchChangeDetailsProps, Se
     namespaceID: Scalars['ID']
     /** The batch change name. */
     batchChangeName: BatchChangeFields['name']
+    /** The name of the tab that should be initially open */
+    initialTab?: TabName
     /** For testing only. */
     deleteBatchChange?: typeof _deleteBatchChange
 }

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
@@ -38,7 +38,10 @@ import { BatchChangeChangesets } from './changesets/BatchChangeChangesets'
 export enum TabName {
     Changesets = 'changesets',
     Chart = 'chart',
+    // Non-SSBC
     Spec = 'spec',
+    // SSBC-only
+    Executions = 'executions',
     Archived = 'archived',
     BulkOperations = 'bulkoperations',
 }
@@ -51,6 +54,8 @@ export interface BatchChangeDetailsProps
         TelemetryProps {
     history: H.History
     location: H.Location
+    /** The name of the tab that should be initially open */
+    initialTab?: TabName
 
     /** For testing only. */
     queryExternalChangesetWithFileDiffs?: typeof _queryExternalChangesetWithFileDiffs
@@ -73,6 +78,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<BatchChangeDetailsT
     location,
     platformContext,
     settingsCascade,
+    initialTab = TabName.Changesets,
     queryChangesetCountsOverTime,
     queryExternalChangesetWithFileDiffs,
     queryAllChangesetIDs,
@@ -86,7 +92,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<BatchChangeDetailsT
         false
 
     return (
-        <BatchChangeTabs history={history} location={location}>
+        <BatchChangeTabs history={history} location={location} initialTab={initialTab}>
             <BatchChangeTabList>
                 <BatchChangeTab index={0} name={TabName.Changesets}>
                     <span>
@@ -118,11 +124,11 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<BatchChangeDetailsT
                     </BatchChangeTab>
                 )}
                 {executionEnabled && (
-                    <BatchChangeTab index={2} name={TabName.Spec}>
+                    <BatchChangeTab index={2} name={TabName.Executions} customPath="/executions">
                         <span>
                             <FileDocumentIcon className="icon-inline text-muted mr-1" />{' '}
-                            <span className="text-content" data-tab-content="Specs">
-                                Specs
+                            <span className="text-content" data-tab-content="Executions">
+                                Executions
                             </span>
                         </span>
                     </BatchChangeTab>

--- a/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
@@ -121,7 +121,7 @@ export const BatchSpecExecutionDetailsPage: React.FunctionComponent<BatchSpecExe
             <Switch>
                 <Route render={() => <Redirect to={`${match.url}/execution`} />} path={match.url} exact={true} />
                 <Route
-                    path={`${match.url}/edit`}
+                    path={`${match.url}/spec`}
                     render={() => (
                         <EditPage
                             name={batchSpec.description.name}
@@ -159,7 +159,7 @@ const TabBar: React.FunctionComponent<{ url: string; batchSpec: BatchSpecExecuti
     <div className="mb-3">
         <ul className="nav nav-tabs d-inline-flex d-sm-flex flex-nowrap text-nowrap">
             <li className="nav-item">
-                <RouterLink to={`${url}/edit`} role="button" activeClassName="active" className="nav-link">
+                <RouterLink to={`${url}/spec`} role="button" activeClassName="active" className="nav-link">
                     {/* TODO: Rename to edit once this IS an editor. */}
                     <span className="text-content" data-tab-content="1. Batch spec">
                         1. Batch spec

--- a/client/web/src/enterprise/batches/global/GlobalBatchChangesArea.tsx
+++ b/client/web/src/enterprise/batches/global/GlobalBatchChangesArea.tsx
@@ -16,6 +16,7 @@ import { HeroPage } from '../../../components/HeroPage'
 import type { BatchChangeClosePageProps } from '../close/BatchChangeClosePage'
 import type { CreateBatchChangePageProps } from '../create/CreateBatchChangePage'
 import type { BatchChangeDetailsPageProps } from '../detail/BatchChangeDetailsPage'
+import { TabName } from '../detail/BatchChangeDetailsTabs'
 import type { BatchSpecExecutionDetailsPageProps } from '../execution/BatchSpecExecutionDetailsPage'
 import type { BatchChangeListPageProps, NamespaceBatchChangeListPageProps } from '../list/BatchChangeListPage'
 import type { BatchChangePreviewPageProps } from '../preview/BatchChangePreviewPage'
@@ -54,8 +55,8 @@ const DotcomGettingStartedPage = lazyComponent<DotcomGettingStartedPageProps, 'D
     () => import('./DotcomGettingStartedPage'),
     'DotcomGettingStartedPage'
 )
-interface Props
-    extends RouteComponentProps<{}>,
+interface Props<RouteProps extends {} = {}>
+    extends RouteComponentProps<RouteProps>,
         ThemeProps,
         ExtensionsControllerProps,
         TelemetryProps,
@@ -92,22 +93,11 @@ export const AuthenticatedBatchChangesArea = withAuthenticatedUser<Authenticated
             render={props => <CreateBatchChangePage headingElement="h1" {...outerProps} {...props} />}
             exact={true}
         />
-        <Route
-            path={`${match.url}/executions/:batchSpecID`}
-            render={({ match, ...props }: RouteComponentProps<{ batchSpecID: string }>) => (
-                <BatchSpecExecutionDetailsPage
-                    {...outerProps}
-                    {...props}
-                    match={match}
-                    batchSpecID={match.params.batchSpecID}
-                />
-            )}
-        />
         <Route component={NotFoundPage} key="hardcoded-key" />
     </Switch>
 ))
 
-export interface NamespaceBatchChangesAreaProps extends Props {
+export interface NamespaceBatchChangesAreaProps<RouteProps = {}> extends Props<RouteProps> {
     namespaceID: Scalars['ID']
 }
 
@@ -171,3 +161,17 @@ export const NamespaceBatchChangesArea = withAuthenticatedUser<
         </Switch>
     </div>
 ))
+
+export interface ExecutionAreaProps extends NamespaceBatchChangesAreaProps<{ batchSpecID: string }> {}
+
+/**
+ * This is just a dumb hack to work around the namespaces header that is preserved on
+ * original, non-SSBC pages but omitted from newer, SSBC ones, which bring their own
+ * header. Eventually all BC pages should supply their own header, at which point this can
+ * be removed.
+ */
+export const ExecutionArea = withAuthenticatedUser<ExecutionAreaProps & { authenticatedUser: AuthenticatedUser }>(
+    ({ match, namespaceID, ...outerProps }) => (
+        <BatchSpecExecutionDetailsPage {...outerProps} match={match} batchSpecID={match.params.batchSpecID} />
+    )
+)

--- a/client/web/src/enterprise/batches/global/GlobalBatchChangesArea.tsx
+++ b/client/web/src/enterprise/batches/global/GlobalBatchChangesArea.tsx
@@ -134,6 +134,18 @@ export const NamespaceBatchChangesArea = withAuthenticatedUser<
                 )}
             />
             <Route
+                path={`${match.url}/:batchChangeName/executions`}
+                render={({ match, ...props }: RouteComponentProps<{ batchChangeName: string }>) => (
+                    <BatchChangeDetailsPage
+                        {...outerProps}
+                        {...props}
+                        namespaceID={namespaceID}
+                        batchChangeName={match.params.batchChangeName}
+                        initialTab={TabName.Executions}
+                    />
+                )}
+            />
+            <Route
                 path={`${match.url}/:batchChangeName`}
                 render={({ match, ...props }: RouteComponentProps<{ batchChangeName: string }>) => (
                     <BatchChangeDetailsPage

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.module.scss
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.module.scss
@@ -16,4 +16,21 @@
             row-gap: 0.5rem;
         }
     }
+
+    // A variant of the above grid but with a wider first column for the state pill
+    &__grid-wide {
+        display: grid;
+        grid-template-columns: [state] 100px [info] minmax(auto, 1fr) [open] min-content [closed] min-content [merged] min-content [end];
+        row-gap: 1rem;
+        column-gap: 1.5rem;
+        align-items: center;
+        @media (--sm-breakpoint-down) {
+            // Reduce gap on sm and xs screens.
+            column-gap: 1rem;
+        }
+        @media (--xs-breakpoint-down) {
+            // Reduce gap on xs screens.
+            row-gap: 0.5rem;
+        }
+    }
 }

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.module.scss
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.module.scss
@@ -1,36 +1,26 @@
 @import 'wildcard/src/global-styles/breakpoints';
 
-.batch-change-list-page {
-    &__grid {
-        display: grid;
-        grid-template-columns: [state] 70px [info] minmax(auto, 1fr) [open] min-content [closed] min-content [merged] min-content [end];
-        row-gap: 1rem;
-        column-gap: 1.5rem;
-        align-items: center;
-        @media (--sm-breakpoint-down) {
-            // Reduce gap on sm and xs screens.
-            column-gap: 1rem;
-        }
-        @media (--xs-breakpoint-down) {
-            // Reduce gap on xs screens.
-            row-gap: 0.5rem;
-        }
+.grid {
+    display: grid;
+    row-gap: 1rem;
+    column-gap: 1.5rem;
+    align-items: center;
+    @media (--sm-breakpoint-down) {
+        // Reduce gap on sm and xs screens.
+        column-gap: 1rem;
     }
+    @media (--xs-breakpoint-down) {
+        // Reduce gap on xs screens.
+        row-gap: 0.5rem;
+    }
+}
 
-    // A variant of the above grid but with a wider first column for the state pill
-    &__grid-wide {
-        display: grid;
-        grid-template-columns: [state] 100px [info] minmax(auto, 1fr) [open] min-content [closed] min-content [merged] min-content [end];
-        row-gap: 1rem;
-        column-gap: 1.5rem;
-        align-items: center;
-        @media (--sm-breakpoint-down) {
-            // Reduce gap on sm and xs screens.
-            column-gap: 1rem;
-        }
-        @media (--xs-breakpoint-down) {
-            // Reduce gap on xs screens.
-            row-gap: 0.5rem;
-        }
-    }
+// A wider first column for the new execution state pill.
+.wide {
+    grid-template-columns: [state] 100px [info] minmax(auto, 1fr) [open] min-content [closed] min-content [merged] min-content [end];
+}
+
+// A narrower first column for the original state badge.
+.narrow {
+    grid-template-columns: [state] 70px [info] minmax(auto, 1fr) [open] min-content [closed] min-content [merged] min-content [end];
 }

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.story.tsx
@@ -10,7 +10,7 @@ import { WebStory } from '../../../components/WebStory'
 import { BatchChangeListPage } from './BatchChangeListPage'
 import { nodes } from './testData'
 
-const { add } = storiesOf('web/batches/BatchChangeListPage', module)
+const { add } = storiesOf('web/batches/list/BatchChangeListPage', module)
     .addDecorator(story => <div className="p-3 container">{story()}</div>)
     .addParameters({
         chromatic: {

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.story.tsx
@@ -48,6 +48,26 @@ add('List of batch changes', () => (
     </WebStory>
 ))
 
+add('List of batch changes, server-side execution enabled', () => (
+    <WebStory>
+        {props => (
+            <BatchChangeListPage
+                {...props}
+                headingElement="h1"
+                canCreate={true}
+                queryBatchChanges={queryBatchChanges}
+                areBatchChangesLicensed={batchChangesLicensed}
+                settingsCascade={{
+                    ...EMPTY_SETTINGS_CASCADE,
+                    final: {
+                        experimentalFeatures: { batchChangesExecution: true },
+                    },
+                }}
+            />
+        )}
+    </WebStory>
+))
+
 add('Licensing not enforced', () => (
     <WebStory>
         {props => (

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -104,7 +104,7 @@ export const BatchChangeListPage: React.FunctionComponent<BatchChangeListPagePro
 }) => {
     useEffect(() => props.telemetryService.logViewEvent('BatchChangesListPage'), [props.telemetryService])
 
-    const showDrafts = isBatchChangesExecutionEnabled(settingsCascade)
+    const executionEnabled = isBatchChangesExecutionEnabled(settingsCascade)
 
     /*
      * Tracks whether this is the first fetch since this page has been rendered the first time.
@@ -160,11 +160,13 @@ export const BatchChangeListPage: React.FunctionComponent<BatchChangeListPagePro
                         {...props}
                         location={location}
                         nodeComponent={BatchChangeNode}
-                        nodeComponentProps={{ displayNamespace }}
+                        nodeComponentProps={{ displayNamespace, executionEnabled }}
                         queryConnection={query}
                         hideSearch={true}
                         defaultFirst={15}
-                        filters={getFilters(showDrafts)}
+                        // Drafts are a new feature of severside execution that for now
+                        // should not be shown otherwise.
+                        filters={getFilters(executionEnabled)}
                         noun="batch change"
                         pluralNoun="batch changes"
                         listComponent="div"
@@ -260,7 +262,6 @@ const BatchChangeListTabHeader: React.FunctionComponent<{
         <div className="overflow-auto mb-2">
             <ul className="nav nav-tabs d-inline-flex d-sm-flex flex-nowrap text-nowrap">
                 <li className="nav-item">
-                    {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                     <Link
                         to=""
                         onClick={onSelectBatchChanges}
@@ -273,7 +274,6 @@ const BatchChangeListTabHeader: React.FunctionComponent<{
                     </Link>
                 </li>
                 <li className="nav-item">
-                    {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                     <Link
                         to=""
                         onClick={onSelectGettingStarted}

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -170,9 +170,7 @@ export const BatchChangeListPage: React.FunctionComponent<BatchChangeListPagePro
                         noun="batch change"
                         pluralNoun="batch changes"
                         listComponent="div"
-                        listClassName={
-                            executionEnabled ? styles.batchChangeListPageGridWide : styles.batchChangeListPageGrid
-                        }
+                        listClassName={classNames(styles.grid, executionEnabled ? styles.wide : styles.narrow)}
                         withCenteredSummary={true}
                         cursorPaging={true}
                         noSummaryIfAllNodesVisible={true}

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -170,7 +170,9 @@ export const BatchChangeListPage: React.FunctionComponent<BatchChangeListPagePro
                         noun="batch change"
                         pluralNoun="batch changes"
                         listComponent="div"
-                        listClassName={styles.batchChangeListPageGrid}
+                        listClassName={
+                            executionEnabled ? styles.batchChangeListPageGridWide : styles.batchChangeListPageGrid
+                        }
                         withCenteredSummary={true}
                         cursorPaging={true}
                         noSummaryIfAllNodesVisible={true}

--- a/client/web/src/enterprise/batches/list/BatchChangeNode.module.scss
+++ b/client/web/src/enterprise/batches/list/BatchChangeNode.module.scss
@@ -1,6 +1,7 @@
 @import 'wildcard/src/global-styles/breakpoints';
 
 .batch-change-node {
+    // Old state badge
     &__badge {
         justify-self: center;
         padding-left: 0.5rem;
@@ -9,6 +10,13 @@
             width: fit-content;
             // Make it full width in the current row.
             grid-column: 1 / -1;
+        }
+    }
+    // New SSBC state pill
+    &__pill {
+        justify-self: center;
+        @media (--xs-breakpoint-down) {
+            justify-self: flex-start;
         }
     }
     &__title {

--- a/client/web/src/enterprise/batches/list/BatchChangeNode.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeNode.story.tsx
@@ -11,7 +11,7 @@ import styles from './BatchChangeListPage.module.scss'
 import { BatchChangeNode } from './BatchChangeNode'
 import { nodes, now } from './testData'
 
-const { add } = storiesOf('web/batches/BatchChangeNode', module).addDecorator(story => (
+const { add } = storiesOf('web/batches/list/BatchChangeNode', module).addDecorator(story => (
     <div className={classNames(styles.batchChangeListPageGrid, 'p-3 container')}>{story()}</div>
 ))
 

--- a/client/web/src/enterprise/batches/list/BatchChangeNode.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeNode.story.tsx
@@ -12,7 +12,7 @@ import { BatchChangeNode } from './BatchChangeNode'
 import { nodes, now } from './testData'
 
 const { add } = storiesOf('web/batches/list/BatchChangeNode', module).addDecorator(story => (
-    <div className={classNames(styles.batchChangeListPageGrid, 'p-3 container')}>{story()}</div>
+    <div className={classNames(styles.grid, styles.narrow, 'p-3 container')}>{story()}</div>
 ))
 
 for (const key of Object.keys(nodes)) {

--- a/client/web/src/enterprise/batches/list/BatchChangeNode.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeNode.story.tsx
@@ -24,6 +24,7 @@ for (const key of Object.keys(nodes)) {
                     node={nodes[key]}
                     displayNamespace={boolean('Display namespace', true)}
                     now={isChromatic() ? () => subDays(now, 5) : undefined}
+                    executionEnabled={false}
                 />
             )}
         </WebStory>

--- a/client/web/src/enterprise/batches/list/BatchChangeNode.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeNode.tsx
@@ -17,6 +17,7 @@ import styles from './BatchChangeNode.module.scss'
 
 export interface BatchChangeNodeProps {
     node: ListBatchChange
+    executionEnabled: boolean
     /** Used for testing purposes. Sets the current date */
     now?: () => Date
     displayNamespace: boolean

--- a/client/web/src/enterprise/batches/list/BatchChangeNode.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeNode.tsx
@@ -90,10 +90,16 @@ export const BatchChangeNode: React.FunctionComponent<BatchChangeNodeProps> = ({
             case BatchSpecState.PROCESSING:
             case BatchSpecState.FAILED:
                 return `${node.url}/executions/${latestExecution.id}`
+            case BatchSpecState.COMPLETED:
+                // If the latest spec hasn't been applied, we take you to the preview
+                // page. Otherwise, we just take you tot he details page.
+                return node.currentSpec.id === latestExecution?.id
+                    ? node.url
+                    : `${node.url}/executions/${latestExecution.id}/preview`
             default:
                 return node.url
         }
-    }, [executionEnabled, node.url, node.state, latestExecution])
+    }, [executionEnabled, node.url, node.state, node.currentSpec, latestExecution])
 
     return (
         <>

--- a/client/web/src/enterprise/batches/list/BatchChangeNode.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeNode.tsx
@@ -6,7 +6,12 @@ import { Markdown } from '@sourcegraph/shared/src/components/Markdown'
 import { Badge, Link } from '@sourcegraph/wildcard'
 
 import { Timestamp } from '../../../components/time/Timestamp'
-import { BatchChangeState, BatchSpecState, ListBatchChange } from '../../../graphql-operations'
+import {
+    BatchChangeState,
+    BatchSpecState,
+    ListBatchChange,
+    ListBatchChangeLatestSpecFields,
+} from '../../../graphql-operations'
 import {
     ChangesetStatusOpen,
     ChangesetStatusClosed,
@@ -60,7 +65,9 @@ export const BatchChangeNode: React.FunctionComponent<BatchChangeNodeProps> = ({
     now = () => new Date(),
     displayNamespace,
 }) => {
-    const latestExecution = useMemo(() => node.batchSpecs.nodes[0], [node.batchSpecs.nodes])
+    const latestExecution: ListBatchChangeLatestSpecFields | undefined = useMemo(() => node.batchSpecs.nodes?.[0], [
+        node.batchSpecs.nodes,
+    ])
 
     // The URL to follow when a batch change is clicked on depends on the current state
     // and execution state.
@@ -90,7 +97,7 @@ export const BatchChangeNode: React.FunctionComponent<BatchChangeNodeProps> = ({
             case BatchSpecState.COMPLETED:
                 // If it hasn't been applied, we take you to the preview page. Otherwise,
                 // we just take you to the details page.
-                return node.currentSpec.id === latestExecution?.id
+                return node.currentSpec.id === latestExecution.id
                     ? node.url
                     : `${node.url}/executions/${latestExecution.id}/preview`
             default:

--- a/client/web/src/enterprise/batches/list/BatchChangeNode.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeNode.tsx
@@ -1,12 +1,12 @@
 import classNames from 'classnames'
-import React from 'react'
+import React, { useMemo } from 'react'
 
 import { renderMarkdown } from '@sourcegraph/common'
 import { Markdown } from '@sourcegraph/shared/src/components/Markdown'
 import { Badge, Link } from '@sourcegraph/wildcard'
 
 import { Timestamp } from '../../../components/time/Timestamp'
-import { BatchChangeState, ListBatchChange } from '../../../graphql-operations'
+import { BatchChangeState, BatchSpecState, ListBatchChange } from '../../../graphql-operations'
 import {
     ChangesetStatusOpen,
     ChangesetStatusClosed,
@@ -14,6 +14,7 @@ import {
 } from '../detail/changesets/ChangesetStatusCell'
 
 import styles from './BatchChangeNode.module.scss'
+import { BatchChangeStatePill } from './BatchChangeStatePill'
 
 export interface BatchChangeNodeProps {
     node: ListBatchChange
@@ -52,59 +53,110 @@ const StateBadge: React.FunctionComponent<{ state: BatchChangeState }> = ({ stat
  */
 export const BatchChangeNode: React.FunctionComponent<BatchChangeNodeProps> = ({
     node,
+    executionEnabled,
     now = () => new Date(),
     displayNamespace,
-}) => (
-    <>
-        <span className={styles.batchChangeNodeSeparator} />
-        <StateBadge state={node.state} />
-        <div className={styles.batchChangeNodeContent}>
-            <div className="m-0 d-md-flex d-block align-items-baseline">
-                <h3 className={classNames(styles.batchChangeNodeTitle, 'm-0 d-md-inline-block d-block')}>
-                    {displayNamespace && (
-                        <div className="d-md-inline-block d-block">
-                            <Link
-                                className="text-muted test-batches-namespace-link"
-                                to={`${node.namespace.url}/batch-changes`}
-                            >
-                                {node.namespace.namespaceName}
-                            </Link>
-                            <span className="text-muted d-inline-block mx-1">/</span>
-                        </div>
+}) => {
+    const latestExecution = useMemo(() => node.batchSpecs.nodes[0], [node.batchSpecs.nodes])
+
+    // The URL to follow when a batch change is clicked on depends on the current state
+    // and execution state.
+    const nodeLink = useMemo(() => {
+        // Before SSBC, all batch changes took you to the same place, the node detail
+        // page. Closed batch changes also take you to this page.
+        if (!executionEnabled || node.state === BatchChangeState.CLOSED) {
+            return node.url
+        }
+
+        const latestExecutionState = latestExecution?.state
+
+        // If the batch change is a draft (has not yet had a spec applied) and the latest
+        // spec has not been executed, we take you to the editor page to continue working
+        // on it.
+        if (node.state === BatchChangeState.DRAFT && latestExecutionState === BatchSpecState.PENDING) {
+            return `${node.url}/edit`
+        }
+
+        switch (latestExecutionState) {
+            // If the latest spec hasn't been executed yet...
+            case BatchSpecState.PENDING:
+                // If it's a draft (no spec has been applied yet), we take you to the
+                // editor page to continue working on it. Otherwise, we just take you to
+                // the details page.
+                return node.state === BatchChangeState.DRAFT ? `${node.url}/edit` : node.url
+            // If the latest spec is in the middle of execution, or failed, we take you to
+            // the execution details page.
+            case BatchSpecState.QUEUED:
+            case BatchSpecState.PROCESSING:
+            case BatchSpecState.FAILED:
+                return `${node.url}/executions/${latestExecution.id}`
+            default:
+                return node.url
+        }
+    }, [executionEnabled, node.url, node.state, latestExecution])
+
+    return (
+        <>
+            <span className={styles.batchChangeNodeSeparator} />
+            {executionEnabled ? (
+                <BatchChangeStatePill
+                    state={node.state}
+                    latestExecutionState={node.batchSpecs.nodes[0]?.state}
+                    currentSpecID={node.currentSpec.id}
+                    latestSpecID={latestExecution?.id}
+                    className={styles.batchChangeNodePill}
+                />
+            ) : (
+                <StateBadge state={node.state} />
+            )}
+            <div className={styles.batchChangeNodeContent}>
+                <div className="m-0 d-md-flex d-block align-items-baseline">
+                    <h3 className={classNames(styles.batchChangeNodeTitle, 'm-0 d-md-inline-block d-block')}>
+                        {displayNamespace && (
+                            <div className="d-md-inline-block d-block">
+                                <Link
+                                    className="text-muted test-batches-namespace-link"
+                                    to={`${node.namespace.url}/batch-changes`}
+                                >
+                                    {node.namespace.namespaceName}
+                                </Link>
+                                <span className="text-muted d-inline-block mx-1">/</span>
+                            </div>
+                        )}
+                        <Link className="test-batches-link mr-2" to={nodeLink}>
+                            {node.name}
+                        </Link>
+                    </h3>
+                    <small className="text-muted d-sm-block">
+                        created <Timestamp date={node.createdAt} now={now} />
+                    </small>
+                </div>
+                <Markdown
+                    className={classNames(
+                        'text-truncate text-muted d-none d-md-block',
+                        !node.description && 'font-italic'
                     )}
-                    <Link
-                        className="test-batches-link mr-2"
-                        to={`${node.url}${node.state === BatchChangeState.DRAFT ? '/edit' : ''}`}
-                    >
-                        {node.name}
-                    </Link>
-                </h3>
-                <small className="text-muted d-sm-block">
-                    created <Timestamp date={node.createdAt} now={now} />
-                </small>
+                    dangerousInnerHTML={
+                        node.description ? renderMarkdown(node.description, { plainText: true }) : 'No description'
+                    }
+                />
             </div>
-            <Markdown
-                className={classNames('text-truncate text-muted d-none d-md-block', !node.description && 'font-italic')}
-                dangerousInnerHTML={
-                    node.description ? renderMarkdown(node.description, { plainText: true }) : 'No description'
-                }
-            />
-        </div>
-        {node.state !== BatchChangeState.DRAFT && (
-            <>
-                <ChangesetStatusOpen
-                    className="d-block d-sm-flex"
-                    label={<span className="text-muted">{node.changesetsStats.open} open</span>}
-                />
-                <ChangesetStatusClosed
-                    className="d-block d-sm-flex text-center"
-                    label={<span className="text-muted">{node.changesetsStats.closed} closed</span>}
-                />
-                <ChangesetStatusMerged
-                    className="d-block d-sm-flex"
-                    label={<span className="text-muted">{node.changesetsStats.merged} merged</span>}
-                />
-            </>
-        )}
-    </>
-)
+            {node.state !== BatchChangeState.DRAFT && (
+                <>
+                    <ChangesetStatusOpen
+                        className="d-block d-sm-flex"
+                        label={<span className="text-muted">{node.changesetsStats.open} open</span>}
+                    />
+                    <ChangesetStatusClosed
+                        className="d-block d-sm-flex text-center"
+                        label={<span className="text-muted">{node.changesetsStats.closed} closed</span>}
+                    />
+                    <ChangesetStatusMerged
+                        className="d-block d-sm-flex"
+                        label={<span className="text-muted">{node.changesetsStats.merged} merged</span>}
+                    />
+                </>
+            )}
+        </>
+    )
+}

--- a/client/web/src/enterprise/batches/list/BatchChangeNode.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeNode.tsx
@@ -24,6 +24,9 @@ export interface BatchChangeNodeProps {
     displayNamespace: boolean
 }
 
+// This is the original, pre-SSBC version of the state badge. It has been superseded by
+// `BatchChangeStatePill` and should be removed once SSBC is not longer behind a feature
+// flag.
 const StateBadge: React.FunctionComponent<{ state: BatchChangeState }> = ({ state }) => {
     switch (state) {
         case BatchChangeState.OPEN:
@@ -70,13 +73,6 @@ export const BatchChangeNode: React.FunctionComponent<BatchChangeNodeProps> = ({
 
         const latestExecutionState = latestExecution?.state
 
-        // If the batch change is a draft (has not yet had a spec applied) and the latest
-        // spec has not been executed, we take you to the editor page to continue working
-        // on it.
-        if (node.state === BatchChangeState.DRAFT && latestExecutionState === BatchSpecState.PENDING) {
-            return `${node.url}/edit`
-        }
-
         switch (latestExecutionState) {
             // If the latest spec hasn't been executed yet...
             case BatchSpecState.PENDING:
@@ -90,9 +86,10 @@ export const BatchChangeNode: React.FunctionComponent<BatchChangeNodeProps> = ({
             case BatchSpecState.PROCESSING:
             case BatchSpecState.FAILED:
                 return `${node.url}/executions/${latestExecution.id}`
+            // If the latest spec finished execution successfully...
             case BatchSpecState.COMPLETED:
-                // If the latest spec hasn't been applied, we take you to the preview
-                // page. Otherwise, we just take you tot he details page.
+                // If it hasn't been applied, we take you to the preview page. Otherwise,
+                // we just take you to the details page.
                 return node.currentSpec.id === latestExecution?.id
                     ? node.url
                     : `${node.url}/executions/${latestExecution.id}/preview`

--- a/client/web/src/enterprise/batches/list/BatchChangeStatePill.module.scss
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatePill.module.scss
@@ -1,41 +1,41 @@
 .pill-group {
     display: flex;
-    // The .05 is to prevent a tiny gap from forming
-    border-radius: calc(var(--badge-border-radius) * 2.05);
+    border-radius: calc(var(--badge-border-radius) * 1.5);
     border-width: 2px;
     border-style: solid;
+    overflow: hidden;
 
     &.open {
+        background-color: var(--success);
         border-color: var(--success);
     }
 
     &.draft {
+        background-color: var(--secondary);
         border-color: var(--secondary);
     }
 
     &.closed {
+        background-color: var(--danger);
         border-color: var(--danger);
     }
 
     .state-pill {
-        padding: 0.25rem 0.5rem;
+        padding: 0.125rem 0.375rem;
         text-transform: uppercase;
-
-        &:not(:last-child) {
-            border-top-right-radius: 0;
-            border-bottom-right-radius: 0;
-        }
+        border-radius: 0;
+        border: none;
     }
 
     .execution-pill {
         display: flex;
         align-items: center;
-        padding: 0 0.25rem;
-        border-top-left-radius: 0;
-        border-bottom-left-radius: 0;
+        border: none;
+        border-radius: 0;
+        padding: 0 0.125rem;
 
         .execution-icon {
-            height: 1.125rem;
+            height: 1rem;
         }
     }
 }

--- a/client/web/src/enterprise/batches/list/BatchChangeStatePill.module.scss
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatePill.module.scss
@@ -1,0 +1,41 @@
+.pill-group {
+    display: flex;
+    // The .05 is to prevent a tiny gap from forming
+    border-radius: calc(var(--badge-border-radius) * 2.05);
+    border-width: 2px;
+    border-style: solid;
+
+    &.open {
+        border-color: var(--success);
+    }
+
+    &.draft {
+        border-color: var(--secondary);
+    }
+
+    &.closed {
+        border-color: var(--danger);
+    }
+
+    .state-pill {
+        padding: 0.25rem 0.5rem;
+        text-transform: uppercase;
+
+        &:not(:last-child) {
+            border-top-right-radius: 0;
+            border-bottom-right-radius: 0;
+        }
+    }
+
+    .execution-pill {
+        display: flex;
+        align-items: center;
+        padding: 0 0.25rem;
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+
+        .execution-icon {
+            height: 1.125rem;
+        }
+    }
+}

--- a/client/web/src/enterprise/batches/list/BatchChangeStatePill.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatePill.story.tsx
@@ -23,7 +23,7 @@ const buildTestProps = (
     latestSpecID: isApplied ? `${firstID}` : `${firstID + 1}`,
 })
 
-// Some of these state combinations shouldn't be possible (e.g. Failed and Applied), but
+// Some of these state combinations shouldn't be possible (e.g. failed and applied), but
 // it's easier to include them just in case.
 const STATE_COMBINATIONS: BatchChangeStatePillProps[] = Object.values(BatchChangeState).flatMap((state, index) =>
     // Latest execution state will be undefined if the batch change was executed locally

--- a/client/web/src/enterprise/batches/list/BatchChangeStatePill.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatePill.story.tsx
@@ -11,44 +11,49 @@ const { add } = storiesOf('web/batches/list', module).addDecorator(story => (
     <div className="p-3 container">{story()}</div>
 ))
 
-const STATE_COMBINATIONS: BatchChangeStatePillProps[] = [
-    { state: BatchChangeState.DRAFT },
-    { state: BatchChangeState.DRAFT, latestExecutionState: BatchSpecState.PENDING },
-    { state: BatchChangeState.DRAFT, latestExecutionState: BatchSpecState.QUEUED },
-    { state: BatchChangeState.DRAFT, latestExecutionState: BatchSpecState.PROCESSING },
-    { state: BatchChangeState.DRAFT, latestExecutionState: BatchSpecState.FAILED },
-    { state: BatchChangeState.DRAFT, latestExecutionState: BatchSpecState.COMPLETED },
-    { state: BatchChangeState.DRAFT, latestExecutionState: BatchSpecState.CANCELING },
-    { state: BatchChangeState.DRAFT, latestExecutionState: BatchSpecState.CANCELED },
-    // This state would only come from a batch change executed with src-cli.
-    { state: BatchChangeState.OPEN },
-    { state: BatchChangeState.OPEN, latestExecutionState: BatchSpecState.PENDING },
-    { state: BatchChangeState.OPEN, latestExecutionState: BatchSpecState.QUEUED },
-    { state: BatchChangeState.OPEN, latestExecutionState: BatchSpecState.PROCESSING },
-    { state: BatchChangeState.OPEN, latestExecutionState: BatchSpecState.FAILED },
-    { state: BatchChangeState.OPEN, latestExecutionState: BatchSpecState.COMPLETED },
-    { state: BatchChangeState.OPEN, latestExecutionState: BatchSpecState.CANCELING },
-    { state: BatchChangeState.OPEN, latestExecutionState: BatchSpecState.CANCELED },
-    { state: BatchChangeState.CLOSED },
-    // If it's closed, we don't care about execution state, but let's just check one.
-    { state: BatchChangeState.OPEN, latestExecutionState: BatchSpecState.PENDING },
-]
+const buildTestProps = (
+    state: BatchChangeState,
+    firstID: number,
+    isApplied: boolean,
+    latestExecutionState?: BatchSpecState
+): BatchChangeStatePillProps => ({
+    state,
+    latestExecutionState,
+    currentSpecID: `${firstID}`,
+    latestSpecID: isApplied ? `${firstID}` : `${firstID + 1}`,
+})
+
+// Some of these state combinations shouldn't be possible (e.g. Failed and Applied), but
+// it's easier to include them just in case.
+const STATE_COMBINATIONS: BatchChangeStatePillProps[] = Object.values(BatchChangeState).flatMap((state, index) =>
+    // Latest execution state will be undefined if the batch change was executed locally
+    // with src-cli.
+    [undefined, ...Object.values(BatchSpecState)].flatMap((executionState, innerIndex) => [
+        // Add a version where the latest batch spec has been applied, and one where it
+        // has not.
+        buildTestProps(state, index * 100 + innerIndex, true, executionState),
+        buildTestProps(state, index * 100 + 50 + innerIndex, false, executionState),
+    ])
+)
 
 add('BatchChangeStatePill', () => (
     <WebStory>
         {props => (
             <div className="d-flex flex-column align-items-start">
-                {STATE_COMBINATIONS.map(({ state, latestExecutionState }) => (
+                {STATE_COMBINATIONS.map(({ state, latestExecutionState, currentSpecID, latestSpecID }) => (
                     <React.Fragment key={`${state}-${latestExecutionState || ''}`}>
                         <h3>
                             {upperFirst(state.toLowerCase())}
                             {latestExecutionState ? `, ${upperFirst(latestExecutionState.toLowerCase())}` : ''}
+                            {currentSpecID === latestSpecID ? '' : ' (latest is not applied)'}
                         </h3>
                         <BatchChangeStatePill
                             className="mt-1 mb-3"
                             {...props}
                             state={state}
                             latestExecutionState={latestExecutionState}
+                            currentSpecID={currentSpecID}
+                            latestSpecID={latestSpecID}
                         />
                     </React.Fragment>
                 ))}

--- a/client/web/src/enterprise/batches/list/BatchChangeStatePill.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatePill.story.tsx
@@ -1,0 +1,58 @@
+import { storiesOf } from '@storybook/react'
+import { upperFirst } from 'lodash'
+import React from 'react'
+
+import { WebStory } from '../../../components/WebStory'
+import { BatchChangeState, BatchSpecState } from '../../../graphql-operations'
+
+import { BatchChangeStatePill, BatchChangeStatePillProps } from './BatchChangeStatePill'
+
+const { add } = storiesOf('web/batches/list', module).addDecorator(story => (
+    <div className="p-3 container">{story()}</div>
+))
+
+const STATE_COMBINATIONS: BatchChangeStatePillProps[] = [
+    { state: BatchChangeState.DRAFT },
+    { state: BatchChangeState.DRAFT, latestExecutionState: BatchSpecState.PENDING },
+    { state: BatchChangeState.DRAFT, latestExecutionState: BatchSpecState.QUEUED },
+    { state: BatchChangeState.DRAFT, latestExecutionState: BatchSpecState.PROCESSING },
+    { state: BatchChangeState.DRAFT, latestExecutionState: BatchSpecState.FAILED },
+    { state: BatchChangeState.DRAFT, latestExecutionState: BatchSpecState.COMPLETED },
+    { state: BatchChangeState.DRAFT, latestExecutionState: BatchSpecState.CANCELING },
+    { state: BatchChangeState.DRAFT, latestExecutionState: BatchSpecState.CANCELED },
+    // This state would only come from a batch change executed with src-cli.
+    { state: BatchChangeState.OPEN },
+    { state: BatchChangeState.OPEN, latestExecutionState: BatchSpecState.PENDING },
+    { state: BatchChangeState.OPEN, latestExecutionState: BatchSpecState.QUEUED },
+    { state: BatchChangeState.OPEN, latestExecutionState: BatchSpecState.PROCESSING },
+    { state: BatchChangeState.OPEN, latestExecutionState: BatchSpecState.FAILED },
+    { state: BatchChangeState.OPEN, latestExecutionState: BatchSpecState.COMPLETED },
+    { state: BatchChangeState.OPEN, latestExecutionState: BatchSpecState.CANCELING },
+    { state: BatchChangeState.OPEN, latestExecutionState: BatchSpecState.CANCELED },
+    { state: BatchChangeState.CLOSED },
+    // If it's closed, we don't care about execution state, but let's just check one.
+    { state: BatchChangeState.OPEN, latestExecutionState: BatchSpecState.PENDING },
+]
+
+add('BatchChangeStatePill', () => (
+    <WebStory>
+        {props => (
+            <div className="d-flex flex-column align-items-start">
+                {STATE_COMBINATIONS.map(({ state, latestExecutionState }) => (
+                    <React.Fragment key={`${state}-${latestExecutionState || ''}`}>
+                        <h3>
+                            {upperFirst(state.toLowerCase())}
+                            {latestExecutionState ? `, ${upperFirst(latestExecutionState.toLowerCase())}` : ''}
+                        </h3>
+                        <BatchChangeStatePill
+                            className="mt-1 mb-3"
+                            {...props}
+                            state={state}
+                            latestExecutionState={latestExecutionState}
+                        />
+                    </React.Fragment>
+                ))}
+            </div>
+        )}
+    </WebStory>
+))

--- a/client/web/src/enterprise/batches/list/BatchChangeStatePill.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatePill.tsx
@@ -1,0 +1,115 @@
+import classNames from 'classnames'
+import { includes } from 'lodash'
+import HistoryIcon from 'mdi-react/HistoryIcon'
+import React, { useMemo } from 'react'
+
+import { Badge } from '@sourcegraph/wildcard'
+
+import { BatchChangeState, BatchSpecState } from '../../../graphql-operations'
+
+import styles from './BatchChangeStatePill.module.scss'
+
+export interface BatchChangeStatePillProps {
+    className?: string
+    state: BatchChangeState
+    latestExecutionState?: BatchSpecState
+}
+
+export const BatchChangeStatePill: React.FunctionComponent<BatchChangeStatePillProps> = ({
+    className,
+    state,
+    latestExecutionState,
+}) => {
+    const hasExecutionVisible = useMemo(() => {
+        // If the batch change is closed, we don't show any execution state.
+        if (state === BatchChangeState.CLOSED) {
+            return false
+        }
+        // If the batch change is a draft or open, we show execution state that the user
+        // would want to take action on.
+        return includes(
+            [BatchSpecState.COMPLETED, BatchSpecState.FAILED, BatchSpecState.PROCESSING, BatchSpecState.QUEUED],
+            latestExecutionState
+        )
+    }, [latestExecutionState, state])
+
+    return (
+        <div
+            role="group"
+            className={classNames(styles.pillGroup, className, {
+                [styles.open]: state === BatchChangeState.OPEN,
+                [styles.draft]: state === BatchChangeState.DRAFT,
+                [styles.closed]: state === BatchChangeState.CLOSED,
+            })}
+        >
+            <StatePill state={state} />
+            {hasExecutionVisible && <ExecutionStatePill latestExecutionState={latestExecutionState} />}
+        </div>
+    )
+}
+
+const StatePill: React.FunctionComponent<Pick<BatchChangeStatePillProps, 'state'>> = ({ state }) => {
+    switch (state) {
+        case BatchChangeState.OPEN:
+            return (
+                <Badge variant="success" className={styles.statePill}>
+                    Open
+                </Badge>
+            )
+        case BatchChangeState.CLOSED:
+            return (
+                <Badge variant="danger" className={styles.statePill}>
+                    Closed
+                </Badge>
+            )
+        case BatchChangeState.DRAFT:
+        default:
+            return (
+                <Badge variant="secondary" className={styles.statePill}>
+                    Draft
+                </Badge>
+            )
+    }
+}
+
+const ExecutionStatePill: React.FunctionComponent<Pick<BatchChangeStatePillProps, 'latestExecutionState'>> = ({
+    latestExecutionState,
+}) => {
+    switch (latestExecutionState) {
+        case BatchSpecState.PROCESSING:
+        case BatchSpecState.QUEUED:
+            return (
+                <Badge
+                    variant="warning"
+                    className={styles.executionPill}
+                    data-tooltip={`This batch change has a new spec ${
+                        latestExecutionState === BatchSpecState.QUEUED ? 'queued for execution' : 'preparing to execute'
+                    }.`}
+                >
+                    <HistoryIcon className={styles.executionIcon} />
+                </Badge>
+            )
+
+        case BatchSpecState.COMPLETED:
+            return (
+                <Badge
+                    variant="primary"
+                    className={styles.executionPill}
+                    data-tooltip="This batch change has a newer batch spec execution that is ready to be applied."
+                >
+                    <HistoryIcon className={styles.executionIcon} />
+                </Badge>
+            )
+        case BatchSpecState.FAILED:
+        default:
+            return (
+                <Badge
+                    variant="danger"
+                    className={styles.executionPill}
+                    data-tooltip="The latest batch spec execution for this batch change failed."
+                >
+                    <HistoryIcon className={styles.executionIcon} />
+                </Badge>
+            )
+    }
+}

--- a/client/web/src/enterprise/batches/list/BatchChangesListIntro.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesListIntro.story.tsx
@@ -6,7 +6,7 @@ import { WebStory } from '../../../components/WebStory'
 
 import { BatchChangesListIntro } from './BatchChangesListIntro'
 
-const { add } = storiesOf('web/batches/BatchChangesListIntro', module).addDecorator(story => (
+const { add } = storiesOf('web/batches/list/BatchChangesListIntro', module).addDecorator(story => (
     <div className="p-3 container">{story()}</div>
 ))
 

--- a/client/web/src/enterprise/batches/list/backend.ts
+++ b/client/web/src/enterprise/batches/list/backend.ts
@@ -36,11 +36,16 @@ const listBatchChangeFragment = gql`
         }
         batchSpecs(first: 1) {
             nodes {
-                id
-                state
-                applyURL
+                ...ListBatchChangeLatestSpecFields
             }
         }
+    }
+
+    fragment ListBatchChangeLatestSpecFields on BatchSpec {
+        __typename
+        id
+        state
+        applyURL
     }
 `
 

--- a/client/web/src/enterprise/batches/list/backend.ts
+++ b/client/web/src/enterprise/batches/list/backend.ts
@@ -31,6 +31,16 @@ const listBatchChangeFragment = gql`
             closed
             merged
         }
+        currentSpec {
+            id
+        }
+        batchSpecs(first: 1) {
+            nodes {
+                id
+                state
+                applyURL
+            }
+        }
     }
 `
 

--- a/client/web/src/enterprise/batches/list/testData.ts
+++ b/client/web/src/enterprise/batches/list/testData.ts
@@ -1,6 +1,6 @@
 import { subDays } from 'date-fns'
 
-import { BatchChangeState, ListBatchChange } from '../../../graphql-operations'
+import { BatchChangeState, BatchSpecState, ListBatchChange } from '../../../graphql-operations'
 
 export const now = new Date()
 
@@ -24,6 +24,48 @@ This is my thorough explanation. And it can also get very long, in that case the
             namespaceName: 'alice',
             url: '/users/alice',
         },
+        currentSpec: {
+            id: 'old-spec',
+        },
+        batchSpecs: {
+            nodes: [
+                {
+                    id: 'test',
+                    state: BatchSpecState.PROCESSING,
+                    applyURL: null,
+                },
+            ],
+        },
+    },
+    'Failed draft': {
+        id: 'testdraft',
+        url: '/users/alice/batch-change/test',
+        name: 'Awesome batch',
+        state: BatchChangeState.DRAFT,
+        description: 'The execution of the batch spec failed.',
+        createdAt: subDays(now, 5).toISOString(),
+        closedAt: null,
+        changesetsStats: {
+            open: 10,
+            closed: 0,
+            merged: 5,
+        },
+        namespace: {
+            namespaceName: 'alice',
+            url: '/users/alice',
+        },
+        currentSpec: {
+            id: 'empty-draft',
+        },
+        batchSpecs: {
+            nodes: [
+                {
+                    id: 'test',
+                    state: BatchSpecState.FAILED,
+                    applyURL: null,
+                },
+            ],
+        },
     },
     'No description': {
         id: 'test2',
@@ -41,6 +83,18 @@ This is my thorough explanation. And it can also get very long, in that case the
         namespace: {
             namespaceName: 'alice',
             url: '/users/alice',
+        },
+        currentSpec: {
+            id: 'old-spec',
+        },
+        batchSpecs: {
+            nodes: [
+                {
+                    id: 'test',
+                    state: BatchSpecState.COMPLETED,
+                    applyURL: '/fake-apply-url',
+                },
+            ],
         },
     },
     'Closed batch change': {
@@ -61,6 +115,18 @@ This is my thorough explanation. And it can also get very long, in that case the
         namespace: {
             namespaceName: 'alice',
             url: '/users/alice',
+        },
+        currentSpec: {
+            id: 'test',
+        },
+        batchSpecs: {
+            nodes: [
+                {
+                    id: 'test',
+                    state: BatchSpecState.COMPLETED,
+                    applyURL: '/fake-apply-url',
+                },
+            ],
         },
     },
 }

--- a/client/web/src/enterprise/batches/list/testData.ts
+++ b/client/web/src/enterprise/batches/list/testData.ts
@@ -30,6 +30,7 @@ This is my thorough explanation. And it can also get very long, in that case the
         batchSpecs: {
             nodes: [
                 {
+                    __typename: 'BatchSpec',
                     id: 'test',
                     state: BatchSpecState.PROCESSING,
                     applyURL: null,
@@ -60,6 +61,7 @@ This is my thorough explanation. And it can also get very long, in that case the
         batchSpecs: {
             nodes: [
                 {
+                    __typename: 'BatchSpec',
                     id: 'test',
                     state: BatchSpecState.FAILED,
                     applyURL: null,
@@ -90,6 +92,7 @@ This is my thorough explanation. And it can also get very long, in that case the
         batchSpecs: {
             nodes: [
                 {
+                    __typename: 'BatchSpec',
                     id: 'test',
                     state: BatchSpecState.COMPLETED,
                     applyURL: '/fake-apply-url',
@@ -122,6 +125,7 @@ This is my thorough explanation. And it can also get very long, in that case the
         batchSpecs: {
             nodes: [
                 {
+                    __typename: 'BatchSpec',
                     id: 'test',
                     state: BatchSpecState.COMPLETED,
                     applyURL: '/fake-apply-url',

--- a/client/web/src/enterprise/organizations/routes.tsx
+++ b/client/web/src/enterprise/organizations/routes.tsx
@@ -7,12 +7,17 @@ import { OrgAreaPageProps, OrgAreaRoute } from '../../org/area/OrgArea'
 import { orgAreaRoutes } from '../../org/area/routes'
 import { CreateBatchChangePageProps } from '../batches/create/CreateBatchChangePage'
 import { CreateOrEditBatchChangePageProps } from '../batches/create/CreateOrEditBatchChangePage'
-import { NamespaceBatchChangesAreaProps } from '../batches/global/GlobalBatchChangesArea'
+import { NamespaceBatchChangesAreaProps, ExecutionAreaProps } from '../batches/global/GlobalBatchChangesArea'
 import { enterpriseNamespaceAreaRoutes } from '../namespaces/routes'
 
 const NamespaceBatchChangesArea = lazyComponent<NamespaceBatchChangesAreaProps, 'NamespaceBatchChangesArea'>(
     () => import('../batches/global/GlobalBatchChangesArea'),
     'NamespaceBatchChangesArea'
+)
+
+const ExecutionArea = lazyComponent<ExecutionAreaProps, 'ExecutionArea'>(
+    () => import('../batches/global/GlobalBatchChangesArea'),
+    'ExecutionArea'
 )
 
 const CreateOrEditBatchChangePage = lazyComponent<CreateOrEditBatchChangePageProps, 'CreateOrEditBatchChangePage'>(
@@ -42,6 +47,15 @@ export const enterpriseOrganizationAreaRoutes: readonly OrgAreaRoute[] = [
                 initialNamespaceID={props.org.id}
                 batchChangeName={match.params.batchChangeName}
             />
+        ),
+        condition: ({ batchChangesEnabled, batchChangesExecutionEnabled }) =>
+            batchChangesEnabled && batchChangesExecutionEnabled,
+        fullPage: true,
+    },
+    {
+        path: '/batch-changes/:batchChangeName/executions/:batchSpecID',
+        render: (props: OrgAreaPageProps & RouteComponentProps<{ batchSpecID: string }>) => (
+            <ExecutionArea {...props} namespaceID={props.org.id} />
         ),
         condition: ({ batchChangesEnabled, batchChangesExecutionEnabled }) =>
             batchChangesEnabled && batchChangesExecutionEnabled,

--- a/client/web/src/enterprise/user/routes.tsx
+++ b/client/web/src/enterprise/user/routes.tsx
@@ -7,13 +7,18 @@ import { userAreaRoutes } from '../../user/area/routes'
 import { UserAreaRoute, UserAreaRouteContext } from '../../user/area/UserArea'
 import { CreateBatchChangePageProps } from '../batches/create/CreateBatchChangePage'
 import { CreateOrEditBatchChangePageProps } from '../batches/create/CreateOrEditBatchChangePage'
-import { NamespaceBatchChangesAreaProps } from '../batches/global/GlobalBatchChangesArea'
+import { ExecutionAreaProps, NamespaceBatchChangesAreaProps } from '../batches/global/GlobalBatchChangesArea'
 import { SHOW_BUSINESS_FEATURES } from '../dotcom/productSubscriptions/features'
 import { enterpriseNamespaceAreaRoutes } from '../namespaces/routes'
 
 const NamespaceBatchChangesArea = lazyComponent<NamespaceBatchChangesAreaProps, 'NamespaceBatchChangesArea'>(
     () => import('../batches/global/GlobalBatchChangesArea'),
     'NamespaceBatchChangesArea'
+)
+
+const ExecutionArea = lazyComponent<ExecutionAreaProps, 'ExecutionArea'>(
+    () => import('../batches/global/GlobalBatchChangesArea'),
+    'ExecutionArea'
 )
 
 const CreateOrEditBatchChangePage = lazyComponent<CreateOrEditBatchChangePageProps, 'CreateOrEditBatchChangePage'>(
@@ -56,6 +61,15 @@ export const enterpriseUserAreaRoutes: readonly UserAreaRoute[] = [
                 initialNamespaceID={props.user.id}
                 batchChangeName={match.params.batchChangeName}
             />
+        ),
+        condition: ({ batchChangesEnabled, batchChangesExecutionEnabled }) =>
+            batchChangesEnabled && batchChangesExecutionEnabled,
+        fullPage: true,
+    },
+    {
+        path: '/batch-changes/:batchChangeName/executions/:batchSpecID',
+        render: (props: UserAreaRouteContext & RouteComponentProps<{ batchSpecID: string }>) => (
+            <ExecutionArea {...props} namespaceID={props.user.id} />
         ),
         condition: ({ batchChangesEnabled, batchChangesExecutionEnabled }) =>
             batchChangesEnabled && batchChangesExecutionEnabled,

--- a/client/web/src/integration/batches.test.ts
+++ b/client/web/src/integration/batches.test.ts
@@ -27,6 +27,7 @@ import {
     BatchChangeChangesetsVariables,
     BatchChangeChangesetsResult,
     BatchChangeState,
+    BatchSpecState,
 } from '../graphql-operations'
 
 import { createWebIntegrationTestContext, WebIntegrationTestContext } from './context'
@@ -47,6 +48,18 @@ const batchChangeListNode: ListBatchChange = {
     namespace: {
         namespaceName: 'alice',
         url: '/users/alice',
+    },
+    currentSpec: {
+        id: 'test-spec',
+    },
+    batchSpecs: {
+        nodes: [
+            {
+                id: 'test-spec',
+                state: BatchSpecState.COMPLETED,
+                applyURL: '/fake-apply-url',
+            },
+        ],
     },
 }
 

--- a/client/web/src/integration/batches.test.ts
+++ b/client/web/src/integration/batches.test.ts
@@ -55,6 +55,7 @@ const batchChangeListNode: ListBatchChange = {
     batchSpecs: {
         nodes: [
             {
+                __typename: 'BatchSpec',
                 id: 'test-spec',
                 state: BatchSpecState.COMPLETED,
                 applyURL: '/fake-apply-url',


### PR DESCRIPTION
**Note:** Temporarily based on https://github.com/sourcegraph/sourcegraph/pull/31521 since some changes want the updated page URLs.

Closes https://github.com/sourcegraph/sourcegraph/issues/31166.

Introduces the new double-status pills for the batch changes list page that indicate batch change state as well as latest execution state. Best showcased through the new [storybook story](https://5f0f381c0e50750022dc6bf7-zmwxncharf.chromatic.com/?path=/story/web-batches-list--batchchangestatepill).

Additionally, each node on the list will now be a bit smarter about where it takes you when you click on it. If there's an unapplied preview, it will take you to that preview page. If there's an execution in progress or failed, it will take you to that execution page. If it's a draft that's never been executed, it will take you to the editor page.

Definitely recommend reviewing with whitespace changes hidden. The diff without that is confusing.

## Test plan

These changes are experimental behind a feature flag and should not impact existing customers, so I only went as far as to verify the intended functionality locally myself. The existing screen stories and snapshots should continue to match the existing behavior.


