### PR TITLE
Fix missing argument to printf call

### DIFF
--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -256,7 +256,7 @@ func runMigrator() {
 		e.Command("migrator", "up", "-db", schemaName)
 
 		if err := e.Error(); err != nil {
-			pgPrintf("Migrating %s schema failed%s", schemaName)
+			pgPrintf("Migrating %s schema failed: %s", schemaName, err)
 			log.Fatal(err.Error())
 		}
 	}


### PR DESCRIPTION
Just seen in [this Slack conversation](https://sourcegraph.slack.com/archives/C07KZF47K/p1645432599402469)

## Test plan

- Linter warning went away


