### PR TITLE
Remove Apollo client warning by querying id of repo/commit

### DIFF
--- a/client/web/src/components/fuzzyFinder/FuzzyFinder.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinder.tsx
@@ -131,7 +131,9 @@ export interface Failed {
 const FILE_NAMES = gql`
     query FileNames($repository: String!, $commit: String!) {
         repository(name: $repository) {
+            id
             commit(rev: $commit) {
+                id
                 fileNames
             }
         }

--- a/client/web/src/integration/blob-viewer.test.ts
+++ b/client/web/src/integration/blob-viewer.test.ts
@@ -54,8 +54,10 @@ describe('Blob viewer', () => {
         Blob: ({ filePath }) => createBlobContentResult(`content for: ${filePath}\nsecond line\nthird line`),
         FileNames: () => ({
             repository: {
+                id: 'repo-123',
                 __typename: 'Repository',
                 commit: {
+                    id: 'c0ff33',
                     __typename: 'GitCommit',
                     fileNames: ['README.md'],
                 },

--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -376,8 +376,10 @@ describe('Repository', () => {
                 }),
                 FileNames: () => ({
                     repository: {
+                        id: 'repo-123',
                         __typename: 'Repository',
                         commit: {
+                            id: 'c0ff33',
                             __typename: 'GitCommit',
                             fileNames: ['README.md'],
                         },
@@ -486,8 +488,10 @@ describe('Repository', () => {
                 }),
                 FileNames: () => ({
                     repository: {
+                        id: 'repo-123',
                         __typename: 'Repository',
                         commit: {
+                            id: 'c0ff33',
                             __typename: 'GitCommit',
                             fileNames: ['README.md'],
                         },
@@ -553,8 +557,10 @@ describe('Repository', () => {
                 ...getCommonRepositoryGraphQlResults(repositoryName, repositorySourcegraphUrl, ['readme.md']),
                 FileNames: () => ({
                     repository: {
+                        id: 'repo-123',
                         __typename: 'Repository',
                         commit: {
+                            id: 'c0ff33',
                             __typename: 'GitCommit',
                             fileNames: ['README.md'],
                         },
@@ -599,8 +605,10 @@ describe('Repository', () => {
                 ...getCommonRepositoryGraphQlResults(repositoryName, repositorySourcegraphUrl, ['readme.md']),
                 FileNames: () => ({
                     repository: {
+                        id: 'repo-123',
                         __typename: 'Repository',
                         commit: {
+                            id: 'c0ff33',
                             __typename: 'GitCommit',
                             fileNames: ['README.md'],
                         },
@@ -814,8 +822,10 @@ describe('Repository', () => {
                 }),
                 FileNames: () => ({
                     repository: {
+                        id: 'repo-123',
                         __typename: 'Repository',
                         commit: {
+                            id: 'c0ff33',
                             __typename: 'GitCommit',
                             fileNames: ['README.md'],
                         },


### PR DESCRIPTION
I've seen Apollo warn me about not being able to properly cache/merge
repository in its internal cache because it can't find an identifier.

This queries the ID of repository and commit, which don't produce a
performance hit here.

<img width="847" alt="screenshot_2022-02-21_10 50 35@2x" src="https://user-images.githubusercontent.com/1185253/154930496-21ff66b8-0ddd-46ef-841c-7ffa08883d07.png">


## Test plan

- Browse repository locally in Sourcegraph, open reference panel, see warning
- Fix issue by adding `id`s to the query
- Do the same thing as in step 1, get no warning

