### PR TITLE
Post Sign-up: Add view event for teams beta step

### DIFF
--- a/client/web/src/auth/welcome/TeamsBeta.tsx
+++ b/client/web/src/auth/welcome/TeamsBeta.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import React, { useState, useRef, SyntheticEvent, useCallback, useMemo } from 'react'
+import React, { useState, useRef, SyntheticEvent, useCallback, useMemo, useEffect } from 'react'
 
 import { Button, ProductStatusBadge } from '@sourcegraph/wildcard'
 
@@ -25,6 +25,10 @@ export const TeamsBeta: React.FunctionComponent<TeamsBeta> = ({ onFinish, onErro
     const [isTransitioning, setIsTransitioning] = useState<boolean>(false)
 
     const { setComplete, currentIndex } = useSteps()
+
+    useEffect(() => {
+        eventLogger.logViewEvent('PostSignUpOrgTabBetaForm')
+    }, [])
 
     const logFormSubmission = useCallback(() => {
         eventLogger.log('PostSignUpOrgTabBetaFormSubmit')


### PR DESCRIPTION
Fixes #31556

Adds a view event (`ViewPostSignUpOrgTabBetaForm`) for the teams beta page in the post-signup form.

## Test plan

![Screenshot 2022-02-21 at 14 02 48](https://user-images.githubusercontent.com/458591/154960702-0691f9ac-220a-4a15-80c6-91caa45efbfb.png)

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


