### PR TITLE
gqltest: add tests for sub-repo permissions for diff, symbol and commit search

### DIFF
--- a/dev/gqltest/sub_repo_permissions_test.go
+++ b/dev/gqltest/sub_repo_permissions_test.go
@@ -85,7 +85,6 @@ func TestSubRepoPermissionsSearch(t *testing.T) {
 		query         string
 		zeroResult    bool
 		minMatchCount int64
-		specificCheck func(results *gqltestutil.SearchFileResults)
 	}{
 		{
 			name:          "indexed search, nonzero result",
@@ -175,11 +174,6 @@ func TestSubRepoPermissionsSearch(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if test.specificCheck != nil {
-				test.specificCheck(results)
-				return
-			}
-
 			if test.zeroResult {
 				if len(results.Results) > 0 {
 					t.Fatalf("Want zero result but got %d", len(results.Results))
@@ -197,12 +191,15 @@ func TestSubRepoPermissionsSearch(t *testing.T) {
 	}
 
 	t.Run("commit search", func(t *testing.T) {
-		results, err := client.SearchCommits(`repo:^perforce/test-perms$ type:commit`)
+		results, err := userClient.SearchCommits(`repo:^perforce/test-perms$ type:commit`)
 		if err != nil {
 			t.Fatal(err)
 		}
-		for _, res := range results.Results {
-			t.Log(res)
+		// Alice should have access to only 1 commit at the moment (other 2 commits modify hack.sh which is
+		// inaccessible for Alice)
+		commitsNumber := len(results.Results)
+		if commitsNumber != 1 {
+			t.Fatalf("Should have access to 1 commit but got %d", commitsNumber)
 		}
 	})
 }


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/27448

## Test plan
This PR contains integration tests only
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


