### PR TITLE
executors: Add docs on how to update terraform modules with new executor versions

### DIFF
--- a/doc/dev/how-to/deploy_executor_image.md
+++ b/doc/dev/how-to/deploy_executor_image.md
@@ -40,7 +40,7 @@ this step can be skipped. Otherwise, we need to update the variable defaults for
 as well. This, for example, should be done before every release cut to ensure the terraform
 module version for the to-be-cut Sourcegraph version exists.
 
-1. Clone both [github.com/sourcegraph/terraform-google-executors](github.com/sourcegraph/terraform-google-executors) and [github.com/sourcegraph/terraform-aws-executors](github.com/sourcegraph/terraform-aws-executors).
+1. Clone both [github.com/sourcegraph/terraform-google-executors](https://github.com/sourcegraph/terraform-google-executors) and [github.com/sourcegraph/terraform-aws-executors](https://github.com/sourcegraph/terraform-aws-executors).
 1. In each module, replace the variable default for the machine image both in the root module `variables.tf` and in the `./modules/executors` module's `variables.tf`.
 1. Open a PR with this change.
 1. Get approval and merge this PR.

--- a/doc/dev/how-to/deploy_executor_image.md
+++ b/doc/dev/how-to/deploy_executor_image.md
@@ -25,10 +25,24 @@ This guide documents how to deploy a new image of [executors](../../../admin/exe
     Try to find the AWS AMI name, i.e. `ami-0fb21656aeba5eb7c`
 
 2. In the `infrastructure` repository:
-  * Open `executors/gcp.tf` and update the image at the top in `gcp_executor_machine_image`.
-  * open `executors/aws.tf` and update the image at the top in `aws_executor_ami`.
+  * Open `executors/(dogfood|cloud)/gcp.tf` and update the image at the top in `gcp_executor_machine_image`.
+  * open `executors/dogfood/aws.tf` and update the image at the top in `aws_executor_ami` (only for dogfood).
 3. Create a pull request with that change.
 4. Get approval for PR.
-5. In that PR branch, in the `executors` folder, run: `terraform apply`.
-6. Open https://k8s.sgdev.org/site-admin/executors to see that the new version is used.
+5. In that PR branch, in the `executors/(dogfood|cloud)` folders, run: `terraform apply`.
+6. Open https://k8s.sgdev.org/site-admin/executors to see check the new version is used.
 7. Merge PR.
+
+## Releasing a new terraform module version with these newly built images
+
+When we only dogfood a new image in between Sourcegraph releases using our own enviroments,
+this step can be skipped. Otherwise, we need to update the variable defaults for those images
+as well. This, for example, should be done before every release cut to ensure the terraform
+module version for the to-be-cut Sourcegraph version exists.
+
+1. Clone both [github.com/sourcegraph/terraform-google-executors](github.com/sourcegraph/terraform-google-executors) and [github.com/sourcegraph/terraform-aws-executors](github.com/sourcegraph/terraform-aws-executors).
+1. In each module, replace the variable default for the machine image both in the root module `variables.tf` and in the `./modules/executors` module's `variables.tf`.
+1. Open a PR with this change.
+1. Get approval and merge this PR.
+1. If necessary: Cut a new release of the modules. For that, run `./release.sh` from the two repos. See [the section on compatibility with Sourcegraph](https://github.com/sourcegraph/terraform-google-executors#compatibility-with-sourcegraph) for versioning constraints.
+1. Update the executor modules in our infrastructure repo to validate and dogfood those new version tags.


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/29689

## Test plan

Is just a docs PR.