### PR TITLE
repos: do not append .git to other

### DIFF
--- a/internal/repos/other.go
+++ b/internal/repos/other.go
@@ -190,7 +190,7 @@ func (s OtherSource) srcExpose(ctx context.Context) ([]*types.Repo, error) {
 			ServiceType: extsvc.TypeOther,
 			ServiceID:   s.conn.Url,
 		}
-		cloneURL := clonePrefix + strings.TrimPrefix(r.URI, "/") + "/.git"
+		cloneURL := clonePrefix + strings.TrimPrefix(r.URI, "/")
 		r.Sources = map[string]*types.SourceInfo{
 			urn: {
 				ID:       urn,

--- a/internal/repos/other_test.go
+++ b/internal/repos/other_test.go
@@ -58,10 +58,10 @@ func TestSrcExpose(t *testing.T) {
 			Sources: map[string]*types.SourceInfo{
 				"extsvc:other:1": {
 					ID:       "extsvc:other:1",
-					CloneURL: s.URL + "/foo/.git",
+					CloneURL: s.URL + "/foo",
 				},
 			},
-			Metadata: &extsvc.OtherRepoMetadata{RelativePath: "/foo/.git"},
+			Metadata: &extsvc.OtherRepoMetadata{RelativePath: "/foo"},
 		}, {
 			URI:  "bar/baz",
 			Name: "bar/baz",
@@ -73,10 +73,10 @@ func TestSrcExpose(t *testing.T) {
 			Sources: map[string]*types.SourceInfo{
 				"extsvc:other:1": {
 					ID:       "extsvc:other:1",
-					CloneURL: s.URL + "/bar/baz/.git",
+					CloneURL: s.URL + "/bar/baz",
 				},
 			},
-			Metadata: &extsvc.OtherRepoMetadata{RelativePath: "/bar/baz/.git"},
+			Metadata: &extsvc.OtherRepoMetadata{RelativePath: "/bar/baz"},
 		}},
 	}, {
 		name: "override",
@@ -93,10 +93,10 @@ func TestSrcExpose(t *testing.T) {
 			Sources: map[string]*types.SourceInfo{
 				"extsvc:other:1": {
 					ID:       "extsvc:other:1",
-					CloneURL: s.URL + "/repos/foo/.git",
+					CloneURL: s.URL + "/repos/foo",
 				},
 			},
-			Metadata: &extsvc.OtherRepoMetadata{RelativePath: "/repos/foo/.git"},
+			Metadata: &extsvc.OtherRepoMetadata{RelativePath: "/repos/foo"},
 		}},
 	}, {
 		name: "immutable",
@@ -112,10 +112,10 @@ func TestSrcExpose(t *testing.T) {
 			Sources: map[string]*types.SourceInfo{
 				"extsvc:other:1": {
 					ID:       "extsvc:other:1",
-					CloneURL: s.URL + "/foo/.git",
+					CloneURL: s.URL + "/foo",
 				},
 			},
-			Metadata: &extsvc.OtherRepoMetadata{RelativePath: "/foo/.git"},
+			Metadata: &extsvc.OtherRepoMetadata{RelativePath: "/foo"},
 		}},
 	}}
 


### PR DESCRIPTION
DONOTMERGE: src-cli does not handle this. See the test plan for what we want vs what we get when testing.

By appending .git we are not able to handle bare repos. The remote should be able to handle this. We originally added ".git" due to our src-expose implementation relying on the "dumb" git protocol. src-cli now relys on a git subprocess serving git-protocol-v2 that should be more robust.

Test Plan: Manually test. Expect git ls-remote works without .git for bare and non-bare repos.

``` shellsession
# Create test repos with and without .git
git-combine-0:/data/repos# git init nonbaretest
git-combine-0:/data/repos# git init --bare baretest

# Test from a remote
gitserver-0:/data/repos/.tmp# curl -s http://git-combine/v1/list-repos | grep test
      "Name": "baretest",
      "URI": "/repos/baretest"
      "Name": "nonbaretest",
      "URI": "/repos/nonbaretest"
gitserver-0:/data/repos/.tmp# git ls-remote http://git-combine/repos/baretest
gitserver-0:/data/repos/.tmp# git ls-remote http://git-combine/repos/baretest/.git
remote: repository not found
fatal: repository 'http://git-combine/repos/baretest/.git/' not found
gitserver-0:/data/repos/.tmp# git ls-remote http://git-combine/repos/nonbaretest/.git
gitserver-0:/data/repos/.tmp# git ls-remote http://git-combine/repos/nonbaretest
fatal: protocol error: bad line length character:
err
```

