### PR TITLE
Search backend: remove UserSettings from SearchResultsResolver

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -44,7 +44,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/usagestats"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
-	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 // SearchResultsResolver is a resolver for the GraphQL type `SearchResults`
@@ -56,10 +55,6 @@ type SearchResultsResolver struct {
 
 	// The time it took to compute all results.
 	elapsed time.Duration
-
-	// cache for user settings. Ideally this should be set just once in the code path
-	// by an upstream resolver
-	UserSettings *schema.Settings
 }
 
 func (c *SearchResultsResolver) LimitHit() bool {
@@ -529,11 +524,10 @@ func (r *searchResolver) resultsStreaming(ctx context.Context) (*SearchResultsRe
 
 func (r *searchResolver) resultsToResolver(matches result.Matches, alert *search.Alert, stats streaming.Stats) *SearchResultsResolver {
 	return &SearchResultsResolver{
-		Matches:      matches,
-		SearchAlert:  alert,
-		Stats:        stats,
-		db:           r.db,
-		UserSettings: r.SearchInputs.UserSettings,
+		Matches:     matches,
+		SearchAlert: alert,
+		Stats:       stats,
+		db:          r.db,
 	}
 }
 

--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -230,9 +230,7 @@ func (h *mockSearchResolver) Results(ctx context.Context) (*graphqlbackend.Searc
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	case <-h.done:
-		return &graphqlbackend.SearchResultsResolver{
-			UserSettings: &schema.Settings{},
-		}, nil
+		return &graphqlbackend.SearchResultsResolver{}, nil
 	}
 }
 


### PR DESCRIPTION
This removes the unused UserSettings field from SearchResultsResolver.

## Test plan

Semantics preserving, just removing dead code.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


