### PR TITLE
web: Fix layout for home page panels and logged out content

### DIFF
--- a/client/web/src/search/home/SearchPage.module.scss
+++ b/client/web/src/search/home/SearchPage.module.scss
@@ -34,3 +34,16 @@
         margin-bottom: 5rem;
     }
 }
+
+.panels-container {
+    display: flex;
+    justify-content: center;
+    max-width: 100%;
+    flex-grow: 1;
+
+    @media (--xl-breakpoint-up) {
+        min-width: var(--max-homepage-container-width);
+    }
+
+    position: relative;
+}

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -93,7 +93,7 @@ export const SearchPage: React.FunctionComponent<SearchPageProps> = props => {
                     where="homepage"
                 />
             </div>
-            <div className="flex-grow-1">
+            <div className={styles.panelsContainer}>
                 {props.isSourcegraphDotCom && !props.authenticatedUser && <LoggedOutHomepage {...props} />}
 
                 {showEnterpriseHomePanels && props.authenticatedUser && <HomePanels {...props} />}

--- a/client/web/src/search/panels/HomePanels.module.scss
+++ b/client/web/src/search/panels/HomePanels.module.scss
@@ -1,6 +1,6 @@
 .home-panels {
     margin-top: 1rem;
-    max-width: 90%;
+    max-width: 90vw;
 }
 
 .panel {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/31560

The layout for the home page panels and logged out content has quite a few requirements:

- It needs to be able to grow up to 90% of the viewport on large pages since some of the pervious queries might get big.
- It should have at least the same width as the search bar, otherwise it looks odd 
  - This was not working as expected currently and it was possible to get the layout into a stage where the content would collapse below that.
- It needs to support smaller screens by being contained within the screen and not requiring vertical scroll.

This diff fixes the layout to support all three properties by making the panels section behave similarly than the search bar. 

Additionally, this fixes responsive use by not capping the layout width to 90% (see Chromatic)

## Test plan

|                      | Prev | Next |
|----------------------|------|------|
| Cloud logged out     |![cloud-loggedout-prev](https://user-images.githubusercontent.com/458591/154988565-a1aefe20-e35c-432e-bbb1-170391c08d97.png)|![cloud-loggedout-new](https://user-images.githubusercontent.com/458591/154988691-dc45cb31-3868-427c-97d9-e14c18fe38df.png)|
| Cloud logged in      |![cloud-loggedin-prev](https://user-images.githubusercontent.com/458591/154988732-eebd2a29-c181-4740-aa16-dbfc420fc8d9.png)|![cloud-loggedin-new](https://user-images.githubusercontent.com/458591/154988805-a7782205-8031-4485-93a8-3831009e7c17.png)|
| On-prem null state   |![onprem-loggedin-prev-null](https://user-images.githubusercontent.com/458591/154988819-ab5a1743-0507-4215-9ad4-f4667ac7a2a1.png)|![onprem-loggedin-new-null](https://user-images.githubusercontent.com/458591/154988787-cb70fd80-49fe-4b30-bc8c-2128e17c571d.png)|
| On-prem saved search |![onprem-loggedin-prev-search-results](https://user-images.githubusercontent.com/458591/154988824-1be230fb-f719-47aa-b255-acb7e97db341.png)|![onprem-loggedin-new-search-results](https://user-images.githubusercontent.com/458591/154988782-d295d7f9-01a4-4911-827e-70a3d2f8f695.png)|


<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


