### PR TITLE
ssbc: Some quick wins on workspace items

### DIFF
--- a/client/web/src/enterprise/batches/execution/WorkspacesList.module.scss
+++ b/client/web/src/enterprise/batches/execution/WorkspacesList.module.scss
@@ -4,14 +4,40 @@
     min-width: 0;
 }
 
+.workspace-name {
+    &:hover {
+        text-decoration: none;
+    }
+}
+
 .workspace-repo {
     align-items: flex-start;
 }
 
-.workspace-selected {
-    background-color: var(--color-bg-1);
-}
-
 .workspace-list-icon {
     align-self: center;
+}
+
+.workspace-list-node {
+    display: block;
+    padding: 0.5rem;
+    &:focus,
+    &:hover {
+        text-decoration: none;
+        background-color: var(--color-bg-2);
+    }
+}
+
+.list-group-item {
+    padding: 0;
+    &:nth-child(odd) {
+        background-color: var(--subtle-bg-2);
+    }
+    &:nth-child(even) {
+        background-color: none;
+    }
+}
+
+.workspace-selected {
+    background-color: var(--color-bg-1);
 }

--- a/client/web/src/enterprise/batches/execution/WorkspacesList.tsx
+++ b/client/web/src/enterprise/batches/execution/WorkspacesList.tsx
@@ -72,9 +72,12 @@ interface WorkspaceNodeProps {
 }
 
 const WorkspaceNode: React.FunctionComponent<WorkspaceNodeProps> = ({ node, selectedNode }) => (
-    <li className={classNames('list-group-item', node.id === selectedNode && styles.workspaceSelected)}>
-        <Link to={`?workspace=${node.id}`}>
-            <div className={classNames(styles.workspaceRepo, 'd-flex justify-content-between mb-1')}>
+    <li className={classNames('list-group-item', styles.listGroupItem)}>
+        <Link
+            to={`?workspace=${node.id}`}
+            className={classNames(styles.workspaceListNode, node.id === selectedNode && styles.workspaceSelected)}
+        >
+            <div className="d-flex mb-1">
                 <span>
                     <WorkspaceStateIcon
                         cachedResultFound={node.cachedResultFound}
@@ -82,10 +85,14 @@ const WorkspaceNode: React.FunctionComponent<WorkspaceNodeProps> = ({ node, sele
                         className={classNames(styles.workspaceListIcon, 'mr-2 flex-shrink-0')}
                     />
                 </span>
-                <strong className={classNames(styles.workspaceName, 'flex-grow-1')}>{node.repository.name}</strong>
-                {node.diffStat && <DiffStat {...node.diffStat} expandedCounts={true} />}
+                <div className="flex-grow-1">
+                    <div className={classNames(styles.workspaceRepo, 'd-flex justify-content-between mb-1')}>
+                        <h4 className={classNames(styles.workspaceName, 'flex-grow-1')}>{node.repository.name}</h4>
+                        {node.diffStat && <DiffStat {...node.diffStat} expandedCounts={true} />}
+                    </div>
+                    <Branch name={node.branch.abbrevName} />
+                </div>
             </div>
-            <Branch name={node.branch.abbrevName} />
         </Link>
     </li>
 )


### PR DESCRIPTION
- Better hover styles
- Align on h4 for the repo name
- Icon has its own column
- Even/odd striping as in preview list
- Whole item is clickable and no text-decoration underline anymore

<img width="388" alt="image" src="https://user-images.githubusercontent.com/19534377/154990713-c1729939-8e22-4308-a7e3-56612c242c5f.png">

Closes #30468

## Test plan

Are just stylistic changes. I made sure everything still works as before by hand. 