### PR TITLE
codeintel: extend PackageDependency for dependency search

### DIFF
--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -38,13 +38,13 @@ const (
 // placeholderMavenDependency is used to set GIT_AUTHOR_NAME for git commands
 // that don't create commits or tags. The name of this dependency should never
 // be publicly visible so it can have any random value.
-var placeholderMavenDependency = reposource.MavenDependency{
-	MavenModule: reposource.MavenModule{
-		GroupID:    "com.sourcegraph",
-		ArtifactID: "sourcegraph",
-	},
-	Version: "1.0.0",
-}
+var placeholderMavenDependency = func() *reposource.MavenDependency {
+	d, err := reposource.ParseMavenDependency("com.sourcegraph:sourcegraph:1.0.0")
+	if err != nil {
+		panic(err)
+	}
+	return d
+}()
 
 type JVMPackagesSyncer struct {
 	Config  *schema.JVMPackagesConnection
@@ -173,7 +173,7 @@ func (s *JVMPackagesSyncer) RemoteShowCommand(ctx context.Context, remoteURL *vc
 // packageDependencies returns the list of JVM dependencies that belong to the given URL path.
 // The returned package dependencies are sorted by semantic versioning.
 // A URL maps to a single JVM package, which may contain multiple versions (one git tag per version).
-func (s *JVMPackagesSyncer) packageDependencies(ctx context.Context, repoUrlPath string) (dependencies []reposource.MavenDependency, err error) {
+func (s *JVMPackagesSyncer) packageDependencies(ctx context.Context, repoUrlPath string) (dependencies []*reposource.MavenDependency, err error) {
 	module, err := reposource.ParseMavenModule(repoUrlPath)
 	if err != nil {
 		return nil, err
@@ -181,7 +181,7 @@ func (s *JVMPackagesSyncer) packageDependencies(ctx context.Context, repoUrlPath
 
 	var (
 		totalConfigMatched int
-		timedout           []reposource.MavenDependency
+		timedout           []*reposource.MavenDependency
 	)
 	for _, dependency := range s.MavenDependencies() {
 		if module.MatchesDependencyString(dependency) {
@@ -221,8 +221,8 @@ func (s *JVMPackagesSyncer) packageDependencies(ctx context.Context, repoUrlPath
 			log15.Warn("error parsing maven module", "error", err, "module", dep.Module)
 			continue
 		}
-		if module == parsedModule {
-			dependency := reposource.MavenDependency{
+		if module.Equal(parsedModule) {
+			dependency := &reposource.MavenDependency{
 				MavenModule: parsedModule,
 				Version:     dep.Version,
 			}
@@ -245,7 +245,7 @@ func (s *JVMPackagesSyncer) packageDependencies(ctx context.Context, repoUrlPath
 // tag points to a commit that adds all sources of given dependency. When
 // isMainBranch is true, the main branch of the bare git directory will also be
 // updated to point to the same commit as the git tag.
-func (s *JVMPackagesSyncer) gitPushDependencyTag(ctx context.Context, bareGitDirectory string, dependency reposource.MavenDependency, isLatestVersion bool) error {
+func (s *JVMPackagesSyncer) gitPushDependencyTag(ctx context.Context, bareGitDirectory string, dependency *reposource.MavenDependency, isLatestVersion bool) error {
 	tmpDirectory, err := os.MkdirTemp("", "maven")
 	if err != nil {
 		return err
@@ -296,7 +296,7 @@ func (s *JVMPackagesSyncer) gitPushDependencyTag(ctx context.Context, bareGitDir
 
 // commitJar creates a git commit in the given working directory that adds all the file contents of the given jar file.
 // A `*.jar` file works the same way as a `*.zip` file, it can even be uncompressed with the `unzip` command-line tool.
-func (s *JVMPackagesSyncer) commitJar(ctx context.Context, dependency reposource.MavenDependency,
+func (s *JVMPackagesSyncer) commitJar(ctx context.Context, dependency *reposource.MavenDependency,
 	workingDirectory, sourceCodeJarPath string, connection *schema.JVMPackagesConnection) error {
 	if err := unzipJarFile(sourceCodeJarPath, workingDirectory); err != nil {
 		return errors.Wrapf(err, "failed to unzip jar file for %s to %v", dependency.PackageManagerSyntax(), sourceCodeJarPath)
@@ -403,7 +403,7 @@ func copyZipFileEntry(entry *zip.File, outputPath string) (err error) {
 // inferJVMVersionFromByteCode returns the JVM version that was used to compile
 // the bytecode in the given jar file.
 func inferJVMVersionFromByteCode(ctx context.Context, connection *schema.JVMPackagesConnection,
-	dependency reposource.MavenDependency) (string, error) {
+	dependency *reposource.MavenDependency) (string, error) {
 	if dependency.IsJDK() {
 		return dependency.Version, nil
 	}

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -77,7 +77,7 @@ func (s *JVMPackagesSyncer) IsCloneable(ctx context.Context, remoteURL *vcs.URL)
 		if err != nil {
 			// Temporary: We shouldn't need both these checks but we're continuing to see the
 			// error in production logs which implies `Is` is not matching.
-			if errors.Is(err, coursier.ErrNoSources{}) || strings.Contains(err.Error(), "no sources for dependency") {
+			if errors.HasType(err, &coursier.ErrNoSources{}) || strings.Contains(err.Error(), "no sources for dependency") {
 				// We can't do anything and it's leading to increases in our
 				// src_repoupdater_sched_error alert firing more often.
 				continue

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages_test.go
@@ -146,7 +146,8 @@ func TestNoMaliciousFiles(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel now  to prevent any network IO
-	err = s.commitJar(ctx, reposource.MavenDependency{}, extractPath, jarPath, &schema.JVMPackagesConnection{Maven: &schema.Maven{}})
+	dep := &reposource.MavenDependency{MavenModule: &reposource.MavenModule{}}
+	err = s.commitJar(ctx, dep, extractPath, jarPath, &schema.JVMPackagesConnection{Maven: &schema.Maven{}})
 	assert.NotNil(t, err)
 
 	dirEntries, err := os.ReadDir(extractPath)
@@ -261,7 +262,7 @@ func (m *simpleJVMPackageDBStoreMock) GetJVMDependencyRepos(ctx context.Context,
 
 // Sanity check errors.Is
 func TestIsError(t *testing.T) {
-	err := coursier.ErrNoSources{Dependency: reposource.MavenDependency{}}
+	err := coursier.ErrNoSources{Dependency: &reposource.MavenDependency{}}
 	if !errors.Is(err, coursier.ErrNoSources{}) {
 		t.Fatal("should be true")
 	}

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages_test.go
@@ -260,13 +260,13 @@ func (m *simpleJVMPackageDBStoreMock) GetJVMDependencyRepos(ctx context.Context,
 	return []dbstore.JVMDependencyRepo{}, nil
 }
 
-// Sanity check errors.Is
-func TestIsError(t *testing.T) {
-	err := coursier.ErrNoSources{Dependency: &reposource.MavenDependency{}}
-	if !errors.Is(err, coursier.ErrNoSources{}) {
+// Sanity check errors.HasType
+func TestErrorHasType(t *testing.T) {
+	err := &coursier.ErrNoSources{}
+	if !errors.HasType(err, &coursier.ErrNoSources{}) {
 		t.Fatal("should be true")
 	}
-	if errors.Is(nil, coursier.ErrNoSources{}) {
+	if errors.Is(nil, &coursier.ErrNoSources{}) {
 		t.Fatal("should be false")
 	}
 }

--- a/cmd/gitserver/server/vcs_syncer_npm_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages_test.go
@@ -61,7 +61,7 @@ func TestNoMaliciousFilesNPM(t *testing.T) {
 	tgzFile, err := os.Open(tgzPath)
 	require.Nil(t, err)
 	defer func() { require.Nil(t, tgzFile.Close()) }()
-	err = s.commitTgz(ctx, reposource.NPMDependency{}, extractPath, tgzFile)
+	err = s.commitTgz(ctx, &reposource.NPMDependency{}, extractPath, tgzFile)
 	require.NotNil(t, err, "malicious tarball should not be committed successfully")
 
 	dirEntries, err := os.ReadDir(extractPath)

--- a/cmd/gitserver/server/vcs_syncer_npm_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages_test.go
@@ -61,7 +61,8 @@ func TestNoMaliciousFilesNPM(t *testing.T) {
 	tgzFile, err := os.Open(tgzPath)
 	require.Nil(t, err)
 	defer func() { require.Nil(t, tgzFile.Close()) }()
-	err = s.commitTgz(ctx, &reposource.NPMDependency{}, extractPath, tgzFile)
+	dep := &reposource.NPMDependency{NPMPackage: &reposource.NPMPackage{}}
+	err = s.commitTgz(ctx, dep, extractPath, tgzFile)
 	require.NotNil(t, err, "malicious tarball should not be committed successfully")
 
 	dirEntries, err := os.ReadDir(extractPath)

--- a/internal/conf/reposource/jvm_packages.go
+++ b/internal/conf/reposource/jvm_packages.go
@@ -69,7 +69,7 @@ type MavenDependency struct {
 // slice
 func SortDependencies(dependencies []*MavenDependency) {
 	sort.Slice(dependencies, func(i, j int) bool {
-		if dependencies[i].Equal(dependencies[j]) {
+		if dependencies[i].MavenModule.Equal(dependencies[j].MavenModule) {
 			return versionGreaterThan(dependencies[i].Version, dependencies[j].Version)
 		}
 		return dependencies[i].MavenModule.SortText() > dependencies[j].MavenModule.SortText()

--- a/internal/conf/reposource/jvm_packages.go
+++ b/internal/conf/reposource/jvm_packages.go
@@ -15,8 +15,12 @@ type MavenModule struct {
 	ArtifactID string
 }
 
+func (m *MavenModule) Equal(other *MavenModule) bool {
+	return m == other || (m != nil && other != nil && *m == *other)
+}
+
 func (m *MavenModule) IsJDK() bool {
-	return *m == jdkModule()
+	return m.Equal(jdkModule())
 }
 
 func (m *MavenModule) MatchesDependencyString(dependency string) bool {
@@ -25,6 +29,10 @@ func (m *MavenModule) MatchesDependencyString(dependency string) bool {
 
 func (m *MavenModule) CoursierSyntax() string {
 	return fmt.Sprintf("%s:%s", m.GroupID, m.ArtifactID)
+}
+
+func (m *MavenModule) PackageSyntax() string {
+	return m.CoursierSyntax()
 }
 
 func (m *MavenModule) SortText() string {
@@ -52,35 +60,45 @@ func (m *MavenModule) CloneURL() string {
 
 // See [NOTE: Dependency-terminology]
 type MavenDependency struct {
-	MavenModule
+	*MavenModule
 	Version string
 }
 
 // SortDependencies sorts the dependencies by the semantic version in descending
 // order. The latest version of a dependency becomes the first element of the
 // slice
-func SortDependencies(dependencies []MavenDependency) {
+func SortDependencies(dependencies []*MavenDependency) {
 	sort.Slice(dependencies, func(i, j int) bool {
-		if dependencies[i].MavenModule == dependencies[j].MavenModule {
+		if dependencies[i].Equal(dependencies[j]) {
 			return versionGreaterThan(dependencies[i].Version, dependencies[j].Version)
 		}
 		return dependencies[i].MavenModule.SortText() > dependencies[j].MavenModule.SortText()
 	})
 }
 
-func (d MavenDependency) IsJDK() bool {
-	return d.MavenModule.IsJDK()
+func (m *MavenDependency) Equal(other *MavenDependency) bool {
+	return m == other || (m != nil && other != nil &&
+		m.MavenModule.Equal(other.MavenModule) &&
+		m.Version == other.Version)
 }
 
-func (d MavenDependency) PackageManagerSyntax() string {
-	return fmt.Sprintf("%s:%s:%s", d.MavenModule.GroupID, d.MavenModule.ArtifactID, d.Version)
+func (d *MavenDependency) PackageManagerSyntax() string {
+	return fmt.Sprintf("%s:%s", d.PackageSyntax(), d.Version)
 }
 
-func (d MavenDependency) GitTagFromVersion() string {
+func (d *MavenDependency) PackageVersion() string {
+	return d.Version
+}
+
+func (d *MavenDependency) Scheme() string {
+	return "semanticdb"
+}
+
+func (d *MavenDependency) GitTagFromVersion() string {
 	return "v" + d.Version
 }
 
-func (d MavenDependency) LsifJavaDependencies() []string {
+func (d *MavenDependency) LsifJavaDependencies() []string {
 	if d.IsJDK() {
 		return []string{}
 	}
@@ -89,15 +107,15 @@ func (d MavenDependency) LsifJavaDependencies() []string {
 
 // ParseMavenDependency parses a dependency string in the Coursier format (colon seperated group ID, artifact ID and version)
 // into a MavenDependency.
-func ParseMavenDependency(dependency string) (MavenDependency, error) {
+func ParseMavenDependency(dependency string) (*MavenDependency, error) {
 	parts := strings.Split(dependency, ":")
 	if len(parts) < 3 {
-		return MavenDependency{}, errors.Newf("dependency %q must contain at least two colon ':' characters", dependency)
+		return nil, errors.Newf("dependency %q must contain at least two colon ':' characters", dependency)
 	}
 	version := parts[2]
 
-	return MavenDependency{
-		MavenModule: MavenModule{
+	return &MavenDependency{
+		MavenModule: &MavenModule{
 			GroupID:    parts[0],
 			ArtifactID: parts[1],
 		},
@@ -106,16 +124,16 @@ func ParseMavenDependency(dependency string) (MavenDependency, error) {
 }
 
 // ParseMavenModule returns a parsed JVM module from the provided URL path, without a leading `/`
-func ParseMavenModule(urlPath string) (MavenModule, error) {
+func ParseMavenModule(urlPath string) (*MavenModule, error) {
 	if urlPath == "jdk" {
 		return jdkModule(), nil
 	}
 	parts := strings.SplitN(strings.TrimPrefix(urlPath, "maven/"), "/", 2)
 	if len(parts) != 2 {
-		return MavenModule{}, errors.Newf("failed to parse a maven module from the path %s", urlPath)
+		return nil, errors.Newf("failed to parse a maven module from the path %s", urlPath)
 	}
 
-	return MavenModule{
+	return &MavenModule{
 		GroupID:    parts[0],
 		ArtifactID: parts[1],
 	}, nil
@@ -130,8 +148,8 @@ func ParseMavenModule(urlPath string) (MavenModule, error) {
 // - Maven sources: `coursier fetch MAVEN_MODULE:VERSION --classifier=sources`
 // Since the difference is so small, the code is easier to read/maintain if we
 // model the JDK as a Maven module.
-func jdkModule() MavenModule {
-	return MavenModule{
+func jdkModule() *MavenModule {
+	return &MavenModule{
 		GroupID:    "jdk",
 		ArtifactID: "jdk",
 	}

--- a/internal/conf/reposource/jvm_packages_test.go
+++ b/internal/conf/reposource/jvm_packages_test.go
@@ -43,18 +43,26 @@ func TestSortDependencies(t *testing.T) {
 		ParseMavenDependencyOrPanic(t, "a:b:1.2.0-RC1"),
 		ParseMavenDependencyOrPanic(t, "a:b:1.1.0"),
 	}
-	expected := []*MavenDependency{
-		ParseMavenDependencyOrPanic(t, "a:c:1.2.0"),
-		ParseMavenDependencyOrPanic(t, "a:b:1.11.0"),
-		ParseMavenDependencyOrPanic(t, "a:b:1.2.0"),
-		ParseMavenDependencyOrPanic(t, "a:b:1.2.0.Final"),
-		ParseMavenDependencyOrPanic(t, "a:b:1.2.0-RC11"),
-		ParseMavenDependencyOrPanic(t, "a:b:1.2.0-RC1"),
-		ParseMavenDependencyOrPanic(t, "a:b:1.2.0-M11"),
-		ParseMavenDependencyOrPanic(t, "a:b:1.2.0-M1"),
-		ParseMavenDependencyOrPanic(t, "a:b:1.1.0"),
-		ParseMavenDependencyOrPanic(t, "a:a:1.2.0"),
-	}
+
 	SortDependencies(dependencies)
-	assert.Equal(t, expected, dependencies)
+
+	have := make([]string, 0, len(dependencies))
+	for _, dep := range dependencies {
+		have = append(have, dep.PackageManagerSyntax())
+	}
+
+	want := []string{
+		"a:c:1.2.0",
+		"a:b:1.11.0",
+		"a:b:1.2.0",
+		"a:b:1.2.0.Final",
+		"a:b:1.2.0-RC11",
+		"a:b:1.2.0-RC1",
+		"a:b:1.2.0-M11",
+		"a:b:1.2.0-M1",
+		"a:b:1.1.0",
+		"a:a:1.2.0",
+	}
+
+	assert.Equal(t, want, have)
 }

--- a/internal/conf/reposource/jvm_packages_test.go
+++ b/internal/conf/reposource/jvm_packages_test.go
@@ -15,7 +15,7 @@ func TestDecomposeMavenPath(t *testing.T) {
 	assert.Equal(t, api.RepoName("maven/org.hamcrest/hamcrest-core"), obtained.RepoName())
 }
 
-func ParseMavenDependencyOrPanic(t *testing.T, value string) MavenDependency {
+func ParseMavenDependencyOrPanic(t *testing.T, value string) *MavenDependency {
 	dependency, err := ParseMavenDependency(value)
 	if err != nil {
 		t.Fatalf("error=%s", err)
@@ -31,7 +31,7 @@ func TestGreaterThan(t *testing.T) {
 }
 
 func TestSortDependencies(t *testing.T) {
-	dependencies := []MavenDependency{
+	dependencies := []*MavenDependency{
 		ParseMavenDependencyOrPanic(t, "a:c:1.2.0"),
 		ParseMavenDependencyOrPanic(t, "a:b:1.2.0.Final"),
 		ParseMavenDependencyOrPanic(t, "a:a:1.2.0"),
@@ -43,7 +43,7 @@ func TestSortDependencies(t *testing.T) {
 		ParseMavenDependencyOrPanic(t, "a:b:1.2.0-RC1"),
 		ParseMavenDependencyOrPanic(t, "a:b:1.1.0"),
 	}
-	expected := []MavenDependency{
+	expected := []*MavenDependency{
 		ParseMavenDependencyOrPanic(t, "a:c:1.2.0"),
 		ParseMavenDependencyOrPanic(t, "a:b:1.11.0"),
 		ParseMavenDependencyOrPanic(t, "a:b:1.2.0"),

--- a/internal/conf/reposource/npm_packages.go
+++ b/internal/conf/reposource/npm_packages.go
@@ -52,6 +52,10 @@ func NewNPMPackage(scope string, name string) (*NPMPackage, error) {
 	return &NPMPackage{scope, name}, nil
 }
 
+func (pkg *NPMPackage) Equal(other *NPMPackage) bool {
+	return pkg == other || (pkg != nil && other != nil && *pkg == *other)
+}
+
 // ParseNPMPackageFromRepoURL is a convenience function to parse a string in a
 // 'npm/(scope/)?name' format into an NPMPackage.
 func ParseNPMPackageFromRepoURL(urlPath string) (*NPMPackage, error) {
@@ -76,7 +80,7 @@ func ParseNPMPackageFromPackageSyntax(pkg string) (*NPMPackage, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &dep.Package, nil
+	return dep.NPMPackage, nil
 }
 
 type NPMPackageSerializationHelper struct {
@@ -122,7 +126,7 @@ func (pkg *NPMPackage) CloneURL() string {
 
 // MatchesDependencyString checks if a dependency (= package + version pair)
 // refers to the same package as pkg.
-func (pkg NPMPackage) MatchesDependencyString(depPackageSyntax string) bool {
+func (pkg *NPMPackage) MatchesDependencyString(depPackageSyntax string) bool {
 	return strings.HasPrefix(depPackageSyntax, pkg.PackageSyntax()+"@")
 }
 
@@ -131,7 +135,7 @@ func (pkg NPMPackage) MatchesDependencyString(depPackageSyntax string) bool {
 // This is largely for "lower-level" code interacting with the NPM API.
 //
 // In most cases, you want to use NPMDependency's PackageManagerSyntax() instead.
-func (pkg NPMPackage) PackageSyntax() string {
+func (pkg *NPMPackage) PackageSyntax() string {
 	if pkg.scope != "" {
 		return fmt.Sprintf("@%s/%s", pkg.scope, pkg.name)
 	}
@@ -145,7 +149,7 @@ func (pkg NPMPackage) PackageSyntax() string {
 //
 // Reference:  https://docs.npmjs.com/cli/v8/commands/npm-install
 type NPMDependency struct {
-	Package NPMPackage
+	*NPMPackage
 
 	// The version or tag (such as "latest") for a dependency.
 	//
@@ -182,26 +186,40 @@ func ParseNPMDependency(dependency string) (*NPMDependency, error) {
 		}
 	}
 	scope, name, version := result["scope"], result["name"], result["version"]
-	return &NPMDependency{NPMPackage{scope, name}, version}, nil
+	return &NPMDependency{&NPMPackage{scope, name}, version}, nil
 }
 
 // PackageManagerSyntax returns the dependency in NPM/Yarn syntax. The returned
 // string can (for example) be passed to `npm install`.
-func (d NPMDependency) PackageManagerSyntax() string {
-	return fmt.Sprintf("%s@%s", d.Package.PackageSyntax(), d.Version)
+func (d *NPMDependency) PackageManagerSyntax() string {
+	return fmt.Sprintf("%s@%s", d.PackageSyntax(), d.Version)
 }
 
-func (d NPMDependency) GitTagFromVersion() string {
+func (d *NPMDependency) Scheme() string {
+	return "npm"
+}
+
+func (d *NPMDependency) PackageVersion() string {
+	return d.Version
+}
+
+func (d *NPMDependency) GitTagFromVersion() string {
 	return "v" + d.Version
+}
+
+func (d *NPMDependency) Equal(other *NPMDependency) bool {
+	return d == other || (d != nil && other != nil &&
+		d.NPMPackage.Equal(other.NPMPackage) &&
+		d.Version == other.Version)
 }
 
 // SortDependencies sorts the dependencies by the semantic version in descending
 // order. The latest version of a dependency becomes the first element of the
 // slice.
-func SortNPMDependencies(dependencies []NPMDependency) {
+func SortNPMDependencies(dependencies []*NPMDependency) {
 	sort.Slice(dependencies, func(i, j int) bool {
-		iPkg, jPkg := dependencies[i].Package, dependencies[j].Package
-		if iPkg == jPkg {
+		iPkg, jPkg := dependencies[i].NPMPackage, dependencies[j].NPMPackage
+		if iPkg.Equal(jPkg) {
 			return versionGreaterThan(dependencies[i].Version, dependencies[j].Version)
 		}
 		if iPkg.scope == jPkg.scope {

--- a/internal/conf/reposource/npm_packages_test.go
+++ b/internal/conf/reposource/npm_packages_test.go
@@ -37,7 +37,7 @@ func TestParseNPMDependency(t *testing.T) {
 }
 
 func TestSortNPMDependencies(t *testing.T) {
-	dependencies := []NPMDependency{
+	dependencies := []*NPMDependency{
 		parseNPMDependencyOrPanic(t, "ac@1.2.0"),
 		parseNPMDependencyOrPanic(t, "ab@1.2.0.Final"),
 		parseNPMDependencyOrPanic(t, "aa@1.2.0"),
@@ -49,7 +49,7 @@ func TestSortNPMDependencies(t *testing.T) {
 		parseNPMDependencyOrPanic(t, "ab@1.2.0-RC1"),
 		parseNPMDependencyOrPanic(t, "ab@1.1.0"),
 	}
-	expected := []NPMDependency{
+	expected := []*NPMDependency{
 		parseNPMDependencyOrPanic(t, "ac@1.2.0"),
 		parseNPMDependencyOrPanic(t, "ab@1.11.0"),
 		parseNPMDependencyOrPanic(t, "ab@1.2.0"),
@@ -65,10 +65,10 @@ func TestSortNPMDependencies(t *testing.T) {
 	assert.Equal(t, expected, dependencies)
 }
 
-func parseNPMDependencyOrPanic(t *testing.T, value string) NPMDependency {
+func parseNPMDependencyOrPanic(t *testing.T, value string) *NPMDependency {
 	dependency, err := ParseNPMDependency(value)
 	if err != nil {
 		t.Fatalf("error=%s", err)
 	}
-	return *dependency
+	return dependency
 }

--- a/internal/conf/reposource/packages_helper.go
+++ b/internal/conf/reposource/packages_helper.go
@@ -1,5 +1,7 @@
 package reposource
 
+import "github.com/sourcegraph/sourcegraph/internal/api"
+
 // [NOTE: Dependency-terminology]
 // In a dependency graph of packages, such as when doing package resolution,
 // you have the notion of dependencies as a pair of a package + a version range
@@ -18,12 +20,26 @@ package reposource
 // dependency. However, we still use the same type to represent the root for
 // practical purposes. For naming values, prefer "VersionedPackage" for
 // situations where there is no connotation of a dependency edge.
-
 type PackageDependency interface {
-	// Give the name of the dependency as used by the package manager,
+	// The scheme of the dependency (semanticdb, npm)
+	Scheme() string
+
+	// Returns the name of the dependency as used by the package manager,
+	// excluding version information.
+	PackageSyntax() string
+	// Returns the name of the dependency as used by the package manager,
 	// including version information.
 	PackageManagerSyntax() string
+	// The version of the package.
+	PackageVersion() string
+
+	// RepoName provides a name that is "globally unique" for a Sourcegraph instance.
+	// The returned value is used for repo:... in queries.
+	RepoName() api.RepoName
+	// Returns the git tag associated with the given dependency version, used
+	// rev: or repo:foo@rev
+	GitTagFromVersion() string
 }
 
-var _ PackageDependency = MavenDependency{}
-var _ PackageDependency = NPMDependency{}
+var _ PackageDependency = &MavenDependency{}
+var _ PackageDependency = &NPMDependency{}

--- a/internal/extsvc/jvmpackages/coursier/coursier.go
+++ b/internal/extsvc/jvmpackages/coursier/coursier.go
@@ -53,7 +53,7 @@ func init() {
 	}
 }
 
-func FetchSources(ctx context.Context, config *schema.JVMPackagesConnection, dependency reposource.MavenDependency) (sourceCodeJarPath string, err error) {
+func FetchSources(ctx context.Context, config *schema.JVMPackagesConnection, dependency *reposource.MavenDependency) (sourceCodeJarPath string, err error) {
 	ctx, endObservation := operations.fetchSources.With(ctx, &err, observation.Args{LogFields: []otlog.Field{
 		otlog.String("dependency", dependency.PackageManagerSyntax()),
 	}})
@@ -98,7 +98,7 @@ func FetchSources(ctx context.Context, config *schema.JVMPackagesConnection, dep
 		return "", err
 	}
 	if len(paths) == 0 || (len(paths) == 1 && paths[0] == "") {
-		return "", ErrNoSources{Dependency: dependency}
+		return "", &ErrNoSources{Dependency: dependency}
 	}
 	if len(paths) > 1 {
 		return "", errors.Errorf("expected single JAR path but found multiple: %v", paths)
@@ -108,14 +108,14 @@ func FetchSources(ctx context.Context, config *schema.JVMPackagesConnection, dep
 
 // ErrNoSources indicates that a dependency has no sources
 type ErrNoSources struct {
-	Dependency reposource.MavenDependency
+	Dependency *reposource.MavenDependency
 }
 
 func (e ErrNoSources) Error() string {
-	return fmt.Sprintf("no sources for dependency %s", e.Dependency)
+	return fmt.Sprintf("no sources for dependency %v", e.Dependency)
 }
 
-func FetchByteCode(ctx context.Context, config *schema.JVMPackagesConnection, dependency reposource.MavenDependency) (byteCodeJarPath string, err error) {
+func FetchByteCode(ctx context.Context, config *schema.JVMPackagesConnection, dependency *reposource.MavenDependency) (byteCodeJarPath string, err error) {
 	ctx, endObservation := operations.fetchByteCode.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
@@ -142,7 +142,7 @@ func FetchByteCode(ctx context.Context, config *schema.JVMPackagesConnection, de
 	return paths[0], nil
 }
 
-func Exists(ctx context.Context, config *schema.JVMPackagesConnection, dependency reposource.MavenDependency) (exists bool, err error) {
+func Exists(ctx context.Context, config *schema.JVMPackagesConnection, dependency *reposource.MavenDependency) (exists bool, err error) {
 	ctx, endObservation := operations.exists.With(ctx, &err, observation.Args{LogFields: []otlog.Field{
 		otlog.String("dependency", dependency.PackageManagerSyntax()),
 	}})

--- a/internal/extsvc/jvmpackages/repos.go
+++ b/internal/extsvc/jvmpackages/repos.go
@@ -3,5 +3,5 @@ package jvmpackages
 import "github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 
 type Metadata struct {
-	Module reposource.MavenModule
+	Module *reposource.MavenModule
 }

--- a/internal/extsvc/npm/npm_test.go
+++ b/internal/extsvc/npm/npm_test.go
@@ -86,21 +86,21 @@ func TestCredentials(t *testing.T) {
 	absentDep, err := reposource.ParseNPMDependency("left-pad@1.3.1")
 	require.Nil(t, err)
 
-	exists, err := client.DoesDependencyExist(ctx, *presentDep)
+	exists, err := client.DoesDependencyExist(ctx, presentDep)
 	require.Nil(t, err)
 	require.True(t, exists)
 
-	exists, _ = client.DoesDependencyExist(ctx, *absentDep)
+	exists, _ = client.DoesDependencyExist(ctx, absentDep)
 	require.False(t, exists)
 
 	// Check that using the wrong credentials doesn't work
 	client.credentials = "incorrect_credentials"
 
-	_, err = client.DoesDependencyExist(ctx, *presentDep)
+	_, err = client.DoesDependencyExist(ctx, presentDep)
 	var npmErr1 npmError
 	require.True(t, errors.As(err, &npmErr1) && npmErr1.statusCode == http.StatusUnauthorized)
 
-	_, err = client.DoesDependencyExist(ctx, *absentDep)
+	_, err = client.DoesDependencyExist(ctx, absentDep)
 	var npmErr2 npmError
 	require.True(t, errors.As(err, &npmErr2) && npmErr2.statusCode == http.StatusUnauthorized)
 }
@@ -111,7 +111,7 @@ func TestAvailablePackageVersions(t *testing.T) {
 	defer stop()
 	pkg, err := reposource.ParseNPMPackageFromPackageSyntax("is-sorted")
 	require.Nil(t, err)
-	versionMap, err := client.AvailablePackageVersions(ctx, *pkg)
+	versionMap, err := client.AvailablePackageVersions(ctx, pkg)
 	require.Nil(t, err)
 	versions := []string{}
 	for v := range versionMap {
@@ -127,12 +127,12 @@ func TestDoesDependencyExist(t *testing.T) {
 	defer stop()
 	dep, err := reposource.ParseNPMDependency("left-pad@1.3.0")
 	require.Nil(t, err)
-	exists, err := client.DoesDependencyExist(ctx, *dep)
+	exists, err := client.DoesDependencyExist(ctx, dep)
 	require.Nil(t, err)
 	require.True(t, exists)
 	dep, err = reposource.ParseNPMDependency("left-pad@1.3.1")
 	require.Nil(t, err)
-	exists, _ = client.DoesDependencyExist(ctx, *dep)
+	exists, _ = client.DoesDependencyExist(ctx, dep)
 	require.False(t, exists)
 }
 
@@ -142,7 +142,7 @@ func TestFetchSources(t *testing.T) {
 	defer stop()
 	dep, err := reposource.ParseNPMDependency("is-sorted@1.0.0")
 	require.Nil(t, err)
-	readSeekCloser, err := client.FetchTarball(ctx, *dep)
+	readSeekCloser, err := client.FetchTarball(ctx, dep)
 	require.Nil(t, err)
 	defer readSeekCloser.Close()
 	gzipReader, err := gzip.NewReader(readSeekCloser)
@@ -177,6 +177,6 @@ func TestNoPanicOnNonexistentRegistry(t *testing.T) {
 	client.registryURL = "http://not-an-npm-registry.sourcegraph.com"
 	dep, err := reposource.ParseNPMDependency("left-pad@1.3.0")
 	require.Nil(t, err)
-	_, err = client.DoesDependencyExist(ctx, *dep)
+	_, err = client.DoesDependencyExist(ctx, dep)
 	require.NotNil(t, err)
 }

--- a/internal/extsvc/npm/npmpackages/repos.go
+++ b/internal/extsvc/npm/npmpackages/repos.go
@@ -3,5 +3,5 @@ package npmpackages
 import "github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 
 type Metadata struct {
-	Package reposource.NPMPackage
+	Package *reposource.NPMPackage
 }

--- a/internal/extsvc/npm/npmtest/npmtest.go
+++ b/internal/extsvc/npm/npmtest/npmtest.go
@@ -18,14 +18,14 @@ type MockClient struct {
 
 var _ npm.Client = &MockClient{}
 
-func (m *MockClient) AvailablePackageVersions(_ context.Context, pkg reposource.NPMPackage) (versions map[string]struct{}, err error) {
+func (m *MockClient) AvailablePackageVersions(_ context.Context, pkg *reposource.NPMPackage) (versions map[string]struct{}, err error) {
 	versions = map[string]struct{}{}
 	for dep := range m.TarballMap {
 		dep, err := reposource.ParseNPMDependency(dep)
 		if err != nil {
 			return versions, err
 		}
-		if pkg == dep.Package {
+		if *pkg == *dep.NPMPackage {
 			versions[dep.Version] = struct{}{}
 		}
 	}
@@ -35,12 +35,12 @@ func (m *MockClient) AvailablePackageVersions(_ context.Context, pkg reposource.
 	return versions, err
 }
 
-func (m *MockClient) DoesDependencyExist(ctx context.Context, dep reposource.NPMDependency) (exists bool, err error) {
+func (m *MockClient) DoesDependencyExist(ctx context.Context, dep *reposource.NPMDependency) (exists bool, err error) {
 	_, found := m.TarballMap[dep.PackageManagerSyntax()]
 	return found, nil
 }
 
-func (m *MockClient) FetchTarball(_ context.Context, dep reposource.NPMDependency) (closer io.ReadSeekCloser, err error) {
+func (m *MockClient) FetchTarball(_ context.Context, dep *reposource.NPMDependency) (closer io.ReadSeekCloser, err error) {
 	path, found := m.TarballMap[dep.PackageManagerSyntax()]
 	if !found {
 		return nil, errors.Newf("Unknown dependency: %s", dep.PackageManagerSyntax())

--- a/internal/repos/jvm_packages.go
+++ b/internal/repos/jvm_packages.go
@@ -197,18 +197,17 @@ func MavenDependencies(connection schema.JVMPackagesConnection) (dependencies []
 }
 
 func MavenModules(connection schema.JVMPackagesConnection) ([]*reposource.MavenModule, error) {
-	isAdded := make(map[reposource.MavenModule]bool)
+	isAdded := make(map[string]bool)
 	modules := []*reposource.MavenModule{}
 	dependencies, err := MavenDependencies(connection)
 	if err != nil {
 		return nil, err
 	}
 	for _, dep := range dependencies {
-		module := dep.MavenModule
-		if _, added := isAdded[*module]; !added {
-			modules = append(modules, module)
+		if key := dep.PackageSyntax(); !isAdded[key] {
+			modules = append(modules, dep.MavenModule)
+			isAdded[key] = true
 		}
-		isAdded[*module] = true
 	}
 	return modules, nil
 }

--- a/internal/repos/jvm_packages.go
+++ b/internal/repos/jvm_packages.go
@@ -129,7 +129,7 @@ func (s *JVMPackagesSource) listDependentRepos(ctx context.Context, results chan
 				log15.Warn("error parsing maven module", "error", err, "module", dep.Module)
 				continue
 			}
-			mavenDependency := reposource.MavenDependency{MavenModule: parsedModule, Version: dep.Version}
+			mavenDependency := &reposource.MavenDependency{MavenModule: parsedModule, Version: dep.Version}
 
 			// We dont return anything that isnt resolvable here, to reduce logspam from gitserver. This codepath
 			// should be hit much less frequently than gitservers attempts to get packages, so there should be less
@@ -156,7 +156,7 @@ func (s *JVMPackagesSource) listDependentRepos(ctx context.Context, results chan
 	log15.Info("finished listing resolvable maven artifacts", "totalDB", totalDBFetched, "resolvedDB", totalDBResolved, "totalConfig", len(modules), "timedout", timedOut)
 }
 
-func (s *JVMPackagesSource) makeRepo(module reposource.MavenModule) *types.Repo {
+func (s *JVMPackagesSource) makeRepo(module *reposource.MavenModule) *types.Repo {
 	urn := s.svc.URN()
 	cloneURL := module.CloneURL()
 	return &types.Repo{
@@ -185,7 +185,7 @@ func (s *JVMPackagesSource) ExternalServices() types.ExternalServices {
 	return types.ExternalServices{s.svc}
 }
 
-func MavenDependencies(connection schema.JVMPackagesConnection) (dependencies []reposource.MavenDependency, err error) {
+func MavenDependencies(connection schema.JVMPackagesConnection) (dependencies []*reposource.MavenDependency, err error) {
 	for _, dep := range connection.Maven.Dependencies {
 		dependency, err := reposource.ParseMavenDependency(dep)
 		if err != nil {
@@ -196,19 +196,19 @@ func MavenDependencies(connection schema.JVMPackagesConnection) (dependencies []
 	return dependencies, nil
 }
 
-func MavenModules(connection schema.JVMPackagesConnection) ([]reposource.MavenModule, error) {
+func MavenModules(connection schema.JVMPackagesConnection) ([]*reposource.MavenModule, error) {
 	isAdded := make(map[reposource.MavenModule]bool)
-	modules := []reposource.MavenModule{}
+	modules := []*reposource.MavenModule{}
 	dependencies, err := MavenDependencies(connection)
 	if err != nil {
 		return nil, err
 	}
 	for _, dep := range dependencies {
 		module := dep.MavenModule
-		if _, added := isAdded[module]; !added {
+		if _, added := isAdded[*module]; !added {
 			modules = append(modules, module)
 		}
-		isAdded[module] = true
+		isAdded[*module] = true
 	}
 	return modules, nil
 }

--- a/internal/repos/npm_packages_test.go
+++ b/internal/repos/npm_packages_test.go
@@ -44,7 +44,7 @@ func TestGetNPMDependencyRepos(t *testing.T) {
 			pkg, err := reposource.ParseNPMPackageFromPackageSyntax(dep.Package)
 			require.Nil(t, err)
 			depStrs = append(depStrs,
-				reposource.NPMDependency{*pkg, dep.Version}.PackageManagerSyntax(),
+				(&reposource.NPMDependency{pkg, dep.Version}).PackageManagerSyntax(),
 			)
 		}
 		sort.Strings(depStrs)
@@ -65,7 +65,7 @@ func TestGetNPMDependencyRepos(t *testing.T) {
 			require.Equal(t, len(deps), 1)
 			pkg, err := reposource.ParseNPMPackageFromPackageSyntax(deps[0].Package)
 			require.Nil(t, err)
-			depStrs = append(depStrs, reposource.NPMDependency{*pkg, deps[0].Version}.PackageManagerSyntax())
+			depStrs = append(depStrs, (&reposource.NPMDependency{pkg, deps[0].Version}).PackageManagerSyntax())
 			lastID = deps[0].ID
 		}
 		sort.Strings(depStrs)
@@ -131,7 +131,7 @@ func TestListRepos(t *testing.T) {
 	for _, dep := range dependencies {
 		dep, err := reposource.ParseNPMDependency(dep)
 		require.Nil(t, err)
-		expectedRepoURLs = append(expectedRepoURLs, string(dep.Package.RepoName()))
+		expectedRepoURLs = append(expectedRepoURLs, string(dep.RepoName()))
 	}
 	sort.Strings(expectedRepoURLs)
 	// Compare after uniquing after addressing [FIXME: deduplicate-listed-repos].
@@ -146,7 +146,7 @@ func insertDependencies(t *testing.T, ctx context.Context, s *dbstore.Store, dep
 		rows, err :=
 			s.Store.Query(ctx, sqlf.Sprintf(
 				`INSERT INTO lsif_dependency_repos (scheme, name, version) VALUES (%s, %s, %s)`,
-				dbstore.NPMPackagesScheme, dep.Package.PackageSyntax(), dep.Version))
+				dbstore.NPMPackagesScheme, dep.PackageSyntax(), dep.Version))
 		require.Nil(t, err)
 		for rows.Next() {
 		}


### PR DESCRIPTION
## Context

This commit extends the `reposource.PackageDependency` interface with
methods necessary for implementing dependency search (in a follow up PR).

Some methods of the added methods are already implemented by the
embedded type as long as it is a pointer, so we change signatures
everywhere to deal with pointers rather than values, which should have
the added benefit of avoiding a fair bit of unnecessary memory copies.

Part of #28932



## Test plan

This intends to be a semantics preserving refactoring which should be covered by existing unit and integration tests.


