### PR TITLE
Code monitors: move to worker

### DIFF
--- a/doc/admin/workers.md
+++ b/doc/admin/workers.md
@@ -40,6 +40,12 @@ This job periodically removes stale log entries for incoming webhooks.
 
 This job periodically removes old heartbeat records for inactive executor instances.
 
+#### `codemonitors-job`
+This job contains all the background processes for Code Monitors:
+1. Periodically execute searches
+2. Execute actions triggered by searches
+3. Cleanup of old execution logs
+
 ## Deploying workers
 
 By default, all of the jobs listed above are registered to a single instance of the `worker` service. For Sourcegraph instances operating over large data (e.g., a high number of repositories, large monorepos, high commit frequency, or regular precise code intelligence index uploads), a single `worker` instance may experience low throughput or stability issues.

--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/repo-updater/internal/authz"
 	frontendAuthz "github.com/sourcegraph/sourcegraph/enterprise/internal/authz"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches"
-	codemonitorsBackground "github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors/background"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	ossAuthz "github.com/sourcegraph/sourcegraph/internal/authz"
@@ -46,8 +45,6 @@ func enterpriseInit(
 	// NOTE: Internal actor is required to have full visibility of the repo table
 	// 	(i.e. bypass repository authorization).
 	ctx := actor.WithInternalActor(context.Background())
-
-	codemonitorsBackground.StartBackgroundJobs(ctx, edb.NewEnterpriseDB(db))
 
 	// No Batch Changes on dotcom, so we don't need to spawn the
 	// background jobs for this feature.

--- a/enterprise/cmd/worker/internal/codemonitors/codemonitor_job.go
+++ b/enterprise/cmd/worker/internal/codemonitors/codemonitor_job.go
@@ -1,12 +1,15 @@
 package codemonitors
 
 import (
+	"context"
+
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/workerdb"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors/background"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 )
 
 type codeMonitorJob struct{}

--- a/enterprise/cmd/worker/internal/codemonitors/codemonitor_job.go
+++ b/enterprise/cmd/worker/internal/codemonitors/codemonitor_job.go
@@ -1,0 +1,29 @@
+package codemonitors
+
+import (
+	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
+	"github.com/sourcegraph/sourcegraph/cmd/worker/workerdb"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors/background"
+	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/env"
+)
+
+type codeMonitorJob struct{}
+
+func NewCodeMonitorJob() job.Job {
+	return &codeMonitorJob{}
+}
+
+func (j *codeMonitorJob) Config() []env.Config {
+	return []env.Config{}
+}
+
+func (j *codeMonitorJob) Routines(ctx context.Context) ([]goroutine.BackgroundRoutine, error) {
+	sqlDB, err := workerdb.Init()
+	if err != nil {
+		return nil, err
+	}
+
+	return background.NewBackgroundJobs(ctx, edb.NewEnterpriseDB(database.NewDB(sqlDB))), nil
+}

--- a/enterprise/cmd/worker/internal/codemonitors/codemonitor_job.go
+++ b/enterprise/cmd/worker/internal/codemonitors/codemonitor_job.go
@@ -28,5 +28,5 @@ func (j *codeMonitorJob) Routines(ctx context.Context) ([]goroutine.BackgroundRo
 		return nil, err
 	}
 
-	return background.NewBackgroundJobs(ctx, edb.NewEnterpriseDB(database.NewDB(sqlDB))), nil
+	return background.NewBackgroundJobs(edb.NewEnterpriseDB(database.NewDB(sqlDB))), nil
 }

--- a/enterprise/cmd/worker/main.go
+++ b/enterprise/cmd/worker/main.go
@@ -14,6 +14,7 @@ import (
 	batchesmigrations "github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/batches/migrations"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/codeintel"
 	codeintelmigrations "github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/codeintel/migrations"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/codemonitors"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/executors"
 	workerinsights "github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/insights"
 	eiauthz "github.com/sourcegraph/sourcegraph/enterprise/internal/authz"
@@ -41,6 +42,7 @@ func main() {
 		"insights-job":             workerinsights.NewInsightsJob(),
 		"batches-janitor":          batchesjanitor.NewJanitorJob(),
 		"executors-janitor":        executors.NewJanitorJob(),
+		"codemonitors-job":         codemonitors.NewCodeMonitorJob(),
 	}
 
 	shared.Start(additionalJobs, registerEnterpriseMigrations)

--- a/enterprise/internal/codemonitors/background/background.go
+++ b/enterprise/internal/codemonitors/background/background.go
@@ -7,11 +7,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 )
 
-func StartBackgroundJobs(ctx context.Context, db edb.EnterpriseDB) {
-	routines := NewBackgroundJobs(ctx, db)
-	go goroutine.MonitorBackgroundRoutines(ctx, routines...)
-}
-
 func NewBackgroundJobs(ctx context.Context, db edb.EnterpriseDB) []goroutine.BackgroundRoutine {
 	codeMonitorsStore := db.CodeMonitors()
 

--- a/enterprise/internal/codemonitors/background/background.go
+++ b/enterprise/internal/codemonitors/background/background.go
@@ -7,12 +7,15 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 )
 
-func NewBackgroundJobs(ctx context.Context, db edb.EnterpriseDB) []goroutine.BackgroundRoutine {
+func NewBackgroundJobs(db edb.EnterpriseDB) []goroutine.BackgroundRoutine {
 	codeMonitorsStore := db.CodeMonitors()
 
 	triggerMetrics := newMetricsForTriggerQueries()
 	actionMetrics := newActionMetrics()
 
+	// Create a new context. Each background routine will wrap this with
+	// a cancellable context that is canceled when Stop() is called.
+	ctx := context.Background()
 	return []goroutine.BackgroundRoutine{
 		newTriggerQueryEnqueuer(ctx, codeMonitorsStore),
 		newTriggerJobsLogDeleter(ctx, codeMonitorsStore),


### PR DESCRIPTION
This moves the execution of code monitors into the worker process. It's a pretty straightforward move since all the code monitor jobs already implemented the `BackgroundRoutine` interface. 

Fixes #30931

## Test plan

I tested this manually since integration tests for code monitors are still...nonexistent. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


