### PR TITLE
Search jobs: convert alert wrapper to a job

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
 	"sort"
 	"strconv"
 	"sync"
@@ -31,7 +30,6 @@ import (
 	searchhoney "github.com/sourcegraph/sourcegraph/internal/honey/search"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/search"
-	"github.com/sourcegraph/sourcegraph/internal/search/alert"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/predicate"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
@@ -597,7 +595,7 @@ func (r *searchResolver) expandPredicates(ctx context.Context, oldPlan query.Pla
 				}
 
 				agg := streaming.NewAggregatingStream()
-				_, err = r.evaluateJob(ctx, agg, job.NewOrJob(children...))
+				_, err = job.NewOrJob(children...).Run(ctx, r.db, agg)
 				if err != nil {
 					return nil, err
 				}
@@ -646,77 +644,7 @@ func (r *searchResolver) results(ctx context.Context, stream streaming.Sender, p
 		return nil, err
 	}
 
-	return r.evaluateJob(ctx, stream, planJob)
-}
-
-// evaluateJob is a toplevel function that runs a search job to yield results.
-// A search job represents a tree of evaluation steps. If the deadline
-// is exceeded, returns a search alert with a did-you-mean link for the same
-// query with a longer timeout.
-func (r *searchResolver) evaluateJob(ctx context.Context, stream streaming.Sender, job job.Job) (_ *search.Alert, err error) {
-	tr, ctx := trace.New(ctx, "evaluateJob", "")
-	defer func() {
-		tr.SetError(err)
-		tr.Finish()
-	}()
-	tr.LazyPrintf("job name: %s", job.Name())
-
-	start := time.Now()
-	countingStream := streaming.NewResultCountingStream(stream)
-	statsObserver := streaming.NewStatsObservingStream(countingStream)
-	jobAlert, err := job.Run(ctx, r.db, statsObserver)
-
-	ao := alert.Observer{
-		Db:           r.db,
-		SearchInputs: r.SearchInputs,
-		HasResults:   countingStream.Count() > 0,
-	}
-	if err != nil {
-		ao.Error(ctx, err)
-	}
-	observerAlert, err := ao.Done()
-
-	// We have an alert for context timeouts and we have a progress
-	// notification for timeouts. We don't want to show both, so we only show
-	// it if no repos are marked as timedout. This somewhat couples us to how
-	// progress notifications work, but this is the third attempt at trying to
-	// fix this behaviour so we are accepting that.
-	if errors.Is(err, context.DeadlineExceeded) {
-		if !statsObserver.Status.Any(search.RepoStatusTimedout) {
-			usedTime := time.Since(start)
-			suggestTime := longer(2, usedTime)
-			return search.AlertForTimeout(usedTime, suggestTime, r.SearchInputs.OriginalQuery, r.SearchInputs.PatternType), nil
-		} else {
-			err = nil
-		}
-	}
-
-	return search.MaxPriorityAlert(jobAlert, observerAlert), err
-}
-
-// longer returns a suggested longer time to wait if the given duration wasn't long enough.
-func longer(n int, dt time.Duration) time.Duration {
-	dt2 := func() time.Duration {
-		Ndt := time.Duration(n) * dt
-		dceil := func(x float64) time.Duration {
-			return time.Duration(math.Ceil(x))
-		}
-		switch {
-		case math.Floor(Ndt.Hours()) > 0:
-			return dceil(Ndt.Hours()) * time.Hour
-		case math.Floor(Ndt.Minutes()) > 0:
-			return dceil(Ndt.Minutes()) * time.Minute
-		case math.Floor(Ndt.Seconds()) > 0:
-			return dceil(Ndt.Seconds()) * time.Second
-		default:
-			return 0
-		}
-	}()
-	lowest := 2 * time.Second
-	if dt2 < lowest {
-		return lowest
-	}
-	return dt2
+	return planJob.Run(ctx, r.db, stream)
 }
 
 type searchResultsStats struct {

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strings"
 	"testing"
-	"time"
 
 	mockrequire "github.com/derision-test/go-mockgen/testutil/require"
 	"github.com/google/go-cmp/cmp"
@@ -344,24 +343,6 @@ func TestSearchResolver_DynamicFilters(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-func TestLonger(t *testing.T) {
-	N := 2
-	noise := time.Nanosecond
-	for dt := time.Millisecond + noise; dt < time.Hour; dt += time.Millisecond {
-		dt2 := longer(N, dt)
-		if dt2 < time.Duration(N)*dt {
-			t.Fatalf("longer(%v)=%v < 2*%v, want more", dt, dt2, dt)
-		}
-		if strings.Contains(dt2.String(), ".") {
-			t.Fatalf("longer(%v).String() = %q contains an unwanted decimal point, want a nice round duration", dt, dt2)
-		}
-		lowest := 2 * time.Second
-		if dt2 < lowest {
-			t.Fatalf("longer(%v) = %v < %s, too short", dt, dt2, lowest)
-		}
 	}
 }
 

--- a/internal/search/job/alert.go
+++ b/internal/search/job/alert.go
@@ -1,0 +1,99 @@
+package job
+
+import (
+	"context"
+	"math"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/alert"
+	"github.com/sourcegraph/sourcegraph/internal/search/run"
+	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func NewAlertJob(inputs *run.SearchInputs, child Job) Job {
+	if _, ok := child.(*noopJob); ok {
+		return child
+	}
+	return &alertJob{
+		inputs: inputs,
+		child:  child,
+	}
+}
+
+type alertJob struct {
+	inputs *run.SearchInputs
+	child  Job
+}
+
+func (j *alertJob) Run(ctx context.Context, db database.DB, stream streaming.Sender) (_ *search.Alert, err error) {
+	tr, ctx := trace.New(ctx, "AlertJob", "")
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
+
+	start := time.Now()
+	countingStream := streaming.NewResultCountingStream(stream)
+	statsObserver := streaming.NewStatsObservingStream(countingStream)
+	jobAlert, err := j.child.Run(ctx, db, statsObserver)
+
+	ao := alert.Observer{
+		Db:           db,
+		SearchInputs: j.inputs,
+		HasResults:   countingStream.Count() > 0,
+	}
+	if err != nil {
+		ao.Error(ctx, err)
+	}
+	observerAlert, err := ao.Done()
+
+	// We have an alert for context timeouts and we have a progress
+	// notification for timeouts. We don't want to show both, so we only show
+	// it if no repos are marked as timedout. This somewhat couples us to how
+	// progress notifications work, but this is the third attempt at trying to
+	// fix this behaviour so we are accepting that.
+	if errors.Is(err, context.DeadlineExceeded) {
+		if !statsObserver.Status.Any(search.RepoStatusTimedout) {
+			usedTime := time.Since(start)
+			suggestTime := longer(2, usedTime)
+			return search.AlertForTimeout(usedTime, suggestTime, j.inputs.OriginalQuery, j.inputs.PatternType), nil
+		} else {
+			err = nil
+		}
+	}
+
+	return search.MaxPriorityAlert(jobAlert, observerAlert), err
+}
+
+func (j *alertJob) Name() string {
+	return "AlertJob"
+}
+
+// longer returns a suggested longer time to wait if the given duration wasn't long enough.
+func longer(n int, dt time.Duration) time.Duration {
+	dt2 := func() time.Duration {
+		Ndt := time.Duration(n) * dt
+		dceil := func(x float64) time.Duration {
+			return time.Duration(math.Ceil(x))
+		}
+		switch {
+		case math.Floor(Ndt.Hours()) > 0:
+			return dceil(Ndt.Hours()) * time.Hour
+		case math.Floor(Ndt.Minutes()) > 0:
+			return dceil(Ndt.Minutes()) * time.Minute
+		case math.Floor(Ndt.Seconds()) > 0:
+			return dceil(Ndt.Seconds()) * time.Second
+		default:
+			return 0
+		}
+	}()
+	lowest := 2 * time.Second
+	if dt2 < lowest {
+		return lowest
+	}
+	return dt2
+}

--- a/internal/search/job/alert.go
+++ b/internal/search/job/alert.go
@@ -14,6 +14,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
+// NewAlertJob creates a job that translates errors from child jobs
+// into alerts when necessary.
 func NewAlertJob(inputs *run.SearchInputs, child Job) Job {
 	if _, ok := child.(*noopJob); ok {
 		return child

--- a/internal/search/job/alert_test.go
+++ b/internal/search/job/alert_test.go
@@ -1,0 +1,25 @@
+package job
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLonger(t *testing.T) {
+	N := 2
+	noise := time.Nanosecond
+	for dt := time.Millisecond + noise; dt < time.Hour; dt += time.Millisecond {
+		dt2 := longer(N, dt)
+		if dt2 < time.Duration(N)*dt {
+			t.Fatalf("longer(%v)=%v < 2*%v, want more", dt, dt2, dt)
+		}
+		if strings.Contains(dt2.String(), ".") {
+			t.Fatalf("longer(%v).String() = %q contains an unwanted decimal point, want a nice round duration", dt, dt2)
+		}
+		lowest := 2 * time.Second
+		if dt2 < lowest {
+			t.Fatalf("longer(%v) = %v < %s, too short", dt, dt2, lowest)
+		}
+	}
+}

--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -631,7 +631,7 @@ func ToEvaluateJob(args *Args, q query.Basic) (Job, error) {
 		job = NewSelectJob(sp, job)
 	}
 
-	return NewTimeoutJob(timeout, NewLimitJob(maxResults, job)), err
+	return NewAlertJob(args.SearchInputs, NewTimeoutJob(timeout, NewLimitJob(maxResults, job))), err
 }
 
 // FromExpandedPlan takes a query plan that has had all predicates expanded,

--- a/internal/search/job/job_test.go
+++ b/internal/search/job/job_test.go
@@ -168,24 +168,26 @@ func TestToEvaluateJob(t *testing.T) {
 	}
 
 	autogold.Want("root limit for streaming search", `
-(TIMEOUT
-  20s
-  (LIMIT
-    500
-    (PARALLEL
-      RepoUniverseText
-      Repo
-      ComputeExcludedRepos)))
+(ALERT
+  (TIMEOUT
+    20s
+    (LIMIT
+      500
+      (PARALLEL
+        RepoUniverseText
+        Repo
+        ComputeExcludedRepos))))
 `).Equal(t, test("foo", search.Streaming))
 
 	autogold.Want("root limit for batch search", `
-(TIMEOUT
-  20s
-  (LIMIT
-    30
-    (PARALLEL
-      RepoUniverseText
-      Repo
-      ComputeExcludedRepos)))
+(ALERT
+  (TIMEOUT
+    20s
+    (LIMIT
+      30
+      (PARALLEL
+        RepoUniverseText
+        Repo
+        ComputeExcludedRepos))))
 `).Equal(t, test("foo", search.Batch))
 }

--- a/internal/search/job/printers.go
+++ b/internal/search/job/printers.go
@@ -131,6 +131,13 @@ func SexpFormat(job Job, sep, indent string) string {
 			writeSexp(j.child)
 			b.WriteString(")")
 			depth--
+		case *alertJob:
+			b.WriteString("(ALERT")
+			depth++
+			writeSep(b, sep, indent, depth)
+			writeSexp(j.child)
+			b.WriteString(")")
+			depth--
 		default:
 			panic(fmt.Sprintf("unsupported job %T for SexpFormat printer", job))
 		}
@@ -281,6 +288,13 @@ func PrettyMermaid(job Job) string {
 			writeEdge(b, depth, srcId, id)
 			writeMermaid(j.child)
 			depth--
+		case *alertJob:
+			srcId := id
+			depth++
+			writeNode(b, depth, RoundedStyle, &id, "ALERT")
+			writeEdge(b, depth, srcId, id)
+			writeMermaid(j.child)
+			depth--
 		default:
 			panic(fmt.Sprintf("unsupported job %T for PrettyMermaid printer", job))
 		}
@@ -395,7 +409,12 @@ func toJSON(job Job, verbose bool) interface{} {
 				Select: emitJSON(j.child),
 				Value:  j.path.String(),
 			}
-
+		case *alertJob:
+			return struct {
+				Alert interface{} `json:"ALERT"`
+			}{
+				Alert: emitJSON(j.child),
+			}
 		default:
 			panic(fmt.Sprintf("unsupported job %T for toJSON converter", job))
 		}

--- a/internal/search/job/types.go
+++ b/internal/search/job/types.go
@@ -44,4 +44,5 @@ var allJobs = []Job{
 	&LimitJob{},
 	&subRepoPermsFilterJob{},
 	&selectJob{},
+	&alertJob{},
 }


### PR DESCRIPTION
Previously, we had a method on `searchResolver` (`evaluateJob`) that translated any errors from a job into alerts. This converts that method into a job. This means that we basically have three, clean steps to `searchResolver.results()`:
1) expand predicates
2) convert the expanded plan to a job
3) run the job

We're getting close to being able to decouple search code from resolvers entirely.

I don't expect this job to exist long-term. I think the ideal situation is that either 1) jobs emit alerts that apply to them, or 2) we generate alerts by expecting the execution results, and don't return alerts from jobs at all.

## Test plan

Should be semantics-preserving and covered by integration tests.


<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


