### PR TITLE
search: predicate plans are optional

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -590,12 +590,7 @@ func (r *searchResolver) expandPredicates(ctx context.Context, oldPlan query.Pla
 	for _, q := range oldPlan {
 		q := q
 		g.Go(func() error {
-			predicatePlan, err := predicate.Substitute(q, func(pred query.Predicate) (result.Matches, error) {
-				plan, err := pred.Plan(q)
-				if err != nil {
-					return nil, err
-				}
-
+			predicatePlan, err := predicate.Substitute(q, func(plan query.Plan) (result.Matches, error) {
 				children := make([]job.Job, 0, len(plan))
 				for _, basicQuery := range plan {
 					child, err := job.ToEvaluateJob(r.JobArgs(), basicQuery)

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -21,8 +21,11 @@ type Predicate interface {
 	// into the predicate object.
 	ParseParams(string) error
 
-	// Plan generates a plan of (possibly multiple) queries to execute the
-	// behavior of a predicate in a query Q.
+	// Plan optionally generates a plan of queries to evaluate. Currently
+	// all such queries are evaluated and the results are substituted in the
+	// original query. If Plan returns nil, it means this predicate doesn't
+	// need evaluation and just exposes it's value in the query, which can
+	// be used for any purpose.
 	Plan(parent Basic) (Plan, error)
 }
 


### PR DESCRIPTION
In support of https://github.com/sourcegraph/sourcegraph/pull/31577.

Currently all predicates assume we generate and evaluate a subquery, and substitute results into the original query. This assumption was never meant to be a hard constraint--it only worked out that our goal at the time was to implement this behavior.

Predicate syntax itself has no bearing on the behavior (semantics) of evaluating predicates. For example, if someone wanted to add a predicate like `file:licenses(GPL)`, it should be possible, and simple, to just find whether this `licenses` predicate exists, and access its value `GPL`. What our internal logic decides to do with those values is completely up to itself and shouldn't impose that a predicate must generate a plan. This is the case with `repo:dependencies(...)` -- we simply want to access the values.

This PR updates the interface for predicate `Plan` to return `nil` if a predicate does not generate a plan or need evaluation. Values of predicates that don't generate plans can be pulled out with a simple helper function (will add in upcoming PR).

There may be more elegant ways to make the current plan/substitution optional, but this suffices for now, in the interest of `repo:dependencies(...)` work.

## Test plan
Added unit tests.


