### PR TITLE
search: add VisitPredicate helper

### DIFF
--- a/internal/search/query/visitor.go
+++ b/internal/search/query/visitor.go
@@ -71,3 +71,14 @@ func VisitField(nodes []Node, field string, f func(value string, negated bool, a
 		}
 	})
 }
+
+// VisitPredicate convenience function that calls `f` on all query predicates,
+// supplying the node's field and predicate info.
+func VisitPredicate(nodes []Node, f func(field, name, value string)) {
+	VisitParameter(nodes, func(gotField, value string, negated bool, annotation Annotation) {
+		if annotation.Labels.IsSet(IsPredicate) {
+			name, predValue := ParseAsPredicate(value)
+			f(gotField, name, predValue)
+		}
+	})
+}

--- a/internal/search/query/visitor_test.go
+++ b/internal/search/query/visitor_test.go
@@ -1,0 +1,24 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/hexops/autogold"
+)
+
+func TestSubstitute(t *testing.T) {
+	test := func(input string) string {
+		q, _ := ParseLiteral(input)
+		var result string
+		VisitPredicate(q, func(field, name, value string) {
+			if field == FieldRepo && name == "contains" {
+				result = "contains value is " + value
+			}
+		})
+		return result
+	}
+
+	autogold.Want("VisitPredicate visits predicates",
+		"contains value is file:foo").
+		Equal(t, test("repo:contains(file:foo)"))
+}


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/31591.
In support of https://github.com/sourcegraph/sourcegraph/pull/31577.

We can just use this helper to expose the value of `repo:dependencies` in the upcoming `q.Dependencies()` method.

## Test plan
Added unit test.


