### PR TITLE
search: remove dead FuzzifyRegexpPatterns

### DIFF
--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -646,15 +646,6 @@ func Map(query []Node, fns ...func([]Node) []Node) []Node {
 	return query
 }
 
-func FuzzifyRegexPatterns(nodes []Node) []Node {
-	return MapParameter(nodes, func(field string, value string, negated bool, annotation Annotation) Node {
-		if field == FieldRepo || field == FieldFile || field == FieldRepoHasFile {
-			value = strings.TrimSuffix(value, "$")
-		}
-		return Parameter{Field: field, Value: value, Negated: negated, Annotation: annotation}
-	})
-}
-
 // concatRevFilters removes rev: filters from parameters and attaches their value as @rev to the repo: filters.
 // Invariant: Guaranteed to succeed on a validat Basic query.
 func ConcatRevFilters(b Basic) Basic {

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -697,29 +697,6 @@ func TestReporevToRegex(t *testing.T) {
 	}
 }
 
-func TestFuzzifyRegexPatterns(t *testing.T) {
-	tests := []struct {
-		in   string
-		want string
-	}{
-		{in: "repo:foo$", want: `"repo:foo"`},
-		{in: "file:foo$", want: `"file:foo"`},
-		{in: "repohasfile:foo$", want: `"repohasfile:foo"`},
-		{in: "repo:foo$ file:bar$ author:foo", want: `(and "repo:foo" "file:bar" "author:foo")`},
-		{in: "repo:foo$ ^bar$", want: `(and "repo:foo" "^bar$")`},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.in, func(t *testing.T) {
-			query, _ := Parse(tt.in, SearchTypeRegex)
-			got := toString(FuzzifyRegexPatterns(query))
-			if got != tt.want {
-				t.Fatalf("got = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestContainsNoGlobSyntax(t *testing.T) {
 	tests := []struct {
 		in   string


### PR DESCRIPTION
This is dead. It was for globbing introduced in https://github.com/sourcegraph/sourcegraph/pull/12659 but since we've changed our suggestions code it doesn't apply any more. There still exists some globbing logic I want to keep since I have an experimental branch to support this, but we won't need the suggestion logic.

## Test plan
Removes dead code.

