### PR TITLE
search: remove dead types

### DIFF
--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -17,13 +17,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-type TypeParameters interface {
-	typeParametersValue()
-}
-
-func (SymbolsParameters) typeParametersValue() {}
-func (TextParameters) typeParametersValue()    {}
-
 type SymbolsParameters struct {
 	// Repo is the name of the repository to search in.
 	Repo api.RepoName `json:"repo"`


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/31601.

Jobs replace the need for these types

## Test plan
Semantics-preserving


