### PR TITLE
tests: reduce global DB mocks

### DIFF
--- a/enterprise/cmd/frontend/internal/licensing/enforcement/external_services.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/external_services.go
@@ -17,12 +17,12 @@ type ExternalServicesStore interface {
 
 // NewBeforeCreateExternalServiceHook enforces any per-tier validations prior to
 // creating a new external service.
-func NewBeforeCreateExternalServiceHook() func(ctx context.Context, db database.DB) error {
+func NewBeforeCreateExternalServiceHook() func(ctx context.Context, store database.ExternalServiceStore) error {
 	if !licensing.EnforceTiers {
 		return nil
 	}
 
-	return func(ctx context.Context, db database.DB) error {
+	return func(ctx context.Context, store database.ExternalServiceStore) error {
 		// Licenses are associated with features and resource limits according to
 		// the current plan. We first need to determine the instance license, and then
 		// extract the maximum external service count from it.
@@ -38,7 +38,7 @@ func NewBeforeCreateExternalServiceHook() func(ctx context.Context, db database.
 		}
 
 		// Next we'll grab the current count of external services.
-		extSvcCount, err := database.ExternalServices(db).Count(ctx, database.ExternalServicesListOptions{})
+		extSvcCount, err := store.Count(ctx, database.ExternalServicesListOptions{})
 		if err != nil {
 			return err
 		}

--- a/enterprise/cmd/frontend/internal/licensing/enforcement/external_services_test.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/external_services_test.go
@@ -54,11 +54,10 @@ func TestNewPreCreateExternalServiceHook(t *testing.T) {
 			}
 			defer func() { licensing.MockGetConfiguredProductLicenseInfo = nil }()
 
-			database.Mocks.ExternalServices.Count = func(ctx context.Context, opt database.ExternalServicesListOptions) (int, error) {
-				return test.externalServiceCount, nil
-			}
+			externalServices := database.NewMockExternalServiceStore()
+			externalServices.CountFunc.SetDefaultReturn(test.externalServiceCount, nil)
 			t.Cleanup(func() { database.Mocks.ExternalServices.Count = nil })
-			err := NewBeforeCreateExternalServiceHook()(context.Background(), nil)
+			err := NewBeforeCreateExternalServiceHook()(context.Background(), externalServices)
 			if gotErr := err != nil; gotErr != test.wantErr {
 				t.Errorf("got error %v, want %v", gotErr, test.wantErr)
 			}

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -34,7 +34,7 @@ import (
 
 // BeforeCreateExternalService (if set) is invoked as a hook prior to creating a
 // new external service in the database.
-var BeforeCreateExternalService func(context.Context, DB) error
+var BeforeCreateExternalService func(context.Context, ExternalServiceStore) error
 
 type ExternalServiceStore interface {
 	// Count counts all external services that satisfy the options (ignoring limit and offset).
@@ -702,7 +702,7 @@ func (e *externalServiceStore) Create(ctx context.Context, confGet func() *conf.
 
 	// Prior to saving the record, run a validation hook.
 	if BeforeCreateExternalService != nil {
-		if err := BeforeCreateExternalService(ctx, NewDB(e.Store.Handle().DB())); err != nil {
+		if err := BeforeCreateExternalService(ctx, NewDB(e.Store.Handle().DB()).ExternalServices()); err != nil {
 			return err
 		}
 	}

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -503,7 +503,7 @@ func TestExternalServicesStore_CreateWithTierEnforcement(t *testing.T) {
 		Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
 	}
 	store := ExternalServices(db)
-	BeforeCreateExternalService = func(ctx context.Context, _ DB) error {
+	BeforeCreateExternalService = func(ctx context.Context, _ ExternalServiceStore) error {
 		return errcode.NewPresentationError("test plan limit exceeded")
 	}
 	t.Cleanup(func() { BeforeCreateExternalService = nil })


### PR DESCRIPTION
This PR reduces usage of `database.Mocks`.

This is the result of a time-boxed effort.

## Test plan

As long as CI passes.

---

Part of #26113
