### PR TITLE
sg: remove deprecated run-set command

### DIFF
--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -47,7 +47,6 @@ var (
 		},
 		Subcommands: []*ffcli.Command{
 			runCommand,
-			runSetCommand,
 			startCommand,
 			testCommand,
 			doctorCommand,

--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -36,16 +36,6 @@ var (
 		FlagSet: startFlagSet,
 		Exec:    startExec,
 	}
-
-	// run-set is the deprecated older version of `start`
-	runSetFlagSet = flag.NewFlagSet("sg run-set", flag.ExitOnError)
-	runSetCommand = &ffcli.Command{
-		Name:       "run-set",
-		ShortUsage: "sg run-set <commandset>",
-		ShortHelp:  "DEPRECATED. Use 'sg start' instead. Run the given commandset.",
-		FlagSet:    runSetFlagSet,
-		Exec:       runSetExec,
-	}
 )
 
 func constructStartCmdLongHelp() string {
@@ -225,29 +215,6 @@ func parseCsv(input string) []string {
 		results = append(results, strings.TrimSpace(token))
 	}
 	return results
-}
-
-var deprecationStyle = output.CombineStyles(output.Fg256Color(255), output.Bg256Color(124))
-
-func runSetExec(ctx context.Context, args []string) error {
-	stdout.Out.WriteLine(output.Linef("", deprecationStyle, " _______________________________________________________________________ "))
-	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "/         `sg run-set` is deprecated - use `sg start` instead!          \\"))
-	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "!                                                                       !"))
-	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "!         Run `sg start -help` for usage information.                   !"))
-	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "\\_______________________________________________________________________/"))
-	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "                               !  !                                      "))
-	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "                               !  !                                      "))
-	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "                               L_ !                                      "))
-	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "                              / _)!                                      "))
-	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "                             / /__L                                      "))
-	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "                       _____/ (____)                                     "))
-	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "                              (____)                                     "))
-	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "                       _____  (____)                                     "))
-	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "                            \\_(____)                                     "))
-	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "                               !  !                                      "))
-	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "                               !  !                                      "))
-	stdout.Out.WriteLine(output.Linef("", deprecationStyle, "                               \\__/                                      "))
-	return startExec(ctx, args)
 }
 
 func pathExists(path string) (bool, error) {


### PR DESCRIPTION
It's been a while since this has been deprecated, so I think it's pretty
safe to remove it now.


## Test plan

- Ran `go run . start` to make sure things still work


