### PR TITLE
Fix bad url linter false positives

### DIFF
--- a/dev/check/broken-urls.bash
+++ b/dev/check/broken-urls.bash
@@ -11,7 +11,7 @@ if [[ -n "$BUILDKITE_BRANCH" ]]; then
     fi
 fi
 
-URL_MATCHES=$(git grep -h -e https://about.sourcegraph.com --and --not -e '^\s*//' --and --not -e 'CI\:URL_OK' -- '*.go' '*.js' '*.jsx' '*.ts' '*.tsx' '*.json' ':(exclude)vendor' | grep -Eo 'https://about.sourcegraph.com[^'"'"'`)>" ]+' | sed 's/\.$//' | sort -u)
+URL_MATCHES=$(git grep -h -e https://about.sourcegraph.com --and --not -e '^\s*//' --and --not -e 'CI\:URL_OK' -- '*.go' '*.js' '*.jsx' '*.ts' '*.tsx' '*.json' ':(exclude)vendor' ':(exclude)*testdata*' | grep -Eo 'https://about.sourcegraph.com[^'"'"'`)>" ]+' | sed 's/\.$//' | sort -u)
 
 for url in $URL_MATCHES; do
     if ! curl -fsSL -o /dev/null --max-time 5 --retry 3 --retry-max-time 5 --retry-delay 1 "$url"; then

--- a/dev/release/src/github.ts
+++ b/dev/release/src/github.ts
@@ -661,7 +661,7 @@ export async function createLatestRelease(
     }
 
     const updateURL = 'https://docs.sourcegraph.com/admin/updates'
-    const releasePostURL = `https://about.sourcegraph.com/blog/release/${release.major}.${release.minor}`
+    const releasePostURL = `https://about.sourcegraph.com/blog/release/${release.major}.${release.minor}` // CI:URL_OK
 
     const request: Octokit.RequestOptions & Octokit.ReposCreateReleaseParams = {
         owner,


### PR DESCRIPTION
This fixes a few false positives that were caused by the bad URL linter running on testdata and a hard to parse generated URL. 

Relates to #31612

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

- local test run of the script 

<img width="538" alt="image" src="https://user-images.githubusercontent.com/10151/155111345-7a6cba13-74d7-4b99-9457-491a3ea562e2.png">

