### PR TITLE
Handle hadolint curl failure due to missing arch

### DIFF
--- a/dev/check/docker-lint.sh
+++ b/dev/check/docker-lint.sh
@@ -1,14 +1,29 @@
 #!/usr/bin/env bash
 
-set -e
+set -eu
 
 HADOLINT=./.bin/hadolint
 HADOLINT_VERSION=v1.15.0
 
+arch=$(uname -m)
+os=$(uname -s)
+
+# Previous versions of this script may have downloaded a 404 as the binary
+if [[ -f "$HADOLINT" ]]; then
+  if head -c 10 "$HADOLINT" | grep "Not Found" >/dev/null; then
+    rm $HADOLINT
+  fi
+fi
+
+# Hadolint does not release arm64 binaries, rely on Rosetta instead.
+if [[ "$os" == "Darwin" ]] && [[ "$arch" = "arm64" ]]; then
+  arch="x86_64"
+fi
+
 if [[ ! -f "$HADOLINT" ]]; then
   echo "--- install hadolint"
   mkdir -p .bin
-  curl -sL -o $HADOLINT "https://github.com/hadolint/hadolint/releases/download/$HADOLINT_VERSION/hadolint-$(uname -s)-$(uname -m)"
+  curl -sLf -o $HADOLINT -w "Downloading hadolint from %{url}\n%{http_code}\n" "https://github.com/hadolint/hadolint/releases/download/$HADOLINT_VERSION/hadolint-$os-$arch"
   chmod 700 $HADOLINT
 fi
 


### PR DESCRIPTION
Along with fixing the issue on M1 macs, I added some code to kill previous incorrect binaries. The script will now print the HTTP status of the DL and fail if curl fails to DL. 

Relates to #31612

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

- Local testing with and without the invalid binary (containing `Not found` due to the previous `curl` call without `-f`) 
