### PR TITLE
user invites: Log when users visit the sign-up page using the invited…

### DIFF
--- a/client/web/src/auth/CloudSignUpPage.tsx
+++ b/client/web/src/auth/CloudSignUpPage.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import ChevronLeftIcon from 'mdi-react/ChevronLeftIcon'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useLocation } from 'react-router-dom'
 
 import { useQuery } from '@sourcegraph/http-client'
@@ -73,6 +73,12 @@ export const CloudSignUpPage: React.FunctionComponent<Props> = ({
         skip: !invitedBy,
     })
     const invitedByUser = data?.user
+
+    useEffect(() => {
+        if (invitedBy !== null) {
+            telemetryService.log('SignUpInvitedByUser')
+        }
+    }, [telemetryService, invitedBy])
 
     const logEvent = (type: AuthProvider['serviceType']): void => {
         const eventType = type === 'builtin' ? 'form' : type


### PR DESCRIPTION
Closes #31613

From the task:

> Right now, when a user visits an invite link like `https://sourcegraph.test:3443/sign-up?invitedBy=philippspiess` we don't have anything logged that we can use to distinguish this from a visit to `https://sourcegraph.test:3443/sign-up`.

## Test plan

You can enable the console debug mode (`localStorage.enableLogDebug = "true"` in the console) and verify that this emits an event. Note that this is not a "view" prefixed event since we already have a generic view event for all sign-up pages that won't allow us to add custom properties, unfortunately.

![Screenshot 2022-02-22 at 11 47 22](https://user-images.githubusercontent.com/458591/155117095-fb5acddd-409c-4b92-9577-1511cb9990b4.png)

 