### PR TITLE
Fix sg check shell broken locally due to annotation and missing arch

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -2,7 +2,7 @@ golang 1.17.5
 nodejs 16.7.0
 yarn 1.22.17
 fd 7.4.0
-shfmt 3.2.0
+shfmt 3.4.3
 shellcheck 0.7.1
 kubectl 1.21.7
 github-cli 2.0.0

--- a/dev/check/docsite.sh
+++ b/dev/check/docsite.sh
@@ -15,7 +15,7 @@ set -e
 
 echo -e "$OUT"
 
-if [ $EXIT_CODE -ne 0 ]; then
+if [ $EXIT_CODE -ne 0 ] && [[ "$CI" == "true" ]]; then
   echo -e "$OUT" >./annotations/docsite
   echo "^^^ +++"
 fi

--- a/dev/check/shellcheck.sh
+++ b/dev/check/shellcheck.sh
@@ -18,7 +18,7 @@ EXIT_CODE=$?
 set -e
 echo -e "$OUT"
 
-if [ $EXIT_CODE -ne 0 ]; then
+if [ $EXIT_CODE -ne 0 ] && [[ "$CI" == "true" ]]; then
   echo -e "$OUT" >./annotations/shellcheck
   echo "^^^ +++"
 fi

--- a/dev/check/shfmt.sh
+++ b/dev/check/shfmt.sh
@@ -11,7 +11,7 @@ EXIT_CODE=$?
 set -e
 echo -e "$OUT"
 
-if [ $EXIT_CODE -ne 0 ]; then
+if [ $EXIT_CODE -ne 0 ] && [[ "$CI" == "true" ]]; then
   echo -e "$OUT" >./annotations/shfmt
   echo "^^^ +++"
 fi

--- a/enterprise/dev/ci/scripts/upload-build-logs.sh
+++ b/enterprise/dev/ci/scripts/upload-build-logs.sh
@@ -18,6 +18,7 @@ if [ "$1" == "-h" ]; then
   exit 1
 fi
 
+# shellcheck disable=SC1091
 source /root/.profile
 
 set -euo pipefail


### PR DESCRIPTION
Relates to #31612

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

- Tested locally, with both `unset CI` and `export CI=true` 

