### PR TITLE
Wildcard: [Tabs] Support item wrapping for the mobile screen

### DIFF
--- a/client/wildcard/src/components/Tabs/Tabs.module.scss
+++ b/client/wildcard/src/components/Tabs/Tabs.module.scss
@@ -12,7 +12,8 @@
     [data-reach-tab] {
         align-items: center;
         letter-spacing: normal;
-        margin: 0 0.375rem;
+        margin: 0;
+        min-height: 2rem;
         padding: 0 0.125rem;
         color: var(--body-color);
         text-transform: none;
@@ -65,12 +66,17 @@
     }
 
     .tablist-wrapper {
-        min-height: 2rem;
         border-bottom: 1px solid var(--border-color-2);
         padding-bottom: 0;
         display: flex;
         align-items: stretch;
         justify-content: space-between;
+    }
+
+    .tab-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
     }
 
     .small {

--- a/client/wildcard/src/components/Tabs/Tabs.tsx
+++ b/client/wildcard/src/components/Tabs/Tabs.tsx
@@ -57,7 +57,9 @@ export interface TabListProps extends PropsWithAs<As, ReachTabListProps>, React.
 }
 
 export interface TabProps extends PropsWithAs<As, ReachTabProps>, React.HTMLAttributes<HTMLDivElement> {}
+
 export interface TabPanelsProps extends PropsWithAs<As, ReachTabPanelsProps>, React.HTMLAttributes<HTMLDivElement> {}
+
 export interface TabPanelProps extends PropsWithAs<As, ReachTabPanelProps>, React.HTMLAttributes<HTMLDivElement> {}
 
 /**
@@ -82,10 +84,16 @@ export const Tabs: React.FunctionComponent<TabsProps> = React.forwardRef((props,
 })
 
 export const TabList: React.FunctionComponent<TabListProps> = React.forwardRef((props, reference) => {
-    const { actions, as = 'div', wrapperClassName, ...reachProps } = props
+    const { actions, as = 'div', wrapperClassName, className, ...reachProps } = props
     return (
         <div className={classNames(styles.tablistWrapper, wrapperClassName)}>
-            <ReachTabList data-testid="wildcard-tab-list" as={as} ref={reference} {...reachProps} />
+            <ReachTabList
+                data-testid="wildcard-tab-list"
+                as={as}
+                ref={reference}
+                className={classNames(className, styles.tabList)}
+                {...reachProps}
+            />
             {actions}
         </div>
     )


### PR DESCRIPTION
This PR improves `<Tabs />` component layout for the mobile layouts. Prior to this PR, all tabs buttons were placed always in just one row. 

The following screenshots were taken from Code Insights landing page but I assume this problem would be solved in other placese where Tabs are used as well. 

<table>
  <tr>
     <th>Before</th>
     <th>After</th>
  </tr>
  <tr>
     <td>
<img width="568" alt="Screenshot 2022-02-22 at 16 32 33" src="https://user-images.githubusercontent.com/18492575/155143011-0917b7dd-3409-4e65-9669-5793e14dba0c.png">
     </td>
     <td>
<img width="532" alt="Screenshot 2022-02-22 at 16 33 14" src="https://user-images.githubusercontent.com/18492575/155143033-7fe9b8e8-aee2-4cf4-89ac-d00b3298d95c.png">
     </td>
  </tr>
</table>