### PR TITLE
repo-updater: Move debug code out of main

### DIFF
--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	connections "github.com/sourcegraph/sourcegraph/internal/database/connections/live"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -59,6 +60,12 @@ var stateHTMLTemplate string
 // created in Main are ready for use.
 type EnterpriseInit func(db database.DB, store *repos.Store, keyring keyring.Ring, cf *httpcli.Factory, server *repoupdater.Server) []debugserver.Dumper
 
+type LazyDebugserverEndpoint struct {
+	repoUpdaterStateEndpoint   http.HandlerFunc
+	listAuthzProvidersEndpoint http.HandlerFunc
+	gitserverReposStatus       http.HandlerFunc
+}
+
 func Main(enterpriseInit EnterpriseInit) {
 	// NOTE: Internal actor is required to have full visibility of the repo table
 	// 	(i.e. bypass repository authorization).
@@ -79,45 +86,10 @@ func Main(enterpriseInit EnterpriseInit) {
 	// Signals health of startup
 	ready := make(chan struct{})
 
-	type LazyDebugserverEndpoint struct {
-		repoUpdaterStateEndpoint   http.HandlerFunc
-		listAuthzProvidersEndpoint http.HandlerFunc
-		gitserverReposStatus       http.HandlerFunc
-	}
-	debugserverEndpoints := LazyDebugserverEndpoint{}
-
 	// Start debug server
-	go debugserver.NewServerRoutine(
-		ready,
-		debugserver.Endpoint{
-			Name: "Repo Updater State",
-			Path: "/repo-updater-state",
-			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				// wait until we're healthy to respond
-				<-ready
-				// repoUpdaterStateEndpoint is guaranteed to be assigned now
-				debugserverEndpoints.repoUpdaterStateEndpoint(w, r)
-			}),
-		},
-		debugserver.Endpoint{
-			Name: "List Authz Providers",
-			Path: "/list-authz-providers",
-			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				// wait until we're healthy to respond
-				<-ready
-				// listAuthzProvidersEndpoint is guaranteed to be assigned now
-				debugserverEndpoints.listAuthzProvidersEndpoint(w, r)
-			}),
-		},
-		debugserver.Endpoint{
-			Name: "Gitserver Repo Status",
-			Path: "/gitserver-repo-status",
-			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				<-ready
-				debugserverEndpoints.gitserverReposStatus(w, r)
-			}),
-		},
-	).Start()
+	debugserverEndpoints := LazyDebugserverEndpoint{}
+	debugServerRoutine := createDebugServerRoutine(ready, &debugserverEndpoints)
+	go debugServerRoutine.Start()
 
 	clock := func() time.Time { return time.Now().UTC() }
 
@@ -133,11 +105,12 @@ func Main(enterpriseInit EnterpriseInit) {
 		log.Fatalf("failed to initialize database store: %v", err)
 	}
 	db := database.NewDB(sqlDB)
-	// Generally we'll mark the service as ready sometime after the database
-	// has been connected; migrations may take a while and we don't want to
-	// start accepting traffic until we've fully constructed the server we'll
-	// be exposing. We have a bit more to do in this method, though, and the
-	// process will be marked ready further down this function.
+
+	// Generally we'll mark the service as ready sometime after the database has been
+	// connected; migrations may take a while and we don't want to start accepting
+	// traffic until we've fully constructed the server we'll be exposing. We have a
+	// bit more to do in this method, though, and the process will be marked ready
+	// further down this function.
 
 	repos.MustRegisterMetrics(db, envvar.SourcegraphDotComMode())
 
@@ -247,8 +220,124 @@ func Main(enterpriseInit EnterpriseInit) {
 
 	globals.WatchExternalURL(nil)
 
-	// TODO: Break this out of Main
-	debugserverEndpoints.repoUpdaterStateEndpoint = func(w http.ResponseWriter, r *http.Request) {
+	debugserverEndpoints.repoUpdaterStateEndpoint = repoUpdaterStatsHandler(db, scheduler, debugDumpers)
+	debugserverEndpoints.listAuthzProvidersEndpoint = listAuthzProvidersHandler()
+	debugserverEndpoints.gitserverReposStatus = gitserverReposStatusHandler(db)
+
+	// We mark the service as ready now AFTER assigning the additional endpoints in
+	// the debugserver constructed at the top of this function. This ensures we don't
+	// have a race between becoming ready and a debugserver request failing directly
+	// after being unblocked.
+	close(ready)
+
+	// NOTE: Internal actor is required to have full visibility of the repo table
+	// 	(i.e. bypass repository authorization).
+	authzBypass := func(f http.Handler) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			r = r.WithContext(actor.WithInternalActor(r.Context()))
+			f.ServeHTTP(w, r)
+		}
+	}
+	httpSrv := httpserver.NewFromAddr(addr, &http.Server{
+		ReadTimeout:  75 * time.Second,
+		WriteTimeout: 10 * time.Minute,
+		Handler:      ot.HTTPMiddleware(trace.HTTPMiddleware(authzBypass(handler), conf.DefaultClient())),
+	})
+	goroutine.MonitorBackgroundRoutines(ctx, httpSrv)
+}
+
+func createDebugServerRoutine(ready chan struct{}, debugserverEndpoints *LazyDebugserverEndpoint) goroutine.BackgroundRoutine {
+	return debugserver.NewServerRoutine(
+		ready,
+		debugserver.Endpoint{
+			Name: "Repo Updater State",
+			Path: "/repo-updater-state",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// wait until we're healthy to respond
+				<-ready
+				// repoUpdaterStateEndpoint is guaranteed to be assigned now
+				debugserverEndpoints.repoUpdaterStateEndpoint(w, r)
+			}),
+		},
+		debugserver.Endpoint{
+			Name: "List Authz Providers",
+			Path: "/list-authz-providers",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// wait until we're healthy to respond
+				<-ready
+				// listAuthzProvidersEndpoint is guaranteed to be assigned now
+				debugserverEndpoints.listAuthzProvidersEndpoint(w, r)
+			}),
+		},
+		debugserver.Endpoint{
+			Name: "Gitserver Repo Status",
+			Path: "/gitserver-repo-status",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				<-ready
+				debugserverEndpoints.gitserverReposStatus(w, r)
+			}),
+		},
+	)
+}
+
+func gitserverReposStatusHandler(db database.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		repo := r.FormValue("repo")
+		if repo == "" {
+			http.Error(w, "missing 'repo' param", http.StatusBadRequest)
+			return
+		}
+
+		status, err := db.GitserverRepos().GetByName(r.Context(), api.RepoName(repo))
+		if err != nil {
+			http.Error(w, fmt.Sprintf("fetching repository status: %q", err), http.StatusInternalServerError)
+			return
+		}
+
+		resp, err := json.MarshalIndent(status, "", "  ")
+		if err != nil {
+			http.Error(w, fmt.Sprintf("failed to marshal status: %q", err.Error()), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(resp)
+	}
+}
+
+func listAuthzProvidersHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		type providerInfo struct {
+			ServiceType        string `json:"service_type"`
+			ServiceID          string `json:"service_id"`
+			ExternalServiceURL string `json:"external_service_url"`
+		}
+
+		_, providers := authz.GetProviders()
+		infos := make([]providerInfo, len(providers))
+		for i, p := range providers {
+			_, id := extsvc.DecodeURN(p.URN())
+
+			// Note that the ID marshalling below replicates code found in `graphqlbackend`.
+			// We cannot import that package's code into this one (see /dev/check/go-dbconn-import.sh).
+			infos[i] = providerInfo{
+				ServiceType:        p.ServiceType(),
+				ServiceID:          p.ServiceID(),
+				ExternalServiceURL: fmt.Sprintf("%s/site-admin/external-services/%s", globals.ExternalURL(), relay.MarshalID("ExternalService", id)),
+			}
+		}
+
+		resp, err := json.MarshalIndent(infos, "", "  ")
+		if err != nil {
+			http.Error(w, "failed to marshal infos: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(resp)
+	}
+}
+
+func repoUpdaterStatsHandler(db database.DB, scheduler scheduler, debugDumpers []debugserver.Dumper) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
 		dumps := []interface{}{
 			scheduler.DebugDump(r.Context(), db),
 		}
@@ -301,79 +390,6 @@ func Main(enterpriseInit EnterpriseInit) {
 			}
 		}
 	}
-
-	debugserverEndpoints.listAuthzProvidersEndpoint = func(w http.ResponseWriter, r *http.Request) {
-		type providerInfo struct {
-			ServiceType        string `json:"service_type"`
-			ServiceID          string `json:"service_id"`
-			ExternalServiceURL string `json:"external_service_url"`
-		}
-
-		_, providers := authz.GetProviders()
-		infos := make([]providerInfo, len(providers))
-		for i, p := range providers {
-			_, id := extsvc.DecodeURN(p.URN())
-
-			// Note that the ID marshalling below replicates code found in `graphqlbackend`.
-			// We cannot import that package's code into this one (see /dev/check/go-dbconn-import.sh).
-			infos[i] = providerInfo{
-				ServiceType:        p.ServiceType(),
-				ServiceID:          p.ServiceID(),
-				ExternalServiceURL: fmt.Sprintf("%s/site-admin/external-services/%s", globals.ExternalURL(), relay.MarshalID("ExternalService", id)),
-			}
-		}
-
-		resp, err := json.MarshalIndent(infos, "", "  ")
-		if err != nil {
-			http.Error(w, "failed to marshal infos: "+err.Error(), http.StatusInternalServerError)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(resp)
-	}
-
-	debugserverEndpoints.gitserverReposStatus = func(w http.ResponseWriter, r *http.Request) {
-		repo := r.FormValue("repo")
-		if repo == "" {
-			http.Error(w, "missing 'repo' param", http.StatusBadRequest)
-			return
-		}
-
-		status, err := db.GitserverRepos().GetByName(r.Context(), api.RepoName(repo))
-		if err != nil {
-			http.Error(w, fmt.Sprintf("fetching repository status: %q", err), http.StatusInternalServerError)
-			return
-		}
-
-		resp, err := json.MarshalIndent(status, "", "  ")
-		if err != nil {
-			http.Error(w, fmt.Sprintf("failed to marshal status: %q", err.Error()), http.StatusInternalServerError)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(resp)
-	}
-
-	// We mark the service as ready now AFTER assigning the additional endpoints in
-	// the debugserver constructed at the top of this function. This ensures we don't
-	// have a race between becoming ready and a debugserver request failing directly
-	// after being unblocked.
-	close(ready)
-
-	// NOTE: Internal actor is required to have full visibility of the repo table
-	// 	(i.e. bypass repository authorization).
-	authzBypass := func(f http.Handler) http.HandlerFunc {
-		return func(w http.ResponseWriter, r *http.Request) {
-			r = r.WithContext(actor.WithInternalActor(r.Context()))
-			f.ServeHTTP(w, r)
-		}
-	}
-	httpSrv := httpserver.NewFromAddr(addr, &http.Server{
-		ReadTimeout:  75 * time.Second,
-		WriteTimeout: 10 * time.Minute,
-		Handler:      ot.HTTPMiddleware(trace.HTTPMiddleware(authzBypass(handler), conf.DefaultClient())),
-	})
-	goroutine.MonitorBackgroundRoutines(ctx, httpSrv)
 }
 
 type scheduler interface {
@@ -388,6 +404,9 @@ type scheduler interface {
 
 	// EnsureScheduled ensures that all the repos provided are known to the scheduler.
 	EnsureScheduled([]types.MinimalRepo)
+
+	// DebugDump returns the state of the update scheduler for debugging.
+	DebugDump(ctx context.Context, db dbutil.DB) interface{}
 }
 
 type permsSyncer interface {


### PR DESCRIPTION
This change moves all the debug endpoint logic out of main which makes
it a lot easier to follow the initialisation flow for repo-updater.
