### PR TITLE
Revert Mocha JUnit reporter usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,4 +163,3 @@ annotations/
 
 # Buildkite analytics files
 jest-junit.xml
-mocha-junit.xml

--- a/client/web/src/theme.test.ts
+++ b/client/web/src/theme.test.ts
@@ -9,7 +9,6 @@ import { useThemeProps } from './theme'
 // Don't test reacting to system-wide theme changes, for simplicity. This means that
 // observeSystemIsLightTheme's initial value will be used, but it will not monitor for subsequent
 // changes.
-// TODO trigger changes
 jest.mock('@sourcegraph/wildcard', () => {
     const actual = jest.requireActual('@sourcegraph/wildcard')
 

--- a/dev/ci/integration/e2e/test.sh
+++ b/dev/ci/integration/e2e/test.sh
@@ -5,75 +5,8 @@ set -ex
 
 URL="${1:-"http://localhost:7080"}"
 
-function integration_test() {
-  MOCHA_JUNIT_OUTPUT_DIR=$(mktemp -d)
-  export MOCHA_JUNIT_OUTPUT_DIR
-  MOCHA_FILE="$MOCHA_JUNIT_OUTPUT_DIR/mocha-junit.xml"
-  export MOCHA_FILE
-  trap 'rm -Rf "$MOCHA_JUNIT_OUTPUT_DIR"' EXIT
-
-  set +eo pipefail # so we still get the result if the test failed
-  local test_exit_code
-
-  echo "--- yarn run test-e2e"
-  env SOURCEGRAPH_BASE_URL="$URL" PERCY_ON=true ./node_modules/.bin/percy exec -- yarn run cover-e2e --reporter mocha-junit-reporter
-
-  # Save the test exit code so we can return it after submitting the test run to the analytics.
-  test_exit_code="$?"
-
-  set -eo pipefail # resume being strict about errors
-
-  # escape xml output properly for JSON
-  set +x
-  local quoted_xml
-  quoted_xml="$(jq -R -s '.' "$MOCHA_FILE")"
-
-  local data
-  data=$(
-    cat <<EOF
-{
-  "format": "junit",
-  "run_env": {
-    "CI": "buildkite",
-    "key": "$BUILDKITE_BUILD_ID",
-    "job_id": "$BUILDKITE_JOB_ID",
-    "branch": "$BUILDKITE_BRANCH",
-    "commit_sha": "$BUILDKITE_COMMIT",
-    "message": "$BUILDKITE_MESSAGE",
-    "url": "$BUILDKITE_BUILD_URL"
-  },
-  "data": $quoted_xml
-}
-EOF
-  )
-
-  echo -e "\n--- :information_source: Uploading test results to Buildkite analytics"
-  set +e
-  echo "$data" | curl \
-    --fail \
-    --request POST \
-    --url https://analytics-api.buildkite.com/v1/uploads \
-    --header "Authorization: Token token=\"$BUILDKITE_ANALYTICS_FRONTEND_E2E_TEST_SUITE_API_KEY\";" \
-    --header 'Content-Type: application/json' \
-    --data-binary @-
-  local curl_exit="$?"
-  if [ "$curl_exit" -eq 0 ]; then
-    echo -e "\n--- :information_source: Succesfully uploaded test results to Buildkite analytics"
-  else
-    echo -e "\n^^^ +++ :warning: Failed to upload test results to Buildkite analytics"
-  fi
-  set -e
-
-  unset MOCHA_JUNIT_OUTPUT_DIR
-  unset MOCHA_FILE
-  set -x
-
-  return "$test_exit_code"
-}
-
-BUILDKITE_ANALYTICS_FRONTEND_E2E_TEST_SUITE_API_KEY=$(gcloud secrets versions access latest --secret="BUILDKITE_ANALYTICS_FRONTEND_E2E_TEST_SUITE_API_KEY" --project="sourcegraph-ci" --quiet)
-
-integration_test
+echo "--- yarn run test-e2e"
+env SOURCEGRAPH_BASE_URL="$URL" PERCY_ON=true ./node_modules/.bin/percy exec -- yarn run cover-e2e
 
 echo "--- coverage"
 yarn nyc report -r json

--- a/dev/ci/integration/qa/test.sh
+++ b/dev/ci/integration/qa/test.sh
@@ -23,74 +23,9 @@ echo "--- TEST: Checking Sourcegraph instance is accessible"
 curl -f http://localhost:7080
 curl -f http://localhost:7080/healthz
 echo "--- TEST: Running tests"
-
-function qa_test() {
-  MOCHA_JUNIT_OUTPUT_DIR=$(mktemp -d)
-  export MOCHA_JUNIT_OUTPUT_DIR
-  MOCHA_FILE="$MOCHA_JUNIT_OUTPUT_DIR/mocha-junit.xml"
-  export MOCHA_FILE
-  trap 'rm -Rf "$MOCHA_JUNIT_OUTPUT_DIR"' EXIT
-
-  set +eo pipefail # so we still get the result if the test failed
-  local test_exit_code
-
-  pushd client/web
-  yarn run test:regression --reporter mocha-junit-reporter
-  # Save the test exit code so we can return it after submitting the test run to the analytics.
-  test_exit_code="$?"
-
-  popd
-
-  set -eo pipefail # resume being strict about errors
-
-  # escape xml output properly for JSON
-  set +x
-  local quoted_xml
-  quoted_xml="$(jq -R -s '.' "$MOCHA_FILE")"
-
-  local data
-  data=$(
-    cat <<EOF
-{
-  "format": "junit",
-  "run_env": {
-    "CI": "buildkite",
-    "key": "$BUILDKITE_BUILD_ID",
-    "job_id": "$BUILDKITE_JOB_ID",
-    "branch": "$BUILDKITE_BRANCH",
-    "commit_sha": "$BUILDKITE_COMMIT",
-    "message": "$BUILDKITE_MESSAGE",
-    "url": "$BUILDKITE_BUILD_URL"
-  },
-  "data": $quoted_xml
-}
-EOF
-  )
-
-  echo -e "\n--- :information_source: Uploading test results to Buildkite analytics"
-  set +e
-  echo "$data" | curl \
-    --fail \
-    --request POST \
-    --url https://analytics-api.buildkite.com/v1/uploads \
-    --header "Authorization: Token token=\"$BUILDKITE_ANALYTICS_FRONTEND_E2E_TEST_SUITE_API_KEY\";" \
-    --header 'Content-Type: application/json' \
-    --data-binary @-
-  local curl_exit="$?"
-  if [ "$curl_exit" -eq 0 ]; then
-    echo -e "\n--- :information_source: Succesfully uploaded test results to Buildkite analytics"
-  else
-    echo -e "\n^^^ +++ :warning: Failed to upload test results to Buildkite analytics"
-  fi
-  set -e
-
-  unset MOCHA_JUNIT_OUTPUT_DIR
-  unset MOCHA_FILE
-  set -x
-
-  return "$test_exit_code"
-}
-
-BUILDKITE_ANALYTICS_FRONTEND_E2E_TEST_SUITE_API_KEY=$(gcloud secrets versions access latest --secret="BUILDKITE_ANALYTICS_FRONTEND_E2E_TEST_SUITE_API_KEY" --project="sourcegraph-ci" --quiet)
-
-qa_test
+# Run all tests, and error if one fails
+test_status=0
+pushd client/web
+yarn run test:regression || test_status=1
+popd
+exit $test_status

--- a/package.json
+++ b/package.json
@@ -274,7 +274,6 @@
     "mime-types": "^2.1.28",
     "mini-css-extract-plugin": "^2.1.0",
     "mocha": "^8.3.2",
-    "mocha-junit-reporter": "^2.0.2",
     "mockdate": "^3.0.2",
     "monaco-editor-webpack-plugin": "^3.1.0",
     "mz": "^2.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16479,7 +16479,7 @@ mathml-tag-names@^2.1.3:
   resolved "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz#4ddadd67308e780cf16a47685878ee27b736a0a3"
   integrity sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==
 
-md5@^2.1.0, md5@^2.2.1:
+md5@^2.2.1:
   version "2.3.0"
   resolved "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz#c3da9a6aae3a30b46b7b0c349b87b110dc3bda4f"
   integrity sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==
@@ -16916,22 +16916,6 @@ mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.5, mkdirp@~0.5.1:
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
-
-mkdirp@^1.0.3, mkdirp@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
-  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
-
-mocha-junit-reporter@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/mocha-junit-reporter/-/mocha-junit-reporter-2.0.2.tgz#d521689b651dc52f52044739f8ffb368be415731"
-  integrity sha512-vYwWq5hh3v1lG0gdQCBxwNipBfvDiAM1PHroQRNp96+2l72e9wEUTw+mzoK+O0SudgfQ7WvTQZ9Nh3qkAYAjfg==
-  dependencies:
-    debug "^2.2.0"
-    md5 "^2.1.0"
-    mkdirp "~0.5.1"
-    strip-ansi "^6.0.1"
-    xml "^1.0.0"
 
 mocha@^8.3.2:
   version "8.3.2"
@@ -24259,7 +24243,7 @@ xml2js@~0.4.4:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
 
-xml@^1.0.0, xml@^1.0.1:
+xml@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
   integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=


### PR DESCRIPTION
## Description
We started generated JUnit reports through `mocha-junit-reporter` in this PR: https://github.com/sourcegraph/sourcegraph/pull/28262

This library appears to swallow the output of the CI command, so errors become very difficult to debug

This PR reverts the test commands back to their state before this reporter was added

Issue to fix/re-enable: https://github.com/sourcegraph/sourcegraph/issues/31627

## Test plan
1. Break some Mocha tests (e.g. e2e or qa tests)
2. Notice that the error is correctly surfaced in the command output

