### PR TITLE
pr-auditor: explicitly add success status

### DIFF
--- a/dev/pr-auditor/main.go
+++ b/dev/pr-auditor/main.go
@@ -57,7 +57,7 @@ func main() {
 		return
 	}
 	if payload.PullRequest.Draft {
-		log.Printf("skipping event on draft PR")
+		log.Println("skipping event on draft PR")
 		return
 	}
 	if payload.Action == "closed" && !payload.PullRequest.Merged {
@@ -154,8 +154,8 @@ func preMergeAudit(ctx context.Context, ghc *github.Client, payload *EventPayloa
 		stateDescription = "No test plan detected - please provide one!"
 		stateURL = "https://docs.sourcegraph.com/dev/background-information/testing_principles#test-plans"
 	default:
-		// No need to set a status
-		return nil
+		prState = "success"
+		stateDescription = "No action needed, nice!"
 	}
 
 	owner, repo := payload.Repository.GetOwnerAndName()


### PR DESCRIPTION
I thought initially we could save the API call, but this doesn't work if a PR _starts_ without a test plan and then gets a test plan - the commit status is never reset

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

<img width="969" alt="Screen Shot 2022-02-22 at 8 01 05 AM" src="https://user-images.githubusercontent.com/23356519/155171060-d53dc613-ed5e-4c63-8e03-1cb8894646df.png">

then added a test plan:

<img width="956" alt="image" src="https://user-images.githubusercontent.com/23356519/155170999-20ddea0d-fff7-48c9-afc0-f9fa3156e4b4.png">