### PR TITLE
search: Make search stack/notepad entries selectable

### DIFF
--- a/client/web/src/search/SearchStack.module.scss
+++ b/client/web/src/search/SearchStack.module.scss
@@ -12,7 +12,7 @@
     border: 1px solid var(--border-color-2);
     overflow: hidden;
 
-    width: 15rem;
+    width: 20rem;
 
     h4 {
         margin: 0;
@@ -42,9 +42,12 @@
         overflow-wrap: anywhere;
         background-color: var(--color-bg-);
 
-        &:hover,
-        &.selected {
+        &:hover {
             background-color: var(--color-bg-2);
+        }
+
+        &.selected {
+            background-color: var(--color-bg-3);
         }
     }
 

--- a/client/web/src/search/SearchStack.module.scss
+++ b/client/web/src/search/SearchStack.module.scss
@@ -42,7 +42,8 @@
         overflow-wrap: anywhere;
         background-color: var(--color-bg-);
 
-        &:hover {
+        &:hover,
+        &.selected {
             background-color: var(--color-bg-2);
         }
     }

--- a/client/web/src/search/SearchStack.test.tsx
+++ b/client/web/src/search/SearchStack.test.tsx
@@ -186,7 +186,7 @@ describe('Search Stack', () => {
             // item3
             // item4
             userEvent.click(item[1])
-            expect(screen.queryAllByRole('option', { selected: true }).length).toBe(1)
+            expect(screen.queryAllByRole('option', { selected: true })).toEqual([item[1]])
 
             item[2].focus()
             // item1
@@ -213,7 +213,7 @@ describe('Search Stack', () => {
             // item3
             // item4
             userEvent.click(item[1], { ctrlKey: true })
-            expect(screen.queryAllByRole('option', { selected: true })).toHaveLength(2)
+            expect(screen.queryAllByRole('option', { selected: true })).toEqual([item[0], item[1]])
 
             item[3].focus()
             // item1 <-
@@ -222,7 +222,7 @@ describe('Search Stack', () => {
             // item4 <-
             userEvent.keyboard('{ctrl}{space}')
 
-            expect(screen.queryAllByRole('option', { selected: true })).toHaveLength(3)
+            expect(screen.queryAllByRole('option', { selected: true })).toEqual([item[0], item[1], item[3]])
         })
 
         it('selects a range of items on shift+click', () => {
@@ -241,7 +241,7 @@ describe('Search Stack', () => {
             // item4
             userEvent.click(item[2], { shiftKey: true })
 
-            expect(screen.queryAllByRole('option', { selected: true })).toHaveLength(3)
+            expect(screen.queryAllByRole('option', { selected: true })).toEqual([item[0], item[1], item[2]])
         })
 
         it('extends the range of items on shift+click', () => {
@@ -266,7 +266,7 @@ describe('Search Stack', () => {
             // item4 <- (last)
             userEvent.click(item[0], { shiftKey: true })
 
-            expect(screen.queryAllByRole('option', { selected: true })).toHaveLength(4)
+            expect(screen.queryAllByRole('option', { selected: true })).toEqual(item)
         })
 
         it('selects a range of items on shift+space', () => {
@@ -287,7 +287,7 @@ describe('Search Stack', () => {
             item[2].focus()
             userEvent.keyboard('{shift}{space}')
 
-            expect(screen.queryAllByRole('option', { selected: true })).toHaveLength(3)
+            expect(screen.queryAllByRole('option', { selected: true })).toEqual([item[0], item[1], item[2]])
         })
 
         it('extends the range of items on shift+space', () => {
@@ -315,7 +315,7 @@ describe('Search Stack', () => {
             item[0].focus()
             userEvent.keyboard('{shift}{space}')
 
-            expect(screen.queryAllByRole('option', { selected: true })).toHaveLength(4)
+            expect(screen.queryAllByRole('option', { selected: true })).toEqual(item)
         })
 
         it('deletes all selected entries', () => {

--- a/client/web/src/search/SearchStack.test.tsx
+++ b/client/web/src/search/SearchStack.test.tsx
@@ -14,6 +14,10 @@ describe('Search Stack', () => {
     const renderSearchStack = (props?: Partial<{ initialOpen: boolean }>): RenderWithBrandedContextResult =>
         renderWithBrandedContext(<SearchStack {...props} />)
 
+    function open() {
+        userEvent.click(screen.getByRole('button', { name: 'Open search session' }))
+    }
+
     afterEach(cleanup)
 
     const mockEntries: SearchStackEntry[] = [
@@ -97,7 +101,7 @@ describe('Search Stack', () => {
 
         it('redirects to entries', () => {
             renderSearchStack()
-            userEvent.click(screen.getByRole('button', { name: 'Open search session' }))
+            open()
 
             const entryLinks = screen.queryAllByRole('link')
 
@@ -108,8 +112,8 @@ describe('Search Stack', () => {
 
         it('creates notebooks', () => {
             const result = renderSearchStack()
+            open()
 
-            userEvent.click(screen.getByRole('button', { name: 'Open search session' }))
             userEvent.click(screen.getByRole('button', { name: 'Create Notebook' }))
 
             expect(result.history.location.pathname).toMatchInlineSnapshot('"/notebooks/new"')
@@ -120,7 +124,7 @@ describe('Search Stack', () => {
 
         it('allows to delete entries', () => {
             renderSearchStack()
-            userEvent.click(screen.getByRole('button', { name: 'Open search session' }))
+            open()
 
             userEvent.click(screen.getAllByRole('button', { name: 'Remove entry' })[0])
             const entryLinks = screen.queryByRole('link')
@@ -129,10 +133,220 @@ describe('Search Stack', () => {
 
         it('opens the text annotation aria', () => {
             renderSearchStack()
-            userEvent.click(screen.getByRole('button', { name: 'Open search session' }))
+            open()
 
             userEvent.click(screen.getAllByRole('button', { name: 'Add annotation' })[0])
             expect(screen.queryByPlaceholderText('Type to add annotation...')).toBeInTheDocument()
+        })
+    })
+
+    describe('selection', () => {
+        beforeEach(() => {
+            useExperimentalFeatures.setState({ enableSearchStack: true })
+            useSearchStackState.setState({
+                entries: [
+                    {
+                        id: 0,
+                        type: 'search',
+                        query: 'TODO',
+                        caseSensitive: false,
+                        patternType: SearchPatternType.literal,
+                    },
+                    { id: 1, type: 'file', path: 'path/to/file', repo: 'test', revision: 'master', lineRange: null },
+                    {
+                        id: 2,
+                        type: 'search',
+                        query: 'another query',
+                        caseSensitive: true,
+                        patternType: SearchPatternType.literal,
+                    },
+                    {
+                        id: 3,
+                        type: 'search',
+                        query: 'yet another query',
+                        caseSensitive: true,
+                        patternType: SearchPatternType.literal,
+                    },
+                ],
+            })
+        })
+
+        it('selects an item on click or space', () => {
+            renderSearchStack()
+            open()
+
+            const item = screen.getAllByRole('option')
+            // item1 <-
+            // item2
+            // item3
+            // item4
+            userEvent.click(item[0])
+            // item1
+            // item2 <-
+            // item3
+            // item4
+            userEvent.click(item[1])
+            expect(screen.queryAllByRole('option', { selected: true }).length).toBe(1)
+
+            item[2].focus()
+            // item1
+            // item2
+            // item3 <-
+            // item4
+            userEvent.keyboard('{space}')
+
+            expect(screen.getByRole('option', { selected: true })).toBe(item[2])
+        })
+
+        it('selects multiple items on ctrl/meta+click/space', () => {
+            renderSearchStack()
+            open()
+
+            const item = screen.getAllByRole('option')
+            // item1 <-
+            // item2
+            // item3
+            // item4
+            userEvent.click(item[0])
+            // item1 <-
+            // item2 <-
+            // item3
+            // item4
+            userEvent.click(item[1], { ctrlKey: true })
+            expect(screen.queryAllByRole('option', { selected: true })).toHaveLength(2)
+
+            item[3].focus()
+            // item1 <-
+            // item2 <-
+            // item3
+            // item4 <-
+            userEvent.keyboard('{ctrl}{space}')
+
+            expect(screen.queryAllByRole('option', { selected: true })).toHaveLength(3)
+        })
+
+        it('selects a range of items on shift+click', () => {
+            renderSearchStack()
+            open()
+
+            const item = screen.getAllByRole('option')
+            // item1 <-
+            // item2
+            // item3
+            // item4
+            userEvent.click(item[0])
+            // item1 <- (last)
+            // item2 <-
+            // item3 <-
+            // item4
+            userEvent.click(item[2], { shiftKey: true })
+
+            expect(screen.queryAllByRole('option', { selected: true })).toHaveLength(3)
+        })
+
+        it('extends the range of items on shift+click', () => {
+            renderSearchStack()
+            open()
+
+            const item = screen.getAllByRole('option')
+            // item1
+            // item2 <-
+            // item3
+            // item4
+            userEvent.click(item[1])
+            // item1
+            // item2 <- (last)
+            // item3 <-
+            // item4 <-
+            userEvent.click(item[3], { shiftKey: true })
+            // Shift click always adds!
+            // item1 <-
+            // item2 <-
+            // item3 <-
+            // item4 <- (last)
+            userEvent.click(item[0], { shiftKey: true })
+
+            expect(screen.queryAllByRole('option', { selected: true })).toHaveLength(4)
+        })
+
+        it('selects a range of items on shift+space', () => {
+            renderSearchStack()
+            open()
+
+            const item = screen.getAllByRole('option')
+            // item1 <-
+            // item2
+            // item3
+            // item4
+            item[0].focus()
+            userEvent.keyboard('{space}')
+            // item1 <- (last)
+            // item2 <-
+            // item3 <-
+            // item4
+            item[2].focus()
+            userEvent.keyboard('{shift}{space}')
+
+            expect(screen.queryAllByRole('option', { selected: true })).toHaveLength(3)
+        })
+
+        it('extends the range of items on shift+space', () => {
+            renderSearchStack()
+            open()
+
+            const item = screen.getAllByRole('option')
+            // item1
+            // item2 <-
+            // item3
+            // item4
+            item[1].focus()
+            userEvent.keyboard('{space}')
+            // item1
+            // item2 <- (last)
+            // item3 <-
+            // item4 <-
+            item[3].focus()
+            userEvent.keyboard('{shift}{space}')
+            // Shift click always adds!
+            // item1 <-
+            // item2 <-
+            // item3 <-
+            // item4 <- (last)
+            item[0].focus()
+            userEvent.keyboard('{shift}{space}')
+
+            expect(screen.queryAllByRole('option', { selected: true })).toHaveLength(4)
+        })
+
+        it('deletes all selected entries', () => {
+            renderSearchStack()
+            open()
+
+            const item = screen.getAllByRole('option')
+            userEvent.click(item[0])
+            userEvent.click(item[2], { shiftKey: true })
+            userEvent.click(screen.queryAllByRole('button', { name: 'Remove all selected entries' })[0])
+
+            expect(screen.queryAllByRole('option').length).toBe(1)
+        })
+
+        it('does not select entry on toggle annotion click', () => {
+            renderSearchStack()
+            open()
+
+            userEvent.click(screen.queryAllByRole('button', { name: 'Add annotation' })[0])
+
+            expect(screen.queryByRole('option', { selected: true })).not.toBeInTheDocument()
+        })
+
+        it('does not select entry on typing space into the annotation area', () => {
+            renderSearchStack()
+            open()
+
+            userEvent.click(screen.queryAllByRole('button', { name: 'Add annotation' })[0])
+            userEvent.type(screen.getByPlaceholderText('Type to add annotation...'), '{space}')
+
+            expect(screen.queryByRole('option', { selected: true })).not.toBeInTheDocument()
         })
     })
 })

--- a/client/web/src/search/__snapshots__/SearchStack.test.tsx.snap
+++ b/client/web/src/search/__snapshots__/SearchStack.test.tsx.snap
@@ -2,90 +2,64 @@
 
 exports[`Search Stack inital state shows the add button if an entry can be added 1`] = `
 <DocumentFragment>
-  <div
-    aria-controls="search:search-stack"
-    aria-expanded="false"
-    aria-label="Open search session"
+  <section
+    aria-label="Notepad"
     class="root"
-    role="button"
-    tabindex="0"
+    id="search:search-stack"
   >
-    <button
-      class="btn btnPrimary btnSm button"
-      title="Add search"
-      type="button"
+    <div
+      aria-controls="search:search-stack"
+      aria-expanded="false"
+      aria-label="Open search session"
+      role="button"
+      tabindex="0"
     >
-      + 
-      <svg
-        class="mdi-icon icon-inline"
-        fill="currentColor"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
+      <button
+        class="btn btnPrimary btnSm button"
+        title="Add search"
+        type="button"
       >
-        <path
-          d="M9.5,3A6.5,6.5 0 0,1 16,9.5C16,11.11 15.41,12.59 14.44,13.73L14.71,14H15.5L20.5,19L19,20.5L14,15.5V14.71L13.73,14.44C12.59,15.41 11.11,16 9.5,16A6.5,6.5 0 0,1 3,9.5A6.5,6.5 0 0,1 9.5,3M9.5,5C7,5 5,7 5,9.5C5,12 7,14 9.5,14C12,14 14,12 14,9.5C14,7 12,5 9.5,5Z"
-        />
-      </svg>
-       Search
-    </button>
-  </div>
+        + 
+        <svg
+          class="mdi-icon icon-inline"
+          fill="currentColor"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+        >
+          <path
+            d="M9.5,3A6.5,6.5 0 0,1 16,9.5C16,11.11 15.41,12.59 14.44,13.73L14.71,14H15.5L20.5,19L19,20.5L14,15.5V14.71L13.73,14.44C12.59,15.41 11.11,16 9.5,16A6.5,6.5 0 0,1 3,9.5A6.5,6.5 0 0,1 9.5,3M9.5,5C7,5 5,7 5,9.5C5,12 7,14 9.5,14C12,14 14,12 14,9.5C14,7 12,5 9.5,5Z"
+          />
+        </svg>
+         Search
+      </button>
+    </div>
+  </section>
 </DocumentFragment>
 `;
 
 exports[`Search Stack inital state shows the top of the stack if entries exist 1`] = `
 <DocumentFragment>
-  <div
-    aria-controls="search:search-stack"
-    aria-expanded="false"
-    aria-label="Open search session"
+  <section
+    aria-label="Notepad"
     class="root"
-    role="button"
-    tabindex="0"
+    id="search:search-stack"
   >
     <div
-      class="entry"
+      aria-controls="search:search-stack"
+      aria-expanded="false"
+      aria-label="Open search session"
+      role="button"
+      tabindex="0"
     >
       <div
-        class="d-flex"
+        class="entry"
       >
-        <span
-          class="flex-shrink-0 text-muted mr-1"
+        <div
+          class="d-flex"
         >
-          <svg
-            class="mdi-icon icon-inline"
-            fill="currentColor"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-          >
-            <path
-              d="M6,2A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2H6M6,4H13V9H18V20H6V4M8,12V14H16V12H8M8,16V18H13V16H8Z"
-            />
-          </svg>
-        </span>
-        <span
-          class="flex-1"
-        >
-          <a
-            class="anchorLink p-0"
-            href="/test@master/-/blob/path/to/file"
-          >
-            <span
-              title="path/to/file"
-            >
-              file
-            </span>
-          </a>
-        </span>
-        <span
-          class="ml-1 d-flex"
-        >
-          <button
-            aria-label="Add annotation"
-            class="btn btnIcon text-muted"
-            title="Add annotation"
-            type="button"
+          <span
+            class="flex-shrink-0 text-muted mr-1"
           >
             <svg
               class="mdi-icon icon-inline"
@@ -95,31 +69,67 @@ exports[`Search Stack inital state shows the top of the stack if entries exist 1
               width="24"
             >
               <path
-                d="M14,17H7V15H14M17,13H7V11H17M17,9H7V7H17M19,3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3Z"
+                d="M6,2A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2H6M6,4H13V9H18V20H6V4M8,12V14H16V12H8M8,16V18H13V16H8Z"
               />
             </svg>
-          </button>
-          <button
-            aria-label="Remove entry"
-            class="btn btnIcon ml-1 text-muted"
-            title="Remove entry"
-            type="button"
+          </span>
+          <span
+            class="flex-1"
           >
-            <svg
-              class="mdi-icon icon-inline"
-              fill="currentColor"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
+            <a
+              class="anchorLink p-0"
+              href="/test@master/-/blob/path/to/file"
             >
-              <path
-                d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
-              />
-            </svg>
-          </button>
-        </span>
+              <span
+                title="path/to/file"
+              >
+                file
+              </span>
+            </a>
+          </span>
+          <span
+            class="ml-1 d-flex"
+          >
+            <button
+              aria-label="Add annotation"
+              class="btn btnIcon text-muted"
+              title="Add annotation"
+              type="button"
+            >
+              <svg
+                class="mdi-icon icon-inline"
+                fill="currentColor"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M14,17H7V15H14M17,13H7V11H17M17,9H7V7H17M19,3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3Z"
+                />
+              </svg>
+            </button>
+            <button
+              aria-label="Remove entry"
+              class="btn btnIcon ml-1 text-muted"
+              title="Remove entry"
+              type="button"
+            >
+              <svg
+                class="mdi-icon icon-inline"
+                fill="currentColor"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
+                />
+              </svg>
+            </button>
+          </span>
+        </div>
       </div>
     </div>
-  </div>
+  </section>
 </DocumentFragment>
 `;

--- a/client/web/src/stores/searchStack.test.ts
+++ b/client/web/src/stores/searchStack.test.ts
@@ -8,7 +8,7 @@ import { useExperimentalFeatures } from './experimentalFeatures'
 import {
     addSearchStackEntry,
     removeAllSearchStackEntries,
-    removeSearchStackEntry,
+    removeFromSearchStack,
     restorePreviousSession,
     SearchStackEntry,
     SearchStackEntryInput,
@@ -71,15 +71,15 @@ describe('search stack store', () => {
     })
 
     it('removes individual entries', () => {
-        useSearchStackState.setState({ entries: [exampleEntry, { ...exampleEntry }] })
-        removeSearchStackEntry(exampleEntry)
+        useSearchStackState.setState({ entries: [exampleEntry, { ...exampleEntry, id: 1 }] })
+        removeFromSearchStack(exampleEntry.id)
 
         const state = useSearchStackState.getState()
         expect(state.entries).toHaveLength(1)
     })
 
     it('removes all entries', () => {
-        useSearchStackState.setState({ entries: [exampleEntry, { ...exampleEntry }] })
+        useSearchStackState.setState({ entries: [exampleEntry, { ...exampleEntry, id: 1 }] })
         removeAllSearchStackEntries()
 
         const state = useSearchStackState.getState()

--- a/client/web/src/stores/searchStack.ts
+++ b/client/web/src/stores/searchStack.ts
@@ -149,17 +149,15 @@ export function restorePreviousSession(): void {
 
 export function removeFromSearchStack(idsToDelete: SearchStackEntryID | SearchStackEntryID[]): void {
     useSearchStackState.setState(currentState => {
-        let entries: SearchStackEntry[]
-        if (Array.isArray(idsToDelete)) {
-            entries = [...currentState.entries]
-            for (const id of idsToDelete) {
-                entries.splice(
-                    entries.findIndex(entry => entry.id === id),
-                    1
-                )
-            }
-        } else {
-            entries = currentState.entries.filter(entry => entry.id !== idsToDelete)
+        if (!Array.isArray(idsToDelete)) {
+            idsToDelete = [idsToDelete]
+        }
+        const entries = [...currentState.entries]
+        for (const id of idsToDelete) {
+            entries.splice(
+                entries.findIndex(entry => entry.id === id),
+                1
+            )
         }
         persistSession(entries)
         return { entries }

--- a/client/web/src/stores/searchStack.ts
+++ b/client/web/src/stores/searchStack.ts
@@ -9,12 +9,13 @@ import { omitFilter } from '@sourcegraph/shared/src/search/query/transformer'
 
 import { useExperimentalFeatures } from './experimentalFeatures'
 
+export type SearchStackEntryID = number
 export interface SearchEntry {
     type: 'search'
     /**
      * The ID is primarily used to let the UI uniquily identifiy each entry.
      */
-    id: number
+    id: SearchStackEntryID
     query: string
     caseSensitive: boolean
     searchContext?: string
@@ -27,7 +28,7 @@ export interface FileEntry {
     /**
      * The ID is primarily used to let the UI uniquily identifiy each entry.
      */
-    id: number
+    id: SearchStackEntryID
     path: string
     repo: string
     revision: string
@@ -146,9 +147,20 @@ export function restorePreviousSession(): void {
     }
 }
 
-export function removeSearchStackEntry(entryToDelete: SearchStackEntry): void {
+export function removeFromSearchStack(idsToDelete: SearchStackEntryID | SearchStackEntryID[]): void {
     useSearchStackState.setState(currentState => {
-        const entries = currentState.entries.filter(entry => entry !== entryToDelete)
+        let entries: SearchStackEntry[]
+        if (Array.isArray(idsToDelete)) {
+            entries = [...currentState.entries]
+            for (const id of idsToDelete) {
+                entries.splice(
+                    entries.findIndex(entry => entry.id === id),
+                    1
+                )
+            }
+        } else {
+            entries = currentState.entries.filter(entry => entry.id !== idsToDelete)
+        }
         persistSession(entries)
         return { entries }
     })


### PR DESCRIPTION
This commit adds the ability to select search stack/notepad entries via
click, ctrl/meta+click and shift+click.
The entries can also be selected via space, ctrl+space and shift+space
if they are focused.

In the end I went with role=listbox and role=option for the entries,
because I think that comes closes to how we want this component to
behave eventually. But note that more work is required to make this
component fully usable via [the keyboard](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/listbox_role#keyboard_interactions).

I also switched to using `<section>` since that seemed appropriate according to [this guide](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/region.html).


https://user-images.githubusercontent.com/179026/155176072-60757880-11c2-42c9-a1a5-e6a933fabbc3.mp4



## Test plan

New unit tests for selecting with and without modifier keys and via keyboard.

