### PR TITLE
Modified site config doc to include tls.external flag

### DIFF
--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -389,6 +389,14 @@
               "fetch": "customgitbinary someflag anotherflag"
             }
           ]
+        },
+        {
+          "tls.external": {
+            "certificates": [
+              "-----BEGIN CERTIFICATE-----\n..."
+            ],
+            "insecureSkipVerify": true
+          }
         }
       ],
       "group": "Experimental"

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -392,9 +392,7 @@
         },
         {
           "tls.external": {
-            "certificates": [
-              "-----BEGIN CERTIFICATE-----\n..."
-            ],
+            "certificates": ["-----BEGIN CERTIFICATE-----\n..."],
             "insecureSkipVerify": true
           }
         }


### PR DESCRIPTION
## Test plan

Debugged locally, no test plan required.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


