### PR TITLE
Search backend: rip out in-progress repo-aware code monitor ID stuff

### DIFF
--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -24,8 +24,6 @@ type CodeMonitorsResolver interface {
 	TriggerTestSlackWebhookAction(ctx context.Context, args *TriggerTestSlackWebhookActionArgs) (*EmptyResponse, error)
 
 	NodeResolvers() map[string]NodeByIDFunc
-
-	CodeMonitorSearch(context.Context, *SearchArgs) (SearchImplementer, error)
 }
 
 type MonitorConnectionResolver interface {

--- a/cmd/frontend/graphqlbackend/code_monitors.graphql
+++ b/cmd/frontend/graphqlbackend/code_monitors.graphql
@@ -1,24 +1,3 @@
-extend type Query {
-    """
-    Runs a code monitor search.
-    """
-    codeMonitorSearch(
-        """
-        PatternType controls the search pattern type, if and only if it is not specified in the query string using
-        the patternType: field.
-        """
-        patternType: SearchPatternType
-        """
-        The search query (such as "foo" or "repo:myrepo foo").
-        """
-        query: String = ""
-        """
-        codeMonitorID is the code monitor associated with this search
-        """
-        codeMonitorID: ID
-    ): Search
-}
-
 extend type Mutation {
     """
     Create a code monitor.

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -4,8 +4,6 @@ import (
 	"context"
 
 	"github.com/google/zoekt"
-	"github.com/graph-gophers/graphql-go"
-	"github.com/graph-gophers/graphql-go/relay"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -25,14 +23,6 @@ type SearchArgs struct {
 	Version     string
 	PatternType *string
 	Query       string
-
-	// CodeMonitorID, if set, is the graphql-encoded ID of the code monitor
-	// that is running the search. This will likely be removed in the future
-	// once the worker can mutate and execute the search directly, but for now,
-	// there are too many dependencies in frontend to do that. For anyone looking
-	// to rip this out in the future, this should be possible once we can build
-	// a static representation of our job tree independently of any resolvers.
-	CodeMonitorID *graphql.ID
 
 	// Stream if non-nil will stream all SearchEvents.
 	//
@@ -103,15 +93,6 @@ func NewSearchImplementer(ctx context.Context, db database.DB, args *SearchArgs)
 	}
 	tr.LazyPrintf("parsing done")
 
-	var codeMonitorID *int64
-	if args.CodeMonitorID != nil {
-		var i int64
-		if err := relay.UnmarshalSpec(*args.CodeMonitorID, &i); err != nil {
-			return nil, err
-		}
-		codeMonitorID = &i
-	}
-
 	protocol := search.Batch
 	if args.Stream != nil {
 		protocol = search.Streaming
@@ -124,7 +105,6 @@ func NewSearchImplementer(ctx context.Context, db database.DB, args *SearchArgs)
 		UserSettings:  settings,
 		Features:      featureflag.FromContext(ctx),
 		PatternType:   searchType,
-		CodeMonitorID: codeMonitorID,
 		Protocol:      protocol,
 	}
 

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -385,11 +385,6 @@ func (r *Resolver) TriggerTestSlackWebhookAction(ctx context.Context, args *grap
 	return &graphqlbackend.EmptyResponse{}, nil
 }
 
-func (r *Resolver) CodeMonitorSearch(ctx context.Context, args *graphqlbackend.SearchArgs) (graphqlbackend.SearchImplementer, error) {
-	args.Version = "V2"
-	return graphqlbackend.NewSearchImplementer(ctx, r.db, args)
-}
-
 func sendTestEmail(ctx context.Context, recipient graphql.ID, description string) error {
 	var (
 		userID int32

--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -32,7 +32,6 @@ type CommitSearch struct {
 	Diff                 bool
 	HasTimeFilter        bool
 	Limit                int
-	CodeMonitorID        *int64
 	IncludeModifiedFiles bool
 }
 
@@ -127,12 +126,6 @@ func (j *CommitSearch) Tags() []log.Field {
 		log.Bool("diff", j.Diff),
 		log.Bool("hasTimeFilter", j.HasTimeFilter),
 		log.Int("limit", j.Limit),
-		log.Int64("codeMonitorID", func() int64 {
-			if j.CodeMonitorID != nil {
-				return *j.CodeMonitorID
-			}
-			return 0
-		}()),
 		log.Bool("includeModifiedFiles", j.IncludeModifiedFiles),
 	}
 }

--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -60,13 +60,6 @@ func ToSearchJob(jargs *Args, q query.Q) (Job, error) {
 
 	var requiredJobs, optionalJobs []Job
 	addJob := func(required bool, job Job) {
-		// Filter out any jobs that aren't commit jobs as they are added
-		if jargs.SearchInputs.CodeMonitorID != nil {
-			if _, ok := job.(*commit.CommitSearch); !ok {
-				return
-			}
-		}
-
 		if required {
 			requiredJobs = append(requiredJobs, job)
 		} else {
@@ -224,7 +217,6 @@ func ToSearchJob(jargs *Args, q query.Q) (Job, error) {
 				Diff:                 diff,
 				HasTimeFilter:        commit.HasTimeFilter(args.Query),
 				Limit:                int(args.PatternInfo.FileMatchLimit),
-				CodeMonitorID:        jargs.SearchInputs.CodeMonitorID,
 				IncludeModifiedFiles: authz.SubRepoEnabled(authz.DefaultSubRepoPermsChecker),
 			})
 		}

--- a/internal/search/run/run.go
+++ b/internal/search/run/run.go
@@ -16,7 +16,6 @@ type SearchInputs struct {
 	PatternType   query.SearchType
 	UserSettings  *schema.Settings
 	Features      featureflag.FlagSet
-	CodeMonitorID *int64
 	Protocol      search.Protocol
 }
 


### PR DESCRIPTION
Since we're so close to being able to run search without importing
anything from graphqlbackend, I think that's the better target here.
None of this will be needed if we can just run searches from the worker
process, and it's just getting in the way at the moment.

Stacked on #31644 

## Test plan

This was all behind a feature flag, and everything else is covered by existing tests.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


