### PR TITLE
[cloud] Make invite_id field in JWT invitations lowercase

### DIFF
--- a/cmd/frontend/graphqlbackend/org_invitations.go
+++ b/cmd/frontend/graphqlbackend/org_invitations.go
@@ -65,7 +65,7 @@ type inviteUserToOrganizationResult struct {
 }
 
 type orgInvitationClaims struct {
-	InvitationID int64 `json:"invite_ID"`
+	InvitationID int64 `json:"invite_id"`
 	SenderID     int32 `json:"sender_id"`
 	jwt.RegisteredClaims
 }

--- a/cmd/frontend/graphqlbackend/org_invitations_test.go
+++ b/cmd/frontend/graphqlbackend/org_invitations_test.go
@@ -277,7 +277,7 @@ func TestInviteUserToOrganization(t *testing.T) {
 				ExpectedResult: `
 				{
 					"inviteUserToOrganization": {
-						"invitationURL": "http://example.com/organizations/invitation/eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJpbnZpdGVfSUQiOjEsInNlbmRlcl9pZCI6MCwiaXNzIjoiaHR0cDovL2V4YW1wbGUuY29tIiwic3ViIjoiMCIsImV4cCI6MTYxMTk2NDgwMH0.UGJRadHkOsL3PTPgyXTKJE1XYIh-DDDfL_MjIlR5FJJRXPkpEgF97L1S30_n_2Nrj__A3ipXCJ-SQmH8ASMbIg",
+						"invitationURL": "http://example.com/organizations/invitation/eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJpbnZpdGVfaWQiOjEsInNlbmRlcl9pZCI6MCwiaXNzIjoiaHR0cDovL2V4YW1wbGUuY29tIiwic3ViIjoiMCIsImV4cCI6MTYxMTk2NDgwMH0.26FeOWbKQJ0uZ6_aeCmbYoIb2mnP0e96hiSYrw1gd91CKyVvuZQRvbzDnUf4D2gOPnwBl4GLovBjByy6xgN1ow",
 						"sentInvitationEmail": false
 					}
 				}
@@ -341,7 +341,7 @@ func TestInviteUserToOrganization(t *testing.T) {
 				ExpectedResult: `
 				{
 					"inviteUserToOrganization": {
-						"invitationURL": "http://example.com/organizations/invitation/eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJpbnZpdGVfSUQiOjEsInNlbmRlcl9pZCI6MCwiaXNzIjoiaHR0cDovL2V4YW1wbGUuY29tIiwic3ViIjoiMCIsImV4cCI6MTYxMTk2NDgwMH0.UGJRadHkOsL3PTPgyXTKJE1XYIh-DDDfL_MjIlR5FJJRXPkpEgF97L1S30_n_2Nrj__A3ipXCJ-SQmH8ASMbIg",
+						"invitationURL": "http://example.com/organizations/invitation/eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJpbnZpdGVfaWQiOjEsInNlbmRlcl9pZCI6MCwiaXNzIjoiaHR0cDovL2V4YW1wbGUuY29tIiwic3ViIjoiMCIsImV4cCI6MTYxMTk2NDgwMH0.26FeOWbKQJ0uZ6_aeCmbYoIb2mnP0e96hiSYrw1gd91CKyVvuZQRvbzDnUf4D2gOPnwBl4GLovBjByy6xgN1ow",
 						"sentInvitationEmail": false
 					}
 				}


### PR DESCRIPTION
# Description

Making all the fields of the JWT lowercase is the convention. Not sure how we missed this in the original review, but hopefully it will not make any more eyes cry by looking at the decoded JWT anymore :)

## How it looks now
```
{
  "invite_id": 1,
  "sender_id": 0,
  "iss": "http://example.com",
  "sub": "0",
  "exp": 1611964800
}
```
Notice the shining `invite_id` now all in lowercase :trollface: 


## Test plan

See the updated unit test. As a result of changing the field to the lowercase, the resulting base64 encoding of the token changed as well.

Parsing of the JWT is using [GoLang native JSON Unmarshal function](https://pkg.go.dev/encoding/json#Unmarshal), which is case insensitive. So this change will not affect reading existing invitation URLs.
