### PR TITLE
Backend: add non-empty constraints to settings contents

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -2167,7 +2167,7 @@ Contains security-relevant events with a long time horizon for storage.
 ----------------+--------------------------+-----------+----------+--------------------------------------
  id             | integer                  |           | not null | nextval('settings_id_seq'::regclass)
  org_id         | integer                  |           |          | 
- contents       | text                     |           |          | 
+ contents       | text                     |           | not null | '{}'::text
  created_at     | timestamp with time zone |           | not null | now()
  user_id        | integer                  |           |          | 
  author_user_id | integer                  |           |          | 
@@ -2176,6 +2176,8 @@ Indexes:
     "settings_global_id" btree (id DESC) WHERE user_id IS NULL AND org_id IS NULL
     "settings_org_id_idx" btree (org_id)
     "settings_user_id_idx" btree (user_id)
+Check constraints:
+    "settings_no_empty_contents" CHECK (contents <> ''::text)
 Foreign-key constraints:
     "settings_author_user_id_fkey" FOREIGN KEY (author_user_id) REFERENCES users(id) ON DELETE RESTRICT
     "settings_references_orgs" FOREIGN KEY (org_id) REFERENCES orgs(id) ON DELETE RESTRICT

--- a/internal/database/settings.go
+++ b/internal/database/settings.go
@@ -134,15 +134,6 @@ func (o *settingsStore) GetLatest(ctx context.Context, subject api.SettingsSubje
 		// No configuration has been set for this subject yet.
 		return nil, nil
 	}
-	if settings[0].Contents == "" {
-		// On some instances user, org, and global settings are an invalid
-		// empty string / null.
-		//
-		// This happens particularly on instances that ran old versions of
-		// Sourcegraph where we didn't enforce that settings contents had to be
-		// non-empty for correctness.
-		settings[0].Contents = "{}"
-	}
 	return settings[0], nil
 }
 

--- a/migrations/frontend/1645554732/down.sql
+++ b/migrations/frontend/1645554732/down.sql
@@ -4,6 +4,7 @@ ALTER TABLE settings
     ALTER COLUMN contents DROP NOT NULL;
 
 ALTER TABLE settings
-    ALTER COLUMN contents DROP DEFAULT;
+    ALTER COLUMN contents DROP DEFAULT,
+    DROP CONSTRAINT settings_no_empty_contents;
 
 COMMIT;

--- a/migrations/frontend/1645554732/down.sql
+++ b/migrations/frontend/1645554732/down.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+ALTER TABLE settings
+    ALTER COLUMN contents DROP NOT NULL;
+
+ALTER TABLE settings
+    ALTER COLUMN contents DROP DEFAULT;
+
+COMMIT;

--- a/migrations/frontend/1645554732/metadata.yaml
+++ b/migrations/frontend/1645554732/metadata.yaml
@@ -1,0 +1,2 @@
+name: default-settings-value
+parents: [1645106226]

--- a/migrations/frontend/1645554732/up.sql
+++ b/migrations/frontend/1645554732/up.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+ALTER TABLE settings
+    ALTER COLUMN contents SET DEFAULT '{}';
+
+UPDATE settings
+SET contents = '{}'
+WHERE contents = NULL
+    OR contents = '';
+
+ALTER TABLE settings
+    ALTER COLUMN contents SET NOT NULL,
+    ADD CONSTRAINT settings_no_empty_contents CHECK ( contents <> '' );
+    
+COMMIT;


### PR DESCRIPTION
Currently, in code we check that the contents of settings are non-empty.
This replaces that check with a constraint in the db.

## Test plan

Covered by existing tests and tested settings modifications manually.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


