### PR TITLE
migrations: Improve logging in sg migration squash

### DIFF
--- a/dev/sg/internal/migration/squash.go
+++ b/dev/sg/internal/migration/squash.go
@@ -146,6 +146,7 @@ func generateSquashedMigrations(database db.Database, targetVersions []int) (up,
 func runTargetedUpMigrations(database db.Database, targetVersions []int, postgresDSN string) (err error) {
 	// Disable runner logs to prevent clashing progress output below
 	runner.DisableLogging()
+	defer runner.EnableLogging()
 
 	pending := stdout.Out.Pending(output.Line("", output.StylePending, "Migrating PostgreSQL schema..."))
 	defer func() {

--- a/dev/sg/internal/migration/squash.go
+++ b/dev/sg/internal/migration/squash.go
@@ -144,6 +144,9 @@ func generateSquashedMigrations(database db.Database, targetVersions []int) (up,
 
 // runTargetedUpMigrations runs up migration targeting the given versions on the given database instance.
 func runTargetedUpMigrations(database db.Database, targetVersions []int, postgresDSN string) (err error) {
+	// Disable runner logs to prevent clashing progress output below
+	runner.DisableLogging()
+
 	pending := stdout.Out.Pending(output.Line("", output.StylePending, "Migrating PostgreSQL schema..."))
 	defer func() {
 		if err == nil {

--- a/internal/database/migration/runner/logger.go
+++ b/internal/database/migration/runner/logger.go
@@ -11,15 +11,19 @@ import (
 // replaced with a no-op logger in unrelated tests that need to run migrations.
 var logger = log15.Root()
 
+func DisableLogging() {
+	logger = log15.New()
+	logger.SetHandler(log15.DiscardHandler())
+}
+
+// This package is INCREDIBLY noisy and imported by basically any package
+// that touches the database. We disable all logs during tests to save the noise
+// in local development as well as CI.
+//
+// If logs are needed to debug unit test behavior, then temporarily
+// comment out the following lines.
 func init() {
 	if strings.HasSuffix(os.Args[0], ".test") || strings.Contains(os.Args[0], "/_test/") {
-		// This package is INCREDIBLY noisy and imported by basically any package
-		// that touches the database. We disable all logs during tests to save the noise
-		// in local development as well as CI.
-		//
-		// If logs are needed to debug unit test behavior, then temporarily
-		// comment out the following lines.
-		logger = log15.New()
-		logger.SetHandler(log15.DiscardHandler())
+		DisableLogging()
 	}
 }

--- a/internal/database/migration/runner/logger.go
+++ b/internal/database/migration/runner/logger.go
@@ -11,6 +11,10 @@ import (
 // replaced with a no-op logger in unrelated tests that need to run migrations.
 var logger = log15.Root()
 
+func EnableLogging() {
+	logger = log15.Root()
+}
+
 func DisableLogging() {
 	logger = log15.New()
 	logger.SetHandler(log15.DiscardHandler())


### PR DESCRIPTION
This stops the migration runner logger from interrupting `lib/output` progress tickers.

## Test plan

Does not affect runtime.