### PR TITLE
vscode: set build.allowImplicitNetworkAccess true

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,6 +34,7 @@
   "editor.formatOnSave": true,
   "go.useLanguageServer": true,
   "gopls": {
+    "build.allowImplicitNetworkAccess": true,
     "local": "github.com/sourcegraph/sourcegraph",
   },
   "jest.pathToJest": "yarn -s test",


### PR DESCRIPTION
Fixes the super annoying `module lookup disabled by GOPROXY=off` from gopls thats been plaguing me forever

## Test plan

n/a


