### PR TITLE
Tag delivery on managed instance upgrade issues

### DIFF
--- a/dev/release/src/github.ts
+++ b/dev/release/src/github.ts
@@ -37,6 +37,7 @@ export enum IssueLabel {
     RELEASE = 'release',
     PATCH = 'patch',
     MANAGED = 'managed-instances',
+    DELIVERY_TEAM = 'team/delivery',
 }
 
 enum IssueTitleSuffix {
@@ -115,7 +116,7 @@ const getTemplates = () => {
         repo: 'handbook',
         path: 'content/departments/product-engineering/engineering/process/releases/upgrade_managed_issue_template.md',
         titleSuffix: IssueTitleSuffix.MANAGED_TRACKING,
-        labels: [IssueLabel.RELEASE_TRACKING, IssueLabel.MANAGED],
+        labels: [IssueLabel.RELEASE_TRACKING, IssueLabel.MANAGED, IssueLabel.DELIVERY_TEAM],
     }
     return { releaseIssue, patchReleaseIssue, upgradeManagedInstanceIssue }
 }


### PR DESCRIPTION
Add team/delivery label on managed instance upgrade tracking issues, so it is automatically added to the Delivery board.

## Test plan
Confirm that team/delivery label is added to next managed instance upgrade issue
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


