### PR TITLE
gqltest: add tests for sub-repo permissions

### DIFF
--- a/internal/gqltestutil/client.go
+++ b/internal/gqltestutil/client.go
@@ -320,12 +320,23 @@ func (c *Client) GraphQL(token, query string, variables map[string]interface{}, 
 
 // Get performs a GET request to the URL with authenticated user.
 func (c *Client) Get(url string) (*http.Response, error) {
+	return c.GetWithHeaders(url, nil)
+}
+
+// GetWithHeaders performs a GET request to the URL with authenticated user and provided headers.
+func (c *Client) GetWithHeaders(url string, header http.Header) (*http.Response, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	c.addCookies(req)
+
+	for name, values := range header {
+		for _, value := range values {
+			req.Header.Add(name, value)
+		}
+	}
 
 	return http.DefaultClient.Do(req)
 }


### PR DESCRIPTION
for direct commit access, repo archive requests and find references search

the only test left is for finding precise references (Confirmed after uploading an LSIF dump). I just didn't find a way to write such test

Part of https://github.com/sourcegraph/sourcegraph/issues/27448

## Test plan
This PR contains integration tests

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


