### PR TITLE
Revert "dev/ci: set GOPROXY everywhere"

### DIFF
--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -18,6 +18,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/ci/operations"
 )
 
+var goAthensProxyURL = "http://athens-athens-proxy"
+
 // CoreTestOperationsOptions should be used ONLY to adjust the behaviour of specific steps,
 // e.g. by adding flags, and not as a condition for adding steps or commands.
 type CoreTestOperationsOptions struct {
@@ -338,6 +340,7 @@ func addGoTests(pipeline *bk.Pipeline) {
 	buildGoTests(func(description, testSuffix string) {
 		pipeline.AddStep(
 			fmt.Sprintf(":go: Test (%s)", description),
+			bk.Env("GOPROXY", goAthensProxyURL),
 			bk.Cmd("./dev/ci/go-test.sh "+testSuffix),
 			bk.Cmd("./dev/ci/codecov.sh -c -F go"),
 		)
@@ -349,8 +352,10 @@ func addGoTestsBackcompat(minimumUpgradeableVersion string) func(pipeline *bk.Pi
 	return func(pipeline *bk.Pipeline) {
 		buildGoTests(func(description, testSuffix string) {
 			pipeline.AddStep(
+				// TODO - set minimum upgradeable version
 				fmt.Sprintf(":go::postgres: Backcompat test (%s)", description),
 				bk.Env("MINIMUM_UPGRADEABLE_VERSION", minimumUpgradeableVersion),
+				bk.Env("GOPROXY", goAthensProxyURL),
 				bk.Cmd("./dev/ci/go-backcompat/test.sh "+testSuffix),
 			)
 		})
@@ -386,6 +391,7 @@ func buildGoTests(f func(description, testSuffix string)) {
 // Builds the OSS and Enterprise Go commands.
 func addGoBuild(pipeline *bk.Pipeline) {
 	pipeline.AddStep(":go: Build",
+		bk.Env("GOPROXY", goAthensProxyURL),
 		bk.Cmd("./dev/ci/go-build.sh"),
 	)
 }

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -41,10 +41,6 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		"DATE":                               c.Time.Format(time.RFC3339),
 		"VERSION":                            c.Version,
 
-		// Use athens proxy for go modules downloads
-		// https://github.com/sourcegraph/infrastructure/blob/main/buildkite/kubernetes/athens-proxy/athens-athens-proxy.Deployment.yaml
-		"GOPROXY": "http://athens-athens-proxy",
-
 		// Additional flags
 		"GO111MODULE": "on",
 		"FORCE_COLOR": "3",


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#31536

Seeing a lot of these in main: `dial tcp: lookup athens-athens-proxy: Temporary failure in name resolution`. I'm guessing the proxy can't handle the increased load?

Test plan: https://buildkite.com/sourcegraph/sourcegraph/builds/133207