### PR TITLE
fix issue with monitor query using bad endpoint

### DIFF
--- a/enterprise/internal/codemonitors/background/graphql.go
+++ b/enterprise/internal/codemonitors/background/graphql.go
@@ -28,7 +28,7 @@ type graphQLQuery struct {
 
 type gqlSearchVars struct {
 	Query     string      `json:"query"`
-	MonitorID *graphql.ID `json:"monitorID"`
+	MonitorID *graphql.ID `json:"monitorID,omitEmpty"`
 }
 
 type gqlSearchResponse struct {
@@ -49,9 +49,8 @@ type searchResults struct {
 
 const gqlSearchQuery = `query CodeMonitorSearch(
 	$query: String!,
-	$monitorID: ID,
 ) {
-	codeMonitorSearch(query: $query, codeMonitorID: $monitorID) {
+	search(query: $query) {
 		results {
 			approximateResultCount
 			limitHit


### PR DESCRIPTION
I just removed the `codeMonitorSearch` query because we should be able
to run searches directly in the worker process in the near future.
However, I forgot to update the JSON key, so unmarshalling failed. Will
follow up with unit tests once this is fixed.



## Test plan

This fixes an issue that was not hit by tests. Will followup with an added test. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


