### PR TITLE
search: unnest check for creating jobs

### DIFF
--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -145,67 +145,63 @@ func ToSearchJob(jargs *Args, q query.Q) (Job, error) {
 			}
 		}
 
-		if args.ResultTypes.Has(result.TypeFile | result.TypePath) {
-			if !skipRepoSubsetSearch {
-				typ := search.TextRequest
-				// TODO(rvantonder): we don't always have to run
-				// this converter. It depends on whether we run
-				// a zoekt search at all.
-				zoektQuery, err := search.QueryToZoektQuery(args.PatternInfo, &args.Features, typ)
-				if err != nil {
-					return nil, err
-				}
-				zoektArgs := &search.ZoektParameters{
-					Query:          zoektQuery,
-					Typ:            typ,
-					FileMatchLimit: args.PatternInfo.FileMatchLimit,
-					Select:         args.PatternInfo.Select,
-					Zoekt:          args.Zoekt,
-				}
-
-				searcherArgs := &search.SearcherParameters{
-					SearcherURLs:    args.SearcherURLs,
-					PatternInfo:     args.PatternInfo,
-					UseFullDeadline: args.UseFullDeadline,
-				}
-
-				addJob(true, &textsearch.RepoSubsetTextSearch{
-					ZoektArgs:        zoektArgs,
-					SearcherArgs:     searcherArgs,
-					NotSearcherOnly:  !onlyRunSearcher,
-					UseIndex:         args.PatternInfo.Index,
-					ContainsRefGlobs: query.ContainsRefGlobs(q),
-					RepoOpts:         repoOptions,
-				})
+		if args.ResultTypes.Has(result.TypeFile|result.TypePath) && !skipRepoSubsetSearch {
+			typ := search.TextRequest
+			// TODO(rvantonder): we don't always have to run
+			// this converter. It depends on whether we run
+			// a zoekt search at all.
+			zoektQuery, err := search.QueryToZoektQuery(args.PatternInfo, &args.Features, typ)
+			if err != nil {
+				return nil, err
 			}
+			zoektArgs := &search.ZoektParameters{
+				Query:          zoektQuery,
+				Typ:            typ,
+				FileMatchLimit: args.PatternInfo.FileMatchLimit,
+				Select:         args.PatternInfo.Select,
+				Zoekt:          args.Zoekt,
+			}
+
+			searcherArgs := &search.SearcherParameters{
+				SearcherURLs:    args.SearcherURLs,
+				PatternInfo:     args.PatternInfo,
+				UseFullDeadline: args.UseFullDeadline,
+			}
+
+			addJob(true, &textsearch.RepoSubsetTextSearch{
+				ZoektArgs:        zoektArgs,
+				SearcherArgs:     searcherArgs,
+				NotSearcherOnly:  !onlyRunSearcher,
+				UseIndex:         args.PatternInfo.Index,
+				ContainsRefGlobs: query.ContainsRefGlobs(q),
+				RepoOpts:         repoOptions,
+			})
 		}
 
-		if args.ResultTypes.Has(result.TypeSymbol) && args.PatternInfo.Pattern != "" {
-			if !skipRepoSubsetSearch {
-				typ := search.SymbolRequest
-				zoektQuery, err := search.QueryToZoektQuery(args.PatternInfo, &args.Features, typ)
-				if err != nil {
-					return nil, err
-				}
-				zoektArgs := &search.ZoektParameters{
-					Query:          zoektQuery,
-					Typ:            typ,
-					FileMatchLimit: args.PatternInfo.FileMatchLimit,
-					Select:         args.PatternInfo.Select,
-					Zoekt:          args.Zoekt,
-				}
-
-				required := args.UseFullDeadline || args.ResultTypes.Without(result.TypeSymbol) == 0
-				addJob(required, &symbol.RepoSubsetSymbolSearch{
-					ZoektArgs:        zoektArgs,
-					PatternInfo:      args.PatternInfo,
-					Limit:            maxResults,
-					NotSearcherOnly:  !onlyRunSearcher,
-					UseIndex:         args.PatternInfo.Index,
-					ContainsRefGlobs: query.ContainsRefGlobs(q),
-					RepoOpts:         repoOptions,
-				})
+		if args.ResultTypes.Has(result.TypeSymbol) && args.PatternInfo.Pattern != "" && !skipRepoSubsetSearch {
+			typ := search.SymbolRequest
+			zoektQuery, err := search.QueryToZoektQuery(args.PatternInfo, &args.Features, typ)
+			if err != nil {
+				return nil, err
 			}
+			zoektArgs := &search.ZoektParameters{
+				Query:          zoektQuery,
+				Typ:            typ,
+				FileMatchLimit: args.PatternInfo.FileMatchLimit,
+				Select:         args.PatternInfo.Select,
+				Zoekt:          args.Zoekt,
+			}
+
+			required := args.UseFullDeadline || args.ResultTypes.Without(result.TypeSymbol) == 0
+			addJob(required, &symbol.RepoSubsetSymbolSearch{
+				ZoektArgs:        zoektArgs,
+				PatternInfo:      args.PatternInfo,
+				Limit:            maxResults,
+				NotSearcherOnly:  !onlyRunSearcher,
+				UseIndex:         args.PatternInfo.Index,
+				ContainsRefGlobs: query.ContainsRefGlobs(q),
+				RepoOpts:         repoOptions,
+			})
 		}
 
 		if args.ResultTypes.Has(result.TypeCommit) || args.ResultTypes.Has(result.TypeDiff) {


### PR DESCRIPTION
```go
		if args.ResultTypes.Has(result.TypeFile | result.TypePath) {
			if !skipRepoSubsetSearch {
```

to

```go
		if args.ResultTypes.Has(result.TypeFile | result.TypePath) && !skipRepoSubsetSearch {
```
## Test plan
semantics-preserving.


