### PR TITLE
Revert "Search backend: rip out in-progress repo-aware code monitor ID stuff"

### DIFF
--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -24,6 +24,8 @@ type CodeMonitorsResolver interface {
 	TriggerTestSlackWebhookAction(ctx context.Context, args *TriggerTestSlackWebhookActionArgs) (*EmptyResponse, error)
 
 	NodeResolvers() map[string]NodeByIDFunc
+
+	CodeMonitorSearch(context.Context, *SearchArgs) (SearchImplementer, error)
 }
 
 type MonitorConnectionResolver interface {

--- a/cmd/frontend/graphqlbackend/code_monitors.graphql
+++ b/cmd/frontend/graphqlbackend/code_monitors.graphql
@@ -1,3 +1,24 @@
+extend type Query {
+    """
+    Runs a code monitor search.
+    """
+    codeMonitorSearch(
+        """
+        PatternType controls the search pattern type, if and only if it is not specified in the query string using
+        the patternType: field.
+        """
+        patternType: SearchPatternType
+        """
+        The search query (such as "foo" or "repo:myrepo foo").
+        """
+        query: String = ""
+        """
+        codeMonitorID is the code monitor associated with this search
+        """
+        codeMonitorID: ID
+    ): Search
+}
+
 extend type Mutation {
     """
     Create a code monitor.

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -385,6 +385,11 @@ func (r *Resolver) TriggerTestSlackWebhookAction(ctx context.Context, args *grap
 	return &graphqlbackend.EmptyResponse{}, nil
 }
 
+func (r *Resolver) CodeMonitorSearch(ctx context.Context, args *graphqlbackend.SearchArgs) (graphqlbackend.SearchImplementer, error) {
+	args.Version = "V2"
+	return graphqlbackend.NewSearchImplementer(ctx, r.db, args)
+}
+
 func sendTestEmail(ctx context.Context, recipient graphql.ID, description string) error {
 	var (
 		userID int32

--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -32,6 +32,7 @@ type CommitSearch struct {
 	Diff                 bool
 	HasTimeFilter        bool
 	Limit                int
+	CodeMonitorID        *int64
 	IncludeModifiedFiles bool
 }
 
@@ -126,6 +127,12 @@ func (j *CommitSearch) Tags() []log.Field {
 		log.Bool("diff", j.Diff),
 		log.Bool("hasTimeFilter", j.HasTimeFilter),
 		log.Int("limit", j.Limit),
+		log.Int64("codeMonitorID", func() int64 {
+			if j.CodeMonitorID != nil {
+				return *j.CodeMonitorID
+			}
+			return 0
+		}()),
 		log.Bool("includeModifiedFiles", j.IncludeModifiedFiles),
 	}
 }

--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -60,6 +60,13 @@ func ToSearchJob(jargs *Args, q query.Q) (Job, error) {
 
 	var requiredJobs, optionalJobs []Job
 	addJob := func(required bool, job Job) {
+		// Filter out any jobs that aren't commit jobs as they are added
+		if jargs.SearchInputs.CodeMonitorID != nil {
+			if _, ok := job.(*commit.CommitSearch); !ok {
+				return
+			}
+		}
+
 		if required {
 			requiredJobs = append(requiredJobs, job)
 		} else {
@@ -217,6 +224,7 @@ func ToSearchJob(jargs *Args, q query.Q) (Job, error) {
 				Diff:                 diff,
 				HasTimeFilter:        commit.HasTimeFilter(args.Query),
 				Limit:                int(args.PatternInfo.FileMatchLimit),
+				CodeMonitorID:        jargs.SearchInputs.CodeMonitorID,
 				IncludeModifiedFiles: authz.SubRepoEnabled(authz.DefaultSubRepoPermsChecker),
 			})
 		}

--- a/internal/search/run/run.go
+++ b/internal/search/run/run.go
@@ -16,6 +16,7 @@ type SearchInputs struct {
 	PatternType   query.SearchType
 	UserSettings  *schema.Settings
 	Features      featureflag.FlagSet
+	CodeMonitorID *int64
 	Protocol      search.Protocol
 }
 


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#31648

I thought some stuff was behind a feature flag that wasn't, so I'll have to retry this after adding some tests that catch that behavior. 