### PR TITLE
migrations: Fix panic when running squash twice

### DIFF
--- a/internal/database/migration/definition/definition.go
+++ b/internal/database/migration/definition/definition.go
@@ -82,7 +82,11 @@ func (ds *Definitions) Filter(ids []int) (*Definitions, error) {
 		idMap[id] = struct{}{}
 	}
 
-	filtered := make([]Definition, 0, len(ds.definitions)-len(ids))
+	n := len(ds.definitions) - len(ids)
+	if n <= 0 {
+		n = 1
+	}
+	filtered := make([]Definition, 0, n)
 	for _, definition := range ds.definitions {
 		if _, ok := idMap[definition.ID]; ok {
 			filtered = append(filtered, definition)


### PR DESCRIPTION
Ensure we don't create a zero-capacity slice.

## Test plan

Ran `sg migration squash` locally twice. No longer panics!