### PR TITLE
Update stories to not use settings cascade

### DIFF
--- a/client/web/src/enterprise/insights/CodeInsightsBackendStoryMock.tsx
+++ b/client/web/src/enterprise/insights/CodeInsightsBackendStoryMock.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+
+import { CodeInsightsBackendContext } from './core/backend/code-insights-backend-context'
+import { CodeInsightsGqlBackend } from './core/backend/gql-api/code-insights-gql-backend'
+
+export const CodeInsightsBackendStoryMock: React.FunctionComponent<{
+    mocks: Partial<CodeInsightsGqlBackend>
+}> = ({ children, mocks }) => {
+    // Pass in an empty object because mocking `watchQuery` is too difficult.
+    const backend = new CodeInsightsGqlBackend({} as any)
+
+    // Override the existing backend with whatever methods we need for this story
+    const backendMock = {
+        ...backend,
+        ...mocks,
+    }
+
+    return <CodeInsightsBackendContext.Provider value={backendMock}>{children}</CodeInsightsBackendContext.Provider>
+}

--- a/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.story.tsx
@@ -10,13 +10,12 @@ import {
     LINE_CHART_WITH_HUGE_NUMBER_OF_LINES,
     LINE_CHART_WITH_MANY_LINES,
 } from '../../../../views/mocks/charts-content'
-import { CodeInsightsBackendContext } from '../../core/backend/code-insights-backend-context'
-import { CodeInsightsGqlBackend } from '../../core/backend/gql-api/code-insights-gql-backend'
+import { CodeInsightsBackendStoryMock } from '../../CodeInsightsBackendStoryMock'
 import { BackendInsight, Insight, InsightExecutionType, InsightType, isCaptureGroupInsight } from '../../core/types'
 
 import { SmartInsightsViewGrid } from './SmartInsightsViewGrid'
 
-export default {
+const defaultStory: Meta = {
     title: 'web/insights/SmartInsightsViewGridExample',
     decorators: [story => <WebStory>{() => story()}</WebStory>],
     parameters: {
@@ -25,7 +24,9 @@ export default {
             enableDarkMode: true,
         },
     },
-} as Meta
+}
+
+export default defaultStory
 
 const insightsWithManyLines: Insight[] = [
     {
@@ -135,12 +136,8 @@ const insightsWithManyLines: Insight[] = [
     },
 ]
 
-class StoryBackendWithManyLinesCharts extends CodeInsightsGqlBackend {
-    constructor() {
-        super({} as any)
-    }
-
-    public getBackendInsightData = (insight: BackendInsight) => {
+const codeInsightsApiWithManyLines = {
+    getBackendInsightData: (insight: BackendInsight) => {
         if (isCaptureGroupInsight(insight)) {
             throw new Error('This demo does not support capture group insight')
         }
@@ -160,13 +157,11 @@ class StoryBackendWithManyLinesCharts extends CodeInsightsGqlBackend {
                 isFetchingHistoricalData: false,
             },
         })
-    }
+    },
 }
 
-const codeInsightsApiWithManyLines = new StoryBackendWithManyLinesCharts()
-
-export const SmartInsightsViewGridExample = () => (
-    <CodeInsightsBackendContext.Provider value={codeInsightsApiWithManyLines}>
+export const SmartInsightsViewGridExample = (): JSX.Element => (
+    <CodeInsightsBackendStoryMock mocks={codeInsightsApiWithManyLines}>
         <SmartInsightsViewGrid insights={insightsWithManyLines} telemetryService={NOOP_TELEMETRY_SERVICE} />
-    </CodeInsightsBackendContext.Provider>
+    </CodeInsightsBackendStoryMock>
 )

--- a/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.story.tsx
@@ -11,9 +11,8 @@ import {
     LINE_CHART_WITH_MANY_LINES,
 } from '../../../../views/mocks/charts-content'
 import { CodeInsightsBackendContext } from '../../core/backend/code-insights-backend-context'
-import { CodeInsightsSettingsCascadeBackend } from '../../core/backend/setting-based-api/code-insights-setting-cascade-backend'
+import { CodeInsightsGqlBackend } from '../../core/backend/gql-api/code-insights-gql-backend'
 import { BackendInsight, Insight, InsightExecutionType, InsightType, isCaptureGroupInsight } from '../../core/types'
-import { SETTINGS_CASCADE_MOCK } from '../../mocks/settings-cascade'
 
 import { SmartInsightsViewGrid } from './SmartInsightsViewGrid'
 
@@ -136,9 +135,9 @@ const insightsWithManyLines: Insight[] = [
     },
 ]
 
-class StoryBackendWithManyLinesCharts extends CodeInsightsSettingsCascadeBackend {
+class StoryBackendWithManyLinesCharts extends CodeInsightsGqlBackend {
     constructor() {
-        super(SETTINGS_CASCADE_MOCK, {} as any)
+        super({} as any)
     }
 
     public getBackendInsightData = (insight: BackendInsight) => {

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
@@ -8,7 +8,7 @@ import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/teleme
 import { WebStory } from '../../../../../../components/WebStory'
 import { LINE_CHART_CONTENT_MOCK, LINE_CHART_CONTENT_MOCK_EMPTY } from '../../../../../../views/mocks/charts-content'
 import { CodeInsightsBackendContext } from '../../../../core/backend/code-insights-backend-context'
-import { CodeInsightsSettingsCascadeBackend } from '../../../../core/backend/setting-based-api/code-insights-setting-cascade-backend'
+import { CodeInsightsGqlBackend } from '../../../../core/backend/gql-api/code-insights-gql-backend'
 import { InsightInProcessError } from '../../../../core/backend/utils/errors'
 import {
     BackendInsight as BackendInsightType,
@@ -17,7 +17,6 @@ import {
     isCaptureGroupInsight,
 } from '../../../../core/types'
 import { SearchBackendBasedInsight } from '../../../../core/types/insight/search-insight'
-import { SETTINGS_CASCADE_MOCK } from '../../../../mocks/settings-cascade'
 
 import { BackendInsightView } from './BackendInsight'
 
@@ -44,7 +43,7 @@ const mockInsightAPI = ({
     throwProcessingError = false,
     hasData = true,
 } = {}) => {
-    class CodeInsightsStoryBackend extends CodeInsightsSettingsCascadeBackend {
+    class CodeInsightsStoryBackend extends CodeInsightsGqlBackend {
         public getBackendInsightData = (insight: BackendInsightType) => {
             if (isCaptureGroupInsight(insight)) {
                 throw new Error('This demo does not support capture group insight')
@@ -66,7 +65,7 @@ const mockInsightAPI = ({
         }
     }
 
-    return new CodeInsightsStoryBackend(SETTINGS_CASCADE_MOCK, {} as any)
+    return new CodeInsightsStoryBackend({} as any)
 }
 
 const TestBackendInsight: React.FunctionComponent = () => (

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
@@ -7,8 +7,7 @@ import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/teleme
 
 import { WebStory } from '../../../../../../components/WebStory'
 import { LINE_CHART_CONTENT_MOCK, LINE_CHART_CONTENT_MOCK_EMPTY } from '../../../../../../views/mocks/charts-content'
-import { CodeInsightsBackendContext } from '../../../../core/backend/code-insights-backend-context'
-import { CodeInsightsGqlBackend } from '../../../../core/backend/gql-api/code-insights-gql-backend'
+import { CodeInsightsBackendStoryMock } from '../../../../CodeInsightsBackendStoryMock'
 import { InsightInProcessError } from '../../../../core/backend/utils/errors'
 import {
     BackendInsight as BackendInsightType,
@@ -20,10 +19,12 @@ import { SearchBackendBasedInsight } from '../../../../core/types/insight/search
 
 import { BackendInsightView } from './BackendInsight'
 
-export default {
+const defaultStory: Meta = {
     title: 'web/insights/BackendInsight',
     decorators: [story => <WebStory>{() => story()}</WebStory>],
-} as Meta
+}
+
+export default defaultStory
 
 const INSIGHT_CONFIGURATION_MOCK: SearchBackendBasedInsight = {
     title: 'Mock Backend Insight',
@@ -42,31 +43,27 @@ const mockInsightAPI = ({
     delayAmount = 0,
     throwProcessingError = false,
     hasData = true,
-} = {}) => {
-    class CodeInsightsStoryBackend extends CodeInsightsGqlBackend {
-        public getBackendInsightData = (insight: BackendInsightType) => {
-            if (isCaptureGroupInsight(insight)) {
-                throw new Error('This demo does not support capture group insight')
-            }
-
-            if (throwProcessingError) {
-                return throwError(new InsightInProcessError())
-            }
-
-            return of({
-                id: insight.id,
-                view: {
-                    title: 'Backend Insight Mock',
-                    subtitle: 'Backend insight description text',
-                    content: [hasData ? LINE_CHART_CONTENT_MOCK : LINE_CHART_CONTENT_MOCK_EMPTY],
-                    isFetchingHistoricalData,
-                },
-            }).pipe(delay(delayAmount))
+} = {}) => ({
+    getBackendInsightData: (insight: BackendInsightType) => {
+        if (isCaptureGroupInsight(insight)) {
+            throw new Error('This demo does not support capture group insight')
         }
-    }
 
-    return new CodeInsightsStoryBackend({} as any)
-}
+        if (throwProcessingError) {
+            return throwError(new InsightInProcessError())
+        }
+
+        return of({
+            id: insight.id,
+            view: {
+                title: 'Backend Insight Mock',
+                subtitle: 'Backend insight description text',
+                content: [hasData ? LINE_CHART_CONTENT_MOCK : LINE_CHART_CONTENT_MOCK_EMPTY],
+                isFetchingHistoricalData,
+            },
+        }).pipe(delay(delayAmount))
+    },
+})
 
 const TestBackendInsight: React.FunctionComponent = () => (
     <BackendInsightView
@@ -81,33 +78,33 @@ export const BackendInsight: Story = () => (
     <section>
         <article>
             <h2>Card</h2>
-            <CodeInsightsBackendContext.Provider value={mockInsightAPI()}>
+            <CodeInsightsBackendStoryMock mocks={mockInsightAPI()}>
                 <TestBackendInsight />
-            </CodeInsightsBackendContext.Provider>
+            </CodeInsightsBackendStoryMock>
         </article>
         <article className="mt-3">
             <h2>Card with delay API</h2>
-            <CodeInsightsBackendContext.Provider value={mockInsightAPI({ delayAmount: 2000 })}>
+            <CodeInsightsBackendStoryMock mocks={mockInsightAPI({ delayAmount: 2000 })}>
                 <TestBackendInsight />
-            </CodeInsightsBackendContext.Provider>
+            </CodeInsightsBackendStoryMock>
         </article>
         <article className="mt-3">
             <h2>Card backfilling data</h2>
-            <CodeInsightsBackendContext.Provider value={mockInsightAPI({ isFetchingHistoricalData: true })}>
+            <CodeInsightsBackendStoryMock mocks={mockInsightAPI({ isFetchingHistoricalData: true })}>
                 <TestBackendInsight />
-            </CodeInsightsBackendContext.Provider>
+            </CodeInsightsBackendStoryMock>
         </article>
         <article className="mt-3">
             <h2>Card no data</h2>
-            <CodeInsightsBackendContext.Provider value={mockInsightAPI({ hasData: false })}>
+            <CodeInsightsBackendStoryMock mocks={mockInsightAPI({ hasData: false })}>
                 <TestBackendInsight />
-            </CodeInsightsBackendContext.Provider>
+            </CodeInsightsBackendStoryMock>
         </article>
         <article className="mt-3">
             <h2>Card insight syncing</h2>
-            <CodeInsightsBackendContext.Provider value={mockInsightAPI({ throwProcessingError: true })}>
+            <CodeInsightsBackendStoryMock mocks={mockInsightAPI({ throwProcessingError: true })}>
                 <TestBackendInsight />
-            </CodeInsightsBackendContext.Provider>
+            </CodeInsightsBackendStoryMock>
         </article>
     </section>
 )

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownFiltersPanel.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownFiltersPanel.story.tsx
@@ -5,6 +5,7 @@ import { of } from 'rxjs'
 
 import { WebStory } from '../../../../../../../../components/WebStory'
 import { CodeInsightsBackendContext } from '../../../../../../core/backend/code-insights-backend-context'
+import { CodeInsightsGqlBackend } from '../../../../../../core/backend/gql-api/code-insights-gql-backend'
 import { FORM_ERROR } from '../../../../../form/hooks/useForm'
 
 import {
@@ -19,9 +20,11 @@ const fakeAPIRequest = async () => {
     return { [FORM_ERROR]: new Error('Fake api request error') }
 }
 
-const codeInsightsBackend = {
-    findInsightByName: () => of(null),
+class CodeInsightsStoryBackend extends CodeInsightsGqlBackend {
+    public findInsightByName = () => of(null)
 }
+
+const codeInsightsBackend = new CodeInsightsStoryBackend({} as any)
 
 const EMPTY_DRILLDOWN_FILTERS: DrillDownFiltersFormValues = {
     excludeRepoRegexp: '',
@@ -37,7 +40,7 @@ export const DrillDownFiltersPanel: Story = () => (
     <section>
         <article>
             <h2>Creation Form</h2>
-            <CodeInsightsBackendContext.Provider value={codeInsightsBackend as any}>
+            <CodeInsightsBackendContext.Provider value={codeInsightsBackend}>
                 <DrillDownInsightCreationForm onCreateInsight={fakeAPIRequest} onCancel={() => {}} />
             </CodeInsightsBackendContext.Provider>
         </article>

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownFiltersPanel.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownFiltersPanel.story.tsx
@@ -4,8 +4,7 @@ import React from 'react'
 import { of } from 'rxjs'
 
 import { WebStory } from '../../../../../../../../components/WebStory'
-import { CodeInsightsBackendContext } from '../../../../../../core/backend/code-insights-backend-context'
-import { CodeInsightsGqlBackend } from '../../../../../../core/backend/gql-api/code-insights-gql-backend'
+import { CodeInsightsBackendStoryMock } from '../../../../../../CodeInsightsBackendStoryMock'
 import { FORM_ERROR } from '../../../../../form/hooks/useForm'
 
 import {
@@ -20,11 +19,9 @@ const fakeAPIRequest = async () => {
     return { [FORM_ERROR]: new Error('Fake api request error') }
 }
 
-class CodeInsightsStoryBackend extends CodeInsightsGqlBackend {
-    public findInsightByName = () => of(null)
+const backendMock = {
+    findInsightByName: () => of(null),
 }
-
-const codeInsightsBackend = new CodeInsightsStoryBackend({} as any)
 
 const EMPTY_DRILLDOWN_FILTERS: DrillDownFiltersFormValues = {
     excludeRepoRegexp: '',
@@ -40,9 +37,9 @@ export const DrillDownFiltersPanel: Story = () => (
     <section>
         <article>
             <h2>Creation Form</h2>
-            <CodeInsightsBackendContext.Provider value={codeInsightsBackend}>
+            <CodeInsightsBackendStoryMock mocks={backendMock}>
                 <DrillDownInsightCreationForm onCreateInsight={fakeAPIRequest} onCancel={() => {}} />
-            </CodeInsightsBackendContext.Provider>
+            </CodeInsightsBackendStoryMock>
         </article>
         <article>
             <h2>Filters Form</h2>
@@ -57,7 +54,9 @@ export const DrillDownFiltersPanel: Story = () => (
     </section>
 )
 
-export default {
+const defaultStory: Meta = {
     title: 'web/insights/DrillDownFiltersPanel',
     decorators: [story => <WebStory>{() => story()}</WebStory>],
-} as Meta
+}
+
+export default defaultStory

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownFiltersPanel.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownFiltersPanel.story.tsx
@@ -1,11 +1,10 @@
 import { Meta, Story } from '@storybook/react'
 import delay from 'delay'
 import React from 'react'
+import { of } from 'rxjs'
 
 import { WebStory } from '../../../../../../../../components/WebStory'
 import { CodeInsightsBackendContext } from '../../../../../../core/backend/code-insights-backend-context'
-import { CodeInsightsSettingsCascadeBackend } from '../../../../../../core/backend/setting-based-api/code-insights-setting-cascade-backend'
-import { SETTINGS_CASCADE_MOCK } from '../../../../../../mocks/settings-cascade'
 import { FORM_ERROR } from '../../../../../form/hooks/useForm'
 
 import {
@@ -20,7 +19,9 @@ const fakeAPIRequest = async () => {
     return { [FORM_ERROR]: new Error('Fake api request error') }
 }
 
-const codeInsightsBackend = new CodeInsightsSettingsCascadeBackend(SETTINGS_CASCADE_MOCK, {} as any)
+const codeInsightsBackend = {
+    findInsightByName: () => of(null),
+}
 
 const EMPTY_DRILLDOWN_FILTERS: DrillDownFiltersFormValues = {
     excludeRepoRegexp: '',
@@ -36,7 +37,7 @@ export const DrillDownFiltersPanel: Story = () => (
     <section>
         <article>
             <h2>Creation Form</h2>
-            <CodeInsightsBackendContext.Provider value={codeInsightsBackend}>
+            <CodeInsightsBackendContext.Provider value={codeInsightsBackend as any}>
                 <DrillDownInsightCreationForm onCreateInsight={fakeAPIRequest} onCancel={() => {}} />
             </CodeInsightsBackendContext.Provider>
         </article>

--- a/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.story.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.story.tsx
@@ -5,8 +5,7 @@ import { of } from 'rxjs'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { WebStory } from '../../../../../components/WebStory'
-import { CodeInsightsBackendContext } from '../../../core/backend/code-insights-backend-context'
-import { CodeInsightsGqlBackend } from '../../../core/backend/gql-api/code-insights-gql-backend'
+import { CodeInsightsBackendStoryMock } from '../../../CodeInsightsBackendStoryMock'
 import { SupportedInsightSubject } from '../../../core/types/subjects'
 import { SETTINGS_CASCADE_MOCK } from '../../../mocks/settings-cascade'
 
@@ -27,14 +26,12 @@ export default defaultStory
 
 const subjects = SETTINGS_CASCADE_MOCK.subjects.map(({ subject }) => subject) as SupportedInsightSubject[]
 
-class CodeInsightsStoryBackend extends CodeInsightsGqlBackend {
-    public getDashboardSubjects = () => of(subjects)
+const codeInsightsBackend = {
+    getDashboardSubjects: () => of(subjects),
 }
 
-const codeInsightsBackend = new CodeInsightsStoryBackend({} as any)
-
 export const InsightsDashboardCreationPage: Story = () => (
-    <CodeInsightsBackendContext.Provider value={codeInsightsBackend}>
+    <CodeInsightsBackendStoryMock mocks={codeInsightsBackend}>
         <InsightsDashboardCreationPageComponent telemetryService={NOOP_TELEMETRY_SERVICE} />
-    </CodeInsightsBackendContext.Provider>
+    </CodeInsightsBackendStoryMock>
 )

--- a/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.story.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.story.tsx
@@ -6,6 +6,8 @@ import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/teleme
 
 import { WebStory } from '../../../../../components/WebStory'
 import { CodeInsightsBackendContext } from '../../../core/backend/code-insights-backend-context'
+import { CodeInsightsGqlBackend } from '../../../core/backend/gql-api/code-insights-gql-backend'
+import { SupportedInsightSubject } from '../../../core/types/subjects'
 import { SETTINGS_CASCADE_MOCK } from '../../../mocks/settings-cascade'
 
 import { InsightsDashboardCreationPage as InsightsDashboardCreationPageComponent } from './InsightsDashboardCreationPage'
@@ -23,14 +25,16 @@ const defaultStory: Meta = {
 
 export default defaultStory
 
-const subjects = SETTINGS_CASCADE_MOCK.subjects.map(({ subject }) => subject)
+const subjects = SETTINGS_CASCADE_MOCK.subjects.map(({ subject }) => subject) as SupportedInsightSubject[]
 
-const codeInsightsBackend = {
-    getDashboardSubjects: () => of(subjects),
+class CodeInsightsStoryBackend extends CodeInsightsGqlBackend {
+    public getDashboardSubjects = () => of(subjects)
 }
 
+const codeInsightsBackend = new CodeInsightsStoryBackend({} as any)
+
 export const InsightsDashboardCreationPage: Story = () => (
-    <CodeInsightsBackendContext.Provider value={codeInsightsBackend as any}>
+    <CodeInsightsBackendContext.Provider value={codeInsightsBackend}>
         <InsightsDashboardCreationPageComponent telemetryService={NOOP_TELEMETRY_SERVICE} />
     </CodeInsightsBackendContext.Provider>
 )

--- a/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.story.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.story.tsx
@@ -1,16 +1,16 @@
 import { Meta, Story } from '@storybook/react'
 import React from 'react'
+import { of } from 'rxjs'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { WebStory } from '../../../../../components/WebStory'
 import { CodeInsightsBackendContext } from '../../../core/backend/code-insights-backend-context'
-import { CodeInsightsSettingsCascadeBackend } from '../../../core/backend/setting-based-api/code-insights-setting-cascade-backend'
 import { SETTINGS_CASCADE_MOCK } from '../../../mocks/settings-cascade'
 
 import { InsightsDashboardCreationPage as InsightsDashboardCreationPageComponent } from './InsightsDashboardCreationPage'
 
-export default {
+const defaultStory: Meta = {
     title: 'web/insights/InsightsDashboardCreationPage',
     decorators: [story => <WebStory>{() => story()}</WebStory>],
     parameters: {
@@ -19,19 +19,18 @@ export default {
             disableSnapshot: false,
         },
     },
-} as Meta
-
-const PLATFORM_CONTEXT = {
-    // eslint-disable-next-line @typescript-eslint/require-await
-    updateSettings: async (...args: any[]) => {
-        console.log('PLATFORM CONTEXT update settings with', { ...args })
-    },
 }
 
-const codeInsightsBackend = new CodeInsightsSettingsCascadeBackend(SETTINGS_CASCADE_MOCK, PLATFORM_CONTEXT)
+export default defaultStory
+
+const subjects = SETTINGS_CASCADE_MOCK.subjects.map(({ subject }) => subject)
+
+const codeInsightsBackend = {
+    getDashboardSubjects: () => of(subjects),
+}
 
 export const InsightsDashboardCreationPage: Story = () => (
-    <CodeInsightsBackendContext.Provider value={codeInsightsBackend}>
+    <CodeInsightsBackendContext.Provider value={codeInsightsBackend as any}>
         <InsightsDashboardCreationPageComponent telemetryService={NOOP_TELEMETRY_SERVICE} />
     </CodeInsightsBackendContext.Provider>
 )

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/add-insight-modal/AddInsightModal.story.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/add-insight-modal/AddInsightModal.story.tsx
@@ -6,6 +6,7 @@ import { of } from 'rxjs'
 import { WebStory } from '../../../../../../../components/WebStory'
 import { CodeInsightsBackendContext } from '../../../../../core/backend/code-insights-backend-context'
 import { ReachableInsight } from '../../../../../core/backend/code-insights-backend-types'
+import { CodeInsightsGqlBackend } from '../../../../../core/backend/gql-api/code-insights-gql-backend'
 import {
     InsightsDashboardType,
     InsightsDashboardScope,
@@ -104,17 +105,18 @@ const mockInsights: ReachableInsight[] = [
     visibility: 'global',
 }))
 
-const codeInsightsBackend = {
-    getReachableInsights: () => of(mockInsights),
-    getDashboardSubjects: () => of(undefined),
-    assignInsightsToDashboard: () => undefined,
+class CodeInsightsStoryBackend extends CodeInsightsGqlBackend {
+    public getReachableInsights = () => of(mockInsights)
+    public getDashboardSubjects = () => of([])
 }
+
+const codeInsightsBackend = new CodeInsightsStoryBackend({} as any)
 
 add('AddInsightModal', () => {
     const [open, setOpen] = useState<boolean>(true)
 
     return (
-        <CodeInsightsBackendContext.Provider value={codeInsightsBackend as any}>
+        <CodeInsightsBackendContext.Provider value={codeInsightsBackend}>
             {open && <AddInsightModal dashboard={dashboard} onClose={() => setOpen(false)} />}
         </CodeInsightsBackendContext.Provider>
     )

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/add-insight-modal/AddInsightModal.story.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/add-insight-modal/AddInsightModal.story.tsx
@@ -4,9 +4,8 @@ import React, { useState } from 'react'
 import { of } from 'rxjs'
 
 import { WebStory } from '../../../../../../../components/WebStory'
-import { CodeInsightsBackendContext } from '../../../../../core/backend/code-insights-backend-context'
+import { CodeInsightsBackendStoryMock } from '../../../../../CodeInsightsBackendStoryMock'
 import { ReachableInsight } from '../../../../../core/backend/code-insights-backend-types'
-import { CodeInsightsGqlBackend } from '../../../../../core/backend/gql-api/code-insights-gql-backend'
 import {
     InsightsDashboardType,
     InsightsDashboardScope,
@@ -105,19 +104,17 @@ const mockInsights: ReachableInsight[] = [
     visibility: 'global',
 }))
 
-class CodeInsightsStoryBackend extends CodeInsightsGqlBackend {
-    public getReachableInsights = () => of(mockInsights)
-    public getDashboardSubjects = () => of([])
+const codeInsightsBackend = {
+    getReachableInsights: () => of(mockInsights),
+    getDashboardSubjects: () => of([]),
 }
-
-const codeInsightsBackend = new CodeInsightsStoryBackend({} as any)
 
 add('AddInsightModal', () => {
     const [open, setOpen] = useState<boolean>(true)
 
     return (
-        <CodeInsightsBackendContext.Provider value={codeInsightsBackend}>
+        <CodeInsightsBackendStoryMock mocks={codeInsightsBackend}>
             {open && <AddInsightModal dashboard={dashboard} onClose={() => setOpen(false)} />}
-        </CodeInsightsBackendContext.Provider>
+        </CodeInsightsBackendStoryMock>
     )
 })

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/add-insight-modal/AddInsightModal.story.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/add-insight-modal/AddInsightModal.story.tsx
@@ -1,18 +1,18 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
-import { useApolloClient } from '@apollo/client'
-import { MockedProvider, MockedResponse } from '@apollo/client/testing'
 import { storiesOf } from '@storybook/react'
 import React, { useState } from 'react'
-
-import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
-import { ConfiguredSubjectOrError, SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
+import { of } from 'rxjs'
 
 import { WebStory } from '../../../../../../../components/WebStory'
 import { CodeInsightsBackendContext } from '../../../../../core/backend/code-insights-backend-context'
-import { CodeInsightsGqlBackend } from '../../../../../core/backend/gql-api/code-insights-gql-backend'
-import { GET_INSIGHTS_GQL } from '../../../../../core/backend/gql-api/gql/GetInsights'
-import { GET_INSIGHTS_SUBJECTS_GQL } from '../../../../../core/backend/gql-api/gql/GetInsightSubjects'
-import { InsightsDashboardType, InsightsDashboardScope, CustomInsightDashboard } from '../../../../../core/types'
+import { ReachableInsight } from '../../../../../core/backend/code-insights-backend-types'
+import {
+    InsightsDashboardType,
+    InsightsDashboardScope,
+    CustomInsightDashboard,
+    InsightExecutionType,
+    InsightType,
+} from '../../../../../core/types'
 
 import { AddInsightModal } from './AddInsightModal'
 
@@ -37,123 +37,85 @@ const dashboard: CustomInsightDashboard = {
     },
 }
 
-const ORG_1_SETTINGS: ConfiguredSubjectOrError = {
-    lastID: 100,
-    settings: {
-        'searchInsights.insight.testOrg1graphQLTypesMigration': {
-            title:
-                '[Test ORG 1] Migration to new GraphQL TS types [Test ORG 1] Migration to new GraphQL TS types [Test ORG 1] Migration to new GraphQL TS types',
-            repositories: ['github.com/sourcegraph/sourcegraph'],
-            series: [],
-            step: { weeks: 6 },
-        },
-        'searchInsights.insight.testOrg1graphQLTypesMigration1': {
-            title: '[Test ORG 1] Migration to new GraphQL TS types',
-            repositories: ['github.com/sourcegraph/sourcegraph'],
-            series: [],
-            step: { weeks: 6 },
-        },
-        'searchInsights.insight.testOrg1graphQLTypesMigration2': {
-            title: '[Test ORG 1] Migration to new GraphQL TS types',
-            repositories: ['github.com/sourcegraph/sourcegraph'],
-            series: [],
-            step: { weeks: 6 },
+const mockInsights: ReachableInsight[] = [
+    {
+        id: 'searchInsights.insight.personalGraphQLTypesMigration',
+        title: '[Personal] Migration to new GraphQL TS types',
+        repositories: ['github.com/sourcegraph/sourcegraph'],
+        series: [],
+        step: { weeks: 6 },
+        owner: {
+            id: 'user_test_id',
+            name: 'test',
         },
     },
-    subject: {
-        __typename: 'Org' as const,
-        name: 'test organization 1',
-        displayName: 'Test organization 1 Test organization 1 Test organization 1',
-        viewerCanAdminister: true,
-        id: 'test_org_1_id',
+    {
+        id: 'searchInsights.insight.testOrg1graphQLTypesMigration',
+        title:
+            '[Test ORG 1] Migration to new GraphQL TS types [Test ORG 1] Migration to new GraphQL TS types [Test ORG 1] Migration to new GraphQL TS types',
+        repositories: ['github.com/sourcegraph/sourcegraph'],
+        series: [],
+        step: { weeks: 6 },
+        owner: {
+            id: 'test_org_1_id',
+            name: 'Test organization 1 Test organization 1 Test organization 1',
+        },
     },
-}
+    {
+        id: 'searchInsights.insight.testOrg1graphQLTypesMigration1',
+        title: '[Test ORG 1] Migration to new GraphQL TS types',
+        repositories: ['github.com/sourcegraph/sourcegraph'],
+        series: [],
+        step: { weeks: 6 },
+        owner: {
+            id: 'test_org_1_id',
+            name: 'Test organization 1 Test organization 1 Test organization 1',
+        },
+    },
+    {
+        id: 'searchInsights.insight.testOrg1graphQLTypesMigration2',
+        title: '[Test ORG 1] Migration to new GraphQL TS types',
+        repositories: ['github.com/sourcegraph/sourcegraph'],
+        series: [],
+        step: { weeks: 6 },
+        owner: {
+            id: 'test_org_1_id',
+            name: 'Test organization 1 Test organization 1 Test organization 1',
+        },
+    },
+    {
+        id: 'searchInsights.insight.testOrg2graphQLTypesMigration',
+        title: '[Test ORG 2] Migration to new GraphQL TS types',
+        repositories: ['github.com/sourcegraph/sourcegraph'],
+        series: [],
+        step: { weeks: 6 },
+        owner: {
+            id: 'test_org_2_id',
+            name: 'Test organization 2',
+        },
+    },
+].map(insight => ({
+    ...insight,
+    dashboardReferenceCount: 0,
+    otherThreshold: 0,
+    query: '',
+    type: InsightExecutionType.Backend,
+    viewType: InsightType.SearchBased,
+    visibility: 'global',
+}))
 
-const ORG_2_SETTINGS: ConfiguredSubjectOrError = {
-    lastID: 101,
-    settings: {
-        'searchInsights.insight.testOrg2graphQLTypesMigration': {
-            title: '[Test ORG 2] Migration to new GraphQL TS types',
-            repositories: ['github.com/sourcegraph/sourcegraph'],
-            series: [],
-            step: { weeks: 6 },
-        },
-    },
-    subject: {
-        __typename: 'Org' as const,
-        name: 'test organization 2',
-        displayName: 'Test organization 2',
-        viewerCanAdminister: true,
-        id: 'test_org_2_id',
-    },
-}
-
-const USER_SETTINGS: ConfiguredSubjectOrError = {
-    lastID: 102,
-    settings: {
-        'searchInsights.insight.personalGraphQLTypesMigration': {
-            title: '[Personal] Migration to new GraphQL TS types',
-            repositories: ['github.com/sourcegraph/sourcegraph'],
-            series: [],
-            step: { weeks: 6 },
-        },
-    },
-    subject: {
-        __typename: 'User' as const,
-        id: 'user_test_id',
-        username: 'testusername',
-        displayName: 'test',
-        viewerCanAdminister: true,
-    },
-}
-
-const SETTINGS_CASCADE: SettingsCascadeOrError<Settings> = {
-    subjects: [ORG_1_SETTINGS, ORG_2_SETTINGS, USER_SETTINGS],
-    final: {
-        // Naive merging of subject settings file for testing UI.
-        ...ORG_1_SETTINGS.settings,
-        ...ORG_2_SETTINGS.settings,
-        ...USER_SETTINGS.settings,
-    },
+const codeInsightsBackend = {
+    getReachableInsights: () => of(mockInsights),
+    getDashboardSubjects: () => of(undefined),
+    assignInsightsToDashboard: () => undefined,
 }
 
 add('AddInsightModal', () => {
-    const apolloClient = useApolloClient()
     const [open, setOpen] = useState<boolean>(true)
 
-    const codeInsightsBackend = new CodeInsightsGqlBackend(apolloClient)
-    const mocks: MockedResponse<Record<string, any>>[] = [
-        {
-            request: {
-                query: GET_INSIGHTS_GQL,
-                variables: {},
-            },
-            result: {
-                data: {
-                    insightViews: {
-                        nodes: [],
-                    },
-                },
-            },
-        },
-        {
-            request: {
-                query: GET_INSIGHTS_SUBJECTS_GQL,
-                variables: {},
-            },
-            result: {
-                data: {},
-            },
-        },
-    ]
-
-    // apolloClient.clearStore()
-
     return (
-        <MockedProvider mocks={mocks}>
-            <CodeInsightsBackendContext.Provider value={codeInsightsBackend}>
-                {open && <AddInsightModal dashboard={dashboard} onClose={() => setOpen(false)} />}
-            </CodeInsightsBackendContext.Provider>
-        </MockedProvider>
+        <CodeInsightsBackendContext.Provider value={codeInsightsBackend as any}>
+            {open && <AddInsightModal dashboard={dashboard} onClose={() => setOpen(false)} />}
+        </CodeInsightsBackendContext.Provider>
     )
 })

--- a/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.story.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.story.tsx
@@ -7,19 +7,14 @@ import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/teleme
 
 import { WebStory } from '../../../../../../components/WebStory'
 import { CodeInsightsBackendContext } from '../../../../core/backend/code-insights-backend-context'
-import { CodeInsightsSettingsCascadeBackend } from '../../../../core/backend/setting-based-api/code-insights-setting-cascade-backend'
+import { CodeInsightsGqlBackend } from '../../../../core/backend/gql-api/code-insights-gql-backend'
 import { SupportedInsightSubject } from '../../../../core/types/subjects'
-import {
-    createGlobalSubject,
-    createOrgSubject,
-    createUserSubject,
-    SETTINGS_CASCADE_MOCK,
-} from '../../../../mocks/settings-cascade'
+import { createGlobalSubject, createOrgSubject, createUserSubject } from '../../../../mocks/settings-cascade'
 
 import { getRandomLangStatsMock } from './components/live-preview-chart/live-preview-mock-data'
 import { LangStatsInsightCreationPage as LangStatsInsightCreationPageComponent } from './LangStatsInsightCreationPage'
 
-export default {
+const defaultStory: Meta = {
     title: 'web/insights/creation-ui/LangStatsInsightCreationPage',
     decorators: [story => <WebStory>{() => story()}</WebStory>],
     parameters: {
@@ -28,7 +23,9 @@ export default {
             disableSnapshot: false,
         },
     },
-} as Meta
+}
+
+export default defaultStory
 
 function sleep(delay: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, delay))
@@ -40,7 +37,7 @@ const fakeAPIRequest = async () => {
     throw new Error('Network error')
 }
 
-class CodeInsightsStoryBackend extends CodeInsightsSettingsCascadeBackend {
+class CodeInsightsStoryBackend extends CodeInsightsGqlBackend {
     public getLangStatsInsightContent = async () => {
         await sleep(2000)
 
@@ -59,7 +56,7 @@ class CodeInsightsStoryBackend extends CodeInsightsSettingsCascadeBackend {
     }
 }
 
-const codeInsightsBackend = new CodeInsightsStoryBackend(SETTINGS_CASCADE_MOCK, {} as any)
+const codeInsightsBackend = new CodeInsightsStoryBackend({} as any)
 
 const SUBJECTS = [
     createUserSubject('Emir Kusturica'),

--- a/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.story.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.story.tsx
@@ -6,8 +6,7 @@ import React from 'react'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { WebStory } from '../../../../../../components/WebStory'
-import { CodeInsightsBackendContext } from '../../../../core/backend/code-insights-backend-context'
-import { CodeInsightsGqlBackend } from '../../../../core/backend/gql-api/code-insights-gql-backend'
+import { CodeInsightsBackendStoryMock } from '../../../../CodeInsightsBackendStoryMock'
 import { SupportedInsightSubject } from '../../../../core/types/subjects'
 import { createGlobalSubject, createOrgSubject, createUserSubject } from '../../../../mocks/settings-cascade'
 
@@ -37,14 +36,13 @@ const fakeAPIRequest = async () => {
     throw new Error('Network error')
 }
 
-class CodeInsightsStoryBackend extends CodeInsightsGqlBackend {
-    public getLangStatsInsightContent = async () => {
+const codeInsightsBackend = {
+    getLangStatsInsightContent: async () => {
         await sleep(2000)
 
         return getRandomLangStatsMock()
-    }
-
-    public getRepositorySuggestions = async () => {
+    },
+    getRepositorySuggestions: async () => {
         await sleep(2000)
 
         return [
@@ -53,10 +51,8 @@ class CodeInsightsStoryBackend extends CodeInsightsGqlBackend {
             { id: '3', name: 'github.com/another-example/sub-repo-1' },
             { id: '4', name: 'github.com/another-example/sub-repo-2' },
         ]
-    }
+    },
 }
-
-const codeInsightsBackend = new CodeInsightsStoryBackend({} as any)
 
 const SUBJECTS = [
     createUserSubject('Emir Kusturica'),
@@ -66,7 +62,7 @@ const SUBJECTS = [
 ] as SupportedInsightSubject[]
 
 export const LangStatsInsightCreationPage: Story = () => (
-    <CodeInsightsBackendContext.Provider value={codeInsightsBackend}>
+    <CodeInsightsBackendStoryMock mocks={codeInsightsBackend}>
         <LangStatsInsightCreationPageComponent
             subjects={SUBJECTS}
             visibility="user_test_id"
@@ -75,5 +71,5 @@ export const LangStatsInsightCreationPage: Story = () => (
             onSuccessfulCreation={noop}
             onCancel={noop}
         />
-    </CodeInsightsBackendContext.Provider>
+    </CodeInsightsBackendStoryMock>
 )

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/SearchInsightCreationPage.story.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/SearchInsightCreationPage.story.tsx
@@ -7,14 +7,9 @@ import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/teleme
 
 import { WebStory } from '../../../../../../components/WebStory'
 import { CodeInsightsBackendContext } from '../../../../core/backend/code-insights-backend-context'
-import { CodeInsightsSettingsCascadeBackend } from '../../../../core/backend/setting-based-api/code-insights-setting-cascade-backend'
+import { CodeInsightsGqlBackend } from '../../../../core/backend/gql-api/code-insights-gql-backend'
 import { SupportedInsightSubject } from '../../../../core/types/subjects'
-import {
-    createGlobalSubject,
-    createOrgSubject,
-    createUserSubject,
-    SETTINGS_CASCADE_MOCK,
-} from '../../../../mocks/settings-cascade'
+import { createGlobalSubject, createOrgSubject, createUserSubject } from '../../../../mocks/settings-cascade'
 
 import {
     DEFAULT_MOCK_CHART_CONTENT,
@@ -22,7 +17,7 @@ import {
 } from './components/live-preview-chart/live-preview-mock-data'
 import { SearchInsightCreationPage as SearchInsightCreationPageComponent } from './SearchInsightCreationPage'
 
-export default {
+const defaultStory: Meta = {
     title: 'web/insights/creation-ui/SearchInsightCreationPage',
     decorators: [story => <WebStory>{() => story()}</WebStory>],
     parameters: {
@@ -31,7 +26,9 @@ export default {
             disableSnapshot: false,
         },
     },
-} as Meta
+}
+
+export default defaultStory
 
 function sleep(delay: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, delay))
@@ -43,7 +40,7 @@ const fakeAPIRequest = async () => {
     throw new Error('Network error')
 }
 
-class CodeInsightsStoryBackend extends CodeInsightsSettingsCascadeBackend {
+class CodeInsightsStoryBackend extends CodeInsightsGqlBackend {
     public getSearchInsightContent = async () => {
         await sleep(2000)
 
@@ -62,7 +59,7 @@ class CodeInsightsStoryBackend extends CodeInsightsSettingsCascadeBackend {
     ]
 }
 
-const codeInsightsBackend = new CodeInsightsStoryBackend(SETTINGS_CASCADE_MOCK, {} as any)
+const codeInsightsBackend = new CodeInsightsStoryBackend({} as any)
 
 const SUBJECTS = [
     createUserSubject('Emir Kusturica'),

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/SearchInsightCreationPage.story.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/SearchInsightCreationPage.story.tsx
@@ -6,8 +6,7 @@ import React from 'react'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { WebStory } from '../../../../../../components/WebStory'
-import { CodeInsightsBackendContext } from '../../../../core/backend/code-insights-backend-context'
-import { CodeInsightsGqlBackend } from '../../../../core/backend/gql-api/code-insights-gql-backend'
+import { CodeInsightsBackendStoryMock } from '../../../../CodeInsightsBackendStoryMock'
 import { SupportedInsightSubject } from '../../../../core/types/subjects'
 import { createGlobalSubject, createOrgSubject, createUserSubject } from '../../../../mocks/settings-cascade'
 
@@ -40,26 +39,23 @@ const fakeAPIRequest = async () => {
     throw new Error('Network error')
 }
 
-class CodeInsightsStoryBackend extends CodeInsightsGqlBackend {
-    public getSearchInsightContent = async () => {
+const codeInsightsBackend = {
+    getSearchInsightContent: async () => {
         await sleep(2000)
 
         return {
             ...DEFAULT_MOCK_CHART_CONTENT,
             data: getRandomDataForMock(),
         }
-    }
-
+    },
     // eslint-disable-next-line @typescript-eslint/require-await
-    public getRepositorySuggestions = async () => [
+    getRepositorySuggestions: async () => [
         { id: '1', name: 'github.com/example/sub-repo-1' },
         { id: '2', name: 'github.com/example/sub-repo-2' },
         { id: '3', name: 'github.com/another-example/sub-repo-1' },
         { id: '4', name: 'github.com/another-example/sub-repo-2' },
-    ]
+    ],
 }
-
-const codeInsightsBackend = new CodeInsightsStoryBackend({} as any)
 
 const SUBJECTS = [
     createUserSubject('Emir Kusturica'),
@@ -68,7 +64,7 @@ const SUBJECTS = [
 ] as SupportedInsightSubject[]
 
 export const SearchInsightCreationPage: Story = () => (
-    <CodeInsightsBackendContext.Provider value={codeInsightsBackend}>
+    <CodeInsightsBackendStoryMock mocks={codeInsightsBackend}>
         <SearchInsightCreationPageComponent
             visibility="user_test_id"
             subjects={SUBJECTS}
@@ -77,5 +73,5 @@ export const SearchInsightCreationPage: Story = () => (
             onSuccessfulCreation={noop}
             onCancel={noop}
         />
-    </CodeInsightsBackendContext.Provider>
+    </CodeInsightsBackendStoryMock>
 )


### PR DESCRIPTION
Related to https://github.com/sourcegraph/sourcegraph/issues/31412

## Test plan

All stories should still run and the Chromatic screenshots should have no changes.