### PR TITLE
migration: Fix squashing tables defined as a row value

### DIFF
--- a/dev/sg/internal/db/db.go
+++ b/dev/sg/internal/db/db.go
@@ -24,11 +24,14 @@ type Database struct {
 	// Name of database, used to convert from arguments to Database
 	Name string
 
-	// Table in database for storing information about migrations.
+	// Table in database for storing information about migrations
 	MigrationsTable string
 
 	// Additional data tables for database
 	DataTables []string
+
+	// Additional single-row aggregate ocunt tables for database
+	CountTables []string
 
 	// Used for retrieving the directory where migrations live
 	FS func() (fs.FS, error)
@@ -45,14 +48,19 @@ var (
 	codeIntelDatabase = Database{
 		Name:            "codeintel",
 		MigrationsTable: "codeintel_schema_migrations",
-		DataTables:      nil,
-		FS:              getFSForPath("codeintel"),
+		CountTables: []string{
+			"lsif_data_apidocs_num_dumps",
+			"lsif_data_apidocs_num_dumps_indexed",
+			"lsif_data_apidocs_num_pages",
+			"lsif_data_apidocs_num_search_results_private",
+			"lsif_data_apidocs_num_search_results_public",
+		},
+		FS: getFSForPath("codeintel"),
 	}
 
 	codeInsightsDatabase = Database{
 		Name:            "codeinsights",
 		MigrationsTable: "codeinsights_schema_migrations",
-		DataTables:      nil,
 		FS:              getFSForPath("codeinsights"),
 	}
 

--- a/dev/sg/internal/migration/squash.go
+++ b/dev/sg/internal/migration/squash.go
@@ -277,6 +277,10 @@ func generateSquashedUpMigration(database db.Database, postgresDSN string) (_ st
 		pgDumpOutput += dataOutput
 	}
 
+	for _, table := range database.CountTables {
+		pgDumpOutput += fmt.Sprintf("INSERT INTO %s VALUES (0);\n", table)
+	}
+
 	return sanitizePgDumpOutput(pgDumpOutput), nil
 }
 

--- a/enterprise/internal/codeintel/stores/lsifstore/data_write_documentation.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/data_write_documentation.go
@@ -731,11 +731,11 @@ func (s *Store) truncateDocumentationSearchIndexSize(ctx context.Context, tableS
 	totalRows, exists, err := basestore.ScanFirstInt64(s.Query(ctx, sqlf.Sprintf(
 		strings.ReplaceAll(countDocumentationSearchRowsQuery, "$SUFFIX", tableSuffix),
 	)))
-	if !exists {
-		return errors.Newf("failed to count table size")
-	}
 	if err != nil {
 		return errors.Wrap(err, "counting table size")
+	}
+	if !exists {
+		return errors.Newf("failed to count table size")
 	}
 
 	searchIndexLimitFactor := s.config.SiteConfig().ApidocsSearchIndexSizeLimitFactor


### PR DESCRIPTION
API docs defined a series of objects composed of counting tables (`CREATE TABLE counter AS SELECT COUNT(*) FROM ...`) and triggers to update those counts.

Squashing these currently fail unit tests. Because the pre-squashed migration actually inserted an initial row value into the table, we must do the same thing in the squashed migration.

## Test plan

This code only modifies the migration squash utility.