### PR TITLE
dev/ci: set direct as goproxy fallback

### DIFF
--- a/enterprise/dev/ci/internal/buildkite/buildkite.go
+++ b/enterprise/dev/ci/internal/buildkite/buildkite.go
@@ -168,21 +168,6 @@ func (p *Pipeline) AddStep(label string, opts ...StepOpt) {
 		opt(step)
 	}
 
-	// Set a default agent queue to assign this job to
-	if len(step.Agents) == 0 {
-		if FeatureFlags.StatelessBuild {
-			step.Agents["queue"] = AgentQueueJob
-		} else {
-			step.Agents["queue"] = AgentQueueStandard
-		}
-	}
-
-	if step.Agents["queue"] != AgentQueueBaremetal {
-		// Use athens proxy for go modules downloads on non-baremetal agents
-		// https://github.com/sourcegraph/infrastructure/blob/main/buildkite/kubernetes/athens-proxy/athens-athens-proxy.Deployment.yaml
-		step.Env["GOPROXY"] = "http://athens-athens-proxy"
-	}
-
 	p.Steps = append(p.Steps, step)
 }
 

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -40,8 +40,13 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		"DATE":                               c.Time.Format(time.RFC3339),
 		"VERSION":                            c.Version,
 
-		// Additional flags
+		// Go flags
 		"GO111MODULE": "on",
+		// Use athens proxy for go modules downloads on non-baremetal agents
+		// https://github.com/sourcegraph/infrastructure/blob/main/buildkite/kubernetes/athens-proxy/athens-athens-proxy.Deployment.yaml
+		"GOPROXY": "http://athens-athens-proxy,direct",
+
+		// Additional flags
 		"FORCE_COLOR": "3",
 		"ENTERPRISE":  "1",
 		// Add debug flags for scripts to consume
@@ -313,12 +318,6 @@ func withAgentQueueDefaults(s *bk.Step) {
 		} else {
 			s.Agents["queue"] = bk.AgentQueueStandard
 		}
-	}
-
-	if s.Agents["queue"] != bk.AgentQueueBaremetal {
-		// Use athens proxy for go modules downloads on non-baremetal agents
-		// https://github.com/sourcegraph/infrastructure/blob/main/buildkite/kubernetes/athens-proxy/athens-athens-proxy.Deployment.yaml
-		s.Env["GOPROXY"] = "http://athens-athens-proxy"
 	}
 }
 


### PR DESCRIPTION
idk how this took me so long but I eventually found https://go-review.googlesource.com/c/go/+/226460/ and some usage examples: https://sourcegraph.com/search?q=context:global+GOPROXY%3D%22.*%28%2C%7C%5C%7C%29direct%22&patternType=regexp

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

gonna run main-dry-run a lot

- https://buildkite.com/sourcegraph/sourcegraph/builds/133240

