### PR TITLE
pr-auditor: allow more base refs

### DIFF
--- a/dev/pr-auditor/main.go
+++ b/dev/pr-auditor/main.go
@@ -52,9 +52,14 @@ func main() {
 	log.Printf("handling event for pull request %s, payload: %+v\n", payload.PullRequest.URL, payload.Dump())
 
 	// Discard unwanted events
-	if payload.PullRequest.Base.Ref != "main" {
-		log.Printf("unknown pull request base %q - discarding\n", payload.PullRequest.Base.Ref)
-		return
+	switch ref := payload.PullRequest.Base.Ref; ref {
+	// This is purely an API call usage requirement, so we don't need to be so specific
+	// as to require usage to provide the default branch - we can just rely on a simple
+	// allowlist of commonly used default branches.
+	case "main", "master", "release":
+		log.Printf("performing checks against allow-listed pull request base %q", ref)
+	default:
+		log.Printf("unknown pull request base %q - discarding\n", ref)
 	}
 	if payload.PullRequest.Draft {
 		log.Println("skipping event on draft PR")


### PR DESCRIPTION
Adds "main", "master", "release" to the allowed base refs.  This is purely an API call usage requirement, so we don't need to be so specific as to require usage to provide the default branch - we can just rely on a simple allowlist of commonly used default branches.

Enables https://github.com/sourcegraph/sourcegraph/pull/31687

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

This PR should still get a status check