### PR TITLE
Run all integration test files in CI

### DIFF
--- a/dev/ci/yarn-web-integration.sh
+++ b/dev/ci/yarn-web-integration.sh
@@ -11,9 +11,7 @@ echo "--- Yarn install in root"
 yarn --mutex network --frozen-lockfile --network-timeout 60000
 
 echo "--- Run integration test suite"
-# Word splittinng is intentional here. $1 contains a string with test files separated by a space.
-# shellcheck disable=SC2086
-yarn percy exec --parallel yarn cover-integration:base $1
+yarn percy exec --parallel yarn cover-integration:base "$@"
 
 echo "--- Process NYC report"
 yarn nyc report -r json


### PR DESCRIPTION
Instead of just the first argument, we should pass all arguments to the `yarn-web-integration.sh` script.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


*  Checked that all integration test files are now running in Buildkite