### PR TITLE
repo-updater: Remove scheduler interface

### DIFF
--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -30,7 +30,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	connections "github.com/sourcegraph/sourcegraph/internal/database/connections/live"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -48,7 +47,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 const port = "3182"
@@ -131,10 +129,10 @@ func Main(enterpriseInit EnterpriseInit) {
 		src = repos.NewSourcer(cf, repos.WithDB(db), repos.ObservedSource(log15.Root(), m))
 	}
 
-	scheduler := repos.NewUpdateScheduler()
+	updateScheduler := repos.NewUpdateScheduler()
 	server := &repoupdater.Server{
 		Store:                 store,
-		Scheduler:             scheduler,
+		Scheduler:             updateScheduler,
 		GitserverClient:       gitserver.DefaultClient,
 		SourcegraphDotComMode: envvar.SourcegraphDotComMode(),
 	}
@@ -170,7 +168,7 @@ func Main(enterpriseInit EnterpriseInit) {
 		gps = repos.NewGitolitePhabricatorMetadataSyncer(store)
 	}
 
-	go watchSyncer(ctx, syncer, scheduler, gps, server.PermsSyncer)
+	go watchSyncer(ctx, syncer, updateScheduler, gps, server.PermsSyncer)
 	go func() {
 		log.Fatal(syncer.Run(ctx, store, repos.RunOptions{
 			EnqueueInterval: repos.ConfRepoListUpdateInterval,
@@ -180,7 +178,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	}()
 	server.Syncer = syncer
 
-	go syncScheduler(ctx, scheduler, store)
+	go syncScheduler(ctx, updateScheduler, store)
 
 	if envvar.SourcegraphDotComMode() {
 		rateLimiter := rate.NewLimiter(.05, 1)
@@ -195,7 +193,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	}
 
 	// Git fetches scheduler
-	go repos.RunScheduler(ctx, scheduler)
+	go repos.RunScheduler(ctx, updateScheduler)
 	log15.Debug("started scheduler")
 
 	host := ""
@@ -220,7 +218,7 @@ func Main(enterpriseInit EnterpriseInit) {
 
 	globals.WatchExternalURL(nil)
 
-	debugserverEndpoints.repoUpdaterStateEndpoint = repoUpdaterStatsHandler(db, scheduler, debugDumpers)
+	debugserverEndpoints.repoUpdaterStateEndpoint = repoUpdaterStatsHandler(db, updateScheduler, debugDumpers)
 	debugserverEndpoints.listAuthzProvidersEndpoint = listAuthzProvidersHandler()
 	debugserverEndpoints.gitserverReposStatus = gitserverReposStatusHandler(db)
 
@@ -336,7 +334,7 @@ func listAuthzProvidersHandler() http.HandlerFunc {
 	}
 }
 
-func repoUpdaterStatsHandler(db database.DB, scheduler scheduler, debugDumpers []debugserver.Dumper) http.HandlerFunc {
+func repoUpdaterStatsHandler(db database.DB, scheduler *repos.UpdateScheduler, debugDumpers []debugserver.Dumper) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		dumps := []interface{}{
 			scheduler.DebugDump(r.Context(), db),
@@ -392,23 +390,6 @@ func repoUpdaterStatsHandler(db database.DB, scheduler scheduler, debugDumpers [
 	}
 }
 
-type scheduler interface {
-	// UpdateFromDiff updates the scheduled and queued repos from the given sync diff.
-	UpdateFromDiff(repos.Diff)
-
-	// PrioritiseUncloned ensures uncloned repos are given priority in the scheduler.
-	PrioritiseUncloned([]string)
-
-	// ListRepos lists all the repos managed by the scheduler.
-	ListRepos() []string
-
-	// EnsureScheduled ensures that all the repos provided are known to the scheduler.
-	EnsureScheduled([]types.MinimalRepo)
-
-	// DebugDump returns the state of the update scheduler for debugging.
-	DebugDump(ctx context.Context, db dbutil.DB) interface{}
-}
-
 type permsSyncer interface {
 	// ScheduleRepos schedules new permissions syncing requests for given repositories.
 	ScheduleRepos(ctx context.Context, repoIDs ...api.RepoID)
@@ -417,7 +398,7 @@ type permsSyncer interface {
 func watchSyncer(
 	ctx context.Context,
 	syncer *repos.Syncer,
-	sched scheduler,
+	sched *repos.UpdateScheduler,
 	gps *repos.GitolitePhabricatorMetadataSyncer,
 	permsSyncer permsSyncer,
 ) {
@@ -471,7 +452,7 @@ func getPrivateAddedOrModifiedRepos(diff repos.Diff) []api.RepoID {
 // syncScheduler will periodically list the cloned repositories on gitserver and
 // update the scheduler with the list. It also ensures that if any of our default
 // repos are missing from the cloned list they will be added for cloning ASAP.
-func syncScheduler(ctx context.Context, sched scheduler, store *repos.Store) {
+func syncScheduler(ctx context.Context, sched *repos.UpdateScheduler, store *repos.Store) {
 	baseRepoStore := database.ReposWith(store)
 
 	doSync := func() {

--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -29,7 +29,7 @@ type schedulerConfig struct {
 }
 
 // RunScheduler runs the worker that schedules git fetches of synced repositories in git-server.
-func RunScheduler(ctx context.Context, scheduler *updateScheduler) {
+func RunScheduler(ctx context.Context, scheduler *UpdateScheduler) {
 	var (
 		have schedulerConfig
 		stop context.CancelFunc
@@ -86,7 +86,7 @@ const (
 	maxDelay = 8 * time.Hour
 )
 
-// updateScheduler schedules repo update (or clone) requests to gitserver.
+// UpdateScheduler schedules repo update (or clone) requests to gitserver.
 //
 // Repository metadata is synced from configured code hosts and added to the scheduler.
 //
@@ -104,7 +104,7 @@ const (
 //
 // A worker continuously dequeues repos and sends updates to gitserver, but its concurrency
 // is limited by the gitMaxConcurrentClones site configuration.
-type updateScheduler struct {
+type UpdateScheduler struct {
 	updateQueue *updateQueue
 	schedule    *schedule
 }
@@ -123,8 +123,8 @@ type configuredRepo struct {
 const notifyChanBuffer = 1
 
 // NewUpdateScheduler returns a new scheduler.
-func NewUpdateScheduler() *updateScheduler {
-	return &updateScheduler{
+func NewUpdateScheduler() *UpdateScheduler {
+	return &UpdateScheduler{
 		updateQueue: &updateQueue{
 			index:         make(map[api.RepoID]*repoUpdate),
 			notifyEnqueue: make(chan struct{}, notifyChanBuffer),
@@ -138,7 +138,7 @@ func NewUpdateScheduler() *updateScheduler {
 }
 
 // runScheduleLoop starts the loop that schedules updates by enqueuing them into the updateQueue.
-func (s *updateScheduler) runScheduleLoop(ctx context.Context) {
+func (s *UpdateScheduler) runScheduleLoop(ctx context.Context) {
 	for {
 		select {
 		case <-s.schedule.wakeup:
@@ -152,7 +152,7 @@ func (s *updateScheduler) runScheduleLoop(ctx context.Context) {
 	}
 }
 
-func (s *updateScheduler) runSchedule() {
+func (s *UpdateScheduler) runSchedule() {
 	s.schedule.mu.Lock()
 	defer s.schedule.mu.Unlock()
 	defer s.schedule.rescheduleTimer()
@@ -171,7 +171,7 @@ func (s *updateScheduler) runSchedule() {
 }
 
 // runUpdateLoop sends repo update requests to gitserver.
-func (s *updateScheduler) runUpdateLoop(ctx context.Context) {
+func (s *UpdateScheduler) runUpdateLoop(ctx context.Context) {
 	limiter := configuredLimiter()
 
 	for {
@@ -224,7 +224,7 @@ func (s *updateScheduler) runUpdateLoop(ctx context.Context) {
 						s.schedule.updateInterval(repo, currentInterval*2)
 					}
 				} else if resp != nil && resp.LastFetched != nil && resp.LastChanged != nil {
-					// This is the heuristic that is described in the updateScheduler documentation.
+					// This is the heuristic that is described in the UpdateScheduler documentation.
 					// Update that documentation if you update this logic.
 					interval := resp.LastFetched.Sub(*resp.LastChanged) / 2
 					s.schedule.updateInterval(repo, interval)
@@ -285,7 +285,7 @@ var configuredLimiter = func() *mutablelimiter.Limiter {
 //                commits. Enqueue for asap clone (or fetch).
 //   Unmodified - we likely already have this cloned. Just rely on
 //                the scheduler and do not enqueue.
-func (s *updateScheduler) UpdateFromDiff(diff Diff) {
+func (s *UpdateScheduler) UpdateFromDiff(diff Diff) {
 	for _, r := range diff.Deleted {
 		s.remove(r)
 	}
@@ -314,17 +314,17 @@ func (s *updateScheduler) UpdateFromDiff(diff Diff) {
 //
 // This method should be called periodically with the list of all repositories
 // managed by the scheduler that are not cloned on gitserver.
-func (s *updateScheduler) PrioritiseUncloned(names []string) {
+func (s *UpdateScheduler) PrioritiseUncloned(names []string) {
 	s.schedule.prioritiseUncloned(names)
 }
 
 // EnsureScheduled ensures that all repos in repos exist in the scheduler.
-func (s *updateScheduler) EnsureScheduled(repos []types.MinimalRepo) {
+func (s *UpdateScheduler) EnsureScheduled(repos []types.MinimalRepo) {
 	s.schedule.insertNew(repos)
 }
 
 // ListRepos list all repos managed by the scheduler
-func (s *updateScheduler) ListRepos() []string {
+func (s *UpdateScheduler) ListRepos() []string {
 	s.schedule.mu.Lock()
 	defer s.schedule.mu.Unlock()
 
@@ -340,7 +340,7 @@ func (s *updateScheduler) ListRepos() []string {
 //
 // If enqueue is true then r is also enqueued to the update queue for a git
 // fetch/clone soon.
-func (s *updateScheduler) upsert(r *types.Repo, enqueue bool) {
+func (s *UpdateScheduler) upsert(r *types.Repo, enqueue bool) {
 	repo := configuredRepoFromRepo(r)
 
 	updated := s.schedule.upsert(repo)
@@ -353,7 +353,7 @@ func (s *updateScheduler) upsert(r *types.Repo, enqueue bool) {
 	log15.Debug("scheduler.updateQueue.enqueued", "repo", r.Name, "updated", updated)
 }
 
-func (s *updateScheduler) remove(r *types.Repo) {
+func (s *UpdateScheduler) remove(r *types.Repo) {
 	repo := configuredRepoFromRepo(r)
 
 	if s.schedule.remove(repo) {
@@ -376,7 +376,7 @@ func configuredRepoFromRepo(r *types.Repo) configuredRepo {
 
 // UpdateOnce causes a single update of the given repository.
 // It neither adds nor removes the repo from the schedule.
-func (s *updateScheduler) UpdateOnce(id api.RepoID, name api.RepoName) {
+func (s *UpdateScheduler) UpdateOnce(id api.RepoID, name api.RepoName) {
 	repo := configuredRepo{
 		ID:   id,
 		Name: name,
@@ -386,7 +386,7 @@ func (s *updateScheduler) UpdateOnce(id api.RepoID, name api.RepoName) {
 }
 
 // DebugDump returns the state of the update scheduler for debugging.
-func (s *updateScheduler) DebugDump(ctx context.Context, db dbutil.DB) interface{} {
+func (s *UpdateScheduler) DebugDump(ctx context.Context, db dbutil.DB) interface{} {
 	data := struct {
 		Name        string
 		UpdateQueue []*repoUpdate
@@ -444,7 +444,7 @@ func (s *updateScheduler) DebugDump(ctx context.Context, db dbutil.DB) interface
 }
 
 // ScheduleInfo returns the current schedule info for a repo.
-func (s *updateScheduler) ScheduleInfo(id api.RepoID) *protocol.RepoUpdateSchedulerInfoResult {
+func (s *UpdateScheduler) ScheduleInfo(id api.RepoID) *protocol.RepoUpdateSchedulerInfoResult {
 	var result protocol.RepoUpdateSchedulerInfoResult
 
 	s.schedule.mu.Lock()

--- a/internal/repos/scheduler_test.go
+++ b/internal/repos/scheduler_test.go
@@ -538,13 +538,13 @@ func TestUpdateQueue_acquireNext(t *testing.T) {
 	}
 }
 
-func setupInitialQueue(s *updateScheduler, initialQueue []*repoUpdate) {
+func setupInitialQueue(s *UpdateScheduler, initialQueue []*repoUpdate) {
 	for _, update := range initialQueue {
 		heap.Push(s.updateQueue, update)
 	}
 }
 
-func verifyQueue(t *testing.T, s *updateScheduler, expected []*repoUpdate) {
+func verifyQueue(t *testing.T, s *UpdateScheduler, expected []*repoUpdate) {
 	t.Helper()
 
 	var actualQueue []*repoUpdate
@@ -1147,13 +1147,13 @@ func TestSchedule_remove(t *testing.T) {
 	}
 }
 
-func setupInitialSchedule(s *updateScheduler, initialSchedule []*scheduledRepoUpdate) {
+func setupInitialSchedule(s *UpdateScheduler, initialSchedule []*scheduledRepoUpdate) {
 	for _, update := range initialSchedule {
 		heap.Push(s.schedule, update)
 	}
 }
 
-func verifySchedule(t *testing.T, s *updateScheduler, expected []*scheduledRepoUpdate) {
+func verifySchedule(t *testing.T, s *UpdateScheduler, expected []*scheduledRepoUpdate) {
 	t.Helper()
 
 	var actualSchedule []*scheduledRepoUpdate
@@ -1168,7 +1168,7 @@ func verifySchedule(t *testing.T, s *updateScheduler, expected []*scheduledRepoU
 	}
 }
 
-func verifyScheduleRecording(t *testing.T, s *updateScheduler, timeAfterFuncDelays []time.Duration, wakeupNotifications int, r *recording) {
+func verifyScheduleRecording(t *testing.T, s *UpdateScheduler, timeAfterFuncDelays []time.Duration, wakeupNotifications int, r *recording) {
 	t.Helper()
 
 	if !reflect.DeepEqual(timeAfterFuncDelays, r.timeAfterFuncDelays) {
@@ -1199,7 +1199,7 @@ func TestUpdateScheduler_runSchedule(t *testing.T) {
 		finalSchedule         []*scheduledRepoUpdate
 		finalQueue            []*repoUpdate
 		timeAfterFuncDelays   []time.Duration
-		expectedNotifications func(s *updateScheduler) []chan struct{}
+		expectedNotifications func(s *UpdateScheduler) []chan struct{}
 	}{
 		{
 			name: "empty schedule",
@@ -1213,7 +1213,7 @@ func TestUpdateScheduler_runSchedule(t *testing.T) {
 				{Repo: a, Interval: 11 * time.Second, Due: defaultTime.Add(time.Minute)},
 			},
 			timeAfterFuncDelays: []time.Duration{time.Minute},
-			expectedNotifications: func(s *updateScheduler) []chan struct{} {
+			expectedNotifications: func(s *UpdateScheduler) []chan struct{} {
 				return []chan struct{}{s.schedule.wakeup}
 			},
 		},
@@ -1231,7 +1231,7 @@ func TestUpdateScheduler_runSchedule(t *testing.T) {
 				{Repo: a, Priority: priorityLow, Seq: 1},
 			},
 			timeAfterFuncDelays: []time.Duration{11 * time.Second},
-			expectedNotifications: func(s *updateScheduler) []chan struct{} {
+			expectedNotifications: func(s *UpdateScheduler) []chan struct{} {
 				return []chan struct{}{s.updateQueue.notifyEnqueue, s.schedule.wakeup}
 			},
 		},
@@ -1249,7 +1249,7 @@ func TestUpdateScheduler_runSchedule(t *testing.T) {
 				{Repo: a, Priority: priorityLow, Seq: 1},
 			},
 			timeAfterFuncDelays: []time.Duration{time.Minute},
-			expectedNotifications: func(s *updateScheduler) []chan struct{} {
+			expectedNotifications: func(s *UpdateScheduler) []chan struct{} {
 				return []chan struct{}{s.updateQueue.notifyEnqueue, s.schedule.wakeup}
 			},
 		},
@@ -1277,7 +1277,7 @@ func TestUpdateScheduler_runSchedule(t *testing.T) {
 				{Repo: b, Priority: priorityLow, Seq: 5},
 			},
 			timeAfterFuncDelays: []time.Duration{1 * time.Minute},
-			expectedNotifications: func(s *updateScheduler) []chan struct{} {
+			expectedNotifications: func(s *UpdateScheduler) []chan struct{} {
 				return []chan struct{}{
 					s.updateQueue.notifyEnqueue,
 					s.updateQueue.notifyEnqueue,
@@ -1328,7 +1328,7 @@ func TestUpdateScheduler_runUpdateLoop(t *testing.T) {
 		finalSchedule          []*scheduledRepoUpdate
 		finalQueue             []*repoUpdate
 		timeAfterFuncDelays    []time.Duration
-		expectedNotifications  func(s *updateScheduler) []chan struct{}
+		expectedNotifications  func(s *UpdateScheduler) []chan struct{}
 	}{
 		{
 			name: "empty queue",
@@ -1386,7 +1386,7 @@ func TestUpdateScheduler_runUpdateLoop(t *testing.T) {
 				{Repo: a, Interval: time.Minute, Due: defaultTime.Add(time.Minute)},
 			},
 			timeAfterFuncDelays: []time.Duration{time.Minute},
-			expectedNotifications: func(s *updateScheduler) []chan struct{} {
+			expectedNotifications: func(s *UpdateScheduler) []chan struct{} {
 				return []chan struct{}{s.schedule.wakeup}
 			},
 		},
@@ -1468,13 +1468,13 @@ func TestUpdateScheduler_runUpdateLoop(t *testing.T) {
 	}
 }
 
-func verifyRecording(t *testing.T, s *updateScheduler, timeAfterFuncDelays []time.Duration, expectedNotifications func(s *updateScheduler) []chan struct{}, r *recording) {
+func verifyRecording(t *testing.T, s *UpdateScheduler, timeAfterFuncDelays []time.Duration, expectedNotifications func(s *UpdateScheduler) []chan struct{}, r *recording) {
 	if !reflect.DeepEqual(timeAfterFuncDelays, r.timeAfterFuncDelays) {
 		t.Fatalf("\nexpected timeAfterFuncDelays\n%s\ngot\n%s", spew.Sdump(timeAfterFuncDelays), spew.Sdump(r.timeAfterFuncDelays))
 	}
 
 	if expectedNotifications == nil {
-		expectedNotifications = func(s *updateScheduler) []chan struct{} {
+		expectedNotifications = func(s *UpdateScheduler) []chan struct{} {
 			return nil
 		}
 	}


### PR DESCRIPTION
We introduce a couple of cleanups here:

* Export the `repos.UpdateScheduler` type as it is reference a lot outside of the `repos` package
* Remove the `scheduler` interface from repo updater. There's no need for the indirection and we can just use `repos.UpdateScheduler` directly.
* Extracted some code into a `getPrivateAddedOrModifiedRepos` helper function

# Test Plan

No functional changes, all unit test continue to pass.