### PR TITLE
insights: skip timescaledb tests if testing -short

### DIFF
--- a/enterprise/internal/insights/dbtesting/insights.go
+++ b/enterprise/internal/insights/dbtesting/insights.go
@@ -18,6 +18,10 @@ import (
 // The returned DB handle is initialized with a unique database just for the specified test, with
 // all migrations applied.
 func TimescaleDB(t testing.TB) (db *sql.DB, cleanup func()) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	// Setup TimescaleDB for testing.
 	if os.Getenv("CODEINSIGHTS_PGDATASOURCE") == "" {
 		os.Setenv("CODEINSIGHTS_PGDATASOURCE", "postgres://postgres:password@127.0.0.1:5435/postgres")


### PR DESCRIPTION
This is mentioned in the documentation but not respected. Now tests will
run faster if short is passed in. This is the same behaviour for our
normal DB tests.

Test Plan: `go test -short enterprise/internal/insights/background/queryrunner` runs quickly and passes