### PR TITLE
Only requests extra scopes when adding code host connection

### DIFF
--- a/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
@@ -69,12 +69,17 @@ func newOAuthFlowHandler(db database.DB, serviceType string) http.Handler {
 			http.Error(w, "Misconfigured GitHub auth provider.", http.StatusInternalServerError)
 			return
 		}
+		op := req.URL.Query().Get("op")
+		extraScopes := []string{}
+		var err error
+		if op == string(LoginStateOpCreateCodeHostConnection) {
 
-		extraScopes, err := getExtraScopes(req.Context(), db, serviceType)
-		if err != nil {
-			log15.Error("Getting extra OAuth scopes", "error", err)
-			http.Error(w, "Authentication failed. Try signing in again (and clearing cookies for the current site).", http.StatusInternalServerError)
-			return
+			extraScopes, err = getExtraScopes(req.Context(), db, serviceType)
+			if err != nil {
+				log15.Error("Getting extra OAuth scopes", "error", err)
+				http.Error(w, "Authentication failed. Try signing in again (and clearing cookies for the current site).", http.StatusInternalServerError)
+				return
+			}
 		}
 
 		p.Login(p.OAuth2Config(extraScopes...)).ServeHTTP(w, req)

--- a/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
@@ -70,16 +70,11 @@ func newOAuthFlowHandler(db database.DB, serviceType string) http.Handler {
 			return
 		}
 		op := LoginStateOp(req.URL.Query().Get("op"))
-		extraScopes := []string{}
-		var err error
-		if op == LoginStateOpCreateCodeHostConnection {
-
-			extraScopes, err = getExtraScopes(req.Context(), db, serviceType)
-			if err != nil {
-				log15.Error("Getting extra OAuth scopes", "error", err)
-				http.Error(w, "Authentication failed. Try signing in again (and clearing cookies for the current site).", http.StatusInternalServerError)
-				return
-			}
+		extraScopes, err := getExtraScopes(req.Context(), db, serviceType, op)
+		if err != nil {
+			log15.Error("Getting extra OAuth scopes", "error", err)
+			http.Error(w, "Authentication failed. Try signing in again (and clearing cookies for the current site).", http.StatusInternalServerError)
+			return
 		}
 
 		p.Login(p.OAuth2Config(extraScopes...)).ServeHTTP(w, req)
@@ -110,9 +105,13 @@ var extraScopes = map[string][]string{
 	extsvc.TypeGitLab: {"api"},
 }
 
-func getExtraScopes(ctx context.Context, db database.DB, serviceType string) ([]string, error) {
+func getExtraScopes(ctx context.Context, db database.DB, serviceType string, op LoginStateOp) ([]string, error) {
 	// Extra scopes are only needed on Sourcegraph.com
 	if !envvar.SourcegraphDotComMode() {
+		return nil, nil
+	}
+	// Extra scopes are only needed when creating a code host connection, not for account creation
+	if op == LoginStateOpCreateAccount {
 		return nil, nil
 	}
 	scopes, ok := extraScopes[serviceType]
@@ -120,7 +119,7 @@ func getExtraScopes(ctx context.Context, db database.DB, serviceType string) ([]
 		return nil, nil
 	}
 
-	mode, err := database.Users(db).CurrentUserAllowedExternalServices(ctx)
+	mode, err := db.Users().CurrentUserAllowedExternalServices(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
@@ -69,10 +69,10 @@ func newOAuthFlowHandler(db database.DB, serviceType string) http.Handler {
 			http.Error(w, "Misconfigured GitHub auth provider.", http.StatusInternalServerError)
 			return
 		}
-		op := req.URL.Query().Get("op")
+		op := LoginStateOp(req.URL.Query().Get("op"))
 		extraScopes := []string{}
 		var err error
-		if op == string(LoginStateOpCreateCodeHostConnection) {
+		if op == LoginStateOpCreateCodeHostConnection {
 
 			extraScopes, err = getExtraScopes(req.Context(), db, serviceType)
 			if err != nil {

--- a/enterprise/cmd/frontend/internal/auth/oauth/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/middleware_test.go
@@ -21,17 +21,17 @@ func Test_getExtraScopes(t *testing.T) {
 	db := database.NewStrictMockDB()
 	db.UsersFunc.SetDefaultReturn(u)
 	for name, test := range map[string]struct {
-		operation, provider string
-		scopes              []string
+		operation LoginStateOp
+		provider  string
+		scopes    []string
 	}{
-		"withoutScopes_gitlab": {"", extsvc.TypeGitLab, []string{}},
-		"withoutScopes_github": {"", extsvc.TypeGitHub, []string{}},
-		"withScopes_gitlab":    {LoginStateOpCreateAccount, extsvc.TypeGitLab, []string{"api"}},
-		"withScopes_github":    {LoginStateOpCreateAccount, extsvc.TypeGitHub, []string{"repo"}},
+		"withoutScopes_gitlab": {LoginStateOpCreateAccount, extsvc.TypeGitLab, []string{}},
+		"withoutScopes_github": {LoginStateOpCreateAccount, extsvc.TypeGitHub, []string{}},
+		"withScopes_gitlab":    {LoginStateOpCreateCodeHostConnection, extsvc.TypeGitLab, []string{"api"}},
+		"withScopes_github":    {LoginStateOpCreateCodeHostConnection, extsvc.TypeGitHub, []string{"repo"}},
 	} {
 		t.Run(name, func(t *testing.T) {
-
-			got, err := getExtraScopes(context.Background(), db, test.provider, LoginStateOp(test.operation))
+			got, err := getExtraScopes(context.Background(), db, test.provider, test.operation)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/enterprise/cmd/frontend/internal/auth/oauth/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/middleware_test.go
@@ -24,8 +24,8 @@ func Test_getExtraScopes(t *testing.T) {
 	}{
 		"withoutScopes_gitlab": {"", extsvc.TypeGitLab, []string{}},
 		"withoutScopes_github": {"", extsvc.TypeGitHub, []string{}},
-		"withScopes_gitlab":    {"createCodeHostConnection", extsvc.TypeGitLab, []string{"api"}},
-		"withScopes_github":    {"createCodeHostConnection", extsvc.TypeGitHub, []string{"repo"}},
+		"withScopes_gitlab":    {LoginStateOpCreateAccount, extsvc.TypeGitLab, []string{"api"}},
+		"withScopes_github":    {LoginStateOpCreateAccount, extsvc.TypeGitHub, []string{"repo"}},
 	} {
 		t.Run(name, func(t *testing.T) {
 

--- a/enterprise/cmd/frontend/internal/auth/oauth/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/middleware_test.go
@@ -13,7 +13,9 @@ import (
 )
 
 func Test_getExtraScopes(t *testing.T) {
+	dotcom := envvar.SourcegraphDotComMode()
 	envvar.MockSourcegraphDotComMode(true)
+	defer envvar.MockSourcegraphDotComMode(dotcom)
 	u := database.NewStrictMockUserStore()
 	u.CurrentUserAllowedExternalServicesFunc.SetDefaultReturn(conf.ExternalServiceModeAll, nil)
 	db := database.NewStrictMockDB()

--- a/enterprise/cmd/frontend/internal/auth/oauth/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/middleware_test.go
@@ -1,0 +1,41 @@
+package oauth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+)
+
+func Test_getExtraScopes(t *testing.T) {
+	envvar.MockSourcegraphDotComMode(true)
+	u := database.NewStrictMockUserStore()
+	u.CurrentUserAllowedExternalServicesFunc.SetDefaultReturn(conf.ExternalServiceModeAll, nil)
+	db := database.NewStrictMockDB()
+	db.UsersFunc.SetDefaultReturn(u)
+	for name, test := range map[string]struct {
+		operation, provider string
+		scopes              []string
+	}{
+		"withoutScopes_gitlab": {"", extsvc.TypeGitLab, []string{}},
+		"withoutScopes_github": {"", extsvc.TypeGitHub, []string{}},
+		"withScopes_gitlab":    {"createCodeHostConnection", extsvc.TypeGitLab, []string{"api"}},
+		"withScopes_github":    {"createCodeHostConnection", extsvc.TypeGitHub, []string{"repo"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+
+			got, err := getExtraScopes(context.Background(), db, test.provider, LoginStateOp(test.operation))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !assert.ElementsMatch(t, got, test.scopes) {
+				t.Errorf("Expected %v got %v", test.scopes, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Only request extraScopes when `op=createCodeHostConnection` parameter was passed during OAuth login - [CLOUD-129](https://sourcegraph.atlassian.net/browse/CLOUD-129)

**Tested**

1. Added unit tests
2. Verified locally in this [Loom](https://www.loom.com/share/b5edf94038b5437db6a589ba2eb74935)