### PR TITLE
Remove plus button and fix outline

### DIFF
--- a/client/web/src/search/panels/SavedSearchesPanel.tsx
+++ b/client/web/src/search/panels/SavedSearchesPanel.tsx
@@ -130,7 +130,7 @@ export const SavedSearchesPanel: React.FunctionComponent<Props> = ({
             <ButtonGroup>
                 <Button
                     onClick={() => setShowAllSearches(false)}
-                    className={classNames('test-saved-search-panel-my-searches')}
+                    className="test-saved-search-panel-my-searches"
                     outline={showAllSearches}
                     variant="secondary"
                     size="sm"
@@ -139,7 +139,7 @@ export const SavedSearchesPanel: React.FunctionComponent<Props> = ({
                 </Button>
                 <Button
                     onClick={() => setShowAllSearches(true)}
-                    className={classNames('test-saved-search-panel-all-searches')}
+                    className="test-saved-search-panel-all-searches"
                     outline={!showAllSearches}
                     variant="secondary"
                     size="sm"

--- a/client/web/src/search/panels/SavedSearchesPanel.tsx
+++ b/client/web/src/search/panels/SavedSearchesPanel.tsx
@@ -128,27 +128,10 @@ export const SavedSearchesPanel: React.FunctionComponent<Props> = ({
     const actionButtons = (
         <ActionButtonGroup>
             <ButtonGroup>
-                {authenticatedUser && (
-                    <Button
-                        to={`/users/${authenticatedUser.username}/searches/add`}
-                        className="mr-2"
-                        onClick={logEvent('SavedSearchesPanelCreateButtonClicked', { source: 'toolbar' })}
-                        variant="secondary"
-                        outline={true}
-                        as={Link}
-                        size="sm"
-                    >
-                        +
-                    </Button>
-                )}
-            </ButtonGroup>
-            <ButtonGroup>
                 <Button
                     onClick={() => setShowAllSearches(false)}
-                    className={classNames('test-saved-search-panel-my-searches', {
-                        active: !showAllSearches,
-                    })}
-                    outline={true}
+                    className={classNames('test-saved-search-panel-my-searches')}
+                    outline={showAllSearches}
                     variant="secondary"
                     size="sm"
                 >
@@ -156,10 +139,8 @@ export const SavedSearchesPanel: React.FunctionComponent<Props> = ({
                 </Button>
                 <Button
                     onClick={() => setShowAllSearches(true)}
-                    className={classNames('test-saved-search-panel-all-searches', {
-                        active: showAllSearches,
-                    })}
-                    outline={true}
+                    className={classNames('test-saved-search-panel-all-searches')}
+                    outline={!showAllSearches}
                     variant="secondary"
                     size="sm"
                 >


### PR DESCRIPTION
Currently, the action buttons shown in the saved searches panel on the home pages shows an outline for when one button is selected:

![image](https://user-images.githubusercontent.com/458591/155337092-00563551-e484-4fef-acc8-07da70a8811b.png)

This is an issue in multiple ways:

- It steals attention even though there's nothing to work on 
- It makes the site less accessible since it can be confused with the active element.

This has also been raised internally: https://sourcegraph.slack.com/archives/CHEKCRWKV/p1645538194224819

To fix this and also pave the way for making this panel a tab component for the user invitations work (https://github.com/sourcegraph/sourcegraph/issues/31214), we're making two small changes here as also discussed in this [Figma](https://www.figma.com/file/Og1zVk7BbZ7SWTXM5WsWA5/Account-Setups-OKR-explorations?node-id=77%3A12655):

- We remove the plus sign since it looks really odd and people clashes with the null page that also has an "add" CTA. Additionally, if a user already has saved searches, they can add one by following the link at the bottom of this panel.
- Instead of showing an active outline, we toggle between the outline properties of the button to make it appear "grayed out"

_Note: as part of the above work we will also make this button group collapsable if there's not enough space to avoid it overlapping the tab elements. This will happen later in https://github.com/sourcegraph/sourcegraph/pull/31406._

## Test plan

- Start SG in on-prem mode (`sg start`) and go to the home page.
- You will see the changes on the bottom right:
![Screenshot 2022-02-23 at 15 23 30](https://user-images.githubusercontent.com/458591/155338080-bd7fb77c-3559-47f7-8445-bd2afc47d0a9.png)

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


