### PR TITLE
migrations: Make revert operation more resilient

### DIFF
--- a/internal/database/migration/runner/options.go
+++ b/internal/database/migration/runner/options.go
@@ -82,7 +82,7 @@ func desugarRevert(schemaContext schemaContext, operation MigrationOperation) (M
 			counts[parent] = counts[parent] + 1
 		}
 
-		// Smort :clueless:
+Ensure that we have an entry for this definition (but do not modify the count)
 		counts[definition.ID] = counts[definition.ID] + 0
 	}
 

--- a/internal/database/migration/runner/options.go
+++ b/internal/database/migration/runner/options.go
@@ -82,7 +82,7 @@ func desugarRevert(schemaContext schemaContext, operation MigrationOperation) (M
 			counts[parent] = counts[parent] + 1
 		}
 
-Ensure that we have an entry for this definition (but do not modify the count)
+		// Ensure that we have an entry for this definition (but do not modify the count)
 		counts[definition.ID] = counts[definition.ID] + 0
 	}
 

--- a/internal/database/migration/runner/options.go
+++ b/internal/database/migration/runner/options.go
@@ -1,6 +1,8 @@
 package runner
 
-import "github.com/sourcegraph/sourcegraph/lib/errors"
+import (
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
 
 type Options struct {
 	Operations []MigrationOperation
@@ -71,17 +73,17 @@ func desugarRevert(schemaContext schemaContext, operation MigrationOperation) (M
 	// Construct a map from migration version to the number of its children that are also applied
 	counts := make(map[int]int, len(schemaVersion.appliedVersions))
 	for _, version := range schemaVersion.appliedVersions {
-		counts[version] = 0
-	}
-	for _, version := range schemaVersion.appliedVersions {
 		definition, ok := definitions.GetByID(version)
 		if !ok {
-			return MigrationOperation{}, errors.Newf("unknown version %d", version)
+			continue
 		}
 
 		for _, parent := range definition.Parents {
-			counts[parent]++
+			counts[parent] = counts[parent] + 1
 		}
+
+		// Smort :clueless:
+		counts[definition.ID] = counts[definition.ID] + 0
 	}
 
 	// Find applied migrations with no applied children


### PR DESCRIPTION
In dev, where the `sg migration undo` command is most useful, we error if there are unknown definitions (from migrations applied on another branch or due to a squash since the last application). This removes that error instead looking only at the set of applied migrations.

## Test plan

Unit tests.