### PR TITLE
pr-auditor: ensure repo label exists on issue create

### DIFF
--- a/dev/pr-auditor/main.go
+++ b/dev/pr-auditor/main.go
@@ -119,6 +119,14 @@ func postMergeAudit(ctx context.Context, ghc *github.Client, payload *EventPaylo
 
 	issue := generateExceptionIssue(payload, &result)
 
+	log.Printf("Ensuring label for repository %q\n", payload.Repository.FullName)
+	_, _, err := ghc.Issues.CreateLabel(ctx, flags.IssuesRepoName, flags.IssuesRepoName, &github.Label{
+		Name: github.String(payload.Repository.FullName),
+	})
+	if err != nil {
+		log.Printf("Ignoring error on CreateLabel: %s\n", err)
+	}
+
 	log.Printf("Creating issue for exception: %+v\n", issue)
 	created, _, err := ghc.Issues.Create(ctx, flags.IssuesRepoOwner, flags.IssuesRepoName, issue)
 	if err != nil {


### PR DESCRIPTION
A closer look at https://github.com/sourcegraph/sourcegraph/issues/30427#issuecomment-1048905542 indicates we will have far more repos than anticipated that require pr auditing. Rather than create labels for the repositories manually, we have `pr-auditor` ensure them instead.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

n/a
