### PR TITLE
Code monitors: expose query and result count on trigger resolver

### DIFF
--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -67,6 +67,8 @@ type MonitorTriggerEventResolver interface {
 	Message() *string
 	Timestamp() (DateTime, error)
 	Actions(ctx context.Context, args *ListActionArgs) (MonitorActionConnectionResolver, error)
+	ResultCount() int32
+	Query() *string
 }
 
 type MonitorActionConnectionResolver interface {

--- a/cmd/frontend/graphqlbackend/code_monitors.graphql
+++ b/cmd/frontend/graphqlbackend/code_monitors.graphql
@@ -265,6 +265,19 @@ type MonitorTriggerEvent implements Node {
     """
     timestamp: DateTime!
     """
+    The query (with after filter) that provides an approximation of the
+    set of results associated with this trigger run. Will always be empty
+    while status is PENDING.
+    """
+    query: String
+
+    """
+    The number of results recorded for this trigger run. Will always be
+    zero until status is SUCCESS.
+    """
+    resultCount: Int!
+
+    """
     A list of actions.
     """
     actions(

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -927,6 +927,28 @@ func (m *monitorTriggerEvent) Status() (string, error) {
 	return "", errors.Errorf("unknown status: %s", m.State)
 }
 
+func (m *monitorTriggerEvent) Query() *string {
+	return m.TriggerJob.QueryString
+}
+
+func (m *monitorTriggerEvent) ResultCount() int32 {
+	var count int
+	for _, res := range m.TriggerJob.SearchResults {
+		var highlightCount int
+		if res.MessagePreview != nil {
+			highlightCount = len(res.MessagePreview.Highlights)
+		} else if res.DiffPreview != nil {
+			highlightCount = len(res.DiffPreview.Highlights)
+		}
+		if highlightCount > 0 {
+			count += highlightCount
+		} else {
+			count += 1
+		}
+	}
+	return int32(count)
+}
+
 func (m *monitorTriggerEvent) Message() *string {
 	return m.FailureMessage
 }


### PR DESCRIPTION
This exposes the query that approximates the result set for the trigger
job and the number of results for that trigger job.

Example query:
```graphql
query List {
  currentUser {
    monitors{
      nodes {
        trigger{
          ...on MonitorQuery{
            events{
              nodes {
                query
                resultCount
              }
            }
          }
        }
      }
    }
  }
}
```

Example response: 
```json
{
  "data": {
    "currentUser": {
      "monitors": {
        "nodes": [
          {
            "trigger": {
              "events": {
                "nodes": [
                  {
                    "query": "repo:sourcegraph type:commit patternType:literal after:\"2022-02-22T22:49:18Z\"",
                    "resultCount": 30
                  },
                  {
                    "query": "repo:sourcegraph type:commit patternType:literal after:\"2022-02-22T22:20:38Z\"",
                    "resultCount": 1
                  }
                ]
              }
            }
          }
        ]
      }
    }
  }
}
```

I'll expose the actual result contents in a followup PR.

## Test plan

Tested manually. Will later be covered by unit tests and goldenfile tests. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


