### PR TITLE
Code monitors: remove code monitor info in graphqlbackend

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/google/zoekt"
 	"github.com/graph-gophers/graphql-go"
-	"github.com/graph-gophers/graphql-go/relay"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -103,15 +102,6 @@ func NewSearchImplementer(ctx context.Context, db database.DB, args *SearchArgs)
 	}
 	tr.LazyPrintf("parsing done")
 
-	var codeMonitorID *int64
-	if args.CodeMonitorID != nil {
-		var i int64
-		if err := relay.UnmarshalSpec(*args.CodeMonitorID, &i); err != nil {
-			return nil, err
-		}
-		codeMonitorID = &i
-	}
-
 	protocol := search.Batch
 	if args.Stream != nil {
 		protocol = search.Streaming
@@ -124,7 +114,6 @@ func NewSearchImplementer(ctx context.Context, db database.DB, args *SearchArgs)
 		UserSettings:  settings,
 		Features:      featureflag.FromContext(ctx),
 		PatternType:   searchType,
-		CodeMonitorID: codeMonitorID,
 		Protocol:      protocol,
 	}
 

--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -127,12 +127,6 @@ func (j *CommitSearch) Tags() []log.Field {
 		log.Bool("diff", j.Diff),
 		log.Bool("hasTimeFilter", j.HasTimeFilter),
 		log.Int("limit", j.Limit),
-		log.Int64("codeMonitorID", func() int64 {
-			if j.CodeMonitorID != nil {
-				return *j.CodeMonitorID
-			}
-			return 0
-		}()),
 		log.Bool("includeModifiedFiles", j.IncludeModifiedFiles),
 	}
 }

--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -60,13 +60,6 @@ func ToSearchJob(jargs *Args, q query.Q) (Job, error) {
 
 	var requiredJobs, optionalJobs []Job
 	addJob := func(required bool, job Job) {
-		// Filter out any jobs that aren't commit jobs as they are added
-		if jargs.SearchInputs.CodeMonitorID != nil {
-			if _, ok := job.(*commit.CommitSearch); !ok {
-				return
-			}
-		}
-
 		if required {
 			requiredJobs = append(requiredJobs, job)
 		} else {
@@ -220,7 +213,6 @@ func ToSearchJob(jargs *Args, q query.Q) (Job, error) {
 				Diff:                 diff,
 				HasTimeFilter:        commit.HasTimeFilter(args.Query),
 				Limit:                int(args.PatternInfo.FileMatchLimit),
-				CodeMonitorID:        jargs.SearchInputs.CodeMonitorID,
 				IncludeModifiedFiles: authz.SubRepoEnabled(authz.DefaultSubRepoPermsChecker),
 			})
 		}

--- a/internal/search/run/run.go
+++ b/internal/search/run/run.go
@@ -16,7 +16,6 @@ type SearchInputs struct {
 	PatternType   query.SearchType
 	UserSettings  *schema.Settings
 	Features      featureflag.FlagSet
-	CodeMonitorID *int64
 	Protocol      search.Protocol
 }
 


### PR DESCRIPTION
This removes some stuff that I had staged for repo-aware code monitors.
It is unused right now, and is just getting in the way. I tried to do
this once before, but removed the GraphQL endpoint that was still being
used, which broke things. This does not break things. I have tested it.

## Test plan

Manual testing because no integration tests cover this yet. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


