### PR TITLE
Search backend: move search inputs creation out of graphqlbackend

### DIFF
--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -252,44 +252,6 @@ var testSearchGQLQuery = `
 		}
 `
 
-func TestDetectSearchType(t *testing.T) {
-	typeRegexp := "regexp"
-	typeLiteral := "literal"
-	testCases := []struct {
-		name        string
-		version     string
-		patternType *string
-		input       string
-		want        query.SearchType
-	}{
-		{"V1, no pattern type", "V1", nil, "", query.SearchTypeRegex},
-		{"V2, no pattern type", "V2", nil, "", query.SearchTypeLiteral},
-		{"V2, no pattern type, input does not produce parse error", "V2", nil, "/-/godoc", query.SearchTypeLiteral},
-		{"V1, regexp pattern type", "V1", &typeRegexp, "", query.SearchTypeRegex},
-		{"V2, regexp pattern type", "V2", &typeRegexp, "", query.SearchTypeRegex},
-		{"V1, literal pattern type", "V1", &typeLiteral, "", query.SearchTypeLiteral},
-		{"V2, override regexp pattern type", "V2", &typeLiteral, "patterntype:regexp", query.SearchTypeRegex},
-		{"V2, override regex variant pattern type", "V2", &typeLiteral, "patterntype:regex", query.SearchTypeRegex},
-		{"V2, override regex variant pattern type with double quotes", "V2", &typeLiteral, `patterntype:"regex"`, query.SearchTypeRegex},
-		{"V2, override regex variant pattern type with single quotes", "V2", &typeLiteral, `patterntype:'regex'`, query.SearchTypeRegex},
-		{"V1, override literal pattern type", "V1", &typeRegexp, "patterntype:literal", query.SearchTypeLiteral},
-		{"V1, override literal pattern type, with case-insensitive query", "V1", &typeRegexp, "pAtTErNTypE:literal", query.SearchTypeLiteral},
-	}
-
-	for _, test := range testCases {
-		t.Run(test.name, func(*testing.T) {
-			got, err := detectSearchType(test.version, test.patternType)
-			got = overrideSearchType(test.input, got)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if got != test.want {
-				t.Errorf("failed %v, got %v, expected %v", test.name, got, test.want)
-			}
-		})
-	}
-}
-
 func TestExactlyOneRepo(t *testing.T) {
 	cases := []struct {
 		repoFilters []string

--- a/internal/search/run/run_test.go
+++ b/internal/search/run/run_test.go
@@ -1,0 +1,45 @@
+package run
+
+import (
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/search/query"
+)
+
+func TestDetectSearchType(t *testing.T) {
+	typeRegexp := "regexp"
+	typeLiteral := "literal"
+	testCases := []struct {
+		name        string
+		version     string
+		patternType *string
+		input       string
+		want        query.SearchType
+	}{
+		{"V1, no pattern type", "V1", nil, "", query.SearchTypeRegex},
+		{"V2, no pattern type", "V2", nil, "", query.SearchTypeLiteral},
+		{"V2, no pattern type, input does not produce parse error", "V2", nil, "/-/godoc", query.SearchTypeLiteral},
+		{"V1, regexp pattern type", "V1", &typeRegexp, "", query.SearchTypeRegex},
+		{"V2, regexp pattern type", "V2", &typeRegexp, "", query.SearchTypeRegex},
+		{"V1, literal pattern type", "V1", &typeLiteral, "", query.SearchTypeLiteral},
+		{"V2, override regexp pattern type", "V2", &typeLiteral, "patterntype:regexp", query.SearchTypeRegex},
+		{"V2, override regex variant pattern type", "V2", &typeLiteral, "patterntype:regex", query.SearchTypeRegex},
+		{"V2, override regex variant pattern type with double quotes", "V2", &typeLiteral, `patterntype:"regex"`, query.SearchTypeRegex},
+		{"V2, override regex variant pattern type with single quotes", "V2", &typeLiteral, `patterntype:'regex'`, query.SearchTypeRegex},
+		{"V1, override literal pattern type", "V1", &typeRegexp, "patterntype:literal", query.SearchTypeLiteral},
+		{"V1, override literal pattern type, with case-insensitive query", "V1", &typeRegexp, "pAtTErNTypE:literal", query.SearchTypeLiteral},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(*testing.T) {
+			got, err := detectSearchType(test.version, test.patternType)
+			got = overrideSearchType(test.input, got)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != test.want {
+				t.Errorf("failed %v, got %v, expected %v", test.name, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This moves the creation of the SearchInputs type out of graphqlbackend
and into `internal/search/run`. 

Next step: cut all ties to `searchResolver`. 

## Test plan

Semantics-preserving. Running integration tests on this PR. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


