### PR TITLE
Search backend: extract results into new package `execute`

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -506,7 +506,7 @@ func (r *searchResolver) logBatch(ctx context.Context, srr *SearchResultsResolve
 func (r *searchResolver) resultsBatch(ctx context.Context) (*SearchResultsResolver, error) {
 	start := time.Now()
 	agg := streaming.NewAggregatingStream()
-	alert, err := r.results(ctx, agg, r.SearchInputs.Plan)
+	alert, err := execute.Execute(ctx, r.db, agg, r.JobArgs(), r.SearchInputs)
 	srr := r.resultsToResolver(agg.Results, alert, agg.Stats)
 	srr.elapsed = time.Since(start)
 	r.logBatch(ctx, srr, err)
@@ -514,7 +514,7 @@ func (r *searchResolver) resultsBatch(ctx context.Context) (*SearchResultsResolv
 }
 
 func (r *searchResolver) resultsStreaming(ctx context.Context) (*SearchResultsResolver, error) {
-	alert, err := r.results(ctx, r.stream, r.SearchInputs.Plan)
+	alert, err := execute.Execute(ctx, r.db, r.stream, r.JobArgs(), r.SearchInputs)
 	srr := r.resultsToResolver(nil, alert, streaming.Stats{})
 	return srr, err
 }
@@ -552,10 +552,6 @@ func DetermineStatusForLogs(alert *search.Alert, stats streaming.Stats, err erro
 	default:
 		return "success"
 	}
-}
-
-func (r *searchResolver) results(ctx context.Context, stream streaming.Sender, plan query.Plan) (_ *search.Alert, err error) {
-	return execute.Execute(ctx, r.db, stream, r.JobArgs(), r.SearchInputs)
 }
 
 type searchResultsStats struct {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -506,7 +506,7 @@ func (r *searchResolver) logBatch(ctx context.Context, srr *SearchResultsResolve
 func (r *searchResolver) resultsBatch(ctx context.Context) (*SearchResultsResolver, error) {
 	start := time.Now()
 	agg := streaming.NewAggregatingStream()
-	alert, err := execute.Execute(ctx, r.db, agg, r.JobArgs(), r.SearchInputs)
+	alert, err := execute.Execute(ctx, r.db, agg, r.JobArgs())
 	srr := r.resultsToResolver(agg.Results, alert, agg.Stats)
 	srr.elapsed = time.Since(start)
 	r.logBatch(ctx, srr, err)
@@ -514,7 +514,7 @@ func (r *searchResolver) resultsBatch(ctx context.Context) (*SearchResultsResolv
 }
 
 func (r *searchResolver) resultsStreaming(ctx context.Context) (*SearchResultsResolver, error) {
-	alert, err := execute.Execute(ctx, r.db, r.stream, r.JobArgs(), r.SearchInputs)
+	alert, err := execute.Execute(ctx, r.db, r.stream, r.JobArgs())
 	srr := r.resultsToResolver(nil, alert, streaming.Stats{})
 	return srr, err
 }

--- a/internal/search/execute/execute.go
+++ b/internal/search/execute/execute.go
@@ -11,6 +11,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
+// Execute is the top-level entrypoint to executing a search. It will
+// expand predicates, create jobs, and execute those jobs.
 func Execute(
 	ctx context.Context,
 	db database.DB,

--- a/internal/search/execute/execute.go
+++ b/internal/search/execute/execute.go
@@ -7,7 +7,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/predicate"
-	"github.com/sourcegraph/sourcegraph/internal/search/run"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
@@ -17,7 +16,6 @@ func Execute(
 	db database.DB,
 	stream streaming.Sender,
 	jobArgs *job.Args,
-	searchInputs *run.SearchInputs,
 ) (_ *search.Alert, err error) {
 	tr, ctx := trace.New(ctx, "Execute", "")
 	defer func() {
@@ -25,7 +23,7 @@ func Execute(
 		tr.Finish()
 	}()
 
-	plan := searchInputs.Plan
+	plan := jobArgs.SearchInputs.Plan
 	plan, err = predicate.Expand(ctx, db, jobArgs, plan)
 	if err != nil {
 		return nil, err

--- a/internal/search/execute/execute.go
+++ b/internal/search/execute/execute.go
@@ -1,0 +1,40 @@
+package execute
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/job"
+	"github.com/sourcegraph/sourcegraph/internal/search/predicate"
+	"github.com/sourcegraph/sourcegraph/internal/search/run"
+	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+)
+
+func Execute(
+	ctx context.Context,
+	db database.DB,
+	stream streaming.Sender,
+	jobArgs *job.Args,
+	searchInputs *run.SearchInputs,
+) (_ *search.Alert, err error) {
+	tr, ctx := trace.New(ctx, "Execute", "")
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
+
+	plan := searchInputs.Plan
+	plan, err = predicate.Expand(ctx, db, jobArgs, plan)
+	if err != nil {
+		return nil, err
+	}
+
+	planJob, err := job.FromExpandedPlan(jobArgs, plan)
+	if err != nil {
+		return nil, err
+	}
+
+	return planJob.Run(ctx, db, stream)
+}


### PR DESCRIPTION
This extracts the logic of `searchResolver.results()` into a new function `execute.Execute`. I created a new package because of circular imports. I think this would probably better belong in `run`, but the fact that we use `SearchInputs` in other dependent packages makes that not possible. We should be able to clean this up more easily once we have better partitioned. 

## Test plan

Semantics preserving, covered by integration tests. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


