### PR TITLE
search: inline SearchFilesInReposBatch

### DIFF
--- a/internal/search/run/repository_test.go
+++ b/internal/search/run/repository_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
-	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
-	"github.com/sourcegraph/sourcegraph/internal/search/textsearch"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -24,15 +22,15 @@ func TestRepoShouldBeAdded(t *testing.T) {
 
 	t.Run("repo should be included in results, query has repoHasFile filter", func(t *testing.T) {
 		repo := &search.RepositoryRevisions{Repo: types.MinimalRepo{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
-		textsearch.MockSearchFilesInRepos = func() ([]result.Match, *streaming.Stats, error) {
+		MockReposContainingPath = func() ([]*result.FileMatch, error) {
 			rev := "1a2b3c"
-			return []result.Match{&result.FileMatch{
+			return []*result.FileMatch{{
 				File: result.File{
 					Repo:     types.MinimalRepo{ID: 123, Name: repo.Repo.Name},
 					InputRev: &rev,
 					Path:     "foo.go",
 				},
-			}}, &streaming.Stats{}, nil
+			}}, nil
 		}
 		pat := &search.TextPatternInfo{
 			Pattern:                      "",
@@ -54,8 +52,8 @@ func TestRepoShouldBeAdded(t *testing.T) {
 
 	t.Run("repo shouldn't be included in results, query has repoHasFile filter ", func(t *testing.T) {
 		repo := &search.RepositoryRevisions{Repo: types.MinimalRepo{Name: "foo/no-match"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
-		textsearch.MockSearchFilesInRepos = func() ([]result.Match, *streaming.Stats, error) {
-			return nil, &streaming.Stats{}, nil
+		MockReposContainingPath = func() ([]*result.FileMatch, error) {
+			return nil, nil
 		}
 		pat := &search.TextPatternInfo{
 			Pattern:                      "",
@@ -77,15 +75,15 @@ func TestRepoShouldBeAdded(t *testing.T) {
 
 	t.Run("repo shouldn't be included in results, query has -repoHasFile filter", func(t *testing.T) {
 		repo := &search.RepositoryRevisions{Repo: types.MinimalRepo{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
-		textsearch.MockSearchFilesInRepos = func() ([]result.Match, *streaming.Stats, error) {
+		MockReposContainingPath = func() ([]*result.FileMatch, error) {
 			rev := "1a2b3c"
-			return []result.Match{&result.FileMatch{
+			return []*result.FileMatch{{
 				File: result.File{
 					Repo:     types.MinimalRepo{ID: 123, Name: repo.Repo.Name},
 					InputRev: &rev,
 					Path:     "foo.go",
 				},
-			}}, &streaming.Stats{}, nil
+			}}, nil
 		}
 		pat := &search.TextPatternInfo{
 			Pattern:                      "",
@@ -107,8 +105,8 @@ func TestRepoShouldBeAdded(t *testing.T) {
 
 	t.Run("repo should be included in results, query has -repoHasFile filter", func(t *testing.T) {
 		repo := &search.RepositoryRevisions{Repo: types.MinimalRepo{Name: "foo/no-match"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
-		textsearch.MockSearchFilesInRepos = func() ([]result.Match, *streaming.Stats, error) {
-			return nil, &streaming.Stats{}, nil
+		MockReposContainingPath = func() ([]*result.FileMatch, error) {
+			return nil, nil
 		}
 		pat := &search.TextPatternInfo{
 			Pattern:                      "",

--- a/internal/search/textsearch/textsearch.go
+++ b/internal/search/textsearch/textsearch.go
@@ -9,55 +9,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	searchrepos "github.com/sourcegraph/sourcegraph/internal/search/repos"
-	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/searcher"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
-
-var MockSearchFilesInRepos func() ([]result.Match, *streaming.Stats, error)
-
-// SearchFilesInReposBatch is a convenience function around searchFilesInRepos
-// which collects the results from the stream.
-func SearchFilesInReposBatch(ctx context.Context, request zoektutil.IndexedSearchRequest, searcherArgs *search.SearcherParameters, notSearcherOnly bool) ([]*result.FileMatch, streaming.Stats, error) {
-	agg := streaming.NewAggregatingStream()
-
-	g, ctx := errgroup.WithContext(ctx)
-
-	if notSearcherOnly {
-		// Run literal and regexp searches on indexed repositories.
-		g.Go(func() error {
-			return request.Search(ctx, agg)
-		})
-	}
-
-	// Concurrently run searcher for all unindexed repos regardless whether text or regexp.
-	g.Go(func() error {
-		return searcher.SearchOverRepos(ctx, searcherArgs, agg, request.UnindexedRepos(), false)
-	})
-
-	err := g.Wait()
-
-	fms, fmErr := matchesToFileMatches(agg.Results)
-	if fmErr != nil && err == nil {
-		err = errors.Wrap(fmErr, "searchFilesInReposBatch failed to convert results")
-	}
-	return fms, agg.Stats, err
-}
-
-func matchesToFileMatches(matches []result.Match) ([]*result.FileMatch, error) {
-	fms := make([]*result.FileMatch, 0, len(matches))
-	for _, match := range matches {
-		fm, ok := match.(*result.FileMatch)
-		if !ok {
-			return nil, errors.Errorf("expected only file match results")
-		}
-		fms = append(fms, fm)
-	}
-	return fms, nil
-}
 
 type RepoSubsetTextSearch struct {
 	ZoektArgs        *search.ZoektParameters


### PR DESCRIPTION
This just inlines `SearchFilesInReposBatch` where it's used for `repoHasFile`. The diff looks busy but it's only because of updating the mocking code. I don't recommend spending time reading changes in test files.

The reason this helps is because I can now simplify logic for repo index/unindex partitioning inside these function without (more annoying) changes signature/args to `SearchFilesInRepos*` functions.

## Test plan
Semantics-preserving

