### PR TITLE
go-backcompat: create back-compat guidance as annotation

### DIFF
--- a/dev/ci/go-backcompat/test.sh
+++ b/dev/ci/go-backcompat/test.sh
@@ -4,7 +4,7 @@
 # of the continuous backwards compatibility regression tests.
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../../../"
-set -eu
+set -eux
 
 MIGRATION_STAGING=$(mktemp -d -t sgdockerbuild_XXXXXXX)
 cleanup() {

--- a/dev/ci/go-backcompat/test.sh
+++ b/dev/ci/go-backcompat/test.sh
@@ -151,8 +151,7 @@ ${flakefile}
 
 EOF
   )
-  echo "$annotation"
   mkdir -p ./annotations/
-  echo "$annotation" >'./annotations/go-backcompat.md'
+  echo "$annotation" | tee './annotations/go-backcompat.md'
   exit 1
 fi

--- a/dev/ci/go-backcompat/test.sh
+++ b/dev/ci/go-backcompat/test.sh
@@ -135,7 +135,8 @@ fi
 ./.buildkite/hooks/pre-command
 
 if ! ./dev/ci/go-test.sh "$@"; then
-  IFS='' read -r -d '' annotation <<EOF
+  annotation=$(
+    cat <<EOF
 This commit contains database schema definitions that caused an unexpected
 failure of one or more unit tests at tagged commit \`${latest_minor_release_tag}\`.
 If this backwards incompatibility is intentional or of the test is flaky,
@@ -148,6 +149,7 @@ ${flakefile}
 Rewrite these schema changes to be backwards compatible. For help,
 see [the migrations guide](docs.sourcegraph.com/dev/background-information/sql/migrations).
 EOF
+  )
   echo "$annotation"
   mkdir -p ./annotations/
   echo "$annotation" >'./annotations/go-backcompat.md'

--- a/dev/ci/go-backcompat/test.sh
+++ b/dev/ci/go-backcompat/test.sh
@@ -4,7 +4,7 @@
 # of the continuous backwards compatibility regression tests.
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../../../"
-set -eux
+set -eu
 
 MIGRATION_STAGING=$(mktemp -d -t sgdockerbuild_XXXXXXX)
 cleanup() {

--- a/dev/ci/go-backcompat/test.sh
+++ b/dev/ci/go-backcompat/test.sh
@@ -135,7 +135,7 @@ fi
 ./.buildkite/hooks/pre-command
 
 if ! ./dev/ci/go-test.sh "$@"; then
-  read -r -d '' annotation <<EOF
+  IFS='' read -r -d '' annotation <<EOF
 This commit contains database schema definitions that caused an unexpected
 failure of one or more unit tests at tagged commit \`${latest_minor_release_tag}\`.
 If this backwards incompatibility is intentional or of the test is flaky,

--- a/dev/ci/go-backcompat/test.sh
+++ b/dev/ci/go-backcompat/test.sh
@@ -139,8 +139,8 @@ if ! ./dev/ci/go-test.sh "$@"; then
     cat <<EOF
 This commit contains database schema definitions that caused an unexpected
 failure of one or more unit tests at tagged commit \`${latest_minor_release_tag}\`.
-If this backwards incompatibility is intentional or of the test is flaky,
-an exception for this text can be added to the following flakefile:
+If this backwards incompatibility is intentional or if the test is flaky,
+an exception for this test can be added to the following flakefile:
 
 \`\`\`
 ${flakefile}

--- a/dev/ci/go-backcompat/test.sh
+++ b/dev/ci/go-backcompat/test.sh
@@ -135,19 +135,21 @@ fi
 ./.buildkite/hooks/pre-command
 
 if ! ./dev/ci/go-test.sh "$@"; then
-  mkdir -p ./annotations
-  annotation_file='./annotations/Backwards incompatibility detected.md'
-  cat <<EOF >"$annotation_file"
+  read -r -d '' annotation <<EOF
 This commit contains database schema definitions that caused an unexpected
-failure of one or more unit tests at tagged commit ${latest_minor_release_tag}.
+failure of one or more unit tests at tagged commit \`${latest_minor_release_tag}\`.
 If this backwards incompatibility is intentional or of the test is flaky,
 an exception for this text can be added to the following flakefile:
 
-  ${flakefile}
+\`\`\`
+${flakefile}
+\`\`\`
 
 Rewrite these schema changes to be backwards compatible. For help,
-see docs.sourcegraph.com/dev/background-information/sql/migrations.
+see [the migrations guide](docs.sourcegraph.com/dev/background-information/sql/migrations).
 EOF
-  echo "$annotation_file"
+  echo "$annotation"
+  mkdir -p ./annotations/
+  echo "$annotation" >'./annotations/go-backcompat.md'
   exit 1
 fi

--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+exit 1
+
 function usage {
   cat <<EOF
 Usage: go-test.sh [only|exclude package-path-1 package-path-2 ...]
@@ -123,7 +125,6 @@ export NO_GRAPHQL_LOG=true
 go install github.com/kyoh86/richgo@latest
 asdf reshim golang
 
-
 # Used to ignore directories (for example, when using submodules)
 #   (It appears to be unused, but it's actually used doing -v below)
 #
@@ -136,8 +137,8 @@ declare -A IGNORED_DIRS=(
 find . -name go.mod -exec dirname '{}' \; | while read -r d; do
 
   # Skip any ignored directories.
-  if [ -v "IGNORED_DIRS[$d]" ] ; then
-      continue
+  if [ -v "IGNORED_DIRS[$d]" ]; then
+    continue
   fi
 
   pushd "$d" >/dev/null

--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -2,8 +2,6 @@
 
 set -euo pipefail
 
-exit 1
-
 function usage {
   cat <<EOF
 Usage: go-test.sh [only|exclude package-path-1 package-path-2 ...]

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -351,7 +351,7 @@ func addGoTestsBackcompat(minimumUpgradeableVersion string) func(pipeline *bk.Pi
 			pipeline.AddStep(
 				fmt.Sprintf(":go::postgres: Backcompat test (%s)", description),
 				bk.Env("MINIMUM_UPGRADEABLE_VERSION", minimumUpgradeableVersion),
-				bk.Cmd("./dev/ci/go-backcompat/test.sh "+testSuffix),
+				bk.AnnotatedCmd("./dev/ci/go-backcompat/test.sh "+testSuffix, bk.AnnotatedCmdOpts{}),
 			)
 		})
 	}

--- a/enterprise/dev/ci/scripts/annotated-command.sh
+++ b/enterprise/dev/ci/scripts/annotated-command.sh
@@ -28,15 +28,15 @@ for file in "$annotation_dir"/*; do
   fi
 
   echo "handling $file"
+  name=$(basename "$file")
   annotate_file_opts=$annotate_opts
 
-  if [ "$include_names" = "true" ]; then
-    name=$(basename "$file")
-    case "$name" in
-      # Append markdown annotations as markdown, and remove the suffix from the name
-      *.md) annotate_file_opts="$annotate_file_opts -m" && name="${name%.*}" ;;
-    esac
+  case "$name" in
+    # Append markdown annotations as markdown, and remove the suffix from the name
+    *.md) annotate_file_opts="$annotate_file_opts -m" && name="${name%.*}" ;;
+  esac
 
+  if [ "$include_names" = "true" ]; then
     # Set the name of the file as the title of this annotation section
     annotate_file_opts="-s '$name' $annotate_file_opts"
   fi

--- a/enterprise/dev/ci/scripts/annotated-command.sh
+++ b/enterprise/dev/ci/scripts/annotated-command.sh
@@ -21,7 +21,7 @@ eval "$cmd"
 exit_code="$?"
 
 # Check for annotations left behind by the command
-echo "--- uploading annotations"
+echo "--- Uploading annotations"
 for file in "$annotation_dir"/*; do
   if [ ! -f "$file" ]; then
     continue

--- a/enterprise/dev/ci/scripts/annotated-command.sh
+++ b/enterprise/dev/ci/scripts/annotated-command.sh
@@ -21,16 +21,22 @@ eval "$cmd"
 exit_code="$?"
 
 # Check for annotations left behind by the command
+echo "--- uploading annotations"
 for file in "$annotation_dir"/*; do
-  name=$(basename "$file")
+  if [ ! -f "$file" ]; then
+    continue
+  fi
+
+  echo "handling $file"
   annotate_file_opts=$annotate_opts
 
-  case "$name" in
-    # Append markdown annotations as markdown, and remove the suffix from the name
-    *.md) annotate_file_opts="$annotate_file_opts -m" && name="${name%.*}" ;;
-  esac
-
   if [ "$include_names" = "true" ]; then
+    name=$(basename "$file")
+    case "$name" in
+      # Append markdown annotations as markdown, and remove the suffix from the name
+      *.md) annotate_file_opts="$annotate_file_opts -m" && name="${name%.*}" ;;
+    esac
+
     # Set the name of the file as the title of this annotation section
     annotate_file_opts="-s '$name' $annotate_file_opts"
   fi

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -22,7 +22,7 @@ Up migrations will happen automatically in development on service startup. In pr
 
 To create a new migration file, run the following command.
 
-```
+```sh
 $ sg migration add -db=<db_name> <my_migration_name>
 Migration files created
  Up query file: ~/migrations/codeintel/1644260831/up.sql


### PR DESCRIPTION
Generate migration failure warning as an annotation. This should happen rarely enough to warrant taking up the extra space, and I think should primarily happen on PRs?

(aside: I just want to assign a multi line string to a variable but it kept failing 😞 tried a bunch of stack overflows to make this work ugh bash why)

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

https://buildkite.com/sourcegraph/sourcegraph/builds/133499

<img width="1162" alt="image" src="https://user-images.githubusercontent.com/23356519/155437319-88527b63-7ac1-4609-a703-cfb66e790a0f.png">
