### PR TITLE
pr-auditor: add support for 'no review required'

### DIFF
--- a/dev/pr-auditor/main.go
+++ b/dev/pr-auditor/main.go
@@ -152,7 +152,7 @@ func postMergeAudit(ctx context.Context, ghc *github.Client, payload *EventPaylo
 
 func preMergeAudit(ctx context.Context, ghc *github.Client, payload *EventPayload, flags *Flags) error {
 	result := checkPR(ctx, ghc, payload, checkOpts{
-		ValidateReviews: true,
+		ValidateReviews: false, // only validate reviews on post-merge
 	})
 	log.Printf("checkPR: %+v\n", result)
 

--- a/dev/pr-auditor/testdata/pull_request_body/no-review-required.md
+++ b/dev/pr-auditor/testdata/pull_request_body/no-review-required.md
@@ -1,0 +1,1 @@
+Test plan: I have a plan! No review required: this is a bot PR

--- a/doc/dev/background-information/testing_principles.md
+++ b/doc/dev/background-information/testing_principles.md
@@ -118,8 +118,6 @@ We use [Percy](https://percy.io/) to detect visual changes in Sourcegraph featur
 
 If for a situational reason, a pull request needs to be exempted from the testing guidelines, skipping reviews or not providing a [test plan](#test-plans) will trigger an automated process that create and link an issue requesting that the author document a reason for the exception within [sourcegraph/sec-pr-audit-trail](https://github.com/sourcegraph/sec-pr-audit-trail).
 
-Explanations for exceptions can also simply be provided within a pull request's [test plan](#test-plans).
-
 ### Fixed exceptions
 
 The list below designates source code exempt from the testing guidelines because they do not directly impact the behaviour of the application in any way.
@@ -128,6 +126,19 @@ The list below designates source code exempt from the testing guidelines because
   - `dev/*`: internal tools, scripts for the local environment and continuous integration.
   - `enterprise/dev/*`: internal tools, scripts for the local environment and continuous integration that fall under the [Sourcegraph Enterprise license](https://github.com/sourcegraph/sourcegraph/blob/main/LICENSE.enterprise).
   - Dev environment configuration (e.g. `.editorconfig`, `shell.nix`, etc.)
+
+To indicate exceptions like these, simply write `n/a` within your pull request's [test plan](#test-plans).
+
+### Pull request review exceptions
+
+Certain workflows leverage PRs that deploy already-tested changes or boilerplate work.
+For these PRs a review may not be required. This can be indicated by creating a section within your test plan indicating `No review required`, like so:
+
+```md
+## Test plan
+
+No review required: deploys tested changes.
+```
 
 ## Test health
 


### PR DESCRIPTION
You can now indicate a `No review required: blah blah` anywhere in your test plan to indicate that your PR does not need a review ahead of time. This will mark your PR as reviewed.

See [thread](https://sourcegraph.slack.com/archives/C02E4HE42BX/p1645643977684139?thread_ts=1645643357.643249&cid=C02E4HE42BX):

> now that this process is in place for the managed instance repo, we’re forced to get a review on normal upgrade procedures. We don’t normally ask for reviews on these, they’re boilerplate operations.
It’s not a huge deal to change our process, but I’m not sure it’s adding any value because the changes are already live.

This will likely also be needed to enable workflows where bots make image updates that should be automatically deployed.

Note that this will _not_ bypass repo-permissions-level branch protection requiring review, but it allows repositories to implement workflows that don't require reviews while still maintaining an audit log.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

unit tests for days
