### PR TITLE
dependencies api: Move existing lockfile parser behind codeintel API

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -35,6 +35,10 @@ func (c CommitID) Short() string {
 	return string(c)
 }
 
+// RevSpec is a revision range specifier suitable for passing to git. See
+// the manpage gitrevisions(7).
+type RevSpec string
+
 // Repo represents a source code repository.
 type Repo struct {
 	// ID is the unique numeric ID for this repository on Sourcegraph.

--- a/internal/codeintel/stores/dbstore/repos.go
+++ b/internal/codeintel/stores/dbstore/repos.go
@@ -138,6 +138,12 @@ func (s *Store) GetNPMDependencyRepos(ctx context.Context, filter GetNPMDependen
 	return scanNPMDependencyRepo(rows)
 }
 
+const getLSIFDependencyReposQuery = `
+-- source: internal/codeintel/stores/dbstore/repos.go:GetLSIFDependencyRepos
+SELECT id, name, version FROM lsif_dependency_repos
+WHERE %s ORDER BY id DESC %s
+`
+
 func scanNPMDependencyRepo(rows *sql.Rows) (dependencies []NPMDependencyRepo, err error) {
 	defer func() { err = basestore.CloseRows(rows, err) }()
 
@@ -178,9 +184,3 @@ func (s *Store) UpsertDependencyRepo(ctx context.Context, dep reposource.Package
 		dep.PackageVersion(),
 	))
 }
-
-const getLSIFDependencyReposQuery = `
--- source: internal/codeintel/stores/dbstore/repos.go:GetLSIFDependencyRepos
-SELECT id, name, version FROM lsif_dependency_repos
-WHERE %s ORDER BY id DESC %s
-`

--- a/internal/search/repos/dependencies.go
+++ b/internal/search/repos/dependencies.go
@@ -2,6 +2,7 @@ package repos
 
 import (
 	"context"
+	"database/sql"
 	"sync"
 
 	"golang.org/x/sync/errgroup"
@@ -10,62 +11,58 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	codeinteldbstore "github.com/sourcegraph/sourcegraph/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/lockfiles"
-	"github.com/sourcegraph/sourcegraph/internal/types"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
 // RevSpecSet is a utility type for a set of RevSpecs.
 type RevSpecSet map[api.RevSpec]struct{}
 
-type DependenciesResolver interface {
+type DependenciesService interface {
 	Dependencies(ctx context.Context, repoRevs map[api.RepoName]RevSpecSet) (_ map[api.RepoName]RevSpecSet, err error)
 }
 
-type dependenciesResolver struct {
-	db       database.DB
-	listFunc func(context.Context, database.ExternalServicesListOptions) (dependencyRevs []*types.ExternalService, err error)
-	syncFunc func(context.Context, int64) error
+type dependenciesService struct {
+	db          database.DB
+	repoupdater *repoupdater.Client
 }
 
-func NewDependenciesResolver(
-	db database.DB,
-	listFunc func(context.Context, database.ExternalServicesListOptions) (dependencyRevs []*types.ExternalService, err error),
-	syncFunc func(context.Context, int64) error,
-) *dependenciesResolver {
-	return &dependenciesResolver{
-		db:       db,
-		listFunc: listFunc,
-		syncFunc: syncFunc,
-	}
+func NewDependenciesService(db database.DB) *dependenciesService {
+	return &dependenciesService{db: db}
 }
 
 // Dependencies resolves the (transitive) dependencies for a set of repository and revisions.
 // Both the input repoRevs and the output dependencyRevs are a map from repository names to
 // `40-char commit hashes belonging to that repository.
-func (r *dependenciesResolver) Dependencies(ctx context.Context, repoRevs map[api.RepoName]RevSpecSet) (_ map[api.RepoName]RevSpecSet, err error) {
-	depsStore := codeinteldbstore.NewDependencyInserter(r.db, r.listFunc, r.syncFunc)
+func (r *dependenciesService) Dependencies(ctx context.Context, repoRevs map[api.RepoName]RevSpecSet) (_ map[api.RepoName]RevSpecSet, err error) {
+	tr, ctx := trace.New(ctx, "DependenciesService", "Dependencies")
 	defer func() {
-		if flushErr := depsStore.Flush(context.Background()); flushErr != nil {
-			err = errors.Append(err, flushErr)
+		if len(repoRevs) > 1 {
+			tr.LazyPrintf("repoRevs: %d", len(repoRevs))
+		} else {
+			tr.LazyPrintf("repoRevs: %v", repoRevs)
 		}
+		tr.SetError(err)
+		tr.Finish()
 	}()
 
-	var (
-		mu             sync.Mutex
-		dependencyRevs = make(map[api.RepoName]RevSpecSet)
-	)
+	var mu sync.Mutex
+	dependencyRevs := make(map[api.RepoName]RevSpecSet)
 
-	rg, ctx := errgroup.WithContext(ctx)
 	svc := &lockfiles.Service{GitArchive: gitserver.DefaultClient.Archive}
+	depsStore := codeinteldbstore.Store{Store: basestore.NewWithDB(r.db, sql.TxOptions{})}
+
 	sem := semaphore.NewWeighted(16)
+	g, ctx := errgroup.WithContext(ctx)
 
 	for repoName, revs := range repoRevs {
 		for rev := range revs {
 			repoName, rev := repoName, rev
 
-			rg.Go(func() error {
+			g.Go(func() error {
 				if err := sem.Acquire(ctx, 1); err != nil {
 					return err
 				}
@@ -77,22 +74,24 @@ func (r *dependenciesResolver) Dependencies(ctx context.Context, repoRevs map[ap
 				}
 
 				for _, dep := range deps {
-					if err := depsStore.Insert(ctx, dep); err != nil {
-						return err
-					}
+					g.Go(func() error {
+						if err := depsStore.UpsertDependencyRepo(ctx, dep); err != nil {
+							return err
+						}
 
-					depName := dep.RepoName()
-					depRev := api.RevSpec(dep.GitTagFromVersion())
+						depName := dep.RepoName()
+						depRev := api.RevSpec(dep.GitTagFromVersion())
 
-					mu.Lock()
+						mu.Lock()
+						defer mu.Unlock()
 
-					if _, ok := dependencyRevs[depName]; !ok {
-						dependencyRevs[depName] = RevSpecSet{}
-					}
+						if _, ok := dependencyRevs[depName]; !ok {
+							dependencyRevs[depName] = RevSpecSet{}
+						}
+						dependencyRevs[depName][depRev] = struct{}{}
 
-					dependencyRevs[depName][depRev] = struct{}{}
-
-					mu.Unlock()
+						return nil
+					})
 				}
 
 				return nil
@@ -100,7 +99,7 @@ func (r *dependenciesResolver) Dependencies(ctx context.Context, repoRevs map[ap
 		}
 	}
 
-	if err := rg.Wait(); err != nil {
+	if err := g.Wait(); err != nil {
 		return nil, err
 	}
 

--- a/internal/search/repos/dependencies.go
+++ b/internal/search/repos/dependencies.go
@@ -1,0 +1,108 @@
+package repos
+
+import (
+	"context"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/semaphore"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	codeinteldbstore "github.com/sourcegraph/sourcegraph/internal/codeintel/stores/dbstore"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/lockfiles"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// RevSpecSet is a utility type for a set of RevSpecs.
+type RevSpecSet map[api.RevSpec]struct{}
+
+type DependenciesResolver interface {
+	Dependencies(ctx context.Context, repoRevs map[api.RepoName]RevSpecSet) (_ map[api.RepoName]RevSpecSet, err error)
+}
+
+type dependenciesResolver struct {
+	db       database.DB
+	listFunc func(context.Context, database.ExternalServicesListOptions) (dependencyRevs []*types.ExternalService, err error)
+	syncFunc func(context.Context, int64) error
+}
+
+func NewDependenciesResolver(
+	db database.DB,
+	listFunc func(context.Context, database.ExternalServicesListOptions) (dependencyRevs []*types.ExternalService, err error),
+	syncFunc func(context.Context, int64) error,
+) *dependenciesResolver {
+	return &dependenciesResolver{
+		db:       db,
+		listFunc: listFunc,
+		syncFunc: syncFunc,
+	}
+}
+
+// Dependencies resolves the (transitive) dependencies for a set of repository and revisions.
+// Both the input repoRevs and the output dependencyRevs are a map from repository names to
+// `40-char commit hashes belonging to that repository.
+func (r *dependenciesResolver) Dependencies(ctx context.Context, repoRevs map[api.RepoName]RevSpecSet) (_ map[api.RepoName]RevSpecSet, err error) {
+	depsStore := codeinteldbstore.NewDependencyInserter(r.db, r.listFunc, r.syncFunc)
+	defer func() {
+		if flushErr := depsStore.Flush(context.Background()); flushErr != nil {
+			err = errors.Append(err, flushErr)
+		}
+	}()
+
+	var (
+		mu             sync.Mutex
+		dependencyRevs = make(map[api.RepoName]RevSpecSet)
+	)
+
+	rg, ctx := errgroup.WithContext(ctx)
+	svc := &lockfiles.Service{GitArchive: gitserver.DefaultClient.Archive}
+	sem := semaphore.NewWeighted(16)
+
+	for repoName, revs := range repoRevs {
+		for rev := range revs {
+			repoName, rev := repoName, rev
+
+			rg.Go(func() error {
+				if err := sem.Acquire(ctx, 1); err != nil {
+					return err
+				}
+				defer sem.Release(1)
+
+				deps, err := svc.ListDependencies(ctx, repoName, string(rev))
+				if err != nil {
+					return err
+				}
+
+				for _, dep := range deps {
+					if err := depsStore.Insert(ctx, dep); err != nil {
+						return err
+					}
+
+					depName := dep.RepoName()
+					depRev := api.RevSpec(dep.GitTagFromVersion())
+
+					mu.Lock()
+
+					if _, ok := dependencyRevs[depName]; !ok {
+						dependencyRevs[depName] = RevSpecSet{}
+					}
+
+					dependencyRevs[depName][depRev] = struct{}{}
+
+					mu.Unlock()
+				}
+
+				return nil
+			})
+		}
+	}
+
+	if err := rg.Wait(); err != nil {
+		return nil, err
+	}
+
+	return dependencyRevs, nil
+}

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -2,7 +2,6 @@ package repos
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"sort"
 	"strconv"
@@ -21,14 +20,29 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+<<<<<<< HEAD
 	codeintelstore "github.com/sourcegraph/sourcegraph/internal/codeintel/stores/dbstore"
+||||||| parent of 737cafe325 (search: Factor out codeintel Dependencies resolver)
+	codeinteldbstore "github.com/sourcegraph/sourcegraph/internal/codeintel/stores/dbstore"
+=======
+>>>>>>> 737cafe325 (search: Factor out codeintel Dependencies resolver)
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+<<<<<<< HEAD
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+||||||| parent of 737cafe325 (search: Factor out codeintel Dependencies resolver)
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+=======
+>>>>>>> 737cafe325 (search: Factor out codeintel Dependencies resolver)
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
+<<<<<<< HEAD
 	"github.com/sourcegraph/sourcegraph/internal/lockfiles"
+||||||| parent of 737cafe325 (search: Factor out codeintel Dependencies resolver)
+	"github.com/sourcegraph/sourcegraph/internal/lockfiles"
+	"github.com/sourcegraph/sourcegraph/internal/repos"
+=======
+>>>>>>> 737cafe325 (search: Factor out codeintel Dependencies resolver)
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/limits"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
@@ -62,8 +76,9 @@ type Pager interface {
 }
 
 type Resolver struct {
-	DB   database.DB
-	Opts search.RepoOptions
+	DB                   database.DB
+	Opts                 search.RepoOptions
+	DependenciesResolver DependenciesResolver
 }
 
 func (r *Resolver) Paginate(ctx context.Context, op *search.RepoOptions, handle func(*Resolved) error) (err error) {
@@ -141,7 +156,7 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 
 	var (
 		depNames []string
-		depRevs  map[string][]search.RevisionSpecifier
+		depRevs  map[api.RepoName][]search.RevisionSpecifier
 	)
 
 	if len(op.Dependencies) > 0 {
@@ -277,7 +292,7 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 			)
 
 			if len(depRevs) > 0 {
-				revs = depRevs[string(repo.Name)]
+				revs = depRevs[repo.Name]
 			}
 
 			if len(searchContextRepositoryRevisions) > 0 && len(revs) == 0 {
@@ -520,11 +535,10 @@ func (r *Resolver) Excluded(ctx context.Context, op search.RepoOptions) (ex Excl
 // dependency repositories for the given repos and revision(s). It does so by:
 //
 // 1. Expanding each `repo:dependencies(regex@revA:revB:...)` filter regex to a list of repositories that exist in the DB.
-// 2. For each of those (repo, rev) tuple, computing all their dependencies (transitive included).
+// 2. For each of those (repo, rev) tuple, asking the code intelligence dependency API for their (transitive) dependencies.
+//    Calling this API also has the effect of triggering a sync of all discovered dependency repos.
 // 3. Return those dependencies to the caller to be included in repository resolution.
-// 4. Triggering a sync of all the dependency repos.
-//
-func (r *Resolver) dependencies(ctx context.Context, op *search.RepoOptions) (_ []string, _ map[string][]search.RevisionSpecifier, err error) {
+func (r *Resolver) dependencies(ctx context.Context, op *search.RepoOptions) (_ []string, _ map[api.RepoName][]search.RevisionSpecifier, err error) {
 	tr, ctx := trace.New(ctx, "searchrepos.dependencies", "")
 	defer func() {
 		tr.LazyPrintf("deps: %v", op.Dependencies)
@@ -536,103 +550,58 @@ func (r *Resolver) dependencies(ctx context.Context, op *search.RepoOptions) (_ 
 		return nil, nil, errors.Errorf("support for `repo:dependencies()` is disabled in site config (`experimentalFeatures.dependenciesSearch`)")
 	}
 
-	g, ctx := errgroup.WithContext(ctx)
-	withRepoRevs := func(depParams string, cb func([]types.MinimalRepo, []search.RevisionSpecifier) error) {
-		g.Go(func() error {
-			repoPattern, revs := search.ParseRepositoryRevisions(depParams)
-			if len(revs) == 0 {
-				revs = append(revs, search.RevisionSpecifier{RevSpec: "HEAD"})
-			}
-
-			rs, err := r.DB.Repos().ListMinimalRepos(ctx, database.ReposListOptions{
-				IncludePatterns:       []string{repoPattern},
-				CaseSensitivePatterns: op.CaseSensitiveRepoFilters,
-			})
-
-			if err != nil {
-				return err
-			}
-
-			return cb(rs, revs)
-		})
+	// FIXME:
+	if r.DependenciesResolver == nil {
+		panic("Failed to set internal/search/repos/Resolver.DependenciesResolver")
 	}
 
-	svc := &lockfiles.Service{GitArchive: gitserver.DefaultClient.Archive}
-	sem := semaphore.NewWeighted(16)
+	repoRevs := make(map[api.RepoName]RevSpecSet, len(op.Dependencies))
+	for _, depParams := range op.Dependencies {
+		repoPattern, revs := search.ParseRepositoryRevisions(depParams)
+		if len(revs) == 0 {
+			revs = append(revs, search.RevisionSpecifier{RevSpec: "HEAD"})
+		}
 
-	withDependencies := func(rs []types.MinimalRepo, revs []search.RevisionSpecifier, cb func(reposource.PackageDependency) error) error {
-		rg, ctx := errgroup.WithContext(ctx)
+		rs, err := r.DB.Repos().ListMinimalRepos(ctx, database.ReposListOptions{
+			IncludePatterns:       []string{repoPattern},
+			CaseSensitivePatterns: op.CaseSensitiveRepoFilters,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+
 		for _, repo := range rs {
 			for _, rev := range revs {
-				repo, rev := repo, rev
-				rg.Go(func() error {
-					if rev == (search.RevisionSpecifier{}) {
-						rev.RevSpec = "HEAD"
-					} else if rev.RevSpec == "" {
-						return errors.New("unsupported glob rev in dependencies filter")
-					}
+				if rev == (search.RevisionSpecifier{}) {
+					rev.RevSpec = "HEAD"
+				} else if rev.RevSpec == "" {
+					return nil, nil, errors.New("unsupported glob rev in dependencies filter")
+				}
 
-					if err := sem.Acquire(ctx, 1); err != nil {
-						return err
-					}
-					defer sem.Release(1)
+				if _, ok := repoRevs[repo.Name]; !ok {
+					repoRevs[repo.Name] = RevSpecSet{}
+				}
 
-					return svc.StreamDependencies(ctx, repo.Name, rev.RevSpec, cb)
-				})
+				repoRevs[repo.Name][api.RevSpec(rev.RevSpec)] = struct{}{}
 			}
 		}
-		return rg.Wait()
 	}
 
-	var (
-		mu       sync.Mutex
-		depRevs  = make(map[string][]search.RevisionSpecifier)
-		depNames []string
-	)
-
-	depsStore := codeintelstore.Store{Store: basestore.NewWithDB(r.DB, sql.TxOptions{})}
-	reposSvc := backend.NewRepos(r.DB.Repos())
-
-	for _, depParams := range op.Dependencies {
-		withRepoRevs(depParams, func(rs []types.MinimalRepo, revs []search.RevisionSpecifier) error {
-			return withDependencies(rs, revs, func(dep reposource.PackageDependency) error {
-				depName := string(dep.RepoName())
-
-				if err := depsStore.UpsertDependencyRepo(ctx, dep); err != nil {
-					log15.Warn("failed to insert lockfile dependency repo", "error", err, "repo", dep)
-				}
-
-				// Trigger a repo sync.
-				_, err := reposSvc.GetByName(ctx, api.RepoName(depName))
-				if err != nil {
-					log15.Warn("failed to sync dependency repo", "error", err, "repo", dep)
-				}
-
-				depRev := search.RevisionSpecifier{RevSpec: dep.GitTagFromVersion()}
-
-				mu.Lock()
-				defer mu.Unlock()
-
-				if _, ok := depRevs[depName]; !ok {
-					depNames = append(depNames, depName)
-					depRevs[depName] = append(depRevs[depName], depRev)
-					return nil
-				}
-
-				for _, other := range depRevs[depName] {
-					if depRev == other {
-						return nil
-					}
-				}
-
-				depRevs[depName] = append(depRevs[depName], depRev)
-				return nil
-			})
-		})
-	}
-
-	if err = g.Wait(); err != nil {
+	dependencyRepoRevs, err := r.DependenciesResolver.Dependencies(ctx, repoRevs)
+	if err != nil {
 		return nil, nil, err
+	}
+
+	depRevs := make(map[api.RepoName][]search.RevisionSpecifier, len(dependencyRepoRevs))
+	depNames := make([]string, 0, len(dependencyRepoRevs))
+
+	for repoName, revs := range dependencyRepoRevs {
+		depNames = append(depNames, string(repoName))
+		revSpecs := make([]search.RevisionSpecifier, 0, len(revs))
+		for rev := range revs {
+			revSpecs = append(revSpecs, search.RevisionSpecifier{RevSpec: string(rev)})
+		}
+		depRevs[repoName] = revSpecs
 	}
 
 	return depNames, depRevs, nil


### PR DESCRIPTION
This PR moves the code related to dependency/lockfile parsing within search's repository resolver into its own package that can be controlled by code intelligence. The code intel data platform has already started storing like data and we can correlate/supplement lockfile intelligence easily. Fixes #31637.

This is good practice to start forming code intel's internal API shape into something actually usable by other teams.

This is a work in progress:

- [x] Found good boundary point in `dependencies` function between search/codeintel
- [x] Moved codeintel code into a new struct `DependenciesResolver`
- [x] Updated search's repository resolver to call `DependenciesResolver` to get dependencies. Note that this resolver is not yet initialized so will NPE at runtime; see next point.
- [x] Find out how to initialize a single `DependenciesResolver` at app startup and pass it around to the call sites. This is trickier for me since search and code intel code styles clash at this point. We'd like to have a single instance per service (not one created within a particular query) so that we can do things like share caches behind the interface boundary.
- [x] Find out additional unknowns and expand this list as needed

## Test plan

Will test locally/manually.