### PR TITLE
licensing: remove redundant mock cleanup

### DIFF
--- a/enterprise/cmd/frontend/internal/licensing/enforcement/external_services_test.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/external_services_test.go
@@ -56,7 +56,6 @@ func TestNewPreCreateExternalServiceHook(t *testing.T) {
 
 			externalServices := database.NewMockExternalServiceStore()
 			externalServices.CountFunc.SetDefaultReturn(test.externalServiceCount, nil)
-			t.Cleanup(func() { database.Mocks.ExternalServices.Count = nil })
 			err := NewBeforeCreateExternalServiceHook()(context.Background(), externalServices)
 			if gotErr := err != nil; gotErr != test.wantErr {
 				t.Errorf("got error %v, want %v", gotErr, test.wantErr)


### PR DESCRIPTION
Overlooked in https://github.com/sourcegraph/sourcegraph/pull/31607, this makes the count down to 14.

## Test plan

As long as tests pass.


