### PR TITLE
GraphQL: unremove deprecated resultCount field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Removed
 
-- The deprecated GraphQL field `SearchResults.resultCount` has been removed in favor of its replacement, `matchCount`. [#31573](https://github.com/sourcegraph/sourcegraph/pull/31573)
+- 
 
 ## 3.37.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Removed
 
-- 
+-
 
 ## 3.37.0
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1933,6 +1933,10 @@ type SearchResults {
     """
     matchCount: Int!
     """
+    DEPRECATED: Renamed to 'matchCount' for less ambiguity.
+    """
+    resultCount: Int! @deprecated(reason: "renamed to matchCount for less ambiguity")
+    """
     The approximate number of results. This is like the length of the results
     array, except it can indicate the number of results regardless of whether
     or not the limit was hit. Currently, this is represented as e.g. "5+"


### PR DESCRIPTION
I missed that this field [is still being used by src CLI](https://github.com/sourcegraph/sourcegraph/pull/31573#issuecomment-1049702098), so removing it
breaks existing installs. To remove this field safely, we'll need to
remove references to it from src CLI, then after giving people ample
time to upgrade, we can remove the field.



## Test plan

I ran src CLI against this locally and everything worked fine again. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


