### PR TITLE
Search backend: remove stream from searchResolver

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -81,7 +81,6 @@ func NewSearchImplementer(ctx context.Context, db database.DB, args *SearchArgs)
 	return &searchResolver{
 		db:           db,
 		SearchInputs: inputs,
-		stream:       args.Stream,
 		zoekt:        search.Indexed(),
 		searcherURLs: search.SearcherURLs(),
 	}, nil
@@ -95,9 +94,6 @@ func (r *schemaResolver) Search(ctx context.Context, args *SearchArgs) (SearchIm
 type searchResolver struct {
 	SearchInputs *run.SearchInputs
 	db           database.DB
-
-	// stream if non-nil will send all search events we receive down it.
-	stream streaming.Sender
 
 	zoekt        zoekt.Streamer
 	searcherURLs *endpoint.Map

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/run"
-	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -28,15 +27,6 @@ type SearchArgs struct {
 	// to rip this out in the future, this should be possible once we can build
 	// a static representation of our job tree independently of any resolvers.
 	CodeMonitorID *graphql.ID
-
-	// Stream if non-nil will stream all SearchEvents.
-	//
-	// This is how our streaming and our batch interface co-exist. When this
-	// is set, it exposes a way to stream out results as we collect them. By
-	// default we stream all results, including results that are processed
-	// over batch-based evaluation (like and/or expressions), where results
-	// are first collected, merged, and then sent on the stream.
-	Stream streaming.Sender
 
 	// For tests
 	Settings *schema.Settings
@@ -67,7 +57,7 @@ func NewSearchImplementer(ctx context.Context, db database.DB, args *SearchArgs)
 		args.Version,
 		args.PatternType,
 		args.Query,
-		args.Stream,
+		search.Batch,
 		settings,
 	)
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -40,8 +40,8 @@ type SearchImplementer interface {
 	Inputs() run.SearchInputs
 }
 
-// NewSearchImplementer returns a SearchImplementer that provides search results and suggestions.
-func NewSearchImplementer(ctx context.Context, db database.DB, args *SearchArgs) (_ SearchImplementer, err error) {
+// NewBatchSearchImplementer returns a SearchImplementer that provides search results and suggestions.
+func NewBatchSearchImplementer(ctx context.Context, db database.DB, args *SearchArgs) (_ SearchImplementer, err error) {
 	settings := args.Settings
 	if settings == nil {
 		var err error
@@ -77,7 +77,7 @@ func NewSearchImplementer(ctx context.Context, db database.DB, args *SearchArgs)
 }
 
 func (r *schemaResolver) Search(ctx context.Context, args *SearchArgs) (SearchImplementer, error) {
-	return NewSearchImplementer(ctx, r.db, args)
+	return NewBatchSearchImplementer(ctx, r.db, args)
 }
 
 // searchResolver is a resolver for the GraphQL type `Search`

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -503,19 +503,13 @@ func (r *searchResolver) logBatch(ctx context.Context, srr *SearchResultsResolve
 	}
 }
 
-func (r *searchResolver) resultsBatch(ctx context.Context) (*SearchResultsResolver, error) {
+func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, error) {
 	start := time.Now()
 	agg := streaming.NewAggregatingStream()
 	alert, err := execute.Execute(ctx, r.db, agg, r.JobArgs())
 	srr := r.resultsToResolver(agg.Results, alert, agg.Stats)
 	srr.elapsed = time.Since(start)
 	r.logBatch(ctx, srr, err)
-	return srr, err
-}
-
-func (r *searchResolver) resultsStreaming(ctx context.Context) (*SearchResultsResolver, error) {
-	alert, err := execute.Execute(ctx, r.db, r.stream, r.JobArgs())
-	srr := r.resultsToResolver(nil, alert, streaming.Stats{})
 	return srr, err
 }
 
@@ -526,13 +520,6 @@ func (r *searchResolver) resultsToResolver(matches result.Matches, alert *search
 		Stats:       stats,
 		db:          r.db,
 	}
-}
-
-func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, error) {
-	if r.stream == nil {
-		return r.resultsBatch(ctx)
-	}
-	return r.resultsStreaming(ctx)
 }
 
 // DetermineStatusForLogs determines the final status of a search for logging

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -295,7 +295,7 @@ func (h *streamHandler) startSearch(ctx context.Context, a *args) (<-chan stream
 	}
 
 	searchClient := h.newSearchClient(search.Indexed(), search.SearcherURLs())
-	inputs, err := searchClient.Plan(ctx, h.db, a.Version, strPtr(a.PatternType), a.Query, batchedStream, settings)
+	inputs, err := searchClient.Plan(ctx, h.db, a.Version, strPtr(a.PatternType), a.Query, search.Streaming, settings)
 	if err != nil {
 		close(eventsC)
 		var queryErr *run.QueryError

--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -120,7 +120,7 @@ func TestDisplayLimit(t *testing.T) {
 
 			mockInput := make(chan streaming.SearchEvent)
 			mock := client.NewMockSearchClient()
-			mock.PlanFunc.SetDefaultHook(func(_ context.Context, _ database.DB, _ string, _ *string, queryString string, _ streaming.Sender, _ *schema.Settings) (*run.SearchInputs, error) {
+			mock.PlanFunc.SetDefaultHook(func(_ context.Context, _ database.DB, _ string, _ *string, queryString string, _ search.Protocol, _ *schema.Settings) (*run.SearchInputs, error) {
 				q, err := query.Parse(queryString, query.SearchTypeLiteral)
 				require.NoError(t, err)
 				return &run.SearchInputs{

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -387,7 +387,7 @@ func (r *Resolver) TriggerTestSlackWebhookAction(ctx context.Context, args *grap
 
 func (r *Resolver) CodeMonitorSearch(ctx context.Context, args *graphqlbackend.SearchArgs) (graphqlbackend.SearchImplementer, error) {
 	args.Version = "V2"
-	return graphqlbackend.NewSearchImplementer(ctx, r.db, args)
+	return graphqlbackend.NewBatchSearchImplementer(ctx, r.db, args)
 }
 
 func sendTestEmail(ctx context.Context, recipient graphql.ID, description string) error {

--- a/enterprise/cmd/frontend/internal/compute/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/compute/resolvers/resolvers.go
@@ -216,9 +216,9 @@ func toResultResolverList(ctx context.Context, cmd compute.Command, matches []re
 	return results, nil
 }
 
-// NewComputeImplementer is a function that abstracts away the need to have a
+// NewBatchComputeImplementer is a function that abstracts away the need to have a
 // handle on (*schemaResolver) Compute.
-func NewComputeImplementer(ctx context.Context, db database.DB, args *gql.ComputeArgs) ([]gql.ComputeResultResolver, error) {
+func NewBatchComputeImplementer(ctx context.Context, db database.DB, args *gql.ComputeArgs) ([]gql.ComputeResultResolver, error) {
 	computeQuery, err := compute.Parse(args.Query)
 	if err != nil {
 		return nil, err
@@ -231,7 +231,7 @@ func NewComputeImplementer(ctx context.Context, db database.DB, args *gql.Comput
 	log15.Debug("compute", "search", searchQuery)
 
 	patternType := "regexp"
-	job, err := gql.NewSearchImplementer(ctx, db, &gql.SearchArgs{Query: searchQuery, PatternType: &patternType})
+	job, err := gql.NewBatchSearchImplementer(ctx, db, &gql.SearchArgs{Query: searchQuery, PatternType: &patternType})
 	if err != nil {
 		return nil, err
 	}
@@ -244,5 +244,5 @@ func NewComputeImplementer(ctx context.Context, db database.DB, args *gql.Comput
 }
 
 func (r *Resolver) Compute(ctx context.Context, args *gql.ComputeArgs) ([]gql.ComputeResultResolver, error) {
-	return NewComputeImplementer(ctx, r.db, args)
+	return NewBatchComputeImplementer(ctx, r.db, args)
 }

--- a/enterprise/cmd/frontend/internal/compute/streaming/compute.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/compute.go
@@ -53,7 +53,7 @@ func NewComputeStream(ctx context.Context, db database.DB, query string) (<-chan
 
 	patternType := "regexp"
 	searchClient := client.NewSearchClient(search.Indexed(), search.SearcherURLs())
-	inputs, err := searchClient.Plan(ctx, db, "", &patternType, searchQuery, stream, settings)
+	inputs, err := searchClient.Plan(ctx, db, "", &patternType, searchQuery, search.Streaming, settings)
 	if err != nil {
 		close(eventsC)
 		return eventsC, func() error { return err }

--- a/enterprise/cmd/frontend/internal/compute/streaming/compute.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/compute.go
@@ -6,6 +6,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/compute"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/client"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 )
@@ -43,13 +45,15 @@ func NewComputeStream(ctx context.Context, db database.DB, query string) (<-chan
 		}
 	})
 
-	patternType := "regexp"
-	searchArgs := &graphqlbackend.SearchArgs{
-		Query:       searchQuery,
-		PatternType: &patternType,
-		Stream:      stream,
+	settings, err := graphqlbackend.DecodedViewerFinalSettings(ctx, db)
+	if err != nil {
+		close(eventsC)
+		return eventsC, func() error { return err }
 	}
-	job, err := graphqlbackend.NewSearchImplementer(ctx, db, searchArgs)
+
+	patternType := "regexp"
+	searchClient := client.NewSearchClient(search.Indexed(), search.SearcherURLs())
+	inputs, err := searchClient.Plan(ctx, db, "", &patternType, searchQuery, stream, settings)
 	if err != nil {
 		close(eventsC)
 		return eventsC, func() error { return err }
@@ -63,7 +67,7 @@ func NewComputeStream(ctx context.Context, db database.DB, query string) (<-chan
 		defer close(final)
 		defer close(eventsC)
 
-		_, err := job.Results(ctx)
+		_, err := searchClient.Execute(ctx, db, stream, inputs)
 		final <- finalResult{err: err}
 	}()
 

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -24,7 +24,7 @@ type SearchClient interface {
 		version string,
 		patternType *string,
 		searchQuery string,
-		stream streaming.Sender,
+		protocol search.Protocol,
 		settings *schema.Settings,
 	) (*run.SearchInputs, error)
 
@@ -54,10 +54,10 @@ func (s *searchClient) Plan(
 	version string,
 	patternType *string,
 	searchQuery string,
-	stream streaming.Sender,
+	protocol search.Protocol,
 	settings *schema.Settings,
 ) (*run.SearchInputs, error) {
-	return run.NewSearchInputs(ctx, db, version, patternType, searchQuery, stream, settings)
+	return run.NewSearchInputs(ctx, db, version, patternType, searchQuery, protocol, settings)
 }
 
 func (s *searchClient) Execute(

--- a/internal/search/client/mock_client.go
+++ b/internal/search/client/mock_client.go
@@ -36,7 +36,7 @@ func NewMockSearchClient() *MockSearchClient {
 			},
 		},
 		PlanFunc: &SearchClientPlanFunc{
-			defaultHook: func(context.Context, database.DB, string, *string, string, streaming.Sender, *schema.Settings) (*run.SearchInputs, error) {
+			defaultHook: func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings) (*run.SearchInputs, error) {
 				return nil, nil
 			},
 		},
@@ -53,7 +53,7 @@ func NewStrictMockSearchClient() *MockSearchClient {
 			},
 		},
 		PlanFunc: &SearchClientPlanFunc{
-			defaultHook: func(context.Context, database.DB, string, *string, string, streaming.Sender, *schema.Settings) (*run.SearchInputs, error) {
+			defaultHook: func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings) (*run.SearchInputs, error) {
 				panic("unexpected invocation of MockSearchClient.Plan")
 			},
 		},
@@ -191,15 +191,15 @@ func (c SearchClientExecuteFuncCall) Results() []interface{} {
 // SearchClientPlanFunc describes the behavior when the Plan method of the
 // parent MockSearchClient instance is invoked.
 type SearchClientPlanFunc struct {
-	defaultHook func(context.Context, database.DB, string, *string, string, streaming.Sender, *schema.Settings) (*run.SearchInputs, error)
-	hooks       []func(context.Context, database.DB, string, *string, string, streaming.Sender, *schema.Settings) (*run.SearchInputs, error)
+	defaultHook func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings) (*run.SearchInputs, error)
+	hooks       []func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings) (*run.SearchInputs, error)
 	history     []SearchClientPlanFuncCall
 	mutex       sync.Mutex
 }
 
 // Plan delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockSearchClient) Plan(v0 context.Context, v1 database.DB, v2 string, v3 *string, v4 string, v5 streaming.Sender, v6 *schema.Settings) (*run.SearchInputs, error) {
+func (m *MockSearchClient) Plan(v0 context.Context, v1 database.DB, v2 string, v3 *string, v4 string, v5 search.Protocol, v6 *schema.Settings) (*run.SearchInputs, error) {
 	r0, r1 := m.PlanFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6)
 	m.PlanFunc.appendCall(SearchClientPlanFuncCall{v0, v1, v2, v3, v4, v5, v6, r0, r1})
 	return r0, r1
@@ -207,7 +207,7 @@ func (m *MockSearchClient) Plan(v0 context.Context, v1 database.DB, v2 string, v
 
 // SetDefaultHook sets function that is called when the Plan method of the
 // parent MockSearchClient instance is invoked and the hook queue is empty.
-func (f *SearchClientPlanFunc) SetDefaultHook(hook func(context.Context, database.DB, string, *string, string, streaming.Sender, *schema.Settings) (*run.SearchInputs, error)) {
+func (f *SearchClientPlanFunc) SetDefaultHook(hook func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings) (*run.SearchInputs, error)) {
 	f.defaultHook = hook
 }
 
@@ -215,7 +215,7 @@ func (f *SearchClientPlanFunc) SetDefaultHook(hook func(context.Context, databas
 // Plan method of the parent MockSearchClient instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *SearchClientPlanFunc) PushHook(hook func(context.Context, database.DB, string, *string, string, streaming.Sender, *schema.Settings) (*run.SearchInputs, error)) {
+func (f *SearchClientPlanFunc) PushHook(hook func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings) (*run.SearchInputs, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -224,19 +224,19 @@ func (f *SearchClientPlanFunc) PushHook(hook func(context.Context, database.DB, 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *SearchClientPlanFunc) SetDefaultReturn(r0 *run.SearchInputs, r1 error) {
-	f.SetDefaultHook(func(context.Context, database.DB, string, *string, string, streaming.Sender, *schema.Settings) (*run.SearchInputs, error) {
+	f.SetDefaultHook(func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings) (*run.SearchInputs, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *SearchClientPlanFunc) PushReturn(r0 *run.SearchInputs, r1 error) {
-	f.PushHook(func(context.Context, database.DB, string, *string, string, streaming.Sender, *schema.Settings) (*run.SearchInputs, error) {
+	f.PushHook(func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings) (*run.SearchInputs, error) {
 		return r0, r1
 	})
 }
 
-func (f *SearchClientPlanFunc) nextHook() func(context.Context, database.DB, string, *string, string, streaming.Sender, *schema.Settings) (*run.SearchInputs, error) {
+func (f *SearchClientPlanFunc) nextHook() func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings) (*run.SearchInputs, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -286,7 +286,7 @@ type SearchClientPlanFuncCall struct {
 	Arg4 string
 	// Arg5 is the value of the 6th argument passed to this method
 	// invocation.
-	Arg5 streaming.Sender
+	Arg5 search.Protocol
 	// Arg6 is the value of the 7th argument passed to this method
 	// invocation.
 	Arg6 *schema.Settings

--- a/internal/search/run/run.go
+++ b/internal/search/run/run.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/limits"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/searchcontexts"
-	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -47,7 +46,7 @@ func NewSearchInputs(
 	version string,
 	patternType *string,
 	searchQuery string,
-	stream streaming.Sender,
+	protocol search.Protocol,
 	settings *schema.Settings,
 ) (_ *SearchInputs, err error) {
 	tr, ctx := trace.New(ctx, "NewSearchInputs", searchQuery)
@@ -86,11 +85,6 @@ func NewSearchInputs(
 		return nil, &QueryError{Query: searchQuery, Err: err}
 	}
 	tr.LazyPrintf("parsing done")
-
-	protocol := search.Batch
-	if stream != nil {
-		protocol = search.Streaming
-	}
 
 	inputs := &SearchInputs{
 		Plan:          plan,


### PR DESCRIPTION
This does a few things, split up into separate commits:
1) It uses the new `SearchClient` for the compute streaming endpoint
2) Now that no streaming clients use `searchResolver`, we can remove stream from the search args and inline `resultsBatch`, removing `resultsStream`.
3) Since we only care about whether we're streaming or not during planning phase (we just check if stream is nil or not), we can just pass a protocol into the `Plan()` function. 

Stacked on #31786

## Test plan

Covered by integration tests and briefly manually tested. It was unclear to me whether there are any tests covering streaming compute, so lemme know if I should test that manually. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


