### PR TITLE
dev/ci: go back to only setting goproxy on non-baremetal agents

### DIFF
--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -42,9 +42,6 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 
 		// Go flags
 		"GO111MODULE": "on",
-		// Use athens proxy for go modules downloads, falling back to direct
-		// https://github.com/sourcegraph/infrastructure/blob/main/buildkite/kubernetes/athens-proxy/athens-athens-proxy.Deployment.yaml
-		"GOPROXY": "http://athens-athens-proxy,direct",
 
 		// Additional flags
 		"FORCE_COLOR": "3",
@@ -318,6 +315,12 @@ func withAgentQueueDefaults(s *bk.Step) {
 		} else {
 			s.Agents["queue"] = bk.AgentQueueStandard
 		}
+	}
+
+	if s.Agents["queue"] != bk.AgentQueueBaremetal {
+		// Use athens proxy for go modules downloads, falling back to direct
+		// https://github.com/sourcegraph/infrastructure/blob/main/buildkite/kubernetes/athens-proxy/athens-athens-proxy.Deployment.yaml
+		s.Agents["GOPROXY"] = "http://athens-athens-proxy,direct"
 	}
 }
 

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -320,7 +320,7 @@ func withAgentQueueDefaults(s *bk.Step) {
 	if s.Agents["queue"] != bk.AgentQueueBaremetal {
 		// Use athens proxy for go modules downloads, falling back to direct
 		// https://github.com/sourcegraph/infrastructure/blob/main/buildkite/kubernetes/athens-proxy/athens-athens-proxy.Deployment.yaml
-		s.Agents["GOPROXY"] = "http://athens-athens-proxy,direct"
+		s.Env["GOPROXY"] = "http://athens-athens-proxy,direct"
 	}
 }
 


### PR DESCRIPTION
Looks like `direct` isn't working out consistently, so back to only setting these on non-baremetal agents

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

This is a revert back to a previously working state
