### PR TITLE
doc/dev: add intro to MultiErrors and printing errors

### DIFF
--- a/doc/dev/background-information/languages/go_errors.md
+++ b/doc/dev/background-information/languages/go_errors.md
@@ -170,7 +170,7 @@ for _, fn := range fnsThatReturnError {
 return err
 ```
 
-The `MultiErrors` type:
+The `MultiError` type:
 
 - will be treated as a `nil` error if an `Append` or `CombineErrors` only merges errors that are `nil`
 - exposes errors within to introspection methods like `As`, `Is`, etc.

--- a/doc/dev/background-information/languages/go_errors.md
+++ b/doc/dev/background-information/languages/go_errors.md
@@ -4,7 +4,7 @@ We disallow use of error packages — including the stdlib [`errors`](https://go
 
 We also require the use of `errors.Newf` over the use of `fmt.Errorf`, which also constructs an error type. This is to ensure that each error constructed by Sourcegraph is tagged with a stack depth and allows redaction of content within user-visible strings.
 
-#### Use of `errors.New`
+## Use of `errors.New`
 
 Use this function to create an error value with a static message.
 
@@ -18,7 +18,7 @@ Generally, errors of this class should be created as a constant at the highest l
 
 Idiomatically, error constant _values_ should always have a name of the format `ErrX` (or `errX` if package-private) and types that can be used as `error` should have a name of the format `XError`.
 
-#### Use of `errors.Errorf`
+## Use of `errors.Errorf`
 
 Use this function to create an error value with non-static message.
 
@@ -28,7 +28,7 @@ return errors.Errorf("user %d does not exist", userID)
 
 The formatting directives are the same as `fmt.Sprintf`. The [`%w` formatting directive](https://blog.golang.org/go1.13-errors#TOC_3.3.) special cases error values. Prefer to use `errors.Wrap` over this directive.
 
-#### Use of `errors.Wrap`
+## Use of `errors.Wrap`
 
 Use this function to add additional data to an existing error value.
 
@@ -40,7 +40,7 @@ if err := myPkg.MyFunc(ctx); err != nil {
 
 Wrap all errors being returned from a method if that error did not originate in the same package (except for standard library packages like `os` or `http` which have very obvious and distinct error messages) or the same struct (unless its not used from multiple callers). This produces error messages with a usable stacktrace.
 
-#### Use of `errors.Is`
+## Use of `errors.Is`
 
 Use this function to determine if any cause of a given error value is equal to a target error value.
 
@@ -62,9 +62,9 @@ for _, filename := range filenames {
 }
 ```
 
-**Note**: The second argument to this function should generally be error constant, or at the least a trivial (message-only) error value. Comparison of error values uses the `==` operator or the first error value's `Is(other error) bool` method (if implemented). Comparing two error values of the same type but with different field values will generally not do what you want; use the `HasType` function instead.
+> NOTE: The second argument to this function should generally be error constant, or at the least a trivial (message-only) error value. Comparison of error values uses the `==` operator or the first error value's `Is(other error) bool` method (if implemented). Comparing two error values of the same type but with different field values will generally not do what you want; use the `HasType` function instead.
 
-#### Use of `errors.IsAny`
+## Use of `errors.IsAny`
 
 Use this function to determine if any cause of a given error is equal to at least one target error value.
 
@@ -107,7 +107,7 @@ This function should be preferred when comparing an error value with an _error s
 
 Note that using the `Is` function here will fail to match any error that does not have equivalent fields. In the example above, `Is` will only match error values where the value of the `ID` field is the zero value.
 
-#### Use of `errors.As`
+## Use of `errors.As`
 
 Use this function to safely cast a given error value to a particular type. This should be preferred over using Go language-level type casing of an error value (e.g., `err.(*MyType)`), which fails to unwrap errors.
 
@@ -148,7 +148,7 @@ func isRetryable(err error) bool {
 }
 ```
 
-#### Use of `errors.Cause`
+## Use of `errors.Cause`
 
 Use this function to remove all layers from a given error value and return only the root cause. This function should be used rarely as the `Is`, `HasType`, and `As` functions cover the most common functionality.
 
@@ -156,7 +156,7 @@ Use this function to remove all layers from a given error value and return only 
 fmt.Printf("Root error: %s\n", errors.Cause(err))
 ```
 
-### Use of `errors.MultiError`
+## Use of `errors.MultiError`
 
 `MultiError` is an error interface that implements a "_bag_ of errors". Typically, errors are _chains_: where error A causes error B, and so on, through the use of [`Wrap`](#use-of-errorswrap). If you have tasks that run in parallel and return errors in tandem, for example, you may want a _bag_ of errors instead.
 
@@ -179,7 +179,7 @@ The `MultiErrors` type:
 
 Check out the source code for the `MultiError` implementation in [`lib/errors`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/lib/errors).
 
-### Printing errors
+## Printing errors
 
 Printing errors with most formatting directives like `%s`, `%v`, etc. will render an error by calling its `Error()` implementation.
 


### PR DESCRIPTION
Documentation for the newly introduced `MultiError` type (#31466) and a brief primer on printing errors.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


n/a