### PR TITLE
buildchecker: run history upload on a cron

### DIFF
--- a/.github/workflows/buildchecker-history.yml
+++ b/.github/workflows/buildchecker-history.yml
@@ -1,0 +1,25 @@
+# See dev/buildchecker/README.md
+name: buildchecker
+on:
+  schedule:
+  - cron: '0 1 * * *'
+  workflow_dispatch:
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+
+    # secrets for this workflow are configured in the 'autobuildsherrif' environment.
+    # 'autobuildsherrif' was the original name of the 'buildchecker' tool - GitHub does
+    # not provide a simple way to do a rename, so we leave it as is for now.
+    environment: autobuildsherrif
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with: { go-version: '1.17' }
+
+      - run: ./dev/buildchecker/run-day-history.sh
+        env:
+          BUILDKITE_TOKEN: ${{ secrets.AUTOBUILDSHERRIF_BUILDKITE_TOKEN }}
+          HONEYCOMB_TOKEN: ${{ secrets.AUTOBUILDSHERRIF_HONEYCOMB_TOKEN }}

--- a/dev/buildchecker/run-day-history.sh
+++ b/dev/buildchecker/run-day-history.sh
@@ -1,0 +1,18 @@
+#! /usr/bin/env bash
+
+# Make this script independent of where it's called
+cd "$(dirname "${BASH_SOURCE[0]}")"/../..
+
+set -eu
+
+created_from=$(date -d "yesterday" '+%Y-%m-%d')
+created_to=$(date '+%Y-%m-%d')
+
+echo "--- Running 'buildchecker history' from $created_from to $created_to"
+go run ./dev/buildchecker/ \
+  -buildkite.token="$BUILDKITE_TOKEN" \
+  -created.from="$created_from" \
+  -created.to="$created_to" \
+  -honeycomb.dataset="buildkite-history" \
+  -honeycomb.token="$HONEYCOMB_TOKEN" \
+  history


### PR DESCRIPTION
Runs https://github.com/sourcegraph/sourcegraph/pull/31360 on a cron. Closes https://github.com/sourcegraph/sourcegraph/issues/31260

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

n/a