### PR TITLE
remove settings api references

### DIFF
--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -44,7 +44,7 @@ import {
 } from './global/CoolCodeIntel'
 import { GlobalAlerts } from './global/GlobalAlerts'
 import { GlobalDebug } from './global/GlobalDebug'
-import { CodeInsightsContextProps, CodeInsightsProps } from './insights/types'
+import { CodeInsightsProps } from './insights/types'
 import styles from './Layout.module.scss'
 import { SurveyToast } from './marketing/SurveyToast'
 import { GlobalNavbar } from './nav/GlobalNavbar'
@@ -86,7 +86,6 @@ export interface LayoutProps
         CodeIntelligenceProps,
         BatchChangesProps,
         CodeInsightsProps,
-        CodeInsightsContextProps,
         FeatureFlagProps {
     extensionAreaRoutes: readonly ExtensionAreaRoute[]
     extensionAreaHeaderNavItems: readonly ExtensionAreaHeaderNavItem[]

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -455,9 +455,6 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
                                                                     this.state.defaultSearchContextSpec
                                                                 }
                                                                 globbing={this.state.globbing}
-                                                                isCodeInsightsGqlApiEnabled={
-                                                                    window.context.codeInsightsGqlApiEnabled
-                                                                }
                                                                 fetchSavedSearches={fetchSavedSearches}
                                                                 fetchRecentSearches={fetchRecentSearches}
                                                                 fetchRecentFileViews={fetchRecentFileViews}

--- a/client/web/src/enterprise/insights/CodeInsightsAppRouter.tsx
+++ b/client/web/src/enterprise/insights/CodeInsightsAppRouter.tsx
@@ -14,11 +14,9 @@ import { LoadingSpinner, useObservable } from '@sourcegraph/wildcard'
 import { AuthenticatedUser } from '../../auth'
 import { withAuthenticatedUser } from '../../auth/withAuthenticatedUser'
 import { HeroPage } from '../../components/HeroPage'
-import { CodeInsightsContextProps } from '../../insights/types'
 
 import { CodeInsightsBackendContext } from './core/backend/code-insights-backend-context'
 import { CodeInsightsGqlBackend } from './core/backend/gql-api/code-insights-gql-backend'
-import { CodeInsightsSettingsCascadeBackend } from './core/backend/setting-based-api/code-insights-setting-cascade-backend'
 import { GaConfirmationModal } from './modals/GaConfirmationModal'
 import {
     CodeInsightsRootPage,
@@ -41,11 +39,7 @@ const NotFoundPage: React.FunctionComponent = () => <HeroPage icon={MapSearchIco
  * Because we need to pass all required prop from main Sourcegraph.tsx component to
  * subcomponents withing app tree.
  */
-export interface CodeInsightsAppRouter
-    extends CodeInsightsContextProps,
-        SettingsCascadeProps<Settings>,
-        PlatformContextProps,
-        TelemetryProps {
+export interface CodeInsightsAppRouter extends SettingsCascadeProps<Settings>, PlatformContextProps, TelemetryProps {
     /**
      * Authenticated user info, Used to decide where code insight will appears
      * in personal dashboard (private) or in organisation dashboard (public)
@@ -57,22 +51,15 @@ export interface CodeInsightsAppRouter
  * Main Insight routing component. Main entry point to code insights UI.
  */
 export const CodeInsightsAppRouter = withAuthenticatedUser<CodeInsightsAppRouter>(props => {
-    const { isCodeInsightsGqlApiEnabled, platformContext, settingsCascade, telemetryService, authenticatedUser } = props
+    const { telemetryService, authenticatedUser } = props
 
     const match = useRouteMatch()
     const apolloClient = useApolloClient()
 
     const gqlApi = useMemo(() => new CodeInsightsGqlBackend(apolloClient), [apolloClient])
-    const api = useMemo(
-        () =>
-            isCodeInsightsGqlApiEnabled
-                ? gqlApi
-                : new CodeInsightsSettingsCascadeBackend(settingsCascade, platformContext),
-        [isCodeInsightsGqlApiEnabled, gqlApi, settingsCascade, platformContext]
-    )
 
     return (
-        <CodeInsightsBackendContext.Provider value={api}>
+        <CodeInsightsBackendContext.Provider value={gqlApi}>
             <Route path="*" component={GaConfirmationModal} />
 
             <Switch>

--- a/client/web/src/enterprise/insights/CodeInsightsRouter.tsx
+++ b/client/web/src/enterprise/insights/CodeInsightsRouter.tsx
@@ -8,7 +8,6 @@ import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
 import { AuthenticatedUser } from '../../auth'
 import { withAuthenticatedUser } from '../../auth/withAuthenticatedUser'
-import { CodeInsightsContextProps } from '../../insights/types'
 
 const CodeInsightsAppLazyRouter = lazyComponent(() => import('./CodeInsightsAppRouter'), 'CodeInsightsAppRouter')
 
@@ -22,11 +21,7 @@ const CodeInsightsDotComGetStartedLazy = lazyComponent(
  * Because we need to pass all required prop from main Sourcegraph.tsx component to
  * subcomponents withing app tree.
  */
-export interface CodeInsightsRouterProps
-    extends CodeInsightsContextProps,
-        SettingsCascadeProps<Settings>,
-        PlatformContextProps,
-        TelemetryProps {
+export interface CodeInsightsRouterProps extends SettingsCascadeProps<Settings>, PlatformContextProps, TelemetryProps {
     /**
      * Authenticated user info, Used to decide where code insight will appears
      * in personal dashboard (private) or in organisation dashboard (public)

--- a/client/web/src/enterprise/insights/sections/ExtensionViewsDirectorySection.tsx
+++ b/client/web/src/enterprise/insights/sections/ExtensionViewsDirectorySection.tsx
@@ -1,3 +1,4 @@
+import { useApolloClient } from '@apollo/client'
 import React, { useContext, useMemo } from 'react'
 import { EMPTY, from } from 'rxjs'
 import { map, switchMap } from 'rxjs/operators'
@@ -7,11 +8,10 @@ import { ViewProviderResult } from '@sourcegraph/shared/src/api/extension/extens
 import { useObservable } from '@sourcegraph/wildcard'
 
 import { ExtensionViewsSectionCommonProps } from '../../../insights/sections/types'
-import { isCodeInsightsEnabled } from '../../../insights/utils/is-code-insights-enabled'
 import { StaticView, ViewGrid } from '../../../views'
 import { SmartInsight } from '../components/insights-view-grid/components/smart-insight/SmartInsight'
 import { CodeInsightsBackendContext } from '../core/backend/code-insights-backend-context'
-import { CodeInsightsSettingsCascadeBackend } from '../core/backend/setting-based-api/code-insights-setting-cascade-backend'
+import { CodeInsightsGqlBackend } from '../core/backend/gql-api/code-insights-gql-backend'
 import { Insight } from '../core/types'
 import { ALL_INSIGHTS_DASHBOARD_ID } from '../core/types/dashboard/virtual-dashboard'
 
@@ -29,16 +29,9 @@ const EMPTY_EXTENSION_LIST: ViewProviderResult[] = []
 export const ExtensionViewsDirectorySection: React.FunctionComponent<ExtensionViewsDirectorySectionProps> = props => {
     const { platformContext, settingsCascade, extensionsController, uri, telemetryService, className = '' } = props
 
-    const showCodeInsights = isCodeInsightsEnabled(settingsCascade, { directory: true })
+    const apolloClient = useApolloClient()
 
-    const api = useMemo(() => new CodeInsightsSettingsCascadeBackend(settingsCascade, platformContext), [
-        platformContext,
-        settingsCascade,
-    ])
-
-    if (!showCodeInsights) {
-        return null
-    }
+    const api = useMemo(() => new CodeInsightsGqlBackend(apolloClient), [apolloClient])
 
     return (
         <CodeInsightsBackendContext.Provider value={api}>

--- a/client/web/src/enterprise/insights/sections/ExtensionViewsHomepageSection.tsx
+++ b/client/web/src/enterprise/insights/sections/ExtensionViewsHomepageSection.tsx
@@ -1,3 +1,4 @@
+import { useApolloClient } from '@apollo/client'
 import React, { useContext, useMemo } from 'react'
 import { from } from 'rxjs'
 import { switchMap } from 'rxjs/operators'
@@ -7,11 +8,10 @@ import { ViewProviderResult } from '@sourcegraph/shared/src/api/extension/extens
 import { useObservable } from '@sourcegraph/wildcard'
 
 import { ExtensionViewsSectionCommonProps } from '../../../insights/sections/types'
-import { isCodeInsightsEnabled } from '../../../insights/utils/is-code-insights-enabled'
 import { StaticView, ViewGrid } from '../../../views'
 import { SmartInsight } from '../components/insights-view-grid/components/smart-insight/SmartInsight'
 import { CodeInsightsBackendContext } from '../core/backend/code-insights-backend-context'
-import { CodeInsightsSettingsCascadeBackend } from '../core/backend/setting-based-api/code-insights-setting-cascade-backend'
+import { CodeInsightsGqlBackend } from '../core/backend/gql-api/code-insights-gql-backend'
 import { Insight } from '../core/types'
 import { ALL_INSIGHTS_DASHBOARD_ID } from '../core/types/dashboard/virtual-dashboard'
 
@@ -29,16 +29,9 @@ const EMPTY_INSIGHT_LIST: Insight[] = []
 export const ExtensionViewsHomepageSection: React.FunctionComponent<ExtensionViewsHomepageSectionProps> = props => {
     const { platformContext, telemetryService, extensionsController, settingsCascade, className = '' } = props
 
-    const showCodeInsights = isCodeInsightsEnabled(settingsCascade, { homepage: true })
+    const apolloClient = useApolloClient()
 
-    const api = useMemo(() => new CodeInsightsSettingsCascadeBackend(settingsCascade, platformContext), [
-        platformContext,
-        settingsCascade,
-    ])
-
-    if (!showCodeInsights) {
-        return null
-    }
+    const api = useMemo(() => new CodeInsightsGqlBackend(apolloClient), [apolloClient])
 
     return (
         <CodeInsightsBackendContext.Provider value={api}>

--- a/client/web/src/insights/types.ts
+++ b/client/web/src/insights/types.ts
@@ -12,11 +12,3 @@ export interface CodeInsightsProps {
     codeInsightsEnabled?: boolean
     extensionViews: React.FunctionComponent<ExtensionViewsSectionProps>
 }
-
-/**
- * Props that are needed to tune code insights internal logic. Like switching different
- * code insights api backend (setting-based vs gql based api)
- */
-export interface CodeInsightsContextProps {
-    isCodeInsightsGqlApiEnabled: boolean
-}


### PR DESCRIPTION
Related to https://github.com/sourcegraph/sourcegraph/issues/31412

This PR removes references to the settings api from the web app code. Since the graphql api is enabled by default now, no changes should be seen in the app.

## Test plan

- all visibility tests should not change
- all automated tests should pass
- app should still function as normal