### PR TITLE
search: db no longer part of job interface

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -506,7 +506,7 @@ func (r *searchResolver) logBatch(ctx context.Context, srr *SearchResultsResolve
 func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, error) {
 	start := time.Now()
 	agg := streaming.NewAggregatingStream()
-	alert, err := execute.Execute(ctx, r.db, agg, r.JobArgs())
+	alert, err := execute.Execute(ctx, agg, r.JobArgs())
 	srr := r.resultsToResolver(agg.Results, alert, agg.Stats)
 	srr.elapsed = time.Since(start)
 	r.logBatch(ctx, srr, err)
@@ -602,7 +602,7 @@ func (r *searchResolver) Stats(ctx context.Context) (stats *searchResultsStats, 
 			return nil, err
 		}
 		agg := streaming.NewAggregatingStream()
-		alert, err := j.Run(ctx, r.db, agg)
+		alert, err := j.Run(ctx, agg)
 		if err != nil {
 			return nil, err // do not cache errors.
 		}

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -47,7 +47,7 @@ func (srs *searchResultsStats) getResults(ctx context.Context) (result.Matches, 
 			return
 		}
 		agg := streaming.NewAggregatingStream()
-		_, err = j.Run(ctx, srs.sr.db, agg)
+		_, err = j.Run(ctx, agg)
 		if err != nil {
 			srs.err = err
 			return

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -319,7 +319,7 @@ func (h *streamHandler) startSearch(ctx context.Context, a *args) (<-chan stream
 		defer close(eventsC)
 		defer batchedStream.Done()
 
-		alert, err := searchClient.Execute(ctx, h.db, batchedStream, inputs)
+		alert, err := searchClient.Execute(ctx, batchedStream, inputs)
 		final <- finalResult{alert: alert, err: err}
 	}()
 

--- a/enterprise/cmd/frontend/internal/compute/streaming/compute.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/compute.go
@@ -67,7 +67,7 @@ func NewComputeStream(ctx context.Context, db database.DB, query string) (<-chan
 		defer close(final)
 		defer close(eventsC)
 
-		_, err := searchClient.Execute(ctx, db, stream, inputs)
+		_, err := searchClient.Execute(ctx, stream, inputs)
 		final <- finalResult{err: err}
 	}()
 

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -30,7 +30,6 @@ type SearchClient interface {
 
 	Execute(
 		ctx context.Context,
-		db database.DB,
 		stream streaming.Sender,
 		inputs *run.SearchInputs,
 	) (_ *search.Alert, err error)
@@ -62,7 +61,6 @@ func (s *searchClient) Plan(
 
 func (s *searchClient) Execute(
 	ctx context.Context,
-	db database.DB,
 	stream streaming.Sender,
 	inputs *run.SearchInputs,
 ) (*search.Alert, error) {
@@ -72,5 +70,5 @@ func (s *searchClient) Execute(
 		SearcherURLs:        s.searcherURLs,
 		OnSourcegraphDotCom: envvar.SourcegraphDotComMode(),
 	}
-	return execute.Execute(ctx, db, stream, jobArgs)
+	return execute.Execute(ctx, stream, jobArgs)
 }

--- a/internal/search/execute/execute.go
+++ b/internal/search/execute/execute.go
@@ -3,7 +3,6 @@ package execute
 import (
 	"context"
 
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/predicate"
@@ -15,7 +14,6 @@ import (
 // expand predicates, create jobs, and execute those jobs.
 func Execute(
 	ctx context.Context,
-	db database.DB,
 	stream streaming.Sender,
 	jobArgs *job.Args,
 ) (_ *search.Alert, err error) {
@@ -26,7 +24,7 @@ func Execute(
 	}()
 
 	plan := jobArgs.SearchInputs.Plan
-	plan, err = predicate.Expand(ctx, db, jobArgs, plan)
+	plan, err = predicate.Expand(ctx, jobArgs, plan)
 	if err != nil {
 		return nil, err
 	}
@@ -36,5 +34,5 @@ func Execute(
 		return nil, err
 	}
 
-	return planJob.Run(ctx, db, stream)
+	return planJob.Run(ctx, stream)
 }

--- a/internal/search/job/combinators_test.go
+++ b/internal/search/job/combinators_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
@@ -17,7 +16,7 @@ import (
 func TestLimitJob(t *testing.T) {
 	t.Run("only send limit", func(t *testing.T) {
 		mockJob := NewMockJob()
-		mockJob.RunFunc.SetDefaultHook(func(ctx context.Context, db database.DB, s streaming.Sender) (*search.Alert, error) {
+		mockJob.RunFunc.SetDefaultHook(func(ctx context.Context, s streaming.Sender) (*search.Alert, error) {
 			for i := 0; i < 10; i++ {
 				s.Send(streaming.SearchEvent{
 					Results: []result.Match{&result.FileMatch{}},
@@ -32,7 +31,7 @@ func TestLimitJob(t *testing.T) {
 		})
 
 		limitJob := NewLimitJob(5, mockJob)
-		limitJob.Run(context.Background(), database.NewMockDB(), stream)
+		limitJob.Run(context.Background(), stream)
 
 		// The number sent is one more than the limit because
 		// the stream limiter only cancels after the limit is exceeded,
@@ -42,7 +41,7 @@ func TestLimitJob(t *testing.T) {
 
 	t.Run("send partial event", func(t *testing.T) {
 		mockJob := NewMockJob()
-		mockJob.RunFunc.SetDefaultHook(func(ctx context.Context, db database.DB, s streaming.Sender) (*search.Alert, error) {
+		mockJob.RunFunc.SetDefaultHook(func(ctx context.Context, s streaming.Sender) (*search.Alert, error) {
 			for i := 0; i < 10; i++ {
 				s.Send(streaming.SearchEvent{
 					Results: []result.Match{
@@ -60,7 +59,7 @@ func TestLimitJob(t *testing.T) {
 		})
 
 		limitJob := NewLimitJob(5, mockJob)
-		limitJob.Run(context.Background(), database.NewMockDB(), stream)
+		limitJob.Run(context.Background(), stream)
 
 		// The number sent is one more than the limit because
 		// the stream limiter only cancels after the limit is exceeded,
@@ -70,7 +69,7 @@ func TestLimitJob(t *testing.T) {
 
 	t.Run("cancel after limit", func(t *testing.T) {
 		mockJob := NewMockJob()
-		mockJob.RunFunc.SetDefaultHook(func(ctx context.Context, db database.DB, s streaming.Sender) (*search.Alert, error) {
+		mockJob.RunFunc.SetDefaultHook(func(ctx context.Context, s streaming.Sender) (*search.Alert, error) {
 			for i := 0; i < 10; i++ {
 				select {
 				case <-ctx.Done():
@@ -90,7 +89,7 @@ func TestLimitJob(t *testing.T) {
 		})
 
 		limitJob := NewLimitJob(5, mockJob)
-		limitJob.Run(context.Background(), database.NewMockDB(), stream)
+		limitJob.Run(context.Background(), stream)
 
 		// The number sent is one more than the limit because
 		// the stream limiter only cancels after the limit is exceeded,
@@ -107,18 +106,18 @@ func TestLimitJob(t *testing.T) {
 func TestTimeoutJob(t *testing.T) {
 	t.Run("timeout works", func(t *testing.T) {
 		timeoutWaiter := NewMockJob()
-		timeoutWaiter.RunFunc.SetDefaultHook(func(ctx context.Context, _ database.DB, _ streaming.Sender) (*search.Alert, error) {
+		timeoutWaiter.RunFunc.SetDefaultHook(func(ctx context.Context, _ streaming.Sender) (*search.Alert, error) {
 			<-ctx.Done()
 			return nil, ctx.Err()
 		})
 		timeoutJob := NewTimeoutJob(10*time.Millisecond, timeoutWaiter)
-		_, err := timeoutJob.Run(context.Background(), nil, nil)
+		_, err := timeoutJob.Run(context.Background(), nil)
 		require.ErrorIs(t, err, context.DeadlineExceeded)
 	})
 
 	t.Run("early return returns early", func(t *testing.T) {
 		timeoutWaiter := NewMockJob()
-		timeoutWaiter.RunFunc.SetDefaultHook(func(ctx context.Context, _ database.DB, _ streaming.Sender) (*search.Alert, error) {
+		timeoutWaiter.RunFunc.SetDefaultHook(func(ctx context.Context, _ streaming.Sender) (*search.Alert, error) {
 			select {
 			case <-time.After(10 * time.Millisecond):
 				return nil, nil
@@ -128,7 +127,7 @@ func TestTimeoutJob(t *testing.T) {
 		})
 		timeoutJob := NewTimeoutJob(time.Second, timeoutWaiter)
 		start := time.Now()
-		_, err := timeoutJob.Run(context.Background(), nil, nil)
+		_, err := timeoutJob.Run(context.Background(), nil)
 		require.NoError(t, err)
 		require.WithinDuration(t, time.Now(), start.Add(10*time.Millisecond), 5*time.Millisecond)
 	})
@@ -142,13 +141,13 @@ func TestTimeoutJob(t *testing.T) {
 func TestParallelJob(t *testing.T) {
 	t.Run("jobs run in parallel", func(t *testing.T) {
 		waiter := NewMockJob()
-		waiter.RunFunc.SetDefaultHook(func(ctx context.Context, _ database.DB, _ streaming.Sender) (*search.Alert, error) {
+		waiter.RunFunc.SetDefaultHook(func(ctx context.Context, _ streaming.Sender) (*search.Alert, error) {
 			time.Sleep(10 * time.Millisecond)
 			return nil, nil
 		})
 		parallelJob := NewParallelJob(waiter, waiter, waiter)
 		start := time.Now()
-		_, err := parallelJob.Run(context.Background(), nil, nil)
+		_, err := parallelJob.Run(context.Background(), nil)
 		require.NoError(t, err)
 		require.WithinDuration(t, time.Now(), start.Add(20*time.Millisecond), 10*time.Millisecond)
 	})
@@ -161,7 +160,7 @@ func TestParallelJob(t *testing.T) {
 		j2.RunFunc.SetDefaultReturn(nil, e2)
 
 		parallelJob := NewParallelJob(j1, j2)
-		_, err := parallelJob.Run(context.Background(), nil, nil)
+		_, err := parallelJob.Run(context.Background(), nil)
 		require.ErrorIs(t, err, e1)
 		require.ErrorIs(t, err, e2)
 	})
@@ -174,7 +173,7 @@ func TestParallelJob(t *testing.T) {
 		j2.RunFunc.SetDefaultReturn(a2, nil)
 
 		parallelJob := NewParallelJob(j1, j2)
-		alert, err := parallelJob.Run(context.Background(), nil, nil)
+		alert, err := parallelJob.Run(context.Background(), nil)
 		require.NoError(t, err)
 		require.Equal(t, a2, alert)
 	})
@@ -195,7 +194,7 @@ func TestPriorityJob(t *testing.T) {
 	t.Run("optional job is canceled after required finishes", func(t *testing.T) {
 		required, optional := NewMockJob(), NewMockJob()
 		required.RunFunc.SetDefaultReturn(nil, nil)
-		optional.RunFunc.SetDefaultHook(func(ctx context.Context, _ database.DB, _ streaming.Sender) (*search.Alert, error) {
+		optional.RunFunc.SetDefaultHook(func(ctx context.Context, _ streaming.Sender) (*search.Alert, error) {
 			select {
 			case <-ctx.Done():
 				return nil, ctx.Err()
@@ -206,7 +205,7 @@ func TestPriorityJob(t *testing.T) {
 
 		start := time.Now()
 		job := NewPriorityJob(required, optional)
-		_, err := job.Run(context.Background(), nil, nil)
+		_, err := job.Run(context.Background(), nil)
 		require.ErrorIs(t, err, context.Canceled)
 		require.WithinDuration(t, time.Now(), start.Add(100*time.Millisecond), 40*time.Millisecond)
 	})
@@ -214,7 +213,7 @@ func TestPriorityJob(t *testing.T) {
 	t.Run("optional job has some time to complete", func(t *testing.T) {
 		required, optional := NewMockJob(), NewMockJob()
 		required.RunFunc.SetDefaultReturn(nil, nil)
-		optional.RunFunc.SetDefaultHook(func(ctx context.Context, _ database.DB, _ streaming.Sender) (*search.Alert, error) {
+		optional.RunFunc.SetDefaultHook(func(ctx context.Context, _ streaming.Sender) (*search.Alert, error) {
 			select {
 			case <-ctx.Done():
 				return nil, ctx.Err()
@@ -225,7 +224,7 @@ func TestPriorityJob(t *testing.T) {
 
 		start := time.Now()
 		job := NewPriorityJob(required, optional)
-		_, err := job.Run(context.Background(), nil, nil)
+		_, err := job.Run(context.Background(), nil)
 		require.NoError(t, err, context.Canceled)
 		require.WithinDuration(t, time.Now(), start.Add(50*time.Millisecond), 30*time.Millisecond)
 	})

--- a/internal/search/job/expression_job_test.go
+++ b/internal/search/job/expression_job_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
@@ -53,7 +52,7 @@ func (ss senders) Jobs() []Job {
 func newMockSender() sender {
 	mj := NewMockJob()
 	send := make(chan streaming.SearchEvent)
-	mj.RunFunc.SetDefaultHook(func(_ context.Context, _ database.DB, s streaming.Sender) (*search.Alert, error) {
+	mj.RunFunc.SetDefaultHook(func(_ context.Context, s streaming.Sender) (*search.Alert, error) {
 		for event := range send {
 			s.Send(event)
 		}
@@ -108,7 +107,7 @@ func TestAndJob(t *testing.T) {
 
 				finished := make(chan struct{})
 				go func() {
-					_, err := j.Run(context.Background(), nil, stream)
+					_, err := j.Run(context.Background(), stream)
 					require.NoError(t, err)
 					close(finished)
 				}()
@@ -134,7 +133,7 @@ func TestAndJob(t *testing.T) {
 
 				finished := make(chan struct{})
 				go func() {
-					_, err := j.Run(context.Background(), nil, stream)
+					_, err := j.Run(context.Background(), stream)
 					require.NoError(t, err)
 					close(finished)
 				}()
@@ -171,7 +170,7 @@ func TestOrJob(t *testing.T) {
 
 				finished := make(chan struct{})
 				go func() {
-					_, err := j.Run(context.Background(), nil, stream)
+					_, err := j.Run(context.Background(), stream)
 					require.NoError(t, err)
 					close(finished)
 				}()
@@ -200,7 +199,7 @@ func TestOrJob(t *testing.T) {
 
 				finished := make(chan struct{})
 				go func() {
-					_, err := j.Run(context.Background(), nil, stream)
+					_, err := j.Run(context.Background(), stream)
 					require.NoError(t, err)
 					close(finished)
 				}()

--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -107,6 +107,7 @@ func ToSearchJob(jargs *Args, q query.Q) (Job, error) {
 					GlobalZoektQuery: globalZoektQuery,
 					ZoektArgs:        zoektArgs,
 
+					DB:          jargs.SearchInputs.DB,
 					RepoOptions: repoOptions,
 				})
 			}
@@ -133,6 +134,7 @@ func ToSearchJob(jargs *Args, q query.Q) (Job, error) {
 					PatternInfo:      args.PatternInfo,
 					Limit:            maxResults,
 
+					DB:          jargs.SearchInputs.DB,
 					RepoOptions: repoOptions,
 				})
 			}
@@ -167,6 +169,7 @@ func ToSearchJob(jargs *Args, q query.Q) (Job, error) {
 				NotSearcherOnly:  !onlyRunSearcher,
 				UseIndex:         args.PatternInfo.Index,
 				ContainsRefGlobs: query.ContainsRefGlobs(q),
+				DB:               jargs.SearchInputs.DB,
 				RepoOpts:         repoOptions,
 			})
 		}
@@ -193,6 +196,7 @@ func ToSearchJob(jargs *Args, q query.Q) (Job, error) {
 				NotSearcherOnly:  !onlyRunSearcher,
 				UseIndex:         args.PatternInfo.Index,
 				ContainsRefGlobs: query.ContainsRefGlobs(q),
+				DB:               jargs.SearchInputs.DB,
 				RepoOpts:         repoOptions,
 			})
 		}
@@ -244,6 +248,7 @@ func ToSearchJob(jargs *Args, q query.Q) (Job, error) {
 				NotSearcherOnly:  !onlyRunSearcher,
 				UseIndex:         args.PatternInfo.Index,
 				ContainsRefGlobs: query.ContainsRefGlobs(q),
+				DB:               jargs.SearchInputs.DB,
 				RepoOpts:         repoOptions,
 			})
 		}
@@ -334,6 +339,7 @@ func ToSearchJob(jargs *Args, q query.Q) (Job, error) {
 						args.Mode = search.SkipUnindexed
 					}
 					addJob(true, &run.RepoSearch{
+						DB:   jargs.SearchInputs.DB,
 						Args: &args,
 					})
 				}
@@ -342,6 +348,7 @@ func ToSearchJob(jargs *Args, q query.Q) (Job, error) {
 	}
 
 	addJob(true, &searchrepos.ComputeExcludedRepos{
+		DB:      jargs.SearchInputs.DB,
 		Options: repoOptions,
 	})
 

--- a/internal/search/job/printers_test.go
+++ b/internal/search/job/printers_test.go
@@ -241,6 +241,7 @@ func TestPrettyJSON(t *testing.T) {
         "NotSearcherOnly": true,
         "UseIndex": "yes",
         "ContainsRefGlobs": false,
+        "DB": null,
         "RepoOpts": {
           "RepoFilters": [
             "foo"
@@ -292,6 +293,7 @@ func TestPrettyJSON(t *testing.T) {
     },
     {
       "Repo": {
+        "DB": null,
         "Args": {
           "PatternInfo": {
             "Pattern": "bar",
@@ -406,6 +408,7 @@ func TestPrettyJSON(t *testing.T) {
     },
     {
       "ComputeExcludedRepos": {
+        "DB": null,
         "Options": {
           "RepoFilters": [
             "foo"

--- a/internal/search/job/select.go
+++ b/internal/search/job/select.go
@@ -3,7 +3,6 @@ package job
 import (
 	"context"
 
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
@@ -20,9 +19,9 @@ type selectJob struct {
 	child Job
 }
 
-func (j *selectJob) Run(ctx context.Context, db database.DB, stream streaming.Sender) (*search.Alert, error) {
+func (j *selectJob) Run(ctx context.Context, stream streaming.Sender) (*search.Alert, error) {
 	selectingStream := streaming.WithSelect(stream, j.path)
-	return j.child.Run(ctx, db, selectingStream)
+	return j.child.Run(ctx, selectingStream)
 }
 
 func (j *selectJob) Name() string {

--- a/internal/search/job/sub_repo_perms_job.go
+++ b/internal/search/job/sub_repo_perms_job.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
@@ -26,7 +25,7 @@ type subRepoPermsFilterJob struct {
 	child Job
 }
 
-func (s *subRepoPermsFilterJob) Run(ctx context.Context, db database.DB, stream streaming.Sender) (*search.Alert, error) {
+func (s *subRepoPermsFilterJob) Run(ctx context.Context, stream streaming.Sender) (*search.Alert, error) {
 	checker := authz.DefaultSubRepoPermsChecker
 
 	var (
@@ -45,7 +44,7 @@ func (s *subRepoPermsFilterJob) Run(ctx context.Context, db database.DB, stream 
 		stream.Send(event)
 	})
 
-	alert, err := s.child.Run(ctx, db, filteredStream)
+	alert, err := s.child.Run(ctx, filteredStream)
 	if err != nil {
 		errs = errors.Append(errs, err)
 	}

--- a/internal/search/job/types.go
+++ b/internal/search/job/types.go
@@ -3,7 +3,6 @@ package job
 import (
 	"context"
 
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/commit"
 	"github.com/sourcegraph/sourcegraph/internal/search/repos"
@@ -20,7 +19,7 @@ import (
 // timeout). Calling Run on a job object runs a search.
 //go:generate ../../../dev/mockgen.sh github.com/sourcegraph/sourcegraph/internal/search/job -i Job -o job_mock_test.go
 type Job interface {
-	Run(context.Context, database.DB, streaming.Sender) (*search.Alert, error)
+	Run(context.Context, streaming.Sender) (*search.Alert, error)
 	Name() string
 }
 

--- a/internal/search/predicate/substitute.go
+++ b/internal/search/predicate/substitute.go
@@ -7,7 +7,6 @@ import (
 	"github.com/grafana/regexp"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
@@ -20,7 +19,7 @@ var ErrNoResults = errors.New("no results returned for predicate")
 
 // Expand takes a query plan, and replaces any predicates with their expansion. The returned plan
 // is guaranteed to be predicate-free.
-func Expand(ctx context.Context, db database.DB, jobArgs *job.Args, oldPlan query.Plan) (_ query.Plan, err error) {
+func Expand(ctx context.Context, jobArgs *job.Args, oldPlan query.Plan) (_ query.Plan, err error) {
 	tr, ctx := trace.New(ctx, "ExpandPredicates", "")
 	defer func() {
 		tr.SetError(err)
@@ -47,7 +46,7 @@ func Expand(ctx context.Context, db database.DB, jobArgs *job.Args, oldPlan quer
 				}
 
 				agg := streaming.NewAggregatingStream()
-				_, err = job.NewOrJob(children...).Run(ctx, db, agg)
+				_, err = job.NewOrJob(children...).Run(ctx, agg)
 				if err != nil {
 					return nil, err
 				}

--- a/internal/search/repos/excluded_job.go
+++ b/internal/search/repos/excluded_job.go
@@ -10,17 +10,18 @@ import (
 )
 
 type ComputeExcludedRepos struct {
+	DB      database.DB
 	Options search.RepoOptions
 }
 
-func (c *ComputeExcludedRepos) Run(ctx context.Context, db database.DB, s streaming.Sender) (_ *search.Alert, err error) {
+func (c *ComputeExcludedRepos) Run(ctx context.Context, s streaming.Sender) (_ *search.Alert, err error) {
 	tr, ctx := trace.New(ctx, "ComputeExcludedRepos", "")
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
 	}()
 
-	repositoryResolver := Resolver{DB: db}
+	repositoryResolver := Resolver{DB: c.DB}
 	excluded, err := repositoryResolver.Excluded(ctx, c.Options)
 	if err != nil {
 		return nil, err

--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -21,10 +21,11 @@ import (
 )
 
 type RepoSearch struct {
+	DB   database.DB
 	Args *search.TextParameters
 }
 
-func (s *RepoSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (_ *search.Alert, err error) {
+func (s *RepoSearch) Run(ctx context.Context, stream streaming.Sender) (_ *search.Alert, err error) {
 	tr, ctx := trace.New(ctx, "RepoSearch", "")
 	defer func() {
 		tr.SetError(err)
@@ -33,7 +34,7 @@ func (s *RepoSearch) Run(ctx context.Context, db database.DB, stream streaming.S
 
 	tr.LogFields(otlog.String("pattern", s.Args.PatternInfo.Pattern))
 
-	repos := &searchrepos.Resolver{DB: db, Opts: s.Args.RepoOptions}
+	repos := &searchrepos.Resolver{DB: s.DB, Opts: s.Args.RepoOptions}
 	err = repos.Paginate(ctx, nil, func(page *searchrepos.Resolved) error {
 		tr.LogFields(otlog.Int("resolved.len", len(page.RepoRevs)))
 

--- a/internal/search/run/run.go
+++ b/internal/search/run/run.go
@@ -25,6 +25,7 @@ type SearchInputs struct {
 	UserSettings  *schema.Settings
 	Features      featureflag.FlagSet
 	Protocol      search.Protocol
+	DB            database.DB
 }
 
 // MaxResults computes the limit for the query.
@@ -94,6 +95,7 @@ func NewSearchInputs(
 		Features:      featureflag.FromContext(ctx),
 		PatternType:   searchType,
 		Protocol:      protocol,
+		DB:            db,
 	}
 
 	tr.LazyPrintf("Parsed query: %s", inputs.Query)

--- a/internal/search/structural/structural.go
+++ b/internal/search/structural/structural.go
@@ -158,17 +158,18 @@ type StructuralSearch struct {
 	UseIndex         query.YesNoOnly
 	ContainsRefGlobs bool
 
+	DB       database.DB
 	RepoOpts search.RepoOptions
 }
 
-func (s *StructuralSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (_ *search.Alert, err error) {
+func (s *StructuralSearch) Run(ctx context.Context, stream streaming.Sender) (_ *search.Alert, err error) {
 	tr, ctx := trace.New(ctx, "StructuralSearch", "")
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
 	}()
 
-	repos := &searchrepos.Resolver{DB: db, Opts: s.RepoOpts}
+	repos := &searchrepos.Resolver{DB: s.DB, Opts: s.RepoOpts}
 	return nil, repos.Paginate(ctx, nil, func(page *searchrepos.Resolved) error {
 		request, ok, err := zoektutil.OnlyUnindexed(page.RepoRevs, s.ZoektArgs.Zoekt, s.UseIndex, s.ContainsRefGlobs, zoektutil.MissingRepoRevStatus(stream))
 		if err != nil {


### PR DESCRIPTION
Removes `database.DB` as a required argument to job `Run` method. Two reasons why I strongly think this is the right move now:

- I'm hard blocked on creating a ZoektJob (which doesn't need DB, [wip branch here]( https://github.com/sourcegraph/sourcegraph/commit/58115eef6e52e6809de1d7672183b40001a0840b#diff-a0b580ce6b4db3783ac7b447edecc057f540111a3ae4814f6b3b63e5e8af07b8R817)) where the Zoekt package is used in searcher (for structural search). This because we don't allow a DB handle in searcher (lint). I could make the ZoektJob live in a different package but:
  - (a) we actually _want_ to be able to use this ZoektJob from searcher for structural search, and it would allow creating it statically at some point
  - (b) it's not good to include `DB` and give the impression that it can be used, when it can't (e.g., in a ZoektJob)

- Second big reason: almost all current uses of DB are just for repo resolution/pager. It often appears with `repoOptions` for jobs. We should instead pass the repo pager (which requires both) to these jobs, and not the DB handle.

I'll have to check back on CI to see that I caught everything but please review so long.

## Test plan
Semantics-preserving.


