### PR TITLE
git-combine: Fix thrashing of log

### DIFF
--- a/internal/cmd/git-combine/build.sh
+++ b/internal/cmd/git-combine/build.sh
@@ -14,7 +14,7 @@ fi
 
 set -x
 
-docker build \
+docker build --platform=linux/amd64 \
   --build-arg VERSION="$version" \
   --build-arg COMMIT_SHA="$commit" \
   --tag "$image" \

--- a/internal/cmd/git-combine/git-combine.go
+++ b/internal/cmd/git-combine/git-combine.go
@@ -122,6 +122,10 @@ func Combine(path string, opt Options) error {
 		seen := recentRootTrees[remote]
 
 		for i := 0; i < opt.LimitRemote; i++ {
+			if commit.NumParents() == 0 {
+				break
+			}
+
 			commit, err = commit.Parent(0)
 			if err == io.EOF {
 				break

--- a/internal/cmd/git-combine/git-combine.go
+++ b/internal/cmd/git-combine/git-combine.go
@@ -114,9 +114,7 @@ func Combine(path string, opt Options) error {
 			continue
 		}
 
-		iter, err := r.Log(&git.LogOptions{
-			From: ref.Hash(),
-		})
+		commit, err := r.CommitObject(ref.Hash())
 		if err != nil {
 			return err
 		}
@@ -124,7 +122,7 @@ func Combine(path string, opt Options) error {
 		seen := recentRootTrees[remote]
 
 		for i := 0; i < opt.LimitRemote; i++ {
-			commit, err := iter.Next()
+			commit, err := commit.Parent(0)
 			if err == io.EOF {
 				break
 			} else if err != nil {
@@ -142,10 +140,6 @@ func Combine(path string, opt Options) error {
 			})
 		}
 	}
-
-	sort.Slice(commits, func(i, j int) bool {
-		return commits[i].Committer.When.Before(commits[j].Committer.When)
-	})
 
 	if len(commits) > opt.Limit {
 		// We only take the last Limit commits. But we want to ensure we are

--- a/internal/cmd/git-combine/git-combine.go
+++ b/internal/cmd/git-combine/git-combine.go
@@ -125,7 +125,7 @@ func Combine(path string, opt Options) error {
 		seen := recentRootTrees[remote]
 
 		for i := 0; i < opt.LimitRemote; i++ {
-			if time.Since(lastLog) > time.Minute {
+			if time.Since(lastLog) > time.Second {
 				log.Printf("Combine: collecting new commits... (remote %s, commit depth %d, commit hash %s)", remote, i, commit.Hash)
 				lastLog = time.Now()
 			}
@@ -223,7 +223,10 @@ func Combine(path string, opt Options) error {
 			return err
 		}
 
-		log.Printf("%d/%d created %s from %s %s", i+1, len(commits), parentHash, commit.Hash, commitTitle(newCommit))
+		if time.Since(lastLog) > time.Second {
+			log.Printf("%d/%d created %s from %s %s", i+1, len(commits), parentHash, commit.Hash, commitTitle(newCommit))
+			lastLog = time.Now()
+		}
 	}
 
 	return nil

--- a/internal/cmd/git-combine/git-combine.go
+++ b/internal/cmd/git-combine/git-combine.go
@@ -126,8 +126,23 @@ func Combine(path string, opt Options) error {
 
 		for i := 0; i < opt.LimitRemote; i++ {
 			if time.Since(lastLog) > time.Second {
-				log.Printf("Combine: collecting new commits... (remote %s, commit depth %d, commit hash %s)", remote, i, commit.Hash)
+				log.Printf("Combine: collecting new commits... (remote %s, commit depth %d, commit hash %s)", remote, i+1, commit.Hash)
 				lastLog = time.Now()
+			}
+
+			if seen.Contains(commit.TreeHash) {
+				rootTree[remote] = commit.TreeHash
+				break
+			}
+
+			commits = append(commits, &dirCommit{
+				dir:    remote,
+				Commit: commit,
+			})
+
+			if i >= opt.LimitRemote-1 {
+				// Avoid getting the next commit if we're done iterating.
+				break
 			}
 
 			if commit.NumParents() == 0 {
@@ -140,16 +155,6 @@ func Combine(path string, opt Options) error {
 			} else if err != nil {
 				return err
 			}
-
-			if seen.Contains(commit.TreeHash) {
-				rootTree[remote] = commit.TreeHash
-				break
-			}
-
-			commits = append(commits, &dirCommit{
-				dir:    remote,
-				Commit: commit,
-			})
 		}
 	}
 

--- a/internal/cmd/git-combine/git-combine.go
+++ b/internal/cmd/git-combine/git-combine.go
@@ -122,7 +122,7 @@ func Combine(path string, opt Options) error {
 		seen := recentRootTrees[remote]
 
 		for i := 0; i < opt.LimitRemote; i++ {
-			commit, err := commit.Parent(0)
+			commit, err = commit.Parent(0)
 			if err == io.EOF {
 				break
 			} else if err != nil {

--- a/internal/cmd/git-combine/git-combine.go
+++ b/internal/cmd/git-combine/git-combine.go
@@ -70,6 +70,7 @@ func Combine(path string, opt Options) error {
 
 	parentHash := getHeadHash(r)
 
+	log.Println("Combine: getting recent root trees...")
 	recentRootTrees, err := getRecentRootTrees(r, recentRootTreesMaxEntries)
 	if err != nil {
 		return err
@@ -92,6 +93,8 @@ func Combine(path string, opt Options) error {
 		dir string
 	}
 
+	log.Println("Combine: collecting new commits...")
+	lastLog := time.Now()
 	rootTree := map[string]plumbing.Hash{}
 	var commits []*dirCommit
 	for remote := range conf.Remotes {
@@ -122,6 +125,11 @@ func Combine(path string, opt Options) error {
 		seen := recentRootTrees[remote]
 
 		for i := 0; i < opt.LimitRemote; i++ {
+			if time.Since(lastLog) > time.Minute {
+				log.Printf("Combine: collecting new commits... (remote %s, commit depth %d, commit hash %s)", remote, i, commit.Hash)
+				lastLog = time.Now()
+			}
+
 			if commit.NumParents() == 0 {
 				break
 			}

--- a/internal/cmd/git-combine/git-combine.go
+++ b/internal/cmd/git-combine/git-combine.go
@@ -153,6 +153,11 @@ func Combine(path string, opt Options) error {
 		}
 	}
 
+	// Reverse the commits so we apply them in the right order.
+	for i, j := 0, len(commits)-1; i < j; i, j = i+1, j-1 {
+		commits[i], commits[j] = commits[j], commits[i]
+	}
+
 	if len(commits) > opt.Limit {
 		// We only take the last Limit commits. But we want to ensure we are
 		// using the latest treehash for each dir, so we need to walk over the


### PR DESCRIPTION
Prior to this change, git-combine would interleave commit trees from different dates and across parent histories, which was causing lots of thrashing with added/deleted blobs.

After this change, it'll preserve the order of commits and only include the first parent's history.

From [Slack](https://sourcegraph.slack.com/archives/C023ELQLV7F/p1645665659705139?thread_ts=1645458918.861179&cid=C023ELQLV7F)

## Test plan

N/A, this is for testing in the dogfood environment.