### PR TITLE
Fix getting-started-tour external link steps

### DIFF
--- a/client/web/src/onboarding-tour/OnboardingTourSteps.tsx
+++ b/client/web/src/onboarding-tour/OnboardingTourSteps.tsx
@@ -26,9 +26,11 @@ interface LinkOrAnchorProps {
 const LinkOrAnchor: React.FunctionComponent<LinkOrAnchorProps> = ({ href, children, ...props }) => {
     if (isExternalURL(href)) {
         return (
-            <Link to={href} target="_blank" rel="noopener noreferrer" {...props}>
+            // Using <a> tag explicitly for external link
+            // eslint-disable-next-line react/forbid-elements
+            <a href={href} target="_blank" rel="noopener noreferrer" {...props}>
                 {children}
-            </Link>
+            </a>
         )
     }
 

--- a/client/web/src/onboarding-tour/OnboardingTourSteps.tsx
+++ b/client/web/src/onboarding-tour/OnboardingTourSteps.tsx
@@ -5,9 +5,10 @@ import ArrowDropDownIcon from 'mdi-react/ArrowDropDownIcon'
 import CheckCircleIcon from 'mdi-react/CheckCircleIcon'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { CircularProgressbar } from 'react-circular-progressbar'
-import { Link, useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { Link } from '@sourcegraph/wildcard'
 
 import { useOnboardingTourState } from '../stores/onboardingTourState'
 
@@ -26,11 +27,9 @@ interface LinkOrAnchorProps {
 const LinkOrAnchor: React.FunctionComponent<LinkOrAnchorProps> = ({ href, children, ...props }) => {
     if (isExternalURL(href)) {
         return (
-            // Using <a> tag explicitly for external link
-            // eslint-disable-next-line react/forbid-elements
-            <a href={href} target="_blank" rel="noopener noreferrer" {...props}>
+            <Link to={href} target="_blank" rel="noopener noreferrer" {...props}>
                 {children}
-            </a>
+            </Link>
         )
     }
 

--- a/client/web/src/onboarding-tour/OnboardingTourSteps.tsx
+++ b/client/web/src/onboarding-tour/OnboardingTourSteps.tsx
@@ -24,21 +24,11 @@ interface LinkOrAnchorProps {
     onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void
 }
 
-const LinkOrAnchor: React.FunctionComponent<LinkOrAnchorProps> = ({ href, children, ...props }) => {
-    if (isExternalURL(href)) {
-        return (
-            <Link to={href} target="_blank" rel="noopener noreferrer" {...props}>
-                {children}
-            </Link>
-        )
-    }
-
-    return (
-        <Link to={href} {...props}>
-            {children}
-        </Link>
-    )
-}
+const LinkOrAnchor: React.FunctionComponent<LinkOrAnchorProps> = ({ href, children, ...props }) => (
+    <Link to={href} {...props} {...(isExternalURL(href) && { target: '_blank', rel: 'noopener noreferrer' })}>
+        {children}
+    </Link>
+)
 
 interface OnboardingTourStepProps extends OnboardingTourStepItem, TelemetryProps {}
 

--- a/client/web/src/onboarding-tour/utils.tsx
+++ b/client/web/src/onboarding-tour/utils.tsx
@@ -1,3 +1,5 @@
+import isAbsoluteURL from 'is-absolute-url'
+
 export const buildURIMarkers = (href: string, stepId: string): string => {
     const isRelative = !isAbsoluteURL(href)
 
@@ -17,7 +19,5 @@ export const parseURIMarkers = (searchParameters: string): { isTour: boolean; st
     const stepId = parameters.get('stepId')
     return { isTour, stepId }
 }
-
-const isAbsoluteURL = (url: string): boolean => /^https?:\/\//i.test(url)
 
 export const isExternalURL = (url: string): boolean => isAbsoluteURL(url) && new URL(url).origin !== location.origin


### PR DESCRIPTION
Looks like external links in "getting started tour" were broken in https://github.com/sourcegraph/sourcegraph/pull/30534.

## Screenshots
| Before | After |
| --: | :-- |
| <img width="752" alt="image" src="https://user-images.githubusercontent.com/6717049/155702430-4fe2fd0a-eb7c-49bd-8603-60f02d5af9ac.png">  | <img width="752" alt="image" src="https://user-images.githubusercontent.com/6717049/155702179-47b63d8b-67e0-49ab-a01e-055cdbbe9308.png"> |
| <img width="752" alt="image" src="https://user-images.githubusercontent.com/6717049/155702460-e365ab7c-ad60-46c7-8baa-3c6910cc7af8.png"> | <img width="752" alt="image" src="https://user-images.githubusercontent.com/6717049/155702227-6f482d7c-db1a-45ed-9fb0-ccb1a441f6fc.png"> |

## Test plan
- `sg start dotcom`
- Open https://sourcegraph.com/search?feature-flag-key=getting-started-tour&feature-flag-value=true
- Chech last 2 steps/link in getting started tour are working correctly 
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


