### PR TITLE
history panel: add user setting to show absolute timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Pings now include code host integration usage metrics [#31379](https://github.com/sourcegraph/sourcegraph/pull/31379)
 - LSIF upload pages now include a section listing the reasons and retention policies resulting in an upload being retained and not expired. [#30864](https://github.com/sourcegraph/sourcegraph/pull/30864)
 - Timestamps in the history panel can now be formatted as absolute timestamps by using user setting `history.preferAbsoluteTimestamps`
+- Timestamps in the history panel can now be formatted as absolute timestamps by using user setting `history.preferAbsoluteTimestamps` [#31837](https://github.com/sourcegraph/sourcegraph/pull/31837)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Pings now include code host integration usage metrics [#31379](https://github.com/sourcegraph/sourcegraph/pull/31379)
 - LSIF upload pages now include a section listing the reasons and retention policies resulting in an upload being retained and not expired. [#30864](https://github.com/sourcegraph/sourcegraph/pull/30864)
+- Timestamps in the history panel can now be formatted as absolute timestamps by using user setting `history.preferAbsoluteTimestamps`
 
 ### Changed
 

--- a/client/web/src/components/time/Timestamp.tsx
+++ b/client/web/src/components/time/Timestamp.tsx
@@ -16,8 +16,8 @@ interface Props {
     /** Whether to use exact timestamps (i.e. omit "less than", "about", etc.) */
     strict?: boolean
 
-    /** Whether to show absolute timestamps and show relative ones in tooltip */
-    flip?: boolean
+    /** Whether to show absolute timestamp and show relative one in tooltip */
+    preferAbsolute?: boolean
 }
 
 const RERENDER_INTERVAL_MSEC = 7000
@@ -31,7 +31,7 @@ export const Timestamp: React.FunctionComponent<Props> = ({
     noAbout = false,
     strict = false,
     now = Date.now,
-    flip = false,
+    preferAbsolute = false,
 }) => {
     const [label, setLabel] = useState<string>(calculateLabel(date, now, strict, noAbout))
     useEffect(() => {
@@ -51,8 +51,8 @@ export const Timestamp: React.FunctionComponent<Props> = ({
     }, [date])
 
     return (
-        <span className="timestamp" data-tooltip={flip ? label : tooltip}>
-            {flip ? tooltip : label}
+        <span className="timestamp" data-tooltip={preferAbsolute ? label : tooltip}>
+            {preferAbsolute ? tooltip : label}
         </span>
     )
 }

--- a/client/web/src/components/time/Timestamp.tsx
+++ b/client/web/src/components/time/Timestamp.tsx
@@ -15,6 +15,9 @@ interface Props {
 
     /** Whether to use exact timestamps (i.e. omit "less than", "about", etc.) */
     strict?: boolean
+
+    /** Whether to show absolute timestamps and show relative ones in tooltip */
+    flip?: boolean
 }
 
 const RERENDER_INTERVAL_MSEC = 7000
@@ -28,6 +31,7 @@ export const Timestamp: React.FunctionComponent<Props> = ({
     noAbout = false,
     strict = false,
     now = Date.now,
+    flip = false,
 }) => {
     const [label, setLabel] = useState<string>(calculateLabel(date, now, strict, noAbout))
     useEffect(() => {
@@ -47,8 +51,8 @@ export const Timestamp: React.FunctionComponent<Props> = ({
     }, [date])
 
     return (
-        <span className="timestamp" data-tooltip={tooltip}>
-            {label}
+        <span className="timestamp" data-tooltip={flip ? label : tooltip}>
+            {flip ? tooltip : label}
         </span>
     )
 }

--- a/client/web/src/repo/RepoRevisionSidebarCommits.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarCommits.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames'
 import * as H from 'history'
 import FileIcon from 'mdi-react/FileIcon'
 import * as React from 'react'
+import { useCallback } from 'react'
 import { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
 
@@ -59,8 +60,11 @@ interface Props extends Partial<RevisionSpec>, FileSpec {
 }
 
 export const RepoRevisionSidebarCommits: React.FunctionComponent<Props> = props => {
-    const queryCommits = (args: { query?: string }): Observable<CommitAncestorsConnectionFields> =>
-        fetchCommits(props.repoID, props.revision || '', { ...args, currentPath: props.filePath || '' })
+    const queryCommits = useCallback(
+        (args: { query?: string }): Observable<CommitAncestorsConnectionFields> =>
+            fetchCommits(props.repoID, props.revision || '', { ...args, currentPath: props.filePath || '' }),
+        [props.repoID, props.revision, props.filePath]
+    )
 
     return (
         <FilteredConnection<

--- a/client/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/client/web/src/repo/blob/panel/BlobPanel.tsx
@@ -80,6 +80,7 @@ export function useBlobPanelViews({
     )
 
     const maxPanelResults = maxPanelResultsFromSettings(settingsCascade)
+    const preferAbsoluteTimestamps = preferAbsoluteTimestampsFromSettings(settingsCascade)
 
     // Creates source for definition and reference panels
     const createLocationProvider = useCallback(
@@ -168,6 +169,7 @@ export function useBlobPanelViews({
                                     filePath={filePath}
                                     history={history}
                                     location={location}
+                                    preferAbsoluteTimestamps={preferAbsoluteTimestamps}
                                 />
                             ),
                         }))
@@ -196,7 +198,7 @@ export function useBlobPanelViews({
                     ),
                 },
             ],
-            [createLocationProvider, extensionsController.extHostAPI, panelSubjectChanges]
+            [createLocationProvider, extensionsController.extHostAPI, panelSubjectChanges, preferAbsoluteTimestamps]
         )
     )
 
@@ -208,4 +210,12 @@ function maxPanelResultsFromSettings(settingsCascade: SettingsCascadeOrError<Set
         return settingsCascade.final['codeIntelligence.maxPanelResults'] as number
     }
     return undefined
+}
+
+function preferAbsoluteTimestampsFromSettings(settingsCascade: SettingsCascadeOrError<Settings>): boolean {
+    if (settingsCascade.final && !isErrorLike(settingsCascade.final)) {
+        console.log(settingsCascade.final['history.preferAbsoluteTimestamps'])
+        return settingsCascade.final['history.preferAbsoluteTimestamps'] as boolean
+    }
+    return false
 }

--- a/client/web/src/repo/commits/GitCommitNode.story.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.story.tsx
@@ -76,6 +76,7 @@ add('Full customizable', () => (
                     expandCommitMessageBody={boolean('expandCommitMessageBody', false)}
                     showSHAAndParentsRow={boolean('showSHAAndParentsRow', false)}
                     hideExpandCommitMessageBody={boolean('hideExpandCommitMessageBody', false)}
+                    preferAbsoluteTimestamps={boolean('preferAbsoluteTimestamps', false)}
                 />
             </Card>
         )}

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -35,6 +35,9 @@ export interface GitCommitNodeProps {
     /** Show the full 40-character SHA and parents on their own row. */
     showSHAAndParentsRow?: boolean
 
+    /** Show the absolute timestamp and move relative time to tooltip. */
+    preferAbsoluteTimestamps?: boolean
+
     /** Fragment to show at the end to the right of the SHA. */
     afterElement?: React.ReactFragment
 
@@ -58,6 +61,7 @@ export const GitCommitNode: React.FunctionComponent<GitCommitNodeProps> = ({
     hideExpandCommitMessageBody,
     messageSubjectClassName,
     showSHAAndParentsRow,
+    preferAbsoluteTimestamps,
     diffMode,
     onHandleDiffMode,
 }) => {
@@ -108,7 +112,11 @@ export const GitCommitNode: React.FunctionComponent<GitCommitNodeProps> = ({
             )}
             {compact && (
                 <small className={classNames('text-muted', styles.messageTimestamp)}>
-                    <Timestamp noAbout={true} date={node.committer ? node.committer.date : node.author.date} />
+                    <Timestamp
+                        noAbout={true}
+                        flip={preferAbsoluteTimestamps}
+                        date={node.committer ? node.committer.date : node.author.date}
+                    />
                 </small>
             )}
         </div>
@@ -131,6 +139,7 @@ export const GitCommitNode: React.FunctionComponent<GitCommitNodeProps> = ({
             compact={Boolean(compact)}
             messageElement={messageElement}
             commitMessageBody={commitMessageBody}
+            preferAbsoluteTimestamps={preferAbsoluteTimestamps}
         />
     )
 

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -114,7 +114,7 @@ export const GitCommitNode: React.FunctionComponent<GitCommitNodeProps> = ({
                 <small className={classNames('text-muted', styles.messageTimestamp)}>
                     <Timestamp
                         noAbout={true}
-                        flip={preferAbsoluteTimestamps}
+                        preferAbsoluteTimestamp={preferAbsoluteTimestamps}
                         date={node.committer ? node.committer.date : node.author.date}
                     />
                 </small>

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -114,7 +114,7 @@ export const GitCommitNode: React.FunctionComponent<GitCommitNodeProps> = ({
                 <small className={classNames('text-muted', styles.messageTimestamp)}>
                     <Timestamp
                         noAbout={true}
-                        preferAbsoluteTimestamp={preferAbsoluteTimestamps}
+                        preferAbsolute={preferAbsoluteTimestamps}
                         date={node.committer ? node.committer.date : node.author.date}
                     />
                 </small>

--- a/client/web/src/repo/commits/GitCommitNodeByline.tsx
+++ b/client/web/src/repo/commits/GitCommitNodeByline.tsx
@@ -63,7 +63,7 @@ export const GitCommitNodeByline: React.FunctionComponent<Props> = ({
                             {messageElement}
                             <PersonLink person={author.person} className="font-weight-bold" /> authored and commited by{' '}
                             <PersonLink person={committer.person} className="font-weight-bold" />{' '}
-                            <Timestamp date={committer.date} flip={preferAbsoluteTimestamps} />
+                            <Timestamp date={committer.date} preferAbsolute={preferAbsoluteTimestamps} />
                             {commitMessageBody}
                         </>
                     ) : (
@@ -91,7 +91,7 @@ export const GitCommitNodeByline: React.FunctionComponent<Props> = ({
                     <>
                         {messageElement}
                         committed by <PersonLink person={author.person} className="font-weight-bold" />{' '}
-                        <Timestamp date={author.date} flip={preferAbsoluteTimestamps} />
+                        <Timestamp date={author.date} preferAbsolute={preferAbsoluteTimestamps} />
                         {commitMessageBody}
                     </>
                 )}

--- a/client/web/src/repo/commits/GitCommitNodeByline.tsx
+++ b/client/web/src/repo/commits/GitCommitNodeByline.tsx
@@ -12,6 +12,7 @@ interface Props {
     className?: string
     avatarClassName?: string
     compact?: boolean
+    preferAbsoluteTimestamps?: boolean
     messageElement?: JSX.Element
     commitMessageBody?: JSX.Element
 }
@@ -25,6 +26,7 @@ export const GitCommitNodeByline: React.FunctionComponent<Props> = ({
     className = '',
     avatarClassName,
     compact,
+    preferAbsoluteTimestamps,
     messageElement,
     commitMessageBody,
 }) => {
@@ -61,7 +63,7 @@ export const GitCommitNodeByline: React.FunctionComponent<Props> = ({
                             {messageElement}
                             <PersonLink person={author.person} className="font-weight-bold" /> authored and commited by{' '}
                             <PersonLink person={committer.person} className="font-weight-bold" />{' '}
-                            <Timestamp date={committer.date} />
+                            <Timestamp date={committer.date} flip={preferAbsoluteTimestamps} />
                             {commitMessageBody}
                         </>
                     ) : (
@@ -89,7 +91,7 @@ export const GitCommitNodeByline: React.FunctionComponent<Props> = ({
                     <>
                         {messageElement}
                         committed by <PersonLink person={author.person} className="font-weight-bold" />{' '}
-                        <Timestamp date={author.date} />
+                        <Timestamp date={author.date} flip={preferAbsoluteTimestamps} />
                         {commitMessageBody}
                     </>
                 )}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1504,6 +1504,8 @@ type Settings struct {
 	ExtensionsActiveLoggers []string `json:"extensions.activeLoggers,omitempty"`
 	// FileSidebarVisibleByDefault description: Whether the sidebar on the repo view should be open by default.
 	FileSidebarVisibleByDefault bool `json:"fileSidebarVisibleByDefault,omitempty"`
+	// HistoryPreferAbsoluteTimestamps description: Show absolute timestamps in the history panel and only show relative timestamps (e.g.: "5 days ago") in tooltip when hovering.
+	HistoryPreferAbsoluteTimestamps bool `json:"history.preferAbsoluteTimestamps,omitempty"`
 	// Insights description: EXPERIMENTAL: Code Insights
 	Insights []*Insight `json:"insights,omitempty"`
 	// InsightsAllrepos description: EXPERIMENTAL: Backend-based Code Insights

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -394,6 +394,11 @@
         "type": "string"
       }
     },
+    "history.preferAbsoluteTimestamps": {
+      "description": "Show absolute timestamps in the history panel and only show relative timestamps (e.g.: \"5 days ago\") in tooltip when hovering.",
+      "type": "boolean",
+      "default": false
+    },
     "notices": {
       "description": "Custom informational messages to display to users at specific locations in the Sourcegraph user interface.\n\nUsually this setting is used in global and organization settings. If set in user settings, the message will only be displayed to that single user.",
       "type": "array",


### PR DESCRIPTION
This fixes #31712 by adding the `history.preferAbsoluteTimestamps` user setting that determines whether the history panel shows relative (default) or absolute timestamps. If it's `true` it will show absolute timestamps but relative timestamp will be shown in tooltip (which is the flipped behaviour).

While this can be used to switch to absolute timestamps in all displays of git commits, I only do that in the history panel because I didn't want to query the user settings everywhere.

## Screenshot

<img width="1308" alt="screenshot_2022-02-25_12 05 34@2x" src="https://user-images.githubusercontent.com/1185253/155704746-e7c5b52d-9500-42e2-8043-756a0ae793c9.png">

## Test plan

- Tested locally by viewing history panel and toggling user setting `history.preferAbsoluteTimestamps` on/off
- Added a toggle to existing story and ran `yarn run storybook` to test that the knob does the expected thing.


