### PR TITLE
post sign-up: Various fixes

### DIFF
--- a/client/web/src/auth/PostSignUpPage.module.scss
+++ b/client/web/src/auth/PostSignUpPage.module.scss
@@ -19,7 +19,6 @@
     @media (--md-breakpoint-down) {
         margin-left: 0;
     }
-
 }
 
 .logo-link {

--- a/client/web/src/auth/PostSignUpPage.module.scss
+++ b/client/web/src/auth/PostSignUpPage.module.scss
@@ -13,6 +13,13 @@
 .logo {
     height: 1.75rem;
     width: 1.75rem;
+    margin-left: 1rem;
+    margin-top: 1rem;
+
+    @media (--md-breakpoint-down) {
+        margin-left: 0;
+    }
+
 }
 
 .logo-link {
@@ -32,8 +39,30 @@
 
 .container {
     width: 37.25rem;
+    max-width: calc(100vw - 2rem);
 }
 
 .progress {
     width: 50.25rem;
+    max-width: 100%;
+
+    @media (--md-breakpoint-down) {
+        ol {
+            flex-direction: column;
+        }
+    }
+}
+
+.wrapper {
+    display: flex;
+    width: 100%;
+    height: 100%;
+    flex-direction: row;
+    overflow: auto;
+
+    @media (--md-breakpoint-down) {
+        flex-direction: column;
+        padding-left: 1rem;
+        padding-right: 1rem;
+    }
 }

--- a/client/web/src/auth/PostSignUpPage.tsx
+++ b/client/web/src/auth/PostSignUpPage.tsx
@@ -126,9 +126,8 @@ export const PostSignUpPage: FunctionComponent<PostSignUpPage> = ({
     const onError = useCallback((error: ErrorLike) => setError(error), [])
 
     return (
-        <>
-            <BrandLogo className={classNames('ml-3 mt-3', styles.logo)} isLightTheme={true} variant="symbol" />
-
+        <div className={styles.wrapper}>
+              <BrandLogo className={ styles.logo} isLightTheme={true} variant="symbol" />
             <div className={classNames(signInSignUpCommonStyles.signinSignupPage, styles.postSignupPage)}>
                 <PageTitle title="Welcome" />
                 <HeroPage
@@ -146,7 +145,7 @@ export const PostSignUpPage: FunctionComponent<PostSignUpPage> = ({
                                 <h2>Get started with Sourcegraph</h2>
                                 <p className="text-muted pb-3">Follow these steps to set up your account</p>
                             </div>
-                            <div className="mt-2 pb-3 d-flex flex-column align-items-center">
+                            <div className="mt-2 pb-3 d-flex flex-column align-items-center w-100">
                                 <Steps initialStep={debug ? parseInt(debug, 10) : 1} totalSteps={4}>
                                     <StepList numeric={true} className={styles.progress}>
                                         <Step borderColor="purple">Connect with code hosts</Step>
@@ -220,6 +219,6 @@ export const PostSignUpPage: FunctionComponent<PostSignUpPage> = ({
                     }
                 />
             </div>
-        </>
+        </div>
     )
 }

--- a/client/web/src/auth/PostSignUpPage.tsx
+++ b/client/web/src/auth/PostSignUpPage.tsx
@@ -127,7 +127,7 @@ export const PostSignUpPage: FunctionComponent<PostSignUpPage> = ({
 
     return (
         <div className={styles.wrapper}>
-              <BrandLogo className={ styles.logo} isLightTheme={true} variant="symbol" />
+            <BrandLogo className={styles.logo} isLightTheme={true} variant="symbol" />
             <div className={classNames(signInSignUpCommonStyles.signinSignupPage, styles.postSignupPage)}>
                 <PageTitle title="Welcome" />
                 <HeroPage
@@ -197,7 +197,11 @@ export const PostSignUpPage: FunctionComponent<PostSignUpPage> = ({
                                             </div>
                                         </StepPanel>
                                         <StepPanel>
-                                            <TeamsBeta onFinish={finishWelcomeFlow} onError={onError} username={user.username} />
+                                            <TeamsBeta
+                                                onFinish={finishWelcomeFlow}
+                                                onError={onError}
+                                                username={user.username}
+                                            />
                                         </StepPanel>
                                         <StepPanel>
                                             <InviteCollaborators

--- a/client/web/src/auth/PostSignUpPage.tsx
+++ b/client/web/src/auth/PostSignUpPage.tsx
@@ -197,7 +197,7 @@ export const PostSignUpPage: FunctionComponent<PostSignUpPage> = ({
                                             </div>
                                         </StepPanel>
                                         <StepPanel>
-                                            <TeamsBeta onFinish={finishWelcomeFlow} onError={onError} />
+                                            <TeamsBeta onFinish={finishWelcomeFlow} onError={onError} username={user.username} />
                                         </StepPanel>
                                         <StepPanel>
                                             <InviteCollaborators

--- a/client/web/src/auth/welcome/Footer.tsx
+++ b/client/web/src/auth/welcome/Footer.tsx
@@ -30,7 +30,7 @@ export const Footer: React.FunctionComponent<Props> = ({ onFinish, isSkippable }
             <div>
                 {currentStep.isFirstStep && (
                     <Button
-                        className="font-weight-normal text-secondary"
+                        className="font-weight-normal"
                         onClick={event => {
                             event.currentTarget.blur()
                             setStep(currentIndex + 1)

--- a/client/web/src/auth/welcome/InviteCollaborators/InviteCollaborators.tsx
+++ b/client/web/src/auth/welcome/InviteCollaborators/InviteCollaborators.tsx
@@ -159,7 +159,7 @@ export const InviteCollaborators: React.FunctionComponent<InviteCollaborators> =
 
     return (
         <div>
-            <div className="m5-5 d-flex">
+            <div className="d-flex flex-column flex-xl-row w-100">
                 <InvitePane
                     user={user}
                     className={className}

--- a/client/web/src/auth/welcome/InviteCollaborators/InvitePane.tsx
+++ b/client/web/src/auth/welcome/InviteCollaborators/InvitePane.tsx
@@ -109,7 +109,7 @@ export const InvitePane: React.FunctionComponent<Props> = ({
             <div className={styles.titleDescription}>
                 <h3>Introduce friends and colleagues to Sourcegraph</h3>
                 <p className="text-muted mb-4">
-                    We’ve selected a few collaborators you might want to invite to Sourcegraph. These users won’t be
+                    We’ll look for a few collaborators you might want to invite to Sourcegraph. These users won’t be
                     able to see your code unless they have access to it on the code host and also add that code to
                     Sourcegraph.
                 </p>

--- a/client/web/src/auth/welcome/TeamsBeta.module.scss
+++ b/client/web/src/auth/welcome/TeamsBeta.module.scss
@@ -24,6 +24,10 @@
     background-color: var(--white);
 }
 
+.content-submitted {
+    min-height: 14rem;
+}
+
 .content-inner {
     margin-top: 4rem;
     display: flex;

--- a/client/web/src/auth/welcome/TeamsBeta.module.scss
+++ b/client/web/src/auth/welcome/TeamsBeta.module.scss
@@ -21,7 +21,7 @@
     min-height: 56rem;
     // Hard-code white here as the iframe of HubSpot is not easily configurable and ignores our
     // dark-mode setting.
-    background-color: white;
+    background-color: var(--white);
 }
 
 .content-inner {

--- a/client/web/src/auth/welcome/TeamsBeta.module.scss
+++ b/client/web/src/auth/welcome/TeamsBeta.module.scss
@@ -1,6 +1,6 @@
 .container {
     width: 45.5rem;
-    max-width: calc(100vw - 2rem)
+    max-width: calc(100vw - 2rem);
 }
 
 .content {

--- a/client/web/src/auth/welcome/TeamsBeta.module.scss
+++ b/client/web/src/auth/welcome/TeamsBeta.module.scss
@@ -1,5 +1,6 @@
 .container {
     width: 45.5rem;
+    max-width: calc(100vw - 2rem)
 }
 
 .content {
@@ -9,7 +10,7 @@
     padding: 1rem;
     position: static;
     min-height: 14rem;
-    background: var(--color-bg-1);
+    background-color: var(--color-bg-1);
     border: 1px solid var(--border-color);
     border-radius: 3px;
     opacity: 1;
@@ -18,6 +19,9 @@
 
 .content-transitioning {
     min-height: 56rem;
+    // Hard-code white here as the iframe of HubSpot is not easily configurable and ignores our
+    // dark-mode setting.
+    background-color: white;
 }
 
 .content-inner {

--- a/client/web/src/auth/welcome/TeamsBeta.tsx
+++ b/client/web/src/auth/welcome/TeamsBeta.tsx
@@ -15,7 +15,7 @@ const PORTAL_ID = '2762526'
 const FORM_ID = 'b65cc7a2-75ad-4114-be4c-cd9637e7c068'
 
 interface TeamsBeta {
-    username: string,
+    username: string
     onFinish: FinishWelcomeFlow
     onError: (error: Error) => void
 }
@@ -45,7 +45,7 @@ export const TeamsBeta: React.FunctionComponent<TeamsBeta> = ({ onFinish, onErro
             onFormSubmitted: logFormSubmission,
             onError,
             initialFormValues: {
-                cftb_sourcegraph_username: username
+                cftb_sourcegraph_username: username,
             },
         }),
         [logFormSubmission, onError, username]

--- a/client/web/src/auth/welcome/TeamsBeta.tsx
+++ b/client/web/src/auth/welcome/TeamsBeta.tsx
@@ -48,7 +48,7 @@ export const TeamsBeta: React.FunctionComponent<TeamsBeta> = ({ onFinish, onErro
                 cftb_sourcegraph_username: username
             },
         }),
-        [logFormSubmission, onError]
+        [logFormSubmission, onError, username]
     )
     const form = useHubSpotForm(config)
 

--- a/client/web/src/auth/welcome/TeamsBeta.tsx
+++ b/client/web/src/auth/welcome/TeamsBeta.tsx
@@ -15,11 +15,12 @@ const PORTAL_ID = '2762526'
 const FORM_ID = 'b65cc7a2-75ad-4114-be4c-cd9637e7c068'
 
 interface TeamsBeta {
+    username: string,
     onFinish: FinishWelcomeFlow
     onError: (error: Error) => void
 }
 
-export const TeamsBeta: React.FunctionComponent<TeamsBeta> = ({ onFinish, onError }) => {
+export const TeamsBeta: React.FunctionComponent<TeamsBeta> = ({ onFinish, onError, username }) => {
     const contentReference = useRef<HTMLDivElement | null>(null)
     const [isExpanded, setIsExpanded] = useState<boolean>(false)
     const [isTransitioning, setIsTransitioning] = useState<boolean>(false)
@@ -43,7 +44,9 @@ export const TeamsBeta: React.FunctionComponent<TeamsBeta> = ({ onFinish, onErro
             },
             onFormSubmitted: logFormSubmission,
             onError,
-            initialFormValues: {},
+            initialFormValues: {
+                cftb_sourcegraph_username: username
+            },
         }),
         [logFormSubmission, onError]
     )

--- a/client/web/src/auth/welcome/TeamsBeta.tsx
+++ b/client/web/src/auth/welcome/TeamsBeta.tsx
@@ -23,6 +23,7 @@ interface TeamsBeta {
 export const TeamsBeta: React.FunctionComponent<TeamsBeta> = ({ onFinish, onError, username }) => {
     const contentReference = useRef<HTMLDivElement | null>(null)
     const [isExpanded, setIsExpanded] = useState<boolean>(false)
+    const [isSubmitted, setIsSubmitted] = useState<boolean>(false)
     const [isTransitioning, setIsTransitioning] = useState<boolean>(false)
 
     const { setComplete, currentIndex } = useSteps()
@@ -32,6 +33,7 @@ export const TeamsBeta: React.FunctionComponent<TeamsBeta> = ({ onFinish, onErro
     }, [])
 
     const logFormSubmission = useCallback(() => {
+        setIsSubmitted(true)
         eventLogger.log('PostSignUpOrgTabBetaFormSubmit')
         setComplete(currentIndex, true)
     }, [currentIndex, setComplete])
@@ -75,7 +77,11 @@ export const TeamsBeta: React.FunctionComponent<TeamsBeta> = ({ onFinish, onErro
                 </p>
             </div>
             <div
-                className={classNames({ [styles.content]: true, [styles.contentTransitioning]: isTransitioning })}
+                className={classNames({
+                    [styles.content]: true,
+                    [styles.contentTransitioning]: isTransitioning,
+                    [styles.contentSubmitted]: isSubmitted,
+                })}
                 onTransitionEnd={onTransitionEnd}
                 ref={contentReference}
             >


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/31834

This PR has a collection of fixes as according to [this Figma](https://www.figma.com/file/9KUQex1haXP6BpC2wDgtXC/Inviting-collaborators?node-id=850%3A9700) and [this Slack thread](https://sourcegraph.slack.com/archives/C0W2E592M/p1645720681986919).

- Fixes the "Not right now" button in dark mode
- Fix margins of the teams beta form
- Pre-fills username in the teams beta form
- Changes the text on the invite collaborators page
- Various responsive mode improvements

## Open questions

- @rrhyne please take a not at the "Invite Collaborators Responsive Changes" part of the test plan. These are probably the biggest changes that I've made that divert the design quite a bit but I felt like the current version of having the two sides stacked even on very small screens/mobile was really awkward. 

## Test plan

### UI/UX changes

|   | Light mode | Dark mode  |
|---|---|---|
|Skip this step button fixes| ![skip-this-step-light-mode](https://user-images.githubusercontent.com/458591/155718406-3b7cffdd-90f5-4187-b6c0-2e483bdcb2ea.png) | ![skip-this-step-dark-mode](https://user-images.githubusercontent.com/458591/155718418-5cef6e57-82d4-4d3e-8d44-df448239a03f.png)  |
| Responsive Code Hosts  | ![responsive-code-hosts](https://user-images.githubusercontent.com/458591/155718452-9f79f76b-a748-42e2-8f20-b79f5667103b.png)  | n/a  |
| Teams Beta  | ![teams-beta-responsive-light-mode](https://user-images.githubusercontent.com/458591/155718475-5e2d39f1-6429-474b-a793-45cabcb5ca61.png)  |  ![teams-beta-responsive-dark-mode](https://user-images.githubusercontent.com/458591/155718489-1da13a16-5003-4140-9d47-9b8a75fb3aa1.png) |

### Invite Collaborators Responsive Changes

https://user-images.githubusercontent.com/458591/155718704-a64d82f1-ebdc-47fe-afab-7e7398b42155.mov

### Form auto-filling

Since this implementation takes use of custom DOM events I wanted to verify this across more browsers just to be sure. The field is not hidden yet so the test is visible but once we hide it the logic stays the same.

| Chrome | Firefox | Safari |
|--------|---------|--------|
|![form-filling-chrome](https://user-images.githubusercontent.com/458591/155718909-0702b320-0da8-433f-95cc-7cc36b202ddf.png)|![form-filling-firefox](https://user-images.githubusercontent.com/458591/155718934-a9543315-3042-4248-b4e5-3b8afea910c7.png)|![form-filling-safari](https://user-images.githubusercontent.com/458591/155718956-f7fbaebc-50ed-4695-a7a5-f33a25880bb1.png)|


