### PR TITLE
ci: fix a typo in bkstats README

### DIFF
--- a/dev/bkstats/README.md
+++ b/dev/bkstats/README.md
@@ -20,6 +20,6 @@ On 2021-10-22, the pipeline was red for 1h8m32.856s
 1. Go over [your personal settings](https://buildkite.com/user/api-access-tokens)
 2. Create a new token with the following permissions:
 
-- check `sourcegraph` organization
+- Check `sourcegraph` organization
 - `read_builds`
 - `read_pipelines`


### PR DESCRIPTION
I'm using this fix to exhibit an audit trail exception for a missing review. 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

n/a, it's just a typo fix. 
