### PR TITLE
docs: add a paragraph about skipping reviews

### DIFF
--- a/doc/dev/background-information/pull_request_reviews.md
+++ b/doc/dev/background-information/pull_request_reviews.md
@@ -4,7 +4,10 @@ Sourcegraph has a formal software development life cycle methodology and support
 
 All contributions to Sourcegraph must be reviewed and approved before being merged into the `main` branch. This includes code changes, documentation changes, and more.
 
-Our goal is to have a pull request review process and culture that everyone would opt-in to even if reviews weren't required.
+GitHub repositories are configured to prevent merging without a review (including administrators), but in the eventuality of a pull request being merged without review, 
+[`pr-auditor`](https://github.com/sourcegraph/sourcegraph/tree/main/dev/pr-auditor) will open an exception in the [audit trail](https://github.com/sourcegraph/sec-pr-audit-trail/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) where the teammate who merged the pull request can document the exception.
+
+Our goal is to have a pull request review process and culture that everyone would opt-in to even if reviews weren't required. 
 
 In addition to being peer-reviewed, all contributions must pass our [continuous integration](./continuous_integration.md).
 


### PR DESCRIPTION
@bobheadxi We need this to exhibit more from the docs in an explicit way that we can't merge without a review without triggering an exception. 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Looking at the changes locally in the doc site. 
