### PR TITLE
Hide reference panel when not viewing code

### DIFF
--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useCallback, useEffect, useMemo, useState } from 'react'
+import React, { Suspense, useCallback, useEffect, useMemo } from 'react'
 import { Redirect, Route, RouteComponentProps, Switch, matchPath } from 'react-router'
 import { Observable } from 'rxjs'
 
@@ -36,12 +36,7 @@ import { ExtensionAreaHeaderNavItem } from './extensions/extension/ExtensionArea
 import { ExtensionsAreaRoute } from './extensions/ExtensionsArea'
 import { ExtensionsAreaHeaderActionButton } from './extensions/ExtensionsAreaHeader'
 import { FeatureFlagProps } from './featureFlags/featureFlags'
-import {
-    CoolCodeIntel,
-    CoolClickedToken,
-    isCoolCodeIntelEnabled,
-    locationWithoutViewState,
-} from './global/CoolCodeIntel'
+import { isCoolCodeIntelEnabled } from './global/CoolCodeIntel'
 import { GlobalAlerts } from './global/GlobalAlerts'
 import { GlobalDebug } from './global/GlobalDebug'
 import { CodeInsightsContextProps, CodeInsightsProps } from './insights/types'
@@ -195,11 +190,6 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
     // }, [])
 
     // Experimental reference panel
-    const [clickedToken, onTokenClick] = useState<CoolClickedToken>()
-    const onTokenClickRemoveViewState = (token: CoolClickedToken): void => {
-        props.history.push(locationWithoutViewState(props.location))
-        onTokenClick(token)
-    }
     const coolCodeIntelEnabled = isCoolCodeIntelEnabled(props.settingsCascade)
 
     // Remove trailing slash (which is never valid in any of our URLs).
@@ -221,9 +211,6 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
         ...breadcrumbProps,
         onExtensionAlertDismissed,
         isMacPlatform: isMacPlatform(),
-        // Experimental reference panel
-        coolCodeIntelEnabled,
-        onTokenClick: coolCodeIntelEnabled ? onTokenClickRemoveViewState : undefined,
     }
 
     return (
@@ -304,17 +291,6 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
                 history={props.history}
             />
             <GlobalDebug {...props} />
-            {coolCodeIntelEnabled && (
-                <CoolCodeIntel
-                    {...props}
-                    {...themeProps}
-                    onClose={() => {
-                        onTokenClick(undefined)
-                    }}
-                    onTokenClick={onTokenClick}
-                    clickedToken={clickedToken}
-                />
-            )}
         </div>
     )
 }

--- a/client/web/src/global/CoolCodeIntel.tsx
+++ b/client/web/src/global/CoolCodeIntel.tsx
@@ -6,7 +6,7 @@ import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 import CloseIcon from 'mdi-react/CloseIcon'
 import OpenInAppIcon from 'mdi-react/OpenInAppIcon'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import { useHistory, useLocation } from 'react-router'
+import { useLocation } from 'react-router'
 import { Collapse } from 'reactstrap'
 
 import { HoveredToken } from '@sourcegraph/codeintellify'
@@ -66,7 +66,7 @@ import { usePreciseCodeIntel } from './usePreciseCodeIntel'
 
 export interface GlobalCoolCodeIntelProps {
     coolCodeIntelEnabled: boolean
-    onTokenClick?: (clickedToken: CoolClickedToken) => void
+    onTokenClick?: (clickedToken: CoolClickedToken | undefined) => void
 }
 
 export type CoolClickedToken = HoveredToken & RepoSpec & RevisionSpec & FileSpec & ResolvedRevisionSpec
@@ -79,7 +79,7 @@ interface CoolCodeIntelProps
 export const isCoolCodeIntelEnabled = (settingsCascade: SettingsCascadeOrError): boolean =>
     !isErrorLike(settingsCascade.final) && settingsCascade.final?.experimentalFeatures?.coolCodeIntel === true
 
-export const CoolCodeIntel: React.FunctionComponent<CoolCodeIntelProps & { onClose: () => void }> = props => (
+export const CoolCodeIntel: React.FunctionComponent<CoolCodeIntelProps> = props => (
     <ErrorBoundary
         location={null}
         render={error => (
@@ -525,7 +525,7 @@ const SideBlob: React.FunctionComponent<
     return (
         <Blob
             {...props}
-            onTokenClick={(token: CoolClickedToken) => {
+            onTokenClick={(token: CoolClickedToken | undefined) => {
                 if (props.onTokenClick) {
                     props.onTokenClick(token)
                 }
@@ -801,20 +801,17 @@ export function locationWithoutViewState(location: H.Location): H.LocationDescri
     return result
 }
 
-const CoolCodeIntelResizablePanel: React.FunctionComponent<CoolCodeIntelProps & { onClose: () => void }> = props => {
+const CoolCodeIntelResizablePanel: React.FunctionComponent<CoolCodeIntelProps> = props => {
     let token = props.clickedToken
 
-    const history = useHistory()
     const location = useLocation()
 
     const [closed, close] = useState(false)
     const handlePanelClose = useCallback(() => {
-        // Signal up that panel is closed
-        props.onClose()
-        // Remove 'viewState' from location
-        history.push(locationWithoutViewState(location))
-        // close(true)
-    }, [props, history, location])
+        if (props.onTokenClick) {
+            props.onTokenClick(undefined)
+        }
+    }, [props])
 
     useEffect(() => {
         if (token) {

--- a/client/web/src/global/CoolCodeIntel.tsx
+++ b/client/web/src/global/CoolCodeIntel.tsx
@@ -525,11 +525,6 @@ const SideBlob: React.FunctionComponent<
     return (
         <Blob
             {...props}
-            onTokenClick={(token: CoolClickedToken | undefined) => {
-                if (props.onTokenClick) {
-                    props.onTokenClick(token)
-                }
-            }}
             coolCodeIntelEnabled={true}
             disableStatusBar={true}
             wrapCode={true}

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -40,7 +40,6 @@ import { ErrorBoundary } from '../components/ErrorBoundary'
 import { HeroPage } from '../components/HeroPage'
 import { ActionItemsBarProps, useWebActionItems } from '../extensions/components/ActionItemsBar'
 import { FeatureFlagProps } from '../featureFlags/featureFlags'
-import { GlobalCoolCodeIntelProps } from '../global/CoolCodeIntel'
 import { ExternalLinkFields, RepositoryFields } from '../graphql-operations'
 import { CodeInsightsProps } from '../insights/types'
 import { searchQueryForRepoRevision, SearchStreamingProps } from '../search'
@@ -84,8 +83,7 @@ export interface RepoContainerContext
         BatchChangesProps,
         CodeInsightsProps,
         ExtensionAlertProps,
-        FeatureFlagProps,
-        GlobalCoolCodeIntelProps {
+        FeatureFlagProps {
     repo: RepositoryFields
     authenticatedUser: AuthenticatedUser | null
     repoSettingsAreaRoutes: readonly RepoSettingsAreaRoute[]
@@ -127,8 +125,7 @@ interface RepoContainerProps
         CodeIntelligenceProps,
         BatchChangesProps,
         CodeInsightsProps,
-        FeatureFlagProps,
-        GlobalCoolCodeIntelProps {
+        FeatureFlagProps {
     repoContainerRoutes: readonly RepoContainerRoute[]
     repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[]
     repoHeaderActionButtons: readonly RepoHeaderActionButton[]
@@ -449,9 +446,6 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
                                     // must exactly match how the revision was encoded in the URL
                                     routePrefix={`${repoMatchURL}${rawRevision ? `@${rawRevision}` : ''}`}
                                     useActionItemsBar={useActionItemsBar}
-                                    // Experimental ref panel
-                                    coolCodeIntelEnabled={props.coolCodeIntelEnabled}
-                                    onTokenClick={props.onTokenClick}
                                 />
                             )}
                         />

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -1,8 +1,8 @@
 import * as H from 'history'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
-import React, { useCallback, useMemo, useState } from 'react'
-import { Route, RouteComponentProps, Switch } from 'react-router'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { Route, RouteComponentProps, Switch, useRouteMatch } from 'react-router'
 import { Popover } from 'reactstrap'
 
 import { ErrorMessage } from '@sourcegraph/branded/src/components/alerts'
@@ -31,7 +31,13 @@ import { BreadcrumbSetters } from '../components/Breadcrumbs'
 import { HeroPage } from '../components/HeroPage'
 import { ActionItemsBarProps } from '../extensions/components/ActionItemsBar'
 import { FeatureFlagProps } from '../featureFlags/featureFlags'
-import { GlobalCoolCodeIntelProps } from '../global/CoolCodeIntel'
+import {
+    CoolClickedToken,
+    CoolCodeIntel,
+    GlobalCoolCodeIntelProps,
+    isCoolCodeIntelEnabled,
+    locationWithoutViewState,
+} from '../global/CoolCodeIntel'
 import { RepositoryFields } from '../graphql-operations'
 import { CodeInsightsProps } from '../insights/types'
 import { SearchStreamingProps } from '../search'
@@ -109,8 +115,7 @@ interface RepoRevisionContainerProps
         CodeIntelligenceProps,
         BatchChangesProps,
         CodeInsightsProps,
-        ExtensionAlertProps,
-        GlobalCoolCodeIntelProps {
+        ExtensionAlertProps {
     routes: readonly RepoRevisionContainerRoute[]
     repoSettingsAreaRoutes: readonly RepoSettingsAreaRoute[]
     repoSettingsSidebarGroups: readonly RepoSettingsSideBarGroup[]
@@ -209,6 +214,26 @@ export const RepoRevisionContainer: React.FunctionComponent<RepoRevisionContaine
     useBreadcrumb,
     ...props
 }) => {
+    // Experimental reference panel
+    const coolCodeIntelEnabled = isCoolCodeIntelEnabled(props.settingsCascade)
+
+    // We only render the reference panel when looking at files
+    const referencePanelRoute = props.routePrefix + '/-/blob/:filePath*'
+    const referencePanelRouteMatch = useRouteMatch(referencePanelRoute)
+
+    const [clickedToken, onTokenClick] = useState<CoolClickedToken>()
+    const onTokenClickRemoveViewState = (token: CoolClickedToken | undefined): void => {
+        props.history.push(locationWithoutViewState(context.location))
+        onTokenClick(token)
+    }
+    useEffect(() => {
+        // If we don't have a route match anymore, we reset the state of the
+        // reference panel by setting the token to undefined
+        if (coolCodeIntelEnabled && !referencePanelRouteMatch) {
+            onTokenClick(undefined)
+        }
+    }, [coolCodeIntelEnabled, referencePanelRouteMatch])
+
     const breadcrumbSetters = useBreadcrumb(
         useMemo(() => {
             if (!props.resolvedRevisionOrError || isErrorLike(props.resolvedRevisionOrError)) {
@@ -278,50 +303,62 @@ export const RepoRevisionContainer: React.FunctionComponent<RepoRevisionContaine
         ...props,
         ...breadcrumbSetters,
         resolvedRev: props.resolvedRevisionOrError,
+        onTokenClick: onTokenClickRemoveViewState,
+        coolCodeIntelEnabled,
     }
 
     const resolvedRevisionOrError = props.resolvedRevisionOrError
 
     return (
-        <RepoRevisionWrapper className="pl-3">
-            <Switch>
-                {props.routes.map(
-                    ({ path, render, exact, condition = () => true }) =>
-                        condition(context) && (
-                            <Route
-                                path={props.routePrefix + path}
-                                key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                                exact={exact}
-                                render={routeComponentProps => render({ ...context, ...routeComponentProps })}
-                            />
-                        )
-                )}
-            </Switch>
-            <RepoHeaderContributionPortal
-                position="left"
-                id="copy-path"
-                repoHeaderContributionsLifecycleProps={props.repoHeaderContributionsLifecycleProps}
-            >
-                {() => <CopyPathAction key="copy-path" />}
-            </RepoHeaderContributionPortal>
-            <RepoHeaderContributionPortal
-                position="right"
-                priority={3}
-                id="go-to-permalink"
-                repoHeaderContributionsLifecycleProps={props.repoHeaderContributionsLifecycleProps}
-            >
-                {context => (
-                    <GoToPermalinkAction
-                        key="go-to-permalink"
-                        telemetryService={props.telemetryService}
-                        revision={props.revision}
-                        commitID={resolvedRevisionOrError.commitID}
-                        location={props.location}
-                        history={props.history}
-                        {...context}
-                    />
-                )}
-            </RepoHeaderContributionPortal>
-        </RepoRevisionWrapper>
+        <>
+            <RepoRevisionWrapper className="pl-3">
+                <Switch>
+                    {props.routes.map(
+                        ({ path, render, exact, condition = () => true }) =>
+                            condition(context) && (
+                                <Route
+                                    path={props.routePrefix + path}
+                                    key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                                    exact={exact}
+                                    render={routeComponentProps =>
+                                        render({
+                                            ...context,
+                                            ...routeComponentProps,
+                                        })
+                                    }
+                                />
+                            )
+                    )}
+                </Switch>
+                <RepoHeaderContributionPortal
+                    position="left"
+                    id="copy-path"
+                    repoHeaderContributionsLifecycleProps={props.repoHeaderContributionsLifecycleProps}
+                >
+                    {() => <CopyPathAction key="copy-path" />}
+                </RepoHeaderContributionPortal>
+                <RepoHeaderContributionPortal
+                    position="right"
+                    priority={3}
+                    id="go-to-permalink"
+                    repoHeaderContributionsLifecycleProps={props.repoHeaderContributionsLifecycleProps}
+                >
+                    {context => (
+                        <GoToPermalinkAction
+                            key="go-to-permalink"
+                            telemetryService={props.telemetryService}
+                            revision={props.revision}
+                            commitID={resolvedRevisionOrError.commitID}
+                            location={props.location}
+                            history={props.history}
+                            {...context}
+                        />
+                    )}
+                </RepoHeaderContributionPortal>
+            </RepoRevisionWrapper>
+            {coolCodeIntelEnabled && referencePanelRouteMatch && (
+                <CoolCodeIntel {...props} onTokenClick={onTokenClickRemoveViewState} clickedToken={clickedToken} />
+            )}
+        </>
     )
 }

--- a/client/web/src/repo/compare/RepositoryCompareArea.tsx
+++ b/client/web/src/repo/compare/RepositoryCompareArea.tsx
@@ -34,7 +34,6 @@ import { getHover, getDocumentHighlights } from '../../backend/features'
 import { BreadcrumbSetters } from '../../components/Breadcrumbs'
 import { HeroPage } from '../../components/HeroPage'
 import { WebHoverOverlay } from '../../components/shared'
-import { GlobalCoolCodeIntelProps } from '../../global/CoolCodeIntel'
 import { RepositoryFields, Scalars } from '../../graphql-operations'
 import { RepoHeaderContributionsLifecycleProps } from '../RepoHeader'
 
@@ -57,8 +56,7 @@ interface RepositoryCompareAreaProps
         TelemetryProps,
         ExtensionsControllerProps,
         ThemeProps,
-        BreadcrumbSetters,
-        GlobalCoolCodeIntelProps {
+        BreadcrumbSetters {
     repo: RepositoryFields
     history: H.History
 }
@@ -218,6 +216,7 @@ export class RepositoryCompareArea extends React.Component<RepositoryCompareArea
                         hoveredTokenElement={this.state.hoveredTokenElement}
                         telemetryService={this.props.telemetryService}
                         hoverRef={this.nextOverlayElement}
+                        coolCodeIntelEnabled={false}
                     />
                 )}
             </div>

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -8,7 +8,6 @@ import { BatchChangesProps } from './batches'
 import { CodeIntelligenceProps } from './codeintel'
 import { communitySearchContextsRoutes } from './communitySearchContexts/routes'
 import { BreadcrumbsProps, BreadcrumbSetters } from './components/Breadcrumbs'
-import { GlobalCoolCodeIntelProps } from './global/CoolCodeIntel'
 import type { LayoutProps } from './Layout'
 import { CreateNotebookPage } from './notebooks/createPage/CreateNotebookPage'
 import { NotebooksListPage } from './notebooks/listPage/NotebooksListPage'
@@ -38,8 +37,7 @@ export interface LayoutRouteComponentProps<RouteParameters extends { [K in keyof
         ExtensionAlertProps,
         CodeIntelligenceProps,
         BatchChangesProps,
-        UserExternalServicesOrRepositoriesUpdateProps,
-        GlobalCoolCodeIntelProps {
+        UserExternalServicesOrRepositoriesUpdateProps {
     isSourcegraphDotCom: boolean
     isMacPlatform: boolean
 }


### PR DESCRIPTION
This fixes https://github.com/sourcegraph/sourcegraph/issues/31640 by only showing the experimental reference panel when viewing files. Previously the panel would stay open when navigating from a file view to a directory view, or from file view to search results.

In order to implement this I moved all of the state related to the reference panel to the `RepoRevisionContainer` and also only render the reference panel in there. The nice side-effect of that is that we now don't re-render `Layout` on any change to the clicked token anymore.

I also refactored some of the state keeping in the panel by getting rid of one callback (`onClose`)

## Test plan

- Tested locally with `sg start enterprise-codeintel`, opened reference panel on file (via click and URL), navigated away to directory/search, navigated back to file, opened it again.


