### PR TITLE
codeintel: fix nil pointer in retention policy match overview for visible to tip-of-default-branch uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - Pings now include code host integration usage metrics [#31379](https://github.com/sourcegraph/sourcegraph/pull/31379)
+- LSIF upload pages now include a section listing the reasons and retention policies resulting in an upload being retained and not expired. [#30864](https://github.com/sourcegraph/sourcegraph/pull/30864)
 
 ### Changed
 

--- a/client/web/src/enterprise/codeintel/uploads/components/UploadRetentionStatusNode.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/UploadRetentionStatusNode.tsx
@@ -52,7 +52,7 @@ const RetentionPolicyRetentionMatchNode: FunctionComponent<{ match: RetentionPol
                             {pluralize('commit', match.protectingCommits.length)}, including{' '}
                             {match.protectingCommits
                                 .slice(0, 4)
-                                .map(hash => hash.slice(0, 9))
+                                .map(hash => hash.slice(0, 7))
                                 .join(', ')}
                             <InformationOutlineIcon
                                 className="ml-1 icon-inline"

--- a/client/web/src/enterprise/codeintel/uploads/components/UploadRetentionStatusNode.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/UploadRetentionStatusNode.tsx
@@ -48,8 +48,12 @@ const RetentionPolicyRetentionMatchNode: FunctionComponent<{ match: RetentionPol
                     Retained: {match.matches ? 'yes' : 'no'}
                     {match.protectingCommits.length !== 0 && (
                         <>
-                            , by visible {pluralize('commit', match.protectingCommits.length)}{' '}
-                            {match.protectingCommits.map(hash => hash.slice(0, 9)).join(', ')}
+                            , by {match.protectingCommits.length} visible{' '}
+                            {pluralize('commit', match.protectingCommits.length)}, including{' '}
+                            {match.protectingCommits
+                                .slice(0, 4)
+                                .map(hash => hash.slice(0, 9))
+                                .join(', ')}
                             <InformationOutlineIcon
                                 className="ml-1 icon-inline"
                                 data-tooltip="This upload is retained to service code-intel queries for commit(s) with applicable retention policies."

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index_connection.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index_connection.go
@@ -30,6 +30,7 @@ func NewIndexConnectionResolver(db database.DB, gitserver policies.GitserverClie
 		indexesResolver:  indexesResolver,
 		prefetcher:       prefetcher,
 		locationResolver: locationResolver,
+		errTracer:        errTracer,
 	}
 }
 


### PR DESCRIPTION
Addresses bug when a non tip-of-default-branch upload was retained by being visible to a tip-of-default-branch commit, causing nil pointer as an incorrect assumption was made (see deleted comment)
 
Also updated UI to limit number of visible commits listed.

## Test plan

Added unit tests and manually tested in UI


