### PR TITLE
dependencies api: Prepare for batch repository sync calls

### DIFF
--- a/internal/codeintel/dependencies.go
+++ b/internal/codeintel/dependencies.go
@@ -35,7 +35,7 @@ type DependenciesService struct {
 }
 
 type Syncer interface {
-	Sync(context.Context, api.RepoName) error
+	Sync(ctx context.Context, repos []api.RepoName) error
 }
 
 var (
@@ -138,7 +138,7 @@ func (r *DependenciesService) Dependencies(ctx context.Context, repoRevs map[api
 						}
 
 						depName := dep.RepoName()
-						if err := r.syncer.Sync(ctx, depName); err != nil {
+						if err := r.syncer.Sync(ctx, []api.RepoName{depName}); err != nil {
 							return err
 						}
 

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -587,9 +587,14 @@ type syncer struct {
 	repoStore database.RepoStore
 }
 
-func (s *syncer) Sync(ctx context.Context, repo api.RepoName) error {
-	_, err := backend.NewRepos(s.repoStore).GetByName(ctx, repo)
-	return err
+func (s *syncer) Sync(ctx context.Context, repos []api.RepoName) error {
+	for _, repo := range repos {
+		if _, err := backend.NewRepos(s.repoStore).GetByName(ctx, repo); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // ExactlyOneRepo returns whether exactly one repo: literal field is specified and


### PR DESCRIPTION
Stacked on #31870. This PR does some of the work required to be able to send a single (or, at a minimum, batched) requests to repo-updater. To make use of this in the future:

- codeintel side should send larger batches instead of `n` calls with singleton lists
- search side should update repo-updater interface instead of looping over them and making individual requests

## Test plan

Behavior-preserving refactor.