### PR TITLE
graphql: Add option to query event logs by source

### DIFF
--- a/cmd/frontend/graphqlbackend/event_logs.go
+++ b/cmd/frontend/graphqlbackend/event_logs.go
@@ -12,6 +12,7 @@ import (
 type eventLogsArgs struct {
 	graphqlutil.ConnectionArgs
 	EventName *string // return only event logs matching the event name
+	Source *string // return only event logs matching the event source
 }
 
 func (r *UserResolver) EventLogs(ctx context.Context, args *eventLogsArgs) (*userEventLogsConnectionResolver, error) {
@@ -33,6 +34,7 @@ func (r *UserResolver) EventLogs(ctx context.Context, args *eventLogsArgs) (*use
 	args.ConnectionArgs.Set(&opt.LimitOffset)
 	opt.UserID = r.user.ID
 	opt.EventName = args.EventName
+	opt.Source = args.Source
 	return &userEventLogsConnectionResolver{db: r.db, opt: opt}, nil
 }
 
@@ -59,11 +61,7 @@ func (r *userEventLogsConnectionResolver) TotalCount(ctx context.Context) (int32
 	var count int
 	var err error
 
-	if r.opt.EventName != nil {
-		count, err = r.db.EventLogs().CountByUserIDAndEventName(ctx, r.opt.UserID, *r.opt.EventName)
-	} else {
-		count, err = r.db.EventLogs().CountByUserID(ctx, r.opt.UserID)
-	}
+	count, err = r.db.EventLogs().CountAll(ctx, r.opt)
 
 	return int32(count), err
 }
@@ -72,11 +70,7 @@ func (r *userEventLogsConnectionResolver) PageInfo(ctx context.Context) (*graphq
 	var count int
 	var err error
 
-	if r.opt.EventName != nil {
-		count, err = r.db.EventLogs().CountByUserIDAndEventName(ctx, r.opt.UserID, *r.opt.EventName)
-	} else {
-		count, err = r.db.EventLogs().CountByUserID(ctx, r.opt.UserID)
-	}
+	count, err = r.db.EventLogs().CountAll(ctx, r.opt)
 
 	if err != nil {
 		return nil, err

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -4627,6 +4627,10 @@ type User implements Node & SettingsSubject & Namespace {
         Only return events matching this event name
         """
         eventName: String
+        """
+        Only return events matching this event source
+        """
+        source: EventSource
     ): EventLogsConnection!
     """
     The user's email addresses.


### PR DESCRIPTION
Part of: #30843

We [only want to show the VSCE CTA](https://github.com/sourcegraph/sourcegraph/issues/30843) when a user does not already have this CTA installed. One way of doing this is to query event logs for the presence of any logs from VS Code (here is [some context in Slack](https://sourcegraph.slack.com/archives/C01LZKLRF0C/p1644336829838729)).

I also verified that we do have an index on the `source` field:
![Screenshot 2022-02-25 at 16 42 41](https://user-images.githubusercontent.com/458591/155751041-76623e8a-8772-4003-a596-3a45780f944d.png) 

## Alternatives

- Instead of querying events using this eventLogs API, we could also store a pre-computed value (e.g. "has_vsce") on the user model. [I wrote about this approach in Slack](https://sourcegraph.slack.com/archives/C01LZKLRF0C/p1645028682426599).
  - The benefit here is that we would avoid this query since the user is already loaded in these cases. The obvious downside is that we have to parse every incoming event payload and need to do extra work to backfill the data.

## Test plan

- Run the tests in GO
- Run a GraphQL query through https://sourcegraph.test:3443/api/console

![Screenshot 2022-02-25 at 17 12 07](https://user-images.githubusercontent.com/458591/155756619-3076d7be-6677-425f-b150-47390b4010a1.png)


<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


