### PR TITLE
Search backend: add a stable JSON encoding for CommitMatch

### DIFF
--- a/internal/search/result/commit_json.go
+++ b/internal/search/result/commit_json.go
@@ -1,0 +1,124 @@
+package result
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+// stableCommitMatchJSONMarshaler is a type that is used to marshal and unmarshal
+// a CommitMatch. We create this type as a stable representation of the serialized
+// match so that changes to the shape of the type or types it embeds don't break
+// stored, serialized results. If changes are made, care should be taken to update
+// this in a backwards-compatible manner.
+//
+// Specifically, this representation of commit matches is stored in the database
+// as the results of code monitor runs.
+type stableCommitMatchJSONMarshaler struct {
+	RepoID          int32                     `json:"repoID"`
+	RepoName        string                    `json:"repoName"`
+	RepoStars       int                       `json:"repoStars"`
+	CommitID        string                    `json:"commitID"`
+	CommitAuthor    stableSignatureMarshaler  `json:"author"`
+	CommitCommitter *stableSignatureMarshaler `json:"committer,omitempty"`
+	Message         string                    `json:"message"`
+	Parents         []string                  `json:"parents,omitempty"`
+	Refs            []string                  `json:"refs,omitempty"`
+	SourceRefs      []string                  `json:"sourceRefs,omitempty"`
+	MessagePreview  *MatchedString            `json:"messagePreview,omitempty"`
+	DiffPreview     *MatchedString            `json:"diffPreview,omitempty"`
+	ModifiedFiles   []string                  `json:"modifiedFiles,omitempty"`
+}
+
+type stableSignatureMarshaler struct {
+	Name  string    `json:"name"`
+	Email string    `json:"email"`
+	Date  time.Time `json:"date"`
+}
+
+func (cm CommitMatch) MarshalJSON() ([]byte, error) {
+	var committer *stableSignatureMarshaler
+	if cm.Commit.Committer != nil {
+		committer = &stableSignatureMarshaler{
+			Name:  cm.Commit.Committer.Name,
+			Email: cm.Commit.Committer.Email,
+			Date:  cm.Commit.Committer.Date,
+		}
+	}
+
+	parents := make([]string, len(cm.Commit.Parents))
+	for i, parent := range cm.Commit.Parents {
+		parents[i] = string(parent)
+	}
+
+	marshaler := stableCommitMatchJSONMarshaler{
+		RepoID:    int32(cm.Repo.ID),
+		RepoName:  string(cm.Repo.Name),
+		RepoStars: cm.Repo.Stars,
+		CommitID:  string(cm.Commit.ID),
+		CommitAuthor: stableSignatureMarshaler{
+			Name:  cm.Commit.Author.Name,
+			Email: cm.Commit.Author.Email,
+			Date:  cm.Commit.Author.Date,
+		},
+		CommitCommitter: committer,
+		Message:         string(cm.Commit.Message),
+		Parents:         parents,
+		Refs:            cm.Refs,
+		SourceRefs:      cm.SourceRefs,
+		MessagePreview:  cm.MessagePreview,
+		DiffPreview:     cm.DiffPreview,
+		ModifiedFiles:   cm.ModifiedFiles,
+	}
+
+	return json.Marshal(marshaler)
+}
+
+func (cm *CommitMatch) UnmarshalJSON(input []byte) error {
+	var unmarshaler stableCommitMatchJSONMarshaler
+	if err := json.Unmarshal(input, &unmarshaler); err != nil {
+		return err
+	}
+
+	var committer *gitdomain.Signature
+	if unmarshaler.CommitCommitter != nil {
+		committer = &gitdomain.Signature{
+			Name:  unmarshaler.CommitCommitter.Name,
+			Email: unmarshaler.CommitCommitter.Email,
+			Date:  unmarshaler.CommitCommitter.Date,
+		}
+	}
+
+	parents := make([]api.CommitID, len(unmarshaler.Parents))
+	for i, parent := range unmarshaler.Parents {
+		parents[i] = api.CommitID(parent)
+	}
+
+	*cm = CommitMatch{
+		Commit: gitdomain.Commit{
+			ID: api.CommitID(unmarshaler.CommitID),
+			Author: gitdomain.Signature{
+				Name:  unmarshaler.CommitAuthor.Name,
+				Email: unmarshaler.CommitAuthor.Email,
+				Date:  unmarshaler.CommitAuthor.Date,
+			},
+			Committer: committer,
+			Message:   gitdomain.Message(unmarshaler.Message),
+			Parents:   parents,
+		},
+		Repo: types.MinimalRepo{
+			ID:    api.RepoID(unmarshaler.RepoID),
+			Name:  api.RepoName(unmarshaler.RepoName),
+			Stars: unmarshaler.RepoStars,
+		},
+		Refs:           unmarshaler.Refs,
+		SourceRefs:     unmarshaler.SourceRefs,
+		MessagePreview: unmarshaler.MessagePreview,
+		DiffPreview:    unmarshaler.DiffPreview,
+		ModifiedFiles:  unmarshaler.ModifiedFiles,
+	}
+	return nil
+}

--- a/internal/search/result/commit_json.go
+++ b/internal/search/result/commit_json.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-// stableCommitMatchJSONMarshaler is a type that is used to marshal and unmarshal
+// stableCommitMatchJSON is a type that is used to marshal and unmarshal
 // a CommitMatch. We create this type as a stable representation of the serialized
 // match so that changes to the shape of the type or types it embeds don't break
 // stored, serialized results. If changes are made, care should be taken to update
@@ -17,7 +17,7 @@ import (
 //
 // Specifically, this representation of commit matches is stored in the database
 // as the results of code monitor runs.
-type stableCommitMatchJSONMarshaler struct {
+type stableCommitMatchJSON struct {
 	RepoID          int32                     `json:"repoID"`
 	RepoName        string                    `json:"repoName"`
 	RepoStars       int                       `json:"repoStars"`
@@ -54,7 +54,7 @@ func (cm CommitMatch) MarshalJSON() ([]byte, error) {
 		parents[i] = string(parent)
 	}
 
-	marshaler := stableCommitMatchJSONMarshaler{
+	marshaler := stableCommitMatchJSON{
 		RepoID:    int32(cm.Repo.ID),
 		RepoName:  string(cm.Repo.Name),
 		RepoStars: cm.Repo.Stars,
@@ -78,7 +78,7 @@ func (cm CommitMatch) MarshalJSON() ([]byte, error) {
 }
 
 func (cm *CommitMatch) UnmarshalJSON(input []byte) error {
-	var unmarshaler stableCommitMatchJSONMarshaler
+	var unmarshaler stableCommitMatchJSON
 	if err := json.Unmarshal(input, &unmarshaler); err != nil {
 		return err
 	}

--- a/internal/search/result/commit_json_test.go
+++ b/internal/search/result/commit_json_test.go
@@ -1,0 +1,64 @@
+package result
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func TestCommitMatchMarshaling(t *testing.T) {
+	t.Run("roundtrip", func(t *testing.T) {
+		cm1 := CommitMatch{
+			Commit: gitdomain.Commit{
+				ID: api.CommitID("saccolabium"),
+				Author: gitdomain.Signature{
+					Name:  "Looseleaf teaperson",
+					Email: "75celsius@hotwater.com",
+					Date:  time.Date(237, time.November, 15, 8, 0, 0, 0, time.FixedZone("Ancient China", int(+8*time.Hour/time.Second))),
+				},
+				Committer: &gitdomain.Signature{
+					Name:  "Coffee drinkerperson",
+					Email: "93celsius@hotterwater.com",
+					Date:  time.Date(1402, time.January, 18, 7, 0, 0, 0, time.FixedZone("Aksum Ethiopia", int(+3*time.Hour/time.Second))),
+				},
+				Message: "add documentation for hot beverages",
+				Parents: []api.CommitID{"coffeeae", "coffea", "arabica"},
+			},
+			Repo: types.MinimalRepo{
+				ID:    42,
+				Name:  api.RepoName("github.com/historyofconsumption/beverages"),
+				Stars: 7,
+			},
+			Refs:       []string{"awakeness"},
+			SourceRefs: []string{"caffeine"},
+			MessagePreview: &MatchedString{
+				Content:       "add documentation for hot beverages",
+				MatchedRanges: Ranges{{Start: Location{Offset: 0, Line: 0, Column: 0}, End: Location{Offset: 3, Line: 0, Column: 3}}},
+			},
+			DiffPreview: &MatchedString{
+				Content:       "/dev/null drinks/coffee.md",
+				MatchedRanges: Ranges{{Start: Location{Offset: 17, Line: 0, Column: 17}, End: Location{Offset: 23, Line: 0, Column: 23}}},
+			},
+			ModifiedFiles: []string{"drinks/coffee.md", "drinks/tea.md"},
+		}
+
+		marshaled, err := json.Marshal(cm1)
+		require.NoError(t, err)
+
+		var cm2 CommitMatch
+		err = json.Unmarshal(marshaled, &cm2)
+		require.NoError(t, err)
+
+		require.True(t, cm1.Commit.Author.Date.Equal(cm2.Commit.Author.Date))
+		require.True(t, cm1.Commit.Committer.Date.Equal(cm2.Commit.Committer.Date))
+		cm2.Commit.Author.Date = cm1.Commit.Author.Date
+		cm2.Commit.Committer.Date = cm1.Commit.Committer.Date
+		require.Equal(t, cm1, cm2)
+	})
+}

--- a/internal/search/result/range.go
+++ b/internal/search/result/range.go
@@ -9,7 +9,7 @@ import (
 
 type MatchedString struct {
 	Content       string `json:"content"`
-	MatchedRanges Ranges `json:"matched_ranges"`
+	MatchedRanges Ranges `json:"matchedRanges"`
 }
 
 func (m MatchedString) ToHighlightedString() HighlightedString {


### PR DESCRIPTION
Since we will be calling search directly for code monitors, we will now
have access to the real CommitMatch type for code monitors. We store
result types in the database, so this adds a stable JSON representation
to CommitMatch so we can safely marshal/unmarshal. This will make it
much more obvious when a change would break encoding compatibility,
which is convenient.

Stacked on #31872 

## Test plan

Added a unit test that ensures roundtrip equality through the JSON encoding.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


