### PR TITLE
Update utm params for bext cta links

### DIFF
--- a/client/web/src/components/SelfHostedCta/SelfHostedCta.tsx
+++ b/client/web/src/components/SelfHostedCta/SelfHostedCta.tsx
@@ -74,7 +74,7 @@ export const SelfHostedCta: React.FunctionComponent<SelfHostedCtaProps> = ({
                 <div>
                     <Link
                         onClick={helpGettingStartedCTAOnClick}
-                        to=" https://info.sourcegraph.com/talk-to-a-developer?form_submission_source=inproduct?utm_campaign=inproduct-talktoadev&utm_medium=direct_traffic&utm_source=inproduct-talktoadev&utm_term=null&utm_content=talktoadevform"
+                        to=" https://info.sourcegraph.com/talk-to-a-developer?form_submission_source=inproduct&utm_campaign=inproduct-talktoadev&utm_medium=direct_traffic&utm_source=in-product&utm_term=null&utm_content=talktoadevform"
                         {...linkProps}
                     >
                         Speak to an engineer

--- a/client/web/src/repo/actions/BrowserExtensionAlert.tsx
+++ b/client/web/src/repo/actions/BrowserExtensionAlert.tsx
@@ -28,7 +28,7 @@ export const BrowserExtensionAlert: React.FunctionComponent<Props> = ({ classNam
             cta={{
                 label: 'Learn more about the extension',
                 href:
-                    'https://docs.sourcegraph.com/integration/browser_extension?utm_campaign=inproduct-cta&utm_medium=direct_traffic&utm_source=search-results-cta&utm_term=null&utm_content=install-browser-exten',
+                    'https://docs.sourcegraph.com/integration/browser_extension?utm_campaign=search-results-cta&utm_medium=direct_traffic&utm_source=in-product&utm_term=null&utm_content=install-browser-exten',
                 onClick: onBrowserExtensionClick,
             }}
             icon={<ExtensionRadialGradientIcon />}

--- a/client/web/src/repo/actions/NativeIntegrationAlert.tsx
+++ b/client/web/src/repo/actions/NativeIntegrationAlert.tsx
@@ -54,7 +54,7 @@ export const NativeIntegrationAlert: React.FunctionComponent<NativeIntegrationAl
                 <>
                     Sourcegraph's code intelligence will follow you to your code host.{' '}
                     <AlertLink
-                        to="https://docs.sourcegraph.com/integration/browser_extension?utm_campaign=inproduct-cta&utm_medium=direct_traffic&utm_source=search-results-cta&utm_term=null&utm_content=install-browser-exten"
+                        to="https://docs.sourcegraph.com/integration/browser_extension?utm_campaign=search-results-cta&utm_medium=direct_traffic&utm_source=in-product&utm_term=null&utm_content=install-browser-exten"
                         target="_blank"
                         rel="noopener"
                     >

--- a/client/web/src/search/home/SelfHostInstructions.tsx
+++ b/client/web/src/search/home/SelfHostInstructions.tsx
@@ -87,7 +87,7 @@ export const SelfHostInstructions: React.FunctionComponent<TelemetryProps> = ({ 
                         <OpenInNewIcon aria-label="Open in new window" className="icon-inline" />
                     </Link>
                     <Link
-                        to="https://info.sourcegraph.com/talk-to-a-developer?form_submission_source=inproduct?utm_campaign=inproduct-self-hosted-install&utm_medium=direct_traffic&utm_source=inproduct-self-hosted-install&utm_term=null&utm_content=self-hosted-install"
+                        to="https://info.sourcegraph.com/talk-to-a-developer?form_submission_source=inproduct&utm_campaign=inproduct-self-hosted-install&utm_medium=direct_traffic&utm_source=in-product&utm_term=null&utm_content=self-hosted-install"
                         onClick={onTalkToEngineerClicked}
                         className="text-right flex-shrink-0"
                     >


### PR DESCRIPTION
Fix https://github.com/sourcegraph/sourcegraph/issues/31880

Updated the `utm_source` for the links from this [search result ](https://sourcegraph.com/search?q=context:global+r:sourcegraph/sourcegraph+inproduct%3F&patternType=literal) from  `inproduct-talktoadev` & `inproduct-self-hosted-install` to `in-product`

Updated links from [this search result](https://sourcegraph.com/search?q=context:global+r:sourcegraph/sourcegraph+utm_source%3Dsearch-results-cta&patternType=literal):
From `utm_source=search-results-cta` to `utm_source=in-product`
From `utm_campaign=inproduct-cta` to `utm_campaign=search-results-cta`