### PR TITLE
search: use Zoekt partition repos in structural search

### DIFF
--- a/internal/search/structural/structural.go
+++ b/internal/search/structural/structural.go
@@ -57,14 +57,6 @@ type searchRepos struct {
 	stream  streaming.Sender
 }
 
-func PartitionRepos(request zoektutil.IndexedSearchRequest, notSearcherOnly bool) ([]repoData, error) {
-	repoSets := []repoData{UnindexedList(request.UnindexedRepos())} // unindexed included by default
-	if notSearcherOnly {
-		repoSets = append(repoSets, IndexedMap(request.IndexedRepos()))
-	}
-	return repoSets, nil
-}
-
 // getJob returns a function parameterized by ctx to search over repos.
 func (s *searchRepos) getJob(ctx context.Context) func() error {
 	return func() error {
@@ -170,23 +162,26 @@ func (s *StructuralSearch) Run(ctx context.Context, db database.DB, stream strea
 
 	repos := &searchrepos.Resolver{DB: db, Opts: s.RepoOpts}
 	return nil, repos.Paginate(ctx, nil, func(page *searchrepos.Resolved) error {
-		request, ok, err := zoektutil.OnlyUnindexed(page.RepoRevs, s.ZoektArgs.Zoekt, s.UseIndex, s.ContainsRefGlobs, zoektutil.MissingRepoRevStatus(stream))
+		indexed, unindexed, err := zoektutil.PartitionRepos(
+			ctx,
+			page.RepoRevs,
+			s.ZoektArgs.Zoekt,
+			search.TextRequest,
+			s.UseIndex,
+			s.ContainsRefGlobs,
+			zoektutil.MissingRepoRevStatus(stream),
+		)
 		if err != nil {
 			return err
 		}
-		if !ok {
-			request, err = zoektutil.NewIndexedSubsetSearchRequest(ctx, page.RepoRevs, s.UseIndex, s.ZoektArgs, zoektutil.MissingRepoRevStatus(stream))
-			if err != nil {
-				return err
+
+		repoSet := []repoData{UnindexedList(unindexed)}
+		if s.NotSearcherOnly {
+			if indexed != nil {
+				repoSet = append(repoSet, IndexedMap(indexed.RepoRevs))
 			}
 		}
-
-		partitionedRepos, err := PartitionRepos(request, s.NotSearcherOnly)
-		if err != nil {
-			return err
-		}
-
-		return runStructuralSearch(ctx, s.SearcherArgs, partitionedRepos, stream)
+		return runStructuralSearch(ctx, s.SearcherArgs, repoSet, stream)
 	})
 }
 

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -428,7 +428,7 @@ func TestZoektIndexedRepos(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			indexed, unindexed := zoektIndexedRepos(zoektRepos, tc.repos, nil)
 
-			if diff := cmp.Diff(repoRevsSliceToMap(tc.indexed), indexed.repoRevs); diff != "" {
+			if diff := cmp.Diff(repoRevsSliceToMap(tc.indexed), indexed.RepoRevs); diff != "" {
 				t.Error("unexpected indexed:", diff)
 			}
 			if diff := cmp.Diff(tc.unindexed, unindexed); diff != "" {
@@ -568,7 +568,7 @@ func TestZoektIndexedRepos_single(t *testing.T) {
 	for _, tt := range cases {
 		indexed, unindexed := zoektIndexedRepos(zoektRepos, []*search.RepositoryRevisions{repoRev(tt.rev)}, nil)
 		got := ret{
-			Indexed:   indexed.repoRevs,
+			Indexed:   indexed.RepoRevs,
 			Unindexed: unindexed,
 		}
 		want := ret{


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/31783.

This makes progress by removing the dependency on `IndexedSearchRequest` type by structural search. Instead we use the `PartitionRepos` introduced in previous PR.

## Test plan
Semantics-preserving.
