### PR TITLE
buildchecker: default to not writing to cache

### DIFF
--- a/dev/buildchecker/README.md
+++ b/dev/buildchecker/README.md
@@ -31,6 +31,7 @@ Writes aggregated historical data, including the builds it finds, to a few files
 go run ./dev/buildchecker \
   -buildkite.token=$BUILDKITE_TOKEN \
   -builds.write-to=".tmp/builds.json" \
+  -csv.write-to=".tmp/" \
   -failures.timeout=999 \
   -created.from="2021-08-01" \
   history

--- a/dev/buildchecker/README.md
+++ b/dev/buildchecker/README.md
@@ -30,6 +30,7 @@ Writes aggregated historical data, including the builds it finds, to a few files
 ```sh
 go run ./dev/buildchecker \
   -buildkite.token=$BUILDKITE_TOKEN \
+  -builds.write-to=".tmp/builds.json" \
   -failures.timeout=999 \
   -created.from="2021-08-01" \
   history

--- a/dev/buildchecker/main.go
+++ b/dev/buildchecker/main.go
@@ -58,7 +58,7 @@ func main() {
 	flag.StringVar(&historyFlags.createdToDate, "created.to", "", "date in YYYY-MM-DD format")
 	flag.StringVar(&historyFlags.buildsLoadFrom, "builds.load-from", "", "file to load builds from - if unset, fetches from Buildkite")
 	flag.StringVar(&historyFlags.buildsWriteTo, "builds.write-to", "", "file to write builds to (unused if loading from file)")
-	flag.StringVar(&historyFlags.resultsCsvPath, "csv", ".tmp/", "path for CSV results exports")
+	flag.StringVar(&historyFlags.resultsCsvPath, "csv", "", "path for CSV results exports")
 	flag.StringVar(&historyFlags.honeycombDataset, "honeycomb.dataset", "", "honeycomb dataset to publish to")
 	flag.StringVar(&historyFlags.honeycombToken, "honeycomb.token", "", "honeycomb API token")
 
@@ -289,6 +289,7 @@ func cmdHistory(ctx context.Context, flags *Flags, historyFlags *cmdHistoryFlags
 	log.Printf("running analyses with options: %+v\n", checkOpts)
 	totals, flakes, incidents := generateHistory(builds, createdTo, checkOpts)
 
+	// Prepare output
 	if historyFlags.resultsCsvPath != "" {
 		// Write to files
 		log.Printf("Writing CSV results to %s\n", historyFlags.resultsCsvPath)

--- a/dev/buildchecker/main.go
+++ b/dev/buildchecker/main.go
@@ -57,7 +57,7 @@ func main() {
 	flag.StringVar(&historyFlags.createdFromDate, "created.from", "", "date in YYYY-MM-DD format")
 	flag.StringVar(&historyFlags.createdToDate, "created.to", "", "date in YYYY-MM-DD format")
 	flag.StringVar(&historyFlags.buildsLoadFrom, "builds.load-from", "", "file to load builds from - if unset, fetches from Buildkite")
-	flag.StringVar(&historyFlags.buildsWriteTo, "builds.write-to", ".tmp/builds.json", "file to write builds to (unused if loading from file)")
+	flag.StringVar(&historyFlags.buildsWriteTo, "builds.write-to", "", "file to write builds to (unused if loading from file)")
 	flag.StringVar(&historyFlags.resultsCsvPath, "csv", ".tmp/", "path for CSV results exports")
 	flag.StringVar(&historyFlags.honeycombDataset, "honeycomb.dataset", "", "honeycomb dataset to publish to")
 	flag.StringVar(&historyFlags.honeycombToken, "honeycomb.token", "", "honeycomb API token")
@@ -238,7 +238,7 @@ func cmdHistory(ctx context.Context, flags *Flags, historyFlags *cmdHistoryFlags
 
 		if historyFlags.buildsWriteTo != "" {
 			// Cache builds for ease of re-running analyses
-			log.Printf("Caching discovered builts in %s\n", historyFlags.buildsWriteTo)
+			log.Printf("Caching discovered builds in %s\n", historyFlags.buildsWriteTo)
 			buildsJSON, err := json.Marshal(&builds)
 			if err != nil {
 				log.Fatal("json.Marshal(&builds): ", err)


### PR DESCRIPTION
Lack of `.tmp` dir is causing buildchecker-history to fail.

_code is hard rip_

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

I forgot I can run workflows on branches once it exists in `main`:

<img width="522" alt="image" src="https://user-images.githubusercontent.com/23356519/155804341-4f0107fc-8b89-4289-bd69-be6c2fec7a8b.png">

https://github.com/sourcegraph/sourcegraph/actions/runs/1900847990

<img width="923" alt="image" src="https://user-images.githubusercontent.com/23356519/155804709-a62f3f64-188b-4821-affb-79cdcf8a89dd.png">

Datapoint for the day: 

<img width="1008" alt="image" src="https://user-images.githubusercontent.com/23356519/155804854-088c3542-d249-4857-ae36-2e892e41e62c.png">

