### PR TITLE
search: remove dead code for repoHasFile logic

### DIFF
--- a/internal/search/job/printers_test.go
+++ b/internal/search/job/printers_test.go
@@ -367,7 +367,6 @@ func TestPrettyJSON(t *testing.T) {
           "ResultTypes": 13,
           "Timeout": 20000000000,
           "Repos": null,
-          "UserPrivateRepos": null,
           "Mode": 0,
           "Query": [
             {

--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -122,8 +122,7 @@ func reposContainingPath(ctx context.Context, args *search.TextParameters, repos
 	newArgs.Query = q
 	newArgs.UseFullDeadline = true
 
-	globalSearch := newArgs.Mode == search.ZoektGlobalSearch
-	request, err := zoektutil.NewIndexedSearchRequest(ctx, &newArgs, globalSearch, search.TextRequest, func([]*search.RepositoryRevisions) {})
+	request, err := zoektutil.NewIndexedSearchRequest(ctx, &newArgs, search.TextRequest, func([]*search.RepositoryRevisions) {})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/search/textsearch/textsearch_test.go
+++ b/internal/search/textsearch/textsearch_test.go
@@ -99,8 +99,7 @@ func TestRepoSubsetTextSearch(t *testing.T) {
 		SearcherURLs: endpoint.Static("test"),
 	}
 
-	globalSearch := args.Mode == search.ZoektGlobalSearch
-	zoektArgs, err := zoektutil.NewIndexedSearchRequest(context.Background(), args, globalSearch, search.TextRequest, func([]*search.RepositoryRevisions) {})
+	zoektArgs, err := zoektutil.NewIndexedSearchRequest(context.Background(), args, search.TextRequest, func([]*search.RepositoryRevisions) {})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,8 +139,7 @@ func TestRepoSubsetTextSearch(t *testing.T) {
 		SearcherURLs: endpoint.Static("test"),
 	}
 
-	globalSearch = args.Mode == search.ZoektGlobalSearch
-	zoektArgs, err = zoektutil.NewIndexedSearchRequest(context.Background(), args, globalSearch, search.TextRequest, func([]*search.RepositoryRevisions) {})
+	zoektArgs, err = zoektutil.NewIndexedSearchRequest(context.Background(), args, search.TextRequest, func([]*search.RepositoryRevisions) {})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -216,8 +214,7 @@ func TestSearchFilesInReposStream(t *testing.T) {
 		SearcherURLs: endpoint.Static("test"),
 	}
 
-	globalSearch := args.Mode == search.ZoektGlobalSearch
-	zoektArgs, err := zoektutil.NewIndexedSearchRequest(context.Background(), args, globalSearch, search.TextRequest, func([]*search.RepositoryRevisions) {})
+	zoektArgs, err := zoektutil.NewIndexedSearchRequest(context.Background(), args, search.TextRequest, func([]*search.RepositoryRevisions) {})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -298,8 +295,7 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 		return []git.Ref{{Name: "refs/heads/branch3"}, {Name: "refs/heads/branch4"}}, nil
 	}
 
-	globalSearch := args.Mode == search.ZoektGlobalSearch
-	zoektArgs, err := zoektutil.NewIndexedSearchRequest(context.Background(), args, globalSearch, search.TextRequest, func([]*search.RepositoryRevisions) {})
+	zoektArgs, err := zoektutil.NewIndexedSearchRequest(context.Background(), args, search.TextRequest, func([]*search.RepositoryRevisions) {})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -137,9 +137,7 @@ type TextParameters struct {
 
 	Repos []*RepositoryRevisions
 
-	// perf: For global queries, we only resolve private repos.
-	UserPrivateRepos []types.MinimalRepo
-	Mode             GlobalSearchMode
+	Mode GlobalSearchMode
 
 	// Query is the parsed query from the user. You should be using Pattern
 	// instead, but Query is useful for checking extra fields that are set and

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -296,11 +296,9 @@ func TestIndexedSearch(t *testing.T) {
 				Zoekt: zoektArgs.Zoekt,
 			}
 
-			globalSearch := args.Mode == search.ZoektGlobalSearch
 			indexed, err := NewIndexedSearchRequest(
 				context.Background(),
 				args,
-				globalSearch,
 				search.TextRequest,
 				MissingRepoRevStatus(streaming.StreamFunc(func(streaming.SearchEvent) {})),
 			)


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/31894

Only `repoHasFile` logic depends on `IndexedSearchRequest` now. But `repoHasFile` can never run in global mode: https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/search/job/job.go?L472-473&subtree=true. So `globalSearch` is always false and this makes `IndexedUniverseSearchRequest` dead.

This also makes `UserPrivateRepos []types.MinimalRepo` in `TextParameters` dead, since it will never be populated (private repos for global search are populated only in global search jobs).

## Test plan
Semantics-preserving.

