### PR TITLE
insights: Add 4 new backend dashboard pings

### DIFF
--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -101,6 +101,11 @@ func getTotalUsersCount(ctx context.Context, db database.DB) (_ int, err error) 
 	return database.Users(db).Count(ctx, &database.UsersListOptions{})
 }
 
+func getTotalOrgsCount(ctx context.Context, db database.DB) (_ int, err error) {
+	defer recordOperation("getTotalUsersCount")(&err)
+	return database.Orgs(db).Count(ctx, database.OrgsListOptions{})
+}
+
 // hasRepo returns true when the instance has at least one repository that isn't
 // soft-deleted nor blocked.
 func hasRepos(ctx context.Context, db database.DB) (_ bool, err error) {
@@ -402,6 +407,12 @@ func updateBody(ctx context.Context, db database.DB) (io.Reader, error) {
 			logFunc("telemetry: updatecheck.getUsersActiveToday failed", "error", err)
 		}
 		r.UniqueUsers = int32(count)
+
+		totalOrgs, err := getTotalOrgsCount(ctx, db)
+		if err != nil {
+			logFunc("telemetry: database.Orgs.Count failed", "error", err)
+		}
+		r.TotalOrgs = int32(totalOrgs)
 
 		r.HasRepos, err = hasRepos(ctx, db)
 		if err != nil {

--- a/cmd/frontend/internal/app/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/updatecheck/handler.go
@@ -198,6 +198,7 @@ type pingRequest struct {
 	InitialAdminEmail             string          `json:"initAdmin"`
 	TosAccepted                   bool            `json:"tosAccepted"`
 	TotalUsers                    int32           `json:"totalUsers"`
+	TotalOrgs                     int32           `json:"totalOrgs"`
 	HasRepos                      bool            `json:"repos"`
 	EverSearched                  bool            `json:"searched"`
 	EverFindRefs                  bool            `json:"refs"`

--- a/enterprise/internal/insights/background/pings/insights_ping_aggregators.go
+++ b/enterprise/internal/insights/background/pings/insights_ping_aggregators.go
@@ -243,8 +243,8 @@ SELECT COUNT(*) FROM dashboard WHERE deleted_at IS NULL;
 const insightsPerDashboardQuery = `
 SELECT
 	AVG(count) AS average,
-	MAX(count) AS max,
 	MIN(count) AS min,
+	MAX(count) AS max,
 	STDDEV(count) AS stddev,
 	PERCENTILE_CONT(0.5) WITHIN GROUP(ORDER BY count) AS median FROM
 	(

--- a/enterprise/internal/insights/background/pings/insights_ping_aggregators.go
+++ b/enterprise/internal/insights/background/pings/insights_ping_aggregators.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	insightTypes "github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -112,6 +113,44 @@ func (e *InsightsPingEmitter) GetOrgVisibleInsightCounts(ctx context.Context) (_
 	return results, nil
 }
 
+func (e *InsightsPingEmitter) GetTotalOrgsWithDashboard(ctx context.Context) (int, error) {
+	total, _, err := basestore.ScanFirstInt(e.insightsDb.QueryContext(ctx, totalOrgsWithDashboardsQuery))
+	if err != nil {
+		return 0, err
+	}
+	return total, nil
+}
+
+func (e *InsightsPingEmitter) GetTotalDashboards(ctx context.Context) (int, error) {
+	total, _, err := basestore.ScanFirstInt(e.insightsDb.QueryContext(ctx, totalDashboardsQuery))
+	if err != nil {
+		return 0, err
+	}
+	return total, nil
+}
+
+func (e *InsightsPingEmitter) GetInsightsPerDashboard(ctx context.Context) (types.InsightsPerDashboardPing, error) {
+	rows, err := e.insightsDb.QueryContext(ctx, insightsPerDashboardQuery)
+	if err != nil {
+		return types.InsightsPerDashboardPing{}, err
+	}
+	defer func() { err = rows.Close() }()
+
+	var insightsPerDashboardStats types.InsightsPerDashboardPing
+	rows.Next()
+	if err := rows.Scan(
+		&insightsPerDashboardStats.Avg,
+		&insightsPerDashboardStats.Min,
+		&insightsPerDashboardStats.Max,
+		&insightsPerDashboardStats.StdDev,
+		&insightsPerDashboardStats.Median,
+	); err != nil {
+		return types.InsightsPerDashboardPing{}, err
+	}
+
+	return insightsPerDashboardStats, nil
+}
+
 func getDays(intervalValue int, intervalUnit insightTypes.IntervalUnit) int {
 	switch intervalUnit {
 	case insightTypes.Month:
@@ -191,4 +230,24 @@ SELECT iv.presentation_type, COUNT(iv.presentation_type) FROM insight_view AS iv
 JOIN insight_view_grants AS ivg ON iv.id = ivg.insight_view_id
 WHERE ivg.org_id IS NOT NULL
 GROUP BY iv.presentation_type;
+`
+
+const totalOrgsWithDashboardsQuery = `
+SELECT COUNT(DISTINCT(org_id)) FROM dashboard_grants WHERE org_id IS NOT NULL;
+`
+
+const totalDashboardsQuery = `
+SELECT COUNT(*) FROM dashboard WHERE deleted_at IS NULL;
+`
+
+const insightsPerDashboardQuery = `
+SELECT
+	AVG(count) AS average,
+	MAX(count) AS max,
+	MIN(count) AS min,
+	STDDEV(count) AS stddev,
+	PERCENTILE_CONT(0.5) WITHIN GROUP(ORDER BY count) AS median FROM
+	(
+		SELECT DISTINCT(dashboard_id), COUNT(insight_view_id) FROM dashboard_insight_view GROUP BY dashboard_id
+	) counts;
 `

--- a/enterprise/internal/insights/background/pings/insights_ping_emitter.go
+++ b/enterprise/internal/insights/background/pings/insights_ping_emitter.go
@@ -48,6 +48,18 @@ func (e *InsightsPingEmitter) emit(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "emitOrgVisibleInsightCounts")
 	}
+	err = e.emitTotalOrgsWithDashboard(ctx)
+	if err != nil {
+		return errors.Wrap(err, "emitTotalOrgsWithDashboard")
+	}
+	err = e.emitTotalDashboards(ctx)
+	if err != nil {
+		return errors.Wrap(err, "emitTotalDashboards")
+	}
+	err = e.emitInsightsPerDashboard(ctx)
+	if err != nil {
+		return errors.Wrap(err, "emitInsightsPerDashboard")
+	}
 	return nil
 }
 
@@ -113,6 +125,60 @@ func (e *InsightsPingEmitter) emitOrgVisibleInsightCounts(ctx context.Context) e
 	}
 
 	err = e.SaveEvent(ctx, usagestats.InsightsOrgVisibleInsightsPingName, marshal)
+	if err != nil {
+		return errors.Wrap(err, "SaveEvent")
+	}
+	return nil
+}
+
+func (e *InsightsPingEmitter) emitTotalOrgsWithDashboard(ctx context.Context) error {
+	counts, err := e.GetTotalOrgsWithDashboard(ctx)
+	if err != nil {
+		return errors.Wrap(err, "GetTotalOrgsWithDashboard")
+	}
+
+	marshal, err := json.Marshal(counts)
+	if err != nil {
+		return errors.Wrap(err, "Marshal")
+	}
+
+	err = e.SaveEvent(ctx, usagestats.InsightsTotalOrgsWithDashboardPingName, marshal)
+	if err != nil {
+		return errors.Wrap(err, "SaveEvent")
+	}
+	return nil
+}
+
+func (e *InsightsPingEmitter) emitTotalDashboards(ctx context.Context) error {
+	counts, err := e.GetTotalDashboards(ctx)
+	if err != nil {
+		return errors.Wrap(err, "GetTotalDashboards")
+	}
+
+	marshal, err := json.Marshal(counts)
+	if err != nil {
+		return errors.Wrap(err, "Marshal")
+	}
+
+	err = e.SaveEvent(ctx, usagestats.InsightsDashboardTotalCountPingName, marshal)
+	if err != nil {
+		return errors.Wrap(err, "SaveEvent")
+	}
+	return nil
+}
+
+func (e *InsightsPingEmitter) emitInsightsPerDashboard(ctx context.Context) error {
+	counts, err := e.GetInsightsPerDashboard(ctx)
+	if err != nil {
+		return errors.Wrap(err, "GetInsightsPerDashboard")
+	}
+
+	marshal, err := json.Marshal(counts)
+	if err != nil {
+		return errors.Wrap(err, "Marshal")
+	}
+
+	err = e.SaveEvent(ctx, usagestats.InsightsPerDashboardPingName, marshal)
 	if err != nil {
 		return errors.Wrap(err, "SaveEvent")
 	}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1230,7 +1230,7 @@ type InsightsPerDashboardPing struct {
 	Max    int
 	Min    int
 	StdDev float32
-	Median int
+	Median float32
 }
 
 type CodeMonitoringUsageStatistics struct {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1160,8 +1160,7 @@ type CodeInsightsUsageStatistics struct {
 	InsightOrgVisible                       []OrgVisibleInsightPing
 	InsightTotalCounts                      InsightTotalCounts
 	TotalOrgsWithDashboard                  *int32
-	TotalOrgs                               *int32
-	WeeklyDashboardCount                    *int32
+	TotalDashboardCount                     *int32
 	InsightsPerDashboard                    InsightsPerDashboardPing
 }
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1159,6 +1159,10 @@ type CodeInsightsUsageStatistics struct {
 	InsightTimeIntervals                    []InsightTimeIntervalPing
 	InsightOrgVisible                       []OrgVisibleInsightPing
 	InsightTotalCounts                      InsightTotalCounts
+	TotalOrgsWithDashboard                  *int32
+	TotalOrgs                               *int32
+	WeeklyDashboardCount                    *int32
+	InsightsPerDashboard                    InsightsPerDashboardPing
 }
 
 type CodeInsightsCriticalTelemetry struct {
@@ -1220,6 +1224,14 @@ type InsightTotalCounts struct {
 	ViewCounts       []InsightViewsCountPing
 	SeriesCounts     []InsightSeriesCountPing
 	ViewSeriesCounts []InsightViewSeriesCountPing
+}
+
+type InsightsPerDashboardPing struct {
+	Avg    float32
+	Max    int
+	Min    int
+	StdDev float32
+	Median int
 }
 
 type CodeMonitoringUsageStatistics struct {

--- a/internal/usagestats/code_insights.go
+++ b/internal/usagestats/code_insights.go
@@ -10,6 +10,7 @@ import (
 	"github.com/lib/pq"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -152,6 +153,31 @@ func GetCodeInsightsUsageStatistics(ctx context.Context, db database.DB) (*types
 	}
 	stats.WeeklyGetStartedTabMoreClickByTab = weeklyGetStartedTabMoreClickByTab
 
+	totalOrgsWithDashboard, err := GetIntCount(ctx, db, InsightsTotalOrgsWithDashboardPingName)
+	if err != nil {
+		return nil, errors.Wrap(err, "GetTotalOrgsWithDashboard")
+	}
+	stats.TotalOrgsWithDashboard = &totalOrgsWithDashboard
+
+	totalOrgs, _, err := basestore.ScanFirstInt(db.QueryContext(ctx, getTotalOrgsSql))
+	if err != nil {
+		return nil, errors.Wrap(err, "GetTotalOrgs")
+	}
+	totalOrgsInt := int32(totalOrgs)
+	stats.TotalOrgs = &totalOrgsInt
+
+	totalDashboards, err := GetIntCount(ctx, db, InsightsDashboardTotalCountPingName)
+	if err != nil {
+		return nil, errors.Wrap(err, "GetTotalDashboards")
+	}
+	stats.WeeklyDashboardCount = &totalDashboards
+
+	insightsPerDashboard, err := GetInsightsPerDashboard(ctx, db)
+	if err != nil {
+		return nil, errors.Wrap(err, "GetInsightsPerDashboard")
+	}
+	stats.InsightsPerDashboard = insightsPerDashboard
+
 	return &stats, nil
 }
 
@@ -252,6 +278,28 @@ func GetOrgInsightCounts(ctx context.Context, db database.DB) ([]types.OrgVisibl
 	return orgVisibleInsightCounts, nil
 }
 
+func GetIntCount(ctx context.Context, db database.DB, pingName string) (int32, error) {
+	store := database.EventLogs(db)
+	all, err := store.ListAll(ctx, database.EventLogsListOptions{
+		LimitOffset: &database.LimitOffset{
+			Limit:  1,
+			Offset: 0,
+		},
+		EventName: &pingName,
+	})
+	if err != nil || len(all) == 0 {
+		return 0, err
+	}
+
+	latest := all[0]
+	var count int
+	err = json.Unmarshal([]byte(latest.Argument), &count)
+	if err != nil {
+		return 0, errors.Wrap(err, "Unmarshal")
+	}
+	return int32(count), nil
+}
+
 func GetCreationViewUsage(ctx context.Context, db database.DB, timeSupplier func() time.Time) ([]types.AggregatedPingStats, error) {
 	builder := creationPagesPingBuilder(timeSupplier)
 
@@ -261,6 +309,31 @@ func GetCreationViewUsage(ctx context.Context, db database.DB, timeSupplier func
 	}
 
 	return results, nil
+}
+
+func GetInsightsPerDashboard(ctx context.Context, db database.DB) (types.InsightsPerDashboardPing, error) {
+	store := database.EventLogs(db)
+	name := InsightsPerDashboardPingName
+	all, err := store.ListAll(ctx, database.EventLogsListOptions{
+		LimitOffset: &database.LimitOffset{
+			Limit:  1,
+			Offset: 0,
+		},
+		EventName: &name,
+	})
+	if err != nil {
+		return types.InsightsPerDashboardPing{}, err
+	} else if len(all) == 0 {
+		return types.InsightsPerDashboardPing{}, nil
+	}
+
+	latest := all[0]
+	var insightsPerDashboardStats types.InsightsPerDashboardPing
+	err = json.Unmarshal([]byte(latest.Argument), &insightsPerDashboardStats)
+	if err != nil {
+		return types.InsightsPerDashboardPing{}, errors.Wrap(err, "Unmarshal")
+	}
+	return insightsPerDashboardStats, nil
 }
 
 // WithAll adds multiple pings by name to this builder
@@ -373,6 +446,13 @@ WHERE name = 'InsightsGetStartedTabMoreClick' AND timestamp > DATE_TRUNC('week',
 GROUP BY argument;
 `
 
+const getTotalOrgsSql = `
+SELECT COUNT(*) FROM orgs WHERE deleted_at IS NOT NULL;
+`
+
 const InsightsTotalCountPingName = `INSIGHT_TOTAL_COUNTS`
 const InsightsIntervalCountsPingName = `INSIGHT_TIME_INTERVALS`
 const InsightsOrgVisibleInsightsPingName = `INSIGHT_ORG_VISIBLE_INSIGHTS`
+const InsightsTotalOrgsWithDashboardPingName = `INSIGHT_TOTAL_ORGS_WITH_DASHBOARD`
+const InsightsDashboardTotalCountPingName = `INSIGHT_DASHBOARD_TOTAL_COUNT`
+const InsightsPerDashboardPingName = `INSIGHTS_PER_DASHBORD_STATS`

--- a/internal/usagestats/code_insights_test.go
+++ b/internal/usagestats/code_insights_test.go
@@ -95,6 +95,9 @@ func TestCodeInsightsUsageStatistics(t *testing.T) {
 		WeeklyFirstTimeInsightCreators:          &oneInt,
 		WeeklyGetStartedTabClickByTab:           []types.InsightGetStartedTabClickPing{},
 		WeeklyGetStartedTabMoreClickByTab:       []types.InsightGetStartedTabClickPing{},
+		WeeklyDashboardCount:                    &zeroInt,
+		TotalOrgs:                               &zeroInt,
+		TotalOrgsWithDashboard:                  &zeroInt,
 	}
 
 	wantedWeeklyUsage := []types.AggregatedPingStats{

--- a/internal/usagestats/code_insights_test.go
+++ b/internal/usagestats/code_insights_test.go
@@ -95,8 +95,7 @@ func TestCodeInsightsUsageStatistics(t *testing.T) {
 		WeeklyFirstTimeInsightCreators:          &oneInt,
 		WeeklyGetStartedTabClickByTab:           []types.InsightGetStartedTabClickPing{},
 		WeeklyGetStartedTabMoreClickByTab:       []types.InsightGetStartedTabClickPing{},
-		WeeklyDashboardCount:                    &zeroInt,
-		TotalOrgs:                               &zeroInt,
+		TotalDashboardCount:                     &zeroInt,
 		TotalOrgsWithDashboard:                  &zeroInt,
 	}
 


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/28374

## Description

This PR adds 4 new backend-calculated insights pings, for dashboards.

- **TotalOrgs**: This ping exists at the top level, outside of `codeInsightsUsage`
- **TotalOrgsWithDashboard**
- **TotalDashboardCount**
- **InsightsPerDashboard** (stats)

[Schema PR](https://github.com/sourcegraph/analytics/pull/364) which needs to be merged in before this one.
[Docs PR](https://github.com/sourcegraph/sourcegraph/pull/32092)

## Test plan

I tested this locally by examining the output of the pings at `site-admin/pings`. Here is an example of the 4 new pings:

```
"totalOrgs": 6,        
"codeInsightsUsage": {
        "InsightsPerDashboard": {
            "Avg": 3.3703704,
            "Max": 10,
            "Min": 1,
            "Median": 3,
            "StdDev": 2.6039636
        },
        "TotalDashboardCount": 41,
        "TotalOrgsWithDashboard": 4,
        ... (rest of our existing pings)
}
```