### PR TITLE
Remove core Bootstrap transitions

### DIFF
--- a/client/branded/src/global-styles/collapse.scss
+++ b/client/branded/src/global-styles/collapse.scss
@@ -1,0 +1,17 @@
+.fade {
+    &:not(.show) {
+        opacity: 0;
+    }
+}
+
+.collapse {
+    &:not(.show) {
+        display: none;
+    }
+}
+
+.collapsing {
+    position: relative;
+    height: 0;
+    overflow: hidden;
+}

--- a/client/branded/src/global-styles/index.scss
+++ b/client/branded/src/global-styles/index.scss
@@ -85,8 +85,8 @@ $table-border-color: var(--border-color);
 $hr-border-color: var(--border-color);
 $hr-margin-y: 0.25rem;
 
-// Disable transitions
-$input-transition: none;
+// Disable all Bootstrap transitions
+$enable-transitions: false;
 
 // Spacer
 $spacer: 1rem;
@@ -102,7 +102,6 @@ $spacer: 1rem;
 @import 'bootstrap/scss/reboot';
 @import 'bootstrap/scss/utilities';
 @import 'bootstrap/scss/grid';
-@import 'bootstrap/scss/transitions';
 
 // Modified in `./buttons.scss`
 @import 'bootstrap/scss/buttons';
@@ -129,6 +128,7 @@ $spacer: 1rem;
 @import './highlight';
 @import './tabs';
 @import './progress';
+@import './collapse';
 
 * {
     box-sizing: border-box;

--- a/client/search-ui/src/results/sidebar/SearchSidebarSection.tsx
+++ b/client/search-ui/src/results/sidebar/SearchSidebarSection.tsx
@@ -89,8 +89,6 @@ export const SearchSidebarSection: React.FunctionComponent<{
         }
 
         const [collapsed, setCollapsed] = useState(startCollapsed)
-        useEffect(() => setCollapsed(startCollapsed), [startCollapsed])
-
         return visible ? (
             <div className={classNames(styles.sidebarSection, className)}>
                 <Button

--- a/client/shared/src/hover/HoverOverlay.module.scss
+++ b/client/shared/src/hover/HoverOverlay.module.scss
@@ -14,7 +14,6 @@
     min-width: 6rem;
     max-width: 34rem; // was 32rem; + 2rem to fit maximum code intel alert text
     z-index: 100;
-    transition: opacity 100ms ease-in-out;
     // Make sure content doesn't leak behind border-radius
     overflow: hidden;
     padding-bottom: var(--hover-overlay-vertical-padding);


### PR DESCRIPTION
## Test plan
Run web app on home page
Type in / Search in any keyword of your choice
On results page, click to toggle sections header on LHS
Confirm that the click event does not cause multiple Toggle

## Problem
`collapsed` state, was being controlled both internally (`collapsed`) and externally (`startCollapsed`)

## Demo
https://www.loom.com/share/52b54c3903bd4b50880bf51695559c9b

## Ref
[SG Issue](https://github.com/sourcegraph/sourcegraph/issues/28901)
[Gitstart Issue](https://app.gitstart.com/clients/sourcegraph/tickets/SG-28901)

