### PR TITLE
Code Insights: Fix in-product landing page for the customers who don't have any TODO matches 

### DIFF
--- a/client/web/src/enterprise/insights/core/backend/gql-api/code-insights-gql-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-api/code-insights-gql-backend.ts
@@ -492,4 +492,4 @@ export class CodeInsightsGqlBackend implements CodeInsightsBackend {
 
 const getRepositoryName = (
     result: ApolloQueryResult<ExampleTodoRepositoryResult | ExampleFirstRepositoryResult>
-): string => result.data.search?.results.repositories[0].name || ''
+): string => result.data.search?.results.repositories[0]?.name || ''


### PR DESCRIPTION
## The problem 

Prior to this PR in case a customer doesn't have any TODO search matches we failed our landing page in a bad (completely inaccessible) way - by rendering a full-page runtime error. This was happening because our FE response parsers weren't correct. 

The following expression will throw an error in case if repositories array is empty (not undefined this is important but empty)  

```ts
result.data.search?.results.repositories[0].name || ''
```

This PR simply fixes this problem by adding another nullish operator for the `repositories` field 
```ts
result.data.search?.results.repositories[0]?.name || ''
```

## Test plan

- Open the in-product landing page and check that the first dynamic insight example section is still working properly
- Check the in-product landing page on the account where there are no repositories with TODO (you should see a fallback - the first indexed repo)


## Why did this happen

- Well I was sure and I believe @unclejustin also that this statement `search?.results.repositories[0].name` should work 
properly for this corner case
- We didn't test this in a real account where we don't have any matches and this is why we didn't catch this

## Follow up work 
I gather my thoughs on how we could avoid problems like this in the future https://github.com/sourcegraph/sourcegraph/issues/31908
