### PR TITLE
Code Insights: Hide Code Insights global nav-bar item for the cloud accounts

### DIFF
--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -189,7 +189,14 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
 
     // CodeInsightsEnabled props controls insights appearance over OSS and Enterprise version
     // isCodeInsightsEnabled selector controls appearance based on user settings flags
-    const codeInsights = props.authenticatedUser && codeInsightsEnabled && isCodeInsightsEnabled(props.settingsCascade)
+    const codeInsights =
+        // This is temporal gate check since cloud landing page hasn't been released yet and
+        // cloud doesn't support code insights yet. Remove this line when code insights cloud
+        // landing page will be released
+        !isSourcegraphDotCom &&
+        props.authenticatedUser &&
+        codeInsightsEnabled &&
+        isCodeInsightsEnabled(props.settingsCascade)
     const [hasInsightPageBeenViewed] = useTemporarySetting('insights.wasMainPageOpen', false)
 
     const searchNavBar = (


### PR DESCRIPTION

This PR adds a temporal gate check since the cloud landing page hasn't been released yet and
the cloud itself doesn't support code insights yet. Remove this check when the code insights cloud
landing page will be released. In this PR https://github.com/sourcegraph/sourcegraph/pull/31704

## Test plan
- Check that cloud account (sign in/sign out) can't see the code insights navbar item
