### PR TITLE
gitserver: relax npm package file limits

### DIFF
--- a/cmd/gitserver/server/vcs_syncer_npm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages.go
@@ -447,11 +447,16 @@ func copyTarFileEntry(header *tar.Header, tarReader *tar.Reader, outputPath stri
 	}
 	// For reference, "pathological" code like SQLite's amalgamation file is
 	// about 7.9 MiB. So a 15 MiB limit seems good enough.
-	const sizeLimitMiB = 15
-	if header.Size >= (sizeLimitMiB * 1024 * 1024) {
-		return errors.Errorf("file size for %s (%d bytes) exceeded limit (%d MiB)",
-			path.Base(outputPath), header.Size, sizeLimitMiB)
+	const sizeLimit = 15 * 1024 * 1024
+	if header.Size >= sizeLimit {
+		log15.Warn("skipping large file in npm package",
+			"path", outputPath,
+			"size", header.Size,
+			"limit", sizeLimit,
+		)
+		return nil
 	}
+
 	if err = os.MkdirAll(path.Dir(outputPath), 0700); err != nil {
 		return err
 	}

--- a/cmd/gitserver/server/vcs_syncer_npm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages.go
@@ -408,9 +408,7 @@ func decompressTgz(tgzReadSeeker namedReadSeeker, destination string) (err error
 
 	return withTgz(tgzReadSeeker, func(tarReader *tar.Reader) (err error) {
 		destinationDir := strings.TrimSuffix(destination, string(os.PathSeparator)) + string(os.PathSeparator)
-		count := 0
-		tarballFileLimit := 10000
-		for count < tarballFileLimit {
+		for {
 			header, err := tarReader.Next()
 			if err == io.EOF {
 				return nil
@@ -431,12 +429,10 @@ func decompressTgz(tgzReadSeeker namedReadSeeker, destination string) (err error
 				if err != nil {
 					return err
 				}
-				count++
 			default:
 				return errors.Errorf("unrecognized type of header %+v in tarball for %s", header.Typeflag, tgzReadSeeker.name)
 			}
 		}
-		return errors.Errorf("number of files in tarball for %s exceeded limit (10000)", tgzReadSeeker.name)
 	})
 }
 


### PR DESCRIPTION
## Background

Many packages in production [fail to clone](https://sourcegraph.grafana.net/explore?left=%7B%22datasource%22:%22grafanacloud-sourcegraph-logs%22,%22queries%22:%5B%7B%22expr%22:%22%7Bnamespace%3D%5C%22prod%5C%22,%20app%3D%5C%22repo-updater%5C%22%7D%20%7C%3D%20%5C%22npm%5C%22%20%7C%3D%20%5C%22size%5C%22%22,%22queryType%22:%22randomWalk%22,%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22grafanacloud-logs%22%7D%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D&orgId=1) due to hitting the current file limits (max files and max size).

This PR:
- Makes us skip any files larger than the existing 15MB limit instead of hard failing the whole clone. 
- Removes the maximum file limit per package. Happy to revert this commit after discussing the usefulness of enforcing this limit.

## Test plan

Existing unit and integration tests should tell us this patch introduces no regression.

