### PR TITLE
ci: add number field to analytics report

### DIFF
--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -49,6 +49,7 @@ function go_test() {
   "run_env": {
     "CI": "buildkite",
     "key": "$BUILDKITE_BUILD_ID",
+    "number": "$BUILDKITE_BUILD_NUMBER",
     "job_id": "$BUILDKITE_JOB_ID",
     "branch": "$BUILDKITE_BRANCH",
     "commit_sha": "$BUILDKITE_COMMIT",

--- a/dev/ci/yarn-test.sh
+++ b/dev/ci/yarn-test.sh
@@ -44,6 +44,7 @@ function yarn_test() {
   "run_env": {
     "CI": "buildkite",
     "key": "$BUILDKITE_BUILD_ID",
+    "number": "$BUILDKITE_BUILD_NUMBER",
     "job_id": "$BUILDKITE_JOB_ID",
     "branch": "$BUILDKITE_BRANCH",
     "commit_sha": "$BUILDKITE_COMMIT",


### PR DESCRIPTION
Buildkite Analytics recently updated their app, which now require to add the build number in order to link back to the original build. 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

An analytics build report will now link back to the BK build, showing that this is working.
