### PR TITLE
Remove debug log statement from BlobPanel

### DIFF
--- a/client/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/client/web/src/repo/blob/panel/BlobPanel.tsx
@@ -214,7 +214,6 @@ function maxPanelResultsFromSettings(settingsCascade: SettingsCascadeOrError<Set
 
 function preferAbsoluteTimestampsFromSettings(settingsCascade: SettingsCascadeOrError<Settings>): boolean {
     if (settingsCascade.final && !isErrorLike(settingsCascade.final)) {
-        console.log(settingsCascade.final['history.preferAbsoluteTimestamps'])
         return settingsCascade.final['history.preferAbsoluteTimestamps'] as boolean
     }
     return false


### PR DESCRIPTION
Removes a debug log statement I added in #31837


## Test plan

- Ran `sg start`, visited `sourcegraph.test:3443`, made sure that `true`/`false` don't show up on console anymore

