### PR TITLE
search: Quickly sync new versions of dependency repos

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -325,6 +325,11 @@ func (s *Server) repoLookup(ctx context.Context, args protocol.RepoLookupArgs) (
 		return nil, err
 	}
 
+	if s.Scheduler != nil && args.Update {
+		// Enqueue a high priority update for this repo.
+		s.Scheduler.UpdateOnce(repo.ID, repo.Name)
+	}
+
 	repoInfo := protocol.NewRepoInfo(repo)
 
 	return &protocol.RepoLookupResult{Repo: repoInfo}, nil

--- a/internal/codeintel/stores/dbstore/repos.go
+++ b/internal/codeintel/stores/dbstore/repos.go
@@ -176,11 +176,22 @@ type NPMDependencyRepo struct {
 }
 
 // UpsertDependencyRepo creates the given dependency repo if it doesn't yet exist.
-func (s *Store) UpsertDependencyRepo(ctx context.Context, dep reposource.PackageDependency) (err error) {
-	return s.Exec(ctx, sqlf.Sprintf(
+func (s *Store) UpsertDependencyRepo(ctx context.Context, dep reposource.PackageDependency) (isNew bool, err error) {
+	res, err := s.ExecResult(ctx, sqlf.Sprintf(
 		`insert into lsif_dependency_repos (scheme, name, version) values (%s, %s, %s) on conflict do nothing`,
 		dep.Scheme(),
 		dep.PackageSyntax(),
 		dep.PackageVersion(),
 	))
+
+	if err != nil {
+		return false, err
+	}
+
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+
+	return affected == 1, nil
 }

--- a/internal/codeintel/stores/dbstore/repos_test.go
+++ b/internal/codeintel/stores/dbstore/repos_test.go
@@ -38,16 +38,24 @@ func TestUpsertDependencyRepo(t *testing.T) {
 	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
-	for _, dep := range []reposource.PackageDependency{
-		parseNPMDependency(t, "bar@2.0.0"),
-		parseNPMDependency(t, "bar@2.0.0"),
-		parseNPMDependency(t, "bar@3.0.0"),
-		parseNPMDependency(t, "foo@1.0.0"),
-		parseNPMDependency(t, "foo@1.0.0"),
-		parseNPMDependency(t, "foo@2.0.0"),
+	for _, dep := range []struct {
+		reposource.PackageDependency
+		isNew bool
+	}{
+		{parseNPMDependency(t, "bar@2.0.0"), true},
+		{parseNPMDependency(t, "bar@2.0.0"), false},
+		{parseNPMDependency(t, "bar@3.0.0"), true},
+		{parseNPMDependency(t, "foo@1.0.0"), true},
+		{parseNPMDependency(t, "foo@1.0.0"), false},
+		{parseNPMDependency(t, "foo@2.0.0"), true},
 	} {
-		if err := store.UpsertDependencyRepo(ctx, dep); err != nil {
+		isNew, err := store.UpsertDependencyRepo(ctx, dep)
+		if err != nil {
 			t.Fatal(err)
+		}
+
+		if have, want := isNew, dep.isNew; have != want {
+			t.Fatalf("%s: want isNew=%t, have %t", dep.PackageManagerSyntax(), want, have)
 		}
 	}
 

--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -464,6 +464,7 @@ func (s *updateScheduler) ScheduleInfo(id api.RepoID) *protocol.RepoUpdateSchedu
 			Index:    update.Index,
 			Total:    len(s.updateQueue.index),
 			Updating: update.Updating,
+			Priority: int(update.Priority),
 		}
 	}
 	s.updateQueue.mu.Unlock()

--- a/internal/repoupdater/protocol/repoupdater.go
+++ b/internal/repoupdater/protocol/repoupdater.go
@@ -40,6 +40,7 @@ type RepoQueueState struct {
 	Index    int
 	Total    int
 	Updating bool
+	Priority int
 }
 
 // RepoExternalServicesRequest is a request for the external services
@@ -56,15 +57,17 @@ type RepoExternalServicesResponse struct {
 }
 
 // RepoLookupArgs is a request for information about a repository on repoupdater.
-//
-// Exactly one of Repo and ExternalRepo should be set.
 type RepoLookupArgs struct {
 	// Repo is the repository name to look up.
 	Repo api.RepoName `json:",omitempty"`
+
+	// Update will enqueue a high priority git update for this repo if it exists and this
+	// field is true.
+	Update bool
 }
 
 func (a *RepoLookupArgs) String() string {
-	return fmt.Sprintf("RepoLookupArgs{%s}", a.Repo)
+	return fmt.Sprintf("RepoLookupArgs{Repo: %s, Update: %t}", a.Repo, a.Update)
 }
 
 // RepoLookupResult is the response to a repository information request (RepoLookupArgs).


### PR DESCRIPTION
## Background

We recently introduced a way to lazy sync package repos via repo-updater's lookup endpoint.
This worked well for entirely new package repos, but not new versions of existing package repos,
since we don't enqueue a high priority update for existing repos.

This PR addresses that problem by introducing an Update argument to the
endpoint that allows us to request such an update. We could just issue
an additional request to the enqueue-repo-update endpoint, but this approach avoids the extra roundtrip.

## Test plan

Unit and integration tests.

