### PR TITLE
sg migration: prefer ENV vars from config, fallback to process env

### DIFF
--- a/dev/sg/sg_migration.go
+++ b/dev/sg/sg_migration.go
@@ -100,6 +100,16 @@ var (
 )
 
 func makeRunner(ctx context.Context, schemaNames []string) (cliutil.Runner, error) {
+	// Try to read the `sg` configuration so we can read ENV vars from the
+	// configuration and use process env as fallback.
+	var getEnv func(string) string
+	ok, _ := parseConf(*configFlag, *overwriteConfigFlag)
+	if ok {
+		getEnv = globalConf.GetEnv
+	} else {
+		getEnv = os.Getenv
+	}
+
 	storeFactory := func(db *sql.DB, migrationsTable string) connections.Store {
 		return connections.NewStoreShim(store.NewWithDB(db, migrationsTable, store.NewOperations(&observation.TestContext)))
 	}
@@ -107,7 +117,7 @@ func makeRunner(ctx context.Context, schemaNames []string) (cliutil.Runner, erro
 	if err != nil {
 		return nil, err
 	}
-	r, err := connections.RunnerFromDSNsWithSchemas(postgresdsn.RawDSNsBySchema(schemaNames), "sg", storeFactory, schemas)
+	r, err := connections.RunnerFromDSNsWithSchemas(postgresdsn.RawDSNsBySchema(schemaNames, getEnv), "sg", storeFactory, schemas)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/postgresdsn/schema.go
+++ b/internal/database/postgresdsn/schema.go
@@ -9,7 +9,7 @@ import (
 )
 
 func DSNsBySchema(schemaNames []string) (map[string]string, error) {
-	dsns := RawDSNsBySchema(schemaNames)
+	dsns := RawDSNsBySchema(schemaNames, os.Getenv)
 
 	// We set this envvar in development to disable the following check
 	if os.Getenv("CODEINTEL_PG_ALLOW_SINGLE_DB") == "" {
@@ -26,7 +26,7 @@ func DSNsBySchema(schemaNames []string) (map[string]string, error) {
 	return dsns, nil
 }
 
-func RawDSNsBySchema(schemaNames []string) map[string]string {
+func RawDSNsBySchema(schemaNames []string, getenv func(string) string) map[string]string {
 	username := ""
 	if user, err := user.Current(); err == nil {
 		username = user.Username
@@ -34,7 +34,7 @@ func RawDSNsBySchema(schemaNames []string) map[string]string {
 
 	dsns := make(map[string]string, len(schemaNames))
 	for _, schemaName := range schemaNames {
-		dsns[schemaName] = New(schemaName, username, os.Getenv)
+		dsns[schemaName] = New(schemaName, username, getenv)
 	}
 
 	return dsns


### PR DESCRIPTION
This fixes #31919 and with it the last reason for having `PG*` env vars set in an environment. Rest should now be in `sg.config.yaml`.

## Test plan

- Unset `PG*` env vars in my `.envrc`
- `env | grep PG` to confirm they're gone in new shell
-  In `dev/sg`: `go run . migration up` to confirm it works



