### PR TITLE
Search backend: fix symbol duplication

### DIFF
--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -72,10 +72,10 @@ func searchInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, pat
 
 	// All symbols are from the same repo, so we can just partition them by path
 	// to build file matches
-	symbolsByPath := make(map[string][]*result.Symbol)
+	symbolsByPath := make(map[string][]result.Symbol)
 	for _, symbol := range symbols {
 		cur := symbolsByPath[symbol.Path]
-		symbolsByPath[symbol.Path] = append(cur, &symbol)
+		symbolsByPath[symbol.Path] = append(cur, symbol)
 	}
 
 	// Create file matches from partitioned symbols
@@ -92,7 +92,7 @@ func searchInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, pat
 		for _, symbol := range symbols {
 			symbolMatches = append(symbolMatches, &result.SymbolMatch{
 				File:   &file,
-				Symbol: *symbol,
+				Symbol: symbol,
 			})
 		}
 


### PR DESCRIPTION
This fixes an issue where we would return duplicate symbols. This was happening because we were capturing a reference to a loop variable. 

Maybe we should look at enabling https://github.com/kyoh86/exportloopref in our linters.

Fixes https://github.com/sourcegraph/sourcegraph/issues/31934


Before: 
<img width="1284" alt="Screen Shot 2022-02-28 at 11 32 08" src="https://user-images.githubusercontent.com/12631702/156038527-4a0f524c-41ed-4fcc-abb6-f6a8868cddaf.png">

After:
<img width="1280" alt="Screen Shot 2022-02-28 at 11 32 33" src="https://user-images.githubusercontent.com/12631702/156038542-1c98861c-ea46-4b10-a973-2445d9960f56.png">


## Test plan

Manually tested the minimal bug fix. I will followup with a PR that extracts that chunk of code and tests it.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


