### PR TITLE
symbols: Fix duplicate symbols

### DIFF
--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -72,6 +72,10 @@ func searchInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, pat
 
 	// All symbols are from the same repo, so we can just partition them by path
 	// to build file matches
+	return symbolsToMatches(symbols, repoRevs.Repo, commitID, inputRev), err
+}
+
+func symbolsToMatches(symbols []result.Symbol, repo types.MinimalRepo, commitID api.CommitID, inputRev string) result.Matches {
 	symbolsByPath := make(map[string][]result.Symbol)
 	for _, symbol := range symbols {
 		cur := symbolsByPath[symbol.Path]
@@ -83,7 +87,7 @@ func searchInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, pat
 	for path, symbols := range symbolsByPath {
 		file := result.File{
 			Path:     path,
-			Repo:     repoRevs.Repo,
+			Repo:     repo,
 			CommitID: commitID,
 			InputRev: &inputRev,
 		}
@@ -104,7 +108,7 @@ func searchInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, pat
 
 	// Make the results deterministic
 	sort.Sort(matches)
-	return matches, err
+	return matches
 }
 
 // indexedSymbols checks to see if Zoekt has indexed symbols information for a

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -72,10 +72,10 @@ func searchInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, pat
 
 	// All symbols are from the same repo, so we can just partition them by path
 	// to build file matches
-	symbolsByPath := make(map[string][]*result.Symbol)
+	symbolsByPath := make(map[string][]result.Symbol)
 	for _, symbol := range symbols {
 		cur := symbolsByPath[symbol.Path]
-		symbolsByPath[symbol.Path] = append(cur, &symbol)
+		symbolsByPath[symbol.Path] = append(cur, symbol)
 	}
 
 	// Create file matches from partitioned symbols
@@ -92,7 +92,7 @@ func searchInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, pat
 		for _, symbol := range symbols {
 			symbolMatches = append(symbolMatches, &result.SymbolMatch{
 				File:   &file,
-				Symbol: *symbol,
+				Symbol: symbol,
 			})
 		}
 

--- a/internal/search/symbol/symbol_test.go
+++ b/internal/search/symbol/symbol_test.go
@@ -1,0 +1,50 @@
+package symbol
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func TestSymbolsToMatches(t *testing.T) {
+	type fileType struct {
+		Path    string
+		Symbols []string
+	}
+
+	fixture := []fileType{
+		{Path: "path1", Symbols: []string{"sym1"}},
+		{Path: "path2", Symbols: []string{"sym1", "sym2"}},
+	}
+
+	input := []result.Symbol{}
+	for _, file := range fixture {
+		for _, symbol := range file.Symbols {
+			input = append(input, result.Symbol{Path: file.Path, Name: symbol})
+		}
+	}
+
+	output := symbolsToMatches(input, types.MinimalRepo{Name: "somerepo"}, "abcdef", "abcdef")
+
+	got := []fileType{}
+	for _, match := range output {
+		fileMatch := match.(*result.FileMatch)
+		symbols := []string{}
+		for _, symbol := range fileMatch.Symbols {
+			symbols = append(symbols, symbol.Symbol.Name)
+		}
+		got = append(got, fileType{
+			Path:    fileMatch.Path,
+			Symbols: symbols,
+		})
+	}
+
+	want := fixture
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("symbolsToMatches() returned diff (-got +want):\n%s", diff)
+	}
+}


### PR DESCRIPTION
Caused by https://github.com/sourcegraph/sourcegraph/pull/20310/files?w=1#r816133824

Resolves https://github.com/sourcegraph/sourcegraph/issues/31934

Images from Camden's PR

Before: 
<img width="1284" alt="Screen Shot 2022-02-28 at 11 32 08" src="https://user-images.githubusercontent.com/12631702/156038527-4a0f524c-41ed-4fcc-abb6-f6a8868cddaf.png">

After:
<img width="1280" alt="Screen Shot 2022-02-28 at 11 32 33" src="https://user-images.githubusercontent.com/12631702/156038542-1c98861c-ea46-4b10-a973-2445d9960f56.png">



## Test plan

Added a test.
