### PR TITLE
Enable exportloopref lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,7 @@ linters:
     - unconvert
     - unused
     - unparam
+    - exportloopref
 
 linters-settings:
   depguard:

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -241,6 +241,7 @@ func TestSearchResolver_DynamicFilters(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.descr, func(t *testing.T) {
 			for _, globbing := range []bool{true, false} {
+				globbing := globbing // avoid a reference to the loop variable
 				MockDecodedViewerFinalSettings.SearchGlobbing = &globbing
 				actualDynamicFilters := (&SearchResultsResolver{db: database.NewMockDB(), Matches: test.searchResults}).DynamicFilters(context.Background())
 				actualDynamicFilterStrs := make(map[string]int)

--- a/enterprise/internal/codeintel/policies/matcher.go
+++ b/enterprise/internal/codeintel/policies/matcher.go
@@ -256,9 +256,10 @@ func (m *Matcher) matchCommitPolicies(ctx context.Context, context matcherContex
 				continue
 			}
 
+			id := policy.ID // avoid a reference to the loop variable
 			context.commitMap[policy.Pattern] = append(context.commitMap[policy.Pattern], PolicyMatch{
 				Name:           commit,
-				PolicyID:       &policy.ID,
+				PolicyID:       &id,
 				PolicyDuration: policyDuration,
 			})
 		}

--- a/enterprise/internal/codeintel/stores/lsifstore/documentation.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/documentation.go
@@ -336,6 +336,9 @@ func (s *Store) documentationDefinitions(
 	var found *precise.RangeData
 	for _, rn := range documentData.Document.Ranges {
 		if rn.DocumentationResultID == resultID {
+			//nolint:exportloopref
+			// We immediately break, so there are no more loop iterations, which means
+			// the value of rn will not change.
 			found = &rn
 			break
 		}

--- a/internal/database/migration/definition/definition.go
+++ b/internal/database/migration/definition/definition.go
@@ -307,7 +307,8 @@ func (ds *Definitions) traverse(targetIDs []int, next func(definition Definition
 			}
 
 			for _, id := range next(definition) {
-				newFrontier = append(newFrontier, node{id, &n.id})
+				nodeID := n.id // avoid referencing the loop variable
+				newFrontier = append(newFrontier, node{id, &nodeID})
 			}
 		}
 

--- a/lib/batches/env/var.go
+++ b/lib/batches/env/var.go
@@ -51,6 +51,7 @@ func (v *variable) UnmarshalJSON(data []byte) error {
 
 	for k, value := range kv {
 		v.name = k
+		//nolint:exportloopref // There should only be one iteration, so the value of `value` should not change
 		v.value = &value
 	}
 
@@ -77,6 +78,7 @@ func (v *variable) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	for k, value := range kv {
 		v.name = k
+		//nolint:exportloopref // There should only be one iteration, so the value of `value` should not change
 		v.value = &value
 	}
 


### PR DESCRIPTION
This enables the `exportloopref` [lint](https://github.com/kyoh86/exportloopref), which checks for the footgun of [capturing a reference to
the a loop variable](https://github.com/sourcegraph/sourcegraph/pull/31950#issuecomment-1054549205). I figure if I still hit this even though I explicitly look for it when writing code and reviewing PRs, other people probably do too. After enabling, it exposed a few things that look like actual issues, so this PR also fixes those.

## Test plan

Just adds a lint and fixes violations. I ran `./dev/golangci-lint.sh --config .golangci.yml run` to test it.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


