### PR TITLE
codeintel: Allow dash in scope names.

### DIFF
--- a/internal/conf/reposource/npm_packages.go
+++ b/internal/conf/reposource/npm_packages.go
@@ -14,9 +14,9 @@ import (
 const (
 	// Exported for [NOTE: npm-tarball-filename-workaround].
 	// . is allowed in scope names: for example https://www.npmjs.com/package/@dinero.js/core
-	NPMScopeRegexString = `(?P<scope>[0-9a-z_\\-\\.]+)`
+	NPMScopeRegexString = `(?P<scope>[0-9a-z_\-\.]+)`
 	// . is allowed in package names: for example https://www.npmjs.com/package/highlight.js
-	npmPackageNameRegexString = `(?P<name>[0-9a-z_\\-]+(\.[0-9a-z_\\-]+)*)`
+	npmPackageNameRegexString = `(?P<name>[0-9a-z_\-]+(\.[0-9a-z_\-]+)*)`
 )
 
 var (
@@ -25,7 +25,7 @@ var (
 	scopedPackageNameRegex = lazyregexp.New(
 		`^(@` + NPMScopeRegexString + `/)?` +
 			npmPackageNameRegexString +
-			`@(?P<version>[0-9a-zA-Z_\\-]+(\.[0-9a-zA-Z_\\-]+)*)$`)
+			`@(?P<version>[0-9a-zA-Z_\-]+(\.[0-9a-zA-Z_\-]+)*)$`)
 	npmURLRegex = lazyregexp.New(
 		`^npm/(` + NPMScopeRegexString + `/)?` +
 			npmPackageNameRegexString + `$`)

--- a/internal/conf/reposource/npm_packages_test.go
+++ b/internal/conf/reposource/npm_packages_test.go
@@ -24,6 +24,8 @@ func TestParseNPMDependency(t *testing.T) {
 		{"@scope-package@1.2.3", false},
 		{"@/package@1.2.3", false},
 		{"@scope/@1.2.3", false},
+		{"@dashed-scope/abc@0", true},
+		{"@a.b-c.d-e/f.g--h.ijk-l@0.1-abc", true},
 	}
 	for _, entry := range table {
 		dep, err := ParseNPMDependency(entry.testName)


### PR DESCRIPTION
Due to incorrect regex matching earlier, dashes didn't
work in scope names. I've simplified other surrounding
code as well.

## Test plan

Added unit tests.