### PR TITLE
dev/ci: provide annotation opts as env instead of args

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -2,10 +2,10 @@
 
 set -eu
 
-# HoneyComb's buildevent plumbing.
+# Honeycomb's buildevent plumbing.
 # -------------------------------
 
-echo "--- Setting up HoneyComb tracing for the build"
+echo "~~~ Setting up Honeycomb tracing for the build"
 
 # Record start time if we need to exit
 BUILD_START_TIME=$(curl -H "Authorization: Bearer $BUILDKITE_API_TOKEN" "https://api.buildkite.com/v2/organizations/$BUILDKITE_ORGANIZATION_SLUG/pipelines/$BUILDKITE_PIPELINE_SLUG/builds/$BUILDKITE_BUILD_NUMBER/" | jq -r .started_at)

--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -38,7 +38,7 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 
 RUN apk add --no-cache \
     # We require git 2.34.1 because we use git-repack with flag --write-midx.
-    'git>=2.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
+    'git==2.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
     git-p4 \
     && apk add --no-cache  \
     openssh-client \

--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -38,7 +38,7 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 
 RUN apk add --no-cache \
     # We require git 2.34.1 because we use git-repack with flag --write-midx.
-    'git==2.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
+    'git>=2.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
     git-p4 \
     && apk add --no-cache  \
     openssh-client \

--- a/enterprise/dev/ci/internal/buildkite/buildkite.go
+++ b/enterprise/dev/ci/internal/buildkite/buildkite.go
@@ -310,23 +310,22 @@ type AnnotatedCmdOpts struct {
 // DO NOT use 'buildkite-agent annotate' or 'annotate.sh' directly in scripts.
 func AnnotatedCmd(command string, opts AnnotatedCmdOpts) StepOpt {
 	var annotateOpts string
-
 	if opts.Type == "" {
 		annotateOpts += fmt.Sprintf(" -t %s", AnnotationTypeError)
 	} else {
 		annotateOpts += fmt.Sprintf(" -t %s", opts.Type)
 	}
-
 	if opts.MultiJobContext != "" {
 		annotateOpts += fmt.Sprintf(" -c %q", opts.MultiJobContext)
 	}
+	annotateOpts = fmt.Sprintf("%v %s", opts.IncludeNames, strings.TrimSpace(annotateOpts))
 
 	// ./an is a symbolic link created by the .buildkite/hooks/post-checkout hook.
 	// Its purpose is to keep the command excerpt in the buildkite UI clear enough to
 	// see the underlying command even if prefixed by the annotation script.
-	annotatedCmd := fmt.Sprintf("./an %q %q %q",
-		tracedCmd(command), fmt.Sprintf("%v", opts.IncludeNames), strings.TrimSpace(annotateOpts))
-	return RawCmd(annotatedCmd)
+	annotatedCmd := fmt.Sprintf("./an %q", tracedCmd(command))
+	return flattenStepOpts(RawCmd(annotatedCmd),
+		Env("ANNOTATE_OPTS", annotateOpts))
 }
 
 func Async(async bool) StepOpt {

--- a/enterprise/dev/ci/scripts/annotated-command.sh
+++ b/enterprise/dev/ci/scripts/annotated-command.sh
@@ -1,15 +1,11 @@
 #!/usr/bin/env bash
 
-# This script is designed to wrap commands to run them and pick up the annotations they
-# leave behind for upload.
+# This script is designed to wrap commands to run them and pick up the annotations and
+# test reports they leave behind for upload.
 #
 # An alias for this command, './an', is set up in .buildkite/post-checkout
 
 cmd=$1
-include_names=$2
-shift 2
-# shellcheck disable=SC2124
-annotate_opts="$@"
 
 # Set up directory for annotated command to leave annotations
 annotation_dir="./annotations"
@@ -21,28 +17,41 @@ eval "$cmd"
 exit_code="$?"
 
 # Check for annotations left behind by the command
-echo "--- Uploading annotations"
-for file in "$annotation_dir"/*; do
-  if [ ! -f "$file" ]; then
-    continue
-  fi
+if [ -n "$ANNOTATE_OPTS" ]; then
+  # Parse annotation options:
+  # - args[0] => include_names
+  # - args[1:] => annotate_opts, base options for the ./annotate.sh script
+  # shellcheck disable=SC2086
+  set -- $ANNOTATE_OPTS
+  include_names=$1
+  shift 1
+  # shellcheck disable=SC2124
+  annotate_opts="$@"
 
-  echo "handling $file"
-  name=$(basename "$file")
-  annotate_file_opts=$annotate_opts
+  echo "--- Uploading annotations"
+  echo "include_names=$include_names, annotate_opts=$annotate_opts"
+  for file in "$annotation_dir"/*; do
+    if [ ! -f "$file" ]; then
+      continue
+    fi
 
-  case "$name" in
-    # Append markdown annotations as markdown, and remove the suffix from the name
-    *.md) annotate_file_opts="$annotate_file_opts -m" && name="${name%.*}" ;;
-  esac
+    echo "handling $file"
+    name=$(basename "$file")
+    annotate_file_opts=$annotate_opts
 
-  if [ "$include_names" = "true" ]; then
-    # Set the name of the file as the title of this annotation section
-    annotate_file_opts="-s '$name' $annotate_file_opts"
-  fi
+    case "$name" in
+      # Append markdown annotations as markdown, and remove the suffix from the name
+      *.md) annotate_file_opts="$annotate_file_opts -m" && name="${name%.*}" ;;
+    esac
 
-  # Generate annotation from file contents
-  eval "./enterprise/dev/ci/scripts/annotate.sh $annotate_file_opts <'$file'"
-done
+    if [ "$include_names" = "true" ]; then
+      # Set the name of the file as the title of this annotation section
+      annotate_file_opts="-s '$name' $annotate_file_opts"
+    fi
+
+    # Generate annotation from file contents
+    eval "./enterprise/dev/ci/scripts/annotate.sh $annotate_file_opts <'$file'"
+  done
+fi
 
 exit "$exit_code"

--- a/enterprise/dev/ci/scripts/annotated-command.sh
+++ b/enterprise/dev/ci/scripts/annotated-command.sh
@@ -17,7 +17,7 @@ eval "$cmd"
 exit_code="$?"
 
 # Check for annotations left behind by the command
-if [ -n "$ANNOTATE_OPTS" ]; then
+if [ -n "${ANNOTATE_OPTS-''}" ]; then
   # Parse annotation options:
   # - args[0] => include_names
   # - args[1:] => annotate_opts, base options for the ./annotate.sh script

--- a/enterprise/dev/ci/scripts/annotated-command.sh
+++ b/enterprise/dev/ci/scripts/annotated-command.sh
@@ -19,8 +19,8 @@ exit_code="$?"
 # Check for annotations left behind by the command
 if [ -n "${ANNOTATE_OPTS-''}" ]; then
   # Parse annotation options:
-  # - args[0] => include_names
-  # - args[1:] => annotate_opts, base options for the ./annotate.sh script
+  # - $1 => include_names
+  # - $2... => annotate_opts, base options for the ./annotate.sh script
   # shellcheck disable=SC2086
   set -- $ANNOTATE_OPTS
   include_names=$1

--- a/enterprise/dev/ci/scripts/annotated-command.sh
+++ b/enterprise/dev/ci/scripts/annotated-command.sh
@@ -28,7 +28,7 @@ if [ -n "$ANNOTATE_OPTS" ]; then
   # shellcheck disable=SC2124
   annotate_opts="$@"
 
-  echo "--- Uploading annotations"
+  echo "~~~ Uploading annotations"
   echo "include_names=$include_names, annotate_opts=$annotate_opts"
   for file in "$annotation_dir"/*; do
     if [ ! -f "$file" ]; then


### PR DESCRIPTION
This change allows us to configure multiple "scrapers" on `AnnotatedCmd` more easily by passing the annotation options as an env var, `ANNOTATE_OPTS`, rather than positional arguments. No external API or behavioural changes in this PR.

The next step will be to add a scraper and option builder for test reports uploads (https://github.com/sourcegraph/sourcegraph/pull/31969) as part of https://github.com/sourcegraph/sourcegraph/issues/31409 

Don't mind the branch name, I forgot to change it 😅 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

1. add demo failure: https://github.com/sourcegraph/sourcegraph/commit/c1350d83ffc62984a5d4a0d68c1f5629152681b0
2. verify annotations still render: https://buildkite.com/sourcegraph/sourcegraph/builds/134284

<img width="1194" alt="image" src="https://user-images.githubusercontent.com/23356519/156079223-c2b77093-1f61-4f07-8bfa-37d7f7ec115c.png">
