### PR TITLE
ssbc: Decrease minimum width of editor container

### DIFF
--- a/client/shared/src/components/MonacoEditor.tsx
+++ b/client/shared/src/components/MonacoEditor.tsx
@@ -284,7 +284,7 @@ export class MonacoEditor extends React.PureComponent<Props, State> {
                     // eslint-disable-next-line react/forbid-dom-props
                     style={{
                         height: this.state.computedHeight,
-                        width: 'relative',
+                        position: 'relative',
                     }}
                     data-placeholder={this.props.placeholder}
                     ref={this.setRef}

--- a/client/shared/src/components/MonacoEditor.tsx
+++ b/client/shared/src/components/MonacoEditor.tsx
@@ -284,7 +284,7 @@ export class MonacoEditor extends React.PureComponent<Props, State> {
                     // eslint-disable-next-line react/forbid-dom-props
                     style={{
                         height: this.state.computedHeight,
-                        position: 'relative',
+                        width: 'relative',
                     }}
                     data-placeholder={this.props.placeholder}
                     ref={this.setRef}

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.module.scss
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.module.scss
@@ -9,7 +9,7 @@
     display: flex;
     flex-direction: column;
     flex: 1;
-    min-width: 60%;
+    min-width: 20%;
     height: 100%;
 }
 


### PR DESCRIPTION
closes #30465

Reduce width for smaller windows. In Rob's example you can see there is word wrapping in the workspace when there is still blank space in the right side of the editor. With this fix, wrapping doesnt start until after there extra space in the editor is gone. 

Prior:
<img width="603" alt="Screen Shot 2022-02-28 at 9 11 48 PM" src="https://user-images.githubusercontent.com/67931373/156091618-19dcda2b-db71-4c0c-b6cb-78ff5a6c1a49.png">

Fix:
<img width="1221" alt="Screen Shot 2022-02-28 at 9 09 56 PM" src="https://user-images.githubusercontent.com/67931373/156091419-5079b4f2-2352-4473-bdbb-63068567fe7b.png">

