### PR TITLE
notebooks: support for copying

### DIFF
--- a/client/web/src/integration/notebook.test.ts
+++ b/client/web/src/integration/notebook.test.ts
@@ -455,4 +455,32 @@ https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph@main/-/blob/cli
         // Verify the redirected URL contains the imported notebook id.
         expect(driver.page.url()).toContain('/notebooks/importedId')
     })
+
+    it('Should copy the notebook', async () => {
+        testContext.overrideGraphQL({
+            ...commonSearchGraphQLResults,
+            CreateNotebook: ({ notebook }) => ({
+                createNotebook: notebookFixture(
+                    'copiedId',
+                    notebook.title,
+                    notebook.blocks.map(GQLBlockInputToResponse)
+                ),
+            }),
+        })
+
+        await driver.page.goto(driver.sourcegraphBaseUrl + '/notebooks/n1')
+        await driver.page.waitForSelector('[data-testid="copy-notebook-button"]', { visible: true })
+
+        await Promise.all([
+            // We should be redirected to the copied notebook page, wait for the navigation.
+            driver.page.waitForNavigation({ waitUntil: 'networkidle0' }),
+            driver.page.click('[data-testid="copy-notebook-button"]'),
+        ])
+
+        // Wait for blocks to load.
+        await driver.page.waitForSelector('[data-block-id]', { visible: true })
+
+        // Verify the redirected URL contains the copied notebook id.
+        expect(driver.page.url()).toContain('/notebooks/copiedId')
+    })
 })

--- a/client/web/src/notebooks/notebook/NotebookComponent.story.tsx
+++ b/client/web/src/notebooks/notebook/NotebookComponent.story.tsx
@@ -61,6 +61,7 @@ add('default', () => (
                 showSearchContext={true}
                 platformContext={NOOP_PLATFORM_CONTEXT}
                 exportedFileName="notebook.snb.md"
+                onCopyNotebook={() => NEVER}
             />
         )}
     </WebStory>
@@ -89,6 +90,7 @@ add('default read-only', () => (
                 showSearchContext={true}
                 platformContext={NOOP_PLATFORM_CONTEXT}
                 exportedFileName="notebook.snb.md"
+                onCopyNotebook={() => NEVER}
             />
         )}
     </WebStory>

--- a/client/web/src/notebooks/notebook/NotebookComponent.tsx
+++ b/client/web/src/notebooks/notebook/NotebookComponent.tsx
@@ -1,14 +1,16 @@
 import { noop } from 'lodash'
+import ContentCopyIcon from 'mdi-react/ContentCopyIcon'
 import DownloadIcon from 'mdi-react/DownloadIcon'
 import PlayCircleOutlineIcon from 'mdi-react/PlayCircleOutlineIcon'
 import * as Monaco from 'monaco-editor'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useLocation } from 'react-router'
+import { Redirect } from 'react-router-dom'
 import { Observable, ReplaySubject } from 'rxjs'
-import { filter, map, startWith, switchMap, tap, withLatestFrom } from 'rxjs/operators'
+import { catchError, delay, filter, map, startWith, switchMap, tap, withLatestFrom } from 'rxjs/operators'
 
 import { createHoverifier } from '@sourcegraph/codeintellify'
-import { isDefined, property } from '@sourcegraph/common'
+import { asError, isDefined, isErrorLike, property } from '@sourcegraph/common'
 import { StreamingSearchResultsListProps } from '@sourcegraph/search-ui'
 import { useQueryIntelligence } from '@sourcegraph/search/src/useQueryIntelligence'
 import { ActionItemAction } from '@sourcegraph/shared/src/actions/ActionItem'
@@ -28,7 +30,9 @@ import { Block, BlockDirection, BlockInit, BlockInput, BlockType } from '..'
 import { AuthenticatedUser } from '../../auth'
 import { getHover, getDocumentHighlights } from '../../backend/features'
 import { WebHoverOverlay } from '../../components/WebHoverOverlay'
+import { NotebookFields } from '../../graphql-operations'
 import { getLSPTextDocumentPositionParameters } from '../../repo/blob/Blob'
+import { PageRoutes } from '../../routes.constants'
 import { SearchStreamingProps } from '../../search'
 import { useExperimentalFeatures } from '../../stores'
 import { NotebookFileBlock } from '../blocks/file/NotebookFileBlock'
@@ -40,7 +44,7 @@ import { isMonacoEditorDescendant } from '../blocks/useBlockSelection'
 import { NotebookAddBlockButtons } from './NotebookAddBlockButtons'
 import styles from './NotebookComponent.module.scss'
 
-import { Notebook } from '.'
+import { Notebook, CopyNotebookProps } from '.'
 
 export interface NotebookComponentProps
     extends SearchStreamingProps,
@@ -51,13 +55,14 @@ export interface NotebookComponentProps
     globbing: boolean
     isMacPlatform: boolean
     isReadOnly?: boolean
-    onSerializeBlocks: (blocks: Block[]) => void
     blocks: BlockInit[]
     authenticatedUser: AuthenticatedUser | null
     extensionsController: Pick<ExtensionsController, 'extHostAPI' | 'executeCommand'>
     platformContext: Pick<PlatformContext, 'requestGraphQL' | 'urlToFile' | 'settings' | 'forceUpdateTooltip'>
     exportedFileName: string
     isEmbedded?: boolean
+    onSerializeBlocks: (blocks: Block[]) => void
+    onCopyNotebook: (props: Omit<CopyNotebookProps, 'title'>) => Observable<NotebookFields>
 }
 
 const LOADING = 'LOADING' as const
@@ -87,10 +92,12 @@ function downloadTextAsFile(text: string, fileName: string): void {
 
 export const NotebookComponent: React.FunctionComponent<NotebookComponentProps> = ({
     onSerializeBlocks,
+    onCopyNotebook,
     isReadOnly = false,
     extensionsController,
     exportedFileName,
     isEmbedded,
+    authenticatedUser,
     ...props
 }) => {
     const notebook = useMemo(
@@ -158,6 +165,24 @@ export const NotebookComponent: React.FunctionComponent<NotebookComponentProps> 
         downloadTextAsFile(exportedMarkdown, exportedFileName)
         props.telemetryService.log('SearchNotebookExportNotebook')
     }, [notebook, exportedFileName, props.telemetryService])
+
+    const [copyNotebook, copiedNotebookOrError] = useEventObservable(
+        useCallback(
+            (input: Observable<Omit<CopyNotebookProps, 'title'>>) =>
+                input.pipe(
+                    switchMap(props => onCopyNotebook(props).pipe(delay(400), startWith(LOADING))),
+                    catchError(error => [asError(error)])
+                ),
+            [onCopyNotebook]
+        )
+    )
+
+    const onCopyNotebookButtonClick = useCallback(() => {
+        if (!authenticatedUser) {
+            return
+        }
+        copyNotebook({ namespace: authenticatedUser.id, blocks: notebook.getBlocks() })
+    }, [authenticatedUser, copyNotebook, notebook])
 
     const onBlockInputChange = useCallback(
         (id: string, blockInput: BlockInput) => {
@@ -400,6 +425,7 @@ export const NotebookComponent: React.FunctionComponent<NotebookComponentProps> 
                         <NotebookQueryBlock
                             {...block}
                             {...blockProps}
+                            authenticatedUser={authenticatedUser}
                             hoverifier={hoverifier}
                             sourcegraphSearchLanguageId={sourcegraphSearchLanguageId}
                             extensionsController={extensionsController}
@@ -421,11 +447,16 @@ export const NotebookComponent: React.FunctionComponent<NotebookComponentProps> 
             sourcegraphSearchLanguageId,
             extensionsController,
             hoverifier,
+            authenticatedUser,
         ]
     )
 
     const location = useLocation()
     const coolCodeIntelEnabled = useExperimentalFeatures(features => features.coolCodeIntel)
+
+    if (copiedNotebookOrError && !isErrorLike(copiedNotebookOrError) && copiedNotebookOrError !== LOADING) {
+        return <Redirect to={PageRoutes.Notebook.replace(':id', copiedNotebookOrError.id)} />
+    }
 
     return (
         <div className={styles.searchNotebook} ref={nextNotebookElement}>
@@ -450,6 +481,19 @@ export const NotebookComponent: React.FunctionComponent<NotebookComponentProps> 
                     >
                         <DownloadIcon className="icon-inline mr-1" />
                         <span>Export as Markdown</span>
+                    </Button>
+                )}
+                {!isEmbedded && authenticatedUser && (
+                    <Button
+                        className="mr-2"
+                        variant="secondary"
+                        size="sm"
+                        onClick={onCopyNotebookButtonClick}
+                        data-testid="copy-notebook-button"
+                        disabled={copiedNotebookOrError === LOADING}
+                    >
+                        <ContentCopyIcon className="icon-inline mr-1" />
+                        <span>{copiedNotebookOrError === LOADING ? 'Copying...' : 'Copy to My Notebooks'}</span>
                     </Button>
                 )}
             </div>

--- a/client/web/src/notebooks/notebook/index.ts
+++ b/client/web/src/notebooks/notebook/index.ts
@@ -7,11 +7,29 @@ import { transformSearchQuery } from '@sourcegraph/shared/src/api/client/search'
 import { aggregateStreamingSearch, emptyAggregateResults } from '@sourcegraph/shared/src/search/stream'
 
 import { Block, BlockInit, BlockDependencies, BlockInput, BlockDirection } from '..'
-import { SearchPatternType } from '../../graphql-operations'
+import { NotebookFields, SearchPatternType } from '../../graphql-operations'
 import { LATEST_VERSION } from '../../search/results/StreamingSearchResults'
-import { serializeBlockToMarkdown } from '../serialize'
+import { createNotebook } from '../backend'
+import { blockToGQLInput, serializeBlockToMarkdown } from '../serialize'
 
 const DONE = 'DONE' as const
+
+export interface CopyNotebookProps {
+    title: string
+    blocks: BlockInit[]
+    namespace: string
+}
+
+export function copyNotebook({ title, blocks, namespace }: CopyNotebookProps): Observable<NotebookFields> {
+    return createNotebook({
+        notebook: {
+            title,
+            blocks: blocks.map(blockToGQLInput),
+            namespace,
+            public: false,
+        },
+    })
+}
 
 export class Notebook {
     private blocks: Map<string, Block>

--- a/client/web/src/notebooks/notebookPage/EmbeddedNotebookPage.tsx
+++ b/client/web/src/notebooks/notebookPage/EmbeddedNotebookPage.tsx
@@ -1,6 +1,7 @@
 import { noop } from 'lodash'
 import React, { useEffect, useMemo } from 'react'
 import { useLocation } from 'react-router-dom'
+import { NEVER } from 'rxjs'
 import { catchError, startWith } from 'rxjs/operators'
 
 import { asError, isErrorLike, isMacPlatform } from '@sourcegraph/common'
@@ -79,6 +80,8 @@ export const EmbeddedNotebookPage: React.FunctionComponent<EmbeddedNotebookPageP
                     platformContext={platformContext}
                     extensionsController={extensionsController}
                     exportedFileName={convertNotebookTitleToFileName(notebookOrError.title)}
+                    // Copying is not supported in embedded notebooks
+                    onCopyNotebook={() => NEVER}
                     isEmbedded={true}
                 />
             )}

--- a/client/web/src/notebooks/notebookPage/NotebookContent.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookContent.tsx
@@ -1,5 +1,6 @@
 import { noop } from 'lodash'
 import React, { useMemo } from 'react'
+import { Observable } from 'rxjs'
 
 import { StreamingSearchResultsListProps } from '@sourcegraph/search-ui'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
@@ -9,8 +10,10 @@ import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryServi
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
 import { Block, BlockInit } from '..'
+import { NotebookFields } from '../../graphql-operations'
 import { fetchRepository, resolveRevision } from '../../repo/backend'
 import { SearchStreamingProps } from '../../search'
+import { CopyNotebookProps } from '../notebook'
 import { NotebookComponent } from '../notebook/NotebookComponent'
 
 export interface NotebookContentProps
@@ -27,6 +30,7 @@ export interface NotebookContentProps
     exportedFileName: string
     isEmbedded?: boolean
     onUpdateBlocks: (blocks: Block[]) => void
+    onCopyNotebook: (props: Omit<CopyNotebookProps, 'title'>) => Observable<NotebookFields>
     fetchRepository: typeof fetchRepository
     resolveRevision: typeof resolveRevision
 }

--- a/client/web/src/notebooks/notebookPage/NotebookPage.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookPage.tsx
@@ -36,6 +36,7 @@ import {
     createNotebookStar as _createNotebookStar,
     deleteNotebookStar as _deleteNotebookStar,
 } from '../backend'
+import { copyNotebook as _copyNotebook, CopyNotebookProps } from '../notebook'
 import { blockToGQLInput, convertNotebookTitleToFileName, GQLBlockToGQLInput } from '../serialize'
 
 import { NotebookContent } from './NotebookContent'
@@ -61,6 +62,7 @@ interface NotebookPageProps
     deleteNotebook?: typeof _deleteNotebook
     createNotebookStar?: typeof _createNotebookStar
     deleteNotebookStar?: typeof _deleteNotebookStar
+    copyNotebook?: typeof _copyNotebook
 }
 
 const LOADING = 'loading' as const
@@ -77,6 +79,7 @@ export const NotebookPage: React.FunctionComponent<NotebookPageProps> = ({
     deleteNotebook = _deleteNotebook,
     createNotebookStar = _createNotebookStar,
     deleteNotebookStar = _deleteNotebookStar,
+    copyNotebook = _copyNotebook,
     ...props
 }) => {
     useEffect(() => props.telemetryService.logViewEvent('SearchNotebookPage'), [props.telemetryService])
@@ -159,6 +162,11 @@ export const NotebookPage: React.FunctionComponent<NotebookPageProps> = ({
         (isPublic: boolean, namespace: string) =>
             setUpdateQueue(queue => queue.concat([{ public: isPublic, namespace }])),
         [setUpdateQueue]
+    )
+
+    const onCopyNotebook = useCallback(
+        (props: Omit<CopyNotebookProps, 'title'>) => copyNotebook({ title: `Copy of ${notebookTitle}`, ...props }),
+        [notebookTitle, copyNotebook]
     )
 
     return (
@@ -262,6 +270,7 @@ export const NotebookPage: React.FunctionComponent<NotebookPageProps> = ({
                             onUpdateBlocks={onUpdateBlocks}
                             fetchRepository={fetchRepository}
                             resolveRevision={resolveRevision}
+                            onCopyNotebook={onCopyNotebook}
                             exportedFileName={exportedFileName}
                         />
                         <div className={styles.spacer} />

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -26,6 +26,7 @@ import { HeroPage } from '../../components/HeroPage'
 import { PageTitle } from '../../components/PageTitle'
 import { GlobalCoolCodeIntelProps } from '../../global/CoolCodeIntel'
 import { render as renderLsifHtml } from '../../lsif/html'
+import { copyNotebook, CopyNotebookProps } from '../../notebooks/notebook'
 import { SearchStreamingProps } from '../../search'
 import { useSearchStack, useExperimentalFeatures } from '../../stores'
 import { getExperimentalFeatures } from '../../util/get-experimental-features'
@@ -213,6 +214,15 @@ export const BlobPage: React.FunctionComponent<Props> = props => {
         blobInfoOrError.filePath.endsWith(SEARCH_NOTEBOOK_FILE_EXTENSION) &&
         showSearchNotebook
 
+    const onCopyNotebook = useCallback(
+        (props: Omit<CopyNotebookProps, 'title'>) => {
+            const title =
+                blobInfoOrError && !isErrorLike(blobInfoOrError) ? basename(blobInfoOrError.filePath) : 'Notebook'
+            return copyNotebook({ title: `Copy of ${title}`, ...props })
+        },
+        [blobInfoOrError]
+    )
+
     // If url explicitly asks for a certain rendering mode, renderMode is set to that mode, else it checks:
     // - If file contains richHTML and url does not include a line number: We render in richHTML.
     // - If file does not contain richHTML or the url includes a line number: We render in code view.
@@ -338,6 +348,7 @@ export const BlobPage: React.FunctionComponent<Props> = props => {
                     markdown={blobInfoOrError.content}
                     resolveRevision={resolveRevision}
                     fetchRepository={fetchRepository}
+                    onCopyNotebook={onCopyNotebook}
                     showSearchContext={showSearchContext}
                     exportedFileName={basename(blobInfoOrError.filePath)}
                 />


### PR DESCRIPTION
Fixes #30730

Adds "Copy to My Notebooks" button next to "Run all blocks" and "Export to Markdown" buttons.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

* Create a notebook
* Click on the "Copy to My Notebooks" button
* You should be redirected to the newly copied notebook
* The notebook should be private
* I also added an integration test
