### PR TITLE
Wildcard: Fix `FeedbackPrompt.tsx` spacing visual bug

### DIFF
--- a/client/wildcard/src/components/Feedback/FeedbackPrompt/FeedbackPrompt.tsx
+++ b/client/wildcard/src/components/Feedback/FeedbackPrompt/FeedbackPrompt.tsx
@@ -125,7 +125,7 @@ const FeedbackPromptContent: React.FunctionComponent<FeedbackPromptContentProps>
                 </div>
             ) : (
                 <Form onSubmit={handleSubmit}>
-                    <h3 className="mb-0">What’s on your mind?</h3>
+                    <h3 className="mb-3">What’s on your mind?</h3>
 
                     <FlexTextArea
                         onChange={handleTextChange}
@@ -144,6 +144,7 @@ const FeedbackPromptContent: React.FunctionComponent<FeedbackPromptContentProps>
                         selected={rating}
                         onChange={handleRateChange}
                         disabled={submitting}
+                        className="mt-3"
                     />
                     {submitResponse?.errorMessage && (
                         <ErrorAlert

--- a/client/wildcard/src/components/Feedback/FeedbackPrompt/IconRadioButtons.tsx
+++ b/client/wildcard/src/components/Feedback/FeedbackPrompt/IconRadioButtons.tsx
@@ -14,20 +14,28 @@ interface Props {
     disabled: boolean
     name: string
     selected?: number
+    className?: string
     onChange: (value: number) => void
 }
 
 /**
  * Used to render a list of icons with <input type="radio" />
  */
-export const IconRadioButtons: React.FunctionComponent<Props> = ({ name, icons, selected, onChange, disabled }) => {
+export const IconRadioButtons: React.FunctionComponent<Props> = ({
+    name,
+    icons,
+    selected,
+    onChange,
+    disabled,
+    className,
+}) => {
     const handleChange = useCallback(
         (event: React.ChangeEvent<HTMLInputElement>) => onChange(Number(event.target.value)),
         [onChange]
     )
 
     return (
-        <ul className={styles.buttons}>
+        <ul className={classNames(className, styles.buttons)}>
             {Object.values(icons).map(({ icon: Icon, name: iconName, value }) => (
                 <li key={iconName} className="d-flex">
                     <label className={styles.label}>

--- a/client/wildcard/src/components/Feedback/FeedbackPrompt/__snapshots__/FeedbackPrompt.test.tsx.snap
+++ b/client/wildcard/src/components/Feedback/FeedbackPrompt/__snapshots__/FeedbackPrompt.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`FeedbackPrompt should render correctly 1`] = `
           class=""
         >
           <h3
-            class="mb-0"
+            class="mb-3"
           >
             What’s on your mind?
           </h3>
@@ -66,7 +66,7 @@ exports[`FeedbackPrompt should render correctly 1`] = `
             />
           </label>
           <ul
-            class="buttons"
+            class="mt-3 buttons"
           >
             <li
               class="d-flex"
@@ -282,21 +282,20 @@ exports[`FeedbackPrompt should render submit error correctly 1`] = `
     <div
       aria-modal="true"
       class="floatingPanel dropdown-menu menu"
-      hidden=""
       role="dialog"
     >
       <div
         data-focus-guard="true"
         style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-        tabindex="0"
+        tabindex="-1"
       />
       <div
         data-focus-guard="true"
         style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-        tabindex="1"
+        tabindex="-1"
       />
       <div
-        data-focus-lock-disabled="false"
+        data-focus-lock-disabled="disabled"
       >
         <button
           class="close"
@@ -318,7 +317,7 @@ exports[`FeedbackPrompt should render submit error correctly 1`] = `
           class=""
         >
           <h3
-            class="mb-0"
+            class="mb-3"
           >
             What’s on your mind?
           </h3>
@@ -334,7 +333,7 @@ exports[`FeedbackPrompt should render submit error correctly 1`] = `
             </textarea>
           </label>
           <ul
-            class="buttons"
+            class="mt-3 buttons"
           >
             <li
               class="d-flex"
@@ -539,7 +538,7 @@ exports[`FeedbackPrompt should render submit error correctly 1`] = `
       <div
         data-focus-guard="true"
         style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-        tabindex="0"
+        tabindex="-1"
       />
     </div>
   </div>

--- a/client/wildcard/src/components/Feedback/FeedbackPrompt/__snapshots__/FeedbackPrompt.test.tsx.snap
+++ b/client/wildcard/src/components/Feedback/FeedbackPrompt/__snapshots__/FeedbackPrompt.test.tsx.snap
@@ -282,20 +282,21 @@ exports[`FeedbackPrompt should render submit error correctly 1`] = `
     <div
       aria-modal="true"
       class="floatingPanel dropdown-menu menu"
+      hidden=""
       role="dialog"
     >
       <div
         data-focus-guard="true"
         style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-        tabindex="-1"
+        tabindex="0"
       />
       <div
         data-focus-guard="true"
         style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-        tabindex="-1"
+        tabindex="1"
       />
       <div
-        data-focus-lock-disabled="disabled"
+        data-focus-lock-disabled="false"
       >
         <button
           class="close"
@@ -538,7 +539,7 @@ exports[`FeedbackPrompt should render submit error correctly 1`] = `
       <div
         data-focus-guard="true"
         style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-        tabindex="-1"
+        tabindex="0"
       />
     </div>
   </div>


### PR DESCRIPTION
## Background

Prior to this PR the textarea component had an incorrect visual spacing values. However we had an explicit styles for this input in the CSS modules file. It turned out that `FlexTextarea` component has its own styles `margin: 0` that overrides consumer `FeedbackPrompt` styles. The `FlexTextarea` was added because by default all labels element have some margin values. 

I think the problem here is deeper that it looks like at the first glance. I think that `FlexTextarea` component shouldn't provide element with label as a part of internal implementation component. This makes API of this component more complicated (like having separate className props for the root element and input element it brings some misunderstanding in popular case of usage) Instead of this I think a composition of Label and `FlexTextarea` components right in the consumer would have worked better in our cases. @sourcegraph/frontend-platform-devs what do you think?


## Test plan

- Make sure that `FeedbackPrompt` component has a right spacings between texarea and other form input components.


