### PR TITLE
Experimental ref panel: restore click2j2d behaviour

### DIFF
--- a/client/web/src/components/WebHoverOverlay/WebHoverOverlay.story.tsx
+++ b/client/web/src/components/WebHoverOverlay/WebHoverOverlay.story.tsx
@@ -39,14 +39,7 @@ const { add } = storiesOf('web/WebHoverOverlay', module)
         },
     })
 
-add('Loading', () => (
-    <WebHoverOverlay
-        {...commonProps()}
-        hoverOrError="loading"
-        actionsOrError={FIXTURE_ACTIONS}
-        coolCodeIntelEnabled={false}
-    />
-))
+add('Loading', () => <WebHoverOverlay {...commonProps()} hoverOrError="loading" actionsOrError={FIXTURE_ACTIONS} />)
 
 add('Error', () => (
     <WebHoverOverlay
@@ -57,21 +50,15 @@ add('Error', () => (
             )
         }
         actionsOrError={FIXTURE_ACTIONS}
-        coolCodeIntelEnabled={false}
     />
 ))
 
 add('No hover information', () => (
-    <WebHoverOverlay
-        {...commonProps()}
-        hoverOrError={null}
-        actionsOrError={FIXTURE_ACTIONS}
-        coolCodeIntelEnabled={false}
-    />
+    <WebHoverOverlay {...commonProps()} hoverOrError={null} actionsOrError={FIXTURE_ACTIONS} />
 ))
 
 add('Common content without actions', () => (
-    <WebHoverOverlay {...commonProps()} hoverOrError={{ contents: [FIXTURE_CONTENT] }} coolCodeIntelEnabled={false} />
+    <WebHoverOverlay {...commonProps()} hoverOrError={{ contents: [FIXTURE_CONTENT] }} />
 ))
 
 add('Common content with actions', () => (
@@ -81,7 +68,6 @@ add('Common content with actions', () => (
             contents: [FIXTURE_CONTENT],
         }}
         actionsOrError={FIXTURE_ACTIONS}
-        coolCodeIntelEnabled={false}
     />
 ))
 
@@ -93,7 +79,6 @@ add('Aggregated Badges', () => (
             aggregatedBadges: [FIXTURE_SEMANTIC_BADGE],
         }}
         actionsOrError={FIXTURE_ACTIONS}
-        coolCodeIntelEnabled={false}
     />
 ))
 
@@ -105,7 +90,6 @@ add('Long code', () => (
             aggregatedBadges: [FIXTURE_SEMANTIC_BADGE],
         }}
         actionsOrError={FIXTURE_ACTIONS}
-        coolCodeIntelEnabled={false}
     />
 ))
 
@@ -116,7 +100,6 @@ add('Long text only', () => (
             contents: [FIXTURE_CONTENT_LONG_TEXT_ONLY],
         }}
         actionsOrError={FIXTURE_ACTIONS}
-        coolCodeIntelEnabled={false}
     />
 ))
 
@@ -127,7 +110,6 @@ add('Long markdown with <div>', () => (
             contents: [FIXTURE_CONTENT_MARKDOWN],
         }}
         actionsOrError={FIXTURE_ACTIONS}
-        coolCodeIntelEnabled={false}
     />
 ))
 
@@ -139,7 +121,6 @@ add('Multiple MarkupContents', () => (
             aggregatedBadges: [FIXTURE_SEMANTIC_BADGE],
         }}
         actionsOrError={FIXTURE_ACTIONS}
-        coolCodeIntelEnabled={false}
     />
 ))
 
@@ -152,7 +133,6 @@ add('With small-text alert', () => (
         }}
         actionsOrError={FIXTURE_ACTIONS}
         onAlertDismissed={action('onAlertDismissed')}
-        coolCodeIntelEnabled={false}
     />
 ))
 
@@ -172,7 +152,6 @@ add('With one-line alert', () => (
         }}
         actionsOrError={FIXTURE_ACTIONS}
         onAlertDismissed={action('onAlertDismissed')}
-        coolCodeIntelEnabled={false}
     />
 ))
 
@@ -193,7 +172,6 @@ add('With alert with warning icon', () => (
         }}
         actionsOrError={FIXTURE_ACTIONS}
         onAlertDismissed={action('onAlertDismissed')}
-        coolCodeIntelEnabled={false}
     />
 ))
 
@@ -216,7 +194,6 @@ add('With dismissible alert with icon', () => (
         }}
         actionsOrError={FIXTURE_ACTIONS}
         onAlertDismissed={action('onAlertDismissed')}
-        coolCodeIntelEnabled={false}
     />
 ))
 
@@ -230,7 +207,6 @@ add('With long markdown text and dismissible alert with icon.', () => (
         }}
         actionsOrError={FIXTURE_ACTIONS}
         onAlertDismissed={action('onAlertDismissed')}
-        coolCodeIntelEnabled={false}
     />
 ))
 
@@ -244,6 +220,5 @@ add('Multiple MarkupContents with badges and alerts', () => (
         }}
         actionsOrError={FIXTURE_ACTIONS}
         onAlertDismissed={action('onAlertDismissed')}
-        coolCodeIntelEnabled={false}
     />
 ))

--- a/client/web/src/components/WebHoverOverlay/WebHoverOverlay.tsx
+++ b/client/web/src/components/WebHoverOverlay/WebHoverOverlay.tsx
@@ -46,7 +46,7 @@ export const WebHoverOverlay: React.FunctionComponent<Props> = props => {
     }
 
     const { hoverOrError } = propsToUse
-    const { onHoverShown, hoveredToken, onTokenClick, coolCodeIntelEnabled } = props
+    const { onHoverShown, hoveredToken, coolCodeIntelEnabled } = props
 
     /** Whether the hover has actual content (that provides value to the user) */
     const hoverHasValue = hoverOrError !== 'loading' && !isErrorLike(hoverOrError) && !!hoverOrError?.contents?.length
@@ -91,13 +91,9 @@ export const WebHoverOverlay: React.FunctionComponent<Props> = props => {
                         return
                     }
 
-                    if (coolCodeIntelEnabled && onTokenClick !== undefined && hoveredToken !== undefined) {
-                        onTokenClick(hoveredToken)
-                    } else {
-                        const actionType = action === definitionAction ? 'definition' : 'reference'
-                        props.telemetryService.log(`${actionType}HoverOverlay.click`)
-                        nav(url)
-                    }
+                    const actionType = action === definitionAction ? 'definition' : 'reference'
+                    props.telemetryService.log(`${actionType}HoverOverlay.click`)
+                    nav(url)
                 }),
                 finalize(() => (token.style.cursor = oldCursor))
             )
@@ -112,7 +108,6 @@ export const WebHoverOverlay: React.FunctionComponent<Props> = props => {
         props.telemetryService,
         hoveredToken,
         coolCodeIntelEnabled,
-        onTokenClick,
     ])
 
     const onlyGoToDefinition = Array.isArray(props.actionsOrError)

--- a/client/web/src/components/WebHoverOverlay/WebHoverOverlay.tsx
+++ b/client/web/src/components/WebHoverOverlay/WebHoverOverlay.tsx
@@ -110,18 +110,9 @@ export const WebHoverOverlay: React.FunctionComponent<Props> = props => {
         coolCodeIntelEnabled,
     ])
 
-    const onlyGoToDefinition = Array.isArray(props.actionsOrError)
-        ? props.actionsOrError.filter(
-              a => a.action.id === 'goToDefinition.preloaded' || a.action.id === 'goToDefinition'
-          )
-        : []
-
     return (
         <HoverOverlay
             {...propsToUse}
-            {...(coolCodeIntelEnabled && {
-                actionsOrError: onlyGoToDefinition,
-            })}
             className={styles.webHoverOverlay}
             actionItemClassName="border-0"
             onAlertDismissed={onAlertDismissed}

--- a/client/web/src/components/WebHoverOverlay/WebHoverOverlay.tsx
+++ b/client/web/src/components/WebHoverOverlay/WebHoverOverlay.tsx
@@ -8,7 +8,6 @@ import { NotificationType } from '@sourcegraph/shared/src/api/extension/extensio
 import { HoverOverlay, HoverOverlayProps } from '@sourcegraph/shared/src/hover/HoverOverlay'
 import { AlertProps, useLocalStorage } from '@sourcegraph/wildcard'
 
-import { GlobalCoolCodeIntelProps } from '../../global/CoolCodeIntel'
 import { HoverThresholdProps } from '../../repo/RepoContainer'
 
 import styles from './WebHoverOverlay.module.scss'
@@ -21,7 +20,7 @@ const iconKindToAlertVariant: Record<number, AlertProps['variant']> = {
 
 const getAlertVariant: HoverOverlayProps['getAlertVariant'] = iconKind => iconKindToAlertVariant[iconKind]
 
-interface Props extends HoverOverlayProps, HoverThresholdProps, GlobalCoolCodeIntelProps {
+interface Props extends HoverOverlayProps, HoverThresholdProps {
     hoveredTokenElement?: HTMLElement
     nav?: (url: string) => void
 }
@@ -46,7 +45,7 @@ export const WebHoverOverlay: React.FunctionComponent<Props> = props => {
     }
 
     const { hoverOrError } = propsToUse
-    const { onHoverShown, hoveredToken, coolCodeIntelEnabled } = props
+    const { onHoverShown, hoveredToken } = props
 
     /** Whether the hover has actual content (that provides value to the user) */
     const hoverHasValue = hoverOrError !== 'loading' && !isErrorLike(hoverOrError) && !!hoverOrError?.contents?.length
@@ -107,7 +106,6 @@ export const WebHoverOverlay: React.FunctionComponent<Props> = props => {
         props.nav,
         props.telemetryService,
         hoveredToken,
-        coolCodeIntelEnabled,
     ])
 
     return (

--- a/client/web/src/enterprise/batches/close/BatchChangeCloseChangesetsList.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeCloseChangesetsList.tsx
@@ -174,7 +174,6 @@ export const BatchChangeCloseChangesetsList: React.FunctionComponent<Props> = ({
                         location={location}
                         platformContext={platformContext}
                         hoverRef={nextOverlayElement}
-                        coolCodeIntelEnabled={false}
                     />
                 )}
             </Container>

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
@@ -307,7 +307,6 @@ const BatchChangeChangesetsImpl: React.FunctionComponent<Props> = ({
                         location={location}
                         platformContext={platformContext}
                         hoverRef={nextOverlayElement}
-                        coolCodeIntelEnabled={false}
                     />
                 )}
             </div>

--- a/client/web/src/global/CoolCodeIntel.tsx
+++ b/client/web/src/global/CoolCodeIntel.tsx
@@ -22,7 +22,11 @@ import { Range } from '@sourcegraph/extension-api-types'
 import { useQuery } from '@sourcegraph/http-client'
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoFileLink'
 import { Resizable } from '@sourcegraph/shared/src/components/Resizable'
-import { SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
+import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
+import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
+import { SettingsCascadeOrError, SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import {
     RepoSpec,
     RevisionSpec,
@@ -54,7 +58,8 @@ import {
     LocationFields,
 } from '../graphql-operations'
 import { resolveRevision } from '../repo/backend'
-import { Blob, BlobProps } from '../repo/blob/Blob'
+import { Blob } from '../repo/blob/Blob'
+import { HoverThresholdProps } from '../repo/RepoContainer'
 import { parseBrowserRepoURL } from '../util/url'
 
 import styles from './CoolCodeIntel.module.scss'
@@ -65,10 +70,16 @@ export interface GlobalCoolCodeIntelProps {
     coolCodeIntelEnabled: boolean
 }
 
-export type Token = HoveredToken & RepoSpec & RevisionSpec & FileSpec & ResolvedRevisionSpec
+type Token = HoveredToken & RepoSpec & RevisionSpec & FileSpec & ResolvedRevisionSpec
 
 interface CoolCodeIntelProps
-    extends Omit<BlobProps, 'className' | 'wrapCode' | 'blobInfo' | 'disableStatusBar' | 'coolCodeIntelEnabled'> {
+    extends SettingsCascadeProps,
+        PlatformContextProps,
+        TelemetryProps,
+        HoverThresholdProps,
+        ExtensionsControllerProps,
+        ThemeProps {
+    // The token for which to show references
     token?: Token
     /**
      * The panel runs inside its own MemoryRouter, we keep track of externalHistory
@@ -481,6 +492,9 @@ const CollapsibleLocationList: React.FunctionComponent<{
 const SideBlob: React.FunctionComponent<
     CoolCodeIntelProps & {
         activeLocation: Location
+
+        location: H.Location
+        history: H.History
         blobNav: (url: string) => void
     }
 > = props => {
@@ -547,7 +561,6 @@ const SideBlob: React.FunctionComponent<
             nav={props.blobNav}
             history={props.history}
             location={props.location}
-            coolCodeIntelEnabled={true}
             disableStatusBar={true}
             wrapCode={true}
             className={styles.referencesSideBlobCode}

--- a/client/web/src/global/CoolCodeIntel.tsx
+++ b/client/web/src/global/CoolCodeIntel.tsx
@@ -245,7 +245,10 @@ export const ReferencesList: React.FunctionComponent<
                                 {activeLocation.resource.path}{' '}
                                 <Link
                                     to={activeLocation.url}
-                                    onClick={() => props.externalHistory.push(activeLocation.url)}
+                                    onClick={event => {
+                                        event.preventDefault()
+                                        props.externalHistory.push(activeLocation.url)
+                                    }}
                                 >
                                     <OpenInAppIcon className="icon-inline" />
                                 </Link>

--- a/client/web/src/global/CoolCodeIntel.tsx
+++ b/client/web/src/global/CoolCodeIntel.tsx
@@ -834,21 +834,22 @@ const CoolCodeIntelResizablePanel: React.FunctionComponent<CoolCodeIntelProps> =
         return null
     }
 
-    const urlBasedToken = {
-        repoName,
-        line,
-        character,
-        filePath,
-    }
+    const token = { repoName, line, character, filePath }
+
     if (commitID === undefined || revision === undefined) {
-        return <CoolCodeIntelPanelUrlBased {...props} {...urlBasedToken} handlePanelClose={handlePanelClose} />
+        return <RevisionResolvingCoolCodeIntelPanel {...props} {...token} handlePanelClose={handlePanelClose} />
     }
 
-    const token = { ...urlBasedToken, revision, commitID }
-    return <ResizableCoolCodeIntelPanel {...props} clickedToken={token} handlePanelClose={handlePanelClose} />
+    return (
+        <ResizableCoolCodeIntelPanel
+            {...props}
+            clickedToken={{ ...token, revision, commitID }}
+            handlePanelClose={handlePanelClose}
+        />
+    )
 }
 
-export const CoolCodeIntelPanelUrlBased: React.FunctionComponent<
+export const RevisionResolvingCoolCodeIntelPanel: React.FunctionComponent<
     CoolCodeIntelProps & {
         repoName: string
         line: number

--- a/client/web/src/global/CoolCodeIntelQueries.tsx
+++ b/client/web/src/global/CoolCodeIntelQueries.tsx
@@ -43,15 +43,6 @@ const codeIntelFragments = gql`
     }
 `
 
-const hoverFragments = gql`
-    fragment HoverFields on Hover {
-        markdown {
-            html
-            text
-        }
-    }
-`
-
 const gitBlobLsifDataQueryFragment = gql`
     fragment PreciseCodeIntelForLocationFields on GitBlobLSIFData {
         references(
@@ -74,9 +65,6 @@ const gitBlobLsifDataQueryFragment = gql`
         }
         definitions(line: $line, character: $character, filter: $filter) {
             ...LocationConnectionFields
-        }
-        hover(line: $line, character: $character) {
-            ...HoverFields
         }
     }
 `
@@ -108,7 +96,6 @@ export const USE_PRECISE_CODE_INTEL_FOR_POSITION_QUERY = gql`
     }
 
     ${codeIntelFragments}
-    ${hoverFragments}
     ${gitBlobLsifDataQueryFragment}
 `
 

--- a/client/web/src/global/usePreciseCodeIntel.tsx
+++ b/client/web/src/global/usePreciseCodeIntel.tsx
@@ -82,7 +82,6 @@ export const usePreciseCodeIntel = ({ variables }: UsePreciseCodeIntelParameters
             setReferenceData({
                 implementations: previousData.implementations,
                 definitions: previousData.definitions,
-                hover: previousData.hover,
                 references: {
                     ...newReferenceData,
                     nodes: [...previousData.references.nodes, ...newReferenceData.nodes],
@@ -108,7 +107,6 @@ export const usePreciseCodeIntel = ({ variables }: UsePreciseCodeIntelParameters
             setReferenceData({
                 references: previousData.references,
                 definitions: previousData.definitions,
-                hover: previousData.hover,
                 implementations: {
                     ...newImplementationsData,
                     nodes: [...previousData.implementations.nodes, ...newImplementationsData.nodes],
@@ -165,7 +163,6 @@ const getLsifData = ({
     // If there weren't any errors and we just didn't receive any data
     if (!extractedData || !extractedData.repository?.commit?.blob?.lsif) {
         return {
-            hover: null,
             definitions: {
                 nodes: [],
                 pageInfo: {

--- a/client/web/src/notebooks/notebook/NotebookComponent.tsx
+++ b/client/web/src/notebooks/notebook/NotebookComponent.tsx
@@ -34,7 +34,6 @@ import { NotebookFields } from '../../graphql-operations'
 import { getLSPTextDocumentPositionParameters } from '../../repo/blob/Blob'
 import { PageRoutes } from '../../routes.constants'
 import { SearchStreamingProps } from '../../search'
-import { useExperimentalFeatures } from '../../stores'
 import { NotebookFileBlock } from '../blocks/file/NotebookFileBlock'
 import { FileBlockValidationFunctions } from '../blocks/file/useFileBlockInputValidation'
 import { NotebookMarkdownBlock } from '../blocks/markdown/NotebookMarkdownBlock'
@@ -455,7 +454,6 @@ export const NotebookComponent: React.FunctionComponent<NotebookComponentProps> 
     )
 
     const location = useLocation()
-    const coolCodeIntelEnabled = useExperimentalFeatures(features => features.coolCodeIntel)
 
     if (copiedNotebookOrError && !isErrorLike(copiedNotebookOrError) && copiedNotebookOrError !== LOADING) {
         return <Redirect to={PageRoutes.Notebook.replace(':id', copiedNotebookOrError.id)} />
@@ -528,7 +526,6 @@ export const NotebookComponent: React.FunctionComponent<NotebookComponentProps> 
                     location={location}
                     telemetryService={props.telemetryService}
                     isLightTheme={props.isLightTheme}
-                    coolCodeIntelEnabled={!!coolCodeIntelEnabled}
                 />
             )}
         </div>

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -31,7 +31,7 @@ import { BreadcrumbSetters } from '../components/Breadcrumbs'
 import { HeroPage } from '../components/HeroPage'
 import { ActionItemsBarProps } from '../extensions/components/ActionItemsBar'
 import { FeatureFlagProps } from '../featureFlags/featureFlags'
-import { CoolCodeIntel, GlobalCoolCodeIntelProps, isCoolCodeIntelEnabled } from '../global/CoolCodeIntel'
+import { CoolCodeIntel, isCoolCodeIntelEnabled } from '../global/CoolCodeIntel'
 import { RepositoryFields } from '../graphql-operations'
 import { CodeInsightsProps } from '../insights/types'
 import { SearchStreamingProps } from '../search'
@@ -71,8 +71,7 @@ export interface RepoRevisionContainerContext
         BatchChangesProps,
         CodeInsightsProps,
         ExtensionAlertProps,
-        FeatureFlagProps,
-        GlobalCoolCodeIntelProps {
+        FeatureFlagProps {
     repo: RepositoryFields
     resolvedRev: ResolvedRevision
 
@@ -210,9 +209,6 @@ export const RepoRevisionContainer: React.FunctionComponent<RepoRevisionContaine
 }) => {
     // Experimental reference panel
     const coolCodeIntelEnabled = isCoolCodeIntelEnabled(props.settingsCascade)
-    // We only render the reference panel when looking at files
-    // const referencePanelRoute = props.routePrefix + '/-/blob/:filePath*'
-    // const referencePanelRouteMatch = useRouteMatch(referencePanelRoute)
     const viewState = parseQueryAndHash(props.location.search, props.location.hash).viewState
     // If we don't have // '#tab=...' in the URL, we don't need to show the panel.
     const showCoolCodeIntelPanel =
@@ -287,7 +283,6 @@ export const RepoRevisionContainer: React.FunctionComponent<RepoRevisionContaine
         ...props,
         ...breadcrumbSetters,
         resolvedRev: props.resolvedRevisionOrError,
-        coolCodeIntelEnabled,
     }
 
     const resolvedRevisionOrError = props.resolvedRevisionOrError

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -335,7 +335,9 @@ export const RepoRevisionContainer: React.FunctionComponent<RepoRevisionContaine
                     )}
                 </RepoHeaderContributionPortal>
             </RepoRevisionWrapper>
-            {coolCodeIntelEnabled && referencePanelRouteMatch && <CoolCodeIntel {...props} />}
+            {coolCodeIntelEnabled && referencePanelRouteMatch && (
+                <CoolCodeIntel {...props} externalHistory={props.history} externalLocation={props.location} />
+            )}
         </>
     )
 }

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -2,7 +2,7 @@ import * as H from 'history'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import React, { useCallback, useMemo, useState } from 'react'
-import { Route, RouteComponentProps, Switch, useRouteMatch } from 'react-router'
+import { Route, RouteComponentProps, Switch } from 'react-router'
 import { Popover } from 'reactstrap'
 
 import { ErrorMessage } from '@sourcegraph/branded/src/components/alerts'
@@ -211,11 +211,12 @@ export const RepoRevisionContainer: React.FunctionComponent<RepoRevisionContaine
     // Experimental reference panel
     const coolCodeIntelEnabled = isCoolCodeIntelEnabled(props.settingsCascade)
     // We only render the reference panel when looking at files
-    const referencePanelRoute = props.routePrefix + '/-/blob/:filePath*'
-    const referencePanelRouteMatch = useRouteMatch(referencePanelRoute)
+    // const referencePanelRoute = props.routePrefix + '/-/blob/:filePath*'
+    // const referencePanelRouteMatch = useRouteMatch(referencePanelRoute)
     const viewState = parseQueryAndHash(props.location.search, props.location.hash).viewState
     // If we don't have // '#tab=...' in the URL, we don't need to show the panel.
-    const showCoolCodeIntelPanel = coolCodeIntelEnabled && referencePanelRouteMatch && viewState
+    const showCoolCodeIntelPanel =
+        coolCodeIntelEnabled && viewState && (viewState === 'references' || viewState.startsWith('implementations_'))
 
     const breadcrumbSetters = useBreadcrumb(
         useMemo(() => {

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -21,7 +21,7 @@ import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { RevisionSpec } from '@sourcegraph/shared/src/util/url'
+import { parseQueryAndHash, RevisionSpec } from '@sourcegraph/shared/src/util/url'
 import { Button } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'
@@ -213,6 +213,9 @@ export const RepoRevisionContainer: React.FunctionComponent<RepoRevisionContaine
     // We only render the reference panel when looking at files
     const referencePanelRoute = props.routePrefix + '/-/blob/:filePath*'
     const referencePanelRouteMatch = useRouteMatch(referencePanelRoute)
+    const viewState = parseQueryAndHash(props.location.search, props.location.hash).viewState
+    // If we don't have // '#tab=...' in the URL, we don't need to show the panel.
+    const showCoolCodeIntelPanel = coolCodeIntelEnabled && referencePanelRouteMatch && viewState
 
     const breadcrumbSetters = useBreadcrumb(
         useMemo(() => {
@@ -335,7 +338,7 @@ export const RepoRevisionContainer: React.FunctionComponent<RepoRevisionContaine
                     )}
                 </RepoHeaderContributionPortal>
             </RepoRevisionWrapper>
-            {coolCodeIntelEnabled && referencePanelRouteMatch && (
+            {showCoolCodeIntelPanel && (
                 <CoolCodeIntel {...props} externalHistory={props.history} externalLocation={props.location} />
             )}
         </>

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -1,7 +1,7 @@
 import * as H from 'history'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { Route, RouteComponentProps, Switch, useRouteMatch } from 'react-router'
 import { Popover } from 'reactstrap'
 
@@ -31,13 +31,7 @@ import { BreadcrumbSetters } from '../components/Breadcrumbs'
 import { HeroPage } from '../components/HeroPage'
 import { ActionItemsBarProps } from '../extensions/components/ActionItemsBar'
 import { FeatureFlagProps } from '../featureFlags/featureFlags'
-import {
-    CoolClickedToken,
-    CoolCodeIntel,
-    GlobalCoolCodeIntelProps,
-    isCoolCodeIntelEnabled,
-    locationWithoutViewState,
-} from '../global/CoolCodeIntel'
+import { CoolCodeIntel, GlobalCoolCodeIntelProps, isCoolCodeIntelEnabled } from '../global/CoolCodeIntel'
 import { RepositoryFields } from '../graphql-operations'
 import { CodeInsightsProps } from '../insights/types'
 import { SearchStreamingProps } from '../search'
@@ -216,23 +210,9 @@ export const RepoRevisionContainer: React.FunctionComponent<RepoRevisionContaine
 }) => {
     // Experimental reference panel
     const coolCodeIntelEnabled = isCoolCodeIntelEnabled(props.settingsCascade)
-
     // We only render the reference panel when looking at files
     const referencePanelRoute = props.routePrefix + '/-/blob/:filePath*'
     const referencePanelRouteMatch = useRouteMatch(referencePanelRoute)
-
-    const [clickedToken, onTokenClick] = useState<CoolClickedToken>()
-    const onTokenClickRemoveViewState = (token: CoolClickedToken | undefined): void => {
-        props.history.push(locationWithoutViewState(context.location))
-        onTokenClick(token)
-    }
-    useEffect(() => {
-        // If we don't have a route match anymore, we reset the state of the
-        // reference panel by setting the token to undefined
-        if (coolCodeIntelEnabled && !referencePanelRouteMatch) {
-            onTokenClick(undefined)
-        }
-    }, [coolCodeIntelEnabled, referencePanelRouteMatch])
 
     const breadcrumbSetters = useBreadcrumb(
         useMemo(() => {
@@ -303,7 +283,6 @@ export const RepoRevisionContainer: React.FunctionComponent<RepoRevisionContaine
         ...props,
         ...breadcrumbSetters,
         resolvedRev: props.resolvedRevisionOrError,
-        onTokenClick: onTokenClickRemoveViewState,
         coolCodeIntelEnabled,
     }
 
@@ -356,9 +335,7 @@ export const RepoRevisionContainer: React.FunctionComponent<RepoRevisionContaine
                     )}
                 </RepoHeaderContributionPortal>
             </RepoRevisionWrapper>
-            {coolCodeIntelEnabled && referencePanelRouteMatch && (
-                <CoolCodeIntel {...props} onTokenClick={onTokenClickRemoveViewState} clickedToken={clickedToken} />
-            )}
+            {coolCodeIntelEnabled && referencePanelRouteMatch && <CoolCodeIntel {...props} />}
         </>
     )
 }

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -99,6 +99,9 @@ export interface BlobProps
 
     // Experimental reference panel
     disableStatusBar: boolean
+    // If set, nav is called when a user clicks on a token highlighted by
+    // WebHoverOverlay
+    nav?: (url: string) => void
 }
 
 export interface BlobInfo extends AbsoluteRepoFile, ModeSpec {
@@ -204,7 +207,6 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
         (lineOrPositionOrRange: LineOrPositionOrRange) => locationPositions.next(lineOrPositionOrRange),
         [locationPositions]
     )
-    console.log('blob location.hash', location.hash)
     const parsedHash = useMemo(() => parseQueryAndHash(location.search, location.hash), [
         location.search,
         location.hash,
@@ -616,7 +618,7 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
                     <WebHoverOverlay
                         {...props}
                         {...hoverState.hoverOverlayProps}
-                        nav={url => props.history.push(url)}
+                        nav={url => (props.nav ? props.nav(url) : props.history.push(url))}
                         hoveredTokenElement={hoverState.hoveredTokenElement}
                         hoverRef={nextOverlayElement}
                         extensionsController={extensionsController}

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -204,6 +204,7 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
         (lineOrPositionOrRange: LineOrPositionOrRange) => locationPositions.next(lineOrPositionOrRange),
         [locationPositions]
     )
+    console.log('blob location.hash', location.hash)
     const parsedHash = useMemo(() => parseQueryAndHash(location.search, location.hash), [
         location.search,
         location.hash,

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -71,7 +71,6 @@ import { useObservable } from '@sourcegraph/wildcard'
 import { getHover, getDocumentHighlights } from '../../backend/features'
 import { WebHoverOverlay } from '../../components/shared'
 import { StatusBar } from '../../extensions/components/StatusBar'
-import { GlobalCoolCodeIntelProps } from '../../global/CoolCodeIntel'
 import { HoverThresholdProps } from '../RepoContainer'
 
 import styles from './Blob.module.scss'
@@ -88,8 +87,7 @@ export interface BlobProps
         TelemetryProps,
         HoverThresholdProps,
         ExtensionsControllerProps,
-        ThemeProps,
-        GlobalCoolCodeIntelProps {
+        ThemeProps {
     location: H.Location
     history: H.History
     className: string

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -381,7 +381,6 @@ export const BlobPage: React.FunctionComponent<Props> = props => {
                     telemetryService={props.telemetryService}
                     location={props.location}
                     disableStatusBar={false}
-                    onTokenClick={props.onTokenClick}
                     coolCodeIntelEnabled={props.coolCodeIntelEnabled}
                 />
             )}

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -24,7 +24,6 @@ import { AuthenticatedUser } from '../../auth'
 import { BreadcrumbSetters } from '../../components/Breadcrumbs'
 import { HeroPage } from '../../components/HeroPage'
 import { PageTitle } from '../../components/PageTitle'
-import { GlobalCoolCodeIntelProps } from '../../global/CoolCodeIntel'
 import { render as renderLsifHtml } from '../../lsif/html'
 import { copyNotebook, CopyNotebookProps } from '../../notebooks/notebook'
 import { SearchStreamingProps } from '../../search'
@@ -63,8 +62,7 @@ interface Props
         BreadcrumbSetters,
         SearchStreamingProps,
         Pick<SearchContextProps, 'searchContextsEnabled'>,
-        Pick<StreamingSearchResultsListProps, 'fetchHighlightedFileLineRanges'>,
-        GlobalCoolCodeIntelProps {
+        Pick<StreamingSearchResultsListProps, 'fetchHighlightedFileLineRanges'> {
     location: H.Location
     history: H.History
     repoID: Scalars['ID']
@@ -381,7 +379,6 @@ export const BlobPage: React.FunctionComponent<Props> = props => {
                     telemetryService={props.telemetryService}
                     location={props.location}
                     disableStatusBar={false}
-                    coolCodeIntelEnabled={props.coolCodeIntelEnabled}
                 />
             )}
         </>

--- a/client/web/src/repo/commit/RepositoryCommitPage.tsx
+++ b/client/web/src/repo/commit/RepositoryCommitPage.tsx
@@ -326,7 +326,6 @@ export class RepositoryCommitPage extends React.Component<Props, State> {
                         hoveredTokenElement={this.state.hoveredTokenElement}
                         telemetryService={this.props.telemetryService}
                         hoverRef={this.nextOverlayElement}
-                        coolCodeIntelEnabled={false}
                     />
                 )}
             </div>

--- a/client/web/src/repo/compare/RepositoryCompareArea.tsx
+++ b/client/web/src/repo/compare/RepositoryCompareArea.tsx
@@ -216,7 +216,6 @@ export class RepositoryCompareArea extends React.Component<RepositoryCompareArea
                         hoveredTokenElement={this.state.hoveredTokenElement}
                         telemetryService={this.props.telemetryService}
                         hoverRef={this.nextOverlayElement}
-                        coolCodeIntelEnabled={false}
                     />
                 )}
             </div>


### PR DESCRIPTION
This fixes #31642 by reverting to the old behaviour of the reference panel and only opening it when clicking on the token _at the definition_ site.

It does this by making the complete panel and its state driven by the URL and the `#tab=references` hash.

All of the other code related to the clicked token, the global props, etc. is gone.

## Test plan

- Tested this locally by going through different scenarios: opening panel, closing it, clicking on references (in same file, other file), clicking on references _inside_ the opened code blob, etc. See video.


https://user-images.githubusercontent.com/1185253/156393737-6b13cb8c-f68b-4d26-aa46-78d3bcb290e3.mp4



