### PR TITLE
database: Add observability to batch insertion

### DIFF
--- a/internal/database/batch/batch.go
+++ b/internal/database/batch/batch.go
@@ -7,9 +7,12 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/opentracing/opentracing-go/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -24,6 +27,8 @@ type Inserter struct {
 	onConflictSuffix string
 	returningSuffix  string
 	returningScanner ReturningScanner
+	operations       *operations
+	logFields        []log.Field
 }
 
 type ReturningScanner func(rows *sql.Rows) error
@@ -141,6 +146,13 @@ func NewInserterWithReturn(
 		onConflictSuffix: onConflictSuffix,
 		returningSuffix:  returningSuffix,
 		returningScanner: returningScanner,
+		operations:       getOperations(),
+		logFields: []log.Field{
+			log.String("tableName", tableName),
+			log.String("columnNames", strings.Join(columnNames, ",")),
+			log.Int("numColumns", numColumns),
+			log.Int("maxBatchSize", maxBatchSize),
+		},
 	}
 }
 
@@ -163,20 +175,29 @@ func (i *Inserter) Insert(ctx context.Context, values ...interface{}) error {
 // Flush ensures that all queued rows are inserted. This method must be invoked at the end
 // of insertion to ensure that all records are flushed to the underlying Execable.
 func (i *Inserter) Flush(ctx context.Context) (err error) {
-	if batch := i.pop(); len(batch) != 0 {
-		// Create a query with enough placeholders to match the current batch size. This should
-		// generally be the full querySuffix string, except for the last call to Flush which
-		// may be a partial batch.
-		rows, err := i.db.QueryContext(dbconn.WithBulkInsertion(ctx, true), i.makeQuery(len(batch)), batch...)
-		if err != nil {
-			return err
-		}
-		defer func() { err = basestore.CloseRows(rows, err) }()
+	batch := i.pop()
+	if len(batch) != 0 {
+		return nil
+	}
 
-		for rows.Next() {
-			if err := i.returningScanner(rows); err != nil {
-				return err
-			}
+	logFields := []log.Field{
+		log.Int("batchSize", len(batch)),
+	}
+	ctx, endObservation := i.operations.flush.With(ctx, &err, observation.Args{LogFields: append(logFields, i.logFields...)})
+	endObservation(1, observation.Args{})
+
+	// Create a query with enough placeholders to match the current batch size. This should
+	// generally be the full querySuffix string, except for the last call to Flush which
+	// may be a partial batch.
+	rows, err := i.db.QueryContext(dbconn.WithBulkInsertion(ctx, true), i.makeQuery(len(batch)), batch...)
+	if err != nil {
+		return err
+	}
+	defer func() { err = basestore.CloseRows(rows, err) }()
+
+	for rows.Next() {
+		if err := i.returningScanner(rows); err != nil {
+			return err
 		}
 	}
 

--- a/internal/database/batch/batch.go
+++ b/internal/database/batch/batch.go
@@ -176,7 +176,7 @@ func (i *Inserter) Insert(ctx context.Context, values ...interface{}) error {
 // of insertion to ensure that all records are flushed to the underlying Execable.
 func (i *Inserter) Flush(ctx context.Context) (err error) {
 	batch := i.pop()
-	if len(batch) != 0 {
+	if len(batch) == 0 {
 		return nil
 	}
 

--- a/internal/database/batch/observability.go
+++ b/internal/database/batch/observability.go
@@ -1,0 +1,63 @@
+package batch
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/inconshreveable/log15"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/sourcegraph/sourcegraph/internal/honey"
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+)
+
+type operations struct {
+	flush *observation.Operation
+}
+
+func newOperations(observationContext *observation.Context) *operations {
+	metrics := metrics.NewREDMetrics(
+		observationContext.Registerer,
+		"database_batch",
+		metrics.WithLabels("op"),
+		metrics.WithCountHelp("Total number of method invocations."),
+	)
+
+	op := func(name string) *observation.Operation {
+		return observationContext.Operation(observation.Op{
+			Name:              fmt.Sprintf("database.batch.%s", name),
+			MetricLabelValues: []string{name},
+			Metrics:           metrics,
+		})
+	}
+
+	return &operations{
+		flush: op("Flush"),
+	}
+}
+
+var (
+	ops     *operations
+	opsOnce sync.Once
+)
+
+func getOperations() *operations {
+	opsOnce.Do(func() {
+		observationContext := &observation.Context{
+			Logger:     log15.Root(),
+			Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
+			Registerer: prometheus.DefaultRegisterer,
+			HoneyDataset: &honey.Dataset{
+				Name:       "database-batch",
+				SampleRate: 5,
+			},
+		}
+
+		ops = newOperations(observationContext)
+	})
+
+	return ops
+}


### PR DESCRIPTION
This adds observability+honeycomb to the database batch inserter.

## Test plan

Unit tests.