### PR TITLE
codeintel locations: fix URLs by using git blob as resource

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations.go
@@ -235,7 +235,7 @@ func (r *CachedLocationResolver) resolveCommit(ctx context.Context, repositoryRe
 // Path resolves the git tree entry with the given commit resolver and relative path. This method must be
 // called only when constructing a resolver to populate the cache.
 func (r *CachedLocationResolver) resolvePath(commitResolver *gql.GitCommitResolver, path string) *gql.GitTreeEntryResolver {
-	return gql.NewGitTreeEntryResolver(r.db, commitResolver, gql.CreateFileInfo(path, true))
+	return gql.NewGitTreeEntryResolver(r.db, commitResolver, gql.CreateFileInfo(path, false))
 }
 
 // resolveLocations creates a slide of LocationResolvers for the given list of adjusted locations. The

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations_test.go
@@ -271,13 +271,13 @@ func TestResolveLocations(t *testing.T) {
 	if len(locations) != 3 {
 		t.Fatalf("unexpected length. want=%d have=%d", 3, len(locations))
 	}
-	if url := locations[0].CanonicalURL(); url != "/repo50@deadbeef1/-/tree/p1?L12:13-14:15" {
-		t.Errorf("unexpected canonical url. want=%s have=%s", "/repo50@deadbeef1/-/tree/p1?L12:13-14:15", url)
+	if url := locations[0].CanonicalURL(); url != "/repo50@deadbeef1/-/blob/p1?L12:13-14:15" {
+		t.Errorf("unexpected canonical url. want=%s have=%s", "/repo50@deadbeef1/-/blob/p1?L12:13-14:15", url)
 	}
-	if url := locations[1].CanonicalURL(); url != "/repo51@deadbeef2/-/tree/p2?L22:23-24:25" {
-		t.Errorf("unexpected canonical url. want=%s have=%s", "/repo51@deadbeef2/-/tree/p2?L22:23-24:25", url)
+	if url := locations[1].CanonicalURL(); url != "/repo51@deadbeef2/-/blob/p2?L22:23-24:25" {
+		t.Errorf("unexpected canonical url. want=%s have=%s", "/repo51@deadbeef2/-/blob/p2?L22:23-24:25", url)
 	}
-	if url := locations[2].CanonicalURL(); url != "/repo53@deadbeef4/-/tree/p4?L42:43-44:45" {
-		t.Errorf("unexpected canonical url. want=%s have=%s", "/repo53@deadbeef4/-/tree/p4?L42:43-44:45", url)
+	if url := locations[2].CanonicalURL(); url != "/repo53@deadbeef4/-/blob/p4?L42:43-44:45" {
+		t.Errorf("unexpected canonical url. want=%s have=%s", "/repo53@deadbeef4/-/blob/p4?L42:43-44:45", url)
 	}
 }


### PR DESCRIPTION
This fixes inconsistent behaviour in our `GitBlobLSIFData` resolver that
would cause the `Locations` being returned in the
`definitions`/`references`/... having `/tree/` as opposed to `/blob/` in
their URL.

`tree` is only meant to be used for directories and not files, though,
which is why the produced URLs that include line ranges would be
redirected by our web application.

So this changes the second parameter of `gql.CreateFileInfo` to
correctly say that the locations are *not* directories, but files.


## Test plan

- Adjusted and ran unit tests


