### PR TITLE
sg: Change sg.config.yaml to point to insiders for syntax-highlighter

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -346,7 +346,7 @@ commands:
     cmd: |
       docker run --name=syntax-highlighter --rm -p9238:9238 \
       -e WORKERS=1 -e ROCKET_ADDRESS=0.0.0.0 \
-      sourcegraph/syntax-highlighter@sha256:92a5c181dbf2d8aead5171c985139bf38c496bef2ac98afbd64c3612967fe5cc
+      sourcegraph/syntax-highlighter:insiders
     install: |
       # Remove containers by the old name, too.
       docker inspect syntect_server >/dev/null 2>&1 && docker rm -f syntect_server || true

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -351,6 +351,8 @@ commands:
       # Remove containers by the old name, too.
       docker inspect syntect_server >/dev/null 2>&1 && docker rm -f syntect_server || true
       docker inspect syntax-highlighter >/dev/null 2>&1 && docker rm -f syntax-highlighter || true
+      # Pull syntax-highlighter latest insider image, only during install
+      docker pull sourcegraph/syntax-highlighter:insiders
     env:
       # This is not needed actually
       INSECURE_DEV: 1

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -352,7 +352,7 @@ commands:
       docker inspect syntect_server >/dev/null 2>&1 && docker rm -f syntect_server || true
       docker inspect syntax-highlighter >/dev/null 2>&1 && docker rm -f syntax-highlighter || true
       # Pull syntax-highlighter latest insider image, only during install
-      docker pull sourcegraph/syntax-highlighter:insiders
+      docker pull -q sourcegraph/syntax-highlighter:insiders
     env:
       # This is not needed actually
       INSECURE_DEV: 1


### PR DESCRIPTION
Does this seem OK @mrnugget ?

## Test plan

Run `sg start enterprise-codeintel` and see if you can get tree-sitter highlighting after enabling.

