### PR TITLE
Add migration to add create_at column in external_service_repo table

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -815,13 +815,14 @@ Tracks the most recent activity of executors attached to this Sourcegraph instan
 
 # Table "public.external_service_repos"
 ```
-       Column        |  Type   | Collation | Nullable | Default 
----------------------+---------+-----------+----------+---------
- external_service_id | bigint  |           | not null | 
- repo_id             | integer |           | not null | 
- clone_url           | text    |           | not null | 
- user_id             | integer |           |          | 
- org_id              | integer |           |          | 
+       Column        |           Type           | Collation | Nullable |         Default         
+---------------------+--------------------------+-----------+----------+-------------------------
+ external_service_id | bigint                   |           | not null | 
+ repo_id             | integer                  |           | not null | 
+ clone_url           | text                     |           | not null | 
+ user_id             | integer                  |           |          | 
+ org_id              | integer                  |           |          | 
+ created_at          | timestamp with time zone |           |          | transaction_timestamp()
 Indexes:
     "external_service_repos_repo_id_external_service_id_unique" UNIQUE CONSTRAINT, btree (repo_id, external_service_id)
     "external_service_repos_clone_url_idx" btree (clone_url)

--- a/migrations/frontend/1646153853/down.sql
+++ b/migrations/frontend/1646153853/down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE IF EXISTS external_service_repos
+    DROP COLUMN IF EXISTS created_at;
+
+COMMIT;

--- a/migrations/frontend/1646153853/metadata.yaml
+++ b/migrations/frontend/1646153853/metadata.yaml
@@ -1,0 +1,2 @@
+name: add-created-at-to-external-service-repos
+parents: [1645554732]

--- a/migrations/frontend/1646153853/up.sql
+++ b/migrations/frontend/1646153853/up.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE IF EXISTS external_service_repos
+    ADD COLUMN IF NOT EXISTS created_at timestamp with time zone DEFAULT transaction_timestamp();
+
+COMMIT;


### PR DESCRIPTION
Closes #27795

Adding an additional row to the external_service_repos table to log when repos are added by users so we can keep track of the added times for the repos if multiple adds are made.

Example:
![image](https://user-images.githubusercontent.com/20795805/156220108-c1027d0a-e625-4785-9755-746978b01e58.png)


## Test plan
Tested by running migration up and down against development environment, as well as adding a new repo and verifying the default created_at time was set correctly in the DB table





