### PR TITLE
database: Track payload sizes in batch inserter

### DIFF
--- a/internal/database/batch/batch.go
+++ b/internal/database/batch/batch.go
@@ -270,9 +270,9 @@ func (i *Inserter) pop() (batch []interface{}, payloadSize int) {
 	i.cumulativeValueSizes = i.cumulativeValueSizes[i.maxBatchSize:]
 
 	for idx := range i.cumulativeValueSizes {
-		// Batch payload sizes are cumulative. Remove the size of the batch we've just
-		// extracted from every value remaining in the slice. This should generally only
-		// be a handful of elements and shouldn't be anywhere near a dominating loop.
+		// Remove the size of the batch we've just extracted from every value remaining in the slice.
+		// This should generally only be a handful of elements and shouldn't be anywhere near a dominating
+		// loop.
 		i.cumulativeValueSizes[idx] -= payloadSize
 	}
 

--- a/internal/database/batch/batch.go
+++ b/internal/database/batch/batch.go
@@ -18,18 +18,18 @@ import (
 
 // Inserter allows for bulk updates to a single Postgres table.
 type Inserter struct {
-	db                dbutil.DB
-	numColumns        int
-	maxBatchSize      int
-	batch             []interface{}
-	batchPayloadSizes []int
-	queryPrefix       string
-	querySuffix       string
-	onConflictSuffix  string
-	returningSuffix   string
-	returningScanner  ReturningScanner
-	operations        *operations
-	commonLogFields   []log.Field
+	db                   dbutil.DB
+	numColumns           int
+	maxBatchSize         int
+	batch                []interface{}
+	cumulativeValueSizes []int
+	queryPrefix          string
+	querySuffix          string
+	onConflictSuffix     string
+	returningSuffix      string
+	returningScanner     ReturningScanner
+	operations           *operations
+	commonLogFields      []log.Field
 }
 
 type ReturningScanner func(rows *sql.Rows) error
@@ -138,17 +138,17 @@ func NewInserterWithReturn(
 	returningSuffix := makeReturningSuffix(returningColumnNames)
 
 	return &Inserter{
-		db:                db,
-		numColumns:        numColumns,
-		maxBatchSize:      maxBatchSize,
-		batch:             make([]interface{}, 0, maxBatchSize),
-		batchPayloadSizes: make([]int, 0, maxBatchSize),
-		queryPrefix:       queryPrefix,
-		querySuffix:       querySuffix,
-		onConflictSuffix:  onConflictSuffix,
-		returningSuffix:   returningSuffix,
-		returningScanner:  returningScanner,
-		operations:        getOperations(),
+		db:                   db,
+		numColumns:           numColumns,
+		maxBatchSize:         maxBatchSize,
+		batch:                make([]interface{}, 0, maxBatchSize),
+		cumulativeValueSizes: make([]int, 0, maxBatchSize),
+		queryPrefix:          queryPrefix,
+		querySuffix:          querySuffix,
+		onConflictSuffix:     onConflictSuffix,
+		returningSuffix:      returningSuffix,
+		returningScanner:     returningScanner,
+		operations:           getOperations(),
 		commonLogFields: []log.Field{
 			log.String("tableName", tableName),
 			log.String("columnNames", strings.Join(columnNames, ",")),
@@ -168,8 +168,8 @@ func (i *Inserter) Insert(ctx context.Context, values ...interface{}) error {
 	}
 
 	size := 0
-	if n := len(i.batchPayloadSizes); n != 0 {
-		size = i.batchPayloadSizes[n-1]
+	if n := len(i.cumulativeValueSizes); n != 0 {
+		size = i.cumulativeValueSizes[n-1]
 	}
 
 	sizes := make([]int, 0, len(values))
@@ -185,7 +185,7 @@ func (i *Inserter) Insert(ctx context.Context, values ...interface{}) error {
 	}
 
 	i.batch = append(i.batch, values...)
-	i.batchPayloadSizes = append(i.batchPayloadSizes, sizes...)
+	i.cumulativeValueSizes = append(i.cumulativeValueSizes, sizes...)
 
 	if len(i.batch) >= i.maxBatchSize {
 		// Flush full batch
@@ -238,8 +238,8 @@ func (i *Inserter) Flush(ctx context.Context) (err error) {
 var checkBatchInserterInvariants = false
 
 func (i *Inserter) checkInvariants() {
-	if checkBatchInserterInvariants && len(i.batch) != len(i.batchPayloadSizes) {
-		panic(fmt.Sprintf("broken invariant: len(i.batch) != len(i.batchPayloadSizes): %d != %d", len(i.batch), len(i.batchPayloadSizes)))
+	if checkBatchInserterInvariants && len(i.batch) != len(i.cumulativeValueSizes) {
+		panic(fmt.Sprintf("broken invariant: len(i.batch) != len(i.batchPayloadSizes): %d != %d", len(i.batch), len(i.cumulativeValueSizes)))
 	}
 }
 
@@ -253,27 +253,27 @@ func (i *Inserter) pop() (batch []interface{}, batchPayloadSize int) {
 
 	if len(i.batch) < i.maxBatchSize {
 		// Grab size before overwriting it
-		batchPayloadSize = i.batchPayloadSizes[len(i.batchPayloadSizes)-1]
+		batchPayloadSize = i.cumulativeValueSizes[len(i.cumulativeValueSizes)-1]
 
 		// Use entire batch. This allows us to cleanly reset the sizes we were tracking for value
 		// payloads by just cutting the length of the slice back to zero.
 		batch, i.batch = i.batch, i.batch[:0]
-		i.batchPayloadSizes = i.batchPayloadSizes[:0]
+		i.cumulativeValueSizes = i.cumulativeValueSizes[:0]
 		return batch, batchPayloadSize
 	}
 
 	// Grab size before altering containing slice
-	batchPayloadSize = i.batchPayloadSizes[i.maxBatchSize-1]
+	batchPayloadSize = i.cumulativeValueSizes[i.maxBatchSize-1]
 
 	// Extract partial batch along with the size tracking data for each elemetn
 	batch, i.batch = i.batch[:i.maxBatchSize], i.batch[i.maxBatchSize:]
-	i.batchPayloadSizes = i.batchPayloadSizes[i.maxBatchSize:]
+	i.cumulativeValueSizes = i.cumulativeValueSizes[i.maxBatchSize:]
 
-	for idx := range i.batchPayloadSizes {
+	for idx := range i.cumulativeValueSizes {
 		// Batch payload sizes are cumulative. Remove the size of the batch we've just
 		// extracted from every value remaining in the slice. This should generally only
 		// be a handful of elements and shouldn't be anywhere near a dominating loop.
-		i.batchPayloadSizes[idx] -= batchPayloadSize
+		i.cumulativeValueSizes[idx] -= batchPayloadSize
 	}
 
 	return batch, batchPayloadSize

--- a/internal/database/batch/batch.go
+++ b/internal/database/batch/batch.go
@@ -246,24 +246,24 @@ func (i *Inserter) checkInvariants() {
 // pop removes and returns as many values from the current batch that can be attached to a single
 // insert statement. The returned values are the oldest values submitted to the batch (in order).
 // This method additionally returns the total (approximate) size of the batch being inserted.
-func (i *Inserter) pop() (batch []interface{}, batchPayloadSize int) {
+func (i *Inserter) pop() (batch []interface{}, payloadSize int) {
 	if len(i.batch) == 0 {
 		return nil, 0
 	}
 
 	if len(i.batch) < i.maxBatchSize {
 		// Grab size before overwriting it
-		batchPayloadSize = i.cumulativeValueSizes[len(i.cumulativeValueSizes)-1]
+		payloadSize = i.cumulativeValueSizes[len(i.cumulativeValueSizes)-1]
 
 		// Use entire batch. This allows us to cleanly reset the sizes we were tracking for value
 		// payloads by just cutting the length of the slice back to zero.
 		batch, i.batch = i.batch, i.batch[:0]
 		i.cumulativeValueSizes = i.cumulativeValueSizes[:0]
-		return batch, batchPayloadSize
+		return batch, payloadSize
 	}
 
 	// Grab size before altering containing slice
-	batchPayloadSize = i.cumulativeValueSizes[i.maxBatchSize-1]
+	payloadSize = i.cumulativeValueSizes[i.maxBatchSize-1]
 
 	// Extract partial batch along with the size tracking data for each elemetn
 	batch, i.batch = i.batch[:i.maxBatchSize], i.batch[i.maxBatchSize:]
@@ -273,10 +273,10 @@ func (i *Inserter) pop() (batch []interface{}, batchPayloadSize int) {
 		// Batch payload sizes are cumulative. Remove the size of the batch we've just
 		// extracted from every value remaining in the slice. This should generally only
 		// be a handful of elements and shouldn't be anywhere near a dominating loop.
-		i.cumulativeValueSizes[idx] -= batchPayloadSize
+		i.cumulativeValueSizes[idx] -= payloadSize
 	}
 
-	return batch, batchPayloadSize
+	return batch, payloadSize
 }
 
 // makeQuery returns a parameterized SQL query that has the given number of values worth of

--- a/internal/database/batch/batch_test.go
+++ b/internal/database/batch/batch_test.go
@@ -10,6 +10,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 )
 
+func init() {
+	checkBatchInserterInvariants = true
+}
+
 func TestBatchInserter(t *testing.T) {
 	db := dbtest.NewDB(t)
 	setupTestTable(t, db)


### PR DESCRIPTION
This adds an approximate size of the payloads sent via each batch inserter flush to our observability calls. Currently this only counts strings as variable size and marks everything else as constant. We can expand the set of detected types post-merge.

## Test plan

Integration tests.