### PR TITLE
Code Insights: Migrate insight integration test to GQL API

### DIFF
--- a/client/shared/src/testing/driver.ts
+++ b/client/shared/src/testing/driver.ts
@@ -763,7 +763,7 @@ async function getFirefoxCfgPath(): Promise<string> {
     return path.join(configPath, 'puppeteer.cfg')
 }
 
-interface DriverOptions extends LaunchOptions, BrowserConnectOptions {
+interface DriverOptions extends LaunchOptions, BrowserConnectOptions, BrowserLaunchArgumentOptions {
     browser?: 'chrome' | 'firefox'
 
     /** If true, load the Sourcegraph browser extension. */

--- a/client/web/src/enterprise/insights/pages/dashboards/creation/components/InsightsDashboardCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/creation/components/InsightsDashboardCreationContent.tsx
@@ -62,7 +62,7 @@ export const InsightsDashboardCreationContent: React.FunctionComponent<InsightsD
     const { ref, handleSubmit, formAPI } = useForm<DashboardCreationFields>({
         initialValues: initialValues ?? { ...DASHBOARD_INITIAL_VALUES, visibility: userSubjectID },
         // Override onSubmit to pass type value
-        // to correctly set the grants property for graphql api
+        // to correctly set the grants' property for graphql api
         onSubmit: async (): Promise<SubmissionErrors> => {
             let type = 'organization'
             if (visibility.input.value === userSubjectID) {

--- a/client/web/src/integration/insights/create-insights.test.ts
+++ b/client/web/src/integration/insights/create-insights.test.ts
@@ -9,11 +9,11 @@ import { createWebIntegrationTestContext, WebIntegrationTestContext } from '../c
 import { percySnapshotWithVariants } from '../utils'
 
 import {
-    INSIGHT_TYPES_MIGRATION_BULK_SEARCH,
-    INSIGHT_TYPES_MIGRATION_COMMITS,
-    LangStatsInsightContent,
-} from './utils/insight-mock-data'
-import { overrideGraphQLExtensions } from './utils/override-insights-graphql'
+    MIGRATION_TO_GQL_INSIGHT_COMMITS_FIXTURE,
+    MIGRATION_TO_GQL_INSIGHT_MATCHES_DATA_FIXTURE,
+    SOURCEGRAPH_LANG_STATS_INSIGHT_DATA_FIXTURE,
+} from './fixtures/runtime-insights'
+import { overrideInsightsGraphQLApi } from './utils/override-insights-graphql-api'
 
 describe('Code insight create insight page', () => {
     let driver: Driver
@@ -40,7 +40,7 @@ describe('Code insight create insight page', () => {
     afterEachSaveScreenshotIfFailed(() => driver.page)
 
     it('is styled correctly, with welcome popup', async () => {
-        overrideGraphQLExtensions({ testContext })
+        overrideInsightsGraphQLApi({ testContext })
         await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/create')
 
         // Waiting for all important part page be rendered.
@@ -52,7 +52,7 @@ describe('Code insight create insight page', () => {
     })
 
     it('is styled correctly, without welcome popup', async () => {
-        overrideGraphQLExtensions({ testContext })
+        overrideInsightsGraphQLApi({ testContext })
         await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/create')
 
         // Waiting for all important part page be rendered.
@@ -64,7 +64,7 @@ describe('Code insight create insight page', () => {
     })
 
     it('should run a proper GQL mutation if code-stats insight has been created', async () => {
-        overrideGraphQLExtensions({
+        overrideInsightsGraphQLApi({
             testContext,
             overrides: {
                 /**
@@ -74,7 +74,7 @@ describe('Code insight create insight page', () => {
                     repoSearch0: { name: 'github.com/sourcegraph/sourcegraph' },
                 }),
 
-                LangStatsInsightContent: () => LangStatsInsightContent,
+                LangStatsInsightContent: () => SOURCEGRAPH_LANG_STATS_INSIGHT_DATA_FIXTURE,
 
                 /** Mock for repository suggest component. */
                 RepositorySearchSuggestions: () => ({
@@ -137,7 +137,7 @@ describe('Code insight create insight page', () => {
             Date.now = () => mockMs
         })
 
-        overrideGraphQLExtensions({
+        overrideInsightsGraphQLApi({
             testContext,
             overrides: {
                 // Mock for async repositories field validation.
@@ -146,8 +146,8 @@ describe('Code insight create insight page', () => {
                 }),
 
                 // Mocks of commits searching and data search itself for live preview chart
-                BulkSearchCommits: () => INSIGHT_TYPES_MIGRATION_COMMITS,
-                BulkSearch: () => INSIGHT_TYPES_MIGRATION_BULK_SEARCH,
+                BulkSearchCommits: () => MIGRATION_TO_GQL_INSIGHT_COMMITS_FIXTURE,
+                BulkSearch: () => MIGRATION_TO_GQL_INSIGHT_MATCHES_DATA_FIXTURE,
 
                 // Mock for repository suggest component
                 RepositorySearchSuggestions: () => ({

--- a/client/web/src/integration/insights/delete-insights.test.ts
+++ b/client/web/src/integration/insights/delete-insights.test.ts
@@ -1,13 +1,13 @@
 import assert from 'assert'
 
 import { createDriverForTest, Driver } from '@sourcegraph/shared/src/testing/driver'
-import { emptyResponse } from '@sourcegraph/shared/src/testing/integration/graphQlResults'
 import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
 
 import { createWebIntegrationTestContext, WebIntegrationTestContext } from '../context'
 
-import { SEARCH_INSIGHT_COMMITS_MOCK, SEARCH_INSIGHT_RESULT_MOCK } from './utils/insight-mock-data'
-import { overrideGraphQLExtensions } from './utils/override-insights-graphql'
+import { MIGRATION_TO_GQL_INSIGHT_DATA_FIXTURE } from './fixtures/calculated-insights'
+import { createJITMigrationToGQLInsightMetadataFixture } from './fixtures/insights-metadata'
+import { overrideInsightsGraphQLApi } from './utils/override-insights-graphql-api'
 
 describe('Code insights page', () => {
     let driver: Driver
@@ -17,79 +17,50 @@ describe('Code insights page', () => {
         driver = await createDriverForTest()
     })
 
-    after(() => driver?.close())
-
     beforeEach(async function () {
         testContext = await createWebIntegrationTestContext({
             driver,
             currentTest: this.currentTest!,
             directory: __dirname,
+            customContext: {
+                // Enforce using a new gql API for code insights pages
+                codeInsightsGqlApiEnabled: true,
+            },
         })
     })
 
-    afterEachSaveScreenshotIfFailed(() => driver.page)
+    after(() => driver?.close())
     afterEach(() => testContext?.dispose())
+    afterEachSaveScreenshotIfFailed(() => driver.page)
 
     it('should update user/org settings if insight delete happened', async () => {
-        const settings = {
-            'searchInsights.insight.graphQLTypesMigration': {
-                title: 'The First search-based insight',
-                repositories: ['github.com/sourcegraph/sourcegraph'],
-                series: [
-                    {
-                        name: 'The first series of the first chart',
-                        stroke: 'var(--oc-grape-7)',
-                        query: 'Kapica',
-                    },
-                ],
-                step: {
-                    months: 8,
-                },
-            },
-            'searchInsights.insight.teamSize': {
-                title: 'The Second search-based insight',
-                repositories: ['github.com/sourcegraph/sourcegraph'],
-                series: [
-                    {
-                        name: 'The second series of the second chart',
-                        stroke: 'var(--oc-blue-7)',
-                        query: 'Korolev',
-                    },
-                ],
-                step: {
-                    months: 8,
-                },
-            },
-        }
-
-        overrideGraphQLExtensions({
+        overrideInsightsGraphQLApi({
             testContext,
 
             // Since search insight and code stats insights work via user/org
             // settings. We have to mock them by mocking user settings cascade.
-            userSettings: settings,
+            // userSettings: settings,
             overrides: {
-                // Mock back-end insights with standard gql API handler.
-                Insights: () => ({ insights: { nodes: [] } }),
-
-                // Mock built-in search-based insight
-                BulkSearchCommits: () => SEARCH_INSIGHT_COMMITS_MOCK,
-                BulkSearch: () => SEARCH_INSIGHT_RESULT_MOCK,
-
-                OverwriteSettings: () => ({
-                    settingsMutation: {
-                        overwriteSettings: {
-                            empty: emptyResponse,
-                        },
+                GetInsights: () => ({
+                    __typename: 'Query',
+                    insightViews: {
+                        __typename: 'InsightViewConnection',
+                        nodes: [createJITMigrationToGQLInsightMetadataFixture({ type: 'calculated' })],
+                    },
+                }),
+                GetInsightView: () => ({
+                    __typename: 'Query',
+                    insightViews: {
+                        __typename: 'InsightViewConnection',
+                        nodes: [MIGRATION_TO_GQL_INSIGHT_DATA_FIXTURE],
                     },
                 }),
 
-                SubjectSettings: () => ({
-                    settingsSubject: {
-                        latestSettings: {
-                            id: 310,
-                            contents: JSON.stringify(settings),
-                        },
+                DeleteInsightView: () => ({
+                    __typename: 'Mutation',
+                    deleteInsightView: {
+                        __typename: 'EmptyResponse',
+                        alwaysNil: '',
                     },
                 }),
             },
@@ -99,31 +70,14 @@ describe('Code insights page', () => {
         await driver.page.waitForSelector('[data-testid="line-chart__content"] svg circle')
 
         const variables = await testContext.waitForGraphQLRequest(async () => {
-            await driver.page.click(
-                '[data-testid="insight-card.searchInsights.insight.graphQLTypesMigration"] [data-testid="InsightContextMenuButton"]'
-            )
+            await driver.page.click('[data-testid="insight-card.001"] [data-testid="InsightContextMenuButton"]')
 
             await Promise.all([
                 driver.acceptNextDialog(),
                 driver.page.click('[data-testid="insight-context-menu-delete-button"]'),
             ])
-        }, 'OverwriteSettings')
+        }, 'DeleteInsightView')
 
-        assert.deepStrictEqual(JSON.parse(variables.contents), {
-            'searchInsights.insight.teamSize': {
-                title: 'The Second search-based insight',
-                repositories: ['github.com/sourcegraph/sourcegraph'],
-                series: [
-                    {
-                        name: 'The second series of the second chart',
-                        stroke: 'var(--oc-blue-7)',
-                        query: 'Korolev',
-                    },
-                ],
-                step: {
-                    months: 8,
-                },
-            },
-        })
+        assert.strictEqual(variables.id, '001')
     })
 })

--- a/client/web/src/integration/insights/drill-down-filters.test.ts
+++ b/client/web/src/integration/insights/drill-down-filters.test.ts
@@ -4,13 +4,14 @@ import delay from 'delay'
 import { Key } from 'ts-key-enum'
 
 import { createDriverForTest, Driver } from '@sourcegraph/shared/src/testing/driver'
-import { emptyResponse } from '@sourcegraph/shared/src/testing/integration/graphQlResults'
 import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
 
+import { InsightViewNode } from '../../graphql-operations'
 import { createWebIntegrationTestContext, WebIntegrationTestContext } from '../context'
 
-import { BACKEND_INSIGHTS } from './utils/insight-mock-data'
-import { overrideGraphQLExtensions } from './utils/override-insights-graphql'
+import { MIGRATION_TO_GQL_INSIGHT_DATA_FIXTURE } from './fixtures/calculated-insights'
+import { createJITMigrationToGQLInsightMetadataFixture } from './fixtures/insights-metadata'
+import { overrideInsightsGraphQLApi } from './utils/override-insights-graphql-api'
 
 describe('Backend insight drill down filters', () => {
     let driver: Driver
@@ -20,48 +21,49 @@ describe('Backend insight drill down filters', () => {
         driver = await createDriverForTest()
     })
 
-    after(() => driver?.close())
-
     beforeEach(async function () {
         testContext = await createWebIntegrationTestContext({
             driver,
             currentTest: this.currentTest!,
             directory: __dirname,
+            customContext: {
+                // Enforce using a new gql API for code insights pages
+                codeInsightsGqlApiEnabled: true,
+            },
         })
     })
 
-    afterEachSaveScreenshotIfFailed(() => driver.page)
+    after(() => driver?.close())
     afterEach(() => testContext?.dispose())
+    afterEachSaveScreenshotIfFailed(() => driver.page)
 
     it('should update user settings if drill-down filters have been persisted', async () => {
-        const userSubjectSettigns = {
-            'insights.allrepos': {
-                'searchInsights.insight.backend_ID_001': {
-                    series: [],
-                },
-            },
-        }
-
-        overrideGraphQLExtensions({
+        overrideInsightsGraphQLApi({
             testContext,
-            userSettings: userSubjectSettigns,
             overrides: {
-                // Mock back-end insights with standard gql API handler.
-                Insights: () => ({ insights: { nodes: BACKEND_INSIGHTS } }),
-                OverwriteSettings: () => ({
-                    settingsMutation: {
-                        overwriteSettings: {
-                            empty: emptyResponse,
-                        },
+                // Mock back-end insights with standard gql API handler
+                GetInsights: () => ({
+                    __typename: 'Query',
+                    insightViews: {
+                        __typename: 'InsightViewConnection',
+                        nodes: [createJITMigrationToGQLInsightMetadataFixture({ type: 'calculated' })],
                     },
                 }),
 
-                SubjectSettings: () => ({
-                    settingsSubject: {
-                        latestSettings: {
-                            id: 310,
-                            contents: JSON.stringify(userSubjectSettigns),
-                        },
+                // Calculated insight mock
+                GetInsightView: () => ({
+                    __typename: 'Query',
+                    insightViews: {
+                        __typename: 'InsightViewConnection',
+                        nodes: [MIGRATION_TO_GQL_INSIGHT_DATA_FIXTURE],
+                    },
+                }),
+
+                UpdateLineChartSearchInsight: () => ({
+                    __typename: 'Mutation',
+                    updateLineChartSearchInsight: {
+                        __typename: 'InsightViewPayload',
+                        view: createJITMigrationToGQLInsightMetadataFixture({ type: 'calculated' }),
                     },
                 }),
             },
@@ -85,56 +87,60 @@ describe('Backend insight drill down filters', () => {
 
         const variables = await testContext.waitForGraphQLRequest(async () => {
             await driver.page.click('[role="dialog"][aria-label="Drill-down filters panel"] button[type="submit"]')
-        }, 'Insights')
+        }, 'UpdateLineChartSearchInsight')
 
-        assert.deepStrictEqual(variables, {
-            ids: ['searchInsights.insight.backend_ID_001'],
-            includeRepoRegex: '',
-            excludeRepoRegex: 'github.com/sourcegraph/sourcegraph',
+        assert.deepStrictEqual(variables.input.viewControls, {
+            filters: {
+                includeRepoRegex: '',
+                excludeRepoRegex: 'github.com/sourcegraph/sourcegraph',
+            },
         })
     })
 
     it('should create a new insight with predefined filters via drill-down flow insight creation', async () => {
-        const userSubjectSettigns = {
-            'insights.allrepos': {
-                'searchInsights.insight.backend_ID_001': {
-                    title: 'Linear backend insight with filters',
-                    repositories: [],
-                    series: [
-                        {
-                            name: 'Series #1',
-                            query: 'test query string',
-                            stroke: 'var(--primary)',
-                        },
-                    ],
-                    filters: {
-                        includeRepoRegexp: '',
-                        excludeRepoRegexp: 'github.com/sourcegraph/sourcegraph',
-                    },
-                },
+        const insightWithFilters: InsightViewNode = {
+            ...createJITMigrationToGQLInsightMetadataFixture({ type: 'calculated' }),
+            appliedFilters: {
+                __typename: 'InsightViewFilters',
+                includeRepoRegex: '',
+                excludeRepoRegex: 'github.com/sourcegraph/sourcegraph',
             },
         }
 
-        overrideGraphQLExtensions({
+        overrideInsightsGraphQLApi({
             testContext,
-            userSettings: userSubjectSettigns,
             overrides: {
-                // Mock back-end insights with standard gql API handler.
-                Insights: () => ({ insights: { nodes: BACKEND_INSIGHTS } }),
-                OverwriteSettings: () => ({
-                    settingsMutation: {
-                        overwriteSettings: {
-                            empty: emptyResponse,
-                        },
+                // Mock back-end insights with standard gql API handler
+                GetInsights: () => ({
+                    __typename: 'Query',
+                    insightViews: {
+                        __typename: 'InsightViewConnection',
+                        nodes: [insightWithFilters],
                     },
                 }),
 
-                SubjectSettings: () => ({
-                    settingsSubject: {
-                        latestSettings: {
-                            id: 310,
-                            contents: JSON.stringify(userSubjectSettigns),
-                        },
+                // Calculated insight mock
+                GetInsightView: () => ({
+                    __typename: 'Query',
+                    insightViews: {
+                        __typename: 'InsightViewConnection',
+                        nodes: [MIGRATION_TO_GQL_INSIGHT_DATA_FIXTURE],
+                    },
+                }),
+
+                FirstStepCreateSearchBasedInsight: () => ({
+                    __typename: 'Mutation',
+                    createLineChartSearchInsight: {
+                        __typename: 'InsightViewPayload',
+                        view: createJITMigrationToGQLInsightMetadataFixture({ type: 'calculated' }),
+                    },
+                }),
+
+                UpdateLineChartSearchInsight: () => ({
+                    __typename: 'Mutation',
+                    updateLineChartSearchInsight: {
+                        __typename: 'InsightViewPayload',
+                        view: createJITMigrationToGQLInsightMetadataFixture({ type: 'calculated' }),
                     },
                 }),
             },
@@ -157,42 +163,52 @@ describe('Backend insight drill down filters', () => {
 
         const variables = await testContext.waitForGraphQLRequest(async () => {
             await driver.page.click('[role="dialog"][aria-label="Drill-down filters panel"] button[type="submit"]')
-        }, 'OverwriteSettings')
+        }, 'UpdateLineChartSearchInsight')
 
-        assert.deepStrictEqual(JSON.parse(variables.contents), {
-            'insights.allrepos': {
-                'searchInsights.insight.backend_ID_001': {
-                    title: 'Linear backend insight with filters',
-                    repositories: [],
-                    series: [
-                        {
-                            name: 'Series #1',
-                            query: 'test query string',
-                            stroke: 'var(--primary)',
+        assert.deepStrictEqual(variables.input, {
+            dataSeries: [
+                {
+                    seriesId: '001',
+                    query: 'patternType:regex case:yes \\*\\sas\\sGQL',
+                    options: {
+                        label: 'Imports of old GQL.* types',
+                        lineColor: 'var(--oc-red-7)',
+                    },
+                    repositoryScope: {
+                        repositories: [],
+                    },
+                    timeScope: {
+                        stepInterval: {
+                            unit: 'WEEK',
+                            value: 6,
                         },
-                    ],
-                    filters: {
-                        includeRepoRegexp: '',
-                        excludeRepoRegexp: 'github.com/sourcegraph/sourcegraph',
                     },
                 },
-                'searchInsights.insight.insightWithFilters': {
-                    title: 'Insight with filters',
-                    repositories: [],
-                    series: [
-                        {
-                            name: 'Series #1',
-                            query: 'test query string',
-                            stroke: 'var(--primary)',
+                {
+                    seriesId: '002',
+                    query: "patternType:regexp case:yes /graphql-operations'",
+                    options: {
+                        label: 'Imports of new graphql-operations types',
+                        lineColor: 'var(--oc-blue-7)',
+                    },
+                    repositoryScope: {
+                        repositories: [],
+                    },
+                    timeScope: {
+                        stepInterval: {
+                            unit: 'WEEK',
+                            value: 6,
                         },
-                    ],
-                    step: {
-                        months: 1,
                     },
-                    filters: {
-                        includeRepoRegexp: '',
-                        excludeRepoRegexp: 'github.com/sourcegraph/sourcegraph',
-                    },
+                },
+            ],
+            presentationOptions: {
+                title: 'Migration to new GraphQL TS types',
+            },
+            viewControls: {
+                filters: {
+                    includeRepoRegex: '',
+                    excludeRepoRegex: 'github.com/sourcegraph/sourcegraph',
                 },
             },
         })

--- a/client/web/src/integration/insights/fixtures/calculated-insights.ts
+++ b/client/web/src/integration/insights/fixtures/calculated-insights.ts
@@ -1,0 +1,116 @@
+import { InsightDataNode } from '../../../graphql-operations'
+
+export const MIGRATION_TO_GQL_INSIGHT_DATA_FIXTURE: InsightDataNode = {
+    __typename: 'InsightView',
+    id: '001',
+    dataSeries: [
+        {
+            __typename: 'InsightsSeries',
+            seriesId: '001',
+            label: 'Imports of old GQL.* types',
+            points: [
+                {
+                    dateTime: '2021-02-11T00:00:00Z',
+                    value: 100,
+                },
+                {
+                    dateTime: '2021-01-27T00:00:00Z',
+                    value: 90,
+                },
+                {
+                    dateTime: '2021-01-12T00:00:00Z',
+                    value: 85,
+                },
+                {
+                    dateTime: '2020-12-28T00:00:00Z',
+                    value: 45,
+                },
+                {
+                    dateTime: '2020-12-13T00:00:00Z',
+                    value: 36,
+                },
+                {
+                    dateTime: '2020-11-28T00:00:00Z',
+                    value: 20,
+                },
+                {
+                    dateTime: '2020-11-13T00:00:00Z',
+                    value: 15,
+                },
+                {
+                    dateTime: '2020-10-29T00:00:00Z',
+                    value: 8,
+                },
+                {
+                    dateTime: '2020-10-14T00:00:00Z',
+                    value: 7,
+                },
+                {
+                    dateTime: '2020-09-29T00:00:00Z',
+                    value: 1,
+                },
+            ],
+            status: {
+                __typename: 'InsightSeriesStatus',
+                backfillQueuedAt: '2022-01-01',
+                completedJobs: 100,
+                pendingJobs: 0,
+                failedJobs: 0,
+            },
+        },
+        {
+            __typename: 'InsightsSeries',
+            seriesId: '002',
+            label: 'Imports of new graphql-operations types',
+            points: [
+                {
+                    dateTime: '2021-02-11T00:00:00Z',
+                    value: 0,
+                },
+                {
+                    dateTime: '2021-01-27T00:00:00Z',
+                    value: 0,
+                },
+                {
+                    dateTime: '2021-01-12T00:00:00Z',
+                    value: 10,
+                },
+                {
+                    dateTime: '2020-12-28T00:00:00Z',
+                    value: 45,
+                },
+                {
+                    dateTime: '2020-12-13T00:00:00Z',
+                    value: 60,
+                },
+                {
+                    dateTime: '2020-11-28T00:00:00Z',
+                    value: 65,
+                },
+                {
+                    dateTime: '2020-11-13T00:00:00Z',
+                    value: 65,
+                },
+                {
+                    dateTime: '2020-10-29T00:00:00Z',
+                    value: 88,
+                },
+                {
+                    dateTime: '2020-10-14T00:00:00Z',
+                    value: 96,
+                },
+                {
+                    dateTime: '2020-09-29T00:00:00Z',
+                    value: 99,
+                },
+            ],
+            status: {
+                __typename: 'InsightSeriesStatus',
+                backfillQueuedAt: '2022-01-01',
+                completedJobs: 100,
+                pendingJobs: 0,
+                failedJobs: 0,
+            },
+        },
+    ],
+}

--- a/client/web/src/integration/insights/fixtures/insights-metadata.ts
+++ b/client/web/src/integration/insights/fixtures/insights-metadata.ts
@@ -1,0 +1,143 @@
+import { InsightViewNode, TimeIntervalStepUnit } from '../../../graphql-operations'
+
+interface InsightOptions {
+    type: 'calculated' | 'just-in-time'
+}
+
+export const createJITMigrationToGQLInsightMetadataFixture = (options: InsightOptions): InsightViewNode => ({
+    __typename: 'InsightView',
+    id: '001',
+    dashboardReferenceCount: 0,
+    appliedFilters: {
+        __typename: 'InsightViewFilters',
+        includeRepoRegex: '',
+        excludeRepoRegex: '',
+    },
+    presentation: {
+        __typename: 'LineChartInsightViewPresentation',
+        title: 'Migration to new GraphQL TS types',
+        seriesPresentation: [
+            {
+                __typename: 'LineChartDataSeriesPresentation',
+                seriesId: '001',
+                label: 'Imports of old GQL.* types',
+                color: 'var(--oc-red-7)',
+            },
+            {
+                __typename: 'LineChartDataSeriesPresentation',
+                seriesId: '002',
+                label: 'Imports of new graphql-operations types',
+                color: 'var(--oc-blue-7)',
+            },
+        ],
+    },
+    dataSeriesDefinitions: [
+        {
+            __typename: 'SearchInsightDataSeriesDefinition',
+            seriesId: '001',
+            query: 'patternType:regex case:yes \\*\\sas\\sGQL',
+            isCalculated: options.type === 'calculated',
+            generatedFromCaptureGroups: false,
+            repositoryScope: {
+                __typename: 'InsightRepositoryScope',
+                repositories: ['github.com/sourcegraph/sourcegraph'],
+            },
+            timeScope: {
+                __typename: 'InsightIntervalTimeScope',
+                unit: TimeIntervalStepUnit.WEEK,
+                value: 6,
+            },
+        },
+        {
+            __typename: 'SearchInsightDataSeriesDefinition',
+            seriesId: '002',
+            query: "patternType:regexp case:yes /graphql-operations'",
+            isCalculated: options.type === 'calculated',
+            generatedFromCaptureGroups: false,
+            repositoryScope: {
+                __typename: 'InsightRepositoryScope',
+                repositories: ['github.com/sourcegraph/sourcegraph'],
+            },
+            timeScope: {
+                __typename: 'InsightIntervalTimeScope',
+                unit: TimeIntervalStepUnit.WEEK,
+                value: 6,
+            },
+        },
+    ],
+})
+
+export const STORYBOOK_GROWTH_INSIGHT_METADATA_FIXTURE: InsightViewNode = {
+    __typename: 'InsightView',
+    id: '002',
+    dashboardReferenceCount: 0,
+    appliedFilters: {
+        __typename: 'InsightViewFilters',
+        includeRepoRegex: '',
+        excludeRepoRegex: '',
+    },
+    presentation: {
+        __typename: 'LineChartInsightViewPresentation',
+        title: 'Team head count',
+        seriesPresentation: [
+            {
+                __typename: 'LineChartDataSeriesPresentation',
+                seriesId: '001',
+                label: 'Client storybook tests',
+                color: 'var(--oc-blue-7)',
+            },
+        ],
+    },
+    dataSeriesDefinitions: [
+        {
+            __typename: 'SearchInsightDataSeriesDefinition',
+            seriesId: '001',
+            query: 'patternType:regexp f:\\.story\\.tsx$ \\badd\\(',
+            isCalculated: false,
+            generatedFromCaptureGroups: false,
+            repositoryScope: {
+                __typename: 'InsightRepositoryScope',
+                repositories: ['github.com/sourcegraph/sourcegraph'],
+            },
+            timeScope: {
+                __typename: 'InsightIntervalTimeScope',
+                unit: TimeIntervalStepUnit.WEEK,
+                value: 6,
+            },
+        },
+    ],
+}
+
+export const SOURCEGRAPH_LANG_STATS_INSIGHT_METADATA_FIXTURE: InsightViewNode = {
+    __typename: 'InsightView',
+    id: '003',
+    dashboardReferenceCount: 0,
+    appliedFilters: {
+        __typename: 'InsightViewFilters',
+        includeRepoRegex: '',
+        excludeRepoRegex: '',
+    },
+    presentation: {
+        __typename: 'PieChartInsightViewPresentation',
+        title: 'Sourcegraph languages',
+        otherThreshold: 0.03,
+    },
+    dataSeriesDefinitions: [
+        {
+            seriesId: '001',
+            query: '',
+            repositoryScope: {
+                repositories: ['github.com/sourcegraph/sourcegraph'],
+                __typename: 'InsightRepositoryScope',
+            },
+            timeScope: {
+                unit: TimeIntervalStepUnit.MONTH,
+                value: 0,
+                __typename: 'InsightIntervalTimeScope',
+            },
+            isCalculated: false,
+            generatedFromCaptureGroups: false,
+            __typename: 'SearchInsightDataSeriesDefinition',
+        },
+    ],
+}

--- a/client/web/src/integration/insights/fixtures/runtime-insights.ts
+++ b/client/web/src/integration/insights/fixtures/runtime-insights.ts
@@ -1,6 +1,25 @@
-import { BulkSearchCommits } from '../../../graphql-operations'
+import { BulkSearchCommits, BulkSearchFields, SearchResultsStatsResult } from '../../../graphql-operations'
 
-export const SEARCH_INSIGHT_COMMITS_MOCK: Record<string, BulkSearchCommits> = {
+/**
+ * All just in time insights on the fronted since we don't have pre-calculated data for them in
+ * the code insights database tables work through our Search API gql handlers and have two steps
+ * pipeline.
+ *
+ * 1. FE logic calculates list of dates for possible commits in insight's repositories field -
+ * BulkSearchCommits mock
+ *
+ * 2. Then we query insight query for each commit that we got on the first step and process search
+ * matches - BulkSearchCommits
+ *
+ * Note that code stats insight works in one-step pipeline since we don't history quries there and
+ * always show the latest data for code stat insight repository.
+ */
+
+/**
+ * Metadata for just in time (FE) insight commit search. This fixture provides commits metadata
+ * - the first step in just in time insight processing
+ */
+export const STORYBOOK_GROWTH_INSIGHT_COMMITS_FIXTURE: Record<string, BulkSearchCommits> = {
     search0: {
         results: {
             results: [
@@ -108,7 +127,11 @@ export const SEARCH_INSIGHT_COMMITS_MOCK: Record<string, BulkSearchCommits> = {
     },
 }
 
-export const SEARCH_INSIGHT_RESULT_MOCK = {
+/**
+ * This fixture provides search API matches data - the second step in just in time processing
+ * data.
+ */
+export const STORYBOOK_GROWTH_INSIGHT_MATCH_DATA_FIXTURE: Record<string, BulkSearchFields> = {
     search0: { results: { matchCount: 10245 } },
     search1: { results: { matchCount: 16502 } },
     search2: { results: { matchCount: 17207 } },
@@ -118,95 +141,7 @@ export const SEARCH_INSIGHT_RESULT_MOCK = {
     search6: { results: { matchCount: 41029 } },
 }
 
-export const CODE_STATS_RESULT_MOCK = {
-    search: {
-        results: { limitHit: false },
-        stats: {
-            languages: [
-                { name: 'Go', totalLines: 4498 },
-                { name: 'JavaScript', totalLines: 948 },
-                { name: 'Markdown', totalLines: 557 },
-                { name: 'CSS', totalLines: 338 },
-                { name: 'HTML', totalLines: 48 },
-                { name: 'Text', totalLines: 21 },
-                { name: 'YAML', totalLines: 1 },
-            ],
-        },
-    },
-}
-
-/**
- * Backend Insight with linear increasing data
- */
-export const LINEAR_BACKEND_INSIGHT = {
-    id: 'backend_ID_001',
-    title: 'Testing Insight',
-    description: 'Insight for testing',
-    series: [
-        {
-            label: 'Insight',
-            points: [
-                {
-                    dateTime: '2021-02-11T00:00:00Z',
-                    value: 9,
-                },
-                {
-                    dateTime: '2021-01-27T00:00:00Z',
-                    value: 8,
-                },
-                {
-                    dateTime: '2021-01-12T00:00:00Z',
-                    value: 7,
-                },
-                {
-                    dateTime: '2020-12-28T00:00:00Z',
-                    value: 6,
-                },
-                {
-                    dateTime: '2020-12-13T00:00:00Z',
-                    value: 5,
-                },
-                {
-                    dateTime: '2020-11-28T00:00:00Z',
-                    value: 4,
-                },
-                {
-                    dateTime: '2020-11-13T00:00:00Z',
-                    value: 3,
-                },
-                {
-                    dateTime: '2020-10-29T00:00:00Z',
-                    value: 2,
-                },
-                {
-                    dateTime: '2020-10-14T00:00:00Z',
-                    value: 1,
-                },
-                {
-                    dateTime: '2020-09-29T00:00:00Z',
-                    value: 0,
-                },
-            ],
-            status: {
-                pendingJobs: 0,
-                completedJobs: 0,
-                failedJobs: 0,
-                backfillQueuedAt: '2021-02-11T00:00:00Z',
-            },
-        },
-    ],
-}
-
-/**
- * Mock data for gql api our backend insights.
- */
-export const BACKEND_INSIGHTS = [LINEAR_BACKEND_INSIGHT]
-
-/**
- * Mock gql api for live preview chart of `INSIGHT_VIEW_TYPES_MIGRATION` insight.
- * {@link INSIGHT_VIEW_TYPES_MIGRATION}
- */
-export const INSIGHT_TYPES_MIGRATION_COMMITS: Record<string, BulkSearchCommits> = {
+export const MIGRATION_TO_GQL_INSIGHT_COMMITS_FIXTURE: Record<string, BulkSearchCommits> = {
     search0: {
         results: {
             results: [
@@ -215,7 +150,7 @@ export const INSIGHT_TYPES_MIGRATION_COMMITS: Record<string, BulkSearchCommits> 
                     commit: {
                         oid: '2a1cd8a30c72780ad884159161d0ec828cfe69a3',
                         committer: {
-                            date: '2020-05-30T19:48:57Z',
+                            date: '2020-05-29T19:48:57Z',
                         },
                     },
                 },
@@ -230,7 +165,7 @@ export const INSIGHT_TYPES_MIGRATION_COMMITS: Record<string, BulkSearchCommits> 
                     commit: {
                         oid: '68afed3a2812a197096720c80df928eba0ea0703',
                         committer: {
-                            date: '2020-07-31T20:36:59Z',
+                            date: '2020-07-29T20:36:59Z',
                         },
                     },
                 },
@@ -245,7 +180,7 @@ export const INSIGHT_TYPES_MIGRATION_COMMITS: Record<string, BulkSearchCommits> 
                     commit: {
                         oid: 'f62cb0864d367cfd09fb6f755807e6c25b44e6dd',
                         committer: {
-                            date: '2020-09-30T20:22:52Z',
+                            date: '2020-09-29T20:22:52Z',
                         },
                     },
                 },
@@ -260,7 +195,7 @@ export const INSIGHT_TYPES_MIGRATION_COMMITS: Record<string, BulkSearchCommits> 
                     commit: {
                         oid: 'ccede06037725365c3391e36b9d90c85eb00b71a',
                         committer: {
-                            date: '2020-11-30T20:27:10Z',
+                            date: '2020-11-29T20:27:10Z',
                         },
                     },
                 },
@@ -275,7 +210,7 @@ export const INSIGHT_TYPES_MIGRATION_COMMITS: Record<string, BulkSearchCommits> 
                     commit: {
                         oid: 'b29a72431e10adac2267cd4e5097f11d517e9139',
                         committer: {
-                            date: '2021-01-30T00:52:56Z',
+                            date: '2021-01-31T00:52:56Z',
                         },
                     },
                 },
@@ -290,7 +225,7 @@ export const INSIGHT_TYPES_MIGRATION_COMMITS: Record<string, BulkSearchCommits> 
                     commit: {
                         oid: '4e565e36dc880f75c12982e2aba41f2445eeb4e1',
                         committer: {
-                            date: '2021-03-31T20:47:08Z',
+                            date: '2021-03-30T20:47:08Z',
                         },
                     },
                 },
@@ -314,10 +249,7 @@ export const INSIGHT_TYPES_MIGRATION_COMMITS: Record<string, BulkSearchCommits> 
     },
 }
 
-/**
- * Mock Bulk Search gql api for live preview chart of `INSIGHT_VIEW_TYPES_MIGRATION` insight.
- * */
-export const INSIGHT_TYPES_MIGRATION_BULK_SEARCH = {
+export const MIGRATION_TO_GQL_INSIGHT_MATCHES_DATA_FIXTURE: Record<string, BulkSearchFields> = {
     search0: {
         results: {
             matchCount: 256,
@@ -391,79 +323,21 @@ export const INSIGHT_TYPES_MIGRATION_BULK_SEARCH = {
 }
 
 /**
- * Code stats insight (gql query - LangStatsInsightContent) live preview mock.
+ * For code-stats insight we have 1 step just in time processing. This fixture provides mock
+ * data for this single step.
  */
-export const LangStatsInsightContent = {
+export const SOURCEGRAPH_LANG_STATS_INSIGHT_DATA_FIXTURE: SearchResultsStatsResult = {
     search: {
-        results: {
-            limitHit: false,
-        },
+        results: { limitHit: false },
         stats: {
             languages: [
-                {
-                    name: 'Markdown',
-                    totalLines: 83176,
-                },
-                {
-                    name: 'SVG',
-                    totalLines: 17369,
-                },
-                {
-                    name: 'YAML',
-                    totalLines: 16226,
-                },
-                {
-                    name: 'TypeScript',
-                    totalLines: 9164,
-                },
-                {
-                    name: 'SCSS',
-                    totalLines: 2597,
-                },
-                {
-                    name: 'JSON',
-                    totalLines: 1801,
-                },
-                {
-                    name: 'HTML',
-                    totalLines: 1281,
-                },
-                {
-                    name: 'CSS',
-                    totalLines: 1188,
-                },
-                {
-                    name: 'JavaScript',
-                    totalLines: 473,
-                },
-                {
-                    name: 'Go',
-                    totalLines: 260,
-                },
-                {
-                    name: 'Text',
-                    totalLines: 174,
-                },
-                {
-                    name: 'TOML',
-                    totalLines: 106,
-                },
-                {
-                    name: 'EditorConfig',
-                    totalLines: 20,
-                },
-                {
-                    name: 'Jsonnet',
-                    totalLines: 15,
-                },
-                {
-                    name: 'Makefile',
-                    totalLines: 12,
-                },
-                {
-                    name: 'Ignore List',
-                    totalLines: 8,
-                },
+                { name: 'Go', totalLines: 4498 },
+                { name: 'JavaScript', totalLines: 948 },
+                { name: 'Markdown', totalLines: 557 },
+                { name: 'CSS', totalLines: 338 },
+                { name: 'HTML', totalLines: 48 },
+                { name: 'Text', totalLines: 21 },
+                { name: 'YAML', totalLines: 1 },
             ],
         },
     },


### PR DESCRIPTION
Related to https://github.com/sourcegraph/sourcegraph/issues/31412

## Context
Prior to this PR we run our web app with old setting based API hence we didn't run any integration test over new GQL API. This PR simply migrates our integration test for new GQL API and cleans up our mock and fixtures objects. 

## Test plan
- Make sure that all integration test work properly without regressions 



