### PR TITLE
dev/sg: only look for revisions in main

### DIFF
--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -110,7 +110,7 @@ func checkSgVersion() {
 		rev = BuildCommit[len("dev-"):]
 	}
 
-	out, err := run.GitCmd("rev-list", fmt.Sprintf("%s..HEAD", rev), "./dev/sg")
+	out, err := run.GitCmd("rev-list", fmt.Sprintf("%s..origin/main", rev), "./dev/sg")
 	if err != nil {
 		fmt.Printf("error getting new commits since %s in ./dev/sg: %s\n", rev, err)
 		fmt.Println("try reinstalling sg with `./dev/sg/install.sh`.")

--- a/dev/sg/sg_version.go
+++ b/dev/sg/sg_version.go
@@ -58,7 +58,7 @@ func changelogExec(ctx context.Context, args []string) error {
 	if BuildCommit != "dev" {
 		current := strings.TrimLeft(BuildCommit, "dev-")
 		if *versionChangelogNext {
-			logArgs = append(logArgs, current+"..")
+			logArgs = append(logArgs, current+"..origin/main")
 			title = fmt.Sprintf("Changes since sg release %s", BuildCommit)
 		} else {
 			logArgs = append(logArgs, current)


### PR DESCRIPTION
Fix update checks and `sg version changelog` erroneously detecting changes in branches as new `sg` changes.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Tested the raw `git log` commands.

Before, git log contains unexpected revision on a branch I'm working on:

```
~/Projects/sourcegraph/sourcegraph sg/fix-version-check
❯ git log --pretty=short --no-merges 1e32aa0711560187d8431f2d4510edc161c0d91a.. -- ./dev/sg           
commit 1a40346d264bfc57b9f1dac5cf724f03bd64501b (HEAD -> sg/fix-version-check, origin/sg/fix-version-check)
Author: Robert Lin <robert@bobheadxi.dev>

    dev/sg: only look for revisions in main

commit 5c166e94e349aa3297ef95dcab487527288112bb
Author: Thorsten Ball <mrnugget@gmail.com>

    sg migration: prefer ENV vars from config, fallback to process env (#31926)
```

After:

```
~/Projects/sourcegraph/sourcegraph sg/fix-version-check
❯ git log --pretty=short --no-merges 1e32aa0711560187d8431f2d4510edc161c0d91a..origin/main -- ./dev/sg
commit 5c166e94e349aa3297ef95dcab487527288112bb
Author: Thorsten Ball <mrnugget@gmail.com>

    sg migration: prefer ENV vars from config, fallback to process env (#31926)
```

Similarly for `rev-list`:

```
~/Projects/sourcegraph/sourcegraph sg/fix-version-check
❯ git rev-list --pretty=short --no-merges 1e32aa0711560187d8431f2d4510edc161c0d91a..origin/main -- ./dev/sg
commit 5c166e94e349aa3297ef95dcab487527288112bb
Author: Thorsten Ball <mrnugget@gmail.com>

    sg migration: prefer ENV vars from config, fallback to process env (#31926)


~/Projects/sourcegraph/sourcegraph sg/fix-version-check
❯ git rev-list --pretty=short --no-merges 1e32aa0711560187d8431f2d4510edc161c0d91a.. -- ./dev/sg 
commit 1a40346d264bfc57b9f1dac5cf724f03bd64501b
Author: Robert Lin <robert@bobheadxi.dev>

    dev/sg: only look for revisions in main

commit 5c166e94e349aa3297ef95dcab487527288112bb
Author: Thorsten Ball <mrnugget@gmail.com>

    sg migration: prefer ENV vars from config, fallback to process env (#31926)
```

