### PR TITLE
dev/sg: add update and update -local command

### DIFF
--- a/dev/sg/internal/run/helpers.go
+++ b/dev/sg/internal/run/helpers.go
@@ -49,3 +49,15 @@ func BashInRoot(ctx context.Context, cmd string, env []string) (string, error) {
 func TrimResult(s string, err error) (string, error) {
 	return strings.TrimSpace(s), err
 }
+
+func InteractiveInRoot(cmd *exec.Cmd) error {
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	repoRoot, err := root.RepositoryRoot()
+	if err != nil {
+		return err
+	}
+	cmd.Dir = repoRoot
+	return cmd.Run()
+}

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -64,6 +64,7 @@ var (
 			lintCommand,
 			checkCommand, // TODO remove after a while
 			dbCommand,
+			upgradeCommand,
 		},
 	}
 )
@@ -120,7 +121,7 @@ func checkSgVersion() {
 	out = strings.TrimSpace(out)
 	if out != "" {
 		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "------------------------------------------------------------------------------"))
-		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "  HEY! New version of sg available. Run './dev/sg/install.sh' to install it.  "))
+		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "       HEY! New version of sg available. Run 'sg upgrade' to install it.      "))
 		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "             To see what's new, run 'sg version changelog -next'.             "))
 		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "------------------------------------------------------------------------------"))
 	}

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -64,7 +64,7 @@ var (
 			lintCommand,
 			checkCommand, // TODO remove after a while
 			dbCommand,
-			upgradeCommand,
+			updateCommand,
 		},
 	}
 )

--- a/dev/sg/sg_update.go
+++ b/dev/sg/sg_update.go
@@ -13,21 +13,22 @@ import (
 )
 
 var (
-	upgradeFlags   = flag.NewFlagSet("sg upgrade", flag.ExitOnError)
-	upgradeToLocal = upgradeFlags.Bool("local", false, "Upgrade to local copy of 'dev/sg'")
+	updateFlags   = flag.NewFlagSet("sg update", flag.ExitOnError)
+	updateToLocal = updateFlags.Bool("local", false, "Update to local copy of 'dev/sg'")
 )
 
-var upgradeCommand = &ffcli.Command{
-	Name:      "upgrade",
-	FlagSet:   upgradeFlags,
-	ShortHelp: "Upgrade sg",
-	LongHelp: `Upgrade local sg installation with the latest changes. To see what's new, run:
+var updateCommand = &ffcli.Command{
+	Name:       "update",
+	FlagSet:    updateFlags,
+	ShortUsage: "sg update",
+	ShortHelp:  "Update sg.",
+	LongHelp: `Update local sg installation with the latest changes. To see what's new, run:
 
-	sg version changelog -next
+  sg version changelog -next
 
 Requires a local copy of the 'sourcegraph/sourcegraph' codebase.`,
 	Exec: func(ctx context.Context, args []string) error {
-		if *upgradeToLocal {
+		if *updateToLocal {
 			stdout.Out.WriteLine(output.Line(output.EmojiHourglass, output.StylePending, "Upgrading to local copy of 'dev/sg'..."))
 		} else {
 			// Update from remote
@@ -70,7 +71,7 @@ Requires a local copy of the 'sourcegraph/sourcegraph' codebase.`,
 			}
 
 			// Checkout main, which we will install from
-			stdout.Out.WriteLine(output.Line(output.EmojiHourglass, output.StyleSuggestion, "Setting workspace up for upgrade..."))
+			stdout.Out.WriteLine(output.Line(output.EmojiHourglass, output.StyleSuggestion, "Setting workspace up for update..."))
 			if _, err := run.GitCmd("checkout", "origin/main"); err != nil {
 				return err
 			}
@@ -84,7 +85,7 @@ Requires a local copy of the 'sourcegraph/sourcegraph' codebase.`,
 			if err != nil {
 				return err
 			}
-			stdout.Out.WriteLine(output.Linef(output.EmojiHourglass, output.StylePending, "Upgrading to sg@%s...", commit))
+			stdout.Out.WriteLine(output.Linef(output.EmojiHourglass, output.StylePending, "Updating to sg@%s...", commit))
 		}
 
 		// Run installation script
@@ -92,7 +93,7 @@ Requires a local copy of the 'sourcegraph/sourcegraph' codebase.`,
 		if err := run.InteractiveInRoot(cmd); err != nil {
 			return err
 		}
-		writeSuccessLinef("Upgrade succeeded!")
+		writeSuccessLinef("Update succeeded!")
 		return nil
 	},
 }

--- a/dev/sg/sg_upgrade.go
+++ b/dev/sg/sg_upgrade.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"os/exec"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/run"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
+	"github.com/sourcegraph/sourcegraph/lib/output"
+)
+
+var (
+	upgradeFlags   = flag.NewFlagSet("sg upgrade", flag.ExitOnError)
+	upgradeToLocal = upgradeFlags.Bool("local", false, "Upgrade to local copy of 'dev/sg'")
+)
+
+var upgradeCommand = &ffcli.Command{
+	Name:      "upgrade",
+	FlagSet:   upgradeFlags,
+	ShortHelp: "Upgrade sg",
+	LongHelp: `Upgrade local sg installation with the latest changes. To see what's new, run:
+
+	sg version changelog -next
+
+Requires a local copy of the 'sourcegraph/sourcegraph' codebase.`,
+	Exec: func(ctx context.Context, args []string) error {
+		if *upgradeToLocal {
+			stdout.Out.WriteLine(output.Line(output.EmojiHourglass, output.StylePending, "Upgrading to local copy of 'dev/sg'..."))
+		} else {
+			// Update from remote
+			if _, err := run.GitCmd("fetch", "origin", "main"); err != nil {
+				return err
+			}
+
+			// Make sure to switch back to previous working state
+			var restoreFuncs []func() error
+			defer func() {
+				stdout.Out.WriteLine(output.Line(output.EmojiHourglass, output.StyleSuggestion, "Restoring workspace..."))
+				var failed bool
+				for i := len(restoreFuncs) - 1; i >= 0; i-- {
+					if restoreErr := restoreFuncs[i](); restoreErr != nil {
+						failed = true
+						writeWarningLinef(restoreErr.Error())
+					}
+				}
+				if !failed {
+					stdout.Out.WriteLine(output.Line(output.EmojiInfo, output.StyleSuggestion, "Workspace restored!"))
+				} else {
+					writeFailureLinef("Failed to restore workspace")
+				}
+			}()
+
+			// Stash workspace if dirty
+			changes, err := run.TrimResult(run.GitCmd("status", "--porcelain"))
+			if err != nil {
+				return err
+			}
+			if len(changes) > 0 {
+				stdout.Out.WriteLine(output.Line(output.EmojiHourglass, output.StyleSuggestion, "Stashing workspace..."))
+				if _, err := run.GitCmd("stash", "--include-untracked"); err != nil {
+					return err
+				}
+				restoreFuncs = append(restoreFuncs, func() (restoreErr error) {
+					_, restoreErr = run.GitCmd("stash", "pop")
+					return
+				})
+			}
+
+			// Checkout main, which we will install from
+			stdout.Out.WriteLine(output.Line(output.EmojiHourglass, output.StyleSuggestion, "Setting workspace up for upgrade..."))
+			if _, err := run.GitCmd("checkout", "origin/main"); err != nil {
+				return err
+			}
+			restoreFuncs = append(restoreFuncs, func() (restoreErr error) {
+				_, restoreErr = run.GitCmd("switch", "-")
+				return
+			})
+
+			// For info, show what sg revision we are upgrading to
+			commit, err := run.TrimResult(run.GitCmd("rev-parse", "HEAD"))
+			if err != nil {
+				return err
+			}
+			stdout.Out.WriteLine(output.Linef(output.EmojiHourglass, output.StylePending, "Upgrading to sg@%s...", commit))
+		}
+
+		// Run installation script
+		cmd := exec.CommandContext(ctx, "./dev/sg/install.sh")
+		if err := run.InteractiveInRoot(cmd); err != nil {
+			return err
+		}
+		writeSuccessLinef("Upgrade succeeded!")
+		return nil
+	},
+}

--- a/doc/dev/background-information/sg/index.md
+++ b/doc/dev/background-information/sg/index.md
@@ -103,10 +103,10 @@ Then make sure that `~/my/path` is in your `$PATH`.
 ## Updates
 
 Once set up, `sg` will automatically check for updates and let you know when there are changes.
-To upgrade `sg`, run:
+To update `sg`, run:
 
 ```sh
-sg upgrade
+sg update
 ```
 
 > NOTE: This feature requires that Go has already been installed according to the [development quickstart guide](../../setup/quickstart.md).

--- a/doc/dev/background-information/sg/index.md
+++ b/doc/dev/background-information/sg/index.md
@@ -100,6 +100,17 @@ go build -o ~/my/path/sg ./dev/sg
 
 Then make sure that `~/my/path` is in your `$PATH`.
 
+## Updates
+
+Once set up, `sg` will automatically check for updates and let you know when there are changes.
+To upgrade `sg`, run:
+
+```sh
+sg upgrade
+```
+
+> NOTE: This feature requires that Go has already been installed according to the [development quickstart guide](../../setup/quickstart.md).
+
 ## Usage
 
 See [configuration](#configuration) to learn more about configuring `sg` behaviour.


### PR DESCRIPTION
Potentially a first step towards https://github.com/sourcegraph/sourcegraph/issues/29619 . Introduces a more ergonomic upgrade experience with `sg update`:

- fetch main
- stash changes (if any)
- check out main
- install
- restore workspace

```sh
❯ sg update -h
USAGE
  sg update

Update local sg installation with the latest changes. To see what's new, run:

  sg version changelog -next

Requires a local copy of the 'sourcegraph/sourcegraph' codebase.

FLAGS
  -local=false  Update to local copy of 'dev/sg'
```

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Note that I've since changed the command name from `upgrade` to `update`, but some manual test runs:


```
~/Projects/sourcegraph/sourcegraph sg-upgrade
❯ ./dev/sg/install.sh   
Compiling...
          _____                    _____  
         /\    \                  /\    \  
        /::\    \                /::\    \  
       /::::\    \              /::::\    \  
      /::::::\    \            /::::::\    \  
     /:::/\:::\    \          /:::/\:::\    \  
    /:::/__\:::\    \        /:::/  \:::\    \  
    \:::\   \:::\    \      /:::/    \:::\    \  
  ___\:::\   \:::\    \    /:::/    / \:::\    \  
 /\   \:::\   \:::\    \  /:::/    /   \:::\ ___\  
/::\   \:::\   \:::\____\/:::/____/  ___\:::|    |  
\:::\   \:::\   \::/    /\:::\    \ /\  /:::|____|  
 \:::\   \:::\   \/____/  \:::\    /::\ \::/    /  
  \:::\   \:::\    \       \:::\   \:::\ \/____/  
   \:::\   \:::\____\       \:::\   \:::\____\  
    \:::\  /:::/    /        \:::\  /:::/    /  
     \:::\/:::/    /          \:::\/:::/    /  
      \::::::/    /            \::::::/    /  
       \::::/    /              \::::/    /  
        \::/    /                \::/____/  
         \/____/  
  
                                                  
  sg installed to /Users/robertlin/go/bin/sg
                                                  
                  Happy hacking!

  Run 'sg version changelog' to see what has changed.

~/Projects/sourcegraph/sourcegraph sg-upgrade* 9s
❯ sg upgrade -local
⌛ Upgrading to local copy of 'dev/sg'...
Compiling...
          _____                    _____  
         /\    \                  /\    \  
        /::\    \                /::\    \  
       /::::\    \              /::::\    \  
      /::::::\    \            /::::::\    \  
     /:::/\:::\    \          /:::/\:::\    \  
    /:::/__\:::\    \        /:::/  \:::\    \  
    \:::\   \:::\    \      /:::/    \:::\    \  
  ___\:::\   \:::\    \    /:::/    / \:::\    \  
 /\   \:::\   \:::\    \  /:::/    /   \:::\ ___\  
/::\   \:::\   \:::\____\/:::/____/  ___\:::|    |  
\:::\   \:::\   \::/    /\:::\    \ /\  /:::|____|  
 \:::\   \:::\   \/____/  \:::\    /::\ \::/    /  
  \:::\   \:::\    \       \:::\   \:::\ \/____/  
   \:::\   \:::\____\       \:::\   \:::\____\  
    \:::\  /:::/    /        \:::\  /:::/    /  
     \:::\/:::/    /          \:::\/:::/    /  
      \::::::/    /            \::::::/    /  
       \::::/    /              \::::/    /  
        \::/    /                \::/____/  
         \/____/  
  
                                                  
  sg installed to /Users/robertlin/go/bin/sg
                                                  
                  Happy hacking!

  Run 'sg version changelog' to see what has changed.
✅ Upgrade succeeded!

~/Projects/sourcegraph/sourcegraph sg-upgrade*
❯ sg upgrade
⌛ Stashing workspace...
⌛ Setting workspace up for upgrade...
⌛ Upgrading to sg@09fda16d0260e3c0017cba09dfe02dec3adb3087...
Compiling...
          _____                    _____  
         /\    \                  /\    \  
        /::\    \                /::\    \  
       /::::\    \              /::::\    \  
      /::::::\    \            /::::::\    \  
     /:::/\:::\    \          /:::/\:::\    \  
    /:::/__\:::\    \        /:::/  \:::\    \  
    \:::\   \:::\    \      /:::/    \:::\    \  
  ___\:::\   \:::\    \    /:::/    / \:::\    \  
 /\   \:::\   \:::\    \  /:::/    /   \:::\ ___\  
/::\   \:::\   \:::\____\/:::/____/  ___\:::|    |  
\:::\   \:::\   \::/    /\:::\    \ /\  /:::|____|  
 \:::\   \:::\   \/____/  \:::\    /::\ \::/    /  
  \:::\   \:::\    \       \:::\   \:::\ \/____/  
   \:::\   \:::\____\       \:::\   \:::\____\  
    \:::\  /:::/    /        \:::\  /:::/    /  
     \:::\/:::/    /          \:::\/:::/    /  
      \::::::/    /            \::::::/    /  
       \::::/    /              \::::/    /  
        \::/    /                \::/____/  
         \/____/  
  
                                                  
  sg installed to /Users/robertlin/go/bin/sg
                                                  
                  Happy hacking!

  Run 'sg version changelog' to see what has changed.
✅ Upgrade succeeded!
⌛ Restoring workspace...
ℹ️ Workspace restored!

~/Projects/sourcegraph/sourcegraph sg-upgrade
❯ sg version changelog
Changes in sg release 5c166e94e349aa3297ef95dcab487527288112bb
 sg migration: prefer ENV vars from config, fallback to process env (#31926) 5c166e94e3 by Thorsten Ball, 28 hours ago
 golangci-lint: enable unparam linter (#31856) 8d3e231322 by Thorsten Ball, 29 hours ago
 migrator: Support privileged migrations (#31782) 4d73c91ac2 by Eric Fritz, 4 days ago
 dev/sg: rename sg check to sg lint (#31891) 1d524292bb by Robert Lin, 4 days ago
 migrations: Fix squashed migration data tables (#31685) 1146b52e0c by Eric Fritz, 7 days ago
 migration: Fix squashing tables defined as a row value (#31674) 66fc69bcd8 by Eric Fritz, 7 days ago
```

Also works with clean workspace:

```
~/Projects/sourcegraph/sourcegraph sg-upgrade
❯ git st
On branch sg-upgrade
nothing to commit, working tree clean

~/Projects/sourcegraph/sourcegraph sg-upgrade 9s
❯ sg upgrade
⌛ Setting up workspace for upgrade...
⌛ Upgrading to sg@09fda16d0260e3c0017cba09dfe02dec3adb3087...
Compiling...
          _____                    _____  
         /\    \                  /\    \  
        /::\    \                /::\    \  
       /::::\    \              /::::\    \  
      /::::::\    \            /::::::\    \  
     /:::/\:::\    \          /:::/\:::\    \  
    /:::/__\:::\    \        /:::/  \:::\    \  
    \:::\   \:::\    \      /:::/    \:::\    \  
  ___\:::\   \:::\    \    /:::/    / \:::\    \  
 /\   \:::\   \:::\    \  /:::/    /   \:::\ ___\  
/::\   \:::\   \:::\____\/:::/____/  ___\:::|    |  
\:::\   \:::\   \::/    /\:::\    \ /\  /:::|____|  
 \:::\   \:::\   \/____/  \:::\    /::\ \::/    /  
  \:::\   \:::\    \       \:::\   \:::\ \/____/  
   \:::\   \:::\____\       \:::\   \:::\____\  
    \:::\  /:::/    /        \:::\  /:::/    /  
     \:::\/:::/    /          \:::\/:::/    /  
      \::::::/    /            \::::::/    /  
       \::::/    /              \::::/    /  
        \::/    /                \::/____/  
         \/____/  
  
                                                  
  sg installed to /Users/robertlin/go/bin/sg
                                                  
                  Happy hacking!

  Run 'sg version changelog' to see what has changed.
✅ Upgrade succeeded!
⌛ Restoring workspace...
ℹ️ Workspace restored!
```