### PR TITLE
Revert "[cloud] Fix invitation bugs"

### DIFF
--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -196,11 +196,6 @@ func (o *OrgResolver) ViewerPendingInvitation(ctx context.Context) (*organizatio
 			return nil, nil
 		}
 		if err != nil {
-			// ignore expired invitations, otherwise error is returned
-			// for all users who have an expired invitation on record
-			if _, ok := err.(database.OrgInvitationExpiredErr); ok {
-				return nil, nil
-			}
 			return nil, err
 		}
 		return &organizationInvitationResolver{o.db, orgInvitation}, nil

--- a/cmd/frontend/graphqlbackend/org_invitations_test.go
+++ b/cmd/frontend/graphqlbackend/org_invitations_test.go
@@ -873,7 +873,6 @@ func TestResendOrganizationInvitationNotification(t *testing.T) {
 		email := "foo@bar.baz"
 		yesterday := timeNow().Add(-24 * time.Hour)
 		orgInvitations.GetPendingByIDFunc.SetDefaultReturn(&database.OrgInvitation{ID: invitationID, OrgID: orgID, RecipientEmail: email, ExpiresAt: &yesterday}, nil)
-		wantErr := database.NewOrgInvitationExpiredErr(invitationID)
 
 		RunTests(t, []*Test{
 			{
@@ -892,7 +891,7 @@ func TestResendOrganizationInvitationNotification(t *testing.T) {
 				ExpectedResult: "null",
 				ExpectedErrors: []*errors.QueryError{
 					{
-						Message: wantErr.Error(),
+						Message: "invitation is expired",
 						Path:    []interface{}{"resendOrganizationInvitationNotification"},
 					},
 				},

--- a/internal/database/org_invitations.go
+++ b/internal/database/org_invitations.go
@@ -7,10 +7,12 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/jackc/pgconn"
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 var timeNow = time.Now
@@ -41,18 +43,6 @@ func (oi *OrgInvitation) Pending() bool {
 // because it has not been expired yet).
 func (oi *OrgInvitation) Expired() bool {
 	return oi.ExpiresAt != nil && timeNow().After(*oi.ExpiresAt)
-}
-
-type OrgInvitationExpiredErr struct {
-	id int64
-}
-
-func (e OrgInvitationExpiredErr) Error() string {
-	return fmt.Sprintf("invitation with id %d is expired", e.id)
-}
-
-func NewOrgInvitationExpiredErr(id int64) OrgInvitationExpiredErr {
-	return OrgInvitationExpiredErr{id: id}
 }
 
 type OrgInvitationStore interface {
@@ -124,21 +114,10 @@ func (s *orgInvitationStore) Create(ctx context.Context, orgID, senderUserID, re
 	if recipientUserID > 0 {
 		column = "recipient_user_id"
 		value = strconv.FormatInt(int64(recipientUserID), 10)
-	} else if email != "" {
+	}
+	if email != "" {
 		column = "recipient_email"
 		value = email
-	}
-
-	// check if the invitation exists first and return that
-	q := sqlf.Sprintf(fmt.Sprintf("org_id=%%d AND %s=%%s AND responded_at IS NULL AND revoked_at IS NULL AND expires_at > now()", column), orgID, value)
-	results, err := s.list(ctx, []*sqlf.Query{
-		q,
-	}, nil)
-	if err != nil {
-		return nil, err
-	}
-	if len(results) > 0 {
-		return results[len(results)-1], nil
 	}
 
 	if err := s.Handle().DB().QueryRowContext(
@@ -146,6 +125,10 @@ func (s *orgInvitationStore) Create(ctx context.Context, orgID, senderUserID, re
 		fmt.Sprintf("INSERT INTO org_invitations(org_id, sender_user_id, %s, expires_at) VALUES($1, $2, $3, $4) RETURNING id, created_at", column),
 		orgID, senderUserID, value, expiryTime,
 	).Scan(&t.ID, &t.CreatedAt); err != nil {
+		var e *pgconn.PgError
+		if errors.As(err, &e) && e.ConstraintName == "org_invitations_singleflight" {
+			return nil, errors.New("user was already invited to organization (and has not responded yet)")
+		}
 		return nil, err
 	}
 	return t, nil
@@ -194,11 +177,10 @@ func (s *orgInvitationStore) GetPending(ctx context.Context, orgID, recipientUse
 	if len(results) == 0 {
 		return nil, OrgInvitationNotFoundError{[]interface{}{fmt.Sprintf("pending for org %d recipient %d", orgID, recipientUserID)}}
 	}
-	lastInvitation := results[len(results)-1]
-	if lastInvitation.Expired() {
-		return nil, NewOrgInvitationExpiredErr(lastInvitation.ID)
+	if results[0].Expired() {
+		return nil, errors.New("invitation is expired")
 	}
-	return lastInvitation, nil
+	return results[0], nil
 }
 
 // GetPendingByID retrieves the pending invitation (if any) based on the invitation ID
@@ -215,7 +197,7 @@ func (s *orgInvitationStore) GetPendingByID(ctx context.Context, id int64) (*Org
 		return nil, NewOrgInvitationNotFoundError(id)
 	}
 	if results[0].Expired() {
-		return nil, NewOrgInvitationExpiredErr(results[0].ID)
+		return nil, errors.New("invitation is expired")
 	}
 	return results[0], nil
 }

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1657,6 +1657,7 @@ Referenced by:
  expires_at        | timestamp with time zone |           |          | 
 Indexes:
     "org_invitations_pkey" PRIMARY KEY, btree (id)
+    "org_invitations_singleflight" UNIQUE, btree (org_id, recipient_user_id) WHERE responded_at IS NULL AND revoked_at IS NULL AND deleted_at IS NULL
     "org_invitations_org_id" btree (org_id) WHERE deleted_at IS NULL
     "org_invitations_recipient_user_id" btree (recipient_user_id) WHERE deleted_at IS NULL
 Check constraints:

--- a/migrations/frontend/1645635177/down.sql
+++ b/migrations/frontend/1645635177/down.sql
@@ -1,1 +1,0 @@
-CREATE UNIQUE INDEX org_invitations_singleflight ON org_invitations USING btree (org_id, recipient_user_id) WHERE ((responded_at IS NULL) AND (revoked_at IS NULL) AND (deleted_at IS NULL));

--- a/migrations/frontend/1645635177/metadata.yaml
+++ b/migrations/frontend/1645635177/metadata.yaml
@@ -1,2 +1,0 @@
-name: allow_another_invitation_after_previous_expired
-parents: [1645554732]

--- a/migrations/frontend/1645635177/up.sql
+++ b/migrations/frontend/1645635177/up.sql
@@ -1,1 +1,0 @@
-DROP INDEX IF EXISTS org_invitations_singleflight;


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#31727

I'm seeing this failure in my branches: https://buildkite.com/sourcegraph/sourcegraph/builds/134505#cd00284a-9139-4378-9e03-b879d81f6a32/109-2397

```
FAIL |     Migrations/frontend/idempotent_down (0.50s)
```

Test plan: https://buildkite.com/sourcegraph/sourcegraph/builds/134525 should pass