### PR TITLE
Search backend: remove unused Inputs() from SearchImplementer

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -36,8 +36,6 @@ type SearchImplementer interface {
 	Results(context.Context) (*SearchResultsResolver, error)
 	//lint:ignore U1000 is used by graphql via reflection
 	Stats(context.Context) (*searchResultsStats, error)
-
-	Inputs() run.SearchInputs
 }
 
 // NewBatchSearchImplementer returns a SearchImplementer that provides search results and suggestions.
@@ -87,10 +85,6 @@ type searchResolver struct {
 
 	zoekt        zoekt.Streamer
 	searcherURLs *endpoint.Map
-}
-
-func (r *searchResolver) Inputs() run.SearchInputs {
-	return *r.SearchInputs
 }
 
 var MockDecodedViewerFinalSettings *schema.Settings

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
-	"github.com/sourcegraph/sourcegraph/internal/search/run"
 )
 
 type searchAlertResolver struct {
@@ -62,6 +61,3 @@ func (a alertSearchImplementer) Results(context.Context) (*SearchResultsResolver
 }
 
 func (alertSearchImplementer) Stats(context.Context) (*searchResultsStats, error) { return nil, nil }
-func (alertSearchImplementer) Inputs() run.SearchInputs {
-	return run.SearchInputs{}
-}


### PR DESCRIPTION
This method is not actually part of the GraphQL interface, and was only
used by streaming search to pull the inputs off the resolver.

## Test plan

Removing dead code. Covered by static checks. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


