### PR TITLE
Search backend: remove settings from SearchArgs

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -27,9 +27,6 @@ type SearchArgs struct {
 	// to rip this out in the future, this should be possible once we can build
 	// a static representation of our job tree independently of any resolvers.
 	CodeMonitorID *graphql.ID
-
-	// For tests
-	Settings *schema.Settings
 }
 
 type SearchImplementer interface {
@@ -40,13 +37,9 @@ type SearchImplementer interface {
 
 // NewBatchSearchImplementer returns a SearchImplementer that provides search results and suggestions.
 func NewBatchSearchImplementer(ctx context.Context, db database.DB, args *SearchArgs) (_ SearchImplementer, err error) {
-	settings := args.Settings
-	if settings == nil {
-		var err error
-		settings, err = DecodedViewerFinalSettings(ctx, db)
-		if err != nil {
-			return nil, err
-		}
+	settings, err := DecodedViewerFinalSettings(ctx, db)
+	if err != nil {
+		return nil, err
 	}
 
 	inputs, err := run.NewSearchInputs(


### PR DESCRIPTION
These are documented as "for tests", but are never actually set in
tests. It is not part of the GraphQL schema, so is safe to remove.

Stacked on #32018 

## Test plan

Removing dead code. Covered statically. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


