### PR TITLE
dev/sg: use TrimPrefix instead of TrimLeft

### DIFF
--- a/dev/sg/checks.go
+++ b/dev/sg/checks.go
@@ -295,7 +295,7 @@ func checkGoVersion(versionConstraint string) func(context.Context) error {
 			return errors.Newf("unexpected output from %q: %s", out)
 		}
 
-		haveVersion := strings.TrimLeft(elems[2], "go")
+		haveVersion := strings.TrimPrefix(elems[2], "go")
 
 		return check.Version("go", haveVersion, versionConstraint)
 	}

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -106,10 +106,7 @@ func checkSgVersion() {
 		return
 	}
 
-	rev := BuildCommit
-	if strings.HasPrefix(BuildCommit, "dev-") {
-		rev = BuildCommit[len("dev-"):]
-	}
+	rev := strings.TrimPrefix(BuildCommit, "dev-")
 
 	out, err := run.GitCmd("rev-list", fmt.Sprintf("%s..origin/main", rev), "./dev/sg")
 	if err != nil {

--- a/dev/sg/sg_version.go
+++ b/dev/sg/sg_version.go
@@ -56,7 +56,7 @@ func changelogExec(ctx context.Context, args []string) error {
 	}
 	var title string
 	if BuildCommit != "dev" {
-		current := strings.TrimLeft(BuildCommit, "dev-")
+		current := strings.TrimPrefix(BuildCommit, "dev-")
 		if *versionChangelogNext {
 			logArgs = append(logArgs, current+"..origin/main")
 			title = fmt.Sprintf("Changes since sg release %s", BuildCommit)


### PR DESCRIPTION
`TrimLeft` removes all characters in the cutset, so:

```go
strings.TrimLeft("dev-e3b35a01fae596c6ca75610081cd38212de2bb68", "dev-")
// "3b35a01fae596c6ca75610081cd38212de2bb68"
```

this is because the leading `e` in the commit is trimmed out because `e` is in `dev-`. what I actually want here is `TrimPrefix`

Updates another usage of `TrimLeft` that was likely intended to be `TrimPrefix` as well

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


n/a, hard to generate a commit that starts with `d`, `e`, or `v` but this should work