### PR TITLE
move OnSourcegraphDotCom from JobArgs to SearchInputs

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/zoekt"
 	"github.com/graph-gophers/graphql-go"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 	"github.com/sourcegraph/sourcegraph/internal/search"
@@ -50,6 +51,7 @@ func NewBatchSearchImplementer(ctx context.Context, db database.DB, args *Search
 		args.Query,
 		search.Batch,
 		settings,
+		envvar.SourcegraphDotComMode(),
 	)
 	if err != nil {
 		var queryErr *run.QueryError

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -16,7 +16,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	searchlogs "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/logs"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -441,10 +440,9 @@ func LogSearchLatency(ctx context.Context, db database.DB, wg *sync.WaitGroup, s
 // JobArgs converts the parts of search resolver state to values needed to create search jobs.
 func (r *searchResolver) JobArgs() *job.Args {
 	return &job.Args{
-		SearchInputs:        r.SearchInputs,
-		OnSourcegraphDotCom: envvar.SourcegraphDotComMode(),
-		Zoekt:               r.zoekt,
-		SearcherURLs:        r.searcherURLs,
+		SearchInputs: r.SearchInputs,
+		Zoekt:        r.zoekt,
+		SearcherURLs: r.searcherURLs,
 	}
 }
 

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -20,6 +20,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	searchlogs "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/logs"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -295,7 +296,7 @@ func (h *streamHandler) startSearch(ctx context.Context, a *args) (<-chan stream
 	}
 
 	searchClient := h.newSearchClient(search.Indexed(), search.SearcherURLs())
-	inputs, err := searchClient.Plan(ctx, h.db, a.Version, strPtr(a.PatternType), a.Query, search.Streaming, settings)
+	inputs, err := searchClient.Plan(ctx, h.db, a.Version, strPtr(a.PatternType), a.Query, search.Streaming, settings, envvar.SourcegraphDotComMode())
 	if err != nil {
 		close(eventsC)
 		var queryErr *run.QueryError

--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -120,7 +120,7 @@ func TestDisplayLimit(t *testing.T) {
 
 			mockInput := make(chan streaming.SearchEvent)
 			mock := client.NewMockSearchClient()
-			mock.PlanFunc.SetDefaultHook(func(_ context.Context, _ database.DB, _ string, _ *string, queryString string, _ search.Protocol, _ *schema.Settings) (*run.SearchInputs, error) {
+			mock.PlanFunc.SetDefaultHook(func(_ context.Context, _ database.DB, _ string, _ *string, queryString string, _ search.Protocol, _ *schema.Settings, _ bool) (*run.SearchInputs, error) {
 				q, err := query.Parse(queryString, query.SearchTypeLiteral)
 				require.NoError(t, err)
 				return &run.SearchInputs{

--- a/enterprise/cmd/frontend/internal/compute/streaming/compute.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/compute.go
@@ -3,6 +3,7 @@ package streaming
 import (
 	"context"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/compute"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -53,7 +54,7 @@ func NewComputeStream(ctx context.Context, db database.DB, query string) (<-chan
 
 	patternType := "regexp"
 	searchClient := client.NewSearchClient(search.Indexed(), search.SearcherURLs())
-	inputs, err := searchClient.Plan(ctx, db, "", &patternType, searchQuery, search.Streaming, settings)
+	inputs, err := searchClient.Plan(ctx, db, "", &patternType, searchQuery, search.Streaming, settings, envvar.SourcegraphDotComMode())
 	if err != nil {
 		close(eventsC)
 		return eventsC, func() error { return err }

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/google/zoekt"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 	"github.com/sourcegraph/sourcegraph/internal/search"
@@ -26,6 +25,7 @@ type SearchClient interface {
 		searchQuery string,
 		protocol search.Protocol,
 		settings *schema.Settings,
+		sourcegraphDotComMode bool,
 	) (*run.SearchInputs, error)
 
 	Execute(
@@ -56,8 +56,9 @@ func (s *searchClient) Plan(
 	searchQuery string,
 	protocol search.Protocol,
 	settings *schema.Settings,
+	sourcegraphDotComMode bool,
 ) (*run.SearchInputs, error) {
-	return run.NewSearchInputs(ctx, db, version, patternType, searchQuery, protocol, settings)
+	return run.NewSearchInputs(ctx, db, version, patternType, searchQuery, protocol, settings, sourcegraphDotComMode)
 }
 
 func (s *searchClient) Execute(
@@ -67,10 +68,9 @@ func (s *searchClient) Execute(
 	inputs *run.SearchInputs,
 ) (*search.Alert, error) {
 	jobArgs := &job.Args{
-		SearchInputs:        inputs,
-		Zoekt:               s.zoekt,
-		SearcherURLs:        s.searcherURLs,
-		OnSourcegraphDotCom: envvar.SourcegraphDotComMode(),
+		SearchInputs: inputs,
+		Zoekt:        s.zoekt,
+		SearcherURLs: s.searcherURLs,
 	}
 	return execute.Execute(ctx, db, stream, jobArgs)
 }

--- a/internal/search/client/mock_client.go
+++ b/internal/search/client/mock_client.go
@@ -36,7 +36,7 @@ func NewMockSearchClient() *MockSearchClient {
 			},
 		},
 		PlanFunc: &SearchClientPlanFunc{
-			defaultHook: func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings) (*run.SearchInputs, error) {
+			defaultHook: func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings, bool) (*run.SearchInputs, error) {
 				return nil, nil
 			},
 		},
@@ -53,7 +53,7 @@ func NewStrictMockSearchClient() *MockSearchClient {
 			},
 		},
 		PlanFunc: &SearchClientPlanFunc{
-			defaultHook: func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings) (*run.SearchInputs, error) {
+			defaultHook: func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings, bool) (*run.SearchInputs, error) {
 				panic("unexpected invocation of MockSearchClient.Plan")
 			},
 		},
@@ -191,23 +191,23 @@ func (c SearchClientExecuteFuncCall) Results() []interface{} {
 // SearchClientPlanFunc describes the behavior when the Plan method of the
 // parent MockSearchClient instance is invoked.
 type SearchClientPlanFunc struct {
-	defaultHook func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings) (*run.SearchInputs, error)
-	hooks       []func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings) (*run.SearchInputs, error)
+	defaultHook func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings, bool) (*run.SearchInputs, error)
+	hooks       []func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings, bool) (*run.SearchInputs, error)
 	history     []SearchClientPlanFuncCall
 	mutex       sync.Mutex
 }
 
 // Plan delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockSearchClient) Plan(v0 context.Context, v1 database.DB, v2 string, v3 *string, v4 string, v5 search.Protocol, v6 *schema.Settings) (*run.SearchInputs, error) {
-	r0, r1 := m.PlanFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6)
-	m.PlanFunc.appendCall(SearchClientPlanFuncCall{v0, v1, v2, v3, v4, v5, v6, r0, r1})
+func (m *MockSearchClient) Plan(v0 context.Context, v1 database.DB, v2 string, v3 *string, v4 string, v5 search.Protocol, v6 *schema.Settings, v7 bool) (*run.SearchInputs, error) {
+	r0, r1 := m.PlanFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6, v7)
+	m.PlanFunc.appendCall(SearchClientPlanFuncCall{v0, v1, v2, v3, v4, v5, v6, v7, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the Plan method of the
 // parent MockSearchClient instance is invoked and the hook queue is empty.
-func (f *SearchClientPlanFunc) SetDefaultHook(hook func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings) (*run.SearchInputs, error)) {
+func (f *SearchClientPlanFunc) SetDefaultHook(hook func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings, bool) (*run.SearchInputs, error)) {
 	f.defaultHook = hook
 }
 
@@ -215,7 +215,7 @@ func (f *SearchClientPlanFunc) SetDefaultHook(hook func(context.Context, databas
 // Plan method of the parent MockSearchClient instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *SearchClientPlanFunc) PushHook(hook func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings) (*run.SearchInputs, error)) {
+func (f *SearchClientPlanFunc) PushHook(hook func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings, bool) (*run.SearchInputs, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -224,19 +224,19 @@ func (f *SearchClientPlanFunc) PushHook(hook func(context.Context, database.DB, 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *SearchClientPlanFunc) SetDefaultReturn(r0 *run.SearchInputs, r1 error) {
-	f.SetDefaultHook(func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings) (*run.SearchInputs, error) {
+	f.SetDefaultHook(func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings, bool) (*run.SearchInputs, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *SearchClientPlanFunc) PushReturn(r0 *run.SearchInputs, r1 error) {
-	f.PushHook(func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings) (*run.SearchInputs, error) {
+	f.PushHook(func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings, bool) (*run.SearchInputs, error) {
 		return r0, r1
 	})
 }
 
-func (f *SearchClientPlanFunc) nextHook() func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings) (*run.SearchInputs, error) {
+func (f *SearchClientPlanFunc) nextHook() func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings, bool) (*run.SearchInputs, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -290,6 +290,9 @@ type SearchClientPlanFuncCall struct {
 	// Arg6 is the value of the 7th argument passed to this method
 	// invocation.
 	Arg6 *schema.Settings
+	// Arg7 is the value of the 8th argument passed to this method
+	// invocation.
+	Arg7 bool
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 *run.SearchInputs
@@ -301,7 +304,7 @@ type SearchClientPlanFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c SearchClientPlanFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6, c.Arg7}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -30,10 +30,9 @@ import (
 )
 
 type Args struct {
-	SearchInputs        *run.SearchInputs
-	OnSourcegraphDotCom bool
-	Zoekt               zoekt.Streamer
-	SearcherURLs        *endpoint.Map
+	SearchInputs *run.SearchInputs
+	Zoekt        zoekt.Streamer
+	SearcherURLs *endpoint.Map
 }
 
 // ToSearchJob converts a query parse tree to the _internal_ representation
@@ -57,7 +56,7 @@ func ToSearchJob(jargs *Args, q query.Q) (Job, error) {
 	// still relies on all of args. In time it should depend only on the bits it truly needs.
 	args.RepoOptions = repoOptions
 
-	repoUniverseSearch, skipRepoSubsetSearch, onlyRunSearcher := jobMode(args, jargs.SearchInputs.PatternType, jargs.OnSourcegraphDotCom)
+	repoUniverseSearch, skipRepoSubsetSearch, onlyRunSearcher := jobMode(args, jargs.SearchInputs.PatternType, jargs.SearchInputs.OnSourcegraphDotCom)
 
 	var requiredJobs, optionalJobs []Job
 	addJob := func(required bool, job Job) {

--- a/internal/search/job/job_test.go
+++ b/internal/search/job/job_test.go
@@ -16,11 +16,11 @@ func TestToSearchInputs(t *testing.T) {
 		q, _ := parser(input)
 		args := &Args{
 			SearchInputs: &run.SearchInputs{
-				UserSettings: &schema.Settings{},
-				PatternType:  query.SearchTypeLiteral,
-				Protocol:     protocol,
+				UserSettings:        &schema.Settings{},
+				PatternType:         query.SearchTypeLiteral,
+				Protocol:            protocol,
+				OnSourcegraphDotCom: true,
 			},
-			OnSourcegraphDotCom: true,
 		}
 
 		j, _ := ToSearchJob(args, q)
@@ -155,11 +155,11 @@ func TestToEvaluateJob(t *testing.T) {
 		q, _ := query.ParseLiteral(input)
 		args := &Args{
 			SearchInputs: &run.SearchInputs{
-				UserSettings: &schema.Settings{},
-				PatternType:  query.SearchTypeLiteral,
-				Protocol:     protocol,
+				UserSettings:        &schema.Settings{},
+				PatternType:         query.SearchTypeLiteral,
+				Protocol:            protocol,
+				OnSourcegraphDotCom: true,
 			},
-			OnSourcegraphDotCom: true,
 		}
 
 		b, _ := query.ToBasicQuery(q)

--- a/internal/search/run/run.go
+++ b/internal/search/run/run.go
@@ -18,13 +18,14 @@ import (
 
 // SearchInputs contains fields we set before kicking off search.
 type SearchInputs struct {
-	Plan          query.Plan // the comprehensive query plan
-	Query         query.Q    // the current basic query being evaluated, one part of query.Plan
-	OriginalQuery string     // the raw string of the original search query
-	PatternType   query.SearchType
-	UserSettings  *schema.Settings
-	Features      featureflag.FlagSet
-	Protocol      search.Protocol
+	Plan                query.Plan // the comprehensive query plan
+	Query               query.Q    // the current basic query being evaluated, one part of query.Plan
+	OriginalQuery       string     // the raw string of the original search query
+	PatternType         query.SearchType
+	UserSettings        *schema.Settings
+	OnSourcegraphDotCom bool
+	Features            featureflag.FlagSet
+	Protocol            search.Protocol
 }
 
 // MaxResults computes the limit for the query.
@@ -48,6 +49,7 @@ func NewSearchInputs(
 	searchQuery string,
 	protocol search.Protocol,
 	settings *schema.Settings,
+	sourcegraphDotComMode bool,
 ) (_ *SearchInputs, err error) {
 	tr, ctx := trace.New(ctx, "NewSearchInputs", searchQuery)
 	defer func() {
@@ -87,13 +89,14 @@ func NewSearchInputs(
 	tr.LazyPrintf("parsing done")
 
 	inputs := &SearchInputs{
-		Plan:          plan,
-		Query:         plan.ToParseTree(),
-		OriginalQuery: searchQuery,
-		UserSettings:  settings,
-		Features:      featureflag.FromContext(ctx),
-		PatternType:   searchType,
-		Protocol:      protocol,
+		Plan:                plan,
+		Query:               plan.ToParseTree(),
+		OriginalQuery:       searchQuery,
+		UserSettings:        settings,
+		OnSourcegraphDotCom: sourcegraphDotComMode,
+		Features:            featureflag.FromContext(ctx),
+		PatternType:         searchType,
+		Protocol:            protocol,
 	}
 
 	tr.LazyPrintf("Parsed query: %s", inputs.Query)


### PR DESCRIPTION
I think it fits better along with the other settings, and I'm pretty
sure we can get rid of JobArgs entirely.

## Test plan

Covered by integration tests. Should be semantics-preserving though. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


