### PR TITLE
Support traceURLs with Datadog

### DIFF
--- a/cmd/frontend/internal/app/errorutil/handlers.go
+++ b/cmd/frontend/internal/app/errorutil/handlers.go
@@ -28,7 +28,7 @@ func Handler(h func(http.ResponseWriter, *http.Request) error) http.Handler {
 					ext.Error.Set(span, true)
 					span.SetTag("err", err)
 					traceID = trace.IDFromSpan(span)
-					traceURL = trace.URL(traceID, conf.ExternalURL())
+					traceURL = trace.URL(traceID, conf.ExternalURL(), conf.Tracer())
 				}
 				log15.Error(
 					"App HTTP handler error response",

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -476,7 +476,7 @@ func serveErrorNoDebug(w http.ResponseWriter, r *http.Request, db database.DB, e
 		ext.Error.Set(span, true)
 		span.SetTag("err", err)
 		span.SetTag("error-id", errorID)
-		traceURL = trace.URL(trace.IDFromSpan(span), conf.ExternalURL())
+		traceURL = trace.URL(trace.IDFromSpan(span), conf.ExternalURL(), conf.Tracer())
 	}
 	log15.Error("ui HTTP handler error response", "method", r.Method, "request_uri", r.URL.RequestURI(), "status_code", statusCode, "error", err, "error_id", errorID, "trace", traceURL)
 

--- a/cmd/frontend/internal/handlerutil/error_reporting.go
+++ b/cmd/frontend/internal/handlerutil/error_reporting.go
@@ -78,7 +78,7 @@ func reportError(r *http.Request, status int, err error, panicked bool) {
 
 	// Add appdash span ID.
 	if traceID := trace.ID(r.Context()); traceID != "" {
-		pkt.Extra["trace"] = trace.URL(traceID, conf.ExternalURL())
+		pkt.Extra["trace"] = trace.URL(traceID, conf.ExternalURL(), conf.Tracer())
 		pkt.Extra["traceID"] = traceID
 	}
 

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -223,7 +223,7 @@ func (h *errorHandler) Handle(w http.ResponseWriter, r *http.Request, status int
 	}
 	http.Error(w, displayErrBody, status)
 	traceID := trace.ID(r.Context())
-	traceURL := trace.URL(traceID, conf.ExternalURL())
+	traceURL := trace.URL(traceID, conf.ExternalURL(), conf.Tracer())
 
 	if status < 200 || status >= 500 {
 		log15.Error("API HTTP handler error response", "method", r.Method, "request_uri", r.URL.RequestURI(), "status_code", status, "error", err, "trace", traceURL, "traceID", traceID)

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -108,7 +108,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	progress := progressAggregator{
 		Start:        start,
 		Limit:        inputs.MaxResults(),
-		Trace:        trace.URL(trace.ID(ctx), conf.ExternalURL()),
+		Trace:        trace.URL(trace.ID(ctx), conf.ExternalURL(), conf.Tracer()),
 		DisplayLimit: displayLimit,
 		RepoNamer:    repoNamer(ctx, h.db),
 	}

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -997,7 +997,7 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 		}
 		if traceID := trace.ID(ctx); traceID != "" {
 			ev.AddField("traceID", traceID)
-			ev.AddField("trace", trace.URL(traceID, conf.ExternalURL()))
+			ev.AddField("trace", trace.URL(traceID, conf.ExternalURL(), conf.Tracer()))
 		}
 		if honey.Enabled() {
 			_ = ev.Send()
@@ -1389,7 +1389,7 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 
 				if traceID := trace.ID(ctx); traceID != "" {
 					ev.AddField("traceID", traceID)
-					ev.AddField("trace", trace.URL(traceID, conf.ExternalURL()))
+					ev.AddField("trace", trace.URL(traceID, conf.ExternalURL(), conf.Tracer()))
 				}
 
 				if honey.Enabled() {
@@ -1623,7 +1623,7 @@ func (s *Server) p4exec(w http.ResponseWriter, r *http.Request, req *protocol.P4
 
 				if traceID := trace.ID(ctx); traceID != "" {
 					ev.AddField("traceID", traceID)
-					ev.AddField("trace", trace.URL(traceID, conf.ExternalURL()))
+					ev.AddField("trace", trace.URL(traceID, conf.ExternalURL(), conf.Tracer()))
 				}
 
 				_ = ev.Send()

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -268,6 +268,14 @@ func ExperimentalFeatures() schema.ExperimentalFeatures {
 	return *val
 }
 
+func Tracer() string {
+	ot := Get().ObservabilityTracing
+	if ot == nil {
+		return ""
+	}
+	return ot.Type
+}
+
 // AuthMinPasswordLength returns the value of minimum password length requirement.
 // If not set, it returns the default value 12.
 func AuthMinPasswordLength() int {

--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -9,9 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
-	"github.com/sourcegraph/sourcegraph/internal/env"
-
 	"github.com/felixge/httpsnoop"
 	"github.com/gorilla/mux"
 	"github.com/inconshreveable/log15"
@@ -21,6 +18,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/repotrackutil"
 	"github.com/sourcegraph/sourcegraph/internal/sentry"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
@@ -155,7 +155,7 @@ func HTTPMiddleware(next http.Handler, siteConfig conftypes.SiteConfigQuerier) h
 		defer span.Finish()
 
 		traceID := IDFromSpan(span)
-		traceURL := URL(traceID, siteConfig.SiteConfig().ExternalURL)
+		traceURL := URL(traceID, conf.ExternalURL(), conf.Tracer())
 
 		rw.Header().Set("X-Trace", traceURL)
 		ctx = opentracing.ContextWithSpan(ctx, span)

--- a/internal/trace/traceutil.go
+++ b/internal/trace/traceutil.go
@@ -48,8 +48,7 @@ func URL(traceID, externalURL, traceProvider string) string {
 	if traceID == "" {
 		return ""
 	}
-
-	if tracerType(traceProvider) == tracer.Datadog {
+	if tracer.TracerType(traceProvider) == tracer.Datadog {
 		return "https://app.datadoghq.com/apm/trace/" + traceID
 	}
 

--- a/internal/trace/traceutil.go
+++ b/internal/trace/traceutil.go
@@ -49,7 +49,7 @@ func URL(traceID, externalURL, traceProvider string) string {
 		return ""
 	}
 
-	if traceProvider == string(tracer.Datadog) {
+	if tracerType(traceProvider) == tracer.Datadog {
 		return "https://app.datadoghq.com/apm/trace/" + traceID
 	}
 

--- a/internal/trace/traceutil.go
+++ b/internal/trace/traceutil.go
@@ -17,6 +17,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	"github.com/sourcegraph/sourcegraph/internal/tracer"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -43,9 +44,13 @@ func IDFromSpan(span opentracing.Span) string {
 }
 
 // URL returns a trace URL for the given trace ID at the given external URL.
-func URL(traceID, externalURL string) string {
+func URL(traceID, externalURL, traceProvider string) string {
 	if traceID == "" {
 		return ""
+	}
+
+	if traceProvider == string(tracer.Datadog) {
+		return "https://app.datadoghq.com/apm/trace/" + traceID
 	}
 
 	if os.Getenv("ENABLE_GRAFANA_CLOUD_TRACE_URL") != "true" {

--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -34,9 +34,9 @@ func init() {
 	}
 }
 
-// options control the behavior of a tracerType
+// options control the behavior of a TracerType
 type options struct {
-	tracerType
+	TracerType
 	externalURL string
 	debug       bool
 	// these values are not configurable at runtime
@@ -45,17 +45,17 @@ type options struct {
 	env         string
 }
 
-type tracerType string
+type TracerType string
 
 const (
-	None    tracerType = "none"
-	Datadog tracerType = "datadog"
-	Ot      tracerType = "opentracing"
+	None    TracerType = "none"
+	Datadog TracerType = "datadog"
+	Ot      TracerType = "opentracing"
 )
 
-// isSetByUser returns true if the tracerType is one supported by the schema
+// isSetByUser returns true if the TracerType is one supported by the schema
 // should be kept in sync with ObservabilityTracing.Type in schema/site.schema.json
-func (t tracerType) isSetByUser() bool {
+func (t TracerType) isSetByUser() bool {
 	switch t {
 	case Datadog, Ot:
 		return true
@@ -90,7 +90,7 @@ func initTracer(opts *options, c conftypes.WatchableSiteConfig) {
 		version:     opts.version,
 		env:         opts.env,
 		// the values below may change
-		tracerType:  None,
+		TracerType:  None,
 		debug:       false,
 		externalURL: "",
 	}
@@ -111,7 +111,7 @@ func initTracer(opts *options, c conftypes.WatchableSiteConfig) {
 				samplingStrategy = ot.TraceSelective
 				setTracer = Ot
 			}
-			if t := tracerType(tracingConfig.Type); t.isSetByUser() {
+			if t := TracerType(tracingConfig.Type); t.isSetByUser() {
 				setTracer = t
 			}
 			shouldLog = tracingConfig.Debug
@@ -124,7 +124,7 @@ func initTracer(opts *options, c conftypes.WatchableSiteConfig) {
 
 		opts := options{
 			externalURL: siteConfig.ExternalURL,
-			tracerType:  setTracer,
+			TracerType:  setTracer,
 			debug:       shouldLog,
 			serviceName: opts.serviceName,
 			version:     opts.version,
@@ -135,12 +135,12 @@ func initTracer(opts *options, c conftypes.WatchableSiteConfig) {
 			// Nothing changed
 			return
 		}
-		prevTracer := oldOpts.tracerType
+		prevTracer := oldOpts.TracerType
 		oldOpts = opts
 
 		t, closer, err := newTracer(&opts, prevTracer)
 		if err != nil {
-			log15.Warn("Could not initialize tracer", "tracer", opts.tracerType, "error", err.Error())
+			log15.Warn("Could not initialize tracer", "tracer", opts.TracerType, "error", err.Error())
 			return
 		}
 		globalTracer.set(t, closer, opts.debug)
@@ -148,15 +148,15 @@ func initTracer(opts *options, c conftypes.WatchableSiteConfig) {
 }
 
 // TODO Use openTelemetry https://github.com/sourcegraph/sourcegraph/issues/27386
-func newTracer(opts *options, prevTracer tracerType) (opentracing.Tracer, io.Closer, error) {
-	if opts.tracerType == None {
+func newTracer(opts *options, prevTracer TracerType) (opentracing.Tracer, io.Closer, error) {
+	if opts.TracerType == None {
 		log15.Info("tracing disabled")
 		if prevTracer == Datadog {
 			ddtracer.Stop()
 		}
 		return opentracing.NoopTracer{}, nil, nil
 	}
-	if opts.tracerType == Datadog {
+	if opts.TracerType == Datadog {
 		log15.Info("Datadog: tracing enabled")
 		tracer := ddopentracing.New(ddtracer.WithService(opts.serviceName),
 			ddtracer.WithDebugMode(opts.debug),


### PR DESCRIPTION
Add the same support for viewing traces on Sourcegraph Cloud as Grafana
Part of https://github.com/sourcegraph/sourcegraph/issues/30699

~~Blocked on https://github.com/sourcegraph/zoekt/issues/294~~
## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->
Steps to run locally: 

First start the local datadog agent:
```
docker run -d --cgroupns host \
              -v /var/run/docker.sock:/var/run/docker.sock:ro \
              -v /proc/:/host/proc/:ro \
              -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
              -p 127.0.0.1:8126:8126/tcp \
              -e DD_API_KEY=<DD_API_KEY>     \
              -e DD_APM_ENABLED=true \
            gcr.io/datadoghq/agent:latest
```

Modify the default dev-private to set the tracer to Datadog:
```patch
   "observability.tracing": {
     "sampling": "selective",
-    "type": "opentracing"
+    "type": "datadog"
   },
``` 

Start Sourcegraph with `CTAGS_COMMAND=ctags DD_ENV=dev DD_PROFILE_ALL=true  sg start`

