### PR TITLE
search: create dedicated searcher job

### DIFF
--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -179,7 +179,16 @@ func reposContainingPath(ctx context.Context, args *search.TextParameters, repos
 
 	// Concurrently run searcher for all unindexed repos regardless whether text or regexp.
 	g.Go(func() error {
-		return searcher.SearchOverRepos(ctx, searcherArgs, agg, unindexed, false)
+		searcherJob := &searcher.Searcher{
+			PatternInfo:     searcherArgs.PatternInfo,
+			Repos:           unindexed,
+			Indexed:         false,
+			SearcherURLs:    searcherArgs.SearcherURLs,
+			UseFullDeadline: searcherArgs.UseFullDeadline,
+		}
+
+		_, err := searcherJob.Run(ctx, nil, agg)
+		return err
 	})
 
 	err = g.Wait()

--- a/internal/search/structural/structural.go
+++ b/internal/search/structural/structural.go
@@ -60,7 +60,16 @@ type searchRepos struct {
 // getJob returns a function parameterized by ctx to search over repos.
 func (s *searchRepos) getJob(ctx context.Context) func() error {
 	return func() error {
-		return searcher.SearchOverRepos(ctx, s.args, s.stream, s.repoSet.AsList(), s.repoSet.IsIndexed())
+		searcherJob := &searcher.Searcher{
+			PatternInfo:     s.args.PatternInfo,
+			Repos:           s.repoSet.AsList(),
+			Indexed:         s.repoSet.IsIndexed(),
+			SearcherURLs:    s.args.SearcherURLs,
+			UseFullDeadline: s.args.UseFullDeadline,
+		}
+
+		_, err := searcherJob.Run(ctx, nil, s.stream)
+		return err
 	}
 }
 

--- a/internal/search/textsearch/textsearch.go
+++ b/internal/search/textsearch/textsearch.go
@@ -70,7 +70,15 @@ func (t *RepoSubsetTextSearch) Run(ctx context.Context, db database.DB, stream s
 
 		// Concurrently run searcher for all unindexed repos regardless whether text or regexp.
 		g.Go(func() error {
-			return searcher.SearchOverRepos(ctx, t.SearcherArgs, stream, unindexed, false)
+			searcherJob := &searcher.Searcher{
+				PatternInfo:     t.SearcherArgs.PatternInfo,
+				Repos:           unindexed,
+				Indexed:         false,
+				SearcherURLs:    t.SearcherArgs.SearcherURLs,
+				UseFullDeadline: t.SearcherArgs.UseFullDeadline,
+			}
+			_, err := searcherJob.Run(ctx, db, stream)
+			return err
 		})
 
 		return g.Wait()

--- a/internal/search/textsearch/textsearch_test.go
+++ b/internal/search/textsearch/textsearch_test.go
@@ -446,7 +446,16 @@ func RunRepoSubsetTextSearch(ctx context.Context, args *search.TextParameters) (
 
 	// Concurrently run searcher for all unindexed repos regardless whether text or regexp.
 	g.Go(func() error {
-		return searcher.SearchOverRepos(ctx, searcherArgs, agg, unindexed, false)
+		searcherJob := &searcher.Searcher{
+			PatternInfo:     searcherArgs.PatternInfo,
+			Repos:           unindexed,
+			Indexed:         false,
+			SearcherURLs:    searcherArgs.SearcherURLs,
+			UseFullDeadline: searcherArgs.UseFullDeadline,
+		}
+
+		_, err := searcherJob.Run(ctx, nil, agg)
+		return err
 	})
 
 	err = g.Wait()


### PR DESCRIPTION
This turns `searcher.SearchOverRepos(...)` into `Run(...)` method and converts the arguments/values to implement the `Job` interface.

## Test plan
Semantics-preserving.


