### PR TITLE
search: add repo partition job

### DIFF
--- a/internal/search/job/repo_partition_job.go
+++ b/internal/search/job/repo_partition_job.go
@@ -1,0 +1,66 @@
+package job
+
+import (
+	"context"
+	"fmt"
+
+	zoektstreamer "github.com/google/zoekt"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	"github.com/sourcegraph/sourcegraph/internal/search/repos"
+	"github.com/sourcegraph/sourcegraph/internal/search/searcher"
+	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+	"github.com/sourcegraph/sourcegraph/internal/search/zoekt"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+)
+
+type PartitionRepos struct {
+	RepoOptions      search.RepoOptions
+	UseIndex         query.YesNoOnly // whether to include indexed repos
+	ContainsRefGlobs bool            // wether to include repositories with refs
+	Jobs             []Job           // child jobs to receive partitioned repos.
+
+	Zoekt zoektstreamer.Streamer
+}
+
+func (p *PartitionRepos) Run(ctx context.Context, db database.DB, stream streaming.Sender) (_ *search.Alert, err error) {
+	tr, ctx := trace.New(ctx, "PartitionRepos", "")
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
+
+	repoResolver := &repos.Resolver{DB: db, Opts: p.RepoOptions}
+	pager := func(page *repos.Resolved) error {
+		indexed, unindexed, err := zoekt.PartitionRepos(
+			ctx,
+			page.RepoRevs,
+			p.Zoekt,
+			search.TextRequest,
+			p.UseIndex,
+			p.ContainsRefGlobs,
+			zoekt.MissingRepoRevStatus(stream),
+		)
+		if err != nil {
+			return err
+		}
+
+		for _, job := range p.Jobs {
+			switch j := job.(type) {
+			case *zoekt.ZoektRepoSubsetSearch:
+				j.Repos = indexed
+
+			case *searcher.Searcher:
+				j.Repos = unindexed
+
+			default:
+				panic(fmt.Sprintf("job %T not supported for repo pagination", job))
+			}
+
+		}
+		return nil
+	}
+
+	return nil, repoResolver.Paginate(ctx, nil, pager)
+}

--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -179,7 +179,16 @@ func reposContainingPath(ctx context.Context, args *search.TextParameters, repos
 
 	// Concurrently run searcher for all unindexed repos regardless whether text or regexp.
 	g.Go(func() error {
-		return searcher.SearchOverRepos(ctx, searcherArgs, agg, unindexed, false)
+		searcherJob := &searcher.Searcher{
+			PatternInfo:     searcherArgs.PatternInfo,
+			Repos:           unindexed,
+			Indexed:         false,
+			SearcherURLs:    searcherArgs.SearcherURLs,
+			UseFullDeadline: searcherArgs.UseFullDeadline,
+		}
+
+		_, err := searcherJob.Run(ctx, nil, agg)
+		return err
 	})
 
 	err = g.Wait()

--- a/internal/search/structural/structural.go
+++ b/internal/search/structural/structural.go
@@ -60,7 +60,16 @@ type searchRepos struct {
 // getJob returns a function parameterized by ctx to search over repos.
 func (s *searchRepos) getJob(ctx context.Context) func() error {
 	return func() error {
-		return searcher.SearchOverRepos(ctx, s.args, s.stream, s.repoSet.AsList(), s.repoSet.IsIndexed())
+		searcherJob := &searcher.Searcher{
+			PatternInfo:     s.args.PatternInfo,
+			Repos:           s.repoSet.AsList(),
+			Indexed:         s.repoSet.IsIndexed(),
+			SearcherURLs:    s.args.SearcherURLs,
+			UseFullDeadline: s.args.UseFullDeadline,
+		}
+
+		_, err := searcherJob.Run(ctx, nil, s.stream)
+		return err
 	}
 }
 

--- a/internal/search/textsearch/textsearch.go
+++ b/internal/search/textsearch/textsearch.go
@@ -70,7 +70,15 @@ func (t *RepoSubsetTextSearch) Run(ctx context.Context, db database.DB, stream s
 
 		// Concurrently run searcher for all unindexed repos regardless whether text or regexp.
 		g.Go(func() error {
-			return searcher.SearchOverRepos(ctx, t.SearcherArgs, stream, unindexed, false)
+			searcherJob := &searcher.Searcher{
+				PatternInfo:     t.SearcherArgs.PatternInfo,
+				Repos:           unindexed,
+				Indexed:         false,
+				SearcherURLs:    t.SearcherArgs.SearcherURLs,
+				UseFullDeadline: t.SearcherArgs.UseFullDeadline,
+			}
+			_, err := searcherJob.Run(ctx, db, stream)
+			return err
 		})
 
 		return g.Wait()

--- a/internal/search/textsearch/textsearch_test.go
+++ b/internal/search/textsearch/textsearch_test.go
@@ -446,7 +446,16 @@ func RunRepoSubsetTextSearch(ctx context.Context, args *search.TextParameters) (
 
 	// Concurrently run searcher for all unindexed repos regardless whether text or regexp.
 	g.Go(func() error {
-		return searcher.SearchOverRepos(ctx, searcherArgs, agg, unindexed, false)
+		searcherJob := &searcher.Searcher{
+			PatternInfo:     searcherArgs.PatternInfo,
+			Repos:           unindexed,
+			Indexed:         false,
+			SearcherURLs:    searcherArgs.SearcherURLs,
+			UseFullDeadline: searcherArgs.UseFullDeadline,
+		}
+
+		_, err := searcherJob.Run(ctx, nil, agg)
+		return err
 	})
 
 	err = g.Wait()


### PR DESCRIPTION
Putting in draft for discussion.

This makes progress on separating repo pagination and partitioning (index/unindexed) for jobs. The idea is to pull that logic into its own job (i.e., [most of these calls](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+PartitionRepos%28...%29+count:all&patternType=structural)). The open question is how to ensure/enforce hydrating repos inside this job. This PR makes progress to do that and I think we should move forward with a direction like this. It's not the final ideal state, but I do think it makes significant progress immediately by (a) disentangling state/concerns and (b) avoiding redundant repo resolution for text search jobs (and eventually, all jobs).

You can read the code to toggle comments off first:


![Screen Shot 2022-03-01 at 6 26 14 PM](https://user-images.githubusercontent.com/888624/156282887-6d880ca7-276e-455f-9e72-5a2b0927af75.png)


and then show comments for notes/discussion.



## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


