### PR TITLE
gitserver: Remove feature flag enableGitServerCommandExecFilter

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1160,12 +1160,9 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 
 		log15.Warn("exec: bad command", "RemoteAddr", r.RemoteAddr, "req.Args", req.Args)
 
-		// Temporary feature flag to disable this feature in case their are any regressions.
-		if conf.ExperimentalFeatures().EnableGitServerCommandExecFilter {
-			w.WriteHeader(http.StatusBadRequest)
-			_, _ = w.Write([]byte("invalid command"))
-			return
-		}
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("invalid command"))
+		return
 	}
 
 	ctx := r.Context()

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -24,7 +24,6 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/mutablelimiter"
@@ -32,16 +31,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
-	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 type Test struct {
-	Name                             string
-	Request                          *http.Request
-	ExpectedCode                     int
-	ExpectedBody                     string
-	ExpectedTrailers                 http.Header
-	EnableGitServerCommandExecFilter bool
+	Name             string
+	Request          *http.Request
+	ExpectedCode     int
+	ExpectedBody     string
+	ExpectedTrailers http.Header
 }
 
 func TestRequest(t *testing.T) {
@@ -118,28 +115,14 @@ func TestRequest(t *testing.T) {
 		{
 			Name:         "EmptyInput",
 			Request:      httptest.NewRequest("POST", "/exec", strings.NewReader("{}")),
-			ExpectedCode: http.StatusNotFound,
-			ExpectedBody: `{"cloneInProgress":false}`,
-		},
-		{
-			Name:                             "EmptyInput/EnableGitServerCommandExecFilter",
-			Request:                          httptest.NewRequest("POST", "/exec", strings.NewReader("{}")),
-			ExpectedCode:                     http.StatusBadRequest,
-			ExpectedBody:                     "invalid command",
-			EnableGitServerCommandExecFilter: true,
+			ExpectedCode: http.StatusBadRequest,
+			ExpectedBody: `invalid command`,
 		},
 		{
 			Name:         "BadCommand",
 			Request:      httptest.NewRequest("POST", "/exec", strings.NewReader(`{"repo":"github.com/sourcegraph/sourcegraph", "args": ["invalid-command"]}`)),
-			ExpectedCode: http.StatusNotFound,
-			ExpectedBody: `{"cloneInProgress":false}`,
-		},
-		{
-			Name:                             "BadCommand/EnableGitServerCommandExecFilter",
-			Request:                          httptest.NewRequest("POST", "/exec", strings.NewReader(`{"repo":"github.com/sourcegraph/sourcegraph", "args": ["invalid-command"]}`)),
-			ExpectedCode:                     http.StatusBadRequest,
-			ExpectedBody:                     "invalid command",
-			EnableGitServerCommandExecFilter: true,
+			ExpectedCode: http.StatusBadRequest,
+			ExpectedBody: `invalid command`,
 		},
 	}
 
@@ -184,14 +167,6 @@ func TestRequest(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			conf.Mock(&conf.Unified{
-				SiteConfiguration: schema.SiteConfiguration{
-					ExperimentalFeatures: &schema.ExperimentalFeatures{
-						EnableGitServerCommandExecFilter: test.EnableGitServerCommandExecFilter,
-					},
-				},
-			})
-
 			w := httptest.ResponseRecorder{Body: new(bytes.Buffer)}
 			h.ServeHTTP(&w, test.Request)
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -571,8 +571,6 @@ type ExperimentalFeatures struct {
 	DebugLog *DebugLog `json:"debug.log,omitempty"`
 	// DependenciesSearch description: Enables support for repo:dependencies predicate queries.
 	DependenciesSearch bool `json:"dependenciesSearch,omitempty"`
-	// EnableGitServerCommandExecFilter description: Enable filtering of all exec commands on gitserver based on a pre-defined allowlist
-	EnableGitServerCommandExecFilter bool `json:"enableGitServerCommandExecFilter,omitempty"`
 	// EnableGithubInternalRepoVisibility description: Enable support for visilibity of internal Github repositories
 	EnableGithubInternalRepoVisibility bool `json:"enableGithubInternalRepoVisibility,omitempty"`
 	// EnablePermissionsWebhooks description: Enables webhook consumers to sync permissions from external services faster than the defaults schedule

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -375,11 +375,6 @@
           "description": "Enable support for visilibity of internal Github repositories",
           "type": "boolean",
           "default": false
-        },
-        "enableGitServerCommandExecFilter": {
-          "description": "Enable filtering of all exec commands on gitserver based on a pre-defined allowlist",
-          "type": "boolean",
-          "default": true
         }
       },
       "examples": [


### PR DESCRIPTION
We have noticed no regressions so it is safe to remove the flag and
enable the guarded behaviour by default.

Closes #31388.

Closes the loop on
https://github.com/sourcegraph/security-issues/issues/213.

Easier to see the diff with [hide whitespace enabled](https://github.com/sourcegraph/sourcegraph/pull/32030/files?diff=unified&w=1).

## Test plan

`sg start dotcom` works locally. No additional testing required.

## Post deployment

Remove the flag from site config on dogfood and cloud.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


