### PR TITLE
dependencies api: Batch database updates

### DIFF
--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -208,8 +208,9 @@ func (s *JVMPackagesSyncer) packageDependencies(ctx context.Context, repoUrlPath
 	}
 
 	dbDeps, err := s.DepsStore.ListDependencyRepos(ctx, dependenciesStore.ListDependencyReposOpts{
-		Scheme: dependenciesStore.JVMPackagesScheme,
-		Name:   repoUrlPath,
+		Scheme:      dependenciesStore.JVMPackagesScheme,
+		Name:        repoUrlPath,
+		NewestFirst: true,
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get JVM dependency repos from database", "repoPath", repoUrlPath)

--- a/cmd/gitserver/server/vcs_syncer_npm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages.go
@@ -201,8 +201,9 @@ func (s *NPMPackagesSyncer) packageDependencies(ctx context.Context, repoUrlPath
 		return nil, err
 	}
 	dbDeps, err := s.depsStore.ListDependencyRepos(ctx, dependenciesStore.ListDependencyReposOpts{
-		Scheme: dependenciesStore.NPMPackagesScheme,
-		Name:   parsedPackage.PackageSyntax(),
+		Scheme:      dependenciesStore.NPMPackagesScheme,
+		Name:        parsedPackage.PackageSyntax(),
+		NewestFirst: true,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get npm dependencies from dbStore")

--- a/enterprise/internal/batches/store/batch_spec_workspaces.go
+++ b/enterprise/internal/batches/store/batch_spec_workspaces.go
@@ -134,7 +134,7 @@ func (s *Store) CreateBatchSpecWorkspace(ctx context.Context, ws ...*btypes.Batc
 		batchSpecWorkspaceInsertColumns,
 		"",
 		BatchSpecWorkspaceColums,
-		func(rows *sql.Rows) error {
+		func(rows dbutil.Scanner) error {
 			i++
 			return scanBatchSpecWorkspace(ws[i], rows)
 		},

--- a/enterprise/internal/batches/store/changeset_jobs.go
+++ b/enterprise/internal/batches/store/changeset_jobs.go
@@ -111,7 +111,7 @@ func (s *Store) CreateChangesetJob(ctx context.Context, cs ...*btypes.ChangesetJ
 		changesetJobInsertColumns,
 		"",
 		changesetJobColumns,
-		func(rows *sql.Rows) error {
+		func(rows dbutil.Scanner) error {
 			i++
 			return scanChangesetJob(cs[i], rows)
 		},

--- a/enterprise/internal/batches/store/changeset_specs.go
+++ b/enterprise/internal/batches/store/changeset_specs.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"strconv"
 
@@ -134,7 +133,7 @@ func (s *Store) CreateChangesetSpec(ctx context.Context, cs ...*btypes.Changeset
 		changesetSpecInsertColumns,
 		"",
 		changesetSpecColumns,
-		func(rows *sql.Rows) error {
+		func(rows dbutil.Scanner) error {
 			i++
 			return scanChangesetSpec(cs[i], rows)
 		},

--- a/enterprise/internal/batches/testing/batch_spec_workspace_execution_jobs.go
+++ b/enterprise/internal/batches/testing/batch_spec_workspace_execution_jobs.go
@@ -2,7 +2,6 @@ package testing
 
 import (
 	"context"
-	"database/sql"
 	"testing"
 	"time"
 
@@ -105,7 +104,7 @@ func CreateBatchSpecWorkspaceExecutionJob(ctx context.Context, s createBatchSpec
 			"batch_spec_workspace_execution_jobs.created_at",
 			"batch_spec_workspace_execution_jobs.updated_at",
 		},
-		func(rows *sql.Rows) error {
+		func(rows dbutil.Scanner) error {
 			i++
 			return scanFn(jobs[i], rows)
 		},

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -3,7 +3,6 @@ package dependencies
 import (
 	"context"
 	"strings"
-	"sync"
 
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go/log"
@@ -13,30 +12,159 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/store"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
+	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
+	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 // Service encapsulates the resolution and persistence of dependencies at the repository and package levels.
 type Service struct {
-	dependenciesStore *store.Store
-	lockfilesSvc      LockfilesService
-	syncer            Syncer
-	operations        *operations
+	dependenciesStore  *store.Store
+	lockfilesSvc       LockfilesService
+	lockfilesSemaphore *semaphore.Weighted
+	syncer             Syncer
+	syncerSemaphore    *semaphore.Weighted
+	operations         *operations
 }
+
+var (
+	lockfilesSemaphoreWeight = env.MustGetInt("CODEINTEL_DEPENDENCIES_LOCKFILES_SEMAPHORE_WEIGHT", 64, "The maximum number of concurrent routines parsing lockfile contents.")``
+	syncerSemaphoreWeight    = env.MustGetInt("CODEINTEL_DEPENDENCIES_LOCKFILES_SYNCER_WEIGHT", 64, "The maximum number of concurrent routines actively syncing repositories.")``
+)
 
 func newService(depsStore *store.Store, lockfilesSvc LockfilesService, syncer Syncer, observationContext *observation.Context) *Service {
 	return &Service{
-		dependenciesStore: depsStore,
-		lockfilesSvc:      lockfilesSvc,
-		syncer:            syncer,
-		operations:        newOperations(observationContext),
+		dependenciesStore:  depsStore,
+		lockfilesSvc:       lockfilesSvc,
+		lockfilesSemaphore: semaphore.NewWeighted(int64(lockfilesSemaphoreWeight)),
+		syncer:             syncer,
+		syncerSemaphore:    semaphore.NewWeighted(int64(syncerSemaphoreWeight)),
+		operations:         newOperations(observationContext),
 	}
 }
 
 // Dependencies resolves the (transitive) dependencies for a set of repository and revisions.
 // Both the input repoRevs and the output dependencyRevs are a map from repository names to revspecs.
 func (s *Service) Dependencies(ctx context.Context, repoRevs map[api.RepoName]types.RevSpecSet) (dependencyRevs map[api.RepoName]types.RevSpecSet, err error) {
-	logFields := make([]log.Field, 0, 2)
+	ctx, endObservation := s.operations.dependencies.With(ctx, &err, observation.Args{LogFields: constructLogFields(repoRevs)})
+	defer func() {
+		endObservation(1, observation.Args{LogFields: []log.Field{
+			log.Int("numDependencyRevs", len(dependencyRevs)),
+		}})
+	}()
+
+	// Parse lockfile contents for the given repository and revision pairs
+	deps, err := s.lockfileDependencies(ctx, repoRevs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Populate return value map from the given information. In teh same pass, populate
+	// auxiliary data structures that can be used to feed the upsert and sync operations
+	// below.
+	dependencyRevs = make(map[api.RepoName]types.RevSpecSet, len(repoRevs))
+	dependencies := []store.DependencyRepo{}
+	repoNamesByDependency := map[store.DependencyRepo]api.RepoName{}
+
+	for _, dep := range deps {
+		repo := dep.RepoName()
+		rev := api.RevSpec(dep.GitTagFromVersion())
+		scheme := dep.Scheme()
+		name := dep.PackageSyntax()
+		version := dep.PackageVersion()
+
+		if _, ok := dependencyRevs[repo]; !ok {
+			dependencyRevs[repo] = types.RevSpecSet{}
+		}
+		dependencyRevs[repo][rev] = struct{}{}
+
+		dependencyRepo := store.DependencyRepo{Scheme: scheme, Name: name, Version: version}
+		dependencies = append(dependencies, dependencyRepo)
+		repoNamesByDependency[dependencyRepo] = repo
+	}
+
+	// Write depenencies to database and sync all of the ones that were newly inserted
+	newDependencies, err := s.dependenciesStore.UpsertDependencyRepos(ctx, dependencies)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.syncNew(ctx, newDependencies, repoNamesByDependency); err != nil {
+		return nil, err
+	}
+
+	return dependencyRevs, nil
+}
+
+// lockfileDependencies returns a flattened list of package dependencies for every repo and
+// revision pair specified in the given map.
+func (s *Service) lockfileDependencies(ctx context.Context, repoRevs map[api.RepoName]types.RevSpecSet) ([]reposource.PackageDependency, error) {
+	n := 0
+	for _, revs := range repoRevs {
+		n += len(revs)
+	}
+	depsChan := make(chan []reposource.PackageDependency, n)
+
+	g, ctx := errgroup.WithContext(ctx)
+	for repoName, revs := range repoRevs {
+		for rev := range revs {
+			// Capture outside of goroutine below
+			repoName, rev := repoName, rev
+
+			g.Go(func() error {
+				if err := s.lockfilesSemaphore.Acquire(ctx, 1); err != nil {
+					return err
+				}
+				defer s.lockfilesSemaphore.Release(1)
+
+				repoDeps, err := s.lockfilesSvc.ListDependencies(ctx, repoName, string(rev))
+				depsChan <- repoDeps
+				return err
+			})
+		}
+	}
+
+	if err := g.Wait(); err != nil {
+		close(depsChan)
+		return nil, err
+	}
+	close(depsChan)
+
+	var deps []reposource.PackageDependency
+	for batch := range depsChan {
+		deps = append(deps, batch...)
+	}
+
+	return deps, nil
+}
+
+// syncNew calls sync on every repo in the supplied slice. It is assumed that for every value in the
+// slice there is an associated value in the given map correlating a DependencyRepo struct to a repo
+// name usable by the syncer.
+func (s *Service) syncNew(ctx context.Context, newDependencies []store.DependencyRepo, repoNamesByDependency map[store.DependencyRepo]api.RepoName) error {
+	g, ctx := errgroup.WithContext(ctx)
+	for _, dep := range newDependencies {
+		// Capture outside of goroutine below
+		repo := repoNamesByDependency[dep]
+
+		if err := s.syncerSemaphore.Acquire(ctx, 1); err != nil {
+			return err
+		}
+
+		g.Go(func() error {
+			defer s.syncerSemaphore.Release(1)
+
+			if err := s.syncer.Sync(ctx, repo); err != nil {
+				log15.Warn("Failed to sync dependency repo", "repo", repo, "error", err)
+			}
+
+			return nil
+		})
+	}
+
+	return nil
+}
+
+func constructLogFields(repoRevs map[api.RepoName]types.RevSpecSet) []log.Field {
 	if len(repoRevs) == 1 {
 		for repoName, revs := range repoRevs {
 			revStrs := make([]string, 0, len(revs))
@@ -44,87 +172,14 @@ func (s *Service) Dependencies(ctx context.Context, repoRevs map[api.RepoName]ty
 				revStrs = append(revStrs, string(rev))
 			}
 
-			logFields = append(logFields,
+			return []log.Field{
 				log.String("repo", string(repoName)),
 				log.String("revs", strings.Join(revStrs, ",")),
-			)
-		}
-	} else {
-		logFields = append(logFields, log.Int("repoRevs", len(repoRevs)))
-	}
-
-	ctx, endObservation := s.operations.dependencies.With(ctx, &err, observation.Args{LogFields: logFields})
-	defer func() {
-		endObservation(1, observation.Args{LogFields: []log.Field{
-			log.Int("numDependencyRevs", len(dependencyRevs)),
-		}})
-	}()
-
-	var mu sync.Mutex
-	dependencyRevs = make(map[api.RepoName]types.RevSpecSet)
-
-	sem := semaphore.NewWeighted(32)
-	g, ctx := errgroup.WithContext(ctx)
-
-	for repoName, revs := range repoRevs {
-		for rev := range revs {
-			repoName, rev := repoName, rev
-
-			g.Go(func() error {
-				if err := sem.Acquire(ctx, 1); err != nil {
-					return err
-				}
-				defer sem.Release(1)
-
-				deps, err := s.lockfilesSvc.ListDependencies(ctx, repoName, string(rev))
-				if err != nil {
-					return err
-				}
-
-				for _, dep := range deps {
-					if err := sem.Acquire(ctx, 1); err != nil {
-						return err
-					}
-
-					dep := dep
-
-					g.Go(func() error {
-						defer sem.Release(1)
-
-						isNew, err := s.dependenciesStore.UpsertDependencyRepo(ctx, dep)
-						if err != nil {
-							return err
-						}
-
-						depName := dep.RepoName()
-						depRev := api.RevSpec(dep.GitTagFromVersion())
-
-						if isNew {
-							if err := s.syncer.Sync(ctx, depName); err != nil {
-								log15.Warn("failed to sync dependency repo", "repo", depName, "rev", depRev, "error", err)
-							}
-						}
-
-						mu.Lock()
-						defer mu.Unlock()
-
-						if _, ok := dependencyRevs[depName]; !ok {
-							dependencyRevs[depName] = types.RevSpecSet{}
-						}
-						dependencyRevs[depName][depRev] = struct{}{}
-
-						return nil
-					})
-				}
-
-				return nil
-			})
+			}
 		}
 	}
 
-	if err := g.Wait(); err != nil {
-		return nil, err
+	return []log.Field{
+		log.Int("repoRevs", len(repoRevs)),
 	}
-
-	return dependencyRevs, nil
 }

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -59,7 +59,7 @@ func (s *Service) Dependencies(ctx context.Context, repoRevs map[api.RepoName]ty
 		return nil, err
 	}
 
-	// Populate return value map from the given information. In teh same pass, populate
+	// Populate return value map from the given information. In the same pass, populate
 	// auxiliary data structures that can be used to feed the upsert and sync operations
 	// below.
 	dependencyRevs = make(map[api.RepoName]types.RevSpecSet, len(repoRevs))

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -128,8 +128,12 @@ func (s *Service) lockfileDependencies(ctx context.Context, repoRevs map[api.Rep
 				defer s.lockfilesSemaphore.Release(1)
 
 				repoDeps, err := s.lockfilesSvc.ListDependencies(ctx, repoName, string(rev))
+				if err != nil {
+					return err
+				}
+
 				depsChan <- repoDeps
-				return err
+				return nil
 			})
 		}
 	}

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -28,8 +28,8 @@ type Service struct {
 }
 
 var (
-	lockfilesSemaphoreWeight = env.MustGetInt("CODEINTEL_DEPENDENCIES_LOCKFILES_SEMAPHORE_WEIGHT", 64, "The maximum number of concurrent routines parsing lockfile contents.")``
-	syncerSemaphoreWeight    = env.MustGetInt("CODEINTEL_DEPENDENCIES_LOCKFILES_SYNCER_WEIGHT", 64, "The maximum number of concurrent routines actively syncing repositories.")``
+	lockfilesSemaphoreWeight = env.MustGetInt("CODEINTEL_DEPENDENCIES_LOCKFILES_SEMAPHORE_WEIGHT", 64, "The maximum number of concurrent routines parsing lockfile contents.")
+	syncerSemaphoreWeight    = env.MustGetInt("CODEINTEL_DEPENDENCIES_LOCKFILES_SYNCER_WEIGHT", 64, "The maximum number of concurrent routines actively syncing repositories.")
 )
 
 func newService(depsStore *store.Store, lockfilesSvc LockfilesService, syncer Syncer, observationContext *observation.Context) *Service {

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -88,7 +88,7 @@ func (s *Service) Dependencies(ctx context.Context, repoRevs map[api.RepoName]ty
 	if err != nil {
 		return nil, err
 	}
-	if err := s.syncNew(ctx, newDependencies, repoNamesByDependency); err != nil {
+	if err := s.sync(ctx, newDependencies, repoNamesByDependency); err != nil {
 		return nil, err
 	}
 

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -153,10 +153,10 @@ func (s *Service) lockfileDependencies(ctx context.Context, repoRevs map[api.Rep
 	return deps, nil
 }
 
-// syncNew calls sync on every repo in the supplied slice. It is assumed that for every value in the
+// sync calls sync on every repo in the supplied slice. It is assumed that for every value in the
 // slice there is an associated value in the given map correlating a DependencyRepo struct to a repo
 // name usable by the syncer.
-func (s *Service) syncNew(ctx context.Context, newDependencies []store.DependencyRepo, repoNamesByDependency map[store.DependencyRepo]api.RepoName) error {
+func (s *Service) sync(ctx context.Context, newDependencies []store.DependencyRepo, repoNamesByDependency map[store.DependencyRepo]api.RepoName) error {
 	g, ctx := errgroup.WithContext(ctx)
 	for _, dep := range newDependencies {
 		// Capture outside of goroutine below

--- a/internal/codeintel/dependencies/store/observability.go
+++ b/internal/codeintel/dependencies/store/observability.go
@@ -8,8 +8,8 @@ import (
 )
 
 type operations struct {
-	listDependencyRepos  *observation.Operation
-	upsertDependencyRepo *observation.Operation
+	listDependencyRepos   *observation.Operation
+	upsertDependencyRepos *observation.Operation
 }
 
 func newOperations(observationContext *observation.Context) *operations {
@@ -29,7 +29,7 @@ func newOperations(observationContext *observation.Context) *operations {
 	}
 
 	return &operations{
-		listDependencyRepos:  op("ListDependencyRepos"),
-		upsertDependencyRepo: op("UpsertDependencyRepo"),
+		listDependencyRepos:   op("ListDependencyRepos"),
+		upsertDependencyRepos: op("UpsertDependencyRepos"),
 	}
 }

--- a/internal/codeintel/dependencies/store/store.go
+++ b/internal/codeintel/dependencies/store/store.go
@@ -134,7 +134,12 @@ func (s *Store) UpsertDependencyRepos(ctx context.Context, deps []DependencyRepo
 
 	returningScanner := func(rows dbutil.Scanner) error {
 		var dependencyRepo DependencyRepo
-		if err = rows.Scan(&dependencyRepo.ID, &dependencyRepo.Scheme, &dependencyRepo.Name, &dependencyRepo.Version); err != nil {
+		if err = rows.Scan(
+			&dependencyRepo.ID,
+			&dependencyRepo.Scheme,
+			&dependencyRepo.Name,
+			&dependencyRepo.Version,
+		); err != nil {
 			return err
 		}
 

--- a/internal/codeintel/dependencies/store/store.go
+++ b/internal/codeintel/dependencies/store/store.go
@@ -7,8 +7,8 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/opentracing/opentracing-go/log"
 
-	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/batch"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -110,23 +110,48 @@ func makeLimit(limit int) *sqlf.Query {
 	return sqlf.Sprintf("LIMIT %s", limit)
 }
 
-// UpsertDependencyRepo creates the given dependency repo if it doesn't yet exist.
-func (s *Store) UpsertDependencyRepo(ctx context.Context, dep reposource.PackageDependency) (isNew bool, err error) {
-	res, err := s.ExecResult(ctx, sqlf.Sprintf(
-		`insert into lsif_dependency_repos (scheme, name, version) values (%s, %s, %s) on conflict do nothing`,
-		dep.Scheme(),
-		dep.PackageSyntax(),
-		dep.PackageVersion(),
-	))
+// UpsertDependencyRepos creates the given dependency repos if they doesn't yet exist. The values that
+// did not exist previously are returned.
+func (s *Store) UpsertDependencyRepos(ctx context.Context, deps []DependencyRepo) (newDeps []DependencyRepo, err error) {
+	ctx, endObservation := s.operations.upsertDependencyRepos.With(ctx, &err, observation.Args{LogFields: []log.Field{
+		log.Int("numDeps", len(deps)),
+	}})
+	defer func() {
+		endObservation(1, observation.Args{LogFields: []log.Field{
+			log.Int("numNewDeps", len(newDeps)),
+		}})
+	}()
 
-	if err != nil {
-		return false, err
+	callback := func(inserter *batch.Inserter) error {
+		for _, dep := range deps {
+			if err := inserter.Insert(ctx, dep.Scheme, dep.Name, dep.Version); err != nil {
+				return err
+			}
+		}
+
+		return nil
 	}
 
-	affected, err := res.RowsAffected()
-	if err != nil {
-		return false, err
+	returningScanner := func(rows dbutil.Scanner) error {
+		var dependencyRepo DependencyRepo
+		if err = rows.Scan(&dependencyRepo.ID, &dependencyRepo.Scheme, &dependencyRepo.Name, &dependencyRepo.Version); err != nil {
+			return err
+		}
+
+		newDeps = append(newDeps, dependencyRepo)
+		return nil
 	}
 
-	return affected == 1, nil
+	err = batch.WithInserterWithReturn(
+		ctx,
+		s.Handle().DB(),
+		"lsif_dependency_repos",
+		batch.MaxNumPostgresParameters,
+		[]string{"scheme", "name", "version"},
+		"ON CONFLICT DO NOTHING",
+		[]string{"id", "scheme", "name", "version"},
+		returningScanner,
+		callback,
+	)
+	return newDeps, err
 }

--- a/internal/codeintel/dependencies/store/store_test.go
+++ b/internal/codeintel/dependencies/store/store_test.go
@@ -5,9 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 
-	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
@@ -23,25 +21,41 @@ func TestUpsertDependencyRepo(t *testing.T) {
 	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
-	for _, dep := range []struct {
-		reposource.PackageDependency
-		isNew bool
-	}{
-		{mustParseNPMDependency(t, "bar@2.0.0"), true},
-		{mustParseNPMDependency(t, "bar@2.0.0"), false},
-		{mustParseNPMDependency(t, "bar@3.0.0"), true},
-		{mustParseNPMDependency(t, "foo@1.0.0"), true},
-		{mustParseNPMDependency(t, "foo@1.0.0"), false},
-		{mustParseNPMDependency(t, "foo@2.0.0"), true},
-	} {
-		isNew, err := store.UpsertDependencyRepo(ctx, dep)
+	batches := [][]DependencyRepo{
+		{
+			// Test same-set flushes
+			DependencyRepo{Scheme: "npm", Name: "bar", Version: "2.0.0"}, // id=1
+			DependencyRepo{Scheme: "npm", Name: "bar", Version: "2.0.0"}, // id=2, duplicate
+		},
+		{
+			DependencyRepo{Scheme: "npm", Name: "bar", Version: "3.0.0"}, // id=3
+			DependencyRepo{Scheme: "npm", Name: "foo", Version: "1.0.0"}, // id=4
+		},
+		{
+			// Test different-set flushes
+			DependencyRepo{Scheme: "npm", Name: "foo", Version: "1.0.0"}, // id=5, duplicate
+			DependencyRepo{Scheme: "npm", Name: "foo", Version: "2.0.0"}, // id=6
+		},
+	}
+
+	var allNewDeps []DependencyRepo
+	for _, batch := range batches {
+		newDeps, err := store.UpsertDependencyRepos(ctx, batch)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if have, want := isNew, dep.isNew; have != want {
-			t.Fatalf("%s: want isNew=%t, have %t", dep.PackageManagerSyntax(), want, have)
-		}
+		allNewDeps = append(allNewDeps, newDeps...)
+	}
+
+	want := []DependencyRepo{
+		{ID: 1, Scheme: "npm", Name: "bar", Version: "2.0.0"},
+		{ID: 3, Scheme: "npm", Name: "bar", Version: "3.0.0"},
+		{ID: 4, Scheme: "npm", Name: "foo", Version: "1.0.0"},
+		{ID: 6, Scheme: "npm", Name: "foo", Version: "2.0.0"},
+	}
+	if diff := cmp.Diff(allNewDeps, want); diff != "" {
+		t.Fatalf("mismatch (-have, +want): %s", diff)
 	}
 
 	have, err := store.ListDependencyRepos(ctx, ListDependencyReposOpts{
@@ -50,29 +64,9 @@ func TestUpsertDependencyRepo(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	want := []DependencyRepo{
-		{ID: 6, Scheme: "npm", Name: "foo", Version: "2.0.0"},
-		{ID: 4, Scheme: "npm", Name: "foo", Version: "1.0.0"},
-		{ID: 3, Scheme: "npm", Name: "bar", Version: "3.0.0"},
-		{ID: 1, Scheme: "npm", Name: "bar", Version: "2.0.0"},
-	}
-
-	opt := cmpopts.IgnoreFields(DependencyRepo{}, "ID")
-	if diff := cmp.Diff(have, want, opt); diff != "" {
+	if diff := cmp.Diff(have, want); diff != "" {
 		t.Fatalf("mismatch (-have, +want): %s", diff)
 	}
-}
-
-func mustParseNPMDependency(t testing.TB, dep string) reposource.PackageDependency {
-	t.Helper()
-
-	d, err := reposource.ParseNPMDependency(dep)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return d
 }
 
 func testStore(db dbutil.DB) *Store {

--- a/internal/database/batch/batch.go
+++ b/internal/database/batch/batch.go
@@ -2,7 +2,6 @@ package batch
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"strings"
 	"sync"
@@ -32,7 +31,7 @@ type Inserter struct {
 	commonLogFields      []log.Field
 }
 
-type ReturningScanner func(rows *sql.Rows) error
+type ReturningScanner func(rows dbutil.Scanner) error
 
 // InsertValues creates a new batch inserter using the given database handle, table name, and
 // column names, then reads from the given channel as if they specify values for a single row.

--- a/internal/database/batch/batch_test.go
+++ b/internal/database/batch/batch_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 func init() {
@@ -172,7 +173,7 @@ func testInsertWithReturn(t testing.TB, db *sql.DB, expectedValues [][]interface
 		[]string{"col1", "col2", "col3", "col4", "col5"},
 		"",
 		[]string{"id"},
-		func(rows *sql.Rows) error {
+		func(rows dbutil.Scanner) error {
 			var id int
 			if err := rows.Scan(&id); err != nil {
 				return err
@@ -207,7 +208,7 @@ func testInsertWithReturnWithConflicts(t testing.TB, db *sql.DB, n int, expected
 		[]string{"id", "col1", "col2", "col3", "col4", "col5"},
 		"ON CONFLICT DO NOTHING",
 		[]string{"id"},
-		func(rows *sql.Rows) error {
+		func(rows dbutil.Scanner) error {
 			var id int
 			if err := rows.Scan(&id); err != nil {
 				return err

--- a/internal/repos/jvm_packages.go
+++ b/internal/repos/jvm_packages.go
@@ -84,9 +84,10 @@ func (s *JVMPackagesSource) listDependentRepos(ctx context.Context, results chan
 	)
 	for {
 		dbDeps, err := s.depsStore.ListDependencyRepos(ctx, dependenciesStore.ListDependencyReposOpts{
-			Scheme: dependenciesStore.JVMPackagesScheme,
-			After:  lastID,
-			Limit:  100,
+			Scheme:      dependenciesStore.JVMPackagesScheme,
+			After:       lastID,
+			Limit:       100,
+			NewestFirst: true,
 		})
 		if err != nil {
 			results <- SourceResult{Err: err}

--- a/internal/repos/npm_packages.go
+++ b/internal/repos/npm_packages.go
@@ -75,9 +75,10 @@ func (s *NPMPackagesSource) ListRepos(ctx context.Context, results chan SourceRe
 	pkgVersions := map[string]*npm.PackageInfo{}
 	for {
 		dbDeps, err := s.depsStore.ListDependencyRepos(ctx, dependenciesStore.ListDependencyReposOpts{
-			Scheme: dependenciesStore.NPMPackagesScheme,
-			After:  lastID,
-			Limit:  100,
+			Scheme:      dependenciesStore.NPMPackagesScheme,
+			After:       lastID,
+			Limit:       100,
+			NewestFirst: true,
 		})
 		if err != nil {
 			results <- SourceResult{Err: err}


### PR DESCRIPTION
This PR refactors some of the dependency API internals to treat the database a little bit more kindly 😅 . Previously, we had a shared worker pool to stream dependencies and upsert/sync them. This means that we can have up to _MAX_CONCURRENCY_ connections upserting into the database at once. Now, we have a shared worker pool to stream dependencies, collect them in memory, synchronously upsert large batches, then sync all new repos in a second shared worker pool.

Refactor changes include:
- [x] Returns dependency repos in *ascending* order of ID rather than descending
- [x] Adds instrumentation to the upsert method in the store
- [x] Makes the worker pool semaphore shared across all requests
- [x] Adds a safety check to the batch inserter `returningScanner` (I really confused myself here before I remembered the proper semantics; it was not intuitive)
- [x] Parallelize `ListDependencies`

## Test plan

Unit and integration tests: [main-dry-run](https://buildkite.com/sourcegraph/sourcegraph/builds/135003).