### PR TITLE
home: update total number of searchable repositories

### DIFF
--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -75,7 +75,7 @@ export const SearchPage: React.FunctionComponent<SearchPageProps> = props => {
             <BrandLogo className={styles.logo} isLightTheme={props.isLightTheme} variant="logo" />
             {props.isSourcegraphDotCom && (
                 <div className="text-muted text-center font-italic mt-3">
-                    Search your code and 2M+ open source repositories
+                    Search your code and 5M+ open source repositories
                 </div>
             )}
             <div


### PR DESCRIPTION
According to our [gitserver_repos and external_service_repos table](https://console.cloud.google.com/bigquery?sq=527047051561:c471943b73c74b6bb5675b168e0dba9c) on Cloud, we are actually having 5M+ repositories cloned.

## Test plan

Text change.


