### PR TITLE
git-combine: Fix too many commits bug

### DIFF
--- a/internal/cmd/git-combine/git-combine.go
+++ b/internal/cmd/git-combine/git-combine.go
@@ -5,9 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"hash/crc32"
-	"io"
 	"log"
-	"math"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -26,35 +24,14 @@ import (
 
 // Options are configurables for Combine.
 type Options struct {
-	// Limit is the maximum number of commits we import in total. Limit is
-	// useful to specify when creating a new combined repo.
-	Limit int
-
-	// LimitRemote is the maximum number of commits we import from each remote. The
-	// memory usage of Combine is based on the number of unseen commits per
-	// remote. LimitRemote is useful to specify when importing a large new upstream.
-	LimitRemote int
-
 	Logger *log.Logger
 }
 
 func (o *Options) SetDefaults() {
-	if o.Limit == 0 {
-		o.Limit = math.MaxInt
-	}
-
-	if o.LimitRemote == 0 {
-		o.LimitRemote = o.Limit
-	}
-
 	if o.Logger == nil {
 		o.Logger = log.Default()
 	}
 }
-
-// how many entries to keep track of per repo when deciding if we have seen a
-// commit before.
-const recentRootTreesMaxEntries = 1000
 
 // Combine opens the git repository at path and transforms commits from all
 // non-origin remotes into commits onto HEAD.
@@ -64,14 +41,6 @@ func Combine(path string, opt Options) error {
 	log := opt.Logger
 
 	r, err := git.PlainOpen(path)
-	if err != nil {
-		return err
-	}
-
-	parentHash := getHeadHash(r)
-
-	log.Println("Combine: getting recent root trees...")
-	recentRootTrees, err := getRecentRootTrees(r, recentRootTreesMaxEntries)
 	if err != nil {
 		return err
 	}
@@ -86,118 +55,95 @@ func Combine(path string, opt Options) error {
 		return err
 	}
 
-	type dirCommit struct {
-		*object.Commit
+	lastLog := time.Now()
 
-		// dir is the name of the directory we will import Commit into.
-		dir string
+	headRef, _ := r.Head()
+	var head *object.Commit
+	if headRef != nil {
+		head, err = r.CommitObject(headRef.Hash())
+		if err != nil {
+			return err
+		}
 	}
 
-	log.Println("Combine: collecting new commits...")
-	lastLog := time.Now()
-	rootTree := map[string]plumbing.Hash{}
-	var commits []*dirCommit
+	log.Println("Determining the tree hashes of subdirectories...")
+	remoteToTree := map[string]plumbing.Hash{}
+	if head != nil {
+		tree, err := head.Tree()
+		if err != nil {
+			return err
+		}
+		for _, entry := range tree.Entries {
+			remoteToTree[entry.Name] = entry.Hash
+		}
+	}
+
+	log.Println("Collecting new commits...")
+	lastLog = time.Now()
+	remoteToCommits := map[string][]*object.Commit{}
 	for remote := range conf.Remotes {
 		if remote == "origin" {
 			continue
 		}
 
-		// we don't know what the remote HEAD is, so we hardcode the usual
-		// options and test if they exist.
-		var ref *plumbing.Reference
-		for _, name := range []string{"main", "master", "trunk", "development"} {
-			cand, err := storer.ResolveReference(r.Storer, plumbing.NewRemoteReferenceName(remote, name))
-			if err == nil {
-				ref = cand
-				break
-			}
-		}
-		if ref == nil {
-			log.Printf("ignoring remote %q since can't find HEAD branch", remote)
-			continue
-		}
-
-		commit, err := r.CommitObject(ref.Hash())
+		commit, err := remoteHead(r, remote)
 		if err != nil {
 			return err
 		}
+		if commit == nil {
+			// No known default branch on this remote, ignore it.
+			continue
+		}
 
-		seen := recentRootTrees[remote]
-
-		for i := 0; i < opt.LimitRemote; i++ {
+		for depth := 0; ; depth++ {
 			if time.Since(lastLog) > time.Second {
-				log.Printf("Combine: collecting new commits... (remote %s, commit depth %d, commit hash %s)", remote, i+1, commit.Hash)
+				log.Printf("Collecting new commits... (remotes %s, commit depth %d)", remote, depth)
 				lastLog = time.Now()
 			}
 
-			if seen.Contains(commit.TreeHash) {
-				rootTree[remote] = commit.TreeHash
+			if commit.TreeHash == remoteToTree[remote] {
 				break
 			}
 
-			commits = append(commits, &dirCommit{
-				dir:    remote,
-				Commit: commit,
-			})
-
-			if i >= opt.LimitRemote-1 {
-				// Avoid getting the next commit if we're done iterating.
-				break
-			}
+			remoteToCommits[remote] = append(remoteToCommits[remote], commit)
 
 			if commit.NumParents() == 0 {
+				remoteToTree[remote] = commit.TreeHash
 				break
 			}
-
 			commit, err = commit.Parent(0)
-			if err == io.EOF {
-				break
-			} else if err != nil {
+			if err != nil {
 				return err
 			}
 		}
 	}
 
-	// Reverse the commits so we apply them in the right order.
-	for i, j := 0, len(commits)-1; i < j; i, j = i+1, j-1 {
-		commits[i], commits[j] = commits[j], commits[i]
-	}
+	applyCommit := func(remote string, commit *object.Commit) error {
+		remoteToTree[remote] = commit.TreeHash
 
-	if len(commits) > opt.Limit {
-		// We only take the last Limit commits. But we want to ensure we are
-		// using the latest treehash for each dir, so we need to walk over the
-		// commits we are cutting out first.
-		cut := len(commits) - opt.Limit
-		for _, commit := range commits[:cut] {
-			rootTree[commit.dir] = commit.TreeHash
-		}
-		commits = commits[cut:]
-	}
-
-	for i, commit := range commits {
-		// This is the important line, "/dir" will now be the code (tree) for
-		// this commit. We don't touch the other entries, so the other
-		// directories will have the same code as the previous commit we
-		// created.
-		rootTree[commit.dir] = commit.TreeHash
-
+		// Add tree entries for each remote in matching directories.
 		var entries []object.TreeEntry
-		for dir, hash := range rootTree {
+		for thisRemote, tree := range remoteToTree {
 			entries = append(entries, object.TreeEntry{
-				Name: dir,
+				Name: thisRemote,
 				Mode: filemode.Dir,
-				Hash: hash,
+				Hash: tree,
 			})
 		}
+
+		// Add README.md.
 		entries = append(entries, object.TreeEntry{
 			Name: "README.md",
 			Mode: filemode.Regular,
 			Hash: readmeHash,
 		})
+
+		// TODO is this necessary?
 		sort.Slice(entries, func(i, j int) bool {
 			return entries[i].Name < entries[j].Name
 		})
 
+		// Construct the root tree.
 		treeHash, err := storeObject(r.Storer, &object.Tree{
 			Entries: entries,
 		})
@@ -214,100 +160,74 @@ func Combine(path string, opt Options) error {
 				Email: "no-reply@sourcegraph.com",
 				When:  commit.Committer.When,
 			},
-			Message:  sanitizeMessage(commit.dir, commit.Commit),
+			Message:  sanitizeMessage(remote, commit),
 			TreeHash: treeHash,
 		}
 
 		// We just create a linear history. parentHash is zero if this is the
 		// first commit to HEAD.
-		if !parentHash.IsZero() {
-			newCommit.ParentHashes = []plumbing.Hash{parentHash}
+		if head != nil {
+			newCommit.ParentHashes = []plumbing.Hash{head.Hash}
 		}
 
-		parentHash, err = storeObject(r.Storer, newCommit)
+		headHash, err := storeObject(r.Storer, newCommit)
 		if err != nil {
 			return err
 		}
 
-		if err := setHEAD(r.Storer, parentHash); err != nil {
+		if err := setHEAD(r.Storer, headHash); err != nil {
 			return err
 		}
 
-		if time.Since(lastLog) > time.Second {
-			log.Printf("%d/%d created %s from %s %s", i+1, len(commits), parentHash, commit.Hash, commitTitle(newCommit))
-			lastLog = time.Now()
-		}
-	}
-
-	return nil
-}
-
-// getHeadHash returns the hash for HEAD. If that fails plumbing.ZeroHash is
-// returned.
-func getHeadHash(r *git.Repository) plumbing.Hash {
-	head, err := r.Head()
-	if err != nil {
-		return plumbing.ZeroHash
-	}
-	return head.Hash()
-}
-
-type hashSet map[plumbing.Hash]struct{}
-
-func (h hashSet) Add(k plumbing.Hash) {
-	h[k] = struct{}{}
-}
-
-func (h hashSet) Contains(k plumbing.Hash) bool {
-	if h == nil {
-		return false
-	}
-	_, ok := h[k]
-	return ok
-}
-
-func getRecentRootTrees(r *git.Repository, maxEntries int) (map[string]hashSet, error) {
-	dirs := map[string]hashSet{}
-
-	// Ensure HEAD exists so we fallback to empty behaviour on empty branch
-	// instead of error.
-	_, err := r.Head()
-	if err != nil {
-		return dirs, nil
-	}
-
-	iter, err := r.Log(&git.LogOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	for i := 0; i < maxEntries; i++ {
-		commit, err := iter.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return nil, err
+		headRef, _ := r.Head()
+		if headRef != nil {
+			head, err = r.CommitObject(headRef.Hash())
+			if err != nil {
+				return err
+			}
 		}
 
-		tree, err := commit.Tree()
-		if err != nil {
-			return nil, err
+		return nil
+	}
+
+	log.Println("Applying new commits...")
+	total := 0
+	for _, commits := range remoteToCommits {
+		total += len(commits)
+	}
+	for height := 0; len(remoteToCommits) > 0; height++ {
+		// Loop over keys so we can delete entries from the map.
+		remotes := []string{}
+		for remote := range remoteToCommits {
+			remotes = append(remotes, remote)
 		}
 
-		for _, entry := range tree.Entries {
-			if entry.Mode == filemode.Dir {
-				seen, ok := dirs[entry.Name]
-				if !ok {
-					seen = make(hashSet)
-					dirs[entry.Name] = seen
-				}
-				seen.Add(entry.Hash)
+		// Pop 1 commit per remote and put each tree in a directory by the same name as the remote.
+		for _, remote := range remotes {
+			deepestCommit := remoteToCommits[remote][len(remoteToCommits[remote])-1]
+
+			err = applyCommit(remote, deepestCommit)
+			if err != nil {
+				return err
+			}
+
+			// Pop the deepest commit.
+			remoteToCommits[remote] = remoteToCommits[remote][:len(remoteToCommits[remote])-1]
+
+			// Delete this remote once we applied all of its new commits.
+			if len(remoteToCommits[remote]) == 0 {
+				delete(remoteToCommits, remote)
+			}
+
+			if time.Since(lastLog) > time.Second {
+				progress := float64(height) / float64(total)
+				log.Printf("%.2f%% done (applied %d commits out of %d total)", progress*100, height+1, total)
+				lastLog = time.Now()
 			}
 		}
 	}
 
-	return dirs, nil
+	return nil
 }
 
 func readmeObject(storer storer.EncodedObjectStorer) (plumbing.Hash, error) {
@@ -516,15 +436,10 @@ func doDaemon(dir string, done <-chan struct{}, opt Options) error {
 
 func main() {
 	daemon := flag.Bool("daemon", false, "run in daemon mode. This mode loops on fetch, combine, push.")
-	limitRemote := flag.Int("limit-remote", 0, "limits the number of commits imported from each remote. If 0 there is no limit. Used to reduce memory usage when importing new large remotes.")
-	limit := flag.Int("limit", 0, "limits the number of commits imported in total. If 0 there is no limit. Used to reduce memory usage when importing new large remotes.")
 
 	flag.Parse()
 
-	opt := Options{
-		Limit:       *limit,
-		LimitRemote: *limitRemote,
-	}
+	opt := Options{}
 
 	gitDir, err := getGitDir()
 	if err != nil {
@@ -552,4 +467,19 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+}
+
+// remoteHead returns the HEAD commit for the given remote.
+func remoteHead(r *git.Repository, remote string) (*object.Commit, error) {
+	// We don't know what the remote HEAD is, so we hardcode the usual options and test if they exist.
+	commonDefaultBranches := []string{"main", "master", "trunk", "development"}
+	for _, name := range commonDefaultBranches {
+		ref, err := storer.ResolveReference(r.Storer, plumbing.NewRemoteReferenceName(remote, name))
+		if err == nil {
+			return r.CommitObject(ref.Hash())
+		}
+	}
+
+	log.Printf("ignoring remote %q because it doesn't have any of the common default branches %v", remote, commonDefaultBranches)
+	return nil, nil
 }

--- a/internal/cmd/git-combine/git-combine.go
+++ b/internal/cmd/git-combine/git-combine.go
@@ -45,11 +45,6 @@ func Combine(path string, opt Options) error {
 		return err
 	}
 
-	readmeHash, err := readmeObject(r.Storer)
-	if err != nil {
-		return err
-	}
-
 	conf, err := r.Config()
 	if err != nil {
 		return err
@@ -130,13 +125,6 @@ func Combine(path string, opt Options) error {
 				Hash: tree,
 			})
 		}
-
-		// Add README.md.
-		entries = append(entries, object.TreeEntry{
-			Name: "README.md",
-			Mode: filemode.Regular,
-			Hash: readmeHash,
-		})
 
 		// TODO is this necessary?
 		sort.Slice(entries, func(i, j int) bool {
@@ -229,34 +217,6 @@ func Combine(path string, opt Options) error {
 	}
 
 	return nil
-}
-
-func readmeObject(storer storer.EncodedObjectStorer) (plumbing.Hash, error) {
-	readme := []byte(`# megarepo
-
-This is a synthetic monorepo created by continuously applying commits from upstream projects into respective sub directories.
-
-See https://github.com/sourcegraph/sourcegraph/tree/main/internal/cmd/git-combine
-`)
-	obj := storer.NewEncodedObject()
-	obj.SetType(plumbing.BlobObject)
-	obj.SetSize(int64(len(readme)))
-
-	w, err := obj.Writer()
-	if err != nil {
-		return plumbing.ZeroHash, err
-	}
-
-	if _, err := w.Write(readme); err != nil {
-		_ = w.Close()
-		return plumbing.ZeroHash, err
-	}
-
-	if err := w.Close(); err != nil {
-		return plumbing.ZeroHash, err
-	}
-
-	return storer.SetEncodedObject(obj)
 }
 
 func storeObject(storer storer.EncodedObjectStorer, obj interface {

--- a/internal/cmd/git-combine/git-combine.go
+++ b/internal/cmd/git-combine/git-combine.go
@@ -50,8 +50,6 @@ func Combine(path string, opt Options) error {
 		return err
 	}
 
-	lastLog := time.Now()
-
 	headRef, _ := r.Head()
 	var head *object.Commit
 	if headRef != nil {
@@ -74,7 +72,7 @@ func Combine(path string, opt Options) error {
 	}
 
 	log.Println("Collecting new commits...")
-	lastLog = time.Now()
+	lastLog := time.Now()
 	remoteToCommits := map[string][]*object.Commit{}
 	for remote := range conf.Remotes {
 		if remote == "origin" {

--- a/internal/cmd/git-combine/git-combine.go
+++ b/internal/cmd/git-combine/git-combine.go
@@ -195,7 +195,7 @@ func Combine(path string, opt Options) error {
 	for _, commits := range remoteToCommits {
 		total += len(commits)
 	}
-	for height := 0; len(remoteToCommits) > 0; height++ {
+	for height := 0; len(remoteToCommits) > 0; {
 		// Loop over keys so we can delete entries from the map.
 		remotes := []string{}
 		for remote := range remoteToCommits {
@@ -210,6 +210,7 @@ func Combine(path string, opt Options) error {
 			if err != nil {
 				return err
 			}
+			height++
 
 			// Pop the deepest commit.
 			remoteToCommits[remote] = remoteToCommits[remote][:len(remoteToCommits[remote])-1]

--- a/internal/cmd/git-combine/git-combine.go
+++ b/internal/cmd/git-combine/git-combine.go
@@ -104,10 +104,14 @@ func Combine(path string, opt Options) error {
 				remoteToTree[remote] = commit.TreeHash
 				break
 			}
-			commit, err = commit.Parent(0)
-			if err != nil {
+			nextCommit, err := commit.Parent(0)
+			if err == plumbing.ErrObjectNotFound {
+				remoteToTree[remote] = commit.TreeHash
+				break
+			} else if err != nil {
 				return err
 			}
+			commit = nextCommit
 		}
 	}
 

--- a/internal/cmd/git-combine/git-combine_test.go
+++ b/internal/cmd/git-combine/git-combine_test.go
@@ -48,8 +48,7 @@ git fetch --depth 100 sourcegraph
 	}
 
 	opt := Options{
-		LimitRemote: 100,
-		Logger:      log.New(io.Discard, "", 0),
+		Logger: log.New(io.Discard, "", 0),
 	}
 	if testing.Verbose() {
 		opt.Logger = log.Default()


### PR DESCRIPTION
There are over 10M commits on the megarepo right now 🙀 

<img width="159" alt="CleanShot 2022-03-02 at 01 44 33@2x" src="https://user-images.githubusercontent.com/1387653/156326643-9ea43e60-6c56-4bd6-b3de-d29fa91553ae.png">

This is because I introduced some logic in https://github.com/sourcegraph/sourcegraph/pull/31832 that interacted poorly with the 1K commit depth limit.

cc @tsenart in case you'd like to review this.

## Test plan

Ran locally.