### PR TITLE
gitserver: read HOSTNAME env var

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -157,12 +157,15 @@ func main() {
 	defer cancel()
 	gitserver.StartClonePipeline(ctx)
 
-	port := "3178"
-	host := ""
-	if env.InsecureDev {
-		host = "127.0.0.1"
+	addr := os.Getenv("HOSTNAME")
+	if addr == "" {
+		port := "3178"
+		host := ""
+		if env.InsecureDev {
+			host = "127.0.0.1"
+		}
+		addr = net.JoinHostPort(host, port)
 	}
-	addr := net.JoinHostPort(host, port)
 	srv := &http.Server{
 		Addr:    addr,
 		Handler: handler,


### PR DESCRIPTION
This allows overriding the gitserver address using the HOSTNAME env var.

## Test plan

Tested it locally with and without the variable


