### PR TITLE
sg: fix loading of the overwrite config

### DIFF
--- a/dev/sg/sg_run.go
+++ b/dev/sg/sg_run.go
@@ -73,5 +73,10 @@ func constructRunCmdLongHelp() string {
 
 	}
 
+	// This is a quick fix to get the overwrite config flag to load properly,
+	// as this function is called before the flags are parsed and sets the globalConf
+	// variable with the wrong override config path.
+	globalConf = nil
+
 	return out.String()
 }

--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -83,6 +83,11 @@ Use this to start your Sourcegraph environment!
 		fmt.Fprintf(&out, "\n%sNo commandsets found! Please change your current directory to the Sourcegraph repository.%s", output.StyleOrange, output.StyleReset)
 	}
 
+	// This is a quick fix to get the overwrite config flag to load properly,
+	// as this function is called before the flags are parsed and sets the globalConf
+	// variable with the wrong override config path.
+	globalConf = nil
+
 	return out.String()
 }
 


### PR DESCRIPTION
This PR is a quick fix for #32061 to make the overwrite config work properly.
However it doesn't fix the output of the help functions, which might require a bigger change.

## Test plan

Tested locally with and without the flag


