### PR TITLE
sg: fix bootstrap script for old curls by using grep -i

### DIFF
--- a/dev/sg/bootstrap.sh
+++ b/dev/sg/bootstrap.sh
@@ -34,7 +34,7 @@ main() {
   printf '%s\n' 'determining latest release of sg' 1>&2
 
   local _location_header
-  _location_header="$(curl --silent -I "https://github.com/sourcegraph/sg/releases/latest" | grep "location:" | tr -d '\r')"
+  _location_header="$(curl --silent -I "https://github.com/sourcegraph/sg/releases/latest" | grep -i "location:" | tr -d '\r')"
 
   local _base_url
   _base_url="$(echo "${_location_header}" | sed s/location:\ // | sed s/tag/download/ | tr -d "[:blank:]")"


### PR DESCRIPTION
As reported by @leonore on Slack: older versions of `curl` do not print the header names in all-lowercase,
so we can do this little thing here and be prepared for old and new
curl.

## Test plan

- Ran the `curl` commands on old and new machine and compared output


