### PR TITLE
Make created_at in external_service_repos not nullable

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -822,7 +822,7 @@ Tracks the most recent activity of executors attached to this Sourcegraph instan
  clone_url           | text                     |           | not null | 
  user_id             | integer                  |           |          | 
  org_id              | integer                  |           |          | 
- created_at          | timestamp with time zone |           |          | transaction_timestamp()
+ created_at          | timestamp with time zone |           | not null | transaction_timestamp()
 Indexes:
     "external_service_repos_repo_id_external_service_id_unique" UNIQUE CONSTRAINT, btree (repo_id, external_service_id)
     "external_service_repos_clone_url_idx" btree (clone_url)

--- a/migrations/frontend/1646239940/down.sql
+++ b/migrations/frontend/1646239940/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS external_service_repos
+    ALTER COLUMN created_at DROP NOT NULL ;

--- a/migrations/frontend/1646239940/metadata.yaml
+++ b/migrations/frontend/1646239940/metadata.yaml
@@ -1,0 +1,2 @@
+name: non-nullable-created-at-external-service-repos
+parents: [1645635177, 1646153853]

--- a/migrations/frontend/1646239940/up.sql
+++ b/migrations/frontend/1646239940/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS external_service_repos
+    ALTER COLUMN created_at SET NOT NULL ;


### PR DESCRIPTION

## Test plan

Tested through running migration up and down on the local development environment


