### PR TITLE
search: simplify search results tests

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
-	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/run"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
@@ -327,19 +326,26 @@ func TestSearchResultsHydration(t *testing.T) {
 	var ctxUser int32 = 1234
 	ctx := actor.WithActor(context.Background(), actor.FromMockUser(ctxUser))
 
-	p, err := query.Pipeline(query.InitLiteral(`foobar index:only count:350`))
+	query := `foobar index:only count:350`
+	literalPatternType := "literal"
+	searchInputs, err := run.NewSearchInputs(
+		ctx,
+		db,
+		"V2",
+		&literalPatternType,
+		query,
+		search.Batch,
+		&schema.Settings{},
+		false,
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	resolver := &searchResolver{
-		db: db,
-		SearchInputs: &run.SearchInputs{
-			Plan:         p,
-			Query:        p.ToParseTree(),
-			UserSettings: &schema.Settings{},
-		},
-		zoekt: z,
+		db:           db,
+		SearchInputs: searchInputs,
+		zoekt:        z,
 	}
 	results, err := resolver.Results(ctx)
 	if err != nil {
@@ -565,19 +571,25 @@ func TestEvaluateAnd(t *testing.T) {
 			repos.CountFunc.SetDefaultReturn(len(minimalRepos), nil)
 			db.ReposFunc.SetDefaultReturn(repos)
 
-			p, err := query.Pipeline(query.InitLiteral(tt.query))
+			literalPatternType := "literal"
+			searchInputs, err := run.NewSearchInputs(
+				context.Background(),
+				db,
+				"V2",
+				&literalPatternType,
+				tt.query,
+				search.Batch,
+				&schema.Settings{},
+				false,
+			)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			resolver := &searchResolver{
-				db: db,
-				SearchInputs: &run.SearchInputs{
-					Plan:         p,
-					Query:        p.ToParseTree(),
-					UserSettings: &schema.Settings{},
-				},
-				zoekt: z,
+				db:           db,
+				SearchInputs: searchInputs,
+				zoekt:        z,
 			}
 			results, err := resolver.Results(ctx)
 			if err != nil {
@@ -617,11 +629,6 @@ func TestSearchContext(t *testing.T) {
 
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {
-			p, err := query.Pipeline(query.InitLiteral(tt.searchQuery))
-			if err != nil {
-				t.Fatal(err)
-			}
-
 			repos := database.NewMockRepoStore()
 			repos.ListMinimalReposFunc.SetDefaultReturn([]types.MinimalRepo{}, nil)
 			repos.CountFunc.SetDefaultReturn(0, nil)
@@ -639,14 +646,25 @@ func TestSearchContext(t *testing.T) {
 			db.ReposFunc.SetDefaultReturn(repos)
 			db.NamespacesFunc.SetDefaultReturn(ns)
 
+			literalPatternType := "literal"
+			searchInputs, err := run.NewSearchInputs(
+				context.Background(),
+				db,
+				"V2",
+				&literalPatternType,
+				tt.searchQuery,
+				search.Batch,
+				&schema.Settings{},
+				false,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
 			resolver := searchResolver{
-				SearchInputs: &run.SearchInputs{
-					Plan:         p,
-					Query:        p.ToParseTree(),
-					UserSettings: &schema.Settings{},
-				},
-				zoekt: mockZoekt,
-				db:    db,
+				SearchInputs: searchInputs,
+				zoekt:        mockZoekt,
+				db:           db,
 			}
 
 			_, err = resolver.Results(context.Background())
@@ -748,11 +766,6 @@ func TestSubRepoFiltering(t *testing.T) {
 				authz.DefaultSubRepoPermsChecker = tt.checker()
 			}
 
-			p, err := query.Pipeline(query.InitLiteral(tt.searchQuery))
-			if err != nil {
-				t.Fatal(err)
-			}
-
 			repos := database.NewMockRepoStore()
 			repos.ListMinimalReposFunc.SetDefaultReturn([]types.MinimalRepo{}, nil)
 			repos.CountFunc.SetDefaultReturn(0, nil)
@@ -763,14 +776,25 @@ func TestSubRepoFiltering(t *testing.T) {
 				return database.NewMockEventLogStore()
 			})
 
+			literalPatternType := "literal"
+			searchInputs, err := run.NewSearchInputs(
+				context.Background(),
+				db,
+				"V2",
+				&literalPatternType,
+				tt.searchQuery,
+				search.Batch,
+				&schema.Settings{},
+				false,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
 			resolver := searchResolver{
-				SearchInputs: &run.SearchInputs{
-					Plan:         p,
-					Query:        p.ToParseTree(),
-					UserSettings: &schema.Settings{},
-				},
-				zoekt: mockZoekt,
-				db:    db,
+				SearchInputs: searchInputs,
+				zoekt:        mockZoekt,
+				db:           db,
 			}
 
 			ctx := context.Background()


### PR DESCRIPTION
It's just https://github.com/sourcegraph/sourcegraph/pull/32026 but needed to revert because of unlucky merge (needed rebase on https://github.com/sourcegraph/sourcegraph/pull/32023)

## Test plan
Semantics-preserving


