### PR TITLE
internal/extsvc/github: Remove unused arg from newOrgsCache

### DIFF
--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -118,7 +118,7 @@ func newV3Client(apiURL *url.URL, a auth.Authenticator, resource string, cli htt
 		httpClient:       cli,
 		rateLimit:        rl,
 		rateLimitMonitor: rlm,
-		orgsCache:        newOrgsCache(apiURL, a),
+		orgsCache:        newOrgsCache(a),
 		repoCache:        newRepoCache(apiURL, a),
 		resource:         resource,
 	}

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -217,7 +217,7 @@ func (c *V3Client) request(ctx context.Context, req *http.Request, result interf
 	return doRequest(ctx, c.apiURL, c.auth, c.rateLimitMonitor, c.httpClient, req, result)
 }
 
-func newOrgsCache(apiURL *url.URL, a auth.Authenticator) *rcache.Cache {
+func newOrgsCache(a auth.Authenticator) *rcache.Cache {
 	if a == nil {
 		log15.Warn("Cannot initialize orgsCache for nil auth")
 		return nil


### PR DESCRIPTION
How did this not get caught in the PR check? :thinking:

Originally introduced in #31275.

## Test plan

Not needed. Fixing errors caught in linting checks.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


