### PR TITLE
Streaming search: stream filters

### DIFF
--- a/client/web/src/search/results/SearchResultsCacheProvider.tsx
+++ b/client/web/src/search/results/SearchResultsCacheProvider.tsx
@@ -2,8 +2,8 @@ import { Remote } from 'comlink'
 import { isEqual } from 'lodash'
 import React, { createContext, Dispatch, SetStateAction, useContext, useEffect, useMemo, useState } from 'react'
 import { useHistory } from 'react-router'
-import { of } from 'rxjs'
-import { throttleTime } from 'rxjs/operators'
+import { merge, of } from 'rxjs'
+import { last, throttleTime } from 'rxjs/operators'
 
 import { transformSearchQuery } from '@sourcegraph/shared/src/api/client/search'
 import { FlatExtensionHostAPI } from '@sourcegraph/shared/src/api/contract'
@@ -55,8 +55,17 @@ export function useCachedSearchResults(
                 return of(cachedResults?.results)
             }
 
-            return streamSearch(transformedQuery, options).pipe(
-                throttleTime(500, undefined, { leading: true, trailing: true })
+            const stream = streamSearch(transformedQuery, options)
+
+            // If the throttleTime option `trailing` is set, we will return the
+            // final value, but it also removes the guarantee that the output events
+            // are a minimum of 200ms apart. If it's unset, we might throw away
+            // some trailing events. This is a fundamental issue with throttleTime,
+            // and is discussed extensively in github issues. Instead, we just manually
+            // merge throttleTime with only leading values and the final value.
+            return merge(
+                stream.pipe(throttleTime(200)),
+                stream.pipe(last()),
             )
         }, [
             query,

--- a/client/web/src/search/results/SearchResultsCacheProvider.tsx
+++ b/client/web/src/search/results/SearchResultsCacheProvider.tsx
@@ -63,10 +63,7 @@ export function useCachedSearchResults(
             // some trailing events. This is a fundamental issue with throttleTime,
             // and is discussed extensively in github issues. Instead, we just manually
             // merge throttleTime with only leading values and the final value.
-            return merge(
-                stream.pipe(throttleTime(200)),
-                stream.pipe(last()),
-            )
+            return merge(stream.pipe(throttleTime(500)), stream.pipe(last()))
         }, [
             query,
             cachedResults?.query,

--- a/client/web/src/search/results/SearchResultsCacheProvider.tsx
+++ b/client/web/src/search/results/SearchResultsCacheProvider.tsx
@@ -63,6 +63,7 @@ export function useCachedSearchResults(
             // some trailing events. This is a fundamental issue with throttleTime,
             // and is discussed extensively in github issues. Instead, we just manually
             // merge throttleTime with only leading values and the final value.
+            // See: https://github.com/ReactiveX/rxjs/issues/5732
             return merge(stream.pipe(throttleTime(500)), stream.pipe(last()))
         }, [
             query,


### PR DESCRIPTION
Currently, we don't send filters until a search has completed. This means that we don't render the sidebar dynamic filters until the end of the search. This leads to a somewhat jarring page flashing where 1) you start a search, 2) the first results show up, 3) the search completes and the dynamic filters load. 

This updates the backend to stream filters instead. Currently, it computes and sends filters whenever we flush matches. I don't think this will be practically too expensive, given the relatively low cardinality of repos compared to matches, but I'll keep an eye on profiles in prod, but it seems fine locally. If it is too expensive, I'm pretty sure we can compute filters incrementally as we stream. 

Additionally, this fixes an rxjs issue I noticed with `throttleTime`. Basically, with leading and trailing set for `throttleTime`, it no longer guarantees a minimum separation between output events. This causes a "galloping" effect in the UI where you'll see pairs of very close updates. It looks very unnatural. 

## Test plan

Manually tested. See attached video for results. 


https://user-images.githubusercontent.com/12631702/156481507-eeffad75-af53-4136-977b-5b3e990d50d4.mov




<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


