### PR TITLE
dev/team: make ResolveByGitHubHandle case-insensitive

### DIFF
--- a/dev/team/team.go
+++ b/dev/team/team.go
@@ -90,9 +90,13 @@ func (r *teammateResolver) ResolveByGitHubHandle(ctx context.Context, handle str
 		return nil, errors.Newf("getTeamData: %w", err)
 	}
 
+	// Normalize and match against lowercased handle - GitHub handles are not case-sensitive
+	handle = strings.ToLower(handle)
+
+	// Scan for teammates
 	var teammate *Teammate
 	for _, tm := range team {
-		if tm.GitHub == handle {
+		if strings.ToLower(tm.GitHub) == handle {
 			teammate = tm
 			break
 		}


### PR DESCRIPTION
Makes `ResolveByGitHubHandle` case-insensitive when scanning for matching GitHub handles.

Example:

<img width="588" alt="image" src="https://user-images.githubusercontent.com/23356519/156492462-b1583ed8-5e95-4e34-9911-8fc7d5c081d1.png">

Noah has his handle provided in lowercase: https://github.com/sourcegraph/handbook/blob/main/data/team.yml#L422

GitHub handles aren't case sensitive, so this should be allowed

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

n/a dev lib
