### PR TITLE
gitserver: read GITSERVER_ADDR env var

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -144,12 +144,15 @@ func main() {
 	defer cancel()
 	gitserver.StartClonePipeline(ctx)
 
-	port := "3178"
-	host := ""
-	if env.InsecureDev {
-		host = "127.0.0.1"
+	addr := os.Getenv("GITSERVER_ADDR")
+	if addr == "" {
+		port := "3178"
+		host := ""
+		if env.InsecureDev {
+			host = "127.0.0.1"
+		}
+		addr = net.JoinHostPort(host, port)
 	}
-	addr := net.JoinHostPort(host, port)
 	srv := &http.Server{
 		Addr:    addr,
 		Handler: handler,


### PR DESCRIPTION
This allows overriding the gitserver address using the GITSERVER_ADDR env var.
This time I chose a less generic env var to avoid conflicts in deployments with shared environment.

## Test plan

Tested with and without the env var


