### PR TITLE
auth: show GitLab icon for signin button

### DIFF
--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames'
 import * as H from 'history'
 import { partition } from 'lodash'
 import GithubIcon from 'mdi-react/GithubIcon'
+import GitlabIcon from 'mdi-react/GitlabIcon'
 import React, { useEffect, useState } from 'react'
 import { Redirect } from 'react-router-dom'
 
@@ -79,9 +80,14 @@ export const SignInPage: React.FunctionComponent<SignInPageProps> = props => {
                                 variant="secondary"
                                 as="a"
                             >
-                                {provider.displayName === 'GitHub' && (
+                                {provider.serviceType === 'github' && (
                                     <>
                                         <GithubIcon className="icon-inline" />{' '}
+                                    </>
+                                )}
+                                {provider.serviceType === 'gitlab' && (
+                                    <>
+                                        <GitlabIcon className="icon-inline" />{' '}
                                     </>
                                 )}
                                 Continue with {provider.displayName}


### PR DESCRIPTION
The icon has been missing for "Sign in with GitLab", this is very inconsistent to "Sign in with GitHub".

<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td> <img width="376" alt="CleanShot 2022-03-03 at 15 36 31@2x" src="https://user-images.githubusercontent.com/2946214/156518158-14b77af4-df25-4506-98cf-0e5b1169677c.png">
	<td> <img width="337" alt="CleanShot 2022-03-03 at 15 37 03@2x" src="https://user-images.githubusercontent.com/2946214/156518230-2aeb2147-de1d-44bf-9434-e54ae1767a0a.png">
</table>

## Test plan

Unit tests.


