### PR TITLE
[CLOUD-294] user: validate the avatar URL

### DIFF
--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -2,6 +2,7 @@ package graphqlbackend
 
 import (
 	"context"
+	"net/url"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
@@ -237,6 +238,19 @@ func (r *schemaResolver) UpdateUser(ctx context.Context, args *updateUserArgs) (
 	if args.Username != nil {
 		if err := suspiciousnames.CheckNameAllowedForUserOrOrganization(*args.Username); err != nil {
 			return nil, err
+		}
+	}
+
+	if args.AvatarURL != nil {
+		if len(*args.AvatarURL) > 3000 {
+			return nil, errors.New("avatar URL exceeded 3000 characters")
+		}
+
+		u, err := url.Parse(*args.AvatarURL)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to parse avatar URL")
+		} else if u.Scheme != "http" && u.Scheme != "https" {
+			return nil, errors.New("avatar URL must be an HTTP or HTTPS URL")
 		}
 	}
 

--- a/cmd/frontend/graphqlbackend/user_test.go
+++ b/cmd/frontend/graphqlbackend/user_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	gqlerrors "github.com/graph-gophers/graphql-go/errors"
@@ -465,6 +466,42 @@ func TestUpdateUser(t *testing.T) {
 		}
 	})
 
+	t.Run("bad avatarURL", func(t *testing.T) {
+		users := database.NewMockUserStore()
+		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: true}, nil)
+		db.UsersFunc.SetDefaultReturn(users)
+
+		tests := []struct {
+			name      string
+			avatarURL string
+			wantErr   string
+		}{
+			{
+				name:      "exceeded 3000 characters",
+				avatarURL: strings.Repeat("bad", 1001),
+				wantErr:   "avatar URL exceeded 3000 characters",
+			},
+			{
+				name:      "not HTTP nor HTTPS",
+				avatarURL: "ftp://avatars3.githubusercontent.com/u/404",
+				wantErr:   "avatar URL must be an HTTP or HTTPS URL",
+			},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				_, err := newSchemaResolver(db).UpdateUser(
+					context.Background(),
+					&updateUserArgs{
+						User:      MarshalUserID(1),
+						AvatarURL: &test.avatarURL,
+					},
+				)
+				got := fmt.Sprintf("%v", err)
+				assert.Equal(t, test.wantErr, got)
+			})
+		}
+	})
+
 	t.Run("success", func(t *testing.T) {
 		users := database.NewMockUserStore()
 		users.GetByIDFunc.SetDefaultHook(func(ctx context.Context, id int32) (*types.User, error) {
@@ -484,7 +521,8 @@ func TestUpdateUser(t *testing.T) {
 			mutation {
 				updateUser(
 					user: "VXNlcjox",
-					username: "alice.bob-chris-"
+					username: "alice.bob-chris-",
+					avatarURL: "https://avatars3.githubusercontent.com/u/404"
 				) {
 					username
 				}


### PR DESCRIPTION
Adds following validations when a user tries update the avatar URL:

- Make sure the value is a HTTP or HTTPS URL.
- The length of URL is no more than 3k characters.


## Test plan

Unit tests.

---

Jira: CLOUD-294


