### PR TITLE
notebooks: add compute block scaffolding

### DIFF
--- a/client/web/src/notebooks/blocks/compute/NotebookComputeBlock.module.scss
+++ b/client/web/src/notebooks/blocks/compute/NotebookComputeBlock.module.scss
@@ -1,0 +1,4 @@
+.input {
+    padding: 0.5rem 1rem;
+    background-color: var(--color-bg-1);
+}

--- a/client/web/src/notebooks/blocks/compute/NotebookComputeBlock.tsx
+++ b/client/web/src/notebooks/blocks/compute/NotebookComputeBlock.tsx
@@ -1,0 +1,86 @@
+import classNames from 'classnames'
+import React, { useRef } from 'react'
+
+import { ThemeProps } from '@sourcegraph/shared/src/theme'
+
+import { BlockProps, ComputeBlock } from '../..'
+import { NotebookBlockMenu } from '../menu/NotebookBlockMenu'
+import { useCommonBlockMenuActions } from '../menu/useCommonBlockMenuActions'
+import blockStyles from '../NotebookBlock.module.scss'
+import { useBlockSelection } from '../useBlockSelection'
+import { useBlockShortcuts } from '../useBlockShortcuts'
+
+import styles from './NotebookComputeBlock.module.scss'
+
+interface ComputeBlockProps extends BlockProps, ComputeBlock, ThemeProps {
+    isMacPlatform: boolean
+}
+
+export const NotebookComputeBlock: React.FunctionComponent<ComputeBlockProps> = ({
+    id,
+    input,
+    output,
+    isSelected,
+    isLightTheme,
+    isMacPlatform,
+    isReadOnly,
+    onRunBlock,
+    onSelectBlock,
+    ...props
+}) => {
+    const isInputFocused = false
+    const blockElement = useRef<HTMLDivElement>(null)
+
+    const { onSelect } = useBlockSelection({
+        id,
+        blockElement: blockElement.current,
+        isSelected,
+        isInputFocused,
+        onSelectBlock,
+        ...props,
+    })
+
+    const { onKeyDown } = useBlockShortcuts({
+        id,
+        isMacPlatform,
+        onEnterBlock: () => {},
+        ...props,
+        onRunBlock: () => {},
+    })
+
+    const modifierKeyLabel = isMacPlatform ? '⌘' : 'Ctrl'
+    const commonMenuActions = useCommonBlockMenuActions({
+        modifierKeyLabel,
+        isInputFocused,
+        isReadOnly,
+        isMacPlatform,
+        ...props,
+    })
+
+    const blockMenu = isSelected && !isReadOnly && <NotebookBlockMenu id={id} actions={commonMenuActions} />
+
+    return (
+        <div className={classNames('block-wrapper', blockStyles.blockWrapper)} data-block-id={id}>
+            {/* See the explanation for the disable above. */}
+            {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+            <div
+                className={classNames(
+                    blockStyles.block,
+                    styles.input,
+                    (isInputFocused || isSelected) && blockStyles.selected
+                )}
+                onClick={onSelect}
+                onFocus={onSelect}
+                onKeyDown={onKeyDown}
+                // A tabIndex is necessary to make the block focusable.
+                // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+                tabIndex={0}
+                aria-label="Notebook compute block"
+                ref={blockElement}
+            >
+                <div className="elm" />
+            </div>
+            {blockMenu}
+        </div>
+    )
+}

--- a/client/web/src/notebooks/createPage/CreateNotebookPage.tsx
+++ b/client/web/src/notebooks/createPage/CreateNotebookPage.tsx
@@ -17,13 +17,16 @@ import { blockToGQLInput, deserializeBlockInput } from '../serialize'
 const LOADING = 'loading' as const
 
 function deserializeBlocks(serializedBlocks: string): CreateNotebookBlockInput[] {
-    return serializedBlocks.split(',').map(serializedBlock => {
+    return serializedBlocks.split(',').flatMap(serializedBlock => {
         const [type, encodedInput] = serializedBlock.split(':')
-        if (type !== 'md' && type !== 'query' && type !== 'file') {
+        if (type !== 'md' && type !== 'query' && type !== 'file' && type !== 'compute') {
             throw new Error(`Unknown block type: ${type}`)
         }
+        if (type === 'compute') {
+            return [] // compute blocks do not support deserialization yet.
+        }
         const block = deserializeBlockInput(type, decodeURIComponent(encodedInput))
-        return blockToGQLInput({ id: uuid.v4(), ...block })
+        return [blockToGQLInput({ id: uuid.v4(), ...block })]
     })
 }
 

--- a/client/web/src/notebooks/index.ts
+++ b/client/web/src/notebooks/index.ts
@@ -6,7 +6,7 @@ import { FetchFileParameters } from '@sourcegraph/shared/src/components/CodeExce
 import { IHighlightLineRange } from '@sourcegraph/shared/src/schema'
 import { AggregateStreamingSearchResults } from '@sourcegraph/shared/src/search/stream'
 
-export type BlockType = 'md' | 'query' | 'file'
+export type BlockType = 'md' | 'query' | 'file' | 'compute'
 
 interface BaseBlock<I, O> {
     id: string
@@ -34,14 +34,23 @@ export interface FileBlock extends BaseBlock<FileBlockInput, Observable<string[]
     type: 'file'
 }
 
-export type Block = QueryBlock | MarkdownBlock | FileBlock
+export interface ComputeBlock extends BaseBlock<string, string> {
+    type: 'compute'
+}
+
+export type Block = QueryBlock | MarkdownBlock | FileBlock | ComputeBlock
 
 export type BlockInput =
     | Pick<FileBlock, 'type' | 'input'>
     | Pick<MarkdownBlock, 'type' | 'input'>
     | Pick<QueryBlock, 'type' | 'input'>
+    | Pick<ComputeBlock, 'type' | 'input'>
 
-export type BlockInit = Omit<FileBlock, 'output'> | Omit<MarkdownBlock, 'output'> | Omit<QueryBlock, 'output'>
+export type BlockInit =
+    | Omit<FileBlock, 'output'>
+    | Omit<MarkdownBlock, 'output'>
+    | Omit<QueryBlock, 'output'>
+    | Omit<ComputeBlock, 'output'>
 
 export type BlockDirection = 'up' | 'down'
 

--- a/client/web/src/notebooks/listPage/ImportMarkdownNotebookButton.tsx
+++ b/client/web/src/notebooks/listPage/ImportMarkdownNotebookButton.tsx
@@ -47,8 +47,8 @@ export const ImportMarkdownNotebookButton: React.FunctionComponent<ImportMarkdow
                 setImportState(INVALID_IMPORT_FILE_ERROR)
                 return
             }
-            const blocks = convertMarkdownToBlocks(event.target.result).map(block =>
-                blockToGQLInput({ id: uuid.v4(), ...block })
+            const blocks = convertMarkdownToBlocks(event.target.result).flatMap(block =>
+                block.type === 'compute' ? [] : [blockToGQLInput({ id: uuid.v4(), ...block })]
             )
             const title = fileName.split('.snb.md')[0].trim() || 'New Notebook'
             importNotebook({ title, blocks, public: false, namespace: authenticatedUser.id })

--- a/client/web/src/notebooks/notebook/NotebookComponent.tsx
+++ b/client/web/src/notebooks/notebook/NotebookComponent.tsx
@@ -34,6 +34,7 @@ import { NotebookFields } from '../../graphql-operations'
 import { getLSPTextDocumentPositionParameters } from '../../repo/blob/Blob'
 import { PageRoutes } from '../../routes.constants'
 import { SearchStreamingProps } from '../../search'
+import { NotebookComputeBlock } from '../blocks/compute/NotebookComputeBlock'
 import { NotebookFileBlock } from '../blocks/file/NotebookFileBlock'
 import { FileBlockValidationFunctions } from '../blocks/file/useFileBlockInputValidation'
 import { NotebookMarkdownBlock } from '../blocks/markdown/NotebookMarkdownBlock'
@@ -73,6 +74,7 @@ function countBlockTypes(blocks: Block[]): BlockCounts {
         md: 0,
         file: 0,
         query: 0,
+        compute: 0,
     })
 }
 
@@ -433,6 +435,8 @@ export const NotebookComponent: React.FunctionComponent<NotebookComponentProps> 
                             extensionsController={extensionsController}
                         />
                     )
+                case 'compute':
+                    return <NotebookComputeBlock {...block} {...blockProps} />
             }
         },
         [

--- a/client/web/src/notebooks/notebook/index.ts
+++ b/client/web/src/notebooks/notebook/index.ts
@@ -24,7 +24,7 @@ export function copyNotebook({ title, blocks, namespace }: CopyNotebookProps): O
     return createNotebook({
         notebook: {
             title,
-            blocks: blocks.map(blockToGQLInput),
+            blocks: blocks.flatMap(block => (block.type === 'compute' ? [] : [blockToGQLInput(block)])),
             namespace,
             public: false,
         },

--- a/client/web/src/notebooks/notebookPage/NotebookPage.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookPage.tsx
@@ -150,7 +150,12 @@ export const NotebookPage: React.FunctionComponent<NotebookPageProps> = ({
     }, [updateQueue, latestNotebook, onUpdateNotebook, setUpdateQueue])
 
     const onUpdateBlocks = useCallback(
-        (blocks: Block[]) => setUpdateQueue(queue => queue.concat([{ blocks: blocks.map(blockToGQLInput) }])),
+        (blocks: Block[]) =>
+            setUpdateQueue(queue =>
+                queue.concat([
+                    { blocks: blocks.flatMap(block => (block.type === 'compute' ? [] : [blockToGQLInput(block)])) },
+                ])
+            ),
         [setUpdateQueue]
     )
 

--- a/client/web/src/notebooks/serialize/index.ts
+++ b/client/web/src/notebooks/serialize/index.ts
@@ -22,6 +22,7 @@ export function serializeBlockToMarkdown(block: Block, sourcegraphURL: string): 
         case 'query':
             return `\`\`\`sourcegraph\n${serializedInput}\n\`\`\``
         case 'file':
+        case 'compute':
             return serializedInput
     }
 }
@@ -30,6 +31,7 @@ export function serializeBlockInput(block: BlockInput, sourcegraphURL: string): 
     switch (block.type) {
         case 'md':
         case 'query':
+        case 'compute':
             return block.input
         case 'file':
             return toAbsoluteBlobURL(sourcegraphURL, {
@@ -76,6 +78,7 @@ export function deserializeBlockInput(type: Block['type'], input: string): Block
     switch (type) {
         case 'md':
         case 'query':
+        case 'compute':
             return { type, input }
         case 'file':
             return { type, input: parseFileBlockInput(input) }
@@ -116,6 +119,8 @@ export function blockToGQLInput(block: BlockInit): CreateNotebookBlockInput {
             return { id: block.id, type: NotebookBlockType.QUERY, queryInput: block.input }
         case 'file':
             return { id: block.id, type: NotebookBlockType.FILE, fileInput: block.input }
+        case 'compute':
+            throw new Error('Unreachable: Compute block deserialization not supported yet.')
     }
 }
 


### PR DESCRIPTION
Adds scaffolding to prepare for `compute` block. Just want to get the types added and boiler for the block. It's not possible to exercise this code yet (no way to add a `compute` block). Excludes actual functionality, deserialization for GQL/GQL types, and feature flag for `compute` block. These will come in follow up PRs.

## Test plan
Code is not exercisable, no tests yet.

