### PR TITLE
wildcard: `UserAvatar` to intrinsic `<Icon />`

### DIFF
--- a/client/web/src/auth/CloudSignUpPage.tsx
+++ b/client/web/src/auth/CloudSignUpPage.tsx
@@ -149,7 +149,8 @@ export const CloudSignUpPage: React.FunctionComponent<Props> = ({
                         {invitedByUser ? (
                             <>
                                 <UserAvatar
-                                    className={classNames('icon-inline', 'mr-3', styles.avatar)}
+                                    inline={true}
+                                    className={classNames('mr-3', styles.avatar)}
                                     user={invitedByUser}
                                 />
                                 <strong className="mr-1">{invitedBy}</strong> has invited you to join Sourcegraph

--- a/client/web/src/auth/welcome/InviteCollaborators/InvitePane.tsx
+++ b/client/web/src/auth/welcome/InviteCollaborators/InvitePane.tsx
@@ -149,10 +149,7 @@ export const InvitePane: React.FunctionComponent<Props> = ({
                                 className={classNames('d-flex', 'ml-3', 'align-items-center', index !== 0 && 'mt-3')}
                                 key={person.email}
                             >
-                                <UserAvatar
-                                    className={classNames('icon-inline', 'mr-3', styles.avatar)}
-                                    user={person}
-                                />
+                                <UserAvatar inline={true} className={classNames('mr-3', styles.avatar)} user={person} />
                                 <div>
                                     <strong>{person.displayName}</strong>
                                     <div className="text-muted">{person.email}</div>

--- a/client/web/src/enterprise/batches/preview/list/GitBranchChangesetDescriptionInfo.tsx
+++ b/client/web/src/enterprise/batches/preview/list/GitBranchChangesetDescriptionInfo.tsx
@@ -41,7 +41,8 @@ export const GitBranchChangesetDescriptionInfo: React.FunctionComponent<Props> =
                         >
                             <div className="d-flex flex-column align-items-center mr-3">
                                 <UserAvatar
-                                    className="icon-inline mb-1"
+                                    inline={true}
+                                    className="mb-1"
                                     user={previousCommit.author}
                                     data-tooltip={formatPersonName(previousCommit.author)}
                                 />{' '}
@@ -62,7 +63,8 @@ export const GitBranchChangesetDescriptionInfo: React.FunctionComponent<Props> =
                 )}
             <div className="d-flex flex-column align-items-center mr-3">
                 <UserAvatar
-                    className="icon-inline mb-1"
+                    inline={true}
+                    className="mb-1"
                     user={commit.author}
                     data-tooltip={formatPersonName(commit.author)}
                 />{' '}

--- a/client/web/src/repo/commits/GitCommitNodeByline.tsx
+++ b/client/web/src/repo/commits/GitCommitNodeByline.tsx
@@ -48,12 +48,14 @@ export const GitCommitNodeByline: React.FunctionComponent<Props> = ({
             <div data-testid="git-commit-node-byline" className={className}>
                 <div className="flex-shrink-0">
                     <UserAvatar
-                        className={classNames('icon-inline', avatarClassName)}
+                        inline={true}
+                        className={avatarClassName}
                         user={author.person}
                         data-tooltip={`${formatPersonName(author.person)} (author)`}
                     />{' '}
                     <UserAvatar
-                        className={classNames('icon-inline mr-2', avatarClassName)}
+                        inline={true}
+                        className={classNames('mr-2', avatarClassName)}
                         user={committer.person}
                         data-tooltip={`${formatPersonName(committer.person)} (committer)`}
                     />
@@ -82,7 +84,8 @@ export const GitCommitNodeByline: React.FunctionComponent<Props> = ({
         <div data-testid="git-commit-node-byline" className={className}>
             <div>
                 <UserAvatar
-                    className={classNames('icon-inline mr-1 mr-2', avatarClassName)}
+                    inline={true}
+                    className={classNames('mr-1 mr-2', avatarClassName)}
                     user={author.person}
                     data-tooltip={formatPersonName(author.person)}
                 />

--- a/client/web/src/repo/commits/__snapshots__/GitCommitNodeByline.test.tsx.snap
+++ b/client/web/src/repo/commits/__snapshots__/GitCommitNodeByline.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`GitCommitNodeByline author (compact) 1`] = `
     <div>
       <img
         alt=""
-        class="userAvatar icon-inline mr-1 mr-2"
+        class="iconInline userAvatar mr-1 mr-2"
         data-tooltip="Alice Zhao"
         role="presentation"
         src="http://example.com/alice.png"
@@ -46,7 +46,7 @@ exports[`GitCommitNodeByline author 1`] = `
     <div>
       <img
         alt=""
-        class="userAvatar icon-inline mr-1 mr-2"
+        class="iconInline userAvatar mr-1 mr-2"
         data-tooltip="Alice Zhao"
         role="presentation"
         src="http://example.com/alice.png"
@@ -85,7 +85,7 @@ exports[`GitCommitNodeByline different author and committer (compact) 1`] = `
     >
       <img
         alt=""
-        class="userAvatar icon-inline"
+        class="iconInline userAvatar"
         data-tooltip="Alice Zhao (author)"
         role="presentation"
         src="http://example.com/alice.png"
@@ -93,7 +93,7 @@ exports[`GitCommitNodeByline different author and committer (compact) 1`] = `
        
       <img
         alt=""
-        class="userAvatar icon-inline mr-2"
+        class="iconInline userAvatar mr-2"
         data-tooltip="bYang (committer)"
         role="presentation"
         src="http://example.com/bob.png"
@@ -139,7 +139,7 @@ exports[`GitCommitNodeByline different author and committer 1`] = `
     >
       <img
         alt=""
-        class="userAvatar icon-inline"
+        class="iconInline userAvatar"
         data-tooltip="Alice Zhao (author)"
         role="presentation"
         src="http://example.com/alice.png"
@@ -147,7 +147,7 @@ exports[`GitCommitNodeByline different author and committer 1`] = `
        
       <img
         alt=""
-        class="userAvatar icon-inline mr-2"
+        class="iconInline userAvatar mr-2"
         data-tooltip="bYang (committer)"
         role="presentation"
         src="http://example.com/bob.png"
@@ -191,7 +191,7 @@ exports[`GitCommitNodeByline omit GitHub committer 1`] = `
     <div>
       <img
         alt=""
-        class="userAvatar icon-inline mr-1 mr-2"
+        class="iconInline userAvatar mr-1 mr-2"
         data-tooltip="Alice Zhao"
         role="presentation"
         src="http://example.com/alice.png"
@@ -228,7 +228,7 @@ exports[`GitCommitNodeByline same author and committer 1`] = `
     <div>
       <img
         alt=""
-        class="userAvatar icon-inline mr-1 mr-2"
+        class="iconInline userAvatar mr-1 mr-2"
         data-tooltip="Alice Zhao"
         role="presentation"
         src="http://example.com/alice.png"

--- a/client/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
+++ b/client/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
@@ -62,7 +62,7 @@ const RepositoryContributorNode: React.FunctionComponent<RepositoryContributorNo
     return (
         <div className={classNames('list-group-item py-2', styles.repositoryContributorNode)}>
             <div className={styles.person}>
-                <UserAvatar className="icon-inline mr-2" user={node.person} />
+                <UserAvatar inline={true} className="mr-2" user={node.person} />
                 <PersonLink userClassName="font-weight-bold" person={node.person} />
             </div>
             <div className={styles.commits}>

--- a/client/web/src/user/UserAvatar.tsx
+++ b/client/web/src/user/UserAvatar.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import classNames from 'classnames'
 
 import { Maybe } from '@sourcegraph/shared/src/graphql-operations'
+import { Icon } from '@sourcegraph/wildcard'
 
 import styles from './UserAvatar.module.scss'
 
@@ -17,6 +18,10 @@ interface Props {
     ['data-tooltip']?: string
     targetID?: string
     alt?: string
+    /**
+     * Whether to render with icon-inline className
+     */
+    inline?: boolean
 }
 
 /**
@@ -27,6 +32,7 @@ export const UserAvatar: React.FunctionComponent<Props> = ({
     user,
     className,
     targetID,
+    inline,
     // Exclude children since neither <img /> nor mdi-react icons receive them
     children,
     ...otherProps
@@ -42,16 +48,20 @@ export const UserAvatar: React.FunctionComponent<Props> = ({
         } catch {
             // noop
         }
-        return (
-            <img
-                className={classNames(styles.userAvatar, className)}
-                src={url}
-                id={targetID}
-                alt=""
-                role="presentation"
-                {...otherProps}
-            />
-        )
+
+        const imgProps = {
+            className: classNames(styles.userAvatar, className),
+            src: url,
+            id: targetID,
+            role: 'presentation',
+            ...otherProps,
+        }
+
+        if (inline) {
+            return <Icon as="img" alt="" {...imgProps} />
+        }
+
+        return <img alt="" {...imgProps} />
     }
 
     const name = user?.displayName || user?.username || ''
@@ -64,9 +74,15 @@ export const UserAvatar: React.FunctionComponent<Props> = ({
         return initials[0]
     }
 
-    return (
-        <div id={targetID} className={classNames(styles.userAvatar, className)}>
-            <span className={styles.initials}>{getInitials(name)}</span>
-        </div>
-    )
+    const props = {
+        id: targetID,
+        className: classNames(styles.userAvatar, className),
+        children: <span className={styles.initials}>{getInitials(name)}</span>,
+    }
+
+    if (inline) {
+        return <Icon as="div" {...props} />
+    }
+
+    return <div {...props} />
 }

--- a/client/wildcard/src/components/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/client/wildcard/src/components/Alert/__snapshots__/Alert.test.tsx.snap
@@ -77,6 +77,17 @@ exports[`Alert renders variant 'success' correctly 1`] = `
 </div>
 `;
 
+exports[`Alert renders variant 'waiting' correctly 1`] = `
+<div
+  class=""
+>
+  <h4>
+    Too many matching repositories
+  </h4>
+  Use a 'repo:' or 'repogroup:' filter to narrow your search.
+</div>
+`;
+
 exports[`Alert renders variant 'warning' correctly 1`] = `
 <div
   class=""

--- a/client/wildcard/src/components/Icon/Icon.tsx
+++ b/client/wildcard/src/components/Icon/Icon.tsx
@@ -5,6 +5,8 @@ import { MdiReactIconProps } from 'mdi-react'
 
 import { ForwardReferenceComponent } from '../..'
 
+import { ICON_SIZES } from './constants'
+
 import styles from './Icon.module.scss'
 
 export interface IconProps extends Omit<MdiReactIconProps, 'children'> {

--- a/client/wildcard/src/components/Icon/Icon.tsx
+++ b/client/wildcard/src/components/Icon/Icon.tsx
@@ -1,26 +1,24 @@
-import React, { ElementType, SVGProps } from 'react'
+import React, { ComponentType, ElementType, PropsWithChildren } from 'react'
 
 import classNames from 'classnames'
+import { MdiReactIconProps } from 'mdi-react'
 
-import { ICON_SIZES } from './constants'
+import { ForwardReferenceComponent } from '../..'
 
 import styles from './Icon.module.scss'
 
-export interface IconProps extends SVGProps<SVGSVGElement> {
+export interface IconProps extends Omit<MdiReactIconProps, 'children'> {
     className?: string
     /**
      * The variant style of the icon. defaults to 'sm'
      */
     size?: typeof ICON_SIZES[number]
-    /**
-     * Used to change the element that is rendered.
-     * Always be mindful of potentially accessibility pitfalls when using this!
-     */
-    as?: ElementType
 }
 
-export const Icon = React.forwardRef<SVGElement, IconProps>(
-    ({ children, className, size, as: Component = 'svg', ...attributes }, reference) => (
+export const Icon = React.forwardRef((props, reference) => {
+    const { children, inline = true, className, size, as: Component = 'svg', ...attributes } = props
+
+    return (
         <Component
             className={classNames(styles.iconInline, size === 'md' && styles.iconInlineMd, className)}
             ref={reference}
@@ -29,4 +27,4 @@ export const Icon = React.forwardRef<SVGElement, IconProps>(
             {children}
         </Component>
     )
-)
+}) as ForwardReferenceComponent<ComponentType<MdiReactIconProps> | ElementType, PropsWithChildren<IconProps>>


### PR DESCRIPTION
## Description
Migrated `UserAvatar` component, to use `<Icon />` component

[SG Issue](https://github.com/sourcegraph/sourcegraph/issues/27669)
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-27669)


## Test plan
Open web app
- compare avatar icons rendered here with avatar Icons rendered on prod environment
- Confirm there are no UI variations

## Preview App
[Storybook](https://client-sourcegraph-storybook-pr-267.onrender.com/)
[Frontend](https://client-sourcegraph-frontend-pr-267.onrender.com/)