### PR TITLE
sg: fix loading of the overwrite config

### DIFF
--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -166,7 +166,7 @@ func startCommandSet(ctx context.Context, set *Commandset, conf *Config, addToMa
 		enrichWithLogLevels(&cmd, levelOverrides)
 	}
 
-	env := globalConf.Env
+	env := conf.Env
 	for k, v := range set.Env {
 		env[k] = v
 	}

--- a/dev/sg/sg_start_test.go
+++ b/dev/sg/sg_start_test.go
@@ -30,6 +30,7 @@ func TestStartCommandSet(t *testing.T) {
 		Commandsets: map[string]*Commandset{"test-set": commandSet},
 	}
 
+	globalConf = testConf
 	if err := startCommandSet(ctx, commandSet, testConf, false); err != nil {
 		t.Errorf("failed to start: %s", err)
 	}

--- a/dev/sg/sg_start_test.go
+++ b/dev/sg/sg_start_test.go
@@ -30,7 +30,6 @@ func TestStartCommandSet(t *testing.T) {
 		Commandsets: map[string]*Commandset{"test-set": commandSet},
 	}
 
-	globalConf = testConf
 	if err := startCommandSet(ctx, commandSet, testConf, false); err != nil {
 		t.Errorf("failed to start: %s", err)
 	}

--- a/dev/sg/sg_tests.go
+++ b/dev/sg/sg_tests.go
@@ -55,15 +55,15 @@ func constructTestCmdLongHelp() string {
 
 	// Attempt to parse config to list available testsuites, but don't fail on
 	// error, because we should never error when the user wants --help output.
-	_, _ = parseConf(*configFlag, *overwriteConfigFlag)
+	cfg := parseConfAndReset()
 
-	if globalConf != nil {
+	if cfg != nil {
 		fmt.Fprintf(&out, "\n\n")
 		fmt.Fprintf(&out, "AVAILABLE TESTSUITES IN %s%s%s:\n", output.StyleBold, *configFlag, output.StyleReset)
 		fmt.Fprintf(&out, "\n")
 
 		var names []string
-		for name := range globalConf.Tests {
+		for name := range cfg.Tests {
 			names = append(names, name)
 		}
 		sort.Strings(names)


### PR DESCRIPTION
The test command must also use the `parseConfAndReset` function to not set the global conf during startup. This is related to https://github.com/sourcegraph/sourcegraph/issues/32061 but it doesn't completely fix the issue, as the help string still uses the default paths.

## Test plan

Run the tool with and without custom files.


