### PR TITLE
Client side pagination to Organization members and pending invites

### DIFF
--- a/client/web/src/org/members/OrgPendingInvites.tsx
+++ b/client/web/src/org/members/OrgPendingInvites.tsx
@@ -17,6 +17,7 @@ import {
     MenuList,
     MenuItem,
     Position,
+    PageSelector,
 } from '@sourcegraph/wildcard'
 
 import { PageTitle } from '../../components/PageTitle'
@@ -39,6 +40,7 @@ import {
     getInvitationCreationDateString,
     getInvitationExpiryDateString,
     getLocaleFormattedDateFromString,
+    getPaginatedItems,
     OrgMemberNotification,
 } from './utils'
 
@@ -242,6 +244,7 @@ export const OrgPendingInvitesPage: React.FunctionComponent<Props> = ({ org, aut
 
     const [invite, setInvite] = useState<IModalInviteResult>()
     const [notification, setNotification] = useState<string>()
+    const [page, setPage] = useState(1)
     const { data, loading, error, refetch } = useQuery<IPendingInvitations, PendingInvitationsVariables>(
         ORG_PENDING_INVITES_QUERY,
         {
@@ -261,6 +264,7 @@ export const OrgPendingInvitesPage: React.FunctionComponent<Props> = ({ org, aut
         async (recipient: string, revoked?: boolean) => {
             const message = `${revoked ? 'Revoked' : 'Resent'} invite for ${recipient}`
             setNotification(message)
+            setPage(1)
             await refetch({ id: orgId })
         },
         [setNotification, orgId, refetch]
@@ -275,6 +279,7 @@ export const OrgPendingInvitesPage: React.FunctionComponent<Props> = ({ org, aut
     }, [setNotification])
 
     const viewerCanInviteUserToOrganization = !!authenticatedUser
+    const pagedData = getPaginatedItems(page, data?.pendingInvitations)
 
     return (
         <>
@@ -313,7 +318,7 @@ export const OrgPendingInvitesPage: React.FunctionComponent<Props> = ({ org, aut
                     {data && (
                         <ul>
                             {data && data.pendingInvitations.length > 0 && <PendingInvitesHeader />}
-                            {data.pendingInvitations.map(item => (
+                            {pagedData.results.map(item => (
                                 <InvitationItem
                                     key={item.id}
                                     invite={item}
@@ -330,6 +335,14 @@ export const OrgPendingInvitesPage: React.FunctionComponent<Props> = ({ org, aut
                         />
                     )}
                 </Container>
+                {pagedData.totalPages > 1 && (
+                    <PageSelector
+                        className="mt-4"
+                        currentPage={page}
+                        onPageChange={setPage}
+                        totalPages={pagedData.totalPages}
+                    />
+                )}
                 {authenticatedUser && data && data.pendingInvitations.length === 0 && (
                     <Container>
                         <div className="d-flex flex-0 flex-column justify-content-center align-items-center">

--- a/client/web/src/org/members/utils.tsx
+++ b/client/web/src/org/members/utils.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames'
+import { drop } from 'lodash'
 import CloseIcon from 'mdi-react/CloseIcon'
 import React from 'react'
 
@@ -61,3 +62,23 @@ export const OrgMemberNotification: React.FunctionComponent<MembersNotificationP
         </Button>
     </Alert>
 )
+
+export function getPaginatedItems<T>(
+    currentPage: number,
+    items?: T[],
+    pageSize = 20
+): { totalPages: number; results: T[] } {
+    if (!items || items.length === 0) {
+        return {
+            totalPages: 0,
+            results: [],
+        }
+    }
+    const page = currentPage || 1
+    const offset = (page - 1) * pageSize
+    const pagedItems = drop(items, offset).slice(0, pageSize)
+    return {
+        totalPages: Math.ceil(items.length / pageSize),
+        results: pagedItems,
+    }
+}


### PR DESCRIPTION
Adding client side only pagination to Members list and pending invites list. This is a first step while waiting for implementing pagination on the api side. 
![image](https://user-images.githubusercontent.com/3056730/156547990-1c51a62f-d391-4e7f-b1d0-65ff0975fc89.png)

## Test plan
The new flow is behind feature flag. This change has been manually tested
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


