### PR TITLE
Move Global scss variable into `global-styles/variables.scss`

### DIFF
--- a/client/branded/src/global-styles/forms.scss
+++ b/client/branded/src/global-styles/forms.scss
@@ -1,23 +1,6 @@
 @import 'wildcard/src/global-styles/breakpoints';
 
 :root {
-    --input-font-size: var(--font-size-base);
-    --input-line-height: var(--line-height-base);
-    --input-line-height-sm: 1.5;
-    --input-padding-y: 0.375rem;
-    --input-padding-x: 0.75rem;
-    --input-padding-y-sm: 0.25rem;
-    --input-padding-x-sm: 0.5rem;
-    --input-border-width: 0.0625rem;
-    --input-height: calc((var(--input-line-height) * 1em) + (var(--input-padding-y) * 2) + var(--input-height-border));
-    --input-height-sm: calc(
-        (var(--input-line-height-sm) * 1em) + (var(--input-padding-y-sm) * 2) + var(--input-height-border)
-    );
-    --input-height-border: calc(var(--input-border-width) * 2);
-    --input-height-inner: calc((var(--input-line-height) * 1em) + (var(--input-padding-y) * 2));
-    --input-height-inner-quarter: calc((var(--input-line-height) * 0.25em) + (var(--input-padding-y) / 2));
-    --input-height-inner-half: calc((var(--input-line-height) * 0.5em) + var(--input-padding-y));
-    --input-font-weight: 400;
     --form-group-margin-bottom: 1rem;
     --form-text-margin-top: 0.25rem;
     --form-check-input-gutter: 1.25rem;

--- a/client/branded/src/global-styles/index.scss
+++ b/client/branded/src/global-styles/index.scss
@@ -1,14 +1,12 @@
 @import './colors.scss';
 @import './border-radius.scss';
+@import './variables.scss';
 
 // Bootstrap configuration before Bootstrap is imported
 $border-radius: var(--border-radius);
 $border-radius-sm: var(--border-radius);
 $border-radius-lg: var(--border-radius);
 $popover-border-radius: var(--popover-border-radius);
-
-$font-size-base: 0.875rem;
-$line-height-base: (20/14);
 
 $box-shadow: var(--box-shadow);
 
@@ -87,15 +85,6 @@ $hr-margin-y: 0.25rem;
 
 // Disable all Bootstrap transitions
 $enable-transitions: false;
-
-// Spacer
-$spacer: 1rem;
-
-:root {
-    --spacer: #{$spacer};
-    --font-size-base: #{$font-size-base};
-    --line-height-base: #{$line-height-base};
-}
 
 // Apply static variables before Bootstrap imports.
 @import 'bootstrap/scss/functions';

--- a/client/branded/src/global-styles/typography.scss
+++ b/client/branded/src/global-styles/typography.scss
@@ -76,19 +76,13 @@ strong {
     font-weight: 600;
 }
 
-$input-font-size-sm: (11/14) + em;
-
 // Input / Small
 .form-control-sm,
 %form-control-sm,
 .custom-select-sm,
 %custom-select-sm {
-    font-size: $input-font-size-sm;
+    font-size: var(--input-font-size-sm);
     line-height: 1rem;
-}
-
-:root {
-    --input-font-size-sm: #{$input-font-size-sm};
 }
 
 // Label / Base

--- a/client/branded/src/global-styles/variables.scss
+++ b/client/branded/src/global-styles/variables.scss
@@ -1,0 +1,34 @@
+$font-size-base: 0.875rem;
+$line-height-base: (20/14);
+
+// Input
+$input-padding-y: 0.375rem;
+$input-padding-x: 0.75rem;
+$input-font-size-sm: (11/14) + em;
+
+// Spacer
+$spacer: 1rem;
+
+:root {
+    --spacer: #{$spacer};
+    --font-size-base: #{$font-size-base};
+    --line-height-base: #{$line-height-base};
+    --input-font-size: var(--font-size-base);
+    --input-font-size-sm: #{$input-font-size-sm};
+    --input-line-height: var(--line-height-base);
+    --input-line-height-sm: 1.5;
+    --input-padding-y: #{$input-padding-y};
+    --input-padding-x: #{$input-padding-x};
+    --input-padding-y-sm: 0.25rem;
+    --input-padding-x-sm: 0.5rem;
+    --input-height: calc((var(--input-line-height) * 1em) + (var(--input-padding-y) * 2) + var(--input-height-border));
+    --input-height-sm: calc(
+        (var(--input-line-height-sm) * 1em) + (var(--input-padding-y-sm) * 2) + var(--input-height-border)
+    );
+    --input-height-border: calc(var(--input-border-width) * 2);
+    --input-height-inner: calc((var(--input-line-height) * 1em) + (var(--input-padding-y) * 2));
+    --input-height-inner-quarter: calc((var(--input-line-height) * 0.25em) + (var(--input-padding-y) / 2));
+    --input-height-inner-half: calc((var(--input-line-height) * 0.5em) + var(--input-padding-y));
+    --input-border-width: 0.0625rem;
+    --input-font-weight: 400;
+}


### PR DESCRIPTION
## Description
It's confusing to see global CSS variables related to input in multiple places.

## Implementation Details
Move all global CSS variables affected by [this PR](https://github.com/sourcegraph/sourcegraph/pull/30287) into a global-styles/variables.scss and import it in global-styles/index.scss

## Refs
-  [Sourcegraph Issue](https://github.com/sourcegraph/sourcegraph/issues/32117)
- [Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-32117)

## Preview App
- [Frontend](https://client-sourcegraph-frontend-pr-269.onrender.com/)
- [Storybook](https://client-sourcegraph-storybook-pr-269.onrender.com/)

## Test plan
- Compare UI on local and remote SourceGraph app
- Confirm that there is no diff in both versions


