### PR TITLE
Experimental ref panel: when clicking definition in mini code view, open code view immediately

### DIFF
--- a/client/web/src/global/CoolCodeIntel.tsx
+++ b/client/web/src/global/CoolCodeIntel.tsx
@@ -273,7 +273,7 @@ export const ReferencesList: React.FunctionComponent<
     // definitions) we select the first definition. We set it as activeLocation
     // and push it to the blobMemoryHistory so the code blob is open.
     useEffect(() => {
-        if (props.jumpToFirst === true && definitions.length > 0) {
+        if (props.jumpToFirst && definitions.length > 0) {
             blobMemoryHistory.push(definitions[0].url)
             setActiveLocation(definitions[0])
         }


### PR DESCRIPTION
This changes the behaviour of the code blob on the right: it now stays open when the user landed on a reference that they clicked on _inside the code view_.

In order to implement this I had to simplify the component structure a bit, which I think is a good thing.

https://user-images.githubusercontent.com/1185253/156743318-1a2b55e6-b6c7-4b80-a26a-68b174efafdd.mp4

## Test plan

- Tested manually all the different behaviours. See video.


