### PR TITLE
Search backend: store db on `searchClient`

### DIFF
--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -117,14 +117,14 @@ func TestDisplayLimit(t *testing.T) {
 
 			mockInput := make(chan streaming.SearchEvent)
 			mock := client.NewMockSearchClient()
-			mock.PlanFunc.SetDefaultHook(func(_ context.Context, _ database.DB, _ string, _ *string, queryString string, _ search.Protocol, _ *schema.Settings, _ bool) (*run.SearchInputs, error) {
+			mock.PlanFunc.SetDefaultHook(func(_ context.Context, _ string, _ *string, queryString string, _ search.Protocol, _ *schema.Settings, _ bool) (*run.SearchInputs, error) {
 				q, err := query.Parse(queryString, query.SearchTypeLiteral)
 				require.NoError(t, err)
 				return &run.SearchInputs{
 					Query: q,
 				}, nil
 			})
-			mock.ExecuteFunc.SetDefaultHook(func(_ context.Context, _ database.DB, stream streaming.Sender, _ *run.SearchInputs) (*search.Alert, error) {
+			mock.ExecuteFunc.SetDefaultHook(func(_ context.Context, stream streaming.Sender, _ *run.SearchInputs) (*search.Alert, error) {
 				event := <-mockInput
 				stream.Send(event)
 				return nil, nil

--- a/enterprise/cmd/frontend/internal/compute/streaming/compute.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/compute.go
@@ -53,8 +53,8 @@ func NewComputeStream(ctx context.Context, db database.DB, query string) (<-chan
 	}
 
 	patternType := "regexp"
-	searchClient := client.NewSearchClient(search.Indexed(), search.SearcherURLs())
-	inputs, err := searchClient.Plan(ctx, db, "", &patternType, searchQuery, search.Streaming, settings, envvar.SourcegraphDotComMode())
+	searchClient := client.NewSearchClient(db, search.Indexed(), search.SearcherURLs())
+	inputs, err := searchClient.Plan(ctx, "", &patternType, searchQuery, search.Streaming, settings, envvar.SourcegraphDotComMode())
 	if err != nil {
 		close(eventsC)
 		return eventsC, func() error { return err }
@@ -68,7 +68,7 @@ func NewComputeStream(ctx context.Context, db database.DB, query string) (<-chan
 		defer close(final)
 		defer close(eventsC)
 
-		_, err := searchClient.Execute(ctx, db, stream, inputs)
+		_, err := searchClient.Execute(ctx, stream, inputs)
 		final <- finalResult{err: err}
 	}()
 

--- a/enterprise/internal/codemonitors/background/graphql.go
+++ b/enterprise/internal/codemonitors/background/graphql.go
@@ -97,14 +97,14 @@ func settings(ctx context.Context) (_ *schema.Settings, err error) {
 }
 
 func doSearch(ctx context.Context, db database.DB, query string, settings *schema.Settings) (_ []*result.CommitMatch, err error) {
-	searchClient := client.NewSearchClient(search.Indexed(), search.SearcherURLs())
-	inputs, err := searchClient.Plan(ctx, db, "V2", nil, query, search.Streaming, settings, envvar.SourcegraphDotComMode())
+	searchClient := client.NewSearchClient(db, search.Indexed(), search.SearcherURLs())
+	inputs, err := searchClient.Plan(ctx, "V2", nil, query, search.Streaming, settings, envvar.SourcegraphDotComMode())
 	if err != nil {
 		return nil, err
 	}
 
 	agg := streaming.NewAggregatingStream()
-	_, err = searchClient.Execute(ctx, db, agg, inputs)
+	_, err = searchClient.Execute(ctx, agg, inputs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/search/client/mock_client.go
+++ b/internal/search/client/mock_client.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"sync"
 
-	database "github.com/sourcegraph/sourcegraph/internal/database"
 	search "github.com/sourcegraph/sourcegraph/internal/search"
 	run "github.com/sourcegraph/sourcegraph/internal/search/run"
 	streaming "github.com/sourcegraph/sourcegraph/internal/search/streaming"
@@ -31,12 +30,12 @@ type MockSearchClient struct {
 func NewMockSearchClient() *MockSearchClient {
 	return &MockSearchClient{
 		ExecuteFunc: &SearchClientExecuteFunc{
-			defaultHook: func(context.Context, database.DB, streaming.Sender, *run.SearchInputs) (*search.Alert, error) {
+			defaultHook: func(context.Context, streaming.Sender, *run.SearchInputs) (*search.Alert, error) {
 				return nil, nil
 			},
 		},
 		PlanFunc: &SearchClientPlanFunc{
-			defaultHook: func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings, bool) (*run.SearchInputs, error) {
+			defaultHook: func(context.Context, string, *string, string, search.Protocol, *schema.Settings, bool) (*run.SearchInputs, error) {
 				return nil, nil
 			},
 		},
@@ -48,12 +47,12 @@ func NewMockSearchClient() *MockSearchClient {
 func NewStrictMockSearchClient() *MockSearchClient {
 	return &MockSearchClient{
 		ExecuteFunc: &SearchClientExecuteFunc{
-			defaultHook: func(context.Context, database.DB, streaming.Sender, *run.SearchInputs) (*search.Alert, error) {
+			defaultHook: func(context.Context, streaming.Sender, *run.SearchInputs) (*search.Alert, error) {
 				panic("unexpected invocation of MockSearchClient.Execute")
 			},
 		},
 		PlanFunc: &SearchClientPlanFunc{
-			defaultHook: func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings, bool) (*run.SearchInputs, error) {
+			defaultHook: func(context.Context, string, *string, string, search.Protocol, *schema.Settings, bool) (*run.SearchInputs, error) {
 				panic("unexpected invocation of MockSearchClient.Plan")
 			},
 		},
@@ -77,24 +76,24 @@ func NewMockSearchClientFrom(i SearchClient) *MockSearchClient {
 // SearchClientExecuteFunc describes the behavior when the Execute method of
 // the parent MockSearchClient instance is invoked.
 type SearchClientExecuteFunc struct {
-	defaultHook func(context.Context, database.DB, streaming.Sender, *run.SearchInputs) (*search.Alert, error)
-	hooks       []func(context.Context, database.DB, streaming.Sender, *run.SearchInputs) (*search.Alert, error)
+	defaultHook func(context.Context, streaming.Sender, *run.SearchInputs) (*search.Alert, error)
+	hooks       []func(context.Context, streaming.Sender, *run.SearchInputs) (*search.Alert, error)
 	history     []SearchClientExecuteFuncCall
 	mutex       sync.Mutex
 }
 
 // Execute delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockSearchClient) Execute(v0 context.Context, v1 database.DB, v2 streaming.Sender, v3 *run.SearchInputs) (*search.Alert, error) {
-	r0, r1 := m.ExecuteFunc.nextHook()(v0, v1, v2, v3)
-	m.ExecuteFunc.appendCall(SearchClientExecuteFuncCall{v0, v1, v2, v3, r0, r1})
+func (m *MockSearchClient) Execute(v0 context.Context, v1 streaming.Sender, v2 *run.SearchInputs) (*search.Alert, error) {
+	r0, r1 := m.ExecuteFunc.nextHook()(v0, v1, v2)
+	m.ExecuteFunc.appendCall(SearchClientExecuteFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the Execute method of
 // the parent MockSearchClient instance is invoked and the hook queue is
 // empty.
-func (f *SearchClientExecuteFunc) SetDefaultHook(hook func(context.Context, database.DB, streaming.Sender, *run.SearchInputs) (*search.Alert, error)) {
+func (f *SearchClientExecuteFunc) SetDefaultHook(hook func(context.Context, streaming.Sender, *run.SearchInputs) (*search.Alert, error)) {
 	f.defaultHook = hook
 }
 
@@ -102,7 +101,7 @@ func (f *SearchClientExecuteFunc) SetDefaultHook(hook func(context.Context, data
 // Execute method of the parent MockSearchClient instance invokes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *SearchClientExecuteFunc) PushHook(hook func(context.Context, database.DB, streaming.Sender, *run.SearchInputs) (*search.Alert, error)) {
+func (f *SearchClientExecuteFunc) PushHook(hook func(context.Context, streaming.Sender, *run.SearchInputs) (*search.Alert, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -111,19 +110,19 @@ func (f *SearchClientExecuteFunc) PushHook(hook func(context.Context, database.D
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *SearchClientExecuteFunc) SetDefaultReturn(r0 *search.Alert, r1 error) {
-	f.SetDefaultHook(func(context.Context, database.DB, streaming.Sender, *run.SearchInputs) (*search.Alert, error) {
+	f.SetDefaultHook(func(context.Context, streaming.Sender, *run.SearchInputs) (*search.Alert, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *SearchClientExecuteFunc) PushReturn(r0 *search.Alert, r1 error) {
-	f.PushHook(func(context.Context, database.DB, streaming.Sender, *run.SearchInputs) (*search.Alert, error) {
+	f.PushHook(func(context.Context, streaming.Sender, *run.SearchInputs) (*search.Alert, error) {
 		return r0, r1
 	})
 }
 
-func (f *SearchClientExecuteFunc) nextHook() func(context.Context, database.DB, streaming.Sender, *run.SearchInputs) (*search.Alert, error) {
+func (f *SearchClientExecuteFunc) nextHook() func(context.Context, streaming.Sender, *run.SearchInputs) (*search.Alert, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -161,13 +160,10 @@ type SearchClientExecuteFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 database.DB
+	Arg1 streaming.Sender
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 streaming.Sender
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 *run.SearchInputs
+	Arg2 *run.SearchInputs
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 *search.Alert
@@ -179,7 +175,7 @@ type SearchClientExecuteFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c SearchClientExecuteFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
@@ -191,23 +187,23 @@ func (c SearchClientExecuteFuncCall) Results() []interface{} {
 // SearchClientPlanFunc describes the behavior when the Plan method of the
 // parent MockSearchClient instance is invoked.
 type SearchClientPlanFunc struct {
-	defaultHook func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings, bool) (*run.SearchInputs, error)
-	hooks       []func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings, bool) (*run.SearchInputs, error)
+	defaultHook func(context.Context, string, *string, string, search.Protocol, *schema.Settings, bool) (*run.SearchInputs, error)
+	hooks       []func(context.Context, string, *string, string, search.Protocol, *schema.Settings, bool) (*run.SearchInputs, error)
 	history     []SearchClientPlanFuncCall
 	mutex       sync.Mutex
 }
 
 // Plan delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockSearchClient) Plan(v0 context.Context, v1 database.DB, v2 string, v3 *string, v4 string, v5 search.Protocol, v6 *schema.Settings, v7 bool) (*run.SearchInputs, error) {
-	r0, r1 := m.PlanFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6, v7)
-	m.PlanFunc.appendCall(SearchClientPlanFuncCall{v0, v1, v2, v3, v4, v5, v6, v7, r0, r1})
+func (m *MockSearchClient) Plan(v0 context.Context, v1 string, v2 *string, v3 string, v4 search.Protocol, v5 *schema.Settings, v6 bool) (*run.SearchInputs, error) {
+	r0, r1 := m.PlanFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6)
+	m.PlanFunc.appendCall(SearchClientPlanFuncCall{v0, v1, v2, v3, v4, v5, v6, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the Plan method of the
 // parent MockSearchClient instance is invoked and the hook queue is empty.
-func (f *SearchClientPlanFunc) SetDefaultHook(hook func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings, bool) (*run.SearchInputs, error)) {
+func (f *SearchClientPlanFunc) SetDefaultHook(hook func(context.Context, string, *string, string, search.Protocol, *schema.Settings, bool) (*run.SearchInputs, error)) {
 	f.defaultHook = hook
 }
 
@@ -215,7 +211,7 @@ func (f *SearchClientPlanFunc) SetDefaultHook(hook func(context.Context, databas
 // Plan method of the parent MockSearchClient instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *SearchClientPlanFunc) PushHook(hook func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings, bool) (*run.SearchInputs, error)) {
+func (f *SearchClientPlanFunc) PushHook(hook func(context.Context, string, *string, string, search.Protocol, *schema.Settings, bool) (*run.SearchInputs, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -224,19 +220,19 @@ func (f *SearchClientPlanFunc) PushHook(hook func(context.Context, database.DB, 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *SearchClientPlanFunc) SetDefaultReturn(r0 *run.SearchInputs, r1 error) {
-	f.SetDefaultHook(func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings, bool) (*run.SearchInputs, error) {
+	f.SetDefaultHook(func(context.Context, string, *string, string, search.Protocol, *schema.Settings, bool) (*run.SearchInputs, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *SearchClientPlanFunc) PushReturn(r0 *run.SearchInputs, r1 error) {
-	f.PushHook(func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings, bool) (*run.SearchInputs, error) {
+	f.PushHook(func(context.Context, string, *string, string, search.Protocol, *schema.Settings, bool) (*run.SearchInputs, error) {
 		return r0, r1
 	})
 }
 
-func (f *SearchClientPlanFunc) nextHook() func(context.Context, database.DB, string, *string, string, search.Protocol, *schema.Settings, bool) (*run.SearchInputs, error) {
+func (f *SearchClientPlanFunc) nextHook() func(context.Context, string, *string, string, search.Protocol, *schema.Settings, bool) (*run.SearchInputs, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -274,25 +270,22 @@ type SearchClientPlanFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 database.DB
+	Arg1 string
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 string
+	Arg2 *string
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 *string
+	Arg3 string
 	// Arg4 is the value of the 5th argument passed to this method
 	// invocation.
-	Arg4 string
+	Arg4 search.Protocol
 	// Arg5 is the value of the 6th argument passed to this method
 	// invocation.
-	Arg5 search.Protocol
+	Arg5 *schema.Settings
 	// Arg6 is the value of the 7th argument passed to this method
 	// invocation.
-	Arg6 *schema.Settings
-	// Arg7 is the value of the 8th argument passed to this method
-	// invocation.
-	Arg7 bool
+	Arg6 bool
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 *run.SearchInputs
@@ -304,7 +297,7 @@ type SearchClientPlanFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c SearchClientPlanFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6, c.Arg7}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6}
 }
 
 // Results returns an interface slice containing the results of this


### PR DESCRIPTION
This moves the onto the searchClient struct. This effectively makes
searchClient our "clients" struct that we talked about passing into our
jobs at execution time. Also needed for some imminent code monitor
changes.

Stacked on #32145

## Test plan

Semantics preserving. Covered by unit tests. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


