### PR TITLE
remove dead code monitor GraphQL code

### DIFF
--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -24,8 +24,6 @@ type CodeMonitorsResolver interface {
 	TriggerTestSlackWebhookAction(ctx context.Context, args *TriggerTestSlackWebhookActionArgs) (*EmptyResponse, error)
 
 	NodeResolvers() map[string]NodeByIDFunc
-
-	CodeMonitorSearch(context.Context, *SearchArgs) (SearchImplementer, error)
 }
 
 type MonitorConnectionResolver interface {

--- a/cmd/frontend/graphqlbackend/code_monitors.graphql
+++ b/cmd/frontend/graphqlbackend/code_monitors.graphql
@@ -1,24 +1,3 @@
-extend type Query {
-    """
-    Runs a code monitor search.
-    """
-    codeMonitorSearch(
-        """
-        PatternType controls the search pattern type, if and only if it is not specified in the query string using
-        the patternType: field.
-        """
-        patternType: SearchPatternType
-        """
-        The search query (such as "foo" or "repo:myrepo foo").
-        """
-        query: String = ""
-        """
-        codeMonitorID is the code monitor associated with this search
-        """
-        codeMonitorID: ID
-    ): Search
-}
-
 extend type Mutation {
     """
     Create a code monitor.

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/google/zoekt"
-	"github.com/graph-gophers/graphql-go"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -20,14 +19,6 @@ type SearchArgs struct {
 	Version     string
 	PatternType *string
 	Query       string
-
-	// CodeMonitorID, if set, is the graphql-encoded ID of the code monitor
-	// that is running the search. This will likely be removed in the future
-	// once the worker can mutate and execute the search directly, but for now,
-	// there are too many dependencies in frontend to do that. For anyone looking
-	// to rip this out in the future, this should be possible once we can build
-	// a static representation of our job tree independently of any resolvers.
-	CodeMonitorID *graphql.ID
 }
 
 type SearchImplementer interface {

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -385,11 +385,6 @@ func (r *Resolver) TriggerTestSlackWebhookAction(ctx context.Context, args *grap
 	return &graphqlbackend.EmptyResponse{}, nil
 }
 
-func (r *Resolver) CodeMonitorSearch(ctx context.Context, args *graphqlbackend.SearchArgs) (graphqlbackend.SearchImplementer, error) {
-	args.Version = "V2"
-	return graphqlbackend.NewBatchSearchImplementer(ctx, r.db, args)
-}
-
 func sendTestEmail(ctx context.Context, recipient graphql.ID, description string) error {
 	var (
 		userID int32


### PR DESCRIPTION
This is no longer used now that we don't do code monitor searches
through GraphQL.

## Test plan

Just removing dead code. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


