### PR TITLE
codeintel: expose code intel info for `GitTree`

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -25,7 +25,8 @@ type CodeIntelResolver interface {
 	CommitGraph(ctx context.Context, id graphql.ID) (CodeIntelligenceCommitGraphResolver, error)
 	QueueAutoIndexJobsForRepo(ctx context.Context, args *QueueAutoIndexJobsForRepoArgs) ([]LSIFIndexResolver, error)
 	GitBlobLSIFData(ctx context.Context, args *GitBlobLSIFDataArgs) (GitBlobLSIFDataResolver, error)
-	GitBlobCodeIntelInfo(ctx context.Context, args *GitBlobCodeIntelInfoArgs) (CodeIntelSupportResolver, error)
+	GitBlobCodeIntelInfo(ctx context.Context, args *GitTreeEntryCodeIntelInfoArgs) (GitBlobCodeIntelSupportResolver, error)
+	GitTreeCodeIntelInfo(ctx context.Context, args *GitTreeEntryCodeIntelInfoArgs) (GitTreeCodeIntelSupportResolver, error)
 
 	CodeIntelligenceConfigurationPolicies(ctx context.Context, args *CodeIntelligenceConfigurationPoliciesArgs) (CodeIntelligenceConfigurationPolicyConnectionResolver, error)
 	CreateCodeIntelligenceConfigurationPolicy(ctx context.Context, args *CreateCodeIntelligenceConfigurationPolicyArgs) (CodeIntelligenceConfigurationPolicyResolver, error)
@@ -363,22 +364,34 @@ type CodeIntelligenceRetentionPolicyMatchResolver interface {
 	ProtectingCommits() *[]string
 }
 
-type GitBlobCodeIntelInfoArgs struct {
-	Repo api.RepoName
-	Path string
+type GitTreeEntryCodeIntelInfoArgs struct {
+	Repo   *types.Repo
+	Path   string
+	Commit string
 }
 
-type GitBlobCodeIntelInfoResolver interface {
-	Support(context.Context) CodeIntelSupportResolver
-	LSIFUploads(context.Context) (LSIFUploadConnectionResolver, error)
+type GitTreeCodeIntelSupportResolver interface {
+	SearchBasedSupport(context.Context) ([]GitTreeSearchBasedCoverage, error)
+	PreciseSupport(context.Context) ([]GitTreePreciseCoverage, error)
 }
 
-type CodeIntelSupportResolver interface {
-	SearchBasedSupport(context.Context) (SearchBasedCodeIntelSupportResolver, error)
-	PreciseSupport(context.Context) (PreciseCodeIntelSupportResolver, error)
+type GitTreeSearchBasedCoverage interface {
+	CoveredPaths() []string
+	Support() SearchBasedSupportResolver
 }
 
-type PreciseCodeIntelSupportResolver interface {
+type GitTreePreciseCoverage interface {
+	CoveredPaths() []string
+	Support() PreciseSupportResolver
+	Confidence() string
+}
+
+type GitBlobCodeIntelSupportResolver interface {
+	SearchBasedSupport(context.Context) (SearchBasedSupportResolver, error)
+	PreciseSupport(context.Context) (PreciseSupportResolver, error)
+}
+
+type PreciseSupportResolver interface {
 	SupportLevel() string
 	Indexers() *[]CodeIntelIndexerResolver
 }
@@ -388,7 +401,7 @@ type CodeIntelIndexerResolver interface {
 	URL() string
 }
 
-type SearchBasedCodeIntelSupportResolver interface {
+type SearchBasedSupportResolver interface {
 	SupportLevel() string
 	Language() *string
 }

--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -381,7 +381,6 @@ type GitTreeSearchBasedCoverage interface {
 }
 
 type GitTreePreciseCoverage interface {
-	CoveredPaths() []string
 	Support() PreciseSupportResolver
 	Confidence() string
 }

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -1425,7 +1425,7 @@ type IndexConfiguration {
     """
     The raw JSON-encoded index configuration as infered by the auto-indexer.
     """
-    inferedConfiguration: String
+    inferredConfiguration: String
 }
 
 """

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -1450,6 +1450,7 @@ type GitTreePreciseCoverage {
 enum InferredPreciseSupportLevel {
     LANGUAGE_SUPPORTED
     PROJECT_STRUCTURE_SUPPORTED
+    INDEX_JOB_INFERRED
 }
 
 """

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -535,6 +535,11 @@ extend type GitTree {
         """
         toolName: String
     ): GitTreeLSIFData
+
+    """
+    Provides info on the level of code-intel support for the direct children of this git tree.
+    """
+    codeIntelInfo: GitTreeCodeIntelInfo
 }
 
 extend type GitBlob {
@@ -550,9 +555,9 @@ extend type GitBlob {
     ): GitBlobLSIFData
 
     """
-    Provides info on the level of code-intel support.
+    Provides info on the level of code-intel support for this git blob.
     """
-    codeIntelInfo: CodeIntelSupport!
+    codeIntelSupport: CodeIntelSupport!
 }
 
 """
@@ -1421,6 +1426,30 @@ type IndexConfiguration {
     The raw JSON-encoded index configuration as inferred by the auto-indexer.
     """
     inferredConfiguration: String
+}
+
+"""
+Details code-intel support for a group of files rooted at a tree.
+"""
+type GitTreeCodeIntelInfo {
+    searchBasedSupport: [GitTreeSearchBasedCoverage!]!
+    preciseSupport: [GitTreePreciseCoverage!]!
+}
+
+type GitTreeSearchBasedCoverage {
+    coveredPaths: [String!]!
+    support: SearchBasedCodeIntelSupport!
+}
+
+type GitTreePreciseCoverage {
+    coveredPaths: [String!]!
+    support: PreciseCodeIntelSupport!
+    confidence: InferredPreciseSupportLevel!
+}
+
+enum InferredPreciseSupportLevel {
+    LANGUAGE_SUPPORTED
+    PROJECT_STRUCTURE_SUPPORTED
 }
 
 """

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -1449,6 +1449,8 @@ Search-based code-intel support coverage grouped by related files.
 type GitTreeSearchBasedCoverage {
     """
     The files comprising this grouping of search-based support.
+    Each grouping consists of all the files of the same langauge e.g.
+    all .go files in one group, all .kt and .kts files in another.
     """
     coveredPaths: [String!]!
     """
@@ -1462,10 +1464,6 @@ Precise code-intel support coverage grouped by LSIF indexer language
 support for a group of files.
 """
 type GitTreePreciseCoverage {
-    """
-    The files comprising this grouping of precise support.
-    """
-    coveredPaths: [String!]!
     """
     Overview of the level of support for this group of files.
     """

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -61,7 +61,7 @@ extend type Mutation {
     If a configuration is supplied, that configuration is used to determine what jobs to
     schedule. If no configuration is supplied, it will go through the regular index scheduling
     rules: first read any in-repo configuration (e.g., sourcegraph.yaml), then look for any
-    existing in-database configuration, finally falling back to the automatically inferred
+    existing in-database configuration, finally falling back to the automatically infered
     connfiguration based on the repo contents at the target commit.
     """
     queueAutoIndexJobsForRepo(repository: ID!, rev: String, configuration: String): [LSIFIndex!]!
@@ -1423,34 +1423,82 @@ type IndexConfiguration {
     configuration: String
 
     """
-    The raw JSON-encoded index configuration as inferred by the auto-indexer.
+    The raw JSON-encoded index configuration as infered by the auto-indexer.
     """
-    inferredConfiguration: String
+    inferedConfiguration: String
 }
 
 """
 Details code-intel support for a group of files rooted at a tree.
 """
 type GitTreeCodeIntelInfo {
-    searchBasedSupport: [GitTreeSearchBasedCoverage!]!
-    preciseSupport: [GitTreePreciseCoverage!]!
+    """
+    Search-based coverage grouped by language.
+    """
+    searchBasedSupport: [GitTreeSearchBasedCoverage!]
+    """
+    Precise coverage based on inference derived from the directory
+    structure and its files.
+    """
+    preciseSupport: [GitTreePreciseCoverage!]
 }
 
+"""
+Search-based code-intel support coverage grouped by related files.
+"""
 type GitTreeSearchBasedCoverage {
+    """
+    The files comprising this grouping of search-based support.
+    """
     coveredPaths: [String!]!
+    """
+    Overview of the level of support for this group of files.
+    """
     support: SearchBasedCodeIntelSupport!
 }
 
+"""
+Precise code-intel support coverage grouped by LSIF indexer language
+support for a group of files.
+"""
 type GitTreePreciseCoverage {
+    """
+    The files comprising this grouping of precise support.
+    """
     coveredPaths: [String!]!
+    """
+    Overview of the level of support for this group of files.
+    """
     support: PreciseCodeIntelSupport!
-    confidence: InferredPreciseSupportLevel!
+    """
+    Level of confidence in the inference of an indexing target suggestion.
+    """
+    confidence: InferedPreciseSupportLevel!
 }
 
-enum InferredPreciseSupportLevel {
+"""
+Denotes the confidence in the correctness of the proposed index target.
+"""
+enum InferedPreciseSupportLevel {
+    """
+    The language is known to have an LSIF indexer associated with it
+    but this may not be the directory from which it should be invoked.
+    Relevant build tool configuration may be available at a parent directory.
+    """
     LANGUAGE_SUPPORTED
+    """
+    Relevant build tool configuration files were located that indicate
+    a good possibility of this directory being where an LSIF indexer
+    could be invoked, however we have or can not infer a potentially complete
+    auto indexing job configuration.
+    """
     PROJECT_STRUCTURE_SUPPORTED
-    INDEX_JOB_INFERRED
+    """
+    An auto-indexing job configuration was able to be infered for this
+    directory that has a high likelyhood of being complete enough to result
+    in an LSIF index.
+    """
+    INDEX_JOB_INFERED
 }
 
 """
@@ -1528,7 +1576,7 @@ type SearchBasedCodeIntelSupport {
     """
     supportLevel: SearchBasedSupportLevel!
     """
-    The inferred language the underlying tool inferred when building an index for
+    The infered language the underlying tool infered when building an index for
     search-based code-intel.
     """
     language: String

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -253,15 +253,28 @@ func (r *GitTreeEntryResolver) LSIF(ctx context.Context, args *struct{ ToolName 
 	})
 }
 
-func (r *GitTreeEntryResolver) CodeIntelInfo(ctx context.Context) (CodeIntelSupportResolver, error) {
+func (r *GitTreeEntryResolver) CodeIntelSupport(ctx context.Context) (GitBlobCodeIntelSupportResolver, error) {
 	repo, err := r.commit.repoResolver.repo(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return EnterpriseResolvers.codeIntelResolver.GitBlobCodeIntelInfo(ctx, &GitBlobCodeIntelInfoArgs{
-		Repo: repo.Name,
+	return EnterpriseResolvers.codeIntelResolver.GitBlobCodeIntelInfo(ctx, &GitTreeEntryCodeIntelInfoArgs{
+		Repo: repo,
 		Path: r.Path(),
+	})
+}
+
+func (r *GitTreeEntryResolver) CodeIntelInfo(ctx context.Context) (GitTreeCodeIntelSupportResolver, error) {
+	repo, err := r.commit.repoResolver.repo(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return EnterpriseResolvers.codeIntelResolver.GitTreeCodeIntelInfo(ctx, &GitTreeEntryCodeIntelInfoArgs{
+		Repo:   repo,
+		Commit: *r.Commit().InputRev(),
+		Path:   r.Path(),
 	})
 }
 

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -273,7 +273,7 @@ func (r *GitTreeEntryResolver) CodeIntelInfo(ctx context.Context) (GitTreeCodeIn
 
 	return EnterpriseResolvers.codeIntelResolver.GitTreeCodeIntelInfo(ctx, &GitTreeEntryCodeIntelInfoArgs{
 		Repo:   repo,
-		Commit: *r.Commit().InputRev(),
+		Commit: string(r.Commit().OID()),
 		Path:   r.Path(),
 	})
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/codeintel_blob_info_resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/codeintel_blob_info_resolver.go
@@ -1,0 +1,57 @@
+package graphql
+
+import (
+	"context"
+
+	"github.com/opentracing/opentracing-go/log"
+
+	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+type codeIntelSupportResolver struct {
+	repo      api.RepoName
+	path      string
+	resolver  resolvers.Resolver
+	errTracer *observation.ErrCollector
+}
+
+func NewCodeIntelSupportResolver(resolver resolvers.Resolver, repoName api.RepoName, path string, errTracer *observation.ErrCollector) gql.GitBlobCodeIntelSupportResolver {
+	return &codeIntelSupportResolver{
+		repo:      repoName,
+		path:      path,
+		resolver:  resolver,
+		errTracer: errTracer,
+	}
+}
+
+func (r *codeIntelSupportResolver) SearchBasedSupport(ctx context.Context) (_ gql.SearchBasedSupportResolver, err error) {
+	var (
+		ctagsSupported bool
+		language       string
+	)
+
+	defer func() {
+		r.errTracer.Collect(&err,
+			log.String("codeIntelSupportResolver.field", "searchBasedSupport"),
+			log.String("inferredLanguage", language),
+			log.Bool("ctagsSupported", ctagsSupported))
+	}()
+
+	ctagsSupported, language, err = r.resolver.SupportedByCtags(ctx, r.path, r.repo)
+	if err != nil {
+		return nil, err
+	}
+
+	if ctagsSupported {
+		return NewSearchBasedCodeIntelResolver(&language), nil
+	}
+
+	return NewSearchBasedCodeIntelResolver(nil), nil
+}
+
+func (r *codeIntelSupportResolver) PreciseSupport(ctx context.Context) (gql.PreciseSupportResolver, error) {
+	return NewPreciseCodeIntelSupportResolver(r.path), nil
+}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/codeintel_blob_info_resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/codeintel_blob_info_resolver.go
@@ -36,7 +36,7 @@ func (r *codeIntelSupportResolver) SearchBasedSupport(ctx context.Context) (_ gq
 	defer func() {
 		r.errTracer.Collect(&err,
 			log.String("codeIntelSupportResolver.field", "searchBasedSupport"),
-			log.String("inferredLanguage", language),
+			log.String("inferedLanguage", language),
 			log.Bool("ctagsSupported", ctagsSupported))
 	}()
 

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/codeintel_tree_info_resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/codeintel_tree_info_resolver.go
@@ -1,0 +1,92 @@
+package graphql
+
+import (
+	"context"
+
+	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+type codeIntelTreeInfoResolver struct {
+	resolver  resolvers.Resolver
+	commit    string
+	path      string
+	files     []string
+	repo      *types.Repo
+	errTracer *observation.ErrCollector
+}
+
+func NewCodeIntelTreeInfoResolver(
+	resolver resolvers.Resolver,
+	repo *types.Repo,
+	commit, path string,
+	files []string,
+	errTracer *observation.ErrCollector,
+) gql.GitTreeCodeIntelSupportResolver {
+	return &codeIntelTreeInfoResolver{
+		resolver:  resolver,
+		repo:      repo,
+		commit:    commit,
+		path:      path,
+		files:     files,
+		errTracer: errTracer,
+	}
+}
+
+func (r *codeIntelTreeInfoResolver) SearchBasedSupport(ctx context.Context) ([]gql.GitTreeSearchBasedCoverage, error) {
+	langMapping := make(map[string][]string)
+
+	for _, file := range r.files {
+		ok, lang, err := r.resolver.SupportedByCtags(ctx, file, r.repo.Name)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			langMapping[lang] = append(langMapping[lang], file)
+		}
+	}
+
+	resolvers := make([]gql.GitTreeSearchBasedCoverage, 0, len(langMapping))
+
+	for lang, files := range langMapping {
+		resolvers = append(resolvers, &codeIntelTreeSearchBasedCoverageResolver{
+			paths:    files,
+			language: lang,
+		})
+	}
+
+	return resolvers, nil
+}
+
+func (r *codeIntelTreeInfoResolver) PreciseSupport(ctx context.Context) ([]gql.GitTreePreciseCoverage, error) {
+	return nil, nil
+}
+
+type codeIntelTreePreciseCoverageResolver struct{}
+
+func (r *codeIntelTreePreciseCoverageResolver) CoveredPaths() []string {
+	return nil
+}
+
+func (r *codeIntelTreePreciseCoverageResolver) Support() gql.PreciseSupportResolver {
+	return nil
+}
+
+func (r *codeIntelTreePreciseCoverageResolver) Confidence() string {
+	return ""
+}
+
+type codeIntelTreeSearchBasedCoverageResolver struct {
+	paths    []string
+	language string
+}
+
+func (r *codeIntelTreeSearchBasedCoverageResolver) CoveredPaths() []string {
+	return r.paths
+}
+
+func (r *codeIntelTreeSearchBasedCoverageResolver) Support() gql.SearchBasedSupportResolver {
+	return NewSearchBasedCodeIntelResolver(&r.language)
+}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/codeintel_tree_info_resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/codeintel_tree_info_resolver.go
@@ -97,10 +97,13 @@ func (r *codeIntelTreeInfoResolver) PreciseSupport(ctx context.Context) ([]gql.G
 
 	for _, hint := range hints {
 		var confidence preciseSupportInferenceConfidence
-		if hint.HintConfidence == config.LanguageSupport {
+		switch hint.HintConfidence {
+		case config.HintConfidenceLanguageSupport:
 			confidence = languageSupport
-		} else {
+		case config.HintConfidenceProjectStructureSupported:
 			confidence = projectStructureSupported
+		default:
+			continue
 		}
 		resolvers = append(resolvers, &codeIntelTreePreciseCoverageResolver{
 			confidence: confidence,
@@ -115,11 +118,6 @@ func (r *codeIntelTreeInfoResolver) PreciseSupport(ctx context.Context) ([]gql.G
 type codeIntelTreePreciseCoverageResolver struct {
 	confidence preciseSupportInferenceConfidence
 	indexer    gql.CodeIntelIndexerResolver
-}
-
-func (r *codeIntelTreePreciseCoverageResolver) CoveredPaths() []string {
-	// TODO: maybe? maybe we won't include it. Not currently supported by the data access methods we have
-	return nil
 }
 
 func (r *codeIntelTreePreciseCoverageResolver) Support() gql.PreciseSupportResolver {

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/codeintel_tree_info_resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/codeintel_tree_info_resolver.go
@@ -16,7 +16,7 @@ type preciseSupportInferenceConfidence string
 const (
 	languageSupport           preciseSupportInferenceConfidence = "LANGUAGE_SUPPORTED"
 	projectStructureSupported preciseSupportInferenceConfidence = "PROJECT_STRUCTURE_SUPPORTED"
-	indexJobInferred          preciseSupportInferenceConfidence = "INDEX_JOB_INFERRED"
+	indexJobInfered           preciseSupportInferenceConfidence = "INDEX_JOB_INFERED"
 )
 
 type codeIntelTreeInfoResolver struct {
@@ -71,7 +71,7 @@ func (r *codeIntelTreeInfoResolver) SearchBasedSupport(ctx context.Context) ([]g
 }
 
 func (r *codeIntelTreeInfoResolver) PreciseSupport(ctx context.Context) ([]gql.GitTreePreciseCoverage, error) {
-	configurations, ok, err := r.resolver.InferredIndexConfiguration(ctx, int(r.repo.ID), r.commit)
+	configurations, ok, err := r.resolver.InferedIndexConfiguration(ctx, int(r.repo.ID), r.commit)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func (r *codeIntelTreeInfoResolver) PreciseSupport(ctx context.Context) ([]gql.G
 		for _, job := range configurations.IndexJobs {
 			if job.Root == r.path {
 				resolvers = append(resolvers, &codeIntelTreePreciseCoverageResolver{
-					confidence: indexJobInferred,
+					confidence: indexJobInfered,
 					// drop the tag if it exists
 					indexer: imageToIndexer[strings.Split(job.Indexer, ":")[0]],
 				})
@@ -90,7 +90,7 @@ func (r *codeIntelTreeInfoResolver) PreciseSupport(ctx context.Context) ([]gql.G
 		}
 	}
 
-	hints, err := r.resolver.InferredIndexConfigurationHints(ctx, int(r.repo.ID), r.commit)
+	hints, err := r.resolver.InferedIndexConfigurationHints(ctx, int(r.repo.ID), r.commit)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/configuration.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/configuration.go
@@ -44,7 +44,7 @@ func (r *IndexConfigurationResolver) Configuration(ctx context.Context) (_ *stri
 func (r *IndexConfigurationResolver) InferredConfiguration(ctx context.Context) (_ *string, err error) {
 	defer r.errTracer.Collect(&err, log.String("indexConfigResolver.field", "inferredConfiguration"))
 
-	configuration, exists, err := r.resolver.InferredIndexConfiguration(ctx, r.repositoryID, "")
+	configuration, exists, err := r.resolver.InferedIndexConfiguration(ctx, r.repositoryID, "")
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/configuration.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/configuration.go
@@ -44,7 +44,7 @@ func (r *IndexConfigurationResolver) Configuration(ctx context.Context) (_ *stri
 func (r *IndexConfigurationResolver) InferredConfiguration(ctx context.Context) (_ *string, err error) {
 	defer r.errTracer.Collect(&err, log.String("indexConfigResolver.field", "inferredConfiguration"))
 
-	configuration, exists, err := r.resolver.InferredIndexConfiguration(ctx, r.repositoryID)
+	configuration, exists, err := r.resolver.InferredIndexConfiguration(ctx, r.repositoryID, "")
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/iface.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/iface.go
@@ -1,0 +1,14 @@
+package graphql
+
+import (
+	"context"
+
+	"github.com/grafana/regexp"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies"
+)
+
+type GitserverClient interface {
+	policies.GitserverClient
+	ListFiles(ctx context.Context, repositoryID int, commit string, pattern *regexp.Regexp) ([]string, error)
+}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/indexers.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/indexers.go
@@ -32,7 +32,7 @@ var (
 		name: "lsif-java",
 		urn:  "github.com/sourcegraph/lsif-java",
 	}
-	msftJAva = codeIntelIndexerResolver{
+	msftJava = codeIntelIndexerResolver{
 		name: "msft/lsif-java",
 		urn:  "github.com/Microsoft/lsif-java",
 	}
@@ -40,7 +40,7 @@ var (
 		name: "lsif-go",
 		urn:  "github.com/sourcegraph/lsif-go",
 	}
-	LSIFClang = codeIntelIndexerResolver{
+	lsifClang = codeIntelIndexerResolver{
 		name: "lsif-clang",
 		urn:  "github.com/sourcegraph/lsif-clang",
 	}
@@ -94,7 +94,7 @@ var (
 // from most to least.
 var languageToIndexer = map[string][]gql.CodeIntelIndexerResolver{
 	".go":      {&lsifGo},
-	".java":    {&lsifJava, &msftJAva},
+	".java":    {&lsifJava, &msftJava},
 	".kt":      {&lsifJava},
 	".scala":   {&lsifJava},
 	".js":      {&lsifTypescript, &lsifNode, &msftNode},
@@ -102,11 +102,12 @@ var languageToIndexer = map[string][]gql.CodeIntelIndexerResolver{
 	".ts":      {&lsifTypescript, &lsifNode, &msftNode},
 	".tsx":     {&lsifTypescript, &lsifNode, &msftNode},
 	".dart":    {&workivaDart, &lsifDart},
-	".c":       {&LSIFClang, &lsifCPP},
-	".cc":      {&LSIFClang, &lsifCPP},
-	".cpp":     {&LSIFClang, &lsifCPP},
-	".cxx":     {&LSIFClang, &lsifCPP},
-	".h":       {&LSIFClang, &lsifCPP},
+	".c":       {&lsifClang, &lsifCPP},
+	".cc":      {&lsifClang, &lsifCPP},
+	".cpp":     {&lsifClang, &lsifCPP},
+	".cxx":     {&lsifClang, &lsifCPP},
+	".h":       {&lsifClang, &lsifCPP},
+	".hpp":     {&lsifClang, &lsifCPP},
 	".hs":      {&hieLSIF},
 	".jsonnet": {&lsifJsonnet},
 	".py":      {&lsifPy},
@@ -115,4 +116,14 @@ var languageToIndexer = map[string][]gql.CodeIntelIndexerResolver{
 	".php":     {&lsifPHP},
 	".tf":      {&lsifTerraform},
 	".cs":      {&lsifDotnet},
+}
+
+var imageToIndexer = map[string]gql.CodeIntelIndexerResolver{
+	"sourcegraph/lsif-java":       &lsifJava,
+	"sourcegraph/lsif-go":         &lsifGo,
+	"sourcegraph/lsif-typescript": &lsifTypescript,
+	"sourcegraph/lsif-node":       &lsifNode,
+	"sourcegraph/lsif-clang":      &lsifClang,
+	"davidrjenni/lsif-php":        &lsifPHP,
+	"sourcegraph/lsif-rust":       &rustAnalyzer,
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/observability.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/observability.go
@@ -19,6 +19,7 @@ type operations struct {
 	queueAutoIndexJobsForRepo *observation.Operation
 	gitBlobLsifData           *observation.Operation
 	gitBlobCodeIntelInfo      *observation.Operation
+	gitTreeCodeIntelInfo      *observation.Operation
 	configurationPolicyByID   *observation.Operation
 	configurationPolicies     *observation.Operation
 	createConfigurationPolicy *observation.Operation
@@ -56,6 +57,7 @@ func newOperations(observationContext *observation.Context) *operations {
 		queueAutoIndexJobsForRepo: op("QueueAutoIndexJobsForRepo"),
 		gitBlobLsifData:           op("GitBlobLSIFData"),
 		gitBlobCodeIntelInfo:      op("GitBlobCodeIntelInfo"),
+		gitTreeCodeIntelInfo:      op("GitTreeCodeIntelInfo"),
 		configurationPolicyByID:   op("ConfigurationPolicyByID"),
 		configurationPolicies:     op("ConfigurationPolicies"),
 		createConfigurationPolicy: op("CreateConfigurationPolicy"),

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
@@ -329,7 +329,7 @@ func (r *Resolver) GitTreeCodeIntelInfo(ctx context.Context, args *gql.GitTreeEn
 	}})
 	endObservation.OnCancel(ctx, 1, observation.Args{})
 
-	filesRegex, err := regexp.Compile("^" + args.Path + "[^.]{1}[^/]*$")
+	filesRegex, err := regexp.Compile("^" + regexp.QuoteMeta(args.Path) + "[^.]{1}[^/]*$")
 	if err != nil {
 		return nil, errors.Wrapf(err, "path '%s' caused invalid regex", args.Path)
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/regexp"
 	"github.com/graph-gophers/graphql-go"
 	"github.com/opentracing/opentracing-go/log"
 
@@ -13,7 +14,6 @@ import (
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -39,14 +39,14 @@ var errAutoIndexingNotEnabled = errors.New("precise code intelligence auto-index
 // in the parent package.
 type Resolver struct {
 	db                 database.DB
-	gitserver          policies.GitserverClient
+	gitserver          GitserverClient
 	resolver           resolvers.Resolver
 	locationResolver   *CachedLocationResolver
 	observationContext *operations
 }
 
 // NewResolver creates a new Resolver with the given resolver that defines all code intel-specific behavior.
-func NewResolver(db database.DB, gitserver policies.GitserverClient, resolver resolvers.Resolver, observationContext *observation.Context) gql.CodeIntelResolver {
+func NewResolver(db database.DB, gitserver GitserverClient, resolver resolvers.Resolver, observationContext *observation.Context) gql.CodeIntelResolver {
 	return &Resolver{
 		db:                 db,
 		gitserver:          gitserver,
@@ -314,11 +314,32 @@ func (r *Resolver) GitBlobLSIFData(ctx context.Context, args *gql.GitBlobLSIFDat
 	return NewQueryResolver(r.gitserver, resolver, r.resolver, r.locationResolver, errTracer), nil
 }
 
-func (r *Resolver) GitBlobCodeIntelInfo(ctx context.Context, args *gql.GitBlobCodeIntelInfoArgs) (_ gql.CodeIntelSupportResolver, err error) {
+func (r *Resolver) GitBlobCodeIntelInfo(ctx context.Context, args *gql.GitTreeEntryCodeIntelInfoArgs) (_ gql.GitBlobCodeIntelSupportResolver, err error) {
 	ctx, errTracer, endObservation := r.observationContext.gitBlobCodeIntelInfo.WithErrors(ctx, &err, observation.Args{})
 	endObservation.OnCancel(ctx, 1, observation.Args{})
 
-	return NewCodeIntelSupportResolver(r.resolver, args, errTracer), nil
+	return NewCodeIntelSupportResolver(r.resolver, args.Repo.Name, args.Path, errTracer), nil
+}
+
+func (r *Resolver) GitTreeCodeIntelInfo(ctx context.Context, args *gql.GitTreeEntryCodeIntelInfoArgs) (resolver gql.GitTreeCodeIntelSupportResolver, err error) {
+	ctx, errTracer, endObservation := r.observationContext.gitBlobCodeIntelInfo.WithErrors(ctx, &err, observation.Args{LogFields: []log.Field{
+		log.Int("repoID", int(args.Repo.ID)),
+		log.String("path", args.Path),
+		log.String("commit", args.Commit),
+	}})
+	endObservation.OnCancel(ctx, 1, observation.Args{})
+
+	filesRegex, err := regexp.Compile("^" + args.Path + "[^.]{1}[^/]*$")
+	if err != nil {
+		return nil, errors.Wrapf(err, "path '%s' caused invalid regex", args.Path)
+	}
+
+	files, err := r.gitserver.ListFiles(ctx, int(args.Repo.ID), args.Commit, filesRegex)
+	if err != nil {
+		return nil, errors.Wrapf(err, "gitserver.ListFiles: error listing files at %s for repo %d", args.Path, args.Repo.ID)
+	}
+
+	return NewCodeIntelTreeInfoResolver(r.resolver, args.Repo, args.Commit, args.Path, files, errTracer), nil
 }
 
 // 🚨 SECURITY: dbstore layer handles authz for GetConfigurationPolicyByID

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/support.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/support.go
@@ -51,6 +51,12 @@ func NewPreciseCodeIntelSupportResolver(filepath string) gql.PreciseSupportResol
 	}
 }
 
+func NewPreciseCodeIntelSupportResolverFromIndexers(indexers []gql.CodeIntelIndexerResolver) gql.PreciseSupportResolver {
+	return &preciseCodeIntelSupportResolver{
+		indexers: indexers,
+	}
+}
+
 func (r *preciseCodeIntelSupportResolver) SupportLevel() string {
 	// if the first indexer in a list is from us, consider native support
 	nativeRecommendation := len(r.indexers) > 0 &&

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/support.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/support.go
@@ -1,15 +1,10 @@
 package graphql
 
 import (
-	"context"
 	"path"
 	"strings"
 
-	"github.com/opentracing/opentracing-go/log"
-
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
-	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers"
-	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 type searchBasedCodeIntelSupportType string
@@ -27,54 +22,11 @@ const (
 	unknown    preciseCodeIntelSupportType = "UNKNOWN"
 )
 
-type codeIntelSupportResolver struct {
-	gitBlobMeta *gql.GitBlobCodeIntelInfoArgs
-	resolver    resolvers.Resolver
-	errTracer   *observation.ErrCollector
-}
-
-func NewCodeIntelSupportResolver(resolver resolvers.Resolver, args *gql.GitBlobCodeIntelInfoArgs, errTracer *observation.ErrCollector) gql.CodeIntelSupportResolver {
-	return &codeIntelSupportResolver{
-		gitBlobMeta: args,
-		resolver:    resolver,
-		errTracer:   errTracer,
-	}
-}
-
-func (r *codeIntelSupportResolver) SearchBasedSupport(ctx context.Context) (_ gql.SearchBasedCodeIntelSupportResolver, err error) {
-	var (
-		ctagsSupported bool
-		language       string
-	)
-
-	defer func() {
-		r.errTracer.Collect(&err,
-			log.String("codeIntelSupportResolver.field", "searchBasedSupport"),
-			log.String("inferredLanguage", language),
-			log.Bool("ctagsSupported", ctagsSupported))
-	}()
-
-	ctagsSupported, language, err = r.resolver.SupportedByCtags(ctx, r.gitBlobMeta.Path, r.gitBlobMeta.Repo)
-	if err != nil {
-		return nil, err
-	}
-
-	if ctagsSupported {
-		return NewSearchBasedCodeIntelResolver(&language), nil
-	}
-
-	return NewSearchBasedCodeIntelResolver(nil), nil
-}
-
-func (r *codeIntelSupportResolver) PreciseSupport(ctx context.Context) (gql.PreciseCodeIntelSupportResolver, error) {
-	return NewPreciseCodeIntelSupportResolver(r.gitBlobMeta.Path), nil
-}
-
 type searchBasedSupportResolver struct {
 	language *string
 }
 
-func NewSearchBasedCodeIntelResolver(language *string) gql.SearchBasedCodeIntelSupportResolver {
+func NewSearchBasedCodeIntelResolver(language *string) gql.SearchBasedSupportResolver {
 	return &searchBasedSupportResolver{language}
 }
 
@@ -93,7 +45,7 @@ type preciseCodeIntelSupportResolver struct {
 	indexers []gql.CodeIntelIndexerResolver
 }
 
-func NewPreciseCodeIntelSupportResolver(filepath string) gql.PreciseCodeIntelSupportResolver {
+func NewPreciseCodeIntelSupportResolver(filepath string) gql.PreciseSupportResolver {
 	return &preciseCodeIntelSupportResolver{
 		indexers: languageToIndexer[path.Ext(filepath)],
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/grafana/regexp"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindex/enqueuer"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
@@ -22,6 +24,7 @@ type GitserverClient interface {
 	CommitsUniqueToBranch(ctx context.Context, repositoryID int, branchName string, isDefaultBranch bool, maxAge *time.Time) (map[string]time.Time, error)
 	CommitExists(ctx context.Context, repositoryID int, commit string) (bool, error)
 	CommitGraph(ctx context.Context, repositoryID int, options git.CommitGraphOptions) (*gitdomain.CommitGraph, error)
+	ListFiles(ctx context.Context, repositoryID int, commit string, pattern *regexp.Regexp) ([]string, error)
 }
 
 type DBStore interface {

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
@@ -79,7 +79,7 @@ type LSIFStore interface {
 
 type IndexEnqueuer interface {
 	QueueIndexes(ctx context.Context, repositoryID int, rev, configuration string, force bool) ([]dbstore.Index, error)
-	InferIndexConfiguration(ctx context.Context, repositoryID int) (*config.IndexConfiguration, error)
+	InferIndexConfiguration(ctx context.Context, repositoryID int, commit string) (*config.IndexConfiguration, []config.IndexJobHint, error)
 }
 
 type (

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
@@ -5259,6 +5259,9 @@ type MockGitserverClient struct {
 	// CommitsUniqueToBranchFunc is an instance of a mock function object
 	// controlling the behavior of the method CommitsUniqueToBranch.
 	CommitsUniqueToBranchFunc *GitserverClientCommitsUniqueToBranchFunc
+	// ListFilesFunc is an instance of a mock function object controlling
+	// the behavior of the method ListFiles.
+	ListFilesFunc *GitserverClientListFilesFunc
 	// RefDescriptionsFunc is an instance of a mock function object
 	// controlling the behavior of the method RefDescriptions.
 	RefDescriptionsFunc *GitserverClientRefDescriptionsFunc
@@ -5289,6 +5292,11 @@ func NewMockGitserverClient() *MockGitserverClient {
 		},
 		CommitsUniqueToBranchFunc: &GitserverClientCommitsUniqueToBranchFunc{
 			defaultHook: func(context.Context, int, string, bool, *time.Time) (map[string]time.Time, error) {
+				return nil, nil
+			},
+		},
+		ListFilesFunc: &GitserverClientListFilesFunc{
+			defaultHook: func(context.Context, int, string, *regexp.Regexp) ([]string, error) {
 				return nil, nil
 			},
 		},
@@ -5329,6 +5337,11 @@ func NewStrictMockGitserverClient() *MockGitserverClient {
 				panic("unexpected invocation of MockGitserverClient.CommitsUniqueToBranch")
 			},
 		},
+		ListFilesFunc: &GitserverClientListFilesFunc{
+			defaultHook: func(context.Context, int, string, *regexp.Regexp) ([]string, error) {
+				panic("unexpected invocation of MockGitserverClient.ListFiles")
+			},
+		},
 		RefDescriptionsFunc: &GitserverClientRefDescriptionsFunc{
 			defaultHook: func(context.Context, int, ...string) (map[string][]gitdomain.RefDescription, error) {
 				panic("unexpected invocation of MockGitserverClient.RefDescriptions")
@@ -5358,6 +5371,9 @@ func NewMockGitserverClientFrom(i GitserverClient) *MockGitserverClient {
 		},
 		CommitsUniqueToBranchFunc: &GitserverClientCommitsUniqueToBranchFunc{
 			defaultHook: i.CommitsUniqueToBranch,
+		},
+		ListFilesFunc: &GitserverClientListFilesFunc{
+			defaultHook: i.ListFiles,
 		},
 		RefDescriptionsFunc: &GitserverClientRefDescriptionsFunc{
 			defaultHook: i.RefDescriptions,
@@ -5826,6 +5842,120 @@ func (c GitserverClientCommitsUniqueToBranchFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c GitserverClientCommitsUniqueToBranchFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// GitserverClientListFilesFunc describes the behavior when the ListFiles
+// method of the parent MockGitserverClient instance is invoked.
+type GitserverClientListFilesFunc struct {
+	defaultHook func(context.Context, int, string, *regexp.Regexp) ([]string, error)
+	hooks       []func(context.Context, int, string, *regexp.Regexp) ([]string, error)
+	history     []GitserverClientListFilesFuncCall
+	mutex       sync.Mutex
+}
+
+// ListFiles delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockGitserverClient) ListFiles(v0 context.Context, v1 int, v2 string, v3 *regexp.Regexp) ([]string, error) {
+	r0, r1 := m.ListFilesFunc.nextHook()(v0, v1, v2, v3)
+	m.ListFilesFunc.appendCall(GitserverClientListFilesFuncCall{v0, v1, v2, v3, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the ListFiles method of
+// the parent MockGitserverClient instance is invoked and the hook queue is
+// empty.
+func (f *GitserverClientListFilesFunc) SetDefaultHook(hook func(context.Context, int, string, *regexp.Regexp) ([]string, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// ListFiles method of the parent MockGitserverClient instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *GitserverClientListFilesFunc) PushHook(hook func(context.Context, int, string, *regexp.Regexp) ([]string, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *GitserverClientListFilesFunc) SetDefaultReturn(r0 []string, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string, *regexp.Regexp) ([]string, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *GitserverClientListFilesFunc) PushReturn(r0 []string, r1 error) {
+	f.PushHook(func(context.Context, int, string, *regexp.Regexp) ([]string, error) {
+		return r0, r1
+	})
+}
+
+func (f *GitserverClientListFilesFunc) nextHook() func(context.Context, int, string, *regexp.Regexp) ([]string, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *GitserverClientListFilesFunc) appendCall(r0 GitserverClientListFilesFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of GitserverClientListFilesFuncCall objects
+// describing the invocations of this function.
+func (f *GitserverClientListFilesFunc) History() []GitserverClientListFilesFuncCall {
+	f.mutex.Lock()
+	history := make([]GitserverClientListFilesFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// GitserverClientListFilesFuncCall is an object that describes an
+// invocation of method ListFiles on an instance of MockGitserverClient.
+type GitserverClientListFilesFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 *regexp.Regexp
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []string
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c GitserverClientListFilesFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c GitserverClientListFilesFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
@@ -4559,6 +4559,9 @@ func (c EnqueuerDBStoreTransactFuncCall) Results() []interface{} {
 // github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers)
 // used for unit testing.
 type MockEnqueuerGitserverClient struct {
+	// CommitExistsFunc is an instance of a mock function object controlling
+	// the behavior of the method CommitExists.
+	CommitExistsFunc *EnqueuerGitserverClientCommitExistsFunc
 	// FileExistsFunc is an instance of a mock function object controlling
 	// the behavior of the method FileExists.
 	FileExistsFunc *EnqueuerGitserverClientFileExistsFunc
@@ -4581,6 +4584,11 @@ type MockEnqueuerGitserverClient struct {
 // results, unless overwritten.
 func NewMockEnqueuerGitserverClient() *MockEnqueuerGitserverClient {
 	return &MockEnqueuerGitserverClient{
+		CommitExistsFunc: &EnqueuerGitserverClientCommitExistsFunc{
+			defaultHook: func(context.Context, int, string) (bool, error) {
+				return false, nil
+			},
+		},
 		FileExistsFunc: &EnqueuerGitserverClientFileExistsFunc{
 			defaultHook: func(context.Context, int, string, string) (bool, error) {
 				return false, nil
@@ -4614,6 +4622,11 @@ func NewMockEnqueuerGitserverClient() *MockEnqueuerGitserverClient {
 // unless overwritten.
 func NewStrictMockEnqueuerGitserverClient() *MockEnqueuerGitserverClient {
 	return &MockEnqueuerGitserverClient{
+		CommitExistsFunc: &EnqueuerGitserverClientCommitExistsFunc{
+			defaultHook: func(context.Context, int, string) (bool, error) {
+				panic("unexpected invocation of MockEnqueuerGitserverClient.CommitExists")
+			},
+		},
 		FileExistsFunc: &EnqueuerGitserverClientFileExistsFunc{
 			defaultHook: func(context.Context, int, string, string) (bool, error) {
 				panic("unexpected invocation of MockEnqueuerGitserverClient.FileExists")
@@ -4647,6 +4660,9 @@ func NewStrictMockEnqueuerGitserverClient() *MockEnqueuerGitserverClient {
 // implementation, unless overwritten.
 func NewMockEnqueuerGitserverClientFrom(i EnqueuerGitserverClient) *MockEnqueuerGitserverClient {
 	return &MockEnqueuerGitserverClient{
+		CommitExistsFunc: &EnqueuerGitserverClientCommitExistsFunc{
+			defaultHook: i.CommitExists,
+		},
 		FileExistsFunc: &EnqueuerGitserverClientFileExistsFunc{
 			defaultHook: i.FileExists,
 		},
@@ -4663,6 +4679,120 @@ func NewMockEnqueuerGitserverClientFrom(i EnqueuerGitserverClient) *MockEnqueuer
 			defaultHook: i.ResolveRevision,
 		},
 	}
+}
+
+// EnqueuerGitserverClientCommitExistsFunc describes the behavior when the
+// CommitExists method of the parent MockEnqueuerGitserverClient instance is
+// invoked.
+type EnqueuerGitserverClientCommitExistsFunc struct {
+	defaultHook func(context.Context, int, string) (bool, error)
+	hooks       []func(context.Context, int, string) (bool, error)
+	history     []EnqueuerGitserverClientCommitExistsFuncCall
+	mutex       sync.Mutex
+}
+
+// CommitExists delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockEnqueuerGitserverClient) CommitExists(v0 context.Context, v1 int, v2 string) (bool, error) {
+	r0, r1 := m.CommitExistsFunc.nextHook()(v0, v1, v2)
+	m.CommitExistsFunc.appendCall(EnqueuerGitserverClientCommitExistsFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the CommitExists method
+// of the parent MockEnqueuerGitserverClient instance is invoked and the
+// hook queue is empty.
+func (f *EnqueuerGitserverClientCommitExistsFunc) SetDefaultHook(hook func(context.Context, int, string) (bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// CommitExists method of the parent MockEnqueuerGitserverClient instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *EnqueuerGitserverClientCommitExistsFunc) PushHook(hook func(context.Context, int, string) (bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *EnqueuerGitserverClientCommitExistsFunc) SetDefaultReturn(r0 bool, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string) (bool, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *EnqueuerGitserverClientCommitExistsFunc) PushReturn(r0 bool, r1 error) {
+	f.PushHook(func(context.Context, int, string) (bool, error) {
+		return r0, r1
+	})
+}
+
+func (f *EnqueuerGitserverClientCommitExistsFunc) nextHook() func(context.Context, int, string) (bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *EnqueuerGitserverClientCommitExistsFunc) appendCall(r0 EnqueuerGitserverClientCommitExistsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of EnqueuerGitserverClientCommitExistsFuncCall
+// objects describing the invocations of this function.
+func (f *EnqueuerGitserverClientCommitExistsFunc) History() []EnqueuerGitserverClientCommitExistsFuncCall {
+	f.mutex.Lock()
+	history := make([]EnqueuerGitserverClientCommitExistsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// EnqueuerGitserverClientCommitExistsFuncCall is an object that describes
+// an invocation of method CommitExists on an instance of
+// MockEnqueuerGitserverClient.
+type EnqueuerGitserverClientCommitExistsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 bool
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c EnqueuerGitserverClientCommitExistsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c EnqueuerGitserverClientCommitExistsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // EnqueuerGitserverClientFileExistsFunc describes the behavior when the
@@ -6210,8 +6340,8 @@ type MockIndexEnqueuer struct {
 func NewMockIndexEnqueuer() *MockIndexEnqueuer {
 	return &MockIndexEnqueuer{
 		InferIndexConfigurationFunc: &IndexEnqueuerInferIndexConfigurationFunc{
-			defaultHook: func(context.Context, int) (*config.IndexConfiguration, error) {
-				return nil, nil
+			defaultHook: func(context.Context, int, string) (*config.IndexConfiguration, []config.IndexJobHint, error) {
+				return nil, nil, nil
 			},
 		},
 		QueueIndexesFunc: &IndexEnqueuerQueueIndexesFunc{
@@ -6227,7 +6357,7 @@ func NewMockIndexEnqueuer() *MockIndexEnqueuer {
 func NewStrictMockIndexEnqueuer() *MockIndexEnqueuer {
 	return &MockIndexEnqueuer{
 		InferIndexConfigurationFunc: &IndexEnqueuerInferIndexConfigurationFunc{
-			defaultHook: func(context.Context, int) (*config.IndexConfiguration, error) {
+			defaultHook: func(context.Context, int, string) (*config.IndexConfiguration, []config.IndexJobHint, error) {
 				panic("unexpected invocation of MockIndexEnqueuer.InferIndexConfiguration")
 			},
 		},
@@ -6257,24 +6387,24 @@ func NewMockIndexEnqueuerFrom(i IndexEnqueuer) *MockIndexEnqueuer {
 // InferIndexConfiguration method of the parent MockIndexEnqueuer instance
 // is invoked.
 type IndexEnqueuerInferIndexConfigurationFunc struct {
-	defaultHook func(context.Context, int) (*config.IndexConfiguration, error)
-	hooks       []func(context.Context, int) (*config.IndexConfiguration, error)
+	defaultHook func(context.Context, int, string) (*config.IndexConfiguration, []config.IndexJobHint, error)
+	hooks       []func(context.Context, int, string) (*config.IndexConfiguration, []config.IndexJobHint, error)
 	history     []IndexEnqueuerInferIndexConfigurationFuncCall
 	mutex       sync.Mutex
 }
 
 // InferIndexConfiguration delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockIndexEnqueuer) InferIndexConfiguration(v0 context.Context, v1 int) (*config.IndexConfiguration, error) {
-	r0, r1 := m.InferIndexConfigurationFunc.nextHook()(v0, v1)
-	m.InferIndexConfigurationFunc.appendCall(IndexEnqueuerInferIndexConfigurationFuncCall{v0, v1, r0, r1})
-	return r0, r1
+func (m *MockIndexEnqueuer) InferIndexConfiguration(v0 context.Context, v1 int, v2 string) (*config.IndexConfiguration, []config.IndexJobHint, error) {
+	r0, r1, r2 := m.InferIndexConfigurationFunc.nextHook()(v0, v1, v2)
+	m.InferIndexConfigurationFunc.appendCall(IndexEnqueuerInferIndexConfigurationFuncCall{v0, v1, v2, r0, r1, r2})
+	return r0, r1, r2
 }
 
 // SetDefaultHook sets function that is called when the
 // InferIndexConfiguration method of the parent MockIndexEnqueuer instance
 // is invoked and the hook queue is empty.
-func (f *IndexEnqueuerInferIndexConfigurationFunc) SetDefaultHook(hook func(context.Context, int) (*config.IndexConfiguration, error)) {
+func (f *IndexEnqueuerInferIndexConfigurationFunc) SetDefaultHook(hook func(context.Context, int, string) (*config.IndexConfiguration, []config.IndexJobHint, error)) {
 	f.defaultHook = hook
 }
 
@@ -6283,7 +6413,7 @@ func (f *IndexEnqueuerInferIndexConfigurationFunc) SetDefaultHook(hook func(cont
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *IndexEnqueuerInferIndexConfigurationFunc) PushHook(hook func(context.Context, int) (*config.IndexConfiguration, error)) {
+func (f *IndexEnqueuerInferIndexConfigurationFunc) PushHook(hook func(context.Context, int, string) (*config.IndexConfiguration, []config.IndexJobHint, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -6291,20 +6421,20 @@ func (f *IndexEnqueuerInferIndexConfigurationFunc) PushHook(hook func(context.Co
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *IndexEnqueuerInferIndexConfigurationFunc) SetDefaultReturn(r0 *config.IndexConfiguration, r1 error) {
-	f.SetDefaultHook(func(context.Context, int) (*config.IndexConfiguration, error) {
-		return r0, r1
+func (f *IndexEnqueuerInferIndexConfigurationFunc) SetDefaultReturn(r0 *config.IndexConfiguration, r1 []config.IndexJobHint, r2 error) {
+	f.SetDefaultHook(func(context.Context, int, string) (*config.IndexConfiguration, []config.IndexJobHint, error) {
+		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *IndexEnqueuerInferIndexConfigurationFunc) PushReturn(r0 *config.IndexConfiguration, r1 error) {
-	f.PushHook(func(context.Context, int) (*config.IndexConfiguration, error) {
-		return r0, r1
+func (f *IndexEnqueuerInferIndexConfigurationFunc) PushReturn(r0 *config.IndexConfiguration, r1 []config.IndexJobHint, r2 error) {
+	f.PushHook(func(context.Context, int, string) (*config.IndexConfiguration, []config.IndexJobHint, error) {
+		return r0, r1, r2
 	})
 }
 
-func (f *IndexEnqueuerInferIndexConfigurationFunc) nextHook() func(context.Context, int) (*config.IndexConfiguration, error) {
+func (f *IndexEnqueuerInferIndexConfigurationFunc) nextHook() func(context.Context, int, string) (*config.IndexConfiguration, []config.IndexJobHint, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -6345,24 +6475,30 @@ type IndexEnqueuerInferIndexConfigurationFuncCall struct {
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
 	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 *config.IndexConfiguration
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
-	Result1 error
+	Result1 []config.IndexJobHint
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 error
 }
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c IndexEnqueuerInferIndexConfigurationFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c IndexEnqueuerInferIndexConfigurationFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
 // IndexEnqueuerQueueIndexesFunc describes the behavior when the

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_resolver.go
@@ -69,14 +69,14 @@ type MockResolver struct {
 	// IndexConnectionResolverFunc is an instance of a mock function object
 	// controlling the behavior of the method IndexConnectionResolver.
 	IndexConnectionResolverFunc *ResolverIndexConnectionResolverFunc
-	// InferredIndexConfigurationFunc is an instance of a mock function
+	// InferedIndexConfigurationFunc is an instance of a mock function
 	// object controlling the behavior of the method
-	// InferredIndexConfiguration.
-	InferredIndexConfigurationFunc *ResolverInferredIndexConfigurationFunc
-	// InferredIndexConfigurationHintsFunc is an instance of a mock function
+	// InferedIndexConfiguration.
+	InferedIndexConfigurationFunc *ResolverInferedIndexConfigurationFunc
+	// InferedIndexConfigurationHintsFunc is an instance of a mock function
 	// object controlling the behavior of the method
-	// InferredIndexConfigurationHints.
-	InferredIndexConfigurationHintsFunc *ResolverInferredIndexConfigurationHintsFunc
+	// InferedIndexConfigurationHints.
+	InferedIndexConfigurationHintsFunc *ResolverInferedIndexConfigurationHintsFunc
 	// PreviewGitObjectFilterFunc is an instance of a mock function object
 	// controlling the behavior of the method PreviewGitObjectFilter.
 	PreviewGitObjectFilterFunc *ResolverPreviewGitObjectFilterFunc
@@ -188,12 +188,12 @@ func NewMockResolver() *MockResolver {
 				return nil
 			},
 		},
-		InferredIndexConfigurationFunc: &ResolverInferredIndexConfigurationFunc{
+		InferedIndexConfigurationFunc: &ResolverInferedIndexConfigurationFunc{
 			defaultHook: func(context.Context, int, string) (*config.IndexConfiguration, bool, error) {
 				return nil, false, nil
 			},
 		},
-		InferredIndexConfigurationHintsFunc: &ResolverInferredIndexConfigurationHintsFunc{
+		InferedIndexConfigurationHintsFunc: &ResolverInferedIndexConfigurationHintsFunc{
 			defaultHook: func(context.Context, int, string) ([]config.IndexJobHint, error) {
 				return nil, nil
 			},
@@ -325,14 +325,14 @@ func NewStrictMockResolver() *MockResolver {
 				panic("unexpected invocation of MockResolver.IndexConnectionResolver")
 			},
 		},
-		InferredIndexConfigurationFunc: &ResolverInferredIndexConfigurationFunc{
+		InferedIndexConfigurationFunc: &ResolverInferedIndexConfigurationFunc{
 			defaultHook: func(context.Context, int, string) (*config.IndexConfiguration, bool, error) {
-				panic("unexpected invocation of MockResolver.InferredIndexConfiguration")
+				panic("unexpected invocation of MockResolver.InferedIndexConfiguration")
 			},
 		},
-		InferredIndexConfigurationHintsFunc: &ResolverInferredIndexConfigurationHintsFunc{
+		InferedIndexConfigurationHintsFunc: &ResolverInferedIndexConfigurationHintsFunc{
 			defaultHook: func(context.Context, int, string) ([]config.IndexJobHint, error) {
-				panic("unexpected invocation of MockResolver.InferredIndexConfigurationHints")
+				panic("unexpected invocation of MockResolver.InferedIndexConfigurationHints")
 			},
 		},
 		PreviewGitObjectFilterFunc: &ResolverPreviewGitObjectFilterFunc{
@@ -432,11 +432,11 @@ func NewMockResolverFrom(i resolvers.Resolver) *MockResolver {
 		IndexConnectionResolverFunc: &ResolverIndexConnectionResolverFunc{
 			defaultHook: i.IndexConnectionResolver,
 		},
-		InferredIndexConfigurationFunc: &ResolverInferredIndexConfigurationFunc{
-			defaultHook: i.InferredIndexConfiguration,
+		InferedIndexConfigurationFunc: &ResolverInferedIndexConfigurationFunc{
+			defaultHook: i.InferedIndexConfiguration,
 		},
-		InferredIndexConfigurationHintsFunc: &ResolverInferredIndexConfigurationHintsFunc{
-			defaultHook: i.InferredIndexConfigurationHints,
+		InferedIndexConfigurationHintsFunc: &ResolverInferedIndexConfigurationHintsFunc{
+			defaultHook: i.InferedIndexConfigurationHints,
 		},
 		PreviewGitObjectFilterFunc: &ResolverPreviewGitObjectFilterFunc{
 			defaultHook: i.PreviewGitObjectFilter,
@@ -2113,37 +2113,37 @@ func (c ResolverIndexConnectionResolverFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
-// ResolverInferredIndexConfigurationFunc describes the behavior when the
-// InferredIndexConfiguration method of the parent MockResolver instance is
+// ResolverInferedIndexConfigurationFunc describes the behavior when the
+// InferedIndexConfiguration method of the parent MockResolver instance is
 // invoked.
-type ResolverInferredIndexConfigurationFunc struct {
+type ResolverInferedIndexConfigurationFunc struct {
 	defaultHook func(context.Context, int, string) (*config.IndexConfiguration, bool, error)
 	hooks       []func(context.Context, int, string) (*config.IndexConfiguration, bool, error)
-	history     []ResolverInferredIndexConfigurationFuncCall
+	history     []ResolverInferedIndexConfigurationFuncCall
 	mutex       sync.Mutex
 }
 
-// InferredIndexConfiguration delegates to the next hook function in the
+// InferedIndexConfiguration delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockResolver) InferredIndexConfiguration(v0 context.Context, v1 int, v2 string) (*config.IndexConfiguration, bool, error) {
-	r0, r1, r2 := m.InferredIndexConfigurationFunc.nextHook()(v0, v1, v2)
-	m.InferredIndexConfigurationFunc.appendCall(ResolverInferredIndexConfigurationFuncCall{v0, v1, v2, r0, r1, r2})
+func (m *MockResolver) InferedIndexConfiguration(v0 context.Context, v1 int, v2 string) (*config.IndexConfiguration, bool, error) {
+	r0, r1, r2 := m.InferedIndexConfigurationFunc.nextHook()(v0, v1, v2)
+	m.InferedIndexConfigurationFunc.appendCall(ResolverInferedIndexConfigurationFuncCall{v0, v1, v2, r0, r1, r2})
 	return r0, r1, r2
 }
 
 // SetDefaultHook sets function that is called when the
-// InferredIndexConfiguration method of the parent MockResolver instance is
+// InferedIndexConfiguration method of the parent MockResolver instance is
 // invoked and the hook queue is empty.
-func (f *ResolverInferredIndexConfigurationFunc) SetDefaultHook(hook func(context.Context, int, string) (*config.IndexConfiguration, bool, error)) {
+func (f *ResolverInferedIndexConfigurationFunc) SetDefaultHook(hook func(context.Context, int, string) (*config.IndexConfiguration, bool, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// InferredIndexConfiguration method of the parent MockResolver instance
+// InferedIndexConfiguration method of the parent MockResolver instance
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *ResolverInferredIndexConfigurationFunc) PushHook(hook func(context.Context, int, string) (*config.IndexConfiguration, bool, error)) {
+func (f *ResolverInferedIndexConfigurationFunc) PushHook(hook func(context.Context, int, string) (*config.IndexConfiguration, bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2151,20 +2151,20 @@ func (f *ResolverInferredIndexConfigurationFunc) PushHook(hook func(context.Cont
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *ResolverInferredIndexConfigurationFunc) SetDefaultReturn(r0 *config.IndexConfiguration, r1 bool, r2 error) {
+func (f *ResolverInferedIndexConfigurationFunc) SetDefaultReturn(r0 *config.IndexConfiguration, r1 bool, r2 error) {
 	f.SetDefaultHook(func(context.Context, int, string) (*config.IndexConfiguration, bool, error) {
 		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *ResolverInferredIndexConfigurationFunc) PushReturn(r0 *config.IndexConfiguration, r1 bool, r2 error) {
+func (f *ResolverInferedIndexConfigurationFunc) PushReturn(r0 *config.IndexConfiguration, r1 bool, r2 error) {
 	f.PushHook(func(context.Context, int, string) (*config.IndexConfiguration, bool, error) {
 		return r0, r1, r2
 	})
 }
 
-func (f *ResolverInferredIndexConfigurationFunc) nextHook() func(context.Context, int, string) (*config.IndexConfiguration, bool, error) {
+func (f *ResolverInferedIndexConfigurationFunc) nextHook() func(context.Context, int, string) (*config.IndexConfiguration, bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2177,27 +2177,27 @@ func (f *ResolverInferredIndexConfigurationFunc) nextHook() func(context.Context
 	return hook
 }
 
-func (f *ResolverInferredIndexConfigurationFunc) appendCall(r0 ResolverInferredIndexConfigurationFuncCall) {
+func (f *ResolverInferedIndexConfigurationFunc) appendCall(r0 ResolverInferedIndexConfigurationFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of ResolverInferredIndexConfigurationFuncCall
+// History returns a sequence of ResolverInferedIndexConfigurationFuncCall
 // objects describing the invocations of this function.
-func (f *ResolverInferredIndexConfigurationFunc) History() []ResolverInferredIndexConfigurationFuncCall {
+func (f *ResolverInferedIndexConfigurationFunc) History() []ResolverInferedIndexConfigurationFuncCall {
 	f.mutex.Lock()
-	history := make([]ResolverInferredIndexConfigurationFuncCall, len(f.history))
+	history := make([]ResolverInferedIndexConfigurationFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// ResolverInferredIndexConfigurationFuncCall is an object that describes an
-// invocation of method InferredIndexConfiguration on an instance of
+// ResolverInferedIndexConfigurationFuncCall is an object that describes an
+// invocation of method InferedIndexConfiguration on an instance of
 // MockResolver.
-type ResolverInferredIndexConfigurationFuncCall struct {
+type ResolverInferedIndexConfigurationFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -2220,47 +2220,47 @@ type ResolverInferredIndexConfigurationFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c ResolverInferredIndexConfigurationFuncCall) Args() []interface{} {
+func (c ResolverInferedIndexConfigurationFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c ResolverInferredIndexConfigurationFuncCall) Results() []interface{} {
+func (c ResolverInferedIndexConfigurationFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
-// ResolverInferredIndexConfigurationHintsFunc describes the behavior when
-// the InferredIndexConfigurationHints method of the parent MockResolver
+// ResolverInferedIndexConfigurationHintsFunc describes the behavior when
+// the InferedIndexConfigurationHints method of the parent MockResolver
 // instance is invoked.
-type ResolverInferredIndexConfigurationHintsFunc struct {
+type ResolverInferedIndexConfigurationHintsFunc struct {
 	defaultHook func(context.Context, int, string) ([]config.IndexJobHint, error)
 	hooks       []func(context.Context, int, string) ([]config.IndexJobHint, error)
-	history     []ResolverInferredIndexConfigurationHintsFuncCall
+	history     []ResolverInferedIndexConfigurationHintsFuncCall
 	mutex       sync.Mutex
 }
 
-// InferredIndexConfigurationHints delegates to the next hook function in
-// the queue and stores the parameter and result values of this invocation.
-func (m *MockResolver) InferredIndexConfigurationHints(v0 context.Context, v1 int, v2 string) ([]config.IndexJobHint, error) {
-	r0, r1 := m.InferredIndexConfigurationHintsFunc.nextHook()(v0, v1, v2)
-	m.InferredIndexConfigurationHintsFunc.appendCall(ResolverInferredIndexConfigurationHintsFuncCall{v0, v1, v2, r0, r1})
+// InferedIndexConfigurationHints delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockResolver) InferedIndexConfigurationHints(v0 context.Context, v1 int, v2 string) ([]config.IndexJobHint, error) {
+	r0, r1 := m.InferedIndexConfigurationHintsFunc.nextHook()(v0, v1, v2)
+	m.InferedIndexConfigurationHintsFunc.appendCall(ResolverInferedIndexConfigurationHintsFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// InferredIndexConfigurationHints method of the parent MockResolver
-// instance is invoked and the hook queue is empty.
-func (f *ResolverInferredIndexConfigurationHintsFunc) SetDefaultHook(hook func(context.Context, int, string) ([]config.IndexJobHint, error)) {
+// InferedIndexConfigurationHints method of the parent MockResolver instance
+// is invoked and the hook queue is empty.
+func (f *ResolverInferedIndexConfigurationHintsFunc) SetDefaultHook(hook func(context.Context, int, string) ([]config.IndexJobHint, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// InferredIndexConfigurationHints method of the parent MockResolver
-// instance invokes the hook at the front of the queue and discards it.
-// After the queue is empty, the default hook function is invoked for any
-// future action.
-func (f *ResolverInferredIndexConfigurationHintsFunc) PushHook(hook func(context.Context, int, string) ([]config.IndexJobHint, error)) {
+// InferedIndexConfigurationHints method of the parent MockResolver instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *ResolverInferedIndexConfigurationHintsFunc) PushHook(hook func(context.Context, int, string) ([]config.IndexJobHint, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2268,20 +2268,20 @@ func (f *ResolverInferredIndexConfigurationHintsFunc) PushHook(hook func(context
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *ResolverInferredIndexConfigurationHintsFunc) SetDefaultReturn(r0 []config.IndexJobHint, r1 error) {
+func (f *ResolverInferedIndexConfigurationHintsFunc) SetDefaultReturn(r0 []config.IndexJobHint, r1 error) {
 	f.SetDefaultHook(func(context.Context, int, string) ([]config.IndexJobHint, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *ResolverInferredIndexConfigurationHintsFunc) PushReturn(r0 []config.IndexJobHint, r1 error) {
+func (f *ResolverInferedIndexConfigurationHintsFunc) PushReturn(r0 []config.IndexJobHint, r1 error) {
 	f.PushHook(func(context.Context, int, string) ([]config.IndexJobHint, error) {
 		return r0, r1
 	})
 }
 
-func (f *ResolverInferredIndexConfigurationHintsFunc) nextHook() func(context.Context, int, string) ([]config.IndexJobHint, error) {
+func (f *ResolverInferedIndexConfigurationHintsFunc) nextHook() func(context.Context, int, string) ([]config.IndexJobHint, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2294,28 +2294,28 @@ func (f *ResolverInferredIndexConfigurationHintsFunc) nextHook() func(context.Co
 	return hook
 }
 
-func (f *ResolverInferredIndexConfigurationHintsFunc) appendCall(r0 ResolverInferredIndexConfigurationHintsFuncCall) {
+func (f *ResolverInferedIndexConfigurationHintsFunc) appendCall(r0 ResolverInferedIndexConfigurationHintsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// ResolverInferredIndexConfigurationHintsFuncCall objects describing the
+// ResolverInferedIndexConfigurationHintsFuncCall objects describing the
 // invocations of this function.
-func (f *ResolverInferredIndexConfigurationHintsFunc) History() []ResolverInferredIndexConfigurationHintsFuncCall {
+func (f *ResolverInferedIndexConfigurationHintsFunc) History() []ResolverInferedIndexConfigurationHintsFuncCall {
 	f.mutex.Lock()
-	history := make([]ResolverInferredIndexConfigurationHintsFuncCall, len(f.history))
+	history := make([]ResolverInferedIndexConfigurationHintsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// ResolverInferredIndexConfigurationHintsFuncCall is an object that
-// describes an invocation of method InferredIndexConfigurationHints on an
+// ResolverInferedIndexConfigurationHintsFuncCall is an object that
+// describes an invocation of method InferedIndexConfigurationHints on an
 // instance of MockResolver.
-type ResolverInferredIndexConfigurationHintsFuncCall struct {
+type ResolverInferedIndexConfigurationHintsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -2335,13 +2335,13 @@ type ResolverInferredIndexConfigurationHintsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c ResolverInferredIndexConfigurationHintsFuncCall) Args() []interface{} {
+func (c ResolverInferedIndexConfigurationHintsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c ResolverInferredIndexConfigurationHintsFuncCall) Results() []interface{} {
+func (c ResolverInferedIndexConfigurationHintsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_resolver.go
@@ -73,6 +73,10 @@ type MockResolver struct {
 	// object controlling the behavior of the method
 	// InferredIndexConfiguration.
 	InferredIndexConfigurationFunc *ResolverInferredIndexConfigurationFunc
+	// InferredIndexConfigurationHintsFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// InferredIndexConfigurationHints.
+	InferredIndexConfigurationHintsFunc *ResolverInferredIndexConfigurationHintsFunc
 	// PreviewGitObjectFilterFunc is an instance of a mock function object
 	// controlling the behavior of the method PreviewGitObjectFilter.
 	PreviewGitObjectFilterFunc *ResolverPreviewGitObjectFilterFunc
@@ -185,8 +189,13 @@ func NewMockResolver() *MockResolver {
 			},
 		},
 		InferredIndexConfigurationFunc: &ResolverInferredIndexConfigurationFunc{
-			defaultHook: func(context.Context, int) (*config.IndexConfiguration, bool, error) {
+			defaultHook: func(context.Context, int, string) (*config.IndexConfiguration, bool, error) {
 				return nil, false, nil
+			},
+		},
+		InferredIndexConfigurationHintsFunc: &ResolverInferredIndexConfigurationHintsFunc{
+			defaultHook: func(context.Context, int, string) ([]config.IndexJobHint, error) {
+				return nil, nil
 			},
 		},
 		PreviewGitObjectFilterFunc: &ResolverPreviewGitObjectFilterFunc{
@@ -317,8 +326,13 @@ func NewStrictMockResolver() *MockResolver {
 			},
 		},
 		InferredIndexConfigurationFunc: &ResolverInferredIndexConfigurationFunc{
-			defaultHook: func(context.Context, int) (*config.IndexConfiguration, bool, error) {
+			defaultHook: func(context.Context, int, string) (*config.IndexConfiguration, bool, error) {
 				panic("unexpected invocation of MockResolver.InferredIndexConfiguration")
+			},
+		},
+		InferredIndexConfigurationHintsFunc: &ResolverInferredIndexConfigurationHintsFunc{
+			defaultHook: func(context.Context, int, string) ([]config.IndexJobHint, error) {
+				panic("unexpected invocation of MockResolver.InferredIndexConfigurationHints")
 			},
 		},
 		PreviewGitObjectFilterFunc: &ResolverPreviewGitObjectFilterFunc{
@@ -420,6 +434,9 @@ func NewMockResolverFrom(i resolvers.Resolver) *MockResolver {
 		},
 		InferredIndexConfigurationFunc: &ResolverInferredIndexConfigurationFunc{
 			defaultHook: i.InferredIndexConfiguration,
+		},
+		InferredIndexConfigurationHintsFunc: &ResolverInferredIndexConfigurationHintsFunc{
+			defaultHook: i.InferredIndexConfigurationHints,
 		},
 		PreviewGitObjectFilterFunc: &ResolverPreviewGitObjectFilterFunc{
 			defaultHook: i.PreviewGitObjectFilter,
@@ -2100,24 +2117,24 @@ func (c ResolverIndexConnectionResolverFuncCall) Results() []interface{} {
 // InferredIndexConfiguration method of the parent MockResolver instance is
 // invoked.
 type ResolverInferredIndexConfigurationFunc struct {
-	defaultHook func(context.Context, int) (*config.IndexConfiguration, bool, error)
-	hooks       []func(context.Context, int) (*config.IndexConfiguration, bool, error)
+	defaultHook func(context.Context, int, string) (*config.IndexConfiguration, bool, error)
+	hooks       []func(context.Context, int, string) (*config.IndexConfiguration, bool, error)
 	history     []ResolverInferredIndexConfigurationFuncCall
 	mutex       sync.Mutex
 }
 
 // InferredIndexConfiguration delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockResolver) InferredIndexConfiguration(v0 context.Context, v1 int) (*config.IndexConfiguration, bool, error) {
-	r0, r1, r2 := m.InferredIndexConfigurationFunc.nextHook()(v0, v1)
-	m.InferredIndexConfigurationFunc.appendCall(ResolverInferredIndexConfigurationFuncCall{v0, v1, r0, r1, r2})
+func (m *MockResolver) InferredIndexConfiguration(v0 context.Context, v1 int, v2 string) (*config.IndexConfiguration, bool, error) {
+	r0, r1, r2 := m.InferredIndexConfigurationFunc.nextHook()(v0, v1, v2)
+	m.InferredIndexConfigurationFunc.appendCall(ResolverInferredIndexConfigurationFuncCall{v0, v1, v2, r0, r1, r2})
 	return r0, r1, r2
 }
 
 // SetDefaultHook sets function that is called when the
 // InferredIndexConfiguration method of the parent MockResolver instance is
 // invoked and the hook queue is empty.
-func (f *ResolverInferredIndexConfigurationFunc) SetDefaultHook(hook func(context.Context, int) (*config.IndexConfiguration, bool, error)) {
+func (f *ResolverInferredIndexConfigurationFunc) SetDefaultHook(hook func(context.Context, int, string) (*config.IndexConfiguration, bool, error)) {
 	f.defaultHook = hook
 }
 
@@ -2126,7 +2143,7 @@ func (f *ResolverInferredIndexConfigurationFunc) SetDefaultHook(hook func(contex
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *ResolverInferredIndexConfigurationFunc) PushHook(hook func(context.Context, int) (*config.IndexConfiguration, bool, error)) {
+func (f *ResolverInferredIndexConfigurationFunc) PushHook(hook func(context.Context, int, string) (*config.IndexConfiguration, bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2135,19 +2152,19 @@ func (f *ResolverInferredIndexConfigurationFunc) PushHook(hook func(context.Cont
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ResolverInferredIndexConfigurationFunc) SetDefaultReturn(r0 *config.IndexConfiguration, r1 bool, r2 error) {
-	f.SetDefaultHook(func(context.Context, int) (*config.IndexConfiguration, bool, error) {
+	f.SetDefaultHook(func(context.Context, int, string) (*config.IndexConfiguration, bool, error) {
 		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ResolverInferredIndexConfigurationFunc) PushReturn(r0 *config.IndexConfiguration, r1 bool, r2 error) {
-	f.PushHook(func(context.Context, int) (*config.IndexConfiguration, bool, error) {
+	f.PushHook(func(context.Context, int, string) (*config.IndexConfiguration, bool, error) {
 		return r0, r1, r2
 	})
 }
 
-func (f *ResolverInferredIndexConfigurationFunc) nextHook() func(context.Context, int) (*config.IndexConfiguration, bool, error) {
+func (f *ResolverInferredIndexConfigurationFunc) nextHook() func(context.Context, int, string) (*config.IndexConfiguration, bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2187,6 +2204,9 @@ type ResolverInferredIndexConfigurationFuncCall struct {
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
 	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 *config.IndexConfiguration
@@ -2201,13 +2221,128 @@ type ResolverInferredIndexConfigurationFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c ResolverInferredIndexConfigurationFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c ResolverInferredIndexConfigurationFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
+}
+
+// ResolverInferredIndexConfigurationHintsFunc describes the behavior when
+// the InferredIndexConfigurationHints method of the parent MockResolver
+// instance is invoked.
+type ResolverInferredIndexConfigurationHintsFunc struct {
+	defaultHook func(context.Context, int, string) ([]config.IndexJobHint, error)
+	hooks       []func(context.Context, int, string) ([]config.IndexJobHint, error)
+	history     []ResolverInferredIndexConfigurationHintsFuncCall
+	mutex       sync.Mutex
+}
+
+// InferredIndexConfigurationHints delegates to the next hook function in
+// the queue and stores the parameter and result values of this invocation.
+func (m *MockResolver) InferredIndexConfigurationHints(v0 context.Context, v1 int, v2 string) ([]config.IndexJobHint, error) {
+	r0, r1 := m.InferredIndexConfigurationHintsFunc.nextHook()(v0, v1, v2)
+	m.InferredIndexConfigurationHintsFunc.appendCall(ResolverInferredIndexConfigurationHintsFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// InferredIndexConfigurationHints method of the parent MockResolver
+// instance is invoked and the hook queue is empty.
+func (f *ResolverInferredIndexConfigurationHintsFunc) SetDefaultHook(hook func(context.Context, int, string) ([]config.IndexJobHint, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// InferredIndexConfigurationHints method of the parent MockResolver
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *ResolverInferredIndexConfigurationHintsFunc) PushHook(hook func(context.Context, int, string) ([]config.IndexJobHint, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ResolverInferredIndexConfigurationHintsFunc) SetDefaultReturn(r0 []config.IndexJobHint, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string) ([]config.IndexJobHint, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ResolverInferredIndexConfigurationHintsFunc) PushReturn(r0 []config.IndexJobHint, r1 error) {
+	f.PushHook(func(context.Context, int, string) ([]config.IndexJobHint, error) {
+		return r0, r1
+	})
+}
+
+func (f *ResolverInferredIndexConfigurationHintsFunc) nextHook() func(context.Context, int, string) ([]config.IndexJobHint, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ResolverInferredIndexConfigurationHintsFunc) appendCall(r0 ResolverInferredIndexConfigurationHintsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// ResolverInferredIndexConfigurationHintsFuncCall objects describing the
+// invocations of this function.
+func (f *ResolverInferredIndexConfigurationHintsFunc) History() []ResolverInferredIndexConfigurationHintsFuncCall {
+	f.mutex.Lock()
+	history := make([]ResolverInferredIndexConfigurationHintsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ResolverInferredIndexConfigurationHintsFuncCall is an object that
+// describes an invocation of method InferredIndexConfigurationHints on an
+// instance of MockResolver.
+type ResolverInferredIndexConfigurationHintsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []config.IndexJobHint
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ResolverInferredIndexConfigurationHintsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ResolverInferredIndexConfigurationHintsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // ResolverPreviewGitObjectFilterFunc describes the behavior when the

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver.go
@@ -42,8 +42,8 @@ type Resolver interface {
 	DeleteConfigurationPolicyByID(ctx context.Context, id int) (err error)
 
 	IndexConfiguration(ctx context.Context, repositoryID int) ([]byte, bool, error)
-	InferredIndexConfiguration(ctx context.Context, repositoryID int, commit string) (*config.IndexConfiguration, bool, error)
-	InferredIndexConfigurationHints(ctx context.Context, repositoryID int, commit string) ([]config.IndexJobHint, error)
+	InferedIndexConfiguration(ctx context.Context, repositoryID int, commit string) (*config.IndexConfiguration, bool, error)
+	InferedIndexConfigurationHints(ctx context.Context, repositoryID int, commit string) ([]config.IndexJobHint, error)
 	UpdateIndexConfigurationByRepositoryID(ctx context.Context, repositoryID int, configuration string) error
 
 	CommitGraph(ctx context.Context, repositoryID int) (gql.CodeIntelligenceCommitGraphResolver, error)
@@ -242,7 +242,7 @@ func (r *resolver) IndexConfiguration(ctx context.Context, repositoryID int) ([]
 	return configuration.Data, true, nil
 }
 
-func (r *resolver) InferredIndexConfiguration(ctx context.Context, repositoryID int, commit string) (*config.IndexConfiguration, bool, error) {
+func (r *resolver) InferedIndexConfiguration(ctx context.Context, repositoryID int, commit string) (*config.IndexConfiguration, bool, error) {
 	maybeConfig, _, err := r.indexEnqueuer.InferIndexConfiguration(ctx, repositoryID, commit)
 	if err != nil || maybeConfig == nil {
 		return nil, false, err
@@ -251,7 +251,7 @@ func (r *resolver) InferredIndexConfiguration(ctx context.Context, repositoryID 
 	return maybeConfig, true, nil
 }
 
-func (r *resolver) InferredIndexConfigurationHints(ctx context.Context, repositoryID int, commit string) ([]config.IndexJobHint, error) {
+func (r *resolver) InferedIndexConfigurationHints(ctx context.Context, repositoryID int, commit string) ([]config.IndexJobHint, error) {
 	_, hints, err := r.indexEnqueuer.InferIndexConfiguration(ctx, repositoryID, commit)
 	if err != nil {
 		return nil, err

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver.go
@@ -42,7 +42,8 @@ type Resolver interface {
 	DeleteConfigurationPolicyByID(ctx context.Context, id int) (err error)
 
 	IndexConfiguration(ctx context.Context, repositoryID int) ([]byte, bool, error)
-	InferredIndexConfiguration(ctx context.Context, repositoryID int) (*config.IndexConfiguration, bool, error)
+	InferredIndexConfiguration(ctx context.Context, repositoryID int, commit string) (*config.IndexConfiguration, bool, error)
+	InferredIndexConfigurationHints(ctx context.Context, repositoryID int, commit string) ([]config.IndexJobHint, error)
 	UpdateIndexConfigurationByRepositoryID(ctx context.Context, repositoryID int, configuration string) error
 
 	CommitGraph(ctx context.Context, repositoryID int) (gql.CodeIntelligenceCommitGraphResolver, error)
@@ -241,13 +242,22 @@ func (r *resolver) IndexConfiguration(ctx context.Context, repositoryID int) ([]
 	return configuration.Data, true, nil
 }
 
-func (r *resolver) InferredIndexConfiguration(ctx context.Context, repositoryID int) (*config.IndexConfiguration, bool, error) {
-	maybeConfig, err := r.indexEnqueuer.InferIndexConfiguration(ctx, repositoryID)
+func (r *resolver) InferredIndexConfiguration(ctx context.Context, repositoryID int, commit string) (*config.IndexConfiguration, bool, error) {
+	maybeConfig, _, err := r.indexEnqueuer.InferIndexConfiguration(ctx, repositoryID, commit)
 	if err != nil || maybeConfig == nil {
 		return nil, false, err
 	}
 
 	return maybeConfig, true, nil
+}
+
+func (r *resolver) InferredIndexConfigurationHints(ctx context.Context, repositoryID int, commit string) ([]config.IndexJobHint, error) {
+	_, hints, err := r.indexEnqueuer.InferIndexConfiguration(ctx, repositoryID, commit)
+	if err != nil {
+		return nil, err
+	}
+
+	return hints, nil
 }
 
 func (r *resolver) UpdateIndexConfigurationByRepositoryID(ctx context.Context, repositoryID int, configuration string) error {

--- a/enterprise/internal/codeintel/autoindex/enqueuer/iface.go
+++ b/enterprise/internal/codeintel/autoindex/enqueuer/iface.go
@@ -45,6 +45,7 @@ type RepoUpdaterClient interface {
 
 type GitserverClient interface {
 	Head(ctx context.Context, repositoryID int) (string, bool, error)
+	CommitExists(ctx context.Context, repositoryID int, commit string) (bool, error)
 	ListFiles(ctx context.Context, repositoryID int, commit string, pattern *regexp.Regexp) ([]string, error)
 	FileExists(ctx context.Context, repositoryID int, commit, file string) (bool, error)
 	RawContents(ctx context.Context, repositoryID int, commit, file string) ([]byte, error)

--- a/lib/codeintel/autoindex/config/types.go
+++ b/lib/codeintel/autoindex/config/types.go
@@ -23,8 +23,9 @@ type DockerStep struct {
 type HintConfidence int
 
 const (
-	LanguageSupport HintConfidence = iota
-	ProjectStructureSupported
+	HintConfidenceUnknown HintConfidence = iota
+	HintConfidenceLanguageSupport
+	HintConfidenceProjectStructureSupported
 )
 
 type IndexJobHint struct {

--- a/lib/codeintel/autoindex/config/types.go
+++ b/lib/codeintel/autoindex/config/types.go
@@ -19,3 +19,16 @@ type DockerStep struct {
 	Image    string   `json:"image" yaml:"image"`
 	Commands []string `json:"commands" yaml:"commands"`
 }
+
+type HintConfidence int
+
+const (
+	LanguageSupport HintConfidence = iota
+	ProjectStructureSupported
+)
+
+type IndexJobHint struct {
+	Root           string
+	Indexer        string
+	HintConfidence HintConfidence
+}

--- a/lib/codeintel/autoindex/inference/clang.go
+++ b/lib/codeintel/autoindex/inference/clang.go
@@ -10,23 +10,31 @@ import (
 )
 
 func InferClangIndexJobHints(gitserver GitClient, paths []string) (hints []config.IndexJobHint) {
+	inferredDir := make(map[string]bool)
+
 	for _, path := range paths {
+		dir := filepath.Dir(path)
+		if inferredDir[dir] {
+			continue
+		}
 		if strings.ToLower(filepath.Base(path)) == "cmakelists.txt" {
 			hints = append(hints, config.IndexJobHint{
-				Root:           filepath.Dir(path),
+				Root:           dir,
 				Indexer:        "sourcegraph/lsif-clang",
-				HintConfidence: config.ProjectStructureSupported,
+				HintConfidence: config.HintConfidenceProjectStructureSupported,
 			})
+			inferredDir[dir] = true
 			continue
 		}
 
-		ext := filepath.Ext(path)
+		ext := strings.ToLower(filepath.Ext(path))
 		if ext == ".cpp" || ext == ".c" || ext == ".h" || ext == ".hpp" || ext == ".cxx" || ext == ".cc" {
 			hints = append(hints, config.IndexJobHint{
-				Root:           filepath.Dir(path),
+				Root:           dir,
 				Indexer:        "sourcegraph/lsif-clang",
-				HintConfidence: config.LanguageSupport,
+				HintConfidence: config.HintConfidenceLanguageSupport,
 			})
+			inferredDir[dir] = true
 		}
 	}
 

--- a/lib/codeintel/autoindex/inference/clang.go
+++ b/lib/codeintel/autoindex/inference/clang.go
@@ -1,0 +1,46 @@
+package inference
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/grafana/regexp"
+
+	"github.com/sourcegraph/sourcegraph/lib/codeintel/autoindex/config"
+)
+
+func InferClangIndexJobHints(gitserver GitClient, paths []string) (hints []config.IndexJobHint) {
+	for _, path := range paths {
+		if strings.ToLower(filepath.Base(path)) == "cmakelists.txt" {
+			hints = append(hints, config.IndexJobHint{
+				Root:           filepath.Dir(path),
+				Indexer:        "sourcegraph/lsif-clang",
+				HintConfidence: config.ProjectStructureSupported,
+			})
+			continue
+		}
+
+		ext := filepath.Ext(path)
+		if ext == ".cpp" || ext == ".c" || ext == ".h" || ext == ".hpp" || ext == ".cxx" || ext == ".cc" {
+			hints = append(hints, config.IndexJobHint{
+				Root:           filepath.Dir(path),
+				Indexer:        "sourcegraph/lsif-clang",
+				HintConfidence: config.LanguageSupport,
+			})
+		}
+	}
+
+	return
+}
+
+func ClangPatterns() []*regexp.Regexp {
+	return []*regexp.Regexp{
+		suffixPattern(pathPattern(rawPattern("[cC][mM]ake[lL]ists.txt"))),
+		extensionPattern(rawPattern("cpp")),
+		extensionPattern(rawPattern("c")),
+		extensionPattern(rawPattern("h")),
+		extensionPattern(rawPattern("hpp")),
+		extensionPattern(rawPattern("cxx")),
+		extensionPattern(rawPattern("cc")),
+	}
+}

--- a/lib/codeintel/autoindex/inference/clang_test.go
+++ b/lib/codeintel/autoindex/inference/clang_test.go
@@ -1,0 +1,40 @@
+package inference
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/sourcegraph/sourcegraph/lib/codeintel/autoindex/config"
+)
+
+func TestInferClangJobHints(t *testing.T) {
+	paths := []string{
+		"CMakeLists.txt",
+		"dir/cmakelists.txt",
+		"other/test.cpp",
+		"other/test.h",
+	}
+
+	expectedHints := []config.IndexJobHint{
+		{
+			Root:           ".",
+			Indexer:        "sourcegraph/lsif-clang",
+			HintConfidence: config.HintConfidenceProjectStructureSupported,
+		},
+		{
+			Root:           "dir",
+			Indexer:        "sourcegraph/lsif-clang",
+			HintConfidence: config.HintConfidenceProjectStructureSupported,
+		},
+		{
+			Root:           "other",
+			Indexer:        "sourcegraph/lsif-clang",
+			HintConfidence: config.HintConfidenceLanguageSupport,
+		},
+	}
+
+	if diff := cmp.Diff(expectedHints, InferClangIndexJobHints(NewMockGitClient(), paths)); diff != "" {
+		t.Errorf("unexpected index job hints (-want +got)\n%s", diff)
+	}
+}

--- a/lib/codeintel/autoindex/inference/java.go
+++ b/lib/codeintel/autoindex/inference/java.go
@@ -1,6 +1,7 @@
 package inference
 
 import (
+	"path/filepath"
 	"strings"
 
 	"github.com/grafana/regexp"
@@ -20,15 +21,31 @@ func InferJavaIndexJobs(gitserver GitClient, paths []string) (indexes []config.I
 			Steps:   []config.DockerStep{},
 		})
 	}
-	return indexes
+	return
+}
+
+func InferJavaIndexJobHints(gitserver GitClient, paths []string) (hints []config.IndexJobHint) {
+	for _, path := range paths {
+		if filepath.Base(path) == "pom.xml" || filepath.Base(path) == "build.gradle" || filepath.Base(path) == "build.gradle.kts" {
+			hints = append(hints, config.IndexJobHint{
+				Root:           filepath.Dir(path),
+				Indexer:        "sourcegraph/lsif-java",
+				HintConfidence: config.ProjectStructureSupported,
+			})
+		}
+	}
+
+	return
 }
 
 func JavaPatterns() []*regexp.Regexp {
 	return []*regexp.Regexp{
-		suffixPattern(rawPattern("lsif-java.json")),
+		suffixPattern(pathPattern(rawPattern("lsif-java.json"))),
 		suffixPattern(rawPattern(".java")),
 		suffixPattern(rawPattern(".scala")),
 		suffixPattern(rawPattern(".kt")),
+		suffixPattern(pathPattern(rawPattern("pom.xml"))),
+		suffixPattern(pathPattern(rawPattern("build.gradle(.kts)?"))),
 	}
 }
 

--- a/lib/codeintel/autoindex/inference/java_test.go
+++ b/lib/codeintel/autoindex/inference/java_test.go
@@ -42,3 +42,51 @@ func TestInferJavaIndexJobs(t *testing.T) {
 		t.Errorf("unexpected index jobs (-want +got):\n%s", diff)
 	}
 }
+
+func TestInferJavaIndexJobHints(t *testing.T) {
+	paths := []string{
+		"build.gradle",
+		"kt/build.gradle.kts",
+		"maven/pom.xml",
+		"subdir/src/java/App.java",
+		"subdir/src/kotlin/App.kt",
+		"subdir/src/scala/App.scala",
+	}
+
+	expectedHints := []config.IndexJobHint{
+		{
+			Root:           ".",
+			Indexer:        "sourcegraph/lsif-java",
+			HintConfidence: config.HintConfidenceProjectStructureSupported,
+		},
+		{
+			Root:           "kt",
+			Indexer:        "sourcegraph/lsif-java",
+			HintConfidence: config.HintConfidenceProjectStructureSupported,
+		},
+		{
+			Root:           "maven",
+			Indexer:        "sourcegraph/lsif-java",
+			HintConfidence: config.HintConfidenceProjectStructureSupported,
+		},
+		{
+			Root:           "subdir/src/java",
+			Indexer:        "sourcegraph/lsif-java",
+			HintConfidence: config.HintConfidenceLanguageSupport,
+		},
+		{
+			Root:           "subdir/src/kotlin",
+			Indexer:        "sourcegraph/lsif-java",
+			HintConfidence: config.HintConfidenceLanguageSupport,
+		},
+		{
+			Root:           "subdir/src/scala",
+			Indexer:        "sourcegraph/lsif-java",
+			HintConfidence: config.HintConfidenceLanguageSupport,
+		},
+	}
+
+	if diff := cmp.Diff(expectedHints, InferJavaIndexJobHints(NewMockGitClient(), paths)); diff != "" {
+		t.Errorf("unexpected index job hints (-want +got)\n%s", diff)
+	}
+}

--- a/lib/codeintel/autoindex/inference/recognizers.go
+++ b/lib/codeintel/autoindex/inference/recognizers.go
@@ -17,19 +17,26 @@ type IndexJobRecognizer interface {
 	// The given file paths should be all of the file path matches in the
 	// repository that matches any pattern returned from Patterns.
 	InferIndexJobs(gitserver GitClient, paths []string) []config.IndexJob
+
+	// InferIndexJobHints returns a set of hints as to the indexers and index
+	// roots that seem likely to support indexing but for which we could/can not
+	// infer sufficient index job configurations.
+	InferIndexJobHints(gitserver GitClient, paths []string) []config.IndexJobHint
 }
 
 // Recognizers is a list of registered index job recognizers.
 var Recognizers = map[string]IndexJobRecognizer{
-	"go":   recognizer{GoPatterns, InferGoIndexJobs},
-	"tsc":  recognizer{TypeScriptPatterns, InferTypeScriptIndexJobs},
-	"java": recognizer{JavaPatterns, InferJavaIndexJobs},
-	"rust": recognizer{RustPatterns, InferRustIndexJobs},
+	"go":    recognizer{GoPatterns, InferGoIndexJobs, nil},
+	"tsc":   recognizer{TypeScriptPatterns, InferTypeScriptIndexJobs, nil},
+	"java":  recognizer{JavaPatterns, InferJavaIndexJobs, InferJavaIndexJobHints},
+	"rust":  recognizer{RustPatterns, InferRustIndexJobs, nil},
+	"clang": recognizer{ClangPatterns, nil, InferClangIndexJobHints},
 }
 
 type recognizer struct {
-	patterns       func() []*regexp.Regexp
-	inferIndexJobs func(gitserver GitClient, paths []string) []config.IndexJob
+	patterns           func() []*regexp.Regexp
+	inferIndexJobs     func(gitserver GitClient, paths []string) []config.IndexJob
+	inferIndexJobHints func(gitserver GitClient, paths []string) []config.IndexJobHint
 }
 
 func (r recognizer) Patterns() []*regexp.Regexp {
@@ -37,5 +44,15 @@ func (r recognizer) Patterns() []*regexp.Regexp {
 }
 
 func (r recognizer) InferIndexJobs(gitserver GitClient, paths []string) []config.IndexJob {
+	if r.inferIndexJobs == nil {
+		return nil
+	}
 	return r.inferIndexJobs(gitserver, paths)
+}
+
+func (r recognizer) InferIndexJobHints(gitserver GitClient, paths []string) []config.IndexJobHint {
+	if r.inferIndexJobHints == nil {
+		return nil
+	}
+	return r.inferIndexJobHints(gitserver, paths)
 }


### PR DESCRIPTION
Closes #31074

This is an initial pass that takes a directory in isolation into account in a relatively crude way (file-basis). There is a lot of room for expansion into walking up the paths to determine project structures etc

## Test plan
Tested by hand in the API console. The brunt of the work was done and tested as part of https://github.com/sourcegraph/sourcegraph/pull/31442


