### PR TITLE
code monitoring: fix unstable storybook tests due to dates

### DIFF
--- a/client/web/src/enterprise/code-monitoring/components/logs/MonitorLogNode.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/logs/MonitorLogNode.tsx
@@ -86,7 +86,12 @@ export const MonitorLogNode: React.FunctionComponent<{
             {expanded && (
                 <div className={styles.expandedRow}>
                     {monitor.trigger.events.nodes.map(triggerEvent => (
-                        <TriggerEvent key={triggerEvent.id} triggerEvent={triggerEvent} startOpen={startOpen} />
+                        <TriggerEvent
+                            key={triggerEvent.id}
+                            triggerEvent={triggerEvent}
+                            startOpen={startOpen}
+                            now={now}
+                        />
                     ))}
 
                     {monitor.trigger.events.nodes.length === 0 && <div>This code monitor has not been run yet.</div>}

--- a/client/web/src/enterprise/code-monitoring/components/logs/TriggerEvent.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/logs/TriggerEvent.tsx
@@ -15,7 +15,8 @@ import styles from './TriggerEvent.module.scss'
 export const TriggerEvent: React.FunctionComponent<{
     triggerEvent: MonitorTriggerEventWithActions
     startOpen?: boolean
-}> = ({ triggerEvent, startOpen = false }) => {
+    now?: () => Date
+}> = ({ triggerEvent, startOpen = false, now }) => {
     const [expanded, setExpanded] = useState(startOpen)
 
     const toggleExpanded = useCallback(() => setExpanded(expanded => !expanded), [])
@@ -57,7 +58,7 @@ export const TriggerEvent: React.FunctionComponent<{
                 {hasError ? <AlertCircleIcon className={classNames(styles.errorIcon, 'icon-inline mr-2')} /> : <span />}
 
                 <span>
-                    Run <Timestamp date={triggerEvent.timestamp} />
+                    Run <Timestamp date={triggerEvent.timestamp} now={now} />
                 </span>
             </Button>
 

--- a/client/web/src/enterprise/code-monitoring/components/logs/TriggerEvent.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/logs/TriggerEvent.tsx
@@ -58,7 +58,7 @@ export const TriggerEvent: React.FunctionComponent<{
                 {hasError ? <AlertCircleIcon className={classNames(styles.errorIcon, 'icon-inline mr-2')} /> : <span />}
 
                 <span>
-                    Run <Timestamp date={triggerEvent.timestamp} now={now} />
+                    Run <Timestamp date={triggerEvent.timestamp} noAbout={true} now={now} />
                 </span>
             </Button>
 


### PR DESCRIPTION
Fixes unstable storybook tests due to use of date. The `now` injection was not being passed all the way down. [Example](https://www.chromatic.com/pullrequest?appId=5f0f381c0e50750022dc6bf7&number=31989&view=changes)


## Test plan

- Storybook tests verified


