### PR TITLE
code monitoring logs: show link to results with count

### DIFF
--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringLogs.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringLogs.tsx
@@ -58,6 +58,8 @@ export const CODE_MONITOR_EVENTS = gql`
         status
         message
         timestamp
+        resultCount
+        query
         actions {
             nodes {
                 ... on MonitorWebhook {

--- a/client/web/src/enterprise/code-monitoring/components/logs/MonitorLogNode.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/logs/MonitorLogNode.tsx
@@ -3,6 +3,7 @@ import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import CheckBoldIcon from 'mdi-react/CheckBoldIcon'
 import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
 import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
+import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
 import React, { useCallback, useMemo, useState } from 'react'
 
 import { Button, Link } from '@sourcegraph/wildcard'
@@ -75,8 +76,14 @@ export const MonitorLogNode: React.FunctionComponent<{
                 )}
                 {monitor.description}
                 {/* Use clickCatcher so clicking on link doesn't expand/collapse row */}
-                <Link to={`/code-monitoring/${monitor.id}`} className="ml-2 font-weight-normal" onClick={clickCatcher}>
-                    Monitor details
+                <Link
+                    to={`/code-monitoring/${monitor.id}`}
+                    className="ml-2 font-weight-normal"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={clickCatcher}
+                >
+                    Monitor details <OpenInNewIcon className="icon-inline" />
                 </Link>
             </Button>
             <span className="text-nowrap mr-2">

--- a/client/web/src/enterprise/code-monitoring/components/logs/TriggerEvent.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/logs/TriggerEvent.tsx
@@ -2,12 +2,20 @@ import classNames from 'classnames'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
 import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
+import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
 import React, { useCallback, useMemo, useState } from 'react'
 
-import { Button } from '@sourcegraph/wildcard'
+import { pluralize } from '@sourcegraph/common'
+import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
+import { Button, Link } from '@sourcegraph/wildcard'
 
 import { Timestamp } from '../../../../components/time/Timestamp'
-import { EventStatus, MonitorActionEvents, MonitorTriggerEventWithActions } from '../../../../graphql-operations'
+import {
+    EventStatus,
+    MonitorActionEvents,
+    MonitorTriggerEventWithActions,
+    SearchPatternType,
+} from '../../../../graphql-operations'
 
 import { CollapsibleDetailsWithStatus } from './CollapsibleDetailsWithStatus'
 import styles from './TriggerEvent.module.scss'
@@ -59,6 +67,17 @@ export const TriggerEvent: React.FunctionComponent<{
 
                 <span>
                     Run <Timestamp date={triggerEvent.timestamp} noAbout={true} now={now} />
+                    {triggerEvent.query && (
+                        <Link
+                            to={`/search?${buildSearchURLQuery(triggerEvent.query, SearchPatternType.literal, false)}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="font-weight-normal ml-2"
+                        >
+                            {triggerEvent.resultCount} new {pluralize('result', triggerEvent.resultCount)}{' '}
+                            <OpenInNewIcon className="icon-inline" />
+                        </Link>
+                    )}
                 </span>
             </Button>
 

--- a/client/web/src/enterprise/code-monitoring/testing/util.ts
+++ b/client/web/src/enterprise/code-monitoring/testing/util.ts
@@ -327,6 +327,8 @@ export const mockLogs: MonitorTriggerEventsResult = {
                                     status: EventStatus.SUCCESS,
                                     message: null,
                                     timestamp: '2022-02-11T18:30:50Z',
+                                    query: 'test type:diff',
+                                    resultCount: 1,
                                     actions: {
                                         __typename: 'MonitorActionConnection',
                                         nodes: [
@@ -361,6 +363,8 @@ export const mockLogs: MonitorTriggerEventsResult = {
                                     status: EventStatus.SUCCESS,
                                     message: null,
                                     timestamp: '2022-02-11T18:24:49Z',
+                                    query: 'test type:diff',
+                                    resultCount: 2,
                                     actions: {
                                         __typename: 'MonitorActionConnection',
                                         nodes: [
@@ -395,6 +399,8 @@ export const mockLogs: MonitorTriggerEventsResult = {
                                     status: EventStatus.SUCCESS,
                                     message: null,
                                     timestamp: '2022-02-11T17:29:16Z',
+                                    query: 'test type:diff',
+                                    resultCount: 5,
                                     actions: {
                                         __typename: 'MonitorActionConnection',
                                         nodes: [
@@ -463,6 +469,8 @@ export const mockLogs: MonitorTriggerEventsResult = {
                                     status: EventStatus.ERROR,
                                     message: 'Search failed',
                                     timestamp: '2022-02-14T12:29:21Z',
+                                    query: '',
+                                    resultCount: 0,
                                     actions: {
                                         __typename: 'MonitorActionConnection',
                                         nodes: [
@@ -506,6 +514,8 @@ export const mockLogs: MonitorTriggerEventsResult = {
                                     status: EventStatus.SUCCESS,
                                     message: null,
                                     timestamp: '2022-02-13T12:29:21Z',
+                                    query: '',
+                                    resultCount: 0,
                                     actions: {
                                         __typename: 'MonitorActionConnection',
                                         nodes: [


### PR DESCRIPTION
Part of #27168

- Added link to the query run for a specific trigger event, with the result count. This link opens in a new tab, so it has the "open in new" icon.
- Modified the monitor details link to also open in a new tab and added the icon there as well.
- Decided to make these open in new tabs because we currently don't have a URL schema for code monitoring logs, so if a user navigates elsewhere, they lose context if they hit the back button.

![image](https://user-images.githubusercontent.com/206864/156665251-68d91bc4-13d6-4520-be97-97f5ee18b081.png)

## Test plan

- Storybook tests

