### PR TITLE
dev/ci: annotate failures with test summary

### DIFF
--- a/dev/ci/go-test-failures.richstyle.yml
+++ b/dev/ci/go-test-failures.richstyle.yml
@@ -1,0 +1,26 @@
+anyStyle:
+  hide: true
+
+# Style of the "Start" lines.
+startStyle:
+  hide: true
+
+# Style of the "Pass" lines.
+passStyle:
+  hide: true
+
+# Style of the "Skip" lines.
+skipStyle:
+  hide: true
+
+# Style of the "Pass" package lines.
+passPackageStyle:
+  hide: true
+
+# Style of the "Cover" lines with the coverage that is higher than coverThreshold.
+coveredStyle:
+  hide: true
+
+# Style of the "Cover" lines with the coverage that is lower than coverThreshold.
+uncoveredStyle:
+  hide: true

--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -38,6 +38,18 @@ function go_test() {
   mkdir -p './test-reports'
   go-junit-report <"$tmpfile" >>./test-reports/go-test-junit.xml
 
+  # Create annotation from test failure
+  if [ "$test_exit_code" -ne 0 ]; then
+    set -x
+    echo "~~~ Creating test failures anotation"
+    RICHGO_CONFIG="./.richstyle.yml"
+    cp "./dev/ci/go-test-failures.richstyle.yml" $RICHGO_CONFIG
+    mkdir -p ./annotations
+    richgo testfilter <"$tmpfile" >>./annotations/go-test
+    rm -rf RICHGO_CONFIG
+    set +x
+  fi
+
   return "$test_exit_code"
 }
 
@@ -77,7 +89,7 @@ export DB_STARTUP_TIMEOUT=360s # codeinsights-db needs more time to start in som
 export NO_GRAPHQL_LOG=true
 
 # Install richgo for better output
-go install github.com/kyoh86/richgo@latest
+go install github.com/jhchabran/richgo@installable
 asdf reshim golang
 
 # Used to ignore directories (for example, when using submodules)

--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -89,6 +89,7 @@ export DB_STARTUP_TIMEOUT=360s # codeinsights-db needs more time to start in som
 export NO_GRAPHQL_LOG=true
 
 # Install richgo for better output
+# This fork gives us the `anyStyle` configuration required to hide log lines
 go install github.com/jhchabran/richgo@installable
 asdf reshim golang
 

--- a/docker-images/prometheus/cmd/prom-wrapper/receivers_test.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/receivers_test.go
@@ -32,7 +32,7 @@ func TestAlertSolutionsURL(t *testing.T) {
 			wantIncludes: defaultURL,
 		}, {
 			name:         "semver",
-			mockVersion:  "3.24.1",
+			mockVersion:  "bobeadxi",
 			wantIncludes: "@v3.24.1",
 		},
 	}

--- a/docker-images/prometheus/cmd/prom-wrapper/receivers_test.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/receivers_test.go
@@ -32,7 +32,7 @@ func TestAlertSolutionsURL(t *testing.T) {
 			wantIncludes: defaultURL,
 		}, {
 			name:         "semver",
-			mockVersion:  "bobeadxi",
+			mockVersion:  "3.24.1",
 			wantIncludes: "@v3.24.1",
 		},
 	}

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -343,6 +343,7 @@ func addGoTests(pipeline *bk.Pipeline) {
 		pipeline.AddStep(
 			fmt.Sprintf(":go: Test (%s)", description),
 			bk.AnnotatedCmd("./dev/ci/go-test.sh "+testSuffix, bk.AnnotatedCmdOpts{
+				Annotations: &bk.AnnotationOpts{},
 				TestReports: &bk.TestReportOpts{
 					TestSuiteKeyVariableName: "BUILDKITE_ANALYTICS_BACKEND_TEST_SUITE_API_KEY",
 				},


### PR DESCRIPTION
Annotate builds with go test failures using @jhchabran 's `gorich` fork, which gives us more configuration on filtering log lines to get a nice tidy summary

This unfortunately hides assertion failures, but I think it's better than nothing for now!

Closes https://github.com/sourcegraph/sourcegraph/issues/30115

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

https://buildkite.com/sourcegraph/sourcegraph/builds/135125

<img width="1203" alt="image" src="https://user-images.githubusercontent.com/23356519/156670656-3013a668-a04b-40b3-bd63-a485f0ea4c8b.png">

