### PR TITLE
Fixing repo-updater sync alerts

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -10388,7 +10388,7 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (state) (rate(src_repoupdater_syncer_synced_repos_total[1m]))`
+Query: `max(max by (state) (rate(src_repoupdater_syncer_synced_repos_total[1m])))`
 
 </details>
 

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -112,7 +112,7 @@ func RepoUpdater() *monitoring.Container {
 						{
 							Name:        "syncer_synced_repos",
 							Description: "repositories synced",
-							Query:       `max by (state) (rate(src_repoupdater_syncer_synced_repos_total[1m]))`,
+							Query:       `max(max by (state) (rate(src_repoupdater_syncer_synced_repos_total[1m])))`,
 							Warning: monitoring.Alert().LessOrEqual(0).
 								AggregateBy(monitoring.AggregatorMax).
 								For(syncDurationThreshold),


### PR DESCRIPTION
Fixes #20911

The previous query would return back that it isnt performing a sync if any of the 4 sync states were reporting 0, therefore the alert would be fired even if there are syncs happening.

![image](https://user-images.githubusercontent.com/20795805/156675581-a77c371f-fb57-4408-81be-555b9dbfb6a6.png)

![image](https://user-images.githubusercontent.com/20795805/156675760-e292c8c2-7791-4b01-8af5-5864678be362.png)

Fix:
![image](https://user-images.githubusercontent.com/20795805/156675793-f4cbc014-b07d-4151-97d6-8f436ebd44ac.png)


## Test plan

Ran the updated query against my local environment.


