### PR TITLE
repo-updater: Update out parameter on missed code path

### DIFF
--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -704,6 +704,7 @@ func (s *Syncer) sync(ctx context.Context, svc *types.ExternalService, sourced *
 			return Diff{}, errors.Wrap(err, "syncer: failed to update external service repo")
 		}
 
+		*sourced = *stored[0]
 		d.Modified = append(d.Modified, stored[0])
 	case 0: // New repo, create.
 		if !svc.IsSiteOwned() { // enforce user and org repo limits

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -706,7 +706,7 @@ func testSyncRepo(s *repos.Store) func(*testing.T) {
 					Store:  s,
 					Synced: make(chan repos.Diff, 1),
 					Sourcer: repos.NewFakeSourcer(nil,
-						repos.NewFakeSource(servicesPerKind[extsvc.KindGitHub], nil, repo),
+						repos.NewFakeSource(servicesPerKind[extsvc.KindGitHub], nil, repo.Clone()),
 					),
 				}
 

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -636,34 +636,47 @@ func testSyncRepo(s *repos.Store) func(*testing.T) {
 		testCases := []struct {
 			name          string
 			repo          api.RepoName
+			background    bool
 			before, after types.Repos
 			returned      *types.Repo
 		}{{
-			name:     "insert",
-			repo:     repo.Name,
-			returned: repo,
-			after:    types.Repos{repo},
+			name:       "insert",
+			repo:       repo.Name,
+			background: true,
+			returned:   repo,
+			after:      types.Repos{repo},
 		}, {
-			name:     "update",
-			repo:     repo.Name,
-			before:   types.Repos{oldRepo},
-			returned: oldRepo,
-			after:    types.Repos{repo},
+			name:       "update",
+			repo:       repo.Name,
+			background: true,
+			before:     types.Repos{oldRepo},
+			returned:   oldRepo,
+			after:      types.Repos{repo},
 		}, {
-			name:     "update name",
-			repo:     repo.Name,
-			before:   types.Repos{repo.With(typestest.Opt.RepoName("old/name"))},
-			returned: repo,
-			after:    types.Repos{repo},
+			name:       "blocking update",
+			repo:       repo.Name,
+			background: false,
+			before:     types.Repos{oldRepo},
+			returned:   repo,
+			after:      types.Repos{repo},
 		}, {
-			name:     "delete conflicting name",
-			repo:     repo.Name,
-			before:   types.Repos{repo.With(typestest.Opt.RepoExternalID("old id"))},
-			returned: repo.With(typestest.Opt.RepoExternalID("old id")),
-			after:    types.Repos{repo},
+			name:       "update name",
+			repo:       repo.Name,
+			background: true,
+			before:     types.Repos{repo.With(typestest.Opt.RepoName("old/name"))},
+			returned:   repo,
+			after:      types.Repos{repo},
 		}, {
-			name: "rename and delete conflicting name",
-			repo: repo.Name,
+			name:       "delete conflicting name",
+			repo:       repo.Name,
+			background: true,
+			before:     types.Repos{repo.With(typestest.Opt.RepoExternalID("old id"))},
+			returned:   repo.With(typestest.Opt.RepoExternalID("old id")),
+			after:      types.Repos{repo},
+		}, {
+			name:       "rename and delete conflicting name",
+			repo:       repo.Name,
+			background: true,
 			before: types.Repos{
 				repo.With(typestest.Opt.RepoExternalID("old id")),
 				repo.With(typestest.Opt.RepoName("old name")),
@@ -697,9 +710,13 @@ func testSyncRepo(s *repos.Store) func(*testing.T) {
 					),
 				}
 
-				have, err := syncer.SyncRepo(ctx, tc.repo, true)
+				have, err := syncer.SyncRepo(ctx, tc.repo, tc.background)
 				if err != nil {
 					t.Fatal(err)
+				}
+
+				if have.ID == 0 {
+					t.Errorf("expected returned synced repo to have an ID set")
 				}
 
 				opt := cmpopts.IgnoreFields(types.Repo{}, "ID", "CreatedAt", "UpdatedAt")


### PR DESCRIPTION
The 'sourced' parameter is used as an "out parameter",
initially its ID is not set, but it will set when the repo
is created. However, on this code path, the ID was not updated.

Since the returned diff is ignored in syncRepo, it makes
sense to update the out parameter, otherwise the new ID is lost.

This fixes a downstream crash when trying to enqueue an update
for a repo with ID == 0.

Tentative fix for #32171. This seem to fix the crash in local testing
when I try a dependency search after truncating `lsif_dependency_repos`
and using `update repo set deleted_at = now() where name like 'npm/%';`.

## Test plan

- [x] TODO: Add tests (how do we test this easily?)

