### PR TITLE
external_services: only execute update once

### DIFF
--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -1062,6 +1062,10 @@ func (e *externalServiceStore) Update(ctx context.Context, ps []schema.AuthProvi
 		updates = append(updates, sqlf.Sprintf("token_expires_at = %s", update.TokenExpiresAt))
 	}
 
+	if len(updates) == 0 {
+		return nil
+	}
+
 	q := sqlf.Sprintf("UPDATE external_services SET %s, updated_at = NOW() WHERE id = %d AND deleted_at IS NULL", sqlf.Join(updates, ","), id)
 	res, err := e.Store.Handle().DB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 	if err != nil {

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -1038,52 +1038,41 @@ func (e *externalServiceStore) Update(ctx context.Context, ps []schema.AuthProvi
 		update.Config = &config
 	}
 
-	// FIXME: UPDATEs are executed N times if N fields are marked.
-	execUpdate := func(ctx context.Context, tx dbutil.DB, update *sqlf.Query) error {
-		q := sqlf.Sprintf("UPDATE external_services SET %s, updated_at=now() WHERE id=%d AND deleted_at IS NULL", update, id)
-		res, err := tx.ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
-		if err != nil {
-			return err
-		}
-		affected, err := res.RowsAffected()
-		if err != nil {
-			return err
-		}
-		if affected == 0 {
-			return externalServiceNotFoundError{id: id}
-		}
-		return nil
-	}
-	tx, err := e.Store.Handle().Transact(ctx)
-	if err != nil {
-		return err
-	}
-	defer func() { err = tx.Done(err) }()
+	// 4 is the number of fields of the ExternalServiceUpdate
+	updates := make([]*sqlf.Query, 0, 4)
 
 	if update.DisplayName != nil {
-		if err := execUpdate(ctx, tx.DB(), sqlf.Sprintf("display_name=%s", update.DisplayName)); err != nil {
-			return err
-		}
+		updates = append(updates, sqlf.Sprintf("display_name = %s", update.DisplayName))
 	}
 
 	if update.Config != nil {
 		unrestricted := !envvar.SourcegraphDotComMode() && !gjson.GetBytes(normalized, "authorization").Exists()
-		q := sqlf.Sprintf(`config = %s, encryption_key_id = %s, next_sync_at = NOW(), unrestricted = %s, has_webhooks = %s`, update.Config, keyID, unrestricted, hasWebhooks)
-		if err := execUpdate(ctx, tx.DB(), q); err != nil {
-			return err
-		}
+		updates = append(updates,
+			sqlf.Sprintf(
+				"config = %s, encryption_key_id = %s, next_sync_at = NOW(), unrestricted = %s, has_webhooks = %s",
+				update.Config, keyID, unrestricted, hasWebhooks,
+			))
 	}
 
 	if update.CloudDefault != nil {
-		if err := execUpdate(ctx, tx.DB(), sqlf.Sprintf("cloud_default=%s", update.CloudDefault)); err != nil {
-			return err
-		}
+		updates = append(updates, sqlf.Sprintf("cloud_default = %s", update.CloudDefault))
 	}
 
 	if update.TokenExpiresAt != nil {
-		if err := execUpdate(ctx, tx.DB(), sqlf.Sprintf("token_expires_at=%s", update.TokenExpiresAt)); err != nil {
-			return err
-		}
+		updates = append(updates, sqlf.Sprintf("token_expires_at = %s", update.TokenExpiresAt))
+	}
+
+	q := sqlf.Sprintf("UPDATE external_services SET %s, updated_at = NOW() WHERE id = %d AND deleted_at IS NULL", sqlf.Join(updates, ","), id)
+	res, err := e.Store.Handle().DB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return externalServiceNotFoundError{id: id}
 	}
 	return nil
 }

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -538,11 +538,12 @@ func TestExternalServicesStore_Update(t *testing.T) {
 
 	// NOTE: The order of tests matters
 	tests := []struct {
-		name             string
-		update           *ExternalServiceUpdate
-		wantUnrestricted bool
-		wantCloudDefault bool
-		wantHasWebhooks  bool
+		name               string
+		update             *ExternalServiceUpdate
+		wantUnrestricted   bool
+		wantCloudDefault   bool
+		wantHasWebhooks    bool
+		wantTokenExpiresAt bool
 	}{
 		{
 			name: "update with authorization",
@@ -583,7 +584,7 @@ func TestExternalServicesStore_Update(t *testing.T) {
 		{
 			name: "set cloud_default true",
 			update: &ExternalServiceUpdate{
-				DisplayName:  strptr("GITHUB (updated) #3"),
+				DisplayName:  strptr("GITHUB (updated) #4"),
 				CloudDefault: boolptr(true),
 				Config: strptr(`
 {
@@ -597,6 +598,16 @@ func TestExternalServicesStore_Update(t *testing.T) {
 			wantUnrestricted: false,
 			wantCloudDefault: true,
 			wantHasWebhooks:  true,
+		},
+		{
+			name: "update token_expires_at",
+			update: &ExternalServiceUpdate{
+				DisplayName:    strptr("GITHUB (updated) #5"),
+				Config:         strptr(`{"url": "https://github.com", "repositoryQuery": ["none"], "token": "def"}`),
+				TokenExpiresAt: timePtr(time.Now()),
+			},
+			wantCloudDefault:   true,
+			wantTokenExpiresAt: true,
 		},
 	}
 	for _, test := range tests {
@@ -632,6 +643,10 @@ func TestExternalServicesStore_Update(t *testing.T) {
 				t.Fatal("has_webhooks is unexpectedly null")
 			} else if test.wantHasWebhooks != *got.HasWebhooks {
 				t.Fatalf("Want has_webhooks = %v, but got %v", test.wantHasWebhooks, *got.HasWebhooks)
+			}
+
+			if (got.TokenExpiresAt != nil) != test.wantTokenExpiresAt {
+				t.Fatalf("Want token_expires_at = %v, but got %v", test.wantTokenExpiresAt, got.TokenExpiresAt)
 			}
 		})
 	}


### PR DESCRIPTION
UPDATEs are being executed N times if N fields are updated for a given external service, now reduces to at most once.

Also added a test case overlooked in https://github.com/sourcegraph/sourcegraph/pull/31918.

## Test plan

Uint tests.


