### PR TITLE
Add deleted_at IS NULL check for GetUserIDsByExternalAccounts

### DIFF
--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -1399,6 +1399,7 @@ FROM user_external_accounts
 WHERE service_type = %s
 AND service_id = %s
 AND account_id IN (%s)
+AND deleted_at IS NULL
 `, accounts.ServiceType, accounts.ServiceID, sqlf.Join(items, ","))
 	rows, err := s.Query(ctx, q)
 	if err != nil {

--- a/enterprise/internal/database/perms_store_test.go
+++ b/enterprise/internal/database/perms_store_test.go
@@ -2340,18 +2340,19 @@ func testPermsStore_GetUserIDsByExternalAccounts(db *sql.DB) func(*testing.T) {
 
 		// Set up test users and external accounts
 		extSQL := `
-INSERT INTO user_external_accounts(user_id, service_type, service_id, account_id, client_id, created_at, updated_at)
-	VALUES(%s, %s, %s, %s, %s, %s, %s)
+INSERT INTO user_external_accounts(user_id, service_type, service_id, account_id, client_id, created_at, updated_at, deleted_at)
+	VALUES(%s, %s, %s, %s, %s, %s, %s, %s)
 `
 		qs := []*sqlf.Query{
 			sqlf.Sprintf(`INSERT INTO users(username) VALUES('alice')`), // ID=1
 			sqlf.Sprintf(`INSERT INTO users(username) VALUES('bob')`),   // ID=2
 			sqlf.Sprintf(`INSERT INTO users(username) VALUES('cindy')`), // ID=3
 
-			sqlf.Sprintf(extSQL, 1, extsvc.TypeGitLab, "https://gitlab.com/", "alice_gitlab", "alice_gitlab_client_id", clock(), clock()), // ID=1
-			sqlf.Sprintf(extSQL, 1, "github", "https://github.com/", "alice_github", "alice_github_client_id", clock(), clock()),          // ID=2
-			sqlf.Sprintf(extSQL, 2, extsvc.TypeGitLab, "https://gitlab.com/", "bob_gitlab", "bob_gitlab_client_id", clock(), clock()),     // ID=3
-			sqlf.Sprintf(extSQL, 3, extsvc.TypeGitLab, "https://gitlab.com/", "cindy_gitlab", "cindy_gitlab_client_id", clock(), clock()), // ID=4
+			sqlf.Sprintf(extSQL, 1, extsvc.TypeGitLab, "https://gitlab.com/", "alice_gitlab", "alice_gitlab_client_id", clock(), clock(), nil), // ID=1
+			sqlf.Sprintf(extSQL, 1, "github", "https://github.com/", "alice_github", "alice_github_client_id", clock(), clock(), nil),          // ID=2
+			sqlf.Sprintf(extSQL, 2, extsvc.TypeGitLab, "https://gitlab.com/", "bob_gitlab", "bob_gitlab_client_id", clock(), clock(), nil),     // ID=3
+			sqlf.Sprintf(extSQL, 3, extsvc.TypeGitLab, "https://gitlab.com/", "cindy_gitlab", "cindy_gitlab_client_id", clock(), clock(), nil), // ID=4
+			sqlf.Sprintf(extSQL, 3, "github", "https://github.com/", "cindy_github", "cindy_github_client_id", clock(), clock(), clock()),      // ID=5, deleted
 		}
 		for _, q := range qs {
 			if err := s.execute(ctx, q); err != nil {
@@ -2378,6 +2379,16 @@ INSERT INTO user_external_accounts(user_id, service_type, service_id, account_id
 		} else if userIDs["bob_gitlab"] != 2 {
 			t.Fatalf(`userIDs["bob_gitlab"]: want 2 but got %d`, userIDs["bob_gitlab"])
 		}
+
+		accounts = &extsvc.Accounts{
+			ServiceType: "github",
+			ServiceID:   "https://github.com/",
+			AccountIDs:  []string{"cindy_github"},
+		}
+		userIDs, err = s.GetUserIDsByExternalAccounts(ctx, accounts)
+
+		require.Nil(t, err)
+		require.Empty(t, userIDs)
 	}
 }
 

--- a/enterprise/internal/database/perms_store_test.go
+++ b/enterprise/internal/database/perms_store_test.go
@@ -2386,9 +2386,8 @@ INSERT INTO user_external_accounts(user_id, service_type, service_id, account_id
 			AccountIDs:  []string{"cindy_github"},
 		}
 		userIDs, err = s.GetUserIDsByExternalAccounts(ctx, accounts)
-
 		require.Nil(t, err)
-		require.Empty(t, userIDs)
+		assert.Empty(t, userIDs)
 	}
 }
 


### PR DESCRIPTION
This PR addresses https://sourcegraph.atlassian.net/browse/CLOUD-309 where a deleted user external account is still used to associate GitHub userIDs to Sourcegraph User IDs. As stated in the ticket description, we don't know of a way in which this can be abused, but it does lead to an inconsistent user experience.

## Test plan

Added unit test and tested the behaviour manually

