### PR TITLE
Do not show IDE CTAs to users who have these products installed

### DIFF
--- a/client/shared/src/settings/temporary/TemporarySettings.ts
+++ b/client/shared/src/settings/temporary/TemporarySettings.ts
@@ -20,6 +20,8 @@ export interface TemporarySettingsSchema {
     'signup.finishedWelcomeFlow': boolean
     'codemonitor.info.visible': boolean
     'homepage.userInvites.tab': number
+    'integrations.vscode.lastDetectionTimestamp': number
+    'integrations.jetbrains.lastDetectionTimestamp': number
 }
 
 /**

--- a/client/web/src/IdeExtensionTracker.test.tsx
+++ b/client/web/src/IdeExtensionTracker.test.tsx
@@ -1,0 +1,77 @@
+import { gql } from '@apollo/client'
+import { createMockClient } from '@apollo/client/testing'
+import { cleanup, render } from '@testing-library/react'
+import React from 'react'
+
+import { TemporarySettingsContext } from '@sourcegraph/shared/src/settings/temporary/TemporarySettingsProvider'
+import {
+    InMemoryMockSettingsBackend,
+    TemporarySettingsStorage,
+} from '@sourcegraph/shared/src/settings/temporary/TemporarySettingsStorage'
+
+import { IdeExtensionTracker } from './IdeExtensionTracker'
+
+const settingsClient = createMockClient(
+    { contents: JSON.stringify({}) },
+    gql`
+        query {
+            temporarySettings {
+                contents
+            }
+        }
+    `
+)
+
+type ExpectedResult = null | 'vscode' | 'jetbrains'
+
+describe('IdeExtensionTracker', () => {
+    afterAll(cleanup)
+
+    const cases: [string, ExpectedResult][] = [
+        [
+            'https://sourcegraph.com/-/editor?remote_url=git%40github.com%3Asourcegraph%2Fsourcegraph-jetbrains.git&branch=main&file=src%2Fmain%2Fjava%2FOpenRevisionAction.java&editor=JetBrains&version=v1.2.2&start_row=68&start_col=26&end_row=68&end_col=26&utm_product_name=IntelliJ+IDEA&utm_product_version=2021.3.2',
+            'jetbrains',
+        ],
+        [
+            'https://sourcegraph.com/-/editor?remote_url=git@github.com:sourcegraph/sourcegraph.git&branch=ps/detect-ide-extensions&file=client/web/src/tracking/util.ts&editor=VSCode&version=2.0.9&start_row=13&start_col=22&end_row=13&end_col=22&utm_campaign=vscode-extension&utm_medium=direct_traffic&utm_source=vscode-extension&utm_content=vsce-commands',
+            'vscode',
+        ],
+        [
+            'https://sourcegraph.com/sign-up?editor=vscode&utm_medium=VSCIDE&utm_source=sidebar&utm_campaign=vsce-sign-up&utm_content=sign-up',
+            'vscode',
+        ],
+        ['https://sourcegraph.com/?something=different', null],
+    ]
+    test.each(cases)('Detects the proper extension for %p', async (url, expectedResult) => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        delete window.location
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        window.location = new URL(url)
+
+        const settingsStorage = new TemporarySettingsStorage(settingsClient, true)
+        const settingsBackend = new InMemoryMockSettingsBackend({})
+        settingsStorage.setSettingsBackend(settingsBackend)
+
+        render(
+            <TemporarySettingsContext.Provider value={settingsStorage}>
+                <IdeExtensionTracker />
+            </TemporarySettingsContext.Provider>
+        )
+
+        const settings = await settingsBackend.load().toPromise()
+
+        if (expectedResult === 'vscode') {
+            expect(settings).toHaveProperty(['integrations.vscode.lastDetectionTimestamp'])
+        } else {
+            expect(settings).not.toHaveProperty(['integrations.vscode.lastDetectionTimestamp'])
+        }
+
+        if (expectedResult === 'jetbrains') {
+            expect(settings).toHaveProperty(['integrations.jetbrains.lastDetectionTimestamp'])
+        } else {
+            expect(settings).not.toHaveProperty(['integrations.jetbrains.lastDetectionTimestamp'])
+        }
+    })
+})

--- a/client/web/src/IdeExtensionTracker.tsx
+++ b/client/web/src/IdeExtensionTracker.tsx
@@ -20,11 +20,6 @@ export const IdeExtensionTracker: React.FunctionComponent = () => {
     // never update.
     const locationReference = useRef(location)
 
-    // We only want to run the below effect once. Since the setter function changes over time, we
-    // capture a copy in a ref to avoid passing it into the dependency array of the effect.
-    const setLastVSCodeDetectionReference = useRef(setLastVSCodeDetection)
-    const setLastJetBrainsDetectionReference = useRef(setLastJetBrainsDetection)
-
     useEffect(() => {
         const parameters = new URLSearchParams(locationReference.current.search)
         const utmProductName = parameters.get('utm_product_name')
@@ -32,11 +27,11 @@ export const IdeExtensionTracker: React.FunctionComponent = () => {
         const utmSource = parameters.get('utm_source')
 
         if (utmProductName === 'IntelliJ IDEA') {
-            setLastJetBrainsDetectionReference.current(Date.now())
+            setLastJetBrainsDetection(Date.now())
         } else if (utmMedium === 'VSCIDE' || utmSource?.toLowerCase().startsWith('vscode')) {
-            setLastVSCodeDetectionReference.current(Date.now())
+            setLastVSCodeDetection(Date.now())
         }
-    }, [])
+    }, [setLastJetBrainsDetection, setLastVSCodeDetection])
 
     return null
 }

--- a/client/web/src/IdeExtensionTracker.tsx
+++ b/client/web/src/IdeExtensionTracker.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useRef, useState } from 'react'
+
+const VSCODE_SETTING = 'integrations.vscode.lastDetectionTimestamp'
+const JETBRAINS_SETTING = 'integrations.jetbrains.lastDetectionTimestamp'
+const ONE_MONTH = 1000 * 60 * 60 * 24 * 30
+
+import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
+
+// @todo: Add explaination
+// @todo: Add tests
+// https://sourcegraph.test:3443/-/editor?remote_url=git%40github.com%3Asourcegraph%2Fsourcegraph-jetbrains.git&branch=main&file=src%2Fmain%2Fjava%2FOpenRevisionAction.java&editor=JetBrains&version=v1.2.2&start_row=68&start_col=26&end_row=68&end_col=26&utm_product_name=IntelliJ+IDEA&utm_product_version=2021.3.2
+// https://sourcegraph.test:3443/-/editor?remote_url=git@github.com:sourcegraph/sourcegraph.git&branch=ps/detect-ide-extensions&file=client/web/src/tracking/util.ts&editor=VSCode&version=2.0.9&start_row=13&start_col=22&end_row=13&end_col=22&utm_campaign=vscode-extension&utm_medium=direct_traffic&utm_source=vscode-extension&utm_content=vsce-commands
+// https://sourcegraph.test:3443/sign-up?editor=vscode&utm_medium=VSCIDE&utm_source=sidebar&utm_campaign=vsce-sign-up&utm_content=sign-up
+export const IdeExtensionTracker: React.FunctionComponent = () => {
+    const [, setLastVSCodeDetection] = useTemporarySetting(VSCODE_SETTING, 0)
+    const [, setLastJetBrainsDetection] = useTemporarySetting(JETBRAINS_SETTING, 0)
+
+    // We only want to run the below effect once. Since the setter function changes over time, we
+    // capture a copy in a ref to avoid passing it into the dependency array of the effect.
+    const setLastVSCodeDetectionReference = useRef(setLastVSCodeDetection)
+    const setLastJetBrainsDetectionReference = useRef(setLastJetBrainsDetection)
+
+    useEffect(() => {
+        const parameters = new URLSearchParams(location.search)
+        const utmProductName = parameters.get('utm_product_name')
+        const utmMedium = parameters.get('utm_medium')
+        const utmSource = parameters.get('utm_source')
+
+        if (utmProductName === 'IntelliJ IDEA') {
+            setLastJetBrainsDetectionReference.current(Date.now())
+        } else if (utmMedium === 'VSCIDE' || utmSource?.toLowerCase().startsWith('vscode')) {
+            setLastVSCodeDetectionReference.current(Date.now())
+        }
+    }, [])
+
+    return null
+}
+
+export const useIsUsingIDEIntegration = (): undefined | boolean => {
+    const [lastVSCodeDetection] = useTemporarySetting(VSCODE_SETTING, 0)
+    const [lastJetBrainsDetection] = useTemporarySetting(JETBRAINS_SETTING, 0)
+
+    const [now] = useState<number>(Date.now())
+
+    if (lastVSCodeDetection === undefined || lastJetBrainsDetection === undefined) {
+        return undefined
+    }
+
+    if (now - lastVSCodeDetection < ONE_MONTH) {
+        return true
+    }
+    if (now - lastJetBrainsDetection < ONE_MONTH) {
+        return true
+    }
+    return false
+}

--- a/client/web/src/IdeExtensionTracker.tsx
+++ b/client/web/src/IdeExtensionTracker.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useLocation } from 'react-router'
 
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
@@ -15,13 +15,8 @@ export const IdeExtensionTracker: React.FunctionComponent = () => {
     const [, setLastVSCodeDetection] = useTemporarySetting('integrations.vscode.lastDetectionTimestamp', 0)
     const [, setLastJetBrainsDetection] = useTemporarySetting('integrations.jetbrains.lastDetectionTimestamp', 0)
 
-    // We only want to capture the IDE UTM parameters on the first page load. In order to avoid
-    // rerunning the effect below whenever location change, we instead capture a reference that we
-    // never update.
-    const locationReference = useRef(location)
-
     useEffect(() => {
-        const parameters = new URLSearchParams(locationReference.current.search)
+        const parameters = new URLSearchParams(location.search)
         const utmProductName = parameters.get('utm_product_name')
         const utmMedium = parameters.get('utm_medium')
         const utmSource = parameters.get('utm_source')
@@ -31,6 +26,10 @@ export const IdeExtensionTracker: React.FunctionComponent = () => {
         } else if (utmMedium === 'VSCIDE' || utmSource?.toLowerCase().startsWith('vscode')) {
             setLastVSCodeDetection(Date.now())
         }
+
+        // We only want to capture the IDE UTM parameters on the first page load. In order to avoid
+        // rerunning the effect whenever location change, we skip it from the dependecy array.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [setLastJetBrainsDetection, setLastVSCodeDetection])
 
     return null

--- a/client/web/src/IdeExtensionTracker.tsx
+++ b/client/web/src/IdeExtensionTracker.tsx
@@ -6,11 +6,10 @@ const ONE_MONTH = 1000 * 60 * 60 * 24 * 30
 
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 
-// @todo: Add explaination
-// @todo: Add tests
-// https://sourcegraph.test:3443/-/editor?remote_url=git%40github.com%3Asourcegraph%2Fsourcegraph-jetbrains.git&branch=main&file=src%2Fmain%2Fjava%2FOpenRevisionAction.java&editor=JetBrains&version=v1.2.2&start_row=68&start_col=26&end_row=68&end_col=26&utm_product_name=IntelliJ+IDEA&utm_product_version=2021.3.2
-// https://sourcegraph.test:3443/-/editor?remote_url=git@github.com:sourcegraph/sourcegraph.git&branch=ps/detect-ide-extensions&file=client/web/src/tracking/util.ts&editor=VSCode&version=2.0.9&start_row=13&start_col=22&end_row=13&end_col=22&utm_campaign=vscode-extension&utm_medium=direct_traffic&utm_source=vscode-extension&utm_content=vsce-commands
-// https://sourcegraph.test:3443/sign-up?editor=vscode&utm_medium=VSCIDE&utm_source=sidebar&utm_campaign=vsce-sign-up&utm_content=sign-up
+/**
+ * This component uses UTM parameters to detect incoming traffic from our IDE extensions (VS Code
+ * and JetBrains) and updates a temporary setting whenever these are found.
+ */
 export const IdeExtensionTracker: React.FunctionComponent = () => {
     const [, setLastVSCodeDetection] = useTemporarySetting(VSCODE_SETTING, 0)
     const [, setLastJetBrainsDetection] = useTemporarySetting(JETBRAINS_SETTING, 0)
@@ -36,10 +35,9 @@ export const IdeExtensionTracker: React.FunctionComponent = () => {
     return null
 }
 
-export const useIsUsingIDEIntegration = (): undefined | boolean => {
+export const useIsUsingIdeIntegration = (): undefined | boolean => {
     const [lastVSCodeDetection] = useTemporarySetting(VSCODE_SETTING, 0)
     const [lastJetBrainsDetection] = useTemporarySetting(JETBRAINS_SETTING, 0)
-
     const [now] = useState<number>(Date.now())
 
     if (lastVSCodeDetection === undefined || lastJetBrainsDetection === undefined) {

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -68,6 +68,7 @@ import { ExtensionsAreaRoute } from './extensions/ExtensionsArea'
 import { ExtensionsAreaHeaderActionButton } from './extensions/ExtensionsAreaHeader'
 import { FeatureFlagName, fetchFeatureFlags, FlagSet } from './featureFlags/featureFlags'
 import { OverrideFeatureFlagsAgent } from './featureFlags/OverrideFeatureFlagsAgent'
+import { IdeExtensionTracker } from './IdeExtensionTracker'
 import { CodeInsightsProps } from './insights/types'
 import { Layout, LayoutProps } from './Layout'
 import { OrgAreaRoute } from './org/area/OrgArea'
@@ -481,6 +482,7 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
                                             notificationItemStyleProps={notificationStyles}
                                         />
                                         <UserSessionStores />
+                                        <IdeExtensionTracker />
                                     </SearchQueryStateStoreProvider>
                                 </SearchResultsCacheProvider>
                             </TemporarySettingsProvider>

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -473,6 +473,7 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
                                                     )}
                                                 />
                                                 <SearchStack />
+                                                <IdeExtensionTracker />
                                             </Router>
                                         </ScrollManager>
                                         <Tooltip key={1} />
@@ -482,7 +483,6 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
                                             notificationItemStyleProps={notificationStyles}
                                         />
                                         <UserSessionStores />
-                                        <IdeExtensionTracker />
                                     </SearchQueryStateStoreProvider>
                                 </SearchResultsCacheProvider>
                             </TemporarySettingsProvider>

--- a/client/web/src/repo/actions/InstallIntegrationsAlert.tsx
+++ b/client/web/src/repo/actions/InstallIntegrationsAlert.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useMemo } from 'react'
 import { useLocalStorage, useObservable } from '@sourcegraph/wildcard'
 
 import { usePersistentCadence } from '../../hooks'
+import { useIsUsingIDEIntegration } from '../../IdeExtensionTracker'
 import { browserExtensionInstalled } from '../../tracking/analyticsUtils'
 import { HOVER_COUNT_KEY, HOVER_THRESHOLD } from '../RepoContainer'
 
@@ -42,6 +43,7 @@ export const InstallIntegrationsAlert: React.FunctionComponent<InstallIntegratio
         IDE_CTA_CADENCE_SHIFT
     )
     const isBrowserExtensionInstalled = useObservable<boolean>(browserExtensionInstalled)
+    const isUsingIDEIntegration = useIsUsingIDEIntegration()
     const [hoverCount] = useLocalStorage<number>(HOVER_COUNT_KEY, 0)
     const [hasDismissedBrowserExtensionAlert, setHasDismissedBrowserExtensionAlert] = useLocalStorage<boolean>(
         HAS_DISMISSED_BROWSER_EXTENSION_ALERT_KEY,
@@ -63,7 +65,11 @@ export const InstallIntegrationsAlert: React.FunctionComponent<InstallIntegratio
                 return 'browser'
             }
 
-            if (displayIDEExtensionCTABasedOnCadence && !hasDismissedIDEExtensionAlert) {
+            if (
+                isUsingIDEIntegration === false &&
+                displayIDEExtensionCTABasedOnCadence &&
+                !hasDismissedIDEExtensionAlert
+            ) {
                 return 'ide'
             }
 
@@ -80,6 +86,7 @@ export const InstallIntegrationsAlert: React.FunctionComponent<InstallIntegratio
             hasDismissedBrowserExtensionAlert,
             hasDismissedIDEExtensionAlert,
             isBrowserExtensionInstalled,
+            isUsingIDEIntegration,
         ]
     )
 

--- a/client/web/src/repo/actions/InstallIntegrationsAlert.tsx
+++ b/client/web/src/repo/actions/InstallIntegrationsAlert.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useMemo } from 'react'
 import { useLocalStorage, useObservable } from '@sourcegraph/wildcard'
 
 import { usePersistentCadence } from '../../hooks'
-import { useIsUsingIdeIntegration } from '../../IdeExtensionTracker'
+import { useIsActiveIdeIntegrationUser } from '../../IdeExtensionTracker'
 import { browserExtensionInstalled } from '../../tracking/analyticsUtils'
 import { HOVER_COUNT_KEY, HOVER_THRESHOLD } from '../RepoContainer'
 
@@ -43,7 +43,7 @@ export const InstallIntegrationsAlert: React.FunctionComponent<InstallIntegratio
         IDE_CTA_CADENCE_SHIFT
     )
     const isBrowserExtensionInstalled = useObservable<boolean>(browserExtensionInstalled)
-    const isUsingIdeIntegration = useIsUsingIdeIntegration()
+    const isUsingIdeIntegration = useIsActiveIdeIntegrationUser()
     const [hoverCount] = useLocalStorage<number>(HOVER_COUNT_KEY, 0)
     const [hasDismissedBrowserExtensionAlert, setHasDismissedBrowserExtensionAlert] = useLocalStorage<boolean>(
         HAS_DISMISSED_BROWSER_EXTENSION_ALERT_KEY,

--- a/client/web/src/repo/actions/InstallIntegrationsAlert.tsx
+++ b/client/web/src/repo/actions/InstallIntegrationsAlert.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useMemo } from 'react'
 import { useLocalStorage, useObservable } from '@sourcegraph/wildcard'
 
 import { usePersistentCadence } from '../../hooks'
-import { useIsUsingIDEIntegration } from '../../IdeExtensionTracker'
+import { useIsUsingIdeIntegration } from '../../IdeExtensionTracker'
 import { browserExtensionInstalled } from '../../tracking/analyticsUtils'
 import { HOVER_COUNT_KEY, HOVER_THRESHOLD } from '../RepoContainer'
 
@@ -43,7 +43,7 @@ export const InstallIntegrationsAlert: React.FunctionComponent<InstallIntegratio
         IDE_CTA_CADENCE_SHIFT
     )
     const isBrowserExtensionInstalled = useObservable<boolean>(browserExtensionInstalled)
-    const isUsingIDEIntegration = useIsUsingIDEIntegration()
+    const isUsingIdeIntegration = useIsUsingIdeIntegration()
     const [hoverCount] = useLocalStorage<number>(HOVER_COUNT_KEY, 0)
     const [hasDismissedBrowserExtensionAlert, setHasDismissedBrowserExtensionAlert] = useLocalStorage<boolean>(
         HAS_DISMISSED_BROWSER_EXTENSION_ALERT_KEY,
@@ -66,7 +66,7 @@ export const InstallIntegrationsAlert: React.FunctionComponent<InstallIntegratio
             }
 
             if (
-                isUsingIDEIntegration === false &&
+                isUsingIdeIntegration === false &&
                 displayIDEExtensionCTABasedOnCadence &&
                 !hasDismissedIDEExtensionAlert
             ) {
@@ -86,7 +86,7 @@ export const InstallIntegrationsAlert: React.FunctionComponent<InstallIntegratio
             hasDismissedBrowserExtensionAlert,
             hasDismissedIDEExtensionAlert,
             isBrowserExtensionInstalled,
-            isUsingIDEIntegration,
+            isUsingIdeIntegration,
         ]
     )
 

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -27,7 +27,7 @@ import { SearchBetaIcon } from '../../components/CtaIcons'
 import { PageTitle } from '../../components/PageTitle'
 import { FeatureFlagProps } from '../../featureFlags/featureFlags'
 import { usePersistentCadence } from '../../hooks'
-import { useIsUsingIdeIntegration } from '../../IdeExtensionTracker'
+import { useIsActiveIdeIntegrationUser } from '../../IdeExtensionTracker'
 import { CodeInsightsProps } from '../../insights/types'
 import { isCodeInsightsEnabled } from '../../insights/utils/is-code-insights-enabled'
 import { OnboardingTour } from '../../onboarding-tour/OnboardingTour'
@@ -106,7 +106,7 @@ function useCtaAlert(
         false
     )
     const isBrowserExtensionInstalled = useObservable<boolean>(browserExtensionInstalled)
-    const isUsingIdeIntegration = useIsUsingIdeIntegration()
+    const isUsingIdeIntegration = useIsActiveIdeIntegrationUser()
 
     const displaySignupAndBrowserExtensionCTAsBasedOnCadence = usePersistentCadence(
         CTA_ALERTS_CADENCE_KEY,

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -27,6 +27,7 @@ import { SearchBetaIcon } from '../../components/CtaIcons'
 import { PageTitle } from '../../components/PageTitle'
 import { FeatureFlagProps } from '../../featureFlags/featureFlags'
 import { usePersistentCadence } from '../../hooks'
+import { useIsUsingIDEIntegration } from '../../IdeExtensionTracker'
 import { CodeInsightsProps } from '../../insights/types'
 import { isCodeInsightsEnabled } from '../../insights/utils/is-code-insights-enabled'
 import { OnboardingTour } from '../../onboarding-tour/OnboardingTour'
@@ -105,6 +106,7 @@ function useCtaAlert(
         false
     )
     const isBrowserExtensionInstalled = useObservable<boolean>(browserExtensionInstalled)
+    const isUsingIDEIntegration = useIsUsingIDEIntegration()
 
     const displaySignupAndBrowserExtensionCTAsBasedOnCadence = usePersistentCadence(
         CTA_ALERTS_CADENCE_KEY,
@@ -134,7 +136,12 @@ function useCtaAlert(
             return 'browser'
         }
 
-        if (!hasDismissedIDEExtensionAlert && displayIDEExtensionCTABasedOnCadence) {
+        if (
+            isUsingIDEIntegration === false &&
+            displayIDEExtensionCTABasedOnCadence &&
+            !hasDismissedIDEExtensionAlert &&
+            true
+        ) {
             return 'ide'
         }
 
@@ -146,6 +153,7 @@ function useCtaAlert(
         displaySignupAndBrowserExtensionCTAsBasedOnCadence,
         hasDismissedBrowserExtensionAlert,
         isBrowserExtensionInstalled,
+        isUsingIDEIntegration,
         hasDismissedIDEExtensionAlert,
         displayIDEExtensionCTABasedOnCadence,
     ])

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -27,7 +27,7 @@ import { SearchBetaIcon } from '../../components/CtaIcons'
 import { PageTitle } from '../../components/PageTitle'
 import { FeatureFlagProps } from '../../featureFlags/featureFlags'
 import { usePersistentCadence } from '../../hooks'
-import { useIsUsingIDEIntegration } from '../../IdeExtensionTracker'
+import { useIsUsingIdeIntegration } from '../../IdeExtensionTracker'
 import { CodeInsightsProps } from '../../insights/types'
 import { isCodeInsightsEnabled } from '../../insights/utils/is-code-insights-enabled'
 import { OnboardingTour } from '../../onboarding-tour/OnboardingTour'
@@ -106,7 +106,7 @@ function useCtaAlert(
         false
     )
     const isBrowserExtensionInstalled = useObservable<boolean>(browserExtensionInstalled)
-    const isUsingIDEIntegration = useIsUsingIDEIntegration()
+    const isUsingIdeIntegration = useIsUsingIdeIntegration()
 
     const displaySignupAndBrowserExtensionCTAsBasedOnCadence = usePersistentCadence(
         CTA_ALERTS_CADENCE_KEY,
@@ -137,7 +137,7 @@ function useCtaAlert(
         }
 
         if (
-            isUsingIDEIntegration === false &&
+            isUsingIdeIntegration === false &&
             displayIDEExtensionCTABasedOnCadence &&
             !hasDismissedIDEExtensionAlert &&
             true
@@ -153,7 +153,7 @@ function useCtaAlert(
         displaySignupAndBrowserExtensionCTAsBasedOnCadence,
         hasDismissedBrowserExtensionAlert,
         isBrowserExtensionInstalled,
-        isUsingIDEIntegration,
+        isUsingIdeIntegration,
         hasDismissedIDEExtensionAlert,
         displayIDEExtensionCTABasedOnCadence,
     ])

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -136,12 +136,7 @@ function useCtaAlert(
             return 'browser'
         }
 
-        if (
-            isUsingIdeIntegration === false &&
-            displayIDEExtensionCTABasedOnCadence &&
-            !hasDismissedIDEExtensionAlert &&
-            true
-        ) {
+        if (isUsingIdeIntegration === false && displayIDEExtensionCTABasedOnCadence && !hasDismissedIDEExtensionAlert) {
             return 'ide'
         }
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/30843

We do not want to show IDE CTAs for users that we know are already users of our IDE extensions.

In discussions prior to creating this PR we [ruled out the option of using VSCE specific logs](https://github.com/sourcegraph/sourcegraph/pull/31876), most importantly because we noticed that only ~25% of our VSCE users properly have their Sourcegraph account linked (and it's unclear if this is even possible for JetBrains?).

Instead, this PR takes a different approach. We're using the fact that all links coming from an IDE extension and opening in the browser have their UTM tags added. With this we can "tag" the currently logged in user's extension usage ([or use localStorage if no one is logged in](https://docs.sourcegraph.com/dev/background-information/web/temporary_settings)).

To avoid stale data, we require a link to be opened in the last 30 days in order to count the user as an active extension user.

## Test plan

We (@vdavid and I) manually tested this by changing the conditions of the CTA banners to always render and then using the following three example links and verify they correctly store the extension usage in a user's temporary settings:

- `https://sourcegraph.test:3443/-/editor?remote_url=git%40github.com%3Asourcegraph%2Fsourcegraph-jetbrains.git&branch=main&file=src%2Fmain%2Fjava%2FOpenRevisionAction.java&editor=JetBrains&version=v1.2.2&start_row=68&start_col=26&end_row=68&end_col=26&utm_product_name=IntelliJ+IDEA&utm_product_version=2021.3.2`
- `https://sourcegraph.test:3443/-/editor?remote_url=git@github.com:sourcegraph/sourcegraph.git&branch=ps/detect-ide-extensions&file=client/web/src/tracking/util.ts&editor=VSCode&version=2.0.9&start_row=13&start_col=22&end_row=13&end_col=22&utm_campaign=vscode-extension&utm_medium=direct_traffic&utm_source=vscode-extension&utm_content=vsce-commands`
- `https://sourcegraph.test:3443/sign-up?editor=vscode&utm_medium=VSCIDE&utm_source=sidebar&utm_campaign=vsce-sign-up&utm_content=sign-up`

Additionally, we've added a test for the component:

```
α sourcegraph (ps/detect-ide-extensions)✗ yarn jest IdeExtensionTracker
yarn run v1.22.17
$ /Users/philipp/dev/sourcegraph/node_modules/.bin/jest IdeExtensionTracker
 PASS   web  client/web/src/IdeExtensionTracker.test.tsx
  IdeExtensionTracker
    ✓ Detects the proper extension for "https://sourcegraph.com/-/editor?remote_url=git%40github.com%3Asourcegraph%2Fsourcegraph-jetbrains.git&branch=main&file=src%2Fmain%2Fjava%2FOpenRevisionAction.java&editor=JetBrains&version=v1.2.2&start_row=68&start_col=26&end_row=68&end_col=26&utm_product_name=IntelliJ+IDEA&utm_product_version=2021.3.2" (13 ms)
    ✓ Detects the proper extension for "https://sourcegraph.com/-/editor?remote_url=git@github.com:sourcegraph/sourcegraph.git&branch=ps/detect-ide-extensions&file=client/web/src/tracking/util.ts&editor=VSCode&version=2.0.9&start_row=13&start_col=22&end_row=13&end_col=22&utm_campaign=vscode-extension&utm_medium=direct_traffic&utm_source=vscode-extension&utm_content=vsce-commands" (2 ms)
    ✓ Detects the proper extension for "https://sourcegraph.com/sign-up?editor=vscode&utm_medium=VSCIDE&utm_source=sidebar&utm_campaign=vsce-sign-up&utm_content=sign-up" (2 ms)
    ✓ Detects the proper extension for "https://sourcegraph.com/?something=different" (2 ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        1.009 s
Ran all test suites matching /IdeExtensionTracker/i.
✨  Done in 2.00s.
```

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


