### PR TITLE
migrator: Auto-retry to apply one failed migration in local dev

### DIFF
--- a/cmd/migrator/main.go
+++ b/cmd/migrator/main.go
@@ -52,9 +52,9 @@ func mainErr(ctx context.Context, args []string) error {
 			return flag.ErrHelp
 		},
 		Subcommands: []*ffcli.Command{
-			cliutil.Up(appName, runnerFactory, out),
-			cliutil.UpTo(appName, runnerFactory, out),
-			cliutil.DownTo(appName, runnerFactory, out),
+			cliutil.Up(appName, runnerFactory, out, false),
+			cliutil.UpTo(appName, runnerFactory, out, false),
+			cliutil.DownTo(appName, runnerFactory, out, false),
 			cliutil.Validate(appName, runnerFactory, out),
 			cliutil.AddLog(appName, runnerFactory, out),
 		},

--- a/dev/sg/sg_migration.go
+++ b/dev/sg/sg_migration.go
@@ -47,10 +47,10 @@ var (
 		LongHelp:   cliutil.ConstructLongHelp(),
 	}
 
-	upCommand       = cliutil.Up("sg migration", makeRunner, stdout.Out)
-	upToCommand     = cliutil.UpTo("sg migration", makeRunner, stdout.Out)
-	UndoCommand     = cliutil.Undo("sg migration", makeRunner, stdout.Out)
-	downToCommand   = cliutil.DownTo("sg migration", makeRunner, stdout.Out)
+	upCommand       = cliutil.Up("sg migration", makeRunner, stdout.Out, true)
+	upToCommand     = cliutil.UpTo("sg migration", makeRunner, stdout.Out, true)
+	UndoCommand     = cliutil.Undo("sg migration", makeRunner, stdout.Out, true)
+	downToCommand   = cliutil.DownTo("sg migration", makeRunner, stdout.Out, true)
 	validateCommand = cliutil.Validate("sg validate", makeRunner, stdout.Out)
 	addLogCommand   = cliutil.AddLog("sg migration", makeRunner, stdout.Out)
 

--- a/internal/database/migration/cliutil/downto.go
+++ b/internal/database/migration/cliutil/downto.go
@@ -13,12 +13,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
-func DownTo(commandName string, factory RunnerFactory, out *output.Output) *ffcli.Command {
+func DownTo(commandName string, factory RunnerFactory, out *output.Output, development bool) *ffcli.Command {
 	var (
-		flagSet              = flag.NewFlagSet(fmt.Sprintf("%s downto", commandName), flag.ExitOnError)
-		schemaNameFlag       = flagSet.String("db", "", `The target schema to modify.`)
-		unprivilegedOnlyFlag = flagSet.Bool("unprivileged-only", false, `Do not apply privileged migrations.`)
-		targetsFlag          = flagSet.String("target", "", "Revert all children of the given target. Comma-separated values are accepted.")
+		flagSet                  = flag.NewFlagSet(fmt.Sprintf("%s downto", commandName), flag.ExitOnError)
+		schemaNameFlag           = flagSet.String("db", "", `The target schema to modify.`)
+		unprivilegedOnlyFlag     = flagSet.Bool("unprivileged-only", false, `Do not apply privileged migrations.`)
+		ignoreSingleDirtyLogFlag = flagSet.Bool("ignore-single-dirty-log", development, `Ignore a previously failed attempt if it will be immediately retried by this operation.`)
+		targetsFlag              = flagSet.String("target", "", "Revert all children of the given target. Comma-separated values are accepted.")
 	)
 
 	exec := func(ctx context.Context, args []string) error {
@@ -61,7 +62,8 @@ func DownTo(commandName string, factory RunnerFactory, out *output.Output) *ffcl
 					TargetVersions: versions,
 				},
 			},
-			UnprivilegedOnly: *unprivilegedOnlyFlag,
+			UnprivilegedOnly:     *unprivilegedOnlyFlag,
+			IgnoreSingleDirtyLog: *ignoreSingleDirtyLogFlag,
 		})
 	}
 

--- a/internal/database/migration/cliutil/undo.go
+++ b/internal/database/migration/cliutil/undo.go
@@ -11,10 +11,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
-func Undo(commandName string, factory RunnerFactory, out *output.Output) *ffcli.Command {
+func Undo(commandName string, factory RunnerFactory, out *output.Output, development bool) *ffcli.Command {
 	var (
-		flagSet        = flag.NewFlagSet(fmt.Sprintf("%s undo", commandName), flag.ExitOnError)
-		schemaNameFlag = flagSet.String("db", "", `The target schema to modify.`)
+		flagSet                  = flag.NewFlagSet(fmt.Sprintf("%s undo", commandName), flag.ExitOnError)
+		schemaNameFlag           = flagSet.String("db", "", `The target schema to modify.`)
+		ignoreSingleDirtyLogFlag = flagSet.Bool("ignore-single-dirty-log", development, `Ignore a previously failed attempt if it will be immediately retried by this operation.`)
 	)
 
 	exec := func(ctx context.Context, args []string) error {
@@ -40,6 +41,7 @@ func Undo(commandName string, factory RunnerFactory, out *output.Output) *ffcli.
 					Type:       runner.MigrationOperationTypeRevert,
 				},
 			},
+			IgnoreSingleDirtyLog: *ignoreSingleDirtyLogFlag,
 		})
 	}
 

--- a/internal/database/migration/cliutil/up.go
+++ b/internal/database/migration/cliutil/up.go
@@ -14,11 +14,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
-func Up(commandName string, factory RunnerFactory, out *output.Output) *ffcli.Command {
+func Up(commandName string, factory RunnerFactory, out *output.Output, development bool) *ffcli.Command {
 	var (
-		flagSet              = flag.NewFlagSet(fmt.Sprintf("%s up", commandName), flag.ExitOnError)
-		schemaNameFlag       = flagSet.String("db", "all", `The target schema(s) to modify. Comma-separated values are accepted. Supply "all" (the default) to migrate all schemas.`)
-		unprivilegedOnlyFlag = flagSet.Bool("unprivileged-only", false, `Do not apply privileged migrations.`)
+		flagSet                  = flag.NewFlagSet(fmt.Sprintf("%s up", commandName), flag.ExitOnError)
+		schemaNameFlag           = flagSet.String("db", "all", `The target schema(s) to modify. Comma-separated values are accepted. Supply "all" (the default) to migrate all schemas.`)
+		unprivilegedOnlyFlag     = flagSet.Bool("unprivileged-only", false, `Do not apply privileged migrations.`)
+		ignoreSingleDirtyLogFlag = flagSet.Bool("ignore-single-dirty-log", development, `Ignore a previously failed attempt if it will be immediately retried by this operation.`)
 	)
 
 	exec := func(ctx context.Context, args []string) error {
@@ -51,8 +52,9 @@ func Up(commandName string, factory RunnerFactory, out *output.Output) *ffcli.Co
 		}
 
 		return r.Run(ctx, runner.Options{
-			Operations:       operations,
-			UnprivilegedOnly: *unprivilegedOnlyFlag,
+			Operations:           operations,
+			UnprivilegedOnly:     *unprivilegedOnlyFlag,
+			IgnoreSingleDirtyLog: *ignoreSingleDirtyLogFlag,
 		})
 	}
 

--- a/internal/database/migration/cliutil/upto.go
+++ b/internal/database/migration/cliutil/upto.go
@@ -13,12 +13,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
-func UpTo(commandName string, factory RunnerFactory, out *output.Output) *ffcli.Command {
+func UpTo(commandName string, factory RunnerFactory, out *output.Output, development bool) *ffcli.Command {
 	var (
-		flagSet              = flag.NewFlagSet(fmt.Sprintf("%s upto", commandName), flag.ExitOnError)
-		schemaNameFlag       = flagSet.String("db", "", `The target schema to modify.`)
-		unprivilegedOnlyFlag = flagSet.Bool("unprivileged-only", false, `Do not apply privileged migrations.`)
-		targetsFlag          = flagSet.String("target", "", "The migration to apply. Comma-separated values are accepted.")
+		flagSet                  = flag.NewFlagSet(fmt.Sprintf("%s upto", commandName), flag.ExitOnError)
+		schemaNameFlag           = flagSet.String("db", "", `The target schema to modify.`)
+		unprivilegedOnlyFlag     = flagSet.Bool("unprivileged-only", false, `Do not apply privileged migrations.`)
+		ignoreSingleDirtyLogFlag = flagSet.Bool("ignore-single-dirty-log", development, `Ignore a previously failed attempt if it will be immediately retried by this operation.`)
+		targetsFlag              = flagSet.String("target", "", "The migration to apply. Comma-separated values are accepted.")
 	)
 
 	exec := func(ctx context.Context, args []string) error {
@@ -61,7 +62,8 @@ func UpTo(commandName string, factory RunnerFactory, out *output.Output) *ffcli.
 					TargetVersions: versions,
 				},
 			},
-			UnprivilegedOnly: *unprivilegedOnlyFlag,
+			UnprivilegedOnly:     *unprivilegedOnlyFlag,
+			IgnoreSingleDirtyLog: *ignoreSingleDirtyLogFlag,
 		})
 	}
 

--- a/internal/database/migration/runner/options.go
+++ b/internal/database/migration/runner/options.go
@@ -17,6 +17,12 @@ type Options struct {
 	// credentials, or if an error should be printed so the site admin can apply manulaly the
 	// privileged migration file with a superuser.
 	UnprivilegedOnly bool
+
+	// IgnoreSingleDirtyLog controls whether or not to ignore a dirty database in the specific
+	// case when the _next_ migration application is the only failure. This is meant to enable
+	// a short development loop where the user can re-apply the `up` command without having to
+	// create a dummy migration log to proceed.
+	IgnoreSingleDirtyLog bool
 }
 
 type MigrationOperation struct {

--- a/internal/database/migration/runner/run.go
+++ b/internal/database/migration/runner/run.go
@@ -38,7 +38,13 @@ func (r *Runner) Run(ctx context.Context, options Options) error {
 		semaphore <- struct{}{}
 		defer func() { <-semaphore }()
 
-		if err := r.runSchema(ctx, operationMap[schemaName], schemaContext, options.UnprivilegedOnly); err != nil {
+		if err := r.runSchema(
+			ctx,
+			operationMap[schemaName],
+			schemaContext,
+			options.UnprivilegedOnly,
+			options.IgnoreSingleDirtyLog,
+		); err != nil {
 			return errors.Wrapf(err, "failed to run migration for schema %q", schemaName)
 		}
 
@@ -50,7 +56,13 @@ func (r *Runner) Run(ctx context.Context, options Options) error {
 // method will attempt to coordinate with other concurrently running instances and may block while
 // attempting to acquire a lock. An error is returned only if user intervention is deemed a necessity,
 // the "dirty database" condition, or on context cancellation.
-func (r *Runner) runSchema(ctx context.Context, operation MigrationOperation, schemaContext schemaContext, unprivilegedOnly bool) error {
+func (r *Runner) runSchema(
+	ctx context.Context,
+	operation MigrationOperation,
+	schemaContext schemaContext,
+	unprivilegedOnly bool,
+	ignoreSingleDirtyLog bool,
+) error {
 	// First, rewrite operations into a smaller set of operations we'll handle below. This call converts
 	// upgrade and revert operations into targeted up and down operations.
 	operation, err := desugarOperation(schemaContext, operation)
@@ -123,7 +135,14 @@ func (r *Runner) runSchema(ctx context.Context, operation MigrationOperation, sc
 		// Therefore, some invocations of this method will return with a flag to request re-invocation under a
 		// new lock.
 
-		if retry, err := r.applyMigrations(ctx, operation, schemaContext, definitions, unprivilegedOnly); err != nil {
+		if retry, err := r.applyMigrations(
+			ctx,
+			operation,
+			schemaContext,
+			definitions,
+			unprivilegedOnly,
+			ignoreSingleDirtyLog,
+		); err != nil {
 			return err
 		} else if !retry {
 			break
@@ -148,6 +167,7 @@ func (r *Runner) applyMigrations(
 	schemaContext schemaContext,
 	definitions []definition.Definition,
 	unprivilegedOnly bool,
+	ignoreSingleDirtyLog bool,
 ) (retry bool, _ error) {
 	var (
 		droppedLock bool
@@ -192,7 +212,7 @@ func (r *Runner) applyMigrations(
 		return nil
 	}
 
-	if retry, err := r.withLockedSchemaState(ctx, schemaContext, definitions, callback); err != nil {
+	if retry, err := r.withLockedSchemaState(ctx, schemaContext, definitions, ignoreSingleDirtyLog, callback); err != nil {
 		return false, err
 	} else if retry {
 		// There are active index creation operations ongoing; wait a short time before requerying

--- a/internal/database/migration/runner/run_test.go
+++ b/internal/database/migration/runner/run_test.go
@@ -136,6 +136,22 @@ func TestRun(t *testing.T) {
 		}
 	})
 
+	t.Run("upgrade (dirty database, ignore single dirty log)", func(t *testing.T) {
+		store := testStoreWithVersion(10003, true)
+
+		if err := makeTestRunner(t, store).Run(ctx, Options{
+			Operations: []MigrationOperation{
+				{
+					SchemaName: "well-formed",
+					Type:       MigrationOperationTypeUpgrade,
+				},
+			},
+			IgnoreSingleDirtyLog: true,
+		}); err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+	})
+
 	t.Run("upgrade (dirty database/dead migrations)", func(t *testing.T) {
 		store := testStoreWithVersion(10003, true)
 		store.VersionsFunc.SetDefaultReturn(nil, []int{10003}, nil, nil)

--- a/internal/database/migration/runner/validate.go
+++ b/internal/database/migration/runner/validate.go
@@ -92,7 +92,7 @@ func (r *Runner) validateSchema(ctx context.Context, schemaContext schemaContext
 // validateDefinitions attempts to take an advisory lock, then re-checks the version of the database.
 // If there are still migrations to apply from the given definitions, an error is returned.
 func (r *Runner) validateDefinitions(ctx context.Context, schemaContext schemaContext, definitions []definition.Definition) (retry bool, _ error) {
-	return r.withLockedSchemaState(ctx, schemaContext, definitions, func(schemaVersion schemaVersion, byState definitionsByState, _ unlockFunc) error {
+	return r.withLockedSchemaState(ctx, schemaContext, definitions, false, func(schemaVersion schemaVersion, byState definitionsByState, _ unlockFunc) error {
 		if len(byState.applied) != len(definitions) {
 			// Return an error if all expected schemas have not been applied
 			return newOutOfDateError(schemaContext, schemaVersion)


### PR DESCRIPTION
Do not complain about a dirty database in local dev if the next migration to apply is the only failure. This allows developers to  locally fix an error in a migration file without having to jump through hoops to remove the failed migration log.

## Test plan

Existing unit and integration tests.