### PR TITLE
dev/sg: remove deprecated check comand

### DIFF
--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -62,7 +62,6 @@ var (
 			setupCommand,
 			opsCommand,
 			lintCommand,
-			checkCommand, // TODO remove after a while
 			dbCommand,
 			updateCommand,
 		},

--- a/dev/sg/sg_lint.go
+++ b/dev/sg/sg_lint.go
@@ -91,34 +91,24 @@ var allLintTargets = lintTargets{
 	},
 }
 
-var (
-	lintCommand = &ffcli.Command{
-		Name:       "lint",
-		ShortUsage: "sg lint [target]",
-		ShortHelp:  "Run all or specified linter on the codebase.",
-		LongHelp:   `Run all or specified linter on the codebase and display failures, if any. To run all checks, don't provide an argument.`,
-		FlagSet:    lintFlagSet,
-		Exec: func(ctx context.Context, args []string) error {
-			if len(args) > 0 {
-				return errors.New("unrecognized command, please run 'sg lint --help' to list available linters")
-			}
-			var fns []lintFunc
-			for _, c := range allLintTargets {
-				fns = append(fns, c.Linters...)
-			}
-			return runCheckScriptsAndReport(fns...)(ctx, args)
-		},
-		Subcommands: allLintTargets.Commands(),
-	}
-	// TODO remove after a while
-	checkCommand = &ffcli.Command{
-		Name:      "check",
-		ShortHelp: "DEPRECATED: use 'sg lint' instead",
-		Exec: func(context.Context, []string) error {
-			return errors.New("'sg check' is deprecated - use 'sg lint' instead")
-		},
-	}
-)
+var lintCommand = &ffcli.Command{
+	Name:       "lint",
+	ShortUsage: "sg lint [target]",
+	ShortHelp:  "Run all or specified linter on the codebase.",
+	LongHelp:   `Run all or specified linter on the codebase and display failures, if any. To run all checks, don't provide an argument.`,
+	FlagSet:    lintFlagSet,
+	Exec: func(ctx context.Context, args []string) error {
+		if len(args) > 0 {
+			return errors.New("unrecognized command, please run 'sg lint --help' to list available linters")
+		}
+		var fns []lintFunc
+		for _, c := range allLintTargets {
+			fns = append(fns, c.Linters...)
+		}
+		return runCheckScriptsAndReport(fns...)(ctx, args)
+	},
+	Subcommands: allLintTargets.Commands(),
+}
 
 type lintFunc func(context.Context) *lintReport
 


### PR DESCRIPTION
This was deprecated last week in https://github.com/sourcegraph/sourcegraph/pull/31891 , where I set a calendar reminder to remove this today.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

n/a