### PR TITLE
go.mod: bump zoekt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -398,7 +398,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20220211090549-756e833d8ebe
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20220304131919-8e025c4a0e94
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20211110092431-863f5b1ee51b

--- a/go.sum
+++ b/go.sum
@@ -1991,7 +1991,6 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d h1:yKm7XZV6j9
 github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:UdhH50NIW0fCiwBSr0co2m7BnFLdv4fQTgdqdJTHFeE=
 github.com/sourcegraph/ctxvfs v0.0.0-20180418081416-2b65f1b1ea81 h1:v4/JVxZSPWifxmICRqgXK7khThjw03RfdGhyeA2S4EQ=
 github.com/sourcegraph/ctxvfs v0.0.0-20180418081416-2b65f1b1ea81/go.mod h1:xIvvI5FiHLxhv8prbzVpaMHaaGPFPFQSuTcxC91ryOo=
-github.com/sourcegraph/go-ctags v0.0.0-20220210084826-96f4236f0a78 h1:DY/m+6+PnBz49fMU7rE+DfPf09QYgO1RLPDeJ/1BY9w=
 github.com/sourcegraph/go-ctags v0.0.0-20220210084826-96f4236f0a78/go.mod h1:ZYjpRXoJrRlxjU9ZfpaUKJkk62AjhJPffN3rlw2aqxM=
 github.com/sourcegraph/go-ctags v0.0.0-20220221141751-78951a22ec08 h1:cuI0tTyrf6sS2TXh2OJHEKLfpDM7K4V360X9bU+3l0k=
 github.com/sourcegraph/go-ctags v0.0.0-20220221141751-78951a22ec08/go.mod h1:ZYjpRXoJrRlxjU9ZfpaUKJkk62AjhJPffN3rlw2aqxM=
@@ -2021,8 +2020,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20220211090549-756e833d8ebe h1:Eh4QsOq1jXT3RCwflCxHIGGvFEylFYoqZnxiK2ED1wo=
-github.com/sourcegraph/zoekt v0.0.0-20220211090549-756e833d8ebe/go.mod h1:7ch4x99rdVR1l7wn4D/LIK4q+0bkXhJUC8C37QISsDY=
+github.com/sourcegraph/zoekt v0.0.0-20220304131919-8e025c4a0e94 h1:OaWanWUGnmf8Mi8arZ3A/E8utqEXqbQ2tIsX5fDsZ+4=
+github.com/sourcegraph/zoekt v0.0.0-20220304131919-8e025c4a0e94/go.mod h1:SfsXv9hUd4wJv9/h4J16OxEv7k0r/6YtoLLePkKIQZI=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
- 8e025c4 debug: remove "debug find"
- 4a774cf explode: delete input shard first
- 7bfb736 zoekt-mirror-gerrit: fix typo
- 300e175 zoekt-mirror: allow to index only active projects
- 7dc4539 zoekt-mirror-gerrit: fix issue when anonymous http is disabled on Gerrit
- 321d522 builder: implement basic delta shard functioanlity
- f150b3a ctags: only include log output for debug
- 781cfea merging: tolerate process interruptions during merging
- 881cec1 indexserver: add debug subcommand
- 27375b3 indexserver: remove deprecated GetIndexOptions
- 1210f0f webserver: remove kubernetes sd drain time
- b5c8272 indexserver: remove atomics for fingerprint
- 0316d52 shardedSearcher - implement functionality for filetombstones
- 8082708 all: switch to RFC3339 for timestamps in log files
- 9d43e8e merging: add unit test for explode
- 39b2af4 merging: support exploding compound shards


## Test plan
This is already rolled out to production. This PR just aligns the repo with deploy-sourcegraph-cloud.
