### PR TITLE
rockskip: Small optimization for AppendHop

### DIFF
--- a/enterprise/internal/rockskip/index.go
+++ b/enterprise/internal/rockskip/index.go
@@ -106,12 +106,12 @@ func (s *Service) Index(ctx context.Context, repo, givenCommit string) (err erro
 		}
 
 		tasklog.Start("AppendHop+")
-		err = AppendHop(ctx, tx, repoId, hops[0:r], AddedAD, commit)
+		err = AppendHop(ctx, tx, repoId, hops[0:r], AddedAD, DeletedAD, commit)
 		if err != nil {
 			return errors.Wrap(err, "AppendHop (added)")
 		}
 		tasklog.Start("AppendHop-")
-		err = AppendHop(ctx, tx, repoId, hops[0:r], DeletedAD, commit)
+		err = AppendHop(ctx, tx, repoId, hops[0:r], DeletedAD, AddedAD, commit)
 		if err != nil {
 			return errors.Wrap(err, "AppendHop (deleted)")
 		}


### PR DESCRIPTION
I realized `AppendHop` doesn't need to touch symbols that were deleted (and vice versa for added).

I thought this would increase the speed by a lot, so it seemed worth trying, but it turned out to only be a 10% improvement.

## Test plan

Automated Go tests
