### PR TITLE
search: Add keybindings to Notepad open state

### DIFF
--- a/client/web/src/search/SearchStack.module.scss
+++ b/client/web/src/search/SearchStack.module.scss
@@ -42,10 +42,6 @@
         overflow-wrap: anywhere;
         background-color: var(--color-bg-);
 
-        &:hover {
-            background-color: var(--color-bg-2);
-        }
-
         &.selected {
             background-color: var(--color-bg-3);
         }

--- a/client/web/src/search/SearchStack.test.tsx
+++ b/client/web/src/search/SearchStack.test.tsx
@@ -318,6 +318,120 @@ describe('Search Stack', () => {
             expect(screen.queryAllByRole('option', { selected: true })).toEqual(item)
         })
 
+        it('selects all items on ctrl+a', () => {
+            renderSearchStack()
+            open()
+
+            const list = screen.getByRole('listbox')
+            const items = screen.getAllByRole('option')
+
+            list.focus()
+            userEvent.keyboard('{ctrl}{a}')
+            expect(screen.queryAllByRole('option', { selected: true })).toEqual(items)
+        })
+
+        it('selects the next item on arrow-down', () => {
+            renderSearchStack()
+            open()
+
+            const list = screen.getByRole('listbox')
+            const items = screen.getAllByRole('option')
+
+            list.focus()
+            userEvent.keyboard('{arrowdown}')
+            expect(screen.queryAllByRole('option', { selected: true })).toEqual([items[0]])
+
+            userEvent.keyboard('{arrowdown}')
+            expect(screen.queryAllByRole('option', { selected: true })).toEqual([items[1]])
+        })
+
+        it('selects the previous item on arrow-up', () => {
+            renderSearchStack()
+            open()
+
+            const list = screen.getByRole('listbox')
+            const items = screen.getAllByRole('option')
+
+            list.focus()
+            userEvent.keyboard('{arrowup}')
+            expect(screen.queryAllByRole('option', { selected: true })).toEqual([items[3]])
+
+            userEvent.keyboard('{arrowup}')
+            expect(screen.queryAllByRole('option', { selected: true })).toEqual([items[2]])
+        })
+
+        it('extends/shrinks selection on shift+arrow-down/up', () => {
+            renderSearchStack()
+            open()
+
+            const list = screen.getByRole('listbox')
+            const items = screen.getAllByRole('option')
+
+            list.focus()
+            userEvent.keyboard('{arrowdown}')
+            userEvent.keyboard('{shift}{arrowdown}')
+            expect(screen.queryAllByRole('option', { selected: true })).toEqual([items[0], items[1]])
+
+            userEvent.keyboard('{shift}{arrowup}')
+            expect(screen.queryAllByRole('option', { selected: true })).toEqual([items[0]])
+        })
+
+        it('skips over selected entries using shift+arrow-down', () => {
+            renderSearchStack()
+            open()
+
+            const items = screen.getAllByRole('option')
+
+            userEvent.click(items[2], { ctrlKey: true }) // select 3. item
+            userEvent.click(items[0], { ctrlKey: true }) // select 1. item
+
+            userEvent.keyboard('{shift}{arrowdown}') // selects 2. item
+            userEvent.keyboard('{shift}{arrowdown}') // selects 4. item
+
+            expect(screen.queryAllByRole('option', { selected: true })).toEqual([
+                items[0],
+                items[1],
+                items[2],
+                items[3],
+            ])
+        })
+
+        it('skips over selected entries using shift+arrow-up', () => {
+            renderSearchStack()
+            open()
+
+            const items = screen.getAllByRole('option')
+
+            userEvent.click(items[1], { ctrlKey: true }) // select 2. item
+            userEvent.click(items[3], { ctrlKey: true }) // select 4. item
+
+            userEvent.keyboard('{shift}{arrowdown}') // selects 3. item
+            userEvent.keyboard('{shift}{arrowdown}') // selects 1. item
+
+            expect(screen.queryAllByRole('option', { selected: true })).toEqual([
+                items[0],
+                items[1],
+                items[2],
+                items[3],
+            ])
+        })
+
+        it('extends/shrinks selection on shift+arrow-up/down', () => {
+            renderSearchStack()
+            open()
+
+            const list = screen.getByRole('listbox')
+            const items = screen.getAllByRole('option')
+
+            list.focus()
+            userEvent.keyboard('{arrowup}')
+            userEvent.keyboard('{shift}{arrowup}')
+            expect(screen.queryAllByRole('option', { selected: true })).toEqual([items[2], items[3]])
+
+            userEvent.keyboard('{shift}{arrowdown}')
+            expect(screen.queryAllByRole('option', { selected: true })).toEqual([items[3]])
+        })
+
         it('deletes all selected entries', () => {
             renderSearchStack()
             open()
@@ -328,6 +442,30 @@ describe('Search Stack', () => {
             userEvent.click(screen.queryAllByRole('button', { name: 'Remove all selected entries' })[0])
 
             expect(screen.queryAllByRole('option').length).toBe(1)
+        })
+
+        it('deletes all selected entries when Delete is pressed', () => {
+            renderSearchStack()
+            open()
+
+            const item = screen.getAllByRole('option')
+            userEvent.click(item[0])
+            userEvent.click(item[2], { shiftKey: true })
+            userEvent.keyboard('{delete}')
+
+            expect(screen.queryAllByRole('option').length).toBe(1)
+        })
+
+        it('clears selection on ESC', () => {
+            renderSearchStack()
+            open()
+
+            const item = screen.getAllByRole('option')
+            userEvent.click(item[0])
+            expect(screen.queryAllByRole('option', { selected: true }).length).toBe(1)
+
+            userEvent.keyboard('{escape}')
+            expect(screen.queryAllByRole('option', { selected: true }).length).toBe(0)
         })
 
         it('does not select entry on toggle annotion click', () => {

--- a/client/web/src/search/SearchStack.tsx
+++ b/client/web/src/search/SearchStack.tsx
@@ -195,7 +195,7 @@ export const SearchStack: React.FunctionComponent<{ initialOpen?: boolean }> = (
                         setSelectedEntries(reversedEntries.map((_value, index) => index))
                     }
                     break
-                // Clear entry selection
+                // Clear selection
                 case 'Escape':
                     if (selectedEntries.length > 0) {
                         setSelectedEntries([])
@@ -208,7 +208,7 @@ export const SearchStack: React.FunctionComponent<{ initialOpen?: boolean }> = (
                         deleteSelectedEntries()
                     }
                     break
-                // Select next entry
+                // Select "next" entry
                 case 'ArrowUp':
                 case 'ArrowDown': {
                     const { shiftKey, key } = event
@@ -285,7 +285,7 @@ export const SearchStack: React.FunctionComponent<{ initialOpen?: boolean }> = (
                         <CloseIcon className="icon-inline" />
                     </Button>
                 </div>
-                <ul role="listbox" onKeyDown={handleKey}>
+                <ul role="listbox" aria-multiselectable={true} onKeyDown={handleKey} tabIndex={0}>
                     <li className="d-flex flex-column">{addableEntry && <AddEntryButton entry={addableEntry} />}</li>
                     {reversedEntries.map((entry, index) => {
                         const selected = selectedEntries.includes(index)

--- a/client/web/src/search/SearchStack.tsx
+++ b/client/web/src/search/SearchStack.tsx
@@ -191,13 +191,12 @@ export const SearchStack: React.FunctionComponent<{ initialOpen?: boolean }> = (
     // Handles key events on the whole list
     const handleKey = useCallback(
         (event: KeyboardEvent): void => {
-            const macMeta = isMacPlatform_ && event.metaKey
-            const otherMeta = !isMacPlatform_ && event.ctrlKey
+            const hasMeta = (isMacPlatform_ && event.metaKey) || (!isMacPlatform_ && event.ctrlKey)
 
             switch (event.key) {
                 // Select all entries
                 case 'a':
-                    if (macMeta || otherMeta) {
+                    if (hasMeta) {
                         // This prevents text selection
                         event.preventDefault()
                         setSelectedEntries(reversedEntries.map((_value, index) => index))
@@ -227,7 +226,7 @@ export const SearchStack: React.FunctionComponent<{ initialOpen?: boolean }> = (
                     }
 
                     setSelectedEntries(selection => {
-                        if (shiftKey || macMeta || otherMeta) {
+                        if (shiftKey || hasMeta) {
                             // Extend (or shrink) selected entries range
                             // Shift and ctrl modifier are equivalent in this scenario
                             return growOrShrinkSelection(

--- a/client/web/src/search/SearchStack.tsx
+++ b/client/web/src/search/SearchStack.tsx
@@ -20,6 +20,7 @@ import React, {
 } from 'react'
 import { useHistory } from 'react-router-dom'
 
+import { isMacPlatform } from '@sourcegraph/common'
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { IHighlightLineRange } from '@sourcegraph/shared/src/schema'
@@ -42,7 +43,6 @@ import {
     SearchStackEntryInput,
     addSearchStackEntry,
     setEntryAnnotation,
-    SearchStackEntryID,
 } from '../stores/searchStack'
 
 import styles from './SearchStack.module.scss'
@@ -54,7 +54,7 @@ const SEARCH_STACK_ID = 'search:search-stack'
  * stack entries are selected with Shift+click.
  * (tested in Firefox and Chromium)
  */
-function preventTextSelection(event: MouseEvent): void {
+function preventTextSelection(event: MouseEvent | KeyboardEvent): void {
     if (event.shiftKey) {
         event.preventDefault()
     }
@@ -84,76 +84,57 @@ export const SearchStack: React.FunctionComponent<{ initialOpen?: boolean }> = (
     const entries = useSearchStackState(state => state.entries)
     const canRestore = useSearchStackState(state => state.canRestoreSession)
     const enableSearchStack = useExperimentalFeatures(features => features.enableSearchStack)
-    const [selectedEntries, setSelectedEntries] = useState<SearchStackEntryID[]>([])
+    const [selectedEntries, setSelectedEntries] = useState<number[]>([])
+    const isMacPlatform_ = useMemo(isMacPlatform, [])
 
     const reversedEntries = useMemo(() => [...entries].reverse(), [entries])
     const hasNewEntry = useHasNewEntry(reversedEntries)
 
     const toggleSelectedEntry = useCallback(
-        (entry: SearchStackEntry, event: MouseEvent | KeyboardEvent) => {
+        (position: number, event: MouseEvent | KeyboardEvent) => {
             const { ctrlKey, metaKey, shiftKey } = event
 
             setSelectedEntries(selectedEntries => {
-                const index = selectedEntries.indexOf(entry.id)
-
-                if (ctrlKey || metaKey) {
-                    // Add or remove item to selection
-                    if (index > -1) {
-                        const copy = selectedEntries.slice()
-                        copy.splice(index, 1)
-                        return copy
-                    }
-                    return [...selectedEntries, entry.id]
-                }
-
                 if (shiftKey) {
-                    // Select range. This will always add items.
-                    // The range of entries is always computed from the last
-                    // selected entry.
-                    if (selectedEntries.length === 0) {
-                        return [entry.id]
-                    }
-
-                    const newSelectedEntries = [...selectedEntries]
-
-                    const lastSelectedID = selectedEntries[selectedEntries.length - 1]
-                    // Find all entries between this one the selected entry
-                    const indexA = reversedEntries.findIndex(entry => entry.id === lastSelectedID)
-                    const indexB = reversedEntries.indexOf(entry)
-                    const direction = indexA > indexB ? -1 : 1
-                    for (let index_ = indexA; index_ !== indexB + direction; index_ += direction) {
-                        // Re-arrange selected entries as necessary
-                        const existingSelectionIndex = newSelectedEntries.indexOf(reversedEntries[index_].id)
-                        if (existingSelectionIndex > -1) {
-                            newSelectedEntries.splice(existingSelectionIndex, 1)
-                        }
-                        newSelectedEntries.push(reversedEntries[index_].id)
-                    }
-                    return newSelectedEntries
+                    // Select range. The range of entries is always computed
+                    // from the last selected entry.
+                    return extendSelection(selectedEntries, position)
                 }
 
-                // Normal (de)selection
-                if (index > -1) {
-                    // If multiple entries are selected then selecting
-                    // (without ctrl/cmd/shift) an already selected entry will
-                    // just select that entry.
-                    if (selectedEntries.length > 1) {
-                        return [entry.id]
-                    }
-                    // Otherwise we delesect it.
-                    return []
-                }
-
-                return [entry.id]
+                // Normal (de)selection, taking into account modifier keys for
+                // multiple selection.
+                // If multiple entries are selected then selecting
+                // (without ctrl/cmd/shift) an already selected entry will
+                // just select that entry.
+                return toggleSelection(
+                    selectedEntries,
+                    position,
+                    (isMacPlatform_ && metaKey) || (!isMacPlatform_ && ctrlKey)
+                )
             })
         },
-        [reversedEntries, setSelectedEntries]
+        [setSelectedEntries, isMacPlatform_]
     )
 
     const deleteSelectedEntries = useCallback(() => {
-        removeFromSearchStack(selectedEntries)
-        setSelectedEntries([])
-    }, [selectedEntries, setSelectedEntries])
+        if (selectedEntries.length > 0) {
+            const entryIDs = selectedEntries.map(index => reversedEntries[index].id)
+            removeFromSearchStack(entryIDs)
+            // Clear selection for now.
+            setSelectedEntries([])
+        }
+    }, [reversedEntries, selectedEntries, setSelectedEntries])
+
+    const deleteEntry = useCallback(
+        (toDelete: SearchStackEntry) => {
+            if (selectedEntries.length > 0) {
+                const entryPosition = reversedEntries.findIndex(entry => entry.id === toDelete.id)
+                setSelectedEntries(selection => adjustSelection(selection, entryPosition))
+            }
+            removeFromSearchStack([toDelete.id])
+        },
+        [reversedEntries, selectedEntries, setSelectedEntries]
+    )
 
     const createNotebook = useCallback(() => {
         const blocks: BlockInput[] = []
@@ -199,6 +180,78 @@ export const SearchStack: React.FunctionComponent<{ initialOpen?: boolean }> = (
         })
     }, [setSelectedEntries, setOpen])
 
+    // Handles key events on the whole list
+    const handleKey = useCallback(
+        (event: KeyboardEvent): void => {
+            const macMeta = isMacPlatform_ && event.metaKey
+            const otherMeta = !isMacPlatform_ && event.ctrlKey
+
+            switch (event.key) {
+                // Select all entries
+                case 'a':
+                    if (macMeta || otherMeta) {
+                        // This prevents text selection
+                        event.preventDefault()
+                        setSelectedEntries(reversedEntries.map((_value, index) => index))
+                    }
+                    break
+                // Clear entry selection
+                case 'Escape':
+                    if (selectedEntries.length > 0) {
+                        setSelectedEntries([])
+                    }
+                    break
+                // Delete selected entries
+                case 'Delete':
+                case 'Backspace':
+                    if (selectedEntries.length > 0) {
+                        deleteSelectedEntries()
+                    }
+                    break
+                // Select next entry
+                case 'ArrowUp':
+                case 'ArrowDown': {
+                    const { shiftKey, key } = event
+
+                    if (shiftKey) {
+                        // This prevents text selection
+                        event.preventDefault()
+                    }
+
+                    setSelectedEntries(selection => {
+                        if (shiftKey || macMeta || otherMeta) {
+                            // Extend (or shrink) selected entries range
+                            // Shift and ctrl modifier are equivalent in this scenario
+                            return growOrShrinkSelection(
+                                selection,
+                                key === 'ArrowDown' ? 'DOWN' : 'UP',
+                                reversedEntries.length
+                            )
+                        }
+                        if (selection.length > 0) {
+                            // Select next entry
+                            return toggleSelection(
+                                selection,
+                                wrapPosition(
+                                    selection[selection.length - 1] + (key === 'ArrowDown' ? 1 : -1),
+                                    reversedEntries.length
+                                )
+                            )
+                        }
+                        if (reversedEntries.length > 0) {
+                            // Select default (bottom or top) entry
+                            return [key === 'ArrowDown' ? 0 : reversedEntries.length - 1]
+                        }
+
+                        return selection
+                    })
+                    break
+                }
+            }
+        },
+        [reversedEntries, selectedEntries, deleteSelectedEntries, isMacPlatform_]
+    )
+
     if (!enableSearchStack || (reversedEntries.length === 0 && !addableEntry)) {
         return null
     }
@@ -232,18 +285,19 @@ export const SearchStack: React.FunctionComponent<{ initialOpen?: boolean }> = (
                         <CloseIcon className="icon-inline" />
                     </Button>
                 </div>
-                <ul role="listbox">
+                <ul role="listbox" onKeyDown={handleKey}>
                     <li className="d-flex flex-column">{addableEntry && <AddEntryButton entry={addableEntry} />}</li>
                     {reversedEntries.map((entry, index) => {
-                        const selected = selectedEntries.includes(entry.id)
+                        const selected = selectedEntries.includes(index)
                         return (
                             <li
                                 key={entry.id}
                                 role="option"
-                                onClick={event => toggleSelectedEntry(entry, event)}
-                                onKeyUp={event => {
+                                onClick={event => toggleSelectedEntry(index, event)}
+                                onKeyDown={event => {
                                     if (document.activeElement === event.currentTarget && event.key === ' ') {
-                                        toggleSelectedEntry(entry, event)
+                                        event.stopPropagation()
+                                        toggleSelectedEntry(index, event)
                                     }
                                 }}
                                 aria-selected={selected}
@@ -255,7 +309,7 @@ export const SearchStack: React.FunctionComponent<{ initialOpen?: boolean }> = (
                                     entry={entry}
                                     focus={hasNewEntry && index === 0}
                                     selected={selected}
-                                    onDelete={selected ? deleteSelectedEntries : () => removeFromSearchStack(entry.id)}
+                                    onDelete={selected ? deleteSelectedEntries : deleteEntry}
                                 />
                             </li>
                         )
@@ -413,7 +467,7 @@ interface SearchStackEntryComponentProps {
      */
     focus?: boolean
     selected?: boolean
-    onDelete: (event: MouseEvent | KeyboardEvent) => void
+    onDelete: (entry: SearchStackEntry) => void
 }
 
 const SearchStackEntryComponent: React.FunctionComponent<SearchStackEntryComponentProps> = ({
@@ -462,7 +516,7 @@ const SearchStackEntryComponent: React.FunctionComponent<SearchStackEntryCompone
                         className="ml-1 text-muted"
                         onClick={event => {
                             event.stopPropagation()
-                            onDelete(event)
+                            onDelete(entry)
                         }}
                     >
                         <CloseIcon className="icon-inline" />
@@ -478,6 +532,13 @@ const SearchStackEntryComponent: React.FunctionComponent<SearchStackEntryCompone
                     onBlur={() => setEntryAnnotation(entry, annotation)}
                     onChange={event => setAnnotation(event.currentTarget.value)}
                     onClick={stopPropagation}
+                    onKeyUp={event => {
+                        // This is used mainly to prevent deletion of the entry
+                        // when Delete or Backspace are pressed (one of the
+                        // ancestors listens to keyup events to handle
+                        // keybindings)
+                        event.stopPropagation()
+                    }}
                 />
             )}
         </div>
@@ -562,4 +623,138 @@ function formatLineRange(lineRange: IHighlightLineRange): string {
         return `L${lineRange.startLine + 1}`
     }
     return `L${lineRange.startLine + 1}:${lineRange.endLine + 1}`
+}
+
+// Helper functions for working with "selections", an ordered list of indexes
+type Selection = number[]
+
+/**
+ * Adds or removes a position from a selection. If `multiple` is false (default)
+ * but the selection contains multiple elements the new position will always be
+ * added.
+ *
+ * @param selection The selection to operate on
+ * @param position The position to add or remove
+ * @param multiple Whether to allow multiple selected items or not.
+ */
+function toggleSelection(selection: Selection, position: number, multiple: boolean = false): Selection {
+    const index = selection.indexOf(position)
+
+    if (multiple) {
+        if (index === -1) {
+            return [...selection, position]
+        }
+
+        const newSelection = [...selection]
+        newSelection.splice(index, 1)
+        return newSelection
+    }
+    return index === -1 || selection.length > 1 ? [position] : []
+}
+
+/**
+ * Extends a given selection to contain all positions between the last one and
+ * the new newly added one. The new selection will always contain the new
+ * position. This will rearrange existing selected positions.
+ *
+ * ([1,2,3], 5) => [1,2,3,4,5]
+ * ([1,2,3], 3) => [1,2,3]
+ * ([1,2,3], 2) => [1,3,2]
+ * ([1,2,3], 0) => [3,2,1,0]
+ *
+ * @param selection The selection to operate on
+ * @param newPosition The position to extend the selection to
+ */
+function extendSelection(selection: Selection, newPosition: number): Selection {
+    if (selection.length === 0) {
+        return [newPosition]
+    }
+
+    const newSelection = [...selection]
+
+    const lastSelectedPosition = newSelection[newSelection.length - 1]
+    const direction = lastSelectedPosition > newPosition ? -1 : 1
+    for (let position = lastSelectedPosition; position !== newPosition + direction; position += direction) {
+        // Re-arrange selection as necessary
+        const existingSelectionIndex = newSelection.indexOf(position)
+        if (existingSelectionIndex > -1) {
+            newSelection.splice(existingSelectionIndex, 1)
+        }
+        newSelection.push(position)
+    }
+    return newSelection
+}
+
+/**
+ * This function is supposed to be used when reacting to shift+arrow_up/down
+ * events. In particular it
+ * - selects the next unselected position
+ * - deselects a previously selected position if the direction changes
+ *
+ * This behavior is different enough from shift+click to warrant its own
+ * function.
+ *
+ * @param selection The selection to operator on
+ * @param direction The direction in which to change the selection
+ * @param total The total number of entries in the list (to handle
+ * wrapping around)
+ */
+function growOrShrinkSelection(selection: Selection, direction: 'UP' | 'DOWN', total: number): Selection {
+    // Select top/bottom element if selection is empty
+    if (selection.length === 0) {
+        return [direction === 'UP' ? total - 1 : 0]
+    }
+
+    const delta = direction === 'UP' ? -1 : 1
+    let nextPosition = wrapPosition(selection[selection.length - 1] + delta, total)
+
+    // Did we change direction and "deselected" the last position?
+    // (it's enough to look at the penultimate selected position)
+    if (selection.length > 1 && selection[selection.length - 2] === nextPosition) {
+        return selection.slice(0, -1)
+    }
+
+    // Otherwise select the next unselected position (and rearrange positions
+    // accordingly)
+    const selectionCopy = [...selection]
+    let index = selectionCopy.indexOf(nextPosition)
+    while (index !== -1) {
+        selectionCopy.splice(index, 1)
+        selectionCopy.push(nextPosition)
+        nextPosition += delta
+        index = selectionCopy.indexOf(nextPosition)
+    }
+    selectionCopy.push(nextPosition)
+    return selectionCopy
+}
+
+/**
+ * Adjusts all indexes in the selection which are above the removed position.
+ */
+function adjustSelection(selection: Selection, removedPosition: number): Selection {
+    const result: number[] = []
+    for (const position of selection) {
+        if (position === removedPosition) {
+            continue
+        } else if (position > removedPosition) {
+            result.push(position - 1)
+            continue
+        }
+        result.push(position)
+    }
+    return result
+}
+
+/**
+ * Helper function for properly wrapping a value between 0 and max (exclusive).
+ * Basically modulo without negative numbers.
+ */
+function wrapPosition(position: number, max: number): number {
+    if (position >= max) {
+        return position % max
+    }
+    if (position < 0) {
+        return max + position
+    }
+    return position
 }


### PR DESCRIPTION
This commit adds keybindings to the Notepad entry list:

- Arrow up/down selects the next/previous item in the list.
- Shift + Arrow up/down adds or removes the next/previous deselected item to the selection.
- CTRL+a selects all items.
- Delete/Backspace removes all selected items.
- ESC deselects all selected items.

For any of these to work, the list or an element within it must have focus.

I had difficulties getting the the Shift-arrow up/down behavior right until I treated shift+arrow and shift+click as two different user interactions.

I also changed how selected items are being represented from using a list of selected entry IDs to a list of indexes. This requires some additional bookkeeping when items are added or removed.

I removed the background color change on hover to prevent people from thinking that any keybindings (but delete in particular) would interact with hover items.

Demo video from work in progress (ctrl+click to select multiple items, then shift+arrow up/down to extend/shrink selection):


https://user-images.githubusercontent.com/179026/157089346-da093166-17a8-4219-afb7-4a1309423b98.mp4



## Test plan

New unit tests and manual testing. In particular:
- Select item and change selection with arrow up/down.
- Expand/shrink selection with shift+arrow up/down.
- Select non-consecutive items with ctrl+click and use shift+arrow up/down to expand selection. Already selected items are skipped.
- Delete/Backspace deletes selected items.
- Adding a new item with select it.
- Select non-consecutive items and click the delete button of a deselected item. The selection is preserved.
- Pressing escape deselects items.
