### PR TITLE
buildchecker-history: run weekly

### DIFF
--- a/.github/workflows/buildchecker-history.yml
+++ b/.github/workflows/buildchecker-history.yml
@@ -2,7 +2,7 @@
 name: buildchecker-history
 on:
   schedule:
-  - cron: '0 1 * * *'
+  - cron: '* * * * SUN'
   workflow_dispatch:
 
 jobs:
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-go@v2
         with: { go-version: '1.17' }
 
-      - run: ./dev/buildchecker/run-day-history.sh
+      - run: ./dev/buildchecker/run-week-history.sh
         env:
           BUILDKITE_TOKEN: ${{ secrets.AUTOBUILDSHERRIF_BUILDKITE_TOKEN }}
           HONEYCOMB_TOKEN: ${{ secrets.AUTOBUILDSHERRIF_HONEYCOMB_TOKEN }}

--- a/dev/buildchecker/run-week-history.sh
+++ b/dev/buildchecker/run-week-history.sh
@@ -5,7 +5,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"/../..
 
 set -eu
 
-created_from=$(date -d "yesterday" '+%Y-%m-%d')
+created_from=$(date -d "7 days ago" '+%Y-%m-%d')
 created_to=$(date '+%Y-%m-%d')
 
 echo "--- Running 'buildchecker history' from $created_from to $created_to"


### PR DESCRIPTION
Because incidents might spill over multiple days, I think it's better to run this weekly.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

n/a