### PR TITLE
code monitors: action cancel button doesn't undo changes

### DIFF
--- a/client/web/src/enterprise/code-monitoring/components/actions/ActionEditor.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/ActionEditor.test.tsx
@@ -96,7 +96,7 @@ describe('ActionEditor', () => {
         expect(getByTestId('enable-action-toggle-collapsed-email')).toBeChecked()
 
         userEvent.click(getByTestId('enable-action-toggle-collapsed-email'))
-        sinon.assert.calledWithExactly(toggleActionEnabledSpy, false)
+        sinon.assert.calledWithExactly(toggleActionEnabledSpy, false, true)
     })
 
     test('toggle disable when expanded', () => {
@@ -113,6 +113,6 @@ describe('ActionEditor', () => {
         expect(getByTestId('enable-action-toggle-expanded-email')).not.toBeChecked()
 
         userEvent.click(getByTestId('enable-action-toggle-expanded-email'))
-        sinon.assert.calledWithExactly(toggleActionEnabledSpy, true)
+        sinon.assert.calledWithExactly(toggleActionEnabledSpy, true, false)
     })
 })

--- a/client/web/src/enterprise/code-monitoring/components/actions/ActionEditor.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/ActionEditor.tsx
@@ -16,7 +16,7 @@ export interface ActionEditorProps {
     idName: string // Name used for generating IDs, including form control IDs and test IDs
 
     actionEnabled: boolean
-    toggleActionEnabled: (enabled: boolean) => void
+    toggleActionEnabled: (enabled: boolean, saveImmediately: boolean) => void
 
     canSubmit?: boolean
     onSubmit: React.FormEventHandler
@@ -94,7 +94,7 @@ export const ActionEditor: React.FunctionComponent<ActionEditorProps> = ({
                             <Toggle
                                 title="Enabled"
                                 value={actionEnabled}
-                                onToggle={toggleActionEnabled}
+                                onToggle={enabled => toggleActionEnabled(enabled, !expanded)}
                                 className="mr-2"
                                 aria-labelledby={`code-monitoring-${idName}-form-actions-enable-toggle`}
                                 data-testid={`enable-action-toggle-expanded-${idName}`}
@@ -172,7 +172,7 @@ export const ActionEditor: React.FunctionComponent<ActionEditorProps> = ({
                                     <Toggle
                                         title="Enabled"
                                         value={actionEnabled}
-                                        onToggle={toggleActionEnabled}
+                                        onToggle={enabled => toggleActionEnabled(enabled, !expanded)}
                                         className="mr-3"
                                         data-testid={`enable-action-toggle-collapsed-${idName}`}
                                     />

--- a/client/web/src/enterprise/code-monitoring/components/actions/EmailAction.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/EmailAction.test.tsx
@@ -108,6 +108,37 @@ describe('EmailAction', () => {
         })
     })
 
+    test('open, edit, cancel, open again', () => {
+        const setActionSpy = sinon.spy()
+        const { getByTestId } = render(
+            <MockedTestProvider>
+                <EmailAction
+                    {...props}
+                    setAction={setActionSpy}
+                    action={{
+                        __typename: 'MonitorEmail',
+                        enabled: true,
+                        includeResults: false,
+                        id: '1',
+                        recipients: { nodes: [{ id: 'userID' }] },
+                    }}
+                />
+            </MockedTestProvider>
+        )
+
+        userEvent.click(getByTestId('form-action-toggle-email'))
+
+        expect(getByTestId('enable-action-toggle-expanded-email')).toBeChecked()
+        userEvent.click(getByTestId('enable-action-toggle-expanded-email'))
+        expect(getByTestId('enable-action-toggle-expanded-email')).not.toBeChecked()
+        userEvent.click(getByTestId('cancel-action-email'))
+
+        userEvent.click(getByTestId('form-action-toggle-email'))
+        expect(getByTestId('enable-action-toggle-expanded-email')).toBeChecked()
+
+        sinon.assert.notCalled(setActionSpy)
+    })
+
     describe('Send test email', () => {
         const mockedVars: SendTestEmailVariables = {
             namespace: props.authenticatedUser.id,

--- a/client/web/src/enterprise/code-monitoring/components/actions/EmailAction.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/EmailAction.tsx
@@ -29,18 +29,14 @@ export const EmailAction: React.FunctionComponent<ActionProps> = ({
 }) => {
     const [emailNotificationEnabled, setEmailNotificationEnabled] = useState(action ? action.enabled : true)
 
-    const toggleEmailNotificationEnabled: (enabled: boolean) => void = useCallback(
-        enabled => {
+    const toggleEmailNotificationEnabled: (enabled: boolean, saveImmediately: boolean) => void = useCallback(
+        (enabled, saveImmediately) => {
             setEmailNotificationEnabled(enabled)
-            setAction({
-                __typename: 'MonitorEmail',
-                id: action?.id ?? '',
-                recipients: { nodes: [{ id: authenticatedUser.id }] },
-                enabled,
-                includeResults: false,
-            })
+            if (action && saveImmediately) {
+                setAction({ ...action, enabled })
+            }
         },
-        [action?.id, authenticatedUser.id, setAction]
+        [action, setAction]
     )
 
     const onSubmit: React.FormEventHandler = useCallback(
@@ -53,13 +49,17 @@ export const EmailAction: React.FunctionComponent<ActionProps> = ({
                     __typename: 'MonitorEmail',
                     id: '',
                     recipients: { nodes: [{ id: authenticatedUser.id }] },
-                    enabled: true,
+                    enabled: emailNotificationEnabled,
                     includeResults: false,
                 })
             }
         },
-        [action, authenticatedUser.id, setAction]
+        [action, authenticatedUser.id, emailNotificationEnabled, setAction]
     )
+
+    const onCancel: React.FormEventHandler = useCallback(() => {
+        setEmailNotificationEnabled(action ? action.enabled : true)
+    }, [action])
 
     const onDelete: React.FormEventHandler = useCallback(() => {
         setAction(undefined)
@@ -76,7 +76,7 @@ export const EmailAction: React.FunctionComponent<ActionProps> = ({
                 namespace: authenticatedUser.id,
                 description: monitorName,
                 email: {
-                    enabled: true,
+                    enabled: emailNotificationEnabled,
                     includeResults: false,
                     priority: MonitorEmailPriority.NORMAL,
                     recipients: [authenticatedUser.id],
@@ -84,7 +84,7 @@ export const EmailAction: React.FunctionComponent<ActionProps> = ({
                 },
             },
         }).catch(noop) // Ignore errors, they will be handled with the error state from useMutation
-    }, [authenticatedUser.id, monitorName, sendTestEmail])
+    }, [authenticatedUser.id, emailNotificationEnabled, monitorName, sendTestEmail])
 
     const sendTestEmailButtonText = loading
         ? 'Sending email...'
@@ -104,6 +104,7 @@ export const EmailAction: React.FunctionComponent<ActionProps> = ({
             actionEnabled={emailNotificationEnabled}
             toggleActionEnabled={toggleEmailNotificationEnabled}
             onSubmit={onSubmit}
+            onCancel={onCancel}
             canDelete={!!action}
             onDelete={onDelete}
             _testStartOpen={_testStartOpen}

--- a/client/web/src/enterprise/code-monitoring/components/actions/SlackWebhookAction.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/SlackWebhookAction.test.tsx
@@ -152,6 +152,41 @@ describe('SlackWebhookAction', () => {
         })
     })
 
+    test('open, edit, cancel, open again', () => {
+        const setActionSpy = sinon.spy()
+        const { getByTestId } = render(
+            <MockedTestProvider>
+                <SlackWebhookAction
+                    {...props}
+                    action={{
+                        __typename: 'MonitorSlackWebhook',
+                        enabled: true,
+                        includeResults: false,
+                        id: '5',
+                        url: 'https://example.com',
+                    }}
+                    setAction={setActionSpy}
+                />
+            </MockedTestProvider>
+        )
+
+        userEvent.click(getByTestId('form-action-toggle-slack-webhook'))
+
+        expect(getByTestId('enable-action-toggle-expanded-slack-webhook')).toBeChecked()
+        userEvent.click(getByTestId('enable-action-toggle-expanded-slack-webhook'))
+        expect(getByTestId('enable-action-toggle-expanded-slack-webhook')).not.toBeChecked()
+
+        userEvent.type(getByTestId('slack-webhook-url'), 'https://example2.com')
+
+        userEvent.click(getByTestId('cancel-action-slack-webhook'))
+
+        userEvent.click(getByTestId('form-action-toggle-slack-webhook'))
+        expect(getByTestId('slack-webhook-url')).toHaveValue('https://example.com')
+        expect(getByTestId('enable-action-toggle-expanded-slack-webhook')).toBeChecked()
+
+        sinon.assert.notCalled(setActionSpy)
+    })
+
     describe('Send test message', () => {
         const mockAction: MonitorAction = {
             __typename: 'MonitorSlackWebhook',

--- a/client/web/src/enterprise/code-monitoring/components/actions/SlackWebhookAction.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/SlackWebhookAction.tsx
@@ -29,11 +29,10 @@ export const SlackWebhookAction: React.FunctionComponent<ActionProps> = ({
 }) => {
     const [webhookEnabled, setWebhookEnabled] = useState(action ? action.enabled : true)
 
-    const toggleWebhookEnabled: (enabled: boolean) => void = useCallback(
-        enabled => {
+    const toggleWebhookEnabled: (enabled: boolean, saveImmediately: boolean) => void = useCallback(
+        (enabled, saveImmediately) => {
             setWebhookEnabled(enabled)
-
-            if (action) {
+            if (action && saveImmediately) {
                 setAction({ ...action, enabled })
             }
         },
@@ -49,12 +48,17 @@ export const SlackWebhookAction: React.FunctionComponent<ActionProps> = ({
                 __typename: 'MonitorSlackWebhook',
                 id: action ? action.id : '',
                 url,
-                enabled: webhookEnabled,
+                enabled: true,
                 includeResults: false,
             })
         },
-        [action, setAction, url, webhookEnabled]
+        [action, setAction, url]
     )
+
+    const onCancel: React.FormEventHandler = useCallback(() => {
+        setWebhookEnabled(action ? action.enabled : true)
+        setUrl(action && action.__typename === 'MonitorSlackWebhook' ? action.url : '')
+    }, [action])
 
     const onDelete: React.FormEventHandler = useCallback(() => {
         setAction(undefined)
@@ -99,7 +103,7 @@ export const SlackWebhookAction: React.FunctionComponent<ActionProps> = ({
             toggleActionEnabled={toggleWebhookEnabled}
             canSubmit={!!url}
             onSubmit={onSubmit}
-            onCancel={() => {}}
+            onCancel={onCancel}
             canDelete={!!action}
             onDelete={onDelete}
             _testStartOpen={_testStartOpen}

--- a/client/web/src/enterprise/code-monitoring/components/actions/WebhookAction.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/WebhookAction.test.tsx
@@ -152,6 +152,41 @@ describe('WebhookAction', () => {
         })
     })
 
+    test('open, edit, cancel, open again', () => {
+        const setActionSpy = sinon.spy()
+        const { getByTestId } = render(
+            <MockedTestProvider>
+                <WebhookAction
+                    {...props}
+                    action={{
+                        __typename: 'MonitorWebhook',
+                        enabled: true,
+                        includeResults: false,
+                        id: '5',
+                        url: 'https://example.com',
+                    }}
+                    setAction={setActionSpy}
+                />
+            </MockedTestProvider>
+        )
+
+        userEvent.click(getByTestId('form-action-toggle-webhook'))
+
+        expect(getByTestId('enable-action-toggle-expanded-webhook')).toBeChecked()
+        userEvent.click(getByTestId('enable-action-toggle-expanded-webhook'))
+        expect(getByTestId('enable-action-toggle-expanded-webhook')).not.toBeChecked()
+
+        userEvent.type(getByTestId('webhook-url'), 'https://example2.com')
+
+        userEvent.click(getByTestId('cancel-action-webhook'))
+
+        userEvent.click(getByTestId('form-action-toggle-webhook'))
+        expect(getByTestId('webhook-url')).toHaveValue('https://example.com')
+        expect(getByTestId('enable-action-toggle-expanded-webhook')).toBeChecked()
+
+        sinon.assert.notCalled(setActionSpy)
+    })
+
     describe('Send test message', () => {
         const mockAction: MonitorAction = {
             __typename: 'MonitorWebhook',

--- a/client/web/src/enterprise/code-monitoring/components/actions/WebhookAction.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/WebhookAction.tsx
@@ -29,11 +29,10 @@ export const WebhookAction: React.FunctionComponent<ActionProps> = ({
 }) => {
     const [webhookEnabled, setWebhookEnabled] = useState(action ? action.enabled : true)
 
-    const toggleWebhookEnabled: (enabled: boolean) => void = useCallback(
-        enabled => {
+    const toggleWebhookEnabled: (enabled: boolean, saveImmediately: boolean) => void = useCallback(
+        (enabled, saveImmediately) => {
             setWebhookEnabled(enabled)
-
-            if (action) {
+            if (action && saveImmediately) {
                 setAction({ ...action, enabled })
             }
         },
@@ -55,6 +54,11 @@ export const WebhookAction: React.FunctionComponent<ActionProps> = ({
         },
         [action, setAction, url, webhookEnabled]
     )
+
+    const onCancel: React.FormEventHandler = useCallback(() => {
+        setWebhookEnabled(action ? action.enabled : true)
+        setUrl(action && action.__typename === 'MonitorWebhook' ? action.url : '')
+    }, [action])
 
     const onDelete: React.FormEventHandler = useCallback(() => {
         setAction(undefined)
@@ -98,7 +102,7 @@ export const WebhookAction: React.FunctionComponent<ActionProps> = ({
             toggleActionEnabled={toggleWebhookEnabled}
             canSubmit={!!url}
             onSubmit={onSubmit}
-            onCancel={() => {}}
+            onCancel={onCancel}
             canDelete={!!action}
             onDelete={onDelete}
             _testStartOpen={_testStartOpen}


### PR DESCRIPTION
Fixes #32222

- "Cancel" button now undoes changes to actions, restoring the enable/disable state and, for webhooks, the URL.
  - #32097 will be updated to also do the same thing for `includeResults`
- Enable/disable no longer saved immediately when action is expanded; the action must be saved for the enable/disable toggle state to be saved. Enable/disable toggle still saves immediately if the action is collapsed.

![CleanShot 2022-03-04 at 14 05 56](https://user-images.githubusercontent.com/206864/156848331-dcf88732-937f-41d3-8ff3-08368cd8ca59.png)


## Test plan

- Unit tests have been updated for all three actions to test the cancel button.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


