### PR TITLE
codeintel: Add setting codeIntelligence.clickToGoToDefinition

### DIFF
--- a/client/shared/src/hover/HoverOverlay.fixtures.ts
+++ b/client/shared/src/hover/HoverOverlay.fixtures.ts
@@ -7,6 +7,7 @@ import { MarkupKind } from '@sourcegraph/extension-api-classes'
 
 import { ActionItemAction } from '../actions/ActionItem'
 import { PlatformContext } from '../platform/context'
+import { EMPTY_SETTINGS_CASCADE, SettingsCascadeProps } from '../settings/settings'
 import { NOOP_TELEMETRY_SERVICE } from '../telemetry/telemetryService'
 
 import { HoverOverlayProps } from './HoverOverlay'
@@ -18,7 +19,7 @@ const NOOP_PLATFORM_CONTEXT: Pick<PlatformContext, 'forceUpdateTooltip' | 'setti
     settings: of({ final: {}, subjects: [] }),
 }
 
-export const commonProps = (): HoverOverlayProps => ({
+export const commonProps = (): HoverOverlayProps & SettingsCascadeProps => ({
     location: history.location,
     telemetryService: NOOP_TELEMETRY_SERVICE,
     extensionsController: NOOP_EXTENSIONS_CONTROLLER,
@@ -26,6 +27,7 @@ export const commonProps = (): HoverOverlayProps => ({
     isLightTheme: true,
     overlayPosition: { top: 16, left: 16 },
     onAlertDismissed: action('onAlertDismissed'),
+    settingsCascade: EMPTY_SETTINGS_CASCADE,
 })
 
 export const FIXTURE_CONTENT: Badged<MarkupContent> = {

--- a/client/web/src/enterprise/batches/close/BatchChangeCloseChangesetsList.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeCloseChangesetsList.tsx
@@ -11,6 +11,7 @@ import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/co
 import { ChangesetState } from '@sourcegraph/shared/src/graphql-operations'
 import { getHoverActions } from '@sourcegraph/shared/src/hover/actions'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
+import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { RepoSpec, RevisionSpec, FileSpec, ResolvedRevisionSpec } from '@sourcegraph/shared/src/util/url'
@@ -34,7 +35,12 @@ import {
 import { ChangesetCloseNodeProps, ChangesetCloseNode } from './ChangesetCloseNode'
 import { CloseChangesetsListEmptyElement } from './CloseChangesetsListEmptyElement'
 
-interface Props extends ThemeProps, PlatformContextProps, TelemetryProps, ExtensionsControllerProps {
+interface Props
+    extends ThemeProps,
+        PlatformContextProps,
+        TelemetryProps,
+        ExtensionsControllerProps,
+        SettingsCascadeProps {
     batchChangeID: Scalars['ID']
     viewerCanAdminister: boolean
     history: H.History
@@ -66,6 +72,7 @@ export const BatchChangeCloseChangesetsList: React.FunctionComponent<Props> = ({
     onUpdate,
     queryChangesets = _queryChangesets,
     queryExternalChangesetWithFileDiffs,
+    settingsCascade,
 }) => {
     const queryChangesetsConnection = useCallback(
         (args: FilteredConnectionQueryArguments) =>
@@ -174,6 +181,7 @@ export const BatchChangeCloseChangesetsList: React.FunctionComponent<Props> = ({
                         location={location}
                         platformContext={platformContext}
                         hoverRef={nextOverlayElement}
+                        settingsCascade={settingsCascade}
                     />
                 )}
             </Container>

--- a/client/web/src/enterprise/batches/close/BatchChangeClosePage.story.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeClosePage.story.tsx
@@ -5,6 +5,8 @@ import { subDays } from 'date-fns'
 import React from 'react'
 import { of } from 'rxjs'
 
+import { EMPTY_SETTINGS_CASCADE } from '@sourcegraph/shared/src/settings/settings'
+
 import { WebStory } from '../../../components/WebStory'
 import {
     ChangesetCheckState,
@@ -256,6 +258,7 @@ add('Overview', () => {
                     fetchBatchChangeByNamespace={fetchBatchChange}
                     extensionsController={{} as any}
                     platformContext={{} as any}
+                    settingsCascade={EMPTY_SETTINGS_CASCADE}
                 />
             )}
         </WebStory>
@@ -290,6 +293,7 @@ add('No open changesets', () => {
                     fetchBatchChangeByNamespace={fetchBatchChange}
                     extensionsController={{} as any}
                     platformContext={{} as any}
+                    settingsCascade={EMPTY_SETTINGS_CASCADE}
                 />
             )}
         </WebStory>

--- a/client/web/src/enterprise/batches/close/BatchChangeClosePage.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeClosePage.tsx
@@ -6,6 +6,7 @@ import React, { useState, useMemo, useCallback } from 'react'
 import { ErrorLike, isErrorLike } from '@sourcegraph/common'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
+import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { PageHeader, LoadingSpinner, useObservable } from '@sourcegraph/wildcard'
@@ -29,7 +30,8 @@ export interface BatchChangeClosePageProps
     extends ThemeProps,
         TelemetryProps,
         PlatformContextProps,
-        ExtensionsControllerProps {
+        ExtensionsControllerProps,
+        SettingsCascadeProps {
     /**
      * The namespace ID.
      */
@@ -64,6 +66,7 @@ export const BatchChangeClosePage: React.FunctionComponent<BatchChangeClosePageP
     queryChangesets,
     queryExternalChangesetWithFileDiffs,
     closeBatchChange,
+    settingsCascade,
 }) => {
     const [closeChangesets, setCloseChangesets] = useState<boolean>(false)
     const createdAfter = useMemo(() => subDays(new Date(), 3).toISOString(), [])
@@ -151,6 +154,7 @@ export const BatchChangeClosePage: React.FunctionComponent<BatchChangeClosePageP
                 queryExternalChangesetWithFileDiffs={queryExternalChangesetWithFileDiffs}
                 willClose={closeChangesets}
                 onUpdate={onFetchChangesets}
+                settingsCascade={settingsCascade}
             />
         </>
     )

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
@@ -171,6 +171,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<BatchChangeDetailsT
                         queryExternalChangesetWithFileDiffs={queryExternalChangesetWithFileDiffs}
                         queryAllChangesetIDs={queryAllChangesetIDs}
                         onlyArchived={false}
+                        settingsCascade={settingsCascade}
                     />
                 </BatchChangeTabPanel>
                 <BatchChangeTabPanel>
@@ -229,6 +230,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<BatchChangeDetailsT
                         queryExternalChangesetWithFileDiffs={queryExternalChangesetWithFileDiffs}
                         onlyArchived={true}
                         refetchBatchChange={refetchBatchChange}
+                        settingsCascade={settingsCascade}
                     />
                 </BatchChangeTabPanel>
                 <BatchChangeTabPanel>

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.story.tsx
@@ -6,6 +6,7 @@ import { of } from 'rxjs'
 import { WildcardMockLink, MATCH_ANY_PARAMETERS } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { EMPTY_SETTINGS_CASCADE } from '@sourcegraph/shared/src/settings/settings'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
 import { WebStory } from '../../../../components/WebStory'
@@ -65,6 +66,7 @@ add('List of changesets', () => (
                     platformContext={undefined as any}
                     batchChangeID="batchid"
                     viewerCanAdminister={boolean('viewerCanAdminister', true)}
+                    settingsCascade={EMPTY_SETTINGS_CASCADE}
                 />
             </MockedTestProvider>
         )}
@@ -84,6 +86,7 @@ add('List of expanded changesets', () => (
                     batchChangeID="batchid"
                     viewerCanAdminister={boolean('viewerCanAdminister', true)}
                     expandByDefault={true}
+                    settingsCascade={EMPTY_SETTINGS_CASCADE}
                 />
             </MockedTestProvider>
         )}

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
@@ -11,6 +11,7 @@ import { HoverMerged } from '@sourcegraph/shared/src/api/client/types/hover'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { getHoverActions } from '@sourcegraph/shared/src/hover/actions'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
+import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { RepoSpec, RevisionSpec, FileSpec, ResolvedRevisionSpec } from '@sourcegraph/shared/src/util/url'
@@ -52,7 +53,12 @@ import { EmptyArchivedChangesetListElement } from './EmptyArchivedChangesetListE
 import { EmptyChangesetListElement } from './EmptyChangesetListElement'
 import { EmptyChangesetSearchElement } from './EmptyChangesetSearchElement'
 
-interface Props extends ThemeProps, PlatformContextProps, TelemetryProps, ExtensionsControllerProps {
+interface Props
+    extends ThemeProps,
+        PlatformContextProps,
+        TelemetryProps,
+        ExtensionsControllerProps,
+        SettingsCascadeProps {
     batchChangeID: Scalars['ID']
     viewerCanAdminister: boolean
     history: H.History
@@ -96,6 +102,7 @@ const BatchChangeChangesetsImpl: React.FunctionComponent<Props> = ({
     expandByDefault,
     onlyArchived,
     refetchBatchChange,
+    settingsCascade,
 }) => {
     // You might look at this destructuring statement and wonder why this isn't
     // just a single context consumer object. The reason is because making it a
@@ -307,6 +314,7 @@ const BatchChangeChangesetsImpl: React.FunctionComponent<Props> = ({
                         location={location}
                         platformContext={platformContext}
                         hoverRef={nextOverlayElement}
+                        settingsCascade={settingsCascade}
                     />
                 )}
             </div>

--- a/client/web/src/repo/commit/RepositoryCommitPage.tsx
+++ b/client/web/src/repo/commit/RepositoryCommitPage.tsx
@@ -25,6 +25,7 @@ import { HoverContext } from '@sourcegraph/shared/src/hover/HoverOverlay'
 import { getModeFromPath } from '@sourcegraph/shared/src/languages'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import * as GQL from '@sourcegraph/shared/src/schema'
+import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import {
@@ -117,7 +118,8 @@ interface Props
         TelemetryProps,
         PlatformContextProps,
         ExtensionsControllerProps,
-        ThemeProps {
+        ThemeProps,
+        SettingsCascadeProps {
     repo: RepositoryFields
     onDidUpdateExternalLinks: (externalLinks: ExternalLinkFields[] | undefined) => void
 }

--- a/client/web/src/repo/compare/RepositoryCompareArea.tsx
+++ b/client/web/src/repo/compare/RepositoryCompareArea.tsx
@@ -18,6 +18,7 @@ import { getHoverActions } from '@sourcegraph/shared/src/hover/actions'
 import { HoverContext } from '@sourcegraph/shared/src/hover/HoverOverlay'
 import { getModeFromPath } from '@sourcegraph/shared/src/languages'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
+import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import {
@@ -56,6 +57,7 @@ interface RepositoryCompareAreaProps
         TelemetryProps,
         ExtensionsControllerProps,
         ThemeProps,
+        SettingsCascadeProps,
         BreadcrumbSetters {
     repo: RepositoryFields
     history: H.History

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1496,6 +1496,8 @@ type Settings struct {
 	CodeIntelligenceAutoIndexPopularRepoLimit int `json:"codeIntelligence.autoIndexPopularRepoLimit,omitempty"`
 	// CodeIntelligenceAutoIndexRepositoryGroups description: A list of search.repositoryGroups that have auto-indexing enabled.
 	CodeIntelligenceAutoIndexRepositoryGroups []string `json:"codeIntelligence.autoIndexRepositoryGroups,omitempty"`
+	// CodeIntelligenceClickToGoToDefinition description: Enable click to go to definition.
+	CodeIntelligenceClickToGoToDefinition bool `json:"codeIntelligence.clickToGoToDefinition,omitempty"`
 	// CodeIntelligenceMaxPanelResults description: Maximum number of references/definitions (or other code intelligence results provided by extensions) shown in the panel. If not set a default value will be used to ensure best performance.
 	CodeIntelligenceMaxPanelResults int `json:"codeIntelligence.maxPanelResults,omitempty"`
 	// ExperimentalFeatures description: Experimental features to enable or disable. Features that are now enabled by default are marked as deprecated.

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -351,6 +351,11 @@
       "description": "Maximum number of references/definitions (or other code intelligence results provided by extensions) shown in the panel. If not set a default value will be used to ensure best performance.",
       "type": "integer"
     },
+    "codeIntelligence.clickToGoToDefinition": {
+      "description": "Enable click to go to definition.",
+      "type": "boolean",
+      "default": true
+    },
     "search.contextLines": {
       "description": "The default number of lines to show as context below and above search results. Default is 1.",
       "type": "integer",


### PR DESCRIPTION
If you set this to false, you can click on tokens without triggering a go to definition.

```jsonc
{
  "codeIntelligence.clickToGoToDefinition": false // defaults to true
}
```

From [Slack](https://sourcegraph.slack.com/archives/CHXHX7XAS/p1646349310695839)

## Test plan

Ran locally with and without the setting and verified it had the intended behavior.