### PR TITLE
site-admin: add feature flags list view

### DIFF
--- a/client/web/src/components/Collapsible.tsx
+++ b/client/web/src/components/Collapsible.tsx
@@ -44,6 +44,11 @@ interface Props {
      * Whether the title should be placed before the chevron icon.
      */
     titleAtStart?: true
+
+    /**
+     * Whether the title and the chevron icon should be floated to the ends.
+     */
+    justifyContentBetween?: boolean
 }
 
 /**
@@ -62,6 +67,7 @@ export const Collapsible: React.FunctionComponent<Props> = ({
     buttonClassName = '',
     expandedButtonClassName = '',
     wholeTitleClickable = true,
+    justifyContentBetween = true,
 }) => {
     const [isExpanded, setIsExpanded] = useState(defaultExpanded)
     const toggleIsExpanded = useCallback<React.MouseEventHandler<HTMLButtonElement>>(
@@ -85,7 +91,8 @@ export const Collapsible: React.FunctionComponent<Props> = ({
         <div className={className}>
             <div
                 className={classNames(
-                    'd-flex justify-content-between align-items-center position-relative',
+                    'd-flex align-items-center position-relative',
+                    justifyContentBetween && 'justify-content-between',
                     isExpanded && expandedButtonClassName,
                     buttonClassName
                 )}

--- a/client/web/src/components/Collapsible.tsx
+++ b/client/web/src/components/Collapsible.tsx
@@ -44,11 +44,6 @@ interface Props {
      * Whether the title should be placed before the chevron icon.
      */
     titleAtStart?: true
-
-    /**
-     * Whether the title and the chevron icon should be floated to the ends.
-     */
-    justifyContentBetween?: boolean
 }
 
 /**
@@ -67,7 +62,6 @@ export const Collapsible: React.FunctionComponent<Props> = ({
     buttonClassName = '',
     expandedButtonClassName = '',
     wholeTitleClickable = true,
-    justifyContentBetween = true,
 }) => {
     const [isExpanded, setIsExpanded] = useState(defaultExpanded)
     const toggleIsExpanded = useCallback<React.MouseEventHandler<HTMLButtonElement>>(
@@ -91,8 +85,7 @@ export const Collapsible: React.FunctionComponent<Props> = ({
         <div className={className}>
             <div
                 className={classNames(
-                    'd-flex align-items-center position-relative',
-                    justifyContentBetween && 'justify-content-between',
+                    'd-flex justify-content-between align-items-center position-relative',
                     isExpanded && expandedButtonClassName,
                     buttonClassName
                 )}

--- a/client/web/src/site-admin/SiteAdminFeatureFlagsPage.module.scss
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagsPage.module.scss
@@ -1,0 +1,40 @@
+@import 'wildcard/src/global-styles/breakpoints';
+
+.flags-grid {
+    display: grid;
+    grid-template-columns: [info] minmax(auto, 1fr) [progress] min-content [end];
+    row-gap: 1rem;
+    column-gap: 1rem;
+    align-items: center;
+    @media (--sm-breakpoint-down) {
+        row-gap: 0.5rem;
+        column-gap: 0.5rem;
+    }
+}
+
+.separator {
+    /* Make it full width in the current row. */
+    grid-column: 1 / -1;
+    border-top: 1px solid var(--border-color-2);
+    @media (--xs-breakpoint-down) {
+        margin-top: 1rem;
+        padding-bottom: 1rem;
+    }
+}
+
+.progress,
+.information {
+    @media (--xs-breakpoint-down) {
+        grid-column: 1 / -1;
+    }
+}
+
+.node-grid {
+    display: grid;
+    grid-template-columns: [date] max-content [error] minmax(auto, 1fr) [end];
+    align-items: center;
+
+    &-code {
+        border-left: 1px solid var(--border-color-2);
+    }
+}

--- a/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
@@ -14,7 +14,7 @@ import { PageTitle } from '../components/PageTitle'
 import { FeatureFlagFields } from '../graphql-operations'
 
 import { fetchFeatureFlags as defaultFetchFeatureFlags } from './backend'
-import styles from './SiteAdminMigrationsPage.module.scss'
+import styles from './SiteAdminFeatureFlagsPage.module.scss'
 
 export interface SiteAdminFeatureFlagsPageProps extends RouteComponentProps<{}>, TelemetryProps {
     fetchFeatureFlags?: typeof defaultFetchFeatureFlags
@@ -113,7 +113,7 @@ export const SiteAdminFeatureFlagsPage: React.FunctionComponent<SiteAdminFeature
             <Container>
                 <FilteredConnection<FeatureFlagFields, {}>
                     listComponent="div"
-                    listClassName={classNames('mb-3', styles.migrationsGrid)}
+                    listClassName={classNames('mb-3', styles.flagsGrid)}
                     noun="feature flag"
                     pluralNoun="feature flags"
                     queryConnection={queryFeatureFlags}

--- a/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
@@ -1,0 +1,201 @@
+import classNames from 'classnames'
+import React, { useCallback, useMemo } from 'react'
+import { RouteComponentProps } from 'react-router'
+import { of } from 'rxjs'
+import { catchError } from 'rxjs/operators'
+
+import { asError, ErrorLike, isErrorLike } from '@sourcegraph/common'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { Link, PageHeader, Container, useObservable } from '@sourcegraph/wildcard'
+
+import { Collapsible } from '../components/Collapsible'
+import { FilteredConnection, FilteredConnectionFilter } from '../components/FilteredConnection'
+import { PageTitle } from '../components/PageTitle'
+import { FeatureFlagFields } from '../graphql-operations'
+
+import { fetchFeatureFlags as defaultFetchFeatureFlags } from './backend'
+import styles from './SiteAdminMigrationsPage.module.scss'
+
+export interface SiteAdminFeatureFlagsPageProps extends RouteComponentProps<{}>, TelemetryProps {
+    fetchFeatureFlags?: typeof defaultFetchFeatureFlags
+}
+
+const filters: FilteredConnectionFilter[] = [
+    {
+        id: 'filters',
+        label: 'Type',
+        type: 'select',
+        values: [
+            {
+                label: 'All',
+                value: 'all',
+                tooltip: 'Show all feature flags',
+                args: {},
+            },
+            {
+                label: 'Boolean',
+                value: 'boolean',
+                tooltip: 'Show boolean feature flags',
+                args: { type: 'FeatureFlagBoolean' },
+            },
+            {
+                label: 'Rollout',
+                value: 'rollout',
+                tooltip: 'Show rollout feature flags',
+                args: { type: 'FeatureFlagRollout' },
+            },
+        ],
+    },
+]
+
+export const SiteAdminFeatureFlagsPage: React.FunctionComponent<SiteAdminFeatureFlagsPageProps> = ({
+    fetchFeatureFlags = defaultFetchFeatureFlags,
+    telemetryService,
+    ...props
+}) => {
+    const featureFlagsOrErrors = useObservable(
+        useMemo(
+            () => fetchFeatureFlags().pipe(
+                catchError((error): [ErrorLike] => [asError(error)]),
+            ),
+            [fetchFeatureFlags]
+        )
+    )
+
+    const queryFeatureFlags = useCallback(
+        (args: { query?: string, type?: string }) => {
+            if (isErrorLike(featureFlagsOrErrors) || featureFlagsOrErrors === undefined) {
+                return of({ nodes: [] })
+            }
+            return of({
+                nodes: featureFlagsOrErrors.filter(node =>
+                    (args.type === undefined || node.__typename === args.type) &&
+                    (!args.query || node.name.toLowerCase().includes(args.query.toLowerCase()))),
+            })
+        },
+        [featureFlagsOrErrors]
+    )
+
+    return (
+        <>
+            <PageTitle title="Feature flags - Admin" />
+            <PageHeader
+                headingElement="h2"
+                path={[
+                    {
+                        text: <>Feature flags</>,
+                    },
+                ]}
+                description={(
+                    <>
+                        <p>
+                        Feature flags, as opposed to experimental features, are intended
+                        to be strictly short-lived. They are designed to be useful for A/B
+                        testing, and the values of all active feature flags are added to
+                        every event log for the purpose of analytics.
+                        </p>
+                        <p>
+                            To learn more, refer to <Link
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                to="/help/dev/how-to/use_feature_flags"
+                            >
+                                How to use feature flags
+                            </Link>.
+                        </p>
+                    </>
+                )}
+                className="mb-3"
+            />
+
+            <Container>
+                <FilteredConnection<FeatureFlagFields, {}>
+                    listComponent="div"
+                    listClassName={classNames('mb-3', styles.migrationsGrid)}
+                    noun="feature flag"
+                    pluralNoun="feature flags"
+                    queryConnection={queryFeatureFlags}
+                    nodeComponent={FeatureFlagNode}
+                    history={props.history}
+                    location={props.location}
+                    filters={filters}
+                />
+            </Container>
+        </>
+    )
+}
+
+interface FeatureFlagNodeProps {
+    node: FeatureFlagFields
+}
+
+const FeatureFlagNode: React.FunctionComponent<FeatureFlagNodeProps> = ({ node }) => (
+    <React.Fragment key={node.name}>
+        <span className={styles.separator} />
+
+        <div className={classNames('d-flex flex-column', styles.information)}>
+            <div>
+                <h3>{node.name}</h3>
+
+                <p className="m-0">
+                    <span className="text-muted">{node.__typename}</span>
+                </p>
+            </div>
+        </div>
+
+        <span className={classNames('d-none d-md-inline', styles.progress)}>
+            <div className="m-0 text-nowrap d-flex flex-column align-items-center justify-content-center">
+                <div>
+                    {node.__typename === 'FeatureFlagBoolean' && <code>{JSON.stringify(node.value)}</code>}
+                    {node.__typename === 'FeatureFlagRollout' && node.rolloutBasisPoints}
+                </div>
+
+                {node.__typename === 'FeatureFlagRollout' && (<div>
+                    <meter
+                        min={0}
+                        max={1}
+                        optimum={1}
+                        value={node.rolloutBasisPoints/(100 * 100)}
+                        data-tooltip={`${Math.floor(node.rolloutBasisPoints/100)}%`}
+                        aria-label="rollout progress"
+                        data-placement="bottom"
+                    />
+                </div>)}
+            </div>
+        </span>
+
+        {/*
+            TODO: move into individual feature flag page as part of
+            https://github.com/sourcegraph/sourcegraph/issues/32232
+        */}
+        {node.overrides.length > 0 && (
+            <Collapsible
+                title={<strong>{node.overrides.length} {node.overrides.length > 1 ? 'overrides' : 'override'}</strong>}
+                className="p-0 font-weight-normal"
+                buttonClassName="mb-0"
+                titleAtStart={true}
+                defaultExpanded={false}
+                justifyContentBetween={false}
+            >
+                <div className={classNames('pt-2', styles.nodeGrid)}>
+                    {node.overrides
+                        .map(override => (
+                            <React.Fragment key={override.id}>
+                                <div className="py-1 pr-2">
+                                    <code>{JSON.stringify(override.value)}</code>
+                                </div>
+
+                                <span className={classNames('py-1 pl-2', styles.nodeGridCode)}>
+                                    {/*
+                                        TODO: querying for namespace connection seems to
+                                        error out often, so just present the ID for now.
+                                    */}
+                                    <code>{override.id}</code>
+                                </span>
+                            </React.Fragment>
+                        ))}
+                </div>
+            </Collapsible>
+        )}
+    </React.Fragment>
+)

--- a/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
@@ -54,23 +54,22 @@ export const SiteAdminFeatureFlagsPage: React.FunctionComponent<SiteAdminFeature
     ...props
 }) => {
     const featureFlagsOrErrors = useObservable(
-        useMemo(
-            () => fetchFeatureFlags().pipe(
-                catchError((error): [ErrorLike] => [asError(error)]),
-            ),
-            [fetchFeatureFlags]
-        )
+        useMemo(() => fetchFeatureFlags().pipe(catchError((error): [ErrorLike] => [asError(error)])), [
+            fetchFeatureFlags,
+        ])
     )
 
     const queryFeatureFlags = useCallback(
-        (args: { query?: string, type?: string }) => {
+        (args: { query?: string; type?: string }) => {
             if (isErrorLike(featureFlagsOrErrors) || featureFlagsOrErrors === undefined) {
                 return of({ nodes: [] })
             }
             return of({
-                nodes: featureFlagsOrErrors.filter(node =>
-                    (args.type === undefined || node.__typename === args.type) &&
-                    (!args.query || node.name.toLowerCase().includes(args.query.toLowerCase()))),
+                nodes: featureFlagsOrErrors.filter(
+                    node =>
+                        (args.type === undefined || node.__typename === args.type) &&
+                        (!args.query || node.name.toLowerCase().includes(args.query.toLowerCase()))
+                ),
                 totalCount: featureFlagsOrErrors.length,
                 pageInfo: { hasNextPage: false },
             })
@@ -88,25 +87,22 @@ export const SiteAdminFeatureFlagsPage: React.FunctionComponent<SiteAdminFeature
                         text: <>Feature flags</>,
                     },
                 ]}
-                description={(
+                description={
                     <>
                         <p>
-                        Feature flags, as opposed to experimental features, are intended
-                        to be strictly short-lived. They are designed to be useful for A/B
-                        testing, and the values of all active feature flags are added to
-                        every event log for the purpose of analytics.
+                            Feature flags, as opposed to experimental features, are intended to be strictly short-lived.
+                            They are designed to be useful for A/B testing, and the values of all active feature flags
+                            are added to every event log for the purpose of analytics.
                         </p>
                         <p>
-                            To learn more, refer to <Link
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                to="/help/dev/how-to/use_feature_flags"
-                            >
+                            To learn more, refer to{' '}
+                            <Link target="_blank" rel="noopener noreferrer" to="/help/dev/how-to/use_feature_flags">
                                 How to use feature flags
-                            </Link>.
+                            </Link>
+                            .
                         </p>
                     </>
-                )}
+                }
                 className="mb-3"
             />
 
@@ -152,17 +148,19 @@ const FeatureFlagNode: React.FunctionComponent<FeatureFlagNodeProps> = ({ node }
                     {node.__typename === 'FeatureFlagRollout' && node.rolloutBasisPoints}
                 </div>
 
-                {node.__typename === 'FeatureFlagRollout' && (<div>
-                    <meter
-                        min={0}
-                        max={1}
-                        optimum={1}
-                        value={node.rolloutBasisPoints/(100 * 100)}
-                        data-tooltip={`${Math.floor(node.rolloutBasisPoints/100)}%`}
-                        aria-label="rollout progress"
-                        data-placement="bottom"
-                    />
-                </div>)}
+                {node.__typename === 'FeatureFlagRollout' && (
+                    <div>
+                        <meter
+                            min={0}
+                            max={1}
+                            optimum={1}
+                            value={node.rolloutBasisPoints / (100 * 100)}
+                            data-tooltip={`${Math.floor(node.rolloutBasisPoints / 100)}%`}
+                            aria-label="rollout progress"
+                            data-placement="bottom"
+                        />
+                    </div>
+                )}
             </div>
         </span>
 
@@ -172,30 +170,33 @@ const FeatureFlagNode: React.FunctionComponent<FeatureFlagNodeProps> = ({ node }
         */}
         {node.overrides.length > 0 && (
             <Collapsible
-                title={<strong>{node.overrides.length} {node.overrides.length > 1 ? 'overrides' : 'override'}</strong>}
+                title={
+                    <strong>
+                        {node.overrides.length} {node.overrides.length > 1 ? 'overrides' : 'override'}
+                    </strong>
+                }
                 className="p-0 font-weight-normal"
                 titleClassName="flex-grow-1"
                 buttonClassName="mb-0"
                 defaultExpanded={false}
             >
                 <div className={classNames('pt-2', styles.nodeGrid)}>
-                    {node.overrides
-                        .map(override => (
-                            <React.Fragment key={override.id}>
-                                <div className="py-1 pr-2">
-                                    <code>{JSON.stringify(override.value)}</code>
-                                </div>
+                    {node.overrides.map(override => (
+                        <React.Fragment key={override.id}>
+                            <div className="py-1 pr-2">
+                                <code>{JSON.stringify(override.value)}</code>
+                            </div>
 
-                                <span className={classNames('py-1 pl-2', styles.nodeGridCode)}>
-                                    {/*
+                            <span className={classNames('py-1 pl-2', styles.nodeGridCode)}>
+                                {/*
                                         TODO: querying for namespace connection seems to
                                         error out often, so just present the ID for now.
                                         https://github.com/sourcegraph/sourcegraph/issues/32238
                                     */}
-                                    <code>{override.id}</code>
-                                </span>
-                            </React.Fragment>
-                        ))}
+                                <code>{override.id}</code>
+                            </span>
+                        </React.Fragment>
+                    ))}
                 </div>
             </Collapsible>
         )}

--- a/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
@@ -190,6 +190,7 @@ const FeatureFlagNode: React.FunctionComponent<FeatureFlagNodeProps> = ({ node }
                                     {/*
                                         TODO: querying for namespace connection seems to
                                         error out often, so just present the ID for now.
+                                        https://github.com/sourcegraph/sourcegraph/issues/32238
                                     */}
                                     <code>{override.id}</code>
                                 </span>

--- a/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
@@ -71,6 +71,8 @@ export const SiteAdminFeatureFlagsPage: React.FunctionComponent<SiteAdminFeature
                 nodes: featureFlagsOrErrors.filter(node =>
                     (args.type === undefined || node.__typename === args.type) &&
                     (!args.query || node.name.toLowerCase().includes(args.query.toLowerCase()))),
+                totalCount: featureFlagsOrErrors.length,
+                pageInfo: { hasNextPage: false },
             })
         },
         [featureFlagsOrErrors]

--- a/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
@@ -174,10 +174,9 @@ const FeatureFlagNode: React.FunctionComponent<FeatureFlagNodeProps> = ({ node }
             <Collapsible
                 title={<strong>{node.overrides.length} {node.overrides.length > 1 ? 'overrides' : 'override'}</strong>}
                 className="p-0 font-weight-normal"
+                titleClassName="flex-grow-1"
                 buttonClassName="mb-0"
-                titleAtStart={true}
                 defaultExpanded={false}
-                justifyContentBetween={false}
             >
                 <div className={classNames('pt-2', styles.nodeGrid)}>
                     {node.overrides

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -56,6 +56,9 @@ import {
     UserRepositoriesTotalCountVariables,
     SetUserTagResult,
     SetUserTagVariables,
+    FeatureFlagsResult,
+    FeatureFlagsVariables,
+    FeatureFlagFields,
 } from '../graphql-operations'
 
 type UserRepositories = (NonNullable<UserRepositoriesResult['node']> & { __typename: 'User' })['repositories']
@@ -1050,5 +1053,47 @@ export function fetchAllOutOfBandMigrations(): Observable<OutOfBandMigrationFiel
     ).pipe(
         map(dataOrThrowErrors),
         map(data => data.outOfBandMigrations)
+    )
+}
+
+/**
+ * Fetches all feature flags.
+ */
+export function fetchFeatureFlags(): Observable<FeatureFlagFields[]> {
+    return requestGraphQL<FeatureFlagsResult, FeatureFlagsVariables>(
+        gql`
+            query FeatureFlags {
+                featureFlags {
+                    ...FeatureFlagFields
+                }
+            }
+
+            fragment FeatureFlagFields on FeatureFlag {
+                __typename
+                ... on FeatureFlagBoolean {
+                    name
+                    value
+                    overrides {
+                        ...OverrideFields
+                    }
+                }
+                ... on FeatureFlagRollout {
+                    name
+                    rolloutBasisPoints
+                    overrides {
+                        ...OverrideFields
+                    }
+                }
+            }
+
+            fragment OverrideFields on FeatureFlagOverride {
+                id
+                value
+                # Querying on namespace seems bugged, so we just get id and value for now.
+            }
+        `
+    ).pipe(
+        map(dataOrThrowErrors),
+        map(data => data.featureFlags)
     )
 }

--- a/client/web/src/site-admin/routes.tsx
+++ b/client/web/src/site-admin/routes.tsx
@@ -120,4 +120,9 @@ export const siteAdminAreaRoutes: readonly SiteAdminAreaRoute[] = [
         exact: true,
         render: lazyComponent(() => import('./SiteAdminMigrationsPage'), 'SiteAdminMigrationsPage'),
     },
+    {
+        path: '/feature-flags',
+        exact: true,
+        render: lazyComponent(() => import('./SiteAdminFeatureFlagsPage'), 'SiteAdminFeatureFlagsPage'),
+    },
 ]

--- a/client/web/src/site-admin/sidebaritems.ts
+++ b/client/web/src/site-admin/sidebaritems.ts
@@ -43,6 +43,10 @@ export const configurationGroup: SiteAdminSideBarGroup = {
             label: 'Global settings',
             to: '/site-admin/global-settings',
         },
+        {
+            label: 'Feature flags',
+            to: '/site-admin/feature-flags',
+        },
     ],
 }
 


### PR DESCRIPTION
Adds a simple list view to the site admin pages that presents a simple list (of active feature flags)

This is a first iteration of https://github.com/sourcegraph/sourcegraph/issues/31182, which aims to introduce nicer UI/UX for [feature flags](https://docs.sourcegraph.com/dev/how-to/use_feature_flags).

Closes https://github.com/sourcegraph/sourcegraph/issues/32231

<img width="1182" alt="image" src="https://user-images.githubusercontent.com/23356519/156860333-fbfdbb31-75c0-42f5-8d71-9ecb2788a5b7.png">

## Notes

Querying for the namespace of an override seems to cause auth errors, at least on sourcegraph.com:

[API console link](https://sourcegraph.com/api/console#%7B%22query%22%3A%22%7B%5Cn%20%20featureFlags%20%7B%5Cn%20%20%20%20__typename%5Cn%20%20%20%20...%20on%20FeatureFlagBoolean%20%7B%5Cn%20%20%20%20%20%20name%5Cn%20%20%20%20%20%20value%5Cn%20%20%20%20%20%20overrides%20%7B%5Cn%20%20%20%20%20%20%20%20...OverrideFields%5Cn%20%20%20%20%20%20%7D%5Cn%20%20%20%20%7D%5Cn%20%20%20%20...%20on%20FeatureFlagRollout%20%7B%5Cn%20%20%20%20%20%20name%5Cn%20%20%20%20%20%20rolloutBasisPoints%5Cn%20%20%20%20%20%20overrides%20%7B%5Cn%20%20%20%20%20%20%20%20...OverrideFields%5Cn%20%20%20%20%20%20%7D%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%5Cn%5Cnfragment%20OverrideFields%20on%20FeatureFlagOverride%20%7B%5Cn%20%20id%5Cn%20%20value%5Cn%20%20namespace%20%7B%20namespaceName%20%7D%5Cn%7D%5Cn%22%7D)

```
{
  "errors": [
    {
      "message": "org not found: id 2615",
      "path": [
        "featureFlags",
        2,
        "overrides",
        0,
        "namespace"
      ]
    },
```

To avoid this, I'm opting to not render the namespace name for now, and just show the override ID (see screenshot)

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

```
sg run web-standalone-http-prod
```

See above for screenshot

