### PR TITLE
rockskip: Add an index on file extension

### DIFF
--- a/enterprise/internal/rockskip/search.go
+++ b/enterprise/internal/rockskip/search.go
@@ -370,11 +370,11 @@ func convertSearchArgsToSqlQuery(args types.SearchArgs) *sqlf.Query {
 
 	// IncludePatterns
 	for _, includePattern := range args.IncludePatterns {
-		conjunctOrNils = append(conjunctOrNils, regexMatch("path", "path_prefixes(path)", "singleton(file_extension)", includePattern, args.IsCaseSensitive))
+		conjunctOrNils = append(conjunctOrNils, regexMatch("path", "path_prefixes(path)", "singleton(get_file_extension(path))", includePattern, args.IsCaseSensitive))
 	}
 
 	// ExcludePattern
-	conjunctOrNils = append(conjunctOrNils, negate(regexMatch("path", "path_prefixes(path)", "singleton(file_extension)", args.ExcludePattern, args.IsCaseSensitive)))
+	conjunctOrNils = append(conjunctOrNils, negate(regexMatch("path", "path_prefixes(path)", "singleton(get_file_extension(path))", args.ExcludePattern, args.IsCaseSensitive)))
 
 	// Drop nils
 	conjuncts := []*sqlf.Query{}

--- a/enterprise/internal/rockskip/search.go
+++ b/enterprise/internal/rockskip/search.go
@@ -366,15 +366,15 @@ func convertSearchArgsToSqlQuery(args types.SearchArgs) *sqlf.Query {
 	conjunctOrNils := []*sqlf.Query{}
 
 	// Query
-	conjunctOrNils = append(conjunctOrNils, regexMatch("name", "", args.Query, args.IsCaseSensitive))
+	conjunctOrNils = append(conjunctOrNils, regexMatch("name", "", "", args.Query, args.IsCaseSensitive))
 
 	// IncludePatterns
 	for _, includePattern := range args.IncludePatterns {
-		conjunctOrNils = append(conjunctOrNils, regexMatch("path", "path_prefixes(path)", includePattern, args.IsCaseSensitive))
+		conjunctOrNils = append(conjunctOrNils, regexMatch("path", "path_prefixes(path)", "singleton(file_extension)", includePattern, args.IsCaseSensitive))
 	}
 
 	// ExcludePattern
-	conjunctOrNils = append(conjunctOrNils, negate(regexMatch("path", "path_prefixes(path)", args.ExcludePattern, args.IsCaseSensitive)))
+	conjunctOrNils = append(conjunctOrNils, negate(regexMatch("path", "path_prefixes(path)", "singleton(file_extension)", args.ExcludePattern, args.IsCaseSensitive)))
 
 	// Drop nils
 	conjuncts := []*sqlf.Query{}
@@ -391,7 +391,7 @@ func convertSearchArgsToSqlQuery(args types.SearchArgs) *sqlf.Query {
 	return sqlf.Join(conjuncts, "AND")
 }
 
-func regexMatch(column, columnForLiteralPrefix, regex string, isCaseSensitive bool) *sqlf.Query {
+func regexMatch(column, columnForLiteralPrefix, columnForFileExtension, regex string, isCaseSensitive bool) *sqlf.Query {
 	if regex == "" || regex == "^" {
 		return nil
 	}
@@ -404,6 +404,11 @@ func regexMatch(column, columnForLiteralPrefix, regex string, isCaseSensitive bo
 	// Prefix match optimization
 	if literal, ok, err := isLiteralPrefix(regex); err == nil && ok && isCaseSensitive && columnForLiteralPrefix != "" {
 		return sqlf.Sprintf(fmt.Sprintf("%%s && %s", columnForLiteralPrefix), pg.Array([]string{literal}))
+	}
+
+	// File extension match optimization
+	if exts := isFileExtensionMatch(regex); exts != nil && isCaseSensitive && columnForFileExtension != "" {
+		return sqlf.Sprintf(fmt.Sprintf("%%s && %s", columnForFileExtension), pg.Array(exts))
 	}
 
 	// Regex match
@@ -462,6 +467,26 @@ func isLiteralPrefix(expr string) (string, bool, error) {
 	}
 
 	return "", false, nil
+}
+
+// isFileExtensionMatch returns true if the given regex matches file extensions. If so, this function
+// returns true along with the extensions. If not, this function returns false.
+func isFileExtensionMatch(expr string) []string {
+	if !strings.HasPrefix(expr, `\.(`) {
+		return nil
+	}
+
+	expr = strings.TrimPrefix(expr, `\.(`)
+
+	if !strings.HasSuffix(expr, `)$`) {
+		return nil
+	}
+
+	expr = strings.TrimSuffix(expr, `)$`)
+
+	exts := strings.Split(expr, `|`)
+
+	return exts
 }
 
 func negate(query *sqlf.Query) *sqlf.Query {

--- a/enterprise/internal/rockskip/search_test.go
+++ b/enterprise/internal/rockskip/search_test.go
@@ -1,0 +1,37 @@
+package rockskip
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestIsFileExtensionMatch(t *testing.T) {
+	tests := []struct {
+		regex string
+		want  []string
+	}{
+		{
+			regex: "\\.(go)",
+			want:  nil,
+		},
+		{
+			regex: "(go)$",
+			want:  nil,
+		},
+		{
+			regex: "\\.(go)$",
+			want:  []string{"go"},
+		},
+		{
+			regex: "\\.(ts|tsx)$",
+			want:  []string{"ts", "tsx"},
+		},
+	}
+	for _, test := range tests {
+		got := isFileExtensionMatch(test.regex)
+		if diff := cmp.Diff(got, test.want); diff != "" {
+			t.Fatalf("isFileExtensionMatch(%q) returned %v, want %v, diff: %s", test.regex, got, test.want, diff)
+		}
+	}
+}

--- a/internal/database/schema.codeintel.md
+++ b/internal/database/schema.codeintel.md
@@ -786,7 +786,7 @@ Indexes:
  name    | text      |           | not null | 
 Indexes:
     "rockskip_symbols_pkey" PRIMARY KEY, btree (id)
-    "rockskip_symbols_gin" gin (singleton_integer(repo_id) gin__int_ops, added gin__int_ops, deleted gin__int_ops, singleton(path), path_prefixes(path), singleton(name), name gin_trgm_ops)
+    "rockskip_symbols_gin" gin (singleton_integer(repo_id) gin__int_ops, added gin__int_ops, deleted gin__int_ops, singleton(path), path_prefixes(path), singleton(name), name gin_trgm_ops, singleton(get_file_extension(path)))
     "rockskip_symbols_repo_id_path_name" btree (repo_id, path, name)
 
 ```

--- a/migrations/codeintel/1000000033/down.sql
+++ b/migrations/codeintel/1000000033/down.sql
@@ -1,0 +1,15 @@
+DROP INDEX IF EXISTS rockskip_symbols_gin;
+
+ALTER TABLE rockskip_symbols DROP COLUMN file_extension;
+
+DROP FUNCTION IF EXISTS get_file_extension;
+
+CREATE INDEX IF NOT EXISTS rockskip_symbols_gin ON rockskip_symbols USING GIN (
+    singleton_integer(repo_id) gin__int_ops,
+    added gin__int_ops,
+    deleted gin__int_ops,
+    singleton(path),
+    path_prefixes(path),
+    singleton(name),
+    name gin_trgm_ops
+);

--- a/migrations/codeintel/1000000033/down.sql
+++ b/migrations/codeintel/1000000033/down.sql
@@ -1,7 +1,5 @@
 DROP INDEX IF EXISTS rockskip_symbols_gin;
 
-ALTER TABLE rockskip_symbols DROP COLUMN file_extension;
-
 DROP FUNCTION IF EXISTS get_file_extension;
 
 CREATE INDEX IF NOT EXISTS rockskip_symbols_gin ON rockskip_symbols USING GIN (

--- a/migrations/codeintel/1000000033/metadata.yaml
+++ b/migrations/codeintel/1000000033/metadata.yaml
@@ -1,0 +1,2 @@
+name: 'rockskip file extension'
+parent: 1000000032

--- a/migrations/codeintel/1000000033/up.sql
+++ b/migrations/codeintel/1000000033/up.sql
@@ -1,0 +1,18 @@
+DROP INDEX IF EXISTS rockskip_symbols_gin;
+
+CREATE OR REPLACE FUNCTION get_file_extension(path TEXT) RETURNS TEXT AS $$ BEGIN
+    RETURN substring(path FROM '\.([^\.]*)$');
+END; $$ IMMUTABLE language plpgsql;
+
+ALTER TABLE rockskip_symbols ADD COLUMN file_extension TEXT GENERATED ALWAYS AS (get_file_extension(path)) STORED;
+
+CREATE INDEX IF NOT EXISTS rockskip_symbols_gin ON rockskip_symbols USING GIN (
+    singleton_integer(repo_id) gin__int_ops,
+    added gin__int_ops,
+    deleted gin__int_ops,
+    singleton(path),
+    path_prefixes(path),
+    singleton(name),
+    name gin_trgm_ops,
+    singleton(file_extension)
+);

--- a/migrations/codeintel/1000000033/up.sql
+++ b/migrations/codeintel/1000000033/up.sql
@@ -4,8 +4,6 @@ CREATE OR REPLACE FUNCTION get_file_extension(path TEXT) RETURNS TEXT AS $$ BEGI
     RETURN substring(path FROM '\.([^\.]*)$');
 END; $$ IMMUTABLE language plpgsql;
 
-ALTER TABLE rockskip_symbols ADD COLUMN file_extension TEXT GENERATED ALWAYS AS (get_file_extension(path)) STORED;
-
 CREATE INDEX IF NOT EXISTS rockskip_symbols_gin ON rockskip_symbols USING GIN (
     singleton_integer(repo_id) gin__int_ops,
     added gin__int_ops,
@@ -14,5 +12,5 @@ CREATE INDEX IF NOT EXISTS rockskip_symbols_gin ON rockskip_symbols USING GIN (
     path_prefixes(path),
     singleton(name),
     name gin_trgm_ops,
-    singleton(file_extension)
+    singleton(get_file_extension(path))
 );


### PR DESCRIPTION
Search-based code intel [searches by file extension](https://github.com/sourcegraph/code-intel-extensions/blob/1b78262e538b5bb1c31ecf9d249060fad5915016/template/src/search/queries.ts#L80) with queries like:

```
file:\.(ts|tsx)$
```

This change adds an index on file extension and optimizes these queries. Without this optimization, queries on the megarepo can take multiple seconds.


## Test plan

Automated tests
