### PR TITLE
zoekt: Fix nil panic

### DIFF
--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -275,6 +275,10 @@ func PartitionRepos(
 }
 
 func DoZoektSearchGlobal(ctx context.Context, args *search.ZoektParameters, c streaming.Sender) error {
+	if args.Zoekt == nil {
+		return nil
+	}
+
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 


### PR DESCRIPTION
With `"search.index.enabled": false`, Zoekt searches panic because `args.Zoekt` is `nil`.

Is this an appropriate fix? I didn't see where the choice between indexed and unindexed search is made, so I simply returned `nil` early.

![CleanShot 2022-03-05 at 13 01 22@2x](https://user-images.githubusercontent.com/1387653/156898383-edd10086-c545-4e87-b4df-3b5230c8080f.png)

## Test plan

No test plan yet, this is a draft.