### PR TITLE
repos: remove global DB mocks in fetching status messages

### DIFF
--- a/internal/repos/status_messages.go
+++ b/internal/repos/status_messages.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -16,7 +15,7 @@ var MockStatusMessages func(context.Context, *types.User) ([]StatusMessage, erro
 // external service sync errors we'll fetch any external services owned by the
 // user. In addition, if the user is a site admin we'll also fetch site level
 // external services.
-func FetchStatusMessages(ctx context.Context, db dbutil.DB, u *types.User) ([]StatusMessage, error) {
+func FetchStatusMessages(ctx context.Context, db database.DB, u *types.User) ([]StatusMessage, error) {
 	if MockStatusMessages != nil {
 		return MockStatusMessages(ctx, u)
 	}
@@ -27,7 +26,7 @@ func FetchStatusMessages(ctx context.Context, db dbutil.DB, u *types.User) ([]St
 
 	// We first fetch affiliated sync errors since this will also find all the
 	// external services the user cares about.
-	externalServiceSyncErrors, err := database.ExternalServices(db).GetAffiliatedSyncErrors(ctx, u)
+	externalServiceSyncErrors, err := db.ExternalServices().GetAffiliatedSyncErrors(ctx, u)
 	if err != nil {
 		return nil, errors.Wrap(err, "fetching sync errors")
 	}
@@ -66,7 +65,7 @@ func FetchStatusMessages(ctx context.Context, db dbutil.DB, u *types.User) ([]St
 			Limit: 1,
 		},
 	}
-	notCloned, err := database.Repos(db).ListMinimalRepos(ctx, opts)
+	notCloned, err := db.Repos().ListMinimalRepos(ctx, opts)
 	if err != nil {
 		return nil, errors.Wrap(err, "listing not-cloned repos")
 	}
@@ -86,7 +85,7 @@ func FetchStatusMessages(ctx context.Context, db dbutil.DB, u *types.User) ([]St
 			Limit: 1,
 		},
 	}
-	failedSync, err := database.Repos(db).ListMinimalRepos(ctx, opts)
+	failedSync, err := db.Repos().ListMinimalRepos(ctx, opts)
 	if err != nil {
 		return nil, errors.Wrap(err, "counting repo sync failures")
 	}


### PR DESCRIPTION
This PR reduces usage of `database.Mocks`.

This is the result of a time-boxed effort.

## Test plan

Unit tests.


---

Part of #26113