### PR TITLE
docs: Remove warning about Batch Changes renaming

### DIFF
--- a/doc/batch_changes/index.md
+++ b/doc/batch_changes/index.md
@@ -35,8 +35,6 @@ body.theme-dark .markdown-body ul li:before {
 
 <p class="subtitle">Make large-scale code changes across many repositories and code hosts</p>
 
-> WARNING: Campaigns was renamed to Sourcegraph Batch Changes in version 3.26. [Read more](references/name-change.md)
-
 <p class="lead">
 Create a batch change by specifying a search query to get a list of repositories and a script to run in each. You can also <a href="how-tos/creating_changesets_per_project_in_monorepos">create a batch change on a monorepo</a> by specifying which projects to run the script on. The batch change then lets you create changesets (a generic term for pull requests or merge requests) on all affected repositories or projects. Batch Changes allows you to track their progress until they're all merged. You can preview the changes and update them at any time. A batch change can also be used to track and manage manually created changesets.
 </p>


### PR DESCRIPTION
I ran into this while doing something different in the docs and I have
to say: the first impression when seeing something orange with
"WARNING:" in it on the top of a docs page is not good.

So since it's been over 10 releases, I think it's fine to remove it.

## Test plan

- `sg run docsite` and look at the docs.
