### PR TITLE
user invites: Small accessibility improvements for homepage invites

### DIFF
--- a/client/web/src/search/panels/CollaboratorsPanel.module.scss
+++ b/client/web/src/search/panels/CollaboratorsPanel.module.scss
@@ -65,6 +65,10 @@
     font-size: 0.75rem;
 }
 
+.info-button {
+    padding: 0;
+}
+
 .info-box {
     font-size: 0.85rem;
 }

--- a/client/web/src/search/panels/CollaboratorsPanel.module.scss
+++ b/client/web/src/search/panels/CollaboratorsPanel.module.scss
@@ -65,10 +65,6 @@
     font-size: 0.75rem;
 }
 
-.info-button {
-    padding: 0;
-}
-
 .info-box {
     font-size: 0.85rem;
 }

--- a/client/web/src/search/panels/CollaboratorsPanel.tsx
+++ b/client/web/src/search/panels/CollaboratorsPanel.tsx
@@ -8,7 +8,7 @@ import { Observable } from 'rxjs'
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { ErrorLike, isErrorLike } from '@sourcegraph/common'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Button, Card, CardBody, Link, LoadingSpinner } from '@sourcegraph/wildcard'
+import { Button, Card, CardBody, Link, LoadingSpinner, useObservable } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { InvitableCollaborator } from '../../auth/welcome/InviteCollaborators/InviteCollaborators'
@@ -243,7 +243,7 @@ const CollaboratorsPanelInfo: React.FunctionComponent<{ isSiteAdmin: boolean }> 
                 <InformationOutlineIcon className="icon-inline mr-1 text-muted" />
                 <Button
                     variant="link"
-                    className={classNames(styles.info, styles.infoButton)}
+                    className={classNames(styles.info, 'p-0')}
                     onClick={() => setInfoShown(true)}
                     aria-haspopup="true"
                     aria-expanded="false"

--- a/client/web/src/search/panels/CollaboratorsPanel.tsx
+++ b/client/web/src/search/panels/CollaboratorsPanel.tsx
@@ -8,7 +8,7 @@ import { Observable } from 'rxjs'
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { ErrorLike, isErrorLike } from '@sourcegraph/common'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Button, Card, CardBody, Link, LoadingSpinner, useObservable } from '@sourcegraph/wildcard'
+import { Button, Card, CardBody, Link, LoadingSpinner } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { InvitableCollaborator } from '../../auth/welcome/InviteCollaborators/InviteCollaborators'
@@ -210,7 +210,7 @@ const CollaboratorsPanelInfo: React.FunctionComponent<{ isSiteAdmin: boolean }> 
                                 aria-label="Close info box"
                                 aria-expanded="true"
                             >
-                                ×
+                                <span aria-hidden="true">×</span>
                             </Button>
                         </div>
                         {isSiteAdmin ? (
@@ -221,6 +221,7 @@ const CollaboratorsPanelInfo: React.FunctionComponent<{ isSiteAdmin: boolean }> 
                                     but no special permissions are granted.
                                 </p>
                                 <p className={classNames(styles.infoBox, 'mb-0')}>
+                                    {/* TODO(#32253): Update the documentation link */}
                                     If you wish to disable this feature, see <Link to="#">this documentation</Link>.
                                 </p>
                             </>
@@ -241,18 +242,15 @@ const CollaboratorsPanelInfo: React.FunctionComponent<{ isSiteAdmin: boolean }> 
             <div className="flex-grow-1" />
             <div>
                 <InformationOutlineIcon className="icon-inline mr-1 text-muted" />
-                <Link
-                    to="#"
-                    className={styles.info}
-                    onClick={event => {
-                        event.preventDefault()
-                        setInfoShown(true)
-                    }}
+                <Button
+                    variant="link"
+                    className={classNames(styles.info, styles.infoButton)}
+                    onClick={() => setInfoShown(true)}
                     aria-haspopup="true"
                     aria-expanded="false"
                 >
                     What is this?
-                </Link>
+                </Button>
             </div>
         </div>
     )

--- a/client/web/src/search/panels/CollaboratorsPanel.tsx
+++ b/client/web/src/search/panels/CollaboratorsPanel.tsx
@@ -34,7 +34,6 @@ export const CollaboratorsPanel: React.FunctionComponent<Props> = ({
     authenticatedUser,
     fetchCollaborators,
 }) => {
-    console.log(authenticatedUser)
     const inviteEmailToSourcegraph = useInviteEmailToSourcegraph()
     const collaborators = useObservable(
         useMemo(() => fetchCollaborators(authenticatedUser?.id || ''), [fetchCollaborators, authenticatedUser?.id])


### PR DESCRIPTION
Follow up for #32006

This PR implements the suggested changes from @limitedmage in https://github.com/sourcegraph/sourcegraph/pull/32006. Thanks for the feedback!

- The button to toggle the info view is now a proper `<Button>`
- I created a ticket so we don't forget to change the documentation link (#32253)
- The `×` is now behind an aria-hidden (the button already has an aria-label)
- Removed a leftover `console.log`

## Test plan

The biggest changes are the switch from `Link` to `Button` so I made sure there are no visual regression:
 
![Screenshot 2022-03-07 at 12 39 54](https://user-images.githubusercontent.com/458591/157027259-ed81e2f8-95db-4f49-a978-c26abd6cabeb.png)

We also have UI screenshot tests.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


