### PR TITLE
Do not use legacy URL format in code intel docs

### DIFF
--- a/doc/code_intelligence/index.md
+++ b/doc/code_intelligence/index.md
@@ -60,7 +60,7 @@ Code intelligence provides advanced code navigation features that let developers
    Watch the code intelligence demo video to see it in action on GitHub.
   </a>
 
-  <a href="https://sourcegraph.com/github.com/dgrijalva/jwt-go/-/blob/token.go#L37:6$references" class="btn" alt="Try code intelligence on public code">
+  <a href="https://sourcegraph.com/github.com/dgrijalva/jwt-go/-/blob/token.go?L37:6#tab=references" class="btn" alt="Try code intelligence on public code">
    <span>Try on public code</span>
    </br>
    Interested in trying code intelligence out on public code? See this sample file on Sourcegraph Cloud.


### PR DESCRIPTION
Tiniest of all the fixes, but hey, fix it when you see it, right?

## Test plan

- `sg run docsite`

