### PR TITLE
Initially implement new empty avatar background

### DIFF
--- a/client/web/src/nav/__snapshots__/UserNavItem.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/UserNavItem.test.tsx.snap
@@ -20,7 +20,11 @@ exports[`UserNavItem simple 1`] = `
           class="userAvatar icon-inline avatar"
           id="target-user-avatar"
         >
-          ad
+          <span
+            class="initials"
+          >
+            ad
+          </span>
         </div>
         <svg
           class="mdi-icon icon-inline"

--- a/client/web/src/user/UserAvatar.module.scss
+++ b/client/web/src/user/UserAvatar.module.scss
@@ -11,7 +11,7 @@
     left: 0;
     border-radius: 50%;
     background: linear-gradient(to right, $v1, $v3);
-    -webkit-mask-image: linear-gradient(to bottom, black, transparent);
+    mask-image: linear-gradient(to bottom, black, transparent);
   }
 }
 
@@ -30,4 +30,5 @@
 
 .initials {
     z-index: 1;
+    color: var(--white);
 }

--- a/client/web/src/user/UserAvatar.module.scss
+++ b/client/web/src/user/UserAvatar.module.scss
@@ -1,18 +1,17 @@
 @mixin quad-vertex-colors($v0, $v1, $v2, $v3) {
-  background: linear-gradient(to bottom, $v0, $v2);
+    background: linear-gradient(to bottom, $v0, $v2);
 
-  &::after {
-
-    content: '';
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    border-radius: 50%;
-    background: linear-gradient(to right, $v1, $v3);
-    mask-image: linear-gradient(to bottom, #000000, transparent);
-  }
+    &::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        border-radius: 50%;
+        background: linear-gradient(to right, $v1, $v3);
+        mask-image: linear-gradient(to bottom, #000000, transparent);
+    }
 }
 
 .user-avatar {

--- a/client/web/src/user/UserAvatar.module.scss
+++ b/client/web/src/user/UserAvatar.module.scss
@@ -1,9 +1,9 @@
-@mixin QuadVertexColors($v0, $v1, $v2, $v3) {
+@mixin quad-vertex-colors($v0, $v1, $v2, $v3) {
   background: linear-gradient(to bottom, $v0, $v2);
 
   &::after {
 
-    content: "";
+    content: '';
     position: absolute;
     top: 0;
     right: 0;
@@ -11,7 +11,7 @@
     left: 0;
     border-radius: 50%;
     background: linear-gradient(to right, $v1, $v3);
-    mask-image: linear-gradient(to bottom, black, transparent);
+    mask-image: linear-gradient(to bottom, #000000, transparent);
   }
 }
 
@@ -25,7 +25,7 @@
     min-width: 1.5rem;
     min-height: 1.5rem;
     position: relative;
-    @include QuadVertexColors(var(--logo-purple), var(--logo-purple), var(--logo-orange), var(--logo-blue));
+    @include quad-vertex-colors(var(--logo-purple), var(--logo-purple), var(--logo-orange), var(--logo-blue));
 }
 
 .initials {

--- a/client/web/src/user/UserAvatar.module.scss
+++ b/client/web/src/user/UserAvatar.module.scss
@@ -1,11 +1,33 @@
+@mixin QuadVertexColors($v0, $v1, $v2, $v3) {
+  background: linear-gradient(to bottom, $v0, $v2);
+
+  &::after {
+
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    border-radius: 50%;
+    background: linear-gradient(to right, $v1, $v3);
+    -webkit-mask-image: linear-gradient(to bottom, black, transparent);
+  }
+}
+
 .user-avatar {
     display: inline-flex;
     border-radius: 50%;
     text-transform: capitalize;
-    background: linear-gradient(90deg, #b200f8 0%, #a537f8 20%, #974ff9 40%, #8760f9 60%, #746ffa 80%, #5c7cfa 100%);
     color: var(--color-bg-1);
     align-items: center;
     justify-content: center;
     min-width: 1.5rem;
     min-height: 1.5rem;
+    position: relative;
+    @include QuadVertexColors(var(--logo-purple), var(--logo-purple), var(--logo-orange), var(--logo-blue));
+}
+
+.initials {
+    z-index: 1;
 }

--- a/client/web/src/user/UserAvatar.tsx
+++ b/client/web/src/user/UserAvatar.tsx
@@ -65,7 +65,7 @@ export const UserAvatar: React.FunctionComponent<Props> = ({
 
     return (
         <div id={targetID} className={classNames(styles.userAvatar, className)}>
-            {getInitials(name)}
+            <span className={styles.initials}>{getInitials(name)}</span>
         </div>
     )
 }

--- a/client/web/src/user/__snapshots__/UserAvatar.test.tsx.snap
+++ b/client/web/src/user/__snapshots__/UserAvatar.test.tsx.snap
@@ -5,7 +5,11 @@ exports[`UserAvatar no avatar URL 1`] = `
   <div
     class="userAvatar"
   >
-    t
+    <span
+      class="initials"
+    >
+      t
+    </span>
   </div>
 </DocumentFragment>
 `;


### PR DESCRIPTION
This updates the default avatar background from a simple gradient to a slightly more complex 4-colour gradient. This was originally designed as part of the redesign, but we didn't carry it out in full. I'm using this element in an upcoming effort and will value having the full gradient. 

I'm also enforcing the initial colour as `var(--white)` regardless of theme, for better contrast and visibility.

**Before:**

<img width="191" alt="image" src="https://user-images.githubusercontent.com/6304497/157043646-acf0d3dc-ac43-44bc-9c76-3bbbc6318614.png">
<img width="395" alt="image" src="https://user-images.githubusercontent.com/6304497/157043644-1d610a04-a235-4d49-98c3-124eb75f7f7e.png">

**After:**

<img width="321" alt="image" src="https://user-images.githubusercontent.com/6304497/157043687-fcb40fc9-b3a8-4798-b52e-0bed562e54f1.png">
<img width="248" alt="image" src="https://user-images.githubusercontent.com/6304497/157043693-709d558f-99cf-4fc2-8ae0-5344ff0a551e.png">

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

This is used anywhere the default user avatar is displayed.