### PR TITLE
Fix unnecessary recreation of temporary settings hook updater callback

### DIFF
--- a/client/shared/src/settings/temporary/useTemporarySetting.test.tsx
+++ b/client/shared/src/settings/temporary/useTemporarySetting.test.tsx
@@ -1,7 +1,8 @@
 import { gql } from '@apollo/client'
 import { createMockClient } from '@apollo/client/testing'
-import { renderHook, act } from '@testing-library/react-hooks'
-import React from 'react'
+import { render } from '@testing-library/react'
+import { renderHook, act as actHook } from '@testing-library/react-hooks'
+import React, { useEffect } from 'react'
 
 import { TemporarySettingsContext } from './TemporarySettingsProvider'
 import { InMemoryMockSettingsBackend, TemporarySettingsStorage } from './TemporarySettingsStorage'
@@ -68,11 +69,42 @@ describe('useTemporarySetting', () => {
         })
 
         const [, setValue] = result.current
-        act(() => setValue({ filters: true, reference: false }))
-        act(() => setValue({ filters: true, reference: false }))
+        actHook(() => setValue({ filters: true, reference: false }))
+        actHook(() => setValue({ filters: true, reference: false }))
 
         const [value] = result.current
         expect(value).toEqual({ filters: true, reference: false })
+    })
+
+    it('should support the updater callback pattern', () => {
+        const settingsBackend = new InMemoryMockSettingsBackend({})
+        const settingsStorage = new TemporarySettingsStorage(mockClient, false)
+        settingsStorage.setSettingsBackend(settingsBackend)
+
+        const { result } = renderHook(() => useTemporarySetting('search.collapsedSidebarSections'), {
+            wrapper: ({ children }) => (
+                <TemporarySettingsContext.Provider value={settingsStorage}>
+                    {children}
+                </TemporarySettingsContext.Provider>
+            ),
+        })
+
+        const [, setValue] = result.current
+        actHook(() =>
+            setValue(currentValue => {
+                expect(currentValue).toEqual(undefined)
+                return { filters: true, reference: false }
+            })
+        )
+        actHook(() =>
+            setValue(currentValue => {
+                expect(currentValue).toEqual({ filters: true, reference: false })
+                return { filters: true, reference: true }
+            })
+        )
+
+        const [value] = result.current
+        expect(value).toEqual({ filters: true, reference: true })
     })
 
     it('should update other hook values if changed in another hook', () => {
@@ -97,7 +129,7 @@ describe('useTemporarySetting', () => {
         })
 
         const [, setValue] = result1.current
-        act(() => setValue({ filters: true, reference: false }))
+        actHook(() => setValue({ filters: true, reference: false }))
 
         const [value] = result2.current
         expect(value).toEqual({ filters: true, reference: false })
@@ -122,9 +154,34 @@ describe('useTemporarySetting', () => {
             'search.collapsedSidebarSections': { repositories: true },
         })
 
-        act(() => settingsStorage.setSettingsBackend(settingsBackend2))
+        actHook(() => settingsStorage.setSettingsBackend(settingsBackend2))
 
         const [value] = result.current
         expect(value).toEqual({ repositories: true })
+    })
+
+    it('should not recreate the updater function', () => {
+        const settingsBackend1 = new InMemoryMockSettingsBackend({
+            'search.collapsedSidebarSections': { filters: true, reference: false },
+        })
+        const settingsStorage = new TemporarySettingsStorage(mockClient, false)
+        settingsStorage.setSettingsBackend(settingsBackend1)
+
+        let updateCount = 0
+        const Component = () => {
+            const [_setting, setSetting] = useTemporarySetting('search.collapsedSidebarSections')
+            useEffect(() => {
+                updateCount++
+            }, [setSetting])
+            return null
+        }
+
+        render(
+            <TemporarySettingsContext.Provider value={settingsStorage}>
+                <Component />
+            </TemporarySettingsContext.Provider>
+        )
+
+        expect(updateCount).toBe(1)
     })
 })


### PR DESCRIPTION
While working on https://github.com/sourcegraph/sourcegraph/pull/32209 I noticed that the updater function of the temporary settings hook is not stable across renders.

This means that if you want to use it inside an effect, that effect would re-render whenever the current value changes. That would happen on load (as the currentValue switch from `undefined` to what the backend returns) but also when the updater function is used to update the value.

To fix the issue, we create a reference that  always points to the latest updated value.

## Test plan

I started by adding a regression test for the updater function pattern as well as a test that _FAILS_ with the current implementation:

```
$ /Users/philipp/dev/sourcegraph/node_modules/.bin/jest useTemporarySetting
 FAIL   shared  client/shared/src/settings/temporary/useTemporarySetting.test.tsx
  useTemporarySetting
    ✓ should get correct data from storage (9 ms)
    ✓ should get undefined if data does not exist in storage (1 ms)
    ✓ should save data and update value (1 ms)
    ✓ should support the updater callback pattern (2 ms)
    ✓ should update other hook values if changed in another hook (1 ms)
    ✓ should update data if backend changed (1 ms)
    ✕ should not recreate the updater function (7 ms)

  ● useTemporarySetting › should not recreate the updater function

    expect(received).toBe(expected) // Object.is equality

    Expected: 1
    Received: 2

      183 |         )
      184 |
    > 185 |         expect(updateCount).toBe(1)
          |                             ^
      186 |     })
      187 | })
      188 |

      at Object.<anonymous> (src/settings/temporary/useTemporarySetting.test.tsx:185:29)
      at TestScheduler.scheduleTests (../../node_modules/@jest/core/build/TestScheduler.js:333:13)
      at runJest (../../node_modules/@jest/core/build/runJest.js:404:19)
      at _run10000 (../../node_modules/@jest/core/build/cli/index.js:320:7)
      at runCLI (../../node_modules/@jest/core/build/cli/index.js:173:3)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 6 passed, 7 total
Snapshots:   0 total
Time:        1.05 s
Ran all test suites matching /useTemporarySetting/i.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

With the changes applied, all tests pass:

```
α sourcegraph (ps/fix-temporary-settings-hook-rerender)✗ yarn jest useTemporarySetting
yarn run v1.22.17
$ /Users/philipp/dev/sourcegraph/node_modules/.bin/jest useTemporarySetting
 PASS   shared  client/shared/src/settings/temporary/useTemporarySetting.test.tsx
  useTemporarySetting
    ✓ should get correct data from storage (10 ms)
    ✓ should get undefined if data does not exist in storage (2 ms)
    ✓ should save data and update value (2 ms)
    ✓ should support the updater callback pattern (2 ms)
    ✓ should update other hook values if changed in another hook (3 ms)
    ✓ should update data if backend changed (1 ms)
    ✓ should not recreate the updater function (7 ms)

Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
Snapshots:   0 total
Time:        1.016 s
Ran all test suites matching /useTemporarySetting/i.
✨  Done in 2.05s.
```

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


