### PR TITLE
Add example for how to use <MockTemporarySettings> to the docs

### DIFF
--- a/doc/dev/background-information/web/temporary_settings.md
+++ b/doc/dev/background-information/web/temporary_settings.md
@@ -4,10 +4,10 @@ Basic user settings that should be retained for users across sessions
 can be stored as temporary settings. These should be trivial settings
 that would be fine if they were lost.
 
-For authenticated users, temporary settings are stored in the database 
+For authenticated users, temporary settings are stored in the database
 in the `temporary_setings` table and are queried and modified via the GraphQL API.
 
-For unauthenticated users, temporary settings are stored in `localStorage`. 
+For unauthenticated users, temporary settings are stored in `localStorage`.
 
 ## Difference between temporary settings and site settings
 
@@ -34,7 +34,7 @@ Examples of data that is a good candidate for temporary settings include:
 * The collapse state of a panel
 * Basic theme settings like "light" or "dark"
 * "Most recently used" lists
-* Data needed for keeping track of a user's interactions as part of an 
+* Data needed for keeping track of a user's interactions as part of an
   A/B test or flight, or similar settings that should not be user-editable
 
 Examples of data that should not be stored as temporary settings include:
@@ -51,14 +51,14 @@ Examples of data that should not be stored as temporary settings include:
 
 ### Update schema
 
-Update the interface [`TemporarySettingsSchema` in `TemporarySettings.ts`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/settings/temporary/TemporarySettings.ts?L8:18) 
+Update the interface [`TemporarySettingsSchema` in `TemporarySettings.ts`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/settings/temporary/TemporarySettings.ts?L8:18)
 by adding a key for the setting you want to store. The key should be namespaced based on
-the area of the site that will be using the settings. Example names include `'search.collapsedSidebarSections'` 
+the area of the site that will be using the settings. Example names include `'search.collapsedSidebarSections'`
 or `'codeInsights.hiddenCharts'`. The value of the setting can be any JSON-serializable type.
 
 ### Getting and setting settings
 
-Use the React hook [`useTemporarySetting`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/settings/temporary/useTemporarySetting.ts?L14:33) 
+Use the React hook [`useTemporarySetting`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/settings/temporary/useTemporarySetting.ts?L14:33)
 to get an up-to-date value of the setting and a function that can update the value,
 similar to other hooks like `useState`. The value will be updated automatically if
 the user's authentication state changes or the setting is modified elsewhere in the
@@ -140,4 +140,20 @@ mutation {
     alwaysNil
   }
 }
+```
+
+## Testing temporary settings
+
+In order to make it easier to write test against temporary settings, you can use the `<MockTemporarySettings>` component inside your component tests:
+
+```typescript
+it('mocks saved temporary settings', () => {
+    render(
+        <MockTemporarySettings settings={{ 'search.contexts.ctaDismissed': false }}>
+            <MyComponent />
+        </MockTemporarySettings>
+    )
+
+    // Your test assertions
+})
 ```


### PR DESCRIPTION
Based on feedback from https://github.com/sourcegraph/sourcegraph/pull/32209#discussion_r819778771. I did look at the wiki page before attempting to set up my own mocking so I thought it might be fitting to add an example of it there.

## Test plan

Not applicable, this is only a docs change.