### PR TITLE
Remove no contributors found text when emails are disabled

### DIFF
--- a/client/web/src/search/panels/CollaboratorsPanel.tsx
+++ b/client/web/src/search/panels/CollaboratorsPanel.tsx
@@ -175,7 +175,7 @@ const CollaboratorsPanelNullState: React.FunctionComponent<{ username: string }>
                 'h-100'
             )}
         >
-            <div className="text-center">No collaborators found in sampled repositories.</div>
+            {emailEnabled ? <div className="text-center">No collaborators found in sampled repositories.</div> : null}
             <div className="text-muted mt-3 text-center">
                 You can invite people to Sourcegraph with this direct link:
             </div>


### PR DESCRIPTION
Part of #31214
Fixes #32123

If you take a look at [this test plan](https://github.com/sourcegraph/sourcegraph/pull/31406#issue-1141477945) it's rather odd that we show a message saying that we haven't found collaborators when the real reason is that email is not configured.

We could also add a hint here for site admins to enable emails. WDYT @rrhyne @slimsag?

## Test plan

Here's a dotcom version with email disabled but invites enabled:

![Screenshot 2022-03-07 at 16 49 12](https://user-images.githubusercontent.com/458591/157068948-1be267fa-f4c0-449c-aca3-97de42827574.png)

