### PR TITLE
user invites: Disable user invites when instance signup is disabled and on on-prem

### DIFF
--- a/client/web/src/search/home/SearchPage.story.tsx
+++ b/client/web/src/search/home/SearchPage.story.tsx
@@ -13,6 +13,7 @@ import { extensionsController } from '@sourcegraph/shared/src/testing/searchTest
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
 import { WebStory } from '../../components/WebStory'
+import { SourcegraphContext } from '../../jscontext'
 import { useExperimentalFeatures } from '../../stores'
 import { ThemePreference } from '../../stores/themeState'
 import {
@@ -59,6 +60,12 @@ const defaultProps = (props: ThemeProps): SearchPageProps => ({
     getUserSearchContextNamespaces: mockGetUserSearchContextNamespaces,
     featureFlags: new Map(),
 })
+
+if (!window.context) {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    window.context = {} as SourcegraphContext & Mocha.SuiteFunction
+}
+window.context.allowSignup = true
 
 const { add } = storiesOf('web/search/home/SearchPage', module)
     .addParameters({

--- a/client/web/src/search/home/SearchPage.test.tsx
+++ b/client/web/src/search/home/SearchPage.test.tsx
@@ -12,6 +12,7 @@ import {
 } from '@sourcegraph/shared/src/testing/searchContexts/testHelpers'
 import { extensionsController } from '@sourcegraph/shared/src/testing/searchTestHelpers'
 
+import { SourcegraphContext } from '../../jscontext'
 import { useExperimentalFeatures } from '../../stores'
 import { ThemePreference } from '../../stores/themeState'
 import { authUser } from '../panels/utils'
@@ -33,6 +34,11 @@ jest.mock('./LoggedOutHomepage.constants', () => ({
 
 describe('SearchPage', () => {
     afterAll(cleanup)
+
+    beforeEach(() => {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        window.context = {} as SourcegraphContext & Mocha.SuiteFunction
+    })
 
     let container: HTMLElement
 

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -66,7 +66,8 @@ export const SearchPage: React.FunctionComponent<SearchPageProps> = props => {
         () => isExperimentalOnboardingTourEnabled && !hasSearchQuery && !isGettingStartedTourEnabled,
         [hasSearchQuery, isGettingStartedTourEnabled, isExperimentalOnboardingTourEnabled]
     )
-    const showCollaborators = useExperimentalFeatures(features => features.homepageUserInvitation) ?? false
+    const homepageUserInvitation = useExperimentalFeatures(features => features.homepageUserInvitation) ?? false
+    const showCollaborators = window.context.allowSignup && homepageUserInvitation
 
     useEffect(() => props.telemetryService.logViewEvent('Home'), [props.telemetryService])
 

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -67,8 +67,7 @@ export const SearchPage: React.FunctionComponent<SearchPageProps> = props => {
         [hasSearchQuery, isGettingStartedTourEnabled, isExperimentalOnboardingTourEnabled]
     )
     const homepageUserInvitation = useExperimentalFeatures(features => features.homepageUserInvitation) ?? false
-    const showCollaborators =
-        window.context.allowSignup && homepageUserInvitation && window.context.sourcegraphDotComMode
+    const showCollaborators = window.context.allowSignup && homepageUserInvitation && props.isSourcegraphDotCom
 
     useEffect(() => props.telemetryService.logViewEvent('Home'), [props.telemetryService])
 

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -67,7 +67,8 @@ export const SearchPage: React.FunctionComponent<SearchPageProps> = props => {
         [hasSearchQuery, isGettingStartedTourEnabled, isExperimentalOnboardingTourEnabled]
     )
     const homepageUserInvitation = useExperimentalFeatures(features => features.homepageUserInvitation) ?? false
-    const showCollaborators = window.context.allowSignup && homepageUserInvitation
+    const showCollaborators =
+        window.context.allowSignup && homepageUserInvitation && window.context.sourcegraphDotComMode
 
     useEffect(() => props.telemetryService.logViewEvent('Home'), [props.telemetryService])
 


### PR DESCRIPTION
Fixes #32123

When an instance has signups disabled, there's no value in our feature so we might as well disable it?

Additionally this force-disables this feature on non .com instances for now.

## Test plan

I configured the server as suggested below and verified that the variables have the correct value by adding `console.log` statements:

![Screenshot 2022-03-08 at 11 51 13](https://user-images.githubusercontent.com/458591/157224264-29a79c25-5832-44ea-9397-579c277beff8.png)

![Screenshot 2022-03-08 at 14 01 04](https://user-images.githubusercontent.com/458591/157243083-c4d4e550-a201-4db2-9304-90e7a1922616.png)


<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


