### PR TITLE
Validate an insight has data series before view creation or update

### DIFF
--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -380,6 +380,10 @@ func (l *lineChartDataSeriesPresentationResolver) Color(ctx context.Context) (st
 }
 
 func (r *Resolver) CreateLineChartSearchInsight(ctx context.Context, args *graphqlbackend.CreateLineChartSearchInsightArgs) (_ graphqlbackend.InsightViewPayloadResolver, err error) {
+	if len(args.Input.DataSeries) == 0 {
+		return nil, errors.New("Insight views need at least one data series to be created")
+	}
+
 	uid := actor.FromContext(ctx).UID
 	permissionsValidator := PermissionsValidatorFromBase(&r.baseInsightResolver)
 
@@ -431,6 +435,10 @@ func (r *Resolver) CreateLineChartSearchInsight(ctx context.Context, args *graph
 }
 
 func (r *Resolver) UpdateLineChartSearchInsight(ctx context.Context, args *graphqlbackend.UpdateLineChartSearchInsightArgs) (_ graphqlbackend.InsightViewPayloadResolver, err error) {
+	if len(args.Input.DataSeries) == 0 {
+		return nil, errors.New("Cannot update insight view with no data series")
+	}
+
 	tx, err := r.insightStore.Transact(ctx)
 	if err != nil {
 		return nil, err

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -381,7 +381,7 @@ func (l *lineChartDataSeriesPresentationResolver) Color(ctx context.Context) (st
 
 func (r *Resolver) CreateLineChartSearchInsight(ctx context.Context, args *graphqlbackend.CreateLineChartSearchInsightArgs) (_ graphqlbackend.InsightViewPayloadResolver, err error) {
 	if len(args.Input.DataSeries) == 0 {
-		return nil, errors.New("Insight views need at least one data series to be created")
+		return nil, errors.New("At least one data series is required to create an insight view")
 	}
 
 	uid := actor.FromContext(ctx).UID
@@ -436,7 +436,7 @@ func (r *Resolver) CreateLineChartSearchInsight(ctx context.Context, args *graph
 
 func (r *Resolver) UpdateLineChartSearchInsight(ctx context.Context, args *graphqlbackend.UpdateLineChartSearchInsightArgs) (_ graphqlbackend.InsightViewPayloadResolver, err error) {
 	if len(args.Input.DataSeries) == 0 {
-		return nil, errors.New("Cannot update insight view with no data series")
+		return nil, errors.New("At least one data series is required to update an insight view")
 	}
 
 	tx, err := r.insightStore.Transact(ctx)


### PR DESCRIPTION
closes #30649.

Alternative error messages can be proposed!

## Test plan

There are no integration tests available for the insight view resolvers, but this was tested using the API console and the following queries:
```
mutation {
    createLineChartSearchInsight (input: {
        options: {
            title: "test response no dashboard"
        },
        dataSeries: []
    })
    {
        view { id }
    }
}
```
and
```
mutation UpdateLineChartSearchInsight($input: UpdateLineChartSearchInsightInput!, $id: ID!) {
  updateLineChartSearchInsight(input: $input, id: $id) {
    view { id }
  }
}
# variables: 
{
  "id": "insight-id",
  "input": {
    "dataSeries": [],
    "presentationOptions": {
      "title": "test"
    },
    "viewControls": {
      "filters": {}
    }
  }
}
```
Each query returned the correct error message for each mutation.



