### PR TITLE
symbols: Fix columns

### DIFF
--- a/cmd/frontend/backend/symbols.go
+++ b/cmd/frontend/backend/symbols.go
@@ -15,5 +15,12 @@ type symbols struct{}
 
 // ListTags returns symbols in a repository from ctags.
 func (symbols) ListTags(ctx context.Context, args search.SymbolsParameters) (result.Symbols, error) {
-	return symbolsclient.DefaultClient.Search(ctx, args)
+	symbols, err := symbolsclient.DefaultClient.Search(ctx, args)
+	if err != nil {
+		return nil, err
+	}
+	for i := range symbols {
+		symbols[i].Line += 1 // callers expect 1-indexed lines
+	}
+	return symbols, nil
 }

--- a/cmd/symbols/internal/database/store/search.go
+++ b/cmd/symbols/internal/database/store/search.go
@@ -27,12 +27,12 @@ func scanSymbols(rows *sql.Rows, queryErr error) (symbols []result.Symbol, err e
 			&symbol.Name,
 			&symbol.Path,
 			&symbol.Line,
+			&symbol.Character,
 			&symbol.Kind,
 			&symbol.Language,
 			&symbol.Parent,
 			&symbol.ParentKind,
 			&symbol.Signature,
-			&symbol.Pattern,
 			&symbol.FileLimited,
 		); err != nil {
 			return nil, err
@@ -51,12 +51,12 @@ func (s *store) Search(ctx context.Context, args types.SearchArgs) ([]result.Sym
 				name,
 				path,
 				line,
+				character,
 				kind,
 				language,
 				parent,
 				parentkind,
 				signature,
-				pattern,
 				filelimited
 			FROM symbols
 			WHERE %s

--- a/cmd/symbols/internal/database/store/symbols.go
+++ b/cmd/symbols/internal/database/store/symbols.go
@@ -20,12 +20,12 @@ func (s *store) CreateSymbolsTable(ctx context.Context) error {
 			path VARCHAR(4096) NOT NULL,
 			pathlowercase VARCHAR(4096) NOT NULL,
 			line INT NOT NULL,
+			character INT NOT NULL,
 			kind VARCHAR(255) NOT NULL,
 			language VARCHAR(255) NOT NULL,
 			parent VARCHAR(255) NOT NULL,
 			parentkind VARCHAR(255) NOT NULL,
 			signature VARCHAR(255) NOT NULL,
-			pattern VARCHAR(255) NOT NULL,
 			filelimited BOOLEAN NOT NULL
 		)
 	`))
@@ -118,12 +118,12 @@ func (s *store) WriteSymbols(ctx context.Context, symbolOrErrors <-chan parser.S
 				"path",
 				"pathlowercase",
 				"line",
+				"character",
 				"kind",
 				"language",
 				"parent",
 				"parentkind",
 				"signature",
-				"pattern",
 				"filelimited",
 			},
 			rows,
@@ -140,12 +140,12 @@ func symbolToRow(symbol result.Symbol) []interface{} {
 		symbol.Path,
 		strings.ToLower(symbol.Path),
 		symbol.Line,
+		symbol.Character,
 		symbol.Kind,
 		symbol.Language,
 		symbol.Parent,
 		symbol.ParentKind,
 		symbol.Signature,
-		symbol.Pattern,
 		symbol.FileLimited,
 	}
 }

--- a/cmd/symbols/internal/database/writer/cache.go
+++ b/cmd/symbols/internal/database/writer/cache.go
@@ -29,7 +29,7 @@ func NewCachedDatabaseWriter(databaseWriter DatabaseWriter, cache diskcache.Stor
 // The version of the symbols database schema. This is included in the database filenames to prevent a
 // newer version of the symbols service from attempting to read from a database created by an older and
 // likely incompatible symbols service. Increment this when you change the database schema.
-const symbolsDBVersion = 4
+const symbolsDBVersion = 5
 
 func (w *cachedDatabaseWriter) GetOrCreateDatabaseFile(ctx context.Context, args types.SearchArgs) (string, error) {
 	key := []string{

--- a/cmd/symbols/parser/parser.go
+++ b/cmd/symbols/parser/parser.go
@@ -170,7 +170,7 @@ func (p *parser) handleParseRequest(ctx context.Context, symbolOrErrors chan<- S
 	}
 	trace.Log(log.Int("numEntries", len(entries)))
 
-	lines := strings.Split(string(parseRequest.Data), "/")
+	lines := strings.Split(string(parseRequest.Data), "\n")
 
 	for _, e := range entries {
 		if !shouldPersistEntry(e) {

--- a/cmd/symbols/parser/parser.go
+++ b/cmd/symbols/parser/parser.go
@@ -177,21 +177,23 @@ func (p *parser) handleParseRequest(ctx context.Context, symbolOrErrors chan<- S
 			continue
 		}
 
-		if e.Line < 0 || e.Line >= len(lines) {
+		// ⚠️ Careful, ctags lines are 1-indexed!
+		line := e.Line - 1
+		if line < 0 || line >= len(lines) {
 			log15.Warn("Invalid line number", "entry", e)
 			continue
 		}
 
-		character := strings.Index(lines[e.Line], e.Name)
+		character := strings.Index(lines[line], e.Name)
 		if character == -1 {
-			log15.Warn("Could not find symbol on line", "symbol", e.Name, "line", e.Line)
+			log15.Warn("Could not find symbol on line", "symbol", e.Name, "line", line)
 			character = 0
 		}
 
 		symbol := result.Symbol{
 			Name:        e.Name,
 			Path:        e.Path,
-			Line:        e.Line,
+			Line:        line,
 			Character:   character,
 			Kind:        e.Kind,
 			Language:    e.Language,

--- a/cmd/symbols/parser/parser.go
+++ b/cmd/symbols/parser/parser.go
@@ -170,21 +170,34 @@ func (p *parser) handleParseRequest(ctx context.Context, symbolOrErrors chan<- S
 	}
 	trace.Log(log.Int("numEntries", len(entries)))
 
+	lines := strings.Split(string(parseRequest.Data), "/")
+
 	for _, e := range entries {
 		if !shouldPersistEntry(e) {
 			continue
+		}
+
+		if e.Line < 0 || e.Line >= len(lines) {
+			log15.Warn("Invalid line number", "entry", e)
+			continue
+		}
+
+		character := strings.Index(lines[e.Line], e.Name)
+		if character == -1 {
+			log15.Warn("Could not find symbol on line", "symbol", e.Name, "line", e.Line)
+			character = 0
 		}
 
 		symbol := result.Symbol{
 			Name:        e.Name,
 			Path:        e.Path,
 			Line:        e.Line,
+			Character:   character,
 			Kind:        e.Kind,
 			Language:    e.Language,
 			Parent:      e.Parent,
 			ParentKind:  e.ParentKind,
 			Signature:   e.Signature,
-			Pattern:     e.Pattern,
 			FileLimited: e.FileLimited,
 		}
 

--- a/cmd/symbols/parser/parser_factory_ctags_test.go
+++ b/cmd/symbols/parser/parser_factory_ctags_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/sourcegraph/go-ctags"
 

--- a/cmd/symbols/parser/parser_factory_ctags_test.go
+++ b/cmd/symbols/parser/parser_factory_ctags_test.go
@@ -153,7 +153,7 @@ interface Node {
 			t.Error(err)
 		}
 
-		if d := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(ctags.Entry{}, "Pattern")); d != "" {
+		if d := cmp.Diff(tc.want, got); d != "" {
 			t.Errorf("%s mismatch (-want +got):\n%s", tc.path, d)
 		}
 	}

--- a/enterprise/cmd/symbols/main.go
+++ b/enterprise/cmd/symbols/main.go
@@ -118,7 +118,7 @@ func createParserWithConfig(config types.CtagsConfig) rockskip.ParseSymbolsFunc 
 				Name:   entry.Name,
 				Parent: entry.Parent,
 				Kind:   entry.Kind,
-				Line:   entry.Line,
+				Line:   entry.Line - 1,
 			})
 		}
 

--- a/internal/search/result/symbol_test.go
+++ b/internal/search/result/symbol_test.go
@@ -3,25 +3,10 @@ package result
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/sourcegraph/go-lsp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
-
-func TestSymbolRange(t *testing.T) {
-	t.Run("unescaped pattern", func(t *testing.T) {
-		want := lsp.Range{
-			Start: lsp.Position{Line: 0, Character: 37},
-			End:   lsp.Position{Line: 0, Character: 40},
-		}
-		got := Symbol{Line: 1, Name: "baz", Pattern: `/^bar() { var regex = \/.*\\\/\/; function baz() { }  } $/`}.Range()
-		if diff := cmp.Diff(want, got); diff != "" {
-			t.Fatal(diff)
-		}
-	})
-}
 
 func TestSymbolURL(t *testing.T) {
 	repoA := types.MinimalRepo{Name: "repo/A", ID: 1}
@@ -40,27 +25,15 @@ func TestSymbolURL(t *testing.T) {
 			symbol: SymbolMatch{
 				File: &fileAA,
 				Symbol: Symbol{
-					Name:    "testsymbol",
-					Line:    3,
-					Pattern: `/^abc testsymbol def$/`,
+					Name:      "testsymbol",
+					Line:      3,
+					Character: 4,
 				},
 			},
 			url: "/repo/A/-/blob/A#L3:5-3:15",
 		},
 		{
 			name: "with rev",
-			symbol: SymbolMatch{
-				File: &fileAB,
-				Symbol: Symbol{
-					Name:    "testsymbol",
-					Line:    3,
-					Pattern: `/^abc testsymbol def$/`,
-				},
-			},
-			url: "/repo/A@testrev/-/blob/B#L3:5-3:15",
-		},
-		{
-			name: "with character instead of pattern",
 			symbol: SymbolMatch{
 				File: &fileAB,
 				Symbol: Symbol{

--- a/internal/search/result/symbol_test.go
+++ b/internal/search/result/symbol_test.go
@@ -5,8 +5,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/go-lsp"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 func TestSymbolRange(t *testing.T) {
@@ -54,6 +55,18 @@ func TestSymbolURL(t *testing.T) {
 					Name:    "testsymbol",
 					Line:    3,
 					Pattern: `/^abc testsymbol def$/`,
+				},
+			},
+			url: "/repo/A@testrev/-/blob/B#L3:5-3:15",
+		},
+		{
+			name: "with character instead of pattern",
+			symbol: SymbolMatch{
+				File: &fileAB,
+				Symbol: Symbol{
+					Name:      "testsymbol",
+					Line:      3,
+					Character: 4,
 				},
 			},
 			url: "/repo/A@testrev/-/blob/B#L3:5-3:15",

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -217,6 +217,7 @@ func searchZoekt(ctx context.Context, repoName types.MinimalRepo, commitID api.C
 				res = append(res, result.NewSymbolMatch(
 					newFile,
 					l.LineNumber,
+					-1, // -1 means infer the column
 					m.SymbolInfo.Sym,
 					m.SymbolInfo.Kind,
 					m.SymbolInfo.Parent,

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -478,6 +478,7 @@ func zoektFileMatchToSymbolResults(repoName types.MinimalRepo, inputRev string, 
 			symbols = append(symbols, result.NewSymbolMatch(
 				newFile,
 				l.LineNumber,
+				-1, // -1 means infer the column
 				m.SymbolInfo.Sym,
 				m.SymbolInfo.Kind,
 				m.SymbolInfo.Parent,

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -619,21 +619,21 @@ func TestZoektFileMatchToSymbolResults(t *testing.T) {
 	}
 
 	want := []result.Symbol{{
-		Name:    "a",
-		Line:    10,
-		Pattern: "/^symbol a symbol b$/",
+		Name:      "a",
+		Line:      10,
+		Character: 7,
 	}, {
-		Name:    "b",
-		Line:    10,
-		Pattern: "/^symbol a symbol b$/",
+		Name:      "b",
+		Line:      10,
+		Character: 3,
 	}, {
-		Name:    "c",
-		Line:    15,
-		Pattern: "/^symbol c$/",
+		Name:      "c",
+		Line:      15,
+		Character: 7,
 	}, {
-		Name:    "baz",
-		Line:    20,
-		Pattern: `/^bar() { var regex = \/.*\\\/\/; function baz() { }  } $/`,
+		Name:      "baz",
+		Line:      20,
+		Character: 37,
 	},
 	}
 	for i := range want {


### PR DESCRIPTION
**Before**

![image](https://user-images.githubusercontent.com/1387653/157152763-562cf48c-8dbf-4822-b430-84a15eaa7987.png)


**After**

<img width="637" alt="CleanShot 2022-03-07 at 19 13 18@2x" src="https://user-images.githubusercontent.com/1387653/157152735-2e1d7663-f537-4f44-adf3-005b6061b95d.png">

- Made the symbols service return lines 0-based
- Added `character` to the output of the symbols service
- Adjusted back to 1-based in the `frontend/backend` package (lol it really is called that)
- Dropped `pattern`

Resolves https://github.com/sourcegraph/sourcegraph/issues/32295

Depends on https://github.com/sourcegraph/sourcegraph/pull/32300

There's another issue that seems relevant https://github.com/sourcegraph/sourcegraph/pull/23664 @rvantonder am I missing something here?

The indexed search query path still seems to work:

![CleanShot 2022-03-07 at 19 32 37](https://user-images.githubusercontent.com/1387653/157154903-f780877e-4fdf-4ddc-8ba3-7b466079b87d.gif)

## Test plan

Ran locally, also added a test.