### PR TITLE
symbols: Key on version directory

### DIFF
--- a/cmd/symbols/internal/database/writer/cache.go
+++ b/cmd/symbols/internal/database/writer/cache.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/symbols/internal/api/observability"
 	"github.com/sourcegraph/sourcegraph/cmd/symbols/types"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/diskcache"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -32,14 +33,9 @@ func NewCachedDatabaseWriter(databaseWriter DatabaseWriter, cache diskcache.Stor
 const symbolsDBVersion = 4
 
 func (w *cachedDatabaseWriter) GetOrCreateDatabaseFile(ctx context.Context, args types.SearchArgs) (string, error) {
-	key := []string{
-		string(args.Repo),
-		fmt.Sprintf("%s-%d", args.CommitID, symbolsDBVersion),
-	}
-
 	// set to noop parse originally, this will be overridden if the fetcher func below is called
 	observability.SetParseAmount(ctx, observability.CachedParse)
-	cacheFile, err := w.cache.OpenWithPath(ctx, key, func(fetcherCtx context.Context, tempDBFile string) error {
+	cacheFile, err := w.cache.OpenWithPath(ctx, repoCommitKey(args.Repo, args.CommitID), func(fetcherCtx context.Context, tempDBFile string) error {
 		if err := w.databaseWriter.WriteDBFile(fetcherCtx, args, tempDBFile); err != nil {
 			return errors.Wrap(err, "databaseWriter.WriteDBFile")
 		}
@@ -52,4 +48,21 @@ func (w *cachedDatabaseWriter) GetOrCreateDatabaseFile(ctx context.Context, args
 	defer cacheFile.File.Close()
 
 	return cacheFile.File.Name(), err
+}
+
+// repoCommitKey returns the diskcache key for a repo and commit (points to a SQLite DB file).
+func repoCommitKey(repo api.RepoName, commitID api.CommitID) []string {
+	return []string{
+		fmt.Sprint(symbolsDBVersion),
+		string(repo),
+		string(commitID),
+	}
+}
+
+// repoKey returns the diskcache key for a repo (points to a directory).
+func repoKey(repo api.RepoName) []string {
+	return []string{
+		fmt.Sprint(symbolsDBVersion),
+		string(repo),
+	}
 }

--- a/cmd/symbols/internal/database/writer/writer.go
+++ b/cmd/symbols/internal/database/writer/writer.go
@@ -59,7 +59,7 @@ func (w *databaseWriter) WriteDBFile(ctx context.Context, args types.SearchArgs,
 func (w *databaseWriter) getNewestCommit(ctx context.Context, args types.SearchArgs) (dbFile string, commit string, ok bool, err error) {
 	components := []string{}
 	components = append(components, w.path)
-	components = append(components, diskcache.EncodeKeyComponents([]string{string(args.Repo)})...)
+	components = append(components, diskcache.EncodeKeyComponents(repoKey(args.Repo))...)
 
 	newest, err := findNewestFile(filepath.Join(components...))
 	if err != nil || newest == "" {


### PR DESCRIPTION
Before this, the symbols service could accidentally read a SQLite DB from the same repo but different application-level SQLite DB version. This would happen when bumping the version and then doing a symbol search with a previously indexed SQLite DB on disk. Here's what the disk structure looked like:

```
<repo> / <commit>-<version>
```

Different versions would be right alongside each other:

```
github.com/foo/bar / 1234-4.zip
github.com/foo/bar / 1234-5.zip <-- while building this DB, the symbols service would try to reuse v4 above and fail
```

After this, the disk structure will be:

```
<version> / <repo> / <commit>
```

That way, grabbing a previously-indexed SQLite DB from the repo dir will always give you a SQLite DB with the same version.

Encountered in https://github.com/sourcegraph/sourcegraph/pull/32299

Depends on https://github.com/sourcegraph/sourcegraph/pull/32301

## Test plan

Ran it locally both ways.