### PR TITLE
Revert "search: Fix correct Zoekt branch (#32250)" DONTMERGE

### DIFF
--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -59,6 +59,17 @@ func (rb *IndexedRepoRevs) add(reporev *search.RepositoryRevisions, repo *zoekt.
 		return reporev.Revs
 	}
 
+	if len(reporev.Revs) == 1 && repo.Branches[0].Name == "HEAD" && (reporev.Revs[0].RevSpec == "" || reporev.Revs[0].RevSpec == "HEAD") {
+		rb.RepoRevs[reporev.Repo.ID] = reporev
+		br, ok := rb.branchRepos["HEAD"]
+		if !ok {
+			br = &zoektquery.BranchRepos{Branch: "HEAD", Repos: roaring.New()}
+			rb.branchRepos["HEAD"] = br
+		}
+		br.Repos.Add(uint32(reporev.Repo.ID))
+		return nil
+	}
+
 	// Assume for large searches they will mostly involve indexed
 	// revisions, so just allocate that.
 	var unindexed []search.RevisionSpecifier
@@ -68,20 +79,22 @@ func (rb *IndexedRepoRevs) add(reporev *search.RepositoryRevisions, repo *zoekt.
 	indexed := reporev.Revs[:0]
 
 	for _, rev := range reporev.Revs {
-		found := false
-		revSpec := rev.RevSpec
-		if revSpec == "" {
-			revSpec = "HEAD"
+		if rev.RevSpec == "" || rev.RevSpec == "HEAD" {
+			// Zoekt convention that first branch is HEAD
+			branches = append(branches, repo.Branches[0].Name)
+			indexed = append(indexed, rev)
+			continue
 		}
 
+		found := false
 		for _, branch := range repo.Branches {
-			if branch.Name == revSpec {
+			if branch.Name == rev.RevSpec {
 				branches = append(branches, branch.Name)
 				found = true
 				break
 			}
 			// Check if rev is an abbrev commit SHA
-			if len(revSpec) >= 4 && strings.HasPrefix(branch.Version, revSpec) {
+			if len(rev.RevSpec) >= 4 && strings.HasPrefix(branch.Version, rev.RevSpec) {
 				branches = append(branches, branch.Name)
 				found = true
 				break


### PR DESCRIPTION
On second thought this optimization doesn't seem worth it, and the current code is safer.

## Test plan

Existing tests.


