### PR TITLE
gitserver: Ignore "no sources" errors for JVM deps

### DIFF
--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -76,7 +76,7 @@ func (s *JVMPackagesSyncer) IsCloneable(ctx context.Context, remoteURL *vcs.URL)
 		_, err := coursier.FetchSources(ctx, s.Config, dependency)
 		if err != nil {
 			// Temporary: We shouldn't need both these checks but we're continuing to see the
-			// error in production logs which implies `Is` is not matching.
+			// error in production logs which implies `HasType` is not matching.
 			if errors.HasType(err, &coursier.ErrNoSources{}) || strings.Contains(err.Error(), "no sources for dependency") {
 				// We can't do anything and it's leading to increases in our
 				// src_repoupdater_sched_error alert firing more often.
@@ -258,7 +258,7 @@ func (s *JVMPackagesSyncer) gitPushDependencyTag(ctx context.Context, bareGitDir
 	sourceCodeJarPath, err := coursier.FetchSources(ctx, s.Config, dependency)
 	if err != nil {
 		// Temporary: We shouldn't need both these checks but we're continuing to see the
-		// error in production logs which implies `Is` is not matching.
+		// error in production logs which implies `HasType` is not matching.
 		if errors.HasType(err, &coursier.ErrNoSources{}) || strings.Contains(err.Error(), "no sources for dependency") {
 			// We can't do anything and it's leading to increases in our
 			// src_repoupdater_sched_error alert firing more often.

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -257,6 +257,13 @@ func (s *JVMPackagesSyncer) gitPushDependencyTag(ctx context.Context, bareGitDir
 
 	sourceCodeJarPath, err := coursier.FetchSources(ctx, s.Config, dependency)
 	if err != nil {
+		// Temporary: We shouldn't need both these checks but we're continuing to see the
+		// error in production logs which implies `Is` is not matching.
+		if errors.HasType(err, &coursier.ErrNoSources{}) || strings.Contains(err.Error(), "no sources for dependency") {
+			// We can't do anything and it's leading to increases in our
+			// src_repoupdater_sched_error alert firing more often.
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
It's not a fatal error and is leading to an increase in error metrics.

# Test plan

Will roll out and confirm a drop in errors