### PR TITLE
gitserver: Extract all regular files from NPM packages

### DIFF
--- a/cmd/gitserver/server/vcs_syncer_npm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages.go
@@ -358,20 +358,21 @@ func decompressTgz(tgz io.Reader, destination string) error {
 	return stripSingleOutermostDirectory(destination)
 }
 
+// stripSingleOutermostDirectory strips a single outermost directory in dir
+// if it has no sibling files or directories beyond `.git`.
+//
+// In practice, NPM tarballs seem to contain a superfluous directory which
+// contains the files. For example, if you extract react's tarball,
+// all files will be under a package/ directory, and if you extract
+// @types/lodash's files, all files are under lodash/.
+//
+// However, this additional directory has no meaning. Moreover, it makes
+// the UX slightly worse, as when you navigate to a repo, you would see
+// that it contains just 1 folder, and you'd need to click again to drill
+// down further. So we strip the superfluous directory if we detect one.
+//
+// https://github.com/sourcegraph/sourcegraph/pull/28057#issuecomment-987890718
 func stripSingleOutermostDirectory(dir string) error {
-	// [NOTE: npm-strip-outermost-directory]
-	// In practice, NPM tarballs seem to contain a superfluous directory which
-	// contains the files. For example, if you extract react's tarball,
-	// all files will be under a package/ directory, and if you extract
-	// @types/lodash's files, all files are under lodash/.
-	//
-	// However, this additional directory has no meaning. Moreover, it makes
-	// the UX slightly worse, as when you navigate to a repo, you would see
-	// that it contains just 1 folder, and you'd need to click again to drill
-	// down further. So we strip the superfluous directory if we detect one.
-	//
-	// https://github.com/sourcegraph/sourcegraph/pull/28057#issuecomment-987890718
-
 	files, err := os.ReadDir(dir)
 	if err != nil {
 		return err

--- a/cmd/gitserver/server/vcs_syncer_npm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages.go
@@ -330,8 +330,8 @@ func (s *NPMPackagesSyncer) commitTgz(ctx context.Context, dependency *reposourc
 //
 // Additionally, if all the files in the tarball have paths of the form
 // dir/<blah> for the same directory 'dir', the 'dir' will be stripped.
-func decompressTgz(targz io.Reader, destination string) error {
-	err := unpack.Targz(targz, destination, unpack.Opts{
+func decompressTgz(tgz io.Reader, destination string) error {
+	err := unpack.Tgz(tgz, destination, unpack.Opts{
 		SkipInvalid: true,
 		Filter: func(file fs.FileInfo) bool {
 			size := file.Size()

--- a/cmd/gitserver/server/vcs_syncer_npm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages.go
@@ -373,14 +373,14 @@ func decompressTgz(tgz io.Reader, destination string) error {
 //
 // https://github.com/sourcegraph/sourcegraph/pull/28057#issuecomment-987890718
 func stripSingleOutermostDirectory(dir string) error {
-	files, err := os.ReadDir(dir)
+	dirEntries, err := os.ReadDir(dir)
 	if err != nil {
 		return err
 	}
 
 	outermostDir := dir
-	for _, f := range files {
-		if !f.IsDir() || f.Name() == ".git" {
+	for _, fi := range dirEntries {
+		if !fi.IsDir() || fi.Name() == ".git" {
 			continue
 		}
 
@@ -389,7 +389,7 @@ func stripSingleOutermostDirectory(dir string) error {
 			return nil
 		}
 
-		outermostDir = path.Join(dir, f.Name())
+		outermostDir = path.Join(dir, fi.Name())
 	}
 
 	tmpDir := dir + ".tmp"

--- a/cmd/gitserver/server/vcs_syncer_npm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages.go
@@ -333,7 +333,7 @@ func (s *NPMPackagesSyncer) commitTgz(ctx context.Context, dependency *reposourc
 func decompressTgz(tgz io.Reader, destination string) error {
 	err := unpack.Tgz(tgz, destination, unpack.Opts{
 		SkipInvalid: true,
-		Filter: func(file fs.FileInfo) bool {
+		Filter: func(path string, file fs.FileInfo) bool {
 			size := file.Size()
 
 			const sizeLimit = 15 * 1024 * 1024
@@ -346,7 +346,7 @@ func decompressTgz(tgz io.Reader, destination string) error {
 				return false
 			}
 
-			_, malicious := isPotentiallyMaliciousFilepathInArchive(file.Name(), destination)
+			_, malicious := isPotentiallyMaliciousFilepathInArchive(path, destination)
 			return !malicious
 		},
 	})

--- a/cmd/gitserver/server/vcs_syncer_npm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages.go
@@ -289,8 +289,8 @@ func (s *NPMPackagesSyncer) gitPushDependencyTag(ctx context.Context, bareGitDir
 	return nil
 }
 
-// commitTgz creates a git commit in the given working directory that adds all
-// the file contents of the given tgz file.
+// commitTgz initializes a git repository in the given working directory and creates
+// a git commit in that contains all the file contents of the given tgz.
 func (s *NPMPackagesSyncer) commitTgz(ctx context.Context, dependency *reposource.NPMDependency,
 	workingDirectory string, tgz io.Reader) error {
 	if err := decompressTgz(tgz, workingDirectory); err != nil {

--- a/cmd/gitserver/server/vcs_syncer_npm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages.go
@@ -336,10 +336,6 @@ func decompressTgz(tgz io.Reader, destination string) error {
 		Filter: func(file fs.FileInfo) bool {
 			size := file.Size()
 
-			if size < 0 {
-				return false
-			}
-
 			const sizeLimit = 15 * 1024 * 1024
 			if size >= sizeLimit {
 				log15.Warn("skipping large file in npm package",

--- a/cmd/gitserver/server/vcs_syncer_npm_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages_test.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
@@ -46,11 +47,10 @@ func TestNoMaliciousFilesNPM(t *testing.T) {
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 
-	tgzPath := path.Join(dir, "malicious.tgz")
 	extractPath := path.Join(dir, "extracted")
 	assert.Nil(t, os.Mkdir(extractPath, os.ModePerm))
 
-	createMaliciousTgz(t, tgzPath)
+	tgz := bytes.NewReader(createMaliciousTgz(t))
 
 	s := NewNPMPackagesSyncer(
 		schema.NPMPackagesConnection{Dependencies: []string{}},
@@ -59,11 +59,9 @@ func TestNoMaliciousFilesNPM(t *testing.T) {
 	)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel now  to prevent any network IO
-	tgzFile, err := os.Open(tgzPath)
-	require.Nil(t, err)
-	defer func() { require.Nil(t, tgzFile.Close()) }()
+
 	dep := &reposource.NPMDependency{NPMPackage: &reposource.NPMPackage{}}
-	err = s.commitTgz(ctx, dep, extractPath, tgzFile)
+	err = s.commitTgz(ctx, dep, extractPath, tgz)
 	require.NotNil(t, err, "malicious tarball should not be committed successfully")
 
 	dirEntries, err := os.ReadDir(extractPath)
@@ -78,40 +76,43 @@ func TestNoMaliciousFilesNPM(t *testing.T) {
 	}
 }
 
-func createMaliciousTgz(t *testing.T, tgzPath string) {
+func createMaliciousTgz(t *testing.T) []byte {
 	fileInfos := []fileInfo{
 		{harmlessPath, []byte("harmless")},
 	}
 	for _, filepath := range maliciousPaths {
 		fileInfos = append(fileInfos, fileInfo{filepath, []byte("malicious")})
 	}
-	createTgz(t, tgzPath, fileInfos)
+	return createTgz(t, fileInfos)
 }
 
 func TestNPMCloneCommand(t *testing.T) {
 	dir, err := os.MkdirTemp("", "")
-	assert.Nil(t, err)
-	defer func() { assert.Nil(t, os.RemoveAll(dir)) }()
+	require.NoError(t, err)
 
-	tgzPath := path.Join(dir, exampleTgz)
-	createTgz(t, tgzPath, []fileInfo{{exampleJSFilepath, []byte(exampleJSFileContents)}})
-	defer func() { assert.Nil(t, os.Remove(tgzPath)) }()
-	tgzPath2 := path.Join(dir, exampleTgz2)
-	createTgz(t, tgzPath2, []fileInfo{{exampleTSFilepath, []byte(exampleTSFileContents)}})
-	defer func() { assert.Nil(t, os.Remove(tgzPath2)) }()
+	t.Cleanup(func() {
+		require.NoError(t, os.RemoveAll(dir))
+	})
+
+	tgz1 := createTgz(t, []fileInfo{{exampleJSFilepath, []byte(exampleJSFileContents)}})
+	tgz2 := createTgz(t, []fileInfo{{exampleTSFilepath, []byte(exampleTSFileContents)}})
 
 	client := npmtest.MockClient{
 		Packages: map[string]*npm.PackageInfo{
 			"example": {
 				Versions: map[string]*npm.DependencyInfo{
 					exampleNPMVersion: {
-						Dist: npm.DependencyInfoDist{TarballURL: tgzPath},
+						Dist: npm.DependencyInfoDist{TarballURL: exampleNPMVersion},
 					},
 					exampleNPMVersion2: {
-						Dist: npm.DependencyInfoDist{TarballURL: tgzPath2},
+						Dist: npm.DependencyInfoDist{TarballURL: exampleNPMVersion2},
 					},
 				},
 			},
+		},
+		Tarballs: map[string][]byte{
+			exampleNPMVersion:  tgz1,
+			exampleNPMVersion2: tgz2,
 		},
 	}
 	s := NewNPMPackagesSyncer(
@@ -198,24 +199,25 @@ func (s NPMPackagesSyncer) runCloneCommand(t *testing.T, bareGitDirectory string
 	packageURL := vcs.URL{URL: url.URL{Path: exampleNPMPackageURL}}
 	s.connection.Dependencies = dependencies
 	cmd, err := s.CloneCommand(context.Background(), &packageURL, bareGitDirectory)
-	assert.Nil(t, err)
-	assert.Nil(t, cmd.Run())
+	require.NoError(t, err)
+	require.NoError(t, cmd.Run())
 }
 
-func createTgz(t *testing.T, tgzPath string, fileInfos []fileInfo) {
+func createTgz(t *testing.T, fileInfos []fileInfo) []byte {
 	t.Helper()
-	ioWriter, err := os.Create(tgzPath)
-	assert.Nil(t, err)
-	gzipWriter := gzip.NewWriter(ioWriter)
+
+	var buf bytes.Buffer
+	gzipWriter := gzip.NewWriter(&buf)
 	tarWriter := tar.NewWriter(gzipWriter)
-	defer func() {
-		assert.Nil(t, tarWriter.Close())
-		assert.Nil(t, gzipWriter.Close())
-		assert.Nil(t, ioWriter.Close())
-	}()
+
 	for _, fileinfo := range fileInfos {
-		assert.Nil(t, addFileToTarball(t, tarWriter, fileinfo))
+		require.NoError(t, addFileToTarball(t, tarWriter, fileinfo))
 	}
+
+	require.NoError(t, tarWriter.Close())
+	require.NoError(t, gzipWriter.Close())
+
+	return buf.Bytes()
 }
 
 func addFileToTarball(t *testing.T, tarWriter *tar.Writer, info fileInfo) error {
@@ -256,35 +258,29 @@ func TestDecompressTgz(t *testing.T) {
 		{[]string{"d/f1", "d/f2"}, []string{"f1", "f2"}},
 		{[]string{"d1/d2/f1", "d1/d2/f2"}, []string{"d2"}},
 		{[]string{"d1/f1", "d2/f2", "d3/f3"}, []string{"d1", "d2", "d3"}},
+		{[]string{"f1", "d1/f2", "d1/f3"}, []string{"d1", "f1"}},
 	}
 
-	for _, testData := range table {
-		dir, err := os.MkdirTemp("", "")
-		assert.Nil(t, err)
-		defer func() { assert.Nil(t, os.RemoveAll(dir)) }()
+	for i, testData := range table {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			dir, err := os.MkdirTemp("", "")
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, os.RemoveAll(dir)) })
 
-		tarballName := "test.tgz"
-		tgzPath := path.Join(dir, tarballName)
-		// Creating a tarball with empty files fails???
-		fileInfos := []fileInfo{}
-		for _, path := range testData.paths {
-			fileInfos = append(fileInfos, fileInfo{path: path, contents: []byte("x")})
-		}
-		createTgz(t, tgzPath, fileInfos)
-		tgzFile, err := os.Open(tgzPath)
-		require.Nil(t, err)
-		defer tgzFile.Close()
-		assert.Nil(t, decompressTgz(tgzFile, dir))
-		dirEntries, err := os.ReadDir(dir)
-		assert.Nil(t, err)
-		dirEntryNames := []string{}
-		for _, entry := range dirEntries {
-			if entry.Name() == tarballName {
-				continue
+			var fileInfos []fileInfo
+			for _, path := range testData.paths {
+				fileInfos = append(fileInfos, fileInfo{path: path, contents: []byte("x")})
 			}
-			dirEntryNames = append(dirEntryNames, entry.Name())
-		}
-		assert.True(t, reflect.DeepEqual(dirEntryNames, testData.expect))
+
+			tgz := bytes.NewReader(createTgz(t, fileInfos))
+
+			require.NoError(t, decompressTgz(tgz, dir))
+
+			have, err := fs.Glob(os.DirFS(dir), "*")
+			require.NoError(t, err)
+
+			require.Equal(t, testData.expect, have)
+		})
 	}
 }
 

--- a/cmd/gitserver/server/vcs_syncer_npm_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages_test.go
@@ -65,7 +65,7 @@ func TestNoMaliciousFilesNPM(t *testing.T) {
 	require.NotNil(t, err, "malicious tarball should not be committed successfully")
 
 	dirEntries, err := os.ReadDir(extractPath)
-	baseline := []string{"src"}
+	baseline := []string{"harmless.java"}
 	assert.Nil(t, err)
 	paths := []string{}
 	for _, dirEntry := range dirEntries {

--- a/cmd/gitserver/server/vcs_syncer_npm_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages_test.go
@@ -80,10 +80,10 @@ func TestNoMaliciousFilesNPM(t *testing.T) {
 
 func createMaliciousTgz(t *testing.T, tgzPath string) {
 	fileInfos := []fileInfo{
-		{harmlessPath, []byte{}},
+		{harmlessPath, []byte("harmless")},
 	}
 	for _, filepath := range maliciousPaths {
-		fileInfos = append(fileInfos, fileInfo{filepath, []byte{}})
+		fileInfos = append(fileInfos, fileInfo{filepath, []byte("malicious")})
 	}
 	createTgz(t, tgzPath, fileInfos)
 }

--- a/cmd/gitserver/server/vcs_syncer_npm_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages_test.go
@@ -274,7 +274,7 @@ func TestDecompressTgz(t *testing.T) {
 		tgzFile, err := os.Open(tgzPath)
 		require.Nil(t, err)
 		defer tgzFile.Close()
-		assert.Nil(t, decompressTgz(namedReadSeeker{tgzPath, tgzFile}, dir))
+		assert.Nil(t, decompressTgz(tgzFile, dir))
 		dirEntries, err := os.ReadDir(dir)
 		assert.Nil(t, err)
 		dirEntryNames := []string{}
@@ -325,13 +325,13 @@ func testDecompressTgzNoOOBImpl(t *testing.T, entries []tar.Header) {
 	tarWriter.Close()
 	gzipWriter.Close()
 
-	readSeeker := bytes.NewReader(buffer.Bytes())
+	reader := bytes.NewReader(buffer.Bytes())
 
 	outDir, err := os.MkdirTemp("", "decompress-oobfix-")
 	require.Nil(t, err)
 	defer os.RemoveAll(outDir)
 
 	require.NotPanics(t, func() {
-		decompressTgz(namedReadSeeker{"buffer", readSeeker}, outDir)
+		decompressTgz(reader, outDir)
 	})
 }

--- a/internal/extsvc/npm/npmtest/npmtest.go
+++ b/internal/extsvc/npm/npmtest/npmtest.go
@@ -62,7 +62,7 @@ func (m *MockClient) DoesDependencyExist(ctx context.Context, dep *reposource.NP
 	return pkg.Versions[dep.Version] != nil, nil
 }
 
-func (m *MockClient) FetchTarball(_ context.Context, dep *reposource.NPMDependency) (closer io.ReadSeekCloser, err error) {
+func (m *MockClient) FetchTarball(_ context.Context, dep *reposource.NPMDependency) (io.ReadCloser, error) {
 	info, ok := m.Packages[dep.PackageSyntax()]
 	if !ok {
 		return nil, errors.Newf("Unknown dependency: %s", dep.PackageManagerSyntax())

--- a/internal/unpack/unpack.go
+++ b/internal/unpack/unpack.go
@@ -1,3 +1,16 @@
+/*
+Copyright 2018 Gravitational, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package unpack
 
 import (

--- a/internal/unpack/unpack.go
+++ b/internal/unpack/unpack.go
@@ -1,0 +1,142 @@
+package unpack
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type Opts struct {
+	// SkipInvalid makes unpacking skip any invalid files rather than aborting
+	// the whole unpack.
+	SkipInvalid bool
+
+	// Filter filters out files that match the given predicate.
+	Filter func(file fs.FileInfo) bool
+}
+
+// Targz unpacks the contents of the given gzip compressed tarball under dir.
+func Targz(r io.Reader, dir string, opt Opts) error {
+	gzr, err := gzip.NewReader(r)
+	if err != nil {
+		return err
+	}
+	return Tar(gzr, dir, opt)
+}
+
+// Tar unpacks the contents of the specified tarball under dir.
+func Tar(r io.Reader, dir string, opt Opts) error {
+	tr := tar.NewReader(r)
+	for {
+		header, err := tr.Next()
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+
+		if opt.Filter != nil && !opt.Filter(header.FileInfo()) {
+			continue
+		}
+
+		err = sanitizeTarPath(header, dir)
+		if err != nil {
+			if opt.SkipInvalid {
+				continue
+			}
+			return err
+		}
+
+		err = extractFile(tr, header, dir)
+		if err != nil {
+			return err
+		}
+	}
+}
+
+// extractTarFile extracts a single file or directory from tarball into dir.
+func extractFile(tr *tar.Reader, h *tar.Header, dir string) error {
+	switch h.Typeflag {
+	case tar.TypeDir:
+		return withDir(filepath.Join(dir, h.Name), nil)
+	case tar.TypeBlock, tar.TypeChar, tar.TypeReg, tar.TypeRegA, tar.TypeFifo:
+		return writeFile(filepath.Join(dir, h.Name), tr, h.Size, h.FileInfo().Mode())
+	case tar.TypeLink:
+		return writeHardLink(filepath.Join(dir, h.Name), filepath.Join(dir, h.Linkname))
+	case tar.TypeSymlink:
+		return writeSymbolicLink(filepath.Join(dir, h.Name), h.Linkname)
+	}
+	return nil
+}
+
+// sanitizeTarPath checks that the tar header paths resolve to a subdirectory
+// path, and don't contain file paths or links that could escape the tar file
+// like ../../etc/password.
+func sanitizeTarPath(h *tar.Header, dir string) error {
+	// Sanitize all tar paths resolve to within the destination directory.
+	destPath := filepath.Join(dir, h.Name)
+	if !strings.HasPrefix(destPath, filepath.Clean(dir)+string(os.PathSeparator)) {
+		return errors.Errorf("%s: illegal file path", h.Name)
+	}
+
+	// Ensure link destinations resolve to within the destination directory.
+	if h.Linkname != "" {
+		if filepath.IsAbs(h.Linkname) {
+			if !strings.HasPrefix(filepath.Clean(h.Linkname), filepath.Clean(dir)+string(os.PathSeparator)) {
+				return errors.Errorf("%s: illegal link path", h.Linkname)
+			}
+		} else {
+			// Relative paths are relative to filename after extraction to directory.
+			linkPath := filepath.Join(dir, filepath.Dir(h.Name), h.Linkname)
+			if !strings.HasPrefix(linkPath, filepath.Clean(dir)+string(os.PathSeparator)) {
+				return errors.Errorf("%s: illegal link path", h.Linkname)
+			}
+		}
+	}
+	return nil
+}
+
+func writeFile(path string, r io.Reader, n int64, mode os.FileMode) error {
+	return withDir(path, func() error {
+		// Create file only if it does not exist to prevent overwriting existing
+		// files (like session recordings).
+		out, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode)
+		if err != nil {
+			return err
+		}
+
+		if _, err = io.CopyN(out, r, n); err != nil {
+			return err
+		}
+
+		return out.Close()
+	})
+}
+
+func writeSymbolicLink(path string, target string) error {
+	return withDir(path, func() error { return os.Symlink(target, path) })
+}
+
+func writeHardLink(path string, target string) error {
+	return withDir(path, func() error { return os.Link(target, path) })
+}
+
+func withDir(path string, fn func() error) error {
+	err := os.MkdirAll(filepath.Dir(path), 0770)
+	if err != nil {
+		return err
+	}
+
+	if fn == nil {
+		return nil
+	}
+
+	return fn()
+}

--- a/internal/unpack/unpack.go
+++ b/internal/unpack/unpack.go
@@ -33,7 +33,7 @@ type Opts struct {
 	SkipInvalid bool
 
 	// Filter filters out files that do not match the given predicate.
-	Filter func(file fs.FileInfo) bool
+	Filter func(path string, file fs.FileInfo) bool
 }
 
 // Tgz unpacks the contents of the given gzip compressed tarball under dir.
@@ -61,7 +61,7 @@ func Tar(r io.Reader, dir string, opt Opts) error {
 			continue
 		}
 
-		if opt.Filter != nil && !opt.Filter(header.FileInfo()) {
+		if opt.Filter != nil && !opt.Filter(header.Name, header.FileInfo()) {
 			continue
 		}
 

--- a/internal/unpack/unpack.go
+++ b/internal/unpack/unpack.go
@@ -34,8 +34,8 @@ type Opts struct {
 	Filter func(file fs.FileInfo) bool
 }
 
-// Targz unpacks the contents of the given gzip compressed tarball under dir.
-func Targz(r io.Reader, dir string, opt Opts) error {
+// Tgz unpacks the contents of the given gzip compressed tarball under dir.
+func Tgz(r io.Reader, dir string, opt Opts) error {
 	gzr, err := gzip.NewReader(r)
 	if err != nil {
 		return err

--- a/internal/unpack/unpack.go
+++ b/internal/unpack/unpack.go
@@ -55,6 +55,10 @@ func Tar(r io.Reader, dir string, opt Opts) error {
 			return err
 		}
 
+		if header.Size < 0 {
+			continue
+		}
+
 		if opt.Filter != nil && !opt.Filter(header.FileInfo()) {
 			continue
 		}

--- a/internal/unpack/unpack.go
+++ b/internal/unpack/unpack.go
@@ -11,6 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Based on https://github.com/gravitational/teleport/blob/350ea5bb953f741b222a08c85acac30254e92f66/lib/utils/unpack.go
+
 package unpack
 
 import (

--- a/internal/unpack/unpack.go
+++ b/internal/unpack/unpack.go
@@ -101,7 +101,7 @@ func extractFile(tr *tar.Reader, h *tar.Header, dir string) error {
 func sanitizeTarPath(h *tar.Header, dir string) error {
 	// Sanitize all tar paths resolve to within the destination directory.
 	cleanDir := filepath.Clean(dir) + string(os.PathSeparator)
-	destPath := filepath.Join(dir, h.Name)
+	destPath := filepath.Join(dir, h.Name) // Join calls filepath.Clean on each element.
 
 	if !strings.HasPrefix(destPath, cleanDir) {
 		return errors.Errorf("%s: illegal file path", h.Name)

--- a/internal/unpack/unpack.go
+++ b/internal/unpack/unpack.go
@@ -100,25 +100,28 @@ func extractFile(tr *tar.Reader, h *tar.Header, dir string) error {
 // like ../../etc/password.
 func sanitizeTarPath(h *tar.Header, dir string) error {
 	// Sanitize all tar paths resolve to within the destination directory.
+	cleanDir := filepath.Clean(dir) + string(os.PathSeparator)
 	destPath := filepath.Join(dir, h.Name)
-	if !strings.HasPrefix(destPath, filepath.Clean(dir)+string(os.PathSeparator)) {
+
+	if !strings.HasPrefix(destPath, cleanDir) {
 		return errors.Errorf("%s: illegal file path", h.Name)
 	}
 
 	// Ensure link destinations resolve to within the destination directory.
 	if h.Linkname != "" {
 		if filepath.IsAbs(h.Linkname) {
-			if !strings.HasPrefix(filepath.Clean(h.Linkname), filepath.Clean(dir)+string(os.PathSeparator)) {
+			if !strings.HasPrefix(filepath.Clean(h.Linkname), cleanDir) {
 				return errors.Errorf("%s: illegal link path", h.Linkname)
 			}
 		} else {
 			// Relative paths are relative to filename after extraction to directory.
 			linkPath := filepath.Join(dir, filepath.Dir(h.Name), h.Linkname)
-			if !strings.HasPrefix(linkPath, filepath.Clean(dir)+string(os.PathSeparator)) {
+			if !strings.HasPrefix(linkPath, cleanDir) {
 				return errors.Errorf("%s: illegal link path", h.Linkname)
 			}
 		}
 	}
+
 	return nil
 }
 

--- a/internal/unpack/unpack_test.go
+++ b/internal/unpack/unpack_test.go
@@ -44,14 +44,20 @@ func TestUnpack(t *testing.T) {
 				packer: p,
 				name:   "filter",
 				opts: Opts{
-					Filter: func(file fs.FileInfo) bool { return file.Size() <= 3 },
+					Filter: func(path string, file fs.FileInfo) bool {
+						return file.Size() <= 3 && (path == "bar" || path == "foo/bar")
+					},
 				},
 				in: []*fileInfo{
 					{path: "big", contents: "E_TOO_BIG", mode: 0655},
-					{path: "foo", contents: "bar", mode: 0655},
+					{path: "bar/baz", contents: "bar", mode: 0655},
+					{path: "bar", contents: "bar", mode: 0655},
+					{path: "foo/bar", contents: "bar", mode: 0655},
 				},
 				out: []*fileInfo{
-					{path: "foo", contents: "bar", mode: 0655, size: 3},
+					{path: "bar", contents: "bar", mode: 0655, size: 3},
+					{path: "foo", mode: fs.ModeDir | 0750},
+					{path: "foo/bar", contents: "bar", mode: 0655, size: 3},
 				},
 			},
 			{

--- a/internal/unpack/unpack_test.go
+++ b/internal/unpack/unpack_test.go
@@ -1,0 +1,276 @@
+package unpack
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+// TestUnpack tests general properties of all unpack functions.
+func TestUnpack(t *testing.T) {
+	type packer struct {
+		name   string
+		unpack func(io.Reader, string, Opts) error
+		pack   func(testing.TB, ...*fileInfo) []byte
+	}
+
+	type testCase struct {
+		packer
+		name string
+		opts Opts
+		in   []*fileInfo
+		out  []*fileInfo
+		err  string
+	}
+
+	var testCases []testCase
+	for _, p := range []packer{
+		{"tar", Tar, makeTar},
+		{"tgz", Tgz, makeTgz},
+	} {
+		testCases = append(testCases, []testCase{
+			{
+				packer: p,
+				name:   "filter",
+				opts: Opts{
+					Filter: func(file fs.FileInfo) bool { return file.Size() <= 3 },
+				},
+				in: []*fileInfo{
+					{path: "big", contents: "E_TOO_BIG", mode: 0655},
+					{path: "foo", contents: "bar", mode: 0655},
+				},
+				out: []*fileInfo{
+					{path: "foo", contents: "bar", mode: 0655, size: 3},
+				},
+			},
+			{
+				packer: p,
+				name:   "empty-dirs",
+				in: []*fileInfo{
+					{path: "foo", mode: fs.ModeDir | 0740},
+				},
+				out: []*fileInfo{
+					{path: "foo", mode: fs.ModeDir | 0740},
+				},
+			},
+			{
+				packer: p,
+				name:   "illegal-file-path",
+				in: []*fileInfo{
+					{path: "../../etc/passwd", contents: "foo", mode: 0655},
+				},
+				err: "../../etc/passwd: illegal file path",
+			},
+			{
+				packer: p,
+				name:   "illegal-absolute-link-path",
+				in: []*fileInfo{
+					{path: "passwd", link: "/etc/passwd", mode: fs.ModeSymlink | 0655},
+				},
+				err: "/etc/passwd: illegal link path",
+			},
+			{
+				packer: p,
+				name:   "illegal-relative-link-path",
+				in: []*fileInfo{
+					{path: "passwd", link: "../../etc/passwd", mode: fs.ModeSymlink | 0655},
+				},
+				err: "../../etc/passwd: illegal link path",
+			},
+			{
+				packer: p,
+				name:   "skip-invalid",
+				opts:   Opts{SkipInvalid: true},
+				in: []*fileInfo{
+					{path: "bar", contents: "bar", mode: 0655},
+					{path: "../../etc/passwd", contents: "foo", mode: 0655},
+					{path: "passwd", link: "../../etc/passwd", mode: fs.ModeSymlink | 0655},
+					{path: "passwd", link: "/etc/passwd", mode: fs.ModeSymlink | 0655},
+				},
+				out: []*fileInfo{
+					{path: "bar", contents: "bar", mode: 0655, size: 3},
+				},
+			},
+			{
+				packer: p,
+				name:   "symbolic-link",
+				in: []*fileInfo{
+					{path: "bar", contents: "bar", mode: 0655},
+					{path: "foo", link: "bar", mode: fs.ModeSymlink | 0755},
+				},
+				out: []*fileInfo{
+					{path: "bar", contents: "bar", mode: 0655, size: 3},
+					{path: "foo", link: "bar", mode: fs.ModeSymlink | 0755},
+				},
+			},
+		}...)
+	}
+
+	for _, tc := range testCases {
+		t.Run(path.Join(tc.packer.name, tc.name), func(t *testing.T) {
+			dir := t.TempDir()
+
+			err := tc.unpack(
+				bytes.NewReader(tc.pack(t, tc.in...)),
+				dir,
+				tc.opts,
+			)
+
+			assertError(t, err, tc.err)
+			assertUnpack(t, dir, tc.out)
+		})
+	}
+}
+
+func makeTgz(t testing.TB, files ...*fileInfo) []byte {
+	var buf bytes.Buffer
+
+	gzw := gzip.NewWriter(&buf)
+	_, err := gzw.Write(makeTar(t, files...))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = gzw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	return buf.Bytes()
+}
+
+func makeTar(t testing.TB, files ...*fileInfo) []byte {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+
+	for _, f := range makeTarFiles(t, files...) {
+		if err := tw.WriteHeader(f.Header); err != nil {
+			t.Fatal(err)
+		}
+
+		if len(f.contents) > 0 {
+			if _, err := tw.Write([]byte(f.contents)); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	return buf.Bytes()
+}
+
+func assertError(t testing.TB, have error, want string) {
+	if want == "" {
+		want = "<nil>"
+	}
+
+	if diff := cmp.Diff(fmt.Sprint(have), want); diff != "" {
+		t.Fatalf("error mismatch: %s", diff)
+	}
+}
+
+func assertUnpack(t testing.TB, dir string, want []*fileInfo) {
+	var have []*fileInfo
+	_ = fs.WalkDir(os.DirFS(dir), ".", func(path string, d fs.DirEntry, err error) error {
+		if path != "." {
+			have = append(have, makeFileInfo(t, dir, path, d))
+		}
+		return nil
+	})
+
+	cmpOpts := []cmp.Option{
+		cmp.AllowUnexported(fileInfo{}),
+		cmpopts.IgnoreFields(fileInfo{}, "modtime"),
+	}
+
+	if diff := cmp.Diff(want, have, cmpOpts...); diff != "" {
+		t.Errorf("files mismatch: %s", diff)
+	}
+}
+
+type tarFile struct {
+	*tar.Header
+	*fileInfo
+}
+
+func makeTarFiles(t testing.TB, fs ...*fileInfo) []*tarFile {
+	tfs := make([]*tarFile, 0, len(fs))
+	for _, f := range fs {
+		header, err := tar.FileInfoHeader(f, f.link)
+		if err != nil {
+			t.Fatal(err)
+		}
+		header.Name = f.path
+		tfs = append(tfs, &tarFile{Header: header, fileInfo: f})
+	}
+	return tfs
+}
+
+type fileInfo struct {
+	path     string
+	link     string
+	mode     fs.FileMode
+	modtime  time.Time
+	contents string
+	size     int64
+}
+
+func makeFileInfo(t testing.TB, dir, path string, d fs.DirEntry) *fileInfo {
+	info, err := d.Info()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		contents []byte
+		link     string
+	)
+
+	if !d.IsDir() {
+		name := filepath.Join(dir, path)
+		if info.Mode()&fs.ModeSymlink != 0 {
+			link, err = os.Readlink(name)
+			if err != nil {
+				t.Fatal(err)
+			}
+		} else if contents, err = os.ReadFile(name); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return &fileInfo{
+		path:     path,
+		link:     link,
+		mode:     info.Mode(),
+		modtime:  info.ModTime(),
+		contents: string(contents),
+		size:     int64(len(contents)),
+	}
+}
+
+var _ fs.FileInfo = &fileInfo{}
+
+func (f *fileInfo) Name() string { return path.Base(f.path) }
+func (f *fileInfo) Size() int64 {
+	if f.size != 0 {
+		return f.size
+	}
+	return int64(len(f.contents))
+}
+func (f *fileInfo) Mode() fs.FileMode  { return f.mode }
+func (f *fileInfo) ModTime() time.Time { return f.modtime }
+func (f *fileInfo) IsDir() bool        { return f.mode.IsDir() }
+func (f *fileInfo) Sys() interface{}   { return nil }


### PR DESCRIPTION
## Context

This PR factors out `.tar.gz` unpacking into its own package, based off of https://github.com/gravitational/teleport/blob/master/lib/utils/unpack.go and uses it in gitserver to unpack NPM packages.

With this change we now handle more kinds of files and skip any we don't care about rather than erroring out.

Fixes #31663

## Test plan

Unit, integration and manual testing.


