### PR TITLE
npm: Ignore missing package versions

### DIFF
--- a/cmd/gitserver/server/vcs_syncer_npm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages.go
@@ -112,6 +112,7 @@ func (s *NPMPackagesSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, dir G
 		} else {
 			cloneable = append(cloneable, dependency)
 		}
+	}
 
 	dependencies = cloneable
 

--- a/internal/extsvc/npm/npm.go
+++ b/internal/extsvc/npm/npm.go
@@ -225,7 +225,6 @@ func (client *HTTPClient) DoesDependencyExist(ctx context.Context, dep *reposour
 	_, err = client.getDependencyInfo(ctx, dep)
 	var npmErr npmError
 	if err != nil && errors.As(err, &npmErr) && npmErr.statusCode == http.StatusNotFound {
-		log15.Info("npm dependency does not exist", "dependency", dep.PackageManagerSyntax())
 		return false, err
 	}
 	var e illFormedJSONError

--- a/internal/extsvc/npm/npm.go
+++ b/internal/extsvc/npm/npm.go
@@ -32,14 +32,12 @@ import (
 type Client interface {
 	// GetPackageInfo gets a package's data from the registry, including versions.
 	//
-	// It is preferable to use this method instead of calling DoesDependencyExist
-	// in a loop, if different dependencies may share the same underlying package.
+	// It is preferable to use this method instead of calling GetDependencyInfo for
+	// multiple versions of a package in a loop.
 	GetPackageInfo(ctx context.Context, pkg *reposource.NPMPackage) (*PackageInfo, error)
 
-	// DoesDependencyExist checks if a particular dependency exists on a particular registry.
-	//
-	// exists should be checked even if err is nil.
-	DoesDependencyExist(ctx context.Context, dep *reposource.NPMDependency) (exists bool, err error)
+	// GetDependencyInfo gets a dependency's data from the registry.
+	GetDependencyInfo(ctx context.Context, dep *reposource.NPMDependency) (*DependencyInfo, error)
 
 	// FetchTarball fetches the sources in .tar.gz format for a dependency.
 	//
@@ -69,23 +67,24 @@ func FetchSources(ctx context.Context, client Client, dependency *reposource.NPM
 		otlog.String("dependency", dependency.PackageManagerSyntax()),
 	}})
 	defer endObservation(1, observation.Args{})
+
 	return client.FetchTarball(ctx, dependency)
 }
 
-func Exists(ctx context.Context, client Client, dependency *reposource.NPMDependency) (err error) {
+func Exists(ctx context.Context, client Client, dependency *reposource.NPMDependency) (exists bool, err error) {
 	ctx, endObservation := operations.exists.With(ctx, &err, observation.Args{LogFields: []otlog.Field{
+		otlog.Bool("exists", exists),
 		otlog.String("dependency", dependency.PackageManagerSyntax()),
 	}})
 	defer endObservation(1, observation.Args{})
 
-	exists, err := client.DoesDependencyExist(ctx, dependency)
-	if err != nil {
-		return errors.Wrapf(err, "tried to check if npm package %s exists but failed", dependency.PackageManagerSyntax())
+	if _, err = client.GetDependencyInfo(ctx, dependency); err != nil {
+		if errors.HasType(err, npmError{}) {
+			return false, nil
+		}
+		return false, err
 	}
-	if !exists {
-		return errors.Newf("npm package %s does not exist", dependency.PackageManagerSyntax())
-	}
-	return nil
+	return true, nil
 }
 
 type HTTPClient struct {
@@ -189,10 +188,7 @@ func (client *HTTPClient) makeGetRequest(ctx context.Context, url string) (io.Re
 
 	resp, err := client.do(ctx, req)
 	if err != nil {
-		if resp == nil { // possible if you pass in an incorrect registry URL
-			return nil, err
-		}
-		return nil, npmError{resp.StatusCode, err}
+		return nil, err
 	}
 	defer resp.Body.Close()
 
@@ -201,13 +197,13 @@ func (client *HTTPClient) makeGetRequest(ctx context.Context, url string) (io.Re
 		return nil, err
 	}
 	if resp.StatusCode >= 400 {
-		return nil, npmError{resp.StatusCode, errors.Newf("%s", bodyBuffer.String())}
+		return nil, npmError{resp.StatusCode, errors.New(bodyBuffer.String())}
 	}
 
 	return io.NopCloser(&bodyBuffer), nil
 }
 
-func (client *HTTPClient) getDependencyInfo(ctx context.Context, dep *reposource.NPMDependency) (*DependencyInfo, error) {
+func (client *HTTPClient) GetDependencyInfo(ctx context.Context, dep *reposource.NPMDependency) (*DependencyInfo, error) {
 	// https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md#getpackageversion
 	url := fmt.Sprintf("%s/%s/%s", client.registryURL, dep.PackageSyntax(), dep.Version)
 	body, err := client.makeGetRequest(ctx, url)
@@ -221,22 +217,8 @@ func (client *HTTPClient) getDependencyInfo(ctx context.Context, dep *reposource
 	return &info, nil
 }
 
-func (client *HTTPClient) DoesDependencyExist(ctx context.Context, dep *reposource.NPMDependency) (exists bool, err error) {
-	_, err = client.getDependencyInfo(ctx, dep)
-	var npmErr npmError
-	if err != nil && errors.As(err, &npmErr) && npmErr.statusCode == http.StatusNotFound {
-		return false, err
-	}
-	var e illFormedJSONError
-	if errors.As(err, &e) {
-		log15.Warn("received ill-formed JSON payload from NPM Registry API", "error", e)
-		return false, nil
-	}
-	return err == nil, err
-}
-
 func (client *HTTPClient) FetchTarball(ctx context.Context, dep *reposource.NPMDependency) (io.ReadCloser, error) {
-	info, err := client.getDependencyInfo(ctx, dep)
+	info, err := client.GetDependencyInfo(ctx, dep)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/extsvc/npm/npmtest/npmtest.go
+++ b/internal/extsvc/npm/npmtest/npmtest.go
@@ -50,17 +50,23 @@ var _ npm.Client = &MockClient{}
 func (m *MockClient) GetPackageInfo(ctx context.Context, pkg *reposource.NPMPackage) (info *npm.PackageInfo, err error) {
 	info = m.Packages[pkg.PackageSyntax()]
 	if info == nil {
-		return nil, errors.Newf("No version for package: %s", pkg)
+		return nil, errors.Newf("package not found: %s", pkg.PackageSyntax())
 	}
 	return info, nil
 }
 
-func (m *MockClient) DoesDependencyExist(ctx context.Context, dep *reposource.NPMDependency) (exists bool, err error) {
-	pkg := m.Packages[dep.PackageSyntax()]
-	if pkg == nil {
-		return false, nil
+func (m *MockClient) GetDependencyInfo(ctx context.Context, dep *reposource.NPMDependency) (info *npm.DependencyInfo, err error) {
+	pkg, err := m.GetPackageInfo(ctx, dep.NPMPackage)
+	if err != nil {
+		return nil, err
 	}
-	return pkg.Versions[dep.Version] != nil, nil
+
+	info = pkg.Versions[dep.Version]
+	if info == nil {
+		return nil, errors.Newf("package version not found: %s", dep.PackageManagerSyntax())
+	}
+
+	return info, nil
 }
 
 func (m *MockClient) FetchTarball(_ context.Context, dep *reposource.NPMDependency) (io.ReadCloser, error) {

--- a/internal/extsvc/npm/testdata/vcr/TestGetDependencyInfo.yaml
+++ b/internal/extsvc/npm/testdata/vcr/TestGetDependencyInfo.yaml
@@ -1,0 +1,59 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://registry.npmjs.org/left-pad/1.3.0
+    method: GET
+  response:
+    body: '{"name":"left-pad","version":"1.3.0","description":"String left pad","main":"index.js","types":"index.d.ts","scripts":{"test":"node
+      test","bench":"node perf/perf.js"},"devDependencies":{"benchmark":"^2.1.0","fast-check":"0.0.8","tape":"*"},"keywords":["leftpad","left","pad","padding","string","repeat"],"repository":{"url":"git+ssh://git@github.com/stevemao/left-pad.git","type":"git"},"author":{"name":"azer"},"maintainers":[{"name":"sebmck","email":"sebmck@gmail.com"},{"name":"stevemao","email":"maochenyan@gmail.com"},{"name":"westlac","email":"cameron.westland@autodesk.com"}],"license":"WTFPL","gitHead":"ff8e7ba8b4122829cf66125ca8445cac7f073bce","bugs":{"url":"https://github.com/stevemao/left-pad/issues"},"homepage":"https://github.com/stevemao/left-pad#readme","_id":"left-pad@1.3.0","_npmVersion":"5.5.1","_nodeVersion":"9.2.1","_npmUser":{"name":"stevemao","email":"maochenyan@gmail.com"},"dist":{"integrity":"sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==","shasum":"5b8a3a7765dfe001261dde915589e782f8c94d1e","tarball":"https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz","fileCount":10,"unpackedSize":9752},"directories":{},"_npmOperationalInternal":{"host":"s3://npm-registry-packages","tmp":"tmp/left-pad_1.3.0_1523236245678_0.2849598021556574"},"_hasShrinkwrap":false,"deprecated":"use
+      String.prototype.padStart()"}'
+    headers:
+      Cache-Control:
+      - max-age=300
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 6ea39fe4ed5f58ea-TXL
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 11 Mar 2022 10:32:09 GMT
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding, accept
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://registry.npmjs.org/left-pad/1.3.1
+    method: GET
+  response:
+    body: '"version not found: 1.3.1"'
+    headers:
+      Cf-Ray:
+      - 6ea39fe6e9d258ea-TXL
+      Content-Length:
+      - "26"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 11 Mar 2022 10:32:10 GMT
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Vary:
+      - Accept-Encoding
+    status: 404 Not Found
+    code: 404
+    duration: ""

--- a/internal/repos/npm_packages.go
+++ b/internal/repos/npm_packages.go
@@ -99,22 +99,21 @@ func (s *NPMPackagesSource) ListRepos(ctx context.Context, results chan SourceRe
 			npmDependency := reposource.NPMDependency{NPMPackage: parsedDbPackage, Version: dbDep.Version}
 			pkgKey := npmDependency.PackageSyntax()
 			info := pkgVersions[pkgKey]
+
 			if info == nil {
 				info, err = s.client.GetPackageInfo(ctx, npmDependency.NPMPackage)
 				if err != nil {
 					pkgVersions[pkgKey] = &npm.PackageInfo{Versions: map[string]*npm.DependencyInfo{}}
-					log15.Warn("npm package not found in registry", "package", pkgKey, "err", err)
 					continue
 				}
+
 				pkgVersions[pkgKey] = info
 			}
+
 			if _, hasVersion := info.Versions[npmDependency.Version]; !hasVersion {
-				if len(info.Versions) != 0 { // We must've already logged a package not found earlier if len is 0.
-					log15.Warn("npm dependency does not exist",
-						"dependency", npmDependency.PackageManagerSyntax())
-				}
 				continue
 			}
+
 			repo := s.makeRepo(npmDependency.NPMPackage, info.Description)
 			totalDBResolved++
 			results <- SourceResult{Source: s, Repo: repo}

--- a/internal/repos/observability.go
+++ b/internal/repos/observability.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/sourcegraph/sourcegraph/internal/logging"
@@ -127,7 +126,6 @@ func (o *observedSource) GetRepo(ctx context.Context, path string) (sourced *typ
 	defer func(began time.Time) {
 		secs := time.Since(began).Seconds()
 		o.metrics.GetRepo.Observe(secs, 1, &err)
-		log15.Info("source.get-repo", "name", path)
 		logging.Log(o.log, "source.get-repo", &err)
 	}(time.Now())
 


### PR DESCRIPTION
This commit makes the NPM package repos integration ignore missing
package versions altogether, reducing noisy logging and allowing
existing versions of a package to be cloned when others don't exist.

Part of #32052



## Test plan

Unit and integration tests.


