### PR TITLE
gitserver: Add repo_size_bytes column to the gitserver_repos table

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -972,6 +972,7 @@ Referenced by:
  updated_at   | timestamp with time zone |           | not null | now()
  last_fetched | timestamp with time zone |           | not null | now()
  last_changed | timestamp with time zone |           | not null | now()
+ repo_size    | bigint                   |           |          | 
 Indexes:
     "gitserver_repos_pkey" PRIMARY KEY, btree (repo_id)
     "gitserver_repos_cloned_status_idx" btree (repo_id) WHERE clone_status = 'cloned'::text

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -963,16 +963,16 @@ Referenced by:
 
 # Table "public.gitserver_repos"
 ```
-    Column    |           Type           | Collation | Nullable |      Default       
---------------+--------------------------+-----------+----------+--------------------
- repo_id      | integer                  |           | not null | 
- clone_status | text                     |           | not null | 'not_cloned'::text
- shard_id     | text                     |           | not null | 
- last_error   | text                     |           |          | 
- updated_at   | timestamp with time zone |           | not null | now()
- last_fetched | timestamp with time zone |           | not null | now()
- last_changed | timestamp with time zone |           | not null | now()
- repo_size    | bigint                   |           |          | 
+     Column      |           Type           | Collation | Nullable |      Default       
+-----------------+--------------------------+-----------+----------+--------------------
+ repo_id         | integer                  |           | not null | 
+ clone_status    | text                     |           | not null | 'not_cloned'::text
+ shard_id        | text                     |           | not null | 
+ last_error      | text                     |           |          | 
+ updated_at      | timestamp with time zone |           | not null | now()
+ last_fetched    | timestamp with time zone |           | not null | now()
+ last_changed    | timestamp with time zone |           | not null | now()
+ repo_size_bytes | bigint                   |           |          | 
 Indexes:
     "gitserver_repos_pkey" PRIMARY KEY, btree (repo_id)
     "gitserver_repos_cloned_status_idx" btree (repo_id) WHERE clone_status = 'cloned'::text

--- a/migrations/frontend/1646741362/down.sql
+++ b/migrations/frontend/1646741362/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS gitserver_repos
+    DROP COLUMN IF EXISTS repo_size;

--- a/migrations/frontend/1646741362/down.sql
+++ b/migrations/frontend/1646741362/down.sql
@@ -1,2 +1,2 @@
 ALTER TABLE IF EXISTS gitserver_repos
-    DROP COLUMN IF EXISTS repo_size;
+    DROP COLUMN IF EXISTS repo_size_bytes;

--- a/migrations/frontend/1646741362/metadata.yaml
+++ b/migrations/frontend/1646741362/metadata.yaml
@@ -1,2 +1,2 @@
-name: add_gitserver_repos_repo_size_column
+name: add_gitserver_repos_repo_size_bytes_column
 parents: [1646306565]

--- a/migrations/frontend/1646741362/metadata.yaml
+++ b/migrations/frontend/1646741362/metadata.yaml
@@ -1,0 +1,2 @@
+name: add_gitserver_repos_repo_size_column
+parents: [1646306565]

--- a/migrations/frontend/1646741362/up.sql
+++ b/migrations/frontend/1646741362/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS gitserver_repos
+    ADD COLUMN IF NOT EXISTS repo_size BIGINT;

--- a/migrations/frontend/1646741362/up.sql
+++ b/migrations/frontend/1646741362/up.sql
@@ -1,2 +1,2 @@
 ALTER TABLE IF EXISTS gitserver_repos
-    ADD COLUMN IF NOT EXISTS repo_size BIGINT;
+    ADD COLUMN IF NOT EXISTS repo_size_bytes BIGINT;


### PR DESCRIPTION
This adds a new column to the `gitserver_repos` table to host the size of the repository on disk.
Related to https://github.com/sourcegraph/sourcegraph/issues/32197

## Test plan

Tested with `sg migration up` and `sg migration undo`


