### PR TITLE
sg: fix ops update-images auth bug

### DIFF
--- a/dev/sg/internal/images/images.go
+++ b/dev/sg/internal/images/images.go
@@ -106,7 +106,7 @@ func ParseHelm(path string, creds credentials.Credentials, pinTag string) error 
 	}
 
 	var values map[string]interface{}
-	json.Unmarshal(rawValues, &values)
+	_ = json.Unmarshal(rawValues, &values)
 
 	var images []string
 	extraImages(values, &images)
@@ -178,7 +178,6 @@ func findImage(r *yaml.RNode, credential credentials.Credentials, pinTag string)
 		return err
 	}
 	if containers == nil && initContainers == nil {
-
 		return ErrNoImage{
 			Kind: r.GetKind(),
 			Name: r.GetName(),
@@ -354,7 +353,6 @@ func (i *imageRepository) fetchAuthToken(registryName string) (string, error) {
 }
 
 func createAndFillImageRepository(ref *ImageReference, pinTag string) (repo *imageRepository, err error) {
-
 	repo = &imageRepository{name: ref.Name, imageRef: ref}
 	repo.authToken, err = repo.fetchAuthToken(ref.Registry)
 	if err != nil {
@@ -475,7 +473,7 @@ func (i *imageRepository) fetchDigest(tag string) (digest.Digest, error) {
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		data, _ := io.ReadAll(resp.Body)
-		return "", errors.New(resp.Status + ": " + string(data))
+		return "", errors.Newf("GET https://index.docker.io/v2/%s/manifests/%s %s: %s", i.name, tag, resp.Status, string(data))
 	}
 
 	d := resp.Header.Get("Docker-Content-Digest")

--- a/dev/sg/internal/images/images.go
+++ b/dev/sg/internal/images/images.go
@@ -106,7 +106,10 @@ func ParseHelm(path string, creds credentials.Credentials, pinTag string) error 
 	}
 
 	var values map[string]interface{}
-	_ = json.Unmarshal(rawValues, &values)
+	err = json.Unmarshal(rawValues, &values)
+	if err != nil {
+		return errors.Wrapf(err, "couldn't unmarshal %s", valuesFilePath)
+	}
 
 	var images []string
 	extraImages(values, &images)

--- a/dev/sg/sg_ops.go
+++ b/dev/sg/sg_ops.go
@@ -68,19 +68,22 @@ func opsUpdateImage(ctx context.Context, args []string) error {
 		stdout.Out.WriteLine(output.Linef("", output.StyleWarning, "Multiple paths not currently supported"))
 		return flag.ErrHelp
 	}
-	var dockerCredentials *credentials.Credentials
+	dockerCredentials := &credentials.Credentials{
+		ServerURL: "https://index.docker.io/v1/",
+		Username:  *opsUpdateImagesContainerRegistryUsernameFlag,
+		Secret:    *opsUpdateImagesContainerRegistryPasswordFlag,
+	}
 	var err error
 	if *opsUpdateImagesContainerRegistryUsernameFlag == "" || *opsUpdateImagesContainerRegistryPasswordFlag == "" {
-		dockerCredentials, err = docker.GetCredentialsFromStore("https://index.docker.io/v1/")
+		dockerCredentials, err = docker.GetCredentialsFromStore(dockerCredentials.ServerURL)
 		if err != nil {
 			// We do not want any error handling here, just fallback to anonymous requests
 			writeWarningLinef("Registry credentials are not provided and could not be retrieved from docker config.")
 			writeWarningLinef("You will be using anonymous requests and may be subject to rate limiting by Docker Hub.")
-			dockerCredentials = &credentials.Credentials{ServerURL: "https://index.docker.io/v1/", Username: "", Secret: ""}
+			dockerCredentials.Username = ""
+			dockerCredentials.Secret = ""
 		} else {
 			writeFingerPointingLinef("Using credentials from docker credentials store (learn more https://docs.docker.com/engine/reference/commandline/login/#credentials-store)")
-			opsUpdateImagesContainerRegistryUsernameFlag = &dockerCredentials.Username
-			opsUpdateImagesContainerRegistryPasswordFlag = &dockerCredentials.Secret
 		}
 	}
 

--- a/dev/sg/sg_ops.go
+++ b/dev/sg/sg_ops.go
@@ -37,7 +37,7 @@ var (
 		Name:        "update-images",
 		ShortUsage:  "sg ops update-images [flags] <dir>",
 		ShortHelp:   "Updates images in given directory to latest published image",
-		LongHelp:    "Updates images in given directory to latest published image",
+		LongHelp:    "Updates images in given directory to latest published image.\nEx: in deploy-sourcegraph-cloud, run `sg ops update-images base/.`",
 		UsageFunc:   nil,
 		FlagSet:     opsUpdateImagesFlagSet,
 		Options:     nil,


### PR DESCRIPTION
This small PR fixes a bug with the authentication flags, who weren't passed down to the functions doing the work. 

I added some clarification around an error message along the way, which helps to nail down which image it causing a problem. 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

- Ran it locally and tested manually entered credentials. 
