### PR TITLE
Code Insights: Fix insight tooltip overflow layout problem

### DIFF
--- a/client/web/src/views/components/view/content/chart-view-content/charts/line/LineChart.module.scss
+++ b/client/web/src/views/components/view/content/chart-view-content/charts/line/LineChart.module.scss
@@ -54,6 +54,11 @@
 .legend-item {
     display: flex;
     align-items: baseline;
+    min-width: 0;
+}
+
+.legend-item-text {
+    overflow: hidden;
 }
 
 .legend-mark {

--- a/client/web/src/views/components/view/content/chart-view-content/charts/line/LineChart.tsx
+++ b/client/web/src/views/components/view/content/chart-view-content/charts/line/LineChart.tsx
@@ -78,6 +78,6 @@ export const LegendItem: React.FunctionComponent<LegendItemProps> = props => (
             style={{ backgroundColor: props.color }}
             className={styles.legendMark}
         />
-        {props.children}
+        <span className={styles.legendItemText}>{props.children}</span>
     </li>
 )

--- a/client/web/src/views/components/view/content/chart-view-content/charts/line/components/tooltip-content/TooltipContent.module.scss
+++ b/client/web/src/views/components/view/content/chart-view-content/charts/line/components/tooltip-content/TooltipContent.module.scss
@@ -20,6 +20,8 @@
 
 .legend-text {
     flex-grow: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .legend-value {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/30014

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<th>

<img width="773" alt="Screenshot 2022-03-08 at 20 09 14" src="https://user-images.githubusercontent.com/18492575/157277633-108b1d87-db8a-438a-a0af-64bf8b82c504.png">

</th>
<th>

<img width="740" alt="Screenshot 2022-03-08 at 20 02 31" src="https://user-images.githubusercontent.com/18492575/157277447-51833d77-aec5-4dab-9321-47cebe058a0d.png">

</th>
</tr>
</table>


## Test plan
- Check that long text items are rendered correctly and have a right layout 
- Check that capture group insight layout hasn't been affected (I mean legend items with aside chart layout)

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


