### PR TITLE
ci: ship sg image without deploy

### DIFF
--- a/enterprise/dev/ci/images/images.go
+++ b/enterprise/dev/ci/images/images.go
@@ -48,7 +48,7 @@ func maybeTaggedImage(rootImage, tag string) string {
 //
 // The `addDockerImages` pipeline step determines what images are built and published.
 var SourcegraphDockerImages = append(DeploySourcegraphDockerImages,
-	"server")
+	"server", "sg")
 
 // DeploySourcegraphDockerImages denotes all Docker images that are included in a typical
 // deploy-sourcegraph installation.
@@ -83,7 +83,6 @@ var DeploySourcegraphDockerImages = []string{
 	"syntax-highlighter",
 	"worker",
 	"migrator",
-	"sg",
 }
 
 // CandidateImageTag provides the tag for a candidate image built for this Buildkite run.


### PR DESCRIPTION
Hotfix for a bug introduced in https://github.com/sourcegraph/sourcegraph/pull/32326#discussion_r821860229 that @bobheadxi spotted after the merge (thank you so much for reviewing it anyway!). 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

- check in CI that the image is still built (https://buildkite.com/sourcegraph/sourcegraph/builds/135736) 
