### PR TITLE
Search: break dependencies on pre-formatted markdown

### DIFF
--- a/client/search-ui/src/components/SearchResult.module.scss
+++ b/client/search-ui/src/components/SearchResult.module.scss
@@ -83,3 +83,7 @@
     flex-grow: 1;
     min-width: 0;
 }
+
+.commit-oid {
+    background: var(--code-bg);
+}

--- a/client/search-ui/src/components/SearchResult.module.scss
+++ b/client/search-ui/src/components/SearchResult.module.scss
@@ -86,4 +86,6 @@
 
 .commit-oid {
     background: var(--code-bg);
+    display: inline-block;
+    padding: 0.25rem;
 }

--- a/client/search-ui/src/components/SearchResult.tsx
+++ b/client/search-ui/src/components/SearchResult.tsx
@@ -4,9 +4,8 @@ import LockIcon from 'mdi-react/LockIcon'
 import SourceForkIcon from 'mdi-react/SourceForkIcon'
 import React from 'react'
 
-import { renderMarkdown } from '@sourcegraph/common'
+import { Timestamp } from '@sourcegraph/web/src/components/time/Timestamp'
 import { LastSyncedIcon } from '@sourcegraph/shared/src/components/LastSyncedIcon'
-import { Markdown } from '@sourcegraph/shared/src/components/Markdown'
 import { RepoIcon } from '@sourcegraph/shared/src/components/RepoIcon'
 import { ResultContainer } from '@sourcegraph/shared/src/components/ResultContainer'
 import { SearchResultStar } from '@sourcegraph/shared/src/components/SearchResultStar'
@@ -41,21 +40,26 @@ export const SearchResult: React.FunctionComponent<Props> = ({
                 <RepoIcon repoName={repoName} className="icon-inline text-muted flex-shrink-0" />
                 {result.type === 'commit' && (
                     <>
-                        <a href={'/'+encodeURI(result.repository)}>{result.repository}</a>
-                        <span> › </span>
-                        <a href={'/'+encodeURI(result.repository)+'/-/commit/'+result.oid}>{result.authorName}</a>
-                        <span>: </span>
-                        <a href={'/'+encodeURI(result.repository)+'/-/commit/'+result.oid}>{result.message.split('\n', 1)[0]}</a>
+                        &nbsp;
+                        <a href={'/' + encodeURI(result.repository)}>{result.repository}</a>
+                        &nbsp;›&nbsp;
+                        <a href={'/' + encodeURI(result.repository) + '/-/commit/' + result.oid}>{result.authorName}</a>
+                        :&nbsp;
+                        <a href={'/' + encodeURI(result.repository) + '/-/commit/' + result.oid}>
+                            {result.message.split('\n', 1)[0]}
+                        </a>
                     </>
                 )}
                 {result.type === 'repo' && (
                     <a href={getRepoMatchUrl(result)}>{displayRepoName(getRepoMatchLabel(result))}</a>
                 )}
                 <span className={styles.spacer} />
-                {result.type === 'commit' && result.detail && (
-                    <>
-                        <Markdown className="flex-shrink-0" dangerousInnerHTML={renderMarkdown(result.detail)} />
-                    </>
+                {result.type === 'commit' && (
+                    <a href={'/' + encodeURI(result.repository) + '/-/commit/' + result.oid}>
+                        <code>{result.oid.slice(0, 7)}</code>
+                        &nbsp;
+                        <Timestamp date={result.authorDate} noAbout={true} />
+                    </a>
                 )}
                 {result.type === 'commit' && result.detail && formattedRepositoryStarCount && (
                     <div className={styles.divider} />

--- a/client/search-ui/src/components/SearchResult.tsx
+++ b/client/search-ui/src/components/SearchResult.tsx
@@ -5,6 +5,7 @@ import SourceForkIcon from 'mdi-react/SourceForkIcon'
 import React from 'react'
 
 import { Timestamp } from '@sourcegraph/web/src/components/time/Timestamp'
+import { Link } from '@sourcegraph/wildcard'
 import { LastSyncedIcon } from '@sourcegraph/shared/src/components/LastSyncedIcon'
 import { RepoIcon } from '@sourcegraph/shared/src/components/RepoIcon'
 import { ResultContainer } from '@sourcegraph/shared/src/components/ResultContainer'
@@ -41,13 +42,15 @@ export const SearchResult: React.FunctionComponent<Props> = ({
                 {result.type === 'commit' && (
                     <>
                         &nbsp;
-                        <a href={'/' + encodeURI(result.repository)}>{result.repository}</a>
+                        <Link to={'/' + encodeURI(result.repository)}>{result.repository}</Link>
                         &nbsp;›&nbsp;
-                        <a href={'/' + encodeURI(result.repository) + '/-/commit/' + result.oid}>{result.authorName}</a>
+                        <Link to={'/' + encodeURI(result.repository) + '/-/commit/' + result.oid}>
+                            {result.authorName}
+                        </Link>
                         :&nbsp;
-                        <a href={'/' + encodeURI(result.repository) + '/-/commit/' + result.oid}>
+                        <Link to={'/' + encodeURI(result.repository) + '/-/commit/' + result.oid}>
                             {result.message.split('\n', 1)[0]}
-                        </a>
+                        </Link>
                     </>
                 )}
                 {result.type === 'repo' && (

--- a/client/search-ui/src/components/SearchResult.tsx
+++ b/client/search-ui/src/components/SearchResult.tsx
@@ -60,9 +60,9 @@ export const SearchResult: React.FunctionComponent<Props> = ({
                 <span className={styles.spacer} />
                 {result.type === 'commit' && (
                     <Link to={'/' + encodeURI(result.repository) + '/-/commit/' + result.oid}>
-                        <code>{result.oid.slice(0, 7)}</code>
+                        <code className={styles.commitOid}>{result.oid.slice(0, 7)}</code>
                         &nbsp;
-                        <Timestamp date={result.authorDate} noAbout={true} />
+                        <Timestamp date={result.authorDate} noAbout={true} strict={true}/>
                     </Link>
                 )}
                 {result.type === 'commit' && result.detail && formattedRepositoryStarCount && (

--- a/client/search-ui/src/components/SearchResult.tsx
+++ b/client/search-ui/src/components/SearchResult.tsx
@@ -11,7 +11,8 @@ import { RepoIcon } from '@sourcegraph/shared/src/components/RepoIcon'
 import { ResultContainer } from '@sourcegraph/shared/src/components/ResultContainer'
 import { SearchResultStar } from '@sourcegraph/shared/src/components/SearchResultStar'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
-import { CommitMatch, getMatchTitle, RepositoryMatch } from '@sourcegraph/shared/src/search/stream'
+import { CommitMatch, getRepoMatchLabel, getRepoMatchUrl, RepositoryMatch } from '@sourcegraph/shared/src/search/stream'
+import { displayRepoName } from '@sourcegraph/shared/src/components/RepoFileLink'
 import { formatRepositoryStarCount } from '@sourcegraph/shared/src/util/stars'
 
 import { CommitSearchResultMatch } from './CommitSearchResultMatch'
@@ -38,10 +39,18 @@ export const SearchResult: React.FunctionComponent<Props> = ({
         return (
             <div className={styles.title}>
                 <RepoIcon repoName={repoName} className="icon-inline text-muted flex-shrink-0" />
-                <Markdown
-                    className="test-search-result-label ml-1 flex-shrink-past-contents text-truncate"
-                    dangerousInnerHTML={renderMarkdown(getMatchTitle(result))}
-                />
+                {result.type === 'commit' && (
+                    <>
+                        <a href={'/'+encodeURI(result.repository)}>{result.repository}</a>
+                        <span> › </span>
+                        <a href={'/'+encodeURI(result.repository)+'/-/commit/'+result.oid}>{result.authorName}</a>
+                        <span>: </span>
+                        <a href={'/'+encodeURI(result.repository)+'/-/commit/'+result.oid}>{result.message.split('\n', 1)[0]}</a>
+                    </>
+                )}
+                {result.type === 'repo' && (
+                    <a href={getRepoMatchUrl(result)}>{displayRepoName(getRepoMatchLabel(result))}</a>
+                )}
                 <span className={styles.spacer} />
                 {result.type === 'commit' && result.detail && (
                     <>

--- a/client/search-ui/src/components/SearchResult.tsx
+++ b/client/search-ui/src/components/SearchResult.tsx
@@ -4,16 +4,16 @@ import LockIcon from 'mdi-react/LockIcon'
 import SourceForkIcon from 'mdi-react/SourceForkIcon'
 import React from 'react'
 
-import { CommitMatch, getRepoMatchLabel, getRepoMatchUrl, RepositoryMatch } from '@sourcegraph/shared/src/search/stream'
 import { LastSyncedIcon } from '@sourcegraph/shared/src/components/LastSyncedIcon'
-import { Link } from '@sourcegraph/wildcard'
-import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
+import { displayRepoName } from '@sourcegraph/shared/src/components/RepoFileLink'
 import { RepoIcon } from '@sourcegraph/shared/src/components/RepoIcon'
 import { ResultContainer } from '@sourcegraph/shared/src/components/ResultContainer'
 import { SearchResultStar } from '@sourcegraph/shared/src/components/SearchResultStar'
-import { Timestamp } from '@sourcegraph/web/src/components/time/Timestamp'
-import { displayRepoName } from '@sourcegraph/shared/src/components/RepoFileLink'
+import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
+import { CommitMatch, getRepoMatchLabel, getRepoMatchUrl, RepositoryMatch } from '@sourcegraph/shared/src/search/stream'
 import { formatRepositoryStarCount } from '@sourcegraph/shared/src/util/stars'
+import { Timestamp } from '@sourcegraph/web/src/components/time/Timestamp'
+import { Link } from '@sourcegraph/wildcard'
 
 import { CommitSearchResultMatch } from './CommitSearchResultMatch'
 import styles from './SearchResult.module.scss'
@@ -54,7 +54,7 @@ export const SearchResult: React.FunctionComponent<Props> = ({
                     </>
                 )}
                 {result.type === 'repo' && (
-                    <a href={getRepoMatchUrl(result)}>{displayRepoName(getRepoMatchLabel(result))}</a>
+                    <Link to={getRepoMatchUrl(result)}>{displayRepoName(getRepoMatchLabel(result))}</Link>
                 )}
                 <span className={styles.spacer} />
                 {result.type === 'commit' && (

--- a/client/search-ui/src/components/SearchResult.tsx
+++ b/client/search-ui/src/components/SearchResult.tsx
@@ -50,9 +50,9 @@ export const SearchResult: React.FunctionComponent<Props> = ({
                     {result.type === 'commit' && (
                         <>
                             <Link to={getRepositoryUrl(result.repository)}>{displayRepoName(result.repository)}</Link>
-                            &nbsp;›&nbsp;
+                            {' › '}
                             <Link to={getCommitMatchUrl(result)}>{result.authorName}</Link>
-                            :&nbsp;
+                            {': '}
                             <Link to={getCommitMatchUrl(result)}>{result.message.split('\n', 1)[0]}</Link>
                         </>
                     )}
@@ -64,7 +64,7 @@ export const SearchResult: React.FunctionComponent<Props> = ({
                 {result.type === 'commit' && (
                     <Link to={getCommitMatchUrl(result)}>
                         <code className={styles.commitOid}>{result.oid.slice(0, 7)}</code>
-                        &nbsp;
+                        {' '}
                         <Timestamp date={result.authorDate} noAbout={true} strict={true} />
                     </Link>
                 )}

--- a/client/search-ui/src/components/SearchResult.tsx
+++ b/client/search-ui/src/components/SearchResult.tsx
@@ -67,9 +67,7 @@ export const SearchResult: React.FunctionComponent<Props> = ({
                         <Timestamp date={result.authorDate} noAbout={true} strict={true} />
                     </Link>
                 )}
-                {result.type === 'commit' && formattedRepositoryStarCount && (
-                    <div className={styles.divider} />
-                )}
+                {result.type === 'commit' && formattedRepositoryStarCount && <div className={styles.divider} />}
                 {formattedRepositoryStarCount && (
                     <>
                         <SearchResultStar />

--- a/client/search-ui/src/components/SearchResult.tsx
+++ b/client/search-ui/src/components/SearchResult.tsx
@@ -4,14 +4,14 @@ import LockIcon from 'mdi-react/LockIcon'
 import SourceForkIcon from 'mdi-react/SourceForkIcon'
 import React from 'react'
 
-import { Timestamp } from '@sourcegraph/web/src/components/time/Timestamp'
-import { Link } from '@sourcegraph/wildcard'
+import { CommitMatch, getRepoMatchLabel, getRepoMatchUrl, RepositoryMatch } from '@sourcegraph/shared/src/search/stream'
 import { LastSyncedIcon } from '@sourcegraph/shared/src/components/LastSyncedIcon'
+import { Link } from '@sourcegraph/wildcard'
+import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { RepoIcon } from '@sourcegraph/shared/src/components/RepoIcon'
 import { ResultContainer } from '@sourcegraph/shared/src/components/ResultContainer'
 import { SearchResultStar } from '@sourcegraph/shared/src/components/SearchResultStar'
-import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
-import { CommitMatch, getRepoMatchLabel, getRepoMatchUrl, RepositoryMatch } from '@sourcegraph/shared/src/search/stream'
+import { Timestamp } from '@sourcegraph/web/src/components/time/Timestamp'
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoFileLink'
 import { formatRepositoryStarCount } from '@sourcegraph/shared/src/util/stars'
 
@@ -58,11 +58,11 @@ export const SearchResult: React.FunctionComponent<Props> = ({
                 )}
                 <span className={styles.spacer} />
                 {result.type === 'commit' && (
-                    <a href={'/' + encodeURI(result.repository) + '/-/commit/' + result.oid}>
+                    <Link to={'/' + encodeURI(result.repository) + '/-/commit/' + result.oid}>
                         <code>{result.oid.slice(0, 7)}</code>
                         &nbsp;
                         <Timestamp date={result.authorDate} noAbout={true} />
-                    </a>
+                    </Link>
                 )}
                 {result.type === 'commit' && result.detail && formattedRepositoryStarCount && (
                     <div className={styles.divider} />

--- a/client/search-ui/src/components/SearchResult.tsx
+++ b/client/search-ui/src/components/SearchResult.tsx
@@ -39,23 +39,24 @@ export const SearchResult: React.FunctionComponent<Props> = ({
         return (
             <div className={styles.title}>
                 <RepoIcon repoName={repoName} className="icon-inline text-muted flex-shrink-0" />
-                {result.type === 'commit' && (
-                    <>
-                        &nbsp;
-                        <Link to={'/' + encodeURI(result.repository)}>{result.repository}</Link>
-                        &nbsp;›&nbsp;
-                        <Link to={'/' + encodeURI(result.repository) + '/-/commit/' + result.oid}>
-                            {result.authorName}
-                        </Link>
-                        :&nbsp;
-                        <Link to={'/' + encodeURI(result.repository) + '/-/commit/' + result.oid}>
-                            {result.message.split('\n', 1)[0]}
-                        </Link>
-                    </>
-                )}
-                {result.type === 'repo' && (
-                    <Link to={getRepoMatchUrl(result)}>{displayRepoName(getRepoMatchLabel(result))}</Link>
-                )}
+                    <span className="test-search-result-label ml-1 flex-shrink-past-contents text-truncate">
+                        {result.type === 'commit' && (
+                            <>
+                                <Link to={'/' + encodeURI(result.repository)}>{result.repository}</Link>
+                                &nbsp;›&nbsp;
+                                <Link to={'/' + encodeURI(result.repository) + '/-/commit/' + result.oid}>
+                                    {result.authorName}
+                                </Link>
+                                :&nbsp;
+                                <Link to={'/' + encodeURI(result.repository) + '/-/commit/' + result.oid}>
+                                    {result.message.split('\n', 1)[0]}
+                                </Link>
+                            </>
+                        )}
+                        {result.type === 'repo' && (
+                            <Link to={getRepoMatchUrl(result)}>{displayRepoName(getRepoMatchLabel(result))}</Link>
+                        )}
+                    </span>
                 <span className={styles.spacer} />
                 {result.type === 'commit' && (
                     <Link to={'/' + encodeURI(result.repository) + '/-/commit/' + result.oid}>

--- a/client/search-ui/src/components/SearchResult.tsx
+++ b/client/search-ui/src/components/SearchResult.tsx
@@ -62,7 +62,7 @@ export const SearchResult: React.FunctionComponent<Props> = ({
                     <Link to={'/' + encodeURI(result.repository) + '/-/commit/' + result.oid}>
                         <code className={styles.commitOid}>{result.oid.slice(0, 7)}</code>
                         &nbsp;
-                        <Timestamp date={result.authorDate} noAbout={true} strict={true}/>
+                        <Timestamp date={result.authorDate} noAbout={true} strict={true} />
                     </Link>
                 )}
                 {result.type === 'commit' && result.detail && formattedRepositoryStarCount && (

--- a/client/search-ui/src/components/SearchResult.tsx
+++ b/client/search-ui/src/components/SearchResult.tsx
@@ -10,7 +10,7 @@ import { RepoIcon } from '@sourcegraph/shared/src/components/RepoIcon'
 import { ResultContainer } from '@sourcegraph/shared/src/components/ResultContainer'
 import { SearchResultStar } from '@sourcegraph/shared/src/components/SearchResultStar'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
-import { CommitMatch, getRepoMatchLabel, getRepoMatchUrl, RepositoryMatch } from '@sourcegraph/shared/src/search/stream'
+import { CommitMatch, getCommitMatchUrl, getRepoMatchLabel, getRepoMatchUrl, getRepositoryUrl, RepositoryMatch } from '@sourcegraph/shared/src/search/stream'
 import { formatRepositoryStarCount } from '@sourcegraph/shared/src/util/stars'
 import { Timestamp } from '@sourcegraph/web/src/components/time/Timestamp'
 import { Link } from '@sourcegraph/wildcard'
@@ -42,13 +42,13 @@ export const SearchResult: React.FunctionComponent<Props> = ({
                 <span className="test-search-result-label ml-1 flex-shrink-past-contents text-truncate">
                     {result.type === 'commit' && (
                         <>
-                            <Link to={'/' + encodeURI(result.repository)}>{displayRepoName(result.repository)}</Link>
+                            <Link to={getRepositoryUrl(result.repository)}>{displayRepoName(result.repository)}</Link>
                             &nbsp;›&nbsp;
-                            <Link to={'/' + encodeURI(result.repository) + '/-/commit/' + result.oid}>
+                            <Link to={getCommitMatchUrl(result)}>
                                 {result.authorName}
                             </Link>
                             :&nbsp;
-                            <Link to={'/' + encodeURI(result.repository) + '/-/commit/' + result.oid}>
+                            <Link to={getCommitMatchUrl(result)}>
                                 {result.message.split('\n', 1)[0]}
                             </Link>
                         </>
@@ -59,7 +59,7 @@ export const SearchResult: React.FunctionComponent<Props> = ({
                 </span>
                 <span className={styles.spacer} />
                 {result.type === 'commit' && (
-                    <Link to={'/' + encodeURI(result.repository) + '/-/commit/' + result.oid}>
+                    <Link to={getCommitMatchUrl(result)}>
                         <code className={styles.commitOid}>{result.oid.slice(0, 7)}</code>
                         &nbsp;
                         <Timestamp date={result.authorDate} noAbout={true} strict={true} />

--- a/client/search-ui/src/components/SearchResult.tsx
+++ b/client/search-ui/src/components/SearchResult.tsx
@@ -67,7 +67,7 @@ export const SearchResult: React.FunctionComponent<Props> = ({
                         <Timestamp date={result.authorDate} noAbout={true} strict={true} />
                     </Link>
                 )}
-                {result.type === 'commit' && result.detail && formattedRepositoryStarCount && (
+                {result.type === 'commit' && formattedRepositoryStarCount && (
                     <div className={styles.divider} />
                 )}
                 {formattedRepositoryStarCount && (

--- a/client/search-ui/src/components/SearchResult.tsx
+++ b/client/search-ui/src/components/SearchResult.tsx
@@ -39,24 +39,24 @@ export const SearchResult: React.FunctionComponent<Props> = ({
         return (
             <div className={styles.title}>
                 <RepoIcon repoName={repoName} className="icon-inline text-muted flex-shrink-0" />
-                    <span className="test-search-result-label ml-1 flex-shrink-past-contents text-truncate">
-                        {result.type === 'commit' && (
-                            <>
-                                <Link to={'/' + encodeURI(result.repository)}>{result.repository}</Link>
-                                &nbsp;›&nbsp;
-                                <Link to={'/' + encodeURI(result.repository) + '/-/commit/' + result.oid}>
-                                    {result.authorName}
-                                </Link>
-                                :&nbsp;
-                                <Link to={'/' + encodeURI(result.repository) + '/-/commit/' + result.oid}>
-                                    {result.message.split('\n', 1)[0]}
-                                </Link>
-                            </>
-                        )}
-                        {result.type === 'repo' && (
-                            <Link to={getRepoMatchUrl(result)}>{displayRepoName(getRepoMatchLabel(result))}</Link>
-                        )}
-                    </span>
+                <span className="test-search-result-label ml-1 flex-shrink-past-contents text-truncate">
+                    {result.type === 'commit' && (
+                        <>
+                            <Link to={'/' + encodeURI(result.repository)}>{displayRepoName(result.repository)}</Link>
+                            &nbsp;›&nbsp;
+                            <Link to={'/' + encodeURI(result.repository) + '/-/commit/' + result.oid}>
+                                {result.authorName}
+                            </Link>
+                            :&nbsp;
+                            <Link to={'/' + encodeURI(result.repository) + '/-/commit/' + result.oid}>
+                                {result.message.split('\n', 1)[0]}
+                            </Link>
+                        </>
+                    )}
+                    {result.type === 'repo' && (
+                        <Link to={getRepoMatchUrl(result)}>{displayRepoName(getRepoMatchLabel(result))}</Link>
+                    )}
+                </span>
                 <span className={styles.spacer} />
                 {result.type === 'commit' && (
                     <Link to={'/' + encodeURI(result.repository) + '/-/commit/' + result.oid}>

--- a/client/search-ui/src/components/SearchResult.tsx
+++ b/client/search-ui/src/components/SearchResult.tsx
@@ -63,8 +63,7 @@ export const SearchResult: React.FunctionComponent<Props> = ({
                 <span className={styles.spacer} />
                 {result.type === 'commit' && (
                     <Link to={getCommitMatchUrl(result)}>
-                        <code className={styles.commitOid}>{result.oid.slice(0, 7)}</code>
-                        {' '}
+                        <code className={styles.commitOid}>{result.oid.slice(0, 7)}</code>{' '}
                         <Timestamp date={result.authorDate} noAbout={true} strict={true} />
                     </Link>
                 )}

--- a/client/search-ui/src/components/SearchResult.tsx
+++ b/client/search-ui/src/components/SearchResult.tsx
@@ -10,7 +10,14 @@ import { RepoIcon } from '@sourcegraph/shared/src/components/RepoIcon'
 import { ResultContainer } from '@sourcegraph/shared/src/components/ResultContainer'
 import { SearchResultStar } from '@sourcegraph/shared/src/components/SearchResultStar'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
-import { CommitMatch, getCommitMatchUrl, getRepoMatchLabel, getRepoMatchUrl, getRepositoryUrl, RepositoryMatch } from '@sourcegraph/shared/src/search/stream'
+import {
+    CommitMatch,
+    getCommitMatchUrl,
+    getRepoMatchLabel,
+    getRepoMatchUrl,
+    getRepositoryUrl,
+    RepositoryMatch,
+} from '@sourcegraph/shared/src/search/stream'
 import { formatRepositoryStarCount } from '@sourcegraph/shared/src/util/stars'
 import { Timestamp } from '@sourcegraph/web/src/components/time/Timestamp'
 import { Link } from '@sourcegraph/wildcard'
@@ -44,13 +51,9 @@ export const SearchResult: React.FunctionComponent<Props> = ({
                         <>
                             <Link to={getRepositoryUrl(result.repository)}>{displayRepoName(result.repository)}</Link>
                             &nbsp;›&nbsp;
-                            <Link to={getCommitMatchUrl(result)}>
-                                {result.authorName}
-                            </Link>
+                            <Link to={getCommitMatchUrl(result)}>{result.authorName}</Link>
                             :&nbsp;
-                            <Link to={getCommitMatchUrl(result)}>
-                                {result.message.split('\n', 1)[0]}
-                            </Link>
+                            <Link to={getCommitMatchUrl(result)}>{result.message.split('\n', 1)[0]}</Link>
                         </>
                     )}
                     {result.type === 'repo' && (

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -101,9 +101,7 @@ type MarkdownText = string
  */
 export interface CommitMatch {
     type: 'commit'
-    label: MarkdownText
     url: string
-    detail: MarkdownText
     repository: string
     oid: string
     message: string
@@ -174,16 +172,16 @@ export interface Skipped {
      * - display :: we hit the display limit, so we stopped sending results from the backend.
      */
     reason:
-        | 'document-match-limit'
-        | 'shard-match-limit'
-        | 'repository-limit'
-        | 'shard-timedout'
-        | 'repository-cloning'
-        | 'repository-missing'
-        | 'excluded-fork'
-        | 'excluded-archive'
-        | 'display'
-        | 'error'
+    | 'document-match-limit'
+    | 'shard-match-limit'
+    | 'repository-limit'
+    | 'shard-timedout'
+    | 'repository-cloning'
+    | 'repository-missing'
+    | 'excluded-fork'
+    | 'excluded-archive'
+    | 'display'
+    | 'error'
     /**
      * A short message. eg 1,200 timed out.
      */

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -106,6 +106,10 @@ export interface CommitMatch {
     url: string
     detail: MarkdownText
     repository: string
+    oid: string
+    message: string
+    authorName: string
+    authorDate: string
     repoStars?: number
     repoLastFetched?: string
 
@@ -513,6 +517,10 @@ export function getRepoMatchUrl(repoMatch: RepositoryMatch): string {
     return '/' + encodeURI(label)
 }
 
+export function getCommitMatchUrl(commitMatch: CommitMatch): string {
+    return '/' + encodeURI(commitMatch.repository) + '/-/commit/' + commitMatch.oid
+}
+
 export function getMatchUrl(match: SearchMatch): string {
     switch (match.type) {
         case 'path':
@@ -520,7 +528,7 @@ export function getMatchUrl(match: SearchMatch): string {
         case 'symbol':
             return getFileMatchUrl(match)
         case 'commit':
-            return match.url
+            return getCommitMatchUrl(match)
         case 'repo':
             return getRepoMatchUrl(match)
     }
@@ -528,7 +536,10 @@ export function getMatchUrl(match: SearchMatch): string {
 
 export function getMatchTitle(match: RepositoryMatch | CommitMatch): MarkdownText {
     if (match.type === 'commit') {
-        return match.label
+        const repoUrl = '/' + encodeURI(match.repository)
+        const commitUrl = getCommitMatchUrl(match)
+        const subject = match.message.split('\n', 1)[0]
+        return `[${match.repository}](${repoUrl}) › [${match.authorName}](${commitUrl}): [${subject}](${commitUrl})`
     }
 
     return `[${displayRepoName(getRepoMatchLabel(match))}](${getRepoMatchUrl(match)})`

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -5,7 +5,6 @@ import { AggregableBadge } from 'sourcegraph'
 
 import { asError, ErrorLike, isErrorLike } from '@sourcegraph/common'
 
-import { displayRepoName } from '../components/RepoFileLink'
 import { SearchPatternType } from '../graphql-operations'
 import { SymbolKind } from '../schema'
 
@@ -532,15 +531,4 @@ export function getMatchUrl(match: SearchMatch): string {
         case 'repo':
             return getRepoMatchUrl(match)
     }
-}
-
-export function getMatchTitle(match: RepositoryMatch | CommitMatch): MarkdownText {
-    if (match.type === 'commit') {
-        const repoUrl = '/' + encodeURI(match.repository)
-        const commitUrl = getCommitMatchUrl(match)
-        const subject = match.message.split('\n', 1)[0]
-        return `[${match.repository}](${repoUrl}) › [${match.authorName}](${commitUrl}): [${subject}](${commitUrl})`
-    }
-
-    return `[${displayRepoName(getRepoMatchLabel(match))}](${getRepoMatchUrl(match)})`
 }

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -172,16 +172,16 @@ export interface Skipped {
      * - display :: we hit the display limit, so we stopped sending results from the backend.
      */
     reason:
-    | 'document-match-limit'
-    | 'shard-match-limit'
-    | 'repository-limit'
-    | 'shard-timedout'
-    | 'repository-cloning'
-    | 'repository-missing'
-    | 'excluded-fork'
-    | 'excluded-archive'
-    | 'display'
-    | 'error'
+        | 'document-match-limit'
+        | 'shard-match-limit'
+        | 'repository-limit'
+        | 'shard-timedout'
+        | 'repository-cloning'
+        | 'repository-missing'
+        | 'excluded-fork'
+        | 'excluded-archive'
+        | 'display'
+        | 'error'
     /**
      * A short message. eg 1,200 timed out.
      */

--- a/client/web/src/integration/streaming-search-mocks.ts
+++ b/client/web/src/integration/streaming-search-mocks.ts
@@ -12,6 +12,10 @@ export const diffSearchStreamEvents: SearchEvent[] = [
                 type: 'commit',
                 label:
                     '[sourcegraph/sourcegraph-lightstep](/gitlab.sgdev.org/sourcegraph/sourcegraph-lightstep) › [Quinn Slack](/gitlab.sgdev.org/sourcegraph/sourcegraph-lightstep/-/commit/65dba23797be9e0ce1941f92c5385a7856bc5a42): [build: set up test deps and scripts](/gitlab.sgdev.org/sourcegraph/sourcegraph-lightstep/-/commit/65dba23797be9e0ce1941f92c5385a7856bc5a42)',
+                oid: '65dba23797be9e0ce1941f92c5385a7856bc5a42',
+                message: 'build: set up test deps and scripts\n',
+                authorName: 'Quinn Slack',
+                authorDate: '2019-10-29T20:59:15Z',
                 url:
                     '/gitlab.sgdev.org/sourcegraph/sourcegraph-lightstep/-/commit/65dba23797be9e0ce1941f92c5385a7856bc5a42',
                 detail:
@@ -50,6 +54,10 @@ export const commitSearchStreamEvents: SearchEvent[] = [
                 type: 'commit',
                 label:
                     '[sourcegraph/sourcegraph-sentry](/gitlab.sgdev.org/sourcegraph/sourcegraph-sentry) › [Vanesa](/gitlab.sgdev.org/sourcegraph/sourcegraph-sentry/-/commit/7e69ceb49adc30cb46bbe50335e1a371a0f2f6b1): [add more tests, use the Sourcegraph stubs api and improve repo matching. (#13)](/gitlab.sgdev.org/sourcegraph/sourcegraph-sentry/-/commit/7e69ceb49adc30cb46bbe50335e1a371a0f2f6b1)',
+                oid: '7e69ceb49adc30cb46bbe50335e1a371a0f2f6b1',
+                message: 'add more tests, use the Sourcegraph stubs api and improve repo matching. (#13)',
+                authorName: 'Vanesa',
+                authorDate: '2019-10-29T20:59:15Z',
                 url:
                     '/gitlab.sgdev.org/sourcegraph/sourcegraph-sentry/-/commit/7e69ceb49adc30cb46bbe50335e1a371a0f2f6b1',
                 detail:

--- a/client/web/src/integration/streaming-search-mocks.ts
+++ b/client/web/src/integration/streaming-search-mocks.ts
@@ -10,16 +10,12 @@ export const diffSearchStreamEvents: SearchEvent[] = [
         data: [
             {
                 type: 'commit',
-                label:
-                    '[sourcegraph/sourcegraph-lightstep](/gitlab.sgdev.org/sourcegraph/sourcegraph-lightstep) › [Quinn Slack](/gitlab.sgdev.org/sourcegraph/sourcegraph-lightstep/-/commit/65dba23797be9e0ce1941f92c5385a7856bc5a42): [build: set up test deps and scripts](/gitlab.sgdev.org/sourcegraph/sourcegraph-lightstep/-/commit/65dba23797be9e0ce1941f92c5385a7856bc5a42)',
                 oid: '65dba23797be9e0ce1941f92c5385a7856bc5a42',
                 message: 'build: set up test deps and scripts\n',
                 authorName: 'Quinn Slack',
                 authorDate: '2019-10-29T20:59:15Z',
                 url:
                     '/gitlab.sgdev.org/sourcegraph/sourcegraph-lightstep/-/commit/65dba23797be9e0ce1941f92c5385a7856bc5a42',
-                detail:
-                    '[`65dba23` 2 years ago](/gitlab.sgdev.org/sourcegraph/sourcegraph-lightstep/-/commit/65dba23797be9e0ce1941f92c5385a7856bc5a42)',
                 repository: 'gitlab.sgdev.org/sourcegraph/sourcegraph-lightstep',
                 content:
                     '```diff\nmocha.opts mocha.opts\n@@ -0,0 +3,2 @@\n+--timeout 200\n+src/**/*.test.ts\n\\ No newline at end of file\npackage.json package.json\n@@ -50,0 +54,3 @@\n+    "exclude": [\n+      "**/*.test.ts"\n+    ],\n@@ -54,1 +64,2 @@\n-    "serve": "parcel serve --no-hmr --out-file dist/extension.js src/extension.ts",\n+    "test": "TS_NODE_COMPILER_OPTIONS=\'{\\"module\\":\\"commonjs\\"}\' mocha --require ts-node/register --require source-map-support/register --opts mocha.opts",\n+    "cover": "TS_NODE_COMPILER_OPTIONS=\'{\\"module\\":\\"commonjs\\"}\' nyc --require ts-node/register --require source-map-support/register --all mocha --opts mocha.opts --timeout 10000",\n@@ -57,2 +70,2 @@\n-    "sourcegraph:prepublish": "parcel build src/extension.ts"\n+    "sourcegraph:prepublish": "yarn typecheck && yarn test && yarn build"\n   },\nyarn.lock yarn.lock\n@@ -3736,0 +4204,3 @@ number-is-nan@^1.0.0:\n+    spawn-wrap "^1.4.2"\n+    test-exclude "^5.1.0"\n+    uuid "^3.3.2"\n@@ -5550,1 +6166,5 @@ terser@^3.7.3, terser@^3.8.1:\n \n+test-exclude@^5.1.0:\n+  version "5.1.0"\n+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-5.1.0.tgz#6ba6b25179d2d38724824661323b73e03c0c1de1"\n+  integrity sha512-gwf0S2fFsANC55fSeSqpb8BYk6w3FDvwZxfNjeF6FRgvFa43r+7wRiA/Q0IxoRU37wB/LE8IQ4221BsNucTaCA==\n```',
@@ -52,16 +48,12 @@ export const commitSearchStreamEvents: SearchEvent[] = [
         data: [
             {
                 type: 'commit',
-                label:
-                    '[sourcegraph/sourcegraph-sentry](/gitlab.sgdev.org/sourcegraph/sourcegraph-sentry) › [Vanesa](/gitlab.sgdev.org/sourcegraph/sourcegraph-sentry/-/commit/7e69ceb49adc30cb46bbe50335e1a371a0f2f6b1): [add more tests, use the Sourcegraph stubs api and improve repo matching. (#13)](/gitlab.sgdev.org/sourcegraph/sourcegraph-sentry/-/commit/7e69ceb49adc30cb46bbe50335e1a371a0f2f6b1)',
                 oid: '7e69ceb49adc30cb46bbe50335e1a371a0f2f6b1',
                 message: 'add more tests, use the Sourcegraph stubs api and improve repo matching. (#13)',
                 authorName: 'Vanesa',
                 authorDate: '2019-10-29T20:59:15Z',
                 url:
                     '/gitlab.sgdev.org/sourcegraph/sourcegraph-sentry/-/commit/7e69ceb49adc30cb46bbe50335e1a371a0f2f6b1',
-                detail:
-                    '[`7e69ceb` 2 years ago](/gitlab.sgdev.org/sourcegraph/sourcegraph-sentry/-/commit/7e69ceb49adc30cb46bbe50335e1a371a0f2f6b1)',
                 repository: 'gitlab.sgdev.org/sourcegraph/sourcegraph-sentry',
                 content:
                     '```COMMIT_EDITMSG\nadd more tests, use the Sourcegraph stubs api and improve repo matching. (#13)\n\n* add more tests, refactor to use extension api stubs\r\n* improve repo matching\r\nCo-Authored-By: Felix Becker <felix.b@outlook.com>\n```',

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -564,7 +564,7 @@ func fromCommit(commit *result.CommitMatch, repoCache map[api.RepoID]*types.Sear
 		OID:        string(commit.Commit.ID),
 		Message:    string(commit.Commit.Message),
 		AuthorName: commit.Commit.Author.Name,
-		AuthorDate: string(commit.Commit.Author.Date),
+		AuthorDate: commit.Commit.Author.Date,
 		Content:    hls.Value,
 		Ranges:     ranges,
 	}

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -561,6 +561,10 @@ func fromCommit(commit *result.CommitMatch, repoCache map[api.RepoID]*types.Sear
 		URL:        commit.URL().String(),
 		Detail:     commit.Detail(),
 		Repository: string(commit.Repo.Name),
+		OID:        string(commit.Commit.ID),
+		Message:    string(commit.Commit.Message),
+		AuthorName: commit.Commit.Author.Name,
+		AuthorDate: string(commit.Commit.Author.Date),
 		Content:    hls.Value,
 		Ranges:     ranges,
 	}

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -137,6 +137,10 @@ type EventCommitMatch struct {
 	Detail          string     `json:"detail"`
 	RepositoryID    int32      `json:"repositoryID"`
 	Repository      string     `json:"repository"`
+	OID             string     `json:"oid"`
+	Message         string     `json:"message"`
+	AuthorName      string     `json:"authorName"`
+	AuthorDate      time.Time  `json:"authorDate"`
 	RepoStars       int        `json:"repoStars,omitempty"`
 	RepoLastFetched *time.Time `json:"repoLastFetched,omitempty"`
 	Content         string     `json:"content"`


### PR DESCRIPTION
Currently, for commit matches, we generate `label` and `detail` in the backend as markdown-formatted strings. This is non-ideal for a number of reasons, including, including but not limited to:
- Consumers of the API would need to parse these fields to get information like OID or author date. 
- Formatting in the UI is constrained by the format returned by the API
- Rendering markdown returned by the backend is dangerous (we do a bunch of allowlisting) and a historical source of bugs (highlighting weirdness)
- It adds complexity to our backend types

This adds the information needed to generate these fields to the commit match stream type cuts markdown out of the loop. 

For the moment, this keeps the `label` and `detail` fields on our API types since removing them is a breaking change, but I think we should move towards removing them entirely since it seems unlikely that anyone actually wants a markdown representation in the API. We do explicitly call out that the streaming API may be unstable, and we do not document the exact fields in the streamed types.

## Test plan

Tested manually and tried to minimize visual changes in Percy.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


