### PR TITLE
add free trial language to modal

### DIFF
--- a/client/web/src/enterprise/insights/modals/GaConfirmationModal.module.scss
+++ b/client/web/src/enterprise/insights/modals/GaConfirmationModal.module.scss
@@ -10,13 +10,36 @@
 
 .media-hero-content {
     display: flex;
-    // Stretch the charts container to the full width ignore parent paddings and border
-    // stylelint-disable-next-line declaration-property-unit-allowed-list
-    margin: 1.5rem calc((-1px - 1.5rem));
     padding: 1rem 1.5rem;
-    background: var(--marketing-gradient);
     height: 10.625rem;
     gap: 0.5rem;
+}
+
+.media-hero-overlay {
+    top: 0;
+    position: absolute;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    background: var(--marketing-gradient);
+    height: 10.625rem;
+    width: 100%;
+    opacity: 0.9;
+
+    font-style: normal;
+    font-weight: 600;
+    font-size: 1.25rem;
+    line-height: 125%;
+    text-align: center;
+    letter-spacing: 1px;
+
+    color: var(--text-muted);
+}
+
+.media-hero-wrapper {
+    position: relative;
+    // stylelint-disable-next-line declaration-property-unit-allowed-list
+    margin: 1.5rem calc((-1px - 1.5rem));
 }
 
 .chart {

--- a/client/web/src/enterprise/insights/modals/GaConfirmationModal.tsx
+++ b/client/web/src/enterprise/insights/modals/GaConfirmationModal.tsx
@@ -44,31 +44,37 @@ export const GaConfirmationModalContent: React.FunctionComponent<GaConfirmationM
 
     return (
         <>
-            <h1 className={styles.title}>Code Insights is Generally Available</h1>
+            <h1 className={styles.title}>Thank you for trying Code Insights!</h1>
 
-            <div className={styles.mediaHeroContent}>
-                <ThreeLineChart className={styles.chart} />
-                <FourLineChart className={styles.chart} />
-                <LangStatsInsightChart className={styles.chart} />
+            <div className={styles.mediaHeroWrapper}>
+                <div className={styles.mediaHeroContent}>
+                    <ThreeLineChart className={styles.chart} />
+                    <FourLineChart className={styles.chart} />
+                    <LangStatsInsightChart className={styles.chart} />
+                </div>
+                <div className={styles.mediaHeroOverlay}>Your trial has expired</div>
             </div>
 
             <div className={styles.textContent}>
                 <p>
-                    Code Insights is a new analytics product that transforms your code into a queryable database so you
-                    can create customizable, visual dashboards to understand your codebase at a high level.
+                    <b>Your instance is now using the limited access version of Code Insights.</b> This version is
+                    limited to 2 code insights.
                 </p>
 
                 <p>
-                    Code Insights is now Generally Available.{' '}
-                    <b>You can create unlimited insights and dashboards while on this version of Sourcegraph.</b> In the
-                    next version upgrade, you will either need to purchase Code Insights to continue using its full
-                    functionality, or you can use{' '}
-                    <Link to="/help/code_insights/references/license">a limited number of insights for free</Link>.
+                    If your team has created more than 2 insights during the trial, some insights will be hidden.{' '}
+                    <b>All of the insights you’ve created are preserved and will be displayed as locked.</b> All
+                    insights will be visible again after upgrading your license.
                 </p>
 
                 <p>
-                    Reach out to your Sourcegraph admin or account team to purchase Code Insights. Questions? Please{' '}
-                    <Link to="mailto:support@sourcegraph.com">contact us</Link>.
+                    Contact your admin or reach out to us to upgrade your licence for unlimited insights and dashboards.
+                </p>
+
+                <p>
+                    Questions? Learn more about the{' '}
+                    <Link to="/help/code_insights/references/license">Code Insights limited access</Link> or contact us
+                    directly.
                 </p>
             </div>
 

--- a/client/web/src/enterprise/insights/modals/GaConfirmationModal.tsx
+++ b/client/web/src/enterprise/insights/modals/GaConfirmationModal.tsx
@@ -62,9 +62,9 @@ export const GaConfirmationModalContent: React.FunctionComponent<GaConfirmationM
                 </p>
 
                 <p>
-                    If your team has created more than 2 insights during the trial, some insights will be hidden.{' '}
-                    <b>All of the insights you’ve created are preserved and will be displayed as locked.</b> All
-                    insights will be visible again after upgrading your license.
+                    If your team has created more than 2 insights during the trial, some insights will be hidden. All of
+                    the insights you've created are preserved, <b>but</b> will be locked. All insights will be visible
+                    again after upgrading your license.
                 </p>
 
                 <p>


### PR DESCRIPTION
Update "GA Modal" to use "free trial" language

![PixelSnap 2022-03-11 at 10 35 22](https://user-images.githubusercontent.com/1855233/157908998-0d0b6dae-4d41-4fe0-a364-fbb8db4237d5.png)

"Code Insights limited access" links to `/help/code_insights/references/license` in same window

Closes https://github.com/sourcegraph/sourcegraph/issues/32283

## Test plan

View modal in storybook. Should match designs.