### PR TITLE
rockskip: Optimize case insensitive queries

### DIFF
--- a/enterprise/internal/rockskip/search.go
+++ b/enterprise/internal/rockskip/search.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/grafana/regexp"
 	"github.com/grafana/regexp/syntax"
+	"github.com/inconshreveable/log15"
 	"github.com/keegancsmith/sqlf"
 	pg "github.com/lib/pq"
 	"github.com/segmentio/fasthash/fnv1"
@@ -366,15 +367,15 @@ func convertSearchArgsToSqlQuery(args types.SearchArgs) *sqlf.Query {
 	conjunctOrNils := []*sqlf.Query{}
 
 	// Query
-	conjunctOrNils = append(conjunctOrNils, regexMatch("name", "", "", args.Query, args.IsCaseSensitive))
+	conjunctOrNils = append(conjunctOrNils, regexMatch(nameConditions, args.Query, args.IsCaseSensitive))
 
 	// IncludePatterns
 	for _, includePattern := range args.IncludePatterns {
-		conjunctOrNils = append(conjunctOrNils, regexMatch("path", "path_prefixes(path)", "singleton(get_file_extension(path))", includePattern, args.IsCaseSensitive))
+		conjunctOrNils = append(conjunctOrNils, regexMatch(pathConditions, includePattern, args.IsCaseSensitive))
 	}
 
 	// ExcludePattern
-	conjunctOrNils = append(conjunctOrNils, negate(regexMatch("path", "path_prefixes(path)", "singleton(get_file_extension(path))", args.ExcludePattern, args.IsCaseSensitive)))
+	conjunctOrNils = append(conjunctOrNils, negate(regexMatch(pathConditions, args.ExcludePattern, args.IsCaseSensitive)))
 
 	// Drop nils
 	conjuncts := []*sqlf.Query{}
@@ -391,33 +392,95 @@ func convertSearchArgsToSqlQuery(args types.SearchArgs) *sqlf.Query {
 	return sqlf.Join(conjuncts, "AND")
 }
 
-func regexMatch(column, columnForLiteralPrefix, columnForFileExtension, regex string, isCaseSensitive bool) *sqlf.Query {
+// Conditions specifies how to construct query clauses depending on the regex kind.
+type Conditions struct {
+	regex    QueryFunc
+	regexI   QueryFunc
+	exact    QueryFunc
+	exactI   QueryFunc
+	prefix   QueryFunc
+	prefixI  QueryFunc
+	fileExt  QueryNFunc
+	fileExtI QueryNFunc
+}
+
+// Returns a SQL query for the given value.
+type QueryFunc func(value string) *sqlf.Query
+
+// Returns a SQL query for the given values.
+type QueryNFunc func(values []string) *sqlf.Query
+
+var nameConditions = Conditions{
+	regex:    func(v string) *sqlf.Query { return sqlf.Sprintf("name ~ %s", v) },
+	regexI:   func(v string) *sqlf.Query { return sqlf.Sprintf("name ~* %s", v) },
+	exact:    func(v string) *sqlf.Query { return sqlf.Sprintf("ARRAY[%s] && singleton(name)", v) },
+	exactI:   func(v string) *sqlf.Query { return sqlf.Sprintf("ARRAY[%s] && singleton(lower(name))", v) },
+	prefix:   nil,
+	prefixI:  nil,
+	fileExt:  nil,
+	fileExtI: nil,
+}
+
+var pathConditions = Conditions{
+	regex:   func(v string) *sqlf.Query { return sqlf.Sprintf("path ~ %s", v) },
+	regexI:  func(v string) *sqlf.Query { return sqlf.Sprintf("path ~* %s", v) },
+	exact:   func(v string) *sqlf.Query { return sqlf.Sprintf("ARRAY[%s] && singleton(path)", v) },
+	exactI:  func(v string) *sqlf.Query { return sqlf.Sprintf("ARRAY[%s] && singleton(lower(path))", v) },
+	prefix:  func(v string) *sqlf.Query { return sqlf.Sprintf("ARRAY[%s] && path_prefixes(path)", v) },
+	prefixI: func(v string) *sqlf.Query { return sqlf.Sprintf("ARRAY[%s] && path_prefixes(lower(path))", v) },
+	fileExt: func(vs []string) *sqlf.Query {
+		return sqlf.Sprintf("%s && singleton(get_file_extension(path))", pg.Array(vs))
+	},
+	fileExtI: func(vs []string) *sqlf.Query {
+		return sqlf.Sprintf("%s && singleton(get_file_extension(lower(path)))", pg.Array(vs))
+	},
+}
+
+func regexMatch(conditions Conditions, regex string, isCaseSensitive bool) *sqlf.Query {
 	if regex == "" || regex == "^" {
 		return nil
 	}
 
 	// Exact match optimization
-	if literal, ok, err := isLiteralEquality(regex); err == nil && ok && isCaseSensitive {
-		return sqlf.Sprintf(fmt.Sprintf("%%s = %s", column), literal)
+	if literal, ok, err := isLiteralEquality(regex); err == nil && ok {
+		if isCaseSensitive && conditions.exact != nil {
+			return conditions.exact(literal)
+		}
+		if !isCaseSensitive && conditions.exactI != nil {
+			return conditions.exactI(literal)
+		}
 	}
 
 	// Prefix match optimization
-	if literal, ok, err := isLiteralPrefix(regex); err == nil && ok && isCaseSensitive && columnForLiteralPrefix != "" {
-		return sqlf.Sprintf(fmt.Sprintf("%%s && %s", columnForLiteralPrefix), pg.Array([]string{literal}))
+	if literal, ok, err := isLiteralPrefix(regex); err == nil && ok {
+		if isCaseSensitive && conditions.prefix != nil {
+			return conditions.prefix(literal)
+		}
+		if !isCaseSensitive && conditions.prefixI != nil {
+			return conditions.prefixI(literal)
+		}
 	}
 
 	// File extension match optimization
-	if exts := isFileExtensionMatch(regex); exts != nil && isCaseSensitive && columnForFileExtension != "" {
-		return sqlf.Sprintf(fmt.Sprintf("%%s && %s", columnForFileExtension), pg.Array(exts))
+	if exts := isFileExtensionMatch(regex); exts != nil {
+		if isCaseSensitive && conditions.fileExt != nil {
+			return conditions.fileExt(exts)
+		}
+		if !isCaseSensitive && conditions.fileExtI != nil {
+			return conditions.fileExtI(exts)
+		}
 	}
 
 	// Regex match
-	operator := "~"
-	if !isCaseSensitive {
-		operator = "~*"
+	if isCaseSensitive && conditions.regex != nil {
+		return conditions.regex(regex)
+	}
+	if !isCaseSensitive && conditions.regexI != nil {
+		return conditions.regexI(regex)
 	}
 
-	return sqlf.Sprintf(fmt.Sprintf("%s %s %%s", column, operator), regex)
+	log15.Error("None of the conditions matched", "regex", regex)
+	return nil
 }
 
 // isLiteralEquality returns true if the given regex matches literal strings exactly.

--- a/enterprise/internal/rockskip/search_test.go
+++ b/enterprise/internal/rockskip/search_test.go
@@ -35,3 +35,36 @@ func TestIsFileExtensionMatch(t *testing.T) {
 		}
 	}
 }
+
+func TestIsLiteralPrefix(t *testing.T) {
+	ptr := func(s string) *string { return &s }
+
+	tests := []struct {
+		expr   string
+		prefix *string
+	}{
+		{``, nil},
+		{`^`, ptr(``)},
+		{`^foo`, ptr(`foo`)},
+		{`^foo/bar\.go`, ptr(`foo/bar.go`)},
+		{`foo/bar\.go`, nil},
+	}
+
+	for _, test := range tests {
+		prefix, isPrefix, err := isLiteralPrefix(test.expr)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if test.prefix == nil {
+			if isPrefix {
+				t.Fatalf("expected isLiteralPrefix(%q) to return false", test.expr)
+			}
+			continue
+		}
+
+		if prefix != *test.prefix {
+			t.Errorf("isLiteralPrefix(%q) = %v, want %v", test.expr, prefix, *test.prefix)
+		}
+	}
+}

--- a/internal/database/schema.codeintel.md
+++ b/internal/database/schema.codeintel.md
@@ -786,7 +786,7 @@ Indexes:
  name    | text      |           | not null | 
 Indexes:
     "rockskip_symbols_pkey" PRIMARY KEY, btree (id)
-    "rockskip_symbols_gin" gin (singleton_integer(repo_id) gin__int_ops, added gin__int_ops, deleted gin__int_ops, singleton(path), path_prefixes(path), singleton(name), name gin_trgm_ops, singleton(get_file_extension(path)))
+    "rockskip_symbols_gin" gin (singleton_integer(repo_id) gin__int_ops, added gin__int_ops, deleted gin__int_ops, name gin_trgm_ops, singleton(name), singleton(lower(name)), path gin_trgm_ops, singleton(path), path_prefixes(path), singleton(lower(path)), path_prefixes(lower(path)), singleton(get_file_extension(path)), singleton(get_file_extension(lower(path))))
     "rockskip_symbols_repo_id_path_name" btree (repo_id, path, name)
 
 ```

--- a/migrations/codeintel/1000000034/down.sql
+++ b/migrations/codeintel/1000000034/down.sql
@@ -1,0 +1,12 @@
+DROP INDEX IF EXISTS rockskip_symbols_gin;
+
+CREATE INDEX IF NOT EXISTS rockskip_symbols_gin ON rockskip_symbols USING GIN (
+    singleton_integer(repo_id) gin__int_ops,
+    added gin__int_ops,
+    deleted gin__int_ops,
+    singleton(path),
+    path_prefixes(path),
+    singleton(name),
+    name gin_trgm_ops,
+    singleton(get_file_extension(path))
+);

--- a/migrations/codeintel/1000000034/metadata.yaml
+++ b/migrations/codeintel/1000000034/metadata.yaml
@@ -1,0 +1,2 @@
+name: 'rockskip lowercase'
+parent: 1000000033

--- a/migrations/codeintel/1000000034/up.sql
+++ b/migrations/codeintel/1000000034/up.sql
@@ -1,0 +1,30 @@
+DROP INDEX IF EXISTS rockskip_symbols_gin;
+
+CREATE OR REPLACE FUNCTION get_file_extension(path TEXT) RETURNS TEXT AS $$ BEGIN
+    RETURN substring(path FROM '\.([^\.]*)$');
+END; $$ IMMUTABLE language plpgsql;
+
+CREATE INDEX IF NOT EXISTS rockskip_symbols_gin ON rockskip_symbols USING GIN (
+    -- repo_id
+    singleton_integer(repo_id) gin__int_ops,
+
+    -- added,deleted
+    added gin__int_ops,
+    deleted gin__int_ops,
+
+    -- name
+    name gin_trgm_ops,
+    singleton(name),
+    singleton(lower(name)),
+
+    -- path
+    path gin_trgm_ops,
+    singleton(path),
+    path_prefixes(path),
+    singleton(lower(path)),
+    path_prefixes(lower(path)),
+
+    -- file extension
+    singleton(get_file_extension(path)),
+    singleton(get_file_extension(lower(path)))
+);


### PR DESCRIPTION
This adds indexes on `lower(name)` and `lower(path)` (and various combinations).

The symbols sidebar doesn't send case sensitive queries, so it was timing out on the megarepo without these indexes.

The logic got a bit unwieldy so I flattened it out. There might be a better way to write this. Is it readable as is?

## Test plan

Ran through all these cases by running different queries in the search bar:

![CleanShot 2022-03-08 at 15 59 54@2x](https://user-images.githubusercontent.com/1387653/157341199-b5ffdb7a-a7cd-4ada-bddb-892544434268.png)
