### PR TITLE
authz/github: allow list group repos 404 to persist to cache

### DIFF
--- a/enterprise/internal/authz/github/github.go
+++ b/enterprise/internal/authz/github/github.go
@@ -254,13 +254,15 @@ func (p *Provider) fetchUserPermsByToken(ctx context.Context, accountID extsvc.A
 			}
 		}
 
-		// If a valid cached value was found, use it and continue
-		if len(group.Repositories) > 0 {
+		// If a valid cached value was found, use it and continue. Check for a nil,
+		// because it is possible this cached group does not have any repositories, in
+		// which case it should have a non-nil length 0 slice of repositories.
+		if group.Repositories == nil {
 			addRepoToUserPerms(group.Repositories...)
 			continue
 		}
 
-		// Perform full sync
+		// Perform full sync. Start with instantiating the repos slice.
 		group.Repositories = make([]extsvc.RepoID, 0, repoSetSize)
 		isOrg := group.Team == ""
 		hasNextPage = true

--- a/enterprise/internal/authz/github/github.go
+++ b/enterprise/internal/authz/github/github.go
@@ -259,7 +259,7 @@ func (p *Provider) fetchUserPermsByToken(ctx context.Context, accountID extsvc.A
 		// If a valid cached value was found, use it and continue. Check for a nil,
 		// because it is possible this cached group does not have any repositories, in
 		// which case it should have a non-nil length 0 slice of repositories.
-		if group.Repositories == nil {
+		if group.Repositories != nil {
 			addRepoToUserPerms(group.Repositories...)
 			continue
 		}

--- a/enterprise/internal/authz/github/github_test.go
+++ b/enterprise/internal/authz/github/github_test.go
@@ -379,7 +379,6 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 			}
 
 			p := setupProvider(t, mc)
-			_, found := p.groupsCache.getGroup("not-sourcegraph", "ns-team-2")
 
 			repoIDs, err := p.FetchUserPerms(context.Background(),
 				mockAccount,
@@ -400,7 +399,7 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 			if diff := cmp.Diff(wantRepoIDs, repoIDs.Exacts); diff != "" {
 				t.Fatalf("RepoIDs mismatch (-want +got):\n%s", diff)
 			}
-			_, found = p.groupsCache.getGroup("not-sourcegraph", "ns-team-2")
+			_, found := p.groupsCache.getGroup("not-sourcegraph", "ns-team-2")
 			if !found {
 				t.Error("expected to find group in cache")
 			}

--- a/enterprise/internal/authz/github/github_test.go
+++ b/enterprise/internal/authz/github/github_test.go
@@ -391,10 +391,10 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 			wantRepoIDs := []extsvc.RepoID{
 				"MDEwOlJlcG9zaXRvcnkyNTI0MjU2NzE=", // from ListAffiliatedRepos
 				"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1MzY=", // from ListAffiliatedRepos
-				"MDEwOlJlcG9zaXRvcnkyNDI2NTEwMDA=", // this one is associated w/ the ListTeamRepos call... why is it showing up here TODO: investigate why this is showing up
-				"MDEwOlJlcG9zaXRvcnkyNDI2NTadmin=", // org repo
-				"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1234=", // org repo
-				"MDEwOlJlcG9zaXRvcnkyNDI2NTE5678=", // org repo
+				"MDEwOlJlcG9zaXRvcnkyNDI2NTEwMDA=", // from ListAffiliatedRepos
+				"MDEwOlJlcG9zaXRvcnkyNDI2NTadmin=", // from ListOrgRepositories
+				"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1234=", // from ListOrgRepositories
+				"MDEwOlJlcG9zaXRvcnkyNDI2NTE5678=", // from ListOrgRepositories
 			}
 			if diff := cmp.Diff(wantRepoIDs, repoIDs.Exacts); diff != "" {
 				t.Fatalf("RepoIDs mismatch (-want +got):\n%s", diff)

--- a/enterprise/internal/authz/github/github_test.go
+++ b/enterprise/internal/authz/github/github_test.go
@@ -248,7 +248,7 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 		})
 
 		t.Run("user in orgs", func(t *testing.T) {
-			mockClient := &mockClient{
+			mc := &mockClient{
 				MockListAffiliatedRepositories:                   mockListAffiliatedRepositories,
 				MockGetAuthenticatedUserOrgsDetailsAndMembership: mockListOrgDetails,
 				MockGetAuthenticatedUserTeams: func(ctx context.Context, page int) (teams []*github.Team, hasNextPage bool, rateLimitCost int, err error) {
@@ -258,9 +258,7 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 				MockListOrgRepositories: mockListOrgRepositories,
 			}
 
-			p := NewProvider("", ProviderOptions{GitHubURL: mustURL(t, "https://github.com")})
-			p.client = mockClientFunc(mockClient)
-			p.groupsCache = memGroupsCache()
+			p := setupProvider(t, mc)
 
 			repoIDs, err := p.FetchUserPerms(context.Background(),
 				mockAccount,
@@ -284,7 +282,7 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 		})
 
 		t.Run("user in orgs and teams", func(t *testing.T) {
-			mockClient := &mockClient{
+			mc := &mockClient{
 				MockListAffiliatedRepositories:                   mockListAffiliatedRepositories,
 				MockGetAuthenticatedUserOrgsDetailsAndMembership: mockListOrgDetails,
 				MockGetAuthenticatedUserTeams: func(_ context.Context, page int) (teams []*github.Team, hasNextPage bool, rateLimitCost int, err error) {
@@ -328,9 +326,7 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 				},
 			}
 
-			p := NewProvider("", ProviderOptions{GitHubURL: mustURL(t, "https://github.com")})
-			p.client = mockClientFunc(mockClient)
-			p.groupsCache = memGroupsCache()
+			p := setupProvider(t, mc)
 
 			repoIDs, err := p.FetchUserPerms(context.Background(),
 				mockAccount,
@@ -352,6 +348,61 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 			}
 			if diff := cmp.Diff(wantRepoIDs, repoIDs.Exacts); diff != "" {
 				t.Fatalf("RepoIDs mismatch (-want +got):\n%s", diff)
+			}
+		})
+
+		t.Run("special case: ListTeamRepositories returns 404", func(t *testing.T) {
+			mc := &mockClient{
+				MockListAffiliatedRepositories:                   mockListAffiliatedRepositories,
+				MockGetAuthenticatedUserOrgsDetailsAndMembership: mockListOrgDetails,
+				MockGetAuthenticatedUserTeams: func(_ context.Context, page int) (teams []*github.Team, hasNextPage bool, rateLimitCost int, err error) {
+					switch page {
+					case 1:
+						return []*github.Team{
+							// should not get repos from this team because parent org has default read permissions
+							{Organization: &mockOrgRead.Org, Name: "ns team", Slug: "ns-team"},
+							// should not get repos from this team since it has no repos
+							{Organization: &mockOrgNoRead.Org, Name: "ns team", Slug: "ns-team", ReposCount: 0},
+						}, true, 1, nil
+					case 2:
+						return []*github.Team{
+							// should get repos from this team
+							{Organization: &mockOrgNoRead.Org, Name: "ns team 2", Slug: "ns-team-2", ReposCount: 3},
+						}, false, 1, nil
+					}
+					return nil, false, 1, nil
+				},
+				MockListOrgRepositories: mockListOrgRepositories,
+				MockListTeamRepositories: func(_ context.Context, org, team string, page int) (repos []*github.Repository, hasNextPage bool, rateLimitCost int, err error) {
+					return nil, false, 1, &github.APIError{Code: 404}
+				},
+			}
+
+			p := setupProvider(t, mc)
+			_, found := p.groupsCache.getGroup("not-sourcegraph", "ns-team-2")
+
+			repoIDs, err := p.FetchUserPerms(context.Background(),
+				mockAccount,
+				authz.FetchPermsOptions{InvalidateCaches: true},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			wantRepoIDs := []extsvc.RepoID{
+				"MDEwOlJlcG9zaXRvcnkyNTI0MjU2NzE=", // from ListAffiliatedRepos
+				"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1MzY=", // from ListAffiliatedRepos
+				"MDEwOlJlcG9zaXRvcnkyNDI2NTEwMDA=", // this one is associated w/ the ListTeamRepos call... why is it showing up here TODO: investigate why this is showing up
+				"MDEwOlJlcG9zaXRvcnkyNDI2NTadmin=", // org repo
+				"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1234=", // org repo
+				"MDEwOlJlcG9zaXRvcnkyNDI2NTE5678=", // org repo
+			}
+			if diff := cmp.Diff(wantRepoIDs, repoIDs.Exacts); diff != "" {
+				t.Fatalf("RepoIDs mismatch (-want +got):\n%s", diff)
+			}
+			_, found = p.groupsCache.getGroup("not-sourcegraph", "ns-team-2")
+			if !found {
+				t.Error("expected to find group in cache")
 			}
 		})
 
@@ -1179,4 +1230,11 @@ func TestProvider_ValidateConnection(t *testing.T) {
 			}
 		})
 	})
+}
+
+func setupProvider(t *testing.T, mc *mockClient) *Provider {
+	p := NewProvider("", ProviderOptions{GitHubURL: mustURL(t, "https://github.com")})
+	p.client = mockClientFunc(mc)
+	p.groupsCache = memGroupsCache()
+	return p
 }


### PR DESCRIPTION
Potential solution to https://github.com/sourcegraph/customer/issues/742 . Looks like GitHub has some odd behaviours related to teams called `owners` etc. that may cause "list repo" on an existing repo to return 404. Retrying on a 404 will not make it un-404, so we allow these errors to persist to cache. I've added a docstring inline to explain why this is safe. 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Existing behaviour should hold (tests should pass)