### PR TITLE
doc: update syntax-highlighter scalability info

### DIFF
--- a/doc/dev/background-information/architecture/architecture.dot
+++ b/doc/dev/background-information/architecture/architecture.dot
@@ -168,6 +168,7 @@ digraph architecture {
             syntect_server [
                 label="syntect\nserver"
                 fillcolor="#cc0085"
+                shape="box3d"
                 URL="https://github.com/sourcegraph/sourcegraph/tree/main/docker-images/syntax-highlighter"
             ]
         }

--- a/doc/dev/background-information/architecture/architecture.svg
+++ b/doc/dev/background-information/architecture/architecture.svg
@@ -12,6 +12,11 @@
 <polygon fill="white" stroke="transparent" points="-14.4,14.4 -14.4,-1130.4 1008.9,-1130.4 1008.9,14.4 -14.4,14.4"/>
 <text text-anchor="middle" x="497.25" y="-34.4" font-family="Source Code Pro, monospace" font-size="12.00">Sourcegraph Architecture Overview</text>
 <text text-anchor="middle" x="497.25" y="-7.4" font-family="Source Code Pro, monospace" font-size="12.00">Box =&gt; horizontally scalable service, Rectangle =&gt; singleton service</text>
+<g id="clust10" class="cluster">
+<title>cluster_external_precise_code_intel</title>
+<polygon fill="none" stroke="black" stroke-dasharray="1,5" points="0,-173 0,-246 317,-246 317,-173 0,-173"/>
+<text text-anchor="middle" x="158.5" y="-232.4" font-family="Source Code Pro, monospace" font-size="12.00">External services (on raw compute nodes)</text>
+</g>
 <g id="clust1" class="cluster">
 <title>cluster_clients</title>
 <polygon fill="none" stroke="black" stroke-dasharray="1,5" points="114.5,-254 114.5,-868 202.5,-868 202.5,-254 114.5,-254"/>
@@ -27,6 +32,11 @@
 <polygon fill="none" stroke="black" stroke-dasharray="1,5" points="350.5,-315 350.5,-1079 849.5,-1079 849.5,-315 350.5,-315"/>
 <text text-anchor="middle" x="600" y="-1065.4" font-family="Source Code Pro, monospace" font-size="12.00">Internal services</text>
 </g>
+<g id="clust6" class="cluster">
+<title>cluster_code_intelligence</title>
+<polygon fill="none" stroke="black" stroke-dasharray="1,5" points="502.5,-912 502.5,-1050 691.5,-1050 691.5,-912 502.5,-912"/>
+<text text-anchor="middle" x="597" y="-1036.4" font-family="Source Code Pro, monospace" font-size="12.00">Code intelligence</text>
+</g>
 <g id="clust4" class="cluster">
 <title>cluster_search</title>
 <polygon fill="none" stroke="black" stroke-dasharray="1,5" points="518.5,-607 518.5,-839 675.5,-839 675.5,-607 518.5,-607"/>
@@ -36,11 +46,6 @@
 <title>cluster_zoekt</title>
 <polygon fill="none" stroke="black" stroke-dasharray="1,5" points="526.5,-672 526.5,-810 667.5,-810 667.5,-672 526.5,-672"/>
 <text text-anchor="middle" x="597" y="-796.4" font-family="Source Code Pro, monospace" font-size="12.00">Indexed search</text>
-</g>
-<g id="clust6" class="cluster">
-<title>cluster_code_intelligence</title>
-<polygon fill="none" stroke="black" stroke-dasharray="1,5" points="502.5,-912 502.5,-1050 691.5,-1050 691.5,-912 502.5,-912"/>
-<text text-anchor="middle" x="597" y="-1036.4" font-family="Source Code Pro, monospace" font-size="12.00">Code intelligence</text>
 </g>
 <g id="clust7" class="cluster">
 <title>cluster_code_insights</title>
@@ -56,11 +61,6 @@
 <title>cluster_databases</title>
 <polygon fill="none" stroke="black" stroke-dasharray="1,5" points="738.5,-64 738.5,-147 849.5,-147 849.5,-64 738.5,-64"/>
 <text text-anchor="middle" x="794" y="-133.4" font-family="Source Code Pro, monospace" font-size="12.00">Postgres</text>
-</g>
-<g id="clust10" class="cluster">
-<title>cluster_external_precise_code_intel</title>
-<polygon fill="none" stroke="black" stroke-dasharray="1,5" points="0,-173 0,-246 317,-246 317,-173 0,-173"/>
-<text text-anchor="middle" x="158.5" y="-232.4" font-family="Source Code Pro, monospace" font-size="12.00">External services (on raw compute nodes)</text>
 </g>
 <g id="clust11" class="cluster">
 <title>cluster_codehosts</title>
@@ -250,7 +250,10 @@
 <g id="node19" class="node">
 <title>syntect_server</title>
 <g id="a_node19"><a xlink:href="https://github.com/sourcegraph/sourcegraph/tree/main/docker-images/syntax-highlighter" xlink:title="syntect\nserver" target="_blank">
-<polygon fill="#cc0085" stroke="black" points="629.5,-891 564.5,-891 564.5,-847 629.5,-847 629.5,-891"/>
+<polygon fill="#cc0085" stroke="black" points="629.5,-891 568.5,-891 564.5,-887 564.5,-847 625.5,-847 629.5,-851 629.5,-891"/>
+<polyline fill="none" stroke="black" points="625.5,-887 564.5,-887 "/>
+<polyline fill="none" stroke="black" points="625.5,-887 625.5,-847 "/>
+<polyline fill="none" stroke="black" points="625.5,-887 629.5,-891 "/>
 <text text-anchor="middle" x="597" y="-872" font-family="Source Code Pro, monospace" font-size="10.00">syntect</text>
 <text text-anchor="middle" x="597" y="-861" font-family="Source Code Pro, monospace" font-size="10.00">server</text>
 </a>

--- a/doc/dev/background-information/architecture/generate.sh
+++ b/doc/dev/background-information/architecture/generate.sh
@@ -2,4 +2,5 @@
 
 set -ex
 
+# Install `dot` from https://graphviz.org/download/
 dot architecture.dot -Tsvg >architecture.svg

--- a/doc/dev/background-information/architecture/index.md
+++ b/doc/dev/background-information/architecture/index.md
@@ -8,6 +8,10 @@ The **"Dependencies"** sections give a short, high-level overview of dependencie
 
 You can click on each component to jump to its respective code repository or subtree. <a href="./architecture.svg" target="_blank">Open in new tab</a>
 
+<!-- 
+Auto-generated from ./doc/dev/background-information/architecture/architecture.dot
+Run cd ./doc/dev/background-information/architecture && ./generate.sh to update the .svg
+-->
 <object data="./architecture/architecture.svg" type="image/svg+xml" width="1023" height="1113" style="width:100%; height: auto">
 </object>
 

--- a/docker-images/syntax-highlighter/README.md
+++ b/docker-images/syntax-highlighter/README.md
@@ -1,6 +1,6 @@
 # Syntect Server
 
-This is an HTTP server that exposes the Rust [Syntect](https://github.com/trishume/syntect) syntax highlighting library for use by other services. Send it some code, and it'll send you syntax-highlighted code in response.
+This is an HTTP server that exposes the Rust [Syntect](https://github.com/trishume/syntect) syntax highlighting library for use by other services. Send it some code, and it'll send you syntax-highlighted code in response. This service is horizontally scalable, but please give [#21942](https://github.com/sourcegraph/sourcegraph/issues/21942) and [#32359](https://github.com/sourcegraph/sourcegraph/pull/32359#issuecomment-1063310638) a read before scaling it up.
 
 ### Cargo Usage
 


### PR DESCRIPTION
Follow up on https://sourcegraph.slack.com/archives/CHXHX7XAS/p1646783148867999

`syntax-highlighter` is a stateless service and has no external dependencies (e.g. pg), so it should be horizontally scaleable.

## Test plan

```sh
sg run docsite 
```

Go to http://localhost:5080/dev/background-information/architecture#diagram

`syntech server` should be surrounded by a box instead of a rectangle.

~Should we experiment it on dogfod? https://github.com/sourcegraph/deploy-sourcegraph-dogfood-k8s/pull/4008~ merged
dogfood syntaxhighliting seems fine to me
container logs look fine too