### PR TITLE
Add check to make sure local main branch is neither behind nor ahead of remote main branch

### DIFF
--- a/dev/release/src/util.ts
+++ b/dev/release/src/util.ts
@@ -98,9 +98,7 @@ export function ensureMainBranchUpToDate(): void {
         )
         process.exit(1)
     } else if (stdout.includes('Your branch is ahead')) {
-        console.log(
-            `Your branch is ahead of the ${mainBranch} branch.`
-        )
+        console.log(`Your branch is ahead of the ${mainBranch} branch.`)
         process.exit(1)
     }
 }

--- a/dev/release/src/util.ts
+++ b/dev/release/src/util.ts
@@ -97,6 +97,11 @@ export function ensureMainBranchUpToDate(): void {
             `Your branch is behind the ${mainBranch} branch. You should run \`git pull\` to update your ${mainBranch} branch.`
         )
         process.exit(1)
+    } else if (stdout.includes('Your branch is ahead')) {
+        console.log(
+            `Your branch is ahead of the ${mainBranch} branch.`
+        )
+        process.exit(1)
     }
 }
 interface ContainerRegistryCredential {


### PR DESCRIPTION
Solve #31734

Added a simple, similar check to make sure local `main` branch is not ahead of remote main branch as well.

## Test plan
@coury-clark tested locally by removing the `main` branch limitation, testing a dry run slack update before the new commit, pushing a new commit, and testing to receive this error:

<img width="687" alt="image" src="https://user-images.githubusercontent.com/5090588/157542692-be5b8d07-c99e-4e9b-81af-f2908f49d73e.png">

