### PR TITLE
Track preferred commit-ish to account for synthetic git repos

### DIFF
--- a/cmd/frontend/graphqlbackend/commit_search_result.go
+++ b/cmd/frontend/graphqlbackend/commit_search_result.go
@@ -79,15 +79,19 @@ func (r *CommitSearchResultResolver) Detail() Markdown {
 	return Markdown(r.CommitMatch.Detail())
 }
 
-func (r *CommitSearchResultResolver) Matches(ctx context.Context) []*searchResultMatchResolver {
+func (r *CommitSearchResultResolver) Matches(ctx context.Context) ([]*searchResultMatchResolver, error) {
 	hls := r.CommitMatch.Body().ToHighlightedString()
+	url, err := r.Commit().URL(ctx)
+	if err != nil {
+		return nil, err
+	}
 	match := &searchResultMatchResolver{
 		body:       hls.Value,
 		highlights: hls.Highlights,
-		url:        r.Commit().URL(ctx),
+		url:        url,
 	}
 	matches := []*searchResultMatchResolver{match}
-	return matches
+	return matches, nil
 }
 
 func (r *CommitSearchResultResolver) ToRepository() (*RepositoryResolver, bool) { return nil, false }

--- a/cmd/frontend/graphqlbackend/commit_search_result.go
+++ b/cmd/frontend/graphqlbackend/commit_search_result.go
@@ -1,6 +1,7 @@
 package graphqlbackend
 
 import (
+	"context"
 	"sync"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -78,12 +79,12 @@ func (r *CommitSearchResultResolver) Detail() Markdown {
 	return Markdown(r.CommitMatch.Detail())
 }
 
-func (r *CommitSearchResultResolver) Matches() []*searchResultMatchResolver {
+func (r *CommitSearchResultResolver) Matches(ctx context.Context) []*searchResultMatchResolver {
 	hls := r.CommitMatch.Body().ToHighlightedString()
 	match := &searchResultMatchResolver{
 		body:       hls.Value,
 		highlights: hls.Highlights,
-		url:        r.Commit().URL(),
+		url:        r.Commit().URL(ctx),
 	}
 	matches := []*searchResultMatchResolver{match}
 	return matches

--- a/cmd/frontend/graphqlbackend/file.go
+++ b/cmd/frontend/graphqlbackend/file.go
@@ -18,7 +18,7 @@ type FileResolver interface {
 	Binary(ctx context.Context) (bool, error)
 	RichHTML(ctx context.Context) (string, error)
 	URL(ctx context.Context) (string, error)
-	CanonicalURL(ctx context.Context) string
+	CanonicalURL(ctx context.Context) (string, error)
 	ExternalURLs(ctx context.Context) ([]*externallink.Resolver, error)
 	Highlight(ctx context.Context, args *HighlightArgs) (*highlightedFileResolver, error)
 

--- a/cmd/frontend/graphqlbackend/file.go
+++ b/cmd/frontend/graphqlbackend/file.go
@@ -18,7 +18,7 @@ type FileResolver interface {
 	Binary(ctx context.Context) (bool, error)
 	RichHTML(ctx context.Context) (string, error)
 	URL(ctx context.Context) (string, error)
-	CanonicalURL() string
+	CanonicalURL(ctx context.Context) string
 	ExternalURLs(ctx context.Context) ([]*externallink.Resolver, error)
 	Highlight(ctx context.Context, args *HighlightArgs) (*highlightedFileResolver, error)
 

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -340,7 +340,7 @@ func (r *GitCommitResolver) currentTag(ctx context.Context) string {
 	if !r.repoResolver.IsPackageRepo() {
 		return ""
 	}
-	tags, err := r.resolveTags(ctx)
+	tags, err := r.tags(ctx)
 	if err != nil || len(tags) == 0 {
 		return ""
 	}
@@ -387,7 +387,7 @@ func (r *GitCommitResolver) canonicalRepoRevURL(ctx context.Context) *url.URL {
 	return &url
 }
 
-func (r *GitCommitResolver) resolveTags(ctx context.Context) ([]string, error) {
+func (r *GitCommitResolver) tags(ctx context.Context) ([]string, error) {
 	commit, err := r.resolveCommit(ctx)
 	if err != nil {
 		return nil, err

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -184,7 +184,7 @@ func (r *GitCommitResolver) Parents(ctx context.Context) ([]*GitCommitResolver, 
 
 func (r *GitCommitResolver) URL() string {
 	url := r.repoResolver.url()
-	url.Path += "/-/commit/" + r.inputRevOrImmutableRev()
+	url.Path += "/-/commit/" + r.preferredCommitish()
 	return url.String()
 }
 
@@ -326,9 +326,9 @@ type behindAheadCountsResolver struct{ behind, ahead int32 }
 func (r *behindAheadCountsResolver) Behind() int32 { return r.behind }
 func (r *behindAheadCountsResolver) Ahead() int32  { return r.ahead }
 
-// inputRevOrImmutableRev returns the input revspec, if it is provided and nonempty. Otherwise it returns the
-// canonical OID for the revision.
-func (r *GitCommitResolver) inputRevOrImmutableRev() string {
+// preferredCommitish returns the preferred commit-ish suitable for use in
+// (not necessarily canonical) user-facing URLs, such as for navigation.
+func (r *GitCommitResolver) preferredCommitish() string {
 	if r.inputRev != nil && *r.inputRev != "" {
 		return *r.inputRev
 	}
@@ -336,7 +336,7 @@ func (r *GitCommitResolver) inputRevOrImmutableRev() string {
 }
 
 // repoRevURL returns the URL path prefix to use when constructing URLs to resources at this
-// revision. Unlike inputRevOrImmutableRev, it does NOT use the OID if no input revspec is
+// revision. Unlike preferredCommitish, it does NOT include a commit-ish if no input revspec is
 // given. This is because the convention in the frontend is for repo-rev URLs to omit the "@rev"
 // portion (unlike for commit page URLs, which must include some revspec in
 // "/REPO/-/commit/REVSPEC").

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"net/url"
 	"os"
+	"sort"
 	"sync"
 
 	"github.com/graph-gophers/graphql-go"
@@ -15,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
@@ -80,7 +82,7 @@ func (r *GitCommitResolver) resolveCommit(ctx context.Context) (*gitdomain.Commi
 			return
 		}
 
-		opts := git.ResolveRevisionOptions{}
+		opts := git.ResolveRevisionOptions{IncludeTags: true}
 		r.commit, r.commitErr = git.GetCommit(ctx, r.db, r.gitRepo, api.CommitID(r.oid), opts, authz.DefaultSubRepoPermsChecker)
 	})
 	return r.commit, r.commitErr
@@ -110,6 +112,13 @@ func (r *GitCommitResolver) ID() graphql.ID {
 func (r *GitCommitResolver) Repository() *RepositoryResolver { return r.repoResolver }
 
 func (r *GitCommitResolver) OID() GitObjectID { return r.oid }
+
+func (r *GitCommitResolver) PreferredCanonicalCommitish(ctx context.Context) string {
+	if tag := r.currentTag(ctx); tag != "" {
+		return tag
+	}
+	return string(r.oid)
+}
 
 func (r *GitCommitResolver) InputRev() *string { return r.inputRev }
 
@@ -182,15 +191,15 @@ func (r *GitCommitResolver) Parents(ctx context.Context) ([]*GitCommitResolver, 
 	return resolvers, nil
 }
 
-func (r *GitCommitResolver) URL() string {
+func (r *GitCommitResolver) URL(ctx context.Context) string {
 	url := r.repoResolver.url()
-	url.Path += "/-/commit/" + r.preferredCommitish()
+	url.Path += "/-/commit/" + r.preferredCommitish(ctx)
 	return url.String()
 }
 
-func (r *GitCommitResolver) CanonicalURL() string {
+func (r *GitCommitResolver) CanonicalURL(ctx context.Context) string {
 	url := r.repoResolver.url()
-	url.Path += "/-/commit/" + string(r.oid)
+	url.Path += "/-/commit/" + r.PreferredCanonicalCommitish(ctx)
 	return url.String()
 }
 
@@ -326,13 +335,29 @@ type behindAheadCountsResolver struct{ behind, ahead int32 }
 func (r *behindAheadCountsResolver) Behind() int32 { return r.behind }
 func (r *behindAheadCountsResolver) Ahead() int32  { return r.ahead }
 
+// currentTag returns the tag corresponding the current commit for a package repo.
+func (r *GitCommitResolver) currentTag(ctx context.Context) string {
+	if !r.repoResolver.IsPackageRepo() {
+		return ""
+	}
+	tags, err := r.resolveTags(ctx)
+	if err != nil || len(tags) == 0 {
+		return ""
+	}
+	sort.Slice(tags, func(i, j int) bool {
+		// tags for package repos are formatted as 'v<version>'
+		return reposource.VersionGreaterThan(tags[i], tags[j])
+	})
+	return tags[0]
+}
+
 // preferredCommitish returns the preferred commit-ish suitable for use in
 // (not necessarily canonical) user-facing URLs, such as for navigation.
-func (r *GitCommitResolver) preferredCommitish() string {
+func (r *GitCommitResolver) preferredCommitish(ctx context.Context) string {
 	if r.inputRev != nil && *r.inputRev != "" {
 		return *r.inputRev
 	}
-	return string(r.oid)
+	return r.PreferredCanonicalCommitish(ctx)
 }
 
 // repoRevURL returns the URL path prefix to use when constructing URLs to resources at this
@@ -340,14 +365,14 @@ func (r *GitCommitResolver) preferredCommitish() string {
 // given. This is because the convention in the frontend is for repo-rev URLs to omit the "@rev"
 // portion (unlike for commit page URLs, which must include some revspec in
 // "/REPO/-/commit/REVSPEC").
-func (r *GitCommitResolver) repoRevURL() *url.URL {
+func (r *GitCommitResolver) repoRevURL(ctx context.Context) *url.URL {
 	// Dereference to copy to avoid mutation
 	url := *r.repoResolver.RepoMatch.URL()
 	var rev string
 	if r.inputRev != nil {
 		rev = *r.inputRev // use the original input rev from the user
 	} else {
-		rev = string(r.oid)
+		rev = r.PreferredCanonicalCommitish(ctx)
 	}
 	if rev != "" {
 		url.Path += "@" + rev
@@ -355,9 +380,17 @@ func (r *GitCommitResolver) repoRevURL() *url.URL {
 	return &url
 }
 
-func (r *GitCommitResolver) canonicalRepoRevURL() *url.URL {
+func (r *GitCommitResolver) canonicalRepoRevURL(ctx context.Context) *url.URL {
 	// Dereference to copy the URL to avoid mutation
 	url := *r.repoResolver.RepoMatch.URL()
-	url.Path += "@" + string(r.oid)
+	url.Path += "@" + r.PreferredCanonicalCommitish(ctx)
 	return &url
+}
+
+func (r *GitCommitResolver) resolveTags(ctx context.Context) ([]string, error) {
+	commit, err := r.resolveCommit(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return commit.Tags, nil
 }

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -114,7 +114,7 @@ func (r *GitCommitResolver) Repository() *RepositoryResolver { return r.repoReso
 func (r *GitCommitResolver) OID() GitObjectID { return r.oid }
 
 func (r *GitCommitResolver) PreferredCanonicalCommitish(ctx context.Context) string {
-	if tag := r.currentTag(ctx); tag != "" {
+	if tag := r.packageRepoVersionTag(ctx); tag != "" {
 		return tag
 	}
 	return string(r.oid)
@@ -335,8 +335,8 @@ type behindAheadCountsResolver struct{ behind, ahead int32 }
 func (r *behindAheadCountsResolver) Behind() int32 { return r.behind }
 func (r *behindAheadCountsResolver) Ahead() int32  { return r.ahead }
 
-// currentTag returns the tag corresponding the current commit for a package repo.
-func (r *GitCommitResolver) currentTag(ctx context.Context) string {
+// packageRepoVersionTag returns the git tag corresponding the current commit for a package repo.
+func (r *GitCommitResolver) packageRepoVersionTag(ctx context.Context) string {
 	if !r.repoResolver.IsPackageRepo() {
 		return ""
 	}

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -337,7 +337,11 @@ func (r *behindAheadCountsResolver) Ahead() int32  { return r.ahead }
 
 // packageRepoVersionTag returns the git tag corresponding the current commit for a package repo.
 func (r *GitCommitResolver) packageRepoVersionTag(ctx context.Context) string {
-	if !r.repoResolver.IsPackageRepo() {
+	repo, err := r.repoResolver.repo(ctx)
+	if err != nil {
+		panic(err)
+	}
+	if !repo.IsPackageRepo() {
 		return ""
 	}
 	tags, err := r.tags(ctx)

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -36,15 +36,20 @@ func TestGitCommitResolver(t *testing.T) {
 			Email: "alice@bob.com",
 			Date:  time.Now(),
 		},
+		Tags: []string{"v1.0", "v2.0"},
 	}
 
-	t.Run("URL Escaping", func(t *testing.T) {
+	t.Run("URLs", func(t *testing.T) {
 		repo := NewRepositoryResolver(db, &types.Repo{Name: "xyz"})
 		commitResolver := NewGitCommitResolver(db, repo, "c1", commit)
 		{
+			require.Equal(t, "/xyz/-/commit/c1", commitResolver.URL(ctx))
+			require.Equal(t, "/xyz/-/commit/c1", commitResolver.CanonicalURL(ctx))
+
 			inputRev := "master^1"
 			commitResolver.inputRev = &inputRev
-			require.Equal(t, "/xyz/-/commit/master%5E1", commitResolver.URL())
+			require.Equal(t, "/xyz/-/commit/master%5E1", commitResolver.URL(ctx))
+			require.Equal(t, "/xyz/-/commit/c1", commitResolver.CanonicalURL(ctx))
 
 			treeResolver := NewGitTreeEntryResolver(db, commitResolver, CreateFileInfo("a/b", false))
 			url, err := treeResolver.URL(ctx)
@@ -54,8 +59,23 @@ func TestGitCommitResolver(t *testing.T) {
 		{
 			inputRev := "refs/heads/main"
 			commitResolver.inputRev = &inputRev
-			require.Equal(t, "/xyz/-/commit/refs/heads/main", commitResolver.URL())
+			require.Equal(t, "/xyz/-/commit/refs/heads/main", commitResolver.URL(ctx))
 		}
+	})
+
+	t.Run("Tags", func(t *testing.T) {
+		repo := NewRepositoryResolver(db, &types.Repo{Name: "npm/pkg"})
+		commitResolver := NewGitCommitResolver(db, repo, "c1", commit)
+
+		require.Equal(t, "/npm/pkg/-/commit/v2.0", commitResolver.URL(ctx))
+		require.Equal(t, "v2.0", commitResolver.PreferredCanonicalCommitish(ctx))
+
+		inputRev := "master"
+		commitResolver.inputRev = &inputRev
+
+		require.Equal(t, "/npm/pkg/-/commit/master", commitResolver.URL(ctx))
+		require.Equal(t, "v2.0", commitResolver.PreferredCanonicalCommitish(ctx))
+		require.Equal(t, "/npm/pkg/-/commit/v2.0", commitResolver.CanonicalURL(ctx))
 	})
 
 	t.Run("Lazy loading", func(t *testing.T) {
@@ -105,13 +125,13 @@ func TestGitCommitResolver(t *testing.T) {
 			name: "url",
 			want: "/bob-repo/-/commit/c1",
 			have: func(r *GitCommitResolver) (interface{}, error) {
-				return r.URL(), nil
+				return r.URL(ctx), nil
 			},
 		}, {
 			name: "canonical-url",
 			want: "/bob-repo/-/commit/c1",
 			have: func(r *GitCommitResolver) (interface{}, error) {
-				return r.CanonicalURL(), nil
+				return r.CanonicalURL(ctx), nil
 			},
 		}} {
 			t.Run(tc.name, func(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -148,11 +148,11 @@ func (r *GitTreeEntryResolver) url(ctx context.Context) *url.URL {
 		}
 		return &url.URL{Path: "/" + repoName + "@" + submodule.Commit()}
 	}
-	return r.urlPath(r.commit.repoRevURL())
+	return r.urlPath(r.commit.repoRevURL(ctx))
 }
 
-func (r *GitTreeEntryResolver) CanonicalURL() string {
-	url := r.commit.canonicalRepoRevURL()
+func (r *GitTreeEntryResolver) CanonicalURL(ctx context.Context) string {
+	url := r.commit.canonicalRepoRevURL(ctx)
 	return r.urlPath(url).String()
 }
 
@@ -179,7 +179,7 @@ func (r *GitTreeEntryResolver) ExternalURLs(ctx context.Context) ([]*externallin
 	if err != nil {
 		return nil, err
 	}
-	return externallink.FileOrDir(ctx, r.db, repo, r.commit.preferredCommitish(), r.Path(), r.stat.Mode().IsDir())
+	return externallink.FileOrDir(ctx, r.db, repo, r.commit.preferredCommitish(ctx), r.Path(), r.stat.Mode().IsDir())
 }
 
 func (r *GitTreeEntryResolver) RawZipArchiveURL() string {

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -179,7 +179,7 @@ func (r *GitTreeEntryResolver) ExternalURLs(ctx context.Context) ([]*externallin
 	if err != nil {
 		return nil, err
 	}
-	return externallink.FileOrDir(ctx, r.db, repo, r.commit.inputRevOrImmutableRev(), r.Path(), r.stat.Mode().IsDir())
+	return externallink.FileOrDir(ctx, r.db, repo, r.commit.preferredCommitish(), r.Path(), r.stat.Mode().IsDir())
 }
 
 func (r *GitTreeEntryResolver) RawZipArchiveURL() string {

--- a/cmd/frontend/graphqlbackend/location.go
+++ b/cmd/frontend/graphqlbackend/location.go
@@ -12,7 +12,7 @@ type LocationResolver interface {
 	Resource() *GitTreeEntryResolver
 	Range() *rangeResolver
 	URL(ctx context.Context) (string, error)
-	CanonicalURL(ctx context.Context) string
+	CanonicalURL(ctx context.Context) (string, error)
 }
 
 type locationResolver struct {
@@ -46,9 +46,12 @@ func (r *locationResolver) URL(ctx context.Context) (string, error) {
 	return r.urlPath(url), nil
 }
 
-func (r *locationResolver) CanonicalURL(ctx context.Context) string {
-	url := r.resource.CanonicalURL(ctx)
-	return r.urlPath(url)
+func (r *locationResolver) CanonicalURL(ctx context.Context) (string, error) {
+	url, err := r.resource.CanonicalURL(ctx)
+	if err != nil {
+		return "", err
+	}
+	return r.urlPath(url), nil
 }
 
 func (r *locationResolver) urlPath(prefix string) string {

--- a/cmd/frontend/graphqlbackend/location.go
+++ b/cmd/frontend/graphqlbackend/location.go
@@ -12,7 +12,7 @@ type LocationResolver interface {
 	Resource() *GitTreeEntryResolver
 	Range() *rangeResolver
 	URL(ctx context.Context) (string, error)
-	CanonicalURL() string
+	CanonicalURL(ctx context.Context) string
 }
 
 type locationResolver struct {
@@ -46,8 +46,8 @@ func (r *locationResolver) URL(ctx context.Context) (string, error) {
 	return r.urlPath(url), nil
 }
 
-func (r *locationResolver) CanonicalURL() string {
-	url := r.resource.CanonicalURL()
+func (r *locationResolver) CanonicalURL(ctx context.Context) string {
+	url := r.resource.CanonicalURL(ctx)
 	return r.urlPath(url)
 }
 

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"strings"
 	"sync"
 	"time"
 
@@ -116,11 +115,6 @@ func (r *RepositoryResolver) IsArchived(ctx context.Context) (bool, error) {
 func (r *RepositoryResolver) IsPrivate(ctx context.Context) (bool, error) {
 	repo, err := r.repo(ctx)
 	return repo.Private, err
-}
-
-func (r *RepositoryResolver) IsPackageRepo() bool {
-	name := r.Name()
-	return strings.HasPrefix(name, "maven/") || strings.HasPrefix(name, "npm/")
 }
 
 func (r *RepositoryResolver) URI(ctx context.Context) (string, error) {

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -115,6 +116,11 @@ func (r *RepositoryResolver) IsArchived(ctx context.Context) (bool, error) {
 func (r *RepositoryResolver) IsPrivate(ctx context.Context) (bool, error) {
 	repo, err := r.repo(ctx)
 	return repo.Private, err
+}
+
+func (r *RepositoryResolver) IsPackageRepo() bool {
+	name := r.Name()
+	return strings.HasPrefix(name, "maven/") || strings.HasPrefix(name, "npm/")
 }
 
 func (r *RepositoryResolver) URI(ctx context.Context) (string, error) {

--- a/cmd/frontend/graphqlbackend/repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison_test.go
@@ -260,14 +260,14 @@ func TestRepositoryComparison(t *testing.T) {
 			if mostRelevant == nil {
 				t.Fatalf("MostRelevantFile is nil")
 			}
-			relevantURL := mostRelevant.CanonicalURL()
+			relevantURL := mostRelevant.CanonicalURL(ctx)
 
 			wantRelevantURL := fmt.Sprintf("/%s@%s/-/blob/%s", repo.Name, wantHeadRevision, "INSTALL.md")
 			if relevantURL != wantRelevantURL {
 				t.Fatalf("MostRelevantFile.CanonicalURL() is wrong. have=%q, want=%q", relevantURL, wantRelevantURL)
 			}
 
-			newFileURL := newFile.CanonicalURL()
+			newFileURL := newFile.CanonicalURL(ctx)
 			// NewFile should be the most relevant file
 			if newFileURL != wantRelevantURL {
 				t.Fatalf(
@@ -836,7 +836,7 @@ func (d *dummyFileResolver) URL(ctx context.Context) (string, error) {
 	return d.url, nil
 }
 
-func (d *dummyFileResolver) CanonicalURL() string {
+func (d *dummyFileResolver) CanonicalURL(ctx context.Context) string {
 	return d.canonicalURL
 }
 

--- a/cmd/frontend/graphqlbackend/repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison_test.go
@@ -260,14 +260,16 @@ func TestRepositoryComparison(t *testing.T) {
 			if mostRelevant == nil {
 				t.Fatalf("MostRelevantFile is nil")
 			}
-			relevantURL := mostRelevant.CanonicalURL(ctx)
+			relevantURL, err := mostRelevant.CanonicalURL(ctx)
+			require.NoError(t, err)
 
 			wantRelevantURL := fmt.Sprintf("/%s@%s/-/blob/%s", repo.Name, wantHeadRevision, "INSTALL.md")
 			if relevantURL != wantRelevantURL {
 				t.Fatalf("MostRelevantFile.CanonicalURL() is wrong. have=%q, want=%q", relevantURL, wantRelevantURL)
 			}
 
-			newFileURL := newFile.CanonicalURL(ctx)
+			newFileURL, err := newFile.CanonicalURL(ctx)
+			require.NoError(t, err)
 			// NewFile should be the most relevant file
 			if newFileURL != wantRelevantURL {
 				t.Fatalf(
@@ -836,8 +838,8 @@ func (d *dummyFileResolver) URL(ctx context.Context) (string, error) {
 	return d.url, nil
 }
 
-func (d *dummyFileResolver) CanonicalURL(ctx context.Context) string {
-	return d.canonicalURL
+func (d *dummyFileResolver) CanonicalURL(ctx context.Context) (string, error) {
+	return d.canonicalURL, nil
 }
 
 func (d *dummyFileResolver) ExternalURLs(ctx context.Context) ([]*externallink.Resolver, error) {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3731,6 +3731,14 @@ type GitCommit implements Node {
     """
     abbreviatedOID: String!
     """
+    The canonical commit-ish (a hash, a tag etc., see https://git-scm.com/docs/gitglossary)
+    that should be used for identifying a commit in a stable way, such as in canonical URLs.
+
+    This is separate from oid because git hashes are not meaningful for synthetic git repos,
+    such as those generated from package repos or from a Perforce import.
+    """
+    preferredCanonicalCommitish: String!
+    """
     This commit's author.
     """
     author: Signature!

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -126,6 +126,8 @@ func (r symbolResolver) Location() *locationResolver {
 
 func (r symbolResolver) URL(ctx context.Context) (string, error) { return r.Location().URL(ctx) }
 
-func (r symbolResolver) CanonicalURL() string { return r.Location().CanonicalURL() }
+func (r symbolResolver) CanonicalURL(ctx context.Context) string {
+	return r.Location().CanonicalURL(ctx)
+}
 
 func (r symbolResolver) FileLocal() bool { return r.Symbol.FileLimited }

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -126,7 +126,7 @@ func (r symbolResolver) Location() *locationResolver {
 
 func (r symbolResolver) URL(ctx context.Context) (string, error) { return r.Location().URL(ctx) }
 
-func (r symbolResolver) CanonicalURL(ctx context.Context) string {
+func (r symbolResolver) CanonicalURL(ctx context.Context) (string, error) {
 	return r.Location().CanonicalURL(ctx)
 }
 

--- a/cmd/frontend/graphqlbackend/virtual_file.go
+++ b/cmd/frontend/graphqlbackend/virtual_file.go
@@ -42,7 +42,7 @@ func (r *virtualFileResolver) URL(ctx context.Context) (string, error) {
 	return "", nil
 }
 
-func (r *virtualFileResolver) CanonicalURL() string {
+func (r *virtualFileResolver) CanonicalURL(_ context.Context) string {
 	// Todo: allow viewing arbitrary files in the webapp.
 	return ""
 }

--- a/cmd/frontend/graphqlbackend/virtual_file.go
+++ b/cmd/frontend/graphqlbackend/virtual_file.go
@@ -42,9 +42,9 @@ func (r *virtualFileResolver) URL(ctx context.Context) (string, error) {
 	return "", nil
 }
 
-func (r *virtualFileResolver) CanonicalURL(_ context.Context) string {
+func (r *virtualFileResolver) CanonicalURL(_ context.Context) (string, error) {
 	// Todo: allow viewing arbitrary files in the webapp.
-	return ""
+	return "", nil
 }
 
 func (r *virtualFileResolver) ExternalURLs(ctx context.Context) ([]*externallink.Resolver, error) {

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations_test.go
@@ -272,13 +272,13 @@ func TestResolveLocations(t *testing.T) {
 		t.Fatalf("unexpected length. want=%d have=%d", 3, len(locations))
 	}
 	ctx := context.Background()
-	if url := locations[0].CanonicalURL(ctx); url != "/repo50@deadbeef1/-/blob/p1?L12:13-14:15" {
+	if url, _ := locations[0].CanonicalURL(ctx); url != "/repo50@deadbeef1/-/blob/p1?L12:13-14:15" {
 		t.Errorf("unexpected canonical url. want=%s have=%s", "/repo50@deadbeef1/-/blob/p1?L12:13-14:15", url)
 	}
-	if url := locations[1].CanonicalURL(ctx); url != "/repo51@deadbeef2/-/blob/p2?L22:23-24:25" {
+	if url, _ := locations[1].CanonicalURL(ctx); url != "/repo51@deadbeef2/-/blob/p2?L22:23-24:25" {
 		t.Errorf("unexpected canonical url. want=%s have=%s", "/repo51@deadbeef2/-/blob/p2?L22:23-24:25", url)
 	}
-	if url := locations[2].CanonicalURL(ctx); url != "/repo53@deadbeef4/-/blob/p4?L42:43-44:45" {
+	if url, _ := locations[2].CanonicalURL(ctx); url != "/repo53@deadbeef4/-/blob/p4?L42:43-44:45" {
 		t.Errorf("unexpected canonical url. want=%s have=%s", "/repo53@deadbeef4/-/blob/p4?L42:43-44:45", url)
 	}
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations_test.go
@@ -271,13 +271,14 @@ func TestResolveLocations(t *testing.T) {
 	if len(locations) != 3 {
 		t.Fatalf("unexpected length. want=%d have=%d", 3, len(locations))
 	}
-	if url := locations[0].CanonicalURL(); url != "/repo50@deadbeef1/-/blob/p1?L12:13-14:15" {
+	ctx := context.Background()
+	if url := locations[0].CanonicalURL(ctx); url != "/repo50@deadbeef1/-/blob/p1?L12:13-14:15" {
 		t.Errorf("unexpected canonical url. want=%s have=%s", "/repo50@deadbeef1/-/blob/p1?L12:13-14:15", url)
 	}
-	if url := locations[1].CanonicalURL(); url != "/repo51@deadbeef2/-/blob/p2?L22:23-24:25" {
+	if url := locations[1].CanonicalURL(ctx); url != "/repo51@deadbeef2/-/blob/p2?L22:23-24:25" {
 		t.Errorf("unexpected canonical url. want=%s have=%s", "/repo51@deadbeef2/-/blob/p2?L22:23-24:25", url)
 	}
-	if url := locations[2].CanonicalURL(); url != "/repo53@deadbeef4/-/blob/p4?L42:43-44:45" {
+	if url := locations[2].CanonicalURL(ctx); url != "/repo53@deadbeef4/-/blob/p4?L42:43-44:45" {
 		t.Errorf("unexpected canonical url. want=%s have=%s", "/repo53@deadbeef4/-/blob/p4?L42:43-44:45", url)
 	}
 }

--- a/internal/conf/reposource/jvm_packages.go
+++ b/internal/conf/reposource/jvm_packages.go
@@ -70,7 +70,7 @@ type MavenDependency struct {
 func SortDependencies(dependencies []*MavenDependency) {
 	sort.Slice(dependencies, func(i, j int) bool {
 		if dependencies[i].MavenModule.Equal(dependencies[j].MavenModule) {
-			return versionGreaterThan(dependencies[i].Version, dependencies[j].Version)
+			return VersionGreaterThan(dependencies[i].Version, dependencies[j].Version)
 		}
 		return dependencies[i].MavenModule.SortText() > dependencies[j].MavenModule.SortText()
 	})

--- a/internal/conf/reposource/jvm_packages_test.go
+++ b/internal/conf/reposource/jvm_packages_test.go
@@ -24,10 +24,10 @@ func ParseMavenDependencyOrPanic(t *testing.T, value string) *MavenDependency {
 }
 
 func TestGreaterThan(t *testing.T) {
-	assert.True(t, versionGreaterThan("11.2.0", "1.2.0"))
-	assert.True(t, versionGreaterThan("11.2.0", "2.2.0"))
-	assert.True(t, versionGreaterThan("11.2.0", "11.2.0-M1"))
-	assert.False(t, versionGreaterThan("11.2.0-M11", "11.2.0"))
+	assert.True(t, VersionGreaterThan("11.2.0", "1.2.0"))
+	assert.True(t, VersionGreaterThan("11.2.0", "2.2.0"))
+	assert.True(t, VersionGreaterThan("11.2.0", "11.2.0-M1"))
+	assert.False(t, VersionGreaterThan("11.2.0-M11", "11.2.0"))
 }
 
 func TestSortDependencies(t *testing.T) {

--- a/internal/conf/reposource/npm_packages.go
+++ b/internal/conf/reposource/npm_packages.go
@@ -221,7 +221,7 @@ func SortNpmDependencies(dependencies []*NpmDependency) {
 	sort.Slice(dependencies, func(i, j int) bool {
 		iPkg, jPkg := dependencies[i].NpmPackage, dependencies[j].NpmPackage
 		if iPkg.Equal(jPkg) {
-			return versionGreaterThan(dependencies[i].Version, dependencies[j].Version)
+			return VersionGreaterThan(dependencies[i].Version, dependencies[j].Version)
 		}
 		if iPkg.scope == jPkg.scope {
 			return iPkg.name > jPkg.name

--- a/internal/conf/reposource/package_version.go
+++ b/internal/conf/reposource/package_version.go
@@ -5,13 +5,13 @@ import (
 	"unicode"
 )
 
-// versionGreaterThan is a generalized version of comparing two strings
+// VersionGreaterThan is a generalized version of comparing two strings
 // using semantic versioning that allows for non-numeric characters.
 // When a non-numeric character is encountered, the comparison switches to
 // lexicographic.
 //
 // For example, 11.0x > 11.0a > 11.0 > 8.0.
-func versionGreaterThan(version1, version2 string) bool {
+func VersionGreaterThan(version1, version2 string) bool {
 	index := 0
 	end := len(version1)
 	if len(version2) < end {

--- a/internal/gitserver/gitdomain/common.go
+++ b/internal/gitserver/gitdomain/common.go
@@ -56,6 +56,11 @@ type Commit struct {
 	Message   Message      `json:"Message,omitempty"`
 	// Parents are the commit IDs of this commit's parent commits.
 	Parents []api.CommitID `json:"Parents,omitempty"`
+	// Tags represents the git tags (annotated or lightweight) attached to this commit.
+	//
+	// Depending on how the Commit object may have been created, this value may be
+	// unset (i.e. it may have len == 0 but the commit might actually have tags).
+	Tags []string `json:"Tags,omitempty"`
 }
 
 // Message represents a git commit message

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -65,11 +65,12 @@ func NewSearchEventDone(limitHit bool, err error) SearchEventDone {
 	return event
 }
 
-type CommitMatch struct {
+type CommitMatch struct { // TODO: [Varun] Audit places where CommitMatch is used.
 	Oid        api.CommitID
 	Author     Signature      `json:",omitempty"`
 	Committer  Signature      `json:",omitempty"`
 	Parents    []api.CommitID `json:",omitempty"`
+	Tags       []string       `json:",omitempty"`
 	Refs       []string       `json:",omitempty"`
 	SourceRefs []string       `json:",omitempty"`
 

--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -346,6 +346,7 @@ func protocolMatchToCommitMatch(repo types.MinimalRepo, diff bool, in protocol.C
 			},
 			Message: gitdomain.Message(in.Message.Content),
 			Parents: in.Parents,
+			Tags:    in.Tags,
 		},
 		Repo:           repo,
 		DiffPreview:    diffPreview,

--- a/internal/search/result/commit_json.go
+++ b/internal/search/result/commit_json.go
@@ -26,6 +26,7 @@ type stableCommitMatchJSON struct {
 	CommitCommitter *stableSignatureMarshaler `json:"committer,omitempty"`
 	Message         string                    `json:"message"`
 	Parents         []string                  `json:"parents,omitempty"`
+	Tags            []string                  `json:"tags,omitempty"`
 	Refs            []string                  `json:"refs,omitempty"`
 	SourceRefs      []string                  `json:"sourceRefs,omitempty"`
 	MessagePreview  *MatchedString            `json:"messagePreview,omitempty"`
@@ -54,6 +55,11 @@ func (cm CommitMatch) MarshalJSON() ([]byte, error) {
 		parents[i] = string(parent)
 	}
 
+	tags := make([]string, len(cm.Commit.Tags))
+	for i, tag := range cm.Commit.Tags {
+		tags[i] = tag
+	}
+
 	marshaler := stableCommitMatchJSON{
 		RepoID:    int32(cm.Repo.ID),
 		RepoName:  string(cm.Repo.Name),
@@ -67,6 +73,7 @@ func (cm CommitMatch) MarshalJSON() ([]byte, error) {
 		CommitCommitter: committer,
 		Message:         string(cm.Commit.Message),
 		Parents:         parents,
+		Tags:            tags,
 		Refs:            cm.Refs,
 		SourceRefs:      cm.SourceRefs,
 		MessagePreview:  cm.MessagePreview,
@@ -97,6 +104,11 @@ func (cm *CommitMatch) UnmarshalJSON(input []byte) error {
 		parents[i] = api.CommitID(parent)
 	}
 
+	tags := make([]string, len(unmarshaler.Tags))
+	for i, tag := range unmarshaler.Tags {
+		tags[i] = tag
+	}
+
 	*cm = CommitMatch{
 		Commit: gitdomain.Commit{
 			ID: api.CommitID(unmarshaler.CommitID),
@@ -108,6 +120,7 @@ func (cm *CommitMatch) UnmarshalJSON(input []byte) error {
 			Committer: committer,
 			Message:   gitdomain.Message(unmarshaler.Message),
 			Parents:   parents,
+			Tags:      tags,
 		},
 		Repo: types.MinimalRepo{
 			ID:    api.RepoID(unmarshaler.RepoID),

--- a/internal/search/result/commit_json_test.go
+++ b/internal/search/result/commit_json_test.go
@@ -29,6 +29,7 @@ func TestCommitMatchMarshaling(t *testing.T) {
 				},
 				Message: "add documentation for hot beverages",
 				Parents: []api.CommitID{"coffeeae", "coffea", "arabica"},
+				Tags:    []string{"cappuccino", "latte"},
 			},
 			Repo: types.MinimalRepo{
 				ID:    42,

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -259,6 +259,11 @@ func (r *Repo) String() string {
 	return fmt.Sprintf("Repo{ID: %d, Name: %q, EID: %s}", r.ID, r.Name, eid)
 }
 
+func (r *Repo) IsPackageRepo() bool {
+	name := string(r.Name)
+	return strings.HasPrefix(name, "maven/") || strings.HasPrefix(name, "npm/")
+}
+
 func sourcesKeys(m map[string]*SourceInfo) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -665,13 +665,12 @@ func parseCommitTags(opt CommitsOptions, parts [][]byte) []string {
 		return tags
 	}
 	// Assuming that refs don't have commas in them.
-	refs := bytes.Split(parts[tagsIndex], []byte{','})
+	refs := bytes.Split(parts[tagsIndex], []byte(", "))
 	for _, ref := range refs {
-		ref = bytes.TrimSpace(ref)
-		if !bytes.HasPrefix(ref, []byte("tag:")) {
+		if !bytes.HasPrefix(ref, []byte("tag: ")) {
 			continue
 		}
-		tags = append(tags, string(bytes.TrimSpace(ref[4:])))
+		tags = append(tags, string(ref[5:]))
 	}
 	return tags
 }

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -46,14 +46,27 @@ type CommitsOptions struct {
 
 	// When true return the names of the files changed in the commit
 	NameOnly bool
+
+	// When true, return the tags attached to this commit
+	IncludeTags bool
 }
 
 func (opt *CommitsOptions) partsPerCommit() int {
 	p := partsPerCommitBasic
+	if opt.IncludeTags {
+		p++
+	}
 	if opt.NameOnly {
 		p++
 	}
 	return p
+}
+
+func (opt *CommitsOptions) tagsIndex() int {
+	if opt.IncludeTags {
+		return partsPerCommitBasic
+	}
+	return -312877 // sentinel value to catch errors
 }
 
 func (opt *CommitsOptions) fileNamesIndex() int {
@@ -468,6 +481,11 @@ func commitLogArgs(initialArgs []string, formatString string, opt CommitsOptions
 	if opt.Range != "" {
 		args = append(args, opt.Range)
 	}
+	if opt.IncludeTags {
+		// Use %D instead of %(describe:tags) (introduced in git v2.5.0) as the
+		// latter only returns a single tag even if there are multiple tags.
+		formatString += "%D%x00"
+	}
 	if opt.NameOnly {
 		args = append(args, "--name-only")
 	}
@@ -610,6 +628,8 @@ func parseCommitFromLog(data []byte, opt CommitsOptions) (commit *wrappedCommit,
 		}
 	}
 
+	tags := parseCommitTags(opt, parts)
+
 	fileNames, nextCommit := parseCommitFileNames(opt, parts)
 
 	commit = &wrappedCommit{
@@ -619,6 +639,7 @@ func parseCommitFromLog(data []byte, opt CommitsOptions) (commit *wrappedCommit,
 			Committer: &gitdomain.Signature{Name: string(parts[4]), Email: string(parts[5]), Date: time.Unix(committerTime, 0).UTC()},
 			Message:   gitdomain.Message(strings.TrimSuffix(string(parts[7]), "\n")),
 			Parents:   parents,
+			Tags:      tags,
 		}, files: fileNames,
 	}
 
@@ -631,6 +652,27 @@ func parseCommitFromLog(data []byte, opt CommitsOptions) (commit *wrappedCommit,
 	}
 
 	return commit, rest, nil
+}
+
+// parseCommitTags parses tags formatted using git log --format's %D specifier.
+//
+// Non-tag refs are ignored.
+func parseCommitTags(opt CommitsOptions, parts [][]byte) []string {
+	var tags []string
+	tagsIndex := opt.tagsIndex()
+	if tagsIndex < 0 {
+		return tags
+	}
+	// Assuming that refs don't have commas in them.
+	refs := bytes.Split(parts[tagsIndex], []byte{','})
+	for _, ref := range refs {
+		ref = bytes.TrimSpace(ref)
+		if !bytes.HasPrefix(ref, []byte("tag:")) {
+			continue
+		}
+		tags = append(tags, string(bytes.TrimSpace(ref[4:])))
+	}
+	return tags
 }
 
 // If the commit has filenames, parse those and return as a list. Also, in this case the next commit ID shows up in this

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -48,6 +48,21 @@ type CommitsOptions struct {
 	NameOnly bool
 }
 
+func (opt *CommitsOptions) partsPerCommit() int {
+	p := partsPerCommitBasic
+	if opt.NameOnly {
+		p++
+	}
+	return p
+}
+
+func (opt *CommitsOptions) fileNamesIndex() int {
+	if opt.NameOnly {
+		return opt.partsPerCommit() - 1
+	}
+	return -312948 // sentinel value to catch errors
+}
+
 // logEntryPattern is the regexp pattern that matches entries in the output of the `git shortlog
 // -sne` command.
 var logEntryPattern = lazyregexp.New(`^\s*([0-9]+)\s+(.*)$`)
@@ -302,7 +317,7 @@ func commitLog(ctx context.Context, db database.DB, repo api.RepoName, opt Commi
 }
 
 func getWrappedCommits(ctx context.Context, db database.DB, repo api.RepoName, opt CommitsOptions) ([]*wrappedCommit, error) {
-	args, err := commitLogArgs([]string{"log", logFormatWithoutRefs}, opt)
+	args, err := commitLogArgs([]string{"log"}, defaultLogFormat, opt)
 	if err != nil {
 		return nil, err
 	}
@@ -394,16 +409,12 @@ var runCommitLog = func(ctx context.Context, cmd *gitserver.Cmd, opt CommitsOpti
 	}
 
 	allParts := bytes.Split(data, []byte{'\x00'})
-	partsPerCommit := partsPerCommitBasic
-	if opt.NameOnly {
-		partsPerCommit = partsPerCommitWithFileNames
-	}
-	numCommits := len(allParts) / partsPerCommit
+	numCommits := len(allParts) / opt.partsPerCommit()
 	commits := make([]*wrappedCommit, 0, numCommits)
 	for len(data) > 0 {
 		var commit *wrappedCommit
 		var err error
-		commit, data, err = parseCommitFromLog(data, partsPerCommit)
+		commit, data, err = parseCommitFromLog(data, opt)
 		if err != nil {
 			return nil, err
 		}
@@ -417,7 +428,10 @@ type wrappedCommit struct {
 	files []string
 }
 
-func commitLogArgs(initialArgs []string, opt CommitsOptions) (args []string, err error) {
+// commitLogArgs prepares the arguments for commands like git-log and git rev-list.
+//
+// Not all fields in CommitsOptions are supported for all git commands. :
+func commitLogArgs(initialArgs []string, formatString string, opt CommitsOptions) (args []string, err error) {
 	if err := checkSpecArgSafety(opt.Range); err != nil {
 		return nil, err
 	}
@@ -457,6 +471,9 @@ func commitLogArgs(initialArgs []string, opt CommitsOptions) (args []string, err
 	if opt.NameOnly {
 		args = append(args, "--name-only")
 	}
+
+	args = append(args, fmt.Sprintf("--format=%s", formatString))
+
 	if opt.Path != "" {
 		args = append(args, "--", opt.Path)
 	}
@@ -469,7 +486,7 @@ func commitCount(ctx context.Context, db database.DB, repo api.RepoName, opt Com
 	span.SetTag("Opt", opt)
 	defer span.Finish()
 
-	args, err := commitLogArgs([]string{"rev-list", "--count"}, opt)
+	args, err := commitLogArgs([]string{"rev-list", "--count"}, "", opt)
 	if err != nil {
 		return 0, err
 	}
@@ -554,17 +571,17 @@ func checkError(err error) (string, bool, error) {
 }
 
 const (
-	partsPerCommitBasic         = 9  // number of \x00-separated fields per commit
-	partsPerCommitWithFileNames = 10 // number of \x00-separated fields per commit with names of modified files also returned
+	// partsPerCommitBasic is the number of \x00-separated fields in defaultLogFormat.
+	partsPerCommitBasic = 9
 
-	// don't include refs (faster, should be used if refs are not needed)
-	logFormatWithoutRefs = "--format=format:%H%x00%aN%x00%aE%x00%at%x00%cN%x00%cE%x00%ct%x00%B%x00%P%x00"
+	// defaultLogFormat is the baseline string for formatting git log output
+	defaultLogFormat = "format:%H%x00%aN%x00%aE%x00%at%x00%cN%x00%cE%x00%ct%x00%B%x00%P%x00"
 )
 
 // parseCommitFromLog parses the next commit from data and returns the commit and the remaining
-// data. The data arg is a byte array that contains NUL-separated log fields as formatted by
-// logFormatFlag.
-func parseCommitFromLog(data []byte, partsPerCommit int) (commit *wrappedCommit, rest []byte, err error) {
+// data. The data arg is a byte array that contains NUL-separated log fields.
+func parseCommitFromLog(data []byte, opt CommitsOptions) (commit *wrappedCommit, rest []byte, err error) {
+	partsPerCommit := opt.partsPerCommit()
 	parts := bytes.SplitN(data, []byte{'\x00'}, partsPerCommit+1)
 	if len(parts) < partsPerCommit {
 		return nil, nil, errors.Errorf("invalid commit log entry: %q", parts)
@@ -593,7 +610,7 @@ func parseCommitFromLog(data []byte, partsPerCommit int) (commit *wrappedCommit,
 		}
 	}
 
-	fileNames, nextCommit := parseCommitFileNames(partsPerCommit, parts)
+	fileNames, nextCommit := parseCommitFileNames(opt, parts)
 
 	commit = &wrappedCommit{
 		Commit: &gitdomain.Commit{
@@ -618,12 +635,12 @@ func parseCommitFromLog(data []byte, partsPerCommit int) (commit *wrappedCommit,
 
 // If the commit has filenames, parse those and return as a list. Also, in this case the next commit ID shows up in this
 // portion of the byte array, so it must be returned as well to be added to the rest of the commits to be processed.
-func parseCommitFileNames(partsPerCommit int, parts [][]byte) ([]string, []byte) {
+func parseCommitFileNames(opt CommitsOptions, parts [][]byte) ([]string, []byte) {
 	var fileNames []string
 	var nextCommit []byte
-	if partsPerCommit == partsPerCommitWithFileNames {
-		parts[9] = bytes.TrimPrefix(parts[9], []byte{'\n'})
-		fileNamesRaw := parts[9]
+	if fileNameIndex := opt.fileNamesIndex(); fileNameIndex >= 0 {
+		parts[fileNameIndex] = bytes.TrimPrefix(parts[fileNameIndex], []byte{'\n'})
+		fileNamesRaw := parts[fileNameIndex]
 		fileNameParts := bytes.Split(fileNamesRaw, []byte{'\n'})
 		for i, name := range fileNameParts {
 			// The last item contains the files modified, some empty space, and the commit ID for the next commit. Drop

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -116,6 +116,7 @@ func getCommit(ctx context.Context, db database.DB, repo api.RepoName, id api.Co
 		Range:            string(id),
 		N:                1,
 		NoEnsureRevision: opt.NoEnsureRevision,
+		IncludeTags:      opt.IncludeTags,
 	}
 	commitOptions = addNameOnly(commitOptions, checker)
 

--- a/internal/vcs/git/commits_test.go
+++ b/internal/vcs/git/commits_test.go
@@ -31,6 +31,13 @@ func TestLogPartsPerCommitInSync(t *testing.T) {
 		partsPerCommitBasic)
 }
 
+func TestParseCommitTags(t *testing.T) {
+	opt := CommitsOptions{IncludeTags: true}
+	parts := make([][]byte, opt.tagsIndex()+1)
+	parts[opt.tagsIndex()] = []byte("HEAD -> main, tag: v0.4, origin/main, tag: v0.3")
+	require.Equal(t, []string{"v0.4", "v0.3"}, parseCommitTags(opt, parts))
+}
+
 func TestRepository_GetCommit(t *testing.T) {
 	ctx := actor.WithActor(context.Background(), &actor.Actor{
 		UID: 1,

--- a/internal/vcs/git/commits_test.go
+++ b/internal/vcs/git/commits_test.go
@@ -26,7 +26,7 @@ var (
 )
 
 func TestLogPartsPerCommitInSync(t *testing.T) {
-	require.Equal(t, 2*partsPerCommitBasic, strings.Count(logFormatWithoutRefs, "%"),
+	require.Equal(t, 2*partsPerCommitBasic, strings.Count(defaultLogFormat, "%"),
 		"Expected (2 * %0d) %% signs in log format string (%0d fields, %0d %%x00 separators)",
 		partsPerCommitBasic)
 }

--- a/internal/vcs/git/revisions.go
+++ b/internal/vcs/git/revisions.go
@@ -48,6 +48,8 @@ func ensureAbsoluteCommit(commitID api.CommitID) error {
 // The zero value should contain appropriate default values.
 type ResolveRevisionOptions struct {
 	NoEnsureRevision bool // do not try to fetch from remote if revision doesn't exist locally
+
+	IncludeTags bool
 }
 
 var resolveRevisionCounter = promauto.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
Partial progress towards #31937. This only includes backend changes.

## Notes for reviewers

- The first commit is from https://github.com/sourcegraph/sourcegraph/pull/32625.
- Commits are mostly cleaned up for easier reviewing; most commits are no-ops. I will add further changes as fixups or new commits once review starts.
- The key change is that we have a new `preferredCanonicalCommitish` field in the GraphQL schema. In the future, we can prefer tags over versions in frontend code by requesting this field and using it to create any necessary canonical URLs (instead of directly using the oid). The commit-ish [[definition](https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefcommit-ishacommit-ishalsocommittish)] terminology is taken from git itself. It's more precise than "revision".
- Frontend changes will be in subsequent PRs. For example, some of the changes need to go in the code-intel-extension repo, not this repo.

## Test plan

I've added some unit tests for tags + canonical URLs. Specific suggestions for other tests that would be useful to add are welcome. 😄