### PR TITLE
Remove server with contributors story until we ship contributors for server

### DIFF
--- a/client/web/src/search/home/SearchPage.story.tsx
+++ b/client/web/src/search/home/SearchPage.story.tsx
@@ -126,13 +126,3 @@ add('Server with panels', () => (
         }}
     </WebStory>
 ))
-
-add('Server with panels and collaborators', () => (
-    <WebStory>
-        {webProps => {
-            useExperimentalFeatures.setState({ showEnterpriseHomePanels: true })
-            useExperimentalFeatures.setState({ homepageUserInvitation: true })
-            return <SearchPage {...defaultProps(webProps)} />
-        }}
-    </WebStory>
-))


### PR DESCRIPTION
We currently have homepage invites for server disabled (since we don't want to accidentally ship it). As a result, this story is now equivalent to the normal server story so we can remove it for now.

## Test plan

- This PR should cause a change in our screenshot tests.