### PR TITLE
Remove italic style on subtitle on search home

### DIFF
--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -75,9 +75,7 @@ export const SearchPage: React.FunctionComponent<SearchPageProps> = props => {
         <div className={classNames('d-flex flex-column align-items-center px-3', styles.searchPage)}>
             <BrandLogo className={styles.logo} isLightTheme={props.isLightTheme} variant="logo" />
             {props.isSourcegraphDotCom && (
-                <div className="text-muted text-center mt-3">
-                    Search your code and 2M+ open source repositories
-                </div>
+                <div className="text-muted text-center mt-3">Search your code and 2M+ open source repositories</div>
             )}
             <div
                 className={classNames(styles.searchContainer, {

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -75,7 +75,7 @@ export const SearchPage: React.FunctionComponent<SearchPageProps> = props => {
         <div className={classNames('d-flex flex-column align-items-center px-3', styles.searchPage)}>
             <BrandLogo className={styles.logo} isLightTheme={props.isLightTheme} variant="logo" />
             {props.isSourcegraphDotCom && (
-                <div className="text-muted text-center font-italic mt-3">
+                <div className="text-muted text-center mt-3">
                     Search your code and 2M+ open source repositories
                 </div>
             )}


### PR DESCRIPTION
On the search home, we have a subtitle that reads _"Search your code and 2M+ open source repositories"_ set in an italic text style.

<img width="627" alt="image" src="https://user-images.githubusercontent.com/6304497/157421809-6394df42-bfdc-4785-af29-b155ac3c49e0.png">

This hasn't felt right to me and I think about it every time I open Sourcegraph, and I finally figured out why it doesn't feel right: when used in copy, italics convey _semantic meaning_, as demonstrated in this sentence. As used in this subtitle, they don't convey any semantic meaning, so the italics are used only for visual style/hierarchy.

While this seems like a super small thing (which is why I haven't acted on it earlier), I believe it feeds back into our content guidelines and Wildcard more generally and influences design decisions elsewhere. 

My feeling is that we should use italics only when we want to highlight something within a line of copy to provide additional semantic meaning. When we want to create additional levels of visual hierarchy for entire lines of text content, we should use other tools at our disposal, like colour, size, and weight.

After this change is applied:

<img width="642" alt="image" src="https://user-images.githubusercontent.com/6304497/157423386-f00c2d25-d4f1-4a63-815d-571fc09c6f19.png">

If we're aligned on this as a design team, then I'll follow up when this PR is merged to also update the content guidelines.

## Test plan

See screenshots for visual difference.