### PR TITLE
Change BExt and IDE CTA copy and download links

### DIFF
--- a/client/shared/src/components/CtaAlert.tsx
+++ b/client/shared/src/components/CtaAlert.tsx
@@ -14,6 +14,11 @@ export interface CtaAlertProps {
         href: string
         onClick?: () => void
     }
+    secondary?: {
+        label: string
+        href: string
+        onClick?: () => void
+    }
     icon: React.ReactNode
     className?: string
     onClose: () => void
@@ -41,6 +46,18 @@ export const CtaAlert: React.FunctionComponent<CtaAlertProps> = props => (
             <Button to={props.cta.href} onClick={props.cta.onClick} variant="primary" as={Link} target="_blank">
                 {props.cta.label}
             </Button>
+            {props.secondary ? (
+                <Button
+                    to={props.secondary.href}
+                    onClick={props.secondary.onClick}
+                    variant="link"
+                    as={Link}
+                    target="_blank"
+                    className="ml-2"
+                >
+                    {props.secondary.label}
+                </Button>
+            ) : null}
         </div>
         <CloseIcon
             className="icon-inline position-absolute cursor-pointer"

--- a/client/web/src/repo/actions/BrowserExtensionAlert.tsx
+++ b/client/web/src/repo/actions/BrowserExtensionAlert.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect, useMemo } from 'react'
 import { CtaAlert } from '@sourcegraph/shared/src/components/CtaAlert'
 
 import { ExtensionRadialGradientIcon } from '../../components/CtaIcons'
+import { IS_CHROME } from '../../marketing/util'
 import { eventLogger } from '../../tracking/eventLogger'
 
 interface Props {
@@ -11,25 +12,41 @@ interface Props {
     onAlertDismissed: () => void
 }
 
+const CHROME_LINK = 'https://chrome.google.com/webstore/detail/sourcegraph/dgjhfomjieaadpoljlnidmbgkdffpack'
+const SAFARI_LINK = 'https://apps.apple.com/us/app/sourcegraph-for-safari/id1543262193'
+const FIREFOX_LINK = 'https://addons.mozilla.org/en-US/firefox/addon/sourcegraph-for-firefox/'
+
 export const BrowserExtensionAlert: React.FunctionComponent<Props> = ({ className, page, onAlertDismissed }) => {
     const args = useMemo(() => ({ page }), [page])
+
     useEffect(() => {
         eventLogger.log('InstallBrowserExtensionCTAShown', args, args)
     }, [args])
 
-    const onBrowserExtensionClick = useCallback((): void => {
+    const onBrowserExtensionPrimaryClick = useCallback((): void => {
         eventLogger.log('InstallBrowserExtensionCTAClicked', args, args)
+    }, [args])
+
+    const onBrowserExtensionSecondaryClick = useCallback((): void => {
+        eventLogger.log('InstallBrowserExtensionLearnClicked', args, args)
     }, [args])
 
     return (
         <CtaAlert
-            title="Install the Sourcegraph browser extension"
-            description="Add code intelligence to pull requests and file views on GitHub, GitLab, Bitbucket Server, and Phabricator"
+            title="Get more from Sourcegraph with the browser extension"
+            description="Add code intelligence to pull requests and file views on GitHub, GitLab, Bitbucket Server, and Phabricator."
             cta={{
-                label: 'Learn more about the extension',
+                label: 'Install now',
+                href: IS_CHROME
+                    ? SAFARI_LINK
+                    : 'https://docs.sourcegraph.com/integration/browser_extension?utm_campaign=search-results-cta&utm_medium=direct_traffic&utm_source=in-product&utm_term=null&utm_content=install-browser-exten',
+                onClick: onBrowserExtensionPrimaryClick,
+            }}
+            secondary={{
+                label: 'Learn more',
                 href:
                     'https://docs.sourcegraph.com/integration/browser_extension?utm_campaign=search-results-cta&utm_medium=direct_traffic&utm_source=in-product&utm_term=null&utm_content=install-browser-exten',
-                onClick: onBrowserExtensionClick,
+                onClick: onBrowserExtensionSecondaryClick,
             }}
             icon={<ExtensionRadialGradientIcon />}
             className={className}

--- a/client/web/src/repo/actions/BrowserExtensionAlert.tsx
+++ b/client/web/src/repo/actions/BrowserExtensionAlert.tsx
@@ -3,7 +3,6 @@ import React, { useCallback, useEffect, useMemo } from 'react'
 import { CtaAlert } from '@sourcegraph/shared/src/components/CtaAlert'
 
 import { ExtensionRadialGradientIcon } from '../../components/CtaIcons'
-import { IS_CHROME } from '../../marketing/util'
 import { eventLogger } from '../../tracking/eventLogger'
 
 interface Props {
@@ -12,12 +11,24 @@ interface Props {
     onAlertDismissed: () => void
 }
 
+const UA = navigator.userAgent
+const BROWSER: 'chrome' | 'safari' | 'firefox' | 'other' = UA.match(/chrome|chromium|crios/i)
+    ? 'chrome'
+    : UA.match(/firefox|fxios/i)
+    ? 'firefox'
+    : UA.match(/safari/i)
+    ? 'safari'
+    : 'other'
+
 const CHROME_LINK = 'https://chrome.google.com/webstore/detail/sourcegraph/dgjhfomjieaadpoljlnidmbgkdffpack'
 const SAFARI_LINK = 'https://apps.apple.com/us/app/sourcegraph-for-safari/id1543262193'
 const FIREFOX_LINK = 'https://addons.mozilla.org/en-US/firefox/addon/sourcegraph-for-firefox/'
 
+const LEARN_MORE_LINK =
+    'https://docs.sourcegraph.com/integration/browser_extension?utm_campaign=search-results-cta&utm_medium=direct_traffic&utm_source=in-product&utm_term=null&utm_content=install-browser-exten'
+
 export const BrowserExtensionAlert: React.FunctionComponent<Props> = ({ className, page, onAlertDismissed }) => {
-    const args = useMemo(() => ({ page }), [page])
+    const args = useMemo(() => ({ page, browser: BROWSER }), [page])
 
     useEffect(() => {
         eventLogger.log('InstallBrowserExtensionCTAShown', args, args)
@@ -31,23 +42,34 @@ export const BrowserExtensionAlert: React.FunctionComponent<Props> = ({ classNam
         eventLogger.log('InstallBrowserExtensionLearnClicked', args, args)
     }, [args])
 
+    const cta = {
+        label: BROWSER !== 'other' ? 'Install now' : 'Learn more',
+        href:
+            BROWSER === 'chrome'
+                ? CHROME_LINK
+                : BROWSER === 'safari'
+                ? SAFARI_LINK
+                : BROWSER === 'firefox'
+                ? FIREFOX_LINK
+                : LEARN_MORE_LINK,
+        onClick: BROWSER !== 'other' ? onBrowserExtensionPrimaryClick : onBrowserExtensionSecondaryClick,
+    }
+
+    const secondary =
+        BROWSER !== 'other'
+            ? {
+                  label: 'Learn more',
+                  href: LEARN_MORE_LINK,
+                  onClick: onBrowserExtensionSecondaryClick,
+              }
+            : undefined
+
     return (
         <CtaAlert
             title="Get more from Sourcegraph with the browser extension"
             description="Add code intelligence to pull requests and file views on GitHub, GitLab, Bitbucket Server, and Phabricator."
-            cta={{
-                label: 'Install now',
-                href: IS_CHROME
-                    ? SAFARI_LINK
-                    : 'https://docs.sourcegraph.com/integration/browser_extension?utm_campaign=search-results-cta&utm_medium=direct_traffic&utm_source=in-product&utm_term=null&utm_content=install-browser-exten',
-                onClick: onBrowserExtensionPrimaryClick,
-            }}
-            secondary={{
-                label: 'Learn more',
-                href:
-                    'https://docs.sourcegraph.com/integration/browser_extension?utm_campaign=search-results-cta&utm_medium=direct_traffic&utm_source=in-product&utm_term=null&utm_content=install-browser-exten',
-                onClick: onBrowserExtensionSecondaryClick,
-            }}
+            cta={cta}
+            secondary={secondary}
             icon={<ExtensionRadialGradientIcon />}
             className={className}
             onClose={onAlertDismissed}

--- a/client/web/src/repo/actions/IdeExtensionAlert.tsx
+++ b/client/web/src/repo/actions/IdeExtensionAlert.tsx
@@ -27,7 +27,7 @@ export const IDEExtensionAlert: React.FunctionComponent<Props> = ({ className, p
             title="The power of Sourcegraph in your IDE"
             description="Link your editor and Sourcegraph to improve your ability to reference and reuse code across multiple repositories."
             cta={{
-                label: 'Learn more about IDE extensions',
+                label: 'Learn more',
                 href:
                     'https://docs.sourcegraph.com/integration/editor?utm_medium=inproduct&utm_source=search-results&utm_campaign=inproduct-cta&utm_term=null',
                 onClick: onIDEExtensionClick,

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -93,6 +93,7 @@ function useCtaAlert(
     ctaToDisplay?: CtaToDisplay
     onCtaAlertDismissed: () => void
 } {
+    return { ctaToDisplay: 'browser', onCtaAlertDismissed: () => {} }
     const [hasDismissedSignupAlert, setHasDismissedSignupAlert] = useLocalStorage<boolean>(
         'StreamingSearchResults.hasDismissedSignupAlert',
         false

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -93,7 +93,6 @@ function useCtaAlert(
     ctaToDisplay?: CtaToDisplay
     onCtaAlertDismissed: () => void
 } {
-    return { ctaToDisplay: 'browser', onCtaAlertDismissed: () => {} }
     const [hasDismissedSignupAlert, setHasDismissedSignupAlert] = useLocalStorage<boolean>(
         'StreamingSearchResults.hasDismissedSignupAlert',
         false


### PR DESCRIPTION
Closes #32287

This implements the changes of #32287. The IDE banner is left mostly as-is since we have no way of detecting in the browser which IDE is installed, unfortunatly.

For the browser extension we fall back to a very simple user agent test that works for the browser I have tested with (All latest desktop version of Firefox, Chrome, and Safari).  

We also add the browser to the events logged in the BExt CTA so we can know if there is something particularly interesting to optimize later. 

## Test plan

###  IDE CTA
![IDE](https://user-images.githubusercontent.com/458591/157426610-fedee7ae-231e-4c3f-88e6-94c1822ed800.png)

### BExt Firefox

![Firefox](https://user-images.githubusercontent.com/458591/157426611-10fb7998-7948-4110-9d5a-fae675083f44.png)

### BExt Chrome

![Chrome](https://user-images.githubusercontent.com/458591/157426613-9106be2f-f736-4509-814d-31bf0dbed552.png)

### BExt Safari

![Safari](https://user-images.githubusercontent.com/458591/157426602-0ca5d3e0-d3e5-4cb0-919e-03a8ddaae845.png)

### BExt Unknown

![Unknown](https://user-images.githubusercontent.com/458591/157426593-cb05e2e4-c534-4fa9-84fb-549ff1e515b3.png)

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


