### PR TITLE
Update spacing following h4s in notices

### DIFF
--- a/client/wildcard/src/components/Alert/Alert.module.scss
+++ b/client/wildcard/src/components/Alert/Alert.module.scss
@@ -13,6 +13,10 @@
     }
 }
 
+.alert h4 {
+    margin-bottom: 0.25rem;
+}
+
 .alert-primary,
 .alert-secondary,
 .alert-success,


### PR DESCRIPTION
Update `Alert` component to reduce spacing after `h4` elements and bring in line with the [alerts in the Wildcard design library](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/Wildcard-Design-System?node-id=5606%3A40766).

## Test plan

Visual regression testing.