### PR TITLE
Notify user that they need to update their personal Code host connection

### DIFF
--- a/client/web/src/integration/batches.test.ts
+++ b/client/web/src/integration/batches.test.ts
@@ -267,6 +267,7 @@ function mockCommonGraphQLResponses(
                 viewerCanAdminister: true,
                 viewerIsMember: false,
                 viewerPendingInvitation: null,
+                viewerNeedsCodeHostUpdate:false,
             },
         }),
         UserAreaUserProfile: () => ({

--- a/client/web/src/integration/batches.test.ts
+++ b/client/web/src/integration/batches.test.ts
@@ -267,7 +267,7 @@ function mockCommonGraphQLResponses(
                 viewerCanAdminister: true,
                 viewerIsMember: false,
                 viewerPendingInvitation: null,
-                viewerNeedsCodeHostUpdate:false,
+                viewerNeedsCodeHostUpdate: false,
             },
         }),
         UserAreaUserProfile: () => ({

--- a/client/web/src/integration/org.test.ts
+++ b/client/web/src/integration/org.test.ts
@@ -25,7 +25,7 @@ describe('Organizations', () => {
         viewerCanAdminister: true,
         viewerIsMember: false,
         viewerPendingInvitation: null,
-        viewerNeedsCodeHostUpdate:false,
+        viewerNeedsCodeHostUpdate: false,
     })
 
     let driver: Driver

--- a/client/web/src/integration/org.test.ts
+++ b/client/web/src/integration/org.test.ts
@@ -25,6 +25,7 @@ describe('Organizations', () => {
         viewerCanAdminister: true,
         viewerIsMember: false,
         viewerPendingInvitation: null,
+        viewerNeedsCodeHostUpdate:false,
     })
 
     let driver: Driver

--- a/client/web/src/org/area/OrgArea.tsx
+++ b/client/web/src/org/area/OrgArea.tsx
@@ -70,6 +70,7 @@ function queryOrganization(args: {
                 }
                 viewerIsMember
                 viewerCanAdminister
+                viewerNeedsCodeHostUpdate
                 createdAt
             }
         `,

--- a/client/web/src/search/panels/utils.ts
+++ b/client/web/src/search/panels/utils.ts
@@ -57,6 +57,7 @@ export const org: IOrg = {
     viewerPendingInvitation: null,
     viewerCanAdminister: true,
     viewerIsMember: true,
+    viewerNeedsCodeHostUpdate: false,
     url: '/organizations/test-org',
     settingsURL: '/organizations/test-org/settings',
     namespaceName: 'test-org',

--- a/client/web/src/user/settings/codeHosts/OrgUserNeedsGithubUpgrade.tsx
+++ b/client/web/src/user/settings/codeHosts/OrgUserNeedsGithubUpgrade.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+
+import { Container, Button, Link } from '@sourcegraph/wildcard'
+
+export interface OrgUserNeedsGithubUpgrade {
+    orgDisplayName: string
+    user: {
+        id: string
+        username: string
+    }
+}
+
+export const OrgUserNeedsGithubUpgrade: React.FunctionComponent<OrgUserNeedsGithubUpgrade> = ({
+    user,
+    orgDisplayName,
+}) => (
+    <Container className="mb-4">
+        <h3>Just one more step...</h3>
+        <p>
+            Upgrade your GitHub code-host connection to start searching across the {orgDisplayName} organization's
+            private repositories on Sourcegraph.
+        </p>
+        <Button to={`/users/${user.username}/settings/code-hosts`} variant="primary" as={Link}>
+            Connect with Github
+        </Button>
+    </Container>
+)

--- a/client/web/src/user/settings/codeHosts/OrgUserNeedsGithubUpgrade.tsx
+++ b/client/web/src/user/settings/codeHosts/OrgUserNeedsGithubUpgrade.tsx
@@ -15,7 +15,6 @@ export const OrgUserNeedsGithubUpgrade: React.FunctionComponent<OrgUserNeedsGith
     orgDisplayName,
 }) => (
     <Container className="mb-4">
-        <h3>Just one more step...</h3>
         <p>
             Upgrade your GitHub code-host connection to start searching across the {orgDisplayName} organization's
             private repositories on Sourcegraph.

--- a/client/web/src/user/settings/codeHosts/OrgUserNeedsGithubUpgrade.tsx
+++ b/client/web/src/user/settings/codeHosts/OrgUserNeedsGithubUpgrade.tsx
@@ -1,26 +1,16 @@
 import React from 'react'
 
-import { Container, Button, Link } from '@sourcegraph/wildcard'
+import { Alert, Link } from '@sourcegraph/wildcard'
 
-export interface OrgUserNeedsGithubUpgrade {
-    orgDisplayName: string
-    user: {
-        id: string
-        username: string
-    }
-}
+import { updateGitHubApp } from './UserAddCodeHostsPage'
 
-export const OrgUserNeedsGithubUpgrade: React.FunctionComponent<OrgUserNeedsGithubUpgrade> = ({
-    user,
-    orgDisplayName,
-}) => (
-    <Container className="mb-4">
-        <p>
-            Upgrade your GitHub code-host connection to start searching across the {orgDisplayName} organization's
-            private repositories on Sourcegraph.
-        </p>
-        <Button to={`/users/${user.username}/settings/code-hosts`} variant="primary" as={Link}>
-            Connect with Github
-        </Button>
-    </Container>
+export interface OrgUserNeedsGithubUpgrade {}
+
+export const OrgUserNeedsGithubUpgrade: React.FunctionComponent<OrgUserNeedsGithubUpgrade> = () => (
+    <Alert className="mb-4" role="alert" variant="warning">
+        <h4>Update your code host connection with GitHub</h4>
+        We’ve changed how we sync repositories with GitHub. Please{' '}
+        <Link onClick={updateGitHubApp}>update your code host connection</Link> with GitHub to continue searching across
+        your organization’s private repositories on Sourcegraph.
+    </Alert>
 )

--- a/client/web/src/user/settings/codeHosts/OrgUserNeedsGithubUpgrade.tsx
+++ b/client/web/src/user/settings/codeHosts/OrgUserNeedsGithubUpgrade.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { Alert, Link } from '@sourcegraph/wildcard'
+import { Alert, ButtonLink } from '@sourcegraph/wildcard'
 
 import { updateGitHubApp } from './UserAddCodeHostsPage'
 
@@ -10,7 +10,9 @@ export const OrgUserNeedsGithubUpgrade: React.FunctionComponent<OrgUserNeedsGith
     <Alert className="mb-4" role="alert" variant="warning">
         <h4>Update your code host connection with GitHub</h4>
         We’ve changed how we sync repositories with GitHub. Please{' '}
-        <Link onClick={updateGitHubApp}>update your code host connection</Link> with GitHub to continue searching across
-        your organization’s private repositories on Sourcegraph.
+        <ButtonLink onClick={updateGitHubApp} variant="link" display="inline" className="align-baseline m-0 p-0">
+            update your code host connection
+        </ButtonLink>{' '}
+        with GitHub to continue searching across your organization’s private repositories on Sourcegraph.
     </Alert>
 )

--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -45,6 +45,14 @@ type Status = undefined | 'loading' | ServicesByKind | ErrorLike
 const isServicesByKind = (status: Status): status is ServicesByKind =>
     typeof status === 'object' && Object.keys(status).every(key => keyExistsIn(key, ExternalServiceKind))
 
+export const updateGitHubApp = (): void => {
+    window.location.assign(
+        `/.auth/github/login?pc=${encodeURIComponent(
+            `https://github.com/::${window.context.githubAppCloudClientID}`
+        )}&op=createCodeHostConnection&redirect=${window.location.href}`
+    )
+}
+
 export const ifNotNavigated = (callback: () => void, waitMS: number = 2000): void => {
     let timeoutID = 0
     let willNavigate = false
@@ -422,11 +430,7 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
                         }
                     }, 500)
                 } else {
-                    window.location.assign(
-                        `/.auth/github/login?pc=${encodeURIComponent(
-                            `https://github.com/::${window.context.githubAppCloudClientID}`
-                        )}&op=createCodeHostConnection&redirect=${window.location.href}`
-                    )
+                    updateGitHubApp()
                 }
             }
         },

--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -45,7 +45,10 @@ type Status = undefined | 'loading' | ServicesByKind | ErrorLike
 const isServicesByKind = (status: Status): status is ServicesByKind =>
     typeof status === 'object' && Object.keys(status).every(key => keyExistsIn(key, ExternalServiceKind))
 
-export const updateGitHubApp = (): void => {
+export const updateGitHubApp = (event?: { preventDefault(): void }): void => {
+    if (event) {
+        event.preventDefault()
+    }
     window.location.assign(
         `/.auth/github/login?pc=${encodeURIComponent(
             `https://github.com/::${window.context.githubAppCloudClientID}`

--- a/client/web/src/user/settings/repositories/SettingsRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/SettingsRepositoriesPage.tsx
@@ -338,10 +338,9 @@ export const SettingsRepositoriesPage: React.FunctionComponent<Props> = ({
                     orgDisplayName={owner.name}
                 />
             )}
-            {!isUserOwner && authenticatedUser && org && org.viewerNeedsCodeHostUpdate && (
-                <OrgUserNeedsGithubUpgrade user={authenticatedUser} />
+            {!isUserOwner && authenticatedUser && org && org.viewerNeedsCodeHostUpdate && org.displayName && (
+                <OrgUserNeedsGithubUpgrade user={authenticatedUser} orgDisplayName={org.displayName} />
             )}
-
             <PageTitle title="Your repositories" />
             <PageHeader
                 headingElement="h2"

--- a/client/web/src/user/settings/repositories/SettingsRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/SettingsRepositoriesPage.tsx
@@ -36,6 +36,7 @@ import {
     CodeHostSyncDueResult,
     CodeHostSyncDueVariables,
     RepositoriesResult,
+    OrgAreaOrganizationFields,
 } from '../../../graphql-operations'
 import {
     listUserRepositories,
@@ -47,6 +48,7 @@ import { eventLogger } from '../../../tracking/eventLogger'
 import { UserExternalServicesOrRepositoriesUpdateProps } from '../../../util'
 import { Owner } from '../cloud-ga'
 import { OrgUserNeedsCodeHost } from '../codeHosts/OrgUserNeedsCodeHost'
+import { OrgUserNeedsGithubUpgrade } from '../codeHosts/OrgUserNeedsGithubUpgrade'
 
 import { UserSettingReposContainer } from './components'
 import { defaultFilters, RepositoriesList } from './RepositoriesList'
@@ -60,6 +62,7 @@ interface Props
     routingPrefix: string
     authenticatedUser: AuthenticatedUser
     onOrgGetStartedRefresh?: () => void
+    org?: OrgAreaOrganizationFields
 }
 
 type SyncStatusOrError = undefined | 'scheduled' | 'schedule-complete' | ErrorLike
@@ -74,6 +77,7 @@ export const SettingsRepositoriesPage: React.FunctionComponent<Props> = ({
     onUserExternalServicesOrRepositoriesUpdate,
     authenticatedUser,
     onOrgGetStartedRefresh,
+    org,
 }) => {
     const [hasRepos, setHasRepos] = useState(false)
     const [externalServices, setExternalServices] = useState<ExternalServicesResult['externalServices']['nodes']>()
@@ -333,6 +337,9 @@ export const SettingsRepositoriesPage: React.FunctionComponent<Props> = ({
                     orgExternalServices={externalServices}
                     orgDisplayName={owner.name}
                 />
+            )}
+            {!isUserOwner && authenticatedUser && org && org.viewerNeedsCodeHostUpdate && (
+                <OrgUserNeedsGithubUpgrade user={authenticatedUser} />
             )}
 
             <PageTitle title="Your repositories" />

--- a/client/web/src/user/settings/repositories/SettingsRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/SettingsRepositoriesPage.tsx
@@ -338,9 +338,7 @@ export const SettingsRepositoriesPage: React.FunctionComponent<Props> = ({
                     orgDisplayName={owner.name}
                 />
             )}
-            {!isUserOwner && authenticatedUser && org && org.viewerNeedsCodeHostUpdate && org.displayName && (
-                <OrgUserNeedsGithubUpgrade user={authenticatedUser} orgDisplayName={org.displayName} />
-            )}
+            {!isUserOwner && authenticatedUser && org && org.viewerNeedsCodeHostUpdate && <OrgUserNeedsGithubUpgrade />}
             <PageTitle title="Your repositories" />
             <PageHeader
                 headingElement="h2"

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -232,6 +232,48 @@ func (o *OrgResolver) ViewerIsMember(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
+func (o *OrgResolver) ViewerNeedsCodeHostUpdate(ctx context.Context) (bool, error) {
+	actor := actor.FromContext(ctx)
+	if !actor.IsAuthenticated() {
+		return false, nil
+	}
+	// enabled, err := o.db.FeatureFlags().GetOrgFeatureFlag(ctx, o.OrgID(), "github-app-cloud")
+	// if err != nil {
+	// 	return false, err
+	// } else if !enabled {
+	// 	return false, nil
+	// }
+	if _, err := o.db.OrgMembers().GetByOrgIDAndUserID(ctx, o.org.ID, actor.UID); err != nil {
+		return false, nil
+	}
+	orgServices, err := o.db.ExternalServices().List(ctx, database.ExternalServicesListOptions{NamespaceOrgID: o.OrgID()})
+	if err != nil {
+		return false, err
+	}
+	// no need to update
+	if len(orgServices) == 0 {
+		return false, nil
+	}
+	userServices, err := o.db.ExternalServices().List(ctx, database.ExternalServicesListOptions{NamespaceUserID: actor.UID})
+	if err != nil {
+		return false, err
+	}
+	// no need to update
+	if len(userServices) == 0 {
+		return false, nil
+	}
+	for _, os := range orgServices {
+		for _, us := range userServices {
+			if os.Kind == us.Kind {
+				if os.UpdatedAt.After(us.UpdatedAt) {
+					return true, nil
+				}
+			}
+		}
+	}
+	return false, nil
+}
+
 func (o *OrgResolver) NamespaceName() string { return o.org.Name }
 
 func (o *OrgResolver) BatchChanges(ctx context.Context, args *ListBatchChangesArgs) (BatchChangesConnectionResolver, error) {

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -238,12 +238,12 @@ func (o *OrgResolver) ViewerNeedsCodeHostUpdate(ctx context.Context) (bool, erro
 	if !actor.IsAuthenticated() {
 		return false, nil
 	}
-	// enabled, err := o.db.FeatureFlags().GetOrgFeatureFlag(ctx, o.OrgID(), "github-app-cloud")
-	// if err != nil {
-	// 	return false, err
-	// } else if !enabled {
-	// 	return false, nil
-	// }
+	enabled, err := o.db.FeatureFlags().GetOrgFeatureFlag(ctx, o.OrgID(), "github-app-cloud")
+	if err != nil {
+		return false, err
+	} else if !enabled {
+		return false, nil
+	}
 	if _, err := o.db.OrgMembers().GetByOrgIDAndUserID(ctx, o.org.ID, actor.UID); err != nil {
 		return false, nil
 	}

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -246,25 +247,26 @@ func (o *OrgResolver) ViewerNeedsCodeHostUpdate(ctx context.Context) (bool, erro
 	if _, err := o.db.OrgMembers().GetByOrgIDAndUserID(ctx, o.org.ID, actor.UID); err != nil {
 		return false, nil
 	}
-	orgServices, err := o.db.ExternalServices().List(ctx, database.ExternalServicesListOptions{NamespaceOrgID: o.OrgID()})
+	orgServices, err := o.db.ExternalServices().List(ctx, database.ExternalServicesListOptions{Kinds: []string{extsvc.KindGitHub}, NamespaceOrgID: o.OrgID()})
 	if err != nil {
 		return false, err
 	}
-	// no need to update
 	if len(orgServices) == 0 {
+		// no need to update
 		return false, nil
 	}
-	userServices, err := o.db.ExternalServices().List(ctx, database.ExternalServicesListOptions{NamespaceUserID: actor.UID})
+	userServices, err := o.db.ExternalServices().List(ctx, database.ExternalServicesListOptions{Kinds: []string{extsvc.KindGitHub}, NamespaceUserID: actor.UID})
 	if err != nil {
 		return false, err
 	}
 	// no need to update
 	if len(userServices) == 0 {
+		// no need to update
 		return false, nil
 	}
 	for _, os := range orgServices {
 		for _, us := range userServices {
-			if os.Kind == us.Kind {
+			if os.Kind == extsvc.KindGitHub && us.Kind == extsvc.KindGitHub {
 				if os.UpdatedAt.After(us.UpdatedAt) {
 					return true, nil
 				}

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -266,7 +266,7 @@ func (o *OrgResolver) ViewerNeedsCodeHostUpdate(ctx context.Context) (bool, erro
 	for _, os := range orgServices {
 		for _, us := range userServices {
 			if os.Kind == extsvc.KindGitHub && us.Kind == extsvc.KindGitHub {
-				if os.UpdatedAt.After(us.UpdatedAt) {
+				if os.CreatedAt.After(us.UpdatedAt) {
 					return true, nil
 				}
 			}

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -259,7 +259,6 @@ func (o *OrgResolver) ViewerNeedsCodeHostUpdate(ctx context.Context) (bool, erro
 	if err != nil {
 		return false, err
 	}
-	// no need to update
 	if len(userServices) == 0 {
 		// no need to update
 		return false, nil

--- a/cmd/frontend/graphqlbackend/org_test.go
+++ b/cmd/frontend/graphqlbackend/org_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/gofrs/uuid"
 	"github.com/graph-gophers/graphql-go/errors"
@@ -18,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -567,4 +569,90 @@ func TestUnmarshalOrgID(t *testing.T) {
 		_, err := UnmarshalOrgID(namespaceOrgID)
 		assert.Error(t, err)
 	})
+}
+
+func TestOrganization_viewerNeedsCodeHostUpdate(t *testing.T) {
+	ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
+	featureFlags := database.NewMockFeatureFlagStore()
+	featureFlags.GetOrgFeatureFlagFunc.SetDefaultReturn(true, nil)
+	users := database.NewStrictMockUserStore()
+	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 1}, nil)
+	orgs := database.NewMockOrgStore()
+	mockedOrg := types.Org{ID: 1, Name: "acme"}
+	orgs.GetByNameFunc.SetDefaultReturn(&mockedOrg, nil)
+	orgs.GetByIDFunc.SetDefaultReturn(&mockedOrg, nil)
+	for name, test := range map[string]struct {
+		OrgServices  []*types.ExternalService
+		UserServices []*types.ExternalService
+		OrgMembers   *types.OrgMembership
+		Expected     string
+	}{
+		"not a member": {
+			Expected: `{"organization":{"viewerNeedsCodeHostUpdate":false}}`,
+		},
+		"member and org without service": {
+			OrgMembers: &types.OrgMembership{OrgID: 1, UserID: 1},
+			Expected:   `{"organization":{"viewerNeedsCodeHostUpdate":false}}`,
+		},
+		"member without service, org with service": {
+			OrgServices:  []*types.ExternalService{{Kind: extsvc.KindGitHub}},
+			UserServices: []*types.ExternalService{},
+			OrgMembers:   &types.OrgMembership{OrgID: 1, UserID: 1},
+			Expected:     `{"organization":{"viewerNeedsCodeHostUpdate":false}}`,
+		},
+		"member with service, org without service": {
+			OrgServices:  []*types.ExternalService{{Kind: extsvc.KindGitHub}},
+			UserServices: []*types.ExternalService{},
+			OrgMembers:   &types.OrgMembership{OrgID: 1, UserID: 1},
+			Expected:     `{"organization":{"viewerNeedsCodeHostUpdate":false}}`,
+		},
+		"member with service, org with older service": {
+			OrgServices:  []*types.ExternalService{{Kind: extsvc.KindGitHub, UpdatedAt: time.Now().Add(-1 * time.Hour)}},
+			UserServices: []*types.ExternalService{{Kind: extsvc.KindGitHub, UpdatedAt: time.Now()}},
+			OrgMembers:   &types.OrgMembership{OrgID: 1, UserID: 1},
+			Expected:     `{"organization":{"viewerNeedsCodeHostUpdate":false}}`,
+		},
+		"member with service, org with newer service": {
+			OrgServices:  []*types.ExternalService{{Kind: extsvc.KindGitHub, UpdatedAt: time.Now().Add(-1 * time.Hour)}},
+			UserServices: []*types.ExternalService{{Kind: extsvc.KindGitHub, UpdatedAt: time.Now().Add(-2 * time.Hour)}},
+			OrgMembers:   &types.OrgMembership{OrgID: 1, UserID: 1},
+			Expected:     `{"organization":{"viewerNeedsCodeHostUpdate":true}}`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			orgMembers := database.NewStrictMockOrgMemberStore()
+			orgMembers.GetByOrgIDAndUserIDFunc.SetDefaultReturn(test.OrgMembers, nil)
+			externalServices := database.NewStrictMockExternalServiceStore()
+			externalServices.ListFunc.SetDefaultHook(func(_ context.Context, opts database.ExternalServicesListOptions) ([]*types.ExternalService, error) {
+				if opts.NamespaceUserID == 1 {
+					return test.UserServices, nil
+				}
+				if opts.NamespaceOrgID == 1 {
+					return test.OrgServices, nil
+				}
+				return nil, nil
+			})
+			db := database.NewStrictMockDB()
+			db.UsersFunc.SetDefaultReturn(users)
+			db.OrgMembersFunc.SetDefaultReturn(orgMembers)
+			db.OrgsFunc.SetDefaultReturn(orgs)
+			db.FeatureFlagsFunc.SetDefaultReturn(featureFlags)
+			db.ExternalServicesFunc.SetDefaultReturn(externalServices)
+
+			RunTests(t, []*Test{
+				{
+					Schema:  mustParseGraphQLSchema(t, db),
+					Context: ctx,
+					Query: `
+					{
+						organization(name: "acme") {
+							viewerNeedsCodeHostUpdate
+						}
+					}
+				`,
+					ExpectedResult: test.Expected,
+				},
+			})
+		})
+	}
 }

--- a/cmd/frontend/graphqlbackend/org_test.go
+++ b/cmd/frontend/graphqlbackend/org_test.go
@@ -606,14 +606,14 @@ func TestOrganization_viewerNeedsCodeHostUpdate(t *testing.T) {
 			OrgMembers:   &types.OrgMembership{OrgID: 1, UserID: 1},
 			Expected:     `{"organization":{"viewerNeedsCodeHostUpdate":false}}`,
 		},
-		"member with service, org with older service": {
-			OrgServices:  []*types.ExternalService{{Kind: extsvc.KindGitHub, UpdatedAt: time.Now().Add(-1 * time.Hour)}},
+		"member with service, org with service created earlier": {
+			OrgServices:  []*types.ExternalService{{Kind: extsvc.KindGitHub, CreatedAt: time.Now().Add(-1 * time.Hour)}},
 			UserServices: []*types.ExternalService{{Kind: extsvc.KindGitHub, UpdatedAt: time.Now()}},
 			OrgMembers:   &types.OrgMembership{OrgID: 1, UserID: 1},
 			Expected:     `{"organization":{"viewerNeedsCodeHostUpdate":false}}`,
 		},
-		"member with service, org with newer service": {
-			OrgServices:  []*types.ExternalService{{Kind: extsvc.KindGitHub, UpdatedAt: time.Now().Add(-1 * time.Hour)}},
+		"member with service, org with service created later": {
+			OrgServices:  []*types.ExternalService{{Kind: extsvc.KindGitHub, CreatedAt: time.Now().Add(-1 * time.Hour)}},
 			UserServices: []*types.ExternalService{{Kind: extsvc.KindGitHub, UpdatedAt: time.Now().Add(-2 * time.Hour)}},
 			OrgMembers:   &types.OrgMembership{OrgID: 1, UserID: 1},
 			Expected:     `{"organization":{"viewerNeedsCodeHostUpdate":true}}`,

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -5092,6 +5092,10 @@ type Org implements Node & SettingsSubject & Namespace {
     """
     viewerIsMember: Boolean!
     """
+    Whether the viewer needs to update their code host connection.
+    """
+    viewerNeedsCodeHostUpdate: Boolean!
+    """
     The URL to the organization.
     """
     url: String!


### PR DESCRIPTION
Context in [CLOUD-316](https://sourcegraph.atlassian.net/browse/CLOUD-316) and [parent](https://sourcegraph.atlassian.net/browse/CLOUD-254). This shows an alert in Org repositories page - showing it in user Code Host page is left for CLOUD-317 (it required fanout across Orgs).
## Test plan

- [x] Tested manually in this [Loom](https://www.loom.com/share/2eb6d44b7f3c487c9176edf4f446cd58)
- [x] Added unit tests 
- [x] This is behind a feature flag

