### PR TITLE
Code Insights: Fix `hasInsights` api method and therefore smart redirect for the main insight page

### DIFF
--- a/client/web/src/enterprise/insights/core/backend/gql-api/code-insights-gql-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-api/code-insights-gql-backend.ts
@@ -116,15 +116,15 @@ export class CodeInsightsGqlBackend implements CodeInsightsBackend {
             this.apolloClient.query<HasAvailableCodeInsightResult>({
                 query: gql`
                     query HasAvailableCodeInsight {
-                        insightViews {
-                            pageInfo {
-                                hasNextPage
+                        insightViews(first: 1) {
+                            nodes {
+                                id
                             }
                         }
                     }
                 `,
             })
-        ).pipe(map(({ data }) => data.insightViews.pageInfo.hasNextPage))
+        ).pipe(map(({ data }) => data.insightViews.nodes.length > 0))
 
     // TODO: This method is used only for insight title validation but since we don't have
     // limitations about title field in gql api remove this method and async validation for

--- a/client/web/src/integration/insights/utils/override-insights-graphql-api.ts
+++ b/client/web/src/integration/insights/utils/override-insights-graphql-api.ts
@@ -70,7 +70,7 @@ export function overrideInsightsGraphQLApi(props: OverrideGraphQLExtensionsProps
         HasAvailableCodeInsight: () => ({
             insightViews: {
                 __typename: 'InsightViewConnection',
-                pageInfo: { __typename: 'PageInfo', hasNextPage: true },
+                nodes: [{ id: '001' }],
             },
         }),
         IsCodeInsightsLicensed: () => ({ __typename: 'Query', enterpriseLicenseHasFeature: true }),


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/32387

## Test plan
- Check that if you have at least one available to you insight you see the dashboard page when you click on the global nav item "Insights" 
- Check that you don't have any available insights you should have been redirected to the getting started page

## How did we miss this

Prior to this PR, we did rely on the page info object to determine do users have available to their insights or not. It always returns has next page and therefore we always saw redirections to the dashboard page. It has been fixed in this PR https://github.com/sourcegraph/sourcegraph/pull/30086 and now everything works as it should but it broke bad FE logic.  


