### PR TITLE
Migrate BExt and IDE dismissal to temporary settings

### DIFF
--- a/client/shared/src/settings/temporary/TemporarySettings.ts
+++ b/client/shared/src/settings/temporary/TemporarySettings.ts
@@ -22,6 +22,8 @@ export interface TemporarySettingsSchema {
     'homepage.userInvites.tab': number
     'integrations.vscode.lastDetectionTimestamp': number
     'integrations.jetbrains.lastDetectionTimestamp': number
+    'cta.browserExtensionAlertDismissed': boolean
+    'cta.ideExtensionAlertDismissed': boolean
 }
 
 /**

--- a/client/shared/src/settings/temporary/migrateLocalStorageToTemporarySettings.ts
+++ b/client/shared/src/settings/temporary/migrateLocalStorageToTemporarySettings.ts
@@ -35,6 +35,16 @@ const migrations: Migration[] = [
         temporarySettingsKey: 'signup.finishedWelcomeFlow',
         type: 'boolean',
     },
+    {
+        localStorageKey: 'hasDismissedBrowserExtensionAlert',
+        temporarySettingsKey: 'cta.browserExtensionAlertDismissed',
+        type: 'boolean',
+    },
+    {
+        localStorageKey: 'hasDismissedIdeExtensionAlert',
+        temporarySettingsKey: 'cta.ideExtensionAlertDismissed',
+        type: 'boolean',
+    },
 ]
 
 export async function migrateLocalStorageToTemporarySettings(storage: TemporarySettingsStorage): Promise<void> {

--- a/client/web/src/repo/actions/InstallIntegrationsAlert.tsx
+++ b/client/web/src/repo/actions/InstallIntegrationsAlert.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo } from 'react'
 
+import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { useLocalStorage, useObservable } from '@sourcegraph/wildcard'
 
 import { usePersistentCadence } from '../../hooks'
@@ -24,8 +25,6 @@ interface InstallIntegrationsAlertProps
 const CADENCE_KEY = 'InstallIntegrationsAlert.pageViews'
 const DISPLAY_CADENCE = 6
 const IDE_CTA_CADENCE_SHIFT = 3
-export const HAS_DISMISSED_BROWSER_EXTENSION_ALERT_KEY = 'hasDismissedBrowserExtensionAlert'
-export const HAS_DISMISSED_IDE_EXTENSION_ALERT_KEY = 'hasDismissedIdeExtensionAlert'
 
 type CtaToDisplay = 'browser' | 'ide'
 
@@ -45,12 +44,12 @@ export const InstallIntegrationsAlert: React.FunctionComponent<InstallIntegratio
     const isBrowserExtensionInstalled = useObservable<boolean>(browserExtensionInstalled)
     const isUsingIdeIntegration = useIsActiveIdeIntegrationUser()
     const [hoverCount] = useLocalStorage<number>(HOVER_COUNT_KEY, 0)
-    const [hasDismissedBrowserExtensionAlert, setHasDismissedBrowserExtensionAlert] = useLocalStorage<boolean>(
-        HAS_DISMISSED_BROWSER_EXTENSION_ALERT_KEY,
+    const [hasDismissedBrowserExtensionAlert, setHasDismissedBrowserExtensionAlert] = useTemporarySetting(
+        'cta.browserExtensionAlertDismissed',
         false
     )
-    const [hasDismissedIDEExtensionAlert, setHasDismissedIDEExtensionAlert] = useLocalStorage<boolean>(
-        HAS_DISMISSED_IDE_EXTENSION_ALERT_KEY,
+    const [hasDismissedIDEExtensionAlert, setHasDismissedIDEExtensionAlert] = useTemporarySetting(
+        'cta.ideExtensionAlertDismissed',
         false
     )
 
@@ -59,7 +58,7 @@ export const InstallIntegrationsAlert: React.FunctionComponent<InstallIntegratio
             if (
                 isBrowserExtensionInstalled === false &&
                 displayBrowserExtensionCTABasedOnCadence &&
-                !hasDismissedBrowserExtensionAlert &&
+                hasDismissedBrowserExtensionAlert === false &&
                 hoverCount >= HOVER_THRESHOLD
             ) {
                 return 'browser'
@@ -68,7 +67,7 @@ export const InstallIntegrationsAlert: React.FunctionComponent<InstallIntegratio
             if (
                 isUsingIdeIntegration === false &&
                 displayIDEExtensionCTABasedOnCadence &&
-                !hasDismissedIDEExtensionAlert
+                hasDismissedIDEExtensionAlert === false
             ) {
                 return 'ide'
             }

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -16,6 +16,7 @@ import { collectMetrics } from '@sourcegraph/shared/src/search/query/metrics'
 import { sanitizeQueryForTelemetry, updateFilters } from '@sourcegraph/shared/src/search/query/transformer'
 import { StreamSearchOptions } from '@sourcegraph/shared/src/search/stream'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { buildGetStartedURL } from '@sourcegraph/shared/src/util/url'
@@ -34,10 +35,6 @@ import { CodeInsightsProps } from '../../insights/types'
 import { isCodeInsightsEnabled } from '../../insights/utils/is-code-insights-enabled'
 import { BrowserExtensionAlert } from '../../repo/actions/BrowserExtensionAlert'
 import { IDEExtensionAlert } from '../../repo/actions/IdeExtensionAlert'
-import {
-    HAS_DISMISSED_BROWSER_EXTENSION_ALERT_KEY,
-    HAS_DISMISSED_IDE_EXTENSION_ALERT_KEY,
-} from '../../repo/actions/InstallIntegrationsAlert'
 import { SavedSearchModal } from '../../savedSearches/SavedSearchModal'
 import {
     useExperimentalFeatures,
@@ -97,12 +94,12 @@ function useCtaAlert(
         'StreamingSearchResults.hasDismissedSignupAlert',
         false
     )
-    const [hasDismissedBrowserExtensionAlert, setHasDismissedBrowserExtensionAlert] = useLocalStorage<boolean>(
-        HAS_DISMISSED_BROWSER_EXTENSION_ALERT_KEY,
+    const [hasDismissedBrowserExtensionAlert, setHasDismissedBrowserExtensionAlert] = useTemporarySetting(
+        'cta.browserExtensionAlertDismissed',
         false
     )
-    const [hasDismissedIDEExtensionAlert, setHasDismissedIDEExtensionAlert] = useLocalStorage<boolean>(
-        HAS_DISMISSED_IDE_EXTENSION_ALERT_KEY,
+    const [hasDismissedIDEExtensionAlert, setHasDismissedIDEExtensionAlert] = useTemporarySetting(
+        'cta.ideExtensionAlertDismissed',
         false
     )
     const isBrowserExtensionInstalled = useObservable<boolean>(browserExtensionInstalled)
@@ -128,7 +125,7 @@ function useCtaAlert(
         }
 
         if (
-            !hasDismissedBrowserExtensionAlert &&
+            hasDismissedBrowserExtensionAlert === false &&
             isAuthenticated &&
             isBrowserExtensionInstalled === false &&
             displaySignupAndBrowserExtensionCTAsBasedOnCadence
@@ -136,7 +133,11 @@ function useCtaAlert(
             return 'browser'
         }
 
-        if (isUsingIdeIntegration === false && displayIDEExtensionCTABasedOnCadence && !hasDismissedIDEExtensionAlert) {
+        if (
+            isUsingIdeIntegration === false &&
+            displayIDEExtensionCTABasedOnCadence &&
+            hasDismissedIDEExtensionAlert === false
+        ) {
             return 'ide'
         }
 


### PR DESCRIPTION
This PR addresses a further issue with the current BExt and IDe CTAs: When the banner is dismissed, we will currently only store it inside `localStorage`. To remember this config per-user, we should instead use temporary settings (for logged out users, the behavior is the same).

## Test plan

I made sure that the preference is now saved in GraphQL: 

![Screenshot 2022-03-09 at 12 22 14](https://user-images.githubusercontent.com/458591/157478507-58f0f50e-7790-435a-93c6-0dca3864e21f.png)


<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


