### PR TITLE
Code Insights: Add the demo banner for code insights pages 

### DIFF
--- a/client/web/src/enterprise/insights/components/code-insights-page/CodeInsightsPage.tsx
+++ b/client/web/src/enterprise/insights/components/code-insights-page/CodeInsightsPage.tsx
@@ -1,0 +1,23 @@
+import React, { useContext, useMemo } from 'react'
+
+import { Page } from '../../../../components/Page'
+import { CodeInsightsBackendContext } from '../../core/backend/code-insights-backend-context'
+import { CodeInsightsLimitAccessBanner } from '../limit-access-banner/CodeInsightsLimitAccessBanner'
+
+interface CodeInsightsPageProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+/**
+ * Shared common component for creation a typical code insights pages. Contains common styles
+ * and demo mode banner in order to render it across all pages.
+ */
+export const CodeInsightsPage: React.FunctionComponent<CodeInsightsPageProps> = props => {
+    const { getUiFeatures } = useContext(CodeInsightsBackendContext)
+    const { licensed } = useMemo(() => getUiFeatures(), [getUiFeatures])
+
+    return (
+        <Page {...props}>
+            {!licensed && <CodeInsightsLimitAccessBanner className="mb-3" />}
+            {props.children}
+        </Page>
+    )
+}

--- a/client/web/src/enterprise/insights/components/limit-access-banner/CodeInsightsLimitAccessBanner.module.scss
+++ b/client/web/src/enterprise/insights/components/limit-access-banner/CodeInsightsLimitAccessBanner.module.scss
@@ -1,0 +1,11 @@
+.banner {
+    background: var(--marketing-gradient);
+    padding: 0.25rem;
+    border-radius: 5px;
+}
+
+.content {
+    background-color: var(--body-bg);
+    border-radius: var(--border-radius);
+    padding: 0.5rem;
+}

--- a/client/web/src/enterprise/insights/components/limit-access-banner/CodeInsightsLimitAccessBanner.tsx
+++ b/client/web/src/enterprise/insights/components/limit-access-banner/CodeInsightsLimitAccessBanner.tsx
@@ -1,0 +1,20 @@
+import classNames from 'classnames'
+import React from 'react'
+
+import { Link } from '@sourcegraph/wildcard'
+
+import styles from './CodeInsightsLimitAccessBanner.module.scss'
+
+interface CodeInsightsLimitAccessBannerProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const CodeInsightsLimitAccessBanner: React.FunctionComponent<CodeInsightsLimitAccessBannerProps> = props => (
+    <div {...props} className={classNames(styles.banner, props.className)}>
+        <div className={styles.content}>
+            <h4>You’re currently viewing a demo version of Code Insights</h4>
+            <span>
+                Contact your admin or <Link to="mailto:support@sourcegraph.com">reach out to us</Link> to upgrade your
+                licence for unlimited insights and dashboards.
+            </span>
+        </div>
+    </div>
+)

--- a/client/web/src/enterprise/insights/components/limit-access-banner/CodeInsightsLimitAccessBanner.tsx
+++ b/client/web/src/enterprise/insights/components/limit-access-banner/CodeInsightsLimitAccessBanner.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames'
 import React from 'react'
 
-import { Link } from '@sourcegraph/wildcard'
+import { Badge, Link } from '@sourcegraph/wildcard'
 
 import styles from './CodeInsightsLimitAccessBanner.module.scss'
 
@@ -10,11 +10,23 @@ interface CodeInsightsLimitAccessBannerProps extends React.HTMLAttributes<HTMLDi
 export const CodeInsightsLimitAccessBanner: React.FunctionComponent<CodeInsightsLimitAccessBannerProps> = props => (
     <div {...props} className={classNames(styles.banner, props.className)}>
         <div className={styles.content}>
-            <h4>You’re currently viewing a demo version of Code Insights</h4>
-            <span>
-                Contact your admin or <Link to="mailto:support@sourcegraph.com">reach out to us</Link> to upgrade your
-                licence for unlimited insights and dashboards.
-            </span>
+            <Badge variant="merged" className="mb-2">
+                LIMITED ACCESS
+            </Badge>
+            <p className="m-0">
+                Contact your admin or{' '}
+                <Link
+                    to="https://about.sourcegraph.com/contact/request-code-insights-demo?utm_medium=direct-traffic&utm_source=in-product&utm_campaign=code-insights-getting-started"
+                    target="_blank"
+                    rel="noopener"
+                >
+                    reach out to us
+                </Link>{' '}
+                to upgrade your Sourcegraph license to unlock Code Insights for unlimited insights and dashboards.{' '}
+                <Link to="/help/code_insights" rel="noopener noreferrer" target="_blank">
+                    Learn more
+                </Link>
+            </p>
         </div>
     </div>
 )

--- a/client/web/src/enterprise/insights/core/backend/code-insights-backend-context.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-backend-context.ts
@@ -6,6 +6,9 @@ import { CodeInsightsBackend } from './code-insights-backend'
 import { RepositorySuggestionData } from './code-insights-backend-types'
 
 const errorMockMethod = (methodName: string) => () => throwError(new Error(`Implement ${methodName} method first`))
+const errorMockSyncMethod = (methodName: string) => () => {
+    throw new Error(`Implement ${methodName} method first`)
+}
 
 /**
  * Default context api class. Provides mock methods only.
@@ -54,7 +57,7 @@ export class FakeDefaultCodeInsightsBackend implements CodeInsightsBackend {
     public getFirstExampleRepository = errorMockMethod('getFirstExampleRepository')
 
     // License check
-    public getUiFeatures = errorMockMethod('getUiFeatures')
+    public getUiFeatures = errorMockSyncMethod('getUiFeatures')
 }
 
 export const CodeInsightsBackendContext = React.createContext<CodeInsightsBackend>(new FakeDefaultCodeInsightsBackend())

--- a/client/web/src/enterprise/insights/core/backend/code-insights-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-backend.ts
@@ -152,7 +152,7 @@ export interface CodeInsightsBackend {
     getFirstExampleRepository: () => Observable<string>
 
     /**
-     * Returns a feaures object used to show/hide and enable/disable UI elements
+     * Returns a features object used to show/hide and enable/disable UI elements
      */
-    getUiFeatures: () => Observable<UiFeatures>
+    getUiFeatures: () => UiFeatures
 }

--- a/client/web/src/enterprise/insights/core/backend/gql-api/code-insights-gql-backend-limited.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-api/code-insights-gql-backend-limited.ts
@@ -1,12 +1,9 @@
-import { Observable, forkJoin, of } from 'rxjs'
-
 import { UiFeatures } from '../code-insights-backend'
 
 import { CodeInsightsGqlBackend } from './code-insights-gql-backend'
 
 export class CodeInsightsGqlBackendLimited extends CodeInsightsGqlBackend {
-    public getUiFeatures = (): Observable<UiFeatures> =>
-        forkJoin({
-            licensed: of(false),
-        })
+    public getUiFeatures = (): UiFeatures => ({
+        licensed: false,
+    })
 }

--- a/client/web/src/enterprise/insights/core/backend/gql-api/code-insights-gql-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-api/code-insights-gql-backend.ts
@@ -1,5 +1,5 @@
 import { ApolloCache, ApolloClient, ApolloQueryResult, gql } from '@apollo/client'
-import { forkJoin, from, Observable, of } from 'rxjs'
+import { from, Observable, of } from 'rxjs'
 import { map, mapTo, switchMap } from 'rxjs/operators'
 import { LineChartContent, PieChartContent } from 'sourcegraph'
 import {
@@ -476,10 +476,9 @@ export class CodeInsightsGqlBackend implements CodeInsightsBackend {
         )
     }
 
-    public getUiFeatures = (): Observable<UiFeatures> =>
-        forkJoin({
-            licensed: of(true),
-        })
+    public getUiFeatures = (): UiFeatures => ({
+        licensed: true,
+    })
 }
 
 const getRepositoryName = (

--- a/client/web/src/enterprise/insights/hooks/use-ui-features.test.tsx
+++ b/client/web/src/enterprise/insights/hooks/use-ui-features.test.tsx
@@ -1,6 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks'
 import React from 'react'
-import { of } from 'rxjs'
 
 import { CodeInsightsBackend } from '../core/backend/code-insights-backend'
 import { CodeInsightsBackendContext } from '../core/backend/code-insights-backend-context'
@@ -23,7 +22,7 @@ const UiFeatureWrapper: React.FunctionComponent<UiFeatureWrapperProps> = ({ mock
 describe('useUiFeatures', () => {
     test.each([true, false])('should return licensed: %s', licensed => {
         const mockApi: Partial<CodeInsightsBackend> = {
-            getUiFeatures: () => of({ licensed }),
+            getUiFeatures: () => ({ licensed }),
         }
         const wrapper: React.FunctionComponent = ({ children }) => (
             <UiFeatureWrapper mockApi={mockApi}>{children}</UiFeatureWrapper>

--- a/client/web/src/enterprise/insights/hooks/use-ui-features.ts
+++ b/client/web/src/enterprise/insights/hooks/use-ui-features.ts
@@ -1,7 +1,5 @@
 import { useContext, useMemo } from 'react'
 
-import { useObservable } from '@sourcegraph/wildcard'
-
 import { CodeInsightsBackendContext } from '../core/backend/code-insights-backend-context'
 
 export interface UseUiFeatures {
@@ -11,7 +9,7 @@ export interface UseUiFeatures {
 export function useUiFeatures(): UseUiFeatures {
     const { getUiFeatures } = useContext(CodeInsightsBackendContext)
 
-    const uiFeatures = useObservable(useMemo(() => getUiFeatures(), [getUiFeatures]))
+    const uiFeatures = useMemo(() => getUiFeatures(), [getUiFeatures])
 
     return {
         licensed: !!uiFeatures?.licensed,

--- a/client/web/src/enterprise/insights/modals/GaConfirmationModal.story.tsx
+++ b/client/web/src/enterprise/insights/modals/GaConfirmationModal.story.tsx
@@ -2,7 +2,6 @@ import { gql } from '@apollo/client'
 import { createMockClient } from '@apollo/client/testing'
 import { Meta } from '@storybook/react'
 import React from 'react'
-import { of } from 'rxjs'
 
 import { TemporarySettingsContext } from '@sourcegraph/shared/src/settings/temporary/TemporarySettingsProvider'
 import {
@@ -28,7 +27,7 @@ const settingsClient = createMockClient(
 )
 
 class CodeInsightExampleBackend extends CodeInsightsGqlBackend {
-    public getUiFeatures = () => of({ licensed: false })
+    public getUiFeatures = () => ({ licensed: false })
 }
 const api = new CodeInsightExampleBackend({} as any)
 

--- a/client/web/src/enterprise/insights/modals/GaConfirmationModal.tsx
+++ b/client/web/src/enterprise/insights/modals/GaConfirmationModal.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useMemo } from 'react'
 
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
-import { Button, Modal, Link, useObservable } from '@sourcegraph/wildcard'
+import { Button, Modal, Link } from '@sourcegraph/wildcard'
 
 import { CodeInsightsBackendContext } from '../core/backend/code-insights-backend-context'
 
@@ -11,7 +11,7 @@ import styles from './GaConfirmationModal.module.scss'
 export const GaConfirmationModal: React.FunctionComponent = () => {
     const [isGaAccepted, setGaAccepted] = useTemporarySetting('insights.freeGaAccepted', false)
     const { getUiFeatures } = useContext(CodeInsightsBackendContext)
-    const features = useObservable(useMemo(() => getUiFeatures(), [getUiFeatures]))
+    const features = useMemo(() => getUiFeatures(), [getUiFeatures])
 
     const showConfirmationModal = !features?.licensed && isGaAccepted === false
 

--- a/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
+++ b/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
@@ -1,16 +1,15 @@
 import PlusIcon from 'mdi-react/PlusIcon'
-import React, { useContext, useMemo, useEffect } from 'react'
+import React, { useEffect } from 'react'
 import { matchPath, useHistory } from 'react-router'
 import { useLocation } from 'react-router-dom'
 
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
-import { Button, Link, PageHeader, Tabs, TabList, Tab, Badge } from '@sourcegraph/wildcard'
+import { Button, Link, PageHeader, Tabs, TabList, Tab, Icon } from '@sourcegraph/wildcard'
 
 import { CodeInsightsIcon } from '../../../insights/Icons'
 import { CodeInsightsPage } from '../components/code-insights-page/CodeInsightsPage'
-import { CodeInsightsBackendContext } from '../core/backend/code-insights-backend-context'
 import { ALL_INSIGHTS_DASHBOARD_ID } from '../core/types/dashboard/virtual-dashboard'
 
 import { DashboardsContentPage } from './dashboards/dashboard-page/DashboardsContentPage'
@@ -51,9 +50,7 @@ export const CodeInsightsRootPage: React.FunctionComponent<CodeInsightsRootPageP
             path: `/insights${CodeInsightsRootPageURLPaths.CodeInsights}`,
         }) ?? {}
 
-    const { getUiFeatures } = useContext(CodeInsightsBackendContext)
     const [hasInsightPageBeenViewed, markMainPageAsViewed] = useTemporarySetting('insights.wasMainPageOpen', false)
-    const features = useMemo(() => getUiFeatures(), [getUiFeatures])
 
     const dashboardId = params?.dashboardId ?? ALL_INSIGHTS_DASHBOARD_ID
     const queryParameterDashboardId = query.get('dashboardId') ?? ALL_INSIGHTS_DASHBOARD_ID
@@ -75,11 +72,6 @@ export const CodeInsightsRootPage: React.FunctionComponent<CodeInsightsRootPageP
 
     return (
         <CodeInsightsPage>
-            {!features.licensed && (
-                <Badge variant="merged" className="mb-2">
-                    Demo
-                </Badge>
-            )}
             <PageHeader
                 path={[{ icon: CodeInsightsIcon }, { text: 'Insights' }]}
                 actions={

--- a/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
+++ b/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
@@ -6,10 +6,10 @@ import { useLocation } from 'react-router-dom'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
-import { Button, Link, PageHeader, Tabs, TabList, Tab, Badge, useObservable, Icon } from '@sourcegraph/wildcard'
+import { Button, Link, PageHeader, Tabs, TabList, Tab, Badge } from '@sourcegraph/wildcard'
 
-import { Page } from '../../../components/Page'
 import { CodeInsightsIcon } from '../../../insights/Icons'
+import { CodeInsightsPage } from '../components/code-insights-page/CodeInsightsPage'
 import { CodeInsightsBackendContext } from '../core/backend/code-insights-backend-context'
 import { ALL_INSIGHTS_DASHBOARD_ID } from '../core/types/dashboard/virtual-dashboard'
 
@@ -51,9 +51,9 @@ export const CodeInsightsRootPage: React.FunctionComponent<CodeInsightsRootPageP
             path: `/insights${CodeInsightsRootPageURLPaths.CodeInsights}`,
         }) ?? {}
 
-    const [hasInsightPageBeenViewed, markMainPageAsViewed] = useTemporarySetting('insights.wasMainPageOpen', false)
     const { getUiFeatures } = useContext(CodeInsightsBackendContext)
-    const features = useObservable(useMemo(() => getUiFeatures(), [getUiFeatures]))
+    const [hasInsightPageBeenViewed, markMainPageAsViewed] = useTemporarySetting('insights.wasMainPageOpen', false)
+    const features = useMemo(() => getUiFeatures(), [getUiFeatures])
 
     const dashboardId = params?.dashboardId ?? ALL_INSIGHTS_DASHBOARD_ID
     const queryParameterDashboardId = query.get('dashboardId') ?? ALL_INSIGHTS_DASHBOARD_ID
@@ -74,10 +74,10 @@ export const CodeInsightsRootPage: React.FunctionComponent<CodeInsightsRootPageP
     }, [hasInsightPageBeenViewed, markMainPageAsViewed])
 
     return (
-        <Page>
-            {!features?.licensed && (
-                <Badge variant="info" className="mb-2">
-                    Free trial
+        <CodeInsightsPage>
+            {!features.licensed && (
+                <Badge variant="merged" className="mb-2">
+                    Demo
                 </Badge>
             )}
             <PageHeader
@@ -115,6 +115,6 @@ export const CodeInsightsRootPage: React.FunctionComponent<CodeInsightsRootPageP
             {activeView === CodeInsightsRootPageTab.GettingStarted && (
                 <LazyCodeInsightsGettingStartedPage telemetryService={telemetryService} />
             )}
-        </Page>
+        </CodeInsightsPage>
     )
 }

--- a/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
@@ -7,9 +7,9 @@ import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryServi
 import { PageHeader, Container, Button, LoadingSpinner, useObservable, Link } from '@sourcegraph/wildcard'
 
 import { LoaderButton } from '../../../../../components/LoaderButton'
-import { Page } from '../../../../../components/Page'
 import { PageTitle } from '../../../../../components/PageTitle'
 import { CodeInsightsIcon } from '../../../components'
+import { CodeInsightsPage } from '../../../components/code-insights-page/CodeInsightsPage'
 import { FORM_ERROR, SubmissionErrors } from '../../../components/form/hooks/useForm'
 import { CodeInsightsBackendContext } from '../../../core/backend/code-insights-backend-context'
 
@@ -52,7 +52,7 @@ export const InsightsDashboardCreationPage: React.FunctionComponent<InsightsDash
     }
 
     return (
-        <Page className={classNames('col-8', styles.page)}>
+        <CodeInsightsPage className={classNames('col-8', styles.page)}>
             <PageTitle title="Add new dashboard" />
 
             <PageHeader path={[{ icon: CodeInsightsIcon }, { text: 'Add new dashboard' }]} />
@@ -92,6 +92,6 @@ export const InsightsDashboardCreationPage: React.FunctionComponent<InsightsDash
                     )}
                 </InsightsDashboardCreationContent>
             </Container>
-        </Page>
+        </CodeInsightsPage>
     )
 }

--- a/client/web/src/enterprise/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
@@ -9,9 +9,9 @@ import { Badge, Button, Container, LoadingSpinner, PageHeader, useObservable, Li
 import { AuthenticatedUser } from '../../../../../auth'
 import { HeroPage } from '../../../../../components/HeroPage'
 import { LoaderButton } from '../../../../../components/LoaderButton'
-import { Page } from '../../../../../components/Page'
 import { PageTitle } from '../../../../../components/PageTitle'
 import { CodeInsightsIcon } from '../../../components'
+import { CodeInsightsPage } from '../../../components/code-insights-page/CodeInsightsPage'
 import { FORM_ERROR, SubmissionErrors } from '../../../components/form/hooks/useForm'
 import { CodeInsightsBackendContext } from '../../../core/backend/code-insights-backend-context'
 import { CustomInsightDashboard, isVirtualDashboard } from '../../../core/types'
@@ -101,7 +101,7 @@ export const EditDashboardPage: React.FunctionComponent<EditDashboardPageProps> 
     const handleCancel = (): void => history.goBack()
 
     return (
-        <Page className={classNames('col-8', styles.page)}>
+        <CodeInsightsPage className={classNames('col-8', styles.page)}>
             <PageTitle title="Configure dashboard" />
 
             <PageHeader path={[{ icon: CodeInsightsIcon }, { text: 'Configure dashboard' }]} />
@@ -145,7 +145,7 @@ export const EditDashboardPage: React.FunctionComponent<EditDashboardPageProps> 
                     )}
                 </InsightsDashboardCreationContent>
             </Container>
-        </Page>
+        </CodeInsightsPage>
     )
 }
 

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/CaptureGroupCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/CaptureGroupCreationPage.tsx
@@ -3,8 +3,8 @@ import React, { useEffect } from 'react'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Link } from '@sourcegraph/wildcard'
 
-import { Page } from '../../../../../../components/Page'
 import { PageTitle } from '../../../../../../components/PageTitle'
+import { CodeInsightsPage } from '../../../../components/code-insights-page/CodeInsightsPage'
 import { FormChangeEvent, SubmissionErrors } from '../../../../components/form/hooks/useForm'
 import { CaptureGroupInsight } from '../../../../core/types'
 import { CodeInsightTrackType } from '../../../../pings'
@@ -58,7 +58,7 @@ export const CaptureGroupCreationPage: React.FunctionComponent<CaptureGroupCreat
     }
 
     return (
-        <Page>
+        <CodeInsightsPage>
             <PageTitle title="Create new capture group code insight" />
 
             <header className="mb-5">
@@ -80,6 +80,6 @@ export const CaptureGroupCreationPage: React.FunctionComponent<CaptureGroupCreat
                 onCancel={handleCancel}
                 onChange={handleChange}
             />
-        </Page>
+        </CodeInsightsPage>
     )
 }

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames'
 import React, { useEffect } from 'react'
 import { useHistory } from 'react-router'
 import { useLocation } from 'react-router-dom'
@@ -6,8 +5,8 @@ import { useLocation } from 'react-router-dom'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { PageHeader, Link } from '@sourcegraph/wildcard'
 
-import { Page } from '../../../../../../components/Page'
 import { CodeInsightsIcon } from '../../../../../../insights/Icons'
+import { CodeInsightsPage } from '../../../../components/code-insights-page/CodeInsightsPage'
 
 import {
     CaptureGroupInsightCard,
@@ -51,7 +50,7 @@ export const IntroCreationPage: React.FunctionComponent<IntroCreationPageProps> 
     }, [telemetryService])
 
     return (
-        <Page className={classNames('container pb-5', styles.container)}>
+        <CodeInsightsPage className={styles.container}>
             <PageHeader
                 path={[{ icon: CodeInsightsIcon }, { text: 'Create new code insight' }]}
                 description={
@@ -87,6 +86,6 @@ export const IntroCreationPage: React.FunctionComponent<IntroCreationPageProps> 
 
                 <ExtensionInsightsCard data-testid="explore-extensions" onClick={handleExploreExtensionsClick} />
             </div>
-        </Page>
+        </CodeInsightsPage>
     )
 }

--- a/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.tsx
@@ -5,8 +5,8 @@ import { asError } from '@sourcegraph/common'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useLocalStorage, Link } from '@sourcegraph/wildcard'
 
-import { Page } from '../../../../../../components/Page'
 import { PageTitle } from '../../../../../../components/PageTitle'
+import { CodeInsightsPage } from '../../../../components/code-insights-page/CodeInsightsPage'
 import { FORM_ERROR, FormChangeEvent } from '../../../../components/form/hooks/useForm'
 import { LangStatsInsight } from '../../../../core/types'
 import { CodeInsightTrackType } from '../../../../pings'
@@ -94,7 +94,7 @@ export const LangStatsInsightCreationPage: React.FunctionComponent<LangStatsInsi
     }
 
     return (
-        <Page className={classNames(styles.creationPage, 'col-10')}>
+        <CodeInsightsPage className={classNames(styles.creationPage, 'col-10')}>
             <PageTitle title="Create new code insight" />
 
             <div className="mb-5">
@@ -115,6 +115,6 @@ export const LangStatsInsightCreationPage: React.FunctionComponent<LangStatsInsi
                 onCancel={handleCancel}
                 onChange={handleChange}
             />
-        </Page>
+        </CodeInsightsPage>
     )
 }

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/SearchInsightCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/SearchInsightCreationPage.tsx
@@ -1,12 +1,11 @@
-import classNames from 'classnames'
 import React, { useCallback, useEffect } from 'react'
 
 import { asError } from '@sourcegraph/common'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, Link } from '@sourcegraph/wildcard'
 
-import { Page } from '../../../../../../components/Page'
 import { PageTitle } from '../../../../../../components/PageTitle'
+import { CodeInsightsPage } from '../../../../components/code-insights-page/CodeInsightsPage'
 import { FORM_ERROR, FormChangeEvent } from '../../../../components/form/hooks/useForm'
 import { SearchBasedInsight } from '../../../../core/types'
 import { CodeInsightTrackType } from '../../../../pings'
@@ -91,7 +90,7 @@ export const SearchInsightCreationPage: React.FunctionComponent<SearchInsightCre
     }, [telemetryService, setLocalStorageFormValues, onCancel])
 
     return (
-        <Page className={classNames(styles.creationPage)}>
+        <CodeInsightsPage className={styles.creationPage}>
             <PageTitle title="Create new code insight" />
 
             {loading && (
@@ -129,6 +128,6 @@ export const SearchInsightCreationPage: React.FunctionComponent<SearchInsightCre
                     </>
                 )
             }
-        </Page>
+        </CodeInsightsPage>
     )
 }

--- a/client/web/src/enterprise/insights/pages/insights/edit-insight/EditInsightPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/edit-insight/EditInsightPage.tsx
@@ -5,8 +5,8 @@ import { Badge, LoadingSpinner, useObservable, Link } from '@sourcegraph/wildcar
 
 import { AuthenticatedUser } from '../../../../../auth'
 import { HeroPage } from '../../../../../components/HeroPage'
-import { Page } from '../../../../../components/Page'
 import { PageTitle } from '../../../../../components/PageTitle'
+import { CodeInsightsPage } from '../../../components/code-insights-page/CodeInsightsPage'
 import { CodeInsightsBackendContext } from '../../../core/backend/code-insights-backend-context'
 import { isCaptureGroupInsight, isLangStatsInsight, isSearchBasedInsight } from '../../../core/types'
 
@@ -57,7 +57,7 @@ export const EditInsightPage: React.FunctionComponent<EditInsightPageProps> = pr
     }
 
     return (
-        <Page className="container">
+        <CodeInsightsPage>
             <PageTitle title="Edit code insight" />
 
             <div className="mb-5">
@@ -82,6 +82,6 @@ export const EditInsightPage: React.FunctionComponent<EditInsightPageProps> = pr
             {isLangStatsInsight(insight) && (
                 <EditLangStatsInsight insight={insight} onSubmit={handleSubmit} onCancel={handleCancel} />
             )}
-        </Page>
+        </CodeInsightsPage>
     )
 }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/32163
[[Desings] ](https://www.figma.com/file/38cMCA2pOScKIqzt3ZNuiz/Limited-access-mode-RFC-Private-567-%2330165-%5BWIP%5D?node-id=1117%3A7545)

## For reviewers 
This PR generalizes component for building code insights pages with included logic about rendering or not the limited access UI within the page (like limited access banner)

The "reach out us" link has code insights request demo link let me know if think it should be a different URL. 

## Test plan
- Make sure that if you don't have code insights license tag you should see a limited access banner on all code insights pages

<img width="778" alt="Screenshot 2022-03-11 at 19 08 39" src="https://user-images.githubusercontent.com/18492575/157893884-57499cfa-ef38-4a26-a241-127baa8d53bb.png">

- You shouldn't see this banner if you have the code insights license tag
