### PR TITLE
Code Insights: Adjust getting started page component for the limited access mode

### DIFF
--- a/client/web/src/enterprise/insights/components/code-insights-page/CodeInsightsPage.tsx
+++ b/client/web/src/enterprise/insights/components/code-insights-page/CodeInsightsPage.tsx
@@ -16,7 +16,7 @@ export const CodeInsightsPage: React.FunctionComponent<CodeInsightsPageProps> = 
 
     return (
         <Page {...props}>
-            {!licensed && <CodeInsightsLimitAccessBanner className="mb-3" />}
+            {!licensed && <CodeInsightsLimitAccessBanner className="mb-4" />}
             {props.children}
         </Page>
     )

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardsContentPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardsContentPage.tsx
@@ -23,7 +23,7 @@ export const DashboardsContentPage: React.FunctionComponent<DashboardsContentPag
     const { url } = useRouteMatch()
 
     if (!dashboardID) {
-        // In case if url doesn't have a dashboard id we should fallback on
+        // In case if url doesn't have a dashboard id we should fall back on
         // built-in "All insights" dashboard
         return <Redirect to={`${url}/${ALL_INSIGHTS_DASHBOARD_ID}`} />
     }

--- a/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/CodeInsightsDotComGetStarted.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/CodeInsightsDotComGetStarted.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/media-has-caption */
 import classNames from 'classnames'
 import React, { useEffect } from 'react'
 

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-examples/CodeInsightsExamples.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-examples/CodeInsightsExamples.tsx
@@ -5,7 +5,7 @@ import { useLocation } from 'react-router'
 
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Button, Link, useObservable } from '@sourcegraph/wildcard'
+import { Button, Link } from '@sourcegraph/wildcard'
 
 import * as View from '../../../../../../../views'
 import { LegendBlock, LegendItem } from '../../../../../../../views'
@@ -13,7 +13,7 @@ import {
     getLineStroke,
     LineChart,
 } from '../../../../../../../views/components/view/content/chart-view-content/charts/line/components/LineChartContent'
-import { CodeInsightsBackendContext } from '../../../../core/backend/code-insights-backend-context'
+import { CodeInsightsBackendContext } from '../../../../../core/backend/code-insights-backend-context'
 import { InsightType } from '../../../../../core/types'
 import { CodeInsightTrackType, useCodeInsightViewPings } from '../../../../../pings'
 import { encodeCaptureInsightURL } from '../../../../insights/creation/capture-group'
@@ -105,7 +105,7 @@ const CodeInsightSearchExample: React.FunctionComponent<CodeInsightSearchExample
     const bigTemplateClickPingName = useLogEventName('InsightsGetStartedBigTemplateClick')
 
     const { getUiFeatures } = useContext(CodeInsightsBackendContext)
-    const features = useObservable(useMemo(() => getUiFeatures(), [getUiFeatures]))
+    const features = useMemo(() => getUiFeatures(), [getUiFeatures])
 
     const { trackMouseEnter, trackMouseLeave } = useCodeInsightViewPings({
         telemetryService,
@@ -175,12 +175,12 @@ interface CodeInsightCaptureExampleProps extends TelemetryProps {
 const CodeInsightCaptureExample: React.FunctionComponent<CodeInsightCaptureExampleProps> = props => {
     const { content, templateLink, className, telemetryService } = props
 
-    const bigTemplateClickPingName = useLogEventName('InsightsGetStartedBigTemplateClick')
-    const { mode } = useContext(CodeInsightsLandingPageContext)
-
-
     const { getUiFeatures } = useContext(CodeInsightsBackendContext)
-    const features = useObservable(useMemo(() => getUiFeatures(), [getUiFeatures]))
+    const features = useMemo(() => getUiFeatures(), [getUiFeatures])
+
+    const { mode } = useContext(CodeInsightsLandingPageContext)
+    const bigTemplateClickPingName = useLogEventName('InsightsGetStartedBigTemplateClick')
+
     const { trackMouseEnter, trackMouseLeave } = useCodeInsightViewPings({
         telemetryService,
         insightType:

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-examples/CodeInsightsExamples.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-examples/CodeInsightsExamples.tsx
@@ -1,11 +1,11 @@
 import { ParentSize } from '@visx/responsive'
 import classNames from 'classnames'
-import React, { useContext } from 'react'
+import React, { useContext, useMemo } from 'react'
 import { useLocation } from 'react-router'
 
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Button, Link } from '@sourcegraph/wildcard'
+import { Button, Link, useObservable } from '@sourcegraph/wildcard'
 
 import * as View from '../../../../../../../views'
 import { LegendBlock, LegendItem } from '../../../../../../../views'
@@ -13,6 +13,7 @@ import {
     getLineStroke,
     LineChart,
 } from '../../../../../../../views/components/view/content/chart-view-content/charts/line/components/LineChartContent'
+import { CodeInsightsBackendContext } from '../../../../core/backend/code-insights-backend-context'
 import { InsightType } from '../../../../../core/types'
 import { CodeInsightTrackType, useCodeInsightViewPings } from '../../../../../pings'
 import { encodeCaptureInsightURL } from '../../../../insights/creation/capture-group'
@@ -103,6 +104,9 @@ const CodeInsightSearchExample: React.FunctionComponent<CodeInsightSearchExample
     const { mode } = useContext(CodeInsightsLandingPageContext)
     const bigTemplateClickPingName = useLogEventName('InsightsGetStartedBigTemplateClick')
 
+    const { getUiFeatures } = useContext(CodeInsightsBackendContext)
+    const features = useObservable(useMemo(() => getUiFeatures(), [getUiFeatures]))
+
     const { trackMouseEnter, trackMouseLeave } = useCodeInsightViewPings({
         telemetryService,
         insightType:
@@ -136,7 +140,7 @@ const CodeInsightSearchExample: React.FunctionComponent<CodeInsightSearchExample
                         to={templateLink}
                         onClick={handleTemplateLinkClick}
                     >
-                        Use as template
+                        {features?.licensed ? 'Use as template' : 'Explore template'}
                     </Button>
                 )
             }
@@ -174,6 +178,9 @@ const CodeInsightCaptureExample: React.FunctionComponent<CodeInsightCaptureExamp
     const bigTemplateClickPingName = useLogEventName('InsightsGetStartedBigTemplateClick')
     const { mode } = useContext(CodeInsightsLandingPageContext)
 
+
+    const { getUiFeatures } = useContext(CodeInsightsBackendContext)
+    const features = useObservable(useMemo(() => getUiFeatures(), [getUiFeatures]))
     const { trackMouseEnter, trackMouseLeave } = useCodeInsightViewPings({
         telemetryService,
         insightType:
@@ -206,7 +213,7 @@ const CodeInsightCaptureExample: React.FunctionComponent<CodeInsightCaptureExamp
                         to={templateLink}
                         onClick={handleTemplateLinkClick}
                     >
-                        Use as template
+                        {features?.licensed ? 'Use as template' : 'Explore template'}
                     </Button>
                 )
             }

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-templates/CodeInsightsTemplates.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-templates/CodeInsightsTemplates.tsx
@@ -18,10 +18,9 @@ import {
     TooltipController,
     Icon,
     Link,
-    useObservable,
 } from '@sourcegraph/wildcard'
 
-import { CodeInsightsBackendContext } from '../../../../core/backend/code-insights-backend-context'
+import { CodeInsightsBackendContext } from '../../../../../core/backend/code-insights-backend-context'
 import { InsightType } from '../../../../../core/types'
 import { encodeCaptureInsightURL } from '../../../../insights/creation/capture-group'
 import { encodeSearchInsightUrl } from '../../../../insights/creation/search-insight'
@@ -138,7 +137,7 @@ const TemplateCard: React.FunctionComponent<TemplateCardProps> = props => {
     const { mode } = useContext(CodeInsightsLandingPageContext)
 
     const { getUiFeatures } = useContext(CodeInsightsBackendContext)
-    const features = useObservable(useMemo(() => getUiFeatures(), [getUiFeatures]))
+    const features = useMemo(() => getUiFeatures(), [getUiFeatures])
 
     const series =
         template.type === InsightType.SearchBased

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-templates/CodeInsightsTemplates.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-templates/CodeInsightsTemplates.tsx
@@ -1,6 +1,6 @@
 import copy from 'copy-to-clipboard'
 import ContentCopyIcon from 'mdi-react/ContentCopyIcon'
-import React, { MouseEvent, useContext, useState } from 'react'
+import React, { MouseEvent, useContext, useMemo, useState } from 'react'
 
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -18,8 +18,10 @@ import {
     TooltipController,
     Icon,
     Link,
+    useObservable,
 } from '@sourcegraph/wildcard'
 
+import { CodeInsightsBackendContext } from '../../../../core/backend/code-insights-backend-context'
 import { InsightType } from '../../../../../core/types'
 import { encodeCaptureInsightURL } from '../../../../insights/creation/capture-group'
 import { encodeSearchInsightUrl } from '../../../../insights/creation/search-insight'
@@ -135,6 +137,9 @@ const TemplateCard: React.FunctionComponent<TemplateCardProps> = props => {
     const { template, telemetryService } = props
     const { mode } = useContext(CodeInsightsLandingPageContext)
 
+    const { getUiFeatures } = useContext(CodeInsightsBackendContext)
+    const features = useObservable(useMemo(() => getUiFeatures(), [getUiFeatures]))
+
     const series =
         template.type === InsightType.SearchBased
             ? template.templateValues.series ?? []
@@ -167,7 +172,7 @@ const TemplateCard: React.FunctionComponent<TemplateCardProps> = props => {
                     className="mr-auto"
                     onClick={handleUseTemplateLinkClick}
                 >
-                    Use this template
+                    {features?.licensed ? 'Use this template' : 'Explore template'}
                 </Button>
             )}
         </Card>

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.module.scss
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.module.scss
@@ -28,6 +28,13 @@
     }
 }
 
+.footer {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 1.5rem;
+}
+
 .chart {
     min-height: 19.5rem;
 }

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
@@ -50,7 +50,8 @@ interface DynamicCodeInsightExampleProps extends TelemetryProps, React.HTMLAttri
 export const DynamicCodeInsightExample: React.FunctionComponent<DynamicCodeInsightExampleProps> = props => {
     const { telemetryService, ...otherProps } = props
 
-    const { getFirstExampleRepository } = useContext(CodeInsightsBackendContext)
+    const { getFirstExampleRepository, getUiFeatures } = useContext(CodeInsightsBackendContext)
+    const features = useObservable(useMemo(() => getUiFeatures(), [getUiFeatures]))
 
     const form = useForm<CodeInsightExampleFormValues>({
         initialValues: INITIAL_INSIGHT_VALUES,
@@ -181,9 +182,30 @@ export const DynamicCodeInsightExample: React.FunctionComponent<DynamicCodeInsig
                     <li>Track code smells, ownership, and configurations</li>
                 </ul>
 
-                <Button variant="primary" as={Link} to="/insights/create" onClick={handleGetStartedClick}>
-                    <Icon as={PlusIcon} /> Create your first insight
-                </Button>
+                <footer className={styles.footer}>
+                    {features?.licensed ? (
+                        <Button variant="primary" as={Link} to="/insights/create" onClick={handleGetStartedClick}>
+                            <Icon as={PlusIcon} /> Create your first insight
+                        </Button>
+                    ) : (
+                        <Button
+                            as={Link}
+                            variant="primary"
+                            to="http://about.sourcegraph.com/contact/request-code-insights-demo"
+                            target="_blank"
+                            rel="noopener"
+                            onClick={handleGetStartedClick}
+                        >
+                            Schedule a demo
+                        </Button>
+                    )}
+
+                    {!features?.licensed && (
+                        <Button as={Link} variant="secondary" to="/insights/about#code-insights-templates">
+                            Explore use cases
+                        </Button>
+                    )}
+                </footer>
 
                 <CalloutArrow className={styles.calloutBlockHorizontal} />
             </section>

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
@@ -51,7 +51,7 @@ export const DynamicCodeInsightExample: React.FunctionComponent<DynamicCodeInsig
     const { telemetryService, ...otherProps } = props
 
     const { getFirstExampleRepository, getUiFeatures } = useContext(CodeInsightsBackendContext)
-    const features = useObservable(useMemo(() => getUiFeatures(), [getUiFeatures]))
+    const features = useMemo(() => getUiFeatures(), [getUiFeatures])
 
     const form = useForm<CodeInsightExampleFormValues>({
         initialValues: INITIAL_INSIGHT_VALUES,


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/32280

## Test plan
[Design](https://www.figma.com/file/38cMCA2pOScKIqzt3ZNuiz/Limited-access-mode-RFC-Private-567-%2330165-%5BWIP%5D?node-id=1116%3A4199)

1. Changes in the CTAs:
- ‘schedule a demo’ - should open the ‘request a demo’ (same as from about.sourcegraph) - [wip netifly link](https://deploy-preview-5148--sourcegraph.netlify.app/contact/request-code-insights-demo/)
- Explore use cases - link to the ‘Templates’ section

2. Example insights: change button to 'Explore template'
3. Templates: change button label to 'Explore template'


