### PR TITLE
.github: note that a test plan can be explanation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,8 @@
 <!--
   As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
   provide a "test plan". A test plan is a loose explanation of what you have done or
-  implemented to test this, as outlined in our Testing principles and guidelines:
+  implemented to test this, or why this change does not need testing, as outlined in our
+  Testing principles and guidelines:
   https://docs.sourcegraph.com/dev/background-information/testing_principles
   Write your test plan here after the "## Test plan" header.
 -->


### PR DESCRIPTION
I noticed that I never called out explicitly that a test plan can just be an explanation of why no testing is needed!

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

n/a