### PR TITLE
Add helm as a supported deploy_type parameter

### DIFF
--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -1,6 +1,6 @@
 import { SiteConfiguration } from '@sourcegraph/shared/src/schema/site.schema'
 
-export type DeployType = 'kubernetes' | 'docker-container' | 'docker-compose' | 'pure-docker' | 'dev'
+export type DeployType = 'kubernetes' | 'docker-container' | 'docker-compose' | 'pure-docker' | 'dev' | 'helm'
 
 /**
  * Defined in cmd/frontend/internal/app/jscontext/jscontext.go JSContext struct

--- a/client/web/src/site-admin/SiteAdminPingsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminPingsPage.tsx
@@ -93,7 +93,8 @@ export const SiteAdminPingsPage: React.FunctionComponent<Props> = props => {
                 <li>Sourcegraph version string (e.g. "vX.X.X")</li>
                 <li>Dependency versions (e.g. "6.0.9" for Redis, or "13.0" for Postgres)</li>
                 <li>
-                    Deployment type (single Docker image, Docker Compose, Kubernetes cluster, or pure Docker cluster)
+                    Deployment type (single Docker image, Docker Compose, Kubernetes cluster, Helm, or pure Docker
+                    cluster)
                 </li>
                 <li>License key associated with your Sourcegraph subscription</li>
                 <li>Aggregate count of current monthly users</li>

--- a/client/web/src/site-admin/sidebaritems.ts
+++ b/client/web/src/site-admin/sidebaritems.ts
@@ -118,7 +118,10 @@ export const maintenanceGroup: SiteAdminSideBarGroup = {
             label: 'Instrumentation',
             to: '/-/debug/',
             source: 'server',
-            condition: () => window.context.deployType === 'kubernetes' || window.context.deployType === 'dev',
+            condition: () =>
+                window.context.deployType === 'kubernetes' ||
+                window.context.deployType === 'dev' ||
+                window.context.deployType === 'helm',
         },
         {
             label: 'Monitoring',

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -354,7 +354,7 @@ func makeInternalAPI(schema *graphql.Schema, db database.DB, enterprise enterpri
 }
 
 func makeServerOptions() (options []httpserver.ServerOptions) {
-	if deploy.Type() == deploy.Kubernetes {
+	if deploy.IsDeployTypeKubernetes(deploy.Type()) {
 		// On kubernetes, we want to wait an additional 5 seconds after we receive a
 		// shutdown request to give some additional time for the endpoint changes
 		// to propagate to services talking to this server like the LB or ingress

--- a/doc/admin/pings.md
+++ b/doc/admin/pings.md
@@ -10,7 +10,7 @@ Critical telemetry includes only the high-level data below required for billing,
 - The email address of the initial site installer (or if deleted, the first active site admin), to know who to contact regarding sales, product updates, security updates, and policy updates
 - Sourcegraph version string (e.g. "vX.X.X")
 - Dependency versions (e.g. "6.0.9" for Redis, or "13.0" for Postgres)
-- Deployment type (single Docker image, Docker Compose, Kubernetes cluster, or pure Docker cluster)
+- Deployment type (single Docker image, Docker Compose, Kubernetes cluster, Helm, or pure Docker cluster)
 - License key associated with your Sourcegraph subscription
 - Aggregate count of current monthly users
 - Total count of existing user accounts

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -19,7 +19,7 @@ import (
 func init() {
 	deployType := deploy.Type()
 	if !deploy.IsValidDeployType(deployType) {
-		log.Fatalf("The 'DEPLOY_TYPE' environment variable is invalid. Expected one of: %q, %q, %q, %q, %q. Got: %q", deploy.Kubernetes, deploy.DockerCompose, deploy.PureDocker, deploy.SingleDocker, deploy.Dev, deployType)
+		log.Fatalf("The 'DEPLOY_TYPE' environment variable is invalid. Expected one of: %q, %q, %q, %q, %q, %q. Got: %q", deploy.Kubernetes, deploy.DockerCompose, deploy.PureDocker, deploy.SingleDocker, deploy.Dev, deploy.Helm, deployType)
 	}
 
 	confdefaults.Default = defaultConfigForDeployment()

--- a/internal/conf/deploy/deploytype.go
+++ b/internal/conf/deploy/deploytype.go
@@ -2,7 +2,7 @@ package deploy
 
 import "os"
 
-// Deploy type constants. Any changes here should be reflected in the DeployType type declared in web/src/globals.d.ts:
+// Deploy type constants. Any changes here should be reflected in the DeployType type declared in client/web/src/jscontext.ts:
 // https://sourcegraph.com/search?q=r:github.com/sourcegraph/sourcegraph%24+%22type+DeployType%22
 const (
 	Kubernetes    = "kubernetes"
@@ -10,6 +10,7 @@ const (
 	DockerCompose = "docker-compose"
 	PureDocker    = "pure-docker"
 	Dev           = "dev"
+	Helm          = "helm"
 )
 
 // Type tells the deployment type.
@@ -27,7 +28,7 @@ func Type() string {
 func IsDeployTypeKubernetes(deployType string) bool {
 	switch deployType {
 	// includes older Kubernetes aliases for backwards compatibility
-	case "k8s", "cluster", Kubernetes:
+	case "k8s", "cluster", Kubernetes, Helm:
 		return true
 	}
 


### PR DESCRIPTION
Update the supported DeployTypes to include Helm. From a code perspective it should be treated the same as Kubernetes, but tracked as a separate item in ping data.

This will allow us to monitor the adoption of Helm by setting the DEPLOY_TYPE env var in the helm chart (#32204).

### Concerns
There is an argument to be made that Helm is more of a deployment method than a type (environment?), and shouldn't be included in the existing structures. I opted for this approach due to the simplicity but open to objections.

**Question**: this is not actually changing ping data structures or altering any behavior, just enabling a new value in the existing schema. Is it required to get BizOps approval / submit an RFC / add to the Changelog, or is this considered normal activity?

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->
Confirmed that the "helm" deploy type correctly showed up in ping data when set. Checked all references of `deploy.Type()` and `IsDeployTypeKubernetes` to make sure that the new type would be treated the same as Kubernetes.