### PR TITLE
insights: Fix dashboard ping, coalesce all values with 0 in case of nulls

### DIFF
--- a/enterprise/internal/insights/background/pings/insights_ping_aggregators.go
+++ b/enterprise/internal/insights/background/pings/insights_ping_aggregators.go
@@ -242,11 +242,11 @@ SELECT COUNT(*) FROM dashboard WHERE deleted_at IS NULL;
 
 const insightsPerDashboardQuery = `
 SELECT
-	AVG(count) AS average,
-	MIN(count) AS min,
-	MAX(count) AS max,
-	STDDEV(count) AS stddev,
-	PERCENTILE_CONT(0.5) WITHIN GROUP(ORDER BY count) AS median FROM
+	COALESCE(AVG(count), 0) AS average,
+	COALESCE(MIN(count), 0) AS min,
+	COALESCE(MAX(count), 0) AS max,
+	COALESCE(STDDEV(count), 0) AS stddev,
+	COALESCE(PERCENTILE_CONT(0.5) WITHIN GROUP(ORDER BY count), 0) AS median FROM
 	(
 		SELECT DISTINCT(dashboard_id), COUNT(insight_view_id) FROM dashboard_insight_view GROUP BY dashboard_id
 	) counts;


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/32404

## Description

If there were no insights attached to dashboards, `NULL` would be returned for these values and cause an error. This fix makes sure to return `0` instead.

## Test plan

I ran this with locally with no insights attached to dashboards, and verified this result, and that no error is present in the logs.

```
      "InsightsPerDashboard": {
          "Avg": 0,
          "Max": 0,
          "Min": 0,
          "Median": 0,
          "StdDev": 0
      },
```

