### PR TITLE
doc/dev: update feature flags guide to reference site admin UI

### DIFF
--- a/doc/dev/how-to/use_feature_flags.md
+++ b/doc/dev/how-to/use_feature_flags.md
@@ -10,10 +10,12 @@ are added to every event log for the purpose of analytics.
 
 ## How it works
 
-Each feature flag is either a static feature flag, or a "rollout" flag.
+Each feature flag is either a boolean feature flag, or a "rollout" flag.
 
-- A static feature flag has a single value (currently only "true" or "false") for all users that haven't overriden it.
-- A rollout flag assigns a random (but stable) value to each user. Each rollout flag is created with a percentage of users that should be randomly assigned the value "true".
+- A **boolean flag** has a single value (`true` or `false`) for all users that haven't [overriden](#feature-flag-overrides) it.
+- A **rollout flag** assigns a random (but stable) value to each user. Each rollout flag is created with a percentage of users that should be randomly assigned the value `true`.
+  - The percentage is measured in increments of 0.01% (a "rollout basis point").
+  - For example, to create a feature flag that applies to 50% of users, set the rollout basis points of the flag to 5000.
 
 A user is identified either by their user ID (if logged in), or by an anonymous user ID in local storage.
 
@@ -90,11 +92,7 @@ When writing code that uses feature flags, you may wish to avoid needing to pass
 Depending on how you implement a feature flag, you can disable a feature flag to turn off a feature.
 To do so, go to `/site-admin/feature-flags`, click "Create feature flag", and create a flag corresponding to your feature flag name.
 
-There are two types of feature flags:
-
-- Boolean flags, which represent a simple `true` or `false` value.
-- Rollout flags, which represent a numerical `rolloutBasisPoints` value. This value is measured in increments of 0.01% (a basis point).
-  - For example, to create a feature flag that applies to 50% of users, set `rolloutBasisPoints` to 5000.
+There are two types of feature flags - see [How it works](#how-it-works) for more details.
 
 Creating a feature flag can also be done with a GraphQL query like the following from `/api/console`:
 

--- a/doc/dev/how-to/use_feature_flags.md
+++ b/doc/dev/how-to/use_feature_flags.md
@@ -10,40 +10,45 @@ are added to every event log for the purpose of analytics.
 
 ## How it works
 
-Each feature flag is either a static feature flag, or a "rollout" flag. 
+Each feature flag is either a static feature flag, or a "rollout" flag.
 
 - A static feature flag has a single value (currently only "true" or "false") for all users that haven't overriden it.
 - A rollout flag assigns a random (but stable) value to each user. Each rollout flag is created with a percentage of users that should be randomly assigned the value "true".
 
-A user is identified either by their user ID (if logged in), or by an anonymous user ID in local 
-storage. 
+A user is identified either by their user ID (if logged in), or by an anonymous user ID in local storage.
 
 The set of evaluated feature flags is appended to each event log so they can be queried against
 for analytics.
 
-## Example lifecycle of a feature flag (for frontend A/B testing)
+## Example lifecycle of a feature flag
+
+### Frontend A/B testing
 
 The standard use of a feature flag for A/B testing a frontend feature will look like the following:
 
-1. Implement the feature that you want to be behind a feature flag
+1. [Implement a feature behind a feature flag](#implement-a-feature-flag)
 2. Deploy to sourcegraph.com
-3. Create the feature flag through the GraphQL API
-4. Measure the effect of the feature flag
-5. Disable or delete the feature flag
-6. Remove the code that references the feature flag
+3. [Create the feature flag](#create-a-feature-flag)
+4. [Measure the effect of the feature flag](#measure-the-effect-of-a-feature-flag)
+   1. [Update the feature flag](#update-a-feature-flag) if needed
+5. [Delete the feature flag](#delete-a-feature-flag)
+6. [Remove code that references the feature flag](#remove-code-that-references-the-feature-flag)
 
-### Implement the feature flag
+## Implement a feature flag
 
-#### Frontend
+### Frontend
 
 In the frontend, evaluated feature flags map for the current user is available on 
 the SourcegraphWebAppState. The map can be prop-drilled into the components that need access to the feature flags.
 
-Ensure that a default value is set for feature flags so that 
-(i) code can be deployed before creating the feature flag, (ii) deleting the feature flag is safe before removing referenced code, (iii) enterprise deployments continue to work as
-expected. 
+Ensure that a default value is set for feature flags so that:
+
+1. code can be deployed before creating the feature flag
+2. deleting the feature flag is safe before removing referenced code
+3. self-hosted deployments continue to work as expected
 
 You can add a new feature flag by adding the name as a new case to the `FeatureFlagName` type:
+
 ```typescript
 export type FeatureFlagName = ... | 'my-feature-flag'
 ```
@@ -53,13 +58,14 @@ that we can only access feature flags defined in the type. Deleting a flag name 
 error if the flag is still referenced somewhere.
 
 Example usage:
+
 ```typescript
 const evaluatedFeatureFlagValue = featureFlags.get('my-feature-flag') ?? false
 
 featureFlags.get('unknown-feature-flag') // compiler error
 ```
 
-#### Backend
+### Backend
 
 In the backend, the [`featureflag` package](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/featureflag/middleware.go) provides
 the implementation of feature flag functionality.
@@ -79,11 +85,19 @@ doSomething(value)
 
 When writing code that uses feature flags, you may wish to avoid needing to pass a `context.Context` (for `featureFlag.FromContext()`) in every function that consumes it for a variety of reasons (avoiding mixing concerns, lack of type safety, etc.). See [search: add Features type #28969](https://github.com/sourcegraph/sourcegraph/pull/28969) for an example of a pattern in the search code base that successfully minimizes the need to pass around a full context object.
 
-### Create the feature flag through the GraphQL API
+## Create a feature flag
 
-To create a rollout feature flag, currently the best way is to use the GraphQL API.
+Depending on how you implement a feature flag, you can disable a feature flag to turn off a feature.
+To do so, go to `/site-admin/feature-flags`, click "Create feature flag", and create a flag corresponding to your feature flag name.
 
-Go to `sourcegraph.com/api/console`, then create a feature flag like the following:
+There are two types of feature flags:
+
+- Boolean flags, which represent a simple `true` or `false` value.
+- Rollout flags, which represent a numerical `rolloutBasisPoints` value. This value is measured in increments of 0.01% (a basis point).
+  - For example, to create a feature flag that applies to 50% of users, set `rolloutBasisPoints` to 5000.
+
+Creating a feature flag can also be done with a GraphQL query like the following from `/api/console`:
+
 ```graphql
 mutation CreateFeatureFlag{
   createFeatureFlag(
@@ -95,11 +109,7 @@ mutation CreateFeatureFlag{
 }
 ```
 
-The value of `rolloutBasisPoints` is measured in increments of 0.01% (a basis point).
-To create a feature flag that applies to 50% of users, set `rolloutBasisPoints` 
-to 5000.
-
-### Measure the effect of the feature flag
+## Measure the effect of a feature flag
 
 Feature flags are added as a column to all event logs, so in order to measure any 
 effect, there needs to be a related event for it. For example, to compare the number of
@@ -108,17 +118,29 @@ you could use a query like the following:
 
 ```sql
 SELECT 
-	JSON_VALUE(feature_flags, '$.myFeatureFlag') AS my_flag, 
-	count(*) 
+  JSON_VALUE(feature_flags, '$.myFeatureFlag') AS my_flag, 
+  count(*) 
 FROM `telligentsourcegraph.dotcom_events.events` 
 WHERE name = 'ShareButtonClicked' 
 GROUP BY my_flag;
 ```
 
-### Disable or delete the feature flag
+## Update a feature flag
+
+Depending on how you implement a feature flag, you can disable a feature flag to turn off a feature or update the rollout basis point value to roll out a feature to more or less users.
+To do so, go to `/site-admin/feature-flags`, find your feature flag, and update the value
+using the UI.
+
+## Delete a feature flag
 
 In most cases, after an A/B test is performed, a feature flag should be deleted.
-That can be done with a GraphQL query like the following:
+Once a feature flag is deleted, it will no longer be added to events as metadata,
+so removing the code path that uses it will not change any measurements.
+
+To delete a feature flag, go to `/site-admin/feature-flags`, find your feature flag, and click the "Delete" button.
+
+Deleting a feature flag can also be done with a GraphQL query like the following from `/api/console`:
+
 ```graphql
 mutation DeleteFeatureFlag{
   deleteFeatureFlag(
@@ -129,13 +151,10 @@ mutation DeleteFeatureFlag{
 }
 ```
 
-Once a feature flag is deleted, it will no longer be added to events as metadata,
-so removing the code path that uses it will not change any measurements.
+### Remove code that references the feature flag
 
-### Remove the code that references the feature flag
-
-Once the feature flag is deleted, the code that references it can be safely deleted
-without changing any of the measurements. 
+Once [a feature flag is deleted](#disable-or-delete-a-feature-flag), the code that references it can be safely deleted
+without changing any of the measurements.
 
 ## Feature flag overrides
 
@@ -168,9 +187,11 @@ mutation CreateFeatureFlagOverride{
 
 The `namespace` argument is the graphql ID of either a user or an organization.
 
-### Listing all feature flags (including A/B tests)
+## Listing all feature flags
 
-To list all currently running A/B tests:
+To view a list of all current feature flags on a Sourcegraph instance, go to `/site-admin/feature-flags`.
+
+Listing feature flags can also be done with a GraphQL query like the following from `/api/console`:
 
 ```graphql
 query FetchFeatureFlags {
@@ -189,4 +210,4 @@ query FetchFeatureFlags {
 
 ## Further reading
 
-- Initial RFC [#286](https://docs.google.com/document/d/1aT8uI3mUXpm9IK9_WbXhFM5ahHj9KQeQ521hd9EE5U8/edit)
+- Initial proposal: [RFC 286](https://docs.google.com/document/d/1aT8uI3mUXpm9IK9_WbXhFM5ahHj9KQeQ521hd9EE5U8/edit)


### PR DESCRIPTION
Updates the feature flag guide to reference the new feature flags management UI (https://github.com/sourcegraph/sourcegraph/pull/32246, https://github.com/sourcegraph/sourcegraph/pull/32237). Part of https://github.com/sourcegraph/sourcegraph/issues/31182

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

`sg run docsite` to review the content