### PR TITLE
batches: migrate list page, enable filtering to multiple statuses

### DIFF
--- a/client/web/src/components/FilteredConnection/hooks/useConnection.ts
+++ b/client/web/src/components/FilteredConnection/hooks/useConnection.ts
@@ -20,20 +20,22 @@ export interface UseConnectionResult<TData> {
     stopPolling: () => void
 }
 
-interface UseConnectionConfig {
+interface UseConnectionConfig<TResult> {
     /** Set if query variables should be updated in and derived from the URL */
     useURL?: boolean
     /** Allows modifying how the query interacts with the Apollo cache */
     fetchPolicy?: WatchQueryFetchPolicy
     /** Set to enable polling of all the nodes currently loaded in the connection */
     pollInterval?: number
+    /** Allows running an optional callback on any successful request */
+    onCompleted?: (data: TResult) => void
 }
 
 interface UseConnectionParameters<TResult, TVariables, TData> {
     query: string
     variables: TVariables & ConnectionQueryArguments
     getConnection: (result: GraphQLResult<TResult>) => Connection<TData>
-    options?: UseConnectionConfig
+    options?: UseConnectionConfig<TResult>
 }
 
 const DEFAULT_AFTER: ConnectionQueryArguments['after'] = undefined
@@ -104,6 +106,7 @@ export const useConnection = <TResult, TVariables, TData>({
         },
         notifyOnNetworkStatusChange: true, // Ensures loading state is updated on `fetchMore`
         fetchPolicy: options?.fetchPolicy,
+        onCompleted: options?.onCompleted,
     })
 
     /**

--- a/client/web/src/enterprise/batches/list/BatchChangeListFilters.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListFilters.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+
+import { MultiSelect, MultiSelectOption, MultiSelectProps } from '@sourcegraph/wildcard'
+
+import { BatchChangeState } from '../../../graphql-operations'
+
+export const OPEN_STATUS: MultiSelectOption<BatchChangeState> = { label: 'Open', value: BatchChangeState.OPEN }
+export const DRAFT_STATUS: MultiSelectOption<BatchChangeState> = { label: 'Draft', value: BatchChangeState.DRAFT }
+export const CLOSED_STATUS: MultiSelectOption<BatchChangeState> = { label: 'Closed', value: BatchChangeState.CLOSED }
+
+const STATUS_OPTIONS: MultiSelectOption<BatchChangeState>[] = [OPEN_STATUS, DRAFT_STATUS, CLOSED_STATUS]
+// Drafts are a new feature of severside execution that for now should not be shown if
+// execution is not enabled.
+const STATUS_OPTIONS_NO_DRAFTS: MultiSelectOption<BatchChangeState>[] = [OPEN_STATUS, CLOSED_STATUS]
+
+interface BatchChangeListFiltersProps
+    extends Required<Pick<MultiSelectProps<MultiSelectOption<BatchChangeState>>, 'onChange' | 'defaultValue'>> {
+    className?: string
+    isExecutionEnabled: boolean
+}
+
+export const BatchChangeListFilters: React.FunctionComponent<BatchChangeListFiltersProps> = ({
+    isExecutionEnabled,
+    ...props
+}) => (
+    <MultiSelect
+        {...props}
+        options={isExecutionEnabled ? STATUS_OPTIONS : STATUS_OPTIONS_NO_DRAFTS}
+        aria-label="Select batch change status to filter."
+    />
+)

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.module.scss
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.module.scss
@@ -35,8 +35,3 @@
         margin-bottom: 1rem;
     }
 }
-
-.status-dropdown {
-    margin: 0;
-    width: 17rem;
-}

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.module.scss
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.module.scss
@@ -25,6 +25,17 @@
     grid-template-columns: [state] 70px [info] minmax(auto, 1fr) [open] min-content [closed] min-content [merged] min-content [end];
 }
 
+.filters-row {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    margin-bottom: 1.5rem;
+    @media (--xs-breakpoint-down) {
+        display: block;
+        margin-bottom: 1rem;
+    }
+}
+
 .status-dropdown {
     margin: 0;
     width: 17rem;

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.module.scss
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.module.scss
@@ -24,3 +24,8 @@
 .narrow {
     grid-template-columns: [state] 70px [info] minmax(auto, 1fr) [open] min-content [closed] min-content [merged] min-content [end];
 }
+
+.status-dropdown {
+    margin: 0;
+    width: 17rem;
+}

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.story.tsx
@@ -9,9 +9,14 @@ import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
 import { WebStory } from '../../../components/WebStory'
 
-import { BATCH_CHANGES, GET_LICENSE_AND_USAGE_INFO } from './backend'
+import { BATCH_CHANGES, BATCH_CHANGES_BY_NAMESPACE, GET_LICENSE_AND_USAGE_INFO } from './backend'
 import { BatchChangeListPage } from './BatchChangeListPage'
-import { BATCH_CHANGES_RESULT, getLicenseAndUsageInfoResult, NO_BATCH_CHANGES_RESULT } from './testData'
+import {
+    BATCH_CHANGES_BY_NAMESPACE_RESULT,
+    BATCH_CHANGES_RESULT,
+    getLicenseAndUsageInfoResult,
+    NO_BATCH_CHANGES_RESULT,
+} from './testData'
 
 const { add } = storiesOf('web/batches/list/BatchChangeListPage', module)
     .addDecorator(story => <div className="p-3 container">{story()}</div>)
@@ -38,6 +43,19 @@ const buildMocks = (isLicensed = true, hasBatchChanges = true, hasFilteredBatchC
         },
     ])
 
+const MOCKS_FOR_NAMESPACE = new WildcardMockLink([
+    {
+        request: { query: getDocumentNode(BATCH_CHANGES_BY_NAMESPACE), variables: MATCH_ANY_PARAMETERS },
+        result: { data: BATCH_CHANGES_BY_NAMESPACE_RESULT },
+        nMatches: Number.POSITIVE_INFINITY,
+    },
+    {
+        request: { query: getDocumentNode(GET_LICENSE_AND_USAGE_INFO), variables: MATCH_ANY_PARAMETERS },
+        result: { data: getLicenseAndUsageInfoResult() },
+        nMatches: Number.POSITIVE_INFINITY,
+    },
+])
+
 add('List of batch changes', () => {
     const canCreate = boolean('can create batch changes', true)
 
@@ -56,6 +74,22 @@ add('List of batch changes', () => {
         </WebStory>
     )
 })
+
+add('List of batch changes, for a specific namespace', () => (
+    <WebStory>
+        {props => (
+            <MockedTestProvider link={MOCKS_FOR_NAMESPACE}>
+                <BatchChangeListPage
+                    {...props}
+                    headingElement="h1"
+                    canCreate={true}
+                    namespaceID="test-12345"
+                    settingsCascade={EMPTY_SETTINGS_CASCADE}
+                />
+            </MockedTestProvider>
+        )}
+    </WebStory>
+))
 
 add('List of batch changes, server-side execution enabled', () => (
     <WebStory>

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.story.tsx
@@ -1,14 +1,17 @@
-import { useCallback } from '@storybook/addons'
+import { boolean } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 import React from 'react'
-import { of } from 'rxjs'
+import { WildcardMockLink, MATCH_ANY_PARAMETERS } from 'wildcard-mock-link'
 
+import { getDocumentNode } from '@sourcegraph/http-client'
 import { EMPTY_SETTINGS_CASCADE } from '@sourcegraph/shared/src/settings/settings'
+import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
 import { WebStory } from '../../../components/WebStory'
 
+import { BATCH_CHANGES, GET_LICENSE_AND_USAGE_INFO } from './backend'
 import { BatchChangeListPage } from './BatchChangeListPage'
-import { nodes } from './testData'
+import { BATCH_CHANGES_RESULT, getLicenseAndUsageInfoResult, NO_BATCH_CHANGES_RESULT } from './testData'
 
 const { add } = storiesOf('web/batches/list/BatchChangeListPage', module)
     .addDecorator(story => <div className="p-3 container">{story()}</div>)
@@ -19,51 +22,57 @@ const { add } = storiesOf('web/batches/list/BatchChangeListPage', module)
         },
     })
 
-const queryBatchChanges = () =>
-    of({
-        batchChanges: {
-            totalCount: Object.values(nodes).length,
-            nodes: Object.values(nodes),
-            pageInfo: { endCursor: null, hasNextPage: false },
+const buildMocks = (isLicensed = true, hasBatchChanges = true, hasFilteredBatchChanges = true) =>
+    new WildcardMockLink([
+        {
+            request: { query: getDocumentNode(BATCH_CHANGES), variables: MATCH_ANY_PARAMETERS },
+            result: {
+                data: hasBatchChanges && hasFilteredBatchChanges ? BATCH_CHANGES_RESULT : NO_BATCH_CHANGES_RESULT,
+            },
+            nMatches: Number.POSITIVE_INFINITY,
         },
-        totalCount: Object.values(nodes).length,
-    })
+        {
+            request: { query: getDocumentNode(GET_LICENSE_AND_USAGE_INFO), variables: MATCH_ANY_PARAMETERS },
+            result: { data: getLicenseAndUsageInfoResult(isLicensed, hasBatchChanges) },
+            nMatches: Number.POSITIVE_INFINITY,
+        },
+    ])
 
-const batchChangesNotLicensed = () => of(false)
+add('List of batch changes', () => {
+    const canCreate = boolean('can create batch changes', true)
 
-const batchChangesLicensed = () => of(true)
-
-add('List of batch changes', () => (
-    <WebStory>
-        {props => (
-            <BatchChangeListPage
-                {...props}
-                headingElement="h1"
-                canCreate={true}
-                queryBatchChanges={queryBatchChanges}
-                areBatchChangesLicensed={batchChangesLicensed}
-                settingsCascade={EMPTY_SETTINGS_CASCADE}
-            />
-        )}
-    </WebStory>
-))
+    return (
+        <WebStory>
+            {props => (
+                <MockedTestProvider link={buildMocks()}>
+                    <BatchChangeListPage
+                        {...props}
+                        headingElement="h1"
+                        canCreate={canCreate}
+                        settingsCascade={EMPTY_SETTINGS_CASCADE}
+                    />
+                </MockedTestProvider>
+            )}
+        </WebStory>
+    )
+})
 
 add('List of batch changes, server-side execution enabled', () => (
     <WebStory>
         {props => (
-            <BatchChangeListPage
-                {...props}
-                headingElement="h1"
-                canCreate={true}
-                queryBatchChanges={queryBatchChanges}
-                areBatchChangesLicensed={batchChangesLicensed}
-                settingsCascade={{
-                    ...EMPTY_SETTINGS_CASCADE,
-                    final: {
-                        experimentalFeatures: { batchChangesExecution: true },
-                    },
-                }}
-            />
+            <MockedTestProvider link={buildMocks()}>
+                <BatchChangeListPage
+                    {...props}
+                    headingElement="h1"
+                    canCreate={true}
+                    settingsCascade={{
+                        ...EMPTY_SETTINGS_CASCADE,
+                        final: {
+                            experimentalFeatures: { batchChangesExecution: true },
+                        },
+                    }}
+                />
+            </MockedTestProvider>
         )}
     </WebStory>
 ))
@@ -71,91 +80,45 @@ add('List of batch changes, server-side execution enabled', () => (
 add('Licensing not enforced', () => (
     <WebStory>
         {props => (
-            <BatchChangeListPage
-                {...props}
-                headingElement="h1"
-                canCreate={true}
-                queryBatchChanges={queryBatchChanges}
-                areBatchChangesLicensed={batchChangesNotLicensed}
-                settingsCascade={EMPTY_SETTINGS_CASCADE}
-            />
-        )}
-    </WebStory>
-))
-
-add('No batch changes', () => {
-    const queryBatchChanges = useCallback(
-        () =>
-            of({
-                batchChanges: {
-                    totalCount: 0,
-                    nodes: [],
-                    pageInfo: {
-                        endCursor: null,
-                        hasNextPage: false,
-                    },
-                },
-                totalCount: 0,
-            }),
-        []
-    )
-    return (
-        <WebStory>
-            {props => (
+            <MockedTestProvider link={buildMocks(false)}>
                 <BatchChangeListPage
                     {...props}
                     headingElement="h1"
                     canCreate={true}
-                    queryBatchChanges={queryBatchChanges}
-                    areBatchChangesLicensed={batchChangesLicensed}
                     settingsCascade={EMPTY_SETTINGS_CASCADE}
                 />
-            )}
-        </WebStory>
-    )
-})
-
-const QUERY_NO_BATCH_CHANGES = () =>
-    of({
-        batchChanges: {
-            totalCount: 0,
-            nodes: [],
-            pageInfo: {
-                endCursor: null,
-                hasNextPage: false,
-            },
-        },
-        totalCount: 0,
-    })
-
-add('All batch changes tab empty', () => (
-    <WebStory>
-        {props => (
-            <BatchChangeListPage
-                {...props}
-                headingElement="h1"
-                canCreate={true}
-                queryBatchChanges={QUERY_NO_BATCH_CHANGES}
-                areBatchChangesLicensed={batchChangesLicensed}
-                openTab="batchChanges"
-                settingsCascade={EMPTY_SETTINGS_CASCADE}
-            />
+            </MockedTestProvider>
         )}
     </WebStory>
 ))
 
-add('All batch changes tab empty, cannot create', () => (
+add('No batch changes', () => (
     <WebStory>
         {props => (
-            <BatchChangeListPage
-                {...props}
-                headingElement="h1"
-                canCreate={false}
-                queryBatchChanges={QUERY_NO_BATCH_CHANGES}
-                areBatchChangesLicensed={batchChangesLicensed}
-                openTab="batchChanges"
-                settingsCascade={EMPTY_SETTINGS_CASCADE}
-            />
+            <MockedTestProvider link={buildMocks(true, false)}>
+                <BatchChangeListPage
+                    {...props}
+                    headingElement="h1"
+                    canCreate={true}
+                    settingsCascade={EMPTY_SETTINGS_CASCADE}
+                />
+            </MockedTestProvider>
+        )}
+    </WebStory>
+))
+
+add('All batch changes tab empty', () => (
+    <WebStory>
+        {props => (
+            <MockedTestProvider link={buildMocks(true, true, false)}>
+                <BatchChangeListPage
+                    {...props}
+                    headingElement="h1"
+                    canCreate={true}
+                    openTab="batchChanges"
+                    settingsCascade={EMPTY_SETTINGS_CASCADE}
+                />
+            </MockedTestProvider>
         )}
     </WebStory>
 ))

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -7,7 +7,7 @@ import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Page } from '@sourcegraph/web/src/components/Page'
-import { PageHeader, CardBody, Card, Link, MultiSelectState } from '@sourcegraph/wildcard'
+import { PageHeader, CardBody, Card, Link, MultiSelectState, Container } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../../auth'
 import { isBatchChangesExecutionEnabled } from '../../../batches'
@@ -146,46 +146,53 @@ export const BatchChangeListPage: React.FunctionComponent<BatchChangeListPagePro
             <BatchChangeListTabHeader selectedTab={selectedTab} setSelectedTab={setSelectedTab} />
             {selectedTab === 'gettingStarted' && <GettingStarted className="mb-4" footer={<GettingStartedFooter />} />}
             {selectedTab === 'batchChanges' && (
-                <ConnectionContainer>
-                    <div className="d-flex align-items-center justify-content-end mb-2">
-                        <h4 className="mb-0 mr-2">Status</h4>
-                        <BatchChangeListFilters
-                            className={styles.statusDropdown}
-                            isExecutionEnabled={isExecutionEnabled}
-                            defaultValue={selectedFilters}
-                            onChange={setSelectedFilters}
-                        />
-                    </div>
-                    {error && <ConnectionError errors={[error.message]} />}
-                    <ConnectionList
-                        className={classNames(styles.grid, isExecutionEnabled ? styles.wide : styles.narrow)}
-                    >
-                        {connection?.nodes?.map(node => (
-                            <BatchChangeNode
-                                key={node.id}
-                                node={node}
-                                isExecutionEnabled={isExecutionEnabled}
-                                // Show the namespace unless we're viewing batch changes for a single namespace.
-                                displayNamespace={!namespaceID}
-                            />
-                        ))}
-                    </ConnectionList>
-                    {loading && <ConnectionLoading />}
-                    {connection && (
-                        <SummaryContainer centered={true}>
-                            <ConnectionSummary
-                                noSummaryIfAllNodesVisible={true}
-                                first={BATCH_CHANGES_PER_PAGE_COUNT}
-                                connection={connection}
-                                noun="batch change"
-                                pluralNoun="batch changes"
-                                hasNextPage={hasNextPage}
-                                emptyElement={<BatchChangeListEmptyElement canCreate={canCreate} location={location} />}
-                            />
-                            {hasNextPage && <ShowMoreButton onClick={fetchMore} />}
-                        </SummaryContainer>
-                    )}
-                </ConnectionContainer>
+                <Container className="mb-4">
+                    <ConnectionContainer>
+                        {!!connection?.nodes.length && (
+                            <div className="d-flex align-items-center justify-content-end mb-4">
+                                <h3 className="align-self-end flex-1">{connection?.totalCount} batch changes</h3>
+                                <h4 className="mb-0 mr-2">Status</h4>
+                                <BatchChangeListFilters
+                                    className={styles.statusDropdown}
+                                    isExecutionEnabled={isExecutionEnabled}
+                                    defaultValue={selectedFilters}
+                                    onChange={setSelectedFilters}
+                                />
+                            </div>
+                        )}
+                        {error && <ConnectionError errors={[error.message]} />}
+                        <ConnectionList
+                            className={classNames(styles.grid, isExecutionEnabled ? styles.wide : styles.narrow)}
+                        >
+                            {connection?.nodes?.map(node => (
+                                <BatchChangeNode
+                                    key={node.id}
+                                    node={node}
+                                    isExecutionEnabled={isExecutionEnabled}
+                                    // Show the namespace unless we're viewing batch changes for a single namespace.
+                                    displayNamespace={!namespaceID}
+                                />
+                            ))}
+                        </ConnectionList>
+                        {loading && <ConnectionLoading />}
+                        {connection && (
+                            <SummaryContainer centered={true}>
+                                <ConnectionSummary
+                                    noSummaryIfAllNodesVisible={true}
+                                    first={BATCH_CHANGES_PER_PAGE_COUNT}
+                                    connection={connection}
+                                    noun="batch change"
+                                    pluralNoun="batch changes"
+                                    hasNextPage={hasNextPage}
+                                    emptyElement={
+                                        <BatchChangeListEmptyElement canCreate={canCreate} location={location} />
+                                    }
+                                />
+                                {hasNextPage && <ShowMoreButton onClick={fetchMore} />}
+                            </SummaryContainer>
+                        )}
+                    </ConnectionContainer>
+                </Container>
             )}
         </Page>
     )

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -149,7 +149,7 @@ export const BatchChangeListPage: React.FunctionComponent<BatchChangeListPagePro
                 <Container className="mb-4">
                     <ConnectionContainer>
                         {!!connection?.nodes.length && (
-                            <div className="d-flex align-items-center justify-content-end mb-4">
+                            <div className={styles.filtersRow}>
                                 <h3 className="align-self-end flex-1">{connection?.totalCount} batch changes</h3>
                                 <h4 className="mb-0 mr-2">Status</h4>
                                 <BatchChangeListFilters

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -60,7 +60,7 @@ const BATCH_CHANGES_PER_PAGE_COUNT = 15
 // Drafts are a new feature of severside execution that for now should not be shown if
 // execution is not enabled.
 const getInitialFilters = (isExecutionEnabled: boolean): MultiSelectState<BatchChangeState> =>
-    isExecutionEnabled ? [OPEN_STATUS] : [OPEN_STATUS, DRAFT_STATUS]
+    isExecutionEnabled ? [OPEN_STATUS, DRAFT_STATUS] : [OPEN_STATUS]
 
 /**
  * A list of all batch changes on the Sourcegraph instance.

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -1,35 +1,43 @@
 import classNames from 'classnames'
 import React, { useEffect, useCallback, useState, useMemo } from 'react'
 import { RouteComponentProps } from 'react-router'
-import { Observable, ReplaySubject } from 'rxjs'
-import { filter, map, tap, withLatestFrom } from 'rxjs/operators'
 
+import { dataOrThrowErrors, useQuery } from '@sourcegraph/http-client'
 import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Page } from '@sourcegraph/web/src/components/Page'
-import { Container, PageHeader, useObservable, CardBody, Card, Link } from '@sourcegraph/wildcard'
+import { PageHeader, CardBody, Card, Link, MultiSelectState } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../../auth'
 import { isBatchChangesExecutionEnabled } from '../../../batches'
 import { BatchChangesIcon } from '../../../batches/icons'
-import { FilteredConnection, FilteredConnectionFilter } from '../../../components/FilteredConnection'
+import { useConnection } from '../../../components/FilteredConnection/hooks/useConnection'
+import {
+    ConnectionContainer,
+    ConnectionError,
+    ConnectionList,
+    ConnectionLoading,
+    ConnectionSummary,
+    ShowMoreButton,
+    SummaryContainer,
+} from '../../../components/FilteredConnection/ui'
 import {
     ListBatchChange,
     Scalars,
     BatchChangeState,
     BatchChangesVariables,
     BatchChangesResult,
+    BatchChangesByNamespaceResult,
     BatchChangesByNamespaceVariables,
+    GetLicenseAndUsageInfoResult,
+    GetLicenseAndUsageInfoVariables,
 } from '../../../graphql-operations'
 
-import {
-    areBatchChangesLicensed as _areBatchChangesLicensed,
-    queryBatchChanges as _queryBatchChanges,
-    queryBatchChangesByNamespace,
-} from './backend'
+import { BATCH_CHANGES, BATCH_CHANGES_BY_NAMESPACE, GET_LICENSE_AND_USAGE_INFO } from './backend'
+import { BatchChangeListFilters, DRAFT_STATUS, OPEN_STATUS } from './BatchChangeListFilters'
 import styles from './BatchChangeListPage.module.scss'
-import { BatchChangeNode, BatchChangeNodeProps } from './BatchChangeNode'
+import { BatchChangeNode } from './BatchChangeNode'
 import { BatchChangesListIntro } from './BatchChangesListIntro'
 import { GettingStarted } from './GettingStarted'
 import { NewBatchChangeButton } from './NewBatchChangeButton'
@@ -40,107 +48,86 @@ export interface BatchChangeListPageProps
         SettingsCascadeProps<Settings> {
     canCreate: boolean
     headingElement: 'h1' | 'h2'
-    displayNamespace?: boolean
-    /** For testing only. */
-    queryBatchChanges?: typeof _queryBatchChanges
-    /** For testing only. */
-    areBatchChangesLicensed?: typeof _areBatchChangesLicensed
+    namespaceID?: Scalars['ID']
     /** For testing only. */
     openTab?: SelectedTab
 }
 
-const OPEN_FILTER = {
-    label: 'Open',
-    value: 'open',
-    tooltip: 'Show only batch changes that are open',
-    args: { state: BatchChangeState.OPEN },
-} as const
-
-const DRAFT_FILTER = {
-    label: 'Draft',
-    value: 'draft',
-    tooltip: 'Show only batch changes that have not been applied yet',
-    args: { state: BatchChangeState.DRAFT },
-} as const
-
-const CLOSED_FILTER = {
-    label: 'Closed',
-    value: 'closed',
-    tooltip: 'Show only batch changes that are closed',
-    args: { state: BatchChangeState.CLOSED },
-}
-
-const ALL_FILTER = {
-    label: 'All',
-    value: 'all',
-    tooltip: 'Show all batch changes',
-    args: {},
-} as const
-
-const getFilters = (withDrafts = false): FilteredConnectionFilter[] => [
-    {
-        id: 'status',
-        label: 'Status',
-        type: 'radio',
-        values: [ALL_FILTER, OPEN_FILTER, ...(withDrafts ? [DRAFT_FILTER] : []), CLOSED_FILTER],
-    },
-]
-
 type SelectedTab = 'batchChanges' | 'gettingStarted'
+
+const BATCH_CHANGES_PER_PAGE_COUNT = 15
 
 /**
  * A list of all batch changes on the Sourcegraph instance.
  */
 export const BatchChangeListPage: React.FunctionComponent<BatchChangeListPageProps> = ({
-    queryBatchChanges = _queryBatchChanges,
-    areBatchChangesLicensed = _areBatchChangesLicensed,
     canCreate,
-    displayNamespace = true,
+    namespaceID,
     headingElement,
     location,
     openTab,
     settingsCascade,
-    ...props
+    telemetryService,
 }) => {
-    useEffect(() => props.telemetryService.logViewEvent('BatchChangesListPage'), [props.telemetryService])
+    useEffect(() => telemetryService.logViewEvent('BatchChangesListPage'), [telemetryService])
 
-    const executionEnabled = isBatchChangesExecutionEnabled(settingsCascade)
+    const isExecutionEnabled = isBatchChangesExecutionEnabled(settingsCascade)
 
-    /*
-     * Tracks whether this is the first fetch since this page has been rendered the first time.
-     * Used to only switch to the "Getting started" tab if the user didn't select the tab manually.
-     */
-    const isFirstFetch = useMemo(() => {
-        const subject = new ReplaySubject(1)
-        subject.next(true)
-        return subject
-    }, [])
     const [selectedTab, setSelectedTab] = useState<SelectedTab>(openTab ?? 'batchChanges')
-    const query = useCallback<(args: Partial<BatchChangesVariables>) => Observable<BatchChangesResult['batchChanges']>>(
-        args =>
-            queryBatchChanges(args).pipe(
-                withLatestFrom(isFirstFetch),
-                tap(([response, isFirst]) => {
-                    if (isFirst) {
-                        isFirstFetch.next(false)
-                        if (!openTab && response.totalCount === 0) {
-                            setSelectedTab('gettingStarted')
-                        }
-                    }
-                }),
-                // Don't emit when we are switching to the getting started tab right away to prevent a costly render.
-                // Only if:
-                //  - We don't fetch for the first time (the user clicked a tab) OR
-                //  - There are more than 0 changesets in the namespace OR
-                //  - A test forces us to display a specific tab
-                filter(([response, isFirst]) => !isFirst || openTab !== undefined || response.totalCount > 0),
-                map(([response]) => response.batchChanges)
-            ),
-        [queryBatchChanges, isFirstFetch, openTab]
+    const [selectedFilters, setSelectedFilters] = useState<MultiSelectState<BatchChangeState>>([
+        OPEN_STATUS,
+        DRAFT_STATUS,
+    ])
+
+    // We use the license and usage query to check whether or not there are any batch
+    // changes at all. If there aren't, we automatically switch the user to the "Getting
+    // started" tab.
+    const onUsageCheckCompleted = useCallback(
+        (data: GetLicenseAndUsageInfoResult) => {
+            if (!openTab && data.allBatchChanges.totalCount === 0) {
+                setSelectedTab('gettingStarted')
+            }
+        },
+        [openTab]
     )
-    const licensed: boolean | undefined = useObservable(
-        useMemo(() => areBatchChangesLicensed(), [areBatchChangesLicensed])
+
+    const { data: licenseAndUsageInfo } = useQuery<GetLicenseAndUsageInfoResult, GetLicenseAndUsageInfoVariables>(
+        GET_LICENSE_AND_USAGE_INFO,
+        { onCompleted: onUsageCheckCompleted }
     )
+
+    const filterStates = useMemo<BatchChangeState[]>(() => selectedFilters.map(filter => filter.value), [
+        selectedFilters,
+    ])
+
+    const { connection, error, loading, fetchMore, hasNextPage } = useConnection<
+        BatchChangesByNamespaceResult | BatchChangesResult,
+        BatchChangesByNamespaceVariables | BatchChangesVariables,
+        ListBatchChange
+    >({
+        query: namespaceID ? BATCH_CHANGES_BY_NAMESPACE : BATCH_CHANGES,
+        variables: {
+            namespaceID,
+            states: filterStates,
+            first: BATCH_CHANGES_PER_PAGE_COUNT,
+            after: null,
+            viewerCanAdminister: null,
+        },
+        options: { useURL: true },
+        getConnection: result => {
+            const data = dataOrThrowErrors(result)
+            if (!namespaceID) {
+                return (data as BatchChangesResult).batchChanges
+            }
+            if (!('node' in data) || !data.node) {
+                throw new Error('Namespace not found')
+            }
+            if (data.node.__typename !== 'Org' && data.node.__typename !== 'User') {
+                throw new Error(`Requested node is a ${data.node.__typename}, not a User or Org`)
+            }
+            return data.node.batchChanges
+        },
+    })
 
     return (
         <Page>
@@ -151,32 +138,50 @@ export const BatchChangeListPage: React.FunctionComponent<BatchChangeListPagePro
                 headingElement={headingElement}
                 description="Run custom code over hundreds of repositories and manage the resulting changesets."
             />
-            <BatchChangesListIntro licensed={licensed} />
+            <BatchChangesListIntro isLicensed={licenseAndUsageInfo?.batchChanges || licenseAndUsageInfo?.campaigns} />
             <BatchChangeListTabHeader selectedTab={selectedTab} setSelectedTab={setSelectedTab} />
             {selectedTab === 'gettingStarted' && <GettingStarted className="mb-4" footer={<GettingStartedFooter />} />}
             {selectedTab === 'batchChanges' && (
-                <Container className="mb-4">
-                    <FilteredConnection<ListBatchChange, Omit<BatchChangeNodeProps, 'node'>>
-                        {...props}
-                        location={location}
-                        nodeComponent={BatchChangeNode}
-                        nodeComponentProps={{ displayNamespace, executionEnabled }}
-                        queryConnection={query}
-                        hideSearch={true}
-                        defaultFirst={15}
-                        // Drafts are a new feature of severside execution that for now
-                        // should not be shown otherwise.
-                        filters={getFilters(executionEnabled)}
-                        noun="batch change"
-                        pluralNoun="batch changes"
-                        listComponent="div"
-                        listClassName={classNames(styles.grid, executionEnabled ? styles.wide : styles.narrow)}
-                        withCenteredSummary={true}
-                        cursorPaging={true}
-                        noSummaryIfAllNodesVisible={true}
-                        emptyElement={<BatchChangeListEmptyElement canCreate={canCreate} location={location} />}
-                    />
-                </Container>
+                <ConnectionContainer>
+                    <div className="d-flex align-items-center justify-content-end mb-2">
+                        <h4 className="mb-0 mr-2">Status</h4>
+                        <BatchChangeListFilters
+                            className={styles.statusDropdown}
+                            isExecutionEnabled={isExecutionEnabled}
+                            defaultValue={selectedFilters}
+                            onChange={setSelectedFilters}
+                        />
+                    </div>
+                    {error && <ConnectionError errors={[error.message]} />}
+                    <ConnectionList
+                        className={classNames(styles.grid, isExecutionEnabled ? styles.wide : styles.narrow)}
+                    >
+                        {connection?.nodes?.map(node => (
+                            <BatchChangeNode
+                                key={node.id}
+                                node={node}
+                                isExecutionEnabled={isExecutionEnabled}
+                                // Show the namespace unless we're viewing batch changes for a single namespace.
+                                displayNamespace={!namespaceID}
+                            />
+                        ))}
+                    </ConnectionList>
+                    {loading && <ConnectionLoading />}
+                    {connection && (
+                        <SummaryContainer centered={true}>
+                            <ConnectionSummary
+                                noSummaryIfAllNodesVisible={true}
+                                first={BATCH_CHANGES_PER_PAGE_COUNT}
+                                connection={connection}
+                                noun="batch change"
+                                pluralNoun="batch changes"
+                                hasNextPage={hasNextPage}
+                                emptyElement={<BatchChangeListEmptyElement canCreate={canCreate} location={location} />}
+                            />
+                            {hasNextPage && <ShowMoreButton onClick={fetchMore} />}
+                        </SummaryContainer>
+                    )}
+                </ConnectionContainer>
             )}
         </Page>
     )
@@ -204,26 +209,7 @@ export const NamespaceBatchChangeListPage: React.FunctionComponent<NamespaceBatc
         [authenticatedUser, namespaceID]
     )
 
-    const queryConnection = useCallback(
-        (args: Partial<BatchChangesByNamespaceVariables>) =>
-            queryBatchChangesByNamespace({
-                namespaceID,
-                first: args.first ?? null,
-                after: args.after ?? null,
-                // The types for FilteredConnectionQueryArguments don't allow access to the filter arguments.
-                state: (args as { state: BatchChangeState | undefined }).state ?? null,
-                viewerCanAdminister: null,
-            }),
-        [namespaceID]
-    )
-    return (
-        <BatchChangeListPage
-            {...props}
-            canCreate={canCreateInThisNamespace}
-            displayNamespace={false}
-            queryBatchChanges={queryConnection}
-        />
-    )
+    return <BatchChangeListPage {...props} canCreate={canCreateInThisNamespace} namespaceID={namespaceID} />
 }
 
 interface BatchChangeListEmptyElementProps extends Pick<BatchChangeListPageProps, 'location' | 'canCreate'> {}

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -152,14 +152,14 @@ export const BatchChangeListPage: React.FunctionComponent<BatchChangeListPagePro
                             <div className={styles.filtersRow}>
                                 <h3 className="align-self-end flex-1">{connection?.totalCount} batch changes</h3>
                                 <h4 className="mb-0 mr-2">Status</h4>
-                                <BatchChangeListFilters
-                                    className={styles.statusDropdown}
-                                    isExecutionEnabled={isExecutionEnabled}
-                                    defaultValue={selectedFilters}
-                                    onChange={setSelectedFilters}
-                                />
-                            </div>
                         )}
+                            <BatchChangeListFilters
+                                className="m-0"
+                                isExecutionEnabled={isExecutionEnabled}
+                                defaultValue={selectedFilters}
+                                onChange={setSelectedFilters}
+                                isDisabled={licenseAndUsageInfo?.allBatchChanges.totalCount === 0}
+                            />
                         {error && <ConnectionError errors={[error.message]} />}
                         <ConnectionList
                             className={classNames(styles.grid, isExecutionEnabled ? styles.wide : styles.narrow)}

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -57,6 +57,11 @@ type SelectedTab = 'batchChanges' | 'gettingStarted'
 
 const BATCH_CHANGES_PER_PAGE_COUNT = 15
 
+// Drafts are a new feature of severside execution that for now should not be shown if
+// execution is not enabled.
+const getInitialFilters = (isExecutionEnabled: boolean): MultiSelectState<BatchChangeState> =>
+    isExecutionEnabled ? [OPEN_STATUS] : [OPEN_STATUS, DRAFT_STATUS]
+
 /**
  * A list of all batch changes on the Sourcegraph instance.
  */
@@ -74,10 +79,9 @@ export const BatchChangeListPage: React.FunctionComponent<BatchChangeListPagePro
     const isExecutionEnabled = isBatchChangesExecutionEnabled(settingsCascade)
 
     const [selectedTab, setSelectedTab] = useState<SelectedTab>(openTab ?? 'batchChanges')
-    const [selectedFilters, setSelectedFilters] = useState<MultiSelectState<BatchChangeState>>([
-        OPEN_STATUS,
-        DRAFT_STATUS,
-    ])
+    const [selectedFilters, setSelectedFilters] = useState<MultiSelectState<BatchChangeState>>(
+        getInitialFilters(isExecutionEnabled)
+    )
 
     // We use the license and usage query to check whether or not there are any batch
     // changes at all. If there aren't, we automatically switch the user to the "Getting

--- a/client/web/src/enterprise/batches/list/BatchChangeNode.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeNode.story.tsx
@@ -24,7 +24,7 @@ for (const key of Object.keys(nodes)) {
                     node={nodes[key]}
                     displayNamespace={boolean('Display namespace', true)}
                     now={isChromatic() ? () => subDays(now, 5) : undefined}
-                    executionEnabled={false}
+                    isExecutionEnabled={false}
                 />
             )}
         </WebStory>

--- a/client/web/src/enterprise/batches/list/BatchChangeNode.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeNode.tsx
@@ -23,7 +23,7 @@ import { BatchChangeStatePill } from './BatchChangeStatePill'
 
 export interface BatchChangeNodeProps {
     node: ListBatchChange
-    executionEnabled: boolean
+    isExecutionEnabled: boolean
     /** Used for testing purposes. Sets the current date */
     now?: () => Date
     displayNamespace: boolean
@@ -61,7 +61,7 @@ const StateBadge: React.FunctionComponent<{ state: BatchChangeState }> = ({ stat
  */
 export const BatchChangeNode: React.FunctionComponent<BatchChangeNodeProps> = ({
     node,
-    executionEnabled,
+    isExecutionEnabled,
     now = () => new Date(),
     displayNamespace,
 }) => {
@@ -74,7 +74,7 @@ export const BatchChangeNode: React.FunctionComponent<BatchChangeNodeProps> = ({
     const nodeLink = useMemo(() => {
         // Before SSBC, all batch changes took you to the same place, the node detail
         // page. Closed batch changes also take you to this page.
-        if (!executionEnabled || node.state === BatchChangeState.CLOSED) {
+        if (!isExecutionEnabled || node.state === BatchChangeState.CLOSED) {
             return node.url
         }
 
@@ -103,12 +103,12 @@ export const BatchChangeNode: React.FunctionComponent<BatchChangeNodeProps> = ({
             default:
                 return node.url
         }
-    }, [executionEnabled, node.url, node.state, node.currentSpec, latestExecution])
+    }, [isExecutionEnabled, node.url, node.state, node.currentSpec, latestExecution])
 
     return (
         <>
             <span className={styles.batchChangeNodeSeparator} />
-            {executionEnabled ? (
+            {isExecutionEnabled ? (
                 <BatchChangeStatePill
                     state={node.state}
                     latestExecutionState={node.batchSpecs.nodes[0]?.state}

--- a/client/web/src/enterprise/batches/list/BatchChangesListIntro.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesListIntro.story.tsx
@@ -30,7 +30,7 @@ function stateToInput(state: LicensingState): boolean | undefined {
 for (const state of Object.values(LicensingState)) {
     add(state, () => (
         <WebStory>
-            {() => <BatchChangesListIntro licensed={stateToInput(radios('licensed', LicensingState, state))} />}
+            {() => <BatchChangesListIntro isLicensed={stateToInput(radios('licensed', LicensingState, state))} />}
         </WebStory>
     ))
 }

--- a/client/web/src/enterprise/batches/list/BatchChangesListIntro.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesListIntro.tsx
@@ -8,11 +8,11 @@ import { SourcegraphIcon } from '../../../auth/icons'
 import styles from './BatchChangesListIntro.module.scss'
 
 export interface BatchChangesListIntroProps {
-    licensed: boolean | undefined
+    isLicensed: boolean | undefined
 }
 
-export const BatchChangesListIntro: React.FunctionComponent<BatchChangesListIntroProps> = ({ licensed }) => {
-    if (licensed === undefined || licensed === true) {
+export const BatchChangesListIntro: React.FunctionComponent<BatchChangesListIntroProps> = ({ isLicensed }) => {
+    if (isLicensed === undefined || isLicensed === true) {
         return null
     }
 

--- a/client/web/src/enterprise/batches/list/backend.ts
+++ b/client/web/src/enterprise/batches/list/backend.ts
@@ -1,19 +1,19 @@
-import { Observable } from 'rxjs'
-import { map } from 'rxjs/operators'
+import { gql } from '@sourcegraph/http-client'
 
-import { dataOrThrowErrors, gql } from '@sourcegraph/http-client'
-
-import { requestGraphQL } from '../../../backend/graphql'
-import {
-    BatchChangesVariables,
-    BatchChangesResult,
-    BatchChangesByNamespaceResult,
-    BatchChangesByNamespaceVariables,
-    AreBatchChangesLicensedResult,
-    AreBatchChangesLicensedVariables,
-} from '../../../graphql-operations'
+import { BatchChangesResult } from '../../../graphql-operations'
 
 const listBatchChangeFragment = gql`
+    fragment BatchChangesFields on BatchChangeConnection {
+        nodes {
+            ...ListBatchChange
+        }
+        pageInfo {
+            endCursor
+            hasNextPage
+        }
+        totalCount
+    }
+
     fragment ListBatchChange on BatchChange {
         id
         url
@@ -54,134 +54,47 @@ export interface ListBatchChangesResult {
     totalCount: number
 }
 
-export const queryBatchChanges = ({
-    first,
-    after,
-    state,
-    viewerCanAdminister,
-}: Partial<BatchChangesVariables>): Observable<ListBatchChangesResult> =>
-    requestGraphQL<BatchChangesResult, BatchChangesVariables>(
-        gql`
-            query BatchChanges($first: Int, $after: String, $state: BatchChangeState, $viewerCanAdminister: Boolean) {
-                batchChanges(first: $first, after: $after, state: $state, viewerCanAdminister: $viewerCanAdminister) {
-                    nodes {
-                        ...ListBatchChange
-                    }
-                    pageInfo {
-                        endCursor
-                        hasNextPage
-                    }
-                    totalCount
-                }
-                allBatchChanges: batchChanges(first: 0) {
-                    totalCount
-                }
-            }
-
-            ${listBatchChangeFragment}
-        `,
-        {
-            first: first ?? null,
-            after: after ?? null,
-            state: state ?? null,
-            viewerCanAdminister: viewerCanAdminister ?? null,
+export const BATCH_CHANGES = gql`
+    query BatchChanges($first: Int, $after: String, $states: [BatchChangeState!], $viewerCanAdminister: Boolean) {
+        batchChanges(first: $first, after: $after, states: $states, viewerCanAdminister: $viewerCanAdminister) {
+            ...BatchChangesFields
         }
-    ).pipe(
-        map(dataOrThrowErrors),
-        map(data => ({
-            batchChanges: data.batchChanges,
-            totalCount: data.allBatchChanges.totalCount,
-        }))
-    )
+    }
 
-export const queryBatchChangesByNamespace = ({
-    namespaceID,
-    first,
-    after,
-    state,
-    viewerCanAdminister,
-}: BatchChangesByNamespaceVariables): Observable<ListBatchChangesResult> =>
-    requestGraphQL<BatchChangesByNamespaceResult, BatchChangesByNamespaceVariables>(
-        gql`
-            query BatchChangesByNamespace(
-                $namespaceID: ID!
-                $first: Int
-                $after: String
-                $state: BatchChangeState
-                $viewerCanAdminister: Boolean
-            ) {
-                node(id: $namespaceID) {
-                    __typename
-                    ... on User {
-                        batchChanges(
-                            first: $first
-                            after: $after
-                            state: $state
-                            viewerCanAdminister: $viewerCanAdminister
-                        ) {
-                            ...BatchChangesFields
-                        }
-                        allBatchChanges: batchChanges(first: 0) {
-                            totalCount
-                        }
-                    }
-                    ... on Org {
-                        batchChanges(
-                            first: $first
-                            after: $after
-                            state: $state
-                            viewerCanAdminister: $viewerCanAdminister
-                        ) {
-                            ...BatchChangesFields
-                        }
-                        allBatchChanges: batchChanges(first: 0) {
-                            totalCount
-                        }
-                    }
+    ${listBatchChangeFragment}
+`
+export const BATCH_CHANGES_BY_NAMESPACE = gql`
+    query BatchChangesByNamespace(
+        $namespaceID: ID!
+        $first: Int
+        $after: String
+        $states: [BatchChangeState!]
+        $viewerCanAdminister: Boolean
+    ) {
+        node(id: $namespaceID) {
+            __typename
+            ... on User {
+                batchChanges(first: $first, after: $after, states: $states, viewerCanAdminister: $viewerCanAdminister) {
+                    ...BatchChangesFields
                 }
             }
-
-            fragment BatchChangesFields on BatchChangeConnection {
-                nodes {
-                    ...ListBatchChange
+            ... on Org {
+                batchChanges(first: $first, after: $after, states: $states, viewerCanAdminister: $viewerCanAdminister) {
+                    ...BatchChangesFields
                 }
-                pageInfo {
-                    endCursor
-                    hasNextPage
-                }
-                totalCount
             }
+        }
+    }
 
-            ${listBatchChangeFragment}
-        `,
-        { first, after, state, viewerCanAdminister, namespaceID }
-    ).pipe(
-        map(dataOrThrowErrors),
-        map(data => {
-            if (!data.node) {
-                throw new Error('Namespace not found')
-            }
+    ${listBatchChangeFragment}
+`
 
-            if (data.node.__typename !== 'Org' && data.node.__typename !== 'User') {
-                throw new Error(`Requested node is a ${data.node.__typename}, not a User or Org`)
-            }
-            return {
-                batchChanges: data.node.batchChanges,
-                totalCount: data.node.allBatchChanges.totalCount,
-            }
-        })
-    )
-
-export function areBatchChangesLicensed(): Observable<boolean> {
-    return requestGraphQL<AreBatchChangesLicensedResult, AreBatchChangesLicensedVariables>(
-        gql`
-            query AreBatchChangesLicensed {
-                campaigns: enterpriseLicenseHasFeature(feature: "campaigns")
-                batchChanges: enterpriseLicenseHasFeature(feature: "batch-changes")
-            }
-        `
-    ).pipe(
-        map(dataOrThrowErrors),
-        map(data => data.campaigns || data.batchChanges)
-    )
-}
+export const GET_LICENSE_AND_USAGE_INFO = gql`
+    query GetLicenseAndUsageInfo {
+        campaigns: enterpriseLicenseHasFeature(feature: "campaigns")
+        batchChanges: enterpriseLicenseHasFeature(feature: "batch-changes")
+        allBatchChanges: batchChanges(first: 1) {
+            totalCount
+        }
+    }
+`

--- a/client/web/src/enterprise/batches/list/backend.ts
+++ b/client/web/src/enterprise/batches/list/backend.ts
@@ -1,10 +1,9 @@
 import { gql } from '@sourcegraph/http-client'
 
-import { BatchChangesResult } from '../../../graphql-operations'
-
 const listBatchChangeFragment = gql`
     fragment BatchChangesFields on BatchChangeConnection {
         nodes {
+            __typename
             ...ListBatchChange
         }
         pageInfo {
@@ -36,27 +35,23 @@ const listBatchChangeFragment = gql`
         }
         batchSpecs(first: 1) {
             nodes {
+                __typename
                 ...ListBatchChangeLatestSpecFields
             }
         }
     }
 
     fragment ListBatchChangeLatestSpecFields on BatchSpec {
-        __typename
         id
         state
         applyURL
     }
 `
 
-export interface ListBatchChangesResult {
-    batchChanges: BatchChangesResult['batchChanges']
-    totalCount: number
-}
-
 export const BATCH_CHANGES = gql`
     query BatchChanges($first: Int, $after: String, $states: [BatchChangeState!], $viewerCanAdminister: Boolean) {
         batchChanges(first: $first, after: $after, states: $states, viewerCanAdminister: $viewerCanAdminister) {
+            __typename
             ...BatchChangesFields
         }
     }
@@ -75,11 +70,13 @@ export const BATCH_CHANGES_BY_NAMESPACE = gql`
             __typename
             ... on User {
                 batchChanges(first: $first, after: $after, states: $states, viewerCanAdminister: $viewerCanAdminister) {
+                    __typename
                     ...BatchChangesFields
                 }
             }
             ... on Org {
                 batchChanges(first: $first, after: $after, states: $states, viewerCanAdminister: $viewerCanAdminister) {
+                    __typename
                     ...BatchChangesFields
                 }
             }

--- a/client/web/src/enterprise/batches/list/testData.ts
+++ b/client/web/src/enterprise/batches/list/testData.ts
@@ -1,6 +1,7 @@
 import { subDays } from 'date-fns'
 
 import {
+    BatchChangesByNamespaceResult,
     BatchChangesResult,
     BatchChangeState,
     BatchSpecState,
@@ -160,6 +161,13 @@ export const NO_BATCH_CHANGES_RESULT: BatchChangesResult = {
         totalCount: 0,
         nodes: [],
         pageInfo: { endCursor: null, hasNextPage: false },
+    },
+}
+
+export const BATCH_CHANGES_BY_NAMESPACE_RESULT: BatchChangesByNamespaceResult = {
+    node: {
+        __typename: 'User',
+        batchChanges: BATCH_CHANGES_RESULT.batchChanges,
     },
 }
 

--- a/client/web/src/enterprise/batches/list/testData.ts
+++ b/client/web/src/enterprise/batches/list/testData.ts
@@ -1,11 +1,18 @@
 import { subDays } from 'date-fns'
 
-import { BatchChangeState, BatchSpecState, ListBatchChange } from '../../../graphql-operations'
+import {
+    BatchChangesResult,
+    BatchChangeState,
+    BatchSpecState,
+    GetLicenseAndUsageInfoResult,
+    ListBatchChange,
+} from '../../../graphql-operations'
 
 export const now = new Date()
 
-export const nodes: Record<string, ListBatchChange> = {
+export const nodes: Record<string, { __typename: 'BatchChange' } & ListBatchChange> = {
     'Open batch change': {
+        __typename: 'BatchChange',
         id: 'test',
         url: '/users/alice/batch-change/test',
         name: 'Awesome batch',
@@ -25,13 +32,13 @@ This is my thorough explanation. And it can also get very long, in that case the
             url: '/users/alice',
         },
         currentSpec: {
-            id: 'old-spec',
+            id: 'old-spec-1',
         },
         batchSpecs: {
             nodes: [
                 {
                     __typename: 'BatchSpec',
-                    id: 'test',
+                    id: 'test-1',
                     state: BatchSpecState.PROCESSING,
                     applyURL: null,
                 },
@@ -39,6 +46,7 @@ This is my thorough explanation. And it can also get very long, in that case the
         },
     },
     'Failed draft': {
+        __typename: 'BatchChange',
         id: 'testdraft',
         url: '/users/alice/batch-change/test',
         name: 'Awesome batch',
@@ -56,13 +64,13 @@ This is my thorough explanation. And it can also get very long, in that case the
             url: '/users/alice',
         },
         currentSpec: {
-            id: 'empty-draft',
+            id: 'empty-draft-2',
         },
         batchSpecs: {
             nodes: [
                 {
                     __typename: 'BatchSpec',
-                    id: 'test',
+                    id: 'test-2',
                     state: BatchSpecState.FAILED,
                     applyURL: null,
                 },
@@ -70,6 +78,7 @@ This is my thorough explanation. And it can also get very long, in that case the
         },
     },
     'No description': {
+        __typename: 'BatchChange',
         id: 'test2',
         url: '/users/alice/batch-changes/test2',
         name: 'Awesome batch',
@@ -87,13 +96,13 @@ This is my thorough explanation. And it can also get very long, in that case the
             url: '/users/alice',
         },
         currentSpec: {
-            id: 'old-spec',
+            id: 'old-spec-3',
         },
         batchSpecs: {
             nodes: [
                 {
                     __typename: 'BatchSpec',
-                    id: 'test',
+                    id: 'test-3',
                     state: BatchSpecState.COMPLETED,
                     applyURL: '/fake-apply-url',
                 },
@@ -101,6 +110,7 @@ This is my thorough explanation. And it can also get very long, in that case the
         },
     },
     'Closed batch change': {
+        __typename: 'BatchChange',
         id: 'test3',
         url: '/users/alice/batch-changes/test3',
         name: 'Awesome batch',
@@ -120,13 +130,13 @@ This is my thorough explanation. And it can also get very long, in that case the
             url: '/users/alice',
         },
         currentSpec: {
-            id: 'test',
+            id: 'test-4',
         },
         batchSpecs: {
             nodes: [
                 {
                     __typename: 'BatchSpec',
-                    id: 'test',
+                    id: 'test-4',
                     state: BatchSpecState.COMPLETED,
                     applyURL: '/fake-apply-url',
                 },
@@ -134,3 +144,30 @@ This is my thorough explanation. And it can also get very long, in that case the
         },
     },
 }
+
+export const BATCH_CHANGES_RESULT: BatchChangesResult = {
+    batchChanges: {
+        __typename: 'BatchChangeConnection',
+        totalCount: Object.values(nodes).length,
+        nodes: Object.values(nodes),
+        pageInfo: { endCursor: null, hasNextPage: false },
+    },
+}
+
+export const NO_BATCH_CHANGES_RESULT: BatchChangesResult = {
+    batchChanges: {
+        __typename: 'BatchChangeConnection',
+        totalCount: 0,
+        nodes: [],
+        pageInfo: { endCursor: null, hasNextPage: false },
+    },
+}
+
+export const getLicenseAndUsageInfoResult = (
+    isLicensed = true,
+    hasBatchChanges = true
+): GetLicenseAndUsageInfoResult => ({
+    campaigns: isLicensed,
+    batchChanges: isLicensed,
+    allBatchChanges: { totalCount: hasBatchChanges ? Object.values(nodes).length : 0 },
+})

--- a/client/web/src/integration/batches.test.ts
+++ b/client/web/src/integration/batches.test.ts
@@ -36,7 +36,8 @@ import { percySnapshotWithVariants } from './utils'
 
 const now = new Date()
 
-const batchChangeListNode: ListBatchChange = {
+const batchChangeListNode: ListBatchChange & { __typename: 'BatchChange' } = {
+    __typename: 'BatchChange',
     id: 'batch123',
     url: '/users/alice/batch-changes/test-batch-change',
     name: 'test-batch-change',
@@ -359,14 +360,12 @@ function mockCommonGraphQLResponses(
                       node: {
                           __typename: 'User',
                           batchChanges: {
+                              __typename: 'BatchChangeConnection',
                               nodes: [batchChangeListNode],
                               pageInfo: {
                                   endCursor: null,
                                   hasNextPage: false,
                               },
-                              totalCount: 1,
-                          },
-                          allBatchChanges: {
                               totalCount: 1,
                           },
                       },
@@ -375,6 +374,7 @@ function mockCommonGraphQLResponses(
                       node: {
                           __typename: 'Org',
                           batchChanges: {
+                              __typename: 'BatchChangeConnection',
                               nodes: [
                                   {
                                       ...batchChangeListNode,
@@ -389,9 +389,6 @@ function mockCommonGraphQLResponses(
                                   endCursor: null,
                                   hasNextPage: false,
                               },
-                              totalCount: 1,
-                          },
-                          allBatchChanges: {
                               totalCount: 1,
                           },
                       },
@@ -417,22 +414,23 @@ describe('Batches', () => {
     afterEach(() => testContext?.dispose())
 
     const batchChangeLicenseGraphQlResults = {
-        AreBatchChangesLicensed: () => ({
+        GetLicenseAndUsageInfo: () => ({
             campaigns: true,
             batchChanges: true,
+            allBatchChanges: {
+                totalCount: 1,
+            },
         }),
     }
     const batchChangesListResults = {
         BatchChanges: () => ({
             batchChanges: {
+                __typename: 'BatchChangeConnection' as const,
                 nodes: [batchChangeListNode],
                 pageInfo: {
                     endCursor: null,
                     hasNextPage: false,
                 },
-                totalCount: 1,
-            },
-            allBatchChanges: {
                 totalCount: 1,
             },
         }),


### PR DESCRIPTION
Closes #31164.

Swaps out the filters on the batch changes index (list) page from a set of radio buttons to a new `MultiSelect`, which defaults to open + draft (or just open, if running batch changes server-side is not enabled).

<img width="1169" alt="image" src="https://user-images.githubusercontent.com/8942601/157564433-659dffc0-1b52-4246-9baf-8ef8c8c33a19.png">

Design based on [this Figma screen](https://www.figma.com/file/cTKjwbvWqU6xAykZmCTTqy/SSBC?node-id=1455%3A48950), but with a multi-select in place of the single select dropdown and without the search field.

Granted, it looks a little odd right now for users without server-side execution enabled, since there are only the two options for open and closed. But I don't think it's necessarily worth the effort and extra code to preserve the radio buttons when the flag is disabled when we'll only be supporting that case for at most a couple more releases.

Most of the code changes here, as you might notice, are actually because I migrated the list view for this page from the older `requestGraphQL` and `FilteredConnection` to Apollo, `useConnection`, and the new filtered connection component composition API as part of this work. As part of _that_ migration, I was also able to simplify the logic around if batch changes is licensed and if there are any batch changes created yet (to auto-switch to the "Getting started" tab if not) by capturing them both in a single query, independent from the connection.

## Test plan

This page is heavily covered by storybook stories as well as an integration test. I've added an additional storybook story for the namespace version of this page. I also verified manually that things were functioning as expected as thoroughly as I could.


