### PR TITLE
Revert "Add a ready mechanism to the conf pkg"

### DIFF
--- a/cmd/github-proxy/github-proxy.go
+++ b/cmd/github-proxy/github-proxy.go
@@ -59,7 +59,6 @@ func main() {
 	env.Lock()
 	env.HandleHelpFlag()
 	logging.Init()
-	conf.Init()
 	tracer.Init(conf.DefaultClient())
 	sentry.Init(conf.DefaultClient())
 	trace.Init()

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -93,20 +93,30 @@ func initDefaultClient() *client {
 	defaultClient := &client{store: clientStore}
 
 	mode := getMode()
+
 	// Don't kickoff the background updaters for the client/server
 	// when in empty mode.
 	if mode == modeEmpty {
 		close(configurationServerFrontendOnlyInitialized)
 
 		// Seed the client store with an empty configuration.
-		_, err := defaultClient.store.MaybeUpdate(conftypes.RawUnified{
+		_, err := clientStore.MaybeUpdate(conftypes.RawUnified{
 			Site:               "{}",
 			ServiceConnections: conftypes.ServiceConnections{},
 		})
 		if err != nil {
 			log.Fatalf("received error when setting up the store for the default client during test, err :%s", err)
 		}
+		return defaultClient
 	}
+
+	// The default client is started in InitConfigurationServerFrontendOnly in
+	// the case of server mode.
+	if mode == modeClient {
+		go defaultClient.continuouslyUpdate(nil)
+		close(configurationServerFrontendOnlyInitialized)
+	}
+
 	return defaultClient
 }
 

--- a/internal/conf/init.go
+++ b/internal/conf/init.go
@@ -6,20 +6,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
 
-// Init function completes the initialization process of the conf package, starting the configuration continuous changes polling
-// if in client mode. The conf.Watch function can safely be called before calling Init to register callbacks reacting to the changes.
-//
-// The Init function must be called early in an application initialization process, but tests do not need to call it.
 func Init() {
-	// The default client is started in InitConfigurationServerFrontendOnly in
-	// the case of server mode.
-	if getMode() == modeClient {
-		go DefaultClient().continuouslyUpdate(nil)
-		close(configurationServerFrontendOnlyInitialized)
-	}
-
 	// This watch loop is here so that we don't introduce
-	// package dependency cycles, since conf itself uses httpcli's internal
+	// dependency cycles, since conf itself uses httpcli's internal
 	// client. This is gross, and the whole conf package is gross.
 	go Watch(func() {
 		before := httpcli.TLSExternalConfig()


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#32265

This was causing the symbols service in dogfood to not be found:

<img width="304" alt="CleanShot 2022-03-09 at 17 12 54@2x" src="https://user-images.githubusercontent.com/1387653/157561236-1af0a4b6-99ef-41d4-ba5c-a529614999ac.png">

Here's a stack frame dump:

<details>
<summary>Click to expand 👈</summary>

```
SIGQUIT: quit
PC=0x475921 m=0 sigcode=0

goroutine 42 [syscall]:
runtime.notetsleepg(0x0, 0x0)
	runtime/lock_futex.go:236 +0x34 fp=0xc000398fa0 sp=0xc000398f68 pc=0x4143b4
os/signal.signal_recv()
	runtime/sigqueue.go:169 +0x98 fp=0xc000398fc0 sp=0xc000398fa0 pc=0x46ff78
os/signal.loop()
	os/signal/signal_unix.go:24 +0x19 fp=0xc000398fe0 sp=0xc000398fc0 pc=0xdc0eb9
runtime.goexit()
	runtime/asm_amd64.s:1581 +0x1 fp=0xc000398fe8 sp=0xc000398fe0 pc=0x473b21
created by os/signal.Notify.func1.1
	os/signal/signal.go:151 +0x2c

goroutine 1 [select]:
github.com/sourcegraph/sourcegraph/internal/goroutine.waitForSignal({0x17cb7f8, 0xc0000a4000}, 0xc000efd620)
	github.com/sourcegraph/sourcegraph/internal/goroutine/background.go:91 +0x6f
github.com/sourcegraph/sourcegraph/internal/goroutine.monitorBackgroundRoutines({0x17cb7f8, 0xc0000a4000}, 0x3, {0xc00046f760, 0x2, 0x2})
	github.com/sourcegraph/sourcegraph/internal/goroutine/background.go:62 +0x72
github.com/sourcegraph/sourcegraph/internal/goroutine.MonitorBackgroundRoutines({0x17cb7f8, 0xc0000a4000}, {0xc00046f760, 0x2, 0x2})
	github.com/sourcegraph/sourcegraph/internal/goroutine/background.go:56 +0xe5
github.com/sourcegraph/sourcegraph/cmd/symbols/shared.Main(0x14eb9d0)
	github.com/sourcegraph/sourcegraph/cmd/symbols/shared/main.go:86 +0x6d1
main.main()
	github.com/sourcegraph/sourcegraph/enterprise/cmd/symbols/main.go:60 +0xea

goroutine 45 [chan receive]:
github.com/sourcegraph/sourcegraph/internal/conf.(*client).Watch.func1()
	github.com/sourcegraph/sourcegraph/internal/conf/client.go:154 +0x2d
created by github.com/sourcegraph/sourcegraph/internal/conf.(*client).Watch
	github.com/sourcegraph/sourcegraph/internal/conf/client.go:151 +0x175

goroutine 8 [select]:
go.opencensus.io/stats/view.(*worker).start(0xc00025fa00)
	go.opencensus.io@v0.23.0/stats/view/worker.go:276 +0xb9
created by go.opencensus.io/stats/view.init.0
	go.opencensus.io@v0.23.0/stats/view/worker.go:34 +0x92

goroutine 9 [chan receive]:
github.com/golang/glog.(*loggingT).flushDaemon(0x0)
	github.com/golang/glog@v1.0.0/glog.go:882 +0x6a
created by github.com/golang/glog.init.0
	github.com/golang/glog@v1.0.0/glog.go:410 +0x1c5

goroutine 83 [sleep]:
time.Sleep(0x29c92625)
	runtime/time.go:193 +0x12e
github.com/sourcegraph/sourcegraph/internal/conf.(*client).continuouslyUpdate.func1()
	github.com/sourcegraph/sourcegraph/internal/conf/client.go:223 +0x2f
github.com/sourcegraph/sourcegraph/internal/conf.(*client).continuouslyUpdate(0x0, 0xc000efc840)
	github.com/sourcegraph/sourcegraph/internal/conf/client.go:249 +0x94
created by github.com/sourcegraph/sourcegraph/internal/conf.Init
	github.com/sourcegraph/sourcegraph/internal/conf/init.go:17 +0x7a

goroutine 90 [IO wait]:
internal/poll.runtime_pollWait(0x4027718958, 0x72)
	runtime/netpoll.go:234 +0x89
internal/poll.(*pollDesc).wait(0xc00025e000, 0x4, 0x0)
	internal/poll/fd_poll_runtime.go:84 +0x32
internal/poll.(*pollDesc).waitRead(...)
	internal/poll/fd_poll_runtime.go:89
internal/poll.(*FD).Accept(0xc00025e000)
	internal/poll/fd_unix.go:402 +0x22c
net.(*netFD).accept(0xc00025e000)
	net/fd_unix.go:173 +0x35
net.(*TCPListener).accept(0xc000fac030)
	net/tcpsock_posix.go:140 +0x28
net.(*TCPListener).Accept(0xc000fac030)
	net/tcpsock.go:262 +0x3d
net/http.(*Server).Serve(0xc000338700, {0x17bf240, 0xc000fac030})
	net/http/server.go:3002 +0x394
github.com/sourcegraph/sourcegraph/internal/httpserver.(*server).Start(0xc000eae390)
	github.com/sourcegraph/sourcegraph/internal/httpserver/server.go:61 +0xec
created by github.com/sourcegraph/sourcegraph/cmd/symbols/shared.Main
	github.com/sourcegraph/sourcegraph/cmd/symbols/shared/main.go:74 +0x4f2

goroutine 43 [IO wait]:
internal/poll.runtime_pollWait(0x40277186a0, 0x72)
	runtime/netpoll.go:234 +0x89
internal/poll.(*pollDesc).wait(0xc00025e580, 0xc0005d4000, 0x0)
	internal/poll/fd_poll_runtime.go:84 +0x32
internal/poll.(*pollDesc).waitRead(...)
	internal/poll/fd_poll_runtime.go:89
internal/poll.(*FD).Read(0xc00025e580, {0xc0005d4000, 0x1000, 0x1000})
	internal/poll/fd_unix.go:167 +0x25a
net.(*netFD).Read(0xc00025e580, {0xc0005d4000, 0x442187, 0xc0005bec30})
	net/fd_posix.go:56 +0x29
net.(*conn).Read(0xc000312030, {0xc0005d4000, 0x19, 0xc000302000})
	net/net.go:183 +0x45
net/http.(*persistConn).Read(0xc0005c2000, {0xc0005d4000, 0xc000f781e0, 0xc0005bed30})
	net/http/transport.go:1926 +0x4e
bufio.(*Reader).fill(0xc00018e540)
	bufio/bufio.go:101 +0x103
bufio.(*Reader).Peek(0xc00018e540, 0x1)
	bufio/bufio.go:139 +0x5d
net/http.(*persistConn).readLoop(0xc0005c2000)
	net/http/transport.go:2087 +0x1ac
created by net/http.(*Transport).dialConn
	net/http/transport.go:1747 +0x1e05

goroutine 92 [select]:
github.com/sourcegraph/sourcegraph/internal/goroutine.(*PeriodicGoroutine).Start(0xc000488870)
	github.com/sourcegraph/sourcegraph/internal/goroutine/periodic.go:117 +0x15b
github.com/sourcegraph/sourcegraph/internal/goroutine.startAll.func1()
	github.com/sourcegraph/sourcegraph/internal/goroutine/background.go:73 +0x5d
github.com/sourcegraph/sourcegraph/internal/goroutine.Go.func1()
	github.com/sourcegraph/sourcegraph/internal/goroutine/goroutine.go:24 +0x3f
created by github.com/sourcegraph/sourcegraph/internal/goroutine.Go
	github.com/sourcegraph/sourcegraph/internal/goroutine/goroutine.go:16 +0x5b

goroutine 93 [IO wait]:
internal/poll.runtime_pollWait(0x4027718788, 0x72)
	runtime/netpoll.go:234 +0x89
internal/poll.(*pollDesc).wait(0xc00053c280, 0x2, 0x0)
	internal/poll/fd_poll_runtime.go:84 +0x32
internal/poll.(*pollDesc).waitRead(...)
	internal/poll/fd_poll_runtime.go:89
internal/poll.(*FD).Accept(0xc00053c280)
	internal/poll/fd_unix.go:402 +0x22c
net.(*netFD).accept(0xc00053c280)
	net/fd_unix.go:173 +0x35
net.(*TCPListener).accept(0xc00118c060)
	net/tcpsock_posix.go:140 +0x28
net.(*TCPListener).Accept(0xc00118c060)
	net/tcpsock.go:262 +0x3d
net/http.(*Server).Serve(0xc0003387e0, {0x17bf240, 0xc00118c060})
	net/http/server.go:3002 +0x394
github.com/sourcegraph/sourcegraph/internal/httpserver.(*server).Start(0xc000eae510)
	github.com/sourcegraph/sourcegraph/internal/httpserver/server.go:61 +0xec
github.com/sourcegraph/sourcegraph/internal/goroutine.startAll.func1()
	github.com/sourcegraph/sourcegraph/internal/goroutine/background.go:73 +0x5d
github.com/sourcegraph/sourcegraph/internal/goroutine.Go.func1()
	github.com/sourcegraph/sourcegraph/internal/goroutine/goroutine.go:24 +0x3f
created by github.com/sourcegraph/sourcegraph/internal/goroutine.Go
	github.com/sourcegraph/sourcegraph/internal/goroutine/goroutine.go:16 +0x5b

goroutine 94 [chan receive]:
github.com/sourcegraph/sourcegraph/internal/conf.(*client).Watch.func1()
	github.com/sourcegraph/sourcegraph/internal/conf/client.go:154 +0x2d
created by github.com/sourcegraph/sourcegraph/internal/conf.(*client).Watch
	github.com/sourcegraph/sourcegraph/internal/conf/client.go:151 +0x175

goroutine 26 [chan receive]:
github.com/sourcegraph/sourcegraph/internal/conf.(*client).Watch.func1()
	github.com/sourcegraph/sourcegraph/internal/conf/client.go:154 +0x2d
created by github.com/sourcegraph/sourcegraph/internal/conf.(*client).Watch
	github.com/sourcegraph/sourcegraph/internal/conf/client.go:151 +0x175

goroutine 44 [select]:
net/http.(*persistConn).writeLoop(0xc0005c2000)
	net/http/transport.go:2386 +0xfb
created by net/http.(*Transport).dialConn
	net/http/transport.go:1748 +0x1e65

rax    0xca
rbx    0x0
rcx    0xffffffffffffffff
rdx    0x0
rdi    0x258b060
rsi    0x80
rbp    0xc000398f18
rsp    0xc000398ed0
r8     0x0
r9     0x0
r10    0x0
r11    0x3
r12    0xc00004a000
r13    0x0
r14    0xc0011dc340
r15    0x4027214716
rip    0x475921
rflags 0x286
cs     0x33
fs     0x0
gs     0x0
```

</details>

I verified by building and running both:

- On c4d4caa65b (which includes #32265), symbols run successfully ✅
- On c4d4caa65b + reverted e3e69376b2e8b74dc056b0dc9f7949615d0bff5c (which does **not** include #32265), symbols got stuck on conf ❌

Does the symbols service also need to remove `conf.Init()`?