### PR TITLE
pr-auditor: try using default GITHUB_TOKEN to set commit status on forks

### DIFF
--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -15,5 +15,6 @@ jobs:
       - run: ./dev/pr-auditor/check-pr.sh
         env:
           GITHUB_EVENT_PATH: ${{ env.GITHUB_EVENT_PATH }}
-          GITHUB_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
           GITHUB_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/dev/pr-auditor/check-pr.sh
+++ b/dev/pr-auditor/check-pr.sh
@@ -9,4 +9,5 @@ echo "--- Running 'pr-auditor'"
 go run ./dev/pr-auditor/ \
   -github.payload-path="$GITHUB_EVENT_PATH" \
   -github.token="$GITHUB_TOKEN" \
+  -github.repo-token="$GITHUB_REPO_TOKEN" \
   -github.run-url="$GITHUB_RUN_URL"


### PR DESCRIPTION
testing out forks again, wondering if the default GITHUB_TOKEN might be allowed to set commit statuses on forks. previous attempt to switch to using the run output did not work very well: https://github.com/sourcegraph/sourcegraph/pull/31946#issuecomment-1054550210

looks like it doesn't work :( even with the default token, https://github.com/sourcegraph/sourcegraph/runs/5488972911?check_suite_focus=true#step:4:31 

```
2022/03/10 00:27:10 checkPR: {Reviewed:false TestPlan: Error:<nil>}
2022/03/10 00:27:10 preMergeAudit: CreateStatus: POST [api.github.com/repos/sourcegraph/sourcegraph/statuses/96ae789554c724890663518d83cc8b895aacc0a9:](https://api.github.com/repos/sourcegraph/sourcegraph/statuses/96ae789554c724890663518d83cc8b895aacc0a9:) 403 Resource not accessible by integration []
```


more details from thread: https://sourcegraph.slack.com/archives/C01N83PS4TU/p1646870889938299?thread_ts=1646865673.857509&cid=C01N83PS4TU

> The issue is setting commit statuses on PRs - the check does run (see check logs), but for whatever reason GitHub doesn't allow you to set the status on commits on forks :grimacing: You're only allowed to use the run output. This doesn't work for us because we use the pull request events so that we get the pull request payload in the event - subsequent pushes will look "green" when it is not. We can run on push, but that doesn't include the PR payload, necessitating extra API requests to perform the PR description check

Another experiment: https://github.com/sourcegraph/sourcegraph/pull/32423

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


