### PR TITLE
pr-auditor: try setting status on fork origin

### DIFF
--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -12,6 +12,11 @@ jobs:
       - uses: actions/setup-go@v2
         with: { go-version: '1.17' }
 
+      - name: print payload
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: |
+          echo "$GITHUB_CONTEXT"
       - run: ./dev/pr-auditor/check-pr.sh
         env:
           GITHUB_EVENT_PATH: ${{ env.GITHUB_EVENT_PATH }}

--- a/dev/pr-auditor/main.go
+++ b/dev/pr-auditor/main.go
@@ -171,8 +171,8 @@ func preMergeAudit(ctx context.Context, ghc *github.Client, payload *EventPayloa
 		stateDescription = "No action needed, nice!"
 	}
 
-	owner, repo := payload.Repository.GetOwnerAndName()
-	_, _, err := ghc.Repositories.CreateStatus(ctx, owner, repo, payload.PullRequest.Head.SHA, &github.RepoStatus{
+	_, repo := payload.Repository.GetOwnerAndName()
+	_, _, err := ghc.Repositories.CreateStatus(ctx, "bobheadlabs", repo, payload.PullRequest.Head.SHA, &github.RepoStatus{
 		Context:     github.String(commitStatusPreMerge),
 		State:       github.String(prState),
 		Description: github.String(stateDescription),


### PR DESCRIPTION
Another take on PR-auditor for PRs from forks, another approach at https://github.com/sourcegraph/sourcegraph/pull/32421

No-go either:

```
2022/03/10 00:47:[30](https://github.com/sourcegraph/sourcegraph/runs/5489139306?check_suite_focus=true#step:5:30) checkPR: {Reviewed:false TestPlan: Error:<nil>}
2022/03/10 00:47:30 preMergeAudit: CreateStatus: POST [api.github.com/repos/bobheadlabs/sourcegraph/statuses/fef24a03d1114359ee3c607d7c1e6b87dfa95135:](https://api.github.com/repos/bobheadlabs/sourcegraph/statuses/fef24a03d1114359ee3c607d7c1e6b87dfa95135:) 401 Bad credentials []
```

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->
