### PR TITLE
search: add repo pager job

### DIFF
--- a/internal/search/job/printers.go
+++ b/internal/search/job/printers.go
@@ -9,9 +9,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/commit"
 	"github.com/sourcegraph/sourcegraph/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/search/run"
+	"github.com/sourcegraph/sourcegraph/internal/search/searcher"
 	"github.com/sourcegraph/sourcegraph/internal/search/structural"
 	"github.com/sourcegraph/sourcegraph/internal/search/symbol"
 	"github.com/sourcegraph/sourcegraph/internal/search/textsearch"
+	"github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 )
 
 func writeSep(b *bytes.Buffer, sep, indent string, depth int) {
@@ -39,6 +41,8 @@ func SexpFormat(job Job, sep, indent string) string {
 		}
 		switch j := job.(type) {
 		case
+			*zoekt.ZoektRepoSubsetSearch,
+			*searcher.Searcher,
 			*run.RepoSearch,
 			*textsearch.RepoSubsetTextSearch,
 			*textsearch.RepoUniverseTextSearch,
@@ -49,6 +53,15 @@ func SexpFormat(job Job, sep, indent string) string {
 			*repos.ComputeExcludedRepos,
 			*noopJob:
 			b.WriteString(j.Name())
+
+		case *repoPagerJob:
+			b.WriteString("REPOPAGER")
+			depth++
+			writeSep(b, sep, indent, depth)
+			writeSexp(j.child)
+			b.WriteString(")")
+			depth--
+
 		case *AndJob:
 			b.WriteString("(AND")
 			depth++
@@ -198,6 +211,8 @@ func PrettyMermaid(job Job) string {
 		}
 		switch j := job.(type) {
 		case
+			*zoekt.ZoektRepoSubsetSearch,
+			*searcher.Searcher,
 			*run.RepoSearch,
 			*textsearch.RepoSubsetTextSearch,
 			*textsearch.RepoUniverseTextSearch,
@@ -208,6 +223,14 @@ func PrettyMermaid(job Job) string {
 			*repos.ComputeExcludedRepos,
 			*noopJob:
 			writeNode(b, depth, RoundedStyle, &id, j.Name())
+
+		case *repoPagerJob:
+			srcId := id
+			depth++
+			writeNode(b, depth, RoundedStyle, &id, "REPOPAGER")
+			writeEdge(b, depth, srcId, id)
+			writeMermaid(j.child)
+			depth--
 		case *AndJob:
 			srcId := id
 			depth++
@@ -314,6 +337,8 @@ func toJSON(job Job, verbose bool) interface{} {
 		}
 		switch j := job.(type) {
 		case
+			*zoekt.ZoektRepoSubsetSearch,
+			*searcher.Searcher,
 			*run.RepoSearch,
 			*textsearch.RepoSubsetTextSearch,
 			*textsearch.RepoUniverseTextSearch,
@@ -327,6 +352,13 @@ func toJSON(job Job, verbose bool) interface{} {
 				return map[string]interface{}{j.Name(): j}
 			}
 			return j.Name()
+
+		case *repoPagerJob:
+			return struct {
+				Repopager interface{} `json:"REPOPAGER"`
+			}{
+				Repopager: emitJSON(j.child),
+			}
 
 		case *AndJob:
 			children := make([]interface{}, 0, len(j.children))

--- a/internal/search/job/repo_pager_job.go
+++ b/internal/search/job/repo_pager_job.go
@@ -1,0 +1,84 @@
+package job
+
+import (
+	"context"
+
+	zoektstreamer "github.com/google/zoekt"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	"github.com/sourcegraph/sourcegraph/internal/search/repos"
+	"github.com/sourcegraph/sourcegraph/internal/search/searcher"
+	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+	"github.com/sourcegraph/sourcegraph/internal/search/zoekt"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+)
+
+type repoPagerJob struct {
+	repoOptions      search.RepoOptions
+	useIndex         query.YesNoOnly // whether to include indexed repos
+	containsRefGlobs bool            // whether to include repositories with refs
+	child            Job             // child job tree that need populating a repos field to run
+
+	zoekt zoektstreamer.Streamer
+}
+
+// setRepos populates the repos field for all jobs that need repos. Jobs are
+// copied, ensuring this function is side-effect free.
+func setRepos(job Job, indexed *zoekt.IndexedRepoRevs, unindexed []*search.RepositoryRevisions) Job {
+	setZoektRepos := func(job *zoekt.ZoektRepoSubsetSearch) *zoekt.ZoektRepoSubsetSearch {
+		jobCopy := *job
+		jobCopy.Repos = indexed
+		return &jobCopy
+	}
+
+	setSearcherRepos := func(job *searcher.Searcher) *searcher.Searcher {
+		jobCopy := *job
+		jobCopy.Repos = unindexed
+		return &jobCopy
+	}
+
+	setRepos := Mapper{
+		MapZoektRepoSubsetSearchJob: setZoektRepos,
+		MapSearcherJob:              setSearcherRepos,
+	}
+
+	return setRepos.Map(job)
+}
+
+func (p *repoPagerJob) Run(ctx context.Context, db database.DB, stream streaming.Sender) (_ *search.Alert, err error) {
+	tr, ctx := trace.New(ctx, "pageReposJob", "")
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
+
+	var maxAlerter search.MaxAlerter
+
+	repoResolver := &repos.Resolver{DB: db, Opts: p.repoOptions}
+	pager := func(page *repos.Resolved) error {
+		indexed, unindexed, err := zoekt.PartitionRepos(
+			ctx,
+			page.RepoRevs,
+			p.zoekt,
+			search.TextRequest,
+			p.useIndex,
+			p.containsRefGlobs,
+			zoekt.MissingRepoRevStatus(stream),
+		)
+		if err != nil {
+			return err
+		}
+
+		job := setRepos(p.child, indexed, unindexed)
+		alert, err := job.Run(ctx, db, stream)
+		maxAlerter.Add(alert)
+		return err
+	}
+
+	return maxAlerter.Alert, repoResolver.Paginate(ctx, nil, pager)
+}
+
+func (p *repoPagerJob) Name() string {
+	return "RepoPager"
+}

--- a/internal/search/job/repo_pager_job_test.go
+++ b/internal/search/job/repo_pager_job_test.go
@@ -1,0 +1,80 @@
+package job
+
+import (
+	"testing"
+
+	"github.com/hexops/autogold"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/searcher"
+	"github.com/sourcegraph/sourcegraph/internal/search/zoekt"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func Test_setRepos(t *testing.T) {
+	// Static test data
+	indexed := &zoekt.IndexedRepoRevs{
+		RepoRevs: map[api.RepoID]*search.RepositoryRevisions{
+			1: {Repo: types.MinimalRepo{Name: "indexed"}},
+		},
+	}
+	unindexed := []*search.RepositoryRevisions{
+		{Repo: types.MinimalRepo{Name: "unindexed"}},
+	}
+
+	// Test function
+	test := func(job Job) string {
+		job = setRepos(job, indexed, unindexed)
+		return "\n" + PrettyJSONVerbose(job)
+	}
+
+	autogold.Want("set repos for jobs that need them", `
+{
+  "PARALLEL": [
+    {
+      "ZoektRepoSubset": {
+        "Repos": {
+          "RepoRevs": {
+            "1": {
+              "Repo": {
+                "ID": 0,
+                "Name": "indexed",
+                "Stars": 0
+              },
+              "Revs": null
+            }
+          }
+        },
+        "Query": null,
+        "Typ": "",
+        "FileMatchLimit": 0,
+        "Select": null,
+        "Zoekt": null
+      }
+    },
+    {
+      "Searcher": {
+        "PatternInfo": null,
+        "Repos": [
+          {
+            "Repo": {
+              "ID": 0,
+              "Name": "unindexed",
+              "Stars": 0
+            },
+            "Revs": null
+          }
+        ],
+        "Indexed": false,
+        "SearcherURLs": null,
+        "UseFullDeadline": false
+      }
+    }
+  ]
+}`).Equal(t, test(
+		NewParallelJob(
+			&zoekt.ZoektRepoSubsetSearch{},
+			&searcher.Searcher{},
+		),
+	))
+}

--- a/internal/search/job/types.go
+++ b/internal/search/job/types.go
@@ -8,10 +8,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/commit"
 	"github.com/sourcegraph/sourcegraph/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/search/run"
+	"github.com/sourcegraph/sourcegraph/internal/search/searcher"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/search/structural"
 	"github.com/sourcegraph/sourcegraph/internal/search/symbol"
 	"github.com/sourcegraph/sourcegraph/internal/search/textsearch"
+	"github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 )
 
 // Job is an interface shared by all individual search operations in the
@@ -25,6 +27,8 @@ type Job interface {
 }
 
 var allJobs = []Job{
+	&zoekt.ZoektRepoSubsetSearch{},
+	&searcher.Searcher{},
 	&run.RepoSearch{},
 	&textsearch.RepoSubsetTextSearch{},
 	&textsearch.RepoUniverseTextSearch{},
@@ -34,6 +38,8 @@ var allJobs = []Job{
 	&symbol.RepoUniverseSymbolSearch{},
 	&repos.ComputeExcludedRepos{},
 	&noopJob{},
+
+	&repoPagerJob{},
 
 	&AndJob{},
 	&OrJob{},

--- a/internal/search/repo_revs.go
+++ b/internal/search/repo_revs.go
@@ -72,7 +72,7 @@ type RepositoryRevisions struct {
 
 	// ListRefs is called to list all Git refs for a repository. It is intended to be mocked by
 	// tests. If nil, git.ListRefs is used.
-	ListRefs func(context.Context, api.RepoName) ([]git.Ref, error)
+	ListRefs func(context.Context, api.RepoName) ([]git.Ref, error) `json:"-"`
 }
 
 func (r *RepositoryRevisions) Copy() *RepositoryRevisions {

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -584,7 +584,7 @@ type ZoektRepoSubsetSearch struct {
 	FileMatchLimit int32
 	Select         filter.SelectPath
 	Zoekt          zoekt.Streamer
-	Since          func(time.Time) time.Duration // since if non-nil will be used instead of time.Since. For tests
+	Since          func(time.Time) time.Duration `json:"-"` // since if non-nil will be used instead of time.Since. For tests
 }
 
 // ZoektSearch is a job that searches repositories using zoekt.


### PR DESCRIPTION
A polished up version of previous repo pagination job in https://github.com/sourcegraph/sourcegraph/pull/32029. The main change is that I realized using the mapper interface actually reduces the complexity and brittleness of more separate ad-hoc case statements/type assertions.

This after trying to add methods to the current `Job` interface to populate repos, I realized that this is going to make everything _incredibly ugly_ and more difficult to reason about.

## Test plan
Added unit test for the main partitioning logic. This job isn't hooked up or used yet (no `backend-integration` test needed).

