### PR TITLE
 🌈🦋🦄 fix all the "how do I configure email / SMTP?" issues

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -746,6 +746,13 @@ type Mutation {
         """
         settingsToEdit: String!
     ): EmptyResponse!
+
+    """
+    Sends an email for testing Sourcegraph's email configuration.
+
+    Only administrators can use this API.
+    """
+    sendTestEmail(to: String!): String!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/send_test_email.go
+++ b/cmd/frontend/graphqlbackend/send_test_email.go
@@ -1,0 +1,44 @@
+package graphqlbackend
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/internal/txemail"
+	"github.com/sourcegraph/sourcegraph/internal/txemail/txtypes"
+)
+
+func (r *schemaResolver) SendTestEmail(ctx context.Context, args struct{ To string }) (string, error) {
+	// 🚨 SECURITY: Only site admins can send test emails.
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
+		return "", err
+	}
+
+	if err := txemail.Send(ctx, txemail.Message{
+		To:       []string{args.To},
+		Template: emailTemplateTest,
+		Data:     struct{}{},
+	}); err != nil {
+		return fmt.Sprintf("Failed to send test email: %s", err), nil
+	}
+	return fmt.Sprintf("Sent test email to %q successfully! Please check it was received.", args.To), nil
+}
+
+var emailTemplateTest = txemail.MustValidate(txtypes.Templates{
+	Subject: `TEST: email sent from Sourcegraph`,
+	Text: `
+If you're seeing this, Sourcegraph is able to send email correctly for all of it's product features!
+
+Congratulations!
+
+* Sourcegraph
+`,
+	HTML: `
+<p>Sourcegraph is able to send email correctly for all of it's product features!</p>
+<br>
+<p>Congratulations!</p>
+<br>
+<p>* Sourcegraph</p>
+`,
+})

--- a/cmd/frontend/graphqlbackend/site_alerts.go
+++ b/cmd/frontend/graphqlbackend/site_alerts.go
@@ -215,14 +215,14 @@ func isMinorUpdateAvailable(currentVersion, updateVersion string) bool {
 
 func emailSendingNotConfiguredAlert(args AlertFuncArgs) []*Alert {
 	if conf.Get().EmailSmtp == nil || conf.Get().EmailSmtp.Host == "" {
-		return []*Alert{&Alert{
+		return []*Alert{{
 			TypeValue:                 AlertTypeWarning,
 			MessageValue:              "Warning: Sourcegraph cannot send emails! [Configure `email.smtp`](/help/admin/config/email) so that features such as Code Monitors, password resets, and invitations work. [documentation](/help/admin/config/email)",
 			IsDismissibleWithKeyValue: "email-sending",
 		}}
 	}
 	if conf.Get().EmailAddress == "" {
-		return []*Alert{&Alert{
+		return []*Alert{{
 			TypeValue:                 AlertTypeWarning,
 			MessageValue:              "Warning: Sourcegraph cannot send emails! [Configure `email.address`](/help/admin/config/email) so that features such as Code Monitors, password resets, and invitations work. [documentation](/help/admin/config/email)",
 			IsDismissibleWithKeyValue: "email-sending",

--- a/cmd/frontend/graphqlbackend/site_alerts.go
+++ b/cmd/frontend/graphqlbackend/site_alerts.go
@@ -97,6 +97,9 @@ func init() {
 		return problems
 	})
 
+	// Warn if email sending is not configured.
+	AlertFuncs = append(AlertFuncs, emailSendingNotConfiguredAlert)
+
 	if !disableSecurity {
 		// Warn about Sourcegraph being out of date.
 		AlertFuncs = append(AlertFuncs, outOfDateAlert)
@@ -208,6 +211,24 @@ func isMinorUpdateAvailable(currentVersion, updateVersion string) bool {
 		return true
 	}
 	return cv.Major() != uv.Major() || cv.Minor() != uv.Minor()
+}
+
+func emailSendingNotConfiguredAlert(args AlertFuncArgs) []*Alert {
+	if conf.Get().EmailSmtp == nil || conf.Get().EmailSmtp.Host == "" {
+		return []*Alert{&Alert{
+			TypeValue:                 AlertTypeWarning,
+			MessageValue:              "Warning: Sourcegraph cannot send emails! [Configure `email.smtp`](/help/admin/config/email) so that features such as Code Monitors, password resets, and invitations work. [documentation](/help/admin/config/email)",
+			IsDismissibleWithKeyValue: "email-sending",
+		}}
+	}
+	if conf.Get().EmailAddress == "" {
+		return []*Alert{&Alert{
+			TypeValue:                 AlertTypeWarning,
+			MessageValue:              "Warning: Sourcegraph cannot send emails! [Configure `email.address`](/help/admin/config/email) so that features such as Code Monitors, password resets, and invitations work. [documentation](/help/admin/config/email)",
+			IsDismissibleWithKeyValue: "email-sending",
+		}}
+	}
+	return nil
 }
 
 func outOfDateAlert(args AlertFuncArgs) []*Alert {

--- a/doc/admin/config/email.md
+++ b/doc/admin/config/email.md
@@ -1,0 +1,114 @@
+# Configure email sending / SMTP server
+
+Sourcegraph uses an SMTP server of your choosing to send emails for:
+
+* [Code Monitoring](../../code_monitoring/index.md) notifications
+* Password reset requests
+* Email verification when built-in authentication is enabled
+* Inviting other users to Sourcegraph itself, or to an organization/team on Sourcegraph
+
+## Configuring Sourcegraph to send email via Amazon AWS / SES
+
+To use Amazon SES with Sourcegraph, first [follow these steps to create an SES account for Sourcegraph](https://docs.aws.amazon.com/ses/latest/dg/send-email-smtp-software-package.html).
+
+Navigate to your site configuration (e.g. https://sourcegraph.com/site-admin/configuration) and fill in the configuration:
+
+```json
+  "email.address": "from@domain.com",
+  "email.smtp": {
+    "authentication": "PLAIN",
+    "username": "<SES SMTP username>",
+    "password": "<SES SMTP password>",
+    "host": "email-smtp.us-west-2.amazonaws.com",
+    "port": 587
+  },
+```
+
+Please note that the configured `email.address` (the from address) must be a verified address with SES, see [this page for details](https://docs.aws.amazon.com/ses/latest/dg/verify-addresses-and-domains.html).
+
+[Send a test email](#sending-a-test-email) to verify it is configured properly.
+
+## Configuring Sourcegraph to send email via Google Workspace / GMail
+
+To use Google Workspace with Sourcegraph, you will need to [create an SMTP Relay account](https://support.google.com/a/answer/2956491). Be sure to choose `Require SMTP Authentication` and `Require TLS encryption` in step 7.
+
+Navigate to your site configuration (e.g. https://sourcegraph.com/site-admin/configuration) and fill in the configuration:
+
+```json
+  "email.address": "test@domain.com",
+  "email.smtp": {
+    "authentication": "PLAIN",
+    "username": "test@domain.com",
+    "password": "<YOUR SECRET>",
+    "host": "smtp-relay.gmail.com",
+    "port": 587
+  },
+```
+
+Make sure that `test@domain.com` in both places of the configuration matches the email address of the account you created, and that `<YOUR SECRET>` is replaced with the account password.
+
+[Send a test email](#sending-a-test-email) to verify it is configured properly.
+
+## Configuring Sourcegraph to send email using another provider
+
+Other providers such as Mailchimp and Sendgrid may also be used with Sourcegraph. Any valid SMTP server account should do. For those two providers in specific, you may follow their documentation:
+
+* https://mailchimp.com/developer/transactional/docs/smtp-integration/
+* https://docs.sendgrid.com/for-developers/sending-email/getting-started-smtp
+
+Once you have an SMTP account, simply navigate to your site configuration (e.g. https://sourcegraph.com/site-admin/configuration) and fill in the configuration:
+
+```json
+  "email.address": "from@domain.com",
+  "email.smtp": {
+    "authentication": "PLAIN",
+    "username": "test@domain.com",
+    "password": "<YOUR SECRET>",
+    "host": "smtp-server.example.com",
+    "port": 587
+  },
+```
+
+A few helpful tips:
+
+* `email.address` is the email Sourcegraph will send email `FROM`. Make sure your account has privilege to send mail from that address.
+* You should use a TLS/SSL enabled port, either `587` or `2525`. Any port number is allowed, though.
+* The following `authentication` types are allowed: `PLAIN` (default), `CRAM-MD5`, and `none`
+* If a `HELO` domain is required, simply add `"domain": "<the domain>",` under `email.smtp`
+* TLS certificate verification can be disabled if your SMTP server does not have a valid TLS cert. To do so, set `"noVerifyTLS": true,` (this is not recommended and may be a security risk)
+
+[Send a test email](#sending-a-test-email) to verify it is configured properly.
+
+## Sending a test email
+
+(Added in Sourcegraph v3.38)
+
+To verify email sending is working correctly, visit the GraphQL API console at e.g. https://sourcegraph.example.com/api/console and then run the following query replacing `test@example.com` with your personal email address:
+
+```graphql
+mutation {
+  sendTestEmail(to: "test@example.com")
+}
+```
+
+If everything is successfully configured, you should see a response like:
+
+```json
+{
+  "data": {
+    "sendTestEmail": "Sent test email to \"test@example.com\" successfully! Please check it was received."
+  }
+}
+```
+
+Otherwise, you should see an error with more information:
+
+```json
+{
+  "data": {
+    "sendTestEmail": "Failed to send test email: mail: ..."
+  }
+}
+```
+
+If you need further assistance, please let us know at <mailto:support@sourcegraph.com>.

--- a/doc/admin/config/index.md
+++ b/doc/admin/config/index.md
@@ -17,6 +17,7 @@ This page documents how to configure a Sourcegraph instance. For deployment conf
 - [Add organizations](../organizations.md)
 - [Set up HTTPS](../http_https_configuration.md)
 - [Use a custom domain](../url.md)
+- [Configure email sending / SMTP server](email.md)
 - [Update Sourcegraph](../updates/index.md)
 - [Using external services (PostgreSQL, Redis, S3/GCS)](../external_services/index.md)
 - [PostgreSQL Config](./postgres-conf.md)

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1416,7 +1416,8 @@ type SAMLAuthProvider struct {
 	Type         string `json:"type"`
 }
 
-// SMTPServerConfig description: The SMTP server used to send transactional emails (such as email verifications, reset-password emails, and notifications).
+// SMTPServerConfig description: The SMTP server used to send transactional emails.
+// Please see https://docs.sourcegraph.com/admin/config/email
 type SMTPServerConfig struct {
 	// Authentication description: The type of authentication to use for the SMTP server.
 	Authentication string `json:"authentication"`
@@ -1712,8 +1713,10 @@ type SiteConfiguration struct {
 	// Dotcom description: Configuration options for Sourcegraph.com only.
 	Dotcom *Dotcom `json:"dotcom,omitempty"`
 	// EmailAddress description: The "from" address for emails sent by this server.
+	// Please see https://docs.sourcegraph.com/admin/config/email
 	EmailAddress string `json:"email.address,omitempty"`
-	// EmailSmtp description: The SMTP server used to send transactional emails (such as email verifications, reset-password emails, and notifications).
+	// EmailSmtp description: The SMTP server used to send transactional emails.
+	// Please see https://docs.sourcegraph.com/admin/config/email
 	EmailSmtp *SMTPServerConfig `json:"email.smtp,omitempty"`
 	// EncryptionKeys description: Configuration for encryption keys used to encrypt data at rest in the database.
 	EncryptionKeys *EncryptionKeys `json:"encryption.keys,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -790,7 +790,7 @@
     },
     "email.smtp": {
       "title": "SMTPServerConfig",
-      "description": "The SMTP server used to send transactional emails (such as email verifications, reset-password emails, and notifications).",
+      "description": "The SMTP server used to send transactional emails.\nPlease see https://docs.sourcegraph.com/admin/config/email",
       "type": "object",
       "additionalProperties": false,
       "required": ["host", "port", "authentication"],
@@ -838,7 +838,7 @@
       "group": "Email"
     },
     "email.address": {
-      "description": "The \"from\" address for emails sent by this server.",
+      "description": "The \"from\" address for emails sent by this server.\nPlease see https://docs.sourcegraph.com/admin/config/email",
       "type": "string",
       "format": "email",
       "group": "Email",


### PR DESCRIPTION
# Problem

Lots of customers don't have SMTP email sending configured. First off, we don't even tell site admins that this is something they _should_ do. I would bet many of them don't even know that a part of their Sourcegraph instance isn't configured!

Secondly, it's hard, like real hard, to configure. There are NO docs. Creating an SMTP account is a huge pain, too. We don't even really give people a way to test if it works once you do try to configure it (code monitors aside.)

Yet, many features of Sourcegraph depend CRITICALLY on the ability to send emails! Password resets, inviting other users to Sourcegraph / an org/team, code monitors is virtually useless without email sending!

## Solution: fix everything

## Prompting admins to configure SMTP

Site admins are now warned if email sending is not configured:

<img width="1096" alt="image" src="https://user-images.githubusercontent.com/3173176/157567518-d77872e3-78ad-41a5-aea3-f21273f342ea.png">

## Test email sending? Now ridiculously easy

The API console now lets you test email sending with a dirt simple query:

<img width="712" alt="image" src="https://user-images.githubusercontent.com/3173176/157563948-083f8a51-7976-41cc-80e1-dcd2c7b24bd6.png">

You'll get a detailed response back indicating any issues (NO need to go digging through logs anymore to find out why it mmight not be working!):

<img width="719" alt="image" src="https://user-images.githubusercontent.com/3173176/157563968-ef26df7d-2f02-4f46-9753-d039be870e1c.png">

## Clear documentation for using Amazon SES, Google Workspace/GMail, and other SMTP providers

A new docs page has DETAILED information on configuring Sourcegraph to use Amazon SES, Google Workspace/GMail, and other SMTP providers - as well as how to test it all works:

https://user-images.githubusercontent.com/3173176/157564199-ff95429f-1f7f-4986-9607-14b0d3dd7aa8.png

The Site Configuration page in our docs, as well as the help text in-product, now notes to look at that new page:

<img width="877" alt="image" src="https://user-images.githubusercontent.com/3173176/157561987-6b0ee42d-9909-4be8-a3a3-33a750366db5.png">

## Asks

@philipp-spiess can you update the user invites frontend to link to this new docs page? It'll be https://docs.sourcegraph.com/admin/config/email

@limitedmage are there places on the Code Monitoring side that Search would like to update to point to this page?

## Test plan

Docs: `sg start docsite` && viewing the docs pages manually.

Email send testing API: followed docs instructions and saw expected behavior.

Admin warning: Manually tested by removing `email.smtp` and `email.address` from site config, seeing it appear on refresh, adding it and seeing it go away.