### PR TITLE
doc: document user invitations & how to disable them

### DIFF
--- a/doc/admin/config/index.md
+++ b/doc/admin/config/index.md
@@ -20,6 +20,7 @@ This page documents how to configure a Sourcegraph instance. For deployment conf
 - [Update Sourcegraph](../updates/index.md)
 - [Using external services (PostgreSQL, Redis, S3/GCS)](../external_services/index.md)
 - [PostgreSQL Config](./postgres-conf.md)
+- [Disabling user invitations](./user_invitations.md)
 
 ## Advanced tasks
 

--- a/doc/admin/config/user_invitations.md
+++ b/doc/admin/config/user_invitations.md
@@ -1,0 +1,31 @@
+# Sourcegraph user invitations
+
+Starting in Sourcegraph v3.38, the homepage offers the ability for users to invite collaborators:
+
+![image](https://user-images.githubusercontent.com/3173176/157572519-a9876e04-53bd-4134-acbd-19926ffbf616.png)
+
+## How it works
+
+The collaborators you see are determined based on your repository's Git commit history. We sample a few random repositories and use some heuristics to suggest collaborators you may want to invite to Sourcegraph.
+
+When a user is invited, **no additional permissions are granted**: they merely receive an email informing them that the Sourcegraph instance exists. When the invited user visits Sourcegraph, they will have to sign in using the configured authentication providers.
+
+If `"allowSignup": false,` is configured in any of your authentication providers, user invitations are disabled entirely.
+
+## Disabling
+
+You can disable user invitations for all users by setting the feature flag to _false_ in your **global user settings** at e.g. https://sourcegraph.example.com/site-admin/global-settings with the following:
+
+```json
+{
+  "experimentalFeatures": {
+    "homepageUserInvitation": false,
+  }
+}
+```
+
+Teams on Sourcegraph.com can disable this via **Your organizations** > **Settings** using the same configuration.
+
+Individuals can disable this in their user settings at https://sourcegraph.example.com/user/settings using the same configuration.
+
+If you have any feedback on how we can improve this feature, please [let us know](mailto:feedback@sourcegraph.com)!


### PR DESCRIPTION
Adds the docs that we need for user invitations (what they are and how to disable them). @philipp-spiess can you link these from the frontend?

How it looks: https://user-images.githubusercontent.com/3173176/157572667-495491c6-8406-402f-88e1-a1bc3f6db016.png

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>

## Test plan

`sg run docsite` and manually checking the page.
