### PR TITLE
compute: add feature flag to compute notebook block

### DIFF
--- a/client/web/src/notebooks/notebook/NotebookAddBlockButtons.tsx
+++ b/client/web/src/notebooks/notebook/NotebookAddBlockButtons.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { Button } from '@sourcegraph/wildcard'
 
 import { BlockInput } from '..'
+import { useExperimentalFeatures } from '../../stores'
 
 import styles from './NotebookAddBlockButtons.module.scss'
 
@@ -19,48 +20,70 @@ export const NotebookAddBlockButtons: React.FunctionComponent<NotebookAddBlockBu
     index,
     className,
     onAddBlock,
-}) => (
-    <div
-        className={classNames(styles.addBlockButtonsWrapper, !alwaysVisible && styles.showOnHover, className)}
-        data-testid={alwaysVisible && 'always-visible-add-block-buttons'}
-    >
-        <hr className="mx-3" />
-        <div className={styles.addBlockButtons}>
-            <Button
-                className={styles.addBlockButton}
-                onClick={() => onAddBlock(index, { type: 'query', input: '' })}
-                data-testid="add-query-button"
-                outline={true}
-                variant="secondary"
-                size="sm"
-            >
-                + Query
-            </Button>
-            <Button
-                className={classNames('ml-2', styles.addBlockButton)}
-                onClick={() => onAddBlock(index, { type: 'md', input: '' })}
-                data-testid="add-md-button"
-                outline={true}
-                variant="secondary"
-                size="sm"
-            >
-                + Markdown
-            </Button>
-            <Button
-                className={classNames('ml-2', styles.addBlockButton)}
-                onClick={() =>
-                    onAddBlock(index, {
-                        type: 'file',
-                        input: { repositoryName: '', revision: '', filePath: '', lineRange: null },
-                    })
-                }
-                data-testid="add-file-button"
-                outline={true}
-                variant="secondary"
-                size="sm"
-            >
-                + Code
-            </Button>
+}) => {
+    const showComputeComponent = useExperimentalFeatures(features => features.showComputeComponent)
+    return (
+        <div
+            className={classNames(styles.addBlockButtonsWrapper, !alwaysVisible && styles.showOnHover, className)}
+            data-testid={alwaysVisible && 'always-visible-add-block-buttons'}
+        >
+            <hr className="mx-3" />
+            <div className={styles.addBlockButtons}>
+                <Button
+                    className={styles.addBlockButton}
+                    onClick={() => onAddBlock(index, { type: 'query', input: '' })}
+                    data-testid="add-query-button"
+                    outline={true}
+                    variant="secondary"
+                    size="sm"
+                >
+                    + Query
+                </Button>
+                <Button
+                    className={classNames('ml-2', styles.addBlockButton)}
+                    onClick={() => onAddBlock(index, { type: 'md', input: '' })}
+                    data-testid="add-md-button"
+                    outline={true}
+                    variant="secondary"
+                    size="sm"
+                >
+                    + Markdown
+                </Button>
+                <Button
+                    className={classNames('ml-2', styles.addBlockButton)}
+                    onClick={() =>
+                        onAddBlock(index, {
+                            type: 'file',
+                            input: { repositoryName: '', revision: '', filePath: '', lineRange: null },
+                        })
+                    }
+                    data-testid="add-file-button"
+                    outline={true}
+                    variant="secondary"
+                    size="sm"
+                >
+                    + Code
+                </Button>
+                {showComputeComponent ? (
+                    <Button
+                        className={classNames('ml-2', styles.addBlockButton)}
+                        onClick={() =>
+                            onAddBlock(index, {
+                                type: 'compute',
+                                input: 'placeholder',
+                            })
+                        }
+                        data-testid="add-compute-button"
+                        outline={true}
+                        variant="secondary"
+                        size="sm"
+                    >
+                        + Compute
+                    </Button>
+                ) : (
+                    <div />
+                )}
+            </div>
         </div>
-    </div>
-)
+    )
+}

--- a/client/web/src/stores/experimentalFeatures.ts
+++ b/client/web/src/stores/experimentalFeatures.ts
@@ -16,6 +16,7 @@ const defaultSettings: SettingsExperimentalFeatures = {
     showSearchContext: true,
     showSearchContextManagement: true,
     showSearchNotebook: false,
+    showComputeComponent: false,
     codeMonitoringWebHooks: false,
     showCodeMonitoringLogs: true,
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1609,6 +1609,8 @@ type SettingsExperimentalFeatures struct {
 	ShowCodeMonitoringLogs *bool `json:"showCodeMonitoringLogs,omitempty"`
 	// ShowCodeMonitoringTestEmailButton description: REMOVED. Previously, enabled the 'Send test email' button in the code monitoring list.
 	ShowCodeMonitoringTestEmailButton *bool `json:"showCodeMonitoringTestEmailButton,omitempty"`
+	// ShowComputeComponent description: Enables display of compute components (currently Notebook blocks)
+	ShowComputeComponent *bool `json:"showComputeComponent,omitempty"`
 	// ShowEnterpriseHomePanels description: Enabled the homepage panels in the Enterprise homepage
 	ShowEnterpriseHomePanels *bool `json:"showEnterpriseHomePanels,omitempty"`
 	// ShowMultilineSearchConsole description: Enables the multiline search console at search/console

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -159,6 +159,14 @@
             "pointer": true
           }
         },
+        "showComputeComponent": {
+          "description": "Enables display of compute components (currently Notebook blocks)",
+          "type": "boolean",
+          "default": false,
+          "!go": {
+            "pointer": true
+          }
+        },
         "showQueryBuilder": {
           "description": "REMOVED. Previously, enabled the search query builder page. This page has been removed.",
           "type": "boolean",


### PR DESCRIPTION
When `showComputeComponent` is true, it displays a `+ Compute` button on the search notebook page. I tried to use a general name, in case the flag is useful in other contexts to enable some compute component outside notebooks.

## Test plan
Tested manually by toggling the setting
```
  "experimentalFeatures": { 
    "showComputeComponent": true,
  } 
```