### PR TITLE
search stack: create notebook through API

### DIFF
--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -472,7 +472,7 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
                                                         </CodeHostScopeProvider>
                                                     )}
                                                 />
-                                                <SearchStack />
+                                                <SearchStack authenticatedUser={authenticatedUser} />
                                                 <IdeExtensionTracker />
                                             </Router>
                                         </ScrollManager>

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -9,6 +9,7 @@ import { Route, Router } from 'react-router'
 import { ScrollManager } from 'react-scroll-manager'
 import { combineLatest, from, Subscription, fromEvent, of, Subject } from 'rxjs'
 import { catchError, distinctUntilChanged, map, startWith, switchMap } from 'rxjs/operators'
+import * as uuid from 'uuid'
 
 import { asError, isErrorLike } from '@sourcegraph/common'
 import { GraphQLClient, HTTPStatusError } from '@sourcegraph/http-client'
@@ -71,6 +72,9 @@ import { OverrideFeatureFlagsAgent } from './featureFlags/OverrideFeatureFlagsAg
 import { IdeExtensionTracker } from './IdeExtensionTracker'
 import { CodeInsightsProps } from './insights/types'
 import { Layout, LayoutProps } from './Layout'
+import { BlockInput } from './notebooks'
+import { createNotebook } from './notebooks/backend'
+import { blockToGQLInput } from './notebooks/serialize'
 import { OrgAreaRoute } from './org/area/OrgArea'
 import { OrgAreaHeaderNavItem } from './org/area/OrgHeader'
 import { createPlatformContext } from './platform/context'
@@ -81,6 +85,7 @@ import { RepoRevisionContainerRoute } from './repo/RepoRevisionContainer'
 import { RepoSettingsAreaRoute } from './repo/settings/RepoSettingsArea'
 import { RepoSettingsSideBarGroup } from './repo/settings/RepoSettingsSidebar'
 import { LayoutRouteProps } from './routes'
+import { PageRoutes } from './routes.constants'
 import { parseSearchURL } from './search'
 import { fetchSavedSearches, fetchRecentSearches, fetchRecentFileViews, fetchCollaborators } from './search/backend'
 import { SearchResultsCacheProvider } from './search/results/SearchResultsCacheProvider'
@@ -472,7 +477,7 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
                                                         </CodeHostScopeProvider>
                                                     )}
                                                 />
-                                                <SearchStack authenticatedUser={authenticatedUser} />
+                                                <SearchStack onCreateNotebook={this.onCreateNotebook} />
                                                 <IdeExtensionTracker />
                                             </Router>
                                         </ScrollManager>
@@ -540,5 +545,24 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
     private async setWorkspaceSearchContext(spec: string | undefined): Promise<void> {
         const extensionHostAPI = await this.extensionsController.extHostAPI
         await extensionHostAPI.setSearchContext(spec)
+    }
+
+    private onCreateNotebook = (blocks: BlockInput[]): void => {
+        if (!this.state.authenticatedUser) {
+            return
+        }
+
+        this.subscriptions.add(
+            createNotebook({
+                notebook: {
+                    title: 'New Notebook',
+                    blocks: blocks.map(block => blockToGQLInput({ id: uuid.v4(), ...block })),
+                    public: false,
+                    namespace: this.state.authenticatedUser.id,
+                },
+            }).subscribe(createdNotebook => {
+                history.push(PageRoutes.Notebook.replace(':id', createdNotebook.id))
+            })
+        )
     }
 }

--- a/client/web/src/notebooks/createPage/CreateNotebookPage.tsx
+++ b/client/web/src/notebooks/createPage/CreateNotebookPage.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from 'react'
 import { Redirect } from 'react-router'
 import { catchError, startWith } from 'rxjs/operators'
-import * as uuid from 'uuid'
 
 import { asError, isErrorLike } from '@sourcegraph/common'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -9,42 +8,26 @@ import { LoadingSpinner, useObservable, Alert } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { Page } from '../../components/Page'
-import { CreateNotebookBlockInput } from '../../graphql-operations'
 import { PageRoutes } from '../../routes.constants'
 import { createNotebook } from '../backend'
-import { blockToGQLInput, deserializeBlockInput } from '../serialize'
 
 const LOADING = 'loading' as const
-
-function deserializeBlocks(serializedBlocks: string): CreateNotebookBlockInput[] {
-    return serializedBlocks.split(',').flatMap(serializedBlock => {
-        const [type, encodedInput] = serializedBlock.split(':')
-        if (type !== 'md' && type !== 'query' && type !== 'file' && type !== 'compute') {
-            throw new Error(`Unknown block type: ${type}`)
-        }
-        if (type === 'compute') {
-            return [] // compute blocks do not support deserialization yet.
-        }
-        const block = deserializeBlockInput(type, decodeURIComponent(encodedInput))
-        return [blockToGQLInput({ id: uuid.v4(), ...block })]
-    })
-}
 
 export const CreateNotebookPage: React.FunctionComponent<TelemetryProps & { authenticatedUser: AuthenticatedUser }> = ({
     telemetryService,
     authenticatedUser,
 }) => {
     const notebookOrError = useObservable(
-        useMemo(() => {
-            const serializedBlocks = location.hash.trim().slice(1)
-            const blocks = serializedBlocks.length > 0 ? deserializeBlocks(serializedBlocks) : []
-            return createNotebook({
-                notebook: { title: 'New Notebook', blocks, public: false, namespace: authenticatedUser.id },
-            }).pipe(
-                startWith(LOADING),
-                catchError(error => [asError(error)])
-            )
-        }, [authenticatedUser])
+        useMemo(
+            () =>
+                createNotebook({
+                    notebook: { title: 'New Notebook', blocks: [], public: false, namespace: authenticatedUser.id },
+                }).pipe(
+                    startWith(LOADING),
+                    catchError(error => [asError(error)])
+                ),
+            [authenticatedUser]
+        )
     )
 
     if (notebookOrError && !isErrorLike(notebookOrError) && notebookOrError !== LOADING) {

--- a/client/web/src/notebooks/serialize/index.test.ts
+++ b/client/web/src/notebooks/serialize/index.test.ts
@@ -1,6 +1,4 @@
-import { encodeURIPathComponent } from '@sourcegraph/common'
-
-import { parseLineRange, serializeBlockInput, serializeBlocksToURL, serializeLineRange } from '.'
+import { parseLineRange, serializeBlockInput, serializeLineRange } from '.'
 
 const SOURCEGRAPH_URL = 'https://sourcegraph.com'
 
@@ -70,16 +68,4 @@ describe('serialize', () => {
 
     it('should parse multi line range', () =>
         expect(parseLineRange('124-321')).toEqual({ startLine: 123, endLine: 321 }))
-
-    it('should serialize multiple blocks', () => {
-        expect(
-            serializeBlocksToURL(
-                [
-                    { type: 'md', input: '# Title' },
-                    { type: 'query', input: 'repo:a b' },
-                ],
-                SOURCEGRAPH_URL
-            )
-        ).toStrictEqual(`md:${encodeURIPathComponent('# Title')},query:${encodeURIComponent('repo:a b')}`)
-    })
 })

--- a/client/web/src/notebooks/serialize/index.ts
+++ b/client/web/src/notebooks/serialize/index.ts
@@ -5,15 +5,6 @@ import { Block, BlockInit, BlockInput, FileBlockInput } from '..'
 import { CreateNotebookBlockInput, NotebookBlockType } from '../../graphql-operations'
 import { parseBrowserRepoURL } from '../../util/url'
 
-export function serializeBlocksToURL(blocks: BlockInput[], sourcegraphURL: string): string {
-    return blocks
-        .map(
-            block =>
-                `${encodeURIComponent(block.type)}:${encodeURIComponent(serializeBlockInput(block, sourcegraphURL))}`
-        )
-        .join(',')
-}
-
 export function serializeBlockToMarkdown(block: Block, sourcegraphURL: string): string {
     const serializedInput = serializeBlockInput(block, sourcegraphURL)
     switch (block.type) {

--- a/client/web/src/search/SearchStack.story.tsx
+++ b/client/web/src/search/SearchStack.story.tsx
@@ -1,4 +1,5 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react'
+import { noop } from 'lodash'
 import React, { useEffect } from 'react'
 
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
@@ -22,7 +23,7 @@ function SearchStackWrapper({
         useSearchStackState.setState({ entries, previousEntries, canRestoreSession }, true)
     }, [entries, previousEntries, canRestoreSession])
 
-    return <SearchStack authenticatedUser={null} initialOpen={open} />
+    return <SearchStack onCreateNotebook={noop} initialOpen={open} />
 }
 
 export default {

--- a/client/web/src/search/SearchStack.story.tsx
+++ b/client/web/src/search/SearchStack.story.tsx
@@ -22,7 +22,7 @@ function SearchStackWrapper({
         useSearchStackState.setState({ entries, previousEntries, canRestoreSession }, true)
     }, [entries, previousEntries, canRestoreSession])
 
-    return <SearchStack initialOpen={open} />
+    return <SearchStack authenticatedUser={null} initialOpen={open} />
 }
 
 export default {

--- a/client/web/src/search/SearchStack.test.tsx
+++ b/client/web/src/search/SearchStack.test.tsx
@@ -5,14 +5,16 @@ import React from 'react'
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { renderWithBrandedContext, RenderWithBrandedContextResult } from '@sourcegraph/shared/src/testing'
 
+import { AuthenticatedUser } from '../auth'
 import { useExperimentalFeatures, useSearchStackState } from '../stores'
 import { addSearchStackEntry, SearchStackEntry } from '../stores/searchStack'
 
 import { SearchStack } from './SearchStack'
 
 describe('Search Stack', () => {
-    const renderSearchStack = (props?: Partial<{ initialOpen: boolean }>): RenderWithBrandedContextResult =>
-        renderWithBrandedContext(<SearchStack {...props} />)
+    const renderSearchStack = (
+        props?: Partial<{ initialOpen: boolean; authenticatedUser: AuthenticatedUser | null }>
+    ): RenderWithBrandedContextResult => renderWithBrandedContext(<SearchStack authenticatedUser={null} {...props} />)
 
     function open() {
         userEvent.click(screen.getByRole('button', { name: 'Open search session' }))
@@ -111,15 +113,13 @@ describe('Search Stack', () => {
         })
 
         it('creates notebooks', () => {
-            const result = renderSearchStack()
+            const authenticatedUser = { id: 'foobar', username: 'alice', email: 'alice@alice.com' } as AuthenticatedUser
+            renderSearchStack({ authenticatedUser })
             open()
 
             userEvent.click(screen.getByRole('button', { name: 'Create Notebook' }))
 
-            expect(result.history.location.pathname).toMatchInlineSnapshot('"/notebooks/new"')
-            expect(result.history.location.hash).toMatchInlineSnapshot(
-                '"#query:TODO,file:http%3A%2F%2Flocalhost%2Ftest%40master%2F-%2Fblob%2Fpath%2Fto%2Ffile"'
-            )
+            // TODO: How to check for the redirect, because it is async?
         })
 
         it('allows to delete entries', () => {

--- a/client/web/src/search/SearchStack.test.tsx
+++ b/client/web/src/search/SearchStack.test.tsx
@@ -1,20 +1,20 @@
 import { act, cleanup, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { noop } from 'lodash'
 import React from 'react'
+import sinon from 'sinon'
 
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { renderWithBrandedContext, RenderWithBrandedContextResult } from '@sourcegraph/shared/src/testing'
 
-import { AuthenticatedUser } from '../auth'
 import { useExperimentalFeatures, useSearchStackState } from '../stores'
 import { addSearchStackEntry, SearchStackEntry } from '../stores/searchStack'
 
-import { SearchStack } from './SearchStack'
+import { SearchStack, SearchStackProps } from './SearchStack'
 
 describe('Search Stack', () => {
-    const renderSearchStack = (
-        props?: Partial<{ initialOpen: boolean; authenticatedUser: AuthenticatedUser | null }>
-    ): RenderWithBrandedContextResult => renderWithBrandedContext(<SearchStack authenticatedUser={null} {...props} />)
+    const renderSearchStack = (props?: Partial<SearchStackProps>): RenderWithBrandedContextResult =>
+        renderWithBrandedContext(<SearchStack onCreateNotebook={noop} {...props} />)
 
     function open() {
         userEvent.click(screen.getByRole('button', { name: 'Open search session' }))
@@ -113,13 +113,13 @@ describe('Search Stack', () => {
         })
 
         it('creates notebooks', () => {
-            const authenticatedUser = { id: 'foobar', username: 'alice', email: 'alice@alice.com' } as AuthenticatedUser
-            renderSearchStack({ authenticatedUser })
+            const onCreateNotebook = sinon.spy()
+            renderSearchStack({ onCreateNotebook })
             open()
 
             userEvent.click(screen.getByRole('button', { name: 'Create Notebook' }))
 
-            // TODO: How to check for the redirect, because it is async?
+            sinon.assert.calledOnce(onCreateNotebook)
         })
 
         it('allows to delete entries', () => {

--- a/client/web/src/search/SearchStack.tsx
+++ b/client/web/src/search/SearchStack.tsx
@@ -19,25 +19,17 @@ import React, {
     useEffect,
     useLayoutEffect,
 } from 'react'
-import { useHistory } from 'react-router'
-import { Observable, of } from 'rxjs'
-import { map, switchMap, tap } from 'rxjs/operators'
-import * as uuid from 'uuid'
 
 import { isMacPlatform } from '@sourcegraph/common'
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
-import { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { IHighlightLineRange } from '@sourcegraph/shared/src/schema'
 import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
 import { appendContextFilter, updateFilter } from '@sourcegraph/shared/src/search/query/transformer'
 import { buildSearchURLQuery, toPrettyBlobURL } from '@sourcegraph/shared/src/util/url'
-import { Button, Link, TextArea, useEventObservable } from '@sourcegraph/wildcard'
+import { Button, Link, TextArea } from '@sourcegraph/wildcard'
 
 import { BlockInput } from '../notebooks'
-import { createNotebook } from '../notebooks/backend'
-import { blockToGQLInput } from '../notebooks/serialize'
-import { PageRoutes } from '../routes.constants'
 import { useExperimentalFeatures } from '../stores'
 import {
     useSearchStackState,
@@ -80,12 +72,12 @@ function useHasNewEntry(entries: SearchStackEntry[]): boolean {
     return previous !== undefined && previous < entries.length
 }
 
-export const SearchStack: React.FunctionComponent<{
+export interface SearchStackProps {
     initialOpen?: boolean
-    authenticatedUser: AuthenticatedUser | null
-}> = ({ initialOpen = false, authenticatedUser }) => {
-    const history = useHistory()
+    onCreateNotebook: (blocks: BlockInput[]) => void
+}
 
+export const SearchStack: React.FunctionComponent<SearchStackProps> = ({ initialOpen = false, onCreateNotebook }) => {
     const [open, setOpen] = useState(initialOpen)
     const [confirmRemoveAll, setConfirmRemoveAll] = useState(false)
     const addableEntry = useSearchStackState(state => state.addableEntry)
@@ -152,59 +144,34 @@ export const SearchStack: React.FunctionComponent<{
         [reversedEntries, selectedEntries, setSelectedEntries]
     )
 
-    const [onCreateNotebook] = useEventObservable(
-        useCallback(
-            (click: Observable<React.MouseEvent<HTMLButtonElement>>) =>
-                click.pipe(
-                    map(() => {
-                        const blocks: BlockInput[] = []
-                        for (const entry of entries) {
-                            if (entry.annotation) {
-                                blocks.push({ type: 'md', input: entry.annotation })
-                            }
-                            switch (entry.type) {
-                                case 'search':
-                                    blocks.push({ type: 'query', input: toSearchQuery(entry) })
-                                    break
-                                case 'file':
-                                    blocks.push({
-                                        type: 'file',
-                                        input: {
-                                            repositoryName: entry.repo,
-                                            revision: entry.revision,
-                                            filePath: entry.path,
-                                            // Notebooks expect the end line to be exclusive
-                                            lineRange: entry.lineRange
-                                                ? { ...entry.lineRange, endLine: entry.lineRange?.endLine + 1 }
-                                                : null,
-                                        },
-                                    })
-                                    break
-                            }
-                        }
-                        return blocks
-                    }),
-                    switchMap(blocks =>
-                        authenticatedUser
-                            ? createNotebook({
-                                  notebook: {
-                                      title: 'New Notebook',
-                                      blocks: blocks.map(block => blockToGQLInput({ id: uuid.v4(), ...block })),
-                                      public: false,
-                                      namespace: authenticatedUser.id,
-                                  },
-                              })
-                            : of(undefined)
-                    ),
-                    tap(createdNotebook => {
-                        if (createdNotebook) {
-                            history.push(PageRoutes.Notebook.replace(':id', createdNotebook.id))
-                        }
+    const createNotebook = useCallback(() => {
+        const blocks: BlockInput[] = []
+        for (const entry of entries) {
+            if (entry.annotation) {
+                blocks.push({ type: 'md', input: entry.annotation })
+            }
+            switch (entry.type) {
+                case 'search':
+                    blocks.push({ type: 'query', input: toSearchQuery(entry) })
+                    break
+                case 'file':
+                    blocks.push({
+                        type: 'file',
+                        input: {
+                            repositoryName: entry.repo,
+                            revision: entry.revision,
+                            filePath: entry.path,
+                            // Notebooks expect the end line to be exclusive
+                            lineRange: entry.lineRange
+                                ? { ...entry.lineRange, endLine: entry.lineRange?.endLine + 1 }
+                                : null,
+                        },
                     })
-                ),
-            [history, entries, authenticatedUser]
-        )
-    )
+                    break
+            }
+        }
+        onCreateNotebook(blocks)
+    }, [entries, onCreateNotebook])
 
     const toggleOpen = useCallback(() => {
         setOpen(open => {
@@ -382,7 +349,7 @@ export const SearchStack: React.FunctionComponent<{
                         </Button>
                     )}
                     <div className="d-flex justify-content-between align-items-center">
-                        <Button onClick={onCreateNotebook} variant="primary" size="sm" disabled={entries.length === 0}>
+                        <Button onClick={createNotebook} variant="primary" size="sm" disabled={entries.length === 0}>
                             <NotebookPlusIcon className="icon-inline" /> Create Notebook
                         </Button>
                         <Button


### PR DESCRIPTION
## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->
* Do a search, select a line range, open the Notepad (search stack) component, click on the `Create Notebook` button
* It should redirect you to the newly created notebook
* Go to `/notebooks`
* Check that creating a notebook still works

