### PR TITLE
gitserver: store repo size in db when updated

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1589,6 +1589,15 @@ func (s *Server) setCloneStatusNonFatal(ctx context.Context, name api.RepoName, 
 	}
 }
 
+// setRepoSize calculates the size of the repo and stores it in the database.
+func (s *Server) setRepoSize(ctx context.Context, name api.RepoName) error {
+	if s.DB == nil {
+		return nil
+	}
+
+	return database.GitserverRepos(s.DB).SetRepoSize(ctx, name, dirSize(s.dir(name).Path(".")), s.Hostname)
+}
+
 // setGitAttributes writes our global gitattributes to
 // gitDir/info/attributes. This will override .gitattributes inside of
 // repositories. It is used to unset attributes such as export-ignore.
@@ -1839,6 +1848,11 @@ func (s *Server) doClone(ctx context.Context, repo api.RepoName, dir GitDir, syn
 	// disk state.
 	if err := s.setLastFetched(ctx, repo); err != nil {
 		log15.Warn("failed setting last fetch in DB", "repo", repo, "error", err)
+	}
+
+	// Successfully updated, best-effort calculating the repo size.
+	if err := s.setRepoSize(ctx, repo); err != nil {
+		log15.Warn("failed setting repo size", "repo", repo, "error", err)
 	}
 
 	log15.Info("repo cloned", "repo", repo)

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1850,7 +1850,7 @@ func (s *Server) doClone(ctx context.Context, repo api.RepoName, dir GitDir, syn
 		log15.Warn("failed setting last fetch in DB", "repo", repo, "error", err)
 	}
 
-	// Successfully updated, best-effort calculating the repo size.
+	// Successfully updated, best-effort calculation of the repo size.
 	if err := s.setRepoSize(ctx, repo); err != nil {
 		log15.Warn("failed setting repo size", "repo", repo, "error", err)
 	}

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -2185,6 +2185,11 @@ func (s *Server) doBackgroundRepoUpdate(repo api.RepoName) error {
 		log15.Warn("failed setting last fetch in DB", "repo", repo, "error", err)
 	}
 
+	// Successfully updated, best-effort calculation of the repo size.
+	if err := s.setRepoSize(ctx, repo); err != nil {
+		log15.Warn("failed setting repo size", "repo", repo, "error", err)
+	}
+
 	return nil
 }
 

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -538,7 +538,7 @@ func TestCloneRepo(t *testing.T) {
 	if err := database.Repos(db).Create(ctx, dbRepo); err != nil {
 		t.Fatal(err)
 	}
-	assertCloneStatus := func(status types.CloneStatus) {
+	assertRepoState := func(status types.CloneStatus, size int64) {
 		t.Helper()
 		fromDB, err := database.GitserverRepos(db).GetByID(ctx, dbRepo.ID)
 		if err != nil {
@@ -547,16 +547,20 @@ func TestCloneRepo(t *testing.T) {
 		if fromDB.CloneStatus != status {
 			t.Fatalf("Want %q, got %q", status, fromDB.CloneStatus)
 		}
+		if fromDB.RepoSizeBytes != size {
+			t.Fatalf("Want %d, got %d", size, fromDB.RepoSizeBytes)
+		}
 	}
 
-	if err := database.GitserverRepos(db).Upsert(ctx, &types.GitserverRepo{
+	gr := types.GitserverRepo{
 		RepoID:      dbRepo.ID,
 		ShardID:     "test",
 		CloneStatus: types.CloneStatusNotCloned,
-	}); err != nil {
+	}
+	if err := database.GitserverRepos(db).Upsert(ctx, &gr); err != nil {
 		t.Fatal(err)
 	}
-	assertCloneStatus(types.CloneStatusNotCloned)
+	assertRepoState(types.CloneStatusNotCloned, 0)
 
 	repo := remote
 	cmd := func(name string, arg ...string) string {
@@ -586,7 +590,8 @@ func TestCloneRepo(t *testing.T) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	assertCloneStatus(types.CloneStatusCloned)
+	wantRepoSize := dirSize(dst.Path("."))
+	assertRepoState(types.CloneStatusCloned, wantRepoSize)
 
 	repo = filepath.Dir(string(dst))
 	gotCommit := cmd("git", "rev-parse", "HEAD")
@@ -599,7 +604,7 @@ func TestCloneRepo(t *testing.T) {
 	if !errors.Is(err, os.ErrExist) {
 		t.Fatalf("expected clone repo to fail with already exists: %s", err)
 	}
-	assertCloneStatus(types.CloneStatusCloned)
+	assertRepoState(types.CloneStatusCloned, wantRepoSize)
 
 	// Test blocking with overwrite. First add random file to GIT_DIR. If the
 	// file is missing after cloning we know the directory was replaced
@@ -608,7 +613,7 @@ func TestCloneRepo(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assertCloneStatus(types.CloneStatusCloned)
+	assertRepoState(types.CloneStatusCloned, wantRepoSize)
 
 	if _, err := os.Stat(dst.Path("HELLO")); !os.IsNotExist(err) {
 		t.Fatalf("expected clone to be overwritten: %s", err)

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -497,6 +497,12 @@ func makeSingleCommitRepo(cmd func(string, ...string) string) string {
 	// Setup a repo with a commit so we can see if we can clone it.
 	cmd("git", "init", ".")
 	cmd("sh", "-c", "echo hello world > hello.txt")
+	return addCommitToRepo(cmd)
+}
+
+// addCommitToRepo adds a commit to the repo at the current path.
+func addCommitToRepo(cmd func(string, ...string) string) string {
+	// Setup a repo with a commit so we can see if we can clone it.
 	cmd("git", "add", "hello.txt")
 	cmd("git", "commit", "-m", "hello")
 	return cmd("git", "rev-parse", "HEAD")
@@ -673,17 +679,19 @@ func TestHandleRepoUpdate(t *testing.T) {
 	req := httptest.NewRequest("GET", "/repo-update", bytes.NewReader(body))
 	s.handleRepoUpdate(rr, req)
 
+	size := dirSize(s.dir(repoName).Path("."))
 	want := &types.GitserverRepo{
-		RepoID:      dbRepo.ID,
-		ShardID:     "",
-		CloneStatus: types.CloneStatusCloned,
+		RepoID:        dbRepo.ID,
+		ShardID:       "",
+		CloneStatus:   types.CloneStatusCloned,
+		RepoSizeBytes: size,
 	}
 	fromDB, err := database.GitserverRepos(db).GetByID(ctx, dbRepo.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	cmpIgnored := cmpopts.IgnoreFields(types.GitserverRepo{}, "LastFetched", "LastChanged", "RepoSizeBytes", "UpdatedAt")
+	cmpIgnored := cmpopts.IgnoreFields(types.GitserverRepo{}, "LastFetched", "LastChanged", "UpdatedAt")
 
 	// We don't expect an error
 	if diff := cmp.Diff(want, fromDB, cmpIgnored); diff != "" {
@@ -691,21 +699,21 @@ func TestHandleRepoUpdate(t *testing.T) {
 	}
 
 	// Now we'll call again and with an update that fails
-
 	doBackgroundRepoUpdateMock = func(name api.RepoName) error {
 		return errors.New("fail")
 	}
 	t.Cleanup(func() { doBackgroundRepoUpdateMock = nil })
 
-	// This will an update since the repo is already cloned
+	// This will trigger an update since the repo is already cloned
 	req = httptest.NewRequest("GET", "/repo-update", bytes.NewReader(body))
 	s.handleRepoUpdate(rr, req)
 
 	want = &types.GitserverRepo{
-		RepoID:      dbRepo.ID,
-		ShardID:     "",
-		CloneStatus: types.CloneStatusCloned,
-		LastError:   "fail",
+		RepoID:        dbRepo.ID,
+		ShardID:       "",
+		CloneStatus:   types.CloneStatusCloned,
+		LastError:     "fail",
+		RepoSizeBytes: size,
 	}
 	fromDB, err = database.GitserverRepos(db).GetByID(ctx, dbRepo.ID)
 	if err != nil {
@@ -716,6 +724,30 @@ func TestHandleRepoUpdate(t *testing.T) {
 	if diff := cmp.Diff(want, fromDB, cmpIgnored); diff != "" {
 		t.Fatal(diff)
 	}
+
+	// Now we'll call again and with an update that succeeds
+	doBackgroundRepoUpdateMock = nil
+
+	// This will trigger an update since the repo is already cloned
+	req = httptest.NewRequest("GET", "/repo-update", bytes.NewReader(body))
+	s.handleRepoUpdate(rr, req)
+
+	want = &types.GitserverRepo{
+		RepoID:        dbRepo.ID,
+		ShardID:       "",
+		CloneStatus:   types.CloneStatusCloned,
+		RepoSizeBytes: dirSize(s.dir(repoName).Path(".")), // we compute the new size
+	}
+	fromDB, err = database.GitserverRepos(db).GetByID(ctx, dbRepo.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We expect an update
+	if diff := cmp.Diff(want, fromDB, cmpIgnored); diff != "" {
+		t.Fatal(diff)
+	}
+
 }
 
 func TestRemoveBadRefs(t *testing.T) {

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -683,7 +683,7 @@ func TestHandleRepoUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cmpIgnored := cmpopts.IgnoreFields(types.GitserverRepo{}, "LastFetched", "LastChanged", "UpdatedAt")
+	cmpIgnored := cmpopts.IgnoreFields(types.GitserverRepo{}, "LastFetched", "LastChanged", "RepoSizeBytes", "UpdatedAt")
 
 	// We don't expect an error
 	if diff := cmp.Diff(want, fromDB, cmpIgnored); diff != "" {


### PR DESCRIPTION
Store repo size in the database whenever a repo is cloned.
Fixes https://github.com/sourcegraph/sourcegraph/issues/32197

## Test plan

- Wrote a unit test
- Run sg locally and checked the database state

