### PR TITLE
gitserver: rename MigrateFrom to CloneFromShard

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -806,13 +806,13 @@ func (s *Server) handleRepoUpdate(w http.ResponseWriter, r *http.Request) {
 		// succeed.
 		resp.CloneInProgress = true
 
-		// We do not need to check if req.MigrateFrom is non-zero here since that has no effect on
+		// We do not need to check if req.CloneFromShard is non-zero here since that has no effect on
 		// the code path at this point. Since the repo is already not cloned at this point, either
 		// this request was received for a repo migration or a regular clone - for both of which we
 		// want to go ahead and clone the repo. The responsibility of figuring out where to clone
 		// the repo from (upstream URL of the external service or the gitserver instance) lies with
 		// the implementation details of cloneRepo.
-		_, err := s.cloneRepo(ctx, req.Repo, &cloneOptions{Block: true, MigrateFrom: req.MigrateFrom})
+		_, err := s.cloneRepo(ctx, req.Repo, &cloneOptions{Block: true, CloneFromShard: req.CloneFromShard})
 		if err != nil {
 			log15.Warn("error cloning repo", "repo", req.Repo, "err", err)
 			resp.Error = err.Error()
@@ -1594,13 +1594,10 @@ type cloneOptions struct {
 	// Overwrite will overwrite the existing clone.
 	Overwrite bool
 
-	// MigrateFrom is the name of the gitserver instance which is the current owner of the
+	// CloneFromShard is the name of the gitserver instance which is the current owner of the
 	// repository. If this is a non-zero string, then gitserver will attempt to clone the repo from
-	// the current gitserver instance instead of the upstream repo URL of the external service.
-	//
-	// Once migration is complete for all repos in Sourcegraph, there is no need for this attribute
-	// and it should be removed.
-	MigrateFrom string
+	// that gitserver instance instead of the upstream repo URL of the external service.
+	CloneFromShard string
 }
 
 // cloneRepo performs a clone operation for the given repository. It is

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1594,7 +1594,7 @@ type cloneOptions struct {
 	// Overwrite will overwrite the existing clone.
 	Overwrite bool
 
-	// CloneFromShard is the name of the gitserver instance which is the current owner of the
+	// CloneFromShard is the hostname of the gitserver instance which is the current owner of the
 	// repository. If this is a non-zero string, then gitserver will attempt to clone the repo from
 	// that gitserver instance instead of the upstream repo URL of the external service.
 	CloneFromShard string

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -746,14 +746,14 @@ func (c *ClientImplementor) RequestRepoMigrate(ctx context.Context, repo api.Rep
 	// be cloned at the new gitserver instance. And for not cloned repos, this attribute is already
 	// ignored.
 	req := &protocol.RepoUpdateRequest{
-		Repo:        repo,
-		MigrateFrom: c.AddrForRepo(repo),
+		Repo:           repo,
+		CloneFromShard: c.AddrForRepo(repo),
 	}
 
 	// We set "uri" to the HTTP URL of the gitserver instance that should be the new owner of this
 	// "repo" based on the rendezvous hashing scheme. This way, when the gitserver instance receives
 	// the request at /repo-update, it will treat it as a new clone operation and attempt to clone
-	// the repo from the URL set in MigrateFrom - the gitserver instance that owns this repo based
+	// the repo from the URL set in CloneFromShard - the gitserver instance that owns this repo based
 	// on the existing hashing scheme.
 	uri := "http://" + c.RendezvousAddrForRepo(repo) + "/repo-update"
 	resp, err := c.httpPostWithURI(ctx, repo, uri, req)

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -134,7 +134,7 @@ type RepoUpdateRequest struct {
 	Repo  api.RepoName  `json:"repo"`  // identifying URL for repo
 	Since time.Duration `json:"since"` // debounce interval for queries, used only with request-repo-update
 
-	// CloneFromShard is the name of the gitserver instance that is the current owner of the
+	// CloneFromShard is the hostname of the gitserver instance that is the current owner of the
 	// repository. If this is set, then the RepoUpdateRequest is to migrate the repo from
 	// that gitserver instance to the new home of the repo.
 	CloneFromShard string `json:"cloneFromShard"`

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -134,14 +134,10 @@ type RepoUpdateRequest struct {
 	Repo  api.RepoName  `json:"repo"`  // identifying URL for repo
 	Since time.Duration `json:"since"` // debounce interval for queries, used only with request-repo-update
 
-	// MigrateFrom is the name of the gitserver instance that is the current owner of the
-	// repository. If this is set, then the RepoUpdateRequest is to migrate the repo from the
-	// current gitserver instance to the new home of the repo based on the rendezvous hashing
-	// scheme.
-	//
-	// Once migration is complete for all repos in Sourcegraph, there is no need for this attribute
-	// and it should be removed.
-	MigrateFrom string `json:"migrateFrom"`
+	// CloneFromShard is the name of the gitserver instance that is the current owner of the
+	// repository. If this is set, then the RepoUpdateRequest is to migrate the repo from
+	// that gitserver instance to the new home of the repo.
+	CloneFromShard string `json:"cloneFromShard"`
 }
 
 // RepoUpdateResponse returns meta information of the repo enqueued for


### PR DESCRIPTION
The `MigrateFrom` option is no longer temporary and must be used as an API to copy repos from one shard to another.
This PR renames it to `CloneFromShard` and updates some comments.

Related to #32312

## Test plan

- Breaking change: This option is not used yet so it's safe to rename it
- Relying on the test suite


