### PR TITLE
schema: add "pending" field to GitHub code host connection

### DIFF
--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -175,6 +175,11 @@
       "description": "The installation ID of the GitHub App.",
       "type": "string"
     },
+    "pending": {
+      "description": "Whether the code host connection is in a pending state.",
+      "type": "boolean",
+      "default": false
+    },
     "cloudGlobal": {
       "title": "CloudGlobal",
       "description": "When set to true, this external service will be chosen as our 'Global' GitHub service. Only valid on Sourcegraph.com. Only one service can have this flag set.",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -729,6 +729,8 @@ type GitHubConnection struct {
 	InitialRepositoryEnablement bool `json:"initialRepositoryEnablement,omitempty"`
 	// Orgs description: An array of organization names identifying GitHub organizations whose repositories should be mirrored on Sourcegraph.
 	Orgs []string `json:"orgs,omitempty"`
+	// Pending description: Whether the code host connection is in a pending state.
+	Pending bool `json:"pending,omitempty"`
 	// RateLimit description: Rate limit applied when making background API requests to GitHub.
 	RateLimit *GitHubRateLimit `json:"rateLimit,omitempty"`
 	// Repos description: An array of repository "owner/name" strings specifying which GitHub or GitHub Enterprise repositories to mirror on Sourcegraph.


### PR DESCRIPTION
We need a pending state for connecting code hosts through GitHub App if GitHub org admin approval is required. As this is very specific to the GitHub App flow, adding an extra field to the GitHub code host connection schema takes the minimal effort.

Due to the fact that the `"repos": []` field is empty, our repo syncing would effectively do nothing despite at this point, the `"token"` value is invalid.

## Test plan

JSON schema validation.

---

Jira: CLOUD-310