### PR TITLE
Integrate new reference panel into existing `BlobPanel`

### DIFF
--- a/client/branded/src/components/panel/Panel.module.scss
+++ b/client/branded/src/components/panel/Panel.module.scss
@@ -6,6 +6,8 @@
 }
 
 .panel {
+    $panel-header-height: 2rem;
+
     flex: 1 1 50%;
     min-height: 0;
 
@@ -15,24 +17,34 @@
     flex-direction: column;
     position: relative;
 
+    [data-reach-tab-panels] {
+        // Ensure wrapper spans entire height of panel, and that the scrollable area does not include the header height
+        height: calc(100% - #{$panel-header-height});
+    }
+
+    [data-reach-tab-panel] {
+        height: 100%;
+    }
+
     background-color: var(--color-bg-1);
     border-top: 2px solid var(--border-color-2);
     width: 100%;
-}
 
-.header {
-    padding: 0 1rem;
-    background-color: var(--color-bg-1);
+    &--header {
+        padding: 0 1rem;
+        background-color: var(--color-bg-1);
+        height: $panel-header-height;
+    }
 }
 
 .dismiss-button {
     color: var(--icon-color);
 }
 
-.tabs {
-    padding: 0.25rem 1rem;
-}
-
 .tabs-content {
     flex: 1;
+    overflow: auto;
+    height: 100%;
+
+    padding: 0.25rem 1rem;
 }

--- a/client/branded/src/components/panel/Panel.module.scss
+++ b/client/branded/src/components/panel/Panel.module.scss
@@ -43,8 +43,4 @@
 
 .tabs-content {
     flex: 1;
-    overflow: auto;
-    height: 100%;
-
-    padding: 0.25rem 1rem;
 }

--- a/client/branded/src/components/panel/Panel.tsx
+++ b/client/branded/src/components/panel/Panel.tsx
@@ -294,7 +294,7 @@ export const Panel = React.memo<Props>(props => {
         <Tabs className={styles.panel} index={tabIndex} onChange={handleActiveTab}>
             <div className="sticky-top">
                 <TabList
-                    wrapperClassName={styles.header}
+                    wrapperClassName={styles.panelHeader}
                     actions={
                         <div className="align-items-center d-flex">
                             {activeTab && (
@@ -339,7 +339,7 @@ export const Panel = React.memo<Props>(props => {
                     ))}
                 </TabList>
             </div>
-            <TabPanels className={styles.tabs}>
+            <TabPanels>
                 {activeTab ? (
                     items.map(({ id, element }) => (
                         <TabPanel key={id} className={styles.tabsContent} data-testid="panel-tabs-content">

--- a/client/branded/src/components/panel/Panel.tsx
+++ b/client/branded/src/components/panel/Panel.tsx
@@ -59,6 +59,9 @@ export interface PanelViewWithComponent extends PanelViewData {
      * The React element to render in the panel view.
      */
     reactElement?: React.ReactFragment
+
+    // Put React element inside wrapper
+    noWrapper?: boolean
 }
 
 /**
@@ -292,53 +295,51 @@ export const Panel = React.memo<Props>(props => {
 
     return (
         <Tabs className={styles.panel} index={tabIndex} onChange={handleActiveTab}>
-            <div className="sticky-top">
-                <TabList
-                    wrapperClassName={styles.panelHeader}
-                    actions={
-                        <div className="align-items-center d-flex">
-                            {activeTab && (
-                                <ActionsNavItems
-                                    {...props}
-                                    // TODO remove references to Bootstrap from shared, get class name from prop
-                                    // This is okay for now because the Panel is currently only used in the webapp
-                                    listClass="d-flex justify-content-end list-unstyled m-0 align-items-center"
-                                    listItemClass="px-2 mx-2"
-                                    actionItemClass="font-weight-medium"
-                                    actionItemIconClass="icon-inline"
-                                    menu={ContributableMenu.PanelToolbar}
-                                    scope={{
-                                        type: 'panelView',
-                                        id: activeTab.id,
-                                        hasLocations: Boolean(activeTab.hasLocations),
-                                    }}
-                                    wrapInList={true}
-                                    location={location}
-                                    transformContributions={transformPanelContributions}
-                                />
-                            )}
-                            <Button
-                                onClick={handlePanelClose}
-                                variant="icon"
-                                className={classNames('ml-2', styles.dismissButton)}
-                                title="Close panel"
-                                data-tooltip="Close panel"
-                                data-placement="left"
-                            >
-                                <CloseIcon className="icon-inline" />
-                            </Button>
-                        </div>
-                    }
-                >
-                    {items.map(({ label, id, trackTabClick }) => (
-                        <Tab key={id}>
-                            <span className="tablist-wrapper--tab-label" onClick={trackTabClick} role="none">
-                                {label}
-                            </span>
-                        </Tab>
-                    ))}
-                </TabList>
-            </div>
+            <TabList
+                wrapperClassName={classNames(styles.panelHeader, 'sticky-top')}
+                actions={
+                    <div className="align-items-center d-flex">
+                        {activeTab && (
+                            <ActionsNavItems
+                                {...props}
+                                // TODO remove references to Bootstrap from shared, get class name from prop
+                                // This is okay for now because the Panel is currently only used in the webapp
+                                listClass="d-flex justify-content-end list-unstyled m-0 align-items-center"
+                                listItemClass="px-2 mx-2"
+                                actionItemClass="font-weight-medium"
+                                actionItemIconClass="icon-inline"
+                                menu={ContributableMenu.PanelToolbar}
+                                scope={{
+                                    type: 'panelView',
+                                    id: activeTab.id,
+                                    hasLocations: Boolean(activeTab.hasLocations),
+                                }}
+                                wrapInList={true}
+                                location={location}
+                                transformContributions={transformPanelContributions}
+                            />
+                        )}
+                        <Button
+                            onClick={handlePanelClose}
+                            variant="icon"
+                            className={classNames('ml-2', styles.dismissButton)}
+                            title="Close panel"
+                            data-tooltip="Close panel"
+                            data-placement="left"
+                        >
+                            <CloseIcon className="icon-inline" />
+                        </Button>
+                    </div>
+                }
+            >
+                {items.map(({ label, id, trackTabClick }) => (
+                    <Tab key={id}>
+                        <span className="tablist-wrapper--tab-label" onClick={trackTabClick} role="none">
+                            {label}
+                        </span>
+                    </Tab>
+                ))}
+            </TabList>
             <TabPanels>
                 {activeTab ? (
                     items.map(({ id, element }) => (

--- a/client/branded/src/components/panel/Panel.tsx
+++ b/client/branded/src/components/panel/Panel.tsx
@@ -60,7 +60,7 @@ export interface PanelViewWithComponent extends PanelViewData {
      */
     reactElement?: React.ReactFragment
 
-    // Put React element inside wrapper
+    // Should the content of the panel be put inside a wrapper container with padding or not.
     noWrapper?: boolean
 }
 

--- a/client/branded/src/components/panel/Panel.tsx
+++ b/client/branded/src/components/panel/Panel.tsx
@@ -117,10 +117,7 @@ export interface BuiltinPanelDefinition {
 export function useBuiltinPanelViews(builtinPanels: BuiltinPanelDefinition[]): void {
     useEffect(() => {
         for (const builtinPanel of builtinPanels) {
-            builtinPanelViewProviders.value.set(builtinPanel.id, {
-                id: builtinPanel.id,
-                provider: builtinPanel.provider,
-            })
+            builtinPanelViewProviders.value.set(builtinPanel.id, builtinPanel)
         }
         builtinPanelViewProviders.next(new Map([...builtinPanelViewProviders.value]))
 

--- a/client/branded/src/components/panel/Panel.tsx
+++ b/client/branded/src/components/panel/Panel.tsx
@@ -95,35 +95,30 @@ const builtinPanelViewProviders = new BehaviorSubject<
 >(new Map())
 
 /**
+ * BuiltinPanelDefinition defines which BuiltinPanelViews will be available.
+ */
+export interface BuiltinPanelDefinition {
+    id: string
+    matches?: (id: string) => boolean
+    provider: Observable<BuiltinPanelView | null>
+}
+/**
  * React hook to add panel views from other components (panel views are typically
  * contributed by Sourcegraph extensions)
  */
-export function useBuiltinPanelViews(
-    builtinPanels: {
-        id: string
-        matches?: (id: string) => boolean
-        enabled: boolean
-        provider: Observable<BuiltinPanelView | null>
-    }[]
-): void {
+export function useBuiltinPanelViews(builtinPanels: BuiltinPanelDefinition[]): void {
     useEffect(() => {
         for (const builtinPanel of builtinPanels) {
-            if (builtinPanel.enabled) {
-                builtinPanelViewProviders.value.set(builtinPanel.id, {
-                    id: builtinPanel.id,
-                    provider: builtinPanel.provider,
-                    matches: builtinPanel.matches,
-                })
-            }
+            builtinPanelViewProviders.value.set(builtinPanel.id, {
+                id: builtinPanel.id,
+                provider: builtinPanel.provider,
+                matches: builtinPanel.matches,
+            })
         }
         builtinPanelViewProviders.next(new Map([...builtinPanelViewProviders.value]))
 
         return () => {
             for (const builtinPanel of builtinPanels) {
-                if (!builtinPanel.enabled) {
-                    continue
-                }
-
                 builtinPanelViewProviders.value.delete(builtinPanel.id)
             }
             builtinPanelViewProviders.next(new Map([...builtinPanelViewProviders.value]))
@@ -131,6 +126,13 @@ export function useBuiltinPanelViews(
     }, [builtinPanels])
 }
 
+/**
+ * DynamicPanelView is a PanelViewWithComponent that can dynamically decide
+ * whether to be shown for the given panel tab ID.
+ *
+ * This ID comes from the `#tab=<ID>` location hash.
+ *
+ */
 interface DynamicPanelView extends PanelViewWithComponent {
     matches?: (id: string) => boolean
 }

--- a/client/branded/src/components/panel/Panel.tsx
+++ b/client/branded/src/components/panel/Panel.tsx
@@ -19,7 +19,7 @@ import { FetchFileParameters } from '@sourcegraph/shared/src/components/CodeExce
 import { Resizable } from '@sourcegraph/shared/src/components/Resizable'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
-import { SettingsCascadeOrError, SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { Button, useObservable, Tab, TabList, TabPanel, TabPanels, Tabs } from '@sourcegraph/wildcard'
@@ -145,7 +145,9 @@ export const Panel = React.memo<Props>(props => {
         useMemo(() => haveInitialExtensionsLoaded(props.extensionsController.extHostAPI), [props.extensionsController])
     )
 
-    const isExperimentalReferencePanelEnabled = isCoolCodeIntelEnabled(props.settingsCascade)
+    const isExperimentalReferencePanelEnabled =
+        !isErrorLike(props.settingsCascade.final) &&
+        props.settingsCascade.final?.experimentalFeatures?.coolCodeIntel === true
 
     const [tabIndex, setTabIndex] = useState(0)
     const location = useLocation()
@@ -391,7 +393,3 @@ function transformPanelContributions(contributions: Evaluated<Contributions>): E
         return contributions
     }
 }
-
-// isCoolCodeIntelEnabled is duplicated. Need to move to src/shared
-export const isCoolCodeIntelEnabled = (settingsCascade: SettingsCascadeOrError): boolean =>
-    !isErrorLike(settingsCascade.final) && settingsCascade.final?.experimentalFeatures?.coolCodeIntel === true

--- a/client/branded/src/components/panel/views/PanelView.module.scss
+++ b/client/branded/src/components/panel/views/PanelView.module.scss
@@ -1,4 +1,5 @@
 .panel-view {
     flex: 1;
     overflow: auto;
+    padding: 0.25rem 1rem;
 }

--- a/client/branded/src/components/panel/views/PanelView.tsx
+++ b/client/branded/src/components/panel/views/PanelView.tsx
@@ -27,7 +27,7 @@ interface Props extends ExtensionsControllerProps, SettingsCascadeProps, Telemet
  * A panel view contributed by an extension using {@link sourcegraph.app.createPanelView}.
  */
 export const PanelView = React.memo<Props>(props => {
-    const content = (
+    const panelView = (
         <>
             {props.panelView.content && (
                 <div className="px-2 pt-2">
@@ -58,7 +58,8 @@ export const PanelView = React.memo<Props>(props => {
     )
 
     if (props.panelView.noWrapper) {
-        return <>{content}</>
+        return <>{panelView}</>
     }
-    return <div className={styles.panelView}>{content}</div>
+
+    return <div className={styles.panelView}>{panelView}</div>
 })

--- a/client/branded/src/components/panel/views/PanelView.tsx
+++ b/client/branded/src/components/panel/views/PanelView.tsx
@@ -26,32 +26,39 @@ interface Props extends ExtensionsControllerProps, SettingsCascadeProps, Telemet
 /**
  * A panel view contributed by an extension using {@link sourcegraph.app.createPanelView}.
  */
-export const PanelView = React.memo<Props>(props => (
-    <div className={styles.panelView}>
-        {props.panelView.content && (
-            <div className="px-2 pt-2">
-                <Markdown dangerousInnerHTML={renderMarkdown(props.panelView.content)} />
-            </div>
-        )}
-        {props.panelView.reactElement}
-        {props.panelView.locationProvider && props.repoName && (
-            <HierarchicalLocationsView
-                location={props.location}
-                locations={props.panelView.locationProvider}
-                maxLocationResults={props.panelView.maxLocationResults}
-                defaultGroup={props.repoName}
-                isLightTheme={props.isLightTheme}
-                fetchHighlightedFileLineRanges={props.fetchHighlightedFileLineRanges}
-                extensionsController={props.extensionsController}
-                settingsCascade={props.settingsCascade}
-                telemetryService={props.telemetryService}
-                onSelectLocation={(): void =>
-                    props.telemetryService.log('ReferencePanelResultsClicked', { action: 'click' })
-                }
-            />
-        )}
-        {!props.panelView.content && !props.panelView.reactElement && !props.panelView.locationProvider && (
-            <EmptyPanelView className="mt-3" />
-        )}
-    </div>
-))
+export const PanelView = React.memo<Props>(props => {
+    const content = (
+        <>
+            {props.panelView.content && (
+                <div className="px-2 pt-2">
+                    <Markdown dangerousInnerHTML={renderMarkdown(props.panelView.content)} />
+                </div>
+            )}
+            {props.panelView.reactElement}
+            {props.panelView.locationProvider && props.repoName && (
+                <HierarchicalLocationsView
+                    location={props.location}
+                    locations={props.panelView.locationProvider}
+                    maxLocationResults={props.panelView.maxLocationResults}
+                    defaultGroup={props.repoName}
+                    isLightTheme={props.isLightTheme}
+                    fetchHighlightedFileLineRanges={props.fetchHighlightedFileLineRanges}
+                    extensionsController={props.extensionsController}
+                    settingsCascade={props.settingsCascade}
+                    telemetryService={props.telemetryService}
+                    onSelectLocation={(): void =>
+                        props.telemetryService.log('ReferencePanelResultsClicked', { action: 'click' })
+                    }
+                />
+            )}
+            {!props.panelView.content && !props.panelView.reactElement && !props.panelView.locationProvider && (
+                <EmptyPanelView className="mt-3" />
+            )}
+        </>
+    )
+
+    if (props.panelView.noWrapper) {
+        return <>{content}</>
+    }
+    return <div className={styles.panelView}>{content}</div>
+})

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -36,7 +36,6 @@ import { ExtensionAreaHeaderNavItem } from './extensions/extension/ExtensionArea
 import { ExtensionsAreaRoute } from './extensions/ExtensionsArea'
 import { ExtensionsAreaHeaderActionButton } from './extensions/ExtensionsAreaHeader'
 import { FeatureFlagProps } from './featureFlags/featureFlags'
-import { isCoolCodeIntelEnabled } from './global/CoolCodeIntel'
 import { GlobalAlerts } from './global/GlobalAlerts'
 import { GlobalDebug } from './global/GlobalDebug'
 import styles from './Layout.module.scss'
@@ -186,9 +185,6 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
     //     setTosAccepted(true)
     // }, [])
 
-    // Experimental reference panel
-    const coolCodeIntelEnabled = isCoolCodeIntelEnabled(props.settingsCascade)
-
     // Remove trailing slash (which is never valid in any of our URLs).
     if (props.location.pathname !== '/' && props.location.pathname.endsWith('/')) {
         return <Redirect to={{ ...props.location, pathname: props.location.pathname.slice(0, -1) }} />
@@ -271,8 +267,7 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
                     </Switch>
                 </Suspense>
             </ErrorBoundary>
-            {!coolCodeIntelEnabled &&
-                parseQueryAndHash(props.location.search, props.location.hash).viewState &&
+            {parseQueryAndHash(props.location.search, props.location.hash).viewState &&
                 props.location.pathname !== PageRoutes.SignIn && (
                     <ResizablePanel
                         {...props}

--- a/client/web/src/global/CoolCodeIntel.module.scss
+++ b/client/web/src/global/CoolCodeIntel.module.scss
@@ -1,23 +1,3 @@
-.global-codeintel {
-    position: fixed;
-    right: 0;
-    bottom: 0;
-    background-color: var(--body-bg);
-}
-
-.hover-markdown {
-    p,
-    pre {
-        padding-left: 0.5rem;
-        margin-bottom: 0;
-        padding-bottom: 0;
-        padding-top: 0;
-    }
-    code {
-        padding-left: 0;
-    }
-}
-
 .cool-code-intel-reference {
     code {
         overflow: hidden;

--- a/client/web/src/global/CoolCodeIntel.module.scss
+++ b/client/web/src/global/CoolCodeIntel.module.scss
@@ -1,4 +1,4 @@
-.cool-code-intel-reference {
+.reference {
     code {
         overflow: hidden;
         color: var(--body-color);
@@ -19,66 +19,18 @@
             font-weight: bold;
         }
     }
-}
 
-.reference-link {
-    color: inherit;
+    &--link {
+        color: inherit;
 
-    &--line-number {
-        font-family: monospace;
-        color: var(--primary);
-    }
-}
-
-.resizable-panel {
-    isolation: isolate;
-    min-height: 6rem;
-    max-height: calc(100% - 3rem);
-    width: 100%;
-}
-
-.panel {
-    $panel-header-height: 2rem;
-
-    flex: 1 1 50%;
-    min-height: 0;
-
-    overflow-x: auto;
-
-    display: flex;
-    flex-direction: column;
-    position: relative;
-
-    [data-reach-tab-panels] {
-        // Ensure wrapper spans entire height of panel, and that the scrollable area does not include the header height
-        height: calc(100% - #{$panel-header-height});
-    }
-
-    [data-reach-tab-panel] {
-        height: 100%;
-    }
-
-    background-color: var(--color-bg-1);
-    border-top: 2px solid var(--border-color-2);
-    width: 100%;
-
-    &--header {
-        padding: 0 1rem;
-        background-color: var(--color-bg-1);
-        height: $panel-header-height;
+        &--line-number {
+            font-family: monospace;
+            color: var(--primary);
+        }
     }
 }
 
 .dismiss-button {
-    color: var(--icon-color);
-}
-
-.tabs-content {
-    flex: 1;
-}
-
-.chevron {
-    margin-top: 0.2rem;
     color: var(--icon-color);
 }
 
@@ -106,12 +58,6 @@
     &--side-blob {
         flex: 1;
         overflow: auto;
-    }
-
-    // Sticky filename at top
-    &--side-blob-filename {
-        height: $references-filter-height;
-        padding-top: 0.5rem;
     }
 
     // Code needs to be smaller than 100% so it scrolls correctly

--- a/client/web/src/global/CoolCodeIntel.tsx
+++ b/client/web/src/global/CoolCodeIntel.tsx
@@ -113,23 +113,124 @@ export const CoolCodeIntel: React.FunctionComponent<CoolCodeIntelProps> = props 
     </ErrorBoundary>
 )
 
-const LAST_TAB_STORAGE_KEY = 'CoolCodeIntel.lastTab'
+const CoolCodeIntelResizablePanel: React.FunctionComponent<CoolCodeIntelProps> = props => {
+    const location = useLocation()
 
-type CoolCodeIntelTabID = 'references' | 'token' | 'definition'
+    const { hash, pathname, search } = location
+    const { line, character, viewState } = parseQueryAndHash(search, hash)
+    const { filePath, repoName, revision, commitID } = parseBrowserRepoURL(pathname)
 
-interface CoolCodeIntelTab {
-    id: CoolCodeIntelTabID
-    label: string
-    component: React.ComponentType<CoolCodeIntelProps>
-}
-
-export const ReferencesPanel: React.FunctionComponent<CoolCodeIntelProps> = props => {
-    if (!props.token) {
+    // If we don't have enough information in the URL, we can't render the panel
+    if (!(line && character && filePath && viewState)) {
         return null
     }
 
-    return <FilterableReferencesList token={props.token} {...props} />
+    const searchParameters = new URLSearchParams(search)
+    const jumpToFirst = searchParameters.get('jumpToFirst') === 'true'
+
+    const token = { repoName, line, character, filePath }
+
+    if (commitID === undefined || revision === undefined) {
+        return <RevisionResolvingCoolCodeIntelPanel {...props} {...token} jumpToFirst={jumpToFirst} />
+    }
+
+    return <ResizableCoolCodeIntelPanel {...props} token={{ ...token, revision, commitID }} jumpToFirst={jumpToFirst} />
 }
+
+export const BuiltinCoolCodeIntelPanel: React.FunctionComponent<CoolCodeIntelProps> = props => (
+    <MemoryRouter
+        // Force router to remount the Panel when external location changes
+        key={`${props.externalLocation.pathname}${props.externalLocation.search}${props.externalLocation.hash}`}
+        initialEntries={[props.externalLocation]}
+    >
+        <FilterableReferencesList {...props} />
+    </MemoryRouter>
+)
+
+export const RevisionResolvingCoolCodeIntelPanel: React.FunctionComponent<
+    CoolCodeIntelProps & {
+        repoName: string
+        line: number
+        character: number
+        filePath: string
+        revision?: string
+    }
+> = props => {
+    const resolvedRevision = useObservable(useMemo(() => resolveRevision(props), [props]))
+
+    if (!resolvedRevision) {
+        return null
+    }
+
+    const token = {
+        repoName: props.repoName,
+        line: props.line,
+        character: props.character,
+        filePath: props.filePath,
+
+        revision: props.revision || resolvedRevision.defaultBranch,
+        commitID: resolvedRevision.commitID,
+    }
+
+    return <ResizableCoolCodeIntelPanel {...props} token={token} />
+}
+
+const LAST_TAB_STORAGE_KEY = 'CoolCodeIntel.lastTab'
+
+const ResizableCoolCodeIntelPanel = React.memo<CoolCodeIntelProps>(props => (
+    <Resizable
+        className={styles.resizablePanel}
+        handlePosition="top"
+        defaultSize={350}
+        storageKey="panel-size"
+        element={<CoolCodeIntelPanel {...props} />}
+    />
+))
+
+const CoolCodeIntelPanel = React.memo<CoolCodeIntelProps>(props => {
+    const [tabIndex, setTabIndex] = useLocalStorage(LAST_TAB_STORAGE_KEY, 0)
+    const handleTabsChange = useCallback((index: number) => setTabIndex(index), [setTabIndex])
+
+    const location = useLocation()
+    const handlePanelClose = useCallback(() => {
+        // We close the panel by removing the viewState in the external history
+        props.externalHistory.push(locationWithoutViewState(location))
+    }, [props.externalHistory, location])
+
+    return (
+        <Tabs size="medium" className={styles.panel} index={tabIndex} onChange={handleTabsChange}>
+            <div
+                className={classNames('tablist-wrapper d-flex justify-content-between sticky-top', styles.panelHeader)}
+            >
+                <TabList>
+                    <div className="d-flex w-100">
+                        <Tab key="references">
+                            <span className="tablist-wrapper--tab-label" role="none">
+                                References
+                            </span>
+                        </Tab>
+                    </div>
+                </TabList>
+                <div className="align-items-center d-flex">
+                    <Button
+                        onClick={handlePanelClose}
+                        className={classNames('btn-icon ml-2', styles.dismissButton)}
+                        title="Close panel"
+                        data-tooltip="Close panel"
+                        data-placement="left"
+                    >
+                        <CloseIcon className="icon-inline" />
+                    </Button>
+                </div>
+            </div>
+            <TabPanels>
+                <TabPanel key="references">
+                    <FilterableReferencesList {...props} />
+                </TabPanel>
+            </TabPanels>
+        </Tabs>
+    )
+})
 
 interface Location {
     resource: {
@@ -177,17 +278,17 @@ interface LocationGroup {
     locations: Location[]
 }
 
-const FilterableReferencesList: React.FunctionComponent<
-    CoolCodeIntelProps & {
-        token: Token
-    }
-> = props => {
+const FilterableReferencesList: React.FunctionComponent<CoolCodeIntelProps> = props => {
     const [filter, setFilter] = useState<string>()
     const debouncedFilter = useDebounce(filter, 150)
 
     useEffect(() => {
         setFilter(undefined)
     }, [props.token])
+
+    if (props.token === undefined) {
+        return null
+    }
 
     return (
         <>
@@ -198,7 +299,7 @@ const FilterableReferencesList: React.FunctionComponent<
                 value={filter === undefined ? '' : filter}
                 onChange={event => setFilter(event.target.value)}
             />
-            <ReferencesList {...props} filter={debouncedFilter} />
+            <ReferencesList {...props} token={props.token} filter={debouncedFilter} />
         </>
     )
 }
@@ -780,67 +881,6 @@ const ReferenceGroup: React.FunctionComponent<{
     )
 }
 
-const TABS: CoolCodeIntelTab[] = [{ id: 'references', label: 'References', component: ReferencesPanel }]
-
-const ResizableCoolCodeIntelPanel = React.memo<CoolCodeIntelProps>(props => (
-    <Resizable
-        className={styles.resizablePanel}
-        handlePosition="top"
-        defaultSize={350}
-        storageKey="panel-size"
-        element={<CoolCodeIntelPanel {...props} />}
-    />
-))
-
-const CoolCodeIntelPanel = React.memo<CoolCodeIntelProps>(props => {
-    const [tabIndex, setTabIndex] = useLocalStorage(LAST_TAB_STORAGE_KEY, 0)
-    const handleTabsChange = useCallback((index: number) => setTabIndex(index), [setTabIndex])
-
-    const location = useLocation()
-    const handlePanelClose = useCallback(() => {
-        // We close the panel by removing the viewState in the external history
-        props.externalHistory.push(locationWithoutViewState(location))
-    }, [props.externalHistory, location])
-
-    return (
-        <Tabs size="medium" className={styles.panel} index={tabIndex} onChange={handleTabsChange}>
-            <div
-                className={classNames('tablist-wrapper d-flex justify-content-between sticky-top', styles.panelHeader)}
-            >
-                <TabList>
-                    <div className="d-flex w-100">
-                        {TABS.map(({ label, id }) => (
-                            <Tab key={id}>
-                                <span className="tablist-wrapper--tab-label" role="none">
-                                    {label}
-                                </span>
-                            </Tab>
-                        ))}
-                    </div>
-                </TabList>
-                <div className="align-items-center d-flex">
-                    <Button
-                        onClick={handlePanelClose}
-                        className={classNames('btn-icon ml-2', styles.dismissButton)}
-                        title="Close panel"
-                        data-tooltip="Close panel"
-                        data-placement="left"
-                    >
-                        <CloseIcon className="icon-inline" />
-                    </Button>
-                </div>
-            </div>
-            <TabPanels>
-                {TABS.map(tab => (
-                    <TabPanel key={tab.id}>
-                        <tab.component {...props} />
-                    </TabPanel>
-                ))}
-            </TabPanels>
-        </Tabs>
-    )
-})
-
 export function locationWithoutViewState(location: H.Location): H.LocationDescriptorObject {
     const parsedQuery = parseQueryAndHash(location.search, location.hash)
     delete parsedQuery.viewState
@@ -853,58 +893,6 @@ export function locationWithoutViewState(location: H.Location): H.LocationDescri
         hash: '',
     }
     return result
-}
-
-const CoolCodeIntelResizablePanel: React.FunctionComponent<CoolCodeIntelProps> = props => {
-    const location = useLocation()
-
-    const { hash, pathname, search } = location
-    const { line, character, viewState } = parseQueryAndHash(search, hash)
-    const { filePath, repoName, revision, commitID } = parseBrowserRepoURL(pathname)
-
-    // If we don't have enough information in the URL, we can't render the panel
-    if (!(line && character && filePath && viewState)) {
-        return null
-    }
-
-    const searchParameters = new URLSearchParams(search)
-    const jumpToFirst = searchParameters.get('jumpToFirst') === 'true'
-
-    const token = { repoName, line, character, filePath }
-
-    if (commitID === undefined || revision === undefined) {
-        return <RevisionResolvingCoolCodeIntelPanel {...props} {...token} jumpToFirst={jumpToFirst} />
-    }
-
-    return <ResizableCoolCodeIntelPanel {...props} token={{ ...token, revision, commitID }} jumpToFirst={jumpToFirst} />
-}
-
-export const RevisionResolvingCoolCodeIntelPanel: React.FunctionComponent<
-    CoolCodeIntelProps & {
-        repoName: string
-        line: number
-        character: number
-        filePath: string
-        revision?: string
-    }
-> = props => {
-    const resolvedRevision = useObservable(useMemo(() => resolveRevision(props), [props]))
-
-    if (!resolvedRevision) {
-        return null
-    }
-
-    const token = {
-        repoName: props.repoName,
-        line: props.line,
-        character: props.character,
-        filePath: props.filePath,
-
-        revision: props.revision || resolvedRevision.defaultBranch,
-        commitID: resolvedRevision.commitID,
-    }
-
-    return <ResizableCoolCodeIntelPanel {...props} token={token} />
 }
 
 export const appendJumpToFirstQueryParameter = (url: string): string => {

--- a/client/web/src/global/CoolCodeIntel.tsx
+++ b/client/web/src/global/CoolCodeIntel.tsx
@@ -13,7 +13,6 @@ import { HoveredToken } from '@sourcegraph/codeintellify'
 import {
     addLineRangeQueryParameter,
     formatSearchParameters,
-    isErrorLike,
     lprToRange,
     toPositionOrRangeQueryParameter,
     toViewStateHash,
@@ -23,7 +22,7 @@ import { useQuery } from '@sourcegraph/http-client'
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoFileLink'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
-import { SettingsCascadeOrError, SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import {
@@ -83,9 +82,6 @@ interface CoolCodeIntelProps
     externalLocation: H.Location
 }
 
-export const isCoolCodeIntelEnabled = (settingsCascade: SettingsCascadeOrError): boolean =>
-    !isErrorLike(settingsCascade.final) && settingsCascade.final?.experimentalFeatures?.coolCodeIntel === true
-
 export const BuiltinCoolCodeIntelPanel: React.FunctionComponent<CoolCodeIntelProps> = props => (
     <MemoryRouter
         // Force router to remount the Panel when external location changes
@@ -95,6 +91,7 @@ export const BuiltinCoolCodeIntelPanel: React.FunctionComponent<CoolCodeIntelPro
         <CodeNavPanel {...props} />
     </MemoryRouter>
 )
+
 const CodeNavPanel: React.FunctionComponent<CoolCodeIntelProps> = props => {
     const location = useLocation()
 

--- a/client/web/src/global/CoolCodeIntel.tsx
+++ b/client/web/src/global/CoolCodeIntel.tsx
@@ -399,13 +399,8 @@ export const ReferencesList: React.FunctionComponent<
                 </div>
                 {activeLocation !== undefined && (
                     <div className={classNames('px-0 border-left', styles.referencesSideBlob)}>
-                        <CardHeader
-                            className={classNames(
-                                'pl-1 d-flex justify-content-between',
-                                styles.referencesSideBlobFilename
-                            )}
-                        >
-                            <h4>
+                        <CardHeader className={classNames('pl-1 pr-3 py-1 d-flex justify-content-between')}>
+                            <h4 className="mb-0">
                                 {activeLocation.resource.path}{' '}
                                 <Link
                                     to={activeLocation.url}
@@ -420,7 +415,7 @@ export const ReferencesList: React.FunctionComponent<
 
                             <Button
                                 onClick={() => setActiveLocation(undefined)}
-                                className={classNames('btn-icon py-0', styles.dismissButton)}
+                                className={classNames('btn-icon p-0', styles.dismissButton)}
                                 title="Close panel"
                                 data-tooltip="Close panel"
                                 data-placement="left"
@@ -746,7 +741,7 @@ const ReferenceGroup: React.FunctionComponent<{
                 onClick={handleOpen}
                 className="bg-transparent py-1 border-bottom border-top-0 border-left-0 border-right-0 d-flex justify-content-start w-100"
             >
-                <span className={styles.coolCodeIntelReferenceFilename}>
+                <span className={styles.referenceFilename}>
                     {isOpen ? (
                         <ChevronDownIcon className="icon-inline" aria-label="Close" />
                     ) : (
@@ -769,9 +764,7 @@ const ReferenceGroup: React.FunctionComponent<{
                 <ul className="list-unstyled pl-3 py-1 mb-0">
                     {group.locations.map(reference => {
                         const className =
-                            activeLocation && activeLocation.url === reference.url
-                                ? styles.coolCodeIntelReferenceActive
-                                : ''
+                            activeLocation && activeLocation.url === reference.url ? styles.referenceActive : ''
 
                         return (
                             <li key={reference.url} className={classNames('border-0 rounded-0', className)}>

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -20,7 +20,7 @@ import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { parseQueryAndHash, RevisionSpec } from '@sourcegraph/shared/src/util/url'
+import { RevisionSpec } from '@sourcegraph/shared/src/util/url'
 import { Button, Popover, PopoverContent, PopoverTrigger, Position } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'
@@ -30,7 +30,6 @@ import { BreadcrumbSetters } from '../components/Breadcrumbs'
 import { HeroPage } from '../components/HeroPage'
 import { ActionItemsBarProps } from '../extensions/components/ActionItemsBar'
 import { FeatureFlagProps } from '../featureFlags/featureFlags'
-import { CoolCodeIntel, isCoolCodeIntelEnabled } from '../global/CoolCodeIntel'
 import { RepositoryFields } from '../graphql-operations'
 import { CodeInsightsProps } from '../insights/types'
 import { SearchStreamingProps } from '../search'
@@ -183,13 +182,6 @@ export const RepoRevisionContainer: React.FunctionComponent<RepoRevisionContaine
     useBreadcrumb,
     ...props
 }) => {
-    // Experimental reference panel
-    const coolCodeIntelEnabled = isCoolCodeIntelEnabled(props.settingsCascade)
-    const viewState = parseQueryAndHash(props.location.search, props.location.hash).viewState
-    // If we don't have // '#tab=...' in the URL, we don't need to show the panel.
-    const showCoolCodeIntelPanel =
-        coolCodeIntelEnabled && viewState && (viewState === 'references' || viewState.startsWith('implementations_'))
-
     const breadcrumbSetters = useBreadcrumb(
         useMemo(() => {
             if (!props.resolvedRevisionOrError || isErrorLike(props.resolvedRevisionOrError)) {
@@ -310,7 +302,6 @@ export const RepoRevisionContainer: React.FunctionComponent<RepoRevisionContaine
                     )}
                 </RepoHeaderContributionPortal>
             </RepoRevisionWrapper>
-            {false && <CoolCodeIntel {...props} externalHistory={props.history} externalLocation={props.location} />}
         </>
     )
 }

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -310,9 +310,7 @@ export const RepoRevisionContainer: React.FunctionComponent<RepoRevisionContaine
                     )}
                 </RepoHeaderContributionPortal>
             </RepoRevisionWrapper>
-            {showCoolCodeIntelPanel && (
-                <CoolCodeIntel {...props} externalHistory={props.history} externalLocation={props.location} />
-            )}
+            {false && <CoolCodeIntel {...props} externalHistory={props.history} externalLocation={props.location} />}
         </>
     )
 }

--- a/client/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/client/web/src/repo/blob/panel/BlobPanel.tsx
@@ -193,7 +193,13 @@ export function useBlobPanelViews({
                     ),
                 },
                 {
-                    id: 'references',
+                    id: 'codenav',
+                    matches: (id: string): boolean =>
+                        id === 'codenav' ||
+                        id === 'def' ||
+                        id === 'references' ||
+                        id.startsWith('implementations_') ||
+                        id === 'ketchup',
                     enabled: experimentalReferencePanelEnabled,
                     provider: panelSubjectChanges.pipe(
                         map(({ repoName, commitID, position, revision, filePath, history, location }) => ({

--- a/client/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/client/web/src/repo/blob/panel/BlobPanel.tsx
@@ -178,7 +178,6 @@ export function useBlobPanelViews({
                             priority: 150,
                             selector: null,
                             locationProvider: undefined,
-                            noWrapper: true,
                             reactElement: (
                                 <RepoRevisionSidebarCommits
                                     key="commits"
@@ -209,7 +208,6 @@ export function useBlobPanelViews({
                             priority: 180,
                             selector: null,
                             locationProvider: undefined,
-                            // TODO: What do we do if we have no position?
                             noWrapper: true,
                             reactElement: position ? (
                                 <BuiltinCoolCodeIntelPanel

--- a/client/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/client/web/src/repo/blob/panel/BlobPanel.tsx
@@ -23,7 +23,7 @@ import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { AbsoluteRepoFile, ModeSpec, parseQueryAndHash, UIPositionSpec } from '@sourcegraph/shared/src/util/url'
 import { useObservable } from '@sourcegraph/wildcard'
 
-import { BuiltinCoolCodeIntelPanel } from '../../../global/CoolCodeIntel'
+import { ReferencesPanelWithMemoryRouter } from '../../../global/CoolCodeIntel'
 import { RepoRevisionSidebarCommits } from '../../RepoRevisionSidebarCommits'
 
 interface Props
@@ -248,7 +248,7 @@ export function useBlobPanelViews({
                             // This panel doesn't need a wrapper
                             noWrapper: true,
                             reactElement: position ? (
-                                <BuiltinCoolCodeIntelPanel
+                                <ReferencesPanelWithMemoryRouter
                                     settingsCascade={settingsCascade}
                                     platformContext={platformContext}
                                     isLightTheme={isLightTheme}

--- a/client/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/client/web/src/repo/blob/panel/BlobPanel.tsx
@@ -38,7 +38,7 @@ interface Props
     commitID: string
 }
 
-export type BlobPanelTabID = 'info' | 'def' | 'references' | 'impl' | 'typedef' | 'history' | 'cool'
+export type BlobPanelTabID = 'info' | 'def' | 'references' | 'impl' | 'typedef' | 'history'
 
 /** The subject (what the contextual information refers to). */
 interface PanelSubject extends AbsoluteRepoFile, ModeSpec, Partial<UIPositionSpec> {

--- a/client/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/client/web/src/repo/blob/panel/BlobPanel.tsx
@@ -202,7 +202,6 @@ export function useBlobPanelViews({
                     ...[
                         {
                             id: 'def',
-                            matches: undefined,
                             provider: createLocationProvider('def', 'Definition', 190, parameters =>
                                 from(extensionsController.extHostAPI).pipe(
                                     switchMap(extensionHostAPI =>
@@ -213,7 +212,6 @@ export function useBlobPanelViews({
                         },
                         {
                             id: 'references',
-                            matches: undefined,
                             provider: createLocationProvider<ReferenceParameters>(
                                 'references',
                                 'References',
@@ -235,8 +233,6 @@ export function useBlobPanelViews({
             } else {
                 panelDefinitions.push({
                     id: 'references',
-                    matches: (id: string): boolean =>
-                        id === 'def' || id === 'references' || id.startsWith('implementations_'),
                     provider: panelSubjectChanges.pipe(
                         map(({ repoName, commitID, position, revision, filePath, history, location }) => ({
                             title: 'References',
@@ -244,6 +240,10 @@ export function useBlobPanelViews({
                             priority: 180,
                             selector: null,
                             locationProvider: undefined,
+                            // The new reference panel contains definitoins, references, and implementations. We need it to
+                            // match all these IDs so it shows up when one of the IDs is used as `#tab=<ID>` in the URL.
+                            matches: (id: string): boolean =>
+                                id === 'def' || id === 'references' || id.startsWith('implementations_'),
                             // This panel doesn't need a wrapper
                             noWrapper: true,
                             reactElement: position ? (
@@ -259,8 +259,8 @@ export function useBlobPanelViews({
                                         commitID,
                                         revision,
                                         filePath,
-                                        line: position?.line,
-                                        character: position?.character,
+                                        line: position.line,
+                                        character: position.character,
                                     }}
                                     externalHistory={history}
                                     externalLocation={location}

--- a/client/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/client/web/src/repo/blob/panel/BlobPanel.tsx
@@ -23,7 +23,7 @@ import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { AbsoluteRepoFile, ModeSpec, parseQueryAndHash, UIPositionSpec } from '@sourcegraph/shared/src/util/url'
 import { useObservable } from '@sourcegraph/wildcard'
 
-import { BuiltinCoolCodeIntelPanel, isCoolCodeIntelEnabled } from '../../../global/CoolCodeIntel'
+import { BuiltinCoolCodeIntelPanel } from '../../../global/CoolCodeIntel'
 import { RepoRevisionSidebarCommits } from '../../RepoRevisionSidebarCommits'
 
 interface Props
@@ -100,7 +100,8 @@ export function useBlobPanelViews({
 
     const maxPanelResults = maxPanelResultsFromSettings(settingsCascade)
     const preferAbsoluteTimestamps = preferAbsoluteTimestampsFromSettings(settingsCascade)
-    const experimentalReferencePanelEnabled = isCoolCodeIntelEnabled(settingsCascade)
+    const experimentalReferencePanelEnabled =
+        !isErrorLike(settingsCascade.final) && settingsCascade.final?.experimentalFeatures?.coolCodeIntel === true
 
     // Creates source for definition and reference panels
     const createLocationProvider = useCallback(

--- a/client/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/client/web/src/repo/blob/panel/BlobPanel.tsx
@@ -178,6 +178,7 @@ export function useBlobPanelViews({
                             priority: 150,
                             selector: null,
                             locationProvider: undefined,
+                            noWrapper: true,
                             reactElement: (
                                 <RepoRevisionSidebarCommits
                                     key="commits"
@@ -209,6 +210,7 @@ export function useBlobPanelViews({
                             selector: null,
                             locationProvider: undefined,
                             // TODO: What do we do if we have no position?
+                            noWrapper: true,
                             reactElement: position ? (
                                 <BuiltinCoolCodeIntelPanel
                                     settingsCascade={settingsCascade}


### PR DESCRIPTION
This fixes #32307 by integrating the new reference panel into the existing `BlobPanel` as another `BuiltinPanelView`.

There's three interesting bits here:

* I made the `PanelViews` dynamic so that they can match different tab IDs in the URL (`#tab=<ID>`), since the new reference panel needs to be backward compatible and react to `#tab=def`, `#tab=references`, `#tab=implementations_$LANGUAGE`, which are hardcoded into the extensions.
* Depending on whether the feature flag `coolCodeIntel` is enabled, the new panel or the old def/ref/implementations panels are used. The `def` and `ref` panels are easily deactivated, but the `implementations_$LANGUAGE` panels come from extensions, so I had to dynamically filter them.
* I had to essentially move the styling of the panels. They still look the same, but I had to move some styling and optionally disable a wrapper element so I can get the `overflow: scroll` working correctly for the two panes inside the new panel.

The rest is essentially cleanup and restructuring of the existing components and removal of those that we don't need anymore. I also thought about moving components but that would've made the diff unreadable. So I'll save that for a follow-up PR.


## Test plan

- Tested this locally by enabling/disabling the flag, checking whether the new panel reacts to all URLs, testing that dynamic matching works, etc. See video.

https://user-images.githubusercontent.com/1185253/157863497-65eecf67-5e4c-4a1e-88e6-7b2073eaaedb.mp4





