### PR TITLE
site config: redact more secrets 

### DIFF
--- a/internal/conf/validate_test.go
+++ b/internal/conf/validate_test.go
@@ -5,14 +5,24 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-var executorsAccessToken = "executors-access-token"
-var openIDSecret = "open-id-secret"
-var gitlabClientSecret = "gitlab-client-secret"
-var githubClientSecret = "github-client-secret"
+const (
+	executorsAccessToken              = "executorsAccessToken"
+	authOpenIDClientSecret            = "authOpenIDClientSecret"
+	authGitHubClientSecret            = "authGitHubClientSecret"
+	authGitLabClientSecret            = "authGitLabClientSecret"
+	emailSMTPPassword                 = "emailSMTPPassword"
+	organizationInvitationsSigningKey = "organizationInvitationsSigningKey"
+	githubClientSecret                = "githubClientSecret"
+	dotcomGitHubAppCloudClientSecret  = "dotcomGitHubAppCloudClientSecret"
+	dotcomGitHubAppCloudPrivateKey    = "dotcomGitHubAppCloudPrivateKey"
+)
 
 func TestValidate(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
@@ -130,75 +140,123 @@ func TestProblems(t *testing.T) {
 	}
 }
 
-func TestRedact(t *testing.T) {
-	t.Run("redact secrets", func(t *testing.T) {
-		input := getTestSiteWithSecrets(executorsAccessToken, openIDSecret, gitlabClientSecret, githubClientSecret)
-		redacted, err := RedactSecrets(conftypes.RawUnified{
-			Site: input,
-		})
-		if err != nil {
-			t.Errorf("unexpected error redacting secrets: %s", err)
-		}
-		expected := getTestSiteWithRedactedSecrets()
-		if !redacted.Equal(conftypes.RawUnified{Site: expected}) {
-			t.Errorf("unexpected output of RedactSecrets")
-		}
-	})
+func TestRedactSecrets(t *testing.T) {
+	redacted, err := RedactSecrets(
+		conftypes.RawUnified{
+			Site: getTestSiteWithSecrets(
+				executorsAccessToken,
+				authOpenIDClientSecret, authGitLabClientSecret, authGitHubClientSecret,
+				emailSMTPPassword,
+				organizationInvitationsSigningKey,
+				githubClientSecret,
+				dotcomGitHubAppCloudClientSecret,
+				dotcomGitHubAppCloudPrivateKey,
+			),
+		},
+	)
+	require.NoError(t, err)
+
+	want := getTestSiteWithRedactedSecrets()
+	assert.Equal(t, want, redacted.Site)
 }
 
-func TestUnredact(t *testing.T) {
+func TestUnredactSecrets(t *testing.T) {
+	previousSite := getTestSiteWithSecrets(
+		executorsAccessToken,
+		authOpenIDClientSecret, authGitLabClientSecret, authGitHubClientSecret,
+		emailSMTPPassword,
+		organizationInvitationsSigningKey,
+		githubClientSecret,
+		dotcomGitHubAppCloudClientSecret,
+		dotcomGitHubAppCloudPrivateKey,
+	)
+
 	t.Run("replaces REDACTED with corresponding secret", func(t *testing.T) {
 		input := getTestSiteWithRedactedSecrets()
-		previousSite := getTestSiteWithSecrets(executorsAccessToken, openIDSecret, githubClientSecret, gitlabClientSecret)
 		unredactedSite, err := UnredactSecrets(input, conftypes.RawUnified{Site: previousSite})
-		if err != nil {
-			t.Errorf("unexpected error unredacting secrets: %s", err)
-		}
-		if strings.Contains(unredactedSite, RedactedSecret) {
-			t.Errorf("expected unredacted to contain secrets")
-		}
-		expectedUnredacted := conftypes.RawUnified{Site: previousSite}
-		unredacted := conftypes.RawUnified{Site: unredactedSite}
-		if !unredacted.Equal(expectedUnredacted) {
-			t.Errorf("unexpected output of UnredactSecrets")
-		}
+		require.NoError(t, err)
+		assert.Contains(t, unredactedSite, RedactedSecret)
+
+		got := conftypes.RawUnified{Site: unredactedSite}
+		want := conftypes.RawUnified{Site: previousSite}
+		assert.Equal(t, want, got)
 	})
+
 	t.Run("unredacts secrets AND respects specified edits to secret", func(t *testing.T) {
-		input := getTestSiteWithSecrets("new-access-token", RedactedSecret, "new-github-client-secret", RedactedSecret)
-		previousSite := getTestSiteWithSecrets(executorsAccessToken, openIDSecret, githubClientSecret, gitlabClientSecret)
+		input := getTestSiteWithSecrets(
+			"new"+executorsAccessToken,
+			RedactedSecret, "new"+authGitLabClientSecret, RedactedSecret,
+			RedactedSecret,
+			RedactedSecret,
+			RedactedSecret,
+			RedactedSecret,
+			RedactedSecret,
+		)
 		unredactedSite, err := UnredactSecrets(input, conftypes.RawUnified{Site: previousSite})
-		if err != nil {
-			t.Errorf("unexpected error unredacting secrets: %s", err)
+		require.NoError(t, err)
+
+		got := conftypes.RawUnified{Site: unredactedSite}
+		// Expect to have newly-specified secrets and to fill in "REDACTED" secrets with secrets from previous site
+		want := conftypes.RawUnified{
+			Site: getTestSiteWithSecrets(
+				"new"+executorsAccessToken,
+				authOpenIDClientSecret, "new"+authGitLabClientSecret, authGitHubClientSecret,
+				emailSMTPPassword,
+				organizationInvitationsSigningKey,
+				githubClientSecret,
+				dotcomGitHubAppCloudClientSecret,
+				dotcomGitHubAppCloudPrivateKey,
+			),
 		}
-		// Expect to have newly-specified secrets and to fill in "REDACTED" secrets w/ secrets from previous site
-		expectedUnredacted := conftypes.RawUnified{Site: getTestSiteWithSecrets("new-access-token", openIDSecret, "new-github-client-secret", gitlabClientSecret)}
-		unredacted := conftypes.RawUnified{Site: unredactedSite}
-		if !unredacted.Equal(expectedUnredacted) {
-			t.Errorf("unexpected output of UnredactSecrets")
-		}
+		assert.Equal(t, want, got)
 	})
+
 	t.Run("unredacts secrets and respects edits to config", func(t *testing.T) {
-		newEmail := "new_email@example.com"
-		input := getTestSiteWithSecrets("new-access-token", RedactedSecret, "new-github-client-secret", RedactedSecret, newEmail)
-		previousSite := getTestSiteWithSecrets(executorsAccessToken, openIDSecret, githubClientSecret, gitlabClientSecret)
+		const newEmail = "new_email@example.com"
+		input := getTestSiteWithSecrets(
+			"new"+executorsAccessToken,
+			RedactedSecret, "new"+authGitLabClientSecret, RedactedSecret,
+			RedactedSecret,
+			RedactedSecret,
+			RedactedSecret,
+			RedactedSecret,
+			RedactedSecret,
+			newEmail,
+		)
 		unredactedSite, err := UnredactSecrets(input, conftypes.RawUnified{Site: previousSite})
-		if err != nil {
-			t.Errorf("unexpected error unredacting secrets: %s", err)
-		}
+		require.NoError(t, err)
+
+		got := conftypes.RawUnified{Site: unredactedSite}
 		// Expect new secrets and new email to show up in the unredacted version
-		expectedUnredacted := conftypes.RawUnified{Site: getTestSiteWithSecrets("new-access-token", openIDSecret, "new-github-client-secret", gitlabClientSecret, newEmail)}
-		unredacted := conftypes.RawUnified{Site: unredactedSite}
-		if !unredacted.Equal(expectedUnredacted) {
-			t.Errorf("unexpected output of UnredactSecrets")
+		want := conftypes.RawUnified{
+			Site: getTestSiteWithSecrets(
+				"new"+executorsAccessToken,
+				authOpenIDClientSecret, "new"+authGitLabClientSecret, authGitHubClientSecret,
+				emailSMTPPassword,
+				organizationInvitationsSigningKey,
+				githubClientSecret,
+				dotcomGitHubAppCloudClientSecret,
+				dotcomGitHubAppCloudPrivateKey,
+				newEmail,
+			),
 		}
+		assert.Equal(t, want, got)
 	})
 }
 
 func getTestSiteWithRedactedSecrets() string {
-	return getTestSiteWithSecrets(RedactedSecret, RedactedSecret, RedactedSecret, RedactedSecret)
+	return getTestSiteWithSecrets(RedactedSecret, RedactedSecret, RedactedSecret, RedactedSecret, RedactedSecret, RedactedSecret, RedactedSecret, RedactedSecret, RedactedSecret)
 }
 
-func getTestSiteWithSecrets(execAccessToken, openIDSecret, githubSecret, gitlabSecret string, optionalEdit ...string) string {
+func getTestSiteWithSecrets(
+	executorsAccessToken,
+	authOpenIDClientSecret, authGitHubClientSecret, authGitLabClientSecret,
+	emailSMTPPassword,
+	organizationInvitationsSigningKey,
+	githubClientSecret,
+	dotcomGitHubAppCloudClientSecret, dotcomGitHubAppCloudPrivateKey string,
+	optionalEdit ...string,
+) string {
 	email := "noreply+dev@sourcegraph.com"
 	if len(optionalEdit) > 0 {
 		email = optionalEdit[0]
@@ -240,8 +298,29 @@ func getTestSiteWithSecrets(execAccessToken, openIDSecret, githubSecret, gitlabS
   "observability.tracing": {
     "sampling":"selective"
   },
-  "externalService.userMode": "all"
+  "externalService.userMode": "all",
+  "email.smtp": {
+    "password": "%s"
+  },
+  "organizationInvitations": {
+    "signingKey": "%s"
+  },
+  "authGitHubClientSecret": "%s",
+  "dotcom": {
+    "githubApp.cloud": {
+      "clientSecret": "%s",
+      "privateKey": "%s"
+    }
+  }
 }
-`, email, execAccessToken, openIDSecret, githubSecret, gitlabSecret)
+`,
+		email,
+		executorsAccessToken,
+		authOpenIDClientSecret, authGitHubClientSecret, authGitLabClientSecret,
+		emailSMTPPassword,
+		organizationInvitationsSigningKey,
+		githubClientSecret,
+		dotcomGitHubAppCloudClientSecret, dotcomGitHubAppCloudPrivateKey,
+	)
 
 }

--- a/internal/conf/validate_test.go
+++ b/internal/conf/validate_test.go
@@ -175,11 +175,8 @@ func TestUnredactSecrets(t *testing.T) {
 		input := getTestSiteWithRedactedSecrets()
 		unredactedSite, err := UnredactSecrets(input, conftypes.RawUnified{Site: previousSite})
 		require.NoError(t, err)
-		assert.Contains(t, unredactedSite, RedactedSecret)
-
-		got := conftypes.RawUnified{Site: unredactedSite}
-		want := conftypes.RawUnified{Site: previousSite}
-		assert.Equal(t, want, got)
+		assert.NotContains(t, unredactedSite, RedactedSecret)
+		assert.Equal(t, previousSite, unredactedSite)
 	})
 
 	t.Run("unredacts secrets AND respects specified edits to secret", func(t *testing.T) {
@@ -195,20 +192,17 @@ func TestUnredactSecrets(t *testing.T) {
 		unredactedSite, err := UnredactSecrets(input, conftypes.RawUnified{Site: previousSite})
 		require.NoError(t, err)
 
-		got := conftypes.RawUnified{Site: unredactedSite}
 		// Expect to have newly-specified secrets and to fill in "REDACTED" secrets with secrets from previous site
-		want := conftypes.RawUnified{
-			Site: getTestSiteWithSecrets(
-				"new"+executorsAccessToken,
-				authOpenIDClientSecret, "new"+authGitLabClientSecret, authGitHubClientSecret,
-				emailSMTPPassword,
-				organizationInvitationsSigningKey,
-				githubClientSecret,
-				dotcomGitHubAppCloudClientSecret,
-				dotcomGitHubAppCloudPrivateKey,
-			),
-		}
-		assert.Equal(t, want, got)
+		want := getTestSiteWithSecrets(
+			"new"+executorsAccessToken,
+			authOpenIDClientSecret, "new"+authGitLabClientSecret, authGitHubClientSecret,
+			emailSMTPPassword,
+			organizationInvitationsSigningKey,
+			githubClientSecret,
+			dotcomGitHubAppCloudClientSecret,
+			dotcomGitHubAppCloudPrivateKey,
+		)
+		assert.Equal(t, want, unredactedSite)
 	})
 
 	t.Run("unredacts secrets and respects edits to config", func(t *testing.T) {
@@ -226,21 +220,18 @@ func TestUnredactSecrets(t *testing.T) {
 		unredactedSite, err := UnredactSecrets(input, conftypes.RawUnified{Site: previousSite})
 		require.NoError(t, err)
 
-		got := conftypes.RawUnified{Site: unredactedSite}
 		// Expect new secrets and new email to show up in the unredacted version
-		want := conftypes.RawUnified{
-			Site: getTestSiteWithSecrets(
-				"new"+executorsAccessToken,
-				authOpenIDClientSecret, "new"+authGitLabClientSecret, authGitHubClientSecret,
-				emailSMTPPassword,
-				organizationInvitationsSigningKey,
-				githubClientSecret,
-				dotcomGitHubAppCloudClientSecret,
-				dotcomGitHubAppCloudPrivateKey,
-				newEmail,
-			),
-		}
-		assert.Equal(t, want, got)
+		want := getTestSiteWithSecrets(
+			"new"+executorsAccessToken,
+			authOpenIDClientSecret, "new"+authGitLabClientSecret, authGitHubClientSecret,
+			emailSMTPPassword,
+			organizationInvitationsSigningKey,
+			githubClientSecret,
+			dotcomGitHubAppCloudClientSecret,
+			dotcomGitHubAppCloudPrivateKey,
+			newEmail,
+		)
+		assert.Equal(t, want, unredactedSite)
 	})
 }
 
@@ -305,7 +296,7 @@ func getTestSiteWithSecrets(
   "organizationInvitations": {
     "signingKey": "%s"
   },
-  "authGitHubClientSecret": "%s",
+  "githubClientSecret": "%s",
   "dotcom": {
     "githubApp.cloud": {
       "clientSecret": "%s",


### PR DESCRIPTION
There are some secrets not being redacted in the site config before serving to the web app, this fixes that. In addition, this PR refactors the implementation a bit to make future edits of the list of secrets easier.

## Test plan

Unit tests.
