### PR TITLE
database: Remove database.Mocks.ExternalServices

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/init.go
+++ b/enterprise/cmd/frontend/internal/authz/init.go
@@ -33,7 +33,7 @@ import (
 var clock = timeutil.Now
 
 func Init(ctx context.Context, db database.DB, _ conftypes.UnifiedWatchable, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
-	database.ExternalServices = edb.NewExternalServicesStore
+	database.ValidateExternalServiceConfig = edb.ValidateExternalServiceConfig
 	database.Authz = func(db dbutil.DB) database.AuthzStore {
 		return edb.NewAuthzStore(db, clock)
 	}

--- a/enterprise/internal/database/external_services.go
+++ b/enterprise/internal/database/external_services.go
@@ -6,19 +6,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/authz/gitlab"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/authz/perforce"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-// NewExternalServicesStore returns an OSS database.ExternalServicesStore set with
-// enterprise validators.
-func NewExternalServicesStore(db dbutil.DB) database.ExternalServiceStore {
-	return database.NewExternalServiceStoreWithValidators(
-		db,
-		[]func(*types.GitHubConnection) error{github.ValidateAuthz},
-		[]func(*schema.GitLabConnection, []schema.AuthProviders) error{gitlab.ValidateAuthz},
-		[]func(*schema.BitbucketServerConnection) error{bitbucketserver.ValidateAuthz},
-		[]func(connection *schema.PerforceConnection) error{perforce.ValidateAuthz},
-	)
-}
+var ValidateExternalServiceConfig = database.MakeValidateExternalServiceConfigFunc([]func(*types.GitHubConnection) error{github.ValidateAuthz},
+	[]func(*schema.GitLabConnection, []schema.AuthProviders) error{gitlab.ValidateAuthz},
+	[]func(*schema.BitbucketServerConnection) error{bitbucketserver.ValidateAuthz},
+	[]func(connection *schema.PerforceConnection) error{perforce.ValidateAuthz})

--- a/enterprise/internal/database/external_services_test.go
+++ b/enterprise/internal/database/external_services_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -20,8 +19,8 @@ import (
 
 // This test lives in cmd/enterprise because it tests a proprietary
 // super-set of the validation performed by the OSS version.
-func TestExternalServices_ValidateConfig(t *testing.T) {
-	d := dbtest.NewDB(t)
+func TestValidateExternalServiceConfig(t *testing.T) {
+	t.Parallel()
 
 	// Assertion helpers
 	equals := func(want ...string) func(testing.TB, []string) {
@@ -1298,7 +1297,7 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 				tc.ps = conf.Get().AuthProviders
 			}
 
-			s := database.ExternalServices(d)
+			s := database.NewMockExternalServiceStore()
 			_, err := ValidateExternalServiceConfig(context.Background(), s, database.ValidateExternalServiceConfigOptions{
 				Kind:          tc.kind,
 				Config:        tc.config,

--- a/enterprise/internal/database/external_services_test.go
+++ b/enterprise/internal/database/external_services_test.go
@@ -1298,8 +1298,8 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 				tc.ps = conf.Get().AuthProviders
 			}
 
-			s := NewExternalServicesStore(d)
-			_, err := s.ValidateConfig(context.Background(), database.ValidateExternalServiceConfigOptions{
+			s := database.ExternalServices(d)
+			_, err := ValidateExternalServiceConfig(context.Background(), s, database.ValidateExternalServiceConfigOptions{
 				Kind:          tc.kind,
 				Config:        tc.config,
 				AuthProviders: tc.ps,

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -125,11 +125,6 @@ type ExternalServiceStore interface {
 	// false (i.e. enforce permissions).
 	Upsert(ctx context.Context, svcs ...*types.ExternalService) (err error)
 
-	// ValidateConfig validates the given external service configuration, and returns a normalized
-	// version of the configuration (i.e. valid JSON without comments).
-	// A positive opt.ID indicates we are updating an existing service, adding a new one otherwise.
-	ValidateConfig(ctx context.Context, opt ValidateExternalServiceConfigOptions) (normalized []byte, err error)
-
 	WithEncryptionKey(key encryption.Key) ExternalServiceStore
 
 	Transact(ctx context.Context) (ExternalServiceStore, error)
@@ -145,46 +140,19 @@ type ExternalServiceStore interface {
 type externalServiceStore struct {
 	*basestore.Store
 
-	gitHubValidators          []func(*types.GitHubConnection) error
-	gitLabValidators          []func(*schema.GitLabConnection, []schema.AuthProviders) error
-	bitbucketServerValidators []func(*schema.BitbucketServerConnection) error
-	perforceValidators        []func(*schema.PerforceConnection) error
-
 	key encryption.Key
 }
 
 func (e *externalServiceStore) copy() *externalServiceStore {
 	return &externalServiceStore{
-		Store:                     e.Store,
-		key:                       e.key,
-		gitHubValidators:          e.gitHubValidators,
-		gitLabValidators:          e.gitLabValidators,
-		bitbucketServerValidators: e.bitbucketServerValidators,
-		perforceValidators:        e.perforceValidators,
+		Store: e.Store,
+		key:   e.key,
 	}
 }
 
 // ExternalServices instantiates and returns a new ExternalServicesStore with prepared statements.
-var ExternalServices = NewExternalServiceStore
-
-func NewExternalServiceStore(db dbutil.DB) ExternalServiceStore {
+func ExternalServices(db dbutil.DB) ExternalServiceStore {
 	return &externalServiceStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
-}
-
-func NewExternalServiceStoreWithValidators(
-	db dbutil.DB,
-	gitHubValidators []func(*types.GitHubConnection) error,
-	gitLabValidators []func(*schema.GitLabConnection, []schema.AuthProviders) error,
-	bitbucketServerValidators []func(*schema.BitbucketServerConnection) error,
-	perforceValidators []func(*schema.PerforceConnection) error,
-) ExternalServiceStore {
-	return &externalServiceStore{
-		Store:                     basestore.NewWithDB(db, sql.TxOptions{}),
-		gitHubValidators:          gitHubValidators,
-		gitLabValidators:          gitLabValidators,
-		bitbucketServerValidators: bitbucketServerValidators,
-		perforceValidators:        perforceValidators,
-	}
 }
 
 // ExternalServicesWith instantiates and returns a new ExternalServicesStore with prepared statements.
@@ -342,129 +310,136 @@ func (e *ValidateExternalServiceConfigOptions) IsSiteOwned() bool {
 	return e.NamespaceUserID == 0 && e.NamespaceOrgID == 0
 }
 
-func (e *externalServiceStore) ValidateConfig(ctx context.Context, opt ValidateExternalServiceConfigOptions) (normalized []byte, err error) {
-	ext, ok := ExternalServiceKinds[opt.Kind]
-	if !ok {
-		return nil, errors.Errorf("invalid external service kind: %s", opt.Kind)
-	}
+type ValidateExternalServiceConfigFunc = func(ctx context.Context, e ExternalServiceStore, opt ValidateExternalServiceConfigOptions) (normalized []byte, err error)
 
-	// All configs must be valid JSON.
-	// If this requirement is ever changed, you will need to update
-	// serveExternalServiceConfigs to handle this case.
+// ValidateExternalServiceConfig is the default non-enterprise version of our validation function
+var ValidateExternalServiceConfig = MakeValidateExternalServiceConfigFunc(nil, nil, nil, nil)
 
-	sl := gojsonschema.NewSchemaLoader()
-	sc, err := sl.Compile(gojsonschema.NewStringLoader(ext.JSONSchema))
-	if err != nil {
-		return nil, errors.Wrapf(err, "unable to compile schema for external service of kind %q", opt.Kind)
-	}
+func MakeValidateExternalServiceConfigFunc(gitHubValidators []func(*types.GitHubConnection) error, gitLabValidators []func(*schema.GitLabConnection, []schema.AuthProviders) error, bitbucketServerValidators []func(*schema.BitbucketServerConnection) error, perforceValidators []func(*schema.PerforceConnection) error) ValidateExternalServiceConfigFunc {
+	return func(ctx context.Context, e ExternalServiceStore, opt ValidateExternalServiceConfigOptions) (normalized []byte, err error) {
+		ext, ok := ExternalServiceKinds[opt.Kind]
+		if !ok {
+			return nil, errors.Errorf("invalid external service kind: %s", opt.Kind)
+		}
 
-	normalized, err = jsonc.Parse(opt.Config)
-	if err != nil {
-		return nil, errors.Wrapf(err, "unable to normalize JSON")
-	}
+		// All configs must be valid JSON.
+		// If this requirement is ever changed, you will need to update
+		// serveExternalServiceConfigs to handle this case.
 
-	// Check for any redacted secrets, in
-	// graphqlbackend/external_service.go:externalServiceByID() we call
-	// svc.RedactConfigSecrets() replacing any secret fields in the JSON with
-	// types.RedactedSecret, this is to prevent us leaking tokens that users add.
-	// Here we check that the config we've been passed doesn't contain any redacted
-	// secrets in order to avoid breaking configs by writing the redacted version to
-	// the database. we should have called svc.UnredactConfig(oldSvc) before this
-	// point, e.g. in the Update method of the ExternalServiceStore.
-	if bytes.Contains(normalized, []byte(types.RedactedSecret)) {
-		return nil, errors.Errorf(
-			"unable to write external service config as it contains redacted fields, this is likely a bug rather than a problem with your config",
-		)
-	}
-
-	// For user-added and org-added external services, we need to prevent them from using disallowed fields.
-	if !opt.IsSiteOwned() {
-		// We do not allow users to add external service other than GitHub.com and GitLab.com
-		result := gjson.GetBytes(normalized, "url")
-		baseURL, err := url.Parse(result.String())
+		sl := gojsonschema.NewSchemaLoader()
+		sc, err := sl.Compile(gojsonschema.NewStringLoader(ext.JSONSchema))
 		if err != nil {
-			return nil, errors.Wrap(err, "parse base URL")
-		}
-		normalizedURL := extsvc.NormalizeBaseURL(baseURL).String()
-		if normalizedURL != "https://github.com/" &&
-			normalizedURL != "https://gitlab.com/" {
-			return nil, errors.New("external service only allowed for https://github.com/ and https://gitlab.com/")
+			return nil, errors.Wrapf(err, "unable to compile schema for external service of kind %q", opt.Kind)
 		}
 
-		disallowedFields := []string{"repositoryPathPattern", "nameTransformations", "rateLimit"}
-		results := gjson.GetManyBytes(normalized, disallowedFields...)
-		for i, r := range results {
-			if r.Exists() {
-				return nil, errors.Errorf("field %q is not allowed in a user-added external service", disallowedFields[i])
+		normalized, err = jsonc.Parse(opt.Config)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to normalize JSON")
+		}
+
+		// Check for any redacted secrets, in
+		// graphqlbackend/external_service.go:externalServiceByID() we call
+		// svc.RedactConfigSecrets() replacing any secret fields in the JSON with
+		// types.RedactedSecret, this is to prevent us leaking tokens that users add.
+		// Here we check that the config we've been passed doesn't contain any redacted
+		// secrets in order to avoid breaking configs by writing the redacted version to
+		// the database. we should have called svc.UnredactConfig(oldSvc) before this
+		// point, e.g. in the Update method of the ExternalServiceStore.
+		if bytes.Contains(normalized, []byte(types.RedactedSecret)) {
+			return nil, errors.Errorf(
+				"unable to write external service config as it contains redacted fields, this is likely a bug rather than a problem with your config",
+			)
+		}
+
+		// For user-added and org-added external services, we need to prevent them from using disallowed fields.
+		if !opt.IsSiteOwned() {
+			// We do not allow users to add external service other than GitHub.com and GitLab.com
+			result := gjson.GetBytes(normalized, "url")
+			baseURL, err := url.Parse(result.String())
+			if err != nil {
+				return nil, errors.Wrap(err, "parse base URL")
+			}
+			normalizedURL := extsvc.NormalizeBaseURL(baseURL).String()
+			if normalizedURL != "https://github.com/" &&
+				normalizedURL != "https://gitlab.com/" {
+				return nil, errors.New("external service only allowed for https://github.com/ and https://gitlab.com/")
+			}
+
+			disallowedFields := []string{"repositoryPathPattern", "nameTransformations", "rateLimit"}
+			results := gjson.GetManyBytes(normalized, disallowedFields...)
+			for i, r := range results {
+				if r.Exists() {
+					return nil, errors.Errorf("field %q is not allowed in a user-added external service", disallowedFields[i])
+				}
+			}
+
+			// Allow only create one external service per kind
+			if err := validateSingleKindPerNamespace(ctx, e, opt.ExternalServiceID, opt.Kind, opt.NamespaceUserID, opt.NamespaceOrgID); err != nil {
+				return nil, err
 			}
 		}
 
-		// Allow only create one external service per kind
-		if err := e.validateSingleKindPerNamespace(ctx, opt.ExternalServiceID, opt.Kind, opt.NamespaceUserID, opt.NamespaceOrgID); err != nil {
-			return nil, err
+		res, err := sc.Validate(gojsonschema.NewBytesLoader(normalized))
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to validate config against schema")
 		}
+
+		var errs error
+		for _, err := range res.Errors() {
+			errString := err.String()
+			// Remove `(root): ` from error formatting since these errors are
+			// presented to users.
+			errString = strings.TrimPrefix(errString, "(root): ")
+			errs = errors.Append(errs, errors.New(errString))
+		}
+
+		// Extra validation not based on JSON Schema.
+		switch opt.Kind {
+		case extsvc.KindGitHub:
+			var c schema.GitHubConnection
+			if err = jsoniter.Unmarshal(normalized, &c); err != nil {
+				return nil, err
+			}
+			err = validateGitHubConnection(ctx, e, gitHubValidators, opt.ExternalServiceID, &c)
+
+		case extsvc.KindGitLab:
+			var c schema.GitLabConnection
+			if err = jsoniter.Unmarshal(normalized, &c); err != nil {
+				return nil, err
+			}
+			err = validateGitLabConnection(ctx, e, gitLabValidators, opt.ExternalServiceID, &c, opt.AuthProviders)
+
+		case extsvc.KindBitbucketServer:
+			var c schema.BitbucketServerConnection
+			if err = jsoniter.Unmarshal(normalized, &c); err != nil {
+				return nil, err
+			}
+			err = validateBitbucketServerConnection(ctx, e, bitbucketServerValidators, opt.ExternalServiceID, &c)
+
+		case extsvc.KindBitbucketCloud:
+			var c schema.BitbucketCloudConnection
+			if err = jsoniter.Unmarshal(normalized, &c); err != nil {
+				return nil, err
+			}
+			err = validateBitbucketCloudConnection(ctx, e, opt.ExternalServiceID, &c)
+
+		case extsvc.KindPerforce:
+			var c schema.PerforceConnection
+			if err = jsoniter.Unmarshal(normalized, &c); err != nil {
+				return nil, err
+			}
+			err = validatePerforceConnection(ctx, e, perforceValidators, opt.ExternalServiceID, &c)
+
+		case extsvc.KindOther:
+			var c schema.OtherExternalServiceConnection
+			if err = jsoniter.Unmarshal(normalized, &c); err != nil {
+				return nil, err
+			}
+			err = validateOtherExternalServiceConnection(&c)
+		}
+
+		return normalized, errors.Append(errs, err)
 	}
-
-	res, err := sc.Validate(gojsonschema.NewBytesLoader(normalized))
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to validate config against schema")
-	}
-
-	var errs error
-	for _, err := range res.Errors() {
-		e := err.String()
-		// Remove `(root): ` from error formatting since these errors are
-		// presented to users.
-		e = strings.TrimPrefix(e, "(root): ")
-		errs = errors.Append(errs, errors.New(e))
-	}
-
-	// Extra validation not based on JSON Schema.
-	switch opt.Kind {
-	case extsvc.KindGitHub:
-		var c schema.GitHubConnection
-		if err = jsoniter.Unmarshal(normalized, &c); err != nil {
-			return nil, err
-		}
-		err = e.validateGitHubConnection(ctx, opt.ExternalServiceID, &c)
-
-	case extsvc.KindGitLab:
-		var c schema.GitLabConnection
-		if err = jsoniter.Unmarshal(normalized, &c); err != nil {
-			return nil, err
-		}
-		err = e.validateGitLabConnection(ctx, opt.ExternalServiceID, &c, opt.AuthProviders)
-
-	case extsvc.KindBitbucketServer:
-		var c schema.BitbucketServerConnection
-		if err = jsoniter.Unmarshal(normalized, &c); err != nil {
-			return nil, err
-		}
-		err = e.validateBitbucketServerConnection(ctx, opt.ExternalServiceID, &c)
-
-	case extsvc.KindBitbucketCloud:
-		var c schema.BitbucketCloudConnection
-		if err = jsoniter.Unmarshal(normalized, &c); err != nil {
-			return nil, err
-		}
-		err = e.validateBitbucketCloudConnection(ctx, opt.ExternalServiceID, &c)
-
-	case extsvc.KindPerforce:
-		var c schema.PerforceConnection
-		if err = jsoniter.Unmarshal(normalized, &c); err != nil {
-			return nil, err
-		}
-		err = e.validatePerforceConnection(ctx, opt.ExternalServiceID, &c)
-
-	case extsvc.KindOther:
-		var c schema.OtherExternalServiceConnection
-		if err = jsoniter.Unmarshal(normalized, &c); err != nil {
-			return nil, err
-		}
-		err = validateOtherExternalServiceConnection(&c)
-	}
-
-	return normalized, errors.Append(errs, err)
 }
 
 // Neither our JSON schema library nor the Monaco editor we use supports
@@ -496,9 +471,9 @@ func validateOtherExternalServiceConnection(c *schema.OtherExternalServiceConnec
 	return nil
 }
 
-func (e *externalServiceStore) validateGitHubConnection(ctx context.Context, id int64, c *schema.GitHubConnection) error {
+func validateGitHubConnection(ctx context.Context, e ExternalServiceStore, githubValidators []func(*types.GitHubConnection) error, id int64, c *schema.GitHubConnection) error {
 	var err error
-	for _, validate := range e.gitHubValidators {
+	for _, validate := range githubValidators {
 		err = errors.Append(err,
 			validate(&types.GitHubConnection{
 				URN:              extsvc.URN(extsvc.KindGitHub, id),
@@ -514,25 +489,25 @@ func (e *externalServiceStore) validateGitHubConnection(ctx context.Context, id 
 		err = errors.Append(err, errors.New("at least one of repositoryQuery, repos or orgs must be set"))
 	}
 
-	err = errors.Append(err, e.validateDuplicateRateLimits(ctx, id, extsvc.KindGitHub, c))
+	err = errors.Append(err, validateDuplicateRateLimits(ctx, e, id, extsvc.KindGitHub, c))
 
 	return err
 }
 
-func (e *externalServiceStore) validateGitLabConnection(ctx context.Context, id int64, c *schema.GitLabConnection, ps []schema.AuthProviders) error {
+func validateGitLabConnection(ctx context.Context, e ExternalServiceStore, gitLabValidators []func(*schema.GitLabConnection, []schema.AuthProviders) error, id int64, c *schema.GitLabConnection, ps []schema.AuthProviders) error {
 	var err error
-	for _, validate := range e.gitLabValidators {
+	for _, validate := range gitLabValidators {
 		err = errors.Append(err, validate(c, ps))
 	}
 
-	err = errors.Append(err, e.validateDuplicateRateLimits(ctx, id, extsvc.KindGitLab, c))
+	err = errors.Append(err, validateDuplicateRateLimits(ctx, e, id, extsvc.KindGitLab, c))
 
 	return err
 }
 
-func (e *externalServiceStore) validateBitbucketServerConnection(ctx context.Context, id int64, c *schema.BitbucketServerConnection) error {
+func validateBitbucketServerConnection(ctx context.Context, e ExternalServiceStore, bitbucketServerValidators []func(connection *schema.BitbucketServerConnection) error, id int64, c *schema.BitbucketServerConnection) error {
 	var err error
-	for _, validate := range e.bitbucketServerValidators {
+	for _, validate := range bitbucketServerValidators {
 		err = errors.Append(err, validate(c))
 	}
 
@@ -540,18 +515,18 @@ func (e *externalServiceStore) validateBitbucketServerConnection(ctx context.Con
 		err = errors.Append(err, errors.New("at least one of repositoryQuery or repos must be set"))
 	}
 
-	err = errors.Append(err, e.validateDuplicateRateLimits(ctx, id, extsvc.KindBitbucketServer, c))
+	err = errors.Append(err, validateDuplicateRateLimits(ctx, e, id, extsvc.KindBitbucketServer, c))
 
 	return err
 }
 
-func (e *externalServiceStore) validateBitbucketCloudConnection(ctx context.Context, id int64, c *schema.BitbucketCloudConnection) error {
-	return e.validateDuplicateRateLimits(ctx, id, extsvc.KindBitbucketCloud, c)
+func validateBitbucketCloudConnection(ctx context.Context, e ExternalServiceStore, id int64, c *schema.BitbucketCloudConnection) error {
+	return validateDuplicateRateLimits(ctx, e, id, extsvc.KindBitbucketCloud, c)
 }
 
-func (e *externalServiceStore) validatePerforceConnection(ctx context.Context, id int64, c *schema.PerforceConnection) error {
+func validatePerforceConnection(ctx context.Context, e ExternalServiceStore, perforceValidators []func(*schema.PerforceConnection) error, id int64, c *schema.PerforceConnection) error {
 	var err error
-	for _, validate := range e.perforceValidators {
+	for _, validate := range perforceValidators {
 		err = errors.Append(err, validate(c))
 	}
 
@@ -559,14 +534,14 @@ func (e *externalServiceStore) validatePerforceConnection(ctx context.Context, i
 		err = errors.Append(err, errors.New("depots must be set"))
 	}
 
-	err = errors.Append(err, e.validateDuplicateRateLimits(ctx, id, extsvc.KindPerforce, c))
+	err = errors.Append(err, validateDuplicateRateLimits(ctx, e, id, extsvc.KindPerforce, c))
 
 	return err
 }
 
 // validateDuplicateRateLimits returns an error if given config has duplicated non-default rate limit
 // with another external service for the same code host.
-func (e *externalServiceStore) validateDuplicateRateLimits(ctx context.Context, id int64, kind string, parsedConfig interface{}) error {
+func validateDuplicateRateLimits(ctx context.Context, e ExternalServiceStore, id int64, kind string, parsedConfig interface{}) error {
 	// Check if rate limit is already defined for this code host on another external service
 	rlc, err := extsvc.GetLimitFromConfig(kind, parsedConfig)
 	if err != nil {
@@ -613,8 +588,7 @@ func (e *externalServiceStore) validateDuplicateRateLimits(ctx context.Context, 
 }
 
 // validateSingleKindPerNamespace returns an error if the user/org attempts to add more than one external service of the same kind.
-func (e *externalServiceStore) validateSingleKindPerNamespace(ctx context.Context, id int64, kind string, userID int32, orgID int32) error {
-
+func validateSingleKindPerNamespace(ctx context.Context, e ExternalServiceStore, id int64, kind string, userID int32, orgID int32) error {
 	opt := ExternalServicesListOptions{
 		Kinds: []string{kind},
 		LimitOffset: &LimitOffset{
@@ -671,7 +645,7 @@ func upsertAuthorizationToExternalService(kind, config string) (string, error) {
 }
 
 func (e *externalServiceStore) Create(ctx context.Context, confGet func() *conf.Unified, es *types.ExternalService) error {
-	normalized, err := e.ValidateConfig(ctx, ValidateExternalServiceConfigOptions{
+	normalized, err := ValidateExternalServiceConfig(ctx, e, ValidateExternalServiceConfigOptions{
 		Kind:            es.Kind,
 		Config:          es.Config,
 		AuthProviders:   confGet().AuthProviders,
@@ -994,7 +968,7 @@ func (e *externalServiceStore) Update(ctx context.Context, ps []schema.AuthProvi
 		}
 		update.Config = &newSvc.Config
 
-		normalized, err = e.ValidateConfig(ctx, ValidateExternalServiceConfigOptions{
+		normalized, err = ValidateExternalServiceConfig(ctx, e, ValidateExternalServiceConfigOptions{
 			ExternalServiceID: id,
 			Kind:              externalService.Kind,
 			Config:            *update.Config,

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -1231,10 +1231,6 @@ ORDER BY es.id, essj.finished_at DESC
 }
 
 func (e *externalServiceStore) List(ctx context.Context, opt ExternalServicesListOptions) ([]*types.ExternalService, error) {
-	if Mocks.externalServices.List != nil {
-		return Mocks.externalServices.List(opt)
-	}
-
 	span, _ := ot.StartSpanFromContext(ctx, "ExternalServiceStore.list")
 	defer span.Finish()
 

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -124,8 +124,7 @@ func TestExternalServicesListOptions_sqlConditions(t *testing.T) {
 }
 
 func TestExternalServicesStore_ValidateConfig(t *testing.T) {
-	// Can't currently run in parallel because of global mocks
-	db := dbtest.NewDB(t)
+	t.Parallel()
 
 	tests := []struct {
 		name            string
@@ -133,7 +132,7 @@ func TestExternalServicesStore_ValidateConfig(t *testing.T) {
 		config          string
 		namespaceUserID int32
 		namespaceOrgID  int32
-		setup           func(t *testing.T)
+		listFunc        func(ctx context.Context, opt ExternalServicesListOptions) ([]*types.ExternalService, error)
 		wantErr         string
 	}{
 		{
@@ -170,13 +169,8 @@ func TestExternalServicesStore_ValidateConfig(t *testing.T) {
 			name:   "no conflicting rate limit",
 			kind:   extsvc.KindGitHub,
 			config: `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc", "rateLimit": {"enabled": true, "requestsPerHour": 5000}}`,
-			setup: func(t *testing.T) {
-				t.Cleanup(func() {
-					Mocks.externalServices.List = nil
-				})
-				Mocks.externalServices.List = func(opt ExternalServicesListOptions) ([]*types.ExternalService, error) {
-					return nil, nil
-				}
+			listFunc: func(ctx context.Context, opt ExternalServicesListOptions) ([]*types.ExternalService, error) {
+				return nil, nil
 			},
 			wantErr: "<nil>",
 		},
@@ -184,20 +178,15 @@ func TestExternalServicesStore_ValidateConfig(t *testing.T) {
 			name:   "conflicting rate limit",
 			kind:   extsvc.KindGitHub,
 			config: `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc", "rateLimit": {"enabled": true, "requestsPerHour": 5000}}`,
-			setup: func(t *testing.T) {
-				t.Cleanup(func() {
-					Mocks.externalServices.List = nil
-				})
-				Mocks.externalServices.List = func(opt ExternalServicesListOptions) ([]*types.ExternalService, error) {
-					return []*types.ExternalService{
-						{
-							ID:          1,
-							Kind:        extsvc.KindGitHub,
-							DisplayName: "GITHUB 1",
-							Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc", "rateLimit": {"enabled": true, "requestsPerHour": 5000}}`,
-						},
-					}, nil
-				}
+			listFunc: func(ctx context.Context, opt ExternalServicesListOptions) ([]*types.ExternalService, error) {
+				return []*types.ExternalService{
+					{
+						ID:          1,
+						Kind:        extsvc.KindGitHub,
+						DisplayName: "GITHUB 1",
+						Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc", "rateLimit": {"enabled": true, "requestsPerHour": 5000}}`,
+					},
+				}, nil
 			},
 			wantErr: "existing external service, \"GITHUB 1\", already has a rate limit set",
 		},
@@ -248,20 +237,15 @@ func TestExternalServicesStore_ValidateConfig(t *testing.T) {
 			kind:            extsvc.KindGitHub,
 			config:          `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
 			namespaceUserID: 1,
-			setup: func(t *testing.T) {
-				t.Cleanup(func() {
-					Mocks.externalServices.List = nil
-				})
-				Mocks.externalServices.List = func(opt ExternalServicesListOptions) ([]*types.ExternalService, error) {
-					return []*types.ExternalService{
-						{
-							ID:          1,
-							Kind:        extsvc.KindGitHub,
-							DisplayName: "GITHUB 1",
-							Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
-						},
-					}, nil
-				}
+			listFunc: func(ctx context.Context, opt ExternalServicesListOptions) ([]*types.ExternalService, error) {
+				return []*types.ExternalService{
+					{
+						ID:          1,
+						Kind:        extsvc.KindGitHub,
+						DisplayName: "GITHUB 1",
+						Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
+					},
+				}, nil
 			},
 			wantErr: `existing external service, "GITHUB 1", of same kind already added`,
 		},
@@ -270,20 +254,15 @@ func TestExternalServicesStore_ValidateConfig(t *testing.T) {
 			kind:           extsvc.KindGitHub,
 			config:         `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
 			namespaceOrgID: 1,
-			setup: func(t *testing.T) {
-				t.Cleanup(func() {
-					Mocks.externalServices.List = nil
-				})
-				Mocks.externalServices.List = func(opt ExternalServicesListOptions) ([]*types.ExternalService, error) {
-					return []*types.ExternalService{
-						{
-							ID:          1,
-							Kind:        extsvc.KindGitHub,
-							DisplayName: "GITHUB 1",
-							Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
-						},
-					}, nil
-				}
+			listFunc: func(ctx context.Context, opt ExternalServicesListOptions) ([]*types.ExternalService, error) {
+				return []*types.ExternalService{
+					{
+						ID:          1,
+						Kind:        extsvc.KindGitHub,
+						DisplayName: "GITHUB 1",
+						Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
+					},
+				}, nil
 			},
 			wantErr: `existing external service, "GITHUB 1", of same kind already added`,
 		},
@@ -302,11 +281,10 @@ func TestExternalServicesStore_ValidateConfig(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if test.setup != nil {
-				test.setup(t)
+			ess := NewMockExternalServiceStore()
+			if test.listFunc != nil {
+				ess.ListFunc.SetDefaultHook(test.listFunc)
 			}
-
-			ess := ExternalServices(db)
 			_, err := ValidateExternalServiceConfig(context.Background(), ess, ValidateExternalServiceConfigOptions{
 				Kind:            test.kind,
 				Config:          test.config,

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -306,7 +306,8 @@ func TestExternalServicesStore_ValidateConfig(t *testing.T) {
 				test.setup(t)
 			}
 
-			_, err := ExternalServices(db).ValidateConfig(context.Background(), ValidateExternalServiceConfigOptions{
+			ess := ExternalServices(db)
+			_, err := ValidateExternalServiceConfig(context.Background(), ess, ValidateExternalServiceConfigOptions{
 				Kind:            test.kind,
 				Config:          test.config,
 				NamespaceUserID: test.namespaceUserID,

--- a/internal/database/mocks.go
+++ b/internal/database/mocks.go
@@ -10706,9 +10706,6 @@ type MockExternalServiceStore struct {
 	// UpsertFunc is an instance of a mock function object controlling the
 	// behavior of the method Upsert.
 	UpsertFunc *ExternalServiceStoreUpsertFunc
-	// ValidateConfigFunc is an instance of a mock function object
-	// controlling the behavior of the method ValidateConfig.
-	ValidateConfigFunc *ExternalServiceStoreValidateConfigFunc
 	// WithFunc is an instance of a mock function object controlling the
 	// behavior of the method With.
 	WithFunc *ExternalServiceStoreWithFunc
@@ -10800,11 +10797,6 @@ func NewMockExternalServiceStore() *MockExternalServiceStore {
 		UpsertFunc: &ExternalServiceStoreUpsertFunc{
 			defaultHook: func(context.Context, ...*types.ExternalService) error {
 				return nil
-			},
-		},
-		ValidateConfigFunc: &ExternalServiceStoreValidateConfigFunc{
-			defaultHook: func(context.Context, ValidateExternalServiceConfigOptions) ([]byte, error) {
-				return nil, nil
 			},
 		},
 		WithFunc: &ExternalServiceStoreWithFunc{
@@ -10905,11 +10897,6 @@ func NewStrictMockExternalServiceStore() *MockExternalServiceStore {
 				panic("unexpected invocation of MockExternalServiceStore.Upsert")
 			},
 		},
-		ValidateConfigFunc: &ExternalServiceStoreValidateConfigFunc{
-			defaultHook: func(context.Context, ValidateExternalServiceConfigOptions) ([]byte, error) {
-				panic("unexpected invocation of MockExternalServiceStore.ValidateConfig")
-			},
-		},
 		WithFunc: &ExternalServiceStoreWithFunc{
 			defaultHook: func(basestore.ShareableStore) ExternalServiceStore {
 				panic("unexpected invocation of MockExternalServiceStore.With")
@@ -10975,9 +10962,6 @@ func NewMockExternalServiceStoreFrom(i ExternalServiceStore) *MockExternalServic
 		},
 		UpsertFunc: &ExternalServiceStoreUpsertFunc{
 			defaultHook: i.Upsert,
-		},
-		ValidateConfigFunc: &ExternalServiceStoreValidateConfigFunc{
-			defaultHook: i.ValidateConfig,
 		},
 		WithFunc: &ExternalServiceStoreWithFunc{
 			defaultHook: i.With,
@@ -12713,117 +12697,6 @@ func (c ExternalServiceStoreUpsertFuncCall) Args() []interface{} {
 // invocation.
 func (c ExternalServiceStoreUpsertFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
-}
-
-// ExternalServiceStoreValidateConfigFunc describes the behavior when the
-// ValidateConfig method of the parent MockExternalServiceStore instance is
-// invoked.
-type ExternalServiceStoreValidateConfigFunc struct {
-	defaultHook func(context.Context, ValidateExternalServiceConfigOptions) ([]byte, error)
-	hooks       []func(context.Context, ValidateExternalServiceConfigOptions) ([]byte, error)
-	history     []ExternalServiceStoreValidateConfigFuncCall
-	mutex       sync.Mutex
-}
-
-// ValidateConfig delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockExternalServiceStore) ValidateConfig(v0 context.Context, v1 ValidateExternalServiceConfigOptions) ([]byte, error) {
-	r0, r1 := m.ValidateConfigFunc.nextHook()(v0, v1)
-	m.ValidateConfigFunc.appendCall(ExternalServiceStoreValidateConfigFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the ValidateConfig
-// method of the parent MockExternalServiceStore instance is invoked and the
-// hook queue is empty.
-func (f *ExternalServiceStoreValidateConfigFunc) SetDefaultHook(hook func(context.Context, ValidateExternalServiceConfigOptions) ([]byte, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// ValidateConfig method of the parent MockExternalServiceStore instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *ExternalServiceStoreValidateConfigFunc) PushHook(hook func(context.Context, ValidateExternalServiceConfigOptions) ([]byte, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *ExternalServiceStoreValidateConfigFunc) SetDefaultReturn(r0 []byte, r1 error) {
-	f.SetDefaultHook(func(context.Context, ValidateExternalServiceConfigOptions) ([]byte, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *ExternalServiceStoreValidateConfigFunc) PushReturn(r0 []byte, r1 error) {
-	f.PushHook(func(context.Context, ValidateExternalServiceConfigOptions) ([]byte, error) {
-		return r0, r1
-	})
-}
-
-func (f *ExternalServiceStoreValidateConfigFunc) nextHook() func(context.Context, ValidateExternalServiceConfigOptions) ([]byte, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *ExternalServiceStoreValidateConfigFunc) appendCall(r0 ExternalServiceStoreValidateConfigFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of ExternalServiceStoreValidateConfigFuncCall
-// objects describing the invocations of this function.
-func (f *ExternalServiceStoreValidateConfigFunc) History() []ExternalServiceStoreValidateConfigFuncCall {
-	f.mutex.Lock()
-	history := make([]ExternalServiceStoreValidateConfigFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// ExternalServiceStoreValidateConfigFuncCall is an object that describes an
-// invocation of method ValidateConfig on an instance of
-// MockExternalServiceStore.
-type ExternalServiceStoreValidateConfigFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 ValidateExternalServiceConfigOptions
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []byte
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c ExternalServiceStoreValidateConfigFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c ExternalServiceStoreValidateConfigFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
 }
 
 // ExternalServiceStoreWithFunc describes the behavior when the With method

--- a/internal/database/mockstores.go
+++ b/internal/database/mockstores.go
@@ -9,6 +9,5 @@ var Mocks MockStores
 //   internal/database/mocks.go. If you came here looking for a store that isn't listed,
 //   consider passing in the generated db or stores from there.
 type MockStores struct {
-	AccessTokens     MockAccessTokens
-	externalServices MockExternalServices
+	AccessTokens MockAccessTokens
 }


### PR DESCRIPTION
The ValidateConfig method was extracted from the ExternalServiceStore
and renamed to ValidateExternalServiceConfig.

Instead, it is now a function that takes the store as a parameter. This
allows us to mock the store functions using our new mocking system and
allows us to remove the global database.Mocks.externalServices.

Because we have custom validators when running in enterprise mode
the validation function is exposed as a variable so that we can swap
in different implementations. This is similar to we had before where
the store constructor was exposed as a variable.

Once all of the above refactoring was done, the external service mock 
could be removed.

Best viewed with whitespace ignored.

# Test plan

All tests still pass after the refactor.

Closes https://github.com/sourcegraph/sourcegraph/issues/32380