### PR TITLE
Explicitly set path to elm binary

### DIFF
--- a/client/storybook/src/main.ts
+++ b/client/storybook/src/main.ts
@@ -189,6 +189,7 @@ const config = {
                 options: {
                     cwd: path.resolve(ROOT_PATH, 'client/web/src/notebooks/blocks/compute/component'),
                     report: 'json',
+                    pathToElm: path.resolve(ROOT_PATH, 'node_modules/.bin/elm'),
                 },
             },
         })

--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -239,6 +239,7 @@ const config = {
           options: {
             cwd: path.resolve(ROOT_PATH, 'client/web/src/notebooks/blocks/compute/component'),
             report: 'json',
+            pathToElm: path.resolve(ROOT_PATH, 'node_modules/.bin/elm'),
           },
         },
       },


### PR DESCRIPTION
In local dev it would fail for me with Error: spawn elm ENOENT, probably it's not properly including node_modules/.bin in the PATH somewhere. This fixes it.



## Test plan

Tested that `sg start` runs through successfully now.