### PR TITLE
user invites: Log sign up views with invitedBy param even if the user is logged in or sign up is disabled

### DIFF
--- a/client/web/src/auth/CloudSignUpPage.tsx
+++ b/client/web/src/auth/CloudSignUpPage.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import ChevronLeftIcon from 'mdi-react/ChevronLeftIcon'
-import React, { useEffect } from 'react'
+import React from 'react'
 import { useLocation } from 'react-router-dom'
 
 import { useQuery } from '@sourcegraph/http-client'
@@ -73,12 +73,6 @@ export const CloudSignUpPage: React.FunctionComponent<Props> = ({
         skip: !invitedBy,
     })
     const invitedByUser = data?.user
-
-    useEffect(() => {
-        if (invitedBy !== null) {
-            telemetryService.log('SignUpInvitedByUser')
-        }
-    }, [telemetryService, invitedBy])
 
     const logEvent = (type: AuthProvider['serviceType']): void => {
         const eventType = type === 'builtin' ? 'form' : type

--- a/client/web/src/auth/SignUpPage.tsx
+++ b/client/web/src/auth/SignUpPage.tsx
@@ -37,10 +37,19 @@ export const SignUpPage: React.FunctionComponent<SignUpPageProps> = ({
 }) => {
     const location = useLocation()
     const query = new URLSearchParams(location.search)
+    const invitedBy = query.get('invitedBy')
 
     useEffect(() => {
         eventLogger.logViewEvent('SignUp', null, false)
-    }, [])
+
+        if (invitedBy !== null) {
+            const parameters = {
+                isAuthenticated: !!authenticatedUser,
+                allowSignup: context.allowSignup,
+            }
+            eventLogger.log('SignUpInvitedByUser', parameters, parameters)
+        }
+    }, [invitedBy, authenticatedUser, context.allowSignup])
 
     if (authenticatedUser) {
         const returnTo = getReturnTo(location)


### PR DESCRIPTION
Part of #31214

[After a discussion with @slimsag](https://sourcegraph.slack.com/archives/C01LZKLRF0C/p1646736316535459) I’m making a change to when we log incoming page views with the invitedBy link set. These events are used to know when invited users click on the invitation link. 

Right now, these events are only logged when users have no account yet and render the sign up form. However, especially if we want to include server users, we'll need to be more liberal in what we accept since e.g. in some on-prem setups, SSO is configured so that users will always be logged in once they visit this link.

To do this, we move the logging to before we do any potential redirects and I've also added two params to the event that we can later use to distinguish between the new scenarios and the existing case:

- `isAuthenticated`: When this is true, the user is authenticated and will be redirected to the product instead. 
- `allowSignup`: When this is false, sign-up is disabled and the user will be redirected to the login screen instead.

## Test plan

I verified that there's no regression in the case of cloud sign-up when logged out and verified that this works with redirects for cloud when signed in:

### Signed out

![Screenshot 2022-03-10 at 14 29 37](https://user-images.githubusercontent.com/458591/157673682-9336a295-dbcb-4e1d-95ec-00ffcfe2252c.png)

### Signed in

![Screenshot 2022-03-10 at 14 30 16](https://user-images.githubusercontent.com/458591/157673672-a5c4c0fd-9b16-4a9f-b0e7-ef4938dad684.png)

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


