### PR TITLE
ci: report pipeline step hooks on nested ones

### DIFF
--- a/enterprise/dev/ci/internal/ci/operations/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations/operations.go
@@ -88,6 +88,8 @@ func (o *Set) Apply(pipeline *bk.Pipeline) {
 					Key:   item.set.Key(),
 					Group: item.set.name,
 				},
+				BeforeEveryStepOpts: pipeline.BeforeEveryStepOpts,
+				AfterEveryStepOpts:  pipeline.AfterEveryStepOpts,
 			}
 			item.set.Apply(group)
 			pipeline.Steps = append(pipeline.Steps, group)


### PR DESCRIPTION
@bobheadxi with the introduction of groups, it has been forgotten to copy the hooks over the nested `bk.Pipeline` we're creating, which caused the stateless pipeline to fail since then. 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

- checked pipeline generation output 
- test run on the stateless agents pipeline TODO
