### PR TITLE
[SG-32439] Drop `ListGroupItem` and `ListGroupItem` `reactstrap` imports

### DIFF
--- a/client/web/src/site-admin/SiteAdminSidebar.tsx
+++ b/client/web/src/site-admin/SiteAdminSidebar.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import classNames from 'classnames'
-import { ListGroup, ListGroupItem } from 'reactstrap'
 
 import { Link } from '@sourcegraph/wildcard'
 
@@ -29,12 +28,12 @@ export interface SiteAdminSidebarProps extends BatchChangesProps {
  */
 export const SiteAdminSidebar: React.FunctionComponent<SiteAdminSidebarProps> = ({ className, groups, ...props }) => (
     <SidebarGroup className={classNames('site-admin-sidebar', className)}>
-        <ListGroup>
+        <ul className="list-group">
             {groups.map(
                 ({ header, items, condition = () => true }, index) =>
                     condition(props) &&
                     (items.length > 1 ? (
-                        <ListGroupItem className="p-0" key={index}>
+                        <li className="p-0 list-group-item" key={index}>
                             <SidebarCollapseItems icon={header?.icon} label={header?.label} openByDefault={true}>
                                 {items.map(
                                     ({ label, to, source = 'client', condition = () => true }) =>
@@ -45,18 +44,18 @@ export const SiteAdminSidebar: React.FunctionComponent<SiteAdminSidebarProps> = 
                                         )
                                 )}
                             </SidebarCollapseItems>
-                        </ListGroupItem>
+                        </li>
                     ) : (
-                        <ListGroupItem className="p-0" key={items[0].label}>
+                        <li className="p-0 list-group-item" key={items[0].label}>
                             <Link to={items[0].to} className="bg-2 border-0 d-flex list-group-item-action p-2 w-100">
                                 <span>
                                     {header?.icon && <header.icon className="sidebar__icon icon-inline mr-1" />}{' '}
                                     {items[0].label}
                                 </span>
                             </Link>
-                        </ListGroupItem>
+                        </li>
                     ))
             )}
-        </ListGroup>
+        </ul>
     </SidebarGroup>
 )


### PR DESCRIPTION
## Success criteria
1. `ListGroup` and `ListGroupItem` imports are removed from the codebase.
2. Instead of these components a combination of HTML and CSS module classes is used.

## Implementation details
Rely on the internal implementation of [ListGroup](https://github.com/reactstrap/reactstrap/blob/ae4b5c5f5dddb6f928e51b89cf2a055cf078c481/src/ListGroup.js) and [ListGroupItem](https://github.com/reactstrap/reactstrap/blob/ae4b5c5f5dddb6f928e51b89cf2a055cf078c481/src/ListGroupItem.js) available here. The component that needs to be updated: [SiteAdminSidebar.tsx](https://github.com/sourcegraph/sourcegraph/blob/main/client/web/src/site-admin/SiteAdminSidebar.tsx).

## Test plan
1. `ListGroup` and `ListGroupItem` `reactstrap` imports should be dropped and replaced by `HTML` and `CSS` implementation.
2. `CI` should pass as expected and no UI diff from the client end

## Refs
[Gitstart ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-32439)
[Sourcegraph issue](https://github.com/sourcegraph/sourcegraph/issues/32439)

## Preview App
[Storybook](https://client-sourcegraph-storybook-pr-276.onrender.com/)
[Frontend](https://client-sourcegraph-frontend-pr-276.onrender.com/)