### PR TITLE
Revert "Revert "insights: remove some beta labels in prep""

### DIFF
--- a/doc/code_insights/explanations/automatically_generated_data_series.md
+++ b/doc/code_insights/explanations/automatically_generated_data_series.md
@@ -26,7 +26,7 @@ For the above example, this means that if `<java.version>1.9</java.version>` was
 
 ## Current limitations 
 
-Code Insights is in Beta and this feature has some yet-released limitations. In rough order, with limitations listed first likely to be removed soonest, they are: 
+This feature has some yet-released limitations. In rough order, with limitations listed first likely to be removed soonest, they are: 
 
 ### Limited to 20 matches
 

--- a/doc/code_insights/explanations/current_limitations_of_code_insights.md
+++ b/doc/code_insights/explanations/current_limitations_of_code_insights.md
@@ -1,6 +1,6 @@
-# Current limitations of Code Insights (Beta limitations)
+# Current limitations of Code Insights
 
-Because code insights is currently a private [beta feature](../../admin/beta_and_experimental_features.md#beta-features), there are some limitations that we have not finished building solutions for yet. 
+There are a few existing limitations.  
 
 If you have strong feedback, please do [let us know](mailto:feedback@sourcegraph.com). 
 
@@ -48,7 +48,7 @@ Because these insights need to run dramatically fewer queries than insights over
 * **[Released] Dynamic x-axis ranges**: available in 3.35+ ~~set a custom amount of historical data you care about~~
 * **[Released] Editing data series queries after creation**: available in 3.35+ ~~for insights over all repositories, you must make a new insight if you wish to run a different query~~
 * **Live previews**: showing the preview of your insight in real time
-* **"Diff click"**: click a datapoint on your insight and be taken to a diff search showing any changes contributing to the difference between a datapoint and the prior one
+* **[Released] "Diff click"**: available in 3.36+ ~~click a datapoint on your insight and be taken to a diff search showing any changes contributing to the difference between a datapoint and the prior one~~
 
 > NOTE: many of the above-listed features will become available for insights over all repositories as well. The above list is ordererd top-down, where items on the top of the list will arrive roughly sooner than items on the bottom. 
 

--- a/doc/code_insights/index.md
+++ b/doc/code_insights/index.md
@@ -1,4 +1,4 @@
-# Code Insights <a href="../admin/beta_and_experimental_features"><sup><span class="badge badge-beta">Beta</span></sup></a>
+# Code Insights
 
 <style>
 
@@ -42,16 +42,6 @@ body.theme-dark .markdown-body ul li:before {
 
 Code Insights is based on our universal code search, making it precise and configurable. Track anything that can be expressed with a Sourcegraph search query: migrations, package use, version adoption, code smells, codebase size and much more, across 1,000s of repositories.
 
-### Code Insights is in Beta
-
-Code Insights are currently in [Beta](../admin/beta_and_experimental_features.md). If you want early access or support, please [send us an email](mailto:feedback@sourcegraph.com).
-
-> NOTE: While in Beta, Code Insights is free for enterprise customers. Once Code Insights is generally available and no sooner than January 1, 2022, to continue using Code Insights may require a separate paid plan.
-
-We're still polishing Code Insights and you might find bugs while we’re in beta. Please [share any bugs 🐛 or feedback](mailto:feedback@sourcegraph.com) you have to help us make Code Insights better.
-
-Code insights docs are actively in progress during the beta.
-
 <div class="cta-group">
 <a class="btn btn-primary" href="quickstart">★ Quickstart</a>
 <a class="btn" href="language_insight_quickstart">Language Insight Quickstart</a>
@@ -62,7 +52,7 @@ Code insights docs are actively in progress during the beta.
 - [Administration and security of Code Insights](explanations/administration_and_security_of_code_insights.md)
 - [Automatically generated data series for version or pattern tracking](explanations/automatically_generated_data_series.md)
 - [Code Insights filters](explanations/code_insights_filters.md)
-- [Current limitations of Code Insights (Beta limitations)](explanations/current_limitations_of_code_insights.md)
+- [Current limitations of Code Insights](explanations/current_limitations_of_code_insights.md)
 - [Viewing code insights](explanations/viewing_code_insights.md)
 
 ## [How-tos](how-tos/index.md)

--- a/doc/code_insights/language_insight_quickstart.md
+++ b/doc/code_insights/language_insight_quickstart.md
@@ -28,7 +28,7 @@ Enter repositories in the repository URL format, like `github.com/Sourcegraph/So
 
 The form field will validate that you've entered the repository correctly. 
 
-In the current Beta version, you can only set up a language insight for one repository at a time. (Want us to prioritize the ability to analyze multiple repositories in one pie chart? [Please do let us know](mailto:feedback@sourcegraph.com).)
+In the current version, you can only set up a language insight for one repository at a time. (Want us to prioritize the ability to analyze multiple repositories in one pie chart? [Please do let us know](mailto:feedback@sourcegraph.com).)
 
 ### 4. Title your insight 
 


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#31507

Test plan: 
This is just a re-reversion of something already in the release docs. 