### PR TITLE
Correct UTM issues on code insights getting-started page

### DIFF
--- a/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/CodeInsightsDotComGetStarted.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/CodeInsightsDotComGetStarted.tsx
@@ -93,7 +93,7 @@ export const CodeInsightsDotComGetStarted: React.FunctionComponent<CodeInsightsD
                                 <Button
                                     variant="primary"
                                     as={Link}
-                                    to="https://about.sourcegraph.com/contact/request-code-insights-demo?utm_medium=getting-started&utm_source=in-product&utm_campaign=getting-started"
+                                    to="https://about.sourcegraph.com/contact/request-code-insights-demo?utm_medium=direct-traffic&utm_source=in-product&utm_campaign=getting-started"
                                     target="_blank"
                                     rel="noopener"
                                     onClick={handleScheduleDemoClick}
@@ -159,7 +159,7 @@ export const CodeInsightsDotComGetStarted: React.FunctionComponent<CodeInsightsD
                                 <Button
                                     as={Link}
                                     variant="primary"
-                                    to="/help/admin/install?utm_medium=getting-started&utm_source=in-product&utm_campaign=inproduct-cta"
+                                    to="/help/admin/install?utm_medium=direct-traffic&utm_source=in-product&utm_campaign=getting-started"
                                     onClick={handleInstallLocalInstanceClick}
                                 >
                                     Install local instance

--- a/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/CodeInsightsDotComGetStarted.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/CodeInsightsDotComGetStarted.tsx
@@ -93,7 +93,7 @@ export const CodeInsightsDotComGetStarted: React.FunctionComponent<CodeInsightsD
                                 <Button
                                     variant="primary"
                                     as={Link}
-                                    to="https://about.sourcegraph.com/contact/request-code-insights-demo"
+                                    to="https://about.sourcegraph.com/contact/request-code-insights-demo?utm_medium=getting-started&utm_source=in-product&utm_campaign=getting-started"
                                     target="_blank"
                                     rel="noopener"
                                     onClick={handleScheduleDemoClick}
@@ -159,7 +159,7 @@ export const CodeInsightsDotComGetStarted: React.FunctionComponent<CodeInsightsD
                                 <Button
                                     as={Link}
                                     variant="primary"
-                                    to="/help/admin/install?utm_medium=inproduct&utm_source=inproduct-code-insights&term="
+                                    to="/help/admin/install?utm_medium=getting-started&utm_source=in-product&utm_campaign=inproduct-cta"
                                     onClick={handleInstallLocalInstanceClick}
                                 >
                                     Install local instance

--- a/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/CodeInsightsDotComGetStarted.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/CodeInsightsDotComGetStarted.tsx
@@ -93,7 +93,7 @@ export const CodeInsightsDotComGetStarted: React.FunctionComponent<CodeInsightsD
                                 <Button
                                     variant="primary"
                                     as={Link}
-                                    to="https://about.sourcegraph.com/contact/request-code-insights-demo?utm_medium=direct-traffic&utm_source=in-product&utm_campaign=getting-started"
+                                    to="https://about.sourcegraph.com/contact/request-code-insights-demo?utm_medium=direct-traffic&utm_source=in-product&utm_campaign=code-insights-getting-started"
                                     target="_blank"
                                     rel="noopener"
                                     onClick={handleScheduleDemoClick}
@@ -159,7 +159,7 @@ export const CodeInsightsDotComGetStarted: React.FunctionComponent<CodeInsightsD
                                 <Button
                                     as={Link}
                                     variant="primary"
-                                    to="/help/admin/install?utm_medium=direct-traffic&utm_source=in-product&utm_campaign=getting-started"
+                                    to="/help/admin/install?utm_medium=direct-traffic&utm_source=in-product&utm_campaign=code-insights-getting-started"
                                     onClick={handleInstallLocalInstanceClick}
                                 >
                                     Install local instance


### PR DESCRIPTION
This pull request adds utm parameters to two links on the getting started page to aid in tracking conversions. 

## Test plan

Verify the links work as expected. 


