### PR TITLE
compute: un-hardcode sourcegraphURL endpoint in notebook block

### DIFF
--- a/client/shared/src/testing/searchTestHelpers.ts
+++ b/client/shared/src/testing/searchTestHelpers.ts
@@ -325,10 +325,11 @@ export const extensionsController: Controller = {
 
 export const NOOP_PLATFORM_CONTEXT: Pick<
     PlatformContext,
-    'requestGraphQL' | 'urlToFile' | 'settings' | 'forceUpdateTooltip'
+    'sourcegraphURL' | 'requestGraphQL' | 'urlToFile' | 'settings' | 'forceUpdateTooltip'
 > = {
     requestGraphQL: () => EMPTY,
     urlToFile: () => '',
     settings: of(NOOP_SETTINGS_CASCADE),
     forceUpdateTooltip: () => {},
+    sourcegraphURL: '',
 }

--- a/client/web/src/notebooks/blocks/compute/NotebookComputeBlock.story.tsx
+++ b/client/web/src/notebooks/blocks/compute/NotebookComputeBlock.story.tsx
@@ -2,6 +2,8 @@ import { storiesOf } from '@storybook/react'
 import { noop } from 'lodash'
 import React from 'react'
 
+import { NOOP_PLATFORM_CONTEXT } from '@sourcegraph/shared/src/testing/searchTestHelpers'
+
 import { WebStory } from '../../../components/WebStory'
 
 import { NotebookComputeBlock } from './NotebookComputeBlock'
@@ -34,6 +36,7 @@ add('default', () => (
                 isReadOnly={false}
                 isOtherBlockSelected={false}
                 isMacPlatform={true}
+                platformContext={NOOP_PLATFORM_CONTEXT}
             />
         )}
     </WebStory>

--- a/client/web/src/notebooks/blocks/compute/NotebookComputeBlock.tsx
+++ b/client/web/src/notebooks/blocks/compute/NotebookComputeBlock.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames'
 import React, { useRef } from 'react'
 import ElmComponent from 'react-elm-components'
 
+import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
 import { BlockProps, ComputeBlock } from '../..'
@@ -16,6 +17,7 @@ import styles from './NotebookComputeBlock.module.scss'
 
 interface ComputeBlockProps extends BlockProps, ComputeBlock, ThemeProps {
     isMacPlatform: boolean
+    platformContext: Pick<PlatformContext, 'sourcegraphURL'>
 }
 
 interface ElmEvent {
@@ -80,6 +82,7 @@ export const NotebookComputeBlock: React.FunctionComponent<ComputeBlockProps> = 
     isSelected,
     isLightTheme,
     isMacPlatform,
+    platformContext,
     isReadOnly,
     onRunBlock,
     onSelectBlock,
@@ -137,7 +140,7 @@ export const NotebookComputeBlock: React.FunctionComponent<ComputeBlockProps> = 
             >
                 <div className="elm">
                     {/* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */}
-                    <ElmComponent src={Elm.Main} ports={setupPorts} flags={null} />
+                    <ElmComponent src={Elm.Main} ports={setupPorts} flags={platformContext.sourcegraphURL} />
                 </div>
             </div>
             {blockMenu}

--- a/client/web/src/notebooks/notebook/NotebookComponent.tsx
+++ b/client/web/src/notebooks/notebook/NotebookComponent.tsx
@@ -58,7 +58,10 @@ export interface NotebookComponentProps
     blocks: BlockInit[]
     authenticatedUser: AuthenticatedUser | null
     extensionsController: Pick<ExtensionsController, 'extHostAPI' | 'executeCommand'>
-    platformContext: Pick<PlatformContext, 'requestGraphQL' | 'urlToFile' | 'settings' | 'forceUpdateTooltip'>
+    platformContext: Pick<
+        PlatformContext,
+        'sourcegraphURL' | 'requestGraphQL' | 'urlToFile' | 'settings' | 'forceUpdateTooltip'
+    >
     exportedFileName: string
     isEmbedded?: boolean
     onSerializeBlocks: (blocks: Block[]) => void

--- a/client/web/src/notebooks/notebookPage/NotebookContent.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookContent.tsx
@@ -21,7 +21,7 @@ export interface NotebookContentProps
         ThemeProps,
         TelemetryProps,
         Omit<StreamingSearchResultsListProps, 'allExpanded' | 'extensionsController' | 'platformContext'>,
-        PlatformContextProps<'requestGraphQL' | 'urlToFile' | 'settings' | 'forceUpdateTooltip'>,
+        PlatformContextProps<'sourcegraphURL' | 'requestGraphQL' | 'urlToFile' | 'settings' | 'forceUpdateTooltip'>,
         ExtensionsControllerProps<'extHostAPI' | 'executeCommand'> {
     globbing: boolean
     isMacPlatform: boolean

--- a/client/web/src/notebooks/notebookPage/NotebookPage.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookPage.tsx
@@ -50,7 +50,7 @@ interface NotebookPageProps
         ThemeProps,
         TelemetryProps,
         Omit<StreamingSearchResultsListProps, 'allExpanded' | 'extensionsController' | 'platformContext'>,
-        PlatformContextProps<'requestGraphQL' | 'urlToFile' | 'settings' | 'forceUpdateTooltip'>,
+        PlatformContextProps<'sourcegraphURL' | 'requestGraphQL' | 'urlToFile' | 'settings' | 'forceUpdateTooltip'>,
         ExtensionsControllerProps<'extHostAPI' | 'executeCommand'> {
     authenticatedUser: AuthenticatedUser | null
     globbing: boolean


### PR DESCRIPTION
This will let the compute notebook block talk to the instance's endpoint (`sourcegraph.test`, `sourcegraph.com`, `customer.instance.sourcegraph.com`, etc)

## Test plan
Manually tested, since this just propagates existing state (`sourcegraphURL`) and doesn't add logic. End-to-end test would cover this once there's stable functionality to test.


