### PR TITLE
Backend: add AnonymousUID to Actor struct

### DIFF
--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -57,6 +57,7 @@ func newExternalHTTPHandler(
 		apiHandler = hooks.PostAuthMiddleware(apiHandler)
 	}
 	apiHandler = featureflag.Middleware(database.FeatureFlags(db), apiHandler)
+	apiHandler = actor.AnonymousUIDMiddleware(apiHandler)
 	apiHandler = authMiddlewares.API(apiHandler) // 🚨 SECURITY: auth middleware
 	// 🚨 SECURITY: The HTTP API should not accept cookies as authentication, except from trusted
 	// origins, to avoid CSRF attacks. See session.CookieMiddlewareWithCSRFSafety for details.
@@ -79,6 +80,7 @@ func newExternalHTTPHandler(
 		appHandler = hooks.PostAuthMiddleware(appHandler)
 	}
 	appHandler = featureflag.Middleware(database.FeatureFlags(db), appHandler)
+	appHandler = actor.AnonymousUIDMiddleware(appHandler)
 	appHandler = authMiddlewares.App(appHandler)                           // 🚨 SECURITY: auth middleware
 	appHandler = session.CookieMiddleware(db, appHandler)                  // app accepts cookies
 	appHandler = internalhttpapi.AccessTokenAuthMiddleware(db, appHandler) // app accepts access tokens

--- a/cmd/frontend/internal/session/session.go
+++ b/cmd/frontend/internal/session/session.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
-	"github.com/sourcegraph/sourcegraph/internal/cookie"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
@@ -407,12 +406,6 @@ func authenticateByCookie(db database.DB, r *http.Request, w http.ResponseWriter
 
 		info.Actor.FromSessionCookie = true
 		return actor.WithActor(r.Context(), info.Actor)
-	}
-
-	// If the user cannot be authenticated by cookie, attempt to identify the
-	// actor by anonymous UID if it exists.
-	if anonymousUID, ok := cookie.AnonymousUID(r); ok {
-		return actor.WithActor(r.Contex(), actor.FromAnonymousUser(anonymousUID))
 	}
 
 	return r.Context()

--- a/internal/actor/actor.go
+++ b/internal/actor/actor.go
@@ -53,7 +53,7 @@ type Actor struct {
 // FromUser returns an actor corresponding to the user with the given ID
 func FromUser(uid int32) *Actor { return &Actor{UID: uid} }
 
-// FromAnonymousUser returns an actor corresponding to an anonymous user with the given anonymous ID
+// FromAnonymousUser returns an actor corresponding to an unauthenticated user with the given anonymous ID
 func FromAnonymousUser(anonymousUID string) *Actor { return &Actor{AnonymousUID: anonymousUID} }
 
 // FromMockUser returns an actor corresponding to a test user. Do not use outside of tests.

--- a/internal/actor/actor.go
+++ b/internal/actor/actor.go
@@ -21,9 +21,16 @@ import (
 // that actor propagation is enabled on both ends of the request.
 //
 // To learn more about actor propagation, see: https://sourcegraph.com/notebooks/Tm90ZWJvb2s6OTI=
+//
+// At most one of UID, AnonymousUID, or Internal must be set.
 type Actor struct {
-	// UID is the unique ID of the authenticated user, or 0 for anonymous actors.
+	// UID is the unique ID of the authenticated user.
+	// Only set if the current actor is an authenticated user.
 	UID int32 `json:",omitempty"`
+
+	// AnonymousUID is the user's semi-stable anonymousID from the request cookie.
+	// Only set if the user is unauthenticated and the request contains an anonymousID.
+	AnonymousUID string `json:",omitempty"`
 
 	// Internal is true if the actor represents an internal Sourcegraph service (and is therefore
 	// not tied to a specific user).
@@ -43,8 +50,11 @@ type Actor struct {
 	mockUser bool
 }
 
-// FromUser returns an actor corresponding to a user
+// FromUser returns an actor corresponding to the user with the given ID
 func FromUser(uid int32) *Actor { return &Actor{UID: uid} }
+
+// FromAnonymousUser returns an actor corresponding to an anonymous user with the given anonymous ID
+func FromAnonymousUser(anonymousUID string) *Actor { return &Actor{AnonymousUID: anonymousUID} }
 
 // FromMockUser returns an actor corresponding to a test user. Do not use outside of tests.
 func FromMockUser(uid int32) *Actor { return &Actor{UID: uid, mockUser: true} }

--- a/internal/actor/http_test.go
+++ b/internal/actor/http_test.go
@@ -104,6 +104,13 @@ func TestHTTPMiddleware(t *testing.T) {
 			headerKeyActorUID: "",
 		},
 		wantActor: &Actor{Internal: false},
+	}, {
+		name: "anonymous UID for unauthed actor",
+		headers: map[string]string{
+			headerKeyActorUID:          "none",
+			headerKeyActorAnonymousUID: "anonymousUID",
+		},
+		wantActor: &Actor{AnonymousUID: "anonymousUID"},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/actor/http_test.go
+++ b/internal/actor/http_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 )
 
 type roundTripFunc func(req *http.Request) *http.Response
@@ -118,7 +119,7 @@ func TestHTTPMiddleware(t *testing.T) {
 				got := FromContext(r.Context())
 				// Compare string representation
 				if diff := cmp.Diff(tt.wantActor.String(), got.String()); diff != "" {
-					t.Errorf("aactor mismatch (-want +got):\n%s", diff)
+					t.Errorf("actor mismatch (-want +got):\n%s", diff)
 				}
 			}))
 			req, err := http.NewRequest(http.MethodGet, "/test", nil)
@@ -131,4 +132,36 @@ func TestHTTPMiddleware(t *testing.T) {
 			handler.ServeHTTP(httptest.NewRecorder(), req)
 		})
 	}
+}
+
+func TestAnonymousUIDMiddleware(t *testing.T) {
+	t.Run("cookie value is respected", func(t *testing.T) {
+		handler := AnonymousUIDMiddleware(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			got := FromContext(r.Context())
+			require.Equal(t, "anon", got.AnonymousUID)
+		}))
+
+		req, err := http.NewRequest(http.MethodGet, "/test", nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "sourcegraphAnonymousUid", Value: "anon"})
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+	})
+
+	t.Run("cookie doesn't overwrite existing middleware", func(t *testing.T) {
+		handler := http.Handler(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			got := FromContext(r.Context())
+			require.Equal(t, int32(132), got.UID)
+			require.Equal(t, "", got.AnonymousUID)
+		}))
+		anonHandler := AnonymousUIDMiddleware(handler)
+		userHandler := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			// Add an authenticated actor
+			anonHandler.ServeHTTP(rw, r.WithContext(WithActor(r.Context(), FromUser(132))))
+		})
+
+		req, err := http.NewRequest(http.MethodGet, "/test", nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "sourcegraphAnonymousUid", Value: "anon"})
+		userHandler.ServeHTTP(httptest.NewRecorder(), req)
+	})
 }


### PR DESCRIPTION
There are a few places (feature flags, event logging) where we are forced to propagate a handle to a HTTP request because we need the AnonymousUID cookie value if it exists. Since the AnonymousUID is used to identify the current actor (even (and especially) when that actor is unauthenticated), I think it makes sense to propagate through our backend as part of the actor struct. 

This PR adds `AnonymousUID` to the `Actor` struct. The presense of `AnonymousUID` does not change the value of `IsAuthenticated()`, nor is it guaranteed to exist for an unauthenticated actor. However, when it does exist, it can act as a semi-stable identifier for the current actor, which is useful for things like random-but-stable feature flags or for identifying unauthenticated user sessions in event logs.

## Test plan

Added a test that `AnonymousUID` is propagated over internal APIs. Also added tests that it works and that it doesn't override an existing authenticated actor.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


