### PR TITLE
search: use repo pager job for text search jobs over repo sets

### DIFF
--- a/internal/search/job/job_test.go
+++ b/internal/search/job/job_test.go
@@ -30,7 +30,10 @@ func TestToSearchInputs(t *testing.T) {
 	// Job generation for global vs non-global search
 	autogold.Want("user search context", `
 (PARALLEL
-  RepoSubsetText
+  REPOPAGER
+    (PARALLEL
+      ZoektRepoSubset
+      Searcher))
   Repo
   ComputeExcludedRepos)
 `).Equal(t, test(`foo context:@userA`, search.Streaming, query.ParseLiteral))
@@ -51,14 +54,20 @@ func TestToSearchInputs(t *testing.T) {
 
 	autogold.Want("nonglobal repo", `
 (PARALLEL
-  RepoSubsetText
+  REPOPAGER
+    (PARALLEL
+      ZoektRepoSubset
+      Searcher))
   Repo
   ComputeExcludedRepos)
 `).Equal(t, test(`foo repo:sourcegraph/sourcegraph`, search.Streaming, query.ParseLiteral))
 
 	autogold.Want("nonglobal repo contains", `
 (PARALLEL
-  RepoSubsetText
+  REPOPAGER
+    (PARALLEL
+      ZoektRepoSubset
+      Searcher))
   Repo
   ComputeExcludedRepos)
 `).Equal(t, test(`foo repo:contains(bar)`, search.Streaming, query.ParseLiteral))
@@ -118,7 +127,10 @@ func TestToSearchInputs(t *testing.T) {
 
 	autogold.Want("Streaming: many types", `
 (PARALLEL
-  RepoSubsetText
+  REPOPAGER
+    (PARALLEL
+      ZoektRepoSubset
+      Searcher))
   RepoSubsetSymbol
   Commit
   Repo
@@ -140,7 +152,10 @@ func TestToSearchInputs(t *testing.T) {
 (PRIORITY
   (REQUIRED
     (PARALLEL
-      RepoSubsetText
+      REPOPAGER
+        (PARALLEL
+          ZoektRepoSubset
+          Searcher))
       Repo
       ComputeExcludedRepos))
   (OPTIONAL

--- a/internal/search/job/printers_test.go
+++ b/internal/search/job/printers_test.go
@@ -201,92 +201,52 @@ func TestPrettyJSON(t *testing.T) {
 {
   "PARALLEL": [
     {
-      "RepoSubsetText": {
-        "ZoektArgs": {
-          "Query": {
-            "Pattern": "bar",
-            "CaseSensitive": false,
-            "FileName": false,
-            "Content": false
-          },
-          "Typ": "text",
-          "FileMatchLimit": 500,
-          "Select": [],
-          "Zoekt": null
-        },
-        "SearcherArgs": {
-          "SearcherURLs": null,
-          "PatternInfo": {
-            "Pattern": "bar",
-            "IsNegated": false,
-            "IsRegExp": true,
-            "IsStructuralPat": false,
-            "CombyRule": "",
-            "IsWordMatch": false,
-            "IsCaseSensitive": false,
-            "FileMatchLimit": 500,
-            "Index": "yes",
-            "Select": [],
-            "IncludePatterns": null,
-            "ExcludePattern": "",
-            "FilePatternsReposMustInclude": null,
-            "FilePatternsReposMustExclude": null,
-            "PathPatternsAreCaseSensitive": false,
-            "PatternMatchesContent": true,
-            "PatternMatchesPath": true,
-            "Languages": null
-          },
-          "UseFullDeadline": true
-        },
-        "NotSearcherOnly": true,
-        "UseIndex": "yes",
-        "ContainsRefGlobs": false,
-        "RepoOpts": {
-          "RepoFilters": [
-            "foo"
-          ],
-          "MinusRepoFilters": null,
-          "Dependencies": null,
-          "CaseSensitiveRepoFilters": false,
-          "SearchContextSpec": "",
-          "NoForks": true,
-          "OnlyForks": false,
-          "NoArchived": true,
-          "OnlyArchived": false,
-          "CommitAfter": "",
-          "Visibility": "Any",
-          "Limit": 0,
-          "Cursors": null,
-          "Query": [
-            {
-              "Kind": 1,
-              "Operands": [
-                {
-                  "field": "repo",
-                  "value": "foo",
-                  "negated": false
-                },
-                {
-                  "value": "bar",
-                  "negated": false
-                }
-              ],
-              "Annotation": {
-                "labels": 0,
-                "range": {
-                  "start": {
-                    "line": 0,
-                    "column": 0
-                  },
-                  "end": {
-                    "line": 0,
-                    "column": 0
-                  }
-                }
-              }
+      "REPOPAGER": {
+        "PARALLEL": [
+          {
+            "ZoektRepoSubset": {
+              "Repos": null,
+              "Query": {
+                "Pattern": "bar",
+                "CaseSensitive": false,
+                "FileName": false,
+                "Content": false
+              },
+              "Typ": "text",
+              "FileMatchLimit": 500,
+              "Select": [],
+              "Zoekt": null
             }
-          ]
-        }
+          },
+          {
+            "Searcher": {
+              "PatternInfo": {
+                "Pattern": "bar",
+                "IsNegated": false,
+                "IsRegExp": true,
+                "IsStructuralPat": false,
+                "CombyRule": "",
+                "IsWordMatch": false,
+                "IsCaseSensitive": false,
+                "FileMatchLimit": 500,
+                "Index": "yes",
+                "Select": [],
+                "IncludePatterns": null,
+                "ExcludePattern": "",
+                "FilePatternsReposMustInclude": null,
+                "FilePatternsReposMustExclude": null,
+                "PathPatternsAreCaseSensitive": false,
+                "PatternMatchesContent": true,
+                "PatternMatchesPath": true,
+                "Languages": null
+              },
+              "Repos": null,
+              "Indexed": false,
+              "SearcherURLs": null,
+              "UseFullDeadline": true
+            }
+          }
+        ]
       }
     },
     {


### PR DESCRIPTION
A very satisfying PR: this converts the textsearch jobs to be created and expressed as just independent Zoekt and Searcher jobs (after teasing out the different state and parameterizing over repos). The actual change is only about 30 lines, the rest is test values. Some fun observations in line.


## Test plan
Intended to be semantics-preserving. Covered by unit tests and backend integration tests.

