### PR TITLE
batches: acknowledge draft changesets when closing a Batch Change

### DIFF
--- a/client/web/src/enterprise/batches/close/BatchChangeCloseAlert.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeCloseAlert.tsx
@@ -51,7 +51,6 @@ export const BatchChangeCloseAlert: React.FunctionComponent<BatchChangeCloseAler
             setIsClosing(asError(error))
         }
     }, [history, closeChangesets, closeBatchChange, batchChangeID, batchChangeURL])
-
     return (
         <>
             <Card className="mb-3">

--- a/client/web/src/enterprise/batches/close/BatchChangeCloseAlert.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeCloseAlert.tsx
@@ -51,6 +51,7 @@ export const BatchChangeCloseAlert: React.FunctionComponent<BatchChangeCloseAler
             setIsClosing(asError(error))
         }
     }, [history, closeChangesets, closeBatchChange, batchChangeID, batchChangeURL])
+
     return (
         <>
             <Card className="mb-3">

--- a/client/web/src/enterprise/batches/close/BatchChangeCloseChangesetsList.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeCloseChangesetsList.tsx
@@ -8,7 +8,6 @@ import { ErrorLike, isDefined, property } from '@sourcegraph/common'
 import { ActionItemAction } from '@sourcegraph/shared/src/actions/ActionItem'
 import { HoverMerged } from '@sourcegraph/shared/src/api/client/types/hover'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
-import { ChangesetState } from '@sourcegraph/shared/src/graphql-operations'
 import { getHoverActions } from '@sourcegraph/shared/src/hover/actions'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
@@ -80,7 +79,8 @@ export const BatchChangeCloseChangesetsList: React.FunctionComponent<Props> = ({
                 // TODO: This doesn't account for draft changesets. Ideally, this would
                 // use the delta API and apply an empty batch spec, but then changesets
                 // would currently be lost.
-                state: ChangesetState.OPEN,
+                state: null,
+                checkOpenOrDraft: true,
                 checkState: null,
                 reviewState: null,
                 first: args.first ?? null,

--- a/client/web/src/enterprise/batches/close/BatchChangeCloseChangesetsList.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeCloseChangesetsList.tsx
@@ -76,9 +76,6 @@ export const BatchChangeCloseChangesetsList: React.FunctionComponent<Props> = ({
     const queryChangesetsConnection = useCallback(
         (args: FilteredConnectionQueryArguments) =>
             queryChangesets({
-                // TODO: This doesn't account for draft changesets. Ideally, this would
-                // use the delta API and apply an empty batch spec, but then changesets
-                // would currently be lost.
                 state: null,
                 checkOpenOrDraft: true,
                 checkState: null,

--- a/client/web/src/enterprise/batches/close/BatchChangeCloseChangesetsList.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeCloseChangesetsList.tsx
@@ -77,7 +77,7 @@ export const BatchChangeCloseChangesetsList: React.FunctionComponent<Props> = ({
         (args: FilteredConnectionQueryArguments) =>
             queryChangesets({
                 state: null,
-                checkOpenOrDraft: true,
+                onlyClosable: true,
                 checkState: null,
                 reviewState: null,
                 first: args.first ?? null,

--- a/client/web/src/enterprise/batches/detail/backend.ts
+++ b/client/web/src/enterprise/batches/detail/backend.ts
@@ -43,7 +43,7 @@ import {
     CloseChangesetsResult,
     CloseChangesetsVariables,
     PublishChangesetsResult,
-    PublishChangesetsVariables,
+    PublishChangesetsVariables
 } from '../../../graphql-operations'
 
 const changesetsStatsFragment = gql`
@@ -309,6 +309,7 @@ export const CHANGESETS = gql`
         $onlyPublishedByThisBatchChange: Boolean
         $search: String
         $onlyArchived: Boolean
+        $checkOpenOrDraft: Boolean
     ) {
         node(id: $batchChange) {
             __typename
@@ -322,6 +323,7 @@ export const CHANGESETS = gql`
                     onlyPublishedByThisBatchChange: $onlyPublishedByThisBatchChange
                     search: $search
                     onlyArchived: $onlyArchived
+                    checkOpenOrDraft: $checkOpenOrDraft
                 ) {
                     __typename
                     totalCount
@@ -349,7 +351,7 @@ export const CHANGESETS = gql`
     ${externalChangesetFieldsFragment}
 `
 
-// TODO: This has been superseded by CHANGESETS below, but the "Close" page still uses
+// TODO: This has been superseded by CHANGESETS above, but the "Close" page still uses
 // this older `requestGraphQL` one. The variables and result types are the same, so
 // eventually this can just go away when we refactor the requests from the "Close" page.
 export const queryChangesets = ({
@@ -357,6 +359,7 @@ export const queryChangesets = ({
     first,
     after,
     state,
+    checkOpenOrDraft,
     reviewState,
     checkState,
     onlyPublishedByThisBatchChange,
@@ -370,6 +373,7 @@ export const queryChangesets = ({
         first,
         after,
         state,
+        checkOpenOrDraft,
         reviewState,
         checkState,
         onlyPublishedByThisBatchChange,

--- a/client/web/src/enterprise/batches/detail/backend.ts
+++ b/client/web/src/enterprise/batches/detail/backend.ts
@@ -309,7 +309,7 @@ export const CHANGESETS = gql`
         $onlyPublishedByThisBatchChange: Boolean
         $search: String
         $onlyArchived: Boolean
-        $checkOpenOrDraft: Boolean
+        $onlyClosable: Boolean
     ) {
         node(id: $batchChange) {
             __typename
@@ -323,7 +323,7 @@ export const CHANGESETS = gql`
                     onlyPublishedByThisBatchChange: $onlyPublishedByThisBatchChange
                     search: $search
                     onlyArchived: $onlyArchived
-                    checkOpenOrDraft: $checkOpenOrDraft
+                    onlyClosable: $onlyClosable
                 ) {
                     __typename
                     totalCount
@@ -359,7 +359,7 @@ export const queryChangesets = ({
     first,
     after,
     state,
-    checkOpenOrDraft,
+    onlyClosable,
     reviewState,
     checkState,
     onlyPublishedByThisBatchChange,
@@ -373,7 +373,7 @@ export const queryChangesets = ({
         first,
         after,
         state,
-        checkOpenOrDraft,
+        onlyClosable,
         reviewState,
         checkState,
         onlyPublishedByThisBatchChange,

--- a/client/web/src/enterprise/batches/detail/backend.ts
+++ b/client/web/src/enterprise/batches/detail/backend.ts
@@ -43,7 +43,7 @@ import {
     CloseChangesetsResult,
     CloseChangesetsVariables,
     PublishChangesetsResult,
-    PublishChangesetsVariables
+    PublishChangesetsVariables,
 } from '../../../graphql-operations'
 
 const changesetsStatsFragment = gql`

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
@@ -164,7 +164,7 @@ const BatchChangeChangesetsImpl: React.FunctionComponent<Props> = ({
             ...queryArguments,
             first: BATCH_COUNT,
             after: null,
-            onlyClosable: false,
+            onlyClosable: null,
         },
         options: {
             useURL: true,

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
@@ -164,7 +164,7 @@ const BatchChangeChangesetsImpl: React.FunctionComponent<Props> = ({
             ...queryArguments,
             first: BATCH_COUNT,
             after: null,
-            checkOpenOrDraft: false,
+            onlyClosable: false,
         },
         options: {
             useURL: true,

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
@@ -164,7 +164,7 @@ const BatchChangeChangesetsImpl: React.FunctionComponent<Props> = ({
             ...queryArguments,
             first: BATCH_COUNT,
             after: null,
-            checkOpenOrDraft: false
+            checkOpenOrDraft: false,
         },
         options: {
             useURL: true,

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
@@ -164,6 +164,7 @@ const BatchChangeChangesetsImpl: React.FunctionComponent<Props> = ({
             ...queryArguments,
             first: BATCH_COUNT,
             after: null,
+            checkOpenOrDraft: false
         },
         options: {
             useURL: true,

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -558,6 +558,8 @@ type ListChangesetsArgs struct {
 	ExternalState *string
 	// State is a value of type *btypes.ChangesetState.
 	State *string
+	// CheckOpenOrDraft is a field use to query for Open or Draft changests.
+	CheckOpenOrDraft *bool
 	// ReviewState is a value of type *btypes.ChangesetReviewState.
 	ReviewState *string
 	// CheckState is a value of type *btypes.ChangesetCheckState.

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -558,8 +558,8 @@ type ListChangesetsArgs struct {
 	ExternalState *string
 	// State is a value of type *btypes.ChangesetState.
 	State *string
-	// CheckOpenOrDraft is a field use to query for Open or Draft changests.
-	CheckOpenOrDraft *bool
+	// onlyClosable indicates the user only wants open and draft changesets to be returned
+	OnlyClosable *bool
 	// ReviewState is a value of type *btypes.ChangesetReviewState.
 	ReviewState *string
 	// CheckState is a value of type *btypes.ChangesetCheckState.

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2408,6 +2408,11 @@ type BatchChange implements Node {
         """
         state: ChangesetState
         """
+        query only changesets that are either open or draft
+        this is used exclusively on the close page when closing a batch change
+        """
+        checkOpenOrDraft: Boolean
+        """
         Only include changesets with the given review state.
         """
         reviewState: ChangesetReviewState

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2408,10 +2408,10 @@ type BatchChange implements Node {
         """
         state: ChangesetState
         """
-        query only changesets that are either open or draft
-        this is used exclusively on the close page when closing a batch change
+        Query only changesets that are either open or draft. This is used on the close page to list changesets that remain open.
+        When set, passing state is not allowed.
         """
-        checkOpenOrDraft: Boolean
+        onlyClosable: Boolean
         """
         Only include changesets with the given review state.
         """

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -828,6 +828,20 @@ func listChangesetOptsFromArgs(args *graphqlbackend.ListChangesetsArgs, batchCha
 		opts.Cursor = cursor
 	}
 
+	if args.CheckOpenOrDraft != nil && *args.CheckOpenOrDraft {
+		if args.State != nil {
+			return opts, false, errors.New("invalid combination of state and checkOpenOrDraft")
+		}
+
+		publicationState := btypes.ChangesetPublicationStatePublished
+		opts.ExternalStates = []btypes.ChangesetExternalState{
+			btypes.ChangesetExternalStateDraft,
+			btypes.ChangesetExternalStateOpen,
+		}
+		opts.ReconcilerStates = []btypes.ReconcilerState{btypes.ReconcilerStateCompleted}
+		opts.PublicationState = &publicationState
+	}
+
 	if args.State != nil {
 		state := btypes.ChangesetState(*args.State)
 		if !state.Valid() {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -828,9 +828,9 @@ func listChangesetOptsFromArgs(args *graphqlbackend.ListChangesetsArgs, batchCha
 		opts.Cursor = cursor
 	}
 
-	if args.CheckOpenOrDraft != nil && *args.CheckOpenOrDraft {
+	if args.OnlyClosable != nil && *args.OnlyClosable {
 		if args.State != nil {
-			return opts, false, errors.New("invalid combination of state and checkOpenOrDraft")
+			return opts, false, errors.New("invalid combination of state and onlyClosable")
 		}
 
 		publicationState := btypes.ChangesetPublicationStatePublished

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
@@ -988,6 +988,8 @@ func TestListChangesetOptsFromArgs(t *testing.T) {
 	var batchChangeID int64 = 1
 	var repoID api.RepoID = 123
 	repoGraphQLID := graphqlbackend.MarshalRepositoryID(repoID)
+	checkOpenOrDraft := true
+	checkOpenOrDraftPublicationState := btypes.ChangesetPublicationStatePublished
 
 	tcs := []struct {
 		args       *graphqlbackend.ListChangesetsArgs
@@ -1107,6 +1109,21 @@ func TestListChangesetOptsFromArgs(t *testing.T) {
 			wantSafe: true,
 			wantParsed: store.ListChangesetsOpts{
 				RepoID: repoID,
+			},
+		},
+		// CheckOpenOrDraft changesets
+		{
+			args: &graphqlbackend.ListChangesetsArgs{
+				CheckOpenOrDraft: &checkOpenOrDraft,
+			},
+			wantSafe: true,
+			wantParsed: store.ListChangesetsOpts{
+				PublicationState: &checkOpenOrDraftPublicationState,
+				ExternalStates: []btypes.ChangesetExternalState{
+					btypes.ChangesetExternalStateDraft,
+					btypes.ChangesetExternalStateOpen,
+				},
+				ReconcilerStates: []btypes.ReconcilerState{btypes.ReconcilerStateCompleted},
 			},
 		},
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
@@ -1132,9 +1132,9 @@ func TestListChangesetOptsFromArgs(t *testing.T) {
 				OnlyClosable: &onlyClosable,
 				State:        &openChangsetState,
 			},
-			wantSafe: false,
+			wantSafe: 	false,
 			wantParsed: store.ListChangesetsOpts{},
-			wantErr: "invalid combination of state and onlyClosable",
+			wantErr: 	"invalid combination of state and onlyClosable",
 		},
 	}
 	for i, tc := range tcs {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
@@ -1132,9 +1132,9 @@ func TestListChangesetOptsFromArgs(t *testing.T) {
 				OnlyClosable: &onlyClosable,
 				State:        &openChangsetState,
 			},
-			wantSafe: 	false,
+			wantSafe:   false,
 			wantParsed: store.ListChangesetsOpts{},
-			wantErr: 	"invalid combination of state and onlyClosable",
+			wantErr:    "invalid combination of state and onlyClosable",
 		},
 	}
 	for i, tc := range tcs {


### PR DESCRIPTION
## Description
When a batch change has one or more open changesets, we ask the user if they want to close them or not, but we don't trigger this behaviour for draft changesets.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

* Create a batch change with multiple changesets
* Ensure at least one of them is a published draft and the other is published and open
* Closing the batch changes should prompt you about both `open` and `draft` changesets attached to the batch change

Below is a sample batch spec to use for testing.

```yaml
name: another-bc
description: "All death metal^W^Wdrafts, all the time"

# "on" specifies on which repositories to execute the "steps".
on:
  # Example: find all repositories that contain a README.md file.
  - repository: github.com/sourcegraph-testing/zap

# "steps" are run in each repository. Each step is run in a Docker container
# with the repository as the working directory. Once complete, each
# repository's resulting diff is captured.
steps:
  # Example: append "Hello World" to every README.md
  - run: echo "Hello World" | tee -a $(find -name README.md)
    container: alpine:3

# "changesetTemplate" describes the changeset (e.g., GitHub pull request) that
# will be created for each repository.
changesetTemplate:
  title: Draft PR
  body: "This is a draft PR. Thrilling, yes?"

  branch: bo/drafts-bc-test

  commit:
    author:
      name: Bolaji Olajide
      email: bolaji.olajide@sourcegraph.com
    message: Append Hello World to all README.md files

  # Change published to true once you're ready to create changesets on the code host.
  published: draft
```

## Screenshot

<img width="1072" alt="Screenshot 2022-03-11 at 05 55 07" src="https://user-images.githubusercontent.com/25608335/157810623-a9a17348-8b0a-4f92-adad-3687f10724e0.png">

Closes #22250 
