### PR TITLE
db: add gitserver_repo_migration_cursor table

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -965,7 +965,7 @@ Referenced by:
 ```
  Column | Type | Collation | Nullable | Default 
 --------+------+-----------+----------+---------
- cursor | text |           | not null | 
+ cursor | text |           |          | 
 
 ```
 

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -961,6 +961,14 @@ Referenced by:
 
 **rollout**: Rollout only defined when flag_type is rollout. Increments of 0.01%
 
+# Table "public.gitserver_repo_migration_cursor"
+```
+ Column | Type | Collation | Nullable | Default 
+--------+------+-----------+----------+---------
+ cursor | text |           | not null | 
+
+```
+
 # Table "public.gitserver_repos"
 ```
      Column      |           Type           | Collation | Nullable |      Default       

--- a/migrations/frontend/1646983037/down.sql
+++ b/migrations/frontend/1646983037/down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE IF EXISTS gitserver_repo_migration_cursor;
+
+COMMIT;

--- a/migrations/frontend/1646983037/metadata.yaml
+++ b/migrations/frontend/1646983037/metadata.yaml
@@ -1,2 +1,2 @@
-name: add_rendezvous_migration_table
+name: add_gitserver_repo_migration_cursor_table
 parents: [1646741362]

--- a/migrations/frontend/1646983037/metadata.yaml
+++ b/migrations/frontend/1646983037/metadata.yaml
@@ -1,0 +1,2 @@
+name: add_rendezvous_migration_table
+parents: [1646741362]

--- a/migrations/frontend/1646983037/up.sql
+++ b/migrations/frontend/1646983037/up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS gitserver_repo_migration_cursor (
+    cursor text not null
+);
+
+COMMIT;

--- a/migrations/frontend/1646983037/up.sql
+++ b/migrations/frontend/1646983037/up.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
 CREATE TABLE IF NOT EXISTS gitserver_repo_migration_cursor (
-    cursor text not null
+    cursor text
 );
 
 COMMIT;


### PR DESCRIPTION
Adds a table to host the migration cursor.
Fixes #32313

## Test plan

Tested with sg migration up and undo