### PR TITLE
Add site-config option for configuring schedule interval

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -3,7 +3,6 @@ package authz
 import (
 	"container/heap"
 	"context"
-	"log"
 	"net/http"
 	"strconv"
 	"time"
@@ -1141,7 +1140,6 @@ func (s *PermsSyncer) runSchedule(ctx context.Context) {
 			log15.Error("Failed to compute schedule", "err", err)
 			continue
 		}
-		log.Println("Scheduling dat 🌈🦋🦄")
 		s.scheduleUsers(ctx, schedule.Users...)
 		s.scheduleRepos(ctx, schedule.Repos...)
 	}

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -3,6 +3,7 @@ package authz
 import (
 	"container/heap"
 	"context"
+	"log"
 	"net/http"
 	"strconv"
 	"time"
@@ -73,7 +74,7 @@ func NewPermsSyncer(
 		permsStore:          permsStore,
 		clock:               clock,
 		rateLimiterRegistry: rateLimiterRegistry,
-		scheduleInterval:    15 * time.Second,
+		scheduleInterval:    scheduleInterval(),
 	}
 }
 
@@ -1140,7 +1141,7 @@ func (s *PermsSyncer) runSchedule(ctx context.Context) {
 			log15.Error("Failed to compute schedule", "err", err)
 			continue
 		}
-
+		log.Println("Scheduling dat 🌈🦋🦄")
 		s.scheduleUsers(ctx, schedule.Users...)
 		s.scheduleRepos(ctx, schedule.Repos...)
 	}
@@ -1263,4 +1264,12 @@ func (s *PermsSyncer) Run(ctx context.Context) {
 	go s.collectMetrics(ctx)
 
 	<-ctx.Done()
+}
+
+func scheduleInterval() time.Duration {
+	seconds := conf.Get().PermissionsSyncScheduleInterval
+	if seconds <= 0 {
+		return 15 * time.Second
+	}
+	return time.Duration(seconds) * time.Second
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1790,6 +1790,8 @@ type SiteConfiguration struct {
 	OrganizationInvitations *OrganizationInvitations `json:"organizationInvitations,omitempty"`
 	// ParentSourcegraph description: URL to fetch unreachable repository details from. Defaults to "https://sourcegraph.com"
 	ParentSourcegraph *ParentSourcegraph `json:"parentSourcegraph,omitempty"`
+	// PermissionsSyncScheduleInterval description: Time interval (in seconds) of how often each component picks up authorization changes in external services.
+	PermissionsSyncScheduleInterval int `json:"permissions.syncScheduleInterval,omitempty"`
 	// PermissionsUserMapping description: Settings for Sourcegraph permissions, which allow the site admin to explicitly manage repository permissions via the GraphQL API. This setting cannot be enabled if repository permissions for any specific external service are enabled (i.e., when the external service's `authorization` field is set).
 	PermissionsUserMapping *PermissionsUserMapping `json:"permissions.userMapping,omitempty"`
 	// ProductResearchPageEnabled description: Enables users access to the product research page in their settings.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -746,6 +746,11 @@
       "examples": [{ "bindID": "email" }, { "bindID": "username" }],
       "group": "Security"
     },
+    "permissions.syncScheduleInterval": {
+      "description": "Time interval (in seconds) of how often each component picks up authorization changes in external services.",
+      "type": "integer",
+      "default": 15
+    },
     "branding": {
       "description": "Customize Sourcegraph homepage logo and search icon.\n\nOnly available in Sourcegraph Enterprise.",
       "type": "object",


### PR DESCRIPTION
Task 1/3 for [CLOUD-304](https://sourcegraph.atlassian.net/browse/CLOUD-304) - add site-config option for configuring schedule interval, will use this to tune permissions syncing in follow-up PRs.

## Test plan

Tested locally by:

- verifying that if parameter is unset we keep current interval of 15s
- we use the value provided in site config to schedule syncing

