### PR TITLE
gitserver: add GetCursor helper function

### DIFF
--- a/internal/gitserver/migration/migration.go
+++ b/internal/gitserver/migration/migration.go
@@ -1,0 +1,18 @@
+// Package migration contains code for migrating repositories from instance to instance
+// using the Rendezvous hashing algorithm.
+package migration
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+)
+
+// GetCursor is a helper function that returns the current state of the migration.
+// The cursor is used to determine which is the last repository that was migrated.
+// Since repositories are migrated in alphabetical order, the cursor can be used by clients
+// to determine which hashing algorithm to use.
+// Before the migration is run, this function returns an empty string.
+func GetCursor(ctx context.Context, db dbutil.DB) (string, error) {
+	return "", nil
+}


### PR DESCRIPTION
This adds a simple cursor API for the migration that we can all use to get the cursor.
The function doesn't do anything for now and returns an empty string, which is the value that will be returned before the migration starts.

## Test plan

The function doesn't do anything for now, so no need to test anything.


