### PR TITLE
Add metrics for stricter staleness definition (>1h)

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/metrics.go
+++ b/enterprise/cmd/repo-updater/internal/authz/metrics.go
@@ -19,6 +19,10 @@ var (
 		Name: "src_repoupdater_perms_syncer_stale_perms",
 		Help: "The number of records that have stale permissions",
 	}, []string{"type"})
+	metricsStrictStalePerms = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "src_repoupdater_perms_syncer_strict_stale_perms",
+		Help: "The number of records that have permissions older than 1h",
+	}, []string{"type"})
 	metricsPermsGap = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "src_repoupdater_perms_syncer_perms_gap_seconds",
 		Help: "The time gap between least and most up to date permissions",

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -1241,12 +1241,20 @@ func (s *PermsSyncer) collectMetrics(ctx context.Context) {
 			log15.Error("Failed to get metrics from database", "err", err)
 			continue
 		}
+		mstrict, err := s.permsStore.Metrics(ctx, 1*time.Hour)
+		if err != nil {
+			log15.Error("Failed to get metrics from database", "err", err)
+			continue
+		}
 
 		metricsStalePerms.WithLabelValues("user").Set(float64(m.UsersWithStalePerms))
+		metricsStrictStalePerms.WithLabelValues("user").Set(float64(mstrict.UsersWithStalePerms))
 		metricsPermsGap.WithLabelValues("user").Set(m.UsersPermsGapSeconds)
 		metricsStalePerms.WithLabelValues("repo").Set(float64(m.ReposWithStalePerms))
+		metricsStrictStalePerms.WithLabelValues("repo").Set(float64(mstrict.ReposWithStalePerms))
 		metricsPermsGap.WithLabelValues("repo").Set(m.ReposPermsGapSeconds)
 		metricsStalePerms.WithLabelValues("sub-repo").Set(float64(m.SubReposWithStalePerms))
+		metricsStrictStalePerms.WithLabelValues("sub-repo").Set(float64(mstrict.SubReposWithStalePerms))
 		metricsPermsGap.WithLabelValues("sub-repo").Set(m.SubReposPermsGapSeconds)
 
 		s.queue.mu.RLock()


### PR DESCRIPTION
We currently report permissions as stale if they are >72h out of date.
This PR adds a Prometheus metric tracking permissions that are >1h out of date ("strict" staleness).

## Test plan
Tested locally by verifying old and new permissions are added to Prometheus.


