### PR TITLE
Add route handling for unauth'd app install

### DIFF
--- a/client/web/src/org/settings/codeHosts/InstallGitHubAppSuccessPage.tsx
+++ b/client/web/src/org/settings/codeHosts/InstallGitHubAppSuccessPage.tsx
@@ -1,0 +1,27 @@
+import GithubIcon from 'mdi-react/GithubIcon'
+import React from 'react'
+
+import { Card, CardBody, PageHeader } from '@sourcegraph/wildcard'
+
+import { Page } from '../../../components/Page'
+import { PageTitle } from '../../../components/PageTitle'
+
+export const InstallGithubAppSuccessPage: React.FunctionComponent<{}> = () => (
+    <Page>
+        <PageTitle>Success!</PageTitle>
+        <PageHeader
+            path={[
+                {
+                    icon: GithubIcon,
+                    text: 'Success!',
+                },
+            ]}
+            className="mb-3"
+        />
+        <Card>
+            <CardBody>
+                <p>The Sourcegraph GitHub App has been successfully installed!</p>
+            </CardBody>
+        </Card>
+    </Page>
+)

--- a/client/web/src/org/settings/codeHosts/InstallGitHubAppSuccessPage.tsx
+++ b/client/web/src/org/settings/codeHosts/InstallGitHubAppSuccessPage.tsx
@@ -6,7 +6,7 @@ import { Card, CardBody, PageHeader } from '@sourcegraph/wildcard'
 import { Page } from '../../../components/Page'
 import { PageTitle } from '../../../components/PageTitle'
 
-export const InstallGithubAppSuccessPage: React.FunctionComponent<{}> = () => (
+export const InstallGitHubAppSuccessPage: React.FunctionComponent<{}> = () => (
     <Page>
         <PageTitle>Success!</PageTitle>
         <PageHeader

--- a/client/web/src/routes.constants.ts
+++ b/client/web/src/routes.constants.ts
@@ -22,6 +22,7 @@ export enum PageRoutes {
     Notebook = '/notebooks/:id',
     Notebooks = '/notebooks',
     RepoContainer = '/:repoRevAndRest+',
+    InstallGitHubAppSuccess = '/install-github-app-success',
 }
 
 export enum EnterprisePageRoutes {

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -11,6 +11,7 @@ import { BreadcrumbsProps, BreadcrumbSetters } from './components/Breadcrumbs'
 import type { LayoutProps } from './Layout'
 import { CreateNotebookPage } from './notebooks/createPage/CreateNotebookPage'
 import { NotebooksListPage } from './notebooks/listPage/NotebooksListPage'
+import { InstallGithubAppSuccessPage } from './org/settings/codeHosts/InstallGitHubAppSuccessPage'
 import type { ExtensionAlertProps } from './repo/actions/InstallIntegrationsAlert'
 import { PageRoutes } from './routes.constants'
 import { SearchPageWrapper } from './search/SearchPageWrapper'
@@ -168,6 +169,10 @@ export const routes: readonly LayoutRouteProps<any>[] = [
             ),
 
         exact: true,
+    },
+    {
+        path: PageRoutes.InstallGitHubAppSuccess,
+        render: () => <InstallGithubAppSuccessPage />,
     },
     {
         path: PageRoutes.Settings,

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -11,7 +11,7 @@ import { BreadcrumbsProps, BreadcrumbSetters } from './components/Breadcrumbs'
 import type { LayoutProps } from './Layout'
 import { CreateNotebookPage } from './notebooks/createPage/CreateNotebookPage'
 import { NotebooksListPage } from './notebooks/listPage/NotebooksListPage'
-import { InstallGithubAppSuccessPage } from './org/settings/codeHosts/InstallGitHubAppSuccessPage'
+import { InstallGitHubAppSuccessPage } from './org/settings/codeHosts/InstallGitHubAppSuccessPage'
 import type { ExtensionAlertProps } from './repo/actions/InstallIntegrationsAlert'
 import { PageRoutes } from './routes.constants'
 import { SearchPageWrapper } from './search/SearchPageWrapper'
@@ -172,7 +172,7 @@ export const routes: readonly LayoutRouteProps<any>[] = [
     },
     {
         path: PageRoutes.InstallGitHubAppSuccess,
-        render: () => <InstallGithubAppSuccessPage />,
+        render: () => <InstallGitHubAppSuccessPage />,
     },
     {
         path: PageRoutes.Settings,

--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -213,7 +213,8 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
         requestSuccess ? (
             <Alert className="mb-4" role="alert" key="update-gitlab" variant="info">
                 <h4>GitHub code host connection pending</h4>
-                An installation request was sent to your GitHub organization’s owners. After the request is approved, finish connecting with GitHub to choose repositories to sync with Sourcegraph.
+                An installation request was sent to your GitHub organization’s owners. After the request is approved,
+                finish connecting with GitHub to choose repositories to sync with Sourcegraph.
             </Alert>
         ) : null
 

--- a/enterprise/cmd/frontend/internal/app/app.go
+++ b/enterprise/cmd/frontend/internal/app/app.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -100,6 +101,14 @@ func newGitHubAppCloudSetupHandler(db database.DB, apiURL *url.URL, client githu
 		}
 
 		setupAction := r.URL.Query().Get("setup_action")
+
+		a := actor.FromContext(r.Context())
+
+		if !a.IsAuthenticated() {
+			if setupAction == "install" {
+				http.Redirect(w, r, "/install_success", http.StatusFound)
+			}
+		}
 
 		state := r.URL.Query().Get("state")
 		orgID, err := graphqlbackend.UnmarshalOrgID(graphql.ID(state))

--- a/enterprise/cmd/frontend/internal/app/app.go
+++ b/enterprise/cmd/frontend/internal/app/app.go
@@ -113,7 +113,6 @@ func newGitHubAppCloudSetupHandler(db database.DB, apiURL *url.URL, client githu
 				http.Redirect(w, r, "/install-github-app-request", http.StatusFound)
 				return
 			}
-
 		}
 
 		state := r.URL.Query().Get("state")

--- a/enterprise/cmd/frontend/internal/app/app_test.go
+++ b/enterprise/cmd/frontend/internal/app/app_test.go
@@ -57,7 +57,6 @@ func TestNewGitHubAppCloudSetupHandler(t *testing.T) {
 	)
 
 	req, err := http.NewRequest(http.MethodGet, "/.setup/github-app-cloud?installation_id=21994992&setup_action=install&state=T3JnOjE%3D", nil)
-
 	require.Nil(t, err)
 
 	h := newGitHubAppCloudSetupHandler(db, apiURL, client)

--- a/enterprise/cmd/frontend/internal/app/app_test.go
+++ b/enterprise/cmd/frontend/internal/app/app_test.go
@@ -57,11 +57,21 @@ func TestNewGitHubAppCloudSetupHandler(t *testing.T) {
 	)
 
 	req, err := http.NewRequest(http.MethodGet, "/.setup/github-app-cloud?installation_id=21994992&setup_action=install&state=T3JnOjE%3D", nil)
-	ctx := a.WithActor(req.Context(), &a.Actor{UID: 1})
-	req = req.WithContext(ctx)
+
 	require.Nil(t, err)
 
 	h := newGitHubAppCloudSetupHandler(db, apiURL, client)
+
+	t.Run("user not logged in (no actor in context)", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+		h.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusFound, resp.Code)
+		assert.Equal(t, "/install-github-app-success", resp.Header().Get("Location"))
+	})
+
+	ctx := a.WithActor(req.Context(), &a.Actor{UID: 1})
+	req = req.WithContext(ctx)
 
 	t.Run("feature flag not enabled", func(t *testing.T) {
 		resp := httptest.NewRecorder()

--- a/enterprise/cmd/frontend/internal/app/app_test.go
+++ b/enterprise/cmd/frontend/internal/app/app_test.go
@@ -70,6 +70,17 @@ func TestNewGitHubAppCloudSetupHandler(t *testing.T) {
 		assert.Equal(t, "/install-github-app-success", resp.Header().Get("Location"))
 	})
 
+	t.Run("invalid setup action", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+		badReq, err := http.NewRequest(http.MethodGet, "/.setup/github-app-cloud?installation_id=21994992&setup_action=incorrect&state=T3JnOjE%3D", nil)
+		require.Nil(t, err)
+
+		h.ServeHTTP(resp, badReq)
+
+		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, "Invalid setup action 'incorrect'", resp.Body.String())
+	})
+
 	ctx := a.WithActor(req.Context(), &a.Actor{UID: 1})
 	req = req.WithContext(ctx)
 

--- a/enterprise/cmd/frontend/internal/app/app_test.go
+++ b/enterprise/cmd/frontend/internal/app/app_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	a "github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -56,6 +57,8 @@ func TestNewGitHubAppCloudSetupHandler(t *testing.T) {
 	)
 
 	req, err := http.NewRequest(http.MethodGet, "/.setup/github-app-cloud?installation_id=21994992&setup_action=install&state=T3JnOjE%3D", nil)
+	ctx := a.WithActor(req.Context(), &a.Actor{UID: 1})
+	req = req.WithContext(ctx)
 	require.Nil(t, err)
 
 	h := newGitHubAppCloudSetupHandler(db, apiURL, client)

--- a/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
@@ -108,6 +108,9 @@ func newOAuthFlowHandler(db database.DB, serviceType string) http.Handler {
 
 		http.Redirect(w, req, appInstallURL, http.StatusFound)
 	}))
+	mux.Handle("/install-github-app-success", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+
+	}))
 	return mux
 }
 

--- a/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
@@ -108,9 +108,6 @@ func newOAuthFlowHandler(db database.DB, serviceType string) http.Handler {
 
 		http.Redirect(w, req, appInstallURL, http.StatusFound)
 	}))
-	mux.Handle("/install-github-app-success", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-
-	}))
 	return mux
 }
 


### PR DESCRIPTION
Adds a placeholder landing page for a successful GitHub App installation from a user not logged into Sourcegraph.

## Test plan

Updated unit tests as well as manual e2e test.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


