### PR TITLE
Add documentation for npm/JVM package repos

### DIFF
--- a/client/web/src/components/externalServices/externalServices.tsx
+++ b/client/web/src/components/externalServices/externalServices.tsx
@@ -1210,6 +1210,8 @@ const JVM_PACKAGES: AddExternalServiceOptions = {
                     <code>"org.hamcrest:hamcrest-core:1.3:default"</code>.
                 </li>
             </ol>
+            <p>⚠️ JVM dependency repositories are visible by all users of the Sourcegraph instance.</p>
+            <p>⚠️ It is only possible to register one JVM dependency code host per Sourcegraph instance.</p>
         </div>
     ),
     editorActions: [],
@@ -1264,6 +1266,8 @@ const NPM_PACKAGES: AddExternalServiceOptions = {
                     supported.
                 </li>
             </ol>
+            <p>⚠️ npm package repositories are visible by all users of the Sourcegraph instance.</p>
+            <p>⚠️ It is only possible to register one npm package code host per Sourcegraph instance.</p>
         </div>
     ),
     editorActions: [],
@@ -1281,9 +1285,9 @@ export const codeHostExternalServices: Record<string, AddExternalServiceOptions>
     gitolite: GITOLITE,
     git: GENERIC_GIT,
     ...(window.context?.experimentalFeatures?.perforce === 'enabled' ? { perforce: PERFORCE } : {}),
-    ...(window.context?.experimentalFeatures?.jvmPackages === 'enabled' ? { jvmPackages: JVM_PACKAGES } : {}),
+    ...(window.context?.experimentalFeatures?.jvmPackages === 'disabled' ? {} : { jvmPackages: JVM_PACKAGES }),
     ...(window.context?.experimentalFeatures?.pagure === 'enabled' ? { pagure: PAGURE } : {}),
-    ...(window.context?.experimentalFeatures?.npmPackages === 'enabled' ? { npmPackages: NPM_PACKAGES } : {}),
+    ...(window.context?.experimentalFeatures?.npmPackages === 'disabled' ? {} : { npmPackages: NPM_PACKAGES }),
 }
 
 export const nonCodeHostExternalServices: Record<string, AddExternalServiceOptions> = {

--- a/doc/code_intelligence/explanations/features.md
+++ b/doc/code_intelligence/explanations/features.md
@@ -26,11 +26,18 @@ When you select 'Find references' from the popover, a panel will be shown at the
 
 ## Dependency navigation
 
-If [auto-indexing](auto_indexing.md) is enabled for your instance, you will also be able to Find references and navigate precisely across your dependencies. 
+Dependency navigation enables "Find references" and "Go to definition" to show usages across multiple repositories, including transitive dependencies.
+For example, the animation below demonstrates how to trigger "Find references" in the repository `github.com/Netflix/Hystrix` and navigate to results in the Java standard library (JDK).
 
 <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/dependency-nav.gif" width="500"/>
 
-> NOTE: This feature is in Experimental phase and currently available for Go, Java, Scala, Kotlin packages only. We plan to expand language support for this feature in the future.
+The instructions to setup dependency navigation are different depending on what language ecosystem you use.
+
+* **Go**: Setup [auto-indexing](auto_indexing.md).
+* **Java, Scala, Kotlin**: Setup [auto-indexing](auto_indexing.md) and a [JVM dependencies code host](../../integration/jvm.md).
+* **JavaScript, TypeScript**: Setup [auto-indexing](auto_indexing.md) and a [npm dependencies code host](../../integration/npm.md).
+
+> NOTE: This feature is in Experimental phase and is not available for other language ecosystems at the moment.
 
 ## Find implementations
 

--- a/doc/integration/index.md
+++ b/doc/integration/index.md
@@ -12,6 +12,8 @@ Sourcegraph integrates with your other tools to help you search, navigate, and r
   - [Phabricator](phabricator.md)
   - [AWS CodeCommit](aws_codecommit.md)
   - [Gitolite](gitolite.md)
+  - [JVM dependencies](jvm.md)
+  - [npm dependencies](npm.md)
   - [Other Git repository hosts](../admin/external_service/other.md)
 - Other services
   - [Codecov](https://sourcegraph.com/extensions/sourcegraph/codecov)

--- a/doc/integration/jvm.md
+++ b/doc/integration/jvm.md
@@ -1,0 +1,33 @@
+# JVM dependency integration with Sourcegraph
+
+You can use Sourcegraph with JVM dependencies from any Maven repository, including Maven Central, Sonatype, or Artifactory.
+This integration makes it possible to search and navigate through the source code of the JDK (Java standard library) or published Java, Scala, and Kotlin libraries (for example, [`com.google.guava:guava:27.0-jre`](https://sourcegraph.com/maven/com.google.guava/guava@v27.0-jre/-/blob/com/google/common/util/concurrent/Futures.java?L35)).
+
+Feature | Supported?
+------- | ----------
+[Repository syncing](#repository-syncing) | ✅
+[Credentials](#credentials) | ✅
+[Repository permissions](#repository-syncing) | ❌
+[Multiple JVM dependency code hosts](#multiple-jvm-dependency-code-hosts) | ❌
+
+## Repository syncing
+
+There are two ways to sync JVM dependency repositories.
+
+* **LSIF** (recommended): run [`lsif-java`](https://sourcegraph.github.io/lsif-java/) against your JVM codebase and upload the generated index to Sourcegraph using the  [src-cli](https://github.com/sourcegraph/src-cli) command `src lsif upload`. Sourcegraph automatically synchronizes JVM dependency repositories based on the dependencies that are discovered by `lsif-java`.
+* **Code host configuration**: manually list dependencies in the `"dependencies"` section of the JSON configuration when creating the JVM dependency code host. This method can be useful to verify that the credentials are picked up correctly without having to upload LSIF.
+
+## Credentials
+
+Sourcegraph uses [Coursier](https://get-coursier.io/) to resolve JVM dependencies.
+Use the `"credentials"` section of the JSON configuration to provide usernames and passwords to access your Maven repository. See the Coursier documentation about [inline credentials](https://get-coursier.io/docs/other-credentials#inline) to learn more about how to format the `"credentials"` configuration.
+
+
+## Repository permissions
+
+⚠️ JVM dependency repositories are visible by all users of the Sourcegraph instance.
+
+## Multiple JVM dependency code hosts
+
+⚠️ It's only possible to create one JVM dependency code host for each Sourcegraph instance.
+See the issue [sourcegraph#32461](https://github.com/sourcegraph/sourcegraph/issues/32461) for more details about this limitation. In most situations, it's possible to work around this limitation by configurating multiple Maven repositories to the same JVM dependency code host.

--- a/doc/integration/npm.md
+++ b/doc/integration/npm.md
@@ -1,0 +1,32 @@
+# npm dependency integration with Sourcegraph
+
+You can use Sourcegraph with npm packages from any npm registry, including open source code from npmjs.com or a private registry such as Verdaccio.
+This integration makes it possible to search and navigate through the source code of published JavaScript or TypeScript packages (for example, [`@types/gzip-js@0.3.3`](https://sourcegraph.com/npm/types/gzip-js@v0.3.3/-/blob/index.d.ts)).
+
+Feature | Supported?
+------- | ----------
+[Repository syncing](#repository-syncing) | ✅
+[Credentials](#credentials) | ✅
+[Repository permissions](#repository-syncing) | ❌
+[Multiple npm dependency code hosts](#multiple-npm-dependency-code-hosts) | ❌
+
+## Repository syncing
+
+There are two ways to sync npm dependency repositories.
+
+* **LSIF** (recommended): run [`lsif-node`](https://github.com/sourcegraph/lsif-node) against your JS/TS codebase and upload the generated index to Sourcegraph using the  [src-cli](https://github.com/sourcegraph/src-cli) command `src lsif upload`. Sourcegraph automatically synchronizes npm dependency repositories based on the dependencies that are discovered by `lsif-node`.
+* **Code host configuration**: manually list dependencies in the `"dependencies"` section of the JSON configuration when creating the npm dependency code host. This method can be useful to verify that the credentials are picked up correctly without having to upload LSIF.
+
+## Credentials
+
+Use the `"credentials"` section of the JSON configuration to provide an access token for your private npm registry. See the [official npm documentation](https://docs.npmjs.com/about-access-tokens) for more details about how to create, list and view npm access tokens.
+
+
+## Repository permissions
+
+⚠️ npm dependency repositories are visible by all users of the Sourcegraph instance.
+
+## Multiple npm dependency code hosts
+
+⚠️ It's only possible to create one npm dependency code host for each Sourcegraph instance.
+See the issue [sourcegraph#32499](https://github.com/sourcegraph/sourcegraph/issues/32499) for more details about this limitation. In most situations, it's possible to work around this limitation by configurating a single private npm registry to proxy multiple underlying registries.


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/31717 

To simplify the setup, the experimental feature flags are no longer needed to create JVM/npm package code hosts.


## Test plan

This PR is mostly updating documentation so there are no new tests. I manually verified that it's possible to create npm/JVM code hosts without experimental feature flags.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


