### PR TITLE
gitserver: clone from another instance

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1730,7 +1730,6 @@ func (s *Server) cloneRepo(ctx context.Context, repo api.RepoName, opts *cloneOp
 		return "", err
 	}
 
-	fmt.Println(6)
 	// We push the cloneJob to a queue and let the producer-consumer pipeline take over from this
 	// point. See definitions of cloneJobProducer and cloneJobConsumer to understand how these jobs
 	// are processed.


### PR DESCRIPTION
During a clone request, Gitserver now reads the `CloneFromShard` option and clones a repo from the given gitserver instance if provided.

Fixes https://github.com/sourcegraph/sourcegraph/issues/32312

## Test plan

- Unit test
- Manual test with two different gitserver instances


