### PR TITLE
client/web: Remove beta label from Dependencies button

### DIFF
--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -441,7 +441,6 @@ export const TreePage: React.FunctionComponent<Props> = ({
                                                 as={Link}
                                             >
                                                 <GraphOutlineIcon className="icon-inline" /> Dependencies{' '}
-                                                <ProductStatusBadge status="beta" />
                                             </Button>
                                         )}
                                         {batchChangesEnabled && <RepoBatchChangesButton repoName={repo.name} />}


### PR DESCRIPTION
The feature is still in beta, but we don't need to advertise that everywhere and this reduces the width of the overall row.

Closes #32332

## Test plan

Visual testing with my left eye. The other one was looking out the train window.

