### PR TITLE
[cloud][CLOUD-311] Collect orgs open beta metadata

### DIFF
--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -2,6 +2,7 @@ package graphqlbackend
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/graph-gophers/graphql-go"
@@ -242,6 +243,7 @@ func (o *OrgResolver) BatchChanges(ctx context.Context, args *ListBatchChangesAr
 func (r *schemaResolver) CreateOrganization(ctx context.Context, args *struct {
 	Name        string
 	DisplayName *string
+	StatsID     *string
 }) (*OrgResolver, error) {
 	a := actor.FromContext(ctx)
 	if !a.IsAuthenticated() {
@@ -254,6 +256,15 @@ func (r *schemaResolver) CreateOrganization(ctx context.Context, args *struct {
 	newOrg, err := database.Orgs(r.db).Create(ctx, args.Name, args.DisplayName)
 	if err != nil {
 		return nil, err
+	}
+
+	// Write the org_id into orgs open beta stats table on Cloud
+	if envvar.SourcegraphDotComMode() && args.StatsID != nil {
+		// we do not throw errors here as this is best effort
+		err = database.Orgs(r.db).UpdateOrgsOpenBetaStats(ctx, *args.StatsID, newOrg.ID)
+		if err != nil {
+			log15.Warn("Cannot update orgs open beta stats", "id", *args.StatsID, "orgID", newOrg.ID, "error", err)
+		}
 	}
 
 	// Add the current user as the first member of the new org.
@@ -377,6 +388,26 @@ func (r *schemaResolver) AddUserToOrganization(ctx context.Context, args *struct
 		)
 	}
 	return &EmptyResponse{}, nil
+}
+
+func (r *schemaResolver) AddOrgsOpenBetaStats(ctx context.Context, args *struct {
+	Stats JSONCString
+}) (*graphql.ID, error) {
+	a := actor.FromContext(ctx)
+	if !a.IsAuthenticated() {
+		return nil, errors.New("no current user")
+	}
+	if args == nil || !json.Valid([]byte(args.Stats)) {
+		return nil, errors.New("must supply valid json")
+	}
+
+	id, err := database.Orgs(r.db).AddOrgsOpenBetaStats(ctx, a.UID, string(args.Stats))
+	if err != nil {
+		return nil, err
+	}
+
+	graphqlID := graphql.ID(id)
+	return &graphqlID, nil
 }
 
 type ListOrgRepositoriesArgs struct {

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -253,7 +253,7 @@ func (r *schemaResolver) CreateOrganization(ctx context.Context, args *struct {
 	if err := suspiciousnames.CheckNameAllowedForUserOrOrganization(args.Name); err != nil {
 		return nil, err
 	}
-	newOrg, err := database.Orgs(r.db).Create(ctx, args.Name, args.DisplayName)
+	newOrg, err := r.db.Orgs().Create(ctx, args.Name, args.DisplayName)
 	if err != nil {
 		return nil, err
 	}
@@ -261,14 +261,14 @@ func (r *schemaResolver) CreateOrganization(ctx context.Context, args *struct {
 	// Write the org_id into orgs open beta stats table on Cloud
 	if envvar.SourcegraphDotComMode() && args.StatsID != nil {
 		// we do not throw errors here as this is best effort
-		err = database.Orgs(r.db).UpdateOrgsOpenBetaStats(ctx, *args.StatsID, newOrg.ID)
+		err = r.db.Orgs().UpdateOrgsOpenBetaStats(ctx, *args.StatsID, newOrg.ID)
 		if err != nil {
 			log15.Warn("Cannot update orgs open beta stats", "id", *args.StatsID, "orgID", newOrg.ID, "error", err)
 		}
 	}
 
 	// Add the current user as the first member of the new org.
-	_, err = database.OrgMembers(r.db).Create(ctx, newOrg.ID, a.UID)
+	_, err = r.db.OrgMembers().Create(ctx, newOrg.ID, a.UID)
 	if err != nil {
 		return nil, err
 	}
@@ -401,7 +401,7 @@ func (r *schemaResolver) AddOrgsOpenBetaStats(ctx context.Context, args *struct 
 		return nil, errors.New("must supply valid json")
 	}
 
-	id, err := database.Orgs(r.db).AddOrgsOpenBetaStats(ctx, a.UID, string(args.Stats))
+	id, err := r.db.Orgs().AddOrgsOpenBetaStats(ctx, a.UID, string(args.Stats))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/org.graphql
+++ b/cmd/frontend/graphqlbackend/org.graphql
@@ -37,3 +37,14 @@ extend type Org {
         externalServiceIDs: [ID]
     ): RepositoryConnection!
 }
+
+extend type Mutation {
+    """
+    Collects the stats users enter when accessing organizations open beta on Cloud
+
+    Only authenticated users are able to perform this operation.
+
+    Only possible to execute on Cloud deployment.
+    """
+    addOrgsOpenBetaStats(stats: JSONCString!): ID
+}

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -87,7 +87,7 @@ type Mutation {
 
     Only authenticated users may perform this mutation.
     """
-    createOrganization(name: String!, displayName: String): Org!
+    createOrganization(name: String!, displayName: String, statsID: ID): Org!
     """
     Updates an organization.
 

--- a/go.mod
+++ b/go.mod
@@ -221,7 +221,7 @@ require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bufbuild/buf v0.56.0
 	github.com/gofrs/flock v0.8.1 // indirect
-	github.com/gofrs/uuid v4.0.0+incompatible // indirect
+	github.com/gofrs/uuid v4.0.0+incompatible
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jhump/protoreflect v1.9.1-0.20210817181203-db1a327a393e // indirect
 	github.com/klauspost/pgzip v1.2.5 // indirect

--- a/internal/database/mocks.go
+++ b/internal/database/mocks.go
@@ -21331,6 +21331,9 @@ func (c OrgMemberStoreWithFuncCall) Results() []interface{} {
 // package github.com/sourcegraph/sourcegraph/internal/database) used for
 // unit testing.
 type MockOrgStore struct {
+	// AddOrgsOpenBetaStatsFunc is an instance of a mock function object
+	// controlling the behavior of the method AddOrgsOpenBetaStats.
+	AddOrgsOpenBetaStatsFunc *OrgStoreAddOrgsOpenBetaStatsFunc
 	// CountFunc is an instance of a mock function object controlling the
 	// behavior of the method Count.
 	CountFunc *OrgStoreCountFunc
@@ -21371,6 +21374,9 @@ type MockOrgStore struct {
 	// UpdateFunc is an instance of a mock function object controlling the
 	// behavior of the method Update.
 	UpdateFunc *OrgStoreUpdateFunc
+	// UpdateOrgsOpenBetaStatsFunc is an instance of a mock function object
+	// controlling the behavior of the method UpdateOrgsOpenBetaStats.
+	UpdateOrgsOpenBetaStatsFunc *OrgStoreUpdateOrgsOpenBetaStatsFunc
 	// WithFunc is an instance of a mock function object controlling the
 	// behavior of the method With.
 	WithFunc *OrgStoreWithFunc
@@ -21380,6 +21386,11 @@ type MockOrgStore struct {
 // return zero values for all results, unless overwritten.
 func NewMockOrgStore() *MockOrgStore {
 	return &MockOrgStore{
+		AddOrgsOpenBetaStatsFunc: &OrgStoreAddOrgsOpenBetaStatsFunc{
+			defaultHook: func(context.Context, int32, string) (string, error) {
+				return "", nil
+			},
+		},
 		CountFunc: &OrgStoreCountFunc{
 			defaultHook: func(context.Context, OrgsListOptions) (int, error) {
 				return 0, nil
@@ -21445,6 +21456,11 @@ func NewMockOrgStore() *MockOrgStore {
 				return nil, nil
 			},
 		},
+		UpdateOrgsOpenBetaStatsFunc: &OrgStoreUpdateOrgsOpenBetaStatsFunc{
+			defaultHook: func(context.Context, string, int32) error {
+				return nil
+			},
+		},
 		WithFunc: &OrgStoreWithFunc{
 			defaultHook: func(basestore.ShareableStore) OrgStore {
 				return nil
@@ -21457,6 +21473,11 @@ func NewMockOrgStore() *MockOrgStore {
 // methods panic on invocation, unless overwritten.
 func NewStrictMockOrgStore() *MockOrgStore {
 	return &MockOrgStore{
+		AddOrgsOpenBetaStatsFunc: &OrgStoreAddOrgsOpenBetaStatsFunc{
+			defaultHook: func(context.Context, int32, string) (string, error) {
+				panic("unexpected invocation of MockOrgStore.AddOrgsOpenBetaStats")
+			},
+		},
 		CountFunc: &OrgStoreCountFunc{
 			defaultHook: func(context.Context, OrgsListOptions) (int, error) {
 				panic("unexpected invocation of MockOrgStore.Count")
@@ -21522,6 +21543,11 @@ func NewStrictMockOrgStore() *MockOrgStore {
 				panic("unexpected invocation of MockOrgStore.Update")
 			},
 		},
+		UpdateOrgsOpenBetaStatsFunc: &OrgStoreUpdateOrgsOpenBetaStatsFunc{
+			defaultHook: func(context.Context, string, int32) error {
+				panic("unexpected invocation of MockOrgStore.UpdateOrgsOpenBetaStats")
+			},
+		},
 		WithFunc: &OrgStoreWithFunc{
 			defaultHook: func(basestore.ShareableStore) OrgStore {
 				panic("unexpected invocation of MockOrgStore.With")
@@ -21534,6 +21560,9 @@ func NewStrictMockOrgStore() *MockOrgStore {
 // methods delegate to the given implementation, unless overwritten.
 func NewMockOrgStoreFrom(i OrgStore) *MockOrgStore {
 	return &MockOrgStore{
+		AddOrgsOpenBetaStatsFunc: &OrgStoreAddOrgsOpenBetaStatsFunc{
+			defaultHook: i.AddOrgsOpenBetaStats,
+		},
 		CountFunc: &OrgStoreCountFunc{
 			defaultHook: i.Count,
 		},
@@ -21573,10 +21602,125 @@ func NewMockOrgStoreFrom(i OrgStore) *MockOrgStore {
 		UpdateFunc: &OrgStoreUpdateFunc{
 			defaultHook: i.Update,
 		},
+		UpdateOrgsOpenBetaStatsFunc: &OrgStoreUpdateOrgsOpenBetaStatsFunc{
+			defaultHook: i.UpdateOrgsOpenBetaStats,
+		},
 		WithFunc: &OrgStoreWithFunc{
 			defaultHook: i.With,
 		},
 	}
+}
+
+// OrgStoreAddOrgsOpenBetaStatsFunc describes the behavior when the
+// AddOrgsOpenBetaStats method of the parent MockOrgStore instance is
+// invoked.
+type OrgStoreAddOrgsOpenBetaStatsFunc struct {
+	defaultHook func(context.Context, int32, string) (string, error)
+	hooks       []func(context.Context, int32, string) (string, error)
+	history     []OrgStoreAddOrgsOpenBetaStatsFuncCall
+	mutex       sync.Mutex
+}
+
+// AddOrgsOpenBetaStats delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockOrgStore) AddOrgsOpenBetaStats(v0 context.Context, v1 int32, v2 string) (string, error) {
+	r0, r1 := m.AddOrgsOpenBetaStatsFunc.nextHook()(v0, v1, v2)
+	m.AddOrgsOpenBetaStatsFunc.appendCall(OrgStoreAddOrgsOpenBetaStatsFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the AddOrgsOpenBetaStats
+// method of the parent MockOrgStore instance is invoked and the hook queue
+// is empty.
+func (f *OrgStoreAddOrgsOpenBetaStatsFunc) SetDefaultHook(hook func(context.Context, int32, string) (string, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// AddOrgsOpenBetaStats method of the parent MockOrgStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *OrgStoreAddOrgsOpenBetaStatsFunc) PushHook(hook func(context.Context, int32, string) (string, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *OrgStoreAddOrgsOpenBetaStatsFunc) SetDefaultReturn(r0 string, r1 error) {
+	f.SetDefaultHook(func(context.Context, int32, string) (string, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *OrgStoreAddOrgsOpenBetaStatsFunc) PushReturn(r0 string, r1 error) {
+	f.PushHook(func(context.Context, int32, string) (string, error) {
+		return r0, r1
+	})
+}
+
+func (f *OrgStoreAddOrgsOpenBetaStatsFunc) nextHook() func(context.Context, int32, string) (string, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *OrgStoreAddOrgsOpenBetaStatsFunc) appendCall(r0 OrgStoreAddOrgsOpenBetaStatsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of OrgStoreAddOrgsOpenBetaStatsFuncCall
+// objects describing the invocations of this function.
+func (f *OrgStoreAddOrgsOpenBetaStatsFunc) History() []OrgStoreAddOrgsOpenBetaStatsFuncCall {
+	f.mutex.Lock()
+	history := make([]OrgStoreAddOrgsOpenBetaStatsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// OrgStoreAddOrgsOpenBetaStatsFuncCall is an object that describes an
+// invocation of method AddOrgsOpenBetaStats on an instance of MockOrgStore.
+type OrgStoreAddOrgsOpenBetaStatsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int32
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 string
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c OrgStoreAddOrgsOpenBetaStatsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c OrgStoreAddOrgsOpenBetaStatsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // OrgStoreCountFunc describes the behavior when the Count method of the
@@ -22956,6 +23100,117 @@ func (c OrgStoreUpdateFuncCall) Args() []interface{} {
 // invocation.
 func (c OrgStoreUpdateFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
+}
+
+// OrgStoreUpdateOrgsOpenBetaStatsFunc describes the behavior when the
+// UpdateOrgsOpenBetaStats method of the parent MockOrgStore instance is
+// invoked.
+type OrgStoreUpdateOrgsOpenBetaStatsFunc struct {
+	defaultHook func(context.Context, string, int32) error
+	hooks       []func(context.Context, string, int32) error
+	history     []OrgStoreUpdateOrgsOpenBetaStatsFuncCall
+	mutex       sync.Mutex
+}
+
+// UpdateOrgsOpenBetaStats delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockOrgStore) UpdateOrgsOpenBetaStats(v0 context.Context, v1 string, v2 int32) error {
+	r0 := m.UpdateOrgsOpenBetaStatsFunc.nextHook()(v0, v1, v2)
+	m.UpdateOrgsOpenBetaStatsFunc.appendCall(OrgStoreUpdateOrgsOpenBetaStatsFuncCall{v0, v1, v2, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the
+// UpdateOrgsOpenBetaStats method of the parent MockOrgStore instance is
+// invoked and the hook queue is empty.
+func (f *OrgStoreUpdateOrgsOpenBetaStatsFunc) SetDefaultHook(hook func(context.Context, string, int32) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// UpdateOrgsOpenBetaStats method of the parent MockOrgStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *OrgStoreUpdateOrgsOpenBetaStatsFunc) PushHook(hook func(context.Context, string, int32) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *OrgStoreUpdateOrgsOpenBetaStatsFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, string, int32) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *OrgStoreUpdateOrgsOpenBetaStatsFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, string, int32) error {
+		return r0
+	})
+}
+
+func (f *OrgStoreUpdateOrgsOpenBetaStatsFunc) nextHook() func(context.Context, string, int32) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *OrgStoreUpdateOrgsOpenBetaStatsFunc) appendCall(r0 OrgStoreUpdateOrgsOpenBetaStatsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of OrgStoreUpdateOrgsOpenBetaStatsFuncCall
+// objects describing the invocations of this function.
+func (f *OrgStoreUpdateOrgsOpenBetaStatsFunc) History() []OrgStoreUpdateOrgsOpenBetaStatsFuncCall {
+	f.mutex.Lock()
+	history := make([]OrgStoreUpdateOrgsOpenBetaStatsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// OrgStoreUpdateOrgsOpenBetaStatsFuncCall is an object that describes an
+// invocation of method UpdateOrgsOpenBetaStats on an instance of
+// MockOrgStore.
+type OrgStoreUpdateOrgsOpenBetaStatsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 int32
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c OrgStoreUpdateOrgsOpenBetaStatsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c OrgStoreUpdateOrgsOpenBetaStatsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
 }
 
 // OrgStoreWithFunc describes the behavior when the With method of the

--- a/internal/database/orgs.go
+++ b/internal/database/orgs.go
@@ -31,6 +31,7 @@ func (e *OrgNotFoundError) NotFound() bool {
 var errOrgNameAlreadyExists = errors.New("organization name is already taken (by a user or another organization)")
 
 type OrgStore interface {
+	AddOrgsOpenBetaStats(ctx context.Context, userID int32, data string) (string, error)
 	Count(context.Context, OrgsListOptions) (int, error)
 	Create(ctx context.Context, name string, displayName *string) (*types.Org, error)
 	Delete(ctx context.Context, id int32) (err error)
@@ -43,6 +44,7 @@ type OrgStore interface {
 	List(context.Context, *OrgsListOptions) ([]*types.Org, error)
 	Transact(context.Context) (OrgStore, error)
 	Update(ctx context.Context, id int32, displayName *string) (*types.Org, error)
+	UpdateOrgsOpenBetaStats(ctx context.Context, id string, orgID int32) error
 	With(basestore.ShareableStore) OrgStore
 	basestore.ShareableStore
 }
@@ -354,4 +356,18 @@ func (o *orgStore) HardDelete(ctx context.Context, id int32) (err error) {
 	}
 
 	return nil
+}
+
+func (o *orgStore) AddOrgsOpenBetaStats(ctx context.Context, userID int32, data string) (id string, err error) {
+	query := sqlf.Sprintf("INSERT INTO orgs_open_beta_stats(user_id, data) VALUES(%d, %s) RETURNING id;", userID, data)
+
+	err = o.Handle().DB().QueryRowContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...).Scan(&id)
+	return id, err
+}
+
+func (o *orgStore) UpdateOrgsOpenBetaStats(ctx context.Context, id string, orgID int32) error {
+	query := sqlf.Sprintf("UPDATE orgs_open_beta_stats SET org_id=%d WHERE id=%s;", orgID, id)
+
+	_, err := o.Handle().DB().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
+	return err
 }

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1784,6 +1784,20 @@ Referenced by:
 
 ```
 
+# Table "public.orgs_open_beta_stats"
+```
+   Column   |           Type           | Collation | Nullable |      Default      
+------------+--------------------------+-----------+----------+-------------------
+ id         | uuid                     |           | not null | gen_random_uuid()
+ user_id    | integer                  |           |          | 
+ org_id     | integer                  |           |          | 
+ created_at | timestamp with time zone |           |          | now()
+ data       | jsonb                    |           | not null | '{}'::jsonb
+Indexes:
+    "orgs_open_beta_stats_pkey" PRIMARY KEY, btree (id)
+
+```
+
 # Table "public.out_of_band_migrations"
 ```
           Column          |           Type           | Collation | Nullable |                      Default                       

--- a/migrations/frontend/1646652951/down.sql
+++ b/migrations/frontend/1646652951/down.sql
@@ -1,0 +1,2 @@
+-- Undo the changes made in the up migration
+DROP TABLE IF EXISTS orgs_open_beta_stats;

--- a/migrations/frontend/1646652951/metadata.yaml
+++ b/migrations/frontend/1646652951/metadata.yaml
@@ -1,0 +1,2 @@
+name: store_org_open_beta_metadata
+parents: [1646306565]

--- a/migrations/frontend/1646652951/up.sql
+++ b/migrations/frontend/1646652951/up.sql
@@ -1,0 +1,16 @@
+-- Perform migration here.
+--
+-- See /migrations/README.md. Highlights:
+--  * Make migrations idempotent (use IF EXISTS)
+--  * Make migrations backwards-compatible (old readers/writers must continue to work)
+--  * If you are using CREATE INDEX CONCURRENTLY, then make sure that only one statement
+--    is defined per file, and that each such statement is NOT wrapped in a transaction.
+--    Each such migration must also declare "createIndexConcurrently: true" in their
+--    associated metadata.yaml file.
+CREATE TABLE IF NOT EXISTS orgs_open_beta_stats (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id integer,
+    org_id integer,
+    created_at timestamptz DEFAULT now(),
+    data jsonb NOT NULL DEFAULT '{}'
+);


### PR DESCRIPTION
As part of CLOUD-311, we need to collect some metadata about how many devs the org has, use cases customers want to cover with sourcegraph, etc. We have decided to temporarily store this data in postgres until we launch the GA, as that was the quickest solution that ticked all the boxes.

## Test plan

Planning on unit testing and manually testing this locally.


