### PR TITLE
sg: add 'codeintel' commandset and alias enterprise-codeintel to it

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -774,7 +774,7 @@ commandsets:
     env:
       SOURCEGRAPHDOTCOM_MODE: true
 
-  enterprise-codeintel:
+  codeintel: &codeintel_set
     requiresDevPrivate: true
     checks:
       - docker
@@ -803,6 +803,9 @@ commandsets:
       - jaeger
       - grafana
       - prometheus
+
+  enterprise-codeintel:
+    <<: *codeintel_set
 
   enterprise-codeinsights:
     requiresDevPrivate: true


### PR DESCRIPTION
Petition was started to rename this. Turns out we can alias it.

## Test plan

- Ran `sg start enterprise-codeintel`
- Ran `sg start codeintel`


