### PR TITLE
insights: fix sql error on landing page when no insights exist

### DIFF
--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -126,6 +126,10 @@ func (s *InsightStore) GetAll(ctx context.Context, args InsightQueryArgs) ([]typ
 	if err != nil {
 		return nil, err
 	}
+	if len(insightIds) == 0 {
+		return []types.InsightViewSeries{}, nil
+	}
+
 	insightIdElems := make([]*sqlf.Query, 0, len(insightIds))
 	for _, id := range insightIds {
 		insightIdElems = append(insightIdElems, sqlf.Sprintf("%s", id))

--- a/enterprise/internal/insights/store/insight_store_test.go
+++ b/enterprise/internal/insights/store/insight_store_test.go
@@ -256,6 +256,19 @@ func TestGetAll(t *testing.T) {
 	timescale, cleanup := insightsdbtesting.TimescaleDB(t)
 	defer cleanup()
 	now := time.Now().Truncate(time.Microsecond).Round(0)
+	ctx := context.Background()
+
+	// First test the method on an empty database.
+	t.Run("test empty database", func(t *testing.T) {
+		store := NewInsightStore(timescale)
+		got, err := store.GetAll(ctx, InsightQueryArgs{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff([]types.InsightViewSeries{}, got); diff != "" {
+			t.Errorf("unexpected insight view series want/got: %s", diff)
+		}
+	})
 
 	// Set up some insight views to test pagination and permissions.
 	_, err := timescale.Exec(`INSERT INTO insight_view (id, title, description, unique_id)
@@ -305,8 +318,6 @@ func TestGetAll(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	ctx := context.Background()
 
 	t.Run("test all results", func(t *testing.T) {
 		store := NewInsightStore(timescale)


### PR DESCRIPTION
closes #32510

## Test plan
Ran insight store unit test.
Compared behaviour of insights landing page before/after change, with a sg instance launched using `sg start enterprise-codeinsights`

Prior to the change, `insights/` and `/insights/dashboards` would display an SQL error.
After the change, the landing page is correct and invites you to create an insight.