### PR TITLE
search: Fix backspace item deletion bug

### DIFF
--- a/client/web/src/search/SearchStack.tsx
+++ b/client/web/src/search/SearchStack.tsx
@@ -186,7 +186,8 @@ export const SearchStack: React.FunctionComponent<SearchStackProps> = ({ initial
     // Handles key events on the whole list
     const handleKey = useCallback(
         (event: KeyboardEvent): void => {
-            const hasMeta = (isMacPlatform_ && event.metaKey) || (!isMacPlatform_ && event.ctrlKey)
+            const hasMacMeta = isMacPlatform_ && event.metaKey
+            const hasMeta = hasMacMeta || (!isMacPlatform_ && event.ctrlKey)
 
             if (document.activeElement && document.activeElement.tagName === 'TEXTAREA') {
                 // Ignore any events originating from an annotations input
@@ -211,6 +212,12 @@ export const SearchStack: React.FunctionComponent<SearchStackProps> = ({ initial
                 // Delete selected entries
                 case 'Delete':
                     if (selectedEntries.length > 0) {
+                        deleteSelectedEntries()
+                    }
+                    break
+                // On macOS we also support CMD+Backpace for deletion
+                case 'Backspace':
+                    if (hasMacMeta && selectedEntries.length > 0) {
                         deleteSelectedEntries()
                     }
                     break

--- a/client/web/src/search/SearchStack.tsx
+++ b/client/web/src/search/SearchStack.tsx
@@ -210,7 +210,6 @@ export const SearchStack: React.FunctionComponent<SearchStackProps> = ({ initial
                     break
                 // Delete selected entries
                 case 'Delete':
-                case 'Backspace':
                     if (selectedEntries.length > 0) {
                         deleteSelectedEntries()
                     }

--- a/client/web/src/search/SearchStack.tsx
+++ b/client/web/src/search/SearchStack.tsx
@@ -188,6 +188,11 @@ export const SearchStack: React.FunctionComponent<SearchStackProps> = ({ initial
         (event: KeyboardEvent): void => {
             const hasMeta = (isMacPlatform_ && event.metaKey) || (!isMacPlatform_ && event.ctrlKey)
 
+            if (document.activeElement && document.activeElement.tagName === 'TEXTAREA') {
+                // Ignore any events originating from an annotations input
+                return
+            }
+
             switch (event.key) {
                 // Select all entries
                 case 'a':
@@ -534,12 +539,10 @@ const SearchStackEntryComponent: React.FunctionComponent<SearchStackEntryCompone
                     onBlur={() => setEntryAnnotation(entry, annotation)}
                     onChange={event => setAnnotation(event.currentTarget.value)}
                     onClick={stopPropagation}
-                    onKeyUp={event => {
-                        // This is used mainly to prevent deletion of the entry
-                        // when Delete or Backspace are pressed (one of the
-                        // ancestors listens to keyup events to handle
-                        // keybindings)
-                        event.stopPropagation()
+                    onKeyDown={event => {
+                        if (event.key === 'Escape') {
+                            event.currentTarget.blur()
+                        }
                     }}
                 />
             )}


### PR DESCRIPTION
Fixes #32352 

This was caused by the fact that I switched from listing to key *up*
events to key *down* events, but didn't make the same change to the
event handler bound to the textarea, so all key events bubbled up to the
parent.

Instead of relying on stopping the event propagation, the list event
handler now checks whether an annotation textarea is focused and if yes
it ignores the event.

This commit also adds the ability to remove focus from the annotation
textarea by pressing Escape.



## Test plan

With enabled search stack feature:

- Navigate to any search, open/expand the notepad widget and add the current search. If the current search is not automatically selected, select it.
- Open the selected item's annotation input (if not already open) and enter any text.
- Press backspace or delete to delete text. The selected item does not get deleted.
- Press Escape, the textarea looses focus

