### PR TITLE
Repo aware code monitors: populate feature flags and gate `after:` filter

### DIFF
--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -12,6 +12,7 @@ import (
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
@@ -169,6 +170,7 @@ func (r *queryRunner) Handle(ctx context.Context, record workerutil.Record) (err
 	// For all downstream actions (specifically executing searches),
 	// we should run as the user who owns the code monitor.
 	ctx = actor.WithActor(ctx, actor.FromUser(m.UserID))
+	ctx = featureflag.WithFlags(ctx, r.db.FeatureFlags())
 
 	settings, err := settings(ctx)
 	if err != nil {


### PR DESCRIPTION
This adds feature flags to the context after setting an artificial actor for the search.
It then uses those feature flags to check whether we should be adding an `after:` filter.

Stacked on #32512 
Pulled from #32464 

## Test plan

No visible change. Currently behind a feature flag that doesn't actually do anything yet.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


