### PR TITLE
Repo aware monitors: add cm_last_searched table

### DIFF
--- a/enterprise/internal/database/code_monitor_last_searched.go
+++ b/enterprise/internal/database/code_monitor_last_searched.go
@@ -1,0 +1,45 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/keegancsmith/sqlf"
+	"github.com/lib/pq"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func (s *codeMonitorStore) UpsertLastSearched(ctx context.Context, monitorID, argsHash int64, commitOIDs []string) error {
+	rawQuery := `
+	INSERT INTO cm_last_searched (monitor_id, args_hash, commit_oids)
+	VALUES (%s, %s, %s)
+	ON CONFLICT (monitor_id, args_hash) DO UPDATE
+	SET commit_oids = %s
+	`
+
+	// Appease non-null constraint on column
+	if commitOIDs == nil {
+		commitOIDs = []string{}
+	}
+	q := sqlf.Sprintf(rawQuery, monitorID, argsHash, pq.StringArray(commitOIDs), pq.StringArray(commitOIDs))
+	return s.Exec(ctx, q)
+}
+
+func (s *codeMonitorStore) GetLastSearched(ctx context.Context, monitorID, argsHash int64) ([]string, error) {
+	rawQuery := `
+	SELECT commit_oids
+	FROM cm_last_searched
+	WHERE monitor_id = %s
+		AND args_hash = %s
+	LIMIT 1
+	`
+
+	q := sqlf.Sprintf(rawQuery, monitorID, argsHash)
+	var commitOIDs []string
+	err := s.QueryRow(ctx, q).Scan((*pq.StringArray)(&commitOIDs))
+	if err != nil && errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	return commitOIDs, err
+}

--- a/enterprise/internal/database/code_monitor_last_searched_test.go
+++ b/enterprise/internal/database/code_monitor_last_searched_test.go
@@ -1,0 +1,99 @@
+package database
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func TestCodeMonitorStoreLastSearched(t *testing.T) {
+	t.Parallel()
+
+	type testFixtures struct {
+		User    *types.User
+		Monitor *Monitor
+	}
+	populateFixtures := func(db EnterpriseDB) testFixtures {
+		ctx := context.Background()
+		u, err := db.Users().Create(ctx, database.NewUser{Email: "test", Username: "test", EmailVerificationCode: "test"})
+		require.NoError(t, err)
+		ctx = actor.WithActor(ctx, actor.FromUser(u.ID))
+		m, err := db.CodeMonitors().CreateMonitor(ctx, MonitorArgs{NamespaceUserID: &u.ID})
+		require.NoError(t, err)
+		return testFixtures{User: u, Monitor: m}
+	}
+
+	t.Run("insert get upsert get", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		db := NewEnterpriseDB(database.NewDB(dbtest.NewDB(t)))
+		fixtures := populateFixtures(db)
+		cm := db.CodeMonitors()
+
+		// Insert
+		insertLastSearched := []string{"commit1", "commit2"}
+		err := cm.UpsertLastSearched(ctx, fixtures.Monitor.ID, 3851, insertLastSearched)
+		require.NoError(t, err)
+
+		// Get
+		lastSearched, err := cm.GetLastSearched(ctx, fixtures.Monitor.ID, 3851)
+		require.NoError(t, err)
+		require.Equal(t, insertLastSearched, lastSearched)
+
+		// Update
+		updateLastSearched := []string{"commit3", "commit4"}
+		err = cm.UpsertLastSearched(ctx, fixtures.Monitor.ID, 3851, updateLastSearched)
+		require.NoError(t, err)
+
+		// Get
+		lastSearched, err = cm.GetLastSearched(ctx, fixtures.Monitor.ID, 3851)
+		require.NoError(t, err)
+		require.Equal(t, updateLastSearched, lastSearched)
+	})
+
+	t.Run("no error for missing get", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		db := NewEnterpriseDB(database.NewDB(dbtest.NewDB(t)))
+		fixtures := populateFixtures(db)
+		cm := db.CodeMonitors()
+
+		// GetLastSearched should not return an error for a monitor that hasn't
+		// been run yet. It should just return an empty value for lastSearched
+		lastSearched, err := cm.GetLastSearched(ctx, fixtures.Monitor.ID+1, 19793)
+		require.NoError(t, err)
+		require.Empty(t, lastSearched)
+	})
+
+	t.Run("no error for missing get", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		db := NewEnterpriseDB(database.NewDB(dbtest.NewDB(t)))
+		fixtures := populateFixtures(db)
+		cm := db.CodeMonitors()
+
+		// Insert with nil last searched
+		err := cm.UpsertLastSearched(ctx, fixtures.Monitor.ID, 3851, nil)
+		require.NoError(t, err)
+
+		// Get nil last searched
+		lastSearched, err := cm.GetLastSearched(ctx, fixtures.Monitor.ID, 3851)
+		require.NoError(t, err)
+		require.Empty(t, lastSearched)
+
+		// Insert with empty last searched
+		err = cm.UpsertLastSearched(ctx, fixtures.Monitor.ID, 3852, []string{})
+		require.NoError(t, err)
+
+		// Get nil last searched
+		lastSearched, err = cm.GetLastSearched(ctx, fixtures.Monitor.ID, 3852)
+		require.NoError(t, err)
+		require.Empty(t, lastSearched)
+	})
+}

--- a/enterprise/internal/database/code_monitors.go
+++ b/enterprise/internal/database/code_monitors.go
@@ -80,6 +80,9 @@ type CodeMonitorStore interface {
 	GetActionJobMetadata(ctx context.Context, jobID int32) (*ActionJobMetadata, error)
 	GetActionJob(ctx context.Context, jobID int32) (*ActionJob, error)
 	EnqueueActionJobsForMonitor(ctx context.Context, monitorID int64, triggerJob int32) ([]*ActionJob, error)
+
+	UpsertLastSearched(ctx context.Context, monitorID int64, argsHash int64, lastSearched []string) error
+	GetLastSearched(ctx context.Context, monitorID int64, argsHash int64) ([]string, error)
 }
 
 // codeMonitorStore exposes methods to read and write codemonitors domain models

--- a/enterprise/internal/database/mocks.go
+++ b/enterprise/internal/database/mocks.go
@@ -107,6 +107,9 @@ type MockCodeMonitorStore struct {
 	// GetEmailActionFunc is an instance of a mock function object
 	// controlling the behavior of the method GetEmailAction.
 	GetEmailActionFunc *CodeMonitorStoreGetEmailActionFunc
+	// GetLastSearchedFunc is an instance of a mock function object
+	// controlling the behavior of the method GetLastSearched.
+	GetLastSearchedFunc *CodeMonitorStoreGetLastSearchedFunc
 	// GetMonitorFunc is an instance of a mock function object controlling
 	// the behavior of the method GetMonitor.
 	GetMonitorFunc *CodeMonitorStoreGetMonitorFunc
@@ -182,6 +185,9 @@ type MockCodeMonitorStore struct {
 	// UpdateWebhookActionFunc is an instance of a mock function object
 	// controlling the behavior of the method UpdateWebhookAction.
 	UpdateWebhookActionFunc *CodeMonitorStoreUpdateWebhookActionFunc
+	// UpsertLastSearchedFunc is an instance of a mock function object
+	// controlling the behavior of the method UpsertLastSearched.
+	UpsertLastSearchedFunc *CodeMonitorStoreUpsertLastSearchedFunc
 }
 
 // NewMockCodeMonitorStore creates a new mock of the CodeMonitorStore
@@ -324,6 +330,11 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 				return nil, nil
 			},
 		},
+		GetLastSearchedFunc: &CodeMonitorStoreGetLastSearchedFunc{
+			defaultHook: func(context.Context, int64, int64) ([]string, error) {
+				return nil, nil
+			},
+		},
 		GetMonitorFunc: &CodeMonitorStoreGetMonitorFunc{
 			defaultHook: func(context.Context, int64) (*Monitor, error) {
 				return nil, nil
@@ -442,6 +453,11 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 		UpdateWebhookActionFunc: &CodeMonitorStoreUpdateWebhookActionFunc{
 			defaultHook: func(context.Context, int64, bool, bool, string) (*WebhookAction, error) {
 				return nil, nil
+			},
+		},
+		UpsertLastSearchedFunc: &CodeMonitorStoreUpsertLastSearchedFunc{
+			defaultHook: func(context.Context, int64, int64, []string) error {
+				return nil
 			},
 		},
 	}
@@ -586,6 +602,11 @@ func NewStrictMockCodeMonitorStore() *MockCodeMonitorStore {
 				panic("unexpected invocation of MockCodeMonitorStore.GetEmailAction")
 			},
 		},
+		GetLastSearchedFunc: &CodeMonitorStoreGetLastSearchedFunc{
+			defaultHook: func(context.Context, int64, int64) ([]string, error) {
+				panic("unexpected invocation of MockCodeMonitorStore.GetLastSearched")
+			},
+		},
 		GetMonitorFunc: &CodeMonitorStoreGetMonitorFunc{
 			defaultHook: func(context.Context, int64) (*Monitor, error) {
 				panic("unexpected invocation of MockCodeMonitorStore.GetMonitor")
@@ -706,6 +727,11 @@ func NewStrictMockCodeMonitorStore() *MockCodeMonitorStore {
 				panic("unexpected invocation of MockCodeMonitorStore.UpdateWebhookAction")
 			},
 		},
+		UpsertLastSearchedFunc: &CodeMonitorStoreUpsertLastSearchedFunc{
+			defaultHook: func(context.Context, int64, int64, []string) error {
+				panic("unexpected invocation of MockCodeMonitorStore.UpsertLastSearched")
+			},
+		},
 	}
 }
 
@@ -795,6 +821,9 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 		GetEmailActionFunc: &CodeMonitorStoreGetEmailActionFunc{
 			defaultHook: i.GetEmailAction,
 		},
+		GetLastSearchedFunc: &CodeMonitorStoreGetLastSearchedFunc{
+			defaultHook: i.GetLastSearched,
+		},
 		GetMonitorFunc: &CodeMonitorStoreGetMonitorFunc{
 			defaultHook: i.GetMonitor,
 		},
@@ -866,6 +895,9 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 		},
 		UpdateWebhookActionFunc: &CodeMonitorStoreUpdateWebhookActionFunc{
 			defaultHook: i.UpdateWebhookAction,
+		},
+		UpsertLastSearchedFunc: &CodeMonitorStoreUpsertLastSearchedFunc{
+			defaultHook: i.UpsertLastSearched,
 		},
 	}
 }
@@ -3873,6 +3905,120 @@ func (c CodeMonitorStoreGetEmailActionFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
+// CodeMonitorStoreGetLastSearchedFunc describes the behavior when the
+// GetLastSearched method of the parent MockCodeMonitorStore instance is
+// invoked.
+type CodeMonitorStoreGetLastSearchedFunc struct {
+	defaultHook func(context.Context, int64, int64) ([]string, error)
+	hooks       []func(context.Context, int64, int64) ([]string, error)
+	history     []CodeMonitorStoreGetLastSearchedFuncCall
+	mutex       sync.Mutex
+}
+
+// GetLastSearched delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockCodeMonitorStore) GetLastSearched(v0 context.Context, v1 int64, v2 int64) ([]string, error) {
+	r0, r1 := m.GetLastSearchedFunc.nextHook()(v0, v1, v2)
+	m.GetLastSearchedFunc.appendCall(CodeMonitorStoreGetLastSearchedFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the GetLastSearched
+// method of the parent MockCodeMonitorStore instance is invoked and the
+// hook queue is empty.
+func (f *CodeMonitorStoreGetLastSearchedFunc) SetDefaultHook(hook func(context.Context, int64, int64) ([]string, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetLastSearched method of the parent MockCodeMonitorStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *CodeMonitorStoreGetLastSearchedFunc) PushHook(hook func(context.Context, int64, int64) ([]string, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *CodeMonitorStoreGetLastSearchedFunc) SetDefaultReturn(r0 []string, r1 error) {
+	f.SetDefaultHook(func(context.Context, int64, int64) ([]string, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *CodeMonitorStoreGetLastSearchedFunc) PushReturn(r0 []string, r1 error) {
+	f.PushHook(func(context.Context, int64, int64) ([]string, error) {
+		return r0, r1
+	})
+}
+
+func (f *CodeMonitorStoreGetLastSearchedFunc) nextHook() func(context.Context, int64, int64) ([]string, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *CodeMonitorStoreGetLastSearchedFunc) appendCall(r0 CodeMonitorStoreGetLastSearchedFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of CodeMonitorStoreGetLastSearchedFuncCall
+// objects describing the invocations of this function.
+func (f *CodeMonitorStoreGetLastSearchedFunc) History() []CodeMonitorStoreGetLastSearchedFuncCall {
+	f.mutex.Lock()
+	history := make([]CodeMonitorStoreGetLastSearchedFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// CodeMonitorStoreGetLastSearchedFuncCall is an object that describes an
+// invocation of method GetLastSearched on an instance of
+// MockCodeMonitorStore.
+type CodeMonitorStoreGetLastSearchedFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int64
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 int64
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []string
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c CodeMonitorStoreGetLastSearchedFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c CodeMonitorStoreGetLastSearchedFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
 // CodeMonitorStoreGetMonitorFunc describes the behavior when the GetMonitor
 // method of the parent MockCodeMonitorStore instance is invoked.
 type CodeMonitorStoreGetMonitorFunc struct {
@@ -6537,6 +6683,120 @@ func (c CodeMonitorStoreUpdateWebhookActionFuncCall) Args() []interface{} {
 // invocation.
 func (c CodeMonitorStoreUpdateWebhookActionFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
+}
+
+// CodeMonitorStoreUpsertLastSearchedFunc describes the behavior when the
+// UpsertLastSearched method of the parent MockCodeMonitorStore instance is
+// invoked.
+type CodeMonitorStoreUpsertLastSearchedFunc struct {
+	defaultHook func(context.Context, int64, int64, []string) error
+	hooks       []func(context.Context, int64, int64, []string) error
+	history     []CodeMonitorStoreUpsertLastSearchedFuncCall
+	mutex       sync.Mutex
+}
+
+// UpsertLastSearched delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockCodeMonitorStore) UpsertLastSearched(v0 context.Context, v1 int64, v2 int64, v3 []string) error {
+	r0 := m.UpsertLastSearchedFunc.nextHook()(v0, v1, v2, v3)
+	m.UpsertLastSearchedFunc.appendCall(CodeMonitorStoreUpsertLastSearchedFuncCall{v0, v1, v2, v3, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the UpsertLastSearched
+// method of the parent MockCodeMonitorStore instance is invoked and the
+// hook queue is empty.
+func (f *CodeMonitorStoreUpsertLastSearchedFunc) SetDefaultHook(hook func(context.Context, int64, int64, []string) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// UpsertLastSearched method of the parent MockCodeMonitorStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *CodeMonitorStoreUpsertLastSearchedFunc) PushHook(hook func(context.Context, int64, int64, []string) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *CodeMonitorStoreUpsertLastSearchedFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, int64, int64, []string) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *CodeMonitorStoreUpsertLastSearchedFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, int64, int64, []string) error {
+		return r0
+	})
+}
+
+func (f *CodeMonitorStoreUpsertLastSearchedFunc) nextHook() func(context.Context, int64, int64, []string) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *CodeMonitorStoreUpsertLastSearchedFunc) appendCall(r0 CodeMonitorStoreUpsertLastSearchedFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of CodeMonitorStoreUpsertLastSearchedFuncCall
+// objects describing the invocations of this function.
+func (f *CodeMonitorStoreUpsertLastSearchedFunc) History() []CodeMonitorStoreUpsertLastSearchedFuncCall {
+	f.mutex.Lock()
+	history := make([]CodeMonitorStoreUpsertLastSearchedFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// CodeMonitorStoreUpsertLastSearchedFuncCall is an object that describes an
+// invocation of method UpsertLastSearched on an instance of
+// MockCodeMonitorStore.
+type CodeMonitorStoreUpsertLastSearchedFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int64
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 int64
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 []string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c CodeMonitorStoreUpsertLastSearchedFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c CodeMonitorStoreUpsertLastSearchedFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
 }
 
 // MockEnterpriseDB is a mock implementation of the EnterpriseDB interface

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -456,6 +456,26 @@ Referenced by:
 
 ```
 
+# Table "public.cm_last_searched"
+```
+   Column    |  Type  | Collation | Nullable | Default 
+-------------+--------+-----------+----------+---------
+ monitor_id  | bigint |           | not null | 
+ args_hash   | bigint |           | not null | 
+ commit_oids | text[] |           | not null | 
+Indexes:
+    "cm_last_searched_pkey" PRIMARY KEY, btree (monitor_id, args_hash)
+Foreign-key constraints:
+    "cm_last_searched_monitor_id_fkey" FOREIGN KEY (monitor_id) REFERENCES cm_monitors(id) ON DELETE CASCADE
+
+```
+
+The last searched commit hashes for the given code monitor and unique set of search arguments
+
+**args_hash**: A unique hash of the gitserver search arguments to identify this search job
+
+**commit_oids**: The set of commit OIDs that was previously successfully searched and should be excluded on the next run
+
 # Table "public.cm_monitors"
 ```
       Column       |           Type           | Collation | Nullable |                 Default                 
@@ -478,6 +498,7 @@ Foreign-key constraints:
     "cm_monitors_user_id_fk" FOREIGN KEY (namespace_user_id) REFERENCES users(id) ON DELETE CASCADE
 Referenced by:
     TABLE "cm_emails" CONSTRAINT "cm_emails_monitor" FOREIGN KEY (monitor) REFERENCES cm_monitors(id) ON DELETE CASCADE
+    TABLE "cm_last_searched" CONSTRAINT "cm_last_searched_monitor_id_fkey" FOREIGN KEY (monitor_id) REFERENCES cm_monitors(id) ON DELETE CASCADE
     TABLE "cm_slack_webhooks" CONSTRAINT "cm_slack_webhooks_monitor_fkey" FOREIGN KEY (monitor) REFERENCES cm_monitors(id) ON DELETE CASCADE
     TABLE "cm_queries" CONSTRAINT "cm_triggers_monitor" FOREIGN KEY (monitor) REFERENCES cm_monitors(id) ON DELETE CASCADE
     TABLE "cm_webhooks" CONSTRAINT "cm_webhooks_monitor_fkey" FOREIGN KEY (monitor) REFERENCES cm_monitors(id) ON DELETE CASCADE

--- a/migrations/frontend/1646847163/down.sql
+++ b/migrations/frontend/1646847163/down.sql
@@ -1,0 +1,3 @@
+-- Undo the changes made in the up migration
+
+DROP TABLE cm_last_searched;

--- a/migrations/frontend/1646847163/down.sql
+++ b/migrations/frontend/1646847163/down.sql
@@ -1,3 +1,3 @@
 -- Undo the changes made in the up migration
 
-DROP TABLE cm_last_searched;
+DROP TABLE IF EXISTS cm_last_searched;

--- a/migrations/frontend/1646847163/metadata.yaml
+++ b/migrations/frontend/1646847163/metadata.yaml
@@ -1,0 +1,2 @@
+name: code monitor last searched
+parents: [1646306565]

--- a/migrations/frontend/1646847163/up.sql
+++ b/migrations/frontend/1646847163/up.sql
@@ -1,0 +1,25 @@
+-- Perform migration here.
+--
+-- See /migrations/README.md. Highlights:
+--  * Make migrations idempotent (use IF EXISTS)
+--  * Make migrations backwards-compatible (old readers/writers must continue to work)
+--  * If you are using CREATE INDEX CONCURRENTLY, then make sure that only one statement
+--    is defined per file, and that each such statement is NOT wrapped in a transaction.
+--    Each such migration must also declare "createIndexConcurrently: true" in their
+--    associated metadata.yaml file.
+--  * If you are modifying Postgres extensions, you must also declare "privileged: true"
+--    in the associated metadata.yaml file.
+
+CREATE TABLE IF NOT EXISTS cm_last_searched (
+    monitor_id BIGINT NOT NULL REFERENCES cm_monitors(id) ON DELETE CASCADE,
+    args_hash BIGINT NOT NULL,
+    commit_oids text[] NOT NULL,
+    PRIMARY KEY (monitor_id, args_hash)
+);
+
+COMMENT ON TABLE cm_last_searched
+    IS 'The last searched commit hashes for the given code monitor and unique set of search arguments';
+COMMENT ON COLUMN cm_last_searched.args_hash
+    IS 'A unique hash of the gitserver search arguments to identify this search job';
+COMMENT ON COLUMN cm_last_searched.commit_oids
+    IS 'The set of commit OIDs that was previously successfully searched and should be excluded on the next run';


### PR DESCRIPTION
This adds a table that will store the set of commits that were
successfully searched. On subsequent runs, this set of commits (and all
commits reachable from those commits) will be excluded from the search.

Currently unused, but will be exercised behind the `cc-repo-aware-monitors`
feature flag in subsequent PRs.

Stacked on #32518
Pulled from #32464

## Test plan

Tests added for the new DB methods.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


