### PR TITLE
code monitoring: fix spacing when logs are empty

### DIFF
--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringLogs.module.scss
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringLogs.module.scss
@@ -3,3 +3,7 @@
     grid-template-columns: [name] minmax(auto, 1fr) [lastrun] min-content [end];
     align-items: center;
 }
+
+.empty {
+    margin-top: -1rem; // Remove default summary view margin
+}

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringLogs.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringLogs.story.tsx
@@ -48,3 +48,31 @@ add('open', () => (
         )}
     </WebStory>
 ))
+
+add('empty', () => {
+    const emptyMockedResponse: MockedResponse[] = [
+        {
+            request: {
+                query: getDocumentNode(CODE_MONITOR_EVENTS),
+                variables: { first: 20, after: null, triggerEventsFirst: 20, triggerEventsAfter: null },
+            },
+            result: {
+                data: {
+                    currentUser: {
+                        monitors: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null }, totalCount: 0 },
+                    },
+                },
+            },
+        },
+    ]
+
+    return (
+        <WebStory>
+            {() => (
+                <MockedTestProvider mocks={emptyMockedResponse}>
+                    <CodeMonitoringLogs now={() => parseISO('2022-02-14T16:21:00+00:00')} _testStartOpen={true} />
+                </MockedTestProvider>
+            )}
+        </WebStory>
+    )
+})

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringLogs.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringLogs.tsx
@@ -160,7 +160,7 @@ export const CodeMonitoringLogs: React.FunctionComponent<{ now?: () => Date; _te
                                 noun="monitor"
                                 pluralNoun="monitors"
                                 hasNextPage={hasNextPage}
-                                emptyElement={<div>You haven't created any monitors yet</div>}
+                                emptyElement={<div className={styles.empty}>You haven't created any monitors yet</div>}
                             />
                             {hasNextPage && <ShowMoreButton onClick={fetchMore} />}
                         </SummaryContainer>


### PR DESCRIPTION
Fixes spacing above message when there are no monitors in the logs.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/206864/157923350-d0277745-4c6f-45bf-b5db-61a3f8da0dd1.png)

### After

![image](https://user-images.githubusercontent.com/206864/157923431-76fb16c7-5221-4bb1-b3a9-2d9aed7e8c51.png)

## Test plan

- Storybook test added
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


