### PR TITLE
compute: fix merge issue passing flags

### DIFF
--- a/client/web/src/notebooks/blocks/compute/NotebookComputeBlock.tsx
+++ b/client/web/src/notebooks/blocks/compute/NotebookComputeBlock.tsx
@@ -106,7 +106,7 @@ export const NotebookComputeBlock: React.FunctionComponent<ComputeBlockProps> = 
         >
             <div className="elm">
                 {/* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */}
-                <ElmComponent src={Elm.Main} ports={setupPorts} flags={null} />
+                <ElmComponent src={Elm.Main} ports={setupPorts} flags={platformContext.sourcegraphURL} />
             </div>
         </NotebookBlock>
     )


### PR DESCRIPTION
A change in https://github.com/sourcegraph/sourcegraph/pull/32370 effectively reverted https://github.com/sourcegraph/sourcegraph/pull/32471 on accident, in this commit:
https://github.com/sourcegraph/sourcegraph/pull/32370/commits/24cf6ac76dc6be638bf09f04192f931fea26ddbc#diff-a36ff3a63dd65597105dbc4f0f71fee3d05ef8b3669ef04a9e8c1725d5395437R109

This restores the behavior in https://github.com/sourcegraph/sourcegraph/pull/32471

## Test plan
Same as [previous PR.](https://github.com/sourcegraph/sourcegraph/pull/32471)


