### PR TITLE
fix insights context init

### DIFF
--- a/client/web/src/enterprise/insights/CodeInsightsAppRouter.tsx
+++ b/client/web/src/enterprise/insights/CodeInsightsAppRouter.tsx
@@ -14,7 +14,6 @@ import { withAuthenticatedUser } from '../../auth/withAuthenticatedUser'
 import { HeroPage } from '../../components/HeroPage'
 
 import { CodeInsightsBackendContext } from './core/backend/code-insights-backend-context'
-import { useGetApi } from './hooks/use-get-api'
 import { GaConfirmationModal } from './modals/GaConfirmationModal'
 import {
     CodeInsightsRootPage,
@@ -52,14 +51,8 @@ export const CodeInsightsAppRouter = withAuthenticatedUser<CodeInsightsAppRouter
     const { telemetryService, authenticatedUser } = props
 
     const match = useRouteMatch()
-    const api = useGetApi()
-
-    if (!api) {
-        return null
-    }
-
     return (
-        <CodeInsightsBackendContext.Provider value={api}>
+        <>
             <Route path="*" component={GaConfirmationModal} />
 
             <Switch>
@@ -113,7 +106,7 @@ export const CodeInsightsAppRouter = withAuthenticatedUser<CodeInsightsAppRouter
 
                 <Route component={NotFoundPage} key="hardcoded-key" />
             </Switch>
-        </CodeInsightsBackendContext.Provider>
+        </>
     )
 })
 

--- a/client/web/src/enterprise/insights/CodeInsightsRouter.tsx
+++ b/client/web/src/enterprise/insights/CodeInsightsRouter.tsx
@@ -7,6 +7,9 @@ import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
 import { AuthenticatedUser } from '../../auth'
 
+import { CodeInsightsBackendContext } from './core/backend/code-insights-backend-context'
+import { useGetApi } from './hooks/use-get-api'
+
 const CodeInsightsAppLazyRouter = lazyComponent(() => import('./CodeInsightsAppRouter'), 'CodeInsightsAppRouter')
 
 const CodeInsightsDotComGetStartedLazy = lazyComponent(
@@ -29,9 +32,19 @@ export interface CodeInsightsRouterProps extends SettingsCascadeProps<Settings>,
 }
 
 export const CodeInsightsRouter: React.FunctionComponent<CodeInsightsRouterProps> = props => {
-    if (props.isSourcegraphDotCom) {
-        return <CodeInsightsDotComGetStartedLazy telemetryService={props.telemetryService} />
+    const api = useGetApi()
+
+    if (!api) {
+        return null
     }
 
-    return <CodeInsightsAppLazyRouter {...props} />
+    return (
+        <CodeInsightsBackendContext.Provider value={api}>
+            {props.isSourcegraphDotCom ? (
+                <CodeInsightsDotComGetStartedLazy telemetryService={props.telemetryService} />
+            ) : (
+                <CodeInsightsAppLazyRouter {...props} />
+            )}
+        </CodeInsightsBackendContext.Provider>
+    )
 }


### PR DESCRIPTION
moves provider context up one level so that all routes have access

## Test plan

View insights main page on dotcom. Should not throw error.

Note for reviewing locally. run `sg start web-standalone` to get a local instance that runs in "dotcom mode".