### PR TITLE
unpack: Fallback to untar when tgz isn't compressed

### DIFF
--- a/internal/unpack/unpack.go
+++ b/internal/unpack/unpack.go
@@ -17,6 +17,7 @@ package unpack
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"io"
 	"io/fs"
@@ -38,10 +39,33 @@ type Opts struct {
 
 // Tgz unpacks the contents of the given gzip compressed tarball under dir.
 func Tgz(r io.Reader, dir string, opt Opts) error {
-	gzr, err := gzip.NewReader(r)
+	// Since we fallback to untar the input reader if it isn't
+	// a gzipped tar, we need to seek back the bytes already read
+	// from gzip.NewReader() trying to read a gzip header, so make
+	// sure we have an io.ReadSeeker.
+	tgz, ok := r.(io.ReadSeeker)
+	if !ok {
+		bs, err := io.ReadAll(r)
+		if err != nil {
+			return err
+		}
+		tgz = bytes.NewReader(bs)
+	}
+
+	gzr, err := gzip.NewReader(tgz)
 	if err != nil {
+		if err == gzip.ErrHeader || err == gzip.ErrChecksum {
+			// Some archives aren't compressed at all, despite the tgz extension.
+			// Try to untar them without gzip decompression.
+			if _, err = tgz.Seek(0, io.SeekStart); err != nil {
+				return err
+			}
+			return Tar(tgz, dir, opt)
+		}
 		return err
 	}
+
+	defer gzr.Close()
 	return Tar(gzr, dir, opt)
 }
 

--- a/internal/unpack/unpack_test.go
+++ b/internal/unpack/unpack_test.go
@@ -17,6 +17,24 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
+func TestTgzFallback(t *testing.T) {
+  tar := makeTar(t, &fileInfo{path: "foo", contents: "bar", mode: 0655})
+
+  t.Run("with-io-read-seeker", func(t *testing.T) {
+    err := Tgz(bytes.NewReader(tar), t.TempDir(), Opts{})
+    if err != nil {
+      t.Fatal(err)
+    }
+  })
+
+  t.Run("without-io-read-seeker", func(t *testing.T) {
+    err := Tgz(bytes.NewBuffer(tar), t.TempDir(), Opts{})
+    if err != nil {
+      t.Fatal(err)
+    }
+  })
+}
+
 // TestUnpack tests general properties of all unpack functions.
 func TestUnpack(t *testing.T) {
 	type packer struct {

--- a/internal/unpack/unpack_test.go
+++ b/internal/unpack/unpack_test.go
@@ -18,21 +18,21 @@ import (
 )
 
 func TestTgzFallback(t *testing.T) {
-  tar := makeTar(t, &fileInfo{path: "foo", contents: "bar", mode: 0655})
+	tar := makeTar(t, &fileInfo{path: "foo", contents: "bar", mode: 0655})
 
-  t.Run("with-io-read-seeker", func(t *testing.T) {
-    err := Tgz(bytes.NewReader(tar), t.TempDir(), Opts{})
-    if err != nil {
-      t.Fatal(err)
-    }
-  })
+	t.Run("with-io-read-seeker", func(t *testing.T) {
+		err := Tgz(bytes.NewReader(tar), t.TempDir(), Opts{})
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 
-  t.Run("without-io-read-seeker", func(t *testing.T) {
-    err := Tgz(bytes.NewBuffer(tar), t.TempDir(), Opts{})
-    if err != nil {
-      t.Fatal(err)
-    }
-  })
+	t.Run("without-io-read-seeker", func(t *testing.T) {
+		err := Tgz(bytes.NewBuffer(tar), t.TempDir(), Opts{})
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 }
 
 // TestUnpack tests general properties of all unpack functions.


### PR DESCRIPTION
This commit makes `unpack.Tgz` fallback to `unpack.Tar` when the input
isn't gzip compressed.

Some npm package tarballs, despite ending with the `.tgz` extension,
aren't actually gzip compressed, only tar-ed up.

Example: https://registry.npmjs.org/@types/tmp/-/tmp-0.0.28.tgz


<img width="645" alt="image" src="https://user-images.githubusercontent.com/67471/157975815-4d035e98-b249-4d01-9235-7d2b4b56d31b.png">

From https://sourcegraph.com/github.com/golang/go@baf61e4a67789e20f019507287a324cca06bed42/-/blob/src/compress/gzip/gunzip.go?L185
<img width="218" alt="image" src="https://user-images.githubusercontent.com/67471/157976012-a6ec2bc2-d881-46ed-9cba-9814ea688d1c.png">

Closes #32052

## Test plan

Integration test.


