### PR TITLE
search: separate symbol jobs for zoekt and searcher

### DIFF
--- a/internal/search/searcher/symbol_search_job.go
+++ b/internal/search/searcher/symbol_search_job.go
@@ -1,0 +1,156 @@
+package searcher
+
+import (
+	"context"
+	"sort"
+
+	"github.com/neelance/parallel"
+	"github.com/opentracing/opentracing-go/ext"
+	otlog "github.com/opentracing/opentracing-go/log"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+)
+
+type SymbolSearcher struct {
+	PatternInfo *search.TextPatternInfo
+	Repos       []*search.RepositoryRevisions // the set of repositories to search with searcher.
+	Limit       int
+}
+
+// Run calls the searcher service to search symbols.
+func (s *SymbolSearcher) Run(ctx context.Context, _ database.DB, stream streaming.Sender) (_ *search.Alert, err error) {
+	tr, ctx := trace.New(ctx, "SymbolSearcher", "")
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	run := parallel.NewRun(conf.SearchSymbolsParallelism())
+
+	for _, repoRevs := range s.Repos {
+		repoRevs := repoRevs
+		if ctx.Err() != nil {
+			break
+		}
+		if len(repoRevs.RevSpecs()) == 0 {
+			continue
+		}
+		run.Acquire()
+		goroutine.Go(func() {
+			defer run.Release()
+
+			matches, err := searchInRepo(ctx, repoRevs, s.PatternInfo, s.Limit)
+			status, limitHit, err := search.HandleRepoSearchResult(repoRevs, len(matches) > s.Limit, false, err)
+			stream.Send(streaming.SearchEvent{
+				Results: matches,
+				Stats: streaming.Stats{
+					Status:     status,
+					IsLimitHit: limitHit,
+				},
+			})
+			if err != nil {
+				tr.LogFields(otlog.String("repo", string(repoRevs.Repo.Name)), otlog.Error(err))
+				// Only record error if we haven't timed out.
+				if ctx.Err() == nil {
+					cancel()
+					run.Error(err)
+				}
+			}
+		})
+	}
+
+	return nil, run.Wait()
+}
+
+func (s *SymbolSearcher) Name() string {
+	return "SymbolSearcher"
+}
+
+func searchInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, patternInfo *search.TextPatternInfo, limit int) (res []result.Match, err error) {
+	span, ctx := ot.StartSpanFromContext(ctx, "Search symbols in repo")
+	defer func() {
+		if err != nil {
+			ext.Error.Set(span, true)
+			span.LogFields(otlog.Error(err))
+		}
+		span.Finish()
+	}()
+	span.SetTag("repo", string(repoRevs.Repo.Name))
+
+	inputRev := repoRevs.RevSpecs()[0]
+	span.SetTag("rev", inputRev)
+	// Do not trigger a repo-updater lookup (e.g.,
+	// backend.{GitRepo,Repos.ResolveRev}) because that would slow this operation
+	// down by a lot (if we're looping over many repos). This means that it'll fail if a
+	// repo is not on gitserver.
+	commitID, err := git.ResolveRevision(ctx, repoRevs.GitserverRepo(), inputRev, git.ResolveRevisionOptions{})
+	if err != nil {
+		return nil, err
+	}
+	span.SetTag("commit", string(commitID))
+
+	symbols, err := backend.Symbols.ListTags(ctx, search.SymbolsParameters{
+		Repo:            repoRevs.Repo.Name,
+		CommitID:        commitID,
+		Query:           patternInfo.Pattern,
+		IsCaseSensitive: patternInfo.IsCaseSensitive,
+		IsRegExp:        patternInfo.IsRegExp,
+		IncludePatterns: patternInfo.IncludePatterns,
+		ExcludePattern:  patternInfo.ExcludePattern,
+		// Ask for limit + 1 so we can detect whether there are more results than the limit.
+		First: limit + 1,
+	})
+
+	// All symbols are from the same repo, so we can just partition them by path
+	// to build file matches
+	return symbolsToMatches(symbols, repoRevs.Repo, commitID, inputRev), err
+}
+
+func symbolsToMatches(symbols []result.Symbol, repo types.MinimalRepo, commitID api.CommitID, inputRev string) result.Matches {
+	symbolsByPath := make(map[string][]result.Symbol)
+	for _, symbol := range symbols {
+		cur := symbolsByPath[symbol.Path]
+		symbolsByPath[symbol.Path] = append(cur, symbol)
+	}
+
+	// Create file matches from partitioned symbols
+	matches := make(result.Matches, 0, len(symbolsByPath))
+	for path, symbols := range symbolsByPath {
+		file := result.File{
+			Path:     path,
+			Repo:     repo,
+			CommitID: commitID,
+			InputRev: &inputRev,
+		}
+
+		symbolMatches := make([]*result.SymbolMatch, 0, len(symbols))
+		for _, symbol := range symbols {
+			symbolMatches = append(symbolMatches, &result.SymbolMatch{
+				File:   &file,
+				Symbol: symbol,
+			})
+		}
+
+		matches = append(matches, &result.FileMatch{
+			Symbols: symbolMatches,
+			File:    file,
+		})
+	}
+
+	// Make the results deterministic
+	sort.Sort(matches)
+	return matches
+}

--- a/internal/search/zoekt/symbol_search_job.go
+++ b/internal/search/zoekt/symbol_search_job.go
@@ -1,0 +1,63 @@
+package zoekt
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/zoekt"
+	zoektquery "github.com/google/zoekt/query"
+	otlog "github.com/opentracing/opentracing-go/log"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/filter"
+	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+)
+
+type ZoektSymbolSearch struct {
+	Repos          *IndexedRepoRevs // the set of indexed repository revisions to search.
+	Query          zoektquery.Q
+	FileMatchLimit int32
+	Select         filter.SelectPath
+	Zoekt          zoekt.Streamer
+	Since          func(time.Time) time.Duration `json:"-"` // since if non-nil will be used instead of time.Since. For tests
+}
+
+// Run calls the zoekt backend to search symbols
+func (z *ZoektSymbolSearch) Run(ctx context.Context, _ database.DB, stream streaming.Sender) (_ *search.Alert, err error) {
+	tr, ctx := trace.New(ctx, "ZoektSymbolSearch", "")
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
+
+	if z.Repos == nil {
+		return nil, nil
+	}
+	if len(z.Repos.RepoRevs) == 0 {
+		return nil, nil
+	}
+
+	since := time.Since
+	if z.Since != nil {
+		since = z.Since
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	err = zoektSearch(ctx, z.Repos, z.Query, search.SymbolRequest, z.Zoekt, z.FileMatchLimit, z.Select, since, stream)
+	if err != nil {
+		tr.LogFields(otlog.Error(err))
+		// Only record error if we haven't timed out.
+		if ctx.Err() == nil {
+			cancel()
+			return nil, err
+		}
+	}
+	return nil, nil
+}
+
+func (z *ZoektSymbolSearch) Name() string {
+	return "ZoektSymbolSearch"
+}


### PR DESCRIPTION
This creates two separate jobs for symbol search: one that runs on the Zoekt backend, and one that runs on the searcher backend. This is the separation of the [current symbol search job](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/search/symbol/symbol.go?L328-415&subtree=true), which does both. Basically I'm doing the same thing for symbol search that I did for text search, so that we can page over symbol jobs that need paging. This is the first of 3 PRs, the third PR does the switch to use this: https://github.com/sourcegraph/sourcegraph/pull/32538. Everything was tested before I put the PRs up for review :-) 

This is setup, it is not used yet.



## Test plan
Unused currently.

