### PR TITLE
search: populate repos for symbol search jobs

### DIFF
--- a/internal/search/job/mapper.go
+++ b/internal/search/job/mapper.go
@@ -19,7 +19,9 @@ type Mapper struct {
 
 	// Search Jobs (leaf nodes)
 	MapZoektRepoSubsetSearchJob    func(*zoekt.ZoektRepoSubsetSearch) *zoekt.ZoektRepoSubsetSearch
+	MapZoektSymbolSearchJob        func(*zoekt.ZoektSymbolSearch) *zoekt.ZoektSymbolSearch
 	MapSearcherJob                 func(*searcher.Searcher) *searcher.Searcher
+	MapSymbolSearcherJob           func(*searcher.SymbolSearcher) *searcher.SymbolSearcher
 	MapRepoSearchJob               func(*run.RepoSearch) *run.RepoSearch
 	MapRepoUniverseTextSearchJob   func(*zoekt.GlobalSearch) *zoekt.GlobalSearch
 	MapStructuralSearchJob         func(*structural.StructuralSearch) *structural.StructuralSearch
@@ -63,9 +65,21 @@ func (m *Mapper) Map(job Job) Job {
 		}
 		return j
 
+	case *zoekt.ZoektSymbolSearch:
+		if m.MapZoektSymbolSearchJob != nil {
+			j = m.MapZoektSymbolSearchJob(j)
+		}
+		return j
+
 	case *searcher.Searcher:
 		if m.MapSearcherJob != nil {
 			j = m.MapSearcherJob(j)
+		}
+		return j
+
+	case *searcher.SymbolSearcher:
+		if m.MapSymbolSearcherJob != nil {
+			j = m.MapSymbolSearcherJob(j)
 		}
 		return j
 

--- a/internal/search/job/printers.go
+++ b/internal/search/job/printers.go
@@ -41,7 +41,9 @@ func SexpFormat(job Job, sep, indent string) string {
 		switch j := job.(type) {
 		case
 			*zoekt.ZoektRepoSubsetSearch,
+			*zoekt.ZoektSymbolSearch,
 			*searcher.Searcher,
+			*searcher.SymbolSearcher,
 			*run.RepoSearch,
 			*zoekt.GlobalSearch,
 			*structural.StructuralSearch,
@@ -210,7 +212,9 @@ func PrettyMermaid(job Job) string {
 		switch j := job.(type) {
 		case
 			*zoekt.ZoektRepoSubsetSearch,
+			*zoekt.ZoektSymbolSearch,
 			*searcher.Searcher,
+			*searcher.SymbolSearcher,
 			*run.RepoSearch,
 			*zoekt.GlobalSearch,
 			*structural.StructuralSearch,
@@ -335,7 +339,9 @@ func toJSON(job Job, verbose bool) interface{} {
 		switch j := job.(type) {
 		case
 			*zoekt.ZoektRepoSubsetSearch,
+			*zoekt.ZoektSymbolSearch,
 			*searcher.Searcher,
+			*searcher.SymbolSearcher,
 			*run.RepoSearch,
 			*zoekt.GlobalSearch,
 			*structural.StructuralSearch,

--- a/internal/search/job/repo_pager_job.go
+++ b/internal/search/job/repo_pager_job.go
@@ -38,9 +38,23 @@ func setRepos(job Job, indexed *zoekt.IndexedRepoRevs, unindexed []*search.Repos
 		return &jobCopy
 	}
 
+	setZoektSymbolRepos := func(job *zoekt.ZoektSymbolSearch) *zoekt.ZoektSymbolSearch {
+		jobCopy := *job
+		jobCopy.Repos = indexed
+		return &jobCopy
+	}
+
+	setSymbolSearcherRepos := func(job *searcher.SymbolSearcher) *searcher.SymbolSearcher {
+		jobCopy := *job
+		jobCopy.Repos = unindexed
+		return &jobCopy
+	}
+
 	setRepos := Mapper{
 		MapZoektRepoSubsetSearchJob: setZoektRepos,
+		MapZoektSymbolSearchJob:     setZoektSymbolRepos,
 		MapSearcherJob:              setSearcherRepos,
+		MapSymbolSearcherJob:        setSymbolSearcherRepos,
 	}
 
 	return setRepos.Map(job)

--- a/internal/search/job/types.go
+++ b/internal/search/job/types.go
@@ -27,7 +27,9 @@ type Job interface {
 
 var allJobs = []Job{
 	&zoekt.ZoektRepoSubsetSearch{},
+	&zoekt.ZoektSymbolSearch{},
 	&searcher.Searcher{},
+	&searcher.SymbolSearcher{},
 	&run.RepoSearch{},
 	&zoekt.GlobalSearch{},
 	&structural.StructuralSearch{},


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/32534.

This adds mappers for the new symbol search jobs, and populates repos in the repo pager job. This is still a noop and unused, because the job construction doesn't yet create those independent search jobs yet. I want to minimize that actual change (next PR).

## Test plan
Setup for follow up PR and semantics-preserving.


