### PR TITLE
search: create and run symbol search with repo pager

### DIFF
--- a/internal/search/job/job_test.go
+++ b/internal/search/job/job_test.go
@@ -131,7 +131,10 @@ func TestToSearchInputs(t *testing.T) {
     (PARALLEL
       ZoektRepoSubset
       Searcher))
-  RepoSubsetSymbol
+  REPOPAGER
+    (PARALLEL
+      ZoektSymbolSearch
+      SymbolSearcher))
   Commit
   Repo
   ComputeExcludedRepos)
@@ -160,7 +163,10 @@ func TestToSearchInputs(t *testing.T) {
       ComputeExcludedRepos))
   (OPTIONAL
     (PARALLEL
-      RepoSubsetSymbol
+      REPOPAGER
+        (PARALLEL
+          ZoektSymbolSearch
+          SymbolSearcher))
       Commit)))
 `).Equal(t, test("type:file type:path type:repo type:commit type:symbol repo:test test", search.Batch, query.ParseRegexp))
 }


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/32537.

This changes symbol job construction to create two symbol jobs parameterized by the repo pager. Fully relying on integration and e2e tests for correctness here. Tests pass, unrelated percy is in the way

## Test plan
Should be semantics-preserving, covered by existing tests.


