### PR TITLE
search: Capture dependencies searches in pings

### DIFF
--- a/client/shared/src/search/query/metrics.test.ts
+++ b/client/shared/src/search/query/metrics.test.ts
@@ -18,9 +18,7 @@ describe('collectMetrics', () => {
 
     test('predicates', () => {
         expect(
-            collectMetrics(
-                'repo:contains.file(foo) and repo:contains(file:foo content:bar) and repo:deps(foo) and repo:dependencies(bar)'
-            )
+            collectMetrics('repo:contains.file(foo) r:contains(file:foo content:bar) r:deps(foo) r:dependencies(bar)')
         ).toMatchInlineSnapshot(`
             {
               "count_and": 3,

--- a/client/shared/src/search/query/metrics.test.ts
+++ b/client/shared/src/search/query/metrics.test.ts
@@ -17,12 +17,13 @@ describe('collectMetrics', () => {
     })
 
     test('predicates', () => {
-        expect(collectMetrics('repo:contains.file(foo) and repo:contains(file:foo content:bar)'))
+        expect(collectMetrics('r:contains.file(foo) r:contains(file:foo content:bar) r:deps(foo) r:dependencies(bar)'))
             .toMatchInlineSnapshot(`
             {
               "count_and": 1,
               "count_repo_contains": 1,
-              "count_repo_contains_file": 1
+              "count_repo_contains_file": 1,
+              "count_repo_dependencies": 2,
             }
         `)
     })

--- a/client/shared/src/search/query/metrics.test.ts
+++ b/client/shared/src/search/query/metrics.test.ts
@@ -21,7 +21,6 @@ describe('collectMetrics', () => {
             collectMetrics('repo:contains.file(foo) r:contains(file:foo content:bar) r:deps(foo) r:dependencies(bar)')
         ).toMatchInlineSnapshot(`
             {
-              "count_and": 3,
               "count_repo_contains": 1,
               "count_repo_contains_file": 1,
               "count_repo_dependencies": 2

--- a/client/shared/src/search/query/metrics.test.ts
+++ b/client/shared/src/search/query/metrics.test.ts
@@ -23,10 +23,10 @@ describe('collectMetrics', () => {
             )
         ).toMatchInlineSnapshot(`
             {
-              "count_and": 1,
+              "count_and": 3,
               "count_repo_contains": 1,
               "count_repo_contains_file": 1,
-              "count_repo_dependencies": 2,
+              "count_repo_dependencies": 2
             }
         `)
     })

--- a/client/shared/src/search/query/metrics.test.ts
+++ b/client/shared/src/search/query/metrics.test.ts
@@ -17,8 +17,11 @@ describe('collectMetrics', () => {
     })
 
     test('predicates', () => {
-        expect(collectMetrics('r:contains.file(foo) r:contains(file:foo content:bar) r:deps(foo) r:dependencies(bar)'))
-            .toMatchInlineSnapshot(`
+        expect(
+            collectMetrics(
+                'repo:contains.file(foo) and repo:contains(file:foo content:bar) and repo:deps(foo) and repo:dependencies(bar)'
+            )
+        ).toMatchInlineSnapshot(`
             {
               "count_and": 1,
               "count_repo_contains": 1,

--- a/client/shared/src/search/query/metrics.ts
+++ b/client/shared/src/search/query/metrics.ts
@@ -18,6 +18,7 @@ interface Metrics {
     count_repo_contains_file?: number
     count_repo_contains_content?: number
     count_repo_contains_commit_after?: number
+    count_repo_dependencies?: number
     count_count_all?: number
     count_non_global_context?: number
     count_only_patterns?: number
@@ -42,6 +43,7 @@ export const collectMetrics = (query: string): Metrics | undefined => {
     let count_repo_contains_file = 0
     let count_repo_contains_content = 0
     let count_repo_contains_commit_after = 0
+    let count_repo_dependencies = 0
     let count_count_all = 0
     let count_non_global_context = 0
     let count_only_patterns = 0
@@ -129,6 +131,12 @@ export const collectMetrics = (query: string): Metrics | undefined => {
                             case 'contains.commit.after':
                                 count_repo_contains_commit_after += 1
                                 break
+                            case 'deps':
+                                count_repo_dependencies += 1
+                                break
+                            case 'dependencies':
+                                count_repo_dependencies += 1
+                                break
                         }
                     }
                     case 'count': {
@@ -164,6 +172,7 @@ export const collectMetrics = (query: string): Metrics | undefined => {
         count_repo_contains_file: nonzero(count_repo_contains_file),
         count_repo_contains_content: nonzero(count_repo_contains_content),
         count_repo_contains_commit_after: nonzero(count_repo_contains_commit_after),
+        count_repo_dependencies: nonzero(count_repo_dependencies),
         // RFC 384: exhaustive search frequency
         count_count_all: nonzero(count_count_all),
         // RFC 384: context usage

--- a/client/shared/src/search/query/metrics.ts
+++ b/client/shared/src/search/query/metrics.ts
@@ -1,3 +1,4 @@
+import { resolveFieldAlias } from './filters'
 import { scanPredicate } from './predicates'
 import { scanSearchQuery } from './scanner'
 import { KeywordKind } from './token'
@@ -30,6 +31,7 @@ export const collectMetrics = (query: string): Metrics | undefined => {
     if (tokens.type !== 'success') {
         return undefined
     }
+
     let count_or = 0
     let count_and = 0
     let count_not = 0
@@ -91,7 +93,7 @@ export const collectMetrics = (query: string): Metrics | undefined => {
                 if (!token.value) {
                     continue
                 }
-                switch (token.field.value) {
+                switch (resolveFieldAlias(token.field.value)) {
                     case 'select':
                         switch (token.value.value) {
                             case 'repo':

--- a/doc/admin/pings.md
+++ b/doc/admin/pings.md
@@ -39,7 +39,7 @@ This telemetry can be disabled using the `disableNonCriticalTelemetry` option in
 - Aggregate daily, weekly, and monthly latencies (in ms) of search queries
 - Aggregate daily, weekly, and monthly integer counts of the following query syntax:
   - The number of boolean operators (`and`, `or`, `not` keywords)
-  - The number of built-in predicate keywords (`contains`, `contains.file`, `contains.repo`, `contains.commit.after`)
+  - The number of built-in predicate keywords (`contains`, `contains.file`, `contains.repo`, `contains.commit.after`, `dependencies`)
   - The number of `select` keywords by kind (`repo`, `file`, `content`, `symbol`, `commit.diff.added`, `commit.diff.removed`)
   - The number of queries using the `context:` filter without the default `global` value
   - The number of queries with only patterns (e.g., without filters like `repo:` or `file:`)

--- a/internal/database/event_logs.go
+++ b/internal/database/event_logs.go
@@ -1237,6 +1237,7 @@ WHERE key IN
 	'count_repo_contains_file',
 	'count_repo_contains_content',
 	'count_repo_contains_commit_after',
+	'count_repo_dependencies',
 	'count_count_all',
 	'count_non_global_context',
 	'count_only_patterns',

--- a/internal/database/event_logs_test.go
+++ b/internal/database/event_logs_test.go
@@ -818,7 +818,8 @@ func TestEventLogs_AggregatedSearchEvents(t *testing.T) {
       "query_data":{
          "query":{
              "count_and":3,
-             "count_repo_contains_commit_after":2
+             "count_repo_contains_commit_after":2,
+             "count_repo_dependencies":5
          },
          "empty":false,
          "combined":"don't care"
@@ -891,6 +892,17 @@ func TestEventLogs_AggregatedSearchEvents(t *testing.T) {
 			Day:          now.Truncate(time.Hour * 24),
 			TotalMonth:   2,
 			TotalWeek:    2,
+			TotalDay:     0,
+			UniquesMonth: 1,
+			UniquesWeek:  1,
+		},
+		{
+			Name:         "count_repo_dependencies",
+			Month:        time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC),
+			Week:         now.Truncate(time.Hour * 24).Add(-time.Hour * 24 * 5),
+			Day:          now.Truncate(time.Hour * 24),
+			TotalMonth:   5,
+			TotalWeek:    5,
 			TotalDay:     0,
 			UniquesMonth: 1,
 			UniquesWeek:  1,

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -914,6 +914,7 @@ type SearchUsagePeriod struct {
 	RepoContainsFile        *SearchCountStatistics
 	RepoContainsContent     *SearchCountStatistics
 	RepoContainsCommitAfter *SearchCountStatistics
+	RepoDependencies        *SearchCountStatistics
 	CountAll                *SearchCountStatistics
 	NonGlobalContext        *SearchCountStatistics
 	OnlyPatterns            *SearchCountStatistics

--- a/internal/usagestats/aggregated_search.go
+++ b/internal/usagestats/aggregated_search.go
@@ -166,6 +166,7 @@ func newSearchEventPeriod() *types.SearchUsagePeriod {
 		RepoContainsFile:        newSearchCountStatistics(),
 		RepoContainsContent:     newSearchCountStatistics(),
 		RepoContainsCommitAfter: newSearchCountStatistics(),
+		RepoDependencies:        newSearchCountStatistics(),
 		CountAll:                newSearchCountStatistics(),
 		NonGlobalContext:        newSearchCountStatistics(),
 		OnlyPatterns:            newSearchCountStatistics(),

--- a/internal/usagestats/aggregated_search.go
+++ b/internal/usagestats/aggregated_search.go
@@ -65,6 +65,7 @@ var searchFilterCountExtractors = map[string]func(p *types.SearchUsagePeriod) *t
 	"count_repo_contains_file":          func(p *types.SearchUsagePeriod) *types.SearchCountStatistics { return p.RepoContainsFile },
 	"count_repo_contains_content":       func(p *types.SearchUsagePeriod) *types.SearchCountStatistics { return p.RepoContainsContent },
 	"count_repo_contains_commit_after":  func(p *types.SearchUsagePeriod) *types.SearchCountStatistics { return p.RepoContainsCommitAfter },
+	"count_repo_dependencies":           func(p *types.SearchUsagePeriod) *types.SearchCountStatistics { return p.RepoDependencies },
 	"count_count_all":                   func(p *types.SearchUsagePeriod) *types.SearchCountStatistics { return p.CountAll },
 	"count_non_global_context":          func(p *types.SearchUsagePeriod) *types.SearchCountStatistics { return p.NonGlobalContext },
 	"count_only_patterns":               func(p *types.SearchUsagePeriod) *types.SearchCountStatistics { return p.OnlyPatterns },

--- a/internal/usagestats/aggregated_search_test.go
+++ b/internal/usagestats/aggregated_search_test.go
@@ -103,6 +103,7 @@ func newSearchUsagePeriod(t time.Time, structuralEvent, commitEvent *types.Searc
 			RepoContainsFile:        newSearchCountStatistics(),
 			RepoContainsContent:     newSearchCountStatistics(),
 			RepoContainsCommitAfter: newSearchCountStatistics(),
+			RepoDependencies:        newSearchCountStatistics(),
 			CountAll:                newSearchCountStatistics(),
 			NonGlobalContext:        newSearchCountStatistics(),
 			OnlyPatterns:            newSearchCountStatistics(),


### PR DESCRIPTION
This commit adds aggregate tracking of dependencies searches in pings, together with the other predicates.

Fixes #32048



## Test plan

Unit tests.

