### PR TITLE
client/search-ui: Add search repo dependencies snippet

### DIFF
--- a/client/search-ui/src/results/sidebar/SearchTypeLink.tsx
+++ b/client/search-ui/src/results/sidebar/SearchTypeLink.tsx
@@ -136,7 +136,7 @@ export const getSearchTypeLinks = (props: SearchTypeLinksProps): ReactElement[] 
             Search repos by org or name
         </SearchTypeButton>,
         <SearchTypeButton onClick={updateQueryWithRepoDependenciesExample} key="repo-dependencies">
-            Search repo dependencies
+            Search through repo dependencies
         </SearchTypeButton>,
         <SearchSymbol {...props} key="symbol">
             Find a symbol

--- a/client/search-ui/src/results/sidebar/SearchTypeLink.tsx
+++ b/client/search-ui/src/results/sidebar/SearchTypeLink.tsx
@@ -98,6 +98,7 @@ const SearchSymbol: React.FunctionComponent<Omit<SearchTypeLinkProps, 'type'>> =
 }
 
 const repoExample = createQueryExampleFromString('{regexp-pattern}')
+const repoDependenciesExample = createQueryExampleFromString('deps({^github\\.com/sourcegraph/sourcegraph$@HEAD})')
 
 export const getSearchTypeLinks = (props: SearchTypeLinksProps): ReactElement[] => {
     function updateQueryWithRepoExample(): void {
@@ -115,9 +116,27 @@ export const getSearchTypeLinks = (props: SearchTypeLinksProps): ReactElement[] 
         })
     }
 
+    function updateQueryWithRepoDependenciesExample(): void {
+        const updatedQuery = updateQueryWithFilterAndExample(props.query, FilterType.repo, repoDependenciesExample, {
+            singular: true,
+            negate: false,
+            emptyValue: false,
+        })
+        props.onNavbarQueryChange({
+            changeSource: QueryChangeSource.searchTypes,
+            query: updatedQuery.query,
+            selectionRange: updatedQuery.placeholderRange,
+            revealRange: updatedQuery.filterRange,
+            showSuggestions: false,
+        })
+    }
+
     return [
         <SearchTypeButton onClick={updateQueryWithRepoExample} key="repo">
             Search repos by org or name
+        </SearchTypeButton>,
+        <SearchTypeButton onClick={updateQueryWithRepoDependenciesExample} key="repo-dependencies">
+            Search repo dependencies
         </SearchTypeButton>,
         <SearchSymbol {...props} key="symbol">
             Find a symbol

--- a/client/search-ui/src/results/sidebar/SearchTypeLink.tsx
+++ b/client/search-ui/src/results/sidebar/SearchTypeLink.tsx
@@ -136,7 +136,7 @@ export const getSearchTypeLinks = (props: SearchTypeLinksProps): ReactElement[] 
             Search repos by org or name
         </SearchTypeButton>,
         <SearchTypeButton onClick={updateQueryWithRepoDependenciesExample} key="repo-dependencies">
-            Search through repo dependencies
+            Search repo dependencies
         </SearchTypeButton>,
         <SearchSymbol {...props} key="symbol">
             Find a symbol

--- a/client/search-ui/src/results/sidebar/SearchTypeLink.tsx
+++ b/client/search-ui/src/results/sidebar/SearchTypeLink.tsx
@@ -98,7 +98,7 @@ const SearchSymbol: React.FunctionComponent<Omit<SearchTypeLinkProps, 'type'>> =
 }
 
 const repoExample = createQueryExampleFromString('{regexp-pattern}')
-const repoDependenciesExample = createQueryExampleFromString('deps({^github\\.com/sourcegraph/sourcegraph$@HEAD})')
+const repoDependenciesExample = createQueryExampleFromString('deps({})')
 
 export const getSearchTypeLinks = (props: SearchTypeLinksProps): ReactElement[] => {
     function updateQueryWithRepoExample(): void {

--- a/client/shared/src/search/query/completion.ts
+++ b/client/shared/src/search/query/completion.ts
@@ -19,7 +19,7 @@ const filterCompletionItemKind = Monaco.languages.CompletionItemKind.Issue
 type PartialCompletionItem = Omit<Monaco.languages.CompletionItem, 'range'>
 
 export const REPO_DEPS_PREDICATE_REGEX = /^(deps|dependencies)\((.*?)\)?$/
-export const PREDICATE_REGEX = /^([\a-zA-Z\.]+)\((.*?)\)?$/
+export const PREDICATE_REGEX = /^([.A-Za-z]+)\((.*?)\)?$/
 
 /**
  * COMPLETION_ITEM_SELECTED is a custom Monaco command that we fire after the user selects an autocomplete suggestion.

--- a/client/shared/src/search/query/completion.ts
+++ b/client/shared/src/search/query/completion.ts
@@ -19,6 +19,7 @@ const filterCompletionItemKind = Monaco.languages.CompletionItemKind.Issue
 type PartialCompletionItem = Omit<Monaco.languages.CompletionItem, 'range'>
 
 export const REPO_DEPS_PREDICATE_REGEX = /^(deps|dependencies)\((.*?)\)?$/
+export const PREDICATE_REGEX = /^([\a-zA-Z\.]+)\((.*?)\)?$/
 
 /**
  * COMPLETION_ITEM_SELECTED is a custom Monaco command that we fire after the user selects an autocomplete suggestion.
@@ -257,8 +258,15 @@ async function completeFilter(
     if (!resolvedFilter) {
         return null
     }
+
+    // FIXME(tsenart): We need to refactor completions to work with
+    // complex predicates like repo:dependencies()
+    // For now we just disable all static suggestions for a predicate's filter
+    // if we are inside that predicate.
+    const insidePredicate = value ? PREDICATE_REGEX.test(value.value) : false
+
     let staticSuggestions: Monaco.languages.CompletionItem[] = []
-    if (resolvedFilter.definition.discreteValues) {
+    if (resolvedFilter.definition.discreteValues && !insidePredicate) {
         staticSuggestions = resolvedFilter.definition.discreteValues(token.value, isSourcegraphDotCom).map(
             ({ label, insertText, asSnippet }, index): Monaco.languages.CompletionItem => ({
                 label,


### PR DESCRIPTION
This commits adds a "Search repo dependencies" snippet to the search types panel.

<img width="504" alt="image" src="https://user-images.githubusercontent.com/67471/158037078-328d692f-2eb6-4c5b-9e0c-a2b29dd970cd.png">


Closes #32065

## Test plan

Manual testing.


