### PR TITLE
batches: enable resizable columns in execution workflow UI

### DIFF
--- a/client/branded/src/components/panel/views/HierarchicalLocationsView.module.scss
+++ b/client/branded/src/components/panel/views/HierarchicalLocationsView.module.scss
@@ -4,22 +4,13 @@
     overflow-x: hidden;
 }
 
-.resizable-group {
-    min-width: 6rem;
-    padding-top: 0.5rem;
-    margin-right: 0.375rem;
-    overflow-y: auto;
-}
-
 .group-list {
-    flex: 1;
-    border-right: none;
-    overflow-x: hidden;
-    margin-right: 0.375rem;
+    width: 100%;
+    margin-right: 0.5rem;
 }
 
 .file-locations {
     flex: 1;
     width: 100%;
-    margin-right: -1rem;
+    margin: 0 -1rem 0 0.5rem;
 }

--- a/client/branded/src/components/panel/views/HierarchicalLocationsView.module.scss
+++ b/client/branded/src/components/panel/views/HierarchicalLocationsView.module.scss
@@ -7,25 +7,15 @@
 .resizable-group {
     min-width: 6rem;
     padding-top: 0.5rem;
+    margin-right: 0.375rem;
     overflow-y: auto;
-}
-
-.resizable-handle {
-    width: 0;
-    margin-right: 0.5rem;
-    padding-left: 0.5rem;
-    transition: opacity 150ms;
-    border-right: 1px solid var(--border-color-2);
-
-    &:hover {
-        opacity: 1;
-    }
 }
 
 .group-list {
     flex: 1;
     border-right: none;
     overflow-x: hidden;
+    margin-right: 0.375rem;
 }
 
 .file-locations {

--- a/client/branded/src/components/panel/views/HierarchicalLocationsView.tsx
+++ b/client/branded/src/components/panel/views/HierarchicalLocationsView.tsx
@@ -254,7 +254,7 @@ export class HierarchicalLocationsView extends React.PureComponent<HierarchicalL
                                         <Resizable
                                             key={index}
                                             className={styles.resizableGroup}
-                                            handleClassName={styles.resizableHandle}
+                                            handleClassName="m-0"
                                             handlePosition="right"
                                             storageKey={`hierarchical-locations-view-resizable:${group.name}`}
                                             defaultSize={group.defaultSize}

--- a/client/branded/src/components/panel/views/HierarchicalLocationsView.tsx
+++ b/client/branded/src/components/panel/views/HierarchicalLocationsView.tsx
@@ -246,48 +246,40 @@ export class HierarchicalLocationsView extends React.PureComponent<HierarchicalL
                     className={classNames(styles.referencesContainer, this.props.className)}
                     data-testid="hierarchical-locations-view"
                 >
-                    <div className="d-flex">
-                        {selectedGroups &&
-                            groupsToDisplay.map(
-                                (group, index) =>
-                                    group && (
-                                        <Resizable
-                                            key={index}
-                                            className={styles.resizableGroup}
-                                            handleClassName="m-0"
-                                            handlePosition="right"
-                                            storageKey={`hierarchical-locations-view-resizable:${group.name}`}
-                                            defaultSize={group.defaultSize}
-                                            element={
-                                                <div
-                                                    data-testid="hierarchical-locations-view-list"
-                                                    className={classNames('list-group', styles.groupList)}
-                                                >
-                                                    {groups[index].map((group, innerIndex) => (
-                                                        <HierarchicalLocationsViewButton
-                                                            key={innerIndex}
-                                                            groupKey={group.key}
-                                                            groupCount={group.count}
-                                                            isActive={selectedGroups[index] === group.key}
-                                                            onClick={event =>
-                                                                this.onSelectTree(
-                                                                    event,
-                                                                    selectedGroups,
-                                                                    index,
-                                                                    group.key
-                                                                )
-                                                            }
-                                                        />
-                                                    ))}
-                                                    {this.state.locationsOrError.isLoading && (
-                                                        <LoadingSpinner className="m-2 flex-shrink-0 test-loading-spinner" />
-                                                    )}
-                                                </div>
-                                            }
-                                        />
-                                    )
-                            )}
-                    </div>
+                    {selectedGroups &&
+                        groupsToDisplay.map(
+                            (group, index) =>
+                                group && (
+                                    <Resizable
+                                        key={index}
+                                        handlePosition="right"
+                                        storageKey={`hierarchical-locations-view-resizable:${group.name}`}
+                                        minSize={100}
+                                        defaultSize={group.defaultSize}
+                                        element={
+                                            <div
+                                                data-testid="hierarchical-locations-view-list"
+                                                className={styles.groupList}
+                                            >
+                                                {groups[index].map((group, innerIndex) => (
+                                                    <HierarchicalLocationsViewButton
+                                                        key={innerIndex}
+                                                        groupKey={group.key}
+                                                        groupCount={group.count}
+                                                        isActive={selectedGroups[index] === group.key}
+                                                        onClick={event =>
+                                                            this.onSelectTree(event, selectedGroups, index, group.key)
+                                                        }
+                                                    />
+                                                ))}
+                                                {this.state.locationsOrError.isLoading && (
+                                                    <LoadingSpinner className="m-2 flex-shrink-0 test-loading-spinner" />
+                                                )}
+                                            </div>
+                                        }
+                                    />
+                                )
+                        )}
                     <FileLocations
                         className={styles.fileLocations}
                         location={this.props.location}

--- a/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
+++ b/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
@@ -8,9 +8,6 @@ exports[`<HierarchicalLocationsView /> displays a single location when complete 
       data-testid="hierarchical-locations-view"
     >
       <div
-        class="d-flex"
-      />
-      <div
         class="fileLocations fileLocations"
       >
         <div>
@@ -163,78 +160,74 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
       data-testid="hierarchical-locations-view"
     >
       <div
-        class="d-flex"
+        class="resizable"
+        style="width: 200px;"
       >
         <div
-          class="resizable resizableGroup"
-          style="width: 200px;"
+          class="groupList"
+          data-testid="hierarchical-locations-view-list"
         >
-          <div
-            class="list-group groupList"
-            data-testid="hierarchical-locations-view-list"
+          <button
+            class="list-group-item list-group-item-action locationButton active"
+            data-testid="hierarchical-locations-view-button"
+            type="button"
           >
-            <button
-              class="list-group-item list-group-item-action locationButton active"
-              data-testid="hierarchical-locations-view-button"
-              type="button"
+            <span
+              class="locationName"
+              title="file1.txt"
             >
               <span
-                class="locationName"
-                title="file1.txt"
+                class="locationNameText"
               >
                 <span
-                  class="locationNameText"
+                  class=""
                 >
-                  <span
-                    class=""
-                  >
-                     
-                    <span>
-                      file1.txt
-                    </span>
+                   
+                  <span>
+                    file1.txt
                   </span>
                 </span>
               </span>
-              <span
-                class="locationBadge ml-1"
-              >
-                2
-              </span>
-            </button>
-            <button
-              class="list-group-item list-group-item-action locationButton"
-              data-testid="hierarchical-locations-view-button"
-              type="button"
+            </span>
+            <span
+              class="locationBadge ml-1"
+            >
+              2
+            </span>
+          </button>
+          <button
+            class="list-group-item list-group-item-action locationButton"
+            data-testid="hierarchical-locations-view-button"
+            type="button"
+          >
+            <span
+              class="locationName"
+              title="file2.txt"
             >
               <span
-                class="locationName"
-                title="file2.txt"
+                class="locationNameText"
               >
                 <span
-                  class="locationNameText"
+                  class=""
                 >
-                  <span
-                    class=""
-                  >
-                     
-                    <span>
-                      file2.txt
-                    </span>
+                   
+                  <span>
+                    file2.txt
                   </span>
                 </span>
               </span>
-              <span
-                class="locationBadge ml-1"
-              >
-                3
-              </span>
-            </button>
-          </div>
-          <div
-            class="handle handleRight resizableHandle"
-            role="presentation"
-          />
+            </span>
+            <span
+              class="locationBadge ml-1"
+            >
+              3
+            </span>
+          </button>
         </div>
+        <div
+          class="handle handleRight"
+          role="presentation"
+        />
       </div>
       <div
         class="fileLocations fileLocations"
@@ -414,9 +407,6 @@ exports[`<HierarchicalLocationsView /> displays partial locations before complet
       class="referencesContainer"
       data-testid="hierarchical-locations-view"
     >
-      <div
-        class="d-flex"
-      />
       <div
         class="fileLocations fileLocations"
       >

--- a/client/shared/src/components/Resizable.module.scss
+++ b/client/shared/src/components/Resizable.module.scss
@@ -12,7 +12,6 @@
 }
 
 .handle {
-    // Should match JS constant `HANDLE_SIZE`
     --handle-size: 0.35rem;
 
     position: relative;
@@ -20,6 +19,7 @@
     user-select: none;
     z-index: 1;
     transition: opacity 150ms;
+    flex-shrink: 0;
 
     &--right,
     &--left {
@@ -32,12 +32,12 @@
 
     &--left {
         margin-left: calc(-1 * var(--handle-size));
-        right: 0;
+        right: calc(-1 / 2 * var(--handle-size));
     }
 
     &--right {
         margin-right: calc(-1 * var(--handle-size));
-        left: 0;
+        left: calc(-1 / 2 * var(--handle-size));
     }
 
     &--top {

--- a/client/shared/src/components/Resizable.module.scss
+++ b/client/shared/src/components/Resizable.module.scss
@@ -12,18 +12,20 @@
 }
 
 .handle {
+    // Should match JS constant `HANDLE_SIZE`
     --handle-size: 0.35rem;
 
     position: relative;
     opacity: 0;
     user-select: none;
     z-index: 1;
+    transition: opacity 150ms;
 
     &--right,
     &--left {
         height: 100%;
         width: var(--handle-size);
-        cursor: ew-resize;
+        cursor: col-resize;
         top: 0;
         bottom: 0;
     }
@@ -42,13 +44,20 @@
         width: 100%;
         height: var(--handle-size);
         margin-bottom: calc(-1 * var(--handle-size));
-        cursor: ns-resize;
+        cursor: row-resize;
         top: 0;
         left: 0;
         right: 0;
     }
 
-    &--resizing {
+    &:hover {
+        opacity: 0.5;
+        background-color: var(--border-color-2);
+    }
+
+    &--resizing,
+    &--resizing:hover {
         opacity: 1;
+        background-color: var(--border-color-2);
     }
 }

--- a/client/shared/src/components/Resizable.tsx
+++ b/client/shared/src/components/Resizable.tsx
@@ -7,7 +7,6 @@ import styles from './Resizable.module.scss'
 
 interface Props<C extends React.ReactElement = React.ReactElement> {
     className?: string
-    handleClassName?: string
 
     /**
      * Where the resize handle is (which also determines the axis along which the element can be
@@ -126,7 +125,7 @@ export class Resizable<C extends React.ReactElement> extends React.PureComponent
 
     public render(): React.ReactNode {
         const { size, resizing } = this.state
-        const { element, handlePosition, handleClassName, className } = this.props
+        const { element, handlePosition, className } = this.props
 
         return (
             <div
@@ -141,8 +140,7 @@ export class Resizable<C extends React.ReactElement> extends React.PureComponent
                     className={classNames(
                         styles.handle,
                         handleClassNameMap[handlePosition],
-                        resizing && styles.handleResizing,
-                        handleClassName
+                        resizing && styles.handleResizing
                     )}
                     onMouseDown={this.onMouseDown}
                 />

--- a/client/shared/src/components/Resizable.tsx
+++ b/client/shared/src/components/Resizable.tsx
@@ -4,7 +4,6 @@ import { Subject, Subscription } from 'rxjs'
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators'
 
 import styles from './Resizable.module.scss'
-import { convertREMToPX } from './utils/size'
 
 interface Props<C extends React.ReactElement = React.ReactElement> {
     className?: string
@@ -41,9 +40,6 @@ interface Props<C extends React.ReactElement = React.ReactElement> {
      */
     element: C
 }
-
-// Should match CSS variable `--handle-size`
-const HANDLE_SIZE = convertREMToPX(0.35)
 
 const containerClassNameMap: Record<Props['handlePosition'], string> = {
     top: styles.resizableTop,
@@ -168,8 +164,8 @@ export class Resizable<C extends React.ReactElement> extends React.PureComponent
                 if (this.state.resizing && this.containerRef) {
                     let size = isHorizontal(this.props.handlePosition)
                         ? this.props.handlePosition === 'right'
-                            ? event.pageX - this.containerRef.getBoundingClientRect().left - HANDLE_SIZE / 2
-                            : this.containerRef.getBoundingClientRect().right - event.pageX - HANDLE_SIZE / 2
+                            ? event.pageX - this.containerRef.getBoundingClientRect().left
+                            : this.containerRef.getBoundingClientRect().right - event.pageX
                         : this.containerRef.getBoundingClientRect().bottom - event.pageY
                     if (event.shiftKey) {
                         size = Math.ceil(size / 20) * 20

--- a/client/shared/src/components/Resizable.tsx
+++ b/client/shared/src/components/Resizable.tsx
@@ -4,6 +4,7 @@ import { Subject, Subscription } from 'rxjs'
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators'
 
 import styles from './Resizable.module.scss'
+import { convertREMToPX } from './utils/size'
 
 interface Props<C extends React.ReactElement = React.ReactElement> {
     className?: string
@@ -40,6 +41,9 @@ interface Props<C extends React.ReactElement = React.ReactElement> {
      */
     element: C
 }
+
+// Should match CSS variable `--handle-size`
+const HANDLE_SIZE = convertREMToPX(0.35)
 
 const containerClassNameMap: Record<Props['handlePosition'], string> = {
     top: styles.resizableTop,
@@ -164,8 +168,8 @@ export class Resizable<C extends React.ReactElement> extends React.PureComponent
                 if (this.state.resizing && this.containerRef) {
                     let size = isHorizontal(this.props.handlePosition)
                         ? this.props.handlePosition === 'right'
-                            ? event.pageX - this.containerRef.getBoundingClientRect().left
-                            : this.containerRef.getBoundingClientRect().right - event.pageX
+                            ? event.pageX - this.containerRef.getBoundingClientRect().left - HANDLE_SIZE / 2
+                            : this.containerRef.getBoundingClientRect().right - event.pageX - HANDLE_SIZE / 2
                         : this.containerRef.getBoundingClientRect().bottom - event.pageY
                     if (event.shiftKey) {
                         size = Math.ceil(size / 20) * 20

--- a/client/shared/src/components/utils/size.ts
+++ b/client/shared/src/components/utils/size.ts
@@ -1,0 +1,7 @@
+/**
+ * Utility for computing the PX equivalent of a value in REM.
+ *
+ * @param rem Size in REM
+ */
+export const convertREMToPX = (rem: number): number =>
+    rem * parseFloat(getComputedStyle(document.documentElement).fontSize)

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.module.scss
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.module.scss
@@ -25,9 +25,7 @@
     margin-left: 1rem;
     background: none;
     border: none;
-    min-width: 300px;
-    width: 30%;
-    max-width: 700px;
+    width: 100%;
 }
 
 // Should mostly match WorkspacesPreview header and LibraryPane header

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -10,6 +10,7 @@ import { useHistory } from 'react-router'
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { Form } from '@sourcegraph/branded/src/components/Form'
 import { useMutation, useQuery } from '@sourcegraph/http-client'
+import { Resizable } from '@sourcegraph/shared/src/components/Resizable'
 import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import {
     SettingsCascadeProps,
@@ -248,6 +249,7 @@ const CreatePage: React.FunctionComponent<CreatePageProps> = ({ namespaceID, set
 }
 
 const INVALID_BATCH_SPEC_TOOLTIP = "There's a problem with your batch spec."
+const WORKSPACES_PREVIEW_SIZE = 'batch-changes.ssbc-workspaces-preview-size'
 
 interface EditPageProps extends ThemeProps {
     batchChange: EditBatchChangeFields
@@ -404,23 +406,32 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({ batchChange, refetch
                         errors={compact([codeErrors.update, codeErrors.validation, previewError, executeError])}
                     />
                 </div>
-                <div className={styles.workspacesPreviewContainer}>
-                    <WorkspacesPreview
-                        previewDisabled={previewDisabled}
-                        preview={() => previewBatchSpec(debouncedCode)}
-                        batchSpecStale={
-                            isBatchSpecStale || isWorkspacesPreviewInProgress || resolutionState === 'CANCELED'
-                        }
-                        hasPreviewed={hasPreviewed}
-                        excludeRepo={excludeRepo}
-                        cancel={cancel}
-                        isWorkspacesPreviewInProgress={isWorkspacesPreviewInProgress}
-                        resolutionState={resolutionState}
-                        workspacesConnection={workspacesConnection}
-                        importingChangesetsConnection={importingChangesetsConnection}
-                        setFilters={setFilters}
-                    />
-                </div>
+                <Resizable
+                    defaultSize={500}
+                    minSize={405}
+                    maxSize={1400}
+                    handlePosition="left"
+                    storageKey={WORKSPACES_PREVIEW_SIZE}
+                    element={
+                        <div className={styles.workspacesPreviewContainer}>
+                            <WorkspacesPreview
+                                previewDisabled={previewDisabled}
+                                preview={() => previewBatchSpec(debouncedCode)}
+                                batchSpecStale={
+                                    isBatchSpecStale || isWorkspacesPreviewInProgress || resolutionState === 'CANCELED'
+                                }
+                                hasPreviewed={hasPreviewed}
+                                excludeRepo={excludeRepo}
+                                cancel={cancel}
+                                isWorkspacesPreviewInProgress={isWorkspacesPreviewInProgress}
+                                resolutionState={resolutionState}
+                                workspacesConnection={workspacesConnection}
+                                importingChangesetsConnection={importingChangesetsConnection}
+                                setFilters={setFilters}
+                            />
+                        </div>
+                    }
+                />
             </div>
         </BatchChangePage>
     )

--- a/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.module.scss
+++ b/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.module.scss
@@ -3,12 +3,6 @@
     height: 100%;
 }
 
-.workspaces-list-container {
-    width: 40%;
-    max-width: 350px;
-    flex-shrink: 0;
-}
-
 .layout-container {
     // Default of min-height: auto when this element is display: flex allows children to
     // set its height. We want to keep this fixed and have children overflow: auto

--- a/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
@@ -9,6 +9,7 @@ import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { asError, isErrorLike } from '@sourcegraph/common'
 import { useQuery } from '@sourcegraph/http-client'
 import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
+import { Resizable } from '@sourcegraph/shared/src/components/Resizable'
 import { BatchSpecState } from '@sourcegraph/shared/src/graphql-operations'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
@@ -360,12 +361,24 @@ const ExecutionPage: React.FunctionComponent<ExecutionPageProps> = ({ batchSpec,
         <>
             {batchSpec.failureMessage && <ErrorAlert error={batchSpec.failureMessage} />}
             <div className={classNames(styles.layoutContainer, 'd-flex flex-1')}>
-                <div className={classNames(styles.workspacesListContainer, 'd-flex flex-column')}>
-                    <h3 className="mb-2">Workspaces</h3>
-                    <div className={styles.workspacesList}>
-                        <WorkspacesList batchSpecID={batchSpec.id} selectedNode={selectedWorkspace ?? undefined} />
-                    </div>
-                </div>
+                <Resizable
+                    defaultSize={500}
+                    minSize={405}
+                    maxSize={1400}
+                    handlePosition="right"
+                    storageKey="temp"
+                    element={
+                        <div className="w-100 d-flex flex-column">
+                            <h3 className="mb-2">Workspaces</h3>
+                            <div className={styles.workspacesList}>
+                                <WorkspacesList
+                                    batchSpecID={batchSpec.id}
+                                    selectedNode={selectedWorkspace ?? undefined}
+                                />
+                            </div>
+                        </div>
+                    }
+                />
                 <div className="d-flex flex-grow-1">
                     <div className="d-flex overflow-auto w-100">
                         <SelectedWorkspace workspace={selectedWorkspace} isLightTheme={isLightTheme} />

--- a/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
@@ -344,6 +344,8 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({ name, content, isLig
     </div>
 )
 
+const WORKSPACES_LIST_SIZE = 'batch-changes.ssbc-workspaces-list-size'
+
 interface ExecutionPageProps extends ThemeProps {
     batchSpec: BatchSpecExecutionFields
 }
@@ -366,7 +368,7 @@ const ExecutionPage: React.FunctionComponent<ExecutionPageProps> = ({ batchSpec,
                     minSize={405}
                     maxSize={1400}
                     handlePosition="right"
-                    storageKey="temp"
+                    storageKey={WORKSPACES_LIST_SIZE}
                     element={
                         <div className="w-100 d-flex flex-column">
                             <h3 className="mb-2">Workspaces</h3>


### PR DESCRIPTION
Closes #32344.

Wraps the workspaces preview list and execution workspaces list in `Resizable`, so that they can be dragged to change the width.

Preview | Execution
:-------:|:----------:
<video src="https://user-images.githubusercontent.com/8942601/158043286-1c1bf3b5-8a31-47e9-ab77-f58bc76853a3.mov" /> | <video src="https://user-images.githubusercontent.com/8942601/158043288-1cff03b7-3bfe-4d0e-8a1d-d5d3d7a7cbdb.mov" />

I made a couple improvements to `Resizable` as part of this:

- `Resizable` now supports optionally setting a minimum and maximum size
- Resize handle is more obvious when you hover over it or click and drag it:
	
Example from the repo sidebar:

Before | After
:------:|:------:
<video src="https://user-images.githubusercontent.com/8942601/158043994-46a54637-03b3-41ab-bfb7-b0adb6a38ca9.mov" /> | <video src="https://user-images.githubusercontent.com/8942601/158044001-8ccd9060-b7c5-4078-ad3e-96a53bdb41b6.mov" />

- Resize handle cursor uses specific column/row-resize cursors, which are recommended over the original single-direction-resize cursors by various [UX standard guides](https://docs.microsoft.com/en-us/windows/win32/uxguide/inter-mouse)
- Width of the element being controlled by `Resize` now corresponds to the midpoint of the `Resize` handle, which fixes jumpiness/alignment issues like this:

Before | After
:------:|:-----:
<video src="https://user-images.githubusercontent.com/8942601/158043692-43497bc8-7971-49f7-ba60-db5cf7a13ebd.mov" /> | <video src="https://user-images.githubusercontent.com/8942601/158043698-920b1a16-f04a-4b0c-b2a2-92c1bb6c1e28.mov" />

## Test plan

Manually verified every existing instance of `Resizable` functions as expected. Verified expected differences appeared in snapshots for `HierarchicalLocationsView`. Manually tested integration in Batch Changes execution workflow UI with long and short lists of workspaces. These screens are not mobile-friendly yet but that's a pre-existing concern.


