### PR TITLE
bext: fix styles conflict on GitLab

### DIFF
--- a/client/browser/src/shared/code-hosts/gitlab/codeHost.module.scss
+++ b/client/browser/src/shared/code-hosts/gitlab/codeHost.module.scss
@@ -1,3 +1,7 @@
+:root {
+    --gray-10: transparent;
+}
+
 .command-list-popover {
     // The navbar has z-index 1000
     z-index: 1001 !important;

--- a/client/browser/src/shared/code-hosts/gitlab/codeHost.module.scss
+++ b/client/browser/src/shared/code-hosts/gitlab/codeHost.module.scss
@@ -1,5 +1,5 @@
 :root {
-    --gray-10: #fafafa;
+    --gray-10: #fafafa; // override value to avoid style conflics: https://github.com/sourcegraph/sourcegraph/pull/32548
 }
 
 .command-list-popover {

--- a/client/browser/src/shared/code-hosts/gitlab/codeHost.module.scss
+++ b/client/browser/src/shared/code-hosts/gitlab/codeHost.module.scss
@@ -1,5 +1,5 @@
 :root {
-    --gray-10: transparent;
+    --gray-10: #fafafa;
 }
 
 .command-list-popover {


### PR DESCRIPTION
Closes #32462

## Notes on implementation
| State | Screenshot | Note |
| ------- | --------------- | ------- |
| Browser extension disabled | ![Screenshot from 2022-03-14 11-34-23](https://user-images.githubusercontent.com/25318659/158145531-e033eb46-9776-4df3-a805-374cb6d84a74.png) ![Screenshot from 2022-03-14 11-34-31](https://user-images.githubusercontent.com/25318659/158145534-a342d52c-328a-4b00-95f3-ab7a3b65eb64.png) | Background is defined as `var(--gray-10, #fafafa)`. Variable `--gray-10` is not defined and fallback color `#fafafa` is used. |
| Browser extension enabled | ![Screenshot from 2022-03-14 11-35-16](https://user-images.githubusercontent.com/25318659/158146267-de5723be-3d28-4880-a40f-8c3faf752c3a.png) | - [_client/branded/src/global-styles/colors.scss_ defining `--gray-10`](https://github.com/sourcegraph/sourcegraph/blob/3d8cbe1a2c0594a02f8104d06c5d98f74cc8020c/client/branded/src/global-styles/colors.scss#L59) is loaded (it's imported by [client/browser/src/app.scss](https://github.com/sourcegraph/sourcegraph/blob/1a99819d474e5d4c2c913f24252e8faed28daf6c/client/browser/src/app.scss#L1)) <br> - As there is no other rule overriding `--gray-10` value, the one from _client/branded/src/global-styles/colors.scss_ is used  |  
| Suggested fix | ![Screenshot from 2022-03-14 11-53-01](https://user-images.githubusercontent.com/25318659/158148310-beb45c0b-ba72-4928-b7f4-eba33c1c2fbd.png) | Set `--gray-10` value to equal the initial fallback value `#fafafa` for GitLab. |

### Implementation weak spot
- If GitLab updates its stylesheets to include `--gray-10` value, it will be overridden by browser extension styles as browser extension [stylesheets](https://sourcegraph.com/gitlab.com/rluna-open-source/code-management/sourcegraph/sourcegraph-2020/-/blob/client/browser/src/browser-extension/scripts/contentPage.main.ts?L113-122) are [injected at the very end of `<head>`](https://sourcegraph.com/gitlab.com/rluna-open-source/code-management/sourcegraph/sourcegraph-2020/-/blob/client/browser/src/browser-extension/scripts/contentPage.main.ts?L51-62).

### Possible solution
- Inject browser extension stylesheets above the code host ones.
- Prefix browser extension CSS variables to avoid conflicts.

## Test plan
- `sg run bext`
- enable extension for browser
- open GitLab project board and ensure that the [styles issue](https://github.com/sourcegraph/sourcegraph/issues/32462) is no longer reproduced
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


