### PR TITLE
web: use `SOURCEGRAPHDOTCOM_MODE` with `web-standalone`

### DIFF
--- a/.buildkite/pipeline.async.yml
+++ b/.buildkite/pipeline.async.yml
@@ -22,3 +22,4 @@ steps:
       NODE_ENV: production
       WEBPACK_SERVE_INDEX: 'true'
       SOURCEGRAPH_API_URL: https://sourcegraph.com
+      SOURCEGRAPHDOTCOM_MODE: 'true'

--- a/client/web/dev/utils/create-js-context.ts
+++ b/client/web/dev/utils/create-js-context.ts
@@ -1,5 +1,6 @@
 import { SourcegraphContext } from '../../src/jscontext'
 
+import { environmentConfig } from './environment-config'
 import { getSiteConfig } from './get-site-config'
 
 // TODO: share with `client/web/src/integration/jscontext` which is not included into `tsconfig.json` now.
@@ -49,7 +50,7 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
         },
         siteID: 'TestSiteID',
         siteGQLID: 'TestGQLSiteID',
-        sourcegraphDotComMode: true,
+        sourcegraphDotComMode: environmentConfig.SOURCEGRAPHDOTCOM_MODE,
         githubAppCloudSlug: 'TestApp',
         githubAppCloudClientID: 'TestClientID',
         userAgentIsBot: false,

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -926,11 +926,14 @@ commandsets:
       - caddy
     env:
       ENTERPRISE: 1
+      SOURCEGRAPHDOTCOM_MODE: true
 
   oss-web-standalone:
     commands:
       - web-standalone-http
       - caddy
+    env:
+      SOURCEGRAPHDOTCOM_MODE: true
 
   web-standalone-prod:
     commands:
@@ -938,11 +941,14 @@ commandsets:
       - caddy
     env:
       ENTERPRISE: 1
+      SOURCEGRAPHDOTCOM_MODE: true
 
   oss-web-standalone-prod:
     commands:
       - web-standalone-http-prod
       - caddy
+    env:
+      SOURCEGRAPHDOTCOM_MODE: true
 
 tests:
   # These can be run with `sg test [name]`

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -926,14 +926,11 @@ commandsets:
       - caddy
     env:
       ENTERPRISE: 1
-      SOURCEGRAPHDOTCOM_MODE: true
 
   oss-web-standalone:
     commands:
       - web-standalone-http
       - caddy
-    env:
-      SOURCEGRAPHDOTCOM_MODE: true
 
   web-standalone-prod:
     commands:
@@ -941,14 +938,11 @@ commandsets:
       - caddy
     env:
       ENTERPRISE: 1
-      SOURCEGRAPHDOTCOM_MODE: true
 
   oss-web-standalone-prod:
     commands:
       - web-standalone-http-prod
       - caddy
-    env:
-      SOURCEGRAPHDOTCOM_MODE: true
 
 tests:
   # These can be run with `sg test [name]`


### PR DESCRIPTION
## Context

Make it possible to change `DOTCOM_MODE` via the local environment variable. 
See related [Slack thread](https://sourcegraph.slack.com/archives/C07KZF47K/p1647011166885719?thread_ts=1647010122.034929&cid=C07KZF47K).

A related issue for further improvements: https://github.com/sourcegraph/sourcegraph/issues/21870

## Test plan

`DOTCOM_MODE` should be `false` for `sg start web-standalone`.
`DOTCOM_MODE` should be `true` for `SOURCEGRAPHDOTCOM_MODE=true sg start web-standalone`.

