### PR TITLE
Revert "Revert "Add a ready mechanism to the conf pkg""

### DIFF
--- a/cmd/github-proxy/github-proxy.go
+++ b/cmd/github-proxy/github-proxy.go
@@ -59,6 +59,7 @@ func main() {
 	env.Lock()
 	env.HandleHelpFlag()
 	logging.Init()
+	conf.Init()
 	tracer.Init(conf.DefaultClient())
 	sentry.Init(conf.DefaultClient())
 	trace.Init()

--- a/cmd/symbols/shared/main.go
+++ b/cmd/symbols/shared/main.go
@@ -52,6 +52,10 @@ func Main(setup SetupFunc) {
 			SampleRate: 5,
 		},
 	}
+
+	// Conf package must be initialized prior to Rockskip init
+	conf.Init()
+
 	// Run setup
 	gitserverClient := gitserver.NewClient(observationContext)
 	repositoryFetcher := fetcher.NewRepositoryFetcher(gitserverClient, types.LoadRepositoryFetcherConfig(env.BaseConfig{}).MaxTotalPathsLength, observationContext)
@@ -63,7 +67,6 @@ func Main(setup SetupFunc) {
 
 	// Initialization
 	env.HandleHelpFlag()
-	conf.Init()
 	logging.Init()
 	tracer.Init(conf.DefaultClient())
 	sentry.Init(conf.DefaultClient())

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -93,30 +93,20 @@ func initDefaultClient() *client {
 	defaultClient := &client{store: clientStore}
 
 	mode := getMode()
-
 	// Don't kickoff the background updaters for the client/server
 	// when in empty mode.
 	if mode == modeEmpty {
 		close(configurationServerFrontendOnlyInitialized)
 
 		// Seed the client store with an empty configuration.
-		_, err := clientStore.MaybeUpdate(conftypes.RawUnified{
+		_, err := defaultClient.store.MaybeUpdate(conftypes.RawUnified{
 			Site:               "{}",
 			ServiceConnections: conftypes.ServiceConnections{},
 		})
 		if err != nil {
 			log.Fatalf("received error when setting up the store for the default client during test, err :%s", err)
 		}
-		return defaultClient
 	}
-
-	// The default client is started in InitConfigurationServerFrontendOnly in
-	// the case of server mode.
-	if mode == modeClient {
-		go defaultClient.continuouslyUpdate(nil)
-		close(configurationServerFrontendOnlyInitialized)
-	}
-
 	return defaultClient
 }
 

--- a/internal/conf/init.go
+++ b/internal/conf/init.go
@@ -6,9 +6,20 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
 
+// Init function completes the initialization process of the conf package, starting the configuration continuous changes polling
+// if in client mode. The conf.Watch function can safely be called before calling Init to register callbacks reacting to the changes.
+//
+// The Init function must be called early in an application initialization process, but tests do not need to call it.
 func Init() {
+	// The default client is started in InitConfigurationServerFrontendOnly in
+	// the case of server mode.
+	if getMode() == modeClient {
+		go DefaultClient().continuouslyUpdate(nil)
+		close(configurationServerFrontendOnlyInitialized)
+	}
+
 	// This watch loop is here so that we don't introduce
-	// dependency cycles, since conf itself uses httpcli's internal
+	// package dependency cycles, since conf itself uses httpcli's internal
 	// client. This is gross, and the whole conf package is gross.
 	go Watch(func() {
 		before := httpcli.TLSExternalConfig()


### PR DESCRIPTION
### Description

Reverts sourcegraph/sourcegraph#32420 and tweaks the original solution with the following fix.

### Problem

`symbols-enterprise` runs, but it's deadlocked, unable to process requests.

We've [moved](https://github.com/sourcegraph/sourcegraph/pull/32265/files#diff-c4e3bed6025b6c9e2d1546734956c48e6e89b0fc7a2f344b34a4c14995423993R18) continuous conf updates to `conf.Init` call that must be called explicitly. However [enterprise/symbols/Main](https://github.com/sourcegraph/sourcegraph/blob/31ea284a6fe7444ed4c545c7a281091f2ee51780/cmd/symbols/shared/main.go#L37) accepts an optional hook that's in this cased invoked if `USE_ROCKSKIP` environment variable is set to `true`. This hook assumed it could call `conf.Get`, but that call wasn't safe as `conf.Init` must be called before calling the former.

### Solution

Refactor enterprise symbols to Invoke `conf.Init` before calling the `setup` set up hook.

During our pairing session with @jhchabran, we've also realized that we don't have sufficient feedback for identifying similar errors locally. `sg` does run the command but does not report anything if the command isn't healthy (deadlocked like in our case). We agreed that adding simple health checking to our local `sg` would be beneficial, so we'd spot this error earlier.

## Test plan

- manual pairing QA session - we've tested this both locally with `sg` and using our dogfood k8s instance
- we've identified the need to expand `sg` with the health-checking capability 