### PR TITLE
Configurable sync limits + rate limiter wait metrics

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/metrics.go
+++ b/enterprise/cmd/repo-updater/internal/authz/metrics.go
@@ -40,4 +40,9 @@ var (
 		Name: "src_repoupdater_perms_syncer_queue_size",
 		Help: "The size of the sync request queue",
 	})
+	metricsRateLimiterWaitDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "src_repoupdater_perms_syncer_sync_wait_duration_seconds",
+		Help:    "Time spent waiting on rate-limiter to sync permissions",
+		Buckets: []float64{1, 2, 5, 10, 30, 60, 120},
+	}, []string{"type", "success"})
 )

--- a/enterprise/cmd/repo-updater/internal/authz/metrics.go
+++ b/enterprise/cmd/repo-updater/internal/authz/metrics.go
@@ -43,6 +43,6 @@ var (
 	metricsRateLimiterWaitDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "src_repoupdater_perms_syncer_sync_wait_duration_seconds",
 		Help:    "Time spent waiting on rate-limiter to sync permissions",
-		Buckets: []float64{1, 2, 5, 10, 30, 60, 120},
+		Buckets: []float64{0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120},
 	}, []string{"type", "success"})
 )

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -318,7 +318,7 @@ func (s *PermsSyncer) fetchUserPermsViaExternalAccounts(ctx context.Context, use
 			continue
 		}
 
-		if err := s.waitForRateLimit(ctx, provider.ServiceID(), 1); err != nil {
+		if err := s.waitForRateLimit(ctx, provider.ServiceID(), 1, "user"); err != nil {
 			return nil, nil, errors.Wrap(err, "wait for rate limiter")
 		}
 
@@ -493,7 +493,7 @@ func (s *PermsSyncer) fetchUserPermsViaExternalServices(ctx context.Context, use
 			return nil, errors.Errorf("empty token from external service %d", svc.ID)
 		}
 
-		if err := s.waitForRateLimit(ctx, provider.ServiceID(), 1); err != nil {
+		if err := s.waitForRateLimit(ctx, provider.ServiceID(), 1, "user"); err != nil {
 			return nil, errors.Wrap(err, "wait for rate limiter")
 		}
 
@@ -720,7 +720,7 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 	pendingAccountIDsSet := make(map[string]struct{})
 	accountIDsToUserIDs := make(map[string]int32) // Account ID -> User ID
 	if provider != nil {
-		if err := s.waitForRateLimit(ctx, provider.ServiceID(), 1); err != nil {
+		if err := s.waitForRateLimit(ctx, provider.ServiceID(), 1, "repo"); err != nil {
 			return errors.Wrap(err, "wait for rate limiter")
 		}
 
@@ -846,15 +846,18 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 // an error if n exceeds the limiter's burst size, the context is canceled, or the
 // expected wait time exceeds the context's deadline. The burst limit is ignored if
 // the rate limit is Inf.
-func (s *PermsSyncer) waitForRateLimit(ctx context.Context, serviceID string, n int) error {
+func (s *PermsSyncer) waitForRateLimit(ctx context.Context, serviceID string, n int, syncType string) error {
 	if s.rateLimiterRegistry == nil {
 		return nil
 	}
 
 	rl := s.rateLimiterRegistry.Get(serviceID)
+	began := time.Now()
 	if err := rl.WaitN(ctx, n); err != nil {
+		metricsRateLimiterWaitDuration.WithLabelValues(syncType, strconv.FormatBool(false)).Observe(time.Since(began).Seconds())
 		return err
 	}
+	metricsRateLimiterWaitDuration.WithLabelValues(syncType, strconv.FormatBool(true)).Observe(time.Since(began).Seconds())
 	return nil
 }
 
@@ -1083,18 +1086,18 @@ func (s *PermsSyncer) schedule(ctx context.Context) (*schedule, error) {
 	//	 consumed by users = <initial limit> / (<total repos> / <page size>)
 	//   consumed by repos = (<initial limit> - <consumed by users>) / (<total users> / <page size>)
 	// Hard coded both to 10 for now.
-	const limit = 10
+	userLimit, repoLimit := oldestUserPermissionsBatchSize(), oldestRepoPermissionsBatchSize()
 
 	// TODO(jchen): Use better heuristics for setting NextSyncAt, the initial version
 	// just uses the value of LastUpdatedAt get from the perms tables.
 
-	users, err = s.scheduleUsersWithOldestPerms(ctx, limit)
+	users, err = s.scheduleUsersWithOldestPerms(ctx, userLimit)
 	if err != nil {
 		return nil, errors.Wrap(err, "load users with oldest permissions")
 	}
 	schedule.Users = append(schedule.Users, users...)
 
-	repos, err = s.scheduleReposWithOldestPerms(ctx, limit)
+	repos, err = s.scheduleReposWithOldestPerms(ctx, repoLimit)
 	if err != nil {
 		return nil, errors.Wrap(err, "scan repositories with oldest permissions")
 	}
@@ -1278,4 +1281,20 @@ func scheduleInterval() time.Duration {
 		return 15 * time.Second
 	}
 	return time.Duration(seconds) * time.Second
+}
+
+func oldestUserPermissionsBatchSize() int {
+	batchSize := conf.Get().PermissionsSyncOldestUsers
+	if batchSize <= 0 {
+		return 10
+	}
+	return batchSize
+}
+
+func oldestRepoPermissionsBatchSize() int {
+	batchSize := conf.Get().PermissionsSyncOldestRepos
+	if batchSize <= 0 {
+		return batchSize
+	}
+	return batchSize
 }

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -1294,7 +1294,7 @@ func oldestUserPermissionsBatchSize() int {
 func oldestRepoPermissionsBatchSize() int {
 	batchSize := conf.Get().PermissionsSyncOldestRepos
 	if batchSize <= 0 {
-		return batchSize
+		return 10
 	}
 	return batchSize
 }

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
@@ -869,7 +869,7 @@ func TestPermsSyncer_waitForRateLimit(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(ctx, time.Second)
 		defer cancel()
-		err := s.waitForRateLimit(ctx, "https://github.com/", 100000)
+		err := s.waitForRateLimit(ctx, "https://github.com/", 100000, "user")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -881,7 +881,7 @@ func TestPermsSyncer_waitForRateLimit(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(ctx, time.Second)
 		defer cancel()
-		err := s.waitForRateLimit(ctx, "https://github.com/", 1)
+		err := s.waitForRateLimit(ctx, "https://github.com/", 1, "user")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -896,7 +896,7 @@ func TestPermsSyncer_waitForRateLimit(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(ctx, time.Second)
 		defer cancel()
-		err := s.waitForRateLimit(ctx, "https://github.com/", 10)
+		err := s.waitForRateLimit(ctx, "https://github.com/", 10, "user")
 		if err == nil {
 			t.Fatalf("err: want %v but got nil", context.Canceled)
 		}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1780,6 +1780,10 @@ type SiteConfiguration struct {
 	OrganizationInvitations *OrganizationInvitations `json:"organizationInvitations,omitempty"`
 	// ParentSourcegraph description: URL to fetch unreachable repository details from. Defaults to "https://sourcegraph.com"
 	ParentSourcegraph *ParentSourcegraph `json:"parentSourcegraph,omitempty"`
+	// PermissionsSyncOldestRepos description: Number of repo permissions to schedule for syncing in single scheduler iteration
+	PermissionsSyncOldestRepos int `json:"permissions.syncOldestRepos,omitempty"`
+	// PermissionsSyncOldestUsers description: Number of user permissions to schedule for syncing in single scheduler iteration
+	PermissionsSyncOldestUsers int `json:"permissions.syncOldestUsers,omitempty"`
 	// PermissionsSyncScheduleInterval description: Time interval (in seconds) of how often each component picks up authorization changes in external services.
 	PermissionsSyncScheduleInterval int `json:"permissions.syncScheduleInterval,omitempty"`
 	// PermissionsUserMapping description: Settings for Sourcegraph permissions, which allow the site admin to explicitly manage repository permissions via the GraphQL API. This setting cannot be enabled if repository permissions for any specific external service are enabled (i.e., when the external service's `authorization` field is set).

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -751,6 +751,16 @@
       "type": "integer",
       "default": 15
     },
+    "permissions.syncOldestUsers": {
+      "description": "Number of user permissions to schedule for syncing in single scheduler iteration",
+      "type": "integer",
+      "default": 10
+    },
+    "permissions.syncOldestRepos": {
+      "description": "Number of repo permissions to schedule for syncing in single scheduler iteration",
+      "type": "integer",
+      "default": 10
+    },
     "branding": {
       "description": "Customize Sourcegraph homepage logo and search icon.\n\nOnly available in Sourcegraph Enterprise.",
       "type": "object",


### PR DESCRIPTION
This PR adds site-config options for configuring the number of users / repos for which we sync permissions in a single iteration of PermsSyncer (currently hardcoded to 10).
To keep permissions fresh-enough, we'd need to schedule 
```
batch_size=(number_of_permission_owners)/(age_window_minutes*sync_per_minute)
``` 
syncs in a single iteration - 565 repos / 236 users per sync with 30 min SLA, 47 repos / 20 users per sync with 6h SLA.

This is a large increase over what we do today, so this PR adds a metric tracking time spent waiting for rate limiter (not to add more work than we can get through).


## Test plan
Updated unit tests
Verified locally (by reconfiguring parameters / verifying rate limiter metric is updated).


