### PR TITLE
gitserver: Skip unpacking nested .git directories

### DIFF
--- a/cmd/gitserver/server/vcs_syncer_jvm_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages_test.go
@@ -121,6 +121,8 @@ var maliciousPaths []string = []string{
 	"/sh", "/usr/bin/sh",
 	// Paths into .git which may trigger when git runs a hook
 	".git/blah", ".git/hooks/pre-commit",
+	// Paths into a nested .git which may trigger when git runs a hook
+	"src/.git/blah", "src/.git/hooks/pre-commit",
 	// Relative paths which stray outside
 	"../foo/../bar", "../../../usr/bin/sh",
 }


### PR DESCRIPTION
We missed this case before, and just ran into typescript@3.3.3333 failing to clone in production because of it.

> t=2022-03-14T12:41:15+0000 lvl=eror msg="runUpdateLoop: error updating repo" uri=npm/typescript err="repo npm/typescript:: failed to fetch: error pushing dependency \"typescript@3.3.3333\": command [git init] failed with output fatal: not a git repository: /home/daniel/shared/TypeScript/.git/worktrees/TypeScript3: exit status 128"



## Test plan

Integration test.


