### PR TITLE
Search: remove flaky test

### DIFF
--- a/internal/search/job/combinators_test.go
+++ b/internal/search/job/combinators_test.go
@@ -116,23 +116,6 @@ func TestTimeoutJob(t *testing.T) {
 		require.ErrorIs(t, err, context.DeadlineExceeded)
 	})
 
-	t.Run("early return returns early", func(t *testing.T) {
-		timeoutWaiter := NewMockJob()
-		timeoutWaiter.RunFunc.SetDefaultHook(func(ctx context.Context, _ database.DB, _ streaming.Sender) (*search.Alert, error) {
-			select {
-			case <-time.After(10 * time.Millisecond):
-				return nil, nil
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			}
-		})
-		timeoutJob := NewTimeoutJob(time.Second, timeoutWaiter)
-		start := time.Now()
-		_, err := timeoutJob.Run(context.Background(), nil, nil)
-		require.NoError(t, err)
-		require.WithinDuration(t, time.Now(), start.Add(10*time.Millisecond), 5*time.Millisecond)
-	})
-
 	t.Run("NewTimeoutJob propagates noop", func(t *testing.T) {
 		job := NewTimeoutJob(10*time.Second, NewNoopJob())
 		require.Equal(t, NewNoopJob(), job)


### PR DESCRIPTION
This test was flaking, and fixing it is probably more effort than it's
worth. The thing being tested is fairly trivial (basically, just
propagate a context timeout), so it wasn't adding much value anyways.

## Test plan

Deletes a flaky test.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


