### PR TITLE
codeintel: Fix nullable value in scanDumps

### DIFF
--- a/enterprise/internal/codeintel/stores/dbstore/dumps.go
+++ b/enterprise/internal/codeintel/stores/dbstore/dumps.go
@@ -63,7 +63,7 @@ func scanDumps(rows *sql.Rows, queryErr error) (_ []Dump, err error) {
 			&dump.RepositoryID,
 			&dump.RepositoryName,
 			&dump.Indexer,
-			&dump.IndexerVersion,
+			&dbutil.NullString{S: &dump.IndexerVersion},
 			&dump.AssociatedIndexID,
 		); err != nil {
 			return nil, err


### PR DESCRIPTION
This fixes the following errors:

```
[enterprise-frontend] ERROR codeintel.dbstore.FindClosestDumps, error: sql: Scan error on column index 15, name "indexer_version": converting NULL to string is unsupported, count: 1, elapsed: 0.021382459, repositoryID: 3, commit: 9d1f353a285b3094bc33bdae277a19aedabe8b71, path: diff/diff.go, rootMustEnclosePath: true, indexer:
[enterprise-frontend] ERROR codeintel.resolvers.findClosestDumps, error: dbstore.FindClosestDumps: sql: Scan error on column index 15, name "indexer_version": converting NULL to string is unsupported, count: 1, elapsed: 0.0214995, repositoryID: 3, commit: 9d1f353a285b3094bc33bdae277a19aedabe8b71, path: diff/diff.go, exactPath: true, indexer:
[enterprise-frontend] ERROR codeintel.resolvers.QueryResolver, error: dbstore.FindClosestDumps: sql: Scan error on column index 15, name "indexer_version": converting NULL to string is unsupported, count: 1, elapsed: 0.023035125, repositoryID: 3, commit: 9d1f353a285b3094bc33bdae277a19aedabe8b71, path: diff/diff.go, exactPath: true, indexer:
```

## Test plan

Existing unit tests.