### PR TITLE
Spell npm consistently.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1735,7 +1735,7 @@ This is `3.12.8` release with internal infrastructure fixes to publish the docke
 - Global settings can be configured from a local file using the environment variable `GLOBAL_SETTINGS_FILE`.
 - High-level health metrics and dashboards have been added to Sourcegraph's monitoring (found under the **Site admin** -> **Monitoring** area). [#7216](https://github.com/sourcegraph/sourcegraph/pull/7216)
 - Logging for GraphQL API requests not issued by Sourcegraph is now much more verbose, allowing for easier debugging of problematic queries and where they originate from. [#5706](https://github.com/sourcegraph/sourcegraph/issues/5706)
-- A new campaign type finds and removes leaked NPM credentials. [#6893](https://github.com/sourcegraph/sourcegraph/pull/6893)
+- A new campaign type finds and removes leaked npm credentials. [#6893](https://github.com/sourcegraph/sourcegraph/pull/6893)
 - Campaigns can now be retried to create failed changesets due to ephemeral errors (e.g. network problems when creating a pull request on GitHub). [#6718](https://github.com/sourcegraph/sourcegraph/issues/6718)
 - The initial release of [structural code search](https://docs.sourcegraph.com/code_search/reference/structural).
 

--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -171,12 +171,12 @@ export const predicateCompletion = (field: string): Completion[] => {
                 asSnippet: true,
             },
             {
-                label: 'deps(...) Includes NPM dependencies only (beta)',
+                label: 'deps(...) Includes npm dependencies only (beta)',
                 insertText: 'deps(${1})',
                 asSnippet: true,
             },
             {
-                label: 'dependencies(...) Includes NPM dependencies only (beta)',
+                label: 'dependencies(...) Includes npm dependencies only (beta)',
                 insertText: 'dependencies(${1})',
                 asSnippet: true,
             },

--- a/client/web/src/components/externalServices/externalServices.tsx
+++ b/client/web/src/components/externalServices/externalServices.tsx
@@ -1240,10 +1240,10 @@ const PAGURE: AddExternalServiceOptions = {
 
 const NPM_PACKAGES: AddExternalServiceOptions = {
     kind: ExternalServiceKind.NPMPACKAGES,
-    title: 'NPM Dependencies',
+    title: 'npm Dependencies',
     icon: NpmIcon,
     jsonSchema: npmPackagesSchemaJSON,
-    defaultDisplayName: 'NPM Dependencies',
+    defaultDisplayName: 'npm Dependencies',
     defaultConfig: `{
   "registry": "https://registry.npmjs.org",
   "dependencies": []
@@ -1252,7 +1252,7 @@ const NPM_PACKAGES: AddExternalServiceOptions = {
         <div>
             <ol>
                 <li>
-                    In the configuration below, set <Field>registry</Field> to the applicable NPM registry. For example,
+                    In the configuration below, set <Field>registry</Field> to the applicable npm registry. For example,
                     <code>"https://registry.npmjs.mycompany.com"</code> or <code>"https://registry.npmjs.org"</code>.
                     Note that this URL may not be the same as where packages can be searched (such as{' '}
                     <code>https://www.npmjs.org</code>). If you're unsure about the exact URL URL for a custom registry,

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -394,12 +394,12 @@ func getVCSSyncer(ctx context.Context, externalServiceStore database.ExternalSer
 			return nil, err
 		}
 		return &server.JVMPackagesSyncer{Config: &c, DepsStore: codeintelDB}, nil
-	case extsvc.TypeNPMPackages:
-		var c schema.NPMPackagesConnection
+	case extsvc.TypeNpmPackages:
+		var c schema.NpmPackagesConnection
 		if err := extractOptions(&c); err != nil {
 			return nil, err
 		}
-		return server.NewNPMPackagesSyncer(c, codeintelDB, nil), nil
+		return server.NewNpmPackagesSyncer(c, codeintelDB, nil), nil
 	}
 	return &server.GitRepoSyncer{}, nil
 }

--- a/cmd/gitserver/server/vcs_syncer_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_packages.go
@@ -72,7 +72,7 @@ func isPotentiallyMaliciousFilepathInArchive(filepath, destinationDir string) (o
 //    the JDK or whether it's a regular Maven artifact. For the JDK, lsif-java
 //    has a special case to emit "export" monikers instead of "import".
 //
-//    This doesn't apply to JS/S because there is no special NPM module
+//    This doesn't apply to JS/S because there is no special npm module
 //    analogous to the JDK.
 //
 // 3. The lsif-java.json file is used as a marker file to enable inference

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -256,7 +256,7 @@ func TestServer_RepoLookup(t *testing.T) {
 	}
 
 	npmSource := types.ExternalService{
-		Kind:   extsvc.KindNPMPackages,
+		Kind:   extsvc.KindNpmPackages,
 		Config: `{}`,
 	}
 
@@ -355,8 +355,8 @@ func TestServer_RepoLookup(t *testing.T) {
 		URI:  "npm/package",
 		ExternalRepo: api.ExternalRepoSpec{
 			ID:          "npm/package",
-			ServiceType: extsvc.TypeNPMPackages,
-			ServiceID:   extsvc.TypeNPMPackages,
+			ServiceType: extsvc.TypeNpmPackages,
+			ServiceID:   extsvc.TypeNpmPackages,
 		},
 		Sources: map[string]*types.SourceInfo{
 			npmSource.URN(): {
@@ -364,8 +364,8 @@ func TestServer_RepoLookup(t *testing.T) {
 				CloneURL: "npm/package",
 			},
 		},
-		Metadata: &npmpackages.Metadata{Package: func() *reposource.NPMPackage {
-			p, _ := reposource.NewNPMPackage("", "package")
+		Metadata: &npmpackages.Metadata{Package: func() *reposource.NpmPackage {
+			p, _ := reposource.NewNpmPackage("", "package")
 			return p
 		}()},
 	}

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -88,11 +88,11 @@ func TestSearch(t *testing.T) {
 
 	testSearchOther(t)
 
-	// This test runs after all others because its adds a NPM external service
+	// This test runs after all others because its adds a npm external service
 	// which expands the set of repositories in the instance. All previous tests
 	// assume only the repos from gqltest-github-search exist.
 	//
-	// Adding and deleting the NPM external service in between all other tests is
+	// Adding and deleting the npm external service in between all other tests is
 	// flaky since deleting an external service doesn't cancel a running external
 	// service sync job for it.
 	t.Run("repo:deps", testDependenciesSearch(client, streamClient))
@@ -1384,9 +1384,9 @@ func testDependenciesSearch(client, streamClient searchClient) func(*testing.T) 
 		}
 
 		_, err = client.AddExternalService(gqltestutil.AddExternalServiceInput{
-			Kind:        extsvc.KindNPMPackages,
+			Kind:        extsvc.KindNpmPackages,
 			DisplayName: "gqltest-npm-search",
-			Config: mustMarshalJSONString(&schema.NPMPackagesConnection{
+			Config: mustMarshalJSONString(&schema.NpmPackagesConnection{
 				Registry: "https://registry.npmjs.org",
 				Dependencies: []string{
 					"urql@2.2.0", // We're searching the dependencies of this repo.
@@ -1397,7 +1397,7 @@ func testDependenciesSearch(client, streamClient searchClient) func(*testing.T) 
 			t.Fatal(err)
 		}
 
-		// Set up a NPM external service to test dependencies search
+		// Set up a npm external service to test dependencies search
 		t.Cleanup(func() {
 			if err := client.UpdateSiteConfiguration(&oldConfig); err != nil {
 				t.Fatal(err)

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -4661,7 +4661,7 @@ Query: `sum by (op)(increase(src_codeintel_coursier_errors_total{op!="RunCommand
 
 <br />
 
-### Git Server: Codeintel: NPM invocation stats
+### Git Server: Codeintel: npm invocation stats
 
 #### gitserver: codeintel_npm_total
 
@@ -11444,7 +11444,7 @@ Query: `sum by (op)(increase(src_codeintel_coursier_errors_total{op!="RunCommand
 
 <br />
 
-### Repo Updater: Codeintel: NPM invocation stats
+### Repo Updater: Codeintel: npm invocation stats
 
 #### repo-updater: codeintel_npm_total
 

--- a/doc/cli/references/api.md
+++ b/doc/cli/references/api.md
@@ -52,7 +52,7 @@ Examples:
 
   Searching for "Router" and getting result count:
 
-    	$ echo 'query($query: String!) { search(query: $query) { results { matchCount } } }' | src api 'query=Router'
+    	$ echo 'query($query: String!) { search(query: $query) { results { resultCount } } }' | src api 'query=Router'
 
   Get the curl command for a query (just add '-get-curl' in the flags section):
 

--- a/doc/code_intelligence/explanations/auto_indexing_inference.md
+++ b/doc/code_intelligence/explanations/auto_indexing_inference.md
@@ -61,7 +61,7 @@ indexing_jobs:
       - root: <ancestor(dir)>
         image: sourcegraph/lsif-node:autoindex
         commands:
-          # NPM is used to resolve dependencies otherwise.
+          # npm is used to resolve dependencies otherwise.
           - npm install
       - ...
     local_steps:

--- a/doc/dev/background-information/architecture/sourcegraph-extensions.md
+++ b/doc/dev/background-information/architecture/sourcegraph-extensions.md
@@ -57,7 +57,7 @@ Note that the extension host execution context varies depending on the client ap
 ### Publishing
 
 - Once you've opened a PR and received feedback and approval, bump the sourcegraph extension API version. Be sure to follow [semantic versioning](https://semver.org/).
-- Once your PR is merged into `main`, publish the new extension API to NPM.
+- Once your PR is merged into `main`, publish the new extension API to npm.
 - If necessary, update [extension-api-stubs](https://github.com/sourcegraph/extension-api-stubs) to reflect the latest version of the extension API. 
 - Upgrade any extensions you've written to the latest version. Be sure to CHECK that the Sourcegraph extension host that loads your extension supports this feature ([example](https://sourcegraph.com/github.com/codecov/sourcegraph-codecov@19a302e7dccb48b4fe910f1862309e434cf76bb8/-/blob/src/extension.ts#L225-227)).
 	- Sourcegraph.com will support this new feature (almost) immediately

--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -139,7 +139,7 @@ Default pipeline:
 - E2E for chrome extension
 - Extension release
 - Extension release
-- NPM Release
+- npm Release
 - Upload build trace
 
 ### Main branch

--- a/doc/dev/background-information/web/wildcard.md
+++ b/doc/dev/background-information/web/wildcard.md
@@ -90,4 +90,4 @@ You can view our components:
 
 ### *Can I use these components in a different codebase?*
 
-Currently our Wildcard components are not published on NPM, if this is a requirement please create a new issue and add the label: `team/frontend-platform`.
+Currently our Wildcard components are not published on npm, if this is a requirement please create a new issue and add the label: `team/frontend-platform`.

--- a/doc/dev/how-to/testing.md
+++ b/doc/dev/how-to/testing.md
@@ -407,6 +407,6 @@ We measure our generated production build through [Bundlesize](https://github.co
 If `Bundlesize` fails, it is likely because one of the generated bundles has gone over the maximum size we have set. This can be due to numerous reasons, to fix this you should check:
 
 1. That you are lazy-loading code where possible.
-2. That you are not using dependencies that are potentially too large to be suitable for our application. Tip: Use [Bundlephobia](https://bundlephobia.com) to help find the size of an NPM dependency.
+2. That you are not using dependencies that are potentially too large to be suitable for our application. Tip: Use [Bundlephobia](https://bundlephobia.com) to help find the size of an npm dependency.
 
 If none of the above is applicable, we might need to consider adjusting our limits. Please start a discussion with @sourcegraph/frontend-devs before doing this!

--- a/enterprise/cmd/worker/internal/codeintel/indexing/dependency_sync_scheduler.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/dependency_sync_scheduler.go
@@ -22,7 +22,7 @@ import (
 
 var schemeToExternalService = map[string]string{
 	dependenciesStore.JVMPackagesScheme: extsvc.KindJVMPackages,
-	dependenciesStore.NPMPackagesScheme: extsvc.KindNPMPackages,
+	dependenciesStore.NpmPackagesScheme: extsvc.KindNpmPackages,
 }
 
 // NewDependencySyncScheduler returns a new worker instance that processes

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -461,7 +461,7 @@ func addBrowserExtensionReleaseSteps(pipeline *bk.Pipeline) {
 		bk.Cmd("yarn --cwd client/browser release:firefox"))
 
 	// Release to npm
-	pipeline.AddStep(":rocket::npm: NPM Release",
+	pipeline.AddStep(":rocket::npm: npm Release",
 		withYarnCache(),
 		bk.Cmd("yarn --frozen-lockfile --network-timeout 60000"),
 		bk.Cmd("yarn --cwd client/browser -s run build"),

--- a/enterprise/internal/codeintel/autoindex/enqueuer/infer.go
+++ b/enterprise/internal/codeintel/autoindex/enqueuer/infer.go
@@ -16,7 +16,7 @@ func InferRepositoryAndRevision(pkg precise.Package) (repoName api.RepoName, git
 	for _, fn := range []func(pkg precise.Package) (api.RepoName, string, bool){
 		inferGoRepositoryAndRevision,
 		inferJVMRepositoryAndRevision,
-		inferNPMRepositoryAndRevision,
+		inferNpmRepositoryAndRevision,
 	} {
 		if repoName, gitTagOrCommit, ok := fn(pkg); ok {
 			return repoName, gitTagOrCommit, true
@@ -55,13 +55,13 @@ func inferJVMRepositoryAndRevision(pkg precise.Package) (api.RepoName, string, b
 	return api.RepoName(pkg.Name), "v" + pkg.Version, true
 }
 
-func inferNPMRepositoryAndRevision(pkg precise.Package) (api.RepoName, string, bool) {
-	if pkg.Scheme != dependenciesStore.NPMPackagesScheme {
+func inferNpmRepositoryAndRevision(pkg precise.Package) (api.RepoName, string, bool) {
+	if pkg.Scheme != dependenciesStore.NpmPackagesScheme {
 		return "", "", false
 	}
-	npmPkg, err := reposource.ParseNPMPackageFromPackageSyntax(pkg.Name)
+	npmPkg, err := reposource.ParseNpmPackageFromPackageSyntax(pkg.Name)
 	if err != nil {
-		log15.Error("invalid NPM package name in database", "error", err)
+		log15.Error("invalid npm package name in database", "error", err)
 		return "", "", false
 	}
 	return npmPkg.RepoName(), "v" + pkg.Version, true

--- a/internal/codeintel/dependencies/store/consts.go
+++ b/internal/codeintel/dependencies/store/consts.go
@@ -2,5 +2,5 @@ package store
 
 const (
 	JVMPackagesScheme = "semanticdb"
-	NPMPackagesScheme = "npm"
+	NpmPackagesScheme = "npm"
 )

--- a/internal/codeintel/dependencies/store/store_test.go
+++ b/internal/codeintel/dependencies/store/store_test.go
@@ -59,7 +59,7 @@ func TestUpsertDependencyRepo(t *testing.T) {
 	}
 
 	have, err := store.ListDependencyRepos(ctx, ListDependencyReposOpts{
-		Scheme: NPMPackagesScheme,
+		Scheme: NpmPackagesScheme,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/codeintel/lockfiles/npm.go
+++ b/internal/codeintel/lockfiles/npm.go
@@ -41,7 +41,7 @@ func parsePackageLockDependencies(in map[string]*packageLockDependency) ([]repos
 	)
 
 	for name, d := range in {
-		dep, err := reposource.ParseNPMDependency(name + "@" + d.Version)
+		dep, err := reposource.ParseNpmDependency(name + "@" + d.Version)
 		if err != nil {
 			errs = errors.Append(errs, err)
 		} else {
@@ -101,7 +101,7 @@ func parseYarnLockFile(r io.Reader) (deps []reposource.PackageDependency, err er
 				return nil, errors.New("invalid yarn.lock format")
 			}
 
-			dep, err := reposource.ParseNPMDependency(name + "@" + version)
+			dep, err := reposource.ParseNpmDependency(name + "@" + version)
 			if err != nil {
 				errs = errors.Append(errs, err)
 			} else {

--- a/internal/conf/reposource/npm_packages.go
+++ b/internal/conf/reposource/npm_packages.go
@@ -14,28 +14,28 @@ import (
 const (
 	// Exported for [NOTE: npm-tarball-filename-workaround].
 	// . is allowed in scope names: for example https://www.npmjs.com/package/@dinero.js/core
-	NPMScopeRegexString = `(?P<scope>[\w\-\.]+)`
+	NpmScopeRegexString = `(?P<scope>[\w\-\.]+)`
 	// . is allowed in package names: for example https://www.npmjs.com/package/highlight.js
 	npmPackageNameRegexString = `(?P<name>[\w\-]+(\.[\w\-]+)*)`
 )
 
 var (
-	npmScopeRegex          = lazyregexp.New(`^` + NPMScopeRegexString + `$`)
+	npmScopeRegex          = lazyregexp.New(`^` + NpmScopeRegexString + `$`)
 	npmPackageNameRegex    = lazyregexp.New(`^` + npmPackageNameRegexString + `$`)
 	scopedPackageNameRegex = lazyregexp.New(
-		`^(@` + NPMScopeRegexString + `/)?` +
+		`^(@` + NpmScopeRegexString + `/)?` +
 			npmPackageNameRegexString +
 			`@(?P<version>[\w\-]+(\.[\w\-]+)*)$`)
 	npmURLRegex = lazyregexp.New(
-		`^npm/(` + NPMScopeRegexString + `/)?` +
+		`^npm/(` + NpmScopeRegexString + `/)?` +
 			npmPackageNameRegexString + `$`)
 )
 
-// An NPM package of the form (@scope/)?name.
+// An npm package of the form (@scope/)?name.
 //
 // The fields are kept private to reduce risk of not handling the empty scope
 // case correctly.
-type NPMPackage struct {
+type NpmPackage struct {
 	// Optional scope () for a package, can potentially be "".
 	// For more details, see https://docs.npmjs.com/cli/v8/using-npm/scope
 	scope string
@@ -43,23 +43,23 @@ type NPMPackage struct {
 	name string
 }
 
-func NewNPMPackage(scope string, name string) (*NPMPackage, error) {
+func NewNpmPackage(scope string, name string) (*NpmPackage, error) {
 	if scope != "" && !npmScopeRegex.MatchString(scope) {
 		return nil, errors.Errorf("illegal scope %s (allowed characters: 0-9, a-z, A-Z, _, -)", scope)
 	}
 	if !npmPackageNameRegex.MatchString(name) {
 		return nil, errors.Errorf("illegal package name %s (allowed characters: 0-9, a-z, A-Z, _, -)", name)
 	}
-	return &NPMPackage{scope, name}, nil
+	return &NpmPackage{scope, name}, nil
 }
 
-func (pkg *NPMPackage) Equal(other *NPMPackage) bool {
+func (pkg *NpmPackage) Equal(other *NpmPackage) bool {
 	return pkg == other || (pkg != nil && other != nil && *pkg == *other)
 }
 
-// ParseNPMPackageFromRepoURL is a convenience function to parse a string in a
-// 'npm/(scope/)?name' format into an NPMPackage.
-func ParseNPMPackageFromRepoURL(urlPath string) (*NPMPackage, error) {
+// ParseNpmPackageFromRepoURL is a convenience function to parse a string in a
+// 'npm/(scope/)?name' format into an NpmPackage.
+func ParseNpmPackageFromRepoURL(urlPath string) (*NpmPackage, error) {
 	match := npmURLRegex.FindStringSubmatch(urlPath)
 	if match == nil {
 		return nil, errors.Errorf("expected path in npm/(scope/)?name format but found %s", urlPath)
@@ -71,38 +71,38 @@ func ParseNPMPackageFromRepoURL(urlPath string) (*NPMPackage, error) {
 		}
 	}
 	scope, name := result["scope"], result["name"]
-	return &NPMPackage{scope, name}, nil
+	return &NpmPackage{scope, name}, nil
 }
 
-// ParseNPMPackageFromPackageSyntax is a convenience function to parse a
-// string in a '(@scope/)?name' format into an NPMPackage.
-func ParseNPMPackageFromPackageSyntax(pkg string) (*NPMPackage, error) {
-	dep, err := ParseNPMDependency(fmt.Sprintf("%s@0", pkg))
+// ParseNpmPackageFromPackageSyntax is a convenience function to parse a
+// string in a '(@scope/)?name' format into an NpmPackage.
+func ParseNpmPackageFromPackageSyntax(pkg string) (*NpmPackage, error) {
+	dep, err := ParseNpmDependency(fmt.Sprintf("%s@0", pkg))
 	if err != nil {
 		return nil, err
 	}
-	return dep.NPMPackage, nil
+	return dep.NpmPackage, nil
 }
 
-type NPMPackageSerializationHelper struct {
+type NpmPackageSerializationHelper struct {
 	Scope string
 	Name  string
 }
 
-var _ json.Marshaler = &NPMPackage{}
-var _ json.Unmarshaler = &NPMPackage{}
+var _ json.Marshaler = &NpmPackage{}
+var _ json.Unmarshaler = &NpmPackage{}
 
-func (pkg *NPMPackage) MarshalJSON() ([]byte, error) {
-	return json.Marshal(NPMPackageSerializationHelper{pkg.scope, pkg.name})
+func (pkg *NpmPackage) MarshalJSON() ([]byte, error) {
+	return json.Marshal(NpmPackageSerializationHelper{pkg.scope, pkg.name})
 }
 
-func (pkg *NPMPackage) UnmarshalJSON(data []byte) error {
-	var wrapper NPMPackageSerializationHelper
+func (pkg *NpmPackage) UnmarshalJSON(data []byte) error {
+	var wrapper NpmPackageSerializationHelper
 	err := json.Unmarshal(data, &wrapper)
 	if err != nil {
 		return err
 	}
-	newPkg, err := NewNPMPackage(wrapper.Scope, wrapper.Name)
+	newPkg, err := NewNpmPackage(wrapper.Scope, wrapper.Name)
 	if err != nil {
 		return err
 	}
@@ -113,7 +113,7 @@ func (pkg *NPMPackage) UnmarshalJSON(data []byte) error {
 // RepoName provides a name that is "globally unique" for a Sourcegraph instance.
 //
 // The returned value is used for repo:... in queries.
-func (pkg *NPMPackage) RepoName() api.RepoName {
+func (pkg *NpmPackage) RepoName() api.RepoName {
 	if pkg.scope != "" {
 		return api.RepoName(fmt.Sprintf("npm/%s/%s", pkg.scope, pkg.name))
 	}
@@ -121,36 +121,36 @@ func (pkg *NPMPackage) RepoName() api.RepoName {
 }
 
 // CloneURL returns a "URL" that can later be used to download a repo.
-func (pkg *NPMPackage) CloneURL() string {
+func (pkg *NpmPackage) CloneURL() string {
 	return string(pkg.RepoName())
 }
 
 // MatchesDependencyString checks if a dependency (= package + version pair)
 // refers to the same package as pkg.
-func (pkg *NPMPackage) MatchesDependencyString(depPackageSyntax string) bool {
+func (pkg *NpmPackage) MatchesDependencyString(depPackageSyntax string) bool {
 	return strings.HasPrefix(depPackageSyntax, pkg.PackageSyntax()+"@")
 }
 
 // Format a package using (@scope/)?name syntax.
 //
-// This is largely for "lower-level" code interacting with the NPM API.
+// This is largely for "lower-level" code interacting with the npm API.
 //
-// In most cases, you want to use NPMDependency's PackageManagerSyntax() instead.
-func (pkg *NPMPackage) PackageSyntax() string {
+// In most cases, you want to use NpmDependency's PackageManagerSyntax() instead.
+func (pkg *NpmPackage) PackageSyntax() string {
 	if pkg.scope != "" {
 		return fmt.Sprintf("@%s/%s", pkg.scope, pkg.name)
 	}
 	return pkg.name
 }
 
-// NPMDependency is a "versioned package" for use by npm commands, such as
+// NpmDependency is a "versioned package" for use by npm commands, such as
 // `npm install`.
 //
 // See also: [NOTE: Dependency-terminology]
 //
 // Reference:  https://docs.npmjs.com/cli/v8/commands/npm-install
-type NPMDependency struct {
-	*NPMPackage
+type NpmDependency struct {
+	*NpmPackage
 
 	// The version or tag (such as "latest") for a dependency.
 	//
@@ -159,15 +159,15 @@ type NPMDependency struct {
 	Version string
 }
 
-// ParseNPMDependency parses a string in a '(@scope/)?module@version' format into an NPMDependency.
+// ParseNpmDependency parses a string in a '(@scope/)?module@version' format into an NpmDependency.
 //
-// NPM supports many ways of specifying dependencies (https://docs.npmjs.com/cli/v8/commands/npm-install)
+// npm supports many ways of specifying dependencies (https://docs.npmjs.com/cli/v8/commands/npm-install)
 // but we only support exact versions for now.
-func ParseNPMDependency(dependency string) (*NPMDependency, error) {
+func ParseNpmDependency(dependency string) (*NpmDependency, error) {
 	// We use slightly more restrictive validation compared to the official
 	// rules (https://github.com/npm/validate-npm-package-name#naming-rules).
 	//
-	// For example, NPM does not explicitly forbid package names with @ in them.
+	// For example, npm does not explicitly forbid package names with @ in them.
 	// However, there don't seem to be any such packages in practice (I searched
 	// 100k+ packages and got 0 hits). The web frontend relies on using '@' to
 	// split between the package and rev-like part of the URL, such as
@@ -187,39 +187,39 @@ func ParseNPMDependency(dependency string) (*NPMDependency, error) {
 		}
 	}
 	scope, name, version := result["scope"], result["name"], result["version"]
-	return &NPMDependency{&NPMPackage{scope, name}, version}, nil
+	return &NpmDependency{&NpmPackage{scope, name}, version}, nil
 }
 
-// PackageManagerSyntax returns the dependency in NPM/Yarn syntax. The returned
+// PackageManagerSyntax returns the dependency in npm/Yarn syntax. The returned
 // string can (for example) be passed to `npm install`.
-func (d *NPMDependency) PackageManagerSyntax() string {
+func (d *NpmDependency) PackageManagerSyntax() string {
 	return fmt.Sprintf("%s@%s", d.PackageSyntax(), d.Version)
 }
 
-func (d *NPMDependency) Scheme() string {
+func (d *NpmDependency) Scheme() string {
 	return "npm"
 }
 
-func (d *NPMDependency) PackageVersion() string {
+func (d *NpmDependency) PackageVersion() string {
 	return d.Version
 }
 
-func (d *NPMDependency) GitTagFromVersion() string {
+func (d *NpmDependency) GitTagFromVersion() string {
 	return "v" + d.Version
 }
 
-func (d *NPMDependency) Equal(other *NPMDependency) bool {
+func (d *NpmDependency) Equal(other *NpmDependency) bool {
 	return d == other || (d != nil && other != nil &&
-		d.NPMPackage.Equal(other.NPMPackage) &&
+		d.NpmPackage.Equal(other.NpmPackage) &&
 		d.Version == other.Version)
 }
 
 // SortDependencies sorts the dependencies by the semantic version in descending
 // order. The latest version of a dependency becomes the first element of the
 // slice.
-func SortNPMDependencies(dependencies []*NPMDependency) {
+func SortNpmDependencies(dependencies []*NpmDependency) {
 	sort.Slice(dependencies, func(i, j int) bool {
-		iPkg, jPkg := dependencies[i].NPMPackage, dependencies[j].NPMPackage
+		iPkg, jPkg := dependencies[i].NpmPackage, dependencies[j].NpmPackage
 		if iPkg.Equal(jPkg) {
 			return versionGreaterThan(dependencies[i].Version, dependencies[j].Version)
 		}

--- a/internal/conf/reposource/npm_packages_test.go
+++ b/internal/conf/reposource/npm_packages_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseNPMDependency(t *testing.T) {
+func TestParseNpmDependency(t *testing.T) {
 	table := []struct {
 		testName string
 		expect   bool
@@ -29,7 +29,7 @@ func TestParseNPMDependency(t *testing.T) {
 		{"@A.B-C.D-E/F.G--H.IJK-L@0.1-ABC", true},
 	}
 	for _, entry := range table {
-		dep, err := ParseNPMDependency(entry.testName)
+		dep, err := ParseNpmDependency(entry.testName)
 		if entry.expect && (err != nil) {
 			t.Errorf("expected success but got error '%s' when parsing %s",
 				err.Error(), entry.testName)
@@ -39,37 +39,37 @@ func TestParseNPMDependency(t *testing.T) {
 	}
 }
 
-func TestSortNPMDependencies(t *testing.T) {
-	dependencies := []*NPMDependency{
-		parseNPMDependencyOrPanic(t, "ac@1.2.0"),
-		parseNPMDependencyOrPanic(t, "ab@1.2.0.Final"),
-		parseNPMDependencyOrPanic(t, "aa@1.2.0"),
-		parseNPMDependencyOrPanic(t, "ab@1.2.0"),
-		parseNPMDependencyOrPanic(t, "ab@1.11.0"),
-		parseNPMDependencyOrPanic(t, "ab@1.2.0-M11"),
-		parseNPMDependencyOrPanic(t, "ab@1.2.0-M1"),
-		parseNPMDependencyOrPanic(t, "ab@1.2.0-RC11"),
-		parseNPMDependencyOrPanic(t, "ab@1.2.0-RC1"),
-		parseNPMDependencyOrPanic(t, "ab@1.1.0"),
+func TestSortNpmDependencies(t *testing.T) {
+	dependencies := []*NpmDependency{
+		parseNpmDependencyOrPanic(t, "ac@1.2.0"),
+		parseNpmDependencyOrPanic(t, "ab@1.2.0.Final"),
+		parseNpmDependencyOrPanic(t, "aa@1.2.0"),
+		parseNpmDependencyOrPanic(t, "ab@1.2.0"),
+		parseNpmDependencyOrPanic(t, "ab@1.11.0"),
+		parseNpmDependencyOrPanic(t, "ab@1.2.0-M11"),
+		parseNpmDependencyOrPanic(t, "ab@1.2.0-M1"),
+		parseNpmDependencyOrPanic(t, "ab@1.2.0-RC11"),
+		parseNpmDependencyOrPanic(t, "ab@1.2.0-RC1"),
+		parseNpmDependencyOrPanic(t, "ab@1.1.0"),
 	}
-	expected := []*NPMDependency{
-		parseNPMDependencyOrPanic(t, "ac@1.2.0"),
-		parseNPMDependencyOrPanic(t, "ab@1.11.0"),
-		parseNPMDependencyOrPanic(t, "ab@1.2.0"),
-		parseNPMDependencyOrPanic(t, "ab@1.2.0.Final"),
-		parseNPMDependencyOrPanic(t, "ab@1.2.0-RC11"),
-		parseNPMDependencyOrPanic(t, "ab@1.2.0-RC1"),
-		parseNPMDependencyOrPanic(t, "ab@1.2.0-M11"),
-		parseNPMDependencyOrPanic(t, "ab@1.2.0-M1"),
-		parseNPMDependencyOrPanic(t, "ab@1.1.0"),
-		parseNPMDependencyOrPanic(t, "aa@1.2.0"),
+	expected := []*NpmDependency{
+		parseNpmDependencyOrPanic(t, "ac@1.2.0"),
+		parseNpmDependencyOrPanic(t, "ab@1.11.0"),
+		parseNpmDependencyOrPanic(t, "ab@1.2.0"),
+		parseNpmDependencyOrPanic(t, "ab@1.2.0.Final"),
+		parseNpmDependencyOrPanic(t, "ab@1.2.0-RC11"),
+		parseNpmDependencyOrPanic(t, "ab@1.2.0-RC1"),
+		parseNpmDependencyOrPanic(t, "ab@1.2.0-M11"),
+		parseNpmDependencyOrPanic(t, "ab@1.2.0-M1"),
+		parseNpmDependencyOrPanic(t, "ab@1.1.0"),
+		parseNpmDependencyOrPanic(t, "aa@1.2.0"),
 	}
-	SortNPMDependencies(dependencies)
+	SortNpmDependencies(dependencies)
 	assert.Equal(t, expected, dependencies)
 }
 
-func parseNPMDependencyOrPanic(t *testing.T, value string) *NPMDependency {
-	dependency, err := ParseNPMDependency(value)
+func parseNpmDependencyOrPanic(t *testing.T, value string) *NpmDependency {
+	dependency, err := ParseNpmDependency(value)
 	if err != nil {
 		t.Fatalf("error=%s", err)
 	}

--- a/internal/conf/reposource/packages_helper.go
+++ b/internal/conf/reposource/packages_helper.go
@@ -42,4 +42,4 @@ type PackageDependency interface {
 }
 
 var _ PackageDependency = &MavenDependency{}
-var _ PackageDependency = &NPMDependency{}
+var _ PackageDependency = &NpmDependency{}

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -199,7 +199,7 @@ var ExternalServiceKinds = map[string]ExternalServiceKind{
 	extsvc.KindJVMPackages:     {CodeHost: true, JSONSchema: schema.JVMPackagesSchemaJSON},
 	extsvc.KindOther:           {CodeHost: true, JSONSchema: schema.OtherExternalServiceSchemaJSON},
 	extsvc.KindPagure:          {CodeHost: true, JSONSchema: schema.PagureSchemaJSON},
-	extsvc.KindNPMPackages:     {CodeHost: true, JSONSchema: schema.NPMPackagesSchemaJSON},
+	extsvc.KindNpmPackages:     {CodeHost: true, JSONSchema: schema.NpmPackagesSchemaJSON},
 	extsvc.KindPerforce:        {CodeHost: true, JSONSchema: schema.PerforceSchemaJSON},
 	extsvc.KindPhabricator:     {CodeHost: true, JSONSchema: schema.PhabricatorSchemaJSON},
 }

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -493,7 +493,7 @@ func scanRepo(rows *sql.Rows, r *types.Repo) (err error) {
 		r.Metadata = new(extsvc.OtherRepoMetadata)
 	case extsvc.TypeJVMPackages:
 		r.Metadata = new(jvmpackages.Metadata)
-	case extsvc.TypeNPMPackages:
+	case extsvc.TypeNpmPackages:
 		r.Metadata = new(npmpackages.Metadata)
 	default:
 		log15.Warn("scanRepo - unknown service type", "typ", typ)

--- a/internal/extsvc/codehost.go
+++ b/internal/extsvc/codehost.go
@@ -15,7 +15,7 @@ type CodeHost struct {
 
 func (c *CodeHost) IsPackageHost() bool {
 	switch c.ServiceType {
-	case TypeNPMPackages, TypeJVMPackages:
+	case TypeNpmPackages, TypeJVMPackages:
 		return true
 	}
 	return false
@@ -32,14 +32,14 @@ var (
 	MavenURL    = &url.URL{Host: "maven"}
 	JVMPackages = NewCodeHost(MavenURL, TypeJVMPackages)
 
-	NPMURL      = &url.URL{Host: "npm"}
-	NPMPackages = NewCodeHost(NPMURL, TypeNPMPackages)
+	NpmURL      = &url.URL{Host: "npm"}
+	NpmPackages = NewCodeHost(NpmURL, TypeNpmPackages)
 
 	PublicCodeHosts = []*CodeHost{
 		GitHubDotCom,
 		GitLabDotCom,
 		JVMPackages,
-		NPMPackages,
+		NpmPackages,
 	}
 )
 

--- a/internal/extsvc/npm/npm_test.go
+++ b/internal/extsvc/npm/npm_test.go
@@ -30,12 +30,12 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-var updateRecordings = flag.Bool("update", false, "make NPM API calls, record and save data")
+var updateRecordings = flag.Bool("update", false, "make npm API calls, record and save data")
 
 func newTestHTTPClient(t *testing.T) (client *HTTPClient, stop func()) {
 	t.Helper()
 	recorderFactory, stop := httptestutil.NewRecorderFactory(t, *updateRecordings, t.Name())
-	rateLimit := schema.NPMRateLimit{true, 1000}
+	rateLimit := schema.NpmRateLimit{true, 1000}
 	client = NewHTTPClient("https://registry.npmjs.org", &rateLimit, "")
 	doer, err := recorderFactory.Doer()
 	require.Nil(t, err)
@@ -43,7 +43,7 @@ func newTestHTTPClient(t *testing.T) (client *HTTPClient, stop func()) {
 	return client, stop
 }
 
-func mockNPMServer(credentials string) *httptest.Server {
+func mockNpmServer(credentials string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if key, ok := req.Header["Authorization"]; ok && key[0] != fmt.Sprintf("Bearer %s", credentials) {
 			w.WriteHeader(http.StatusUnauthorized)
@@ -74,16 +74,16 @@ func mockNPMServer(credentials string) *httptest.Server {
 
 func TestCredentials(t *testing.T) {
 	credentials := "top secret access token"
-	server := mockNPMServer(credentials)
+	server := mockNpmServer(credentials)
 	defer server.Close()
 
 	ctx := context.Background()
-	rateLimit := schema.NPMRateLimit{true, 1000}
+	rateLimit := schema.NpmRateLimit{true, 1000}
 	client := NewHTTPClient(server.URL, &rateLimit, credentials)
 
-	presentDep, err := reposource.ParseNPMDependency("left-pad@1.3.0")
+	presentDep, err := reposource.ParseNpmDependency("left-pad@1.3.0")
 	require.NoError(t, err)
-	absentDep, err := reposource.ParseNPMDependency("left-pad@1.3.1")
+	absentDep, err := reposource.ParseNpmDependency("left-pad@1.3.1")
 	require.NoError(t, err)
 
 	info, err := client.GetDependencyInfo(ctx, presentDep)
@@ -112,7 +112,7 @@ func TestGetPackage(t *testing.T) {
 	ctx := context.Background()
 	client, stop := newTestHTTPClient(t)
 	defer stop()
-	pkg, err := reposource.ParseNPMPackageFromPackageSyntax("is-sorted")
+	pkg, err := reposource.ParseNpmPackageFromPackageSyntax("is-sorted")
 	require.Nil(t, err)
 	info, err := client.GetPackageInfo(ctx, pkg)
 	require.Nil(t, err)
@@ -129,12 +129,12 @@ func TestGetDependencyInfo(t *testing.T) {
 	ctx := context.Background()
 	client, stop := newTestHTTPClient(t)
 	defer stop()
-	dep, err := reposource.ParseNPMDependency("left-pad@1.3.0")
+	dep, err := reposource.ParseNpmDependency("left-pad@1.3.0")
 	require.NoError(t, err)
 	info, err := client.GetDependencyInfo(ctx, dep)
 	require.NoError(t, err)
 	require.NotNil(t, info)
-	dep, err = reposource.ParseNPMDependency("left-pad@1.3.1")
+	dep, err = reposource.ParseNpmDependency("left-pad@1.3.1")
 	require.NoError(t, err)
 	info, err = client.GetDependencyInfo(ctx, dep)
 	require.Nil(t, info)
@@ -145,7 +145,7 @@ func TestFetchSources(t *testing.T) {
 	ctx := context.Background()
 	client, stop := newTestHTTPClient(t)
 	defer stop()
-	dep, err := reposource.ParseNPMDependency("is-sorted@1.0.0")
+	dep, err := reposource.ParseNpmDependency("is-sorted@1.0.0")
 	require.Nil(t, err)
 	readSeekCloser, err := client.FetchTarball(ctx, dep)
 	require.Nil(t, err)
@@ -180,7 +180,7 @@ func TestNoPanicOnNonexistentRegistry(t *testing.T) {
 	client, stop := newTestHTTPClient(t)
 	defer stop()
 	client.registryURL = "http://not-an-npm-registry.sourcegraph.com"
-	dep, err := reposource.ParseNPMDependency("left-pad@1.3.0")
+	dep, err := reposource.ParseNpmDependency("left-pad@1.3.0")
 	require.Nil(t, err)
 	info, err := client.GetDependencyInfo(ctx, dep)
 	require.Error(t, err)

--- a/internal/extsvc/npm/npmpackages/repos.go
+++ b/internal/extsvc/npm/npmpackages/repos.go
@@ -3,5 +3,5 @@ package npmpackages
 import "github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 
 type Metadata struct {
-	Package *reposource.NPMPackage
+	Package *reposource.NpmPackage
 }

--- a/internal/extsvc/npm/npmtest/npmtest.go
+++ b/internal/extsvc/npm/npmtest/npmtest.go
@@ -21,7 +21,7 @@ func NewMockClient(t testing.TB, deps ...string) *MockClient {
 
 	packages := map[string]*npm.PackageInfo{}
 	for _, dep := range deps {
-		d, err := reposource.ParseNPMDependency(dep)
+		d, err := reposource.ParseNpmDependency(dep)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -47,7 +47,7 @@ func NewMockClient(t testing.TB, deps ...string) *MockClient {
 
 var _ npm.Client = &MockClient{}
 
-func (m *MockClient) GetPackageInfo(ctx context.Context, pkg *reposource.NPMPackage) (info *npm.PackageInfo, err error) {
+func (m *MockClient) GetPackageInfo(ctx context.Context, pkg *reposource.NpmPackage) (info *npm.PackageInfo, err error) {
 	info = m.Packages[pkg.PackageSyntax()]
 	if info == nil {
 		return nil, errors.Newf("package not found: %s", pkg.PackageSyntax())
@@ -55,8 +55,8 @@ func (m *MockClient) GetPackageInfo(ctx context.Context, pkg *reposource.NPMPack
 	return info, nil
 }
 
-func (m *MockClient) GetDependencyInfo(ctx context.Context, dep *reposource.NPMDependency) (info *npm.DependencyInfo, err error) {
-	pkg, err := m.GetPackageInfo(ctx, dep.NPMPackage)
+func (m *MockClient) GetDependencyInfo(ctx context.Context, dep *reposource.NpmDependency) (info *npm.DependencyInfo, err error) {
+	pkg, err := m.GetPackageInfo(ctx, dep.NpmPackage)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func (m *MockClient) GetDependencyInfo(ctx context.Context, dep *reposource.NPMD
 	return info, nil
 }
 
-func (m *MockClient) FetchTarball(_ context.Context, dep *reposource.NPMDependency) (io.ReadCloser, error) {
+func (m *MockClient) FetchTarball(_ context.Context, dep *reposource.NpmDependency) (io.ReadCloser, error) {
 	info, ok := m.Packages[dep.PackageSyntax()]
 	if !ok {
 		return nil, errors.Newf("Unknown dependency: %s", dep.PackageManagerSyntax())

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -84,7 +84,7 @@ const (
 	KindPhabricator     = "PHABRICATOR"
 	KindJVMPackages     = "JVMPACKAGES"
 	KindPagure          = "PAGURE"
-	KindNPMPackages     = "NPMPACKAGES"
+	KindNpmPackages     = "NPMPACKAGES"
 	KindOther           = "OTHER"
 )
 
@@ -127,8 +127,8 @@ const (
 	// TypePagure is the (api.ExternalRepoSpec).ServiceType value for Pagure projects.
 	TypePagure = "pagure"
 
-	// TypeNPMPackages is the (api.ExternalRepoSpec).ServiceType value for NPM packages (JavaScript/TypeScript ecosystem libraries).
-	TypeNPMPackages = "npmPackages"
+	// TypeNpmPackages is the (api.ExternalRepoSpec).ServiceType value for Npm packages (JavaScript/TypeScript ecosystem libraries).
+	TypeNpmPackages = "npmPackages"
 
 	// TypeOther is the (api.ExternalRepoSpec).ServiceType value for other projects.
 	TypeOther = "other"
@@ -187,8 +187,8 @@ func TypeToKind(t string) string {
 		return KindPerforce
 	case TypePhabricator:
 		return KindPhabricator
-	case TypeNPMPackages:
-		return KindNPMPackages
+	case TypeNpmPackages:
+		return KindNpmPackages
 	case TypeJVMPackages:
 		return KindJVMPackages
 	case TypePagure:
@@ -205,7 +205,7 @@ var (
 	bbsLower = strings.ToLower(TypeBitbucketServer)
 	bbcLower = strings.ToLower(TypeBitbucketCloud)
 	jvmLower = strings.ToLower(TypeJVMPackages)
-	npmLower = strings.ToLower(TypeNPMPackages)
+	npmLower = strings.ToLower(TypeNpmPackages)
 )
 
 // ParseServiceType will return a ServiceType constant after doing a case insensitive match on s.
@@ -231,7 +231,7 @@ func ParseServiceType(s string) (string, bool) {
 	case jvmLower:
 		return TypeJVMPackages, true
 	case npmLower:
-		return TypeNPMPackages, true
+		return TypeNpmPackages, true
 	case TypePagure:
 		return TypePagure, true
 	case TypeOther:
@@ -308,8 +308,8 @@ func ParseConfig(kind, config string) (cfg interface{}, _ error) {
 		cfg = &schema.JVMPackagesConnection{}
 	case KindPagure:
 		cfg = &schema.PagureConnection{}
-	case KindNPMPackages:
-		cfg = &schema.NPMPackagesConnection{}
+	case KindNpmPackages:
+		cfg = &schema.NpmPackagesConnection{}
 	case KindOther:
 		cfg = &schema.OtherExternalServiceConnection{}
 	default:
@@ -542,8 +542,8 @@ func UniqueCodeHostIdentifier(kind, config string) (string, error) {
 		return c.P4Port, nil
 	case *schema.JVMPackagesConnection:
 		return KindJVMPackages, nil
-	case *schema.NPMPackagesConnection:
-		return KindNPMPackages, nil
+	case *schema.NpmPackagesConnection:
+		return KindNpmPackages, nil
 	case *schema.PagureConnection:
 		rawURL = c.Url
 	default:

--- a/internal/repos/clone_url.go
+++ b/internal/repos/clone_url.go
@@ -77,7 +77,7 @@ func CloneURL(kind, config string, repo *types.Repo) (string, error) {
 		if r, ok := repo.Metadata.(*jvmpackages.Metadata); ok {
 			return r.Module.CloneURL(), nil
 		}
-	case *schema.NPMPackagesConnection:
+	case *schema.NpmPackagesConnection:
 		if r, ok := repo.Metadata.(*npmpackages.Metadata); ok {
 			return r.Package.CloneURL(), nil
 		}

--- a/internal/repos/sources.go
+++ b/internal/repos/sources.go
@@ -61,8 +61,8 @@ func NewSource(externalServicesStore database.ExternalServiceStore, svc *types.E
 		return NewJVMPackagesSource(svc)
 	case extsvc.KindPagure:
 		return NewPagureSource(svc, cf)
-	case extsvc.KindNPMPackages:
-		return NewNPMPackagesSource(svc)
+	case extsvc.KindNpmPackages:
+		return NewNpmPackagesSource(svc)
 	case extsvc.KindOther:
 		return NewOtherSource(svc, cf)
 	default:

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -252,7 +252,7 @@ func (d Diff) Len() int {
 // It works for repos from:
 // 1. Public "cloud_default" code hosts since we don't sync them in the background
 //    (which would delete lazy synced repos).
-// 2. Any package hosts (i.e. NPM, Maven, etc) since callers are expected to store
+// 2. Any package hosts (i.e. npm, Maven, etc) since callers are expected to store
 //    repos in the `lsif_dependency_repos` table which is used as the source of truth
 //    for the next full sync, so lazy added repos don't get wiped.
 //

--- a/internal/search/alert/observer.go
+++ b/internal/search/alert/observer.go
@@ -90,8 +90,8 @@ func (o *Observer) alertForNoResolvedRepos(ctx context.Context, q query.Q) *sear
 	isSiteAdmin := backend.CheckCurrentUserIsSiteAdmin(ctx, o.Db) == nil
 	if !envvar.SourcegraphDotComMode() {
 		if len(dependencies) > 0 {
-			needsNPMConfig, err := needsNPMPackageHostConfiguration(ctx, o.Db)
-			if err == nil && needsNPMConfig {
+			needsNpmConfig, err := needsNpmPackageHostConfiguration(ctx, o.Db)
+			if err == nil && needsNpmConfig {
 				if isSiteAdmin {
 					return &search.Alert{
 						Title:       "No package hosts configured",
@@ -124,7 +124,7 @@ func (o *Observer) alertForNoResolvedRepos(ctx context.Context, q query.Q) *sear
 	if len(dependencies) > 0 {
 		return &search.Alert{
 			Title:       "No dependency repositories found",
-			Description: "Dependency repos are cloned on-demand when first searched. Try again in a few seconds if you know the given repositories have dependencies.\n\nOnly NPM dependencies from `package-lock.json` and `yarn.lock` files are currently supported.",
+			Description: "Dependency repos are cloned on-demand when first searched. Try again in a few seconds if you know the given repositories have dependencies.\n\nOnly npm dependencies from `package-lock.json` and `yarn.lock` files are currently supported.",
 		}
 	}
 
@@ -362,9 +362,9 @@ func needsRepositoryConfiguration(ctx context.Context, db database.DB) (bool, er
 	return count == 0, nil
 }
 
-func needsNPMPackageHostConfiguration(ctx context.Context, db database.DB) (bool, error) {
+func needsNpmPackageHostConfiguration(ctx context.Context, db database.DB) (bool, error) {
 	count, err := database.ExternalServices(db).Count(ctx, database.ExternalServicesListOptions{
-		Kinds: []string{extsvc.KindNPMPackages},
+		Kinds: []string{extsvc.KindNpmPackages},
 	})
 	if err != nil {
 		return false, err

--- a/internal/types/secret.go
+++ b/internal/types/secret.go
@@ -108,7 +108,7 @@ func redactionInfo(cfg interface{}) ([]jsonStringField, error) {
 			return []jsonStringField{{[]string{"token"}, &cfg.Token}}, nil
 		}
 		return []jsonStringField{}, nil
-	case *schema.NPMPackagesConnection:
+	case *schema.NpmPackagesConnection:
 		return []jsonStringField{{[]string{"credentials"}, &cfg.Credentials}}, nil
 	case *schema.OtherExternalServiceConnection:
 		return []jsonStringField{{[]string{"url"}, &cfg.Url}}, nil

--- a/internal/types/secret_test.go
+++ b/internal/types/secret_test.go
@@ -70,7 +70,7 @@ func TestRoundTripRedactExternalServiceConfig(t *testing.T) {
 	pagureConfig := schema.PagureConnection{
 		Url: "https://src.fedoraproject.org",
 	}
-	npmPackagesConfig := schema.NPMPackagesConnection{
+	npmPackagesConfig := schema.NpmPackagesConnection{
 		Credentials:  "npm credentials!",
 		Dependencies: []string{"placeholder"},
 	}
@@ -141,9 +141,9 @@ func TestRoundTripRedactExternalServiceConfig(t *testing.T) {
 			editField: func(cfg interface{}) *string { return &cfg.(*schema.PagureConnection).Pattern },
 		},
 		{
-			kind:      extsvc.KindNPMPackages,
+			kind:      extsvc.KindNpmPackages,
 			config:    &npmPackagesConfig,
-			editField: func(cfg interface{}) *string { return &cfg.(*schema.NPMPackagesConnection).Dependencies[0] },
+			editField: func(cfg interface{}) *string { return &cfg.(*schema.NpmPackagesConnection).Dependencies[0] },
 		},
 		{
 			kind:   extsvc.KindOther,

--- a/lib/codeintel/autoindex/inference/typescript.go
+++ b/lib/codeintel/autoindex/inference/typescript.go
@@ -112,14 +112,14 @@ func InferTypeScriptIndexJobs(gitclient GitClient, paths []string) (indexes []co
 
 func checkLernaFile(gitclient GitClient, path string, pathMap pathMap) (isYarn bool) {
 	lernaConfig := struct {
-		NPMClient string `json:"npmClient"`
+		NpmClient string `json:"npmClient"`
 	}{}
 
 	for _, dir := range ancestorDirs(path) {
 		if pathMap.contains(dir, "lerna.json") {
 			lernaPath := filepath.Join(dir, "lerna.json")
 			if b, err := gitclient.RawContents(context.TODO(), lernaPath); err == nil {
-				if err := json.Unmarshal(b, &lernaConfig); err == nil && lernaConfig.NPMClient == "yarn" {
+				if err := json.Unmarshal(b, &lernaConfig); err == nil && lernaConfig.NpmClient == "yarn" {
 					return true
 				}
 			}

--- a/monitoring/definitions/git_server.go
+++ b/monitoring/definitions/git_server.go
@@ -451,7 +451,7 @@ func GitServer() *monitoring.Container {
 			},
 
 			shared.CodeIntelligence.NewCoursierGroup(containerName),
-			shared.CodeIntelligence.NewNPMGroup(containerName),
+			shared.CodeIntelligence.NewNpmGroup(containerName),
 
 			shared.NewDatabaseConnectionsMonitoringGroup(containerName),
 			shared.NewContainerMonitoringGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -462,7 +462,7 @@ func RepoUpdater() *monitoring.Container {
 			shared.Batches.NewServiceGroup(containerName),
 
 			shared.CodeIntelligence.NewCoursierGroup(containerName),
-			shared.CodeIntelligence.NewNPMGroup(containerName),
+			shared.CodeIntelligence.NewNpmGroup(containerName),
 
 			shared.NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName, monitoring.ObservableOwnerCoreApplication, nil),
 			shared.NewDatabaseConnectionsMonitoringGroup(containerName),

--- a/monitoring/definitions/shared/codeintel.go
+++ b/monitoring/definitions/shared/codeintel.go
@@ -890,8 +890,8 @@ func (codeIntelligence) NewCoursierGroup(containerName string) monitoring.Group 
 	return newPackageManagerGroup("Coursier", containerName)
 }
 
-func (codeIntelligence) NewNPMGroup(containerName string) monitoring.Group {
-	return newPackageManagerGroup("NPM", containerName)
+func (codeIntelligence) NewNpmGroup(containerName string) monitoring.Group {
+	return newPackageManagerGroup("npm", containerName)
 }
 
 func (codeIntelligence) NewDependencyReposStoreGroup(containerName string) monitoring.Group {

--- a/schema/npm-packages.schema.json
+++ b/schema/npm-packages.schema.json
@@ -1,28 +1,28 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "npm-packages.schema.json#",
-  "title": "NPMPackagesConnection",
-  "description": "Configuration for a connection to an NPM packages repository.",
+  "title": "NpmPackagesConnection",
+  "description": "Configuration for a connection to an npm packages repository.",
   "allowComments": true,
   "type": "object",
   "additionalProperties": false,
   "required": ["registry"],
   "properties": {
     "credentials": {
-      "description": "Access token for logging into the NPM registry.",
+      "description": "Access token for logging into the npm registry.",
       "type": "string",
       "default": "",
       "examples": ["CRs5VaTVbR7pBPcVpaxwQeafrYOId7IdVUiZCkFCqnw="]
     },
     "registry": {
-      "description": "The URL at which the NPM registry can be found.",
+      "description": "The URL at which the npm registry can be found.",
       "type": "string",
       "default": "https://registry.npmjs.org",
       "examples": ["https://npm-registry.mycompany.com"]
     },
     "rateLimit": {
-      "description": "Rate limit applied when making background API requests to the NPM registry.",
-      "title": "NPMRateLimit",
+      "description": "Rate limit applied when making background API requests to the npm registry.",
+      "title": "NpmRateLimit",
       "type": "object",
       "required": ["enabled", "requestsPerHour"],
       "properties": {
@@ -44,7 +44,7 @@
       }
     },
     "dependencies": {
-      "description": "An array of \"(@scope/)?packageName@version\" strings specifying which NPM packages to mirror on Sourcegraph.",
+      "description": "An array of \"(@scope/)?packageName@version\" strings specifying which npm packages to mirror on Sourcegraph.",
       "type": "array",
       "items": {
         "type": "string",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -583,7 +583,7 @@ type ExperimentalFeatures struct {
 	EventLogging string `json:"eventLogging,omitempty"`
 	// JvmPackages description: Allow adding JVM packages code host connections
 	JvmPackages string `json:"jvmPackages,omitempty"`
-	// NpmPackages description: Allow adding NPM packages code host connections
+	// NpmPackages description: Allow adding npm packages code host connections
 	NpmPackages string `json:"npmPackages,omitempty"`
 	// Pagure description: Allow adding Pagure code host connections
 	Pagure string `json:"pagure,omitempty"`
@@ -1026,26 +1026,6 @@ type MountedEncryptionKey struct {
 	Version    string `json:"version,omitempty"`
 }
 
-// NPMPackagesConnection description: Configuration for a connection to an NPM packages repository.
-type NPMPackagesConnection struct {
-	// Credentials description: Access token for logging into the NPM registry.
-	Credentials string `json:"credentials,omitempty"`
-	// Dependencies description: An array of "(@scope/)?packageName@version" strings specifying which NPM packages to mirror on Sourcegraph.
-	Dependencies []string `json:"dependencies,omitempty"`
-	// RateLimit description: Rate limit applied when making background API requests to the NPM registry.
-	RateLimit *NPMRateLimit `json:"rateLimit,omitempty"`
-	// Registry description: The URL at which the NPM registry can be found.
-	Registry string `json:"registry"`
-}
-
-// NPMRateLimit description: Rate limit applied when making background API requests to the NPM registry.
-type NPMRateLimit struct {
-	// Enabled description: true if rate limiting is enabled.
-	Enabled bool `json:"enabled"`
-	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second. Internally, the burst limit is set to 100, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 100 requests immediately, provided that the complexity cost of each request is 1.
-	RequestsPerHour float64 `json:"requestsPerHour"`
-}
-
 // NoOpEncryptionKey description: This encryption key is a no op, leaving your data in plaintext (not recommended).
 type NoOpEncryptionKey struct {
 	Type string `json:"type"`
@@ -1158,6 +1138,26 @@ type NotifierWebhook struct {
 	Type        string `json:"type"`
 	Url         string `json:"url"`
 	Username    string `json:"username,omitempty"`
+}
+
+// NpmPackagesConnection description: Configuration for a connection to an npm packages repository.
+type NpmPackagesConnection struct {
+	// Credentials description: Access token for logging into the npm registry.
+	Credentials string `json:"credentials,omitempty"`
+	// Dependencies description: An array of "(@scope/)?packageName@version" strings specifying which npm packages to mirror on Sourcegraph.
+	Dependencies []string `json:"dependencies,omitempty"`
+	// RateLimit description: Rate limit applied when making background API requests to the npm registry.
+	RateLimit *NpmRateLimit `json:"rateLimit,omitempty"`
+	// Registry description: The URL at which the npm registry can be found.
+	Registry string `json:"registry"`
+}
+
+// NpmRateLimit description: Rate limit applied when making background API requests to the npm registry.
+type NpmRateLimit struct {
+	// Enabled description: true if rate limiting is enabled.
+	Enabled bool `json:"enabled"`
+	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second. Internally, the burst limit is set to 100, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 100 requests immediately, provided that the complexity cost of each request is 1.
+	RequestsPerHour float64 `json:"requestsPerHour"`
 }
 type OAuthIdentity struct {
 	Type string `json:"type"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -160,7 +160,7 @@
           }
         },
         "npmPackages": {
-          "description": "Allow adding NPM packages code host connections",
+          "description": "Allow adding npm packages code host connections",
           "type": "string",
           "enum": ["enabled", "disabled"],
           "default": "enabled"

--- a/schema/stringdata.go
+++ b/schema/stringdata.go
@@ -38,9 +38,9 @@ var GitoliteSchemaJSON string
 //go:embed jvm-packages.schema.json
 var JVMPackagesSchemaJSON string
 
-// NPMPackagesSchemaJSON is the content of the file "npm-packages.schema.json".
+// NpmPackagesSchemaJSON is the content of the file "npm-packages.schema.json".
 //go:embed npm-packages.schema.json
-var NPMPackagesSchemaJSON string
+var NpmPackagesSchemaJSON string
 
 // OtherExternalServiceSchemaJSON is the content of the file "other_external_service.schema.json".
 //go:embed other_external_service.schema.json


### PR DESCRIPTION
- Spelled as Npm or NPM depending on local case convention.
  For local variables and in types, Npm should be preferred.
  For fully uppercase spellings, NPM should be used.
- Default to spelling it as npm otherwise.

This matches the convention in the npm/cli code and the
[recommendation in the npm/cli README](https://github.com/npm/cli/#is-it-npm-or-npm-or-npm).

## Test plan

Ran existing tests.

