### PR TITLE
Repo aware monitors: add hook in CommitSearch job

### DIFF
--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -102,15 +102,18 @@ func (j *CommitSearch) Run(ctx context.Context, db database.DB, stream streaming
 			})
 		}
 
-		bounded.Go(func() error {
+		doSearch := func(args *gitprotocol.SearchRequest) error {
 			limitHit, err := j.Gitserver.Search(ctx, args, onMatches)
 			stream.Send(streaming.SearchEvent{
 				Stats: streaming.Stats{
 					IsLimitHit: limitHit,
 				},
 			})
-
 			return err
+		}
+
+		bounded.Go(func() error {
+			return doSearch(args)
 		})
 	}
 

--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -40,8 +40,6 @@ type CommitSearch struct {
 	CodeMonitorSearchWrapper func(_ context.Context, _ database.DB, _ GitserverClient, doSearch func(*gitprotocol.SearchRequest) error) error `json:"-"`
 }
 
-type DoSearchFunc func(*gitprotocol.SearchRequest) error
-
 type GitserverClient interface {
 	Search(_ context.Context, _ *protocol.SearchRequest, onMatches func([]protocol.CommitMatch)) (limitHit bool, _ error)
 	ResolveRevisions(context.Context, api.RepoName, []gitprotocol.RevisionSpecifier) ([]string, error)

--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/regexp"
 	"github.com/opentracing/opentracing-go/log"
 
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
@@ -33,11 +34,17 @@ type CommitSearch struct {
 	Limit                int
 	CodeMonitorID        *int64
 	IncludeModifiedFiles bool
-	Gitserver            gitserverSearcher `json:"-"`
+	Gitserver            GitserverClient `json:"-"`
+
+	// CodeMonitorSearchWrapper, if set, will wrap the commit search with extra logic specific to code monitors.
+	CodeMonitorSearchWrapper func(_ context.Context, _ database.DB, _ GitserverClient, doSearch func(*gitprotocol.SearchRequest) error) error `json:"-"`
 }
 
-type gitserverSearcher interface {
+type DoSearchFunc func(*gitprotocol.SearchRequest) error
+
+type GitserverClient interface {
 	Search(_ context.Context, _ *protocol.SearchRequest, onMatches func([]protocol.CommitMatch)) (limitHit bool, _ error)
+	ResolveRevisions(context.Context, api.RepoName, []gitprotocol.RevisionSpecifier) ([]string, error)
 }
 
 func (j *CommitSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (_ *search.Alert, err error) {
@@ -113,6 +120,9 @@ func (j *CommitSearch) Run(ctx context.Context, db database.DB, stream streaming
 		}
 
 		bounded.Go(func() error {
+			if j.CodeMonitorSearchWrapper != nil {
+				return j.CodeMonitorSearchWrapper(ctx, db, j.Gitserver, doSearch)
+			}
 			return doSearch(args)
 		})
 	}


### PR DESCRIPTION
This adds a hook function to the `CommitSearch` job that will wrap the search call with logic specific to code monitors. Because repo resolution and revision resolution are currently very tied together, I can't just mutate the inputs to the `CommitSearch` job yet, so for the moment we're stuck with this hook function. Thankfully, the footprint is pretty minimal. All the rest of the logic will live in code monitor packages.

Stacked on #32571 
Pulled from #32464 

## Test plan

Currently unused because `CodeMonitorSearchWrapper` will always be `nil`. Other changes are semantics-preserving and covered by existing tests.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


