### PR TITLE
Repo aware monitors: populate `CommitSearch` hook

### DIFF
--- a/enterprise/internal/codemonitors/background/search.go
+++ b/enterprise/internal/codemonitors/background/search.go
@@ -168,7 +168,6 @@ func addCodeMonitorHook(in job.Job, monitorID int64) (_ job.Job, err error) {
 		MapRepoSearchJob:               func(j *run.RepoSearch) *run.RepoSearch { addErr(j); return nil },
 		MapRepoUniverseTextSearchJob:   func(j *zoekt.GlobalSearch) *zoekt.GlobalSearch { addErr(j); return nil },
 		MapStructuralSearchJob:         func(j *structural.StructuralSearch) *structural.StructuralSearch { addErr(j); return nil },
-		MapRepoSubsetSymbolSearchJob:   func(j *symbol.RepoSubsetSymbolSearch) *symbol.RepoSubsetSymbolSearch { addErr(j); return nil },
 		MapRepoUniverseSymbolSearchJob: func(j *symbol.RepoUniverseSymbolSearch) *symbol.RepoUniverseSymbolSearch { addErr(j); return nil },
 
 		// Add hook to any commit search jobs

--- a/enterprise/internal/codemonitors/background/search.go
+++ b/enterprise/internal/codemonitors/background/search.go
@@ -3,7 +3,9 @@ package background
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/json"
+	"hash/fnv"
 	"net/http"
 	"net/url"
 
@@ -12,15 +14,24 @@ import (
 	"github.com/opentracing/opentracing-go/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/api/internalapi"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
+	gitprotocol "github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/client"
+	"github.com/sourcegraph/sourcegraph/internal/search/commit"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/predicate"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/internal/search/run"
+	"github.com/sourcegraph/sourcegraph/internal/search/searcher"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+	"github.com/sourcegraph/sourcegraph/internal/search/structural"
+	"github.com/sourcegraph/sourcegraph/internal/search/symbol"
+	"github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -98,7 +109,7 @@ func settings(ctx context.Context) (_ *schema.Settings, err error) {
 	return &unmarshaledSettings, nil
 }
 
-func doSearch(ctx context.Context, db database.DB, query string, settings *schema.Settings) (_ []*result.CommitMatch, err error) {
+func doSearch(ctx context.Context, db database.DB, query string, monitorID int64, settings *schema.Settings) (_ []*result.CommitMatch, err error) {
 	searchClient := client.NewSearchClient(db, search.Indexed(), search.SearcherURLs())
 	inputs, err := searchClient.Plan(ctx, "V2", nil, query, search.Streaming, settings, envvar.SourcegraphDotComMode())
 	if err != nil {
@@ -115,6 +126,13 @@ func doSearch(ctx context.Context, db database.DB, query string, settings *schem
 	planJob, err := job.FromExpandedPlan(jobArgs, plan)
 	if err != nil {
 		return nil, err
+	}
+
+	if featureflag.FromContext(ctx).GetBoolOr("cc-repo-aware-monitors", false) {
+		planJob, err = addCodeMonitorHook(planJob, monitorID)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Execute the search
@@ -134,6 +152,104 @@ func doSearch(ctx context.Context, db database.DB, query string, settings *schem
 	}
 
 	return results, nil
+}
+
+func addCodeMonitorHook(in job.Job, monitorID int64) (_ job.Job, err error) {
+	addErr := func(j interface{}) {
+		err = errors.Append(err, errors.Errorf("found invalid leaf job %T", j))
+	}
+
+	mapper := job.Mapper{
+		// Error on any leaf nodes that aren't commit/diff searches
+		MapZoektRepoSubsetSearchJob:    func(j *zoekt.ZoektRepoSubsetSearch) *zoekt.ZoektRepoSubsetSearch { addErr(j); return nil },
+		MapZoektSymbolSearchJob:        func(j *zoekt.ZoektSymbolSearch) *zoekt.ZoektSymbolSearch { addErr(j); return nil },
+		MapSearcherJob:                 func(j *searcher.Searcher) *searcher.Searcher { addErr(j); return nil },
+		MapSymbolSearcherJob:           func(j *searcher.SymbolSearcher) *searcher.SymbolSearcher { addErr(j); return nil },
+		MapRepoSearchJob:               func(j *run.RepoSearch) *run.RepoSearch { addErr(j); return nil },
+		MapRepoUniverseTextSearchJob:   func(j *zoekt.GlobalSearch) *zoekt.GlobalSearch { addErr(j); return nil },
+		MapStructuralSearchJob:         func(j *structural.StructuralSearch) *structural.StructuralSearch { addErr(j); return nil },
+		MapRepoSubsetSymbolSearchJob:   func(j *symbol.RepoSubsetSymbolSearch) *symbol.RepoSubsetSymbolSearch { addErr(j); return nil },
+		MapRepoUniverseSymbolSearchJob: func(j *symbol.RepoUniverseSymbolSearch) *symbol.RepoUniverseSymbolSearch { addErr(j); return nil },
+
+		// Add hook to any commit search jobs
+		MapCommitSearchJob: func(c *commit.CommitSearch) *commit.CommitSearch {
+			jobCopy := *c
+			jobCopy.CodeMonitorSearchWrapper = func(ctx context.Context, db database.DB, gs commit.GitserverClient, args *gitprotocol.SearchRequest, doSearch commit.DoSearchFunc) error {
+				return hookWithID(ctx, db, gs, args, doSearch, monitorID)
+			}
+			return &jobCopy
+		},
+	}
+
+	return mapper.Map(in), err
+}
+
+func hookWithID(
+	ctx context.Context,
+	db database.DB,
+	gs commit.GitserverClient,
+	args *gitprotocol.SearchRequest,
+	doSearch commit.DoSearchFunc,
+	monitorID int64,
+) error {
+	cm := edb.NewEnterpriseDB(db).CodeMonitors()
+
+	// Resolve the requested revisions into a static set of commit hashes
+	commitHashes, err := gs.ResolveRevisions(ctx, args.Repo, args.Revisions)
+	if err != nil {
+		return err
+	}
+
+	// Look up the previously searched set of commit hashes
+	argsHash := hashArgs(args)
+	lastSearched, err := cm.GetLastSearched(ctx, monitorID, argsHash)
+	if err != nil {
+		return err
+	}
+	if len(lastSearched) == 0 {
+		// We've never run this monitor before. Do not run, but start here next time.
+		return cm.UpsertLastSearched(ctx, monitorID, argsHash, commitHashes)
+	}
+
+	// Merge requested hashes and excluded hashes
+	newRevs := make([]gitprotocol.RevisionSpecifier, 0, len(commitHashes)+len(lastSearched))
+	for _, hash := range commitHashes {
+		newRevs = append(newRevs, gitprotocol.RevisionSpecifier{RevSpec: hash})
+	}
+	for _, exclude := range lastSearched {
+		newRevs = append(newRevs, gitprotocol.RevisionSpecifier{RevSpec: "^" + exclude})
+	}
+
+	// Update args with the new set of revisions
+	argsCopy := *args
+	argsCopy.Revisions = newRevs
+
+	// Execute the search
+	err = doSearch(&argsCopy)
+	if err != nil {
+		return err
+	}
+
+	// If the search was successful, store the resolved hashes
+	// as the new "last searched" hashes
+	return cm.UpsertLastSearched(ctx, monitorID, argsHash, commitHashes)
+}
+
+func hashArgs(args *gitprotocol.SearchRequest) int64 {
+	hasher := fnv.New64()
+	hasher.Write([]byte(args.Repo))
+	for _, rev := range args.Revisions {
+		hasher.Write([]byte(rev.RevSpec))
+		hasher.Write([]byte{'|'})
+		hasher.Write([]byte(rev.RefGlob))
+		hasher.Write([]byte{'|'})
+		hasher.Write([]byte(rev.ExcludeRefGlob))
+	}
+	if args.Query != nil {
+		hasher.Write([]byte(args.Query.String()))
+	}
+	binary.Write(hasher, binary.LittleEndian, args.IncludeDiff)
+	return int64(hasher.Sum64())
 }
 
 func gqlURL(queryName string) (string, error) {

--- a/enterprise/internal/codemonitors/background/search_test.go
+++ b/enterprise/internal/codemonitors/background/search_test.go
@@ -1,0 +1,156 @@
+package background
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	gitprotocol "github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/search/commit"
+	"github.com/sourcegraph/sourcegraph/internal/search/job"
+	"github.com/sourcegraph/sourcegraph/internal/search/run"
+	"github.com/sourcegraph/sourcegraph/internal/search/searcher"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func TestHashArgs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("same everything", func(t *testing.T) {
+		args1 := &gitprotocol.SearchRequest{
+			Repo:        "a",
+			Revisions:   []gitprotocol.RevisionSpecifier{{RevSpec: "b"}},
+			Query:       &gitprotocol.AuthorMatches{Expr: "camden"},
+			IncludeDiff: true,
+		}
+		args2 := &gitprotocol.SearchRequest{
+			Repo:        "a",
+			Revisions:   []gitprotocol.RevisionSpecifier{{RevSpec: "b"}},
+			Query:       &gitprotocol.AuthorMatches{Expr: "camden"},
+			IncludeDiff: true,
+		}
+		require.Equal(t, hashArgs(args1), hashArgs(args2))
+	})
+
+	// Requests that search different things should
+	// not have the same hash.
+
+	t.Run("different repos", func(t *testing.T) {
+		args1 := &gitprotocol.SearchRequest{Repo: "a"}
+		args2 := &gitprotocol.SearchRequest{Repo: "b"}
+		require.NotEqual(t, hashArgs(args1), hashArgs(args2))
+	})
+
+	t.Run("different revisions", func(t *testing.T) {
+		args1 := &gitprotocol.SearchRequest{
+			Revisions: []gitprotocol.RevisionSpecifier{{RevSpec: "a"}, {RefGlob: "b"}},
+		}
+		args2 := &gitprotocol.SearchRequest{
+			Revisions: []gitprotocol.RevisionSpecifier{{RevSpec: "a"}, {ExcludeRefGlob: "b"}},
+		}
+		require.NotEqual(t, hashArgs(args1), hashArgs(args2))
+	})
+
+	t.Run("different queries", func(t *testing.T) {
+		args1 := &gitprotocol.SearchRequest{Query: &gitprotocol.AuthorMatches{Expr: "a"}}
+		args2 := &gitprotocol.SearchRequest{Query: &gitprotocol.AuthorMatches{Expr: "b"}}
+		require.NotEqual(t, hashArgs(args1), hashArgs(args2))
+	})
+}
+
+func TestAddCodeMonitorHook(t *testing.T) {
+	t.Parallel()
+
+	t.Run("errors on non-commit search", func(t *testing.T) {
+		erroringJobs := []job.Job{
+			job.NewParallelJob(&run.RepoSearch{}, &commit.CommitSearch{}),
+			&run.RepoSearch{},
+			job.NewAndJob(&searcher.SymbolSearcher{}, &commit.CommitSearch{}),
+			job.NewTimeoutJob(0, &run.RepoSearch{}),
+		}
+
+		for _, j := range erroringJobs {
+			t.Run("", func(t *testing.T) {
+				_, err := addCodeMonitorHook(j, 0)
+				require.Error(t, err)
+			})
+		}
+	})
+
+	t.Run("no errors on only commit search", func(t *testing.T) {
+		nonErroringJobs := []job.Job{
+			job.NewParallelJob(&commit.CommitSearch{}, &commit.CommitSearch{}),
+			job.NewAndJob(&commit.CommitSearch{}, &commit.CommitSearch{}),
+			&commit.CommitSearch{},
+			job.NewTimeoutJob(0, &commit.CommitSearch{}),
+		}
+
+		for _, j := range nonErroringJobs {
+			t.Run("", func(t *testing.T) {
+				_, err := addCodeMonitorHook(j, 0)
+				require.NoError(t, err)
+			})
+		}
+	})
+}
+
+func TestCodeMonitorHook(t *testing.T) {
+	t.Parallel()
+
+	type testFixtures struct {
+		User    *types.User
+		Monitor *edb.Monitor
+	}
+	populateFixtures := func(db edb.EnterpriseDB) testFixtures {
+		ctx := context.Background()
+		u, err := db.Users().Create(ctx, database.NewUser{Email: "test", Username: "test", EmailVerificationCode: "test"})
+		require.NoError(t, err)
+		ctx = actor.WithActor(ctx, actor.FromUser(u.ID))
+		m, err := db.CodeMonitors().CreateMonitor(ctx, edb.MonitorArgs{NamespaceUserID: &u.ID})
+		require.NoError(t, err)
+		return testFixtures{User: u, Monitor: m}
+	}
+
+	db := database.NewDB(dbtest.NewDB(t))
+	fixtures := populateFixtures(edb.NewEnterpriseDB(db))
+	ctx := context.Background()
+
+	gs := gitserver.NewMockClient()
+	gs.ResolveRevisionsFunc.PushReturn([]string{"hash1", "hash2"}, nil)
+	gs.ResolveRevisionsFunc.PushReturn([]string{"hash3", "hash4"}, nil)
+
+	// The first time, doSearch should receive only the resolved hashes
+	doSearch := func(args *gitprotocol.SearchRequest) error {
+		require.Equal(t, args.Revisions, []gitprotocol.RevisionSpecifier{{
+			RevSpec: "hash1",
+		}, {
+			RevSpec: "hash2",
+		}})
+		return nil
+	}
+	err := hookWithID(ctx, db, gs, &gitprotocol.SearchRequest{}, doSearch, fixtures.Monitor.ID)
+	require.NoError(t, err)
+
+	// The next time, doSearch should receive the new resolved hashes plus the
+	// hashes from last time, but excluded
+	doSearch = func(args *gitprotocol.SearchRequest) error {
+		require.Equal(t, args.Revisions, []gitprotocol.RevisionSpecifier{{
+			RevSpec: "hash3",
+		}, {
+			RevSpec: "hash4",
+		}, {
+			RevSpec: "^hash1",
+		}, {
+			RevSpec: "^hash2",
+		}})
+		return nil
+	}
+	err = hookWithID(ctx, db, gs, &gitprotocol.SearchRequest{}, doSearch, fixtures.Monitor.ID)
+	require.NoError(t, err)
+}

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -182,7 +182,7 @@ func (r *queryRunner) Handle(ctx context.Context, record workerutil.Record) (err
 		// Only add an after filter when repo-aware monitors is disabled
 		query = newQueryWithAfterFilter(q)
 	}
-	results, searchErr := doSearch(ctx, r.db, query, settings)
+	results, searchErr := doSearch(ctx, r.db, query, m.ID, settings)
 
 	// Log next_run and latest_result to table cm_queries.
 	newLatestResult := latestResultTime(q.LatestResult, results, searchErr)

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -1170,12 +1170,7 @@ func (c *ClientImplementor) ResolveRevisions(ctx context.Context, repo api.RepoN
 		return nil, errors.WithMessage(err, fmt.Sprintf("git command %v failed (stderr: %q)", cmd.Args, stderr))
 	}
 
-	trimmed := strings.TrimSpace(string(stdout))
-	if len(trimmed) == 0 {
-		return nil, nil
-	}
-	split := strings.Split(trimmed, "\n")
-	return split, nil
+	return strings.Fields(string(stdout)), nil
 }
 
 func revsToGitArgs(revSpecs []protocol.RevisionSpecifier) []string {

--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -40,6 +40,8 @@ type CommitSearch struct {
 	CodeMonitorSearchWrapper func(context.Context, database.DB, GitserverClient, *gitprotocol.SearchRequest, DoSearchFunc) error `json:"-"`
 }
 
+type DoSearchFunc func(*gitprotocol.SearchRequest) error
+
 type GitserverClient interface {
 	Search(_ context.Context, _ *protocol.SearchRequest, onMatches func([]protocol.CommitMatch)) (limitHit bool, _ error)
 	ResolveRevisions(context.Context, api.RepoName, []gitprotocol.RevisionSpecifier) ([]string, error)

--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -40,8 +40,6 @@ type CommitSearch struct {
 	CodeMonitorSearchWrapper func(context.Context, database.DB, GitserverClient, *gitprotocol.SearchRequest, DoSearchFunc) error `json:"-"`
 }
 
-type DoSearchFunc func(*gitprotocol.SearchRequest) error
-
 type GitserverClient interface {
 	Search(_ context.Context, _ *protocol.SearchRequest, onMatches func([]protocol.CommitMatch)) (limitHit bool, _ error)
 	ResolveRevisions(context.Context, api.RepoName, []gitprotocol.RevisionSpecifier) ([]string, error)

--- a/internal/search/job/mapper.go
+++ b/internal/search/job/mapper.go
@@ -208,3 +208,27 @@ func (m *Mapper) Map(job Job) Job {
 		panic(fmt.Sprintf("unsupported job %T for job.Mapper", job))
 	}
 }
+
+func MapAtom(j Job, f func(Job) Job) Job {
+	mapper := Mapper{
+		MapJob: func(currentJob Job) Job {
+			switch typedJob := currentJob.(type) {
+			case
+				*zoekt.ZoektRepoSubsetSearch,
+				*zoekt.ZoektSymbolSearch,
+				*searcher.Searcher,
+				*searcher.SymbolSearcher,
+				*run.RepoSearch,
+				*structural.StructuralSearch,
+				*commit.CommitSearch,
+				*symbol.RepoUniverseSymbolSearch,
+				*repos.ComputeExcludedRepos,
+				*noopJob:
+				return f(typedJob)
+			default:
+				return currentJob
+			}
+		},
+	}
+	return mapper.Map(j)
+}


### PR DESCRIPTION
This PR creates and populates the `CodeMonitorSearchWrapper` hook on the `CommitSearch` job. This is the last PR needed for repo-aware monitors to run end-to-end. Comments inline.

All functionality here is hidden behind the feature flag `cc-repo-aware-monitors`. 

Stacked on #32576
Pulled from #32464

## Test plan

Added some tests to validate the basics, but I've only done light manual testing of the full functionality. I plan to spend time this week doing more manual testing and adding a more complete set of regression tests.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


