### PR TITLE
Update a few cloud docs

### DIFF
--- a/doc/cloud/cloud_ent_on-prem_comparison.md
+++ b/doc/cloud/cloud_ent_on-prem_comparison.md
@@ -19,4 +19,4 @@ Sourcegraph Cloud is a newly-released cloud version of Sourcegraph, which can be
 
 Sourcegraph Cloud offers the same core Code Search experience for private and public code as Sourcegraph self-hosted, but it does not support enterprise features such as user management, SAML integration, and batch changes. It is intended for personal use.
 
-Sourcegraph Cloud is a great choice for individuals who would like to search their own repositories without deploying Sourcegraph themselves. It also allows individuals to easily access our index of over 1 million open source repositories.
+Sourcegraph Cloud is a great choice for individuals or small organizations who would like to search their own repositories without deploying Sourcegraph themselves. It also allows individuals to easily access our index of over 1 million open source repositories. [Sourcegraph Cloud for Teams](https://about.sourcegraph.com/cloud-beta/) is in private beta today. [Join our waitlist](https://share.hsforms.com/14OQ3RoPpQTOXvZlUpgx6-A1n7ku?utm_medium=direct-traffic&utm_source=docs&utm_content=cloud-product-beta-teams) to get access today!

--- a/doc/cloud/index.md
+++ b/doc/cloud/index.md
@@ -2,6 +2,7 @@
 
 ## Sourcegraph Cloud for Individuals
 Sourcegraph Cloud allows individuals to search their personal code as well as more than 2 million open source respositories for free. Sign up today for free on [Sourcegraph.com](https://sourcegraph.com/sign-up).
+
 - [Getting Started on Sourcegraph Cloud](getting_started_on_cloud.md)
 - [Differences between Sourcegraph Cloud, self-hosted, and enterprise](cloud_ent_on-prem_comparison.md)
 - [Indexing open source code in Sourcegraph Cloud](indexing_open_source_code.md)

--- a/doc/code_search/explanations/code_visibility_on_sourcegraph_cloud.md
+++ b/doc/code_search/explanations/code_visibility_on_sourcegraph_cloud.md
@@ -1,5 +1,7 @@
 # Who can see your code on Sourcegraph Cloud
 
+Note: [Sourcegraph Cloud for Teams](https://about.sourcegraph.com/cloud-beta/) is in private beta today. [Join our waitlist](https://share.hsforms.com/14OQ3RoPpQTOXvZlUpgx6-A1n7ku?utm_medium=direct-traffic&utm_source=docs&utm_content=cloud-product-beta-teams) to get access today!
+
 Sourcegraph Cloud protects your private code using repository permissions from GitHub.com and GitLab.com to determine who can see repositories you've [added to Sourcegraph Cloud](../how-to/adding_repositories_to_cloud.md).
 
 ## Public repositories

--- a/doc/code_search/explanations/sourcegraph_cloud.md
+++ b/doc/code_search/explanations/sourcegraph_cloud.md
@@ -1,6 +1,6 @@
 # Sourcegraph Cloud
 
-[Sourcegraph Cloud](https://sourcegraph.com/search) lets you search across your code from GitHub.com or GitLab.com, and across any open-source project on GitHub.com or Gitlab.com. Sourcegraph Cloud is in Public Beta, allowing any individual to sign-up, connect personal repositories, and search across personal code. 
+[Sourcegraph Cloud](https://sourcegraph.com/search) lets you search across your code from GitHub.com or GitLab.com, and across any open-source project on GitHub.com or Gitlab.com. Sourcegraph Cloud is in beta, allowing any individual to sign-up, connect personal repositories, and search across personal code. If you are interested in onboarding your organization to Sourcegraph Cloud, [join our waitlist](https://share.hsforms.com/14OQ3RoPpQTOXvZlUpgx6-A1n7ku?utm_medium=direct-traffic&utm_source=docs&utm_content=cloud-product-beta-teams).
 
 Note that you can search across a maximum of 2,000 repositories at once using Sourcegraph Cloud. To search across more than 2,000 repositories at once or to search code hosted in an on-prem environment, [run your own Sourcegraph instance](../../../admin/install/index.md).
 
@@ -14,7 +14,7 @@ Note that you can search across a maximum of 2,000 repositories at once using So
 
 ### What is Sourcegraph Cloud?
 
-Sourcegraph Cloud is a Software-as-a-Service version of Sourcegraph. This means that we handle hosting and updating Sourcegraph so you can focus on what matters: searching your code. Sourcegraph Cloud is available in Public Beta for any individual user to [sign up for free](https://sourcegraph.com/sign-up).
+Sourcegraph Cloud is a Software-as-a-Service version of Sourcegraph. This means that we handle hosting and updating Sourcegraph so you can focus on what matters: searching your code. Sourcegraph Cloud is available in beta for any individual user to [sign up for free](https://sourcegraph.com/sign-up).
 
 ### Limitations
 
@@ -24,13 +24,12 @@ Sourcegraph Cloud is a Software-as-a-Service version of Sourcegraph. This means 
 
 ### Who is Sourcegraph Cloud for / why should I use this over Sourcegraph self-hosted?
 
-Sourcegraph Cloud is designed for individual developers to connect and search personal code stored on Github.com or Gitlab.com. While our self-hosted product provides an incredible experience for enterprises, we've heard feedback that individual developers want a simple way to search personal code. 
+Sourcegraph Cloud is designed allow developers to connect and search personal code stored on Github.com or Gitlab.com. While our self-hosted product provides an incredible experience for enterprises, we've heard feedback that developers want a way to utilize the benefits of Sourcegraph without hosting. 
 
 [A local Sourcegraph instance](../../../admin/install/index.md) is a better fit for you if:
 
 - You have source code stored on-premises
-- You would like to create an organization for teammates who need to share code
-- You are interested in enterprise solutions such as [Batch Changes](https://about.sourcegraph.com/batch-changes/) to make large-scale code 
+- You are interested in enterprise solutions such as [Batch Changes](https://about.sourcegraph.com/batch-changes/) to make large-scale code changes or [Code Insights]() to visualize code changes over time. 
 - You require more robust admin and user management tooling
 
 Learn more about [how to run your own Sourcegraph instance](../../../admin/install/index.md).
@@ -57,7 +56,7 @@ It's easy to share Sourcegraph with your team. Each team member must [sign up fo
 
 ### How do I use Sourcegraph Cloud for my organization?
 
-Sourcegraph Cloud only supports individual use today. This means that anyone can sign up for Sourcegraph.com, connect public or private repositories hosted on Github.com or Gitlab.com, and leverage the powerful code search of Sourcegraph. To create and manage an organization with Sourcegraph with team-oriented functionality, get started with the [self-hosted deployment](../../../admin/install/index.md).
+Organizational support on Sourcegraph Cloud is currently in private-beta. To gain access to this functionality, please [join our waitlist](https://share.hsforms.com/14OQ3RoPpQTOXvZlUpgx6-A1n7ku?utm_medium=direct-traffic&utm_source=docs&utm_content=cloud-product-beta-teams) and we'll get in touch if you are a good fit. 
 
 ### What if my code is not hosted on Github.com or Gitlab.com?
 

--- a/doc/code_search/explanations/sourcegraph_cloud.md
+++ b/doc/code_search/explanations/sourcegraph_cloud.md
@@ -29,7 +29,7 @@ Sourcegraph Cloud is designed allow developers to connect and search personal co
 [A local Sourcegraph instance](../../../admin/install/index.md) is a better fit for you if:
 
 - You have source code stored on-premises
-- You are interested in enterprise solutions such as [Batch Changes](https://about.sourcegraph.com/batch-changes/) to make large-scale code changes or [Code Insights]() to visualize code changes over time. 
+- You are interested in enterprise solutions such as [Batch Changes](https://about.sourcegraph.com/batch-changes/) to make large-scale code changes or [Code Insights](https://about.sourcegraph.com/code-insights/) to visualize code changes over time. 
 - You require more robust admin and user management tooling
 
 Learn more about [how to run your own Sourcegraph instance](../../../admin/install/index.md).


### PR DESCRIPTION
Updated a few cloud docs that still referenced Sourcegraph Cloud as being for individuals only. 

## Test plan
Docs update - no test plan. 
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


