### PR TITLE
actually generate TS schema from GraphQL

### DIFF
--- a/client/shared/gulpfile.js
+++ b/client/shared/gulpfile.js
@@ -62,7 +62,7 @@ async function graphQlSchema() {
         postProcessor: code => format(code, { ...formatOptions, parser: 'typescript' }),
       }
     )
-  await writeFile(__dirname + '/src/schema.ts', typings)
+  await writeFile(__dirname + '/src/graphql/schema.ts', typings)
 }
 
 /**


### PR DESCRIPTION
After a long time debugging, I couldn't understand why new GQL definitions didn't show up in `schema.ts`. I realized a `schema.ts` is being generated, but not where the current one lives. 

If we moved it under `src/graphql`, we should probably be generating it there. I updated the script and after `yarn generate`, the `schema.ts` is updated with a lot of things that were missing before... (and probably unused, but nevertheless, missing).

addendum: apparently the build looks for schema.ts under src, but it still doesn't keep the one in graphql in sync

## Test plan
Generates file as expected, dev experience issue.


